### PR TITLE
fix: bound agent paste acknowledgement after reconnect

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.app.proof
 
+import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
@@ -17,15 +20,20 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.composer.COMPOSER_DRAFT_TAG
 import com.pocketshell.app.composer.COMPOSER_SEND_ENTER_TAG
+import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.OutboundDeliverySeams
+import com.pocketshell.app.tmux.AgentSubmitCaptureSeams
 import com.pocketshell.app.tmux.PasteChunkSeams
 import com.pocketshell.app.tmux.TMUX_CONSOLIDATED_TAB_PILL_TAG_PREFIX
 import com.pocketshell.app.tmux.TMUX_CONVERSATION_PANE_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -34,7 +42,14 @@ import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
 import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -121,6 +136,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
     private lateinit var fixtureKey: String
     private lateinit var hostRowTag: String
     private var diagnostics: RecordingDiagnosticSink? = null
+    private var issue1739CaptureCleanupGate: CompletableDeferred<Unit>? = null
     private val timings = mutableListOf<String>()
 
     private suspend fun seedBeforeLaunch() {
@@ -138,6 +154,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         OutboundDeliverySeams.failSendResultLostBeforeSubmitEnter = false
         OutboundDeliverySeams.failInputSendResultLostOnce = false
         PasteChunkSeams.reset()
+        AgentSubmitCaptureSeams.reset()
     }
 
     @After
@@ -145,6 +162,9 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         OutboundDeliverySeams.failSendResultLostBeforeSubmitEnter = false
         OutboundDeliverySeams.failInputSendResultLostOnce = false
         PasteChunkSeams.reset()
+        AgentSubmitCaptureSeams.reset()
+        issue1739CaptureCleanupGate?.complete(Unit)
+        issue1739CaptureCleanupGate = null
         diagnostics?.close()
         diagnostics = null
         clearLastSessionPrefs()
@@ -267,6 +287,329 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         )
         writeTimings()
     } }
+
+    /**
+     * Issue #1739 harness guard: the synthetic parked cleanup must model the
+     * real SSH path's threading. `RealSshSession.exec` performs physical channel
+     * close writes on the dedicated `TransportDispatcher` thread (and owns
+     * detached teardown on Dispatchers.IO), never by blocking Android Main.
+     *
+     * This narrow launch-owned proof parks cleanup after one REAL capture,
+     * proves the cancellation continuation is off Main, posts a Main heartbeat,
+     * and observes the bounded ack diagnostic while the cleanup gate is STILL
+     * closed. It prevents the full reconnect journey from manufacturing an ANR
+     * in its test seam and mistaking that harness artifact for product behavior.
+     */
+    @Test
+    fun parkedAckCleanupIsOffMainWhileHeartbeatAndBoundedDiagnosticContinue() {
+        runBlocking<Unit> {
+            attachSeededTmuxSession(hostRowTag)
+            waitForVisibleTerminal("initial attach") { it.contains(FAKE_AGENT_READY) }
+            waitForConnected("initial attach")
+            val viewModel = currentViewModel()
+            viewModel.setAgentSubmitEnterDelayForTest(0)
+            waitForDetectionBound(viewModel)
+            openConversationTab(viewModel)
+
+            val cleanupGate = CompletableDeferred<Unit>()
+            issue1739CaptureCleanupGate = cleanupGate
+            val captureObserved = AtomicBoolean(false)
+            val cleanupParked = AtomicBoolean(false)
+            val cleanupRanOnMain = AtomicReference<Boolean>()
+            AgentSubmitCaptureSeams.afterRealCapture = { response, scrollbackLines ->
+                if (
+                    scrollbackLines == 0 &&
+                    response.output.any { it.contains("[Pasted text #") } &&
+                    captureObserved.compareAndSet(false, true)
+                ) {
+                    try {
+                        CompletableDeferred<Unit>().await()
+                    } catch (cancelled: CancellationException) {
+                        cleanupRanOnMain.set(Looper.myLooper() == Looper.getMainLooper())
+                        cleanupParked.set(true)
+                        withContext(NonCancellable) { cleanupGate.await() }
+                        throw cancelled
+                    }
+                }
+            }
+
+            val nonce = SystemClock.elapsedRealtime().toString().takeLast(6)
+            openComposerAndSend("issue1739 heartbeat $nonce\nissue1739 parked cleanup $nonce")
+            waitUntilWall(ACK_CAPTURE_OBSERVED_TIMEOUT_MS, "real ack capture") {
+                captureObserved.get()
+            }
+            waitForIssue1739Boundary(ACK_BOUNDED_RESULT_TIMEOUT_MS, "off-Main cleanup park") {
+                cleanupParked.get()
+            }
+            assertEquals(
+                "the synthetic NonCancellable cleanup must resume off Android Main, " +
+                    "matching RealSshSession/TransportDispatcher threading",
+                false,
+                cleanupRanOnMain.get(),
+            )
+
+            val mainHeartbeat = AtomicBoolean(false)
+            Handler(Looper.getMainLooper()).post { mainHeartbeat.set(true) }
+            waitForIssue1739Boundary(
+                MAIN_HEARTBEAT_TIMEOUT_MS,
+                "Main heartbeat during parked cleanup",
+            ) {
+                mainHeartbeat.get()
+            }
+            waitForIssue1739Boundary(ACK_BOUNDED_RESULT_TIMEOUT_MS, "bounded ack diagnostic") {
+                diagnostics!!.eventsNamed("agent_submit_ack").any {
+                    it.fields["result"] == "capture_timeout" ||
+                        it.fields["result"] == "ack_timeout"
+                }
+            }
+            assertFalse(
+                "the ack deadline and Main heartbeat must win while cleanup remains parked",
+                cleanupGate.isCompleted,
+            )
+
+            cleanupGate.complete(Unit)
+            AgentSubmitCaptureSeams.reset()
+        }
+    }
+
+    /**
+     * Issue #1739: launch-owned reproduction of the preserved post-reconnect
+     * multiline AgentPayload wedge. A REAL capture first proves the bracketed
+     * paste reached the fake-Claude pane as its collapsed chip; only its
+     * cancellation cleanup is then parked in NonCancellable state. The 800ms
+     * caller boundary must fail/requeue without blind Enter, and the SAME
+     * durable token must verify the landed chip and complete Enter-only.
+     */
+    @Test
+    fun postReconnectAckCleanupIsBoundedAndSameTokenRetrySubmitsExactlyOnce() {
+        runBlocking<Unit> {
+            attachSeededTmuxSession(hostRowTag)
+            waitForVisibleTerminal("initial attach") { it.contains(FAKE_AGENT_READY) }
+            waitForConnected("initial attach")
+            val viewModel = currentViewModel()
+            viewModel.setAgentSubmitEnterDelayForTest(0)
+            waitForDetectionBound(viewModel)
+            openConversationTab(viewModel)
+
+            // First reproduce the prerequisite faithfully: a cut of the live
+            // worker/runtime, followed by a REAL fresh-client reconnect.
+            val clientBeforeCut = viewModel.currentClientIdentityForTest()
+            assertTrue(
+                "precondition: the live worker cut must arm",
+                viewModel.triggerCleanPassiveDropForTest(),
+            )
+            val clientAfterCut = waitForFreshClient(clientBeforeCut)
+            recordTiming("issue1739_reconnected_client", clientAfterCut.toLong())
+
+            val cleanupGate = CompletableDeferred<Unit>()
+            issue1739CaptureCleanupGate = cleanupGate
+            val captureObserved = AtomicBoolean(false)
+            val firstRealCapture = AtomicReference("")
+            AgentSubmitCaptureSeams.afterRealCapture = { response, scrollbackLines ->
+                if (
+                    scrollbackLines == 0 &&
+                    response.output.any { it.contains("[Pasted text #") } &&
+                    captureObserved.compareAndSet(false, true)
+                ) {
+                    firstRealCapture.set(response.output.joinToString("\n"))
+                    try {
+                        CompletableDeferred<Unit>().await()
+                    } catch (cancelled: CancellationException) {
+                        withContext(NonCancellable) { cleanupGate.await() }
+                        throw cancelled
+                    }
+                }
+            }
+
+            val nonce = SystemClock.elapsedRealtime().toString().takeLast(6)
+            val payload =
+                "issue1739 first line $nonce\nissue1739 exact once marker $nonce"
+            val payloadStripped = payload.filterNot { it.isWhitespace() }
+            val store = SharedPrefsOutboundQueueStore(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+            )
+            val sessionKey = requireNotNull(viewModel.currentTargetSessionKeyForTest()) {
+                "the connected VM must expose its exact durable queue session key"
+            }
+
+            val tappedAtMs = SystemClock.elapsedRealtime()
+            openComposerAndSend(payload)
+            waitUntilWall(ACK_CAPTURE_OBSERVED_TIMEOUT_MS, "real ack capture after paste") {
+                captureObserved.get()
+            }
+
+            // Authoritative intermediate evidence, while the first ack capture
+            // is still parked: one durable InFlight row, wire attempted, real
+            // collapsed paste visible, and NO submission/Enter.
+            val inFlightRows = store.itemsFor(sessionKey)
+            assertEquals(
+                "the real composer must own exactly one durable row during the wedged ack; " +
+                    "rows=$inFlightRows",
+                1,
+                inFlightRows.size,
+            )
+            val row = inFlightRows.single()
+            assertEquals(
+                "the row must still be InFlight while the real capture cleanup is parked",
+                OutboundState.InFlight,
+                row.state,
+            )
+            assertTrue("the real bracketed paste commit must be durable", row.wireAttempted)
+            val firstCapture = firstRealCapture.get()
+            assertTrue(
+                "real pane evidence must contain Claude's collapsed multiline-paste chip; " +
+                    "capture=$firstCapture",
+                firstCapture.contains("[Pasted text #"),
+            )
+            assertFalse(
+                "Enter must not be sent while paste acknowledgement is unproven; " +
+                    "capture=$firstCapture",
+                firstCapture.contains("FAKE-AGENT SUBMITTED:"),
+            )
+            writeText("issue1739-first-real-capture.txt", firstCapture)
+            val paneId = requireNotNull(row.paneId) {
+                "the durable AgentPayload row must retain its pane identity"
+            }
+            openTerminalTab(viewModel, paneId)
+            val pendingViewportText = waitForVisibleTerminal(
+                "issue1739 pasted but not submitted viewport",
+            ) {
+                it.contains("[Pasted text #") && !it.contains("FAKE-AGENT SUBMITTED:")
+            }
+            captureLiveTerminalViewport(
+                "issue1739-paste-pending-viewport",
+                pendingViewportText,
+                viewModel,
+                paneId,
+            )
+
+            // The detached boundary must win at ~800ms even though cleanup
+            // remains NonCancellable. The normal composer dispatcher requeues
+            // the SAME row, whose auto-flush verifies the visible chip.
+            waitForIssue1739Boundary(
+                ACK_BOUNDED_RESULT_TIMEOUT_MS,
+                "bounded capture/ack failure",
+            ) {
+                diagnostics!!.eventsNamed("agent_submit_ack")
+                    .any {
+                        it.fields["result"] == "capture_timeout" ||
+                            it.fields["result"] == "ack_timeout"
+                    }
+            }
+            recordTiming(
+                "issue1739_capture_timeout_after_tap_ms",
+                SystemClock.elapsedRealtime() - tappedAtMs,
+            )
+            // The outer ack deadline and its single inner capture both use the
+            // same documented 800ms bound. Either may win the scheduler race:
+            // inner-first records `capture_timeout`; outer-first records
+            // `ack_timeout`. Both carry the immutable runtime identity and both
+            // are the same bounded/no-Enter outcome.
+            val boundedAck = diagnostics!!.eventsNamed("agent_submit_ack")
+                .firstOrNull {
+                    it.fields["result"] == "capture_timeout" ||
+                        it.fields["result"] == "ack_timeout"
+                }
+            assertTrue(
+                "timeout diagnostics must bind to the fresh current client; " +
+                    "clientAfterCut=$clientAfterCut event=$boundedAck",
+                boundedAck != null &&
+                    boundedAck.fields["clientHash"] == clientAfterCut &&
+                    boundedAck.fields["currentClientHash"] == clientAfterCut &&
+                    boundedAck.fields["generation"] ==
+                    boundedAck.fields["currentGeneration"],
+            )
+            cleanupGate.complete(Unit)
+            AgentSubmitCaptureSeams.reset()
+
+            val submitted = waitForIssue1739RetrySubmission(
+                "same-token Enter-only retry submission",
+                SUBMIT_AFTER_FLAP_TIMEOUT_MS,
+                verified = {
+                    diagnostics!!.eventsNamed("outbound_verify_before_resend").any {
+                        it.fields["sendToken"] == row.id &&
+                            it.fields["outcome"] == "AlreadyLanded"
+                    }
+                },
+            ) {
+                val stripped = it.filterNot { ch -> ch.isWhitespace() }
+                stripped.contains(FAKE_AGENT_SUBMITTED_STRIPPED + payloadStripped)
+            }
+            recordTiming(
+                "issue1739_submitted_after_tap_ms",
+                SystemClock.elapsedRealtime() - tappedAtMs,
+            )
+            val settled = waitForStableSidecarCapture()
+            writeText("issue1739-final-raw-transcript.txt", settled)
+            val settledStripped = settled.filterNot { it.isWhitespace() }
+            assertEquals(
+                "the multiline payload must occur exactly once in the real submitted " +
+                    "transcript; capture=$settled",
+                1,
+                countOccurrences(settledStripped, payloadStripped),
+            )
+            assertEquals(
+                "Enter must submit exactly once; capture=$settled",
+                1,
+                countOccurrences(
+                    settledStripped,
+                    FAKE_AGENT_SUBMITTED_STRIPPED + payloadStripped,
+                ),
+            )
+            assertInputBoxEmpty("after issue1739 same-token retry", submitted)
+            assertTrue(
+                "the SAME durable row/token must be Sent and pruned; id=${row.id} " +
+                    "remaining=${store.itemsFor(sessionKey)}",
+                store.item(row.id) == null && store.itemsFor(sessionKey).isEmpty(),
+            )
+            writeText(
+                "issue1739-row-prune.txt",
+                "session=$sessionKey\nrowId=${row.id}\nitem=null\nsessionItems=0\n",
+            )
+            val verifies = diagnostics!!.eventsNamed("outbound_verify_before_resend")
+            assertTrue(
+                "the retry must verify the SAME durable token as AlreadyLanded; " +
+                    "row=${row.id} events=$verifies",
+                verifies.any {
+                    it.fields["sendToken"] == row.id &&
+                        it.fields["outcome"] == "AlreadyLanded"
+                },
+            )
+            assertEquals(
+                "only one collapsed-paste commit may reach the live pane; capture=$settled",
+                1,
+                Regex("""\[Pasted text #\d+ \+\d+ lines?]""")
+                    .findAll(firstCapture)
+                    .count(),
+            )
+            assertEquals(
+                "the fresh reconnect client must remain live after retry",
+                clientAfterCut,
+                currentViewModel().currentClientIdentityForTest(),
+            )
+            val finalViewportText = waitForVisibleTerminal(
+                "issue1739 final one-submission viewport",
+            ) {
+                val stripped = it.filterNot { ch -> ch.isWhitespace() }
+                stripped.contains(FAKE_AGENT_SUBMITTED_STRIPPED + payloadStripped)
+            }
+            openTerminalTab(viewModel, paneId)
+            captureLiveTerminalViewport(
+                "issue1739-final-submitted-viewport",
+                finalViewportText,
+                viewModel,
+                paneId,
+            )
+            writeText(
+                "issue1739-diagnostics.txt",
+                diagnostics!!.events.joinToString("\n") {
+                    "${it.category}/${it.name} ${it.fields}"
+                },
+            )
+            captureArtifacts("issue1739-live-input")
+            writeTimings()
+        }
+    }
 
     /**
      * Issue #1636 — the PAYLOAD-INTEGRITY limb, against the REAL tmux server.
@@ -703,6 +1046,101 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         )
     }
 
+    private fun waitForFreshClient(previousClient: Int?): Int {
+        var current: Int? = null
+        waitUntilWall(CONNECTED_TIMEOUT_MS, "fresh client after worker cut") {
+            current = currentViewModel().currentClientIdentityForTest()
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected &&
+                current != null &&
+                current != previousClient
+        }
+        return requireNotNull(current)
+    }
+
+    private fun waitUntilWall(
+        timeoutMs: Long,
+        label: String,
+        predicate: () -> Boolean,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (predicate()) return
+            SystemClock.sleep(20)
+        }
+        assertTrue("$label did not resolve within ${timeoutMs}ms", predicate())
+    }
+
+    /**
+     * Issue #1739 connected-test pump.
+     *
+     * [createAndroidComposeRule] installs a [kotlinx.coroutines.test.TestDispatcher]
+     * for app Main/viewModelScope. A raw [SystemClock.sleep] loop advances wall
+     * time but leaves that virtual scheduler frozen, so the production 800ms
+     * `withTimeoutOrNull` cannot fire and the synthetic cleanup is never
+     * cancelled. Advance only this journey's Compose Main clock in small steps
+     * while retaining the hard wall-clock deadline. The wall bound is the
+     * load-bearing anti-hang assertion; scheduler advancement only lets the
+     * launch-owned harness model time actually passing on a normal device.
+     */
+    private fun waitForIssue1739Boundary(
+        timeoutMs: Long,
+        label: String,
+        predicate: () -> Boolean,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (predicate()) return
+            compose.mainClock.advanceTimeBy(ISSUE1739_MAIN_CLOCK_STEP_MS)
+            SystemClock.sleep(ISSUE1739_MAIN_CLOCK_STEP_MS)
+        }
+        assertTrue(
+            "$label did not resolve within ${timeoutMs}ms while advancing " +
+                "Compose Main by ${ISSUE1739_MAIN_CLOCK_STEP_MS}ms steps",
+            predicate(),
+        )
+    }
+
+    /**
+     * Issue #1739 post-failure redispatch pump.
+     *
+     * The production auto-flush correctly suppresses an immediate retry, then
+     * wakes after `OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS` on app Main. Under
+     * [createAndroidComposeRule] that delay is virtual, just like the ack
+     * deadline above. Poll the REAL server-side pane and SAME-token diagnostic
+     * while advancing the Compose Main clock in bounded 20ms steps. This keeps
+     * the real queue/backoff/auto-flush path load-bearing—no direct send call,
+     * no production delay override—and retains an independent hard wall bound.
+     */
+    private fun waitForIssue1739RetrySubmission(
+        label: String,
+        timeoutMs: Long,
+        verified: () -> Boolean,
+        submitted: (String) -> Boolean,
+    ): String {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            last = runBlocking { sidecarCapturePane() }
+            if (verified() && submitted(last)) return last
+
+            var tick = 0
+            while (
+                tick < ISSUE1739_MAIN_CLOCK_STEPS_PER_SIDECAR_POLL &&
+                SystemClock.elapsedRealtime() < deadline
+            ) {
+                compose.mainClock.advanceTimeBy(ISSUE1739_MAIN_CLOCK_STEP_MS)
+                SystemClock.sleep(ISSUE1739_MAIN_CLOCK_STEP_MS)
+                tick += 1
+            }
+        }
+        assertTrue(
+            "$label did not resolve within ${timeoutMs}ms while driving the real " +
+                "auto-flush; verified=${verified()} capture:\n$last",
+            verified() && submitted(last),
+        )
+        return last
+    }
+
     private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
         var status: TmuxSessionViewModel.ConnectionStatus =
             TmuxSessionViewModel.ConnectionStatus.Idle
@@ -865,6 +1303,76 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         writeText("$name-visible-terminal.txt", visibleTerminalText())
     }
 
+    /**
+     * Authoritative #1739 evidence: capture the active app window while the
+     * Terminal tab is visibly backed by a live [TerminalView]. The PNG is taken
+     * during the test, before activity teardown, and copied by the connected-test
+     * additional-output collector together with its exact terminal text.
+     */
+    private fun captureLiveTerminalViewport(
+        name: String,
+        visibleText: String,
+        viewModel: TmuxSessionViewModel,
+        paneId: String,
+    ): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        check(viewModel.agentConversations.value[paneId]?.selectedTab == SessionTab.Terminal) {
+            "$name requires Terminal to be the authoritative selected tab"
+        }
+        check(hasNode(TMUX_TERMINAL_TAB_TAG) && !hasNode(TMUX_CONVERSATION_PANE_TAG)) {
+            "$name requires the real Terminal tab UI with no Conversation surface visible"
+        }
+        instrumentation.waitForIdleSync()
+        var terminalIsLiveAndShown = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val terminal = activity.window.decorView.findTerminalView()
+            terminalIsLiveAndShown =
+                terminal != null &&
+                terminal.isShown &&
+                terminal.width > 0 &&
+                terminal.height > 0 &&
+                terminal.currentSession != null
+        }
+        check(terminalIsLiveAndShown) {
+            "$name requires a visible live TerminalView before viewport capture"
+        }
+        val bitmap = checkNotNull(instrumentation.uiAutomation.takeScreenshot()) {
+            "UiAutomation returned no screenshot for $name"
+        }
+        check(bitmap.width == 1080 && bitmap.height == 2400) {
+            "$name must be the reviewer-required 1080x2400 viewport; " +
+                "got ${bitmap.width}x${bitmap.height}"
+        }
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { stream ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)) {
+                "failed to encode ${file.absolutePath}"
+            }
+        }
+        bitmap.recycle()
+        writeText("$name-visible-terminal.txt", visibleText)
+        println("ISSUE1739_LIVE_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun openTerminalTab(viewModel: TmuxSessionViewModel, paneId: String) {
+        compose.activityRule.scenario.onActivity {
+            viewModel.selectSessionTab(paneId, SessionTab.Terminal)
+        }
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            viewModel.agentConversations.value[paneId]?.selectedTab == SessionTab.Terminal
+        }
+        compose.onNodeWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true)
+            .performClick()
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            viewModel.agentConversations.value[paneId]?.selectedTab == SessionTab.Terminal &&
+                hasNode(TMUX_TERMINAL_TAB_TAG) &&
+                !hasNode(TMUX_CONVERSATION_PANE_TAG)
+        }
+        compose.waitForIdle()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
     private fun writeText(name: String, text: String): File {
         val file = artifactFile(name)
         file.writeText(text)
@@ -923,6 +1431,11 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 10_000L
         val CONNECTED_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 90_000L else 45_000L
+        const val ACK_CAPTURE_OBSERVED_TIMEOUT_MS: Long = 5_000L
+        const val ACK_BOUNDED_RESULT_TIMEOUT_MS: Long = 5_000L
+        const val MAIN_HEARTBEAT_TIMEOUT_MS: Long = 2_000L
+        const val ISSUE1739_MAIN_CLOCK_STEP_MS: Long = 20L
+        const val ISSUE1739_MAIN_CLOCK_STEPS_PER_SIDECAR_POLL: Int = 10
         val DEFERRAL_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 30_000L
 

--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1739AgentAckBoundRealTransportIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1739AgentAckBoundRealTransportIntegrationTest.kt
@@ -1,0 +1,462 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.diagnostics.RecordingDiagnosticEventSink
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshSessionTestControl
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxClientFactory
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Issue #1739: headless D34 proof of the preserved #1733 paste/ack wedge.
+ *
+ * The payload and Enter ride a real TmuxClient over real sshj into Docker tmux.
+ * Only the post-paste ack capture is fault-wrapped: it first completes a REAL
+ * capture (proving the paste is in the pane), then models RealSshSession.exec's
+ * cancellation path parking in NonCancellable TransportDispatcher teardown.
+ * The production VM must resolve at its 800 ms deadline without joining that
+ * cleanup and without Enter. A same-token retry then verifies the already-landed
+ * payload over the fresh real transport and sends Enter-only. Command counts and
+ * the real pane transcript prove exactly one paste and one submission.
+ *
+ * Reverting the detached capture boundary to structured `withTimeout` makes the
+ * first result miss [CALLER_BOUND_MS] while cleanup remains parked (RED).
+ * Removing runtime/verify gating either injects the first blind Enter or
+ * duplicate-pastes on retry (RED).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1739AgentAckBoundRealTransportIntegrationTest {
+
+    companion object {
+        private const val CONTAINER_SSH_PORT = 22
+        private const val SESSION_NAME = "issue1739-ack-bound"
+        private const val PAYLOAD =
+            "echo issue1739_agent_ack_line1\necho issue1739_agent_ack_exactly_once"
+        private const val MARKER = "issue1739_agent_ack_exactly_once"
+        private const val CALLER_BOUND_MS = 5_000L
+
+        private val projectRoot: Path by lazy { findProjectRoot() }
+
+        @Volatile
+        private var container: GenericContainer<*>? = null
+
+        private fun startDockerOrFail() {
+            val dockerAvailable = runCatching {
+                DockerClientFactory.instance().isDockerAvailable
+            }.getOrDefault(false)
+            check(dockerAvailable) {
+                "#1739 hard real-transport gate requires Docker, but Docker is unavailable. " +
+                    "Start the Docker daemon and verify `docker info`; this test must never skip."
+            }
+
+            val dockerfile = projectRoot.resolve("tests/docker/Dockerfile.agents")
+            val imageName = "pocketshell-test:agents-issue1739"
+            val imageBuild = ProcessBuilder(
+                "docker",
+                "build",
+                "-t",
+                imageName,
+                "-f",
+                dockerfile.toString(),
+                projectRoot.toString(),
+            ).redirectErrorStream(true).start()
+            val imageOut = imageBuild.inputStream.bufferedReader().readText()
+            check(imageBuild.waitFor() == 0) {
+                "Failed to build $imageName:\n$imageOut"
+            }
+
+            container = GenericContainer(DockerImageName.parse(imageName))
+                .withExposedPorts(CONTAINER_SSH_PORT)
+                .also { it.start() }
+        }
+
+        private fun stopDocker() {
+            container?.stop()
+            container = null
+        }
+
+        private fun findProjectRoot(): Path {
+            var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            while (dir != null) {
+                if (dir.resolve("tests/docker/Dockerfile.tmux").toFile().exists()) return dir
+                dir = dir.parent
+            }
+            error(
+                "Could not locate tests/docker/Dockerfile.tmux from " +
+                    "user.dir=${System.getProperty("user.dir")}",
+            )
+        }
+    }
+
+    private val sshPort: Int get() = container!!.getMappedPort(CONTAINER_SSH_PORT)
+    private val sshHost: String get() = container!!.host
+    private val privateKeyFile: File get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    @Before
+    fun setMain() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @After
+    fun resetMain() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun reconnectPasteAckCleanupIsCallerBoundedThenRecoversEnterOnlyExactlyOnce() {
+        startDockerOrFail()
+        try {
+            runBlocking {
+                runRealTransportJourney()
+            }
+        } finally {
+            AgentSubmitCaptureSeams.reset()
+            stopDocker()
+        }
+    }
+
+    private suspend fun runRealTransportJourney() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        var firstSession: SshSession? = null
+        var secondSession: SshSession? = null
+        var firstClient: TmuxClient? = null
+        var realClient: TmuxClient? = null
+        var vm: TmuxSessionViewModel? = null
+        var diagnostics: RecordingDiagnosticEventSink? = null
+        try {
+            val structuredMutation =
+                System.getenv("POCKETSHELL_ISSUE1739_STRUCTURED_CAPTURE_MUTANT") == "1"
+            AgentSubmitCaptureSeams.structuredChildMutation = structuredMutation
+            println("ISSUE1739_STRUCTURED_CAPTURE_MUTANT enabled=$structuredMutation")
+            diagnostics = installRecordingDiagnosticSink()
+            val factory = TmuxClientFactory(scope)
+
+            // Genuine worker/transport cut, then a fresh real sshj/tmux client.
+            firstSession = connect()
+            seedFakeAgentSession(firstSession)
+            firstClient = factory.create(
+                session = firstSession,
+                sessionName = SESSION_NAME,
+                createIfMissing = false,
+                probeServerLiveness = true,
+            )
+            firstClient.connect()
+            val paneId = requirePaneId(firstSession)
+            SshSessionTestControl.forceTransportDeath(firstSession)
+            withTimeout(10_000) {
+                firstClient.disconnected.first { it }
+            }
+
+            secondSession = connect()
+            realClient = factory.create(
+                session = secondSession,
+                sessionName = SESSION_NAME,
+                createIfMissing = false,
+                probeServerLiveness = true,
+            )
+            realClient.connect()
+            val client = AckCleanupWedgeClient(realClient)
+
+            val queue = InMemoryOutboundQueueStore()
+            val row = queue.enqueue(
+                sessionKey = SESSION_NAME,
+                cleanText = PAYLOAD,
+                paneId = paneId,
+                route = OutboundRoute.AgentPayload,
+                agentKind = AgentKind.ClaudeCode.name,
+                sendKey = "issue1739-real-row",
+            )
+            queue.markInFlight(row.id)
+            val durableRow = DurableOutboundRowIdentity(SESSION_NAME, row.id)
+
+            vm = TmuxSessionViewModel(
+                tmuxClientFactory = factory,
+                activeTmuxClients = ActiveTmuxClients(),
+                outboundQueueStore = queue,
+            )
+            vm.attachClientForTest(client)
+            vm.applyParsedPanesForTest(
+                listOf(
+                    TmuxSessionViewModel.ParsedPane(
+                        paneId = paneId,
+                        windowId = "@0",
+                        sessionId = "\$0",
+                        title = "issue1739",
+                        paneIndex = 0,
+                        sessionName = SESSION_NAME,
+                    ),
+                ),
+            )
+            vm.startAgentConversationForTest(
+                paneId,
+                AgentDetection(
+                    agent = AgentKind.ClaudeCode,
+                    sourcePath = "/tmp/issue1739.jsonl",
+                    sessionId = "issue1739",
+                    confidence = AgentDetection.Confidence.ProcessConfirmed,
+                ),
+            )
+
+            client.wedgeNextVisibleCapture = true
+            val startedAt = System.currentTimeMillis()
+            val first = withTimeout(CALLER_BOUND_MS) {
+                vm.sendAgentPayloadToPaneResult(
+                    paneId,
+                    PAYLOAD,
+                    AgentKind.ClaudeCode,
+                    sendToken = row.id,
+                    durableRow = durableRow,
+                )
+            }
+            val firstElapsedMs = System.currentTimeMillis() - startedAt
+
+            assertTrue("unconfirmed first attempt must remain retryable", first.isFailure)
+            assertTrue(
+                "ack caller must resolve well below the old 50s composer timeout; " +
+                    "elapsed=${firstElapsedMs}ms",
+                firstElapsedMs < CALLER_BOUND_MS,
+            )
+            assertTrue("the real capture completed before teardown wedged", client.realCaptureCompleted)
+            assertTrue(
+                "the real pane must reproduce Claude's collapsed multiline-paste chip: " +
+                    client.landedCapture,
+                client.landedCapture.any { it.contains("[Pasted text #") },
+            )
+            assertEquals("the real bracketed paste must commit exactly once", 1, client.payloadPasteCommands())
+            assertTrue(
+                "the real delivery must use tmux paste-buffer, not the single-line send-keys path",
+                client.usedBracketedPasteCommit(),
+            )
+            assertEquals(0, client.submitEnterCommands())
+            assertEquals(OutboundState.InFlight, queue.item(row.id)?.state)
+            assertTrue(queue.item(row.id)?.wireAttempted == true)
+            val captureDiagnostics = diagnostics.eventsNamed("agent_submit_capture")
+            assertTrue(
+                "diagnostics must prove the caller deadline won over wedged cleanup: " +
+                    captureDiagnostics,
+                captureDiagnostics.any { it.fields["result"] == "TimedOut" },
+            )
+            val ackDiagnostics = diagnostics.eventsNamed("agent_submit_ack")
+            assertTrue(
+                "diagnostics must classify the ambiguous attempt without blind Enter: " +
+                    ackDiagnostics,
+                ackDiagnostics.any { it.fields["result"] == "capture_timeout" },
+            )
+
+            // Let the invalidated cleanup finish. Recovery uses the SAME durable
+            // row/token: real capture proves the typed payload, so Enter-only.
+            client.releaseCaptureCleanup()
+            client.wedgeNextVisibleCapture = false
+            queue.requeueForRetry(row.id)
+            queue.markInFlight(row.id)
+            val retry = withTimeout(CALLER_BOUND_MS) {
+                vm.sendAgentPayloadToPaneResult(
+                    paneId,
+                    PAYLOAD,
+                    AgentKind.ClaudeCode,
+                    sendToken = row.id,
+                    durableRow = durableRow,
+                )
+            }
+            assertTrue("identity-safe verify retry must complete", retry.isSuccess)
+            assertEquals("payload must never be pasted twice", 1, client.payloadPasteCommands())
+            assertEquals("submit Enter must be sent exactly once", 1, client.submitEnterCommands())
+
+            val transcript = withTimeout(10_000) {
+                while (true) {
+                    val response = realClient.capturePaneTextViaExec(
+                        paneId,
+                        timeoutMs = 4_000,
+                        scrollbackLines = 200,
+                    )
+                    if (!response.isError && response.output.any { it.contains(MARKER) }) {
+                        return@withTimeout response.output.joinToString("\n")
+                    }
+                    delay(100)
+                }
+                @Suppress("UNREACHABLE_CODE")
+                ""
+            }
+            assertTrue("real pane transcript must contain submitted marker", transcript.contains(MARKER))
+            assertEquals(
+                "the real fake-agent transcript must contain exactly one submission",
+                1,
+                Regex("FAKE-AGENT SUBMITTED:").findAll(transcript).count(),
+            )
+
+            assertTrue(queue.markDelivered(row.id))
+            assertNull("successful row is Sent/pruned", queue.item(row.id))
+            println(
+                "ISSUE1739_REAL_DOCKER firstElapsedMs=$firstElapsedMs " +
+                    "pasteCommands=${client.payloadPasteCommands()} " +
+                    "enterCommands=${client.submitEnterCommands()} pane=$paneId",
+            )
+            println(
+                "ISSUE1739_REAL_DIAGNOSTICS " +
+                    diagnostics.events
+                        .filter { it.name == "agent_submit_capture" || it.name == "agent_submit_ack" }
+                        .joinToString(separator = "\n"),
+            )
+            println("ISSUE1739_REAL_TRANSCRIPT\n$transcript")
+        } finally {
+            diagnostics?.close()
+            vm?.clearForTest()
+            runCatching { firstClient?.close() }
+            runCatching { realClient?.close() }
+            runCatching { firstSession?.close() }
+            runCatching { secondSession?.close() }
+            scope.cancel()
+        }
+    }
+
+    private suspend fun connect(): SshSession = SshConnection.connect(
+        host = sshHost,
+        port = sshPort,
+        user = "testuser",
+        key = SshKey.Path(privateKeyFile),
+        passphrase = null,
+        knownHosts = KnownHostsPolicy.AcceptAll,
+        timeoutMs = 15_000,
+    ).getOrThrow()
+
+    private suspend fun requirePaneId(session: SshSession): String {
+        val result = session.exec(
+            "tmux display-message -p -t '$SESSION_NAME' '#{pane_id}'",
+        )
+        check(result.exitCode == 0) { "pane lookup failed: ${result.stderr}" }
+        return result.stdout.trim().also {
+            check(it.startsWith("%")) { "invalid pane id '$it'" }
+        }
+    }
+
+    private suspend fun seedFakeAgentSession(session: SshSession) {
+        val command =
+            "tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true; " +
+                "tmux new-session -d -s '$SESSION_NAME' -x 80 -y 40 " +
+                "'exec /usr/local/bin/pocketshell-fake-agent'; " +
+                "tmux set-option -p -t '$SESSION_NAME' @ps_agent_kind claude"
+        val result = session.exec(command)
+        check(result.exitCode == 0) {
+            "fake-agent seed failed: stdout=${result.stdout} stderr=${result.stderr}"
+        }
+        withTimeout(10_000) {
+            while (true) {
+                val capture = withTimeout(4_000) {
+                    session.exec("tmux capture-pane -p -t '$SESSION_NAME'")
+                }
+                if (capture.exitCode == 0 && capture.stdout.contains("FAKE-AGENT-READY")) return@withTimeout
+                delay(100)
+            }
+        }
+    }
+
+    private class AckCleanupWedgeClient(
+        private val delegate: TmuxClient,
+    ) : TmuxClient by delegate {
+        private val commands = CopyOnWriteArrayList<String>()
+        private val cleanupGate = CompletableDeferred<Unit>()
+
+        @Volatile
+        var wedgeNextVisibleCapture: Boolean = false
+
+        @Volatile
+        var realCaptureCompleted: Boolean = false
+            private set
+
+        @Volatile
+        var landedCapture: List<String> = emptyList()
+            private set
+
+        override suspend fun sendKeysViaExec(
+            sendKeysCommand: String,
+            timeoutMs: Long?,
+        ): CommandResponse {
+            commands += sendKeysCommand
+            return delegate.sendKeysViaExec(sendKeysCommand, timeoutMs)
+        }
+
+        override suspend fun capturePaneTextViaExec(
+            paneId: String,
+            timeoutMs: Long?,
+            scrollbackLines: Int,
+        ): CommandResponse {
+            val response = delegate.capturePaneTextViaExec(paneId, timeoutMs, scrollbackLines)
+            if (
+                !wedgeNextVisibleCapture ||
+                scrollbackLines != 0 ||
+                response.output.none { it.contains("[Pasted text #") }
+            ) {
+                return response
+            }
+            wedgeNextVisibleCapture = false
+            realCaptureCompleted = true
+            landedCapture = response.output
+            try {
+                CompletableDeferred<Unit>().await()
+            } catch (cancelled: CancellationException) {
+                withContext(NonCancellable) {
+                    cleanupGate.await()
+                }
+                throw cancelled
+            }
+            error("unreachable")
+        }
+
+        fun releaseCaptureCleanup() {
+            cleanupGate.complete(Unit)
+        }
+
+        fun payloadPasteCommands(): Int =
+            commands.count { it.startsWith("send-keys -l ") || it.startsWith("paste-buffer ") }
+
+        fun usedBracketedPasteCommit(): Boolean =
+            commands.any { it.startsWith("paste-buffer ") }
+
+        fun submitEnterCommands(): Int =
+            commands.count { it == "send-keys -t %0 Enter" || it.endsWith(" Enter") }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -313,11 +313,12 @@ public interface OutboundQueueStore {
     public fun clearSession(sessionKey: String)
 
     /**
-     * Issue #1541 (finding P9): durably mark that any un-delivered row targeting
-     * [paneId] whose ON-WIRE payload is [payload] has been **pushed to the wire**
-     * — a delivery attempt started that may have landed server-side. The payload
-     * is matched against the row's [OutboundItem.cleanText] AND, for an
-     * attachment-backed row, its reconstructed on-wire form (issue #1554).
+     * Issue #1541/#1739: durably mark that the exact outbound row [itemId] in
+     * [sessionKey] has been **pushed to the wire** — a delivery attempt started
+     * that may have landed server-side. Queue row ids are the idempotency tokens
+     * carried by the composer send request; pane ids and payload bytes are not
+     * identities because every tmux session can own `%0` and two sessions can
+     * legitimately send identical text.
      * The flag ([OutboundItem.wireAttempted]) is persisted ON THE ROW, so it
      * survives a plain **VM-clear / back-navigation** (which destroys the volatile
      * [OutboundDeliveryLedger][com.pocketshell.app.tmux.OutboundDeliveryLedger]),
@@ -335,33 +336,28 @@ public interface OutboundQueueStore {
      * landed ⇒ occurrence 1) instead of blindly re-pasting.
      */
     public fun markWireAttempted(
-        paneId: String,
-        payload: String,
+        sessionKey: String,
+        itemId: String,
         atMs: Long = System.currentTimeMillis(),
         baselineCount: Int? = null,
+        collapsedMarkerBaselineCount: Int? = null,
     ): OutboundItem?
 
-    /**
-     * Issue #1541 / #1554: whether any persisted row targeting [paneId] whose
-     * on-wire payload is [payload] carries a durable [OutboundItem.wireAttempted]
-     * flag — i.e. a prior wire attempt survived a VM-clear. [payload] is matched
-     * against the row's [OutboundItem.cleanText] AND, for attachment-backed rows,
-     * its reconstructed on-wire form (`cleanText` + appended attachment paths). This
-     * is what a rebuilt ledger consults so back-navigation mid-delivery re-enters
-     * verify-before-resend — including for attachment sends whose wire payload
-     * differs from `cleanText`.
-     */
-    public fun hasWireAttempt(paneId: String, payload: String): Boolean
+    /** Whether the exact persisted row [itemId] in [sessionKey] has a wire attempt. */
+    public fun hasWireAttempt(sessionKey: String, itemId: String): Boolean
 
     /**
      * Issue #1577: the durable [OutboundItem.wireNeedleBaselineCount] recorded for
-     * the row matching (`paneId`, `payload`), or `null` when none was captured. A
+     * the exact row ([sessionKey], [itemId]), or `null` when none was captured. A
      * ledger rebuilt after a VM-clear reads this so a genuine resend can compare the
      * CURRENT pane needle count against the pre-send baseline (only an INCREASE means
      * "landed"), instead of a presence-only match that a pre-existing status line
      * would false-trip.
      */
-    public fun wireNeedleBaseline(paneId: String, payload: String): Int?
+    public fun wireNeedleBaseline(sessionKey: String, itemId: String): Int?
+
+    /** Issue #1739: durable pre-send collapsed-paste-chip count for multiline payloads. */
+    public fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int?
 }
 
 /**
@@ -373,32 +369,57 @@ public interface OutboundQueueStore {
  */
 public interface OutboundWireAttemptDurableStore {
     /**
-     * Persist that (`paneId`, `payload`) has been pushed to the wire. Issue #1577:
+     * Persist that exact ([sessionKey], [itemId]) row has been pushed to the wire.
+     * Issue #1577:
      * [baselineCount] is the pre-send occurrence count of the payload's verify needle
      * on the pane (or `null` when it could not be captured), stored once with the
      * first wire attempt so a rebuilt ledger can compare against it.
      */
-    public fun recordWireAttempt(paneId: String, payload: String, atMs: Long, baselineCount: Int? = null)
+    public fun recordWireAttempt(
+        sessionKey: String,
+        itemId: String,
+        atMs: Long,
+        baselineCount: Int? = null,
+        collapsedMarkerBaselineCount: Int? = null,
+    )
 
-    /** Whether a durable wire attempt is recorded for (`paneId`, `payload`). */
-    public fun hasWireAttempt(paneId: String, payload: String): Boolean
+    /** Whether a durable wire attempt is recorded for exact ([sessionKey], [itemId]). */
+    public fun hasWireAttempt(sessionKey: String, itemId: String): Boolean
 
-    /** Issue #1577: the durable pre-send needle baseline for (`paneId`, `payload`), or `null`. */
-    public fun wireNeedleBaseline(paneId: String, payload: String): Int?
+    /** Issue #1577: durable pre-send needle baseline for exact row, or `null`. */
+    public fun wireNeedleBaseline(sessionKey: String, itemId: String): Int?
+
+    /** Issue #1739: durable pre-send collapsed-paste-chip count, or `null`. */
+    public fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int?
 }
 
 /** Issue #1541: adapt this store as the ledger's durable wire-attempt backing. */
 public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDurableStore =
     object : OutboundWireAttemptDurableStore {
-        override fun recordWireAttempt(paneId: String, payload: String, atMs: Long, baselineCount: Int?) {
-            markWireAttempted(paneId, payload, atMs, baselineCount)
+        override fun recordWireAttempt(
+            sessionKey: String,
+            itemId: String,
+            atMs: Long,
+            baselineCount: Int?,
+            collapsedMarkerBaselineCount: Int?,
+        ) {
+            markWireAttempted(
+                sessionKey,
+                itemId,
+                atMs,
+                baselineCount,
+                collapsedMarkerBaselineCount,
+            )
         }
 
-        override fun hasWireAttempt(paneId: String, payload: String): Boolean =
-            this@asWireAttemptDurableStore.hasWireAttempt(paneId, payload)
+        override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean =
+            this@asWireAttemptDurableStore.hasWireAttempt(sessionKey, itemId)
 
-        override fun wireNeedleBaseline(paneId: String, payload: String): Int? =
-            this@asWireAttemptDurableStore.wireNeedleBaseline(paneId, payload)
+        override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? =
+            this@asWireAttemptDurableStore.wireNeedleBaseline(sessionKey, itemId)
+
+        override fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int? =
+            this@asWireAttemptDurableStore.wireCollapsedMarkerBaseline(sessionKey, itemId)
     }
 
 /**
@@ -452,6 +473,9 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
  *   pane (a Codex `Goal blocked (/goal resume)` status line) is not mistaken for a
  *   landed send. Persisted so the refinement survives a VM-clear / back-navigation
  *   (the rebuilt ledger reads it back); `null` falls back to presence-only (#1541).
+ * @property wireCollapsedMarkerBaselineCount issue #1739: the pre-send count of
+ *   Claude's collapsed multiline-paste chips. A retry may treat a higher current
+ *   count as proof that the ambiguous paste landed, then submit Enter-only.
  */
 public data class OutboundItem(
     val id: String,
@@ -471,6 +495,7 @@ public data class OutboundItem(
     val wireAttempted: Boolean = false,
     val wireAttemptedAtMs: Long? = null,
     val wireNeedleBaselineCount: Int? = null,
+    val wireCollapsedMarkerBaselineCount: Int? = null,
 )
 
 /** Issue #900: persisted send route selected before an item entered the durable queue. */
@@ -711,26 +736,40 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
         items.values.removeAll { it.sessionKey == sessionKey }
     }
 
-    override fun markWireAttempted(paneId: String, payload: String, atMs: Long, baselineCount: Int?): OutboundItem? =
+    override fun markWireAttempted(
+        sessionKey: String,
+        itemId: String,
+        atMs: Long,
+        baselineCount: Int?,
+        collapsedMarkerBaselineCount: Int?,
+    ): OutboundItem? =
         synchronized(lock) {
-            val target = items.values
-                .filter { it.matchesWireTarget(paneId, payload) }
-                .minByOrNull { it.createdAtMs }
+            val target = items[itemId]
+                ?.takeIf { it.sessionKey == sessionKey && it.state != OutboundState.Delivered }
                 ?: return null
-            val updated = target.markedWireAttempted(atMs, baselineCount)
+            val updated = target.markedWireAttempted(
+                atMs,
+                baselineCount,
+                collapsedMarkerBaselineCount,
+            )
             items[updated.id] = updated
             updated
         }
 
-    override fun hasWireAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
-        items.values.any { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
+    override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean = synchronized(lock) {
+        items[itemId]?.let { it.sessionKey == sessionKey && it.wireAttempted } == true
     }
 
-    override fun wireNeedleBaseline(paneId: String, payload: String): Int? = synchronized(lock) {
-        items.values
-            .filter { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
-            .minByOrNull { it.createdAtMs }
+    override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = synchronized(lock) {
+        items[itemId]
+            ?.takeIf { it.sessionKey == sessionKey && it.wireAttempted }
             ?.wireNeedleBaselineCount
+    }
+
+    override fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int? = synchronized(lock) {
+        items[itemId]
+            ?.takeIf { it.sessionKey == sessionKey && it.wireAttempted }
+            ?.wireCollapsedMarkerBaselineCount
     }
 }
 
@@ -776,9 +815,16 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> = emptyList()
     override fun remove(id: String): Boolean = false
     override fun clearSession(sessionKey: String) = Unit
-    override fun markWireAttempted(paneId: String, payload: String, atMs: Long, baselineCount: Int?): OutboundItem? = null
-    override fun hasWireAttempt(paneId: String, payload: String): Boolean = false
-    override fun wireNeedleBaseline(paneId: String, payload: String): Int? = null
+    override fun markWireAttempted(
+        sessionKey: String,
+        itemId: String,
+        atMs: Long,
+        baselineCount: Int?,
+        collapsedMarkerBaselineCount: Int?,
+    ): OutboundItem? = null
+    override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean = false
+    override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = null
+    override fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int? = null
 }
 
 /**
@@ -1052,33 +1098,45 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         storeSession(sessionKey, emptyList())
     }
 
-    override fun markWireAttempted(paneId: String, payload: String, atMs: Long, baselineCount: Int?): OutboundItem? =
+    override fun markWireAttempted(
+        sessionKey: String,
+        itemId: String,
+        atMs: Long,
+        baselineCount: Int?,
+        collapsedMarkerBaselineCount: Int?,
+    ): OutboundItem? =
         synchronized(lock) {
-            for (sessionKey in sessionKeys()) {
-                val list = loadSession(sessionKey)
-                val target = list
-                    .filter { it.matchesWireTarget(paneId, payload) }
-                    .minByOrNull { it.createdAtMs }
-                    ?: continue
-                val updated = target.markedWireAttempted(atMs, baselineCount)
-                replaceAndStore(sessionKey, list, updated)
-                return@synchronized updated
-            }
-            null
+            val list = loadSession(sessionKey)
+            val target = list.firstOrNull {
+                it.id == itemId &&
+                    it.sessionKey == sessionKey &&
+                    it.state != OutboundState.Delivered
+            } ?: return null
+            val updated = target.markedWireAttempted(
+                atMs,
+                baselineCount,
+                collapsedMarkerBaselineCount,
+            )
+            replaceAndStore(sessionKey, list, updated)
+            updated
         }
 
-    override fun hasWireAttempt(paneId: String, payload: String): Boolean = synchronized(lock) {
-        sessionKeys().any { key ->
-            loadSession(key).any { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
+    override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean = synchronized(lock) {
+        loadSession(sessionKey).any {
+            it.id == itemId && it.sessionKey == sessionKey && it.wireAttempted
         }
     }
 
-    override fun wireNeedleBaseline(paneId: String, payload: String): Int? = synchronized(lock) {
-        sessionKeys()
-            .flatMap { loadSession(it) }
-            .filter { it.wireAttempted && it.matchesWireTarget(paneId, payload) }
-            .minByOrNull { it.createdAtMs }
+    override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = synchronized(lock) {
+        loadSession(sessionKey)
+            .firstOrNull { it.id == itemId && it.sessionKey == sessionKey && it.wireAttempted }
             ?.wireNeedleBaselineCount
+    }
+
+    override fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int? = synchronized(lock) {
+        loadSession(sessionKey)
+            .firstOrNull { it.id == itemId && it.sessionKey == sessionKey && it.wireAttempted }
+            ?.wireCollapsedMarkerBaselineCount
     }
 
     private fun replaceAndStore(sessionKey: String, list: MutableList<OutboundItem>, updated: OutboundItem) {
@@ -1220,14 +1278,23 @@ private fun OutboundItem.claimedForAttempt(): OutboundItem {
  * VM-clear / back-navigation instead of blindly re-pasting a payload that may
  * already have landed.
  */
-private fun OutboundItem.markedWireAttempted(atMs: Long, baselineCount: Int? = null): OutboundItem =
+private fun OutboundItem.markedWireAttempted(
+    atMs: Long,
+    baselineCount: Int? = null,
+    collapsedMarkerBaselineCount: Int? = null,
+): OutboundItem =
     if (wireAttempted) {
         // Idempotent: the first wire attempt's timestamp AND baseline win. A later
         // re-push (after a NotLanded probe) must not overwrite the pre-send baseline
         // (issue #1577) — it is the ONE pre-first-paste snapshot the probe compares.
         this
     } else {
-        copy(wireAttempted = true, wireAttemptedAtMs = atMs, wireNeedleBaselineCount = baselineCount)
+        copy(
+            wireAttempted = true,
+            wireAttemptedAtMs = atMs,
+            wireNeedleBaselineCount = baselineCount,
+            wireCollapsedMarkerBaselineCount = collapsedMarkerBaselineCount,
+        )
     }
 
 private fun OutboundItem.isStaleRecoverableAttempt(cutoffMs: Long): Boolean =
@@ -1240,12 +1307,12 @@ internal fun blobKey(sessionKey: String): String = "@q/$sessionKey"
 /**
  * Issue #900: encode a session's outbound items as newline-separated rows.
  * Each row is tab-delimited:
- * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs \t wireNeedleBaselineCount`
+ * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs \t wireNeedleBaselineCount \t wireCollapsedMarkerBaselineCount`
  * with the same `\`-escaping [ComposerDraftStore] uses so text/paths containing
  * tabs/newlines round-trip losslessly. The attachments field reuses
  * [encodeAttachments], itself escaped as a single field. Trailing fields
  * (`sendKey` #961, `wireAttempted`/`wireAttemptedAtMs` #1541,
- * `wireNeedleBaselineCount` #1577) are appended last so legacy rows without them
+ * `wireNeedleBaselineCount` #1577, collapsed-marker baseline #1739) are appended last so legacy rows without them
  * decode to their defaults (empty `sendKey`, `wireAttempted=false`,
  * `wireNeedleBaselineCount=null`) rather than a malformed row.
  */
@@ -1268,6 +1335,7 @@ internal fun encodeOutboundItems(items: List<OutboundItem>): String =
             if (item.wireAttempted) "1" else "0",
             item.wireAttemptedAtMs?.toString().orEmpty(),
             item.wireNeedleBaselineCount?.toString().orEmpty(),
+            item.wireCollapsedMarkerBaselineCount?.toString().orEmpty(),
         ).joinToString(separator = "\t") { escapeQueueField(it) }
     }
 
@@ -1300,6 +1368,8 @@ internal fun decodeOutboundItems(sessionKey: String, raw: String): List<Outbound
             wireAttempted = f.getOrNull(13) == "1",
             wireAttemptedAtMs = f.getOrNull(14)?.takeIf { it.isNotEmpty() }?.toLongOrNull(),
             wireNeedleBaselineCount = f.getOrNull(15)?.takeIf { it.isNotEmpty() }?.toIntOrNull(),
+            wireCollapsedMarkerBaselineCount =
+                f.getOrNull(16)?.takeIf { it.isNotEmpty() }?.toIntOrNull(),
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
@@ -1,5 +1,61 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClient
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.withContext
+
+/**
+ * Issue #1739 synthetic-injection seam for connected emulator proof.
+ *
+ * The hook runs only AFTER a real `capture-pane` response returns from the real
+ * sshj/tmux transport. Tests can then model the production cancellation-cleanup
+ * wedge without replacing the transport or its pane evidence. [invokeAfterRealCapture]
+ * pins the synthetic teardown to [Dispatchers.IO], matching the real
+ * `RealSshSession.exec` cancellation path: channel-close writes run on the
+ * dedicated `TransportDispatcher` worker while the cancelling coroutine waits
+ * off Main. A test must never park this seam on Android Main, because that would
+ * manufacture an ANR which the real transport path does not have. Null in
+ * production; one-shot ownership/reset belongs to the test.
+ */
+internal object AgentSubmitCaptureSeams {
+    @Volatile
+    var afterRealCapture:
+        (suspend (response: CommandResponse, scrollbackLines: Int) -> Unit)? = null
+
+    /**
+     * Mutation oracle for the original #1739 defect. When armed by the hard
+     * integration gate, the capture becomes a structured child of the bounded
+     * caller; its non-cancellable transport cleanup can therefore hold the
+     * caller past the deadline. Production and ordinary tests leave this false.
+     */
+    @Volatile
+    var structuredChildMutation: Boolean = false
+
+    suspend fun invokeAfterRealCapture(response: CommandResponse, scrollbackLines: Int) {
+        val hook = afterRealCapture ?: return
+        withContext(Dispatchers.IO) {
+            hook(response, scrollbackLines)
+        }
+    }
+
+    fun reset() {
+        afterRealCapture = null
+        structuredChildMutation = false
+    }
+}
+
 /**
  * Issue #869: ack-gate the submit Enter on the pasted composer text actually
  * landing in the agent's input, rather than relying only on a blind fixed sleep.
@@ -12,9 +68,9 @@ internal const val AGENT_SUBMIT_ACK_POLL_INTERVAL_MS: Long = 40L
  * send, so every normal multi-line message paid the FULL 2s window plus the
  * fallback floor before the submit Enter ("takes too long to send even when the
  * connection is okay"). With the collapsed-paste chip now recognised the ack
- * fires in ~1 RTT on the happy path, so the window only bounds the genuine
- * needle-miss fallback; 800ms is comfortably above a real high-latency capture
- * round-trip while keeping a truly unrecognised render from feeling frozen.
+ * fires in ~1 RTT on the happy path. Issue #1739 makes the 800ms window a hard
+ * no-blind-Enter boundary: a genuinely unrecognised render remains retryable,
+ * and verify-before-resend later decides whether Enter-only is safe.
  */
 internal const val AGENT_SUBMIT_ACK_TIMEOUT_MS: Long = 800L
 
@@ -23,6 +79,259 @@ internal const val AGENT_SUBMIT_ACK_TIMEOUT_MS: Long = 800L
  * the ack needle matches against `capture-pane`.
  */
 internal const val AGENT_SUBMIT_ACK_NEEDLE_TAIL_CHARS: Int = 24
+
+/** Immutable authority snapshot for one agent-send attempt. */
+internal data class AgentSendRuntimeIdentity(
+    val client: TmuxClient,
+    val generation: Long,
+    val target: TmuxSessionViewModel.ConnectionTarget?,
+)
+
+internal enum class AgentPaneCaptureStatus {
+    Captured,
+    TimedOut,
+    Failed,
+    Disconnected,
+    StaleRuntime,
+}
+
+internal data class AgentPaneCaptureResult(
+    val status: AgentPaneCaptureStatus,
+    val response: CommandResponse? = null,
+)
+
+/**
+ * Caller-bounded capture for #1739. The capture is a VM-scope sibling, so the
+ * caller's deadline never joins a cancelled SSH exec's non-cancellable cleanup.
+ */
+internal suspend fun captureAgentPaneWithDeadline(
+    scope: CoroutineScope,
+    identity: AgentSendRuntimeIdentity,
+    paneId: String,
+    timeoutMs: Long,
+    scrollbackLines: Int,
+    isCurrent: (AgentSendRuntimeIdentity, String) -> Boolean,
+    nowMs: () -> Long,
+    currentClientHash: () -> Int?,
+    currentGeneration: () -> Long,
+): AgentPaneCaptureResult =
+    if (AgentSubmitCaptureSeams.structuredChildMutation) {
+        coroutineScope {
+            captureAgentPaneWithDeadlineInScope(
+                scope = this,
+                identity = identity,
+                paneId = paneId,
+                timeoutMs = timeoutMs,
+                scrollbackLines = scrollbackLines,
+                isCurrent = isCurrent,
+                nowMs = nowMs,
+                currentClientHash = currentClientHash,
+                currentGeneration = currentGeneration,
+            )
+        }
+    } else {
+        captureAgentPaneWithDeadlineInScope(
+            scope = scope,
+            identity = identity,
+            paneId = paneId,
+            timeoutMs = timeoutMs,
+            scrollbackLines = scrollbackLines,
+            isCurrent = isCurrent,
+            nowMs = nowMs,
+            currentClientHash = currentClientHash,
+            currentGeneration = currentGeneration,
+        )
+    }
+
+private suspend fun captureAgentPaneWithDeadlineInScope(
+    scope: CoroutineScope,
+    identity: AgentSendRuntimeIdentity,
+    paneId: String,
+    timeoutMs: Long,
+    scrollbackLines: Int,
+    isCurrent: (AgentSendRuntimeIdentity, String) -> Boolean,
+    nowMs: () -> Long,
+    currentClientHash: () -> Int?,
+    currentGeneration: () -> Long,
+): AgentPaneCaptureResult {
+    if (!isCurrent(identity, paneId)) return AgentPaneCaptureResult(AgentPaneCaptureStatus.StaleRuntime)
+    if (identity.client.disconnected.value) return AgentPaneCaptureResult(AgentPaneCaptureStatus.Disconnected)
+
+    val startedAtMs = nowMs()
+    DiagnosticEvents.record(
+        "action",
+        "agent_submit_capture",
+        "pane" to paneId,
+        "result" to "started",
+        "clientHash" to System.identityHashCode(identity.client),
+        "generation" to identity.generation,
+        "session" to (identity.target?.sessionName ?: "test"),
+        "timeoutMs" to timeoutMs,
+        "scrollbackLines" to scrollbackLines,
+    )
+    val capture = scope.async(start = CoroutineStart.UNDISPATCHED) {
+        identity.client.capturePaneTextViaExec(paneId, timeoutMs, scrollbackLines).also {
+            AgentSubmitCaptureSeams.invokeAfterRealCapture(it, scrollbackLines)
+        }
+    }
+    val result = try {
+        val response = withTimeoutOrNull(timeoutMs.coerceAtLeast(1L)) { capture.await() }
+        when {
+            response == null -> AgentPaneCaptureResult(AgentPaneCaptureStatus.TimedOut)
+            !isCurrent(identity, paneId) -> AgentPaneCaptureResult(AgentPaneCaptureStatus.StaleRuntime)
+            identity.client.disconnected.value -> AgentPaneCaptureResult(AgentPaneCaptureStatus.Disconnected)
+            else -> AgentPaneCaptureResult(AgentPaneCaptureStatus.Captured, response)
+        }
+    } catch (cancelled: CancellationException) {
+        if (!currentCoroutineContext().isActive) throw cancelled
+        AgentPaneCaptureResult(AgentPaneCaptureStatus.Failed)
+    } catch (_: Throwable) {
+        AgentPaneCaptureResult(AgentPaneCaptureStatus.Failed)
+    } finally {
+        if (!capture.isCompleted) {
+            capture.cancel(CancellationException("agent submit capture deadline/scope ended"))
+        }
+    }
+    DiagnosticEvents.record(
+        "action",
+        "agent_submit_capture",
+        "pane" to paneId,
+        "result" to result.status.name,
+        "clientHash" to System.identityHashCode(identity.client),
+        "currentClientHash" to currentClientHash(),
+        "generation" to identity.generation,
+        "currentGeneration" to currentGeneration(),
+        "session" to (identity.target?.sessionName ?: "test"),
+        "elapsedMs" to (nowMs() - startedAtMs),
+    )
+    return result
+}
+
+/**
+ * Ack-gate Enter on proof from the exact current runtime. Any timeout, failed
+ * capture, disconnect, or stale binding fails without blind Enter.
+ */
+internal suspend fun awaitAgentPasteIngested(
+    identity: AgentSendRuntimeIdentity,
+    paneId: String,
+    payload: String,
+    agent: AgentKind,
+    configuredFloorMs: Long,
+    ackTimeoutMs: Long,
+    baselineNeedleCount: Int,
+    collapsedMarkerBaseline: Int,
+    capture: suspend (timeoutMs: Long, scrollbackLines: Int) -> AgentPaneCaptureResult,
+    currentClientHash: () -> Int?,
+    currentGeneration: () -> Long,
+) {
+    val floorMs = if (agent == AgentKind.Codex) {
+        maxOf(configuredFloorMs, CODEX_AGENT_SUBMIT_DELAY_MS)
+    } else {
+        configuredFloorMs
+    }
+    val needle = agentSubmitAckNeedle(payload)
+    if (needle == null) {
+        if (floorMs > 0L) delay(floorMs)
+        return
+    }
+
+    val multiline = agentSubmitPayloadIsMultiLine(payload)
+    var polls = 0
+    var terminalResult = "ack_timeout"
+    val observed = withTimeoutOrNull(ackTimeoutMs.coerceAtLeast(1L)) {
+        while (true) {
+            val pane = capture(ackTimeoutMs, 0)
+            when (pane.status) {
+                AgentPaneCaptureStatus.Captured -> {
+                    if (
+                        pane.response?.let {
+                            agentPaneShowsPayload(
+                                it,
+                                needle,
+                                baselineNeedleCount,
+                                multiline,
+                                collapsedMarkerBaseline,
+                            )
+                        } == true
+                    ) {
+                        recordAgentSubmitAck(
+                            identity = identity,
+                            paneId = paneId,
+                            result = "ack_observed",
+                            polls = polls,
+                            currentClientHash = currentClientHash,
+                            currentGeneration = currentGeneration,
+                        )
+                        return@withTimeoutOrNull true
+                    }
+                }
+                AgentPaneCaptureStatus.TimedOut -> {
+                    terminalResult = "capture_timeout"
+                    return@withTimeoutOrNull false
+                }
+                AgentPaneCaptureStatus.Failed -> Unit
+                AgentPaneCaptureStatus.Disconnected -> {
+                    terminalResult = "disconnected"
+                    return@withTimeoutOrNull false
+                }
+                AgentPaneCaptureStatus.StaleRuntime -> {
+                    terminalResult = "stale_runtime"
+                    return@withTimeoutOrNull false
+                }
+            }
+            polls += 1
+            delay(AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
+        }
+    } == true
+    if (observed) return
+
+    recordAgentSubmitAck(
+        identity = identity,
+        paneId = paneId,
+        result = terminalResult,
+        polls = polls,
+        currentClientHash = currentClientHash,
+        currentGeneration = currentGeneration,
+    )
+    throw IllegalStateException("Agent paste acknowledgement was not proven ($terminalResult); kept queued.")
+}
+
+private fun recordAgentSubmitAck(
+    identity: AgentSendRuntimeIdentity,
+    paneId: String,
+    result: String,
+    polls: Int,
+    currentClientHash: () -> Int?,
+    currentGeneration: () -> Long,
+) {
+    DiagnosticEvents.record(
+        "action",
+        "agent_submit_ack",
+        "pane" to paneId,
+        "result" to result,
+        "polls" to polls,
+        "clientHash" to System.identityHashCode(identity.client),
+        "currentClientHash" to currentClientHash(),
+        "generation" to identity.generation,
+        "currentGeneration" to currentGeneration(),
+        "session" to (identity.target?.sessionName ?: "test"),
+    )
+}
+
+private fun agentPaneShowsPayload(
+    response: CommandResponse,
+    needle: String,
+    baselineNeedleCount: Int,
+    payloadIsMultiLine: Boolean,
+    collapsedMarkerBaseline: Int,
+): Boolean {
+    if (response.isError) return false
+    return agentSubmitVisibleTextNeedleCount(response.output, needle) > baselineNeedleCount ||
+        (
+            payloadIsMultiLine &&
+                agentSubmitCollapsedPasteMarkerCount(response.output) > collapsedMarkerBaseline
+            )
+}
 
 internal fun agentSubmitAckNeedle(payload: String): String? {
     val lastLine = payload

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -5,6 +5,7 @@ import com.pocketshell.app.composer.OutboundQueueStore
 import com.pocketshell.app.composer.OutboundWireAttemptDurableStore
 import com.pocketshell.app.composer.asWireAttemptDurableStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -83,6 +84,24 @@ internal object OutboundDeliverySeams {
 }
 
 /**
+ * Exact durable queue identity for one composer-owned send.
+ *
+ * [rowId] is [PromptComposerViewModel.SendRequest.outboundQueueItemId]; it is
+ * deliberately separate from pane/payload and from the volatile delivery token.
+ * Both fields are required so a `%0` retry in session A can never stamp or read
+ * an identical `%0` payload row in session B.
+ */
+internal data class DurableOutboundRowIdentity(
+    val sessionKey: String,
+    val rowId: String,
+) {
+    init {
+        require(sessionKey.isNotBlank()) { "durable outbound session key must not be blank" }
+        require(rowId.isNotBlank()) { "durable outbound row id must not be blank" }
+    }
+}
+
+/**
  * Composer-lane verify-before-resend gate: null when this (pane, payload) has no
  * ambiguous prior wire attempt (the common first-send case — no probe cost);
  * otherwise the probe's verdict, recorded to diagnostics.
@@ -93,8 +112,10 @@ internal suspend fun verifyBeforeAgentResend(
     paneId: String,
     sendToken: String,
     payload: String,
+    durableRow: DurableOutboundRowIdentity? = null,
+    capturePane: OutboundPaneCapture? = null,
 ): DeliveryProbeOutcome? {
-    if (!ledger.hasAmbiguousAttempt(paneId, sendToken, payload)) return null
+    if (!ledger.hasAmbiguousAttempt(paneId, sendToken, payload, durableRow)) return null
     // Issue #1577: compare the CURRENT needle count against the pre-send baseline
     // captured at the first wire attempt. `AlreadyLanded` requires the count to have
     // INCREASED (our paste actually added an occurrence) — so a payload that was
@@ -104,16 +125,29 @@ internal suspend fun verifyBeforeAgentResend(
     // capture) is UNTRUSTWORTHY — it CANNOT distinguish "landed" from a permanent
     // footer occurrence, so it must NEVER resolve `AlreadyLanded` (which would submit
     // a bare Enter and silently drop the payload). [probeOutboundPayloadAlreadyLanded]
-    // reports `NotLanded` for a null baseline instead, so the caller does a REAL gated
-    // resend that records a fresh baseline (self-healing), never a bare Enter.
-    val baseline = ledger.needleBaseline(paneId, sendToken, payload)
-    val outcome = probeOutboundPayloadAlreadyLanded(client, paneId, payload, baseline)
+    // reports `Unknown` unless an independent collapsed-chip baseline proves a
+    // multiline paste landed, so neither a blind resend nor a blind Enter follows.
+    val baseline = ledger.needleBaseline(paneId, sendToken, payload, durableRow)
+    val collapsedMarkerBaseline =
+        ledger.collapsedMarkerBaseline(paneId, sendToken, payload, durableRow)
+    val outcome = probeOutboundPayloadAlreadyLanded(
+        client = client,
+        paneId = paneId,
+        payload = payload,
+        baselineCount = baseline,
+        collapsedMarkerBaselineCount = collapsedMarkerBaseline,
+        capturePane = capturePane,
+    )
     DiagnosticEvents.record(
         "action",
         "outbound_verify_before_resend",
         "pane" to paneId,
         "outcome" to outcome.name,
         "baseline" to (baseline?.toString() ?: "none"),
+        "collapsedMarkerBaseline" to (collapsedMarkerBaseline?.toString() ?: "none"),
+        "sendToken" to sendToken,
+        "durableSession" to (durableRow?.sessionKey ?: "none"),
+        "durableRowId" to (durableRow?.rowId ?: "none"),
     )
     return outcome
 }
@@ -161,6 +195,7 @@ internal suspend fun deliverRawInputWithGuard(
     bytes: ByteArray,
     localRenderText: String,
     sendToken: String,
+    durableRow: DurableOutboundRowIdentity? = null,
     send: suspend (TmuxClient, String, ByteArray) -> Unit,
     submitEnter: suspend (TmuxClient, String) -> Unit,
     afterDelivered: suspend (TmuxClient, String, ByteArray) -> Unit,
@@ -181,7 +216,16 @@ internal suspend fun deliverRawInputWithGuard(
             afterDelivered(client, paneId, bytes)
         }
     }
-    when (verifyBeforeAgentResend(ledger, client, paneId, sendToken, payload)) {
+    when (
+        verifyBeforeAgentResend(
+            ledger,
+            client,
+            paneId,
+            sendToken,
+            payload,
+            durableRow = durableRow,
+        )
+    ) {
         DeliveryProbeOutcome.AlreadyLanded -> return runCatching {
             // Issue #1586 (H1b): the payload TEXT landed but the ambiguous cut may have
             // dropped its terminating submit — do NOT drop the delivery silently.
@@ -201,7 +245,14 @@ internal suspend fun deliverRawInputWithGuard(
         DeliveryProbeOutcome.NotLanded, null -> Unit
     }
     return runCatching {
-        ledger.recordWireAttemptWithBaseline(client, paneId, sendToken, payload, localRenderText)
+        ledger.recordWireAttemptWithBaseline(
+            client,
+            paneId,
+            sendToken,
+            payload,
+            localRenderText,
+            durableRow = durableRow,
+        )
         send(client, paneId, bytes)
         ledger.clear(paneId, sendToken)
         afterDelivered(client, paneId, bytes)
@@ -210,6 +261,15 @@ internal suspend fun deliverRawInputWithGuard(
 
 /** Bounded round-trip for a verify-before-resend `capture-pane` probe. */
 internal const val OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS: Long = 4_000L
+
+/**
+ * Optional VM-owned capture boundary. The agent lane supplies an implementation
+ * that is caller-bounded even when SSH exec cancellation enters non-cancellable
+ * teardown, and rejects results from a superseded runtime. Other lanes retain
+ * the TmuxClient's ordinary bounded capture by leaving this null.
+ */
+internal typealias OutboundPaneCapture =
+    suspend (paneId: String, timeoutMs: Long, scrollbackLines: Int) -> CommandResponse?
 
 /**
  * Issue #1587 (H2): how many lines of scrollback the verify-before-resend probe
@@ -272,15 +332,13 @@ internal class OutboundDeliveryLedger(
     // wire attempt, keyed the same way. Bounded alongside [entries]. Backed durably
     // so a VM-clear-rebuilt ledger reads it back (via [needleBaseline]).
     private val baselines = HashMap<String, Int>()
+    private val collapsedMarkerBaselines = HashMap<String, Int>()
 
     // Issue #1529: the VOLATILE identity is the per-send-attempt token (pane + token),
     // NOT the payload. Two DISTINCT user sends of identical bytes get distinct tokens, so
     // the guard dedups only a RETRY of the SAME attempt (same token) and never suppresses
-    // a second intentional send. The DURABLE fallback stays keyed on (pane, payload): a
-    // durable row that survives a VM-clear is re-dispatched by its retry lane, and the
-    // #961 coalesce-on-enqueue invariant means at most ONE un-delivered row exists per
-    // (pane, payload), so a payload-scoped durable lookup can never conflate two distinct
-    // durable sends (they would have coalesced into one row / one token).
+    // a second intentional send. Issue #1739: the DURABLE fallback is the exact
+    // session+row id; pane ids and payload bytes are never durable identities.
     private fun key(paneId: String, sendToken: String): String = "$paneId|$sendToken"
 
     fun recordWireAttempt(
@@ -288,6 +346,8 @@ internal class OutboundDeliveryLedger(
         sendToken: String,
         payload: String,
         baselineCount: Int? = null,
+        collapsedMarkerBaselineCount: Int? = null,
+        durableRow: DurableOutboundRowIdentity? = null,
     ): Unit = synchronized(lock) {
         val key = key(paneId, sendToken)
         entries.remove(key)
@@ -297,15 +357,30 @@ internal class OutboundDeliveryLedger(
         if (baselineCount != null && key !in baselines) {
             baselines[key] = baselineCount
         }
+        if (
+            collapsedMarkerBaselineCount != null &&
+            key !in collapsedMarkerBaselines
+        ) {
+            collapsedMarkerBaselines[key] = collapsedMarkerBaselineCount
+        }
         while (entries.size > maxEntries) {
             val evicted = entries.first()
             entries.remove(evicted)
             baselines.remove(evicted)
+            collapsedMarkerBaselines.remove(evicted)
         }
         // Issue #1541: also persist on the durable row so the attempt survives a
         // VM-clear / back-navigation, not only this live VM. Issue #1577: the
         // baseline rides the same durable row.
-        durable?.recordWireAttempt(paneId, payload, System.currentTimeMillis(), baselineCount)
+        durableRow?.let { row ->
+            durable?.recordWireAttempt(
+                row.sessionKey,
+                row.rowId,
+                System.currentTimeMillis(),
+                baselineCount,
+                collapsedMarkerBaselineCount,
+            )
+        }
     }
 
     fun clear(paneId: String, sendToken: String): Unit = synchronized(lock) {
@@ -315,13 +390,17 @@ internal class OutboundDeliveryLedger(
         val key = key(paneId, sendToken)
         entries.remove(key)
         baselines.remove(key)
+        collapsedMarkerBaselines.remove(key)
     }
 
-    fun hasAmbiguousAttempt(paneId: String, sendToken: String, payload: String): Boolean = synchronized(lock) {
-        // Issue #1541: the durable flag makes a back-nav-rebuilt ledger (empty
-        // in-memory set) still see a prior wire attempt (payload-scoped — the durable
-        // row is re-dispatched under its own token, and coalescing bounds it to one row).
-        key(paneId, sendToken) in entries || durable?.hasWireAttempt(paneId, payload) == true
+    fun hasAmbiguousAttempt(
+        paneId: String,
+        sendToken: String,
+        payload: String,
+        durableRow: DurableOutboundRowIdentity? = null,
+    ): Boolean = synchronized(lock) {
+        key(paneId, sendToken) in entries ||
+            durableRow?.let { durable?.hasWireAttempt(it.sessionKey, it.rowId) } == true
     }
 
     /**
@@ -330,8 +409,26 @@ internal class OutboundDeliveryLedger(
      * ledger). `null` when none was captured; the caller then falls back to
      * presence-only verification.
      */
-    fun needleBaseline(paneId: String, sendToken: String, payload: String): Int? = synchronized(lock) {
-        baselines[key(paneId, sendToken)] ?: durable?.wireNeedleBaseline(paneId, payload)
+    fun needleBaseline(
+        paneId: String,
+        sendToken: String,
+        payload: String,
+        durableRow: DurableOutboundRowIdentity? = null,
+    ): Int? = synchronized(lock) {
+        baselines[key(paneId, sendToken)]
+            ?: durableRow?.let { durable?.wireNeedleBaseline(it.sessionKey, it.rowId) }
+    }
+
+    fun collapsedMarkerBaseline(
+        paneId: String,
+        sendToken: String,
+        payload: String,
+        durableRow: DurableOutboundRowIdentity? = null,
+    ): Int? = synchronized(lock) {
+        collapsedMarkerBaselines[key(paneId, sendToken)]
+            ?: durableRow?.let {
+                durable?.wireCollapsedMarkerBaseline(it.sessionKey, it.rowId)
+            }
     }
 }
 
@@ -370,31 +467,80 @@ internal suspend fun probeOutboundPayloadAlreadyLanded(
     paneId: String,
     payload: String,
     baselineCount: Int? = null,
+    collapsedMarkerBaselineCount: Int? = null,
+    capturePane: OutboundPaneCapture? = null,
 ): DeliveryProbeOutcome {
     val needle = agentSubmitAckNeedle(payload) ?: return DeliveryProbeOutcome.Unknown
-    // Issue #1577b: kill the presence-only fallback. A null baseline cannot tell "our
-    // paste landed" from a payload that was ALREADY on the pane (a Codex `Goal blocked
-    // (/goal resume)` footer), so a presence match would false-`AlreadyLanded` → a
-    // silent bare-Enter drop. Resolve `NotLanded` so the caller does a REAL gated
-    // resend (which records a fresh baseline), never a bare Enter — deliver-safe.
-    if (baselineCount == null) return DeliveryProbeOutcome.NotLanded
-    val response = try {
+    val multiline = agentSubmitPayloadIsMultiLine(payload)
+    // A missing literal baseline cannot prove either "landed" or "not landed".
+    // For multiline sends, however, the independently persisted visible-chip
+    // baseline remains trustworthy and can still prove an increase. With neither
+    // baseline, fail closed as Unknown: never duplicate-paste and never blind Enter.
+    if (baselineCount == null && (!multiline || collapsedMarkerBaselineCount == null)) {
+        return DeliveryProbeOutcome.Unknown
+    }
+    val response = if (baselineCount != null) try {
         // Issue #1587 (H2): bounded scrollback so a landed-then-scrolled-off payload
         // is still found (else NotLanded ⇒ duplicate paste on retry).
-        client.capturePaneTextViaExec(
+        capturePane?.invoke(
             paneId,
-            timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
-            scrollbackLines = OUTBOUND_PROBE_SCROLLBACK_LINES,
-        )
+            OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+            OUTBOUND_PROBE_SCROLLBACK_LINES,
+        ) ?: if (capturePane == null) {
+            client.capturePaneTextViaExec(
+                paneId,
+                timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+                scrollbackLines = OUTBOUND_PROBE_SCROLLBACK_LINES,
+            )
+        } else {
+            return DeliveryProbeOutcome.Unknown
+        }
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Throwable) {
+        return DeliveryProbeOutcome.Unknown
+    } else {
+        null
+    }
+    if (response?.isError == true) return DeliveryProbeOutcome.Unknown
+    if (response != null && baselineCount != null) {
+        // Issue #1577: a captured baseline demands the count INCREASE.
+        val count = agentSubmitVisibleTextNeedleCount(response.output, needle)
+        if (count > baselineCount) return DeliveryProbeOutcome.AlreadyLanded
+    }
+    if (!multiline) return DeliveryProbeOutcome.NotLanded
+
+    // Claude's collapsed-paste chip is generic (it carries no payload identity).
+    // Compare it only in the VISIBLE viewport, whose pre-paste count the send
+    // persisted. Reusing the scrollback capture above could see an older chip
+    // outside that baseline and false-authorize Enter. If neither literal nor a
+    // visible chip increase proves delivery, multiline remains Unknown: it may
+    // have collapsed and scrolled away, so "not seen ⇒ resend" would duplicate.
+    val markerBaseline = collapsedMarkerBaselineCount ?: return DeliveryProbeOutcome.Unknown
+    val visibleResponse = try {
+        capturePane?.invoke(paneId, OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS, 0)
+            ?: if (capturePane == null) {
+                client.capturePaneTextViaExec(
+                    paneId,
+                    timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+                    scrollbackLines = 0,
+                )
+            } else {
+                return DeliveryProbeOutcome.Unknown
+            }
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (_: Throwable) {
         return DeliveryProbeOutcome.Unknown
     }
-    if (response.isError) return DeliveryProbeOutcome.Unknown
-    // Issue #1577: a captured baseline demands the count INCREASE (our paste landed).
-    val count = agentSubmitVisibleTextNeedleCount(response.output, needle)
-    return if (count > baselineCount) DeliveryProbeOutcome.AlreadyLanded else DeliveryProbeOutcome.NotLanded
+    if (visibleResponse.isError) return DeliveryProbeOutcome.Unknown
+    return if (
+        agentSubmitCollapsedPasteMarkerCount(visibleResponse.output) > markerBaseline
+    ) {
+        DeliveryProbeOutcome.AlreadyLanded
+    } else {
+        DeliveryProbeOutcome.Unknown
+    }
 }
 
 /**
@@ -408,17 +554,26 @@ internal suspend fun captureNeedleBaseline(
     client: TmuxClient,
     paneId: String,
     payload: String,
+    capturePane: OutboundPaneCapture? = null,
 ): Int? {
     val needle = agentSubmitAckNeedle(payload) ?: return null
     val response = try {
         // Issue #1587 (H2): the baseline snapshot MUST scope over the SAME bounded
         // scrollback the probe uses ([probeOutboundPayloadAlreadyLanded]) so the
         // count comparison is meaningful (a pre-existing occurrence is in both).
-        client.capturePaneTextViaExec(
+        capturePane?.invoke(
             paneId,
-            timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
-            scrollbackLines = OUTBOUND_PROBE_SCROLLBACK_LINES,
-        )
+            OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+            OUTBOUND_PROBE_SCROLLBACK_LINES,
+        ) ?: if (capturePane == null) {
+            client.capturePaneTextViaExec(
+                paneId,
+                timeoutMs = OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS,
+                scrollbackLines = OUTBOUND_PROBE_SCROLLBACK_LINES,
+            )
+        } else {
+            return null
+        }
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (_: Throwable) {
@@ -450,17 +605,38 @@ internal suspend fun OutboundDeliveryLedger.recordWireAttemptWithBaseline(
     sendToken: String,
     payload: String,
     localRenderText: String,
+    collapsedMarkerBaselineCount: Int? = null,
+    durableRow: DurableOutboundRowIdentity? = null,
+    capturePane: OutboundPaneCapture? = null,
 ) {
-    if (needleBaseline(paneId, sendToken, payload) != null) {
+    if (needleBaseline(paneId, sendToken, payload, durableRow) != null) {
         // A prior push already captured the pre-send baseline; keep it (idempotent).
-        recordWireAttempt(paneId, sendToken, payload, null)
+        recordWireAttempt(
+            paneId,
+            sendToken,
+            payload,
+            baselineCount = null,
+            collapsedMarkerBaselineCount = collapsedMarkerBaselineCount,
+            durableRow = durableRow,
+        )
         return
     }
     val needle = agentSubmitAckNeedle(payload)
     val alreadyVisible = needle != null &&
         agentSubmitVisibleTextNeedleCount(listOf(localRenderText), needle) > 0
-    val baseline = if (alreadyVisible) captureNeedleBaseline(client, paneId, payload) else 0
-    recordWireAttempt(paneId, sendToken, payload, baseline)
+    val baseline = if (alreadyVisible) {
+        captureNeedleBaseline(client, paneId, payload, capturePane)
+    } else {
+        0
+    }
+    recordWireAttempt(
+        paneId,
+        sendToken,
+        payload,
+        baselineCount = baseline,
+        collapsedMarkerBaselineCount = collapsedMarkerBaselineCount,
+        durableRow = durableRow,
+    )
 }
 
 internal suspend fun probeNeedleAlreadyLanded(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxInputCommands.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxInputCommands.kt
@@ -123,6 +123,7 @@ internal suspend fun sendBracketedPaste(
     client: TmuxClient,
     paneId: String?,
     bytes: ByteArray,
+    beforeCommit: suspend () -> Unit = {},
 ) {
     if (bytes.isEmpty()) return
     val bufferName = pasteBufferNameFor(paneId)
@@ -141,6 +142,10 @@ internal suspend fun sendBracketedPaste(
             .throwIfTmuxError("fill paste buffer for pane ${paneId ?: "(active)"}")
     }
     // THE commit point: one exec, all-or-nothing server-side.
+    // Issue #1739: callers that own a durable delivery ledger record the
+    // ambiguous wire attempt only here. A failed set-buffer fill cannot have
+    // touched the pane, so it must remain definitively safe to refill/retry.
+    beforeCommit()
     val target = if (paneId != null) " -t $paneId" else ""
     client.sendKeysViaExec("paste-buffer -d -r -b $bufferName$target")
         .throwIfTmuxError("paste buffer into pane ${paneId ?: "(active)"}")

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
-import com.pocketshell.app.composer.OutboundRoute
 import com.pocketshell.app.composer.PromptComposerSendDispatcher
 import com.pocketshell.app.conversation.ConversationImageViewModel
 import com.pocketshell.app.conversation.LocalConversationImageLoader
@@ -1728,39 +1727,36 @@ private fun TmuxSessionSheetsRegion(
     }
 
     val composerSendHandler: suspend (PromptComposerViewModel.SendRequest) -> Boolean = { request ->
-        val target = request.sendTarget
-        if (target.sessionKey.isNotBlank() && target.sessionKey != targetSessionId.value) {
-            false
-        } else {
-            val paneId = target.paneId.ifBlank { surfacePane?.paneId.orEmpty() }
-            val sent = if (paneId.isBlank()) {
-                false
-            } else when (target.route) {
-                OutboundRoute.AgentConversation ->
-                    tmuxAgentConversationSendResult(
-                        request.text,
-                        target.agentKind,
-                        { t, k -> viewModel.sendAgentPayloadToPaneResult(paneId, t, k).isSuccess },
-                        { t -> viewModel.sendToAgentPaneResult(paneId, t).isSuccess },
-                    ) { onTuiCommandNoticeChange(it) }
-                OutboundRoute.AgentPayload ->
-                    tmuxComposerAgentKindFromToken(target.agentKind)?.let { agentKind ->
-                        viewModel.sendAgentPayloadToPaneResult(
-                            paneId,
-                            request.text,
-                            agentKind,
-                        ).isSuccess
-                    } ?: false
-                OutboundRoute.RawBytes -> {
-                    val payload = if (request.withEnter) request.text + "\r" else request.text
-                    viewModel.writeInputToPaneResult(
-                        paneId,
-                        payload.toByteArray(Charsets.UTF_8),
-                    ).isSuccess
-                }
-            }
-            sent
-        }
+        tmuxComposerSendResult(
+            request = request,
+            targetSessionId = targetSessionId.value,
+            fallbackPaneId = surfacePane?.paneId.orEmpty(),
+            sendAgentPayload = { paneId, text, agentKind, sendToken, durableRow ->
+                viewModel.sendAgentPayloadToPaneResult(
+                    paneId,
+                    text,
+                    agentKind,
+                    sendToken,
+                    durableRow,
+                ).isSuccess
+            },
+            sendToAgent = { paneId, text, sendToken, durableRow ->
+                viewModel.sendToAgentPaneResult(
+                    paneId,
+                    text,
+                    sendToken,
+                    durableRow,
+                ).isSuccess
+            },
+            sendRawBytes = { paneId, bytes, sendToken, durableRow ->
+                viewModel.writeInputToPaneResult(
+                    paneId,
+                    bytes,
+                    sendToken,
+                    durableRow,
+                ).isSuccess
+            },
+        ) { onTuiCommandNoticeChange(it) }
     }
     PromptComposerSendDispatcher(
         viewModel = promptComposerViewModel,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
@@ -594,6 +594,84 @@ internal suspend fun tmuxAgentConversationSendResult(
 }
 
 /**
+ * Issue #1739: route one composer request to the tmux send lane while preserving
+ * its durable delivery identity.
+ *
+ * [PromptComposerViewModel.SendRequest.outboundQueueItemId] is the stable token
+ * for every dispatch of one durable row. The screen used to drop it at this
+ * boundary, so the first attempt and its auto-flush retry each minted a different
+ * token inside the VM. Durable payload lookup happened to find the ambiguous
+ * attempt, but the retry was no longer provably the same send. Resolve the token
+ * once here: durable requests keep their row id; legacy/non-durable requests get
+ * one fresh opaque token for this dispatch.
+ */
+internal suspend fun tmuxComposerSendResult(
+    request: PromptComposerViewModel.SendRequest,
+    targetSessionId: String,
+    fallbackPaneId: String,
+    sendAgentPayload: suspend (
+        paneId: String,
+        text: String,
+        agent: AgentKind,
+        sendToken: String,
+        durableRow: DurableOutboundRowIdentity?,
+    ) -> Boolean,
+    sendToAgent: suspend (
+        paneId: String,
+        text: String,
+        sendToken: String,
+        durableRow: DurableOutboundRowIdentity?,
+    ) -> Boolean,
+    sendRawBytes: suspend (
+        paneId: String,
+        bytes: ByteArray,
+        sendToken: String,
+        durableRow: DurableOutboundRowIdentity?,
+    ) -> Boolean,
+    setTuiNotice: (String) -> Unit,
+): Boolean {
+    val target = request.sendTarget
+    if (target.sessionKey.isNotBlank() && target.sessionKey != targetSessionId) {
+        return false
+    }
+    val paneId = target.paneId.ifBlank { fallbackPaneId }
+    if (paneId.isBlank()) return false
+
+    val sendToken = request.outboundQueueItemId ?: newOutboundDeliveryToken()
+    val durableRow = request.outboundQueueItemId?.let { rowId ->
+        DurableOutboundRowIdentity(
+            sessionKey = target.sessionKey,
+            rowId = rowId,
+        )
+    }
+    return when (target.route) {
+        OutboundRoute.AgentConversation ->
+            tmuxAgentConversationSendResult(
+                request.text,
+                target.agentKind,
+                { text, agent ->
+                    sendAgentPayload(paneId, text, agent, sendToken, durableRow)
+                },
+                { text -> sendToAgent(paneId, text, sendToken, durableRow) },
+                setTuiNotice,
+            )
+        OutboundRoute.AgentPayload ->
+            tmuxComposerAgentKindFromToken(target.agentKind)?.let { agent ->
+                sendAgentPayload(paneId, request.text, agent, sendToken, durableRow)
+            } ?: false
+        OutboundRoute.RawBytes -> {
+            val payload = if (request.withEnter) request.text + "\r" else request.text
+            sendRawBytes(
+                paneId,
+                payload.toByteArray(Charsets.UTF_8),
+                sendToken,
+                durableRow,
+            )
+        }
+    }
+}
+
+/**
  * Issue #1207: resolve the load state the Conversation-tab placeholder renders
  * when it has NO backing conversation row (`rowLoadState == null`).
  *

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -480,13 +480,9 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #869: monotonic millisecond clock used by the submit ack-gate to
-     * (a) measure each `capture-pane` round-trip (the RTT addend) and (b) bound
-     * the needle-miss FALLBACK floor. Defaults to the device monotonic clock.
-     * Unit tests override it to read the `runTest` virtual scheduler time so the
-     * RTT measurement is deterministic under virtual time — `SystemClock`
-     * reads a constant 0 there, which would make every measured RTT zero and
-     * the fallback-floor top-up impossible to assert.
+     * Monotonic millisecond clock used by submit diagnostics. Defaults to the
+     * device monotonic clock; tests may bind it to their virtual scheduler so
+     * bounded-capture elapsed evidence is deterministic.
      */
     @Volatile
     private var agentSubmitMonotonicMsForTest: (() -> Long)? = null
@@ -500,14 +496,8 @@ public class TmuxSessionViewModel @Inject constructor(
         agentSubmitMonotonicMsForTest?.invoke() ?: SystemClock.elapsedRealtime()
 
     /**
-     * Issue #869: test override for the submit ack-gate POLL window
-     * ([AGENT_SUBMIT_ACK_TIMEOUT_MS]). Production polls the full 2s window, but
-     * the needle-miss FALLBACK FLOOR is a SEPARATE invariant (Enter never fires
-     * before `FALLBACK_FLOOR + measuredRtt`) that must hold even if the poll
-     * window is shorter than the floor. A test sets a SHORT poll window so the
-     * floor — not the incidental poll-loop duration — is the binding constraint,
-     * proving the floor genuinely gates the Enter (red→green). Null ⇒ production
-     * default.
+     * Test override for the submit ack-gate hard deadline
+     * ([AGENT_SUBMIT_ACK_TIMEOUT_MS]). Null uses the production default.
      */
     @Volatile
     private var agentSubmitAckTimeoutMsOverrideForTest: Long? = null
@@ -1297,6 +1287,27 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     internal fun currentClientIdentityForTest(): Int? =
         clientRef?.let { System.identityHashCode(it) }
+
+    internal fun currentConnectGenerationForTest(): Long = connectGeneration
+
+    /**
+     * Issue #1739 narrow authority-loss seam: swap only the selected session
+     * identity while retaining the exact same control client and generation.
+     * This exercises the target limb of [AgentSendRuntimeIdentity] independently
+     * from the already-covered reconnect/client-replacement limbs.
+     */
+    internal fun swapActiveSessionTargetForTest(sessionName: String) {
+        val current = checkNotNull(activeTarget) { "a live target is required" }
+        activeTarget = current.copy(
+            sessionName = sessionName,
+            tmuxSessionId = null,
+            sessionCreated = null,
+        )
+    }
+
+    /** Issue #1739 journey seam: the exact durable composer/queue session key. */
+    internal fun currentTargetSessionKeyForTest(): String? =
+        activeTarget?.let { revealController.sessionId(it).value }
 
     /**
      * Issue #1072 test seam — own an attachment upload through the EXACT production
@@ -13963,12 +13974,14 @@ public class TmuxSessionViewModel @Inject constructor(
         paneId: String,
         text: String,
         sendToken: String? = null,
+        durableRow: DurableOutboundRowIdentity? = null,
     ): Result<Unit> =
         sendToAgentPaneResult(
             paneId = paneId,
             text = text,
             keepFailedOptimisticOnDeliveryFailure = false,
             sendToken = sendToken,
+            durableRow = durableRow,
         )
 
     private suspend fun sendToAgentPaneResult(
@@ -13976,6 +13989,7 @@ public class TmuxSessionViewModel @Inject constructor(
         text: String,
         keepFailedOptimisticOnDeliveryFailure: Boolean,
         sendToken: String? = null,
+        durableRow: DurableOutboundRowIdentity? = null,
     ): Result<Unit> {
         val payload = text.trim()
         if (payload.isEmpty()) return Result.success(Unit)
@@ -14011,7 +14025,13 @@ public class TmuxSessionViewModel @Inject constructor(
         }
         appendAgentEvents(paneId, listOf(optimistic))
         // Issue #1529: a fresh direct send keys on its optimistic turn id; a retry passes a STABLE token.
-        val result = sendAgentPayloadToPaneResult(paneId, payload, detection.agent, sendToken ?: optimisticId)
+        val result = sendAgentPayloadToPaneResult(
+            paneId,
+            payload,
+            detection.agent,
+            sendToken ?: optimisticId,
+            durableRow,
+        )
         if (result.isFailure) {
             if (keepFailedOptimisticOnDeliveryFailure) {
                 markOptimisticSendFailed(paneId, optimisticId)
@@ -14081,10 +14101,18 @@ public class TmuxSessionViewModel @Inject constructor(
         payload: String,
         agent: AgentKind,
         sendToken: String = newOutboundDeliveryToken(),
+        durableRow: DurableOutboundRowIdentity? = null,
     ): Result<Unit> {
         val client = awaitLiveTmuxClientForSend()
             ?: return Result.failure(IllegalStateException("Session is disconnected."))
-        return sendAgentPayloadToPaneResult(client, paneId, payload, agent, sendToken)
+        return sendAgentPayloadToPaneResult(
+            client,
+            paneId,
+            payload,
+            agent,
+            sendToken,
+            durableRow,
+        )
     }
 
     // Issue #1526 S1 / #1541 / #1587: verify-before-resend ledger, durable-backed by
@@ -14102,54 +14130,200 @@ public class TmuxSessionViewModel @Inject constructor(
         )
     }
 
+    private fun snapshotAgentSendRuntime(client: TmuxClient): AgentSendRuntimeIdentity =
+        AgentSendRuntimeIdentity(
+            client = client,
+            generation = connectGeneration,
+            target = activeTarget,
+        )
+
+    private fun isCurrentAgentSendRuntime(
+        identity: AgentSendRuntimeIdentity,
+        paneId: String,
+    ): Boolean {
+        if (clientRef !== identity.client || connectGeneration != identity.generation) return false
+        val currentTarget = activeTarget
+        val targetMatches = if (identity.target == null) {
+            // Narrow unit-test attach seam: production sends always have a target.
+            currentTarget == null
+        } else {
+            currentTarget != null && sameSessionIdentity(currentTarget, identity.target)
+        }
+        if (!targetMatches) return false
+
+        // Pane ids are only unique inside a tmux server/session. Once a runtime
+        // has enumerated any pane, an unknown pane is foreign/stale and cannot
+        // authorize a submit. The empty-set allowance preserves the narrow test
+        // seam before pane enumeration; the client/session guard still applies.
+        val hasKnownPanes = paneRows.isNotEmpty() || _agentConversations.value.isNotEmpty()
+        return !hasKnownPanes ||
+            paneRows.containsKey(paneId) ||
+            _agentConversations.value.containsKey(paneId)
+    }
+
+    private suspend fun captureAgentPaneBounded(
+        identity: AgentSendRuntimeIdentity,
+        paneId: String,
+        timeoutMs: Long,
+        scrollbackLines: Int,
+    ): AgentPaneCaptureResult = captureAgentPaneWithDeadline(
+        scope = bridgeScope,
+        identity = identity,
+        paneId = paneId,
+        timeoutMs = timeoutMs,
+        scrollbackLines = scrollbackLines,
+        isCurrent = ::isCurrentAgentSendRuntime,
+        nowMs = ::agentSubmitNowMs,
+        currentClientHash = { clientRef?.let { System.identityHashCode(it) } },
+        currentGeneration = { connectGeneration },
+    )
+
     private suspend fun sendAgentPayloadToPaneResult(
         client: TmuxClient,
         paneId: String,
         payload: String,
         agent: AgentKind,
         sendToken: String,
+        durableRow: DurableOutboundRowIdentity?,
     ): Result<Unit> {
         val payloadBytes = payload.toByteArray(Charsets.UTF_8)
+        val runtimeIdentity = snapshotAgentSendRuntime(client)
         if (client.disconnected.value) {
             return Result.failure(IllegalStateException("Tmux client is disconnected."))
+        }
+        if (!isCurrentAgentSendRuntime(runtimeIdentity, paneId)) {
+            return Result.failure(IllegalStateException("Agent send target is stale or foreign."))
+        }
+        val boundedCapture: OutboundPaneCapture = { capturePaneId, timeoutMs, scrollbackLines ->
+            captureAgentPaneBounded(
+                identity = runtimeIdentity,
+                paneId = capturePaneId,
+                timeoutMs = timeoutMs,
+                scrollbackLines = scrollbackLines,
+            ).takeIf { it.status == AgentPaneCaptureStatus.Captured }?.response
         }
         // Issue #1526 S1 (verify-before-resend): a PRIOR ambiguous attempt for THIS send —
         // keyed by the #1529 [sendToken], NOT the payload, so two distinct identical sends
         // never false-dedup — the paste may have run server-side (audit A1/A2). Probe (#869
         // needle, #1577 baseline): landed ⇒ Enter ONLY; unknown ⇒ fail; else full send.
-        when (verifyBeforeAgentResend(outboundDeliveryLedger, client, paneId, sendToken, payload)) {
-            DeliveryProbeOutcome.AlreadyLanded -> return runCatching {
+        when (
+            verifyBeforeAgentResend(
+                outboundDeliveryLedger,
+                client,
+                paneId,
+                sendToken,
+                payload,
+                durableRow = durableRow,
+                capturePane = boundedCapture,
+            )
+        ) {
+            DeliveryProbeOutcome.AlreadyLanded -> return try {
+                check(isCurrentAgentSendRuntime(runtimeIdentity, paneId)) {
+                    "Agent send runtime changed after verify-before-resend."
+                }
+                check(!client.disconnected.value) {
+                    "Tmux client disconnected after verify-before-resend."
+                }
                 sendNamedKeyToPane(client, paneId, "Enter")
                     .throwIfTmuxError("submit previously pasted agent input")
                 outboundDeliveryLedger.clear(paneId, sendToken)
                 requestReconcile(client, paneId, ReconcileReason.Send)
+                Result.success(Unit)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Throwable) {
+                Result.failure(failure)
             }
             DeliveryProbeOutcome.Unknown -> return Result.failure(
                 IllegalStateException("Prior send outcome unknown; kept queued without resend."),
             )
             DeliveryProbeOutcome.NotLanded, null -> Unit
         }
-        return runCatching {
+        return try {
+            check(isCurrentAgentSendRuntime(runtimeIdentity, paneId)) {
+                "Agent send target changed before delivery."
+            }
             ensurePaneAcceptsInput(client, paneId)
-            outboundDeliveryLedger.recordWireAttemptWithBaseline(client, paneId, sendToken, payload, localRenderTextForPane(paneId))
-            // Issue #1577b: the pre-paste needle baseline the ack gate compares against
-            // (Codex's permanent `(/goal resume)` footer occupies it, so the ack fires
-            // only on OUR paste adding an occurrence, never on the footer).
-            val ackBaseline = outboundDeliveryLedger.needleBaseline(paneId, sendToken, payload) ?: 0
-            // Issue #1687: pre-paste count of the collapsed-paste chip, so a chip already
-            // on the pane can't false-confirm OUR multi-line send (see the ack gate).
+            // Issue #1739: Claude collapses multiline input to a chip and never
+            // echoes the body. Persist its pre-paste count alongside the literal
+            // needle baseline so a reconnect retry can prove the chip increased
+            // and safely complete Enter-only without a duplicate paste.
             val collapsedMarkerBaseline = if (agentSubmitPayloadIsMultiLine(payload)) {
                 agentSubmitCollapsedPasteMarkerCount(listOf(localRenderTextForPane(paneId)))
             } else {
-                0
+                null
             }
+            val recordWireAttempt: suspend () -> Unit = {
+                outboundDeliveryLedger.recordWireAttemptWithBaseline(
+                    client,
+                    paneId,
+                    sendToken,
+                    payload,
+                    localRenderTextForPane(paneId),
+                    collapsedMarkerBaselineCount = collapsedMarkerBaseline,
+                    durableRow = durableRow,
+                    capturePane = boundedCapture,
+                )
+            }
+            // Issue #1577b: the pre-paste needle baseline the ack gate compares against
+            // (Codex's permanent `(/goal resume)` footer occupies it, so the ack fires
+            // only on OUR paste adding an occurrence, never on the footer).
+            // Issue #1687: pre-paste count of the collapsed-paste chip, so a chip already
+            // on the pane can't false-confirm OUR multi-line send (see the ack gate).
             if (payloadBytes.size > TMUX_PASTE_BODY_CHUNK_BYTES || BracketedPaste.containsLineBreak(payloadBytes)) {
-                sendBracketedPaste(client, paneId, payloadBytes)
+                // Issue #1739: set-buffer only fills a private tmux buffer. Record
+                // ambiguity after the complete fill, immediately before the one
+                // paste-buffer command that can touch the pane.
+                sendBracketedPaste(
+                    client = client,
+                    paneId = paneId,
+                    bytes = payloadBytes,
+                    beforeCommit = recordWireAttempt,
+                )
             } else if (payload.isNotEmpty()) {
+                // A literal send has no separate fill/commit boundary: its one
+                // command can touch the pane, so record immediately before it.
+                recordWireAttempt()
                 sendLiteralTextKeys(client, paneId, payload)
                     .throwIfTmuxError("type agent input into pane $paneId")
             }
-            awaitAgentPasteIngestedBeforeSubmit(client, paneId, payload, agent, ackBaseline, collapsedMarkerBaseline)
+            val ackBaseline = outboundDeliveryLedger.needleBaseline(
+                paneId,
+                sendToken,
+                payload,
+                durableRow,
+            ) ?: 0
+            val configuredAckFloorMs = (
+                agentSubmitEnterDelayMsOverrideForTest
+                    ?: settingsRepository?.settings?.value?.agentSubmitEnterDelayMs
+                    ?: com.pocketshell.app.settings.AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS
+                ).toLong()
+            awaitAgentPasteIngested(
+                identity = runtimeIdentity,
+                paneId = paneId,
+                payload = payload,
+                agent = agent,
+                configuredFloorMs = configuredAckFloorMs,
+                ackTimeoutMs = agentSubmitAckTimeoutMsOverrideForTest ?: AGENT_SUBMIT_ACK_TIMEOUT_MS,
+                baselineNeedleCount = ackBaseline,
+                collapsedMarkerBaseline = collapsedMarkerBaseline ?: 0,
+                capture = { timeoutMs, scrollbackLines ->
+                    captureAgentPaneBounded(
+                        identity = runtimeIdentity,
+                        paneId = paneId,
+                        timeoutMs = timeoutMs,
+                        scrollbackLines = scrollbackLines,
+                    )
+                },
+                currentClientHash = { clientRef?.let { System.identityHashCode(it) } },
+                currentGeneration = { connectGeneration },
+            )
+            check(isCurrentAgentSendRuntime(runtimeIdentity, paneId)) {
+                "Agent send target changed after paste acknowledgement."
+            }
+            check(!client.disconnected.value) {
+                "Tmux client disconnected after paste acknowledgement."
+            }
             consumeSendResultLostSeamForTest()
             sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
@@ -14157,6 +14331,11 @@ public class TmuxSessionViewModel @Inject constructor(
             // Issue #941/#1353 R4: after the submit Enter a full-screen agent TUI can overpaint
             // the active pane partial-black; a guarded heal EVENT re-checks and re-seeds.
             requestReconcile(client, paneId, ReconcileReason.Send)
+            Result.success(Unit)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (failure: Throwable) {
+            Result.failure(failure)
         }
     }
 
@@ -14221,152 +14400,6 @@ public class TmuxSessionViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    /**
-     * Issue #869: ack-gate the submit Enter on the pasted text actually landing in the
-     * agent's input (not the pre-#869 blind sleep that raced ingestion). Polls
-     * `capture-pane -p` and presses Enter the INSTANT a capture CONFIRMS the paste
-     * (RTT-adaptive). Bounded by [AGENT_SUBMIT_ACK_TIMEOUT_MS]; a needle miss holds the
-     * Enter to `max(minFloor, FALLBACK_FLOOR + measuredRtt)`, never a hung Send.
-     *
-     * Issue #1687: the confirming capture IS the ingestion evidence, so the happy path
-     * submits the moment it lands with NO pre-capture floor. The old
-     * #526/[CODEX_AGENT_SUBMIT_DELAY_MS] "minimum", paid BEFORE the first capture on
-     * EVERY send (150ms, 250ms Codex), was a flat per-send latency tax; it is gone. The
-     * floor now applies only where there is no ack: a bare-Enter payload and the
-     * needle-miss fallback.
-     *
-     * Issue #1577b: COUNT-BASELINE-aware. [baselineNeedleCount] is the needle's
-     * pre-paste count; the ack fires only on an INCREASE, never on mere presence — so a
-     * Codex `(/goal resume)` footer already on the pane can't fire Enter early (the
-     * swallowed-CR bug). Issue #1687: [collapsedMarkerBaseline] is the same for Claude
-     * Code's `[Pasted text #N +M lines]` chip — a collapsed multi-line paste never
-     * echoes its body, so the ack ALSO confirms on that chip's increase (see
-     * [agentSubmitCollapsedPasteMarkerCount]) instead of stalling to the full timeout.
-     */
-    private suspend fun awaitAgentPasteIngestedBeforeSubmit(
-        client: TmuxClient,
-        paneId: String,
-        payload: String,
-        agent: AgentKind,
-        baselineNeedleCount: Int,
-        collapsedMarkerBaseline: Int,
-    ) {
-        val configured = agentSubmitEnterDelayMsOverrideForTest
-            ?: settingsRepository?.settings?.value?.agentSubmitEnterDelayMs
-            ?: com.pocketshell.app.settings.AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS
-        val minFloorMs = if (agent == AgentKind.Codex) {
-            maxOf(configured.toLong(), CODEX_AGENT_SUBMIT_DELAY_MS)
-        } else {
-            configured.toLong()
-        }
-
-        val gateStartMs = agentSubmitNowMs()
-
-        // An empty payload (bare-Enter submit) has nothing to confirm — honour the
-        // floor and return so we never poll for a missing needle.
-        val ackNeedle = agentSubmitAckNeedle(payload)
-        if (ackNeedle == null) {
-            if (minFloorMs > 0L) delay(minFloorMs)
-            return
-        }
-
-        // Issue #1687: NO pre-capture floor — the ack poll starts immediately and Enter
-        // fires on the confirming capture (~1 RTT), not a flat 150/250ms per-send tax.
-        val payloadIsMultiLine = agentSubmitPayloadIsMultiLine(payload)
-
-        val ackTimeoutMs = agentSubmitAckTimeoutMsOverrideForTest ?: AGENT_SUBMIT_ACK_TIMEOUT_MS
-        var poll = 0
-        // Longest single `capture-pane` round-trip — the RTT addend for the fallback floor (#869).
-        var maxCaptureRttMs = 0L
-        var disconnectedDuringAck = false
-        val ackObserved = withTimeoutOrNull(ackTimeoutMs.coerceAtLeast(1L)) {
-            while (true) {
-                if (client.disconnected.value) {
-                    disconnectedDuringAck = true
-                    return@withTimeoutOrNull false
-                }
-                val captureStartMs = agentSubmitNowMs()
-                val visible = agentPaneShowsPayload(
-                    client,
-                    paneId,
-                    ackNeedle,
-                    baselineNeedleCount,
-                    payloadIsMultiLine,
-                    collapsedMarkerBaseline,
-                )
-                maxCaptureRttMs = maxOf(maxCaptureRttMs, agentSubmitNowMs() - captureStartMs)
-                if (visible) {
-                    // The paste is visible in the pane — the agent has ingested it.
-                    // Press Enter now (caller does the send-keys Enter).
-                    DiagnosticEvents.record(
-                        "action",
-                        "agent_submit_ack",
-                        "pane" to paneId,
-                        "result" to "ack_observed",
-                        "polls" to poll,
-                    )
-                    return@withTimeoutOrNull true
-                }
-                poll += 1
-                delay(AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
-            }
-        } == true
-        if (disconnectedDuringAck) return
-        if (ackObserved) return
-
-        // Codex input-freeze follow-up: the ack timeout bounds the WHOLE capture loop,
-        // not just the poll count — a single stuck `capture-pane` used to park this
-        // coroutine past the timeout, freezing Codex sends. On timeout, keep the #869
-        // fallback floor, then let the caller send Enter rather than blocking forever.
-        val fallbackFloorMs = maxOf(
-            minFloorMs,
-            com.pocketshell.app.settings.AppSettings.AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS +
-                maxCaptureRttMs,
-        )
-        val elapsedMs = agentSubmitNowMs() - gateStartMs
-        val remainingMs = fallbackFloorMs - elapsedMs
-        if (remainingMs > 0L) delay(remainingMs)
-        DiagnosticEvents.record(
-            "action",
-            "agent_submit_ack",
-            "pane" to paneId,
-            "result" to "fallback_floor",
-            "polls" to poll,
-            "fallbackFloorMs" to fallbackFloorMs,
-        )
-    }
-
-    /**
-     * Issue #869/#1577b: `capture-pane -p` the pane and report whether OUR paste landed
-     * — the [needle]'s whitespace-stripped occurrence count now EXCEEDS
-     * [baselineNeedleCount]. Both sides are whitespace-stripped so a wrapped input box
-     * still matches. A count INCREASE (not presence) is required so a payload already on
-     * the pane (a Codex `(/goal resume)` footer) can't false-confirm. A failed/empty
-     * capture is "not yet visible"; best-effort, never throws.
-     *
-     * Issue #1687: a collapsed multi-line paste ([payloadIsMultiLine]) never echoes its
-     * body, so it is EQUALLY confirmed when the `[Pasted text #N +M lines]` chip count
-     * rises above [collapsedMarkerBaseline] — the fix for the per-multi-line-send stall.
-     */
-    private suspend fun agentPaneShowsPayload(
-        client: TmuxClient,
-        paneId: String,
-        needle: String,
-        baselineNeedleCount: Int,
-        payloadIsMultiLine: Boolean,
-        collapsedMarkerBaseline: Int,
-    ): Boolean {
-        val response = runCatching {
-            client.capturePaneTextViaExec(paneId)
-        }.getOrNull() ?: return false
-        if (response.isError) return false
-        if (agentSubmitVisibleTextNeedleCount(response.output, needle) > baselineNeedleCount) {
-            return true
-        }
-        return payloadIsMultiLine &&
-            agentSubmitCollapsedPasteMarkerCount(response.output) > collapsedMarkerBaseline
     }
 
     public fun selectSessionTab(paneId: String, tab: SessionTab) {
@@ -15310,13 +15343,14 @@ public class TmuxSessionViewModel @Inject constructor(
         paneId: String,
         bytes: ByteArray,
         sendToken: String = newOutboundDeliveryToken(),
+        durableRow: DurableOutboundRowIdentity? = null,
     ): Result<Unit> {
         if (bytes.isEmpty()) return Result.success(Unit)
         val client = awaitLiveTmuxClientForSend()
         if (client == null) {
             return Result.failure(IllegalStateException("Session is disconnected."))
         }
-        return writeInputToPaneResult(client, paneId, bytes, sendToken)
+        return writeInputToPaneResult(client, paneId, bytes, sendToken, durableRow)
     }
 
     // Issue #1586: RawBytes lane rides the verify-before-resend ledger (H1b); #1529: per-send token.
@@ -15325,6 +15359,7 @@ public class TmuxSessionViewModel @Inject constructor(
         paneId: String,
         bytes: ByteArray,
         sendToken: String,
+        durableRow: DurableOutboundRowIdentity? = null,
     ): Result<Unit> = deliverRawInputWithGuard(
         ledger = outboundDeliveryLedger,
         client = client,
@@ -15332,6 +15367,7 @@ public class TmuxSessionViewModel @Inject constructor(
         bytes = bytes,
         localRenderText = localRenderTextForPane(paneId),
         sendToken = sendToken,
+        durableRow = durableRow,
         send = { c, p, b -> sendInputBytesToPane(c, p, b) },
         // Issue #1586 (H1b): AlreadyLanded -> Enter-only submit.
         submitEnter = { c, p ->

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
@@ -183,11 +183,13 @@ class OutboundQueueStoreEncodingTest {
                 wireAttempted = true,
                 wireAttemptedAtMs = 1_700_000_009_000,
                 wireNeedleBaselineCount = 1,
+                wireCollapsedMarkerBaselineCount = 2,
             ),
         )
         val decoded = decodeOutboundItems("sessA", encodeOutboundItems(items))
         assertEquals(items, decoded)
         assertEquals(1, decoded.single().wireNeedleBaselineCount)
+        assertEquals(2, decoded.single().wireCollapsedMarkerBaselineCount)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
@@ -50,10 +50,10 @@ class OutboundQueueStoreWireAttemptTest {
     @Test
     fun freshlyEnqueuedRowHasNoWireAttempt() {
         val store = InMemoryOutboundQueueStore()
-        store.enqueue("sessA", "hello", paneId = "%0")
+        val row = store.enqueue("sessA", "hello", paneId = "%0")
         assertFalse(
             "a queued-but-never-sent row has no wire attempt (a fresh send must not verify)",
-            store.hasWireAttempt("%0", "hello"),
+            store.hasWireAttempt("sessA", row.id),
         )
     }
 
@@ -71,7 +71,7 @@ class OutboundQueueStoreWireAttemptTest {
         val claimed = store.claimNext("sessA")!!
         assertEquals(OutboundState.InFlight, claimed.state)
         assertFalse("claiming must NOT set the durable wire-attempt flag (#1577)", claimed.wireAttempted)
-        assertFalse(store.hasWireAttempt("%0", "deploy now"))
+        assertFalse(store.hasWireAttempt("sessA", row.id))
     }
 
     @Test
@@ -82,7 +82,7 @@ class OutboundQueueStoreWireAttemptTest {
         val row = store.enqueue("sessA", "restart pool", paneId = "%0")
         val updated = store.markInFlight(row.id)!!
         assertFalse(updated.wireAttempted)
-        assertFalse(store.hasWireAttempt("%0", "restart pool"))
+        assertFalse(store.hasWireAttempt("sessA", row.id))
     }
 
     @Test
@@ -92,29 +92,35 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "deploy now", paneId = "%0")
         store.claim(row.id) // InFlight, but no flag yet (#1577)
-        assertFalse(store.hasWireAttempt("%0", "deploy now"))
+        assertFalse(store.hasWireAttempt("sessA", row.id))
 
-        val pushed = store.markWireAttempted("%0", "deploy now", baselineCount = 0)!!
+        val pushed = store.markWireAttempted(
+            "sessA",
+            row.id,
+            baselineCount = 0,
+            collapsedMarkerBaselineCount = 2,
+        )!!
         assertTrue("the wire push sets the durable flag", pushed.wireAttempted)
         assertNotNull(pushed.wireAttemptedAtMs)
         assertEquals(0, pushed.wireNeedleBaselineCount)
-        assertTrue(store.hasWireAttempt("%0", "deploy now"))
-        assertEquals(0, store.wireNeedleBaseline("%0", "deploy now"))
+        assertEquals(2, pushed.wireCollapsedMarkerBaselineCount)
+        assertTrue(store.hasWireAttempt("sessA", row.id))
+        assertEquals(0, store.wireNeedleBaseline("sessA", row.id))
+        assertEquals(2, store.wireCollapsedMarkerBaseline("sessA", row.id))
     }
 
     @Test
-    fun markWireAttemptedMatchesByPaneAndPayloadNotId() {
+    fun markWireAttemptedRequiresExactSessionAndRowId() {
         val store = InMemoryOutboundQueueStore()
-        store.enqueue("sessA", "ship the notes", paneId = "%0")
-        // The ledger keys by pane + payload (it does not know the durable id).
-        val marked = store.markWireAttempted("%0", "ship the notes")
-        assertNotNull("markWireAttempted must locate the row by pane + payload", marked)
+        val row = store.enqueue("sessA", "ship the notes", paneId = "%0")
+        val marked = store.markWireAttempted("sessA", row.id)
+        assertNotNull("markWireAttempted must locate the exact durable row", marked)
         assertTrue(marked!!.wireAttempted)
-        assertTrue(store.hasWireAttempt("%0", "ship the notes"))
-        // A different pane / different payload does not match.
-        assertFalse(store.hasWireAttempt("%1", "ship the notes"))
-        assertFalse(store.hasWireAttempt("%0", "something else"))
-        assertNull(store.markWireAttempted("%9", "no such row"))
+        assertTrue(store.hasWireAttempt("sessA", row.id))
+        assertFalse(store.hasWireAttempt("sessB", row.id))
+        assertFalse(store.hasWireAttempt("sessA", "no-such-row"))
+        assertNull(store.markWireAttempted("sessB", row.id))
+        assertNull(store.markWireAttempted("sessA", "no-such-row"))
     }
 
     @Test
@@ -123,13 +129,13 @@ class OutboundQueueStoreWireAttemptTest {
         val row = store.enqueue("sessA", "deferred payload", paneId = "%0")
         store.markInFlight(row.id)
         // Issue #1577: the flag is set at the wire push, not the claim.
-        store.markWireAttempted("%0", "deferred payload")
+        store.markWireAttempted("sessA", row.id)
         // The drop-failure path defers the row back to Queued (issue #987) — the
         // wire attempt MUST persist so the re-flush verifies before re-pasting.
         val requeued = store.requeueForRetry(row.id)!!
         assertEquals(OutboundState.Queued, requeued.state)
         assertTrue("a requeued row keeps its durable wire attempt", requeued.wireAttempted)
-        assertTrue(store.hasWireAttempt("%0", "deferred payload"))
+        assertTrue(store.hasWireAttempt("sessA", row.id))
     }
 
     @Test
@@ -137,11 +143,11 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "stale payload", paneId = "%0", createdAtMs = 1_000L)
         store.markInFlight(row.id)
-        store.markWireAttempted("%0", "stale payload") // #1577: flag set at the wire push
+        store.markWireAttempted("sessA", row.id) // #1577: flag set at the wire push
         val requeued = store.requeueStaleInFlight("sessA", cutoffMs = Long.MAX_VALUE)
         assertEquals(1, requeued.size)
         assertTrue("a stale-recovered row keeps its durable wire attempt", requeued.single().wireAttempted)
-        assertTrue(store.hasWireAttempt("%0", "stale payload"))
+        assertTrue(store.hasWireAttempt("sessA", row.id))
     }
 
     @Test
@@ -149,13 +155,13 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "delivered payload", paneId = "%0")
         store.markInFlight(row.id)
-        store.markWireAttempted("%0", "delivered payload") // #1577: flag set at the wire push
-        assertTrue(store.hasWireAttempt("%0", "delivered payload"))
+        store.markWireAttempted("sessA", row.id) // #1577: flag set at the wire push
+        assertTrue(store.hasWireAttempt("sessA", row.id))
         assertTrue(store.markDelivered(row.id))
         assertFalse(
             "a delivered+pruned row leaves no wire attempt — a deliberate identical " +
                 "re-send after delivery is a normal full send, not a verify",
-            store.hasWireAttempt("%0", "delivered payload"),
+            store.hasWireAttempt("sessA", row.id),
         )
     }
 
@@ -164,16 +170,16 @@ class OutboundQueueStoreWireAttemptTest {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "cancel me", paneId = "%0")
         store.markInFlight(row.id)
-        store.markWireAttempted("%0", "cancel me") // #1577: flag set at the wire push
-        assertTrue(store.hasWireAttempt("%0", "cancel me"))
+        store.markWireAttempted("sessA", row.id) // #1577: flag set at the wire push
+        assertTrue(store.hasWireAttempt("sessA", row.id))
         assertTrue(store.remove(row.id))
-        assertFalse(store.hasWireAttempt("%0", "cancel me"))
+        assertFalse(store.hasWireAttempt("sessA", row.id))
 
         val other = store.enqueue("sessA", "clear me", paneId = "%0")
         store.markInFlight(other.id)
-        store.markWireAttempted("%0", "clear me")
+        store.markWireAttempted("sessA", other.id)
         store.clearSession("sessA")
-        assertFalse(store.hasWireAttempt("%0", "clear me"))
+        assertFalse(store.hasWireAttempt("sessA", other.id))
     }
 
     // ---------------------------------------------------------- durable / restart
@@ -190,14 +196,14 @@ class OutboundQueueStoreWireAttemptTest {
         val first = SharedPrefsOutboundQueueStore(context)
         val row = first.enqueue("sessA", "survive the restart", paneId = "%0")
         first.markInFlight(row.id)
-        first.markWireAttempted("%0", "survive the restart") // #1577: pushed to the wire → durable flag persisted
+        first.markWireAttempted("sessA", row.id) // #1577: pushed to the wire → durable flag persisted
 
         // A brand-new store over the same on-disk prefs = the fresh process / the
         // VM-clear-rebuilt ledger's durable backing.
         val afterRestart = SharedPrefsOutboundQueueStore(context)
         assertTrue(
             "the rebuilt ledger must still see the prior wire attempt (durable flag)",
-            afterRestart.hasWireAttempt("%0", "survive the restart"),
+            afterRestart.hasWireAttempt("sessA", row.id),
         )
         assertTrue(afterRestart.item(row.id)!!.wireAttempted)
     }
@@ -213,7 +219,7 @@ class OutboundQueueStoreWireAttemptTest {
         val first = SharedPrefsOutboundQueueStore(context)
         val row = first.enqueue("sessA", "delivered but prune lost", paneId = "%0")
         first.markInFlight(row.id)
-        first.markWireAttempted("%0", "delivered but prune lost") // #1577: flag set at the wire push
+        first.markWireAttempted("sessA", row.id) // #1577: flag set at the wire push
         // markDelivered() is NEVER persisted (its apply() was lost) — the InFlight
         // row survives the restart with the flag intact.
         val afterRestart = SharedPrefsOutboundQueueStore(context)
@@ -221,7 +227,7 @@ class OutboundQueueStoreWireAttemptTest {
         assertTrue(
             "a delivered row whose prune was lost still carries the wire attempt, so " +
                 "the rebuilt ledger verifies instead of re-pasting",
-            afterRestart.hasWireAttempt("%0", "delivered but prune lost"),
+            afterRestart.hasWireAttempt("sessA", row.id),
         )
     }
 
@@ -229,11 +235,36 @@ class OutboundQueueStoreWireAttemptTest {
     @Test
     fun asWireAttemptDurableStoreDelegatesToTheRow() {
         val store = InMemoryOutboundQueueStore()
-        store.enqueue("sessA", "adapter payload", paneId = "%0")
+        val row = store.enqueue("sessA", "adapter payload", paneId = "%0")
         val durable = store.asWireAttemptDurableStore()
-        assertFalse(durable.hasWireAttempt("%0", "adapter payload"))
-        durable.recordWireAttempt("%0", "adapter payload", atMs = 123L)
-        assertTrue(durable.hasWireAttempt("%0", "adapter payload"))
-        assertTrue(store.item(store.itemsFor("sessA").single().id)!!.wireAttempted)
+        assertFalse(durable.hasWireAttempt("sessA", row.id))
+        durable.recordWireAttempt("sessA", row.id, atMs = 123L)
+        assertTrue(durable.hasWireAttempt("sessA", row.id))
+        assertTrue(store.item(row.id)!!.wireAttempted)
+    }
+
+    @Test
+    fun identicalPaneAndPayloadAcrossSessionsNeverCrossStampOrRead() {
+        val store = SharedPrefsOutboundQueueStore(context)
+        store.clearSession("session-a")
+        store.clearSession("session-b")
+        val rowA = store.enqueue("session-a", "identical payload", paneId = "%0")
+        val rowB = store.enqueue("session-b", "identical payload", paneId = "%0")
+
+        store.markWireAttempted(
+            sessionKey = "session-a",
+            itemId = rowA.id,
+            baselineCount = 3,
+            collapsedMarkerBaselineCount = 1,
+        )
+
+        val rebuilt = SharedPrefsOutboundQueueStore(context)
+        assertTrue(rebuilt.hasWireAttempt("session-a", rowA.id))
+        assertEquals(3, rebuilt.wireNeedleBaseline("session-a", rowA.id))
+        assertEquals(1, rebuilt.wireCollapsedMarkerBaseline("session-a", rowA.id))
+        assertFalse("session B's identical row must remain fresh", rebuilt.hasWireAttempt("session-b", rowB.id))
+        assertNull(rebuilt.wireNeedleBaseline("session-b", rowB.id))
+        assertNull(rebuilt.wireCollapsedMarkerBaseline("session-b", rowB.id))
+        assertFalse("a row id cannot be read through the wrong session", rebuilt.hasWireAttempt("session-b", rowA.id))
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/AgentSubmitAckTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AgentSubmitAckTest.kt
@@ -1,5 +1,9 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.core.agents.AgentKind
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -107,5 +111,64 @@ class AgentSubmitAckTest {
                 listOf("[Pasted text #1 +3 lines]", "[Pasted text #2 +9 lines]"),
             ),
         )
+    }
+
+    @Test
+    fun outerAckTimeoutKeepsAttemptIdentityAndReportsChangedCurrentIdentity() = runTest {
+        val diagnostics = installRecordingDiagnosticSink()
+        try {
+            val attemptClient = FakeTmuxClient()
+            val replacementClient = FakeTmuxClient()
+            val attemptGeneration = 7L
+            var currentClient = attemptClient
+            var currentGeneration = attemptGeneration
+            val identity = AgentSendRuntimeIdentity(
+                client = attemptClient,
+                generation = attemptGeneration,
+                target = TmuxSessionViewModel.ConnectionTarget(
+                    hostId = 1L,
+                    hostName = "docker",
+                    host = "127.0.0.1",
+                    port = 2222,
+                    user = "testuser",
+                    keyPath = "/tmp/test-key",
+                    passphrase = null,
+                    sessionName = "issue1739-outer-timeout",
+                    startDirectory = null,
+                ),
+            )
+
+            val failure = runCatching {
+                awaitAgentPasteIngested(
+                    identity = identity,
+                    paneId = "%0",
+                    payload = "issue1739 outer timeout",
+                    agent = AgentKind.ClaudeCode,
+                    configuredFloorMs = 0L,
+                    ackTimeoutMs = 100L,
+                    baselineNeedleCount = 0,
+                    collapsedMarkerBaseline = 0,
+                    capture = { _, _ ->
+                        currentClient = replacementClient
+                        currentGeneration = 8L
+                        delay(1_000L)
+                        AgentPaneCaptureResult(AgentPaneCaptureStatus.Failed)
+                    },
+                    currentClientHash = { System.identityHashCode(currentClient) },
+                    currentGeneration = { currentGeneration },
+                )
+            }.exceptionOrNull()
+
+            assertTrue(failure is IllegalStateException)
+            val event = diagnostics.eventsNamed("agent_submit_ack").single()
+            assertEquals("ack_timeout", event.fields["result"])
+            assertEquals(System.identityHashCode(attemptClient), event.fields["clientHash"])
+            assertEquals(attemptGeneration, event.fields["generation"])
+            assertEquals("issue1739-outer-timeout", event.fields["session"])
+            assertEquals(System.identityHashCode(replacementClient), event.fields["currentClientHash"])
+            assertEquals(8L, event.fields["currentGeneration"])
+        } finally {
+            diagnostics.close()
+        }
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -8,6 +8,8 @@ import com.pocketshell.core.tmux.TmuxDisconnectReason
 import com.pocketshell.core.tmux.TmuxOutputBacklogOverflow
 import com.pocketshell.core.tmux.protocol.ControlEvent
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -16,6 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.withContext
 
 /**
  * Test double for [TmuxClient] used by [TmuxSessionViewModelTest].
@@ -237,6 +240,15 @@ internal open class FakeTmuxClient(
 
     var suspendForeverOnCapturePaneTextViaExec: Boolean = false
 
+    /**
+     * Issue #1739: models the real post-reconnect SSH exec failure. The capture
+     * is cancelled by the ack deadline, but `RealSshSession.exec` then enters
+     * non-cancellable command/session-channel teardown on the serialized
+     * transport dispatcher. A structured timeout waits for that teardown and
+     * therefore does not actually bound the caller.
+     */
+    var nonCancellableCaptureTeardownGate: CompletableDeferred<Unit>? = null
+
     var sendCommandGatePrefix: String? = null
 
     var sendCommandGate: CompletableDeferred<Unit>? = null
@@ -428,6 +440,16 @@ internal open class FakeTmuxClient(
         capturePaneTextViaExecScrollbackLines += scrollbackLines
         if (suspendForeverOnCapturePaneTextViaExec) {
             CompletableDeferred<Unit>().await()
+        }
+        nonCancellableCaptureTeardownGate?.let { teardownGate ->
+            try {
+                CompletableDeferred<Unit>().await()
+            } catch (cancelled: CancellationException) {
+                withContext(NonCancellable) {
+                    teardownGate.await()
+                }
+                throw cancelled
+            }
         }
         scrollbackCaptureResponse?.let { if (scrollbackLines > 0) return it }
         val command = if (scrollbackLines > 0) {

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
@@ -191,9 +191,9 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
     /**
      * Class coverage — the footer-present FALSE-MATCH itself: when the pane NEVER
      * renders the typed input (a fully wedged busy Codex), the ack gate must NOT
-     * confirm on the permanent footer occurrence. It holds Enter to the bounded
-     * fallback floor instead of firing early on the footer — proving the count-baseline
-     * gate is not satisfied by the pre-existing `(/goal resume)`.
+     * confirm on the permanent footer occurrence. It fails within the bounded
+     * acknowledgement window without Enter — proving the count-baseline gate is
+     * not satisfied by the pre-existing `(/goal resume)`.
      */
     @Test
     fun ackGateDoesNotFalseConfirmOnPermanentFooterOccurrence() = runTest(scheduler) {
@@ -204,13 +204,12 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
 
         val result = async { vm.sendAgentPayloadToPaneResult("%0", "/goal resume", AgentKind.Codex) }
         advanceUntilIdle()
-        // The send still completes (fallback floor), but it must have POLLED capture-pane
-        // more than once — i.e. it did NOT accept the footer as an instant ack (RED on
-        // base: presence-ack fires on the first poll → exactly one poll).
-        assertTrue(result.await().isSuccess)
+        // Issue #1739 hard cut: an unproven paste is retryable failure, never
+        // "timeout then blind Enter".
+        assertTrue(result.await().isFailure)
         assertTrue(
             "the count-baseline ack must NOT confirm on the permanent footer occurrence — " +
-                "it polls to the bounded fallback (multiple polls), not a first-poll footer match " +
+                "it polls to the bounded failure (multiple polls), not a first-poll footer match " +
                 "(pollCount=${client.capturePaneTextViaExecCalls.size})",
             client.capturePaneTextViaExecCalls.size > 2,
         )
@@ -218,6 +217,10 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
             "a wedged Codex that never renders the paste must not report a swallowed-then-" +
                 "spuriously-submitted state from the footer",
             client.submittedCommands.contains("/goal resume"),
+        )
+        assertFalse(
+            "an unproven paste must never receive a blind submit Enter",
+            client.sentCommands.any { it == "send-keys -t %0 Enter" },
         )
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1587SingleStoreWiringTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1587SingleStoreWiringTest.kt
@@ -57,13 +57,20 @@ class Issue1587SingleStoreWiringTest : TmuxSessionViewModelTestBase() {
         var wireMarks: Int = 0
 
         override fun markWireAttempted(
-            paneId: String,
-            payload: String,
+            sessionKey: String,
+            itemId: String,
             atMs: Long,
             baselineCount: Int?,
+            collapsedMarkerBaselineCount: Int?,
         ): OutboundItem? {
             wireMarks += 1
-            return super.markWireAttempted(paneId, payload, atMs, baselineCount)
+            return super.markWireAttempted(
+                sessionKey,
+                itemId,
+                atMs,
+                baselineCount,
+                collapsedMarkerBaselineCount,
+            )
         }
     }
 
@@ -73,7 +80,7 @@ class Issue1587SingleStoreWiringTest : TmuxSessionViewModelTestBase() {
         val paneId = "%0"
         val payload = "wire this exactly once please"
         // The composer's persisted row the sweep would also see.
-        store.enqueue("sessA", payload, paneId = paneId)
+        val row = store.enqueue("sessA", payload, paneId = paneId)
 
         val client = FakeTmuxClient().apply {
             // The ack gate sees the pasted payload immediately (fresh payload ⇒ baseline 0).
@@ -86,7 +93,15 @@ class Issue1587SingleStoreWiringTest : TmuxSessionViewModelTestBase() {
         vm.setAgentSubmitEnterDelayForTest(0)
         vm.setAgentSubmitAckTimeoutForTest(50)
 
-        val result = async { vm.sendAgentPayloadToPaneResult(paneId, payload, AgentKind.ClaudeCode) }
+        val result = async {
+            vm.sendAgentPayloadToPaneResult(
+                paneId,
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = DurableOutboundRowIdentity("sessA", row.id),
+            )
+        }
         advanceUntilIdle()
         assertTrue("the agent send should succeed", result.await().isSuccess)
 
@@ -99,7 +114,7 @@ class Issue1587SingleStoreWiringTest : TmuxSessionViewModelTestBase() {
         assertTrue(
             "the durable wireAttempted flag must be readable via the SAME store the sweep reads " +
                 "(one instance, one lock — no lost-update race)",
-            store.hasWireAttempt(paneId, payload),
+            store.hasWireAttempt("sessA", row.id),
         )
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1739DurableTokenRoutingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1739DurableTokenRoutingTest.kt
@@ -1,0 +1,398 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.PromptComposerViewModel
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1739: the screen-to-VM composer boundary must not discard the durable
+ * queue row id. That id is the delivery guard's stable token across an ambiguous
+ * first attempt and its auto-flush retry.
+ */
+class Issue1739DurableTokenRoutingTest {
+
+    @Test
+    fun durableRowTokenCrossesEveryComposerRoute() = runTest {
+        val cases = listOf(
+            RouteCase(
+                name = "agent payload",
+                request = request(
+                    route = OutboundRoute.AgentPayload,
+                    text = "agent payload",
+                    agentKind = "claude",
+                ),
+                expectedLane = "agent-payload",
+                expectedPayload = "agent payload",
+            ),
+            RouteCase(
+                name = "conversation echo",
+                request = request(
+                    route = OutboundRoute.AgentConversation,
+                    text = "conversation prompt",
+                    agentKind = "claude",
+                ),
+                expectedLane = "agent-echo",
+                expectedPayload = "conversation prompt",
+            ),
+            RouteCase(
+                name = "conversation TUI command",
+                request = request(
+                    route = OutboundRoute.AgentConversation,
+                    text = "/model",
+                    agentKind = "claude",
+                ),
+                expectedLane = "agent-payload",
+                expectedPayload = "/model",
+            ),
+            RouteCase(
+                name = "raw bytes",
+                request = request(
+                    route = OutboundRoute.RawBytes,
+                    text = "printf token",
+                    withEnter = true,
+                ),
+                expectedLane = "raw-bytes",
+                expectedPayload = "printf token\r",
+            ),
+        )
+
+        cases.forEach { case ->
+            val calls = mutableListOf<WireCall>()
+            val sent = dispatch(case.request, calls)
+
+            assertTrue("${case.name} should dispatch", sent)
+            assertEquals("${case.name} must dispatch once", 1, calls.size)
+            assertEquals(case.expectedLane, calls.single().lane)
+            assertEquals(case.expectedPayload, calls.single().payload)
+            assertEquals(
+                "${case.name} must retain the exact durable row id as its guard token",
+                DURABLE_ROW_ID,
+                calls.single().sendToken,
+            )
+            assertEquals(
+                DurableOutboundRowIdentity(SESSION_ID, DURABLE_ROW_ID),
+                calls.single().durableRow,
+            )
+        }
+    }
+
+    @Test
+    fun nullRowIdGetsFreshGeneratedFallbackOnlyForNonDurableRequests() = runTest {
+        val firstCalls = mutableListOf<WireCall>()
+        val secondCalls = mutableListOf<WireCall>()
+        val nonDurable = request(
+            route = OutboundRoute.RawBytes,
+            text = "legacy",
+            outboundQueueItemId = null,
+        )
+
+        assertTrue(dispatch(nonDurable, firstCalls))
+        assertTrue(dispatch(nonDurable, secondCalls))
+
+        val firstToken = firstCalls.single().sendToken
+        val secondToken = secondCalls.single().sendToken
+        assertTrue(firstToken.isNotBlank())
+        assertTrue(secondToken.isNotBlank())
+        assertNotEquals(
+            "distinct non-durable sends must not share delivery identity",
+            firstToken,
+            secondToken,
+        )
+        assertNotEquals(DURABLE_ROW_ID, firstToken)
+        assertNotEquals(DURABLE_ROW_ID, secondToken)
+        assertEquals(null, firstCalls.single().durableRow)
+        assertEquals(null, secondCalls.single().durableRow)
+    }
+
+    @Test
+    fun sameDurableRouteRetryUsesOneTokenAndSubmitsEnterWithoutDuplicatePaste() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val client = FakeTmuxClient()
+        val calls = mutableListOf<WireCall>()
+        var pasteCount = 0
+        var enterCount = 0
+        val durableRequest = request(
+            route = OutboundRoute.AgentPayload,
+            text = MULTILINE_PAYLOAD,
+            agentKind = "claude",
+        )
+
+        val sendAgentPayload = guardedAgentSend(
+            ledger = ledger,
+            client = client,
+            calls = calls,
+            onPaste = { pasteCount += 1 },
+            onEnter = { enterCount += 1 },
+        )
+        val first = dispatch(
+            request = durableRequest,
+            calls = calls,
+            sendAgentPayload = sendAgentPayload,
+        )
+        assertFalse("the first ambiguous paste remains queued", first)
+
+        val landedChip = CommandResponse(
+            number = 0L,
+            output = listOf("> [Pasted text #1 +2 lines]"),
+            isError = false,
+        )
+        client.scrollbackCaptureResponse = landedChip
+        client.defaultCaptureResponse = landedChip
+        val retry = dispatch(
+            request = durableRequest,
+            calls = calls,
+            sendAgentPayload = sendAgentPayload,
+        )
+
+        assertTrue("the proven landed chip authorizes Enter-only completion", retry)
+        assertEquals(listOf(DURABLE_ROW_ID, DURABLE_ROW_ID), calls.map { it.sendToken })
+        assertEquals("the retry must not duplicate-paste", 1, pasteCount)
+        assertEquals("the proven retry submits exactly one Enter", 1, enterCount)
+    }
+
+    @Test
+    fun sameDurableRouteRetryWithoutPaneProofNeverBlindlyPressesEnter() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val client = FakeTmuxClient().apply {
+            defaultCaptureResponse = CommandResponse(
+                number = 0L,
+                output = listOf("> "),
+                isError = false,
+            )
+        }
+        val calls = mutableListOf<WireCall>()
+        var pasteCount = 0
+        var enterCount = 0
+        val durableRequest = request(
+            route = OutboundRoute.AgentPayload,
+            text = MULTILINE_PAYLOAD,
+            agentKind = "claude",
+        )
+        val sendAgentPayload = guardedAgentSend(
+            ledger = ledger,
+            client = client,
+            calls = calls,
+            onPaste = { pasteCount += 1 },
+            onEnter = { enterCount += 1 },
+        )
+
+        assertFalse(dispatch(durableRequest, calls, sendAgentPayload))
+        assertFalse(dispatch(durableRequest, calls, sendAgentPayload))
+
+        assertEquals(listOf(DURABLE_ROW_ID, DURABLE_ROW_ID), calls.map { it.sendToken })
+        assertEquals("unknown delivery must not duplicate-paste", 1, pasteCount)
+        assertEquals("unknown delivery must never authorize a blind Enter", 0, enterCount)
+    }
+
+    @Test
+    fun nullLiteralBaselineWithDurableCollapsedMarkerSubmitsEnterOnly() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val durableRow = DurableOutboundRowIdentity(SESSION_ID, DURABLE_ROW_ID)
+        ledger.recordWireAttempt(
+            paneId = PANE_ID,
+            sendToken = DURABLE_ROW_ID,
+            payload = MULTILINE_PAYLOAD,
+            baselineCount = null,
+            collapsedMarkerBaselineCount = 0,
+            durableRow = durableRow,
+        )
+        val client = FakeTmuxClient().apply {
+            defaultCaptureResponse = CommandResponse(
+                number = 0L,
+                output = listOf("> [Pasted text #1 +2 lines]"),
+                isError = false,
+            )
+        }
+        val calls = mutableListOf<WireCall>()
+        var pasteCount = 0
+        var enterCount = 0
+
+        val result = dispatch(
+            request = request(
+                route = OutboundRoute.AgentPayload,
+                text = MULTILINE_PAYLOAD,
+                agentKind = "claude",
+            ),
+            calls = calls,
+            sendAgentPayload = guardedAgentSend(
+                ledger,
+                client,
+                calls,
+                onPaste = { pasteCount += 1 },
+                onEnter = { enterCount += 1 },
+            ),
+        )
+
+        assertTrue("independent durable marker evidence authorizes completion", result)
+        assertEquals("the already-landed multiline payload must not be pasted again", 0, pasteCount)
+        assertEquals("the proven collapsed marker authorizes exactly one Enter", 1, enterCount)
+    }
+
+    @Test
+    fun nullLiteralAndMarkerBaselinesAuthorizeNeitherRepasteNorEnter() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val durableRow = DurableOutboundRowIdentity(SESSION_ID, DURABLE_ROW_ID)
+        ledger.recordWireAttempt(
+            paneId = PANE_ID,
+            sendToken = DURABLE_ROW_ID,
+            payload = MULTILINE_PAYLOAD,
+            baselineCount = null,
+            collapsedMarkerBaselineCount = null,
+            durableRow = durableRow,
+        )
+        val client = FakeTmuxClient().apply {
+            defaultCaptureResponse = CommandResponse(
+                number = 0L,
+                output = listOf("> [Pasted text #1 +2 lines]"),
+                isError = false,
+            )
+        }
+        val calls = mutableListOf<WireCall>()
+        var pasteCount = 0
+        var enterCount = 0
+
+        val result = dispatch(
+            request = request(
+                route = OutboundRoute.AgentPayload,
+                text = MULTILINE_PAYLOAD,
+                agentKind = "claude",
+            ),
+            calls = calls,
+            sendAgentPayload = guardedAgentSend(
+                ledger,
+                client,
+                calls,
+                onPaste = { pasteCount += 1 },
+                onEnter = { enterCount += 1 },
+            ),
+        )
+
+        assertFalse("untrusted legacy evidence must remain retryable", result)
+        assertEquals("unknown evidence must not duplicate-paste", 0, pasteCount)
+        assertEquals("unknown evidence must never authorize Enter", 0, enterCount)
+    }
+
+    private fun request(
+        route: OutboundRoute,
+        text: String,
+        withEnter: Boolean = true,
+        agentKind: String? = null,
+        outboundQueueItemId: String? = DURABLE_ROW_ID,
+    ): PromptComposerViewModel.SendRequest =
+        PromptComposerViewModel.SendRequest(
+            text = text,
+            withEnter = withEnter,
+            sendTarget = PromptComposerViewModel.SendTargetSnapshot(
+                sessionKey = SESSION_ID,
+                paneId = PANE_ID,
+                route = route,
+                agentKind = agentKind,
+            ),
+            outboundQueueItemId = outboundQueueItemId,
+        )
+
+    private suspend fun dispatch(
+        request: PromptComposerViewModel.SendRequest,
+        calls: MutableList<WireCall>,
+        sendAgentPayload: suspend (
+            paneId: String,
+            text: String,
+            agent: AgentKind,
+            sendToken: String,
+            durableRow: DurableOutboundRowIdentity?,
+        ) -> Boolean = { paneId, text, _, sendToken, durableRow ->
+            calls += WireCall("agent-payload", paneId, text, sendToken, durableRow)
+            true
+        },
+    ): Boolean =
+        tmuxComposerSendResult(
+            request = request,
+            targetSessionId = SESSION_ID,
+            fallbackPaneId = "%fallback",
+            sendAgentPayload = sendAgentPayload,
+            sendToAgent = { paneId, text, sendToken, durableRow ->
+                calls += WireCall("agent-echo", paneId, text, sendToken, durableRow)
+                true
+            },
+            sendRawBytes = { paneId, bytes, sendToken, durableRow ->
+                calls += WireCall(
+                    lane = "raw-bytes",
+                    paneId = paneId,
+                    payload = String(bytes, Charsets.UTF_8),
+                    sendToken = sendToken,
+                    durableRow = durableRow,
+                )
+                true
+            },
+            setTuiNotice = {},
+        )
+
+    private fun guardedAgentSend(
+        ledger: OutboundDeliveryLedger,
+        client: FakeTmuxClient,
+        calls: MutableList<WireCall>,
+        onPaste: () -> Unit,
+        onEnter: () -> Unit,
+    ): suspend (String, String, AgentKind, String, DurableOutboundRowIdentity?) -> Boolean =
+        { paneId, text, _, sendToken, durableRow ->
+            calls += WireCall("agent-payload", paneId, text, sendToken, durableRow)
+            when (
+                verifyBeforeAgentResend(
+                    ledger = ledger,
+                    client = client,
+                    paneId = paneId,
+                    sendToken = sendToken,
+                    payload = text,
+                    durableRow = durableRow,
+                )
+            ) {
+                DeliveryProbeOutcome.AlreadyLanded -> {
+                    onEnter()
+                    ledger.clear(paneId, sendToken)
+                    true
+                }
+                DeliveryProbeOutcome.Unknown -> false
+                DeliveryProbeOutcome.NotLanded, null -> {
+                    ledger.recordWireAttempt(
+                        paneId = paneId,
+                        sendToken = sendToken,
+                        payload = text,
+                        baselineCount = 0,
+                        collapsedMarkerBaselineCount = 0,
+                        durableRow = durableRow,
+                    )
+                    onPaste()
+                    false
+                }
+            }
+        }
+
+    private data class RouteCase(
+        val name: String,
+        val request: PromptComposerViewModel.SendRequest,
+        val expectedLane: String,
+        val expectedPayload: String,
+    )
+
+    private data class WireCall(
+        val lane: String,
+        val paneId: String,
+        val payload: String,
+        val sendToken: String,
+        val durableRow: DurableOutboundRowIdentity?,
+    )
+
+    private companion object {
+        const val SESSION_ID = "issue1739-session"
+        const val PANE_ID = "%0"
+        const val DURABLE_ROW_ID = "issue1739-durable-row"
+        const val MULTILINE_PAYLOAD = "first line\nsecond line\nthird line"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundAttachmentBackNavExactlyOnceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundAttachmentBackNavExactlyOnceTest.kt
@@ -140,13 +140,14 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         assertTrue("attachment payload must differ from cleanText", composed != cleanDraft)
 
         val store = SharedPrefsOutboundQueueStore(context)
-        store.enqueue(
+        val row = store.enqueue(
             "sessA",
             cleanDraft,
             attachments = attachments,
             paneId = "%0",
             route = OutboundRoute.AgentConversation,
         )
+        val durableRow = DurableOutboundRowIdentity("sessA", row.id)
 
         // VM #1: attempt 1 pastes the composed payload, the pane shows it (ack
         // passes), then the submit Enter's exec result is lost after the server
@@ -155,7 +156,15 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         val vm1 = newDurableConnectedVm(client1)
         client1.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client1.throwOnCommandRemaining = 1
-        val first = async { vm1.sendAgentPayloadToPaneResult("%0", composed, AgentKind.ClaudeCode) }
+        val first = async {
+            vm1.sendAgentPayloadToPaneResult(
+                "%0",
+                composed,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue("attempt 1 must surface the ambiguous failure", first.await().isFailure)
         assertEquals("attempt 1 pastes exactly once", 1, client1.bracketedPasteCount(composed))
@@ -164,7 +173,7 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         // payload never matches the row and this is false.
         assertTrue(
             "the durable wire attempt must be recorded for the composed attachment payload",
-            store.hasWireAttempt("%0", composed),
+            store.hasWireAttempt("sessA", row.id),
         )
 
         // Back-nav mid-delivery: VM #1 is cleared (its volatile ledger dies).
@@ -174,7 +183,15 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         // re-dispatches the SAME composed payload; the pane still shows it landed.
         val client2 = clientShowingComposed(composed)
         val vm2 = newDurableConnectedVm(client2)
-        val second = async { vm2.sendAgentPayloadToPaneResult("%0", composed, AgentKind.ClaudeCode) }
+        val second = async {
+            vm2.sendAgentPayloadToPaneResult(
+                "%0",
+                composed,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue("the verified resend must succeed", second.await().isSuccess)
 
@@ -208,29 +225,46 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         assertTrue("multi-attachment payload must differ from cleanText", composed != cleanDraft)
 
         val store = SharedPrefsOutboundQueueStore(context)
-        store.enqueue(
+        val row = store.enqueue(
             "sessM",
             cleanDraft,
             attachments = attachments,
             paneId = "%0",
             route = OutboundRoute.AgentConversation,
         )
+        val durableRow = DurableOutboundRowIdentity("sessM", row.id)
 
         val client1 = clientShowingComposed(composed)
         val vm1 = newDurableConnectedVm(client1)
         client1.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client1.throwOnCommandRemaining = 1
-        val first = async { vm1.sendAgentPayloadToPaneResult("%0", composed, AgentKind.ClaudeCode) }
+        val first = async {
+            vm1.sendAgentPayloadToPaneResult(
+                "%0",
+                composed,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(first.await().isFailure)
         assertEquals(1, client1.bracketedPasteCount(composed))
-        assertTrue(store.hasWireAttempt("%0", composed))
+        assertTrue(store.hasWireAttempt("sessM", row.id))
 
         vm1.clearForTest()
 
         val client2 = clientShowingComposed(composed)
         val vm2 = newDurableConnectedVm(client2)
-        val second = async { vm2.sendAgentPayloadToPaneResult("%0", composed, AgentKind.ClaudeCode) }
+        val second = async {
+            vm2.sendAgentPayloadToPaneResult(
+                "%0",
+                composed,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(second.await().isSuccess)
         assertEquals(
@@ -254,34 +288,54 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         val composed = appendAttachmentPaths(cleanDraft, attachments.map { it.remotePath })
 
         val store = SharedPrefsOutboundQueueStore(context)
-        store.enqueue(
+        val row = store.enqueue(
             "sessL",
             cleanDraft,
             attachments = attachments,
             paneId = "%0",
             route = OutboundRoute.AgentConversation,
         )
+        val durableRow = DurableOutboundRowIdentity("sessL", row.id)
 
-        // VM #1: the paste never lands (the bracketed-paste body send fails before
-        // it reaches the pane). The pane shows only a bare prompt.
-        val client1 = clientShowingComposed("$ ")
+        // VM #1: fail during the private tmux-buffer fill. This is definitively
+        // pre-commit: set-buffer cannot touch the pane, so the durable row must
+        // remain safe to retry without an ambiguous wire-attempt marker.
+        val client1 = FakeTmuxPaneServer()
         val vm1 = newDurableConnectedVm(client1)
-        client1.throwOnCommandPrefix = "paste-buffer"
-        client1.throwOnCommandRemaining = 1
-        val first = async { vm1.sendAgentPayloadToPaneResult("%0", composed, AgentKind.ClaudeCode) }
+        client1.failBeforeApplyAtCommand { it.startsWith("set-buffer ") }
+        val first = async {
+            vm1.sendAgentPayloadToPaneResult(
+                "%0",
+                composed,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(first.await().isFailure)
-        // The attempt still reached the wire (outcome lost) ⇒ durable record exists.
-        assertTrue(store.hasWireAttempt("%0", composed))
+        assertFalse(
+            "a failed private-buffer fill is definitively pre-commit and must not " +
+                "persist an ambiguous pane wire attempt",
+            store.hasWireAttempt("sessL", row.id),
+        )
+        assertEquals(0, client1.bracketedPasteCount(composed))
 
         vm1.clearForTest()
 
-        // VM #2 rebuilds: the pane still shows only a bare prompt, so the verify
-        // probe sees the composed payload NEVER landed ⇒ full re-paste, the
-        // attachment row is NOT dropped.
-        val client2 = clientShowingComposed("$ ")
+        // VM #2 rebuilds with no ambiguous marker, refills and commits the
+        // payload, then its live input-box capture proves ingestion before Enter.
+        val client2 = FakeTmuxPaneServer()
         val vm2 = newDurableConnectedVm(client2)
-        val second = async { vm2.sendAgentPayloadToPaneResult("%0", composed, AgentKind.ClaudeCode) }
+        val second = async {
+            vm2.sendAgentPayloadToPaneResult(
+                "%0",
+                composed,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(second.await().isSuccess)
         assertEquals(
@@ -301,23 +355,45 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
     fun textOnlyBackNavRemainsExactlyOnce() = runTest(scheduler) {
         val payload = "restart the metrics collector"
         val store = SharedPrefsOutboundQueueStore(context)
-        store.enqueue("sessT", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+        val row = store.enqueue(
+            "sessT",
+            payload,
+            paneId = "%0",
+            route = OutboundRoute.AgentConversation,
+        )
+        val durableRow = DurableOutboundRowIdentity("sessT", row.id)
 
         val client1 = clientShowingComposed("> $payload")
         val vm1 = newDurableConnectedVm(client1)
         client1.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client1.throwOnCommandRemaining = 1
-        val first = async { vm1.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        val first = async {
+            vm1.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(first.await().isFailure)
         assertEquals(1, client1.literalPasteCount(payload))
-        assertTrue(store.hasWireAttempt("%0", payload))
+        assertTrue(store.hasWireAttempt("sessT", row.id))
 
         vm1.clearForTest()
 
         val client2 = clientShowingComposed("> $payload")
         val vm2 = newDurableConnectedVm(client2)
-        val second = async { vm2.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        val second = async {
+            vm2.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(second.await().isSuccess)
         assertEquals(
@@ -327,6 +403,7 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         )
         assertTrue(client2.enterCount() >= 1)
         // And a delivered+pruned text row drops the durable flag (not falsely suppressed later).
-        assertFalse(store.hasWireAttempt("%0", "some other unsent text"))
+        store.markDelivered(row.id)
+        assertFalse(store.hasWireAttempt("sessT", row.id))
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
@@ -86,7 +86,13 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         // The composer enqueued the row that is being delivered (Queued, matching
         // pane + payload). Same prefs file the VMs' ledgers read.
         val store = SharedPrefsOutboundQueueStore(context)
-        store.enqueue("sessA", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+        val row = store.enqueue(
+            "sessA",
+            payload,
+            paneId = "%0",
+            route = OutboundRoute.AgentConversation,
+        )
+        val durableRow = DurableOutboundRowIdentity("sessA", row.id)
 
         // VM #1: attempt 1 pastes, the pane shows it (ack passes), then the submit
         // Enter's exec result is lost after the server ran the paste.
@@ -94,12 +100,20 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         val vm1 = newDurableConnectedVm(client1)
         client1.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client1.throwOnCommandRemaining = 1
-        val first = async { vm1.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        val first = async {
+            vm1.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue("attempt 1 must surface the ambiguous failure", first.await().isFailure)
         assertEquals("attempt 1 pastes exactly once", 1, client1.pasteCount(payload))
         // The wire attempt is now DURABLE on the row (survives the VM-clear).
-        assertTrue(store.hasWireAttempt("%0", payload))
+        assertTrue(store.hasWireAttempt("sessA", row.id))
 
         // The user taps BACK mid-delivery → VM #1 is cleared (its volatile ledger
         // dies). #780 model: a synthetic VM-clear, not process death.
@@ -110,7 +124,15 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         // shows the landed payload.
         val client2 = clientShowing("> $payload")
         val vm2 = newDurableConnectedVm(client2)
-        val second = async { vm2.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        val second = async {
+            vm2.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue("the verified resend must succeed", second.await().isSuccess)
 
@@ -135,26 +157,54 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
     fun backNavWithUndeliveredRowStillDeliversOnRebuiltVm() = runTest(scheduler) {
         val payload = "restart the worker pool"
         val store = SharedPrefsOutboundQueueStore(context)
-        store.enqueue("sessB", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+        val row = store.enqueue(
+            "sessB",
+            payload,
+            paneId = "%0",
+            route = OutboundRoute.AgentConversation,
+        )
+        val durableRow = DurableOutboundRowIdentity("sessB", row.id)
 
         // VM #1: the paste never lands (the send fails before it reaches the pane).
         val client1 = clientShowing("$ ")
         val vm1 = newDurableConnectedVm(client1)
         client1.throwOnCommandPrefix = "send-keys -l -t %0"
         client1.throwOnCommandRemaining = 1
-        val first = async { vm1.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        val first = async {
+            vm1.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(first.await().isFailure)
         // The attempt was still recorded durably (it reached the wire, outcome lost).
-        assertTrue(store.hasWireAttempt("%0", payload))
+        assertTrue(store.hasWireAttempt("sessB", row.id))
 
         vm1.clearForTest()
 
         // VM #2 rebuilds: the probe shows the payload NEVER landed ⇒ full re-paste,
-        // the row is NOT dropped.
+        // then the ack capture proves the retry paste landed. The row is NOT dropped.
         val client2 = clientShowing("$ ")
+        client2.capturePaneResponses.addLast(
+            CommandResponse(number = 0L, output = listOf("$ "), isError = false),
+        )
+        client2.capturePaneResponses.addLast(
+            CommandResponse(number = 0L, output = listOf("> $payload"), isError = false),
+        )
         val vm2 = newDurableConnectedVm(client2)
-        val second = async { vm2.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        val second = async {
+            vm2.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(second.await().isSuccess)
         assertEquals(
@@ -179,7 +229,16 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         val client = clientShowing("> $payload")
         val vm = newDurableConnectedVm(client)
 
-        val first = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }
+        val durableRow = DurableOutboundRowIdentity("sessC", row.id)
+        val first = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(first.await().isSuccess)
         assertEquals(1, client.pasteCount(payload))
@@ -187,7 +246,7 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         // The composer acks delivery: the row is delivered+pruned, dropping the
         // durable flag so a later identical send is not falsely suppressed.
         store.markDelivered(row.id)
-        assertFalse(store.hasWireAttempt("%0", payload))
+        assertFalse(store.hasWireAttempt("sessC", row.id))
 
         // A deliberate identical re-send is a normal full send (2 pastes total).
         val second = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode) }

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -338,19 +338,44 @@ class OutboundDeliveryGuardTest {
         )
     }
 
+    @Test
+    fun multilineCollapsedChipIncreaseResolvesAlreadyLandedForEnterOnlyRetry() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "first line\nsecond line\nthird line"
+        val token = "collapsed-reconnect"
+        ledger.recordWireAttempt(
+            paneId,
+            token,
+            payload,
+            baselineCount = 0,
+            collapsedMarkerBaselineCount = 0,
+        )
+        val client = captureShowing("> [Pasted text #1 +2 lines]")
+
+        val outcome = verifyBeforeAgentResend(ledger, client, paneId, token, payload)
+
+        assertEquals(
+            "Claude's collapsed chip is the only pane proof for multiline payloads; " +
+                "its count increase must authorize Enter-only recovery, never a duplicate paste",
+            DeliveryProbeOutcome.AlreadyLanded,
+            outcome,
+        )
+    }
+
     /**
      * Issue #1577b: a NULL baseline (a legacy pre-baseline row, or a failed baseline
      * capture) is UNTRUSTWORTHY — a presence-only check would false-`AlreadyLanded` on
      * a permanent Codex `Goal blocked (/goal resume)` footer and submit a bare Enter,
      * silently dropping the payload (the reopened #1577 symptom). The kill-the-presence-
-     * fallback fix resolves `NotLanded` instead, so the caller does a REAL gated resend
-     * (which records a fresh baseline), never a bare Enter.
+     * fallback fix resolves `Unknown`, so the caller does neither a blind resend nor
+     * a bare Enter.
      *
      * RED on base: the presence-only fallback (`count >= 1`) matched the footer ⇒
-     * AlreadyLanded. GREEN: null baseline ⇒ NotLanded (deliver-safe).
+     * AlreadyLanded. GREEN: null baseline ⇒ Unknown (ambiguity-safe).
      */
     @Test
-    fun nullBaselineUntrustworthyFlagResolvesNotLandedNotBareEnter() = runTest {
+    fun nullBaselineUntrustworthyFlagResolvesUnknownNotBareEnter() = runTest {
         val ledger = OutboundDeliveryLedger()
         val paneId = "%0"
         val payload = "/goal resume"
@@ -364,8 +389,37 @@ class OutboundDeliveryGuardTest {
         assertEquals(
             "a null-baseline (untrustworthy) flag whose payload is already on the pane must NOT " +
                 "resolve AlreadyLanded (that submits a bare Enter and silently drops the send) — " +
-                "it must be NotLanded so the caller does a real gated resend",
-            DeliveryProbeOutcome.NotLanded,
+                "it must stay Unknown so the caller performs no unauthorized wire action",
+            DeliveryProbeOutcome.Unknown,
+            outcome,
+        )
+    }
+
+    @Test
+    fun nullLiteralBaselineStillUsesDurableMultilineCollapsedMarkerEvidence() = runTest {
+        val ledger = OutboundDeliveryLedger()
+        val paneId = "%0"
+        val payload = "first line\nsecond line\nthird line"
+        val token = "legacy-multiline-row"
+        ledger.recordWireAttempt(
+            paneId,
+            token,
+            payload,
+            baselineCount = null,
+            collapsedMarkerBaselineCount = 0,
+        )
+
+        val outcome = verifyBeforeAgentResend(
+            ledger,
+            captureShowing("> [Pasted text #1 +2 lines]"),
+            paneId,
+            token,
+            payload,
+        )
+
+        assertEquals(
+            "a null literal baseline must not discard independent collapsed-marker evidence",
+            DeliveryProbeOutcome.AlreadyLanded,
             outcome,
         )
     }
@@ -402,13 +456,26 @@ class OutboundDeliveryGuardTest {
     fun rebuiltLedgerConsultsDurableFlagAfterVmClear() {
         val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
         // The composer enqueued the row that the VM is delivering.
-        store.enqueue("sessA", "durable payload", paneId = "%0")
+        val row = store.enqueue("sessA", "durable payload", paneId = "%0")
+        val durableRow = DurableOutboundRowIdentity("sessA", row.id)
         val durable = store.asWireAttemptDurableStore()
 
         // VM #1's ledger records the wire attempt (right before the paste).
         val ledger1 = OutboundDeliveryLedger(durable = durable)
-        ledger1.recordWireAttempt("%0", "durable payload", "durable payload")
-        assertTrue(ledger1.hasAmbiguousAttempt("%0", "durable payload", "durable payload"))
+        ledger1.recordWireAttempt(
+            "%0",
+            row.id,
+            "durable payload",
+            durableRow = durableRow,
+        )
+        assertTrue(
+            ledger1.hasAmbiguousAttempt(
+                "%0",
+                row.id,
+                "durable payload",
+                durableRow,
+            ),
+        )
 
         // Back-navigation clears the VM: its volatile ledger dies. A base ledger
         // with NO durable backing has no memory of the attempt (the P9 bug).
@@ -425,7 +492,7 @@ class OutboundDeliveryGuardTest {
         assertTrue(
             "GREEN (fix): the durable `wireAttempted` flag makes the rebuilt ledger " +
                 "verify-before-resend instead of blindly re-pasting",
-            rebuilt.hasAmbiguousAttempt("%0", "durable payload", "durable payload"),
+            rebuilt.hasAmbiguousAttempt("%0", row.id, "durable payload", durableRow),
         )
     }
 
@@ -450,18 +517,19 @@ class OutboundDeliveryGuardTest {
     @Test
     fun clearKeepsDurableRowFlagForAsYetUnackedRow() {
         val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
-        store.enqueue("sessA", "unacked payload", paneId = "%0")
+        val row = store.enqueue("sessA", "unacked payload", paneId = "%0")
+        val durableRow = DurableOutboundRowIdentity("sessA", row.id)
         val durable = store.asWireAttemptDurableStore()
         val ledger = OutboundDeliveryLedger(durable = durable)
-        ledger.recordWireAttempt("%0", "unacked payload", "unacked payload")
-        ledger.clear("%0", "unacked payload")
+        ledger.recordWireAttempt("%0", row.id, "unacked payload", durableRow = durableRow)
+        ledger.clear("%0", row.id)
 
         assertTrue(
             "clear() drops only the volatile entry; the durable row flag persists so " +
                 "a rebuilt ledger still verifies",
-            ledger.hasAmbiguousAttempt("%0", "unacked payload", "unacked payload"),
+            ledger.hasAmbiguousAttempt("%0", row.id, "unacked payload", durableRow),
         )
-        assertTrue(store.hasWireAttempt("%0", "unacked payload"))
+        assertTrue(store.hasWireAttempt("sessA", row.id))
     }
 
     /**
@@ -492,12 +560,12 @@ class OutboundDeliveryGuardTest {
         )
         assertFalse(
             "the claim alone must NOT record a wire attempt (#1577)",
-            store.hasWireAttempt(paneId, payload),
+            store.hasWireAttempt("sessA", row.id),
         )
-        store.markWireAttempted(paneId, payload, baselineCount = 0) // the actual wire push (#1577b: records a baseline)
+        store.markWireAttempted("sessA", row.id, baselineCount = 0)
         assertTrue(
             "the wire push must durably record the wire attempt on the row",
-            store.hasWireAttempt(paneId, payload),
+            store.hasWireAttempt("sessA", row.id),
         )
 
         // VM churn / process death: the volatile ledger dies. A ledger REBUILT with
@@ -512,7 +580,14 @@ class OutboundDeliveryGuardTest {
         // claim-stamped flag → verify → the pane shows the payload → AlreadyLanded,
         // so the send path submits Enter only and never re-pastes (occurrence 1).
         val rebuilt = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
-        val outcome = verifyBeforeAgentResend(rebuilt, captureShowing("$ $payload"), paneId, payload, payload)
+        val outcome = verifyBeforeAgentResend(
+            rebuilt,
+            captureShowing("$ $payload"),
+            paneId,
+            row.id,
+            payload,
+            DurableOutboundRowIdentity("sessA", row.id),
+        )
         assertEquals(
             "an orphaned InFlight row that actually landed must verify AlreadyLanded (occurrence 1)",
             DeliveryProbeOutcome.AlreadyLanded,
@@ -747,15 +822,21 @@ class OutboundDeliveryGuardTest {
     @Test
     fun outboundDeliveryLedgerForThreadsTheExactInjectedStoreNotASecondInstance() {
         val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
-        store.enqueue("sessA", "single-store payload", paneId = "%0")
+        val row = store.enqueue("sessA", "single-store payload", paneId = "%0")
+        val durableRow = DurableOutboundRowIdentity("sessA", row.id)
         val ledger = outboundDeliveryLedgerFor(store)
 
-        ledger.recordWireAttempt("%0", "single-store payload", "single-store payload")
+        ledger.recordWireAttempt(
+            "%0",
+            row.id,
+            "single-store payload",
+            durableRow = durableRow,
+        )
 
         assertTrue(
             "the wire attempt recorded via the ledger must be visible through the SAME store " +
                 "instance the orphan sweep reads (one lock — no lost-update race)",
-            store.hasWireAttempt("%0", "single-store payload"),
+            store.hasWireAttempt("sessA", row.id),
         )
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundExactlyOnceDeliveryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundExactlyOnceDeliveryTest.kt
@@ -165,7 +165,9 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
     @Test
     fun resendRepastesInFullWhenProbeShowsPayloadNeverLanded() = runTest(scheduler) {
         val client = FakeTmuxClient()
-        // The pane never shows the payload (it did NOT land).
+        // The first literal command fails before the pane accepts it. On retry,
+        // the verify capture shows a bare prompt, then the ack capture proves
+        // the re-paste landed.
         client.defaultCaptureResponse = CommandResponse(
             number = 0L,
             output = listOf("$ "),
@@ -173,12 +175,22 @@ class OutboundExactlyOnceDeliveryTest : TmuxSessionViewModelTestBase() {
         )
         val vm = newConnectedVm(client)
 
-        client.throwOnCommandPrefix = "send-keys -t %0 Enter"
+        client.throwOnCommandPrefix = "send-keys -l -t %0"
         client.throwOnCommandRemaining = 1
         val first = async { vm.sendAgentPayloadToPaneResult("%0", "restart the worker pool", AgentKind.ClaudeCode, "s-restart") }
         advanceUntilIdle()
         assertTrue(first.await().isFailure)
 
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 0L, output = listOf("$ "), isError = false),
+        )
+        client.capturePaneResponses.addLast(
+            CommandResponse(
+                number = 0L,
+                output = listOf("> restart the worker pool"),
+                isError = false,
+            ),
+        )
         val second = async { vm.sendAgentPayloadToPaneResult("%0", "restart the worker pool", AgentKind.ClaudeCode, "s-restart") }
         advanceUntilIdle()
         assertTrue(second.await().isSuccess)

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
@@ -97,12 +97,21 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
         val store = SharedPrefsOutboundQueueStore(context)
         val row = store.enqueue("sessGoal", payload, paneId = "%0", route = OutboundRoute.AgentPayload)
         store.markInFlight(row.id)
+        val durableRow = DurableOutboundRowIdentity("sessGoal", row.id)
 
         // The Codex pane permanently advertises the command it wants sent.
         val client = clientShowing("gpt-5.6-sol medium · Context 42% · Goal blocked (/goal resume)")
         val vm = newDurableConnectedVm(client)
 
-        val result = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        val result = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.Codex,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue("the send reports success either way (the drop is silent)", result.await().isSuccess)
 
@@ -125,11 +134,19 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
         val store = SharedPrefsOutboundQueueStore(context)
         val row = store.enqueue("sessEcho", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
         store.markInFlight(row.id)
+        val durableRow = DurableOutboundRowIdentity("sessEcho", row.id)
 
         val client = clientShowing("Goal blocked (/goal resume)")
         val vm = newDurableConnectedVm(client)
 
-        val result = async { vm.sendToAgentPaneResult("%0", payload) }
+        val result = async {
+            vm.sendToAgentPaneResult(
+                "%0",
+                payload,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(result.await().isSuccess)
 
@@ -151,12 +168,21 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
         val store = SharedPrefsOutboundQueueStore(context)
         val row = store.enqueue("sessOk", payload, paneId = "%0", route = OutboundRoute.AgentPayload)
         store.markInFlight(row.id)
+        val durableRow = DurableOutboundRowIdentity("sessOk", row.id)
 
         // "ok" is already visible (e.g. echoed in the transcript / a prior line).
         val client = clientShowing("> ok, running the smoke suite")
         val vm = newDurableConnectedVm(client)
 
-        val result = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        val result = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.Codex,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue(result.await().isSuccess)
 
@@ -180,6 +206,7 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
         val store = SharedPrefsOutboundQueueStore(context)
         val row = store.enqueue("sessDedupe", payload, paneId = "%0", route = OutboundRoute.AgentPayload)
         store.markInFlight(row.id)
+        val durableRow = DurableOutboundRowIdentity("sessDedupe", row.id)
 
         // The unit VM has no attached emulator render, so the pre-send baseline is 0
         // (the payload is not on the local render) and NO baseline capture round-trip
@@ -191,14 +218,30 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
         // Attempt 1: the paste lands, the submit Enter's exec result is lost.
         client.throwOnCommandPrefix = "send-keys -t %0 Enter"
         client.throwOnCommandRemaining = 1
-        val first = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        val first = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.Codex,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue("attempt 1 must surface the ambiguous failure", first.await().isFailure)
         assertEquals("attempt 1 pastes exactly once", 1, client.literalPasteCount(payload))
 
         // The resend (reconnect auto-flush / manual retry) probes: count (1) exceeds
         // the baseline (0) ⇒ AlreadyLanded ⇒ Enter-only, NO second paste.
-        val second = async { vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.Codex) }
+        val second = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.Codex,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
         advanceUntilIdle()
         assertTrue("the verified resend must succeed", second.await().isSuccess)
         assertEquals(

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -194,7 +194,7 @@ class PartialBlackPaneHealTest {
 
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
-        neutralizeSubmitAckGate(vm, client)
+        neutralizeSubmitAckGate(vm, client, "hello agent")
 
         // The send succeeds; the agent then overpaints the pane to partial-black
         // (a `clear`+one-line redraw) — the maintainer's "sent a message -> black".
@@ -247,7 +247,7 @@ class PartialBlackPaneHealTest {
 
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
-        neutralizeSubmitAckGate(vm, client)
+        neutralizeSubmitAckGate(vm, client, "ls -la")
 
         // A clear-only overpaint wipes the pane FULLY black.
         pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
@@ -290,7 +290,7 @@ class PartialBlackPaneHealTest {
 
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
-        neutralizeSubmitAckGate(vm, client)
+        neutralizeSubmitAckGate(vm, client, "another prompt")
 
         // A normal multi-line agent response: a DENSE viewport (well over half the 40 rows
         // live) -> neither blank, nor partial-black, nor sparse-half-black
@@ -445,7 +445,7 @@ class PartialBlackPaneHealTest {
 
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
-        neutralizeSubmitAckGate(vm, client)
+        neutralizeSubmitAckGate(vm, client, WITH_ATTACHMENT_PAYLOAD)
 
         // The send's overpaint leaves the pane HALF-black (>3 live lines, large black band).
         overpaintAltScreenHalfBlack(pane)
@@ -500,7 +500,11 @@ class PartialBlackPaneHealTest {
 
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
-        neutralizeSubmitAckGate(vm, client)
+        neutralizeSubmitAckGate(
+            vm,
+            client,
+            "first line of the prompt\nsecond line of the prompt",
+        )
 
         overpaintAltScreenHalfBlack(pane)
         assertFalse(pane.terminalState.visibleScreenIsPartiallyBlank())
@@ -718,17 +722,25 @@ class PartialBlackPaneHealTest {
         sentCommands.count { it.startsWith("capture-pane") && it.contains(" -e") }
 
     /**
-     * Neutralize the #869 submit-ack gate so its `capture-pane -p -t` poll does not
-     * consume the heal's queued recovery frame or skew the heal-capture count: set a
-     * zero floor + a single-poll timeout, and queue ONE dummy ack frame (no needle
-     * match -> the poll misses and falls through immediately). The heal's
-     * `capture-pane -p -e` frame stays separately queued for the heal to consume.
+     * Satisfy the #869 submit-ack gate with real ingestion evidence so its
+     * `capture-pane -p -t` poll does not consume the heal's queued recovery frame
+     * or skew the heal-capture count. Issue #1739 deliberately removed the old
+     * no-match fallback because it blindly submitted Enter.
      */
-    private fun neutralizeSubmitAckGate(vm: TmuxSessionViewModel, client: FakeTmuxClient) {
+    private fun neutralizeSubmitAckGate(
+        vm: TmuxSessionViewModel,
+        client: FakeTmuxClient,
+        payload: String,
+    ) {
         vm.setAgentSubmitEnterDelayForTest(0)
         vm.setAgentSubmitAckTimeoutForTest(AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
+        val ackOutput = if (agentSubmitPayloadIsMultiLine(payload)) {
+            listOf("[Pasted text #1 +2 lines]")
+        } else {
+            listOf("> $payload")
+        }
         client.capturePaneResponses.addLast(
-            CommandResponse(number = 50L, output = listOf("ack-poll-no-match"), isError = false),
+            CommandResponse(number = 50L, output = ackOutput, isError = false),
         )
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentSendTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentSendTest.kt
@@ -153,6 +153,8 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
     fun sendToAgentPaneAppendsOptimisticMessageAndWritesCarriageReturn() = runTest(scheduler) {
         val vm = newVm()
         val client = FakeTmuxClient()
+        client.defaultCaptureResponse =
+            CommandResponse(number = 0L, output = listOf("> run tests"), isError = false)
         vm.attachClientForTest(client)
         vm.startAgentConversationForTest("%0", newClaudeDetection())
 
@@ -391,7 +393,7 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
      * prior paste) must NOT false-confirm; only OUR chip (a count increase) does.
      * Here the pane permanently shows `[Pasted text #1 +9 lines]` and NEVER renders
      * a new chip, so the ack must poll past the first capture (no instant match) and
-     * fall back — not fire on the pre-existing chip.
+     * resolve unconfirmed without Enter — not fire on the pre-existing chip.
      */
     @Test
     fun collapsedChipAlreadyOnPaneDoesNotFalseConfirm() = runTest(scheduler) {
@@ -421,12 +423,16 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         val send = async { vm.sendToAgentPaneResult("%0", payload) }
         advanceUntilIdle()
 
-        assertTrue("send still completes via the bounded fallback", send.await().isSuccess)
+        assertTrue("unconfirmed chip count must resolve as failure", send.await().isFailure)
         assertTrue(
             "a pre-existing collapsed chip must NOT instant-confirm the ack — the gate " +
-                "must poll past the first capture to the fallback (polls=" +
+                "must poll past the first capture to the deadline (polls=" +
                 "${client.capturePaneTextViaExecCalls.size})",
             client.capturePaneTextViaExecCalls.size > 2,
+        )
+        assertFalse(
+            "a pre-existing chip never authorizes blind Enter",
+            client.sentCommands.contains("send-keys -t %0 Enter"),
         )
     }
 
@@ -566,13 +572,13 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
     }
 
     /**
-     * Issue #869: when the agent's input rendering can never be recognised (the
-     * payload never shows up in `capture-pane`), Send must NOT hang — it falls
-     * back to pressing Enter after the bounded ack timeout (the pre-#869 blind
-     * behaviour as the worst case, never a deadlock).
+     * Issue #1739: absence of acknowledgement is ambiguous: the paste may have
+     * landed, but there is no identity-safe proof that Enter belongs to this
+     * client/session/pane. Resolve the attempt at the bounded deadline and keep
+     * it retryable; never turn a marker miss into a blind Enter.
      */
     @Test
-    fun sendToAgentPaneFallsBackToSubmitEnterAfterAckTimeout() = runTest(scheduler) {
+    fun sendToAgentPaneMarkerAbsentResolvesBoundedWithoutBlindEnter() = runTest(scheduler) {
         val vm = newVm()
         val client = FakeTmuxClient()
         vm.attachClientForTest(client)
@@ -598,11 +604,10 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         )
 
         advanceUntilIdle()
-        assertTrue("submit must not hang — it falls back after the timeout", send.await().isSuccess)
+        assertTrue("unconfirmed paste must resolve as a retryable failure", send.await().isFailure)
         assertEquals(
             listOf(
                 "send-keys -l -t %0 -- 'never-rendered prompt'",
-                "send-keys -t %0 Enter",
             ),
             client.sentCommands.filter { it.startsWith("send-keys") },
         )
@@ -612,8 +617,8 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
      * Codex input-freeze follow-up: a Codex/agent output storm can wedge the
      * `capture-pane` command the submit ack gate uses to confirm the paste
      * landed. The ack timeout must bound the WHOLE capture loop, including a
-     * single stuck capture command, so typing never parks forever before the
-     * submit Enter.
+     * single stuck capture command. An unconfirmed paste remains ambiguous, so
+     * the bounded result is failure without a submit Enter.
      */
     @Test
     fun sendToAgentPaneAckTimeoutBoundsStuckCaptureCommand() = runTest(scheduler) {
@@ -636,7 +641,7 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         )
 
         advanceUntilIdle()
-        assertTrue("stuck capture must fall back instead of hanging Send", send.await().isSuccess)
+        assertTrue("stuck capture must fail bounded instead of hanging Send", send.await().isFailure)
         assertEquals(
             "a stuck ack capture should be tried once, then cancelled by the wall-clock timeout",
             1,
@@ -645,94 +650,222 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         assertEquals(
             listOf(
                 "send-keys -l -t %0 -- 'blocked capture prompt'",
-                "send-keys -t %0 Enter",
             ),
             client.sentCommands.filter { it.startsWith("send-keys") },
         )
     }
 
     /**
-     * Issue #869 (reviewer BLOCKED-G4 follow-up): the needle-miss FALLBACK must
-     * NOT degrade to the pre-#869 short floor — that short delay IS the
-     * maintainer's missed-submit symptom. When the ack is never observed (an
-     * unrecognised / reflowed input box the needle can't match) the submit Enter
-     * must be held to an ADEQUATE working floor:
-     *   max(configuredFloor, AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS + measuredRtt).
+     * Issue #1739 regression-first reproduction of the preserved #1733 hang.
+     * RealSshSession cancellation enters a NonCancellable close on the
+     * serialized TransportDispatcher. A structured `withTimeout` therefore
+     * waits for teardown and leaves the durable row InFlight indefinitely.
      *
-     * This test injects a known per-`capture-pane` RTT and a ZERO configured
-     * floor (so neither the Codex floor nor the #526 setting masks the assertion)
-     * and proves the Enter does NOT fire until at least
-     * `AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS + injectedRtt` of virtual time has
-     * elapsed since the gate started — i.e. the worst case is a working delay,
-     * proportionally larger under latency, never the 150ms that raced.
-     *
-     * RED (pre-hardening): the fallback returns after only the short floor, so
-     * the Enter is present well before FALLBACK_FLOOR + RTT → the
-     * "not pressed before the adequate floor" assertion fails.
-     * GREEN (hardened): the Enter is held until the adequate floor elapses.
+     * RED on current main: at 80ms [send] is still incomplete because the
+     * timeout is waiting on [nonCancellableCaptureTeardownGate].
+     * GREEN: the capture runs in a detached, invalidatable attempt; the caller
+     * returns failure at 80ms, cancels cleanup without joining it, and never
+     * presses Enter.
      */
     @Test
-    fun sendToAgentPaneFallbackHoldsEnterForAdequateFloorPlusRttOnNeedleMiss() =
+    fun sendToAgentPaneDeadlineDoesNotJoinNonCancellableCaptureTeardown() =
         runTest(scheduler) {
             val vm = newVm()
             val client = FakeTmuxClient()
-            // Read the runTest virtual clock so the gate's RTT measurement +
-            // fallback-floor top-up are deterministic (SystemClock reads 0 here).
-            vm.setAgentSubmitMonotonicClockForTest { scheduler.currentTime }
+            val teardownGate = kotlinx.coroutines.CompletableDeferred<Unit>()
+            client.nonCancellableCaptureTeardownGate = teardownGate
             vm.attachClientForTest(client)
             vm.startAgentConversationForTest("%0", newClaudeDetection())
-            // Zero configured floor so the fallback floor is the only thing
-            // gating the Enter (not the #526 setting / Codex floor).
             vm.setAgentSubmitEnterDelayForTest(0)
-            // SHORT poll window so the incidental poll-loop duration is BELOW the
-            // fallback floor — making the floor (not the loop) the binding
-            // constraint, so this is a genuine red→green of the floor itself.
-            vm.setAgentSubmitAckTimeoutForTest(80L) // 2 polls at 40ms
+            vm.setAgentSubmitAckTimeoutForTest(80L)
 
-            val injectedRttMs = 20L
-            client.captureCommandDelayMs = injectedRttMs
-            // Every capture comes back WITHOUT the payload — the needle never
-            // matches (a reflowed/unrecognised input box).
-            repeat(200) {
-                client.capturePaneResponses.addLast(
-                    CommandResponse(number = 0L, output = listOf("> "), isError = false),
+            val send = async {
+                vm.sendAgentPayloadToPaneResult(
+                    "%0",
+                    "post reconnect blocked capture",
+                    AgentKind.ClaudeCode,
+                    "issue-1739-stuck-capture",
                 )
             }
 
-            val gateStart = scheduler.currentTime
-            // Record the virtual-clock instant the submit Enter reaches the wire.
-            var enterSentAtMs: Long = -1L
-            client.onCommandSent = { cmd ->
-                if (cmd == "send-keys -t %0 Enter" && enterSentAtMs < 0L) {
-                    enterSentAtMs = scheduler.currentTime
-                }
+            try {
+                advanceTimeBy(80L)
+                runCurrent()
+                assertTrue(
+                    "the ack deadline must resolve without joining non-cancellable SSH exec teardown",
+                    send.isCompleted,
+                )
+                assertTrue("the ambiguous send must remain retryable", send.await().isFailure)
+                assertFalse(
+                    "an unconfirmed capture must never authorize Enter",
+                    client.sentCommands.contains("send-keys -t %0 Enter"),
+                )
+            } finally {
+                teardownGate.complete(Unit)
+                advanceUntilIdle()
             }
-            val send = async { vm.sendToAgentPaneResult("%0", "never-matched prompt") }
+        }
 
-            // The adequate floor: the Enter must NOT have fired before this.
-            val adequateFloorMs =
-                com.pocketshell.app.settings.AppSettings.AGENT_SUBMIT_ACK_FALLBACK_FLOOR_MS +
-                    injectedRttMs
-            advanceUntilIdle()
-            assertTrue(
-                "fallback submit must have fired (no hang)",
-                send.await().isSuccess,
-            )
-            // The Enter was eventually pressed.
-            assertTrue(
-                "fallback must press the submit Enter",
-                client.sentCommands.contains("send-keys -t %0 Enter"),
-            )
-            // Load-bearing: the submit Enter fired only AFTER the adequate floor
-            // (FALLBACK_FLOOR + injectedRtt) elapsed — never the old short delay.
-            val enterAtMs = enterSentAtMs - gateStart
-            assertTrue(
-                "needle-miss fallback must hold the submit Enter for at least the " +
-                    "adequate floor (FALLBACK_FLOOR + measuredRtt = ${adequateFloorMs}ms); " +
-                    "Enter fired after only ${enterAtMs}ms",
-                enterAtMs >= adequateFloorMs,
+    @Test
+    fun retryAfterUnconfirmedAckVerifiesLandedPasteThenSendsEnterOnly() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(80L)
+        val payload = "verify me after reconnect\nthrough the collapsed chip\nwithout a duplicate paste"
+        val token = "issue-1739-exactly-once"
+
+        val first = async {
+            vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode, token)
+        }
+        advanceUntilIdle()
+        assertTrue("the first unconfirmed attempt remains retryable", first.await().isFailure)
+        assertFalse(client.sentCommands.contains("send-keys -t %0 Enter"))
+
+        // The paste did land despite the lost acknowledgement. The durable
+        // attempt's retry must prove that fact and complete with Enter-only.
+        val landedChip = CommandResponse(
+            number = 0L,
+            output = listOf("> [Pasted text #1 +2 lines]"),
+            isError = false,
+        )
+        client.scrollbackCaptureResponse = landedChip
+        client.defaultCaptureResponse = landedChip
+        val retry = async {
+            vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode, token)
+        }
+        advanceUntilIdle()
+
+        assertTrue("verified retry should complete", retry.await().isSuccess)
+        assertEquals(
+            "collapsed payload is pasted exactly once",
+            1,
+            client.sentCommands.count { it.startsWith("paste-buffer ") },
+        )
+        assertEquals(
+            "verified retry submits exactly one Enter",
+            1,
+            client.sentCommands.count { it == "send-keys -t %0 Enter" },
+        )
+    }
+
+    @Test
+    fun clientSwapDuringAckInvalidatesLateCaptureWithoutEnter() = runTest(scheduler) {
+        val vm = newVm()
+        val oldClient = FakeTmuxClient()
+        vm.attachClientForTest(oldClient)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(80L)
+        oldClient.captureCommandDelayMs = 20L
+        oldClient.capturePaneResponses.addLast(
+            CommandResponse(number = 0L, output = listOf("> swap guarded"), isError = false),
+        )
+
+        val send = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                "swap guarded",
+                AgentKind.ClaudeCode,
+                "issue-1739-client-swap",
             )
         }
+        runCurrent()
+        vm.attachClientForTest(FakeTmuxClient())
+        advanceUntilIdle()
+
+        assertTrue("superseded-client ack must fail", send.await().isFailure)
+        assertFalse(
+            "a capture returned by the old client must never authorize Enter",
+            oldClient.sentCommands.contains("send-keys -t %0 Enter"),
+        )
+    }
+
+    @Test
+    fun disconnectDuringAckInvalidatesCaptureWithoutEnter() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(80L)
+        client.captureCommandDelayMs = 20L
+        client.capturePaneResponses.addLast(
+            CommandResponse(number = 0L, output = listOf("> drop guarded"), isError = false),
+        )
+
+        val send = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                "drop guarded",
+                AgentKind.ClaudeCode,
+                "issue-1739-drop",
+            )
+        }
+        runCurrent()
+        client.disconnectedSignal.value = true
+        advanceUntilIdle()
+
+        assertTrue("drop during acknowledgement must fail", send.await().isFailure)
+        assertFalse(client.sentCommands.contains("send-keys -t %0 Enter"))
+    }
+
+    @Test
+    fun callerCancellationDoesNotJoinCaptureCleanupOrSendEnter() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        val teardownGate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        client.nonCancellableCaptureTeardownGate = teardownGate
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+
+        val send = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                "cancel guarded",
+                AgentKind.ClaudeCode,
+                "issue-1739-cancel",
+            )
+        }
+        try {
+            runCurrent()
+            send.cancel()
+            runCurrent()
+            assertTrue(
+                "caller cancellation must complete without joining non-cancellable capture cleanup",
+                send.isCompleted,
+            )
+            assertTrue(send.isCancelled)
+            assertFalse(client.sentCommands.contains("send-keys -t %0 Enter"))
+        } finally {
+            teardownGate.complete(Unit)
+            advanceUntilIdle()
+        }
+    }
+
+    @Test
+    fun foreignPaneIsRejectedBeforePasteOrEnter() = runTest(scheduler) {
+        val vm = newVm()
+        val client = FakeTmuxClient()
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%foreign",
+            "wrong pane",
+            AgentKind.ClaudeCode,
+            "issue-1739-foreign-pane",
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(
+            "foreign pane must receive neither payload nor Enter",
+            client.sentCommands.none { it.startsWith("send-keys") },
+        )
+    }
 
     /**
      * Issue #869 (reviewer BLOCKED-G4 follow-up): the load-bearing needle-vs-
@@ -817,6 +950,57 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
     }
 
     @Test
+    fun lateAckFromPreviousSessionCannotAuthorizeEnterAfterTargetOnlySwap() = runTest(scheduler) {
+        val payload = "do not submit this into the next session"
+        val client = FakeTmuxClient().apply {
+            captureCommandDelayMs = 200L
+            defaultCaptureResponse = CommandResponse(
+                number = 0L,
+                output = listOf("> $payload"),
+                isError = false,
+            )
+        }
+        val vm = newVm()
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "session-a",
+            client = client,
+        )
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(500)
+
+        val clientIdentity = vm.currentClientIdentityForTest()
+        val generation = vm.currentConnectGenerationForTest()
+        val send = async { vm.sendToAgentPaneResult("%0", payload) }
+        runCurrent()
+
+        assertEquals(
+            "precondition: the old session received exactly one paste before ack capture suspended",
+            listOf("send-keys -l -t %0 -- '${payload.replace("'", "'\\''")}'"),
+            client.sentCommands.filter { it.startsWith("send-keys") },
+        )
+
+        vm.swapActiveSessionTargetForTest("session-b")
+        assertEquals("the target-only seam must retain the exact client", clientIdentity, vm.currentClientIdentityForTest())
+        assertEquals("the target-only seam must retain the generation", generation, vm.currentConnectGenerationForTest())
+
+        advanceUntilIdle()
+
+        assertTrue("late evidence from session A must fail the send after session B becomes current", send.await().isFailure)
+        assertEquals(
+            "a stale capture must authorize neither a second paste nor Enter in the new session",
+            listOf("send-keys -l -t %0 -- '${payload.replace("'", "'\\''")}'"),
+            client.sentCommands.filter { it.startsWith("send-keys") },
+        )
+    }
+
+    @Test
     fun codexSendInFlightSurvivesTerminalOverflowWithoutReconnectOrDuplicateSend() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(0)
         val registry = ActiveTmuxClients()
@@ -826,6 +1010,12 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
             sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
         )
         val client = FakeTmuxClient()
+        client.captureCommandDelayMs = 40L
+        client.defaultCaptureResponse = CommandResponse(
+            number = 0L,
+            output = listOf("> previous user prompt"),
+            isError = false,
+        )
         vm.replaceClientForTest(
             hostId = 7L,
             hostName = "alpha",
@@ -912,7 +1102,7 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
     }
 
     @Test
-    fun agentSubmitDelaysFinalEnterByConfiguredDelayForClaudeCode() = runTest(scheduler) {
+    fun bareAgentSubmitDelaysEnterByConfiguredDelayForClaudeCode() = runTest(scheduler) {
         // Issue #526: the composer/agent send path types the message text,
         // waits the user-configurable delay, then presses the submit Enter as
         // a SEPARATE send-keys so the Enter can't race ahead of the agent
@@ -924,14 +1114,21 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         vm.startAgentConversationForTest("%0", newClaudeDetection())
         vm.setAgentSubmitEnterDelayForTest(200)
 
-        val send = async { vm.sendToAgentPaneResult("%0", "  run tests  ") }
+        val send = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                "",
+                AgentKind.ClaudeCode,
+                "bare-enter-delay",
+            )
+        }
         runCurrent()
 
-        // Text is typed immediately; the submit Enter must NOT have been sent
-        // yet — it waits out the configured delay first.
+        // A bare submit has no paste to acknowledge, so it must wait the
+        // configured floor before Enter.
         assertEquals(
-            "Send should type the prompt before waiting to press Enter",
-            listOf("send-keys -l -t %0 -- 'run tests'"),
+            "bare submit must wait before pressing Enter",
+            emptyList<String>(),
             client.sentCommands.filter { it.startsWith("send-keys") },
         )
 
@@ -939,7 +1136,7 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         runCurrent()
         assertEquals(
             "Submit Enter must not fire before the configured delay elapses",
-            listOf("send-keys -l -t %0 -- 'run tests'"),
+            emptyList<String>(),
             client.sentCommands.filter { it.startsWith("send-keys") },
         )
 
@@ -947,10 +1144,7 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         assertTrue(send.await().isSuccess)
         assertEquals(
             "After the configured delay the submit Enter fires as a separate key",
-            listOf(
-                "send-keys -l -t %0 -- 'run tests'",
-                "send-keys -t %0 Enter",
-            ),
+            listOf("send-keys -t %0 Enter"),
             client.sentCommands.filter { it.startsWith("send-keys") },
         )
     }
@@ -1279,7 +1473,22 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         val scenarioScope = newReconnectScenarioScope()
         val registry = ActiveTmuxClients()
         val connector = QueueLeaseConnector(FakeSshSession())
-        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%0")
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%0").apply {
+            defaultCaptureResponse = CommandResponse(
+                number = 0L,
+                output = listOf("> work ready"),
+                isError = false,
+            )
+            onCommandSent = { command ->
+                if (command == "send-keys -l -t %0 -- 'codex terminal send'") {
+                    defaultCaptureResponse = CommandResponse(
+                        number = 0L,
+                        output = listOf("> codex terminal send"),
+                        isError = false,
+                    )
+                }
+            }
+        }
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(
@@ -1402,7 +1611,22 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         val scenarioScope = newReconnectScenarioScope()
         val registry = ActiveTmuxClients()
         val connector = QueueLeaseConnector(FakeSshSession())
-        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%0")
+        val reconnectClient = FakeTmuxClient().withSinglePane("work", "%0").apply {
+            defaultCaptureResponse = CommandResponse(
+                number = 0L,
+                output = listOf("> work ready"),
+                isError = false,
+            )
+            onCommandSent = { command ->
+                if (command == "send-keys -l -t %0 -- 'send after return'") {
+                    defaultCaptureResponse = CommandResponse(
+                        number = 0L,
+                        output = listOf("> send after return"),
+                        isError = false,
+                    )
+                }
+            }
+        }
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(
@@ -1607,7 +1831,10 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
         vm.appendAgentEventsForTest("%0", listOf(failed))
 
         // Bring up a live client and retry.
-        val client = FakeTmuxClient()
+        val client = FakeTmuxClient().apply {
+            defaultCaptureResponse =
+                CommandResponse(number = 0L, output = listOf("> retry me"), isError = false)
+        }
         vm.attachClientForTest(client)
         vm.retryFailedAgentSend("%0", failed.id)
         advanceUntilIdle()


### PR DESCRIPTION
Closes #1739

## Summary
- detach and bound agent paste acknowledgement capture so cancelled SSH cleanup cannot wedge the durable queue
- key wire-attempt recovery by exact session and durable row identity, with immutable client/generation/session checks
- verify collapsed or literal paste evidence before Enter-only recovery; never blindly repaste or press Enter
- add non-vacuous real-Docker and launch-owned reconnect regressions with authoritative terminal artifacts

## Validation
- independent reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1739#issuecomment-5075561177
- reviewer full JVM: 11,284 tests, 0 skipped/failures/errors; 603/603 tasks executed
- reviewer Docker hard-fail, real green, structural mutant timeout-red, restored green
- reviewer connected methods: 2/2 green with pending/final 1080x2400 viewport inspection
- orchestrator final: assembleDebug + six focused classes, 96 tests green, 281/281 tasks executed
- test-validity, file-size, VM ratchet, journey harness, diff, and dex-register-pressure gates green