### PR TITLE
diagnostics: add connection journal replay

### DIFF
--- a/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionJournalDiagnostics.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionJournalDiagnostics.kt
@@ -1,0 +1,21 @@
+package com.pocketshell.app.diagnostics
+
+import com.pocketshell.core.connection.ConnectionJournalEntry
+import com.pocketshell.core.connection.ConnectionJournalPort
+import com.pocketshell.core.connection.ConnectionJournalSchema
+
+/**
+ * App adapter for the pure connection reducer's journal (#1709).
+ *
+ * Recording remains fire-and-forget: [DiagnosticEvents.record] only offers the
+ * already-flat, privacy-safe entry to [DiagnosticRecorder]'s bounded channel.
+ */
+internal object ConnectionJournalDiagnostics : ConnectionJournalPort {
+    override fun record(entry: ConnectionJournalEntry) {
+        DiagnosticEvents.record(
+            ConnectionJournalSchema.CATEGORY,
+            ConnectionJournalSchema.name(entry),
+            *ConnectionJournalSchema.metadata(entry).toList().toTypedArray(),
+        )
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogPartStore.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogPartStore.kt
@@ -47,10 +47,18 @@ internal class ConnectionLogPartStore(
     private val baseName: String = DEFAULT_BASE_NAME,
     private val maxLinesPerPart: Int = DEFAULT_MAX_LINES_PER_PART,
     private val maxParts: Int = DEFAULT_MAX_PARTS,
+    /**
+     * Optional drop-oldest ceiling for the folded base file. The ordinary
+     * connection log leaves this null to preserve #1669 losslessness; the much
+     * chattier replay journal opts in so months of dogfooding cannot grow the
+     * compacted base without bound (#1709).
+     */
+    private val maxBaseBytes: Long? = null,
 ) {
     init {
         require(maxLinesPerPart > 0) { "maxLinesPerPart must be positive" }
         require(maxParts > 0) { "maxParts must be positive" }
+        require(maxBaseBytes == null || maxBaseBytes > 0L) { "maxBaseBytes must be positive when set" }
     }
 
     private val lock = Any()
@@ -124,18 +132,39 @@ internal class ConnectionLogPartStore(
 
     private fun compactLocked() {
         val parts = partFilesLocked().sortedBy { indexOf(it) }
-        if (parts.size <= maxParts) return
-        val base = baseFile()
-        base.parentFile?.mkdirs()
-        // Fold all but the newest [maxParts] parts into base, oldest first.
-        val toFold = parts.dropLast(maxParts)
-        for (part in toFold) {
-            val lines = part.readNonEmptyLines()
-            if (lines.isNotEmpty()) {
-                base.appendText(lines.joinToString(separator = "\n", postfix = "\n"))
+        if (parts.size > maxParts) {
+            val base = baseFile()
+            base.parentFile?.mkdirs()
+            // Fold all but the newest [maxParts] parts into base, oldest first.
+            val toFold = parts.dropLast(maxParts)
+            for (part in toFold) {
+                val lines = part.readNonEmptyLines()
+                if (lines.isNotEmpty()) {
+                    base.appendText(lines.joinToString(separator = "\n", postfix = "\n"))
+                }
+                part.delete()
             }
-            part.delete()
         }
+        trimBaseToByteCapLocked()
+    }
+
+    /** Keep the newest complete JSONL lines whose UTF-8 bytes fit the cap. */
+    private fun trimBaseToByteCapLocked() {
+        val cap = maxBaseBytes ?: return
+        val base = baseFile()
+        if (!base.isFile || base.length() <= cap) return
+        val kept = ArrayDeque<String>()
+        var bytes = 0L
+        for (line in base.readNonEmptyLines().asReversed()) {
+            val cost = line.toByteArray(Charsets.UTF_8).size.toLong() + 1L
+            if (cost > cap) continue
+            if (bytes + cost > cap) break
+            kept.addFirst(line)
+            bytes += cost
+        }
+        base.writeText(
+            if (kept.isEmpty()) "" else kept.joinToString(separator = "\n", postfix = "\n"),
+        )
     }
 
     private fun baseFile(): File = File(directory, baseName)

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.diagnostics
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.core.connection.ConnectionJournalSchema
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -68,9 +69,18 @@ class DiagnosticRecorder @Inject constructor(
         val connectionLog = ConnectionLogPartStore(
             directory = File(context.filesDir, "diagnostics/connection-log"),
         )
+        val connectionJournal = ConnectionLogPartStore(
+            directory = File(context.filesDir, "diagnostics/connection-journal"),
+            baseName = CONNECTION_JOURNAL_BASE_NAME,
+            maxBaseBytes = CONNECTION_JOURNAL_MAX_BASE_BYTES,
+        )
         lastSequenceReadThreadName = currentPhysicalThreadName()
         sequence.set(store.lastSequence())
-        RecorderStores(events = store, connectionLog = connectionLog)
+        RecorderStores(
+            events = store,
+            connectionLog = connectionLog,
+            connectionJournal = connectionJournal,
+        )
     }
 
     init {
@@ -85,12 +95,14 @@ class DiagnosticRecorder @Inject constructor(
                     is RecorderCommand.Clear -> {
                         stores.events.clear()
                         stores.connectionLog.clear()
+                        stores.connectionJournal.clear()
                         sequence.set(0L)
                         command.done.complete(Unit)
                     }
                     is RecorderCommand.ClearAndRecord -> {
                         stores.events.clear()
                         stores.connectionLog.clear()
+                        stores.connectionJournal.clear()
                         sequence.set(0L)
                         if (settingsRepository.settings.value.diagnosticsRecordingEnabled) {
                             persist(stores, pendingEvent(command.category, command.event, command.fields))
@@ -155,6 +167,15 @@ class DiagnosticRecorder @Inject constructor(
         flush()
         return withContext(Dispatchers.IO) {
             storeDeferred.await().connectionLog.readAllLines().mapNotNull(DiagnosticEventJson::decode)
+        }
+    }
+
+    /** Full device-only replay journal; never used as an automatic host payload. */
+    suspend fun connectionJournalArchive(): List<DiagnosticsEvent> {
+        flush()
+        return withContext(Dispatchers.IO) {
+            storeDeferred.await().connectionJournal.readAllLines()
+                .mapNotNull(DiagnosticEventJson::decode)
         }
     }
 
@@ -231,6 +252,9 @@ class DiagnosticRecorder @Inject constructor(
         val event = buildEvent(pending)
         val line = DiagnosticEventJson.encode(event)
         stores.events.appendLine(line)
+        if (event.category == ConnectionJournalSchema.CATEGORY) {
+            stores.connectionJournal.append(line)
+        }
         if (MirroredDiagnostics.isMirrored(event)) {
             stores.connectionLog.append(line)
         }
@@ -298,6 +322,7 @@ class DiagnosticRecorder @Inject constructor(
     private class RecorderStores(
         val events: DiagnosticLogStore,
         val connectionLog: ConnectionLogPartStore,
+        val connectionJournal: ConnectionLogPartStore,
     )
 
     private sealed interface RecorderCommand {
@@ -314,6 +339,8 @@ class DiagnosticRecorder @Inject constructor(
 
     private companion object {
         const val RECORDER_BUFFER_CAPACITY = 256
+        const val CONNECTION_JOURNAL_BASE_NAME = "connection-journal.jsonl"
+        const val CONNECTION_JOURNAL_MAX_BASE_BYTES = 4L * 1024L * 1024L
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
@@ -1,8 +1,10 @@
 package com.pocketshell.app.tmux.connection
 
+import com.pocketshell.app.diagnostics.ConnectionJournalDiagnostics
 import com.pocketshell.core.connection.Clock
 import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.ConnectionJournalPort
 import com.pocketshell.core.connection.ConnectionState
 import com.pocketshell.core.connection.DropCause
 import com.pocketshell.core.connection.HostKey
@@ -100,8 +102,9 @@ class ConnectionManager(
      *  the effect driver observes. In PRODUCTION this is the REAL [SshLeaseTransportPort]
      *  over the VM's `SshLeaseManager`. */
     val transport: TransportPort,
+    journal: ConnectionJournalPort = ConnectionJournalDiagnostics,
 ) {
-    private val controller = ConnectionController(clock = clock, transport = transport)
+    private val controller = ConnectionController(clock = clock, transport = transport, journal = journal)
 
     /**
      * The `:shared:core-connection` reducer the facade owns. Exposed so the VM can wire the
@@ -119,7 +122,11 @@ class ConnectionManager(
      * equivalence suite; production always injects the real [SshLeaseTransportPort].
      */
     constructor(clock: Clock = SystemElapsedClock, warmSnapshot: (HostKey) -> Boolean = { true }) :
-        this(clock = clock, transport = WarmSnapshotTransportPort(warmSnapshot))
+        this(
+            clock = clock,
+            transport = WarmSnapshotTransportPort(warmSnapshot),
+            journal = ConnectionJournalPort.Noop,
+        )
 
     /** The controller's current state — the SOLE connection-state authority. */
     val state: ConnectionState

--- a/app/src/test/java/com/pocketshell/app/diagnostics/Issue1709ConnectionJournalStorageTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/Issue1709ConnectionJournalStorageTest.kt
@@ -1,0 +1,153 @@
+package com.pocketshell.app.diagnostics
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.app.tmux.connection.ConnectionManager
+import com.pocketshell.core.connection.ConnectionJournalSchema
+import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.TransportPort
+import com.pocketshell.core.connection.TransportUpDown
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * App/storage half of issue #1709: the real manager's typed journal reaches its
+ * own capped archive, carries no raw identity, and is absent from the automatic
+ * 64 KiB host mirror by construction.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1709ConnectionJournalStorageTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        settingsRepository = SettingsRepository(context)
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
+    }
+
+    @Test
+    fun `real manager journals typed privacy-safe checkpoints only to the second archive`() = runTest {
+        val recorder = DiagnosticRecorder(context, settingsRepository)
+        recorder.appVersionOverride = DiagnosticRecorder.AppVersion("0.4.39", 86L)
+        DiagnosticEvents.install(recorder)
+        val transport = WarmTransport(warm = true)
+        val manager = ConnectionManager(transport = transport)
+        val rawHost = "alexey@field-host.example:22"
+        val rawSession = "/srv/private/client/project"
+
+        manager.enter(HostKey(rawHost), SessionId(rawSession))
+        manager.setReconnectLadder(listOf(0L, 1_000L, 2_000L))
+        manager.observeBackground()
+
+        val journal = recorder.connectionJournalArchive()
+        assertEquals(
+            listOf(
+                ConnectionJournalSchema.CONSTRUCT,
+                ConnectionJournalSchema.SUBMIT,
+                ConnectionJournalSchema.LADDER_INSTALL,
+                ConnectionJournalSchema.SUBMIT,
+            ),
+            journal.map { it.name },
+        )
+        assertTrue(journal.all { it.category == ConnectionJournalSchema.CATEGORY })
+        assertTrue(
+            "journal entries must be version-stamped by the #1669 envelope",
+            journal.all { it.versionName == "0.4.39" && it.versionCode == 86L },
+        )
+
+        val enter = journal.first { it.name == ConnectionJournalSchema.SUBMIT }
+        assertEquals("enter", enter.metadata["event"])
+        assertEquals(true, enter.metadata["isWarm"])
+        assertEquals(
+            DiagnosticPrivacy.stableFingerprint(rawHost),
+            enter.metadata["eventHostFingerprint"],
+        )
+        assertTrue(enter.metadata["eventSessionFingerprint"].toString().startsWith("sha256:"))
+        assertEquals(
+            "equal typed IDs must retain equality after sanitization",
+            enter.metadata["eventHostFingerprint"],
+            enter.metadata["postHostFingerprint"],
+        )
+        assertEquals("attaching", enter.metadata["postState"])
+        assertTrue(enter.metadata.containsKey("reconnectAttempt"))
+        assertTrue(enter.metadata.containsKey("episodeStartMs"))
+        assertTrue(enter.metadata.containsKey("liveSinceMs"))
+        assertTrue(enter.metadata.containsKey("graceDeadlineMs"))
+
+        val submits = journal.filter { it.name == ConnectionJournalSchema.SUBMIT }
+        assertEquals(listOf(1L, 2L), submits.map { (it.metadata["journalSeq"] as Number).toLong() })
+        val background = submits.last()
+        assertTrue("non-consulting events must retain the nullable field", background.metadata.containsKey("isWarm"))
+        assertEquals(null, background.metadata["isWarm"])
+
+        val encoded = journal.joinToString("\n", transform = DiagnosticEventJson::encode)
+        assertFalse("raw host leaked into commit-safe journal", encoded.contains(rawHost))
+        assertFalse("path-derived tmux session leaked into commit-safe journal", encoded.contains(rawSession))
+
+        assertTrue(
+            "connection_journal must be deliberately absent from automatic mirroring",
+            journal.none(MirroredDiagnostics::isMirrored),
+        )
+        assertTrue(
+            "the second archive must add zero bytes to the 64 KiB host payload",
+            recorder.connectionLogJsonl().isBlank(),
+        )
+        assertTrue(
+            "journal archive directory must be separate",
+            File(context.filesDir, "diagnostics/connection-journal").isDirectory,
+        )
+    }
+
+    @Test
+    fun `journal base compaction drops oldest complete lines at its byte cap`() {
+        val directory = tmp.newFolder("connection-journal")
+        val cap = 512L
+        val store = ConnectionLogPartStore(
+            directory = directory,
+            baseName = "connection-journal.jsonl",
+            maxLinesPerPart = 1,
+            maxParts = 1,
+            maxBaseBytes = cap,
+        )
+        repeat(200) { index ->
+            store.append("""{"journalSeq":$index,"padding":"${"x".repeat(40)}"}""")
+        }
+
+        val base = File(directory, "connection-journal.jsonl")
+        assertTrue("compaction must create the capped base", base.isFile)
+        assertTrue("base bytes ${base.length()} exceed cap $cap", base.length() <= cap)
+        val all = store.readAllLines()
+        assertTrue("newest checkpoint must survive", all.last().contains("\"journalSeq\":199"))
+        assertFalse("oldest checkpoints must be dropped under the cap", all.any { it.contains("\"journalSeq\":0,") })
+        assertTrue("part count remains independently bounded", store.partCount() <= 1)
+    }
+
+    private class WarmTransport(var warm: Boolean) : TransportPort {
+        override fun isWarm(host: HostKey): Boolean = warm
+        override val transportEvents: Flow<TransportUpDown> = emptyFlow()
+    }
+}

--- a/shared/core-connection/build.gradle.kts
+++ b/shared/core-connection/build.gradle.kts
@@ -66,4 +66,5 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation("org.json:json:20240303")
 }

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -91,6 +91,8 @@ class ConnectionController(
      * Injectable so tests pin the distribution deterministically instead of skipping it.
      */
     private val random: Random = Random.Default,
+    /** Issue #1709: replay-complete submit-boundary journal. */
+    private val journal: ConnectionJournalPort = ConnectionJournalPort.Noop,
 ) {
     /**
      * Enforces the single-confining-dispatcher contract in DEBUG builds by
@@ -146,7 +148,8 @@ class ConnectionController(
      * A plain `var` mutated only from the confining dispatcher (via [setReconnectLadder]),
      * same single-confining-dispatcher contract as [graceDeadlineMs].
      */
-    private var reconnectLadderMs: List<Long> = jitteredLadder(reconnectLadderMs)
+    private val initialReconnectLadderMs: List<Long> = reconnectLadderMs.toList()
+    private var reconnectLadderMs: List<Long> = jitteredLadder(initialReconnectLadderMs)
 
     /**
      * Issue #1328 (S5): the SINGLE reconnect-attempt counter. It lives HERE, in the
@@ -198,6 +201,36 @@ class ConnectionController(
      */
     private var episodeStartMs: Long? = null
 
+    /**
+     * One physical [Clock] read and one nullable warm consult per submit (#1709).
+     *
+     * This is a stack because StateFlow publication can synchronously drive an
+     * existing same-thread effect which re-enters [submit]. The confinement
+     * contract explicitly permits that re-entry.
+     */
+    private val activeSubmits = ArrayDeque<ActiveSubmit>()
+    private val pendingJournalEntries = ArrayDeque<ConnectionJournalEntry>()
+    private var journalSeq: Long = 0L
+
+    init {
+        // Preserve the true zero-overhead default: old/controller-only call sites
+        // neither build an entry nor consult the clock when journaling is absent.
+        if (journal !== ConnectionJournalPort.Noop) {
+            journal.record(
+                ConnectionJournalEntry.Construct(
+                    nowMs = clock.nowMs(),
+                    graceMs = graceMs,
+                    stabilityWindowMs = stabilityWindowMs,
+                    episodeBudgetMs = episodeBudgetMs,
+                    baseLadderMs = initialReconnectLadderMs,
+                    // Qualify `this`: the constructor parameter has the same
+                    // name, but replay needs the resolved post-jitter property.
+                    jitteredLadderMs = this.reconnectLadderMs,
+                ),
+            )
+        }
+    }
+
     /** Current target id — the drop-by-id reference for events and seeds. */
     private val currentTargetId: SessionId?
         get() = _state.value.targetIdOrNull()
@@ -217,12 +250,45 @@ class ConnectionController(
      * [confinement].
      */
     fun submit(event: ConnectionEvent): ConnectionState = confinement.guarded("submit") {
-        val next = reduce(_state.value, event)
-        if (next !== _state.value || next != _state.value) {
-            _state.value = next
+        val submit = ActiveSubmit(nowMs = clock.nowMs())
+        val outermost = activeSubmits.isEmpty()
+        activeSubmits.addLast(submit)
+        val pre = _state.value
+        val seq = ++journalSeq
+        var succeeded = false
+        try {
+            val next = reduce(pre, event)
+            if (journal !== ConnectionJournalPort.Noop) {
+                // Queue before StateFlow publication: publication may re-enter
+                // submit synchronously, and replay must observe outer then inner.
+                pendingJournalEntries.addLast(
+                    ConnectionJournalEntry.Submit(
+                        journalSeq = seq,
+                        nowMs = submit.nowMs,
+                        event = event.journalSafe(),
+                        preState = pre.journalSafe(),
+                        postState = next.journalSafe(),
+                        isWarm = submit.isWarm,
+                        internals = journalInternals(),
+                    ),
+                )
+            }
+            if (next !== _state.value || next != _state.value) {
+                _state.value = next
+            }
+            _revealGate.value = revealFor(next)
+            succeeded = true
+            _state.value
+        } finally {
+            check(activeSubmits.removeLast() === submit)
+            if (outermost) {
+                if (succeeded) {
+                    flushPendingJournal()
+                } else {
+                    pendingJournalEntries.clear()
+                }
+            }
         }
-        _revealGate.value = revealFor(next)
-        _state.value
     }
 
     /**
@@ -260,6 +326,18 @@ class ConnectionController(
         // reducer deterministic (same inputs + same ladder -> same states) while preserving
         // the desynchronisation property: every ladder install is a fresh independent roll.
         reconnectLadderMs = jitteredLadder(delaysMs)
+        if (journal !== ConnectionJournalPort.Noop) {
+            // Order the resolved ladder before publishing a re-stamped state:
+            // StateFlow collectors may synchronously re-enter submit, and that
+            // nested reduction already observes this replacement ladder.
+            recordOrBuffer(
+                ConnectionJournalEntry.LadderInstall(
+                    journalSeq = journalSeq,
+                    baseLadderMs = delaysMs.toList(),
+                    jitteredLadderMs = reconnectLadderMs,
+                ),
+            )
+        }
         // If a reconnect is already in flight when the ladder is (re)installed — the
         // proactive network-handoff / passive-drop paths enter [ConnectionState.Reconnecting]
         // BEFORE the VM effect installs its `autoReconnectDelaysMs` — re-stamp the current
@@ -270,6 +348,40 @@ class ConnectionController(
             _state.value = reconnectingAt(current.host, current.targetId, current.attempt)
         }
     }
+
+    /** The submit's memoized timestamp, or a direct read for the non-submit ladder setter. */
+    private fun reducerNowMs(): Long = activeSubmits.lastOrNull()?.nowMs ?: clock.nowMs()
+
+    /** Record the reducer's sole environmental consultation exactly where it happens. */
+    private fun consultWarm(host: HostKey): Boolean =
+        transport.isWarm(host).also { activeSubmits.lastOrNull()?.isWarm = it }
+
+    private fun recordOrBuffer(entry: ConnectionJournalEntry) {
+        if (activeSubmits.isEmpty()) {
+            journal.record(entry)
+        } else {
+            pendingJournalEntries.addLast(entry)
+        }
+    }
+
+    private fun flushPendingJournal() {
+        val batch = pendingJournalEntries.toList()
+        pendingJournalEntries.clear()
+        batch.forEach(journal::record)
+    }
+
+    private fun journalInternals(): ConnectionJournalInternals =
+        ConnectionJournalInternals(
+            reconnectAttempt = reconnectAttempt,
+            episodeStartMs = episodeStartMs,
+            liveSinceMs = liveSinceMs,
+            graceDeadlineMs = graceDeadlineMs,
+        )
+
+    private data class ActiveSubmit(
+        val nowMs: Long,
+        var isWarm: Boolean? = null,
+    )
 
     /**
      * The attempt budget for the current ladder — the ONE exhaustion boundary.
@@ -334,7 +446,7 @@ class ConnectionController(
      *  episode start if this is the episode's first rung (issue #1633). */
     private fun reconnectingAt(host: HostKey, target: SessionId, attempt: Int): ConnectionState.Reconnecting {
         reconnectAttempt = attempt
-        if (episodeStartMs == null) episodeStartMs = clock.nowMs()
+        if (episodeStartMs == null) episodeStartMs = reducerNowMs()
         liveSinceMs = null
         return ConnectionState.Reconnecting(
             host = host,
@@ -361,7 +473,7 @@ class ConnectionController(
 
     /** Enter [ConnectionState.Live], stamping the stability window's start (issue #1633). */
     private fun liveAt(host: HostKey, target: SessionId): ConnectionState.Live {
-        liveSinceMs = clock.nowMs()
+        liveSinceMs = reducerNowMs()
         return ConnectionState.Live(host, target)
     }
 
@@ -369,7 +481,7 @@ class ConnectionController(
     private fun episodeExhausted(nextAttempt: Int): Boolean {
         if (nextAttempt > effectiveMaxAttempts) return true
         val started = episodeStartMs ?: return false
-        return clock.nowMs() - started >= episodeBudgetMs
+        return reducerNowMs() - started >= episodeBudgetMs
     }
 
     /**
@@ -381,7 +493,7 @@ class ConnectionController(
     private fun endLiveAndCommitIfStable() {
         val since = liveSinceMs
         liveSinceMs = null
-        if (since != null && clock.nowMs() - since >= stabilityWindowMs) endEpisode()
+        if (since != null && reducerNowMs() - since >= stabilityWindowMs) endEpisode()
     }
 
     /** The rung an ending Live should resume the episode at: 1 when none is in flight. */
@@ -408,7 +520,7 @@ class ConnectionController(
 
         if (reconnectAttempt == 0) {
             // A fresh episode: heal silently first; the counter arms only if that fails.
-            episodeStartMs = clock.nowMs()
+            episodeStartMs = reducerNowMs()
             return ConnectionState.Reattaching(host, target)
         }
         val next = reconnectAttempt + 1
@@ -450,7 +562,7 @@ class ConnectionController(
         // affordance out of a terminal Unreachable routes through here.
         graceDeadlineMs = null
         endEpisode()
-        return if (transport.isWarm(event.host)) {
+        return if (consultWarm(event.host)) {
             ConnectionState.Attaching(event.host, event.targetId)
         } else {
             ConnectionState.Connecting(event.host, event.targetId)
@@ -492,7 +604,7 @@ class ConnectionController(
         if (current is ConnectionState.Gone || current is ConnectionState.Unreachable) {
             return current
         }
-        val now = clock.nowMs()
+        val now = reducerNowMs()
         graceDeadlineMs = now + graceMs
         return ConnectionState.Backgrounded(host, target, sinceMs = now)
     }
@@ -512,8 +624,8 @@ class ConnectionController(
         val deadline = graceDeadlineMs
         graceDeadlineMs = null
         val withinGrace = deadline != null &&
-            clock.nowMs() < deadline &&
-            transport.isWarm(current.host)
+            reducerNowMs() < deadline &&
+            consultWarm(current.host)
         return if (withinGrace) {
             ConnectionState.Reattaching(current.host, current.targetId)
         } else {

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionJournal.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionJournal.kt
@@ -1,0 +1,261 @@
+package com.pocketshell.core.connection
+
+import java.security.MessageDigest
+
+/**
+ * Synchronous submit-boundary journal tap (#1709).
+ *
+ * The controller is confined to one dispatcher, so emission is ordered with the
+ * reduction and needs no extra synchronization. The default is a true no-op;
+ * core tests and the app adapter inject a recorder explicitly.
+ */
+fun interface ConnectionJournalPort {
+    fun record(entry: ConnectionJournalEntry)
+
+    companion object {
+        val Noop: ConnectionJournalPort = ConnectionJournalPort { }
+    }
+}
+
+/**
+ * Replay-complete controller journal. Every identity inside an entry is already
+ * an equality-preserving `sha256:` fingerprint; raw host/session values never
+ * cross this boundary.
+ */
+sealed interface ConnectionJournalEntry {
+    val journalSeq: Long
+
+    data class Construct(
+        override val journalSeq: Long = 0L,
+        val nowMs: Long,
+        val graceMs: Long,
+        val stabilityWindowMs: Long,
+        val episodeBudgetMs: Long,
+        val baseLadderMs: List<Long>,
+        val jitteredLadderMs: List<Long>,
+    ) : ConnectionJournalEntry
+
+    data class LadderInstall(
+        override val journalSeq: Long,
+        val baseLadderMs: List<Long>,
+        val jitteredLadderMs: List<Long>,
+    ) : ConnectionJournalEntry
+
+    data class Submit(
+        override val journalSeq: Long,
+        val nowMs: Long,
+        val event: ConnectionEvent,
+        val preState: ConnectionState,
+        val postState: ConnectionState,
+        val isWarm: Boolean?,
+        val internals: ConnectionJournalInternals,
+    ) : ConnectionJournalEntry
+}
+
+/** Hidden episode state that is intentionally not derivable from [ConnectionState]. */
+data class ConnectionJournalInternals(
+    val reconnectAttempt: Int,
+    val episodeStartMs: Long?,
+    val liveSinceMs: Long?,
+    val graceDeadlineMs: Long?,
+)
+
+/**
+ * Stable flat schema stored in `DiagnosticsEvent.metadata`.
+ *
+ * Lists are comma-separated strings because the app redactor deliberately
+ * reduces arbitrary collections to `{count:n}`. Identity values are
+ * pre-fingerprinted and use `*Fingerprint` keys so the app redactor cannot hash
+ * them a second time.
+ */
+object ConnectionJournalSchema {
+    const val CATEGORY: String = "connection_journal"
+    const val CONSTRUCT: String = "construct"
+    const val LADDER_INSTALL: String = "ladder_install"
+    const val SUBMIT: String = "submit"
+
+    fun name(entry: ConnectionJournalEntry): String = when (entry) {
+        is ConnectionJournalEntry.Construct -> CONSTRUCT
+        is ConnectionJournalEntry.LadderInstall -> LADDER_INSTALL
+        is ConnectionJournalEntry.Submit -> SUBMIT
+    }
+
+    fun metadata(entry: ConnectionJournalEntry): Map<String, Any?> = buildMap {
+        put("journalSeq", entry.journalSeq)
+        when (entry) {
+            is ConnectionJournalEntry.Construct -> {
+                put("nowMs", entry.nowMs)
+                put("graceMs", entry.graceMs)
+                put("stabilityWindowMs", entry.stabilityWindowMs)
+                put("episodeBudgetMs", entry.episodeBudgetMs)
+                put("baseLadderMs", entry.baseLadderMs.csv())
+                put("jitteredLadderMs", entry.jitteredLadderMs.csv())
+            }
+
+            is ConnectionJournalEntry.LadderInstall -> {
+                put("baseLadderMs", entry.baseLadderMs.csv())
+                put("jitteredLadderMs", entry.jitteredLadderMs.csv())
+            }
+
+            is ConnectionJournalEntry.Submit -> {
+                put("nowMs", entry.nowMs)
+                put("isWarm", entry.isWarm)
+                putEvent(entry.event)
+                putState("pre", entry.preState)
+                putState("post", entry.postState)
+                put("reconnectAttempt", entry.internals.reconnectAttempt)
+                put("episodeStartMs", entry.internals.episodeStartMs)
+                put("liveSinceMs", entry.internals.liveSinceMs)
+                put("graceDeadlineMs", entry.internals.graceDeadlineMs)
+            }
+        }
+    }
+
+    private fun MutableMap<String, Any?>.putEvent(event: ConnectionEvent) {
+        when (event) {
+            is ConnectionEvent.Enter -> {
+                put("event", "enter")
+                put("eventHostFingerprint", event.host.value)
+                put("eventSessionFingerprint", event.targetId.value)
+            }
+            is ConnectionEvent.Switch -> {
+                put("event", "switch")
+                put("eventSessionFingerprint", event.targetId.value)
+            }
+            ConnectionEvent.Foreground -> put("event", "foreground")
+            ConnectionEvent.Background -> put("event", "background")
+            is ConnectionEvent.TransportDropped -> {
+                put("event", "transport_dropped")
+                when (val cause = event.cause) {
+                    is DropCause.SelfInflicted -> {
+                        put("cause", "self_inflicted")
+                        put("causeReason", cause.reason)
+                    }
+                    is DropCause.RemoteFailure -> {
+                        put("cause", "remote_failure")
+                        put("causeReason", cause.reason)
+                    }
+                    DropCause.KeepaliveDead -> put("cause", "keepalive_dead")
+                    DropCause.Unknown -> put("cause", "unknown")
+                }
+            }
+            ConnectionEvent.TransportLive -> put("event", "transport_live")
+            is ConnectionEvent.NetworkChanged -> {
+                put("event", "network_changed")
+                put("validatedHandoff", event.validatedHandoff)
+            }
+            ConnectionEvent.NetworkLost -> put("event", "network_lost")
+            ConnectionEvent.NetworkRestored -> put("event", "network_restored")
+            is ConnectionEvent.TargetGone -> {
+                put("event", "target_gone")
+                put("eventSessionFingerprint", event.targetId.value)
+            }
+            is ConnectionEvent.SeedLanded -> {
+                put("event", "seed_landed")
+                put("eventSessionFingerprint", event.targetId.value)
+                put("paneId", event.paneId)
+            }
+            ConnectionEvent.ReconnectLadderEntered -> put("event", "reconnect_ladder_entered")
+            ConnectionEvent.ReconnectFailed -> put("event", "reconnect_failed")
+            ConnectionEvent.ReconnectGaveUp -> put("event", "reconnect_gave_up")
+        }
+    }
+
+    private fun MutableMap<String, Any?>.putState(prefix: String, state: ConnectionState) {
+        put("${prefix}State", state.token())
+        state.hostOrNull()?.let { put("${prefix}HostFingerprint", it.value) }
+        state.targetIdOrNull()?.let { put("${prefix}SessionFingerprint", it.value) }
+        when (state) {
+            is ConnectionState.Backgrounded -> put("${prefix}SinceMs", state.sinceMs)
+            is ConnectionState.NetworkLossSuspended -> put("${prefix}SinceMs", state.sinceMs)
+            is ConnectionState.Reconnecting -> {
+                put("${prefix}Attempt", state.attempt)
+                put("${prefix}MaxAttempts", state.maxAttempts)
+                put("${prefix}RetryDelayMs", state.retryDelayMs)
+            }
+            else -> Unit
+        }
+    }
+
+    private fun ConnectionState.token(): String = when (this) {
+        ConnectionState.Idle -> "idle"
+        is ConnectionState.Connecting -> "connecting"
+        is ConnectionState.Attaching -> "attaching"
+        is ConnectionState.Live -> "live"
+        is ConnectionState.Backgrounded -> "backgrounded"
+        is ConnectionState.NetworkLossSuspended -> "network_loss_suspended"
+        is ConnectionState.Reattaching -> "reattaching"
+        is ConnectionState.Reconnecting -> "reconnecting"
+        is ConnectionState.Gone -> "gone"
+        is ConnectionState.Unreachable -> "unreachable"
+    }
+
+    private fun List<Long>.csv(): String = joinToString(",")
+}
+
+internal fun ConnectionEvent.journalSafe(): ConnectionEvent = when (this) {
+    is ConnectionEvent.Enter -> ConnectionEvent.Enter(host.journalSafe(), targetId.journalSafe())
+    is ConnectionEvent.Switch -> ConnectionEvent.Switch(targetId.journalSafe())
+    ConnectionEvent.Foreground -> this
+    ConnectionEvent.Background -> this
+    is ConnectionEvent.TransportDropped -> ConnectionEvent.TransportDropped(cause.journalSafe())
+    ConnectionEvent.TransportLive -> this
+    is ConnectionEvent.NetworkChanged -> this
+    ConnectionEvent.NetworkLost -> this
+    ConnectionEvent.NetworkRestored -> this
+    is ConnectionEvent.TargetGone -> ConnectionEvent.TargetGone(targetId.journalSafe())
+    is ConnectionEvent.SeedLanded ->
+        ConnectionEvent.SeedLanded(targetId.journalSafe(), paneId.journalSafeToken())
+    ConnectionEvent.ReconnectLadderEntered -> this
+    ConnectionEvent.ReconnectFailed -> this
+    ConnectionEvent.ReconnectGaveUp -> this
+}
+
+internal fun ConnectionState.journalSafe(): ConnectionState = when (this) {
+    ConnectionState.Idle -> this
+    is ConnectionState.Connecting -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.Attaching -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.Live -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.Backgrounded -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.NetworkLossSuspended -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.Reattaching -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.Reconnecting -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.Gone -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+    is ConnectionState.Unreachable -> copy(host = host.journalSafe(), targetId = targetId.journalSafe())
+}
+
+private fun HostKey.journalSafe(): HostKey = HostKey(ConnectionJournalPrivacy.fingerprint(value))
+private fun SessionId.journalSafe(): SessionId = SessionId(ConnectionJournalPrivacy.fingerprint(value))
+
+private fun DropCause.journalSafe(): DropCause = when (this) {
+    is DropCause.SelfInflicted -> DropCause.SelfInflicted(reason.journalSafeReason())
+    is DropCause.RemoteFailure -> DropCause.RemoteFailure(reason.journalSafeReason())
+    DropCause.KeepaliveDead -> this
+    DropCause.Unknown -> this
+}
+
+private fun String.journalSafeReason(): String {
+    val normalized = trim().lowercase()
+    if (normalized.matches(Regex("[a-z][a-z0-9_:-]{0,79}"))) return normalized
+    return ConnectionJournalPrivacy.fingerprint(this)
+}
+
+private fun String.journalSafeToken(): String {
+    val normalized = trim()
+    if (normalized.matches(Regex("[%a-zA-Z0-9_.:-]{1,80}"))) return normalized
+    return ConnectionJournalPrivacy.fingerprint(this)
+}
+
+internal object ConnectionJournalPrivacy {
+    private val alreadyFingerprint = Regex("sha256:[0-9a-f]{12}")
+
+    fun fingerprint(value: String): String {
+        val text = value.trim()
+        if (alreadyFingerprint.matches(text.lowercase())) return text.lowercase()
+        if (text.isBlank()) return "sha256:empty"
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(text.lowercase().toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte) }
+        return "sha256:${digest.take(12)}"
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerConfinementTest.kt
@@ -89,7 +89,7 @@ class ConnectionControllerConfinementTest {
         // A clock whose nowMs() (called inside submit(Background)'s reduce) parks
         // thread A inside the guarded mutation until the racing call has happened.
         val blockingClock = object : Clock {
-            @Volatile var blockOnce = true
+            @Volatile var blockOnce = false
             override fun nowMs(): Long {
                 if (blockOnce) {
                     blockOnce = false
@@ -106,6 +106,7 @@ class ConnectionControllerConfinementTest {
         )
         // Establish a target so Background reduces down the grace path (calls nowMs).
         controller.submit(ConnectionEvent.Enter(host, target))
+        blockingClock.blockOnce = true
 
         val threadA = Thread { controller.submit(ConnectionEvent.Background) }
         threadA.start()
@@ -140,7 +141,7 @@ class ConnectionControllerConfinementTest {
         val insideMutation = CountDownLatch(1)
         val releaseMutation = CountDownLatch(1)
         val blockingClock = object : Clock {
-            @Volatile var blockOnce = true
+            @Volatile var blockOnce = false
             override fun nowMs(): Long {
                 if (blockOnce) {
                     blockOnce = false
@@ -156,6 +157,7 @@ class ConnectionControllerConfinementTest {
             confinementAssertionsEnabled = true,
         )
         controller.submit(ConnectionEvent.Enter(host, target))
+        blockingClock.blockOnce = true
 
         val threadA = Thread { controller.submit(ConnectionEvent.Background) }
         threadA.start()
@@ -185,7 +187,7 @@ class ConnectionControllerConfinementTest {
         val insideMutation = CountDownLatch(1)
         val releaseMutation = CountDownLatch(1)
         val blockingClock = object : Clock {
-            @Volatile var blockOnce = true
+            @Volatile var blockOnce = false
             override fun nowMs(): Long {
                 if (blockOnce) {
                     blockOnce = false
@@ -201,6 +203,7 @@ class ConnectionControllerConfinementTest {
             confinementAssertionsEnabled = false,
         )
         controller.submit(ConnectionEvent.Enter(host, target))
+        blockingClock.blockOnce = true
 
         val threadA = Thread { controller.submit(ConnectionEvent.Background) }
         threadA.start()

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionJournalReplay.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionJournalReplay.kt
@@ -1,0 +1,305 @@
+package com.pocketshell.core.connection
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import org.json.JSONObject
+import kotlin.math.floor
+import kotlin.random.Random
+
+/** Pure-JVM field-journal replay harness for issue #1709. */
+internal object ConnectionJournalReplay {
+    fun replay(lines: List<String>): ReplayReport {
+        val expected = lines.filter { it.isNotBlank() }.map(::decodeEnvelope)
+        require(expected.isNotEmpty()) { "connection journal is empty" }
+        require(expected.first() is ConnectionJournalEntry.Construct) {
+            "connection journal must start with construct"
+        }
+        var expectedSubmitSeq = 1L
+        expected.filterIsInstance<ConnectionJournalEntry.Submit>().forEach { submit ->
+            require(submit.journalSeq == expectedSubmitSeq) {
+                "journalSeq gap: expected=$expectedSubmitSeq actual=${submit.journalSeq}"
+            }
+            expectedSubmitSeq++
+        }
+
+        val construct = expected.first() as ConnectionJournalEntry.Construct
+        val clock = ReplayClock(construct.nowMs)
+        val transport = ReplayTransport()
+        val random = ScriptedLadderRandom(construct.baseLadderMs, construct.jitteredLadderMs)
+        val actualJournal = RecordingConnectionJournal()
+        val controller = ConnectionController(
+            clock = clock,
+            transport = transport,
+            reconnectLadderMs = construct.baseLadderMs,
+            graceMs = construct.graceMs,
+            stabilityWindowMs = construct.stabilityWindowMs,
+            episodeBudgetMs = construct.episodeBudgetMs,
+            confinementAssertionsEnabled = false,
+            random = random,
+            journal = actualJournal,
+        )
+        require(actualJournal.entries.single() == construct) {
+            "construct mismatch: expected=$construct actual=${actualJournal.entries.single()}"
+        }
+
+        val postStates = mutableListOf<ConnectionState>()
+        val internals = mutableListOf<ConnectionJournalInternals>()
+        expected.drop(1).forEach { entry ->
+            val beforeCount = actualJournal.entries.size
+            when (entry) {
+                is ConnectionJournalEntry.Construct ->
+                    error("duplicate construct at journal index $beforeCount")
+                is ConnectionJournalEntry.LadderInstall -> {
+                    random.install(entry.baseLadderMs, entry.jitteredLadderMs)
+                    controller.setReconnectLadder(entry.baseLadderMs)
+                }
+                is ConnectionJournalEntry.Submit -> {
+                    clock.value = entry.nowMs
+                    transport.prepare(entry.isWarm)
+                    controller.submit(entry.event)
+                    transport.assertConsultationMatched(entry.journalSeq)
+                }
+            }
+            val actual = actualJournal.entries.drop(beforeCount)
+            require(actual.size == 1) {
+                "journal entry ${entry.journalSeq} emitted ${actual.size} records instead of 1"
+            }
+            require(actual.single() == entry) {
+                "journal divergence at journalSeq=${entry.journalSeq}: " +
+                    "expected=$entry actual=${actual.single()} " +
+                    "construct=$construct " +
+                    "recentExpected=${expected.takeWhile { it !== entry }.takeLast(3)} " +
+                    "recentActual=${actualJournal.entries.dropLast(1).takeLast(3)}"
+            }
+            if (entry is ConnectionJournalEntry.Submit) {
+                postStates += entry.postState
+                internals += entry.internals
+            }
+        }
+        random.assertDrained()
+        return ReplayReport(
+            submitCount = postStates.size,
+            postStateTrail = postStates,
+            internalsTrail = internals,
+        )
+    }
+
+    private fun decodeEnvelope(line: String): ConnectionJournalEntry {
+        val root = JSONObject(line)
+        require(root.getString("category") == ConnectionJournalSchema.CATEGORY) {
+            "not a ${ConnectionJournalSchema.CATEGORY} entry"
+        }
+        val metadata = root.getJSONObject("metadata")
+        val journalSeq = metadata.getLong("journalSeq")
+        return when (root.getString("name")) {
+            ConnectionJournalSchema.CONSTRUCT -> ConnectionJournalEntry.Construct(
+                journalSeq = journalSeq,
+                nowMs = metadata.getLong("nowMs"),
+                graceMs = metadata.getLong("graceMs"),
+                stabilityWindowMs = metadata.getLong("stabilityWindowMs"),
+                episodeBudgetMs = metadata.getLong("episodeBudgetMs"),
+                baseLadderMs = metadata.getString("baseLadderMs").longCsv(),
+                jitteredLadderMs = metadata.getString("jitteredLadderMs").longCsv(),
+            )
+            ConnectionJournalSchema.LADDER_INSTALL -> ConnectionJournalEntry.LadderInstall(
+                journalSeq = journalSeq,
+                baseLadderMs = metadata.getString("baseLadderMs").longCsv(),
+                jitteredLadderMs = metadata.getString("jitteredLadderMs").longCsv(),
+            )
+            ConnectionJournalSchema.SUBMIT -> ConnectionJournalEntry.Submit(
+                journalSeq = journalSeq,
+                nowMs = metadata.getLong("nowMs"),
+                event = metadata.event(),
+                preState = metadata.state("pre"),
+                postState = metadata.state("post"),
+                isWarm = metadata.nullableBoolean("isWarm"),
+                internals = ConnectionJournalInternals(
+                    reconnectAttempt = metadata.getInt("reconnectAttempt"),
+                    episodeStartMs = metadata.nullableLong("episodeStartMs"),
+                    liveSinceMs = metadata.nullableLong("liveSinceMs"),
+                    graceDeadlineMs = metadata.nullableLong("graceDeadlineMs"),
+                ),
+            )
+            else -> error("unknown connection journal entry '${root.getString("name")}'")
+        }
+    }
+
+    private fun JSONObject.event(): ConnectionEvent = when (getString("event")) {
+        "enter" -> ConnectionEvent.Enter(
+            HostKey(getString("eventHostFingerprint")),
+            SessionId(getString("eventSessionFingerprint")),
+        )
+        "switch" -> ConnectionEvent.Switch(SessionId(getString("eventSessionFingerprint")))
+        "foreground" -> ConnectionEvent.Foreground
+        "background" -> ConnectionEvent.Background
+        "transport_dropped" -> ConnectionEvent.TransportDropped(
+            when (getString("cause")) {
+                "self_inflicted" -> DropCause.SelfInflicted(getString("causeReason"))
+                "remote_failure" -> DropCause.RemoteFailure(getString("causeReason"))
+                "keepalive_dead" -> DropCause.KeepaliveDead
+                "unknown" -> DropCause.Unknown
+                else -> error("unknown drop cause '${getString("cause")}'")
+            },
+        )
+        "transport_live" -> ConnectionEvent.TransportLive
+        "network_changed" -> ConnectionEvent.NetworkChanged(getBoolean("validatedHandoff"))
+        "network_lost" -> ConnectionEvent.NetworkLost
+        "network_restored" -> ConnectionEvent.NetworkRestored
+        "target_gone" -> ConnectionEvent.TargetGone(SessionId(getString("eventSessionFingerprint")))
+        "seed_landed" -> ConnectionEvent.SeedLanded(
+            SessionId(getString("eventSessionFingerprint")),
+            getString("paneId"),
+        )
+        "reconnect_ladder_entered" -> ConnectionEvent.ReconnectLadderEntered
+        "reconnect_failed" -> ConnectionEvent.ReconnectFailed
+        "reconnect_gave_up" -> ConnectionEvent.ReconnectGaveUp
+        else -> error("unknown connection event '${getString("event")}'")
+    }
+
+    private fun JSONObject.state(prefix: String): ConnectionState {
+        val host by lazy { HostKey(getString("${prefix}HostFingerprint")) }
+        val session by lazy { SessionId(getString("${prefix}SessionFingerprint")) }
+        return when (getString("${prefix}State")) {
+            "idle" -> ConnectionState.Idle
+            "connecting" -> ConnectionState.Connecting(host, session)
+            "attaching" -> ConnectionState.Attaching(host, session)
+            "live" -> ConnectionState.Live(host, session)
+            "backgrounded" -> ConnectionState.Backgrounded(host, session, getLong("${prefix}SinceMs"))
+            "network_loss_suspended" ->
+                ConnectionState.NetworkLossSuspended(host, session, getLong("${prefix}SinceMs"))
+            "reattaching" -> ConnectionState.Reattaching(host, session)
+            "reconnecting" -> ConnectionState.Reconnecting(
+                host = host,
+                targetId = session,
+                attempt = getInt("${prefix}Attempt"),
+                maxAttempts = getInt("${prefix}MaxAttempts"),
+                retryDelayMs = getLong("${prefix}RetryDelayMs"),
+            )
+            "gone" -> ConnectionState.Gone(host, session)
+            "unreachable" -> ConnectionState.Unreachable(host, session)
+            else -> error("unknown connection state '${getString("${prefix}State")}'")
+        }
+    }
+
+    private fun JSONObject.nullableLong(key: String): Long? =
+        if (!has(key) || isNull(key)) null else getLong(key)
+
+    private fun JSONObject.nullableBoolean(key: String): Boolean? =
+        if (!has(key) || isNull(key)) null else getBoolean(key)
+
+    private fun String.longCsv(): List<Long> =
+        if (isBlank()) emptyList() else split(",").map(String::toLong)
+}
+
+internal data class ReplayReport(
+    val submitCount: Int,
+    val postStateTrail: List<ConnectionState>,
+    val internalsTrail: List<ConnectionJournalInternals>,
+)
+
+internal class RecordingConnectionJournal : ConnectionJournalPort {
+    val entries = mutableListOf<ConnectionJournalEntry>()
+    override fun record(entry: ConnectionJournalEntry) {
+        entries += entry
+    }
+}
+
+private class ReplayClock(var value: Long) : Clock {
+    override fun nowMs(): Long = value
+}
+
+private class ReplayTransport : TransportPort {
+    private var expected: Boolean? = null
+    private var consulted: Boolean = false
+    override val transportEvents: Flow<TransportUpDown> = emptyFlow()
+
+    fun prepare(expectedWarm: Boolean?) {
+        expected = expectedWarm
+        consulted = false
+    }
+
+    override fun isWarm(host: HostKey): Boolean {
+        check(expected != null) { "transport.isWarm consulted but journal recorded isWarm=null" }
+        check(!consulted) { "transport.isWarm consulted more than once in one submit" }
+        consulted = true
+        return expected!!
+    }
+
+    fun assertConsultationMatched(journalSeq: Long) {
+        check((expected != null) == consulted) {
+            "isWarm consultation mismatch at journalSeq=$journalSeq: expected=$expected consulted=$consulted"
+        }
+    }
+}
+
+/**
+ * Reconstructs a recorded post-jitter ladder without a production seam.
+ *
+ * Kotlin Random's `nextDouble()` consumes 53 bits (26 high + 27 low). For each
+ * non-zero rung we choose a representable draw whose `(base + offset).toLong()`
+ * is the recorded rung, then script those exact bit chunks.
+ */
+private class ScriptedLadderRandom(
+    base: List<Long>,
+    jittered: List<Long>,
+) : Random() {
+    private val bits = ArrayDeque<Pair<Int, Int>>()
+
+    init {
+        install(base, jittered)
+    }
+
+    fun install(base: List<Long>, jittered: List<Long>) {
+        check(bits.isEmpty()) { "scripted Random still has unused draws from the prior ladder" }
+        require(base.size == jittered.size) { "base/jittered ladder size mismatch" }
+        base.zip(jittered).forEach { (baseMs, jitteredMs) ->
+            if (baseMs <= 0L) {
+                require(jitteredMs == 0L) { "zero ladder rung changed to $jitteredMs" }
+            } else {
+                val spread = baseMs * ConnectionController.RETRY_JITTER_FRACTION
+                val randomLower = baseMs - spread
+                val randomUpper = baseMs + spread
+                // `toLong()` truncates a positive draw in [v, v + 1) to v.
+                // For v=1, coerceAtLeast also maps every draw below 2 to 1.
+                // Intersect that output bucket with the actual jitter band:
+                // a fixed `v + 0.25` is invalid when a reachable edge bucket
+                // is narrower than 0.25 (for example base=101, resolved=121).
+                val outputLower =
+                    if (jitteredMs == 1L) Double.NEGATIVE_INFINITY else jitteredMs.toDouble()
+                val outputUpper = jitteredMs.toDouble() + 1.0
+                val feasibleLower = maxOf(randomLower, outputLower)
+                val feasibleUpper = minOf(randomUpper, outputUpper)
+                require(feasibleLower < feasibleUpper) {
+                    "jittered rung $jitteredMs is outside replayable band for base $baseMs"
+                }
+                val desired = feasibleLower + (feasibleUpper - feasibleLower) / 2.0
+                val probability = (desired - randomLower) / (randomUpper - randomLower)
+                require(probability >= 0.0 && probability < 1.0) {
+                    "jittered rung $jitteredMs is outside replayable band for base $baseMs"
+                }
+                val sample = floor(probability * TWO_POW_53).toLong().coerceIn(0L, MAX_SAMPLE)
+                bits += 26 to (sample ushr 27).toInt()
+                bits += 27 to (sample and LOW_27_MASK).toInt()
+            }
+        }
+    }
+
+    override fun nextBits(bitCount: Int): Int {
+        val (expectedBits, value) = bits.removeFirstOrNull()
+            ?: error("controller requested more Random bits than the journaled ladder supplies")
+        check(bitCount == expectedBits) {
+            "Random draw shape changed: expected nextBits($expectedBits), got nextBits($bitCount)"
+        }
+        return value
+    }
+
+    fun assertDrained() {
+        check(bits.isEmpty()) { "controller consumed fewer Random draws than the journaled ladders supply" }
+    }
+
+    private companion object {
+        const val TWO_POW_53: Double = 9_007_199_254_740_992.0
+        const val MAX_SAMPLE: Long = 9_007_199_254_740_991L
+        const val LOW_27_MASK: Long = (1L shl 27) - 1L
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionJournalRoundTripTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionJournalRoundTripTest.kt
@@ -1,0 +1,346 @@
+package com.pocketshell.core.connection
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+/**
+ * Issue #1709: the submit-boundary field journal is useful only if it can
+ * reconstruct the reducer's decisions offline. This is the load-bearing
+ * round-trip property: randomized controller runs become diagnostics JSONL,
+ * then a fresh pure-JVM controller replays that JSONL exactly.
+ */
+class ConnectionJournalRoundTripTest {
+
+    @Test
+    fun `randomized journal round trip reproduces every state and episode checkpoint`() {
+        repeat(PROPERTY_SEEDS) { seed ->
+            val random = Random(seed)
+            val clock = CountingClock()
+            val transport = ScriptableWarmTransport()
+            val journal = RecordingConnectionJournal()
+            val controller = ConnectionController(
+                clock = clock,
+                transport = transport,
+                reconnectLadderMs = randomizedLadder(random),
+                graceMs = 800L,
+                stabilityWindowMs = 350L,
+                episodeBudgetMs = 2_500L,
+                random = Random(seed * 37 + 11),
+                journal = journal,
+            )
+            val callsAfterConstruct = clock.calls
+            val events = exhaustivePrefix(seed) + List(RANDOM_EVENTS_PER_SEED) {
+                randomizedEvent(random, seed)
+            }
+
+            events.forEachIndexed { index, event ->
+                clock.advanceBy(random.nextLong(0L, 500L))
+                transport.warm = random.nextBoolean()
+                if (index > 0 && index % 17 == 0) {
+                    controller.setReconnectLadder(randomizedLadder(random))
+                }
+                controller.submit(event)
+            }
+
+            assertEquals(
+                "seed=$seed: exactly one physical clock read per submit",
+                callsAfterConstruct + events.size,
+                clock.calls,
+            )
+
+            val lines = journal.entries.mapIndexed { envelopeSequence, entry ->
+                encodeEnvelope(envelopeSequence.toLong() + 1L, entry)
+            }
+            val report = ConnectionJournalReplay.replay(lines)
+            val expectedSubmits = journal.entries.filterIsInstance<ConnectionJournalEntry.Submit>()
+
+            assertEquals("seed=$seed: every submit replayed", expectedSubmits.size, report.submitCount)
+            assertEquals(
+                "seed=$seed: post-state trail",
+                expectedSubmits.map { it.postState },
+                report.postStateTrail,
+            )
+            assertEquals(
+                "seed=$seed: hidden episode checkpoint trail",
+                expectedSubmits.map { it.internals },
+                report.internalsTrail,
+            )
+
+            val document = lines.joinToString("\n")
+            assertFalse("raw host identity leaked for seed=$seed", document.contains("alexey@field-host"))
+            assertFalse("raw path-derived session leaked for seed=$seed", document.contains("/srv/private"))
+            assertTrue("journal must carry equality-preserving sha256 identities", document.contains("sha256:"))
+        }
+    }
+
+    @Test
+    fun `replay hard fails when controller local submit sequence has a gap`() {
+        val clock = CountingClock()
+        val transport = ScriptableWarmTransport()
+        val journal = RecordingConnectionJournal()
+        val controller = ConnectionController(clock, transport, random = Random(7), journal = journal)
+        controller.submit(ConnectionEvent.Enter(HOST_A, SESSION_A))
+        controller.submit(ConnectionEvent.Background)
+        controller.submit(ConnectionEvent.Foreground)
+
+        val lines = journal.entries
+            .filterNot { it is ConnectionJournalEntry.Submit && it.journalSeq == 2L }
+            .mapIndexed { index, entry -> encodeEnvelope(index.toLong() + 1L, entry) }
+
+        val thrown = assertThrows(IllegalArgumentException::class.java) {
+            ConnectionJournalReplay.replay(lines)
+        }
+        assertTrue(thrown.message.orEmpty().contains("journalSeq gap"))
+        assertTrue(thrown.message.orEmpty().contains("expected=2"))
+        assertTrue(thrown.message.orEmpty().contains("actual=3"))
+    }
+
+    @Test
+    fun `scripted random replays narrow integer buckets at a jitter band edge`() {
+        val journal = RecordingConnectionJournal()
+        ConnectionController(
+            clock = CountingClock(),
+            transport = ScriptableWarmTransport(),
+            reconnectLadderMs = listOf(0L, 101L),
+            random = object : Random() {
+                override fun nextBits(bitCount: Int): Int = (1 shl bitCount) - 1
+            },
+            journal = journal,
+        )
+        val construct = journal.entries.single() as ConnectionJournalEntry.Construct
+        assertEquals(
+            "101ms + just under 20% lands in the narrow [121.0, 121.2) bucket",
+            listOf(0L, 121L),
+            construct.jitteredLadderMs,
+        )
+
+        val report = ConnectionJournalReplay.replay(
+            journal.entries.mapIndexed { index, entry ->
+                encodeEnvelope(index.toLong() + 1L, entry)
+            },
+        )
+        assertEquals(0, report.submitCount)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `same-thread reentrant submits journal outer then inner and replay exactly`() = runTest {
+        val clock = CountingClock()
+        val journal = RecordingConnectionJournal()
+        val controller = ConnectionController(
+            clock = clock,
+            transport = ScriptableWarmTransport(),
+            random = Random(41),
+            journal = journal,
+        )
+        var submittedInner = false
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            controller.state.drop(1).collect { state ->
+                if (state is ConnectionState.Backgrounded && !submittedInner) {
+                    submittedInner = true
+                    controller.submit(ConnectionEvent.TargetGone(SESSION_A))
+                }
+            }
+        }
+
+        controller.submit(ConnectionEvent.Enter(HOST_A, SESSION_A))
+        controller.submit(ConnectionEvent.Background)
+        collector.cancel()
+
+        val submits = journal.entries.filterIsInstance<ConnectionJournalEntry.Submit>()
+        assertEquals(listOf(1L, 2L, 3L), submits.map { it.journalSeq })
+        assertTrue(submits[1].event is ConnectionEvent.Background)
+        assertTrue(submits[1].postState is ConnectionState.Backgrounded)
+        assertTrue(submits[2].event is ConnectionEvent.TargetGone)
+        assertTrue(submits[2].preState is ConnectionState.Backgrounded)
+        assertTrue(submits[2].postState is ConnectionState.Gone)
+        assertEquals("construct plus exactly one read per submit", 4, clock.calls)
+
+        val report = ConnectionJournalReplay.replay(
+            journal.entries.mapIndexed { index, entry ->
+                encodeEnvelope(index.toLong() + 1L, entry)
+            },
+        )
+        assertEquals(3, report.submitCount)
+        assertEquals(submits.map { it.postState }, report.postStateTrail)
+        assertEquals(submits.map { it.internals }, report.internalsTrail)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `ladder install journals before a submit reentered from its restamp publication`() = runTest {
+        val clock = CountingClock()
+        val transport = ScriptableWarmTransport()
+        val journal = RecordingConnectionJournal()
+        val controller = ConnectionController(
+            clock = clock,
+            transport = transport,
+            random = Random(73),
+            journal = journal,
+        )
+        val replacementLadder = listOf(0L, 9_000L, 18_000L, 27_000L)
+        var restampArmed = false
+        var submittedInner = false
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            controller.state.drop(1).collect { state ->
+                if (
+                    restampArmed &&
+                    !submittedInner &&
+                    state is ConnectionState.Reconnecting &&
+                    state.maxAttempts == replacementLadder.size
+                ) {
+                    submittedInner = true
+                    controller.submit(ConnectionEvent.ReconnectFailed)
+                }
+            }
+        }
+
+        transport.warm = false
+        controller.submit(ConnectionEvent.Enter(HOST_A, SESSION_A))
+        transport.warm = true
+        controller.submit(ConnectionEvent.TransportLive)
+        controller.submit(ConnectionEvent.SeedLanded(SESSION_A, "%0"))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("reader_eof")))
+        controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("reader_eof")))
+        assertTrue(controller.state.value is ConnectionState.Reconnecting)
+
+        restampArmed = true
+        controller.setReconnectLadder(replacementLadder)
+        collector.cancel()
+        assertTrue("the restamp observer must synchronously submit", submittedInner)
+
+        val installIndex = journal.entries.indexOfFirst {
+            it is ConnectionJournalEntry.LadderInstall && it.baseLadderMs == replacementLadder
+        }
+        val nestedSubmitIndex = journal.entries.indexOfFirst {
+            it is ConnectionJournalEntry.Submit && it.event is ConnectionEvent.ReconnectFailed
+        }
+        assertTrue("replacement ladder_install must be present", installIndex >= 0)
+        assertTrue("nested reconnect-failed submit must be present", nestedSubmitIndex >= 0)
+        assertTrue(
+            "ladder_install must precede the nested submit that already uses it: " +
+                journal.entries.joinToString { it::class.simpleName.orEmpty() },
+            installIndex < nestedSubmitIndex,
+        )
+
+        val report = ConnectionJournalReplay.replay(
+            journal.entries.mapIndexed { index, entry ->
+                encodeEnvelope(index.toLong() + 1L, entry)
+            },
+        )
+        val submits = journal.entries.filterIsInstance<ConnectionJournalEntry.Submit>()
+        assertEquals(submits.size, report.submitCount)
+        assertEquals(submits.map { it.postState }, report.postStateTrail)
+        assertEquals(submits.map { it.internals }, report.internalsTrail)
+    }
+
+    private fun exhaustivePrefix(seed: Int): List<ConnectionEvent> {
+        val session = if (seed % 2 == 0) SESSION_A else SESSION_B
+        return listOf(
+            ConnectionEvent.Enter(HOST_A, session),
+            ConnectionEvent.Switch(SESSION_B),
+            ConnectionEvent.Foreground,
+            ConnectionEvent.Background,
+            ConnectionEvent.TransportDropped(DropCause.SelfInflicted("force_refresh")),
+            ConnectionEvent.TransportDropped(DropCause.RemoteFailure("lease_down:reader_eof")),
+            ConnectionEvent.TransportDropped(DropCause.KeepaliveDead),
+            ConnectionEvent.TransportDropped(DropCause.Unknown),
+            ConnectionEvent.TransportLive,
+            ConnectionEvent.NetworkChanged(validatedHandoff = false),
+            ConnectionEvent.NetworkChanged(validatedHandoff = true),
+            ConnectionEvent.NetworkLost,
+            ConnectionEvent.NetworkRestored,
+            ConnectionEvent.TargetGone(SESSION_A),
+            ConnectionEvent.SeedLanded(SESSION_B, "%1"),
+            ConnectionEvent.ReconnectLadderEntered,
+            ConnectionEvent.ReconnectFailed,
+            ConnectionEvent.ReconnectGaveUp,
+        )
+    }
+
+    private fun randomizedEvent(random: Random, seed: Int): ConnectionEvent =
+        when (random.nextInt(18)) {
+            0 -> ConnectionEvent.Enter(if (random.nextBoolean()) HOST_A else HOST_B, randomSession(random))
+            1 -> ConnectionEvent.Switch(randomSession(random))
+            2 -> ConnectionEvent.Foreground
+            3 -> ConnectionEvent.Background
+            4 -> ConnectionEvent.TransportDropped(DropCause.SelfInflicted("idle_reap"))
+            5 -> ConnectionEvent.TransportDropped(DropCause.RemoteFailure("lease_down:reader_eof"))
+            6 -> ConnectionEvent.TransportDropped(DropCause.KeepaliveDead)
+            7 -> ConnectionEvent.TransportDropped(DropCause.Unknown)
+            8 -> ConnectionEvent.TransportLive
+            9 -> ConnectionEvent.NetworkChanged(random.nextBoolean())
+            10 -> ConnectionEvent.NetworkLost
+            11 -> ConnectionEvent.NetworkRestored
+            12 -> ConnectionEvent.TargetGone(randomSession(random))
+            13 -> ConnectionEvent.SeedLanded(randomSession(random), "%${random.nextInt(4)}")
+            14 -> ConnectionEvent.ReconnectLadderEntered
+            15 -> ConnectionEvent.ReconnectFailed
+            16 -> ConnectionEvent.ReconnectGaveUp
+            else -> ConnectionEvent.Enter(HOST_A, SessionId("/srv/private/property-$seed"))
+        }
+
+    private fun randomSession(random: Random): SessionId =
+        if (random.nextBoolean()) SESSION_A else SESSION_B
+
+    private fun randomizedLadder(random: Random): List<Long> =
+        listOf(0L) + List(5) { random.nextLong(100L, 5_000L) }
+
+    private fun encodeEnvelope(sequence: Long, entry: ConnectionJournalEntry): String {
+        val metadata = JSONObject()
+        ConnectionJournalSchema.metadata(entry).forEach { (key, value) ->
+            metadata.put(key, JSONObject.wrap(value))
+        }
+        return JSONObject()
+            .put("sequence", sequence)
+            .put("wallClockTime", "2026-07-24T12:00:00Z")
+            .put("monotonicTimestampNanos", sequence * 1_000L)
+            .put("category", ConnectionJournalSchema.CATEGORY)
+            .put("name", ConnectionJournalSchema.name(entry))
+            .put("versionName", "0.4.39")
+            .put("versionCode", 86)
+            .put("metadata", metadata)
+            .toString()
+    }
+
+    private class CountingClock : Clock {
+        private var now: Long = 1_000L
+        var calls: Int = 0
+            private set
+
+        override fun nowMs(): Long {
+            calls++
+            return now
+        }
+
+        fun advanceBy(deltaMs: Long) {
+            now += deltaMs
+        }
+    }
+
+    private class ScriptableWarmTransport : TransportPort {
+        var warm: Boolean = false
+        override fun isWarm(host: HostKey): Boolean = warm
+        override val transportEvents = kotlinx.coroutines.flow.emptyFlow<TransportUpDown>()
+    }
+
+    private companion object {
+        const val PROPERTY_SEEDS = 40
+        const val RANDOM_EVENTS_PER_SEED = 80
+        val HOST_A = HostKey("alexey@field-host.example:22")
+        val HOST_B = HostKey("alexey@backup-field-host.example:2202")
+        val SESSION_A = SessionId("/srv/private/project-alpha")
+        val SESSION_B = SessionId("/srv/private/project-beta")
+    }
+}

--- a/shared/core-connection/src/testDebug/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultDebugTest.kt
+++ b/shared/core-connection/src/testDebug/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultDebugTest.kt
@@ -43,7 +43,7 @@ class ConnectionControllerConfinementDefaultDebugTest {
         val insideMutation = CountDownLatch(1)
         val releaseMutation = CountDownLatch(1)
         val blockingClock = object : Clock {
-            @Volatile var blockOnce = true
+            @Volatile var blockOnce = false
             override fun nowMs(): Long {
                 if (blockOnce) {
                     blockOnce = false
@@ -56,6 +56,9 @@ class ConnectionControllerConfinementDefaultDebugTest {
         // Default constructor: confinementAssertionsEnabled defaults to BuildConfig.DEBUG.
         val controller = ConnectionController(clock = blockingClock, transport = FakeTransportPort())
         controller.submit(ConnectionEvent.Enter(host, target))
+        // #1709 reads the clock once at every submit boundary. Arm only after
+        // the setup Enter so the latch still blocks inside Background.
+        blockingClock.blockOnce = true
 
         val threadA = Thread { controller.submit(ConnectionEvent.Background) }
         threadA.start()

--- a/shared/core-connection/src/testRelease/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultReleaseTest.kt
+++ b/shared/core-connection/src/testRelease/java/com/pocketshell/core/connection/ConnectionControllerConfinementDefaultReleaseTest.kt
@@ -39,7 +39,7 @@ class ConnectionControllerConfinementDefaultReleaseTest {
         val insideMutation = CountDownLatch(1)
         val releaseMutation = CountDownLatch(1)
         val blockingClock = object : Clock {
-            @Volatile var blockOnce = true
+            @Volatile var blockOnce = false
             override fun nowMs(): Long {
                 if (blockOnce) {
                     blockOnce = false
@@ -52,6 +52,7 @@ class ConnectionControllerConfinementDefaultReleaseTest {
         // Default constructor: confinementAssertionsEnabled defaults to BuildConfig.DEBUG.
         val controller = ConnectionController(clock = blockingClock, transport = FakeTransportPort())
         controller.submit(ConnectionEvent.Enter(host, target))
+        blockingClock.blockOnce = true
 
         val threadA = Thread { controller.submit(ConnectionEvent.Background) }
         threadA.start()


### PR DESCRIPTION
Closes #1709

## Summary
- journal construct, ladder-install, and submit checkpoints with privacy-safe identities
- write a separate capped, non-mirrored connection journal archive
- replay captured JSONL deterministically with scripted clock, transport, and jitter
- preserve exact ordering across synchronous submit and ladder-install reentrancy

## Verification
- independent gap/order mutations: RED; byte-exact restore: GREEN
- randomized replay stress: 100/100
- core debug/release: 169/169 each
- app storage + reconnect focused variants: 22/22 each
- full unfiltered suite: 11,186 tests, 0 failures/errors
- Android-test compile and repository guards: green