### PR TITLE
diagnostics: mirror connection journal on demand

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionJournalHostPullJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionJournalHostPullJourneyDockerTest.kt
@@ -1,0 +1,526 @@
+package com.pocketshell.app.diagnostics
+
+import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.App
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.SeedBeforeLaunchRule
+import com.pocketshell.app.proof.TerminalTestTimeouts
+import com.pocketshell.app.proof.clearLastSessionPrefs
+import com.pocketshell.app.proof.execRemoteSetupUntilReady
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.settings.DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_FEEDBACK_TAG
+import com.pocketshell.app.settings.DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_TAG
+import com.pocketshell.app.settings.SETTINGS_LAZY_COLUMN_TAG
+import com.pocketshell.app.settings.HostDetailViewMode
+import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.app.test.testArtifactsRoot
+import com.pocketshell.app.tmux.SSH_HANDSHAKE_ATTEMPTS
+import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_MORE_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_FULL_CHROME_MORE_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SETTINGS_BUTTON_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.connection.ConnectionJournalSchema
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.security.MessageDigest
+
+/**
+ * Issue #1710 real Settings -> held warm SSH session -> fixed host-file journey.
+ * It launches the production activity, opens a real Docker tmux session, and
+ * drives the actual Settings row; no fake writer or lease acquisition seam.
+ */
+@RunWith(AndroidJUnit4::class)
+class ConnectionJournalHostPullJourneyDockerTest {
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+    private lateinit var markerPrefix: String
+
+    @After
+    fun tearDown() {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        clearLastSessionPrefs()
+        if (::fixtureKey.isInitialized) {
+            runCatching { runBlocking { cleanupRemote() } }
+        }
+    }
+
+    @Test
+    fun settingsPullUsesHeldWarmSessionThenNoWarmDoesNoSshWork() {
+        runBlocking {
+            attachSeededSession()
+            val vm = currentViewModel()
+            waitForConnected(vm)
+
+            val app = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext as App
+            app.diagnosticRecorder.clear()
+            val headMarkers = listOf(
+                "$markerPrefix-construct",
+                "$markerPrefix-submit-a",
+                "$markerPrefix-submit-b",
+            )
+            val expectedMarkers = buildList {
+                addAll(headMarkers)
+                repeat(FILLER_ROW_COUNT) { index ->
+                    add("$markerPrefix-filler-$index")
+                }
+            }
+            assertEquals(
+                "precondition: every seeded row has a unique marker",
+                expectedMarkers.size,
+                expectedMarkers.toSet().size,
+            )
+            headMarkers.forEachIndexed { index, marker ->
+                app.diagnosticRecorder.record(
+                    ConnectionJournalSchema.CATEGORY,
+                    if (index == 0) {
+                        ConnectionJournalSchema.CONSTRUCT
+                    } else {
+                        ConnectionJournalSchema.SUBMIT
+                    },
+                    mapOf(
+                        "journalSeq" to index,
+                        "markerValue" to marker,
+                        "paddingValue" to "x".repeat(480),
+                    ),
+                )
+            }
+            // Make the upload large enough that the user-visible Mirroring state is
+            // observable while still staying inside the recorder's bounded channel.
+            repeat(FILLER_ROW_COUNT) { index ->
+                app.diagnosticRecorder.record(
+                    ConnectionJournalSchema.CATEGORY,
+                    ConnectionJournalSchema.SUBMIT,
+                    mapOf(
+                        "journalSeq" to index + headMarkers.size,
+                        "markerValue" to expectedMarkers[index + headMarkers.size],
+                        "paddingValue" to "y".repeat(480),
+                    ),
+                )
+            }
+            val seededArchive = app.diagnosticRecorder.connectionJournalArchive()
+            val seededMarkers = seededArchive
+                .mapNotNull { event -> event.metadata["markerValue"] as? String }
+                .filter(expectedMarkers.toSet()::contains)
+            assertEquals(
+                "precondition: the recorder retained every seeded row in exact order",
+                expectedMarkers,
+                seededMarkers,
+            )
+            val seededJsonl = app.diagnosticRecorder.connectionJournalJsonl()
+            val seededBytes = seededJsonl.toByteArray().size
+            assertTrue(
+                "precondition: the seeded archive must exceed the automatic 64 KiB budget",
+                seededBytes > MIRROR_BUDGET_BYTES,
+            )
+            val seededNewestMarkerOffset = byteOffsetOf(seededJsonl, expectedMarkers.last())
+            assertTrue(
+                "precondition: the newest unique marker must itself begin beyond 64 KiB",
+                seededNewestMarkerOffset > MIRROR_BUDGET_BYTES,
+            )
+            clearRemoteJournal()
+
+            val handshakesBeforeTap = SSH_HANDSHAKE_ATTEMPTS.get()
+            openSettingsFromLiveSession()
+            scrollToJournalRow()
+            compose.onNodeWithTag(
+                DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_TAG,
+                useUnmergedTree = true,
+            ).performClick()
+
+            compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+                compose.onAllNodesWithText(
+                    "Mirroring connection journal...",
+                    useUnmergedTree = true,
+                ).fetchSemanticsNodes().isNotEmpty()
+            }
+            compose.waitUntil(timeoutMillis = UPLOAD_TIMEOUT_MS) {
+                compose.onAllNodesWithText(
+                    SUCCESS_COPY,
+                    useUnmergedTree = true,
+                ).fetchSemanticsNodes().isNotEmpty()
+            }
+            compose.onNodeWithTag(
+                DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_FEEDBACK_TAG,
+                useUnmergedTree = true,
+            ).assertExists()
+
+            assertEquals(
+                "the one-shot action must not initiate another SSH handshake",
+                handshakesBeforeTap,
+                SSH_HANDSHAKE_ATTEMPTS.get(),
+            )
+            assertTrue(
+                "the original held session must remain connected after the upload",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+
+            val landed = readRemoteJournal()
+            val landedLines = landed.lineSequence()
+                .filter(String::isNotBlank)
+                .toList()
+            val decoded = landedLines.mapIndexed { index, line ->
+                requireNotNull(DiagnosticEventJson.decode(line)) {
+                    "host JSONL line ${index + 1} did not decode"
+                }
+            }
+            val landedMarkers = decoded.mapNotNull { it.metadata["markerValue"] as? String }
+            val landedSeededMarkers = landedMarkers.filter(expectedMarkers.toSet()::contains)
+            assertEquals(
+                "host JSONL must contain the exact complete seeded row count",
+                expectedMarkers.size,
+                landedSeededMarkers.size,
+            )
+            assertEquals(
+                "every seeded marker must survive archive render + SCP in exact order",
+                expectedMarkers,
+                landedSeededMarkers,
+            )
+            assertEquals(
+                "oldest unique seeded marker must survive",
+                expectedMarkers.first(),
+                landedSeededMarkers.first(),
+            )
+            assertEquals(
+                "newest unique seeded marker must survive",
+                expectedMarkers.last(),
+                landedSeededMarkers.last(),
+            )
+            val hostPayloadBytes = landed.toByteArray().size
+            assertTrue(
+                "host payload must exceed 64 KiB",
+                hostPayloadBytes > MIRROR_BUDGET_BYTES,
+            )
+            val hostNewestMarkerOffset = byteOffsetOf(landed, expectedMarkers.last())
+            assertTrue(
+                "host newest marker must begin beyond 64 KiB",
+                hostNewestMarkerOffset > MIRROR_BUDGET_BYTES,
+            )
+            val successHash = sha256(landed)
+            val artifactDir = artifactDir()
+            File(artifactDir, "connection-journal.jsonl").writeText(landed)
+            captureFullDevice(File(artifactDir, "settings-journal-success.png"))
+
+            // Remove the activity-scoped VM's held target/lease/session, then drive
+            // the SAME real Settings row. The non-empty archive remains, so this
+            // discriminates NoWarmSession from Empty.
+            vm.closeCurrentConnectionAndJoinForTest()
+            val handshakesBeforeNoWarmTap = SSH_HANDSHAKE_ATTEMPTS.get()
+            compose.onNodeWithTag(
+                DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_TAG,
+                useUnmergedTree = true,
+            ).performClick()
+            compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+                compose.onAllNodesWithText(NO_WARM_COPY, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+            }
+            assertEquals(
+                "no-warm action must not acquire/cold-dial",
+                handshakesBeforeNoWarmTap,
+                SSH_HANDSHAKE_ATTEMPTS.get(),
+            )
+            val unchanged = readRemoteJournal()
+            assertEquals(
+                "no-warm action must not change the host file",
+                successHash,
+                sha256(unchanged),
+            )
+            captureFullDevice(File(artifactDir, "settings-journal-no-warm.png"))
+            captureLogcat(File(artifactDir, "emulator-logcat.txt"))
+            File(artifactDir, "summary.txt").writeText(
+                buildString {
+                    appendLine("issue=1710")
+                    appendLine("fixture=$DEFAULT_HOST:$DEFAULT_PORT")
+                    appendLine("session=$SESSION_NAME")
+                    appendLine("seeded_archive_rows=${seededArchive.size}")
+                    appendLine("seeded_marker_count=${expectedMarkers.size}")
+                    appendLine("seeded_jsonl_bytes=$seededBytes")
+                    appendLine("seeded_newest_marker_byte_offset=$seededNewestMarkerOffset")
+                    appendLine("landed_rows=${decoded.size}")
+                    appendLine("landed_seeded_marker_count=${landedSeededMarkers.size}")
+                    appendLine("oldest_seeded_marker=${expectedMarkers.first()}")
+                    appendLine("newest_seeded_marker=${expectedMarkers.last()}")
+                    appendLine("host_file_bytes=$hostPayloadBytes")
+                    appendLine("host_newest_marker_byte_offset=$hostNewestMarkerOffset")
+                    appendLine("all_landed_lines_decoded=true")
+                    appendLine("exact_seeded_marker_order=true")
+                    appendLine("host_file_sha256=$successHash")
+                    appendLine("handshakes_before_tap=$handshakesBeforeTap")
+                    appendLine("handshakes_after_success=${SSH_HANDSHAKE_ATTEMPTS.get()}")
+                    appendLine("handshakes_before_no_warm_tap=$handshakesBeforeNoWarmTap")
+                    appendLine("original_session_connected_after_success=true")
+                    appendLine("no_warm_file_unchanged=true")
+                },
+            )
+            println("ISSUE1710_ARTIFACT_DIR ${artifactDir.absolutePath}")
+        }
+    }
+
+    private suspend fun seedBeforeLaunch() {
+        clearLastSessionPrefs()
+        fixtureKey = readFixtureKey()
+        markerPrefix = "issue1710-${System.currentTimeMillis().toString(36)}"
+        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        seedRemoteSession()
+        hostRowTag = seedDockerHost()
+        SettingsRepository(InstrumentationRegistry.getInstrumentation().targetContext)
+            .setHostDetailViewMode(HostDetailViewMode.Flat)
+    }
+
+    private fun attachSeededSession() {
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = SESSION_TIMEOUT_MS) {
+            compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        compose.waitUntil(timeoutMillis = SESSION_TIMEOUT_MS) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val terminal = activity.window.decorView.findTerminalView()
+                attached = terminal?.currentSession != null && terminal.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForConnected(vm: TmuxSessionViewModel) {
+        compose.waitUntil(timeoutMillis = SESSION_TIMEOUT_MS) {
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+    }
+
+    private fun openSettingsFromLiveSession() {
+        val moreTags = listOf(
+            TMUX_COMPACT_CHROME_MORE_BUTTON_TAG,
+            TMUX_FULL_CHROME_MORE_BUTTON_TAG,
+        )
+        val moreTag = moreTags.firstOrNull { tag ->
+            compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        } ?: error("no live-session More button")
+        compose.onNodeWithTag(moreTag, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SETTINGS_BUTTON_TAG, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(SETTINGS_LAZY_COLUMN_TAG).assertExists()
+    }
+
+    private fun scrollToJournalRow() {
+        compose.onNodeWithTag(SETTINGS_LAZY_COLUMN_TAG)
+            .performScrollToNode(hasTestTag(DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_TAG))
+        compose.onNodeWithTag(
+            DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_TAG,
+            useUnmergedTree = true,
+        ).assertExists()
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm)
+    }
+
+    private suspend fun seedRemoteSession() {
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(fixtureKey),
+            command = buildString {
+                appendLine("set -eu")
+                appendLine("tmux kill-session -t ${quote(SESSION_NAME)} 2>/dev/null || true")
+                appendLine(
+                    "tmux new-session -d -s ${quote(SESSION_NAME)} " +
+                        quote("printf '$READY_MARKER\\n'; exec sh -i"),
+                )
+                appendLine("sleep 1")
+                appendLine("tmux has-session -t ${quote(SESSION_NAME)}")
+            },
+            description = "issue1710 journal-pull tmux seed",
+        )
+        assertEquals("remote tmux seed failed: ${result.stderr}", 0, result.exitCode)
+    }
+
+    private suspend fun seedDockerHost(): String {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val key = SshKeyStorage.persistKey(
+                context = context,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1710-key-${System.currentTimeMillis()}",
+                content = fixtureKey,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue 1710 Journal Pull",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = key.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            "$HOST_ROW_TAG_PREFIX$hostId"
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun clearRemoteJournal() {
+        remoteExec("rm -f \"\$HOME/${ConnectionLogHostMirror.JOURNAL_REMOTE_PATH}\"")
+    }
+
+    private suspend fun readRemoteJournal(): String {
+        val result = remoteExec("cat \"\$HOME/${ConnectionLogHostMirror.JOURNAL_REMOTE_PATH}\"")
+        assertEquals("host journal read failed: ${result.stderr}", 0, result.exitCode)
+        return result.stdout
+    }
+
+    private suspend fun remoteExec(command: String): com.pocketshell.core.ssh.ExecResult =
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(fixtureKey),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow().use { it.exec(command) }
+
+    private suspend fun cleanupRemote() {
+        runCatching {
+            remoteExec("tmux kill-session -t ${quote(SESSION_NAME)} 2>/dev/null || true")
+        }
+    }
+
+    private fun artifactDir(): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val dir = File(
+            testArtifactsRoot(instrumentation.targetContext),
+            "additional_test_output/issue1710-connection-journal",
+        )
+        check(dir.exists() || dir.mkdirs()) { "could not create ${dir.absolutePath}" }
+        return dir
+    }
+
+    private fun captureFullDevice(file: File) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(200)
+        val bitmap: Bitmap = instrumentation.uiAutomation.takeScreenshot()
+            ?: error("full-device screenshot unavailable")
+        try {
+            FileOutputStream(file).use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+            }
+            println("ISSUE1710_SCREENSHOT ${file.absolutePath}")
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private fun captureLogcat(file: File) {
+        val descriptor = InstrumentationRegistry.getInstrumentation()
+            .uiAutomation
+            .executeShellCommand("logcat -d -v threadtime -t 2000")
+        ParcelFileDescriptor.AutoCloseInputStream(descriptor).use { input ->
+            file.outputStream().use(input::copyTo)
+        }
+    }
+
+    private fun sha256(value: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+
+    private fun byteOffsetOf(value: String, marker: String): Int {
+        val characterIndex = value.indexOf(marker)
+        check(characterIndex >= 0) { "marker not found: $marker" }
+        return value.substring(0, characterIndex).toByteArray().size
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        repeat(childCount) { index ->
+            getChildAt(index).findTerminalView()?.let { return it }
+        }
+        return null
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation().context.assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private fun quote(value: String): String = "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME = "pocketshell.db"
+        const val SESSION_NAME = "issue1710-journal-pull"
+        const val READY_MARKER = "ISSUE1710-READY"
+        const val FILLER_ROW_COUNT = 180
+        const val MIRROR_BUDGET_BYTES = 64 * 1024
+        const val SUCCESS_COPY =
+            "Connection journal mirrored to `~/.pocketshell/connection-journal.jsonl`"
+        const val NO_WARM_COPY = "Open a connected session, then try again."
+        val UI_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+        val SESSION_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 30_000L
+        val UPLOAD_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 25_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -1162,6 +1162,8 @@ private fun AppNavigator(
 
         AppDestination.Settings -> {
             val hostListViewModel: HostListViewModel = hiltViewModel()
+            val journalHostPullState by
+                tmuxSessionViewModel.connectionJournalHostPullState.collectAsState()
             SettingsScreen(
                 onBack = ::back,
                 onOpenCrashReports = { navigate(AppDestination.CrashReports) },
@@ -1172,6 +1174,11 @@ private fun AppNavigator(
                     hostListViewModel.importSharedHostUri(uri)
                     popToHostList()
                 },
+                connectionJournalHostPullState = journalHostPullState,
+                onMirrorFullConnectionJournal =
+                    tmuxSessionViewModel::mirrorFullConnectionJournalToHost,
+                onConsumeConnectionJournalHostPullState =
+                    tmuxSessionViewModel::consumeConnectionJournalHostPullState,
                 // Issue #206: Settings → Watched folders host picker routes
                 // here without SSH credentials. The destination's SSH
                 // fields stay null so the discover-from-remote button is

--- a/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionJournalHostPull.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionJournalHostPull.kt
@@ -1,0 +1,101 @@
+package com.pocketshell.app.diagnostics
+
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+
+/**
+ * UI state for the Settings one-shot full connection-journal pull (#1710).
+ * The terminal states remain visible until the Settings surface consumes them.
+ */
+sealed interface ConnectionJournalHostPullState {
+    data object Idle : ConnectionJournalHostPullState
+    data object Mirroring : ConnectionJournalHostPullState
+    data class Succeeded(val remotePath: String) : ConnectionJournalHostPullState
+    data object Empty : ConnectionJournalHostPullState
+    data object NoWarmSession : ConnectionJournalHostPullState
+    data object Failed : ConnectionJournalHostPullState
+}
+
+/** Exact user-visible one-shot feedback for a terminal state. */
+fun ConnectionJournalHostPullState.feedbackText(): String? = when (this) {
+    ConnectionJournalHostPullState.Idle,
+    ConnectionJournalHostPullState.Mirroring,
+    -> null
+    is ConnectionJournalHostPullState.Succeeded ->
+        "Connection journal mirrored to `~/$remotePath`"
+    ConnectionJournalHostPullState.Empty ->
+        "No connection journal recorded yet."
+    ConnectionJournalHostPullState.NoWarmSession ->
+        "Open a connected session, then try again."
+    ConnectionJournalHostPullState.Failed ->
+        "Could not mirror connection journal to host."
+}
+
+/** Consume one-shot feedback without changing an in-progress operation. */
+fun ConnectionJournalHostPullState.consume(): ConnectionJournalHostPullState = when (this) {
+    ConnectionJournalHostPullState.Mirroring -> this
+    else -> ConnectionJournalHostPullState.Idle
+}
+
+/**
+ * Coordinates archive rendering, tap-time warm-session validation, and the
+ * bounded fixed-path write. It never has a connector or lease manager, so a
+ * missing/mismatched snapshot cannot acquire, cold-dial, retry, or retarget.
+ */
+object ConnectionJournalHostPull {
+    const val DEFAULT_TIMEOUT_MS: Long = 20_000L
+
+    suspend fun pull(
+        recorder: DiagnosticRecorder,
+        expectedLeaseKey: SshLeaseKey?,
+        heldLease: SshLease?,
+        heldSession: SshSession?,
+        timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+    ): ConnectionJournalHostPullState {
+        val jsonl = try {
+            recorder.connectionJournalJsonl()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            return ConnectionJournalHostPullState.Failed
+        }
+        if (jsonl.isBlank()) return ConnectionJournalHostPullState.Empty
+
+        val session = heldSession
+        if (
+            expectedLeaseKey == null ||
+            heldLease == null ||
+            session == null ||
+            heldLease.key != expectedLeaseKey ||
+            heldLease.session !== session ||
+            !session.isConnected ||
+            session.isCloseInitiated
+        ) {
+            return ConnectionJournalHostPullState.NoWarmSession
+        }
+
+        val result = try {
+            withTimeout(timeoutMs) {
+                ConnectionLogHostMirror.mirrorConnectionJournal(session, jsonl)
+            }
+        } catch (_: TimeoutCancellationException) {
+            return ConnectionJournalHostPullState.Failed
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            return ConnectionJournalHostPullState.Failed
+        }
+
+        return result.fold(
+            onSuccess = { remotePath ->
+                remotePath?.let(ConnectionJournalHostPullState::Succeeded)
+                    ?: ConnectionJournalHostPullState.Empty
+            },
+            onFailure = { ConnectionJournalHostPullState.Failed },
+        )
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirror.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirror.kt
@@ -43,6 +43,12 @@ object ConnectionLogHostMirror {
     /** Absolute (home-relative) remote path of the mirrored log. */
     const val REMOTE_PATH: String = "$REMOTE_DIR/$REMOTE_FILENAME"
 
+    /** Fixed filename for the opt-in, full connection-journal pull (#1710). */
+    const val JOURNAL_REMOTE_FILENAME: String = "connection-journal.jsonl"
+
+    /** Fixed home-relative destination for the opt-in replay archive. */
+    const val JOURNAL_REMOTE_PATH: String = "$REMOTE_DIR/$JOURNAL_REMOTE_FILENAME"
+
     /**
      * Write [jsonl] to `~/.pocketshell/connection-log.jsonl` on the host behind
      * [target], reusing [leaseManager]'s warm transport. Returns the absolute
@@ -60,7 +66,12 @@ object ConnectionLogHostMirror {
         if (jsonl.isBlank()) return Result.success(null)
         return try {
             LeaseSessionExec.withSession(leaseManager, target) { session ->
-                writeOverSession(session, jsonl)
+                writeOverSession(
+                    session = session,
+                    jsonl = jsonl,
+                    remoteFilename = REMOTE_FILENAME,
+                    remotePath = REMOTE_PATH,
+                )
             }
         } catch (e: CancellationException) {
             throw e
@@ -72,7 +83,38 @@ object ConnectionLogHostMirror {
         }
     }
 
-    private suspend fun writeOverSession(session: SshSession, jsonl: String): String {
+    /**
+     * Write the complete replay journal over a session the caller already holds.
+     * There is intentionally no lease-manager/acquire overload: #1710 is
+     * tap-time warm-only and must never cold-dial or retarget.
+     */
+    suspend fun mirrorConnectionJournal(
+        session: SshSession,
+        jsonl: String,
+    ): Result<String?> {
+        if (jsonl.isBlank()) return Result.success(null)
+        return try {
+            Result.success(
+                writeOverSession(
+                    session = session,
+                    jsonl = jsonl,
+                    remoteFilename = JOURNAL_REMOTE_FILENAME,
+                    remotePath = JOURNAL_REMOTE_PATH,
+                ),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
+    }
+
+    private suspend fun writeOverSession(
+        session: SshSession,
+        jsonl: String,
+        remoteFilename: String,
+        remotePath: String,
+    ): String {
         // The exec channel drives `mkdir -p $HOME/.pocketshell` (SFTP's per-segment
         // mkdir is more fragile against minimal OpenSSH images — the ShareUploader
         // inbox pattern uses the same exec route).
@@ -86,8 +128,8 @@ object ConnectionLogHostMirror {
         return session.uploadStream(
             input = ByteArrayInputStream(bytes),
             length = bytes.size.toLong(),
-            name = REMOTE_FILENAME,
-            remotePath = REMOTE_PATH,
+            name = remoteFilename,
+            remotePath = remotePath,
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/DiagnosticRecorder.kt
@@ -180,6 +180,19 @@ class DiagnosticRecorder @Inject constructor(
     }
 
     /**
+     * Render the complete device-only connection journal for the opt-in host
+     * pull (#1710). This deliberately serializes [connectionJournalArchive]
+     * directly: the automatic mirror's category policy and 64 KiB transport-up
+     * budget do not apply to a user-triggered replay archive export.
+     */
+    suspend fun connectionJournalJsonl(): String =
+        connectionJournalArchive().joinToString(
+            separator = "\n",
+            postfix = "\n",
+            transform = DiagnosticEventJson::encode,
+        ).takeIf { it != "\n" }.orEmpty()
+
+    /**
      * The host-mirrored connection log rendered as JSONL — one JSON object per
      * line, the same on-disk encoding the rolling diagnostics file uses. This is
      * the payload [com.pocketshell.app.diagnostics.ConnectionLogHostMirror] writes

--- a/app/src/main/java/com/pocketshell/app/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -53,6 +54,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.pocketshell.app.diagnostics.ConnectionJournalHostPullState
+import com.pocketshell.app.diagnostics.feedbackText
 import com.pocketshell.app.release.ReleaseInfo
 import com.pocketshell.app.release.launchUpdateDownload
 import com.pocketshell.core.assistant.AssistantProvider
@@ -105,6 +108,10 @@ fun SettingsScreen(
     onOpenAiCosts: () -> Unit = {},
     onScanHostImport: () -> Unit = {},
     onChooseHostImportFile: (Uri) -> Unit = {},
+    connectionJournalHostPullState: ConnectionJournalHostPullState =
+        ConnectionJournalHostPullState.Idle,
+    onMirrorFullConnectionJournal: () -> Unit = {},
+    onConsumeConnectionJournalHostPullState: () -> Unit = {},
     /**
      * Issue #206: per-host watched-folders config entry. The Settings
      * surface routes through a host picker (no decrypted passphrase
@@ -131,6 +138,10 @@ fun SettingsScreen(
     val hostImportFilePicker = rememberLauncherForActivityResult(
         ActivityResultContracts.GetContent(),
     ) { uri -> uri?.let(onChooseHostImportFile) }
+
+    DisposableEffect(Unit) {
+        onDispose(onConsumeConnectionJournalHostPullState)
+    }
 
     val appBuildInfo = remember {
         try {
@@ -268,9 +279,11 @@ fun SettingsScreen(
                 DiagnosticsSection(
                     recordingEnabled = settings.diagnosticsRecordingEnabled,
                     shareState = diagnosticsShareState,
+                    journalHostPullState = connectionJournalHostPullState,
                     onRecordingChange = viewModel::setDiagnosticsRecordingEnabled,
                     onStartFreshCapture = viewModel::startFreshDiagnosticsCapture,
                     onShareLog = viewModel::shareDiagnosticsLog,
+                    onMirrorFullConnectionJournal = onMirrorFullConnectionJournal,
                     onClearLog = viewModel::clearDiagnosticsLog,
                     onOpenCrashReports = onOpenCrashReports,
                 )
@@ -1688,9 +1701,11 @@ private fun UsageSection(
 private fun DiagnosticsSection(
     recordingEnabled: Boolean,
     shareState: DiagnosticsShareState,
+    journalHostPullState: ConnectionJournalHostPullState,
     onRecordingChange: (Boolean) -> Unit,
     onStartFreshCapture: () -> Unit,
     onShareLog: () -> Unit,
+    onMirrorFullConnectionJournal: () -> Unit,
     onClearLog: () -> Unit,
     onOpenCrashReports: () -> Unit,
 ) {
@@ -1763,6 +1778,34 @@ private fun DiagnosticsSection(
                 },
                 modifier = Modifier.testTag(DIAGNOSTICS_SHARE_LOG_TAG),
             )
+            ListRow(
+                title = if (journalHostPullState == ConnectionJournalHostPullState.Mirroring) {
+                    "Mirroring connection journal..."
+                } else {
+                    "Mirror full connection journal to host"
+                },
+                trailing = { NavigationChevron() },
+                onClick = {
+                    if (journalHostPullState != ConnectionJournalHostPullState.Mirroring) {
+                        onMirrorFullConnectionJournal()
+                    }
+                },
+                modifier = Modifier.testTag(DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_TAG),
+            )
+            journalHostPullState.feedbackText()?.let { feedback ->
+                Text(
+                    text = feedback,
+                    color = PocketShellColors.TextSecondary,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = PocketShellSpacing.md,
+                            vertical = PocketShellSpacing.xs,
+                        )
+                        .testTag(DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_FEEDBACK_TAG),
+                )
+            }
             ListRow(
                 title = "Clear diagnostics recorder",
                 onClick = onClearLog,
@@ -2044,6 +2087,10 @@ internal const val DIAGNOSTICS_RECORDING_SWITCH_TAG = "settings:diagnostics:reco
 internal const val DIAGNOSTICS_RECORDING_INDICATOR_TAG = "settings:diagnostics:recording-indicator"
 internal const val DIAGNOSTICS_START_CAPTURE_TAG = "settings:diagnostics:start-capture"
 internal const val DIAGNOSTICS_SHARE_LOG_TAG = "settings:diagnostics:share-log"
+internal const val DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_TAG =
+    "settings:diagnostics:mirror-connection-journal"
+internal const val DIAGNOSTICS_MIRROR_CONNECTION_JOURNAL_FEEDBACK_TAG =
+    "settings:diagnostics:mirror-connection-journal-feedback"
 internal const val DIAGNOSTICS_CLEAR_LOG_TAG = "settings:diagnostics:clear-log"
 internal const val USAGE_OPEN_TAG = "settings:usage:open"
 internal const val USAGE_EMPTY_HINT_TAG = "settings:usage:empty-hint"

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -30,8 +30,11 @@ import com.pocketshell.app.composer.PromptAttachmentStager
 import com.pocketshell.app.composer.retainedRemoteAttachmentNames
 import com.pocketshell.app.connectivity.TerminalNetworkChange
 import com.pocketshell.app.connectivity.networkDiagnosticFields
+import com.pocketshell.app.diagnostics.ConnectionJournalHostPull
+import com.pocketshell.app.diagnostics.ConnectionJournalHostPullState
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.app.diagnostics.consume
 import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.projects.ClaudeProfile
 import com.pocketshell.app.projects.CodexProfile
@@ -1870,6 +1873,11 @@ public class TmuxSessionViewModel @Inject constructor(
         SessionAssistantController(scope = viewModelScope, sessionFactory = ::buildAssistantDeps)
 
     internal val assistantState: StateFlow<AssistantUiState> = assistant.state
+
+    private val _connectionJournalHostPullState =
+        MutableStateFlow<ConnectionJournalHostPullState>(ConnectionJournalHostPullState.Idle)
+    val connectionJournalHostPullState: StateFlow<ConnectionJournalHostPullState> =
+        _connectionJournalHostPullState.asStateFlow()
 
     // Project roots for the connected host, mirrored from
     // [ProjectRootDao.getByHostId] so the voice planner request can carry
@@ -9066,6 +9074,7 @@ public class TmuxSessionViewModel @Inject constructor(
         session: SshSession? = null,
         tmuxSessionId: String? = null,
         sessionCreated: Long? = null,
+        lease: SshLease? = null,
     ) {
         val target = ConnectionTarget(
             hostId = hostId,
@@ -9082,8 +9091,17 @@ public class TmuxSessionViewModel @Inject constructor(
         )
         // #1085: this synchronous test seam must close the replaced client before returning.
         closeCurrentConnection(deferTeardown = false)
-        // #178: inject a live session so same-host switch tests reuse it without a handshake.
-        if (session != null) {
+        // Issue #178: tests for the same-host fast-switch path need a
+        // way to inject a live `SshSession` into the VM so a follow-up
+        // `connect()` to the same host re-uses it instead of going
+        // through the SSH-handshake path (which requires a real
+        // network). Production callers go through `runConnect` /
+        // `runFastSessionSwitch` — those wire the session ref
+        // themselves.
+        if (lease != null) {
+            leaseRef = lease
+            sessionRef = lease.session
+        } else if (session != null) {
             sessionRef = session
         }
         attachClient(client)
@@ -17387,20 +17405,7 @@ public class TmuxSessionViewModel @Inject constructor(
         override fun hashCode(): Int = connectionTargetIdentityHashCode(this)
     }
 
-    /**
-     * Issue #972 — wire the host connection-log mirror to its trigger. Fired by the
-     * [ConnectionEffectDriver] right after the current host's lease transport comes
-     * back `Up` (a reconnect promoted the controller to Live): mirror the recorded
-     * reconnect-cause trail ([DiagnosticRecorder.connectionLogJsonl]) to the host's
-     * `~/.pocketshell/connection-log.jsonl` over the now-warm lease, so the
-     * maintainer can attribute the just-completed drop in the in-app file viewer
-     * with no adb (#969 part 3 was a tested-but-unwired writer; this is the wiring).
-     *
-     * FAIL-SOFT all the way: a missing recorder, no active target, a blank trail,
-     * or any host-write error is a silent no-op — the mirror NEVER perturbs the
-     * live connection. The write runs on [viewModelScope] off the driver's collect
-     * so the transport-edge collector is never blocked by the host round-trip.
-     */
+    /** Automatic #972 connection-log mirror after a transport-up edge. */
     private fun mirrorConnectionLogToHost() {
         val recorder = diagnosticRecorder ?: return
         val target = activeTarget ?: return
@@ -17412,16 +17417,7 @@ public class TmuxSessionViewModel @Inject constructor(
         }
     }
 
-    /**
-     * The fail-soft mirror body shared by the production fire-and-forget
-     * [mirrorConnectionLogToHost] and the connected-test seam
-     * [mirrorConnectionLogToHostForTest]. Reads the recorder's reconnect-cause
-     * trail and, when non-blank, writes it to the host over the warm lease via
-     * [com.pocketshell.app.diagnostics.ConnectionLogHostMirror] (itself
-     * `Result.failure` fail-soft, never a throw except cancellation). Returns the
-     * mirror's [Result] (the absolute remote path on success, `null` when the
-     * trail was blank so no write happened).
-     */
+    /** Shared fail-soft body for the automatic mirror and its connected seam. */
     private suspend fun mirrorConnectionLogToHostBody(
         recorder: com.pocketshell.app.diagnostics.DiagnosticRecorder,
         leaseTarget: com.pocketshell.app.sessions.LeaseSessionTarget,
@@ -17435,17 +17431,7 @@ public class TmuxSessionViewModel @Inject constructor(
         )
     }
 
-    /**
-     * Issue #972 connected-test seam. Drives the EXACT production mirror glue —
-     * `activeTarget` → [toLeaseSessionTarget] (the byte-identical lease-key
-     * mapping) → the warm-lease write — synchronously and returns the
-     * [ConnectionLogHostMirror][com.pocketshell.app.diagnostics.ConnectionLogHostMirror]
-     * `Result` so a Docker journey can assert the host file actually lands over
-     * the warm lease (a wrong lease-key field mapping would dial a fresh handshake
-     * or fail outright — the exact "wired but the host file never lands" regression
-     * this issue closes). Returns `Result.failure` when there is no recorder or no
-     * active target, exactly like the fire-and-forget production path returns early.
-     */
+    /** Issue #972 connected seam for the exact automatic-mirror VM glue. */
     @androidx.annotation.VisibleForTesting
     internal suspend fun mirrorConnectionLogToHostForTest(): Result<String?> {
         val recorder = diagnosticRecorder
@@ -17453,6 +17439,36 @@ public class TmuxSessionViewModel @Inject constructor(
         val target = activeTarget
             ?: return Result.failure(IllegalStateException("no activeTarget"))
         return mirrorConnectionLogToHostBody(recorder, target.toLeaseSessionTarget())
+    }
+
+    /**
+     * Settings one-shot (#1710). Snapshot all three identities synchronously at
+     * tap time; the coordinator has no acquire capability and finishes against
+     * this exact held session even if navigation changes meanwhile.
+     */
+    fun mirrorFullConnectionJournalToHost() {
+        if (_connectionJournalHostPullState.value == ConnectionJournalHostPullState.Mirroring) return
+        val recorder = diagnosticRecorder
+        val expectedLeaseKey = activeTarget?.toSshLeaseTarget()?.leaseKey
+        val heldLease = leaseRef
+        val heldSession = sessionRef
+        _connectionJournalHostPullState.value = ConnectionJournalHostPullState.Mirroring
+        viewModelScope.launch {
+            _connectionJournalHostPullState.value = if (recorder == null) {
+                ConnectionJournalHostPullState.Failed
+            } else {
+                ConnectionJournalHostPull.pull(
+                    recorder = recorder,
+                    expectedLeaseKey = expectedLeaseKey,
+                    heldLease = heldLease,
+                    heldSession = heldSession,
+                )
+            }
+        }
+    }
+
+    fun consumeConnectionJournalHostPullState() {
+        _connectionJournalHostPullState.update { it.consume() }
     }
 
     // EPIC #687 Slice 1 (#1047): `reduceBackground()` is DELETED. The background

--- a/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogHostMirrorTest.kt
@@ -106,6 +106,60 @@ class ConnectionLogHostMirrorTest {
         assertFalse("a mirror failure must never close the live transport", session.closed)
     }
 
+    @Test
+    fun writesFullJournalOnlyToTheFixedConnectionJournalPathOverTheProvidedSession() = runTest {
+        val session = RecordingSshSession()
+        val journal = buildString {
+            repeat(400) { index ->
+                append("""{"sequence":$index,"category":"connection_journal","marker":"${"x".repeat(200)}"}""")
+                append('\n')
+            }
+        }
+        assertTrue("fixture must exceed the automatic mirror budget", journal.toByteArray().size > 64 * 1024)
+
+        val result = ConnectionLogHostMirror.mirrorConnectionJournal(session, journal)
+
+        assertTrue("journal mirror must succeed", result.isSuccess)
+        assertEquals(ConnectionLogHostMirror.JOURNAL_REMOTE_PATH, result.getOrNull())
+        assertEquals(".pocketshell/connection-journal.jsonl", ConnectionLogHostMirror.JOURNAL_REMOTE_PATH)
+        assertEquals(ConnectionLogHostMirror.JOURNAL_REMOTE_FILENAME, session.uploadedName)
+        assertEquals(ConnectionLogHostMirror.JOURNAL_REMOTE_PATH, session.uploadedRemotePath)
+        assertFalse(
+            "the one-shot journal must never overwrite the automatic connection log",
+            session.uploadedRemotePath == ConnectionLogHostMirror.REMOTE_PATH,
+        )
+        assertEquals(journal, session.uploadedText())
+        assertFalse("journal upload must leave the held session open", session.closed)
+    }
+
+    @Test
+    fun blankJournalIsANoOpOverTheProvidedSession() = runTest {
+        val session = RecordingSshSession()
+
+        val result = ConnectionLogHostMirror.mirrorConnectionJournal(session, " \n ")
+
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrNull())
+        assertTrue("blank journal must do no SSH work", session.execCommands.isEmpty())
+        assertNull(session.uploadedName)
+    }
+
+    @Test
+    fun journalMkdirAndUploadFailuresAreFailSoftAndConnectionNeutral() = runTest {
+        val mkdirFailure = RecordingSshSession(
+            execResult = { ExecResult("", "denied", 1) },
+        )
+        val mkdirResult = ConnectionLogHostMirror.mirrorConnectionJournal(mkdirFailure, jsonl)
+        assertTrue(mkdirResult.isFailure)
+        assertNull(mkdirFailure.uploadedName)
+        assertFalse(mkdirFailure.closed)
+
+        val uploadFailure = RecordingSshSession(failUpload = true)
+        val uploadResult = ConnectionLogHostMirror.mirrorConnectionJournal(uploadFailure, jsonl)
+        assertTrue(uploadResult.isFailure)
+        assertFalse(uploadFailure.closed)
+    }
+
     private class CountingConnector(private val session: RecordingSshSession) : SshLeaseConnector {
         var connectCount: Int = 0
         override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {

--- a/app/src/test/java/com/pocketshell/app/diagnostics/Issue1710ConnectionJournalHostPullTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/Issue1710ConnectionJournalHostPullTest.kt
@@ -1,0 +1,283 @@
+package com.pocketshell.app.diagnostics
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.core.connection.ConnectionJournalSchema
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1710ConnectionJournalHostPullTest {
+    private lateinit var context: Context
+    private lateinit var settings: SettingsRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE).edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        settings = SettingsRepository(context)
+    }
+
+    @Test
+    fun fullArchiveRendersInOrderWithoutMirrorFilteringOr64KiBBudget() = runTest {
+        val recorder = DiagnosticRecorder(context, settings)
+        val marker = "issue1710-${"z".repeat(450)}"
+        repeat(180) { index ->
+            recorder.record(
+                ConnectionJournalSchema.CATEGORY,
+                ConnectionJournalSchema.SUBMIT,
+                mapOf("journalSeq" to index, "markerValue" to "$marker-$index"),
+            )
+        }
+
+        val archive = recorder.connectionJournalArchive()
+        val jsonl = recorder.connectionJournalJsonl()
+        val decoded = jsonl.lineSequence()
+            .filter(String::isNotBlank)
+            .mapNotNull(DiagnosticEventJson::decode)
+            .toList()
+
+        assertEquals("every archived row must be rendered in order", archive, decoded)
+        assertTrue("one-shot archive must not use the 64 KiB mirror budget", jsonl.toByteArray().size > 64 * 1024)
+        assertTrue(decoded.all { it.category == ConnectionJournalSchema.CATEGORY })
+        assertTrue("automatic mirror policy remains separate", recorder.connectionLogJsonl().isBlank())
+    }
+
+    @Test
+    fun emptyArchiveRendersBlankAndReturnsEmptyBeforeInspectingSsh() = runTest {
+        val recorder = DiagnosticRecorder(context, settings)
+        assertTrue(recorder.connectionJournalJsonl().isBlank())
+
+        val state = ConnectionJournalHostPull.pull(
+            recorder = recorder,
+            expectedLeaseKey = null,
+            heldLease = null,
+            heldSession = null,
+        )
+
+        assertEquals(ConnectionJournalHostPullState.Empty, state)
+        assertEquals("No connection journal recorded yet.", state.feedbackText())
+    }
+
+    @Test
+    fun matchingHeldLiveLeaseWritesWithZeroAcquireOrRetarget() = runTest {
+        val recorder = seededRecorder()
+        val session = RecordingSession()
+        val connector = CountingConnector(session)
+        val manager = SshLeaseManager(connector = connector, scope = this)
+        val lease = manager.acquire(TARGET).getOrThrow()
+        assertEquals(1, connector.calls)
+
+        val expected = recorder.connectionJournalJsonl()
+        val state = ConnectionJournalHostPull.pull(
+            recorder = recorder,
+            expectedLeaseKey = TARGET.leaseKey,
+            heldLease = lease,
+            heldSession = session,
+        )
+
+        assertEquals(
+            ConnectionJournalHostPullState.Succeeded(ConnectionLogHostMirror.JOURNAL_REMOTE_PATH),
+            state,
+        )
+        assertEquals("pull must never call acquire", 1, connector.calls)
+        assertEquals(expected, session.uploadedText)
+        assertFalse("held warm session must stay open", session.closed)
+    }
+
+    @Test
+    fun missingMismatchedDisconnectedAndClosingSnapshotsDoNoSshWork() = runTest {
+        val recorder = seededRecorder()
+        val live = RecordingSession()
+        val liveLease = acquiredLease(live)
+
+        val cases = listOf(
+            Triple<SshLeaseKey?, SshLease?, SshSession?>(null, liveLease, live),
+            Triple(TARGET.leaseKey, null, live),
+            Triple(TARGET.leaseKey.copy(port = TARGET.leaseKey.port + 1), liveLease, live),
+            Triple(TARGET.leaseKey, liveLease, RecordingSession(connected = false)),
+        )
+        cases.forEach { (key, lease, session) ->
+            val before = live.sshWork
+            val state = ConnectionJournalHostPull.pull(recorder, key, lease, session)
+            assertEquals(ConnectionJournalHostPullState.NoWarmSession, state)
+            assertEquals("rejected snapshot must do zero SSH work", before, live.sshWork)
+        }
+
+        val closing = RecordingSession(closeInitiated = true)
+        val closingLease = acquiredLease(closing)
+        val closingState = ConnectionJournalHostPull.pull(
+            recorder,
+            TARGET.leaseKey,
+            closingLease,
+            closing,
+        )
+        assertEquals(ConnectionJournalHostPullState.NoWarmSession, closingState)
+        assertEquals(0, closing.sshWork)
+        assertEquals("Open a connected session, then try again.", closingState.feedbackText())
+    }
+
+    @Test
+    fun uploadFailureAndTimeoutMapToFailedWithoutClosingTheSession() = runTest {
+        val recorder = seededRecorder()
+        val failing = RecordingSession(failUpload = true)
+        val failingState = ConnectionJournalHostPull.pull(
+            recorder,
+            TARGET.leaseKey,
+            acquiredLease(failing),
+            failing,
+        )
+        assertEquals(ConnectionJournalHostPullState.Failed, failingState)
+        assertFalse(failing.closed)
+
+        val wedged = RecordingSession(wedgeUpload = true)
+        val timeoutState = ConnectionJournalHostPull.pull(
+            recorder,
+            TARGET.leaseKey,
+            acquiredLease(wedged),
+            wedged,
+            timeoutMs = 100L,
+        )
+        assertEquals(ConnectionJournalHostPullState.Failed, timeoutState)
+        assertFalse(wedged.closed)
+        assertEquals("Could not mirror connection journal to host.", timeoutState.feedbackText())
+    }
+
+    @Test
+    fun everyTerminalStateHasExactVisibleCopyAndCanBeConsumedToIdle() {
+        assertNull(ConnectionJournalHostPullState.Idle.feedbackText())
+        assertNull(ConnectionJournalHostPullState.Mirroring.feedbackText())
+        assertEquals(
+            "Connection journal mirrored to `~/.pocketshell/connection-journal.jsonl`",
+            ConnectionJournalHostPullState.Succeeded(
+                ConnectionLogHostMirror.JOURNAL_REMOTE_PATH,
+            ).feedbackText(),
+        )
+        assertEquals("No connection journal recorded yet.", ConnectionJournalHostPullState.Empty.feedbackText())
+        assertEquals(
+            "Open a connected session, then try again.",
+            ConnectionJournalHostPullState.NoWarmSession.feedbackText(),
+        )
+        assertEquals(
+            "Could not mirror connection journal to host.",
+            ConnectionJournalHostPullState.Failed.feedbackText(),
+        )
+        listOf(
+            ConnectionJournalHostPullState.Succeeded(ConnectionLogHostMirror.JOURNAL_REMOTE_PATH),
+            ConnectionJournalHostPullState.Empty,
+            ConnectionJournalHostPullState.NoWarmSession,
+            ConnectionJournalHostPullState.Failed,
+        ).forEach { terminal ->
+            assertEquals(ConnectionJournalHostPullState.Idle, terminal.consume())
+        }
+    }
+
+    private suspend fun seededRecorder(): DiagnosticRecorder =
+        DiagnosticRecorder(context, settings).also { recorder ->
+            recorder.record(
+                ConnectionJournalSchema.CATEGORY,
+                ConnectionJournalSchema.CONSTRUCT,
+                mapOf("journalSeq" to 0, "markerValue" to "issue1710"),
+            )
+            check(recorder.connectionJournalArchive().isNotEmpty())
+        }
+
+    private suspend fun acquiredLease(session: RecordingSession): SshLease {
+        val manager = SshLeaseManager(
+            connector = SshLeaseConnector { Result.success(session) },
+        )
+        return manager.acquire(TARGET).getOrThrow()
+    }
+
+    private class CountingConnector(private val session: SshSession) : SshLeaseConnector {
+        var calls: Int = 0
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            calls += 1
+            return Result.success(session)
+        }
+    }
+
+    private class RecordingSession(
+        private val connected: Boolean = true,
+        private val closeInitiated: Boolean = false,
+        private val failUpload: Boolean = false,
+        private val wedgeUpload: Boolean = false,
+    ) : SshSession {
+        var sshWork: Int = 0
+        var closed: Boolean = false
+        var uploadedText: String? = null
+
+        override val isConnected: Boolean get() = connected && !closed
+        override val isCloseInitiated: Boolean get() = closeInitiated || closed
+
+        override suspend fun exec(command: String): ExecResult {
+            sshWork += 1
+            return ExecResult("", "", 0)
+        }
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String {
+            sshWork += 1
+            if (wedgeUpload) awaitCancellation()
+            if (failUpload) throw IOException("upload failed")
+            uploadedText = input.readBytes().toString(Charsets.UTF_8)
+            return remotePath
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit) = error("not used")
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        val TARGET = SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = "10.0.2.2",
+                port = 2222,
+                user = "testuser",
+                credentialId = "1710:/tmp/key",
+            ),
+            key = SshKey.Path(File("/tmp/key")),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1710ConnectionJournalViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1710ConnectionJournalViewModelTest.kt
@@ -1,0 +1,193 @@
+package com.pocketshell.app.tmux
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.diagnostics.ConnectionJournalHostPullState
+import com.pocketshell.app.diagnostics.DIAGNOSTICS_EXPORT_CACHE_DIR
+import com.pocketshell.app.diagnostics.DiagnosticRecorder
+import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.core.connection.ConnectionJournalSchema
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1710ConnectionJournalViewModelTest : TmuxSessionViewModelTestBase() {
+    @Test
+    fun matchingTapTimeHeldLeaseSuppressesDuplicateTapAndConsumesSuccess() = runTest(scheduler) {
+        val context = freshContext()
+        val recorder = seededRecorder(context)
+        val session = BlockingUploadSession()
+        var acquireCalls = 0
+        val manager = SshLeaseManager(
+            connector = SshLeaseConnector {
+                acquireCalls += 1
+                Result.success(session)
+            },
+            scope = backgroundScope,
+            connectTimeoutContext = StandardTestDispatcher(scheduler),
+            abortTimeoutContext = StandardTestDispatcher(scheduler),
+            nowMillis = { scheduler.currentTime },
+        )
+        val lease = manager.acquire(TARGET).getOrThrow()
+        val vm = newVm(sshLeaseManager = manager, diagnosticRecorder = recorder)
+        vm.replaceClientForTest(
+            hostId = HOST_ID,
+            hostName = "Issue 1710",
+            host = TARGET.leaseKey.host,
+            port = TARGET.leaseKey.port,
+            user = TARGET.leaseKey.user,
+            keyPath = KEY_PATH,
+            sessionName = "journal",
+            client = FakeTmuxClient(),
+            lease = lease,
+        )
+
+        vm.mirrorFullConnectionJournalToHost()
+        awaitCondition { session.uploadCalls == 1 }
+        assertEquals(ConnectionJournalHostPullState.Mirroring, vm.connectionJournalHostPullState.value)
+        assertEquals(1, session.uploadCalls)
+
+        vm.mirrorFullConnectionJournalToHost()
+        runCurrent()
+        assertEquals("second tap while mirroring must be ignored", 1, session.uploadCalls)
+        assertEquals("action must not call acquire", 1, acquireCalls)
+
+        session.finishUpload.complete(Unit)
+        awaitCondition {
+            vm.connectionJournalHostPullState.value ==
+                ConnectionJournalHostPullState.Succeeded(".pocketshell/connection-journal.jsonl")
+        }
+        assertEquals(
+            ConnectionJournalHostPullState.Succeeded(".pocketshell/connection-journal.jsonl"),
+            vm.connectionJournalHostPullState.value,
+        )
+        assertFalse("success must not close the live session", session.closed)
+
+        vm.consumeConnectionJournalHostPullState()
+        assertEquals(ConnectionJournalHostPullState.Idle, vm.connectionJournalHostPullState.value)
+    }
+
+    @Test
+    fun mismatchedHeldLeaseMapsToNoWarmWithoutSshWork() = runTest(scheduler) {
+        val context = freshContext()
+        val recorder = seededRecorder(context)
+        val session = BlockingUploadSession()
+        val manager = SshLeaseManager(
+            connector = SshLeaseConnector { Result.success(session) },
+            scope = backgroundScope,
+            connectTimeoutContext = StandardTestDispatcher(scheduler),
+            abortTimeoutContext = StandardTestDispatcher(scheduler),
+            nowMillis = { scheduler.currentTime },
+        )
+        val lease = manager.acquire(TARGET).getOrThrow()
+        val vm = newVm(sshLeaseManager = manager, diagnosticRecorder = recorder)
+        vm.replaceClientForTest(
+            hostId = HOST_ID,
+            hostName = "Issue 1710",
+            host = TARGET.leaseKey.host,
+            port = TARGET.leaseKey.port + 1,
+            user = TARGET.leaseKey.user,
+            keyPath = KEY_PATH,
+            sessionName = "journal",
+            client = FakeTmuxClient(),
+            lease = lease,
+        )
+
+        vm.mirrorFullConnectionJournalToHost()
+        awaitCondition {
+            vm.connectionJournalHostPullState.value != ConnectionJournalHostPullState.Mirroring
+        }
+
+        assertEquals(
+            ConnectionJournalHostPullState.NoWarmSession,
+            vm.connectionJournalHostPullState.value,
+        )
+        assertEquals("mismatched tap-time lease must do zero SSH work", 0, session.execCalls)
+        assertEquals(0, session.uploadCalls)
+    }
+
+    private fun freshContext(): Context =
+        ApplicationProvider.getApplicationContext<Context>().also { context ->
+            context.getSharedPreferences("app_settings", Context.MODE_PRIVATE).edit().clear().commit()
+            File(context.filesDir, "diagnostics").deleteRecursively()
+            File(context.cacheDir, DIAGNOSTICS_EXPORT_CACHE_DIR).deleteRecursively()
+        }
+
+    private suspend fun seededRecorder(context: Context): DiagnosticRecorder =
+        DiagnosticRecorder(context, SettingsRepository(context)).also { recorder ->
+            recorder.record(
+                ConnectionJournalSchema.CATEGORY,
+                ConnectionJournalSchema.CONSTRUCT,
+                mapOf("journalSeq" to 0, "markerValue" to "vm-1710"),
+            )
+            check(recorder.connectionJournalArchive().isNotEmpty())
+        }
+
+    private class BlockingUploadSession : SshSession {
+        val finishUpload = CompletableDeferred<Unit>()
+        var execCalls = 0
+        var uploadCalls = 0
+        var closed = false
+
+        override val isConnected: Boolean get() = !closed
+        override suspend fun exec(command: String): ExecResult {
+            execCalls += 1
+            return ExecResult("", "", 0)
+        }
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String {
+            uploadCalls += 1
+            finishUpload.await()
+            input.readBytes()
+            return remotePath
+        }
+        override fun tail(path: String, onLine: (String) -> Unit) = error("not used")
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        const val HOST_ID = 1710L
+        const val KEY_PATH = "/tmp/issue1710-key"
+        val TARGET = SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = "10.0.2.2",
+                port = 2222,
+                user = "testuser",
+                credentialId = "$HOST_ID:$KEY_PATH",
+            ),
+            key = SshKey.Path(File(KEY_PATH)),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
@@ -173,6 +173,7 @@ abstract class TmuxSessionViewModelTestBase {
             applicationContext?.let {
                 com.pocketshell.app.composer.SharedPrefsOutboundQueueStore(it)
             },
+        diagnosticRecorder: com.pocketshell.app.diagnostics.DiagnosticRecorder? = null,
         // Issue #1617: reconnect stress scenarios can inject a scenario-owned
         // virtual scope instead of sharing this class's real-IO factoryScope.
         // The default preserves the genuine reader-loop coverage used by the
@@ -192,6 +193,7 @@ abstract class TmuxSessionViewModelTestBase {
             agentKindRemoteSource = agentKindRemoteSource,
             applicationContext = applicationContext,
             outboundQueueStore = outboundQueueStore,
+            diagnosticRecorder = diagnosticRecorder,
         ).also {
             // Issue #576 (Slice A of #792): pin the structural-reconcile
             // dispatcher to Main (the MainDispatcherRule's

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -272,6 +272,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.projects.FolderListHostOutdatedTreeVersionDaemonDockerTest"  # #1509 G10: real agents-daemon (2239) old cli_version through tree envelope -> banner once, background, after tree shown
   "$FQCN_PREFIX.LaunchNoMainThreadRoomReadE2eTest"  # #951 #928 #305 D2 — launch ANR / crash-loop). The reproduce-first end-to-en…
   "com.pocketshell.app.diagnostics.ConnectionLogHostMirrorReconnectDockerTest"  # #972 #969 D33/G4/G10: prove the host connection-log mirror's VM GLUE o…
+  "com.pocketshell.app.diagnostics.ConnectionJournalHostPullJourneyDockerTest"  # #1710 Settings one-shot full journal over the held warm session; no-warm no-dial proof
   "com.pocketshell.app.env.EnvScreenE2eTest"  # #1094 #1092 durability for ): the env edit/add on-device journeys. The
   "com.pocketshell.app.tmux.TmuxResizeSessionE2eTest#cachedSizeReplayRestoresFullWindowAndAgentPaneIsNotCut"  # #1169 #285 Codex/agent pane rendered CUT: tmux window resized too small
   "com.pocketshell.app.usage.UsageGlancePillE2eTest"  # #1241 #418 the landing app-bar usage GLANCE PILL on-device proof. The


### PR DESCRIPTION
Closes #1710

Adds an on-demand Settings action that mirrors the complete device connection journal to `~/.pocketshell/connection-journal.jsonl` over the currently held warm session only. It never acquires, cold-dials, retargets, or replaces a connection, and reports distinct success/empty/no-warm-session/failure states.

Evidence:
- reviewer-approved after an exact >64 KiB truncation mutation: expected 183 seeded rows, truncated mutant delivered only 147
- clean connected Docker/emulator journey produced an 83,999-byte mirror with all 183 seeded markers in exact order, oldest and newest retained
- 0→0 extra SSH handshakes; live session remained usable; no-warm-session path remained connection-neutral
- focused JVM suite: 18/18 green
- `:app:compileDebugAndroidTestKotlin`: BUILD SUCCESSFUL, 176 tasks
- connection VM ratchet, file-size hygiene, test-validity, release-emulator memory budget, and `git diff --check`: green

Review evidence: https://github.com/alexeygrigorev/pocketshell/issues/1710#issuecomment-5068475762
Post-rebase approval: https://github.com/alexeygrigorev/pocketshell/issues/1710#issuecomment-5068554100