### PR TITLE
test-infra: unify per-AVD ownership locks

### DIFF
--- a/app/src/test/java/com/pocketshell/app/scripts/AvdLockScriptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/scripts/AvdLockScriptTest.kt
@@ -20,8 +20,8 @@ import java.util.concurrent.TimeUnit
  * died at `source: No such file or directory`, and no one saw it. A test that
  * no gate runs is not a test (#1640/#1646); this class is the gate.
  *
- * The harnesses are JVM-free, emulator-free, and Docker-free (fake `adb`, stub
- * `gradlew`, sandboxed lock dir, preset agents port), and run in seconds.
+ * The harnesses are JVM-free, emulator-free, and Docker-daemon-free (fake
+ * `adb`/`docker`, stub `gradlew`, sandboxed lock dirs), and run in seconds.
  * Locks are provable with two processes and a lock file — racing a real AVD to
  * test the lock that protects it would corrupt whatever sibling lane is on it.
  */
@@ -63,6 +63,15 @@ class AvdLockScriptTest {
             "tests/scripts/avd-pool-test.sh",
             timeoutSeconds = 180,
             environmentOverrides = mapOf("ANDROID_SERIAL" to "emulator-5554"),
+        )
+    }
+
+    /** #1737: pool and legacy wrappers must share one serial-ownership domain. */
+    @Test
+    fun connectedTestPoolAndLegacyWrappersCannotMutateOneSerialConcurrently() {
+        runShellHarness(
+            "tests/scripts/connected-test-serial-ownership-test.sh",
+            timeoutSeconds = 180,
         )
     }
 

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -7,10 +7,9 @@ set -euo pipefail
 # and reviewers never sourced scripts/lib/avd-lock.sh, so parallel agents
 # SIGKILLed each other on the shared AVD. This thin wrapper:
 #
-#   1. Acquires the existing AVD lock (option 1) so siblings serialise
-#      politely on a single emulator instead of racing. When ANDROID_SERIAL
-#      is set it takes a *per-serial* lock (pool-ready) so distinct emulators
-#      do not block each other; otherwise it takes the single global lock.
+#   1. Resolves one emulator serial and acquires that serial's common ownership
+#      lock (option 1) so pool and non-pool wrappers never race on one AVD.
+#      Distinct emulators retain independent locks and run concurrently.
 #   2. Threads the per-worktree applicationIdSuffix (option 2) into the gradle
 #      invocation so each worktree's DEBUG apk installs under a distinct
 #      applicationId (e.g. com.pocketshell.app.i672) and multiple test apps
@@ -37,7 +36,7 @@ set -euo pipefail
 # a leftover base com.pocketshell.app[.test] off the pinned device before
 # installing a suffixed APK so it can't hijack the suffixed MainActivity launch.
 # Journey/E2e/Docker classes auto-default to --pool when >1 emulator is online
-# (P2); pass --no-pool to opt out. Single-emulator / CI runs are unchanged.
+# (P2); pass --no-pool to opt out.
 #
 # Flags:
 #   --suffix <token>     Per-worktree applicationIdSuffix token (e.g. i672).
@@ -68,10 +67,9 @@ set -euo pipefail
 #                        -Pandroid.testInstrumentationRunnerArguments.agentsPort=<port>
 #                        so the androidTest suite targets THIS lane's own
 #                        SSH/tmux fixture (no cross-talk). Both the serial and
-#                        the port are released on exit. Without --pool the
-#                        behaviour is unchanged: if ANDROID_SERIAL is preset it
-#                        locks that serial, otherwise it takes the single global
-#                        AVD lock, and the agents port defaults to 2222.
+#                        the port are released on exit. Without --pool the agents
+#                        port stays at 2222, but the wrapper still resolves and
+#                        owns exactly one emulator serial before mutation.
 #                        Pool emulators are booted via scripts/avd-pool.sh; the
 #                        agents fixture pool is scripts/agents-pool.sh. When no
 #                        emulator serial is claimable as a SECOND lane (single
@@ -110,6 +108,11 @@ source "$ROOT_DIR/scripts/lib/agents-pool.sh"
 # session's cgroup. A runaway then OOMs only its own scope; the parent session
 # survives. Degrades to a bare invocation when user systemd is unavailable (CI).
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+
+# Retain the selected serial's flock in this wrapper for the complete package,
+# install, and instrumentation window. Mutating children explicitly close their
+# inherited copy; the wrapper remains the continuous owner (issue #1737).
+export POCKETSHELL_AVD_LOCK_CONTINUOUS=1
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
@@ -318,7 +321,7 @@ if [[ "$CLEANUP_ONLY" != "1" ]]; then
 fi
 if [[ "$NETWORK_FAULT_RUN" == "1" ]]; then
   # Flag the run for the dedicated, machine-wide toxiproxy serialization lock
-  # acquired just before gradle (pocketshell_acquire_toxiproxy_lock). That lock
+  # acquired before serial selection (pocketshell_acquire_toxiproxy_lock). That lock
   # is SEPARATE from the per-serial AVD lock: two network-fault lanes on distinct
   # pool emulators each hold their own serial lock but must still not share the
   # singleton proxy, so they queue on this one shared lock.
@@ -326,20 +329,45 @@ if [[ "$NETWORK_FAULT_RUN" == "1" ]]; then
   printf 'Network-fault class detected (issue #776 P3): the toxiproxy proxy is a global singleton, so this run is SERIALIZED on a shared lock (no concurrent network-fault lanes).\n' >&2
 fi
 
-# Pool mode (issue #674): claim the first FREE emulator from the live pool and
-# export ANDROID_SERIAL so AGP/adb pin to it. The claim is held for the life of
-# this process and released on exit. This must happen BEFORE the per-serial
-# lock selection below so ANDROID_SERIAL is populated. When ANDROID_SERIAL is
-# already preset (explicit target), honour it and skip the pool claim.
-if [[ "$USE_POOL" == "1" && -z "${ANDROID_SERIAL:-}" ]]; then
-  export ADB ANDROID_SDK
-  # Called DIRECTLY (not via $(...)) so its exported ANDROID_SERIAL /
-  # POCKETSHELL_POOL_* vars and the EXIT release trap land in THIS shell.
-  if ! pocketshell_claim_pool_serial "$ROOT_DIR"; then
-    printf 'FAIL: could not claim a free pool emulator. Is scripts/avd-pool.sh start running?\n' >&2
+# Claim non-emulator shared infrastructure before the serial FD exists. This
+# keeps the toxiproxy holder and all of its setup children outside the serial
+# ownership tree by construction.
+if [[ "${POCKETSHELL_TOXIPROXY_SERIALIZED:-0}" == "1" ]]; then
+  if ! pocketshell_acquire_toxiproxy_lock "$ROOT_DIR"; then
+    printf 'FAIL: could not acquire the toxiproxy serialization lock.\n' >&2
     exit 1
   fi
-  printf 'Pool mode: running on %s\n' "${ANDROID_SERIAL:-?}" >&2
+fi
+
+# Common serial ownership (issues #674/#776/#1737): every wrapper mode that can
+# mutate an emulator must resolve and own one serial before package cleanup,
+# install, or instrumentation. The old one-emulator legacy path held the global
+# `avd-lock` while --pool held `avd-lock-emulator-5554`; those unrelated domains
+# let both processes mutate the same AVD. The existing free-serial allocator is
+# now the common allocator for pool, legacy, and cleanup-only modes.
+#
+# A caller-preset ANDROID_SERIAL remains an explicit target and takes the same
+# per-serial lock below. With no preset serial, zero online emulators fail
+# immediately; one or more online emulators are selected only when their common
+# per-serial lock is free. POCKETSHELL_POOL_WAIT_SECONDS retains the existing
+# bounded wait/fail-fast contract.
+if [[ -z "${ANDROID_SERIAL:-}" ]]; then
+  online_count="$(online_emulator_count)"
+  if (( online_count == 0 )); then
+    printf 'FAIL: no online emulator is available; refusing package/install mutation without per-serial ownership.\n' >&2
+    exit 1
+  fi
+  export ADB ANDROID_SDK
+  if ! pocketshell_claim_pool_serial "$ROOT_DIR"; then
+    printf 'FAIL: could not claim an emulator serial; all online serials are owned by other connected-test runs.\n' >&2
+    exit 1
+  fi
+  if [[ "$USE_POOL" == "1" ]]; then
+    printf 'Pool mode: running on %s\n' "${ANDROID_SERIAL:-?}" >&2
+  else
+    printf 'Pinned legacy lane to owned emulator (issue #1737): ANDROID_SERIAL=%s\n' \
+      "${ANDROID_SERIAL:-?}" >&2
+  fi
 fi
 
 # Pool mode (issue #724): claim a free agents fixture PORT to pair with the
@@ -357,37 +385,125 @@ if [[ "$USE_POOL" == "1" && -z "${POCKETSHELL_AGENTS_PORT:-}" ]]; then
   printf 'Pool mode: agents fixture on host port %s\n' "${POCKETSHELL_AGENTS_PORT:-?}" >&2
 fi
 
-# P1 (issue #776) — always pin ANDROID_SERIAL when MORE than one emulator is
-# online, even WITHOUT --pool. AGP's connected DeviceProvider installs +
-# instruments on EVERY online device by default, so the instant the avd-pool is
-# up a bare `connected-test.sh` (no --pool) cross-installs onto the busy pool
-# emulators and SIGKILLs whatever sibling lane is mid-run there (the
-# `Process crashed`/signal-9 family). Claiming + pinning a single FREE serial
-# closes that fan-out hole on the non-pool path too. Skipped when:
-#   * --pool already claimed a serial above (ANDROID_SERIAL set),
-#   * the caller preset ANDROID_SERIAL (explicit target),
-#   * a cleanup-only run, OR
-#   * 0/1 emulator online (single-AVD / CI is byte-for-byte unchanged: AGP
-#     already targets the one device, no pin needed).
-if [[ "$CLEANUP_ONLY" != "1" && -z "${ANDROID_SERIAL:-}" ]]; then
-  if (( "$(online_emulator_count)" > 1 )); then
-    export ADB ANDROID_SDK
-    if ! pocketshell_claim_pool_serial "$ROOT_DIR"; then
-      printf 'FAIL: >1 emulator online but no free one to pin. Other lanes hold them all.\n' >&2
-      printf '      Wait for a lane to finish, or boot more pool emulators (scripts/avd-pool.sh start).\n' >&2
-      exit 1
-    fi
-    printf 'Auto-pinned to a free emulator (issue #776): ANDROID_SERIAL=%s\n' "${ANDROID_SERIAL:-?}" >&2
-  fi
+resolved_serial_lock=""
+if [[ -n "${ANDROID_SERIAL:-}" && -z "${POCKETSHELL_AVD_LOCK_ACQUIRED:-}" ]]; then
+  # The caller-pinned path is resolved before its serial FD is opened.
+  resolved_serial_lock="$(pocketshell_avd_lock_file_for_serial "$ROOT_DIR" "$ANDROID_SERIAL")"
 fi
 
-# Per-serial lock when a specific emulator is targeted; otherwise the single
-# global lock. This keeps single-emulator agents serialised (option 1) while
-# distinct emulators (pool mode) do not block each other.
-if [[ -n "${ANDROID_SERIAL:-}" ]]; then
-  POCKETSHELL_AVD_LOCK_FILE="$(pocketshell_avd_lock_file_for_serial "$ROOT_DIR" "$ANDROID_SERIAL")"
-  export POCKETSHELL_AVD_LOCK_FILE
+# Every path has an explicit serial at this point. Pool/auto claims already hold
+# this lock and mark it acquired; a preset serial acquires the identical file at
+# the common acquire call below.
+if [[ -n "${POCKETSHELL_AVD_LOCK_ACQUIRED:-}" ]]; then
+  resolved_serial_lock="${POCKETSHELL_AVD_LOCK_FILE:-}"
 fi
+if [[ -n "${POCKETSHELL_AVD_LOCK_ACQUIRED:-}" \
+      && -n "${POCKETSHELL_AVD_LOCK_FILE:-}" \
+      && "$POCKETSHELL_AVD_LOCK_FILE" != "$resolved_serial_lock" ]]; then
+  printf 'FAIL: inherited emulator lock %s does not own selected serial %s (%s); refusing mutation.\n' \
+    "$POCKETSHELL_AVD_LOCK_FILE" "$ANDROID_SERIAL" "$resolved_serial_lock" >&2
+  exit 1
+fi
+POCKETSHELL_AVD_LOCK_FILE="$resolved_serial_lock"
+export POCKETSHELL_AVD_LOCK_FILE
+
+MUTATION_PID=""
+POCKETSHELL_AVD_OWNERSHIP_LOST=""
+
+pocketshell_collect_descendant_pids_postorder() {
+  local pid="$1"
+  local children=""
+  if [[ -r "/proc/$pid/task/$pid/children" ]]; then
+    IFS= read -r children < "/proc/$pid/task/$pid/children" || true
+  fi
+  local child
+  for child in $children; do
+    pocketshell_collect_descendant_pids_postorder "$child"
+    POCKETSHELL_DESCENDANT_PIDS+=("$child")
+  done
+}
+
+pocketshell_process_is_running() {
+  local pid="$1"
+  [[ -r "/proc/$pid/stat" ]] || return 1
+  local _pid _comm state
+  read -r _pid _comm state _ < "/proc/$pid/stat" || return 1
+  [[ "$state" != "Z" ]]
+}
+
+pocketshell_terminate_process_tree() {
+  local root_pid="$1"
+  POCKETSHELL_DESCENDANT_PIDS=()
+  pocketshell_collect_descendant_pids_postorder "$root_pid"
+  local victims=("${POCKETSHELL_DESCENDANT_PIDS[@]}")
+  victims+=("$root_pid")
+
+  local pid
+  for pid in "${victims[@]}"; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+
+  local attempt running
+  for ((attempt = 0; attempt < 40; attempt++)); do
+    running=0
+    for pid in "${victims[@]}"; do
+      pocketshell_process_is_running "$pid" && running=1
+    done
+    (( running == 0 )) && return 0
+    pocketshell_run_without_avd_lock_fd sleep 0.05
+  done
+
+  # A wedged child or ignored TERM must not outlive ownership cleanup.
+  for pid in "${victims[@]}"; do
+    if pocketshell_process_is_running "$pid"; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+  done
+  for ((attempt = 0; attempt < 40; attempt++)); do
+    running=0
+    for pid in "${victims[@]}"; do
+      pocketshell_process_is_running "$pid" && running=1
+    done
+    (( running == 0 )) && return 0
+    pocketshell_run_without_avd_lock_fd sleep 0.05
+  done
+  return 1
+}
+
+# Run one device-mutating command with the child's flock copy closed while the
+# wrapper retains its own FD. The sentinel is monitored concurrently. If it
+# dies after a boundary assertion, the still-locked wrapper terminates the
+# child, reports ownership loss, and releases only after mutation has stopped.
+pocketshell_run_guarded_mutation() {
+  pocketshell_assert_avd_lock_owned "$POCKETSHELL_AVD_LOCK_FILE" || return 70
+
+  pocketshell_start_without_avd_lock_fd "$@"
+  local child_pid="$POCKETSHELL_AVD_CHILD_PID"
+  MUTATION_PID="$child_pid"
+  local ownership_lost=0
+  while kill -0 "$child_pid" 2>/dev/null; do
+    if ! pocketshell_assert_avd_lock_owned "$POCKETSHELL_AVD_LOCK_FILE"; then
+      ownership_lost=1
+      POCKETSHELL_AVD_OWNERSHIP_LOST=1
+      if [[ -n "${SCOPE_UNIT:-}" ]]; then
+        pocketshell_run_without_avd_lock_fd \
+          systemctl --user kill --signal=TERM --kill-whom=all "$SCOPE_UNIT.scope" \
+          >/dev/null 2>&1 || true
+      fi
+      pocketshell_terminate_process_tree "$child_pid"
+      break
+    fi
+    pocketshell_run_without_avd_lock_fd sleep 0.05
+  done
+
+  local child_rc=0
+  wait "$child_pid" || child_rc=$?
+  MUTATION_PID=""
+  if (( ownership_lost == 1 )); then
+    return 70
+  fi
+  return "$child_rc"
+}
 
 cleanup_suffixed_packages() {
   # Optional first arg:
@@ -407,7 +523,20 @@ cleanup_suffixed_packages() {
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
     adb_target=("$ADB" -s "$ANDROID_SERIAL")
   fi
-  local pkg removed=0
+  pocketshell_assert_avd_lock_owned "$POCKETSHELL_AVD_LOCK_FILE"
+  local package_file="${TMPDIR:-/tmp}/pocketshell-packages.$$.$RANDOM"
+  : > "$package_file"
+  local list_rc=0
+  pocketshell_run_guarded_mutation "${adb_target[@]}" shell pm list packages \
+    > "$package_file" || list_rc=$?
+  if (( list_rc != 0 )); then
+    pocketshell_run_without_avd_lock_fd rm -f "$package_file"
+    if [[ -n "$POCKETSHELL_AVD_OWNERSHIP_LOST" ]]; then
+      return 70
+    fi
+    return "$list_rc"
+  fi
+  local pkg removed=0 cleanup_rc=0
   # The default (no --include-base) match: the per-worktree convention
   # com.pocketshell.app.i<token> (and its .test sibling) ONLY. This deliberately
   # excludes:
@@ -434,18 +563,30 @@ cleanup_suffixed_packages() {
     self_test_pkg="com.pocketshell.app.$SUFFIX.test"
   fi
   while IFS= read -r pkg; do
+    pkg="${pkg#package:}"
     [[ -n "$pkg" ]] || continue
+    [[ "$pkg" =~ $match_re ]] || continue
     if [[ "$include_base" == "1" && ( "$pkg" == "$self_pkg" || "$pkg" == "$self_test_pkg" ) ]]; then
       continue
     fi
+    # Re-check immediately before each destructive adb operation. If the holder
+    # was killed after allocation, fail closed instead of uninstalling another
+    # run's package without ownership (issue #1737).
+    pocketshell_assert_avd_lock_owned "$POCKETSHELL_AVD_LOCK_FILE"
     printf 'Uninstalling leftover package: %s\n' "$pkg" >&2
-    "${adb_target[@]}" uninstall "$pkg" >/dev/null 2>&1 || true
+    local uninstall_rc=0
+    pocketshell_run_guarded_mutation "${adb_target[@]}" uninstall "$pkg" \
+      >/dev/null || uninstall_rc=$?
+    if (( uninstall_rc != 0 )) && [[ -n "$POCKETSHELL_AVD_OWNERSHIP_LOST" ]]; then
+      cleanup_rc=70
+      break
+    fi
     removed=$((removed + 1))
-  done < <(
-    "${adb_target[@]}" shell pm list packages 2>/dev/null \
-      | sed 's/^package://' \
-      | grep -E "$match_re" || true
-  )
+  done < "$package_file"
+  pocketshell_run_without_avd_lock_fd rm -f "$package_file"
+  if (( cleanup_rc != 0 )); then
+    return "$cleanup_rc"
+  fi
   if [[ "$include_base" == "1" ]]; then
     printf 'Pre-run sweep (incl. base) removed %s package(s).\n' "$removed" >&2
   else
@@ -456,22 +597,11 @@ cleanup_suffixed_packages() {
 # Acquire the AVD lock for BOTH cleanup and test runs so the sweep cannot race
 # a sibling's install/test on the same device.
 pocketshell_acquire_avd_lock "$ROOT_DIR"
+pocketshell_assert_avd_lock_owned "$POCKETSHELL_AVD_LOCK_FILE"
 
 if [[ "$CLEANUP_ONLY" == "1" ]]; then
   cleanup_suffixed_packages
   exit 0
-fi
-
-# P3 (issue #776) — serialize network-fault lanes on the shared toxiproxy lock
-# (the proxy is a global singleton; concurrent lanes corrupt each other's
-# toxics). Acquired AFTER the per-serial AVD lock so a network-fault lane holds
-# BOTH its device lock and exclusive proxy access. A blocking flock: a second
-# network-fault lane queues here until the first releases on exit.
-if [[ "${POCKETSHELL_TOXIPROXY_SERIALIZED:-0}" == "1" ]]; then
-  if ! pocketshell_acquire_toxiproxy_lock "$ROOT_DIR"; then
-    printf 'FAIL: could not acquire the toxiproxy serialization lock.\n' >&2
-    exit 1
-  fi
 fi
 
 # P0 (issue #776) — pre-run hygiene sweep on a SUFFIXED, SERIAL-PINNED lane.
@@ -539,23 +669,27 @@ fi
 GRADLE_INIT_ARGS=()
 LANE_INIT_SCRIPT=""
 if [[ "$USE_POOL" == "1" && -n "$SUFFIX" ]]; then
-  LANE_INIT_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/pocketshell-lane-init-$SUFFIX.XXXXXX.gradle")"
+  LANE_INIT_SCRIPT="${TMPDIR:-/tmp}/pocketshell-lane-init-$SUFFIX.$$.$RANDOM.gradle"
   # Relocate each project's build dir to build/lane-<suffix> under the project
   # dir, so concurrent lanes never share intermediates. Nesting UNDER the
   # existing per-project `build/` keeps the lane outputs inside the already
   # gitignored build tree (/build, /app/build, /shared/*/build, */build/), so a
   # lane run never pollutes `git status` or risks being committed. allprojects
   # covers the root + every module the connected build touches.
-  cat > "$LANE_INIT_SCRIPT" <<INIT
-allprojects {
-    layout.buildDirectory.set(file("\${projectDir}/build/lane-$SUFFIX"))
-}
-INIT
+  printf '%s\n' \
+    'allprojects {' \
+    "    layout.buildDirectory.set(file(\"\${projectDir}/build/lane-$SUFFIX\"))" \
+    '}' > "$LANE_INIT_SCRIPT"
   GRADLE_INIT_ARGS+=("--init-script" "$LANE_INIT_SCRIPT")
   printf 'Pool lane build isolation: per-project build dir -> build/lane-%s\n' "$SUFFIX" >&2
   # Clean up the temp init script when this shell exits (the build dirs
   # themselves are left for artifact inspection; sweep with the suffix sweep).
-  trap 'rm -f "$LANE_INIT_SCRIPT" 2>/dev/null || true; pocketshell_release_all' EXIT
+  # Invoked indirectly by the EXIT trap below.
+  # shellcheck disable=SC2317
+  pocketshell_cleanup_lane_init() {
+    pocketshell_run_without_avd_lock_fd rm -f "$LANE_INIT_SCRIPT" 2>/dev/null || true
+  }
+  trap 'pocketshell_cleanup_lane_init; pocketshell_release_all' EXIT
 fi
 
 # Issue #730: the heavy gradle build runs inside its OWN transient systemd
@@ -580,24 +714,25 @@ SCOPE_UNIT="pocketshell-test-${SCOPE_TOKEN//[^A-Za-z0-9._-]/_}-${SCOPE_SERIAL//[
 # trap then fires on our way out and releases the claim too. The child here is
 # the scope-run wrapper (systemd-run --scope), which propagates the signal to
 # the scoped gradle process tree.
-GRADLE_PID=""
 # Invoked indirectly via the INT/TERM traps below; shellcheck can't see that.
 # shellcheck disable=SC2317
 forward_signal() {
   local sig="$1"
-  if [[ -n "$GRADLE_PID" ]]; then
-    kill -s "$sig" "$GRADLE_PID" 2>/dev/null || true
+  if [[ -n "$MUTATION_PID" ]]; then
+    kill -s "$sig" "$MUTATION_PID" 2>/dev/null || true
   fi
 }
 trap 'forward_signal INT' INT
 trap 'forward_signal TERM' TERM
 
-pocketshell_scope_run "$SCOPE_UNIT" \
+# The wrapper retains the serial flock while scope-run/Gradle has its inherited
+# copy closed. Helper death is monitored until the mutation process exits.
+set +e
+pocketshell_run_guarded_mutation pocketshell_scope_run "$SCOPE_UNIT" \
   ./gradlew --no-daemon "$CONNECTED_TASK" \
   "${GRADLE_INIT_ARGS[@]}" \
   "${GRADLE_SUFFIX_ARGS[@]}" \
-  "${GRADLE_ARGS[@]}" &
-GRADLE_PID="$!"
-wait "$GRADLE_PID"
+  "${GRADLE_ARGS[@]}"
 rc=$?
+set -e
 exit "$rc"

--- a/scripts/lib/agents-pool.sh
+++ b/scripts/lib/agents-pool.sh
@@ -53,6 +53,14 @@ pocketshell_agents_lock_file_for_port() {
   printf '%s/build/.agents-port-lock-%s\n' "$root_dir" "$port"
 }
 
+_pocketshell_agents_run_without_avd_lock_fd() {
+  if declare -F pocketshell_run_without_avd_lock_fd >/dev/null 2>&1; then
+    pocketshell_run_without_avd_lock_fd "$@"
+  else
+    "$@"
+  fi
+}
+
 # --- fixture lifecycle ----------------------------------------------------
 
 # Bring up ONE agents fixture lane on $port (idempotent). When port==2222 and
@@ -62,8 +70,7 @@ pocketshell_agents_lock_file_for_port() {
 pocketshell_agents_fixture_up() {
   local root_dir="$1"
   local port="$2"
-  local compose_file
-  compose_file="$(pocketshell_agents_compose_file "$root_dir")"
+  local compose_file="$root_dir/tests/docker/docker-compose.yml"
 
   local project container
   if [[ "$port" == "2222" ]]; then
@@ -72,8 +79,8 @@ pocketshell_agents_fixture_up() {
     project=""
     container="pocketshell-test-agents"
   else
-    project="$(pocketshell_agents_project_name_for_port "$port")"
-    container="$(pocketshell_agents_container_name_for_port "$port")"
+    project="psagents$port"
+    container="pocketshell-test-agents-$port"
   fi
 
   local env_prefix=(env "AGENTS_HOST_PORT=$port" "AGENTS_CONTAINER_NAME=$container")
@@ -83,23 +90,23 @@ pocketshell_agents_fixture_up() {
 
   printf 'Bringing up agents fixture lane on host port %s (container %s)...\n' \
     "$port" "$container" >&2
-  "${env_prefix[@]}" docker compose -f "$compose_file" up -d --build agents >&2
+  _pocketshell_agents_run_without_avd_lock_fd \
+    "${env_prefix[@]}" docker compose -f "$compose_file" up -d --build agents >&2
 }
 
 # Tear down ONE agents fixture lane on $port.
 pocketshell_agents_fixture_down() {
   local root_dir="$1"
   local port="$2"
-  local compose_file
-  compose_file="$(pocketshell_agents_compose_file "$root_dir")"
+  local compose_file="$root_dir/tests/docker/docker-compose.yml"
 
   local project container
   if [[ "$port" == "2222" ]]; then
     project=""
     container="pocketshell-test-agents"
   else
-    project="$(pocketshell_agents_project_name_for_port "$port")"
-    container="$(pocketshell_agents_container_name_for_port "$port")"
+    project="psagents$port"
+    container="pocketshell-test-agents-$port"
   fi
 
   local env_prefix=(env "AGENTS_HOST_PORT=$port" "AGENTS_CONTAINER_NAME=$container")
@@ -108,7 +115,8 @@ pocketshell_agents_fixture_down() {
   fi
 
   printf 'Tearing down agents fixture lane on host port %s...\n' "$port" >&2
-  "${env_prefix[@]}" docker compose -f "$compose_file" down -v >&2 || true
+  _pocketshell_agents_run_without_avd_lock_fd \
+    "${env_prefix[@]}" docker compose -f "$compose_file" down -v >&2 || true
 }
 
 # Wait until the agents fixture on $port answers SSH healthy. Polls the named
@@ -121,19 +129,26 @@ pocketshell_agents_fixture_wait_healthy() {
   if [[ "$port" == "2222" ]]; then
     container="pocketshell-test-agents"
   else
-    container="$(pocketshell_agents_container_name_for_port "$port")"
+    container="pocketshell-test-agents-$port"
   fi
 
   local deadline=$((SECONDS + timeout_seconds))
+  local status_file="${TMPDIR:-/tmp}/pocketshell-agents-health.$$.$RANDOM"
   while (( SECONDS < deadline )); do
-    local status
-    status="$(docker inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || true)"
+    local status=""
+    : > "$status_file"
+    _pocketshell_agents_run_without_avd_lock_fd \
+      docker inspect --format='{{.State.Health.Status}}' "$container" \
+      > "$status_file" 2>/dev/null || true
+    IFS= read -r status < "$status_file" || true
     if [[ "$status" == "healthy" ]]; then
+      _pocketshell_agents_run_without_avd_lock_fd rm -f "$status_file"
       printf 'agents fixture on port %s healthy (%s).\n' "$port" "$container" >&2
       return 0
     fi
-    sleep 2
+    _pocketshell_agents_run_without_avd_lock_fd sleep 2
   done
+  _pocketshell_agents_run_without_avd_lock_fd rm -f "$status_file"
   printf 'FAIL: agents fixture on port %s (%s) not healthy within %ss.\n' \
     "$port" "$container" "$timeout_seconds" >&2
   return 1
@@ -141,57 +156,67 @@ pocketshell_agents_fixture_wait_healthy() {
 
 # --- port claim/release (mirrors the per-serial AVD claim in avd-lock.sh) ---
 
+_pocketshell_hold_agents_port_lock() {
+  local lock_file="$1"
+  local ready_file="$2"
+  exec >/dev/null 2>/dev/null
+  if ! exec 9>"$lock_file"; then
+    exit 1
+  fi
+  if ! flock -n 9; then
+    exit 1
+  fi
+  printf 'ready\n' > "$ready_file"
+  local sleep_pid=""
+  trap '[[ -n "$sleep_pid" ]] && kill "$sleep_pid" 2>/dev/null || true; exit 0' HUP INT TERM
+  while :; do
+    sleep 3600 9>&- &
+    sleep_pid="$!"
+    wait "$sleep_pid" || true
+  done
+}
+
 # Try a non-blocking flock on a port's lock file. Echoes the holder PID on
 # success; returns non-zero if a sibling holds it.
 _pocketshell_agents_try_lock_port() {
   local root_dir="$1"
   local port="$2"
-  local lock_file
-  lock_file="$(pocketshell_agents_lock_file_for_port "$root_dir" "$port")"
-  mkdir -p "$(dirname "$lock_file")"
+  local lock_file="$root_dir/build/.agents-port-lock-$port"
+  _pocketshell_agents_run_without_avd_lock_fd mkdir -p "$root_dir/build"
 
-  local state_dir
-  state_dir="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-agents-claim.XXXXXX")"
+  local state_dir="${TMPDIR:-/tmp}/pocketshell-agents-claim.$$.$RANDOM"
+  _pocketshell_agents_run_without_avd_lock_fd mkdir -p "$state_dir"
   local ready_file="$state_dir/ready"
+  POCKETSHELL_AGENTS_TRY_HOLDER_PID=""
 
-  (
-    exec >/dev/null 2>/dev/null
-    if ! exec 9>"$lock_file"; then
-      exit 1
-    fi
-    if ! flock -n 9; then
-      exit 1
-    fi
-    printf 'ready\n' > "$ready_file"
-    sleep_pid=""
-    trap '[[ -n "$sleep_pid" ]] && kill "$sleep_pid" 2>/dev/null || true; exit 0' HUP INT TERM
-    while :; do
-      sleep 3600 9>&- &
-      sleep_pid="$!"
-      wait "$sleep_pid" || true
-    done
-  ) &
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" == "1" \
+        && "${POCKETSHELL_AVD_LOCK_FD:-}" =~ ^[0-9]+$ ]]; then
+    _pocketshell_hold_agents_port_lock "$lock_file" "$ready_file" \
+      {POCKETSHELL_AVD_LOCK_FD}>&- &
+  else
+    _pocketshell_hold_agents_port_lock "$lock_file" "$ready_file" &
+  fi
   local holder_pid="$!"
 
   local waited=0
   while [[ ! -e "$ready_file" ]]; do
     if ! kill -0 "$holder_pid" 2>/dev/null; then
-      rm -rf "$state_dir"
+      _pocketshell_agents_run_without_avd_lock_fd rm -rf "$state_dir"
       wait "$holder_pid" 2>/dev/null || true
       return 1
     fi
-    sleep 0.05
+    _pocketshell_agents_run_without_avd_lock_fd sleep 0.05
     waited=$((waited + 1))
     if (( waited > 100 )); then
       kill "$holder_pid" 2>/dev/null || true
       wait "$holder_pid" 2>/dev/null || true
-      rm -rf "$state_dir"
+      _pocketshell_agents_run_without_avd_lock_fd rm -rf "$state_dir"
       return 1
     fi
   done
 
-  rm -rf "$state_dir"
-  printf '%s\n' "$holder_pid"
+  _pocketshell_agents_run_without_avd_lock_fd rm -rf "$state_dir"
+  POCKETSHELL_AGENTS_TRY_HOLDER_PID="$holder_pid"
   return 0
 }
 
@@ -214,14 +239,14 @@ pocketshell_claim_agents_port() {
   local wait_seconds="${POCKETSHELL_AGENTS_WAIT_SECONDS:-600}"
   local deadline=$((SECONDS + wait_seconds))
 
-  local ports
-  ports="$(pocketshell_agents_pool_ports)"
+  local ports="${POCKETSHELL_AGENTS_POOL_PORTS:-2222 2243 2244 2245}"
 
   while :; do
     local port
     for port in $ports; do
       local holder_pid
-      if holder_pid="$(_pocketshell_agents_try_lock_port "$root_dir" "$port")"; then
+      if _pocketshell_agents_try_lock_port "$root_dir" "$port"; then
+        holder_pid="$POCKETSHELL_AGENTS_TRY_HOLDER_PID"
         # Won the port lock. Bring its fixture up + wait healthy; if that
         # fails, release the lock and try the next candidate.
         if ! pocketshell_agents_fixture_up "$root_dir" "$port" \
@@ -251,7 +276,7 @@ pocketshell_claim_agents_port() {
       return 1
     fi
     printf 'All agents fixture ports busy; waiting for a free one...\n' >&2
-    sleep 3
+    _pocketshell_agents_run_without_avd_lock_fd sleep 3
   done
 }
 

--- a/scripts/lib/avd-lock.sh
+++ b/scripts/lib/avd-lock.sh
@@ -87,6 +87,52 @@ pocketshell_avd_lock_file_for_serial() {
   pocketshell_avd_lock_path "avd-lock-$token"
 }
 
+# connected-test.sh needs a stronger lifetime than the general gate helper:
+# the WRAPPER retains this flock FD continuously while each device-mutating
+# child gets an explicitly closed copy. A small sentinel remains so unexpected
+# ownership-helper death is observable, but killing it cannot release the real
+# lock out from under the wrapper (issue #1737 review correction).
+_pocketshell_start_continuous_avd_lock() {
+  local lock_file="$1"
+  local acquire_mode="${2:-blocking}"
+  mkdir -p "$(dirname "$lock_file")"
+
+  exec {POCKETSHELL_AVD_LOCK_FD}>"$lock_file"
+  if [[ "$acquire_mode" == "nonblocking" ]]; then
+    if ! flock -n "$POCKETSHELL_AVD_LOCK_FD"; then
+      exec {POCKETSHELL_AVD_LOCK_FD}>&-
+      unset POCKETSHELL_AVD_LOCK_FD
+      return 1
+    fi
+  elif ! flock "$POCKETSHELL_AVD_LOCK_FD"; then
+    exec {POCKETSHELL_AVD_LOCK_FD}>&-
+    unset POCKETSHELL_AVD_LOCK_FD
+    return 1
+  fi
+
+  (
+    # The sentinel is deliberately NOT another flock owner. The calling
+    # wrapper's FD above is the single continuous authority. The close
+    # redirection is attached to this background process creation below, so
+    # there is no post-fork interval in which the sentinel owns that FD.
+    exec >/dev/null 2>/dev/null
+    local sleep_pid=""
+    trap '[[ -n "$sleep_pid" ]] && kill "$sleep_pid" 2>/dev/null || true; exit 0' HUP INT TERM
+    while :; do
+      sleep 3600 &
+      sleep_pid="$!"
+      wait "$sleep_pid" || true
+    done
+  ) {POCKETSHELL_AVD_LOCK_FD}>&- &
+
+  export POCKETSHELL_AVD_LOCK_HOLDER_PID="$!"
+  export POCKETSHELL_AVD_LOCK_OWNER_PID="$$"
+  export POCKETSHELL_AVD_LOCK_ACQUIRED=1
+  export POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED=1
+  export POCKETSHELL_AVD_LOCK_FILE="$lock_file"
+  trap pocketshell_release_all EXIT
+}
+
 pocketshell_acquire_avd_lock() {
   # $1 (root_dir) is accepted for call-site compatibility and unused: the lock
   # path is machine-wide, not checkout-relative (issue #1657).
@@ -118,12 +164,23 @@ pocketshell_acquire_avd_lock() {
     echo "AVD lock ($lock_file) held by another emulator-touching run; queuing for it..." >&2
   fi
 
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS:-}" == "1" ]]; then
+    if ! _pocketshell_start_continuous_avd_lock "$lock_file" blocking; then
+      echo "failed to acquire continuous AVD lock: $lock_file" >&2
+      return 1
+    fi
+    echo "Acquired continuous AVD lock: $lock_file" >&2
+    return 0
+  fi
+
   local state_dir
   state_dir="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-avd-lock.XXXXXX")"
   local ready_file="$state_dir/ready"
   local error_file="$state_dir/error"
 
   (
+    # The holder is deliberately a separate process so arbitrary child
+    # commands do not inherit the flock FD (tests/scripts/avd-lock-test.sh).
     if ! exec 9>"$lock_file"; then
       printf 'failed to open lock file: %s\n' "$lock_file" > "$error_file"
       exit 1
@@ -167,6 +224,87 @@ pocketshell_acquire_avd_lock() {
   trap pocketshell_release_all EXIT
 }
 
+# Verify that this process still owns the exact lock selected for its serial.
+# A boolean environment marker is not proof: a killed holder, inherited stale
+# state, or a later lock-path overwrite could otherwise let package cleanup or
+# Gradle mutate an emulator after ownership was lost (issue #1737).
+pocketshell_assert_avd_lock_owned() {
+  local expected_lock_file="${1:-${POCKETSHELL_AVD_LOCK_FILE:-}}"
+  if [[ -z "$expected_lock_file" || "${POCKETSHELL_AVD_LOCK_FILE:-}" != "$expected_lock_file" ]]; then
+    echo "FAIL: emulator ownership lock path is missing or changed (expected: ${expected_lock_file:-unset}; actual: ${POCKETSHELL_AVD_LOCK_FILE:-unset}). Refusing device mutation." >&2
+    return 1
+  fi
+
+  local holder_pid=""
+  if [[ -n "${POCKETSHELL_POOL_HOLDER_PID:-}" ]]; then
+    holder_pid="${POCKETSHELL_POOL_HOLDER_PID:-}"
+  elif [[ -n "${POCKETSHELL_AVD_LOCK_HOLDER_PID:-}" ]]; then
+    holder_pid="${POCKETSHELL_AVD_LOCK_HOLDER_PID:-}"
+  fi
+  if [[ -z "$holder_pid" || ! "$holder_pid" =~ ^[0-9]+$ ]] \
+      || ! kill -0 "$holder_pid" 2>/dev/null; then
+    echo "FAIL: lost emulator ownership for ${ANDROID_SERIAL:-unknown serial} ($expected_lock_file); lock holder is gone. Refusing device mutation." >&2
+    return 1
+  fi
+
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" == "1" ]]; then
+    local lock_fd="${POCKETSHELL_AVD_LOCK_FD:-}"
+    if [[ ! "$lock_fd" =~ ^[0-9]+$ || ! -e "/proc/$BASHPID/fd/$lock_fd" ]]; then
+      echo "FAIL: lost emulator ownership for ${ANDROID_SERIAL:-unknown serial} ($expected_lock_file); wrapper flock FD is gone. Refusing device mutation." >&2
+      return 1
+    fi
+    if [[ ! "/proc/$BASHPID/fd/$lock_fd" -ef "$expected_lock_file" ]]; then
+      echo "FAIL: lost emulator ownership for ${ANDROID_SERIAL:-unknown serial} ($expected_lock_file); wrapper flock FD targets another file. Refusing device mutation." >&2
+      return 1
+    fi
+  fi
+
+  # The live holder must actually own the flock. If a stale PID happens to be
+  # reused but the lock is free, this non-blocking probe catches it. In
+  # continuous mode the probe process closes the wrapper FD in its creation
+  # redirection, so even a wrapper SIGKILL during this check cannot leak it.
+  local lock_was_free=1
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" == "1" ]]; then
+    ( flock -n 9 ) {POCKETSHELL_AVD_LOCK_FD}>&- 9>"$expected_lock_file" \
+      && lock_was_free=0
+  elif ( flock -n 9 ) 9>"$expected_lock_file"; then
+    lock_was_free=0
+  fi
+  if (( lock_was_free == 0 )); then
+    echo "FAIL: lost emulator ownership for ${ANDROID_SERIAL:-unknown serial} ($expected_lock_file); lock is no longer held. Refusing device mutation." >&2
+    return 1
+  fi
+}
+
+# Run a child without leaking the wrapper-owned continuous flock FD into it.
+# The wrapper keeps its own descriptor for the complete mutation window.
+pocketshell_run_without_avd_lock_fd() {
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" == "1" \
+        && "${POCKETSHELL_AVD_LOCK_FD:-}" =~ ^[0-9]+$ ]]; then
+    "$@" {POCKETSHELL_AVD_LOCK_FD}>&-
+  else
+    "$@"
+  fi
+}
+
+# Start an asynchronous child with the continuous flock FD closed by the
+# background-command redirection itself. Do NOT background
+# pocketshell_run_without_avd_lock_fd: Bash would first fork an intermediate
+# async function shell carrying the FD, then close it only in a grandchild.
+# This shape closes the descriptor at process creation, before either a shell
+# function body or its eventual external child can run (issue #1737 round 2).
+pocketshell_start_without_avd_lock_fd() {
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" == "1" \
+        && "${POCKETSHELL_AVD_LOCK_FD:-}" =~ ^[0-9]+$ ]]; then
+    "$@" {POCKETSHELL_AVD_LOCK_FD}>&- &
+  else
+    "$@" &
+  fi
+  # Consumed by the sourcing wrapper.
+  # shellcheck disable=SC2034
+  POCKETSHELL_AVD_CHILD_PID="$!"
+}
+
 # Combined EXIT handler so the single-lock release, the pool-claim release, and
 # the agents-fixture-port release never clobber each other's trap. Every acquire
 # path registers THIS handler; each inner release is a no-op when its own state
@@ -199,6 +337,26 @@ pocketshell_release_all() {
 # worktrees got two different files and two network-fault lanes could still
 # corrupt each other's toxics. The proxy is ONE global singleton, so it takes the
 # machine-wide anchor with NO per-serial token: every lane shares this one file.
+_pocketshell_hold_toxiproxy_lock() {
+  local lock_file="$1"
+  local ready_file="$2"
+  exec >/dev/null 2>/dev/null
+  if ! exec 9>"$lock_file"; then
+    exit 1
+  fi
+  if ! flock 9; then
+    exit 1
+  fi
+  printf 'ready\n' > "$ready_file"
+  local sleep_pid=""
+  trap '[[ -n "$sleep_pid" ]] && kill "$sleep_pid" 2>/dev/null || true; exit 0' HUP INT TERM
+  while :; do
+    sleep 3600 9>&- &
+    sleep_pid="$!"
+    wait "$sleep_pid" || true
+  done
+}
+
 pocketshell_acquire_toxiproxy_lock() {
   local _root_dir_unused="$1"
   if [[ -n "${POCKETSHELL_TOXIPROXY_LOCK_OWNER_PID:-}" ]]; then
@@ -216,23 +374,13 @@ pocketshell_acquire_toxiproxy_lock() {
     echo "Toxiproxy serialization lock held by another network-fault lane; queuing..." >&2
   fi
 
-  (
-    exec >/dev/null 2>/dev/null
-    if ! exec 9>"$lock_file"; then
-      exit 1
-    fi
-    if ! flock 9; then
-      exit 1
-    fi
-    printf 'ready\n' > "$ready_file"
-    sleep_pid=""
-    trap '[[ -n "$sleep_pid" ]] && kill "$sleep_pid" 2>/dev/null || true; exit 0' HUP INT TERM
-    while :; do
-      sleep 3600 9>&- &
-      sleep_pid="$!"
-      wait "$sleep_pid" || true
-    done
-  ) &
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" == "1" \
+        && "${POCKETSHELL_AVD_LOCK_FD:-}" =~ ^[0-9]+$ ]]; then
+    _pocketshell_hold_toxiproxy_lock "$lock_file" "$ready_file" \
+      {POCKETSHELL_AVD_LOCK_FD}>&- &
+  else
+    _pocketshell_hold_toxiproxy_lock "$lock_file" "$ready_file" &
+  fi
   local holder_pid="$!"
 
   while [[ ! -e "$ready_file" ]]; do
@@ -271,14 +419,21 @@ pocketshell_release_avd_lock() {
   fi
 
   local holder_pid="${POCKETSHELL_AVD_LOCK_HOLDER_PID:-}"
-  if [[ -z "$holder_pid" ]]; then
-    return 0
-  fi
 
-  kill "$holder_pid" 2>/dev/null || true
-  wait "$holder_pid" 2>/dev/null || true
+  if [[ -n "$holder_pid" ]]; then
+    kill "$holder_pid" 2>/dev/null || true
+    wait "$holder_pid" 2>/dev/null || true
+  fi
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" == "1" \
+        && "${POCKETSHELL_AVD_LOCK_FD:-}" =~ ^[0-9]+$ ]]; then
+    flock -u "$POCKETSHELL_AVD_LOCK_FD" 2>/dev/null || true
+    exec {POCKETSHELL_AVD_LOCK_FD}>&-
+    unset POCKETSHELL_AVD_LOCK_FD
+  fi
   unset POCKETSHELL_AVD_LOCK_HOLDER_PID
   unset POCKETSHELL_AVD_LOCK_OWNER_PID
+  unset POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED
+  unset POCKETSHELL_AVD_LOCK_ACQUIRED
 }
 
 # ---------------------------------------------------------------------------
@@ -417,7 +572,17 @@ pocketshell_claim_pool_serial() {
     local serial
     for serial in "${candidates[@]}"; do
       local holder_pid
-      if holder_pid="$(_pocketshell_pool_try_lock_serial "$root_dir" "$serial")"; then
+      if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS:-}" == "1" ]]; then
+        local lock_file
+        lock_file="$(pocketshell_avd_lock_file_for_serial "$root_dir" "$serial")"
+        if ! _pocketshell_start_continuous_avd_lock "$lock_file" nonblocking; then
+          continue
+        fi
+        holder_pid="$POCKETSHELL_AVD_LOCK_HOLDER_PID"
+      elif ! holder_pid="$(_pocketshell_pool_try_lock_serial "$root_dir" "$serial")"; then
+        continue
+      fi
+      if [[ -n "$holder_pid" ]]; then
         export ANDROID_SERIAL="$serial"
         export POCKETSHELL_POOL_HOLDER_PID="$holder_pid"
         export POCKETSHELL_POOL_OWNER_PID="$$"
@@ -428,7 +593,9 @@ pocketshell_claim_pool_serial() {
         # acquired so a subsequent pocketshell_acquire_avd_lock early-returns
         # instead of dead-locking by trying to re-grab the lock WE hold.
         export POCKETSHELL_AVD_LOCK_ACQUIRED=1
-        POCKETSHELL_AVD_LOCK_FILE="$(pocketshell_avd_lock_file_for_serial "$root_dir" "$serial")"
+        if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS:-}" != "1" ]]; then
+          POCKETSHELL_AVD_LOCK_FILE="$(pocketshell_avd_lock_file_for_serial "$root_dir" "$serial")"
+        fi
         export POCKETSHELL_AVD_LOCK_FILE
         trap pocketshell_release_all EXIT
         echo "Claimed pool emulator: $serial" >&2
@@ -460,7 +627,7 @@ pocketshell_release_pool_serial() {
     return 0
   fi
   local holder_pid="${POCKETSHELL_POOL_HOLDER_PID:-}"
-  if [[ -n "$holder_pid" ]]; then
+  if [[ -n "$holder_pid" && "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" != "1" ]]; then
     kill "$holder_pid" 2>/dev/null || true
     wait "$holder_pid" 2>/dev/null || true
   fi
@@ -469,5 +636,7 @@ pocketshell_release_pool_serial() {
   unset POCKETSHELL_POOL_SERIAL
   # The pool claim stood in for the per-serial AVD lock; clear that marker so a
   # later acquire in the same shell can take a fresh lock if needed.
-  unset POCKETSHELL_AVD_LOCK_ACQUIRED
+  if [[ "${POCKETSHELL_AVD_LOCK_CONTINUOUS_ACQUIRED:-}" != "1" ]]; then
+    unset POCKETSHELL_AVD_LOCK_ACQUIRED
+  fi
 }

--- a/tests/scripts/avd-pool-test.sh
+++ b/tests/scripts/avd-pool-test.sh
@@ -218,10 +218,10 @@ failed_run_still_releases_and_propagates_rc() {
     || fail "failed run leaked a pool serial: claimable=$claimable expected=$expected"
 }
 
-# Default non-pool path: a --suffix-only run (no --pool, no preset ANDROID_SERIAL)
-# must acquire and RELEASE the single base AVD lock. This guards the #672
-# deadlock fix interaction: after the run, build/.avd-lock is free again.
-non_pool_suffix_run_acquires_and_releases_base_lock() {
+# Issue #1737: the default non-pool path must resolve the one online emulator
+# and acquire/release the SAME per-serial ownership lock used by --pool. The old
+# global base lock was a split domain: pool and legacy could both mutate one AVD.
+non_pool_suffix_run_acquires_and_releases_serial_lock() {
   local sandbox="$1"
   make_sandbox "$sandbox" "emulator-5556"
   local sroot="$sandbox/root"
@@ -240,13 +240,19 @@ non_pool_suffix_run_acquires_and_releases_base_lock() {
   grep -q -- '-PpocketshellAppIdSuffix=i674' "$sandbox/args.txt" \
     || fail "suffix was not threaded into gradle on non-pool path"
 
-  # The base lock must be free again after the run (trap released the holder).
-  # Issue #1657: the base lock lives in the machine-wide lock dir (sandboxed
-  # here via POCKETSHELL_AVD_LOCK_DIR), no longer under the checkout's build/.
-  local base_lock="$POCKETSHELL_AVD_LOCK_DIR/avd-lock"
-  [[ -e "$base_lock" ]] || fail "base AVD lock file was never created on non-pool path"
-  flock -n "$base_lock" true \
-    || fail "non-pool run leaked the base AVD lock holder (deadlock-fix regression)"
+  grep -q 'Pinned legacy lane to owned emulator.*ANDROID_SERIAL=emulator-5556' "$sandbox/run.err" \
+    || fail "non-pool run did not pin the sole online emulator"
+
+  local serial_lock
+  serial_lock="$(
+    source "$sroot/scripts/lib/avd-lock.sh"
+    pocketshell_avd_lock_file_for_serial "$sroot" "emulator-5556"
+  )"
+  [[ -e "$serial_lock" ]] || fail "per-serial ownership lock was never created on non-pool path"
+  flock -n "$serial_lock" true \
+    || fail "non-pool run leaked the per-serial ownership lock"
+  [[ ! -e "$POCKETSHELL_AVD_LOCK_DIR/avd-lock" ]] \
+    || fail "non-pool run regressed to the split global lock domain"
 }
 
 run_case() {
@@ -260,6 +266,6 @@ run_case() {
 
 run_case reclaim_after_full_pool_run
 run_case failed_run_still_releases_and_propagates_rc
-run_case non_pool_suffix_run_acquires_and_releases_base_lock
+run_case non_pool_suffix_run_acquires_and_releases_serial_lock
 
 printf 'PASS: avd-pool claim/release\n'

--- a/tests/scripts/connected-test-serial-ownership-test.sh
+++ b/tests/scripts/connected-test-serial-ownership-test.sh
@@ -1,0 +1,988 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper-level serial-ownership regression harness (issue #1737).
+#
+# One physical emulator has one mutation domain: package cleanup, APK install,
+# and instrumentation.  Before #1737, the pool wrapper locked
+# `avd-lock-emulator-5554` while the one-emulator legacy wrapper locked the
+# unrelated global `avd-lock`. Both therefore entered the mutation window and
+# one instrumentation process was killed.
+#
+# This harness runs the REAL connected-test.sh from two fake worktrees against
+# one fake AVD. The fake gradle process models install + instrumentation and
+# hard-fails if another wrapper overlaps its mutation window. No emulator,
+# Docker daemon, Gradle daemon, or maintainer package is touched.
+
+unset POCKETSHELL_AVD_LOCK_ACQUIRED \
+      POCKETSHELL_AVD_LOCK_FILE \
+      POCKETSHELL_AVD_LOCK_FD \
+      POCKETSHELL_AVD_LOCK_HOLDER_PID \
+      POCKETSHELL_AVD_LOCK_OWNER_PID \
+      POCKETSHELL_POOL_HOLDER_PID \
+      POCKETSHELL_POOL_OWNER_PID \
+      POCKETSHELL_POOL_SERIAL \
+      POCKETSHELL_TOXIPROXY_LOCK_HOLDER_PID \
+      POCKETSHELL_TOXIPROXY_LOCK_OWNER_PID \
+      ANDROID_SERIAL \
+      ADB_SERIAL
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ACTIVE_CASE_SANDBOX=""
+ACTIVE_PROCESS_GROUPS=()
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+wait_for_file() {
+  local target="$1" timeout="${2:-10}"
+  local waited=0 limit=$((timeout * 20))
+  while [[ ! -e "$target" ]]; do
+    (( waited++ >= limit )) && return 1
+    sleep 0.05
+  done
+}
+
+wait_for_exit() {
+  local pid="$1" timeout="${2:-10}"
+  local waited=0 limit=$((timeout * 20))
+  while kill -0 "$pid" 2>/dev/null; do
+    (( waited++ >= limit )) && return 1
+    sleep 0.05
+  done
+  wait "$pid"
+}
+
+wait_until_stopped() {
+  local pid="$1" timeout="${2:-10}"
+  local waited=0 limit=$((timeout * 20))
+  while kill -0 "$pid" 2>/dev/null; do
+    (( waited++ >= limit )) && return 1
+    sleep 0.05
+  done
+}
+
+kill_group() {
+  local pid="${1:-}"
+  [[ -n "$pid" ]] || return 0
+  kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+  local waited=0
+  while ps -eo pgid=,stat= | awk -v pgid="$pid" \
+      '$1 == pgid && $2 !~ /^Z/ { found = 1 } END { exit !found }'; do
+    (( waited++ >= 100 )) && break
+    sleep 0.02
+  done
+  kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+  waited=0
+  while ps -eo pgid=,stat= | awk -v pgid="$pid" \
+      '$1 == pgid && $2 !~ /^Z/ { found = 1 } END { exit !found }'; do
+    (( waited++ >= 100 )) && break
+    sleep 0.02
+  done
+  wait "$pid" 2>/dev/null || true
+}
+
+cleanup_active_case() {
+  local pid
+  for pid in "${ACTIVE_PROCESS_GROUPS[@]:-}"; do
+    kill_group "$pid"
+  done
+  if [[ -n "$ACTIVE_CASE_SANDBOX" ]]; then
+    rm -rf "$ACTIVE_CASE_SANDBOX"
+  fi
+}
+trap cleanup_active_case EXIT
+
+descendant_pids() {
+  local parent="$1"
+  local child
+  while IFS= read -r child; do
+    [[ -n "$child" ]] || continue
+    printf '%s\n' "$child"
+    descendant_pids "$child"
+  done < <(ps -o pid= --ppid "$parent" 2>/dev/null | awk '{ print $1 }')
+}
+
+make_worktree() {
+  local source_root="$1" target_root="$2"
+  mkdir -p "$target_root/scripts/lib"
+  cp "$source_root/scripts/connected-test.sh" "$target_root/scripts/connected-test.sh"
+  cp "$source_root"/scripts/lib/*.sh "$target_root/scripts/lib/"
+  chmod +x "$target_root/scripts/connected-test.sh"
+}
+
+make_fake_adb() {
+  local sandbox="$1"
+  cat > "$sandbox/bin/adb" <<'ADB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+serial="${ANDROID_SERIAL:-}"
+if [[ "${1:-}" == "-s" ]]; then
+  serial="$2"
+  shift 2
+fi
+if [[ -z "$serial" ]]; then
+  serial="${FAKE_DEFAULT_SERIAL:?}"
+fi
+
+case "${1:-}" in
+  devices)
+    printf 'List of devices attached\n'
+    for candidate in $FAKE_ONLINE_SERIALS; do
+      printf '%s\tdevice\n' "$candidate"
+    done
+    ;;
+  shell)
+    shift
+    if [[ "${1:-}" == "pm" && "${2:-}" == "list" && "${3:-}" == "packages" ]]; then
+      packages="$FAKE_DEVICE_STATE/packages-$serial"
+      if [[ -e "$packages" ]]; then
+        sed 's/^/package:/' "$packages"
+      fi
+    fi
+    ;;
+  uninstall)
+    package="${2:?}"
+    if [[ "${FAKE_KILL_HOLDER_ON_UNINSTALL_RUN_ID:-}" == "$FAKE_RUN_ID" ]]; then
+      holder="${POCKETSHELL_POOL_HOLDER_PID:-${POCKETSHELL_AVD_LOCK_HOLDER_PID:-}}"
+      [[ "$holder" =~ ^[0-9]+$ ]] || exit 96
+      kill -KILL "$holder" 2>/dev/null || true
+      touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.uninstall-holder-killed"
+      trap 'touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.uninstall-terminated"; exit 143' TERM INT
+      while [[ ! -e "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.uninstall-continue" ]]; do
+        sleep 0.02
+      done
+    fi
+    printf '%s adb-uninstall %s %s\n' "$FAKE_RUN_ID" "$serial" "$package" \
+      >> "$FAKE_DEVICE_STATE/events"
+    packages="$FAKE_DEVICE_STATE/packages-$serial"
+    if [[ -e "$packages" ]]; then
+      grep -Fxv "$package" "$packages" > "$packages.next" || true
+      mv "$packages.next" "$packages"
+    fi
+    if [[ -e "$FAKE_DEVICE_STATE/active-$package" ]]; then
+      touch "$FAKE_DEVICE_STATE/killed-$package"
+      rm -f "$FAKE_DEVICE_STATE/active-$package"
+    fi
+    ;;
+  *)
+    ;;
+esac
+ADB
+  chmod +x "$sandbox/bin/adb"
+}
+
+make_fake_docker() {
+  local sandbox="$1"
+  cat > "$sandbox/bin/docker" <<'DOCKER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  compose)
+    touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.docker-up"
+    if [[ "${FAKE_PAUSE_DOCKER_PHASE:-}" == "up" ]]; then
+      touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.docker-up-paused"
+      while [[ ! -e "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.docker-continue" ]]; do
+        sleep 0.02
+      done
+    fi
+    ;;
+  inspect)
+    if [[ "${FAKE_PAUSE_DOCKER_PHASE:-}" == "health" ]]; then
+      touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.docker-health-paused"
+      while [[ ! -e "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.docker-continue" ]]; do
+        sleep 0.02
+      done
+    fi
+    printf 'healthy\n'
+    ;;
+esac
+DOCKER
+  chmod +x "$sandbox/bin/docker"
+}
+
+inject_agents_fork_pause() {
+  local root="$1"
+  # The literal shell fragment is injected into the sandbox copy and expands
+  # only when that copied helper runs.
+  # shellcheck disable=SC2016
+  sed -i '/local holder_pid="\$!"/a\
+  if [[ "${FAKE_PAUSE_AFTER_AGENTS_FORK_RUN_ID:-}" == "${FAKE_RUN_ID:-}" ]]; then\
+    touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.agents-fork-paused"\
+    while [[ ! -e "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.agents-fork-continue" ]]; do\
+      _pocketshell_agents_run_without_avd_lock_fd sleep 0.02\
+    done\
+  fi' "$root/scripts/lib/agents-pool.sh"
+}
+
+make_fake_gradle() {
+  local root="$1"
+  cat > "$root/gradlew" <<'GRADLEW'
+#!/usr/bin/env bash
+set -euo pipefail
+
+serial="${ANDROID_SERIAL:-${FAKE_DEFAULT_SERIAL:?}}"
+suffix=""
+for arg in "$@"; do
+  case "$arg" in
+    -PpocketshellAppIdSuffix=*) suffix="${arg#*=}" ;;
+  esac
+done
+package="com.pocketshell.app${suffix:+.$suffix}"
+printf '%s\n' "$serial" > "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.serial"
+printf '%s\n' "$*" > "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.gradle-args"
+
+# Reviewer correction: kill the wrapper's helper holder after its final
+# pre-Gradle ownership assertion but before this stub's first mutation. The
+# pause makes the boundary deterministic: the test starts a same-serial
+# contender, then either the wrapper notices the loss and terminates us or the
+# old snapshot-only implementation lets both lanes proceed unlocked.
+if [[ "${FAKE_KILL_HOLDER_RUN_ID:-}" == "$FAKE_RUN_ID" ]]; then
+  holder="${POCKETSHELL_POOL_HOLDER_PID:-${POCKETSHELL_AVD_LOCK_HOLDER_PID:-}}"
+  [[ "$holder" =~ ^[0-9]+$ ]] || {
+    printf 'missing-holder-at-gradle-boundary\n' > "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.hook-error"
+    exit 96
+  }
+  kill -KILL "$holder" 2>/dev/null || true
+  touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.holder-killed"
+  trap 'touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.terminated"; exit 143' TERM INT
+  while [[ ! -e "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.continue" ]]; do
+    sleep 0.02
+  done
+fi
+
+if [[ "${FAKE_PAUSE_BEFORE_MUTATION_RUN_ID:-}" == "$FAKE_RUN_ID" ]]; then
+  touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.pre-mutation-paused"
+  trap 'touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.pause-terminated"; exit 143' TERM INT
+  while [[ ! -e "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.continue" ]]; do
+    sleep 0.02
+  done
+fi
+
+# Install/instrumentation is one mutation window. A second wrapper entering it
+# models the real AGP install that SIGKILLs the instrumentation already running
+# on this serial.
+guard="$FAKE_DEVICE_STATE/mutating-$serial"
+if ! mkdir "$guard" 2>/dev/null; then
+  printf '%s overlap %s\n' "$FAKE_RUN_ID" "$serial" >> "$FAKE_DEVICE_STATE/events"
+  touch "$FAKE_DEVICE_STATE/overlap"
+  for active in "$FAKE_DEVICE_STATE"/active-com.pocketshell.app*; do
+    [[ -e "$active" ]] || continue
+    victim="${active##*/active-}"
+    touch "$FAKE_DEVICE_STATE/killed-$victim"
+    rm -f "$active"
+  done
+else
+  trap 'rmdir "$guard" 2>/dev/null || true' EXIT
+fi
+
+packages="$FAKE_DEVICE_STATE/packages-$serial"
+touch "$packages"
+if ! grep -Fxq "$package" "$packages"; then
+  printf '%s\n' "$package" >> "$packages"
+fi
+touch "$FAKE_DEVICE_STATE/active-$package"
+printf '%s install-instrument %s %s\n' "$FAKE_RUN_ID" "$serial" "$package" \
+  >> "$FAKE_DEVICE_STATE/events"
+touch "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.started"
+
+while [[ ! -e "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.release" ]]; do
+  if [[ -e "$FAKE_DEVICE_STATE/killed-$package" ]]; then
+    printf '%s instrumentation-killed %s %s\n' "$FAKE_RUN_ID" "$serial" "$package" \
+      >> "$FAKE_DEVICE_STATE/events"
+    exit 9
+  fi
+  sleep 0.05
+done
+
+if [[ -e "$FAKE_DEVICE_STATE/killed-$package" || ! -e "$FAKE_DEVICE_STATE/active-$package" ]]; then
+  printf '%s instrumentation-killed %s %s\n' "$FAKE_RUN_ID" "$serial" "$package" \
+    >> "$FAKE_DEVICE_STATE/events"
+  exit 9
+fi
+rm -f "$FAKE_DEVICE_STATE/active-$package"
+printf '%s instrumentation-survived %s %s\n' "$FAKE_RUN_ID" "$serial" "$package" \
+  >> "$FAKE_DEVICE_STATE/events"
+exit "${FAKE_GRADLE_RC:-0}"
+GRADLEW
+  chmod +x "$root/gradlew"
+}
+
+make_sandbox() {
+  local sandbox="$1" serials="${2:-emulator-5554}"
+  mkdir -p "$sandbox/bin" "$sandbox/device-state" "$sandbox/locks"
+  make_fake_adb "$sandbox"
+  make_fake_docker "$sandbox"
+  make_worktree "$ROOT_DIR" "$sandbox/pool-root"
+  make_worktree "$ROOT_DIR" "$sandbox/legacy-root"
+  make_fake_gradle "$sandbox/pool-root"
+  make_fake_gradle "$sandbox/legacy-root"
+  printf '%s\n' "$serials" > "$sandbox/serials"
+}
+
+start_wrapper() {
+  local sandbox="$1" mode="$2" run_id="$3" suffix="$4"
+  local online_serials="${5:-emulator-5554}"
+  local explicit_serial="${6:-}"
+  local pool_serials="${7:-$online_serials}"
+  local wait_seconds="${8:-8}"
+  local gradle_rc="${9:-0}"
+  local agents_port="${10-2222}"
+  local test_class="${11:-}"
+  local root="$sandbox/$mode-root"
+  local mode_arg="--no-pool"
+  local extra_args=()
+  [[ "$mode" == "pool" ]] && mode_arg="--pool"
+  [[ -n "$test_class" ]] && extra_args=("--tests" "$test_class")
+
+  setsid env \
+    PATH="$sandbox/bin:$PATH" \
+    ADB="$sandbox/bin/adb" \
+    ANDROID_SDK="$sandbox" \
+    ANDROID_SERIAL="$explicit_serial" \
+    POCKETSHELL_AVD_LOCK_DIR="$sandbox/locks" \
+    POCKETSHELL_POOL_SERIALS="$pool_serials" \
+    POCKETSHELL_POOL_WAIT_SECONDS="$wait_seconds" \
+    POCKETSHELL_AGENTS_PORT="$agents_port" \
+    POCKETSHELL_AGENTS_POOL_PORTS=2243 \
+    POCKETSHELL_AGENTS_WAIT_SECONDS=0 \
+    POCKETSHELL_TEST_MEM=1G \
+    FAKE_DEFAULT_SERIAL="${online_serials%% *}" \
+    FAKE_ONLINE_SERIALS="$online_serials" \
+    FAKE_DEVICE_STATE="$sandbox/device-state" \
+    FAKE_RUN_ID="$run_id" \
+    FAKE_GRADLE_RC="$gradle_rc" \
+    FAKE_KILL_HOLDER_RUN_ID="${FAKE_KILL_HOLDER_RUN_ID:-}" \
+    FAKE_PAUSE_BEFORE_MUTATION_RUN_ID="${FAKE_PAUSE_BEFORE_MUTATION_RUN_ID:-}" \
+    FAKE_PAUSE_AFTER_AGENTS_FORK_RUN_ID="${FAKE_PAUSE_AFTER_AGENTS_FORK_RUN_ID:-}" \
+    FAKE_PAUSE_DOCKER_PHASE="${FAKE_PAUSE_DOCKER_PHASE:-}" \
+    bash "$root/scripts/connected-test.sh" "$mode_arg" --suffix "$suffix" \
+      "${extra_args[@]}" \
+      > "$sandbox/$run_id.out" 2> "$sandbox/$run_id.err" &
+  WRAPPER_PID="$!"
+  ACTIVE_PROCESS_GROUPS+=("$WRAPPER_PID")
+}
+
+start_cleanup() {
+  local sandbox="$1" run_id="$2" wait_seconds="${3:-8}"
+  local root="$sandbox/legacy-root"
+  setsid env \
+    PATH="$sandbox/bin:$PATH" \
+    ADB="$sandbox/bin/adb" \
+    ANDROID_SDK="$sandbox" \
+    ANDROID_SERIAL="" \
+    POCKETSHELL_AVD_LOCK_DIR="$sandbox/locks" \
+    POCKETSHELL_POOL_SERIALS="emulator-5554" \
+    POCKETSHELL_POOL_WAIT_SECONDS="$wait_seconds" \
+    POCKETSHELL_AGENTS_PORT=2222 \
+    FAKE_DEFAULT_SERIAL="emulator-5554" \
+    FAKE_ONLINE_SERIALS="emulator-5554" \
+    FAKE_DEVICE_STATE="$sandbox/device-state" \
+    FAKE_RUN_ID="$run_id" \
+    FAKE_KILL_HOLDER_ON_UNINSTALL_RUN_ID="${FAKE_KILL_HOLDER_ON_UNINSTALL_RUN_ID:-}" \
+    bash "$root/scripts/connected-test.sh" --cleanup-suffixes \
+      > "$sandbox/$run_id.out" 2> "$sandbox/$run_id.err" &
+  WRAPPER_PID="$!"
+  ACTIVE_PROCESS_GROUPS+=("$WRAPPER_PID")
+}
+
+assert_mixed_order_serialises() {
+  local sandbox="$1" first_mode="$2" second_mode="$3"
+  make_sandbox "$sandbox"
+
+  local first_pid second_pid
+  start_wrapper "$sandbox" "$first_mode" first i1737a
+  first_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/first.started" 10 \
+    || { kill_group "$first_pid"; fail "$first_mode first wrapper never reached instrumentation"; }
+
+  start_wrapper "$sandbox" "$second_mode" second i1737b
+  second_pid="$WRAPPER_PID"
+
+  # Load-bearing assertion: while the first instrumentation owns emulator-5554,
+  # the second wrapper must remain before cleanup/install/instrumentation.
+  if wait_for_file "$sandbox/device-state/second.started" 2; then
+    kill_group "$first_pid"
+    kill_group "$second_pid"
+    fail "$second_mode entered install/instrumentation while $first_mode owned emulator-5554 -- pool and legacy lock domains are split (issue #1737)"
+  fi
+  if [[ -e "$sandbox/device-state/overlap" ]]; then
+    kill_group "$first_pid"
+    kill_group "$second_pid"
+    fail "mutation windows overlapped on emulator-5554"
+  fi
+  if grep -q '^second adb-uninstall ' "$sandbox/device-state/events" 2>/dev/null; then
+    kill_group "$first_pid"
+    kill_group "$second_pid"
+    fail "$second_mode uninstalled packages before owning emulator-5554"
+  fi
+
+  touch "$sandbox/device-state/first.release"
+  wait_for_exit "$first_pid" 10 \
+    || { kill_group "$first_pid"; kill_group "$second_pid"; fail "first instrumentation did not survive/release"; }
+  wait_for_file "$sandbox/device-state/second.started" 10 \
+    || { kill_group "$second_pid"; fail "second wrapper did not acquire emulator-5554 after release"; }
+  touch "$sandbox/device-state/second.release"
+  wait_for_exit "$second_pid" 10 \
+    || { kill_group "$second_pid"; fail "second instrumentation did not survive"; }
+
+  [[ ! -e "$sandbox/device-state/overlap" ]] \
+    || fail "pool/legacy mutation windows overlapped"
+  [[ ! -e "$sandbox/device-state/killed-com.pocketshell.app.i1737a" ]] \
+    || fail "first instrumentation package was killed"
+  grep -q '^first instrumentation-survived emulator-5554 ' "$sandbox/device-state/events" \
+    || fail "first instrumentation survival was not recorded"
+  grep -q '^second instrumentation-survived emulator-5554 ' "$sandbox/device-state/events" \
+    || fail "second instrumentation survival was not recorded"
+  [[ "$(<"$sandbox/device-state/first.serial")" == "emulator-5554" ]] \
+    || fail "first wrapper used the wrong serial"
+  [[ "$(<"$sandbox/device-state/second.serial")" == "emulator-5554" ]] \
+    || fail "second wrapper used the wrong serial"
+}
+
+pool_then_legacy_serialises() {
+  assert_mixed_order_serialises "$1" pool legacy
+}
+
+legacy_then_pool_serialises() {
+  assert_mixed_order_serialises "$1" legacy pool
+}
+
+cleanup_waits_for_serial_owner() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+
+  local owner_pid cleanup_pid
+  start_wrapper "$sandbox" pool owner i1737owner
+  owner_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/owner.started" 10 \
+    || { kill_group "$owner_pid"; fail "owner wrapper never reached instrumentation"; }
+
+  start_cleanup "$sandbox" cleanup
+  cleanup_pid="$WRAPPER_PID"
+  sleep 1
+  if ! kill -0 "$cleanup_pid" 2>/dev/null; then
+    kill_group "$owner_pid"
+    fail "cleanup exited instead of waiting for the common serial owner"
+  fi
+  if grep -q '^cleanup adb-uninstall ' "$sandbox/device-state/events" 2>/dev/null; then
+    kill_group "$owner_pid"
+    kill_group "$cleanup_pid"
+    fail "cleanup uninstalled a package while instrumentation owned emulator-5554"
+  fi
+
+  touch "$sandbox/device-state/owner.release"
+  wait_for_exit "$owner_pid" 10 \
+    || { kill_group "$owner_pid"; kill_group "$cleanup_pid"; fail "owner did not survive cleanup contention"; }
+  wait_for_exit "$cleanup_pid" 10 \
+    || { kill_group "$cleanup_pid"; fail "cleanup did not finish after serial release"; }
+  grep -q '^owner instrumentation-survived emulator-5554 ' "$sandbox/device-state/events" \
+    || fail "instrumentation package did not survive until ownership release"
+}
+
+early_failure_releases_for_other_mode() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+
+  local failed_pid next_pid failed_rc
+  start_wrapper "$sandbox" legacy failed i1737failed \
+    "emulator-5554" "" "emulator-5554" 8 7
+  failed_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/failed.started" 10 \
+    || { kill_group "$failed_pid"; fail "failing legacy wrapper never started"; }
+  touch "$sandbox/device-state/failed.release"
+  wait_until_stopped "$failed_pid" 10 \
+    || { kill_group "$failed_pid"; fail "failing wrapper did not exit"; }
+  set +e
+  wait "$failed_pid"
+  failed_rc=$?
+  set -e
+  [[ "$failed_rc" == "7" ]] \
+    || fail "wrapper did not propagate the early Gradle failure (got $failed_rc, want 7)"
+
+  start_wrapper "$sandbox" pool next i1737next
+  next_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/next.started" 10 \
+    || { kill_group "$next_pid"; fail "pool wrapper could not acquire after legacy failure"; }
+  touch "$sandbox/device-state/next.release"
+  wait_for_exit "$next_pid" 10 \
+    || { kill_group "$next_pid"; fail "pool wrapper failed after prior early failure"; }
+  [[ ! -e "$sandbox/device-state/overlap" ]] \
+    || fail "early-failure cleanup left an overlapping mutation window"
+}
+
+busy_timeout_fails_before_mutation() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+
+  local owner_pid blocked_pid blocked_rc
+  start_wrapper "$sandbox" pool owner i1737owner
+  owner_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/owner.started" 10 \
+    || { kill_group "$owner_pid"; fail "owner wrapper never started"; }
+
+  start_wrapper "$sandbox" legacy blocked i1737blocked \
+    "emulator-5554" "" "emulator-5554" 0
+  blocked_pid="$WRAPPER_PID"
+  wait_until_stopped "$blocked_pid" 5 \
+    || { kill_group "$owner_pid"; kill_group "$blocked_pid"; fail "wait=0 did not preserve fail-fast timeout"; }
+  set +e
+  wait "$blocked_pid"
+  blocked_rc=$?
+  set -e
+  [[ "$blocked_rc" != "0" ]] || fail "busy fail-fast wrapper unexpectedly succeeded"
+  [[ ! -e "$sandbox/device-state/blocked.started" ]] \
+    || fail "busy wrapper entered Gradle before failing ownership"
+  ! grep -q '^blocked adb-uninstall ' "$sandbox/device-state/events" 2>/dev/null \
+    || fail "busy wrapper uninstalled before failing ownership"
+  grep -q 'no free emulator in the pool after 0s' "$sandbox/blocked.err" \
+    || fail "busy failure lacked the bounded-timeout diagnostic"
+
+  touch "$sandbox/device-state/owner.release"
+  wait_for_exit "$owner_pid" 10 \
+    || { kill_group "$owner_pid"; fail "owner did not survive fail-fast contender"; }
+}
+
+distinct_serials_run_concurrently() {
+  local sandbox="$1"
+  make_sandbox "$sandbox" "emulator-5554 emulator-5556"
+
+  local legacy_pid pool_pid
+  start_wrapper "$sandbox" legacy legacy i1737legacy \
+    "emulator-5554 emulator-5556" "emulator-5554"
+  legacy_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/legacy.started" 10 \
+    || { kill_group "$legacy_pid"; fail "legacy distinct-serial wrapper never started"; }
+
+  start_wrapper "$sandbox" pool pool i1737pool \
+    "emulator-5554 emulator-5556" "emulator-5556"
+  pool_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/pool.started" 3 \
+    || { kill_group "$legacy_pid"; kill_group "$pool_pid"; fail "distinct serials were globally serialized"; }
+
+  [[ "$(<"$sandbox/device-state/legacy.serial")" == "emulator-5554" ]] \
+    || fail "legacy lane did not retain emulator-5554"
+  [[ "$(<"$sandbox/device-state/pool.serial")" == "emulator-5556" ]] \
+    || fail "pool lane did not retain emulator-5556"
+  [[ ! -e "$sandbox/device-state/overlap" ]] \
+    || fail "distinct serial mutation guards collided"
+
+  touch "$sandbox/device-state/legacy.release" "$sandbox/device-state/pool.release"
+  wait_for_exit "$legacy_pid" 10 \
+    || { kill_group "$legacy_pid"; kill_group "$pool_pid"; fail "legacy distinct lane failed"; }
+  wait_for_exit "$pool_pid" 10 \
+    || { kill_group "$pool_pid"; fail "pool distinct lane failed"; }
+}
+
+lost_holder_fails_closed_and_stale_lock_recovers() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+  local result="$sandbox/lost-holder.result"
+
+  # The single-quoted script intentionally expands inside the child shell.
+  # shellcheck disable=SC2016
+  env \
+    PATH="$sandbox/bin:$PATH" \
+    ADB="$sandbox/bin/adb" \
+    ANDROID_SDK="$sandbox" \
+    POCKETSHELL_AVD_LOCK_DIR="$sandbox/locks" \
+    POCKETSHELL_POOL_SERIALS="emulator-5554" \
+    POCKETSHELL_POOL_WAIT_SECONDS=0 \
+    FAKE_DEFAULT_SERIAL="emulator-5554" \
+    FAKE_ONLINE_SERIALS="emulator-5554" \
+    bash -c '
+      set -euo pipefail
+      source "$1/scripts/lib/avd-lock.sh"
+      pocketshell_claim_pool_serial "$1" >/dev/null
+      lock_file="$POCKETSHELL_AVD_LOCK_FILE"
+      holder="$POCKETSHELL_POOL_HOLDER_PID"
+      kill "$holder"
+      wait "$holder" 2>/dev/null || true
+      if pocketshell_assert_avd_lock_owned "$lock_file" >/dev/null 2>"$2"; then
+        echo "assert-succeeded" > "$3"
+        exit 1
+      fi
+      flock -n "$lock_file" true
+      echo "lost-holder-rejected-and-lock-recoverable" > "$3"
+    ' bash "$sandbox/pool-root" "$sandbox/lost-holder.err" "$result" \
+    || fail "lost-holder ownership check or stale-lock recovery failed"
+
+  [[ "$(<"$result")" == "lost-holder-rejected-and-lock-recoverable" ]] \
+    || fail "lost ownership did not fail closed"
+  grep -q 'lost emulator ownership' "$sandbox/lost-holder.err" \
+    || fail "lost ownership lacked a clear diagnostic"
+  [[ ! -s "$sandbox/device-state/events" ]] \
+    || fail "device mutation occurred after ownership loss"
+}
+
+holder_loss_at_gradle_boundary_fails_before_mutation() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+
+  local first_pid contender_pid first_rc
+  FAKE_KILL_HOLDER_RUN_ID=first \
+    start_wrapper "$sandbox" pool first i1737loss
+  first_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/first.holder-killed" 10 \
+    || { kill_group "$first_pid"; fail "holder-loss hook never reached the post-check/pre-mutation boundary"; }
+
+  start_wrapper "$sandbox" legacy contender i1737contender
+  contender_pid="$WRAPPER_PID"
+
+  # With continuous wrapper-owned flock, the contender cannot enter while the
+  # first wrapper diagnoses helper loss and terminates the not-yet-mutating
+  # Gradle child. Snapshot-only ownership releases here and the contender
+  # enters immediately -- the reviewer's exact counterexample.
+  local waited=0
+  while kill -0 "$first_pid" 2>/dev/null; do
+    if [[ -e "$sandbox/device-state/contender.started" ]]; then
+      touch "$sandbox/device-state/first.continue"
+      kill_group "$first_pid"
+      kill_group "$contender_pid"
+      fail "same-serial contender entered after helper death while the first wrapper was still live -- ownership was only a snapshot"
+    fi
+    (( waited++ >= 200 )) && {
+      touch "$sandbox/device-state/first.continue"
+      kill_group "$first_pid"
+      kill_group "$contender_pid"
+      fail "wrapper did not terminate within the ownership-loss bound"
+    }
+    sleep 0.05
+  done
+
+  wait_until_stopped "$first_pid" 10 \
+    || {
+      touch "$sandbox/device-state/first.continue"
+      kill_group "$first_pid"
+      kill_group "$contender_pid"
+      fail "wrapper did not fail closed after helper death at the Gradle boundary"
+    }
+  set +e
+  wait "$first_pid"
+  first_rc=$?
+  set -e
+  [[ "$first_rc" != "0" ]] || fail "ownership-losing wrapper unexpectedly succeeded"
+  grep -q 'lost emulator ownership' "$sandbox/first.err" \
+    || fail "boundary ownership loss lacked a clear diagnostic"
+  [[ -e "$sandbox/device-state/first.terminated" ]] \
+    || fail "wrapper did not terminate the pre-mutation Gradle child after ownership loss"
+  [[ ! -e "$sandbox/device-state/first.started" ]] \
+    || fail "first wrapper mutated after losing its helper at the Gradle boundary"
+  ! grep -Eq '^first (adb-uninstall|install-instrument) ' "$sandbox/device-state/events" 2>/dev/null \
+    || fail "first wrapper recorded device mutation after ownership loss"
+
+  wait_for_file "$sandbox/device-state/contender.started" 10 \
+    || { kill_group "$contender_pid"; fail "contender did not acquire after the failed wrapper released ownership"; }
+  touch "$sandbox/device-state/contender.release"
+  wait_for_exit "$contender_pid" 10 \
+    || { kill_group "$contender_pid"; fail "contender failed after ownership-loss recovery"; }
+  [[ ! -e "$sandbox/device-state/overlap" ]] \
+    || fail "ownership-loss correction allowed overlapping mutation"
+
+  local serial_lock="$sandbox/locks/avd-lock-emulator-5554"
+  flock -n "$serial_lock" true \
+    || fail "ownership-loss correction left a stale flock behind"
+}
+
+holder_loss_at_cleanup_boundary_fails_before_uninstall() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+  printf 'com.pocketshell.app.i1737stale\n' \
+    > "$sandbox/device-state/packages-emulator-5554"
+
+  local cleanup_pid contender_pid cleanup_rc
+  FAKE_KILL_HOLDER_ON_UNINSTALL_RUN_ID=cleanup \
+    start_cleanup "$sandbox" cleanup
+  cleanup_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/cleanup.uninstall-holder-killed" 10 \
+    || { kill_group "$cleanup_pid"; fail "cleanup holder-loss hook never reached the pre-uninstall boundary"; }
+
+  start_wrapper "$sandbox" pool contender i1737cleanupcontender
+  contender_pid="$WRAPPER_PID"
+
+  local waited=0
+  while kill -0 "$cleanup_pid" 2>/dev/null; do
+    if [[ -e "$sandbox/device-state/contender.started" ]]; then
+      touch "$sandbox/device-state/cleanup.uninstall-continue"
+      kill_group "$cleanup_pid"
+      kill_group "$contender_pid"
+      fail "contender entered while ownership-losing cleanup wrapper was still live"
+    fi
+    (( waited++ >= 200 )) && {
+      touch "$sandbox/device-state/cleanup.uninstall-continue"
+      kill_group "$cleanup_pid"
+      kill_group "$contender_pid"
+      fail "cleanup wrapper did not terminate within the ownership-loss bound"
+    }
+    sleep 0.05
+  done
+
+  set +e
+  wait "$cleanup_pid"
+  cleanup_rc=$?
+  set -e
+  [[ "$cleanup_rc" != "0" ]] || fail "ownership-losing cleanup unexpectedly succeeded"
+  grep -q 'lost emulator ownership' "$sandbox/cleanup.err" \
+    || fail "cleanup ownership loss lacked a clear diagnostic"
+  [[ -e "$sandbox/device-state/cleanup.uninstall-terminated" ]] \
+    || fail "wrapper did not terminate adb before the ownership-losing uninstall"
+  ! grep -q '^cleanup adb-uninstall ' "$sandbox/device-state/events" 2>/dev/null \
+    || fail "cleanup uninstalled a package after helper loss"
+
+  wait_for_file "$sandbox/device-state/contender.started" 10 \
+    || { kill_group "$contender_pid"; fail "contender did not acquire after cleanup failed closed"; }
+  touch "$sandbox/device-state/contender.release"
+  wait_for_exit "$contender_pid" 10 \
+    || { kill_group "$contender_pid"; fail "contender failed after cleanup ownership loss"; }
+  [[ ! -e "$sandbox/device-state/overlap" ]] \
+    || fail "cleanup ownership loss allowed overlapping mutation"
+  flock -n "$sandbox/locks/avd-lock-emulator-5554" true \
+    || fail "cleanup ownership loss left a stale flock"
+}
+
+hard_killed_wrapper_leaves_no_descendant_flock() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+
+  local wrapper_pid contender_pid
+  FAKE_PAUSE_BEFORE_MUTATION_RUN_ID=crashed \
+    start_wrapper "$sandbox" pool crashed i1737crashed
+  wrapper_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/crashed.pre-mutation-paused" 10 \
+    || { kill_group "$wrapper_pid"; fail "hard-crash case never reached the pre-mutation pause"; }
+
+  local serial_lock="$sandbox/locks/avd-lock-emulator-5554"
+  local descendants=()
+  mapfile -t descendants < <(descendant_pids "$wrapper_pid")
+  (( ${#descendants[@]} >= 2 )) \
+    || fail "hard-crash case did not expose the async shell and mutation child"
+
+  local pid fd target
+  for pid in "${descendants[@]}"; do
+    for fd in "/proc/$pid/fd/"*; do
+      [[ -e "$fd" ]] || continue
+      target="$(readlink -f "$fd" 2>/dev/null || true)"
+      [[ "$target" != "$serial_lock" ]] \
+        || fail "wrapper descendant $pid retained the continuous serial flock FD before the crash"
+    done
+  done
+
+  # Kill ONLY the authoritative wrapper. Its EXIT trap cannot run. The paused
+  # async shell/Gradle descendants deliberately remain alive, yet none may own
+  # the wrapper's FD and the kernel flock must be immediately reclaimable.
+  kill -KILL "$wrapper_pid"
+  wait "$wrapper_pid" 2>/dev/null || true
+  local live_descendant=0
+  for pid in "${descendants[@]}"; do
+    kill -0 "$pid" 2>/dev/null && live_descendant=1
+  done
+  (( live_descendant == 1 )) \
+    || fail "hard-crash proof lost all descendants instead of exercising orphan FD behavior"
+  if ! flock -n "$serial_lock" true; then
+    for fd in /proc/[0-9]*/fd/*; do
+      [[ "$(readlink -f "$fd" 2>/dev/null || true)" == "$serial_lock" ]] || continue
+      printf 'leaked-lock-fd: pid=%s fd=%s cmd=%s\n' \
+        "$(cut -d/ -f3 <<< "$fd")" "$fd" \
+        "$(tr '\0' ' ' < "/proc/$(cut -d/ -f3 <<< "$fd")/cmdline" 2>/dev/null || true)" >&2
+    done
+    fail "SIGKILLed wrapper left its serial flock inherited by an async descendant"
+  fi
+  [[ ! -e "$sandbox/device-state/crashed.started" ]] \
+    || fail "hard-killed wrapper mutated before ownership reclamation"
+
+  start_wrapper "$sandbox" legacy contender i1737aftercrash
+  contender_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/contender.started" 10 \
+    || { kill_group "$contender_pid"; fail "contender could not reclaim the serial after wrapper SIGKILL"; }
+  touch "$sandbox/device-state/contender.release"
+  wait_for_exit "$contender_pid" 10 \
+    || { kill_group "$contender_pid"; fail "post-crash contender failed"; }
+  [[ ! -e "$sandbox/device-state/overlap" ]] \
+    || fail "post-crash contender overlapped a mutation from the killed wrapper"
+
+  kill_group "$wrapper_pid"
+}
+
+hard_killed_pool_setup_leaves_no_descendant_flock() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+  inject_agents_fork_pause "$sandbox/pool-root"
+
+  local wrapper_pid
+  FAKE_PAUSE_AFTER_AGENTS_FORK_RUN_ID=poolsetup \
+    start_wrapper "$sandbox" pool poolsetup i1737poolsetup \
+      emulator-5554 "" emulator-5554 8 0 ""
+  wrapper_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/poolsetup.agents-fork-paused" 10 \
+    || { kill_group "$wrapper_pid"; fail "dynamic agents-port claim never paused after its async fork"; }
+
+  local serial_lock="$sandbox/locks/avd-lock-emulator-5554"
+  local descendants=()
+  mapfile -t descendants < <(descendant_pids "$wrapper_pid")
+  (( ${#descendants[@]} >= 2 )) \
+    || fail "dynamic agents-port claim did not leave its helper descendants alive"
+
+  local pid fd target
+  for pid in "${descendants[@]}"; do
+    for fd in "/proc/$pid/fd/"*; do
+      [[ -e "$fd" ]] || continue
+      target="$(readlink -f "$fd" 2>/dev/null || true)"
+      [[ "$target" != "$serial_lock" ]] \
+        || fail "pool-setup descendant $pid retained the continuous serial flock FD before the crash"
+    done
+  done
+
+  kill -KILL "$wrapper_pid"
+  wait "$wrapper_pid" 2>/dev/null || true
+  local live_descendant=0
+  for pid in "${descendants[@]}"; do
+    kill -0 "$pid" 2>/dev/null && live_descendant=1
+  done
+  (( live_descendant == 1 )) \
+    || fail "pool-setup proof lost every descendant instead of exercising orphan FD behavior"
+  flock -n "$serial_lock" true \
+    || fail "SIGKILLed pool wrapper left its serial flock in the agents-port setup tree"
+  [[ ! -e "$sandbox/device-state/poolsetup.started" ]] \
+    || fail "pool wrapper reached emulator mutation before the setup crash proof"
+
+  kill_group "$wrapper_pid"
+}
+
+assert_hard_killed_docker_phase_reclaims_serial() {
+  local sandbox="$1" phase="$2"
+  make_sandbox "$sandbox"
+
+  local wrapper_pid marker="$sandbox/device-state/pooldocker.docker-$phase-paused"
+  FAKE_PAUSE_DOCKER_PHASE="$phase" \
+    start_wrapper "$sandbox" pool pooldocker "i1737docker$phase" \
+      emulator-5554 "" emulator-5554 8 0 ""
+  wrapper_pid="$WRAPPER_PID"
+  wait_for_file "$marker" 10 \
+    || { kill_group "$wrapper_pid"; fail "agents fixture Docker $phase child never paused"; }
+
+  local serial_lock="$sandbox/locks/avd-lock-emulator-5554"
+  local descendants=()
+  mapfile -t descendants < <(descendant_pids "$wrapper_pid")
+  (( ${#descendants[@]} >= 3 )) \
+    || fail "Docker $phase proof did not leave sentinel, port-holder, and Docker descendants alive"
+
+  local pid fd target
+  for pid in "${descendants[@]}"; do
+    for fd in "/proc/$pid/fd/"*; do
+      [[ -e "$fd" ]] || continue
+      target="$(readlink -f "$fd" 2>/dev/null || true)"
+      [[ "$target" != "$serial_lock" ]] \
+        || fail "agents Docker $phase descendant $pid retained the continuous serial flock FD"
+    done
+  done
+
+  kill -KILL "$wrapper_pid"
+  wait "$wrapper_pid" 2>/dev/null || true
+  local live_descendant=0
+  for pid in "${descendants[@]}"; do
+    kill -0 "$pid" 2>/dev/null && live_descendant=1
+  done
+  (( live_descendant == 1 )) \
+    || fail "Docker $phase proof lost all descendants after wrapper SIGKILL"
+  flock -n "$serial_lock" true \
+    || fail "SIGKILLed pool wrapper left its serial flock in Docker $phase setup"
+  [[ ! -e "$sandbox/device-state/pooldocker.started" ]] \
+    || fail "pool wrapper reached emulator mutation during Docker $phase crash proof"
+
+  kill_group "$wrapper_pid"
+}
+
+hard_killed_agents_docker_up_leaves_no_descendant_flock() {
+  assert_hard_killed_docker_phase_reclaims_serial "$1" up
+}
+
+hard_killed_agents_docker_health_leaves_no_descendant_flock() {
+  assert_hard_killed_docker_phase_reclaims_serial "$1" health
+}
+
+hard_killed_toxiproxy_holder_leaves_no_descendant_flock() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+
+  local wrapper_pid
+  FAKE_PAUSE_BEFORE_MUTATION_RUN_ID=toxcrash \
+    start_wrapper "$sandbox" pool toxcrash i1737tox \
+      emulator-5554 "" emulator-5554 8 0 2222 NetworkFaultProofBase
+  wrapper_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/toxcrash.pre-mutation-paused" 10 \
+    || { kill_group "$wrapper_pid"; fail "network-fault run never reached its mutation pause"; }
+  [[ -e "$sandbox/locks/toxiproxy-serial-lock" ]] \
+    || fail "network-fault run did not exercise the real toxiproxy holder path"
+
+  local serial_lock="$sandbox/locks/avd-lock-emulator-5554"
+  local descendants=()
+  mapfile -t descendants < <(descendant_pids "$wrapper_pid")
+  (( ${#descendants[@]} >= 3 )) \
+    || fail "toxiproxy proof did not leave sentinel, toxiproxy, and mutation descendants alive"
+
+  local pid fd target
+  for pid in "${descendants[@]}"; do
+    for fd in "/proc/$pid/fd/"*; do
+      [[ -e "$fd" ]] || continue
+      target="$(readlink -f "$fd" 2>/dev/null || true)"
+      [[ "$target" != "$serial_lock" ]] \
+        || fail "toxiproxy-path descendant $pid retained the continuous serial flock FD"
+    done
+  done
+
+  kill -KILL "$wrapper_pid"
+  wait "$wrapper_pid" 2>/dev/null || true
+  local live_descendant=0
+  for pid in "${descendants[@]}"; do
+    kill -0 "$pid" 2>/dev/null && live_descendant=1
+  done
+  (( live_descendant == 1 )) \
+    || fail "toxiproxy proof lost all descendants after wrapper SIGKILL"
+  flock -n "$serial_lock" true \
+    || fail "SIGKILLed network-fault wrapper left its serial flock in a descendant"
+  [[ ! -e "$sandbox/device-state/toxcrash.started" ]] \
+    || fail "network-fault wrapper mutated before the crash proof"
+
+  kill_group "$wrapper_pid"
+}
+
+run_case() {
+  local name="$1" sandbox
+  sandbox="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-serial-owner.XXXXXX")"
+  ACTIVE_CASE_SANDBOX="$sandbox"
+  ACTIVE_PROCESS_GROUPS=()
+  "$name" "$sandbox"
+  cleanup_active_case
+  ACTIVE_CASE_SANDBOX=""
+  ACTIVE_PROCESS_GROUPS=()
+  printf '  ok: %s\n' "$name"
+}
+
+CASES=(
+  pool_then_legacy_serialises
+  legacy_then_pool_serialises
+  cleanup_waits_for_serial_owner
+  early_failure_releases_for_other_mode
+  busy_timeout_fails_before_mutation
+  distinct_serials_run_concurrently
+  lost_holder_fails_closed_and_stale_lock_recovers
+  holder_loss_at_gradle_boundary_fails_before_mutation
+  holder_loss_at_cleanup_boundary_fails_before_uninstall
+  hard_killed_wrapper_leaves_no_descendant_flock
+  hard_killed_pool_setup_leaves_no_descendant_flock
+  hard_killed_agents_docker_up_leaves_no_descendant_flock
+  hard_killed_agents_docker_health_leaves_no_descendant_flock
+  hard_killed_toxiproxy_holder_leaves_no_descendant_flock
+)
+if [[ $# -gt 0 ]]; then
+  CASES=("$@")
+fi
+for case_name in "${CASES[@]}"; do
+  run_case "$case_name"
+done
+
+printf 'PASS: connected-test per-serial ownership (issue #1737)\n'


### PR DESCRIPTION
Closes #1737

Unifies pool and legacy connected-test execution under one continuously-held per-serial ownership lock before any uninstall/install/instrumentation mutation. Pool allocation excludes serials owned by either mode; cleanup and early-failure paths share the same ownership. The wrapper fails closed on ownership loss, and async helpers/command substitutions close the serial FD at process creation so wrapper crashes cannot strand the lock in descendants. Distinct serials remain concurrent.

Evidence:
- deterministic base reproduction in pool→legacy and legacy→pool order: both previously mutated emulator-5554; real incident SIGKILLed #1736 instrumentation
- four adversarial review rounds closed TOCTOU, intermediate Bash FD, cleanup, sentinel, Docker/helper, and dynamic agents-port inheritance paths
- independent dynamic-port wrapper-SIGKILL probe: all living descendants had no serial FD and immediate `flock -n` reclaim succeeded
- 14-case wrapper harness + stress: dynamic 20/20, mutation 20/20, cleanup 20/20, Docker up/health/tox cohorts 10/10 each
- focused reviewer gate 5/5; full app-debug reviewer gate 4,084 tests, zero failures/errors/skips, 198/198 tasks
- bash syntax, shellcheck, legacy lock/pool harnesses, validity/hygiene/ratchet/diff guards green
- clean rebase onto `bccf3b58`; exact range/patch/blob/mode identity and post-rebase approval

Review: https://github.com/alexeygrigorev/pocketshell/issues/1737#issuecomment-5072685285
Post-rebase audit: https://github.com/alexeygrigorev/pocketshell/issues/1737#issuecomment-5072701960