### PR TITLE
fix(connection): bind parked health to runtime instances

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -36,12 +37,23 @@ import com.pocketshell.app.tmux.TMUX_FULL_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_PROJECT_SWITCHER_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.CachedTmuxRuntime
+import com.pocketshell.app.tmux.TmuxSessionRuntimeCache
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.closeCachedRuntime
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
@@ -422,6 +434,229 @@ class MultiSessionSwitchJourneyE2eTest {
             ),
         )
         writeTimings()
+        Unit
+    } }
+
+    /**
+     * Issue #1537 G10 deterministic stale-generation reproduction.
+     *
+     * This drives the real Docker/tmux lifecycle with APIs present on both the
+     * untouched base and candidate:
+     *
+     *  1. open A generation 1, then switch to B so A is genuinely parked;
+     *  2. create and connect a second real A control client, construct the same
+     *     common CachedTmuxRuntime shape, and replace generation 1 through the
+     *     production cache.put operation;
+     *  3. remotely detach only generation 1's real tmux client, delivering its
+     *     ReaderEof through the existing parked-health lifecycle.
+     *
+     * On untouched 3e8474d0 the logical host/session removal evicts healthy
+     * generation 2 and records parked_runtime_death. With exact binding, the
+     * callback records stale_callback, generation 2 remains cached, switches
+     * back without a new SSH handshake, and accepts real terminal input.
+     */
+    @Test
+    fun lateOldRuntimeRemoteDeathCannotEvictHealthySameSessionReplacement() { runBlocking {
+        val recording = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+        diagnostics = recording
+
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForFolderListReady(hostRowTag)
+        waitForText(SESSION_A, timeoutMs = pickerWaitMs)
+        compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+        waitForTerminalContains(SESSION_A_MARKER, "issue1537 stale-generation initial A")
+
+        expectedMarker[SESSION_A] = SESSION_A_MARKER
+        expectedMarker[SESSION_B] = SESSION_B_MARKER
+        expectedMarker[SESSION_C] = SESSION_C_MARKER
+        assertInputRoutesToShownSession(SESSION_A, "issue1537-generation1")
+        switchAndAssert(step = 1, fromSession = SESSION_A, toSession = SESSION_B)
+
+        val cache = runtimeCacheFromActiveViewModel()
+        val currentHostId = hostRowTag.removePrefix(HOST_ROW_TAG_PREFIX).toLong()
+        val generation1Key = cache.snapshotKeys().single {
+            it.hostId == currentHostId && it.sessionName == SESSION_A
+        }
+        val generation1 = cache.cachedRuntimesForHost(generation1Key.hostId)
+            .single { it.key == generation1Key }
+        val generation1ClientHash = System.identityHashCode(generation1.client)
+        val generation1TmuxClient = listTmuxClientsForSession(SESSION_A).single()
+
+        val replacementScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val replacementSession = withTimeout(20_000L) {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(fixtureKey),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).getOrThrow()
+        }
+        val replacementClient = TmuxClientFactory(replacementScope).create(
+            session = replacementSession,
+            sessionName = SESSION_A,
+            createIfMissing = false,
+        )
+        withTimeout(20_000L) { replacementClient.connect() }
+        val clientsWithReplacement = listTmuxClientsForSession(SESSION_A)
+        assertEquals(
+            "issue1537 fixture must have exactly old A + healthy replacement A clients",
+            2,
+            clientsWithReplacement.size,
+        )
+        assertTrue(
+            "issue1537 fixture must retain the exact old A client until remote EOF",
+            generation1TmuxClient in clientsWithReplacement,
+        )
+        assertEquals(
+            "issue1537 old and replacement must be distinct remote tmux clients and shell channels",
+            2,
+            clientsWithReplacement.map { it.pid }.distinct().size,
+        )
+        assertEquals(
+            "issue1537 old and replacement must have distinct parent login shells",
+            2,
+            clientsWithReplacement.map { it.shellPid }.distinct().size,
+        )
+        assertTrue(
+            "issue1537 all authoritative tmux and parent shell PIDs must be positive",
+            clientsWithReplacement.all { it.pid > 1L && it.shellPid > 1L },
+        )
+        assertTrue(
+            "issue1537 replacement client/session must be healthy before cache replacement",
+            !replacementClient.disconnected.value && replacementSession.isConnected,
+        )
+        val generation2 = CachedTmuxRuntime(
+            key = generation1.key,
+            hostName = generation1.hostName,
+            startDirectory = generation1.startDirectory,
+            session = replacementSession,
+            client = replacementClient,
+            panes = generation1.panes,
+            paneRows = generation1.paneRows,
+            // The restored-runtime production path rebinds these jobs and
+            // queues to generation 2. Empty maps force that normal rebind.
+            paneProducerJobs = emptyMap(),
+            paneInputQueues = emptyMap(),
+            paneInputJobs = emptyMap(),
+            paneAgentJobs = emptyMap(),
+            paneAgentInputs = generation1.paneAgentInputs,
+            agentConversations = generation1.agentConversations,
+            remoteColumns = generation1.remoteColumns,
+            remoteRows = generation1.remoteRows,
+            lease = null,
+        )
+        val generation2ClientHash = System.identityHashCode(replacementClient)
+        assertTrue(
+            "issue1537 replacement must be a distinct real client generation",
+            generation2ClientHash != generation1ClientHash,
+        )
+        val replaced = cache.put(generation2)
+        assertEquals(
+            "issue1537 fixture must replace exactly old A through production cache.put",
+            listOf(generation1ClientHash),
+            replaced.map { System.identityHashCode(it.client) },
+        )
+        assertTrue(
+            "issue1537: healthy generation 2 must occupy A's common runtime cache key",
+            cache.cachedRuntimesForHost(generation1Key.hostId)
+                .single { it.key == generation1Key }
+                .client === replacementClient,
+        )
+
+        try {
+            killRemoteTmuxClientShell(generation1TmuxClient)
+            val generation1Disconnect = withTimeout(10_000L) {
+                generation1.client.disconnectEvent.first { it != null }!!
+            }
+            assertEquals(
+                "issue1537: killing the exact old remote shell channel must produce ReaderEof",
+                TmuxDisconnectReason.ReaderEof,
+                generation1Disconnect.reason,
+            )
+            assertTrue(
+                "issue1537: old remote death must not damage healthy generation 2",
+                !replacementClient.disconnected.value && replacementSession.isConnected,
+            )
+            compose.waitUntil(timeoutMillis = 15_000L) {
+                recording.eventsNamed("parked_runtime_death_ignored").isNotEmpty() ||
+                    recording.eventsNamed("parked_runtime_death").isNotEmpty()
+            }
+
+            val ignored = recording.eventsNamed("parked_runtime_death_ignored")
+            val falseDeaths = recording.eventsNamed("parked_runtime_death")
+            writeText(
+                "issue1537-stale-generation-diagnostics.txt",
+                buildString {
+                    appendLine("killed_tmux_client=$generation1TmuxClient")
+                    appendLine("generation1_disconnect=$generation1Disconnect")
+                    appendLine("generation1_client_hash=$generation1ClientHash")
+                    appendLine("generation2_client_hash=$generation2ClientHash")
+                    appendLine("ignored=$ignored")
+                    appendLine("parked_runtime_death=$falseDeaths")
+                },
+            )
+            assertEquals(
+                "issue1537: late old-A edge must have exact stale_callback outcome; " +
+                    "untouched base instead records logical-key parked_runtime_death",
+                1,
+                ignored.count {
+                    it.fields["outcome"] == "stale_callback" &&
+                        it.fields["cause"] == "ReaderEof" &&
+                        it.fields["session"] == SESSION_A &&
+                        it.fields["boundClientHash"] == generation1ClientHash
+                },
+            )
+            assertTrue(
+                "issue1537: late old-A edge must cause zero false eviction events; saw $falseDeaths",
+                falseDeaths.isEmpty(),
+            )
+            assertTrue(
+                "issue1537: exact stale callback must leave healthy A generation 2 cached",
+                cache.cachedRuntimesForHost(generation1Key.hostId)
+                    .single { it.key == generation1Key }
+                    .client === replacementClient,
+            )
+
+            val handshakesBeforeReturn = SSH_HANDSHAKE_ATTEMPTS.get()
+            val reconnectsBeforeReturn = reconnectTriggerConnectCount()
+            switchAndAssert(step = 2, fromSession = SESSION_B, toSession = SESSION_A)
+            assertEquals(
+                "issue1537: retained generation 2 must warm-switch without a fresh SSH handshake",
+                handshakesBeforeReturn,
+                SSH_HANDSHAKE_ATTEMPTS.get(),
+            )
+            assertEquals(
+                "issue1537: retained generation 2 must not trigger reconnect on return",
+                reconnectsBeforeReturn,
+                reconnectTriggerConnectCount(),
+            )
+            // switchAndAssert performs the load-bearing terminal input round-trip.
+            captureViewport("issue1537-exact-generation-return-$SESSION_A")
+            writeSummary(
+                lines = listOf(
+                    "issue=1537 deterministic stale old-runtime callback",
+                    "session=$SESSION_A",
+                    "old_client_hash=$generation1ClientHash",
+                    "replacement_client_hash=$generation2ClientHash",
+                    "remote_killed_client=$generation1TmuxClient",
+                    "parked_runtime_death_ignored=${ignored.size}",
+                    "parked_runtime_death=${falseDeaths.size}",
+                    "outcome=stale_callback",
+                    "replacement_cached_and_input_round_trip=true",
+                ),
+            )
+            writeTimings()
+        } finally {
+            runCatching { generation1.closeCachedRuntime() }
+            runCatching { replacementClient.close() }
+            runCatching { replacementSession.close() }
+            replacementScope.cancel()
+        }
         Unit
     } }
 
@@ -1106,6 +1341,72 @@ class MultiSessionSwitchJourneyE2eTest {
     }
 
     // ---------------------------------------------------------------- Helpers
+
+    private fun runtimeCacheFromActiveViewModel(): TmuxSessionRuntimeCache {
+        var cache: TmuxSessionRuntimeCache? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+            cache = TmuxSessionViewModel::class.java
+                .getDeclaredField("runtimeCache")
+                .apply { isAccessible = true }
+                .get(vm) as TmuxSessionRuntimeCache
+        }
+        return requireNotNull(cache) { "issue1537: active VM common runtime cache unavailable" }
+    }
+
+    private suspend fun listTmuxClientsForSession(sessionName: String): List<RemoteTmuxClient> {
+        val script =
+            "tmux list-clients -t ${shellQuote(sessionName)} -F '#{client_name}|#{client_pid}'"
+        val rows = runDockerSshCommand(script, "list clients for $sessionName")
+            .lineSequence()
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .toList()
+        return rows
+            .map { line ->
+                val fields = line.split('|', limit = 2)
+                require(fields.size == 2) { "issue1537: malformed tmux client row '$line'" }
+                val pid = fields[1].toLong()
+                val shellPid = runDockerSshCommand(
+                    "ps -o ppid= -p $pid",
+                    "resolve parent login shell for tmux client ${fields[0]}",
+                ).trim().toLong()
+                RemoteTmuxClient(name = fields[0], pid = pid, shellPid = shellPid)
+            }
+    }
+
+    private suspend fun killRemoteTmuxClientShell(client: RemoteTmuxClient) {
+        require(client.shellPid > 1L) {
+            "issue1537: refusing invalid remote shell PID ${client.shellPid}"
+        }
+        runDockerSshCommand(
+            "kill -KILL ${client.shellPid}",
+            "kill exact old A tmux client shell channel $client",
+        )
+    }
+
+    private data class RemoteTmuxClient(val name: String, val pid: Long, val shellPid: Long)
+
+    private suspend fun runDockerSshCommand(command: String, label: String): String {
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(fixtureKey),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use { it.exec(command) }
+        }
+        val exec = result.getOrNull()
+        assertEquals(
+            "issue1537: Docker SSH command must succeed for $label; " +
+                "exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            0,
+            exec?.exitCode,
+        )
+        return exec?.stdout.orEmpty()
+    }
 
     private fun readFixtureKey(): String =
         InstrumentationRegistry.getInstrumentation()

--- a/app/src/main/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandler.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandler.kt
@@ -2,8 +2,7 @@ package com.pocketshell.app.tmux
 
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.diagnostics.ReconnectCauseTrail
-import com.pocketshell.core.connection.RuntimeDeathCause
-import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.app.tmux.connection.ParkedRuntimeDeathSignal
 import com.pocketshell.core.ssh.SshLeaseKey
 
 /**
@@ -24,43 +23,79 @@ import com.pocketshell.core.ssh.SshLeaseKey
  * killing a transport the active session is still using.
  */
 internal fun handleParkedRuntimeDeath(
-    key: RuntimeHealthKey,
-    leaseKey: SshLeaseKey?,
-    cause: RuntimeDeathCause,
+    signal: ParkedRuntimeDeathSignal,
     runtimeCache: TmuxSessionRuntimeCache,
     // Lease keys the foreground/connecting session currently holds — a shared one
     // must NOT be force-disconnected.
     foregroundLeaseKeys: Set<SshLeaseKey>,
     disconnectLease: suspend (SshLeaseKey) -> Unit,
     launchContained: (suspend () -> Unit) -> Unit,
-) {
-    val removed = runtimeCache.removeSession(key.hostId, key.sessionName)
+): Boolean {
+    // Atomic exact compare-and-remove. If this binding has already been
+    // replaced, the callback is stale and must not touch the new runtime,
+    // release its lease, or disconnect its transport.
+    val removed = runtimeCache.removeExact(signal.binding)
+    if (removed == null) {
+        DiagnosticEvents.record(
+            "connection",
+            "parked_runtime_death_ignored",
+            "source" to "parked_health_subscriber",
+            "outcome" to "stale_callback",
+            "cause" to signal.cause.name,
+            "hostId" to signal.binding.key.hostId,
+            "session" to signal.binding.key.sessionName,
+            "boundRuntimeToken" to signal.binding.token.toString(),
+            "boundClientHash" to signal.boundClientIdentity,
+            *signal.typedCauseDiagnosticFields(),
+        )
+        return false
+    }
     DiagnosticEvents.record(
         "connection",
         "parked_runtime_death",
         "source" to "parked_health_subscriber",
-        "cause" to cause.name,
-        "hostId" to key.hostId,
-        "session" to key.sessionName,
-        "evictedRuntimes" to removed.size,
+        "cause" to signal.cause.name,
+        "hostId" to signal.binding.key.hostId,
+        "session" to signal.binding.key.sessionName,
+        "evictedRuntimes" to 1,
+        "boundRuntimeToken" to signal.binding.token.toString(),
+        "removedRuntimeToken" to removed.healthBinding.token.toString(),
+        "boundClientHash" to signal.boundClientIdentity,
+        "removedClientHash" to System.identityHashCode(removed.client),
+        *signal.typedCauseDiagnosticFields(),
     )
     ReconnectCauseTrail.record(
         stage = "parked_runtime_health",
         outcome = "proactive_evict",
-        cause = cause.name,
-        "hostId" to key.hostId,
+        cause = signal.cause.name,
+        "hostId" to signal.binding.key.hostId,
+        "runtimeToken" to signal.binding.token.toString(),
     )
-    val evictedLeaseKey = leaseKey ?: removed.firstNotNullOfOrNull { it.lease?.key }
+    val evictedLeaseKey = signal.leaseKey ?: removed.lease?.key
     launchContained {
         // closeCachedRuntime releases the lease REF (decrement refcount) — never a
         // raw pool disconnect that would nuke a shared transport.
-        removed.forEach { runCatching { it.closeCachedRuntime() } }
+        runCatching { removed.closeCachedRuntime() }
         val stillShared = evictedLeaseKey != null && (
             evictedLeaseKey in foregroundLeaseKeys ||
-                runtimeCache.cachedRuntimesForHost(key.hostId).any { it.lease?.key == evictedLeaseKey }
+                runtimeCache.cachedRuntimesForHost(signal.binding.key.hostId)
+                    .any { it.lease?.key == evictedLeaseKey }
             )
         if (evictedLeaseKey != null && !stillShared) {
             disconnectLease(evictedLeaseKey)
         }
     }
+    return true
 }
+
+private fun ParkedRuntimeDeathSignal.typedCauseDiagnosticFields(): Array<Pair<String, Any?>> =
+    arrayOf(
+        "disconnectReason" to disconnectEvent?.reason?.logValue,
+        "disconnectSource" to disconnectEvent?.source,
+        "disconnectIntent" to disconnectEvent?.intent,
+        "commandKind" to disconnectEvent?.commandKind,
+        "timeoutMode" to disconnectEvent?.timeoutMode,
+        "exceptionClass" to disconnectEvent?.exceptionClass,
+        "message" to disconnectEvent?.message,
+        "leaseCloseReason" to leaseCloseReason?.name,
+    )

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
@@ -1,6 +1,9 @@
 package com.pocketshell.app.tmux
 
 import android.os.SystemClock
+import com.pocketshell.core.connection.RuntimeHealthBinding
+import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.connection.RuntimeInstanceToken
 import com.pocketshell.core.ssh.SshLease
 import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshSession
@@ -113,6 +116,10 @@ public class TmuxSessionRuntimeCache @Inject constructor() {
         runtimes.containsKey(key)
     }
 
+    internal fun containsExact(binding: RuntimeHealthBinding): Boolean = synchronized(this) {
+        runtimes.values.any { it.runtime.healthBinding == binding }
+    }
+
     internal fun size(): Int = synchronized(this) { runtimes.size }
 
     internal fun diagnosticSnapshot(): TmuxRuntimeCacheDiagnostics = synchronized(this) {
@@ -145,6 +152,27 @@ public class TmuxSessionRuntimeCache @Inject constructor() {
     internal fun remove(key: TmuxRuntimeKey): CachedTmuxRuntime? = synchronized(this) {
         runtimes.remove(key)?.runtime
     }
+
+    /**
+     * Atomically remove only the runtime lifetime named by [binding].
+     *
+     * A logical host/session can already contain a newer replacement when an
+     * old client's delayed EOF callback arrives. The old `removeSession`
+     * operation erased that replacement. Exact compare-and-remove makes the
+     * stale callback a no-op; there is deliberately no logical-key fallback.
+     */
+    internal fun removeExact(binding: RuntimeHealthBinding): CachedTmuxRuntime? =
+        synchronized(this) {
+            val iterator = runtimes.entries.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                if (entry.value.runtime.healthBinding == binding) {
+                    iterator.remove()
+                    return@synchronized entry.value.runtime
+                }
+            }
+            null
+        }
 
     internal fun removeSession(hostId: Long, sessionName: String): List<CachedTmuxRuntime> =
         synchronized(this) {
@@ -283,6 +311,15 @@ internal data class CachedTmuxRuntime(
     val remoteColumns: Int,
     val remoteRows: Int,
     val lease: SshLease? = null,
+    /**
+     * Opaque identity for this exact cached-runtime lifetime. Host/session is
+     * intentionally insufficient because a replacement can reuse both before
+     * the old client's disconnect callback is delivered.
+     */
+    val healthBinding: RuntimeHealthBinding = RuntimeHealthBinding(
+        key = RuntimeHealthKey(hostId = key.hostId, sessionName = key.sessionName),
+        token = RuntimeInstanceToken.create(),
+    ),
 )
 
 internal suspend fun CachedTmuxRuntime.closeCachedRuntime(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeModels.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeModels.kt
@@ -2,7 +2,6 @@ package com.pocketshell.app.tmux
 
 import com.pocketshell.app.sessions.LeaseSessionTarget
 import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
-import com.pocketshell.core.connection.RuntimeHealthKey
 import com.pocketshell.core.tmux.TmuxClient
 
 /**
@@ -93,17 +92,6 @@ internal fun ConnectionTarget.toRuntimeKey(): TmuxRuntimeKey =
         sessionName = sessionName,
         durableSessionKey = durableSessionKey(),
     )
-
-/**
- * Issue #1537 (option b): the parked-runtime health identity for this target.
- * Keyed on host + tmux session name so it aligns with the runtime cache's
- * per-session eviction grain (`removeSession`).
- */
-internal fun ConnectionTarget.toHealthKey(): RuntimeHealthKey =
-    RuntimeHealthKey(hostId = hostId, sessionName = sessionName)
-
-internal fun TmuxRuntimeKey.toHealthKey(): RuntimeHealthKey =
-    RuntimeHealthKey(hostId = hostId, sessionName = sessionName)
 
 internal fun targetLogFields(target: ConnectionTarget): String = buildString {
     append("hostId=")

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -77,6 +77,7 @@ import com.pocketshell.app.tmux.connection.KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS
 import com.pocketshell.app.tmux.connection.KeepaliveDeathRedialAmortizer
 import com.pocketshell.app.tmux.connection.NetworkLossBandDebouncer
 import com.pocketshell.app.tmux.connection.ParkedRuntimeHealthEffects
+import com.pocketshell.app.tmux.connection.ParkedRuntimeDeathSignal
 import com.pocketshell.app.tmux.connection.isSameIdentityNetworkRestore
 import com.pocketshell.app.tmux.connection.recordNetworkRestoreReconnectStart
 import com.pocketshell.app.tmux.connection.recordNetworkRestoreRideThrough
@@ -102,8 +103,6 @@ import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
 import com.pocketshell.core.connection.HostKey
 import com.pocketshell.core.connection.LivenessProbe
 import com.pocketshell.core.connection.RevealState
-import com.pocketshell.core.connection.RuntimeDeathCause
-import com.pocketshell.core.connection.RuntimeHealthKey
 import com.pocketshell.core.connection.RuntimeHealthLedger
 import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.assistant.AssistantLlmClientFactory
@@ -4736,7 +4735,11 @@ public class TmuxSessionViewModel @Inject constructor(
             lease = null
             client = null
             paneRuntime = null
-            closeCachedRuntimesAsync(runtimeCache.put(runtime))
+            val evicted = runtimeCache.put(runtime)
+            if (evicted.none { it.healthBinding == runtime.healthBinding }) {
+                parkedRuntimeHealthEffects.bindParkedRuntime(runtime)
+            }
+            closeCachedRuntimesAsync(evicted)
             rebuildUnifiedPanes()
             TmuxSessionLatencyTelemetry.record(
                 name = "runtime_prewarm_ready",
@@ -5680,6 +5683,8 @@ public class TmuxSessionViewModel @Inject constructor(
             )
             return null
         }
+        // `activate` removed this exact runtime; the live path now owns liveness.
+        parkedRuntimeHealthEffects.onActivated(cached.healthBinding)
         if (cached.client.disconnected.value || cached.session?.isConnected != true) {
             val startedAtMs = visibleSwitchStartedAtMs.takeIf { it > 0L }
                 ?: SystemClock.elapsedRealtime()
@@ -5691,7 +5696,6 @@ public class TmuxSessionViewModel @Inject constructor(
                 trigger = trigger,
                 detail = "source=runtime_cache reason=disconnected",
             )
-            parkedRuntimeHealthEffects.onEvicted(cached.key.toHealthKey()) // #1537 unbind
             // Issue #935 R1: contained — closing a stale cached runtime issues
             // `detach-client`/close IO against a dead transport.
             launchContainedTeardown {
@@ -5721,7 +5725,6 @@ public class TmuxSessionViewModel @Inject constructor(
                 trigger = trigger,
                 detail = "source=runtime_cache reason=health_probe_failed",
             )
-            parkedRuntimeHealthEffects.onEvicted(cached.key.toHealthKey()) // #1537 unbind
             runCatching { cached.client.close() }
             // Issue #935 R1: contained — closing the unhealthy cached runtime +
             // disconnecting its lease is teardown IO against a dead transport.
@@ -5733,7 +5736,6 @@ public class TmuxSessionViewModel @Inject constructor(
             }
             return false
         }
-        parkedRuntimeHealthEffects.onActivated(cached.key.toHealthKey()) // #1537 activated
         val startedAtMs = SystemClock.elapsedRealtime()
         val milestoneStartedAtMs = visibleSwitchStartedAtMs.takeIf { it > 0L } ?: startedAtMs
         closeCachedRuntimesAsync(deactivateCurrentRuntimeToCache())
@@ -5869,12 +5871,9 @@ public class TmuxSessionViewModel @Inject constructor(
             remoteRows = remoteRows,
         )
         val evicted = runtimeCache.put(runtime)
-        // Issue #1537 (option b): bind the parked runtime's liveness edges.
-        parkedRuntimeHealthEffects.bindParked(
-            key = runtime.key.toHealthKey(),
-            client = runtime.client,
-            leaseKey = runtime.lease?.key ?: target.toSshLeaseTarget().leaseKey,
-        )
+        if (evicted.none { it.healthBinding == runtime.healthBinding }) {
+            parkedRuntimeHealthEffects.bindParkedRuntime(runtime)
+        }
         leaseRef = null
         sessionRef = null
         clientRef = null
@@ -5967,8 +5966,9 @@ public class TmuxSessionViewModel @Inject constructor(
 
     private fun closeCachedRuntimesAsync(runtimes: List<CachedTmuxRuntime>) {
         if (runtimes.isEmpty()) return
-        // Issue #1537 (option b): cancel each evicted runtime's parked-health binding.
-        runtimes.forEach { parkedRuntimeHealthEffects.onEvicted(it.key.toHealthKey()) }
+        // Issue #1537: unbind the exact evicted runtime life. A host/session-only
+        // unbind can cancel a same-key replacement parked moments later.
+        runtimes.forEach { parkedRuntimeHealthEffects.onEvicted(it.healthBinding) }
         // Issue #935 R1: contained — async eviction of deactivated cached
         // runtimes is teardown IO that may race the transport drop.
         launchContainedTeardown {
@@ -5981,13 +5981,9 @@ public class TmuxSessionViewModel @Inject constructor(
     // Issue #1537 (option b): parked-runtime death effect — delegates to the
     // extracted [handleParkedRuntimeDeath] (kept out of the god-object, #1047).
     private fun onParkedRuntimeDeath(
-        key: RuntimeHealthKey,
-        leaseKey: SshLeaseKey?,
-        cause: RuntimeDeathCause,
+        signal: ParkedRuntimeDeathSignal,
     ) = handleParkedRuntimeDeath(
-        key = key,
-        leaseKey = leaseKey,
-        cause = cause,
+        signal = signal,
         runtimeCache = runtimeCache,
         foregroundLeaseKeys = setOfNotNull(
             activeTarget?.toSshLeaseTarget()?.leaseKey,
@@ -6201,7 +6197,9 @@ public class TmuxSessionViewModel @Inject constructor(
         val forceFreshLease = shouldForceFreshLease(trigger)
         val evictedIdleLease = if (forceFreshLease) {
             withContext(NonCancellable) {
-                runtimeCache.removeLease(leaseTarget.leaseKey).forEach { cached ->
+                val removed = runtimeCache.removeLease(leaseTarget.leaseKey)
+                removed.forEach { parkedRuntimeHealthEffects.onEvicted(it.healthBinding) }
+                removed.forEach { cached ->
                     runCatching { cached.closeCachedRuntime() }
                 }
                 runCatching { sshLeaseManager.evictIdle(leaseTarget.leaseKey) }
@@ -6933,12 +6931,6 @@ public class TmuxSessionViewModel @Inject constructor(
         // this attempt only (mirrors [runConnect]).
         lastConnectFailureCause = null
         // Issue #1537 (option b): consult the parked-health ledger before attach.
-        parkedRuntimeHealthEffects.consumeParkedDeath(target.toHealthKey())?.let { cause ->
-            ReconnectCauseTrail.record(
-                "parked_runtime_health", "switch_consult_dead", cause.name, trigger.logValue,
-                "hostId" to target.hostId,
-            )
-        }
         try {
             val lease = acquireLeaseForTmux(
                 target = target,
@@ -9170,6 +9162,7 @@ public class TmuxSessionViewModel @Inject constructor(
         deactivateCurrentRuntimeToCache()
         val runtime = runtimeCache.activate(target.toRuntimeKey()).runtime
             ?: error("#1083 test seam: parked runtime missing from cache after deactivate")
+        parkedRuntimeHealthEffects.onActivated(runtime.healthBinding)
         restoreCachedRuntime(target = target, runtime = runtime, trigger = trigger)
     }
 
@@ -17087,13 +17080,18 @@ public class TmuxSessionViewModel @Inject constructor(
         when (cacheEviction) {
             RuntimeCacheEviction.HostWide -> {
                 closingHostId?.let { hostId ->
-                    runtimeCache.removeHost(hostId).forEach { cached ->
+                    val removed = runtimeCache.removeHost(hostId)
+                    removed.forEach { parkedRuntimeHealthEffects.onEvicted(it.healthBinding) }
+                    removed.forEach { cached ->
                         cached.closeCachedRuntime()
                     }
                 }
             }
             is RuntimeCacheEviction.TargetRuntime -> {
-                runtimeCache.remove(cacheEviction.key)?.closeCachedRuntime()
+                runtimeCache.remove(cacheEviction.key)?.let { cached ->
+                    parkedRuntimeHealthEffects.onEvicted(cached.healthBinding)
+                    cached.closeCachedRuntime()
+                }
             }
         }
         releaseCurrentLeaseOrCloseRawSession()
@@ -17235,6 +17233,7 @@ public class TmuxSessionViewModel @Inject constructor(
         val runtimesToClose = closingHostId?.let { hostId ->
             runtimeCache.removeHost(hostId)
         } ?: emptyList()
+        runtimesToClose.forEach { parkedRuntimeHealthEffects.onEvicted(it.healthBinding) }
         val leaseToRelease = leaseRef
         val sessionToClose = sessionRef
         sessionRef = null

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffects.kt
@@ -1,14 +1,17 @@
 package com.pocketshell.app.tmux.connection
 
+import com.pocketshell.app.tmux.CachedTmuxRuntime
 import com.pocketshell.core.connection.RuntimeDeathCause
 import com.pocketshell.core.connection.RuntimeHealthEvent
-import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.connection.RuntimeHealthBinding
 import com.pocketshell.core.connection.RuntimeHealthLedger
 import com.pocketshell.core.ssh.SshLeaseCloseReason
 import com.pocketshell.core.ssh.SshLeaseConnectionState
 import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseStateEvent
 import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
@@ -24,8 +27,8 @@ import kotlinx.coroutines.launch
  * When a same-host session is parked into the runtime cache while another
  * session is foreground, its liveness edges keep firing but nobody listens:
  *
- *  - the parked [TmuxClient]'s own `disconnected` StateFlow latches `true` on
- *    the `-CC` reader EOF (control channel death AND tmux-server death), and
+ *  - the parked [TmuxClient]'s typed `disconnectEvent` latches the exact
+ *    reason/source/intent of a `-CC` reader exit, and
  *  - the pool broadcasts a per-key `Closed(KeepaliveDead)`/`Closed` edge on
  *    [leaseStateEvents] when the always-on keepalive declares the transport dead.
  *
@@ -60,21 +63,38 @@ internal class ParkedRuntimeHealthEffects(
      * shared by the foreground session — that is the same-host residual race the
      * attach-EOF fallback covers.
      */
-    private val onDeath: (RuntimeHealthKey, SshLeaseKey?, RuntimeDeathCause) -> Unit,
+    private val onDeath: (ParkedRuntimeDeathSignal) -> Boolean,
 ) {
-    private val bindings = mutableMapOf<RuntimeHealthKey, Job>()
+    private val bindings = mutableMapOf<RuntimeHealthBinding, Job>()
+
+    fun bindParkedRuntime(runtime: CachedTmuxRuntime) {
+        bindParked(
+            binding = runtime.healthBinding,
+            client = runtime.client,
+            leaseKey = runtime.lease?.key ?: SshLeaseKey(
+                host = runtime.key.hostname,
+                port = runtime.key.port,
+                user = runtime.key.username,
+                credentialId = "${runtime.key.hostId}:${runtime.key.keyPath}",
+            ),
+        )
+    }
 
     /**
      * Bind the liveness edges for a runtime being parked into the cache. Idempotent
      * per key — a re-park cancels the prior binding and resets the ledger to Healthy.
      */
-    fun bindParked(key: RuntimeHealthKey, client: TmuxClient, leaseKey: SshLeaseKey?) {
-        cancelBinding(key)
-        ledger.reduce(RuntimeHealthEvent.Parked(key))
-        bindings[key] = scope.launch {
+    fun bindParked(
+        binding: RuntimeHealthBinding,
+        client: TmuxClient,
+        leaseKey: SshLeaseKey?,
+    ) {
+        cancelBinding(binding)
+        ledger.reduce(RuntimeHealthEvent.Parked(binding))
+        bindings[binding] = scope.launch {
             coroutineScope {
-                launch { awaitClientDeath(key, client) }
-                launch { awaitLeaseDeath(key, leaseKey) }
+                launch { awaitClientDeath(binding, client, leaseKey) }
+                launch { awaitLeaseDeath(binding, client, leaseKey) }
             }
         }
     }
@@ -84,30 +104,23 @@ internal class ParkedRuntimeHealthEffects(
      * again. Cancel the binding and drop it from the ledger (a Dead entry would
      * not activate; it fell out via the health probe first).
      */
-    fun onActivated(key: RuntimeHealthKey) {
-        cancelBinding(key)
-        ledger.reduce(RuntimeHealthEvent.Cleared(key))
+    fun onActivated(binding: RuntimeHealthBinding) {
+        cancelBinding(binding)
+        ledger.reduce(RuntimeHealthEvent.Cleared(binding))
     }
 
     /**
      * The parked runtime is leaving the cache WITHOUT a detected death (TTL,
      * host overflow, twin prune, or an explicit evict). Cancel the binding.
-     * A sticky [RuntimeDeathCause] verdict is preserved so an imminent
-     * switch-back can still consult it; a still-Healthy entry is dropped.
+     * Exact death handling removes its ledger entry after the callback, so an
+     * eviction only needs to clear a still-Healthy binding.
      */
-    fun onEvicted(key: RuntimeHealthKey) {
-        cancelBinding(key)
-        if (!ledger.isDead(key)) ledger.reduce(RuntimeHealthEvent.Cleared(key))
+    fun onEvicted(binding: RuntimeHealthBinding) {
+        cancelBinding(binding)
+        ledger.reduce(RuntimeHealthEvent.Cleared(binding))
     }
 
-    /**
-     * Consult-and-clear: if the parked runtime for [key] was proactively marked
-     * dead, return the cause (one-shot) so the switch path can present the calm
-     * hold; otherwise `null`.
-     */
-    fun consumeParkedDeath(key: RuntimeHealthKey): RuntimeDeathCause? = ledger.consumeDead(key)
-
-    fun isTracked(key: RuntimeHealthKey): Boolean = ledger.health(key) != null
+    fun isTracked(binding: RuntimeHealthBinding): Boolean = ledger.health(binding) != null
 
     /** Cancel every binding (VM teardown). */
     fun cancelAll() {
@@ -115,40 +128,108 @@ internal class ParkedRuntimeHealthEffects(
         bindings.clear()
     }
 
-    private fun cancelBinding(key: RuntimeHealthKey) {
-        bindings.remove(key)?.cancel()
+    private fun cancelBinding(binding: RuntimeHealthBinding) {
+        bindings.remove(binding)?.cancel()
     }
 
-    private suspend fun awaitClientDeath(key: RuntimeHealthKey, client: TmuxClient) {
-        // Suspends until the parked reader latches disconnected (or returns
-        // immediately if it already died before we bound). Terminal by nature.
-        client.disconnected.first { it }
-        fireDeath(key, leaseKeyHint = null, cause = RuntimeDeathCause.ClientDisconnected)
+    private suspend fun awaitClientDeath(
+        binding: RuntimeHealthBinding,
+        client: TmuxClient,
+        leaseKey: SshLeaseKey?,
+    ) {
+        // The typed event is published before the legacy Boolean latch. Waiting
+        // on it preserves the emitter's reason/source/intent and lets the single
+        // SelfInflictedClose authority reject our own detach/close.
+        val event = client.disconnectEvent.first { it != null }!!
+        if (SelfInflictedClose.isSelfInflictedControlChannelClose(event)) {
+            ignoreSelfInflicted(binding)
+            return
+        }
+        fireDeath(
+            ParkedRuntimeDeathSignal(
+                binding = binding,
+                leaseKey = leaseKey,
+                cause = event.toRuntimeDeathCause(),
+                boundClientIdentity = System.identityHashCode(client),
+                disconnectEvent = event,
+                leaseCloseReason = null,
+            ),
+        )
     }
 
-    private suspend fun awaitLeaseDeath(key: RuntimeHealthKey, leaseKey: SshLeaseKey?) {
+    private suspend fun awaitLeaseDeath(
+        binding: RuntimeHealthBinding,
+        client: TmuxClient,
+        leaseKey: SshLeaseKey?,
+    ) {
         if (leaseKey == null) return
         val event = leaseStateEvents.first {
             it.key == leaseKey && it.state == SshLeaseConnectionState.Closed
+        }
+        if (SelfInflictedClose.isSelfInflictedLeaseClose(event.closeReason)) {
+            ignoreSelfInflicted(binding)
+            return
         }
         val cause = when (event.closeReason) {
             SshLeaseCloseReason.KeepaliveDead -> RuntimeDeathCause.KeepaliveDead
             else -> RuntimeDeathCause.LeaseClosed
         }
-        fireDeath(key, leaseKeyHint = leaseKey, cause = cause)
+        fireDeath(
+            ParkedRuntimeDeathSignal(
+                binding = binding,
+                leaseKey = leaseKey,
+                cause = cause,
+                boundClientIdentity = System.identityHashCode(client),
+                disconnectEvent = null,
+                leaseCloseReason = event.closeReason,
+            ),
+        )
     }
 
-    private fun fireDeath(
-        key: RuntimeHealthKey,
-        leaseKeyHint: SshLeaseKey?,
-        cause: RuntimeDeathCause,
-    ) {
-        // Idempotent: only the FIRST edge per binding wins.
-        if (ledger.isDead(key)) return
-        ledger.reduce(RuntimeHealthEvent.Died(key, cause))
-        // Terminal: stop both collectors for this key (this cancels the job we
-        // are running inside; the non-suspending [onDeath] below still runs).
-        cancelBinding(key)
-        onDeath(key, leaseKeyHint, cause)
+    private fun fireDeath(signal: ParkedRuntimeDeathSignal) {
+        // Idempotent: atomically claim/remove this exact binding before
+        // publishing the verdict. A concurrently resumed sibling collector
+        // then sees no binding and cannot double-dispatch after the ledger is
+        // cleared.
+        val bindingJob = bindings.remove(signal.binding) ?: return
+        bindingJob.cancel()
+        ledger.reduce(RuntimeHealthEvent.Died(signal.binding, signal.cause))
+        onDeath(signal)
+        // The exact corpse has now either been removed or identified as a stale
+        // callback. No logical-key consult remains, so retain no tombstone.
+        ledger.reduce(RuntimeHealthEvent.Cleared(signal.binding))
     }
+
+    private fun ignoreSelfInflicted(binding: RuntimeHealthBinding) {
+        val bindingJob = bindings.remove(binding) ?: return
+        bindingJob.cancel()
+        ledger.reduce(RuntimeHealthEvent.Cleared(binding))
+    }
+
+    private fun TmuxDisconnectEvent.toRuntimeDeathCause(): RuntimeDeathCause =
+        when (reason) {
+            TmuxDisconnectReason.ReaderEof -> RuntimeDeathCause.ReaderEof
+            TmuxDisconnectReason.ReaderException -> RuntimeDeathCause.ReaderException
+            TmuxDisconnectReason.ServerExited -> RuntimeDeathCause.ServerExited
+            TmuxDisconnectReason.CommandTimeout -> RuntimeDeathCause.CommandTimeout
+            TmuxDisconnectReason.Unknown -> RuntimeDeathCause.UnknownControlChannel
+            // These are filtered through SelfInflictedClose above. Keeping the
+            // exhaustive branches compiler-enforced prevents future enum drift.
+            TmuxDisconnectReason.ExplicitClose,
+            TmuxDisconnectReason.ExplicitDetach,
+            -> error("self-inflicted disconnect reached parked death: $reason")
+        }
 }
+
+/**
+ * Fully attributed death of one exact parked runtime. The handler carries this
+ * unchanged into diagnostics and atomic cache removal.
+ */
+internal data class ParkedRuntimeDeathSignal(
+    val binding: RuntimeHealthBinding,
+    val leaseKey: SshLeaseKey?,
+    val cause: RuntimeDeathCause,
+    val boundClientIdentity: Int,
+    val disconnectEvent: TmuxDisconnectEvent?,
+    val leaseCloseReason: SshLeaseCloseReason?,
+)

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1537ExactRuntimeBindingSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1537ExactRuntimeBindingSourceGuardTest.kt
@@ -1,0 +1,79 @@
+package com.pocketshell.app.tmux
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Compile-free structural guard for the #1537 exact-runtime hard cut.
+ *
+ * The behavioral suites prove the race semantics. This guard keeps the two
+ * lifecycle omissions that caused the recurrence from silently returning:
+ * host/session-wide death removal and an untracked prewarm cache insertion.
+ */
+class Issue1537ExactRuntimeBindingSourceGuardTest {
+
+    @Test
+    fun parkedDeathUsesAtomicExactRemovalWithoutSessionWideFallback() {
+        val source = source("app/src/main/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandler.kt")
+        assertTrue(source.contains("runtimeCache.removeExact(signal.binding)"))
+        assertFalse(source.contains("runtimeCache.removeSession("))
+    }
+
+    @Test
+    fun bothActiveParkingAndPrewarmBindTheExactRuntime() {
+        val source = source("app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt")
+        assertTrue(
+            "active-runtime parking must bind its exact generated runtime identity",
+            source.contains("parkedRuntimeHealthEffects.bindParkedRuntime(runtime)"),
+        )
+        assertTrue(
+            "prewarm must use the same exact parked-runtime binding helper",
+            Regex(
+                """prewarmRuntime[\s\S]*parkedRuntimeHealthEffects\.bindParkedRuntime\(runtime\)""",
+            ).containsMatchIn(source),
+        )
+    }
+
+    @Test
+    fun booleanDisconnectedCollectorIsHardCutInFavorOfTypedDisconnectEvent() {
+        val source = source(
+            "app/src/main/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffects.kt",
+        )
+        assertTrue(source.contains("client.disconnectEvent.first"))
+        assertTrue(source.contains("SelfInflictedClose.isSelfInflictedControlChannelClose"))
+        assertFalse(source.contains("client.disconnected.first"))
+    }
+
+    @Test
+    fun connectedG10FixtureCompilesAgainstTheCommonBaseSurface() {
+        val source = source(
+            "app/src/androidTest/java/com/pocketshell/app/proof/" +
+                "MultiSessionSwitchJourneyE2eTest.kt",
+        )
+        assertTrue(source.contains("lateOldRuntimeRemoteDeathCannotEvictHealthySameSessionReplacement"))
+        assertTrue(source.contains("it.hostId == currentHostId"))
+        assertTrue(source.contains("cache.put(generation2)"))
+        assertTrue(source.contains("TmuxClientFactory(replacementScope).create("))
+        assertTrue(source.contains("#{client_pid}"))
+        assertTrue(source.contains("ps -o ppid= -p"))
+        assertTrue(source.contains("shellPid"))
+        assertTrue(source.contains("kill -KILL"))
+        assertFalse(source.contains("RuntimeInstanceToken"))
+        assertFalse(source.contains("removeExact("))
+        assertFalse(source.contains("handleParkedRuntimeDeath("))
+        assertFalse(source.contains("healthBinding ="))
+        assertFalse(source.contains("setParkedRuntimeDeathDeliveryPausedForTest"))
+    }
+
+    private fun source(path: String): String {
+        var cursor = File(System.getProperty("user.dir")).absoluteFile
+        repeat(8) {
+            val candidate = File(cursor, path)
+            if (candidate.isFile) return candidate.readText()
+            cursor = cursor.parentFile ?: return@repeat
+        }
+        error("Cannot locate $path from ${System.getProperty("user.dir")}")
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1537ParkedRuntimeHealthTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1537ParkedRuntimeHealthTest.kt
@@ -11,6 +11,8 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -228,7 +230,13 @@ class Issue1537ParkedRuntimeHealthTest {
         val diagnostics = installRecordingDiagnosticSink()
 
         // The parked alpha client's -CC reader EOFs while parked (the blind spot).
-        alphaClient.disconnectedSignal.value = true
+        alphaClient.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ReaderEof,
+                source = "eof",
+                intent = "unknown",
+            ),
+        )
         advanceUntilIdle()
 
         // The health subscriber marks it dead and evicts the corpse PROACTIVELY —
@@ -239,7 +247,7 @@ class Issue1537ParkedRuntimeHealthTest {
         )
         val deaths = diagnostics.eventsNamed("parked_runtime_death")
         assertEquals("the parked-health subscriber records exactly one death", 1, deaths.size)
-        assertEquals("ClientDisconnected", deaths.single().fields["cause"])
+        assertEquals("ReaderEof", deaths.single().fields["cause"])
         assertEquals(1L, deaths.single().fields["hostId"])
         diagnostics.close()
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandlerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ParkedRuntimeDeathHandlerTest.kt
@@ -1,7 +1,11 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.tmux.connection.ParkedRuntimeDeathSignal
 import com.pocketshell.core.connection.RuntimeDeathCause
+import com.pocketshell.core.connection.RuntimeHealthBinding
 import com.pocketshell.core.connection.RuntimeHealthKey
+import com.pocketshell.core.connection.RuntimeInstanceToken
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLeaseConnector
@@ -10,6 +14,8 @@ import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -64,6 +70,7 @@ class ParkedRuntimeDeathHandlerTest {
 
     // The parked runtime that just died: session "alpha" on host 1.
     private val deadKey = RuntimeHealthKey(hostId = 1L, sessionName = "alpha")
+    private val deadBinding = RuntimeHealthBinding(deadKey, RuntimeInstanceToken.create())
 
     // -------------------------------------------------------------------------
     // Test A — same-host, the FOREGROUND session still holds the shared lease
@@ -73,12 +80,13 @@ class ParkedRuntimeDeathHandlerTest {
     fun sameHostForegroundHoldsKey_forceDisconnectWithheld_sharedLiveTransportSurvives() = runTest {
         val sharedTransport = FakeSession()
         val disconnectedKeys = mutableListOf<SshLeaseKey>()
+        val cache = TmuxSessionRuntimeCache().also {
+            it.put(siblingRuntime("alpha", lease = null, healthBinding = deadBinding))
+        }
 
         handleParkedRuntimeDeath(
-            key = deadKey,
-            leaseKey = leaseKey,
-            cause = RuntimeDeathCause.ClientDisconnected,
-            runtimeCache = TmuxSessionRuntimeCache(),
+            signal = deathSignal(deadBinding, leaseKey, RuntimeDeathCause.ReaderEof),
+            runtimeCache = cache,
             // The FOREGROUND (or connecting) session shares the SAME host/key —
             // this is the always-true condition for a same-host parked runtime.
             foregroundLeaseKeys = setOf(leaseKey),
@@ -121,17 +129,15 @@ class ParkedRuntimeDeathHandlerTest {
         advanceUntilIdle()
 
         val cache = TmuxSessionRuntimeCache()
+        cache.put(siblingRuntime("alpha", lease = null, healthBinding = deadBinding))
         // A DIFFERENT same-host session ("beta") is parked holding the SAME
-        // shared lease. The dying runtime is "alpha" (not cached here) — so
-        // removeSession(1,"alpha") returns nothing and the beta corpse-share
-        // must still WITHHOLD the force-disconnect.
+        // shared lease. Exact removal removes only alpha; beta must still
+        // WITHHOLD the force-disconnect.
         cache.put(siblingRuntime(sessionName = "beta", lease = lease))
 
         val disconnectedKeys = mutableListOf<SshLeaseKey>()
         handleParkedRuntimeDeath(
-            key = deadKey,
-            leaseKey = lease.key,
-            cause = RuntimeDeathCause.ClientDisconnected,
+            signal = deathSignal(deadBinding, lease.key, RuntimeDeathCause.ReaderEof),
             runtimeCache = cache,
             // The foreground does NOT hold it here — the ONLY live holder is the
             // sibling cached runtime, which must still block the disconnect.
@@ -162,12 +168,13 @@ class ParkedRuntimeDeathHandlerTest {
     fun foreignSoleHolder_forceDisconnectFires_corpseTransportKilled() = runTest {
         val corpseTransport = FakeSession()
         val disconnectedKeys = mutableListOf<SshLeaseKey>()
+        val cache = TmuxSessionRuntimeCache().also {
+            it.put(siblingRuntime("alpha", lease = null, healthBinding = deadBinding))
+        }
 
         handleParkedRuntimeDeath(
-            key = deadKey,
-            leaseKey = leaseKey,
-            cause = RuntimeDeathCause.KeepaliveDead,
-            runtimeCache = TmuxSessionRuntimeCache(),
+            signal = deathSignal(deadBinding, leaseKey, RuntimeDeathCause.KeepaliveDead),
+            runtimeCache = cache,
             // No foreground/connecting session shares this key, and no sibling
             // cached runtime holds it -> sole holder -> disconnect must fire.
             foregroundLeaseKeys = emptySet(),
@@ -190,12 +197,67 @@ class ParkedRuntimeDeathHandlerTest {
         )
     }
 
+    @Test
+    fun staleOldRuntimeCallbackCannotRemoveNewSameSessionRuntime() = runTest {
+        val cache = TmuxSessionRuntimeCache()
+        val old = siblingRuntime(sessionName = "alpha", lease = null)
+        val replacement = siblingRuntime(sessionName = "alpha", lease = null)
+        cache.put(old)
+        cache.put(replacement)
+        val diagnostics = installRecordingDiagnosticSink()
+
+        val handled = handleParkedRuntimeDeath(
+            signal = deathSignal(old.healthBinding, leaseKey, RuntimeDeathCause.ReaderException),
+            runtimeCache = cache,
+            foregroundLeaseKeys = emptySet(),
+            disconnectLease = { error("stale callback must not disconnect any lease") },
+            launchContained = { block -> launch { block() } },
+        )
+        advanceUntilIdle()
+
+        assertFalse("a callback for an evicted old runtime is explicitly ignored", handled)
+        assertTrue("the exact replacement runtime must remain cached", cache.containsExact(replacement.healthBinding))
+        assertFalse(cache.containsExact(old.healthBinding))
+        val ignored = diagnostics.eventsNamed("parked_runtime_death_ignored").single()
+        assertEquals("stale_callback", ignored.fields["outcome"])
+        assertEquals(old.healthBinding.token.toString(), ignored.fields["boundRuntimeToken"])
+        assertEquals(1234, ignored.fields["boundClientHash"])
+        diagnostics.close()
+    }
+
+    @Test
+    fun readerExceptionRemovesOnlyItsExactRuntime() = runTest {
+        val cache = TmuxSessionRuntimeCache()
+        val dead = siblingRuntime(sessionName = "alpha", lease = null)
+        val sibling = siblingRuntime(sessionName = "beta", lease = null)
+        cache.put(dead)
+        cache.put(sibling)
+
+        val handled = handleParkedRuntimeDeath(
+            signal = deathSignal(
+                dead.healthBinding,
+                leaseKey = null,
+                cause = RuntimeDeathCause.ReaderException,
+            ),
+            runtimeCache = cache,
+            foregroundLeaseKeys = emptySet(),
+            disconnectLease = { error("no lease key was attributed") },
+            launchContained = { block -> launch { block() } },
+        )
+        advanceUntilIdle()
+
+        assertTrue(handled)
+        assertFalse(cache.containsExact(dead.healthBinding))
+        assertTrue("unrelated exact sibling survives", cache.containsExact(sibling.healthBinding))
+    }
+
     // ------------------------------- fakes -----------------------------------
 
     private fun siblingRuntime(
         sessionName: String,
-        lease: com.pocketshell.core.ssh.SshLease,
+        lease: com.pocketshell.core.ssh.SshLease?,
         hostId: Long = 1L,
+        healthBinding: RuntimeHealthBinding? = null,
     ): CachedTmuxRuntime = CachedTmuxRuntime(
         key = TmuxRuntimeKey(
             hostId = hostId,
@@ -220,7 +282,44 @@ class ParkedRuntimeDeathHandlerTest {
         remoteColumns = 0,
         remoteRows = 0,
         lease = lease,
+        healthBinding = healthBinding ?: RuntimeHealthBinding(
+            RuntimeHealthKey(hostId, sessionName),
+            RuntimeInstanceToken.create(),
+        ),
     )
+
+    private fun deathSignal(
+        binding: RuntimeHealthBinding,
+        leaseKey: SshLeaseKey?,
+        cause: RuntimeDeathCause,
+    ): ParkedRuntimeDeathSignal =
+        ParkedRuntimeDeathSignal(
+            binding = binding,
+            leaseKey = leaseKey,
+            cause = cause,
+            boundClientIdentity = 1234,
+            disconnectEvent = if (
+                cause == RuntimeDeathCause.ReaderEof ||
+                cause == RuntimeDeathCause.ReaderException
+            ) {
+                TmuxDisconnectEvent(
+                    reason = if (cause == RuntimeDeathCause.ReaderEof) {
+                        TmuxDisconnectReason.ReaderEof
+                    } else {
+                        TmuxDisconnectReason.ReaderException
+                    },
+                    source = if (cause == RuntimeDeathCause.ReaderEof) "eof" else "read_failure",
+                    intent = "unknown",
+                )
+            } else {
+                null
+            },
+            leaseCloseReason = if (cause == RuntimeDeathCause.KeepaliveDead) {
+                com.pocketshell.core.ssh.SshLeaseCloseReason.KeepaliveDead
+            } else {
+                null
+            },
+        )
 
     private class FakeSession : SshSession {
         @Volatile

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCacheTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCacheTest.kt
@@ -92,6 +92,21 @@ class TmuxSessionRuntimeCacheTest {
         assertEquals(CacheActivation(runtime = runtime, evicted = emptyList()), cache.activate(runtime.key))
     }
 
+    @Test
+    fun removeExactStaleBindingCannotRemoveSameSessionReplacement() {
+        val cache = TmuxSessionRuntimeCache(maxEntries = 4, nowMs = { 0L })
+        val old = cachedRuntime("work")
+        val replacement = cachedRuntime("work")
+
+        cache.put(old)
+        assertEquals(listOf(old), cache.put(replacement))
+
+        assertEquals(null, cache.removeExact(old.healthBinding))
+        assertTrue(cache.containsExact(replacement.healthBinding))
+        assertFalse(cache.containsExact(old.healthBinding))
+        assertSame(replacement, cache.removeExact(replacement.healthBinding))
+    }
+
     private fun cachedRuntime(
         sessionName: String,
         hostId: Long = 1L,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPrewarmSeedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPrewarmSeedTest.kt
@@ -10,6 +10,8 @@ import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientException
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.TestScope
@@ -112,6 +114,51 @@ class TmuxSessionViewModelPrewarmSeedTest : TmuxSessionViewModelTestBase() {
         assertTrue(runtimeCache.contains(TmuxRuntimeKey(1L, "alpha.example", 22, "alex", "/keys/a", "recent")))
         assertFalse("prewarm seed timeout must not close tmux client", prewarmClient.closed)
         assertFalse("prewarm seed timeout must not mark tmux disconnected", prewarmClient.disconnected.value)
+    }
+
+    @Test
+    fun prewarmedRuntimeReaderEofIsBoundAndEvictedBeforeActivation() = runTest(scheduler) {
+        val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 4)
+        val vm = newVm(
+            runtimeCache = runtimeCache,
+            sshLeaseManager = testLeaseManager(
+                connector = QueueLeaseConnector(FakeSshSession()),
+                scope = this,
+                idleTtlMillis = 0L,
+            ),
+        )
+        val prewarmClient = FakeTmuxClient().withSinglePane("recent", "%4")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> prewarmClient }
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            session = FakeSshSession(),
+        )
+        val key = TmuxRuntimeKey(1L, "alpha.example", 22, "alex", "/keys/a", "recent")
+
+        vm.prewarmLikelySwitchTargets(listOf("recent"))
+        advanceUntilIdle()
+        assertTrue(runtimeCache.contains(key))
+
+        prewarmClient.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ReaderEof,
+                source = "eof",
+                intent = "unknown",
+            ),
+        )
+        advanceUntilIdle()
+
+        assertFalse(
+            "prewarm must use the same parked-health binding as switch-away parking",
+            runtimeCache.contains(key),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ParkedRuntimeHealthEffectsTest.kt
@@ -2,12 +2,16 @@ package com.pocketshell.app.tmux.connection
 
 import com.pocketshell.app.tmux.FakeTmuxClient
 import com.pocketshell.core.connection.RuntimeDeathCause
+import com.pocketshell.core.connection.RuntimeHealthBinding
 import com.pocketshell.core.connection.RuntimeHealthKey
 import com.pocketshell.core.connection.RuntimeHealthLedger
+import com.pocketshell.core.connection.RuntimeInstanceToken
 import com.pocketshell.core.ssh.SshLeaseCloseReason
 import com.pocketshell.core.ssh.SshLeaseConnectionState
 import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseStateEvent
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -28,6 +32,7 @@ import org.junit.Test
 class ParkedRuntimeHealthEffectsTest {
 
     private val key = RuntimeHealthKey(hostId = 7L, sessionName = "beta")
+    private val binding = RuntimeHealthBinding(key, RuntimeInstanceToken.create())
     private val leaseKey = SshLeaseKey(
         host = "beta.example",
         port = 22,
@@ -36,9 +41,10 @@ class ParkedRuntimeHealthEffectsTest {
     )
 
     private class DeathCapture {
-        val calls = mutableListOf<Triple<RuntimeHealthKey, SshLeaseKey?, RuntimeDeathCause>>()
-        fun record(k: RuntimeHealthKey, lk: SshLeaseKey?, c: RuntimeDeathCause) {
-            calls += Triple(k, lk, c)
+        val calls = mutableListOf<ParkedRuntimeDeathSignal>()
+        fun record(signal: ParkedRuntimeDeathSignal): Boolean {
+            calls += signal
+            return true
         }
     }
 
@@ -55,19 +61,23 @@ class ParkedRuntimeHealthEffectsTest {
         )
         val client = FakeTmuxClient()
 
-        effects.bindParked(key, client, leaseKey)
+        effects.bindParked(binding, client, leaseKey)
         advanceUntilIdle()
-        assertTrue("bind tracks the parked runtime as healthy", ledger.isHealthy(key))
+        assertTrue("bind tracks the exact parked runtime as healthy", ledger.isHealthy(binding))
         assertTrue(capture.calls.isEmpty())
 
         // The parked -CC reader EOFs while parked.
-        client.disconnectedSignal.value = true
+        client.markDisconnectedForTest(remoteDisconnect(TmuxDisconnectReason.ReaderEof))
         advanceUntilIdle()
 
-        assertTrue("client-disconnect edge marks the parked runtime Dead", ledger.isDead(key))
-        assertEquals(RuntimeDeathCause.ClientDisconnected, ledger.deadCause(key))
+        assertNull("handled exact death leaves no stale ledger tombstone", ledger.health(binding))
         assertEquals("eviction callback fires exactly once", 1, capture.calls.size)
-        assertEquals(key, capture.calls.single().first)
+        assertEquals(binding, capture.calls.single().binding)
+        assertEquals(RuntimeDeathCause.ReaderEof, capture.calls.single().cause)
+        assertEquals(
+            TmuxDisconnectReason.ReaderEof,
+            capture.calls.single().disconnectEvent?.reason,
+        )
 
         // A second edge (a late lease Closed) must NOT double-fire.
         leaseEvents.emit(
@@ -84,7 +94,7 @@ class ParkedRuntimeHealthEffectsTest {
         val capture = DeathCapture()
         val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
 
-        effects.bindParked(key, FakeTmuxClient(), leaseKey)
+        effects.bindParked(binding, FakeTmuxClient(), leaseKey)
         advanceUntilIdle()
 
         leaseEvents.emit(
@@ -92,10 +102,10 @@ class ParkedRuntimeHealthEffectsTest {
         )
         advanceUntilIdle()
 
-        assertTrue(ledger.isDead(key))
-        assertEquals(RuntimeDeathCause.KeepaliveDead, ledger.deadCause(key))
+        assertNull(ledger.health(binding))
         assertEquals(1, capture.calls.size)
-        assertEquals(leaseKey, capture.calls.single().second)
+        assertEquals(RuntimeDeathCause.KeepaliveDead, capture.calls.single().cause)
+        assertEquals(leaseKey, capture.calls.single().leaseKey)
     }
 
     @Test
@@ -104,14 +114,14 @@ class ParkedRuntimeHealthEffectsTest {
         val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
         val capture = DeathCapture()
         val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
-        effects.bindParked(key, FakeTmuxClient(), leaseKey)
+        effects.bindParked(binding, FakeTmuxClient(), leaseKey)
         advanceUntilIdle()
 
         val otherKey = SshLeaseKey("other.example", 22, "alex", "9:/keys/b")
         leaseEvents.emit(SshLeaseStateEvent(otherKey, SshLeaseConnectionState.Closed))
         advanceUntilIdle()
 
-        assertTrue("a foreign key's Closed edge must not kill this parked runtime", ledger.isHealthy(key))
+        assertTrue("a foreign key's Closed edge must not kill this parked runtime", ledger.isHealthy(binding))
         assertTrue(capture.calls.isEmpty())
 
         // A bound-but-unfired runtime is an active binding until VM teardown.
@@ -125,40 +135,37 @@ class ParkedRuntimeHealthEffectsTest {
         val capture = DeathCapture()
         val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
         val client = FakeTmuxClient()
-        effects.bindParked(key, client, leaseKey)
+        effects.bindParked(binding, client, leaseKey)
         advanceUntilIdle()
 
-        effects.onActivated(key)
+        effects.onActivated(binding)
         advanceUntilIdle()
-        assertNull("activation drops the ledger entry", ledger.health(key))
+        assertNull("activation drops the exact ledger entry", ledger.health(binding))
 
         // A death edge AFTER unbind must not fire (the collector is cancelled).
-        client.disconnectedSignal.value = true
+        client.markDisconnectedForTest(remoteDisconnect(TmuxDisconnectReason.ReaderEof))
         advanceUntilIdle()
         assertTrue("no death after activation unbind", capture.calls.isEmpty())
-        assertFalse(ledger.isDead(key))
+        assertFalse(ledger.isDead(binding))
     }
 
     @Test
-    fun evictedPreservesAStickyDeadMarkerForSwitchBack() = runTest {
+    fun handledDeathTerminatesExactLedgerEntry() = runTest {
         val ledger = RuntimeHealthLedger()
         val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
         val capture = DeathCapture()
         val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
         val client = FakeTmuxClient()
-        effects.bindParked(key, client, leaseKey)
+        effects.bindParked(binding, client, leaseKey)
         advanceUntilIdle()
 
-        client.disconnectedSignal.value = true
+        client.markDisconnectedForTest(remoteDisconnect(TmuxDisconnectReason.ReaderException))
         advanceUntilIdle()
-        assertTrue(ledger.isDead(key))
-
-        // A plain evict of the corpse must not wipe the Dead marker — the
-        // switch-back still needs to consult it.
-        effects.onEvicted(key)
+        assertNull(ledger.health(binding))
+        effects.onEvicted(binding)
         advanceUntilIdle()
-        assertEquals(RuntimeDeathCause.ClientDisconnected, effects.consumeParkedDeath(key))
-        assertNull("one-shot consult clears it", ledger.consumeDead(key))
+        assertNull("exact eviction stays idempotent after death handling", ledger.health(binding))
+        assertEquals(RuntimeDeathCause.ReaderException, capture.calls.single().cause)
     }
 
     @Test
@@ -169,14 +176,93 @@ class ParkedRuntimeHealthEffectsTest {
         val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
         val client = FakeTmuxClient()
         // The client already EOFed before we bound it (raced park/death).
-        client.disconnectedSignal.value = true
+        client.markDisconnectedForTest(remoteDisconnect(TmuxDisconnectReason.ReaderEof))
 
-        effects.bindParked(key, client, leaseKey)
+        effects.bindParked(binding, client, leaseKey)
         advanceUntilIdle()
 
-        assertTrue("an already-dead parked client fires on bind", ledger.isDead(key))
+        assertNull("already-dead runtime is handled without a tombstone", ledger.health(binding))
         assertEquals(1, capture.calls.size)
 
         effects.cancelAll()
     }
+
+    @Test
+    fun alreadyClosedExplicitCloseAtParkIsIgnoredNotReportedAsRuntimeDeath() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+        val client = FakeTmuxClient()
+        client.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ExplicitClose,
+                source = "local",
+                intent = "local_close",
+            ),
+        )
+
+        effects.bindParked(binding, client, leaseKey)
+        advanceUntilIdle()
+
+        assertTrue("local teardown must not be reported as parked-runtime death", capture.calls.isEmpty())
+        assertNull("the self-inflicted exact binding is untracked", ledger.health(binding))
+    }
+
+    @Test
+    fun staleOldCallbackCannotClearOrKillReplacementBindingForSameSession() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+        val old = binding
+        val replacement = RuntimeHealthBinding(key, RuntimeInstanceToken.create())
+        val oldClient = FakeTmuxClient()
+        val replacementClient = FakeTmuxClient()
+
+        effects.bindParked(old, oldClient, leaseKey)
+        effects.onEvicted(old)
+        effects.bindParked(replacement, replacementClient, leaseKey)
+        advanceUntilIdle()
+
+        oldClient.markDisconnectedForTest(remoteDisconnect(TmuxDisconnectReason.ReaderEof))
+        advanceUntilIdle()
+
+        assertTrue("replacement with same host/session stays healthy", ledger.isHealthy(replacement))
+        assertTrue("cancelled stale binding cannot dispatch death", capture.calls.isEmpty())
+
+        // The healthy replacement remains intentionally bound after the stale
+        // edge; model VM teardown so runTest does not inherit its live watcher.
+        effects.cancelAll()
+    }
+
+    @Test
+    fun explicitDisconnectLeaseEdgeIsIgnoredNotReportedAsRuntimeDeath() = runTest {
+        val ledger = RuntimeHealthLedger()
+        val leaseEvents = MutableSharedFlow<SshLeaseStateEvent>(extraBufferCapacity = 16)
+        val capture = DeathCapture()
+        val effects = ParkedRuntimeHealthEffects(this, ledger, leaseEvents, capture::record)
+        effects.bindParked(binding, FakeTmuxClient(), leaseKey)
+        advanceUntilIdle()
+
+        leaseEvents.emit(
+            SshLeaseStateEvent(
+                leaseKey,
+                SshLeaseConnectionState.Closed,
+                SshLeaseCloseReason.ExplicitDisconnect,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertTrue(capture.calls.isEmpty())
+        assertNull(ledger.health(binding))
+    }
+
+    private fun remoteDisconnect(reason: TmuxDisconnectReason): TmuxDisconnectEvent =
+        TmuxDisconnectEvent(
+            reason = reason,
+            source = if (reason == TmuxDisconnectReason.ReaderException) "read_failure" else "eof",
+            intent = "unknown",
+            exceptionClass = if (reason == TmuxDisconnectReason.ReaderException) "IOException" else null,
+        )
 }

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RuntimeHealthLedger.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RuntimeHealthLedger.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.core.connection
 
+import java.util.concurrent.atomic.AtomicLong
+
 /**
  * Issue #1537 (option b): the parked-runtime health ledger.
  *
@@ -21,20 +23,21 @@ package com.pocketshell.core.connection
  *
  * ## Shape
  *
- * A pure, single-authority reducer mapping [RuntimeHealthKey] to
+ * A pure, single-authority reducer mapping an exact [RuntimeHealthBinding] to
  * [RuntimeHealth]. It holds NO IO, NO coroutines, NO android imports and NO
  * time — the app-side `ParkedRuntimeHealthEffects` owns the edge subscriptions
  * and feeds this reducer [RuntimeHealthEvent]s, then the switch path consults
  * it. It is confined to the ViewModel's single main dispatcher (same discipline
  * as [ConnectionController]); it is deliberately not internally synchronised.
  *
- * A [RuntimeHealthEvent.Died] verdict is **sticky** — it survives a plain
- * [RuntimeHealthEvent.Cleared] eviction so an imminent switch-back can still
- * consult it — and is cleared only by re-parking the key ([RuntimeHealthEvent.Parked])
- * or by the one-shot [consumeDead].
+ * The opaque [RuntimeInstanceToken] is load-bearing: host + session is only a
+ * logical address and can be reused immediately by a replacement runtime. An
+ * old client's late EOF must never overwrite, clear, or evict the replacement.
+ * Every event therefore carries the exact binding allocated with that runtime;
+ * there is no host/session-only mutation fallback.
  */
 public class RuntimeHealthLedger {
-    private val states = linkedMapOf<RuntimeHealthKey, RuntimeHealth>()
+    private val states = linkedMapOf<RuntimeHealthBinding, RuntimeHealth>()
 
     /**
      * Apply one [event] and return the resulting [RuntimeHealth] for its key
@@ -42,45 +45,43 @@ public class RuntimeHealthLedger {
      */
     public fun reduce(event: RuntimeHealthEvent): RuntimeHealth? = when (event) {
         is RuntimeHealthEvent.Parked -> {
-            // A fresh park always resets to Healthy — even over a stale Dead
-            // marker from a previous life of the same session.
-            states[event.key] = RuntimeHealth.Healthy
+            states[event.binding] = RuntimeHealth.Healthy
             RuntimeHealth.Healthy
         }
         is RuntimeHealthEvent.Died -> {
             val dead = RuntimeHealth.Dead(event.cause)
-            states[event.key] = dead
+            states[event.binding] = dead
             dead
         }
         is RuntimeHealthEvent.Cleared -> {
-            states.remove(event.key)
+            states.remove(event.binding)
             null
         }
     }
 
-    public fun health(key: RuntimeHealthKey): RuntimeHealth? = states[key]
+    public fun health(binding: RuntimeHealthBinding): RuntimeHealth? = states[binding]
 
-    public fun isHealthy(key: RuntimeHealthKey): Boolean = states[key] is RuntimeHealth.Healthy
+    public fun isHealthy(binding: RuntimeHealthBinding): Boolean =
+        states[binding] is RuntimeHealth.Healthy
 
-    public fun isDead(key: RuntimeHealthKey): Boolean = states[key] is RuntimeHealth.Dead
+    public fun isDead(binding: RuntimeHealthBinding): Boolean =
+        states[binding] is RuntimeHealth.Dead
 
-    public fun deadCause(key: RuntimeHealthKey): RuntimeDeathCause? =
-        (states[key] as? RuntimeHealth.Dead)?.cause
+    public fun deadCause(binding: RuntimeHealthBinding): RuntimeDeathCause? =
+        (states[binding] as? RuntimeHealth.Dead)?.cause
 
     /**
-     * One-shot consult: if [key] is currently [RuntimeHealth.Dead], remove the
-     * marker and return its cause; otherwise return `null`. The switch path
-     * uses this to decide, exactly once, that a parked runtime was known-dead
-     * before the switch-back attach so it can present the calm hold instead of
-     * discovering the death as an attach EOF.
+     * One-shot exact-binding consult retained for reducer consumers and tests.
+     * App-side death handling normally clears the binding after its synchronous
+     * exact compare-and-remove callback.
      */
-    public fun consumeDead(key: RuntimeHealthKey): RuntimeDeathCause? {
-        val dead = states[key] as? RuntimeHealth.Dead ?: return null
-        states.remove(key)
+    public fun consumeDead(binding: RuntimeHealthBinding): RuntimeDeathCause? {
+        val dead = states[binding] as? RuntimeHealth.Dead ?: return null
+        states.remove(binding)
         return dead.cause
     }
 
-    public fun trackedKeys(): Set<RuntimeHealthKey> = states.keys.toSet()
+    public fun trackedBindings(): Set<RuntimeHealthBinding> = states.keys.toSet()
 
     public fun size(): Int = states.size
 }
@@ -93,6 +94,37 @@ public class RuntimeHealthLedger {
 public data class RuntimeHealthKey(
     val hostId: Long,
     val sessionName: String,
+)
+
+/**
+ * Opaque identity of one concrete cached-runtime lifetime.
+ *
+ * It deliberately exposes equality and a diagnostic string only — callers
+ * cannot derive it from host/session or choose a generation. This makes every
+ * ledger/binding/cache mutation prove it owns the exact runtime instance.
+ */
+public class RuntimeInstanceToken private constructor(
+    private val sequence: Long,
+) {
+    override fun equals(other: Any?): Boolean =
+        other is RuntimeInstanceToken && sequence == other.sequence
+
+    override fun hashCode(): Int = sequence.hashCode()
+
+    override fun toString(): String = sequence.toString()
+
+    public companion object {
+        private val nextSequence = AtomicLong(0L)
+
+        public fun create(): RuntimeInstanceToken =
+            RuntimeInstanceToken(nextSequence.incrementAndGet())
+    }
+}
+
+/** Exact health ownership: logical session address plus one opaque runtime life. */
+public data class RuntimeHealthBinding(
+    val key: RuntimeHealthKey,
+    val token: RuntimeInstanceToken,
 )
 
 public sealed interface RuntimeHealth {
@@ -108,11 +140,21 @@ public sealed interface RuntimeHealth {
  */
 public enum class RuntimeDeathCause {
     /**
-     * The parked client's own `-CC` reader latched `disconnected` — covers the
-     * control channel EOF AND tmux-server death (the login-scope teardown
-     * class), instantly and with zero new traffic.
+     * The parked client's typed disconnect event reports a reader EOF.
      */
-    ClientDisconnected,
+    ReaderEof,
+
+    /** The parked control-channel reader failed with an exception. */
+    ReaderException,
+
+    /** The remote tmux server announced its own exit in-band. */
+    ServerExited,
+
+    /** A fatal tmux command timeout closed the parked control channel. */
+    CommandTimeout,
+
+    /** A typed control-channel close whose reason remains unattributable. */
+    UnknownControlChannel,
 
     /**
      * The pool declared the parked lease's transport dead via the always-on
@@ -134,14 +176,16 @@ public enum class RuntimeDeathCause {
 }
 
 public sealed interface RuntimeHealthEvent {
-    public val key: RuntimeHealthKey
+    public val binding: RuntimeHealthBinding
 
     /** A runtime was parked into the cache; begin tracking it as Healthy. */
-    public data class Parked(override val key: RuntimeHealthKey) : RuntimeHealthEvent
+    public data class Parked(
+        override val binding: RuntimeHealthBinding,
+    ) : RuntimeHealthEvent
 
     /** A liveness edge declared the parked runtime dead. */
     public data class Died(
-        override val key: RuntimeHealthKey,
+        override val binding: RuntimeHealthBinding,
         val cause: RuntimeDeathCause,
     ) : RuntimeHealthEvent
 
@@ -150,5 +194,7 @@ public sealed interface RuntimeHealthEvent {
      * overflowed, or explicitly evicted); stop tracking it. A sticky [Died]
      * marker is preserved by the effects layer rather than sending this.
      */
-    public data class Cleared(override val key: RuntimeHealthKey) : RuntimeHealthEvent
+    public data class Cleared(
+        override val binding: RuntimeHealthBinding,
+    ) : RuntimeHealthEvent
 }

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/RuntimeHealthLedgerTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/RuntimeHealthLedgerTest.kt
@@ -14,87 +14,115 @@ class RuntimeHealthLedgerTest {
 
     private val a = RuntimeHealthKey(hostId = 1L, sessionName = "alpha")
     private val b = RuntimeHealthKey(hostId = 1L, sessionName = "beta")
+    private val aFirst = RuntimeHealthBinding(a, RuntimeInstanceToken.create())
+    private val aReplacement = RuntimeHealthBinding(a, RuntimeInstanceToken.create())
+    private val bFirst = RuntimeHealthBinding(b, RuntimeInstanceToken.create())
 
     @Test
     fun parkedIsTrackedAsHealthy() {
         val ledger = RuntimeHealthLedger()
-        assertNull("untracked key has no health", ledger.health(a))
+        assertNull("untracked binding has no health", ledger.health(aFirst))
 
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        assertTrue(ledger.isHealthy(a))
-        assertFalse(ledger.isDead(a))
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        assertTrue(ledger.isHealthy(aFirst))
+        assertFalse(ledger.isDead(aFirst))
         assertEquals(1, ledger.size())
     }
 
     @Test
     fun diedMarksDeadWithCause() {
         val ledger = RuntimeHealthLedger()
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        ledger.reduce(RuntimeHealthEvent.Died(a, RuntimeDeathCause.KeepaliveDead))
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Died(aFirst, RuntimeDeathCause.KeepaliveDead))
 
-        assertTrue(ledger.isDead(a))
-        assertFalse(ledger.isHealthy(a))
-        assertEquals(RuntimeDeathCause.KeepaliveDead, ledger.deadCause(a))
+        assertTrue(ledger.isDead(aFirst))
+        assertFalse(ledger.isHealthy(aFirst))
+        assertEquals(RuntimeDeathCause.KeepaliveDead, ledger.deadCause(aFirst))
     }
 
     @Test
     fun clearedRemovesAHealthyKey() {
         val ledger = RuntimeHealthLedger()
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        ledger.reduce(RuntimeHealthEvent.Cleared(a))
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Cleared(aFirst))
 
-        assertNull(ledger.health(a))
+        assertNull(ledger.health(aFirst))
         assertEquals(0, ledger.size())
     }
 
     @Test
-    fun deadMarkerSurvivesClearedSoSwitchBackCanConsult() {
-        // The effects layer does NOT send Cleared for a Dead entry — it keeps
-        // the sticky marker for the imminent switch-back. Model that policy:
-        // even if a Cleared were sent, re-marking Dead restores it. The key
-        // property is that consumeDead is the one-shot the switch path uses.
+    fun deadVerdictCanBeConsumedOnlyForItsExactBinding() {
         val ledger = RuntimeHealthLedger()
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        ledger.reduce(RuntimeHealthEvent.Died(a, RuntimeDeathCause.ClientDisconnected))
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Died(aFirst, RuntimeDeathCause.ReaderEof))
 
         // First consult returns the cause and clears the marker.
-        assertEquals(RuntimeDeathCause.ClientDisconnected, ledger.consumeDead(a))
+        assertEquals(RuntimeDeathCause.ReaderEof, ledger.consumeDead(aFirst))
         // Second consult sees nothing — it is one-shot, no leak.
-        assertNull(ledger.consumeDead(a))
-        assertNull(ledger.health(a))
+        assertNull(ledger.consumeDead(aFirst))
+        assertNull(ledger.health(aFirst))
     }
 
     @Test
     fun consumeDeadIsNullForHealthyOrUntracked() {
         val ledger = RuntimeHealthLedger()
-        assertNull("untracked", ledger.consumeDead(a))
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        assertNull("healthy is not consumable", ledger.consumeDead(a))
-        assertTrue("healthy key still tracked after a no-op consult", ledger.isHealthy(a))
+        assertNull("untracked", ledger.consumeDead(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        assertNull("healthy is not consumable", ledger.consumeDead(aFirst))
+        assertTrue("healthy binding still tracked after a no-op consult", ledger.isHealthy(aFirst))
     }
 
     @Test
     fun reParkResetsAStaleDeadMarker() {
         val ledger = RuntimeHealthLedger()
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        ledger.reduce(RuntimeHealthEvent.Died(a, RuntimeDeathCause.AttachEof))
-        assertTrue(ledger.isDead(a))
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Died(aFirst, RuntimeDeathCause.AttachEof))
+        assertTrue(ledger.isDead(aFirst))
 
-        // A fresh park of the same session (a new live runtime) resets to healthy.
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        assertTrue(ledger.isHealthy(a))
-        assertNull(ledger.consumeDead(a))
+        // A fresh park of the exact same runtime resets that binding to healthy.
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        assertTrue(ledger.isHealthy(aFirst))
+        assertNull(ledger.consumeDead(aFirst))
     }
 
     @Test
     fun keysAreIndependent() {
         val ledger = RuntimeHealthLedger()
-        ledger.reduce(RuntimeHealthEvent.Parked(a))
-        ledger.reduce(RuntimeHealthEvent.Parked(b))
-        ledger.reduce(RuntimeHealthEvent.Died(b, RuntimeDeathCause.LeaseClosed))
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Parked(bFirst))
+        ledger.reduce(RuntimeHealthEvent.Died(bFirst, RuntimeDeathCause.LeaseClosed))
 
-        assertTrue("a stays healthy while b dies", ledger.isHealthy(a))
-        assertTrue(ledger.isDead(b))
-        assertEquals(setOf(a, b), ledger.trackedKeys())
+        assertTrue("a stays healthy while b dies", ledger.isHealthy(aFirst))
+        assertTrue(ledger.isDead(bFirst))
+        assertEquals(setOf(aFirst, bFirst), ledger.trackedBindings())
+    }
+
+    @Test
+    fun staleOldRuntimeDeathCannotOverwriteReplacementWithSameLogicalKey() {
+        val ledger = RuntimeHealthLedger()
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Parked(aReplacement))
+
+        ledger.reduce(RuntimeHealthEvent.Died(aFirst, RuntimeDeathCause.ReaderException))
+
+        assertTrue("the stale old runtime may retain only its own verdict", ledger.isDead(aFirst))
+        assertTrue(
+            "the exact replacement binding must remain healthy despite the same host/session key",
+            ledger.isHealthy(aReplacement),
+        )
+        assertEquals(2, ledger.size())
+    }
+
+    @Test
+    fun staleOldRuntimeClearCannotUnbindReplacementWithSameLogicalKey() {
+        val ledger = RuntimeHealthLedger()
+        ledger.reduce(RuntimeHealthEvent.Parked(aFirst))
+        ledger.reduce(RuntimeHealthEvent.Parked(aReplacement))
+
+        ledger.reduce(RuntimeHealthEvent.Cleared(aFirst))
+
+        assertNull(ledger.health(aFirst))
+        assertTrue(ledger.isHealthy(aReplacement))
+        assertEquals(setOf(aReplacement), ledger.trackedBindings())
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1537 by binding parked-runtime health and death callbacks to one exact
cached-runtime lifetime rather than only host/session.

A delayed EOF from an old A runtime can no longer remove, release, or
disconnect a newer A replacement that reused the same logical key.

Base: `3e8474d05268040b1c9c6881427e2765fe8caf65`  
Candidate: `c093eb616c092247377125153f85053287adeee4`  
Final connected-fixture SHA-256: `104fcd584817254dc7c2c57221d86f276551cf26d8689641c2a6537f49a59cb6`

## Architecture

- Adds opaque runtime-instance ownership to parked-health bindings.
- Carries the exact binding through the ledger, parked-health effects, typed
  death signal, and synchronized cache compare-and-remove.
- Uses typed tmux disconnect attribution.
- Filters self-inflicted control/lease closes.
- Binds normal parking and prewarm through one contract.
- Preserves shared-transport protection.
- Records stale callbacks without touching the replacement.

This preserves D28's single-controller option. Per D22, the Boolean/logical
path is deleted. There is no logical-key fallback, debounce, compatibility
shim, or second controller.

## Reproduce-first proof

Untouched base, after a real old control-channel `ReaderEof`:

```text
ignored=[]
parked_runtime_death:
  cause=ClientDisconnected
  session=issue638-session-a
  evictedRuntimes=1
```

Candidate:

```text
parked_runtime_death_ignored:
  outcome=stale_callback
  cause=ReaderEof
parked_runtime_death=[]
replacement_cached_and_input_round_trip=true
SSH handshakes=0
reconnect-trigger connects=0
```

## Verification

- Focused #1537 JVM suites: 44/44.
- Exact-runtime source guard: 4/4.
- Nine independent mutation families: all killed the applicable assertions;
  sources byte-restored.
- Canonical full JVM: 603/603 tasks, 1,201 suites / 11,436 tests, zero
  failures/errors/skips.
- Reviewer-owned exact base RED and candidate 1/1 GREEN.
- Full `MultiSessionSwitchJourneyE2eTest`: 6/6.
- Opt-in `StaleLeaseSwitchRecoveryE2eTest`: 1/1 after clean Toxiproxy setup.
- Full `BackgroundGraceReconnectE2eTest`: 3/3.
- Connection VM ratchet, file-size hygiene, test-validity, and
  `git diff --check`: PASS.

Independent reviewer verdict: **APPROVED**.

## Risks

This touches lifecycle ownership across parking, prewarm, activation, eviction,
expiry, and teardown. Exact-binding tests, mutation coverage, real Docker/tmux
RED→GREEN, shared-transport adjacency, and the complete JVM graph cover those
seams.

No dependency, database, background-work, or UI changes.

Closes #1537
