### PR TITLE
test: make loading renders deterministic

### DIFF
--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenderStaticLoadingPolicyTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenderStaticLoadingPolicyTest.kt
@@ -1,0 +1,100 @@
+package com.pocketshell.uikit.render
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #1772: Roborazzi drains Robolectric's paused main looper before capture.
+ * A live Material indeterminate indicator continuously posts animation frames,
+ * so the drain cannot reach quiescence. The two design fixtures that explicitly
+ * showcase loading states must therefore paint a deterministic test-only frame.
+ *
+ * This source guard makes restoring either fixture to the production infinite
+ * animation a hard failure while also protecting the opposite boundary:
+ * production [com.pocketshell.uikit.components.LoadingIndicator] must stay live.
+ */
+class DesignRenderStaticLoadingPolicyTest {
+
+    @Test
+    fun loadingIndicatorShowcaseUsesOnlyStaticFixtureFrames() {
+        val source = locateTestSource("DesignRenders.kt")
+        val body = source.substringBetween(
+            start = "fun loadingIndicators()",
+            end = "fun tmuxConnectingStates()",
+        )
+
+        assertTrue(body.contains("StaticLoadingIndicator.Bar()"))
+        assertEquals(4, body.countOccurrences("StaticLoadingIndicator.Spinner("))
+        assertFalse(LIVE_BAR_CALL.containsMatchIn(body))
+        assertFalse(LIVE_SPINNER_CALL.containsMatchIn(body))
+    }
+
+    @Test
+    fun tmuxConnectingShowcaseUsesOnlyStaticFixtureFrames() {
+        val source = locateTestSource("TerminalRenderFixtures.kt")
+        val body = source.substringBetween(
+            start = "internal fun TmuxConnectingStatesRender()",
+            end = "internal fun TmuxDisconnectedStateRender()",
+        )
+
+        assertEquals(2, body.countOccurrences("StaticLoadingIndicator.Spinner("))
+        assertFalse(LIVE_SPINNER_CALL.containsMatchIn(body))
+    }
+
+    @Test
+    fun staticFixtureHasNoAnimationAndProductionIndicatorRemainsLive() {
+        val fixture = locateTestSource("StaticLoadingIndicator.kt")
+        assertTrue(fixture.contains("drawLine("))
+        assertTrue(fixture.contains("drawArc("))
+        assertTrue(fixture.contains("StaticSpinnerSweepDegrees = 270f"))
+        assertFalse(fixture.contains("rememberInfiniteTransition"))
+        assertFalse(fixture.contains("InfiniteTransition"))
+        assertFalse(fixture.contains("LoadingIndicator.Bar("))
+        assertFalse(fixture.contains("LoadingIndicator.Spinner("))
+
+        val production = locateProductionSource("LoadingIndicator.kt")
+        assertTrue(production.contains("LinearProgressIndicator("))
+        assertTrue(production.contains("CircularProgressIndicator("))
+        assertFalse(production.contains("StaticLoadingIndicator"))
+    }
+
+    private fun String.substringBetween(start: String, end: String): String {
+        val startIndex = indexOf(start)
+        check(startIndex >= 0) { "$start not found" }
+        val endIndex = indexOf(end, startIndex)
+        check(endIndex >= 0) { "$end not found after $start" }
+        return substring(startIndex, endIndex)
+    }
+
+    private fun String.countOccurrences(needle: String): Int =
+        windowed(size = needle.length, step = 1).count { it == needle }
+
+    private fun locateTestSource(name: String): String =
+        locate(
+            "shared/ui-kit/src/test/java/com/pocketshell/uikit/render/$name",
+            "src/test/java/com/pocketshell/uikit/render/$name",
+        )
+
+    private fun locateProductionSource(name: String): String =
+        locate(
+            "shared/ui-kit/src/main/java/com/pocketshell/uikit/components/$name",
+            "src/main/java/com/pocketshell/uikit/components/$name",
+        )
+
+    private fun locate(vararg candidates: String): String {
+        val file = candidates
+            .asSequence()
+            .map(::File)
+            .firstOrNull { it.isFile }
+            ?: error("Could not locate ${candidates.joinToString()} from ${File(".").absolutePath}")
+        return file.readText()
+    }
+
+    private companion object {
+        val LIVE_BAR_CALL = Regex("""(?<!Static)LoadingIndicator\.Bar\(""")
+        val LIVE_SPINNER_CALL = Regex("""(?<!Static)LoadingIndicator\.Spinner\(""")
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -325,11 +325,11 @@ class DesignRenders {
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             LoadingLabel("Bar — indeterminate linear (in flight)")
-            LoadingIndicator.Bar()
+            StaticLoadingIndicator.Bar()
 
             LoadingLabel("Spinner — Small (inline / on-row)")
             Row(verticalAlignment = Alignment.CenterVertically) {
-                LoadingIndicator.Spinner(size = SpinnerSize.Small)
+                StaticLoadingIndicator.Spinner(size = SpinnerSize.Small)
                 Spacer(modifier = Modifier.width(10.dp))
                 Text(
                     text = "Transcribing…",
@@ -340,12 +340,12 @@ class DesignRenders {
 
             LoadingLabel("Spinner — Medium (centered, no label)")
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                LoadingIndicator.Spinner(size = SpinnerSize.Medium)
+                StaticLoadingIndicator.Spinner(size = SpinnerSize.Medium)
             }
 
             LoadingLabel("Spinner — Medium + label (whole-area loading)")
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                LoadingIndicator.Spinner(
+                StaticLoadingIndicator.Spinner(
                     size = SpinnerSize.Medium,
                     label = "Attaching…",
                 )
@@ -358,7 +358,7 @@ class DesignRenders {
                     .padding(horizontal = 24.dp, vertical = 12.dp),
                 contentAlignment = Alignment.Center,
             ) {
-                LoadingIndicator.Spinner(size = SpinnerSize.Small, onAccent = true)
+                StaticLoadingIndicator.Spinner(size = SpinnerSize.Small, onAccent = true)
             }
 
             LoadingLabel("ProgressBar — determinate sibling (usage quota)")

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/StaticLoadingIndicator.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/StaticLoadingIndicator.kt
@@ -1,0 +1,158 @@
+package com.pocketshell.uikit.render
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.components.SpinnerSize
+import com.pocketshell.uikit.theme.LocalPocketShellSemantic
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellType
+
+/**
+ * A deterministic snapshot of the canonical loading vocabulary for Roborazzi
+ * design fixtures only (#1772).
+ *
+ * Production deliberately keeps the live indeterminate Material animations in
+ * `LoadingIndicator`. Roborazzi, however, drains Robolectric's paused looper
+ * before capture; an infinite animation continuously posts frames and prevents
+ * that drain from reaching quiescence. These test-source-only painters preserve
+ * one recognizable in-flight frame without scheduling any animation work.
+ */
+internal object StaticLoadingIndicator {
+    private val BarHeight: Dp = 4.dp
+    private val SmallStroke: Dp = 2.dp
+    private val MediumStroke: Dp = 3.dp
+
+    // Two separated segments read as indeterminate rather than "42% complete".
+    private const val FirstBarStartFraction = 0.08f
+    private const val FirstBarEndFraction = 0.46f
+    private const val SecondBarStartFraction = 0.66f
+    private const val SecondBarEndFraction = 0.84f
+
+    // A fixed frame matching the production spinner's rounded arc and left gap.
+    private const val StaticSpinnerStartDegrees = -130f
+    private const val StaticSpinnerSweepDegrees = 270f
+
+    @Composable
+    fun Bar(modifier: Modifier = Modifier) {
+        val semantic = LocalPocketShellSemantic.current
+        Canvas(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(BarHeight),
+        ) {
+            val strokeWidth = size.height
+            val centerY = size.height / 2f
+            val trackColor = semantic.statusIdle.copy(alpha = 0.24f)
+
+            drawLine(
+                color = trackColor,
+                start = Offset(0f, centerY),
+                end = Offset(size.width, centerY),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round,
+            )
+            drawLine(
+                color = semantic.accent,
+                start = Offset(size.width * FirstBarStartFraction, centerY),
+                end = Offset(size.width * FirstBarEndFraction, centerY),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round,
+            )
+            drawLine(
+                color = semantic.accent,
+                start = Offset(size.width * SecondBarStartFraction, centerY),
+                end = Offset(size.width * SecondBarEndFraction, centerY),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+
+    @Composable
+    fun Spinner(
+        modifier: Modifier = Modifier,
+        size: SpinnerSize = SpinnerSize.Medium,
+        label: String? = null,
+        onAccent: Boolean = false,
+    ) {
+        val semantic = LocalPocketShellSemantic.current
+        val arcColor = if (onAccent) PocketShellColors.Background else semantic.accent
+        val diameter: Dp = when (size) {
+            SpinnerSize.Small -> 18.dp
+            SpinnerSize.Medium -> 28.dp
+        }
+        val stroke: Dp = when (size) {
+            SpinnerSize.Small -> SmallStroke
+            SpinnerSize.Medium -> MediumStroke
+        }
+
+        if (label == null) {
+            SpinnerArc(
+                modifier = modifier,
+                diameter = diameter,
+                stroke = stroke,
+                color = arcColor,
+            )
+        } else {
+            Column(
+                modifier = modifier,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+            ) {
+                SpinnerArc(
+                    diameter = diameter,
+                    stroke = stroke,
+                    color = arcColor,
+                )
+                Text(
+                    text = label,
+                    color = semantic.statusIdle,
+                    style = PocketShellType.bodyDense,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun SpinnerArc(
+        diameter: Dp,
+        stroke: Dp,
+        color: Color,
+        modifier: Modifier = Modifier,
+    ) {
+        Canvas(modifier = modifier.size(diameter)) {
+            val strokePx = stroke.toPx()
+            val inset = strokePx / 2f
+            drawArc(
+                color = color,
+                startAngle = StaticSpinnerStartDegrees,
+                sweepAngle = StaticSpinnerSweepDegrees,
+                useCenter = false,
+                topLeft = Offset(inset, inset),
+                size = Size(
+                    width = size.width - strokePx,
+                    height = size.height - strokePx,
+                ),
+                style = Stroke(width = strokePx, cap = StrokeCap.Round),
+            )
+        }
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/TerminalRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/TerminalRenderFixtures.kt
@@ -73,7 +73,7 @@ internal fun TmuxConnectingStatesRender() {
                 .background(color = PocketShellColors.Surface),
             contentAlignment = Alignment.Center,
         ) {
-            LoadingIndicator.Spinner(
+            StaticLoadingIndicator.Spinner(
                 size = SpinnerSize.Medium,
                 label = "waiting for tmux panes…",
             )
@@ -87,7 +87,7 @@ internal fun TmuxConnectingStatesRender() {
                 .background(color = PocketShellColors.Background),
             contentAlignment = Alignment.Center,
         ) {
-            LoadingIndicator.Spinner(
+            StaticLoadingIndicator.Spinner(
                 size = SpinnerSize.Medium,
                 label = "Attaching…",
             )


### PR DESCRIPTION
Closes #1772.

## What changed

- replace live infinite LoadingIndicator calls only in the two implicated Roborazzi fixture families with deterministic static test painters
- preserve bar/spinner geometry, semantic colors, size rungs, labels, and production live animation
- add a policy test preventing live animation from returning to those fixtures while requiring production to remain live

No production UI behavior changes.

## Evidence

- current live-call mutation: policy RED and loadingIndicators render hard-timeout with two matching paused-looper/InfiniteTransition stacks and no PNG
- exact source hashes restored; policy 3/3 green
- filtered loadingIndicators and tmuxConnectingStates renders plus warm repeat green and visually reviewed
- forced uncached all-mode: exactly 65/65 fresh non-empty PNGs, zero missing/extra/stale, including loading and confirm dialog
- canonical full JVM: 603/603 tasks executed; policy 3/3 in debug and release
- design-token, validity, file-size, and diff guards green
- independent source/dynamic review: APPROVED

The branch is rebased on current main with all approved source hashes unchanged.