### PR TITLE
fix: bound session service lifecycle (#1757)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
@@ -1,6 +1,5 @@
 package com.pocketshell.app.sessions.service
 
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -19,6 +18,7 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.R
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.portfwd.DefaultDispatcher
+import com.pocketshell.app.settings.AppSettings
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -56,11 +56,34 @@ class SessionConnectionService : Service() {
     private var wakeLock: PowerManager.WakeLock? = null
     private var hasStartedForeground = false
 
+    @androidx.annotation.VisibleForTesting
+    internal enum class StartupPhase {
+        WAKE_LOCK_ACQUIRED,
+        SNAPSHOT_OBSERVED,
+    }
+
+    /**
+     * Behavioral ordering probe for the foreground-service startup envelope. Null in production.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal var startupPhaseForTest: ((StartupPhase) -> Unit)? = null
+
     companion object {
         private const val TAG = "PsSessionService"
         private const val CHANNEL_ID = "pocketshell_session_status_v1"
         private const val NOTIFICATION_ID = 0x70_53_53_56 // "pSSV"
         private const val WAKE_LOCK_TAG = "PocketShell:session"
+
+        /**
+         * The platform timeout is defense in depth for a hung teardown/ownership regression.
+         * Normal foreground handoff and grace completion still release the lock immediately.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal const val WAKE_LOCK_TEARDOWN_MARGIN_MILLIS: Long = 30_000L
+
+        @androidx.annotation.VisibleForTesting
+        internal const val WAKE_LOCK_TIMEOUT_MILLIS: Long =
+            AppSettings.MAX_BACKGROUND_GRACE_MILLIS + WAKE_LOCK_TEARDOWN_MARGIN_MILLIS
 
         const val ACTION_START = "com.pocketshell.app.sessions.action.START_SESSION_HOLD"
         const val ACTION_STOP = "com.pocketshell.app.sessions.action.STOP_SESSION_HOLD"
@@ -153,7 +176,9 @@ class SessionConnectionService : Service() {
                 }
             }
         }
-        return START_STICKY
+        // The service can hold only an already-live in-process transport. Process recreation has
+        // no recoverable SSH/tmux state to resurrect, so Android must not schedule a sticky retry.
+        return START_NOT_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -176,6 +201,7 @@ class SessionConnectionService : Service() {
         observeJob = scope.launch {
             controller.flowOfSnapshot()
                 .collect { snapshot ->
+                    startupPhaseForTest?.invoke(StartupPhase.SNAPSHOT_OBSERVED)
                     if (!snapshot.isHoldingConnection) {
                         stopSessionHold()
                     } else {
@@ -385,15 +411,15 @@ class SessionConnectionService : Service() {
         manager.createNotificationChannel(channel)
     }
 
-    @SuppressLint("WakelockTimeout")
     private fun acquireWakeLockIfNeeded() {
         val current = wakeLock
         if (current?.isHeld == true) return
         val powerManager = getSystemService(PowerManager::class.java)
         wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKE_LOCK_TAG).apply {
             setReferenceCounted(false)
-            acquire()
+            acquire(WAKE_LOCK_TIMEOUT_MILLIS)
         }
+        startupPhaseForTest?.invoke(StartupPhase.WAKE_LOCK_ACQUIRED)
     }
 
     private fun releaseWakeLock() {

--- a/app/src/main/java/com/pocketshell/app/settings/SettingsModels.kt
+++ b/app/src/main/java/com/pocketshell/app/settings/SettingsModels.kt
@@ -358,6 +358,7 @@ data class AppSettings(
         const val BACKGROUND_GRACE_1_MINUTE_MS: Long = 60_000L
         const val BACKGROUND_GRACE_5_MINUTES_MS: Long = 5 * 60_000L
         const val BACKGROUND_GRACE_10_MINUTES_MS: Long = 10 * 60_000L
+        const val MAX_BACKGROUND_GRACE_MILLIS: Long = BACKGROUND_GRACE_10_MINUTES_MS
 
         /**
          * Issue #1159 (maintainer directive 2026-07-01): the background grace window
@@ -377,7 +378,7 @@ data class AppSettings(
             BackgroundGraceOption(BACKGROUND_GRACE_90_SECONDS_MS, "90 sec"),
             BackgroundGraceOption(BACKGROUND_GRACE_1_MINUTE_MS, "1 min"),
             BackgroundGraceOption(BACKGROUND_GRACE_5_MINUTES_MS, "5 min"),
-            BackgroundGraceOption(BACKGROUND_GRACE_10_MINUTES_MS, "10 min"),
+            BackgroundGraceOption(MAX_BACKGROUND_GRACE_MILLIS, "10 min"),
         )
     }
 }

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceLifecycleTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceLifecycleTest.kt
@@ -1,0 +1,345 @@
+package com.pocketshell.app.sessions.service
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.settings.AppSettings
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.tmux.FakeTmuxClient
+import java.time.Duration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPowerManager
+import org.robolectric.shadows.ShadowSystemClock
+
+/**
+ * Issue #1757: lifecycle contract for the bounded session foreground-service envelope.
+ *
+ * The service cannot recreate an SSH/tmux transport after process death, so every delivered
+ * start is non-sticky. A null-intent platform restart observes the process-local controller's
+ * empty snapshot and stops. While a live snapshot exists, the foreground notification and
+ * wake lock remain only until foreground handoff, last-client/grace teardown, destruction, or
+ * the wake lock's platform safety timeout.
+ *
+ * All lifecycle transitions use StateFlow + a virtual coroutine scheduler. The wake-lock expiry
+ * uses Robolectric's elapsed-realtime clock; no test waits on wall-clock time.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionConnectionServiceLifecycleTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        ShadowPowerManager.clearWakeLocks()
+    }
+
+    @After
+    fun tearDown() {
+        ShadowPowerManager.clearWakeLocks()
+    }
+
+    @Test
+    fun `live session start promotes observes and returns non sticky`() {
+        val rig = serviceRig(withLiveSession = true)
+        try {
+            val result = rig.start(ACTION_START_INTENT)
+
+            assertEquals(
+                "a successful session hold cannot be recreated after process death",
+                Service.START_NOT_STICKY,
+                result,
+            )
+            val shadowService = shadowOf(rig.service)
+            assertNotNull(
+                "the service must promote before beginning its snapshot observation",
+                shadowService.lastForegroundNotification,
+            )
+            assertFalse(
+                "the live controller snapshot must keep the service running during grace",
+                shadowService.isStoppedBySelf,
+            )
+            assertWakeLockHeld()
+        } finally {
+            rig.close()
+        }
+    }
+
+    @Test
+    fun `live start promotes before wake lock and snapshot work`() {
+        val rig = serviceRig(withLiveSession = true)
+        try {
+            val startupEvents = mutableListOf<String>()
+            rig.service.promoteForegroundForTest = {
+                startupEvents += FOREGROUND_PROMOTED
+            }
+            rig.service.startupPhaseForTest = { phase ->
+                startupEvents += phase.name
+            }
+
+            rig.start(ACTION_START_INTENT)
+
+            assertEquals(
+                "Android requires foreground promotion before the service acquires resources " +
+                    "or begins controller-driven work",
+                listOf(
+                    FOREGROUND_PROMOTED,
+                    SessionConnectionService.StartupPhase.WAKE_LOCK_ACQUIRED.name,
+                    SessionConnectionService.StartupPhase.SNAPSHOT_OBSERVED.name,
+                ),
+                startupEvents,
+            )
+        } finally {
+            rig.close()
+        }
+    }
+
+    @Test
+    fun `null intent restart with empty process snapshot is non sticky and stops`() {
+        val rig = serviceRig(withLiveSession = false)
+        try {
+            var promoted = false
+            rig.service.promoteForegroundForTest = { promoted = true }
+            val result = rig.start(intent = null)
+
+            assertEquals(
+                "Android must not establish a sticky restart contract for an unrecoverable transport",
+                Service.START_NOT_STICKY,
+                result,
+            )
+            assertTrue(
+                "a delivered FGS start still promotes before inspecting process-local state",
+                promoted,
+            )
+            val shadowService = shadowOf(rig.service)
+            assertTrue(
+                "the empty controller snapshot must stop the ghost restart",
+                shadowService.isStoppedBySelf,
+            )
+            assertFalse(
+                "stopping the empty restart must remove the foreground notification",
+                shadowService.isLastForegroundNotificationAttached,
+            )
+            assertWakeLockReleased()
+        } finally {
+            rig.close()
+        }
+    }
+
+    @Test
+    fun `wake lock timeout is authoritative maximum grace plus teardown margin`() {
+        assertEquals(
+            "the named maximum must stay aligned with the selectable grace options",
+            AppSettings.BACKGROUND_GRACE_OPTIONS.maxOf { it.millis },
+            AppSettings.MAX_BACKGROUND_GRACE_MILLIS,
+        )
+        assertEquals(
+            EXPECTED_MAX_BACKGROUND_GRACE_MILLIS,
+            AppSettings.MAX_BACKGROUND_GRACE_MILLIS,
+        )
+        assertEquals(
+            EXPECTED_WAKE_LOCK_TEARDOWN_MARGIN_MILLIS,
+            SessionConnectionService.WAKE_LOCK_TEARDOWN_MARGIN_MILLIS,
+        )
+        assertEquals(
+            EXPECTED_WAKE_LOCK_TIMEOUT_MILLIS,
+            SessionConnectionService.WAKE_LOCK_TIMEOUT_MILLIS,
+        )
+
+        val rig = serviceRig(withLiveSession = true)
+        try {
+            rig.start(ACTION_START_INTENT)
+            val wakeLock = requireNotNull(ShadowPowerManager.getLatestWakeLock())
+            assertTrue(wakeLock.isHeld)
+
+            ShadowSystemClock.advanceBy(
+                Duration.ofMillis(EXPECTED_WAKE_LOCK_TIMEOUT_MILLIS - 1L),
+            )
+            assertTrue(
+                "the safety timeout must cover the full maximum grace plus almost all margin",
+                wakeLock.isHeld,
+            )
+
+            // Robolectric considers the lock held at the exact deadline and expires it on the
+            // first elapsed-realtime tick after it, matching the platform's at-most contract.
+            ShadowSystemClock.advanceBy(Duration.ofMillis(2L))
+            assertFalse(
+                "the platform safety timeout must release a wedged ownership path",
+                wakeLock.isHeld,
+            )
+        } finally {
+            rig.close()
+        }
+    }
+
+    @Test
+    fun `foreground return releases wake lock before its timeout`() {
+        val rig = serviceRig(withLiveSession = true)
+        try {
+            rig.start(ACTION_START_INTENT)
+            assertWakeLockHeld()
+
+            rig.controller.onAppForegrounded()
+            rig.scheduler.runCurrent()
+
+            assertTrue(shadowOf(rig.service).isStoppedBySelf)
+            assertWakeLockReleased()
+        } finally {
+            rig.close()
+        }
+    }
+
+    @Test
+    fun `last client grace teardown releases wake lock before its timeout`() {
+        val rig = serviceRig(withLiveSession = true)
+        try {
+            rig.start(ACTION_START_INTENT)
+            assertWakeLockHeld()
+
+            requireNotNull(rig.client).disconnectedSignal.value = true
+            rig.scheduler.runCurrent()
+
+            assertTrue(
+                "the controller's empty snapshot after last-client teardown must stop the hold",
+                shadowOf(rig.service).isStoppedBySelf,
+            )
+            assertWakeLockReleased()
+        } finally {
+            rig.close()
+        }
+    }
+
+    @Test
+    fun `service destruction releases wake lock before its timeout`() {
+        val rig = serviceRig(withLiveSession = true)
+        try {
+            rig.start(ACTION_START_INTENT)
+            assertWakeLockHeld()
+
+            rig.destroyService()
+
+            assertWakeLockReleased()
+        } finally {
+            rig.close()
+        }
+    }
+
+    private fun serviceRig(withLiveSession: Boolean): ServiceRig {
+        val scheduler = TestCoroutineScheduler()
+        val activeClients = ActiveTmuxClients()
+        val controller = SessionServiceController(context, activeClients).apply {
+            scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler))
+            nowMillis = { scheduler.currentTime }
+            observeActiveSessions()
+        }
+        scheduler.runCurrent()
+
+        val client = if (withLiveSession) FakeTmuxClient() else null
+        val registration = client?.let {
+            activeClients.register(
+                hostId = 1L,
+                hostName = "alpha",
+                hostname = "alpha.example",
+                port = 22,
+                username = "alexey",
+                keyPath = "/tmp/key",
+                client = it,
+            )
+        }
+        scheduler.runCurrent()
+        if (withLiveSession) {
+            controller.onAppBackgrounded(disconnectAtWallClockMillis = MAX_GRACE_DEADLINE_MS)
+            scheduler.runCurrent()
+            assertTrue(controller.flowOfSnapshot().value.isHoldingConnection)
+        }
+
+        val serviceController = Robolectric.buildService(SessionConnectionService::class.java)
+        val service = serviceController.get().apply {
+            this.controller = controller
+            observeDispatcher = Dispatchers.Unconfined
+            createNotificationChannel()
+        }
+        return ServiceRig(
+            service = service,
+            controller = controller,
+            activeClients = activeClients,
+            registration = registration,
+            client = client,
+            scheduler = scheduler,
+        )
+    }
+
+    private fun assertWakeLockHeld() {
+        val wakeLock = requireNotNull(ShadowPowerManager.getLatestWakeLock())
+        assertEquals(WAKE_LOCK_TAG, shadowOf(wakeLock).tag)
+        assertTrue(wakeLock.isHeld)
+    }
+
+    private fun assertWakeLockReleased() {
+        val wakeLock = ShadowPowerManager.getLatestWakeLock()
+        assertTrue(
+            "the service must have acquired the session wake lock before releasing it",
+            wakeLock != null,
+        )
+        assertFalse(wakeLock?.isHeld == true)
+    }
+
+    private class ServiceRig(
+        val service: SessionConnectionService,
+        val controller: SessionServiceController,
+        val activeClients: ActiveTmuxClients,
+        val registration: ActiveTmuxClients.Registration?,
+        val client: FakeTmuxClient?,
+        val scheduler: TestCoroutineScheduler,
+    ) : AutoCloseable {
+        private var serviceDestroyed = false
+
+        fun start(intent: Intent?): Int = service.onStartCommand(intent, 0, 1)
+
+        fun destroyService() {
+            if (serviceDestroyed) return
+            serviceDestroyed = true
+            service.onDestroy()
+        }
+
+        override fun close() {
+            destroyService()
+            registration?.let(activeClients::unregister)
+            controller.scope.cancel()
+        }
+    }
+
+    private companion object {
+        const val WAKE_LOCK_TAG = "PocketShell:session"
+        const val FOREGROUND_PROMOTED = "FOREGROUND_PROMOTED"
+        const val EXPECTED_MAX_BACKGROUND_GRACE_MILLIS = 10 * 60_000L
+        const val EXPECTED_WAKE_LOCK_TEARDOWN_MARGIN_MILLIS = 30_000L
+        const val EXPECTED_WAKE_LOCK_TIMEOUT_MILLIS =
+            EXPECTED_MAX_BACKGROUND_GRACE_MILLIS + EXPECTED_WAKE_LOCK_TEARDOWN_MARGIN_MILLIS
+        const val MAX_GRACE_DEADLINE_MS = EXPECTED_MAX_BACKGROUND_GRACE_MILLIS
+
+        val ACTION_START_INTENT: Intent
+            get() = Intent().apply { action = SessionConnectionService.ACTION_START }
+    }
+}


### PR DESCRIPTION
Closes #1757

## Summary
- return `START_NOT_STICKY` because an in-process SSH/tmux transport cannot survive process recreation
- bound the session wake lock to the maximum selectable 10-minute grace plus a named 30-second teardown margin
- preserve foreground promotion-before-work, snapshot observation, early release, and forwarding-service semantics with deterministic lifecycle tests

## Independent review
APPROVED after the reviewer found and the implementation corrected a G9 ordering gap. The final behavioral proof observes `FOREGROUND_PROMOTED -> WAKE_LOCK_ACQUIRED -> SNAPSHOT_OBSERVED`.

## Verification
- exact base RED: 3/7 failures for sticky live/null restart and unbounded wake lock
- reorder mutation: exactly 1/7 failure in the ordering proof
- `START_STICKY` mutation: 2/7 failures
- bare `acquire()` mutation: 1/7 failure
- service package: 43/43
- forced Android-test compilation: green
- API 35 `SessionConnectionServiceE2eTest`: 1/1, zero skips/failures
- canonical JVM: 11,334 tests and 603/603 tasks, zero failures/errors/skips
- static validity, journey wiring, file-size, connection-ratchet, hashes, and cleanup green

The three approved files were transplanted byte-for-byte onto exact main `b3df756fea2ef82171093b3752b659b6ae423ca4`; intervening #966 files have zero path overlap.