### PR TITLE
test: drain Main dispatcher VM fixtures structurally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,17 @@ jobs:
           scripts/check-test-validity.sh
           scripts/check-test-validity-selftest.sh
 
+      # Issue #1355: MainDispatcherRule owns the global Dispatchers.Main reset.
+      # Any standalone TmuxSessionViewModel test that leaves an unregistered VM
+      # can race that reset from a still-unwinding coroutine and fail an
+      # unrelated next class at TestMainDispatcher.kt:72. Keep constructor
+      # registration structural and prove the guard itself goes red.
+      - name: Main-dispatcher VM teardown guard (issue #1355)
+        run: |
+          chmod +x scripts/check-main-dispatcher-vm-teardown.sh
+          scripts/check-main-dispatcher-vm-teardown.sh
+          scripts/check-main-dispatcher-vm-teardown.sh --self-test
+
       # Issue #848: per-push journey harness guard. Proof journeys listed by
       # scripts/ci-journey-suite.sh that launch MainActivity should use the
       # launch-owned createAndroidComposeRule<MainActivity>() +

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestRule
 import org.junit.runners.model.Statement
@@ -33,8 +34,9 @@ import org.junit.runner.Description
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(
-    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+    internal val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
 ) : TestRule {
+    private val beforeResetMain = mutableListOf<() -> Unit>()
 
     override fun apply(base: Statement, description: Description): Statement =
         object : Statement() {
@@ -52,11 +54,53 @@ class MainDispatcherRule(
                         base.evaluate()
                     } finally {
                         LivenessProbeTestOverride.clear()
-                        Dispatchers.resetMain()
+                        var cleanupFailure: Throwable? = null
+                        beforeResetMain.asReversed().forEach { teardown ->
+                            try {
+                                teardown()
+                            } catch (failure: Throwable) {
+                                val firstFailure = cleanupFailure
+                                if (firstFailure == null) {
+                                    cleanupFailure = failure
+                                } else if (firstFailure !== failure) {
+                                    firstFailure.addSuppressed(failure)
+                                }
+                            }
+                        }
+                        beforeResetMain.clear()
+                        try {
+                            Dispatchers.resetMain()
+                        } catch (failure: Throwable) {
+                            val firstFailure = cleanupFailure
+                            if (firstFailure == null) {
+                                cleanupFailure = failure
+                            } else if (firstFailure !== failure) {
+                                firstFailure.addSuppressed(failure)
+                            }
+                        }
+                        cleanupFailure?.let { throw it }
                     }
                 }
             }
         }
+
+    /**
+     * Registers test-owned cleanup that must finish while the rule's process-global
+     * Main dispatcher is still installed.
+     *
+     * This is deliberately a test-only lifecycle seam rather than a generic JUnit
+     * `@After`: the rule owns the ordering boundary, so a consumer cannot
+     * accidentally return from `@After` and let [Dispatchers.resetMain] race a
+     * still-unwinding coroutine.
+     */
+    internal fun beforeResetMain(teardown: () -> Unit) {
+        beforeResetMain += teardown
+    }
+
+    /** Runs only work already due on this rule's virtual clock; never advances time. */
+    internal fun runCurrent() {
+        dispatcher.scheduler.runCurrent()
+    }
 
     private companion object {
         private val mainDispatcherLock = Any()

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1574DeadReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1574DeadReconnectTest.kt
@@ -14,14 +14,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -63,15 +64,23 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue1574DeadReconnectTest {
 
+    private val scheduler = TestCoroutineScheduler()
+    private val testMainDispatcher = UnconfinedTestDispatcher(scheduler)
+
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule()
+    val mainDispatcherRule = MainDispatcherRule(testMainDispatcher)
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
+    private val factoryScope =
+        teardown.trackRoot(
+            "factoryScope",
+            CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        )
+    private val leaseScope =
+        teardown.trackRoot(
+            "leaseScope",
+            CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler)),
+        )
 
     /**
      * Issue #998 determinism helper (copied from TmuxSessionWarmOpenTest): the
@@ -96,12 +105,14 @@ class Issue1574DeadReconnectTest {
     private fun newVm(
         registry: ActiveTmuxClients,
         sshLeaseManager: com.pocketshell.core.ssh.SshLeaseManager,
-    ): TmuxSessionViewModel = TmuxSessionViewModel(
-        tmuxClientFactory = TmuxClientFactory(factoryScope),
-        activeTmuxClients = registry,
-        runtimeCache = TmuxSessionRuntimeCache(),
-        sshLeaseManager = sshLeaseManager,
-        sessionLifecycleSignals = null,
+    ): TmuxSessionViewModel = teardown.track(
+        TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = registry,
+            runtimeCache = TmuxSessionRuntimeCache(),
+            sshLeaseManager = sshLeaseManager,
+            sessionLifecycleSignals = null,
+        ),
     ).also {
         // Issue #926: pin the seed-IO dispatcher to the rule's test Main so the
         // attach/reattach round-trips run inline on the test clock.
@@ -146,13 +157,13 @@ class Issue1574DeadReconnectTest {
     }
 
     @Test
-    fun genericTerminalDialFailure_showingSession_isReconnectableFromRetainedIntent() = runTest {
+    fun genericTerminalDialFailure_showingSession_isReconnectableFromRetainedIntent() = runTest(scheduler) {
         val registry = ActiveTmuxClients()
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(
                 connector = AlwaysConnectingConnector(),
-                scope = this,
+                scope = leaseScope,
                 idleTtlMillis = 60_000L,
             ),
         )
@@ -188,13 +199,13 @@ class Issue1574DeadReconnectTest {
     }
 
     @Test
-    fun neverOpenedSession_reconnectStillReturnsFalse() = runTest {
+    fun neverOpenedSession_reconnectStillReturnsFalse() = runTest(scheduler) {
         val registry = ActiveTmuxClients()
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(
                 connector = AlwaysConnectingConnector(),
-                scope = this,
+                scope = leaseScope,
                 idleTtlMillis = 60_000L,
             ),
         )
@@ -208,18 +219,24 @@ class Issue1574DeadReconnectTest {
     }
 
     @Test
-    fun normalActiveConnection_reconnectUnchanged() = runTest {
+    fun normalActiveConnection_reconnectUnchanged() = runTest(scheduler) {
         val registry = ActiveTmuxClients()
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(
                 connector = AlwaysConnectingConnector(),
-                scope = this,
+                scope = leaseScope,
                 idleTtlMillis = 60_000L,
             ),
         )
         vm.setAutoReconnectDelaysForTest(emptyList())
-        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        // Seed both the initial attach and the reconnect. The old one-round
+        // fixture let this method return with reconnect parked inside its
+        // NonCancellable teardown, which is the #1355 leak seen by the next
+        // rule reset.
+        val client = FakeTmuxClient()
+            .withSinglePaneRow("work", "%1")
+            .withSinglePaneRow("work", "%1")
         vm.setTmuxClientFactoryForTest { _, _, _ -> client }
         vm.connect(
             hostId = 1L,
@@ -240,10 +257,17 @@ class Issue1574DeadReconnectTest {
         // Unchanged: an active target is present, reconnect() still returns true.
         assertTrue("canReconnect stays true with a live active target", vm.canReconnect.value)
         assertTrue("reconnect() with a live active target is unchanged", vm.reconnect())
+        // The reconnect entry point launches a NonCancellable close cascade.
+        // Settle that production path while this test still owns its virtual
+        // clock; a runCurrent-only @After must never advance a product timeout
+        // merely to make teardown finish.
+        pumpUntil(reason = "active reconnect settled back on Connected") {
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
     }
 
     @Test
-    fun genuinelyGoneColdRestore_reconnectStaysFalse_noResurrection() = runTest {
+    fun genuinelyGoneColdRestore_reconnectStaysFalse_noResurrection() = runTest(scheduler) {
         // A GENUINELY-gone session (the cold-restore `has-session` preflight exits
         // non-zero) drops to the list via [failSessionEnded]. The #1574 reconnect
         // fallback must NOT resurrect it — the retained intent is cleared, so
@@ -254,7 +278,7 @@ class Issue1574DeadReconnectTest {
             registry = registry,
             sshLeaseManager = testLeaseManager(
                 connector = SingleSessionConnector(goneSession),
-                scope = this,
+                scope = leaseScope,
                 idleTtlMillis = 60_000L,
             ),
         )

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1575PassphraseDedupeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1575PassphraseDedupeTest.kt
@@ -13,11 +13,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -62,29 +63,39 @@ import java.util.concurrent.atomic.AtomicInteger
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue1575PassphraseDedupeTest {
 
-    @get:Rule
-    val mainDispatcherRule = MainDispatcherRule()
+    private val scheduler = TestCoroutineScheduler()
+    private val testMainDispatcher = UnconfinedTestDispatcher(scheduler)
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testMainDispatcher)
+
+    private val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
+    private val factoryScope =
+        teardown.trackRoot(
+            "factoryScope",
+            CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        )
+    private val leaseScope =
+        teardown.trackRoot(
+            "leaseScope",
+            CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler)),
+        )
 
     /** Fresh-client factory build count — corroborates the attempts signal per-instance. */
     private val builds = AtomicInteger(0)
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun TestScope.newVm(): TmuxSessionViewModel = TmuxSessionViewModel(
-        tmuxClientFactory = TmuxClientFactory(factoryScope),
-        activeTmuxClients = ActiveTmuxClients(),
-        runtimeCache = TmuxSessionRuntimeCache(),
-        sshLeaseManager = testLeaseManager(
-            connector = AlwaysConnectingConnector(),
-            scope = this,
-            idleTtlMillis = 60_000L,
+    private fun TestScope.newVm(): TmuxSessionViewModel = teardown.track(
+        TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = ActiveTmuxClients(),
+            runtimeCache = TmuxSessionRuntimeCache(),
+            sshLeaseManager = testLeaseManager(
+                connector = AlwaysConnectingConnector(),
+                scope = leaseScope,
+                idleTtlMillis = 60_000L,
+            ),
+            sessionLifecycleSignals = null,
         ),
-        sessionLifecycleSignals = null,
     ).also {
         it.setSeedIoDispatcherForTest(Dispatchers.Main)
         it.setAutoReconnectDelaysForTest(emptyList())
@@ -114,7 +125,7 @@ class Issue1575PassphraseDedupeTest {
     }
 
     @Test
-    fun passphraseHost_reenterSameSession_isDedupedNoSpuriousReconnect() = runTest {
+    fun passphraseHost_reenterSameSession_isDedupedNoSpuriousReconnect() = runTest(scheduler) {
         val vm = newVm()
         // First open of a passphrase-protected host + session "work".
         vm.connectTo(passphrase = charArrayOf('s', 'e', 'c', 'r', 'e', 't'), sessionName = "work")
@@ -150,7 +161,7 @@ class Issue1575PassphraseDedupeTest {
     }
 
     @Test
-    fun noPassphraseHost_reenterSameSession_staysDeduped() = runTest {
+    fun noPassphraseHost_reenterSameSession_staysDeduped() = runTest(scheduler) {
         // Class coverage: the previously-working case must remain deduped (regression guard).
         val vm = newVm()
         vm.connectTo(passphrase = null, sessionName = "work")
@@ -179,7 +190,7 @@ class Issue1575PassphraseDedupeTest {
     }
 
     @Test
-    fun passphraseHost_differentSession_isNotFalselyDeduped() = runTest {
+    fun passphraseHost_differentSession_isNotFalselyDeduped() = runTest(scheduler) {
         // Class coverage: a GENUINELY different session (different name) on the same
         // passphrase host must NOT be deduped — the switch/reconnect must still fire.
         val vm = newVm()

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue895SwitchWhileBlackDropTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue895SwitchWhileBlackDropTest.kt
@@ -4,7 +4,9 @@ import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -48,31 +50,47 @@ class Issue895SwitchWhileBlackDropTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule(testMainDispatcher)
 
+    private val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
+    private val factoryScope =
+        teardown.trackRoot(
+            "factoryScope",
+            CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler)),
+        )
+    private val leaseScope =
+        teardown.trackRoot(
+            "leaseScope",
+            CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler)),
+        )
+
     private fun newVm(registry: ActiveTmuxClients): TmuxSessionViewModel =
-        TmuxSessionViewModel(
-            tmuxClientFactory = com.pocketshell.core.tmux.TmuxClientFactory(
-                kotlinx.coroutines.CoroutineScope(StandardTestDispatcher(scheduler)),
+        teardown.track(
+            TmuxSessionViewModel(
+                tmuxClientFactory = com.pocketshell.core.tmux.TmuxClientFactory(
+                    factoryScope,
+                ),
+                activeTmuxClients = registry,
+                hostDao = null,
+                folderListGateway = null,
+                runtimeCache = TmuxSessionRuntimeCache(),
+                agentSessionMemory = AgentSessionMemory(),
+                sshLeaseManager = SshLeaseManager(
+                    connector = SshLeaseConnector { target ->
+                        error("unexpected SSH lease connect for ${target.leaseKey}")
+                    },
+                    scope = leaseScope,
+                    idleTtlMillis = 0L,
+                    connectTimeoutContext = StandardTestDispatcher(scheduler),
+                    abortTimeoutContext = StandardTestDispatcher(scheduler),
+                    nowMillis = { scheduler.currentTime },
+                ),
+                sessionLifecycleSignals = null,
+                // Issue #1168: the default real-IO `tailScope` is safe here — these
+                // tests only connect/drop SHELL sessions and never start an agent
+                // follow, so `tailScope` never launches a drain and there is no
+                // `invokeOnCompletion -> bridgeScope.launch` Main read to leak past
+                // teardown. (No agent pane is bound/followed anywhere in this class.)
+                agentRepository = com.pocketshell.app.session.AgentConversationRepository(),
             ),
-            activeTmuxClients = registry,
-            hostDao = null,
-            folderListGateway = null,
-            runtimeCache = TmuxSessionRuntimeCache(),
-            agentSessionMemory = AgentSessionMemory(),
-            sshLeaseManager = SshLeaseManager(
-                connector = SshLeaseConnector { target ->
-                    error("unexpected SSH lease connect for ${target.leaseKey}")
-                },
-                idleTtlMillis = 0L,
-                connectTimeoutContext = StandardTestDispatcher(scheduler),
-                nowMillis = { scheduler.currentTime },
-            ),
-            sessionLifecycleSignals = null,
-            // Issue #1168: the default real-IO `tailScope` is safe here — these
-            // tests only connect/drop SHELL sessions and never start an agent
-            // follow, so `tailScope` never launches a drain and there is no
-            // `invokeOnCompletion -> bridgeScope.launch` Main read to leak past
-            // teardown. (No agent pane is bound/followed anywhere in this class.)
-            agentRepository = com.pocketshell.app.session.AgentConversationRepository(),
         ).also {
             it.setReconcileDispatcherForTest(testMainDispatcher)
             it.setReconcileApplyDispatcherForTest(testMainDispatcher)

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCloseCascadeNoCrashTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCloseCascadeNoCrashTest.kt
@@ -21,10 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.job
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
@@ -32,7 +29,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -95,11 +91,17 @@ class TmuxSessionCloseCascadeNoCrashTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule(testMainDispatcher)
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
+    private val factoryScope =
+        teardown.trackRoot(
+            "factoryScope",
+            CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        )
 
     // Issue #1168: the AgentConversationRepository tail scope, injected so the
     // default `newVm()` owns it (instead of the repository's own default
-    // real-`Dispatchers.IO` `tailScope`) and can cancel-then-join it in @After.
+    // real-`Dispatchers.IO` `tailScope`) and lets the rule-owned registry
+    // cancel-then-join it before Main resets.
     // Same species as `factoryScope`: an infinite `while (isActive) { delay() }`
     // drain whose `invokeOnCompletion -> bridgeScope.launch` reads
     // `Dispatchers.Main` from a foreign IO thread; un-joined, that read races
@@ -108,8 +110,16 @@ class TmuxSessionCloseCascadeNoCrashTest {
     // agent conversation, so this class is in the same latent-leak class as
     // TmuxSessionViewModelTest — pin the scope rather than leave a sibling that
     // could reintroduce the #1168 flake.
-    private val agentTailScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdViewModels = mutableListOf<TmuxSessionViewModel>()
+    private val agentTailScope =
+        teardown.trackRoot(
+            "agentTailScope",
+            CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        )
+    private val leaseScope =
+        teardown.trackRoot(
+            "leaseScope",
+            CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler)),
+        )
 
     // The thread-level uncaught-exception probe. On device this slot is the
     // CrashReporter handler that records then re-delegates to the platform
@@ -132,25 +142,29 @@ class TmuxSessionCloseCascadeNoCrashTest {
         folderListGateway: FolderListGateway? = null,
         hostDao: HostDao? = null,
         // Issue #1168: inject the test-owned real-IO `agentTailScope` so the tail
-        // drain is joinable in @After (see the field doc).
+        // drain is joinable by the rule-owned teardown registry (see the field doc).
         agentRepository: AgentConversationRepository =
             AgentConversationRepository(tailScope = agentTailScope),
     ): TmuxSessionViewModel =
-        TmuxSessionViewModel(
-            tmuxClientFactory = TmuxClientFactory(factoryScope),
-            activeTmuxClients = registry,
-            hostDao = hostDao,
-            folderListGateway = folderListGateway,
-            sshLeaseManager = SshLeaseManager(
-                connector = SshLeaseConnector { target ->
-                    error("unexpected SSH lease connect for ${target.leaseKey}")
-                },
-                idleTtlMillis = 0L,
-                connectTimeoutContext = StandardTestDispatcher(scheduler),
-                nowMillis = { scheduler.currentTime },
+        teardown.track(
+            TmuxSessionViewModel(
+                tmuxClientFactory = TmuxClientFactory(factoryScope),
+                activeTmuxClients = registry,
+                hostDao = hostDao,
+                folderListGateway = folderListGateway,
+                sshLeaseManager = SshLeaseManager(
+                    connector = SshLeaseConnector { target ->
+                        error("unexpected SSH lease connect for ${target.leaseKey}")
+                    },
+                    scope = leaseScope,
+                    idleTtlMillis = 0L,
+                    connectTimeoutContext = StandardTestDispatcher(scheduler),
+                    abortTimeoutContext = StandardTestDispatcher(scheduler),
+                    nowMillis = { scheduler.currentTime },
+                ),
+                sessionLifecycleSignals = sessionLifecycleSignals,
+                agentRepository = agentRepository,
             ),
-            sessionLifecycleSignals = sessionLifecycleSignals,
-            agentRepository = agentRepository,
         ).also {
             it.setReconcileDispatcherForTest(testMainDispatcher)
             it.setReconcileApplyDispatcherForTest(testMainDispatcher)
@@ -162,29 +176,11 @@ class TmuxSessionCloseCascadeNoCrashTest {
             // `Dispatchers.IO` (off the UI thread, so the seed never freezes it).
             it.setSeedIoDispatcherForTest(testMainDispatcher)
             it.setPortDetectionDispatcherForTest(testMainDispatcher)
-            createdViewModels += it
         }
 
     @After
     fun tearDown() {
         previousThreadHandler?.let { Thread.setDefaultUncaughtExceptionHandler(it) }
-        createdViewModels.asReversed().forEach { vm -> runCatching { vm.clearForTest() } }
-        createdViewModels.clear()
-        factoryScope.cancel()
-        // Issue #1168: cancel-THEN-join the agent tail scope BEFORE @After
-        // returns (i.e. before the rule's `resetMain()`). The drain is an
-        // infinite loop, so it must be cancelled first, then joined — draining
-        // every `invokeOnCompletion -> bridgeScope.launch` foreign-IO Main read
-        // while Main is still stable, so nothing touches Main after `resetMain`.
-        agentTailScope.cancel()
-        runBlocking {
-            withTimeoutOrNull(5_000L) {
-                factoryScope.coroutineContext.job.children.forEach { it.join() }
-            }
-            withTimeoutOrNull(5_000L) {
-                agentTailScope.coroutineContext.job.children.forEach { it.join() }
-            }
-        }
     }
 
     private fun attach(

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionOpenFailedReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionOpenFailedReconnectTest.kt
@@ -16,11 +16,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -49,25 +51,35 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class TmuxSessionOpenFailedReconnectTest {
 
+    private val scheduler = TestCoroutineScheduler()
+    private val testMainDispatcher = UnconfinedTestDispatcher(scheduler)
+
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule()
+    val mainDispatcherRule = MainDispatcherRule(testMainDispatcher)
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
+    private val factoryScope =
+        teardown.trackRoot(
+            "factoryScope",
+            CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        )
+    private val leaseScope =
+        teardown.trackRoot(
+            "leaseScope",
+            CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler)),
+        )
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun TestNewVm(
+    private fun TestScope.testNewVm(
         registry: ActiveTmuxClients,
         sshLeaseManager: SshLeaseManager,
-    ): TmuxSessionViewModel = TmuxSessionViewModel(
-        tmuxClientFactory = TmuxClientFactory(factoryScope),
-        activeTmuxClients = registry,
-        runtimeCache = TmuxSessionRuntimeCache(),
-        sshLeaseManager = sshLeaseManager,
-        sessionLifecycleSignals = null,
+    ): TmuxSessionViewModel = teardown.track(
+        TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = registry,
+            runtimeCache = TmuxSessionRuntimeCache(),
+            sshLeaseManager = sshLeaseManager,
+            sessionLifecycleSignals = null,
+        ),
     ).also {
         // Issue #926: pin the seed-IO dispatcher (off-Main hop for the
         // attach/reattach `capture-pane`/`list-panes` IO) to the rule's test
@@ -79,7 +91,7 @@ class TmuxSessionOpenFailedReconnectTest {
     }
 
     @Test
-    fun reconnectRecoversFromOpenFailedByEvictingPoisonedTransport() = runTest {
+    fun reconnectRecoversFromOpenFailedByEvictingPoisonedTransport() = runTest(scheduler) {
         // The pool holds a transport that stays `isConnected` but whose
         // channel-open keeps failing — exactly the half-dead transport that
         // surfaces "open failed". A fresh transport works.
@@ -87,9 +99,9 @@ class TmuxSessionOpenFailedReconnectTest {
         val healthySession = AlwaysConnectedSession(id = "healthy")
         val connector = TwoSessionConnector(poisonedSession, healthySession)
         val registry = ActiveTmuxClients()
-        val vm = TestNewVm(
+        val vm = testNewVm(
             registry = registry,
-            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+            sshLeaseManager = testLeaseManager(connector = connector, scope = leaseScope, idleTtlMillis = 0L),
         )
 
         // Disable auto-reconnect so the test drives the manual Retry deterministically.
@@ -162,14 +174,14 @@ class TmuxSessionOpenFailedReconnectTest {
     }
 
     @Test
-    fun reconnectRecoversFromCommandTimeoutByEvictingPoisonedTransport() = runTest {
+    fun reconnectRecoversFromCommandTimeoutByEvictingPoisonedTransport() = runTest(scheduler) {
         val poisonedSession = AlwaysConnectedSession(id = "poisoned")
         val healthySession = AlwaysConnectedSession(id = "healthy")
         val connector = TwoSessionConnector(poisonedSession, healthySession)
         val registry = ActiveTmuxClients()
-        val vm = TestNewVm(
+        val vm = testNewVm(
             registry = registry,
-            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+            sshLeaseManager = testLeaseManager(connector = connector, scope = leaseScope, idleTtlMillis = 60_000L),
         )
 
         vm.setAutoReconnectDelaysForTest(emptyList())
@@ -232,14 +244,14 @@ class TmuxSessionOpenFailedReconnectTest {
     }
 
     @Test
-    fun reconnectRecoversFromListPanesEofWriteByEvictingPoisonedTransport() = runTest {
+    fun reconnectRecoversFromListPanesEofWriteByEvictingPoisonedTransport() = runTest(scheduler) {
         val poisonedSession = AlwaysConnectedSession(id = "poisoned")
         val healthySession = AlwaysConnectedSession(id = "healthy")
         val connector = TwoSessionConnector(poisonedSession, healthySession)
         val registry = ActiveTmuxClients()
-        val vm = TestNewVm(
+        val vm = testNewVm(
             registry = registry,
-            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L),
+            sshLeaseManager = testLeaseManager(connector = connector, scope = leaseScope, idleTtlMillis = 60_000L),
         )
 
         vm.setAutoReconnectDelaysForTest(emptyList())

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardown.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardown.kt
@@ -1,0 +1,210 @@
+package com.pocketshell.app.tmux
+
+import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.hosts.MainDispatcherRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Shared #1355 teardown for standalone [MainDispatcherRule] consumers that
+ * construct [TmuxSessionViewModel].
+ *
+ * `clearForTest()` invokes `onCleared()` directly, so it does not perform the
+ * framework-owned `viewModelScope` cancellation. A bare `CoroutineScope.cancel`
+ * also returns before a real-IO child has necessarily unwound. Both can leave a
+ * continuation that reads `Dispatchers.Main` after the rule resets the global
+ * delegate, recreating the `TestMainDispatcher:72` race in an unrelated test.
+ *
+ * This registry makes the ordering structural:
+ *
+ * 1. clear every tracked VM while Main is installed;
+ * 2. cancel every VM-owned root and every explicitly owned collaborator root;
+ * 3. cancel-and-join the collaborator roots;
+ * 4. use only `runCurrent()` (never virtual-time advancement) to drain all VM
+ *    roots to zero; and
+ * 5. return to [MainDispatcherRule], which only then resets Main.
+ */
+internal class TmuxSessionViewModelRuleTeardown(
+    private val rule: MainDispatcherRule,
+    private val timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+) {
+    private data class TrackedVm(
+        val clear: () -> Unit,
+        val cancelOwnScopes: () -> Unit,
+        val activeOwnScopeChildCount: () -> Int,
+        val debugActiveChildren: () -> String,
+    )
+
+    private data class TrackedRoot(
+        val name: String,
+        val job: Job,
+    )
+
+    private val vms = mutableListOf<TrackedVm>()
+    private val roots = mutableListOf<TrackedRoot>()
+    private var drained = false
+
+    init {
+        require(timeoutMs > 0L) { "timeoutMs must be > 0, was $timeoutMs" }
+        rule.beforeResetMain(::drain)
+    }
+
+    fun track(vm: TmuxSessionViewModel): TmuxSessionViewModel =
+        vm.also {
+            track(
+                clear = {
+                    vm.setProcessForegroundForClearedForTest(false)
+                    vm.clearForTest()
+                },
+                cancelOwnScopes = vm::cancelOwnScopesForTest,
+                activeOwnScopeChildCount = vm::activeOwnScopeChildCountForTest,
+                debugActiveChildren = {
+                    vm.viewModelScope.coroutineContext[Job]
+                        ?.children
+                        ?.filterNot(Job::isCompleted)
+                        ?.joinToString(separator = "\n") { child -> child.debugTree() }
+                        .orEmpty()
+                },
+            )
+        }
+
+    fun trackRoot(name: String, scope: CoroutineScope): CoroutineScope =
+        scope.also {
+            roots += TrackedRoot(
+                name = name,
+                job = requireNotNull(scope.coroutineContext[Job]) {
+                    "Issue #1355: $name must have an owned root Job"
+                },
+            )
+        }
+
+    /**
+     * Test adapter for the teardown invariant itself. Production-shaped callers
+     * use [track]; both paths share the exact cancellation/drain implementation.
+     */
+    internal fun track(
+        clear: () -> Unit,
+        cancelOwnScopes: () -> Unit,
+        activeOwnScopeChildCount: () -> Int,
+        debugActiveChildren: () -> String = { "" },
+    ) {
+        check(!drained) { "cannot track a VM after the #1355 teardown drained" }
+        vms += TrackedVm(clear, cancelOwnScopes, activeOwnScopeChildCount, debugActiveChildren)
+    }
+
+    internal fun drain() {
+        if (drained) return
+        drained = true
+
+        var cleanupFailure: Throwable? = null
+        fun capture(block: () -> Unit) {
+            try {
+                block()
+            } catch (failure: Throwable) {
+                val firstFailure = cleanupFailure
+                if (firstFailure == null) {
+                    cleanupFailure = failure
+                } else if (firstFailure !== failure) {
+                    firstFailure.addSuppressed(failure)
+                }
+            }
+        }
+
+        vms.asReversed().forEach { vm -> capture(vm.clear) }
+        // Let already-due Main work reach its next suspension before requesting
+        // cancellation. In particular, Issue1574 ends one method immediately
+        // after starting reconnect(); cancelling first can strand that
+        // reconnect inside its NonCancellable close cascade. This is
+        // runCurrent-only: watchdog deadlines never advance.
+        capture(rule::runCurrent)
+        vms.forEach { vm -> capture(vm.cancelOwnScopes) }
+        roots.forEach { root -> capture(root.job::cancel) }
+
+        roots.forEach { root ->
+            capture {
+                drainUntil(
+                    description = "owned ${root.name} root",
+                    remaining = { if (root.job.isCompleted) 0 else 1 },
+                    cancel = root.job::cancel,
+                )
+                // The bounded pump above makes this non-blocking. Keeping the
+                // actual cancelAndJoin call is the load-bearing proof that a
+                // real-IO factory/lease root cannot survive the rule boundary.
+                runBlocking {
+                    withTimeout(timeoutMs) {
+                        root.job.cancelAndJoin()
+                    }
+                }
+            }
+        }
+
+        capture {
+            drainUntil(
+                description = "TmuxSessionViewModel-owned coroutine",
+                remaining = { vms.sumOf { it.activeOwnScopeChildCount() } },
+                cancel = { vms.forEach { it.cancelOwnScopes() } },
+                debug = {
+                    vms.mapIndexedNotNull { index, vm ->
+                        vm.debugActiveChildren().takeIf(String::isNotBlank)?.let {
+                            "VM[$index]\n$it"
+                        }
+                    }.joinToString(separator = "\n")
+                },
+            )
+        }
+
+        roots.clear()
+        vms.clear()
+        cleanupFailure?.let { throw it }
+    }
+
+    private fun drainUntil(
+        description: String,
+        remaining: () -> Int,
+        cancel: () -> Unit,
+        debug: () -> String = { "" },
+    ) {
+        val deadlineNanos = System.nanoTime() + timeoutMs * NANOS_PER_MILLISECOND
+        while (true) {
+            cancel()
+            rule.runCurrent()
+            val active = remaining()
+            if (active == 0) return
+            if (System.nanoTime() >= deadlineNanos) {
+                throw AssertionError(
+                    "Issue #1355: $active $description child(ren) did not quiesce within " +
+                        "${timeoutMs}ms while Main was installed; resetting Main would " +
+                        "recreate the TestMainDispatcher:72 race" +
+                        debug().takeIf(String::isNotBlank)?.let { "\n$it" }.orEmpty(),
+                )
+            }
+            Thread.sleep(1L)
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_TIMEOUT_MS = 30_000L
+        const val NANOS_PER_MILLISECOND = 1_000_000L
+    }
+}
+
+private fun Job.debugTree(indent: String = ""): String =
+    buildString {
+        append(indent)
+        append(this@debugTree)
+        children.filterNot(Job::isCompleted).forEach { child ->
+            append('\n')
+            append(child.debugTree("$indent  "))
+        }
+    }
+
+internal fun MainDispatcherRule.tmuxSessionViewModelTeardown(
+    timeoutMs: Long = 30_000L,
+): TmuxSessionViewModelRuleTeardown =
+    TmuxSessionViewModelRuleTeardown(
+        rule = this,
+        timeoutMs = timeoutMs,
+    )

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardownTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardownTest.kt
@@ -1,0 +1,99 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.hosts.MainDispatcherRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+class TmuxSessionViewModelRuleTeardownTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun registeredTeardownRunsBeforeTheRuleResetsMain() {
+        val ranOnInstalledMain = AtomicBoolean(false)
+        mainDispatcherRule.beforeResetMain {
+            CoroutineScope(Dispatchers.Main).launch {
+                ranOnInstalledMain.set(true)
+            }
+            mainDispatcherRule.runCurrent()
+            assertTrue(
+                "registered teardown must run while Dispatchers.Main is still installed",
+                ranOnInstalledMain.get(),
+            )
+        }
+    }
+
+    @Test
+    fun automaticRuleFinallyDrainsRegisteredTeardownInLifoOrder() {
+        var activeChildren = 1
+        // Register the assertion first. MainDispatcherRule runs callbacks LIFO,
+        // so the registry created below must drain before this assertion. This
+        // test deliberately never calls drain(): removing the registry's
+        // beforeResetMain(::drain) registration leaves activeChildren == 1 and
+        // fails from the rule's real finally boundary.
+        mainDispatcherRule.beforeResetMain {
+            assertEquals(
+                "the automatic registry callback must run before an earlier rule cleanup",
+                0,
+                activeChildren,
+            )
+        }
+        val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown(timeoutMs = 100L)
+        teardown.track(
+            clear = {},
+            cancelOwnScopes = { activeChildren = 0 },
+            activeOwnScopeChildCount = { activeChildren },
+        )
+    }
+
+    @Test
+    fun omittedVmCancellationHardFailsInsteadOfLeakingAcrossTheRuleBoundary() {
+        val events = mutableListOf<String>()
+        var activeChildren = 1
+        val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown(timeoutMs = 100L)
+        teardown.track(
+            clear = { events += "clear" },
+            cancelOwnScopes = {
+                events += "cancel"
+                activeChildren = 0
+            },
+            activeOwnScopeChildCount = { activeChildren },
+        )
+
+        teardown.drain()
+
+        assertEquals(listOf("clear", "cancel", "cancel"), events)
+        assertEquals(0, activeChildren)
+    }
+
+    @Test
+    fun ownedRealIoRootIsCancelledAndJoinedBeforeMainReset() {
+        val started = AtomicBoolean(false)
+        val root = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown(timeoutMs = 5_000L)
+        teardown.trackRoot("fixture", root)
+        root.launch {
+            started.set(true)
+            awaitCancellation()
+        }
+        while (!started.get()) {
+            Thread.yield()
+        }
+
+        teardown.drain()
+
+        assertTrue(
+            "the tracked root Job must be fully completed, not merely cancellation-requested",
+            root.coroutineContext[kotlinx.coroutines.Job]!!.isCompleted,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelVoiceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelVoiceTest.kt
@@ -8,10 +8,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -37,11 +35,18 @@ class TmuxSessionViewModelVoiceTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
+    private val factoryScope =
+        teardown.trackRoot(
+            "factoryScope",
+            CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        )
 
-    private fun newVm(): TmuxSessionViewModel = TmuxSessionViewModel(
-        tmuxClientFactory = TmuxClientFactory(factoryScope),
-        activeTmuxClients = ActiveTmuxClients(),
+    private fun newVm(): TmuxSessionViewModel = teardown.track(
+        TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = ActiveTmuxClients(),
+        ),
     ).also {
         // Issue #926: pin the seed-IO dispatcher (off-Main hop for the
         // attach/switch/reattach `capture-pane`/`list-panes` IO) to the rule's
@@ -49,11 +54,6 @@ class TmuxSessionViewModelVoiceTest {
         // of a real `Dispatchers.IO` thread `runTest` cannot drain. Production
         // defaults to `Dispatchers.IO` (off the UI thread).
         it.setSeedIoDispatcherForTest(Dispatchers.Main)
-    }
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
     }
 
     @Test

--- a/scripts/check-main-dispatcher-vm-teardown.sh
+++ b/scripts/check-main-dispatcher-vm-teardown.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Issue #1355: every standalone JVM test that combines MainDispatcherRule with
+# TmuxSessionViewModel must register each VM constructor with the rule-owned
+# teardown registry. Otherwise a VM continuation can outlive resetMain() and
+# fail an unrelated next class at TestMainDispatcher.kt:72.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+run_guard() {
+  local scan_root="${POCKETSHELL_RULE_VM_GUARD_ROOT:-$REPO_ROOT}"
+  python3 - "$scan_root" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1]).resolve()
+test_root = root / "app/src/test/java"
+exemptions = {
+    # This inherited mega-suite has its own audited multi-root teardown because
+    # its terminal-feed integration deliberately needs specialized real-IO
+    # pumping. Issue #1355 migrates the standalone rule consumers only.
+    Path("app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt"),
+}
+
+constructor = re.compile(r"\bTmuxSessionViewModel\s*\(")
+tracked_constructor = re.compile(
+    r"\bteardown\s*\.\s*track\s*\(\s*TmuxSessionViewModel\s*\(",
+    re.DOTALL,
+)
+registry = re.compile(
+    r"\bmainDispatcherRule\s*\.\s*tmuxSessionViewModelTeardown\s*\("
+)
+
+failures = []
+consumers = []
+exempt_found = 0
+for path in sorted(test_root.rglob("*.kt")):
+    text = path.read_text(encoding="utf-8")
+    if "MainDispatcherRule(" not in text or not constructor.search(text):
+        continue
+    relative = path.relative_to(root)
+    consumers.append(relative)
+    if relative in exemptions:
+        exempt_found += 1
+        continue
+    constructors = len(constructor.findall(text))
+    tracked = len(tracked_constructor.findall(text))
+    if not registry.search(text):
+        failures.append(f"{relative}: missing mainDispatcherRule.tmuxSessionViewModelTeardown()")
+    if tracked != constructors:
+        failures.append(
+            f"{relative}: {constructors - tracked} of {constructors} "
+            "TmuxSessionViewModel constructor(s) are not wrapped in teardown.track(...)"
+        )
+
+if failures:
+    print("FAIL: MainDispatcherRule/TmuxSessionViewModel teardown guard (#1355)")
+    for failure in failures:
+        print(f"  - {failure}")
+    raise SystemExit(1)
+
+print(
+    "PASS: MainDispatcherRule/TmuxSessionViewModel teardown guard "
+    f"(#1355) — {len(consumers) - exempt_found} standalone consumer(s) registered; "
+    f"{exempt_found} audited inherited-suite exemption(s)."
+)
+PY
+}
+
+if [[ "${1:-}" != "--self-test" ]]; then
+  run_guard
+  exit 0
+fi
+
+fixture_root="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "$fixture_root"
+}
+trap cleanup EXIT INT TERM
+fixture_dir="$fixture_root/app/src/test/java/com/pocketshell/app/tmux"
+mkdir -p "$fixture_dir"
+
+cat > "$fixture_dir/GoodTest.kt" <<'EOF'
+class GoodTest {
+    val mainDispatcherRule = MainDispatcherRule()
+    val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
+    fun newVm() = teardown.track(
+        TmuxSessionViewModel(),
+    )
+}
+EOF
+POCKETSHELL_RULE_VM_GUARD_ROOT="$fixture_root" run_guard
+
+cat > "$fixture_dir/BadTest.kt" <<'EOF'
+class BadTest {
+    val mainDispatcherRule = MainDispatcherRule()
+    fun newVm() = TmuxSessionViewModel()
+}
+EOF
+set +e
+bad_output="$(POCKETSHELL_RULE_VM_GUARD_ROOT="$fixture_root" run_guard 2>&1)"
+bad_rc=$?
+set -e
+if [[ "$bad_rc" -eq 0 ]] ||
+   [[ "$bad_output" != *"BadTest.kt: missing mainDispatcherRule.tmuxSessionViewModelTeardown()"* ]] ||
+   [[ "$bad_output" != *"constructor(s) are not wrapped in teardown.track(...)"* ]]; then
+  printf '%s\n' "$bad_output"
+  echo "FAIL: #1355 guard self-test did not reject an unregistered constructor"
+  exit 1
+fi
+
+rm -- "$fixture_dir/BadTest.kt"
+POCKETSHELL_RULE_VM_GUARD_ROOT="$fixture_root" run_guard
+echo "PASS: #1355 guard self-test rejects an omitted consumer migration"


### PR DESCRIPTION
Closes #1355.

## What changed

- add a MainDispatcherRule pre-reset LIFO cleanup boundary
- track and drain every TmuxSessionViewModel plus owned factory/lease/agent-tail roots in all six standalone rule consumers
- keep teardown virtual-time safe with runCurrent-only draining and hard bounded zero-child diagnostics
- add a required structural guard and selftest preventing new unregistered consumers
- leave production code and #1765 direct-reset manifest unchanged

## Evidence

- mutations RED: removed automatic registration, omitted VM cancellation, and unwrapped consumer constructor
- forced six-consumer + invariant matrix: Debug 3/3 and Release 3/3, each exactly 32 tests with zero failures/errors/skips
- canonical full JVM: 603/603 executed, 11,292 tests, zero failures/errors/skips
- preserved console, source hash manifest, and 1,185 XML artifact manifest
- guard/selftest, validity, file-size, VM-ratchet, and diff checks green
- independent review: APPROVED

The branch is rebased on current main after #1739 and changes test/CI files only.