### PR TITLE
fix: harden partial-render heal ownership (#966)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -22,16 +23,21 @@ import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.HealAttemptReason
+import com.pocketshell.app.tmux.HealAttemptResult
 import com.pocketshell.app.tmux.HealOutcome
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.ActivePaneRenderOwnerSnapshotForTest
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -142,6 +148,12 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         waitForConnected("initial attach")
         capturePaintedRows("issue1138-00-attached")
 
+        // The manual one-pass assertion must own the whole injection→capture→oracle→apply
+        // interval. Disable future production auto-arms and cancel+JOIN the current watchdog
+        // before injecting the partial-black frame.
+        pauseAutomaticStaleRenderWatchdog()
+        val settledOwner = waitForSettledActiveRenderOwner()
+
         // ===== Inject the partial-black on the LIVE, retained emulator. =====
         // Clear the alt screen and paint ONLY the live status line (cursor-addressed) — the
         // maintainer's semi-black: upper rows black, only the status line survives. The REMOTE
@@ -151,14 +163,40 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         // control sequences must carry an actual ESC or they paint as literal
         // text and never clear the screen (the injected partial-black is a no-op).
         val esc = ""
-        feedFrameToEmulator("$esc[2J$esc[H$esc[24;1H Working 7  esc to interrupt streaming the reply")
+        val injectedOwner = feedFrameToActivePaneModel(
+            "$esc[2J$esc[H$esc[24;1H Working 7  esc to interrupt streaming the reply",
+            settledOwner,
+        )
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         capturePaintedRows("issue1138-01-partial-black")
+
+        val remoteCapture = captureAuthoritativeRemotePane(fixtureKey)
+        val remoteCaptureChars = remoteCapture.count { !it.isWhitespace() }
+        assertTrue(
+            "authoritative remote alt-screen frame must remain nonempty before the manual heal " +
+                "(>= $MIN_AUTHORITATIVE_CAPTURE_CHARS chars); found $remoteCaptureChars.\n" +
+                remoteCapture,
+            remoteCaptureChars >= MIN_AUTHORITATIVE_CAPTURE_CHARS,
+        )
+        assertTrue(
+            "authoritative remote alt-screen frame must still carry its marker",
+            remoteCapture.contains(FRAME_MARKER),
+        )
+        val localStale = activePaneLocalHealState(injectedOwner)
 
         // ----- Symptom precondition: the active pane IS partial-black (the #1138 state). -----
         assertTrue(
             "the injected pane must be partial-black (the maintainer's #1138 semi-black state)",
-            activePanePartiallyBlank(),
+            localStale.partiallyBlank,
+        )
+        assertTrue(
+            "pre-call local render must still be suspect; if the automatic watchdog was left " +
+                "armed it can heal first and this assertion must fail. state=$localStale",
+            localStale.renderLooksSuspect,
+        )
+        assertTrue(
+            "pre-call local partial-black must retain a bounded status fragment; state=$localStale",
+            localStale.renderedNonBlankChars in 1..MAX_EXPECTED_FRAGMENT_CHARS,
         )
 
         // ----- DISCRIMINATOR half 1: the transport is GUARANTEED LIVE. -----
@@ -174,12 +212,25 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         assertNoVisibleReconnect("partial-black (no reconnect surface)")
 
         // ----- GREEN: one steady-state watchdog tick must heal + restore the FULL alt frame. -----
-        val healed = driveStaleRenderHeal()
-        assertTrue(
-            "REGRESSION (#1138): the steady-state watchdog must heal a partial-black alt-screen " +
-                "agent pane. On base (divergence-only predicate) it read the sparse frame " +
-                "'healthy' and skipped it — the pane stayed black on a live transport.",
-            healed,
+        val healResult = driveStaleRenderHeal(injectedOwner)
+        writeHealAttemptArtifact(localStale, remoteCaptureChars, healResult)
+        assertEquals(
+            "typed diagnostics must retain the pre-call stale viewport count, not resample " +
+                "the healed viewport; result=$healResult",
+            localStale.renderedNonBlankChars,
+            healResult.stats.renderedNonBlankChars,
+        )
+        assertEquals(
+            "REGRESSION (#1138/#966): the one-pass heal must return the exact " +
+                "divergence-applied reason; result=$healResult",
+            HealAttemptReason.DivergenceApplied,
+            healResult.reason,
+        )
+        assertEquals(
+            "REGRESSION (#1138): the steady-state watchdog must return typed Healed for the " +
+                "partial-black alt-screen agent pane; result=$healResult",
+            HealOutcome.Healed,
+            healResult.outcome,
         )
         val visibleAfter = waitForVisibleTerminal(
             "alt-screen full-frame restore",
@@ -192,7 +243,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         )
         assertFalse(
             "after the heal the pane must NO LONGER be partial-black (the upper rows repainted)",
-            activePanePartiallyBlank(),
+            activePaneLocalHealState().partiallyBlank,
         )
         capturePaintedRows("issue1138-02-healed")
 
@@ -203,35 +254,124 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
                 "observed=${currentConnectionStatus()}",
             currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
         )
-        writeSummary()
+        writeSummary(localStale, remoteCaptureChars, healResult)
     } }
 
     // ---------------------------------------------------------------- Heal driver
 
-    private fun driveStaleRenderHeal(): Boolean {
-        // Issue #1294: the oracle now returns a three-state [HealOutcome]; "the heal fired"
-        // is the HEALED outcome (a real divergence found + repaired).
-        var result: HealOutcome = HealOutcome.Unverified
+    private fun driveStaleRenderHeal(
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+    ): HealAttemptResult {
+        var result: HealAttemptResult? = null
         val latch = java.util.concurrent.CountDownLatch(1)
         compose.activityRule.scenario.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-            runBlocking { result = vm.healActivePaneIfStaleRenderForTest() }
-            latch.countDown()
+            activity.lifecycleScope.launch {
+                try {
+                    result = vm.healActivePaneIfStaleRenderResultForTest(expectedOwner)
+                } finally {
+                    latch.countDown()
+                }
+            }
         }
-        latch.await(RESTORE_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+        val completed = latch.await(
+            RESTORE_TIMEOUT_MS,
+            java.util.concurrent.TimeUnit.MILLISECONDS,
+        )
+        assertTrue("manual stale-render heal latch must complete within the bound", completed)
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        return result == HealOutcome.Healed
+        return checkNotNull(result) { "manual stale-render heal completed without a typed result" }
     }
 
-    private fun activePanePartiallyBlank(): Boolean {
-        var hit = false
+    private fun pauseAutomaticStaleRenderWatchdog() {
+        val latch = java.util.concurrent.CountDownLatch(1)
         compose.activityRule.scenario.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-            hit = vm.panes.value.firstOrNull()
-                ?.terminalState
-                ?.visibleScreenIsPartiallyBlank() ?: false
+            activity.lifecycleScope.launch {
+                try {
+                    vm.pauseActivePaneStaleRenderWatchdogForTest()
+                } finally {
+                    latch.countDown()
+                }
+            }
         }
-        return hit
+        val completed = latch.await(
+            RESTORE_TIMEOUT_MS,
+            java.util.concurrent.TimeUnit.MILLISECONDS,
+        )
+        assertTrue("automatic stale-render watchdog pause latch must complete within the bound", completed)
+        compose.activityRule.scenario.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            assertTrue(
+                "automatic stale-render watchdog must be quiescent before stale injection; " +
+                    "job=${vm.staleRenderWatchdogJobForTest()}",
+                vm.staleRenderWatchdogJobForTest()?.isActive != true,
+            )
+        }
+    }
+
+    private data class LocalHealState(
+        val renderedNonBlankChars: Int,
+        val partiallyBlank: Boolean,
+        val renderLooksSuspect: Boolean,
+    )
+
+    private fun activePaneLocalHealState(
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest? = null,
+    ): LocalHealState {
+        var state: LocalHealState? = null
+        var actualOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var viewTerminalSessionIdentity: Int? = null
+        var viewEmulatorIdentity: Int? = null
+        var failure: String? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            val snapshot = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }
+                .getOrElse {
+                    failure = "could not snapshot active owner: $it"
+                    return@onActivity
+                }
+            actualOwner = snapshot
+            val viewSession = activity.window.decorView.findTerminalView()?.currentSession
+            viewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
+            viewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+            if (expectedOwner != null && (
+                    !snapshot.coherent ||
+                        !snapshot.sameOwnerAs(expectedOwner) ||
+                        snapshot.modelMutationEpoch != expectedOwner.modelMutationEpoch ||
+                        snapshot.controlSizeGeneration != expectedOwner.controlSizeGeneration ||
+                snapshot.sizeOperationsInFlight != 0 ||
+                snapshot.automaticHealOperationsInFlight != 0 ||
+                snapshot.automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch ||
+                viewTerminalSessionIdentity != snapshot.terminalSessionIdentity ||
+                viewEmulatorIdentity != snapshot.emulatorIdentity
+                    )
+            ) {
+                failure = "render owner/model changed before pre-call oracle"
+                return@onActivity
+            }
+            state = LocalHealState(
+                renderedNonBlankChars = snapshot.renderedNonBlankChars,
+                partiallyBlank = snapshot.partiallyBlank,
+                renderLooksSuspect = snapshot.renderLooksSuspect,
+            )
+        }
+        if (expectedOwner != null) {
+            writeRenderOwnerArtifact(
+                label = "pre-call",
+                expected = expectedOwner,
+            actual = actualOwner,
+            viewTerminalSessionIdentity = viewTerminalSessionIdentity,
+            viewEmulatorIdentity = viewEmulatorIdentity,
+                failure = failure,
+            )
+        }
+        assertTrue(
+            "$failure expected=$expectedOwner actual=$actualOwner " +
+                "viewSession=$viewTerminalSessionIdentity viewEmulator=$viewEmulatorIdentity",
+            failure == null,
+        )
+        return checkNotNull(state) { "active pane missing while reading local stale state" }
     }
 
     private fun clientDisconnected(): Boolean {
@@ -245,18 +385,134 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
 
     // ---------------------------------------------------------------- Emulator feed
 
-    private fun feedFrameToEmulator(frame: String) {
+    private fun waitForSettledActiveRenderOwner(): ActivePaneRenderOwnerSnapshotForTest {
+        var lastOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var lastViewTerminalSessionIdentity: Int? = null
+        var lastViewEmulatorIdentity: Int? = null
+        val settled = runCatching {
+            compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+                var ready = false
+                compose.activityRule.scenario.onActivity { activity ->
+                    val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                    lastOwner = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }.getOrNull()
+                    val viewSession = activity.window.decorView.findTerminalView()?.currentSession
+                    lastViewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
+                    lastViewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+                    ready = lastOwner?.attachResizeSeedSettled == true &&
+                        lastViewTerminalSessionIdentity == lastOwner?.terminalSessionIdentity &&
+                        lastViewEmulatorIdentity == lastOwner?.emulatorIdentity
+                }
+                ready
+            }
+            true
+        }.getOrDefault(false)
+        writeRenderOwnerArtifact(
+            label = "settled",
+            expected = null,
+            actual = lastOwner,
+            viewTerminalSessionIdentity = lastViewTerminalSessionIdentity,
+            viewEmulatorIdentity = lastViewEmulatorIdentity,
+            failure = if (settled) null else "attach/resize/reseed settlement timed out",
+        )
+        assertTrue(
+            "attach/resize/reseed must settle on the exact visible VM model; " +
+                "owner=$lastOwner viewSession=$lastViewTerminalSessionIdentity " +
+                "viewEmulator=$lastViewEmulatorIdentity",
+            settled,
+        )
+        return checkNotNull(lastOwner)
+    }
+
+    private fun feedFrameToActivePaneModel(
+        frame: String,
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+    ): ActivePaneRenderOwnerSnapshotForTest {
         val bytes = frame.toByteArray(Charsets.UTF_8)
-        var fed = false
+        var injectedOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var viewTerminalSessionIdentity: Int? = null
+        var viewTerminalSessionIdentityAfter: Int? = null
+        var viewEmulatorIdentity: Int? = null
+        var failure: String? = null
         compose.activityRule.scenario.onActivity { activity ->
-            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
-            val emulator = view.mEmulator ?: return@onActivity
-            emulator.append(bytes, bytes.size)
-            view.invalidate()
-            fed = true
+            val view = activity.window.decorView.findTerminalView()
+            val viewSession = view?.currentSession
+            viewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
+            viewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+            if (viewTerminalSessionIdentity != expectedOwner.terminalSessionIdentity ||
+                viewEmulatorIdentity != expectedOwner.emulatorIdentity
+            ) {
+                failure = "TerminalView session/emulator is not bound to the expected active VM owner"
+                return@onActivity
+            }
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            val preInjectionOwner = vm.activePaneRenderOwnerSnapshotForTest()
+            if (preInjectionOwner.automaticHealOperationsInFlight != 0 ||
+                preInjectionOwner.automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch
+            ) {
+                failure = "automatic render-heal activity changed before active-model injection"
+                return@onActivity
+            }
+            injectedOwner = runCatching {
+                vm.appendToActivePaneRenderModelForTest(bytes, expectedOwner)
+            }.getOrElse {
+                failure = it.message ?: it.toString()
+                return@onActivity
+            }
+            val viewSessionAfter = view?.currentSession
+            viewTerminalSessionIdentityAfter = viewSessionAfter?.let(System::identityHashCode)
+            val viewEmulatorAfter = viewSessionAfter?.emulator?.let(System::identityHashCode)
+            if (viewTerminalSessionIdentityAfter != injectedOwner?.terminalSessionIdentity ||
+                viewEmulatorAfter != injectedOwner?.emulatorIdentity ||
+                injectedOwner?.automaticHealOperationsInFlight != 0 ||
+                injectedOwner?.automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch
+            ) {
+                failure = "TerminalView owner or automatic render-heal epoch changed during active-model injection"
+                return@onActivity
+            }
+            view?.invalidate()
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        assertTrue("expected to feed the frame to the live emulator", fed)
+        writeRenderOwnerArtifact(
+            label = "injected",
+            expected = expectedOwner,
+            actual = injectedOwner,
+            viewTerminalSessionIdentity = viewTerminalSessionIdentity,
+            viewTerminalSessionIdentityAfter = viewTerminalSessionIdentityAfter,
+            viewEmulatorIdentity = viewEmulatorIdentity,
+            failure = failure,
+        )
+        assertTrue(
+            "$failure expected=$expectedOwner injected=$injectedOwner " +
+                "viewSession=$viewTerminalSessionIdentity " +
+                "viewSessionAfter=$viewTerminalSessionIdentityAfter viewEmulator=$viewEmulatorIdentity",
+            failure == null && injectedOwner != null,
+        )
+        return checkNotNull(injectedOwner)
+    }
+
+    private fun writeRenderOwnerArtifact(
+        label: String,
+        expected: ActivePaneRenderOwnerSnapshotForTest?,
+        actual: ActivePaneRenderOwnerSnapshotForTest?,
+        viewTerminalSessionIdentity: Int?,
+        viewTerminalSessionIdentityAfter: Int? = null,
+        viewEmulatorIdentity: Int?,
+        failure: String?,
+    ) {
+        writeText(
+            "issue1138-render-owner-$label.txt",
+            buildString {
+                appendLine("label=$label")
+                appendLine("failure=${failure.orEmpty()}")
+                appendLine("view_terminal_session_identity=$viewTerminalSessionIdentity")
+                appendLine("view_terminal_session_identity_after=$viewTerminalSessionIdentityAfter")
+                appendLine("view_emulator_identity=$viewEmulatorIdentity")
+                appendLine("expected_automatic_heal_activity_epoch=${expected?.automaticHealActivityEpoch}")
+                appendLine("actual_automatic_heal_activity_epoch=${actual?.automaticHealActivityEpoch}")
+                appendLine("expected=$expected")
+                appendLine("actual=$actual")
+            },
+        )
     }
 
     // ---------------------------------------------------------------- Render capture
@@ -494,6 +750,28 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         Log.i(LOG_TAG, "seeded alt-screen session: ${exec?.stdout?.trim()}")
     }
 
+    private suspend fun captureAuthoritativeRemotePane(key: String): String {
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use {
+                it.exec("tmux capture-pane -p -t ${shellQuote(SESSION_NAME)}")
+            }
+        }
+        val exec = result.getOrNull()
+        assertTrue(
+            "authoritative remote capture-pane must succeed before the manual heal; " +
+                "exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        return exec?.stdout.orEmpty()
+    }
+
     private suspend fun cleanupRemoteTmuxSession(key: String) {
         runCatching {
             SshConnection.connect(
@@ -529,7 +807,32 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         return file
     }
 
-    private fun writeSummary(): File =
+    private fun writeHealAttemptArtifact(
+        localStale: LocalHealState,
+        remoteCaptureChars: Int,
+        healResult: HealAttemptResult,
+    ): File =
+        writeText(
+            "issue1138-heal-attempt.txt",
+            buildString {
+                appendLine("stale_kind=ALT_SCREEN_PARTIAL_BLACK")
+                appendLine("auto_watchdog_quiescent=true")
+                appendLine("remote_capture_non_blank_chars=$remoteCaptureChars")
+                appendLine("local_rendered_non_blank_chars=${localStale.renderedNonBlankChars}")
+                appendLine("local_render_looks_suspect=${localStale.renderLooksSuspect}")
+                appendLine("heal_outcome=${healResult.outcome}")
+                appendLine("heal_reason=${healResult.reason}")
+                appendLine("heal_rendered_non_blank_chars=${healResult.stats.renderedNonBlankChars}")
+                appendLine("heal_capture_non_blank_chars=${healResult.stats.captureNonBlankChars}")
+                appendLine("heal_capture_line_count=${healResult.stats.captureLineCount}")
+            },
+        )
+
+    private fun writeSummary(
+        localStale: LocalHealState,
+        remoteCaptureChars: Int,
+        healResult: HealAttemptResult,
+    ): File =
         writeText(
             "issue1138-summary.txt",
             buildString {
@@ -539,6 +842,17 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
                 appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
                 appendLine("session=$SESSION_NAME")
                 appendLine("frame_marker=$FRAME_MARKER")
+                appendLine("auto_watchdog_quiescent=true")
+                appendLine("remote_capture_non_blank_chars=$remoteCaptureChars")
+                appendLine("local_rendered_non_blank_chars=${localStale.renderedNonBlankChars}")
+                appendLine("local_render_looks_suspect=${localStale.renderLooksSuspect}")
+                appendLine("heal_outcome=${healResult.outcome}")
+                appendLine("heal_reason=${healResult.reason}")
+                appendLine(
+                    "heal_stats=rendered:${healResult.stats.renderedNonBlankChars}," +
+                        "capture:${healResult.stats.captureNonBlankChars}," +
+                        "lines:${healResult.stats.captureLineCount}",
+                )
                 appendLine(
                     "scenario=attach a sparse alt-screen agent frame, inject the partial-black " +
                         "(clear + only the live status line) on the LIVE emulator, assert transport " +
@@ -581,6 +895,8 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         const val FRAME_MARKER: String = "ISSUE1138-ALT"
 
         const val MIN_RESTORED_FRAME_ROWS: Int = 5
+        const val MIN_AUTHORITATIVE_CAPTURE_CHARS: Int = 40
+        const val MAX_EXPECTED_FRAGMENT_CHARS: Int = 80
 
         val RESTORE_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -26,14 +27,18 @@ import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
+import com.pocketshell.app.tmux.HealAttemptReason
+import com.pocketshell.app.tmux.HealAttemptResult
 import com.pocketshell.app.tmux.HealOutcome
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.ActivePaneRenderOwnerSnapshotForTest
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -152,15 +157,20 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             bannerRowCount(visibleTerminalText()) >= MIN_RESTORED_BANNER_ROWS,
         )
 
+        // The production 4-second watchdog must not win the race between injection and this
+        // journey's manual one-pass owner. Disable every future auto-arm and cancel+JOIN the
+        // current loop before the first stale frame is injected.
+        pauseAutomaticStaleRenderWatchdog()
+
         // Exercise each stale kind in turn on the SAME live pane (no relaunch).
         for (kind in StaleKind.values()) {
-            runStaleKind(kind)
+            runStaleKind(kind, key)
         }
     } }
 
     private enum class StaleKind { FULLY_BLANK, SCATTERED_FRAGMENT, STALE_AFTER_BURST }
 
-    private fun runStaleKind(kind: StaleKind) {
+    private suspend fun runStaleKind(kind: StaleKind, key: String) {
         val namePrefix = "issue966-${kind.name.lowercase()}"
 
         // Restore the banner baseline before this kind (the prior kind's heal already
@@ -168,17 +178,18 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         waitForVisibleTerminal("$namePrefix pre-kind banner", timeoutMillis = RESTORE_TIMEOUT_MS) {
             bannerRowCount(it) >= MIN_RESTORED_BANNER_ROWS
         }
+        val settledOwner = waitForSettledActiveRenderOwner(namePrefix)
         capturePaintedRows("$namePrefix-01-baseline")
 
         // ===== Inject the stale render on the LIVE, retained emulator. =====
-        when (kind) {
-            StaleKind.SCATTERED_FRAGMENT -> feedScatteredFragmentFrameToEmulator()
-            StaleKind.FULLY_BLANK -> feedFrameToEmulator("[2J[H")
+        val injectedOwner = when (kind) {
+            StaleKind.SCATTERED_FRAGMENT -> feedScatteredFragmentFrameToActiveModel(settledOwner, namePrefix)
+            StaleKind.FULLY_BLANK -> feedFrameToActivePaneModel("[2J[H", settledOwner, namePrefix)
             StaleKind.STALE_AFTER_BURST -> {
                 // A heavy alt-screen repaint burst that outruns the drain, then the
                 // scattered residue — the burst variant of the #966 stale grid.
-                feedHeavyBurstToEmulator()
-                feedScatteredFragmentFrameToEmulator()
+                val burstOwner = feedHeavyBurstToActiveModel(settledOwner, namePrefix)
+                feedScatteredFragmentFrameToActiveModel(burstOwner, namePrefix)
             }
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
@@ -186,12 +197,44 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         // The RED state on the real device: the injected stale render shows almost
         // none of tmux's banner (the user-perceived black/fragment pane).
 
+        val remoteCapture = captureAuthoritativeRemotePane(key)
+        val remoteCaptureChars = remoteCapture.count { !it.isWhitespace() }
+        assertTrue(
+            "$namePrefix authoritative remote tmux frame must remain nonempty before the " +
+                "manual heal (>= $MIN_AUTHORITATIVE_CAPTURE_CHARS chars); found " +
+                "$remoteCaptureChars.\n$remoteCapture",
+            remoteCaptureChars >= MIN_AUTHORITATIVE_CAPTURE_CHARS,
+        )
+        assertTrue(
+            "$namePrefix authoritative remote tmux frame must still carry the banner marker",
+            remoteCapture.contains(BANNER_MARKER),
+        )
+        val localStale = activePaneLocalHealState(injectedOwner, namePrefix)
+        assertTrue(
+            "$namePrefix pre-call local render must still be suspect; if the automatic watchdog " +
+                "was left armed it can heal first and this assertion must fail. state=$localStale",
+            localStale.renderLooksSuspect,
+        )
+        when (kind) {
+            StaleKind.FULLY_BLANK -> assertEquals(
+                "$namePrefix intended local state must be fully blank before the manual call",
+                0,
+                localStale.renderedNonBlankChars,
+            )
+            StaleKind.SCATTERED_FRAGMENT,
+            StaleKind.STALE_AFTER_BURST -> assertTrue(
+                "$namePrefix intended local state must retain bounded fragments before the " +
+                    "manual call; state=$localStale",
+                localStale.renderedNonBlankChars in 1..MAX_EXPECTED_FRAGMENT_CHARS,
+            )
+        }
+
         // ----- RED precondition: the v0.4.17 heal oracle SKIPS this pane. -----
         // For the scattered-fragment / burst case the combined blank||partial-blank
         // oracle reads FALSE, so the v0.4.17 heal would never fire — proving the gap.
         // (The fully-blank case is the boundary the v0.4.17 heal already owned, so it
         // reads TRUE there; the divergence path subsumes it.)
-        val v0417OracleHit = activePaneBlankOrPartiallyBlank()
+        val v0417OracleHit = localStale.blankOrPartiallyBlank
         if (kind != StaleKind.FULLY_BLANK) {
             assertFalse(
                 "$namePrefix RED: the v0.4.17 heal oracle (blank||partial-blank) must SKIP " +
@@ -217,11 +260,30 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         // The divergence oracle fires for ALL three stale kinds (fully-black,
         // scattered fragments, post-burst clear) because tmux's grid holds the full
         // banner while the VISIBLE viewport shows almost none of it.
-        val healed = driveStaleRenderHeal()
-        assertTrue(
-            "$namePrefix the stale-render heal must FIRE ($kind) — divergence detected " +
-                "between the stale VISIBLE render and tmux's authoritative capture",
-            healed,
+        val healResult = driveStaleRenderHeal(injectedOwner)
+        writeHealAttemptArtifact(
+            namePrefix = namePrefix,
+            kind = kind,
+            localStale = localStale,
+            remoteCaptureChars = remoteCaptureChars,
+            healResult = healResult,
+        )
+        assertEquals(
+            "$namePrefix typed diagnostics must retain the pre-call stale viewport count, " +
+                "not resample the healed viewport; result=$healResult",
+            localStale.renderedNonBlankChars,
+            healResult.stats.renderedNonBlankChars,
+        )
+        assertEquals(
+            "$namePrefix the one-pass heal must return the exact divergence-applied reason; " +
+                "result=$healResult",
+            HealAttemptReason.DivergenceApplied,
+            healResult.reason,
+        )
+        assertEquals(
+            "$namePrefix the stale-render heal must be typed Healed ($kind); result=$healResult",
+            HealOutcome.Healed,
+            healResult.outcome,
         )
         val visibleAfter = waitForVisibleTerminal(
             "$namePrefix stale-render heal full-viewport restore",
@@ -252,7 +314,13 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
         )
 
-        writeSummary(namePrefix, kind)
+        writeSummary(
+            namePrefix = namePrefix,
+            kind = kind,
+            localStale = localStale,
+            remoteCaptureChars = remoteCaptureChars,
+            healResult = healResult,
+        )
     }
 
     // ---------------------------------------------------------------- Heal driver
@@ -260,34 +328,120 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
     /**
      * Run ONE stale-render heal pass over the active pane (the watchdog tick),
      * synchronously, via the production test seam [TmuxSessionViewModel.
-     * healActivePaneIfStaleRenderForTest]. Returns whether the heal fired.
+     * healActivePaneIfStaleRenderResultForTest]. Returns the exact typed attempt.
      */
-    private fun driveStaleRenderHeal(): Boolean {
-        // Issue #1294: the oracle now returns a three-state [HealOutcome]; "the heal fired"
-        // is the HEALED outcome (a real divergence found + repaired).
-        var result: HealOutcome = HealOutcome.Unverified
+    private fun driveStaleRenderHeal(
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+    ): HealAttemptResult {
+        var result: HealAttemptResult? = null
         val latch = java.util.concurrent.CountDownLatch(1)
         launchedActivity?.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-            runBlocking {
-                result = vm.healActivePaneIfStaleRenderForTest()
+            activity.lifecycleScope.launch {
+                try {
+                    result = vm.healActivePaneIfStaleRenderResultForTest(expectedOwner)
+                } finally {
+                    latch.countDown()
+                }
             }
-            latch.countDown()
         }
-        latch.await(RESTORE_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+        val completed = latch.await(
+            RESTORE_TIMEOUT_MS,
+            java.util.concurrent.TimeUnit.MILLISECONDS,
+        )
+        assertTrue("manual stale-render heal latch must complete within the bound", completed)
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        return result == HealOutcome.Healed
+        return checkNotNull(result) { "manual stale-render heal completed without a typed result" }
     }
 
-    private fun activePaneBlankOrPartiallyBlank(): Boolean {
-        var hit = false
+    private fun pauseAutomaticStaleRenderWatchdog() {
+        val latch = java.util.concurrent.CountDownLatch(1)
         launchedActivity?.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-            hit = vm.panes.value.firstOrNull()
-                ?.terminalState
-                ?.visibleScreenIsBlankOrPartiallyBlank() ?: false
+            activity.lifecycleScope.launch {
+                try {
+                    vm.pauseActivePaneStaleRenderWatchdogForTest()
+                } finally {
+                    latch.countDown()
+                }
+            }
         }
-        return hit
+        val completed = latch.await(
+            RESTORE_TIMEOUT_MS,
+            java.util.concurrent.TimeUnit.MILLISECONDS,
+        )
+        assertTrue("automatic stale-render watchdog pause latch must complete within the bound", completed)
+        launchedActivity?.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            assertTrue(
+                "automatic stale-render watchdog must be quiescent before stale injection; " +
+                    "job=${vm.staleRenderWatchdogJobForTest()}",
+                vm.staleRenderWatchdogJobForTest()?.isActive != true,
+            )
+        }
+    }
+
+    private data class LocalHealState(
+        val renderedNonBlankChars: Int,
+        val blankOrPartiallyBlank: Boolean,
+        val renderLooksSuspect: Boolean,
+    )
+
+    private fun activePaneLocalHealState(
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+        namePrefix: String,
+    ): LocalHealState {
+        var state: LocalHealState? = null
+        var actualOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var viewTerminalSessionIdentity: Int? = null
+        var viewEmulatorIdentity: Int? = null
+        var failure: String? = null
+        launchedActivity?.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            val snapshot = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }
+                .getOrElse {
+                    failure = "could not snapshot active owner: $it"
+                    return@onActivity
+                }
+            actualOwner = snapshot
+            val viewSession = activity.window.decorView.findTerminalView()?.currentSession
+            viewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
+            viewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+            if (!snapshot.coherent ||
+                !snapshot.sameOwnerAs(expectedOwner) ||
+                snapshot.modelMutationEpoch != expectedOwner.modelMutationEpoch ||
+                snapshot.controlSizeGeneration != expectedOwner.controlSizeGeneration ||
+                snapshot.sizeOperationsInFlight != 0 ||
+                snapshot.automaticHealOperationsInFlight != 0 ||
+                snapshot.automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch ||
+                viewTerminalSessionIdentity != snapshot.terminalSessionIdentity ||
+                viewEmulatorIdentity != snapshot.emulatorIdentity
+            ) {
+                failure = "render owner/model changed before pre-call oracle"
+                return@onActivity
+            }
+            state = LocalHealState(
+                renderedNonBlankChars = snapshot.renderedNonBlankChars,
+                blankOrPartiallyBlank = snapshot.partiallyBlank ||
+                    snapshot.renderedNonBlankChars == 0,
+                renderLooksSuspect = snapshot.renderLooksSuspect,
+            )
+        }
+        writeRenderOwnerArtifact(
+            namePrefix = namePrefix,
+            label = "pre-call",
+            expected = expectedOwner,
+            actual = actualOwner,
+            viewTerminalSessionIdentity = viewTerminalSessionIdentity,
+            viewEmulatorIdentity = viewEmulatorIdentity,
+            failure = failure,
+        )
+        assertTrue(
+            "$failure expected=$expectedOwner actual=$actualOwner " +
+                "viewSession=$viewTerminalSessionIdentity viewEmulator=$viewEmulatorIdentity",
+            failure == null,
+        )
+        return checkNotNull(state) { "active pane missing while reading local stale state" }
     }
 
     private fun clientDisconnected(): Boolean {
@@ -307,7 +461,10 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
      * a status line) — NOT fully blank, NOT cleanly partial-blank, so the v0.4.17
      * oracle skips it. Local to the emulator; the remote tmux grid keeps the banner.
      */
-    private fun feedScatteredFragmentFrameToEmulator() {
+    private fun feedScatteredFragmentFrameToActiveModel(
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+        namePrefix: String,
+    ): ActivePaneRenderOwnerSnapshotForTest {
         val esc = ""
         val frame = buildString {
             append("$esc[2J$esc[H")          // erase + home
@@ -320,12 +477,16 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             append("$esc[20;5H")
             append("y z\r\n")
         }
-        feedFrameToEmulator(frame)
+        return feedFrameToActivePaneModel(frame, expectedOwner, namePrefix)
     }
 
     /** A heavy alt-screen repaint burst — many colored rows faster than the drain. */
-    private fun feedHeavyBurstToEmulator() {
+    private fun feedHeavyBurstToActiveModel(
+        initialOwner: ActivePaneRenderOwnerSnapshotForTest,
+        namePrefix: String,
+    ): ActivePaneRenderOwnerSnapshotForTest {
         val esc = ""
+        var owner = initialOwner
         repeat(8) {
             val frame = buildString {
                 append("$esc[2J$esc[H")
@@ -333,22 +494,144 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
                     append("$esc[3${row % 7}mBURST row $row ${"x".repeat(60)}$esc[0m\r\n")
                 }
             }
-            feedFrameToEmulator(frame)
+            owner = feedFrameToActivePaneModel(frame, owner, namePrefix)
         }
+        return owner
     }
 
-    private fun feedFrameToEmulator(frame: String) {
+    private fun waitForSettledActiveRenderOwner(
+        namePrefix: String,
+    ): ActivePaneRenderOwnerSnapshotForTest {
+        var lastOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var lastViewTerminalSessionIdentity: Int? = null
+        var lastViewEmulatorIdentity: Int? = null
+        val settled = runCatching {
+            compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+                var ready = false
+                launchedActivity?.onActivity { activity ->
+                    val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                    lastOwner = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }.getOrNull()
+                    val viewSession = activity.window.decorView.findTerminalView()?.currentSession
+                    lastViewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
+                    lastViewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+                    ready = lastOwner?.attachResizeSeedSettled == true &&
+                        lastViewTerminalSessionIdentity == lastOwner?.terminalSessionIdentity &&
+                        lastViewEmulatorIdentity == lastOwner?.emulatorIdentity
+                }
+                ready
+            }
+            true
+        }.getOrDefault(false)
+        writeRenderOwnerArtifact(
+            namePrefix = namePrefix,
+            label = "settled",
+            expected = null,
+            actual = lastOwner,
+            viewTerminalSessionIdentity = lastViewTerminalSessionIdentity,
+            viewEmulatorIdentity = lastViewEmulatorIdentity,
+            failure = if (settled) null else "attach/resize/reseed settlement timed out",
+        )
+        assertTrue(
+            "$namePrefix attach/resize/reseed must settle on the exact visible VM model; " +
+                "owner=$lastOwner viewSession=$lastViewTerminalSessionIdentity " +
+                "viewEmulator=$lastViewEmulatorIdentity",
+            settled,
+        )
+        return checkNotNull(lastOwner)
+    }
+
+    private fun feedFrameToActivePaneModel(
+        frame: String,
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+        namePrefix: String,
+    ): ActivePaneRenderOwnerSnapshotForTest {
         val bytes = frame.toByteArray(Charsets.UTF_8)
-        var fed = false
+        var injectedOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var viewTerminalSessionIdentity: Int? = null
+        var viewTerminalSessionIdentityAfter: Int? = null
+        var viewEmulatorIdentity: Int? = null
+        var failure: String? = null
         launchedActivity?.onActivity { activity ->
-            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
-            val emulator = view.mEmulator ?: return@onActivity
-            emulator.append(bytes, bytes.size)
-            view.invalidate()
-            fed = true
+            val view = activity.window.decorView.findTerminalView()
+            val viewSession = view?.currentSession
+            viewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
+            viewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+            if (viewTerminalSessionIdentity != expectedOwner.terminalSessionIdentity ||
+                viewEmulatorIdentity != expectedOwner.emulatorIdentity
+            ) {
+                failure = "TerminalView session/emulator is not bound to the expected active VM owner"
+                return@onActivity
+            }
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            val preInjectionOwner = vm.activePaneRenderOwnerSnapshotForTest()
+            if (preInjectionOwner.automaticHealOperationsInFlight != 0 ||
+                preInjectionOwner.automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch
+            ) {
+                failure = "automatic render-heal activity changed before active-model injection"
+                return@onActivity
+            }
+            injectedOwner = runCatching {
+                vm.appendToActivePaneRenderModelForTest(bytes, expectedOwner)
+            }.getOrElse {
+                failure = it.message ?: it.toString()
+                return@onActivity
+            }
+            val viewSessionAfter = view?.currentSession
+            viewTerminalSessionIdentityAfter = viewSessionAfter?.let(System::identityHashCode)
+            if (viewTerminalSessionIdentityAfter != injectedOwner?.terminalSessionIdentity ||
+                viewSessionAfter?.emulator?.let(System::identityHashCode) != injectedOwner?.emulatorIdentity ||
+                injectedOwner?.automaticHealOperationsInFlight != 0 ||
+                injectedOwner?.automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch
+            ) {
+                failure = "TerminalView owner or automatic render-heal epoch changed during active-model injection"
+                return@onActivity
+            }
+            view?.invalidate()
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        assertTrue("expected to feed the frame to the live emulator", fed)
+        writeRenderOwnerArtifact(
+            namePrefix = namePrefix,
+            label = "injected-${expectedOwner.modelMutationEpoch}",
+            expected = expectedOwner,
+            actual = injectedOwner,
+            viewTerminalSessionIdentity = viewTerminalSessionIdentity,
+            viewTerminalSessionIdentityAfter = viewTerminalSessionIdentityAfter,
+            viewEmulatorIdentity = viewEmulatorIdentity,
+            failure = failure,
+        )
+        assertTrue(
+            "$failure expected=$expectedOwner injected=$injectedOwner " +
+                "viewSession=$viewTerminalSessionIdentity " +
+                "viewSessionAfter=$viewTerminalSessionIdentityAfter viewEmulator=$viewEmulatorIdentity",
+            failure == null && injectedOwner != null,
+        )
+        return checkNotNull(injectedOwner)
+    }
+
+    private fun writeRenderOwnerArtifact(
+        namePrefix: String,
+        label: String,
+        expected: ActivePaneRenderOwnerSnapshotForTest?,
+        actual: ActivePaneRenderOwnerSnapshotForTest?,
+        viewTerminalSessionIdentity: Int?,
+        viewTerminalSessionIdentityAfter: Int? = null,
+        viewEmulatorIdentity: Int?,
+        failure: String?,
+    ) {
+        writeText(
+            "$namePrefix-render-owner-$label.txt",
+            buildString {
+                appendLine("label=$label")
+                appendLine("failure=${failure.orEmpty()}")
+                appendLine("view_terminal_session_identity=$viewTerminalSessionIdentity")
+                appendLine("view_terminal_session_identity_after=$viewTerminalSessionIdentityAfter")
+                appendLine("view_emulator_identity=$viewEmulatorIdentity")
+                appendLine("expected_automatic_heal_activity_epoch=${expected?.automaticHealActivityEpoch}")
+                appendLine("actual_automatic_heal_activity_epoch=${actual?.automaticHealActivityEpoch}")
+                appendLine("expected=$expected")
+                appendLine("actual=$actual")
+            },
+        )
     }
 
     // ---------------------------------------------------------------- Render capture
@@ -591,6 +874,28 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         Log.i(LOG_TAG, "seeded session: ${exec?.stdout?.trim()}")
     }
 
+    private suspend fun captureAuthoritativeRemotePane(key: String): String {
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use {
+                it.exec("tmux capture-pane -p -t ${shellQuote(SESSION_NAME)}")
+            }
+        }
+        val exec = result.getOrNull()
+        assertTrue(
+            "authoritative remote capture-pane must succeed before the manual heal; " +
+                "exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        return exec?.stdout.orEmpty()
+    }
+
     private suspend fun cleanupRemoteTmuxSession(key: String) {
         runCatching {
             SshConnection.connect(
@@ -626,7 +931,36 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         return file
     }
 
-    private fun writeSummary(namePrefix: String, kind: StaleKind): File =
+    private fun writeHealAttemptArtifact(
+        namePrefix: String,
+        kind: StaleKind,
+        localStale: LocalHealState,
+        remoteCaptureChars: Int,
+        healResult: HealAttemptResult,
+    ): File =
+        writeText(
+            "$namePrefix-heal-attempt.txt",
+            buildString {
+                appendLine("stale_kind=$kind")
+                appendLine("auto_watchdog_quiescent=true")
+                appendLine("remote_capture_non_blank_chars=$remoteCaptureChars")
+                appendLine("local_rendered_non_blank_chars=${localStale.renderedNonBlankChars}")
+                appendLine("local_render_looks_suspect=${localStale.renderLooksSuspect}")
+                appendLine("heal_outcome=${healResult.outcome}")
+                appendLine("heal_reason=${healResult.reason}")
+                appendLine("heal_rendered_non_blank_chars=${healResult.stats.renderedNonBlankChars}")
+                appendLine("heal_capture_non_blank_chars=${healResult.stats.captureNonBlankChars}")
+                appendLine("heal_capture_line_count=${healResult.stats.captureLineCount}")
+            },
+        )
+
+    private fun writeSummary(
+        namePrefix: String,
+        kind: StaleKind,
+        localStale: LocalHealState,
+        remoteCaptureChars: Int,
+        healResult: HealAttemptResult,
+    ): File =
         writeText(
             "$namePrefix-summary.txt",
             buildString {
@@ -637,6 +971,17 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
                 appendLine("session=$SESSION_NAME")
                 appendLine("banner_marker=$BANNER_MARKER")
                 appendLine("stale_kind=$kind")
+                appendLine("auto_watchdog_quiescent=true")
+                appendLine("remote_capture_non_blank_chars=$remoteCaptureChars")
+                appendLine("local_rendered_non_blank_chars=${localStale.renderedNonBlankChars}")
+                appendLine("local_render_looks_suspect=${localStale.renderLooksSuspect}")
+                appendLine("heal_outcome=${healResult.outcome}")
+                appendLine("heal_reason=${healResult.reason}")
+                appendLine(
+                    "heal_stats=rendered:${healResult.stats.renderedNonBlankChars}," +
+                        "capture:${healResult.stats.captureNonBlankChars}," +
+                        "lines:${healResult.stats.captureLineCount}",
+                )
                 appendLine(
                     "scenario=attach a full-viewport banner, inject the stale/fragment render " +
                         "($kind) on the LIVE emulator, assert transport stays Connected, then drive " +
@@ -680,6 +1025,8 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         const val POST_RESTORE_SETTLE_MS: Long = 2_000L
         const val MIN_RESTORED_BANNER_ROWS: Int = 20
         const val MIN_PAINTED_ROWS: Int = 30
+        const val MIN_AUTHORITATIVE_CAPTURE_CHARS: Int = 40
+        const val MAX_EXPECTED_FRAGMENT_CHARS: Int = 40
 
         val RESTORE_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 20_000L

--- a/app/src/main/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTest.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTest.kt
@@ -1,0 +1,58 @@
+package com.pocketshell.app.tmux
+
+/**
+ * Issue #966 connected-proof owner snapshot. Identity binds the visible TerminalView session to
+ * the exact active VM pane/model; settlement fields expose positive completion invariants for
+ * attach seed and asynchronous refresh-client/reseed work, without a timing guess.
+ */
+internal data class ActivePaneRenderOwnerSnapshotForTest(
+    val paneId: String,
+    val windowId: String,
+    val sessionId: String,
+    val targetSessionName: String?,
+    val connectGeneration: Long,
+    val clientIdentity: Int?,
+    val stateIdentity: Int,
+    val terminalSessionIdentity: Int?,
+    val emulatorIdentity: Int?,
+    val modelMutationEpoch: Long,
+    val modelDrainBacklogged: Boolean,
+    val seedOperationInFlight: Boolean,
+    val sizeOperationsInFlight: Int,
+    val automaticHealOperationsInFlight: Int,
+    val automaticHealActivityEpoch: Long,
+    val controlSizeGeneration: Long,
+    val effectiveColumns: Int,
+    val effectiveRows: Int,
+    val appliedColumns: Int,
+    val appliedRows: Int,
+    val lastSeedAtMs: Long?,
+    val renderedNonBlankChars: Int,
+    val partiallyBlank: Boolean,
+    val renderLooksSuspect: Boolean,
+    val coherent: Boolean,
+) {
+    val attachResizeSeedSettled: Boolean
+        get() = coherent &&
+            emulatorIdentity != null &&
+            !modelDrainBacklogged &&
+            !seedOperationInFlight &&
+            sizeOperationsInFlight == 0 &&
+            automaticHealOperationsInFlight == 0 &&
+            effectiveColumns > 0 &&
+            effectiveRows > 0 &&
+            appliedColumns == effectiveColumns &&
+            appliedRows == effectiveRows &&
+            lastSeedAtMs != null
+
+    fun sameOwnerAs(other: ActivePaneRenderOwnerSnapshotForTest): Boolean =
+        paneId == other.paneId &&
+            windowId == other.windowId &&
+            sessionId == other.sessionId &&
+            targetSessionName == other.targetSessionName &&
+            connectGeneration == other.connectGeneration &&
+            clientIdentity == other.clientIdentity &&
+            stateIdentity == other.stateIdentity &&
+            terminalSessionIdentity == other.terminalSessionIdentity &&
+            emulatorIdentity == other.emulatorIdentity
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/AutomaticRenderHealTracker.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AutomaticRenderHealTracker.kt
@@ -1,0 +1,35 @@
+package com.pocketshell.app.tmux
+
+/** Synchronous ownership ledger for queued or running automatic render-heal jobs. */
+internal class AutomaticRenderHealTracker(
+    initialActivityEpoch: Long = 1L,
+) {
+    private val lock = Any()
+    private val activeTokens = linkedSetOf<Long>()
+    private var activityEpoch = initialActivityEpoch
+
+    init {
+        require(initialActivityEpoch > 0L) { "automatic render-heal activity epoch must be positive" }
+    }
+
+    fun begin(): Long = synchronized(lock) {
+        val token = Math.incrementExact(activityEpoch)
+        check(token > 0L && activeTokens.add(token)) {
+            "automatic render-heal activity epoch/token must advance uniquely: $token"
+        }
+        activityEpoch = token
+        token
+    }
+
+    fun complete(token: Long) {
+        synchronized(lock) {
+            check(activeTokens.remove(token)) { "automatic render-heal owner completed twice: $token" }
+        }
+    }
+
+    fun snapshot(): Activity = synchronized(lock) {
+        Activity(activeCount = activeTokens.size, activityEpoch = activityEpoch)
+    }
+
+    internal data class Activity(val activeCount: Int, val activityEpoch: Long)
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/HealAttemptResult.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/HealAttemptResult.kt
@@ -1,0 +1,84 @@
+package com.pocketshell.app.tmux
+
+/**
+ * Immutable diagnostic result for one oracle-gated stale-render heal attempt.
+ *
+ * [reason] is the single authority for the legacy [outcome] projection, so a caller cannot
+ * construct a contradictory pair such as `Healthy` + `CaptureError`. The compact numeric
+ * observations are capped before they leave the heal path: connected journeys can retain one
+ * line per stale kind without writing an unbounded terminal capture into the artifact bundle.
+ */
+@ConsistentCopyVisibility
+internal data class HealAttemptResult private constructor(
+    val reason: HealAttemptReason,
+    val stats: HealAttemptStats,
+) {
+    val outcome: HealOutcome
+        get() = reason.outcome
+
+    companion object {
+        internal fun create(
+            reason: HealAttemptReason,
+            renderedNonBlankChars: Int,
+            captureNonBlankChars: Int = 0,
+            captureLineCount: Int = 0,
+        ): HealAttemptResult =
+            HealAttemptResult(
+                reason = reason,
+                stats = HealAttemptStats.bounded(
+                    renderedNonBlankChars = renderedNonBlankChars,
+                    captureNonBlankChars = captureNonBlankChars,
+                    captureLineCount = captureLineCount,
+                ),
+            )
+    }
+}
+
+/**
+ * Exact terminal condition observed by one stale-render heal pass.
+ *
+ * [AuthoritativeCaptureMatched] is deliberately the only [HealOutcome.Healthy] reason: healthy
+ * means a successful, non-empty authoritative capture reached the loss predicate and the
+ * predicate returned false. A missing, thrown, error, or empty capture is always unverified.
+ */
+internal enum class HealAttemptReason(internal val outcome: HealOutcome) {
+    MissingClient(HealOutcome.Unverified),
+    MissingActivePane(HealOutcome.Unverified),
+    MissingActiveTarget(HealOutcome.Unverified),
+    RuntimeSupersededBeforeCapture(HealOutcome.Unverified),
+    ClientDisconnectedBeforeCapture(HealOutcome.Unverified),
+    RuntimeSupersededAfterCapture(HealOutcome.Unverified),
+    CaptureException(HealOutcome.Unverified),
+    CaptureError(HealOutcome.Unverified),
+    CaptureEmpty(HealOutcome.Unverified),
+    AuthoritativeCaptureMatched(HealOutcome.Healthy),
+    DivergenceApplyFailed(HealOutcome.Unverified),
+    DivergenceApplied(HealOutcome.Healed),
+    ForcedSnapshotApplied(HealOutcome.Healed),
+    ForcedSnapshotUnavailable(HealOutcome.Unverified),
+}
+
+internal class HealAttemptStats private constructor(
+    val renderedNonBlankChars: Int,
+    val captureNonBlankChars: Int,
+    val captureLineCount: Int,
+) {
+    override fun toString(): String =
+        "HealAttemptStats(renderedNonBlankChars=$renderedNonBlankChars, " +
+            "captureNonBlankChars=$captureNonBlankChars, captureLineCount=$captureLineCount)"
+
+    companion object {
+        internal const val MAX_RETAINED_VALUE: Int = 100_000
+
+        internal fun bounded(
+            renderedNonBlankChars: Int,
+            captureNonBlankChars: Int,
+            captureLineCount: Int,
+        ): HealAttemptStats =
+            HealAttemptStats(
+                renderedNonBlankChars = renderedNonBlankChars.coerceIn(0, MAX_RETAINED_VALUE),
+                captureNonBlankChars = captureNonBlankChars.coerceIn(0, MAX_RETAINED_VALUE),
+                captureLineCount = captureLineCount.coerceIn(0, MAX_RETAINED_VALUE),
+            )
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -312,7 +312,6 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun setReconcileDispatcherForTest(dispatcher: CoroutineDispatcher) {
         reconcileDispatcher = dispatcher
     }
-
     /**
      * Issue #926: the dispatcher the attach/switch/reattach SEED + `list-panes`
      * BLOCKING control-channel round-trips run on. Defaults to [Dispatchers.IO]
@@ -332,7 +331,6 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun setSeedIoDispatcherForTest(dispatcher: CoroutineDispatcher) {
         seedIoDispatcher = dispatcher
     }
-
     /**
      * Issue #877: the dispatcher the per-`%output` new-port detector
      * ([startPortDetectionForPane] → [PortDetector.scan]) runs its decode +
@@ -359,7 +357,6 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun setPortDetectionDispatcherForTest(dispatcher: CoroutineDispatcher) {
         portDetectionDispatcher = dispatcher
     }
-
     /**
      * Session-card host CLI reads/writes run on real IO in production. Unit
      * tests pin this to the shared scheduler so card refresh assertions do not
@@ -372,7 +369,6 @@ public class TmuxSessionViewModel @Inject constructor(
         sessionCardsDispatcher = dispatcher
         sessionCardsRemoteSource.setExecDispatcherForTest(dispatcher)
     }
-
     /**
      * Issue #1085 (F2): the application-scoped coroutine the SLOW
      * connection-teardown IO ([closeCurrentConnection]'s tmux `detach-client`
@@ -397,7 +393,6 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun setTeardownScopeForTest(scope: CoroutineScope) {
         teardownScope = scope
     }
-
     /**
      * Issue #793: how long the Conversation tab stays in the
      * [ConversationLoadState.Loading] ("Loading conversation…") state before
@@ -1774,9 +1769,12 @@ public class TmuxSessionViewModel @Inject constructor(
     // Issue #966/#967: when false, [armActivePaneStaleRenderWatchdog] is
     // suppressed entirely. Always true in production; a test seam toggles it.
     private var staleRenderWatchdogAutoArmEnabled: Boolean = true
+    private val staleRenderWatchdogArmLock = Any()
 
     internal fun setStaleRenderWatchdogAutoArmEnabledForTest(enabled: Boolean) {
-        staleRenderWatchdogAutoArmEnabled = enabled
+        synchronized(staleRenderWatchdogArmLock) {
+            staleRenderWatchdogAutoArmEnabled = enabled
+        }
     }
 
     // Issue #1166: the single active stale-render watchdog loop. Cancelled and
@@ -1785,7 +1783,22 @@ public class TmuxSessionViewModel @Inject constructor(
     private var staleRenderWatchdogJob: Job? = null
 
     @androidx.annotation.VisibleForTesting
-    internal fun staleRenderWatchdogJobForTest(): Job? = staleRenderWatchdogJob
+    internal fun staleRenderWatchdogJobForTest(): Job? =
+        synchronized(staleRenderWatchdogArmLock) { staleRenderWatchdogJob }
+
+    /**
+     * Issue #966 diagnostics isolation: atomically prevent every future production auto-arm,
+     * then cancel AND join the already-running loop before a connected journey injects stale
+     * state. Once this returns, the manual one-pass seam is the sole heal owner.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun pauseActivePaneStaleRenderWatchdogForTest() {
+        val current = synchronized(staleRenderWatchdogArmLock) {
+            staleRenderWatchdogAutoArmEnabled = false
+            staleRenderWatchdogJob
+        }
+        current?.cancelAndJoin()
+    }
 
     // Issue #1166 (heal-latency fix): a WAKE signal so fresh `%output` on the
     // ACTIVE visible pane snaps a BACKED-OFF watchdog straight back to the hot
@@ -2184,6 +2197,8 @@ public class TmuxSessionViewModel @Inject constructor(
     private var appliedControlClientColumns: Int = 0
     private var appliedControlClientRows: Int = 0
     private var controlClientSizeGeneration: Long = 0L
+    private val controlClientSizeOperationsInFlight = AtomicInteger(0); private val automaticRenderHealTracker =
+        AutomaticRenderHealTracker()
     private var windowSizePolicyAppliedForAttach: Boolean = false
     // Issue #495/#554: injected process-scoped memory of which tmux windows
     // are agent windows (and which agent + the user's last tab choice), keyed
@@ -3259,7 +3274,6 @@ public class TmuxSessionViewModel @Inject constructor(
             connectionManager.setReconnectLadder(delaysMs)
         }
     }
-
     @androidx.annotation.VisibleForTesting
     internal fun setPassiveDisconnectRecoveryForTest(
         graceMs: Long = passiveDisconnectGraceMs,
@@ -7560,7 +7574,6 @@ public class TmuxSessionViewModel @Inject constructor(
         // surface renders a curated sentence, never a raw exception string.
         revealController.driveTerminalError(target, cause)
     }
-
     @androidx.annotation.VisibleForTesting
     internal fun isStaleChannelSymptom(cause: Throwable?): Boolean =
         TmuxSessionFailureClassifiers.isStaleChannelSymptom(cause)
@@ -11201,67 +11214,24 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #966/#967 — the STEADY-STATE stale-render watchdog. The
-     * [armConnectedBlankWatchdog] above exits the instant a frame lands, so it
-     * cannot catch a pane that paints fine at attach and only LATER goes
-     * black-with-fragments (a drop-induced stale grid, a mis-sized resize, a
-     * partial reseed that stalled — the #966 shape). This watchdog runs for the
-     * lifetime of the runtime on a SLOW cadence and, each tick, captures the
-     * ACTIVE visible pane and re-seeds it ONLY when the local render is
-     * mostly-black/stale relative to tmux's authoritative grid
-     * ([healActivePaneIfStaleRender]).
-     *
-     * It is the residual-risk net the #967 spike called out: a render that dies
-     * SILENTLY (no exception, just a stale grid) neither reconnects (correct — the
-     * transport is alive) NOR is caught by the blank/partial-blank oracles. This
-     * watchdog is the missing oracle, gated by a `capture-pane` DIFF so it never
-     * over-fires on a legitimately sparse-but-correct pane.
-     *
-     * Cost: ONE `capture-pane` round-trip per tick, and only while the pane is
-     * NON-blank (the blank watchdog owns the blank case). The diff is computed from
-     * the captured text, so a healthy pane pays just the one cheap round-trip and
-     * never relayouts.
-     *
-     * Issue #1166 (battery/heat) — the watchdog exists to heal the VISIBLE pane, so
-     * it is gated + backed off so an idle/hidden pane stops hammering `capture-pane`
-     * while a churning/agent pane still heals as fast as before:
-     *
-     *  - **Foreground + screen-on gate.** When the app is backgrounded OR the screen
-     *    is off there is nothing on screen to heal, so the tick SKIPS the capture
-     *    round-trip entirely (0 captures/min while backgrounded or screen-off). On
-     *    resume the back-off is reset so the FIRST foreground tick captures at the
-     *    hot 4s cadence — a pane that changed while away heals right on return.
-     *  - **Back-off when HEALTHY (issue #1219 steady-heat fix).** A tick whose
-     *    authoritative capture-diff oracle finds NO divergence widens the next
-     *    interval (4s → 8s → 16s, capped) — EVEN while the pane is actively
-     *    streaming `%output`. Only a real detected divergence (the heal fired), a
-     *    session switch (fresh arm), or a reconnecting band snaps the cadence back
-     *    to 4s. Before #1219 ANY streamed `%output` reset the back-off, so a
-     *    continuously-streaming-but-CORRECT agent pane never left the hot 4s cadence
-     *    and paid a `capture-pane` round-trip every 4s forever (the #1164 "runs
-     *    warm" lever, the heaviest-use foreground window). A streaming-but-BLACK
-     *    pane still heals within the same bound (#1138/#1153/#874) via the suspect
-     *    wake below.
-     *  - **Immediate wake on a SUSPECT redraw (issue #1166 heal-latency fix, #1219
-     *    scoped).** The back-off is NOT purely poll-based: a fresh active-pane
-     *    `%output` fires [staleRenderWatchdogWake] (see [recordVisiblePaneOutput])
-     *    and the loop RACES its backed-off `delay(...)` against that wake (see
-     *    [awaitStaleRenderWatchdogTick]) — but honors it ONLY while the render looks
-     *    locally black/partial-black ([activeVisiblePaneRenderLooksSuspect]). So a
-     *    redraw that turns the pane black ~1s into a 16s backed-off window is
-     *    captured/diffed/healed within the hot bound (≤4s), not up to 16s later —
-     *    the partial-black (#1138) case whose sole steady-state oracle is this
-     *    watchdog can never sit visibly broken for a whole backed-off interval —
-     *    while a healthy streaming pane's output is ignored so it reaps the back-off.
-     *  - **Arm-dedup.** [staleRenderWatchdogJob] is cancelled before each re-arm so
-     *    rapid A→B→A switching can never stack multiple concurrent 4s loops.
+     * Steady-state #966 render net: while foregrounded and screen-on, compare the visible pane
+     * with one authoritative capture. Confirmed-healthy ticks back off; divergence, failure, or
+     * a suspect output wake stays hot. Re-arm replaces the previous loop.
      */
     private fun armActivePaneStaleRenderWatchdog(refreshGuard: RuntimeRefreshGuard) {
-        if (!staleRenderWatchdogAutoArmEnabled) return
-        launchActivePaneStaleRenderWatchdog(refreshGuard)
+        synchronized(staleRenderWatchdogArmLock) {
+            if (!staleRenderWatchdogAutoArmEnabled) return
+            launchActivePaneStaleRenderWatchdogLocked(refreshGuard)
+        }
     }
 
     private fun launchActivePaneStaleRenderWatchdog(refreshGuard: RuntimeRefreshGuard) {
+        synchronized(staleRenderWatchdogArmLock) {
+            launchActivePaneStaleRenderWatchdogLocked(refreshGuard)
+        }
+    }
+
+    private fun launchActivePaneStaleRenderWatchdogLocked(refreshGuard: RuntimeRefreshGuard) {
         // Issue #1166 arm-dedup: cancel any prior loop before launching a new one.
         // A stale loop otherwise only self-terminates on its NEXT tick via
         // isCurrentRuntime (up to one full tick of double/triple captures per switch).
@@ -11504,46 +11474,107 @@ public class TmuxSessionViewModel @Inject constructor(
      */
     @androidx.annotation.VisibleForTesting
     internal suspend fun healActivePaneIfStaleRenderForTest(): HealOutcome {
-        val client = clientRef ?: return HealOutcome.Unverified
-        val activePane = activeVisiblePane() ?: return HealOutcome.Unverified
-        val target = activeTarget ?: return HealOutcome.Unverified
+        return healActivePaneIfStaleRenderResultForTest().outcome
+    }
+
+    /** One production heal pass retaining its exact bounded diagnostic result. */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun healActivePaneIfStaleRenderResultForTest(): HealAttemptResult {
+        val client = clientRef ?: return HealAttemptResult.create(HealAttemptReason.MissingClient, 0)
+        val activePane = activeVisiblePane()
+            ?: return HealAttemptResult.create(HealAttemptReason.MissingActivePane, 0)
+        val target = activeTarget
+            ?: return HealAttemptResult.create(
+                HealAttemptReason.MissingActiveTarget,
+                activePane.terminalState.renderedNonBlankCharCount(),
+            )
         val guard = RuntimeRefreshGuard(
             generation = connectGeneration,
             target = target,
             client = client,
         )
-        return healActivePaneIfStaleRender(client, activePane, guard)
+        return healActivePaneIfStaleRenderAttempt(client, activePane, guard)
     }
 
-    /** Issue #1353 R4 (test seam): submit a reconcile event via [requestReconcile] on the live client. */
+    @androidx.annotation.VisibleForTesting
+    internal fun activePaneRenderOwnerSnapshotForTest(): ActivePaneRenderOwnerSnapshotForTest {
+        val pane = checkNotNull(activeVisiblePane()) { "active visible pane is missing" }
+        val ownerBefore = pane.terminalState.renderModelOwnerSnapshotForTesting()
+        val rendered = pane.terminalState.renderedNonBlankCharCount(); val partial =
+            pane.terminalState.visibleScreenIsPartiallyBlank(); val suspect = pane.terminalState.renderLooksSuspect()
+        val ownerAfter = pane.terminalState.renderModelOwnerSnapshotForTesting(); val automaticHeal =
+            automaticRenderHealTracker.snapshot()
+        return ActivePaneRenderOwnerSnapshotForTest(
+            paneId = pane.paneId, windowId = pane.windowId, sessionId = pane.sessionId,
+            targetSessionName = activeTarget?.sessionName, connectGeneration = connectGeneration,
+            clientIdentity = clientRef?.let(System::identityHashCode),
+            stateIdentity = ownerAfter.stateIdentity, terminalSessionIdentity = ownerAfter.sessionIdentity,
+            emulatorIdentity = ownerAfter.emulatorIdentity, modelMutationEpoch = ownerAfter.mutationEpoch,
+            modelDrainBacklogged = ownerAfter.drainBacklogged,
+            seedOperationInFlight = panesSeedInFlightThisAttach.contains(pane.paneId),
+            sizeOperationsInFlight = controlClientSizeOperationsInFlight.get(), automaticHealOperationsInFlight =
+                automaticHeal.activeCount, automaticHealActivityEpoch = automaticHeal.activityEpoch,
+            controlSizeGeneration = controlClientSizeGeneration,
+            effectiveColumns = effectiveControlClientColumns(), effectiveRows = effectiveControlClientRows(),
+            appliedColumns = appliedControlClientColumns, appliedRows = appliedControlClientRows,
+            lastSeedAtMs = paneLastSeedAtMs[pane.paneId], renderedNonBlankChars = rendered,
+            partiallyBlank = partial, renderLooksSuspect = suspect, coherent = ownerBefore == ownerAfter,
+        )
+    }
+    @androidx.annotation.VisibleForTesting
+    internal fun appendToActivePaneRenderModelForTest(bytes: ByteArray, expectedOwner: ActivePaneRenderOwnerSnapshotForTest, afterAppendBeforeSnapshotForTest: (() -> Unit)? = null):
+        ActivePaneRenderOwnerSnapshotForTest {
+        val before = activePaneRenderOwnerSnapshotForTest()
+        check(expectedOwner.attachResizeSeedSettled) { "expected owner was not settled: $expectedOwner" }
+        check(before.coherent && before.sameOwnerAs(expectedOwner)) {
+            "active render owner changed before injection: expected=$expectedOwner actual=$before"
+        }
+        check(before.modelMutationEpoch == expectedOwner.modelMutationEpoch) {
+            "active render model mutated before injection: expected=$expectedOwner actual=$before"
+        }
+        check(before.controlSizeGeneration == expectedOwner.controlSizeGeneration &&
+            before.sizeOperationsInFlight == 0 && before.automaticHealOperationsInFlight == 0 &&
+                before.automaticHealActivityEpoch == expectedOwner.automaticHealActivityEpoch &&
+            before.appliedColumns == expectedOwner.appliedColumns &&
+            before.appliedRows == expectedOwner.appliedRows
+        ) {
+            "attach/resize owner changed before injection: expected=$expectedOwner actual=$before"
+        }
+        val pane = checkNotNull(activeVisiblePane())
+        pane.terminalState.appendDirectlyToRenderModelForTesting(bytes)
+        afterAppendBeforeSnapshotForTest?.invoke()
+        val after = activePaneRenderOwnerSnapshotForTest()
+        check(after.coherent && after.sameOwnerAs(expectedOwner)) {
+            "active render owner changed during injection: expected=$expectedOwner actual=$after" }
+        check(after.modelMutationEpoch == expectedOwner.modelMutationEpoch + 1L) {
+            "unexpected concurrent model mutation during injection: expected=$expectedOwner actual=$after" }
+        check(after.automaticHealOperationsInFlight == 0 && after.automaticHealActivityEpoch ==
+            expectedOwner.automaticHealActivityEpoch) {
+            "automatic render heal raced injection: expected=$expectedOwner actual=$after" }
+        return after
+    }
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun healActivePaneIfStaleRenderResultForTest(expectedOwner: ActivePaneRenderOwnerSnapshotForTest):
+        HealAttemptResult {
+        val before = activePaneRenderOwnerSnapshotForTest()
+        check(before.coherent && before.sameOwnerAs(expectedOwner)) {
+            "active render owner changed before manual heal: expected=$expectedOwner actual=$before" }
+        check(before.modelMutationEpoch == expectedOwner.modelMutationEpoch &&
+            before.controlSizeGeneration == expectedOwner.controlSizeGeneration &&
+            before.sizeOperationsInFlight == 0 && before.automaticHealOperationsInFlight == 0 &&
+                before.automaticHealActivityEpoch == expectedOwner.automaticHealActivityEpoch
+        ) {
+            "active render model/resize changed before manual heal: expected=$expectedOwner actual=$before" }
+        return healActivePaneIfStaleRenderResultForTest()
+    }
+    @androidx.annotation.VisibleForTesting internal fun completeAutomaticRenderHealActivityCycleForTest() =
+        automaticRenderHealTracker.begin().also(automaticRenderHealTracker::complete)
     internal fun requestReconcileForTest(paneId: String, reason: ReconcileReason) {
         val client = clientRef ?: return
         requestReconcile(client, paneId, reason)
     }
-
-    /** Issue #1353 R4 (test seam): the R3 per-pane single-flight owner the reconcile routes through. */
     internal fun renderHealCoordinatorForTest(): RenderHealCoordinator = renderHealCoordinator
-
-    /**
-     * Issue #966/#967 (test seam): is the underlying tmux control client currently
-     * disconnected? The discriminating connected journey asserts this is FALSE while
-     * the render is stale — proving the transport is alive (a render bug, not a drop).
-     */
-    @androidx.annotation.VisibleForTesting
-    internal fun clientDisconnectedForTest(): Boolean = clientRef?.disconnected?.value ?: true
-
-    /**
-     * Issue #886: the attach reveal never produced a frame within the bounded
-     * blank-watchdog window — surface a retryable error so the user is NEVER
-     * left on an infinite "Attaching…" spinner. The control channel is up (green
-     * dot) but the active pane's `capture-pane` seed is wedged (the #470/#835
-     * enumeration-stall class on a streaming agent pane), so we drive the reveal
-     * to the honest-error surface [RevealState.Error] + the #823 Reconnect
-     * affordance by routing through the existing single-emitter [setConnectionState]
-     * `Unreachable` path (the SAME surface the 30 s panes-ready timeout uses).
-     * The current target is preserved as the reconnect target so the Reconnect
-     * button + pull-to-reconnect have something to re-dial.
-     */
+    @androidx.annotation.VisibleForTesting internal fun clientDisconnectedForTest(): Boolean = clientRef?.disconnected?.value ?: true
     private fun failStuckAttachReveal() {
         val target = activeTarget ?: connectingTarget
         Log.w(
@@ -11563,10 +11594,6 @@ public class TmuxSessionViewModel @Inject constructor(
             "maxTicks" to connectedBlankWatchdogMaxTicks,
             "tickMs" to CONNECTED_BLANK_WATCHDOG_TICK_MS,
         )
-        // Preserve the target so Reconnect has something to re-dial, then drive
-        // the honest-error surface via [ConnectionState.Unreachable] (the reveal
-        // machine + [SessionSurfaceState] resolve the held surface to the calm
-        // failure placeholder — no separate loading-overlay flag; #1326).
         connectingTarget = target
         refreshReconnectAvailability()
         val where = target?.let { " ${it.user}@${it.host}:${it.port}" } ?: ""
@@ -11577,38 +11604,13 @@ public class TmuxSessionViewModel @Inject constructor(
         )
     }
 
-    /**
-     * Issue #662: re-seed a single visible pane from `capture-pane` if its
-     * emulator is rendering a blank (black) screen. Called when the user
-     * switches to a window: tmux `-CC` never re-emits an idle window's existing
-     * content, so a window that was never successfully seeded (or whose seed was
-     * wiped by a reflow) would otherwise stay black no matter how many times the
-     * user switches to it. A no-op when the pane already shows content.
-     */
     public fun reseedVisiblePaneIfBlank(paneId: String) {
         val pane = paneRows[paneId] ?: return
         val client = clientRef ?: return
         if (client.disconnected.value) return
-        // Issue #830: a pane already seeded THIS attach ([panesSeededThisAttach]),
-        // or with a seed round-trip still IN FLIGHT
-        // ([panesSeedInFlightThisAttach]), has its authoritative `capture-pane`
-        // snapshot applied or arriving. The pager settles on the active pane the
-        // instant the route swaps — in the narrow window between the preload seed
-        // STARTING and its snapshot landing, so a `visibleScreenIsBlank()` read here
-        // is a drain-timing artifact racing the in-flight seed, NOT a
-        // genuinely-never-seeded window. Re-seeding then is the redundant cold-open
-        // reseed the #640 single-capture contract forbids (a 2nd `capture-pane`
-        // round-trip + relayout = visible flicker on a high-latency link). The #662
-        // heal this watchdog exists for is a window with NO seed this attach (a
-        // reused pane whose attach-time seed was missing/wiped), so the skip is
-        // scoped to seeded / in-flight panes only and never suppresses a real
-        // black-window heal.
         if (paneId in panesSeededThisAttach || paneId in panesSeedInFlightThisAttach) return
         if (!pane.terminalState.visibleScreenIsBlank()) return
         bridgeScope.launch {
-            // Re-check inside the coroutine: the pane may have painted between
-            // the synchronous guard and dispatch (a late `%output` landed), or its
-            // attach-time seed may have started in the meantime.
             if (paneId in panesSeededThisAttach || paneId in panesSeedInFlightThisAttach) return@launch
             if (!pane.terminalState.visibleScreenIsBlank()) return@launch
             Log.i(
@@ -11621,58 +11623,14 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
-     * Issue #966/#967 — the STALE-RENDER heal. The v0.4.17 black-screen heal only
-     * engages on a FULLY-blank or ≤3-live-line pane, so the maintainer's #966 pane
-     * — a connected Claude window rendering only a lone cursor + a couple of
-     * scattered status fragments while tmux's grid holds the full TUI — reads
-     * "not blank" and is SKIPPED, leaving a black-with-fragments pane on a LIVE
-     * transport (the keepalive keeps succeeding; the render is just stale).
-     *
-     * This heal captures the active pane ONCE, diffs the authoritative capture
-     * against what the local emulator actually rendered
-     * ([TerminalSurfaceState.visibleScreenDivergesFromCapture]), and re-seeds the
-     * pane ONLY when the render is mostly-black/stale relative to tmux. The diff
-     * is what keeps a legitimately sparse-but-correct pane from over-firing: when
-     * the render already matches tmux, the capture is applied as a no-op (the
-     * existing full clear+repaint is idempotent — re-painting the SAME
-     * authoritative content), but we skip even that to avoid a needless relayout.
-     *
-     * Returns true when a stale render was detected and re-seeded. The single
-     * `capture-pane` round-trip is paid ONLY on the watchdog cadence (the caller
-     * gates frequency), never per frame, so steady-state rendering is untouched.
-     */
-    /**
-     * Issue #1175 — fingerprint a degenerate (black / partial-black) frame into the
-     * EXPORTABLE diagnostics JSONL (the same ring the Settings → Diagnostics "Share
-     * log" export reads), so a maintainer who hits a black screen can SHARE the log and
-     * we can tell WHICH class of black screen it was.
-     *
-     * This is emitted ONLY from points the heal/reveal path ALREADY reaches on the
-     * existing gated, backed-off stale-render watchdog tick and the connect/switch
-     * reveal gate — it adds NO new timer/poll/coroutine loop (the deliberate contrast
-     * with the #1164 heat regression). It rides the same `capture-pane` round-trip the
-     * heal already pays; it never issues its own.
-     *
-     * Additive on the OBSERVE side: the successful-heal event (`stale_render_heal`)
-     * still fires from [healActivePaneIfStaleRender]; this fingerprints the frame that
-     * was observed degenerate regardless of whether a heal follows.
-     *
-     * The `class` discriminator is computed at each call site (deterministic per site,
-     * so a unit test can drive every class); this builder just attaches the shared
-     * geometry / lifecycle field set — all redacted by [DiagnosticRedactor] before it
-     * reaches disk (only `session` is host-identifying, as it already is on
-     * `stale_render_heal`).
+     * Record a #1175 degenerate frame using the capture the heal/reveal path already paid for.
+     * No timer, poll, or extra round-trip is introduced.
      */
     private fun recordBlackFrameObserved(
         pane: TmuxPaneState,
         blackClass: String,
         captureText: String?,
-        // Issue #1294: present only on the [BLACK_FRAME_CLASS_HEAL_CAPTURE_UNVERIFIED]
-        // class — the count of consecutive UNVERIFIED heal ticks (capture timeout / error /
-        // empty / mutex-starved) the watchdog has seen without a confirming capture. It lets
-        // a shared-log export distinguish a genuinely-healthy pane that BACKED OFF (watchdog
-        // throttled, unverifiedStreak absent) from a pane whose heal captures are WEDGED
-        // (watchdog BLIND, unverifiedStreak climbing) — the exact #1294 mechanism.
+        // Present only for BLACK_FRAME_CLASS_HEAL_CAPTURE_UNVERIFIED.
         unverifiedStreak: Int? = null,
     ) {
         val nowMs = SystemClock.elapsedRealtime()
@@ -11694,16 +11652,7 @@ public class TmuxSessionViewModel @Inject constructor(
         DiagnosticEvents.record("terminal", BLACK_FRAME_OBSERVED_EVENT, *fields)
     }
 
-    /**
-     * Issue #1294: record a watchdog tick whose authoritative `capture-pane` could NOT
-     * confirm the render's health (a [HealOutcome.Unverified] outcome — capture timeout,
-     * error response, empty-on-live-transport, or mutex-starved by a concurrent burst).
-     * Rides the existing exportable `black_frame_observed` ring (#1175 conventions) under a
-     * dedicated class + an `unverifiedStreak` field, so an export can tell an idle healthy
-     * pane that legitimately backed off from a pane whose heal captures are WEDGED while it
-     * is black (the #1294 "watchdog blind, not throttled" distinction). Emitted from the
-     * watchdog tick that already paid the capture — no new poll/timer/round-trip.
-     */
+    /** Record a #1294 unverified streak on the already-paid watchdog tick. */
     private fun recordHealCaptureUnverified(pane: TmuxPaneState, unverifiedStreak: Int) {
         recordBlackFrameObserved(
             pane,
@@ -11713,16 +11662,7 @@ public class TmuxSessionViewModel @Inject constructor(
         )
     }
 
-    /**
-     * Issue #1295 — emit the POSITIVE watchdog-liveness heartbeat ([WATCHDOG_LIVENESS_EVENT]).
-     * Called once per steady stale-render watchdog tick AFTER every gate has passed (runtime
-     * current + foregrounded + screen-on + a visible pane), so the heartbeat certifies exactly
-     * "an armed watchdog is ticking over a live-attached, foregrounded, visible pane". The
-     * runtime identity is [refreshGuard]'s `generation` + the live client identity hash, so an
-     * export can correlate the heartbeat to the same runtime the reconnect trail names, and its
-     * ABSENCE (while the export otherwise shows foreground+live) convicts the unarmed-watchdog
-     * bug. Rides the tick that already runs — no new poll/timer/round-trip.
-     */
+    /** Emit the #1295 liveness heartbeat after all watchdog gates pass. */
     private fun recordWatchdogLiveness(
         pane: TmuxPaneState,
         refreshGuard: RuntimeRefreshGuard,
@@ -11755,6 +11695,18 @@ public class TmuxSessionViewModel @Inject constructor(
         recordMilestone: Boolean = false,
         maxAttempts: Int = SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
     ): HealOutcome =
+        healActivePaneIfStaleRenderAttempt(
+            client, pane, refreshGuard, force, recordMilestone, maxAttempts,
+        ).outcome
+
+    private suspend fun healActivePaneIfStaleRenderAttempt(
+        client: TmuxClient,
+        pane: TmuxPaneState,
+        refreshGuard: RuntimeRefreshGuard?,
+        force: Boolean = false,
+        recordMilestone: Boolean = false,
+        maxAttempts: Int = SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
+    ): HealAttemptResult =
         // Issue #1353 R3 — SINGLE-FLIGHT per pane. Serialize the whole close→capture→apply→open
         // seed-gate (M9) window so a sibling launcher (L1 send / L2 watchdog / L5 reveal) on the
         // SAME pane can't cross into it and open the gate early, clobbering a buffered newer
@@ -11782,9 +11734,30 @@ public class TmuxSessionViewModel @Inject constructor(
         // Force-mode only: bound on the empty/near-blank capture retry loop (#693/#662).
         // Ignored on the oracle-gated (non-force) path, which pays exactly one capture.
         maxAttempts: Int,
-    ): HealOutcome {
-        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return HealOutcome.Unverified
-        if (client.disconnected.value) return HealOutcome.Unverified
+    ): HealAttemptResult {
+        // Issue #966: diagnostics describe the frame that triggered this attempt, not the
+        // frame after a successful reseed. Snapshot before any guard, capture, predicate, or
+        // apply can change the viewport and carry that immutable observation to every exit.
+        val observedRenderedNonBlankChars =
+            pane.terminalState.renderedNonBlankCharCount()
+        fun result(
+            reason: HealAttemptReason,
+            captureText: String? = null,
+            captureLineCount: Int = 0,
+        ): HealAttemptResult =
+            HealAttemptResult.create(
+                reason = reason,
+                renderedNonBlankChars = observedRenderedNonBlankChars,
+                captureNonBlankChars = captureText?.count { !it.isWhitespace() } ?: 0,
+                captureLineCount = captureLineCount,
+            )
+
+        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) {
+            return result(HealAttemptReason.RuntimeSupersededBeforeCapture)
+        }
+        if (client.disconnected.value) {
+            return result(HealAttemptReason.ClientDisconnectedBeforeCapture)
+        }
         // Issue #1353 R2 — the UNCONDITIONAL reseed (seed mode), folded in from the old
         // `seedPaneFromCapture`: capture tmux's authoritative grid and apply it WITHOUT the
         // oracle gate, RETRYING a transiently empty/near-blank capture (bounded); the
@@ -11801,14 +11774,18 @@ public class TmuxSessionViewModel @Inject constructor(
                 var attempt = 0
                 while (true) {
                     if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) {
-                        return HealOutcome.Unverified
+                        return result(HealAttemptReason.RuntimeSupersededBeforeCapture)
                     }
-                    if (client.disconnected.value) return HealOutcome.Unverified
+                    if (client.disconnected.value) {
+                        return result(HealAttemptReason.ClientDisconnectedBeforeCapture)
+                    }
                     if (captureAndApplyPaneSnapshot(client, pane, refreshGuard, recordMilestone)) {
-                        return HealOutcome.Healed
+                        return result(HealAttemptReason.ForcedSnapshotApplied)
                     }
                     attempt += 1
-                    if (attempt >= maxAttempts) return HealOutcome.Unverified
+                    if (attempt >= maxAttempts) {
+                        return result(HealAttemptReason.ForcedSnapshotUnavailable)
+                    }
                     // Short backoff so a flaky-link empty capture is re-tried after the
                     // channel has a moment to recover, without stalling a genuinely empty
                     // pane's reveal for long. The guard re-check at the top aborts
@@ -11858,7 +11835,7 @@ public class TmuxSessionViewModel @Inject constructor(
             surfaceBlack || pane.terminalState.renderLooksSuspect()
         if (quiesceLiveDeltas) pane.terminalState.closeSeedGate()
         try {
-        val combined = runCatching {
+        val captureAttempt = runCatching {
             withContext(seedIoDispatcher) {
                 client.captureWithCursor(
                     pane.paneId,
@@ -11866,20 +11843,23 @@ public class TmuxSessionViewModel @Inject constructor(
                     timeoutMs = seedCaptureTimeoutMs,
                 )
             }
-        }.getOrNull()
-        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return HealOutcome.Unverified
+        }
+        if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) {
+            return result(HealAttemptReason.RuntimeSupersededAfterCapture)
+        }
+        val combined = captureAttempt.getOrNull()
         val captureResponse = combined?.capture
-        if (captureResponse == null || captureResponse.isError || captureResponse.output.isEmpty()) {
+        val captureText = captureResponse?.output?.joinToString(separator = "\n")
+        val failedReason = when {
+            captureAttempt.isFailure -> HealAttemptReason.CaptureException
+            captureResponse?.isError == true -> HealAttemptReason.CaptureError
+            captureResponse?.output?.isEmpty() != false -> HealAttemptReason.CaptureEmpty
+            else -> null
+        }
+        if (failedReason != null) {
             // Issue #1294: the `capture-pane` round-trip could NOT confirm the render against
             // tmux's grid (timed out / errored / EMPTY on a live transport / starved by a
             // capture-mutex-holding burst). The surface repaint above already fired if black.
-            // Scoring turns on whether the LOCAL render looks LOST ([renderLooksSuspect]):
-            //  - LOOKS LOST → UNVERIFIED: we needed this capture to heal a suspect pane and
-            //    couldn't; the watchdog keeps the HOT cadence (retry at 4s) instead of scoring
-            //    the failure as healthy and backing off to 16s while the pane is black (the bug).
-            //  - looks HEALTHY → a momentary empty/failed capture over a dense render is a
-            //    no-op; scoring HEALTHY preserves the #1219/#1164 battery back-off.
-            val renderLooksLost = surfaceBlack || pane.terminalState.renderLooksSuspect()
             // Issue #1175: fingerprint the observed frame when degenerate so an export sees
             // WHICH class of black it was (rides this same failed capture — no new round-trip):
             // surface-only-black → #1192 class; empty capture over a degenerate render →
@@ -11896,9 +11876,15 @@ public class TmuxSessionViewModel @Inject constructor(
                 }
                 recordBlackFrameObserved(pane, blackClass, captureText = null)
             }
-            return if (renderLooksLost) HealOutcome.Unverified else HealOutcome.Healthy
+            return result(
+                reason = failedReason,
+                captureText = captureText,
+                captureLineCount = captureResponse?.output?.size ?: 0,
+            )
         }
-        val captureText = captureResponse.output.joinToString(separator = "\n")
+        checkNotNull(combined)
+        checkNotNull(captureResponse)
+        checkNotNull(captureText)
         // The discriminating check: tmux carries a real frame but the local render
         // shows almost none of it → stale render on a live transport. If the
         // render already matches tmux, this is false and we never touch the grid.
@@ -11928,7 +11914,11 @@ public class TmuxSessionViewModel @Inject constructor(
                     captureText,
                 )
             }
-            return HealOutcome.Healthy
+            return result(
+                reason = HealAttemptReason.AuthoritativeCaptureMatched,
+                captureText = captureText,
+                captureLineCount = captureResponse.output.size,
+            )
         }
         // Issue #1175: the render LOST tmux's frame (capture carries materially more
         // than the render). Fingerprint the observed black frame BEFORE the heal
@@ -11937,7 +11927,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // painted is `lost_after_paint`. This rides the heal's already-paid capture —
         // no new poll, and it is additive to `stale_render_heal` below (which still
         // fires on the successful heal).
-        val observedClass = if (pane.terminalState.renderedNonBlankCharCount() > 0) {
+        val observedClass = if (observedRenderedNonBlankChars > 0) {
             BLACK_FRAME_CLASS_PARTIAL_BLANK
         } else {
             BLACK_FRAME_CLASS_LOST_AFTER_PAINT
@@ -11971,9 +11961,17 @@ public class TmuxSessionViewModel @Inject constructor(
             // Issue #1294: the divergence was real but the surface write failed — the heal
             // did not complete, so this is UNVERIFIED (keep the hot cadence to retry), not a
             // confirmed-healthy back-off.
-            return HealOutcome.Unverified
+            return result(
+                reason = HealAttemptReason.DivergenceApplyFailed,
+                captureText = captureText,
+                captureLineCount = captureResponse.output.size,
+            )
         }
-        return HealOutcome.Healed
+        return result(
+            reason = HealAttemptReason.DivergenceApplied,
+            captureText = captureText,
+            captureLineCount = captureResponse.output.size,
+        )
         } finally {
             // Issue #1301 (fail-safe): if we quiesced above, REOPEN the seed gate on EVERY
             // exit — the HEALED path already opened it (via `seedThenOpenGate`, an idempotent
@@ -15789,7 +15787,8 @@ public class TmuxSessionViewModel @Inject constructor(
                 rows = rows,
             ),
         )
-        bridgeScope.launch {
+        controlClientSizeOperationsInFlight.incrementAndGet()
+        val refreshJob = bridgeScope.launch {
             val shouldApplyPolicy = !windowSizePolicyAppliedForAttach
             Log.i(
                 ISSUE_145_RECONNECT_TAG,
@@ -15918,6 +15917,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 )
             }
         }
+        refreshJob.invokeOnCompletion {
+            controlClientSizeOperationsInFlight.decrementAndGet()
+        }
     }
 
     /**
@@ -15956,7 +15958,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 "window=${activePane.windowId} session=${target.sessionName} " +
                 "blank=$blank partialBlank=$partialBlank",
         )
-        bridgeScope.launch {
+        val healOwner = automaticRenderHealTracker.begin(); val healJob = bridgeScope.launch {
             if (clientRef !== client) return@launch
             val guard = RuntimeRefreshGuard(
                 generation = attachGeneration,
@@ -15974,6 +15976,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 healActivePaneIfStaleRender(client, activePane, guard)
             }
         }
+        healJob.invokeOnCompletion { automaticRenderHealTracker.complete(healOwner) }
     }
 
     private fun resetControlClientSizeForAttach() {

--- a/app/src/test/java/com/pocketshell/app/tmux/AutomaticRenderHealTrackerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AutomaticRenderHealTrackerTest.kt
@@ -1,0 +1,83 @@
+package com.pocketshell.app.tmux
+
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.thread
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutomaticRenderHealTrackerTest {
+
+    @Test
+    fun idleBeginCompleteReturnsToIdleButPermanentlyAdvancesActivityEpoch() {
+        val tracker = AutomaticRenderHealTracker()
+        val idleBefore = tracker.snapshot()
+
+        val token = tracker.begin()
+        tracker.complete(token)
+        val idleAfter = tracker.snapshot()
+
+        assertEquals(0, idleBefore.activeCount)
+        assertEquals(0, idleAfter.activeCount)
+        assertTrue(idleBefore.activityEpoch > 0L)
+        assertNotEquals(idleBefore.activityEpoch, idleAfter.activityEpoch)
+        assertEquals(token, idleAfter.activityEpoch)
+    }
+
+    @Test
+    fun concurrentBeginsGetUniqueTokensAndEveryBeginAdvancesTheEpoch() {
+        val tracker = AutomaticRenderHealTracker()
+        val initialEpoch = tracker.snapshot().activityEpoch
+        val operationCount = 8
+        val allBegun = CountDownLatch(operationCount)
+        val release = CountDownLatch(1)
+        val tokens = Collections.synchronizedList(mutableListOf<Long>())
+        val workers = List(operationCount) {
+            thread {
+                val token = tracker.begin()
+                tokens += token
+                allBegun.countDown()
+                release.await()
+                tracker.complete(token)
+            }
+        }
+
+        assertTrue(allBegun.await(5, java.util.concurrent.TimeUnit.SECONDS))
+        val active = tracker.snapshot()
+        assertEquals(operationCount, active.activeCount)
+        assertEquals(initialEpoch + operationCount, active.activityEpoch)
+        assertEquals(operationCount, tokens.toSet().size)
+
+        release.countDown()
+        workers.forEach(Thread::join)
+        val completed = tracker.snapshot()
+        assertEquals(0, completed.activeCount)
+        assertEquals(active.activityEpoch, completed.activityEpoch)
+    }
+
+    @Test
+    fun epochOverflowFailsClosedWithoutCreatingAnActiveOwnerOrResettingToZero() {
+        val tracker = AutomaticRenderHealTracker(initialActivityEpoch = Long.MAX_VALUE)
+
+        assertThrows(ArithmeticException::class.java) { tracker.begin() }
+
+        val after = tracker.snapshot()
+        assertEquals(0, after.activeCount)
+        assertEquals(Long.MAX_VALUE, after.activityEpoch)
+    }
+
+    @Test
+    fun duplicateOrUnknownCompletionHardFailsWithoutChangingHistory() {
+        val tracker = AutomaticRenderHealTracker()
+        val token = tracker.begin()
+        tracker.complete(token)
+        val completed = tracker.snapshot()
+
+        assertThrows(IllegalStateException::class.java) { tracker.complete(token) }
+        assertThrows(IllegalStateException::class.java) { tracker.complete(token + 1L) }
+        assertEquals(completed, tracker.snapshot())
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/HealAttemptResultTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/HealAttemptResultTest.kt
@@ -1,0 +1,63 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HealAttemptResultTest {
+
+    @Test
+    fun reasonIsTheSingleOutcomeAuthority() {
+        val healthyReasons = HealAttemptReason.entries.filter { it.outcome == HealOutcome.Healthy }
+        val healedReasons = HealAttemptReason.entries.filter { it.outcome == HealOutcome.Healed }
+
+        assertEquals(
+            "Healthy is reserved for a successful nonempty capture whose predicate was false",
+            listOf(HealAttemptReason.AuthoritativeCaptureMatched),
+            healthyReasons,
+        )
+        assertEquals(
+            listOf(HealAttemptReason.DivergenceApplied, HealAttemptReason.ForcedSnapshotApplied),
+            healedReasons,
+        )
+        HealAttemptReason.entries
+            .filterNot { it in healthyReasons || it in healedReasons }
+            .forEach { reason ->
+                assertEquals("$reason must project to Unverified", HealOutcome.Unverified, reason.outcome)
+            }
+    }
+
+    @Test
+    fun captureFailureReasonsNeverProjectToHealthy() {
+        listOf(
+            HealAttemptReason.CaptureException,
+            HealAttemptReason.CaptureError,
+            HealAttemptReason.CaptureEmpty,
+        ).forEach { reason ->
+            val result = HealAttemptResult.create(
+                reason = reason,
+                renderedNonBlankChars = 500,
+                captureNonBlankChars = 500,
+                captureLineCount = 40,
+            )
+            assertEquals("$reason must remain exact", reason, result.reason)
+            assertEquals("$reason must stay hot/unverified", HealOutcome.Unverified, result.outcome)
+        }
+    }
+
+    @Test
+    fun retainedStatsAreNonnegativeAndBounded() {
+        val result = HealAttemptResult.create(
+            reason = HealAttemptReason.DivergenceApplied,
+            renderedNonBlankChars = -1,
+            captureNonBlankChars = Int.MAX_VALUE,
+            captureLineCount = Int.MAX_VALUE,
+        )
+
+        assertEquals(0, result.stats.renderedNonBlankChars)
+        assertEquals(HealAttemptStats.MAX_RETAINED_VALUE, result.stats.captureNonBlankChars)
+        assertEquals(HealAttemptStats.MAX_RETAINED_VALUE, result.stats.captureLineCount)
+        assertTrue(result.stats.toString().length < 180)
+        assertEquals(HealOutcome.Healed, result.outcome)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -243,12 +244,13 @@ class HealCaptureUnverifiedWatchdogTest {
             client.failBestEffortOnCommandPrefix = "capture-pane"
             client.bestEffortException = TmuxClientException("tmux command timed out")
         }
-        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
         advanceUntilIdle()
+        assertEquals(HealAttemptReason.CaptureException, result.reason)
         assertEquals(
             "a heal-capture TIMEOUT on a black pane is UNVERIFIED (keep hot)",
             HealOutcome.Unverified,
-            outcome,
+            result.outcome,
         )
     }
 
@@ -260,12 +262,14 @@ class HealCaptureUnverifiedWatchdogTest {
                 CommandResponse(number = 90L, output = listOf("capture-pane: no such pane"), isError = true),
             )
         }
-        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
         advanceUntilIdle()
+        assertEquals(HealAttemptReason.CaptureError, result.reason)
+        assertTrue("error response stats stay bounded", result.stats.captureNonBlankChars > 0)
         assertEquals(
             "a heal-capture ERROR response on a black pane is UNVERIFIED (keep hot)",
             HealOutcome.Unverified,
-            outcome,
+            result.outcome,
         )
     }
 
@@ -277,13 +281,64 @@ class HealCaptureUnverifiedWatchdogTest {
             client.defaultCaptureResponse = null
         }
         assertTrue("precondition: the transport is still connected", !vm.clientDisconnectedForTest())
-        val outcome = vm.healActivePaneIfStaleRenderForTest()
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
         advanceUntilIdle()
+        assertEquals(HealAttemptReason.CaptureEmpty, result.reason)
         assertEquals(
             "an EMPTY capture on a live transport over a black pane is UNVERIFIED (keep hot)",
             HealOutcome.Unverified,
-            outcome,
+            result.outcome,
         )
+    }
+
+    // Issue #966: failure classification is independent of whether the local viewport looks
+    // suspect. A dense, non-suspect render still cannot earn Healthy without a successful,
+    // nonempty authoritative capture whose lost-frame predicate returned false.
+
+    @Test
+    fun denseHealthyLocalCaptureExceptionIsUnverified() = runVmTest { _ ->
+        val vm = densePaneVm("%2") { client ->
+            client.failBestEffortOnCommandPrefix = "capture-pane"
+            client.bestEffortException = TmuxClientException("tmux command timed out")
+        }
+
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
+        advanceUntilIdle()
+
+        assertEquals(HealAttemptReason.CaptureException, result.reason)
+        assertEquals(HealOutcome.Unverified, result.outcome)
+        assertTrue(result.stats.renderedNonBlankChars > 0)
+    }
+
+    @Test
+    fun denseHealthyLocalCaptureErrorIsUnverified() = runVmTest { _ ->
+        val vm = densePaneVm("%3") { client ->
+            client.capturePaneResponses.addLast(
+                CommandResponse(number = 91L, output = listOf("capture-pane failed"), isError = true),
+            )
+        }
+
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
+        advanceUntilIdle()
+
+        assertEquals(HealAttemptReason.CaptureError, result.reason)
+        assertEquals(HealOutcome.Unverified, result.outcome)
+        assertTrue(result.stats.renderedNonBlankChars > 0)
+    }
+
+    @Test
+    fun denseHealthyLocalEmptyCaptureIsUnverified() = runVmTest { _ ->
+        val vm = densePaneVm("%4") { client ->
+            client.capturePaneResponses.clear()
+            client.defaultCaptureResponse = null
+        }
+
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
+        advanceUntilIdle()
+
+        assertEquals(HealAttemptReason.CaptureEmpty, result.reason)
+        assertEquals(HealOutcome.Unverified, result.outcome)
+        assertTrue(result.stats.renderedNonBlankChars > 0)
     }
 
     // ------------------------------------------------------------------ Harness
@@ -303,6 +358,25 @@ class HealCaptureUnverifiedWatchdogTest {
         advanceUntilIdle()
         pane.terminalState.appendRemoteOutput(CLEAR_ONLY.toByteArray(Charsets.US_ASCII))
         advanceUntilIdle()
+        configureFailure(client)
+        return vm
+    }
+
+    private fun TestScope.densePaneVm(
+        paneId: String,
+        configureFailure: (FakeTmuxClient) -> Unit,
+    ): TmuxSessionViewModel {
+        val client = FakeTmuxClient().withSinglePaneRow("work", paneId)
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == paneId }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        renderDenseFrame(pane)
+        advanceUntilIdle()
+        assertFalse(
+            "precondition: dense local viewport must not look suspect",
+            pane.terminalState.renderLooksSuspect(),
+        )
         configureFailure(client)
         return vm
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1495WatchdogCoverageTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1495WatchdogCoverageTest.kt
@@ -188,6 +188,32 @@ class Issue1495WatchdogCoverageTest {
         )
     }
 
+    @Test
+    fun diagnosticsPauseSeamCancelsAndJoinsTheCurrentWatchdog() = runVmTest {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+
+        vm.setStaleRenderWatchdogMaxTicksForTest(1000)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        val guard = requireNotNull(vm.currentRuntimeGuardForTest())
+        vm.armActivePaneStaleRenderWatchdogForTest(guard)
+        runCurrent()
+        val armed = requireNotNull(vm.staleRenderWatchdogJobForTest())
+        assertTrue("precondition: watchdog must be active before diagnostics pause", armed.isActive)
+
+        vm.pauseActivePaneStaleRenderWatchdogForTest()
+
+        assertTrue("pause must cancel the exact previously-armed job", armed.isCancelled)
+        assertTrue("pause must JOIN the exact previously-armed job", armed.isCompleted)
+        assertFalse(
+            "no automatic watchdog may remain active after the diagnostics seam returns",
+            vm.staleRenderWatchdogJobForTest()?.isActive == true,
+        )
+    }
+
     // -------------------------------------------------------------------------
     // Part 3 (red→green) — the reseed→arm CANCELLATION-WINDOW race. A cancel/teardown throw
     // between the reseed and the re-arm line must NOT leave a still-current runtime watchdog-

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue966HealDiagnosticsSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue966HealDiagnosticsSourceGuardTest.kt
@@ -1,0 +1,246 @@
+package com.pocketshell.app.tmux
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Source guard for the two connected journeys that own #966's manual one-pass evidence.
+ *
+ * The journeys are expensive emulator tests. These cheap checks stop a future cleanup from
+ * silently restoring the exact ambiguity that reopened #966: an auto-watchdog race, ignored
+ * latch timeout, Boolean outcome collapse, or artifact with no typed reason/stats.
+ */
+class Issue966HealDiagnosticsSourceGuardTest {
+
+    @Test
+    fun bothJourneysQuiesceBeforeInjectionAndRetainTypedEvidence() {
+        listOf(
+            "StaleRenderHealOnLiveTransportJourneyE2eTest.kt",
+            "AgentAltScreenPartialBlackHealJourneyE2eTest.kt",
+        ).forEach { name ->
+            val source = locateJourney(name)
+            val pause = source.indexOf("pauseAutomaticStaleRenderWatchdog()")
+            val settlement = source.indexOf("waitForSettledActiveRenderOwner(")
+            val injection = source.indexOf("feedFrameToActivePaneModel(")
+            val attemptArtifact = source.indexOf("writeHealAttemptArtifact(")
+            val exactAssertion = source.indexOf("HealAttemptReason.DivergenceApplied", attemptArtifact)
+
+            assertTrue("$name must pause the automatic watchdog", pause >= 0)
+            assertTrue("$name must pause before stale injection", injection >= 0 && pause < injection)
+            assertTrue("$name must await positive attach/resize/reseed settlement before injection",
+                settlement >= 0 && settlement < injection)
+            assertTrue("$name must inject through the exact active VM-owned model",
+                source.contains("appendToActivePaneRenderModelForTest(bytes, expectedOwner)"))
+            assertTrue("$name must prove TerminalView and VM emulator identity equality",
+                source.contains("viewEmulatorIdentity != expectedOwner.emulatorIdentity"))
+            assertTrue("$name must retain the injected owner through the pre-call oracle",
+                source.contains("snapshot.modelMutationEpoch != expectedOwner.modelMutationEpoch"))
+            assertTrue("$name must cancel+join through the atomic VM seam",
+                source.contains("pauseActivePaneStaleRenderWatchdogForTest()"))
+            assertTrue("$name must assert the watchdog is quiescent",
+                source.contains("staleRenderWatchdogJobForTest()?.isActive != true"))
+            assertTrue("$name must hard-assert latch completion",
+                source.contains("manual stale-render heal latch must complete within the bound"))
+            assertFalse("$name must not collapse the typed attempt to Boolean",
+                source.contains("private fun driveStaleRenderHeal(): Boolean"))
+            assertTrue("$name must require the exact healed reason",
+                source.contains("HealAttemptReason.DivergenceApplied"))
+            assertTrue("$name must require the typed Healed projection",
+                source.contains("HealOutcome.Healed"))
+            assertTrue("$name must write the typed attempt before a failing exact assertion",
+                attemptArtifact >= 0 && exactAssertion > attemptArtifact)
+            assertTrue("$name must prove the remote frame before the call",
+                source.contains("remoteCaptureChars >= MIN_AUTHORITATIVE_CAPTURE_CHARS"))
+            assertTrue("$name must prove the intended local stale model before the call",
+                source.contains("localStale.renderLooksSuspect"))
+            assertTrue("$name must bind typed stats to the pre-call stale viewport",
+                source.contains(
+                    "localStale.renderedNonBlankChars,\n" +
+                        "            healResult.stats.renderedNonBlankChars",
+                ))
+            assertTrue("$name must retain the exact reason per artifact",
+                source.contains("heal_reason=${'$'}{healResult.reason}"))
+            assertTrue("$name must retain bounded stats per artifact",
+                source.contains("heal_capture_non_blank_chars=") &&
+                    source.contains("heal_capture_line_count="))
+        }
+    }
+
+    @Test
+    fun vmPauseSeamDisablesFutureAutoArmAndJoinsCurrentJob() {
+        val source = locateMain("TmuxSessionViewModel.kt")
+        val seam = source.substringBetween(
+            "internal suspend fun pauseActivePaneStaleRenderWatchdogForTest()",
+            "// Issue #1166 (heal-latency fix)",
+        )
+
+        assertTrue(seam.contains("synchronized(staleRenderWatchdogArmLock)"))
+        assertTrue(seam.contains("staleRenderWatchdogAutoArmEnabled = false"))
+        assertTrue(seam.contains("current?.cancelAndJoin()"))
+    }
+
+    @Test
+    fun vmAttemptStatsAreSampledBeforeCaptureAndNeverAfterApply() {
+        val source = locateMain("TmuxSessionViewModel.kt")
+        val heal = source.substringBetween(
+            "private suspend fun healActivePaneIfStaleRenderLocked(",
+            "private suspend fun captureAndApplyPaneSnapshot(",
+        )
+        val snapshot = heal.indexOf("val observedRenderedNonBlankChars =")
+        val capture = heal.indexOf("val captureAttempt = runCatching")
+        val resultFactory = heal.substringBetween(
+            "fun result(",
+            "if (refreshGuard != null && !isCurrentRuntime(refreshGuard))",
+        )
+
+        assertTrue("local render stats must be sampled before capture", snapshot >= 0 && snapshot < capture)
+        assertTrue(
+            "every attempt result must carry the immutable pre-capture observation",
+            resultFactory.contains("renderedNonBlankChars = observedRenderedNonBlankChars"),
+        )
+        assertFalse(
+            "result creation must not resample a viewport that an apply may already have healed",
+            resultFactory.contains("pane.terminalState.renderedNonBlankCharCount()"),
+        )
+        val failedCaptureBranch = heal.substringBetween(
+            "if (failedReason != null) {",
+            "checkNotNull(combined)",
+        )
+        assertTrue(
+            "capture failures must preserve their exact unverified reason",
+            failedCaptureBranch.contains("reason = failedReason"),
+        )
+        assertFalse(
+            "capture failures cannot claim an authoritative match",
+            failedCaptureBranch.contains("HealAttemptReason.AuthoritativeCaptureMatched"),
+        )
+    }
+
+    @Test
+    fun vmOwnerSeamHardFailsUnequalOrUnsettledInjection() {
+        val seam = locateMain("ActivePaneRenderOwnerSnapshotForTest.kt") +
+            locateMain("TmuxSessionViewModel.kt")
+        assertTrue(seam.contains("attachResizeSeedSettled"))
+        assertTrue(seam.contains("sizeOperationsInFlight == 0"))
+        assertTrue(seam.contains("automaticHealOperationsInFlight == 0"))
+        assertTrue(seam.contains("automaticHealActivityEpoch == expectedOwner.automaticHealActivityEpoch"))
+        assertTrue(seam.contains("appliedColumns == effectiveColumns"))
+        assertTrue(seam.contains("appliedRows == effectiveRows"))
+        assertTrue(seam.contains("lastSeedAtMs != null"))
+        assertTrue(seam.contains("before.sameOwnerAs(expectedOwner)"))
+        assertTrue(seam.contains("before.modelMutationEpoch == expectedOwner.modelMutationEpoch"))
+        assertTrue(seam.contains("appendDirectlyToRenderModelForTesting(bytes)"))
+
+        val regression = locateTest("PartialBlackPaneHealTest.kt")
+        assertTrue(regression.contains("issue966ManualInjectionRejectsAnUnequalVisibleEmulatorOwner"))
+        assertTrue(regression.contains("issue966ManualInjectionRejectsAnUnequalVisibleTerminalSessionOwner"))
+        assertTrue(regression.contains("issue966ManualInjectionRejectsInjectionBeforeResizeSettlement"))
+        assertTrue(regression.contains("issue966ManualProofRejectsQueuedNoOpResizeHealUntilCompletion"))
+        assertTrue(regression.contains("issue966ManualOwnerRatchetRejectsCompletedAutomaticHealAba"))
+        assertTrue(regression.contains("issue966InjectionRejectsCompletedAutomaticHealBeforePostInjectionSnapshot"))
+
+        val postInjection = locateMain("TmuxSessionViewModel.kt").substringBetween(
+            "val after = activePaneRenderOwnerSnapshotForTest()",
+            "return after",
+        )
+        assertTrue(postInjection.contains("after.automaticHealOperationsInFlight == 0"))
+        assertTrue(postInjection.contains(
+            "after.automaticHealActivityEpoch ==\n            expectedOwner.automaticHealActivityEpoch",
+        ))
+    }
+
+    @Test
+    fun journeysBindVisibleTerminalSessionAndAutomaticHealSettlement() {
+        listOf(
+            "StaleRenderHealOnLiveTransportJourneyE2eTest.kt",
+            "AgentAltScreenPartialBlackHealJourneyE2eTest.kt",
+        ).forEach { name ->
+            val source = locateJourney(name)
+            assertTrue("$name must sample the visible TerminalSession identity",
+                source.contains("viewTerminalSessionIdentity"))
+            assertTrue("$name must compare it with the VM owner",
+                source.contains("terminalSessionIdentity"))
+            assertTrue("$name artifacts must retain it",
+                source.contains("view_terminal_session_identity="))
+            assertTrue("$name must reject pending automatic heals",
+                source.contains("automaticHealOperationsInFlight != 0"))
+            assertTrue("$name must reject automatic-heal ABA at every owner checkpoint",
+                source.split("automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch").size >= 4)
+            assertTrue("$name artifacts must retain the automatic-heal epoch",
+                source.contains("expected_automatic_heal_activity_epoch="))
+        }
+
+        val vm = locateMain("TmuxSessionViewModel.kt")
+        val resizeHeal = vm.substringBetween(
+            "private fun maybeHealActivePaneOnNoOpResize",
+            "private fun resetControlClientSizeForAttach",
+        )
+        assertTrue(resizeHeal.indexOf("automaticRenderHealTracker.begin()") <
+            resizeHeal.indexOf("bridgeScope.launch"))
+        assertTrue(resizeHeal.contains("healJob.invokeOnCompletion"))
+        assertTrue(resizeHeal.contains("automaticRenderHealTracker.complete(healOwner)"))
+
+        val tracker = locateMain("AutomaticRenderHealTracker.kt")
+        assertTrue(tracker.contains("Math.incrementExact(activityEpoch)"))
+        assertTrue(tracker.contains("Activity(activeCount = activeTokens.size, activityEpoch = activityEpoch)"))
+        assertFalse(tracker.substringAfter("fun complete(token: Long)").substringBefore("fun snapshot()")
+            .contains("activityEpoch ="))
+    }
+
+    @Test
+    fun denseLocalCaptureFailuresCannotProjectHealthy() {
+        val source = locateTest("HealCaptureUnverifiedWatchdogTest.kt")
+        mapOf(
+            "denseHealthyLocalCaptureExceptionIsUnverified" to "HealAttemptReason.CaptureException",
+            "denseHealthyLocalCaptureErrorIsUnverified" to "HealAttemptReason.CaptureError",
+            "denseHealthyLocalEmptyCaptureIsUnverified" to "HealAttemptReason.CaptureEmpty",
+        ).forEach { (testName, exactReason) ->
+            val test = source.substringBetween("fun $testName()", "\n    @Test", allowEndOfText = true)
+            assertTrue("$testName must use the dense non-suspect harness", test.contains("densePaneVm("))
+            assertTrue("$testName must require $exactReason", test.contains(exactReason))
+            assertTrue("$testName must remain Unverified", test.contains("HealOutcome.Unverified"))
+        }
+        assertTrue(
+            "dense harness must prove the local viewport is not suspect",
+            source.contains("pane.terminalState.renderLooksSuspect()"),
+        )
+    }
+
+    private fun locateJourney(name: String): String =
+        locate(
+            "app/src/androidTest/java/com/pocketshell/app/proof/$name",
+            "src/androidTest/java/com/pocketshell/app/proof/$name",
+        )
+
+    private fun locateMain(name: String): String =
+        locate(
+            "app/src/main/java/com/pocketshell/app/tmux/$name",
+            "src/main/java/com/pocketshell/app/tmux/$name",
+        )
+
+    private fun locateTest(name: String): String =
+        locate(
+            "app/src/test/java/com/pocketshell/app/tmux/$name",
+            "src/test/java/com/pocketshell/app/tmux/$name",
+        )
+
+    private fun locate(vararg candidates: String): String {
+        val file = candidates.asSequence().map(::File).firstOrNull(File::isFile)
+            ?: error("Could not locate ${candidates.joinToString()} from ${File(".").absolutePath}")
+        return file.readText()
+    }
+
+    private fun String.substringBetween(
+        start: String,
+        end: String,
+        allowEndOfText: Boolean = false,
+    ): String {
+        val startIndex = indexOf(start)
+        check(startIndex >= 0) { "$start not found" }
+        val endIndex = indexOf(end, startIndex)
+        check(endIndex >= 0 || allowEndOfText) { "$end not found after $start" }
+        return substring(startIndex, if (endIndex >= 0) endIndex else length)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -85,6 +86,121 @@ class PartialBlackPaneHealTest {
 
     private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val createdVms = mutableListOf<TmuxSessionViewModel>()
+
+    @Test
+    fun issue966ManualInjectionRejectsAnUnequalVisibleEmulatorOwner() = runVmTest {
+        val vm = connectVm(FakeTmuxClient().withSinglePaneRow("work", "%owner"))
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        val settled = vm.activePaneRenderOwnerSnapshotForTest()
+        assertTrue("precondition: owner must be settled", settled.attachResizeSeedSettled)
+
+        val mismatch = settled.copy(
+            emulatorIdentity = requireNotNull(settled.emulatorIdentity) + 1,
+        )
+        assertThrows(IllegalStateException::class.java) {
+            vm.appendToActivePaneRenderModelForTest("stale".toByteArray(), mismatch)
+        }
+    }
+
+    @Test
+    fun issue966ManualInjectionRejectsAnUnequalVisibleTerminalSessionOwner() = runVmTest {
+        val vm = connectVm(FakeTmuxClient().withSinglePaneRow("work", "%session-owner"))
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        val settled = vm.activePaneRenderOwnerSnapshotForTest()
+        assertTrue("precondition: owner must be settled", settled.attachResizeSeedSettled)
+
+        val mismatch = settled.copy(
+            terminalSessionIdentity = requireNotNull(settled.terminalSessionIdentity) + 1,
+        )
+        assertThrows(IllegalStateException::class.java) {
+            vm.appendToActivePaneRenderModelForTest("stale".toByteArray(), mismatch)
+        }
+    }
+
+    @Test
+    fun issue966ManualInjectionRejectsInjectionBeforeResizeSettlement() = runVmTest {
+        val vm = connectVm(FakeTmuxClient().withSinglePaneRow("work", "%unsettled"))
+        val unsettled = vm.activePaneRenderOwnerSnapshotForTest()
+        assertFalse("precondition: no measured/applied grid yet", unsettled.attachResizeSeedSettled)
+
+        assertThrows(IllegalStateException::class.java) {
+            vm.appendToActivePaneRenderModelForTest("stale".toByteArray(), unsettled)
+        }
+    }
+
+    @Test
+    fun issue966ManualProofRejectsQueuedNoOpResizeHealUntilCompletion() = runVmTest {
+        val vm = connectVm(FakeTmuxClient().withSinglePaneRow("work", "%queued-heal"))
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        val settled = vm.activePaneRenderOwnerSnapshotForTest()
+        assertTrue("precondition: owner must be settled", settled.attachResizeSeedSettled)
+
+        val stale = vm.appendToActivePaneRenderModelForTest(
+            "\u001b[2J\u001b[Hstatus".toByteArray(),
+            settled,
+        )
+        assertTrue("precondition: synthetic frame is suspect", stale.renderLooksSuspect)
+        assertTrue(vm.triggerSameDimensionResizeHealForTest())
+
+        val queued = vm.activePaneRenderOwnerSnapshotForTest()
+        assertEquals(1, queued.automaticHealOperationsInFlight)
+        assertTrue(queued.automaticHealActivityEpoch > settled.automaticHealActivityEpoch)
+        assertFalse("a queued automatic heal is not settled", queued.attachResizeSeedSettled)
+        assertThrows(IllegalStateException::class.java) {
+            vm.appendToActivePaneRenderModelForTest("must reject".toByteArray(), stale)
+        }
+
+        advanceUntilIdle()
+        val completed = vm.activePaneRenderOwnerSnapshotForTest()
+        assertEquals(0, completed.automaticHealOperationsInFlight)
+        assertEquals(queued.automaticHealActivityEpoch, completed.automaticHealActivityEpoch)
+        assertTrue("proof may settle only after automatic heal completion", completed.attachResizeSeedSettled)
+    }
+
+    @Test
+    fun issue966ManualOwnerRatchetRejectsCompletedAutomaticHealAba() = runVmTest {
+        val vm = connectVm(FakeTmuxClient().withSinglePaneRow("work", "%heal-aba"))
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        val settled = vm.activePaneRenderOwnerSnapshotForTest()
+        assertTrue("precondition: owner must be settled", settled.attachResizeSeedSettled)
+
+        vm.completeAutomaticRenderHealActivityCycleForTest()
+        val laterIdle = vm.activePaneRenderOwnerSnapshotForTest()
+        assertEquals(0, laterIdle.automaticHealOperationsInFlight)
+        assertTrue(laterIdle.attachResizeSeedSettled)
+        assertTrue(laterIdle.automaticHealActivityEpoch > settled.automaticHealActivityEpoch)
+
+        assertThrows(IllegalStateException::class.java) {
+            vm.appendToActivePaneRenderModelForTest("must reject ABA".toByteArray(), settled)
+        }
+    }
+
+    @Test
+    fun issue966InjectionRejectsCompletedAutomaticHealBeforePostInjectionSnapshot() = runVmTest {
+        val vm = connectVm(FakeTmuxClient().withSinglePaneRow("work", "%heal-mid-injection"))
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        val settled = vm.activePaneRenderOwnerSnapshotForTest()
+        assertTrue("precondition: owner must be settled", settled.attachResizeSeedSettled)
+        var activityBetweenInjectionAndSnapshot: ActivePaneRenderOwnerSnapshotForTest? = null
+
+        val rejected = assertThrows(IllegalStateException::class.java) {
+            vm.appendToActivePaneRenderModelForTest("stale".toByteArray(), settled) {
+                vm.completeAutomaticRenderHealActivityCycleForTest()
+                activityBetweenInjectionAndSnapshot = vm.activePaneRenderOwnerSnapshotForTest()
+            }
+        }
+
+        val completed = requireNotNull(activityBetweenInjectionAndSnapshot)
+        assertEquals(settled.modelMutationEpoch + 1L, completed.modelMutationEpoch)
+        assertEquals(0, completed.automaticHealOperationsInFlight)
+        assertTrue(completed.automaticHealActivityEpoch > settled.automaticHealActivityEpoch)
+        assertTrue(rejected.message.orEmpty().contains("automatic render heal raced injection"))
+    }
 
     @After
     fun tearDown() {
@@ -359,16 +475,23 @@ class PartialBlackPaneHealTest {
             CommandResponse(number = 99L, output = SPARSE_AGENT_FRAME, isError = false),
         )
         val healCapturesBefore = client.healCaptureCount()
+        val staleRenderedNonBlankChars = pane.terminalState.renderedNonBlankCharCount()
 
         // THE REAL PATH: one steady-state stale-render watchdog tick over the active pane.
-        val healed = vm.healActivePaneIfStaleRenderForTest()
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
         advanceUntilIdle()
 
+        assertEquals(HealAttemptReason.DivergenceApplied, result.reason)
+        assertEquals(
+            "diagnostics retain the stale pre-apply viewport rather than the healed frame",
+            staleRenderedNonBlankChars,
+            result.stats.renderedNonBlankChars,
+        )
         assertEquals(
             "REGRESSION (#1138): the steady-state watchdog must heal a partial-black " +
                 "alt-screen agent pane. On base the divergence-only predicate skipped it.",
             HealOutcome.Healed,
-            healed,
+            result.outcome,
         )
         assertTrue(
             "the watchdog issued a heal capture-pane",
@@ -408,15 +531,21 @@ class PartialBlackPaneHealTest {
             CommandResponse(number = 98L, output = listOf(" Working 7  esc to interrupt"), isError = false),
         )
 
-        val healed = vm.healActivePaneIfStaleRenderForTest()
+        val result = vm.healActivePaneIfStaleRenderResultForTest()
         advanceUntilIdle()
 
+        assertEquals(
+            "Healthy is reserved for a successful nonempty authoritative capture whose " +
+                "lost-frame predicate returned false",
+            HealAttemptReason.AuthoritativeCaptureMatched,
+            result.reason,
+        )
         assertEquals(
             "OVER-HEAL GUARD (#1138/#807): when tmux's alt-screen capture is ALSO near-empty " +
                 "there is no lost frame to restore — the watchdog reads the pane HEALTHY and " +
                 "must NOT heal",
             HealOutcome.Healthy,
-            healed,
+            result.outcome,
         )
         assertTrue(
             "the pane is left untouched (still partial-black) — no reseed-thrash on a " +

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
@@ -229,15 +229,15 @@ class StaleRenderWatchdogGatingTest {
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
 
-        // Issue #1294: model a CONFIRMED-healthy idle pane — a DENSE, fully-rendered viewport
-        // (not the 1-line "work ready" partial-blank, which now reads SUSPECT and correctly
-        // stays hot). Each watchdog tick's empty capture over a confidently-dense render scores
-        // HEALTHY (a non-urgent no-op), so the #1219/#1164 battery back-off (4s->8s->16s) holds.
+        // Issue #966: model a CONFIRMED-healthy idle pane — a DENSE, fully-rendered viewport
+        // plus a matching, nonempty authoritative capture on every tick. An empty capture is
+        // UNVERIFIED regardless of local density and must stay hot.
         pane.terminalState.appendRemoteOutput(denseHealthyFrame().toByteArray(Charsets.US_ASCII))
+        client.defaultCaptureResponse = denseHealthyCaptureResponse()
         advanceUntilIdle()
         assertFalse(
-            "precondition: the idle pane is confidently DENSE (not suspect), so an empty " +
-                "capture scores HEALTHY and the pane backs off",
+            "precondition: the idle pane is confidently DENSE (not suspect), and matching " +
+                "authoritative captures let it back off",
             pane.terminalState.renderLooksSuspect(),
         )
 
@@ -282,9 +282,10 @@ class StaleRenderWatchdogGatingTest {
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
 
-        // A DENSE, confidently-healthy idle viewport: each tick's empty capture scores
-        // HEALTHY (a non-urgent no-op), so the pane cools all the way to the ceiling.
+        // A DENSE viewport plus a matching, nonempty capture confirms HEALTHY on each tick,
+        // so the pane cools all the way to the ceiling.
         pane.terminalState.appendRemoteOutput(denseHealthyFrame().toByteArray(Charsets.US_ASCII))
+        client.defaultCaptureResponse = denseHealthyCaptureResponse()
         advanceUntilIdle()
         assertFalse(
             "precondition: the idle pane is confidently DENSE (not suspect), so it cools",
@@ -343,6 +344,7 @@ class StaleRenderWatchdogGatingTest {
         // CONFIDENTLY HEALTHY — a real continuously-streaming agent pane, NOT blank /
         // partial-black / fragments-over-black.
         pane.terminalState.appendRemoteOutput(denseHealthyFrame().toByteArray(Charsets.US_ASCII))
+        client.defaultCaptureResponse = denseHealthyCaptureResponse()
         advanceUntilIdle()
         assertFalse(
             "precondition: a dense pane must NOT read as a possible lost frame " +
@@ -353,9 +355,8 @@ class StaleRenderWatchdogGatingTest {
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
         vm.setProcessForegroundForClearedForTest(true)
         vm.setScreenInteractiveForTest(true)
-        // The watchdog captures return an EMPTY frame each tick (no queued response),
-        // so healActivePaneIfStaleRender no-ops (healed=false) and never repaints —
-        // the dense render is preserved as HEALTHY the whole window.
+        // Matching, nonempty watchdog captures confirm the dense render as HEALTHY and never
+        // repaint it. Empty captures are deliberately not used: #966 classifies them Unverified.
         val guard = requireNotNull(vm.currentRuntimeGuardForTest())
         vm.armActivePaneStaleRenderWatchdogForTest(guard)
         runCurrent()
@@ -406,16 +407,15 @@ class StaleRenderWatchdogGatingTest {
         vm.resizeRemotePty(80, 40)
         advanceUntilIdle()
 
-        // Issue #1294: the pane STREAMS a DENSE, confidently-healthy frame first — the "S" in
-        // "STREAMING pane". Each backoff-phase tick's empty capture over this dense render
-        // scores HEALTHY (a non-urgent no-op), so the pane backs off (a partial-blank pane
-        // would now correctly stay hot). The fragments-over-black redraw below then makes it
-        // suspect.
+        // The pane STREAMS a DENSE frame first — the "S" in "STREAMING pane". Matching,
+        // nonempty captures confirm it HEALTHY during the backoff phase; the
+        // fragments-over-black redraw below then makes it suspect.
         pane.terminalState.appendRemoteOutput(denseHealthyFrame().toByteArray(Charsets.US_ASCII))
+        client.defaultCaptureResponse = denseHealthyCaptureResponse()
         advanceUntilIdle()
 
         // Let the watchdog back off to the widest (16s) interval — captures at t=4s,
-        // t=12s (empty capture over a confidently-dense render => HEALTHY no-op).
+        // t=12s (matching capture over a confidently-dense render => HEALTHY no-op).
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
         vm.setProcessForegroundForClearedForTest(true)
         vm.setScreenInteractiveForTest(true)
@@ -478,6 +478,7 @@ class StaleRenderWatchdogGatingTest {
         advanceUntilIdle()
 
         pane.terminalState.appendRemoteOutput(denseHealthyFrame().toByteArray(Charsets.US_ASCII))
+        client.defaultCaptureResponse = denseHealthyCaptureResponse()
         advanceUntilIdle()
         vm.setStaleRenderWatchdogMaxTicksForTest(1000)
         vm.setProcessForegroundForClearedForTest(true)
@@ -786,8 +787,14 @@ class StaleRenderWatchdogGatingTest {
      */
     private fun denseHealthyFrame(): String = buildString {
         append(CLEAR_ONLY)
-        repeat(32) { append("agent response line $it with real streamed content\r\n") }
+        denseHealthyLines().forEach { append(it).append("\r\n") }
     }
+
+    private fun denseHealthyLines(): List<String> =
+        List(32) { "agent response line $it with real streamed content" }
+
+    private fun denseHealthyCaptureResponse(): CommandResponse =
+        CommandResponse(number = 80L, output = denseHealthyLines(), isError = false)
 
     /**
      * A FRAGMENTS-OVER-BLACK viewport (#966/#1214): a CSI 2J clear then a handful of

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPassiveReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPassiveReconnectTest.kt
@@ -1012,6 +1012,15 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
                 "reattached pane — never a permanent black on a live transport.",
             pane.terminalState.visibleScreenIsBlank(),
         )
+        // Issue #966: the fixture intentionally returns empty captures before recovery.
+        // Empty is now correctly UNVERIFIED and keeps the lifetime watcher hot, so letting
+        // runTest auto-drain it would spin virtual time forever. Quiesce the owned watcher
+        // explicitly after the load-bearing heal assertion.
+        vm.pauseActivePaneStaleRenderWatchdogForTest()
+        assertFalse(
+            "test teardown must not leave a self-rearming unverified watcher for runTest",
+            vm.staleRenderWatchdogJobForTest()?.isActive == true,
+        )
     }
 
     @Test
@@ -1100,6 +1109,11 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             "Issue #1177 (:8319): the stale-render heal must repaint the black " +
                 "reattached pane — never a permanent black on a live transport.",
             pane.terminalState.visibleScreenIsBlank(),
+        )
+        vm.pauseActivePaneStaleRenderWatchdogForTest()
+        assertFalse(
+            "test teardown must not leave a self-rearming unverified watcher for runTest",
+            vm.staleRenderWatchdogJobForTest()?.isActive == true,
         )
     }
 

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.ceil
 
 enum class TerminalRawInputPolicy {
@@ -97,6 +98,7 @@ class TerminalSurfaceState(
     public constructor() : this(Dispatchers.IO)
 
     private var _session: TerminalSession? by mutableStateOf(null)
+    private val renderModelMutationEpoch = AtomicLong(0L)
 
     /**
      * Backing flow for [output]. Replay = 0 — bytes are only delivered to
@@ -387,6 +389,7 @@ class TerminalSurfaceState(
     fun attach(session: TerminalSession) {
         if (_session === session) return
         _session = session
+        renderModelMutationEpoch.incrementAndGet()
     }
 
     /**
@@ -395,6 +398,7 @@ class TerminalSurfaceState(
      * it; this method only severs the state-holder ↔ session link.
      */
     fun detach() {
+        if (_session != null) renderModelMutationEpoch.incrementAndGet()
         _session = null
     }
 
@@ -433,6 +437,7 @@ class TerminalSurfaceState(
             // surface, or a re-seed) this is just an ordinary feed plus an
             // already-open-gate no-op.
             activeBridge.seedThenOpenGate(clean)
+            renderModelMutationEpoch.incrementAndGet()
             _output.tryEmit(clean)
             bufferTick.value = bufferTick.value + 1
         }
@@ -1434,6 +1439,7 @@ class TerminalSurfaceState(
                             }
                             if (clean.isNotEmpty()) {
                                 newBridge.feedBytes(clean)
+                                renderModelMutationEpoch.incrementAndGet()
                                 _output.tryEmit(clean)
                                 // Tick the buffer signal so debounced consumers of
                                 // [flowOfMatches] re-run the detector. Cheap: just a
@@ -1462,6 +1468,49 @@ class TerminalSurfaceState(
         }
         producerJob = job
         return job
+    }
+
+    /**
+     * Issue #966 connected-proof seam. This is an identity-bearing snapshot of the
+     * exact emulator model owned by this state, plus a monotonic epoch for every
+     * accepted producer/seed/rebind mutation. It adds no production control flow.
+     */
+    @androidx.annotation.VisibleForTesting
+    public data class RenderModelOwnerSnapshot(
+        val stateIdentity: Int,
+        val sessionIdentity: Int?,
+        val emulatorIdentity: Int?,
+        val mutationEpoch: Long,
+        val drainBacklogged: Boolean,
+    )
+
+    @androidx.annotation.VisibleForTesting
+    public fun renderModelOwnerSnapshotForTesting(): RenderModelOwnerSnapshot {
+        val activeBridge = bridge
+        val activeSession = activeBridge?.session ?: _session
+        val activeEmulator = activeBridge?.emulator ?: activeSession?.emulator
+        return RenderModelOwnerSnapshot(
+            stateIdentity = System.identityHashCode(this),
+            sessionIdentity = activeSession?.let(System::identityHashCode),
+            emulatorIdentity = activeEmulator?.let(System::identityHashCode),
+            mutationEpoch = renderModelMutationEpoch.get(),
+            drainBacklogged = renderDrainBacklogged(),
+        )
+    }
+
+    /**
+     * Issue #966 connected-proof seam: inject into this state's exact active model.
+     * The caller must first bind this owner to the visible TerminalView and retain
+     * the returned epoch through the pre-call oracle; any late producer/reseed then
+     * changes the epoch and hard-fails the proof.
+     */
+    @androidx.annotation.VisibleForTesting
+    public fun appendDirectlyToRenderModelForTesting(bytes: ByteArray): RenderModelOwnerSnapshot {
+        val emulator = bridge?.emulator ?: _session?.emulator
+            ?: error("no active emulator model")
+        emulator.append(bytes, bytes.size)
+        renderModelMutationEpoch.incrementAndGet()
+        return renderModelOwnerSnapshotForTesting()
     }
 
     /**


### PR DESCRIPTION
Closes #966

## Summary
- make stale-render heal outcomes typed and fail closed on missing/error/empty authoritative captures
- track exact render-model and automatic-heal ownership through settlement, injection, and pre-call ratchets
- add durable alternate-screen, stale-render, ABA, concurrency, overflow, and mutation regressions

## Independent review
APPROVED after five adversarial rounds. The final reviewer independently deleted only the post-injection count/epoch ratchet and confirmed the new behavioral regression failed, then restored the reviewed source byte-for-byte.

## Verification
- focused: 82/82
- forced Android-test build: 274/274 actions
- fresh emulator + Docker journeys: alternate-screen 1/1; stale-render all kinds 1/1; zero skips/failures
- full app: 4,138 tests; zero failures/errors/skips
- canonical JVM: 11,366 tests across 1,193 suites; zero failures/errors/skips; 603/603 actions
- static validity, file-size, VM-ratchet, shell, diff, source-hash, artifact, and cleanup audits green

The branch is refreshed byte-for-byte onto exact main `0dd254e165d9c5f9aa9700c2028cb94eece79734`; intervening #1781 packaging files do not overlap.