### PR TITLE
fix: keep unified pager on active session

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.proof
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.os.SystemClock
 import android.util.Log
 import android.view.View
@@ -27,15 +28,17 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.PrewarmSeedFaultTestOverride
-import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_CONSOLIDATED_SESSION_LABEL_TAG
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_DETECTING_TAG
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_PANE_TAG
 import com.pocketshell.app.tmux.TMUX_FULL_BREADCRUMB_TAG
-import com.pocketshell.app.tmux.TMUX_FULL_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_OVERLAY_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_PAGE_TAG_PREFIX
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -153,11 +156,16 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
             rule = compose,
             sessionName = SESSION_A,
             timeoutMs = pickerWaitMs,
-            onRepoke = { repokeFolderListFromHostRow(hostRowTag) },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
         )
         compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
-        waitForTerminalViewAttached()
+        waitForTerminalViewAttached("initial attach to A")
         waitForTerminalContains(SESSION_A_MARKER, "initial attach to A")
         captureViewport("issue1206-00-attached-$SESSION_A")
 
@@ -192,7 +200,8 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
                 "landed on '$landed'",
             landed == SESSION_B,
         )
-        waitForTerminalViewAttached()
+        selectTerminalSurfaceForOracle("post-pager switch to B")
+        waitForTerminalViewAttached("post-pager switch to B")
 
         // ---- (5) LOAD-BEARING: B lands on a PAINTED grid — its marker visible,
         // NOT blank — despite the empty first prewarm capture. The #1206 retry /
@@ -493,43 +502,132 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
             .commit()
     }
 
-    private fun repokeFolderListFromHostRow(hostRowTag: String) {
-        runCatching {
-            val backTags = listOf(
-                TMUX_COMPACT_CHROME_BACK_BUTTON_TAG,
-                TMUX_FULL_CHROME_BACK_BUTTON_TAG,
-            )
-            for (tag in backTags) {
-                if (compose.onAllNodesWithTag(tag, useUnmergedTree = true)
-                        .fetchSemanticsNodes()
-                        .isNotEmpty()
-                ) {
-                    compose.onNodeWithTag(tag, useUnmergedTree = true).performClick()
-                    break
-                }
-            }
-            compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
-                runCatching {
-                    compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                        .fetchSemanticsNodes()
-                        .isNotEmpty()
-                }.getOrDefault(false)
-            }
-            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        }
-    }
-
     // ---------------------------------------------------------------- Terminal
 
-    private fun waitForTerminalViewAttached() {
-        compose.waitUntil(timeoutMillis = 30_000) {
-            var attached = false
-            compose.activityRule.scenario.onActivity { activity ->
-                val view = activity.window.decorView.findTerminalView()
-                attached = view?.currentSession != null && view.mEmulator != null
+    /**
+     * Put the journey on the real Terminal surface before inspecting the
+     * [TerminalView]. Presumed/detected agent panes can default to Conversation,
+     * where mounting zero TerminalViews is intentional. Shell-only panes expose
+     * no tab pill, so absence of [TMUX_TERMINAL_TAB_TAG] is not itself a failure:
+     * the load-bearing success condition is a live on-screen TerminalView with
+     * neither Conversation surface present.
+     */
+    private fun selectTerminalSurfaceForOracle(label: String) {
+        val timeoutMillis = 30_000L
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        var terminalTabPresent = false
+        var conversationDetectingPresent = false
+        var conversationPanePresent = false
+        var liveTerminalPresent = false
+        var lastClickError: Throwable? = null
+
+        while (SystemClock.elapsedRealtime() < deadline) {
+            compose.waitForIdle()
+            terminalTabPresent = hasTag(TMUX_TERMINAL_TAB_TAG)
+            conversationDetectingPresent = hasTag(TMUX_CONVERSATION_DETECTING_TAG)
+            conversationPanePresent = hasTag(TMUX_CONVERSATION_PANE_TAG)
+            liveTerminalPresent = hasLiveOnScreenTerminalView()
+            if (!conversationDetectingPresent && !conversationPanePresent && liveTerminalPresent) {
+                return
             }
-            attached
+
+            if (terminalTabPresent) {
+                runCatching {
+                    compose.onNodeWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true)
+                        .performClick()
+                }.onFailure { error ->
+                    lastClickError = error
+                    if (error.message?.contains("Failed to inject touch input") == true) {
+                        runCatching {
+                            compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+                        }
+                        compose.waitForIdle()
+                    } else {
+                        throw error
+                    }
+                }
+            }
+            SystemClock.sleep(250)
         }
+
+        terminalTabPresent = hasTag(TMUX_TERMINAL_TAB_TAG)
+        conversationDetectingPresent = hasTag(TMUX_CONVERSATION_DETECTING_TAG)
+        conversationPanePresent = hasTag(TMUX_CONVERSATION_PANE_TAG)
+        liveTerminalPresent = hasLiveOnScreenTerminalView()
+        captureFullFrame(
+            "failure-${label.toArtifactSlug()}-terminal-surface-selection-fullframe",
+        )
+        val diagnostics = buildString {
+            appendLine("terminalTabPresent=$terminalTabPresent")
+            appendLine("conversationDetectingPresent=$conversationDetectingPresent")
+            appendLine("conversationPanePresent=$conversationPanePresent")
+            appendLine("liveOnScreenTerminalPresent=$liveTerminalPresent")
+            appendLine("lastClickError=$lastClickError")
+            appendLine(composeTagDiagnostics(TMUX_TERMINAL_TAB_TAG))
+            appendLine(composeTagDiagnostics(TMUX_CONVERSATION_DETECTING_TAG))
+            appendLine(composeTagDiagnostics(TMUX_CONVERSATION_PANE_TAG))
+            append(terminalViewCandidateDiagnostics())
+        }
+        writeText(
+            "failure-${label.toArtifactSlug()}-terminal-surface-selection.txt",
+            diagnostics,
+        )
+        assertTrue(
+            "Terminal surface for $label was not selected within ${timeoutMillis}ms. " +
+                "Agent panes must leave both Conversation surfaces and mount a live TerminalView; " +
+                "shell-only panes may omit the Terminal tab.\n$diagnostics",
+            false,
+        )
+    }
+
+    private fun hasTag(tag: String): Boolean =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+    private fun composeTagDiagnostics(tag: String): String {
+        val nodes = compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+        if (nodes.isEmpty()) return "semantics[$tag]=absent"
+        return nodes.mapIndexed { index, node ->
+            "semantics[$tag][$index] bounds=${node.boundsInRoot} config=${node.config}"
+        }.joinToString(separator = "\n")
+    }
+
+    private fun hasLiveOnScreenTerminalView(): Boolean {
+        var live = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findOnScreenTerminalView()
+            live = view?.currentSession != null && view.mEmulator != null
+        }
+        return live
+    }
+
+    private fun waitForTerminalViewAttached(label: String) {
+        val timeoutMillis = 30_000L
+        val attached = runCatching {
+            compose.waitUntil(timeoutMillis = timeoutMillis) {
+                var ready = false
+                compose.activityRule.scenario.onActivity { activity ->
+                    val view = activity.window.decorView.findOnScreenTerminalView()
+                    ready = view?.currentSession != null && view.mEmulator != null
+                }
+                ready
+            }
+            true
+        }.getOrDefault(false)
+        if (attached) return
+
+        val diagnostics = terminalViewCandidateDiagnostics()
+        writeText(
+            "failure-${label.toArtifactSlug()}-terminal-view-candidates.txt",
+            diagnostics,
+        )
+        assertTrue(
+            "on-screen TerminalView for $label was not attached within ${timeoutMillis}ms.\n" +
+                diagnostics,
+            false,
+        )
     }
 
     private fun waitForTerminalContains(
@@ -545,10 +643,17 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
             }
             true
         }.getOrDefault(false)
-        if (!satisfied) writeText("failure-$label-visible-terminal.txt", last)
+        val diagnostics = if (!satisfied) {
+            terminalViewCandidateDiagnostics().also {
+                writeText("failure-${label.toArtifactSlug()}-terminal-view-candidates.txt", it)
+                writeText("failure-$label-visible-terminal.txt", last)
+            }
+        } else {
+            ""
+        }
         assertTrue(
             "expected visible terminal for $label to contain '$expected' within " +
-                "${timeoutMillis}ms; got:\n$last",
+                "${timeoutMillis}ms; got:\n$last\n$diagnostics",
             satisfied,
         )
     }
@@ -557,7 +662,7 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
         var text = ""
         compose.activityRule.scenario.onActivity { activity ->
             text = activity.window.decorView
-                .findTerminalView()
+                .findOnScreenTerminalView()
                 ?.currentSession
                 ?.emulator
                 ?.screen
@@ -576,7 +681,7 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
 
         var bitmap: Bitmap? = null
         compose.activityRule.scenario.onActivity { activity ->
-            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val view = activity.window.decorView.findOnScreenTerminalView() ?: return@onActivity
             if (view.width <= 0 || view.height <= 0) return@onActivity
             val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
             view.draw(Canvas(b))
@@ -672,18 +777,113 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
         println("ISSUE1206_TIMING $line")
     }
 
-    private fun View.findTerminalView(): TerminalView? {
-        if (this is TerminalView) return this
-        if (this !is ViewGroup) return null
-        for (index in 0 until childCount) {
-            val match = getChildAt(index).findTerminalView()
-            if (match != null) return match
+    /**
+     * The pager keeps more than one [TerminalView] in the decor tree. A plain
+     * depth-first lookup can therefore return an attached-but-hidden previous
+     * page after A -> B and make B look unattached/blank. Select the actual
+     * on-screen page by visibility, then prefer the candidate with the largest
+     * visible area when pages overlap during a transition.
+     */
+    private fun View.findOnScreenTerminalView(): TerminalView? =
+        terminalViewCandidates()
+            .asSequence()
+            .filter { candidate ->
+                candidate.view.isAttachedToWindow &&
+                    candidate.view.isShown &&
+                    candidate.hasGlobalVisibleRect &&
+                    candidate.globalVisibleArea > 0L
+            }
+            .maxByOrNull { it.globalVisibleArea }
+            ?.view
+
+    private fun terminalViewCandidateDiagnostics(): String {
+        var diagnostics = "TerminalView candidates: activity unavailable"
+        compose.activityRule.scenario.onActivity { activity ->
+            val candidates = activity.window.decorView.terminalViewCandidates()
+            val selected = activity.window.decorView.findOnScreenTerminalView()
+            diagnostics = buildString {
+                appendLine("TerminalView candidates=${candidates.size}")
+                candidates.forEachIndexed { index, candidate ->
+                    val view = candidate.view
+                    val session = view.currentSession
+                    val transcript = session
+                        ?.emulator
+                        ?.screen
+                        ?.transcriptText
+                        .orEmpty()
+                        .replace("\r", "\\r")
+                        .replace("\n", "\\n")
+                        .take(DIAGNOSTIC_TRANSCRIPT_LIMIT)
+                    append("[$index]")
+                    if (view === selected) append(" SELECTED")
+                    append(" identity=${System.identityHashCode(view)}")
+                    append(" attached=${view.isAttachedToWindow}")
+                    append(" shown=${view.isShown}")
+                    append(" visibility=${visibilityName(view.visibility)}")
+                    append(" hasGlobalVisibleRect=${candidate.hasGlobalVisibleRect}")
+                    append(" visibleArea=${candidate.globalVisibleArea}")
+                    append(" localBounds=[0,0,${view.width},${view.height}]")
+                    append(" layoutBounds=[${view.left},${view.top},${view.right},${view.bottom}]")
+                    append(
+                        " globalBounds=[${candidate.globalVisibleRect.left}," +
+                            "${candidate.globalVisibleRect.top}," +
+                            "${candidate.globalVisibleRect.right}," +
+                            "${candidate.globalVisibleRect.bottom}]",
+                    )
+                    append(" currentSession=${session != null}")
+                    append(" emulator=${view.mEmulator != null}")
+                    append(" sessionHandle=${session?.mHandle ?: "<none>"}")
+                    append(" sessionName=${session?.mSessionName ?: "<none>"}")
+                    appendLine(" transcript='$transcript'")
+                }
+            }
         }
-        return null
+        return diagnostics
     }
+
+    private fun View.terminalViewCandidates(): List<TerminalViewCandidate> {
+        val views = mutableListOf<TerminalView>()
+        collectTerminalViews(views)
+        return views.map { view ->
+            val globalRect = Rect()
+            val hasGlobalVisibleRect = view.getGlobalVisibleRect(globalRect)
+            TerminalViewCandidate(
+                view = view,
+                hasGlobalVisibleRect = hasGlobalVisibleRect,
+                globalVisibleRect = globalRect,
+            )
+        }
+    }
+
+    private fun View.collectTerminalViews(destination: MutableList<TerminalView>) {
+        if (this is TerminalView) destination += this
+        if (this !is ViewGroup) return
+        for (index in 0 until childCount) {
+            getChildAt(index).collectTerminalViews(destination)
+        }
+    }
+
+    private fun visibilityName(visibility: Int): String = when (visibility) {
+        View.VISIBLE -> "VISIBLE"
+        View.INVISIBLE -> "INVISIBLE"
+        View.GONE -> "GONE"
+        else -> visibility.toString()
+    }
+
+    private fun String.toArtifactSlug(): String =
+        lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
 
     private fun shellQuote(value: String): String =
         "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private data class TerminalViewCandidate(
+        val view: TerminalView,
+        val hasGlobalVisibleRect: Boolean,
+        val globalVisibleRect: Rect,
+    ) {
+        val globalVisibleArea: Long
+            get() = globalVisibleRect.width().toLong() * globalVisibleRect.height().toLong()
+    }
 
     private companion object {
         const val DATABASE_NAME: String = "pocketshell.db"
@@ -705,6 +905,7 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
         const val SWIPE_PAGER_VELOCITY: Float = 2_000f
         const val SWIPE_PAGER_DURATION_MS: Long = 250L
         const val MAX_PAGER_PAGES_PROBE: Int = 24
+        const val DIAGNOSTIC_TRANSCRIPT_LIMIT: Int = 240
 
         const val LOADING_PLACEHOLDER_STATUS: String = "loading same-host sessions"
         const val READY_CURRENT_STATUS: String = "current"

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
@@ -21,6 +21,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_CONSOLIDATED_SESSION_LABEL_TAG
@@ -133,7 +134,12 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
             rule = compose,
             sessionName = SESSION_A,
             timeoutMs = pickerWaitMs,
-            onRepoke = { repokeFolderListFromHostRow(hostRowTag) },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
         )
         compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
@@ -436,32 +442,6 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
             exec?.exitCode == 0,
         )
         Log.i(LOG_TAG, "started A stream via sidecar send-keys")
-    }
-
-    private fun repokeFolderListFromHostRow(hostRowTag: String) {
-        runCatching {
-            val backTags = listOf(
-                TMUX_COMPACT_CHROME_BACK_BUTTON_TAG,
-                TMUX_FULL_CHROME_BACK_BUTTON_TAG,
-            )
-            for (tag in backTags) {
-                if (compose.onAllNodesWithTag(tag, useUnmergedTree = true)
-                        .fetchSemanticsNodes()
-                        .isNotEmpty()
-                ) {
-                    compose.onNodeWithTag(tag, useUnmergedTree = true).performClick()
-                    break
-                }
-            }
-            compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
-                runCatching {
-                    compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                        .fetchSemanticsNodes()
-                        .isNotEmpty()
-                }.getOrDefault(false)
-            }
-            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        }
     }
 
     private suspend fun cleanupSeededSessions(key: String) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/SessionPickerSignals.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/SessionPickerSignals.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.proof.signals
 
 import android.os.SystemClock
+import android.util.Log
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
@@ -9,6 +10,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.performClick
+import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
 import com.pocketshell.app.projects.FOLDER_LIST_ERROR_TAG
 import com.pocketshell.app.projects.FOLDER_LIST_RETRY_TAG
 import org.junit.Assert.assertTrue
@@ -31,6 +33,7 @@ import org.junit.Assert.assertTrue
  * path it happens to be grouped under.
  */
 private const val FOLDER_HEADER_CLICK_TAG_PREFIX: String = "folder-list:header-click:"
+private const val SESSION_PICKER_SIGNALS_LOG_TAG: String = "SessionPickerSignals"
 
 /**
  * Issue #470 (blocker #2): generous default upper bound for the
@@ -72,6 +75,16 @@ const val SESSION_PICKER_DEFAULT_TIMEOUT_MS: Long = 45_000L
  * swallowing the whole budget.
  */
 const val SESSION_PICKER_STALL_REPOKE_CEILING_MS: Long = 20_000L
+
+/**
+ * Issue #470 recurrence: total bound for navigating FolderList host detail
+ * back to the host list and reopening the same host during a stall re-poke.
+ *
+ * This is deliberately shorter than the picker wait's stall sub-deadline. A
+ * failed navigation must stop at the failing stage with diagnostic node
+ * counts, not consume another full picker timeout.
+ */
+const val SESSION_PICKER_REPOKE_NAVIGATION_TIMEOUT_MS: Long = 10_000L
 
 /**
  * Issue #470 (blocker #2): a deterministic readiness wait for the host's
@@ -264,6 +277,94 @@ fun waitForSessionInPicker(
             "(blocker #2 / infra #470), not the test's assertion path.",
         false,
     )
+}
+
+/**
+ * Re-trigger one host's FolderList enumeration from a stalled host-detail
+ * screen.
+ *
+ * The host detail belongs to FolderList, so its reachable Back affordance is
+ * [FOLDER_LIST_BACK_TAG]. Terminal-detail back tags do not exist here. Each
+ * transition is bounded and verified against the real semantic destination:
+ *
+ *  1. FolderList Back is reachable and clicked.
+ *  2. The requested host row is reachable on the host list and clicked.
+ *  3. FolderList Back is reachable again, proving the same host detail was
+ *     reopened before [waitForSessionInPicker] resumes polling.
+ *
+ * No failure is swallowed. A broken transition fails at its own bounded stage
+ * with node counts and elapsed time, instead of returning to the outer picker
+ * wait and being misreported as a `list-sessions` stall.
+ */
+fun repokeSessionPickerFromHostRow(
+    rule: ComposeTestRule,
+    hostRowTag: String,
+    timeoutMs: Long = SESSION_PICKER_REPOKE_NAVIGATION_TIMEOUT_MS,
+    onStateNote: (String) -> Unit = {},
+) {
+    require(timeoutMs > 0L) { "repoke navigation timeout must be positive" }
+    val startedAt = SystemClock.elapsedRealtime()
+    val deadline = startedAt + timeoutMs
+
+    fun nodeCount(tag: String): Int =
+        rule.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .size
+
+    fun fail(stage: String, cause: Throwable?): Nothing {
+        val elapsed = SystemClock.elapsedRealtime() - startedAt
+        throw AssertionError(
+            "session-picker stall re-poke failed at stage=$stage after ${elapsed}ms: " +
+                "folder_back_nodes=" +
+                "${runCatching { nodeCount(FOLDER_LIST_BACK_TAG) }.getOrDefault(-1)} " +
+                "host_row_tag=$hostRowTag host_row_nodes=" +
+                "${runCatching { nodeCount(hostRowTag) }.getOrDefault(-1)} " +
+                "error_panel_nodes=" +
+                "${runCatching { nodeCount(FOLDER_LIST_ERROR_TAG) }.getOrDefault(-1)}",
+            cause,
+        )
+    }
+
+    fun awaitTag(tag: String, stage: String) {
+        val remainingMs = deadline - SystemClock.elapsedRealtime()
+        if (remainingMs <= 0L) fail(stage, null)
+        try {
+            rule.waitUntil(timeoutMillis = remainingMs) {
+                runCatching { nodeCount(tag) }.getOrDefault(0) > 0
+            }
+        } catch (cause: Throwable) {
+            fail(stage, cause)
+        }
+    }
+
+    fun clickTag(tag: String, stage: String) {
+        try {
+            rule.onAllNodesWithTag(tag, useUnmergedTree = true).onFirst().performClick()
+        } catch (cause: Throwable) {
+            fail(stage, cause)
+        }
+    }
+
+    awaitTag(FOLDER_LIST_BACK_TAG, "folder_detail_back_reachable")
+    clickTag(FOLDER_LIST_BACK_TAG, "folder_detail_back_click")
+    recordRepokeState(onStateNote, "session_list_stall_repoke_back_clicked", startedAt)
+
+    awaitTag(hostRowTag, "host_row_reachable")
+    recordRepokeState(onStateNote, "session_list_stall_repoke_host_row_ready", startedAt)
+    clickTag(hostRowTag, "host_row_reopen_click")
+
+    awaitTag(FOLDER_LIST_BACK_TAG, "folder_detail_reopened")
+    recordRepokeState(onStateNote, "session_list_stall_repoke_reopened", startedAt)
+}
+
+private fun recordRepokeState(
+    onStateNote: (String) -> Unit,
+    note: String,
+    startedAt: Long,
+) {
+    val elapsed = SystemClock.elapsedRealtime() - startedAt
+    onStateNote(note)
+    Log.i(SESSION_PICKER_SIGNALS_LOG_TAG, "$note elapsed_ms=$elapsed")
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxUnifiedPagerSettleEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxUnifiedPagerSettleEffects.kt
@@ -10,6 +10,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 
+internal data class UnifiedPagerOwnershipSnapshot(
+    val currentPage: Int,
+    val settledPage: Int,
+    val measuredCurrentPageKey: Any?,
+    val userDraggedSinceAlignment: Boolean,
+)
+
 @Composable
 internal fun TmuxUnifiedPagerSettleEffects(
     pagerState: PagerState,
@@ -56,21 +63,37 @@ internal fun TmuxUnifiedPagerSettleEffects(
         }
     }
     LaunchedEffect(sessionName, unifiedPanes) {
-        // Snap the pager to the nav target's first page. The active session
-        // always heads `unifiedPanes` (see
-        // [TmuxSessionViewModel.rebuildUnifiedPanes]), so for a freshly-opened
-        // session this is page 0. We keep re-snapping until the page the pager
-        // actually sits on resolves to the nav-target session — that is the
-        // signal the pager has caught up with the deliberate choice, at which
-        // point cross-session swipe detection is safe to re-arm.
-        val targetPage = unifiedPanes.indexOfFirst {
-            viewModel.sessionNameForUnifiedPane(it) == sessionName
-        }
-        if (targetPage < 0) return@LaunchedEffect
-        val currentSession = unifiedPanes.getOrNull(pagerState.currentPage)
-            ?.let { viewModel.sessionNameForUnifiedPane(it) }
-        if (currentSession != sessionName) {
-            pagerState.scrollToPage(targetPage)
+        // Issue #1206 (reopened): continuously enforce TARGET ownership until
+        // the user performs a genuine drag. A one-shot comparison of
+        // `currentPage` against the NEW list is racy: when [unifiedPanes]
+        // reorders from [A, B] to [B, A], currentPage can still be numeric 0
+        // from the PREVIOUS measure. Resolving that index against the new list
+        // falsely says "already B", then Pager's delayed key retention moves
+        // the last-measured A page to index 1 and leaves #661's neutral mask on
+        // screen forever. Include the actually MEASURED page key in the
+        // ownership decision, and keep observing after the first request so a
+        // late key-retention move is corrected too.
+        snapshotFlow {
+            val currentPage = pagerState.currentPage
+            UnifiedPagerOwnershipSnapshot(
+                currentPage = currentPage,
+                settledPage = pagerState.settledPage,
+                measuredCurrentPageKey = pagerState.layoutInfo.visiblePagesInfo
+                    .firstOrNull { it.index == currentPage }
+                    ?.key,
+                userDraggedSinceAlignment = userDraggedSinceAlignment,
+            )
+        }.collect { snapshot ->
+            val correctionPage = unifiedPagerTargetCorrectionPage(
+                unifiedPanes = unifiedPanes,
+                sessionName = sessionName,
+                snapshot = snapshot,
+                sessionNameForPane = viewModel::sessionNameForUnifiedPane,
+            )
+            if (correctionPage != null) {
+                pagerAlignedSession = null
+                pagerState.requestScrollToPage(correctionPage)
+            }
         }
     }
 
@@ -164,5 +187,33 @@ internal fun TmuxUnifiedPagerSettleEffects(
             val settledPane = unifiedPanes.getOrNull(page) ?: return@collect
             viewModel.reseedVisiblePaneIfBlank(settledPane.paneId)
         }
+    }
+}
+
+internal fun unifiedPagerTargetCorrectionPage(
+    unifiedPanes: List<TmuxPaneState>,
+    sessionName: String,
+    snapshot: UnifiedPagerOwnershipSnapshot,
+    sessionNameForPane: (TmuxPaneState) -> String?,
+): Int? {
+    val targetPage = unifiedPanes.indexOfFirst {
+        sessionNameForPane(it) == sessionName
+    }
+    if (targetPage < 0) return null
+    if (snapshot.userDraggedSinceAlignment) return null
+
+    val currentPane = unifiedPanes.getOrNull(snapshot.currentPage)
+    val currentSession = currentPane
+        ?.let(sessionNameForPane)
+    val settledSession = unifiedPanes.getOrNull(snapshot.settledPage)
+        ?.let(sessionNameForPane)
+    val measuredKeyOwnsCurrentPane =
+        currentPane != null && snapshot.measuredCurrentPageKey == currentPane.paneId
+    val targetOwnsCurrentAndSettled =
+        currentSession == sessionName && settledSession == sessionName
+    return if (targetOwnsCurrentAndSettled && measuredKeyOwnsCurrentPane) {
+        null
+    } else {
+        targetPage
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -39,6 +39,121 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TmuxSessionScreenTest {
+    private fun pagerPane(
+        paneId: String,
+        sessionId: String,
+        title: String,
+    ) = TmuxPaneState(
+        paneId = paneId,
+        windowId = "@$paneId",
+        sessionId = sessionId,
+        title = title,
+        cwd = "/work/$title",
+        terminalState = com.pocketshell.core.terminal.ui.TerminalSurfaceState(),
+    )
+
+    @Test
+    fun activeSessionReorderCorrectsPreMeasureFalseAlignmentFromRequestOnlyCandidate() {
+        val paneA = pagerPane("%a", "\$a", "project-a")
+        val paneB = pagerPane("%b", "\$b", "project-b")
+        val panes = listOf(paneB, paneA)
+        val resolve: (TmuxPaneState) -> String? = { pane ->
+            when (pane.paneId) {
+                "%a" -> "project-a"
+                "%b" -> "project-b"
+                else -> null
+            }
+        }
+
+        // Exact RED ordering from the diagnostic journey: Compose already
+        // supplied the NEW [B, A] list, but PagerState still reports numeric
+        // current/settled index 0 from the OLD measure whose actual page key
+        // is A. The rejected request-only candidate resolved index 0 against
+        // the new list, said "already B", and returned without a request.
+        assertEquals("project-b", resolve(panes[0]))
+        val correction = unifiedPagerTargetCorrectionPage(
+            unifiedPanes = panes,
+            sessionName = "project-b",
+            snapshot = UnifiedPagerOwnershipSnapshot(
+                currentPage = 0,
+                settledPage = 0,
+                measuredCurrentPageKey = "%a",
+                userDraggedSinceAlignment = false,
+            ),
+            sessionNameForPane = resolve,
+        )
+
+        assertEquals(
+            "the measured A key proves numeric page 0 is false alignment",
+            0,
+            correction,
+        )
+    }
+
+    @Test
+    fun lateKeyRetentionMoveBackToCachedPageIsContinuouslyCorrected() {
+        val paneB = pagerPane("%b", "\$b", "project-b")
+        val paneA = pagerPane("%a", "\$a", "project-a")
+
+        val correction = unifiedPagerTargetCorrectionPage(
+            unifiedPanes = listOf(paneB, paneA),
+            sessionName = "project-b",
+            snapshot = UnifiedPagerOwnershipSnapshot(
+                currentPage = 1,
+                settledPage = 1,
+                measuredCurrentPageKey = "%a",
+                userDraggedSinceAlignment = false,
+            ),
+            sessionNameForPane = { pane ->
+                if (pane.paneId == "%b") "project-b" else "project-a"
+            },
+        )
+
+        assertEquals(0, correction)
+    }
+
+    @Test
+    fun genuineUserDragToCachedSessionIsNotUndoneByOwnershipEnforcement() {
+        val paneB = pagerPane("%b", "\$b", "project-b")
+        val paneA = pagerPane("%a", "\$a", "project-a")
+
+        val correction = unifiedPagerTargetCorrectionPage(
+            unifiedPanes = listOf(paneB, paneA),
+            sessionName = "project-b",
+            snapshot = UnifiedPagerOwnershipSnapshot(
+                currentPage = 1,
+                settledPage = 1,
+                measuredCurrentPageKey = "%a",
+                userDraggedSinceAlignment = true,
+            ),
+            sessionNameForPane = { pane ->
+                if (pane.paneId == "%b") "project-b" else "project-a"
+            },
+        )
+
+        assertNull(correction)
+    }
+
+    @Test
+    fun anotherMeasuredWindowOfTargetSessionRemainsSelected() {
+        val paneB0 = pagerPane("%b0", "\$b", "project-b-0")
+        val paneB1 = pagerPane("%b1", "\$b", "project-b-1")
+
+        val correction = unifiedPagerTargetCorrectionPage(
+            unifiedPanes = listOf(paneB0, paneB1),
+            sessionName = "project-b",
+            snapshot = UnifiedPagerOwnershipSnapshot(
+                currentPage = 1,
+                settledPage = 1,
+                measuredCurrentPageKey = "%b1",
+                userDraggedSinceAlignment = false,
+            ),
+            sessionNameForPane = { "project-b" },
+        )
+
+        assertNull(correction)
+    }
+
     @Test
     fun reconnectUiRenderingRecordsCauseTrail() {
         val diagnostics = installRecordingDiagnosticSink()


### PR DESCRIPTION
## Summary

- repair #470's FolderList stall repoke so it uses the real FolderList back affordance, reports bounded stage diagnostics, and cannot swallow a broken navigation callback
- make the #1206 connected oracle select the real visible Terminal surface and inspect the on-screen `TerminalView`, eliminating Conversation/default-tab and stale-first-descendant false classifications
- fix the resulting real #1206 recurrence by continuously enforcing active-session ownership from the pager's measured page key, not a transient numeric index
- preserve genuine user swipes and the existing #661/#634/#636 neutral-mask/no-stale-content guards

## Root cause

During a warm A→B switch, `unifiedPanes` reorders from `[A,B]` to `[B,A]`. Compose could report numeric `currentPage=0` / `settledPage=0` against the new list while the last measured keyed page was still A. The old one-shot numeric check declared B aligned; a later keyed remeasure retained A at page 1, leaving the correctly neutral-masked black body forever.

The fix observes current/settled index plus `layoutInfo`'s measured page key for the full alignment lifecycle. It re-requests B when measured ownership is false or delayed key retention drifts back to A, but yields after a genuine drag so cross-session swipes keep working.

## Verification

- request-only mutation: new exact RED-order JVM regression fails (`expected 0, was null`)
- restored focused `TmuxSessionScreenTest`: green; new coverage includes false numeric alignment, delayed key-retention drift, genuine-drag preservation, and another target-session window
- two fresh isolated `Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest` runs: each exactly 1/1, zero skip/failure; forced-empty seam consumed; both authoritative viewports show `B1206-READY` on a painted grid
- `SwitchStaleCaptureSessionBodyJourneyE2eTest`: exactly 1/1; three A→B cycles, zero stale body/boundary/header sightings
- exact no-argument `scripts/full-jvm-gate.sh`: 603/603 tasks executed, `BUILD SUCCESSFUL` in 13m44s
- Android-test compilation, validity/harness/file-size/component/diff guards: green
- independent reviewer: `APPROVED`

Closes #1206
Closes #470
