### PR TITLE
fix: bind terminal input to current session (#959)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -36,6 +36,7 @@ import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.TmuxClientDiagnostics
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
@@ -288,7 +289,7 @@ class BackgroundGraceReconnectE2eTest {
      * TYPES a unique token through the real input path and asserts the shell's
      * FRESH ECHO of that token renders in the visible terminal — the live-terminal
      * property. RED on a frozen reattach (no echo ever appears → times out);
-     * GREEN once the producer + input re-bind to the new client.
+     * GREEN once the visible TerminalView also adopts the reattached session.
      */
     @Test
     fun postGraceReattachLeavesTerminalLiveWithFreshInputEcho() { runBlocking<Unit> {
@@ -355,30 +356,75 @@ class BackgroundGraceReconnectE2eTest {
         captureViewport("issue959-02-post-grace-reattached")
 
         // LOAD-BEARING: type a NEW token AFTER the reattach and require the shell's
-        // FRESH echo to render. On a frozen reattach (producer/input still bound to
-        // the dead client) the keystrokes never reach the shell and/or the echo
+        // FRESH echo to render. On a frozen reattach (the visible TerminalView still
+        // exposing the dead session) the keystrokes never reach the shell and/or the echo
         // never reaches the emulator, so this token NEVER appears -> the wait
         // HARD-fails. This is the user-visible "terminal usable again" property.
         val postToken = "ISSUE959-POST-${SystemClock.elapsedRealtime()}"
-        sendLineToActivePane("echo $postToken")
-        waitForVisibleTerminal("post-grace fresh input echo") { it.contains(postToken) }
+        val diagnosticRunId =
+            "issue959-${System.currentTimeMillis()}-${SystemClock.elapsedRealtime()}"
+        val sendSessionHash = sendLineToActivePane("echo $postToken")
+
+        // Diagnostic-only recurrence slice (unchanged production): take the
+        // independent server/view/input/identity snapshot IMMEDIATELY after the
+        // real TerminalView.currentSession write, before the unchanged load-bearing
+        // visible-terminal wait. The server capture uses a separate
+        // SSH connection, never the app's `clientRef`, so it remains authoritative
+        // when the app-side stream/view is stale.
+        val immediateEvidence = capturePostGraceEvidence(
+            runId = diagnosticRunId,
+            phase = "immediate-post-send",
+            token = postToken,
+            sendSessionHash = sendSessionHash,
+        )
+        assertEquals(
+            "the input write must use the exact TerminalSurfaceState session identity",
+            immediateEvidence.identity.terminalStateSessionHash,
+            immediateEvidence.identity.sendTerminalViewSessionHash,
+        )
+        assertEquals(
+            "the mounted TerminalView must already expose the exact state session at immediate send",
+            immediateEvidence.identity.terminalStateSessionHash,
+            immediateEvidence.identity.terminalViewSessionHash,
+        )
+        assertTrue(
+            "the immediate post-send identity artifact must classify View and state as identical",
+            immediateEvidence.identity.viewSessionMatchesTerminalStateSession,
+        )
+
+        val visibleWaitFailure = runCatching {
+            waitForVisibleTerminal("post-grace fresh input echo") { it.contains(postToken) }
+        }.exceptionOrNull()
+        val terminalEvidence = capturePostGraceEvidence(
+            runId = diagnosticRunId,
+            phase = if (visibleWaitFailure == null) "visible-success" else "visible-timeout",
+            token = postToken,
+            sendSessionHash = sendSessionHash,
+        )
+        writePostGraceDiagnosticSummary(
+            runId = diagnosticRunId,
+            token = postToken,
+            immediate = immediateEvidence,
+            terminal = terminalEvidence,
+            waitFailure = visibleWaitFailure,
+        )
+        if (visibleWaitFailure != null) {
+            throw AssertionError(
+                "post-grace fresh input echo failed; classification=" +
+                    terminalEvidence.classification.code +
+                    " runId=$diagnosticRunId token=$postToken " +
+                    "serverHasToken=${terminalEvidence.serverHasToken} " +
+                    "viewportHasToken=${terminalEvidence.viewportHasToken} " +
+                    "paneInputBatchCount=${terminalEvidence.paneInputBatchCount} " +
+                    "sendFailureCount=${terminalEvidence.sendFailureCount}. " +
+                    "See issue959-post-grace-diagnostic-summary.txt and phase artifacts.",
+                visibleWaitFailure,
+            )
+        }
         captureViewport("issue959-03-post-grace-fresh-echo")
         writeTimings()
     } }
 
-    /**
-     * Issue #959: send a line of text + Enter to the active pane through the
-     * REAL on-device input path: bytes are written to the live Termux
-     * [TerminalView]'s session (`currentSession.write`) — EXACTLY what the Termux
-     * key handler does for a typed character. That session is the bridge's
-     * `TerminalSession`, whose output stream is the pane's `remoteStdin` (the tmux
-     * input sink -> queue -> drain coroutine). This is the path the freeze kills:
-     * after a beyond-grace reattach the reused pane's bridge/remoteStdin/drain are
-     * still wired to the DEAD client (its queue was closed at teardown), so the
-     * keystrokes never reach the shell and nothing echoes. Driving the VM's
-     * `writeInputToPane` (which sends straight to `clientRef`) would BYPASS that
-     * frozen queue and mask the bug — this MUST go through the terminal session.
-     */
     /**
      * Issue #959 (#780 model): arm the synthetic injection so the next background
      * teardown PRESERVES the pane runtime (paneRows + producers + input + client
@@ -395,18 +441,415 @@ class BackgroundGraceReconnectE2eTest {
         check(armed) { "failed to arm the #959 surviving-pane-runtime injection" }
     }
 
-    private fun sendLineToActivePane(line: String) {
+    /**
+     * Issue #959: send a line of text + Enter to the active pane through the
+     * REAL on-device input path: bytes are written to the live Termux
+     * [TerminalView]'s session (`currentSession.write`) — EXACTLY what the Termux
+     * key handler does for a typed character. That session's output stream is the
+     * pane's `remoteStdin` (the tmux input sink -> queue -> drain coroutine).
+     * After a beyond-grace reattach the pane's TerminalSurfaceState may already
+     * own the replacement session while the visible TerminalView still exposes
+     * the dead one, so the keystrokes never reach the shell and nothing echoes.
+     * Driving the VM's `writeInputToPane` (which sends straight to `clientRef`)
+     * would bypass the stale view session and mask the bug.
+     */
+    private fun sendLineToActivePane(line: String): Int {
         val bytes = (line + "\n").toByteArray(Charsets.UTF_8)
         var wrote = false
+        var sessionHash: Int? = null
         compose.activityRule.scenario.onActivity { activity ->
             val session = activity.window.decorView.findTerminalView()?.currentSession
                 ?: return@onActivity
+            sessionHash = System.identityHashCode(session)
             session.write(bytes, 0, bytes.size)
             wrote = true
         }
         check(wrote) { "no live terminal session to send input to" }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        return checkNotNull(sessionHash) {
+            "TerminalView.currentSession identity disappeared during the input write"
+        }
     }
+
+    /**
+     * Issue #959 recurrence diagnosis: preserve the independently-observed
+     * server pane, app viewport/text, real pane-input delivery diagnostics, and
+     * all identities needed to distinguish a stale TerminalView/session from a
+     * superseded client/producer/pane target. This is test-only instrumentation:
+     * it changes no production connection/input/output path, retry, timeout, or
+     * threshold.
+     */
+    private suspend fun capturePostGraceEvidence(
+        runId: String,
+        phase: String,
+        token: String,
+        sendSessionHash: Int,
+    ): PostGraceEvidence {
+        val identity = snapshotPostGraceIdentity(sendSessionHash)
+        val exactPaneId = requireNotNull(identity.paneId) {
+            "cannot classify #959 server evidence without the exact active pane id"
+        }
+        val serverCapture = capturePaneThroughIndependentSsh(exactPaneId)
+        val captureValidity = serverCapture.validity()
+        val viewportText = visibleTerminalText()
+        val inputEvents = relevantPaneInputEvents()
+        val prerequisites = postGracePrerequisiteEvents()
+        val serverHasToken = serverCapture.stdout.contains(token)
+        val viewportHasToken = viewportText.contains(token)
+        val batches = inputEvents.count { it.name == "pane_input_batch" }
+        val failures = inputEvents.count {
+            it.name == "pane_input_send_failed" || it.name == "pane_input_send_abandoned"
+        }
+        val classification = classifyPostGraceEvidence(
+            captureValidity = captureValidity,
+            serverHasToken = serverHasToken,
+            viewportHasToken = viewportHasToken,
+            paneInputBatchCount = batches,
+            sendFailureCount = failures,
+        )
+        val evidence = PostGraceEvidence(
+            phase = phase,
+            identity = identity,
+            serverCapture = serverCapture,
+            captureValidity = captureValidity,
+            viewportText = viewportText,
+            inputEvents = inputEvents,
+            prerequisites = prerequisites,
+            serverHasToken = serverHasToken,
+            viewportHasToken = viewportHasToken,
+            paneInputBatchCount = batches,
+            sendFailureCount = failures,
+            classification = classification,
+        )
+
+        // A direct TerminalView render + transcript pair from THIS snapshot.
+        // captureViewport also leaves an explicit visible-terminal artifact when
+        // the AndroidView cannot be drawn, so absence is observable.
+        captureViewport("issue959-$phase")
+        writeText(
+            "issue959-$phase-server-capture-pane.txt",
+            buildString {
+                appendLine("runId=$runId")
+                appendLine("phase=$phase")
+                appendLine("token=$token")
+                appendLine("command=${serverCapture.command}")
+                appendLine("targetPaneId=${serverCapture.targetPaneId}")
+                appendLine("validity=${captureValidity.code}")
+                appendLine("authoritative=${captureValidity.authoritative}")
+                appendLine("exitCode=${serverCapture.exitCode}")
+                appendLine("failureKind=${serverCapture.failureKind}")
+                appendLine("exception=${serverCapture.exception}")
+                appendLine("stderr:")
+                appendLine(serverCapture.stderr)
+                appendLine("stdout:")
+                append(serverCapture.stdout)
+            },
+        )
+        writeText(
+            "issue959-$phase-identity-input-prerequisites.txt",
+            evidence.describe(runId = runId, token = token),
+        )
+        return evidence
+    }
+
+    private fun snapshotPostGraceIdentity(sendSessionHash: Int): PostGraceIdentity {
+        var snapshot: PostGraceIdentity? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val terminalView = activity.window.decorView.findTerminalView()
+            val viewSession = terminalView?.currentSession
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            val pane = vm.panes.value.firstOrNull()
+            val terminalState = pane?.terminalState
+            val stateSession = terminalState?.terminalSessionForDiagnostics()
+            val clientHash = vm.currentClientIdentityForTest()
+            val generation = vm.currentConnectGenerationForTest()
+            val targetSessionKey = vm.currentTargetSessionKeyForTest()
+            snapshot = PostGraceIdentity(
+                sendTerminalViewSessionHash = sendSessionHash,
+                terminalViewSessionHash = viewSession?.let(System::identityHashCode),
+                terminalViewEmulatorHash = terminalView?.mEmulator?.let(System::identityHashCode),
+                terminalStateHash = terminalState?.let(System::identityHashCode),
+                terminalStateSessionHash = stateSession?.let(System::identityHashCode),
+                viewSessionMatchesTerminalStateSession =
+                    viewSession != null && viewSession === stateSession,
+                terminalStateAttached = terminalState?.isAttached,
+                activeClientRefHash = clientHash,
+                paneProducerClientHash =
+                    pane?.paneId?.let(vm::paneProducerClientIdentityForTest),
+                paneProducerActive = pane?.paneId?.let(vm::paneProducerActiveForTest),
+                generation = generation,
+                paneId = pane?.paneId,
+                windowId = pane?.windowId,
+                tmuxSessionId = pane?.sessionId,
+                targetSessionKey = targetSessionKey,
+                runtimeKey =
+                    "target=$targetSessionKey|client=$clientHash|generation=$generation|" +
+                        "pane=${pane?.paneId}",
+            )
+        }
+        return checkNotNull(snapshot) {
+            "could not snapshot TerminalView/terminalState/client/producer runtime identities"
+        }
+    }
+
+    /**
+     * TerminalSurfaceState.session is `internal` to :shared:core-terminal.
+     * Keep production APIs unchanged: the diagnostic test reads the exact
+     * attached session from the state's private bridge and compares it with
+     * TerminalView.currentSession by identity.
+     */
+    private fun TerminalSurfaceState.terminalSessionForDiagnostics(): Any? =
+        runCatching {
+            val bridgeField = TerminalSurfaceState::class.java.getDeclaredField("bridge").apply {
+                isAccessible = true
+            }
+            val bridge = bridgeField.get(this) ?: return@runCatching null
+            bridge.javaClass.getMethod("getSession").invoke(bridge)
+        }.getOrNull()
+
+    /**
+     * Authoritative discriminator: this opens a brand-new SSH connection and
+     * runs tmux capture-pane directly. It is independent of the app's active SSH
+     * lease, `-CC` client, output producer, TerminalSession, and viewport.
+     */
+    private suspend fun capturePaneThroughIndependentSsh(paneId: String): ServerPaneCapture {
+        val command = "tmux capture-pane -p -S - -t ${shellQuote(paneId)}"
+        val connected = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(fixtureKey),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        )
+        return connected.fold(
+            onSuccess = { session ->
+                session.use {
+                    runCatching { it.exec(command) }.fold(
+                        onSuccess = { result ->
+                            ServerPaneCapture(
+                                targetPaneId = paneId,
+                                command = command,
+                                exitCode = result.exitCode,
+                                stdout = result.stdout,
+                                stderr = result.stderr,
+                                failureKind = null,
+                                exception = null,
+                            )
+                        },
+                        onFailure = { error ->
+                            ServerPaneCapture(
+                                targetPaneId = paneId,
+                                command = command,
+                                exitCode = null,
+                                stdout = "",
+                                stderr = "",
+                                failureKind = ServerPaneCaptureFailure.EXECUTION,
+                                exception = "${error.javaClass.name}: ${error.message}",
+                            )
+                        },
+                    )
+                }
+            },
+            onFailure = { error ->
+                ServerPaneCapture(
+                    targetPaneId = paneId,
+                    command = command,
+                    exitCode = null,
+                    stdout = "",
+                    stderr = "",
+                    failureKind = ServerPaneCaptureFailure.CONNECTION,
+                    exception = "${error.javaClass.name}: ${error.message}",
+                )
+            },
+        )
+    }
+
+    private fun ServerPaneCapture.validity(): ServerPaneCaptureValidity =
+        when {
+            failureKind == ServerPaneCaptureFailure.CONNECTION ->
+                ServerPaneCaptureValidity.CONNECTION_FAILED
+            failureKind == ServerPaneCaptureFailure.EXECUTION ->
+                ServerPaneCaptureValidity.EXEC_EXCEPTION
+            exitCode == null ->
+                ServerPaneCaptureValidity.UNUSABLE_RESULT
+            exitCode != 0 ->
+                ServerPaneCaptureValidity.NONZERO_EXIT
+            stdout.isEmpty() ->
+                ServerPaneCaptureValidity.VERIFIED_EXIT_ZERO_EMPTY
+            else ->
+                ServerPaneCaptureValidity.VERIFIED_EXIT_ZERO_WITH_OUTPUT
+        }
+
+    private fun relevantPaneInputEvents(): List<RecordedDiagnosticEvent> =
+        diagnostics!!.events.filter {
+            it.name in setOf(
+                "pane_input_batch",
+                "pane_input_send_deferred",
+                "pane_input_send_failed",
+                "pane_input_send_abandoned",
+                "pane_input_verify_before_resend",
+            )
+        }
+
+    private fun postGracePrerequisiteEvents(): List<RecordedDiagnosticEvent> {
+        val prerequisiteNames = setOf(
+            "background_grace_elapsed",
+            "terminal_background_teardown",
+            "background_grace_foreground",
+            "terminal_foreground_reattach",
+            "foreground_reattach",
+        )
+        return diagnostics!!.events.filter { it.name in prerequisiteNames }
+    }
+
+    private fun classifyPostGraceEvidence(
+        captureValidity: ServerPaneCaptureValidity,
+        serverHasToken: Boolean,
+        viewportHasToken: Boolean,
+        paneInputBatchCount: Int,
+        sendFailureCount: Int,
+    ): PostGraceClassification =
+        when {
+            !captureValidity.authoritative ->
+                PostGraceClassification.UNVERIFIED_CAPTURE_FAILED
+            serverHasToken && viewportHasToken ->
+                PostGraceClassification.TOKEN_SERVER_SIDE_AND_VIEWPORT
+            serverHasToken ->
+                PostGraceClassification.TOKEN_SERVER_SIDE_VIEWPORT_ABSENT
+            paneInputBatchCount == 0 ->
+                PostGraceClassification.TOKEN_ABSENT_NO_PANE_INPUT_BATCH
+            sendFailureCount > 0 ->
+                PostGraceClassification.TOKEN_ABSENT_BATCH_SEND_FAILED_OR_SUPERSEDED
+            else ->
+                PostGraceClassification.TOKEN_ABSENT_BATCH_NO_FAILURE_WRONG_TARGET_OR_FALSE_SUCCESS
+        }
+
+    private fun writePostGraceDiagnosticSummary(
+        runId: String,
+        token: String,
+        immediate: PostGraceEvidence,
+        terminal: PostGraceEvidence,
+        waitFailure: Throwable?,
+    ) {
+        writeText(
+            "issue959-post-grace-diagnostic-summary.txt",
+            buildString {
+                appendLine("runId=$runId")
+                appendLine("token=$token")
+                appendLine("visibleWaitFailure=${waitFailure?.javaClass?.name}: ${waitFailure?.message}")
+                appendLine()
+                appendLine(immediate.describe(runId = runId, token = token))
+                appendLine()
+                appendLine(terminal.describe(runId = runId, token = token))
+            },
+        )
+    }
+
+    private data class PostGraceIdentity(
+        val sendTerminalViewSessionHash: Int,
+        val terminalViewSessionHash: Int?,
+        val terminalViewEmulatorHash: Int?,
+        val terminalStateHash: Int?,
+        val terminalStateSessionHash: Int?,
+        val viewSessionMatchesTerminalStateSession: Boolean,
+        val terminalStateAttached: Boolean?,
+        val activeClientRefHash: Int?,
+        val paneProducerClientHash: Int?,
+        val paneProducerActive: Boolean?,
+        val generation: Long,
+        val paneId: String?,
+        val windowId: String?,
+        val tmuxSessionId: String?,
+        val targetSessionKey: String?,
+        val runtimeKey: String,
+    )
+
+    private data class ServerPaneCapture(
+        val targetPaneId: String,
+        val command: String,
+        val exitCode: Int?,
+        val stdout: String,
+        val stderr: String,
+        val failureKind: ServerPaneCaptureFailure?,
+        val exception: String?,
+    )
+
+    private data class PostGraceEvidence(
+        val phase: String,
+        val identity: PostGraceIdentity,
+        val serverCapture: ServerPaneCapture,
+        val captureValidity: ServerPaneCaptureValidity,
+        val viewportText: String,
+        val inputEvents: List<RecordedDiagnosticEvent>,
+        val prerequisites: List<RecordedDiagnosticEvent>,
+        val serverHasToken: Boolean,
+        val viewportHasToken: Boolean,
+        val paneInputBatchCount: Int,
+        val sendFailureCount: Int,
+        val classification: PostGraceClassification,
+    ) {
+        fun describe(runId: String, token: String): String =
+            buildString {
+                appendLine("runId=$runId")
+                appendLine("phase=$phase")
+                appendLine("token=$token")
+                appendLine("classification=${classification.code}")
+                appendLine("serverHasToken=$serverHasToken")
+                appendLine("viewportHasToken=$viewportHasToken")
+                appendLine("paneInputBatchCount=$paneInputBatchCount")
+                appendLine("sendFailureCount=$sendFailureCount")
+                appendLine("identity=$identity")
+                appendLine("serverCaptureTargetPaneId=${serverCapture.targetPaneId}")
+                appendLine("serverCaptureCommand=${serverCapture.command}")
+                appendLine("serverCaptureValidity=${captureValidity.code}")
+                appendLine("serverCaptureAuthoritative=${captureValidity.authoritative}")
+                appendLine("serverCaptureExitCode=${serverCapture.exitCode}")
+                appendLine("serverCaptureFailureKind=${serverCapture.failureKind}")
+                appendLine("serverCaptureException=${serverCapture.exception}")
+                appendLine("prerequisites:")
+                prerequisites.forEach {
+                    appendLine("  ${it.category}/${it.name} fields=${it.fields.toSortedMap()}")
+                }
+                appendLine("paneInputAndSendOutcomeDiagnostics:")
+                inputEvents.forEach {
+                    appendLine("  ${it.category}/${it.name} fields=${it.fields.toSortedMap()}")
+                }
+                appendLine("visibleTerminalText:")
+                append(viewportText)
+            }
+    }
+
+    private enum class ServerPaneCaptureFailure {
+        CONNECTION,
+        EXECUTION,
+    }
+
+    private enum class ServerPaneCaptureValidity(
+        val code: String,
+        val authoritative: Boolean,
+    ) {
+        VERIFIED_EXIT_ZERO_WITH_OUTPUT("verified_exit_zero_with_output", true),
+        VERIFIED_EXIT_ZERO_EMPTY("verified_exit_zero_empty", true),
+        CONNECTION_FAILED("connection_failed", false),
+        EXEC_EXCEPTION("exec_exception", false),
+        UNUSABLE_RESULT("unusable_result", false),
+        NONZERO_EXIT("nonzero_exit", false),
+    }
+
+    private enum class PostGraceClassification(val code: String) {
+        UNVERIFIED_CAPTURE_FAILED("unverified_capture_failed"),
+        TOKEN_SERVER_SIDE_AND_VIEWPORT("token_server_side_and_viewport"),
+        TOKEN_SERVER_SIDE_VIEWPORT_ABSENT("token_server_side_viewport_absent_output_or_surface"),
+        TOKEN_ABSENT_NO_PANE_INPUT_BATCH("token_absent_no_batch_stale_session_or_stopped_drainer"),
+        TOKEN_ABSENT_BATCH_SEND_FAILED_OR_SUPERSEDED("token_absent_batch_send_failed_or_superseded"),
+        TOKEN_ABSENT_BATCH_NO_FAILURE_WRONG_TARGET_OR_FALSE_SUCCESS(
+            "token_absent_batch_no_failure_wrong_pane_client_or_false_success",
+        ),
+    }
+
+    private fun RecordedDiagnosticEvent.describe(): String =
+        "$category/$name fields=${fields.toSortedMap()}"
 
     @Test
     fun sixSecondAppSwitchWithProductionGraceDoesNotShowOrRecordReconnect() { runBlocking<Unit> {

--- a/app/src/test/java/com/pocketshell/app/tmux/BackgroundGraceReconnectDiagnosticSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/BackgroundGraceReconnectDiagnosticSourceGuardTest.kt
@@ -1,0 +1,224 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #959 recurrence: keep the connected proof diagnostic-first until its
+ * unchanged-production evidence selects one responsible lifecycle branch.
+ */
+class BackgroundGraceReconnectDiagnosticSourceGuardTest {
+
+    @Test
+    fun independentEvidenceIsCapturedImmediatelyAfterRealTerminalSessionWrite() {
+        val source = journeySource()
+        val method = source.substringBetween(
+            start = "fun postGraceReattachLeavesTerminalLiveWithFreshInputEcho()",
+            end = "private fun forcePreservePaneRuntimeOnBackgroundTeardown()",
+        )
+        val send = method.indexOf("sendLineToActivePane(\"echo \$postToken\")")
+        val immediate = method.indexOf("phase = \"immediate-post-send\"")
+        val visibleWait = method.indexOf(
+            "waitForVisibleTerminal(\"post-grace fresh input echo\")",
+        )
+
+        assertTrue("the proof must write through TerminalView.currentSession", send >= 0)
+        assertTrue(
+            "independent evidence must be captured immediately after send and before " +
+                "the unchanged visible-terminal wait",
+            immediate > send && immediate < visibleWait,
+        )
+        assertTrue(
+            "a timeout must still preserve terminal evidence and a single summary",
+            method.contains("phase = if (visibleWaitFailure == null)") &&
+                method.contains("writePostGraceDiagnosticSummary(") &&
+                method.contains("throw AssertionError("),
+        )
+    }
+
+    @Test
+    fun serverCaptureRequiresTheExactPaneIdentityWithoutFallback() {
+        val source = journeySource()
+        val evidence = source.substringBetween(
+            start = "private suspend fun capturePostGraceEvidence(",
+            end = "private fun snapshotPostGraceIdentity(",
+        ).compact()
+        val capture = source.substringBetween(
+            start = "private suspend fun capturePaneThroughIndependentSsh(",
+            end = "private fun relevantPaneInputEvents()",
+        ).compact()
+
+        assertTrue(
+            "the evidence path must hard-fail without an exact pane id and pass only " +
+                "that non-null id to the independent capture",
+            evidence.contains("valexactPaneId=requireNotNull(identity.paneId)") &&
+                evidence.contains("capturePaneThroughIndependentSsh(exactPaneId)") &&
+                !evidence.contains("capturePaneThroughIndependentSsh(identity.paneId)"),
+        )
+        assertTrue(
+            "the independent capture must accept a non-null pane id and target it " +
+                "directly, with no session-name or nullable fallback",
+            capture.contains(
+                "capturePaneThroughIndependentSsh(paneId:String):ServerPaneCapture",
+            ) &&
+                capture.contains(
+                    "valcommand=\"tmuxcapture-pane-p-S--t${'$'}{shellQuote(paneId)}\"",
+                ) &&
+                !capture.contains("?:SESSION_NAME") &&
+                !capture.contains("paneId:String?"),
+        )
+        assertTrue(
+            "server capture must open its own SSH connection, not use the app clientRef",
+            capture.contains("SshConnection.connect("),
+        )
+    }
+
+    @Test
+    fun captureValidityRejectsConnectionExecNonzeroAndUnusableEvidence() {
+        val source = journeySource()
+        val cases = listOf(
+            CaptureCase("CONNECTION", 0, "token") to "CONNECTION_FAILED",
+            CaptureCase("EXECUTION", 0, "token") to "EXEC_EXCEPTION",
+            CaptureCase(null, null, "") to "UNUSABLE_RESULT",
+            CaptureCase(null, 23, "") to "NONZERO_EXIT",
+            CaptureCase(null, 0, "") to "VERIFIED_EXIT_ZERO_EMPTY",
+            CaptureCase(null, 0, "pane text") to "VERIFIED_EXIT_ZERO_WITH_OUTPUT",
+        )
+
+        cases.forEach { (input, expected) ->
+            val actual = evaluateCaptureValidityFromSource(source, input)
+            assertTrue(
+                "capture validity truth-table mismatch for $input: expected=$expected actual=$actual",
+                actual == expected,
+            )
+        }
+
+        val validityEnum = source.substringBetween(
+            start = "private enum class ServerPaneCaptureValidity(",
+            end = "private enum class PostGraceClassification(",
+        )
+        val authority = Regex("""(\w+)\("[^"]+",\s*(true|false)\)""")
+            .findAll(validityEnum)
+            .associate { it.groupValues[1] to it.groupValues[2].toBoolean() }
+        val expectedAuthority = mapOf(
+            "VERIFIED_EXIT_ZERO_WITH_OUTPUT" to true,
+            "VERIFIED_EXIT_ZERO_EMPTY" to true,
+            "CONNECTION_FAILED" to false,
+            "EXEC_EXCEPTION" to false,
+            "UNUSABLE_RESULT" to false,
+            "NONZERO_EXIT" to false,
+        )
+        assertTrue(
+            "only exact-target exit-zero captures may be authoritative: $authority",
+            authority == expectedAuthority,
+        )
+    }
+
+    @Test
+    fun classifierHasExactTruthTablePrecedenceIncludingUnverifiedCapture() {
+        val source = journeySource()
+        val cases = listOf(
+            ClassifierCase(false, true, true, 5, 0) to "UNVERIFIED_CAPTURE_FAILED",
+            ClassifierCase(true, true, true, 0, 2) to "TOKEN_SERVER_SIDE_AND_VIEWPORT",
+            ClassifierCase(true, true, false, 0, 2) to "TOKEN_SERVER_SIDE_VIEWPORT_ABSENT",
+            ClassifierCase(true, false, false, 0, 2) to "TOKEN_ABSENT_NO_PANE_INPUT_BATCH",
+            ClassifierCase(true, false, false, 1, 2) to
+                "TOKEN_ABSENT_BATCH_SEND_FAILED_OR_SUPERSEDED",
+            ClassifierCase(true, false, false, 1, 0) to
+                "TOKEN_ABSENT_BATCH_NO_FAILURE_WRONG_TARGET_OR_FALSE_SUCCESS",
+        )
+
+        cases.forEach { (input, expected) ->
+            val actual = evaluateClassifierFromSource(source, input)
+            assertTrue(
+                "classifier truth-table mismatch for $input: expected=$expected actual=$actual",
+                actual == expected,
+            )
+        }
+    }
+
+    private fun journeySource(): String {
+        val relative =
+            "src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt"
+        val candidates = listOf(File("app/$relative"), File(relative))
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relative from ${File(".").absolutePath}")
+        return file.readText()
+    }
+
+    private fun String.substringBetween(start: String, end: String): String {
+        val startIndex = indexOf(start)
+        check(startIndex >= 0) { "$start not found" }
+        val endIndex = indexOf(end, startIndex)
+        check(endIndex >= 0) { "$end not found after $start" }
+        return substring(startIndex, endIndex)
+    }
+
+    private fun evaluateCaptureValidityFromSource(source: String, input: CaptureCase): String {
+        val body = source.substringBetween(
+            start = "private fun ServerPaneCapture.validity()",
+            end = "private fun relevantPaneInputEvents()",
+        )
+        val branches = Regex(
+            """(?s)(failureKind\s*==\s*ServerPaneCaptureFailure\.(?:CONNECTION|EXECUTION)|""" +
+                """exitCode\s*==\s*null|exitCode\s*!=\s*0|stdout\.isEmpty\(\)|else)\s*->\s*""" +
+                """ServerPaneCaptureValidity\.(\w+)""",
+        ).findAll(body).map { it.groupValues[1].compact() to it.groupValues[2] }.toList()
+        check(branches.size == 6) { "expected six capture-validity branches, got $branches" }
+        return branches.first { (condition, _) ->
+            when (condition) {
+                "failureKind==ServerPaneCaptureFailure.CONNECTION" ->
+                    input.failureKind == "CONNECTION"
+                "failureKind==ServerPaneCaptureFailure.EXECUTION" ->
+                    input.failureKind == "EXECUTION"
+                "exitCode==null" -> input.exitCode == null
+                "exitCode!=0" -> input.exitCode != 0
+                "stdout.isEmpty()" -> input.stdout.isEmpty()
+                "else" -> true
+                else -> error("unknown capture-validity condition $condition")
+            }
+        }.second
+    }
+
+    private fun evaluateClassifierFromSource(source: String, input: ClassifierCase): String {
+        val body = source.substringBetween(
+            start = "private fun classifyPostGraceEvidence(",
+            end = "private fun writePostGraceDiagnosticSummary(",
+        )
+        val branches = Regex(
+            """(?s)(!captureValidity\.authoritative|serverHasToken\s*&&\s*viewportHasToken|""" +
+                """serverHasToken|paneInputBatchCount\s*==\s*0|sendFailureCount\s*>\s*0|else)""" +
+                """\s*->\s*PostGraceClassification\.(\w+)""",
+        ).findAll(body).map { it.groupValues[1].compact() to it.groupValues[2] }.toList()
+        check(branches.size == 6) { "expected six classifier branches, got $branches" }
+        return branches.first { (condition, _) ->
+            when (condition) {
+                "!captureValidity.authoritative" -> !input.captureAuthoritative
+                "serverHasToken&&viewportHasToken" ->
+                    input.serverHasToken && input.viewportHasToken
+                "serverHasToken" -> input.serverHasToken
+                "paneInputBatchCount==0" -> input.paneInputBatchCount == 0
+                "sendFailureCount>0" -> input.sendFailureCount > 0
+                "else" -> true
+                else -> error("unknown classifier condition $condition")
+            }
+        }.second
+    }
+
+    private fun String.compact(): String = replace(Regex("\\s+"), "")
+
+    private data class CaptureCase(
+        val failureKind: String?,
+        val exitCode: Int?,
+        val stdout: String,
+    )
+
+    private data class ClassifierCase(
+        val captureAuthoritative: Boolean,
+        val serverHasToken: Boolean,
+        val viewportHasToken: Boolean,
+        val paneInputBatchCount: Int,
+        val sendFailureCount: Int,
+    )
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelAttachReadinessTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelAttachReadinessTest.kt
@@ -9,6 +9,7 @@ import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
 import com.pocketshell.core.tmux.protocol.ControlEvent
+import com.pocketshell.testsupport.drainMainLooperUntil as drainMainLooperUntilShared
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
@@ -27,6 +28,7 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TmuxSessionViewModelAttachReadinessTest : TmuxSessionViewModelTestBase() {
@@ -282,6 +284,11 @@ class TmuxSessionViewModelAttachReadinessTest : TmuxSessionViewModelTestBase() {
         // Open the seed gate so live %output flushes to the emulator, then prove
         // I/O is wired to client A: an %output emitted on A renders.
         val state = vm.panes.value.single().terminalState
+        val terminalSessionOnA = terminalSessionFrom(state)
+        assertNotNull(
+            "precondition: terminalState.session must be attached through client A's bridge",
+            terminalSessionOnA,
+        )
         state.appendRemoteOutput("SEED-A\r\n".toByteArray(Charsets.US_ASCII))
         shadowOf(Looper.getMainLooper()).idle()
         clientA.emittedPaneOutputs.emit(
@@ -324,6 +331,17 @@ class TmuxSessionViewModelAttachReadinessTest : TmuxSessionViewModelTestBase() {
             state,
             vm.panes.value.single().terminalState,
         )
+        val terminalSessionOnB = terminalSessionFrom(state)
+        assertNotNull(
+            "the reused terminalState must expose a live TerminalSession after client B rebind",
+            terminalSessionOnB,
+        )
+        assertNotSame(
+            "client B rebind must replace terminalState.session; retaining client A's " +
+                "TerminalSession leaves its remoteStdin closed/stale",
+            terminalSessionOnA,
+            terminalSessionOnB,
+        )
 
         // The rebind re-arms the producer's seed gate (awaitSeed=true closes it
         // until the reattach re-seed lands — in production that is
@@ -346,15 +364,31 @@ class TmuxSessionViewModelAttachReadinessTest : TmuxSessionViewModelTestBase() {
             renderedTranscriptFrom(state).contains("OUTPUT-ON-B"),
         )
 
-        // LOAD-BEARING (input): a key written to the pane's input sink must drain
-        // to the NEW client B (a send-keys on B), NOT the dead client A.
+        // LOAD-BEARING (input): write through terminalState.session — the exact
+        // TerminalView.currentSession -> TerminalSession -> SshTerminalBridge
+        // drainer -> remoteStdin path the connected journey exercises. The old
+        // `tmuxInputSinkForTest` write bypassed the TerminalSession + real drainer
+        // and could stay green while the on-device view retained a closed/stale
+        // session. The shared Shape-B wall-clock pump is mandatory here because
+        // SshTerminalBridge's drainer is a real Thread/Handler, not owned by the
+        // runTest virtual scheduler.
         val keysOnBBefore = clientB.sentCommands.count { it.startsWith("send-keys") }
-        vm.tmuxInputSinkForTest("%0").write("x".toByteArray(Charsets.US_ASCII))
-        advanceUntilIdle()
+        state.writeInput("x".toByteArray(Charsets.US_ASCII))
+        val drainedThroughTerminalSession = drainMainLooperUntilShared(
+            deadlineMs = SLOW_FEED_DRAIN_TIMEOUT_MS,
+            sleepMs = 2L,
+            onTick = {
+                shadowOf(Looper.getMainLooper()).idleFor(16L, TimeUnit.MILLISECONDS)
+                runCurrent()
+            },
+        ) {
+            clientB.sentCommands.count { it.startsWith("send-keys") } > keysOnBBefore
+        }
         assertTrue(
-            "REGRESSION (#959): input after a reattach must reach the NEW client " +
-                "(a send-keys on B), not the dead client.",
-            clientB.sentCommands.count { it.startsWith("send-keys") } > keysOnBBefore,
+            "REGRESSION (#959): terminalState.session input did not drain through " +
+                "SshTerminalBridge to the NEW client B before the bounded wall-clock " +
+                "deadline; B=${clientB.sentCommands} A=${clientA.sentCommands}",
+            drainedThroughTerminalSession,
         )
         assertTrue(
             "the input key must carry the typed byte to client B",
@@ -1043,6 +1077,13 @@ class TmuxSessionViewModelAttachReadinessTest : TmuxSessionViewModelTestBase() {
         }
         val bridge = bridgeField.get(state) as? SshTerminalBridge ?: return ""
         return bridge.emulator.screen.transcriptText
+    }
+
+    private fun terminalSessionFrom(state: TerminalSurfaceState): Any? {
+        val bridgeField = TerminalSurfaceState::class.java.getDeclaredField("bridge").apply {
+            isAccessible = true
+        }
+        return (bridgeField.get(state) as? SshTerminalBridge)?.session
     }
 
     private companion object {

--- a/scripts/ci-journey-core-terminal-functions.sh
+++ b/scripts/ci-journey-core-terminal-functions.sh
@@ -36,6 +36,13 @@ run_core_terminal_reattach_repaint() {
   run_ct_class "$CORE_TERMINAL_REATTACH_REPAINT_CLASS"
 }
 
+CORE_TERMINAL_SESSION_BINDING_CLASS="com.pocketshell.core.terminal.ui.TerminalSurfaceComposeIntegrationTest#mountedViewRebindsImmediatelyFromSessionAToBAndRoutesOnlyToB"
+SESSION_BINDING_STATUS="PASS"
+
+run_core_terminal_session_binding() {
+  run_ct_class "$CORE_TERMINAL_SESSION_BINDING_CLASS"
+}
+
 CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS="com.pocketshell.core.terminal.selection.TerminalOverlayUnboundedMeasureCrashTest"
 OVERLAY_UNBOUNDED_STATUS="PASS"
 

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -640,6 +640,36 @@ else
   fi
 fi
 
+# --------------------------------------------------------------------------
+# Issue #959 recurrence: the real mounted TerminalSurface/AndroidView boundary.
+# Reuse one production TerminalView across session A→null→B, then prove null
+# detaches input and the View adopts B by identity before input readiness,
+# routes input to B only, and renders B output. This closes the historical JVM
+# proxy gap that bypassed TerminalView.currentSession and stayed green while
+# the connected journey lost the first post-grace key into stale session A.
+# Uses no Docker fixture.
+if budget_exhausted; then
+  STEP_TIMEOUT_HIT=1
+  SESSION_BINDING_STATUS="SKIPPED"
+  echo "JOURNEY_STEP_TIMEOUT: skipping #959 mounted session-binding proof — suite budget exhausted (issue #835 / #470 stall)"
+else
+  echo "=========================================================="
+  echo ">>> CORE-TERMINAL #959 MOUNTED SESSION-BINDING PROOF: $CORE_TERMINAL_SESSION_BINDING_CLASS (attempt 1)"
+  echo "=========================================================="
+  session_binding_start=$SECONDS
+  if run_core_terminal_session_binding; then
+    echo "SESSION_BINDING_PASS: passed on attempt 1 (elapsed $((SECONDS - session_binding_start))s)"
+  else
+    echo ">>> SESSION-BINDING PROOF FAILED attempt 1 — retrying once (CI-AVD infra flake / sibling-install)"
+    if run_core_terminal_session_binding; then
+      echo "SESSION_BINDING_FLAKE_RECOVERED: passed on retry (attempt 2)"
+    else
+      echo "SESSION_BINDING_FAILED: #959 mounted session-binding proof failed twice"
+      SESSION_BINDING_STATUS="FAIL"
+    fi
+  fi
+fi
+
 # ---------------------------------------------------------------------------
 # v0.4.17 RELEASE-BLOCKER: the terminal affordance-overlay UNBOUNDED-height
 # measure crash (CI run 28184338389, reproduced 4/4). The draw-only overlays

--- a/scripts/ci-journey-summary-functions.sh
+++ b/scripts/ci-journey-summary-functions.sh
@@ -16,14 +16,16 @@ finish_ci_journey_suite() {
   if [[ "${#FAILED_CLASSES[@]}" -eq 0 && "$STEP_TIMEOUT_HIT" -eq 0 \
         && "$APPEND_BURST_STATUS" == "PASS" && "$OUTPUT_BURST_IME_STATUS" == "PASS" \
         && "$MULTICHUNK_SEED_STATUS" == "PASS" && "$AGENT_LINK_AFFORDANCE_STATUS" == "PASS" \
-        && "$REATTACH_REPAINT_STATUS" == "PASS" && "$OVERLAY_UNBOUNDED_STATUS" == "PASS" \
+        && "$REATTACH_REPAINT_STATUS" == "PASS" && "$SESSION_BINDING_STATUS" == "PASS" \
+        && "$OVERLAY_UNBOUNDED_STATUS" == "PASS" \
         && "$SURFACE_REPAINT_STATUS" == "PASS" && "$SHELL_SNAPSHOT_STATUS" == "PASS" ]]; then
     JOURNEY_EXIT=0
     journey_status="PASS"
   elif [[ "$STEP_TIMEOUT_HIT" -eq 1 && "${#FAILED_CLASSES[@]}" -eq 0 \
           && "$APPEND_BURST_STATUS" != "FAIL" && "$OUTPUT_BURST_IME_STATUS" != "FAIL" \
           && "$MULTICHUNK_SEED_STATUS" != "FAIL" && "$AGENT_LINK_AFFORDANCE_STATUS" != "FAIL" \
-          && "$REATTACH_REPAINT_STATUS" != "FAIL" && "$OVERLAY_UNBOUNDED_STATUS" != "FAIL" \
+          && "$REATTACH_REPAINT_STATUS" != "FAIL" && "$SESSION_BINDING_STATUS" != "FAIL" \
+          && "$OVERLAY_UNBOUNDED_STATUS" != "FAIL" \
           && "$SURFACE_REPAINT_STATUS" != "FAIL" && "$SHELL_SNAPSHOT_STATUS" != "FAIL" ]]; then
     # Only the budget timeout fired (no class failed BOTH attempts on its own
     # merits): a pure #470-stall time-budget casualty.
@@ -70,6 +72,9 @@ finish_ci_journey_suite() {
     echo
     echo "Core-terminal #879 beyond-grace reattach-repaint proof (\`shared:core-terminal\`): **$REATTACH_REPAINT_STATUS**"
     echo "- \`$CORE_TERMINAL_REATTACH_REPAINT_CLASS\`"
+    echo
+    echo "Core-terminal #959 mounted session-binding proof (\`shared:core-terminal\`): **$SESSION_BINDING_STATUS**"
+    echo "- \`$CORE_TERMINAL_SESSION_BINDING_CLASS\`"
     echo
     echo "Core-terminal v0.4.17 overlay-unbounded-measure crash proof (\`shared:core-terminal\`): **$OVERLAY_UNBOUNDED_STATUS**"
     echo "- \`$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS\`"
@@ -122,7 +127,8 @@ finish_ci_journey_suite() {
     # else-branch and is mislabeled as an infra abort, burying the real cause.
     if [[ "${#FAILED_CLASSES[@]}" -gt 0 || "$APPEND_BURST_STATUS" == "FAIL" || "$OUTPUT_BURST_IME_STATUS" == "FAIL" \
           || "$MULTICHUNK_SEED_STATUS" == "FAIL" || "$AGENT_LINK_AFFORDANCE_STATUS" == "FAIL" \
-          || "$REATTACH_REPAINT_STATUS" == "FAIL" || "$OVERLAY_UNBOUNDED_STATUS" == "FAIL" ]]; then
+          || "$REATTACH_REPAINT_STATUS" == "FAIL" || "$SESSION_BINDING_STATUS" == "FAIL" \
+          || "$OVERLAY_UNBOUNDED_STATUS" == "FAIL" ]]; then
       echo
       echo "Failed BOTH attempts (\`JOURNEY_FAILED\` — job red):"
       for c in "${FAILED_CLASSES[@]}"; do
@@ -142,6 +148,9 @@ finish_ci_journey_suite() {
       fi
       if [[ "$REATTACH_REPAINT_STATUS" == "FAIL" ]]; then
         echo "- \`$CORE_TERMINAL_REATTACH_REPAINT_CLASS\` (#879 reattach-repaint proof)"
+      fi
+      if [[ "$SESSION_BINDING_STATUS" == "FAIL" ]]; then
+        echo "- \`$CORE_TERMINAL_SESSION_BINDING_CLASS\` (#959 mounted session-binding proof)"
       fi
       if [[ "$OVERLAY_UNBOUNDED_STATUS" == "FAIL" ]]; then
         echo "- \`$CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS\` (v0.4.17 overlay-unbounded-measure crash proof)"

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceComposeIntegrationTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/TerminalSurfaceComposeIntegrationTest.kt
@@ -6,6 +6,7 @@ import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
 import android.os.SystemClock
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -35,11 +36,14 @@ import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -184,6 +188,136 @@ class TerminalSurfaceComposeIntegrationTest {
     fun tearDown() {
         // No-op — each test scopes its own producer/scope/Intents lifecycle.
     }
+
+    /**
+     * Issue #959 recurrence: exercise the production Compose/AndroidView owner,
+     * not a bare TerminalView or a VM input-sink proxy.
+     *
+     * The same mounted View first displays session A, observes the real detached
+     * null identity, then [TerminalSurfaceState.attachExternalProducer] installs
+     * B. Each transition must reach the View after one main-loop idle boundary;
+     * input is inert while detached, then input written through the View must
+     * reach B only and B output must render through the View's attached emulator.
+     * This is the boundary the historical VM test bypassed and the exact-main
+     * connected diagnostic found stale.
+     */
+    @Test
+    fun mountedViewRebindsImmediatelyFromSessionAToBAndRoutesOnlyToB() { runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val state = TerminalSurfaceState()
+        val stdoutA = MutableSharedFlow<ByteArray>(extraBufferCapacity = 4)
+        val stdoutB = MutableSharedFlow<ByteArray>(extraBufferCapacity = 4)
+        val stdinA = RecordingOutputStream()
+        val stdinB = RecordingOutputStream()
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerA = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = stdoutA,
+            remoteStdin = stdinA,
+        )
+        val sessionA = requireNotNull(state.session)
+        var producerB: kotlinx.coroutines.Job? = null
+
+        try {
+            composeTestRule.setContent {
+                TerminalSurface(state = state, modifier = Modifier)
+            }
+            composeTestRule.waitForIdle()
+            val mountedView = waitForTerminalView()
+            assertSame(
+                "precondition: the production surface must bind mounted View to session A",
+                sessionA,
+                mountedView.currentSession,
+            )
+
+            val inputA = "issue959-input-a"
+            instrumentation.runOnMainSync {
+                val bytes = inputA.toByteArray(Charsets.UTF_8)
+                requireNotNull(mountedView.currentSession).write(bytes, 0, bytes.size)
+            }
+            stdinA.awaitContains(inputA)
+
+            val outputA = "ISSUE959-OUTPUT-A"
+            stdoutA.emit("$outputA\r\n".toByteArray(Charsets.UTF_8))
+            waitForViewTranscript(mountedView, outputA)
+
+            instrumentation.runOnMainSync {
+                state.detachExternalProducer()
+            }
+            composeTestRule.waitForIdle()
+            val detachedView = waitForTerminalView()
+            assertSame(
+                "the AndroidView instance must be reused across A→null",
+                mountedView,
+                detachedView,
+            )
+            assertSame(
+                "the mounted View must expose the exact detached null identity",
+                null,
+                detachedView.currentSession,
+            )
+            val stdinAAfterDetach = stdinA.snapshot()
+            instrumentation.runOnMainSync {
+                detachedView.dispatchKeyEvent(
+                    KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_X),
+                )
+            }
+            assertEquals(
+                "mounted View input must be inert while the state is detached",
+                stdinAAfterDetach,
+                stdinA.snapshot(),
+            )
+
+            lateinit var sessionB: com.termux.terminal.TerminalSession
+            instrumentation.runOnMainSync {
+                producerB = state.attachExternalProducer(
+                    scope = producerScope,
+                    stdout = stdoutB,
+                    remoteStdin = stdinB,
+                )
+                sessionB = requireNotNull(state.session)
+            }
+            assertTrue("session B must replace session A by identity", sessionB !== sessionA)
+
+            // One main-loop idle turn is the readiness boundary: no retry/poll is
+            // allowed for identity. The old AndroidView.update ownership retained A
+            // through the null lifecycle transition until a later unrelated update.
+            composeTestRule.waitForIdle()
+            val reusedView = waitForTerminalView()
+            assertSame("the AndroidView instance must be reused across A→null→B", mountedView, reusedView)
+            assertSame(
+                "the mounted View must expose exact session B before input readiness",
+                sessionB,
+                reusedView.currentSession,
+            )
+
+            val inputB = "issue959-input-b"
+            instrumentation.runOnMainSync {
+                val bytes = inputB.toByteArray(Charsets.UTF_8)
+                requireNotNull(reusedView.currentSession).write(bytes, 0, bytes.size)
+            }
+            stdinB.awaitContains(inputB)
+            assertFalse(
+                "post-rebind input must never leak into stopped session A",
+                stdinA.snapshot().contains(inputB),
+            )
+
+            val lateA = "ISSUE959-LATE-OUTPUT-A"
+            val outputB = "ISSUE959-OUTPUT-B"
+            stdoutA.emit("$lateA\r\n".toByteArray(Charsets.UTF_8))
+            stdoutB.emit("$outputB\r\n".toByteArray(Charsets.UTF_8))
+            waitForViewTranscript(reusedView, outputB)
+            assertFalse(
+                "the reused View must render B's emulator, never late output from A",
+                viewTranscript(reusedView).contains(lateA),
+            )
+        } finally {
+            producerB?.cancel()
+            producerA.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    } }
 
     @Test
     fun copyActionRoutesSelectedTextThroughRealClipboardManager() { runBlocking {
@@ -890,6 +1024,17 @@ class TerminalSurfaceComposeIntegrationTest {
         return null
     }
 
+    private suspend fun waitForViewTranscript(view: TerminalView, expected: String) {
+        withTimeout(5_000) {
+            while (!viewTranscript(view).contains(expected)) {
+                delay(20)
+            }
+        }
+    }
+
+    private fun viewTranscript(view: TerminalView): String =
+        view.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+
     /**
      * Dispatch a synthetic ACTION_DOWN immediately followed by ACTION_UP at
      * `(x, y)` (view-local pixels) so the vendored GestureDetector confirms
@@ -965,6 +1110,31 @@ class TerminalSurfaceComposeIntegrationTest {
                 onImeLookup()
             }
             return super.getSystemService(name)
+        }
+    }
+
+    private class RecordingOutputStream : OutputStream() {
+        private val bytes = ByteArrayOutputStream()
+
+        @Synchronized
+        override fun write(value: Int) {
+            bytes.write(value)
+        }
+
+        @Synchronized
+        override fun write(buffer: ByteArray, offset: Int, length: Int) {
+            bytes.write(buffer, offset, length)
+        }
+
+        @Synchronized
+        fun snapshot(): String = bytes.toString(Charsets.UTF_8.name())
+
+        suspend fun awaitContains(expected: String) {
+            withTimeout(5_000) {
+                while (!snapshot().contains(expected)) {
+                    delay(20)
+                }
+            }
         }
     }
 }

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -272,7 +273,6 @@ fun TerminalSurface(
     viewClient.onTerminalSurfaceError = onLocalTerminalError
     var terminalView by remember { mutableStateOf<TerminalView?>(null) }
     var viewportTick by remember { mutableStateOf(0L) }
-    val desiredSession = state.session
 
     val context = LocalContext.current
 
@@ -378,6 +378,43 @@ fun TerminalSurface(
         onDispose {
             state.setSmartTextStagingBridge(null)
             state.setSurfacePixelSampler(null)
+        }
+    }
+
+    // Issue #959 recurrence: TerminalSurfaceState owns the authoritative
+    // TerminalSession identity, while the mounted TerminalView owns the real
+    // IME/key-event entry point. Binding the two from AndroidView.update left a
+    // lifecycle-sized window where the state and pane producer had already moved
+    // to session B but the reused View still exposed session A. A one-shot key
+    // written in that window disappeared into A's stopped bridge.
+    //
+    // Observe the latest exact session identity independently of recomposition. A
+    // DisposableEffect keyed by state.session is still gated by a Compose apply
+    // turn; the post-grace diagnostic proved that turn can arrive after the
+    // user's first input. snapshotFlow registers directly with snapshot state,
+    // and the Handler-based main dispatcher applies the lifecycle's settled
+    // session identity to the mounted View before the post-reattach input turn.
+    // The A→null→B connected proof separately exercises the detach identity;
+    // snapshotFlow may conflate faster intermediate writes, so this is not a
+    // claim that arbitrary off-main mutations are synchronously mirrored.
+    // This is the single attachment owner; AndroidView.update below only reports
+    // the View instance and never performs a second delayed attachment.
+    LaunchedEffect(state, terminalView) {
+        val view = terminalView ?: return@LaunchedEffect
+        withContext(Dispatchers.Main.immediate) {
+            snapshotFlow { state.session }.collect { session ->
+                if (view.currentSession !== session) {
+                    runCatching {
+                        view.attachSession(session)
+                        if (session != null) {
+                            // Issue #721: a replacement session may already hold
+                            // seeded buffer content, while the reused View's dirty
+                            // cache still describes the old surface.
+                            view.forceFullRepaint()
+                        }
+                    }.onFailure { onLocalTerminalError?.invoke(it) }
+                }
+            }
         }
     }
 
@@ -650,37 +687,6 @@ fun TerminalSurface(
                 },
                 update = { view ->
                     terminalView = view
-                    val current = view.currentSession
-                    // Attach / detach as the state's session reference
-                    // changes. `attachSession` early-returns when given the
-                    // same instance, so this is idempotent across
-                    // recompositions.
-                    if (desiredSession != null) {
-                        if (desiredSession !== current) {
-                            runCatching {
-                                view.attachSession(desiredSession)
-                                // Issue #721: attaching a session that already
-                                // holds buffer content (a tmux session switch via
-                                // pager dispose, or any attach with no fresh bytes
-                                // pending) updates the emulator the View points at
-                                // but does not, on its own, repaint the existing
-                                // screen — the #469 dirty cache still assumes the
-                                // previous surface pixels. Force a full repaint so
-                                // the whole buffer is redrawn on attach, not just
-                                // newly-written cells.
-                                view.forceFullRepaint()
-                            }.onFailure { onLocalTerminalError?.invoke(it) }
-                        }
-                    } else if (desiredSession !== current) {
-                        // No public detach on TerminalView; clear the
-                        // field via an attach of an empty marker is not
-                        // possible because TerminalSession is `final`
-                        // and we cannot construct a sentinel without
-                        // driving JNI. The view simply keeps its last
-                        // session reference until the next attach. This
-                        // is acceptable for #8 — #9 will always have a
-                        // fresh session on hand when changing sessions.
-                    }
                 },
             )
             if (matchScannerEnabled) {

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -377,9 +377,11 @@ class TerminalSurfaceState(
     }
 
     /**
-     * Bind a live [TerminalSession] to this state holder. The next
-     * recomposition of [TerminalSurface] will attach it to the underlying
-     * [TerminalView].
+     * Bind a live [TerminalSession] to this state holder. During the app's
+     * main-thread detach/reattach lifecycle, a mounted [TerminalSurface]'s
+     * observer applies the settled latest identity to the underlying
+     * [TerminalView] independently of an unrelated recomposition. This is not a
+     * synchronous mirroring contract for arbitrary off-main mutations.
      *
      * Attaching twice with the same session is a no-op. Attaching a new
      * session over an existing one replaces it; the old session is NOT
@@ -393,9 +395,10 @@ class TerminalSurfaceState(
     }
 
     /**
-     * Release the current session reference. The [TerminalView] keeps
-     * rendering its existing emulator state until something else replaces
-     * it; this method only severs the state-holder ↔ session link.
+     * Release the current session reference. During the app's main-thread
+     * detach/reattach lifecycle, a mounted [TerminalSurface]'s observer applies
+     * the settled null identity to the underlying [TerminalView]; with no
+     * mounted surface this only severs the state-holder ↔ session link.
      */
     fun detach() {
         if (_session != null) renderModelMutationEpoch.incrementAndGet()


### PR DESCRIPTION
Closes #959.\n\nBinds the mounted TerminalView to the latest TerminalSurfaceState session across detach/reattach, preventing post-grace input from being written through an obsolete terminal session. Adds load-bearing mounted-view, real-drainer, connected journey, and CI wiring coverage.\n\nIndependent review: https://github.com/alexeygrigorev/pocketshell/issues/959#issuecomment-5086319077