### PR TITLE
test(tmux): use stable popup oracle for edge taps

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionScreenImeChromeTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionScreenImeChromeTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -284,12 +285,11 @@ class TmuxSessionScreenImeChromeTest {
             }
         compose.waitForIdle()
 
-        // #782 hard-cut the "In this session" window group; the kebab menu now
-        // opens to the "On this host" section (matching the sibling
-        // compactChromeRightEdgeTapOpensMoreMenu assertion below, which #782
-        // updated — this one was missed and had been asserting a section header
-        // that no longer renders).
-        compose.onNodeWithText("On this host").assertIsDisplayed()
+        // Issue #1749: prove the edge tap opened the production popup through a
+        // stable popup-only semantic node. Section copy/order belongs to
+        // TmuxMoreMenuGroupingTest and must not make this reachability proof
+        // stale again.
+        assertPopupOnlyMenuOracleDisplayedAndContained()
     }
 
     @Test
@@ -308,7 +308,7 @@ class TmuxSessionScreenImeChromeTest {
             }
         compose.waitForIdle()
 
-        compose.onNodeWithText("On this host").assertIsDisplayed()
+        assertPopupOnlyMenuOracleDisplayedAndContained()
     }
 
     @Test
@@ -459,7 +459,27 @@ class TmuxSessionScreenImeChromeTest {
         }
     }
 
+    private fun assertPopupOnlyMenuOracleDisplayedAndContained() {
+        val interaction =
+            compose.onNodeWithTag(TMUX_CHANGE_KIND_BUTTON_TAG, useUnmergedTree = true)
+        interaction.assertIsDisplayed()
+        val node = interaction.fetchSemanticsNode()
+        val owningRoot = compose.onAllNodes(isRoot()).fetchSemanticsNodes()
+            .single { it.root === node.root }
+        val bounds = node.boundsInRoot
+        val rootBounds = owningRoot.boundsInRoot
+        assertTrue(
+            "Popup-only Change-kind action must be fully contained in its owning " +
+                "production menu root. node=$bounds root=$rootBounds",
+            bounds.left >= rootBounds.left - ROOT_SLOP_PX &&
+                bounds.top >= rootBounds.top - ROOT_SLOP_PX &&
+                bounds.right <= rootBounds.right + ROOT_SLOP_PX &&
+                bounds.bottom <= rootBounds.bottom + ROOT_SLOP_PX,
+        )
+    }
+
     private companion object {
+        const val ROOT_SLOP_PX = 1f
         const val TERMINAL_PROXY_TAG = "tmux:ime-chrome-test:terminal"
         const val BOTTOM_CHROME_PROXY_TAG = "tmux:ime-chrome-test:bottom-chrome"
     }


### PR DESCRIPTION
Closes #1749

## Outcome

Replaces the stale `On this host` copy oracle in both compact/full right-edge chrome tap tests with the popup-only `TMUX_CHANGE_KIND_BUTTON_TAG` semantic oracle, including owning-root containment. This keeps the tests focused on whether the production menu opened instead of its mutable section copy.

## Reproduce-first and mutation evidence

- Untouched base whole class: 10 tests, exactly 2 intended failures at the obsolete copy assertions, 0 errors/skips.
- Candidate whole class: 10/10 green.
- Compact `onMore={}` no-op mutation: exact compact method red; byte-exact restore green.
- Full `onMore={}` no-op mutation: exact full method red; byte-exact restore green.
- Paired exact methods: three fresh repetitions, each 2/2 green.
- Revised source SHA-256: `d529de8e387f466c6cb86d5576954f771142daa41c910f68d5827f7001d722e8`.
- Preserved evidence: `/home/alexey/pocketshell-preservation/issue-1749-dynamic/`; 112-file manifest SHA-256 `9cb702548b23d03f1156452b055fa58b82ee15833215fd55e97b32ef0441a7ba`.

The first source-approved candidate exposed a real forced-compile miss (`androidx.compose.ui.test.onAllNodes` unsupported here). The redundant import was removed, compile rerun green, and the revised source/hash received independent APPROVED review.

## Current-main verification

Applied the exact reviewed patch to `a2036be6` (intervening #1537 files are disjoint):

- `:app:compileDebugAndroidTestKotlin --no-daemon --rerun-tasks`: 176/176 tasks, green.
- `scripts/full-jvm-gate.sh` with no args: 603/603 tasks, green in 14m26s.
- `scripts/check-test-validity.sh`: green.
- `scripts/check-ci-journey-harness.sh`: green.
- `git diff --check`: green.
- Independent reviewer: `APPROVED`.

Post-merge Nightly three-shard validation remains the issue's scheduled batched backstop.
