### PR TITLE
CI: classify ddmlib console warnings as ordinary test output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,7 +194,7 @@ jobs:
       # aggregate verdict (scripts/ci-journey-aggregate-verdict.sh) + the
       # per-shard token-writing / aggregation wiring in tests.yml. Proves the
       # load-bearing property WITHOUT an emulator: all-green -> CLEAN,
-      # all-infra-storm -> RE-RUN (neutral, no false red email), and a genuine
+      # all-infra -> RE-RUN (neutral, no false red email), and a genuine
       # journey failure -> RED (never masked). Cheap (< 5 s), no emulator.
       - name: CI journey aggregate-verdict guard (issue #1458)
         run: |
@@ -938,10 +938,9 @@ jobs:
           force-avd-creation: true
           disable-animations: true
           # Issue #1458: `-memory 6144` raises the guest RAM from the pixel_7 AVD
-          # hwconfig default (2048 MB) to 6 GB so the swiftshader render pipeline
-          # + Gradle connected-test + 3 Docker fixtures stop starving the guest
-          # (the `Failed to start Emulator console` storm signature). ubuntu-latest
-          # gives ~16 GB host RAM, so 6 GB guest leaves comfortable host headroom.
+          # hwconfig default (2048 MB) to 6 GB, leaving the render pipeline and
+          # connected journeys enough guest headroom while Docker fixtures run.
+          # ubuntu-latest gives ~16 GB host RAM, so 6 GB leaves host headroom.
           emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -memory 6144 -noaudio -no-boot-anim -camera-back none -camera-front none
           emulator-boot-timeout: 900
           script: scripts/ci-journey-suite.sh
@@ -1062,10 +1061,9 @@ jobs:
           force-avd-creation: true
           disable-animations: true
           # Issue #1458: `-memory 6144` raises the guest RAM from the pixel_7 AVD
-          # hwconfig default (2048 MB) to 6 GB so the swiftshader render pipeline
-          # + Gradle connected-test + 3 Docker fixtures stop starving the guest
-          # (the `Failed to start Emulator console` storm signature). ubuntu-latest
-          # gives ~16 GB host RAM, so 6 GB guest leaves comfortable host headroom.
+          # hwconfig default (2048 MB) to 6 GB, leaving the render pipeline and
+          # connected journeys enough guest headroom while Docker fixtures run.
+          # ubuntu-latest gives ~16 GB host RAM, so 6 GB leaves host headroom.
           emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -memory 6144 -noaudio -no-boot-anim -camera-back none -camera-front none
           emulator-boot-timeout: 900
           script: scripts/ci-journey-suite.sh
@@ -1100,9 +1098,9 @@ jobs:
       # Genuine journey failures still keep the job RED (exit 1), so a real test
       # regression cannot hide behind an "infra" message.
       # Issue #1458 (AGGREGATION): this per-shard classify step is now
-      # `continue-on-error` so a single shard's infra abort (console storm / #470
-      # cancel / #771 never-booted) can NEVER fail the whole `Tests` workflow on
-      # its own and fire a false red-CI email. Instead, EVERY branch below writes
+      # `continue-on-error` so a single shard's infra abort (#470 cancel / #771
+      # never-booted) can NEVER fail the whole `Tests` workflow on its own and
+      # fire a false red-CI email. Instead, EVERY branch below writes
       # a one-word per-shard VERDICT TOKEN (CLEAN | INFRA | RED) to
       # artifacts/ci-journey/shard-verdict.txt, which is uploaded per shard and
       # rolled up by the downstream `emulator-journey-verdict` aggregation job
@@ -1110,9 +1108,9 @@ jobs:
       # ::warning annotations + red step marker are PRESERVED for forensics; the
       # exit codes below are UNCHANGED (genuine failures still exit 1 at the step
       # level, visible in the log), but the AGGREGATION job — not this step — is
-      # what turns the run red. RED (a HEALTHY-console genuine journey failure or
-      # the #835 budget timeout) still produces an aggregate RED, so a real
-      # regression is never masked.
+      # what turns the run red. RED (a genuine journey failure or the #835 budget
+      # timeout) still produces an aggregate RED, so a real regression is never
+      # masked.
       - name: Classify emulator-journey result (infra-abort vs test-failure)
         if: always()
         continue-on-error: true
@@ -1129,32 +1127,12 @@ jobs:
           retry_required_ms="${{ steps.journey_retry_budget.outputs.retry_required_ms }}"
           summary="artifacts/ci-journey/summary.md"
           # Issue #1458: record this shard's verdict token for the aggregation
-          # job. CLEAN = passed; INFRA = environmental (storm / #470 cancel /
-          # #771 never-booted) re-run signal; RED = genuine journey failure or
-          # #835 budget timeout. Written in EVERY branch before its exit.
+          # job. CLEAN = passed; INFRA = environmental (#470 cancel / #771
+          # never-booted) re-run signal; RED = genuine journey failure or #835
+          # budget timeout. Written in EVERY branch before its exit.
           verdict_file="artifacts/ci-journey/shard-verdict.txt"
           mkdir -p "$(dirname "$verdict_file")"
           write_verdict() { printf '%s\n' "$1" > "$verdict_file"; echo "SHARD_VERDICT=$1 (shard ${{ matrix.shard }})"; }
-          # Issue #1458: count the `Failed to start Emulator console` storm from
-          # the durable journey-console capture (teed by run_bounded). On a
-          # CPU/RAM-starved swiftshader AVD this ddmlib line repeats ~100×/shard
-          # and is the signature of a DEGRADED emulator, NOT a product defect. A
-          # storm makes the whole run's JOURNEY_FAILED verdict untrustworthy, so
-          # it is routed to an INFRA-ABORT (re-run) BELOW — but ONLY where a
-          # genuine test-failure would otherwise be reported. A HEALTHY-console
-          # JOURNEY_FAILED (low/zero count) STAYS a genuine red: masking a real
-          # regression behind "infra" is the #657/#844 flake-masks-real trap, the
-          # exact inverse of what this guard exists to prevent. The #835 timeout
-          # and #771 never-booted branches are intentionally NOT gated by the
-          # storm — their behavior is unchanged.
-          console_log="artifacts/ci-journey/journey-console.log"
-          console_storm_threshold=25
-          console_storm_count=0
-          if [[ -f "$console_log" ]]; then
-            console_storm_count="$(grep -c 'Failed to start Emulator console' "$console_log" 2>/dev/null || true)"
-          fi
-          [[ "$console_storm_count" =~ ^[0-9]+$ ]] || console_storm_count=0
-          echo "console-storm 'Failed to start Emulator console' count: $console_storm_count (INFRA-ABORT threshold: >= $console_storm_threshold)"
           echo "first attempt outcome:  $first"
           echo "retry attempt outcome:  ${retry:-<skipped>}"
           echo "first attempt conclusion:  $first_concl"
@@ -1175,11 +1153,6 @@ jobs:
             exit 0
           fi
           if [[ "${first_failure:-false}" == "true" ]]; then
-            if (( console_storm_count >= console_storm_threshold )); then
-              echo "::error title=EMULATOR INFRA UNAVAILABLE / degraded — console storm (${console_storm_count}× 'Failed to start Emulator console')::The first cold boot wrote a JOURNEY_FAILED summary, but the emulator console failed to start ${console_storm_count} times (>= ${console_storm_threshold}) — the signature of a CPU/RAM-starved swiftshader AVD (issue #1458). A JOURNEY_FAILED read off a DEGRADED emulator is NOT a trustworthy product verdict, so this is an infra abort (a re-run signal, same class as the never-booted #771 branch), NOT a genuine regression. A real regression on a HEALTHY console shows a low console-storm count and stays red."
-              write_verdict INFRA
-              exit 1
-            fi
             echo "::error title=Emulator journey FAILED — first attempt genuine failure::The first cold boot wrote a JOURNEY_FAILED / Failed BOTH attempts summary, and the retry did not pass cleanly. Refusing to downgrade this run to advisory timeout even if the retry overwrote summary.md with a timeout-only artifact."
             write_verdict RED
             exit 1
@@ -1195,8 +1168,8 @@ jobs:
           # absolute job wall for a complete retry. Do not start a cold boot that
           # GitHub will cancel at 95m; emit typed INFRA evidence now so classifier,
           # logs, shard-token upload, and teardown can reach terminal completion.
-          # Healthy-console first_failure and #835 first_timeout branches above
-          # retain their existing RED semantics.
+          # Genuine first_failure and #835 first_timeout branches above retain
+          # their existing RED semantics.
           if [[ "${retry_allowed:-false}" != "true" ]]; then
             echo "::warning title=Emulator journey retry skipped — insufficient remaining job wall::The first attempt did not produce a clean verdict, but a complete fresh-cold-boot retry no longer fits before the absolute 95-minute job deadline (reason=${retry_reason:-missing_decision}, remaining=${retry_remaining_ms:-0}ms, required=${retry_required_ms:-5400000}ms). The retry was not started; this shard is typed INFRA so aggregation requests RE-RUN, while classifier and artifacts retain time to finish (issue #1458)."
             write_verdict INFRA
@@ -1213,17 +1186,6 @@ jobs:
           fi
           # Both attempts failed — classify from the suite's own summary artifact.
           if [[ -f "$summary" ]] && grep -qE 'JOURNEY_FAILED|Failed BOTH attempts' "$summary"; then
-            # Issue #1458: before reading this as a genuine regression, gate on the
-            # console storm. If the emulator was storming (>= threshold), the
-            # JOURNEY_FAILED was produced on a DEGRADED emulator and is an infra
-            # abort (re-run), NOT a product verdict. A HEALTHY-console
-            # JOURNEY_FAILED (count below threshold) falls through to the genuine
-            # test-failure verdict below — a real regression is NEVER swallowed.
-            if (( console_storm_count >= console_storm_threshold )); then
-              echo "::error title=EMULATOR INFRA UNAVAILABLE / degraded — console storm (${console_storm_count}× 'Failed to start Emulator console')::A load-bearing journey class failed on both cold-boot attempts, but the emulator console failed to start ${console_storm_count} times (>= ${console_storm_threshold}) — the signature of a CPU/RAM-starved swiftshader AVD (issue #1458). A both-attempts JOURNEY_FAILED read off a DEGRADED emulator is NOT a trustworthy product verdict; this is an infra abort (a re-run signal, same class as the never-booted #771 branch), NOT a genuine test regression. A real regression on a HEALTHY console shows a low console-storm count and stays red."
-              write_verdict INFRA
-              exit 1
-            fi
             # The emulator booted and the suite ran to a verdict: a journey class
             # failed twice. This is a GENUINE test failure (app-code regression),
             # NOT the #771 emulator-infra abort.
@@ -1331,17 +1293,15 @@ jobs:
   # into ONE overall verdict so `main`'s emulator-level health is readable at a
   # glance and an all-infra flake run does NOT fire a false red-CI email.
   #
-  # The research spike on #1458 found the heavy journey job flakes constantly
-  # from host-CPU starvation on 2–4 vCPU hosted runners: each console-storm shard
-  # was classified as `EMULATOR INFRA UNAVAILABLE` but STILL exited 1 (red) with
-  # no rollup, so three independent red checks left main-health unreadable and
-  # spammed red-CI email. The per-shard classify step is now `continue-on-error`
-  # and records a CLEAN | INFRA | RED token; this job consumes those tokens:
+  # Per-shard infra aborts used to exit 1 with no rollup, so three independent
+  # red checks could leave main-health unreadable and spam red-CI email. The
+  # per-shard classify step is now `continue-on-error` and records a
+  # CLEAN | INFRA | RED token; this job consumes those tokens:
   #   * every shard CLEAN            -> CLEAN  (green)
   #   * no RED, at least one INFRA   -> RE-RUN (neutral green + ::warning; the
   #                                    failures were environmental, re-run)
-  #   * any shard RED (a HEALTHY-console genuine journey failure or the #835
-  #     budget timeout)              -> RED    (exit 1, the run goes red)
+  #   * any shard RED (a genuine journey failure or the #835 budget timeout)
+  #                                    -> RED    (exit 1, the run goes red)
   # A genuine journey assertion failure therefore STILL turns the run red — the
   # aggregation never masks a real regression (the #657/#844 flake-masks-real
   # trap's inverse). Per-shard logs/annotations stay intact for forensics.

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -3,14 +3,11 @@
 # overall verdict so `main`'s emulator-level health is readable at a glance and
 # an all-infra flake run does NOT fire a false red-CI email.
 #
-# Background: the heavy `Emulator journey subset` job on `main` flakes constantly
-# from host-CPU starvation on 2–4 vCPU hosted runners. The per-shard classify
-# step already annotates a console-storm shard as `EMULATOR INFRA UNAVAILABLE`,
-# but before this each storm-classified shard STILL exited 1 (red) with no
-# rollup — three independent red checks with no aggregated verdict, so the
-# maintainer could not read main's health and got red-CI email spam. This helper
-# is the aggregation: it reads the one-word verdict token each shard now writes
-# and emits the single overall verdict.
+# Background: per-shard infra aborts used to exit 1 (red) with no rollup —
+# three independent red checks with no aggregated verdict, so the maintainer
+# could not read main's health and got red-CI email spam. This helper is the
+# aggregation: it reads the one-word verdict token each shard now writes and
+# emits the single overall verdict.
 #
 # Usage:
 #   ci-journey-aggregate-verdict.sh [VERDICT_DIR]
@@ -27,15 +24,15 @@
 #
 # Verdict / exit code:
 #   CLEAN   every shard reported CLEAN (and none are missing). exit 0.
-#   RED     at least one shard reported RED (a genuine HEALTHY-console journey
-#           failure, or the #835 budget-timeout hard-red), OR a present token
-#           file held an unrecognised value (fail-closed — corruption must not
-#           silently pass). exit 1 — the run goes red.
+#   RED     at least one shard reported RED (a genuine journey failure, or the
+#           #835 budget-timeout hard-red), OR a present token file held an
+#           unrecognised value (fail-closed — corruption must not silently
+#           pass). exit 1 — the run goes red.
 #   RE-RUN  no RED shard, but at least one INFRA shard and/or a missing shard:
-#           every failing/absent shard was environmental (console storm / #470
-#           cancel / #771 never-booted / not reported). A re-run signal, NOT a
-#           product regression, so it exits 0 (neutral) with a ::warning — no
-#           false red-CI email.
+#           every failing/absent shard was environmental (#470 cancel / #771
+#           never-booted / retry budget denied / not reported). A re-run signal,
+#           NOT a product regression, so it exits 0 (neutral) with a ::warning —
+#           no false red-CI email.
 #
 # The verdict is printed as `AGGREGATE_VERDICT=<verdict>` and appended to
 # $GITHUB_STEP_SUMMARY when that env var is set, so the rollup is readable in the
@@ -119,7 +116,7 @@ fi
 
 # No RED; some shard was environmental (INFRA) or did not report (MISSING).
 if (( have_infra > 0 || missing > 0 )); then
-  echo "::warning title=Emulator journey verdict — RE-RUN (environmental)::No genuine journey failure, but ${have_infra} shard(s) hit an environmental infra abort (console storm / #470 cancel / #771 never-booted) and ${missing} shard(s) did not report. This is a re-run signal, NOT a product regression — the run stays green so main-health is readable and no false red-CI email fires. Re-run the emulator-journey job."
+  echo "::warning title=Emulator journey verdict — RE-RUN (environmental)::No genuine journey failure, but ${have_infra} shard(s) hit an environmental infra abort (#470 cancel / #771 never-booted / retry budget denied) and ${missing} shard(s) did not report. This is a re-run signal, NOT a product regression — the run stays green so main-health is readable and no false red-CI email fires. Re-run the emulator-journey job."
   emit_summary "RE-RUN" "${have_infra} infra shard(s) + ${missing} missing shard(s), no genuine failure — re-run"
   echo "AGGREGATE_VERDICT=RE-RUN"
   exit 0

--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -65,30 +65,16 @@ run_bounded() {
   to_pid=$!
 
   exec {rfd}<"$fifo"
-  # Issue #1458: tee every streamed line to a DURABLE capture file so the
-  # workflow "Classify emulator-journey result" step can count the
-  # `Failed to start Emulator console` storm (a CPU/RAM-starved swiftshader
-  # symptom, ~100×/shard) AFTER this emulator step has ended and its stdout is
-  # gone. Live streaming (the `printf` to stdout) is UNCHANGED. The fd is opened
-  # in append mode ONCE per class attempt (cheap) and only when
-  # JOURNEY_CONSOLE_LOG is set + openable, so the budget self-test and any
-  # non-CI caller that leaves it unset behave exactly as before.
-  local cfd=-1
-  if [[ -n "${JOURNEY_CONSOLE_LOG:-}" ]]; then
-    exec {cfd}>>"$JOURNEY_CONSOLE_LOG" || cfd=-1
-  fi
   read_rc=0
   while :; do
     if IFS= read -r -t "$no_output" -u "$rfd" line; then
       printf '%s\n' "$line"
-      (( cfd >= 0 )) && printf '%s\n' "$line" >&"$cfd"
     else
       read_rc=$?
       break
     fi
   done
   exec {rfd}<&-
-  (( cfd >= 0 )) && exec {cfd}>&-
 
   if (( read_rc > 128 )); then
     echo "JOURNEY_NO_OUTPUT_WATCHDOG: no output for ${no_output}s — hard-killing wedged connectedDebugAndroidTest (issue #1056)" >&2
@@ -124,11 +110,9 @@ run_class() {
     return 124
   fi
   attempt_start=$SECONDS
-  # Issue #1458: --max-workers=2 (parity with the Unit job) caps Gradle's worker
-  # fan-out so it stops fighting the swiftshader emulator + KVM + Docker fixtures
-  # for the 2–4 host vCPUs — the CPU starvation that triggers the
-  # `Failed to start Emulator console` storm. The Gradle DAEMON is still reused
-  # (no --no-daemon), preserving the #835 budget-fit.
+  # Issue #1458: --max-workers=2 (parity with the Unit job) bounds Gradle's
+  # worker fan-out while the emulator and Docker fixtures share the runner. The
+  # Gradle DAEMON is still reused (no --no-daemon), preserving the #835 budget-fit.
   run_bounded "$cap" \
     "$GRADLEW" :app:connectedDebugAndroidTest \
     --max-workers=2 \
@@ -167,9 +151,9 @@ run_ct_class() {
     return 124
   fi
   attempt_start=$SECONDS
-  # Issue #1458: --max-workers=2 (parity with the Unit job + run_class) caps
-  # Gradle's worker fan-out so it stops starving the swiftshader emulator of host
-  # vCPUs (the `Failed to start Emulator console` storm). Daemon still reused.
+  # Issue #1458: --max-workers=2 (parity with the Unit job + run_class) bounds
+  # Gradle's worker fan-out while the proof shares the runner with the emulator.
+  # Daemon reuse is preserved for the #835 budget fit.
   run_bounded "$cap" \
     "$GRADLEW" :shared:core-terminal:connectedDebugAndroidTest \
     --max-workers=2 \

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -87,20 +87,6 @@ ARTIFACT_DIR="$REPO_ROOT/artifacts/ci-journey"
 mkdir -p "$ARTIFACT_DIR"
 SUMMARY="$ARTIFACT_DIR/summary.md"
 
-# Issue #1458: durable capture of the journey run's streamed gradle/ddmlib output.
-# run_bounded appends every streamed line here (while still streaming live) so the
-# workflow "Classify emulator-journey result" step can count the
-# `Failed to start Emulator console` storm — the signature of a CPU/RAM-starved
-# swiftshader AVD (~100×/shard) — AFTER this emulator step has ended and its stdout
-# is gone. A degraded-emulator storm is then classified as an INFRA-ABORT (re-run),
-# never a "genuine test failure" reading, so a starved emulator can no longer make
-# `main`'s emulator-level health unreadable. Truncated once per suite run so the
-# capture reflects THIS attempt only — mirroring how summary.md is overwritten per
-# cold-boot attempt (the classifier reads the last attempt's artifacts).
-JOURNEY_CONSOLE_LOG="$ARTIFACT_DIR/journey-console.log"
-export JOURNEY_CONSOLE_LOG
-: > "$JOURNEY_CONSOLE_LOG"
-
 GRADLEW="$REPO_ROOT/gradlew"
 
 FQCN_PREFIX="com.pocketshell.app.proof"

--- a/scripts/test-ci-journey-aggregate-verdict.sh
+++ b/scripts/test-ci-journey-aggregate-verdict.sh
@@ -63,8 +63,8 @@ run_agg "$d" 3
   || { printf '%s\n' "$AGG_OUT"; fail "(a) all-green expected CLEAN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
 pass "(a) all shards CLEAN -> CLEAN (green, exit 0)"
 
-# (b) all-infra-storm -> RE-RUN (exit 0, NOT red). This is the #1458 core: a
-#     console-storm run must NOT fire a false red-CI email.
+# (b) all-infra -> RE-RUN (exit 0, NOT red). Environmental aborts must not fire
+#     a false red-CI email when no shard carries genuine RED evidence.
 d="$(make_dir all-infra)"
 write_shard "$d" 0 INFRA; write_shard "$d" 1 INFRA; write_shard "$d" 2 INFRA
 run_agg "$d" 3
@@ -74,7 +74,7 @@ grep -q '::warning' <<<"$AGG_OUT" \
   || fail "(b) an all-infra RE-RUN must emit a ::warning (re-run signal), not silence"
 grep -q '::error' <<<"$AGG_OUT" \
   && fail "(b) an all-infra RE-RUN must NOT emit a ::error (that would fire a false red-CI email)"
-pass "(b) all shards INFRA-storm -> RE-RUN (neutral green, exit 0, no false red)"
+pass "(b) all shards INFRA -> RE-RUN (neutral green, exit 0, no false red)"
 
 # (c) one real journey failure + infra elsewhere -> RED (exit 1). The
 #     load-bearing property: a genuine regression is NEVER masked by infra.

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -170,35 +170,21 @@ pass "(pre) #835 right-sized budget arithmetic pinned (${job_cap_secs}s job - ${
 pass "(pre) first-attempt diagnostics are preserved before emulator retry"
 
 # ---------------------------------------------------------------------------
-# Issue #1458 workflow-parity pins: the real workflow classifier must count the
-# `Failed to start Emulator console` storm from the durable journey-console
-# capture and route a STORMING JOURNEY_FAILED to an INFRA-ABORT. Pin the
-# load-bearing pieces so the classify() mirror above cannot silently drift from
-# the workflow, and so a regression that drops the storm gate trips this test.
-grep -q 'journey-console.log' "$WORKFLOW" \
-  || fail "(pre-1458) tests.yml classifier must read the durable journey-console.log capture"
-grep -q "Failed to start Emulator console" "$WORKFLOW" \
-  || fail "(pre-1458) tests.yml classifier must count the 'Failed to start Emulator console' storm signature"
-grep -q 'console_storm_threshold=25' "$WORKFLOW" \
-  || fail "(pre-1458) tests.yml classifier must use the 25-storm INFRA-ABORT threshold"
-grep -q 'console_storm_count >= console_storm_threshold' "$WORKFLOW" \
-  || fail "(pre-1458) tests.yml classifier must gate the genuine-failure verdict on the storm count"
-grep -q 'EMULATOR INFRA UNAVAILABLE / degraded' "$WORKFLOW" \
-  || fail "(pre-1458) tests.yml storm branch must emit a distinct degraded-emulator INFRA-ABORT title"
-# The suite must define + truncate the console capture and route it through
-# run_bounded's tee.
-grep -q 'JOURNEY_CONSOLE_LOG' "$REAL_SUITE" \
-  || fail "(pre-1458) ci-journey-suite.sh must define the durable JOURNEY_CONSOLE_LOG capture"
-grep -q 'JOURNEY_CONSOLE_LOG' "$SCRIPT_DIR/ci-journey-budget-functions.sh" \
-  || fail "(pre-1458) run_bounded (ci-journey-budget-functions.sh) must tee to JOURNEY_CONSOLE_LOG"
-# The storm gate must be a genuine-failure gate ONLY: the #835 timeout ::error
-# lines must NOT be preceded by a storm re-route (already asserted unchanged by
-# the (pre) timeout-exit walk above; here we assert the storm branch sits inside
-# a JOURNEY_FAILED/first_failure context, not the timeout context).
-storm_gate_count="$(grep -c 'console_storm_count >= console_storm_threshold' "$WORKFLOW" || true)"
-[[ "$storm_gate_count" -eq 2 ]] \
-  || fail "(pre-1458) expected exactly 2 storm gates (first_failure + both-failed JOURNEY_FAILED), found $storm_gate_count"
-pass "(pre-1458) console-storm INFRA-ABORT classifier is wired into the workflow + suite + run_bounded"
+# Issue #1458 hard-cut + mutation guard: raw emulator-console warning counts are
+# ordinary per-connected-invocation output, not an infra signal. The workflow
+# must not count them or downgrade JOURNEY_FAILED, and the classifier-only
+# capture plumbing must stay deleted. Reintroducing count>=25 -> INFRA trips
+# these assertions before the behavioural fixture below can pass vacuously.
+if grep -qE \
+  'journey-console\.log|Failed to start Emulator console|console_(storm|warning)_(count|threshold)|EMULATOR INFRA UNAVAILABLE / degraded' \
+  "$WORKFLOW"; then
+  fail "(pre-1458) tests.yml reintroduced raw emulator-console warning classification"
+fi
+if grep -q 'JOURNEY_CONSOLE_LOG' \
+  "$REAL_SUITE" "$SCRIPT_DIR/ci-journey-budget-functions.sh"; then
+  fail "(pre-1458) obsolete classifier-only JOURNEY_CONSOLE_LOG plumbing was reintroduced"
+fi
+pass "(pre-1458) raw console-count classifier + classifier-only capture plumbing are absent"
 
 # ---------------------------------------------------------------------------
 # Build a sandbox "repo root": a copy of the suite script + a stub gradlew that
@@ -298,11 +284,6 @@ classify() {
   local retry_concl="${5:-failure}"
   local first_timeout="${6:-}"
   local first_failure="${7:-false}"
-  # Issue #1458: the count of `Failed to start Emulator console` storms from the
-  # durable journey-console capture. >= threshold => the emulator was DEGRADED and
-  # any JOURNEY_FAILED read is an INFRA-ABORT (re-run), NOT a product verdict.
-  local console_storm_count="${8:-0}"
-  local console_storm_threshold=25
   if [[ -z "$first_timeout" ]]; then
     first_timeout="false"
     if [[ -f "$s" ]] \
@@ -318,11 +299,6 @@ classify() {
     echo "PASS_RETRY"; return
   fi
   if [[ "$first_failure" == "true" ]]; then
-    # #1458: a first-attempt JOURNEY_FAILED off a STORMING (degraded) emulator is
-    # an infra abort (re-run); a healthy-console one stays a genuine red.
-    if (( console_storm_count >= console_storm_threshold )); then
-      echo "INFRA_CONSOLE_STORM"; return
-    fi
     echo "FIRST_GENUINE_FAILURE"; return
   fi
   if [[ "$first_timeout" == "true" ]]; then
@@ -334,11 +310,6 @@ classify() {
     echo "STEP_CANCELLED"; return
   fi
   if [[ -f "$s" ]] && grep -qE 'JOURNEY_FAILED|Failed BOTH attempts' "$s"; then
-    # #1458: a both-attempts JOURNEY_FAILED off a STORMING (degraded) emulator is
-    # an infra abort (re-run); a healthy-console one stays a genuine red.
-    if (( console_storm_count >= console_storm_threshold )); then
-      echo "INFRA_CONSOLE_STORM"; return
-    fi
     echo "GENUINE_FAILURE"; return
   fi
   if [[ -f "$s" ]] && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$s"; then
@@ -408,14 +379,11 @@ overwrite_verdict="$(classify "$retry_timeout_summary" failure failure failure f
 pass "(h) first genuine failure remains red when retry overwrites summary with timeout-only content"
 
 # ---------------------------------------------------------------------------
-# Issue #1458: console-storm INFRA-ABORT classifier. A CPU/RAM-starved
-# swiftshader AVD storms `Failed to start Emulator console` ~100×/shard and
-# produces a JOURNEY_FAILED summary that is NOT a real regression — it made
-# `main`'s emulator-level health unreadable. The classifier must route a
-# STORMING run's genuine-failure reading to an INFRA-ABORT (re-run), while a
-# HEALTHY-console JOURNEY_FAILED STAYS a genuine red — masking a real regression
-# behind "infra" is the #657/#844 flake-masks-real trap this guard must NOT hit.
-echo "== #1458 console-storm INFRA-ABORT classifier =="
+# Issue #1458: raw ddmlib warning cardinality cannot classify emulator health.
+# Historical and current runs show one optional warning per separate connected
+# Gradle invocation, including completed Starting -> Finished blocks. Genuine
+# JOURNEY_FAILED evidence therefore stays RED at every warning count.
+echo "== #1458 raw console-warning count never masks JOURNEY_FAILED =="
 storm_summary="$SANDBOX/storm-summary.md"
 printf '%s\n' \
   '# Per-push CI journey suite — summary' \
@@ -423,69 +391,78 @@ printf '%s\n' \
   '- `com.pocketshell.app.proof.Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest`' \
   > "$storm_summary"
 
-# (p1) STORM: both attempts failed with a JOURNEY_FAILED summary AND the console
-#      stormed (104×, the run-29081790650 forensic count) -> INFRA_CONSOLE_STORM
-#      (re-run), NOT a genuine product verdict.
-storm_verdict="$(classify "$storm_summary" failure failure failure failure false false 104)"
-[[ "$storm_verdict" == "INFRA_CONSOLE_STORM" ]] \
-  || fail "(p1) storming JOURNEY_FAILED routed to '$storm_verdict', expected INFRA_CONSOLE_STORM"
-verdict_is_red "$storm_verdict" \
-  || fail "(p1) INFRA_CONSOLE_STORM must still exit the job non-zero (a re-run signal, like #771)"
-pass "(p1) storming (104×) JOURNEY_FAILED -> INFRA_CONSOLE_STORM re-run signal"
+# (p0) REGRESSION FIXTURE: ddmlib may emit one optional emulator-console warning
+# for each separate connected Gradle invocation. Thirty ordinary completed
+# invocations therefore produce >=30 warnings without proving emulator
+# degradation. A genuine JOURNEY_FAILED beside this warning -> Starting ->
+# Finished transcript must remain a genuine RED; raw warning cardinality is not
+# an infra classifier.
+ordinary_invocations_log="$SANDBOX/ordinary-connected-invocations.log"
+for i in {1..30}; do
+  printf '%s\n' \
+    "WARNING | Failed to start Emulator console for 5554" \
+    "Starting 1 tests on emulator-5554 (invocation $i)" \
+    "Finished 1 tests on emulator-5554 (invocation $i)"
+done > "$ordinary_invocations_log"
 
-# (p2) THE #1 ACCEPTANCE CRITERION: a HEALTHY console (below threshold) with the
-#      SAME JOURNEY_FAILED summary MUST stay a genuine red — a real regression is
-#      NEVER swallowed behind "infra" (the #657/#844 flake-masks-real inverse).
-healthy_verdict="$(classify "$storm_summary" failure failure failure failure false false 3)"
-[[ "$healthy_verdict" == "GENUINE_FAILURE" ]] \
-  || fail "(p2) healthy-console JOURNEY_FAILED routed to '$healthy_verdict', expected GENUINE_FAILURE (a real regression must NOT be masked)"
-verdict_is_red "$healthy_verdict" \
-  || fail "(p2) healthy-console genuine failure must stay red"
-pass "(p2) healthy-console (3×) JOURNEY_FAILED -> GENUINE_FAILURE (real regression NOT masked)"
+awk '
+  NR % 3 == 1 && $0 !~ /Failed to start Emulator console for 5554/ { bad=1 }
+  NR % 3 == 2 && $0 !~ /^Starting / { bad=1 }
+  NR % 3 == 0 && $0 !~ /^Finished / { bad=1 }
+  END { exit(bad || NR != 90) }
+' "$ordinary_invocations_log" \
+  || fail "(p0) malformed regression fixture: expected 30 warning -> Starting -> Finished blocks"
+ordinary_warning_count="$(grep -c 'Failed to start Emulator console' "$ordinary_invocations_log" || true)"
+[[ "$ordinary_warning_count" -eq 30 ]] \
+  || fail "(p0) regression fixture warning count is $ordinary_warning_count, expected 30"
+ordinary_verdict="$(classify "$storm_summary" failure failure failure failure false false "$ordinary_warning_count")"
+[[ "$ordinary_verdict" == "GENUINE_FAILURE" ]] \
+  || fail "(p0) 30 ordinary completed Gradle invocations plus JOURNEY_FAILED routed to '$ordinary_verdict'; raw per-invocation console warnings must never downgrade a genuine failure to INFRA"
+pass "(p0) 30 warning -> Starting -> Finished blocks + JOURNEY_FAILED stay GENUINE_FAILURE"
 
-# (p3) boundary: exactly 25 storms -> INFRA (>= threshold); 24 -> genuine red.
-[[ "$(classify "$storm_summary" failure failure failure failure false false 25)" == "INFRA_CONSOLE_STORM" ]] \
-  || fail "(p3) 25 storms (== threshold) must route to INFRA_CONSOLE_STORM"
-[[ "$(classify "$storm_summary" failure failure failure failure false false 24)" == "GENUINE_FAILURE" ]] \
-  || fail "(p3) 24 storms (< threshold) must stay GENUINE_FAILURE"
-[[ "$(classify "$storm_summary" failure failure failure failure false false 0)" == "GENUINE_FAILURE" ]] \
-  || fail "(p3) 0 storms (healthy) must stay GENUINE_FAILURE"
-pass "(p3) threshold boundary: >=25 INFRA-abort, <25 genuine red"
+# (p1) Mutation-sensitive behavioural boundary: counts on both sides of the old
+# threshold, and the historic 104-warning count, all produce the same genuine
+# failure. Reintroducing >=25 -> INFRA changes at least three of these outcomes.
+for warning_count in 0 24 25 30 104; do
+  count_verdict="$(classify "$storm_summary" failure failure failure failure false false "$warning_count")"
+  [[ "$count_verdict" == "GENUINE_FAILURE" ]] \
+    || fail "(p1) warning count $warning_count routed JOURNEY_FAILED to '$count_verdict', expected GENUINE_FAILURE"
+  verdict_is_red "$count_verdict" \
+    || fail "(p1) warning count $warning_count made a genuine failure green"
+done
+pass "(p1) warning counts 0/24/25/30/104 all keep JOURNEY_FAILED genuinely red"
 
-# (p4) first-attempt genuine failure: storm -> INFRA (re-run); healthy console ->
-#      FIRST_GENUINE_FAILURE (stays red).
-[[ "$(classify "$storm_summary" failure failure failure failure false true 104)" == "INFRA_CONSOLE_STORM" ]] \
-  || fail "(p4) storming first_failure must route to INFRA_CONSOLE_STORM"
-[[ "$(classify "$storm_summary" failure failure failure failure false true 3)" == "FIRST_GENUINE_FAILURE" ]] \
-  || fail "(p4) healthy-console first_failure must stay FIRST_GENUINE_FAILURE"
-pass "(p4) first_failure: storm -> INFRA re-run, healthy -> genuine red"
+# (p2) Captured first-attempt failure evidence must likewise stay RED regardless
+# of raw warning count; retry summary overwrite semantics remain unchanged.
+for warning_count in 0 25 104; do
+  first_failure_verdict="$(classify "$storm_summary" failure failure failure failure false true "$warning_count")"
+  [[ "$first_failure_verdict" == "FIRST_GENUINE_FAILURE" ]] \
+    || fail "(p2) warning count $warning_count routed first_failure to '$first_failure_verdict', expected FIRST_GENUINE_FAILURE"
+done
+pass "(p2) raw warning counts never mask captured first-attempt failure evidence"
 
-# (p5) a storming run that nonetheless PASSED (first or retry success) stays
-#      GREEN — the storm gate never masks a real pass into a re-run.
-[[ "$(classify "$storm_summary" success failure failure failure false false 104)" == "PASS_FIRST" ]] \
-  || fail "(p5) storming first-pass must stay PASS_FIRST (green)"
-[[ "$(classify "$storm_summary" failure success failure failure false false 104)" == "PASS_RETRY" ]] \
-  || fail "(p5) storming retry-pass must stay PASS_RETRY (green)"
-pass "(p5) storm never masks a genuine PASS into a re-run"
-
-# (p6) a storm must NOT preempt the #835 timeout / #771 no-summary branches —
-#      their behavior is intentionally unchanged even with a high storm count.
-storm_timeout_summary="$SANDBOX/storm-timeout-summary.md"
+# (p3) Pass, #835 timeout, cancellation, and #771 no-summary ordering is
+# unchanged by removal of the raw-count classifier.
+[[ "$(classify "$storm_summary" success failure)" == "PASS_FIRST" ]] \
+  || fail "(p3) first-attempt pass no longer routes to PASS_FIRST"
+[[ "$(classify "$storm_summary" failure success)" == "PASS_RETRY" ]] \
+  || fail "(p3) retry pass no longer routes to PASS_RETRY"
+timeout_summary="$SANDBOX/timeout-summary.md"
 printf '%s\n' \
   '# Per-push CI journey suite — summary' \
   'Suite step time budget exhausted — JOURNEY_STEP_TIMEOUT (issue #835 / #470 stall — job red):' \
   '- `com.pocketshell.app.TimedOutClass`' \
-  > "$storm_timeout_summary"
-[[ "$(classify "$storm_timeout_summary" failure failure failure failure true false 104)" == "FIRST_TIMEOUT_RED" ]] \
-  || fail "(p6) a storming first-attempt budget timeout must STAY FIRST_TIMEOUT_RED (#835 unchanged)"
-[[ "$(classify "$storm_timeout_summary" failure failure failure failure false false 104)" == "JOURNEY_TIMEOUT_RED" ]] \
-  || fail "(p6) a storming both-failed budget timeout must STAY JOURNEY_TIMEOUT_RED (#835 unchanged)"
-[[ "$(classify "$storm_timeout_summary" failure failure cancelled failure false false 104)" == "STEP_CANCELLED" ]] \
-  || fail "(p6) a storming cancelled attempt must STAY STEP_CANCELLED"
-missing_storm_summary="$SANDBOX/does-not-exist-storm-summary.md"
-[[ "$(classify "$missing_storm_summary" failure failure failure failure false false 104)" == "INFRA_UNAVAILABLE" ]] \
-  || fail "(p6) a storming no-summary run must STAY INFRA_UNAVAILABLE (#771 unchanged)"
-pass "(p6) storm does not preempt the #835 timeout / cancelled / #771 no-summary branches"
+  > "$timeout_summary"
+[[ "$(classify "$timeout_summary" failure failure failure failure true)" == "FIRST_TIMEOUT_RED" ]] \
+  || fail "(p3) first-attempt budget timeout must stay FIRST_TIMEOUT_RED (#835)"
+[[ "$(classify "$timeout_summary" failure failure failure failure false)" == "JOURNEY_TIMEOUT_RED" ]] \
+  || fail "(p3) both-failed budget timeout must stay JOURNEY_TIMEOUT_RED (#835)"
+[[ "$(classify "$timeout_summary" failure failure cancelled failure false)" == "STEP_CANCELLED" ]] \
+  || fail "(p3) cancelled attempt must stay STEP_CANCELLED"
+missing_summary="$SANDBOX/does-not-exist-summary.md"
+[[ "$(classify "$missing_summary" failure failure)" == "INFRA_UNAVAILABLE" ]] \
+  || fail "(p3) no-summary run must stay INFRA_UNAVAILABLE (#771)"
+pass "(p3) pass / #835 timeout / cancellation / #771 no-summary semantics preserved"
 
 # ---------------------------------------------------------------------------
 # Issue #918: if the per-class `timeout` kills a Gradle invocation, the next
@@ -1060,60 +1037,6 @@ summary_ct="$SANDBOX/artifacts/ci-journey/summary.md"
 grep -qE 'output-burst-IME ANR proof.*\*\*FAIL\*\*' "$summary_ct" \
   || { cat "$summary_ct"; fail "(m) the hung #796 proof must surface as FAIL in the summary (classifiable red, not a cancel)"; }
 pass "(m) core-terminal proofs are timeout-bounded — a hung proof yields a classifiable summary, never a job-cap cancel"
-
-# ---------------------------------------------------------------------------
-# Issue #1458 (AC1): drive the REAL suite with a gradle stub that emits the
-# `Failed to start Emulator console` storm signature and prove run_bounded TEES
-# it to a DURABLE console log the workflow classifier reads AFTER the emulator
-# step ends — while KEEPING live streaming intact (the tee must not break it).
-echo "== #1458 run_bounded tees journey console output to a durable log =="
-cat > "$SANDBOX/gradlew" <<'STUB'
-#!/usr/bin/env bash
-set -u
-[[ "${1:-}" == "--stop" ]] && exit 0
-# Emit the degraded-swiftshader console-storm signature, then a normal task line,
-# then a passing exit — models a storming-but-"passing" run so the tee capture is
-# what proves the storm is durably recorded (not the summary verdict).
-for i in 1 2 3 4 5; do echo "Failed to start Emulator console for 5554"; done
-echo "> Task :app:connectedDebugAndroidTest done"
-exit 0
-STUB
-chmod +x "$SANDBOX/gradlew"
-
-out_tee="$SANDBOX/run-console-tee.log"
-set +e
-PATH="$STUBBIN:$PATH" \
-  JOURNEY_STEP_BUDGET_SECS=600 \
-  JOURNEY_CLASS_TIMEOUT_SECS=60 \
-  bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$out_tee" 2>&1
-rc_tee=$?
-set -e
-
-# The tee must not break a run: this storming-but-"passing" stub exits 0, so the
-# suite must still exit 0 (the durable capture is a side channel, never a gate).
-[[ "$rc_tee" -eq 0 ]] \
-  || { sed -n '1,40p' "$out_tee"; fail "(q0) the #1458 tee broke a passing run (rc=$rc_tee)"; }
-console_log="$SANDBOX/artifacts/ci-journey/journey-console.log"
-[[ -f "$console_log" ]] \
-  || { sed -n '1,40p' "$out_tee"; fail "(q1) run_bounded did not create the durable console log $console_log"; }
-tee_count="$(grep -c 'Failed to start Emulator console' "$console_log" || true)"
-# Each of the many journey + core-terminal classes invokes the stub (5 storm
-# lines each), so the durable count is comfortably above the 25 INFRA-ABORT
-# threshold — this is exactly what the workflow classifier would count.
-(( tee_count >= 25 )) \
-  || { sed -n '1,20p' "$console_log"; fail "(q1) durable console log captured $tee_count storm lines, expected >= 25 (the classifier could not see the storm)"; }
-pass "(q1) run_bounded tees the storm to a durable log the classifier reads (count=$tee_count)"
-
-# (q2) live streaming is UNCHANGED: the storm lines also reached stdout.
-grep -q 'Failed to start Emulator console' "$out_tee" \
-  || { sed -n '1,40p' "$out_tee"; fail "(q2) storm lines were not streamed live — the #1458 tee broke live streaming"; }
-pass "(q2) live streaming intact — storm lines reach stdout AND the durable log"
-
-# (q3) end-to-end: feed the REAL classify() mirror the durable count from this
-# simulated run alongside a JOURNEY_FAILED summary -> INFRA_CONSOLE_STORM.
-[[ "$(classify "$storm_summary" failure failure failure failure false false "$tee_count")" == "INFRA_CONSOLE_STORM" ]] \
-  || fail "(q3) the durably-captured storm count ($tee_count) did not classify a JOURNEY_FAILED as INFRA_CONSOLE_STORM"
-pass "(q3) durable count from a real suite run drives the classifier to INFRA_CONSOLE_STORM"
 
 echo
 echo "ALL TESTS PASSED"

--- a/scripts/test-ci-journey-retry-budget.sh
+++ b/scripts/test-ci-journey-retry-budget.sh
@@ -137,7 +137,7 @@ upload_line="$(grep -n 'name: Upload shard verdict token' "$WORKFLOW" | cut -d: 
 pass "denied path skips retry, then reaches classifier and shard-token upload"
 
 # The new INFRA path must not soften the two pre-existing hard-red meanings:
-# a healthy-console genuine first failure and a #835 suite-budget timeout.
+# a genuine first failure and a #835 suite-budget timeout.
 # shellcheck disable=SC2016 # Literal workflow shell expressions, not test vars.
 first_failure_line="$(grep -Fn 'if [[ "${first_failure:-false}" == "true" ]]' "$WORKFLOW" | cut -d: -f1)"
 # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary

- remove the raw count of Failed to start Emulator console warnings as an INFRA classifier
- remove classifier-only journey console capture plumbing
- keep genuine JOURNEY_FAILED evidence RED at every warning count
- preserve real INFRA states, #835 timeout, retry-budget and aggregate semantics
- correct obsolete console-storm/starvation wording

## Why

AGP/ddmlib emits this optional AVD-metadata warning once per separate connected Gradle invocation while adb instrumentation proceeds. Historical counts equal starts exactly: 104/104, 101/101 and 102/102. Exact-main counts track starts at 57/57, 58/57 with one budget-killed-before-start invocation, and 57/57. The old >=25 gate therefore measured suite size and masked genuine twice-failed journeys as INFRA.

## Evidence

- deterministic base RED with 30 warning-to-Starting-to-Finished blocks plus JOURNEY_FAILED
- fixed GREEN: counts 0, 24, 25, 30 and 104 all remain genuine RED
- first-failure, pass, cancellation, no-summary, #835 timeout and retry-budget branches preserved
- two independent live >=25-to-INFRA mutations killed
- journey budget, retry-budget, aggregate-verdict, harness and harness-selftest green
- bash syntax, ShellCheck error severity, YAML parse and diff check green
- independent review APPROVED

This advances #1458 but does not close it. A later exact-main batch must expose and then resolve the genuine journey failures that the old classifier hid.