### PR TITLE
ci: preserve journey abort evidence across retries (#1458)

### DIFF
--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -20,7 +20,7 @@ cleanup_gradle_after_timeout() {
   local fqcn="$1"
   local stop_rc
 
-  echo "GRADLE_TIMEOUT_CLEANUP: $fqcn timed out; stopping Gradle daemons before any retry"
+  echo "GRADLE_TIMEOUT_CLEANUP: $fqcn aborted; stopping Gradle daemons before any retry"
   if timeout --signal=TERM --kill-after=10 "${JOURNEY_GRADLE_STOP_TIMEOUT_SECS}s" \
       "$GRADLEW" --stop; then
     echo "GRADLE_TIMEOUT_CLEANUP: Gradle daemon stop completed for $fqcn"
@@ -28,12 +28,28 @@ cleanup_gradle_after_timeout() {
   fi
 
   stop_rc=$?
-  echo "GRADLE_TIMEOUT_CLEANUP: Gradle daemon stop exited $stop_rc for $fqcn; continuing with retry/budget handling" >&2
-  return 0
+  echo "GRADLE_TIMEOUT_CLEANUP_FAILED: Gradle daemon stop exited $stop_rc for $fqcn" >&2
+  return "$stop_rc"
 }
 
 LAST_RUN_CLASS_TIMEOUT_HIT=0
 LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=0
+LAST_RUN_CLASS_PRIMARY_RC=0
+LAST_RUN_CLASS_ABORT_CLEANUP_FAILED=0
+LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=0
+LAST_RUN_CLASS_GRADLE_CLEANUP_RC="not_run"
+LAST_RUN_CLASS_DEVICE_CLEANUP_RC="not_run"
+LAST_RUN_CLASS_ATTEMPT_DIR=""
+LAST_RUN_CLASS_MODULE=""
+LAST_RUN_CLASS_SELECTOR=""
+LAST_RUN_CLASS_ATTEMPT=0
+LAST_RUN_CLASS_PRIMARY_CLASSIFICATION=""
+LAST_RUN_CLASS_RAW_JUNIT_STATUS=""
+LAST_RUN_CLASS_RAW_JUNIT_COUNT=0
+LAST_RUN_CLASS_SNAPSHOT_STATUS=""
+JOURNEY_ABORT_ISOLATION_FAILED=0
+JOURNEY_HARNESS_FAILURE_RC=125
+declare -A JOURNEY_CLASS_ATTEMPT_COUNTS=()
 
 is_timeout_rc() {
   [[ "$1" -eq 124 || ( "$1" -eq 137 && "${LAST_RUN_CLASS_TIMEOUT_HIT:-0}" -eq 1 ) ]]
@@ -45,6 +61,694 @@ class_attempt_hit_time_budget() {
 
 needs_gradle_cleanup_after_class_abort() {
   [[ "$1" -eq 124 || "$1" -eq 137 ]]
+}
+
+journey_class_artifact_key() {
+  local fqcn="$1"
+  local readable="${fqcn//[^A-Za-z0-9._-]/_}"
+  local digest
+
+  # Keep one readable path component, but hash the full unsanitized selector so
+  # selectors such as A#method and A_method can never overwrite one another.
+  readable="${readable:0:120}"
+  while [[ "$readable" == .* ]]; do
+    readable="_${readable#.}"
+  done
+  [[ "$readable" =~ [A-Za-z0-9] ]] || readable="unnamed-class"
+  digest="$(printf '%s' "$fqcn" | sha256sum | awk '{ print substr($1, 1, 16) }')" \
+    || return 1
+  [[ "$digest" =~ ^[0-9a-f]{16}$ ]] || return 1
+  printf '%s--%s\n' "$readable" "$digest"
+}
+
+journey_app_package_names() {
+  local suffix="${1:-}"
+  local app_package="com.pocketshell.app"
+
+  if [[ -n "$suffix" ]]; then
+    [[ "$suffix" =~ ^[A-Za-z0-9._]+$ ]] || {
+      echo "JOURNEY_ABORT_CLEANUP_FAILED: invalid application id suffix '$suffix'" >&2
+      return 2
+    }
+    app_package+=".$suffix"
+  fi
+  printf '%s.test\n%s\n' "$app_package" "$app_package"
+}
+
+journey_target_package_names() {
+  local module="$1"
+  local suffix="${2:-}"
+
+  case "$module" in
+    app)
+      journey_app_package_names "$suffix"
+      ;;
+    core-terminal)
+      # Android library androidTest APK namespace from
+      # shared/core-terminal/build.gradle.kts.
+      printf '%s\n' "com.termux.view.test"
+      ;;
+    *)
+      echo "JOURNEY_ABORT_CLEANUP_FAILED: unknown connected-test module '$module'" >&2
+      return 2
+      ;;
+  esac
+}
+
+journey_adb() {
+  local adb_command="${JOURNEY_ADB:-${ADB:-adb}}"
+  command "$adb_command" "$@"
+}
+
+journey_resolve_device_serial() {
+  local devices_output serial candidate found=0
+  local -a serials=()
+
+  if ! devices_output="$(journey_adb devices 2>&1)"; then
+    echo "JOURNEY_ABORT_CLEANUP_FAILED: adb devices failed: $devices_output" >&2
+    return 1
+  fi
+  mapfile -t serials < <(
+    awk 'NR > 1 && $2 == "device" { print $1 }' <<< "$devices_output"
+  )
+
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    serial="$ANDROID_SERIAL"
+    for candidate in "${serials[@]}"; do
+      [[ "$candidate" == "$serial" ]] && found=1
+    done
+    if [[ "$found" -ne 1 ]]; then
+      echo "JOURNEY_ABORT_CLEANUP_FAILED: ANDROID_SERIAL=$serial is not the one online device" >&2
+      return 1
+    fi
+    printf '%s\n' "$serial"
+    return 0
+  fi
+
+  if [[ "${#serials[@]}" -ne 1 ]]; then
+    echo "JOURNEY_ABORT_CLEANUP_FAILED: expected exactly one online device without ANDROID_SERIAL; found ${#serials[@]}" >&2
+    return 1
+  fi
+  printf '%s\n' "${serials[0]}"
+}
+
+journey_device_processes_for_packages() {
+  local serial="$1"
+  shift
+  local ps_output package
+
+  if ! ps_output="$(journey_adb -s "$serial" shell ps -A 2>&1)"; then
+    echo "JOURNEY_ABORT_CLEANUP_FAILED: could not inspect processes on $serial: $ps_output" >&2
+    return 2
+  fi
+
+  for package in "$@"; do
+    awk -v package="$package" '
+      {
+        name=$NF
+        if (name == package || index(name, package ":") == 1) {
+          print
+        }
+      }
+    ' <<< "$ps_output"
+  done
+}
+
+cleanup_device_after_class_abort() {
+  local module="$1"
+  local fqcn="$2"
+  local suffix="${3:-}"
+  local serial package process_output deadline
+  local force_stop_failed=0
+  local -a packages=()
+
+  mapfile -t packages < <(journey_target_package_names "$module" "$suffix") || return 1
+  [[ "${#packages[@]}" -gt 0 ]] || {
+    echo "JOURNEY_ABORT_CLEANUP_FAILED: no exact packages resolved for $fqcn" >&2
+    return 1
+  }
+  serial="$(journey_resolve_device_serial)" || return 1
+
+  echo "JOURNEY_ABORT_DEVICE_CLEANUP: force-stopping exact $module packages on $serial before retry: ${packages[*]}"
+  for package in "${packages[@]}"; do
+    if ! journey_adb -s "$serial" shell am force-stop "$package"; then
+      echo "JOURNEY_ABORT_CLEANUP_FAILED: force-stop failed for exact package $package on $serial" >&2
+      force_stop_failed=1
+    fi
+  done
+
+  deadline=$((SECONDS + ${JOURNEY_DEVICE_CLEANUP_TIMEOUT_SECS:-15}))
+  while :; do
+    process_output="$(journey_device_processes_for_packages "$serial" "${packages[@]}")"
+    case $? in
+      0)
+        if [[ -z "$process_output" ]]; then
+          if [[ "$force_stop_failed" -ne 0 ]]; then
+            echo "JOURNEY_ABORT_CLEANUP_FAILED: process absence was observed but an exact force-stop command failed for $fqcn" >&2
+            return 1
+          fi
+          echo "JOURNEY_ABORT_DEVICE_CLEANUP_VERIFIED: no instrumentation/test/app process remains for $fqcn on $serial"
+          return 0
+        fi
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+
+    if (( SECONDS >= deadline )); then
+      echo "JOURNEY_ABORT_CLEANUP_FAILED: stale exact package process remains after abort for $fqcn:" >&2
+      printf '%s\n' "$process_output" >&2
+      return 1
+    fi
+    # Bounded verification pump, not a fixed correctness sleep: every turn
+    # re-checks the load-bearing process-absence condition until its hard wall.
+    sleep 0.2
+  done
+}
+
+journey_module_build_roots() {
+  local module="$1"
+  local suffix="${2:-}"
+  local module_dir
+
+  case "$module" in
+    app) module_dir="$REPO_ROOT/app" ;;
+    core-terminal) module_dir="$REPO_ROOT/shared/core-terminal" ;;
+    *) return 2 ;;
+  esac
+
+  printf '%s\n' "$module_dir/build"
+  if [[ -n "$suffix" ]]; then
+    [[ "$suffix" =~ ^[A-Za-z0-9._]+$ ]] || return 2
+    printf '%s\n' "$module_dir/build/lane-$suffix"
+  fi
+}
+
+clear_connected_test_outputs() {
+  local module="$1"
+  local suffix="${2:-}"
+  local build_root
+  local -a build_roots=()
+
+  mapfile -t build_roots < <(journey_module_build_roots "$module" "$suffix") || return 1
+  for build_root in "${build_roots[@]}"; do
+    # Exact generated report roots only. Clearing them before the invocation
+    # makes every later snapshot attributable to this attempt, never stale.
+    rm -rf -- \
+      "$build_root/reports/androidTests" \
+      "$build_root/outputs/androidTest-results" \
+      "$build_root/outputs/connected_android_test_additional_output" \
+      || return 1
+  done
+}
+
+begin_class_attempt_artifacts() {
+  local module="$1"
+  local fqcn="$2"
+  local suffix="${3:-}"
+  local key="$module:$fqcn"
+  local attempt=$(( ${JOURNEY_CLASS_ATTEMPT_COUNTS[$key]:-0} + 1 ))
+  local artifact_key
+
+  JOURNEY_CLASS_ATTEMPT_COUNTS["$key"]="$attempt"
+  artifact_key="$(journey_class_artifact_key "$fqcn")" || return 1
+  LAST_RUN_CLASS_ATTEMPT_DIR="$ARTIFACT_DIR/class-attempts/$module/$artifact_key/attempt-$attempt"
+  LAST_RUN_CLASS_MODULE="$module"
+  LAST_RUN_CLASS_SELECTOR="$fqcn"
+  LAST_RUN_CLASS_ATTEMPT="$attempt"
+  LAST_RUN_CLASS_PRIMARY_CLASSIFICATION=""
+  LAST_RUN_CLASS_RAW_JUNIT_STATUS=""
+  LAST_RUN_CLASS_RAW_JUNIT_COUNT=0
+  LAST_RUN_CLASS_SNAPSHOT_STATUS=""
+  rm -rf -- "$LAST_RUN_CLASS_ATTEMPT_DIR" || return 1
+  mkdir -p "$LAST_RUN_CLASS_ATTEMPT_DIR" || return 1
+  : > "$LAST_RUN_CLASS_ATTEMPT_DIR/attempt.log" || return 1
+
+  {
+    printf 'format_version=1\n'
+    printf 'module=%s\n' "$module"
+    printf 'class=%s\n' "$fqcn"
+    printf 'attempt=%s\n' "$attempt"
+    printf 'started_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'application_id_suffix=%s\n' "$suffix"
+    printf 'status=running\n'
+  } > "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt" || return 1
+
+  if ! clear_connected_test_outputs "$module" "$suffix"; then
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: could not clear exact generated outputs for $module / $fqcn" >&2
+    return 1
+  fi
+
+  local serial
+  if ! serial="$(journey_resolve_device_serial)"; then
+    printf 'device_serial=unresolved\nlogcat_clear=unavailable\nstatus=artifact_setup_failed\n' \
+      >> "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt" 2>/dev/null || true
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: device identity is unresolved for $fqcn" >&2
+    return 1
+  fi
+  printf 'device_serial=%s\n' "$serial" >> "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt" \
+    || return 1
+  if ! journey_adb -s "$serial" logcat -c; then
+    printf 'logcat_clear=failed\nstatus=artifact_setup_failed\n' \
+      >> "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt" 2>/dev/null || true
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: could not reset logcat for $fqcn on $serial" >&2
+    return 1
+  fi
+  printf 'logcat_clear=ok\n' >> "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt" \
+    || return 1
+}
+
+capture_required_nonempty() {
+  local label="$1"
+  local destination="$2"
+  shift 2
+
+  if ! "$@" > "$destination" 2>&1; then
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: $label capture command failed" >&2
+    return 1
+  fi
+  if [[ ! -s "$destination" ]]; then
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: $label capture was empty" >&2
+    return 1
+  fi
+}
+
+validate_png_artifact() {
+  local source="$1"
+  local python_command="${PYTHON3:-python3}"
+
+  # Python 3 is present on the ubuntu-latest journey runner and is already a
+  # required repo-gate dependency. The validator uses only its standard library.
+  command -v "$python_command" >/dev/null 2>&1 || return 1
+  command "$python_command" -I - "$source" <<'PY'
+import binascii
+import struct
+import sys
+import zlib
+
+data = open(sys.argv[1], "rb").read()
+if data[:8] != b"\x89PNG\r\n\x1a\n":
+    raise SystemExit(1)
+
+offset = 8
+chunks = []
+idat = []
+ihdr = None
+seen_iend = False
+seen_plte = False
+idat_ended = False
+while offset < len(data):
+    if len(data) - offset < 12:
+        raise SystemExit(1)
+    length = struct.unpack(">I", data[offset:offset + 4])[0]
+    kind = data[offset + 4:offset + 8]
+    end = offset + 12 + length
+    if end > len(data) or len(kind) != 4 or not all(
+        65 <= byte <= 90 or 97 <= byte <= 122 for byte in kind
+    ):
+        raise SystemExit(1)
+    payload = data[offset + 8:offset + 8 + length]
+    stored_crc = struct.unpack(">I", data[offset + 8 + length:end])[0]
+    if binascii.crc32(kind + payload) & 0xFFFFFFFF != stored_crc:
+        raise SystemExit(1)
+    if not chunks and kind != b"IHDR":
+        raise SystemExit(1)
+    if kind == b"IHDR":
+        if chunks or length != 13 or ihdr is not None:
+            raise SystemExit(1)
+        ihdr = struct.unpack(">IIBBBBB", payload)
+    elif kind == b"IDAT":
+        if ihdr is None or idat_ended:
+            raise SystemExit(1)
+        idat.append(payload)
+    elif kind == b"PLTE":
+        if seen_plte or idat or length == 0 or length > 768 or length % 3 != 0:
+            raise SystemExit(1)
+        seen_plte = True
+    elif kind == b"IEND":
+        if length != 0 or not idat or end != len(data):
+            raise SystemExit(1)
+        seen_iend = True
+    elif idat:
+        idat_ended = True
+    if kind[0] & 0x20 == 0 and kind not in {
+        b"IHDR", b"PLTE", b"IDAT", b"IEND"
+    }:
+        raise SystemExit(1)
+    chunks.append(kind)
+    offset = end
+    if seen_iend:
+        break
+
+if not seen_iend or ihdr is None:
+    raise SystemExit(1)
+width, height, bit_depth, color_type, compression, filtering, interlace = ihdr
+valid_depths = {
+    0: {1, 2, 4, 8, 16},
+    2: {8, 16},
+    3: {1, 2, 4, 8},
+    4: {8, 16},
+    6: {8, 16},
+}
+if (
+    width == 0
+    or height == 0
+    or bit_depth not in valid_depths.get(color_type, set())
+    or compression != 0
+    or filtering != 0
+    or interlace not in {0, 1}
+):
+    raise SystemExit(1)
+if color_type == 3 and not seen_plte:
+    raise SystemExit(1)
+
+decoder = zlib.decompressobj()
+try:
+    pixels = decoder.decompress(b"".join(idat)) + decoder.flush()
+except zlib.error:
+    raise SystemExit(1)
+if not decoder.eof or decoder.unused_data or decoder.unconsumed_tail:
+    raise SystemExit(1)
+
+channels = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}[color_type]
+bits_per_pixel = channels * bit_depth
+passes = [(0, 0, 1, 1)]
+if interlace == 1:
+    passes = [
+        (0, 0, 8, 8), (4, 0, 8, 8), (0, 4, 4, 8), (2, 0, 4, 4),
+        (0, 2, 2, 4), (1, 0, 2, 2), (0, 1, 1, 2),
+    ]
+cursor = 0
+for x_start, y_start, x_step, y_step in passes:
+    pass_width = max(0, (width - x_start + x_step - 1) // x_step)
+    pass_height = max(0, (height - y_start + y_step - 1) // y_step)
+    if pass_width == 0 or pass_height == 0:
+        continue
+    row_bytes = (pass_width * bits_per_pixel + 7) // 8
+    for _ in range(pass_height):
+        if cursor >= len(pixels) or pixels[cursor] > 4:
+            raise SystemExit(1)
+        cursor += 1 + row_bytes
+if cursor != len(pixels):
+    raise SystemExit(1)
+PY
+}
+
+capture_required_png() {
+  local destination="$1"
+  shift
+
+  capture_required_nonempty "fallback screenshot" "$destination" "$@" || return 1
+  if ! validate_png_artifact "$destination"; then
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: fallback screenshot is not a structurally valid PNG" >&2
+    return 1
+  fi
+}
+
+snapshot_connected_test_outputs() {
+  local module="$1"
+  local fqcn="$2"
+  local primary_rc="$3"
+  local suffix="${4:-}"
+  local attempt_dir="$LAST_RUN_CLASS_ATTEMPT_DIR"
+  local build_root source_path relative_path destination serial
+  local copied=0
+  local snapshot_failed=0
+  local raw_junit_count=0
+  local raw_junit_status
+  local primary_classification
+  local -a build_roots=()
+
+  mapfile -t build_roots < <(journey_module_build_roots "$module" "$suffix") || return 1
+  for build_root in "${build_roots[@]}"; do
+    for source_path in \
+      "$build_root/reports/androidTests" \
+      "$build_root/outputs/androidTest-results" \
+      "$build_root/outputs/connected_android_test_additional_output"; do
+      [[ -e "$source_path" ]] || continue
+      relative_path="${source_path#"$REPO_ROOT"/}"
+      destination="$attempt_dir/android-test-outputs/$relative_path"
+      mkdir -p "$(dirname "$destination")" || {
+        snapshot_failed=1
+        continue
+      }
+      if cp -a "$source_path" "$destination"; then
+        copied=$((copied + 1))
+      else
+        snapshot_failed=1
+      fi
+    done
+  done
+  if (( copied == 0 )); then
+    printf 'No connected-test report/output directories were produced by this attempt.\n' \
+      > "$attempt_dir/android-test-outputs-missing.txt" || snapshot_failed=1
+  fi
+
+  if [[ -d "$attempt_dir/android-test-outputs" ]]; then
+    raw_junit_count="$(
+      find "$attempt_dir/android-test-outputs" -type f -name 'TEST-*.xml' -print \
+        | wc -l
+    )" || snapshot_failed=1
+    raw_junit_count="${raw_junit_count//[[:space:]]/}"
+  fi
+  [[ "$raw_junit_count" =~ ^[0-9]+$ ]] || {
+    raw_junit_count=0
+    snapshot_failed=1
+  }
+  if (( raw_junit_count > 0 )); then
+    raw_junit_status="present"
+  elif is_timeout_rc "$primary_rc"; then
+    raw_junit_status="absent_by_outer_timeout"
+  else
+    raw_junit_status="absent"
+  fi
+  if [[ "$primary_rc" -eq 0 ]]; then
+    primary_classification="pass"
+  elif is_timeout_rc "$primary_rc"; then
+    primary_classification="outer_timeout"
+  else
+    primary_classification="failure"
+  fi
+
+  if serial="$(journey_resolve_device_serial)"; then
+    if capture_required_nonempty \
+        "device logcat" "$attempt_dir/device-logcat.txt" \
+        journey_adb -s "$serial" logcat -d -v threadtime; then
+      printf 'device_logcat=ok\n' >> "$attempt_dir/manifest.txt" \
+        || snapshot_failed=1
+    else
+      printf 'device_logcat=failed\n' >> "$attempt_dir/manifest.txt" 2>/dev/null \
+        || true
+      snapshot_failed=1
+    fi
+
+    if [[ "$primary_rc" -ne 0 ]]; then
+      capture_required_nonempty \
+        "device process list" "$attempt_dir/device-processes.txt" \
+        journey_adb -s "$serial" shell ps -A \
+        || snapshot_failed=1
+      capture_required_nonempty \
+        "activity processes" "$attempt_dir/activity-processes.txt" \
+        journey_adb -s "$serial" shell dumpsys activity processes \
+        || snapshot_failed=1
+      capture_required_nonempty \
+        "activity top" "$attempt_dir/activity-top.txt" \
+        journey_adb -s "$serial" shell dumpsys activity top \
+        || snapshot_failed=1
+      if capture_required_png \
+          "$attempt_dir/failure-screen.png" \
+          journey_adb -s "$serial" exec-out screencap -p; then
+        printf 'fallback_screenshot=ok\n' >> "$attempt_dir/manifest.txt" \
+          || snapshot_failed=1
+      else
+        printf 'fallback_screenshot=failed\n' >> "$attempt_dir/manifest.txt" 2>/dev/null \
+          || true
+        snapshot_failed=1
+      fi
+    fi
+  else
+    printf 'device_logcat=unavailable\n' >> "$attempt_dir/manifest.txt" 2>/dev/null \
+      || true
+    snapshot_failed=1
+    if [[ "$primary_rc" -ne 0 ]]; then
+      printf 'Device unavailable for post-failure diagnostics.\n' \
+        > "$attempt_dir/device-diagnostics-missing.txt" || snapshot_failed=1
+    fi
+  fi
+
+  {
+    printf 'primary_exit_code=%s\n' "$primary_rc"
+    printf 'primary_classification=%s\n' "$primary_classification"
+    printf 'raw_junit_status=%s\n' "$raw_junit_status"
+    printf 'raw_junit_count=%s\n' "$raw_junit_count"
+    printf 'snapshotted_output_roots=%s\n' "$copied"
+    printf 'snapshot_status=%s\n' "$([[ "$snapshot_failed" -eq 0 ]] && printf complete || printf failed)"
+  } >> "$attempt_dir/manifest.txt" || snapshot_failed=1
+
+  LAST_RUN_CLASS_PRIMARY_CLASSIFICATION="$primary_classification"
+  LAST_RUN_CLASS_RAW_JUNIT_STATUS="$raw_junit_status"
+  LAST_RUN_CLASS_RAW_JUNIT_COUNT="$raw_junit_count"
+  LAST_RUN_CLASS_SNAPSHOT_STATUS="$(
+    [[ "$snapshot_failed" -eq 0 ]] && printf complete || printf failed
+  )"
+
+  if (( snapshot_failed != 0 )); then
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: could not preserve every existing output for $fqcn" >&2
+    return 1
+  fi
+  echo "JOURNEY_ATTEMPT_ARTIFACT_SNAPSHOT: $fqcn -> ${attempt_dir#"$REPO_ROOT"/}"
+}
+
+write_harness_verdict_xml() {
+  local destination="$1"
+  local cleanup_status="$2"
+  local final_status="$3"
+  local python_command="${PYTHON3:-python3}"
+
+  command -v "$python_command" >/dev/null 2>&1 || return 1
+  command "$python_command" -I - \
+    "$destination" \
+    "$LAST_RUN_CLASS_SELECTOR" \
+    "$LAST_RUN_CLASS_MODULE" \
+    "$LAST_RUN_CLASS_ATTEMPT" \
+    "$LAST_RUN_CLASS_PRIMARY_RC" \
+    "$LAST_RUN_CLASS_PRIMARY_CLASSIFICATION" \
+    "$LAST_RUN_CLASS_RAW_JUNIT_STATUS" \
+    "$LAST_RUN_CLASS_RAW_JUNIT_COUNT" \
+    "$LAST_RUN_CLASS_SNAPSHOT_STATUS" \
+    "$cleanup_status" \
+    "$final_status" <<'PY'
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+(
+    destination,
+    selector,
+    module,
+    attempt,
+    primary_rc,
+    classification,
+    raw_status,
+    raw_count,
+    snapshot_status,
+    cleanup_status,
+    final_status,
+) = sys.argv[1:]
+
+root = ET.Element("journey-harness-result", {"format-version": "1"})
+for tag, value in (
+    ("selector", selector),
+    ("module", module),
+    ("attempt", attempt),
+    ("primary-exit-code", primary_rc),
+    ("classification", classification),
+):
+    ET.SubElement(root, tag).text = value
+ET.SubElement(root, "raw-junit", {"status": raw_status, "count": raw_count})
+ET.SubElement(root, "snapshot", {"status": snapshot_status})
+ET.SubElement(root, "cleanup", {"status": cleanup_status})
+ET.SubElement(root, "final-status").text = final_status
+
+directory = os.path.dirname(destination)
+fd, temporary = tempfile.mkstemp(prefix=".journey-harness-verdict.", suffix=".tmp", dir=directory)
+try:
+    with os.fdopen(fd, "wb") as output:
+        ET.ElementTree(root).write(output, encoding="utf-8", xml_declaration=True)
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temporary, destination)
+except BaseException:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+    raise
+PY
+}
+
+validate_harness_verdict_xml() {
+  local source="$1"
+  local cleanup_status="$2"
+  local final_status="$3"
+  local python_command="${PYTHON3:-python3}"
+
+  [[ -s "$source" ]] || return 1
+  command -v "$python_command" >/dev/null 2>&1 || return 1
+  command "$python_command" -I - \
+    "$source" \
+    "$LAST_RUN_CLASS_SELECTOR" \
+    "$LAST_RUN_CLASS_MODULE" \
+    "$LAST_RUN_CLASS_ATTEMPT" \
+    "$LAST_RUN_CLASS_PRIMARY_RC" \
+    "$LAST_RUN_CLASS_PRIMARY_CLASSIFICATION" \
+    "$LAST_RUN_CLASS_RAW_JUNIT_STATUS" \
+    "$LAST_RUN_CLASS_RAW_JUNIT_COUNT" \
+    "$LAST_RUN_CLASS_SNAPSHOT_STATUS" \
+    "$cleanup_status" \
+    "$final_status" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+(
+    source,
+    selector,
+    module,
+    attempt,
+    primary_rc,
+    classification,
+    raw_status,
+    raw_count,
+    snapshot_status,
+    cleanup_status,
+    final_status,
+) = sys.argv[1:]
+
+root = ET.parse(source).getroot()
+assert root.tag == "journey-harness-result"
+assert root.attrib == {"format-version": "1"}
+assert root.findtext("selector") == selector
+assert root.findtext("module") == module
+assert root.findtext("attempt") == attempt
+assert root.findtext("primary-exit-code") == primary_rc
+assert root.findtext("classification") == classification
+assert root.find("raw-junit").attrib == {"status": raw_status, "count": raw_count}
+assert root.find("snapshot").attrib == {"status": snapshot_status}
+assert root.find("cleanup").attrib == {"status": cleanup_status}
+assert root.findtext("final-status") == final_status
+assert len(root) == 9
+PY
+}
+
+finalize_class_attempt_manifest() {
+  local cleanup_status="$1"
+  local final_status="$2"
+  local manifest="$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt"
+  local verdict="$LAST_RUN_CLASS_ATTEMPT_DIR/journey-harness-verdict.xml"
+
+  write_harness_verdict_xml "$verdict" "$cleanup_status" "$final_status" \
+    || return 1
+  validate_harness_verdict_xml "$verdict" "$cleanup_status" "$final_status" \
+    || return 1
+  {
+    printf 'harness_verdict_kind=harness_owned\n'
+    printf 'harness_verdict_xml=journey-harness-verdict.xml\n'
+    printf 'harness_verdict_status=complete\n'
+    printf 'cleanup_status=%s\n' "$cleanup_status"
+    printf 'gradle_cleanup_exit_code=%s\n' "$LAST_RUN_CLASS_GRADLE_CLEANUP_RC"
+    printf 'device_cleanup_exit_code=%s\n' "$LAST_RUN_CLASS_DEVICE_CLEANUP_RC"
+    printf 'status=%s\n' "$final_status"
+    printf 'finished_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } >> "$manifest" || return 1
+
+  [[ -s "$manifest" ]] \
+    && [[ -s "$verdict" ]] \
+    && grep -Fqx "cleanup_status=$cleanup_status" "$manifest" \
+    && grep -Fqx "status=$final_status" "$manifest" \
+    && grep -Fqx "harness_verdict_kind=harness_owned" "$manifest" \
+    && grep -Fqx "harness_verdict_status=complete" "$manifest"
 }
 
 # run_bounded <wall_cap_secs> <cmd...> — issue #1056.
@@ -69,6 +773,9 @@ run_bounded() {
   while :; do
     if IFS= read -r -t "$no_output" -u "$rfd" line; then
       printf '%s\n' "$line"
+      if [[ -n "${JOURNEY_CURRENT_ATTEMPT_LOG:-}" ]]; then
+        printf '%s\n' "$line" >> "$JOURNEY_CURRENT_ATTEMPT_LOG"
+      fi
     else
       read_rc=$?
       break
@@ -78,6 +785,10 @@ run_bounded() {
 
   if (( read_rc > 128 )); then
     echo "JOURNEY_NO_OUTPUT_WATCHDOG: no output for ${no_output}s — hard-killing wedged connectedDebugAndroidTest (issue #1056)" >&2
+    if [[ -n "${JOURNEY_CURRENT_ATTEMPT_LOG:-}" ]]; then
+      printf 'JOURNEY_NO_OUTPUT_WATCHDOG: no output for %ss\n' "$no_output" \
+        >> "$JOURNEY_CURRENT_ATTEMPT_LOG"
+    fi
     kill -TERM "$to_pid" 2>/dev/null || true
     ( sleep "$JOURNEY_CLASS_KILL_AFTER_SECS"; kill -KILL "$to_pid" 2>/dev/null || true ) &
     killer=$!
@@ -98,9 +809,28 @@ run_bounded() {
 # invocation and returns gradle's exit code (0 == that class passed).
 run_class() {
   local fqcn="$1"
-  local remaining cap rc attempt_start attempt_elapsed
+  local remaining cap rc attempt_start attempt_elapsed cleanup_status
+  local app_id_suffix="${POCKETSHELL_APP_ID_SUFFIX:-}"
+  local -a app_id_args=()
+  if [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]]; then
+    return "$JOURNEY_HARNESS_FAILURE_RC"
+  fi
   LAST_RUN_CLASS_TIMEOUT_HIT=0
   LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=0
+  LAST_RUN_CLASS_PRIMARY_RC=0
+  LAST_RUN_CLASS_ABORT_CLEANUP_FAILED=0
+  LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=0
+  LAST_RUN_CLASS_GRADLE_CLEANUP_RC="not_run"
+  LAST_RUN_CLASS_DEVICE_CLEANUP_RC="not_run"
+  if [[ -n "$app_id_suffix" ]]; then
+    [[ "$app_id_suffix" =~ ^[A-Za-z0-9._]+$ ]] || {
+      echo "JOURNEY_INVOCATION_IDENTITY_FAILED: invalid application id suffix '$app_id_suffix'" >&2
+      LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
+      JOURNEY_ABORT_ISOLATION_FAILED=1
+      return "$JOURNEY_HARNESS_FAILURE_RC"
+    }
+    app_id_args+=("-PpocketshellAppIdSuffix=$app_id_suffix")
+  fi
   remaining="$(budget_remaining)"
   cap="$JOURNEY_CLASS_TIMEOUT_SECS"
   (( remaining < cap )) && cap="$remaining"
@@ -109,18 +839,26 @@ run_class() {
     LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=1
     return 124
   fi
+  if ! begin_class_attempt_artifacts app "$fqcn" "$app_id_suffix"; then
+    LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
+    JOURNEY_ABORT_ISOLATION_FAILED=1
+    return "$JOURNEY_HARNESS_FAILURE_RC"
+  fi
+  JOURNEY_CURRENT_ATTEMPT_LOG="$LAST_RUN_CLASS_ATTEMPT_DIR/attempt.log"
   attempt_start=$SECONDS
   # Issue #1458: --max-workers=2 (parity with the Unit job) bounds Gradle's
   # worker fan-out while the emulator and Docker fixtures share the runner. The
   # Gradle DAEMON is still reused (no --no-daemon), preserving the #835 budget-fit.
   run_bounded "$cap" \
     "$GRADLEW" :app:connectedDebugAndroidTest \
+    "${app_id_args[@]}" \
     --max-workers=2 \
     -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
     -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
     --stacktrace
   rc=$?
+  LAST_RUN_CLASS_PRIMARY_RC="$rc"
   attempt_elapsed=$((SECONDS - attempt_start))
   if [[ $rc -eq 124 || ( $rc -eq 137 && $attempt_elapsed -ge $cap ) ]]; then
     LAST_RUN_CLASS_TIMEOUT_HIT=1
@@ -128,8 +866,34 @@ run_class() {
   if budget_exhausted; then
     LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=1
   fi
+  if ! snapshot_connected_test_outputs app "$fqcn" "$rc" "$app_id_suffix"; then
+    LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
+    JOURNEY_ABORT_ISOLATION_FAILED=1
+  fi
+  cleanup_status="not_required"
   if needs_gradle_cleanup_after_class_abort "$rc"; then
+    cleanup_status="failed"
     cleanup_gradle_after_timeout "$fqcn"
+    LAST_RUN_CLASS_GRADLE_CLEANUP_RC=$?
+    cleanup_device_after_class_abort app "$fqcn" "$app_id_suffix"
+    LAST_RUN_CLASS_DEVICE_CLEANUP_RC=$?
+    if [[ "$LAST_RUN_CLASS_GRADLE_CLEANUP_RC" -eq 0 \
+          && "$LAST_RUN_CLASS_DEVICE_CLEANUP_RC" -eq 0 ]]; then
+      cleanup_status="verified_clean"
+    else
+      LAST_RUN_CLASS_ABORT_CLEANUP_FAILED=1
+      JOURNEY_ABORT_ISOLATION_FAILED=1
+    fi
+  fi
+  if ! finalize_class_attempt_manifest "$cleanup_status" \
+      "$([[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 0 ]] && printf complete || printf harness_failure)"; then
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: manifest finalization failed for $fqcn" >&2
+    LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
+    JOURNEY_ABORT_ISOLATION_FAILED=1
+  fi
+  JOURNEY_CURRENT_ATTEMPT_LOG=""
+  if [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]]; then
+    return "$JOURNEY_HARNESS_FAILURE_RC"
   fi
   return "$rc"
 }
@@ -139,9 +903,17 @@ run_class() {
 # SAME budget-capped timeout discipline as run_class.
 run_ct_class() {
   local fqcn="$1"
-  local remaining cap rc attempt_start attempt_elapsed
+  local remaining cap rc attempt_start attempt_elapsed cleanup_status
+  if [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]]; then
+    return "$JOURNEY_HARNESS_FAILURE_RC"
+  fi
   LAST_RUN_CLASS_TIMEOUT_HIT=0
   LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=0
+  LAST_RUN_CLASS_PRIMARY_RC=0
+  LAST_RUN_CLASS_ABORT_CLEANUP_FAILED=0
+  LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=0
+  LAST_RUN_CLASS_GRADLE_CLEANUP_RC="not_run"
+  LAST_RUN_CLASS_DEVICE_CLEANUP_RC="not_run"
   remaining="$(budget_remaining)"
   cap="$JOURNEY_CLASS_TIMEOUT_SECS"
   (( remaining < cap )) && cap="$remaining"
@@ -150,6 +922,12 @@ run_ct_class() {
     LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=1
     return 124
   fi
+  if ! begin_class_attempt_artifacts core-terminal "$fqcn" ""; then
+    LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
+    JOURNEY_ABORT_ISOLATION_FAILED=1
+    return "$JOURNEY_HARNESS_FAILURE_RC"
+  fi
+  JOURNEY_CURRENT_ATTEMPT_LOG="$LAST_RUN_CLASS_ATTEMPT_DIR/attempt.log"
   attempt_start=$SECONDS
   # Issue #1458: --max-workers=2 (parity with the Unit job + run_class) bounds
   # Gradle's worker fan-out while the proof shares the runner with the emulator.
@@ -160,6 +938,7 @@ run_ct_class() {
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
     --stacktrace
   rc=$?
+  LAST_RUN_CLASS_PRIMARY_RC="$rc"
   attempt_elapsed=$((SECONDS - attempt_start))
   if [[ $rc -eq 124 || ( $rc -eq 137 && $attempt_elapsed -ge $cap ) ]]; then
     LAST_RUN_CLASS_TIMEOUT_HIT=1
@@ -167,8 +946,34 @@ run_ct_class() {
   if budget_exhausted; then
     LAST_RUN_CLASS_BUDGET_EXHAUSTED_AFTER_ATTEMPT=1
   fi
+  if ! snapshot_connected_test_outputs core-terminal "$fqcn" "$rc" ""; then
+    LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
+    JOURNEY_ABORT_ISOLATION_FAILED=1
+  fi
+  cleanup_status="not_required"
   if needs_gradle_cleanup_after_class_abort "$rc"; then
+    cleanup_status="failed"
     cleanup_gradle_after_timeout "$fqcn"
+    LAST_RUN_CLASS_GRADLE_CLEANUP_RC=$?
+    cleanup_device_after_class_abort core-terminal "$fqcn" ""
+    LAST_RUN_CLASS_DEVICE_CLEANUP_RC=$?
+    if [[ "$LAST_RUN_CLASS_GRADLE_CLEANUP_RC" -eq 0 \
+          && "$LAST_RUN_CLASS_DEVICE_CLEANUP_RC" -eq 0 ]]; then
+      cleanup_status="verified_clean"
+    else
+      LAST_RUN_CLASS_ABORT_CLEANUP_FAILED=1
+      JOURNEY_ABORT_ISOLATION_FAILED=1
+    fi
+  fi
+  if ! finalize_class_attempt_manifest "$cleanup_status" \
+      "$([[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 0 ]] && printf complete || printf harness_failure)"; then
+    echo "JOURNEY_ATTEMPT_ARTIFACT_FAILED: manifest finalization failed for $fqcn" >&2
+    LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
+    JOURNEY_ABORT_ISOLATION_FAILED=1
+  fi
+  JOURNEY_CURRENT_ATTEMPT_LOG=""
+  if [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]]; then
+    return "$JOURNEY_HARNESS_FAILURE_RC"
   fi
   return "$rc"
 }

--- a/scripts/ci-journey-class-loop-functions.sh
+++ b/scripts/ci-journey-class-loop-functions.sh
@@ -63,6 +63,11 @@ run_journey_classes_with_retry() {
 
     run_class "$fqcn"
     rc=$?
+    if [[ "${JOURNEY_ABORT_ISOLATION_FAILED:-0}" -eq 1 ]]; then
+      echo "JOURNEY_ISOLATION_FAILURE: $fqcn primary_rc=${LAST_RUN_CLASS_PRIMARY_RC:-unknown} cleanup_failed=${LAST_RUN_CLASS_ABORT_CLEANUP_FAILED:-0} artifact_failed=${LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED:-0} — refusing every retry/next class because isolation is unproven"
+      FAILED_CLASSES+=("$fqcn")
+      break
+    fi
     if [[ $rc -eq 0 ]]; then
       echo "JOURNEY_PASS: $fqcn passed on attempt 1 (elapsed $((SECONDS - class_start))s)"
       PASSED_FIRST_TRY+=("$fqcn")
@@ -95,6 +100,11 @@ run_journey_classes_with_retry() {
 
     run_class "$fqcn"
     rc=$?
+    if [[ "${JOURNEY_ABORT_ISOLATION_FAILED:-0}" -eq 1 ]]; then
+      echo "JOURNEY_ISOLATION_FAILURE: $fqcn retry primary_rc=${LAST_RUN_CLASS_PRIMARY_RC:-unknown} cleanup_failed=${LAST_RUN_CLASS_ABORT_CLEANUP_FAILED:-0} artifact_failed=${LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED:-0} — refusing every next class because isolation is unproven"
+      FAILED_CLASSES+=("$fqcn")
+      break
+    fi
     if [[ $rc -eq 0 ]]; then
       # Loud, greppable recovery marker so masked flakes stay visible and a
       # degrading trend is detectable in the CI logs.

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -218,12 +218,126 @@ STUBBIN="$SANDBOX/stubbin"
 mkdir -p "$STUBBIN"
 cat > "$STUBBIN/adb" <<'STUB'
 #!/usr/bin/env bash
-# `adb devices` -> emit one fake device so the show_ime loop iterates once and
-# `adb -s <serial> shell ...` -> no-op success.
-case "$1" in
-  devices) printf 'List of devices attached\nemulator-5554\tdevice\n' ;;
-  *) exit 0 ;;
+set -u
+
+emit_valid_png() {
+  # Real 1x1 RGBA PNG: signature + CRC-valid IHDR/IDAT/IEND chunks with a
+  # complete zlib stream. Keep positives decoder-valid so structural checks
+  # cannot be masked by signature-only fixtures.
+  printf '\211\120\116\107\015\012\032\012\000\000\000\015\111\110\104\122\000\000\000\001\000\000\000\001\010\006\000\000\000\037\025\304\211\000\000\000\015\111\104\101\124\170\234\143\140\140\140\370\017\000\001\004\001\000\137\345\303\113\000\000\000\000\111\105\116\104\256\102\140\202'
+}
+
+# `adb devices` -> emit one fake device so the show_ime loop iterates once.
+if [[ "${1:-}" == "devices" ]]; then
+  if [[ "${JOURNEY_ABORT_ADB_MODE:-}" == "unresolved-device" ]]; then
+    printf 'List of devices attached\n'
+    exit 0
+  fi
+  printf 'List of devices attached\nemulator-5554\tdevice\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "-s" ]]; then
+  serial="${2:-}"
+  shift 2
+  [[ "$serial" == "emulator-5554" ]] || exit 44
+fi
+
+# Most fixtures only need a harmless adb. The abort-isolation fixture below
+# opts into a stateful fake device through JOURNEY_ABORT_STUB_DIR.
+state_dir="${JOURNEY_ABORT_STUB_DIR:-}"
+if [[ -z "$state_dir" ]]; then
+  case "${1:-}" in
+    logcat)
+      [[ "${2:-}" == "-c" ]] || printf 'generic-device-logcat\n'
+      ;;
+    exec-out)
+      emit_valid_png
+      ;;
+    shell)
+      if [[ "${2:-}" == "ps" ]]; then
+        printf 'PID NAME\n'
+      elif [[ "${2:-}" == "dumpsys" ]]; then
+        printf 'generic dumpsys diagnostic\n'
+      fi
+      ;;
+  esac
+  exit 0
+fi
+mkdir -p "$state_dir"
+
+case "${1:-}" in
+  logcat)
+    if [[ "${2:-}" == "-c" ]]; then
+      [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "logcat-clear-fail" ]] || exit 47
+      : > "$state_dir/logcat-cleared"
+    else
+      [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "logcat-fail" ]] || exit 48
+      [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "logcat-empty" ]] || exit 0
+      printf 'device-logcat-%s\n' "$(cat "$state_dir/app-count" 2>/dev/null || printf '0')"
+    fi
+    ;;
+  exec-out)
+    [[ "${2:-}" == "screencap" && "${3:-}" == "-p" ]] || exit 45
+    [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "screenshot-fail" ]] || exit 49
+    [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "screenshot-empty" ]] || exit 0
+    if [[ "${JOURNEY_ABORT_ADB_MODE:-}" == "screenshot-invalid" ]]; then
+      printf 'not-a-png\n'
+      exit 0
+    fi
+    if [[ "${JOURNEY_ABORT_ADB_MODE:-}" == "screenshot-truncated" ]]; then
+      # Correct signature and a declared IHDR chunk, but truncated before the
+      # chunk payload/CRC. A magic-byte-only check incorrectly accepts this.
+      printf '\211PNG\r\n\032\n\000\000\000\015IHDR\000\000\000\001\000\000\000\001'
+      exit 0
+    fi
+    if [[ "${JOURNEY_ABORT_ADB_MODE:-}" == "screenshot-bad-crc" ]]; then
+      # Full chunk layout and decodable IDAT, but the IHDR CRC's final byte is
+      # deliberately changed from octal 211 to 210.
+      printf '\211\120\116\107\015\012\032\012\000\000\000\015\111\110\104\122\000\000\000\001\000\000\000\001\010\006\000\000\000\037\025\304\210\000\000\000\015\111\104\101\124\170\234\143\140\140\140\370\017\000\001\004\001\000\137\345\303\113\000\000\000\000\111\105\116\104\256\102\140\202'
+      exit 0
+    fi
+    emit_valid_png
+    ;;
+  shell)
+    shift
+    if [[ "${1:-}" == "am" && "${2:-}" == "force-stop" ]]; then
+      package="${3:-}"
+      printf '%s\n' "$package" >> "$state_dir/force-stop.log"
+      if [[ "$package" == "${JOURNEY_ABORT_FORCE_STOP_FAIL_PACKAGE:-}" ]]; then
+        exit 46
+      fi
+      if [[ -f "$state_dir/device-processes" ]]; then
+        awk -v package="$package" \
+          '$0 != package && index($0, package ":") != 1 { print }' \
+          "$state_dir/device-processes" > "$state_dir/device-processes.next"
+        mv "$state_dir/device-processes.next" "$state_dir/device-processes"
+      fi
+    elif [[ "${1:-}" == "ps" ]]; then
+      [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "ps-fail" ]] || exit 50
+      [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "ps-empty" ]] || exit 0
+      pid=4100
+      if [[ -f "$state_dir/device-processes" ]]; then
+        while IFS= read -r process_name; do
+          [[ -n "$process_name" ]] || continue
+          printf '%s %s\n' "$pid" "$process_name"
+          pid=$((pid + 1))
+        done < "$state_dir/device-processes"
+      fi
+    elif [[ "${1:-}" == "dumpsys" ]]; then
+      if [[ "${2:-}" == "activity" && "${3:-}" == "processes" ]]; then
+        [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "dumpsys-processes-fail" ]] || exit 51
+        [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "dumpsys-processes-empty" ]] || exit 0
+      fi
+      if [[ "${2:-}" == "activity" && "${3:-}" == "top" ]]; then
+        [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "dumpsys-top-fail" ]] || exit 52
+        [[ "${JOURNEY_ABORT_ADB_MODE:-}" != "dumpsys-top-empty" ]] || exit 0
+      fi
+      printf 'simulated dumpsys %s\n' "$*"
+    fi
+    ;;
 esac
+exit 0
 STUB
 chmod +x "$STUBBIN/adb"
 
@@ -617,6 +731,561 @@ if grep -q 'Cannot lock file hash cache' "$out_kill"; then
   fail "(j) retry still saw the simulated Gradle file-hash lock after SIGKILL timeout"
 fi
 pass "(j) SIGKILL timeout stops Gradle and retry avoids the poisoned file-hash lock"
+
+# ---------------------------------------------------------------------------
+# Issue #1458 exact-main abort contamination + artifact preservation.
+#
+# Attempt 1 wedges after installing a suffixed app/test pair and leaves both
+# processes alive on the simulated device. `gradlew --stop` deliberately does
+# NOT clear them. Attempt 2 refuses to run unless the harness force-stopped and
+# verified those exact packages first. A similarly prefixed neighbouring lane
+# must survive. Every later class overwrites the shared Gradle report locations,
+# so attempt 1/2 evidence can only survive in per-class, per-attempt snapshots.
+echo "== #1458 abort isolation: stale instrumentation is verified dead and attempt artifacts survive =="
+cat > "$SANDBOX/gradlew" <<'STUB'
+#!/usr/bin/env bash
+set -u
+
+state_dir="${JOURNEY_ABORT_STUB_DIR:?}"
+mkdir -p "$state_dir"
+printf '%s\n' "$*" >> "$state_dir/args.log"
+
+if [[ "${1:-}" == "--stop" ]]; then
+  printf 'stop\n' >> "$state_dir/stop.log"
+  exit 0
+fi
+
+if [[ "$*" == *":app:connectedDebugAndroidTest"* ]]; then
+  count="$(cat "$state_dir/app-count" 2>/dev/null || printf '0')"
+  count=$((count + 1))
+  printf '%s' "$count" > "$state_dir/app-count"
+  artifact_label="later-class-$count"
+  app_suffix=""
+  for arg in "$@"; do
+    case "$arg" in
+      -PpocketshellAppIdSuffix=*) app_suffix="${arg#*=}" ;;
+    esac
+  done
+  deep_count=0
+  if [[ "$*" == *"DeepLinkSessionSwitchE2eTest"* ]]; then
+    deep_count="$(cat "$state_dir/deep-count" 2>/dev/null || printf '0')"
+    deep_count=$((deep_count + 1))
+    printf '%s' "$deep_count" > "$state_dir/deep-count"
+    artifact_label="$deep_count"
+  fi
+
+  output_root="$PWD/app/build"
+  mkdir -p \
+    "$output_root/outputs/androidTest-results/connected/debug" \
+    "$output_root/outputs/connected_android_test_additional_output/debugAndroidTest/connected/fake-device/attempt" \
+    "$output_root/reports/androidTests/connected/debug"
+  # The first deep attempt models a real outer kill before UTP materializes
+  # JUnit XML. The retry and ordinary classes still emit raw instrumentation
+  # XML, which the harness must preserve separately from its own verdict.
+  if [[ "$deep_count" -ne 1 ]]; then
+    printf 'xml-attempt-%s\n' "$artifact_label" \
+      > "$output_root/outputs/androidTest-results/connected/debug/TEST-fake.xml"
+  fi
+  printf 'screenshot-attempt-%s\n' "$artifact_label" \
+    > "$output_root/outputs/connected_android_test_additional_output/debugAndroidTest/connected/fake-device/attempt/frame.png"
+  printf 'report-attempt-%s\n' "$artifact_label" \
+    > "$output_root/reports/androidTests/connected/debug/index.html"
+
+  if [[ "$deep_count" -eq 1 ]]; then
+    app_package="com.pocketshell.app"
+    if [[ -n "$app_suffix" ]]; then
+      app_package+=".$app_suffix"
+    fi
+    printf '%s\n' \
+      "$app_package.test" \
+      "$app_package" \
+      "$app_package"0.test \
+      > "$state_dir/device-processes"
+    # Silent outer-timeout wedge. The device processes are independent of this
+    # host child and therefore survive until exact package cleanup removes them.
+    sleep 30
+    exit 0
+  fi
+
+  if [[ "$deep_count" -eq 2 ]]; then
+    app_package="com.pocketshell.app"
+    if [[ -n "$app_suffix" ]]; then
+      app_package+=".$app_suffix"
+    fi
+    if grep -qxE "$app_package([.]test)?" \
+        "$state_dir/device-processes" 2>/dev/null; then
+      printf 'STALE_DEVICE_PROCESS_REACHED_RETRY\n' >&2
+      exit 91
+    fi
+  fi
+fi
+
+exit 0
+STUB
+chmod +x "$SANDBOX/gradlew"
+
+abort_stub_dir="$SANDBOX/abort-isolation-stub"
+mkdir -p "$abort_stub_dir"
+out_abort="$SANDBOX/run-abort-isolation.log"
+set +e
+PATH="$STUBBIN:$PATH" \
+  JOURNEY_ABORT_STUB_DIR="$abort_stub_dir" \
+  POCKETSHELL_APP_ID_SUFFIX=i1458 \
+  JOURNEY_STEP_BUDGET_SECS=600 \
+  JOURNEY_CLASS_TIMEOUT_SECS=30 \
+  JOURNEY_NO_OUTPUT_TIMEOUT_SECS=1 \
+  JOURNEY_CLASS_KILL_AFTER_SECS=1 \
+  JOURNEY_GRADLE_STOP_TIMEOUT_SECS=5 \
+  bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$out_abort" 2>&1
+rc_abort=$?
+set -e
+
+[[ "$rc_abort" -eq 0 ]] \
+  || { sed -n '1,180p' "$out_abort"; fail "(abort) isolated retry run exited $rc_abort; expected recovered success"; }
+grep -q -- '-PpocketshellAppIdSuffix=i1458' "$abort_stub_dir/args.log" \
+  || fail "(abort) suffixed cleanup identity was not bound to the Gradle invocation"
+grep -q 'JOURNEY_FLAKE_RECOVERED:.*DeepLinkSessionSwitchE2eTest' "$out_abort" \
+  || { sed -n '1,220p' "$out_abort"; fail "(abort) wedged attempt did not recover after verified device cleanup"; }
+if grep -q 'STALE_DEVICE_PROCESS_REACHED_RETRY' "$out_abort"; then
+  fail "(abort) retry started while stale instrumentation/app processes were alive"
+fi
+for exact_package in com.pocketshell.app.i1458.test com.pocketshell.app.i1458; do
+  grep -qx "$exact_package" "$abort_stub_dir/force-stop.log" \
+    || fail "(abort) exact package $exact_package was not force-stopped"
+done
+if grep -qx 'com.pocketshell.app' "$abort_stub_dir/force-stop.log" \
+    || grep -qx 'com.pocketshell.app.i14580.test' "$abort_stub_dir/force-stop.log"; then
+  fail "(abort) cleanup escaped the exact suffixed lane package boundary"
+fi
+grep -qx 'com.pocketshell.app.i14580.test' "$abort_stub_dir/device-processes" \
+  || fail "(abort) similarly prefixed neighbouring lane was killed"
+
+deep_class="com.pocketshell.app.proof.DeepLinkSessionSwitchE2eTest"
+deep_artifact_key="$(
+  bash -c 'source "$1"; journey_class_artifact_key "$2"' _ \
+    "$SCRIPT_DIR/ci-journey-budget-functions.sh" "$deep_class"
+)"
+attempt_root="$SANDBOX/artifacts/ci-journey/class-attempts/app/$deep_artifact_key"
+for attempt in 1 2; do
+  attempt_dir="$attempt_root/attempt-$attempt"
+  [[ -f "$attempt_dir/manifest.txt" ]] \
+    || fail "(artifacts) missing attempt-$attempt manifest"
+  [[ -f "$attempt_dir/attempt.log" ]] \
+    || fail "(artifacts) missing attempt-$attempt combined invocation log"
+  [[ -s "$attempt_dir/journey-harness-verdict.xml" ]] \
+    || fail "(artifacts) missing attempt-$attempt harness verdict XML"
+  [[ -f "$attempt_dir/android-test-outputs/app/build/reports/androidTests/connected/debug/index.html" ]] \
+    || fail "(artifacts) missing attempt-$attempt HTML report snapshot"
+  [[ -f "$attempt_dir/android-test-outputs/app/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/fake-device/attempt/frame.png" ]] \
+    || fail "(artifacts) missing attempt-$attempt screenshot/additional-output snapshot"
+  grep -q "screenshot-attempt-$attempt" \
+    "$attempt_dir/android-test-outputs/app/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/fake-device/attempt/frame.png" \
+    || fail "(artifacts) attempt-$attempt screenshot was overwritten by a later invocation"
+done
+attempt_1_raw_xml="$attempt_root/attempt-1/android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-fake.xml"
+attempt_2_raw_xml="$attempt_root/attempt-2/android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-fake.xml"
+[[ ! -e "$attempt_1_raw_xml" ]] \
+  || fail "(artifacts) timeout attempt unexpectedly impersonated missing raw instrumentation XML"
+[[ -f "$attempt_2_raw_xml" ]] \
+  || fail "(artifacts) retry raw JUnit XML was not preserved"
+grep -q 'xml-attempt-2' "$attempt_2_raw_xml" \
+  || fail "(artifacts) retry raw JUnit XML was overwritten by a later invocation"
+python3 - "$attempt_root" <<'PY' \
+  || fail "(artifacts) harness verdict XML type/content is invalid or attempts overwrote one another"
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+root = Path(sys.argv[1])
+expected = {
+    1: ("124", "outer_timeout", "absent_by_outer_timeout", "0", "verified_clean"),
+    2: ("0", "pass", "present", "1", "not_required"),
+}
+for attempt, values in expected.items():
+    xml_root = ET.parse(root / f"attempt-{attempt}" / "journey-harness-verdict.xml").getroot()
+    assert xml_root.tag == "journey-harness-result"
+    assert xml_root.attrib == {"format-version": "1"}
+    assert xml_root.findtext("selector") == "com.pocketshell.app.proof.DeepLinkSessionSwitchE2eTest"
+    assert xml_root.findtext("module") == "app"
+    assert xml_root.findtext("attempt") == str(attempt)
+    assert xml_root.findtext("primary-exit-code") == values[0]
+    assert xml_root.findtext("classification") == values[1]
+    assert xml_root.find("raw-junit").attrib == {"status": values[2], "count": values[3]}
+    assert xml_root.find("snapshot").attrib == {"status": "complete"}
+    assert xml_root.find("cleanup").attrib == {"status": values[4]}
+PY
+[[ -f "$attempt_root/attempt-1/device-logcat.txt" ]] \
+  || fail "(artifacts) timeout attempt is missing the stable device logcat snapshot"
+[[ -f "$attempt_root/attempt-1/failure-screen.png" ]] \
+  || fail "(artifacts) timeout attempt is missing the stable fallback screenshot"
+for diagnostic in device-processes.txt activity-processes.txt activity-top.txt; do
+  [[ -f "$attempt_root/attempt-1/$diagnostic" ]] \
+    || fail "(artifacts) timeout attempt is missing $diagnostic"
+done
+grep -q '^primary_exit_code=124$' "$attempt_root/attempt-1/manifest.txt" \
+  || fail "(artifacts) timeout manifest did not preserve the primary rc=124"
+grep -q '^application_id_suffix=i1458$' "$attempt_root/attempt-1/manifest.txt" \
+  || fail "(artifacts) timeout manifest did not preserve the bound invocation suffix"
+grep -q '^cleanup_status=verified_clean$' "$attempt_root/attempt-1/manifest.txt" \
+  || fail "(artifacts) timeout manifest did not record verified cleanup"
+grep -q '^primary_classification=outer_timeout$' "$attempt_root/attempt-1/manifest.txt" \
+  || fail "(artifacts) timeout manifest did not classify the outer timeout"
+grep -q '^raw_junit_status=absent_by_outer_timeout$' "$attempt_root/attempt-1/manifest.txt" \
+  || fail "(artifacts) timeout manifest silently waived absent raw JUnit"
+grep -q '^raw_junit_count=0$' "$attempt_root/attempt-1/manifest.txt" \
+  || fail "(artifacts) timeout manifest has the wrong raw JUnit count"
+grep -q '^primary_exit_code=0$' "$attempt_root/attempt-2/manifest.txt" \
+  || fail "(artifacts) retry manifest did not preserve primary rc=0"
+grep -q '^raw_junit_status=present$' "$attempt_root/attempt-2/manifest.txt" \
+  || fail "(artifacts) retry manifest did not distinguish preserved raw JUnit"
+grep -q '^raw_junit_count=1$' "$attempt_root/attempt-2/manifest.txt" \
+  || fail "(artifacts) retry manifest has the wrong raw JUnit count"
+pass "(abort) exact suffixed instrumentation/app processes are killed + verified before retry; neighbouring lane survives"
+pass "(artifacts) harness verdicts, raw JUnit distinction, reports, logcat, screenshots, diagnostics, logs and manifests survive later overwrites"
+
+# Ordinary instrumentation pass/failure XML remains raw evidence; the harness
+# result is a separately typed document and safely escapes hostile selectors.
+(
+  REPO_ROOT="$SANDBOX"
+  ARTIFACT_DIR="$SANDBOX/artifacts/ordinary-raw"
+  JOURNEY_ADB="$STUBBIN/adb"
+  JOURNEY_ABORT_STUB_DIR="$SANDBOX/ordinary-raw-state"
+  export JOURNEY_ABORT_STUB_DIR
+  mkdir -p "$JOURNEY_ABORT_STUB_DIR"
+  printf '%s\n' com.pocketshell.app.unrelated \
+    > "$JOURNEY_ABORT_STUB_DIR/device-processes"
+  source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+  selector='com.example.A<&"Test'
+  begin_class_attempt_artifacts app "$selector" "" || exit 120
+  mkdir -p "$REPO_ROOT/app/build/outputs/androidTest-results/connected/debug"
+  printf '<testsuite tests="1" failures="1"/>\n' \
+    > "$REPO_ROOT/app/build/outputs/androidTest-results/connected/debug/TEST-ordinary.xml"
+  LAST_RUN_CLASS_PRIMARY_RC=7
+  snapshot_connected_test_outputs app "$selector" 7 "" || exit 121
+  finalize_class_attempt_manifest not_required complete || exit 122
+  python3 - "$LAST_RUN_CLASS_ATTEMPT_DIR" "$selector" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+attempt = Path(sys.argv[1])
+selector = sys.argv[2]
+root = ET.parse(attempt / "journey-harness-verdict.xml").getroot()
+assert root.tag == "journey-harness-result"
+assert root.findtext("selector") == selector
+assert root.findtext("classification") == "failure"
+assert root.find("raw-junit").attrib == {"status": "present", "count": "1"}
+assert (attempt / "android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-ordinary.xml").is_file()
+PY
+) || fail "(artifacts) ordinary raw-JUnit failure or safely escaped harness verdict contract failed"
+pass "(artifacts) ordinary raw JUnit stays separate; failure classification and XML escaping are exact"
+
+# The failure half is load-bearing: if exact process absence cannot be proven,
+# the primary timeout remains in the manifest, cleanup is separately marked
+# failed, and NO retry or next app class may start.
+cleanup_fail_stub_dir="$SANDBOX/abort-cleanup-failure-stub"
+mkdir -p "$cleanup_fail_stub_dir"
+out_cleanup_fail="$SANDBOX/run-abort-cleanup-failure.log"
+set +e
+PATH="$STUBBIN:$PATH" \
+  JOURNEY_ABORT_STUB_DIR="$cleanup_fail_stub_dir" \
+  JOURNEY_ABORT_FORCE_STOP_FAIL_PACKAGE=com.pocketshell.app.test \
+  JOURNEY_STEP_BUDGET_SECS=600 \
+  JOURNEY_CLASS_TIMEOUT_SECS=30 \
+  JOURNEY_NO_OUTPUT_TIMEOUT_SECS=1 \
+  JOURNEY_CLASS_KILL_AFTER_SECS=1 \
+  JOURNEY_GRADLE_STOP_TIMEOUT_SECS=5 \
+  JOURNEY_DEVICE_CLEANUP_TIMEOUT_SECS=1 \
+  bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$out_cleanup_fail" 2>&1
+rc_cleanup_fail=$?
+set -e
+
+[[ "$rc_cleanup_fail" -ne 0 ]] \
+  || fail "(cleanup-fail) unproven isolation incorrectly exited green"
+grep -q 'JOURNEY_ISOLATION_FAILURE:.*primary_rc=124 cleanup_failed=1' "$out_cleanup_fail" \
+  || { sed -n '1,180p' "$out_cleanup_fail"; fail "(cleanup-fail) hard isolation failure did not preserve primary vs cleanup status"; }
+[[ "$(cat "$cleanup_fail_stub_dir/deep-count")" -eq 1 ]] \
+  || fail "(cleanup-fail) harness retried the wedged class despite unproven isolation"
+[[ "$(cat "$cleanup_fail_stub_dir/app-count")" -eq 2 ]] \
+  || fail "(cleanup-fail) harness launched another app class after unproven isolation"
+if grep -q -- '-PpocketshellAppIdSuffix=' "$cleanup_fail_stub_dir/args.log"; then
+  fail "(cleanup-fail) base-package invocation unexpectedly carried an application-id suffix"
+fi
+cleanup_fail_manifest="$SANDBOX/artifacts/ci-journey/class-attempts/app/$deep_artifact_key/attempt-1/manifest.txt"
+grep -q '^primary_exit_code=124$' "$cleanup_fail_manifest" \
+  || fail "(cleanup-fail) manifest lost the primary timeout rc"
+grep -q '^cleanup_status=failed$' "$cleanup_fail_manifest" \
+  || fail "(cleanup-fail) manifest did not separately record cleanup failure"
+grep -q '^device_cleanup_exit_code=1$' "$cleanup_fail_manifest" \
+  || fail "(cleanup-fail) manifest did not preserve the device cleanup rc"
+pass "(cleanup-fail) unproven process isolation hard-fails and blocks retry/next class while preserving primary+cleanup outcomes"
+
+# Package derivation itself is pinned at both boundaries. This prevents a
+# future cleanup rewrite from broad-matching every com.pocketshell.app.i* lane.
+mapfile -t base_packages < <(
+  bash -c 'source "$1"; journey_app_package_names ""' _ \
+    "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+)
+[[ "${base_packages[*]}" == "com.pocketshell.app.test com.pocketshell.app" ]] \
+  || fail "(packages) base package mapping is not exact: ${base_packages[*]}"
+mapfile -t suffixed_packages < <(
+  bash -c 'source "$1"; journey_app_package_names i1458' _ \
+    "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+)
+[[ "${suffixed_packages[*]}" == "com.pocketshell.app.i1458.test com.pocketshell.app.i1458" ]] \
+  || fail "(packages) suffixed package mapping is not exact: ${suffixed_packages[*]}"
+pass "(packages) base and suffixed lanes resolve only their exact test/app packages"
+
+# A failed force-stop remains a cleanup failure even if a later process-list
+# sample happens to be empty; absence alone cannot erase a failed command.
+(
+  JOURNEY_ADB="$STUBBIN/adb"
+  JOURNEY_ABORT_STUB_DIR="$SANDBOX/force-stop-command-failure"
+  JOURNEY_ABORT_FORCE_STOP_FAIL_PACKAGE=com.pocketshell.app.test
+  export JOURNEY_ABORT_STUB_DIR JOURNEY_ABORT_FORCE_STOP_FAIL_PACKAGE
+  mkdir -p "$JOURNEY_ABORT_STUB_DIR"
+  source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+  if cleanup_device_after_class_abort app "com.example.ForceStopFailureTest" ""; then
+    exit 69
+  fi
+) || fail "(packages) failed exact force-stop was erased by an empty process-list sample"
+pass "(packages) exact force-stop command failure stays fail-closed even when process absence is observed"
+
+# Every required per-attempt device capture is fail-closed. A command error,
+# unresolved device, empty output, or invalid screenshot must make the snapshot
+# fail so run_class can latch the harness and refuse the next invocation.
+echo "== #1458 artifact capture failures are never marked complete =="
+artifact_capture_must_fail() {
+  local mode="$1"
+  local primary_rc="$2"
+  local capture_state="$SANDBOX/capture-$mode"
+  mkdir -p "$capture_state"
+  printf '%s\n' com.pocketshell.app.test > "$capture_state/device-processes"
+
+  set +e
+  (
+    REPO_ROOT="$SANDBOX"
+    ARTIFACT_DIR="$SANDBOX/artifacts/capture-$mode"
+    JOURNEY_ADB="$STUBBIN/adb"
+    JOURNEY_ABORT_STUB_DIR="$capture_state"
+    export JOURNEY_ABORT_STUB_DIR
+    source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+    begin_class_attempt_artifacts app "com.example.CaptureFailureTest" "" \
+      || exit 70
+    export JOURNEY_ABORT_ADB_MODE="$mode"
+    if snapshot_connected_test_outputs \
+        app "com.example.CaptureFailureTest" "$primary_rc" ""; then
+      exit 71
+    fi
+    grep -q '^snapshot_status=failed$' \
+      "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt" || exit 78
+    if grep -q '^snapshot_status=complete$' \
+        "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt"; then
+      exit 79
+    fi
+  )
+  capture_rc=$?
+  set -e
+  [[ "$capture_rc" -eq 0 ]] \
+    || fail "(captures) mode=$mode was accepted or setup failed (rc=$capture_rc)"
+}
+
+for mode in logcat-fail logcat-empty; do
+  artifact_capture_must_fail "$mode" 0
+done
+for mode in \
+  ps-fail ps-empty \
+  dumpsys-processes-fail dumpsys-processes-empty \
+  dumpsys-top-fail dumpsys-top-empty \
+  screenshot-fail screenshot-empty screenshot-invalid \
+  screenshot-truncated screenshot-bad-crc; do
+  artifact_capture_must_fail "$mode" 124
+done
+
+(
+  REPO_ROOT="$SANDBOX"
+  ARTIFACT_DIR="$SANDBOX/artifacts/capture-unresolved"
+  JOURNEY_ADB="$STUBBIN/adb"
+  JOURNEY_ABORT_STUB_DIR="$SANDBOX/capture-unresolved"
+  JOURNEY_ABORT_ADB_MODE=unresolved-device
+  export JOURNEY_ABORT_ADB_MODE
+  mkdir -p "$JOURNEY_ABORT_STUB_DIR"
+  source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+  if begin_class_attempt_artifacts app "com.example.UnresolvedDeviceTest" ""; then
+    exit 72
+  fi
+) || fail "(captures) unresolved device did not fail closed before invocation"
+
+(
+  REPO_ROOT="$SANDBOX"
+  ARTIFACT_DIR="$SANDBOX/artifacts/capture-clear-fail"
+  JOURNEY_ADB="$STUBBIN/adb"
+  JOURNEY_ABORT_STUB_DIR="$SANDBOX/capture-clear-fail"
+  JOURNEY_ABORT_ADB_MODE=logcat-clear-fail
+  export JOURNEY_ABORT_ADB_MODE JOURNEY_ABORT_STUB_DIR
+  mkdir -p "$JOURNEY_ABORT_STUB_DIR"
+  source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+  if begin_class_attempt_artifacts app "com.example.LogcatClearFailureTest" ""; then
+    exit 73
+  fi
+) || fail "(captures) failed per-attempt logcat reset was not fail-closed"
+pass "(captures) command errors, empty content, invalid PNG, unresolved device and logcat-reset failure all fail closed"
+
+# run_class must propagate a manifest-finalization failure into the same hard
+# harness latch; returning the primary success would silently lose metadata.
+cat > "$SANDBOX/finalize-gradlew" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$SANDBOX/finalize-gradlew"
+(
+  REPO_ROOT="$SANDBOX"
+  ARTIFACT_DIR="$SANDBOX/artifacts/snapshot-failure"
+  GRADLEW="$SANDBOX/finalize-gradlew"
+  JOURNEY_ADB="$STUBBIN/adb"
+  JOURNEY_ABORT_STUB_DIR="$SANDBOX/snapshot-state"
+  JOURNEY_ABORT_ADB_MODE=logcat-fail
+  JOURNEY_STEP_BUDGET_SECS=30
+  JOURNEY_CLASS_TIMEOUT_SECS=10
+  JOURNEY_NO_OUTPUT_TIMEOUT_SECS=5
+  JOURNEY_CLASS_KILL_AFTER_SECS=1
+  JOURNEY_GRADLE_STOP_TIMEOUT_SECS=1
+  SUITE_START=$SECONDS
+  export JOURNEY_ABORT_STUB_DIR JOURNEY_ABORT_ADB_MODE
+  mkdir -p "$JOURNEY_ABORT_STUB_DIR"
+  source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+  set +e
+  run_class "com.example.SnapshotFailureTest" >/dev/null 2>&1
+  snapshot_rc=$?
+  set -e
+  [[ "$snapshot_rc" -eq "$JOURNEY_HARNESS_FAILURE_RC" ]] || exit 80
+  [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]] || exit 81
+  [[ "$LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED" -eq 1 ]] || exit 82
+) || fail "(captures) run_class ignored required snapshot-capture failure"
+pass "(captures) required snapshot failure hard-latches the harness and cannot return primary success"
+
+(
+  REPO_ROOT="$SANDBOX"
+  ARTIFACT_DIR="$SANDBOX/artifacts/finalize-failure"
+  GRADLEW="$SANDBOX/finalize-gradlew"
+  JOURNEY_ADB="$STUBBIN/adb"
+  JOURNEY_ABORT_STUB_DIR="$SANDBOX/finalize-state"
+  JOURNEY_STEP_BUDGET_SECS=30
+  JOURNEY_CLASS_TIMEOUT_SECS=10
+  JOURNEY_NO_OUTPUT_TIMEOUT_SECS=5
+  JOURNEY_CLASS_KILL_AFTER_SECS=1
+  JOURNEY_GRADLE_STOP_TIMEOUT_SECS=1
+  SUITE_START=$SECONDS
+  mkdir -p "$JOURNEY_ABORT_STUB_DIR"
+  source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+  finalize_class_attempt_manifest() { return 74; }
+  set +e
+  run_class "com.example.ManifestFinalizeFailureTest" >/dev/null 2>&1
+  finalize_rc=$?
+  set -e
+  [[ "$finalize_rc" -eq "$JOURNEY_HARNESS_FAILURE_RC" ]] || exit 75
+  [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]] || exit 76
+  [[ "$LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED" -eq 1 ]] || exit 77
+) || fail "(manifest) run_class ignored manifest-finalization failure"
+pass "(manifest) finalization failure hard-latches the harness and cannot return primary success"
+
+for verdict_failure_mode in synthesis malformed; do
+  (
+    REPO_ROOT="$SANDBOX"
+    ARTIFACT_DIR="$SANDBOX/artifacts/verdict-$verdict_failure_mode"
+    GRADLEW="$SANDBOX/finalize-gradlew"
+    JOURNEY_ADB="$STUBBIN/adb"
+    JOURNEY_ABORT_STUB_DIR="$SANDBOX/verdict-$verdict_failure_mode-state"
+    JOURNEY_STEP_BUDGET_SECS=30
+    JOURNEY_CLASS_TIMEOUT_SECS=10
+    JOURNEY_NO_OUTPUT_TIMEOUT_SECS=5
+    JOURNEY_CLASS_KILL_AFTER_SECS=1
+    JOURNEY_GRADLE_STOP_TIMEOUT_SECS=1
+    SUITE_START=$SECONDS
+    export JOURNEY_ABORT_STUB_DIR
+    mkdir -p "$JOURNEY_ABORT_STUB_DIR"
+    source "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+    if [[ "$verdict_failure_mode" == synthesis ]]; then
+      write_harness_verdict_xml() { return 74; }
+    else
+      write_harness_verdict_xml() {
+        printf '<journey-harness-result><broken>' > "$1"
+      }
+    fi
+    set +e
+    run_class "com.example.VerdictFailureTest" >/dev/null 2>&1
+    verdict_rc=$?
+    set -e
+    [[ "$verdict_rc" -eq "$JOURNEY_HARNESS_FAILURE_RC" ]] || exit 123
+    [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]] || exit 124
+    [[ "$LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED" -eq 1 ]] || exit 125
+    if grep -q '^harness_verdict_status=complete$' \
+        "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt"; then
+      exit 126
+    fi
+  ) || fail "(verdict) $verdict_failure_mode verdict failure did not hard-latch the harness"
+done
+pass "(verdict) synthesis and parse-back validation failures hard-latch without false finalization"
+
+# Mutation proof: removing the parse-back call must make this probe fail. This
+# demonstrates that malformed-writer coverage is load-bearing rather than
+# passing merely because synthesis happened to return nonzero.
+mutated_budget="$SANDBOX/ci-journey-budget-no-verdict-validation.sh"
+sed '/^[[:space:]]*validate_harness_verdict_xml "\$verdict"/,+1d' \
+  "$SCRIPT_DIR/ci-journey-budget-functions.sh" > "$mutated_budget"
+set +e
+(
+  source "$mutated_budget"
+  LAST_RUN_CLASS_ATTEMPT_DIR="$SANDBOX/mutated-verdict-attempt"
+  LAST_RUN_CLASS_SELECTOR="com.example.MutatedTest"
+  LAST_RUN_CLASS_MODULE=app
+  LAST_RUN_CLASS_ATTEMPT=1
+  LAST_RUN_CLASS_PRIMARY_RC=124
+  LAST_RUN_CLASS_PRIMARY_CLASSIFICATION=outer_timeout
+  LAST_RUN_CLASS_RAW_JUNIT_STATUS=absent_by_outer_timeout
+  LAST_RUN_CLASS_RAW_JUNIT_COUNT=0
+  LAST_RUN_CLASS_SNAPSHOT_STATUS=complete
+  mkdir -p "$LAST_RUN_CLASS_ATTEMPT_DIR"
+  : > "$LAST_RUN_CLASS_ATTEMPT_DIR/manifest.txt"
+  write_harness_verdict_xml() {
+    printf '<journey-harness-result><broken>' > "$1"
+  }
+  finalize_class_attempt_manifest verified_clean complete
+)
+mutation_rc=$?
+set -e
+[[ "$mutation_rc" -eq 0 ]] \
+  || fail "(verdict-mutation) validation-removal mutant did not demonstrate the malformed-XML escape"
+pass "(verdict-mutation) removing parse-back validation is detected by the malformed-writer regression"
+
+# Readable paths retain a stable hash of the full class selector. This separates
+# names that sanitize identically and makes hostile traversal characters inert.
+collision_a="$(
+  bash -c 'source "$1"; journey_class_artifact_key "com.example.A#method"' _ \
+    "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+)"
+collision_b="$(
+  bash -c 'source "$1"; journey_class_artifact_key "com.example.A_method"' _ \
+    "$SCRIPT_DIR/ci-journey-budget-functions.sh"
+)"
+[[ "$collision_a" != "$collision_b" ]] \
+  || fail "(paths) sanitized class collision produced one artifact key: $collision_a"
+for hostile_class in \
+  '../../com.example.A#method' \
+  '/absolute/path/Test' \
+  '.../../#'; do
+  hostile_key="$(
+    bash -c 'source "$1"; journey_class_artifact_key "$2"' _ \
+      "$SCRIPT_DIR/ci-journey-budget-functions.sh" "$hostile_class"
+  )"
+  [[ -n "$hostile_key" && "$hostile_key" != "." && "$hostile_key" != ".." ]] \
+    || fail "(paths) hostile class produced empty/dot artifact key"
+  [[ "$hostile_key" != */* ]] \
+    || fail "(paths) hostile class escaped into a nested path: $hostile_key"
+  [[ "$hostile_key" =~ --[0-9a-f]{16}$ ]] \
+    || fail "(paths) hostile class key lacks its stable collision-resistant hash: $hostile_key"
+done
+pass "(paths) colliding selectors separate; slash/absolute/traversal selectors stay one hashed safe component"
 
 echo "== Timeout cleanup: repeated SIGKILL timeout stays classified as timeout =="
 cat > "$SANDBOX/gradlew" <<'STUB'


### PR DESCRIPTION
## Summary

- bind abort cleanup to the exact suffixed app/test packages and verify their processes are absent before any retry
- preserve immutable per-attempt logs, UTP output, raw-versus-harness JUnit status, logcat, process diagnostics, and a structurally validated screenshot
- fail closed when cleanup, capture, verdict synthesis, or manifest finalization cannot be proven
- stop all later classes when attempt isolation is unproven

Refs #1458.

This intentionally does not close #1458; exact main must still reach a genuinely CLEAN semantic aggregate after the separately owned journey failures are fixed.

## Verification

- `bash scripts/test-ci-journey-budget.sh` — ALL TESTS PASSED
- `bash -n` on all three changed scripts
- `git diff --check`
- independent serialized emulator proof: timeout rc124, exact suffix cleanup, healthy neighbor suffix survival, immutable attempt-1 evidence, valid 1080x2400 PNG, then clean retry
- independent cold-timeout `absent_by_outer_timeout` proof and warm-timeout legitimate partial raw-JUnit proof
- independent reviewer approval: https://github.com/alexeygrigorev/pocketshell/issues/1458#issuecomment-5082827645
