### PR TITLE
diagnostics: mirror hold_active and real producer fields on session_fgs (#1598)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/service/SessionConnectionService.kt
@@ -55,6 +55,7 @@ class SessionConnectionService : Service() {
     private var observeJob: Job? = null
     private var wakeLock: PowerManager.WakeLock? = null
     private var hasStartedForeground = false
+    private var promotionHoldActive = false
 
     @androidx.annotation.VisibleForTesting
     internal enum class StartupPhase {
@@ -87,6 +88,7 @@ class SessionConnectionService : Service() {
 
         const val ACTION_START = "com.pocketshell.app.sessions.action.START_SESSION_HOLD"
         const val ACTION_STOP = "com.pocketshell.app.sessions.action.STOP_SESSION_HOLD"
+        private const val EXTRA_HOLD_ACTIVE = "com.pocketshell.app.sessions.extra.HOLD_ACTIVE"
 
         /**
          * Issue #1595: the connection-trail event recording every session-FGS start/promotion
@@ -107,6 +109,7 @@ class SessionConnectionService : Service() {
         fun start(context: Context, holdActive: Boolean = true): Boolean {
             val intent = Intent(context, SessionConnectionService::class.java).apply {
                 action = ACTION_START
+                putExtra(EXTRA_HOLD_ACTIVE, holdActive)
             }
             return runCatching {
                 startForegroundServiceForTest?.invoke(context, intent)
@@ -166,6 +169,10 @@ class SessionConnectionService : Service() {
                 return START_NOT_STICKY
             }
             else -> {
+                // The start request is the authority for this diagnostic field. A missing extra
+                // (including a platform null-intent restart) is deliberately false rather than
+                // inferred from mutable controller state.
+                promotionHoldActive = intent?.getBooleanExtra(EXTRA_HOLD_ACTIVE, false) ?: false
                 if (!promoteToForegroundIfNeeded(initialNotification())) {
                     stopSessionHold()
                     return START_NOT_STICKY
@@ -249,6 +256,7 @@ class SessionConnectionService : Service() {
                 DIAG_EVENT_FGS,
                 "phase" to "promote",
                 "outcome" to "ok",
+                "hold_active" to promotionHoldActive,
             )
             true
         }.getOrElse {
@@ -263,6 +271,7 @@ class SessionConnectionService : Service() {
                 "phase" to "promote",
                 "outcome" to "denied",
                 "error" to it.javaClass.simpleName,
+                "hold_active" to promotionHoldActive,
             )
             false
         }

--- a/app/src/test/java/com/pocketshell/app/diagnostics/Issue1642ConnectionMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/Issue1642ConnectionMirrorTest.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.diagnostics
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.settings.SettingsRepository
+import com.pocketshell.app.sessions.service.SessionConnectionService
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -141,16 +142,17 @@ class Issue1642ConnectionMirrorTest {
             "clientDisconnected" to true,
             "willRetry" to false,
         )
-        // #1595/#1598: recorded PRECISELY so the FGS outcome could be confirmed
-        // remotely from the synced log — and it never synced.
-        DiagnosticEvents.record(
-            "connection",
-            "session_fgs",
-            "phase" to "request",
-            "outcome" to "denied",
-            "hold_active" to true,
-            "exceptionClass" to "ForegroundServiceStartNotAllowedException",
-        )
+        // #1595/#1598: use the real producer rather than fabricating a look-alike
+        // event. The background-restricted platform call is injected at the seam,
+        // while SessionConnectionService owns the exact fields recorded.
+        SessionConnectionService.startForegroundServiceForTest = { _, _ ->
+            throw android.app.ForegroundServiceStartNotAllowedException("bg restricted")
+        }
+        try {
+            assertFalse(SessionConnectionService.start(context, holdActive = true))
+        } finally {
+            SessionConnectionService.startForegroundServiceForTest = null
+        }
 
         val jsonl = recorder.connectionLogJsonl()
         val names = jsonl.mirroredLines().map { it.getString("name") }
@@ -166,7 +168,15 @@ class Issue1642ConnectionMirrorTest {
             "session_fgs" in names,
         )
         val fgs = jsonl.mirroredLines().single { it.getString("name") == "session_fgs" }
-        assertEquals("denied", fgs.getJSONObject("metadata").getString("outcome"))
+        val metadata = fgs.getJSONObject("metadata")
+        assertEquals("request", metadata.getString("phase"))
+        assertEquals("denied", metadata.getString("outcome"))
+        assertEquals(
+            "ForegroundServiceStartNotAllowedException",
+            metadata.getString("error"),
+        )
+        assertTrue(metadata.getBoolean("hold_active"))
+        assertFalse(metadata.has("exceptionClass"))
     }
 
     /**
@@ -210,7 +220,7 @@ class Issue1642ConnectionMirrorTest {
         val recorder = newRecorder()
 
         DiagnosticEvents.record("connection", "connect_start", "attempt" to 1)
-        DiagnosticEvents.record("action", "tap_send", "pane" to "%1")
+        DiagnosticEvents.record("action", "shortcut_sent", "paneId" to "%1")
         DiagnosticEvents.record("navigation", "screen_shown", "screen" to "hosts")
         DiagnosticEvents.record("strictmode", "violation", "detail" to "disk read on main")
         DiagnosticEvents.record("terminal", "frame_rendered", "rows" to 40)

--- a/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceFgsDiagnosticsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/service/SessionConnectionServiceFgsDiagnosticsTest.kt
@@ -4,11 +4,18 @@ import android.content.Context
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.diagnostics.DiagnosticEventSink
+import com.pocketshell.app.diagnostics.DiagnosticRecorder
 import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.settings.SettingsRepository
 import com.pocketshell.app.sessions.ActiveTmuxClients
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,25 +33,29 @@ import org.robolectric.annotation.Config
  * connection-log was structurally BLIND to the mechanism and the ~4.4s-after-background transport
  * death could not be attributed.
  *
- * These tests reproduce the failure paths synthetically (inject a rejecting starter/promoter) and
- * assert a DiagnosticEvent carrying the exception CLASS is emitted on the `connection` trail.
+ * Issue #1598 closes the remaining fidelity gap end-to-end: these tests inject only the platform
+ * request/promotion outcome, then drive the real producer through the real [DiagnosticRecorder]
+ * and assert the exact JSONL shape uploaded by `connectionLogJsonl()`.
  *
- * RED on base: base swallows both failures with `Log.w` and records nothing → the recording sink
- * stays empty → every assertion below fails.
- * GREEN with the fix: each failure records `connection`/`session_fgs` with `outcome=denied` and
- * the exception class name.
+ * RED on the #1598 base: the captured ACTION_START intent loses `hold_active`, so both promotion
+ * shapes omit it. GREEN: request and promotion carry the same authoritative value, including
+ * false and missing-extra coverage, and denial uses the production `error` key.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
 class SessionConnectionServiceFgsDiagnosticsTest {
 
     private lateinit var context: Context
-    private val sink = RecordingSink()
+    private lateinit var recorder: DiagnosticRecorder
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        DiagnosticEvents.install(sink)
+        context.getSharedPreferences("app_settings", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, "diagnostics").deleteRecursively()
+        recorder = DiagnosticRecorder(context, SettingsRepository(context))
+        DiagnosticEvents.install(recorder)
     }
 
     @After
@@ -54,7 +65,7 @@ class SessionConnectionServiceFgsDiagnosticsTest {
     }
 
     @Test
-    fun `a rejected startForegroundService emits a denied diagnostic with the exception class`() {
+    fun `a rejected startForegroundService emits its exact denied producer shape`() = runTest {
         // The on-device background-FGS-start restriction: startForegroundService() throws.
         SessionConnectionService.startForegroundServiceForTest = { _, _ ->
             throw android.app.ForegroundServiceStartNotAllowedException("bg restricted")
@@ -63,103 +74,121 @@ class SessionConnectionServiceFgsDiagnosticsTest {
         val started = SessionConnectionService.start(context, holdActive = true)
 
         assertEquals("a rejected start must return false, not crash", false, started)
-        val denied = sink.find("session_fgs", phase = "request", outcome = "denied")
-        assertNotNull(
-            "the swallowed FGS start rejection must now emit a connection diagnostic (#1595)",
-            denied,
-        )
+        val denied = recorder.sessionFgsEvents()
+            .single { it.metadataString("phase") == "request" }
         assertEquals(
             "the diagnostic must capture the exception CLASS so the device log can tell " +
                 "ForegroundServiceStartNotAllowedException from a real socket error",
             "ForegroundServiceStartNotAllowedException",
-            denied!!["error"],
+            denied.metadataString("error"),
         )
-        assertEquals(true, denied["hold_active"])
+        assertTrue(denied.metadataBoolean("hold_active"))
+        assertFalse(
+            "production records denial under `error`; the mirror proof must not fabricate " +
+                "`exceptionClass`",
+            denied.getJSONObject("metadata").has("exceptionClass"),
+        )
     }
 
     @Test
-    fun `a successful startForegroundService emits an ok diagnostic so the device log proves it fired`() {
-        // No injected starter → the real ShadowApplication start succeeds.
+    fun `the captured true start intent drives exact request and promotion success fields`() = runTest {
+        var capturedIntent: Intent? = null
+        SessionConnectionService.startForegroundServiceForTest = { _, intent ->
+            capturedIntent = intent
+        }
+
         val started = SessionConnectionService.start(context, holdActive = true)
 
-        assertEquals(true, started)
-        val ok = sink.find("session_fgs", phase = "request", outcome = "ok")
-        assertNotNull(
-            "a successful foreground-eligible start must also be recorded so the next device " +
-                "background proves the start actually fired (#1595)",
-            ok,
-        )
-        assertEquals(true, ok!!["hold_active"])
+        assertTrue(started)
+        val request = recorder.sessionFgsEvents().single()
+        assertEquals("request", request.metadataString("phase"))
+        assertEquals("ok", request.metadataString("outcome"))
+        assertTrue(request.metadataBoolean("hold_active"))
+
+        val service = serviceForPromotion()
+        service.onStartCommand(requireNotNull(capturedIntent), 0, 1)
+
+        val promoted = recorder.sessionFgsEvents()
+            .single { it.metadataString("phase") == "promote" }
+        assertEquals("ok", promoted.metadataString("outcome"))
+        assertTrue(promoted.metadataBoolean("hold_active"))
+        service.onDestroy()
     }
 
     @Test
-    fun `a rejected startForeground promotion emits a denied diagnostic with the exception class`() {
-        val service = Robolectric.buildService(SessionConnectionService::class.java).get()
-        service.createNotificationChannel()
+    fun `the captured true start intent drives exact promotion denial fields`() = runTest {
+        var capturedIntent: Intent? = null
+        SessionConnectionService.startForegroundServiceForTest = { _, intent ->
+            capturedIntent = intent
+        }
+        assertTrue(SessionConnectionService.start(context, holdActive = true))
+
+        val service = serviceForPromotion()
         service.promoteForegroundForTest = {
             throw android.app.ForegroundServiceStartNotAllowedException("promote restricted")
         }
 
-        // ACTION_START drives promoteToForegroundIfNeeded → throws → getOrElse records + returns
-        // false → the service stops cleanly instead of crashing.
-        service.onStartCommand(
-            Intent(context, SessionConnectionService::class.java).apply {
-                action = SessionConnectionService.ACTION_START
-            },
-            0,
-            1,
-        )
+        service.onStartCommand(requireNotNull(capturedIntent), 0, 1)
 
-        val denied = sink.find("session_fgs", phase = "promote", outcome = "denied")
-        assertNotNull(
-            "the swallowed FGS promotion failure must now emit a connection diagnostic (#1595)",
-            denied,
-        )
+        val denied = recorder.sessionFgsEvents()
+            .single { it.metadataString("phase") == "promote" }
+        assertEquals("denied", denied.metadataString("outcome"))
         assertEquals(
             "ForegroundServiceStartNotAllowedException",
-            denied!!["error"],
+            denied.metadataString("error"),
         )
+        assertTrue(denied.metadataBoolean("hold_active"))
+        assertFalse(denied.getJSONObject("metadata").has("exceptionClass"))
     }
 
     @Test
-    fun `a successful promotion emits an ok diagnostic`() {
-        val service = Robolectric.buildService(SessionConnectionService::class.java).get()
-        service.createNotificationChannel()
-        // A successful promotion proceeds to startObserving(), which collects the controller's
-        // snapshot flow on observeDispatcher. Robolectric.buildService does NOT run Hilt field
-        // injection, so wire a real controller (else the collector touches the uninitialized
-        // @Inject lateinit and throws uncaught on Dispatchers.Default — a leaked coroutine that
-        // surfaces as UncaughtExceptionsBeforeTest in the next runTest). Run the collector on an
-        // unconfined dispatcher so the Empty snapshot immediately drives a synchronous
-        // stopSessionHold() — no leaked background coroutine.
-        service.controller = SessionServiceController(context, ActiveTmuxClients())
-        service.observeDispatcher = kotlinx.coroutines.Dispatchers.Unconfined
+    fun `false and missing hold extras both produce false rather than a hard coded value`() = runTest {
+        var capturedFalseIntent: Intent? = null
+        SessionConnectionService.startForegroundServiceForTest = { _, intent ->
+            capturedFalseIntent = intent
+        }
+        assertTrue(SessionConnectionService.start(context, holdActive = false))
+        val falseService = serviceForPromotion()
+        falseService.onStartCommand(requireNotNull(capturedFalseIntent), 0, 1)
 
-        service.onStartCommand(
+        val falseEvents = recorder.sessionFgsEvents()
+        assertEquals(2, falseEvents.size)
+        assertTrue(falseEvents.all { !it.metadataBoolean("hold_active") })
+        falseService.onDestroy()
+
+        val missingService = serviceForPromotion()
+        missingService.onStartCommand(
             Intent(context, SessionConnectionService::class.java).apply {
                 action = SessionConnectionService.ACTION_START
             },
             0,
-            1,
+            2,
         )
 
-        val ok = sink.find("session_fgs", phase = "promote", outcome = "ok")
-        assertNotNull("a successful promotion must be recorded on the connection trail", ok)
-        service.onDestroy()
+        val lastPromotion = recorder.sessionFgsEvents()
+            .last { it.metadataString("phase") == "promote" }
+        assertFalse(lastPromotion.metadataBoolean("hold_active"))
+        missingService.onDestroy()
     }
 
-    private class RecordingSink : DiagnosticEventSink {
-        val events = mutableListOf<Triple<String, String, Map<String, Any?>>>()
-        override fun record(category: String, event: String, fields: Map<String, Any?>) {
-            events.add(Triple(category, event, fields))
+    private fun serviceForPromotion(): SessionConnectionService =
+        Robolectric.buildService(SessionConnectionService::class.java).get().apply {
+            createNotificationChannel()
+            controller = SessionServiceController(context, ActiveTmuxClients())
+            observeDispatcher = Dispatchers.Unconfined
         }
 
-        fun find(event: String, phase: String, outcome: String): Map<String, Any?>? =
-            events.firstOrNull { (category, e, fields) ->
-                category == "connection" &&
-                    e == event &&
-                    fields["phase"] == phase &&
-                    fields["outcome"] == outcome
-            }?.third
-    }
+    private suspend fun DiagnosticRecorder.sessionFgsEvents(): List<JSONObject> =
+        connectionLogJsonl()
+            .lineSequence()
+            .filter(String::isNotBlank)
+            .map(::JSONObject)
+            .filter { it.getString("category") == "connection" && it.getString("name") == "session_fgs" }
+            .toList()
+
+    private fun JSONObject.metadataString(key: String): String =
+        getJSONObject("metadata").getString(key)
+
+    private fun JSONObject.metadataBoolean(key: String): Boolean =
+        getJSONObject("metadata").getBoolean(key)
 }


### PR DESCRIPTION
Closes #1598

## What changed

Three files. `SessionConnectionService.kt` carries the authoritative `holdActive` through `ACTION_START` and emits `hold_active` on promotion success **and** promotion denial, using the real producer key `error` instead of a fabricated `exceptionClass`. The two test files drop the assertions that encoded the fabricated shape.

## Evidence (D33 — reproduce, fix, verify)

Implementer and reviewer independently drove red→green this run:

- **RED on base**: 15 executed, exactly 3 failures, all `org.json.JSONException: No value for hold_active`. The reviewer neutralised the fix by `cp`-restoring base content into the production file (never `git checkout`/`stash`) so the reproduction was against real base behaviour.
- **GREEN with fix**: 22/22, 0 skipped.
- **Mutation**: `"error"` → `"exceptionClass"`, mutant proved live (0 compile errors, 15 executed), killed 2 tests. Restore verified by md5 + patch hash. Implementer additionally killed 6/6 mutations first-hand.
- **Connected journey**: `scripts/connected-test.sh --suffix i1598` on emulator-5554 + Docker `agents:2222` — 3/3 contiguous, 0 skipped, no signal-9. Remote `~/.pocketshell/connection-log.jsonl` read back over a fresh SSH exec.
- **Full JVM gate**: `BUILD SUCCESSFUL`, 603/603 tasks, 11,525 executed / 0 failures / 0 skipped across 1,214 XML files, zero `FROM-CACHE`, child exit 0 captured from the process rather than the systemd unit's `Result=`.
- **Adjacency sweep** (D31): #1642 / #1757 / #1595 / #1682 clean; `action/shortcut_sent` remains device-only.

## The one open question, and why it was resolved rather than waived

The connected journey proves the host file is byte-identical to `connectionLogJsonl()`, but its seeded payload is the reconnect trail only — the remote file contains no `session_fgs` event. So `hold_active` is proven by composition rather than by one end-to-end observation. The implementer flagged this itself rather than letting it pass.

The reviewer ruled it closes, on the grounds that everything below `connectionLogJsonl()` is **content-blind**: `MirroredDiagnostics.isMirrored` is a whole-category rule, `render()` is name-agnostic, and `ConnectionLogHostMirror.writeOverSession()` uploads raw bytes with the payload never interpolated into a shell command — the only content-dependent branch in the transport is `if (jsonl.isBlank())`. The connected assertion is a full `assertEquals` on the payload, not a substring check, so the transport is proven to be an identity function on whatever it carries. The proposed extra seed would route the same bytes through the same content-blind path — relocating an already-proven byte rather than testing a new mechanism.

The genuinely un-observed step is the Binder parcel round-trip of the boolean extra, which that seed would not close either; it is filed as a non-blocking follow-up.

## Orchestrator verification

Applied to a clean worktree off `main` (`8a8487f1`); integrated patch SHA-256 `26690fcdf5410035658fd4555b717507417c754bdee557fe2c7a10e471115dbf` matches the reviewed candidate exactly. `git diff --check` clean; file-size hygiene, VM ratchet, test-validity, and version-coupling guards all exit 0. Focused gate re-run with `--rerun-tasks`: test task unsuffixed (no `UP-TO-DATE`/`FROM-CACHE`/`NO-SOURCE`), both result XMLs newer than the run marker, 15 executed / 0 failed / 0 skipped self-asserted, both load-bearing classes named in the XML.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb