### PR TITLE
ci(journey): type the swiftshader real-IME precondition as INFRA, not RED (#1800)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,6 +232,23 @@ jobs:
           chmod +x scripts/ci-journey-retry-budget.sh scripts/test-ci-journey-retry-budget.sh
           scripts/test-ci-journey-retry-budget.sh
 
+      # Issue #1800: the failure-SIGNATURE classifier that types the CI
+      # swiftshader "real system input-method window never became visible"
+      # PRECONDITION as INFRA (-> RE-RUN) while keeping every genuine journey
+      # assertion failure — including a containment/anchor failure in the SAME
+      # class — hard RED. Drives the real classifier + the real aggregate
+      # reducer over fixture artifacts so BOTH outcomes are observed, and pins
+      # the measured cold-boot retry-cost model against the observed shard-0
+      # numbers from run 30305256109. Cheap (< 5 s), no emulator.
+      - name: CI journey infra-signature + measured retry-budget guard (issue #1800)
+        run: |
+          chmod +x scripts/ci-journey-infra-signature.sh \
+            scripts/ci-journey-infra-signature.py \
+            scripts/ci-journey-shard-signature-verdict.sh \
+            scripts/ci-journey-suite-elapsed.sh \
+            scripts/test-ci-journey-infra-signature.sh
+          scripts/test-ci-journey-infra-signature.sh
+
       # Issue #1781: fast, JVM-free artifact packaging fixture. Proves the
       # first-cold-boot preservation scan keeps real module Android outputs and
       # canonical per-attempt evidence without recursively nesting
@@ -958,6 +975,14 @@ jobs:
       # identical bringup runs. The journey TESTS only "really failed" if the
       # second attempt's suite reports failures — a one-off boot flake recovers
       # to green instead of spamming a red-CI email on an inert diff.
+
+      # Issue #1800: the cold-boot retry-budget decision needs THIS job's own
+      # observed bringup cost, not the 900s boot-timeout ceiling. Recording the
+      # first attempt's start epoch here lets the budget helper derive
+      # `bringup = (now - attempt start) - measured suite elapsed`.
+      - name: Record first journey attempt start
+        run: echo "JOURNEY_FIRST_ATTEMPT_START_EPOCH_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
+
       - name: Run load-bearing journey subset on the emulator
         id: journey
         continue-on-error: true
@@ -1009,10 +1034,24 @@ jobs:
           if [[ "$first_failure" != "true" && -f "$summary" ]] && grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$summary"; then
             first_timeout="true"
           fi
+          # Issue #1800: the suite records its own measured wall cost in the
+          # summary's result table ("| 48 load-bearing journey classes ... | 1 |
+          # 2338s | **FAIL** |"). That measured number — not the 4200s budget
+          # CAP — is what a retry of this same selection actually costs, so the
+          # retry-budget helper uses it instead of the flat worst case.
+          first_suite_elapsed_secs=""
+          if [[ -f "$summary" ]]; then
+            first_suite_elapsed_secs="$(
+              bash scripts/ci-journey-suite-elapsed.sh "$summary" 2>/dev/null || true
+            )"
+          fi
+          [[ "$first_suite_elapsed_secs" =~ ^[0-9]+$ ]] || first_suite_elapsed_secs=""
           echo "first_timeout=$first_timeout" >> "$GITHUB_OUTPUT"
           echo "first_failure=$first_failure" >> "$GITHUB_OUTPUT"
+          echo "first_suite_elapsed_secs=$first_suite_elapsed_secs" >> "$GITHUB_OUTPUT"
           echo "first summary timeout-only: $first_timeout"
           echo "first summary genuine failure: $first_failure"
+          echo "first summary measured suite elapsed: ${first_suite_elapsed_secs:-<unmeasured>}s"
 
       # Preserve the first cold-boot attempt before a retry can overwrite the
       # shared artifacts/ci-journey summary or Gradle connected-test outputs.
@@ -1062,9 +1101,16 @@ jobs:
         if: always()
         run: |
           chmod +x scripts/ci-journey-retry-budget.sh
+          # Issue #1800: pass this job's own measurements (first-attempt start
+          # epoch + the suite's measured elapsed) so the requirement reflects
+          # what redoing the observed work costs. Missing/invalid measurements
+          # fall back to the unchanged flat worst case inside the helper.
           scripts/ci-journey-retry-budget.sh \
             "${JOURNEY_JOB_START_EPOCH_MS:-}" \
-            "$(date +%s%3N)" | tee -a "$GITHUB_OUTPUT"
+            "$(date +%s%3N)" \
+            "${JOURNEY_FIRST_ATTEMPT_START_EPOCH_MS:-}" \
+            "${{ steps.journey_summary.outputs.first_suite_elapsed_secs }}" \
+            | tee -a "$GITHUB_OUTPUT"
 
       # Infra-retry-once: runs if the first bringup failed with a boot/adb abort
       # or a genuine test failure. It is deliberately skipped for a pure
@@ -1155,6 +1201,7 @@ jobs:
           retry_reason="${{ steps.journey_retry_budget.outputs.retry_reason }}"
           retry_remaining_ms="${{ steps.journey_retry_budget.outputs.retry_remaining_ms }}"
           retry_required_ms="${{ steps.journey_retry_budget.outputs.retry_required_ms }}"
+          retry_cost_model="${{ steps.journey_retry_budget.outputs.retry_cost_model }}"
           summary="artifacts/ci-journey/summary.md"
           # Issue #1458: record this shard's verdict token for the aggregation
           # job. CLEAN = passed; INFRA = environmental (#470 cancel / #771
@@ -1172,6 +1219,7 @@ jobs:
           echo "cold-boot retry allowed: ${retry_allowed:-false}"
           echo "cold-boot retry reason: ${retry_reason:-missing_decision}"
           echo "cold-boot retry remaining/required: ${retry_remaining_ms:-0}/${retry_required_ms:-5400000}ms"
+          echo "cold-boot retry cost model: ${retry_cost_model:-worst_case} (issue #1800)"
           if [[ "$first" == "success" ]]; then
             echo "Emulator journey passed on the first cold boot."
             write_verdict CLEAN
@@ -1181,6 +1229,33 @@ jobs:
             echo "::warning title=Emulator infra flake recovered::The first emulator bringup failed but a second cold boot passed (issue #760). Treating as a recovered infra flake, NOT a test failure. Watch for a degrading trend."
             write_verdict CLEAN
             exit 0
+          fi
+          # Issue #1800: ONE captured environment signature is not a product
+          # failure — the CI swiftshader AVD cannot raise a real system
+          # input-method window, so `PromptComposerSaturatedImeAnchorE2eTest`'s
+          # physical-IME PRECONDITION ("The real system input-method window
+          # never became visible.") fails there regardless of app code. That is
+          # the environment-divergent capability process.md F3 / #780 says must
+          # be injected synthetically, and the same class asserts every
+          # load-bearing anchor/containment property on its synthetic
+          # `Type.ime()` path with HARD failures
+          # (saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide),
+          # so typing this precondition INFRA loses no protection on CI.
+          #
+          # The classifier is deliberately narrow and fail-safe: it downgrades
+          # ONLY when EVERY failing test case of EVERY class listed under the
+          # summary's "Failed BOTH attempts" section carries that exact message,
+          # in EVERY preserved attempt. Any containment/anchor/other assertion
+          # failure, any unreadable result file, and any missing evidence keep
+          # the shard RED via the branches below. It cannot swallow a real
+          # regression, and it never applies to a #835 budget timeout.
+          signature_out="$(bash scripts/ci-journey-shard-signature-verdict.sh artifacts 2>&1 || true)"
+          printf '%s\n' "$signature_out" | sed 's/^/journey failure signature: /'
+          signature_verdict="$(sed -n 's/^shard_signature_verdict=//p' <<<"$signature_out" | tail -n 1)"
+          if [[ "$signature_verdict" == "INFRA" && "${first_timeout:-false}" != "true" ]]; then
+            echo "::warning title=Emulator journey INFRA — real system IME unavailable on this AVD::The ONLY failure(s) on this shard were the physical input-method-window PRECONDITION (\"The real system input-method window never became visible.\"), which the CI swiftshader AVD cannot satisfy. This is a captured environment signature (G5), NOT a product regression: the same class's anchor/containment properties are asserted with hard failures on its synthetic Type.ime() path, which ran in this same suite. Typed INFRA so aggregation requests RE-RUN. Any containment/anchor assertion failure would have stayed RED (issue #1800)."
+            write_verdict INFRA
+            exit 1
           fi
           if [[ "${first_failure:-false}" == "true" ]]; then
             echo "::error title=Emulator journey FAILED — first attempt genuine failure::The first cold boot wrote a JOURNEY_FAILED / Failed BOTH attempts summary, and the retry did not pass cleanly. Refusing to downgrade this run to advisory timeout even if the retry overwrote summary.md with a timeout-only artifact."

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
@@ -410,6 +410,255 @@ class PromptComposerSaturatedImeAnchorE2eTest {
         assertFalse(vm.uiState.value.draft.isEmpty())
     }
 
+    /**
+     * Issue #1800: the synthetic-inset MIRROR of
+     * [saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide].
+     *
+     * The real-IME method's load-bearing properties are reachability
+     * (containment of draft/send/attach/mic inside the measured modal root and
+     * above the exact keyboard boundary), keyboard-up editability + draft
+     * durability, and keyboard-down geometry restoration. Every one of those is
+     * a property of the composer's anchor policy, NOT of the physical
+     * input-method window — but on the CI swiftshader AVD the real IME never
+     * becomes visible, so the real-IME method cannot assert them there and the
+     * shard classifier types that precondition as INFRA.
+     *
+     * This method asserts the SAME property set with a HARD failure, driven by
+     * the deterministic synthetic `Type.ime()` inset (the #780 model), so no
+     * protection is lost on an environment without a real IME. It deliberately
+     * uses the SATURATED fixture — a durable long draft plus the real queued
+     * `Sending` banner — because that is the state whose Material
+     * [SheetValue.PartiallyExpanded] anchor crosses the keyboard boundary; it
+     * is therefore sensitive to a regression of the production anchor policy,
+     * which a non-saturated fixture would not be. It also mounts the production
+     * attachment-availability contract so Attach is enabled and can be asserted
+     * reachable alongside Mic.
+     *
+     * The physical keyboard is hard-asserted ABSENT throughout, so this method
+     * behaves identically on a dev-box AVD and on a CI AVD that cannot raise a
+     * real IME.
+     */
+    @Test
+    fun saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide() {
+        val drafts = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newViewModel(drafts, queue)
+        val visible = mutableStateOf(true)
+        val sendEntered = CompletableDeferred<Unit>()
+        val deliveryGate = CompletableDeferred<Unit>().also { releaseDelivery = it }
+        val sheetStateRef = AtomicReference<SheetState?>()
+        val targetKey = "1/issue-1800-synthetic-reach"
+
+        prepareActivityWindow()
+        compose.setContent {
+            PocketShellTheme {
+                Box(Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    if (visible.value) {
+                        val sheetState =
+                            rememberModalBottomSheetState(skipPartiallyExpanded = false)
+                        SideEffect { sheetStateRef.set(sheetState) }
+                        PromptComposerSheet(
+                            onDismiss = { visible.value = false },
+                            onSend = {
+                                sendEntered.complete(Unit)
+                                deliveryGate.await()
+                                true
+                            },
+                            composerTargetKey = targetKey,
+                            sendTargetSnapshotProvider = {
+                                PromptComposerViewModel.SendTargetSnapshot(sessionKey = targetKey)
+                            },
+                            // Same production availability contract the real-IME
+                            // method mounts: a non-null callback enables Attach
+                            // without opening the picker or touching geometry.
+                            onStageAttachments = { uris ->
+                                Result.success(
+                                    uris.mapIndexed { index, uri ->
+                                        "/tmp/issue-1800-" +
+                                            (uri.lastPathSegment ?: "attachment-$index")
+                                    },
+                                )
+                            },
+                            modifier = Modifier.observeProductionSheetIme(),
+                            sheetState = sheetState,
+                            viewModel = vm,
+                        )
+                    }
+                }
+            }
+        }
+        compose.waitUntil(5_000) {
+            vm.composerTarget == targetKey &&
+                sheetStateRef.get()?.currentValue != null &&
+                sheetStateRef.get()?.currentValue != SheetValue.Hidden
+        }
+        val sheetState = checkNotNull(sheetStateRef.get())
+
+        // Saturate exactly like the #1744 anchor oracle: one in-flight queued
+        // send (the real `Sending` banner) plus the long durable draft.
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+            .performClick()
+            .performTextInput("prompt A")
+        compose.waitUntil(5_000) {
+            vm.uiState.value.draft == "prompt A" && drafts.load(targetKey) == "prompt A"
+        }
+        compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, useUnmergedTree = true)
+            .performClick()
+        compose.waitUntil(5_000) {
+            sendEntered.isCompleted && vm.uiState.value.sendInFlight
+        }
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+            .performClick()
+            .performTextInput(LONG_DRAFT_B)
+        compose.waitUntil(5_000) {
+            vm.uiState.value.draft == LONG_DRAFT_B &&
+                drafts.load(targetKey) == LONG_DRAFT_B
+        }
+        assertPromptAExactlyOnce(queue, targetKey)
+        hideRealImeAndAssertHidden(
+            "Synthetic reachability mirror must start with no physical keyboard window.",
+        )
+
+        val keyboardDown = applyInsetsAndReadGeometry(
+            imeBottomPx = 0,
+            sheetState = sheetState,
+        )
+        assertEquals(0, keyboardDown.observedImeBottomPx)
+
+        // HARD "the keyboard-up state actually applied" precondition — the
+        // synthetic equivalent of the real method's physical-IME-window +
+        // positive-app-inset preconditions. `applyInsetsAndReadGeometry`
+        // asserts the exact value was Compose-observed on the production
+        // modifier; no assumeTrue, no skip.
+        val expectedIme = (SYNTHETIC_IME_HEIGHT_DP * displayDensity()).toInt()
+        val keyboardUpBeforeEdit = applyInsetsAndReadGeometry(
+            imeBottomPx = expectedIme,
+            sheetState = sheetState,
+        )
+        assertEquals(expectedIme, keyboardUpBeforeEdit.observedImeBottomPx)
+
+        // Keyboard-up editability + durability (mirrors the real method's
+        // performTextReplacement while the physical keyboard is visible).
+        val editedDraft = "$LONG_DRAFT_B$SYNTHETIC_REACH_SUFFIX"
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
+            .performTextReplacement(editedDraft)
+        compose.waitUntil(5_000) {
+            vm.uiState.value.draft == editedDraft &&
+                drafts.load(targetKey) == editedDraft
+        }
+        assertNoPhysicalImeWindow(
+            "Post-inset semantics input must not summon LatinIME in the synthetic mirror.",
+        )
+
+        val keyboardUp = applyInsetsAndReadGeometry(
+            imeBottomPx = expectedIme,
+            sheetState = sheetState,
+        )
+        val keyboardTopPx = keyboardUp.rootBottomPx - keyboardUp.observedImeBottomPx
+        assertTrue(
+            "The synthetic keyboard must expose a positive inset on the production " +
+                "modal root. geometry=$keyboardUp",
+            keyboardUp.observedImeBottomPx > 0,
+        )
+        // Mirrors the real-IME method's settle gate: reachability is asserted on
+        // a settled anchor, never mid-animation.
+        compose.waitUntil(REAL_IME_TIMEOUT_MS) {
+            sheetState.currentValue == sheetState.targetValue
+        }
+        assertEquals(sheetState.targetValue, sheetState.currentValue)
+
+        // THE load-bearing mirror of the real-IME reachability contract: every
+        // action the maintainer must be able to see and tap stays inside the
+        // measured modal root AND above the exact same-root keyboard boundary.
+        // Containment (all four edges), never a bare assertIsDisplayed().
+        REAL_IME_REACHABLE_TAGS.forEach { tag ->
+            compose.onNodeWithTag(tag, useUnmergedTree = true)
+                .assertIsDisplayed()
+                .assertIsEnabled()
+            assertNodeBelongsToMeasuredModalAndIsReachable(
+                tag = tag,
+                geometry = keyboardUp,
+                keyboardTopPx = keyboardTopPx,
+            )
+        }
+        // The whole Surface (drag handle included) must clear the boundary too,
+        // so a partially-contained sheet cannot pass on its children alone.
+        assertTrue(
+            "The saturated production Surface must be fully above the exact same-root " +
+                "keyboard boundary. keyboardTopPx=$keyboardTopPx geometry=$keyboardUp " +
+                "state=${sheetState.currentValue}/${sheetState.targetValue}",
+            keyboardUp.displayedSurfaceBottomPx <= keyboardTopPx + ROOT_SLOP_PX,
+        )
+        assertEquals(editedDraft, vm.uiState.value.draft)
+        assertEquals(editedDraft, drafts.load(targetKey))
+        assertPromptAExactlyOnce(queue, targetKey)
+        assertTrue(visible.value)
+        assertNotEquals(SheetValue.Hidden, sheetState.currentValue)
+        println(
+            "ISSUE1800_SYNTHETIC_REACH keyboardDown=$keyboardDown keyboardUp=$keyboardUp " +
+                "keyboardTopPx=$keyboardTopPx " +
+                "physicalImeWindows=${visiblePhysicalImeWindows()} " +
+                "state=${sheetState.currentValue}/${sheetState.targetValue}",
+        )
+        assertNoPhysicalImeWindow(
+            "Synthetic reachability screenshot must not contain a physical keyboard.",
+        )
+        WalkthroughScreenshotArtifacts.capture(
+            "issue-1800-synthetic-ime-all-actions-reachable",
+        )
+
+        // Keyboard-down restoration (mirrors the real method's actual-hide leg).
+        applyInsetsAndReadGeometry(imeBottomPx = 0, sheetState = sheetState)
+        compose.waitUntil(REAL_IME_TIMEOUT_MS) {
+            sheetState.currentValue == sheetState.targetValue
+        }
+        assertEquals(sheetState.targetValue, sheetState.currentValue)
+        val restored = readMountedGeometry(
+            sheetState = sheetState,
+            expectedImeBottomPx = 0,
+        )
+        val returnSlopPx = RETURN_GEOMETRY_SLOP_DP * displayDensity()
+        assertEquals(0, restored.observedImeBottomPx)
+        assertTrue(visible.value)
+        assertNotEquals(SheetValue.Hidden, sheetState.currentValue)
+        assertEquals(editedDraft, vm.uiState.value.draft)
+        assertEquals(editedDraft, drafts.load(targetKey))
+        assertTrue(
+            "Hiding the synthetic keyboard must restore the stable keyboard-down " +
+                "sheet geometry. before=$keyboardDown restored=$restored " +
+                "slopPx=$returnSlopPx",
+            abs(restored.surfaceTopPx - keyboardDown.surfaceTopPx) <= returnSlopPx &&
+                abs(
+                    restored.displayedSurfaceBottomPx -
+                        keyboardDown.displayedSurfaceBottomPx,
+                ) <= returnSlopPx,
+        )
+        REAL_IME_REACHABLE_TAGS.forEach { tag ->
+            assertNodeBelongsToMeasuredModalAndIsReachable(
+                tag = tag,
+                geometry = restored,
+                keyboardTopPx = restored.rootBottomPx,
+            )
+        }
+        println(
+            "ISSUE1800_SYNTHETIC_REACH_RESTORED restored=$restored " +
+                "physicalImeWindows=${visiblePhysicalImeWindows()} " +
+                "draftDurable=${drafts.load(targetKey) == editedDraft} " +
+                "state=${sheetState.currentValue}/${sheetState.targetValue}",
+        )
+        assertNoPhysicalImeWindow(
+            "The restored synthetic screenshot must not contain the system keyboard.",
+        )
+        WalkthroughScreenshotArtifacts.capture(
+            "issue-1800-synthetic-ime-hidden-draft-restored",
+        )
+
+        deliveryGate.complete(Unit)
+        compose.waitUntil(5_000) { !vm.uiState.value.sendInFlight }
+        assertEquals(editedDraft, vm.uiState.value.draft)
+        assertEquals(editedDraft, drafts.load(targetKey))
+    }
+
     @Test
     fun saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide() {
         val drafts = InMemoryComposerDraftStore()
@@ -500,13 +749,9 @@ class PromptComposerSaturatedImeAnchorE2eTest {
             "The real-IME artifact requires the system input-method window to be visible.",
         )
 
-        val reachableTags = listOf(
-            COMPOSER_DRAFT_TAG,
-            COMPOSER_SEND_ENTER_TAG,
-            COMPOSER_ATTACH_TAG,
-            COMPOSER_MIC_TAG,
-        )
-        reachableTags.forEach { tag ->
+        // Issue #1800: the SAME tag set the synthetic mirror asserts, shared so
+        // the two paths cannot silently drift apart.
+        REAL_IME_REACHABLE_TAGS.forEach { tag ->
             compose.onNodeWithTag(tag, useUnmergedTree = true)
                 .assertIsDisplayed()
                 .assertIsEnabled()
@@ -994,6 +1239,21 @@ class PromptComposerSaturatedImeAnchorE2eTest {
         const val TERMINAL_MARKER = "agent output remains visible above the composer"
         const val POST_IME_SUFFIX = " remains editable above the keyboard"
         const val REAL_IME_SUFFIX = " edited while the real keyboard is visible"
+        const val SYNTHETIC_REACH_SUFFIX =
+            " edited while the synthetic keyboard boundary is up"
+
+        /**
+         * Issue #1800: the controls whose keyboard-up reachability is the
+         * load-bearing property. Shared by the real-IME journey and its
+         * synthetic mirror so the CI-runnable path can never assert less than
+         * the dev-box path.
+         */
+        val REAL_IME_REACHABLE_TAGS = listOf(
+            COMPOSER_DRAFT_TAG,
+            COMPOSER_SEND_ENTER_TAG,
+            COMPOSER_ATTACH_TAG,
+            COMPOSER_MIC_TAG,
+        )
         val LONG_DRAFT_B = (1..14).joinToString(separator = " ") {
             "draft B segment $it stays durable while prompt A is sending;"
         }

--- a/scripts/ci-journey-infra-signature.py
+++ b/scripts/ci-journey-infra-signature.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Issue #1800: classify an emulator-journey shard's failed-BOTH-attempts
+evidence as either an environment-divergent capability precondition (INFRA) or a
+genuine product failure (RED).
+
+The ONE captured signature this recognises is the CI swiftshader AVD's inability
+to raise a *real system input-method window*:
+
+    The real system input-method window never became visible.
+
+That assertion is not a product assertion. It is the physical-IME precondition
+of `PromptComposerSaturatedImeAnchorE2eTest`, i.e. exactly the
+environment-divergent capability `process.md` F3 / #780 says must be injected
+synthetically rather than required. The load-bearing anchor/containment
+properties of that class are independently asserted on its synthetic
+`Type.ime()` path with hard failures, so typing this precondition as INFRA loses
+no protection on CI.
+
+Narrowness is the whole point. The classifier reports `real_ime_precondition`
+ONLY when EVERY failing test case belonging to a class listed under the suite
+summary's "Failed BOTH attempts" section carries that exact message. A single
+containment / anchor / any other assertion failure — in the same class, in the
+same run, in any attempt — forces `product_failure`, which keeps the shard RED.
+Missing or unreadable evidence reports `unclassified`, which also keeps the
+shard RED (fail-safe toward the red verdict, never toward green).
+
+Usage:
+    ci-journey-infra-signature.py SUMMARY_FILE ARTIFACT_ROOT [ARTIFACT_ROOT ...]
+
+Output (GitHub step-output compatible key=value lines):
+    journey_failure_classification=real_ime_precondition|product_failure|unclassified
+    journey_failed_classes=<space separated FQCNs from the summary>
+    journey_failing_testcases=<count of failing test cases attributed to them>
+    journey_signature_matches=<count of those carrying the captured signature>
+    journey_offending_failures=<semicolon separated "class#method" that did not match>
+
+Exit status is always 0: the caller decides the verdict from the classification.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+# The ONE captured environment signature (issue #1800 / run 30305256109).
+REAL_IME_UNAVAILABLE_SIGNATURE = (
+    "The real system input-method window never became visible."
+)
+
+# `- \`com.example.Foo\`` bullets under the summary's failed-both header.
+_FAILED_HEADER = re.compile(r"Failed BOTH attempts|JOURNEY_FAILED")
+_BULLET = re.compile(r"^\s*-\s+`([A-Za-z_][\w.$]*)`")
+
+
+def failed_both_classes(summary_path: str) -> list[str]:
+    """FQCNs listed under the suite summary's failed-BOTH-attempts section."""
+    try:
+        with open(summary_path, "r", encoding="utf-8", errors="replace") as handle:
+            lines = handle.read().splitlines()
+    except OSError:
+        return []
+
+    classes: list[str] = []
+    in_section = False
+    for line in lines:
+        if _FAILED_HEADER.search(line):
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        match = _BULLET.match(line)
+        if match:
+            name = match.group(1)
+            if name not in classes:
+                classes.append(name)
+            continue
+        if line.strip() == "":
+            continue
+        # Any other non-bullet content ends the section.
+        in_section = False
+    return classes
+
+
+def _iter_result_xml(roots: list[str]):
+    for root in roots:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for name in filenames:
+                if name.startswith("TEST-") and name.endswith(".xml"):
+                    yield os.path.join(dirpath, name)
+
+
+def _failure_text(element: ET.Element) -> str:
+    """Full failure text: the `message` attribute plus the element body."""
+    parts = [element.get("message") or "", element.text or ""]
+    return "\n".join(part for part in parts if part)
+
+
+def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
+    classes = failed_both_classes(summary_path)
+    failing = 0
+    matches = 0
+    offenders: list[str] = []
+
+    if classes:
+        wanted = set(classes)
+        for xml_path in _iter_result_xml(roots):
+            try:
+                tree = ET.parse(xml_path)
+            except (ET.ParseError, OSError):
+                # An unreadable result file is missing evidence, not proof of an
+                # environmental cause. Record it as an offender so the shard
+                # cannot be downgraded on incomplete data.
+                offenders.append(f"<unreadable>#{os.path.basename(xml_path)}")
+                continue
+            for case in tree.iter("testcase"):
+                classname = case.get("classname") or ""
+                # Parameterised runners append the device label, e.g.
+                # `com.example.Foo[emulator-5554 - 15]`.
+                base = classname.split("[", 1)[0].strip()
+                if base not in wanted:
+                    continue
+                problems = list(case.findall("failure")) + list(case.findall("error"))
+                if not problems:
+                    continue
+                failing += 1
+                texts = [_failure_text(problem) for problem in problems]
+                if all(REAL_IME_UNAVAILABLE_SIGNATURE in text for text in texts):
+                    matches += 1
+                else:
+                    offenders.append(f"{base}#{case.get('name') or '<unknown>'}")
+
+    if not classes or failing == 0:
+        classification = "unclassified"
+    elif offenders or matches != failing:
+        classification = "product_failure"
+    else:
+        classification = "real_ime_precondition"
+
+    return {
+        "journey_failure_classification": classification,
+        "journey_failed_classes": " ".join(classes),
+        "journey_failing_testcases": failing,
+        "journey_signature_matches": matches,
+        "journey_offending_failures": ";".join(offenders),
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        sys.stderr.write(
+            "Usage: ci-journey-infra-signature.py SUMMARY_FILE ARTIFACT_ROOT "
+            "[ARTIFACT_ROOT ...]\n",
+        )
+        # Still emit a fail-safe classification so the caller keeps RED.
+        print("journey_failure_classification=unclassified")
+        print("journey_failed_classes=")
+        print("journey_failing_testcases=0")
+        print("journey_signature_matches=0")
+        print("journey_offending_failures=")
+        return 0
+
+    result = classify(argv[1], argv[2:])
+    for key in (
+        "journey_failure_classification",
+        "journey_failed_classes",
+        "journey_failing_testcases",
+        "journey_signature_matches",
+        "journey_offending_failures",
+    ):
+        print(f"{key}={result[key]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/ci-journey-infra-signature.sh
+++ b/scripts/ci-journey-infra-signature.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Issue #1800: fail-safe front end for the emulator-journey failure-signature
+# classifier. Emits GitHub-step-output-compatible key=value lines and ALWAYS
+# exits 0; the caller decides the shard verdict from the classification.
+#
+# The only classification that changes a shard's verdict is
+# `real_ime_precondition` (the captured CI swiftshader "real system
+# input-method window never became visible" precondition -> INFRA / RE-RUN).
+# Everything else — including a missing python3, missing artifacts, an
+# unreadable result file, or ANY other assertion failure — reports
+# `unclassified` or `product_failure`, both of which keep the shard RED.
+#
+# Usage:
+#   ci-journey-infra-signature.sh SUMMARY_FILE ARTIFACT_ROOT [ARTIFACT_ROOT ...]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+CLASSIFIER="${CI_JOURNEY_INFRA_SIGNATURE_CLASSIFIER:-$SCRIPT_DIR/ci-journey-infra-signature.py}"
+PYTHON_BIN="${CI_JOURNEY_PYTHON:-python3}"
+
+emit_unclassified() {
+  local reason="$1"
+  echo "journey_failure_classification=unclassified"
+  echo "journey_failed_classes="
+  echo "journey_failing_testcases=0"
+  echo "journey_signature_matches=0"
+  echo "journey_offending_failures="
+  echo "journey_signature_note=$reason" >&2
+}
+
+if [[ "$#" -lt 2 ]]; then
+  emit_unclassified "usage: SUMMARY_FILE ARTIFACT_ROOT [ARTIFACT_ROOT ...]"
+  exit 0
+fi
+
+if [[ ! -f "$CLASSIFIER" ]]; then
+  emit_unclassified "classifier missing: $CLASSIFIER"
+  exit 0
+fi
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  emit_unclassified "python3 unavailable; keeping the shard verdict red"
+  exit 0
+fi
+
+output=""
+if ! output="$("$PYTHON_BIN" "$CLASSIFIER" "$@" 2>/dev/null)"; then
+  emit_unclassified "classifier exited non-zero; keeping the shard verdict red"
+  exit 0
+fi
+
+if ! grep -q '^journey_failure_classification=' <<<"$output"; then
+  emit_unclassified "classifier produced no classification line"
+  exit 0
+fi
+
+printf '%s\n' "$output"
+exit 0

--- a/scripts/ci-journey-retry-budget.sh
+++ b/scripts/ci-journey-retry-budget.sh
@@ -3,14 +3,30 @@
 # budget left to start a second fresh cold boot.
 #
 # The GitHub job cap is 95 minutes. A retry is allowed only when the remaining
-# wall covers the full worst-case retry path:
+# wall covers the retry path.
+#
+# Issue #1800 — the requirement now reflects the cost of redoing THIS job's
+# observed work instead of a fixed worst case. The original flat reserve was:
 #   900s emulator shutdown/cold-boot/readiness
-# + 4200s selected journey-suite budget
+# + 4200s selected journey-suite budget   <- the suite's CAP, not its cost
 # + 300s classifier, Docker logs, artifact upload, and fixture teardown
 # = 5400s minimum remaining.
+# That over-denied badly: on run 30305256109 shard 0 the first attempt's suite
+# took 2338s (not 4200s) and its emulator bringup took ~50s (not 900s), so a
+# complete retry cost ~2688s while the flat rule demanded 5400s and refused with
+# 3112241ms (~52 min) still on the clock.
+#
+# When the caller supplies this job's own measurements the requirement becomes:
+#   boot reserve   = max(3 x observed bringup, 120s)   — 3x headroom, 2 min floor
+# + suite cost     = 1.10 x observed suite elapsed     — 10% headroom
+# + teardown       = 300s (unchanged)
+# clamped to never EXCEED the legacy flat 5400s, so this can only ever permit
+# retries the old rule refused — never refuse one it allowed. Without usable
+# measurements the flat 5400s worst case is used unchanged (fail-safe).
 #
 # Usage:
-#   ci-journey-retry-budget.sh JOB_START_EPOCH_MS NOW_EPOCH_MS
+#   ci-journey-retry-budget.sh JOB_START_EPOCH_MS NOW_EPOCH_MS \
+#     [FIRST_ATTEMPT_START_EPOCH_MS] [FIRST_SUITE_ELAPSED_SECS]
 #
 # Output is GitHub-step-output-compatible key=value lines. Invalid/missing clock
 # input fails safe by denying the retry while returning success, so the workflow
@@ -19,14 +35,66 @@ set -uo pipefail
 
 readonly JOURNEY_JOB_CAP_MS=5700000
 readonly JOURNEY_RETRY_REQUIRED_MS=5400000
+readonly JOURNEY_RETRY_TEARDOWN_MS=300000
+readonly JOURNEY_RETRY_MIN_BOOT_RESERVE_MS=120000
+readonly JOURNEY_RETRY_BOOT_HEADROOM_NUMERATOR=3
+readonly JOURNEY_RETRY_SUITE_HEADROOM_NUMERATOR=110
+readonly JOURNEY_RETRY_SUITE_HEADROOM_DENOMINATOR=100
 readonly MAX_SIGNED_INT64_DECIMAL=9223372036854775807
+readonly MAX_MEASURED_SUITE_SECS=86400
+
+RETRY_REQUIRED_MS="$JOURNEY_RETRY_REQUIRED_MS"
+RETRY_COST_MODEL="worst_case"
 
 emit_decision() {
   local allowed="$1" reason="$2" remaining="$3"
   printf 'retry_allowed=%s\n' "$allowed"
   printf 'retry_reason=%s\n' "$reason"
   printf 'retry_remaining_ms=%s\n' "$remaining"
-  printf 'retry_required_ms=%s\n' "$JOURNEY_RETRY_REQUIRED_MS"
+  printf 'retry_required_ms=%s\n' "$RETRY_REQUIRED_MS"
+  printf 'retry_cost_model=%s\n' "$RETRY_COST_MODEL"
+}
+
+canonical_decimal() {
+  local value="${1-}"
+  [[ "$value" =~ ^[0-9]+$ ]] || return 1
+  [[ "$value" == "0" || "$value" != 0* ]] || return 1
+  return 0
+}
+
+# measured_retry_required_ms <attempt_start_ms> <suite_elapsed_secs> <now_ms>
+#
+# Echoes the measured requirement, or nothing when the evidence is unusable.
+# Never exceeds the legacy flat worst case.
+measured_retry_required_ms() {
+  local attempt_start="${1-}" suite_secs="${2-}" now_value="$3"
+  local attempt_value suite_ms attempt_elapsed boot_ms boot_reserve suite_cost required
+
+  canonical_decimal "$attempt_start" || return 1
+  canonical_decimal "$suite_secs" || return 1
+  epoch_out_of_range "$attempt_start" && return 1
+  decimal_greater_than "$suite_secs" "$MAX_MEASURED_SUITE_SECS" && return 1
+
+  attempt_value=$((10#$attempt_start))
+  (( attempt_value > 0 )) || return 1
+  (( attempt_value <= now_value )) || return 1
+  suite_ms=$(( (10#$suite_secs) * 1000 ))
+  (( suite_ms > 0 )) || return 1
+
+  attempt_elapsed=$((now_value - attempt_value))
+  boot_ms=$((attempt_elapsed - suite_ms))
+  (( boot_ms >= 0 )) || return 1
+
+  boot_reserve=$((boot_ms * JOURNEY_RETRY_BOOT_HEADROOM_NUMERATOR))
+  (( boot_reserve < JOURNEY_RETRY_MIN_BOOT_RESERVE_MS )) &&
+    boot_reserve="$JOURNEY_RETRY_MIN_BOOT_RESERVE_MS"
+  suite_cost=$((
+    suite_ms * JOURNEY_RETRY_SUITE_HEADROOM_NUMERATOR /
+      JOURNEY_RETRY_SUITE_HEADROOM_DENOMINATOR
+  ))
+  required=$((boot_reserve + suite_cost + JOURNEY_RETRY_TEARDOWN_MS))
+  (( required > JOURNEY_RETRY_REQUIRED_MS )) && required="$JOURNEY_RETRY_REQUIRED_MS"
+  printf '%s' "$required"
 }
 
 # decimal_greater_than <canonical-decimal-a> <canonical-decimal-b>
@@ -50,6 +118,10 @@ epoch_out_of_range() {
 
 journey_retry_budget_decision() {
   local start="${1-}" now="${2-}"
+  local attempt_start="${3-}" suite_secs="${4-}"
+
+  RETRY_REQUIRED_MS="$JOURNEY_RETRY_REQUIRED_MS"
+  RETRY_COST_MODEL="worst_case"
 
   if [[ -z "$start" ]]; then
     emit_decision false missing_job_start 0
@@ -98,7 +170,16 @@ journey_retry_budget_decision() {
     remaining=$((JOURNEY_JOB_CAP_MS - elapsed))
   fi
 
-  if (( remaining >= JOURNEY_RETRY_REQUIRED_MS )); then
+  # Issue #1800: prefer this job's own measured retry cost over the flat
+  # worst case. The helper never returns MORE than the legacy requirement, so
+  # a measurement can only ever unlock a retry the flat rule refused.
+  local measured
+  if measured="$(measured_retry_required_ms "$attempt_start" "$suite_secs" "$now_value")"; then
+    RETRY_REQUIRED_MS="$measured"
+    RETRY_COST_MODEL="measured_first_attempt"
+  fi
+
+  if (( remaining >= RETRY_REQUIRED_MS )); then
     emit_decision true sufficient_remaining_budget "$remaining"
   else
     emit_decision false insufficient_remaining_budget "$remaining"
@@ -106,5 +187,5 @@ journey_retry_budget_decision() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-  journey_retry_budget_decision "${1-}" "${2-}"
+  journey_retry_budget_decision "${1-}" "${2-}" "${3-}" "${4-}"
 fi

--- a/scripts/ci-journey-shard-signature-verdict.sh
+++ b/scripts/ci-journey-shard-signature-verdict.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Issue #1800: decide whether an emulator-journey shard's failure evidence is
+# the ONE captured environment signature (the CI swiftshader AVD cannot raise a
+# real system input-method window) rather than a genuine journey failure.
+#
+# This is the exact decision the workflow's classify step applies, extracted so
+# it can be driven — and observed — without an emulator
+# (scripts/test-ci-journey-infra-signature.sh).
+#
+# Usage:
+#   ci-journey-shard-signature-verdict.sh <artifacts-dir>
+#
+# <artifacts-dir> is the job workspace's artifacts root, holding the canonical
+# layout the journey suite + workflow write:
+#   <artifacts-dir>/ci-journey/                 (final attempt)
+#   <artifacts-dir>/ci-journey-attempt-1/ci-journey/  (preserved first attempt)
+#
+# Output (GitHub-step-output-compatible key=value lines):
+#   shard_signature_verdict=INFRA | NONE
+#   shard_signature_summaries=<count of summaries inspected>
+#   shard_signature_detail=<per-summary classifications, space separated>
+#
+# INFRA is emitted ONLY when at least one summary was inspected AND every
+# inspected summary classified as `real_ime_precondition`. Anything else — a
+# genuine assertion failure, mixed evidence, missing/corrupt result XML, a
+# missing classifier — emits NONE, which leaves the caller's existing RED
+# branches in charge. Always exits 0.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SIGNATURE="${CI_JOURNEY_INFRA_SIGNATURE:-$SCRIPT_DIR/ci-journey-infra-signature.sh}"
+
+artifacts="${1-}"
+
+verdict="NONE"
+seen=0
+detail=""
+
+if [[ -n "$artifacts" && -d "$artifacts" && -f "$SIGNATURE" ]]; then
+  all_signature=true
+  for summary in \
+    "$artifacts/ci-journey-attempt-1/ci-journey/summary.md" \
+    "$artifacts/ci-journey/summary.md"; do
+    [[ -f "$summary" ]] || continue
+    out="$(bash "$SIGNATURE" "$summary" \
+      "$artifacts/ci-journey" \
+      "$artifacts/ci-journey-attempt-1" 2>/dev/null || true)"
+    classification="$(sed -n 's/^journey_failure_classification=//p' <<<"$out" | tail -n 1)"
+    [[ -n "$classification" ]] || classification="unclassified"
+    seen=$((seen + 1))
+    detail="${detail:+$detail }${summary}=${classification}"
+    [[ "$classification" == "real_ime_precondition" ]] || all_signature=false
+  done
+  if (( seen > 0 )) && [[ "$all_signature" == "true" ]]; then
+    verdict="INFRA"
+  fi
+fi
+
+printf 'shard_signature_verdict=%s\n' "$verdict"
+printf 'shard_signature_summaries=%s\n' "$seen"
+printf 'shard_signature_detail=%s\n' "$detail"
+exit 0

--- a/scripts/ci-journey-suite-elapsed.sh
+++ b/scripts/ci-journey-suite-elapsed.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Issue #1800: read the journey suite's OWN measured wall cost out of the
+# summary artifact it writes (scripts/ci-journey-summary-functions.sh).
+#
+# The summary's result table row is:
+#   | <N> load-bearing journey classes (shard i/n; per-class retry-once) | \
+#     `pocketshellCi=true` | <exit> | <elapsed>s | **<STATUS>** |
+#
+# The 4th column is the measured elapsed seconds. That measurement — not the
+# 4200s budget CAP — is what re-running the same selection actually costs, and
+# it is what scripts/ci-journey-retry-budget.sh needs to size the cold-boot
+# retry requirement against the remaining job wall.
+#
+# Prints the elapsed seconds on stdout and exits 0 when it can be read; prints
+# nothing and exits 1 otherwise, so the caller falls back to the flat worst
+# case instead of trusting a guess.
+set -uo pipefail
+
+summary="${1-}"
+
+[[ -n "$summary" && -f "$summary" ]] || exit 1
+
+elapsed="$(
+  awk -F'|' '
+    /load-bearing journey classes/ && NF >= 6 {
+      value = $5
+      gsub(/[ \t]/, "", value)
+      if (value ~ /^[0-9]+s$/) {
+        sub(/s$/, "", value)
+        print value
+        exit
+      }
+    }
+  ' "$summary"
+)"
+
+[[ "$elapsed" =~ ^[0-9]+$ ]] || exit 1
+printf '%s\n' "$elapsed"

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# Issue #1800: deterministic, JVM-free, emulator-free fixture test for the
+# emulator-journey failure-SIGNATURE classifier and the two aggregate outcomes
+# it can produce.
+#
+# The load-bearing property: a shard whose ONLY failure is the CI swiftshader
+# AVD's inability to raise a real system input-method window must aggregate to
+# RE-RUN (neutral green), while a shard carrying ANY genuine journey assertion
+# failure — including a containment/anchor failure in the SAME class, in the
+# same run — must still aggregate to RED. Both outcomes are DEMONSTRATED here by
+# driving the real classifier and then the real aggregate reducer, not argued.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SIGNATURE="$SCRIPT_DIR/ci-journey-infra-signature.sh"
+SHARD_VERDICT="$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh"
+ELAPSED="$SCRIPT_DIR/ci-journey-suite-elapsed.sh"
+RETRY_BUDGET="$SCRIPT_DIR/ci-journey-retry-budget.sh"
+AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+WORKFLOW="${CI_JOURNEY_INFRA_SIGNATURE_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
+ANDROID_TEST="$REPO_ROOT/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+for required in "$SIGNATURE" "$SHARD_VERDICT" "$ELAPSED" "$RETRY_BUDGET" "$AGG" "$WORKFLOW"; do
+  [[ -f "$required" ]] || fail "missing required file: $required"
+done
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+REAL_IME_MESSAGE='java.lang.AssertionError: The real system input-method window never became visible.'
+CONTAINMENT_MESSAGE="java.lang.AssertionError: Node 'prompt-composer-send-enter' must stay above the same-root keyboard boundary. node=Rect.fromLTRB(0.0, 1500.0, 1080.0, 1654.0) keyboardTopPx=1626.0"
+SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
+
+# ---------------------------------------------------------------------------
+# Fixture builders: a realistic suite summary + realistic connected-test JUnit
+# XML under the exact artifact layout the suite writes
+# (artifacts/ci-journey/class-attempts/<module>/<key>/attempt-N/...).
+# ---------------------------------------------------------------------------
+
+# write_summary <root> <elapsed-secs> <failed-class> [<failed-class> ...]
+write_summary() {
+  local root="$1" elapsed="$2"; shift 2
+  mkdir -p "$root/ci-journey"
+  {
+    echo "# Per-push CI journey suite — summary"
+    echo
+    echo "| Selection | Args | Exit | Elapsed | Result |"
+    echo "| --- | --- | --- | --- | --- |"
+    echo "| 48 load-bearing journey classes (shard 0/3; per-class retry-once) | \`pocketshellCi=true\` | 1 | ${elapsed}s | **FAIL** |"
+    echo
+    echo "Classes exercised:"
+    echo "- \`com.pocketshell.app.proof.SomeOtherJourneyE2eTest\`"
+    echo "- \`$SATURATED_CLASS\`"
+    if (( $# > 0 )); then
+      echo
+      echo "Failed BOTH attempts (\`JOURNEY_FAILED\` — job red):"
+      local c
+      for c in "$@"; do
+        echo "- \`$c\`"
+      done
+    fi
+  } > "$root/ci-journey/summary.md"
+}
+
+# write_case_xml <root> <class> <attempt> <method>:<outcome> ...
+#   outcome: pass | realime | containment | error
+write_case_xml() {
+  local root="$1" class="$2" attempt="$3"; shift 3
+  local key="${class##*.}"
+  local dir="$root/ci-journey/class-attempts/app/$key/attempt-$attempt/android-test-outputs/androidTest-results/connected"
+  mkdir -p "$dir"
+  local file="$dir/TEST-emulator-5554-15_$key-$attempt.xml"
+  {
+    echo '<?xml version="1.0" encoding="UTF-8"?>'
+    echo "<testsuite name=\"$class\" tests=\"$#\">"
+    local spec method outcome
+    for spec in "$@"; do
+      method="${spec%%:*}"
+      outcome="${spec##*:}"
+      echo "  <testcase name=\"$method\" classname=\"$class[emulator-5554 - 15]\">"
+      case "$outcome" in
+        pass) ;;
+        realime)
+          echo "    <failure message=\"$REAL_IME_MESSAGE\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:814)</failure>"
+          ;;
+        containment)
+          echo "    <failure message=\"$CONTAINMENT_MESSAGE\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+          ;;
+        error)
+          echo "    <error message=\"java.lang.IllegalStateException: harness exploded\">stack</error>"
+          ;;
+        *) fail "unknown fixture outcome: $outcome" ;;
+      esac
+      echo '  </testcase>'
+    done
+    echo '</testsuite>'
+  } > "$file"
+}
+
+# run_signature <summary> <root> [<root>...] -> SIG_CLASS / SIG_OUT
+run_signature() {
+  local summary="$1"; shift
+  SIG_OUT="$(bash "$SIGNATURE" "$summary" "$@" 2>/dev/null)"
+  SIG_RC=$?
+  SIG_CLASS="$(sed -n 's/^journey_failure_classification=//p' <<<"$SIG_OUT" | tail -n 1)"
+}
+
+# shard_verdict_for <artifacts-dir> — drive the REAL decision script the
+# workflow's classify step calls, over the REAL canonical artifact layout, and
+# map its verdict to the shard token that step writes. No replicated logic: the
+# script is the same one tests.yml invokes (pinned by grep further down).
+SHARD_VERDICT_OUT=""
+SHARD_TOKEN=""
+shard_verdict_for() {
+  local artifacts="$1"
+  SHARD_VERDICT_OUT="$(bash "$SHARD_VERDICT" "$artifacts" 2>/dev/null)"
+  if [[ "$(sed -n 's/^shard_signature_verdict=//p' <<<"$SHARD_VERDICT_OUT" | tail -n 1)" == "INFRA" ]]; then
+    SHARD_TOKEN="INFRA"
+  else
+    SHARD_TOKEN="RED"
+  fi
+}
+
+write_shard_token() {
+  local dir="$1" idx="$2" token="$3"
+  mkdir -p "$dir/emulator-journey-verdict-shard-$idx"
+  printf '%s\n' "$token" > "$dir/emulator-journey-verdict-shard-$idx/shard-verdict.txt"
+}
+
+run_agg() {
+  local dir="$1"
+  AGG_OUT="$(EXPECTED_SHARDS=3 GITHUB_STEP_SUMMARY="" bash "$AGG" "$dir" 2>&1)"
+  AGG_RC=$?
+  AGG_VERDICT="$(sed -n 's/^AGGREGATE_VERDICT=//p' <<<"$AGG_OUT" | tail -n 1)"
+}
+
+echo "== #1800 signature classifier =="
+
+# (a) The captured CI signature alone -> real_ime_precondition.
+root="$SANDBOX/a"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedQueuedDraftExpandsAboveImeThenReturnsWithoutDismissalOrLoss:pass" \
+  "saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide:pass" \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "real_ime_precondition" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(a) expected real_ime_precondition, got '$SIG_CLASS'"; }
+grep -q '^journey_failing_testcases=2$' <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(a) must attribute both failing attempts"; }
+grep -q '^journey_signature_matches=2$' <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(a) both failures must match the captured signature"; }
+pass "(a) only the real-IME precondition -> real_ime_precondition"
+
+# (b) A containment/anchor failure -> product_failure. This is the assertion the
+#     signature must NEVER swallow.
+root="$SANDBOX/b"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide:containment"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(b) a containment failure must be product_failure, got '$SIG_CLASS'"; }
+pass "(b) a containment/anchor assertion failure -> product_failure (stays RED)"
+
+# (c) MIXED in the same class, same run: the real-IME precondition AND a
+#     containment failure. The narrow signature must not swallow the real one.
+root="$SANDBOX/c"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime" \
+  "saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide:containment"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(c) mixed evidence must be product_failure, got '$SIG_CLASS'"; }
+grep -q 'journey_offending_failures=.*WithSyntheticIme' <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(c) the offending containment failure must be named"; }
+pass "(c) real-IME precondition MIXED with a containment failure -> product_failure"
+
+# (d) A DIFFERENT class failing alongside -> product_failure (the signature is
+#     per-run, not per-class: any other failed-both class keeps the shard red).
+root="$SANDBOX/d"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS" "com.pocketshell.app.proof.SomeOtherJourneyE2eTest"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "com.pocketshell.app.proof.SomeOtherJourneyE2eTest" 1 \
+  "someJourney:containment"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(d) a second failing class must be product_failure, got '$SIG_CLASS'"; }
+pass "(d) a second genuinely failing class -> product_failure"
+
+# (e) An earlier attempt's containment failure in the SAME class (recovered or
+#     not) still forces product_failure — the classifier reads every attempt.
+root="$SANDBOX/e"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide:containment"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(e) an earlier-attempt containment failure must be product_failure"; }
+pass "(e) a containment failure in ANY preserved attempt -> product_failure"
+
+# (f) Missing / unreadable evidence -> unclassified (fail-safe: stays RED).
+root="$SANDBOX/f"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "unclassified" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(f) missing result XML must be unclassified, got '$SIG_CLASS'"; }
+
+root="$SANDBOX/f2"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+corrupt="$(find "$root" -name 'TEST-*.xml' | head -n 1)"
+printf '<testsuite><testcase' > "$corrupt"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" != "real_ime_precondition" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(f) a corrupt result file must never yield real_ime_precondition"; }
+pass "(f) missing or corrupt evidence never downgrades the shard (stays RED)"
+
+# (g) A clean run (no failed-both section) -> unclassified; the branch can never
+#     fire on a green shard.
+root="$SANDBOX/g"; mkdir -p "$root"
+write_summary "$root" 2338
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "unclassified" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(g) a summary with no failed-both section must be unclassified"; }
+pass "(g) no failed-both section -> unclassified"
+
+# (h) An error (not failure) element is also a genuine failure -> product_failure.
+root="$SANDBOX/h"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:error"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(h) an <error> element must be product_failure, got '$SIG_CLASS'"; }
+pass "(h) a harness <error> element -> product_failure"
+
+echo
+echo "== #1800 end-to-end aggregate outcomes (observed, not argued) =="
+
+# (i) A run whose ONLY shard failure is the captured signature -> RE-RUN.
+#     Built in the REAL canonical layout, including the preserved first-attempt
+#     snapshot the workflow writes, and decided by the REAL decision script.
+root="$SANDBOX/i"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+token="$SHARD_TOKEN"
+verdicts="$SANDBOX/verdicts-i"; rm -rf "$verdicts"; mkdir -p "$verdicts"
+write_shard_token "$verdicts" 0 "$token"
+write_shard_token "$verdicts" 1 CLEAN
+write_shard_token "$verdicts" 2 CLEAN
+run_agg "$verdicts"
+printf '%s\n' "$SHARD_VERDICT_OUT" | sed 's/^/    decision: /'
+echo "    -> shard token $token"
+printf '%s\n' "$AGG_OUT" | sed 's/^/    /'
+[[ "$token" == "INFRA" ]] || fail "(i) the signature-only shard must be typed INFRA, got $token"
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || fail "(i) expected RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"
+grep -q '::error' <<<"$AGG_OUT" \
+  && fail "(i) a signature-only run must not emit ::error (no false red-CI email)"
+pass "(i) signature-only shard failure -> INFRA -> aggregate RE-RUN (exit 0)"
+
+# (j) A genuine journey assertion failure still -> RED. Same shape as (i), one
+#     containment assertion instead of the precondition.
+root="$SANDBOX/j"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide:containment"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide:containment"
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+token="$SHARD_TOKEN"
+verdicts="$SANDBOX/verdicts-j"; rm -rf "$verdicts"; mkdir -p "$verdicts"
+write_shard_token "$verdicts" 0 "$token"
+write_shard_token "$verdicts" 1 CLEAN
+write_shard_token "$verdicts" 2 CLEAN
+run_agg "$verdicts"
+printf '%s\n' "$SHARD_VERDICT_OUT" | sed 's/^/    decision: /'
+echo "    -> shard token $token"
+printf '%s\n' "$AGG_OUT" | sed 's/^/    /'
+[[ "$token" == "RED" ]] || fail "(j) a genuine assertion failure must stay RED, got $token"
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || fail "(j) expected RED/exit1, got $AGG_VERDICT/exit$AGG_RC"
+pass "(j) genuine journey assertion failure -> RED -> aggregate RED (exit 1)"
+
+# (j2) The preserved FIRST attempt carries a genuine containment failure while
+#      the final attempt's summary is signature-only. Both snapshots are
+#      inspected, so the shard must still be RED.
+root="$SANDBOX/j2"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+write_case_xml "$root/ci-journey-attempt-1" "$SATURATED_CLASS" 9 \
+  "saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide:containment"
+shard_verdict_for "$root"
+token="$SHARD_TOKEN"
+printf '%s\n' "$SHARD_VERDICT_OUT" | sed 's/^/    decision: /'
+[[ "$token" == "RED" ]] \
+  || fail "(j2) a containment failure in the preserved first attempt must stay RED, got $token"
+pass "(j2) a genuine failure in EITHER preserved attempt keeps the shard RED"
+
+echo
+echo "== #1800 measured cold-boot retry budget =="
+
+# The observed shard-0 fixture from run 30305256109: job start 21:32:27.657,
+# first attempt start 21:35:45.145, suite elapsed 2338s, 3112241ms remaining.
+job_start=1785187947657
+remaining=3112241
+now=$((job_start + 5700000 - remaining))
+attempt_start=1785188145145
+suite_secs=2338
+
+legacy_out="$(bash "$RETRY_BUDGET" "$job_start" "$now")"
+grep -q '^retry_allowed=false$' <<<"$legacy_out" \
+  || { printf '%s\n' "$legacy_out"; fail "(k) the flat worst case must still deny the shard-0 retry"; }
+grep -q '^retry_required_ms=5400000$' <<<"$legacy_out" \
+  || { printf '%s\n' "$legacy_out"; fail "(k) the unmeasured fallback must stay the flat 5400000ms"; }
+grep -q '^retry_cost_model=worst_case$' <<<"$legacy_out" \
+  || { printf '%s\n' "$legacy_out"; fail "(k) the unmeasured fallback must report worst_case"; }
+printf '%s\n' "$legacy_out" | sed 's/^/    unmeasured: /'
+pass "(k) without measurements the requirement is the unchanged flat 5400000ms (deny)"
+
+measured_out="$(bash "$RETRY_BUDGET" "$job_start" "$now" "$attempt_start" "$suite_secs")"
+printf '%s\n' "$measured_out" | sed 's/^/    measured:   /'
+grep -q '^retry_allowed=true$' <<<"$measured_out" \
+  || { printf '%s\n' "$measured_out"; fail "(k) shard-0's measured cost must PERMIT the retry at ${remaining}ms"; }
+grep -q '^retry_cost_model=measured_first_attempt$' <<<"$measured_out" \
+  || { printf '%s\n' "$measured_out"; fail "(k) the measured path must report measured_first_attempt"; }
+measured_required="$(sed -n 's/^retry_required_ms=//p' <<<"$measured_out" | tail -n 1)"
+[[ "$measured_required" =~ ^[0-9]+$ ]] || fail "(k) measured requirement is not numeric"
+(( measured_required <= remaining )) \
+  || fail "(k) measured requirement ${measured_required}ms must fit in ${remaining}ms"
+(( measured_required < 5400000 )) \
+  || fail "(k) measured requirement must be below the flat worst case"
+pass "(k) shard-0 (remaining=${remaining}ms) now requires ${measured_required}ms -> retry PERMITTED"
+
+# The measured model may only ever RELAX. A pathologically slow first attempt
+# must never demand more than the legacy flat reserve.
+slow_out="$(bash "$RETRY_BUDGET" "$job_start" "$now" "$((now - 9000000))" 8000)"
+slow_required="$(sed -n 's/^retry_required_ms=//p' <<<"$slow_out" | tail -n 1)"
+[[ "$slow_required" == "5400000" ]] \
+  || { printf '%s\n' "$slow_out"; fail "(l) a slow first attempt must clamp to the flat 5400000ms, got $slow_required"; }
+pass "(l) the measured model never demands MORE than the flat worst case"
+
+# Malformed measurements fall back to the flat worst case, never to a smaller
+# requirement derived from garbage.
+for bad in "not-an-epoch 2338" "$attempt_start not-a-number" "$attempt_start 0" "0 2338" "$((now + 1000)) 2338"; do
+  # shellcheck disable=SC2086 # deliberate word splitting of the fixture pair
+  bad_out="$(bash "$RETRY_BUDGET" "$job_start" "$now" $bad)"
+  grep -q '^retry_required_ms=5400000$' <<<"$bad_out" \
+    || { printf '%s\n' "$bad_out"; fail "(m) malformed measurement '$bad' must fall back to the flat reserve"; }
+  grep -q '^retry_cost_model=worst_case$' <<<"$bad_out" \
+    || { printf '%s\n' "$bad_out"; fail "(m) malformed measurement '$bad' must report worst_case"; }
+done
+pass "(m) malformed/absent measurements fall back to the flat worst case"
+
+# The measured elapsed comes from the suite's own summary table.
+root="$SANDBOX/elapsed"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+parsed="$(bash "$ELAPSED" "$root/ci-journey/summary.md")" \
+  || fail "(n) could not read the measured elapsed from a real-shaped summary"
+[[ "$parsed" == "2338" ]] || fail "(n) measured elapsed parsed as '$parsed', expected 2338"
+bash "$ELAPSED" "$SANDBOX/does-not-exist.md" >/dev/null 2>&1 \
+  && fail "(n) a missing summary must fail so the caller keeps the flat reserve"
+printf 'no table here\n' > "$SANDBOX/no-table.md"
+bash "$ELAPSED" "$SANDBOX/no-table.md" >/dev/null 2>&1 \
+  && fail "(n) a summary without the result table must fail rather than guess"
+pass "(n) the measured elapsed is read from the suite's own summary table"
+
+echo
+echo "== #1800 real-workflow wiring =="
+
+grep -q "scripts/ci-journey-shard-signature-verdict.sh artifacts" "$WORKFLOW" \
+  || fail "the classify step does not call the real shard signature decision script"
+grep -q 'JOURNEY_FIRST_ATTEMPT_START_EPOCH_MS=' "$WORKFLOW" \
+  || fail "the workflow does not record the first journey attempt start epoch"
+grep -q 'scripts/ci-journey-suite-elapsed.sh' "$WORKFLOW" \
+  || fail "the workflow does not read the suite's measured elapsed"
+grep -q 'first_suite_elapsed_secs' "$WORKFLOW" \
+  || fail "the measured elapsed is not passed to the retry-budget helper"
+
+signature_line="$(grep -n 'signature_verdict" == "INFRA"' "$WORKFLOW" | head -n 1 | cut -d: -f1)"
+# shellcheck disable=SC2016 # literal workflow shell expressions, not test vars
+first_failure_line="$(grep -Fn 'if [[ "${first_failure:-false}" == "true" ]]' "$WORKFLOW" | cut -d: -f1)"
+retry_clean_line="$(grep -Fn 'if [[ "$retry" == "success" ]]' "$WORKFLOW" | cut -d: -f1)"
+first_clean_line="$(grep -Fn 'if [[ "$first" == "success" ]]' "$WORKFLOW" | cut -d: -f1)"
+for value in "$signature_line" "$first_failure_line" "$retry_clean_line" "$first_clean_line"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "could not locate the classify-step branches in the workflow"
+done
+(( first_clean_line < signature_line && retry_clean_line < signature_line )) \
+  || fail "the signature branch must not preempt a CLEAN shard"
+(( signature_line < first_failure_line )) \
+  || fail "the signature branch must be evaluated before the genuine-failure RED branch"
+pass "classify-step branch order: CLEAN -> signature INFRA -> genuine-failure RED"
+
+grep -q 'first_timeout:-false}" != "true"' "$WORKFLOW" \
+  || fail "the signature branch does not exclude the #835 budget timeout"
+pass "the signature branch can never fire for a #835 budget timeout"
+
+echo
+echo "== #1800 synthetic coverage is present and wired =="
+
+[[ -f "$ANDROID_TEST" ]] || fail "missing $ANDROID_TEST"
+grep -q 'fun saturatedDraftAndAllActionsStayReachableWithSyntheticImeThenRestoreAfterHide' "$ANDROID_TEST" \
+  || fail "the synthetic mirror of the real-IME reachability journey is missing"
+grep -q 'val REAL_IME_REACHABLE_TAGS' "$ANDROID_TEST" \
+  || fail "the real-IME and synthetic paths no longer share one reachable-tag set"
+grep -c 'REAL_IME_REACHABLE_TAGS.forEach' "$ANDROID_TEST" | grep -qE '^[3-9]$|^[0-9]{2,}$' \
+  || fail "both paths must iterate the shared reachable-tag set"
+grep -qE '\bassume(True|False|NotNull|That)[[:space:]]*\(' "$ANDROID_TEST" \
+  && fail "no Assume self-skip may guard these load-bearing assertions (F3)"
+grep -q "com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest" \
+  "$REPO_ROOT/scripts/ci-journey-suite.sh" \
+  || fail "the class carrying the synthetic mirror is not wired into the per-push journey gate"
+pass "the synthetic mirror exists, shares the tag set, and runs in the per-push gate"
+
+echo
+echo "ALL TESTS PASSED: scripts/test-ci-journey-infra-signature.sh"


### PR DESCRIPTION
Closes #1800

## Why

Exact-main run [30305256109](https://github.com/alexeygrigorev/pocketshell/actions/runs/30305256109) went RED on a **test-only** commit. Triage found the cause was neither a regression nor an aggregator defect: shard 0's verdict token was RED because `PromptComposerSaturatedImeAnchorE2eTest` failed with `The real system input-method window never became visible.` — the CI swiftshader AVD cannot raise a physical system IME. The immediately preceding **green** run failed the same class on the same shard and flake-recovered on retry; shard 0 here was denied its retry by a flat `5400000ms` budget with ~52 minutes of wall clock remaining.

## The order matters more than the change

The tempting fix — string-match that message into an INFRA list — is the F3 anti-pattern: CI goes green with **zero** protection while only the dev-box AVD ever asserts. So the work was sequenced deliberately: **prove synthetic coverage first, classify second.**

Doing it in that order found the synthetic path had **three genuine gaps** (no Attach/Mic assertions, bottom-edge-only rather than four-edge containment, no enabled-state). Classifying first would have locked those gaps in behind a green gate. A synthetic mirror closes them.

One gap is **declared rather than papered over**: "a physical `TYPE_INPUT_METHOD` window is visible" has no synthetic equivalent by construction — that *is* the environment capability, and it is precisely what gets typed INFRA.

## Load-bearing evidence

Reviewer-reproduced independently, with the mutant applied inline (no script from the shared scratchpad, mutated bytes re-verified on disk seconds before the run):

- **Mutant proven live before any conclusion**: `false &&` in the expression body of `composerModalSurfaceOverlapsIme`, consumed in production at `PromptComposerSheet.kt:599`. Compiles; kills the JVM oracle — `11 tests completed, 1 failed`.
- **Synthetic mirror RED alone on the emulator**, real-IME method not executed: `Node 'prompt-composer-send-enter' … node=Rect.fromLTRB(614.0, 1538.0, 854.0, 1654.0) keyboardTopPx=1626.0` — the exact #1743 28px overlap. `ROOT_SLOP_PX = 2f`, so the assertion is tight, not a defanged band.
- **Restored and verified three ways**: md5, empty `git diff` on that file, and `git status --porcelain` back to exactly 3 modified + 5 untracked. Green after restore, 4/4, XML parsed and the load-bearing method named PASS.
- **Narrowness validated on real data**: the reviewer fed its own real mutant XML (real Gradle connected-test output format) through the real classifier — `product_failure` / `shard_signature_verdict=NONE` → RED. So the signature cannot swallow a containment or anchor failure.

## The weakest link, ruled on explicitly

The implementer's attempt to model a no-IME AVD via `adb shell ime disable` **did not hold** (Android re-enabled the only IME) and it declined to claim that run. The reviewer ruled the argument does not depend on it: the mirror never calls `requestRealImeAndAssertVisible()`, opens with `hideRealImeAndAssertHidden`, and hard-asserts `assertNoPhysicalImeWindow` (500ms stability window) before every inset dispatch and screenshot. The mutant RED occurred *after* those gates, i.e. with the physical IME hard-asserted absent. Every CI difference makes those assertions easier, never harder, and the fail-safe direction holds — a mirror failure carries a containment message → `product_failure` → RED, never a green.

## Retry budget

Measured rather than a flat reserve, clamped so it can never demand more than the legacy `5400000ms`; malformed input falls back to worst case. The reviewer verified the overrun consequence rather than assuming it: `ci-journey-aggregate-verdict.sh:117-122` maps a missing shard token to RE-RUN and requires `missing == 0` for CLEAN, so an overrun can never produce a false green or red. Rescoping the retry to failed classes was deliberately **not** done — that changes the gate's selection semantics, which the non-goals assign to #1458.

## Orchestrator verification

Applied to a clean worktree off `main` (`ed53bc60`). **Five new scripts are untracked in the candidate — `git diff` omits them**, so they were copied explicitly and their file modes verified byte-identical (775) against the source. `bash -n` clean on all five shell scripts, Python parses, workflow YAML parses, `git diff --check` clean. The candidate's own guard `scripts/test-ci-journey-infra-signature.sh` passes end to end, including `(k) shard-0 (remaining=3112241ms) now requires 3028613ms -> retry PERMITTED` and `(m) malformed/absent measurements fall back to the flat worst case`.

## Merge sequencing with #1741

Verified from #1741's worktrees directly, not from a status comment: #1741 is one 11-line insertion at `@@ -214,0 +215,11 @@` in the `unit` job; this PR is `@@ -234,0 +235,17 @@` in the `unit` job plus 9 hunks all at base lines 960+, entirely inside `emulator-journey` — a region #1741 does not touch. ~20 base lines apart, disjoint with 3 lines of context. They apply cleanly in either order.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb