### PR TITLE
composer: retain queued attachment bytes during prune

### DIFF
--- a/app/src/main/java/com/pocketshell/app/composer/AttachmentRetentionPolicy.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/AttachmentRetentionPolicy.kt
@@ -24,6 +24,7 @@ internal data class AttachmentRetentionPolicy(
     fun plan(
         entries: List<RemoteEntry>,
         nowMillis: Long,
+        retainedNames: Set<String> = emptySet(),
     ): AttachmentPrunePlan {
         val files = entries
             .asSequence()
@@ -46,6 +47,7 @@ internal data class AttachmentRetentionPolicy(
                 attachment = attachment,
                 newestIndex = index,
                 nowMillis = nowMillis,
+                retainedNames = retainedNames,
             )
         }
         return AttachmentPrunePlan(delete = delete)
@@ -55,7 +57,9 @@ internal data class AttachmentRetentionPolicy(
         attachment: RemoteAttachment,
         newestIndex: Int,
         nowMillis: Long,
+        retainedNames: Set<String>,
     ): Boolean {
+        if (attachment.name in retainedNames) return false
         val ageMillis = nowMillis - attachment.modifiedMillis
         if (ageMillis < protectNewestMillis) return false
 
@@ -89,6 +93,7 @@ internal class RemoteAttachmentPruner(
     suspend fun prune(
         session: SshSession,
         remoteDir: String,
+        retainedNames: Set<String> = emptySet(),
     ) {
         val listing = try {
             session.listDirectory(
@@ -102,7 +107,7 @@ internal class RemoteAttachmentPruner(
             return
         }
 
-        val plan = policy.plan(listing.entries, now())
+        val plan = policy.plan(listing.entries, now(), retainedNames)
         if (plan.delete.isEmpty()) {
             Log.i(
                 LOG_TAG,
@@ -187,4 +192,42 @@ internal class RemoteAttachmentPruner(
                 else -> shellQuoteLiteral(path)
             }
     }
+}
+
+internal fun OutboundQueueStore?.retainedRemoteAttachmentNames(
+    sessionKey: String?,
+    remoteDir: String,
+): Set<String> {
+    if (this == null || sessionKey.isNullOrBlank()) return emptySet()
+    val normalizedDir = normalizeHomeRelativeRemotePath(remoteDir) ?: return emptySet()
+    return itemsFor(sessionKey)
+        .asSequence()
+        .filter { it.state != OutboundState.Delivered }
+        .flatMap { it.attachments.asSequence() }
+        .mapNotNull { ref ->
+            val path = normalizeHomeRelativeRemotePath(ref.remotePath) ?: return@mapNotNull null
+            val separator = path.lastIndexOf('/')
+            if (separator <= 0 || path.substring(0, separator) != normalizedDir) {
+                return@mapNotNull null
+            }
+            path.substring(separator + 1).takeIf { it.isNotBlank() }
+        }
+        .toSet()
+}
+
+private fun normalizeHomeRelativeRemotePath(path: String): String? {
+    val trimmed = path.trim()
+    val relative = when {
+        trimmed == "~" -> ""
+        trimmed.startsWith("~/") -> trimmed.removePrefix("~/")
+        trimmed.startsWith("/") || trimmed.startsWith("~") -> return null
+        else -> trimmed
+    }
+    val segments = relative.split('/')
+    // Staged attachment paths never require parent traversal. Reject alternate
+    // spellings rather than allowing them to pin a different remote object.
+    if (".." in segments) return null
+    return segments
+        .filter { it.isNotEmpty() && it != "." }
+        .joinToString("/")
 }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptAttachmentStager.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptAttachmentStager.kt
@@ -40,6 +40,7 @@ internal class PromptAttachmentStager(
         session: SshSession,
         scopeKey: String,
         uris: List<Uri>,
+        retainedAttachmentNames: (remoteDir: String) -> Set<String> = { emptySet() },
     ): Result<List<String>> = withContext(Dispatchers.IO) {
         if (uris.isEmpty()) return@withContext Result.success(emptyList())
         if (!session.isConnected) {
@@ -136,7 +137,13 @@ internal class PromptAttachmentStager(
         // remote dir now has fresh files worth trimming. A prune failure is
         // already swallowed inside the pruner; never let it fail the stage.
         if (uploadedPaths.isNotEmpty()) {
-            runCatching { attachmentPruner.prune(session, remoteDir) }
+            runCatching {
+                attachmentPruner.prune(
+                    session = session,
+                    remoteDir = remoteDir,
+                    retainedNames = retainedAttachmentNames(remoteDir),
+                )
+            }
         }
 
         when {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -27,6 +27,7 @@ import com.pocketshell.app.conversation.ConversationDiagnostics
 import com.pocketshell.app.crash.CrashReporter
 import com.pocketshell.app.composer.LocalAttachmentSidecarRef
 import com.pocketshell.app.composer.PromptAttachmentStager
+import com.pocketshell.app.composer.retainedRemoteAttachmentNames
 import com.pocketshell.app.connectivity.TerminalNetworkChange
 import com.pocketshell.app.connectivity.networkDiagnosticFields
 import com.pocketshell.app.diagnostics.DiagnosticEvents
@@ -9063,6 +9064,8 @@ public class TmuxSessionViewModel @Inject constructor(
         sessionName: String,
         client: TmuxClient,
         session: SshSession? = null,
+        tmuxSessionId: String? = null,
+        sessionCreated: Long? = null,
     ) {
         val target = ConnectionTarget(
             hostId = hostId,
@@ -9074,24 +9077,12 @@ public class TmuxSessionViewModel @Inject constructor(
             passphrase = null,
             sessionName = sessionName,
             startDirectory = null,
+            tmuxSessionId = tmuxSessionId,
+            sessionCreated = sessionCreated,
         )
-        // Issue #1085 (F2) test isolation: tear the OLD connection down
-        // SYNCHRONOUSLY for this test seam. `closeCurrentConnection`'s
-        // production caller (`onCleared`) defers the slow detach/close off the
-        // Main thread (the F2 fix), but callers of this synchronous seam assert
-        // the replaced client is closed the instant the seam returns (e.g.
-        // `replacingClientClosesOldClientAndUpdatesRegistry` checks
-        // `oldClient.closed`). `deferTeardown = false` runs the same teardown
-        // body inline so the seam keeps its synchronous contract — independent
-        // of whichever teardown scope a test injected.
+        // #1085: this synchronous test seam must close the replaced client before returning.
         closeCurrentConnection(deferTeardown = false)
-        // Issue #178: tests for the same-host fast-switch path need a
-        // way to inject a live `SshSession` into the VM so a follow-up
-        // `connect()` to the same host re-uses it instead of going
-        // through the SSH-handshake path (which requires a real
-        // network). Production callers go through `runConnect` /
-        // `runFastSessionSwitch` — those wire the session ref
-        // themselves.
+        // #178: inject a live session so same-host switch tests reuse it without a handshake.
         if (session != null) {
             sessionRef = session
         }
@@ -13517,6 +13508,9 @@ public class TmuxSessionViewModel @Inject constructor(
             null -> "tmux-session"
             else -> "host-${originTarget.hostId}-${originTarget.sessionName}"
         }
+        val queueSessionKey = originTarget?.let {
+            tmuxTargetSessionId(it.hostId, it.sessionName, it.tmuxSessionId, it.sessionCreated).value
+        }
         // Issue #451: the system file picker backgrounds the app while the
         // user selects a file. Attach now behaves like Send: on a
         // not-currently-live session it lazily connects-then-uploads instead
@@ -13554,18 +13548,17 @@ public class TmuxSessionViewModel @Inject constructor(
                 ),
             )
         }
-        // Issue #1072: OWN the upload as a [viewModelScope] job so a connection
-        // teardown ([closeCurrentConnectionAndJoin]) can cancel-and-join it BEFORE
-        // it drops the transport, instead of leaving a free-floating writer blocked
-        // on the dying `-CC` session that races teardown and wedges reconnect. We
-        // run it in viewModelScope (a SupervisorJob) rather than the caller's
-        // screen scope so a screen recomposition does not abandon the upload, and
-        // the VM stays the single owner that the reconnect ladder coordinates with.
+        // #1072: the VM owns the upload so teardown can cancel-and-join it
+        // before dropping the transport; screen recomposition cannot orphan it.
         val stager = PromptAttachmentStager(
             resolver = context.contentResolver,
             cacheDir = context.cacheDir,
         )
-        val uploadDeferred = viewModelScope.async { stager.stage(session, scopeKey, uris) }
+        val uploadDeferred = viewModelScope.async {
+            stager.stage(session, scopeKey, uris) { remoteDir ->
+                outboundQueueStore.retainedRemoteAttachmentNames(queueSessionKey, remoteDir)
+            }
+        }
         attachmentUploadJob = uploadDeferred
         val result = try {
             uploadDeferred.await()

--- a/app/src/test/java/com/pocketshell/app/composer/AttachmentQueueRetentionProjectionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/AttachmentQueueRetentionProjectionTest.kt
@@ -1,0 +1,102 @@
+package com.pocketshell.app.composer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class AttachmentQueueRetentionProjectionTest {
+
+    @Test
+    fun issue1548_allUndeliveredStatesRetainExactDirectoryButDeliveredDoesNot() {
+        val store = InMemoryOutboundQueueStore()
+        OutboundState.entries.forEachIndexed { index, state ->
+            store.enqueueExisting(
+                OutboundItem(
+                    id = "row-$state",
+                    sessionKey = DURABLE_SESSION_KEY,
+                    cleanText = state.name,
+                    attachments = listOf(
+                        DurableAttachmentRef(
+                            remotePath = pathFor(state),
+                            displayName = "${state.name.lowercase()}.png",
+                            mimeType = "image/png",
+                        ),
+                    ),
+                    state = state,
+                    createdAtMs = index.toLong(),
+                ),
+            )
+        }
+
+        assertEquals(
+            setOf("queued.png", "uploading.png", "inflight.png", "failed.png"),
+            store.retainedRemoteAttachmentNames(DURABLE_SESSION_KEY, CURRENT_DIR),
+        )
+    }
+
+    @Test
+    fun issue1548_sameBasenameInAnotherDirectoryDoesNotPinCurrentDirectory() {
+        val store = InMemoryOutboundQueueStore()
+        store.enqueue(
+            sessionKey = DURABLE_SESSION_KEY,
+            cleanText = "send other scope",
+            attachments = listOf(
+                DurableAttachmentRef(
+                    remotePath = "~/$OTHER_DIR/shared.png",
+                    displayName = "shared.png",
+                    mimeType = "image/png",
+                ),
+            ),
+            createdAtMs = 1L,
+        )
+
+        assertFalse(
+            "a reference in $OTHER_DIR must not pin $CURRENT_DIR/shared.png",
+            "shared.png" in store.retainedRemoteAttachmentNames(DURABLE_SESSION_KEY, CURRENT_DIR),
+        )
+    }
+
+    @Test
+    fun issue1548_absoluteAndTraversalPathsCannotPinCurrentDirectory() {
+        val store = InMemoryOutboundQueueStore()
+        listOf(
+            "/home/alex/$CURRENT_DIR/absolute.png",
+            "../$CURRENT_DIR/escaping.png",
+            "${CURRENT_DIR.substringBeforeLast('/')}/other/../" +
+                "${CURRENT_DIR.substringAfterLast('/')}/interior.png",
+        ).forEachIndexed { index, remotePath ->
+            store.enqueue(
+                sessionKey = DURABLE_SESSION_KEY,
+                cleanText = "unsafe path $index",
+                attachments = listOf(
+                    DurableAttachmentRef(
+                        remotePath = remotePath,
+                        displayName = remotePath.substringAfterLast('/'),
+                        mimeType = "image/png",
+                    ),
+                ),
+                createdAtMs = index.toLong(),
+            )
+        }
+
+        assertEquals(
+            "production-generated attachment paths never need parent traversal",
+            emptySet<String>(),
+            store.retainedRemoteAttachmentNames(DURABLE_SESSION_KEY, CURRENT_DIR),
+        )
+    }
+
+    private fun pathFor(state: OutboundState): String = when (state) {
+        OutboundState.Queued -> "~/$CURRENT_DIR/queued.png"
+        OutboundState.Uploading -> "$CURRENT_DIR/uploading.png"
+        OutboundState.InFlight -> "./$CURRENT_DIR/inflight.png"
+        OutboundState.Failed -> "~/$CURRENT_DIR/./failed.png"
+        OutboundState.Delivered -> "~/$CURRENT_DIR/delivered.png"
+    }
+
+    private companion object {
+        const val DURABLE_SESSION_KEY = "tmux:41:\$9:1700000000"
+        const val CURRENT_DIR = ".pocketshell/attachments/host-41-current"
+        const val OTHER_DIR = ".pocketshell/attachments/host-41-other"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/AttachmentRetentionPolicyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/AttachmentRetentionPolicyTest.kt
@@ -67,6 +67,42 @@ class AttachmentRetentionPolicyTest {
     }
 
     @Test
+    fun retainedNameSurvivesIndependentTtlDeletionWhileUnreferencedPeerIsDeleted() {
+        val now = 10_000_000_000L
+        val plan = AttachmentRetentionPolicy().plan(
+            entries = listOf(
+                file("referenced.txt", now - days(8)),
+                file("unreferenced.txt", now - days(8)),
+            ),
+            nowMillis = now,
+            retainedNames = setOf("referenced.txt"),
+        )
+
+        assertEquals(listOf("unreferenced.txt"), plan.delete.map { it.name })
+    }
+
+    @Test
+    fun retainedNameSurvivesNewestCapWhileUnreferencedPeerIsDeleted() {
+        val now = 10_000_000_000L
+        val policy = AttachmentRetentionPolicy(
+            ttlMillis = days(7),
+            keepNewest = 1,
+            protectNewestMillis = days(1),
+        )
+        val plan = policy.plan(
+            entries = listOf(
+                file("fresh.txt", now - hours(1)),
+                file("referenced.txt", now - days(2)),
+                file("unreferenced.txt", now - days(2)),
+            ),
+            nowMillis = now,
+            retainedNames = setOf("referenced.txt"),
+        )
+
+        assertEquals(listOf("unreferenced.txt"), plan.delete.map { it.name })
+    }
+
+    @Test
     fun entriesWithoutMtimeAndNonFilesAreNeverDeleted() {
         val now = 10_000_000_000L
         val plan = AttachmentRetentionPolicy().plan(

--- a/app/src/test/java/com/pocketshell/app/tmux/AttachmentQueueRetentionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AttachmentQueueRetentionTest.kt
@@ -1,0 +1,334 @@
+package com.pocketshell.app.tmux
+
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.DurableAttachmentRef
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import com.pocketshell.app.composer.OutboundItem
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.RemoteEntry
+import com.pocketshell.core.ssh.RemoteListing
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Issue #1548: upload-triggered pruning must retain remote bytes referenced by
+ * an undelivered durable outbound row after the 24-hour safety window expires.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class AttachmentQueueRetentionTest {
+
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @After
+    fun tearDown() {
+        factoryScope.cancel()
+    }
+
+    @Test
+    fun issue1548_uploadPruneRetainsOldQueuedAttachmentBytesAndDeletesOldUnreferencedPeer() =
+        runVmTest {
+            val now = System.currentTimeMillis()
+            val remoteDir = ".pocketshell/attachments/host-41-alpha"
+            val referencedPath = "~/$remoteDir/referenced.png"
+            val capPeerPath = "~/$remoteDir/cap-peer.png"
+            val ttlPeerPath = "~/$remoteDir/ttl-peer.png"
+            val deliveredPath = "~/$remoteDir/delivered.png"
+            val collisionPath = "~/$remoteDir/shared.png"
+            val otherCollisionPath = "~/.pocketshell/attachments/host-41-other/shared.png"
+            val referencedBytes = "durable queued attachment".toByteArray()
+            val otherCollisionBytes = "other directory".toByteArray()
+            val store = InMemoryOutboundQueueStore()
+            val row = store.enqueue(
+                sessionKey = DURABLE_SESSION_KEY,
+                cleanText = "inspect this",
+                attachments = listOf(
+                    DurableAttachmentRef(
+                        remotePath = referencedPath,
+                        displayName = "referenced.png",
+                        mimeType = "image/png",
+                    ),
+                ),
+                createdAtMs = now - days(2),
+                paneId = "%1",
+                route = OutboundRoute.AgentPayload,
+            )
+            val retainedByState = listOf(
+                OutboundState.Uploading,
+                OutboundState.InFlight,
+                OutboundState.Failed,
+            ).associateWith { state ->
+                val path = "~/$remoteDir/${state.name.lowercase()}.png"
+                val queued = store.enqueue(
+                    sessionKey = DURABLE_SESSION_KEY,
+                    cleanText = state.name,
+                    attachments = listOf(DurableAttachmentRef(path, path.substringAfterLast('/'))),
+                    createdAtMs = now - days(8),
+                )
+                when (state) {
+                    OutboundState.Uploading -> store.markUploading(queued.id)!!
+                    OutboundState.InFlight -> store.markInFlight(queued.id)!!
+                    OutboundState.Failed -> store.markFailed(queued.id, "offline")!!
+                    else -> error("unexpected state $state")
+                }
+                path
+            }
+            store.enqueueExisting(
+                OutboundItem(
+                    id = "delivered-row",
+                    sessionKey = DURABLE_SESSION_KEY,
+                    cleanText = "already sent",
+                    attachments = listOf(DurableAttachmentRef(deliveredPath, "delivered.png")),
+                    state = OutboundState.Delivered,
+                    createdAtMs = now - days(8),
+                ),
+            )
+            store.enqueue(
+                sessionKey = DURABLE_SESSION_KEY,
+                cleanText = "other scope",
+                attachments = listOf(
+                    DurableAttachmentRef(
+                        "~/.pocketshell/attachments/host-41-other/shared.png",
+                        "shared.png",
+                    ),
+                ),
+                createdAtMs = now - days(8),
+            )
+            val session = RetentionSshSession(now).apply {
+                seed(remoteDir, "referenced.png", referencedBytes, now - days(2))
+                seed(remoteDir, "cap-peer.png", "cap peer".toByteArray(), now - days(2))
+                seed(remoteDir, "ttl-peer.png", "ttl peer".toByteArray(), now - days(8))
+                seed(remoteDir, "delivered.png", "delivered".toByteArray(), now - days(8))
+                seed(remoteDir, "shared.png", "unrelated".toByteArray(), now - days(8))
+                seed(
+                    ".pocketshell/attachments/host-41-other",
+                    "shared.png",
+                    otherCollisionBytes,
+                    now - days(8),
+                )
+                retainedByState.forEach { (state, path) ->
+                    seed(remoteDir, path.substringAfterLast('/'), state.name.toByteArray(), now - days(8))
+                }
+                repeat(20) { index ->
+                    seed(
+                        remoteDir,
+                        "fresh-$index.png",
+                        byteArrayOf(index.toByte()),
+                        now - minutes(index + 1L),
+                    )
+                }
+            }
+            val vm = newVm(store)
+            vm.replaceClientForTest(
+                hostId = HOST_ID,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "alpha",
+                client = FakeTmuxClient(),
+                session = session,
+                tmuxSessionId = TMUX_SESSION_ID,
+                sessionCreated = SESSION_CREATED,
+            )
+
+            val incoming = File.createTempFile(
+                "issue1548-new-",
+                ".png",
+                ApplicationProvider.getApplicationContext<android.content.Context>().cacheDir,
+            ).apply { writeBytes("new upload".toByteArray()) }
+            val staged = vm.stagePromptAttachments(listOf(Uri.fromFile(incoming)))
+
+            assertTrue("the upload that triggers prune must succeed: $staged", staged.isSuccess)
+            val deliverable = store.claim(row.id)
+            assertNotNull("the durable queue row must remain claimable after prune", deliverable)
+            assertArrayEquals(
+                "the claimed row must still resolve to its original remote bytes after >24h prune",
+                referencedBytes,
+                session.read(deliverable!!.attachments.single().remotePath),
+            )
+            retainedByState.forEach { (state, path) ->
+                assertArrayEquals(
+                    "$state attachment must survive the independent >7-day TTL branch",
+                    state.name.toByteArray(),
+                    session.read(path),
+                )
+            }
+            assertNull(
+                "an equally-old unreferenced attachment outside the newest cap must be pruned",
+                session.read(capPeerPath),
+            )
+            assertNull(
+                "an unreferenced attachment older than seven days must be pruned by TTL",
+                session.read(ttlPeerPath),
+            )
+            assertNull(
+                "a Delivered row must not retain its remote bytes",
+                session.read(deliveredPath),
+            )
+            assertNull(
+                "the same basename referenced in another directory must not pin this object",
+                session.read(collisionPath),
+            )
+            assertArrayEquals(
+                "pruning the current directory must not delete the same basename elsewhere",
+                otherCollisionBytes,
+                session.read(otherCollisionPath),
+            )
+        }
+
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        try {
+            body()
+        } finally {
+            LivenessProbeTestOverride.clear()
+            Dispatchers.resetMain()
+        }
+    }
+
+    private fun TestScope.newVm(store: InMemoryOutboundQueueStore): TmuxSessionViewModel =
+        TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = ActiveTmuxClients(),
+            runtimeCache = TmuxSessionRuntimeCache(),
+            sshLeaseManager = SshLeaseManager(
+                connector = SshLeaseConnector { target ->
+                    error("unexpected SSH lease connect for ${target.leaseKey}")
+                },
+                idleTtlMillis = 0L,
+                connectTimeoutContext = StandardTestDispatcher(testScheduler),
+                nowMillis = { testScheduler.currentTime },
+            ),
+            sessionLifecycleSignals = null,
+            applicationContext = ApplicationProvider.getApplicationContext(),
+            outboundQueueStore = store,
+        ).also {
+            it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+        }
+
+    private class RetentionSshSession(private val nowMillis: Long) : SshSession {
+        private data class RemoteFile(
+            val bytes: ByteArray,
+            val modifiedMillis: Long,
+        )
+
+        private val files = ConcurrentHashMap<String, RemoteFile>()
+        @Volatile
+        private var connected = true
+
+        override val isConnected: Boolean get() = connected
+
+        fun seed(remoteDir: String, name: String, bytes: ByteArray, modifiedMillis: Long) {
+            files["$remoteDir/$name"] = RemoteFile(bytes, modifiedMillis)
+        }
+
+        fun read(displayPath: String): ByteArray? =
+            files[displayPath.removePrefix("~/")]?.bytes
+
+        override suspend fun exec(command: String): ExecResult {
+            if (!command.startsWith("rm -f -- ")) {
+                return ExecResult(stdout = "", stderr = "", exitCode = 0)
+            }
+            val exactTargets = Regex("""~/'([^']*)'""")
+                .findAll(command)
+                .map { match -> match.groupValues[1] }
+                .toSet()
+            val deleted = exactTargets.count { path -> files.remove(path) != null }
+            return ExecResult(stdout = "deleted\t$deleted\n", stderr = "", exitCode = 0)
+        }
+
+        override suspend fun listDirectory(remotePath: String, maxEntries: Int): RemoteListing {
+            val dir = remotePath.removePrefix("~/").trimEnd('/')
+            val entries = files.entries
+                .asSequence()
+                .filter { (path, _) -> path.substringBeforeLast('/') == dir }
+                .map { (path, file) ->
+                    RemoteEntry(
+                        name = path.substringAfterLast('/'),
+                        type = RemoteEntry.Type.FILE,
+                        sizeBytes = file.bytes.size.toLong(),
+                        modifiedEpochSec = file.modifiedMillis / 1_000L,
+                    )
+                }
+                .sortedBy { it.name }
+                .take(maxEntries)
+                .toList()
+            return RemoteListing(entries = entries, truncated = entries.size < files.size)
+        }
+
+        override suspend fun uploadFile(file: File, remotePath: String): String {
+            files[remotePath] = RemoteFile(file.readBytes(), nowMillis)
+            return remotePath
+        }
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String {
+            files[remotePath] = RemoteFile(input.readBytes(), nowMillis)
+            return remotePath
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override fun close() {
+            connected = false
+        }
+    }
+
+    private companion object {
+        const val HOST_ID = 41L
+        const val TMUX_SESSION_ID = "\$9"
+        const val SESSION_CREATED = 1_700_000_000L
+        const val DURABLE_SESSION_KEY = "tmux:$HOST_ID:$TMUX_SESSION_ID:$SESSION_CREATED"
+
+        fun days(value: Long): Long = value * 24L * 60L * 60L * 1_000L
+        fun minutes(value: Long): Long = value * 60L * 1_000L
+    }
+}


### PR DESCRIPTION
Closes #1548

## Summary
- retain exact remote attachment names referenced by every undelivered durable queue state
- require the durable tmux session identity and exact normalized attachment directory
- keep referenced bytes across both TTL and newest-cap pruning while preserving deletion of unreferenced and delivered objects
- harden the regression fixture to delete exact remote paths rather than basename-globally

## Verification
- reproduce-first queue-byte and cross-directory mutations: RED
- independent reviewer mutations: RED, byte-exact restore
- focused debug/release matrix: 14/14 each
- full unfiltered suite: 603/603 tasks, 0 failures/errors
- Android-test compile: 176/176 tasks
- rebased orchestrator gate: focused 14/14, Android compile 176/176, VM/file-size/workflow guards green
- independent review: APPROVED