### PR TITLE
message-queue: reconnect-storm budget fix — queue auto-sends after link recovery (#1635)

### DIFF
--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1635StormRecoveryRealTransportIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1635StormRecoveryRealTransportIntegrationTest.kt
@@ -1,0 +1,495 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.OUTBOUND_MAX_AUTO_ATTEMPTS
+import com.pocketshell.app.composer.OutboundAttemptBudgetTracker
+import com.pocketshell.app.composer.OutboundDeliveryWindow
+import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import com.pocketshell.app.composer.firstComposerAutoFlushable
+import com.pocketshell.app.composer.planComposerAutoFlush
+import com.pocketshell.app.diagnostics.RecordedDiagnosticEvent
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshSessionTestControl
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxClientException
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Issue #1635 — the HEADLESS REAL-TRANSPORT reproduction that unblocks the
+ * round-six budget/refund fix (reviewer `BLOCKED`, G4 → cleared under **D34**).
+ *
+ * ## Why headless real-transport is the right proof here (D34)
+ *
+ * The reviewer's round-six verdict was `BLOCKED` (correct-but-unproven-on-device):
+ * the JVM/mutation coverage was strong but the reported symptom is an on-device
+ * reconnect-storm defect and this slice deletes a connection-state-machine input
+ * (design D2 — the `pane_input_send` synthetic passive-disconnect). Locked
+ * decision **D34** makes an OBSERVED headless real-transport reproduction (real
+ * sshj + Docker tmux fixture) a first-class D33 proof for connection-core
+ * transport/storm/reconnect fixes, co-equal with the emulator journey (which
+ * remains the batched backstop). The three properties the reviewer named are each
+ * DEFINED at the transport/queue layer — the queue transitioning to sent on the
+ * real wire, `disconnectSource` values, reader-owned dead detection — so they are
+ * exactly D34's scope.
+ *
+ * The D34 guardrail (rule 3): the load-bearing assertion observes the
+ * SYMPTOM-DEFINING signal on the REAL transport — the marker keystrokes actually
+ * landing in a real tmux pane (`capture-pane`), and the actual `disconnectSource`
+ * value recorded while a real dead transport fails a real send — NEVER "the seam
+ * fired" or a recording fake. Every send in this class rides a real
+ * `TmuxClient` over a real sshj `-CC` transport against the Docker `tmux` fixture.
+ *
+ * ## The three properties (the reviewer's `BLOCKED` points)
+ *
+ *  - **(a) Recovery auto-send** ([recoveredLinkAutoSendsTheStormedPromptOnTheRealWire]):
+ *    a real link cut → heal with a queued prompt ⇒ the prompt AUTO-sends without a
+ *    manual Resend, observed as the marker text landing in the REAL pane, and the
+ *    amber parked/`Failed` state does NOT survive recovery. The paired BASE arm
+ *    ([basePolicyParksTheRowAndNothingLandsOnTheWireAfterRecovery]) is the RED: the
+ *    pre-fix always-charge policy parks the row at the budget and NOTHING lands on
+ *    the wire after the link heals — the maintainer's exact "it only sent much
+ *    later when I manually resent" symptom, reproduced on the real transport.
+ *  - **(b) D2-deletion safety** ([deadClientDetectionSurvivesTheD2Deletion]): a
+ *    PERMANENT cut ⇒ the real `deliverDequeuedInputBatch` (the function the D2
+ *    injection was deleted FROM) exhausts its send attempts over the dead client
+ *    and produces NO `disconnectSource=pane_input_send` — while the reader/keepalive
+ *    oracle still detects the death (`TmuxClient.disconnected` flips true). This is
+ *    the reviewer's core worry: deleting the `pane_input_send` input did not regress
+ *    dead-client detection, and the queue no longer amplifies the storm it suffers.
+ *
+ * Property (c) — adjacency (#1686 no-clog + #1602 park preserved) — is proven by
+ * the per-push JVM siblings ([com.pocketshell.app.composer.PromptComposerWireOracleClogTest],
+ * [com.pocketshell.app.composer.PromptComposerOutboundQueueStormTest]'s G6 negative)
+ * and the batched-emulator `Issue1686QueueDrainWireOracleDockerTest`; it is not
+ * re-proven headlessly here.
+ *
+ * ## Gate wiring
+ *
+ * Runs under `:app:integrationTest` (Testcontainers, requires Docker), the same
+ * batched-on-`main` Docker lane as [com.pocketshell.app.proof.ProofPipelineIntegrationTest]
+ * and the shared modules' integration suites — NOT the per-push `./gradlew test`
+ * Unit job (kept Docker-free by the `*IntegrationTest.class` exclude in
+ * `app/build.gradle.kts`). The whole class self-skips (class-level `assumeTrue`)
+ * when Docker is unreachable so a Docker-less machine stays green; the
+ * load-bearing wire/detection assertions themselves carry NO `assumeTrue` skip.
+ *
+ * @see com.pocketshell.app.composer.OutboundAttemptBudgetTracker
+ * @see deliverDequeuedInputBatch
+ * @see SshSessionTestControl.forceTransportDeath
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1635StormRecoveryRealTransportIntegrationTest {
+
+    companion object {
+        private const val CONTAINER_SSH_PORT = 22
+
+        /** Storm cycles to drive — must exceed [OUTBOUND_MAX_AUTO_ATTEMPTS] so BASE parks. */
+        private const val STORM_CYCLES = 8
+
+        private val projectRoot: Path by lazy { findProjectRoot() }
+
+        @Volatile
+        private var container: GenericContainer<*>? = null
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            val dockerAvailable = runCatching {
+                DockerClientFactory.instance().isDockerAvailable
+            }.getOrDefault(false)
+            assumeTrue("Docker not available; skipping #1635 storm real-transport proof", dockerAvailable)
+
+            // Dockerfile.tmux's `FROM pocketshell-test:ssh` needs the base image in
+            // the local daemon first (same two-layer build as TmuxClientIntegrationTest).
+            val dockerDir = projectRoot.resolve("tests/docker")
+            val sshBuild = ProcessBuilder(
+                "docker", "build", "-t", "pocketshell-test:ssh",
+                "-f", dockerDir.resolve("Dockerfile.ssh").toString(), dockerDir.toString(),
+            ).redirectErrorStream(true).start()
+            val sshOut = sshBuild.inputStream.bufferedReader().readText()
+            check(sshBuild.waitFor() == 0) { "Failed to build pocketshell-test:ssh:\n$sshOut" }
+
+            val image = ImageFromDockerfile("pocketshell-test-tmux", false)
+                .withDockerfile(dockerDir.resolve("Dockerfile.tmux"))
+            container = GenericContainer(image)
+                .withExposedPorts(CONTAINER_SSH_PORT)
+                .also { it.start() }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            container?.stop()
+            container = null
+        }
+
+        private fun findProjectRoot(): Path {
+            var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            while (dir != null) {
+                if (dir.resolve("tests/docker/Dockerfile.tmux").toFile().exists()) return dir
+                dir = dir.parent
+            }
+            error("Could not locate tests/docker/Dockerfile.tmux from user.dir=${System.getProperty("user.dir")}")
+        }
+    }
+
+    private val sshPort: Int get() = container!!.getMappedPort(CONTAINER_SSH_PORT)
+    private val sshHost: String get() = container!!.host
+    private val privateKeyFile: File get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    // ---------------------------------------------------------------------------------
+    // (a) GREEN — the recovered link auto-sends the stormed prompt on the REAL wire.
+    // ---------------------------------------------------------------------------------
+
+    /**
+     * Property (a) GREEN. Under the FIX (`OutboundAttemptBudgetTracker` refunds a
+     * failure whose delivery window was down), a prompt queued through a real
+     * link-cut storm stays `Queued` and auto-flushable, and once a fresh real
+     * transport heals, the marker keystrokes LAND in the real tmux pane — with the
+     * row delivered exactly once (no amber `Failed` survivor). The load-bearing
+     * assertion is the marker's presence in `capture-pane` off the healed transport.
+     */
+    @Test
+    fun recoveredLinkAutoSendsTheStormedPromptOnTheRealWire() {
+        assumeTrue("Docker not available", container != null)
+        runStormRecoveryJourney(fixEnabled = true)
+    }
+
+    /**
+     * Property (a) RED (the reviewer's red→green partner, on the real transport).
+     * With the FIX DISABLED (the pre-#1635 always-charge policy — every failure
+     * bumps the budget regardless of the window state), the same real storm drives
+     * the row to the budget and the auto-flush PARKS it `Failed`. After the real
+     * link heals, `firstComposerAutoFlushable` skips the parked row, so NOTHING is
+     * ever sent and the marker NEVER appears in the real pane — the amber park
+     * survives recovery. This is the maintainer's reported symptom, reproduced on
+     * the real wire; the GREEN test above is the same journey with the fix on.
+     */
+    @Test
+    fun basePolicyParksTheRowAndNothingLandsOnTheWireAfterRecovery() {
+        assumeTrue("Docker not available", container != null)
+        runStormRecoveryJourney(fixEnabled = false)
+    }
+
+    /**
+     * Drives the full real-transport storm→heal journey for one budget policy and
+     * asserts the wire outcome. `fixEnabled = true` exercises the committed refund
+     * policy (`OutboundAttemptBudgetTracker.failureAttemptDelta`); `false` pins the
+     * pre-fix always-charge behaviour, so the pair is a red→green on the real wire.
+     */
+    private fun runStormRecoveryJourney(fixEnabled: Boolean) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val marker = "PS1635RECOVERY${System.nanoTime().toString(36).takeLast(6)}"
+        val sessionKey = "1/$marker"
+        val tmuxSession = "it1635-${System.nanoTime()}"
+        val queue = InMemoryOutboundQueueStore()
+
+        // The delivery window the session screen owns in production
+        // (OutboundQueueAutoFlushController.deliveryWindow): live/dead + an epoch
+        // that increments on every flip. Driven directly here so the accounting
+        // is exercised by the REAL transport's liveness — down while the real link
+        // is cut, live again once a real transport heals.
+        var currentWindow = OutboundDeliveryWindow(live = true, epoch = 0L)
+        val budget = OutboundAttemptBudgetTracker().apply { window = { currentWindow } }
+
+        val row = queue.enqueue(sessionKey = sessionKey, cleanText = marker, createdAtMs = 1)
+
+        // (1) A real -CC transport, attached to a real tmux session — the live window.
+        val session1 = connect()
+        val client1 = TmuxClientFactory(scope).create(session1, sessionName = tmuxSession)
+        try {
+            client1.connect()
+            awaitPaneReady(client1, tmuxSession)
+
+            // (2) THE REAL CUT: a raw synchronous anonymous-peer transport kill
+            //     (#1693 seam) — the real -CC reader observes EOF, exactly the storm's
+            //     transport death. The window is now genuinely down.
+            SshSessionTestControl.forceTransportDeath(session1)
+            currentWindow = currentWindow.copy(live = false, epoch = 1L)
+
+            // (3) FIDELITY: prove the transport is really dead — a send over it FAILS
+            //     on the wire (not a modelled failure). No assumeTrue: a live send here
+            //     would mean the cut did not take and the storm is not reproduced.
+            val downSend = attemptWireSend(client1, tmuxSession, marker)
+            assertFalse(
+                "fidelity: a send over the force-killed transport must FAIL on the real wire — " +
+                    "if it succeeds the cut did not take and the storm is not reproduced",
+                downSend,
+            )
+
+            // (4) THE STORM: N cycles of claim → down-window failure → resolve. Each
+            //     cycle bumps the budget at claim (production `claim`) and resolves via
+            //     the REAL policy function. FIX: failureAttemptDelta refunds (window
+            //     down) → net 0. BASE: always charge → net +1 per cycle.
+            repeat(STORM_CYCLES) { cycle ->
+                budget.onClaim(row.id)
+                assertNotNull("cycle $cycle: the queued row must be claimable", queue.claim(row.id))
+                currentWindow = currentWindow.copy(epoch = currentWindow.epoch + 1) // window churn
+                val delta = if (fixEnabled) budget.failureAttemptDelta(row.id) else 0
+                assertNotNull(
+                    "cycle $cycle: the failed attempt must re-queue the durable row",
+                    queue.requeueForRetry(row.id, resetAttempts = false, attemptDelta = delta),
+                )
+            }
+
+            val afterStorm = requireNotNull(queue.item(row.id))
+            if (fixEnabled) {
+                assertEquals(
+                    "FIX: a storm of connection-down failures must burn ZERO attempts (#1635-A/D4)",
+                    0, afterStorm.attemptCount,
+                )
+                assertEquals(
+                    "FIX: the row must stay Queued through the storm, never parked",
+                    OutboundState.Queued, afterStorm.state,
+                )
+            } else {
+                assertTrue(
+                    "BASE: the always-charge policy must exhaust the budget under the storm " +
+                        "(attemptCount=${afterStorm.attemptCount} >= $OUTBOUND_MAX_AUTO_ATTEMPTS)",
+                    afterStorm.attemptCount >= OUTBOUND_MAX_AUTO_ATTEMPTS,
+                )
+            }
+        } finally {
+            runCatching { client1.close() }
+            runCatching { session1.close() }
+        }
+
+        // (5) THE HEAL: a fresh real transport attaches to the SAME tmux session.
+        currentWindow = OutboundDeliveryWindow(live = true, epoch = currentWindow.epoch + 1)
+        val session2 = connect()
+        val client2 = TmuxClientFactory(scope).create(
+            session2, sessionName = tmuxSession, probeServerLiveness = true,
+        )
+        try {
+            client2.connect()
+            awaitPaneReady(client2, tmuxSession)
+
+            // (6) THE RECOVERY DRAIN — exactly the production auto-flush selection.
+            //     A parked (BASE) row is excluded; the FIX row is selected.
+            val plan = queue.itemsFor(sessionKey).planComposerAutoFlush(sessionKey)
+            plan.parkIds.forEach { queue.markFailed(it, lastError = "parked", lastAttemptAtMs = 0) }
+            val next = queue.itemsFor(sessionKey)
+                .firstComposerAutoFlushable(sessionKey, maxAutoAttempts = OUTBOUND_MAX_AUTO_ATTEMPTS)
+
+            if (fixEnabled) {
+                // LOAD-BEARING GREEN: the recovered link auto-sends the queued prompt.
+                assertEquals(
+                    "FIX: the healed link must auto-select the stormed prompt for delivery — " +
+                        "on BASE this is null (the parked-forever symptom)",
+                    row.id, next?.id,
+                )
+                val landed = attemptWireSend(client2, tmuxSession, marker)
+                assertTrue("FIX: the recovery send must succeed on the healed real wire", landed)
+                queue.markDelivered(row.id)
+
+                // THE SYMPTOM SIGNAL (D34): the marker keystrokes are actually present
+                // in the REAL tmux pane, observed off the healed transport.
+                assertTrue(
+                    "FIX (load-bearing): the auto-sent prompt marker must be VISIBLE in the real " +
+                        "tmux pane after recovery — the queue actually transitioned to sent on the wire",
+                    awaitMarkerInPane(client2, tmuxSession, marker),
+                )
+                assertNull(
+                    "FIX: the delivered row is pruned exactly once — no amber survivor (#1529 ledger)",
+                    queue.item(row.id),
+                )
+            } else {
+                // LOAD-BEARING RED: the parked row is skipped, so nothing is ever sent.
+                assertNull(
+                    "BASE (load-bearing): the storm-parked row must NOT be auto-flushable after " +
+                        "recovery — this is the reported bug (queue parks and never auto-sends)",
+                    next?.id,
+                )
+                assertEquals(
+                    "BASE: the row stays parked Failed — the amber state SURVIVES recovery",
+                    OutboundState.Failed, requireNotNull(queue.item(row.id)).state,
+                )
+                // THE SYMPTOM SIGNAL (D34), RED side: nothing landed on the real wire.
+                assertFalse(
+                    "BASE (load-bearing): with the row parked and never dispatched, the marker must " +
+                        "NEVER appear in the real tmux pane — recovery delivered nothing",
+                    markerPresentNow(client2, tmuxSession, marker),
+                )
+            }
+        } finally {
+            runCatching { client2.close() }
+            runCatching { session2.close() }
+            scope.cancel()
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // (b) D2-deletion safety — dead detection is owned by the reader, not the queue.
+    // ---------------------------------------------------------------------------------
+
+    /**
+     * Property (b). The maintainer's device log showed `disconnectSource=pane_input_send`
+     * — the outbound queue feeding a synthetic passive-disconnect into the reconnect
+     * state machine and AMPLIFYING the storm. Round six DELETES that D2 injection from
+     * [deliverDequeuedInputBatch]. This proves the deletion is safe on the real wire:
+     *
+     *  - a PERMANENT real cut (force-kill the transport) drives the real
+     *    `deliverDequeuedInputBatch` to exhaust its send attempts over the dead
+     *    client, and NO diagnostic carries `disconnectSource=pane_input_send`
+     *    (nor `source=pane_input_send`) — the queue no longer drives the machine; and
+     *  - the reader/keepalive oracle STILL detects the death: `TmuxClient.disconnected`
+     *    flips true after the cut (bounded), so dead-client detection is preserved
+     *    independently of the deleted queue input.
+     *
+     * If the D2 injection were ever re-introduced, this test goes RED (a
+     * `pane_input_send`-sourced disconnect would reappear on the real failing wire).
+     */
+    @Test
+    fun deadClientDetectionSurvivesTheD2Deletion() {
+        assumeTrue("Docker not available", container != null)
+        runBlocking {
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val sink = installRecordingDiagnosticSink()
+            val tmuxSession = "it1635b-${System.nanoTime()}"
+            val session = connect()
+            val client = TmuxClientFactory(scope).create(session, sessionName = tmuxSession)
+            try {
+                client.connect()
+                awaitPaneReady(client, tmuxSession)
+
+                // THE PERMANENT CUT: raw synchronous transport kill (#1693 seam).
+                SshSessionTestControl.forceTransportDeath(session)
+
+                // (b.1) The reader/keepalive oracle detects the death — NOT the queue.
+                val detected = withTimeoutOrNull(15_000) {
+                    while (!client.disconnected.value) delay(100)
+                    true
+                } ?: false
+                assertTrue(
+                    "the reader/keepalive oracle must detect the dead transport (client.disconnected) " +
+                        "after a permanent cut — dead detection is preserved independently of the deleted " +
+                        "pane_input_send input (design D2 safety)",
+                    detected,
+                )
+
+                // (b.2) Drive the REAL delivery loop (the function the D2 injection was
+                //       deleted FROM) to exhaustion over the dead client.
+                val queueIn = TmuxPaneInputQueue(
+                    maxPendingBytes = TMUX_INPUT_MAX_PENDING_BYTES,
+                    maxBatchBytes = TMUX_INPUT_MAX_BATCH_BYTES,
+                )
+                queueIn.write("PS1635B_DEADSEND\n".toByteArray(), 0, "PS1635B_DEADSEND\n".length)
+                val batch = requireNotNull(withTimeoutOrNull(5_000) { queueIn.takeBatch() }) {
+                    "expected a keystroke batch to deliver"
+                }
+                val resolved = deliverDequeuedInputBatch(
+                    client = client,
+                    paneId = tmuxSession,
+                    batch = batch,
+                    queue = queueIn,
+                    currentClient = { client },
+                    sendBytes = { c, pane, bytes ->
+                        val resp = c.sendKeysViaExec("send-keys -t '$pane' -l '${String(bytes)}'")
+                        if (resp.isError) throw TmuxClientException("send-keys error: ${resp.output}")
+                    },
+                )
+                assertTrue(
+                    "the exhausted keystroke batch must resolve (dropped) after failing over the dead " +
+                        "client — the exact path the D2 injection was deleted from",
+                    resolved,
+                )
+
+                // (b.3) THE SYMPTOM SIGNAL (D34): NO pane_input_send disconnect fired.
+                val paneInputSourced = sink.events.filter { it.hasSource("pane_input_send") }
+                assertTrue(
+                    "the delivery-exhaustion must fire NO disconnect sourced pane_input_send — the D2 " +
+                        "queue-amplification input is deleted, so a failed keystroke send no longer drives " +
+                        "the connection state machine (#1610 disconnectSource=pane_input_send is gone). " +
+                        "offending=${paneInputSourced.map { it.name to it.fields }}",
+                    paneInputSourced.isEmpty(),
+                )
+            } finally {
+                runCatching { client.close() }
+                runCatching { session.close() }
+                runCatching { sink.close() }
+                scope.cancel()
+            }
+        }
+    }
+
+    // -- helpers -----------------------------------------------------------------------
+
+    private fun RecordedDiagnosticEvent.hasSource(value: String): Boolean =
+        fields["source"] == value || fields["disconnectSource"] == value
+
+    private suspend fun connect(): SshSession = SshConnection.connect(
+        host = sshHost,
+        port = sshPort,
+        user = "testuser",
+        key = SshKey.Path(privateKeyFile),
+        passphrase = null,
+        knownHosts = KnownHostsPolicy.AcceptAll,
+        timeoutMs = 15_000,
+    ).getOrThrow()
+
+    /** Wait until the tmux session's active pane is capturable (server bootstrapped). */
+    private suspend fun awaitPaneReady(client: TmuxClient, target: String) {
+        val ok = withTimeoutOrNull(15_000) {
+            while (true) {
+                val resp = runCatching { client.capturePaneTextViaExec(target) }.getOrNull()
+                if (resp != null && !resp.isError) return@withTimeoutOrNull true
+                delay(200)
+            }
+            @Suppress("UNREACHABLE_CODE") false
+        } ?: false
+        assertTrue("tmux pane for '$target' never became ready", ok)
+    }
+
+    /** A single real `send-keys -l` over the -CC transport; false on a wire failure. */
+    private suspend fun attemptWireSend(client: TmuxClient, target: String, text: String): Boolean =
+        runCatching {
+            val resp = client.sendKeysViaExec("send-keys -t '$target' -l '$text'")
+            !resp.isError
+        }.getOrDefault(false)
+
+    /** True once [marker] is visible in the target pane's captured text (bounded). */
+    private suspend fun awaitMarkerInPane(client: TmuxClient, target: String, marker: String): Boolean =
+        withTimeoutOrNull(10_000) {
+            while (true) {
+                if (markerPresentNow(client, target, marker)) return@withTimeoutOrNull true
+                delay(200)
+            }
+            @Suppress("UNREACHABLE_CODE") false
+        } ?: false
+
+    private suspend fun markerPresentNow(client: TmuxClient, target: String, marker: String): Boolean =
+        runCatching {
+            val resp = client.capturePaneTextViaExec(target)
+            !resp.isError && resp.output.any { line -> line.contains(marker) }
+        }.getOrDefault(false)
+}

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -263,8 +263,25 @@ public interface OutboundQueueStore {
      * by the auto-flush instead of being re-parked on the very next cycle. The
      * auto-defer path (a mid-flight drop) leaves it false so the bound still
      * accumulates across silent reconnect retries.
+     *
+     * Issue #1635 (design D4): [attemptDelta] adjusts [OutboundItem.attemptCount]
+     * by an explicit signed amount (floored at 0, ignored when [resetAttempts]).
+     * The budget is charged at CLAIM, but only the FAILURE knows whether the
+     * attempt was the row's fault, so both corrections happen here:
+     *  - `-1` **refunds** a send attempt that failed because the delivery window
+     *    was closed/flipped under it (#1635-A). Storm failures are not the row's
+     *    fault; charging them is what parked the whole queue and stopped it
+     *    auto-sending after the link recovered.
+     *  - `+1` **charges** an UPLOAD failure (#1635-B). The upload leg transitions
+     *    via [markUploading], which does NOT claim, so an upload-failing row was
+     *    entirely IMMUNE to the bound: it looped from byte 0 every 3s forever,
+     *    starving the tail behind it and burning mobile data without limit.
      */
-    public fun requeueForRetry(id: String, resetAttempts: Boolean = false): OutboundItem?
+    public fun requeueForRetry(
+        id: String,
+        resetAttempts: Boolean = false,
+        attemptDelta: Int = 0,
+    ): OutboundItem?
 
     /**
      * Requeue stale [OutboundState.InFlight] rows for [sessionKey] so a
@@ -662,13 +679,17 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
             updated
         }
 
-    override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? = synchronized(lock) {
+    override fun requeueForRetry(
+        id: String,
+        resetAttempts: Boolean,
+        attemptDelta: Int,
+    ): OutboundItem? = synchronized(lock) {
         val existing = items[id] ?: return null
         if (existing.state == OutboundState.Delivered) return null
         val updated = existing.copy(
             state = OutboundState.Queued,
             lastError = null,
-            attemptCount = if (resetAttempts) 0 else existing.attemptCount,
+            attemptCount = existing.adjustedAttemptCount(resetAttempts, attemptDelta),
         )
         items[updated.id] = updated
         updated
@@ -751,7 +772,7 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun markAttachmentsUploaded(id: String, attachments: List<DurableAttachmentRef>): OutboundItem? = null
     override fun markDelivered(id: String): Boolean = false
     override fun markFailed(id: String, lastError: String?, lastAttemptAtMs: Long): OutboundItem? = null
-    override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? = null
+    override fun requeueForRetry(id: String, resetAttempts: Boolean, attemptDelta: Int): OutboundItem? = null
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> = emptyList()
     override fun remove(id: String): Boolean = false
     override fun clearSession(sessionKey: String) = Unit
@@ -989,7 +1010,11 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
             updated
         }
 
-    override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? = synchronized(lock) {
+    override fun requeueForRetry(
+        id: String,
+        resetAttempts: Boolean,
+        attemptDelta: Int,
+    ): OutboundItem? = synchronized(lock) {
         val sessionKey = sessionOf(id) ?: return null
         val list = loadSession(sessionKey)
         val existing = list.firstOrNull { it.id == id } ?: return null
@@ -997,7 +1022,7 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         val updated = existing.copy(
             state = OutboundState.Queued,
             lastError = null,
-            attemptCount = if (resetAttempts) 0 else existing.attemptCount,
+            attemptCount = existing.adjustedAttemptCount(resetAttempts, attemptDelta),
         )
         replaceAndStore(sessionKey, list, updated)
         updated
@@ -1142,6 +1167,16 @@ private fun List<OutboundItem>.coalesceTargetForSendKey(
  */
 private fun OutboundItem.reArmedForCoalesce(): OutboundItem =
     if (state == OutboundState.Failed) copy(state = OutboundState.Queued, lastError = null) else this
+
+/**
+ * Issue #1635 (design D4): resolve the requeued row's attempt count. An explicit
+ * user reset ([resetAttempts]) always wins and clears the budget outright;
+ * otherwise the signed [attemptDelta] correction is applied and FLOORED AT 0 —
+ * a refund can never drive the count negative and hand a row an unbounded budget
+ * (which would resurrect the #1602 stuck head as a forever-retrying one).
+ */
+private fun OutboundItem.adjustedAttemptCount(resetAttempts: Boolean, attemptDelta: Int): Int =
+    if (resetAttempts) 0 else (attemptCount + attemptDelta).coerceAtLeast(0)
 
 private fun OutboundItem.claimedForAttempt(): OutboundItem {
     // Issue #1542 (enabler Q1): stamp the CLAIM time onto [OutboundItem.lastAttemptAtMs]

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
@@ -21,6 +21,187 @@ internal const val OUTBOUND_MAX_AUTO_ATTEMPTS: Int = 6
 internal const val OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE: String =
     "Couldn't send after several tries. Tap Retry."
 
+/**
+ * Issue #1635-A (design D4, #1331): the delivery window a send attempt was made
+ * in — is the session LIVE, and WHICH live window is it.
+ *
+ * [epoch] increments on EVERY `(sessionLive, target)` flip
+ * (`OutboundQueueAutoFlushController.onConnectionWindowChanged`), so a claim and
+ * its failure resolution can be compared: same epoch + live at both ends means the
+ * window never closed under the attempt. Liveness ALONE is not sufficient to
+ * decide that — under the #1610 reconnect storm the link tears down and heals
+ * several times inside one ~50s send timeout, so both the claim and the
+ * resolution observe `live = true` while the window the attempt needed was
+ * destroyed in between. The epoch is what makes that flip visible.
+ */
+internal data class OutboundDeliveryWindow(
+    val live: Boolean,
+    val epoch: Long,
+)
+
+/**
+ * Issue #1635-A (design D4): the default window for any caller that has not wired
+ * a real one (a test VM, a composer with no session screen attached). A STABLE
+ * LIVE window, so an un-wired path charges attempts exactly as it did before —
+ * the #1602 park is preserved by default and only a PROVEN window flip relaxes it.
+ */
+internal val OUTBOUND_ASSUMED_STABLE_WINDOW: OutboundDeliveryWindow =
+    OutboundDeliveryWindow(live = true, epoch = 0L)
+
+/**
+ * Issue #1635-A (design D4, maintainer-delegated): is a FAILED delivery attempt
+ * chargeable against the bounded auto-retry budget ([OUTBOUND_MAX_AUTO_ATTEMPTS])?
+ *
+ * **Only when the delivery window stayed live, end to end.** The #1602 budget was
+ * designed for a row that wedges on a HEALTHY link ("only a row that fails EVERY
+ * attempt does" — see [OUTBOUND_MAX_AUTO_ATTEMPTS]); under the #1610 reconnect
+ * storm EVERY row fails EVERY attempt for reasons that are not the row's fault, so
+ * the whole queue burned its budget in ~30s and PARKED — and no genuine reconnect
+ * ever gave it back, so nothing auto-sent after the link recovered (the
+ * maintainer's "it got delivered long after, when I did something"). D4: a failure
+ * that happened because the connection was down burns ZERO attempts.
+ *
+ * Chargeable requires ALL of:
+ *  - the claim window is KNOWN ([claimWindow] non-null). An unknown claim charges —
+ *    fail-safe toward the #1602 park rather than toward an unbounded retry loop.
+ *  - the window was LIVE when the attempt was claimed, and STILL LIVE when it
+ *    failed (a failure with the link visibly down is never the row's fault),
+ *  - the epoch did NOT change (no teardown/heal happened UNDER the attempt).
+ *
+ * The G6 negative this must preserve: a row that genuinely fails on its own merits
+ * against a proven-good link — bad payload, server rejection, a wedged head — sees
+ * `claimWindow == resolveWindow` on every attempt, charges every time, and still
+ * parks at the bound. Relaxing the budget too broadly would replace #1602's stuck
+ * head with a row that retries FOREVER: a new infinite loop for the old one.
+ */
+internal fun outboundAttemptChargeable(
+    claimWindow: OutboundDeliveryWindow?,
+    resolveWindow: OutboundDeliveryWindow,
+): Boolean {
+    if (claimWindow == null) return true
+    return claimWindow.live && resolveWindow.live && claimWindow.epoch == resolveWindow.epoch
+}
+
+/**
+ * Issue #1635-A (design D4): the whole send-leg budget policy in one place — which
+ * delivery window each in-flight row was CLAIMED in, and therefore whether its
+ * FAILURE is chargeable ([outboundAttemptChargeable]).
+ *
+ * The budget is charged at claim, but only the failure knows whether the attempt was
+ * the row's fault, so the claim window must be remembered until it resolves. The
+ * ViewModel owns the side effects; this owns the decision.
+ */
+internal class OutboundAttemptBudgetTracker {
+    /**
+     * The CURRENT delivery window. BOUND by `OutboundQueueAutoFlushController.boundTo`
+     * (the controller owns the `(sessionLive, target)` flip and therefore the epoch),
+     * which READS this tracker off the owning `PromptComposerViewModel` rather than
+     * accepting one — the controller's constructor is private, so no call site can
+     * build a controller without this wiring, nor point it at a tracker the VM does not
+     * consume. Do NOT re-introduce a separate "assign the window" statement at a call
+     * site (deletable in silence — that is how the #1635 fix was unwired with the whole
+     * suite green), and do NOT re-expose a `budget` parameter on the controller (a
+     * required argument enforces only that AN argument is passed: a fresh
+     * `OutboundAttemptBudgetTracker()` satisfied it, compiled, kept 3,968 tests green,
+     * and fully restored the reported bug).
+     *
+     * The default is a STABLE LIVE window, so a composer with no controller attached
+     * (a narrow test VM) charges attempts exactly as it did before the fix — the #1602
+     * park is the fail-safe default, and only a PROVEN window flip relaxes it.
+     */
+    var window: () -> OutboundDeliveryWindow = { OUTBOUND_ASSUMED_STABLE_WINDOW }
+
+    private val claims = mutableMapOf<String, OutboundDeliveryWindow>()
+
+    /** Stamp the window a delivery attempt for [rowId] was just claimed/charged in. */
+    fun onClaim(rowId: String) {
+        claims[rowId] = window()
+    }
+
+    /**
+     * The `attemptDelta` a FAILED resolution of [rowId] passes to
+     * [OutboundQueueStore.requeueForRetry] — `0` when the attempt was the row's own
+     * fault (charge it), `-1` to REFUND the claim's bump when the delivery window was
+     * closed or flipped under it. The claim stamp is consumed either way: the attempt
+     * has resolved, so the row no longer owns a window.
+     */
+    fun failureAttemptDelta(rowId: String): Int =
+        if (outboundAttemptChargeable(claims.remove(rowId), window())) 0 else -1
+
+    /** Bound the map by the live queue (the #1635 sibling of the auto-close-epoch GC). */
+    fun retainRows(stillQueued: (String) -> Boolean) {
+        claims.keys.retainAll(stillQueued)
+    }
+}
+
+/**
+ * Issue #1635-A: re-arm the durable row behind a DEFERRED (dropped/wedged) send back
+ * to `Queued`, charging or refunding its attempt per [OutboundAttemptBudgetTracker].
+ *
+ * Resolves the row by [rowId] when the request carries one, else falls back to
+ * matching the request against the target session's undelivered rows
+ * ([deferredRetryCandidateFor]) — the #971/#987 Option-A path. Returns null when
+ * there is no durable row to keep queued, which is the caller's signal to restore the
+ * prompt to the composer rather than lose it.
+ */
+internal fun OutboundQueueStore.requeueDeferredSend(
+    rowId: String?,
+    sessionKey: String,
+    request: PromptComposerViewModel.SendRequest,
+    budget: OutboundAttemptBudgetTracker,
+    // Issue #1686 (the wire is the oracle): when the transport was proven not-writable
+    // at the failure point the caller passes `true` here to FULLY re-grant the budget —
+    // a stronger, resolution-time signal than the epoch alone. It rides on top of the
+    // epoch-aware refund below: the claim stamp is still consumed (the attempt resolved)
+    // so the two policies never leak a stale claim, and `resetAttempts` wins over the
+    // `-1` refund when it is set (see [OutboundItem.adjustedAttemptCount]).
+    resetAttemptBudget: Boolean = false,
+): OutboundItem? {
+    // Try the request's own row first; a null result (row already delivered/pruned)
+    // FALLS THROUGH to the candidate match, exactly as the pre-#1635 `?:` chain did.
+    rowId?.let { id ->
+        requeueForRetry(
+            id,
+            resetAttempts = resetAttemptBudget,
+            attemptDelta = budget.failureAttemptDelta(id),
+        )?.let { return it }
+    }
+    val candidate = sessionKey.takeIf { it.isNotBlank() }
+        ?.let { itemsFor(it).deferredRetryCandidateFor(request) }
+        ?: return null
+    return requeueForRetry(
+        candidate.id,
+        resetAttempts = resetAttemptBudget,
+        attemptDelta = budget.failureAttemptDelta(candidate.id),
+    )
+}
+
+/**
+ * Issue #1635-B: the `attemptDelta` an UPLOAD failure passes to
+ * [OutboundQueueStore.requeueForRetry]. An upload failure ALWAYS charges — this is
+ * deliberately the OPPOSITE of the send leg's window-closed refund
+ * ([outboundAttemptChargeable]), and the asymmetry is the point:
+ *
+ *  - `markUploading` does not claim, so before this an upload-failing row was
+ *    entirely IMMUNE to the [OUTBOUND_MAX_AUTO_ATTEMPTS] bound. The 3s poll
+ *    re-picked it as the oldest retryable row forever, it never parked, the younger
+ *    rows behind it never got a delivery attempt (head-of-line starvation), and each
+ *    retry re-transferred the file FROM BYTE 0 — there is no resume (#1604). A file
+ *    whose transfer time exceeds the live-window duration never completes, so under
+ *    a storm this burns storm-duration x bandwidth of the maintainer's mobile data.
+ *  - A failed SEND is refunded when the window closed under it because it cost
+ *    almost nothing — a few execs. A failed UPLOAD is NEVER free: it already SPENT
+ *    the live window it had, and those megabytes are gone whether or not the
+ *    teardown was the row's fault. "The connection was down" excuses the row from
+ *    blame; it does not refund the data.
+ *
+ * Charging bounds the waste at `OUTBOUND_MAX_AUTO_ATTEMPTS x filesize` and lets the
+ * auto-flush park-and-surface the row exactly like a wedged send head, so the tail
+ * drains. Mid-file offset-resume — which would make retries nearly free and is the
+ * real cure — stays #1604's scope.
+ */
+internal const val OUTBOUND_UPLOAD_FAILURE_ATTEMPT_DELTA: Int = 1
+
 internal fun OutboundItem.isComposerQueueRetryable(): Boolean =
     state == OutboundState.Queued || state == OutboundState.Failed
 

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -205,6 +205,7 @@ public class PromptComposerViewModel @Inject constructor(
     internal var outboundHandoffAttachmentJob: Job? = null
     internal var composerInteractionEpoch: Long = 0L
     internal val outboundAutoCloseEpochs: MutableMap<String, Long> = mutableMapOf()
+    internal val outboundAttemptBudget = OutboundAttemptBudgetTracker() // #1635-A
     internal var backgroundDeliveredRequest: SendRequest? = null
     internal var legacyAutoCloseEpoch: Long? = null
     internal val composerRevisionTracker = ComposerRevisionTracker()
@@ -1156,15 +1157,14 @@ public class PromptComposerViewModel @Inject constructor(
 
     /**
      * Issue #971/#987 (Option A) + #1686 taxonomy: the drop path for a send that owns a
-     * durable queue row. STAYS QUEUED and auto-sends on reconnect (#900): re-arms to
-     * [OutboundState.Queued], clears the in-flight gates + watchdog, composer EMPTY, no
-     * error banner. Falls back to [restoreFailedSend] with [noRowFallbackMessage] ONLY
-     * when there is no durable row.
+     * durable queue row. STAYS QUEUED and auto-sends on reconnect (#900); falls back to
+     * [restoreFailedSend] with [noRowFallbackMessage] ONLY when there is no durable row.
      *
-     * [resetAttemptBudget] (#1686 taxonomy): `false` = a LIVE rejection keeps the claim's
-     * attempt bump so a poison row eventually parks (#1602); `true` = transport UNAVAILABLE
-     * (wire-oracle probe not-writable) re-grants the budget so a flapping/prolonged outage
-     * NEVER parks the row (the #1686 clog).
+     * The budget composes two signals: the epoch-aware [outboundAttemptBudget] refunds a
+     * failure whose delivery window flipped under it (#1635-A storm), and
+     * [resetAttemptBudget] rides on top — `true` = transport proven not-writable
+     * (#1686 wire-oracle) FULLY re-grants the budget; `false` = a proven-live rejection
+     * lets a poison row park (#1602).
      */
     public fun markOutboundSendDeferred(
         request: SendRequest,
@@ -1176,12 +1176,9 @@ public class PromptComposerViewModel @Inject constructor(
         inFlightSendRequest = null
         val id = request.outboundQueueItemId
         id?.let(outboundAutoCloseEpochs::remove)
-        val requeued = id?.let { outboundQueueStore.requeueForRetry(it, resetAttempts = resetAttemptBudget) }
-            ?: request.sendTarget.sessionKey.takeIf { it.isNotBlank() }?.let { sessionKey ->
-                outboundQueueStore.itemsFor(sessionKey).deferredRetryCandidateFor(request)
-            }?.let {
-                outboundQueueStore.requeueForRetry(it.id, resetAttempts = resetAttemptBudget)
-            }
+        val requeued = outboundQueueStore.requeueDeferredSend(
+            id, request.sendTarget.sessionKey, request, outboundAttemptBudget, resetAttemptBudget,
+        )
         if (requeued == null) {
             // No durable row to keep queued — restore to the composer so it is not lost.
             restoreFailedSend(request, message = noRowFallbackMessage)
@@ -1380,6 +1377,7 @@ public class PromptComposerViewModel @Inject constructor(
         // racing a just-resolved delivery's own consume, which happens inline in the
         // send dispatcher long before any switch.
         outboundAutoCloseEpochs.keys.retainAll { outboundQueueStore.item(it) != null }
+        outboundAttemptBudget.retainRows { outboundQueueStore.item(it) != null } // #1635-A
         val draftOwner = savedStateHandle.get<String>(KEY_DRAFT_OWNER)
         val hasDraft = _uiState.value.draft.isNotEmpty() ||
             _uiState.value.attachments.isNotEmpty()
@@ -1695,13 +1693,13 @@ public class PromptComposerViewModel @Inject constructor(
             Result.failure(t)
         }
         val uploadedPaths = result.getOrElse { error ->
-            outboundQueueStore.requeueForRetry(id)
+            outboundQueueStore.requeueForRetry(id, attemptDelta = OUTBOUND_UPLOAD_FAILURE_ATTEMPT_DELTA)
             refreshOutboundQueueItemsFor(uploading.sessionKey)
             clearStrandedSendInFlight()
             return false
         }.filter { it.isNotBlank() }
         if (uploadedPaths.size != pendingSidecars.size) {
-            outboundQueueStore.requeueForRetry(id)
+            outboundQueueStore.requeueForRetry(id, attemptDelta = OUTBOUND_UPLOAD_FAILURE_ATTEMPT_DELTA)
             refreshOutboundQueueItemsFor(uploading.sessionKey)
             clearStrandedSendInFlight()
             return false
@@ -1734,6 +1732,7 @@ public class PromptComposerViewModel @Inject constructor(
             return false
         }
         active.recordQueueRowState("Queued", "InFlight", "claimed") // #1682
+        outboundAttemptBudget.onClaim(id) // #1635-A
         val attachments = active.attachments.toStagedAttachments()
         val text = appendAttachmentPaths(active.cleanText, attachments.map { it.remotePath })
         if (text.isEmpty()) {

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -6,8 +6,6 @@ import com.pocketshell.app.composer.OutboundWireAttemptDurableStore
 import com.pocketshell.app.composer.asWireAttemptDurableStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.core.tmux.TmuxClient
-import com.pocketshell.core.tmux.TmuxDisconnectEvent
-import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 
@@ -554,7 +552,6 @@ internal suspend fun deliverDequeuedInputBatch(
     queue: TmuxPaneInputQueue,
     currentClient: () -> TmuxClient?,
     sendBytes: suspend (TmuxClient, String, ByteArray) -> Unit,
-    onPersistentFailureOfCurrentClient: suspend (TmuxDisconnectEvent) -> Unit,
 ): Boolean {
     var lastFailure: Throwable? = null
     var ambiguousWireAttempt = false
@@ -632,22 +629,18 @@ internal suspend fun deliverDequeuedInputBatch(
             "clientCurrent=${client === currentClient()} clientDisconnected=${client.disconnected.value}",
         failure,
     )
-    if (client === currentClient()) {
-        onPersistentFailureOfCurrentClient(
-            TmuxDisconnectEvent(
-                reason = if (client.disconnected.value) {
-                    TmuxDisconnectReason.ReaderEof
-                } else {
-                    TmuxDisconnectReason.ReaderException
-                },
-                source = "pane_input_send",
-                intent = "input_send_failure",
-                commandKind = "send-keys",
-                exceptionClass = failure?.javaClass?.simpleName,
-                message = failure?.message,
-            ),
-        )
-    }
+    // Issue #1635 / design D2 (#1331): the exhausted batch used to fire a SYNTHETIC
+    // `TmuxDisconnectEvent(source = "pane_input_send")` into `handlePassiveClientDisconnect`
+    // — the outbound queue driving the connection state machine. DELETED (hard-cut,
+    // D22). It made the queue AMPLIFY the storm it was suffering from: a failed
+    // keystroke send fed a passive-disconnect into the reconnect ladder, which caused
+    // more failed sends, which fired more disconnects. That feedback loop is visible
+    // in the maintainer's own device log as `disconnectSource=pane_input_send`
+    // (#1610, 07-15). It is also strictly redundant — a genuinely dead client is
+    // detected by the reader/keepalive that OWN that judgement — and under the #1633
+    // episode semantics it became actively harmful: each synthetic drop ADVANCES the
+    // reconnect attempt counter toward give-up. The queue's only legitimate signal to
+    // the machine is `SendWake` (design D1/A4); a delivery failure is never one.
     queue.recordDropped(batch)
     return true
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -535,8 +535,12 @@ private fun TmuxSessionScreenEffects(
         )
     }
 
-    val outboundQueueAutoFlushController = remember(targetSessionId.value) {
-        OutboundQueueAutoFlushController()
+    val outboundQueueAutoFlushController = remember(targetSessionId.value, promptComposerViewModel) {
+        // #1635-A (D4): `boundTo` BINDS the retry budget to this screen's delivery
+        // window, so a send that failed with the window closed burns zero attempts. It
+        // reads the budget off the composer itself — the screen never names a tracker —
+        // so the wiring can be neither dropped nor misdirected.
+        OutboundQueueAutoFlushController.boundTo(promptComposerViewModel)
     }
     LaunchedEffect(targetSessionId.value) {
         promptComposerViewModel.onComposerTargetChanged(targetSessionId.value)

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import com.pocketshell.app.composer.ComposerQueueDiagnostics
+import com.pocketshell.app.composer.OutboundAttemptBudgetTracker
+import com.pocketshell.app.composer.OutboundDeliveryWindow
 import com.pocketshell.app.composer.OutboundLauncherBadge
 import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.composer.outboundLauncherBadge
@@ -292,9 +294,59 @@ internal fun connectionStatusDiagnosticLabel(
  * verify-before-resend ledger in the send path — a re-dispatch of an
  * already-landed payload is suppressed there, never doubled.
  */
-internal class OutboundQueueAutoFlushController(
-    private val clock: () -> Long = { System.currentTimeMillis() },
+internal class OutboundQueueAutoFlushController private constructor(
+    // Issue #1635-A (design D4): the outbound retry budget this controller's delivery
+    // window drives. PRIVATE constructor — see [boundTo]. No caller outside this class
+    // can name a tracker, so neither of the two failure modes below is expressible at a
+    // call site.
+    budget: OutboundAttemptBudgetTracker,
+    private val clock: () -> Long,
 ) {
+    init {
+        budget.window = { deliveryWindow }
+    }
+
+    internal companion object {
+        /**
+         * Issue #1635-A (design D4): the ONLY way to build a controller. The budget is
+         * READ FROM [composer] — the single authority that owns it and whose send path
+         * (`requeueDeferredSend`, `onClaim`) actually consumes it — rather than passed
+         * in, so a caller cannot supply a tracker the composer does not consume.
+         *
+         * ## Why a factory and not a required constructor argument
+         *
+         * This binding has TWO failure modes, and a required argument only kills one:
+         *
+         *  - **Omission** — the binding used to be a separate
+         *    `budget.window = { controller.deliveryWindow }` statement in the screen's
+         *    `LaunchedEffect`. Deleting that ONE line left the whole app suite green
+         *    while silently restoring the reported bug: the budget fell back to
+         *    [OUTBOUND_ASSUMED_STABLE_WINDOW], every storm failure became chargeable,
+         *    the queue parked at [OUTBOUND_MAX_AUTO_ATTEMPTS] and never auto-sent after
+         *    the link healed. Making `budget` a required constructor argument fixed
+         *    THIS: omitting it stopped compiling.
+         *  - **Wrong value** — but a required argument only enforces that AN argument is
+         *    passed, never that it is THE composer's budget.
+         *    `OutboundQueueAutoFlushController(budget = OutboundAttemptBudgetTracker())`
+         *    compiled, kept 3,968 tests green, and fully restored the maintainer's bug:
+         *    a fresh tracker is bound, the composer's own tracker never is, and every
+         *    storm failure charges exactly as before. The wrong-value idiom was even
+         *    copy-pasteable — it sat in three test files.
+         *
+         * A private constructor plus this factory kills BOTH: there is no `budget`
+         * parameter to forget, and no tracker to get wrong. The one remaining seam is
+         * this factory's own body (the companion can reach the private constructor);
+         * `OutboundDeliveryWindowWiringTest.theOnlyControllerFactoryBindsTheComposersOwnBudget`
+         * is what reds if it ever stops reading `composer.outboundAttemptBudget`.
+         * Hard-cut per D22 — the deletable wiring statement is gone, not duplicated.
+         */
+        fun boundTo(
+            composer: PromptComposerViewModel,
+            clock: () -> Long = { System.currentTimeMillis() },
+        ): OutboundQueueAutoFlushController =
+            OutboundQueueAutoFlushController(budget = composer.outboundAttemptBudget, clock = clock)
+    }
+
     private var windowKey: Pair<Boolean, String>? = null
 
     // Issue #1532 (RC-B): per-row timestamp of the last auto-flush dispatch
@@ -302,6 +354,29 @@ internal class OutboundQueueAutoFlushController(
     // its [OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS] backoff; expired entries are
     // pruned each snapshot, which also bounds the map on a long-lived screen.
     private val lastAttemptAtMs = mutableMapOf<String, Long>()
+
+    // Issue #1635-A (design D4): the CURRENT delivery window. `epoch` counts every
+    // `(sessionLive, target)` flip this controller has observed, so an outbound row
+    // claimed in one window and failing in another can prove the window was torn
+    // down UNDER its attempt — the failure is the storm's fault, not the row's, and
+    // burns zero of its bounded auto-retry budget. Liveness alone cannot show that:
+    // under the #1610 storm the link dies and heals several times inside one ~50s
+    // send timeout, so claim and failure BOTH read `live = true` across a window that
+    // no longer exists. The epoch is the only thing that makes that flip visible.
+    private var deliveryWindowEpoch: Long = 0L
+
+    // Starts LIVE so a controller that has not observed its first flip yet reports
+    // exactly [OUTBOUND_ASSUMED_STABLE_WINDOW] (live, epoch 0) — the same window an
+    // un-bound budget assumed. The binding now happens at CONSTRUCTION (composition)
+    // while the first flip arrives from the screen's `LaunchedEffect`, so that gap is
+    // real; resolving it toward "stable/live" keeps it fail-safe TOWARD the #1602 park
+    // (charge) and never toward an unbounded retry loop (refund-everything), which is
+    // the G6 negative this fix must not mint. Same for a controller stranded by an
+    // abandoned composition.
+    private var deliveryWindowLive: Boolean = true
+
+    val deliveryWindow: OutboundDeliveryWindow
+        get() = OutboundDeliveryWindow(live = deliveryWindowLive, epoch = deliveryWindowEpoch)
 
     fun onConnectionWindowChanged(
         sessionLive: Boolean,
@@ -316,6 +391,11 @@ internal class OutboundQueueAutoFlushController(
         val nextKey = sessionLive to targetSessionId
         if (nextKey == windowKey) return
         windowKey = nextKey
+        // Issue #1635-A: a flip means every attempt claimed in the PREVIOUS window
+        // lost the window it needed. Bump before anything else so a resolution that
+        // races this flip already reads the new epoch and refunds.
+        deliveryWindowEpoch += 1L
+        deliveryWindowLive = sessionLive
         // Issue #1682: the drain window opened/closed — capture WHICH status enum
         // drove it (the smoking-gun pairing). Diagnostics-only; no behaviour change.
         ComposerQueueDiagnostics.windowFlip(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -15530,9 +15530,6 @@ public class TmuxSessionViewModel @Inject constructor(
         queue = queue,
         currentClient = { clientRef },
         sendBytes = { c, p, b -> sendInputBytesToPane(c, p, b) },
-        onPersistentFailureOfCurrentClient = { event ->
-            handlePassiveClientDisconnect(client = client, disconnectEvent = event)
-        },
     )
 
     private suspend fun sendInputBytesToPane(

--- a/app/src/test/java/com/pocketshell/app/composer/ComposerQueueDiagnosticsHostMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/ComposerQueueDiagnosticsHostMirrorTest.kt
@@ -9,6 +9,7 @@ import com.pocketshell.app.diagnostics.DiagnosticRecorder
 import com.pocketshell.app.diagnostics.MirroredDiagnostics
 import com.pocketshell.app.settings.SettingsRepository
 import com.pocketshell.app.tmux.OutboundQueueAutoFlushController
+import com.pocketshell.app.tmux.outboundBudgetTestComposer
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -125,7 +126,7 @@ class ComposerQueueDiagnosticsHostMirrorTest {
     fun `window_flip reaches the host log with sessionLive and the driving status`() = runTest {
         val recorder = newRecorder()
 
-        val controller = OutboundQueueAutoFlushController()
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
         // The drain gate closes while the wire may still be alive (Reconnecting enum).
         controller.onConnectionWindowChanged(
             sessionLive = false,
@@ -154,7 +155,7 @@ class ComposerQueueDiagnosticsHostMirrorTest {
     fun `a drain tick against a shut gate records not_live`() = runTest {
         val recorder = newRecorder()
 
-        val controller = OutboundQueueAutoFlushController()
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
         controller.onConnectionWindowChanged(
             sessionLive = false,
             targetSessionId = sessionPath,
@@ -181,7 +182,7 @@ class ComposerQueueDiagnosticsHostMirrorTest {
     fun `an idle shut gate records no drain tick`() = runTest {
         val recorder = newRecorder()
 
-        val controller = OutboundQueueAutoFlushController()
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
         controller.onConnectionWindowChanged(
             sessionLive = false,
             targetSessionId = sessionPath,

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundQueueStormTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundQueueStormTest.kt
@@ -1,0 +1,617 @@
+package com.pocketshell.app.composer
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.settings.VoiceTranscriptionProvider
+import com.pocketshell.core.ssh.SshException
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1635: what a RECONNECT STORM (#1610 — transport teardown/redial every
+ * ~1s–1min on mobile) does to the outbound queue's bounded auto-retry budget
+ * (#1602). Two asymmetric defects, both reproduced RED on base here and proven
+ * GREEN with the fix.
+ *
+ *  - **#1635-A — the queue parks and STAYS parked.** Every live window burns an
+ *    attempt (the flip clears the per-row backoff, so the flip itself re-arms an
+ *    immediate dispatch) and every attempt dies at the next teardown. Six failures
+ *    take ~30s of storm; the row parks `Failed`, and a genuine reconnect resets the
+ *    BACKOFF but never the ATTEMPT COUNT. So when the storm ends and the link is
+ *    fully healthy, **nothing auto-sends** — the maintainer's "it got delivered long
+ *    after, when I did something".
+ *  - **#1635-B — attachment rows are the inverse and worse.** `markUploading` does
+ *    not claim, so upload failures never bumped the budget: the row was IMMUNE to
+ *    the park and looped at the 3s poll cadence FOREVER, re-transferring the file
+ *    from byte 0 every time (no resume — #1604), starving every younger row behind
+ *    it and burning mobile data without limit.
+ *
+ * **Why every reproduction here drives N >= 5 cycles.** A single-cycle test cannot
+ * see either defect: one flap burns one attempt (budget intact, row still sends)
+ * and one upload failure looks like a normal retry. The bug IS the regime — the
+ * policy's behaviour ACROSS cycles — which is exactly the blindness that let the
+ * #1610 livelock survive four fixes (#1640, #1652) and the gap the #1526 storm
+ * audit named ("no CI gate exercises more than ONE flap cycle against the queue").
+ *
+ * Class coverage (G2):
+ *  - text/prompt row, storm (window-closed) -> zero burn, auto-sends after recovery.
+ *  - text/prompt row, window flipped and HEALED *under* one attempt -> zero burn
+ *    (liveness at both ends reads `true`; only the epoch exposes it).
+ *  - text/prompt row, STABLE live window, genuine failures -> charges and STILL
+ *    parks (the load-bearing negative, G6 — the fix must not mint a new infinite
+ *    retry loop in place of the old stuck head).
+ *  - attachment/sidecar row, upload failures -> charges, parks, data bounded.
+ *  - mixed queue (attachment head + text tail) -> head-of-line starvation cleared.
+ *
+ * Pure JVM/Robolectric ViewModel tests under virtual time, gate-wired in the
+ * per-push `Unit tests` job via `./gradlew test`. No self-skip on any load-bearing
+ * assertion.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PromptComposerOutboundQueueStormTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val createdViewModels = mutableListOf<PromptComposerViewModel>()
+
+    @After
+    fun tearDownViewModels() {
+        createdViewModels.forEach { it.clearForTest() }
+        createdViewModels.clear()
+    }
+
+    /** The number of storm cycles each reproduction drives. Must exceed the budget. */
+    private val stormCycles = 8
+
+    private class FakeVault(initial: CharArray? = null) : ApiKeyVault {
+        private var key: CharArray? = initial?.copyOf()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = key?.copyOf()
+        override fun clear() { key = null }
+    }
+
+    private class FakeMicCapture : PromptComposerViewModel.MicCapture {
+        override fun start() = Unit
+        override fun stop(): ByteArray = byteArrayOf(1)
+        override fun currentAmplitude(): Float = 0f
+    }
+
+    private class FakeVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+        override fun whisperLanguageHint(): String? = null
+        override fun transcriptionProvider(): VoiceTranscriptionProvider =
+            VoiceTranscriptionProvider.OpenAiWhisper
+    }
+
+    /**
+     * The delivery window the session screen owns in production
+     * ([OutboundQueueAutoFlushController.deliveryWindow]): live/dead plus an epoch
+     * that increments on EVERY flip. Driving it directly is what lets this test
+     * reproduce the storm regime deterministically under virtual time.
+     */
+    private class FakeDeliveryWindow {
+        private var live = true
+        private var epoch = 0L
+
+        fun current(): OutboundDeliveryWindow = OutboundDeliveryWindow(live = live, epoch = epoch)
+
+        /** The transport tears down — the window closes. */
+        fun teardown() {
+            live = false
+            epoch += 1L
+        }
+
+        /** The transport redials — a NEW live window (a different epoch). */
+        fun restore() {
+            live = true
+            epoch += 1L
+        }
+    }
+
+    private fun newVm(
+        dispatcher: TestDispatcher,
+        outboundQueueStore: OutboundQueueStore,
+        outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
+        window: FakeDeliveryWindow? = null,
+    ): PromptComposerViewModel {
+        val vm = PromptComposerViewModel(
+            audioRecorder = FakeMicCapture(),
+            whisperClientFactory = WhisperClientFactory { null },
+            apiKeyStorage = FakeVault().also { it.save("sk-test".toCharArray()) },
+            voiceSettings = FakeVoiceSettings(),
+            speechRecognitionProvider = UnavailableSpeechRecognitionProvider,
+            composerDraftStore = InMemoryComposerDraftStore(),
+            outboundQueueStore = outboundQueueStore,
+            outboundAttachmentSidecarStore = outboundAttachmentSidecarStore,
+            savedStateHandle = SavedStateHandle(),
+        )
+        vm.samplerDispatcher = dispatcher
+        vm.outboundQueueDispatcher = dispatcher
+        vm.setSendWatchdogTimeoutForTest(null)
+        // Unwired (null) keeps the production default: a STABLE LIVE window, which
+        // charges every attempt exactly as base did. That default is what the G6
+        // negative below relies on.
+        window?.let { w -> vm.outboundAttemptBudget.window = { w.current() } }
+        createdViewModels += vm
+        return vm
+    }
+
+    private fun TestScope.collectSendRequests(
+        vm: PromptComposerViewModel,
+    ): MutableList<PromptComposerViewModel.SendRequest> {
+        val collected = java.util.Collections.synchronizedList(
+            mutableListOf<PromptComposerViewModel.SendRequest>(),
+        )
+        backgroundScope.launch { vm.sendRequests.collect { collected += it } }
+        runCurrent()
+        return collected
+    }
+
+    private suspend fun TestScope.settleUntil(predicate: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 40_000L
+        while (true) {
+            advanceUntilIdle()
+            if (predicate()) return
+            runCurrent()
+            if (predicate()) return
+            advanceTimeBy(1L)
+            runCurrent()
+            if (predicate()) return
+            withContext(Dispatchers.IO) { Thread.sleep(1L) }
+            if (predicate()) return
+            if (System.currentTimeMillis() >= deadline) {
+                advanceUntilIdle()
+                assertTrue("settleUntil timed out before the predicate held (#1635)", predicate())
+                return
+            }
+        }
+    }
+
+    private fun newSidecarStore(ioDispatcher: TestDispatcher): OutboundAttachmentSidecarStore {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.getSharedPreferences(OutboundAttachmentSidecarStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, OutboundAttachmentSidecarStore.DIRECTORY_NAME).deleteRecursively()
+        var nextId = 0
+        return OutboundAttachmentSidecarStore(context).also { store ->
+            store.idGenerator = { "sidecar-${++nextId}" }
+            store.clock = { nextId.toLong() }
+            store.ioDispatcher = ioDispatcher
+        }
+    }
+
+    private fun pickedFile(name: String, content: String): Uri {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val file = File(File(context.cacheDir, "picked"), name).apply {
+            parentFile?.mkdirs()
+            writeText(content)
+        }
+        return Uri.fromFile(file)
+    }
+
+    // ---- #1635-A: the storm parks the queue, and recovery never un-parks it ------
+
+    /**
+     * THE reported symptom. Drive [stormCycles] teardown/redial cycles with a prompt
+     * queued, each attempt failing because the window died under it, then hand the
+     * queue a STABLE, fully-healthy window.
+     *
+     * BASE (RED): every cycle charges an attempt; the row parks `Failed` at 6; the
+     * stable window delivers NOTHING (`retryNextOutboundItem` returns null forever,
+     * because `firstComposerAutoFlushable` excludes `attemptCount >= 6` regardless of
+     * state). The prompt sits there until the user notices the amber badge and taps
+     * Resend — "delivered long after, when I did something".
+     *
+     * GREEN: window-closed failures burn zero attempts, so the storm leaves the
+     * budget intact and the first stable window delivers the row — exactly once.
+     */
+    @Test
+    fun stormedPromptRowAutoSendsOnceTheWindowIsStableAgain() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val window = FakeDeliveryWindow()
+        val vm = newVm(dispatcher, queue, window = window)
+        val sent = collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+
+        val row = queue.enqueue(sessionKey = session, cleanText = "ship the storm fix", createdAtMs = 1)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        // ---- the storm: N cycles of "live window opens -> dispatch -> teardown" ----
+        repeat(stormCycles) { cycle ->
+            val dispatched = vm.retryNextOutboundItem()
+            advanceUntilIdle()
+            assertEquals(
+                "cycle $cycle: the live window must re-arm the queued row (this is what " +
+                    "burns the budget on base)",
+                row.id,
+                dispatched,
+            )
+            val request = requireNotNull(vm.inFlightSendRequest) {
+                "cycle $cycle: the dispatch must have produced an in-flight request"
+            }
+            // The transport dies mid-send — the delivery window closes UNDER the
+            // attempt. This is the storm's signature failure, and it is not the row's
+            // fault in any sense.
+            window.teardown()
+            vm.markOutboundSendDeferred(request)
+            advanceUntilIdle()
+            window.restore()
+            advanceUntilIdle()
+        }
+
+        // LOAD-BEARING (GREEN): the storm charged NOTHING. (BASE: attemptCount == 8,
+        // state == Failed after the auto-flush parks it.)
+        val afterStorm = requireNotNull(queue.item(row.id))
+        assertEquals(
+            "a failure because the connection was down must burn ZERO attempts — " +
+                "$stormCycles storm cycles left the budget intact (#1635-A / D4)",
+            0,
+            afterStorm.attemptCount,
+        )
+        assertEquals(
+            "the row must still be Queued after the storm, never parked Failed (#1635-A)",
+            OutboundState.Queued,
+            afterStorm.state,
+        )
+
+        // ---- the storm ends: a stable, healthy window ----
+        val sentBefore = sent.size
+        val delivered = vm.retryNextOutboundItem()
+        settleUntil { sent.size > sentBefore }
+
+        // LOAD-BEARING (GREEN): the recovered link auto-sends the row. On BASE this
+        // is null — the whole point of the bug.
+        assertEquals(
+            "once the link is healthy again the queued prompt must AUTO-send — on base " +
+                "the storm-exhausted budget parked it and nothing sent until the user " +
+                "manually tapped Retry (#1635-A)",
+            row.id,
+            delivered,
+        )
+        val request = requireNotNull(sent.lastOrNull { it.outboundQueueItemId == row.id })
+
+        // The host acks: delivered exactly once, the row is pruned, no duplicate left.
+        vm.markSendDelivered(request)
+        settleUntil { queue.item(row.id) == null }
+        assertNull(
+            "the delivered row must be pruned exactly once — no duplicate survives (#1529 ledger intact)",
+            queue.item(row.id),
+        )
+        assertEquals(
+            "exactly one row existed for this logical send throughout",
+            0,
+            queue.itemsFor(session).size,
+        )
+    }
+
+    /**
+     * Class coverage (G2): the window flip that HEALS *inside* one attempt. A ~50s
+     * send timeout spans many cycles of a 1/s storm, so the claim and the failure
+     * BOTH observe `live = true` across a window that was destroyed in between.
+     * Liveness alone would charge this attempt; only the epoch exposes the flip.
+     * This is the storm's most common shape and the reason the window is an epoch
+     * rather than a boolean.
+     */
+    @Test
+    fun windowTornDownAndHealedUnderTheAttemptBurnsZeroAttempts() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val window = FakeDeliveryWindow()
+        val vm = newVm(dispatcher, queue, window = window)
+        collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+        val row = queue.enqueue(sessionKey = session, cleanText = "slow send", createdAtMs = 1)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        repeat(stormCycles) { cycle ->
+            assertEquals(row.id, vm.retryNextOutboundItem())
+            advanceUntilIdle()
+            val request = requireNotNull(vm.inFlightSendRequest) { "cycle $cycle: no in-flight request" }
+            // The link dies AND heals while the attempt is still outstanding, so by
+            // the time the send resolves the window reads LIVE again — just not the
+            // same window the attempt was claimed in.
+            window.teardown()
+            window.restore()
+            advanceUntilIdle()
+            vm.markOutboundSendDeferred(request)
+            advanceUntilIdle()
+        }
+
+        assertEquals(
+            "a window torn down and healed UNDER the attempt is still a window-closed " +
+                "failure — it must burn zero attempts even though liveness reads true " +
+                "at both ends (#1635-A / D4)",
+            0,
+            requireNotNull(queue.item(row.id)).attemptCount,
+        )
+        assertEquals(
+            "the row must remain Queued and auto-sendable",
+            OutboundState.Queued,
+            requireNotNull(queue.item(row.id)).state,
+        )
+        assertEquals(
+            "and the next stable window must dispatch it",
+            row.id,
+            vm.retryNextOutboundItem(),
+        )
+    }
+
+    // ---- The load-bearing NEGATIVE (G6) -----------------------------------------
+
+    /**
+     * **The load-bearing negative (G6).** A row that genuinely fails on its own
+     * merits against a PROVEN-GOOD link — a bad payload, a real server rejection, a
+     * wedged head — must STILL exhaust its budget and park. If "window-closed burns
+     * zero" were applied too broadly (e.g. refunding every deferral, or treating any
+     * failure as connection-classified), this row would retry FOREVER: a new
+     * infinite loop replacing the old parked queue, and #1602's head-of-line clog
+     * would be back with it.
+     *
+     * The window here NEVER flips: same epoch, live at claim and at failure, for
+     * every attempt. That is the whole discriminator.
+     */
+    @Test
+    fun rowThatGenuinelyFailsOnAStableLiveWindowStillExhaustsItsBudgetAndParks() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val window = FakeDeliveryWindow() // live, epoch 0, and never touched again.
+        val vm = newVm(dispatcher, queue, window = window)
+        collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+        val bad = queue.enqueue(sessionKey = session, cleanText = "server rejects this", createdAtMs = 1)
+        val tail = queue.enqueue(sessionKey = session, cleanText = "healthy tail", createdAtMs = 2)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        var tailDispatched = false
+        repeat(stormCycles * 3) {
+            val dispatched = vm.retryNextOutboundItem()
+            advanceUntilIdle()
+            if (dispatched == tail.id) {
+                tailDispatched = true
+                return@repeat
+            }
+            if (dispatched == bad.id) {
+                // Fails against a link that is live, stable, and the SAME window it was
+                // claimed in — this failure is the row's own fault.
+                val request = vm.inFlightSendRequest ?: return@repeat
+                vm.markOutboundSendDeferred(request)
+                advanceUntilIdle()
+            }
+        }
+
+        val parked = requireNotNull(queue.item(bad.id))
+        assertEquals(
+            "a row that fails against a stable live window must STILL charge every " +
+                "attempt — otherwise the #1635-A refund mints a new infinite retry " +
+                "loop in place of #1602's stuck head (G6)",
+            OUTBOUND_MAX_AUTO_ATTEMPTS,
+            parked.attemptCount,
+        )
+        assertEquals(
+            "and it must still be PARKED (Failed, surfaced) at the bound (#1602 preserved)",
+            OutboundState.Failed,
+            parked.state,
+        )
+        assertEquals(
+            "with the surfaced retry label the user acts on",
+            OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE,
+            parked.lastError,
+        )
+        assertTrue(
+            "and the healthy tail must drain past the parked head (#1602 head-of-line unclog preserved)",
+            tailDispatched,
+        )
+    }
+
+    /**
+     * Refactor guard for [requeueDeferredSend]: #1635 routes the deferral through a
+     * single helper so the budget correction has one home. The pre-#1635 `?:` chain
+     * had a subtle property that MUST survive: when the request carries a row id but
+     * that row is already gone (delivered/pruned out from under the deferral), the
+     * lookup FALLS THROUGH to matching the request against the session's undelivered
+     * rows — it does not give up. Losing that fall-through would silently strand the
+     * prompt (the #971/#987 Option-A path drops to `restoreFailedSend`), so pin it.
+     *
+     * **Why the rows start `Failed`, and why there is a decoy.** The FIRST version of
+     * this test was VACUOUS and the reviewer caught it: it enqueued one row (which
+     * [OutboundQueueStore.enqueue] mints already `Queued`) and asserted only that the
+     * row was `Queued` afterwards — a fact that was TRUE BEFORE the code under test
+     * ever ran. Breaking the fall-through outright left all of it green. So:
+     *
+     *  - Both rows are driven to `Failed` FIRST (asserted as a precondition below), so
+     *    `Queued` is a state ONLY the fall-through's `requeueForRetry` can produce.
+     *    The assertion now measures a TRANSITION, not the initial state.
+     *  - A DECOY row — older, non-matching text — sits ahead of the target. The
+     *    candidate lookup is `firstOrNull { cleanText == cleanDraft } ?: firstOrNull()`,
+     *    so without the decoy an id-blind `firstOrNull()` fallback would pick the same
+     *    single row and the test could not tell "matched the right row" from "grabbed
+     *    whatever was first". Requeueing the DECOY instead of the target would strand
+     *    the real prompt and re-fire the wrong one — so the decoy must stay `Failed`.
+     */
+    @Test
+    fun deferralWithAStaleRowIdStillFallsThroughToTheMatchingQueuedRow() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(dispatcher, queue)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+        // Older, non-matching: the row an id-blind `firstOrNull()` would wrongly grab.
+        val decoy = queue.enqueue(sessionKey = session, cleanText = "decoy — do not pick me", createdAtMs = 1)
+        val live = queue.enqueue(sessionKey = session, cleanText = "match me by text", createdAtMs = 2)
+        // Drive both OUT of `Queued` so the post-state can only come from the fall-through.
+        queue.markFailed(decoy.id, lastError = "boom")
+        queue.markFailed(live.id, lastError = "boom")
+        vm.refreshOutboundQueueItemsFor(session)
+
+        // Guard against this test going vacuous again: if the target were already
+        // `Queued` here, the assertion below would pass without the fall-through.
+        assertEquals(
+            "precondition: the target row must NOT already be Queued, or this test proves nothing",
+            OutboundState.Failed,
+            requireNotNull(queue.item(live.id)).state,
+        )
+
+        // A request whose own row id no longer resolves (pruned), but whose text still
+        // matches a live undelivered row.
+        val request = PromptComposerViewModel.SendRequest(
+            text = "match me by text",
+            withEnter = true,
+            sendTarget = PromptComposerViewModel.SendTargetSnapshot(sessionKey = session),
+            outboundQueueItemId = "row-that-no-longer-exists",
+        )
+        vm.markOutboundSendDeferred(request)
+        advanceUntilIdle()
+
+        val target = requireNotNull(queue.item(live.id))
+        assertEquals(
+            "a stale row id must fall through to the matching row and RE-ARM it (Failed -> Queued), not strand the prompt",
+            OutboundState.Queued,
+            target.state,
+        )
+        assertNull(
+            "and the fall-through's requeue must clear the stale error so the auto-flush can re-claim it",
+            target.lastError,
+        )
+        assertEquals(
+            "the fall-through must match the row by TEXT — re-arming the older decoy would strand the real prompt and re-fire the wrong one",
+            OutboundState.Failed,
+            requireNotNull(queue.item(decoy.id)).state,
+        )
+    }
+
+    // ---- #1635-B: the attachment row's budget-immune infinite loop ---------------
+
+    /**
+     * THE second reported symptom, and the expensive one. An attachment row whose
+     * upload keeps failing under the storm.
+     *
+     * BASE (RED): `markUploading` does not claim and every upload failure exits via
+     * `requeueForRetry` with the count preserved, so `attemptCount` stays 0 FOREVER.
+     * The row is re-picked as the oldest retryable row on every cycle, re-transfers
+     * the file from byte 0 every time (no resume — #1604), never parks, and the
+     * younger text row behind it NEVER gets a delivery attempt. On base the upload
+     * count here grows without bound (== the number of cycles driven) and
+     * `tailDispatched` is false.
+     *
+     * GREEN: upload failures charge the budget; the row parks-and-surfaces within
+     * `OUTBOUND_MAX_AUTO_ATTEMPTS` failures; the data burn is BOUNDED; the tail drains.
+     */
+    @Test
+    fun uploadFailingAttachmentHeadParksWithinTheBudgetAndStopsStarvingTheTail() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = newSidecarStore(dispatcher)
+        val window = FakeDeliveryWindow()
+        val vm = newVm(dispatcher, queue, sidecars, window = window)
+        val sent = collectSendRequests(vm)
+        val session = "1/session-a"
+        vm.onComposerTargetChanged(session)
+        vm.onDraftChange("here is the photo")
+
+        // A retained-on-failure local pick -> the Send takes the sidecar upload leg.
+        val picked = pickedFile("photo.png", "REAL-PNG-BYTES")
+        vm.attachFiles(count = 1, previews = listOf(PromptComposerViewModel.AttachmentPreview(picked, "image/png"))) {
+            Result.failure(SshException("Upload of photo.png failed: Stream closed"))
+        }
+        advanceUntilIdle()
+        assertEquals(1, vm.uiState.value.attachments.size)
+
+        // Every upload attempt dies at the next teardown — and each one re-transfers
+        // the whole file from byte 0, which is what burns the maintainer's data.
+        var uploadCalls = 0
+        vm.setOutboundAttachmentSidecarUploader {
+            uploadCalls += 1
+            Result.failure(SshException("upload died mid-transfer: Stream closed"))
+        }
+
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = session)
+        vm.requestSend(withEnter = true, sendTarget = target)
+        settleUntil { queue.itemsFor(session).isNotEmpty() }
+        val head = requireNotNull(queue.itemsFor(session).firstOrNull()) { "the attachment row must exist" }
+
+        // A younger TEXT row queued behind the attachment head.
+        val tail = queue.enqueue(sessionKey = session, cleanText = "and please review it", createdAtMs = Long.MAX_VALUE / 2)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        var tailDispatched = false
+        repeat(stormCycles * 3) {
+            val dispatched = vm.retryNextOutboundItem()
+            settleUntil { !vm.uiState.value.sendInFlight || vm.inFlightSendRequest != null }
+            advanceUntilIdle()
+            if (dispatched == tail.id) {
+                tailDispatched = true
+                return@repeat
+            }
+            // The storm keeps flapping around the failing upload.
+            window.teardown()
+            window.restore()
+            advanceUntilIdle()
+        }
+
+        // LOAD-BEARING (GREEN) #1: the data burn is BOUNDED. On base this is
+        // unbounded — one full re-transfer per cycle, forever, on mobile data.
+        assertTrue(
+            "an upload-failing row must NOT re-transfer the file without limit — on base " +
+                "it looped from byte 0 every 3s forever (#1635-B). uploadCalls=$uploadCalls",
+            uploadCalls in 1..OUTBOUND_MAX_AUTO_ATTEMPTS,
+        )
+
+        // LOAD-BEARING (GREEN) #2: the head is parked AND surfaced (never a silent drop).
+        val parked = requireNotNull(queue.item(head.id))
+        assertEquals(
+            "the upload-failing head must PARK at the bound like the send leg does — " +
+                "on base `markUploading` never claimed, so it was immune to the budget (#1635-B)",
+            OutboundState.Failed,
+            parked.state,
+        )
+        assertEquals(
+            "and its budget must actually have been charged",
+            OUTBOUND_MAX_AUTO_ATTEMPTS,
+            parked.attemptCount,
+        )
+
+        // LOAD-BEARING (GREEN) #3: head-of-line starvation is cleared.
+        assertTrue(
+            "the younger TEXT row must get a delivery attempt once the upload-failing " +
+                "head parks — on base it starved for the storm's entire duration (#1635-B)",
+            tailDispatched,
+        )
+        settleUntil { sent.any { it.outboundQueueItemId == tail.id } }
+        assertNotNull(
+            "and the tail's SendRequest must actually have been emitted",
+            sent.lastOrNull { it.outboundQueueItemId == tail.id },
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -665,7 +665,9 @@ class PromptComposerOutboundSendQueueViewModelTest {
         // row per queue-snapshot emission, on an IMMEDIATELY-resumed collector
         // (UnconfinedTestDispatcher) — the interleave the composed effect
         // produces on-device.
-        val controller = com.pocketshell.app.tmux.OutboundQueueAutoFlushController()
+        val controller = com.pocketshell.app.tmux.OutboundQueueAutoFlushController.boundTo(
+            composer = vm,
+        )
         val flushJob = launch(
             kotlinx.coroutines.test.UnconfinedTestDispatcher(testScheduler),
         ) {
@@ -927,7 +929,10 @@ class PromptComposerOutboundSendQueueViewModelTest {
             runOutboundQueueAutoFlush(
                 sessionLive = true,
                 outboundQueueItems = vm.outboundQueueItems,
-                controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime }),
+                controller = OutboundQueueAutoFlushController.boundTo(
+                    composer = vm,
+                    clock = { testScheduler.currentTime },
+                ),
                 retryNext = { excludingIds -> vm.retryNextOutboundItem(excludingIds = excludingIds) },
                 sweepStaleInFlight = { staleAfterMs ->
                     vm.requeueStaleOutboundInFlight(staleAfterMs = staleAfterMs)
@@ -994,7 +999,10 @@ class PromptComposerOutboundSendQueueViewModelTest {
             runOutboundQueueAutoFlush(
                 sessionLive = true,
                 outboundQueueItems = vm.outboundQueueItems,
-                controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime }),
+                controller = OutboundQueueAutoFlushController.boundTo(
+                    composer = vm,
+                    clock = { testScheduler.currentTime },
+                ),
                 retryNext = { excludingIds -> vm.retryNextOutboundItem(excludingIds = excludingIds) },
                 sweepStaleInFlight = { staleAfterMs ->
                     vm.requeueStaleOutboundInFlight(staleAfterMs = staleAfterMs)
@@ -1313,9 +1321,13 @@ class PromptComposerOutboundSendQueueViewModelTest {
         // — so the wait genuinely blocks until the flush has completed.
         var requeueCount = 0
         val queue = object : InMemoryOutboundQueueStore() {
-            override fun requeueForRetry(id: String, resetAttempts: Boolean): OutboundItem? {
+            override fun requeueForRetry(
+                id: String,
+                resetAttempts: Boolean,
+                attemptDelta: Int,
+            ): OutboundItem? {
                 requeueCount++
-                return super.requeueForRetry(id, resetAttempts)
+                return super.requeueForRetry(id, resetAttempts, attemptDelta)
             }
         }
         val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerWireOracleClogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerWireOracleClogTest.kt
@@ -6,6 +6,7 @@ import com.pocketshell.app.di.WhisperClientFactory
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.tmux.OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS
 import com.pocketshell.app.tmux.OutboundQueueAutoFlushController
+import com.pocketshell.app.tmux.outboundBudgetTestComposer
 import com.pocketshell.app.tmux.runOutboundQueueAutoFlush
 import com.pocketshell.core.voice.WhisperClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -117,7 +118,7 @@ class PromptComposerWireOracleClogTest {
         // with sessionLive=false NOTHING attempts the wire even though the transport
         // is writable — the false-disconnect clog. GREEN: the wire-oracle gate opens
         // on `sessionLive || transportWritable()`, so the drain attempts and drains.
-        val controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime })
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer(), clock = { testScheduler.currentTime })
         controller.onConnectionWindowChanged(sessionLive = false, targetSessionId = "1/s") {}
         val dispatched = mutableListOf<String>()
         val retryEligible: (Set<String>) -> String? = { ex -> if ("r1" in ex) null else "r1" }
@@ -152,7 +153,7 @@ class PromptComposerWireOracleClogTest {
         // Class coverage (G2) + no-new-reconnect-pressure: a GENUINELY dead wire keeps
         // the gate shut (enum false AND transport not writable), so the drain does NOT
         // attempt — no dispatch, no reconnect kick during a real outage.
-        val controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime })
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer(), clock = { testScheduler.currentTime })
         controller.onConnectionWindowChanged(sessionLive = false, targetSessionId = "1/s") {}
         val dispatched = mutableListOf<String>()
         val quietQueue = flow<Any?> { emit(Unit); awaitCancellation() }

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundBudgetTestComposer.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundBudgetTestComposer.kt
@@ -1,0 +1,47 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.PromptComposerViewModel
+import com.pocketshell.app.di.WhisperClientFactory
+
+/**
+ * Issue #1635-A (design D4): a minimal, plain-JVM [PromptComposerViewModel] for tests
+ * that need a controller ([OutboundQueueAutoFlushController.boundTo]) but are NOT about
+ * the retry budget.
+ *
+ * `boundTo` is the only way to build a controller — deliberately, so that no call site
+ * can hand the controller a tracker the composer does not consume (the wrong-value
+ * failure mode a required `budget` argument did NOT close). That means every controller
+ * test needs a composer, so this keeps the cost to one line.
+ *
+ * All four required ViewModel dependencies are plain interfaces, and the rest default to
+ * the `Disabled*` no-op stubs, so this constructs on the JVM with no Robolectric runner
+ * and no Android framework — the controller tests in `TmuxSessionScreenTest` stay plain
+ * JUnit. It launches nothing: the tests below only read `outboundAttemptBudget`.
+ *
+ * This lives in its own file (not in `TmuxSessionScreenTest.kt`) because that file is a
+ * hygiene-ratcheted 122985 B, close to the 128 KiB guard threshold.
+ */
+internal fun outboundBudgetTestComposer(): PromptComposerViewModel =
+    PromptComposerViewModel(
+        audioRecorder = SilentMicCapture,
+        whisperClientFactory = WhisperClientFactory { error("no transcription in a budget test") },
+        apiKeyStorage = EmptyApiKeyVault,
+        voiceSettings = DefaultVoiceSettings,
+    )
+
+private object SilentMicCapture : PromptComposerViewModel.MicCapture {
+    override fun start() = Unit
+    override fun stop(): ByteArray = ByteArray(0)
+    override fun currentAmplitude(): Float = 0f
+}
+
+private object EmptyApiKeyVault : PromptComposerViewModel.ApiKeyVault {
+    override fun save(key: CharArray) = Unit
+    override fun load(): CharArray? = null
+    override fun clear() = Unit
+}
+
+private object DefaultVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+    override fun silenceWindowMs(): Long = 1_000L
+    override fun whisperLanguageHint(): String? = null
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -3,7 +3,6 @@ package com.pocketshell.app.tmux
 import com.pocketshell.app.composer.asWireAttemptDurableStore
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientException
-import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -96,7 +95,6 @@ class OutboundDeliveryGuardTest {
             queue = queue,
             currentClient = { client },
             sendBytes = { _, _, b -> server.send(b) },
-            onPersistentFailureOfCurrentClient = { },
         )
 
         assertTrue("the batch must resolve (already landed)", resolved)
@@ -125,7 +123,6 @@ class OutboundDeliveryGuardTest {
             queue = queue,
             currentClient = { client },
             sendBytes = { _, _, b -> server.send(b) },
-            onPersistentFailureOfCurrentClient = { },
         )
 
         assertTrue(resolved)
@@ -152,7 +149,6 @@ class OutboundDeliveryGuardTest {
             queue = queue,
             currentClient = { client },
             sendBytes = { _, _, b -> server.send(b) },
-            onPersistentFailureOfCurrentClient = { },
         )
 
         assertTrue(resolved)
@@ -187,7 +183,6 @@ class OutboundDeliveryGuardTest {
                 current = newClient
                 server.send(b)
             },
-            onPersistentFailureOfCurrentClient = { },
         )
 
         assertTrue("the batch must resolve as already-landed, not requeue", resolved)
@@ -211,7 +206,6 @@ class OutboundDeliveryGuardTest {
             queue = queue,
             currentClient = { client },
             sendBytes = { _, _, b -> server.send(b) },
-            onPersistentFailureOfCurrentClient = { },
         )
 
         assertTrue(resolved)
@@ -223,15 +217,37 @@ class OutboundDeliveryGuardTest {
         )
     }
 
-    /** Persistent (twice-failed, probe-NotLanded) batches still drop + report. */
+    /**
+     * Issue #1635 / design D2 (#1331): a persistently-failing keystroke batch is
+     * resolved (dropped) WITHOUT firing a synthetic passive-disconnect into the
+     * reconnect ladder.
+     *
+     * BASE (RED): after 2 failed attempts the lane called
+     * `onPersistentFailureOfCurrentClient(TmuxDisconnectEvent(source = "pane_input_send"))`
+     * -> `handlePassiveClientDisconnect`, i.e. the outbound queue DRIVING the
+     * connection state machine. That made the queue amplify the very storm it was
+     * suffering from — a failed keystroke send caused a reconnect, which caused more
+     * failed sends — and it is visible in the maintainer's own device log as
+     * `disconnectSource=pane_input_send` (#1610, 07-15). Under the #1633 episode
+     * semantics it got worse: each synthetic drop advances the attempt counter
+     * toward give-up.
+     *
+     * GREEN: the injection is DELETED (hard-cut, D22). The batch still resolves and
+     * is still recorded as dropped; the connection's own reader/keepalive keep sole
+     * authority over disconnect judgement.
+     *
+     * The load-bearing assertion is structural-by-necessity: the callback no longer
+     * exists to observe, so the proof is that `deliverDequeuedInputBatch` cannot
+     * report a disconnect at all — there is no seam through which the queue can
+     * reach the ladder. `TmuxDisconnectEvent` is unreferenced by this lane now.
+     */
     @Test
-    fun persistentFailureStillDropsAndReportsDisconnectEvent() = runTest {
+    fun persistentFailureDropsWithoutInjectingAPassiveDisconnect() = runTest {
         val text = "persistently failing batch text"
         val client = captureShowing("$ ")
         val server = AmbiguousServer(failures = 2)
         val queue = newQueue()
         val batch = batchOf(queue, text)
-        var reported: TmuxDisconnectEvent? = null
 
         val resolved = deliverDequeuedInputBatch(
             client = client,
@@ -240,12 +256,27 @@ class OutboundDeliveryGuardTest {
             queue = queue,
             currentClient = { client },
             sendBytes = { _, _, b -> server.send(b) },
-            onPersistentFailureOfCurrentClient = { reported = it },
         )
 
+        // The batch is still resolved and still bounded at 2 wire attempts.
         assertTrue(resolved)
         assertEquals(2, server.received.size)
-        assertEquals("pane_input_send", reported?.source)
+        // And the queue's only remaining effect is on its OWN state — never on the
+        // connection. `deliverDequeuedInputBatch` takes no disconnect sink at all,
+        // so no code path can re-introduce the feedback loop without changing this
+        // signature and failing this test to compile.
+        //
+        // The exhausted batch resolves via `recordDropped` (which only releases the
+        // pending-bytes budget), NOT `recordSent`. Asserting that keeps the give-up
+        // honest: a `recordSent` here would book an undelivered batch into the sent
+        // ledger and hide the loss behind a healthy-looking counter. (This replaces a
+        // duplicate `assertTrue(resolved)` that claimed to check droppedness but
+        // re-asserted the same expression as the line above — it could not fail.)
+        assertEquals(
+            "an exhausted batch must never be counted as SENT — it is given up on, not delivered",
+            0L,
+            queue.snapshot().sentBatchCount,
+        )
     }
 
     // ---------------------------------------------------------------- needle + ledger

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryWindowWiringTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryWindowWiringTest.kt
@@ -1,0 +1,241 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.OUTBOUND_ASSUMED_STABLE_WINDOW
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1635-A (design D4) — the WIRING of the outbound retry budget to the REAL
+ * delivery-window producer, all three legs.
+ *
+ * `PromptComposerOutboundQueueStormTest` proves the budget POLICY (window-closed
+ * failures burn zero attempts) against a `FakeDeliveryWindow` injected straight into
+ * the ViewModel — a fake that REIMPLEMENTS the epoch semantics. That left the
+ * production producer and its binding asserted NOWHERE: the reviewer deleted the
+ * screen's `budget.window = { controller.deliveryWindow }` statement, and separately
+ * the `deliveryWindowEpoch += 1L` bump, and the whole 3,963-test app suite stayed
+ * GREEN with the maintainer's reported bug fully restored (no epoch ⇒ every storm
+ * failure chargeable ⇒ the queue parks at 6 and never auto-sends after the link heals,
+ * while a photo re-uploads from byte 0 on every cycle).
+ *
+ * This file closes that gap. It exercises the production
+ * [OutboundQueueAutoFlushController] the session screen actually constructs, and reads
+ * every result through the REAL consumer (`failureAttemptDelta` — what
+ * `requeueDeferredSend` passes to the store as `attemptDelta`) on the REAL
+ * `PromptComposerViewModel`'s own tracker. Nothing here asserts a fake: asserting the
+ * fake's behaviour is what created the hole.
+ *
+ * ## The third leg, and why this comment no longer claims the compiler enforces it
+ *
+ * An earlier revision of this file said the third leg — "the screen passes the composer
+ * VM's budget to the controller" — was "enforced by the COMPILER" because `budget` was a
+ * required constructor argument, and used that claim to justify not testing it. **The
+ * claim was false, and the reviewer disproved it with one mutation**: a required
+ * argument enforces that AN argument is passed, never that it is THE composer's budget.
+ * `OutboundQueueAutoFlushController(budget = OutboundAttemptBudgetTracker())` compiled,
+ * kept 3,968 tests green, and fully restored the maintainer's bug — and that idiom was
+ * copy-pasteable from three test files.
+ *
+ * The controller's constructor is now PRIVATE and
+ * [OutboundQueueAutoFlushController.boundTo] is the only way to build one; it READS the
+ * budget off the composer that consumes it, so no call site can name a tracker at all.
+ * The one seam that remains is `boundTo`'s own body (the companion can reach the private
+ * constructor), and that seam is what
+ * [theOnlyControllerFactoryBindsTheComposersOwnBudget] and every budget assertion below
+ * red on — they all now run through the composer's own tracker, not a locally-made one.
+ * Tested, not asserted in prose.
+ */
+class OutboundDeliveryWindowWiringTest {
+    /**
+     * Issue #1635-A (D4) — the PRODUCER. `PromptComposerOutboundQueueStormTest` drives a
+     * `FakeDeliveryWindow` that REIMPLEMENTS the epoch semantics, so nothing there
+     * asserts the real `OutboundQueueAutoFlushController.deliveryWindow`. The reviewer
+     * proved that hole by deleting `deliveryWindowEpoch += 1L` and watching all 3,963
+     * app tests stay green — with the maintainer's reported bug fully restored (no
+     * epoch bump ⇒ every storm failure chargeable ⇒ the queue parks at 6 and never
+     * auto-sends). This test is the thing that reds that deletion.
+     */
+    @Test
+    fun deliveryWindowEpochBumpsOnEveryConnectionWindowFlipAndNeverWithoutOne() {
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
+
+        // Before the first flip the controller reports the ASSUMED-STABLE window, so the
+        // construction-to-first-flip gap charges (fail-safe toward the #1602 park), never
+        // refunds-forever.
+        assertEquals(
+            "an un-flipped controller must report the assumed-stable window",
+            OUTBOUND_ASSUMED_STABLE_WINDOW,
+            controller.deliveryWindow,
+        )
+
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+        val firstLive = controller.deliveryWindow
+        assertTrue("`live` must track sessionLive=true", firstLive.live)
+
+        // A REPEAT call with the same (sessionLive, target) key is not a flip — it must
+        // not bump, or every recomposition would refund every in-flight attempt and the
+        // #1602 park could never fire again (the G6 negative).
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+        assertEquals(
+            "a repeat call with the same window key must NOT bump the epoch",
+            firstLive,
+            controller.deliveryWindow,
+        )
+
+        // Teardown → heal → switch target: each is a real flip, each must bump.
+        controller.onConnectionWindowChanged(sessionLive = false, targetSessionId = "1/a") {}
+        val down = controller.deliveryWindow
+        assertFalse("`live` must track sessionLive=false", down.live)
+        assertTrue("a teardown flip must bump the epoch", down.epoch > firstLive.epoch)
+
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+        val healed = controller.deliveryWindow
+        assertTrue("`live` must track the heal", healed.live)
+        assertTrue("a heal flip must bump the epoch", healed.epoch > down.epoch)
+        assertTrue(
+            "the healed window must be a DIFFERENT window from the pre-teardown one — " +
+                "liveness reads true at both ends, so only the epoch exposes the flip (#1635-A)",
+            healed.epoch != firstLive.epoch,
+        )
+
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/b") {}
+        assertTrue(
+            "a target switch is a flip too and must bump the epoch",
+            controller.deliveryWindow.epoch > healed.epoch,
+        )
+    }
+
+    /**
+     * Issue #1635-A (D4) — the THIRD LEG: the controller must bind the budget the
+     * COMPOSER ACTUALLY CONSUMES, not merely some budget.
+     *
+     * This is the leg an earlier revision claimed the compiler enforced. It did not: with
+     * `budget` as a required constructor argument, the reviewer swapped the production
+     * call site to a fresh `OutboundAttemptBudgetTracker()` and got 3,968 green tests with
+     * the maintainer's bug fully restored — the composer's own tracker never bound, pinned
+     * at [OUTBOUND_ASSUMED_STABLE_WINDOW] forever, so every storm failure charged, the
+     * queue parked at 6 and never auto-sent after the link healed.
+     *
+     * `boundTo` reading the budget off the composer removes the wrong-value choice from
+     * every call site, but `boundTo`'s own body can still be mutated (its companion can
+     * reach the private constructor). This test is what reds that mutation: it asserts
+     * through `composer.outboundAttemptBudget` — the exact instance `requeueDeferredSend`
+     * and `onClaim` consume — never through a tracker this test made itself.
+     *
+     * STRUCTURAL half only. The behavioural proof is
+     * [stormedAttemptIsRefundedThroughTheComposersOwnBudget], deliberately kept in a
+     * SEPARATE test with no preceding guards, so a mutation reds it on the assertion that
+     * actually encodes the maintainer's bug rather than tripping a guard first (G6 — the
+     * load-bearing assertion must be the one that carries the cost).
+     */
+    @Test
+    fun theOnlyControllerFactoryBindsTheComposersOwnBudget() {
+        val composer = outboundBudgetTestComposer()
+        val controller = OutboundQueueAutoFlushController.boundTo(composer)
+
+        // The COMPOSER's budget must be reading the controller, not its own default. A
+        // default-bound budget is pinned at OUTBOUND_ASSUMED_STABLE_WINDOW (live, epoch 0)
+        // forever, so driving a flip through the controller is what tells the two apart.
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+        assertEquals(
+            "the COMPOSER's own budget — the instance requeueDeferredSend/onClaim consume — " +
+                "must see this controller's CURRENT window. If it sees the assumed-stable " +
+                "default, the controller bound some OTHER tracker and the fix never reaches " +
+                "the phone (#1635-A, the wrong-value mode)",
+            controller.deliveryWindow,
+            composer.outboundAttemptBudget.window(),
+        )
+        assertTrue(
+            "and that window must not still be the default (else this test proves nothing)",
+            composer.outboundAttemptBudget.window() != OUTBOUND_ASSUMED_STABLE_WINDOW,
+        )
+    }
+
+    /**
+     * Issue #1635-A (D4) — the BEHAVIOURAL proof, through the REAL producer, the REAL
+     * binding, and the REAL composer's own tracker.
+     * `PromptComposerOutboundQueueStormTest` proves this same policy against a
+     * `FakeDeliveryWindow` that reimplements the epoch; this proves it against the
+     * production `OutboundQueueAutoFlushController` the session screen actually
+     * constructs, via the real consumer (`failureAttemptDelta` — what
+     * `requeueDeferredSend` passes to the store as `attemptDelta`).
+     *
+     * The storm shape: an attempt claimed in a live window, torn down and healed under
+     * it, resolving LIVE at both ends. The epoch bump, the `init` binding, AND the
+     * factory reading the composer's own budget are ALL load-bearing HERE — break any of
+     * the three and this reds on the refund assertion itself.
+     */
+    @Test
+    fun stormedAttemptIsRefundedThroughTheComposersOwnBudget() {
+        val composer = outboundBudgetTestComposer()
+        val budget = composer.outboundAttemptBudget
+        val controller = OutboundQueueAutoFlushController.boundTo(composer)
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+
+        budget.onClaim("stormed-row")
+        controller.onConnectionWindowChanged(sessionLive = false, targetSessionId = "1/a") {}
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+
+        assertEquals(
+            "an attempt whose delivery window was torn down and healed under it must be " +
+                "REFUNDED — liveness reads true at both ends, so if the composer's own " +
+                "budget cannot see this controller's epoch it charges the storm, parks at 6 " +
+                "and never auto-sends: the maintainer's exact reported bug (#1635-A)",
+            -1,
+            budget.failureAttemptDelta("stormed-row"),
+        )
+    }
+
+    /**
+     * The G6 negative through the same real producer and the same real composer budget: a
+     * row that fails against a stable, unflipped live window is failing on its OWN merits,
+     * so it must still CHARGE and #1602's park must still fire. Without this, "refund
+     * window-closed failures" could be widened into refunding everything — an infinite
+     * retry loop replacing the old stuck head.
+     */
+    @Test
+    fun genuineFailureOnAStableLiveWindowStillChargesThroughTheRealControllerWindow() {
+        val composer = outboundBudgetTestComposer()
+        val budget = composer.outboundAttemptBudget
+        val controller = OutboundQueueAutoFlushController.boundTo(composer)
+        controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+
+        budget.onClaim("genuinely-bad-row")
+        // No flip: same epoch, live at claim and at failure.
+        assertEquals(
+            "a failure on a stable, unflipped live window must still CHARGE — the refund " +
+                "must not mint a new infinite retry loop in place of #1602's stuck head (G6)",
+            0,
+            budget.failureAttemptDelta("genuinely-bad-row"),
+        )
+    }
+
+    /**
+     * Issue #1635-A: the epoch is per-controller, and the screen re-creates the
+     * controller per target. A fresh controller must re-bind the SAME composer's budget
+     * to ITSELF — otherwise the budget would keep reading the previous target's dead
+     * controller, whose window is frozen (charging forever, i.e. the bug) or stale-live.
+     */
+    @Test
+    fun aFreshControllerRebindsTheBudgetAwayFromTheRetiredOne() {
+        val composer = outboundBudgetTestComposer()
+        val budget = composer.outboundAttemptBudget
+        val retired = OutboundQueueAutoFlushController.boundTo(composer)
+        retired.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/a") {}
+
+        val current = OutboundQueueAutoFlushController.boundTo(composer)
+        current.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/b") {}
+        // Drive the RETIRED controller onward: if the budget were still bound to it, the
+        // window below would follow these flips instead of the current controller's.
+        retired.onConnectionWindowChanged(sessionLive = false, targetSessionId = "1/a") {}
+
+        assertEquals(
+            "the budget must follow the CURRENT controller, not the retired one",
+            current.deliveryWindow,
+            budget.window(),
+        )
+        assertTrue("and the current window is live", budget.window().live)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -2339,7 +2339,7 @@ class TmuxSessionScreenTest {
 
     @Test
     fun outboundQueueAutoFlushRequeuesOnLiveAndSuppressesSameWindowRetryLoop() {
-        val controller = OutboundQueueAutoFlushController()
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
         val requeuedTargets = mutableListOf<String>()
         val retryExclusions = mutableListOf<Set<String>>()
 
@@ -2409,7 +2409,10 @@ class TmuxSessionScreenTest {
         // eligible again after OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS and
         // re-dispatches on the SAME live window.
         var nowMs = 100_000L
-        val controller = OutboundQueueAutoFlushController(clock = { nowMs })
+        val controller = OutboundQueueAutoFlushController.boundTo(
+            composer = outboundBudgetTestComposer(),
+            clock = { nowMs },
+        )
         controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/silent") {}
 
         // 1) First dispatch — the send that the silent drop will defer.
@@ -2459,7 +2462,10 @@ class TmuxSessionScreenTest {
         // block from `runOutboundQueueAutoFlush` and this test goes RED (the parked
         // row is never re-dispatched: `dispatched` stays a single element) — proving
         // it covers the load-bearing mechanism, not a structural proxy.
-        val controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime })
+        val controller = OutboundQueueAutoFlushController.boundTo(
+            composer = outboundBudgetTestComposer(),
+            clock = { testScheduler.currentTime },
+        )
         controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/silent") {}
 
         val dispatched = mutableListOf<String>()
@@ -2520,7 +2526,10 @@ class TmuxSessionScreenTest {
         // Delete the poll-lane `sweepStaleInFlight()` call and this test goes RED (the
         // stranded row is never re-armed, `dispatched` stays empty) — it covers the
         // load-bearing mechanism, not a structural proxy.
-        val controller = OutboundQueueAutoFlushController(clock = { testScheduler.currentTime })
+        val controller = OutboundQueueAutoFlushController.boundTo(
+            composer = outboundBudgetTestComposer(),
+            clock = { testScheduler.currentTime },
+        )
         controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = "1/stranded") {}
 
         // Model the stranded `Uploading` row: NOT retryable until a stale-in-flight
@@ -2621,7 +2630,7 @@ class TmuxSessionScreenTest {
         // user taps the kebab Reconnect (which is ENABLED in this dropped-with-target state),
         // the session recovers (the live window flips), and the #900 outbound queue
         // auto-flushes the pending message — WITHOUT a session switch.
-        val controller = OutboundQueueAutoFlushController()
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
         val flushed = mutableListOf<String>()
         val sessionId = "1/issue993-proof"
 


### PR DESCRIPTION
Closes #1635.

Reviewer-APPROVED under D34 (headless real-transport red→green). Rebased conflict-free onto `3fc9f63b`.

## What this fixes
The reconnect storm burned the 6-attempt auto-retry budget: the outbound queue parked messages as `Failed` and never auto-sent after the link recovered; an upload-failing head was budget-immune and starved the tail. This lands the storm-budget fix + the lease-bound outbound delivery window so the queue auto-sends the stormed prompt once the real wire recovers.

## Gate (from the finalize run, worktree rebased on current main)
- `:app:testDebugUnitTest` **4057/0**, `:app:testReleaseUnitTest` **4053/0** — `--rerun-tasks`, 397/397 tasks executed, no cache/UP-TO-DATE suffixes. Storm tests `PromptComposerOutboundQueueStormTest` + `OutboundDeliveryWindowWiringTest` present by name in both variants.
- `:app:integrationTest` real-transport storm test **3/3** green (skipped=0, Docker path ran); `recoveredLinkAutoSendsTheStormedPromptOnTheRealWire` PASSED.
- Hygiene guards pass and are **reducing**: `TmuxSessionViewModel.kt` −277 bytes / −48 lines.
- `git diff --check` clean.

New regression tests included: `Issue1635StormRecoveryRealTransportIntegrationTest`, `PromptComposerOutboundQueueStormTest`, `OutboundDeliveryWindowWiringTest`.