### PR TITLE
ui: keep attach loader in one stable mount

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
@@ -9,6 +9,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -33,6 +36,8 @@ import com.pocketshell.core.connection.sessionSurfaceState
 import com.pocketshell.core.connection.showsCalmFailure
 import com.pocketshell.core.connection.showsCenteredLoader
 import com.pocketshell.core.connection.surfaceOwnsPrimary
+import com.pocketshell.core.terminal.ui.TerminalKeyboardMode
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.uikit.components.LoadingIndicator
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -91,6 +96,122 @@ class TmuxConnectingStatesScreenshotTest {
         reveal: RevealState,
         status: TmuxSessionViewModel.ConnectionStatus,
     ): SessionSurfaceState = sessionSurfaceState(reveal, connectionPhaseOf(status), sid)
+
+    /**
+     * Issue #1684 / #750 recurrence 5: the primary "Attaching…" indicator must
+     * have one screen-level mount whose bounds do not change as a stale pager
+     * page gives way to the attaching surface.
+     *
+     * This composes both REAL production sites that existed on the reported
+     * path: [TmuxTerminalPager]'s non-target-pane mask and the screen-level
+     * [SwitchingLoadingPlaceholder]. The screen-level mount is intentionally
+     * present for both phases, as required by the fused [SessionSurfaceState]
+     * contract. Before the fix, the pager also mounts another labelled
+     * [SwitchingLoadingPlaceholder] in its shorter, vertically-unbounded page:
+     * two semantic nodes with different bounds expose the same top-to-centre
+     * relocation seen on-device. After the fix the pager is a neutral mask, so
+     * exactly one node remains at identical bounds in both frames.
+     */
+    @Test
+    fun connectingToAttaching_keepsOneStableIndicatorMount_issue1684() {
+        val midAttach = mutableStateOf(false)
+        val stalePane = TmuxPaneState(
+            paneId = "%1684",
+            windowId = "@1684",
+            sessionId = "\$1684",
+            title = "previous-session",
+            terminalState = TerminalSurfaceState(),
+        )
+
+        compose.setContent {
+            val pagerState = rememberPagerState(pageCount = { 1 })
+            val panes = remember { listOf(stalePane) }
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(PocketShellColors.Background)
+                    .padding(top = 24.dp)
+                    .testTag(SCREENSHOT_ROOT_TAG),
+            ) {
+                ConsolidatedTopChrome(
+                    sessionName = "git-dap",
+                    onBack = {},
+                    onMore = {},
+                )
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                ) {
+                    SessionSurfaceReconnectWrapper(
+                        pullToReconnectActive = true,
+                        isReconnecting = true,
+                        onReconnect = {},
+                        surfaceShowsCenteredLoader = true,
+                        showReconnectButton = false,
+                    ) {
+                        if (!midAttach.value) {
+                            TmuxTerminalPager(
+                                unifiedPanes = panes,
+                                pagerState = pagerState,
+                                sessionName = "git-dap",
+                                terminalKeyboardMode = TerminalKeyboardMode.RawCommand,
+                                engineCommands = emptySet(),
+                                isAgentPane = false,
+                                // Force the real non-target-pane masking branch.
+                                sessionNameForUnifiedPane = { "previous-session" },
+                                onTerminalSizeChanged = { _, _ -> },
+                                onSurfaceError = { _, _ -> },
+                                onRecreateSurface = {},
+                                onUrlTap = {},
+                                onFilePathTap = { _, _ -> },
+                                onEngineCommandTap = {},
+                            )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(PocketShellColors.Background),
+                            )
+                        }
+                    }
+                    // The one stable screen-level mount required for both
+                    // Connecting and Attaching.
+                    SwitchingLoadingPlaceholder()
+                }
+            }
+        }
+
+        compose.waitForIdle()
+        val earlyNodes = compose
+            .onAllNodesWithText("Attaching…", useUnmergedTree = true)
+            .fetchSemanticsNodes()
+        captureFullDevice(File(artifactDir(), "issue-1684-early-connect.png"))
+        assertEquals(
+            "early connect must expose exactly one primary Attaching indicator",
+            1,
+            earlyNodes.size,
+        )
+        val earlyBounds = earlyNodes.single().boundsInRoot
+
+        compose.runOnIdle { midAttach.value = true }
+        compose.waitForIdle()
+        val attachNodes = compose
+            .onAllNodesWithText("Attaching…", useUnmergedTree = true)
+            .fetchSemanticsNodes()
+        captureFullDevice(File(artifactDir(), "issue-1684-mid-attach.png"))
+        assertEquals(
+            "mid attach must expose exactly one primary Attaching indicator",
+            1,
+            attachNodes.size,
+        )
+        assertEquals(
+            "Connecting → Attaching must keep the indicator at one stable mount",
+            earlyBounds,
+            attachNodes.single().boundsInRoot,
+        )
+        assertIndeterminateIndicatorCount(1)
+    }
 
     @Test
     fun captureWaitingForPanesConnectingState() {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
@@ -777,12 +777,10 @@ internal fun SessionFailureBand(
 }
 
 /**
- * Issue #661: full-surface loading state shown IN PLACE OF the terminal while a
- * cross-session switch attaches the new session. The leaving session's frame is
- * never painted here — the surface is a neutral background with a compact
- * "Attaching…" indicator — so the user never sees the previous session's
- * content for even one frame. The VM ([TmuxSessionViewModel.switchHidesTerminal])
- * reveals the real terminal the instant the new session's panes are seeded.
+ * Issue #661/#1684: the primary full-surface loading overlay while a
+ * cross-session switch attaches the new session. It is mounted exactly once in
+ * the fixed screen-level surface slot; pager pages and swap-latch content use
+ * [SessionSurfaceMaskPlaceholder] and can never relocate this indicator.
  */
 @Composable
 internal fun SwitchingLoadingPlaceholder() {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1187,9 +1187,9 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
         if (surfaceCalmFailure) {
             RevealFailurePlaceholder()
         } else if (terminalHeld) {
-            SwitchingLoadingPlaceholder()
+            SessionSurfaceMaskPlaceholder()
         } else if (deferTerminalAttachForSwap) {
-            SwitchingLoadingPlaceholder()
+            SessionSurfaceMaskPlaceholder()
         } else if (showConversation &&
             visibleConversation != null &&
             visibleConversation.events.isEmpty() &&
@@ -1301,7 +1301,7 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
                 },
             )
         } else if (unifiedPanes.isEmpty()) {
-            EmptyPanesPlaceholder()
+            SessionSurfaceMaskPlaceholder()
         }
 
         val activeTuiCommandNotice = tuiCommandNotice
@@ -1339,6 +1339,19 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
             showReconnectButton = surfaceReconnectButtonVisible(surfaceState),
             content = surfaceContent,
         )
+        // Issue #1684 / #750 recurrence 5: the primary loading indicator has
+        // exactly ONE fixed screen-level mount, outside the reconnect wrapper's
+        // vertically-unbounded scroll geometry. Connecting, Attaching and
+        // Reattaching therefore keep identical bounds instead of moving from a
+        // short pager page near the toolbar to the full-surface center. The
+        // content branches above and TmuxTerminalPager paint neutral masks only.
+        if (surfaceCenteredLoader) {
+            if (terminalHeld) {
+                SwitchingLoadingPlaceholder()
+            } else {
+                EmptyPanesPlaceholder()
+            }
+        }
     }
 
     // Assistant review sits above the input band.

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSurfacePlaceholders.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSurfacePlaceholders.kt
@@ -27,6 +27,24 @@ import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
 
 /**
+ * Issue #1684: an opaque, semantics-free mask for a terminal surface that must
+ * not paint yet (stale non-target pager page, attach hold content, or the
+ * one-frame terminal swap latch).
+ *
+ * This is deliberately NOT loading chrome. The one labelled primary loader is
+ * mounted at the fixed screen-level overlay slot in [TmuxSessionScreen], so a
+ * child measured in pager/scroll geometry cannot relocate that indicator.
+ */
+@Composable
+internal fun SessionSurfaceMaskPlaceholder() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = PocketShellColors.Background),
+    )
+}
+
+/**
  * Issue #778: lightweight Conversation-tab placeholder shown when the user has
  * tapped Conversation on a presumed-agent pane (#716) before live agent
  * detection has landed (`detection == null`). It honours the tap — the view

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxTerminalPager.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxTerminalPager.kt
@@ -136,13 +136,17 @@ internal fun TmuxTerminalPager(
         // non-target session must never paint its terminal surface OR
         // its `SessionBoundaryDivider` (the stray mid-pane label bearing
         // the leaving session's name was the maintainer's
-        // wrong-session-on-switch symptom). Render the loading
-        // placeholder for a non-target pane instead, so a late frame
-        // from the previous session can never bleed into the shown pane.
+        // wrong-session-on-switch symptom). Render a NEUTRAL mask for a
+        // non-target pane instead, so a late frame from the previous session
+        // can never bleed into the shown pane. Issue #1684: this page must not
+        // mount the primary "Attaching…" indicator — the single fixed
+        // screen-level overlay owns that connection chrome. A labelled loader
+        // here was measured inside the pager's shorter/unbounded geometry and
+        // jumped to the screen centre when the surface hold took over.
         val paneIsForTarget = paneSession == null ||
             paneSession == sessionName
         if (!paneIsForTarget) {
-            SwitchingLoadingPlaceholder()
+            SessionSurfaceMaskPlaceholder()
             return@HorizontalPager
         }
         val prevSession = unifiedPanes.getOrNull(pageIndex - 1)


### PR DESCRIPTION
Closes #1684

## Summary
- hoist the primary Attaching loader to one fixed screen-level overlay
- replace pager, held-terminal, and swap-latch loaders with neutral masks
- add a connected transition proof for stable bounds and exactly one indicator

## Verification
- independent secondary-loader mutation: RED with 2 indicators
- focused connected transition: 1/1 green after byte-identical restore
- full connected screenshot class: 8/8 green
- TmuxSessionScreen JVM suite: 122/122 green
- real within-grace Docker journey: 1/1 green
- early-connect, mid-attach, and beyond-grace screenshots independently inspected
- test-validity, file-size, VM-ratchet, and diff guards green

The fast Roborazzi spinner render target has a confirmed pre-existing InfiniteTransition drain hang; the required emulator render/journey evidence is complete.