### PR TITLE
Fix nested Markdown lists and links in file viewer

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -1,23 +1,41 @@
 package com.pocketshell.app.fileviewer
 
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.content.RecordingClipboardManager
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.pdf.PdfDocument
 import android.util.Base64
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.proof.DEFAULT_HOST
@@ -30,6 +48,7 @@ import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLeaseKey
 import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.uikit.theme.PocketShellColors
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
@@ -598,6 +617,324 @@ class FileViewerDockerTest {
         )
     } }
 
+    /**
+     * Issue #1714 real File-viewer journey.
+     *
+     * Provenance is pinned to
+     * DataTalksClub/ai-dev-tools-zoomcamp@132e601061ec3bb46c61a4e594a2bdc431754ca2,
+     * `01-overview/article.md`, blob
+     * 833c847fdd2b94f6ea76d78d8c9ce507e5a67a29, full-file SHA-256
+     * 38703da0717d46fb6b61fb242f7a617e754229f526f02488d686e936b9563383,
+     * reported 2026-07-22. [ISSUE1714_BODY] embeds the exact unordered and
+     * ordered excerpts plus the exact link prose/target under explicitly
+     * synthetic list wrappers; it does not claim to embed the whole article.
+     *
+     * The first rendered and raw-control frames are captured before the first
+     * #1714 structural assertion. Therefore this same source-compatible test on
+     * untouched base produces the required base-wrong screenshot and then fails
+     * at runtime because the complete continued item is not one rendered text
+     * node; it does not rely on fixed-only APIs to manufacture a compile RED.
+     */
+    @Test
+    fun moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl(): Unit { runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val markdownPath = "/tmp/issue1714-module1-$suffix.md"
+        val recordingClipboard = RecordingClipboardManager()
+        val clipboard = object : Clipboard {
+            override val nativeClipboard: android.content.ClipboardManager
+                get() = recordingClipboard
+
+            override suspend fun getClipEntry(): ClipEntry? =
+                recordingClipboard.primaryClip?.let(::ClipEntry)
+
+            override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+                if (clipEntry == null) {
+                    recordingClipboard.clearPrimaryClip()
+                } else {
+                    recordingClipboard.setPrimaryClip(clipEntry.clipData)
+                }
+            }
+        }
+        withTimeout(20_000) {
+            connect()?.use { session ->
+                val body = Base64.encodeToString(ISSUE1714_BODY.toByteArray(), Base64.NO_WRAP)
+                val exit = session.exec("printf '%s' '$body' | base64 -d > '$markdownPath'")
+                assertEquals("seed issue #1714 markdown exit", 0, exit.exitCode)
+                seededPaths += markdownPath
+            } ?: error("could not connect to seed issue #1714 fixture")
+        }
+
+        composeRule.setContent {
+            CompositionLocalProvider(LocalClipboard provides clipboard) {
+                FileViewerScreen(
+                    hostId = TEST_HOST_ID,
+                    hostName = "agents",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyPath = keyFile.absolutePath,
+                    passphrase = null,
+                    remotePath = markdownPath,
+                    cwd = null,
+                    onBack = {},
+                    viewModel = FileViewerViewModel(
+                        InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+                        leasing.manager,
+                    ),
+                )
+            }
+        }
+        composeRule.waitUntil(timeoutMillis = 30_000) {
+            composeRule.onAllNodesWithTag(FILE_VIEWER_MARKDOWN_TAG)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Capture the production rendered observation and raw-source control
+        // before the first structural oracle. On base, the rendered frame is
+        // visibly wrong and the later exact-node assertion is the behavioral RED.
+        composeRule.onNodeWithText(
+            "Feature-level - what a change should do",
+            substring = true,
+        ).performScrollTo()
+        WalkthroughScreenshotArtifacts.capture("issue1714-rendered-before-runtime-assertion")
+        composeRule.onNodeWithTag(FILE_VIEWER_RENDER_MD_TAG).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(FILE_VIEWER_MARKDOWN_TAG)
+                .fetchSemanticsNodes().isEmpty()
+        }
+        composeRule.onNodeWithText(ISSUE1714_BODY).assertExists()
+        WalkthroughScreenshotArtifacts.capture("issue1714-raw-source-control")
+        composeRule.onNodeWithTag(FILE_VIEWER_RENDER_MD_TAG).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(FILE_VIEWER_MARKDOWN_TAG)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val expectedContinuedFeatureBody =
+            "Feature-level - what a change should do and how you'll know it worked, " +
+                "written per task and thrown away after."
+
+        // Load-bearing shared old/new runtime oracle: the production screen
+        // must expose the complete continued item as ONE exact rendered text
+        // node before any fixed-only list tag is consulted. Untouched base
+        // renders the marker line and continuation as separate text nodes.
+        composeRule.onNodeWithText(
+            expectedContinuedFeatureBody,
+            substring = false,
+            useUnmergedTree = true,
+        ).performScrollTo().assertExists()
+
+        // Exact article continuation bodies must belong to their tagged item
+        // bodies. A detached paragraph elsewhere cannot satisfy these oracles.
+        val unorderedBody = listBodyTag("3:1")
+        composeRule.onNodeWithTag(unorderedBody).performScrollTo()
+        assertMarkerText("3:0", "•")
+        assertMarkerText("3:1", "•")
+        assertHangingItem(
+            path = "3:0",
+            expectedBody =
+                "Project-level - what the project is. We create it once and don't modify often.",
+            requireWrap = true,
+        )
+        assertHangingItem(
+            path = "3:1",
+            expectedBody = expectedContinuedFeatureBody,
+            requireWrap = true,
+        )
+        WalkthroughScreenshotArtifacts.capture("issue1714-fixed-unordered")
+
+        // The real production SelectionContainer must still select and copy
+        // Markdown text. Use the platform Copy key action after long-pressing
+        // the body: this avoids both floating-toolbar coordinates and the
+        // unrelated File-viewer header "Copy" / body "Copy all" actions.
+        composeRule.onNodeWithTag(unorderedBody).performTouchInput { longClick() }
+        WalkthroughScreenshotArtifacts.capture("issue1714-fixed-selection")
+        InstrumentationRegistry.getInstrumentation()
+            .sendKeyDownUpSync(android.view.KeyEvent.KEYCODE_COPY)
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            recordingClipboard.lastText != null
+        }
+        val copiedSelection = requireNotNull(recordingClipboard.lastText).trim()
+        assertTrue(
+            "system Copy must put non-blank Markdown text on the clipboard",
+            copiedSelection.isNotEmpty(),
+        )
+        assertTrue(
+            "clipboard payload must come from the continued Feature-level item, was: $copiedSelection",
+            expectedContinuedFeatureBody.contains(copiedSelection),
+        )
+        // The exact article link prose is synthetically nested/continued to
+        // cover the list class. Its body keeps the annotation, accent/underline
+        // style, and exact HTTPS ACTION_VIEW target.
+        val linkPath = "1:0:0:0"
+        val linkBody = composeRule.onNodeWithTag(listBodyTag(linkPath))
+        linkBody.performScrollTo()
+        assertMarkerText(linkPath, "7.")
+        assertHangingItem(
+            path = linkPath,
+            expectedBody = ISSUE1714_LINK_BODY,
+            requireWrap = true,
+        )
+        val linkText = annotatedText(listBodyTag(linkPath))
+        val linkAnnotation = linkText.getStringAnnotations(
+            tag = MD_URL_TAG_FOR_TEST,
+            start = 0,
+            end = linkText.length,
+        ).single()
+        assertEquals(ISSUE1714_URL, linkAnnotation.item)
+        val linkStyle = linkText.spanStyles.single { range ->
+            range.start == linkAnnotation.start &&
+                range.end == linkAnnotation.end &&
+                range.item.textDecoration == TextDecoration.Underline
+        }
+        assertEquals(PocketShellColors.Accent, linkStyle.item.color)
+        assertEquals(TextDecoration.Underline, linkStyle.item.textDecoration)
+
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val monitor = object : Instrumentation.ActivityMonitor() {
+            @Volatile
+            var startedIntent: Intent? = null
+
+            override fun onStartActivity(intent: Intent): Instrumentation.ActivityResult {
+                startedIntent = Intent(intent)
+                return Instrumentation.ActivityResult(Activity.RESULT_CANCELED, null)
+            }
+        }
+        instrumentation.addMonitor(monitor)
+        try {
+            val layout = textLayout(listBodyTag(linkPath))
+            val linkOffset = layout.layoutInput.text.text.indexOf("SQLiteSearch")
+            assertTrue("link label must be in the tagged continued body", linkOffset >= 0)
+            linkBody.performTouchInput { click(layout.getBoundingBox(linkOffset).center) }
+            composeRule.waitUntil(timeoutMillis = 5_000) { monitor.startedIntent != null }
+            val started = requireNotNull(monitor.startedIntent)
+            assertEquals(Intent.ACTION_VIEW, started.action)
+            assertEquals(ISSUE1714_URL, started.dataString)
+        } finally {
+            instrumentation.removeMonitor(monitor)
+        }
+        WalkthroughScreenshotArtifacts.capture("issue1714-fixed-continued-link")
+
+        // Exact ordered article markers and complete bodies.
+        composeRule.onNodeWithTag(listBodyTag("7:3")).performScrollTo()
+        assertMarkerText("7:0", "1.")
+        assertMarkerText("7:3", "4.")
+        assertHangingItem(
+            path = "7:1",
+            expectedBody =
+                "Acceptance criteria - checkable statements. Not \"it works\" but things " +
+                    "where you can point at the screen and say yes or no.",
+            requireWrap = true,
+        )
+        assertHangingItem(
+            path = "7:3",
+            expectedBody =
+                "Constraints - files it should stay inside, libraries it may not add, " +
+                    "patterns it must follow.",
+            requireWrap = true,
+        )
+        WalkthroughScreenshotArtifacts.capture("issue1714-fixed-ordered")
+
+        // Synthetic class coverage: mixed kinds, fifth-level ownership, source
+        // 7/42 ordinals, and an intrinsic nine-digit marker. A fixed marker
+        // column mutation makes the one- and nine-digit widths equal and fails.
+        val widePath = "5:0:0:1"
+        composeRule.onNodeWithTag(listBodyTag(widePath)).performScrollTo()
+        assertMarkerText("5:0:0:0", "7.")
+        assertMarkerText("5:0:0:0:0:0:0:0", "42.")
+        assertMarkerText(widePath, "123456789.")
+        assertHangingItem(
+            path = widePath,
+            expectedBody = "wide ordered sibling",
+            requireWrap = false,
+        )
+        val oneDigitMarker = bounds(listMarkerTag("5:0:0:0"))
+        val wideMarker = bounds(listMarkerTag(widePath))
+        assertTrue(
+            "intrinsic marker width must grow for nine digits: one=$oneDigitMarker wide=$wideMarker",
+            wideMarker.width > oneDigitMarker.width,
+        )
+
+        val deepestPath = "5:0:0:0:0:0:0:0:0:0"
+        composeRule.onNodeWithTag(listBodyTag(deepestPath)).performScrollTo()
+        assertMarkerText(deepestPath, "•")
+        assertHangingItem(
+            path = deepestPath,
+            expectedBody = "fifth level is not clamped",
+            requireWrap = false,
+        )
+        WalkthroughScreenshotArtifacts.capture("issue1714-fixed-wide-deep-containment")
+    } }
+
+    private fun assertMarkerText(path: String, expected: String) {
+        assertEquals(expected, annotatedText(listMarkerTag(path)).text)
+    }
+
+    private fun assertHangingItem(
+        path: String,
+        expectedBody: String,
+        requireWrap: Boolean,
+    ) {
+        val markerBounds = bounds(listMarkerTag(path))
+        val bodyTag = listBodyTag(path)
+        val bodyBounds = bounds(bodyTag)
+        val viewport = bounds(FILE_VIEWER_TEXT_TAG)
+        assertEquals(
+            "complete body must belong to tagged item $path",
+            expectedBody,
+            annotatedText(bodyTag).text,
+        )
+        assertTrue(
+            "marker/body must not overlap for $path: marker=$markerBounds body=$bodyBounds",
+            markerBounds.right <= bodyBounds.left,
+        )
+        assertTrue(
+            "marker must stay in viewport for $path: marker=$markerBounds viewport=$viewport",
+            markerBounds.left >= viewport.left && markerBounds.right <= viewport.right,
+        )
+        assertTrue(
+            "body must stay in viewport for $path: body=$bodyBounds viewport=$viewport",
+            bodyBounds.left >= viewport.left && bodyBounds.right <= viewport.right,
+        )
+
+        val layout = textLayout(bodyTag)
+        if (requireWrap) {
+            assertTrue("body $path must wrap to prove hanging alignment", layout.lineCount > 1)
+        }
+        val firstLeft = layout.getLineLeft(0).toDouble()
+        repeat(layout.lineCount) { line ->
+            assertEquals(
+                "every wrapped line in body $path must share the body-column left edge",
+                firstLeft,
+                layout.getLineLeft(line).toDouble(),
+                0.5,
+            )
+        }
+    }
+
+    private fun annotatedText(tag: String): AnnotatedString {
+        val node = composeRule.onNodeWithTag(tag).fetchSemanticsNode()
+        return node.config.getOrNull(SemanticsProperties.Text)?.single()
+            ?: error("$tag had no unique annotated text semantics")
+    }
+
+    private fun textLayout(tag: String): TextLayoutResult {
+        val node = composeRule.onNodeWithTag(tag).fetchSemanticsNode()
+        val action = node.config.getOrNull(SemanticsActions.GetTextLayoutResult)
+            ?: error("$tag had no text-layout semantics action")
+        val results = mutableListOf<TextLayoutResult>()
+        assertTrue("$tag text-layout action must succeed", action.action?.invoke(results) == true)
+        return results.single()
+    }
+
+    private fun bounds(tag: String): Rect =
+        composeRule.onNodeWithTag(tag).fetchSemanticsNode().boundsInRoot
+
+    // Kept local and literal so this connected RED remains source-compatible
+    // with untouched base, where production does not yet expose these tags.
+    private fun listMarkerTag(path: String): String = "fileViewerMarkdownListMarker:$path"
+    private fun listBodyTag(path: String): String = "fileViewerMarkdownListBody:$path"
+
     private suspend fun connect() = SshConnection.connect(
         host = DEFAULT_HOST,
         port = DEFAULT_PORT,
@@ -687,6 +1024,62 @@ class FileViewerDockerTest {
          * transport.
          */
         const val TEST_HOST_ID: Long = 497L
+
+        const val MD_URL_TAG_FOR_TEST = "md_url"
+        const val ISSUE1714_URL =
+            "https://alexeyondata.substack.com/p/how-i-built-sqlitesearch-a-lightweight"
+        const val ISSUE1714_LINK_BODY =
+            "This is how I built SQLiteSearch, a small SQLite-backed search library. " +
+                "First a long chat session to get the design straight, then I downloaded " +
+                "the plan.md file and started coding. That file had all five sections: " +
+                "what the library is, how it differs from minsearch, when you should use " +
+                "it, when you shouldn't, and the architecture."
+
+        /**
+         * #1714 connected fixture. The two specifications/task-section excerpts
+         * retain the exact issue-time source lines. The SQLiteSearch prose and
+         * URL also come from exact source lines 95-101, but are intentionally
+         * indented beneath synthetic unordered/ordered markers to cover a
+         * continued nested link. The mixed/deep/wide section is wholly
+         * synthetic class coverage. This is not the complete article.
+         */
+        val ISSUE1714_BODY = """
+            # Synthetic nested-link class extension
+
+            - Synthetic list wrapper
+              7. This is how I built
+                 [SQLiteSearch]($ISSUE1714_URL),
+                 a small SQLite-backed search library. First a long chat session to get
+                 the design straight, then I downloaded the `plan.md` file and started
+                 coding. That file had all five sections: what the library is, how it
+                 differs from `minsearch`, when you should use it, when you shouldn't,
+                 and the architecture.
+
+            There are two levels of specifications:
+
+            - Project-level - what the project is. We create it once and don't
+              modify often.
+            - Feature-level - what a change should do and how you'll know it
+              worked, written per task and thrown away after.
+
+            ## Synthetic mixed, deep, and wide class coverage
+
+            + root
+              7) ordered child
+                 * unordered grandchild
+                   42. ordered great-grandchild
+                       + fifth level is not clamped
+              123456789) wide ordered sibling
+
+            Every task has four sections:
+
+            1. Goal - one or two sentences on what should be true afterwards.
+            2. Acceptance criteria - checkable statements. Not "it works" but
+               things where you can point at the screen and say yes or no.
+            3. Out of scope - what this change must not do.
+            4. Constraints - files it should stay inside, libraries it may not
+               add, patterns it must follow.
+        """.trimIndent()
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownModel.kt
@@ -43,11 +43,21 @@ internal sealed interface MarkdownBlock {
     data class CodeBlock(val language: String, val content: String) : MarkdownBlock
 
     /**
-     * A list (ordered or unordered). Each item carries its inline spans and a
-     * nesting [Item.indentLevel] (0 = top level).
+     * A structural ordered or unordered list.
+     *
+     * Each [Item] owns its complete soft-continued inline body and its nested
+     * child lists. Child kind lives on each child [ListBlock], preserving mixed
+     * ordered/unordered nesting instead of flattening structure into an indent
+     * number. Ordered item [Item.ordinal] values come from the source.
      */
-    data class ListBlock(val ordered: Boolean, val items: List<Item>) : MarkdownBlock {
-        data class Item(val indentLevel: Int, val ordinal: Int?, val spans: List<InlineSpan>)
+    data class ListBlock(val kind: Kind, val items: List<Item>) : MarkdownBlock {
+        enum class Kind { ORDERED, UNORDERED }
+
+        data class Item(
+            val ordinal: Int?,
+            val spans: List<InlineSpan>,
+            val children: List<ListBlock> = emptyList(),
+        )
     }
 
     /** A `>` block quote; [spans] is the inline content of the quoted text. */

--- a/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownParser.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownParser.kt
@@ -163,34 +163,13 @@ internal object MarkdownParser {
                 continue
             }
 
-            // List (ordered or unordered) — consume consecutive item lines.
-            if (UL_ITEM.matchEntire(line) != null || OL_ITEM.matchEntire(line) != null) {
-                val items = mutableListOf<MarkdownBlock.ListBlock.Item>()
-                val ordered = OL_ITEM.matchEntire(line) != null
-                while (i < lines.size) {
-                    val ul = UL_ITEM.matchEntire(lines[i])
-                    val ol = OL_ITEM.matchEntire(lines[i])
-                    when {
-                        ol != null && ordered -> {
-                            items += MarkdownBlock.ListBlock.Item(
-                                indentLevel = indentLevel(ol.groupValues[1]),
-                                ordinal = ol.groupValues[2].toIntOrNull(),
-                                spans = parseInline(ol.groupValues[3]),
-                            )
-                            i++
-                        }
-                        ul != null && !ordered -> {
-                            items += MarkdownBlock.ListBlock.Item(
-                                indentLevel = indentLevel(ul.groupValues[1]),
-                                ordinal = null,
-                                spans = parseInline(ul.groupValues[3]),
-                            )
-                            i++
-                        }
-                        else -> break
-                    }
-                }
-                blocks += MarkdownBlock.ListBlock(ordered = ordered, items = items)
+            // Structural list. A marker owns its indented soft-continuation
+            // prose; deeper markers become child list blocks. This preserves
+            // complete item bodies, mixed nesting, and source ordinals (#1714).
+            if (listMarker(line) != null) {
+                val parsed = parseList(lines, i)
+                blocks += parsed.block
+                i = parsed.nextIndex
                 continue
             }
 
@@ -225,9 +204,130 @@ internal object MarkdownParser {
         return blocks
     }
 
-    private fun indentLevel(leading: String): Int {
-        val width = leading.fold(0) { acc, c -> acc + if (c == '\t') 4 else 1 }
-        return (width / 2).coerceAtMost(4)
+    private data class ListMarker(
+        val indent: Int,
+        val kind: MarkdownBlock.ListBlock.Kind,
+        val ordinal: Int?,
+        val body: String,
+    )
+
+    private data class MutableListItem(
+        val ordinal: Int?,
+        val bodyLines: MutableList<String>,
+        val children: MutableList<MarkdownBlock.ListBlock> = mutableListOf(),
+    )
+
+    private data class ParsedList(
+        val block: MarkdownBlock.ListBlock,
+        val nextIndex: Int,
+    )
+
+    /**
+     * Parses one list whose sibling markers share the first marker's indentation
+     * and kind. Deeper markers recursively become children of the current item;
+     * an outdent or same-depth kind switch returns to the caller.
+     *
+     * Supported block starts take precedence over marker-shaped lines: indented
+     * thematic rules such as `* * *` and `- - -` must close the list rather than
+     * become nested unordered items. An indented non-marker line is a soft
+     * continuation only until a blank or another supported block start.
+     * Loose/multi-paragraph items and block contents inside list items remain
+     * outside this bounded Markdown subset. Recursion follows source structure
+     * and deliberately has no depth clamp.
+     */
+    private fun parseList(lines: List<String>, start: Int): ParsedList {
+        val first = requireNotNull(listMarker(lines[start]))
+        val baseIndent = first.indent
+        val kind = first.kind
+        val items = mutableListOf<MutableListItem>()
+        var current: MutableListItem? = null
+        var i = start
+
+        while (i < lines.size) {
+            val line = lines[i]
+            if (line.isBlank() || isSupportedBlockStart(lines, i)) break
+
+            val marker = listMarker(line)
+            if (marker != null) {
+                when {
+                    marker.indent < baseIndent -> break
+                    marker.indent == baseIndent && marker.kind != kind -> break
+                    marker.indent == baseIndent -> {
+                        current = MutableListItem(
+                            ordinal = marker.ordinal,
+                            bodyLines = mutableListOf(marker.body.trim()),
+                        )
+                        items += current
+                        i++
+                    }
+                    else -> {
+                        val owner = current ?: break
+                        val child = parseList(lines, i)
+                        owner.children += child.block
+                        i = child.nextIndex
+                    }
+                }
+                continue
+            }
+
+            val leadingIndent = indentationWidth(line.takeWhile { it == ' ' || it == '\t' })
+            if (leadingIndent <= baseIndent) break
+
+            val owner = current ?: break
+            owner.bodyLines += line.trim()
+            i++
+        }
+
+        return ParsedList(
+            block = MarkdownBlock.ListBlock(
+                kind = kind,
+                items = items.map { item ->
+                    MarkdownBlock.ListBlock.Item(
+                        ordinal = item.ordinal,
+                        spans = parseInline(item.bodyLines.joinToString(" ")),
+                        children = item.children.toList(),
+                    )
+                },
+            ),
+            nextIndex = i,
+        )
+    }
+
+    private fun listMarker(line: String): ListMarker? {
+        OL_ITEM.matchEntire(line)?.let { match ->
+            return ListMarker(
+                indent = indentationWidth(match.groupValues[1]),
+                kind = MarkdownBlock.ListBlock.Kind.ORDERED,
+                ordinal = match.groupValues[2].toIntOrNull(),
+                body = match.groupValues[3],
+            )
+        }
+        UL_ITEM.matchEntire(line)?.let { match ->
+            return ListMarker(
+                indent = indentationWidth(match.groupValues[1]),
+                kind = MarkdownBlock.ListBlock.Kind.UNORDERED,
+                ordinal = null,
+                body = match.groupValues[3],
+            )
+        }
+        return null
+    }
+
+    private fun indentationWidth(leading: String): Int =
+        leading.fold(0) { width, char -> width + if (char == '\t') 4 else 1 }
+
+    private fun isSupportedBlockStart(lines: List<String>, index: Int): Boolean {
+        val line = lines[index]
+        return FENCE.matchEntire(line) != null ||
+            isThematicBreak(line) ||
+            ATX.matchEntire(line) != null ||
+            BLOCKQUOTE.matchEntire(line) != null ||
+            (
+                line.contains('|') &&
+                    index + 1 < lines.size &&
+                    isTableDelimiterRow(lines[index + 1]) &&
+                    splitTableRow(lines[index + 1]).size == splitTableRow(line).size
+                )
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownView.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/MarkdownView.kt
@@ -43,6 +43,10 @@ const val FILE_VIEWER_MARKDOWN_TAG = "fileViewerMarkdown"
 /** Test tag for a rendered Markdown pipe table (issue #921). */
 const val FILE_VIEWER_MARKDOWN_TABLE_TAG = "fileViewerMarkdownTable"
 
+/** Stable semantics tags for structural list marker/body geometry (#1714). */
+private fun markdownListMarkerTag(path: String): String = "fileViewerMarkdownListMarker:$path"
+private fun markdownListBodyTag(path: String): String = "fileViewerMarkdownListBody:$path"
+
 /** The clickable-text URL annotation tag for Markdown links. */
 private const val MD_URL_TAG = "md_url"
 
@@ -50,9 +54,9 @@ private const val MD_URL_TAG = "md_url"
  * Renders parsed [MarkdownBlock]s into a themed Compose column (issue #696).
  *
  * Headers scale by level, fenced code blocks are monospaced on a tinted
- * surface with their own horizontal scroll, lists are bulleted/numbered with
- * indentation, links are tappable (open in the browser), and bold/italic/
- * strikethrough/inline-code carry through. Block layout always wraps to the
+ * surface with their own horizontal scroll, recursive lists use hanging
+ * marker/body columns, links are tappable (open in the browser), and bold/
+ * italic/strikethrough/inline-code carry through. Block layout always wraps to the
  * viewport; only fenced code keeps a horizontal scroll so a wide code line is
  * still readable. Styling is derived from [PocketShellColors] so it matches the
  * rest of the app.
@@ -68,12 +72,12 @@ internal fun MarkdownView(
             .padding(horizontal = 16.dp, vertical = 12.dp)
             .testTag(FILE_VIEWER_MARKDOWN_TAG),
     ) {
-        blocks.forEach { block ->
+        blocks.forEachIndexed { blockIndex, block ->
             when (block) {
                 is MarkdownBlock.Heading -> HeadingBlock(block)
                 is MarkdownBlock.Paragraph -> ParagraphBlock(block.spans)
                 is MarkdownBlock.CodeBlock -> CodeBlock(block)
-                is MarkdownBlock.ListBlock -> ListBlock(block)
+                is MarkdownBlock.ListBlock -> ListBlock(block, path = blockIndex.toString())
                 is MarkdownBlock.BlockQuote -> BlockQuoteBlock(block)
                 is MarkdownBlock.Table -> TableBlock(block)
                 MarkdownBlock.HorizontalRule -> HorizontalRuleBlock()
@@ -137,25 +141,54 @@ private fun CodeBlock(block: MarkdownBlock.CodeBlock) {
 }
 
 @Composable
-private fun ListBlock(block: MarkdownBlock.ListBlock) {
+private fun ListBlock(
+    block: MarkdownBlock.ListBlock,
+    path: String,
+) {
     Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
         block.items.forEachIndexed { index, item ->
-            val marker = if (block.ordered) {
-                "${item.ordinal ?: (index + 1)}. "
+            val itemPath = "$path:$index"
+            val marker = if (block.kind == MarkdownBlock.ListBlock.Kind.ORDERED) {
+                "${item.ordinal ?: (index + 1)}."
             } else {
-                "• "
+                "•"
             }
-            LinkableText(
-                text = buildAnnotatedString {
-                    withStyle(SpanStyle(color = PocketShellColors.TextSecondary)) {
-                        append(marker)
-                    }
-                    append(annotated(item.spans))
-                },
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = (12 * (item.indentLevel + 1)).dp, top = 2.dp, bottom = 2.dp),
-            )
+                    .padding(vertical = 2.dp),
+            ) {
+                // No fixed marker width: the marker measures intrinsically, so
+                // a supported nine-digit source ordinal cannot overlap its
+                // body. The separate weighted body is the hanging column; all
+                // of its wrapped lines therefore share the same left edge.
+                Text(
+                    text = marker,
+                    color = PocketShellColors.TextSecondary,
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    softWrap = false,
+                    textAlign = TextAlign.End,
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .testTag(markdownListMarkerTag(itemPath)),
+                )
+                LinkableText(
+                    text = annotated(item.spans),
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag(markdownListBodyTag(itemPath)),
+                )
+            }
+            item.children.forEachIndexed { childIndex, child ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 12.dp),
+                ) {
+                    ListBlock(child, path = "$itemPath:$childIndex")
+                }
+            }
         }
     }
 }

--- a/app/src/test/java/com/pocketshell/app/fileviewer/MarkdownParserTest.kt
+++ b/app/src/test/java/com/pocketshell/app/fileviewer/MarkdownParserTest.kt
@@ -11,6 +11,86 @@ import org.junit.Test
  */
 class MarkdownParserTest {
 
+    /**
+     * Base-compatible D33/G10 runtime regression for issue #1714. This method
+     * intentionally uses only model observables present before and after the
+     * structural hard cut (`ListBlock.items`, `Item.spans`, and `Paragraph`),
+     * so applying this test to untouched base fails behaviorally rather than at
+     * compilation.
+     *
+     * Exact issue-time excerpt from
+     * DataTalksClub/ai-dev-tools-zoomcamp@132e601061ec3bb46c61a4e594a2bdc431754ca2,
+     * `01-overview/article.md` lines 48-53, blob
+     * 833c847fdd2b94f6ea76d78d8c9ce507e5a67a29. The full article SHA-256 is
+     * 38703da0717d46fb6b61fb242f7a617e754229f526f02488d686e936b9563383;
+     * the report date is 2026-07-22. Only this excerpt is embedded here.
+     */
+    @Test
+    fun `issue 1714 exact unordered excerpt owns both continued item bodies`() {
+        val source = """
+            There are two levels of specifications:
+
+            - Project-level - what the project is. We create it once and don't
+              modify often.
+            - Feature-level - what a change should do and how you'll know it
+              worked, written per task and thrown away after.
+        """.trimIndent()
+
+        val blocks = MarkdownParser.parse(source)
+        val list = blocks.filterIsInstance<MarkdownBlock.ListBlock>().single()
+        assertEquals(2, list.items.size)
+        assertEquals(
+            "Project-level - what the project is. We create it once and don't modify often.",
+            inlineText(list.items[0].spans),
+        )
+        assertEquals(
+            "Feature-level - what a change should do and how you'll know it worked, " +
+                "written per task and thrown away after.",
+            inlineText(list.items[1].spans),
+        )
+        assertTrue(
+            "continuations must not escape into detached paragraphs",
+            blocks.filterIsInstance<MarkdownBlock.Paragraph>().none {
+                inlineText(it.spans).startsWith("modify often") ||
+                    inlineText(it.spans).startsWith("worked, written")
+            },
+        )
+    }
+
+    /**
+     * Second exact excerpt from the same pinned source, lines 156-163. Like the
+     * unordered test, this remains source-compatible with the flat base model
+     * and fails on base because physical continuations split the four-item list.
+     */
+    @Test
+    fun `issue 1714 exact ordered excerpt owns all four continued item bodies`() {
+        val source = """
+            Every task has four sections:
+
+            1. Goal - one or two sentences on what should be true afterwards.
+            2. Acceptance criteria - checkable statements. Not "it works" but
+               things where you can point at the screen and say yes or no.
+            3. Out of scope - what this change must not do.
+            4. Constraints - files it should stay inside, libraries it may not
+               add, patterns it must follow.
+        """.trimIndent()
+
+        val blocks = MarkdownParser.parse(source)
+        val list = blocks.filterIsInstance<MarkdownBlock.ListBlock>().single()
+        assertEquals(4, list.items.size)
+        assertEquals(listOf(1, 2, 3, 4), list.items.map { it.ordinal })
+        assertEquals(
+            "Acceptance criteria - checkable statements. Not \"it works\" but things " +
+                "where you can point at the screen and say yes or no.",
+            inlineText(list.items[1].spans),
+        )
+        assertEquals(
+            "Constraints - files it should stay inside, libraries it may not add, " +
+                "patterns it must follow.",
+            inlineText(list.items[3].spans),
+        )
+    }
+
     @Test
     fun `markdown extensions are detected, others are not`() {
         assertTrue(MarkdownParser.isMarkdownPath("/home/me/README.md"))
@@ -48,19 +128,262 @@ class MarkdownParserTest {
     fun `unordered list items parse with nesting`() {
         val blocks = MarkdownParser.parse("- one\n- two\n  - nested")
         val list = blocks.single() as MarkdownBlock.ListBlock
-        assertFalse(list.ordered)
-        assertEquals(3, list.items.size)
-        assertEquals(0, list.items[0].indentLevel)
-        assertTrue(list.items[2].indentLevel >= 1)
+        assertEquals("UNORDERED", listKindName(list))
+        assertEquals(2, list.items.size)
+        assertTrue(childrenOf(list.items[0]).isEmpty())
+        val child = childrenOf(list.items[1]).single()
+        assertEquals("UNORDERED", listKindName(child))
+        assertEquals("nested", inlineText(child.items.single().spans))
     }
 
     @Test
     fun `ordered list keeps ordinals`() {
         val blocks = MarkdownParser.parse("1. first\n2. second")
         val list = blocks.single() as MarkdownBlock.ListBlock
-        assertTrue(list.ordered)
+        assertEquals("ORDERED", listKindName(list))
         assertEquals(1, list.items[0].ordinal)
         assertEquals(2, list.items[1].ordinal)
+    }
+
+    @Test
+    fun `mixed list kinds retain parentage marker dialects and source ordinals`() {
+        val source = """
+            - unordered root
+              7) ordered child
+                 * unordered grandchild
+                   42. ordered great-grandchild
+                       + plus-marker fifth level
+              123456789) wide ordered sibling
+            * star-marker root sibling
+
+            4. ordered root
+               - unordered below ordered
+                 9) ordered below unordered again
+        """.trimIndent()
+
+        val roots = MarkdownParser.parse(source).filterIsInstance<MarkdownBlock.ListBlock>()
+        assertEquals(2, roots.size)
+
+        val unorderedRoot = roots[0]
+        assertEquals("UNORDERED", listKindName(unorderedRoot))
+        assertEquals(2, unorderedRoot.items.size)
+        val orderedChild = childrenOf(unorderedRoot.items[0]).single()
+        assertEquals("ORDERED", listKindName(orderedChild))
+        assertEquals(listOf(7, 123456789), orderedChild.items.map { it.ordinal })
+        val unorderedGrandchild = childrenOf(orderedChild.items[0]).single()
+        assertEquals("UNORDERED", listKindName(unorderedGrandchild))
+        val orderedGreatGrandchild = childrenOf(unorderedGrandchild.items.single()).single()
+        assertEquals("ORDERED", listKindName(orderedGreatGrandchild))
+        assertEquals(42, orderedGreatGrandchild.items.single().ordinal)
+        val plusMarkerLevel = childrenOf(orderedGreatGrandchild.items.single()).single()
+        assertEquals("UNORDERED", listKindName(plusMarkerLevel))
+        assertEquals("plus-marker fifth level", inlineText(plusMarkerLevel.items.single().spans))
+
+        val orderedRoot = roots[1]
+        assertEquals("ORDERED", listKindName(orderedRoot))
+        assertEquals(4, orderedRoot.items.single().ordinal)
+        val unorderedChild = childrenOf(orderedRoot.items.single()).single()
+        assertEquals("UNORDERED", listKindName(unorderedChild))
+        val orderedGrandchild = childrenOf(unorderedChild.items.single()).single()
+        assertEquals("ORDERED", listKindName(orderedGrandchild))
+        assertEquals(9, orderedGrandchild.items.single().ordinal)
+    }
+
+    @Test
+    fun `recursive list parser has no four-level depth clamp`() {
+        val depth = 12
+        val source = buildString {
+            repeat(depth) { level ->
+                append("  ".repeat(level))
+                if (level % 2 == 0) {
+                    append("-")
+                } else {
+                    append("${level * 10 + 7}.")
+                }
+                append(" depth-").append(level).append('\n')
+            }
+        }
+
+        var list = MarkdownParser.parse(source).single() as MarkdownBlock.ListBlock
+        repeat(depth) { level ->
+            val expectedKind = if (level % 2 == 0) "UNORDERED" else "ORDERED"
+            assertEquals("kind at depth $level", expectedKind, listKindName(list))
+            assertEquals("depth-$level", inlineText(list.items.single().spans))
+            if (level < depth - 1) {
+                list = childrenOf(list.items.single()).single()
+            } else {
+                assertTrue(childrenOf(list.items.single()).isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun `continuations stay with their current sibling only`() {
+        val source = """
+            - first physical line
+              first continuation
+            - second physical line
+              second continuation
+        """.trimIndent()
+
+        val list = MarkdownParser.parse(source).single() as MarkdownBlock.ListBlock
+        assertEquals(
+            listOf(
+                "first physical line first continuation",
+                "second physical line second continuation",
+            ),
+            list.items.map { inlineText(it.spans) },
+        )
+    }
+
+    @Test
+    fun `every supported block boundary and outdent closes continuation ownership`() {
+        val cases = listOf(
+            BoundaryCase(
+                name = "blank paragraph",
+                source = "- item\n  owned continuation\n\n  detached paragraph",
+                followingType = "Paragraph",
+            ),
+            BoundaryCase(
+                name = "heading",
+                source = "- item\n  owned continuation\n  ## detached heading",
+                followingType = "Heading",
+            ),
+            BoundaryCase(
+                name = "fence",
+                source = "- item\n  owned continuation\n  ```text\n  detached code\n  ```",
+                followingType = "CodeBlock",
+            ),
+            BoundaryCase(
+                name = "table",
+                source = "- item\n  owned continuation\n  | A | B |\n  |---|---|\n  | 1 | 2 |",
+                followingType = "Table",
+            ),
+            BoundaryCase(
+                name = "blockquote",
+                source = "- item\n  owned continuation\n  > detached quote",
+                followingType = "BlockQuote",
+            ),
+            BoundaryCase(
+                name = "thematic rule",
+                source = "- item\n  owned continuation\n  ---",
+                followingType = "HorizontalRule",
+            ),
+            BoundaryCase(
+                name = "outdent paragraph",
+                source = "- item\n  owned continuation\nDetached outdent",
+                followingType = "Paragraph",
+            ),
+        )
+
+        cases.forEach { case ->
+            val blocks = MarkdownParser.parse(case.source)
+            val list = blocks.first() as MarkdownBlock.ListBlock
+            assertEquals(case.name, "item owned continuation", inlineText(list.items.single().spans))
+            assertEquals(case.name, case.followingType, blocks[1]::class.simpleName)
+        }
+    }
+
+    /**
+     * Reviewer regression for #1714: both rule spellings also match `UL_ITEM`'s
+     * marker shape when indented. Boundary recognition must win before recursive
+     * list-marker recognition, leaving the owning body, rule, and outdented
+     * paragraph as three separate structures.
+     */
+    @Test
+    fun `indented star and dash thematic rules are boundaries not nested list items`() {
+        listOf("* * *", "- - -").forEach { rule ->
+            val blocks = MarkdownParser.parse(
+                "- item\n  owned continuation\n  $rule\nFollowing paragraph",
+            )
+
+            assertEquals("block sequence for $rule", 3, blocks.size)
+            val list = blocks[0] as MarkdownBlock.ListBlock
+            assertEquals(
+                "list body before $rule",
+                "item owned continuation",
+                inlineText(list.items.single().spans),
+            )
+            assertTrue("$rule must be a thematic rule", blocks[1] === MarkdownBlock.HorizontalRule)
+            val paragraph = blocks[2] as MarkdownBlock.Paragraph
+            assertEquals(
+                "paragraph after $rule",
+                "Following paragraph",
+                inlineText(paragraph.spans),
+            )
+        }
+    }
+
+    @Test
+    fun `nested outdent returns ownership to the correct ancestor and sibling`() {
+        val source = """
+            - parent
+              7. child
+                 child continuation
+              42. child sibling
+            - root sibling
+        """.trimIndent()
+
+        val root = MarkdownParser.parse(source).single() as MarkdownBlock.ListBlock
+        assertEquals(2, root.items.size)
+        val child = childrenOf(root.items[0]).single()
+        assertEquals(listOf(7, 42), child.items.map { it.ordinal })
+        assertEquals("child child continuation", inlineText(child.items[0].spans))
+        assertEquals("child sibling", inlineText(child.items[1].spans))
+        assertEquals("root sibling", inlineText(root.items[1].spans))
+    }
+
+    /**
+     * The real article's lines 95-101 are a paragraph, not a list. This exact
+     * excerpt pins the URL provenance; the separate synthetic test below moves
+     * the same prose/link under mixed nested list markers to cover #1714's list
+     * ownership class without claiming that the source article did so.
+     */
+    @Test
+    fun `issue 1714 exact soft-wrapped article link keeps its target`() {
+        val source = """
+            This is how I built
+            [SQLiteSearch](https://alexeyondata.substack.com/p/how-i-built-sqlitesearch-a-lightweight),
+            a small SQLite-backed search library. First a long chat session to get
+            the design straight, then I downloaded the `plan.md` file and started
+            coding. That file had all five sections: what the library is, how it
+            differs from `minsearch`, when you should use it, when you shouldn't,
+            and the architecture.
+        """.trimIndent()
+        val paragraph = MarkdownParser.parse(source).single() as MarkdownBlock.Paragraph
+        assertEquals(
+            ISSUE1714_LINK_BODY,
+            inlineText(paragraph.spans),
+        )
+        assertEquals(
+            ISSUE1714_LINK,
+            paragraph.spans.filterIsInstance<InlineSpan.Link>().single().url,
+        )
+    }
+
+    @Test
+    fun `synthetic continued nested item keeps complete body and exact link`() {
+        val source = """
+            - synthetic root
+              7. This is how I built
+                 [SQLiteSearch]($ISSUE1714_LINK),
+                 a small SQLite-backed search library. First a long chat session to get
+                 the design straight, then I downloaded the `plan.md` file and started
+                 coding. That file had all five sections: what the library is, how it
+                 differs from `minsearch`, when you should use it, when you shouldn't,
+                 and the architecture.
+        """.trimIndent()
+
+        val root = MarkdownParser.parse(source).single() as MarkdownBlock.ListBlock
+        val nested = childrenOf(root.items.single()).single().items.single()
+        assertEquals(
+            ISSUE1714_LINK_BODY,
+            inlineText(nested.spans),
+        )
+        assertEquals(
+            ISSUE1714_LINK,
+            nested.spans.filterIsInstance<InlineSpan.Link>().single().url,
+        )
     }
 
     @Test
@@ -327,5 +650,60 @@ class MarkdownParserTest {
         // Header has 2 columns, delimiter has 3 — not a table.
         val blocks = MarkdownParser.parse("| a | b |\n|---|---|---|\n| 1 | 2 |")
         assertTrue("mismatched column count must not parse as a table", blocks.none { it is MarkdownBlock.Table })
+    }
+
+    /**
+     * Returns the structural kind through runtime observation so the whole test
+     * source remains compilable on the pre-#1714 flat model. On that base,
+     * `getOrdered()` supplies the legacy observation and structural tests fail
+     * at runtime because parentage is absent; on fixed code `getKind()` is used.
+     */
+    private fun listKindName(list: MarkdownBlock.ListBlock): String {
+        val kindGetter = list.javaClass.methods.firstOrNull {
+            it.name == "getKind" && it.parameterCount == 0
+        }
+        if (kindGetter != null) return kindGetter.invoke(list).toString()
+        val ordered = list.javaClass.methods.first {
+            it.name == "getOrdered" && it.parameterCount == 0
+        }.invoke(list) as Boolean
+        return if (ordered) "ORDERED" else "UNORDERED"
+    }
+
+    /**
+     * Same base-compatibility device for child ownership. The old item has no
+     * `children` property, so it observes an empty list and fails structural
+     * assertions behaviorally rather than making the RED patch uncompilable.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun childrenOf(item: Any): List<MarkdownBlock.ListBlock> {
+        val getter = item.javaClass.methods.firstOrNull {
+            it.name == "getChildren" && it.parameterCount == 0
+        } ?: return emptyList()
+        return getter.invoke(item) as List<MarkdownBlock.ListBlock>
+    }
+
+    private fun inlineText(spans: List<InlineSpan>): String = spans.joinToString("") { span ->
+        when (span) {
+            is InlineSpan.Text -> span.text
+            is InlineSpan.Code -> span.text
+            is InlineSpan.Link -> span.label.ifEmpty { span.url }
+        }
+    }
+
+    private data class BoundaryCase(
+        val name: String,
+        val source: String,
+        val followingType: String,
+    )
+
+    private companion object {
+        const val ISSUE1714_LINK =
+            "https://alexeyondata.substack.com/p/how-i-built-sqlitesearch-a-lightweight"
+        const val ISSUE1714_LINK_BODY =
+            "This is how I built SQLiteSearch, a small SQLite-backed search library. " +
+                "First a long chat session to get the design straight, then I downloaded " +
+                "the plan.md file and started coding. That file had all five sections: " +
+                "what the library is, how it differs from minsearch, when you should use " +
+                "it, when you shouldn't, and the architecture."
     }
 }

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -250,6 +250,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#cannotPreviewWithLocateCandidatesOffersOpenRows"
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#markdownRenderedPipeTableShowsCellsNotRawDelimiter"  # #921 D32 G9): rendered Markdown shows GFM pipe tables as
   "com.pocketshell.app.fileviewer.FileViewerDockerTest#reopeningAChangedTextFileShowsTheFreshHostContent"  # #1713 D33/G10: reopening a text file whose host content changed over the same warm lease must show the FRESH body, not the stale one (bind() no longer early-returns on the identical settled request)
+  "com.pocketshell.app.fileviewer.FileViewerDockerTest#moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl"  # #1714 D33/G9/G10: exact issue-time excerpts plus synthetic mixed/deep/wide class coverage through production MarkdownView
   "com.pocketshell.app.bootstrap.HostReadyPrimaryActionTest"  # #885 #117 D32 G9): the post-update Host ready success sheet must
   "com.pocketshell.app.bootstrap.HostNotificationsReadinessTest"  # #1236 D26 / D32 G9): per-host notification readiness + the
   "$FQCN_PREFIX.StrictModeMainThreadIoDetectorE2eTest"  # #933 #928 #931 #926 ============================================================…


### PR DESCRIPTION
Closes #1714

## Summary
- preserve nested Markdown list structure, marker kind, source ordinal, and continuation ownership
- render hanging markers and selectable item bodies without breaking link annotations or intents
- add real file-viewer journey coverage for nesting, continuation selection/copy, wrapping, markers, and URLs

## Verification
- independent review: APPROVED
- untouched-base JVM and connected RED reproduced
- five compiled mutations killed and restored byte-exact
- forced Android-test compile: 176/176 tasks
- focused parser suite: 34/34 tests
- canonical full JVM gate: 603/603 tasks; 11,498 tests, zero failures/errors/skips
- connected RED/GREEN plus four-test adjacency and screenshot inspection
- `git diff --check`; journey/test-validity guards