### PR TITLE
test(file-explorer): update transfer copy contract

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileexplorer/FileExplorerScaffoldTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileexplorer/FileExplorerScaffoldTest.kt
@@ -243,7 +243,23 @@ class FileExplorerScaffoldTest {
             transfer = FileTransferState.InProgress(name = "a.txt", isUpload = true),
         )
         compose.onNodeWithTag(FILE_EXPLORER_TRANSFER_TAG).assertIsDisplayed()
-        compose.onNodeWithText("Uploading a.txt…").assertIsDisplayed()
+        compose.onNodeWithText("Uploading a.txt (size unknown)…").assertIsDisplayed()
+        // Upload is suppressed while a transfer is running.
+        compose.onNodeWithTag(FILE_EXPLORER_UPLOAD_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun inProgressTransferWithKnownSizeShowsFormattedCopyAndHidesUpload() {
+        setReady(
+            listOf(file("a.txt", 1)),
+            transfer = FileTransferState.InProgress(
+                name = "a.txt",
+                isUpload = true,
+                bytesTotal = 1536,
+            ),
+        )
+        compose.onNodeWithTag(FILE_EXPLORER_TRANSFER_TAG).assertIsDisplayed()
+        compose.onNodeWithText("Uploading a.txt (1.5 KB)…").assertIsDisplayed()
         // Upload is suppressed while a transfer is running.
         compose.onNodeWithTag(FILE_EXPLORER_UPLOAD_TAG).assertDoesNotExist()
     }


### PR DESCRIPTION
Closes #1736

Updates the file-explorer connected test to the intentional post-#1041 transfer-copy contract: unknown-size uploads render `Uploading a.txt (size unknown)…`. Adds a separate 1536-byte case asserting `Uploading a.txt (1.5 KB)…`; both cases retain the load-bearing banner-visible and Upload-absent assertions. Production and journey wiring are untouched. Parent #1677 remains open for its remaining phase-1 inventory.

Evidence:
- exact current-main RED: banner assertion passed, stale `Uploading a.txt…` text assertion failed
- independent old-copy mutation reproduced 1/1 RED at the exact assertion; byte-exact restore
- implementer exclusive stability: 3 whole-class runs, 69/69, zero skips/failures
- reviewer exclusive runs: named 1/1 + two whole-class runs, 46/46, zero skips/failures
- forced Android-test compile: 176/176 tasks
- full JVM suite: 11,248 tests, zero failures/errors/skips, 603/603 tasks
- test-validity, diff, and one-file scope clean
- #1737 collision runs excluded with captured SIGKILL/package-uninstall evidence
- clean rebase onto `8e14bf54`; exact range/patch/blob identity and post-rebase approval

Review: https://github.com/alexeygrigorev/pocketshell/issues/1736#issuecomment-5070452012
Post-rebase audit: https://github.com/alexeygrigorev/pocketshell/issues/1736#issuecomment-5070463578