### PR TITLE
test(tmux): fix androidTest compile break — boundTo() factory (#1720)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1686QueueDrainWireOracleDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1686QueueDrainWireOracleDockerTest.kt
@@ -340,7 +340,8 @@ class Issue1686QueueDrainWireOracleDockerTest {
         // The real production drain: the WIRE-oracle gate opens on
         // `sessionLive || transportWritable()`. sessionLive=false models the enum
         // false-disconnect; the probe reads the live wire.
-        val controller = OutboundQueueAutoFlushController { SystemClock.elapsedRealtime() }
+        val controller =
+            OutboundQueueAutoFlushController.boundTo(composer, clock = { SystemClock.elapsedRealtime() })
         harnessScope.launch {
             controller.onConnectionWindowChanged(sessionLive = false, targetSessionId = target) {}
             runOutboundQueueAutoFlush(


### PR DESCRIPTION
Closes #1720. Reviewer-APPROVED (test-only, zero production changes).

#1635 made `OutboundQueueAutoFlushController`'s constructor private + added the `boundTo(composer, clock)` factory, but left the sibling androidTest `Issue1686QueueDrainWireOracleDockerTest.kt:343` on the removed 1-arg form — breaking `:app:compileDebugAndroidTestKotlin` (whole androidTest source set → all connected/emulator/nightly/release gates). #1635's own gate ran `:app:testDebugUnitTest` + `:app:integrationTest`, which don't compile androidTest, so it shipped green.

**Fix:** one-line swap to `OutboundQueueAutoFlushController.boundTo(composer, clock = { SystemClock.elapsedRealtime() })`. In-scope composer supplies the budget; semantics unchanged.

**Reviewer-run:** `:app:compileDebugAndroidTestKotlin --rerun-tasks` → BUILD SUCCESSFUL, 176 executed (not cached); no stale callers; no assertion weakened (G6).