### PR TITLE
ci: bound journey retry to remaining job wall (#1458)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,6 +201,15 @@ jobs:
           chmod +x scripts/test-ci-journey-aggregate-verdict.sh
           scripts/test-ci-journey-aggregate-verdict.sh
 
+      # Issue #1458: the 95-minute emulator job must not start a second cold boot
+      # when the first attempt has already consumed the wall needed for a full
+      # retry plus classifier/artifact teardown. Deterministic millisecond
+      # boundary fixtures cover allowed/denied and malformed-clock paths.
+      - name: CI journey cold-boot retry-budget guard (issue #1458)
+        run: |
+          chmod +x scripts/ci-journey-retry-budget.sh scripts/test-ci-journey-retry-budget.sh
+          scripts/test-ci-journey-retry-budget.sh
+
       # Issue #1293: fast, JVM-free fixture test for the nightly-fault per-phase
       # test-report preservation helper (scripts/lib/nightly-phase-reports.sh).
       # The nightly-fault suite runs each phase as a separate connected-test
@@ -534,6 +543,12 @@ jobs:
     timeout-minutes: 95
 
     steps:
+      # Issue #1458: capture the job wall clock before setup so the later retry
+      # decision uses one absolute 95-minute deadline. A per-step/suite timer
+      # would miss setup + first cold-boot time and recreate the cancellation.
+      - name: Record emulator-journey job start
+        run: echo "JOURNEY_JOB_START_EPOCH_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -993,13 +1008,31 @@ jobs:
             echo "No Android connected-test output directories existed after the first attempt." > "$snapshot/android-test-outputs-missing.txt"
           fi
 
+      # Issue #1458: the first attempt can consume 50–62 minutes, leaving too
+      # little of the absolute 95-minute job wall for an unconditional second
+      # cold boot. Require the full documented retry reserve:
+      #   900s shutdown/cold-boot/readiness + 4200s selected suite
+      #   + 300s classifier/log/artifact/teardown = 5400s.
+      # Missing/malformed job-start evidence fails safe to retry_allowed=false;
+      # the classifier then writes typed INFRA evidence instead of letting
+      # GitHub cancel the matrix child before artifacts can upload.
+      - name: Check remaining job wall before journey retry
+        id: journey_retry_budget
+        if: always()
+        run: |
+          chmod +x scripts/ci-journey-retry-budget.sh
+          scripts/ci-journey-retry-budget.sh \
+            "${JOURNEY_JOB_START_EPOCH_MS:-}" \
+            "$(date +%s%3N)" | tee -a "$GITHUB_OUTPUT"
+
       # Infra-retry-once: runs if the first bringup failed with a boot/adb abort
       # or a genuine test failure. It is deliberately skipped for a pure
-      # suite-budget timeout because the first cold boot already consumed the
-      # available job budget and wrote the classifier artifact.
+      # suite-budget timeout, and whenever the absolute job deadline cannot fit
+      # a complete retry plus teardown. Genuine first-attempt failure evidence
+      # remains authoritative in the classifier even when retry is denied.
       - name: Retry journey subset on a fresh cold-booted emulator
         id: journey_retry
-        if: steps.journey.outcome == 'failure' && steps.journey_summary.outputs.first_timeout != 'true'
+        if: steps.journey.outcome == 'failure' && steps.journey_summary.outputs.first_timeout != 'true' && steps.journey_retry_budget.outputs.retry_allowed == 'true'
         continue-on-error: true
         # Issue #771: same v2.37.0 pin as the first attempt (see note above).
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
@@ -1078,6 +1111,10 @@ jobs:
           retry_concl="${{ steps.journey_retry.conclusion }}"
           first_timeout="${{ steps.journey_summary.outputs.first_timeout }}"
           first_failure="${{ steps.journey_summary.outputs.first_failure }}"
+          retry_allowed="${{ steps.journey_retry_budget.outputs.retry_allowed }}"
+          retry_reason="${{ steps.journey_retry_budget.outputs.retry_reason }}"
+          retry_remaining_ms="${{ steps.journey_retry_budget.outputs.retry_remaining_ms }}"
+          retry_required_ms="${{ steps.journey_retry_budget.outputs.retry_required_ms }}"
           summary="artifacts/ci-journey/summary.md"
           # Issue #1458: record this shard's verdict token for the aggregation
           # job. CLEAN = passed; INFRA = environmental (storm / #470 cancel /
@@ -1112,6 +1149,9 @@ jobs:
           echo "retry attempt conclusion:  ${retry_concl:-<skipped>}"
           echo "first summary timeout-only: ${first_timeout:-false}"
           echo "first summary genuine failure: ${first_failure:-false}"
+          echo "cold-boot retry allowed: ${retry_allowed:-false}"
+          echo "cold-boot retry reason: ${retry_reason:-missing_decision}"
+          echo "cold-boot retry remaining/required: ${retry_remaining_ms:-0}/${retry_required_ms:-5400000}ms"
           if [[ "$first" == "success" ]]; then
             echo "Emulator journey passed on the first cold boot."
             write_verdict CLEAN
@@ -1137,6 +1177,17 @@ jobs:
             echo "::error title=Emulator journey TIMEOUT — load-bearing classes cut short (#835/#470)::The journey suite booted and ran, but exhausted its own 4200s time budget before every load-bearing class reached a verdict (issue #835 / #470). This is now a HARD RED durable guard (#835 REOPENED, D31): a budget timeout means a load-bearing class was silently cut short, which used to be masked as advisory-green. The retry is skipped because a budget timeout is deterministic. Either the enumeration stall has returned or the selection no longer fits the budget — investigate; do NOT treat as a flake. Class(es) cut short / not run:"
             [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
             write_verdict RED
+            exit 1
+          fi
+          # Issue #1458: no trustworthy first-attempt verdict and insufficient
+          # absolute job wall for a complete retry. Do not start a cold boot that
+          # GitHub will cancel at 95m; emit typed INFRA evidence now so classifier,
+          # logs, shard-token upload, and teardown can reach terminal completion.
+          # Healthy-console first_failure and #835 first_timeout branches above
+          # retain their existing RED semantics.
+          if [[ "${retry_allowed:-false}" != "true" ]]; then
+            echo "::warning title=Emulator journey retry skipped — insufficient remaining job wall::The first attempt did not produce a clean verdict, but a complete fresh-cold-boot retry no longer fits before the absolute 95-minute job deadline (reason=${retry_reason:-missing_decision}, remaining=${retry_remaining_ms:-0}ms, required=${retry_required_ms:-5400000}ms). The retry was not started; this shard is typed INFRA so aggregation requests RE-RUN, while classifier and artifacts retain time to finish (issue #1458)."
+            write_verdict INFRA
             exit 1
           fi
           # If a cold-boot attempt was cancelled, do not trust summary.md for a

--- a/scripts/ci-journey-retry-budget.sh
+++ b/scripts/ci-journey-retry-budget.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Issue #1458: decide whether the emulator-journey job has enough absolute wall
+# budget left to start a second fresh cold boot.
+#
+# The GitHub job cap is 95 minutes. A retry is allowed only when the remaining
+# wall covers the full worst-case retry path:
+#   900s emulator shutdown/cold-boot/readiness
+# + 4200s selected journey-suite budget
+# + 300s classifier, Docker logs, artifact upload, and fixture teardown
+# = 5400s minimum remaining.
+#
+# Usage:
+#   ci-journey-retry-budget.sh JOB_START_EPOCH_MS NOW_EPOCH_MS
+#
+# Output is GitHub-step-output-compatible key=value lines. Invalid/missing clock
+# input fails safe by denying the retry while returning success, so the workflow
+# can continue to its typed INFRA classifier and artifact steps.
+set -uo pipefail
+
+readonly JOURNEY_JOB_CAP_MS=5700000
+readonly JOURNEY_RETRY_REQUIRED_MS=5400000
+readonly MAX_SIGNED_INT64_DECIMAL=9223372036854775807
+
+emit_decision() {
+  local allowed="$1" reason="$2" remaining="$3"
+  printf 'retry_allowed=%s\n' "$allowed"
+  printf 'retry_reason=%s\n' "$reason"
+  printf 'retry_remaining_ms=%s\n' "$remaining"
+  printf 'retry_required_ms=%s\n' "$JOURNEY_RETRY_REQUIRED_MS"
+}
+
+# decimal_greater_than <canonical-decimal-a> <canonical-decimal-b>
+#
+# Compare validated, non-negative canonical decimal strings without shell
+# arithmetic. This is safe even at INT64_MAX and is used before parsing either
+# untrusted epoch.
+decimal_greater_than() {
+  local left="$1" right="$2"
+  if (( ${#left} != ${#right} )); then
+    (( ${#left} > ${#right} ))
+    return
+  fi
+  [[ "$left" > "$right" ]]
+}
+
+epoch_out_of_range() {
+  local value="$1"
+  decimal_greater_than "$value" "$MAX_SIGNED_INT64_DECIMAL"
+}
+
+journey_retry_budget_decision() {
+  local start="${1-}" now="${2-}"
+
+  if [[ -z "$start" ]]; then
+    emit_decision false missing_job_start 0
+    return 0
+  fi
+  if [[ ! "$start" =~ ^[0-9]+$ ]]; then
+    emit_decision false malformed_job_start 0
+    return 0
+  fi
+  if [[ "$start" != "0" && "$start" == 0* ]]; then
+    emit_decision false noncanonical_job_start 0
+    return 0
+  fi
+  if epoch_out_of_range "$start"; then
+    emit_decision false out_of_range_job_start 0
+    return 0
+  fi
+  if [[ ! "$now" =~ ^[0-9]+$ ]]; then
+    emit_decision false malformed_now 0
+    return 0
+  fi
+  if [[ "$now" != "0" && "$now" == 0* ]]; then
+    emit_decision false noncanonical_now 0
+    return 0
+  fi
+  if epoch_out_of_range "$now"; then
+    emit_decision false out_of_range_now 0
+    return 0
+  fi
+  if decimal_greater_than "$start" "$now"; then
+    emit_decision false future_job_start 0
+    return 0
+  fi
+
+  # Both values are now canonical base-10 decimals in signed-64 range and
+  # now >= start. Parse explicitly as base 10, then compute in overflow-safe
+  # order: elapsed first, followed by cap - elapsed only while elapsed < cap.
+  # Never form start + cap, which can overflow near INT64_MAX.
+  local start_value now_value elapsed remaining
+  start_value=$((10#$start))
+  now_value=$((10#$now))
+  elapsed=$((now_value - start_value))
+  if (( elapsed >= JOURNEY_JOB_CAP_MS )); then
+    remaining=0
+  else
+    remaining=$((JOURNEY_JOB_CAP_MS - elapsed))
+  fi
+
+  if (( remaining >= JOURNEY_RETRY_REQUIRED_MS )); then
+    emit_decision true sufficient_remaining_budget "$remaining"
+  else
+    emit_decision false insufficient_remaining_budget "$remaining"
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  journey_retry_budget_decision "${1-}" "${2-}"
+fi

--- a/scripts/test-ci-journey-retry-budget.sh
+++ b/scripts/test-ci-journey-retry-budget.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Issue #1458: deterministic, JVM-free regression test for the emulator-journey
+# cold-boot retry budget. A retry may start only when the absolute 95-minute job
+# deadline leaves enough wall time for shutdown/boot, the selected suite, and
+# classifier/artifact teardown.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="${CI_JOURNEY_RETRY_BUDGET_HELPER:-$SCRIPT_DIR/ci-journey-retry-budget.sh}"
+WORKFLOW="${CI_JOURNEY_RETRY_BUDGET_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
+AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+[[ -f "$HELPER" ]] || fail "retry-budget helper missing: $HELPER"
+[[ -f "$WORKFLOW" ]] || fail "workflow missing: $WORKFLOW"
+[[ -f "$AGG" ]] || fail "aggregate helper missing: $AGG"
+
+run_decision() {
+  local start="${1-}" now="${2-}"
+  DECISION_RC=0
+  DECISION_OUT="$(bash "$HELPER" "$start" "$now" 2>&1)" || DECISION_RC=$?
+  DECISION_ALLOWED="$(sed -n 's/^retry_allowed=//p' <<<"$DECISION_OUT" | tail -n 1)"
+  DECISION_REASON="$(sed -n 's/^retry_reason=//p' <<<"$DECISION_OUT" | tail -n 1)"
+  DECISION_REMAINING="$(sed -n 's/^retry_remaining_ms=//p' <<<"$DECISION_OUT" | tail -n 1)"
+}
+
+assert_decision() {
+  local label="$1" start="$2" now="$3" allowed="$4" reason="$5" remaining="$6"
+  run_decision "$start" "$now"
+  [[ "$DECISION_RC" -eq 0 ]] \
+    || { printf '%s\n' "$DECISION_OUT"; fail "$label: helper exited $DECISION_RC"; }
+  [[ "$DECISION_ALLOWED" == "$allowed" ]] \
+    || { printf '%s\n' "$DECISION_OUT"; fail "$label: allowed=$DECISION_ALLOWED, expected $allowed"; }
+  [[ "$DECISION_REASON" == "$reason" ]] \
+    || { printf '%s\n' "$DECISION_OUT"; fail "$label: reason=$DECISION_REASON, expected $reason"; }
+  [[ "$DECISION_REMAINING" == "$remaining" ]] \
+    || { printf '%s\n' "$DECISION_OUT"; fail "$label: remaining=$DECISION_REMAINING, expected $remaining"; }
+}
+
+echo "== #1458 absolute retry-budget boundaries =="
+
+# Helper constants are pinned by the acceptance contract:
+#   95m absolute job cap = 5,700,000ms
+#   retry reserve = 900s boot/readiness + 4200s suite + 300s teardown
+job_start=1000000
+job_deadline=$((job_start + 5700000))
+retry_threshold=5400000
+
+assert_decision "threshold-1ms" "$job_start" "$((job_deadline - retry_threshold + 1))" \
+  false insufficient_remaining_budget "$((retry_threshold - 1))"
+pass "threshold-1ms denies the cold-boot retry"
+
+assert_decision "threshold" "$job_start" "$((job_deadline - retry_threshold))" \
+  true sufficient_remaining_budget "$retry_threshold"
+pass "the exact threshold allows the cold-boot retry"
+
+assert_decision "threshold+1ms" "$job_start" "$((job_deadline - retry_threshold - 1))" \
+  true sufficient_remaining_budget "$((retry_threshold + 1))"
+pass "threshold+1ms allows the cold-boot retry"
+
+assert_decision "missing start" "" "$job_start" false missing_job_start 0
+pass "a missing job-start epoch fails safe (retry denied)"
+
+assert_decision "malformed start" "not-an-epoch" "$job_start" false malformed_job_start 0
+pass "a malformed job-start epoch fails safe (retry denied)"
+
+assert_decision "malformed now" "$job_start" "not-an-epoch" false malformed_now 0
+pass "a malformed current epoch fails safe (retry denied)"
+
+assert_decision "future start" "2000" "1000" false future_job_start 0
+pass "a future job-start epoch fails safe (retry denied)"
+
+assert_decision "leading-zero start" "08" "9" false noncanonical_job_start 0
+pass "a leading-zero job-start epoch fails safe without octal parsing"
+
+assert_decision "leading-zero now" "8" "09" false noncanonical_now 0
+pass "a leading-zero current epoch fails safe without octal parsing"
+
+oversized_epoch=99999999999999999999999999999999999999999999999999
+assert_decision "oversized start" "$oversized_epoch" "$job_start" false out_of_range_job_start 0
+pass "an oversized job-start epoch fails safe without shell overflow"
+
+assert_decision "oversized now" "$job_start" "9223372036854775808" false out_of_range_now 0
+pass "an oversized current epoch fails safe without shell overflow"
+
+# A valid epoch near INT64_MAX must still use the same exact threshold without
+# ever forming start+cap (which would overflow signed shell arithmetic).
+near_int64_start=9223372036854475807
+assert_decision "near-int64 exact threshold" "$near_int64_start" "9223372036854775807" \
+  true sufficient_remaining_budget "$retry_threshold"
+pass "valid near-INT64_MAX epochs retain exact-threshold green semantics"
+
+echo
+echo "== #1458 allowed/denied retry paths =="
+
+retry_calls=0
+run_retry_if_allowed() {
+  local start="$1" now="$2"
+  run_decision "$start" "$now"
+  [[ "$DECISION_ALLOWED" == "true" ]] && retry_calls=$((retry_calls + 1))
+}
+
+run_retry_if_allowed "$job_start" "$((job_deadline - retry_threshold))"
+[[ "$retry_calls" -eq 1 ]] || fail "allowed path did not invoke the retry exactly once"
+pass "sufficient budget starts one retry"
+
+run_retry_if_allowed "$job_start" "$((job_deadline - retry_threshold + 1))"
+[[ "$retry_calls" -eq 1 ]] || fail "denied path invoked the retry"
+pass "insufficient budget starts no retry"
+
+echo
+echo "== #1458 real-workflow wiring =="
+
+grep -q 'JOURNEY_JOB_START_EPOCH_MS=' "$WORKFLOW" \
+  || fail "workflow does not record a job-start epoch"
+grep -q 'name: Check remaining job wall before journey retry' "$WORKFLOW" \
+  || fail "workflow does not run the retry-budget decision step"
+grep -q 'ci-journey-retry-budget.sh' "$WORKFLOW" \
+  || fail "workflow does not call the real retry-budget helper"
+grep -q "steps.journey_retry_budget.outputs.retry_allowed == 'true'" "$WORKFLOW" \
+  || fail "cold-boot retry is not guarded by retry_allowed=true"
+grep -q 'retry skipped — insufficient remaining job wall' "$WORKFLOW" \
+  || fail "classifier lacks typed insufficient-budget INFRA evidence"
+grep -q 'write_verdict INFRA' "$WORKFLOW" \
+  || fail "classifier cannot emit the INFRA shard token"
+
+retry_line="$(grep -n 'name: Retry journey subset on a fresh cold-booted emulator' "$WORKFLOW" | cut -d: -f1)"
+classify_line="$(grep -n 'name: Classify emulator-journey result' "$WORKFLOW" | cut -d: -f1)"
+upload_line="$(grep -n 'name: Upload shard verdict token' "$WORKFLOW" | cut -d: -f1)"
+[[ "$retry_line" =~ ^[0-9]+$ && "$classify_line" =~ ^[0-9]+$ && "$upload_line" =~ ^[0-9]+$ ]] \
+  || fail "could not locate retry/classifier/verdict-upload steps"
+[[ "$retry_line" -lt "$classify_line" && "$classify_line" -lt "$upload_line" ]] \
+  || fail "no-budget path cannot reach classifier then verdict artifact upload"
+pass "denied path skips retry, then reaches classifier and shard-token upload"
+
+# The new INFRA path must not soften the two pre-existing hard-red meanings:
+# a healthy-console genuine first failure and a #835 suite-budget timeout.
+# shellcheck disable=SC2016 # Literal workflow shell expressions, not test vars.
+first_failure_line="$(grep -Fn 'if [[ "${first_failure:-false}" == "true" ]]' "$WORKFLOW" | cut -d: -f1)"
+# shellcheck disable=SC2016
+first_timeout_line="$(grep -Fn 'if [[ "${first_timeout:-false}" == "true" ]]' "$WORKFLOW" | cut -d: -f1)"
+# shellcheck disable=SC2016
+budget_infra_line="$(grep -Fn 'if [[ "${retry_allowed:-false}" != "true" ]]' "$WORKFLOW" | cut -d: -f1)"
+[[ "$first_failure_line" =~ ^[0-9]+$ && "$first_timeout_line" =~ ^[0-9]+$ && "$budget_infra_line" =~ ^[0-9]+$ ]] \
+  || fail "could not locate genuine-failure/timeout/budget classifier branches"
+[[ "$first_failure_line" -lt "$budget_infra_line" && "$first_timeout_line" -lt "$budget_infra_line" ]] \
+  || fail "insufficient-budget INFRA branch can mask a genuine failure or #835 timeout RED"
+pass "genuine first-failure and #835 timeout RED semantics precede budget INFRA"
+
+# Model the typed no-budget result through the REAL aggregate reducer. Three
+# completed shard jobs each report INFRA, producing the existing RE-RUN state.
+verdict_dir="$(mktemp -d)"
+trap 'rm -rf "$verdict_dir"' EXIT
+for shard in 0 1 2; do
+  mkdir -p "$verdict_dir/emulator-journey-verdict-shard-$shard"
+  printf 'INFRA\n' > "$verdict_dir/emulator-journey-verdict-shard-$shard/shard-verdict.txt"
+done
+agg_rc=0
+agg_out="$(EXPECTED_SHARDS=3 GITHUB_STEP_SUMMARY="" bash "$AGG" "$verdict_dir" 2>&1)" || agg_rc=$?
+[[ "$agg_rc" -eq 0 ]] || { printf '%s\n' "$agg_out"; fail "complete no-budget INFRA evidence did not aggregate cleanly"; }
+grep -q '^AGGREGATE_VERDICT=RE-RUN$' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "complete no-budget INFRA evidence did not produce RE-RUN"; }
+pass "complete INFRA shard evidence reaches aggregate RE-RUN (not cancellation)"
+
+echo
+echo "ALL TESTS PASSED: scripts/test-ci-journey-retry-budget.sh"


### PR DESCRIPTION
## Summary

- record the emulator shard job start before setup
- allow a second cold boot only when the full 90-minute retry + teardown reserve remains inside the 95-minute job cap
- fail closed on malformed/future/out-of-range timestamps and emit typed INFRA/RE-RUN evidence before GitHub cancels the job
- add deterministic boundary, wiring, aggregate, and mutation-tested shell coverage

## Evidence

- reproduce-first self-test RED on the missing helper / unguarded retry
- retry-budget self-test: 17/17 PASS
- existing journey budget self-test: 33/33 PASS
- aggregate verdict self-test: 13/13 PASS
- journey harness: PASS, NEW FAIL=0
- bash syntax, shellcheck, YAML parse, and `git diff --check`: PASS
- live retry-guard and future-epoch-parser mutations: RED, byte-verified restore
- independent reviewer: APPROVED

Refs #1458
