### PR TITLE
Resume interrupted queued attachment uploads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -526,13 +526,13 @@ jobs:
   # the classes above — no new Docker service/port.
   #
   # This is intentionally the FAST subset (scripts/ci-journey-suite.sh), not the
-  # full connected suite — the heavy/long-running + toxiproxy network-fault +
-  # bootstrap-matrix suites stay in nightly-extensive.yml. The selected proofs
-  # need no toxiproxy proxy family, so this job brings up only the deterministic
-  # `agents` (2222) fixture plus the deterministic `agents-old-cli` (2238, issue
-  # #849) fixture — both plain SSH/tmux, keeping the job deterministic (the
-  # maintainer already gets CI email spam — a flaky per-push job would make that
-  # worse).
+  # full connected suite — the heavy/long-running network-fault matrix and
+  # bootstrap matrix stay in nightly-extensive.yml. Issue #1733 is the one
+  # selected proof that also needs the existing deterministic Toxiproxy route
+  # (2228/API 8474) to hold a genuine app-transport outage; all other selected
+  # proofs remain on plain `agents` (2222), `agents-old-cli` (2238), or their
+  # documented fixture. This explicit fixture is not a self-skipping nightly
+  # lane.
   #
   # Issue #849 (epic #848, ADDED): the v0.4.10 connect-break regression tests
   # (FolderListOldCliHydrateDockerTest + FolderListBootstrapSkipTreeLoadsDockerTest)
@@ -830,11 +830,11 @@ jobs:
       # ColdRestoreGoneSessionNoResurrect, ReconnectRepaint,
       # BackgroundGraceReconnect, plus the share-auth pair ShareTarget +
       # SharePassphraseDialog promoted in #727) all drive the plain deterministic
-      # `agents` fixture on host port 2222 (emulator 10.0.2.2:2222) and NONE of
-      # them need the opt-in toxiproxy network-fault proxies. Bring up `agents`
-      # (2222) plus the deterministic `agents-old-cli` (2238, issue #849) fixture
-      # below — both are plain SSH/tmux fixtures with NO toxiproxy, so the job
-      # stays deterministic.
+      # `agents` fixture on host port 2222 (emulator 10.0.2.2:2222). Issue #1733
+      # additionally routes the app transport through the existing Toxiproxy
+      # fixture (2228/API 8474) while retaining its direct checkpoint/killer
+      # sidecar on 2222. Bring up both explicitly so that load-bearing journey
+      # cannot self-skip or silently fall back to the direct route.
       - name: Start Docker fixture (agents)
         run: |
           docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents
@@ -844,6 +844,18 @@ jobs:
           source tests/docker/lib/wait-for-healthy.sh
           wait_for_container_healthy tests/docker/docker-compose.yml agents /tmp/agents-health.log 60
           cat /tmp/agents-health.log
+
+      - name: Start Docker fixture (network-fault-proxy, issue #1733)
+        run: |
+          docker compose -f tests/docker/docker-compose.yml up -d --no-deps network-fault-proxy
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent --show-error http://127.0.0.1:8474/version; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker compose -f tests/docker/docker-compose.yml logs --no-color network-fault-proxy
+          exit 1
 
       - name: Verify agent SSH target tool surface
         run: |
@@ -1247,6 +1259,8 @@ jobs:
           docker compose -f tests/docker/docker-compose.yml ps > artifacts/docker/compose-ps.txt
           docker compose -f tests/docker/docker-compose.yml logs --no-color agents > artifacts/docker/agents.log 2>/dev/null || true
           docker inspect pocketshell-test-agents > artifacts/docker/agents-inspect.json 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color network-fault-proxy > artifacts/docker/network-fault-proxy.log 2>/dev/null || true
+          docker inspect pocketshell-test-network-fault-proxy > artifacts/docker/network-fault-proxy-inspect.json 2>/dev/null || true
           # Issue #849: also capture the old-CLI (2238) fixture diagnostics.
           docker compose -f tests/docker/docker-compose.yml logs --no-color agents-old-cli > artifacts/docker/agents-old-cli.log 2>/dev/null || true
           docker inspect pocketshell-test-agents-old-cli > artifacts/docker/agents-old-cli-inspect.json 2>/dev/null || true

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1733ArtifactPreservationSmokeTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1733ArtifactPreservationSmokeTest.kt
@@ -1,0 +1,109 @@
+package com.pocketshell.app.proof
+
+import android.app.Instrumentation
+import android.os.ParcelFileDescriptor
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+internal object Issue1733ArtifactPreserver {
+    fun preserve(
+        instrumentation: Instrumentation,
+        phase: String,
+        sources: List<File>,
+        destination: String,
+    ) {
+        require(sources.isNotEmpty()) { "phase $phase must preserve at least one artifact" }
+        sources.forEach { source ->
+            assertTrue(
+                "phase $phase source artifact must exist and be nonempty: ${source.absolutePath}",
+                source.isFile && source.length() > 0L,
+            )
+        }
+
+        val script = buildList {
+            add("set -eu")
+            add("mkdir -p ${shellQuoteForPreservation(destination)}")
+            sources.forEach { source ->
+                val copied = "$destination/${source.name}"
+                add(
+                    "cp ${shellQuoteForPreservation(source.absolutePath)} " +
+                        shellQuoteForPreservation(copied),
+                )
+                add("test -s ${shellQuoteForPreservation(copied)}")
+            }
+            add("printf '%s\\n' ${shellQuoteForPreservation("PRESERVED_OK $destination")}")
+        }.joinToString("; ")
+        val encoded = Base64.encodeToString(
+            script.toByteArray(Charsets.UTF_8),
+            Base64.NO_WRAP,
+        )
+
+        // UiAutomation delegates to Runtime.exec(String), which tokenizes on
+        // whitespace and does not add a shell. Keep the third argv token free
+        // of literal whitespace, then let sh expand IFS before decoding the
+        // safely opaque base64 payload into the real script.
+        val command = "/system/bin/sh -c " +
+            "echo\${IFS}$encoded|/system/bin/base64\${IFS}-d|/system/bin/sh"
+        val descriptor = instrumentation.uiAutomation.executeShellCommand(command)
+        val output = ParcelFileDescriptor.AutoCloseInputStream(descriptor)
+            .bufferedReader()
+            .use { it.readText() }
+        assertTrue(
+            "phase $phase preservation failed: destination=$destination output=$output",
+            output.lineSequence().any { it == "PRESERVED_OK $destination" },
+        )
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class Issue1733ArtifactPreservationSmokeTest {
+    @Test
+    fun shellPreserverCopiesAndChecksNonemptySentinel() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val root = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val sourceDir = File(
+            root,
+            "additional_test_output/issue1733-preserver-smoke",
+        )
+        assertTrue(sourceDir.exists() || sourceDir.mkdirs())
+        val sentinel = File(sourceDir, "sentinel.txt")
+        val payload = "issue1733-preserver-sentinel\n"
+        sentinel.writeText(payload)
+        assertTrue(sentinel.isFile && sentinel.length() > 0L)
+
+        val runId = "run-${System.currentTimeMillis()}"
+        val destination = "/sdcard/Download/pocketshell-issue1733-smoke/$runId/smoke"
+        Issue1733ArtifactPreserver.preserve(
+            instrumentation = instrumentation,
+            phase = "smoke",
+            sources = listOf(sentinel),
+            destination = destination,
+        )
+
+        val copied = "$destination/${sentinel.name}"
+        val copiedSize = readShellOutput(
+            instrumentation,
+            "/system/bin/stat -c %s $copied",
+        ).trim().toLong()
+        assertEquals(sentinel.length(), copiedSize)
+        assertEquals(
+            payload,
+            readShellOutput(instrumentation, "/system/bin/cat $copied"),
+        )
+        println("ISSUE1733_PRESERVER_SMOKE destination=$destination size=$copiedSize")
+    }
+}
+
+private fun readShellOutput(instrumentation: Instrumentation, command: String): String =
+    ParcelFileDescriptor.AutoCloseInputStream(
+        instrumentation.uiAutomation.executeShellCommand(command),
+    ).bufferedReader().use { it.readText() }
+
+private fun shellQuoteForPreservation(value: String): String =
+    "'" + value.replace("'", "'\"'\"'") + "'"

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
@@ -1,0 +1,1234 @@
+package com.pocketshell.app.proof
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.net.Uri
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.composer.COMPOSER_CLOSE_TAG
+import com.pocketshell.app.composer.DurableAttachmentRef
+import com.pocketshell.app.composer.LocalAttachmentSidecarRef
+import com.pocketshell.app.composer.COMPOSER_OUTBOUND_QUEUE_BANNER_TAG
+import com.pocketshell.app.composer.OutboundAttachmentSidecarStore
+import com.pocketshell.app.composer.OutboundItem
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.composer.PromptAttachmentStager
+import com.pocketshell.app.composer.PromptComposerViewModel
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
+import com.pocketshell.app.composer.composerOutboundQueueRetryTestTag
+import com.pocketshell.app.composer.pendingAttachmentRemotePath
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.app.proof.signals.assertScreenshotNotBlank
+import com.pocketshell.app.share.FilenameSanitiser
+import com.pocketshell.app.share.ShareUploader
+import com.pocketshell.app.tmux.QueueSidecarUploadJourneySeam
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.durableTmuxSessionKey
+import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.QueueSidecarResumableUploadResult
+import com.pocketshell.core.ssh.QueueSidecarUploadDisposition
+import com.pocketshell.core.ssh.QueueSidecarUploadProgress
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.queueSidecarCheckpointPaths
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import java.io.File
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1733: production durable queue-sidecar upload resumes from the exact
+ * remote checkpoint after the app's real SSH worker dies. This is deliberately
+ * not the immediate/generic attachment staging path.
+ */
+@RunWith(AndroidJUnit4::class)
+class OutboundAttachmentOffsetResumeJourneyE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+    private lateinit var queueSessionKey: String
+    private lateinit var queuedItem: OutboundItem
+    private lateinit var sidecar: LocalAttachmentSidecarRef
+    private lateinit var finalRemotePath: String
+    private lateinit var finalDisplayPath: String
+    private lateinit var localSha256: String
+    private lateinit var proxy: ToxiproxyControl
+    private var diagnostics: RecordingDiagnosticSink? = null
+    private val firstProgress = AtomicReference<QueueSidecarUploadProgress>()
+    private val secondProgress = AtomicReference<QueueSidecarUploadProgress>()
+    private val resumedResult = AtomicReference<QueueSidecarResumableUploadResult>()
+    private val stopFirstAttempt = AtomicBoolean(true)
+    private val firstProgressReady = CountDownLatch(1)
+    private val releaseFirstAttempt = CountDownLatch(1)
+    private val secondProgressReady = CountDownLatch(1)
+    private val releaseSecondAttempt = CountDownLatch(1)
+    private val resumedResultReady = CountDownLatch(1)
+    private val timings = mutableListOf<String>()
+    private val artifactRunId = "run-${System.currentTimeMillis()}"
+
+    private suspend fun seedBeforeLaunch() {
+        val context = targetContext()
+        clearLastSessionPrefs()
+        context.getSharedPreferences(OUTBOUND_QUEUE_PREFS, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        context.getSharedPreferences(OutboundAttachmentSidecarStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, OutboundAttachmentSidecarStore.DIRECTORY_NAME).deleteRecursively()
+
+        fixtureKey = readFixtureKey()
+        assertTrue(
+            "issue #1733 requires the explicitly opted-in Toxiproxy fixture",
+            InstrumentationRegistry.getArguments()
+                .getString(NETWORK_FAULT_ARG)
+                ?.toBooleanStrictOrNull() == true,
+        )
+        waitForSshFixtureReady(SshKey.Pem(fixtureKey), port = DIRECT_AGENTS_SSH_PORT)
+        proxy = ToxiproxyControl(baseUrl = "http://$DEFAULT_HOST:$TOXIPROXY_API_PORT")
+        proxy.reset()
+        waitForSshFixtureReady(SshKey.Pem(fixtureKey), port = NETWORK_FAULT_SSH_PORT)
+        val identity = seedFakeAgentSession(fixtureKey)
+        val hostId = seedDockerHost(fixtureKey)
+        hostRowTag = HOST_ROW_TAG_PREFIX + hostId
+        queueSessionKey = requireNotNull(
+            durableTmuxSessionKey(hostId, identity.sessionId, identity.sessionCreated),
+        )
+
+        val source = createImmutableAttachment(context)
+        localSha256 = sha256(source)
+        val itemId = "issue1733-row-${System.currentTimeMillis()}"
+        sidecar = requireNotNull(
+            OutboundAttachmentSidecarStore(context)
+                .stage(itemId, listOf(Uri.fromFile(source)), listOf(0))
+                .singleOrNull(),
+        )
+        assertEquals(UPLOAD_BYTES, sidecar.byteSize)
+
+        val safeScope = PromptAttachmentStager.safeScopeSegment("host-$hostId-$SESSION_NAME")
+        val remoteName = PromptAttachmentStager.composeAttachmentName(
+            ShareUploader.formatTimestamp(sidecar.createdAtMs),
+            sidecar.attachmentIndex ?: 0,
+            FilenameSanitiser.sanitise(
+                sidecar.displayName,
+                defaultExtension = ShareUploader.extensionForMimeType(sidecar.mimeType),
+            ),
+        )
+        finalRemotePath = "${PromptAttachmentStager.REMOTE_DIRECTORY}/$safeScope/$remoteName"
+        finalDisplayPath = "~/$finalRemotePath"
+        queuedItem = OutboundItem(
+            id = itemId,
+            sessionKey = queueSessionKey,
+            cleanText = PROMPT,
+            attachments = listOf(
+                DurableAttachmentRef(
+                    remotePath = pendingAttachmentRemotePath(queueSessionKey, 0, sidecar.displayName),
+                    displayName = sidecar.displayName,
+                    mimeType = sidecar.mimeType,
+                ),
+            ),
+            withEnter = true,
+            state = OutboundState.Queued,
+            createdAtMs = sidecar.createdAtMs,
+            // Use the authoritative pane identity seeded on the server. A blank
+            // pane would make production fall back to the visible pane while the
+            // durable wire ledger still searched for "", falsely reporting
+            // wireAttempted=false after bytes had demonstrably landed on %N.
+            paneId = identity.paneId,
+            // The fake-agent pane models the production attachment-bearing agent
+            // path: a multi-line payload is pasted atomically, acknowledged, then
+            // submitted with exactly one Enter. RawBytes deliberately has different
+            // terminal semantics and is covered by its own delivery journeys.
+            route = OutboundRoute.AgentPayload,
+            agentKind = "claude",
+        )
+        SharedPrefsOutboundQueueStore(context).enqueueExisting(queuedItem)
+    }
+
+    @Before
+    fun setUp() {
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+        QueueSidecarUploadJourneySeam.onProgress = { ref, progress ->
+            if (ref.id == sidecar.id &&
+                progress.resumedFromBytes == 0L &&
+                progress.bytesTransferred >= CUT_AFTER_BYTES &&
+                stopFirstAttempt.compareAndSet(true, false)
+            ) {
+                firstProgress.set(progress)
+                firstProgressReady.countDown()
+                check(releaseFirstAttempt.await(HOOK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    "timed out waiting for the journey to kill the real app SSH worker"
+                }
+            } else if (ref.id == sidecar.id &&
+                progress.resumedFromBytes > 0L &&
+                progress.bytesTransferred == progress.resumedFromBytes &&
+                secondProgress.compareAndSet(null, progress)
+            ) {
+                secondProgressReady.countDown()
+                check(releaseSecondAttempt.await(HOOK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    "timed out waiting for the journey to verify the resume offset"
+                }
+            }
+        }
+        QueueSidecarUploadJourneySeam.onResult = { ref, result ->
+            if (ref.id == sidecar.id && result.resumedFromBytes > 0L) {
+                resumedResult.set(result)
+                resumedResultReady.countDown()
+            }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        releaseFirstAttempt.countDown()
+        releaseSecondAttempt.countDown()
+        QueueSidecarUploadJourneySeam.reset()
+        diagnostics?.close()
+        diagnostics = null
+        clearLastSessionPrefs()
+        if (::proxy.isInitialized) {
+            runCatching { proxy.reset() }
+        }
+        if (::fixtureKey.isInitialized) {
+            runCatching { runBlocking { cleanupRemote(fixtureKey) } }
+        }
+    }
+
+    @Test
+    fun durableQueueSidecarResumesExactOffsetAfterRealWorkerKill() {
+        runBlocking {
+            val killer = connectSidecar()
+            try {
+            writeText("00-queue-seed.txt", queueSnapshot())
+            writeText("00-sshd-before.txt", remoteExec(killer, SSHD_SNAPSHOT).stdout)
+            writeText(
+                "00-preserved-run.txt",
+                "$PRESERVED_DEVICE_ROOT/$artifactRunId\n",
+            )
+            preserveArtifacts(
+                phase = "00-seed",
+                "00-queue-seed.txt",
+                "00-sshd-before.txt",
+                "00-preserved-run.txt",
+            )
+            attachSeededTmuxSession()
+            waitForConnected("initial attach")
+            waitForVisibleTerminal("fake-agent ready") { it.contains(FAKE_AGENT_READY) }
+            val vm = currentViewModel()
+            val clientBefore = vm.currentClientIdentityForTest()
+
+            val initialManualRetryUsed = ensureQueuedRowReachableOrClaimed()
+            recordTiming("initial_manual_retry_used", if (initialManualRetryUsed) 1L else 0L)
+            assertEquals(
+                "the durable row must be owned by the production sidecar upload before " +
+                    "the composer is dismissed",
+                OutboundState.Uploading,
+                queueStore().item(queuedItem.id)?.state,
+            )
+            dismissComposerAfterOwnership()
+            preserveArtifacts(
+                phase = "00-ownership",
+                "00-queue-ownership.txt",
+            )
+            assertTrue(
+                "production durable queue upload never reached $CUT_AFTER_BYTES bytes; " +
+                    "queue=${queueSnapshot()} status=${currentConnectionStatus()} " +
+                    "diagnostics=${diagnosticSummary()}",
+                firstProgressReady.await(PROGRESS_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+            )
+            val progress = requireNotNull(firstProgress.get())
+            val checkpoint = queueSidecarCheckpointPaths(finalRemotePath, sidecar.id)
+            val committedN = waitForCommittedRemotePrefix(
+                killer,
+                checkpoint.dataPath,
+                progress.bytesTransferred,
+            )
+            assertTrue("checkpoint must be a strict prefix; N=$committedN total=${sidecar.byteSize}", committedN in 1 until sidecar.byteSize)
+            assertTrue(
+                "the server cannot commit beyond the client-side progress watermark; " +
+                    "checkpoint=$committedN progress=${progress.bytesTransferred}",
+                committedN <= progress.bytesTransferred,
+            )
+            assertRemoteAbsent(killer, finalRemotePath, "before worker kill")
+            captureViewport("01-committed-prefix")
+            writeText(
+                "01-checkpoint.txt",
+                "checkpoint=${checkpoint.dataPath}\ncheckpoint_size=$committedN\n" +
+                    "progress_resumed_from=${progress.resumedFromBytes}\n" +
+                    "progress_transferred=${progress.bytesTransferred}\ntotal=${sidecar.byteSize}\n",
+            )
+            preserveArtifacts(
+                phase = "01-checkpoint",
+                "01-checkpoint.txt",
+                "01-committed-prefix-viewport.png",
+                "01-committed-prefix-visible-terminal.txt",
+            )
+
+            val killedAt = SystemClock.elapsedRealtime()
+            val kill = remoteExec(
+                killer,
+                "for p in \$(pgrep -u $DEFAULT_USER sshd); do " +
+                    "[ \"\$p\" != \"\$PPID\" ] && kill -9 \"\$p\" 2>/dev/null || true; done",
+            )
+            assertEquals("real worker-kill command failed: ${kill.stderr}", 0, kill.exitCode)
+            proxy.withDisabledProxy {
+                releaseFirstAttempt.countDown()
+                writeText(
+                    "02-real-outage-hold.txt",
+                    "worker_kill_exit=${kill.exitCode}\n" +
+                        "app_transport_port=$NETWORK_FAULT_SSH_PORT\n" +
+                        "direct_checkpoint_sidecar_port=$DIRECT_AGENTS_SSH_PORT\n" +
+                        "toxiproxy_state=disabled_during_loss_assertion_and_capture\n",
+                )
+
+                val reconnectProof = waitForVisibleReconnectSurface(CONNECTION_LOST_TIMEOUT_MS)
+                assertTrue(
+                    "the genuine app-worker death must project raw+display Reconnecting AND " +
+                        "the visible contained $ATTACHING_LABEL surface while the real proxy " +
+                        "outage is held; raw=${currentConnectionStatus()} " +
+                        "display=${currentDisplayConnectionStatus()} " +
+                        "diagnostics=${diagnosticSummary()}",
+                    reconnectProof != null,
+                )
+                val displayedReconnectProof = requireNotNull(reconnectProof)
+                assertVisibleReconnectSurface()
+                val connectionLostScreenshot = captureDecorViewport("02-connection-lost")
+                val connectionLostText = writeText(
+                    "02-connection-lost-visible-label.txt",
+                    "$ATTACHING_LABEL\n",
+                )
+                val reconnectStateText = writeText(
+                    "02-reconnect-state.txt",
+                    "raw=${displayedReconnectProof.raw}\n" +
+                        "display=${displayedReconnectProof.display}\n",
+                )
+                assertTrue(
+                    "connection-lost screenshot artifact must exist and be nonempty: " +
+                        connectionLostScreenshot.absolutePath,
+                    connectionLostScreenshot.isFile && connectionLostScreenshot.length() > 0L,
+                )
+                assertTrue(
+                    "connection-lost label artifact must exist and be nonempty: " +
+                        connectionLostText.absolutePath,
+                    connectionLostText.isFile && connectionLostText.length() > 0L,
+                )
+                assertTrue(
+                    "reconnect-state artifact must exist and be nonempty: " +
+                        reconnectStateText.absolutePath,
+                    reconnectStateText.isFile && reconnectStateText.length() > 0L,
+                )
+                preserveArtifacts(
+                    phase = "02-loss-visible",
+                    "02-connection-lost-viewport.png",
+                    "02-connection-lost-visible-label.txt",
+                    "02-reconnect-state.txt",
+                    "02-real-outage-hold.txt",
+                )
+                recordTiming("connection_lost_visible_ms", SystemClock.elapsedRealtime() - killedAt)
+                assertTrue(
+                    "killed upload must return the durable row to a retryable state; ${queueSnapshot()}",
+                    waitForRetryableRow(QUEUE_RETRYABLE_TIMEOUT_MS),
+                )
+                writeText("02-queue-retryable.txt", queueSnapshot())
+                writeText("02-sshd-after-kill.txt", remoteExec(killer, SSHD_SNAPSHOT).stdout)
+                preserveArtifacts(
+                    phase = "02-retryable",
+                    "02-queue-retryable.txt",
+                    "02-sshd-after-kill.txt",
+                )
+                assertEquals(committedN, remoteSize(killer, checkpoint.dataPath))
+                assertRemoteAbsent(killer, finalRemotePath, "after worker kill")
+            }
+
+            if (currentConnectionStatus() !is TmuxSessionViewModel.ConnectionStatus.Connected) {
+                compose.activityRule.scenario.onActivity {
+                    ViewModelProvider(it)[TmuxSessionViewModel::class.java].reconnect()
+                }
+            }
+            waitForConnected("reconnect without app restart")
+            if (!secondProgressReady.await(AUTO_RETRY_WINDOW_MS, TimeUnit.MILLISECONDS)) {
+                openComposer()
+                val retryTag = composerOutboundQueueRetryTestTag(queuedItem.id)
+                val retryDeadline = SystemClock.elapsedRealtime() + RESUME_TIMEOUT_MS
+                var retryClicked = false
+                while (secondProgressReady.count > 0L &&
+                    SystemClock.elapsedRealtime() < retryDeadline
+                ) {
+                    if (!retryClicked && hasTag(retryTag)) {
+                        compose.onNodeWithTag(retryTag, useUnmergedTree = true).performClick()
+                        retryClicked = true
+                    }
+                    SystemClock.sleep(100)
+                }
+                recordTiming("manual_retry_used", if (retryClicked) 1L else 0L)
+            } else {
+                recordTiming("manual_retry_used", 0L)
+            }
+            assertTrue(
+                "auto-flush/retry never opened the resumed queue-sidecar attempt",
+                secondProgressReady.await(RESUME_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+            )
+            val resumeStart = requireNotNull(secondProgress.get())
+            assertEquals(committedN, resumeStart.resumedFromBytes)
+            assertEquals(committedN, resumeStart.bytesTransferred)
+            assertEquals(committedN, remoteSize(killer, checkpoint.dataPath))
+            assertRemoteAbsent(killer, finalRemotePath, "at resumed-at-N attempt start")
+            releaseSecondAttempt.countDown()
+            assertTrue(
+                "resumed queue attempt never completed; queue=${queueSnapshot()} diagnostics=${diagnosticSummary()}",
+                resumedResultReady.await(RESUME_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+            )
+            val result = requireNotNull(resumedResult.get())
+            assertEquals(QueueSidecarUploadDisposition.Uploaded, result.disposition)
+            assertEquals(finalRemotePath, result.remotePath)
+            assertEquals(committedN, result.resumedFromBytes)
+            assertEquals(sidecar.byteSize - committedN, result.transmittedBytes)
+            val clientAfter = currentViewModel().currentClientIdentityForTest()
+            assertTrue(
+                "resume must use a fresh app tmux client; before=$clientBefore after=$clientAfter",
+                clientAfter != null && clientAfter != clientBefore,
+            )
+
+            val finalSize = remoteSize(killer, finalRemotePath)
+            val remoteSha = remoteExec(
+                killer,
+                "sha256sum ${shellQuote(finalRemotePath)} | awk '{print \$1}'",
+            ).stdout.trim()
+            assertEquals(sidecar.byteSize, finalSize)
+            assertEquals(localSha256, remoteSha)
+            assertRemoteAbsent(killer, checkpoint.dataPath, "after atomic promotion")
+            assertRemoteAbsent(killer, checkpoint.identityPath, "after atomic promotion")
+
+            waitForDurableDeliveryTerminal(killer, DELIVERY_TERMINAL_TIMEOUT_MS)
+            val submitted = waitForPaneOutput(killer, INPUT_TIMEOUT_MS) {
+                it.contains(PROMPT) && it.contains(finalDisplayPath) && it.contains(FAKE_AGENT_SUBMITTED)
+            }
+            val flattened = submitted.filterNot(Char::isWhitespace)
+            assertEquals(1, countOccurrences(flattened, PROMPT.filterNot(Char::isWhitespace)))
+            assertEquals(
+                "attachment-bearing prompt must receive exactly one Enter; capture:\n" +
+                    Issue1733JourneyContract.xmlSafeFailureText(submitted),
+                1,
+                countOccurrences(flattened, (FAKE_AGENT_SUBMITTED + PROMPT).filterNot(Char::isWhitespace)),
+            )
+
+            writeThroughTerminalSession(LIVE_INPUT_MARKER)
+            val liveCapture = waitForCapture(killer, INPUT_TIMEOUT_MS) { it.contains(LIVE_INPUT_MARKER) }
+            assertTrue(
+                "terminal input must remain live after resume; capture:\n" +
+                    Issue1733JourneyContract.xmlSafeFailureText(liveCapture),
+                liveCapture.contains(LIVE_INPUT_MARKER),
+            )
+            captureViewport("03-resumed-delivered-live")
+            writeText("03-final-capture.txt", liveCapture)
+            writeText("03-pane-output.txt", submitted)
+            writeText("03-queue-final.txt", queueSnapshot())
+            writeText("03-diagnostics.txt", diagnosticSummary())
+            writeText("03-sshd-final.txt", remoteExec(killer, SSHD_SNAPSHOT).stdout)
+            writeText(
+                "03-resume-evidence.txt",
+                "checkpoint_size=$committedN\nresumed_from=${result.resumedFromBytes}\n" +
+                    "second_attempt_transmitted=${result.transmittedBytes}\ntotal=${sidecar.byteSize}\n" +
+                    "final_size=$finalSize\nlocal_sha256=$localSha256\nremote_sha256=$remoteSha\n" +
+                    "final_absent_before_promotion=true\ncheckpoint_removed=true\n" +
+                    "client_before=$clientBefore\nclient_after=$clientAfter\n",
+            )
+            recordTiming("resume_completed_ms", SystemClock.elapsedRealtime() - killedAt)
+            writeText("timings.txt", timings.joinToString("\n", postfix = "\n"))
+            preserveArtifacts(
+                phase = "03-complete",
+                "03-final-capture.txt",
+                "03-pane-output.txt",
+                "03-queue-final.txt",
+                "03-diagnostics.txt",
+                "03-sshd-final.txt",
+                "03-resume-evidence.txt",
+                "03-resumed-delivered-live-viewport.png",
+                "03-resumed-delivered-live-visible-terminal.txt",
+                "timings.txt",
+            )
+            } finally {
+                releaseFirstAttempt.countDown()
+                releaseSecondAttempt.countDown()
+                killer.close()
+            }
+        }
+    }
+
+    private fun ensureQueuedRowReachableOrClaimed(): Boolean {
+        openComposer()
+        val retryTag = composerOutboundQueueRetryTestTag(queuedItem.id)
+        assertTrue(
+            "production queue row never became visible or owned; " +
+                "item=${queueStore().item(queuedItem.id)} queue=${queueSnapshot()}",
+            waitForQueueOwnershipOrProjection(),
+        )
+        val observedBeforeRetry = queueStore().item(queuedItem.id)
+        val alreadyClaimed = firstProgressReady.count == 0L ||
+            observedBeforeRetry?.state in CLAIMED_OUTBOUND_STATES
+        if (alreadyClaimed) {
+            writeText(
+                "00-queue-ownership.txt",
+                "path=auto-claimed\nitem=$observedBeforeRetry\n",
+            )
+            return false
+        }
+
+        assertTrue(
+            "seeded durable row must be projected into the production composer; " +
+                "item=$observedBeforeRetry queue=${queueSnapshot()}",
+            hasTag(COMPOSER_OUTBOUND_QUEUE_BANNER_TAG),
+        )
+        compose.onNodeWithTag(
+            COMPOSER_OUTBOUND_QUEUE_BANNER_TAG,
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot(
+            COMPOSER_OUTBOUND_QUEUE_BANNER_TAG,
+            useUnmergedTree = true,
+        )
+        compose.waitUntil(UI_TIMEOUT_MS) {
+            firstProgressReady.count == 0L ||
+                queueStore().item(queuedItem.id)?.state in CLAIMED_OUTBOUND_STATES ||
+                hasTag(retryTag)
+        }
+        val claimedWhileVisible = firstProgressReady.count == 0L ||
+            queueStore().item(queuedItem.id)?.state in CLAIMED_OUTBOUND_STATES
+        if (claimedWhileVisible) {
+            writeText(
+                "00-queue-ownership.txt",
+                "path=auto-claimed-after-projection\nitem=${queueStore().item(queuedItem.id)}\n",
+            )
+            return false
+        }
+
+        compose.onNodeWithTag(
+            retryTag,
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+        compose.onNodeWithTag(retryTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(UI_TIMEOUT_MS) {
+            firstProgressReady.count == 0L ||
+                queueStore().item(queuedItem.id)?.state in CLAIMED_OUTBOUND_STATES
+        }
+        val claimed = queueStore().item(queuedItem.id)
+        assertTrue(
+            "production Retry must claim the projected durable row; item=$claimed",
+            firstProgressReady.count == 0L || claimed?.state in CLAIMED_OUTBOUND_STATES,
+        )
+        writeText(
+            "00-queue-ownership.txt",
+            "path=visible-production-retry\nitem=$claimed\n",
+        )
+        return true
+    }
+
+    private fun openComposer() {
+        if (hasTag(COMPOSER_OUTBOUND_QUEUE_BANNER_TAG) ||
+            hasTag(composerOutboundQueueRetryTestTag(queuedItem.id))
+        ) {
+            return
+        }
+        compose.waitUntil(UI_TIMEOUT_MS) { hasTag(SESSION_COMPOSER_LAUNCHER_TAG) }
+        compose.onNodeWithTag(
+            SESSION_COMPOSER_LAUNCHER_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+        compose.waitUntil(UI_TIMEOUT_MS) { hasTag(COMPOSER_CLOSE_TAG) }
+    }
+
+    /**
+     * Queue auto-flush owns real-IO work while Compose owns a virtual test clock.
+     * A tight Compose `waitUntil` can starve that IO on a contended emulator, so
+     * use the repository's Shape-B rule: a hard wall-clock deadline, periodic
+     * Compose/semantics drains, and the load-bearing condition as the exit.
+     */
+    private fun waitForQueueOwnershipOrProjection(): Boolean {
+        val deadline = System.currentTimeMillis() + PROGRESS_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
+            compose.waitForIdle()
+            if (
+                firstProgressReady.count == 0L ||
+                queueStore().item(queuedItem.id)?.state in CLAIMED_OUTBOUND_STATES ||
+                hasTag(COMPOSER_OUTBOUND_QUEUE_BANNER_TAG)
+            ) {
+                return true
+            }
+            SystemClock.sleep(100)
+        }
+        return firstProgressReady.count == 0L ||
+            queueStore().item(queuedItem.id)?.state in CLAIMED_OUTBOUND_STATES ||
+            hasTag(COMPOSER_OUTBOUND_QUEUE_BANNER_TAG)
+    }
+
+    private fun dismissComposerAfterOwnership() {
+        compose.waitUntil(UI_TIMEOUT_MS) { hasTag(COMPOSER_CLOSE_TAG) }
+        compose.onNodeWithTag(
+            COMPOSER_CLOSE_TAG,
+            useUnmergedTree = true,
+        ).assertIsDisplayed().performClick()
+        compose.waitUntil(UI_TIMEOUT_MS) { !hasTag(COMPOSER_CLOSE_TAG) }
+        compose.onNodeWithTag(
+            TMUX_SESSION_SCREEN_TAG,
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+    }
+
+    private fun attachSeededTmuxSession() {
+        compose.waitUntil(HOST_ROW_TIMEOUT_MS) { hasTag(hostRowTag) }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        compose.waitUntil(PROGRESS_TIMEOUT_MS) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                attached = activity.window.decorView.findTerminalView()?.currentSession?.emulator != null
+            }
+            attached
+        }
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity {
+            vm = ViewModelProvider(it)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm)
+    }
+
+    private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus = TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity {
+            status = ViewModelProvider(it)[TmuxSessionViewModel::class.java].connectionStatus.value
+        }
+        return status
+    }
+
+    private fun currentDisplayConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus = TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity {
+            status = ViewModelProvider(it)[TmuxSessionViewModel::class.java]
+                .displayConnectionStatus.value
+        }
+        return status
+    }
+
+    private fun waitForConnected(label: String) {
+        compose.waitUntil(CONNECTED_TIMEOUT_MS) {
+            currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue("$label must end Connected; status=${currentConnectionStatus()}", currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected)
+    }
+
+    private fun waitForVisibleTerminal(label: String, predicate: (String) -> Boolean): String {
+        var last = ""
+        compose.waitUntil(PROGRESS_TIMEOUT_MS) {
+            last = visibleTerminalText()
+            predicate(last)
+        }
+        assertTrue("$label missing from terminal:\n$last", predicate(last))
+        return last
+    }
+
+    private data class VisibleReconnectProof(
+        val raw: TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        val display: TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+    )
+
+    private fun waitForVisibleReconnectSurface(timeoutMs: Long): VisibleReconnectProof? {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            visibleReconnectProof()?.let { return it }
+            SystemClock.sleep(100)
+        }
+        return visibleReconnectProof()
+    }
+
+    private fun visibleReconnectProof(): VisibleReconnectProof? {
+        val raw = currentConnectionStatus()
+        val display = currentDisplayConnectionStatus()
+        if (raw !is TmuxSessionViewModel.ConnectionStatus.Reconnecting ||
+            display !is TmuxSessionViewModel.ConnectionStatus.Reconnecting
+        ) {
+            return null
+        }
+        return runCatching {
+            assertVisibleReconnectSurface()
+            VisibleReconnectProof(raw = raw, display = display)
+        }.getOrNull()
+    }
+
+    private fun assertVisibleReconnectSurface() {
+        compose.onNodeWithTag(
+            TMUX_SWITCHING_LOADING_TAG,
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot(
+            TMUX_SWITCHING_LOADING_TAG,
+            useUnmergedTree = true,
+        )
+        compose.onNodeWithText(
+            ATTACHING_LABEL,
+            useUnmergedTree = true,
+        ).assertIsDisplayed().assertTextEquals(ATTACHING_LABEL)
+    }
+
+    private fun hasTag(tag: String): Boolean = runCatching {
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
+    }.getOrDefault(false)
+
+    private fun waitForRetryableRow(timeoutMs: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val state = queueStore().item(queuedItem.id)?.state
+            if (state == OutboundState.Queued || state == OutboundState.Failed) return true
+            SystemClock.sleep(100)
+        }
+        val state = queueStore().item(queuedItem.id)?.state
+        return state == OutboundState.Queued || state == OutboundState.Failed
+    }
+
+    private fun queueSnapshot(): String =
+        queueStore().item(queuedItem.id)?.toString() ?: "item=${queuedItem.id} delivered/pruned"
+
+    private fun queueStore() = SharedPrefsOutboundQueueStore(targetContext())
+
+    private fun diagnosticSummary(): String =
+        diagnostics?.events?.joinToString("\n") { "${it.category}/${it.name} ${it.fields}" }.orEmpty()
+
+    private suspend fun connectSidecar(): SshSession =
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DIRECT_AGENTS_SSH_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(fixtureKey),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+
+    private suspend fun remoteExec(session: SshSession, command: String) = session.exec(command)
+
+    private suspend fun remoteSize(session: SshSession, path: String): Long {
+        val result = remoteExec(
+            session,
+            "if [ -f ${shellQuote(path)} ]; then wc -c < ${shellQuote(path)}; else printf -- -1; fi",
+        )
+        assertEquals("remote size probe failed for $path: ${result.stderr}", 0, result.exitCode)
+        return result.stdout.trim().toLong()
+    }
+
+    private suspend fun waitForCommittedRemotePrefix(
+        session: SshSession,
+        path: String,
+        progressWatermark: Long,
+    ): Long {
+        val deadline = SystemClock.elapsedRealtime() + REMOTE_PROBE_TIMEOUT_MS
+        var last = -1L
+        var stableReads = 0
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val observed = remoteSize(session, path)
+            stableReads = if (observed == last && observed in 1..progressWatermark) {
+                stableReads + 1
+            } else {
+                0
+            }
+            last = observed
+            if (stableReads >= REQUIRED_STABLE_REMOTE_READS) return last
+            SystemClock.sleep(100)
+        }
+        assertTrue(
+            "checkpoint never settled to a strict committed prefix below the progress " +
+                "watermark; checkpoint=$last progress=$progressWatermark",
+            last in 1..progressWatermark && stableReads >= REQUIRED_STABLE_REMOTE_READS,
+        )
+        return last
+    }
+
+    private suspend fun assertRemoteAbsent(session: SshSession, path: String, label: String) {
+        assertEquals("$label: $path must be absent", -1L, remoteSize(session, path))
+    }
+
+    private suspend fun waitForCapture(
+        session: SshSession,
+        timeoutMs: Long,
+        predicate: (String) -> Boolean,
+    ): String {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            last = remoteExec(
+                session,
+                "tmux capture-pane -p -t ${shellQuote(SESSION_NAME)}",
+            ).stdout
+            if (predicate(last)) return last
+            SystemClock.sleep(200)
+        }
+        val serverTranscript = remoteExec(
+            session,
+            "if [ -f ${shellQuote(PANE_OUTPUT_PATH)} ]; then " +
+                "cat ${shellQuote(PANE_OUTPUT_PATH)}; else printf '<absent>\\n'; fi",
+        ).stdout
+        preserveTailFailure(
+            phase = "03-live-input-failure",
+            paneCapture = last,
+            serverTranscript = serverTranscript,
+        )
+        assertTrue(
+            "capture predicate timed out; queue=${queueSnapshot()}; capture:\n" +
+                Issue1733JourneyContract.xmlSafeFailureText(last),
+            predicate(last),
+        )
+        return last
+    }
+
+    /**
+     * Wait for the durable queue owner, not the pane transcript, to finish the
+     * delivery leg. The deadline is deliberately longer than production's 50s
+     * send bound, so the dispatcher has time to mark Sent/prune or defer the row
+     * before this journey judges it stuck.
+     *
+     * Current-main #1739 rule: [createAndroidComposeRule] virtualises app Main,
+     * which owns the production paste-ack delay and queue retry backoff. Advance
+     * that clock in small steps while retaining this independent hard wall-clock
+     * bound; otherwise a first capture just before the fake agent paints its
+     * collapsed-paste chip freezes forever at the production 40ms poll delay.
+     */
+    private suspend fun waitForDurableDeliveryTerminal(
+        session: SshSession,
+        timeoutMs: Long,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var lastItem = queueStore().item(queuedItem.id)
+        var lastPaneCapture = ""
+        var lastPaneOutput = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            lastItem = queueStore().item(queuedItem.id)
+            if (lastItem == null || lastItem.state == OutboundState.Delivered) return
+            lastPaneCapture = remoteExec(
+                session,
+                "tmux capture-pane -p -t ${shellQuote(SESSION_NAME)}",
+            ).stdout
+            lastPaneOutput = remoteExec(
+                session,
+                "if [ -f ${shellQuote(PANE_OUTPUT_PATH)} ]; then " +
+                    "cat ${shellQuote(PANE_OUTPUT_PATH)}; else printf '<absent>\\n'; fi",
+            ).stdout
+            compose.mainClock.advanceTimeBy(DELIVERY_MAIN_CLOCK_STEP_MS)
+            SystemClock.sleep(DELIVERY_MAIN_CLOCK_STEP_MS)
+        }
+
+        // Preserve the authoritative bytes before constructing the XML-safe
+        // assertion. These raw files intentionally retain ESC/control bytes.
+        writeText("03-delivery-failure-queue.txt", lastItem?.toString() ?: "delivered/pruned")
+        writeText("03-delivery-failure-diagnostics.txt", diagnosticSummary().ifEmpty { "<no diagnostics>\n" })
+        writeText("03-delivery-failure-pane-capture-raw.txt", lastPaneCapture)
+        writeText("03-delivery-failure-pane-output-raw.txt", lastPaneOutput)
+        writeText(
+            "03-delivery-failure-report.txt",
+            Issue1733JourneyContract.xmlSafeFailureText(
+                "queue=${lastItem ?: "delivered/pruned"}\n" +
+                    "paneCapture:\n$lastPaneCapture\nserverTranscript:\n$lastPaneOutput\n",
+            ),
+        )
+        preserveArtifacts(
+            phase = "03-delivery-failure",
+            "03-delivery-failure-queue.txt",
+            "03-delivery-failure-diagnostics.txt",
+            "03-delivery-failure-pane-capture-raw.txt",
+            "03-delivery-failure-pane-output-raw.txt",
+            "03-delivery-failure-report.txt",
+        )
+        assertTrue(
+            "durable delivery did not reach Sent/pruned within ${timeoutMs}ms; " +
+                Issue1733JourneyContract.xmlSafeFailureText(
+                    "queue=$lastItem paneCapture=$lastPaneCapture serverTranscript=$lastPaneOutput",
+                ),
+            lastItem == null || lastItem.state == OutboundState.Delivered,
+        )
+    }
+
+    private suspend fun waitForPaneOutput(
+        session: SshSession,
+        timeoutMs: Long,
+        predicate: (String) -> Boolean,
+    ): String {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            last = remoteExec(
+                session,
+                "if [ -f ${shellQuote(PANE_OUTPUT_PATH)} ]; then " +
+                    "cat ${shellQuote(PANE_OUTPUT_PATH)}; fi",
+            ).stdout
+            if (predicate(last)) return last
+            SystemClock.sleep(200)
+        }
+        val paneCapture = remoteExec(
+            session,
+            "tmux capture-pane -p -t ${shellQuote(SESSION_NAME)}",
+        ).stdout
+        preserveTailFailure(
+            phase = "03-transcript-failure",
+            paneCapture = paneCapture,
+            serverTranscript = last,
+        )
+        assertTrue(
+            "server pane-output predicate timed out; queue=${queueSnapshot()}; output:\n" +
+                Issue1733JourneyContract.xmlSafeFailureText(last),
+            predicate(last),
+        )
+        return last
+    }
+
+    private fun preserveTailFailure(
+        phase: String,
+        paneCapture: String,
+        serverTranscript: String,
+    ) {
+        val safePhase = phase.replace(Regex("[^a-z0-9-]"), "-")
+        val queue = writeText("$safePhase-queue.txt", queueSnapshot())
+        val diagnostics = writeText(
+            "$safePhase-diagnostics.txt",
+            diagnosticSummary().ifEmpty { "<no diagnostics>\n" },
+        )
+        val rawCapture = writeText("$safePhase-pane-capture-raw.txt", paneCapture)
+        val rawTranscript = writeText("$safePhase-server-transcript-raw.txt", serverTranscript)
+        val report = writeText(
+            "$safePhase-report.txt",
+            Issue1733JourneyContract.xmlSafeFailureText(
+                "queue=${queueSnapshot()}\npaneCapture:\n$paneCapture\n" +
+                    "serverTranscript:\n$serverTranscript\n",
+            ),
+        )
+        preserveArtifacts(
+            phase = phase,
+            queue.name,
+            diagnostics.name,
+            rawCapture.name,
+            rawTranscript.name,
+            report.name,
+        )
+    }
+
+    private fun writeThroughTerminalSession(text: String) {
+        val bytes = text.toByteArray()
+        var wrote = false
+        compose.activityRule.scenario.onActivity { activity ->
+            activity.window.decorView.findTerminalView()?.currentSession?.let {
+                it.write(bytes, 0, bytes.size)
+                wrote = true
+            }
+        }
+        assertTrue("expected a live TerminalView input session", wrote)
+    }
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView.findTerminalView()
+                ?.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+        return text
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        repeat(childCount) { index ->
+            getChildAt(index).findTerminalView()?.let { return it }
+        }
+        return null
+    }
+
+    private fun captureViewport(name: String) {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also {
+                view.draw(Canvas(it))
+            }
+        }
+        bitmap?.let {
+            FileOutputStream(artifactFile("$name-viewport.png")).use { out ->
+                it.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+            it.recycle()
+        }
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+    }
+
+    private fun captureDecorViewport(name: String): File {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        lateinit var captured: Bitmap
+        compose.activityRule.scenario.onActivity { activity ->
+            val decor = activity.window.decorView
+            check(decor.isShown) { "activity decor is not shown" }
+            check(decor.width > 0 && decor.height > 0) {
+                "activity decor has invalid bounds ${decor.width}x${decor.height}"
+            }
+            captured = Bitmap.createBitmap(
+                decor.width,
+                decor.height,
+                Bitmap.Config.ARGB_8888,
+            ).also { decor.draw(Canvas(it)) }
+        }
+        val artifact = artifactFile("$name-viewport.png")
+        try {
+            FileOutputStream(artifact).use { output ->
+                check(captured.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "failed to encode ${artifact.absolutePath}"
+                }
+            }
+        } finally {
+            captured.recycle()
+        }
+        assertTrue(
+            "full-decor screenshot artifact must exist and be nonempty: ${artifact.absolutePath}",
+            artifact.isFile && artifact.length() > 0L,
+        )
+        assertScreenshotNotBlank(artifact)
+        println("ISSUE1733_ARTIFACT ${artifact.absolutePath}")
+        return artifact
+    }
+
+    private fun writeText(name: String, text: String): File =
+        artifactFile(name).also {
+            it.writeText(text)
+            println("ISSUE1733_ARTIFACT ${it.absolutePath}")
+        }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val root = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(root, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) { "could not create ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    private fun preserveArtifacts(phase: String, vararg names: String) {
+        val sources = names.map(::artifactFile)
+        val destination = "$PRESERVED_DEVICE_ROOT/$artifactRunId/$phase"
+        Issue1733ArtifactPreserver.preserve(
+            instrumentation = InstrumentationRegistry.getInstrumentation(),
+            phase = phase,
+            sources = sources,
+            destination = destination,
+        )
+        println("ISSUE1733_PRESERVED phase=$phase destination=$destination")
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        timings += "$name=$value"
+    }
+
+    private fun countOccurrences(haystack: String, needle: String): Int {
+        var count = 0
+        var at = haystack.indexOf(needle)
+        while (at >= 0) {
+            count += 1
+            at = haystack.indexOf(needle, at + needle.length)
+        }
+        return count
+    }
+
+    private fun targetContext(): Context =
+        InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation().context.assets.open("test_key")
+            .bufferedReader().use { it.readText() }
+
+    private fun createImmutableAttachment(context: Context): File {
+        val file = File(context.cacheDir, ATTACHMENT_NAME)
+        val chunk = ByteArray(64 * 1024) { ((it * 31 + 17) and 0xff).toByte() }
+        file.outputStream().use { output ->
+            var remaining = UPLOAD_BYTES
+            while (remaining > 0) {
+                val count = minOf(chunk.size.toLong(), remaining).toInt()
+                output.write(chunk, 0, count)
+                remaining -= count
+            }
+        }
+        return file
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private suspend fun seedDockerHost(key: String): Long {
+        val context = targetContext()
+        val db = Room.databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context,
+                db.sshKeyDao(),
+                "issue1733-offset-resume-key-${System.currentTimeMillis()}",
+                key,
+            )
+            db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1733 Offset Resume",
+                    hostname = DEFAULT_HOST,
+                    port = NETWORK_FAULT_SSH_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedFakeAgentSession(
+        key: String,
+    ): Issue1733JourneyContract.FakeAgentTmuxIdentity {
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(key),
+            port = DIRECT_AGENTS_SSH_PORT,
+            description = "issue1733 fake-agent durable queue seed",
+            command = """
+                set -eu
+                tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true
+                rm -rf ${shellQuote(PromptAttachmentStager.REMOTE_DIRECTORY)}
+                rm -f ${shellQuote(PANE_OUTPUT_PATH)}
+                tmux new-session -d -s ${shellQuote(SESSION_NAME)} -x 80 -y 40 \
+                  ${shellQuote("exec /usr/local/bin/pocketshell-fake-agent")}
+                tmux pipe-pane -O -t ${shellQuote(SESSION_NAME)} \
+                  ${shellQuote("cat >> $PANE_OUTPUT_PATH")}
+                tmux display-message -p -t ${shellQuote(SESSION_NAME)} \
+                  '#{session_id}:#{session_created}:#{pane_id}'
+            """.trimIndent(),
+        )
+        return Issue1733JourneyContract.parseFakeAgentTmuxIdentity(result.stdout)
+    }
+
+    private suspend fun cleanupRemote(key: String) {
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DIRECT_AGENTS_SSH_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use {
+                it.exec(
+                    "tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true; " +
+                        "rm -rf ${shellQuote(PromptAttachmentStager.REMOTE_DIRECTORY)}; " +
+                        "rm -f ${shellQuote(PANE_OUTPUT_PATH)}",
+                )
+            }
+        }
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME = "pocketshell.db"
+        const val OUTBOUND_QUEUE_PREFS = "outbound_queue"
+        const val DEVICE_DIR_NAME = "issue1733-offset-resume"
+        const val SESSION_NAME = "issue1733-offset-resume"
+        const val PANE_OUTPUT_PATH = "/tmp/issue1733-offset-resume-pane-output"
+        const val ATTACHMENT_NAME = "issue1733-immutable.bin"
+        const val PROMPT = "issue1733 resumable attachment prompt"
+        const val LIVE_INPUT_MARKER = "issue1733-live-input"
+        const val FAKE_AGENT_READY = "FAKE-AGENT-READY"
+        const val FAKE_AGENT_SUBMITTED = "FAKE-AGENT SUBMITTED: "
+        const val UPLOAD_BYTES = 16L * 1024 * 1024
+        const val CUT_AFTER_BYTES = 512L * 1024
+        const val REQUIRED_STABLE_REMOTE_READS = 8
+        const val DELIVERY_MAIN_CLOCK_STEP_MS = 20L
+        const val AUTO_RETRY_WINDOW_MS = 5_000L
+        const val HOOK_TIMEOUT_MS = 90_000L
+        const val SSHD_SNAPSHOT = "ps -o pid,ppid,stat,cmd -u testuser | grep '[s]shd' || true"
+        const val PRESERVED_DEVICE_ROOT = "/sdcard/Download/pocketshell-issue1733"
+        const val NETWORK_FAULT_ARG = "pocketshellNetworkFaultProofs"
+        const val DIRECT_AGENTS_SSH_PORT = 2222
+        const val NETWORK_FAULT_SSH_PORT = 2228
+        const val TOXIPROXY_API_PORT = 8474
+        val CLAIMED_OUTBOUND_STATES = setOf(OutboundState.Uploading, OutboundState.InFlight)
+        const val ATTACHING_LABEL = "Attaching…"
+
+        val HOST_ROW_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 25_000L
+        val PROGRESS_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 120_000L else 60_000L
+        val REMOTE_PROBE_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+        val QUEUE_RETRYABLE_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 25_000L
+        val CONNECTION_LOST_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 25_000L
+        val CONNECTED_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 90_000L else 45_000L
+        val RESUME_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 180_000L else 90_000L
+        val DELIVERY_TERMINAL_TIMEOUT_MS = Issue1733JourneyContract.deliveryTerminalTimeoutMs(
+            productionSendTimeoutMs = PromptComposerViewModel.SEND_TIMEOUT_MS,
+            environmentFloorMs = if (TerminalTestTimeouts.isRunningOnCi()) 120_000L else 90_000L,
+        )
+        val INPUT_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 25_000L
+        val UI_TIMEOUT_MS = if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+    }
+}

--- a/app/src/debug/java/com/pocketshell/app/proof/Issue1733JourneyContract.kt
+++ b/app/src/debug/java/com/pocketshell/app/proof/Issue1733JourneyContract.kt
@@ -1,0 +1,65 @@
+package com.pocketshell.app.proof
+
+/**
+ * Pure, debug-only contracts used by the issue #1733 connected journey.
+ *
+ * Keeping these transformations outside the instrumentation class makes the
+ * pane identity, deadline ordering, and XML-safe failure rendering directly
+ * unit-testable without adding a production test seam.
+ */
+internal object Issue1733JourneyContract {
+
+    data class FakeAgentTmuxIdentity(
+        val sessionId: String,
+        val sessionCreated: Long,
+        val paneId: String,
+    )
+
+    private val identityLine = Regex("""^(\${'$'}\d+):(\d+):(%\d+)$""")
+
+    fun parseFakeAgentTmuxIdentity(output: String): FakeAgentTmuxIdentity {
+        val match = output.lineSequence()
+            .map(String::trim)
+            .mapNotNull(identityLine::matchEntire)
+            .lastOrNull()
+            ?: error("fake-agent setup did not return session_id:session_created:pane_id")
+        return FakeAgentTmuxIdentity(
+            sessionId = match.groupValues[1],
+            sessionCreated = match.groupValues[2].toLong(),
+            paneId = match.groupValues[3],
+        )
+    }
+
+    /**
+     * The journey must never declare delivery stuck before production's own
+     * dispatcher timeout can defer the row. The additional headroom covers the
+     * durable state write and the server transcript becoming observable.
+     */
+    fun deliveryTerminalTimeoutMs(
+        productionSendTimeoutMs: Long,
+        environmentFloorMs: Long,
+        headroomMs: Long = 15_000L,
+    ): Long {
+        require(productionSendTimeoutMs > 0L)
+        require(environmentFloorMs > 0L)
+        require(headroomMs > 0L)
+        return maxOf(environmentFloorMs, productionSendTimeoutMs + headroomMs)
+    }
+
+    /**
+     * JUnit XML is XML 1.0: C0 controls such as ESC are forbidden even as a
+     * numeric character reference. Raw artifacts remain untouched; only text
+     * crossing the assertion/report boundary uses this printable form.
+     */
+    fun xmlSafeFailureText(raw: String): String = buildString(raw.length) {
+        for (ch in raw) {
+            when {
+                ch == '\u001B' -> append("<ESC>")
+                ch == '\t' || ch == '\n' || ch == '\r' -> append(ch)
+                ch < '\u0020' || ch in '\uD800'..'\uDFFF' || ch == '\uFFFE' || ch == '\uFFFF' ->
+                    append("<U+${ch.code.toString(16).uppercase().padStart(4, '0')}>")
+                else -> append(ch)
+            }
+        }
+    }
+}

--- a/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
+++ b/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
@@ -178,6 +178,21 @@ class ToxiproxyControl(
         transport.request("POST", "/proxies/$PROXY_NAME", """{"enabled":true}""")
     }
 
+    /**
+     * Hold a real proxy outage while [whileDisabled] inspects the production UI.
+     *
+     * Restoration is unconditional so a failed visibility assertion cannot leave
+     * the singleton network-fault fixture disabled for the next journey.
+     */
+    suspend inline fun <T> withDisabledProxy(whileDisabled: suspend () -> T): T {
+        disable()
+        return try {
+            whileDisabled()
+        } finally {
+            enable()
+        }
+    }
+
     private fun createProxy() {
         // Tolerate HTTP 409 "proxy already exists": toxiproxy is a single shared
         // instance, so when more than one connected lane resets concurrently the

--- a/app/src/main/java/com/pocketshell/app/tmux/QueueSidecarUploadJourneySeam.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/QueueSidecarUploadJourneySeam.kt
@@ -1,0 +1,44 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.LocalAttachmentSidecarRef
+import com.pocketshell.core.ssh.QueueSidecarResumableUploadRequest
+import com.pocketshell.core.ssh.QueueSidecarResumableUploadResult
+import com.pocketshell.core.ssh.QueueSidecarUploadProgress
+import com.pocketshell.core.ssh.SshSession
+import java.io.File
+
+internal suspend fun SshSession.uploadQueuedSidecar(
+    ref: LocalAttachmentSidecarRef,
+    remotePath: String,
+): QueueSidecarResumableUploadResult =
+    uploadQueueSidecar(
+        QueueSidecarResumableUploadRequest(
+            localFile = File(ref.localPath),
+            remotePath = remotePath,
+            stableToken = ref.id,
+            expectedBytes = ref.byteSize,
+            displayName = ref.displayName,
+        ),
+        onProgress = { progress ->
+            QueueSidecarUploadJourneySeam.onProgress?.invoke(ref, progress)
+        },
+    ).also { result ->
+        QueueSidecarUploadJourneySeam.onResult?.invoke(ref, result)
+    }
+
+/**
+ * Instrumentation-only synchronization seam for issue #1733's genuine wire cut.
+ * Production leaves [onProgress] null.
+ */
+internal object QueueSidecarUploadJourneySeam {
+    @Volatile
+    var onProgress: ((LocalAttachmentSidecarRef, QueueSidecarUploadProgress) -> Unit)? = null
+
+    @Volatile
+    var onResult: ((LocalAttachmentSidecarRef, QueueSidecarResumableUploadResult) -> Unit)? = null
+
+    fun reset() {
+        onProgress = null
+        onResult = null
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -13695,17 +13695,17 @@ public class TmuxSessionViewModel @Inject constructor(
                 )
             }
             val uploadedPaths = sidecars.mapIndexed { index, ref ->
-                val local = File(ref.localPath)
-                if (!local.exists()) {
-                    throw SshException("Queued attachment no longer exists: ${ref.displayName}")
-                }
                 val sanitised = FilenameSanitiser.sanitise(
                     ref.displayName,
                     defaultExtension = ShareUploader.extensionForMimeType(ref.mimeType),
                 )
-                val remoteName = PromptAttachmentStager.composeAttachmentName(timestamp, index, sanitised)
+                val remoteName = PromptAttachmentStager.composeAttachmentName(
+                    timestamp,
+                    ref.attachmentIndex ?: index,
+                    sanitised,
+                )
                 val remotePath = "$remoteDir/$remoteName"
-                session.uploadFile(local, remotePath)
+                session.uploadQueuedSidecar(ref, remotePath)
                 "$displayDir/$remoteName"
             }
             DiagnosticEvents.record(

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerSidecarReuploadSkipTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerSidecarReuploadSkipTest.kt
@@ -288,6 +288,15 @@ class PromptComposerSidecarReuploadSkipTest {
             listOf("~/.pocketshell/attachments/session-a/uploaded-doc.pdf"),
             sent.single().attachments.map { it.remotePath },
         )
+        assertEquals(
+            "the original attachment-bearing prompt is emitted exactly once after resume",
+            "retry me",
+            sent.single().cleanDraft,
+        )
+        assertTrue(
+            "the one resumed delivery preserves the original single Enter intent",
+            sent.single().withEnter,
+        )
     }
 
     // ---- Class coverage: first send uploads normally (skip never fires spuriously) -

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1733QueuedSidecarResumeViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1733QueuedSidecarResumeViewModelTest.kt
@@ -1,0 +1,233 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.DurableAttachmentRef
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import com.pocketshell.app.composer.LocalAttachmentSidecarRef
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.appendAttachmentPaths
+import com.pocketshell.app.composer.asWireAttemptDurableStore
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.QueueSidecarResumableUploadRequest
+import com.pocketshell.core.ssh.QueueSidecarResumableUploadResult
+import com.pocketshell.core.ssh.QueueSidecarUploadDisposition
+import com.pocketshell.core.ssh.QueueSidecarUploadProgress
+import com.pocketshell.core.ssh.SshException
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+class Issue1733QueuedSidecarResumeViewModelTest : TmuxSessionViewModelTestBase() {
+
+    @Test
+    fun realPaneAndStableQueueIdOwnTheDurableWireAttempt() {
+        val paneId = "%12"
+        val cleanText = "issue1733 resumable attachment prompt"
+        val attachment = DurableAttachmentRef(
+            remotePath = "~/.pocketshell/attachments/host/session/proof.bin",
+            displayName = "proof.bin",
+        )
+        val payload = appendAttachmentPaths(cleanText, listOf(attachment.remotePath))
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue(
+            sessionKey = "tmux:1:\$7:1784911681",
+            cleanText = cleanText,
+            attachments = listOf(attachment),
+            paneId = paneId,
+            route = OutboundRoute.AgentPayload,
+            agentKind = "claude",
+        )
+        val otherSessionRow = store.enqueue(
+            sessionKey = "tmux:1:\$7:1784919999",
+            cleanText = cleanText,
+            attachments = listOf(attachment),
+            paneId = paneId,
+            route = OutboundRoute.AgentPayload,
+            agentKind = "claude",
+        )
+        val ledger = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
+        val durableRow = DurableOutboundRowIdentity(
+            sessionKey = row.sessionKey,
+            rowId = row.id,
+        )
+
+        // Normal durable delivery uses the row id as the stable retry token, but
+        // durable ownership is the exact session+row identity. Pane and payload
+        // are deliberately not authorities: another session may own the same %12
+        // and send the same bytes.
+        ledger.recordWireAttempt(
+            paneId = paneId,
+            sendToken = row.id,
+            payload = payload,
+            baselineCount = 0,
+            durableRow = durableRow,
+        )
+
+        assertTrue(store.hasWireAttempt(row.sessionKey, row.id))
+        assertEquals(false, store.hasWireAttempt(otherSessionRow.sessionKey, otherSessionRow.id))
+
+        val rebuiltLedger = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
+        assertTrue(
+            rebuiltLedger.hasAmbiguousAttempt(
+                paneId = paneId,
+                sendToken = row.id,
+                payload = payload,
+                durableRow = durableRow,
+            ),
+        )
+        assertEquals(
+            false,
+            rebuiltLedger.hasAmbiguousAttempt(
+                paneId = paneId,
+                sendToken = otherSessionRow.id,
+                payload = payload,
+                durableRow = DurableOutboundRowIdentity(
+                    sessionKey = otherSessionRow.sessionKey,
+                    rowId = otherSessionRow.id,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun durableSidecarIdentityAndFinalPathStayStableAcrossAttempts() = runTest(scheduler) {
+        val local = File.createTempFile("issue1733-vm", ".bin").apply {
+            writeBytes(ByteArray(64) { it.toByte() })
+            deleteOnExit()
+        }
+        val ref = LocalAttachmentSidecarRef(
+            id = "durable-sidecar-id",
+            outboundItemId = "row-1733",
+            localPath = local.absolutePath,
+            displayName = "proof.bin",
+            mimeType = "application/octet-stream",
+            byteSize = local.length(),
+            createdAtMs = 1_725_000_000_000L,
+            attachmentIndex = 3,
+        )
+        val session = RecordingSession()
+        val vm = newVm()
+        vm.replaceClientForTest(
+            hostId = 1733L,
+            hostName = "Issue 1733",
+            host = "test",
+            port = 22,
+            user = "test",
+            keyPath = "",
+            sessionName = "resume",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+
+        session.nextFailure = SshException("controlled transport cut")
+        val first = vm.uploadQueuedAttachmentSidecars(listOf(ref))
+        assertTrue(first.isFailure)
+
+        val second = vm.uploadQueuedAttachmentSidecars(listOf(ref)).getOrThrow()
+        assertEquals(1, second.size)
+        assertEquals(2, session.requests.size)
+        val firstRequest = session.requests[0]
+        val secondRequest = session.requests[1]
+        assertEquals(ref.id, firstRequest.stableToken)
+        assertEquals(firstRequest.stableToken, secondRequest.stableToken)
+        assertEquals(ref.byteSize, secondRequest.expectedBytes)
+        assertEquals(firstRequest.remotePath, secondRequest.remotePath)
+        assertTrue(
+            "the original durable attachment index, not pending-batch order, owns the final name",
+            secondRequest.remotePath.contains("-04-proof.bin"),
+        )
+        assertEquals(secondRequest.remotePath.replace(".pocketshell/attachments", "~/.pocketshell/attachments"), second.single())
+    }
+
+    @Test
+    fun alreadyCompleteIsMappedToSuccessWithoutASecondByteTransfer() = runTest(scheduler) {
+        val local = File.createTempFile("issue1733-complete", ".txt").apply {
+            writeText("already complete")
+            deleteOnExit()
+        }
+        val ref = LocalAttachmentSidecarRef(
+            id = "already-complete-sidecar",
+            outboundItemId = "row-complete",
+            localPath = local.absolutePath,
+            displayName = "complete.txt",
+            mimeType = "text/plain",
+            byteSize = local.length(),
+            createdAtMs = 1_725_000_000_000L,
+            attachmentIndex = 0,
+        )
+        val session = RecordingSession().apply {
+            nextDisposition = QueueSidecarUploadDisposition.AlreadyComplete
+        }
+        val vm = newVm()
+        vm.replaceClientForTest(
+            hostId = 1733L,
+            hostName = "Issue 1733",
+            host = "test",
+            port = 22,
+            user = "test",
+            keyPath = "",
+            sessionName = "resume",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+
+        val result = vm.uploadQueuedAttachmentSidecars(listOf(ref))
+        assertTrue(result.isSuccess)
+        assertEquals(QueueSidecarUploadDisposition.AlreadyComplete, session.dispositions.single())
+        assertEquals(0L, session.transmitted.single())
+    }
+
+    private class RecordingSession : SshSession {
+        val requests = mutableListOf<QueueSidecarResumableUploadRequest>()
+        val dispositions = mutableListOf<QueueSidecarUploadDisposition>()
+        val transmitted = mutableListOf<Long>()
+        var nextFailure: Throwable? = null
+        var nextDisposition = QueueSidecarUploadDisposition.Uploaded
+
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult = ExecResult("", "", 0)
+
+        override suspend fun uploadQueueSidecar(
+            request: QueueSidecarResumableUploadRequest,
+            onProgress: ((QueueSidecarUploadProgress) -> Unit)?,
+        ): QueueSidecarResumableUploadResult {
+            requests += request
+            nextFailure?.let {
+                nextFailure = null
+                throw it
+            }
+            val disposition = nextDisposition
+            val sent = if (disposition == QueueSidecarUploadDisposition.AlreadyComplete) 0L else request.expectedBytes
+            dispositions += disposition
+            transmitted += sent
+            return QueueSidecarResumableUploadResult(
+                remotePath = request.remotePath,
+                resumedFromBytes = if (sent == 0L) request.expectedBytes else 0L,
+                transmittedBytes = sent,
+                disposition = disposition,
+            )
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit) = error("not used")
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+        override fun close() = Unit
+    }
+}

--- a/app/src/testDebug/java/com/pocketshell/app/proof/Issue1733JourneyContractTest.kt
+++ b/app/src/testDebug/java/com/pocketshell/app/proof/Issue1733JourneyContractTest.kt
@@ -1,0 +1,42 @@
+package com.pocketshell.app.proof
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Issue1733JourneyContractTest {
+
+    @Test
+    fun fakeAgentIdentityCarriesTheAuthoritativeRealPaneId() {
+        val identity = Issue1733JourneyContract.parseFakeAgentTmuxIdentity(
+            "setup chatter\n\$7:1784911681:%12\n",
+        )
+
+        assertEquals("\$7", identity.sessionId)
+        assertEquals(1_784_911_681L, identity.sessionCreated)
+        assertEquals("%12", identity.paneId)
+    }
+
+    @Test
+    fun deliveryDeadlineAlwaysOutlivesTheProductionSendTimeout() {
+        val timeout = Issue1733JourneyContract.deliveryTerminalTimeoutMs(
+            productionSendTimeoutMs = 50_000L,
+            environmentFloorMs = 45_000L,
+        )
+
+        assertEquals(65_000L, timeout)
+        assertTrue(timeout > 50_000L)
+    }
+
+    @Test
+    fun xmlFailureTextEscapesForbiddenControlsWithoutChangingRawInput() {
+        val raw = "\u001B[H\u0000ready\tline\n"
+        val safe = Issue1733JourneyContract.xmlSafeFailureText(raw)
+
+        assertEquals("<ESC>[H<U+0000>ready\tline\n", safe)
+        assertFalse(safe.contains('\u001B'))
+        assertFalse(safe.contains('\u0000'))
+        assertEquals('\u001B', raw.first())
+    }
+}

--- a/app/src/testDebug/java/com/pocketshell/app/proof/ToxiproxyControlTest.kt
+++ b/app/src/testDebug/java/com/pocketshell/app/proof/ToxiproxyControlTest.kt
@@ -1,6 +1,8 @@
 package com.pocketshell.app.proof
 
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class ToxiproxyControlTest {
@@ -68,6 +70,43 @@ class ToxiproxyControlTest {
     }
 
     @Test
+    fun disabledScopeOrdersRealCutBeforeCaptureAndRestoresAfterward() {
+        val events = mutableListOf<String>()
+        val transport = RecordingTransport { request ->
+            events += if (request.body == """{"enabled":false}""") "disable" else "enable"
+        }
+
+        runBlocking {
+            ToxiproxyControl(baseUrl = "http://unused", transport = transport)
+                .withDisabledProxy {
+                    events += "assert-and-capture"
+                }
+        }
+
+        assertEquals(listOf("disable", "assert-and-capture", "enable"), events)
+    }
+
+    @Test
+    fun disabledScopeRestoresProxyWhenCaptureAssertionFails() {
+        val events = mutableListOf<String>()
+        val transport = RecordingTransport { request ->
+            events += if (request.body == """{"enabled":false}""") "disable" else "enable"
+        }
+
+        assertThrows(AssertionError::class.java) {
+            runBlocking {
+                ToxiproxyControl(baseUrl = "http://unused", transport = transport)
+                    .withDisabledProxy {
+                        events += "assert-and-capture"
+                        throw AssertionError("visible pill missing")
+                    }
+            }
+        }
+
+        assertEquals(listOf("disable", "assert-and-capture", "enable"), events)
+    }
+
+    @Test
     fun clearToxicsDeletesEveryKnownFaultModel() {
         val transport = RecordingTransport()
         ToxiproxyControl(baseUrl = "http://unused", transport = transport).clearToxics()
@@ -93,11 +132,15 @@ class ToxiproxyControlTest {
         val body: String?,
     )
 
-    private class RecordingTransport : ToxiproxyTransport {
+    private class RecordingTransport(
+        private val onRequest: (RecordedRequest) -> Unit = {},
+    ) : ToxiproxyTransport {
         val requests = mutableListOf<RecordedRequest>()
 
         override fun request(method: String, path: String, body: String?): String {
-            requests += RecordedRequest(method, path, body)
+            val request = RecordedRequest(method, path, body)
+            requests += request
+            onRequest(request)
             return "{}"
         }
     }

--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -812,6 +812,12 @@ run_class() {
   local remaining cap rc attempt_start attempt_elapsed cleanup_status
   local app_id_suffix="${POCKETSHELL_APP_ID_SUFFIX:-}"
   local -a app_id_args=()
+  local -a network_fault_args=()
+  if [[ "$fqcn" == *OutboundAttachmentOffsetResumeJourneyE2eTest* ]]; then
+    network_fault_args+=(
+      -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true
+    )
+  fi
   if [[ "$JOURNEY_ABORT_ISOLATION_FAILED" -eq 1 ]]; then
     return "$JOURNEY_HARNESS_FAILURE_RC"
   fi
@@ -854,6 +860,7 @@ run_class() {
     "${app_id_args[@]}" \
     --max-workers=2 \
     -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+    "${network_fault_args[@]}" \
     -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
     --stacktrace
@@ -981,8 +988,15 @@ run_ct_class() {
 shard_class() {
   local idx="$1"
   local fqcn="$2"
+  local -a network_fault_args=()
+  if [[ "$fqcn" == *OutboundAttachmentOffsetResumeJourneyE2eTest* ]]; then
+    network_fault_args+=(
+      -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true
+    )
+  fi
   "$REPO_ROOT/scripts/connected-test.sh" --pool --suffix "ij$idx" \
     -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+    "${network_fault_args[@]}" \
     -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
     -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
     --stacktrace

--- a/scripts/ci-journey-class-selection-functions.sh
+++ b/scripts/ci-journey-class-selection-functions.sh
@@ -62,7 +62,7 @@ print_journey_class_selection() {
   for c in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
     echo "  - $c"
   done
-  echo "  (pocketshellCi=true; deterministic agents:2222 only, no toxiproxy)"
+  echo "  (pocketshellCi=true; deterministic agents:2222 plus the existing Toxiproxy fixture for #1733)"
   echo "  (per-class retry-once for CI-AVD infra flakes — issue #712)"
   echo "=========================================================="
 }

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -11,14 +11,15 @@
 # This driver runs inside the `reactivecircus/android-emulator-runner`
 # `script:` step, so the emulator is already booted and `adb` is on PATH. The
 # deterministic Docker `agents` fixture (agents:2222 -> emulator 10.0.2.2:2222)
-# was started + waited-healthy by the workflow before this script runs.
+# and its existing Toxiproxy route (2228/API 8474) are started by the workflow.
 #
 # It runs ONLY the load-bearing subset (NOT the full connected suite — that
-# stays nightly). Every class below uses the plain deterministic `agents:2222`
-# fixture; NONE need the opt-in toxiproxy network-fault proxies, so the job is
-# deterministic and does not depend on the proxy family the per-push job
-# deliberately leaves down. `pocketshellCi=true` selects the generous E2E
-# timeout ceilings so a slow CI runner does not flake these out.
+# stays nightly). Every class below uses the deterministic `agents:2222`
+# fixture. Issue #1733 additionally routes only the app transport through the
+# existing Toxiproxy service while its direct checkpoint/killer sidecar remains
+# on 2222; the suite passes the explicit network-fault opt-in and the workflow
+# starts that service. `pocketshellCi=true` selects the generous E2E timeout
+# ceilings so a slow CI runner does not flake these out.
 #
 # Load-bearing subset and what each pins:
 #   * DeepLinkSessionSwitchE2eTest (issue #470)
@@ -92,8 +93,8 @@ GRADLEW="$REPO_ROOT/gradlew"
 FQCN_PREFIX="com.pocketshell.app.proof"
 
 # The load-bearing journey classes. Keep this list aligned with the issue #691
-# named subset; every class here MUST use only the deterministic agents:2222
-# fixture (no toxiproxy) so the per-push job stays deterministic.
+# named subset. Every class uses deterministic agents:2222; #1733 alone also
+# uses the existing 2228/API-8474 Toxiproxy route to hold its real outage.
 #
 # Issue #705: three picker-driven journeys re-join the picker-FREE
 # DeepLinkSessionSwitchE2eTest now that the picker enumeration wedge is fixed
@@ -156,6 +157,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"  # #848 #900 audit / ): the foreground outbound queue surface was
   "com.pocketshell.app.tmux.Issue1686QueueDrainWireOracleDockerTest"  # #1686 D33/G4 the composer-queue clog fix on the REAL wire: a false not-Connected label (inline enum Reconnecting + drain-gate sessionLive=false) while the -CC transport is writable — the queued prompt must DRAIN to the real tmux pane (capture-pane), and the transport-alive edge un-parks the storm-stranded backlog
   "$FQCN_PREFIX.OutboundExactlyOnceAcrossFlapE2eTest"  # #1526 S1/S6 D31: delivery-level exactly-once across a mid-send flap (server capture-pane occurrence == 1, composer + keystroke lanes)
+  "$FQCN_PREFIX.OutboundAttachmentOffsetResumeJourneyE2eTest"  # #1733 durable queued sidecar: real app-worker death preserves checkpoint N, fresh session sends total-N, atomic SHA-identical promotion and once-only prompt+Enter
   "com.pocketshell.app.composer.PromptComposerUndeliveredRetryTest"  # #1272 #1341 the durable couldn't deliver — retry surface wired into
   "com.pocketshell.app.composer.PromptComposerUndeliveredRetryHiltWiringTest"  # #1272 #1341 round-2, finding 1): the PRODUCTION-WIRING proof. The class…
   "com.pocketshell.app.tmux.AgentQuickReplyBandContainmentProofTest"  # #1235 F2/F3: quick-reply band stays above the IME + doesn't occlude composer/terminal controls (synthetic ime inset)

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -314,7 +314,8 @@ if [[ "$CLEANUP_ONLY" != "1" ]]; then
   case "$gradle_args_str" in
     *NetworkFault*|*NetworkLatencyModel*|*PacketLoss*|*DisconnectBlackhole*\
       |*DisconnectFlap*|*KeepAliveDeadPeer*|*RideThrough*|*WithinGrace*\
-      |*StaleLeaseSwitchRecovery*|*CodexRedrawOverflowReconnect*)
+      |*StaleLeaseSwitchRecovery*|*CodexRedrawOverflowReconnect*\
+      |*OutboundAttachmentOffsetResumeJourneyE2eTest*)
       NETWORK_FAULT_RUN=1
       ;;
   esac

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/ResumableUploadIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/ResumableUploadIntegrationTest.kt
@@ -1,0 +1,452 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.AfterClass
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.File
+import java.io.IOException
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Issue #1733 real-wire regression suite. Every transfer goes through
+ * [RealSshSession] and a real Docker OpenSSH server.
+ */
+class ResumableUploadIntegrationTest {
+
+    companion object {
+        private const val CONTAINER_SSH_PORT = 22
+        private val projectRoot: Path by lazy { findProjectRoot() }
+
+        @Volatile
+        private var container: GenericContainer<*>? = null
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            val dockerAvailable = runCatching {
+                DockerClientFactory.instance().isDockerAvailable
+            }.getOrDefault(false)
+            assumeTrue("Docker not available; skipping resumable-upload tests", dockerAvailable)
+            val image = ImageFromDockerfile("pocketshell-test-ssh", false)
+                .withDockerfile(projectRoot.resolve("tests/docker/Dockerfile.ssh"))
+            container = GenericContainer(image)
+                .withExposedPorts(CONTAINER_SSH_PORT)
+                .also { it.start() }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            runCatching {
+                container?.let {
+                    DockerClientFactory.instance().client().unpauseContainerCmd(it.containerId).exec()
+                }
+            }
+            container?.stop()
+            container = null
+        }
+
+        private fun findProjectRoot(): Path {
+            var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            while (dir != null) {
+                if (dir.resolve("tests/docker/Dockerfile.ssh").toFile().exists()) return dir
+                dir = dir.parent
+            }
+            error("Could not locate tests/docker/Dockerfile.ssh")
+        }
+    }
+
+    private val host: String get() = container!!.host
+    private val port: Int get() = container!!.getMappedPort(CONTAINER_SSH_PORT)
+    private val keyFile: File get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    private suspend fun connect(): SshSession =
+        SshConnection.connect(
+            host = host,
+            port = port,
+            user = "testuser",
+            key = SshKey.Path(keyFile),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+
+    private fun connectReal(uploadStallTimeoutMs: Long): RealSshSession = runBlocking {
+        val connector = SshConnection.RealSshConnector
+        val client = connector.createClient()
+        connector.applyKnownHostsPolicy(client, KnownHostsPolicy.AcceptAll)
+        connector.connect(client, host, port, 15_000)
+        connector.authenticate(client, "testuser", SshKey.Path(keyFile), null)
+        RealSshSession(client, uploadStallTimeoutMs = uploadStallTimeoutMs)
+    }
+
+    @Test
+    fun transportCutCommitsNAndNewSessionSendsOnlyTotalMinusN() = runBlocking {
+        val case = newCase("transport-cut", bytes = 12 * 1024 * 1024)
+        val first = connect()
+        prepare(first, case)
+        val cutIssued = AtomicBoolean(false)
+        val firstFailure = runCatching {
+            first.uploadQueueSidecar(case.request) { progress ->
+                if (progress.bytesTransferred >= 512 * 1024L && cutIssued.compareAndSet(false, true)) {
+                    first.close()
+                    throw IOException("issue #1733 genuine worker/transport cut")
+                }
+            }
+        }.exceptionOrNull()
+        first.close()
+        assertNotNull("the controlled transport cut must fail attempt one", firstFailure)
+
+        connect().use { inspector ->
+            val committedN = remoteSize(inspector, case.paths.dataPath)
+            assertNotNull("retryable transport failure must preserve its stable checkpoint", committedN)
+            assertTrue("checkpoint N must be > 0, got $committedN", committedN!! > 0L)
+            assertTrue("checkpoint N must be < total, got $committedN", committedN < case.request.expectedBytes)
+            assertFalse("final must remain absent before promotion", remoteExists(inspector, case.request.remotePath))
+
+            inspector.close()
+            val second = connect()
+            second.use { resumed ->
+                val result = resumed.uploadQueueSidecar(case.request)
+                assertEquals(committedN, result.resumedFromBytes)
+                assertEquals(
+                    "attempt two must spend only total-N bytes",
+                    case.request.expectedBytes - committedN,
+                    result.transmittedBytes,
+                )
+                assertEquals(QueueSidecarUploadDisposition.Uploaded, result.disposition)
+                assertEquals(case.request.expectedBytes, remoteSize(resumed, case.request.remotePath))
+                assertEquals(case.localSha256, remoteSha256(resumed, case.request.remotePath))
+                assertFalse("checkpoint data must disappear after atomic mv", remoteExists(resumed, case.paths.dataPath))
+                assertFalse("checkpoint identity must disappear after promotion", remoteExists(resumed, case.paths.identityPath))
+            }
+        }
+    }
+
+    @Test
+    fun cancellationPreservesCheckpointAndResumes() = runBlocking {
+        val case = newCase("cancellation", bytes = 4 * 1024 * 1024)
+        connect().use { first ->
+            prepare(first, case)
+            val cancelled = runCatching {
+                first.uploadQueueSidecar(case.request) { progress ->
+                    if (progress.bytesTransferred >= 256 * 1024L) {
+                        throw CancellationException("issue #1733 controlled cancellation")
+                    }
+                }
+            }.exceptionOrNull()
+            assertTrue(cancelled is CancellationException)
+        }
+
+        connect().use { second ->
+            val committed = remoteSize(second, case.paths.dataPath)
+            assertNotNull("cancellation must preserve committed checkpoint bytes", committed)
+            assertTrue(committed!! in 1 until case.request.expectedBytes)
+            val result = second.uploadQueueSidecar(case.request)
+            assertEquals(committed, result.resumedFromBytes)
+            assertEquals(case.request.expectedBytes - committed, result.transmittedBytes)
+            assertEquals(case.localSha256, remoteSha256(second, case.request.remotePath))
+        }
+    }
+
+    @Test
+    fun noProgressTimeoutPreservesCheckpoint() = runBlocking {
+        val case = newCase("stall", bytes = 24 * 1024 * 1024)
+        val session = connectReal(uploadStallTimeoutMs = 500L)
+        prepare(session, case)
+        val paused = AtomicBoolean(false)
+        val failure = try {
+            runCatching {
+                session.uploadQueueSidecar(case.request) { progress ->
+                    if (progress.bytesTransferred >= 512 * 1024L && paused.compareAndSet(false, true)) {
+                        DockerClientFactory.instance().client()
+                            .pauseContainerCmd(container!!.containerId)
+                            .exec()
+                    }
+                }
+            }.exceptionOrNull()
+        } finally {
+            if (paused.get()) {
+                DockerClientFactory.instance().client()
+                    .unpauseContainerCmd(container!!.containerId)
+                    .exec()
+            }
+            session.close()
+        }
+        assertNotNull("a no-progress stall must surface", failure)
+        assertTrue("expected a bounded stall error, got $failure", failure is SshException)
+
+        connect().use { inspector ->
+            val committed = remoteSize(inspector, case.paths.dataPath)
+            assertNotNull("no-progress timeout must preserve checkpoint", committed)
+            assertTrue("preserved checkpoint must contain a strict prefix", committed!! in 1 until case.request.expectedBytes)
+            assertFalse(remoteExists(inspector, case.request.remotePath))
+            cleanup(inspector, case)
+        }
+    }
+
+    @Test
+    fun completeCheckpointPromotesAndLostSuccessReturnsAlreadyComplete() = runBlocking {
+        val case = newCase("complete-and-lost-ack", bytes = 256 * 1024)
+        connect().use { session ->
+            prepare(session, case)
+            seedCheckpoint(session, case, case.localFile.readBytes(), expectedIdentity = true)
+            val promoted = session.uploadQueueSidecar(case.request)
+            assertEquals(case.request.expectedBytes, promoted.resumedFromBytes)
+            assertEquals(0L, promoted.transmittedBytes)
+            assertEquals(QueueSidecarUploadDisposition.Uploaded, promoted.disposition)
+            assertEquals(case.localSha256, remoteSha256(session, case.request.remotePath))
+
+            val lostAckRetry = session.uploadQueueSidecar(case.request)
+            assertEquals(QueueSidecarUploadDisposition.AlreadyComplete, lostAckRetry.disposition)
+            assertEquals(case.request.expectedBytes, lostAckRetry.resumedFromBytes)
+            assertEquals(0L, lostAckRetry.transmittedBytes)
+        }
+    }
+
+    @Test
+    fun corruptCheckpointCleansAndRestartsExplicitly() = runBlocking {
+        val case = newCase("corrupt", bytes = 384 * 1024)
+        connect().use { session ->
+            prepare(session, case)
+            val oversized = ByteArray(case.request.expectedBytes.toInt() + 17) { 0x55 }
+            seedCheckpoint(session, case, oversized, expectedIdentity = false)
+
+            val result = session.uploadQueueSidecar(case.request)
+            assertEquals("corrupt checkpoint must clean-restart at zero", 0L, result.resumedFromBytes)
+            assertEquals(case.request.expectedBytes, result.transmittedBytes)
+            assertEquals(case.localSha256, remoteSha256(session, case.request.remotePath))
+            assertFalse(remoteExists(session, case.paths.dataPath))
+            assertFalse(remoteExists(session, case.paths.identityPath))
+        }
+    }
+
+    @Test
+    fun permanentLocalValidationCleansOnlyOwnedCheckpointAndPreservesFinal() = runBlocking {
+        val case = newCase("local-validation", bytes = 128 * 1024)
+        connect().use { session ->
+            prepare(session, case)
+            seedCheckpoint(session, case, ByteArray(4096) { 0x33 }, expectedIdentity = true)
+            val sentinel = "existing-final-is-untouched"
+            session.exec("printf '%s' ${shellSingleQuote(sentinel)} > ${shellSingleQuote(case.request.remotePath)}")
+            case.localFile.appendBytes(byteArrayOf(1))
+
+            val failure = runCatching { session.uploadQueueSidecar(case.request) }.exceptionOrNull()
+            assertNotNull("changed immutable local sidecar must hard-fail", failure)
+            assertFalse("owned checkpoint data must be cleaned", remoteExists(session, case.paths.dataPath))
+            assertFalse("owned checkpoint identity must be cleaned", remoteExists(session, case.paths.identityPath))
+            val final = session.exec("cat ${shellSingleQuote(case.request.remotePath)}").stdout
+            assertEquals("permanent validation must not overwrite final", sentinel, final)
+        }
+    }
+
+    @Test
+    fun missingLocalFileCleansOwnedCheckpointAndPreservesFinal() = runBlocking {
+        val case = newCase("missing-local", bytes = 128 * 1024)
+        connect().use { session ->
+            prepare(session, case)
+            seedCheckpoint(session, case, ByteArray(4096) { 0x4d }, expectedIdentity = true)
+            val finalBytes = ByteArray(8193) { index -> ((index * 17 + 11) % 251).toByte() }
+            val finalSeed = File.createTempFile("issue1733-missing-local-final", ".bin").apply {
+                writeBytes(finalBytes)
+                deleteOnExit()
+            }
+            val finalSha256 = sha256(finalSeed)
+            session.uploadFile(finalSeed, case.request.remotePath)
+            assertEquals(4096L, remoteSize(session, case.paths.dataPath))
+            assertTrue(remoteExists(session, case.paths.identityPath))
+            assertEquals(
+                queueSidecarCheckpointIdentity(case.request),
+                session.exec("cat ${shellSingleQuote(case.paths.identityPath)}").stdout,
+            )
+            assertEquals(finalBytes.size.toLong(), remoteSize(session, case.request.remotePath))
+            assertEquals(finalSha256, remoteSha256(session, case.request.remotePath))
+            assertArrayEquals(
+                finalBytes,
+                session.downloadFile(case.request.remotePath, finalBytes.size.toLong()),
+            )
+
+            assertTrue("local source deletion must succeed", case.localFile.delete())
+            assertFalse("local source must be absent before upload", case.localFile.exists())
+            val failure = runCatching { session.uploadQueueSidecar(case.request) }.exceptionOrNull()
+
+            assertTrue("missing immutable local sidecar must hard-fail", failure is SshException)
+            assertEquals(
+                "Queued attachment no longer exists: ${case.request.displayName}",
+                failure?.message,
+            )
+            assertFalse("owned checkpoint data must be cleaned", remoteExists(session, case.paths.dataPath))
+            assertFalse("owned checkpoint identity must be cleaned", remoteExists(session, case.paths.identityPath))
+            assertEquals(finalBytes.size.toLong(), remoteSize(session, case.request.remotePath))
+            assertEquals(finalSha256, remoteSha256(session, case.request.remotePath))
+            assertArrayEquals(
+                "permanent missing-local failure must preserve exact final bytes",
+                finalBytes,
+                session.downloadFile(case.request.remotePath, finalBytes.size.toLong()),
+            )
+        }
+    }
+
+    @Test
+    fun wrongSizedPreExistingFinalFailsClosedAndCleansOwnedCheckpoint() = runBlocking {
+        val case = newCase("wrong-sized-final", bytes = 128 * 1024)
+        connect().use { session ->
+            prepare(session, case)
+            seedCheckpoint(session, case, ByteArray(4096) { 0x5a }, expectedIdentity = true)
+            val finalBytes = ByteArray(12_289) { index -> ((index * 29 + 3) % 251).toByte() }
+            val finalSeed = File.createTempFile("issue1733-wrong-sized-final", ".bin").apply {
+                writeBytes(finalBytes)
+                deleteOnExit()
+            }
+            val finalSha256 = sha256(finalSeed)
+            session.uploadFile(finalSeed, case.request.remotePath)
+            assertTrue(
+                "fixture final must conflict with the immutable request size",
+                finalBytes.size.toLong() != case.request.expectedBytes,
+            )
+            assertEquals(4096L, remoteSize(session, case.paths.dataPath))
+            assertTrue(remoteExists(session, case.paths.identityPath))
+            assertEquals(
+                queueSidecarCheckpointIdentity(case.request),
+                session.exec("cat ${shellSingleQuote(case.paths.identityPath)}").stdout,
+            )
+            assertEquals(finalBytes.size.toLong(), remoteSize(session, case.request.remotePath))
+            assertEquals(finalSha256, remoteSha256(session, case.request.remotePath))
+            assertArrayEquals(
+                finalBytes,
+                session.downloadFile(case.request.remotePath, finalBytes.size.toLong()),
+            )
+
+            val failure = runCatching { session.uploadQueueSidecar(case.request) }.exceptionOrNull()
+
+            assertTrue("wrong-sized pre-existing final must hard-fail", failure is SshException)
+            assertEquals(
+                "Queue-sidecar upload refused for ${case.request.displayName}: final path has " +
+                    "${finalBytes.size} bytes; expected ${case.request.expectedBytes}",
+                failure?.message,
+            )
+            assertFalse("owned checkpoint data must be cleaned", remoteExists(session, case.paths.dataPath))
+            assertFalse("owned checkpoint identity must be cleaned", remoteExists(session, case.paths.identityPath))
+            assertEquals(finalBytes.size.toLong(), remoteSize(session, case.request.remotePath))
+            assertEquals(finalSha256, remoteSha256(session, case.request.remotePath))
+            assertArrayEquals(
+                "conflicting final must remain byte-exact after fail-closed refusal",
+                finalBytes,
+                session.downloadFile(case.request.remotePath, finalBytes.size.toLong()),
+            )
+        }
+    }
+
+    private suspend fun prepare(session: SshSession, case: UploadCase) {
+        session.exec(
+            "rm -rf ${shellSingleQuote(case.remoteDir)} && mkdir -p ${shellSingleQuote(case.remoteDir)}",
+        )
+    }
+
+    private suspend fun cleanup(session: SshSession, case: UploadCase) {
+        session.exec("rm -rf ${shellSingleQuote(case.remoteDir)}")
+    }
+
+    private suspend fun seedCheckpoint(
+        session: SshSession,
+        case: UploadCase,
+        bytes: ByteArray,
+        expectedIdentity: Boolean,
+    ) {
+        val seed = File.createTempFile("issue1733-seed", ".bin").apply {
+            writeBytes(bytes)
+            deleteOnExit()
+        }
+        session.uploadFile(seed, case.paths.dataPath)
+        val identity = if (expectedIdentity) {
+            queueSidecarCheckpointIdentity(case.request)
+        } else {
+            "wrong-identity"
+        }
+        session.exec(
+            "printf '%s' ${shellSingleQuote(identity)} > ${shellSingleQuote(case.paths.identityPath)}",
+        )
+    }
+
+    private suspend fun remoteSize(session: SshSession, path: String): Long? {
+        val result = session.exec(
+            "if [ -f ${shellSingleQuote(path)} ]; then wc -c < ${shellSingleQuote(path)}; " +
+                "else printf MISSING; fi",
+        )
+        return result.stdout.trim().toLongOrNull()
+    }
+
+    private suspend fun remoteExists(session: SshSession, path: String): Boolean =
+        session.exec("test -e ${shellSingleQuote(path)}").exitCode == 0
+
+    private suspend fun remoteSha256(session: SshSession, path: String): String {
+        val result = session.exec("sha256sum ${shellSingleQuote(path)}")
+        if (result.exitCode != 0) fail("sha256sum failed: ${result.stderr}")
+        return result.stdout.substringBefore(' ').trim()
+    }
+
+    private fun newCase(name: String, bytes: Int): UploadCase {
+        val file = File.createTempFile("issue1733-$name", ".bin").apply {
+            outputStream().use { output ->
+                val chunk = ByteArray(64 * 1024) { index -> ((index * 31 + 7) % 251).toByte() }
+                var remaining = bytes
+                while (remaining > 0) {
+                    val count = minOf(remaining, chunk.size)
+                    output.write(chunk, 0, count)
+                    remaining -= count
+                }
+            }
+            deleteOnExit()
+        }
+        val remoteDir = ".pocketshell/attachments/issue1733-$name"
+        val request = QueueSidecarResumableUploadRequest(
+            localFile = file,
+            remotePath = "$remoteDir/payload.bin",
+            stableToken = "durable-sidecar-$name",
+            expectedBytes = file.length(),
+            displayName = "payload.bin",
+        )
+        return UploadCase(
+            localFile = file,
+            localSha256 = sha256(file),
+            remoteDir = remoteDir,
+            request = request,
+            paths = queueSidecarCheckpointPaths(request.remotePath, request.stableToken),
+        )
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+    }
+
+    private data class UploadCase(
+        val localFile: File,
+        val localSha256: String,
+        val remoteDir: String,
+        val request: QueueSidecarResumableUploadRequest,
+        val paths: QueueSidecarCheckpointPaths,
+    )
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -1264,6 +1264,37 @@ internal class RealSshSession(
             remotePath
         }
 
+    override suspend fun uploadQueueSidecar(
+        request: QueueSidecarResumableUploadRequest,
+        onProgress: ((QueueSidecarUploadProgress) -> Unit)?,
+    ): QueueSidecarResumableUploadResult = withContext(Dispatchers.IO) {
+        QueueSidecarResumableUploader(
+            isConnected = { isConnected },
+            ensureConnected = ::ensureConnected,
+            exec = ::exec,
+            shellQuote = ::shellSingleQuote,
+            streamRemainder = { paths, offset ->
+                val remainder = request.expectedBytes - offset
+                request.localFile.inputStream().use { input ->
+                    skipQueueSidecarLocalPrefix(input, offset, request.displayName)
+                    streamToRemoteTemp(
+                        input = input,
+                        name = request.displayName,
+                        remotePath = request.remotePath,
+                        tempRemotePath = paths.dataPath,
+                        declaredLength = remainder,
+                        onProgress = { progress ->
+                            onProgress?.invoke(progress.toQueueSidecarProgress(paths, offset))
+                        },
+                        append = true,
+                        progressOffset = offset,
+                        progressTotal = request.expectedBytes,
+                    )
+                }
+            },
+        ).upload(request)
+    }
+
     override suspend fun uploadStream(
         input: InputStream,
         length: Long,
@@ -1563,12 +1594,16 @@ internal class RealSshSession(
         tempRemotePath: String,
         declaredLength: Long,
         onProgress: ((SshUploadProgress) -> Unit)?,
+        append: Boolean = false,
+        progressOffset: Long = 0L,
+        progressTotal: Long = declaredLength,
     ): Long {
         val coroutineJob = currentCoroutineContext()[Job]
         // Channel open + `cat >` exec are transport-mutating packets — serialise
         // through the dispatcher (issue #847). The byte copy below runs OUTSIDE
         // the dispatcher so a large upload never wedges the `-CC` write.
         val quoted = shellSingleQuote(tempRemotePath)
+        val redirect = if (append) ">>" else ">"
         var command: Command? = null
         val sessionChannel = dispatcher.run {
             val channel = try {
@@ -1580,7 +1615,7 @@ internal class RealSshSession(
                 )
             }
             command = try {
-                channel.exec("cat > $quoted")
+                channel.exec("cat $redirect $quoted")
             } catch (t: Throwable) {
                 runCatching { channel.close() }
                 throw SshException(
@@ -1611,7 +1646,14 @@ internal class RealSshSession(
             val copied = try {
                 runInterruptible(Dispatchers.IO) {
                     val output = command!!.outputStream
-                    val n = copyToRemoteBlocking(input, output, declaredLength, onProgress)
+                    val n = copyToRemoteBlocking(
+                        input = input,
+                        output = output,
+                        declaredLength = declaredLength,
+                        onProgress = onProgress,
+                        progressOffset = progressOffset,
+                        progressTotal = progressTotal,
+                    )
                     runTransferStepWithStallTimeout(
                         operation = "closing upload output",
                         timeoutMs = uploadStallTimeoutMs,
@@ -1765,10 +1807,14 @@ internal class RealSshSession(
         output: OutputStream,
         declaredLength: Long,
         onProgress: ((SshUploadProgress) -> Unit)?,
+        progressOffset: Long = 0L,
+        progressTotal: Long = declaredLength,
     ): Long {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         var total = 0L
-        onProgress?.invoke(SshUploadProgress(bytesTransferred = 0L, totalBytes = declaredLength))
+        onProgress?.invoke(
+            SshUploadProgress(bytesTransferred = progressOffset, totalBytes = progressTotal),
+        )
         while (true) {
             if (Thread.interrupted()) throw InterruptedException("SSH upload interrupted")
             val read = runTransferStepWithStallTimeout(
@@ -1793,7 +1839,12 @@ internal class RealSshSession(
             }
             total += read
             recordOutboundActivity()
-            onProgress?.invoke(SshUploadProgress(bytesTransferred = total, totalBytes = declaredLength))
+            onProgress?.invoke(
+                SshUploadProgress(
+                    bytesTransferred = progressOffset + total,
+                    totalBytes = progressTotal,
+                ),
+            )
         }
         runTransferStepWithStallTimeout(
             operation = "flushing upload bytes",

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/ResumableUpload.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/ResumableUpload.kt
@@ -1,0 +1,449 @@
+package com.pocketshell.core.ssh
+
+import java.io.File
+import java.io.InputStream
+import java.security.MessageDigest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * One immutable durable outbound-queue attachment.
+ *
+ * [stableToken] is opaque and stable across delivery attempts (the app uses the
+ * durable sidecar id). It is never interpolated into a shell command: core-ssh
+ * hashes it into [queueSidecarCheckpointPaths]' fixed-hex sibling name.
+ */
+public data class QueueSidecarResumableUploadRequest(
+    val localFile: File,
+    val remotePath: String,
+    val stableToken: String,
+    val expectedBytes: Long,
+    val displayName: String = localFile.name,
+)
+
+public enum class QueueSidecarUploadDisposition {
+    Uploaded,
+    AlreadyComplete,
+}
+
+public data class QueueSidecarResumableUploadResult(
+    val remotePath: String,
+    val resumedFromBytes: Long,
+    val transmittedBytes: Long,
+    val disposition: QueueSidecarUploadDisposition,
+)
+
+public data class QueueSidecarUploadProgress(
+    val checkpointPath: String,
+    val resumedFromBytes: Long,
+    val bytesTransferred: Long,
+    val totalBytes: Long,
+)
+
+public data class QueueSidecarCheckpointPaths(
+    val dataPath: String,
+    val identityPath: String,
+)
+
+/**
+ * Deterministic hidden sibling owned by [stableToken]. Only fixed hex derived
+ * locally from the opaque token reaches the path.
+ */
+public fun queueSidecarCheckpointPaths(
+    remotePath: String,
+    stableToken: String,
+): QueueSidecarCheckpointPaths {
+    require(remotePath.isNotBlank()) { "remotePath must not be blank" }
+    require(stableToken.isNotBlank()) { "stableToken must not be blank" }
+    val slash = remotePath.lastIndexOf('/')
+    val directory = if (slash >= 0) remotePath.substring(0, slash + 1) else ""
+    val baseName = remotePath.substring(slash + 1)
+    require(baseName.isNotBlank()) { "remotePath must name a file" }
+    val tokenHash = sha256Hex(stableToken).take(CHECKPOINT_TOKEN_HEX_LENGTH)
+    val data = "$directory.$baseName.pocketshell-part-$tokenHash"
+    return QueueSidecarCheckpointPaths(dataPath = data, identityPath = "$data.identity")
+}
+
+internal fun queueSidecarCheckpointIdentity(
+    request: QueueSidecarResumableUploadRequest,
+): String = sha256Hex(
+    buildString {
+        append("pocketshell-queue-sidecar-v1\u0000")
+        append(request.stableToken)
+        append('\u0000')
+        append(request.remotePath)
+        append('\u0000')
+        append(request.expectedBytes)
+    },
+)
+
+internal data class ResumableUploadProbe(
+    val finalSize: Long?,
+    val checkpointSize: Long?,
+    val checkpointIdentity: String?,
+)
+
+internal sealed interface ResumableUploadOffsetDecision {
+    val cleanCheckpointFirst: Boolean
+
+    data class Upload(
+        val offsetBytes: Long,
+        override val cleanCheckpointFirst: Boolean,
+    ) : ResumableUploadOffsetDecision
+
+    data class Promote(
+        val resumedFromBytes: Long,
+        override val cleanCheckpointFirst: Boolean = false,
+    ) : ResumableUploadOffsetDecision
+
+    data class AlreadyComplete(
+        val resumedFromBytes: Long,
+        override val cleanCheckpointFirst: Boolean = true,
+    ) : ResumableUploadOffsetDecision
+
+    data class Fail(
+        val reason: String,
+        override val cleanCheckpointFirst: Boolean,
+    ) : ResumableUploadOffsetDecision
+}
+
+/**
+ * Pure remote-offset policy. The deterministic checkpoint is resumed only when
+ * its identity and size both belong to this immutable request.
+ */
+internal fun decideResumableUploadOffset(
+    expectedBytes: Long,
+    expectedIdentity: String,
+    probe: ResumableUploadProbe,
+): ResumableUploadOffsetDecision {
+    if (probe.finalSize != null) {
+        return if (probe.finalSize == expectedBytes) {
+            ResumableUploadOffsetDecision.AlreadyComplete(expectedBytes)
+        } else {
+            ResumableUploadOffsetDecision.Fail(
+                reason = "final path has ${probe.finalSize} bytes; expected $expectedBytes",
+                cleanCheckpointFirst = true,
+            )
+        }
+    }
+
+    val checkpointSize = probe.checkpointSize
+    if (checkpointSize == null) {
+        return ResumableUploadOffsetDecision.Upload(
+            offsetBytes = 0L,
+            cleanCheckpointFirst = probe.checkpointIdentity != null,
+        )
+    }
+    if (checkpointSize < 0L || checkpointSize > expectedBytes) {
+        return ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = true)
+    }
+    if (checkpointSize == 0L && probe.checkpointIdentity == null) {
+        return ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = false)
+    }
+    if (probe.checkpointIdentity != expectedIdentity) {
+        return ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = true)
+    }
+    return if (checkpointSize == expectedBytes) {
+        ResumableUploadOffsetDecision.Promote(expectedBytes)
+    } else {
+        ResumableUploadOffsetDecision.Upload(checkpointSize, cleanCheckpointFirst = false)
+    }
+}
+
+internal enum class ResumableUploadFailureKind {
+    RetryableTransport,
+    Cancellation,
+    NoProgressTimeout,
+    PermanentLocalValidation,
+    PermanentIdentity,
+    PermanentRemoteValidation,
+}
+
+internal enum class ResumableUploadCheckpointAction {
+    Preserve,
+    Cleanup,
+}
+
+internal fun checkpointActionFor(
+    failure: ResumableUploadFailureKind,
+): ResumableUploadCheckpointAction = when (failure) {
+    ResumableUploadFailureKind.RetryableTransport,
+    ResumableUploadFailureKind.Cancellation,
+    ResumableUploadFailureKind.NoProgressTimeout,
+    -> ResumableUploadCheckpointAction.Preserve
+
+    ResumableUploadFailureKind.PermanentLocalValidation,
+    ResumableUploadFailureKind.PermanentIdentity,
+    ResumableUploadFailureKind.PermanentRemoteValidation,
+    -> ResumableUploadCheckpointAction.Cleanup
+}
+
+/**
+ * Queue-only remote checkpoint protocol, kept outside [RealSshSession] so the
+ * transport owner remains focused on channels/dispatch. Every remote mutation
+ * still runs through that session's injected [exec], and the byte stream through
+ * its injected single-writer-owned upload channel.
+ */
+internal class QueueSidecarResumableUploader(
+    private val isConnected: () -> Boolean,
+    private val ensureConnected: () -> Unit,
+    private val exec: suspend (String) -> ExecResult,
+    private val shellQuote: (String) -> String,
+    private val streamRemainder: suspend (
+        paths: QueueSidecarCheckpointPaths,
+        offsetBytes: Long,
+    ) -> Long,
+) {
+    suspend fun upload(
+        request: QueueSidecarResumableUploadRequest,
+    ): QueueSidecarResumableUploadResult {
+        val paths = runCatching {
+            require(request.expectedBytes >= 0L) { "expectedBytes must be non-negative" }
+            queueSidecarCheckpointPaths(request.remotePath, request.stableToken)
+        }.getOrElse { error ->
+            throw SshException("Invalid queue-sidecar upload identity: ${error.message}", error)
+        }
+
+        val local = request.localFile
+        if (!local.isFile) {
+            applyCheckpointAction(
+                paths,
+                ResumableUploadFailureKind.PermanentLocalValidation,
+                onlyWhenConnected = true,
+            )
+            throw SshException("Queued attachment no longer exists: ${request.displayName}")
+        }
+        val actualLocalBytes = local.length()
+        if (actualLocalBytes != request.expectedBytes) {
+            applyCheckpointAction(
+                paths,
+                ResumableUploadFailureKind.PermanentLocalValidation,
+                onlyWhenConnected = true,
+            )
+            throw SshException(
+                "Queued attachment changed: ${request.displayName} has $actualLocalBytes bytes; " +
+                    "expected ${request.expectedBytes}",
+            )
+        }
+
+        ensureConnected()
+        val expectedIdentity = queueSidecarCheckpointIdentity(request)
+        val decision = decideResumableUploadOffset(
+            expectedBytes = request.expectedBytes,
+            expectedIdentity = expectedIdentity,
+            probe = probe(request.remotePath, paths),
+        )
+        if (decision.cleanCheckpointFirst) cleanupCheckpoint(paths)
+
+        return when (decision) {
+            is ResumableUploadOffsetDecision.AlreadyComplete ->
+                QueueSidecarResumableUploadResult(
+                    remotePath = request.remotePath,
+                    resumedFromBytes = decision.resumedFromBytes,
+                    transmittedBytes = 0L,
+                    disposition = QueueSidecarUploadDisposition.AlreadyComplete,
+                )
+
+            is ResumableUploadOffsetDecision.Fail ->
+                throw SshException(
+                    "Queue-sidecar upload refused for ${request.displayName}: ${decision.reason}",
+                )
+
+            is ResumableUploadOffsetDecision.Promote ->
+                promote(request, paths, decision.resumedFromBytes, transmittedBytes = 0L)
+
+            is ResumableUploadOffsetDecision.Upload -> {
+                initialise(
+                    paths = paths,
+                    identity = expectedIdentity,
+                    truncateData = decision.offsetBytes == 0L,
+                )
+                val transmitted = try {
+                    streamRemainder(paths, decision.offsetBytes)
+                } catch (cancelled: CancellationException) {
+                    applyCheckpointAction(paths, ResumableUploadFailureKind.Cancellation)
+                    throw cancelled
+                } catch (error: Throwable) {
+                    // Both a transport loss and the uploader's bounded
+                    // no-progress timeout preserve the committed checkpoint.
+                    applyCheckpointAction(paths, ResumableUploadFailureKind.RetryableTransport)
+                    if (error is SshException) throw error
+                    throw SshException(
+                        "Queue-sidecar upload of ${request.displayName} failed: ${error.message}",
+                        error,
+                    )
+                }
+                promote(request, paths, decision.offsetBytes, transmitted)
+            }
+        }
+    }
+
+    private suspend fun probe(
+        remotePath: String,
+        paths: QueueSidecarCheckpointPaths,
+    ): ResumableUploadProbe {
+        suspend fun sizeOrNull(path: String): Long? {
+            val result = exec(
+                "if [ -f ${shellQuote(path)} ]; then " +
+                    "wc -c < ${shellQuote(path)}; else printf MISSING; fi",
+            )
+            if (result.exitCode != 0) {
+                throw SshException(
+                    "Could not inspect queue-sidecar upload checkpoint: ${result.stderr.trim()}",
+                )
+            }
+            val raw = result.stdout.trim()
+            return if (raw == "MISSING") {
+                null
+            } else {
+                raw.toLongOrNull()
+                    ?: throw SshException("Invalid queue-sidecar checkpoint size '$raw'")
+            }
+        }
+
+        val identityResult = exec(
+            "if [ -f ${shellQuote(paths.identityPath)} ]; then " +
+                "cat ${shellQuote(paths.identityPath)}; else printf MISSING; fi",
+        )
+        if (identityResult.exitCode != 0) {
+            throw SshException(
+                "Could not inspect queue-sidecar checkpoint identity: ${identityResult.stderr.trim()}",
+            )
+        }
+        return ResumableUploadProbe(
+            finalSize = sizeOrNull(remotePath),
+            checkpointSize = sizeOrNull(paths.dataPath),
+            checkpointIdentity = identityResult.stdout.trim().takeUnless { it == "MISSING" },
+        )
+    }
+
+    private suspend fun initialise(
+        paths: QueueSidecarCheckpointPaths,
+        identity: String,
+        truncateData: Boolean,
+    ) {
+        val dataOperation = if (truncateData) {
+            ": > ${shellQuote(paths.dataPath)}"
+        } else {
+            "test -f ${shellQuote(paths.dataPath)}"
+        }
+        val result = exec(
+            "$dataOperation && printf '%s' ${shellQuote(identity)} > " +
+                shellQuote(paths.identityPath),
+        )
+        if (result.exitCode != 0) {
+            applyCheckpointAction(paths, ResumableUploadFailureKind.PermanentIdentity)
+            throw SshException(
+                "Could not initialise queue-sidecar checkpoint: " +
+                    result.stderr.ifBlank { result.stdout }.trim(),
+            )
+        }
+    }
+
+    private suspend fun promote(
+        request: QueueSidecarResumableUploadRequest,
+        paths: QueueSidecarCheckpointPaths,
+        resumedFromBytes: Long,
+        transmittedBytes: Long,
+    ): QueueSidecarResumableUploadResult {
+        val size = exec(
+            "if [ -f ${shellQuote(paths.dataPath)} ]; then " +
+                "wc -c < ${shellQuote(paths.dataPath)}; else printf MISSING; fi",
+        )
+        val actual = size.stdout.trim().toLongOrNull()
+        if (size.exitCode != 0 || actual != request.expectedBytes) {
+            applyCheckpointAction(paths, ResumableUploadFailureKind.PermanentRemoteValidation)
+            throw SshException(
+                "Queue-sidecar integrity check failed for ${request.displayName}: " +
+                    "remote checkpoint has ${actual ?: "no"} bytes; expected ${request.expectedBytes}",
+            )
+        }
+        val promote = exec(
+            "mv -f ${shellQuote(paths.dataPath)} ${shellQuote(request.remotePath)}",
+        )
+        if (promote.exitCode != 0) {
+            applyCheckpointAction(paths, ResumableUploadFailureKind.PermanentRemoteValidation)
+            throw SshException(
+                "Could not finalise queue-sidecar upload of ${request.displayName}: " +
+                    promote.stderr.ifBlank { promote.stdout }.trim(),
+            )
+        }
+        cleanupIdentity(paths.identityPath)
+        return QueueSidecarResumableUploadResult(
+            remotePath = request.remotePath,
+            resumedFromBytes = resumedFromBytes,
+            transmittedBytes = transmittedBytes,
+            disposition = QueueSidecarUploadDisposition.Uploaded,
+        )
+    }
+
+    /**
+     * The pure classification is intentionally production-wired here: changing
+     * preserve to cleanup spends already committed bytes again, while changing
+     * cleanup to preserve leaves an owned corrupt/permanently invalid sidecar.
+     */
+    private suspend fun applyCheckpointAction(
+        paths: QueueSidecarCheckpointPaths,
+        failure: ResumableUploadFailureKind,
+        onlyWhenConnected: Boolean = false,
+    ) {
+        if (checkpointActionFor(failure) == ResumableUploadCheckpointAction.Cleanup &&
+            (!onlyWhenConnected || isConnected())
+        ) {
+            cleanupCheckpoint(paths)
+        }
+    }
+
+    private suspend fun cleanupCheckpoint(paths: QueueSidecarCheckpointPaths) {
+        runCatching {
+            withTimeoutOrNull(UPLOAD_CLEANUP_TIMEOUT_MS) {
+                exec("rm -f ${shellQuote(paths.dataPath)} ${shellQuote(paths.identityPath)}")
+            }
+        }
+    }
+
+    private suspend fun cleanupIdentity(path: String) {
+        runCatching {
+            withTimeoutOrNull(UPLOAD_CLEANUP_TIMEOUT_MS) {
+                exec("rm -f ${shellQuote(path)}")
+            }
+        }
+    }
+}
+
+internal fun skipQueueSidecarLocalPrefix(
+    input: InputStream,
+    offsetBytes: Long,
+    displayName: String,
+) {
+    var remaining = offsetBytes
+    while (remaining > 0L) {
+        val skipped = input.skip(remaining)
+        if (skipped > 0L) {
+            remaining -= skipped
+        } else if (input.read() >= 0) {
+            remaining -= 1L
+        } else {
+            throw SshException(
+                "Queued attachment $displayName ended before resume offset $offsetBytes",
+            )
+        }
+    }
+}
+
+internal fun SshUploadProgress.toQueueSidecarProgress(
+    paths: QueueSidecarCheckpointPaths,
+    resumedFromBytes: Long,
+): QueueSidecarUploadProgress = QueueSidecarUploadProgress(
+    checkpointPath = paths.dataPath,
+    resumedFromBytes = resumedFromBytes,
+    bytesTransferred = bytesTransferred,
+    totalBytes = totalBytes,
+)
+
+private fun sha256Hex(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+
+private const val CHECKPOINT_TOKEN_HEX_LENGTH = 24

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
@@ -157,6 +157,17 @@ public interface SshSession : AutoCloseable {
     ): String = uploadFile(file, remotePath)
 
     /**
+     * Resume one immutable durable outbound-queue sidecar from its deterministic
+     * remote checkpoint. This deliberately does not alter [uploadFile] or
+     * [uploadStream]: their random partials retain cleanup-on-failure semantics.
+     */
+    public suspend fun uploadQueueSidecar(
+        request: QueueSidecarResumableUploadRequest,
+        onProgress: ((QueueSidecarUploadProgress) -> Unit)? = null,
+    ): QueueSidecarResumableUploadResult =
+        throw NotImplementedError("resumable queue-sidecar upload is only implemented by RealSshSession")
+
+    /**
      * Read the contents of a remote file at [remotePath] into memory.
      *
      * The path is resolved by the remote login shell, so `~`-relative and

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/ResumableUploadOffsetPolicyTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/ResumableUploadOffsetPolicyTest.kt
@@ -1,0 +1,127 @@
+package com.pocketshell.core.ssh
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ResumableUploadOffsetPolicyTest {
+
+    private val expected = 1_000L
+    private val identity = "expected-identity"
+
+    @Test
+    fun absentAndZeroCheckpointStartAtZero() {
+        assertEquals(
+            ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = false),
+            decide(final = null, checkpoint = null, checkpointIdentity = null),
+        )
+        assertEquals(
+            ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = false),
+            decide(final = null, checkpoint = 0L, checkpointIdentity = null),
+        )
+        assertEquals(
+            ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = false),
+            decide(final = null, checkpoint = 0L, checkpointIdentity = identity),
+        )
+    }
+
+    @Test
+    fun validPartialResumesAtExactCommittedOffset() {
+        assertEquals(
+            ResumableUploadOffsetDecision.Upload(417L, cleanCheckpointFirst = false),
+            decide(final = null, checkpoint = 417L, checkpointIdentity = identity),
+        )
+    }
+
+    @Test
+    fun completeCheckpointPromotesWithoutTransmission() {
+        assertEquals(
+            ResumableUploadOffsetDecision.Promote(expected),
+            decide(final = null, checkpoint = expected, checkpointIdentity = identity),
+        )
+    }
+
+    @Test
+    fun completeFinalIsAlreadyCompleteAndCleansStaleCheckpoint() {
+        val decision = decide(
+            final = expected,
+            checkpoint = 417L,
+            checkpointIdentity = identity,
+        )
+        assertEquals(ResumableUploadOffsetDecision.AlreadyComplete(expected), decision)
+        assertTrue(decision.cleanCheckpointFirst)
+    }
+
+    @Test
+    fun oversizedOrWrongIdentityCheckpointTakesExplicitCleanRestart() {
+        assertEquals(
+            ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = true),
+            decide(final = null, checkpoint = expected + 1L, checkpointIdentity = identity),
+        )
+        assertEquals(
+            ResumableUploadOffsetDecision.Upload(0L, cleanCheckpointFirst = true),
+            decide(final = null, checkpoint = 417L, checkpointIdentity = "other"),
+        )
+    }
+
+    @Test
+    fun wrongSizedFinalFailsWithoutOverwritingIt() {
+        val decision = decide(
+            final = expected - 1L,
+            checkpoint = 417L,
+            checkpointIdentity = identity,
+        )
+        assertTrue(decision is ResumableUploadOffsetDecision.Fail)
+        assertTrue(decision.cleanCheckpointFirst)
+    }
+
+    @Test
+    fun retryableFailuresPreserveAndPermanentFailuresClean() {
+        listOf(
+            ResumableUploadFailureKind.RetryableTransport,
+            ResumableUploadFailureKind.Cancellation,
+            ResumableUploadFailureKind.NoProgressTimeout,
+        ).forEach {
+            assertEquals(ResumableUploadCheckpointAction.Preserve, checkpointActionFor(it))
+        }
+        listOf(
+            ResumableUploadFailureKind.PermanentLocalValidation,
+            ResumableUploadFailureKind.PermanentIdentity,
+            ResumableUploadFailureKind.PermanentRemoteValidation,
+        ).forEach {
+            assertEquals(ResumableUploadCheckpointAction.Cleanup, checkpointActionFor(it))
+        }
+    }
+
+    @Test
+    fun opaqueTokenIsHashedAndNeverAppearsInCheckpointPath() {
+        val hostile = "id'; touch /tmp/pwned; #"
+        val paths = queueSidecarCheckpointPaths("dir/report.bin", hostile)
+        assertFalse(paths.dataPath.contains(hostile))
+        assertTrue(paths.dataPath.matches(Regex("dir/\\.report\\.bin\\.pocketshell-part-[0-9a-f]{24}")))
+        assertEquals("${paths.dataPath}.identity", paths.identityPath)
+    }
+
+    @Test
+    fun identityBindsTokenFinalPathAndExpectedLength() {
+        fun request(token: String, path: String, size: Long) =
+            QueueSidecarResumableUploadRequest(File("local"), path, token, size)
+
+        val base = queueSidecarCheckpointIdentity(request("stable", "dir/a", expected))
+        assertFalse(base == queueSidecarCheckpointIdentity(request("other", "dir/a", expected)))
+        assertFalse(base == queueSidecarCheckpointIdentity(request("stable", "dir/b", expected)))
+        assertFalse(base == queueSidecarCheckpointIdentity(request("stable", "dir/a", expected + 1L)))
+    }
+
+    private fun decide(
+        final: Long?,
+        checkpoint: Long?,
+        checkpointIdentity: String?,
+    ): ResumableUploadOffsetDecision = decideResumableUploadOffset(
+        expectedBytes = expected,
+        expectedIdentity = identity,
+        probe = ResumableUploadProbe(final, checkpoint, checkpointIdentity),
+    )
+}


### PR DESCRIPTION
Closes #1733

## Summary
- add a queue-only resumable sidecar upload API with stable identity, exact-offset append, size validation, and atomic promotion
- resume interrupted queued attachments from the committed checkpoint while preserving durable row and attachment identity
- strengthen workflow, journey, artifact, and retry-budget coverage for the real interruption path

## Verification
- independent review: APPROVED
- genuine exact-current-base real-SSH RED
- policy 9/9; real SSH integration 8/8; full core-SSH integration 49/49 adjacency
- restart-at-zero compiled mutation killed and restored byte-exact
- forced Android-test compile: 176/176 tasks
- canonical JVM gate: 603 tasks; 11,574 tests; zero failures/errors/skips
- two clean wrapper journeys: exact 491,520-byte resume; only remaining 16,285,696 bytes transmitted; exact 16 MiB SHA match; atomic promotion/checkpoint cleanup; fresh client; exactly-once prompt and live input
- validity, journey, budget, artifact-packaging, file-size and VM ratchets green
- `git diff --check`