### PR TITLE
ui: compact session list state badges

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentStateChipHostCardScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentStateChipHostCardScreenshotTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
@@ -38,9 +39,9 @@ import java.io.FileOutputStream
  * under the real [PocketShellTheme] and captures an authoritative `*-viewport.png`
  * per known state.
  *
- * It asserts, on-device, that:
- *  - Waiting / Working / Idle each render their chip label on the host card, and
- *  - Unknown renders NO chip ("absent, not wrong") — the label is absent.
+ * It asserts, on-device, that Waiting / Working / Idle each render an accessible
+ * compact icon on the host card while the visible text words are gone, and that
+ * Unknown renders NO icon ("absent, not wrong").
  *
  * The captured PNGs let the reviewer compare the on-device chip against the
  * design language (Waiting=amber, Working=accent, Idle=neutral) on the real
@@ -94,17 +95,17 @@ class AgentStateChipHostCardScreenshotTest {
         }
         compose.waitForIdle()
 
-        // On-device chip presence for the three known states.
-        compose.onNodeWithText("Waiting").assertIsDisplayed()
-        compose.onNodeWithText("Working").assertIsDisplayed()
-        compose.onNodeWithText("Idle").assertIsDisplayed()
+        // On-device icon presence for the three known states. The full words
+        // remain accessible descriptions, never width-consuming visible text.
+        compose.onNodeWithContentDescription("Waiting").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Working").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Idle").assertIsDisplayed()
+        compose.onNodeWithText("Waiting").assertDoesNotExist()
+        compose.onNodeWithText("Working").assertDoesNotExist()
+        compose.onNodeWithText("Idle").assertDoesNotExist()
         // "absent, not wrong": the quiet host is rendered but shows NO chip —
-        // each of the three chip labels appears exactly ONCE (one per known
-        // host), so there is no stray fourth chip on the Unknown host.
+        // there is no state description or visible fallback on that card.
         compose.onNodeWithText("quiet-host").assertIsDisplayed()
-        compose.onNodeWithText("Waiting").assertExists()
-        compose.onNodeWithText("Working").assertExists()
-        compose.onNodeWithText("Idle").assertExists()
 
         // Authoritative compose-content capture: the full-device
         // `uiAutomation.takeScreenshot()` does NOT include the compose test-host

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -905,17 +906,15 @@ class FolderListScreenE2eTest {
         compose.onNodeWithText("codex conversation active").assertDoesNotExist()
         compose.onNodeWithText("tmux session detached").assertDoesNotExist()
 
-        // Agent / shell badge labels visible on the expanded project. #478
-        // replaced the inline "Claude · Idle" rollup with a compact right-
-        // aligned badge pill carrying just the agent/shell identity (the mockup
-        // shows no activity word on the row), so match the short badge label.
+        // Agent / shell badge labels remain available to accessibility on the
+        // expanded project. #1701 replaces the visible words with monograms.
         // #471: with active folders auto-expanded, more than one "Claude" badge
         // can render (pocketshell + the outside-lab demo), so assert presence
         // rather than a single node; the precise per-session badge tags below
         // pin the pocketshell claude badge specifically.
         assertTrue(
             "a Claude agent badge should render",
-            compose.onAllNodesWithText("Claude", substring = true)
+            compose.onAllNodes(hasContentDescription("Claude"))
                 .fetchSemanticsNodes().isNotEmpty(),
         )
 
@@ -931,17 +930,15 @@ class FolderListScreenE2eTest {
             folderSessionBadgeTestTag("/home/u/git/pocketshell", "build-shell"),
             useUnmergedTree = true,
         ).assertExists()
-        // The agent badge renders "Claude" and the shell badge renders "Shell".
-        // #471: auto-expand can surface more than one Claude badge, so assert
-        // presence on the unmerged tree rather than a single node.
+        // The compact badges expose full Claude/Shell accessibility labels.
         assertTrue(
             "a Claude badge should render on the unmerged tree",
-            compose.onAllNodesWithText("Claude", useUnmergedTree = true)
+            compose.onAllNodes(hasContentDescription("Claude"), useUnmergedTree = true)
                 .fetchSemanticsNodes().isNotEmpty(),
         )
         assertTrue(
             "a Shell badge should render on the unmerged tree",
-            compose.onAllNodesWithText("Shell", useUnmergedTree = true)
+            compose.onAllNodes(hasContentDescription("Shell"), useUnmergedTree = true)
                 .fetchSemanticsNodes().isNotEmpty(),
         )
 
@@ -1230,22 +1227,20 @@ class FolderListScreenE2eTest {
             folderListFlatRowStatusDotTestTag("claude-main"),
             useUnmergedTree = true,
         ).assertExists()
-        // The badge label `Text` is the single child of the tagged badge `Box`.
-        // The flat row's clickable merges the trailing badge away on the merged
-        // tree, so resolve the badge on the UNMERGED tree and read its one
-        // child's text (the box itself carries no text).
+        // The visible CL/CX/SH monograms are intentionally cleared from
+        // semantics; the tagged badges expose their full labels to TalkBack.
         compose.onNodeWithTag(
             folderListFlatRowBadgeTestTag("claude-main"),
             useUnmergedTree = true,
-        ).onChild().assertTextEquals("Claude")
+        ).assertContentDescriptionEquals("Claude")
         compose.onNodeWithTag(
             folderListFlatRowBadgeTestTag("codex-llm"),
             useUnmergedTree = true,
-        ).onChild().assertTextEquals("Codex")
+        ).assertContentDescriptionEquals("Codex")
         compose.onNodeWithTag(
             folderListFlatRowBadgeTestTag("build-shell"),
             useUnmergedTree = true,
-        ).onChild().assertTextEquals("Shell")
+        ).assertContentDescriptionEquals("Shell")
 
         // #489: sessions group into ACTIVE / IDLE sections (SectionHeaders with
         // counts) and a host header carries the `N active · M idle · K sessions`
@@ -1308,8 +1303,9 @@ class FolderListScreenE2eTest {
     }
 
     /**
-     * Issue #858: the session tree visibly distinguishes a z.ai-profile Claude
-     * from a default Anthropic Claude. CLASS COVERAGE (D31/G2): the flat view is
+     * Issues #858/#1701: the session tree visibly distinguishes a z.ai-profile
+     * Claude from a default Anthropic Claude while rendering compact accessible
+     * state icons and agent monograms. CLASS COVERAGE (D31/G2): the flat view is
      * fed {z.ai-profile Claude, default Claude, named-profile Codex, no-profile
      * Codex}, and the legacy/missing-option case (recordedProfile == null) is the
      * default + no-profile rows. The profiled rows MUST show the profile chip
@@ -1329,15 +1325,19 @@ class FolderListScreenE2eTest {
                     cwd = "/home/u/git/pocketshell",
                     agentKind = SessionAgentKind.Claude,
                     recordedProfile = "Claude (Z.AI)",
+                    agentStateRaw = "working",
+                    agentStateUpdatedAt = 1_700_004_000L,
                 ),
                 // Default Claude — no profile (the legacy/missing-option case).
                 FolderSessionRow(
-                    sessionName = "default-claude",
+                    sessionName = "git-course-management-platform-service",
                     lastActivity = 1_700_003_500L,
                     attached = true,
                     cwd = "/home/u/git/pocketshell",
                     agentKind = SessionAgentKind.Claude,
                     recordedProfile = null,
+                    agentStateRaw = "waiting_for_input",
+                    agentStateUpdatedAt = 1_700_004_000L,
                 ),
                 // Codex WITH a named profile.
                 FolderSessionRow(
@@ -1347,6 +1347,8 @@ class FolderListScreenE2eTest {
                     cwd = "/home/u/git/pocketshell",
                     agentKind = SessionAgentKind.Codex,
                     recordedProfile = "Codex (Work)",
+                    agentStateRaw = "idle",
+                    agentStateUpdatedAt = 1_700_004_000L,
                 ),
                 // Codex WITHOUT a profile.
                 FolderSessionRow(
@@ -1356,6 +1358,8 @@ class FolderListScreenE2eTest {
                     cwd = "/home/u/git/pocketshell",
                     agentKind = SessionAgentKind.Codex,
                     recordedProfile = null,
+                    agentStateRaw = "working",
+                    agentStateUpdatedAt = 1_700_004_000L,
                 ),
             ),
             projectFoldersByRoot = mapOf("~/git" to listOf("/home/u/git/pocketshell")),
@@ -1391,6 +1395,20 @@ class FolderListScreenE2eTest {
                     .fetchSemanticsNodes().isNotEmpty()
         }
 
+        // #1701: the REAL production list exposes every compact state glyph via
+        // its full accessibility label, with no width-consuming status words.
+        listOf("Working", "Waiting", "Idle").forEach { label ->
+            assertTrue(
+                "$label state icon must expose its full content description",
+                compose.onAllNodes(hasContentDescription(label), useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty(),
+            )
+        }
+        compose.onNodeWithText("Working").assertDoesNotExist()
+        compose.onNodeWithText("Waiting").assertDoesNotExist()
+        compose.onNodeWithText("Idle").assertDoesNotExist()
+
         // z.ai Claude: the profile chip is present and reads "Z.AI" (compressed
         // from "Claude (Z.AI)"), next to the "Claude" kind badge.
         compose.onNodeWithTag(
@@ -1400,7 +1418,7 @@ class FolderListScreenE2eTest {
         compose.onNodeWithTag(
             folderListFlatRowBadgeTestTag("zai-claude"),
             useUnmergedTree = true,
-        ).onChild().assertTextEquals("Claude")
+        ).assertContentDescriptionEquals("Claude")
 
         // Codex with a named profile: chip reads "Work" next to the "Codex" badge.
         compose.onNodeWithTag(
@@ -1412,9 +1430,17 @@ class FolderListScreenE2eTest {
         assertTrue(
             "a default Claude must show no profile chip",
             compose.onAllNodesWithTag(
-                folderListFlatRowProfileChipTestTag("default-claude"),
+                folderListFlatRowProfileChipTestTag("git-course-management-platform-service"),
                 useUnmergedTree = true,
             ).fetchSemanticsNodes().isEmpty(),
+        )
+        compose.onNodeWithTag(
+            folderListFlatRowBadgeTestTag("git-course-management-platform-service"),
+            useUnmergedTree = true,
+        ).assertContentDescriptionEquals("Claude")
+        compose.onNodeWithText("git-course-management-platform-service").assertIsDisplayed()
+        assertAccessibleTouchTarget(
+            folderListFlatRowTestTag("git-course-management-platform-service"),
         )
         // No-profile Codex: NO profile chip.
         assertTrue(

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -75,6 +75,8 @@ import com.pocketshell.app.voice.AssistantStrip
 import com.pocketshell.app.voice.InlineDictationErrorStrip
 import com.pocketshell.app.voice.appendDictationText
 import com.pocketshell.app.voice.toMicButtonState
+import com.pocketshell.uikit.components.AgentKindBadge
+import com.pocketshell.uikit.components.AgentStateChip
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.DisclosureIcon
 import com.pocketshell.uikit.components.Kebab
@@ -85,9 +87,7 @@ import com.pocketshell.uikit.components.MicButton
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
-import com.pocketshell.uikit.components.AgentStateChip
 import com.pocketshell.uikit.components.SpinnerSize
-import com.pocketshell.uikit.theme.LocalPocketShellSemantic
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -1624,8 +1624,8 @@ internal fun flatSessionFolderLabel(
  *  - leading: [StatusDot] — green when attached or an agent is live, amber idle.
  *  - title: the session name.
  *  - subtitle: the session's folder label (`bodyMono` muted, via [ListRow]).
- *  - trailing: agent-type [Badge] — purple for Claude/Codex/OpenCode, grey for
- *    Shell.
+ *  - trailing: compact agent-kind monogram — purple for Claude/Codex/OpenCode,
+ *    grey for Shell.
  */
 @Composable
 private fun FlatSessionRow(
@@ -2442,54 +2442,21 @@ private fun WorkspaceSessionWindowRow(
 }
 
 /**
- * Right-aligned agent-type pill on a session row — issue #478. Mockup colours:
- * Codex/Claude/OpenCode = purple (`agentAccent`), Shell = grey/neutral. The
- * short label is just the agent/shell name (no activity word — that lives in
- * the secondary line via [sessionKindLabel]).
+ * Right-aligned compact agent-kind monogram on a session row — issues
+ * #478/#1701. The full label remains its accessibility description.
  */
 @Composable
 private fun AgentTypeBadge(
     session: FolderSessionEntry,
     modifier: Modifier = Modifier,
 ) {
-    AgentTypeBadge(
+    AgentKindBadge(
+        monogram = sessionBadgeMonogram(session),
         label = sessionBadgeLabel(session),
         isAgent = session.agentKind.isAgent(),
         modifier = modifier,
     )
 }
-
-@Composable
-private fun AgentTypeBadge(
-    label: String,
-    isAgent: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    val semantic = LocalPocketShellSemantic.current
-    val fg = if (isAgent) semantic.agentAccent else PocketShellColors.TextSecondary
-    val bg = if (isAgent) {
-        semantic.agentAccent.copy(alpha = 0.16f)
-    } else {
-        PocketShellColors.SurfaceElev.copy(alpha = 0.72f)
-    }
-    Box(
-        modifier = modifier
-            .widthIn(max = SessionBadgeMaxWidth)
-            .background(bg, RoundedCornerShape(6.dp))
-            .padding(horizontal = PocketShellDensity.chipPadH, vertical = PocketShellDensity.chipPadV),
-    ) {
-        Text(
-            text = label,
-            color = fg,
-            style = PocketShellType.labelMono,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
-
-private val SessionBadgeMaxWidth = 84.dp
 
 private val ProfileChipMaxWidth = 70.dp
 

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListTreeChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListTreeChrome.kt
@@ -236,6 +236,17 @@ internal fun sessionBadgeLabel(session: FolderSessionEntry): String = when (sess
     SessionAgentKind.Unknown -> "Unknown"
 }
 
+internal fun sessionBadgeMonogram(session: FolderSessionEntry): String = when (session.agentKind) {
+    SessionAgentKind.Claude -> "CL"
+    SessionAgentKind.Codex -> "CX"
+    SessionAgentKind.OpenCode -> "OC"
+    SessionAgentKind.Probing -> "…"
+    SessionAgentKind.Exited,
+    SessionAgentKind.Shell,
+    -> "SH"
+    SessionAgentKind.Unknown -> "?"
+}
+
 internal fun sessionKindLabel(session: FolderSessionEntry): String = when (session.agentKind) {
     SessionAgentKind.Claude -> "Claude · ${agentStateLabel(session)}"
     SessionAgentKind.Codex -> "Codex · ${agentStateLabel(session)}"

--- a/app/src/test/java/com/pocketshell/app/projects/SessionKindLabelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionKindLabelTest.kt
@@ -118,6 +118,36 @@ class SessionKindLabelTest {
         }
     }
 
+    // --- #1701: rendered badges use compact, distinct monograms while their
+    //     full labels remain available to accessibility semantics. ---
+
+    @Test
+    fun badgeMonogramIsCompactPerAgentGlyph() {
+        assertEquals("CL", sessionBadgeMonogram(entry(SessionAgentKind.Claude)))
+        assertEquals("CX", sessionBadgeMonogram(entry(SessionAgentKind.Codex)))
+        assertEquals("OC", sessionBadgeMonogram(entry(SessionAgentKind.OpenCode)))
+    }
+
+    @Test
+    fun badgeMonogramForShellAndExitedIsSh() {
+        assertEquals("SH", sessionBadgeMonogram(entry(SessionAgentKind.Shell)))
+        assertEquals("SH", sessionBadgeMonogram(entry(SessionAgentKind.Exited)))
+    }
+
+    @Test
+    fun badgeMonogramDistinguishesClaudeFromCodex() {
+        val claude = sessionBadgeMonogram(entry(SessionAgentKind.Claude))
+        val codex = sessionBadgeMonogram(entry(SessionAgentKind.Codex))
+        assertEquals(false, claude == codex)
+    }
+
+    @Test
+    fun badgeMonogramIsShortForEveryKind() {
+        SessionAgentKind.entries.forEach { kind ->
+            assertEquals(true, sessionBadgeMonogram(entry(kind)).length <= 2)
+        }
+    }
+
     // --- #858: the profile chip label compresses the recorded profile to its
     //     distinguishing provider part for the tree chip. ---
 

--- a/shared/ui-kit/build.gradle.kts
+++ b/shared/ui-kit/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.graphics)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.extended)
     debugImplementation(libs.compose.ui.tooling)
 
     // Compose instrumentation tests for the shared primitives (#480). The

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/AgentKindBadge.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/AgentKindBadge.kt
@@ -1,0 +1,62 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.theme.LocalPocketShellSemantic
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellDensity
+import com.pocketshell.uikit.theme.PocketShellType
+
+/**
+ * Compact agent-kind monogram used by session-list rows (#1701).
+ *
+ * The visible monogram reclaims the width previously consumed by full agent
+ * names. [label] remains the node's accessibility description, while the terse
+ * glyph is removed from semantics so TalkBack reads "Claude", not "CL".
+ */
+@Composable
+fun AgentKindBadge(
+    monogram: String,
+    label: String,
+    isAgent: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val semantic = LocalPocketShellSemantic.current
+    val foreground = if (isAgent) semantic.agentAccent else PocketShellColors.TextSecondary
+    val background = if (isAgent) {
+        semantic.agentAccent.copy(alpha = 0.16f)
+    } else {
+        PocketShellColors.SurfaceElev.copy(alpha = 0.72f)
+    }
+
+    Box(
+        modifier = modifier
+            .semantics(mergeDescendants = true) {
+                contentDescription = label
+            }
+            .background(background, RoundedCornerShape(6.dp))
+            .padding(
+                horizontal = PocketShellDensity.chipPadH,
+                vertical = PocketShellDensity.chipPadV,
+            ),
+    ) {
+        Text(
+            text = monogram,
+            color = foreground,
+            style = PocketShellType.labelMono,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            modifier = Modifier.clearAndSetSemantics { },
+        )
+    }
+}

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/AgentStateChip.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/AgentStateChip.kt
@@ -1,22 +1,19 @@
 package com.pocketshell.uikit.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Autorenew
+import androidx.compose.material.icons.outlined.HourglassEmpty
+import androidx.compose.material.icons.outlined.PauseCircle
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.model.SessionAgentState
 import com.pocketshell.uikit.theme.PocketShellColors
-import com.pocketshell.uikit.theme.PocketShellDensity
-import com.pocketshell.uikit.theme.PocketShellType
 
 /**
- * Compact agent resting-state chip (issue #1237) — idle / waiting / working —
+ * Compact agent state icon (issues #1237/#1701) — idle / waiting / working —
  * shared by the host cards and the session rows so the same signal reads
  * identically on every surface.
  *
@@ -25,11 +22,14 @@ import com.pocketshell.uikit.theme.PocketShellType
  * gate surrounding spacing should branch on
  * [SessionAgentState.chipLabel]` != null` first.
  *
- * Design-language semantic colours (docs/design-language.md — "green = ok, amber
- * = warning" for status; UI chrome stays neutral):
+ * Design-language semantic colours:
  *  - Waiting → amber: the agent is blocked on the user — the "come look" signal.
  *  - Working → accent cyan: actively working.
  *  - Idle    → neutral grey: finished / resting.
+ *
+ * The visible words were deliberately hard-cut in #1701 to return their width
+ * to the session name. The full words remain as icon content descriptions so
+ * TalkBack receives the same state information.
  */
 @Composable
 fun AgentStateChip(
@@ -37,24 +37,18 @@ fun AgentStateChip(
     modifier: Modifier = Modifier,
 ) {
     val label = state.chipLabel ?: return
-    val fg = when (state) {
-        SessionAgentState.WaitingForInput -> PocketShellColors.Amber
-        SessionAgentState.Working -> PocketShellColors.Accent
-        SessionAgentState.Idle -> PocketShellColors.TextSecondary
+    val (imageVector, tint) = when (state) {
+        SessionAgentState.WaitingForInput -> Icons.Outlined.HourglassEmpty to PocketShellColors.Amber
+        SessionAgentState.Working -> Icons.Filled.Autorenew to PocketShellColors.Accent
+        SessionAgentState.Idle -> Icons.Outlined.PauseCircle to PocketShellColors.TextSecondary
         SessionAgentState.Unknown -> return
     }
-    Box(
-        modifier = modifier
-            .background(fg.copy(alpha = 0.16f), RoundedCornerShape(6.dp))
-            .padding(horizontal = PocketShellDensity.chipPadH, vertical = PocketShellDensity.chipPadV),
-    ) {
-        Text(
-            text = label,
-            color = fg,
-            style = PocketShellType.labelMono,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
+    Icon(
+        imageVector = imageVector,
+        contentDescription = label,
+        tint = tint,
+        modifier = modifier.size(AgentStateIconSize),
+    )
 }
+
+internal val AgentStateIconSize = 18.dp

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/AgentKindBadgeTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/AgentKindBadgeTest.kt
@@ -1,0 +1,78 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
+class AgentKindBadgeTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun readsFullAgentNameToScreenReaderNotTheMonogram() {
+        setBadge(monogram = "CL", label = "Claude")
+
+        composeRule.onNodeWithContentDescription("Claude").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("CL").assertDoesNotExist()
+    }
+
+    @Test
+    fun codexReadsFullAgentName() {
+        setBadge(monogram = "CX", label = "Codex")
+
+        composeRule.onNodeWithContentDescription("Codex").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("CX").assertDoesNotExist()
+    }
+
+    @Test
+    fun badgeIsCompact() {
+        var density = 1f
+        composeRule.setContent {
+            PocketShellTheme {
+                density = LocalDensity.current.density
+                AgentKindBadge(
+                    monogram = "CL",
+                    label = "Claude",
+                    isAgent = true,
+                    modifier = Modifier.testTag("agent-kind"),
+                )
+            }
+        }
+
+        val widthDp = composeRule.onNodeWithContentDescription("Claude")
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .width / density
+        assertTrue("agent-kind badge must stay under 44dp, was ${widthDp}dp", widthDp < 44f)
+    }
+
+    private fun setBadge(
+        monogram: String,
+        label: String,
+    ) {
+        composeRule.setContent {
+            PocketShellTheme {
+                AgentKindBadge(
+                    monogram = monogram,
+                    label = label,
+                    isAgent = true,
+                )
+            }
+        }
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/AgentStateChipTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/AgentStateChipTest.kt
@@ -1,0 +1,81 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.model.SessionAgentState
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
+class AgentStateChipTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun workingRendersAccessibleCompactIcon() {
+        assertAccessibleCompactIcon(SessionAgentState.Working, "Working")
+    }
+
+    @Test
+    fun waitingRendersAccessibleCompactIcon() {
+        assertAccessibleCompactIcon(SessionAgentState.WaitingForInput, "Waiting")
+    }
+
+    @Test
+    fun idleRendersAccessibleCompactIcon() {
+        assertAccessibleCompactIcon(SessionAgentState.Idle, "Idle")
+    }
+
+    @Test
+    fun unknownRendersNothing() {
+        composeRule.setContent {
+            PocketShellTheme {
+                Text("marker")
+                AgentStateChip(
+                    state = SessionAgentState.Unknown,
+                    modifier = Modifier.testTag("state-icon"),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("marker").assertIsDisplayed()
+        composeRule.onNodeWithTag("state-icon").assertDoesNotExist()
+    }
+
+    private fun assertAccessibleCompactIcon(
+        state: SessionAgentState,
+        label: String,
+    ) {
+        composeRule.setContent {
+            PocketShellTheme {
+                AgentStateChip(
+                    state = state,
+                    modifier = Modifier.testTag("state-icon"),
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription(label)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(18.dp)
+            .assertHeightIsEqualTo(18.dp)
+        composeRule.onNodeWithText(label).assertDoesNotExist()
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -639,6 +639,15 @@ class DesignRenders {
     }
 
     /**
+     * Issue #1701: compact status icons + agent monograms in real shared
+     * session-list rows, with the long session name receiving the saved width.
+     */
+    @Test
+    fun sessionListChipIcons() = render("session-list-chip-icons") {
+        SessionListChipIconsRender()
+    }
+
+    /**
      * Issue #603: the host-detail workspace tree with the redesigned
      * inactive / empty watched-root callout.
      *

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/HostDetailRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/HostDetailRenderFixtures.kt
@@ -18,8 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.pocketshell.uikit.components.Badge
-import com.pocketshell.uikit.components.BadgeRole
+import com.pocketshell.uikit.components.AgentKindBadge
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.StatusDot
 import com.pocketshell.uikit.model.ConnectionStatus
@@ -100,7 +99,11 @@ internal fun HostDetailProfiledSessionTreeRender() {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     ProfileChipMirror(label = "Z.AI")
                     Spacer(modifier = Modifier.width(4.dp))
-                    Badge(label = "Claude", role = BadgeRole.Agent)
+                    AgentKindBadge(
+                        monogram = "CL",
+                        label = "Claude",
+                        isAgent = true,
+                    )
                 }
             },
             onClick = {},
@@ -116,7 +119,13 @@ internal fun HostDetailProfiledSessionTreeRender() {
         ListRow(
             title = "git-default-app",
             leading = { StatusDot(status = ConnectionStatus.Connected) },
-            trailing = { Badge(label = "Claude", role = BadgeRole.Agent) },
+            trailing = {
+                AgentKindBadge(
+                    monogram = "CL",
+                    label = "Claude",
+                    isAgent = true,
+                )
+            },
             onClick = {},
             modifier = Modifier
                 .background(
@@ -145,7 +154,13 @@ internal fun HostDetailMultiWindowAgentTreeRender() {
         ListRow(
             title = "git-pocketshell-c",
             leading = { StatusDot(status = ConnectionStatus.Connected) },
-            trailing = { Badge(label = "Claude", role = BadgeRole.Agent) },
+            trailing = {
+                AgentKindBadge(
+                    monogram = "CL",
+                    label = "Claude",
+                    isAgent = true,
+                )
+            },
             onClick = {},
             modifier = Modifier
                 .background(

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/HostRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/HostRenderFixtures.kt
@@ -22,11 +22,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.components.AgentKindBadge
 import com.pocketshell.uikit.components.AgentStateChip
 import com.pocketshell.uikit.components.Badge
 import com.pocketshell.uikit.components.BadgeRole
 import com.pocketshell.uikit.components.HostCard
+import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.ScreenHeader
+import com.pocketshell.uikit.components.StatusDot
+import com.pocketshell.uikit.model.ConnectionStatus
 import com.pocketshell.uikit.model.HostStatus
 import com.pocketshell.uikit.model.PillKind
 import com.pocketshell.uikit.model.SessionAgentState
@@ -138,6 +142,56 @@ internal fun AgentStateChipsRender() {
             AgentStateChip(state = SessionAgentState.Idle)
         }
     }
+}
+
+/**
+ * Issue #1701: the session-list trailing lane after the full status and agent
+ * words were hard-cut. Covers every state × both same-colour primary agent
+ * kinds, proving the CL/CX monograms stay distinct while the long session name
+ * receives the reclaimed width.
+ */
+@Composable
+internal fun SessionListChipIconsRender() {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        ScreenHeader(
+            title = "Sessions",
+            subtitle = "6 active · compact status and kind",
+        )
+        SessionListIconRow(SessionAgentState.Working, "CL", "Claude")
+        SessionListIconRow(SessionAgentState.WaitingForInput, "CL", "Claude")
+        SessionListIconRow(SessionAgentState.Idle, "CL", "Claude")
+        SessionListIconRow(SessionAgentState.Working, "CX", "Codex")
+        SessionListIconRow(SessionAgentState.WaitingForInput, "CX", "Codex")
+        SessionListIconRow(SessionAgentState.Idle, "CX", "Codex")
+    }
+}
+
+@Composable
+private fun SessionListIconRow(
+    state: SessionAgentState,
+    monogram: String,
+    label: String,
+) {
+    ListRow(
+        title = "git-course-management-platform-service",
+        leading = {
+            StatusDot(status = ConnectionStatus.Connected)
+        },
+        trailing = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                AgentStateChip(state = state)
+                AgentKindBadge(
+                    monogram = monogram,
+                    label = label,
+                    isAgent = true,
+                )
+            }
+        },
+        onClick = {},
+    )
 }
 
 @Composable


### PR DESCRIPTION
Closes #1701

## Summary
- replace Working/Waiting/Idle words with compact colored state icons
- replace full agent-kind words with compact CL/CX/OC/SH monograms
- preserve full TalkBack labels while reclaiming width for session names
- extend render and production-list emulator coverage

## Verification
- independent semantics-removal mutation: focused JVM and connected proofs red
- full JVM gate: 11,196 tests, 0 failures/errors/skips
- production session-list connected proof and tap-through: green
- fresh deterministic renders and full-device screenshot visually inspected
- file-size, test-validity, journey-harness, and diff checks: green