### PR TITLE
core-tmux: bound the render-heal exec lane at the caller, not the read (#1516)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealTimeoutTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealTimeoutTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -194,6 +195,69 @@ class RenderHealTimeoutTest {
         advanceUntilIdle()
         h1.cancel()
         h2.cancel()
+    }
+
+    // -------------------------------------------------------------------------
+    // (3) Issue #1516 — the capture bound must COMPOSE with the #1494 budgets.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun healCaptureBoundComposesUnderTheWatchdogTickAndTheHeldTooLongReset() {
+        // Issue #1516 acceptance: the exec-lane capture bound (now a REAL caller
+        // deadline — see `TmuxExecLane.runBoundedExecLane`) has to sit strictly
+        // UNDER the #1494 per-tick ceiling, which in turn sits under the per-pane
+        // single-flight force-reset. Otherwise a wedged capture is abandoned by the
+        // tick (scored Unverified with no result) instead of returning its own
+        // definite failure inside the tick.
+        assertTrue(
+            "the exec-lane capture bound (${SEED_CAPTURE_TIMEOUT_MS}ms) must be strictly under " +
+                "the #1494 watchdog tick (${RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS}ms)",
+            SEED_CAPTURE_TIMEOUT_MS < RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS,
+        )
+        assertTrue(
+            "the #1494 watchdog tick (${RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS}ms) must be strictly " +
+                "under the per-pane held-too-long force-reset " +
+                "(${RenderHealCoordinator.HELD_TOO_LONG_MS}ms)",
+            RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS < RenderHealCoordinator.HELD_TOO_LONG_MS,
+        )
+    }
+
+    @Test
+    fun bothRenderHealCaptureSitesCarryTheBoundedSeedCeiling() = runVmTest {
+        // Issue #1516 / G9: the bound is only real if BOTH render-heal capture
+        // sites actually hand it to the exec lane — the oracle-gated heal AND the
+        // force-mode reattach reseed (the latter is NOT wrapped by #1494's tick at
+        // all, so it depends entirely on this bound).
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        val pane = vm.panes.value.single { it.paneId == "%1" }
+        vm.resizeRemotePty(80, 40)
+        advanceUntilIdle()
+        pane.terminalState.appendRemoteOutput(
+            (CLEAR_ONLY + "ISSUE1516-LIVE-LINE 7\r\n").toByteArray(Charsets.US_ASCII),
+        )
+        advanceUntilIdle()
+        assertTrue("precondition: the render looks suspect so the heal reseeds", pane.terminalState.renderLooksSuspect())
+
+        // Site 1 — the oracle-gated stale-render heal.
+        client.lastCaptureTimeoutMs = null
+        vm.healActivePaneIfStaleRenderForTest()
+        advanceUntilIdle()
+        assertEquals(
+            "the oracle-gated heal capture must carry the bounded seed ceiling",
+            SEED_CAPTURE_TIMEOUT_MS,
+            client.lastCaptureTimeoutMs,
+        )
+
+        // Site 2 — the force-mode reattach reseed.
+        client.lastCaptureTimeoutMs = null
+        vm.reseedActivePaneForReattachForTest(vm.currentRuntimeGuardForTest())
+        advanceUntilIdle()
+        assertEquals(
+            "the force-mode reattach reseed capture must carry the bounded seed ceiling",
+            SEED_CAPTURE_TIMEOUT_MS,
+            client.lastCaptureTimeoutMs,
+        )
     }
 
     // ------------------------------------------------------------------ Frames

--- a/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/Issue1516HealCaptureHalfOpenBoundIntegrationTest.kt
+++ b/shared/core-tmux/src/integrationTest/java/com/pocketshell/core/tmux/Issue1516HealCaptureHalfOpenBoundIntegrationTest.kt
@@ -1,0 +1,507 @@
+package com.pocketshell.core.tmux
+
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.AfterClass
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.File
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.thread
+
+/**
+ * Issue #1516, reproduce-first END-TO-END on the REAL transport (D34): the
+ * render-heal `capture-pane` exec round-trip must return a DEFINITE failure
+ * within its own bound when the socket goes half-open mid-read — not park past
+ * the #1494 watchdog tick.
+ *
+ * ## The bug
+ * Every exec-lane call was a STRUCTURED child of its bound:
+ * `withTimeoutOrNull(2500) { session.exec(cmd) }`. Structured concurrency means
+ * that bound cannot return until the child completes, and `RealSshSession.exec`'s
+ * `finally` closes the exec channel inside `withContext(NonCancellable)` through
+ * the single-writer `TransportDispatcher` (per-op wall-clock ceiling 8 s). On a
+ * genuinely half-open socket (no FIN/RST) that close is never answered, so the
+ * "2.5 s" heal capture parked its caller for 2.5 s + 8 s.
+ *
+ * Measured on this exact harness before the fix: **10 506 ms** for the
+ * render-heal-shaped call (4x its nominal bound, 2.6x the 4 s
+ * `RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS`); **38 052 ms** with no caller bound at
+ * all (the 30 s session-wide no-progress read watchdog plus the same 8 s tail).
+ *
+ * ## The fixture that reproduces it ([HalfOpenTcpRelay])
+ * A happy fixture cannot enter this state (G10): a live link closes the channel
+ * in milliseconds. This relay forwards the REAL encrypted SSH stream and then
+ * **blackholes the server->client direction after N bytes** — the sockets stay
+ * ESTABLISHED, no FIN, no RST, bytes simply stop arriving. Arming it *after* the
+ * capture's first payload bytes have flowed puts the stall genuinely INSIDE the
+ * blocking exec read, which is the reported state.
+ *
+ * ## Load-bearing assertion
+ * The capture returns a definite [TmuxClientException] in less than
+ * `RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS` (4 s) — the symptom-defining signal, on
+ * the real transport. Not "a timeout lambda fired".
+ *
+ * Class coverage (G2): the shared transport is NOT closed by the stalled capture
+ * (#1567), concurrent captures all fail fast without stranding the
+ * `EXEC_DRAIN_MAX_CONCURRENT_EXECS` = 4 exec-drain permits, and once the link
+ * recovers a fresh capture succeeds on the SAME warm session.
+ *
+ * Wired into the per-push `Integration tests (Docker)` check via
+ * `:shared:core-tmux:integrationTest` (`.github/workflows/tests.yml`).
+ */
+class Issue1516HealCaptureHalfOpenBoundIntegrationTest {
+
+    companion object {
+        private const val CONTAINER_SSH_PORT = 22
+
+        /**
+         * The production render-heal capture bound
+         * (`TmuxSessionSupport.SEED_CAPTURE_TIMEOUT_MS`), passed at both
+         * `TmuxSessionViewModel` capture sites.
+         */
+        private const val SEED_CAPTURE_TIMEOUT_MS = 2_500L
+
+        /**
+         * The #1494 stale-render watchdog per-tick ceiling
+         * (`TmuxSessionSupport.RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS`). The capture
+         * bound must compose UNDER this: a wedged heal has to score a definite
+         * failure inside the tick instead of being abandoned by it.
+         */
+        private const val RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS = 4_000L
+
+        /** `RealSshSession.EXEC_DRAIN_MAX_CONCURRENT_EXECS`. */
+        private const val EXEC_DRAIN_PERMITS = 4
+
+        private val projectRoot: Path by lazy { findProjectRoot() }
+
+        @Volatile
+        private var container: GenericContainer<*>? = null
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            val dockerAvailable = runCatching {
+                DockerClientFactory.instance().isDockerAvailable
+            }.getOrDefault(false)
+            assumeTrue("Docker not available; skipping #1516 half-open bound tests", dockerAvailable)
+
+            val dockerDir = projectRoot.resolve("tests/docker")
+            // Dockerfile.tmux's FROM references the `pocketshell-test:ssh` tag, so
+            // build that tag first (same two-layer dance as TmuxClientIntegrationTest).
+            val sshBuild = ProcessBuilder(
+                "docker", "build", "-t", "pocketshell-test:ssh",
+                "-f", dockerDir.resolve("Dockerfile.ssh").toString(), dockerDir.toString(),
+            ).redirectErrorStream(true).start()
+            val sshOut = sshBuild.inputStream.bufferedReader().readText()
+            check(sshBuild.waitFor() == 0) { "Failed to build pocketshell-test:ssh:\n$sshOut" }
+
+            val image = ImageFromDockerfile("pocketshell-test-tmux", false)
+                .withDockerfile(dockerDir.resolve("Dockerfile.tmux"))
+            container = GenericContainer(image)
+                .withExposedPorts(CONTAINER_SSH_PORT)
+                .also { it.start() }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            container?.stop()
+            container = null
+        }
+
+        private fun findProjectRoot(): Path {
+            var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            while (dir != null) {
+                if (dir.resolve("tests/docker/Dockerfile.tmux").toFile().exists()) return dir
+                dir = dir.parent
+            }
+            error(
+                "Could not locate tests/docker/Dockerfile.tmux from user.dir=" +
+                    System.getProperty("user.dir"),
+            )
+        }
+    }
+
+    private val privateKeyFile: File
+        get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    private suspend fun connectThrough(relay: HalfOpenTcpRelay): SshSession =
+        SshConnection.connect(
+            host = "127.0.0.1",
+            port = relay.localPort,
+            user = "testuser",
+            key = SshKey.Path(privateKeyFile),
+            passphrase = null,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+
+    @Test
+    fun `render-heal capture returns a definite failure inside its bound when the socket goes half-open mid-read`() =
+        runBlocking {
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val relay = HalfOpenTcpRelay(container!!.host, container!!.getMappedPort(CONTAINER_SSH_PORT))
+            relay.start()
+            var session: SshSession? = null
+            try {
+                session = connectThrough(relay)
+                val client = TmuxClientFactory(scope).create(session, sessionName = "it1516-${System.nanoTime()}")
+                client.connect()
+                delay(500)
+                val paneId = resolvePaneId(client)
+                fillPane(client, paneId)
+
+                // Sanity on a HEALTHY link: the same capture succeeds well inside the bound.
+                val healthy = withTimeout(15_000) {
+                    client.captureWithCursor(paneId, scrollbackLines = 200, timeoutMs = SEED_CAPTURE_TIMEOUT_MS)
+                }
+                assertFalse("the healthy pre-fault capture must not be an error", healthy.capture.isError)
+                assertTrue(
+                    "the pane must hold real content so the faulted capture stalls MID-READ",
+                    healthy.capture.output.size >= 50,
+                )
+
+                // Inject the fault: let the exec channel open and the first payload
+                // bytes flow, then blackhole every further server->client byte. The
+                // sockets stay established (no FIN/RST) — a genuine half-open read.
+                relay.blackholeRepliesAfterBytes(REPLY_BYTES_BEFORE_BLACKHOLE)
+
+                val startedAtMs = System.currentTimeMillis()
+                val thrown = runCatching {
+                    client.captureWithCursor(paneId, scrollbackLines = 200, timeoutMs = SEED_CAPTURE_TIMEOUT_MS)
+                }.exceptionOrNull()
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+                // Non-vacuity: the fault really fired, and only AFTER real reply bytes
+                // had flowed — so the capture stalled inside its blocking read.
+                assertTrue(
+                    "the relay must have blackholed the reply direction (fault never fired)",
+                    relay.isBlackholed(),
+                )
+                assertTrue(
+                    "the fault must land AFTER real reply bytes flowed (forwarded=" +
+                        "${relay.repliesForwardedSinceArm()} of $REPLY_BYTES_BEFORE_BLACKHOLE)",
+                    relay.repliesForwardedSinceArm() >= REPLY_BYTES_BEFORE_BLACKHOLE,
+                )
+
+                // LOAD-BEARING (#1516): a DEFINITE failure, inside the bound, on a real
+                // half-open socket. Base measured 10 506 ms here.
+                assertTrue(
+                    "a half-open heal capture must surface a definite TmuxClientException, " +
+                        "never a hang or a silent success (was $thrown)",
+                    thrown is TmuxClientException,
+                )
+                assertTrue(
+                    "the heal capture must return inside the #1494 watchdog tick " +
+                        "(${RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS}ms); elapsed=${elapsedMs}ms",
+                    elapsedMs < RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS,
+                )
+
+                // #1567 adjacency: a stalled exec must NOT close the shared transport.
+                assertTrue(
+                    "a stalled heal capture must not close the shared SSH session",
+                    session.isConnected,
+                )
+
+                // Recovery: with the link restored the SAME warm session captures again.
+                relay.resumeReplies()
+                assertTrue(
+                    "a fresh capture must succeed on the same warm transport once the link recovers",
+                    captureEventually(client, paneId, budgetMs = 30_000L),
+                )
+            } finally {
+                runCatching { session?.close() }
+                relay.close()
+                scope.cancel()
+            }
+        }
+
+    @Test
+    fun `concurrent half-open heal captures all fail inside the bound without stranding the exec drain permits`() =
+        runBlocking {
+            // Class coverage (G2): one bounded capture returning fast is not enough —
+            // the render-heal/force-reseed path fires repeatedly, and every stalled
+            // exec holds one of the four exec-drain permits until it unwinds. If the
+            // bound did not actually reclaim them, the pool would be starved for the
+            // 30 s session no-progress window and the post-recovery capture would hang.
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val relay = HalfOpenTcpRelay(container!!.host, container!!.getMappedPort(CONTAINER_SSH_PORT))
+            relay.start()
+            var session: SshSession? = null
+            try {
+                session = connectThrough(relay)
+                val client = TmuxClientFactory(scope).create(session, sessionName = "it1516c-${System.nanoTime()}")
+                client.connect()
+                delay(500)
+                val paneId = resolvePaneId(client)
+                fillPane(client, paneId)
+                withTimeout(15_000) {
+                    client.captureWithCursor(paneId, scrollbackLines = 200, timeoutMs = SEED_CAPTURE_TIMEOUT_MS)
+                }
+
+                relay.blackholeRepliesAfterBytes(REPLY_BYTES_BEFORE_BLACKHOLE)
+                val startedAtMs = System.currentTimeMillis()
+                val outcomes = (1..EXEC_DRAIN_PERMITS).map {
+                    scope.async {
+                        runCatching {
+                            client.captureWithCursor(
+                                paneId,
+                                scrollbackLines = 200,
+                                timeoutMs = SEED_CAPTURE_TIMEOUT_MS,
+                            )
+                        }
+                    }
+                }.awaitAll()
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+                assertTrue("the relay must have blackholed the reply direction", relay.isBlackholed())
+                assertTrue(
+                    "every concurrent half-open capture must fail definitively (outcomes=$outcomes)",
+                    outcomes.all { it.exceptionOrNull() is TmuxClientException },
+                )
+                assertTrue(
+                    "all $EXEC_DRAIN_PERMITS concurrent captures must return inside the #1494 tick " +
+                        "(${RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS}ms); elapsed=${elapsedMs}ms",
+                    elapsedMs < RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS,
+                )
+                assertTrue(
+                    "a stalled exec must not close the shared SSH session",
+                    session.isConnected,
+                )
+
+                // The permits must have come back: once the link recovers a fresh
+                // capture succeeds instead of queueing behind four stranded permits.
+                relay.resumeReplies()
+                assertTrue(
+                    "the exec-drain permit pool must be reclaimed — a fresh capture must " +
+                        "succeed once the link recovers",
+                    captureEventually(client, paneId, budgetMs = 45_000L),
+                )
+            } finally {
+                runCatching { session?.close() }
+                relay.close()
+                scope.cancel()
+            }
+        }
+
+    private suspend fun resolvePaneId(client: TmuxClient): String {
+        val paneId = withTimeout(15_000) {
+            client.sendCommand("display-message -p \"#{pane_id}\"")
+        }.output.firstOrNull()?.trim().orEmpty()
+        assertTrue("pane id must resolve; got '$paneId'", paneId.startsWith("%"))
+        return paneId
+    }
+
+    /**
+     * Put enough content on the pane's grid that one `capture-pane` reply is
+     * several KiB — so [HalfOpenTcpRelay.blackholeRepliesAfterBytes] can arm
+     * partway THROUGH the capture's payload and stall the blocking read itself
+     * rather than the channel open.
+     */
+    private suspend fun fillPane(client: TmuxClient, paneId: String) {
+        withTimeout(15_000) {
+            client.sendCommand("send-keys -t $paneId 'seq 1 400 | sed \"s/^/ps1516-filler-line-/\"' Enter")
+        }
+        // Wait until the grid actually holds the filler (capture is server-side).
+        val deadline = System.currentTimeMillis() + 20_000
+        while (System.currentTimeMillis() < deadline) {
+            val text = runCatching {
+                client.captureWithCursor(paneId, scrollbackLines = 200, timeoutMs = 5_000L)
+            }.getOrNull()?.capture?.output.orEmpty()
+            if (text.count { it.contains("ps1516-filler-line-") } >= 50) return
+            delay(200)
+        }
+        throw AssertionError("the pane never filled with the capture payload the fault needs")
+    }
+
+    private suspend fun captureEventually(client: TmuxClient, paneId: String, budgetMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + budgetMs
+        while (System.currentTimeMillis() < deadline) {
+            val ok = runCatching {
+                client.captureWithCursor(paneId, scrollbackLines = 200, timeoutMs = 5_000L)
+            }.getOrNull()
+            if (ok != null && !ok.capture.isError && ok.capture.output.isNotEmpty()) return true
+            delay(250)
+        }
+        return false
+    }
+}
+
+/**
+ * Reply bytes allowed through after arming before the blackhole starts. Large
+ * enough that the exec channel-open confirmation AND the first chunk of the
+ * `capture-pane` payload have been delivered (so the stall is genuinely inside
+ * the blocking read), small enough that the multi-KiB payload cannot finish.
+ */
+private const val REPLY_BYTES_BEFORE_BLACKHOLE = 1_500L
+
+/**
+ * Issue #1516 fixture — a minimal in-JVM TCP relay that can turn a live SSH
+ * connection HALF-OPEN on the REAL encrypted transport: after [blackholeRepliesAfterBytes]
+ * has let a budget of server->client bytes through, it stops forwarding that
+ * direction entirely. Both sockets stay ESTABLISHED (no FIN, no RST) — the peer
+ * simply goes silent, exactly the flaky-Wi-Fi / dead-NAT-mapping state where a
+ * blocking JDK read parks forever.
+ *
+ * Deliberately byte-budgeted rather than an all-or-nothing pause: arming mid-payload
+ * is what puts the stall inside the exec's blocking READ instead of inside the
+ * channel-open handshake. Sibling of `core-ssh`'s `PausableTcpRelay` (which is
+ * `internal` to that module's test source set, hence this focused local copy).
+ */
+private class HalfOpenTcpRelay(
+    private val targetHost: String,
+    private val targetPort: Int,
+) : AutoCloseable {
+    private val serverSocket = ServerSocket().apply {
+        reuseAddress = true
+        bind(InetSocketAddress("127.0.0.1", 0))
+    }
+    val localPort: Int get() = serverSocket.localPort
+
+    private val closed = AtomicBoolean(false)
+    private val armed = AtomicBoolean(false)
+    private val blackholed = AtomicBoolean(false)
+    private val replyBudget = AtomicLong(0L)
+    private val repliesForwarded = AtomicLong(0L)
+    private val tunnels = java.util.concurrent.ConcurrentHashMap.newKeySet<Socket>()
+
+    fun start() {
+        thread(name = "ps1516-relay-accept", isDaemon = true) {
+            while (!closed.get()) {
+                val client = try {
+                    serverSocket.accept()
+                } catch (t: Throwable) {
+                    if (closed.get()) break else continue
+                }
+                handleTunnel(client)
+            }
+        }
+    }
+
+    /** Arm the fault: forward [bytes] more server->client bytes, then go silent. */
+    fun blackholeRepliesAfterBytes(bytes: Long) {
+        repliesForwarded.set(0L)
+        replyBudget.set(bytes)
+        blackholed.set(false)
+        armed.set(true)
+    }
+
+    /** Remove the toxic: the reply direction flows again. */
+    fun resumeReplies() {
+        armed.set(false)
+        blackholed.set(false)
+    }
+
+    fun isBlackholed(): Boolean = blackholed.get()
+
+    fun repliesForwardedSinceArm(): Long = repliesForwarded.get()
+
+    private fun handleTunnel(client: Socket) {
+        thread(name = "ps1516-relay-tunnel", isDaemon = true) {
+            val upstream = try {
+                Socket(targetHost, targetPort)
+            } catch (t: Throwable) {
+                runCatching { client.close() }
+                return@thread
+            }
+            tunnels.add(client)
+            tunnels.add(upstream)
+            val a = pump(client, upstream, isReplyDirection = false)
+            val b = pump(upstream, client, isReplyDirection = true)
+            runCatching { a.join() }
+            runCatching { b.join() }
+            tunnels.remove(client)
+            tunnels.remove(upstream)
+            runCatching { client.close() }
+            runCatching { upstream.close() }
+        }
+    }
+
+    private fun pump(from: Socket, to: Socket, isReplyDirection: Boolean): Thread =
+        thread(isDaemon = true) {
+            val buf = ByteArray(16 * 1024)
+            // Bytes read from the peer but not yet forwarded because the budget ran
+            // out mid-chunk. They are HELD, never dropped: dropping would desync the
+            // SSH stream cipher and kill the transport, which would make the recovery
+            // assertion meaningless. Held bytes flush in order on resume.
+            var heldTail: ByteArray? = null
+            try {
+                val input = from.getInputStream()
+                val output = to.getOutputStream()
+                from.soTimeout = 100
+                while (!closed.get()) {
+                    if (isReplyDirection && armed.get() && blackholed.get()) {
+                        // Silent peer: do NOT read, do NOT close. Both sockets stay
+                        // established and the client's read parks — half-open.
+                        Thread.sleep(50)
+                        continue
+                    }
+                    heldTail?.let {
+                        output.write(it)
+                        output.flush()
+                        heldTail = null
+                    }
+                    val n = try {
+                        input.read(buf)
+                    } catch (e: java.net.SocketTimeoutException) {
+                        continue
+                    }
+                    if (n < 0) break
+                    if (!isReplyDirection || !armed.get()) {
+                        output.write(buf, 0, n)
+                        output.flush()
+                        continue
+                    }
+                    // Armed reply direction: forward at most the remaining budget, then
+                    // hold the tail and go silent so the stall lands MID-READ.
+                    var off = 0
+                    while (off < n) {
+                        val budget = replyBudget.get()
+                        if (budget <= 0L) {
+                            heldTail = buf.copyOfRange(off, n)
+                            blackholed.set(true)
+                            break
+                        }
+                        val allowed = minOf((n - off).toLong(), budget).toInt()
+                        output.write(buf, off, allowed)
+                        output.flush()
+                        replyBudget.addAndGet(-allowed.toLong())
+                        repliesForwarded.addAndGet(allowed.toLong())
+                        off += allowed
+                    }
+                }
+            } catch (t: Throwable) {
+                // tunnel broken — let join() finish and clean up.
+            }
+        }
+
+    override fun close() {
+        closed.set(true)
+        tunnels.forEach { runCatching { it.close() } }
+        runCatching { serverSocket.close() }
+    }
+}

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -1257,14 +1257,11 @@ internal class RealTmuxClient(
         }
         val execResult =
             try {
-                // The exec lane is independent of the busy `-CC` channel, so this
-                // returns fast under a burst. The ceiling is the safety bound for
-                // a genuinely wedged/half-open transport (both channels dead);
-                // cancelling the exec closes its own channel (RealSshSession.exec
-                // cancellation handler), never the `-CC` shell.
-                withTimeoutOrNull(effectiveTimeoutMs) {
-                    session.exec(command)
-                }
+                // #1297: independent of the busy `-CC` channel, so this returns fast
+                // under a burst. #1516: [runBoundedExecLane] makes the ceiling a REAL
+                // caller deadline on a half-open transport, and still closes only this
+                // exec's own channel, never the `-CC` shell.
+                runBoundedExecLane(clientScope, session, command, effectiveTimeoutMs)
             } catch (t: Throwable) {
                 throw TmuxClientException(
                     "tmux heal capture exec failed for pane $paneId: ${t.message}",
@@ -1298,9 +1295,8 @@ internal class RealTmuxClient(
         else "tmux capture-pane -p -t $quotedPane"
         val execResult =
             try {
-                withTimeoutOrNull(effectiveTimeoutMs) {
-                    session.exec(command)
-                }
+                // Issue #1516: a REAL caller deadline (see [runBoundedExecLane]).
+                runBoundedExecLane(clientScope, session, command, effectiveTimeoutMs)
             } catch (t: Throwable) {
                 throw TmuxClientException(
                     "tmux text capture exec failed for pane $paneId: ${t.message}",
@@ -1352,13 +1348,10 @@ internal class RealTmuxClient(
         val command = "tmux $listPanesCommand"
         val execResult =
             try {
-                // Independent of the busy `-CC` channel, so this returns fast under
-                // a burst. The ceiling is the safety bound for a genuinely
-                // wedged/half-open transport; cancelling the exec closes its OWN
-                // channel (RealSshSession.exec cancellation handler), never `-CC`.
-                withTimeoutOrNull(effectiveTimeoutMs) {
-                    session.exec(command)
-                }
+                // Independent of the busy `-CC` channel (fast under a burst); #1516's
+                // [runBoundedExecLane] makes the ceiling a REAL caller deadline and
+                // closes only its OWN channel, never `-CC`.
+                runBoundedExecLane(clientScope, session, command, effectiveTimeoutMs)
             } catch (t: Throwable) {
                 throw TmuxClientException(
                     "tmux list-panes exec (attach reconcile lane) failed: ${t.message}",
@@ -1405,13 +1398,10 @@ internal class RealTmuxClient(
         val command = "tmux $sendKeysCommand"
         val execResult =
             try {
-                // Independent of the busy `-CC` channel, so this returns fast under
-                // a burst. The ceiling is the safety bound for a genuinely
-                // wedged/half-open transport; cancelling the exec closes its OWN
-                // channel (RealSshSession.exec cancellation handler), never `-CC`.
-                withTimeoutOrNull(effectiveTimeoutMs) {
-                    session.exec(command)
-                }
+                // Independent of the busy `-CC` channel (fast under a burst); #1516's
+                // [runBoundedExecLane] makes the ceiling a REAL caller deadline and
+                // closes only its OWN channel, never `-CC`.
+                runBoundedExecLane(clientScope, session, command, effectiveTimeoutMs)
             } catch (t: Throwable) {
                 throw TmuxClientException(
                     "tmux send-keys exec (interactive send lane) failed: ${t.message}",
@@ -1452,13 +1442,10 @@ internal class RealTmuxClient(
         val command = "tmux $sessionCommand"
         val execResult =
             try {
-                // Independent of the busy `-CC` channel, so this returns fast under
-                // a burst. The ceiling is the safety bound for a genuinely
-                // wedged/half-open transport; cancelling the exec closes its OWN
-                // channel (RealSshSession.exec cancellation handler), never `-CC`.
-                withTimeoutOrNull(effectiveTimeoutMs) {
-                    session.exec(command)
-                }
+                // Independent of the busy `-CC` channel (fast under a burst); #1516's
+                // [runBoundedExecLane] makes the ceiling a REAL caller deadline and
+                // closes only its OWN channel, never `-CC`.
+                runBoundedExecLane(clientScope, session, command, effectiveTimeoutMs)
             } catch (t: Throwable) {
                 throw TmuxClientException(
                     "tmux session-lifecycle exec (dashboard/rename lane) failed: ${t.message}",

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxExecLane.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxExecLane.kt
@@ -1,0 +1,98 @@
+package com.pocketshell.core.tmux
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Issue #1516 — run ONE `SshSession.exec` round-trip on the dedicated exec lane
+ * under a bound the CALLER can actually enforce.
+ *
+ * ## The defect this exists to fix
+ * Every exec-lane call used to be written as a STRUCTURED child:
+ *
+ * ```
+ * withTimeoutOrNull(effectiveTimeoutMs) { session.exec(command) }   // OLD
+ * ```
+ *
+ * That reads like a bound but is not one. `withTimeoutOrNull` cancels its child
+ * and then — by structured concurrency — **cannot return until that child has
+ * fully completed**. `RealSshSession.exec`'s `finally` closes the exec channel
+ * inside `withContext(NonCancellable)` through the single-writer
+ * `TransportDispatcher`, whose per-op wall-clock ceiling is
+ * `DEFAULT_PER_OP_TIMEOUT_MS` = 8 s. On a genuinely half-open socket (no
+ * FIN/RST) that channel-close write never gets an answer, so the "2.5 s" heal
+ * capture parked its caller for the bound PLUS the whole 8 s teardown ceiling.
+ *
+ * Measured on the real transport (Docker sshd behind a paused in-JVM TCP relay,
+ * `Zz1516` probe, 2026-07-27): the render-heal-shaped
+ * `withTimeoutOrNull(2500) { session.exec(...) }` returned after **10 506 ms** —
+ * 4× its nominal bound and 2.6× the #1494 watchdog tick it is supposed to sit
+ * under. With no caller bound at all the same call took **38 052 ms** (the 30 s
+ * session-wide no-progress read watchdog + the same 8 s teardown tail).
+ *
+ * ## The fix
+ * Own the exec as a **sibling** of the caller on the client's own [CoroutineScope]
+ * instead of as its child, and bound the *await*. The bound is then a real
+ * deadline: when it trips, the caller returns a definite failure immediately and
+ * the cancelled exec finishes unwinding OFF the caller.
+ *
+ * Cancelling the owned exec is what reclaims the resources, and it happens at the
+ * bound, not at the teardown tail:
+ *  - `RealSshSession.exec` runs its blocking stdout/stderr drain inside
+ *    `runInterruptible(Dispatchers.IO)`, so cancellation `Thread.interrupt()`s
+ *    the parked JDK read and the drain workers (`Future.cancel(true)`) —
+ *    the wedged read is unparked at the bound;
+ *  - the `finally` that releases the exec-drain permit (1 of
+ *    `EXEC_DRAIN_MAX_CONCURRENT_EXECS` = 4) runs on that same unwind, so the
+ *    permit pool is not stranded either;
+ *  - only the `NonCancellable` channel-close tail is left, and it now runs
+ *    detached instead of on the caller's clock.
+ *
+ * This is why #1516 does NOT add another nested coroutine timeout (the rejected
+ * round-1 approach: a `withTimeoutOrNull` nested *outside* another
+ * `withTimeoutOrNull` on the same call can never fire first, and inherits the
+ * same "wait for the child" semantics), and does not need a per-call
+ * `execReadTimeoutMs` override in core-ssh: on this lane the caller's bound
+ * already unparks the read strictly EARLIER than any read watchdog we could
+ * install (2.5 s < 3 s < the 30 s session default), so such an override would be
+ * unreachable dead code on the render-heal path.
+ *
+ * ## How the bound composes with the #1494 watchdog budgets
+ * ```
+ * exec-lane caller bound  (SEED_CAPTURE_TIMEOUT_MS)              2.5 s   <-- enforced here
+ *   < render-heal watchdog tick  (RENDER_HEAL_WATCHDOG_TICK_TIMEOUT_MS)  4.0 s
+ *   < per-pane single-flight force-reset (HELD_TOO_LONG_MS)     15.0 s
+ * ```
+ * Because the capture now genuinely returns by 2.5 s, a wedged heal scores a
+ * DEFINITE failure (`TmuxClientException` -> `Unverified`, hot cadence) *inside*
+ * the 4 s tick instead of being abandoned by it at 4 s while the capture kept
+ * parking to 10.5 s — and the force-mode reseed path (which #1494's tick does NOT
+ * wrap at all) gets the same real bound. The detached teardown tail is bounded
+ * independently by the transport dispatcher's 8 s per-op ceiling and completes
+ * well inside the 15 s single-flight reset.
+ *
+ * Returns `null` when [timeoutMs] elapsed first (identical to the old
+ * `withTimeoutOrNull` contract, so callers keep their existing
+ * "null -> throw TmuxClientException" mapping); rethrows whatever the exec threw.
+ */
+internal suspend fun runBoundedExecLane(
+    scope: CoroutineScope,
+    session: SshSession,
+    command: String,
+    timeoutMs: Long,
+): ExecResult? {
+    val owned = scope.async { session.exec(command) }
+    return try {
+        withTimeoutOrNull(timeoutMs) { owned.await() }
+    } finally {
+        // Bound exceeded, caller cancelled, or the exec threw: never leave the
+        // detached exec running. Cancelling unparks its blocking read and frees
+        // its exec-drain permit immediately; the NonCancellable channel teardown
+        // then completes off the caller. A no-op on the success path (cancelling
+        // an already-completed Deferred does nothing).
+        owned.cancel()
+    }
+}

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientExecLaneTest.kt
@@ -8,11 +8,14 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
@@ -32,6 +35,27 @@ import java.nio.charset.StandardCharsets
 import java.util.Collections
 
 private const val ASYNC_AWAIT_TIMEOUT_MS = 15_000L
+
+/**
+ * Issue #1516 — the caller-visible bound handed to an exec-lane call in the
+ * wedged-teardown tests. Short so the tests stay fast; the production render-heal
+ * value is `SEED_CAPTURE_TIMEOUT_MS` = 2 500 ms.
+ */
+private const val SHORT_BOUND_MS = 300L
+
+/**
+ * Issue #1516 — how long the modelled `NonCancellable` channel-close teardown
+ * wedges after the read is cancelled. Production's equivalent is the transport
+ * dispatcher's 8 s per-op wall-clock ceiling on a half-open socket.
+ */
+private const val WEDGED_TEARDOWN_MS = 3_000L
+
+/**
+ * Issue #1516 — the load-bearing ceiling: comfortably above [SHORT_BOUND_MS] plus
+ * scheduling slack on a contended box, and far below [WEDGED_TEARDOWN_MS], so the
+ * assertion is red exactly when the caller waits for the teardown tail.
+ */
+private const val BOUND_ASSERT_CEILING_MS = 1_000L
 
 class TmuxClientExecLaneTest {
 
@@ -960,6 +984,196 @@ class TmuxClientExecLaneTest {
             wedger.cancel()
         } finally {
             client.close()
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1516 — the exec-lane BOUND was not a bound.
+    //
+    // Every exec-lane call was `withTimeoutOrNull(bound) { session.exec(cmd) }`,
+    // i.e. a STRUCTURED CHILD. `withTimeoutOrNull` cancels its child and then
+    // cannot return until the child has fully completed — and
+    // `RealSshSession.exec`'s `finally` closes the exec channel under
+    // `withContext(NonCancellable)` through the single-writer TransportDispatcher,
+    // whose per-op wall-clock ceiling is 8 s. On a genuinely half-open socket
+    // (no FIN/RST) that close never gets an answer, so the "2.5 s" render-heal
+    // capture parked its caller for bound + 8 s.
+    //
+    // Measured on the REAL transport (Docker sshd behind a paused in-JVM TCP
+    // relay): 10 506 ms for the render-heal-shaped call — 4x its nominal bound
+    // and 2.6x the #1494 4 s watchdog tick it must sit under. See the
+    // `Issue1516HealCaptureHalfOpenBoundIntegrationTest` Docker proof; these JVM
+    // tests pin the same mechanism per lane in the per-PR Unit gate.
+    //
+    // [wedgedTeardownExecHandler] models exactly that shape: the read parks until
+    // the caller's bound cancels it (production: `runInterruptible` interrupts the
+    // blocking JDK read), and only THEN does a NonCancellable teardown run for a
+    // long time. It is NOT the older `CompletableDeferred.await()` proxy, whose
+    // cancellation is free and therefore cannot reproduce the reported park.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `issue1516 heal capture returns a definite failure within its own bound when the exec teardown wedges`() =
+        runBlocking {
+            val shell = FakeShell()
+            val wedge = WedgedTeardownExec(teardownMs = WEDGED_TEARDOWN_MS)
+            val session = FakeSession(shell, execHandler = wedge.handler())
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                val startedAtMs = System.currentTimeMillis()
+                val thrown = runCatching {
+                    client.captureWithCursor("%3", scrollbackLines = 200, timeoutMs = SHORT_BOUND_MS)
+                }.exceptionOrNull()
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+
+                // Non-vacuity: this capture really reached the exec lane and parked
+                // there, so the elapsed time below is this call's own cost.
+                assertTrue(
+                    "the capture must have entered the exec lane (it did not park on the read)",
+                    wedge.entered.isCompleted,
+                )
+                assertTrue(
+                    "a wedged heal capture must surface a DEFINITE TmuxClientException failure, " +
+                        "never a hang or a silent success (was $thrown)",
+                    thrown is TmuxClientException,
+                )
+                // LOAD-BEARING (#1516): the caller must be freed by ITS OWN bound, not
+                // by the exec's NonCancellable channel-teardown tail.
+                assertTrue(
+                    "the heal capture must return by its own ${SHORT_BOUND_MS}ms bound, not after " +
+                        "the wedged NonCancellable channel teardown (${WEDGED_TEARDOWN_MS}ms). " +
+                        "elapsed=${elapsedMs}ms",
+                    elapsedMs < BOUND_ASSERT_CEILING_MS,
+                )
+                // Resource reclamation (the read/exec-drain-permit half): cancelling at
+                // the bound is what unparks the blocking read in production, and it
+                // happens AT the bound in both the broken and fixed shapes — which is
+                // precisely why #1516 needs no extra per-call read watchdog.
+                // The exec now unwinds OFF the caller, so poll (bounded, hard-failing)
+                // for the cancellation to reach the parked read.
+                assertTrue(
+                    "the parked exec read must be unparked by the cancellation the bound raised",
+                    withTimeoutOrNull(ASYNC_AWAIT_TIMEOUT_MS) {
+                        while (wedge.readUnparkedAtMs.get() < 0L) delay(10)
+                        true
+                    } == true,
+                )
+                val unparkedAfterMs = wedge.readUnparkedAtMs.get() - startedAtMs
+                assertTrue(
+                    "the parked exec read must be unparked at the bound, not deferred to the " +
+                        "teardown tail (was ${unparkedAfterMs}ms)",
+                    unparkedAfterMs in 0 until BOUND_ASSERT_CEILING_MS,
+                )
+                // No orphan: the detached teardown still runs to completion off-caller.
+                assertTrue(
+                    "the detached exec teardown must still complete after the caller was freed",
+                    withTimeoutOrNull(ASYNC_AWAIT_TIMEOUT_MS) { wedge.teardownDone.await() } != null,
+                )
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `issue1516 every exec lane bound is enforced when the exec teardown wedges`() = runBlocking {
+        // Class coverage (G2): the broken `withTimeoutOrNull { session.exec }` shape
+        // was duplicated at EVERY exec-lane call site, so the fix must hold for the
+        // whole class, not only the render-heal capture the issue reported.
+        val lanes: List<Pair<String, suspend (TmuxClient) -> Unit>> = listOf(
+            "captureWithCursor" to { c ->
+                c.captureWithCursor("%3", scrollbackLines = 200, timeoutMs = SHORT_BOUND_MS)
+                Unit
+            },
+            "capturePaneTextViaExec" to { c ->
+                c.capturePaneTextViaExec("%3", timeoutMs = SHORT_BOUND_MS)
+                Unit
+            },
+            "listPanesViaExec" to { c ->
+                c.listPanesViaExec("list-panes -a -F x", timeoutMs = SHORT_BOUND_MS)
+                Unit
+            },
+            "sendKeysViaExec" to { c ->
+                c.sendKeysViaExec("send-keys -l -t %0 -- 'hi'", timeoutMs = SHORT_BOUND_MS)
+                Unit
+            },
+            "sendLifecycleViaExec" to { c ->
+                c.sendLifecycleViaExec("list-sessions -F x", timeoutMs = SHORT_BOUND_MS)
+                Unit
+            },
+        )
+        for ((lane, call) in lanes) {
+            val shell = FakeShell()
+            val wedge = WedgedTeardownExec(teardownMs = WEDGED_TEARDOWN_MS)
+            val session = FakeSession(shell, execHandler = wedge.handler())
+            val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+            try {
+                client.connect()
+                val startedAtMs = System.currentTimeMillis()
+                val thrown = runCatching { call(client) }.exceptionOrNull()
+                val elapsedMs = System.currentTimeMillis() - startedAtMs
+                assertTrue("$lane must have entered the exec lane", wedge.entered.isCompleted)
+                assertTrue(
+                    "$lane must surface a definite TmuxClientException (was $thrown)",
+                    thrown is TmuxClientException,
+                )
+                assertTrue(
+                    "$lane must return by its own ${SHORT_BOUND_MS}ms bound, not after the wedged " +
+                        "NonCancellable teardown (${WEDGED_TEARDOWN_MS}ms). elapsed=${elapsedMs}ms",
+                    elapsedMs < BOUND_ASSERT_CEILING_MS,
+                )
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun `issue1516 a healthy exec still returns its result through the bounded lane`() = runBlocking {
+        // The ownership change must not break the success path: a normal capture
+        // still resolves through the bound and returns real content.
+        val shell = FakeShell()
+        val session = FakeSession(
+            shell,
+            execHandler = healExecHandler(cursor = "7,3", captureLines = listOf("alive")),
+        )
+        val client = RealTmuxClient(session, scope, commandTimeoutMs = 30_000L)
+        try {
+            client.connect()
+            val combined = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                client.captureWithCursor("%3", scrollbackLines = 200, timeoutMs = 2_500L)
+            }
+            assertFalse(combined.capture.isError)
+            assertEquals(listOf("alive"), combined.capture.output)
+            assertEquals("7,3", combined.cursorReply)
+        } finally {
+            client.close()
+        }
+    }
+
+    /**
+     * Issue #1516 — a `RealSshSession.exec` that models the MEASURED half-open
+     * production shape: the blocking read parks until the caller's bound cancels
+     * it, and only then does the channel-close teardown run under
+     * `NonCancellable` for a long wall-clock window (production: the transport
+     * dispatcher's 8 s per-op ceiling on a socket that never answers).
+     */
+    private class WedgedTeardownExec(private val teardownMs: Long) {
+        val entered = CompletableDeferred<Unit>()
+        val teardownDone = CompletableDeferred<Unit>()
+        val readUnparkedAtMs = java.util.concurrent.atomic.AtomicLong(-1L)
+
+        fun handler(): suspend (String) -> ExecResult = {
+            entered.complete(Unit)
+            try {
+                awaitCancellation()
+            } finally {
+                readUnparkedAtMs.set(System.currentTimeMillis())
+                withContext(NonCancellable) {
+                    delay(teardownMs)
+                    teardownDone.complete(Unit)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1516

## The issue's premise was subtly wrong, and measuring first is what found it

#1494 bounded the render-heal single-flight mutex and the watchdog tick, and deferred the exec-lane capture read. The obvious fix was a read timeout. Probing a genuinely half-open socket on the real transport **before** writing code showed that would have fixed nothing:

- the socket read was **already unparked** at the bound — `RealSshSession.exec` drains inside `runInterruptible`, so cancellation interrupts the JDK read and frees the exec-drain permit in the inner `finally`;
- what was unbounded is the **caller** — `withTimeoutOrNull` cancels its child but cannot return until that child finishes, and `exec`'s `finally` closes the channel under `withContext(NonCancellable)` through `TransportDispatcher`'s 8s per-op ceiling.

`2500ms + 8000ms = 10,500ms` ≈ the measured **10,512ms** park. Without any caller bound: **38,052ms** — which is `EXEC_READ_TIMEOUT_MS = 30_000` plus the tail, the only path that could free the caller if the read really had stayed parked. The two figures are mutually exclusive, and the observed one decides the design.

`TmuxExecLane` therefore owns the exec as a **sibling** of the caller (`scope.async` + bounded `await` + `cancel` in `finally`) so the bound is an enforceable deadline. Applied at **all five** bounded exec-lane sites in `TmuxClient.kt` — the shape was copy-pasted, so fixing only the site the issue named would have been the proxy fix G2 exists to prevent.

## Evidence

Reviewer drove red→green independently this run (backups via `cp`, never `git`; both edited files md5-verified identical afterwards):

- **Real transport (D34)** — Docker sshd + byte-budgeted half-open relay armed mid-payload. RED `elapsed=10512ms` and `elapsed=18521ms` (4 concurrent), landing on the implementer's 10,519 / 18,524. GREEN both under 4s, `tests=12 failures=0 skipped=0`, XML fresh, no cache suffix.
- **JVM** — RED `elapsed=3307ms` against a 300ms bound → GREEN, 208/0 full module.
- **`:shared:core-ssh:integrationTest` re-run: 49/0**, closing the #1144→#1149 precedent where a close/transport contract change passed Unit and went red on the integration suite only after merge.
- **12/12 determinism runs** of the new wall-clock timing tests on a contended box — a single green is not evidence for an `elapsed < 1000ms` assertion.
- **Mutation beyond the brief**: `timeoutMs = seedCaptureTimeoutMs` → `9_999L` at `TmuxSessionViewModel.kt:11831`; `bothRenderHealCaptureSitesCarryTheBoundedSeedCeiling` FAILED, then PASSED after a verified restore. Proves the AC2 wiring test is not vacuous.
- Full `:app:testDebugUnitTest` 4198/0, no hang (#1517 class checked).

## Two judgment calls, both ruled on

1. **Declining the `SshExecOptions` per-call read policy** (~166 `exec` overrides) that two prior audits recommended. With the caller bound enforced the read is interrupted at 2.5s, so any ~3s read watchdog fires strictly later — unreachable dead code on this lane, the exact shape a prior round was rejected for. The reviewer said it would have *rejected* the policy had it been added, but filed a caveat: the argument is lane-specific, and `TmuxClient.kt:1091`'s `has-session` reattach preflight has no caller bound and still rides the 30s watchdog. That is where a per-call read bound would be reachable — filed as a follow-up, not silently absorbed here.
2. **Closing a `TmuxClient` now cancels its in-flight exec-lane calls.** The reviewer walked all 8 `close()` call sites: every one is a teardown/eviction/replacement path that tears down the shell in the same call, so the exec was already doomed — cancelling now unparks the read and returns the permit instead of waiting out 30s. Caller-visible shape unchanged (`CancellationException` → the pre-existing `catch (t: Throwable)` → `TmuxClientException`), and `async` under the `SupervisorJob` scope cannot cancel siblings.

## Orchestrator verification

Applied to a clean worktree off `main` (`ed53bc60`). **Two files are untracked in the candidate, including the new `TmuxExecLane.kt` production file** — `git diff` omits those, so they were copied explicitly with file modes verified against source. `git diff --check` clean; file-size hygiene, VM ratchet, and test-validity guards all exit 0. Note `TmuxClient.kt` had only **6 bytes** of headroom under the 131072 hygiene threshold and this change shrinks it to 130646 — the extraction was structurally forced, not stylistic. Focused gate re-run with `--rerun-tasks`: test task unsuffixed, 0 stale XML against the run marker, **208 executed / 0 failed / 0 skipped** self-asserted, `TmuxClientExecLaneTest` named in the results.

## CI compatibility

The new Docker integration test needs no new service or fixed port — same Testcontainers bootstrap as the CI-proven `TmuxClientIntegrationTest`, ephemeral relay port, already covered by `tests.yml:484`.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb