### PR TITLE
test: make filtered renders invocation-fresh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,17 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
+      # Issue #1766: render PNGs are direct test side effects, so Gradle can
+      # otherwise return FROM-CACHE/UP-TO-DATE for a second, differently
+      # filtered DesignRenders method without creating its PNG. This fake-Gradle
+      # self-test deterministically proves sequential filters, source mapping
+      # validation, and invocation-fresh artifact checks without launching
+      # Gradle or Roborazzi.
+      - name: Render harness freshness self-test (issue #1766)
+        run: |
+          chmod +x scripts/render.sh scripts/render-selftest.sh
+          scripts/render-selftest.sh
+
       # Issue #657 (F4): test-validity grep-guard. Flags the highest-signal
       # test anti-patterns the #657 audit catalogued — chiefly an IME/keyboard/
       # geometry assertion gated behind an `assumeTrue(...)` self-skip, which on

--- a/process.md
+++ b/process.md
@@ -1440,6 +1440,19 @@ Outputs land in `shared/ui-kit/build/renders/`. Add or adjust a `@Test` case in
 the component/screen you changed (the harness fills the Pixel-7 viewport, so a
 render shows the whole screen).
 
+Render PNGs are direct `DesignRenders` execution side effects rather than
+declared Gradle task outputs. Therefore an exit-zero `FROM-CACHE` /
+`UP-TO-DATE` task is **not** render evidence. `scripts/render.sh` parses each
+single-line `fun method() = render("artifact-label")` declaration (spaces/tabs
+are allowed between tokens; crossing a newline is deliberately rejected),
+forces only `:shared:ui-kit:testDebugUnitTest` fresh through its private opt-in
+property, and holds an exclusive output-directory lock across target deletion,
+Gradle execution, and validation. It succeeds only when the selected mapped
+PNG—or every mapped PNG in all-mode—was recreated non-empty after a
+same-filesystem freshness boundary. Never replace this with a blanket
+`--rerun-tasks`, and never accept a stale PNG merely listed from an earlier
+filter.
+
 - **Implementer (design/UI):** render the changed component/screen and visually
   inspect the PNG BEFORE the emulator run; if the issue links a mockup
   (`docs/mockups/`), compare the render to it and note the comparison. Attach the

--- a/scripts/render-selftest.sh
+++ b/scripts/render-selftest.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+#
+# Deterministic regression proof for scripts/render.sh (issue #1766).
+# Uses a fake Gradle/cgroup harness only: no Gradle daemon, Android SDK,
+# Roborazzi, emulator, or Docker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+FIXTURE_ROOT="$TMP_ROOT/repo"
+SELFTEST_RUN=0
+SELFTEST_FAILED=0
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+pass() {
+  SELFTEST_RUN=$((SELFTEST_RUN + 1))
+  printf 'PASS: %s\n' "$1"
+}
+
+fail_case() {
+  SELFTEST_RUN=$((SELFTEST_RUN + 1))
+  SELFTEST_FAILED=$((SELFTEST_FAILED + 1))
+  printf 'FAIL: %s\n' "$1" >&2
+}
+
+expect_status() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$actual" -eq "$expected" ]]; then
+    pass "$label"
+  else
+    fail_case "$label (expected status $expected, got $actual)"
+  fi
+}
+
+write_valid_source() {
+  mkdir -p "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render"
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun firstRender() = render("first-label") {}
+
+    @Test
+    fun secondRender() = render("second-special-label") {}
+}
+KOTLIN
+}
+
+write_missing_mapping_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun firstRender() = render("first-label") {}
+
+    @Test
+    fun secondRender() = Unit
+}
+KOTLIN
+}
+
+write_duplicate_label_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun firstRender() = render("same-label") {}
+
+    @Test
+    fun secondRender() = render("same-label") {}
+}
+KOTLIN
+}
+
+write_duplicate_test_method_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun repeatedRender() = render("first-label") {}
+
+    @Test
+    fun repeatedRender() = render("second-special-label") {}
+}
+KOTLIN
+}
+
+write_duplicate_method_mapping_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun firstRender() = render("first-label") {}
+
+    fun firstRender() = render("second-special-label") {}
+}
+KOTLIN
+}
+
+write_mismatched_mapping_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun firstRender() = render("first-label") {}
+
+    fun secondRender() = render("second-special-label") {}
+}
+KOTLIN
+}
+
+write_unsafe_label_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun firstRender() = render("../unsafe-label") {}
+}
+KOTLIN
+}
+
+write_multiline_mapping_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+    @Test
+    fun firstRender() =
+        render("first-label") {}
+}
+KOTLIN
+}
+
+write_horizontal_whitespace_source() {
+  cat > "$FIXTURE_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt" <<'KOTLIN'
+class DesignRenders {
+	@Test
+	fun	firstRender (	)	=	render("first-label") {}
+}
+KOTLIN
+}
+
+mkdir -p "$FIXTURE_ROOT/scripts" "$FIXTURE_ROOT/build" \
+  "$FIXTURE_ROOT/shared/ui-kit/build/renders"
+cp "$REPO_ROOT/scripts/render.sh" "$FIXTURE_ROOT/scripts/render.sh"
+chmod +x "$FIXTURE_ROOT/scripts/render.sh"
+
+cat > "$FIXTURE_ROOT/scripts/cgroup-run.sh" <<'SHELL'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "--unit" ]] || exit 91
+shift 2
+[[ "${1:-}" == "--" ]] || exit 92
+shift
+exec "$@"
+SHELL
+chmod +x "$FIXTURE_ROOT/scripts/cgroup-run.sh"
+
+cat > "$FIXTURE_ROOT/gradlew" <<'SHELL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> build/fake-gradle-invocations.log
+forced=0
+selector=""
+while (($#)); do
+  case "$1" in
+    -Ppocketshell.forceDesignRender=true)
+      forced=1
+      ;;
+    --tests)
+      shift
+      selector="${1:-}"
+      ;;
+  esac
+  shift
+done
+
+method="${selector##*.}"
+output_dir="shared/ui-kit/build/renders"
+mkdir -p "$output_dir"
+
+# Model the original #1766 failure: without the opt-in force property, the
+# first filtered invocation executes but a different second filter exits 0
+# from cache/up-to-date state without producing its side-effect artifact.
+if [[ "$forced" -ne 1 ]]; then
+  if [[ "$method" == "firstRender" ]]; then
+    printf 'first\n' > "$output_dir/first-label.png"
+  fi
+  exit 0
+fi
+
+case "${FAKE_RENDER_MODE:-fresh}" in
+  fresh)
+    case "$method" in
+      firstRender) printf 'first\n' > "$output_dir/first-label.png" ;;
+      secondRender) printf 'second\n' > "$output_dir/second-special-label.png" ;;
+      DesignRenders)
+        printf 'first\n' > "$output_dir/first-label.png"
+        printf 'second\n' > "$output_dir/second-special-label.png"
+        ;;
+    esac
+    ;;
+  absent)
+    ;;
+  stale)
+    printf 'stale\n' > "$output_dir/second-special-label.png"
+    touch -t 200001010000 "$output_dir/second-special-label.png"
+    ;;
+  mismatched)
+    printf 'wrong mapping\n' > "$output_dir/second-render.png"
+    ;;
+  incomplete-all)
+    printf 'first only\n' > "$output_dir/first-label.png"
+    ;;
+  overlap)
+    active_dir="build/fake-gradle-active"
+    if mkdir "$active_dir" 2>/dev/null; then
+      # The first invocation pauses while the self-test starts the second. If
+      # they overlap, it deliberately does NOT create its own output: the
+      # concurrent invocation below creates that foreign artifact instead.
+      sleep 0.25
+      if [[ ! -e build/fake-gradle-overlap-detected ]]; then
+        case "$method" in
+          firstRender) printf 'first owned\n' > "$output_dir/first-label.png" ;;
+          secondRender) printf 'second owned\n' > "$output_dir/second-special-label.png" ;;
+        esac
+      fi
+      rmdir "$active_dir" 2>/dev/null || true
+    else
+      printf 'overlap\n' > build/fake-gradle-overlap-detected
+      # Model the dangerous false success precisely: a concurrent invocation
+      # creates both its own output and the first invocation's expected output.
+      # Without serialization, the first call can accept this foreign PNG.
+      printf 'foreign first\n' > "$output_dir/first-label.png"
+      printf 'second overlap\n' > "$output_dir/second-special-label.png"
+    fi
+    ;;
+  *)
+    printf 'unknown fake mode: %s\n' "$FAKE_RENDER_MODE" >&2
+    exit 93
+    ;;
+esac
+SHELL
+chmod +x "$FIXTURE_ROOT/gradlew"
+
+run_render() {
+  local mode="$1"
+  shift
+  (
+    cd "$FIXTURE_ROOT"
+    FAKE_RENDER_MODE="$mode" scripts/render.sh "$@"
+  )
+}
+
+write_valid_source
+
+# RED on the old harness: the second call exits 0 but has no mapped PNG.
+set +e
+run_render fresh firstRender > "$TMP_ROOT/first.log" 2>&1
+first_status=$?
+run_render fresh secondRender > "$TMP_ROOT/second.log" 2>&1
+second_status=$?
+set -e
+if [[ "$first_status" -eq 0 && "$second_status" -eq 0 &&
+      -f "$FIXTURE_ROOT/shared/ui-kit/build/renders/first-label.png" &&
+      -f "$FIXTURE_ROOT/shared/ui-kit/build/renders/second-special-label.png" ]]; then
+  pass "two sequential filtered renders each produce their own mapped artifact"
+else
+  fail_case "two sequential filtered renders each produce their own mapped artifact"
+fi
+if [[ "$(grep -c -- '-Ppocketshell.forceDesignRender=true' \
+    "$FIXTURE_ROOT/build/fake-gradle-invocations.log" || true)" -eq 2 ]] &&
+    ! grep -q -- '--rerun-tasks' "$FIXTURE_ROOT/build/fake-gradle-invocations.log"; then
+  pass "filtered calls use the narrow force property without blanket rerun"
+else
+  fail_case "filtered calls did not use only the opt-in render-task force property"
+fi
+if [[ "$(awk '{
+    count = 0
+    for (i = 1; i <= NF; i++) {
+      if ($i == "--no-daemon") {
+        count++
+      }
+    }
+    if (count == 1) {
+      exact++
+    }
+  }
+  END { print exact + 0 }' \
+    "$FIXTURE_ROOT/build/fake-gradle-invocations.log")" -eq 2 ]]; then
+  pass "filtered calls pass exactly one --no-daemon to Gradle"
+else
+  fail_case "filtered calls did not pass exactly one --no-daemon to Gradle"
+fi
+if grep -q 'second-special-label[.]png' "$TMP_ROOT/second.log" &&
+    ! grep -q 'first-label[.]png' "$TMP_ROOT/second.log"; then
+  pass "filtered success reports only its selected verified artifact"
+else
+  fail_case "filtered success did not report only its selected verified artifact"
+fi
+
+before_invocations="$(wc -l < "$FIXTURE_ROOT/build/fake-gradle-invocations.log")"
+set +e
+run_render fresh unknownRender > "$TMP_ROOT/unknown.log" 2>&1
+status=$?
+set -e
+expect_status "unknown filter fails before Gradle" 1 "$status"
+after_invocations="$(wc -l < "$FIXTURE_ROOT/build/fake-gradle-invocations.log")"
+if [[ "$before_invocations" -eq "$after_invocations" ]]; then
+  pass "unknown filter did not invoke Gradle"
+else
+  fail_case "unknown filter invoked Gradle"
+fi
+
+write_missing_mapping_source
+set +e
+run_render fresh firstRender > "$TMP_ROOT/missing-mapping.log" 2>&1
+status=$?
+set -e
+expect_status "missing test-to-label mapping is rejected" 1 "$status"
+
+write_duplicate_label_source
+set +e
+run_render fresh firstRender > "$TMP_ROOT/duplicate-mapping.log" 2>&1
+status=$?
+set -e
+expect_status "duplicate render label mapping is rejected" 1 "$status"
+
+write_duplicate_test_method_source
+set +e
+run_render fresh repeatedRender > "$TMP_ROOT/duplicate-test-method.log" 2>&1
+status=$?
+set -e
+expect_status "duplicate @Test method is rejected" 1 "$status"
+
+write_duplicate_method_mapping_source
+set +e
+run_render fresh firstRender > "$TMP_ROOT/duplicate-method-mapping.log" 2>&1
+status=$?
+set -e
+expect_status "duplicate method mapping is rejected" 1 "$status"
+
+write_mismatched_mapping_source
+set +e
+run_render fresh firstRender > "$TMP_ROOT/mismatched-source-mapping.log" 2>&1
+status=$?
+set -e
+expect_status "render definition without matching test mapping is rejected" 1 "$status"
+
+write_unsafe_label_source
+set +e
+run_render fresh firstRender > "$TMP_ROOT/unsafe-label.log" 2>&1
+status=$?
+set -e
+expect_status "unsafe render label is rejected" 1 "$status"
+
+write_multiline_mapping_source
+set +e
+run_render fresh firstRender > "$TMP_ROOT/multiline-mapping.log" 2>&1
+status=$?
+set -e
+expect_status "multiline method-to-label mapping is intentionally rejected" 1 "$status"
+
+write_horizontal_whitespace_source
+set +e
+run_render fresh firstRender > "$TMP_ROOT/horizontal-whitespace.log" 2>&1
+status=$?
+set -e
+expect_status "spaces and tabs within one mapping line are accepted" 0 "$status"
+
+write_valid_source
+set +e
+run_render mismatched secondRender > "$TMP_ROOT/mismatched-artifact.log" 2>&1
+status=$?
+set -e
+expect_status "artifact at a method-derived instead of mapped label fails" 1 "$status"
+
+set +e
+run_render absent secondRender > "$TMP_ROOT/absent.log" 2>&1
+status=$?
+set -e
+expect_status "missing selected artifact fails" 1 "$status"
+
+set +e
+run_render stale secondRender > "$TMP_ROOT/stale.log" 2>&1
+status=$?
+set -e
+expect_status "stale selected artifact fails" 1 "$status"
+
+set +e
+run_render incomplete-all > "$TMP_ROOT/incomplete-all.log" 2>&1
+status=$?
+set -e
+expect_status "all-renders mode fails when one declared artifact is absent" 1 "$status"
+
+unlink "$FIXTURE_ROOT/shared/ui-kit/build/renders/first-label.png" 2>/dev/null || true
+unlink "$FIXTURE_ROOT/shared/ui-kit/build/renders/second-special-label.png" 2>/dev/null || true
+unlink "$FIXTURE_ROOT/build/fake-gradle-overlap-detected" 2>/dev/null || true
+set +e
+run_render overlap firstRender > "$TMP_ROOT/overlap-first.log" 2>&1 &
+first_pid=$!
+active_observed=0
+for _ in {1..100}; do
+  if [[ -d "$FIXTURE_ROOT/build/fake-gradle-active" ]]; then
+    active_observed=1
+    break
+  fi
+  sleep 0.01
+done
+run_render overlap secondRender > "$TMP_ROOT/overlap-second.log" 2>&1 &
+second_pid=$!
+wait "$first_pid"
+first_status=$?
+wait "$second_pid"
+second_status=$?
+set -e
+if [[ "$active_observed" -eq 1 &&
+      "$first_status" -eq 0 && "$second_status" -eq 0 &&
+      ! -e "$FIXTURE_ROOT/build/fake-gradle-overlap-detected" &&
+      -f "$FIXTURE_ROOT/shared/ui-kit/build/renders/first-label.png" &&
+      -f "$FIXTURE_ROOT/shared/ui-kit/build/renders/second-special-label.png" ]]; then
+  pass "overlapping render calls serialize the complete output-critical section"
+else
+  fail_case "overlapping render calls were not serialized with invocation-owned outputs"
+fi
+
+printf 'stale unregistered render\n' > \
+  "$FIXTURE_ROOT/shared/ui-kit/build/renders/unregistered-old.png"
+run_render fresh > "$TMP_ROOT/fresh-all.log" 2>&1
+if [[ -f "$FIXTURE_ROOT/shared/ui-kit/build/renders/first-label.png" &&
+      -f "$FIXTURE_ROOT/shared/ui-kit/build/renders/second-special-label.png" &&
+      ! -e "$FIXTURE_ROOT/shared/ui-kit/build/renders/unregistered-old.png" ]]; then
+  pass "fresh all-renders invocation replaces the directory with every mapped artifact"
+else
+  fail_case "fresh all-renders invocation left stale output or missed a mapped artifact"
+fi
+
+if [[ "$SELFTEST_RUN" -ne 20 ]]; then
+  printf 'FAIL: self-test ran %s checks, expected 20\n' "$SELFTEST_RUN" >&2
+  exit 1
+fi
+if [[ "$SELFTEST_FAILED" -ne 0 ]]; then
+  printf 'FAIL: %s/%s render self-test checks failed\n' "$SELFTEST_FAILED" "$SELFTEST_RUN" >&2
+  exit 1
+fi
+printf 'PASS: %s/%s render self-test checks (issue #1766)\n' "$SELFTEST_RUN" "$SELFTEST_RUN"

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -17,11 +17,19 @@
 #   Repeat. Each run overwrites the same paths, so a tweak yields a new image at
 #   a stable location.
 #
-# The optional first argument is a test-method-name filter passed straight to
-# Gradle's --tests; it matches the @Test method names in DesignRenders
-# (screenHeader, listRow, hostListScreen, ...). Output files are named after the
-# render label (screen-header.png, list-row.png, host-list-screen.png).
+# Issue #1766 invariant: render PNGs are direct test-execution side effects, not
+# declared Gradle task outputs. A cache hit or UP-TO-DATE task therefore cannot
+# prove that this invocation produced its requested PNG. This harness parses the
+# explicit `fun method() = render("label")` mappings, deletes only the requested
+# target (all declared PNGs in all-mode), opts the render test task out of cache
+# and up-to-date reuse, and accepts only non-empty artifacts recreated after a
+# locked, same-filesystem freshness boundary.
 set -euo pipefail
+
+if (($# > 1)); then
+  printf 'Usage: scripts/render.sh [DesignRenders test method]\n' >&2
+  exit 2
+fi
 
 # Resolve repo root from this script's location so it works from any cwd.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -29,28 +37,221 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 RENDER_CLASS="com.pocketshell.uikit.render.DesignRenders"
+RENDER_SOURCE="$REPO_ROOT/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt"
 # Robolectric writes the PNGs relative to the module dir during the test run.
 OUTPUT_DIR="$REPO_ROOT/shared/ui-kit/build/renders"
-
+PYTHON3="${PYTHON3:-python3}"
 FILTER="${1:-}"
+
+if ! command -v "$PYTHON3" >/dev/null 2>&1; then
+  printf 'render.sh: required Python interpreter not found: %s\n' "$PYTHON3" >&2
+  exit 1
+fi
+if ! command -v flock >/dev/null 2>&1; then
+  printf 'render.sh: required render-output lock command not found: flock\n' >&2
+  exit 1
+fi
+if [[ ! -f "$RENDER_SOURCE" ]]; then
+  printf 'render.sh: render source not found: %s\n' "$RENDER_SOURCE" >&2
+  exit 1
+fi
+
+RUN_TMP="$(mktemp -d)"
+INVOCATION_MARKER=""
+cleanup() {
+  if [[ -n "$INVOCATION_MARKER" ]]; then
+    rm -f -- "$INVOCATION_MARKER"
+  fi
+  rm -rf "$RUN_TMP"
+}
+trap cleanup EXIT
+
+MAPPING_FILE="$RUN_TMP/render-mappings.tsv"
+if ! "$PYTHON3" - "$RENDER_SOURCE" > "$MAPPING_FILE" <<'PY'
+from collections import Counter
+from pathlib import Path
+import re
+import sys
+
+source_path = Path(sys.argv[1])
+source = source_path.read_text(encoding="utf-8")
+
+# `@Test` is the executable inventory. The single-line render call is the
+# machine-readable method -> artifact-label mapping. Its grammar deliberately
+# permits spaces/tabs but never a newline between `fun` and `render(...)`.
+# Keeping the mapping in the real declaration avoids a second manifest that can
+# drift independently.
+test_methods = re.findall(
+    r"(?m)^[ \t]*@Test[ \t]*\r?\n"
+    r"[ \t]*fun[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\(",
+    source,
+)
+mappings = re.findall(
+    r'(?m)^[ \t]*fun[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*'
+    r'\([ \t]*\)[ \t]*=[ \t]*render[ \t]*\([ \t]*"([^"]+)"[ \t]*\)',
+    source,
+)
+
+def duplicates(values):
+    return sorted(value for value, count in Counter(values).items() if count > 1)
+
+errors = []
+duplicate_tests = duplicates(test_methods)
+mapping_methods = [method for method, _ in mappings]
+duplicate_methods = duplicates(mapping_methods)
+labels = [label for _, label in mappings]
+duplicate_labels = duplicates(labels)
+
+if not test_methods:
+    errors.append("no @Test render methods found")
+if duplicate_tests:
+    errors.append(f"duplicate @Test methods: {', '.join(duplicate_tests)}")
+if duplicate_methods:
+    errors.append(f"duplicate render method mappings: {', '.join(duplicate_methods)}")
+if duplicate_labels:
+    errors.append(f"duplicate render labels: {', '.join(duplicate_labels)}")
+
+test_set = set(test_methods)
+mapping_set = set(mapping_methods)
+missing = sorted(test_set - mapping_set)
+extra = sorted(mapping_set - test_set)
+if missing:
+    errors.append(
+        "test methods missing `fun method() = render(\"label\")` mappings: "
+        + ", ".join(missing)
+    )
+if extra:
+    errors.append(
+        "render mappings without matching @Test methods: " + ", ".join(extra)
+    )
+
+for method, label in mappings:
+    if not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", label):
+        errors.append(f"{method} has unsafe render label {label!r}")
+
+if errors:
+    for error in errors:
+        print(f"render.sh: invalid DesignRenders mapping: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+for method, label in mappings:
+    print(f"{method}\t{label}")
+PY
+then
+  exit 1
+fi
+
+declare -a RENDER_METHODS=()
+declare -A LABEL_BY_METHOD=()
+while IFS=$'\t' read -r method label; do
+  [[ -n "$method" && -n "$label" ]] || continue
+  RENDER_METHODS+=("$method")
+  LABEL_BY_METHOD["$method"]="$label"
+done < "$MAPPING_FILE"
+
+if ((${#RENDER_METHODS[@]} == 0)); then
+  printf 'render.sh: mapping parser returned zero render cases\n' >&2
+  exit 1
+fi
+if [[ -n "$FILTER" && -z "${LABEL_BY_METHOD[$FILTER]+present}" ]]; then
+  printf 'render.sh: unknown DesignRenders method: %s\n' "$FILTER" >&2
+  printf 'render.sh: available methods:\n' >&2
+  printf '  - %s\n' "${RENDER_METHODS[@]}" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Serialize the entire output-critical section. The lock lives beside the PNGs,
+# so two worktree-local render.sh calls cannot delete or validate each other's
+# in-flight artifacts. It is intentionally acquired before marker creation and
+# held by this shell through deletion, Gradle execution, and validation.
+RENDER_LOCK="$OUTPUT_DIR/.render.lock"
+exec {RENDER_LOCK_FD}> "$RENDER_LOCK"
+flock --exclusive "$RENDER_LOCK_FD"
+
+# The marker is on the same filesystem as the PNGs. Back it off by a
+# representable two-second guard band and verify that the filesystem preserved
+# at least one second of separation. Combined with deleting the targets under
+# the exclusive lock, this removes cross-filesystem and equal-timestamp-tick
+# ambiguity: a surviving PNG must have been recreated by this invocation and
+# must compare newer than a safely representable boundary.
+INVOCATION_MARKER="$(mktemp "$OUTPUT_DIR/.render-invocation.XXXXXX")"
+if ! "$PYTHON3" - "$INVOCATION_MARKER" <<'PY'
+import os
+from pathlib import Path
+import sys
+import time
+
+marker = Path(sys.argv[1])
+now_ns = time.time_ns()
+requested_ns = now_ns - 2_000_000_000
+os.utime(marker, ns=(requested_ns, requested_ns))
+actual_ns = marker.stat().st_mtime_ns
+if now_ns - actual_ns < 1_000_000_000:
+    print(
+        "render.sh: output filesystem cannot represent a safe freshness boundary",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+PY
+then
+  exit 1
+fi
+
+declare -a EXPECTED_ARTIFACTS=()
 if [[ -n "$FILTER" ]]; then
   TESTS_ARG="$RENDER_CLASS.$FILTER"
+  EXPECTED_ARTIFACTS+=("$OUTPUT_DIR/${LABEL_BY_METHOD[$FILTER]}.png")
+  # Preserve other renders for fast single-case iteration; only the selected
+  # artifact must be recreated by this invocation.
+  rm -f -- "${EXPECTED_ARTIFACTS[0]}"
 else
   TESTS_ARG="$RENDER_CLASS"
+  for method in "${RENDER_METHODS[@]}"; do
+    EXPECTED_ARTIFACTS+=("$OUTPUT_DIR/${LABEL_BY_METHOD[$method]}.png")
+  done
+  # An all-renders run claims a complete fresh set, so no pre-existing PNG may
+  # survive and masquerade as an output of this invocation.
+  find "$OUTPUT_DIR" -maxdepth 1 -type f -name '*.png' -delete
 fi
 
-echo "render.sh: recording Roborazzi renders (filter: ${FILTER:-<all>})"
+printf 'render.sh: recording Roborazzi renders (filter: %s)\n' "${FILTER:-<all>}"
 START="$(date +%s)"
 
-# recordRoborazziDebug (re)writes the golden PNGs. --rerun-tasks isn't needed:
-# editing a composable invalidates the test task, so a normal record re-renders.
+# The property is consumed only by :shared:ui-kit:testDebugUnitTest. It disables
+# cache/up-to-date reuse for that one task while `--tests` still selects the one
+# requested method. Compilation/resources and ordinary test invocations retain
+# their normal incremental/cache behavior; this is deliberately not
+# `--rerun-tasks`.
 scripts/cgroup-run.sh --unit "pocketshell-render-$(date +%Y%m%d-%H%M%S)-$$" -- \
-  ./gradlew :shared:ui-kit:recordRoborazziDebug --tests "$TESTS_ARG"
+  ./gradlew --no-daemon -Ppocketshell.forceDesignRender=true \
+  :shared:ui-kit:recordRoborazziDebug --tests "$TESTS_ARG"
+
+declare -a VERIFIED_ARTIFACTS=()
+artifact_error=0
+for artifact in "${EXPECTED_ARTIFACTS[@]}"; do
+  if [[ ! -f "$artifact" ]]; then
+    printf 'render.sh: expected render artifact was not created: %s\n' "$artifact" >&2
+    artifact_error=1
+  elif [[ ! -s "$artifact" ]]; then
+    printf 'render.sh: expected render artifact is empty: %s\n' "$artifact" >&2
+    artifact_error=1
+  elif [[ ! "$artifact" -nt "$INVOCATION_MARKER" ]]; then
+    printf 'render.sh: expected render artifact is stale for this invocation: %s\n' \
+      "$artifact" >&2
+    artifact_error=1
+  else
+    VERIFIED_ARTIFACTS+=("$artifact")
+  fi
+done
+if [[ "$artifact_error" -ne 0 ]]; then
+  printf 'render.sh: render task exited successfully but fresh artifact validation failed\n' >&2
+  exit 1
+fi
 
 END="$(date +%s)"
-echo
-echo "render.sh: done in $((END - START))s. PNGs in:"
-echo "  $OUTPUT_DIR"
-if [[ -d "$OUTPUT_DIR" ]]; then
-  ls -1 "$OUTPUT_DIR"/*.png 2>/dev/null | sed 's/^/  - /' || true
-fi
+printf '\nrender.sh: done in %ss. Verified fresh PNG%s:\n' \
+  "$((END - START))" \
+  "$([[ ${#VERIFIED_ARTIFACTS[@]} -eq 1 ]] && printf '' || printf 's')"
+printf '  - %s\n' "${VERIFIED_ARTIFACTS[@]}"

--- a/shared/ui-kit/build.gradle.kts
+++ b/shared/ui-kit/build.gradle.kts
@@ -83,3 +83,21 @@ dependencies {
     testImplementation(libs.compose.ui.test.junit4)
     testImplementation(libs.junit)
 }
+
+// Issue #1766: DesignRenders writes build/renders/*.png as direct test side
+// effects, outside Gradle's declared task outputs. A differently filtered prior
+// invocation can therefore restore testDebugUnitTest FROM-CACHE / UP-TO-DATE
+// while the newly requested PNG does not exist. scripts/render.sh opts into
+// this property so only the render test task executes fresh; --tests still
+// selects one method, and compilation/resources/ordinary unit-test runs retain
+// their normal incremental and build-cache behavior.
+val forceDesignRender = providers.gradleProperty("pocketshell.forceDesignRender")
+    .map { it == "true" }
+    .orElse(false)
+
+tasks.withType<Test>().configureEach {
+    if (name == "testDebugUnitTest") {
+        outputs.upToDateWhen { !forceDesignRender.get() }
+        outputs.cacheIf { !forceDesignRender.get() }
+    }
+}


### PR DESCRIPTION
Closes #1766.

## What changed

- map each `DesignRenders` test method to its exact artifact label and reject invalid/ambiguous mappings before Gradle
- force only the ui-kit debug test task fresh for render invocations, with `--no-daemon`
- serialize render output access and require invocation-fresh, non-empty mapped PNGs
- add a deterministic 20-case fake-Gradle harness and required CI wiring
- document the direct-side-effect/cache invariant in `process.md`

## Evidence

- render harness self-test: 20/20
- two sequential warm filtered renders: both test tasks executed; exact mapped PNGs fresh; first preserved when second ran
- every render scope: success then inactive/dead, no child/cgroup/marker; output lock released
- all-mode: exact 65/65, missing=0, extra=0, empty=0, stale=0
- #1772 static loading fixtures preserved byte-exact; policy tests debug 3/3 and release 3/3
- canonical no-arg full JVM gate: 603/603 tasks, 1,187 suites, 11,298 tests, 0 skipped/failures/errors
- `git diff --check`, shell syntax, shellcheck: clean
- independent source and artifact review: APPROVED
