### PR TITLE
Fix terminal resizing under IME

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentQuickReplyBandContainmentProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentQuickReplyBandContainmentProofTest.kt
@@ -248,18 +248,21 @@ class AgentQuickReplyBandContainmentProofTest {
                     replies = sampleReplies,
                     onReply = {},
                 )
-                TmuxTerminalBottomControls(
-                    isImeVisible = isImeVisible,
-                    showConversation = false,
-                    sessionLive = true,
-                    isAgentPane = false,
-                    onChipTap = {},
-                    onDictateTap = {},
-                    onEnterTap = {},
-                    onShowKeyboardTap = {},
-                    onAddSnippetTap = {},
-                    onShowHotkeysTap = {},
-                )
+                if (isImeVisible) {
+                    TmuxTerminalImeHotkeysLauncher(onShowHotkeysTap = {})
+                } else {
+                    TmuxTerminalBottomControls(
+                        showConversation = false,
+                        sessionLive = true,
+                        isAgentPane = false,
+                        onChipTap = {},
+                        onDictateTap = {},
+                        onEnterTap = {},
+                        onShowKeyboardTap = {},
+                        onAddSnippetTap = {},
+                        onShowHotkeysTap = {},
+                    )
+                }
             }
         }
     }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ComposerUnsentBadgeContainmentProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ComposerUnsentBadgeContainmentProofTest.kt
@@ -99,7 +99,6 @@ class ComposerUnsentBadgeContainmentProofTest {
                             .testTag(BAND_TAG),
                     ) {
                         TmuxTerminalBottomControls(
-                            isImeVisible = false,
                             showConversation = showConversation,
                             sessionLive = true,
                             isAgentPane = false,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
@@ -1,10 +1,14 @@
 package com.pocketshell.app.tmux
 
 import android.graphics.Bitmap
+import android.content.Context
 import android.os.SystemClock
+import android.os.ParcelFileDescriptor
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -12,6 +16,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -137,6 +142,12 @@ class Issue887TerminalFixedUnderImeE2eTest {
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+        // Issue #1748: the #810 launcher is present even while #1672 holds the
+        // command band during Connecting / Attaching / Reattaching /
+        // Reconnecting. The Show-keyboard chip is the real Live-band oracle.
+        // Do not measure keyboard-down geometry until that production state
+        // transition has completed and the user-facing chip is reachable.
+        waitForLiveKeyboardChip()
         compose.waitForIdle()
         // Let the terminal grid + bottom band fully settle before measuring.
         SystemClock.sleep(500)
@@ -144,7 +155,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
         // ---------------------------------------------------------------
         // Keyboard DOWN: capture the live TerminalView's on-screen rect.
         // ---------------------------------------------------------------
-        val termDown = terminalViewRect()
+        val termDown = terminalViewSnapshot()
         summaryLines += "keyboard_down_terminal=$termDown"
         captureFullDevice("01-keyboard-down")
 
@@ -152,6 +163,8 @@ class Issue887TerminalFixedUnderImeE2eTest {
         // Raise the REAL soft IME exactly as the user does — tap the
         // `show keyboard` chip, which calls showTerminalSoftKeyboard().
         // ---------------------------------------------------------------
+        val transitionMarker = "issue887-ime-transition-${System.nanoTime()}"
+        Log.i(LOG_TAG, transitionMarker)
         compose.onNodeWithTag(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true).performClick()
 
         var imeTopPx = -1
@@ -165,7 +178,8 @@ class Issue887TerminalFixedUnderImeE2eTest {
         // terminal rect.
         SystemClock.sleep(800)
 
-        val termUp = terminalViewRect()
+        assertImeUpTerminalSurface()
+        val termUp = terminalViewSnapshot()
         summaryLines += "keyboard_up_ime_top_px=$imeTopPx"
         summaryLines += "keyboard_up_terminal=$termUp"
 
@@ -189,49 +203,62 @@ class Issue887TerminalFixedUnderImeE2eTest {
         requireNotNull(termDown)
         requireNotNull(termUp)
 
-        writeSummary()
+        assertSameTerminalSnapshot("keyboard show", termDown, termUp)
 
-        // LOAD-BEARING on-device acceptance: the live TerminalView occupies the
-        // SAME on-screen rectangle keyboard-UP as keyboard-DOWN.
-        //  - same top/left  => no pan (the #887 fix).
-        //  - same width/height => no resize/reflow (the #457 invariant; if the
-        //    window had resized, updateSize() would have changed the grid and the
-        //    view height would shrink by the keyboard overlap).
-        val slopPx = SLOP_PX
-        assertEquals(
-            "Terminal LEFT moved when the keyboard showed (#887). down=$termDown up=$termUp",
-            termDown.left.toFloat(),
-            termUp.left.toFloat(),
-            slopPx,
-        )
-        assertEquals(
-            "Terminal TOP moved when the keyboard showed (#887: must NOT pan up). " +
-                "down=$termDown up=$termUp",
-            termDown.top.toFloat(),
-            termUp.top.toFloat(),
-            slopPx,
-        )
-        assertEquals(
-            "Terminal WIDTH changed when the keyboard showed (#457/#887: must NOT " +
-                "resize). down=$termDown up=$termUp",
-            termDown.width.toFloat(),
-            termUp.width.toFloat(),
-            slopPx,
-        )
-        assertEquals(
-            "Terminal HEIGHT changed when the keyboard showed (#457/#887: must NOT " +
-                "resize/reflow). down=$termDown up=$termUp",
-            termDown.height.toFloat(),
-            termUp.height.toFloat(),
-            slopPx,
+        // Complete the lifecycle: hide the same real IME and prove the exact
+        // same AndroidView/session/emulator + pixel/grid geometry survives the
+        // round-trip. A replacement TerminalView at equal bounds is not
+        // accepted as "fixed".
+        hideSoftKeyboard()
+        compose.waitUntil(timeoutMillis = 15_000) {
+            imeInsetTopOnScreenPx() < 0
+        }
+        compose.waitForIdle()
+        SystemClock.sleep(800)
+        val termHiddenAgain = terminalViewSnapshot()
+        summaryLines += "keyboard_hidden_again_terminal=$termHiddenAgain"
+        captureFullDevice("03-keyboard-hidden-again")
+        assertSameTerminalSnapshot("keyboard hide", termDown, termHiddenAgain)
+
+        // Existing production diagnostics log every actual tmux client-size
+        // refresh. Slice from a unique marker emitted immediately before the
+        // IME transition; there must be no resize wire operation in either the
+        // show or hide half of this lifecycle.
+        val postMarkerLogcat = postMarkerResizeLogcat(transitionMarker)
+        artifactFile("ime-transition-logcat.txt").writeText(postMarkerLogcat)
+        val resizeEvents = listOf(
+            "tmux-client-size-known",
+            "tmux-refresh-client-size-start",
+            "tmux-refresh-client-size-ok",
+            "tmux-refresh-client-size-error",
+        ).filter { it in postMarkerLogcat }
+        summaryLines += "post_marker_resize_events=$resizeEvents"
+        writeSummary()
+        assertTrue(
+            "IME show/hide must not emit a tmux client-size refresh after marker " +
+                "$transitionMarker; events=$resizeEvents log=$postMarkerLogcat",
+            resizeEvents.isEmpty(),
         )
         Unit
     } }
 
     // ---------------------------------------------------------------- geometry
 
-    private data class ViewRect(val left: Int, val top: Int, val width: Int, val height: Int) {
-        override fun toString() = "ViewRect(left=$left top=$top width=$width height=$height)"
+    private data class TerminalSnapshot(
+        val left: Int,
+        val top: Int,
+        val width: Int,
+        val height: Int,
+        val viewIdentity: Int,
+        val sessionIdentity: Int,
+        val emulatorIdentity: Int,
+        val columns: Int,
+        val rows: Int,
+    ) {
+        override fun toString(): String =
+            "TerminalSnapshot(left=$left top=$top width=$width height=$height " +
+                "view=$viewIdentity session=$sessionIdentity emulator=$emulatorIdentity " +
+                "grid=${columns}x$rows)"
     }
 
     /**
@@ -240,22 +267,71 @@ class Issue887TerminalFixedUnderImeE2eTest {
      * reflects the REAL laid-out + (potentially) panned view, not a Compose
      * semantics rect.
      */
-    private fun terminalViewRect(): ViewRect? {
-        var rect: ViewRect? = null
+    private fun terminalViewSnapshot(): TerminalSnapshot? {
+        var snapshot: TerminalSnapshot? = null
         launchedActivity?.onActivity { activity ->
             val view = activity.window.decorView.findTerminalView()
-            if (view != null) {
+            val session = view?.currentSession
+            val emulator = view?.mEmulator
+            if (view != null && session != null && emulator != null) {
                 val loc = IntArray(2)
                 view.getLocationOnScreen(loc)
-                rect = ViewRect(
+                snapshot = TerminalSnapshot(
                     left = loc[0],
                     top = loc[1],
                     width = view.width,
                     height = view.height,
+                    viewIdentity = System.identityHashCode(view),
+                    sessionIdentity = System.identityHashCode(session),
+                    emulatorIdentity = System.identityHashCode(emulator),
+                    columns = emulator.mColumns,
+                    rows = emulator.mRows,
                 )
             }
         }
-        return rect
+        return snapshot
+    }
+
+    private fun assertSameTerminalSnapshot(
+        transition: String,
+        expected: TerminalSnapshot,
+        actual: TerminalSnapshot?,
+    ) {
+        assertTrue(
+            "Terminal snapshot missing after $transition; before=$expected after=$actual",
+            actual != null,
+        )
+        requireNotNull(actual)
+        assertEquals("TerminalView identity changed on $transition", expected.viewIdentity, actual.viewIdentity)
+        assertEquals("TerminalSession identity changed on $transition", expected.sessionIdentity, actual.sessionIdentity)
+        assertEquals("TerminalEmulator identity changed on $transition", expected.emulatorIdentity, actual.emulatorIdentity)
+        assertEquals("Terminal grid columns changed on $transition", expected.columns, actual.columns)
+        assertEquals("Terminal grid rows changed on $transition", expected.rows, actual.rows)
+        assertEquals(
+            "Terminal LEFT moved on $transition (#887). before=$expected after=$actual",
+            expected.left.toFloat(),
+            actual.left.toFloat(),
+            SLOP_PX,
+        )
+        assertEquals(
+            "Terminal TOP moved on $transition (#887: must NOT pan). before=$expected after=$actual",
+            expected.top.toFloat(),
+            actual.top.toFloat(),
+            SLOP_PX,
+        )
+        assertEquals(
+            "Terminal WIDTH changed on $transition (#457/#887). before=$expected after=$actual",
+            expected.width.toFloat(),
+            actual.width.toFloat(),
+            SLOP_PX,
+        )
+        assertEquals(
+            "Terminal HEIGHT changed on $transition (#457/#887: no resize/reflow). " +
+                "before=$expected after=$actual",
+            expected.height.toFloat(),
+            actual.height.toFloat(),
+            SLOP_PX,
+        )
     }
 
     private fun imeInsetTopOnScreenPx(): Int {
@@ -281,6 +357,185 @@ class Issue887TerminalFixedUnderImeE2eTest {
             attached
         }
     }
+
+    private fun hideSoftKeyboard() {
+        launchedActivity?.onActivity { activity ->
+            val view = checkNotNull(activity.window.decorView.findTerminalView())
+            val inputMethodManager =
+                activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun postMarkerResizeLogcat(marker: String): String {
+        val descriptor = InstrumentationRegistry.getInstrumentation()
+            .uiAutomation
+            .executeShellCommand(
+                "logcat -d -v threadtime -s $LOG_TAG:I $ISSUE_145_RECONNECT_TAG:I",
+            )
+        val full = ParcelFileDescriptor.AutoCloseInputStream(descriptor)
+            .bufferedReader()
+            .use { it.readText() }
+        assertTrue(
+            "Unique IME transition marker missing from filtered logcat: $marker",
+            marker in full,
+        )
+        return full.substringAfterLast(marker)
+    }
+
+    private fun assertImeUpTerminalSurface() {
+        fun state(): Triple<Int, Int, Boolean> {
+            val conversationLoadingCount = compose
+                .onAllNodesWithText("Loading conversation…", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size
+            val hotkeysLauncherCount = compose
+                .onAllNodesWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size
+            var terminalVisible = false
+            launchedActivity?.onActivity { activity ->
+                val terminal = activity.window.decorView.findTerminalView()
+                terminalVisible =
+                    terminal?.isShown == true &&
+                    terminal.visibility == View.VISIBLE &&
+                    terminal.width > 0 &&
+                    terminal.height > 0
+            }
+            return Triple(conversationLoadingCount, hotkeysLauncherCount, terminalVisible)
+        }
+
+        try {
+            compose.waitUntil(timeoutMillis = 15_000) {
+                val (conversationLoadingCount, hotkeysLauncherCount, terminalVisible) = state()
+                conversationLoadingCount == 0 &&
+                    hotkeysLauncherCount == 1 &&
+                    terminalVisible
+            }
+        } catch (cause: Throwable) {
+            val (conversationLoadingCount, hotkeysLauncherCount, terminalVisible) = state()
+            throw AssertionError(
+                "IME-up measurement must remain on the same visible Terminal surface. " +
+                    "loadingConversationNodes=$conversationLoadingCount " +
+                    "terminalHotkeysLauncherNodes=$hotkeysLauncherCount " +
+                    "terminalVisible=$terminalVisible",
+                cause,
+            )
+        }
+        val (conversationLoadingCount, hotkeysLauncherCount, terminalVisible) = state()
+        assertTrue(
+            "IME-up measurement must remain on the same visible Terminal surface. " +
+                "loadingConversationNodes=$conversationLoadingCount " +
+                "terminalHotkeysLauncherNodes=$hotkeysLauncherCount " +
+                "terminalVisible=$terminalVisible",
+            conversationLoadingCount == 0 &&
+                hotkeysLauncherCount == 1 &&
+                terminalVisible,
+        )
+        summaryLines += "keyboard_up_same_terminal_surface=true"
+    }
+
+    private fun waitForLiveKeyboardChip() {
+        try {
+            compose.waitUntil(
+                timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs(),
+            ) {
+                liveKeyboardChipFullyWithinOwningRoot()
+            }
+            assertLiveKeyboardChipFullyWithinOwningRoot()
+            summaryLines += "live_band_ready=true"
+        } catch (cause: Throwable) {
+            val screenCount = semanticsNodeCount(TMUX_SESSION_SCREEN_TAG)
+            val launcherCount = semanticsNodeCount(SESSION_COMPOSER_LAUNCHER_TAG)
+            val keyboardChipCount = semanticsNodeCount(SHOW_KEYBOARD_CHIP_TAG)
+            val terminal = terminalViewSnapshot()
+            val connection = currentConnectionDiagnostics()
+            summaryLines += "live_band_ready=false"
+            summaryLines += "live_band_screen_nodes=$screenCount"
+            summaryLines += "live_band_launcher_nodes=$launcherCount"
+            summaryLines += "live_band_keyboard_chip_nodes=$keyboardChipCount"
+            summaryLines += "live_band_terminal=$terminal"
+            summaryLines += "live_band_connection=$connection"
+            val screenshotFailure = runCatching {
+                captureFullDevice("00-live-band-timeout")
+            }.exceptionOrNull()
+            summaryLines += "live_band_timeout_screenshot_saved=${screenshotFailure == null}"
+            screenshotFailure?.let {
+                summaryLines += "live_band_timeout_screenshot_error=${it.message}"
+            }
+            val summaryFailure = runCatching {
+                writeSummary(liveTimeoutScreenshotSaved = screenshotFailure == null)
+            }.exceptionOrNull()
+            throw AssertionError(
+                "Timed out waiting for the contained Live-only Show-keyboard chip. " +
+                    "screenNodes=$screenCount launcherNodes=$launcherCount " +
+                    "keyboardChipNodes=$keyboardChipCount terminal=$terminal " +
+                    "connection=$connection screenshotFailure=${screenshotFailure?.message} " +
+                    "summaryFailure=${summaryFailure?.message}. " +
+                    "The composer launcher alone is not a Live oracle (#1672/#1748).",
+                cause,
+            )
+        }
+    }
+
+    private fun liveKeyboardChipFullyWithinOwningRoot(): Boolean =
+        runCatching {
+            val node = compose.onAllNodesWithTag(
+                SHOW_KEYBOARD_CHIP_TAG,
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().singleOrNull() ?: return@runCatching false
+            val root = compose.onAllNodes(isRoot(), useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .singleOrNull { it.root === node.root }
+                ?: return@runCatching false
+            val bounds = node.boundsInRoot
+            val rootBounds = root.boundsInRoot
+            bounds.left >= rootBounds.left - ROOT_SLOP_PX &&
+                bounds.top >= rootBounds.top - ROOT_SLOP_PX &&
+                bounds.right <= rootBounds.right + ROOT_SLOP_PX &&
+                bounds.bottom <= rootBounds.bottom + ROOT_SLOP_PX
+        }.getOrDefault(false)
+
+    private fun assertLiveKeyboardChipFullyWithinOwningRoot() {
+        val node = compose.onNodeWithTag(
+            SHOW_KEYBOARD_CHIP_TAG,
+            useUnmergedTree = true,
+        ).fetchSemanticsNode()
+        val root = compose.onAllNodes(isRoot(), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .single { it.root === node.root }
+        val bounds = node.boundsInRoot
+        val rootBounds = root.boundsInRoot
+        assertTrue(
+            "Live-only Show-keyboard chip must be fully contained in its owning " +
+                "Compose root. node=$bounds root=$rootBounds",
+            bounds.left >= rootBounds.left - ROOT_SLOP_PX &&
+                bounds.top >= rootBounds.top - ROOT_SLOP_PX &&
+                bounds.right <= rootBounds.right + ROOT_SLOP_PX &&
+                bounds.bottom <= rootBounds.bottom + ROOT_SLOP_PX,
+        )
+    }
+
+    private fun currentConnectionDiagnostics(): String =
+        runCatching {
+            var diagnostics = "activity-unavailable"
+            launchedActivity?.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                diagnostics =
+                    "raw=${viewModel.connectionStatus.value} " +
+                    "display=${viewModel.displayConnectionStatus.value} " +
+                    "reveal=${viewModel.revealState.value} panes=${viewModel.panes.value.size}"
+            }
+            diagnostics
+        }.getOrElse { "unavailable(${it::class.simpleName}: ${it.message})" }
+
+    private fun semanticsNodeCount(tag: String): Int =
+        runCatching {
+            compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size
+        }.getOrDefault(-1)
 
     private fun forceFlatHostDetailViewMode() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
@@ -336,6 +591,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
                 "tmux new-session -d -s ${shellQuote(SESSION_LAB)} " +
                     shellQuote("printf 'SHELL-READY\\n'; while true; do sleep 60; done"),
             )
+            appendLine("tmux set-option -t ${shellQuote(SESSION_LAB)} @ps_agent_kind shell")
         }
         runSsh(key, script)
     }
@@ -406,7 +662,9 @@ class Issue887TerminalFixedUnderImeE2eTest {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         instrumentation.waitForIdleSync()
         SystemClock.sleep(200)
-        val bitmap = instrumentation.uiAutomation.takeScreenshot() ?: return
+        val bitmap = checkNotNull(instrumentation.uiAutomation.takeScreenshot()) {
+            "UiAutomation returned no screenshot for $name"
+        }
         val file = artifactFile("$name.png")
         try {
             FileOutputStream(file).use { output ->
@@ -420,7 +678,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
         }
     }
 
-    private fun writeSummary() {
+    private fun writeSummary(liveTimeoutScreenshotSaved: Boolean? = null) {
         val file = artifactFile("summary.txt")
         file.writeText(
             buildString {
@@ -429,8 +687,16 @@ class Issue887TerminalFixedUnderImeE2eTest {
                 appendLine("seeded_session=$SESSION_LAB")
                 summaryLines.forEach { appendLine(it) }
                 appendLine("artifacts:")
-                appendLine("  01-keyboard-down.png")
-                appendLine("  02-keyboard-up.png")
+                when (liveTimeoutScreenshotSaved) {
+                    true -> appendLine("  00-live-band-timeout.png")
+                    false -> Unit
+                    null -> {
+                        appendLine("  01-keyboard-down.png")
+                        appendLine("  02-keyboard-up.png")
+                        appendLine("  03-keyboard-hidden-again.png")
+                        appendLine("  ime-transition-logcat.txt")
+                    }
+                }
             },
         )
         println("ISSUE887_SUMMARY ${file.absolutePath}")
@@ -450,7 +716,8 @@ class Issue887TerminalFixedUnderImeE2eTest {
         const val DATABASE_NAME: String = "pocketshell.db"
         const val LOG_TAG: String = "Issue887Terminal"
         const val DEVICE_DIR_NAME: String = "issue887-terminal-fixed-under-ime"
-        const val SESSION_LAB: String = "opencode-lab"
+        const val SESSION_LAB: String = "issue1748-887-shell"
+        const val ROOT_SLOP_PX: Float = 1f
 
         // Allow 2px of sub-pixel/location rounding between two on-screen reads;
         // a pan of the keyboard overlap (~787px on this AVD) is far above it.

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ReservedTmuxTerminalBottomBandTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ReservedTmuxTerminalBottomBandTest.kt
@@ -1,0 +1,307 @@
+package com.pocketshell.app.tmux
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #887 recurrence — production-layout proof for the bottom reservation.
+ *
+ * The real keyboard-down child remains measured while the IME is visible but is
+ * not placed. This test drives the framework inset sequence that caused the
+ * regression: visible navigation-bar inset drops to zero as the IME rises,
+ * while navigationBarsIgnoringVisibility retains the device footprint.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReservedTmuxTerminalBottomBandTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    @OptIn(ExperimentalLayoutApi::class)
+    fun imeKeepsMeasuredDownFootprintAndHiddenContentRemeasures() {
+        val imeVisible = mutableStateOf(false)
+        val controlHeightDp = mutableStateOf(56f)
+        val observedImePx = mutableIntStateOf(0)
+        val observedVisibleNavPx = mutableIntStateOf(0)
+        val observedStableNavPx = mutableIntStateOf(0)
+
+        compose.activityRule.scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+        compose.setContent {
+            PocketShellTheme {
+                val density = LocalDensity.current
+                observedImePx.intValue = WindowInsets.ime.getBottom(density)
+                observedVisibleNavPx.intValue = WindowInsets.navigationBars.getBottom(density)
+                observedStableNavPx.intValue =
+                    WindowInsets.navigationBarsIgnoringVisibility.getBottom(density)
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .width(CONTAINER_WIDTH_DP.dp)
+                            .height(CONTAINER_HEIGHT_DP.dp)
+                            .testTag(CONTAINER_TAG),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                                .background(PocketShellColors.Background)
+                                .testTag(TERMINAL_PROXY_TAG),
+                        )
+                        ReservedTmuxTerminalBottomBand(
+                            isImeVisible = imeVisible.value,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(RESERVATION_TAG),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(controlHeightDp.value.dp)
+                                    .background(PocketShellColors.Surface)
+                                    .testTag(KEYBOARD_DOWN_CHILD_TAG),
+                            )
+                        }
+                    }
+
+                    if (imeVisible.value) {
+                        TmuxTerminalImeHotkeysLauncher(
+                            onShowHotkeysTap = {},
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .imePadding(),
+                        )
+                    }
+                }
+            }
+        }
+
+        dispatchInsets(
+            imeBottomPx = 0,
+            visibleNavBottomPx = px(24f),
+            stableNavBottomPx = px(24f),
+        )
+        compose.waitForIdle()
+        assertTrue("stable nav inset must reach Compose", observedStableNavPx.intValue > 0)
+        val downTerminal = bounds(TERMINAL_PROXY_TAG)
+        val downReservation = bounds(RESERVATION_TAG)
+        compose.onNodeWithTag(KEYBOARD_DOWN_CHILD_TAG).assertExists()
+
+        // Real show sequence: nav visibility animates away while the IME and its
+        // much larger bottom inset become visible.
+        dispatchInsets(
+            imeBottomPx = px(300f),
+            visibleNavBottomPx = 0,
+            stableNavBottomPx = px(24f),
+        )
+        compose.runOnIdle { imeVisible.value = true }
+        compose.waitForIdle()
+
+        assertTrue("synthetic IME must reach Compose", observedImePx.intValue > 0)
+        assertEquals("visible nav inset must be gone under IME", 0, observedVisibleNavPx.intValue)
+        assertEquals(
+            "stable nav footprint must survive IME show",
+            px(24f),
+            observedStableNavPx.intValue,
+        )
+        assertRectEquals("terminal bounds across IME show", downTerminal, bounds(TERMINAL_PROXY_TAG))
+        assertRectEquals(
+            "reservation bounds across IME show",
+            downReservation,
+            bounds(RESERVATION_TAG),
+        )
+        // The clear-and-set boundary removes the hidden controls from the
+        // merged accessibility/input semantics tree. Compose deliberately
+        // retains unplaced implementation nodes in its unmerged test tree.
+        compose.onNodeWithTag(KEYBOARD_DOWN_CHILD_TAG).assertDoesNotExist()
+        assertEquals(
+            "exactly one IME-only launcher must replace the unplaced down controls",
+            1,
+            compose.onAllNodesWithTag(
+                TERMINAL_HOTKEYS_LAUNCHER_TAG,
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().size,
+        )
+
+        // No cached height: a different target/content shape remeasures even
+        // though the keyboard-down child remains unplaced.
+        compose.runOnIdle { controlHeightDp.value = 80f }
+        compose.waitForIdle()
+        val tallerReservation = bounds(RESERVATION_TAG)
+        assertTrue(
+            "hidden production controls must remeasure after content change; " +
+                "before=$downReservation after=$tallerReservation",
+            tallerReservation.height > downReservation.height + px(20f),
+        )
+        assertTrue(
+            "terminal proxy must consume the corresponding smaller remainder",
+            bounds(TERMINAL_PROXY_TAG).height < downTerminal.height - px(20f),
+        )
+        compose.onNodeWithTag(KEYBOARD_DOWN_CHILD_TAG).assertDoesNotExist()
+
+        // Likewise a device/config nav-footprint change naturally remeasures;
+        // the visible nav inset stays zero throughout.
+        dispatchInsets(
+            imeBottomPx = px(300f),
+            visibleNavBottomPx = 0,
+            stableNavBottomPx = px(36f),
+        )
+        compose.waitForIdle()
+        val widerStableInsetReservation = bounds(RESERVATION_TAG)
+        assertTrue(
+            "stable nav-inset change must remeasure the hidden child; " +
+                "before=$tallerReservation after=$widerStableInsetReservation",
+            widerStableInsetReservation.height > tallerReservation.height + px(8f),
+        )
+    }
+
+    @Test
+    fun conversationImeOpenReservesZeroBlankBottomRows() {
+        compose.setContent {
+            PocketShellTheme {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .width(CONTAINER_WIDTH_DP.dp)
+                            .height(CONTAINER_HEIGHT_DP.dp)
+                            .testTag(CONVERSATION_CONTAINER_TAG),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                                .testTag(CONVERSATION_CONTENT_TAG),
+                        )
+                        TmuxSessionBottomBandPlacement(
+                            isImeVisible = true,
+                            onConversationTab = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(CONVERSATION_BAND_TAG),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(56.dp)
+                                    .testTag(CONVERSATION_DOWN_CHILD_TAG),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(CONVERSATION_BAND_TAG).assertDoesNotExist()
+        compose.onNodeWithTag(CONVERSATION_DOWN_CHILD_TAG).assertDoesNotExist()
+        assertRectEquals(
+            "Conversation content must consume the entire screen column with IME open",
+            bounds(CONVERSATION_CONTAINER_TAG),
+            bounds(CONVERSATION_CONTENT_TAG),
+        )
+    }
+
+    private fun dispatchInsets(
+        imeBottomPx: Int,
+        visibleNavBottomPx: Int,
+        stableNavBottomPx: Int,
+    ) {
+        compose.activityRule.scenario.onActivity { activity ->
+            val decor = activity.window.decorView
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(
+                    WindowInsetsCompat.Type.ime(),
+                    Insets.of(0, 0, 0, imeBottomPx),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    Insets.of(0, 0, 0, visibleNavBottomPx),
+                )
+                .setInsetsIgnoringVisibility(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    Insets.of(0, 0, 0, stableNavBottomPx),
+                )
+                .setVisible(WindowInsetsCompat.Type.ime(), imeBottomPx > 0)
+                .setVisible(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    visibleNavBottomPx > 0,
+                )
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+        }
+    }
+
+    private fun bounds(tag: String): Rect =
+        compose.onNodeWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+
+    private fun assertRectEquals(label: String, expected: Rect, actual: Rect) {
+        assertEquals("$label left", expected.left, actual.left, SLOP_PX)
+        assertEquals("$label top", expected.top, actual.top, SLOP_PX)
+        assertEquals("$label right", expected.right, actual.right, SLOP_PX)
+        assertEquals("$label bottom", expected.bottom, actual.bottom, SLOP_PX)
+    }
+
+    private fun px(dp: Float): Int = with(compose.density) { dp.dp.roundToPx() }
+
+    private companion object {
+        const val CONTAINER_TAG = "issue887-reserved-band-container"
+        const val TERMINAL_PROXY_TAG = "issue887-reserved-band-terminal"
+        const val RESERVATION_TAG = "issue887-reserved-band"
+        const val KEYBOARD_DOWN_CHILD_TAG = "issue887-reserved-band-down-child"
+        const val CONVERSATION_CONTAINER_TAG = "issue887-conversation-container"
+        const val CONVERSATION_CONTENT_TAG = "issue887-conversation-content"
+        const val CONVERSATION_BAND_TAG = "issue887-conversation-band"
+        const val CONVERSATION_DOWN_CHILD_TAG = "issue887-conversation-down-child"
+        const val CONTAINER_WIDTH_DP = 392f
+        const val CONTAINER_HEIGHT_DP = 740f
+        const val SLOP_PX = 0.5f
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt
@@ -120,16 +120,7 @@ class TerminalHotkeysPanelScreenshotHarness {
                             .testTag(BAND_TAG),
                         contentAlignment = Alignment.BottomCenter,
                     ) {
-                        TmuxTerminalBottomControls(
-                            isImeVisible = true,
-                            showConversation = false,
-                            sessionLive = true,
-                            isAgentPane = false,
-                            onChipTap = {},
-                            onDictateTap = {},
-                            onEnterTap = {},
-                            onShowKeyboardTap = {},
-                            onAddSnippetTap = {},
+                        TmuxTerminalImeHotkeysLauncher(
                             onShowHotkeysTap = {},
                             modifier = Modifier.imePadding(),
                         )

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherLargeFontScreenshotHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherLargeFontScreenshotHarness.kt
@@ -65,19 +65,25 @@ class TmuxComposerLauncherLargeFontScreenshotHarness {
                                 .width(PIXEL_7A_WIDTH_DP.dp)
                                 .testTag(BAND_TAG),
                         ) {
-                            TmuxTerminalBottomControls(
-                                isImeVisible = isImeVisible,
-                                showConversation = false,
-                                sessionLive = true,
-                                isAgentPane = false,
-                                onChipTap = {},
-                                onDictateTap = {},
-                                onEnterTap = {},
-                                onShowKeyboardTap = {},
-                                onAddSnippetTap = {},
-                                onShowHotkeysTap = {},
-                                modifier = Modifier.fillMaxWidth(),
-                            )
+                            if (isImeVisible) {
+                                TmuxTerminalImeHotkeysLauncher(
+                                    onShowHotkeysTap = {},
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            } else {
+                                TmuxTerminalBottomControls(
+                                    showConversation = false,
+                                    sessionLive = true,
+                                    isAgentPane = false,
+                                    onChipTap = {},
+                                    onDictateTap = {},
+                                    onEnterTap = {},
+                                    onShowKeyboardTap = {},
+                                    onAddSnippetTap = {},
+                                    onShowHotkeysTap = {},
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherNarrowFontClipProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherNarrowFontClipProofTest.kt
@@ -13,8 +13,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -23,11 +28,14 @@ import com.pocketshell.app.voice.SESSION_ADD_SNIPPET_CHIP_TAG
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
 import com.pocketshell.app.voice.SESSION_ENTER_CHIP_TAG
 import com.pocketshell.app.voice.SHOW_KEYBOARD_CHIP_TAG
+import com.pocketshell.app.voice.TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL
 import com.pocketshell.app.voice.HOTKEYS_CHIP_TAG
+import com.pocketshell.app.voice.BottomChipControls
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
 import java.io.File
 import java.io.FileOutputStream
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -72,6 +80,8 @@ class TmuxComposerLauncherNarrowFontClipProofTest {
     @get:Rule
     val compose = createAndroidComposeRule<ComponentActivity>()
 
+    private val clickedPrimaryControls = mutableListOf<String>()
+
     /**
      * Render the production bottom controls the way [TmuxSessionScreen] wires them
      * on a Terminal-tab shell pane (keyboard down, all primary chips present),
@@ -79,6 +89,7 @@ class TmuxComposerLauncherNarrowFontClipProofTest {
      * reported state.
      */
     private fun renderBottomControls(widthDp: Int, fontScale: Float) {
+        clickedPrimaryControls.clear()
         compose.setContent {
             val base = LocalDensity.current
             // Synthetic large system font (the maintainer's larger-than-default
@@ -102,7 +113,6 @@ class TmuxComposerLauncherNarrowFontClipProofTest {
                             TmuxTerminalBottomControls(
                                 // Keyboard DOWN — the maintainer's exact state
                                 // (the full chip row, where the launcher lives).
-                                isImeVisible = false,
                                 // Terminal tab (NOT conversation) — the report.
                                 showConversation = false,
                                 sessionLive = true,
@@ -111,10 +121,60 @@ class TmuxComposerLauncherNarrowFontClipProofTest {
                                 isAgentPane = false,
                                 onChipTap = {},
                                 onDictateTap = {},
-                                onEnterTap = {},
-                                onShowKeyboardTap = {},
-                                onAddSnippetTap = {},
-                                onShowHotkeysTap = {},
+                                onEnterTap = { clickedPrimaryControls += SESSION_ENTER_CHIP_TAG },
+                                onShowKeyboardTap = {
+                                    clickedPrimaryControls += SHOW_KEYBOARD_CHIP_TAG
+                                },
+                                onAddSnippetTap = {
+                                    clickedPrimaryControls += SESSION_ADD_SNIPPET_CHIP_TAG
+                                },
+                                onShowHotkeysTap = {
+                                    clickedPrimaryControls += HOTKEYS_CHIP_TAG
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    private fun renderRawSshBottomControls(widthDp: Int, fontScale: Float) {
+        clickedPrimaryControls.clear()
+        compose.setContent {
+            val base = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(density = base.density, fontScale = fontScale),
+            ) {
+                PocketShellTheme {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(PocketShellColors.Background),
+                        contentAlignment = Alignment.BottomCenter,
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .width(widthDp.dp)
+                                .testTag(BAND_TAG),
+                        ) {
+                            BottomChipControls(
+                                chips = emptyList(),
+                                onChipTap = {},
+                                onDictateTap = {
+                                    clickedPrimaryControls += SESSION_COMPOSER_LAUNCHER_TAG
+                                },
+                                onEnterTap = {
+                                    clickedPrimaryControls += SESSION_ENTER_CHIP_TAG
+                                },
+                                onShowKeyboardTap = {
+                                    clickedPrimaryControls += SHOW_KEYBOARD_CHIP_TAG
+                                },
+                                onAddSnippetTap = {
+                                    clickedPrimaryControls += SESSION_ADD_SNIPPET_CHIP_TAG
+                                },
                                 modifier = Modifier.fillMaxWidth(),
                             )
                         }
@@ -165,24 +225,99 @@ class TmuxComposerLauncherNarrowFontClipProofTest {
 
     @Test
     fun allFourPrimaryChipsRemainReachableOnNarrowLargeFont() {
-        // The cluster yields by SCROLLING, never by silently dropping a chip. All
-        // four primary affordances must still exist in the tree (reachable via
-        // scroll) even when the launcher has reserved its width first.
+        // The one-line cluster yields by SCROLLING, never by silently dropping or
+        // clipping an unreachable chip. Bring every control into view, prove its
+        // complete bounds, then invoke its real callback.
         renderBottomControls(widthDp = NARROW_WIDTH_DP, fontScale = LARGE_FONT_SCALE)
-        listOf(
+        val tags = listOf(
             SESSION_ENTER_CHIP_TAG,
             SHOW_KEYBOARD_CHIP_TAG,
             HOTKEYS_CHIP_TAG,
             SESSION_ADD_SNIPPET_CHIP_TAG,
-        ).forEach { tag ->
-            compose.onNodeWithTag(tag).assertExists(
-                "primary chip '$tag' must remain present + reachable (#813: chips " +
-                    "yield by scrolling, they are never silently dropped)",
+        )
+        val bandBounds = compose.onNodeWithTag(BAND_TAG).getUnclippedBoundsInRoot()
+        val launcherBounds = compose.onNodeWithTag(
+            SESSION_COMPOSER_LAUNCHER_TAG,
+        ).getUnclippedBoundsInRoot()
+        tags.forEach { tag ->
+            val control = compose.onNodeWithTag(tag)
+            control.assertExists(
+                "primary control '$tag' must remain in the one-line scroll viewport",
             )
+            control.performScrollTo()
+            compose.waitForIdle()
+            val bounds = control.getUnclippedBoundsInRoot()
+            assertTrue(
+                "bring-into-view must fully contain '$tag' clear of the pinned " +
+                    "composer launcher; control=$bounds band=$bandBounds " +
+                    "launcher=$launcherBounds",
+                bounds.left >= bandBounds.left &&
+                    bounds.top >= bandBounds.top &&
+                    bounds.right <= launcherBounds.left &&
+                    bounds.bottom <= bandBounds.bottom,
+            )
+            control.assertHasClickAction().performClick()
         }
+        compose.runOnIdle { assertEquals(tags, clickedPrimaryControls) }
         // The launcher is also still present + contained.
         compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).assertExists()
         assertLauncherWithinBand("reachability case @ ${NARROW_WIDTH_DP}dp")
+
+        // #789's compact hotkeys launcher remains a real accessible 48dp button,
+        // not a decorative glyph or a clipped sliver, even in this tight case.
+        val hotkeys = compose.onNodeWithTag(HOTKEYS_CHIP_TAG)
+        hotkeys.assertHasClickAction()
+            .assertContentDescriptionEquals(TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL)
+        val hotkeysBounds = hotkeys.getUnclippedBoundsInRoot()
+        assertTrue(
+            "compact Terminal hotkeys launcher must remain fully within the " +
+                "narrow large-font band; hotkeys=$hotkeysBounds band=$bandBounds",
+            hotkeysBounds.left >= bandBounds.left &&
+                hotkeysBounds.top >= bandBounds.top &&
+                hotkeysBounds.right <= bandBounds.right &&
+                hotkeysBounds.bottom <= bandBounds.bottom,
+        )
+    }
+
+    @Test
+    fun rawSshPrimaryControlsScrollIntoFullReachOnNarrowLargeFont() {
+        renderRawSshBottomControls(
+            widthDp = NARROW_WIDTH_DP,
+            fontScale = LARGE_FONT_SCALE,
+        )
+        val tags = listOf(
+            SESSION_ENTER_CHIP_TAG,
+            SHOW_KEYBOARD_CHIP_TAG,
+            SESSION_ADD_SNIPPET_CHIP_TAG,
+        )
+        val bandBounds = compose.onNodeWithTag(BAND_TAG).getUnclippedBoundsInRoot()
+        val launcher = compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG)
+        val launcherBounds = launcher.getUnclippedBoundsInRoot()
+        assertTrue(
+            "raw SSH composer launcher must stay pinned inside the narrow band",
+            launcherBounds.left >= bandBounds.left &&
+                launcherBounds.right <= bandBounds.right &&
+                launcherBounds.bottom <= bandBounds.bottom,
+        )
+        tags.forEach { tag ->
+            val control = compose.onNodeWithTag(tag)
+            control.performScrollTo()
+            compose.waitForIdle()
+            val bounds = control.getUnclippedBoundsInRoot()
+            assertTrue(
+                "raw SSH '$tag' must become fully contained and clear of the " +
+                    "pinned launcher; control=$bounds launcher=$launcherBounds band=$bandBounds",
+                bounds.left >= bandBounds.left &&
+                    bounds.top >= bandBounds.top &&
+                    bounds.right <= launcherBounds.left &&
+                    bounds.bottom <= bandBounds.bottom,
+            )
+            control.assertHasClickAction().performClick()
+        }
+        launcher.assertHasClickAction().performClick()
+        compose.runOnIdle {
+            assertEquals(tags + SESSION_COMPOSER_LAUNCHER_TAG, clickedPrimaryControls)
+        }
     }
 
     private fun artifactDir(): File {

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherNeverClippedProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherNeverClippedProofTest.kt
@@ -83,7 +83,6 @@ class TmuxComposerLauncherNeverClippedProofTest {
                         TmuxTerminalBottomControls(
                             // Keyboard DOWN — the maintainer's exact reported state
                             // (the full chip row, where the launcher lives).
-                            isImeVisible = false,
                             // Terminal tab (NOT conversation) — the reported shot.
                             showConversation = false,
                             sessionLive = true,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConversationBottomComposerScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConversationBottomComposerScreenshotTest.kt
@@ -85,7 +85,6 @@ class TmuxConversationBottomComposerScreenshotTest {
                     // composer launcher: no toggle chip, no snippets chip, no
                     // command chips, no show-keyboard chip.
                     TmuxTerminalBottomControls(
-                        isImeVisible = false,
                         showConversation = true,
                         sessionLive = true,
                         isAgentPane = true,
@@ -102,7 +101,6 @@ class TmuxConversationBottomComposerScreenshotTest {
 
                     SectionLabel("Terminal tab — full band (untouched by #786)")
                     TmuxTerminalBottomControls(
-                        isImeVisible = false,
                         showConversation = false,
                         sessionLive = true,
                         isAgentPane = true,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConversationDetectingComposerVisibleTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConversationDetectingComposerVisibleTest.kt
@@ -108,7 +108,6 @@ class TmuxConversationDetectingComposerVisibleTest {
                     ) {
                         TmuxSessionBottomControlsCallSite(
                             // Keyboard down — the maintainer's exact reported state.
-                            isImeVisible = false,
                             showConversationTranscript = showConversationTranscript,
                             showConversationDetectingPlaceholder = showConversationDetectingPlaceholder,
                             sessionLive = true,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxHotkeysLauncherImeProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxHotkeysLauncherImeProofTest.kt
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith
  * waits on a real keyboard goes green locally and red (or vacuously-skipped) on
  * CI. Instead we DISPATCH a synthetic `Type.ime()` inset to the decor view and
  * read the inset Compose actually consumed from INSIDE the composition. The
- * keyboard-up band ([TmuxTerminalBottomControls] with `isImeVisible = true`)
+ * keyboard-up overlay ([TmuxTerminalImeHotkeysLauncher])
  * is hosted at the bottom of a fixed-height container and wrapped in
  * `Modifier.imePadding()` — exactly the production behaviour: the band is lifted
  * to sit above the keyboard. There is NO `assumeTrue` / self-skip: the synthetic
@@ -98,16 +98,7 @@ class TmuxHotkeysLauncherImeProofTest {
                             .testTag(CONTAINER_TAG),
                         contentAlignment = Alignment.BottomCenter,
                     ) {
-                        TmuxTerminalBottomControls(
-                            isImeVisible = true,
-                            showConversation = false,
-                            sessionLive = true,
-                            isAgentPane = false,
-                            onChipTap = {},
-                            onDictateTap = {},
-                            onEnterTap = {},
-                            onShowKeyboardTap = {},
-                            onAddSnippetTap = {},
+                        TmuxTerminalImeHotkeysLauncher(
                             onShowHotkeysTap = {},
                             modifier = Modifier.imePadding(),
                         )

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxKeyBarImeReachabilityTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxKeyBarImeReachabilityTest.kt
@@ -22,29 +22,26 @@ import org.junit.runner.RunWith
  * `PromptComposerKeyBarImeReachabilityTest` (the twin of the #615 Send
  * reachability test).
  *
- * What survives here is the pure FSM contract: a terminal pane with the IME up
- * still maps to [TmuxTerminalKeyboardChromeMode.OpenImeTerminalHotkeys] (now a
- * render-nothing state on the terminal surface — the bar is in the composer),
- * and a conversation pane maps to the no-accessory state. This belt-and-
- * suspenders guards a future refactor from silently re-routing IME-up terminal
- * panes.
+ * What survives here is the keyboard-down bottom-band contract. Keyboard-up
+ * chrome is now structurally separate at screen-overlay level and covered by
+ * [TmuxTerminalImeHotkeysOverlayLifecycleTest].
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxKeyBarImeReachabilityTest {
 
     @Test
-    fun chromeModeFsmMapsImeStatesCorrectly() {
+    fun keyboardDownSurfaceMapsConversationAndTerminalStates() {
         assertEquals(
-            TmuxTerminalKeyboardChromeMode.HiddenImeControls,
-            tmuxTerminalKeyboardChromeMode(isImeVisible = false, showConversation = false),
+            TmuxTerminalHiddenImeSurface.CommandChips,
+            tmuxTerminalHiddenImeSurface(showConversation = false, terminalHeld = false),
         )
         assertEquals(
-            TmuxTerminalKeyboardChromeMode.OpenImeTerminalHotkeys,
-            tmuxTerminalKeyboardChromeMode(isImeVisible = true, showConversation = false),
+            TmuxTerminalHiddenImeSurface.LauncherOnly,
+            tmuxTerminalHiddenImeSurface(showConversation = true, terminalHeld = false),
         )
         assertEquals(
-            TmuxTerminalKeyboardChromeMode.OpenImeConversationNoAccessory,
-            tmuxTerminalKeyboardChromeMode(isImeVisible = true, showConversation = true),
+            TmuxTerminalHiddenImeSurface.LauncherOnly,
+            tmuxTerminalHiddenImeSurface(showConversation = false, terminalHeld = true),
         )
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionScreenImeChromeTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionScreenImeChromeTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
@@ -373,7 +374,12 @@ class TmuxSessionScreenImeChromeTest {
         ) + fadeOut(
             animationSpec = tween(durationMillis = 200),
         )
-        Column(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            contentAlignment = Alignment.Center,
+        ) {
             AnimatedVisibility(visible = !chromeCompressed, enter = animEnter, exit = animExit) {
                 ConsolidatedTopChrome(
                     sessionName = "claude-main",

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
@@ -33,6 +34,7 @@ import com.pocketshell.app.voice.AssistantStrip
 import com.pocketshell.app.voice.BottomChipControls
 import com.pocketshell.app.voice.DefaultSessionChips
 import com.pocketshell.app.voice.HOTKEYS_CHIP_LABEL
+import com.pocketshell.app.voice.TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL
 import com.pocketshell.app.voice.InlineDictationErrorStrip
 import com.pocketshell.app.voice.SESSION_ADD_SNIPPET_CHIP_TAG
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_CONTENT_DESCRIPTION
@@ -68,22 +70,19 @@ class TmuxSessionVoiceSurfaceUiTest {
         // Issue #784 (D22 hard-cut): with the soft keyboard UP on the Terminal
         // tab, this bottom-controls surface never renders a crammed key GRID
         // above the IME (the #755 cram the maintainer rejected). The full hotkeys
-        // grid is the dedicated `TerminalHotkeysPanel` sheet. When no
-        // `onShowHotkeysTap` is wired (this test), nothing renders here at all.
+        // grid is the dedicated `TerminalHotkeysPanel` sheet. When no active
+        // pane can own `onShowHotkeysTap` (this test), nothing renders here.
         // This guards the hard-cut: no key grid, no Esc/^C/Tab keys, no
         // attachment grid, no chip band when the IME is up on a terminal pane.
         compose.setContent {
             PocketShellTheme {
-                TmuxTerminalBottomControls(
+                TmuxTerminalImeHotkeysOverlay(
                     isImeVisible = true,
-                    showConversation = false,
-                    sessionLive = true,
-                    isAgentPane = false,
-                    onChipTap = {},
-                    onDictateTap = {},
-                    onEnterTap = {},
-                    onShowKeyboardTap = {},
-                    onAddSnippetTap = {},
+                    hasPane = false,
+                    isConversationTab = false,
+                    onShowHotkeysTap = {
+                        error("pane-less Terminal must not expose the hotkeys callback")
+                    },
                     modifier = Modifier.testTag(CONVERSATION_IME_BOTTOM_CONTROLS_TAG),
                 )
             }
@@ -117,16 +116,7 @@ class TmuxSessionVoiceSurfaceUiTest {
         var launched = false
         compose.setContent {
             PocketShellTheme {
-                TmuxTerminalBottomControls(
-                    isImeVisible = true,
-                    showConversation = false,
-                    sessionLive = true,
-                    isAgentPane = false,
-                    onChipTap = {},
-                    onDictateTap = {},
-                    onEnterTap = {},
-                    onShowKeyboardTap = {},
-                    onAddSnippetTap = {},
+                TmuxTerminalImeHotkeysLauncher(
                     onShowHotkeysTap = { launched = true },
                     modifier = Modifier.testTag(CONVERSATION_IME_BOTTOM_CONTROLS_TAG),
                 )
@@ -151,16 +141,7 @@ class TmuxSessionVoiceSurfaceUiTest {
         // reclaimed. The old bar's "Terminal hotkeys" caption no longer appears.
         compose.setContent {
             PocketShellTheme {
-                TmuxTerminalBottomControls(
-                    isImeVisible = true,
-                    showConversation = false,
-                    sessionLive = true,
-                    isAgentPane = false,
-                    onChipTap = {},
-                    onDictateTap = {},
-                    onEnterTap = {},
-                    onShowKeyboardTap = {},
-                    onAddSnippetTap = {},
+                TmuxTerminalImeHotkeysLauncher(
                     onShowHotkeysTap = {},
                     modifier = Modifier.testTag(CONVERSATION_IME_BOTTOM_CONTROLS_TAG),
                 )
@@ -204,7 +185,6 @@ class TmuxSessionVoiceSurfaceUiTest {
         compose.setContent {
             PocketShellTheme {
                 TmuxTerminalBottomControls(
-                    isImeVisible = false,
                     showConversation = false,
                     sessionLive = true,
                     isAgentPane = false,
@@ -231,7 +211,7 @@ class TmuxSessionVoiceSurfaceUiTest {
         compose.assertNodeFullyWithinRoot(SHOW_KEYBOARD_CHIP_TAG)
         compose.onNodeWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG)
             .assertHasClickAction()
-            .assertTextContains(HOTKEYS_CHIP_LABEL)
+            .assertContentDescriptionEquals(TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL)
         compose.assertNodeFullyWithinRoot(TERMINAL_HOTKEYS_LAUNCHER_TAG)
 
         compose.onNodeWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG).performClick()
@@ -243,16 +223,11 @@ class TmuxSessionVoiceSurfaceUiTest {
     fun tmuxConversationImeOpenDoesNotRenderAccessoryStrip() {
         compose.setContent {
             PocketShellTheme {
-                TmuxTerminalBottomControls(
+                TmuxTerminalImeHotkeysOverlay(
                     isImeVisible = true,
-                    showConversation = true,
-                    sessionLive = true,
-                    isAgentPane = true,
-                    onChipTap = {},
-                    onDictateTap = {},
-                    onEnterTap = {},
-                    onShowKeyboardTap = {},
-                    onAddSnippetTap = {},
+                    hasPane = true,
+                    isConversationTab = true,
+                    onShowHotkeysTap = {},
                     modifier = Modifier.testTag(CONVERSATION_IME_BOTTOM_CONTROLS_TAG),
                 )
             }
@@ -278,16 +253,11 @@ class TmuxSessionVoiceSurfaceUiTest {
         // Composer sheet, never in the session view (even in conversation mode).
         compose.setContent {
             PocketShellTheme {
-                TmuxTerminalBottomControls(
+                TmuxTerminalImeHotkeysOverlay(
                     isImeVisible = true,
-                    showConversation = true,
-                    sessionLive = true,
-                    isAgentPane = true,
-                    onChipTap = {},
-                    onDictateTap = {},
-                    onEnterTap = {},
-                    onShowKeyboardTap = {},
-                    onAddSnippetTap = {},
+                    hasPane = true,
+                    isConversationTab = true,
+                    onShowHotkeysTap = {},
                     modifier = Modifier.testTag(CONVERSATION_IME_BOTTOM_CONTROLS_TAG),
                 )
             }
@@ -317,7 +287,6 @@ class TmuxSessionVoiceSurfaceUiTest {
         compose.setContent {
             PocketShellTheme {
                 TmuxTerminalBottomControls(
-                    isImeVisible = false,
                     showConversation = false,
                     sessionLive = true,
                     // Shell (non-agent) pane — the regression case from #641.
@@ -385,7 +354,6 @@ class TmuxSessionVoiceSurfaceUiTest {
         compose.setContent {
             PocketShellTheme {
                 TmuxTerminalBottomControls(
-                    isImeVisible = false,
                     showConversation = false,
                     // Held ⇒ input is not routable; matches the screen's
                     // `controlsInputEnabled = false` during connect.
@@ -432,7 +400,6 @@ class TmuxSessionVoiceSurfaceUiTest {
         compose.setContent {
             PocketShellTheme {
                 TmuxTerminalBottomControls(
-                    isImeVisible = false,
                     showConversation = false,
                     sessionLive = true,
                     terminalHeld = false,
@@ -576,7 +543,6 @@ class TmuxSessionVoiceSurfaceUiTest {
         compose.setContent {
             PocketShellTheme {
                 TmuxTerminalBottomControls(
-                    isImeVisible = false,
                     showConversation = false,
                     sessionLive = true,
                     isAgentPane = true,
@@ -667,7 +633,6 @@ class TmuxSessionVoiceSurfaceUiTest {
             PocketShellTheme {
                 if (!composerOpen) {
                     TmuxTerminalBottomControls(
-                        isImeVisible = false,
                         showConversation = false,
                         sessionLive = true,
                         isAgentPane = true,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
@@ -6,6 +6,11 @@ import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -13,6 +18,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -24,11 +30,15 @@ import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.voice.HOTKEYS_CHIP_TAG
 import com.pocketshell.app.voice.SESSION_ADD_SNIPPET_CHIP_TAG
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
-import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
+import com.pocketshell.app.voice.SESSION_ENTER_CHIP_TAG
 import com.pocketshell.app.voice.SHOW_KEYBOARD_CHIP_TAG
+import com.pocketshell.app.voice.TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -38,6 +48,7 @@ import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -130,6 +141,11 @@ class TmuxShellComposerOcclusionE2eTest {
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+        // Issue #1748: the always-present #810 launcher is not proof that the
+        // #1672 held surface has reached Live. The Show-keyboard chip exists
+        // only in the Live command band, so await and contain that real
+        // user-facing state before measuring the keyboard-down layout.
+        waitForLiveKeyboardChip()
         compose.waitForIdle()
 
         // ---------------------------------------------------------------
@@ -156,19 +172,69 @@ class TmuxShellComposerOcclusionE2eTest {
         val snippetsNodes = compose
             .onAllNodesWithTag(SESSION_ADD_SNIPPET_CHIP_TAG, useUnmergedTree = true)
             .fetchSemanticsNodes()
-        if (snippetsNodes.isNotEmpty()) {
-            val snippetsBounds = boundsInRoot(SESSION_ADD_SNIPPET_CHIP_TAG)
-            summaryLines += "keyboard_down_snippets=$snippetsBounds"
+        assertEquals(
+            "live shell keyboard-down band must expose exactly one snippets chip",
+            1,
+            snippetsNodes.size,
+        )
+        val snippetsBounds = compose.onNodeWithTag(
+            SESSION_ADD_SNIPPET_CHIP_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+        val launcherUnclippedBounds = compose.onNodeWithTag(
+            SESSION_COMPOSER_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).getUnclippedBoundsInRoot()
+        val rootUnclippedBounds = compose.onNode(isRoot()).getUnclippedBoundsInRoot()
+        summaryLines += "keyboard_down_snippets=$snippetsBounds"
+        compose.onNodeWithTag(
+            SESSION_ADD_SNIPPET_CHIP_TAG,
+            useUnmergedTree = true,
+        ).assertHasClickAction()
+        assertTrue(
+            "snippets chip must be fully contained and not clipped behind the launcher " +
+                "(keyboard down); snippets=$snippetsBounds " +
+                "launcher=$launcherUnclippedBounds root=$rootUnclippedBounds",
+            snippetsBounds.left >= rootUnclippedBounds.left &&
+                snippetsBounds.top >= rootUnclippedBounds.top &&
+                snippetsBounds.right <= rootUnclippedBounds.right &&
+                snippetsBounds.bottom <= rootUnclippedBounds.bottom &&
+                snippetsBounds.right <= launcherUnclippedBounds.left,
+        )
+        listOf(
+            SESSION_ENTER_CHIP_TAG,
+            SHOW_KEYBOARD_CHIP_TAG,
+            HOTKEYS_CHIP_TAG,
+            SESSION_ADD_SNIPPET_CHIP_TAG,
+        ).forEach { tag ->
+            val control = compose.onNodeWithTag(tag, useUnmergedTree = true)
+            val bounds = control.getUnclippedBoundsInRoot()
+            summaryLines += "keyboard_down_primary[$tag]=$bounds"
+            control.assertHasClickAction()
             assertTrue(
-                "snippets chip must be fully on-screen and not clipped behind the launcher " +
-                    "(keyboard down); snippets=$snippetsBounds launcher=$launcherBounds root=$rootBounds",
-                snippetsBounds.right <= launcherBounds.left + 0.5f &&
-                    snippetsBounds.right <= rootBounds.right + 0.5f &&
-                    snippetsBounds.left >= rootBounds.left - 0.5f,
+                "every keyboard-down primary control must be fully visible and " +
+                    "clear of the launcher; tag=$tag bounds=$bounds " +
+                    "launcher=$launcherUnclippedBounds root=$rootUnclippedBounds",
+                bounds.left >= rootUnclippedBounds.left &&
+                    bounds.top >= rootUnclippedBounds.top &&
+                    bounds.right <= rootUnclippedBounds.right &&
+                    bounds.bottom <= rootUnclippedBounds.bottom &&
+                    bounds.right <= launcherUnclippedBounds.left,
             )
-        } else {
-            summaryLines += "keyboard_down_snippets=absent"
         }
+        compose.onNodeWithTag(
+            HOTKEYS_CHIP_TAG,
+            useUnmergedTree = true,
+        ).assertContentDescriptionEquals(TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL)
+        val hotkeysOnClick = compose.onNodeWithTag(
+            HOTKEYS_CHIP_TAG,
+            useUnmergedTree = true,
+        ).fetchSemanticsNode().config[SemanticsActions.OnClick]
+        assertEquals(
+            "compact hotkeys button must announce its action",
+            TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL,
+            hotkeysOnClick.label,
+        )
 
         captureFullDevice("01-keyboard-down")
 
@@ -188,6 +254,8 @@ class TmuxShellComposerOcclusionE2eTest {
         compose.waitForIdle()
         SystemClock.sleep(500)
         imeTopPx = imeInsetTopOnScreenPx()
+        assertImeUpTerminalSurface()
+        assertImeHotkeysLauncherReachableAbove(imeTopPx)
         val rootBoundsKbUp = rootBounds()
         summaryLines += "keyboard_up_ime_top_px=$imeTopPx"
         summaryLines += "keyboard_up_root=$rootBoundsKbUp"
@@ -286,6 +354,200 @@ class TmuxShellComposerOcclusionE2eTest {
         return ready
     }
 
+    private fun assertImeUpTerminalSurface() {
+        fun state(): Triple<Int, Int, Boolean> {
+            val conversationLoadingCount = compose
+                .onAllNodesWithText("Loading conversation…", useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size
+            val hotkeysLauncherCount = compose
+                .onAllNodesWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size
+            var terminalVisible = false
+            launchedActivity?.onActivity { activity ->
+                val terminal = activity.window.decorView.findTerminalView()
+                terminalVisible =
+                    terminal?.isShown == true &&
+                    terminal.visibility == View.VISIBLE &&
+                    terminal.width > 0 &&
+                    terminal.height > 0
+            }
+            return Triple(conversationLoadingCount, hotkeysLauncherCount, terminalVisible)
+        }
+
+        try {
+            compose.waitUntil(timeoutMillis = 15_000) {
+                val (conversationLoadingCount, hotkeysLauncherCount, terminalVisible) = state()
+                conversationLoadingCount == 0 &&
+                    hotkeysLauncherCount == 1 &&
+                    terminalVisible
+            }
+        } catch (cause: Throwable) {
+            val (conversationLoadingCount, hotkeysLauncherCount, terminalVisible) = state()
+            throw AssertionError(
+                "IME-up assertions must remain on the same visible Terminal surface. " +
+                    "loadingConversationNodes=$conversationLoadingCount " +
+                    "terminalHotkeysLauncherNodes=$hotkeysLauncherCount " +
+                    "terminalVisible=$terminalVisible",
+                cause,
+            )
+        }
+        val (conversationLoadingCount, hotkeysLauncherCount, terminalVisible) = state()
+        assertTrue(
+            "IME-up assertions must remain on the same visible Terminal surface. " +
+                "loadingConversationNodes=$conversationLoadingCount " +
+                "terminalHotkeysLauncherNodes=$hotkeysLauncherCount " +
+                "terminalVisible=$terminalVisible",
+            conversationLoadingCount == 0 &&
+                hotkeysLauncherCount == 1 &&
+                terminalVisible,
+        )
+        summaryLines += "keyboard_up_same_terminal_surface=true"
+    }
+
+    private fun assertImeHotkeysLauncherReachableAbove(imeTopPx: Int) {
+        val nodes = compose
+            .onAllNodesWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+        assertTrue(
+            "Keyboard-up Terminal surface must expose exactly one compact hotkeys " +
+                "launcher; count=${nodes.size}",
+            nodes.size == 1,
+        )
+        compose.onNodeWithTag(
+            TERMINAL_HOTKEYS_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).assertHasClickAction()
+
+        val node = nodes.single()
+        val owningRoot = compose.onAllNodes(isRoot(), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .single { it.root === node.root }
+        val bounds = node.boundsInRoot
+        val rootBounds = owningRoot.boundsInRoot
+        assertTrue(
+            "Compact hotkeys launcher must be fully contained in its owning root. " +
+                "launcher=$bounds root=$rootBounds",
+            bounds.left >= rootBounds.left - ROOT_SLOP_PX &&
+                bounds.top >= rootBounds.top - ROOT_SLOP_PX &&
+                bounds.right <= rootBounds.right + ROOT_SLOP_PX &&
+                bounds.bottom <= rootBounds.bottom + ROOT_SLOP_PX,
+        )
+
+        val launcherBottomScreenPx = bottomEdgeOnScreenPx(TERMINAL_HOTKEYS_LAUNCHER_TAG)
+        summaryLines += "keyboard_up_hotkeys_launcher_count=${nodes.size}"
+        summaryLines += "keyboard_up_hotkeys_launcher_bounds=$bounds"
+        summaryLines += "keyboard_up_hotkeys_launcher_bottom_screen_px=$launcherBottomScreenPx"
+        assertTrue(
+            "Compact hotkeys launcher must remain fully above the real IME and " +
+                "clickable. launcherBottom=$launcherBottomScreenPx imeTop=$imeTopPx",
+            launcherBottomScreenPx >= 0 &&
+                launcherBottomScreenPx <= imeTopPx + ROOT_SLOP_PX.toInt(),
+        )
+    }
+
+    private fun waitForLiveKeyboardChip() {
+        try {
+            compose.waitUntil(
+                timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs(),
+            ) {
+                liveKeyboardChipFullyWithinOwningRoot()
+            }
+            assertLiveKeyboardChipFullyWithinOwningRoot()
+            summaryLines += "live_band_ready=true"
+        } catch (cause: Throwable) {
+            val screenCount = semanticsNodeCount(TMUX_SESSION_SCREEN_TAG)
+            val launcherCount = semanticsNodeCount(SESSION_COMPOSER_LAUNCHER_TAG)
+            val keyboardChipCount = semanticsNodeCount(SHOW_KEYBOARD_CHIP_TAG)
+            val terminalReady = terminalGridReady()
+            val connection = currentConnectionDiagnostics()
+            summaryLines += "live_band_ready=false"
+            summaryLines += "live_band_screen_nodes=$screenCount"
+            summaryLines += "live_band_launcher_nodes=$launcherCount"
+            summaryLines += "live_band_keyboard_chip_nodes=$keyboardChipCount"
+            summaryLines += "live_band_terminal_ready=$terminalReady"
+            summaryLines += "live_band_connection=$connection"
+            val screenshotFailure = runCatching {
+                captureFullDevice("00-live-band-timeout")
+            }.exceptionOrNull()
+            summaryLines += "live_band_timeout_screenshot_saved=${screenshotFailure == null}"
+            screenshotFailure?.let {
+                summaryLines += "live_band_timeout_screenshot_error=${it.message}"
+            }
+            val summaryFailure = runCatching {
+                writeSummary(liveTimeoutScreenshotSaved = screenshotFailure == null)
+            }.exceptionOrNull()
+            throw AssertionError(
+                "Timed out waiting for the contained Live-only Show-keyboard chip. " +
+                    "screenNodes=$screenCount launcherNodes=$launcherCount " +
+                    "keyboardChipNodes=$keyboardChipCount terminalReady=$terminalReady " +
+                    "connection=$connection screenshotFailure=${screenshotFailure?.message} " +
+                    "summaryFailure=${summaryFailure?.message}. " +
+                    "The composer launcher alone is not a Live oracle (#1672/#1748).",
+                cause,
+            )
+        }
+    }
+
+    private fun liveKeyboardChipFullyWithinOwningRoot(): Boolean =
+        runCatching {
+            val node = compose.onAllNodesWithTag(
+                SHOW_KEYBOARD_CHIP_TAG,
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().singleOrNull() ?: return@runCatching false
+            val root = compose.onAllNodes(isRoot(), useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .singleOrNull { it.root === node.root }
+                ?: return@runCatching false
+            val bounds = node.boundsInRoot
+            val rootBounds = root.boundsInRoot
+            bounds.left >= rootBounds.left - ROOT_SLOP_PX &&
+                bounds.top >= rootBounds.top - ROOT_SLOP_PX &&
+                bounds.right <= rootBounds.right + ROOT_SLOP_PX &&
+                bounds.bottom <= rootBounds.bottom + ROOT_SLOP_PX
+        }.getOrDefault(false)
+
+    private fun assertLiveKeyboardChipFullyWithinOwningRoot() {
+        val node = compose.onNodeWithTag(
+            SHOW_KEYBOARD_CHIP_TAG,
+            useUnmergedTree = true,
+        ).fetchSemanticsNode()
+        val root = compose.onAllNodes(isRoot(), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .single { it.root === node.root }
+        val bounds = node.boundsInRoot
+        val rootBounds = root.boundsInRoot
+        assertTrue(
+            "Live-only Show-keyboard chip must be fully contained in its owning " +
+                "Compose root. node=$bounds root=$rootBounds",
+            bounds.left >= rootBounds.left - ROOT_SLOP_PX &&
+                bounds.top >= rootBounds.top - ROOT_SLOP_PX &&
+                bounds.right <= rootBounds.right + ROOT_SLOP_PX &&
+                bounds.bottom <= rootBounds.bottom + ROOT_SLOP_PX,
+        )
+    }
+
+    private fun currentConnectionDiagnostics(): String =
+        runCatching {
+            var diagnostics = "activity-unavailable"
+            launchedActivity?.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                diagnostics =
+                    "raw=${viewModel.connectionStatus.value} " +
+                    "display=${viewModel.displayConnectionStatus.value} " +
+                    "reveal=${viewModel.revealState.value} panes=${viewModel.panes.value.size}"
+            }
+            diagnostics
+        }.getOrElse { "unavailable(${it::class.simpleName}: ${it.message})" }
+
+    private fun semanticsNodeCount(tag: String): Int =
+        runCatching {
+            compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size
+        }.getOrDefault(-1)
+
     private fun View.findTerminalView(): TerminalView? {
         if (this is TerminalView) return this
         if (this !is ViewGroup) return null
@@ -314,6 +576,7 @@ class TmuxShellComposerOcclusionE2eTest {
                 "tmux new-session -d -s ${shellQuote(SESSION_LAB)} " +
                     shellQuote("printf 'SHELL-READY\\n'; while true; do sleep 60; done"),
             )
+            appendLine("tmux set-option -t ${shellQuote(SESSION_LAB)} @ps_agent_kind shell")
         }
         runSsh(key, script)
     }
@@ -384,7 +647,9 @@ class TmuxShellComposerOcclusionE2eTest {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         instrumentation.waitForIdleSync()
         SystemClock.sleep(200)
-        val bitmap = instrumentation.uiAutomation.takeScreenshot() ?: return
+        val bitmap = checkNotNull(instrumentation.uiAutomation.takeScreenshot()) {
+            "UiAutomation returned no screenshot for $name"
+        }
         val file = artifactFile("$name.png")
         try {
             FileOutputStream(file).use { output ->
@@ -398,7 +663,7 @@ class TmuxShellComposerOcclusionE2eTest {
         }
     }
 
-    private fun writeSummary() {
+    private fun writeSummary(liveTimeoutScreenshotSaved: Boolean? = null) {
         val file = artifactFile("summary.txt")
         file.writeText(
             buildString {
@@ -407,8 +672,14 @@ class TmuxShellComposerOcclusionE2eTest {
                 appendLine("seeded_session=$SESSION_LAB")
                 summaryLines.forEach { appendLine(it) }
                 appendLine("artifacts:")
-                appendLine("  01-keyboard-down.png")
-                appendLine("  02-keyboard-up.png")
+                when (liveTimeoutScreenshotSaved) {
+                    true -> appendLine("  00-live-band-timeout.png")
+                    false -> Unit
+                    null -> {
+                        appendLine("  01-keyboard-down.png")
+                        appendLine("  02-keyboard-up.png")
+                    }
+                }
             },
         )
         println("ISSUE641_SUMMARY ${file.absolutePath}")
@@ -428,6 +699,7 @@ class TmuxShellComposerOcclusionE2eTest {
         const val DATABASE_NAME: String = "pocketshell.db"
         const val LOG_TAG: String = "Issue641Composer"
         const val DEVICE_DIR_NAME: String = "issue641-shell-composer-occlusion"
-        const val SESSION_LAB: String = "opencode-lab"
+        const val SESSION_LAB: String = "issue1748-641-shell"
+        const val ROOT_SLOP_PX: Float = 1f
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxTerminalImeHotkeysOverlayLifecycleTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxTerminalImeHotkeysOverlayLifecycleTest.kt
@@ -1,0 +1,133 @@
+package com.pocketshell.app.tmux
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Retained-screen proof for the root-level IME overlay.
+ *
+ * Two tmux destinations may remain composed during navigation. Exactly the
+ * RESUMED lifecycle owner may expose the public launcher, and the gate must
+ * react when foreground ownership swaps.
+ */
+@RunWith(AndroidJUnit4::class)
+class TmuxTerminalImeHotkeysOverlayLifecycleTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun onlyResumedRetainedScreenExposesClickableLauncher() {
+        val retained = TestLifecycleOwner()
+        val foreground = TestLifecycleOwner()
+        val foregroundUsesSecondPane = mutableStateOf(false)
+        var retainedClicks = 0
+        var foregroundFirstPaneClicks = 0
+        var foregroundSecondPaneClicks = 0
+
+        compose.runOnIdle {
+            retained.registry.currentState = Lifecycle.State.STARTED
+            foreground.registry.currentState = Lifecycle.State.RESUMED
+        }
+        compose.setContent {
+            PocketShellTheme {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    CompositionLocalProvider(LocalLifecycleOwner provides retained) {
+                        TmuxTerminalImeHotkeysOverlay(
+                            isImeVisible = true,
+                            hasPane = true,
+                            isConversationTab = false,
+                            onShowHotkeysTap = { retainedClicks += 1 },
+                        )
+                    }
+                    CompositionLocalProvider(LocalLifecycleOwner provides foreground) {
+                        TmuxTerminalImeHotkeysOverlay(
+                            isImeVisible = true,
+                            hasPane = true,
+                            isConversationTab = false,
+                            onShowHotkeysTap = if (foregroundUsesSecondPane.value) {
+                                { foregroundSecondPaneClicks += 1 }
+                            } else {
+                                { foregroundFirstPaneClicks += 1 }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        assertExactlyOneLauncher()
+        compose.onNodeWithTag(
+            TERMINAL_HOTKEYS_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+        compose.runOnIdle {
+            assertEquals(0, retainedClicks)
+            assertEquals(1, foregroundFirstPaneClicks)
+            assertEquals(0, foregroundSecondPaneClicks)
+            foregroundUsesSecondPane.value = true
+        }
+
+        // A retained destination can also switch its active tmux pane without
+        // changing lifecycle ownership. The single public launcher must invoke
+        // the latest pane-routed callback, not the one captured at first mount.
+        assertExactlyOneLauncher()
+        compose.onNodeWithTag(
+            TERMINAL_HOTKEYS_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+        compose.runOnIdle {
+            assertEquals(1, foregroundFirstPaneClicks)
+            assertEquals(1, foregroundSecondPaneClicks)
+            foreground.registry.currentState = Lifecycle.State.STARTED
+            retained.registry.currentState = Lifecycle.State.RESUMED
+        }
+
+        assertExactlyOneLauncher()
+        compose.onNodeWithTag(
+            TERMINAL_HOTKEYS_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+        compose.runOnIdle {
+            assertEquals(1, retainedClicks)
+            assertEquals(1, foregroundFirstPaneClicks)
+            assertEquals(1, foregroundSecondPaneClicks)
+        }
+    }
+
+    private fun assertExactlyOneLauncher() {
+        val nodes = compose.onAllNodesWithTag(
+            TERMINAL_HOTKEYS_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).fetchSemanticsNodes()
+        assertEquals("only the RESUMED retained screen may expose a launcher", 1, nodes.size)
+        compose.onNodeWithTag(
+            TERMINAL_HOTKEYS_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).assertHasClickAction()
+    }
+
+    private class TestLifecycleOwner : LifecycleOwner {
+        val registry = LifecycleRegistry(this)
+        override val lifecycle: Lifecycle = registry
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
@@ -3,13 +3,20 @@ package com.pocketshell.app.tmux
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsIgnoringVisibility
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.pocketshell.app.composer.PromptComposerSheet
 import com.pocketshell.app.voice.ADD_COMMAND_CHIP_LABEL
@@ -54,7 +61,6 @@ import com.pocketshell.uikit.theme.PocketShellSpacing
  */
 @Composable
 internal fun TmuxSessionBottomControlsCallSite(
-    isImeVisible: Boolean,
     showConversationTranscript: Boolean,
     showConversationDetectingPlaceholder: Boolean,
     sessionLive: Boolean,
@@ -79,6 +85,7 @@ internal fun TmuxSessionBottomControlsCallSite(
     onShowKeyboardTap: (() -> Unit)?,
     onAddSnippetTap: (() -> Unit)?,
     onShowHotkeysTap: (() -> Unit)? = null,
+    hotkeysLauncherTag: String = TERMINAL_HOTKEYS_LAUNCHER_TAG,
     leadingChipContent: (@Composable () -> Unit)? = null,
     // Issue #1531 (audit RC1): the unsent-queue badge shown on the docked composer
     // launcher so a queued / deferred / uploading / failed send is VISIBLE on the
@@ -97,7 +104,6 @@ internal fun TmuxSessionBottomControlsCallSite(
         showConversationDetectingPlaceholder = showConversationDetectingPlaceholder,
     )
     TmuxTerminalBottomControls(
-        isImeVisible = isImeVisible,
         showConversation = onConversationTab,
         sessionLive = sessionLive,
         terminalHeld = terminalHeld,
@@ -109,6 +115,7 @@ internal fun TmuxSessionBottomControlsCallSite(
         onShowKeyboardTap = onShowKeyboardTap,
         onAddSnippetTap = onAddSnippetTap,
         onShowHotkeysTap = onShowHotkeysTap,
+        hotkeysLauncherTag = hotkeysLauncherTag,
         leadingChipContent = leadingChipContent,
         unsentCount = unsentCount,
         unsentHasFailure = unsentHasFailure,
@@ -118,7 +125,6 @@ internal fun TmuxSessionBottomControlsCallSite(
 
 @Composable
 internal fun TmuxTerminalBottomControls(
-    isImeVisible: Boolean,
     showConversation: Boolean,
     sessionLive: Boolean,
     // Issue #1672: while true (terminal held behind the "Attaching…" loader), the
@@ -142,6 +148,7 @@ internal fun TmuxTerminalBottomControls(
     // terminal. Null on surfaces with no pane to receive control bytes (e.g. the
     // Conversation tab).
     onShowHotkeysTap: (() -> Unit)? = null,
+    hotkeysLauncherTag: String = TERMINAL_HOTKEYS_LAUNCHER_TAG,
     leadingChipContent: (@Composable () -> Unit)? = null,
     // Issue #1531 (audit RC1): the unsent-queue badge for the docked composer
     // launcher (see [TmuxSessionBottomControlsCallSite]).
@@ -149,59 +156,12 @@ internal fun TmuxTerminalBottomControls(
     unsentHasFailure: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
-    val chromeMode = tmuxTerminalKeyboardChromeMode(
-        isImeVisible = isImeVisible,
-        showConversation = showConversation,
-    )
-    when (chromeMode) {
-        // Issue #673: the conversation IME-open mode renders no accessory at
-        // all. Staged attachments used to surface here; they now live only
-        // inside the Prompt Composer sheet.
-        TmuxTerminalKeyboardChromeMode.OpenImeConversationNoAccessory -> Unit
-        // Issue #784: with the keyboard up on the Terminal tab, render a SLIM
-        // launcher bar above the IME so the hotkeys panel is one tap away while
-        // typing. The full hotkey grid lives in the dedicated
-        // [TerminalHotkeysPanel] bottom sheet — never crammed above the keyboard
-        // (the #755/#784 occlusion + cram complaints), just a single launcher.
-        TmuxTerminalKeyboardChromeMode.OpenImeTerminalHotkeys -> {
-            if (onShowHotkeysTap != null) {
-                // Issue #789 (hard-cut, D22): above the soft keyboard the
-                // launcher is a COMPACT chip pinned to the right edge — NOT the
-                // deleted full-width bar — so it occupies a single short row and
-                // reclaims the vertical space the bar wasted. It sits on the
-                // surface band so it reads above the IME, and opens the same
-                // dedicated [TerminalHotkeysSheet]. The host's layout modifier
-                // (which carries `imePadding()` upstream) keeps it above the
-                // keyboard. The chip carries the stable `tmux:hotkeys-launcher`
-                // tag so existing tests still find it.
-                Row(
-                    modifier = modifier
-                        .fillMaxWidth()
-                        .background(color = PocketShellColors.Surface)
-                        .border(width = 1.dp, color = PocketShellColors.Border)
-                        .padding(
-                            horizontal = PocketShellSpacing.sm,
-                            vertical = PocketShellSpacing.sm,
-                        ),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    CommandChip(
-                        label = HOTKEYS_CHIP_LABEL,
-                        onClick = onShowHotkeysTap,
-                        icon = HotkeysChipIcon,
-                        modifier = Modifier.testTag(TERMINAL_HOTKEYS_LAUNCHER_TAG),
-                    )
-                }
-            }
-        }
-        TmuxTerminalKeyboardChromeMode.HiddenImeControls -> {
-            when (
-                tmuxTerminalHiddenImeSurface(
-                    showConversation = showConversation,
-                    terminalHeld = terminalHeld,
-                )
-            ) {
+    when (
+        tmuxTerminalHiddenImeSurface(
+            showConversation = showConversation,
+            terminalHeld = terminalHeld,
+        )
+    ) {
                 TmuxTerminalHiddenImeSurface.LauncherOnly -> {
                     // Issue #786 (Conversation tab, hard-cut D22) AND Issue #1672
                     // (Terminal tab while the terminal is HELD during connect): the
@@ -250,6 +210,7 @@ internal fun TmuxTerminalBottomControls(
                         // Issue #789: the compact hotkeys launcher chip (terminal tab
                         // only). Reclaims the deleted full-width bar's row.
                         onShowHotkeysTap = onShowHotkeysTap,
+                        hotkeysLauncherTag = hotkeysLauncherTag,
                         addSnippetLabel = ADD_COMMAND_CHIP_LABEL,
                         addSnippetIcon = SnippetsChipIcon,
                         leadingContent = leadingChipContent,
@@ -263,8 +224,121 @@ internal fun TmuxTerminalBottomControls(
                         modifier = modifier,
                     )
                 }
+    }
+}
+
+/**
+ * Issue #887 recurrence: the IME-only compact launcher is a screen overlay, not
+ * a member of the TerminalView-measuring column. Its host supplies
+ * `imePadding()` so this one user-facing control remains reachable above the
+ * real keyboard while the terminal keeps its keyboard-down constraints.
+ */
+@Composable
+internal fun TmuxTerminalImeHotkeysLauncher(
+    onShowHotkeysTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = PocketShellColors.Surface)
+            .border(width = 1.dp, color = PocketShellColors.Border)
+            .padding(
+                horizontal = PocketShellSpacing.sm,
+                vertical = PocketShellSpacing.sm,
+            ),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CommandChip(
+            label = HOTKEYS_CHIP_LABEL,
+            onClick = onShowHotkeysTap,
+            icon = HotkeysChipIcon,
+            modifier = Modifier.testTag(TERMINAL_HOTKEYS_LAUNCHER_TAG),
+        )
+    }
+}
+
+/**
+ * Issue #887 recurrence: one stable measuring slot for the keyboard-DOWN
+ * production controls. The child remains composed and measured while the IME is
+ * visible, so session/pane content, density, font scale and stable system-inset
+ * changes naturally remeasure without a cached pixel height. It is deliberately
+ * not placed in the IME state: its semantics and pointer input leave the
+ * rendered tree, while this layout still reserves the exact measured height.
+ *
+ * The IME-only compact launcher is rendered separately by
+ * [TmuxTerminalImeHotkeysLauncher] at screen-overlay level.
+ */
+@Composable
+@OptIn(ExperimentalLayoutApi::class)
+internal fun ReservedTmuxTerminalBottomBand(
+    isImeVisible: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Layout(
+        content = {
+            Box(
+                modifier = if (isImeVisible) {
+                    Modifier.clearAndSetSemantics {}
+                } else {
+                    Modifier
+                },
+            ) {
+                content()
+            }
+        },
+        modifier = modifier.windowInsetsPadding(
+            WindowInsets.navigationBarsIgnoringVisibility,
+        ),
+    ) { measurables, constraints ->
+        check(measurables.size == 1) {
+            "ReservedTmuxTerminalBottomBand requires exactly one measurable child"
+        }
+        val placeable = measurables.single().measure(
+            constraints.copy(minWidth = 0, minHeight = 0),
+        )
+        layout(
+            width = maxOf(placeable.width, constraints.minWidth),
+            height = maxOf(placeable.height, constraints.minHeight),
+        ) {
+            if (!isImeVisible) {
+                placeable.placeRelative(0, 0)
             }
         }
+    }
+}
+
+/**
+ * Chooses the screen-level bottom-band geometry. Terminal keeps its measured
+ * keyboard-down reservation through IME transitions; Conversation deliberately
+ * has no IME accessory, so it reserves zero rows while the keyboard is up.
+ */
+@Composable
+@OptIn(ExperimentalLayoutApi::class)
+internal fun TmuxSessionBottomBandPlacement(
+    isImeVisible: Boolean,
+    onConversationTab: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    if (onConversationTab) {
+        if (!isImeVisible) {
+            Box(
+                modifier = modifier.windowInsetsPadding(
+                    WindowInsets.navigationBarsIgnoringVisibility,
+                ),
+            ) {
+                content()
+            }
+        }
+    } else {
+        ReservedTmuxTerminalBottomBand(
+            isImeVisible = isImeVisible,
+            modifier = modifier,
+            content = content,
+        )
     }
 }
 
@@ -284,24 +358,9 @@ internal fun TmuxTerminalBottomControls(
 internal const val TERMINAL_HOTKEYS_LAUNCHER_TAG: String =
     com.pocketshell.app.voice.HOTKEYS_CHIP_TAG
 
-internal enum class TmuxTerminalKeyboardChromeMode {
-    HiddenImeControls,
-    OpenImeTerminalHotkeys,
-    OpenImeConversationNoAccessory,
-}
-
-internal fun tmuxTerminalKeyboardChromeMode(
-    isImeVisible: Boolean,
-    showConversation: Boolean,
-): TmuxTerminalKeyboardChromeMode = when {
-    !isImeVisible -> TmuxTerminalKeyboardChromeMode.HiddenImeControls
-    showConversation -> TmuxTerminalKeyboardChromeMode.OpenImeConversationNoAccessory
-    else -> TmuxTerminalKeyboardChromeMode.OpenImeTerminalHotkeys
-}
-
 /**
- * Issue #1672: what the keyboard-DOWN ([TmuxTerminalKeyboardChromeMode.HiddenImeControls])
- * bottom band renders. This is the SINGLE decision the composable dispatches on, so
+ * Issue #1672: what the keyboard-DOWN bottom band renders. This is the SINGLE
+ * decision the composable dispatches on, so
  * a JVM test of this function is load-bearing for the visible outcome.
  *
  *  - [LauncherOnly] — JUST the composer launcher (no static command chip band, no

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -38,9 +39,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.currentStateAsState
 import com.pocketshell.app.composer.PromptComposerSendDispatcher
 import com.pocketshell.app.conversation.ConversationImageViewModel
 import com.pocketshell.app.conversation.LocalConversationImageLoader
@@ -393,6 +397,27 @@ public fun TmuxSessionScreen(
             )
         }
 
+        val imeOverlayPane = panesSel.surfacePane
+        TmuxTerminalImeHotkeysOverlay(
+            isImeVisible = isImeVisible,
+            hasPane = imeOverlayPane != null,
+            isConversationTab = agent.currentSelectedTab == SessionTab.Conversation,
+            onShowHotkeysTap = {
+                imeOverlayPane?.let { pane ->
+                    DiagnosticEvents.record(
+                        "action",
+                        "hotkey_panel_show",
+                        "mode" to "tmux",
+                        "paneId" to pane.paneId,
+                    )
+                    overlay.showHotkeysPanel = true
+                }
+            },
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .imePadding(),
+        )
+
         TmuxSessionOverlaysRegion(
             viewModel = viewModel,
             sessionPickerViewModel = sessionPickerViewModel,
@@ -428,6 +453,34 @@ public fun TmuxSessionScreen(
         showCardFeedSheet = showCardFeedSheet,
         onShowCardFeedSheet = { showCardFeedSheet = it },
     )
+}
+
+/**
+ * The IME launcher belongs only to the foreground destination. MainActivity's
+ * retained compositions can keep an older tmux screen composed during route
+ * changes; observing lifecycle state reactively prevents that retained screen
+ * from exposing a second interactive overlay.
+ */
+@Composable
+internal fun TmuxTerminalImeHotkeysOverlay(
+    isImeVisible: Boolean,
+    hasPane: Boolean,
+    isConversationTab: Boolean,
+    onShowHotkeysTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val lifecycleState by LocalLifecycleOwner.current.lifecycle.currentStateAsState()
+    if (
+        lifecycleState == Lifecycle.State.RESUMED &&
+        isImeVisible &&
+        hasPane &&
+        !isConversationTab
+    ) {
+        TmuxTerminalImeHotkeysLauncher(
+            onShowHotkeysTap = onShowHotkeysTap,
+            modifier = modifier,
+        )
+    }
 }
 
 /**
@@ -897,13 +950,22 @@ private fun TmuxSessionHeaderRegion(
     Box(
         modifier = Modifier
             .fillMaxWidth()
+            // Issue #887 recurrence: the TerminalView must not inherit a new
+            // top coordinate when the 56dp full chrome swaps to the 40dp
+            // compact visual. The visual still compresses, but both variants
+            // live inside one stable header reservation.
+            .height(56.dp)
             .verticalSwipeInput(
                 thresholdPx = verticalSwipeThresholdPx,
                 onBoundary = { haptics.performHapticFeedback(HapticFeedbackType.LongPress) },
                 onSwipeDown = { overlay.showSessionSwitcher = true },
             ),
+        contentAlignment = Alignment.Center,
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
             AnimatedVisibility(
                 visible = !chromeCompressed,
                 enter = expandVertically(
@@ -917,43 +979,41 @@ private fun TmuxSessionHeaderRegion(
                     animationSpec = tween(durationMillis = MotionDurationMs, easing = MotionEasing),
                 ),
             ) {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    ConsolidatedTopChrome(
-                        sessionName = sessionName,
-                        agentName = if (terminalHeld) {
-                            null
-                        } else {
-                            currentDetection?.agent?.displayName
-                        },
-                        tabLabels = tabState.labels,
-                        selectedTabIndex = tabState.selectedIndex,
-                        onTabSelected = onTabSelected,
-                        pulseConversationTab = tabState.showsConversationTab,
-                        onBack = onBack,
-                        onMore = { overlay.moreExpanded = true },
-                        moreMenu = { AnchoredTmuxMoreMenu() },
-                        projectLabel = projectLabel,
-                        projectSwitcher = projectSwitcherState,
-                        onProjectSwitcherOpen = {
-                            sessionPickerViewModel.refreshProjectSiblings(
-                                host = sessionPickerRequest.host,
-                                keyPath = sessionPickerRequest.keyPath,
-                                currentSessionName = sessionName,
-                                projectPath = projectPath,
-                            )
-                        },
-                        onSwitchToSibling = { selected ->
-                            handleTmuxSessionSelection(
-                                currentSessionName = sessionName,
-                                selectedSessionName = selected,
-                                onDismiss = {},
-                                onReplace = onReplaceTmuxSession,
-                            )
-                        },
-                        connectionStatus = surfaceState.toUiStatus(),
-                        modifier = Modifier.testTag(TMUX_FULL_BREADCRUMB_TAG),
-                    )
-                }
+                ConsolidatedTopChrome(
+                    sessionName = sessionName,
+                    agentName = if (terminalHeld) {
+                        null
+                    } else {
+                        currentDetection?.agent?.displayName
+                    },
+                    tabLabels = tabState.labels,
+                    selectedTabIndex = tabState.selectedIndex,
+                    onTabSelected = onTabSelected,
+                    pulseConversationTab = tabState.showsConversationTab,
+                    onBack = onBack,
+                    onMore = { overlay.moreExpanded = true },
+                    moreMenu = { AnchoredTmuxMoreMenu() },
+                    projectLabel = projectLabel,
+                    projectSwitcher = projectSwitcherState,
+                    onProjectSwitcherOpen = {
+                        sessionPickerViewModel.refreshProjectSiblings(
+                            host = sessionPickerRequest.host,
+                            keyPath = sessionPickerRequest.keyPath,
+                            currentSessionName = sessionName,
+                            projectPath = projectPath,
+                        )
+                    },
+                    onSwitchToSibling = { selected ->
+                        handleTmuxSessionSelection(
+                            currentSessionName = sessionName,
+                            selectedSessionName = selected,
+                            onDismiss = {},
+                            onReplace = onReplaceTmuxSession,
+                        )
+                    },
+                    connectionStatus = surfaceState.toUiStatus(),
+                    modifier = Modifier.testTag(TMUX_FULL_BREADCRUMB_TAG),
+                )
             }
             AnimatedVisibility(
                 visible = chromeCompressed,
@@ -1385,88 +1445,103 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
             hasLiveDetection = currentDetection != null,
             presumedAgent = presumedAgent,
         )
-        val bottomControlsModifier = if (isImeVisible) {
-            Modifier
-        } else {
-            Modifier.navigationBarsPadding()
-        }
         val controlsInputEnabled = sessionLive && pane != null
-        TmuxSessionBottomControlsCallSite(
+        TmuxSessionBottomBandPlacement(
             isImeVisible = isImeVisible,
-            showConversationTranscript = showConversation,
-            showConversationDetectingPlaceholder = showConversationPlaceholder,
-            sessionLive = controlsInputEnabled,
-            terminalHeld = terminalHeld,
-            isAgentPane = isAgentPane,
-            onChipTap = { chip ->
-                pane?.let {
-                    viewModel.writeInputToPane(
-                        it.paneId,
-                        (chip + "\r").toByteArray(Charsets.UTF_8),
-                    )
-                }
-            },
-            onDictateTap = {
-                overlay.micSheetAutoStartRecording = false
-                overlay.showMicSheet = true
-            },
-            onDictateHoldSwipeUp = {
-                overlay.micSheetAutoStartRecording = true
-                overlay.showMicSheet = true
-            },
-            onEnterTap = pane?.let { p -> { viewModel.onKeyBarKey(p.paneId, "Enter") } },
-            onShowKeyboardTap = pane?.let { p ->
-                {
-                    DiagnosticEvents.record(
-                        "action",
-                        "keyboard_panel_show",
-                        "mode" to "tmux",
-                        "paneId" to p.paneId,
-                    )
-                    showTerminalSoftKeyboard(
-                        composeRootView,
-                        onLocalTerminalError = { cause ->
-                            viewModel.reportTerminalSurfaceFailure(p.paneId, cause)
-                        },
-                    )
-                }
-            },
-            onAddSnippetTap = if (
-                pane != null &&
-                tmuxSessionShowsSnippetChip(
-                    hasHost = hostId != 0L,
-                    hasLiveDetection = currentDetection != null,
-                    hasStickyAgent = paletteAgent != null,
+            onConversationTab = showConversation || showConversationPlaceholder,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+                TmuxSessionBottomControlsCallSite(
+                    showConversationTranscript = showConversation,
+                    showConversationDetectingPlaceholder = showConversationPlaceholder,
+                    sessionLive = controlsInputEnabled,
+                    terminalHeld = terminalHeld,
+                    isAgentPane = isAgentPane,
+                    onChipTap = { chip ->
+                        pane?.let {
+                            viewModel.writeInputToPane(
+                                it.paneId,
+                                (chip + "\r").toByteArray(Charsets.UTF_8),
+                            )
+                        }
+                    },
+                    onDictateTap = {
+                        overlay.micSheetAutoStartRecording = false
+                        overlay.showMicSheet = true
+                    },
+                    onDictateHoldSwipeUp = {
+                        overlay.micSheetAutoStartRecording = true
+                        overlay.showMicSheet = true
+                    },
+                    onEnterTap = pane?.let { p -> { viewModel.onKeyBarKey(p.paneId, "Enter") } },
+                    onShowKeyboardTap = pane?.let { p ->
+                        {
+                            DiagnosticEvents.record(
+                                "action",
+                                "keyboard_panel_show",
+                                "mode" to "tmux",
+                                "paneId" to p.paneId,
+                            )
+                            showTerminalSoftKeyboard(
+                                composeRootView,
+                                onLocalTerminalError = { cause ->
+                                    viewModel.reportTerminalSurfaceFailure(p.paneId, cause)
+                                },
+                            )
+                        }
+                    },
+                    onAddSnippetTap = if (
+                        pane != null &&
+                        tmuxSessionShowsSnippetChip(
+                            hasHost = hostId != 0L,
+                            hasLiveDetection = currentDetection != null,
+                            hasStickyAgent = paletteAgent != null,
+                        )
+                    ) {
+                        { overlay.showSnippetPicker = true }
+                    } else null,
+                    onShowHotkeysTap = pane?.let { p ->
+                        {
+                            DiagnosticEvents.record(
+                                "action",
+                                "hotkey_panel_show",
+                                "mode" to "tmux",
+                                "paneId" to p.paneId,
+                            )
+                            overlay.showHotkeysPanel = true
+                        }
+                    },
+                    // The real keyboard-down controls stay composed/measured
+                    // under the IME, including this chip. Their subtree is
+                    // unplaced and accessibility-hidden, but Compose keeps
+                    // implementation nodes in its unmerged test tree. Give
+                    // that hidden measurement copy a private tag so the
+                    // public tag identifies exactly the visible IME overlay.
+                    hotkeysLauncherTag = if (isImeVisible) {
+                        RESERVED_TERMINAL_HOTKEYS_MEASUREMENT_TAG
+                    } else {
+                        TERMINAL_HOTKEYS_LAUNCHER_TAG
+                    },
+                    leadingChipContent = if (controlsInputEnabled) {
+                        sessionCardFeedChipState?.let { state ->
+                            {
+                                SessionCardFeedChip(
+                                    state = state,
+                                    onClick = {
+                                        viewModel.refreshActiveSessionCards()
+                                        onShowCardFeedSheet(true)
+                                    },
+                                )
+                            }
+                        }
+                    } else {
+                        null
+                    },
+                    unsentCount = outboundLauncherBadge?.count ?: 0, // #1531 (RC1)
+                    unsentHasFailure = outboundLauncherBadge?.hasFailure ?: false,
+                    modifier = Modifier,
                 )
-            ) {
-                { overlay.showSnippetPicker = true }
-            } else null,
-            onShowHotkeysTap = pane?.let { p ->
-                {
-                    DiagnosticEvents.record(
-                        "action",
-                        "hotkey_panel_show",
-                        "mode" to "tmux",
-                        "paneId" to p.paneId,
-                    )
-                    overlay.showHotkeysPanel = true
-                }
-            },
-            leadingChipContent = if (controlsInputEnabled) sessionCardFeedChipState?.let { state ->
-                {
-                    SessionCardFeedChip(
-                        state = state,
-                        onClick = {
-                            viewModel.refreshActiveSessionCards()
-                            onShowCardFeedSheet(true)
-                        },
-                    )
-                }
-            } else null,
-            unsentCount = outboundLauncherBadge?.count ?: 0, // #1531 (RC1)
-            unsentHasFailure = outboundLauncherBadge?.hasFailure ?: false,
-            modifier = bottomControlsModifier,
-        )
+        }
     }
 
     // Pane pager dot indicator (only when >1 pane).
@@ -1477,6 +1552,9 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
         )
     }
 }
+
+private const val RESERVED_TERMINAL_HOTKEYS_MEASUREMENT_TAG: String =
+    "tmux:hotkeys-launcher:reserved-measurement"
 
 /**
  * Issue #1685: the modal dialog + auxiliary modals + session switcher / drawer +

--- a/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
+++ b/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Icon
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -428,7 +429,7 @@ private fun StaticChipStripContent(
 }
 
 /**
- * Non-scrolling sticky cluster of primary chips, rendered after the
+ * Sticky one-line cluster of primary controls, rendered after the
  * scrollable [ScrollableChipStrip] in [BottomChipControls].
  *
  * The cluster pins `Enter` (#568), `show keyboard` (#131), and the picker chip
@@ -470,16 +471,10 @@ private fun PrimaryChipCluster(
         onShowHotkeysTap == null
     ) return
     Row(
-        // Issue #813: the primary cluster (`Enter` / `show keyboard` / `hotkeys` /
-        // `snippets`) renders at its NATURAL width. It NO LONGER reserves that
-        // width ahead of the launcher — [BottomChipControls] now hosts the cluster
-        // inside a single horizontally-scrollable, weighted flexible region while
-        // the launcher is pinned UNWEIGHTED (so the launcher reserves its width
-        // FIRST and is never the element that overflows). When the row is wide
-        // enough (Pixel-class width, default font) every cluster chip is fully
-        // visible without scrolling; when it is tight (narrow / large system
-        // font — the #813 07:53 clip) the cluster yields by scrolling within the
-        // flexible region instead of pushing the launcher off the right edge.
+        // Issue #813: the primary cluster is capped to the launcher-reserved
+        // chip area. #789 permits the hotkeys entry to be a compact icon button;
+        // keeping that one affordance at the 48dp touch floor lets all four
+        // primary controls remain fully visible on one Pixel-width line.
         // Issue #787: the `/ commands` chip was hard-cut from this cluster —
         // slash entry now lives only in the composer.
         modifier = modifier
@@ -511,10 +506,8 @@ private fun PrimaryChipCluster(
         // chip opening the same dedicated `TerminalHotkeysSheet` panel. Carries
         // the stable `tmux:hotkeys-launcher` tag so existing tests still find it.
         if (onShowHotkeysTap != null) {
-            CommandChip(
-                label = HOTKEYS_CHIP_LABEL,
+            TerminalHotkeysIconButton(
                 onClick = onShowHotkeysTap,
-                icon = HotkeysChipIcon,
                 modifier = Modifier.testTag(hotkeysLauncherTag),
             )
         }
@@ -526,6 +519,48 @@ private fun PrimaryChipCluster(
                 modifier = Modifier.testTag(SESSION_ADD_SNIPPET_CHIP_TAG),
             )
         }
+    }
+}
+
+/**
+ * Keyboard-down inline hotkeys entry. The 48dp keycap keeps the launcher at the
+ * accessibility touch floor while reclaiming the label width that forced the
+ * terminal control band onto a second row.
+ */
+@Composable
+private fun TerminalHotkeysIconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .minimumInteractiveComponentSize()
+            .size(PocketShellDensity.tapTargetMin)
+            .background(
+                color = LocalPocketShellSemantic.current.accentSoft,
+                shape = PocketShellShapes.small,
+            )
+            .border(
+                width = 1.dp,
+                color = LocalPocketShellSemantic.current.accentDim,
+                shape = PocketShellShapes.small,
+            )
+            .semantics {
+                contentDescription = TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL
+            }
+            .clickable(
+                role = Role.Button,
+                onClickLabel = TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = HotkeysChipIcon,
+            contentDescription = null,
+            tint = LocalPocketShellSemantic.current.accent,
+            modifier = Modifier.size(18.dp),
+        )
     }
 }
 
@@ -543,9 +578,8 @@ private fun PrimaryChipCluster(
  *    is the flexible `weight(1f, fill = false)` scrolling strip that YIELDS
  *    first, followed by the [PrimaryChipCluster] (`Enter`, `show keyboard`,
  *    `hotkeys`, picker) at its natural width, pinned to the right of the chip
- *    area in the right-thumb arc (design-system §9 / #208). The whole chip area
- *    also scrolls, so in the extreme narrow / huge-font case the cluster yields
- *    by scrolling rather than clipping.
+ *    area in the right-thumb arc (design-system §9 / #208). The hotkeys entry is
+ *    an icon-only 48dp keycap so all four primary actions fit without clipping.
  * 2. The composer launcher — its fixed-width slot is reserved up front, so it
  *    RESERVES its width FIRST and is never the element pushed off the right edge
  *    (issue #813). Raw SSH keeps the prompt composer affordance; tmux terminal
@@ -564,8 +598,8 @@ private fun PrimaryChipCluster(
  * last) was squeezed to zero and clipped off the right edge — the maintainer's
  * 07:53 clip (`snippets`-wraps-to-two-lines tell). The fix reserves the
  * launcher's fixed width up front via the constraints math, so the launcher is
- * never the element that overflows; the chip area absorbs the squeeze by
- * scrolling and every chip stays reachable (scroll, never silently dropped).
+ * never the element that overflows; the static strip absorbs horizontal squeeze
+ * by scrolling; the compact hotkeys keycap keeps the primary row visible.
  *
  * `onProjectNavigationTap` is optional because the tmux route does not
  * surface project navigation yet (the raw-SSH `SessionViewModel` owns the
@@ -623,14 +657,8 @@ internal fun BottomChipControls(
         // took its full (font-inflated) natural width and the launcher (declared
         // last) was squeezed to zero and clipped off the right edge. Reserving the
         // launcher's fixed width up front (via the constraints math here) keeps the
-        // launcher fully on-screen; the chip area absorbs the squeeze by scrolling.
-        // On a Pixel-class width with the default font the static chips + cluster
-        // fit in the capped area with room to spare (nothing scrolls, every chip
-        // is fully visible — the existing #641 assertions stay green). When tight
-        // (narrow / large system font), the static strip scrolls first and, only
-        // if even an empty static strip can't fit the cluster, the whole chip area
-        // scrolls — the cluster yields by scrolling, never silently dropping a chip
-        // and never pushing the launcher off-screen.
+        // launcher fully on-screen. The static strip yields by scrolling; if the
+        // compact hotkeys keycap lets the primary cluster stay on one line.
         val launcherSlotWidth = if (onDictateTap != null) {
             // Launcher tap target + its end padding (matches the Box padding below).
             PocketShellDensity.tapTargetMin + PocketShellSpacing.sm
@@ -679,16 +707,11 @@ internal fun BottomChipControls(
                             leadingContent = leadingContent,
                         )
                     }
-                    // Primary cluster: high-frequency, pinned to the right of the
-                    // chip area (right-thumb arc, design-system §9 / #208). Natural
-                    // width, but wrapped in its OWN scroll bounded to the chip area
-                    // (`widthIn(max = chipAreaMaxWidth)`): measured before the
-                    // weighted static strip, so it keeps its full width and the
-                    // static strip yields to it; in the extreme narrow / huge-font
-                    // case where the cluster alone exceeds the chip area it yields by
-                    // scrolling WITHIN the cap instead of overflowing into (and
-                    // clipping) the launcher's reserved slot. Every chip stays
-                    // reachable (#813 AC) and the launcher is never clipped.
+                    // The compact keycap keeps the full default-Pixel cluster on
+                    // one line with no scroll. Narrow / large-font configurations
+                    // retain that one-line terminal-space contract but expose a
+                    // real scroll viewport, so accessibility bring-into-view can
+                    // make every primary control fully visible and clickable.
                     Row(
                         modifier = Modifier
                             .widthIn(max = chipAreaMaxWidth)
@@ -1293,6 +1316,7 @@ private fun ImageVector.Builder.addKeyboardPath(fill: SolidColor): ImageVector.B
  * working unchanged.
  */
 internal const val HOTKEYS_CHIP_LABEL: String = "hotkeys"
+internal const val TERMINAL_HOTKEYS_ACCESSIBILITY_LABEL: String = "Terminal hotkeys"
 internal const val HOTKEYS_CHIP_TAG: String = "tmux:hotkeys-launcher"
 
 /**


### PR DESCRIPTION
Closes #887
Closes #1748

## Summary
- keep the terminal viewport geometry stable while the software keyboard opens and closes
- reserve the keyboard-down terminal control footprint and render IME controls as a lifecycle-safe overlay
- strengthen the Live journey and containment/accessibility coverage for terminal, conversation, narrow-font, and raw-SSH paths

## Verification
- `git diff --check`
- `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` (176/176 tasks)
- canonical full JVM gate: 603/603 tasks; 11,478 tests, 0 failures/errors/skips
- final connected matrix: 54 tests, 0 failures/errors/skips
- repeated exact #887 + #641 device proof: 10 tests, 0 failures/errors/skips
- independent review: APPROVED