### PR TITLE
ci: stop recursive journey artifact packaging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,6 +232,15 @@ jobs:
           chmod +x scripts/ci-journey-retry-budget.sh scripts/test-ci-journey-retry-budget.sh
           scripts/test-ci-journey-retry-budget.sh
 
+      # Issue #1781: fast, JVM-free artifact packaging fixture. Proves the
+      # first-cold-boot preservation scan keeps real module Android outputs and
+      # canonical per-attempt evidence without recursively nesting
+      # artifacts/ci-journey or artifacts/ci-journey-attempt-1.
+      - name: CI journey artifact packaging guard (issue #1781)
+        run: |
+          chmod +x scripts/ci-journey-preserve-android-outputs.sh scripts/test-ci-journey-artifact-packaging.sh
+          scripts/test-ci-journey-artifact-packaging.sh
+
       # Issue #1293: fast, JVM-free fixture test for the nightly-fault per-phase
       # test-report preservation helper (scripts/lib/nightly-phase-reports.sh).
       # The nightly-fault suite runs each phase as a separate connected-test
@@ -1026,20 +1035,7 @@ jobs:
             echo "artifacts/ci-journey/summary.md was missing after the first attempt." > "$snapshot/summary-missing.txt"
           fi
 
-          shopt -s globstar nullglob
-          copied_android_outputs=0
-          for path in **/build/reports/androidTests \
-                      **/build/outputs/androidTest-results \
-                      **/build/outputs/connected_android_test_additional_output; do
-            [[ -e "$path" ]] || continue
-            dest="$snapshot/android-test-outputs/$path"
-            mkdir -p "$(dirname "$dest")"
-            cp -a "$path" "$dest"
-            copied_android_outputs=1
-          done
-          if [[ "$copied_android_outputs" -eq 0 ]]; then
-            echo "No Android connected-test output directories existed after the first attempt." > "$snapshot/android-test-outputs-missing.txt"
-          fi
+          scripts/ci-journey-preserve-android-outputs.sh "$snapshot"
 
       # Issue #1458: the first attempt can consume 50–62 minutes, leaving too
       # little of the absolute 95-minute job wall for an unconditional second

--- a/scripts/ci-journey-preserve-android-outputs.sh
+++ b/scripts/ci-journey-preserve-android-outputs.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Preserve Android connected-test outputs from authoritative Gradle project
+# directories. Validate every source and destination before copying so symlinked
+# paths cannot escape the repository or recursively package artifacts.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="${CI_JOURNEY_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
+SETTINGS_FILE="${CI_JOURNEY_SETTINGS_FILE:-}"
+SETTINGS_PARSER="${CI_JOURNEY_SETTINGS_PARSER:-$SCRIPT_DIR/ci-journey-settings-project-dirs.py}"
+
+fail() {
+  echo "CI journey artifact preservation failed: $*" >&2
+  exit 1
+}
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: $0 <snapshot-directory>" >&2
+  exit 2
+fi
+
+[[ -d "$REPO_ROOT" ]] || fail "repository root is not a directory: $REPO_ROOT"
+repo_root="$(realpath -e -- "$REPO_ROOT")"
+[[ -n "$SETTINGS_FILE" ]] || SETTINGS_FILE="$repo_root/settings.gradle.kts"
+[[ -f "$SETTINGS_FILE" ]] || fail "Gradle settings file is missing: $SETTINGS_FILE"
+[[ -f "$SETTINGS_PARSER" ]] || fail "Gradle settings parser is missing: $SETTINGS_PARSER"
+
+path_has_symlink() {
+  local relative_path="$1"
+  local cursor="$repo_root"
+  local component
+  local -a components=()
+
+  [[ "$relative_path" == "." ]] && return 1
+  IFS='/' read -r -a components <<<"$relative_path"
+  for component in "${components[@]}"; do
+    cursor="$cursor/$component"
+    [[ -L "$cursor" ]] && return 0
+  done
+  return 1
+}
+
+validate_relative_path() {
+  local relative_path="$1"
+  local label="$2"
+  local component
+  local -a components=()
+
+  [[ -n "$relative_path" ]] || fail "$label is empty"
+  [[ "$relative_path" != /* ]] || fail "$label must be repository-relative: $relative_path"
+  [[ "$relative_path" != "." ]] || return 0
+
+  IFS='/' read -r -a components <<<"$relative_path"
+  for component in "${components[@]}"; do
+    [[ -n "$component" && "$component" != "." && "$component" != ".." ]] \
+      || fail "$label has an unsafe component: $relative_path"
+  done
+}
+
+validate_snapshot_write_path() {
+  local target="$1"
+  local relative
+  local cursor="$repo_root"
+  local canonical
+  local component
+  local -a components=()
+
+  case "$target" in
+    "$snapshot"|"$snapshot"/*) ;;
+    *) fail "destination escapes snapshot: $target" ;;
+  esac
+  relative="${target#"$repo_root/"}"
+  validate_relative_path "$relative" "snapshot destination"
+  path_has_symlink "$relative" \
+    && fail "snapshot destination has symlink ancestry: $relative"
+
+  IFS='/' read -r -a components <<<"$relative"
+  for component in "${components[@]}"; do
+    cursor="$cursor/$component"
+    [[ -e "$cursor" ]] || continue
+    canonical="$(realpath -e -- "$cursor")" \
+      || fail "snapshot destination ancestor cannot be canonicalized: $cursor"
+    case "$canonical" in
+      "$repo_root"|"$repo_root"/*) ;;
+      *) fail "snapshot destination ancestor escapes repository: $cursor -> $canonical" ;;
+    esac
+  done
+  if [[ -e "$target" ]]; then
+    canonical="$(realpath -e -- "$target")" \
+      || fail "snapshot destination cannot be canonicalized: $target"
+    case "$canonical" in
+      "$snapshot"|"$snapshot"/*) ;;
+      *) fail "snapshot destination escapes canonical snapshot: $target -> $canonical" ;;
+    esac
+  fi
+}
+
+snapshot_arg="$1"
+validate_relative_path "$snapshot_arg" "snapshot path"
+path_has_symlink "$snapshot_arg" \
+  && fail "snapshot path has symlink ancestry: $snapshot_arg"
+snapshot_abs="$(realpath -m -- "$repo_root/$snapshot_arg")"
+case "$snapshot_abs" in
+  "$repo_root"/*) ;;
+  *) fail "snapshot path escapes repository: $snapshot_arg" ;;
+esac
+[[ -d "$snapshot_abs" ]] || fail "snapshot directory does not exist: $snapshot_arg"
+snapshot="$snapshot_abs"
+
+declare -a source_paths=()
+declare -a destination_paths=()
+project_count=0
+
+project_inventory="$(mktemp)"
+trap 'rm -f "$project_inventory"' EXIT
+python3 "$SETTINGS_PARSER" "$SETTINGS_FILE" > "$project_inventory" \
+  || fail "could not derive Gradle project directories"
+
+while IFS= read -r -d '' project_dir; do
+  validate_relative_path "$project_dir" "Gradle projectDir"
+  path_has_symlink "$project_dir" \
+    && fail "Gradle projectDir has symlink ancestry: $project_dir"
+
+  project_abs="$(realpath -e -- "$repo_root/$project_dir")" \
+    || fail "Gradle projectDir does not exist: $project_dir"
+  case "$project_abs" in
+    "$repo_root"|"$repo_root"/*) ;;
+    *) fail "Gradle projectDir escapes repository: $project_dir -> $project_abs" ;;
+  esac
+  [[ -d "$project_abs" ]] || fail "Gradle projectDir is not a directory: $project_dir"
+  project_relative="$(realpath --relative-to="$repo_root" -- "$project_abs")"
+  project_count=$((project_count + 1))
+
+  build_abs="$project_abs/build"
+  [[ -e "$build_abs" ]] || continue
+  build_relative="${project_relative%/}/build"
+  [[ "$project_relative" == "." ]] && build_relative="build"
+  path_has_symlink "$build_relative" \
+    && fail "Gradle build path has symlink ancestry: $build_relative"
+  canonical_build="$(realpath -e -- "$build_abs")" \
+    || fail "Gradle build path cannot be canonicalized: $build_relative"
+  case "$canonical_build" in
+    "$repo_root"/*) ;;
+    *) fail "Gradle build path escapes repository: $build_relative -> $canonical_build" ;;
+  esac
+  [[ -d "$canonical_build" ]] || fail "Gradle build path is not a directory: $build_relative"
+
+  for output_path in \
+    reports/androidTests \
+    outputs/androidTest-results \
+    outputs/connected_android_test_additional_output; do
+    source_abs="$canonical_build/$output_path"
+    [[ -e "$source_abs" ]] || continue
+    source_relative="$build_relative/$output_path"
+    path_has_symlink "$source_relative" \
+      && fail "Android output path has symlink ancestry: $source_relative"
+    canonical_source="$(realpath -e -- "$source_abs")" \
+      || fail "Android output path cannot be canonicalized: $source_relative"
+    case "$canonical_source" in
+      "$repo_root"/*) ;;
+      *) fail "Android output path escapes repository: $source_relative -> $canonical_source" ;;
+    esac
+    [[ -d "$canonical_source" ]] || fail "Android output path is not a directory: $source_relative"
+    source_paths+=("$canonical_source")
+    destination_paths+=("$snapshot_abs/android-test-outputs/$source_relative")
+  done
+done < "$project_inventory"
+
+[[ "$project_count" -gt 0 ]] || fail "Gradle settings contain no project directories"
+
+validate_snapshot_write_path "$snapshot/android-test-outputs"
+for destination in "${destination_paths[@]}"; do
+  validate_snapshot_write_path "$destination"
+done
+
+if [[ "${#source_paths[@]}" -eq 0 ]]; then
+  validate_snapshot_write_path "$snapshot/android-test-outputs-missing.txt"
+  echo "No Android connected-test output directories existed after the first attempt." \
+    > "$snapshot/android-test-outputs-missing.txt"
+else
+  for index in "${!source_paths[@]}"; do
+    mkdir -p "$(dirname "${destination_paths[$index]}")"
+    cp -a "${source_paths[$index]}" "${destination_paths[$index]}"
+  done
+fi

--- a/scripts/ci-journey-settings-project-dirs.py
+++ b/scripts/ci-journey-settings-project-dirs.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Emit authoritative Gradle project directories from settings.gradle.kts.
+
+The supported repository contract is intentionally small and explicit:
+  include(":a", ":nested:b")
+  project(":a").projectDir = file("modules/a with spaces")
+
+Whitespace, comments, multiple include arguments, and multiline calls are
+supported. Any unsupported projectDir assignment fails closed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class ParseError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Token:
+    kind: str
+    value: str
+    offset: int
+
+
+PUNCTUATION = {"(": "LPAREN", ")": "RPAREN", ",": "COMMA", ".": "DOT", "=": "EQUALS"}
+PROJECT_PATH = re.compile(r"^:(?:[^:]+)(?::[^:]+)*$")
+
+
+def reject_embedded_nul(value: str, label: str) -> None:
+    if "\x00" in value:
+        raise ParseError(f"{label} contains an embedded NUL")
+
+
+def tokenize(source: str) -> list[Token]:
+    tokens: list[Token] = []
+    index = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        if char.isspace():
+            index += 1
+            continue
+        if source.startswith("//", index):
+            newline = source.find("\n", index + 2)
+            index = length if newline == -1 else newline + 1
+            continue
+        if source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            if end == -1:
+                raise ParseError(f"unterminated block comment at offset {index}")
+            index = end + 2
+            continue
+        if source.startswith('"""', index):
+            raise ParseError(f"triple-quoted strings are unsupported at offset {index}")
+        if char == '"':
+            start = index
+            index += 1
+            escaped = False
+            while index < length:
+                current = source[index]
+                if escaped:
+                    escaped = False
+                elif current == "\\":
+                    escaped = True
+                elif current == '"':
+                    index += 1
+                    literal = source[start:index]
+                    try:
+                        value = json.loads(literal)
+                    except json.JSONDecodeError as exc:
+                        raise ParseError(f"unsupported string literal at offset {start}: {exc}") from exc
+                    tokens.append(Token("STRING", value, start))
+                    break
+                index += 1
+            else:
+                raise ParseError(f"unterminated string at offset {start}")
+            continue
+        if char.isalpha() or char == "_":
+            start = index
+            index += 1
+            while index < length and (source[index].isalnum() or source[index] == "_"):
+                index += 1
+            tokens.append(Token("IDENT", source[start:index], start))
+            continue
+        kind = PUNCTUATION.get(char)
+        if kind is not None:
+            tokens.append(Token(kind, char, index))
+        else:
+            tokens.append(Token("OTHER", char, index))
+        index += 1
+    return tokens
+
+
+def expect(tokens: list[Token], index: int, kind: str, value: str | None = None) -> Token:
+    if index >= len(tokens):
+        raise ParseError(f"expected {value or kind}, reached end of settings")
+    token = tokens[index]
+    if token.kind != kind or (value is not None and token.value != value):
+        raise ParseError(
+            f"expected {value or kind} at offset {token.offset}, got {token.value!r}"
+        )
+    return token
+
+
+def parse_include(tokens: list[Token], index: int) -> tuple[list[str], int]:
+    expect(tokens, index, "IDENT", "include")
+    expect(tokens, index + 1, "LPAREN")
+    cursor = index + 2
+    paths: list[str] = []
+    expect_value = True
+    while cursor < len(tokens):
+        token = tokens[cursor]
+        if token.kind == "RPAREN":
+            if expect_value and paths:
+                # A trailing comma is valid Kotlin.
+                return paths, cursor + 1
+            if not paths:
+                raise ParseError(f"empty include() at offset {tokens[index].offset}")
+            return paths, cursor + 1
+        if expect_value:
+            if token.kind != "STRING":
+                raise ParseError(
+                    f"include() accepts only static string arguments; got {token.value!r} "
+                    f"at offset {token.offset}"
+                )
+            reject_embedded_nul(token.value, "Gradle project path in include()")
+            paths.append(token.value)
+            expect_value = False
+        else:
+            if token.kind != "COMMA":
+                raise ParseError(
+                    f"expected comma in include() at offset {token.offset}, got {token.value!r}"
+                )
+            expect_value = True
+        cursor += 1
+    raise ParseError(f"unterminated include() at offset {tokens[index].offset}")
+
+
+def parse_project_remap(tokens: list[Token], index: int) -> tuple[tuple[str, str] | None, int]:
+    expect(tokens, index, "IDENT", "project")
+    if index + 3 >= len(tokens) or tokens[index + 1].kind != "LPAREN":
+        return None, index + 1
+    if tokens[index + 2].kind != "STRING" or tokens[index + 3].kind != "RPAREN":
+        return None, index + 1
+    cursor = index + 4
+    if cursor + 1 >= len(tokens) or tokens[cursor].kind != "DOT":
+        return None, cursor
+    if tokens[cursor + 1].kind != "IDENT" or tokens[cursor + 1].value != "projectDir":
+        return None, cursor
+    project_path = tokens[index + 2].value
+    cursor += 2
+    expect(tokens, cursor, "EQUALS")
+    expect(tokens, cursor + 1, "IDENT", "file")
+    expect(tokens, cursor + 2, "LPAREN")
+    directory = expect(tokens, cursor + 3, "STRING").value
+    reject_embedded_nul(project_path, "Gradle project path in projectDir remap")
+    reject_embedded_nul(directory, "projectDir remap")
+    expect(tokens, cursor + 4, "RPAREN")
+    return (project_path, directory), cursor + 5
+
+
+def derive_project_dirs(source: str) -> list[str]:
+    tokens = tokenize(source)
+    includes: list[str] = []
+    remaps: dict[str, str] = {}
+    consumed_project_dir_offsets: set[int] = set()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.kind == "IDENT" and token.value == "include":
+            paths, index = parse_include(tokens, index)
+            includes.extend(paths)
+            continue
+        if token.kind == "IDENT" and token.value == "project":
+            remap, next_index = parse_project_remap(tokens, index)
+            if remap is not None:
+                project_path, directory = remap
+                project_dir_token = tokens[index + 5]
+                consumed_project_dir_offsets.add(project_dir_token.offset)
+                if project_path in remaps:
+                    raise ParseError(f"duplicate projectDir remap for {project_path}")
+                remaps[project_path] = directory
+                index = next_index
+                continue
+        index += 1
+
+    for token in tokens:
+        if (
+            token.kind == "IDENT"
+            and token.value == "projectDir"
+            and token.offset not in consumed_project_dir_offsets
+        ):
+            raise ParseError(
+                f"unsupported projectDir syntax at offset {token.offset}; "
+                'use project(":path").projectDir = file("relative/path")'
+            )
+
+    seen: set[str] = set()
+    directories = ["."]
+    for project_path in includes:
+        if not PROJECT_PATH.fullmatch(project_path):
+            raise ParseError(f"invalid Gradle project path in include(): {project_path!r}")
+        if "$" in project_path:
+            raise ParseError(f"dynamic Gradle project path is unsupported: {project_path!r}")
+        if project_path in seen:
+            raise ParseError(f"duplicate included project: {project_path}")
+        seen.add(project_path)
+        default_directory = project_path[1:].replace(":", "/")
+        directory = remaps.pop(project_path, default_directory)
+        if "$" in directory:
+            raise ParseError(f"dynamic projectDir is unsupported: {directory!r}")
+        directories.append(directory)
+    if remaps:
+        unknown = ", ".join(sorted(remaps))
+        raise ParseError(f"projectDir remap references project not included in settings: {unknown}")
+    return directories
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {Path(sys.argv[0]).name} <settings.gradle.kts>", file=sys.stderr)
+        return 2
+    settings_path = Path(sys.argv[1])
+    try:
+        source = settings_path.read_text(encoding="utf-8")
+        directories = derive_project_dirs(source)
+    except (OSError, UnicodeError, ParseError) as exc:
+        print(f"CI journey settings parse failed: {exc}", file=sys.stderr)
+        return 1
+    for directory in directories:
+        sys.stdout.buffer.write(directory.encode("utf-8") + b"\0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-ci-journey-artifact-packaging.sh
+++ b/scripts/test-ci-journey-artifact-packaging.sh
@@ -1,0 +1,562 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2154 # Nameref-populated fixture arrays.
+# Issue #1781: deterministic, JVM-free regression for first-cold-boot artifact
+# packaging. Exercises the production snapshot helper and the actual workflow
+# upload-path block against #1458-shaped evidence.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+HELPER="${CI_JOURNEY_ARTIFACT_HELPER:-$SCRIPT_DIR/ci-journey-preserve-android-outputs.sh}"
+SETTINGS_PARSER="${CI_JOURNEY_SETTINGS_PARSER:-$SCRIPT_DIR/ci-journey-settings-project-dirs.py}"
+WORKFLOW="${CI_JOURNEY_ARTIFACT_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
+SETTINGS="${CI_JOURNEY_SETTINGS_FILE:-$REPO_ROOT/settings.gradle.kts}"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+hash_tree() {
+  local root="$1"
+  (
+    cd "$root" || exit 1
+    find . -type f -print0 \
+      | LC_ALL=C sort -z \
+      | xargs -0 -r sha256sum
+  )
+}
+
+seed_fixture() {
+  local root="$1"
+  local attempt="$root/artifacts/ci-journey/class-attempts/app/com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest--dca691208a3658f4/attempt-1"
+
+  mkdir -p \
+    "$root/build/reports/androidTests/connected/debug" \
+    "$root/app/build/reports/androidTests/connected/debug" \
+    "$root/shared/group/deep module/build/outputs/androidTest-results/connected/debug" \
+    "$root/shared/group/deep module/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/diagnostics" \
+    "$attempt/android-test-outputs/app/build/reports/androidTests/connected/debug" \
+    "$attempt/android-test-outputs/app/build/outputs/androidTest-results/connected/debug" \
+    "$attempt/android-test-outputs/app/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/agent-conversation-reconnect" \
+    "$root/artifacts/ci-journey-attempt-1"
+
+  {
+    echo 'rootProject.name = "fixture"'
+    echo 'include(":app", ":deep")'
+    echo 'project(":deep").projectDir = file("shared/group/deep module")'
+  } > "$root/settings.gradle.kts"
+
+  printf 'root module report\n' > "$root/build/reports/androidTests/connected/debug/index.html"
+  printf 'app module report\n' > "$root/app/build/reports/androidTests/connected/debug/index.html"
+  printf 'deep raw result\n' > "$root/shared/group/deep module/build/outputs/androidTest-results/connected/debug/TEST-deep.xml"
+  printf 'deep logcat\n' > "$root/shared/group/deep module/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/diagnostics/logcat.txt"
+
+  printf 'per-attempt report\n' > "$attempt/android-test-outputs/app/build/reports/androidTests/connected/debug/index.html"
+  printf 'per-attempt raw junit\n' > "$attempt/android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-emulator-5554 - 15-_app-.xml"
+  printf 'open_ms=814\nswitch_ms=0\n' > "$attempt/android-test-outputs/app/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/agent-conversation-reconnect/timings.txt"
+  printf 'attempt console\n' > "$attempt/attempt.log"
+  printf 'device logcat\n' > "$attempt/device-logcat.txt"
+  printf 'device processes\n' > "$attempt/device-processes.txt"
+  printf 'activity processes\n' > "$attempt/activity-processes.txt"
+  printf 'activity top\n' > "$attempt/activity-top.txt"
+  printf 'fallback screenshot bytes\n' > "$attempt/failure-screen.png"
+  printf '<testsuite name="journey-harness" tests="1" failures="0"/>\n' > "$attempt/journey-harness-verdict.xml"
+  {
+    echo 'format_version=1'
+    echo 'raw_junit_status=present'
+    echo 'raw_junit_count=1'
+    echo 'snapshot_status=complete'
+    echo 'harness_verdict_xml=journey-harness-verdict.xml'
+    echo 'cleanup_status=failed'
+    echo 'gradle_cleanup_exit_code=0'
+    echo 'device_cleanup_exit_code=1'
+    echo 'status=complete'
+  } > "$attempt/manifest.txt"
+  printf 'journey summary\n' > "$root/artifacts/ci-journey/summary.md"
+  printf 'first-attempt metadata\n' > "$root/artifacts/ci-journey-attempt-1/attempt-metadata.md"
+}
+
+write_current_shard_token() {
+  printf 'CLEAN\n' > "$1/artifacts/ci-journey/shard-verdict.txt"
+}
+
+extract_workflow_snapshot_copy() {
+  awk '
+    /^[[:space:]]+if \[\[ -d artifacts\/ci-journey \]\]; then$/ { in_copy=1 }
+    in_copy && /^[[:space:]]+scripts\/ci-journey-preserve-android-outputs\.sh / { exit }
+    in_copy {
+      sub(/^          /, "")
+      print
+    }
+  ' "$WORKFLOW"
+}
+
+run_production_snapshot() {
+  local root="$1"
+  local snapshot="artifacts/ci-journey-attempt-1"
+  local snapshot_copy
+
+  snapshot_copy="$(extract_workflow_snapshot_copy)"
+  [[ -n "$snapshot_copy" ]] || return 1
+  (
+    cd "$root" || exit 1
+    # shellcheck disable=SC2294 # Execute the trusted production workflow block.
+    eval "$snapshot_copy"
+    CI_JOURNEY_REPO_ROOT="$root" \
+      CI_JOURNEY_SETTINGS_FILE="$root/settings.gradle.kts" \
+      CI_JOURNEY_SETTINGS_PARSER="$SETTINGS_PARSER" \
+      "$HELPER" "$snapshot"
+  )
+}
+
+legacy_snapshot_and_scan() {
+  local root="$1"
+  local snapshot="artifacts/ci-journey-attempt-1"
+
+  (
+    cd "$root" || exit 1
+    mkdir -p "$snapshot/ci-journey"
+    cp -a artifacts/ci-journey/. "$snapshot/ci-journey/"
+    shopt -s globstar nullglob
+    for path in **/build/reports/androidTests \
+                **/build/outputs/androidTest-results \
+                **/build/outputs/connected_android_test_additional_output; do
+      [[ -e "$path" ]] || continue
+      dest="$snapshot/android-test-outputs/$path"
+      mkdir -p "$(dirname "$dest")"
+      cp -a "$path" "$dest"
+    done
+  )
+}
+
+assert_real_attempt_paths() {
+  local root="$1"
+  local current="$root/artifacts/ci-journey/class-attempts/app/com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest--dca691208a3658f4/attempt-1"
+  local first="$root/artifacts/ci-journey-attempt-1/ci-journey/class-attempts/app/com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest--dca691208a3658f4/attempt-1"
+  local relative
+
+  for relative in \
+    "android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-emulator-5554 - 15-_app-.xml" \
+    "android-test-outputs/app/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/agent-conversation-reconnect/timings.txt" \
+    journey-harness-verdict.xml \
+    manifest.txt \
+    device-logcat.txt \
+    device-processes.txt \
+    activity-processes.txt \
+    activity-top.txt \
+    failure-screen.png; do
+    [[ -f "$current/$relative" ]] || fail "current #1458 evidence missing: $relative"
+    [[ -f "$first/$relative" ]] || fail "first-cold-boot #1458 evidence missing: $relative"
+    cmp -s "$current/$relative" "$first/$relative" \
+      || fail "first-cold-boot evidence bytes changed: $relative"
+  done
+  grep -qx 'cleanup_status=failed' "$current/manifest.txt" \
+    || fail "cleanup status was not modeled in the real manifest path"
+  grep -qx 'device_cleanup_exit_code=1' "$first/manifest.txt" \
+    || fail "cleanup exit evidence changed in the first-cold-boot manifest"
+}
+
+echo "== #1781 legacy recursion reproduction =="
+legacy_root="$SANDBOX/legacy"
+seed_fixture "$legacy_root"
+legacy_snapshot_and_scan "$legacy_root"
+write_current_shard_token "$legacy_root"
+
+legacy_nested_current="$legacy_root/artifacts/ci-journey-attempt-1/android-test-outputs/artifacts/ci-journey"
+legacy_nested_first="$legacy_root/artifacts/ci-journey-attempt-1/android-test-outputs/artifacts/ci-journey-attempt-1/ci-journey"
+[[ -d "$legacy_nested_current" ]] \
+  || fail "legacy scan did not reproduce android-test-outputs/artifacts/ci-journey"
+[[ -d "$legacy_nested_first" ]] \
+  || fail "legacy scan did not reproduce android-test-outputs/artifacts/ci-journey-attempt-1"
+legacy_recursive_roots="$(find "$legacy_root/artifacts/ci-journey-attempt-1/android-test-outputs/artifacts" \
+  -type d \( -path '*/artifacts/ci-journey' -o -path '*/artifacts/ci-journey-attempt-1/ci-journey' \) | wc -l)"
+legacy_archive_files="$(find "$legacy_root/artifacts" -type f | wc -l)"
+legacy_archive_bytes="$(du -sb "$legacy_root/artifacts" | awk '{print $1}')"
+[[ "$legacy_recursive_roots" -eq 2 ]] \
+  || fail "expected two legacy recursive artifact roots, got $legacy_recursive_roots"
+pass "real-shaped legacy fixture reproduces both recursive artifact roots (count=2)"
+
+echo
+echo "== #1781 authoritative Gradle settings inventory =="
+[[ -x "$HELPER" ]] || fail "artifact helper missing or not executable: $HELPER"
+[[ -f "$SETTINGS_PARSER" ]] || fail "settings parser missing: $SETTINGS_PARSER"
+[[ -f "$WORKFLOW" && -f "$SETTINGS" ]] || fail "workflow/settings source missing"
+
+parse_settings_into() {
+  local settings_file="$1"
+  local result_name="$2"
+  local output="$SANDBOX/settings-$RANDOM.bin"
+  local -n result="$result_name"
+
+  python3 "$SETTINGS_PARSER" "$settings_file" > "$output" \
+    || fail "settings parser rejected supported fixture: $settings_file"
+  mapfile -d '' -t result < "$output"
+}
+
+assert_arrays_equal() {
+  local label="$1"
+  local expected_name="$2"
+  local actual_name="$3"
+  local -n expected="$expected_name"
+  local -n actual="$actual_name"
+  local index
+
+  [[ "${#expected[@]}" -eq "${#actual[@]}" ]] \
+    || fail "$label count mismatch: expected ${#expected[@]}, got ${#actual[@]}"
+  for index in "${!expected[@]}"; do
+    [[ "${expected[$index]}" == "${actual[$index]}" ]] \
+      || fail "$label element $index mismatch: expected <${expected[$index]}>, got <${actual[$index]}>"
+  done
+}
+
+assert_nul_settings_rejected() {
+  local label="$1"
+  local settings_text="$2"
+  local root="$SANDBOX/nul-$label"
+  local parser_output="$SANDBOX/nul-$label-parser.bin"
+  local parser_log="$SANDBOX/nul-$label-parser.log"
+  local helper_log="$SANDBOX/nul-$label-helper.log"
+  local parser_rc
+  local helper_rc
+
+  mkdir -p \
+    "$root/a/build/reports/androidTests/connected/debug" \
+    "$root/b/build/reports/androidTests/connected/debug" \
+    "$root/artifacts/ci-journey-attempt-1"
+  printf 'must not copy from a\n' > "$root/a/build/reports/androidTests/connected/debug/index.html"
+  printf 'must not copy from b\n' > "$root/b/build/reports/androidTests/connected/debug/index.html"
+  printf '%s\n' "$settings_text" > "$root/settings.gradle.kts"
+
+  python3 "$SETTINGS_PARSER" "$root/settings.gradle.kts" \
+    > "$parser_output" 2> "$parser_log"
+  parser_rc=$?
+  CI_JOURNEY_REPO_ROOT="$root" \
+    CI_JOURNEY_SETTINGS_FILE="$root/settings.gradle.kts" \
+    CI_JOURNEY_SETTINGS_PARSER="$SETTINGS_PARSER" \
+    "$HELPER" "artifacts/ci-journey-attempt-1" > "$helper_log" 2>&1
+  helper_rc=$?
+
+  [[ "$parser_rc" -ne 0 ]] || fail "$label embedded NUL was accepted by settings parser"
+  [[ ! -s "$parser_output" ]] || fail "$label embedded NUL split the parser's NUL-delimited records"
+  grep -q 'embedded NUL' "$parser_log" \
+    || fail "$label embedded NUL parser rejection was not deterministic"
+  [[ "$helper_rc" -ne 0 ]] || fail "$label embedded NUL was accepted by artifact helper"
+  grep -q 'could not derive Gradle project directories' "$helper_log" \
+    || fail "$label embedded NUL parser failure was not propagated by artifact helper"
+  [[ -z "$(find "$root/artifacts/ci-journey-attempt-1" -type f -print -quit)" ]] \
+    || fail "$label embedded NUL copied Android output before helper failure"
+}
+
+expected_repo_projects=(
+  .
+  app
+  shared/core-ssh
+  shared/core-portfwd
+  shared/core-tmux
+  shared/core-terminal
+  shared/core-agents
+  shared/core-usage
+  shared/core-storage
+  shared/core-voice
+  shared/core-assistant
+  shared/core-connection
+  shared/ui-kit
+  shared/test-support
+)
+parse_settings_into "$SETTINGS" parsed_repo_projects
+assert_arrays_equal "repository settings inventory" expected_repo_projects parsed_repo_projects
+pass "settings parser derives root + all ${#parsed_repo_projects[@]} repository projects element-wise"
+
+multi_settings="$SANDBOX/settings-multi.gradle.kts"
+printf 'include(":new:a", ":new:b")\n' > "$multi_settings"
+expected_multi=(. new/a new/b)
+parse_settings_into "$multi_settings" parsed_multi
+assert_arrays_equal "multi-argument include" expected_multi parsed_multi
+
+multiline_settings="$SANDBOX/settings-multiline.gradle.kts"
+printf 'include(\n  ":multi:a",\n  ":multi:b",\n)\n' > "$multiline_settings"
+expected_multiline=(. multi/a multi/b)
+parse_settings_into "$multiline_settings" parsed_multiline
+assert_arrays_equal "multiline include" expected_multiline parsed_multiline
+
+remap_settings="$SANDBOX/settings-remap.gradle.kts"
+{
+  echo 'include(":app")'
+  echo 'project(":app").projectDir = file("modules/app remap")'
+} > "$remap_settings"
+expected_remap=(. "modules/app remap")
+parse_settings_into "$remap_settings" parsed_remap
+assert_arrays_equal "projectDir remap with space" expected_remap parsed_remap
+
+ambiguous_left="$SANDBOX/settings-ambiguous-left.gradle.kts"
+ambiguous_right="$SANDBOX/settings-ambiguous-right.gradle.kts"
+printf 'include(":a b", ":c")\n' > "$ambiguous_left"
+printf 'include(":a", ":b c")\n' > "$ambiguous_right"
+parse_settings_into "$ambiguous_left" parsed_ambiguous_left
+parse_settings_into "$ambiguous_right" parsed_ambiguous_right
+[[ "${parsed_ambiguous_left[*]}" == "${parsed_ambiguous_right[*]}" ]] \
+  || fail "ambiguous-array fixture no longer demonstrates joined-space aliasing"
+arrays_are_equal=1
+if [[ "${#parsed_ambiguous_left[@]}" -ne "${#parsed_ambiguous_right[@]}" ]]; then
+  arrays_are_equal=0
+else
+  for index in "${!parsed_ambiguous_left[@]}"; do
+    [[ "${parsed_ambiguous_left[$index]}" == "${parsed_ambiguous_right[$index]}" ]] \
+      || arrays_are_equal=0
+  done
+fi
+[[ "$arrays_are_equal" -eq 0 ]] \
+  || fail "element-wise inventory comparison collapsed ambiguous space-containing paths"
+
+assert_nul_settings_rejected \
+  "include" \
+  'include(":a\u0000b")'
+assert_nul_settings_rejected \
+  "remap" \
+  $'include(":app")\nproject(":app").projectDir = file("a\\u0000b")'
+pass "multi-arg, multiline, remap-with-space, and element-wise ambiguity fixtures derive exact directories"
+pass "decoded include/remap NULs fail parser + helper with no record split or copied output"
+
+echo
+echo "== #1781 corrected production snapshot + module packaging =="
+fixed_root="$SANDBOX/fixed"
+seed_fixture "$fixed_root"
+current_root="$fixed_root/artifacts/ci-journey"
+snapshot_root="$fixed_root/artifacts/ci-journey-attempt-1"
+current_hashes_before="$(hash_tree "$current_root")"
+current_tree_files="$(wc -l <<<"$current_hashes_before")"
+current_tree_digest="$(sha256sum <<<"$current_hashes_before" | awk '{print $1}')"
+root_report_hash="$(sha256sum "$fixed_root/build/reports/androidTests/connected/debug/index.html" | awk '{print $1}')"
+app_report_hash="$(sha256sum "$fixed_root/app/build/reports/androidTests/connected/debug/index.html" | awk '{print $1}')"
+deep_raw_hash="$(sha256sum "$fixed_root/shared/group/deep module/build/outputs/androidTest-results/connected/debug/TEST-deep.xml" | awk '{print $1}')"
+deep_logcat_hash="$(sha256sum "$fixed_root/shared/group/deep module/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/diagnostics/logcat.txt" | awk '{print $1}')"
+timings_hash="$(sha256sum "$current_root/class-attempts/app/com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest--dca691208a3658f4/attempt-1/android-test-outputs/app/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/agent-conversation-reconnect/timings.txt" | awk '{print $1}')"
+
+run_production_snapshot "$fixed_root" || fail "production workflow snapshot path failed"
+
+[[ "$(hash_tree "$current_root")" == "$current_hashes_before" ]] \
+  || fail "production helper modified current canonical ci-journey bytes"
+[[ "$(hash_tree "$snapshot_root/ci-journey")" == "$current_hashes_before" ]] \
+  || fail "production helper did not byte-copy the canonical first-attempt tree"
+
+[[ "$(sha256sum "$snapshot_root/android-test-outputs/build/reports/androidTests/connected/debug/index.html" | awk '{print $1}')" == "$root_report_hash" ]] \
+  || fail "root-project Android report hash changed"
+[[ "$(sha256sum "$snapshot_root/android-test-outputs/app/build/reports/androidTests/connected/debug/index.html" | awk '{print $1}')" == "$app_report_hash" ]] \
+  || fail "app Android report hash changed"
+[[ "$(sha256sum "$snapshot_root/android-test-outputs/shared/group/deep module/build/outputs/androidTest-results/connected/debug/TEST-deep.xml" | awk '{print $1}')" == "$deep_raw_hash" ]] \
+  || fail "nested/space project raw result hash changed"
+[[ "$(sha256sum "$snapshot_root/android-test-outputs/shared/group/deep module/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/diagnostics/logcat.txt" | awk '{print $1}')" == "$deep_logcat_hash" ]] \
+  || fail "nested/space project diagnostic hash changed"
+[[ ! -e "$snapshot_root/android-test-outputs/artifacts" ]] \
+  || fail "production helper recursively copied an artifact tree"
+
+write_current_shard_token "$fixed_root"
+assert_real_attempt_paths "$fixed_root"
+[[ -f "$current_root/shard-verdict.txt" ]] || fail "current shard token missing"
+[[ ! -e "$snapshot_root/ci-journey/shard-verdict.txt" ]] \
+  || fail "first-cold-boot snapshot incorrectly contains the later-written shard token"
+[[ -f "$current_root/summary.md" && -f "$snapshot_root/ci-journey/summary.md" ]] \
+  || fail "current or first-cold-boot summary missing"
+
+current_attempt_count="$(find "$current_root/class-attempts" -type d -name 'attempt-*' | wc -l)"
+first_attempt_count="$(find "$snapshot_root/ci-journey/class-attempts" -type d -name 'attempt-*' | wc -l)"
+module_output_root_count="$(find "$snapshot_root/android-test-outputs" \
+  -type d \( -path '*/build/reports/androidTests' \
+             -o -path '*/build/outputs/androidTest-results' \
+             -o -path '*/build/outputs/connected_android_test_additional_output' \) | wc -l)"
+fixed_archive_files="$(find "$fixed_root/artifacts" -type f | wc -l)"
+fixed_archive_bytes="$(du -sb "$fixed_root/artifacts" | awk '{print $1}')"
+[[ "$current_attempt_count" -eq 1 && "$first_attempt_count" -eq 1 ]] \
+  || fail "canonical attempt counts changed: current=$current_attempt_count first=$first_attempt_count"
+[[ "$module_output_root_count" -eq 4 ]] \
+  || fail "expected four checked-project output roots, got $module_output_root_count"
+[[ "$fixed_archive_files" -lt "$legacy_archive_files" && "$fixed_archive_bytes" -lt "$legacy_archive_bytes" ]] \
+  || fail "corrected archive did not shrink: legacy=$legacy_archive_files/$legacy_archive_bytes fixed=$fixed_archive_files/$fixed_archive_bytes"
+pass "deep/space project and root project copied; hashes unchanged; recursive roots=0"
+pass "byte digests: attempt_tree_files=$current_tree_files attempt_tree=$current_tree_digest timings=$timings_hash root=$root_report_hash app=$app_report_hash deep_raw=$deep_raw_hash deep_logcat=$deep_logcat_hash"
+pass "archive counts: current_attempts=1 first_attempts=1 module_output_roots=4 legacy_files=$legacy_archive_files fixed_files=$fixed_archive_files"
+pass "archive bytes: legacy=$legacy_archive_bytes fixed=$fixed_archive_bytes"
+
+echo
+echo "== #1781 symlink escape rejection before copy =="
+outside_root="$SANDBOX/outside"
+mkdir -p "$outside_root/build/reports/androidTests"
+printf 'outside secret\n' > "$outside_root/build/reports/androidTests/secret.txt"
+
+project_link_root="$SANDBOX/project-link"
+mkdir -p "$project_link_root/artifacts/ci-journey" "$project_link_root/artifacts/ci-journey-attempt-1"
+printf 'must not copy\n' > "$project_link_root/artifacts/ci-journey/summary.md"
+ln -s "$outside_root" "$project_link_root/outside module"
+printf 'include(":outside module")\n' > "$project_link_root/settings.gradle.kts"
+project_link_rc=0
+CI_JOURNEY_REPO_ROOT="$project_link_root" \
+  CI_JOURNEY_SETTINGS_FILE="$project_link_root/settings.gradle.kts" \
+  CI_JOURNEY_SETTINGS_PARSER="$SETTINGS_PARSER" \
+  "$HELPER" "artifacts/ci-journey-attempt-1" \
+  > "$SANDBOX/project-link.out" 2>&1 || project_link_rc=$?
+[[ "$project_link_rc" -ne 0 ]] || fail "symlinked outside projectDir was accepted"
+grep -q 'projectDir has symlink ancestry' "$SANDBOX/project-link.out" \
+  || fail "projectDir symlink rejection was not deterministic"
+[[ ! -e "$project_link_root/artifacts/ci-journey-attempt-1/android-test-outputs" ]] \
+  || fail "projectDir validation failure copied Android outputs"
+
+build_link_root="$SANDBOX/build-link"
+mkdir -p "$build_link_root/app" "$build_link_root/artifacts/ci-journey" "$build_link_root/artifacts/ci-journey-attempt-1"
+printf 'must not copy\n' > "$build_link_root/artifacts/ci-journey/summary.md"
+ln -s "$outside_root/build" "$build_link_root/app/build"
+printf 'include(":app")\n' > "$build_link_root/settings.gradle.kts"
+build_link_rc=0
+CI_JOURNEY_REPO_ROOT="$build_link_root" \
+  CI_JOURNEY_SETTINGS_FILE="$build_link_root/settings.gradle.kts" \
+  CI_JOURNEY_SETTINGS_PARSER="$SETTINGS_PARSER" \
+  "$HELPER" "artifacts/ci-journey-attempt-1" \
+  > "$SANDBOX/build-link.out" 2>&1 || build_link_rc=$?
+[[ "$build_link_rc" -ne 0 ]] || fail "symlinked outside build root was accepted"
+grep -q 'build path has symlink ancestry' "$SANDBOX/build-link.out" \
+  || fail "build-root symlink rejection was not deterministic"
+[[ ! -e "$build_link_root/artifacts/ci-journey-attempt-1/android-test-outputs" ]] \
+  || fail "build-root validation failure copied Android outputs"
+pass "outside projectDir and build-root symlinks fail before any Android-output copy"
+
+echo
+echo "== #1781 snapshot/destination symlink rejection =="
+snapshot_link_root="$SANDBOX/snapshot-link"
+mkdir -p "$snapshot_link_root/artifacts/real-snapshot"
+printf 'rootProject.name = "snapshot-link"\n' > "$snapshot_link_root/settings.gradle.kts"
+ln -s real-snapshot "$snapshot_link_root/artifacts/snapshot-link"
+snapshot_link_rc=0
+CI_JOURNEY_REPO_ROOT="$snapshot_link_root" \
+  CI_JOURNEY_SETTINGS_FILE="$snapshot_link_root/settings.gradle.kts" \
+  CI_JOURNEY_SETTINGS_PARSER="$SETTINGS_PARSER" \
+  "$HELPER" "artifacts/snapshot-link" \
+  > "$SANDBOX/snapshot-link.out" 2>&1 || snapshot_link_rc=$?
+[[ "$snapshot_link_rc" -ne 0 ]] || fail "repo-local snapshot symlink was accepted"
+grep -q 'snapshot path has symlink ancestry: artifacts/snapshot-link' "$SANDBOX/snapshot-link.out" \
+  || fail "repo-local snapshot symlink rejection was not deterministic"
+[[ ! -e "$snapshot_link_root/artifacts/real-snapshot/android-test-outputs-missing.txt" ]] \
+  || fail "snapshot symlink rejection wrote through the link"
+
+destination_link_root="$SANDBOX/destination-link"
+destination_outside="$SANDBOX/destination-outside"
+mkdir -p \
+  "$destination_link_root/app/build/reports/androidTests/connected/debug" \
+  "$destination_link_root/artifacts/ci-journey-attempt-1" \
+  "$destination_outside"
+printf 'include(":app")\n' > "$destination_link_root/settings.gradle.kts"
+printf 'must remain source-only\n' > "$destination_link_root/app/build/reports/androidTests/connected/debug/index.html"
+destination_source_hash="$(sha256sum "$destination_link_root/app/build/reports/androidTests/connected/debug/index.html" | awk '{print $1}')"
+ln -s "$destination_outside" "$destination_link_root/artifacts/ci-journey-attempt-1/android-test-outputs"
+destination_link_rc=0
+CI_JOURNEY_REPO_ROOT="$destination_link_root" \
+  CI_JOURNEY_SETTINGS_FILE="$destination_link_root/settings.gradle.kts" \
+  CI_JOURNEY_SETTINGS_PARSER="$SETTINGS_PARSER" \
+  "$HELPER" "artifacts/ci-journey-attempt-1" \
+  > "$SANDBOX/destination-link.out" 2>&1 || destination_link_rc=$?
+[[ "$destination_link_rc" -ne 0 ]] || fail "symlinked android-test-outputs destination was accepted"
+grep -q 'snapshot destination has symlink ancestry: artifacts/ci-journey-attempt-1/android-test-outputs' \
+  "$SANDBOX/destination-link.out" \
+  || fail "android-test-outputs symlink rejection was not deterministic"
+[[ -z "$(find "$destination_outside" -mindepth 1 -print -quit)" ]] \
+  || fail "destination symlink escape copied files outside the snapshot"
+[[ "$(sha256sum "$destination_link_root/app/build/reports/androidTests/connected/debug/index.html" | awk '{print $1}')" == "$destination_source_hash" ]] \
+  || fail "destination rejection modified the source report"
+pass "repo-local snapshot link and outside android-test-outputs link fail before writes"
+
+echo
+echo "== #1781 missing-output semantics =="
+empty_root="$SANDBOX/empty"
+mkdir -p "$empty_root/artifacts/ci-journey-attempt-1"
+printf 'rootProject.name = "empty"\n' > "$empty_root/settings.gradle.kts"
+CI_JOURNEY_REPO_ROOT="$empty_root" \
+  CI_JOURNEY_SETTINGS_FILE="$empty_root/settings.gradle.kts" \
+  CI_JOURNEY_SETTINGS_PARSER="$SETTINGS_PARSER" \
+  bash -c '
+    set -euo pipefail
+    root="$1"
+    helper="$2"
+    snapshot="artifacts/ci-journey-attempt-1"
+    snapshot_copy="$3"
+    cd "$root"
+    eval "$snapshot_copy"
+    CI_JOURNEY_REPO_ROOT="$root" CI_JOURNEY_SETTINGS_FILE="$root/settings.gradle.kts" \
+      CI_JOURNEY_SETTINGS_PARSER="$4" \
+      "$helper" "$snapshot"
+  ' _ "$empty_root" "$HELPER" "$(extract_workflow_snapshot_copy)" "$SETTINGS_PARSER" \
+  || fail "production workflow failed on a no-output/missing-summary first attempt"
+grep -qx 'No Android connected-test output directories existed after the first attempt.' \
+  "$empty_root/artifacts/ci-journey-attempt-1/android-test-outputs-missing.txt" \
+  || fail "missing-output marker text changed"
+grep -qx 'artifacts/ci-journey was missing after the first attempt.' \
+  "$empty_root/artifacts/ci-journey-attempt-1/ci-journey-missing.txt" \
+  || fail "missing ci-journey marker text changed"
+grep -qx 'artifacts/ci-journey/summary.md was missing after the first attempt.' \
+  "$empty_root/artifacts/ci-journey-attempt-1/summary-missing.txt" \
+  || fail "missing summary marker text changed"
+pass "all pre-existing missing-evidence marker semantics are unchanged"
+
+echo
+echo "== #1781 actual workflow snapshot/upload guards =="
+preserve_step="$(sed -n \
+  '/- name: Preserve first journey attempt diagnostics/,/- name: Check remaining job wall before journey retry/p' \
+  "$WORKFLOW")"
+# shellcheck disable=SC2016 # Literal workflow shell variable, not a test var.
+grep -Fq 'scripts/ci-journey-preserve-android-outputs.sh "$snapshot"' <<<"$preserve_step" \
+  || fail "workflow does not call the production snapshot helper"
+# shellcheck disable=SC2016 # Literal production workflow variable, not a test var.
+grep -Fq 'cp -a artifacts/ci-journey/. "$snapshot/ci-journey/"' <<<"$preserve_step" \
+  || fail "production workflow lost the canonical ci-journey copy"
+if grep -q '\*\*/build' "$HELPER" || grep -q '\*\*/build' <<<"$preserve_step"; then
+  fail "broad recursive Android build-output scan was restored"
+fi
+preserve_line="$(grep -n 'name: Preserve first journey attempt diagnostics' "$WORKFLOW" | cut -d: -f1)"
+verdict_line="$(grep -n 'verdict_file="artifacts/ci-journey/shard-verdict.txt"' "$WORKFLOW" | cut -d: -f1)"
+[[ "$preserve_line" =~ ^[0-9]+$ && "$verdict_line" =~ ^[0-9]+$ && "$preserve_line" -lt "$verdict_line" ]] \
+  || fail "first-attempt snapshot no longer precedes current shard-token creation"
+
+upload_step="$(sed -n \
+  '/- name: Upload Android test reports/,/- name: Upload Docker logs/p' \
+  "$WORKFLOW")"
+mapfile -t upload_paths < <(
+  awk '
+    /^[[:space:]]+path: \|[[:space:]]*$/ { in_paths=1; next }
+    in_paths && /^[[:space:]]+if-no-files-found:/ { exit }
+    in_paths {
+      sub(/^[[:space:]]+/, "")
+      if (length > 0) print
+    }
+  ' <<<"$upload_step"
+)
+printf '%s\n' "${upload_paths[@]}" | grep -Fxq 'artifacts/ci-journey/' \
+  || fail "actual Android-report upload step lost artifacts/ci-journey/"
+printf '%s\n' "${upload_paths[@]}" | grep -Fxq 'artifacts/ci-journey-attempt-1/' \
+  || fail "actual Android-report upload step lost artifacts/ci-journey-attempt-1/"
+
+upload_manifest="$SANDBOX/upload-manifest.txt"
+: > "$upload_manifest"
+for upload_path in "${upload_paths[@]}"; do
+  [[ "$upload_path" == *'*'* ]] && continue
+  upload_source="$fixed_root/${upload_path%/}"
+  [[ -d "$upload_source" ]] || continue
+  while IFS= read -r -d '' uploaded_file; do
+    uploaded_relative="${uploaded_file#"$fixed_root/"}"
+    printf '%s  %s\n' "$(sha256sum "$uploaded_file" | awk '{print $1}')" "$uploaded_relative" \
+      >> "$upload_manifest"
+  done < <(find "$upload_source" -type f -print0)
+done
+grep -q '  artifacts/ci-journey/summary.md$' "$upload_manifest" \
+  || fail "actual upload paths do not package the canonical summary"
+grep -q '  artifacts/ci-journey/shard-verdict.txt$' "$upload_manifest" \
+  || fail "actual upload paths do not package the current shard token"
+grep -q '  artifacts/ci-journey-attempt-1/ci-journey/summary.md$' "$upload_manifest" \
+  || fail "actual upload paths do not package the first-cold-boot summary"
+if grep -q 'artifacts/ci-journey-attempt-1/ci-journey/shard-verdict.txt$' "$upload_manifest"; then
+  fail "upload model incorrectly found a later-written token in the first snapshot"
+fi
+upload_manifest_count="$(wc -l < "$upload_manifest")"
+upload_manifest_digest="$(sha256sum "$upload_manifest" | awk '{print $1}')"
+pass "actual upload block packages both canonical roots ($upload_manifest_count hashed files, digest=$upload_manifest_digest)"
+
+echo
+echo "ALL TESTS PASSED: scripts/test-ci-journey-artifact-packaging.sh"


### PR DESCRIPTION
## Summary

- replace the broad recursive `**/build` report scan with authoritative Gradle project-directory discovery
- reject source, snapshot, and destination path/symlink escapes before copying
- preserve canonical current and first-cold-boot #1458 evidence byte-for-byte without nesting artifact trees under `android-test-outputs/artifacts`
- add a pure-shell regression covering workflow copy/upload wiring, real evidence timing/order, settings remaps, ambiguous/NUL paths, and recursive-glob mutations

Refs #1781.

Do not close #1781 from this PR alone. Closure still requires an exact-main three-shard run with real per-shard size/file counts, zero recursive roots, and canonical current/first evidence counts compared with the 174,956,438-byte duplicate baseline.

## Verification

- `scripts/test-ci-journey-artifact-packaging.sh`
- `scripts/test-ci-journey-budget.sh`
- `scripts/test-ci-journey-aggregate-verdict.sh`
- `scripts/test-ci-journey-retry-budget.sh`
- `scripts/check-ci-journey-harness.sh`
- `bash -n`, ShellCheck, Python syntax, YAML parse, `git diff --check`
- three independent review rounds; final approval after symlink, settings/remap, evidence-model, timing, and decoded-NUL mutations were killed
