### PR TITLE
fix(storage): preserve shipped version-one databases

### DIFF
--- a/app/src/main/java/com/pocketshell/app/di/StorageModule.kt
+++ b/app/src/main/java/com/pocketshell/app/di/StorageModule.kt
@@ -3,7 +3,6 @@ package com.pocketshell.app.di
 import android.content.Context
 import androidx.room.Room
 import com.pocketshell.core.storage.APP_DATABASE_MIGRATIONS
-import com.pocketshell.core.storage.APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.dao.AiApiCallLogDao
 import com.pocketshell.core.storage.dao.CommandTemplateDao
@@ -50,10 +49,6 @@ object StorageModule {
             DATABASE_NAME,
         )
             .addMigrations(*APP_DATABASE_MIGRATIONS)
-            .fallbackToDestructiveMigrationFrom(
-                true,
-                *APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS,
-            )
             .build()
 
     @Provides

--- a/app/src/test/java/com/pocketshell/app/di/StorageModuleTest.kt
+++ b/app/src/test/java/com/pocketshell/app/di/StorageModuleTest.kt
@@ -1,12 +1,15 @@
 package com.pocketshell.app.di
 
 import android.content.Context
+import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.core.storage.APP_DATABASE_SCHEMA_VERSION
 import org.junit.After
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -27,19 +30,119 @@ class StorageModuleTest {
     }
 
     @Test
-    fun provideAppDatabase_rebuildsIssue261VersionOneStaleDatabase() {
-        seedStaleIdentityDatabase(version = ISSUE_261_STALE_SCHEMA_VERSION)
+    fun provideAppDatabase_preservesTaggedVersion020Database() {
+        assertTaggedVersionOneMigration(ShippedV1Layout.V0_2_0)
+    }
 
-        val db = StorageModule.provideAppDatabase(context)
-        try {
-            db.openHelper.writableDatabase.query("SELECT 1").close()
-        } finally {
-            db.close()
-        }
+    @Test
+    fun provideAppDatabase_preservesTaggedVersion029Database() {
+        assertTaggedVersionOneMigration(ShippedV1Layout.V0_2_9)
+    }
+
+    @Test
+    fun provideAppDatabase_preservesTaggedVersion030Database() {
+        assertTaggedVersionOneMigration(ShippedV1Layout.V0_3_0)
+    }
+
+    @Test
+    fun provideAppDatabase_migratesExactIssue261MarkerDatabase() {
+        seedStaleIdentityDatabase(version = ISSUE_261_STALE_SCHEMA_VERSION)
+        assertEquals(
+            LEGACY_CRASH_IDENTITY_HASH,
+            queryString("SELECT identity_hash FROM room_master_table WHERE id = 42"),
+        )
+        assertEquals(0L, queryLong("SELECT COUNT(*) FROM stale_issue_261_marker"))
+
+        openProductionDatabase()
 
         assertCurrentSchemaVersion()
         assertTableExists("hosts")
-        assertTableMissing("stale_database_marker")
+        assertTableMissing("stale_issue_261_marker")
+    }
+
+    @Test
+    fun provideAppDatabase_unknownVersionOneFailsClosedWithoutDeletingSentinel() {
+        seedUnknownVersionOneDatabase()
+        val databaseFile = context.getDatabasePath(DATABASE_NAME)
+        assertTrue(databaseFile.exists())
+        val beforeOpen = snapshotDatabaseBundle()
+
+        assertProductionOpenFails()
+
+        assertTrue(databaseFile.exists())
+        assertDatabaseBundleUnchanged(beforeOpen)
+        assertEquals(1, queryLong("PRAGMA user_version"))
+        assertEquals("must-survive", queryString("SELECT payload FROM unknown_v1_data WHERE id = 1747"))
+        assertTableExists("unknown_v1_data")
+        assertTableMissing("hosts")
+    }
+
+    @Test
+    fun provideAppDatabase_malformedTaggedVersionOneNearMatchesFailClosedByteForByte() {
+        for (mutation in MalformedV1Mutation.entries) {
+            VersionOneDatabaseFixtures.seed(
+                context,
+                DATABASE_NAME,
+                ShippedV1Layout.V0_3_0,
+                mutation,
+            )
+            val beforeOpen = snapshotDatabaseBundle()
+
+            assertProductionOpenFails(mutation.toString())
+
+            assertDatabaseBundleUnchanged(beforeOpen, mutation.toString())
+            assertEquals(1, queryLong("PRAGMA user_version"))
+            assertHistoricalWriterBackedSentinels(ShippedV1Layout.V0_3_0)
+            if (
+                mutation != MalformedV1Mutation.NON_EMPTY_SESSIONS &&
+                mutation != MalformedV1Mutation.NON_EMPTY_AGENT_SESSIONS
+            ) {
+                assertEmptyHistoricalStubs()
+            }
+            assertMalformedMutationStillPresent(mutation)
+        }
+    }
+
+    @Test
+    fun provideAppDatabase_taggedMetadataNearMatchesFailClosedByteForByteForEveryArm() {
+        for (layout in ShippedV1Layout.entries) {
+            for (mutation in TaggedMetadataMutation.entries) {
+                val label = "${layout.slug}-$mutation"
+                VersionOneDatabaseFixtures.seed(
+                    context = context,
+                    databaseName = DATABASE_NAME,
+                    layout = layout,
+                    metadataMutation = mutation,
+                )
+                val beforeOpen = snapshotDatabaseBundle()
+
+                assertProductionOpenFails(label)
+
+                assertDatabaseBundleUnchanged(beforeOpen, label)
+                assertEquals(1, queryLong("PRAGMA user_version"))
+                assertHistoricalWriterBackedSentinels(layout)
+                assertEmptyHistoricalStubs()
+                assertTaggedMetadataMutationStillPresent(layout, mutation)
+            }
+        }
+    }
+
+    @Test
+    fun provideAppDatabase_markerMetadataNearMatchesFailClosedByteForByte() {
+        for (mutation in MarkerMetadataMutation.entries) {
+            seedStaleIdentityDatabase(
+                version = ISSUE_261_STALE_SCHEMA_VERSION,
+                markerMutation = mutation,
+            )
+            val beforeOpen = snapshotDatabaseBundle()
+
+            assertProductionOpenFails(mutation.toString())
+
+            assertDatabaseBundleUnchanged(beforeOpen, mutation.toString())
+            assertEquals(1, queryLong("PRAGMA user_version"))
+            assertTableExists("stale_issue_261_marker")
+            assertMarkerMutationStillPresent(mutation)
+        }
     }
 
     @Test
@@ -58,29 +161,540 @@ class StorageModuleTest {
         assertTableExists("stale_database_marker")
     }
 
-    private fun seedStaleIdentityDatabase(version: Int) {
+    private fun assertTaggedVersionOneMigration(layout: ShippedV1Layout) {
+        VersionOneDatabaseFixtures.seed(context, DATABASE_NAME, layout)
+        assertEquals(
+            "Raw fixture drifted from tagged ${layout.slug} application schema",
+            VersionOneDatabaseFixtures.expectedApplicationColumns(layout),
+            VersionOneDatabaseFixtures.readApplicationColumns(context, DATABASE_NAME),
+        )
+        assertEquals(1L, queryLong("SELECT COUNT(*) FROM room_master_table"))
+        assertEquals(
+            layout.identityHash,
+            queryString("SELECT identity_hash FROM room_master_table WHERE id = 42"),
+        )
+        assertHistoricalWriterBackedSentinels(layout)
+        assertEmptyHistoricalStubs()
+
+        openProductionDatabase()
+
+        assertCurrentSchemaVersion()
+        assertWriterBackedSentinels(layout)
+        assertTableMissing("sessions")
+        assertTableMissing("agent_sessions")
+        assertColumnMissing("hosts", "pathOverride")
+        assertForeignKeysValid()
+    }
+
+    private fun assertProductionOpenFails(label: String = "unknown v1") {
+        val db = StorageModule.provideAppDatabase(context)
+        assertThrows(label, RuntimeException::class.java) {
+            try {
+                db.openHelper.writableDatabase.query("SELECT 1").close()
+            } finally {
+                db.close()
+            }
+        }
+    }
+
+    private fun openProductionDatabase() {
+        val db = StorageModule.provideAppDatabase(context)
+        try {
+            db.openHelper.writableDatabase.query("SELECT 1").close()
+        } finally {
+            db.close()
+        }
+    }
+
+    private fun assertWriterBackedSentinels(layout: ShippedV1Layout) {
+        val ids = layout.sentinelIds
+        assertRow(
+            "SELECT id, name, privateKeyPath, hasPassphrase, createdAt, fingerprint " +
+                "FROM ssh_keys WHERE id = ${ids.keyId}",
+            ids.keyId,
+            "${layout.slug}-key",
+            "/keys/${layout.slug}",
+            1L,
+            ids.baseTime,
+            "",
+        )
+        assertRow(
+            """
+            SELECT id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                   scanIntervalSec, enabled, createdAt, lastConnectedAt, tmuxInstalled,
+                   lastBootstrapAt, pocketshellInstalled, pocketshellLastDetectedAt,
+                   pocketshellCliVersion, pocketshellExpectedCliVersion,
+                   pocketshellVersionCompatible, pocketshellDaemonRunning,
+                   pocketshellDaemonEnabled, usageCommandOverride
+            FROM hosts WHERE id = ${ids.hostId}
+            """.trimIndent(),
+            ids.hostId,
+            "${layout.slug}-host",
+            "${layout.slug}.example.com",
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 2222L
+                ShippedV1Layout.V0_2_9 -> 2229L
+                ShippedV1Layout.V0_3_0 -> 2230L
+            },
+            "alexey",
+            ids.keyId,
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 12000L
+                ShippedV1Layout.V0_2_9 -> 12900L
+                ShippedV1Layout.V0_3_0 -> 13000L
+            },
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 1200L
+                ShippedV1Layout.V0_2_9 -> 1290L
+                ShippedV1Layout.V0_3_0 -> 1300L
+            },
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 7L
+                ShippedV1Layout.V0_2_9 -> 9L
+                ShippedV1Layout.V0_3_0 -> 10L
+            },
+            1L,
+            ids.baseTime + 1,
+            ids.baseTime + 2,
+            if (layout == ShippedV1Layout.V0_2_0) null else 1L,
+            if (layout == ShippedV1Layout.V0_2_0) null else ids.baseTime + 3,
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> null
+                ShippedV1Layout.V0_2_9 -> 0L
+                ShippedV1Layout.V0_3_0 -> 1L
+            },
+            if (layout == ShippedV1Layout.V0_3_0) ids.baseTime + 4 else null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> null
+                ShippedV1Layout.V0_2_9 -> "legacy-usage-v029"
+                ShippedV1Layout.V0_3_0 -> "legacy-usage-v030"
+            },
+        )
+        assertRow(
+            "SELECT id, hostId, remotePort, localPort FROM port_remappings " +
+                "WHERE id = ${ids.baseId + 2}",
+            ids.baseId + 2,
+            ids.hostId,
+            ids.remotePort.toLong(),
+            ids.localPort.toLong(),
+        )
+        assertRow(
+            "SELECT id, hostId, label, body, kind FROM snippets WHERE id = ${ids.baseId + 3}",
+            ids.baseId + 3,
+            ids.hostId,
+            "${layout.slug}-snippet",
+            "echo ${layout.slug}-preserved",
+            "command",
+        )
+
+        when (layout) {
+            ShippedV1Layout.V0_2_0 -> {
+                assertNull(queryNullableLong("SELECT tmuxInstalled FROM hosts WHERE id = ${ids.hostId}"))
+                assertNull(queryNullableLong("SELECT lastBootstrapAt FROM hosts WHERE id = ${ids.hostId}"))
+                assertNull(queryNullableLong("SELECT pocketshellInstalled FROM hosts WHERE id = ${ids.hostId}"))
+                assertNull(
+                    queryNullableLong("SELECT pocketshellLastDetectedAt FROM hosts WHERE id = ${ids.hostId}"),
+                )
+            }
+            ShippedV1Layout.V0_2_9 -> {
+                assertEquals(0L, queryLong("SELECT pocketshellInstalled FROM hosts WHERE id = ${ids.hostId}"))
+                assertNull(
+                    queryNullableLong("SELECT pocketshellLastDetectedAt FROM hosts WHERE id = ${ids.hostId}"),
+                )
+                assertEquals(
+                    "legacy-usage-v029",
+                    queryString("SELECT usageCommandOverride FROM hosts WHERE id = ${ids.hostId}"),
+                )
+                assertExpandedWriterBackedSentinels(layout)
+            }
+            ShippedV1Layout.V0_3_0 -> {
+                assertEquals(1L, queryLong("SELECT pocketshellInstalled FROM hosts WHERE id = ${ids.hostId}"))
+                assertEquals(
+                    ids.baseTime + 4,
+                    queryLong("SELECT pocketshellLastDetectedAt FROM hosts WHERE id = ${ids.hostId}"),
+                )
+                assertEquals(
+                    "legacy-usage-v030",
+                    queryString("SELECT usageCommandOverride FROM hosts WHERE id = ${ids.hostId}"),
+                )
+                assertExpandedWriterBackedSentinels(layout)
+            }
+        }
+    }
+
+    private fun assertExpandedWriterBackedSentinels(layout: ShippedV1Layout) {
+        val ids = layout.sentinelIds
+        assertRow(
+            "SELECT hostId, remotePort, clickCount, totalBytes, lastUsedAt FROM port_usage " +
+                "WHERE hostId = ${ids.hostId} AND remotePort = ${ids.remotePort}",
+            ids.hostId,
+            ids.remotePort.toLong(),
+            7L,
+            1747L,
+            ids.baseTime + 5,
+        )
+        assertRow(
+            "SELECT id, hostId, label, path, createdAt FROM project_roots " +
+                "WHERE id = ${ids.baseId + 4}",
+            ids.baseId + 4,
+            ids.hostId,
+            "${layout.slug}-root",
+            "/srv/${layout.slug}",
+            ids.baseTime + 6,
+        )
+        assertRow(
+            """
+            SELECT id, timestampMillis, provider, feature, inputUnits, outputUnits,
+                   unitCostUsdMillicents, computedCostUsdMillicents, metadataJson
+            FROM ai_api_call_log WHERE id = ${ids.baseId + 5}
+            """.trimIndent(),
+            ids.baseId + 5,
+            ids.baseTime + 7,
+            "openai",
+            "whisper",
+            17L,
+            47L,
+            10L,
+            174L,
+            """{"layout":"${layout.slug}"}""",
+        )
+        assertRow(
+            """
+            SELECT id, audioPath, recordingTimestampMs, destinationContext, retryCount,
+                   lastErrorMessage, audioByteSize, createdAtMs
+            FROM pending_transcriptions WHERE id = '${layout.slug}-pending'
+            """.trimIndent(),
+            "${layout.slug}-pending",
+            "/audio/${layout.slug}.wav",
+            ids.baseTime + 8,
+            "composer",
+            1L,
+            "offline",
+            1747L,
+            ids.baseTime + 9,
+        )
+    }
+
+    private fun assertHistoricalWriterBackedSentinels(layout: ShippedV1Layout) {
+        val ids = layout.sentinelIds
+        assertRow(
+            "SELECT id, name, privateKeyPath, hasPassphrase, createdAt FROM ssh_keys WHERE id = ${ids.keyId}",
+            ids.keyId,
+            "${layout.slug}-key",
+            "/keys/${layout.slug}",
+            1L,
+            ids.baseTime,
+        )
+        val hostSql = when (layout) {
+            ShippedV1Layout.V0_2_0 ->
+                """
+                SELECT id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                       scanIntervalSec, enabled, createdAt, lastConnectedAt
+                FROM hosts WHERE id = ${ids.hostId}
+                """.trimIndent()
+            ShippedV1Layout.V0_2_9 ->
+                """
+                SELECT id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                       scanIntervalSec, enabled, createdAt, lastConnectedAt, tmuxInstalled,
+                       lastBootstrapAt, quseInstalled, quseLastDetectedAt, usageCommandOverride,
+                       pathOverride, pocketshellInstalled
+                FROM hosts WHERE id = ${ids.hostId}
+                """.trimIndent()
+            ShippedV1Layout.V0_3_0 ->
+                """
+                SELECT id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                       scanIntervalSec, enabled, createdAt, lastConnectedAt, tmuxInstalled,
+                       lastBootstrapAt, pocketshellInstalled, pocketshellLastDetectedAt,
+                       usageCommandOverride, pathOverride
+                FROM hosts WHERE id = ${ids.hostId}
+                """.trimIndent()
+        }
+        val baseHost: List<Any?> = listOf(
+            ids.hostId,
+            "${layout.slug}-host",
+            "${layout.slug}.example.com",
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 2222L
+                ShippedV1Layout.V0_2_9 -> 2229L
+                ShippedV1Layout.V0_3_0 -> 2230L
+            },
+            "alexey",
+            ids.keyId,
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 12000L
+                ShippedV1Layout.V0_2_9 -> 12900L
+                ShippedV1Layout.V0_3_0 -> 13000L
+            },
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 1200L
+                ShippedV1Layout.V0_2_9 -> 1290L
+                ShippedV1Layout.V0_3_0 -> 1300L
+            },
+            when (layout) {
+                ShippedV1Layout.V0_2_0 -> 7L
+                ShippedV1Layout.V0_2_9 -> 9L
+                ShippedV1Layout.V0_3_0 -> 10L
+            },
+            1L,
+            ids.baseTime + 1,
+            ids.baseTime + 2,
+        )
+        val layoutHost: List<Any?> = when (layout) {
+            ShippedV1Layout.V0_2_0 -> emptyList()
+            ShippedV1Layout.V0_2_9 -> listOf(
+                1L,
+                ids.baseTime + 3,
+                1L,
+                ids.baseTime + 4,
+                "legacy-usage-v029",
+                "/opt/v029/bin",
+                0L,
+            )
+            ShippedV1Layout.V0_3_0 -> listOf(
+                1L,
+                ids.baseTime + 3,
+                1L,
+                ids.baseTime + 4,
+                "legacy-usage-v030",
+                "/opt/v030/bin",
+            )
+        }
+        assertRow(hostSql, *(baseHost + layoutHost).toTypedArray())
+        assertRow(
+            "SELECT id, hostId, remotePort, localPort FROM port_remappings WHERE id = ${ids.baseId + 2}",
+            ids.baseId + 2,
+            ids.hostId,
+            ids.remotePort.toLong(),
+            ids.localPort.toLong(),
+        )
+        assertRow(
+            "SELECT id, hostId, label, body, kind FROM snippets WHERE id = ${ids.baseId + 3}",
+            ids.baseId + 3,
+            ids.hostId,
+            "${layout.slug}-snippet",
+            "echo ${layout.slug}-preserved",
+            "command",
+        )
+        if (layout != ShippedV1Layout.V0_2_0) assertExpandedWriterBackedSentinels(layout)
+    }
+
+    private fun assertEmptyHistoricalStubs() {
+        assertEquals(0L, queryLong("SELECT COUNT(*) FROM sessions"))
+        assertEquals(0L, queryLong("SELECT COUNT(*) FROM agent_sessions"))
+    }
+
+    private fun assertMalformedMutationStillPresent(mutation: MalformedV1Mutation) {
+        when (mutation) {
+            MalformedV1Mutation.EXTRA_HOST_COLUMN ->
+                assertTrue(tableColumnNames("hosts").contains("malformedExtra"))
+            MalformedV1Mutation.MISSING_REQUIRED_COLUMN ->
+                assertFalse(tableColumnNames("sessions").contains("tags"))
+            MalformedV1Mutation.GENERATED_HOST_COLUMN ->
+                assertTrue(tableColumnHidden("hosts", "malformedGenerated") != 0L)
+            MalformedV1Mutation.HOSTNAME_AFFINITY ->
+                assertEquals("BLOB", tableColumnType("hosts", "hostname"))
+            MalformedV1Mutation.HOSTNAME_NULLABILITY ->
+                assertEquals(0L, tableColumnNotNull("hosts", "hostname"))
+            MalformedV1Mutation.HOSTNAME_CHECK_CONSTRAINT ->
+                assertTrue(tableSql("hosts").contains("CHECK", ignoreCase = true))
+            MalformedV1Mutation.HOSTNAME_BLOCK_COMMENT_CHECK_CONSTRAINT ->
+                assertTrue(tableSql("hosts").contains("CHECK/**/(", ignoreCase = true))
+            MalformedV1Mutation.HOSTNAME_LINE_COMMENT_CHECK_CONSTRAINT ->
+                assertTrue(
+                    tableSql("hosts").contains(
+                        "CHECK-- comment-separated constraint",
+                        ignoreCase = true,
+                    ),
+                )
+            MalformedV1Mutation.HOSTNAME_COLLATION ->
+                assertTrue(tableSql("hosts").contains("COLLATE NOCASE", ignoreCase = true))
+            MalformedV1Mutation.HOST_INDEX_COLLATION -> {
+                assertEquals("NOCASE", indexKeyCollation("index_hosts_keyId"))
+                assertEquals(1L, indexKeyDescending("index_hosts_keyId"))
+            }
+            MalformedV1Mutation.EXTRA_HOST_UNIQUE_CONSTRAINT ->
+                assertEquals(
+                    1L,
+                    queryLong(
+                        "SELECT COUNT(*) FROM pragma_index_list('hosts') WHERE origin = 'u'",
+                    ),
+                )
+            MalformedV1Mutation.MISSING_HOST_AUTOINCREMENT ->
+                assertFalse(tableSql("hosts").contains("AUTOINCREMENT", ignoreCase = true))
+            MalformedV1Mutation.BLOCK_COMMENT_SPOOFED_HOST_AUTOINCREMENT ->
+                assertTrue(tableSql("hosts").contains("/* AUTOINCREMENT */", ignoreCase = true))
+            MalformedV1Mutation.LINE_COMMENT_SPOOFED_HOST_AUTOINCREMENT ->
+                assertTrue(tableSql("hosts").contains("-- AUTOINCREMENT", ignoreCase = true))
+            MalformedV1Mutation.MISSING_HOST_INDEX ->
+                assertFalse(indexNames("hosts").contains("index_hosts_keyId"))
+            MalformedV1Mutation.MISSING_HOST_FOREIGN_KEY ->
+                assertEquals(0L, queryLong("SELECT COUNT(*) FROM pragma_foreign_key_list('hosts')"))
+            MalformedV1Mutation.NON_EMPTY_SESSIONS ->
+                assertRow(
+                    "SELECT id, hostId, name, lastSeenAt, tags FROM sessions",
+                    1747L,
+                    ShippedV1Layout.V0_3_0.sentinelIds.hostId,
+                    "must-survive-session",
+                    1747L,
+                    "legacy",
+                )
+            MalformedV1Mutation.NON_EMPTY_AGENT_SESSIONS ->
+                assertRow(
+                    "SELECT id, paneRef, agent, jsonlPath, detectedAt FROM agent_sessions",
+                    1747L,
+                    "must-survive-pane",
+                    "claude",
+                    "/logs/must-survive.jsonl",
+                    1747L,
+                )
+            MalformedV1Mutation.UNEXPECTED_VIEW ->
+                assertSchemaObjectExists("view", "malformed_hosts_view")
+            MalformedV1Mutation.UNEXPECTED_TRIGGER ->
+                assertSchemaObjectExists("trigger", "malformed_hosts_trigger")
+        }
+    }
+
+    private fun assertTaggedMetadataMutationStillPresent(
+        layout: ShippedV1Layout,
+        mutation: TaggedMetadataMutation,
+    ) {
+        when (mutation) {
+            TaggedMetadataMutation.MISSING_ROOM_MASTER_TABLE ->
+                assertTableMissing("room_master_table")
+            TaggedMetadataMutation.EMPTY_ROOM_MASTER_TABLE ->
+                assertEquals(0L, queryLong("SELECT COUNT(*) FROM room_master_table"))
+            TaggedMetadataMutation.WRONG_IDENTITY_HASH ->
+                assertEquals(
+                    "not-the-${layout.slug}-identity",
+                    queryString("SELECT identity_hash FROM room_master_table WHERE id = 42"),
+                )
+            TaggedMetadataMutation.EXTRA_ROOM_MASTER_COLUMN ->
+                assertTrue(tableColumnNames("room_master_table").contains("unexpected_metadata"))
+            TaggedMetadataMutation.EXTRA_ROOM_MASTER_ROW -> {
+                assertEquals(2L, queryLong("SELECT COUNT(*) FROM room_master_table"))
+                assertEquals(
+                    "unexpected-extra-room-row",
+                    queryString("SELECT identity_hash FROM room_master_table WHERE id = 43"),
+                )
+            }
+        }
+    }
+
+    private fun assertMarkerMutationStillPresent(mutation: MarkerMetadataMutation) {
+        when (mutation) {
+            MarkerMetadataMutation.NON_EMPTY_MARKER ->
+                assertEquals(1L, queryLong("SELECT COUNT(*) FROM stale_issue_261_marker"))
+            MarkerMetadataMutation.WRONG_IDENTITY_HASH ->
+                assertEquals(
+                    "not-the-issue-261-identity",
+                    queryString("SELECT identity_hash FROM room_master_table WHERE id = 42"),
+                )
+            MarkerMetadataMutation.EXTRA_ROOM_MASTER_COLUMN ->
+                assertTrue(tableColumnNames("room_master_table").contains("unexpected_metadata"))
+            MarkerMetadataMutation.MISSING_ROOM_MASTER_TABLE ->
+                assertTableMissing("room_master_table")
+            MarkerMetadataMutation.EXTRA_ROOM_MASTER_ROW -> {
+                assertEquals(2L, queryLong("SELECT COUNT(*) FROM room_master_table"))
+                assertEquals(
+                    "unexpected-extra-room-row",
+                    queryString("SELECT identity_hash FROM room_master_table WHERE id = 43"),
+                )
+            }
+        }
+    }
+
+    private fun assertForeignKeysValid() {
+        val sqlite = openReadOnlyDatabase()
+        sqlite.use {
+            it.rawQuery("PRAGMA foreign_key_check", null).use { cursor ->
+                assertFalse("Migrated database contains foreign-key violations", cursor.moveToFirst())
+            }
+        }
+    }
+
+    private fun seedStaleIdentityDatabase(
+        version: Int,
+        markerMutation: MarkerMetadataMutation? = null,
+    ) {
         context.deleteDatabase(DATABASE_NAME)
         val databaseFile = context.getDatabasePath(DATABASE_NAME)
         databaseFile.parentFile?.mkdirs()
 
         val sqlite = SQLiteDatabase.openOrCreateDatabase(databaseFile, null)
         sqlite.use {
+            it.rawQuery("PRAGMA journal_mode=WAL", null).use { cursor ->
+                check(cursor.moveToFirst() && cursor.getString(0).equals("wal", ignoreCase = true))
+            }
+            if (markerMutation != MarkerMetadataMutation.MISSING_ROOM_MASTER_TABLE) {
+                val extraRoomMasterColumn =
+                    if (markerMutation == MarkerMetadataMutation.EXTRA_ROOM_MASTER_COLUMN) {
+                        ", unexpected_metadata TEXT"
+                    } else {
+                        ""
+                    }
+                it.execSQL(
+                    "CREATE TABLE room_master_table " +
+                        "(id INTEGER PRIMARY KEY, identity_hash TEXT$extraRoomMasterColumn)",
+                )
+                val identityHash =
+                    if (markerMutation == MarkerMetadataMutation.WRONG_IDENTITY_HASH) {
+                        "not-the-issue-261-identity"
+                    } else {
+                        LEGACY_CRASH_IDENTITY_HASH
+                    }
+                it.execSQL(
+                    "INSERT INTO room_master_table (id, identity_hash) VALUES(42, ?)",
+                    arrayOf(identityHash),
+                )
+                if (markerMutation == MarkerMetadataMutation.EXTRA_ROOM_MASTER_ROW) {
+                    it.execSQL(
+                        """
+                        INSERT INTO room_master_table(id, identity_hash)
+                        VALUES(43, 'unexpected-extra-room-row')
+                        """.trimIndent(),
+                    )
+                }
+            }
+            val markerTable = if (version == ISSUE_261_STALE_SCHEMA_VERSION) {
+                "stale_issue_261_marker"
+            } else {
+                "stale_database_marker"
+            }
+            it.execSQL("CREATE TABLE $markerTable (id INTEGER PRIMARY KEY)")
+            if (markerMutation == MarkerMetadataMutation.NON_EMPTY_MARKER) {
+                it.execSQL("INSERT INTO $markerTable(id) VALUES(1747)")
+            }
+            it.execSQL("PRAGMA user_version = $version")
+        }
+    }
+
+    private fun seedUnknownVersionOneDatabase() {
+        context.deleteDatabase(DATABASE_NAME)
+        val databaseFile = context.getDatabasePath(DATABASE_NAME)
+        databaseFile.parentFile?.mkdirs()
+
+        SQLiteDatabase.openOrCreateDatabase(databaseFile, null).use {
+            it.rawQuery("PRAGMA journal_mode=WAL", null).use { cursor ->
+                check(cursor.moveToFirst() && cursor.getString(0).equals("wal", ignoreCase = true))
+            }
             it.execSQL("CREATE TABLE room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT)")
             it.execSQL(
                 "INSERT INTO room_master_table (id, identity_hash) VALUES(42, ?)",
                 arrayOf(LEGACY_CRASH_IDENTITY_HASH),
             )
-            it.execSQL("CREATE TABLE stale_database_marker (id INTEGER PRIMARY KEY)")
-            it.execSQL("PRAGMA user_version = $version")
+            it.execSQL("CREATE TABLE unknown_v1_data (id INTEGER PRIMARY KEY, payload TEXT NOT NULL)")
+            it.execSQL("INSERT INTO unknown_v1_data(id, payload) VALUES(1747, 'must-survive')")
+            it.execSQL("PRAGMA user_version = 1")
         }
     }
 
     private fun assertCurrentSchemaVersion() {
-        val sqlite = SQLiteDatabase.openDatabase(
-            context.getDatabasePath(DATABASE_NAME).path,
-            null,
-            SQLiteDatabase.OPEN_READONLY,
-        )
+        val sqlite = openReadOnlyDatabase()
         sqlite.use {
             it.rawQuery("PRAGMA user_version", null).use { cursor ->
                 assertTrue(cursor.moveToFirst())
@@ -97,12 +711,132 @@ class StorageModuleTest {
         assertFalse(tableExists(tableName))
     }
 
+    private fun assertColumnMissing(tableName: String, columnName: String) {
+        val sqlite = openReadOnlyDatabase()
+        sqlite.use {
+            it.rawQuery("PRAGMA table_info(`$tableName`)", null).use { cursor ->
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                while (cursor.moveToNext()) {
+                    assertFalse(
+                        "Column $tableName.$columnName should not exist",
+                        cursor.getString(nameIndex) == columnName,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun tableColumnNames(tableName: String): Set<String> {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            buildSet {
+                it.rawQuery("PRAGMA table_info(`$tableName`)", null).use { cursor ->
+                    val nameIndex = cursor.getColumnIndexOrThrow("name")
+                    while (cursor.moveToNext()) add(cursor.getString(nameIndex))
+                }
+            }
+        }
+    }
+
+    private fun tableColumnType(tableName: String, columnName: String): String {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            var result: String? = null
+            it.rawQuery("PRAGMA table_info(`$tableName`)", null).use { cursor ->
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                val typeIndex = cursor.getColumnIndexOrThrow("type")
+                while (cursor.moveToNext()) {
+                    if (cursor.getString(nameIndex) == columnName) {
+                        result = cursor.getString(typeIndex).uppercase()
+                        break
+                    }
+                }
+            }
+            requireNotNull(result) { "Missing column $tableName.$columnName" }
+        }
+    }
+
+    private fun tableColumnNotNull(tableName: String, columnName: String): Long {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            var result: Long? = null
+            it.rawQuery("PRAGMA table_info(`$tableName`)", null).use { cursor ->
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                val notNullIndex = cursor.getColumnIndexOrThrow("notnull")
+                while (cursor.moveToNext()) {
+                    if (cursor.getString(nameIndex) == columnName) {
+                        result = cursor.getLong(notNullIndex)
+                        break
+                    }
+                }
+            }
+            requireNotNull(result) { "Missing column $tableName.$columnName" }
+        }
+    }
+
+    private fun tableColumnHidden(tableName: String, columnName: String): Long {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            var result: Long? = null
+            it.rawQuery("PRAGMA table_xinfo(`$tableName`)", null).use { cursor ->
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                val hiddenIndex = cursor.getColumnIndexOrThrow("hidden")
+                while (cursor.moveToNext()) {
+                    if (cursor.getString(nameIndex) == columnName) {
+                        result = cursor.getLong(hiddenIndex)
+                        break
+                    }
+                }
+            }
+            requireNotNull(result) { "Missing column $tableName.$columnName" }
+        }
+    }
+
+    private fun tableSql(tableName: String): String =
+        queryString("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = '$tableName'")
+
+    private fun indexKeyCollation(indexName: String): String {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            it.rawQuery(
+                "SELECT coll FROM pragma_index_xinfo('$indexName') WHERE key = 1",
+                null,
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                cursor.getString(0)
+            }
+        }
+    }
+
+    private fun indexKeyDescending(indexName: String): Long =
+        queryLong("SELECT desc FROM pragma_index_xinfo('$indexName') WHERE key = 1")
+
+    private fun indexNames(tableName: String): Set<String> {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            buildSet {
+                it.rawQuery("PRAGMA index_list(`$tableName`)", null).use { cursor ->
+                    val nameIndex = cursor.getColumnIndexOrThrow("name")
+                    while (cursor.moveToNext()) add(cursor.getString(nameIndex))
+                }
+            }
+        }
+    }
+
+    private fun assertSchemaObjectExists(type: String, name: String) {
+        val sqlite = openReadOnlyDatabase()
+        sqlite.use {
+            it.rawQuery(
+                "SELECT 1 FROM sqlite_master WHERE type = ? AND name = ?",
+                arrayOf(type, name),
+            ).use { cursor ->
+                assertTrue("Expected $type $name to remain", cursor.moveToFirst())
+            }
+        }
+    }
+
     private fun tableExists(tableName: String): Boolean {
-        val sqlite = SQLiteDatabase.openDatabase(
-            context.getDatabasePath(DATABASE_NAME).path,
-            null,
-            SQLiteDatabase.OPEN_READONLY,
-        )
+        val sqlite = openReadOnlyDatabase()
         return sqlite.use {
             it.rawQuery(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
@@ -113,10 +847,102 @@ class StorageModuleTest {
         }
     }
 
+    private fun queryString(sql: String): String {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            it.rawQuery(sql, null).use { cursor ->
+                assertTrue("Expected one row for: $sql", cursor.moveToFirst())
+                cursor.getString(0)
+            }
+        }
+    }
+
+    private fun queryLong(sql: String): Long =
+        requireNotNull(queryNullableLong(sql)) { "Expected non-null value for: $sql" }
+
+    private fun queryNullableLong(sql: String): Long? {
+        val sqlite = openReadOnlyDatabase()
+        return sqlite.use {
+            it.rawQuery(sql, null).use { cursor ->
+                assertTrue("Expected one row for: $sql", cursor.moveToFirst())
+                if (cursor.isNull(0)) null else cursor.getLong(0)
+            }
+        }
+    }
+
+    private fun assertRow(sql: String, vararg expected: Any?) {
+        val sqlite = openReadOnlyDatabase()
+        sqlite.use {
+            it.rawQuery(sql, null).use { cursor ->
+                assertTrue("Expected exactly one row for: $sql", cursor.moveToFirst())
+                assertEquals(
+                    "Column count mismatch for: $sql",
+                    expected.size,
+                    cursor.columnCount,
+                )
+                val actual = List(cursor.columnCount) { columnIndex ->
+                    when (cursor.getType(columnIndex)) {
+                        Cursor.FIELD_TYPE_NULL -> null
+                        Cursor.FIELD_TYPE_INTEGER -> cursor.getLong(columnIndex)
+                        Cursor.FIELD_TYPE_FLOAT -> cursor.getDouble(columnIndex)
+                        Cursor.FIELD_TYPE_STRING -> cursor.getString(columnIndex)
+                        Cursor.FIELD_TYPE_BLOB -> cursor.getBlob(columnIndex)
+                        else -> error("Unknown SQLite cursor type for column $columnIndex")
+                    }
+                }
+                assertEquals("Row mismatch for: $sql", expected.toList(), actual)
+                assertFalse("Expected exactly one row for: $sql", cursor.moveToNext())
+            }
+        }
+    }
+
+    private fun snapshotDatabaseBundle(): Map<String, ByteArray> {
+        val databaseFile = context.getDatabasePath(DATABASE_NAME)
+        return DATABASE_SUFFIXES.mapNotNull { suffix ->
+            val file = java.io.File(databaseFile.path + suffix)
+            if (file.exists()) suffix to file.readBytes() else null
+        }.toMap()
+    }
+
+    private fun assertDatabaseBundleUnchanged(
+        beforeOpen: Map<String, ByteArray>,
+        label: String = "unknown v1",
+    ) {
+        val afterOpen = snapshotDatabaseBundle()
+        assertEquals(
+            "$label changed the SQLite bundle inventory",
+            beforeOpen.keys,
+            afterOpen.keys,
+        )
+        for ((suffix, expectedBytes) in beforeOpen) {
+            assertArrayEquals(
+                "$label changed pocketshell.db$suffix despite fail-closed classification",
+                expectedBytes,
+                afterOpen.getValue(suffix),
+            )
+        }
+    }
+
+    private fun openReadOnlyDatabase(): SQLiteDatabase =
+        SQLiteDatabase.openDatabase(
+            context.getDatabasePath(DATABASE_NAME).path,
+            null,
+            SQLiteDatabase.OPEN_READONLY,
+        )
+
     private companion object {
         const val DATABASE_NAME = "pocketshell.db"
         const val ISSUE_261_STALE_SCHEMA_VERSION = 1
         const val LEGACY_026_SCHEMA_VERSION = 5
         const val LEGACY_CRASH_IDENTITY_HASH = "4a479a15dfcab2d576e00c7ce10ac581"
+        val DATABASE_SUFFIXES = listOf("", "-wal", "-shm", "-journal")
+    }
+
+    private enum class MarkerMetadataMutation {
+        NON_EMPTY_MARKER,
+        WRONG_IDENTITY_HASH,
+        EXTRA_ROOM_MASTER_COLUMN,
+        MISSING_ROOM_MASTER_TABLE,
+        EXTRA_ROOM_MASTER_ROW,
     }
 }

--- a/app/src/test/java/com/pocketshell/app/di/VersionOneDatabaseFixtures.kt
+++ b/app/src/test/java/com/pocketshell/app/di/VersionOneDatabaseFixtures.kt
@@ -1,0 +1,652 @@
+package com.pocketshell.app.di
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+
+/**
+ * Raw on-disk reconstructions of the three distinct schema-v1 layouts shipped
+ * in v0.2.0, v0.2.9, and v0.3.0.
+ *
+ * The tagged builds predate Room schema export, so these fixtures mirror the
+ * entity DDL at those tags and the exact row-42 identity hash embedded in each
+ * published APK.
+ */
+internal object VersionOneDatabaseFixtures {
+    fun seed(
+        context: Context,
+        databaseName: String,
+        layout: ShippedV1Layout,
+        mutation: MalformedV1Mutation? = null,
+        metadataMutation: TaggedMetadataMutation? = null,
+    ) {
+        context.deleteDatabase(databaseName)
+        val databaseFile = context.getDatabasePath(databaseName)
+        databaseFile.parentFile?.mkdirs()
+
+        SQLiteDatabase.openOrCreateDatabase(databaseFile, null).use { db ->
+            db.rawQuery("PRAGMA journal_mode=WAL", null).use { cursor ->
+                check(cursor.moveToFirst() && cursor.getString(0).equals("wal", ignoreCase = true))
+            }
+            db.execSQL("PRAGMA foreign_keys=OFF")
+            createRoomMasterTable(db, layout, metadataMutation)
+            createSshKeys(db)
+            createHosts(db, layout, mutation)
+            createPortRemappings(db)
+            createSessions(db, mutation)
+            createSnippets(db, labelNotNull = layout == ShippedV1Layout.V0_2_0)
+            createAgentSessions(db)
+            if (layout != ShippedV1Layout.V0_2_0) {
+                createPortUsage(db)
+                createProjectRoots(db)
+                createAiApiCallLog(db)
+                createPendingTranscriptions(db)
+            }
+            insertWriterBackedSentinels(db, layout, mutation)
+            when (mutation) {
+                MalformedV1Mutation.NON_EMPTY_SESSIONS -> db.execSQL(
+                    """
+                    INSERT INTO sessions(id, hostId, name, lastSeenAt, tags)
+                    VALUES(1747, ${layout.sentinelIds.hostId}, 'must-survive-session', 1747, 'legacy')
+                    """.trimIndent(),
+                )
+                MalformedV1Mutation.NON_EMPTY_AGENT_SESSIONS -> db.execSQL(
+                    """
+                    INSERT INTO agent_sessions(id, paneRef, agent, jsonlPath, detectedAt)
+                    VALUES(1747, 'must-survive-pane', 'claude', '/logs/must-survive.jsonl', 1747)
+                    """.trimIndent(),
+                )
+                MalformedV1Mutation.UNEXPECTED_VIEW ->
+                    db.execSQL("CREATE VIEW malformed_hosts_view AS SELECT id FROM hosts")
+                MalformedV1Mutation.UNEXPECTED_TRIGGER -> db.execSQL(
+                    """
+                    CREATE TRIGGER malformed_hosts_trigger
+                    AFTER UPDATE ON hosts
+                    BEGIN
+                        SELECT 1;
+                    END
+                    """.trimIndent(),
+                )
+                else -> Unit
+            }
+            db.execSQL("PRAGMA user_version = 1")
+        }
+    }
+
+    private fun createRoomMasterTable(
+        db: SQLiteDatabase,
+        layout: ShippedV1Layout,
+        mutation: TaggedMetadataMutation?,
+    ) {
+        if (mutation == TaggedMetadataMutation.MISSING_ROOM_MASTER_TABLE) return
+        val extraColumn = if (mutation == TaggedMetadataMutation.EXTRA_ROOM_MASTER_COLUMN) {
+            ", unexpected_metadata TEXT"
+        } else {
+            ""
+        }
+        db.execSQL(
+            "CREATE TABLE room_master_table " +
+                "(id INTEGER PRIMARY KEY, identity_hash TEXT$extraColumn)",
+        )
+        if (mutation == TaggedMetadataMutation.EMPTY_ROOM_MASTER_TABLE) return
+        val identityHash = if (mutation == TaggedMetadataMutation.WRONG_IDENTITY_HASH) {
+            "not-the-${layout.slug}-identity"
+        } else {
+            layout.identityHash
+        }
+        db.execSQL(
+            "INSERT INTO room_master_table(id, identity_hash) VALUES(42, ?)",
+            arrayOf(identityHash),
+        )
+        if (mutation == TaggedMetadataMutation.EXTRA_ROOM_MASTER_ROW) {
+            db.execSQL(
+                """
+                INSERT INTO room_master_table(id, identity_hash)
+                VALUES(43, 'unexpected-extra-room-row')
+                """.trimIndent(),
+            )
+        }
+    }
+
+    fun expectedApplicationColumns(layout: ShippedV1Layout): Map<String, List<String>> =
+        buildMap {
+            put("agent_sessions", listOf("id", "paneRef", "agent", "jsonlPath", "detectedAt"))
+            if (layout != ShippedV1Layout.V0_2_0) {
+                put(
+                    "ai_api_call_log",
+                    listOf(
+                        "id",
+                        "timestampMillis",
+                        "provider",
+                        "feature",
+                        "inputUnits",
+                        "outputUnits",
+                        "unitCostUsdMillicents",
+                        "computedCostUsdMillicents",
+                        "metadataJson",
+                    ),
+                )
+            }
+            put(
+                "hosts",
+                when (layout) {
+                    ShippedV1Layout.V0_2_0 -> BASE_HOST_COLUMNS
+                    ShippedV1Layout.V0_2_9 -> BASE_HOST_COLUMNS + listOf(
+                        "tmuxInstalled",
+                        "lastBootstrapAt",
+                        "quseInstalled",
+                        "quseLastDetectedAt",
+                        "usageCommandOverride",
+                        "pathOverride",
+                        "pocketshellInstalled",
+                    )
+                    ShippedV1Layout.V0_3_0 -> BASE_HOST_COLUMNS + listOf(
+                        "tmuxInstalled",
+                        "lastBootstrapAt",
+                        "pocketshellInstalled",
+                        "pocketshellLastDetectedAt",
+                        "usageCommandOverride",
+                        "pathOverride",
+                    )
+                },
+            )
+            if (layout != ShippedV1Layout.V0_2_0) {
+                put(
+                    "pending_transcriptions",
+                    listOf(
+                        "id",
+                        "audioPath",
+                        "recordingTimestampMs",
+                        "destinationContext",
+                        "retryCount",
+                        "lastErrorMessage",
+                        "audioByteSize",
+                        "createdAtMs",
+                    ),
+                )
+            }
+            put("port_remappings", listOf("id", "hostId", "remotePort", "localPort"))
+            if (layout != ShippedV1Layout.V0_2_0) {
+                put("port_usage", listOf("hostId", "remotePort", "clickCount", "totalBytes", "lastUsedAt"))
+                put("project_roots", listOf("id", "hostId", "label", "path", "createdAt"))
+            }
+            put("sessions", listOf("id", "hostId", "name", "lastSeenAt", "tags"))
+            put("snippets", listOf("id", "hostId", "label", "body", "kind"))
+            put("ssh_keys", listOf("id", "name", "privateKeyPath", "hasPassphrase", "createdAt"))
+        }.toSortedMap()
+
+    fun readApplicationColumns(context: Context, databaseName: String): Map<String, List<String>> {
+        val db = SQLiteDatabase.openDatabase(
+            context.getDatabasePath(databaseName).path,
+            null,
+            SQLiteDatabase.OPEN_READONLY,
+        )
+        return db.use {
+            val tableNames = buildList {
+                it.rawQuery(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'table'
+                      AND name NOT LIKE 'sqlite_%'
+                      AND name NOT IN ('android_metadata', 'room_master_table')
+                    ORDER BY name
+                    """.trimIndent(),
+                    null,
+                ).use { cursor ->
+                    while (cursor.moveToNext()) add(cursor.getString(0))
+                }
+            }
+            tableNames.associateWith { tableName ->
+                buildList {
+                    it.rawQuery("PRAGMA table_info(`$tableName`)", null).use { cursor ->
+                        val nameIndex = cursor.getColumnIndexOrThrow("name")
+                        while (cursor.moveToNext()) add(cursor.getString(nameIndex))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createSshKeys(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE ssh_keys (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                name TEXT NOT NULL,
+                privateKeyPath TEXT NOT NULL,
+                hasPassphrase INTEGER NOT NULL,
+                createdAt INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+    }
+
+    private fun createHosts(
+        db: SQLiteDatabase,
+        layout: ShippedV1Layout,
+        mutation: MalformedV1Mutation?,
+    ) {
+        val hostnameColumn = when (mutation) {
+            MalformedV1Mutation.HOSTNAME_AFFINITY -> "hostname BLOB NOT NULL"
+            MalformedV1Mutation.HOSTNAME_NULLABILITY -> "hostname TEXT"
+            MalformedV1Mutation.HOSTNAME_CHECK_CONSTRAINT ->
+                "hostname TEXT NOT NULL CHECK(length(hostname) > 0)"
+            MalformedV1Mutation.HOSTNAME_BLOCK_COMMENT_CHECK_CONSTRAINT ->
+                "hostname TEXT NOT NULL CHECK/**/(length(hostname) > 0)"
+            MalformedV1Mutation.HOSTNAME_LINE_COMMENT_CHECK_CONSTRAINT ->
+                "hostname TEXT NOT NULL CHECK-- comment-separated constraint\n" +
+                    "(length(hostname) > 0)"
+            MalformedV1Mutation.HOSTNAME_COLLATION -> "hostname TEXT NOT NULL COLLATE NOCASE"
+            else -> "hostname TEXT NOT NULL"
+        }
+        val definitions = mutableListOf(
+            when (mutation) {
+                MalformedV1Mutation.MISSING_HOST_AUTOINCREMENT ->
+                    "id INTEGER PRIMARY KEY NOT NULL"
+                MalformedV1Mutation.BLOCK_COMMENT_SPOOFED_HOST_AUTOINCREMENT ->
+                    "id INTEGER PRIMARY KEY NOT NULL /* AUTOINCREMENT */"
+                MalformedV1Mutation.LINE_COMMENT_SPOOFED_HOST_AUTOINCREMENT ->
+                    "id INTEGER PRIMARY KEY NOT NULL -- AUTOINCREMENT\n"
+                else -> "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL"
+            },
+            "name TEXT NOT NULL",
+            hostnameColumn,
+            "port INTEGER NOT NULL",
+            "username TEXT NOT NULL",
+            "keyId INTEGER NOT NULL",
+            "maxAutoPort INTEGER NOT NULL",
+            "skipPortsBelow INTEGER NOT NULL",
+            "scanIntervalSec INTEGER NOT NULL",
+            "enabled INTEGER NOT NULL",
+            "createdAt INTEGER NOT NULL",
+            "lastConnectedAt INTEGER",
+        )
+        definitions += when (layout) {
+            ShippedV1Layout.V0_2_0 -> emptyList()
+            ShippedV1Layout.V0_2_9 -> listOf(
+                "tmuxInstalled INTEGER",
+                "lastBootstrapAt INTEGER",
+                "quseInstalled INTEGER",
+                "quseLastDetectedAt INTEGER",
+                "usageCommandOverride TEXT",
+                "pathOverride TEXT",
+                "pocketshellInstalled INTEGER",
+            )
+            ShippedV1Layout.V0_3_0 -> listOf(
+                "tmuxInstalled INTEGER",
+                "lastBootstrapAt INTEGER",
+                "pocketshellInstalled INTEGER",
+                "pocketshellLastDetectedAt INTEGER",
+                "usageCommandOverride TEXT",
+                "pathOverride TEXT",
+            )
+        }
+        if (mutation == MalformedV1Mutation.EXTRA_HOST_COLUMN) {
+            definitions += "malformedExtra TEXT"
+        }
+        if (mutation == MalformedV1Mutation.GENERATED_HOST_COLUMN) {
+            // GENERATED is optional SQLite syntax. Omitting the keyword proves
+            // the classifier uses table_xinfo.hidden rather than token matching.
+            definitions += "malformedGenerated TEXT AS (name) STORED"
+        }
+        if (mutation == MalformedV1Mutation.EXTRA_HOST_UNIQUE_CONSTRAINT) {
+            definitions += "UNIQUE(name)"
+        }
+        if (mutation != MalformedV1Mutation.MISSING_HOST_FOREIGN_KEY) {
+            definitions +=
+                "FOREIGN KEY(keyId) REFERENCES ssh_keys(id) ON UPDATE NO ACTION ON DELETE CASCADE"
+        }
+        db.execSQL(
+            """
+            CREATE TABLE hosts (
+                ${definitions.joinToString(",\n                ")}
+            )
+            """.trimIndent(),
+        )
+        if (mutation != MalformedV1Mutation.MISSING_HOST_INDEX) {
+            val indexColumn =
+                if (mutation == MalformedV1Mutation.HOST_INDEX_COLLATION) {
+                    "keyId COLLATE NOCASE DESC"
+                } else {
+                    "keyId"
+                }
+            db.execSQL("CREATE INDEX index_hosts_keyId ON hosts($indexColumn)")
+        }
+    }
+
+    private fun createPortRemappings(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE port_remappings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                hostId INTEGER NOT NULL,
+                remotePort INTEGER NOT NULL,
+                localPort INTEGER NOT NULL,
+                FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX index_port_remappings_hostId ON port_remappings(hostId)")
+        db.execSQL(
+            "CREATE UNIQUE INDEX index_port_remappings_hostId_remotePort " +
+                "ON port_remappings(hostId, remotePort)",
+        )
+    }
+
+    private fun createSessions(db: SQLiteDatabase, mutation: MalformedV1Mutation?) {
+        val tagsColumn = if (mutation == MalformedV1Mutation.MISSING_REQUIRED_COLUMN) {
+            ""
+        } else {
+            ",\n                tags TEXT"
+        }
+        db.execSQL(
+            """
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                hostId INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                lastSeenAt INTEGER NOT NULL$tagsColumn,
+                FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX index_sessions_hostId ON sessions(hostId)")
+        db.execSQL("CREATE UNIQUE INDEX index_sessions_hostId_name ON sessions(hostId, name)")
+    }
+
+    private fun createSnippets(db: SQLiteDatabase, labelNotNull: Boolean) {
+        val labelColumn = if (labelNotNull) "label TEXT NOT NULL" else "label TEXT"
+        db.execSQL(
+            """
+            CREATE TABLE snippets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                hostId INTEGER NOT NULL,
+                $labelColumn,
+                body TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX index_snippets_hostId ON snippets(hostId)")
+    }
+
+    private fun createAgentSessions(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE agent_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                paneRef TEXT NOT NULL,
+                agent TEXT NOT NULL,
+                jsonlPath TEXT,
+                detectedAt INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE UNIQUE INDEX index_agent_sessions_paneRef ON agent_sessions(paneRef)")
+    }
+
+    private fun createPortUsage(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE port_usage (
+                hostId INTEGER NOT NULL,
+                remotePort INTEGER NOT NULL,
+                clickCount INTEGER NOT NULL,
+                totalBytes INTEGER NOT NULL,
+                lastUsedAt INTEGER NOT NULL,
+                PRIMARY KEY(hostId, remotePort),
+                FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX index_port_usage_hostId ON port_usage(hostId)")
+    }
+
+    private fun createProjectRoots(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE project_roots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                hostId INTEGER NOT NULL,
+                label TEXT NOT NULL,
+                path TEXT NOT NULL,
+                createdAt INTEGER NOT NULL,
+                FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX index_project_roots_hostId ON project_roots(hostId)")
+        db.execSQL("CREATE UNIQUE INDEX index_project_roots_hostId_path ON project_roots(hostId, path)")
+    }
+
+    private fun createAiApiCallLog(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE ai_api_call_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                timestampMillis INTEGER NOT NULL,
+                provider TEXT NOT NULL,
+                feature TEXT NOT NULL,
+                inputUnits INTEGER NOT NULL,
+                outputUnits INTEGER NOT NULL,
+                unitCostUsdMillicents INTEGER NOT NULL,
+                computedCostUsdMillicents INTEGER NOT NULL,
+                metadataJson TEXT
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX index_ai_api_call_log_timestampMillis ON ai_api_call_log(timestampMillis)")
+        db.execSQL(
+            "CREATE INDEX index_ai_api_call_log_provider_feature ON ai_api_call_log(provider, feature)",
+        )
+    }
+
+    private fun createPendingTranscriptions(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE pending_transcriptions (
+                id TEXT NOT NULL,
+                audioPath TEXT NOT NULL,
+                recordingTimestampMs INTEGER NOT NULL,
+                destinationContext TEXT NOT NULL,
+                retryCount INTEGER NOT NULL,
+                lastErrorMessage TEXT,
+                audioByteSize INTEGER NOT NULL,
+                createdAtMs INTEGER NOT NULL,
+                PRIMARY KEY(id)
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            "CREATE INDEX index_pending_transcriptions_recordingTimestampMs " +
+                "ON pending_transcriptions(recordingTimestampMs)",
+        )
+    }
+
+    private fun insertWriterBackedSentinels(
+        db: SQLiteDatabase,
+        layout: ShippedV1Layout,
+        mutation: MalformedV1Mutation?,
+    ) {
+        val ids = layout.sentinelIds
+        db.execSQL(
+            """
+            INSERT INTO ssh_keys(id, name, privateKeyPath, hasPassphrase, createdAt)
+            VALUES(${ids.keyId}, '${layout.slug}-key', '/keys/${layout.slug}', 1, ${ids.baseTime})
+            """.trimIndent(),
+        )
+        when (layout) {
+            ShippedV1Layout.V0_2_0 -> db.execSQL(
+                """
+                INSERT INTO hosts(
+                    id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                    scanIntervalSec, enabled, createdAt, lastConnectedAt
+                ) VALUES(
+                    ${ids.hostId}, '${layout.slug}-host', '${layout.slug}.example.com', 2222,
+                    'alexey', ${ids.keyId}, 12000, 1200, 7, 1, ${ids.baseTime + 1}, ${ids.baseTime + 2}
+                )
+                """.trimIndent(),
+            )
+            ShippedV1Layout.V0_2_9 -> db.execSQL(
+                """
+                INSERT INTO hosts(
+                    id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                    scanIntervalSec, enabled, createdAt, lastConnectedAt, tmuxInstalled,
+                    lastBootstrapAt, quseInstalled, quseLastDetectedAt, usageCommandOverride,
+                    pathOverride, pocketshellInstalled
+                ) VALUES(
+                    ${ids.hostId}, '${layout.slug}-host', '${layout.slug}.example.com', 2229,
+                    'alexey', ${ids.keyId}, 12900, 1290, 9, 1, ${ids.baseTime + 1},
+                    ${ids.baseTime + 2}, 1, ${ids.baseTime + 3}, 1, ${ids.baseTime + 4},
+                    'legacy-usage-v029', '/opt/v029/bin', 0
+                )
+                """.trimIndent(),
+            )
+            ShippedV1Layout.V0_3_0 -> db.execSQL(
+                """
+                INSERT INTO hosts(
+                    id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                    scanIntervalSec, enabled, createdAt, lastConnectedAt, tmuxInstalled,
+                    lastBootstrapAt, pocketshellInstalled, pocketshellLastDetectedAt,
+                    usageCommandOverride, pathOverride
+                ) VALUES(
+                    ${ids.hostId}, '${layout.slug}-host', '${layout.slug}.example.com', 2230,
+                    'alexey', ${ids.keyId}, 13000, 1300, 10, 1, ${ids.baseTime + 1},
+                    ${ids.baseTime + 2}, 1, ${ids.baseTime + 3}, 1, ${ids.baseTime + 4},
+                    'legacy-usage-v030', '/opt/v030/bin'
+                )
+                """.trimIndent(),
+            )
+        }
+        db.execSQL(
+            """
+            INSERT INTO port_remappings(id, hostId, remotePort, localPort)
+            VALUES(${ids.baseId + 2}, ${ids.hostId}, ${ids.remotePort}, ${ids.localPort})
+            """.trimIndent(),
+        )
+        db.execSQL(
+            """
+            INSERT INTO snippets(id, hostId, label, body, kind)
+            VALUES(${ids.baseId + 3}, ${ids.hostId}, '${layout.slug}-snippet',
+                   'echo ${layout.slug}-preserved', 'command')
+            """.trimIndent(),
+        )
+
+        if (layout != ShippedV1Layout.V0_2_0) {
+            db.execSQL(
+                """
+                INSERT INTO port_usage(hostId, remotePort, clickCount, totalBytes, lastUsedAt)
+                VALUES(${ids.hostId}, ${ids.remotePort}, 7, 1747, ${ids.baseTime + 5})
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                INSERT INTO project_roots(id, hostId, label, path, createdAt)
+                VALUES(${ids.baseId + 4}, ${ids.hostId}, '${layout.slug}-root',
+                       '/srv/${layout.slug}', ${ids.baseTime + 6})
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                INSERT INTO ai_api_call_log(
+                    id, timestampMillis, provider, feature, inputUnits, outputUnits,
+                    unitCostUsdMillicents, computedCostUsdMillicents, metadataJson
+                ) VALUES(
+                    ${ids.baseId + 5}, ${ids.baseTime + 7}, 'openai', 'whisper',
+                    17, 47, 10, 174, '{"layout":"${layout.slug}"}'
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                """
+                INSERT INTO pending_transcriptions(
+                    id, audioPath, recordingTimestampMs, destinationContext, retryCount,
+                    lastErrorMessage, audioByteSize, createdAtMs
+                ) VALUES(
+                    '${layout.slug}-pending', '/audio/${layout.slug}.wav', ${ids.baseTime + 8},
+                    'composer', 1, 'offline', 1747, ${ids.baseTime + 9}
+                )
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private val BASE_HOST_COLUMNS = listOf(
+        "id",
+        "name",
+        "hostname",
+        "port",
+        "username",
+        "keyId",
+        "maxAutoPort",
+        "skipPortsBelow",
+        "scanIntervalSec",
+        "enabled",
+        "createdAt",
+        "lastConnectedAt",
+    )
+}
+
+internal enum class ShippedV1Layout(
+    val slug: String,
+    val sentinelIds: SentinelIds,
+    val identityHash: String,
+) {
+    V0_2_0(
+        "v020",
+        SentinelIds(baseId = 200, baseTime = 2_000),
+        "4f9cdd46489198fdda4b34e6b682d56d",
+    ),
+    V0_2_9(
+        "v029",
+        SentinelIds(baseId = 290, baseTime = 2_900),
+        "4a479a15dfcab2d576e00c7ce10ac581",
+    ),
+    V0_3_0(
+        "v030",
+        SentinelIds(baseId = 300, baseTime = 3_000),
+        "5c2d470ba861de091b4dad454b282704",
+    ),
+}
+
+internal enum class MalformedV1Mutation {
+    EXTRA_HOST_COLUMN,
+    MISSING_REQUIRED_COLUMN,
+    GENERATED_HOST_COLUMN,
+    HOSTNAME_AFFINITY,
+    HOSTNAME_NULLABILITY,
+    HOSTNAME_CHECK_CONSTRAINT,
+    HOSTNAME_BLOCK_COMMENT_CHECK_CONSTRAINT,
+    HOSTNAME_LINE_COMMENT_CHECK_CONSTRAINT,
+    HOSTNAME_COLLATION,
+    HOST_INDEX_COLLATION,
+    EXTRA_HOST_UNIQUE_CONSTRAINT,
+    MISSING_HOST_AUTOINCREMENT,
+    BLOCK_COMMENT_SPOOFED_HOST_AUTOINCREMENT,
+    LINE_COMMENT_SPOOFED_HOST_AUTOINCREMENT,
+    MISSING_HOST_INDEX,
+    MISSING_HOST_FOREIGN_KEY,
+    NON_EMPTY_SESSIONS,
+    NON_EMPTY_AGENT_SESSIONS,
+    UNEXPECTED_VIEW,
+    UNEXPECTED_TRIGGER,
+}
+
+internal enum class TaggedMetadataMutation {
+    MISSING_ROOM_MASTER_TABLE,
+    EMPTY_ROOM_MASTER_TABLE,
+    WRONG_IDENTITY_HASH,
+    EXTRA_ROOM_MASTER_COLUMN,
+    EXTRA_ROOM_MASTER_ROW,
+}
+
+internal data class SentinelIds(
+    val baseId: Long,
+    val baseTime: Long,
+) {
+    val keyId: Long = baseId
+    val hostId: Long = baseId + 1
+    val remotePort: Int = baseId.toInt() + 4_000
+    val localPort: Int = baseId.toInt() + 14_000
+}

--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -37,7 +37,7 @@ APP_WALKTHROUGH_TRANSPORT_RECOVERY_ATTEMPTS="${APP_WALKTHROUGH_TRANSPORT_RECOVER
 # rendering defect can never be masked into an infinite reboot loop.
 APP_WALKTHROUGH_GL_REBOOT_ATTEMPTS="${APP_WALKTHROUGH_GL_REBOOT_ATTEMPTS:-2}"
 APP_WALKTHROUGH_GL_REBOOT_BOOT_TIMEOUT_SECONDS="${APP_WALKTHROUGH_GL_REBOOT_BOOT_TIMEOUT_SECONDS:-300}"
-ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS="${ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS:-3}"
+LEGACY_V1_DB_MIGRATION_ATTEMPTS="${LEGACY_V1_DB_MIGRATION_ATTEMPTS:-3}"
 CORE_TERMINAL_CONNECTED_ATTEMPTS="${CORE_TERMINAL_CONNECTED_ATTEMPTS:-2}"
 PRE_RELEASE_MANAGE_EMULATOR="${PRE_RELEASE_MANAGE_EMULATOR:-0}"
 PRE_RELEASE_EMULATOR_START_ARGS="${PRE_RELEASE_EMULATOR_START_ARGS:--no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save}"
@@ -110,7 +110,7 @@ Runs the local APK pre-release-confidence gate:
   - compile/unit checks
   - deterministic Docker agent target
   - emulator readiness with explicit Android SDK paths
-  - #261 stale Room DB launch sanity using an explicit cold-reset setup
+  - shipped-v1 + #261 marker Room migration with post-launch data validation
   - focused connected walkthrough tests using an explicit cold-reset package setup
   - debug APK build and data-preserving update install sanity
 
@@ -136,7 +136,7 @@ Environment overrides:
   APP_WALKTHROUGH_TRANSPORT_RECOVERY_ATTEMPTS=3
   APP_WALKTHROUGH_GL_REBOOT_ATTEMPTS=2
   APP_WALKTHROUGH_GL_REBOOT_BOOT_TIMEOUT_SECONDS=300
-  ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS=3
+  LEGACY_V1_DB_MIGRATION_ATTEMPTS=3
   CORE_TERMINAL_CONNECTED_ATTEMPTS=2
   PRE_RELEASE_MANAGE_EMULATOR=0
   PRE_RELEASE_EMULATOR_START_ARGS="-no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot-load -no-snapshot-save"
@@ -167,6 +167,11 @@ fi
 
 source "$ROOT_DIR/scripts/lib/app-version.sh"
 APP_VERSION_NAME="$(pocketshell_app_version_name "$ROOT_DIR")"
+APP_DATABASE_SCHEMA_VERSION="$(
+  sed -nE \
+    's/^const val APP_DATABASE_SCHEMA_VERSION = ([0-9]+)$/\1/p' \
+    "$ROOT_DIR/shared/core-storage/src/main/java/com/pocketshell/core/storage/AppDatabase.kt"
+)"
 export POCKETSHELL_AGENT_FIXTURE_VERSION="$APP_VERSION_NAME"
 
 SUMMARY_PATH="$RUN_DIR/summary.txt"
@@ -181,12 +186,12 @@ FAILURE_LOGCAT_PATH=""
 EMULATOR_SERIAL="unknown"
 APP_WALKTHROUGH_INSTALL_STATUS="not_run"
 FINAL_INSTALL_STATUS="not_run"
-ISSUE_261_STALE_DB_STATUS="not_run"
+LEGACY_V1_DB_MIGRATION_STATUS="not_run"
 # Issue #1314: step 12 (core-terminal burst proof) runs non-fatally so a slow-AVD
 # timing red no longer front-gates the #1302 journey; its captured result is
 # folded into the final verdict after the downstream stages run.
 CONNECTED_TERMINAL_INPUT_STATUS="not_run"
-ISSUE_261_STALE_DB_LOGCAT="$RUN_DIR/issue-261-stale-db-launch-logcat.log"
+LEGACY_V1_DB_MIGRATION_LOGCAT="$RUN_DIR/legacy-v1-db-migration-logcat.log"
 STEP_NAMES=()
 STEP_STATUSES=()
 STEP_LOGS=()
@@ -227,10 +232,10 @@ set_focused_status() {
   local i
   for i in "${!FOCUSED_SELECTORS[@]}"; do
     if [[ "${FOCUSED_SELECTORS[$i]}" == "$selector" ]]; then
-      FOCUSED_STATUSES[$i]="$status"
-      [[ -n "$log_file" ]] && FOCUSED_LOGS[$i]="$log_file"
-      [[ -n "$diagnostics_file" ]] && FOCUSED_DIAGNOSTICS[$i]="$diagnostics_file"
-      [[ -n "$logcat_file" ]] && FOCUSED_LOGCATS[$i]="$logcat_file"
+      FOCUSED_STATUSES[i]="$status"
+      [[ -n "$log_file" ]] && FOCUSED_LOGS[i]="$log_file"
+      [[ -n "$diagnostics_file" ]] && FOCUSED_DIAGNOSTICS[i]="$diagnostics_file"
+      [[ -n "$logcat_file" ]] && FOCUSED_LOGCATS[i]="$logcat_file"
       return 0
     fi
   done
@@ -274,8 +279,8 @@ write_summary() {
     printf 'Connected core-terminal burst proof (step 12, non-fatal — issue #1314): %s\n' "$CONNECTED_TERMINAL_INPUT_STATUS"
     printf 'Focused app cold-reset APK install status: %s\n' "$APP_WALKTHROUGH_INSTALL_STATUS"
     printf 'Final data-preserving update install status: %s\n' "$FINAL_INSTALL_STATUS"
-    printf 'Issue #261 cold-reset stale DB launch status: %s\n' "$ISSUE_261_STALE_DB_STATUS"
-    printf 'Issue #261 stale DB logcat: %s\n' "$ISSUE_261_STALE_DB_LOGCAT"
+    printf 'Legacy v1 database migration status: %s\n' "$LEGACY_V1_DB_MIGRATION_STATUS"
+    printf 'Legacy v1 database migration logcat: %s\n' "$LEGACY_V1_DB_MIGRATION_LOGCAT"
     if [[ "$GATE_RESULT" != "PASS" ]]; then
       printf 'Failing step: %s\n' "${FAILING_STEP:-unknown}"
       printf 'Failure message: %s\n' "${FAILURE_MESSAGE:-unknown}"
@@ -369,7 +374,7 @@ run_step() {
   elapsed_seconds=$((end_seconds - start_seconds))
 
   if [[ "$status" -eq 0 ]]; then
-    STEP_STATUSES[$step_array_index]="passed"
+    STEP_STATUSES[step_array_index]="passed"
     printf 'PASS: %s (%ss)\n' "$name" "$elapsed_seconds"
     case "$name" in
       cold-reset-install-app-walkthrough-apks)
@@ -378,12 +383,12 @@ run_step() {
       update-install-debug-apk)
         FINAL_INSTALL_STATUS="passed"
         ;;
-      cold-reset-issue-261-stale-db-launch)
-        ISSUE_261_STALE_DB_STATUS="passed"
+      migrate-legacy-v1-databases)
+        LEGACY_V1_DB_MIGRATION_STATUS="passed"
         ;;
     esac
   else
-    STEP_STATUSES[$step_array_index]="failed"
+    STEP_STATUSES[step_array_index]="failed"
     FAILING_STEP="$name"
     FAILING_LOG_PATH="$log_file"
     FAILURE_MESSAGE="step '$name' failed with status $status"
@@ -400,9 +405,9 @@ run_step() {
       update-install-debug-apk)
         FINAL_INSTALL_STATUS="failed"
         ;;
-      cold-reset-issue-261-stale-db-launch)
-        ISSUE_261_STALE_DB_STATUS="failed"
-        FAILURE_LOGCAT_PATH="$ISSUE_261_STALE_DB_LOGCAT"
+      migrate-legacy-v1-databases)
+        LEGACY_V1_DB_MIGRATION_STATUS="failed"
+        FAILURE_LOGCAT_PATH="$LEGACY_V1_DB_MIGRATION_LOGCAT"
         ;;
     esac
   fi
@@ -877,13 +882,15 @@ exit 1
 QUIESCE_SCRIPT
 }
 
-cold_reset_issue_261_stale_db_launch_script() {
-  cat <<ISSUE261_SCRIPT
+legacy_v1_database_migration_script() {
+  cat <<LEGACY_V1_SCRIPT
 set -euo pipefail
 
-stale_db_host='$RUN_DIR/issue-261-stale-pocketshell.db'
-stale_db_device='/data/local/tmp/issue-261-stale-pocketshell.db'
-logcat_file='$ISSUE_261_STALE_DB_LOGCAT'
+tagged_db_host='$RUN_DIR/tagged-v030-pocketshell.db'
+marker_db_host='$RUN_DIR/issue-261-marker-pocketshell.db'
+staged_db_device='/data/local/tmp/legacy-v1-pocketshell.db'
+logcat_file='$LEGACY_V1_DB_MIGRATION_LOGCAT'
+expected_schema_version='$APP_DATABASE_SCHEMA_VERSION'
 
 wait_package_manager_idle() {
   '$ADB' shell cmd package wait-for-handler --timeout 60000 >/dev/null 2>&1 || true
@@ -902,7 +909,7 @@ install_or_fallback_uninstall() {
     return 0
   fi
   if printf '%s\n' "\$output" | grep -q 'INSTALL_FAILED_UPDATE_INCOMPATIBLE'; then
-    printf 'COLD-RESET: uninstall fallback for incompatible app package before stale DB setup\n'
+    printf 'LEGACY-V1: uninstall fallback for incompatible app package before migration setup\n'
     '$ADB' uninstall com.pocketshell.app >/dev/null 2>&1 || true
     wait_package_manager_idle
     '$ADB' install -r -d -t '$APK_PATH'
@@ -927,7 +934,7 @@ logcat_has_adb_transport_drop_markers() {
 }
 
 should_retry_launch_attempt() {
-  [ "\$attempt" -lt '$ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS' ] || return 1
+  [ "\$attempt" -lt '$LEGACY_V1_DB_MIGRATION_ATTEMPTS' ] || return 1
   ! logcat_has_app_crash_signature "\$attempt_logcat_file" || return 1
   if [ "\$start_status" -ne 0 ] && {
     adb_output_has_transport_drop_markers "\$start_output" || logcat_has_adb_transport_drop_markers "\$attempt_logcat_file"
@@ -942,117 +949,450 @@ should_retry_launch_attempt() {
   return 1
 }
 
-'$PYTHON3' - "\$stale_db_host" <<'PY'
+'$PYTHON3' - "\$tagged_db_host" "\$marker_db_host" <<'PY'
 import sqlite3
 import sys
 from pathlib import Path
 
-database_path = sys.argv[1]
-if Path(database_path).exists():
-    Path(database_path).unlink()
-connection = sqlite3.connect(database_path)
+tagged_path = Path(sys.argv[1])
+marker_path = Path(sys.argv[2])
+for path in (tagged_path, marker_path):
+    path.unlink(missing_ok=True)
+
+tagged = sqlite3.connect(tagged_path)
 try:
-    connection.execute("CREATE TABLE room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT)")
-    connection.execute(
+    tagged.executescript(
+        """
+        PRAGMA journal_mode=WAL;
+        PRAGMA foreign_keys=OFF;
+        CREATE TABLE room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT);
+        CREATE TABLE ssh_keys (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            name TEXT NOT NULL,
+            privateKeyPath TEXT NOT NULL,
+            hasPassphrase INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL
+        );
+        CREATE TABLE hosts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            name TEXT NOT NULL,
+            hostname TEXT NOT NULL,
+            port INTEGER NOT NULL,
+            username TEXT NOT NULL,
+            keyId INTEGER NOT NULL,
+            maxAutoPort INTEGER NOT NULL,
+            skipPortsBelow INTEGER NOT NULL,
+            scanIntervalSec INTEGER NOT NULL,
+            enabled INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL,
+            lastConnectedAt INTEGER,
+            tmuxInstalled INTEGER,
+            lastBootstrapAt INTEGER,
+            pocketshellInstalled INTEGER,
+            pocketshellLastDetectedAt INTEGER,
+            usageCommandOverride TEXT,
+            pathOverride TEXT,
+            FOREIGN KEY(keyId) REFERENCES ssh_keys(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        );
+        CREATE INDEX index_hosts_keyId ON hosts(keyId);
+        CREATE TABLE port_remappings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            remotePort INTEGER NOT NULL,
+            localPort INTEGER NOT NULL,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        );
+        CREATE INDEX index_port_remappings_hostId ON port_remappings(hostId);
+        CREATE UNIQUE INDEX index_port_remappings_hostId_remotePort
+            ON port_remappings(hostId, remotePort);
+        CREATE TABLE port_usage (
+            hostId INTEGER NOT NULL,
+            remotePort INTEGER NOT NULL,
+            clickCount INTEGER NOT NULL,
+            totalBytes INTEGER NOT NULL,
+            lastUsedAt INTEGER NOT NULL,
+            PRIMARY KEY(hostId, remotePort),
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        );
+        CREATE INDEX index_port_usage_hostId ON port_usage(hostId);
+        CREATE TABLE project_roots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            label TEXT NOT NULL,
+            path TEXT NOT NULL,
+            createdAt INTEGER NOT NULL,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        );
+        CREATE INDEX index_project_roots_hostId ON project_roots(hostId);
+        CREATE UNIQUE INDEX index_project_roots_hostId_path ON project_roots(hostId, path);
+        CREATE TABLE sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            lastSeenAt INTEGER NOT NULL,
+            tags TEXT,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        );
+        CREATE INDEX index_sessions_hostId ON sessions(hostId);
+        CREATE UNIQUE INDEX index_sessions_hostId_name ON sessions(hostId, name);
+        CREATE TABLE snippets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            label TEXT,
+            body TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        );
+        CREATE INDEX index_snippets_hostId ON snippets(hostId);
+        CREATE TABLE agent_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            paneRef TEXT NOT NULL,
+            agent TEXT NOT NULL,
+            jsonlPath TEXT,
+            detectedAt INTEGER NOT NULL
+        );
+        CREATE UNIQUE INDEX index_agent_sessions_paneRef ON agent_sessions(paneRef);
+        CREATE TABLE ai_api_call_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            timestampMillis INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            feature TEXT NOT NULL,
+            inputUnits INTEGER NOT NULL,
+            outputUnits INTEGER NOT NULL,
+            unitCostUsdMillicents INTEGER NOT NULL,
+            computedCostUsdMillicents INTEGER NOT NULL,
+            metadataJson TEXT
+        );
+        CREATE INDEX index_ai_api_call_log_timestampMillis ON ai_api_call_log(timestampMillis);
+        CREATE INDEX index_ai_api_call_log_provider_feature ON ai_api_call_log(provider, feature);
+        CREATE TABLE pending_transcriptions (
+            id TEXT NOT NULL,
+            audioPath TEXT NOT NULL,
+            recordingTimestampMs INTEGER NOT NULL,
+            destinationContext TEXT NOT NULL,
+            retryCount INTEGER NOT NULL,
+            lastErrorMessage TEXT,
+            audioByteSize INTEGER NOT NULL,
+            createdAtMs INTEGER NOT NULL,
+            PRIMARY KEY(id)
+        );
+        CREATE INDEX index_pending_transcriptions_recordingTimestampMs
+            ON pending_transcriptions(recordingTimestampMs);
+
+        INSERT INTO room_master_table(id, identity_hash)
+            VALUES(42, '5c2d470ba861de091b4dad454b282704');
+        INSERT INTO ssh_keys(id, name, privateKeyPath, hasPassphrase, createdAt)
+            VALUES(300, 'gate-v030-key', '/keys/gate-v030', 1, 3000);
+        INSERT INTO hosts(
+            id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+            scanIntervalSec, enabled, createdAt, lastConnectedAt, tmuxInstalled,
+            lastBootstrapAt, pocketshellInstalled, pocketshellLastDetectedAt,
+            usageCommandOverride, pathOverride
+        ) VALUES(
+            301, 'gate-v030-host', 'v030.example.com', 2230, 'alexey', 300,
+            13000, 1300, 10, 1, 3001, 3002, 1, 3003, 1, 3004,
+            'gate-usage-v030', '/opt/gate-v030/bin'
+        );
+        INSERT INTO port_remappings(id, hostId, remotePort, localPort)
+            VALUES(302, 301, 4300, 14300);
+        INSERT INTO port_usage(hostId, remotePort, clickCount, totalBytes, lastUsedAt)
+            VALUES(301, 4300, 7, 1747, 3005);
+        INSERT INTO project_roots(id, hostId, label, path, createdAt)
+            VALUES(304, 301, 'gate-root', '/srv/gate-v030', 3006);
+        INSERT INTO snippets(id, hostId, label, body, kind)
+            VALUES(303, 301, 'gate-snippet', 'echo gate-v030-preserved', 'command');
+        INSERT INTO ai_api_call_log(
+            id, timestampMillis, provider, feature, inputUnits, outputUnits,
+            unitCostUsdMillicents, computedCostUsdMillicents, metadataJson
+        ) VALUES(305, 3007, 'openai', 'whisper', 17, 47, 10, 174, '{"layout":"v030"}');
+        INSERT INTO pending_transcriptions(
+            id, audioPath, recordingTimestampMs, destinationContext, retryCount,
+            lastErrorMessage, audioByteSize, createdAtMs
+        ) VALUES(
+            'gate-v030-pending', '/audio/gate-v030.wav', 3008,
+            'composer', 1, 'offline', 1747, 3009
+        );
+        PRAGMA user_version = 1;
+        """
+    )
+    for stub_table in ("sessions", "agent_sessions"):
+        if tagged.execute(f"SELECT COUNT(*) FROM {stub_table}").fetchone()[0] != 0:
+            raise SystemExit(f"tagged-v030 fixture: {stub_table} must be empty")
+    room_metadata = tagged.execute(
+        "SELECT id, identity_hash FROM room_master_table ORDER BY id"
+    ).fetchall()
+    if room_metadata != [(42, "5c2d470ba861de091b4dad454b282704")]:
+        raise SystemExit(
+            f"tagged-v030 fixture: unexpected Room metadata {room_metadata!r}"
+        )
+    tagged.commit()
+finally:
+    tagged.close()
+
+marker = sqlite3.connect(marker_path)
+try:
+    if marker.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() != "wal":
+        raise SystemExit("issue-261 marker fixture failed to enter WAL mode")
+    marker.execute("CREATE TABLE room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT)")
+    marker.execute(
         "INSERT INTO room_master_table (id, identity_hash) VALUES(42, ?)",
         ("4a479a15dfcab2d576e00c7ce10ac581",),
     )
-    connection.execute("CREATE TABLE stale_issue_261_marker (id INTEGER PRIMARY KEY)")
-    connection.execute("PRAGMA user_version = 1")
-    connection.commit()
+    marker.execute("CREATE TABLE stale_issue_261_marker (id INTEGER PRIMARY KEY)")
+    if marker.execute("SELECT COUNT(*) FROM stale_issue_261_marker").fetchone()[0] != 0:
+        raise SystemExit("issue-261 marker fixture must be data-free")
+    marker.execute("PRAGMA user_version = 1")
+    marker.commit()
+finally:
+    marker.close()
+PY
+
+rm -f "\$logcat_file"
+
+run_migration_scenario() {
+  scenario="\$1"
+  source_db="\$2"
+  migrated_db_dir_host='$RUN_DIR/migrated-'"\$scenario"'-database'
+  migrated_db_host="\$migrated_db_dir_host/pocketshell.db"
+
+  '$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
+  install_or_fallback_uninstall
+  printf 'LEGACY-V1: clearing app data before injecting %s fixture\n' "\$scenario"
+  '$ADB' shell pm clear com.pocketshell.app
+  wait_package_manager_idle
+  '$ADB' push "\$source_db" "\$staged_db_device"
+  '$ADB' shell run-as com.pocketshell.app sh -c "'mkdir -p databases && cp \$staged_db_device databases/pocketshell.db && chmod 600 databases/pocketshell.db && rm -f databases/pocketshell.db-wal databases/pocketshell.db-shm databases/pocketshell.db-journal'"
+  '$ADB' shell rm -f "\$staged_db_device" >/dev/null 2>&1 || true
+
+  for attempt in \$(seq 1 '$LEGACY_V1_DB_MIGRATION_ATTEMPTS'); do
+    attempt_logcat_file='$RUN_DIR/legacy-v1-'"\$scenario"'-attempt'"\$attempt"'.log'
+    rm -f "\$attempt_logcat_file"
+    '$ADB' logcat -c || true
+    '$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
+
+    set +e
+    start_output=\$('$ADB' shell am start -W -n com.pocketshell.app/.MainActivity 2>&1)
+    start_status=\$?
+    set -e
+    printf '%s\n' "\$start_output"
+
+    if [ "\$start_status" -eq 0 ]; then
+      sleep 5
+    else
+      sleep 2
+    fi
+
+    set +e
+    pid_output=\$('$ADB' shell pidof com.pocketshell.app 2>&1)
+    pid_status=\$?
+    set -e
+    pid=""
+    if [ "\$pid_status" -eq 0 ]; then
+      pid=\$(printf '%s\n' "\$pid_output" | tr -d '\r' | awk '/^[[:space:]]*[0-9]+[[:space:]]*$/ { print \$1; exit }')
+    fi
+    '$ADB' logcat -d -v time -t 5000 > "\$attempt_logcat_file" 2>&1 || true
+    {
+      printf '\n===== %s attempt %s =====\n' "\$scenario" "\$attempt"
+      cat "\$attempt_logcat_file"
+    } >> "\$logcat_file"
+
+    if logcat_has_app_crash_signature "\$attempt_logcat_file"; then
+      printf 'Crash signature found after launching the %s legacy-v1 fixture.\n' "\$scenario" >&2
+      grep -Ei -C 40 'Room cannot verify|Expected identity hash|AndroidRuntime|FATAL EXCEPTION|com[.]pocketshell' "\$attempt_logcat_file" >&2 || true
+      exit 1
+    fi
+
+    if [ "\$start_status" -ne 0 ]; then
+      if should_retry_launch_attempt; then
+        printf 'Legacy-v1 %s launch was interrupted by adb transport on attempt %s; retrying.\n' "\$scenario" "\$attempt" >&2
+        '$ADB' reconnect >/dev/null 2>&1 || true
+        '$ADB' wait-for-device >/dev/null 2>&1 || true
+        sleep 2
+        continue
+      fi
+      printf 'Launching PocketShell with the %s legacy-v1 fixture failed with status %s.\n' "\$scenario" "\$start_status" >&2
+      printf '%s\n' "\$start_output" >&2
+      exit "\$start_status"
+    fi
+
+    if [ -z "\$pid" ]; then
+      if should_retry_launch_attempt; then
+        printf 'Legacy-v1 %s pid check was interrupted by adb transport on attempt %s; retrying.\n' "\$scenario" "\$attempt" >&2
+        '$ADB' reconnect >/dev/null 2>&1 || true
+        '$ADB' wait-for-device >/dev/null 2>&1 || true
+        sleep 2
+        continue
+      fi
+      printf 'PocketShell process was not alive after the %s legacy-v1 migration.\n' "\$scenario" >&2
+      exit 1
+    fi
+
+    break
+  done
+
+  '$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
+  '$ADB' shell sync >/dev/null 2>&1 || true
+  mkdir -p "\$migrated_db_dir_host"
+  rm -f \
+    "\$migrated_db_dir_host/pocketshell.db" \
+    "\$migrated_db_dir_host/pocketshell.db-wal" \
+    "\$migrated_db_dir_host/pocketshell.db-shm"
+  for suffix in '' '-wal' '-shm'; do
+    pulled_file="\$migrated_db_dir_host/pocketshell.db\$suffix"
+    set +e
+    '$ADB' exec-out run-as com.pocketshell.app \
+      cat "databases/pocketshell.db\$suffix" > "\$pulled_file" 2>/dev/null
+    pull_status=\$?
+    set -e
+    if [ -z "\$suffix" ]; then
+      if [ "\$pull_status" -ne 0 ] || [ ! -s "\$pulled_file" ]; then
+        printf 'Migrated database pull was empty for %s.\n' "\$scenario" >&2
+        exit 1
+      fi
+    elif [ "\$pull_status" -ne 0 ] || [ ! -s "\$pulled_file" ]; then
+      rm -f "\$pulled_file"
+    fi
+  done
+  if [ ! -s "\$migrated_db_host" ]; then
+    printf 'Migrated database pull was empty for %s.\n' "\$scenario" >&2
+    exit 1
+  fi
+  printf 'LEGACY-V1: pulled authoritative stopped-app SQLite bundle for %s:' "\$scenario"
+  for bundle_file in "\$migrated_db_dir_host"/pocketshell.db*; do
+    printf ' %s' "\$(basename "\$bundle_file")"
+  done
+  printf '\n'
+
+  '$PYTHON3' - "\$migrated_db_host" "\$scenario" "\$expected_schema_version" <<'PY'
+import sqlite3
+import sys
+
+database_path, scenario, expected_version = sys.argv[1], sys.argv[2], int(sys.argv[3])
+connection = sqlite3.connect(f"file:{database_path}?mode=ro", uri=True)
+try:
+    version = connection.execute("PRAGMA user_version").fetchone()[0]
+    if version != expected_version:
+        raise SystemExit(f"{scenario}: expected schema v{expected_version}, found v{version}")
+    tables = {
+        row[0]
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    if "sessions" in tables or "agent_sessions" in tables:
+        raise SystemExit(f"{scenario}: v17 session stubs were not removed")
+    if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+        raise SystemExit(f"{scenario}: foreign-key validation failed")
+
+    if scenario == "tagged-v030":
+        expected = [
+            (
+                """
+                SELECT id, name, privateKeyPath, hasPassphrase, createdAt, fingerprint
+                FROM ssh_keys WHERE id = 300
+                """,
+                (300, "gate-v030-key", "/keys/gate-v030", 1, 3000, ""),
+            ),
+            (
+                """
+                SELECT id, name, hostname, port, username, keyId, maxAutoPort,
+                       skipPortsBelow, scanIntervalSec, enabled, createdAt,
+                       lastConnectedAt, tmuxInstalled, lastBootstrapAt,
+                       pocketshellInstalled, pocketshellLastDetectedAt,
+                       pocketshellCliVersion, pocketshellExpectedCliVersion,
+                       pocketshellVersionCompatible, pocketshellDaemonRunning,
+                       pocketshellDaemonEnabled, usageCommandOverride
+                FROM hosts WHERE id = 301
+                """,
+                (
+                    301, "gate-v030-host", "v030.example.com", 2230, "alexey", 300,
+                    13000, 1300, 10, 1, 3001, 3002, 1, 3003, 1, 3004,
+                    None, None, None, None, None, "gate-usage-v030",
+                ),
+            ),
+            (
+                "SELECT id, hostId, remotePort, localPort FROM port_remappings WHERE id = 302",
+                (302, 301, 4300, 14300),
+            ),
+            (
+                "SELECT id, hostId, label, body, kind FROM snippets WHERE id = 303",
+                (303, 301, "gate-snippet", "echo gate-v030-preserved", "command"),
+            ),
+            (
+                "SELECT id, hostId, label, path, createdAt FROM project_roots WHERE id = 304",
+                (304, 301, "gate-root", "/srv/gate-v030", 3006),
+            ),
+            (
+                """
+                SELECT id, timestampMillis, provider, feature, inputUnits, outputUnits,
+                       unitCostUsdMillicents, computedCostUsdMillicents, metadataJson
+                FROM ai_api_call_log WHERE id = 305
+                """,
+                (305, 3007, "openai", "whisper", 17, 47, 10, 174, '{"layout":"v030"}'),
+            ),
+            (
+                """
+                SELECT hostId, remotePort, clickCount, totalBytes, lastUsedAt
+                FROM port_usage WHERE hostId = 301 AND remotePort = 4300
+                """,
+                (301, 4300, 7, 1747, 3005),
+            ),
+            (
+                """
+                SELECT id, audioPath, recordingTimestampMs, destinationContext,
+                       retryCount, lastErrorMessage, audioByteSize, createdAtMs
+                FROM pending_transcriptions WHERE id = 'gate-v030-pending'
+                """,
+                (
+                    "gate-v030-pending", "/audio/gate-v030.wav", 3008,
+                    "composer", 1, "offline", 1747, 3009,
+                ),
+            ),
+        ]
+        for query, wanted in expected:
+            row = connection.execute(query).fetchone()
+            if row != wanted:
+                raise SystemExit(
+                    f"{scenario}: sentinel mismatch for {query!r}; expected {wanted!r}, got {row!r}"
+                )
+        host_columns = {
+            row[1] for row in connection.execute("PRAGMA table_info(hosts)")
+        }
+        if "pathOverride" in host_columns:
+            raise SystemExit(f"{scenario}: dropped pathOverride column unexpectedly survived")
+        for table_name in (
+            "ssh_keys",
+            "hosts",
+            "port_remappings",
+            "snippets",
+            "project_roots",
+            "ai_api_call_log",
+            "port_usage",
+            "pending_transcriptions",
+        ):
+            count = connection.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
+            if count != 1:
+                raise SystemExit(
+                    f"{scenario}: expected exactly one writer-backed sentinel in "
+                    f"{table_name}, found {count}"
+                )
+    elif scenario == "issue-261-marker":
+        if "stale_issue_261_marker" in tables:
+            raise SystemExit(f"{scenario}: legacy marker still exists after migration")
+        if "hosts" not in tables:
+            raise SystemExit(f"{scenario}: current hosts table was not created")
+    else:
+        raise SystemExit(f"unknown validation scenario: {scenario}")
 finally:
     connection.close()
 PY
 
-'$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
-install_or_fallback_uninstall
-printf 'COLD-RESET: clearing app data before injecting stale Room DB\n'
-'$ADB' shell pm clear com.pocketshell.app
-wait_package_manager_idle
-'$ADB' push "\$stale_db_host" "\$stale_db_device"
-'$ADB' shell run-as com.pocketshell.app sh -c "'mkdir -p databases && cp \$stale_db_device databases/pocketshell.db && chmod 600 databases/pocketshell.db && rm -f databases/pocketshell.db-wal databases/pocketshell.db-shm databases/pocketshell.db-journal'"
-'$ADB' shell rm -f "\$stale_db_device" >/dev/null 2>&1 || true
+  printf 'LEGACY-V1: %s migrated to schema v%s with post-launch data validation; pid was %s\n' \
+    "\$scenario" "\$expected_schema_version" "\$pid"
+}
 
-for attempt in \$(seq 1 '$ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS'); do
-  attempt_logcat_file="\$logcat_file"
-  if [ "\$attempt" -lt '$ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS' ]; then
-    attempt_logcat_file="\$logcat_file.attempt\$attempt"
-  fi
-  rm -f "\$attempt_logcat_file"
-  '$ADB' logcat -c || true
-  '$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
-
-  set +e
-  start_output=\$('$ADB' shell am start -W -n com.pocketshell.app/.MainActivity 2>&1)
-  start_status=\$?
-  set -e
-  printf '%s\n' "\$start_output"
-
-  if [ "\$start_status" -eq 0 ]; then
-    sleep 5
-  else
-    sleep 2
-  fi
-
-  set +e
-  pid_output=\$('$ADB' shell pidof com.pocketshell.app 2>&1)
-  pid_status=\$?
-  set -e
-  pid=""
-  if [ "\$pid_status" -eq 0 ]; then
-    pid=\$(printf '%s\n' "\$pid_output" | tr -d '\r' | awk '/^[[:space:]]*[0-9]+[[:space:]]*$/ { print \$1; exit }')
-  fi
-  '$ADB' logcat -d -v time -t 5000 > "\$attempt_logcat_file" 2>&1 || true
-
-  if logcat_has_app_crash_signature "\$attempt_logcat_file"; then
-    cp "\$attempt_logcat_file" "\$logcat_file" 2>/dev/null || true
-    printf 'Crash signature found after launching with the #261 stale Room DB.\n' >&2
-    grep -Ei -C 40 'Room cannot verify|Expected identity hash|AndroidRuntime|FATAL EXCEPTION|com[.]pocketshell' "\$logcat_file" >&2 || true
-    exit 1
-  fi
-
-  if [ "\$start_status" -ne 0 ]; then
-    if should_retry_launch_attempt; then
-      printf 'Issue #261 stale DB launch was interrupted by adb transport on attempt %s; retrying.\n' "\$attempt" >&2
-      '$ADB' reconnect >/dev/null 2>&1 || true
-      '$ADB' wait-for-device >/dev/null 2>&1 || true
-      sleep 2
-      continue
-    fi
-    cp "\$attempt_logcat_file" "\$logcat_file" 2>/dev/null || true
-    printf 'Launching PocketShell with the #261 stale Room DB failed with status %s.\n' "\$start_status" >&2
-    printf '%s\n' "\$start_output" >&2
-    grep -Ei -C 40 'Room cannot verify|Expected identity hash|AndroidRuntime|FATAL EXCEPTION|com[.]pocketshell|adbd|connection terminated|offline|read failed' "\$logcat_file" >&2 || true
-    exit "\$start_status"
-  fi
-
-  if [ -z "\$pid" ]; then
-    if should_retry_launch_attempt; then
-      printf 'Issue #261 stale DB pid check was interrupted by adb transport on attempt %s; retrying.\n' "\$attempt" >&2
-      '$ADB' reconnect >/dev/null 2>&1 || true
-      '$ADB' wait-for-device >/dev/null 2>&1 || true
-      sleep 2
-      continue
-    fi
-    cp "\$attempt_logcat_file" "\$logcat_file" 2>/dev/null || true
-    printf 'PocketShell process was not alive after launching with the #261 stale Room DB.\n' >&2
-    if [ "\$pid_status" -ne 0 ]; then
-      printf '%s\n' "\$pid_output" >&2
-    fi
-    grep -Ei -C 40 'Room cannot verify|Expected identity hash|AndroidRuntime|FATAL EXCEPTION|com[.]pocketshell|adbd|connection terminated|offline|read failed' "\$logcat_file" >&2 || true
-    exit 1
-  fi
-
-  if [ "\$attempt_logcat_file" != "\$logcat_file" ]; then
-    cp "\$attempt_logcat_file" "\$logcat_file"
-  fi
-  break
-done
-
-'$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
-printf 'COLD-RESET: issue #261 stale Room DB launch survived with pid %s\n' "\$pid"
-printf 'Logcat artifact: %s\n' "\$logcat_file"
-ISSUE261_SCRIPT
+run_migration_scenario "tagged-v030" "\$tagged_db_host"
+run_migration_scenario "issue-261-marker" "\$marker_db_host"
+printf 'Legacy-v1 migration logcat artifact: %s\n' "\$logcat_file"
+LEGACY_V1_SCRIPT
 }
 
 safe_step_name() {
@@ -1313,20 +1653,24 @@ printf 'AVD: %s\n' "$AVD_NAME"
 printf 'App versionName: %s\n' "$APP_VERSION_NAME"
 printf 'Gradle user home: %s\n' "$GRADLE_USER_HOME"
 printf 'Gradle flags: %s\n' "$GRADLE_FLAGS"
+read -r -a GRADLE_ARGS <<< "$GRADLE_FLAGS"
 printf 'Manage emulator during readiness: %s\n' "$PRE_RELEASE_MANAGE_EMULATOR"
 
 require_executable "$ADB" "adb"
 require_executable "$EMULATOR" "emulator"
 require_command_or_executable "$PYTHON3" "python3"
 
+if ! [[ "$APP_DATABASE_SCHEMA_VERSION" =~ ^[1-9][0-9]*$ ]]; then
+  fail "Could not read APP_DATABASE_SCHEMA_VERSION from AppDatabase.kt"
+fi
 if ! [[ "$APP_WALKTHROUGH_INSTRUMENTATION_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
   fail "APP_WALKTHROUGH_INSTRUMENTATION_ATTEMPTS must be a positive integer"
 fi
 if ! [[ "$APP_WALKTHROUGH_TRANSPORT_RECOVERY_ATTEMPTS" =~ ^[0-9]+$ ]]; then
   fail "APP_WALKTHROUGH_TRANSPORT_RECOVERY_ATTEMPTS must be a non-negative integer"
 fi
-if ! [[ "$ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
-  fail "ISSUE_261_STALE_DB_LAUNCH_ATTEMPTS must be a positive integer"
+if ! [[ "$LEGACY_V1_DB_MIGRATION_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  fail "LEGACY_V1_DB_MIGRATION_ATTEMPTS must be a positive integer"
 fi
 if ! [[ "$APP_WALKTHROUGH_GL_REBOOT_ATTEMPTS" =~ ^[0-9]+$ ]]; then
   fail "APP_WALKTHROUGH_GL_REBOOT_ATTEMPTS must be a non-negative integer"
@@ -1411,12 +1755,12 @@ fi
 
 run_step "build-app-test-apks" \
   "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-build-app-test-apks" -- \
-  ./gradlew $GRADLE_FLAGS :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
+  ./gradlew "${GRADLE_ARGS[@]}" :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 [[ -f "$APK_PATH" ]] || fail "APK artifact was not created at $APK_PATH"
 [[ -f "$TEST_APK_PATH" ]] || fail "Android test APK artifact was not created at $TEST_APK_PATH"
 
-ISSUE_261_STALE_DB_STATUS="running"
-run_bash_step "cold-reset-issue-261-stale-db-launch" "$(cold_reset_issue_261_stale_db_launch_script)"
+LEGACY_V1_DB_MIGRATION_STATUS="running"
+run_bash_step "migrate-legacy-v1-databases" "$(legacy_v1_database_migration_script)"
 
 run_bash_step "cold-reset-app-packages-before-app-walkthrough" "$(cold_reset_app_packages_script)"
 run_bash_step "cold-reset-install-app-walkthrough-apks" "$(cold_reset_install_app_walkthrough_apks_script)"
@@ -1446,7 +1790,7 @@ done
 
 run_step "build-debug-apk" \
   "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-build-debug-apk" -- \
-  ./gradlew $GRADLE_FLAGS :app:assembleDebug --stacktrace
+  ./gradlew "${GRADLE_ARGS[@]}" :app:assembleDebug --stacktrace
 [[ -f "$APK_PATH" ]] || fail "APK artifact was not created at $APK_PATH"
 
 run_step "update-install-debug-apk" "$ROOT_DIR/scripts/install-update-apk.sh" "$APK_PATH"

--- a/shared/core-storage/src/main/java/com/pocketshell/core/storage/AppDatabase.kt
+++ b/shared/core-storage/src/main/java/com/pocketshell/core/storage/AppDatabase.kt
@@ -26,15 +26,6 @@ import com.pocketshell.core.storage.entity.SshKeyEntity
 const val APP_DATABASE_SCHEMA_VERSION = 17
 
 /**
- * Issue #261 left a deliberately unsupported pre-migration v1 shape in the
- * release gate: it only contains Room metadata and a stale marker table, not
- * PocketShell user-data tables. Production may destructively rebuild only
- * from these start versions; supported real schemas must be represented in
- * [APP_DATABASE_MIGRATIONS] instead.
- */
-val APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS: IntArray = intArrayOf(1)
-
-/**
  * The PocketShell Room database.
  *
  * Normal APK updates must preserve user data. Any entity-schema change MUST
@@ -275,6 +266,7 @@ val MIGRATION_16_17: Migration = object : Migration(16, 17) {
 }
 
 val APP_DATABASE_MIGRATIONS: Array<Migration> = arrayOf(
+    MIGRATION_1_8,
     MIGRATION_2_8,
     MIGRATION_3_8,
     MIGRATION_4_8,
@@ -299,8 +291,11 @@ private fun legacyMigrationToVersionEight(startVersion: Int): Migration =
         }
     }
 
-private fun normalizeLegacySchemaToVersionEight(db: SupportSQLiteDatabase) {
-    rebuildHostsForVersionEight(db)
+internal fun normalizeLegacySchemaToVersionEight(
+    db: SupportSQLiteDatabase,
+    forcePocketshellLastDetectedAtNull: Boolean = false,
+) {
+    rebuildHostsForVersionEight(db, forcePocketshellLastDetectedAtNull)
     createProjectRootsTableIfMissing(db)
     createAiApiCallLogTableIfMissing(db)
     createPendingTranscriptionsTableIfMissing(db)
@@ -316,19 +311,28 @@ private fun normalizeLegacyVersionNineToVersionTen(db: SupportSQLiteDatabase) {
     createPortUsageTableIfMissing(db)
 }
 
-private fun rebuildHostsForVersionEight(db: SupportSQLiteDatabase) {
+private fun rebuildHostsForVersionEight(
+    db: SupportSQLiteDatabase,
+    forcePocketshellLastDetectedAtNull: Boolean,
+) {
+    val tmuxInstalled = db.firstExistingColumnExpression("hosts", "tmuxInstalled")
+    val lastBootstrapAt = db.firstExistingColumnExpression("hosts", "lastBootstrapAt")
     val usageInstalled = db.firstExistingColumnExpression(
         "hosts",
         "pocketshellInstalled",
         "quseInstalled",
         "heruInstalled",
     )
-    val usageDetectedAt = db.firstExistingColumnExpression(
-        "hosts",
-        "pocketshellLastDetectedAt",
-        "quseLastDetectedAt",
-        "heruLastDetectedAt",
-    )
+    val usageDetectedAt = if (forcePocketshellLastDetectedAtNull) {
+        "NULL"
+    } else {
+        db.firstExistingColumnExpression(
+            "hosts",
+            "pocketshellLastDetectedAt",
+            "quseLastDetectedAt",
+            "heruLastDetectedAt",
+        )
+    }
     val usageCommandOverride = db.firstExistingColumnExpression("hosts", "usageCommandOverride")
     val pathOverride = db.firstExistingColumnExpression("hosts", "pathOverride")
 
@@ -368,8 +372,8 @@ private fun rebuildHostsForVersionEight(db: SupportSQLiteDatabase) {
         )
         SELECT
             id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
-            scanIntervalSec, enabled, createdAt, lastConnectedAt, tmuxInstalled,
-            lastBootstrapAt, $usageInstalled, $usageDetectedAt,
+            scanIntervalSec, enabled, createdAt, lastConnectedAt, $tmuxInstalled,
+            $lastBootstrapAt, $usageInstalled, $usageDetectedAt,
             $usageCommandOverride, $pathOverride
         FROM hosts
         """.trimIndent(),

--- a/shared/core-storage/src/main/java/com/pocketshell/core/storage/LegacyVersionOneMigration.kt
+++ b/shared/core-storage/src/main/java/com/pocketshell/core/storage/LegacyVersionOneMigration.kt
@@ -1,0 +1,824 @@
+package com.pocketshell.core.storage
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Recovers the three distinct application-schema layouts that shipped with
+ * `PRAGMA user_version = 1`, plus the exact data-free issue-261 marker
+ * database. Classification is deliberately read-only and exact: an unknown v1
+ * database fails closed before any DDL can mutate user data.
+ */
+val MIGRATION_1_8: Migration = object : Migration(1, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        when (db.classifyVersionOneSchema()) {
+            VersionOneSchema.V0_2_0 -> normalizeLegacySchemaToVersionEight(db)
+            VersionOneSchema.V0_2_9 -> normalizeLegacySchemaToVersionEight(
+                db,
+                forcePocketshellLastDetectedAtNull = true,
+            )
+            VersionOneSchema.V0_3_0 -> normalizeLegacySchemaToVersionEight(db)
+            VersionOneSchema.ISSUE_261_MARKER -> replaceIssue261MarkerWithVersionEightSchema(db)
+            null -> throw IllegalStateException(
+                "Unsupported PocketShell schema v1 layout; refusing to modify or delete the database",
+            )
+        }
+    }
+}
+
+private enum class VersionOneSchema {
+    V0_2_0,
+    V0_2_9,
+    V0_3_0,
+    ISSUE_261_MARKER,
+}
+
+private data class VersionOneColumn(
+    val name: String,
+    val type: String,
+    val notNull: Boolean,
+    val primaryKeyPosition: Int,
+    val defaultValue: String?,
+    val hidden: Int,
+)
+
+private data class VersionOneIndexColumn(
+    val name: String?,
+    val descending: Boolean,
+    val collation: String,
+)
+
+private data class VersionOneIndex(
+    val name: String?,
+    val unique: Boolean,
+    val columns: List<VersionOneIndexColumn>,
+    val origin: String,
+    val partial: Boolean,
+)
+
+private data class VersionOneForeignKey(
+    val referencedTable: String,
+    val fromColumn: String,
+    val toColumn: String,
+    val onUpdate: String,
+    val onDelete: String,
+    val match: String,
+)
+
+private data class VersionOneTable(
+    val columns: List<VersionOneColumn>,
+    val indices: List<VersionOneIndex> = emptyList(),
+    val foreignKeys: List<VersionOneForeignKey> = emptyList(),
+    val autoIncrement: Boolean = false,
+)
+
+private val VERSION_ONE_INDEX_COMPARATOR =
+    compareBy<VersionOneIndex>(
+        { it.name ?: "" },
+        { it.origin },
+        { it.unique },
+        { it.partial },
+        {
+            it.columns.joinToString("\u0000") { column ->
+                "${column.name}\u0001${column.descending}\u0001${column.collation}"
+            }
+        },
+    )
+
+private fun SupportSQLiteDatabase.classifyVersionOneSchema(): VersionOneSchema? {
+    // Keep every classifier read above the first possible DDL in MIGRATION_1_8.
+    if (hasUnexpectedVersionOneObjects()) return null
+    if (hasVersionOneSqlComments()) return null
+    if (hasUnsupportedVersionOneTableSemantics()) return null
+    val actual = readVersionOneApplicationSchema()
+    return when (actual) {
+        VERSION_ONE_V0_2_0_SCHEMA ->
+            if (
+                hasExactRoomMetadata(V0_2_0_IDENTITY_HASH) &&
+                hasEmptyHistoricalStubTables()
+            ) {
+                VersionOneSchema.V0_2_0
+            } else {
+                null
+            }
+        VERSION_ONE_V0_2_9_SCHEMA ->
+            if (
+                hasExactRoomMetadata(V0_2_9_IDENTITY_HASH) &&
+                hasEmptyHistoricalStubTables()
+            ) {
+                VersionOneSchema.V0_2_9
+            } else {
+                null
+            }
+        VERSION_ONE_V0_3_0_SCHEMA ->
+            if (
+                hasExactRoomMetadata(V0_3_0_IDENTITY_HASH) &&
+                hasEmptyHistoricalStubTables()
+            ) {
+                VersionOneSchema.V0_3_0
+            } else {
+                null
+            }
+        VERSION_ONE_ISSUE_261_MARKER_SCHEMA ->
+            if (hasExactIssue261MarkerMetadata()) VersionOneSchema.ISSUE_261_MARKER else null
+        else -> null
+    }
+}
+
+private fun SupportSQLiteDatabase.hasExactRoomMetadata(identityHash: String): Boolean {
+    if (
+        !hasVersionOneTable("room_master_table") ||
+        VersionOneTable(
+            columns = readVersionOneColumns("room_master_table"),
+            indices = readVersionOneIndices("room_master_table"),
+            foreignKeys = readVersionOneForeignKeys("room_master_table"),
+            autoIncrement = readVersionOneAutoIncrement("room_master_table"),
+        ) != VERSION_ONE_ROOM_MASTER_SCHEMA
+    ) {
+        return false
+    }
+
+    query("SELECT id, identity_hash FROM room_master_table ORDER BY id").use { cursor ->
+        if (!cursor.moveToFirst()) return false
+        if (cursor.getInt(0) != ROOM_MASTER_ID || cursor.getString(1) != identityHash) {
+            return false
+        }
+        if (cursor.moveToNext()) return false
+    }
+    return true
+}
+
+private fun SupportSQLiteDatabase.hasExactIssue261MarkerMetadata(): Boolean {
+    if (!hasExactRoomMetadata(ISSUE_261_IDENTITY_HASH)) return false
+    query("SELECT COUNT(*) FROM stale_issue_261_marker").use { cursor ->
+        return cursor.moveToFirst() && cursor.getLong(0) == 0L
+    }
+}
+
+private fun SupportSQLiteDatabase.hasEmptyHistoricalStubTables(): Boolean =
+    listOf("sessions", "agent_sessions").all { tableName ->
+        query("SELECT 1 FROM ${quoteIdentifier(tableName)} LIMIT 1").use { cursor ->
+            !cursor.moveToFirst()
+        }
+    }
+
+private fun SupportSQLiteDatabase.hasVersionOneTable(tableName: String): Boolean {
+    query(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        arrayOf(tableName),
+    ).use { cursor ->
+        return cursor.moveToFirst()
+    }
+}
+
+private fun SupportSQLiteDatabase.hasUnexpectedVersionOneObjects(): Boolean {
+    query(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type IN ('view', 'trigger')
+          AND name NOT LIKE 'sqlite_%'
+        LIMIT 1
+        """.trimIndent(),
+    ).use { cursor ->
+        return cursor.moveToFirst()
+    }
+}
+
+/**
+ * Room emitted no comments in any shipped v1 CREATE TABLE statement. Reject
+ * comments before token-based semantic checks so comment text cannot spoof an
+ * AUTOINCREMENT token or split an unsupported CHECK clause.
+ * This deliberately fail-closed rule avoids pretending the classifier is a
+ * permissive SQL parser.
+ */
+private fun SupportSQLiteDatabase.hasVersionOneSqlComments(): Boolean {
+    query(
+        """
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != 'android_metadata'
+        """.trimIndent(),
+    ).use { cursor ->
+        while (cursor.moveToNext()) {
+            if (cursor.isNull(0)) return true
+            if (SQL_COMMENT_TOKEN.containsMatchIn(cursor.getString(0))) return true
+        }
+    }
+    return false
+}
+
+/**
+ * The structural signature below intentionally ignores whitespace, quoting,
+ * and declaration formatting, but it must not ignore table semantics that the
+ * SQLite PRAGMAs do not expose. None of the three tagged schemas uses these
+ * clauses. Rejecting them makes an unknown near-match fail closed instead of
+ * treating CHECK/collation/conflict/rowid behavior as the shipped layout.
+ *
+ * The remaining accepted variation is syntax-only: table_xinfo covers visible
+ * and hidden columns, index_list includes implicit sqlite_autoindex entries,
+ * index_xinfo covers expressions/order/collation, foreign keys remain a list so
+ * duplicates cannot collapse, and AUTOINCREMENT is compared separately.
+ */
+private fun SupportSQLiteDatabase.hasUnsupportedVersionOneTableSemantics(): Boolean {
+    query(
+        """
+        SELECT sql
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != 'android_metadata'
+        """.trimIndent(),
+    ).use { cursor ->
+        while (cursor.moveToNext()) {
+            if (cursor.isNull(0)) return true
+            if (UNSUPPORTED_TABLE_SEMANTICS.containsMatchIn(cursor.getString(0))) return true
+        }
+    }
+    return false
+}
+
+private fun SupportSQLiteDatabase.readVersionOneApplicationSchema(): Map<String, VersionOneTable> {
+    val tableNames = buildList {
+        query(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table'
+              AND name NOT LIKE 'sqlite_%'
+              AND name NOT IN ('android_metadata', 'room_master_table')
+            ORDER BY name
+            """.trimIndent(),
+        ).use { cursor ->
+            while (cursor.moveToNext()) add(cursor.getString(0))
+        }
+    }
+    return tableNames.associateWith { tableName ->
+        VersionOneTable(
+            columns = readVersionOneColumns(tableName),
+            indices = readVersionOneIndices(tableName),
+            foreignKeys = readVersionOneForeignKeys(tableName),
+            autoIncrement = readVersionOneAutoIncrement(tableName),
+        )
+    }
+}
+
+private fun SupportSQLiteDatabase.readVersionOneColumns(tableName: String): List<VersionOneColumn> =
+    buildList {
+        query("PRAGMA table_xinfo(${quoteIdentifier(tableName)})").use { cursor ->
+            val nameIndex = cursor.getColumnIndexOrThrow("name")
+            val typeIndex = cursor.getColumnIndexOrThrow("type")
+            val notNullIndex = cursor.getColumnIndexOrThrow("notnull")
+            val primaryKeyIndex = cursor.getColumnIndexOrThrow("pk")
+            val defaultValueIndex = cursor.getColumnIndexOrThrow("dflt_value")
+            val hiddenIndex = cursor.getColumnIndexOrThrow("hidden")
+            while (cursor.moveToNext()) {
+                add(
+                    VersionOneColumn(
+                        name = cursor.getString(nameIndex),
+                        type = cursor.getString(typeIndex).uppercase(),
+                        notNull = cursor.getInt(notNullIndex) == 1,
+                        primaryKeyPosition = cursor.getInt(primaryKeyIndex),
+                        defaultValue = if (cursor.isNull(defaultValueIndex)) {
+                            null
+                        } else {
+                            cursor.getString(defaultValueIndex)
+                        },
+                        hidden = cursor.getInt(hiddenIndex),
+                    ),
+                )
+            }
+        }
+    }
+
+private fun SupportSQLiteDatabase.readVersionOneIndices(tableName: String): List<VersionOneIndex> =
+    buildList {
+        query("PRAGMA index_list(${quoteIdentifier(tableName)})").use { cursor ->
+            val nameIndex = cursor.getColumnIndexOrThrow("name")
+            val uniqueIndex = cursor.getColumnIndexOrThrow("unique")
+            val originIndex = cursor.getColumnIndexOrThrow("origin")
+            val partialIndex = cursor.getColumnIndexOrThrow("partial")
+            while (cursor.moveToNext()) {
+                val indexName = cursor.getString(nameIndex)
+                val origin = cursor.getString(originIndex)
+                add(
+                    VersionOneIndex(
+                        name = if (origin == "c") indexName else null,
+                        unique = cursor.getInt(uniqueIndex) == 1,
+                        columns = readVersionOneIndexColumns(indexName),
+                        origin = origin,
+                        partial = cursor.getInt(partialIndex) == 1,
+                    ),
+                )
+            }
+        }
+    }.sortedWith(VERSION_ONE_INDEX_COMPARATOR)
+
+private fun SupportSQLiteDatabase.readVersionOneIndexColumns(
+    indexName: String,
+): List<VersionOneIndexColumn> =
+    buildList {
+        query("PRAGMA index_xinfo(${quoteIdentifier(indexName)})").use { cursor ->
+            val nameIndex = cursor.getColumnIndexOrThrow("name")
+            val descendingIndex = cursor.getColumnIndexOrThrow("desc")
+            val collationIndex = cursor.getColumnIndexOrThrow("coll")
+            val keyIndex = cursor.getColumnIndexOrThrow("key")
+            while (cursor.moveToNext()) {
+                if (cursor.getInt(keyIndex) != 1) continue
+                add(
+                    VersionOneIndexColumn(
+                        name = if (cursor.isNull(nameIndex)) null else cursor.getString(nameIndex),
+                        descending = cursor.getInt(descendingIndex) == 1,
+                        collation = if (cursor.isNull(collationIndex)) {
+                            ""
+                        } else {
+                            cursor.getString(collationIndex).uppercase()
+                        },
+                    ),
+                )
+            }
+        }
+    }
+
+private fun SupportSQLiteDatabase.readVersionOneForeignKeys(
+    tableName: String,
+): List<VersionOneForeignKey> = buildList {
+    query("PRAGMA foreign_key_list(${quoteIdentifier(tableName)})").use { cursor ->
+        val tableIndex = cursor.getColumnIndexOrThrow("table")
+        val fromIndex = cursor.getColumnIndexOrThrow("from")
+        val toIndex = cursor.getColumnIndexOrThrow("to")
+        val onUpdateIndex = cursor.getColumnIndexOrThrow("on_update")
+        val onDeleteIndex = cursor.getColumnIndexOrThrow("on_delete")
+        val matchIndex = cursor.getColumnIndexOrThrow("match")
+        while (cursor.moveToNext()) {
+            add(
+                VersionOneForeignKey(
+                    referencedTable = cursor.getString(tableIndex),
+                    fromColumn = cursor.getString(fromIndex),
+                    toColumn = cursor.getString(toIndex),
+                    onUpdate = cursor.getString(onUpdateIndex).uppercase(),
+                    onDelete = cursor.getString(onDeleteIndex).uppercase(),
+                    match = cursor.getString(matchIndex).uppercase(),
+                ),
+            )
+        }
+    }
+}
+
+private fun SupportSQLiteDatabase.readVersionOneAutoIncrement(tableName: String): Boolean {
+    query(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        arrayOf(tableName),
+    ).use { cursor ->
+        return cursor.moveToFirst() &&
+            !cursor.isNull(0) &&
+            AUTOINCREMENT_TOKEN.containsMatchIn(cursor.getString(0))
+    }
+}
+
+private fun quoteIdentifier(identifier: String): String =
+    "`" + identifier.replace("`", "``") + "`"
+
+private fun replaceIssue261MarkerWithVersionEightSchema(db: SupportSQLiteDatabase) {
+    db.execSQL("DROP TABLE stale_issue_261_marker")
+    createVersionEightBaseTables(db)
+}
+
+private fun createVersionEightBaseTables(db: SupportSQLiteDatabase) {
+    db.execSQL(
+        """
+        CREATE TABLE ssh_keys (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            name TEXT NOT NULL,
+            privateKeyPath TEXT NOT NULL,
+            hasPassphrase INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL
+        )
+        """.trimIndent(),
+    )
+    db.execSQL(
+        """
+        CREATE TABLE hosts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            name TEXT NOT NULL,
+            hostname TEXT NOT NULL,
+            port INTEGER NOT NULL,
+            username TEXT NOT NULL,
+            keyId INTEGER NOT NULL,
+            maxAutoPort INTEGER NOT NULL,
+            skipPortsBelow INTEGER NOT NULL,
+            scanIntervalSec INTEGER NOT NULL,
+            enabled INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL,
+            lastConnectedAt INTEGER,
+            tmuxInstalled INTEGER,
+            lastBootstrapAt INTEGER,
+            pocketshellInstalled INTEGER,
+            pocketshellLastDetectedAt INTEGER,
+            usageCommandOverride TEXT,
+            pathOverride TEXT,
+            FOREIGN KEY(keyId) REFERENCES ssh_keys(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE INDEX index_hosts_keyId ON hosts(keyId)")
+    db.execSQL(
+        """
+        CREATE TABLE port_remappings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            remotePort INTEGER NOT NULL,
+            localPort INTEGER NOT NULL,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE INDEX index_port_remappings_hostId ON port_remappings(hostId)")
+    db.execSQL(
+        "CREATE UNIQUE INDEX index_port_remappings_hostId_remotePort " +
+            "ON port_remappings(hostId, remotePort)",
+    )
+    db.execSQL(
+        """
+        CREATE TABLE sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            lastSeenAt INTEGER NOT NULL,
+            tags TEXT,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE INDEX index_sessions_hostId ON sessions(hostId)")
+    db.execSQL("CREATE UNIQUE INDEX index_sessions_hostId_name ON sessions(hostId, name)")
+    db.execSQL(
+        """
+        CREATE TABLE snippets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            label TEXT,
+            body TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE INDEX index_snippets_hostId ON snippets(hostId)")
+    db.execSQL(
+        """
+        CREATE TABLE agent_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            paneRef TEXT NOT NULL,
+            agent TEXT NOT NULL,
+            jsonlPath TEXT,
+            detectedAt INTEGER NOT NULL
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE UNIQUE INDEX index_agent_sessions_paneRef ON agent_sessions(paneRef)")
+    db.execSQL(
+        """
+        CREATE TABLE project_roots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            hostId INTEGER NOT NULL,
+            label TEXT NOT NULL,
+            path TEXT NOT NULL,
+            createdAt INTEGER NOT NULL,
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE INDEX index_project_roots_hostId ON project_roots(hostId)")
+    db.execSQL(
+        "CREATE UNIQUE INDEX index_project_roots_hostId_path ON project_roots(hostId, path)",
+    )
+    db.execSQL(
+        """
+        CREATE TABLE ai_api_call_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+            timestampMillis INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            feature TEXT NOT NULL,
+            inputUnits INTEGER NOT NULL,
+            outputUnits INTEGER NOT NULL,
+            unitCostUsdMillicents INTEGER NOT NULL,
+            computedCostUsdMillicents INTEGER NOT NULL,
+            metadataJson TEXT
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE INDEX index_ai_api_call_log_timestampMillis ON ai_api_call_log(timestampMillis)")
+    db.execSQL(
+        "CREATE INDEX index_ai_api_call_log_provider_feature ON ai_api_call_log(provider, feature)",
+    )
+    db.execSQL(
+        """
+        CREATE TABLE pending_transcriptions (
+            id TEXT NOT NULL,
+            audioPath TEXT NOT NULL,
+            recordingTimestampMs INTEGER NOT NULL,
+            destinationContext TEXT NOT NULL,
+            retryCount INTEGER NOT NULL,
+            lastErrorMessage TEXT,
+            audioByteSize INTEGER NOT NULL,
+            createdAtMs INTEGER NOT NULL,
+            PRIMARY KEY(id)
+        )
+        """.trimIndent(),
+    )
+    db.execSQL(
+        "CREATE INDEX index_pending_transcriptions_recordingTimestampMs " +
+            "ON pending_transcriptions(recordingTimestampMs)",
+    )
+    db.execSQL(
+        """
+        CREATE TABLE port_usage (
+            hostId INTEGER NOT NULL,
+            remotePort INTEGER NOT NULL,
+            clickCount INTEGER NOT NULL,
+            totalBytes INTEGER NOT NULL,
+            lastUsedAt INTEGER NOT NULL,
+            PRIMARY KEY(hostId, remotePort),
+            FOREIGN KEY(hostId) REFERENCES hosts(id) ON UPDATE NO ACTION ON DELETE CASCADE
+        )
+        """.trimIndent(),
+    )
+    db.execSQL("CREATE INDEX index_port_usage_hostId ON port_usage(hostId)")
+}
+
+private fun column(
+    name: String,
+    type: String,
+    notNull: Boolean,
+    primaryKeyPosition: Int = 0,
+): VersionOneColumn = VersionOneColumn(
+    name = name,
+    type = type,
+    notNull = notNull,
+    primaryKeyPosition = primaryKeyPosition,
+    defaultValue = null,
+    hidden = 0,
+)
+
+private fun index(name: String, unique: Boolean, vararg columns: String): VersionOneIndex =
+    VersionOneIndex(
+        name = name,
+        unique = unique,
+        columns = columns.map { VersionOneIndexColumn(it, false, "BINARY") },
+        origin = "c",
+        partial = false,
+    )
+
+private fun primaryKeyIndex(vararg columns: String): VersionOneIndex =
+    VersionOneIndex(
+        name = null,
+        unique = true,
+        columns = columns.map { VersionOneIndexColumn(it, false, "BINARY") },
+        origin = "pk",
+        partial = false,
+    )
+
+private fun indices(vararg values: VersionOneIndex): List<VersionOneIndex> =
+    values.sortedWith(VERSION_ONE_INDEX_COMPARATOR)
+
+private fun foreignKey(
+    referencedTable: String,
+    fromColumn: String,
+    toColumn: String,
+): VersionOneForeignKey = VersionOneForeignKey(
+    referencedTable = referencedTable,
+    fromColumn = fromColumn,
+    toColumn = toColumn,
+    onUpdate = "NO ACTION",
+    onDelete = "CASCADE",
+    match = "NONE",
+)
+
+private val BASE_VERSION_ONE_TABLES: Map<String, VersionOneTable> = mapOf(
+    "ssh_keys" to VersionOneTable(
+        columns = listOf(
+            column("id", "INTEGER", true, 1),
+            column("name", "TEXT", true),
+            column("privateKeyPath", "TEXT", true),
+            column("hasPassphrase", "INTEGER", true),
+            column("createdAt", "INTEGER", true),
+        ),
+        autoIncrement = true,
+    ),
+    "port_remappings" to VersionOneTable(
+        columns = listOf(
+            column("id", "INTEGER", true, 1),
+            column("hostId", "INTEGER", true),
+            column("remotePort", "INTEGER", true),
+            column("localPort", "INTEGER", true),
+        ),
+        indices = indices(
+            index("index_port_remappings_hostId", false, "hostId"),
+            index("index_port_remappings_hostId_remotePort", true, "hostId", "remotePort"),
+        ),
+        foreignKeys = listOf(foreignKey("hosts", "hostId", "id")),
+        autoIncrement = true,
+    ),
+    "sessions" to VersionOneTable(
+        columns = listOf(
+            column("id", "INTEGER", true, 1),
+            column("hostId", "INTEGER", true),
+            column("name", "TEXT", true),
+            column("lastSeenAt", "INTEGER", true),
+            column("tags", "TEXT", false),
+        ),
+        indices = indices(
+            index("index_sessions_hostId", false, "hostId"),
+            index("index_sessions_hostId_name", true, "hostId", "name"),
+        ),
+        foreignKeys = listOf(foreignKey("hosts", "hostId", "id")),
+        autoIncrement = true,
+    ),
+    "agent_sessions" to VersionOneTable(
+        columns = listOf(
+            column("id", "INTEGER", true, 1),
+            column("paneRef", "TEXT", true),
+            column("agent", "TEXT", true),
+            column("jsonlPath", "TEXT", false),
+            column("detectedAt", "INTEGER", true),
+        ),
+        indices = indices(index("index_agent_sessions_paneRef", true, "paneRef")),
+        autoIncrement = true,
+    ),
+)
+
+private val BASE_HOST_COLUMNS: List<VersionOneColumn> = listOf(
+    column("id", "INTEGER", true, 1),
+    column("name", "TEXT", true),
+    column("hostname", "TEXT", true),
+    column("port", "INTEGER", true),
+    column("username", "TEXT", true),
+    column("keyId", "INTEGER", true),
+    column("maxAutoPort", "INTEGER", true),
+    column("skipPortsBelow", "INTEGER", true),
+    column("scanIntervalSec", "INTEGER", true),
+    column("enabled", "INTEGER", true),
+    column("createdAt", "INTEGER", true),
+    column("lastConnectedAt", "INTEGER", false),
+)
+
+private val WRITER_BACKED_VERSION_ONE_TABLES: Map<String, VersionOneTable> = mapOf(
+    "port_usage" to VersionOneTable(
+        columns = listOf(
+            column("hostId", "INTEGER", true, 1),
+            column("remotePort", "INTEGER", true, 2),
+            column("clickCount", "INTEGER", true),
+            column("totalBytes", "INTEGER", true),
+            column("lastUsedAt", "INTEGER", true),
+        ),
+        indices = indices(
+            primaryKeyIndex("hostId", "remotePort"),
+            index("index_port_usage_hostId", false, "hostId"),
+        ),
+        foreignKeys = listOf(foreignKey("hosts", "hostId", "id")),
+    ),
+    "project_roots" to VersionOneTable(
+        columns = listOf(
+            column("id", "INTEGER", true, 1),
+            column("hostId", "INTEGER", true),
+            column("label", "TEXT", true),
+            column("path", "TEXT", true),
+            column("createdAt", "INTEGER", true),
+        ),
+        indices = indices(
+            index("index_project_roots_hostId", false, "hostId"),
+            index("index_project_roots_hostId_path", true, "hostId", "path"),
+        ),
+        foreignKeys = listOf(foreignKey("hosts", "hostId", "id")),
+        autoIncrement = true,
+    ),
+    "ai_api_call_log" to VersionOneTable(
+        columns = listOf(
+            column("id", "INTEGER", true, 1),
+            column("timestampMillis", "INTEGER", true),
+            column("provider", "TEXT", true),
+            column("feature", "TEXT", true),
+            column("inputUnits", "INTEGER", true),
+            column("outputUnits", "INTEGER", true),
+            column("unitCostUsdMillicents", "INTEGER", true),
+            column("computedCostUsdMillicents", "INTEGER", true),
+            column("metadataJson", "TEXT", false),
+        ),
+        indices = indices(
+            index("index_ai_api_call_log_timestampMillis", false, "timestampMillis"),
+            index("index_ai_api_call_log_provider_feature", false, "provider", "feature"),
+        ),
+        autoIncrement = true,
+    ),
+    "pending_transcriptions" to VersionOneTable(
+        columns = listOf(
+            column("id", "TEXT", true, 1),
+            column("audioPath", "TEXT", true),
+            column("recordingTimestampMs", "INTEGER", true),
+            column("destinationContext", "TEXT", true),
+            column("retryCount", "INTEGER", true),
+            column("lastErrorMessage", "TEXT", false),
+            column("audioByteSize", "INTEGER", true),
+            column("createdAtMs", "INTEGER", true),
+        ),
+        indices = indices(
+            primaryKeyIndex("id"),
+            index(
+                "index_pending_transcriptions_recordingTimestampMs",
+                false,
+                "recordingTimestampMs",
+            ),
+        ),
+    ),
+)
+
+private fun hostsTable(columns: List<VersionOneColumn>): Pair<String, VersionOneTable> =
+    "hosts" to VersionOneTable(
+        columns = columns,
+        indices = indices(index("index_hosts_keyId", false, "keyId")),
+        foreignKeys = listOf(foreignKey("ssh_keys", "keyId", "id")),
+        autoIncrement = true,
+    )
+
+private fun snippetsTable(labelNotNull: Boolean): Pair<String, VersionOneTable> =
+    "snippets" to VersionOneTable(
+        columns = listOf(
+            column("id", "INTEGER", true, 1),
+            column("hostId", "INTEGER", true),
+            column("label", "TEXT", labelNotNull),
+            column("body", "TEXT", true),
+            column("kind", "TEXT", true),
+        ),
+        indices = indices(index("index_snippets_hostId", false, "hostId")),
+        foreignKeys = listOf(foreignKey("hosts", "hostId", "id")),
+        autoIncrement = true,
+    )
+
+private val VERSION_ONE_V0_2_0_SCHEMA: Map<String, VersionOneTable> =
+    BASE_VERSION_ONE_TABLES + mapOf(
+        hostsTable(BASE_HOST_COLUMNS),
+        snippetsTable(labelNotNull = true),
+    )
+
+private val VERSION_ONE_V0_2_9_SCHEMA: Map<String, VersionOneTable> =
+    BASE_VERSION_ONE_TABLES + WRITER_BACKED_VERSION_ONE_TABLES + mapOf(
+        hostsTable(
+            BASE_HOST_COLUMNS + listOf(
+                column("tmuxInstalled", "INTEGER", false),
+                column("lastBootstrapAt", "INTEGER", false),
+                column("quseInstalled", "INTEGER", false),
+                column("quseLastDetectedAt", "INTEGER", false),
+                column("usageCommandOverride", "TEXT", false),
+                column("pathOverride", "TEXT", false),
+                column("pocketshellInstalled", "INTEGER", false),
+            ),
+        ),
+        snippetsTable(labelNotNull = false),
+    )
+
+private val VERSION_ONE_V0_3_0_SCHEMA: Map<String, VersionOneTable> =
+    BASE_VERSION_ONE_TABLES + WRITER_BACKED_VERSION_ONE_TABLES + mapOf(
+        hostsTable(
+            BASE_HOST_COLUMNS + listOf(
+                column("tmuxInstalled", "INTEGER", false),
+                column("lastBootstrapAt", "INTEGER", false),
+                column("pocketshellInstalled", "INTEGER", false),
+                column("pocketshellLastDetectedAt", "INTEGER", false),
+                column("usageCommandOverride", "TEXT", false),
+                column("pathOverride", "TEXT", false),
+            ),
+        ),
+        snippetsTable(labelNotNull = false),
+    )
+
+private val VERSION_ONE_ISSUE_261_MARKER_SCHEMA: Map<String, VersionOneTable> = mapOf(
+    "stale_issue_261_marker" to VersionOneTable(
+        columns = listOf(column("id", "INTEGER", false, 1)),
+    ),
+)
+
+private val VERSION_ONE_ROOM_MASTER_SCHEMA = VersionOneTable(
+    columns = listOf(
+        column("id", "INTEGER", false, 1),
+        column("identity_hash", "TEXT", false),
+    ),
+)
+
+private const val ROOM_MASTER_ID: Int = 42
+private const val V0_2_0_IDENTITY_HASH: String = "4f9cdd46489198fdda4b34e6b682d56d"
+private const val V0_2_9_IDENTITY_HASH: String = "4a479a15dfcab2d576e00c7ce10ac581"
+private const val V0_3_0_IDENTITY_HASH: String = "5c2d470ba861de091b4dad454b282704"
+private const val ISSUE_261_IDENTITY_HASH: String = "4a479a15dfcab2d576e00c7ce10ac581"
+
+private val SQL_COMMENT_TOKEN = Regex("""--|/\*|\*/""")
+private val AUTOINCREMENT_TOKEN = Regex("""\bAUTOINCREMENT\b""", RegexOption.IGNORE_CASE)
+
+private val UNSUPPORTED_TABLE_SEMANTICS = Regex(
+    pattern =
+        """\b(?:CHECK\s*\(|COLLATE\b|GENERATED\b|ON\s+CONFLICT\b|DEFERRABLE\b|""" +
+            """WITHOUT\s+ROWID\b|STRICT\b)""",
+    option = RegexOption.IGNORE_CASE,
+)

--- a/shared/core-storage/src/test/java/com/pocketshell/core/storage/AppDatabaseTest.kt
+++ b/shared/core-storage/src/test/java/com/pocketshell/core/storage/AppDatabaseTest.kt
@@ -252,32 +252,27 @@ class AppDatabaseTest {
     }
 
     @Test
-    fun missingMigrationFailsWithoutDestroyingLegacyRows() {
-        val databaseName = "missing-migration-${System.nanoTime()}.db"
+    fun exactIssue261MarkerMigratesToCurrentSchema() {
+        val databaseName = "issue-261-marker-${System.nanoTime()}.db"
         seedStaleIdentityDatabase(databaseName, version = LEGACY_CRASH_SCHEMA_VERSION)
 
-        assertThrows(IllegalStateException::class.java) {
-            val staleDb = openOnDiskDatabase(databaseName)
-            try {
-                staleDb.openHelper.writableDatabase.query("SELECT 1").close()
-            } finally {
-                staleDb.close()
-            }
+        val migratedDb = openOnDiskDatabase(databaseName)
+        try {
+            migratedDb.openHelper.writableDatabase.query("SELECT 1").close()
+        } finally {
+            migratedDb.close()
         }
 
-        assertTableExists(databaseName, "stale_issue_261_marker")
+        assertEquals(APP_DATABASE_SCHEMA_VERSION, readSchemaVersion(databaseName))
+        assertTableMissing(databaseName, "stale_issue_261_marker")
+        assertTableExists(databaseName, "hosts")
         context.deleteDatabase(databaseName)
     }
 
     @Test
-    fun destructiveFallbackVersionsDoNotOverlapSupportedMigrationStarts() {
+    fun versionOneHasNonDestructiveMigrationStart() {
         val supportedMigrationStarts = APP_DATABASE_MIGRATIONS.map { it.startVersion }.toSet()
-
-        assertTrue(
-            APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS.none {
-                it in supportedMigrationStarts
-            },
-        )
+        assertTrue(1 in supportedMigrationStarts)
     }
 
     // --- Issue #932 (#928 D2/D9 P5): full migration-chain completeness. The
@@ -338,15 +333,11 @@ class AppDatabaseTest {
     fun legacyRecoveryVersionsHaveNonDestructiveMigrationStarts() {
         val supportedMigrationStarts = APP_DATABASE_MIGRATIONS.map { it.startVersion }.toSet()
 
-        for (version in listOf(2, 3, 4, 5, 6, 7, 9)) {
+        for (version in listOf(1, 2, 3, 4, 5, 6, 7, 9)) {
             assertTrue(
                 "Legacy schema v$version must recover through APP_DATABASE_MIGRATIONS, " +
-                    "not the destructive fallback allowlist",
+                    "without destructive fallback",
                 version in supportedMigrationStarts,
-            )
-            assertTrue(
-                "Legacy schema v$version must not be destructively allowlisted",
-                version !in APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS.toSet(),
             )
         }
     }
@@ -364,7 +355,6 @@ class AppDatabaseTest {
     fun everySupportedStartVersionMigratesToCurrentPreservingRows() = runTest {
         val supportedStartVersions = APP_DATABASE_MIGRATIONS
             .map { it.startVersion }
-            .filter { it !in APP_DATABASE_UNSUPPORTED_STALE_SCHEMA_VERSIONS.toSet() }
             .sorted()
 
         // Sanity: the sweep must actually exercise every start version in the
@@ -400,7 +390,7 @@ class AppDatabaseTest {
                 val key = migratedDb.sshKeyDao().getById(1)
                 assertNotNull("ssh_key row lost migrating from v$startVersion", key)
 
-                if (startVersion in 2..7 || startVersion == 9) {
+                if (startVersion in 1..7 || startVersion == 9) {
                     val snippets = migratedDb.snippetDao().getByHostId(1).first()
                     assertEquals(
                         "Snippet row lost migrating from legacy v$startVersion",
@@ -504,6 +494,10 @@ class AppDatabaseTest {
      * v8+ uses the post-reset preservation ladder.
      */
     private fun buildSchemaLadderUpTo(db: SQLiteDatabase, targetVersion: Int) {
+        if (targetVersion == 1) {
+            createLegacyVersionOneSchema(db)
+            return
+        }
         if (targetVersion in 2..7) {
             createLegacySchemaUpTo(db, targetVersion)
             return
@@ -538,7 +532,7 @@ class AppDatabaseTest {
     }
 
     private fun insertHostRowForVersion(db: SQLiteDatabase, version: Int) {
-        if (version in 2..7 || version == 9) {
+        if (version in 1..7 || version == 9) {
             insertLegacyHostRowForVersion(db, version)
         } else if (version == 8) {
             db.execSQL(
@@ -606,6 +600,13 @@ class AppDatabaseTest {
 
     private fun createLegacyVersionOneSchema(db: SQLiteDatabase) {
         db.execSQL("PRAGMA foreign_keys=OFF")
+        db.execSQL("CREATE TABLE room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT)")
+        db.execSQL(
+            """
+            INSERT INTO room_master_table(id, identity_hash)
+            VALUES(42, '4f9cdd46489198fdda4b34e6b682d56d')
+            """.trimIndent(),
+        )
         db.execSQL(
             """
             CREATE TABLE ssh_keys (
@@ -811,6 +812,17 @@ class AppDatabaseTest {
         )
 
         when (version) {
+            1 -> db.execSQL(
+                """
+                INSERT INTO hosts(
+                    id, name, hostname, port, username, keyId, maxAutoPort, skipPortsBelow,
+                    scanIntervalSec, enabled, createdAt, lastConnectedAt
+                ) VALUES(
+                    1, 'host-v$version', 'h.example.com', 2222, 'alexey', 1, 10000, 1000,
+                    5, 1, 101, 102
+                )
+                """.trimIndent(),
+            )
             2, 3 -> db.execSQL(
                 """
                 INSERT INTO hosts(
@@ -1389,6 +1401,20 @@ class AppDatabaseTest {
                 arrayOf(tableName),
             ).use { cursor ->
                 assertTrue(cursor.moveToFirst())
+            }
+        }
+    }
+
+    private fun readSchemaVersion(databaseName: String): Int {
+        val sqlite = SQLiteDatabase.openDatabase(
+            context.getDatabasePath(databaseName).path,
+            null,
+            SQLiteDatabase.OPEN_READONLY,
+        )
+        return sqlite.use {
+            it.rawQuery("PRAGMA user_version", null).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                cursor.getInt(0)
             }
         }
     }


### PR DESCRIPTION
## Summary

- remove the final production destructive-migration fallback
- add strict, fail-closed migration support for shipped v1 database shapes from v0.2.0, v0.2.9, v0.3.0, and the exact #261 marker
- preserve writer-backed rows/relationships while removing only verified empty historical stubs
- extend the complete pre-release gate with real APK/Hilt migration proofs

## Verification

- production-path RED: 9 tests / 7 expected failures
- restored focused GREEN: 9/9; core-storage 20/20
- 12 independent compiled mutants killed
- forced Android-test compile: 176/176 tasks
- canonical no-arg full JVM gate: 603/603 tasks
- complete pre-release gate: all 38 stages green, including tagged-v0.3.0 and #261-marker on-device migrations
- independent reviewer repeated missing mutations, compile, full JVM, and complete device gate: APPROVED

Reviewer verdict: https://github.com/alexeygrigorev/pocketshell/issues/1747#issuecomment-5082484523

Closes #1747