### PR TITLE
test(notifications): revoke permission before instrumentation, not from the runner (#1741)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,6 +212,17 @@ jobs:
           chmod +x scripts/test-ci-journey-budget.sh
           scripts/test-ci-journey-budget.sh
 
+      # Issue #1741: emulator-free fixture proof for the app-open notification
+      # journey. Exercises the real connected-test wrapper with stubbed
+      # adb/Gradle to pin install -> external revoke/verify -> instrumentation ->
+      # named non-zero report -> external grant/verify for base and suffixed
+      # packages, including killed-runner/zero-test/cleanup mutations. It also
+      # pins the per-push and nightly phase-1b selection without consuming an AVD.
+      - name: Notification permission fixture guard (issue #1741)
+        run: |
+          chmod +x scripts/test-notification-permission-fixture.sh
+          scripts/test-notification-permission-fixture.sh
+
       # Issue #1458: fast, JVM-free fixture test for the emulator-journey
       # aggregate verdict (scripts/ci-journey-aggregate-verdict.sh) + the
       # per-shard token-writing / aggregation wiring in tests.yml. Proves the

--- a/app/src/androidTest/java/com/pocketshell/app/notifications/NoNotificationPromptOnAppOpenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/notifications/NoNotificationPromptOnAppOpenE2eTest.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.app.notifications
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.SystemClock
 import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
@@ -8,6 +11,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.core.storage.AppDatabase
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -39,9 +43,11 @@ import java.io.InputStreamReader
  * place, a re-added `onCreate` trigger early-returns
  * (`ContextCompat.checkSelfPermission(...) == GRANTED`) and NO dialog pops — so
  * every one of those tests stays green while the reported bug returns. This
- * regression MUST therefore run with POST_NOTIFICATIONS explicitly REVOKED so
- * the app-open trigger, if it ever comes back, actually pops the dialog and
- * fails this test.
+ * regression MUST therefore run with POST_NOTIFICATIONS explicitly REVOKED by
+ * the external connected-test fixture before instrumentation starts. Revoking
+ * it here would make Android kill this test's own target/instrumentation UID
+ * before [MainActivity] launches, producing a runner crash instead of a product
+ * verdict.
  *
  * ## The load-bearing assertion (red→green)
  *
@@ -72,10 +78,8 @@ class NoNotificationPromptOnAppOpenE2eTest {
     @Before
     fun setUp() {
         // Deterministic empty state: zero hosts so app open lands on the host
-        // list (never an auto-resolved default host / session), and REVOKE
-        // POST_NOTIFICATIONS so a re-added app-open trigger would actually pop
-        // the system dialog (the reported symptom) instead of early-returning on
-        // an already-granted permission (the #1509 masking gap).
+        // list (never an auto-resolved default host / session). Permission state
+        // is owned by scripts/connected-test.sh before this process starts.
         val db = Room.databaseBuilder(
             instrumentation.targetContext,
             AppDatabase::class.java,
@@ -83,21 +87,30 @@ class NoNotificationPromptOnAppOpenE2eTest {
         ).fallbackToDestructiveMigration(dropAllTables = true).build()
         runCatching { db.clearAllTables() }
         db.close()
-        runShell("pm revoke $targetPackage android.permission.POST_NOTIFICATIONS")
     }
 
     @After
     fun tearDown() {
         scenario?.close()
         scenario = null
-        // Hygiene: re-grant so a subsequent journey class on the shared emulator
-        // is not surprised by the revoked runtime grant (most declare
-        // PreGrantPermissionsRule which re-grants anyway, but leave it clean).
-        runShell("pm grant $targetPackage android.permission.POST_NOTIFICATIONS")
     }
 
     @Test
     fun appOpenDoesNotPopNotificationPermissionDialog() {
+        assertTrue(
+            "POST_NOTIFICATIONS regression requires Android 13+; API ${Build.VERSION.SDK_INT} " +
+                "cannot exercise the reported permission dialog",
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU,
+        )
+        assertEquals(
+            "POST_NOTIFICATIONS must be DENIED by the external pre-instrumentation " +
+                "fixture; never grant/revoke it from this target process",
+            PackageManager.PERMISSION_DENIED,
+            instrumentation.targetContext.checkSelfPermission(
+                Manifest.permission.POST_NOTIFICATIONS,
+            ),
+        )
+
         scenario = ActivityScenario.launch(MainActivity::class.java)
         // Let onCreate + first composition + any (unwanted) permission request
         // settle. A revoked-grant app-open trigger pops GrantPermissionsActivity

--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -810,8 +810,10 @@ run_bounded() {
 run_class() {
   local fqcn="$1"
   local remaining cap rc attempt_start attempt_elapsed cleanup_status
+  local notification_class="com.pocketshell.app.notifications.NoNotificationPromptOnAppOpenE2eTest"
   local app_id_suffix="${POCKETSHELL_APP_ID_SUFFIX:-}"
   local -a app_id_args=()
+  local -a notification_gradle_args=(--max-workers=2)
   local -a network_fault_args=()
   if [[ "$fqcn" == *OutboundAttachmentOffsetResumeJourneyE2eTest* ]]; then
     network_fault_args+=(
@@ -852,18 +854,35 @@ run_class() {
   fi
   JOURNEY_CURRENT_ATTEMPT_LOG="$LAST_RUN_CLASS_ATTEMPT_DIR/attempt.log"
   attempt_start=$SECONDS
-  # Issue #1458: --max-workers=2 (parity with the Unit job) bounds Gradle's
-  # worker fan-out while the emulator and Docker fixtures share the runner. The
-  # Gradle DAEMON is still reused (no --no-daemon), preserving the #835 budget-fit.
-  run_bounded "$cap" \
-    "$GRADLEW" :app:connectedDebugAndroidTest \
-    "${app_id_args[@]}" \
-    --max-workers=2 \
-    -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
-    "${network_fault_args[@]}" \
-    -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
-    -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
-    --stacktrace
+  if [[ "$fqcn" == "$notification_class" ]]; then
+    # Issue #1741: this class must enter instrumentation already DENIED. The
+    # canonical wrapper owns install -> external revoke/verify -> runner ->
+    # result-count validation -> external grant/verify under the AVD lock.
+    # POCKETSHELL_APP_ID_SUFFIX is inherited by the wrapper, which derives the
+    # exact Gradle property and base/suffixed package identity itself.
+    run_bounded "$cap" \
+      "$REPO_ROOT/scripts/connected-test.sh" --no-pool \
+      --deny-notifications-before-instrumentation \
+      "${notification_gradle_args[@]}" \
+      -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+      -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
+      -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
+      --stacktrace
+  else
+    # Issue #1458: --max-workers=2 (parity with the Unit job) bounds Gradle's
+    # worker fan-out while the emulator and Docker fixtures share the runner.
+    # The Gradle DAEMON is still reused (no --no-daemon), preserving the #835
+    # budget-fit for the ordinary class set.
+    run_bounded "$cap" \
+      "$GRADLEW" :app:connectedDebugAndroidTest \
+      "${app_id_args[@]}" \
+      --max-workers=2 \
+      -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+      "${network_fault_args[@]}" \
+      -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
+      -Pandroid.testInstrumentationRunnerArguments.class="$fqcn" \
+      --stacktrace
+  fi
   rc=$?
   LAST_RUN_CLASS_PRIMARY_RC="$rc"
   attempt_elapsed=$((SECONDS - attempt_start))
@@ -988,13 +1007,19 @@ run_ct_class() {
 shard_class() {
   local idx="$1"
   local fqcn="$2"
+  local notification_class="com.pocketshell.app.notifications.NoNotificationPromptOnAppOpenE2eTest"
+  local notification_fixture_args=()
   local -a network_fault_args=()
+  if [[ "$fqcn" == "$notification_class" ]]; then
+    notification_fixture_args+=(--deny-notifications-before-instrumentation)
+  fi
   if [[ "$fqcn" == *OutboundAttachmentOffsetResumeJourneyE2eTest* ]]; then
     network_fault_args+=(
       -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true
     )
   fi
   "$REPO_ROOT/scripts/connected-test.sh" --pool --suffix "ij$idx" \
+    "${notification_fixture_args[@]}" \
     -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
     "${network_fault_args[@]}" \
     -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 #
 # Usage:
 #   scripts/connected-test.sh [--suffix <token>] [--module <gradle-module>] \
+#     [--deny-notifications-before-instrumentation] \
 #     [--pool|--no-pool] [gradle args...]
 #   POCKETSHELL_APP_ID_SUFFIX=i672 scripts/connected-test.sh \
 #     -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.proof.SomeTest
@@ -87,6 +88,13 @@ set -euo pipefail
 #   --cleanup-suffixes   Uninstall every accumulated com.pocketshell.app.i*
 #                        (and .test) package from the target device, then exit.
 #                        Prevents install pile-up across worktrees.
+#   --deny-notifications-before-instrumentation
+#                        Narrow issue-#1741 fixture for
+#                        NoNotificationPromptOnAppOpenE2eTest. Installs the exact
+#                        base/suffixed target APK, externally revokes and verifies
+#                        POST_NOTIFICATIONS before the runner starts, validates a
+#                        non-vacuous named result, then externally restores and
+#                        verifies the grant after the runner exits.
 #
 # Everything after the recognised flags is forwarded verbatim to gradle's
 # connectedDebugAndroidTest task (e.g. instrumentation-runner-argument filters).
@@ -114,8 +122,10 @@ source "$ROOT_DIR/scripts/lib/scope-run.sh"
 # inherited copy; the wrapper remains the continuous owner (issue #1737).
 export POCKETSHELL_AVD_LOCK_CONTINUOUS=1
 
-ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
-ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
+ANDROID_SDK="${ANDROID_SDK:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/home/alexey/Android/Sdk}}}"
+if [[ -z "${ADB:-}" ]]; then
+  ADB="$(command -v adb 2>/dev/null || printf '%s/platform-tools/adb' "$ANDROID_SDK")"
+fi
 
 print_usage() {
   cat >&2 <<'USAGE'
@@ -123,6 +133,7 @@ Lock-wrapped ad-hoc connected-test runner (issues #672/#724/#798).
 
 Usage:
   scripts/connected-test.sh [--suffix <token>] [--module <gradle-module>] \
+    [--deny-notifications-before-instrumentation] \
     [--pool|--no-pool] [gradle args...]
   scripts/connected-test.sh --cleanup-suffixes
   scripts/connected-test.sh --help
@@ -143,6 +154,10 @@ Flags:
   --no-pool            Force the legacy single-lane path.
   --cleanup-suffixes   Uninstall every accumulated com.pocketshell.app.i* package
                        from the target device, then exit.
+  --deny-notifications-before-instrumentation
+                       Run the NoNotificationPromptOnAppOpenE2eTest permission
+                       fixture outside instrumentation: install, revoke+verify,
+                       run, validate its named result, then grant+verify.
   --help, -h           Print this help and exit.
 
 Examples:
@@ -165,6 +180,7 @@ SUFFIX="${POCKETSHELL_APP_ID_SUFFIX:-}"
 # -> the :app default below. Set via --module.
 MODULE=""
 CLEANUP_ONLY=0
+DENY_NOTIFICATIONS_BEFORE_INSTRUMENTATION=0
 USE_POOL=0
 # 0 = unset (auto-decide), 1 = caller forced --pool, -1 = caller forced --no-pool.
 POOL_FLAG=0
@@ -206,6 +222,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cleanup-suffixes)
       CLEANUP_ONLY=1
+      shift
+      ;;
+    --deny-notifications-before-instrumentation)
+      DENY_NOTIFICATIONS_BEFORE_INSTRUMENTATION=1
       shift
       ;;
     --)
@@ -257,6 +277,38 @@ if [[ -n "$MODULE" ]]; then
     exit 2
   fi
   CONNECTED_TASK=":${module_path}:connectedDebugAndroidTest"
+fi
+
+NOTIFICATION_PERMISSION_TEST_CLASS="com.pocketshell.app.notifications.NoNotificationPromptOnAppOpenE2eTest"
+NOTIFICATION_PERMISSION_TEST_METHOD="appOpenDoesNotPopNotificationPermissionDialog"
+NOTIFICATION_PERMISSION="android.permission.POST_NOTIFICATIONS"
+if [[ "$DENY_NOTIFICATIONS_BEFORE_INSTRUMENTATION" == "1" ]]; then
+  if [[ "$CLEANUP_ONLY" == "1" ]]; then
+    printf 'FAIL: notification-permission fixture cannot be combined with --cleanup-suffixes\n' >&2
+    exit 2
+  fi
+  if [[ "$CONNECTED_TASK" != ":app:connectedDebugAndroidTest" ]]; then
+    printf 'FAIL: notification-permission fixture is valid only for the app module\n' >&2
+    exit 2
+  fi
+  notification_class_selected=0
+  for arg in "${GRADLE_ARGS[@]}"; do
+    case "$arg" in
+      "-Pandroid.testInstrumentationRunnerArguments.class=$NOTIFICATION_PERMISSION_TEST_CLASS")
+        notification_class_selected=1
+        ;;
+      -Pandroid.testInstrumentationRunnerArguments.numShards=*\
+      |-Pandroid.testInstrumentationRunnerArguments.shardIndex=*)
+        printf 'FAIL: notification-permission fixture must be a dedicated unsharded invocation\n' >&2
+        exit 2
+        ;;
+    esac
+  done
+  if [[ "$notification_class_selected" != "1" ]]; then
+    printf 'FAIL: notification-permission fixture requires dedicated class=%s\n' \
+      "$NOTIFICATION_PERMISSION_TEST_CLASS" >&2
+    exit 2
+  fi
 fi
 
 # Count emulators currently online (issue #776). Used to decide whether to
@@ -506,6 +558,182 @@ pocketshell_run_guarded_mutation() {
   return "$child_rc"
 }
 
+notification_permission_capture() {
+  local output_file="$1"
+  shift
+  local adb_target=("$ADB")
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    adb_target+=(-s "$ANDROID_SERIAL")
+  fi
+  : > "$output_file"
+  pocketshell_run_guarded_mutation "${adb_target[@]}" "$@" > "$output_file"
+}
+
+notification_permission_state() {
+  local target_package="$1"
+  local output_file="$2"
+  local line
+  notification_permission_capture \
+    "$output_file" \
+    shell dumpsys package "$target_package"
+  line="$(grep -F "$NOTIFICATION_PERMISSION: granted=" "$output_file" | head -1 || true)"
+  case "$line" in
+    *"granted=true"*)
+      printf 'granted\n'
+      ;;
+    *"granted=false"*)
+      printf 'denied\n'
+      ;;
+    *)
+      printf 'unknown\n'
+      ;;
+  esac
+}
+
+notification_permission_prepare() {
+  local target_package="$1"
+  local scratch_dir="$2"
+  local sdk_file="$scratch_dir/sdk"
+  local package_file="$scratch_dir/package"
+  local state_file="$scratch_dir/state"
+  local adb_target=("$ADB")
+  local sdk state
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    adb_target+=(-s "$ANDROID_SERIAL")
+  fi
+
+  notification_permission_capture "$sdk_file" shell getprop ro.build.version.sdk
+  sdk="$(tr -d '\r[:space:]' < "$sdk_file")"
+  if [[ ! "$sdk" =~ ^[0-9]+$ || "$sdk" -lt 33 ]]; then
+    printf 'FAIL: POST_NOTIFICATIONS fixture requires Android API 33+ (got: %s)\n' \
+      "${sdk:-empty}" >&2
+    return 1
+  fi
+
+  notification_permission_capture "$package_file" shell pm path "$target_package"
+  if ! grep -q '^package:' "$package_file"; then
+    printf 'FAIL: target package %s is not installed before permission revoke\n' \
+      "$target_package" >&2
+    return 1
+  fi
+
+  if ! pocketshell_run_guarded_mutation \
+      "${adb_target[@]}" shell pm revoke \
+      "$target_package" "$NOTIFICATION_PERMISSION"; then
+    printf 'FAIL: external pre-instrumentation revoke failed for %s\n' \
+      "$target_package" >&2
+    return 1
+  fi
+  state="$(notification_permission_state "$target_package" "$state_file")"
+  if [[ "$state" != "denied" ]]; then
+    printf 'FAIL: %s must be denied before instrumentation (state=%s)\n' \
+      "$NOTIFICATION_PERMISSION" "${state:-empty}" >&2
+    return 1
+  fi
+  printf 'Notification permission fixture prepared externally: package=%s state=denied api=%s\n' \
+    "$target_package" "$sdk"
+}
+
+notification_permission_restore() {
+  local target_package="$1"
+  local scratch_dir="$2"
+  local target_apk="$3"
+  local package_file="$scratch_dir/restore-package"
+  local state_file="$scratch_dir/restore-state"
+  local adb_target=("$ADB")
+  local state
+  if [[ -n "${ANDROID_SERIAL:-}" ]]; then
+    adb_target+=(-s "$ANDROID_SERIAL")
+  fi
+
+  notification_permission_capture "$package_file" shell pm path "$target_package"
+  if ! grep -q '^package:' "$package_file"; then
+    if [[ ! -s "$target_apk" ]]; then
+      printf 'NOTIFICATION_PERMISSION_CLEANUP_FAILED: target APK missing for restore: %s\n' \
+        "$target_apk" >&2
+      return 1
+    fi
+    if ! pocketshell_run_guarded_mutation \
+        "${adb_target[@]}" install -r "$target_apk"; then
+      printf 'NOTIFICATION_PERMISSION_CLEANUP_FAILED: reinstall failed for %s\n' \
+        "$target_package" >&2
+      return 1
+    fi
+    notification_permission_capture "$package_file" shell pm path "$target_package"
+    if ! grep -q '^package:' "$package_file"; then
+      printf 'NOTIFICATION_PERMISSION_CLEANUP_FAILED: %s absent after reinstall\n' \
+        "$target_package" >&2
+      return 1
+    fi
+  fi
+
+  if ! pocketshell_run_guarded_mutation \
+      "${adb_target[@]}" shell pm grant \
+      "$target_package" "$NOTIFICATION_PERMISSION"; then
+    printf 'NOTIFICATION_PERMISSION_CLEANUP_FAILED: external grant failed for %s\n' \
+      "$target_package" >&2
+    return 1
+  fi
+  state="$(notification_permission_state "$target_package" "$state_file")"
+  if [[ "$state" != "granted" ]]; then
+    printf 'NOTIFICATION_PERMISSION_CLEANUP_FAILED: %s was not restored for %s (state=%s)\n' \
+      "$NOTIFICATION_PERMISSION" "$target_package" "${state:-empty}" >&2
+    return 1
+  fi
+  printf 'Notification permission fixture restored externally: package=%s state=granted\n' \
+    "$target_package"
+}
+
+notification_permission_validate_report() {
+  local report_dir="$1"
+  local tests=0 skipped=0 failures=0 errors=0
+  local xml line value
+  local named_method=0 xml_count=0
+
+  while IFS= read -r -d '' xml; do
+    xml_count=$((xml_count + 1))
+    line="$(grep -m1 '<testsuite ' "$xml" 2>/dev/null || true)"
+    [[ -n "$line" ]] || continue
+    value="$(sed -n 's/.* tests="\([0-9][0-9]*\)".*/\1/p' <<< "$line")"
+    tests=$((tests + ${value:-0}))
+    value="$(sed -n 's/.* skipped="\([0-9][0-9]*\)".*/\1/p' <<< "$line")"
+    skipped=$((skipped + ${value:-0}))
+    value="$(sed -n 's/.* failures="\([0-9][0-9]*\)".*/\1/p' <<< "$line")"
+    failures=$((failures + ${value:-0}))
+    value="$(sed -n 's/.* errors="\([0-9][0-9]*\)".*/\1/p' <<< "$line")"
+    errors=$((errors + ${value:-0}))
+    if grep -q "classname=\"$NOTIFICATION_PERMISSION_TEST_CLASS\"" "$xml" \
+        && grep -q "name=\"$NOTIFICATION_PERMISSION_TEST_METHOD\"" "$xml"; then
+      named_method=1
+    fi
+  done < <(find "$report_dir" -type f -name '*.xml' -print0 2>/dev/null)
+
+  local executed=$((tests - skipped))
+  if (( xml_count == 0 || executed != 1 )); then
+    printf 'FAIL: notification-permission invocation must execute exactly one test (xml=%s tests=%s skipped=%s executed=%s)\n' \
+      "$xml_count" "$tests" "$skipped" "$executed" >&2
+    return 1
+  fi
+  if (( skipped != 0 )); then
+    printf 'FAIL: notification-permission invocation skipped %s test(s); no-self-skip policy requires zero\n' \
+      "$skipped" >&2
+    return 1
+  fi
+  if (( failures != 0 || errors != 0 )); then
+    printf 'FAIL: notification-permission invocation report is red (failures=%s errors=%s)\n' \
+      "$failures" "$errors" >&2
+    return 1
+  fi
+  if [[ "$named_method" != "1" ]]; then
+    printf 'FAIL: notification-permission report did not contain %s#%s\n' \
+      "$NOTIFICATION_PERMISSION_TEST_CLASS" "$NOTIFICATION_PERMISSION_TEST_METHOD" >&2
+    return 1
+  fi
+  printf 'NOTIFICATION_PERMISSION_TEST_RESULT executed=%s skipped=%s failures=%s errors=%s class=%s method=%s\n' \
+    "$executed" "$skipped" "$failures" "$errors" \
+    "$NOTIFICATION_PERMISSION_TEST_CLASS" "$NOTIFICATION_PERMISSION_TEST_METHOD"
+}
+
 cleanup_suffixed_packages() {
   # Optional first arg:
   #   --include-base   ALSO uninstall the base com.pocketshell.app[.test] and
@@ -693,6 +921,37 @@ if [[ "$USE_POOL" == "1" && -n "$SUFFIX" ]]; then
   trap 'pocketshell_cleanup_lane_init; pocketshell_release_all' EXIT
 fi
 
+NOTIFICATION_PERMISSION_RESTORE_NEEDED=0
+NOTIFICATION_PERMISSION_TARGET_PACKAGE="com.pocketshell.app${SUFFIX:+.$SUFFIX}"
+NOTIFICATION_PERMISSION_SCRATCH=""
+NOTIFICATION_PERMISSION_BUILD_DIR="$ROOT_DIR/app/build"
+if [[ "$USE_POOL" == "1" && -n "$SUFFIX" ]]; then
+  NOTIFICATION_PERMISSION_BUILD_DIR="$ROOT_DIR/app/build/lane-$SUFFIX"
+fi
+NOTIFICATION_PERMISSION_TARGET_APK="$NOTIFICATION_PERMISSION_BUILD_DIR/outputs/apk/debug/app-debug.apk"
+
+# Invoked indirectly by the EXIT trap below.
+# shellcheck disable=SC2317
+pocketshell_connected_test_exit_cleanup() {
+  local original_rc=$?
+  if [[ "$NOTIFICATION_PERMISSION_RESTORE_NEEDED" == "1" \
+        && -n "$NOTIFICATION_PERMISSION_SCRATCH" ]]; then
+    notification_permission_restore \
+      "$NOTIFICATION_PERMISSION_TARGET_PACKAGE" \
+      "$NOTIFICATION_PERMISSION_SCRATCH" \
+      "$NOTIFICATION_PERMISSION_TARGET_APK" || true
+  fi
+  if declare -F pocketshell_cleanup_lane_init >/dev/null 2>&1; then
+    pocketshell_cleanup_lane_init
+  fi
+  if [[ -n "$NOTIFICATION_PERMISSION_SCRATCH" ]]; then
+    pocketshell_run_without_avd_lock_fd rm -rf "$NOTIFICATION_PERMISSION_SCRATCH"
+  fi
+  pocketshell_release_all
+  return "$original_rc"
+}
+trap pocketshell_connected_test_exit_cleanup EXIT
+
 # Issue #730: the heavy gradle build runs inside its OWN transient systemd
 # --user scope (a SIBLING of the session's per-session scope under robust.slice,
 # NOT nested), so a runaway OOMs only its own scope and the parent tmux session
@@ -728,12 +987,75 @@ trap 'forward_signal TERM' TERM
 
 # The wrapper retains the serial flock while scope-run/Gradle has its inherited
 # copy closed. Helper death is monitored until the mutation process exits.
-set +e
-pocketshell_run_guarded_mutation pocketshell_scope_run "$SCOPE_UNIT" \
-  ./gradlew --no-daemon "$CONNECTED_TASK" \
-  "${GRADLE_INIT_ARGS[@]}" \
-  "${GRADLE_SUFFIX_ARGS[@]}" \
-  "${GRADLE_ARGS[@]}"
-rc=$?
-set -e
+rc=0
+cleanup_rc=0
+notification_report_dir=""
+if [[ "$DENY_NOTIFICATIONS_BEFORE_INSTRUMENTATION" == "1" ]]; then
+  NOTIFICATION_PERMISSION_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-notification-permission.XXXXXX")"
+
+  # Install the exact base/suffixed target before changing its runtime grant.
+  # No instrumentation process exists during this install/revoke/verify stage.
+  set +e
+  pocketshell_run_guarded_mutation pocketshell_scope_run "${SCOPE_UNIT}-permission-install" \
+    ./gradlew --no-daemon :app:installDebug \
+    "${GRADLE_INIT_ARGS[@]}" \
+    "${GRADLE_SUFFIX_ARGS[@]}" \
+    "${GRADLE_ARGS[@]}"
+  rc=$?
+  set -e
+  if (( rc == 0 )); then
+    NOTIFICATION_PERMISSION_RESTORE_NEEDED=1
+    set +e
+    notification_permission_prepare \
+      "$NOTIFICATION_PERMISSION_TARGET_PACKAGE" \
+      "$NOTIFICATION_PERMISSION_SCRATCH"
+    rc=$?
+    set -e
+  fi
+
+  notification_build_dir="$NOTIFICATION_PERMISSION_BUILD_DIR"
+  notification_report_dir="$notification_build_dir/outputs/androidTest-results/connected"
+  if (( rc == 0 )); then
+    # Prevent a killed/zero-test runner from borrowing an earlier invocation's
+    # XML. The directory is a generated output owned by this dedicated run.
+    rm -rf "$notification_report_dir"
+  fi
+fi
+
+if (( rc == 0 )); then
+  set +e
+  pocketshell_run_guarded_mutation pocketshell_scope_run "$SCOPE_UNIT" \
+    ./gradlew --no-daemon "$CONNECTED_TASK" \
+    "${GRADLE_INIT_ARGS[@]}" \
+    "${GRADLE_SUFFIX_ARGS[@]}" \
+    "${GRADLE_ARGS[@]}"
+  rc=$?
+  set -e
+fi
+
+if [[ "$DENY_NOTIFICATIONS_BEFORE_INSTRUMENTATION" == "1" && "$rc" == "0" ]]; then
+  set +e
+  notification_permission_validate_report "$notification_report_dir"
+  rc=$?
+  set -e
+fi
+
+if [[ "$DENY_NOTIFICATIONS_BEFORE_INSTRUMENTATION" == "1" \
+      && "$NOTIFICATION_PERMISSION_RESTORE_NEEDED" == "1" ]]; then
+  set +e
+  notification_permission_restore \
+    "$NOTIFICATION_PERMISSION_TARGET_PACKAGE" \
+    "$NOTIFICATION_PERMISSION_SCRATCH" \
+    "$NOTIFICATION_PERMISSION_TARGET_APK"
+  cleanup_rc=$?
+  set -e
+  NOTIFICATION_PERMISSION_RESTORE_NEEDED=0
+  if (( cleanup_rc != 0 )); then
+    printf 'NOTIFICATION_PERMISSION_PRIMARY_RC=%s CLEANUP_RC=%s\n' "$rc" "$cleanup_rc" >&2
+    if (( rc == 0 )); then
+      rc="$cleanup_rc"
+    fi
+  fi
+fi
+
 exit "$rc"

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -160,6 +160,7 @@ EXPECTED_FAIL_CLASSES=(
 # Run as a trimmed slice in its own phase; excluded from the journey phase so it
 # does not just self-skip there (the journey phase never passes the opt-in flag).
 BOOTSTRAP_TEST_CLASS="com.pocketshell.app.bootstrap.HostBootstrapScenarioSuiteTest"
+NOTIFICATION_PERMISSION_TEST_CLASS="com.pocketshell.app.notifications.NoNotificationPromptOnAppOpenE2eTest"
 
 # Trimmed but meaningful set of bootstrap scenarios (issue #667): the first-run
 # `ready` profile, the `uvInstall` first-install journey, and the
@@ -190,6 +191,7 @@ JOURNEY_EXCLUDED_CLASSES=(
   "$FQCN_PREFIX.LongRunningInstrumentationHeartbeatTest"
   "$FQCN_PREFIX.RealAgentReleaseGateTest"
   "$BOOTSTRAP_TEST_CLASS"
+  "$NOTIFICATION_PERMISSION_TEST_CLASS"
 )
 
 join_by() {
@@ -280,15 +282,51 @@ echo "phase 1 (journey/E2E) exit code: $JOURNEY_EXIT"
 # (issue #1293). Observability only — never affects JOURNEY_EXIT.
 preserve_phase_reports "phase1-journey" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
 
-# Default the aux phases to SKIPPED; only the shard that owns them flips these.
+# Default the dedicated/aux phases to SKIPPED; only shard 0 owns them.
+NOTIFICATION_PERMISSION_EXIT=0
 NETWORK_FAULT_EXIT=0
 BOOTSTRAP_EXIT=0
 EXPECTED_FAIL_EXIT=0
+notification_permission_status="SKIP"
+notification_permission_executed=0
 nf_status="SKIP"
 bootstrap_status="SKIP"
 expectedfail_status="SKIP"
 
 if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
+  echo "=========================================================="
+  echo "Nightly Extensive Tests — phase 1b: notification permission (NON-GATING)"
+  echo "Included class: $NOTIFICATION_PERMISSION_TEST_CLASS"
+  echo "  (dedicated unsharded invocation; external denied-permission fixture)"
+  echo "=========================================================="
+
+  notification_permission_log="$ARTIFACT_DIR/phase1b-notification-permission.log"
+  "$REPO_ROOT/scripts/connected-test.sh" --no-pool \
+    --deny-notifications-before-instrumentation \
+    -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+    -Pandroid.testInstrumentationRunnerArguments.timeout_msec=300000 \
+    -Pandroid.testInstrumentationRunnerArguments.class="$NOTIFICATION_PERMISSION_TEST_CLASS" \
+    --stacktrace 2>&1 | tee "$notification_permission_log"
+  NOTIFICATION_PERMISSION_EXIT=${PIPESTATUS[0]}
+  notification_permission_executed="$(
+    sed -n 's/^NOTIFICATION_PERMISSION_TEST_RESULT executed=\([0-9][0-9]*\) .*/\1/p' \
+      "$notification_permission_log" | tail -1
+  )"
+  notification_permission_executed="${notification_permission_executed:-0}"
+  echo "phase 1b (notification permission) exit code: $NOTIFICATION_PERMISSION_EXIT"
+  echo "phase 1b (notification permission) executed tests: $notification_permission_executed"
+
+  # Snapshot before phase 2 overwrites the connected-test report. The wrapper
+  # itself hard-fails zero tests, skips, failures, a missing named method, or a
+  # runner crash, so this copy is always a non-vacuous report on green.
+  preserve_phase_reports \
+    "phase1b-notification-permission" \
+    "$APP_BUILD_DIR" \
+    "$PHASE_REPORTS_DIR"
+
+  notification_permission_status="PASS"
+  [[ "$NOTIFICATION_PERMISSION_EXIT" -ne 0 ]] && notification_permission_status="FAIL"
+
   echo "=========================================================="
   echo "Nightly Extensive Tests — phase 2: network-fault proofs (un-gated, GATING)"
   echo "Included classes: $NETWORK_FAULT_CLASS_ARG"
@@ -382,8 +420,8 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   echo "----------------------------------------------------------"
 else
   echo "=========================================================="
-  echo "Nightly Extensive Tests — phases 2, 2b & 3 SKIPPED on shard ${SHARD_INDEX:-0}"
-  echo "  (network-fault + expected-fail + bootstrap run once, on shard 0)"
+  echo "Nightly Extensive Tests — phases 1b, 2, 2b & 3 SKIPPED on shard ${SHARD_INDEX:-0}"
+  echo "  (notification + network-fault + expected-fail + bootstrap run once, on shard 0)"
   echo "=========================================================="
 fi
 
@@ -396,7 +434,10 @@ journey_status="PASS"
 # make the shard summary permanently red for a non-reason. Note: `overall_status`
 # is NOT the release-gating signal; the machine-readable fault verdict above is.
 overall_status="PASS"
-if [[ "$JOURNEY_EXIT" -ne 0 || "$NETWORK_FAULT_EXIT" -ne 0 || "$BOOTSTRAP_EXIT" -ne 0 ]]; then
+if [[ "$JOURNEY_EXIT" -ne 0 \
+      || "$NOTIFICATION_PERMISSION_EXIT" -ne 0 \
+      || "$NETWORK_FAULT_EXIT" -ne 0 \
+      || "$BOOTSTRAP_EXIT" -ne 0 ]]; then
   overall_status="FAIL"
 fi
 
@@ -414,6 +455,7 @@ fi
   echo "| Phase | Selection | Args | Exit | Result |"
   echo "| --- | --- | --- | --- | --- |"
   echo "| Journey / E2E (non-gating) | full connected suite minus network-fault + expected-fail + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** |"
+  echo "| Notification permission (NON-GATING) | dedicated unsharded $NOTIFICATION_PERMISSION_TEST_CLASS; executed=$notification_permission_executed | external revoke/verify before instrumentation; external grant/verify after | $NOTIFICATION_PERMISSION_EXIT | **$notification_permission_status** |"
   echo "| Network-fault proofs (GATING) | ${#NETWORK_FAULT_CLASSES[@]} NetworkFaultProofBase classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** |"
   echo "| #822 expected-fail lane (NON-GATING) | ${#EXPECTED_FAIL_CLASSES[@]} Slice C/D TDD spec class(es) | \`pocketshellNetworkFaultProofs=true\` | $EXPECTED_FAIL_EXIT | **$expectedfail_status** |"
   echo "| Bootstrap setup scenarios (GATING) | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** |"

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -211,9 +211,19 @@ exit 0
 STUB
 chmod +x "$SANDBOX/gradlew"
 
-# The suite shells out to `scripts/connected-test.sh` only on the --pool sharded
-# path (not exercised here) and to `adb` near the top. Stub `adb` on PATH so the
-# top-of-script `settings put` loop is a harmless no-op.
+# The suite shells out to `scripts/connected-test.sh` for the --pool sharded
+# path and for #1741's dedicated external-permission fixture in serial mode.
+# Forward both sandbox paths into the same stub Gradle so the existing timeout /
+# daemon-cleanup mutations still govern every selected class.
+cat > "$SANDBOX/scripts/connected-test.sh" <<'STUB'
+#!/usr/bin/env bash
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$root_dir/gradlew" :app:connectedDebugAndroidTest "$@"
+STUB
+chmod +x "$SANDBOX/scripts/connected-test.sh"
+
+# Stub `adb` on PATH so the top-of-script `settings put` loop is a harmless
+# no-op.
 STUBBIN="$SANDBOX/stubbin"
 mkdir -p "$STUBBIN"
 cat > "$STUBBIN/adb" <<'STUB'

--- a/scripts/test-notification-permission-fixture.sh
+++ b/scripts/test-notification-permission-fixture.sh
@@ -1,0 +1,740 @@
+#!/usr/bin/env bash
+# Issue #1741: fast, emulator-free contract test for the external
+# POST_NOTIFICATIONS connected-test fixture and its per-push/nightly wiring.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REAL_CONNECTED="$SCRIPT_DIR/connected-test.sh"
+REAL_BUDGET_HELPER="$SCRIPT_DIR/ci-journey-budget-functions.sh"
+REAL_NIGHTLY="$SCRIPT_DIR/nightly-extensive-suite.sh"
+NOTIFICATION_CLASS="com.pocketshell.app.notifications.NoNotificationPromptOnAppOpenE2eTest"
+NOTIFICATION_METHOD="appOpenDoesNotPopNotificationPermissionDialog"
+
+fail() {
+  echo "TEST FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "  ok: $*"
+}
+
+for required in "$REAL_CONNECTED" "$REAL_BUDGET_HELPER" "$REAL_NIGHTLY"; do
+  [[ -f "$required" ]] || fail "missing required source: $required"
+done
+grep -q 'shell dumpsys package "$target_package"' "$REAL_CONNECTED" \
+  || fail "permission-state verification must use Android's supported dumpsys package oracle"
+if grep -q 'pm check-permission' "$REAL_CONNECTED"; then
+  fail "unsupported pm check-permission command must not be used"
+fi
+
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_ROOT"' EXIT
+mkdir -p "$FIXTURE_ROOT/repo/scripts/lib" "$FIXTURE_ROOT/stubbin" "$FIXTURE_ROOT/state"
+cp "$REAL_CONNECTED" "$FIXTURE_ROOT/repo/scripts/connected-test.sh"
+cp "$SCRIPT_DIR/lib/avd-lock.sh" "$FIXTURE_ROOT/repo/scripts/lib/avd-lock.sh"
+cp "$SCRIPT_DIR/lib/agents-pool.sh" "$FIXTURE_ROOT/repo/scripts/lib/agents-pool.sh"
+cp "$SCRIPT_DIR/lib/scope-run.sh" "$FIXTURE_ROOT/repo/scripts/lib/scope-run.sh"
+chmod +x "$FIXTURE_ROOT/repo/scripts/connected-test.sh"
+
+# Keep the fixture out of the host's user systemd while exercising the real
+# wrapper. scope-run will take its explicit test-only bare fallback.
+printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$FIXTURE_ROOT/stubbin/systemctl"
+chmod +x "$FIXTURE_ROOT/stubbin/systemctl"
+
+# Fake adb models exactly one API-35 emulator and records every permission
+# transition. It deliberately preserves runtime grants across the fake
+# installDebug, matching adb install -r.
+cat > "$FIXTURE_ROOT/stubbin/adb" <<'ADB_STUB'
+#!/usr/bin/env bash
+set -u
+state_dir="${NOTIFICATION_FIXTURE_STATE:?}"
+if [[ "${1:-}" == "-s" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "install" && "${2:-}" == "-r" ]]; then
+  package="$(cat "$state_dir/last-package" 2>/dev/null || true)"
+  [[ -n "$package" ]] || exit 43
+  printf 'adb:install:%s\n' "$package" >> "$state_dir/events.log"
+  : > "$state_dir/installed-$package"
+  exit 0
+fi
+[[ "${1:-}" == "shell" ]] && shift
+
+case "${1:-} ${2:-} ${3:-}" in
+  "pm list packages"*)
+    exit 0
+    ;;
+  "getprop ro.build.version.sdk "*)
+    printf '%s\n' "${ADB_FIXTURE_SDK:-35}"
+    exit 0
+    ;;
+  "pm path "*)
+    package="${3:-}"
+    printf 'adb:pm-path:%s\n' "$package" >> "$state_dir/events.log"
+    if [[ -f "$state_dir/installed-$package" ]]; then
+      printf 'package:/data/app/%s/base.apk\n' "$package"
+    fi
+    exit 0
+    ;;
+  "pm revoke "*)
+    package="${3:-}"
+    permission="${4:-}"
+    printf 'adb:revoke:%s:%s\n' "$package" "$permission" >> "$state_dir/events.log"
+    [[ "${ADB_FIXTURE_FAIL_REVOKE:-0}" == "1" ]] && exit 41
+    if [[ "${ADB_FIXTURE_REVOKE_DRIFT:-0}" != "1" ]]; then
+      printf 'denied\n' > "$state_dir/permission-$package"
+    fi
+    exit 0
+    ;;
+  "pm grant "*)
+    package="${3:-}"
+    permission="${4:-}"
+    printf 'adb:grant:%s:%s\n' "$package" "$permission" >> "$state_dir/events.log"
+    [[ "${ADB_FIXTURE_FAIL_GRANT:-0}" == "1" ]] && exit 42
+    # Drift models the real Android hazard the failing-exit case cannot: pm
+    # grant reports success while the runtime state stays denied.
+    if [[ "${ADB_FIXTURE_GRANT_DRIFT:-0}" != "1" ]]; then
+      printf 'granted\n' > "$state_dir/permission-$package"
+    fi
+    exit 0
+    ;;
+  "dumpsys package "*)
+    package="${3:-}"
+    state="$(cat "$state_dir/permission-$package" 2>/dev/null || printf 'denied')"
+    printf 'adb:state:%s:android.permission.POST_NOTIFICATIONS:%s\n' "$package" "$state" \
+      >> "$state_dir/events.log"
+    granted=false
+    [[ "$state" == "granted" ]] && granted=true
+    printf '      runtime permissions:\n'
+    printf '        android.permission.POST_NOTIFICATIONS: granted=%s, flags=[ USER_SENSITIVE_WHEN_GRANTED|USER_SENSITIVE_WHEN_DENIED]\n' \
+      "$granted"
+    exit 0
+    ;;
+esac
+
+if [[ "${1:-}" == "uninstall" ]]; then
+  exit 0
+fi
+printf 'unexpected adb args: %s\n' "$*" >&2
+exit 90
+ADB_STUB
+chmod +x "$FIXTURE_ROOT/stubbin/adb"
+
+# Fake Gradle distinguishes the pre-instrumentation install from the runner.
+# The connected leg refuses to run unless adb already recorded DENIED, then
+# writes the same report shape the real wrapper validates.
+cat > "$FIXTURE_ROOT/repo/gradlew" <<'GRADLE_STUB'
+#!/usr/bin/env bash
+set -u
+state_dir="${NOTIFICATION_FIXTURE_STATE:?}"
+package="com.pocketshell.app"
+for arg in "$@"; do
+  case "$arg" in
+    -PpocketshellAppIdSuffix=*)
+      package="com.pocketshell.app.${arg#*=}"
+      ;;
+  esac
+done
+
+if [[ "$*" == *":app:installDebug"* ]]; then
+  permission="$(cat "$state_dir/permission-$package" 2>/dev/null || printf 'denied')"
+  printf 'gradle:install:%s:permission=%s\n' "$package" "$permission" \
+    >> "$state_dir/events.log"
+  if [[ "${GRADLE_FIXTURE_BEHAVIOR:-pass}" != "missing-package" ]]; then
+    : > "$state_dir/installed-$package"
+    printf '%s\n' "$package" > "$state_dir/last-package"
+    mkdir -p "$PWD/app/build/outputs/apk/debug"
+    printf 'fixture apk for %s\n' "$package" > "$PWD/app/build/outputs/apk/debug/app-debug.apk"
+  fi
+  exit "${GRADLE_FIXTURE_INSTALL_RC:-0}"
+fi
+
+if [[ "$*" == *":app:connectedDebugAndroidTest"* ]]; then
+  permission="$(cat "$state_dir/permission-$package" 2>/dev/null || printf 'missing')"
+  printf 'gradle:connected:%s:permission=%s\n' "$package" "$permission" \
+    >> "$state_dir/events.log"
+  [[ "$permission" == "denied" ]] || exit 91
+  # AGP removes the target APK when connectedDebugAndroidTest completes. Model
+  # that real lifecycle so cleanup must reinstall before restoring the grant.
+  rm -f "$state_dir/installed-$package"
+  report_dir="$PWD/app/build/outputs/androidTest-results/connected/fixture"
+  mkdir -p "$report_dir"
+  case "${GRADLE_FIXTURE_BEHAVIOR:-pass}" in
+    pass)
+      cat > "$report_dir/TEST-notification.xml" <<XML
+<testsuite name="$NOTIFICATION_FIXTURE_CLASS" tests="1" skipped="0" failures="0" errors="0">
+  <testcase classname="$NOTIFICATION_FIXTURE_CLASS" name="$NOTIFICATION_FIXTURE_METHOD"/>
+</testsuite>
+XML
+      exit 0
+      ;;
+    runner-kill)
+      printf '<testsuite name="runner" tests="0" skipped="0" failures="1" errors="0"><failure/></testsuite>\n' \
+        > "$report_dir/TEST-notification.xml"
+      exit 137
+      ;;
+    zero-tests)
+      printf '<testsuite name="empty" tests="0" skipped="0" failures="0" errors="0"/>\n' \
+        > "$report_dir/TEST-notification.xml"
+      exit 0
+      ;;
+    test-failure)
+      cat > "$report_dir/TEST-notification.xml" <<XML
+<testsuite name="$NOTIFICATION_FIXTURE_CLASS" tests="1" skipped="0" failures="1" errors="0">
+  <testcase classname="$NOTIFICATION_FIXTURE_CLASS" name="$NOTIFICATION_FIXTURE_METHOD"><failure/></testcase>
+</testsuite>
+XML
+      exit 1
+      ;;
+    self-skip)
+      # One executed + one self-skipped test still yields executed=1. The
+      # no-self-skip policy must reject it on the skip count alone.
+      cat > "$report_dir/TEST-notification.xml" <<XML
+<testsuite name="$NOTIFICATION_FIXTURE_CLASS" tests="2" skipped="1" failures="0" errors="0">
+  <testcase classname="$NOTIFICATION_FIXTURE_CLASS" name="$NOTIFICATION_FIXTURE_METHOD"/>
+  <testcase classname="$NOTIFICATION_FIXTURE_CLASS" name="someAssumptionSkippedCase"><skipped/></testcase>
+</testsuite>
+XML
+      exit 0
+      ;;
+    no-report)
+      # The runner produced NO report at all and still exited zero. Any earlier
+      # invocation's XML left on disk must not be borrowed as this run's result.
+      exit 0
+      ;;
+    wrong-class)
+      # A foreign class's green report must never satisfy this dedicated
+      # invocation, even with a perfectly non-vacuous executed count.
+      cat > "$report_dir/TEST-notification.xml" <<XML
+<testsuite name="com.pocketshell.app.proof.SomeOtherE2eTest" tests="1" skipped="0" failures="0" errors="0">
+  <testcase classname="com.pocketshell.app.proof.SomeOtherE2eTest" name="someOtherJourney"/>
+</testsuite>
+XML
+      exit 0
+      ;;
+  esac
+fi
+
+printf 'unexpected gradle args: %s\n' "$*" >&2
+exit 92
+GRADLE_STUB
+chmod +x "$FIXTURE_ROOT/repo/gradlew"
+
+line_number() {
+  local needle="$1"
+  local file="$2"
+  grep -nF "$needle" "$file" | head -1 | cut -d: -f1
+}
+
+assert_order() {
+  local file="$1"
+  shift
+  local previous=0 needle current
+  for needle in "$@"; do
+    current="$(line_number "$needle" "$file")"
+    [[ "$current" =~ ^[0-9]+$ ]] \
+      || fail "missing ordering event '$needle' in $file"
+    (( current > previous )) \
+      || fail "event '$needle' occurred out of order in $file"
+    previous="$current"
+  done
+}
+
+run_fixture() {
+  local label="$1"
+  local suffix="$2"
+  local behavior="$3"
+  local initial_permission="$4"
+  local fail_revoke="${5:-0}"
+  local fail_grant="${6:-0}"
+  local revoke_drift="${7:-0}"
+  local sdk="${8:-35}"
+  local grant_drift="${9:-0}"
+  local package="com.pocketshell.app${suffix:+.$suffix}"
+  local output="$FIXTURE_ROOT/$label.log"
+  local -a suffix_args=()
+  [[ -n "$suffix" ]] && suffix_args=(--suffix "$suffix")
+
+  rm -rf "$FIXTURE_ROOT/state"
+  mkdir -p "$FIXTURE_ROOT/state"
+  printf '%s\n' "$initial_permission" > "$FIXTURE_ROOT/state/permission-$package"
+
+  set +e
+  (
+    cd "$FIXTURE_ROOT/repo" || exit 99
+    PATH="$FIXTURE_ROOT/stubbin:$PATH" \
+      ADB="$FIXTURE_ROOT/stubbin/adb" \
+      ANDROID_SERIAL="emulator-1741" \
+      POCKETSHELL_AVD_LOCK_DIR="$FIXTURE_ROOT/locks" \
+      POCKETSHELL_SCOPE_ALLOW_BARE=1 \
+      NOTIFICATION_FIXTURE_STATE="$FIXTURE_ROOT/state" \
+      NOTIFICATION_FIXTURE_CLASS="$NOTIFICATION_CLASS" \
+      NOTIFICATION_FIXTURE_METHOD="$NOTIFICATION_METHOD" \
+      GRADLE_FIXTURE_BEHAVIOR="$behavior" \
+      ADB_FIXTURE_FAIL_REVOKE="$fail_revoke" \
+      ADB_FIXTURE_FAIL_GRANT="$fail_grant" \
+      ADB_FIXTURE_REVOKE_DRIFT="$revoke_drift" \
+      ADB_FIXTURE_GRANT_DRIFT="$grant_drift" \
+      ADB_FIXTURE_SDK="$sdk" \
+      scripts/connected-test.sh --no-pool "${suffix_args[@]}" \
+        --deny-notifications-before-instrumentation \
+        -Pandroid.testInstrumentationRunnerArguments.class="$NOTIFICATION_CLASS"
+  ) > "$output" 2>&1
+  FIXTURE_RC=$?
+  set -e
+  FIXTURE_PACKAGE="$package"
+  FIXTURE_OUTPUT="$output"
+}
+
+# Argument-contract probe. These invocations are rejected during flag validation,
+# before any lock/adb/Gradle work, so they need no device state.
+run_fixture_args() {
+  local label="$1"
+  shift
+  local output="$FIXTURE_ROOT/args-$label.log"
+  rm -rf "$FIXTURE_ROOT/state"
+  mkdir -p "$FIXTURE_ROOT/state"
+  set +e
+  (
+    cd "$FIXTURE_ROOT/repo" || exit 99
+    PATH="$FIXTURE_ROOT/stubbin:$PATH" \
+      ADB="$FIXTURE_ROOT/stubbin/adb" \
+      ANDROID_SERIAL="emulator-1741" \
+      POCKETSHELL_AVD_LOCK_DIR="$FIXTURE_ROOT/locks" \
+      POCKETSHELL_SCOPE_ALLOW_BARE=1 \
+      NOTIFICATION_FIXTURE_STATE="$FIXTURE_ROOT/state" \
+      NOTIFICATION_FIXTURE_CLASS="$NOTIFICATION_CLASS" \
+      NOTIFICATION_FIXTURE_METHOD="$NOTIFICATION_METHOD" \
+      scripts/connected-test.sh --no-pool "$@"
+  ) > "$output" 2>&1
+  FIXTURE_RC=$?
+  set -e
+  FIXTURE_OUTPUT="$output"
+}
+
+echo "== External fixture: granted base package -> denied runner -> restored grant =="
+run_fixture base-pass "" pass granted
+[[ "$FIXTURE_RC" -eq 0 ]] || { cat "$FIXTURE_OUTPUT"; fail "base fixture exited $FIXTURE_RC"; }
+[[ "$(cat "$FIXTURE_ROOT/state/permission-$FIXTURE_PACKAGE")" == "granted" ]] \
+  || fail "base package grant was not restored"
+assert_order "$FIXTURE_ROOT/state/events.log" \
+  "gradle:install:$FIXTURE_PACKAGE:permission=granted" \
+  "adb:revoke:$FIXTURE_PACKAGE:android.permission.POST_NOTIFICATIONS" \
+  "adb:state:$FIXTURE_PACKAGE:android.permission.POST_NOTIFICATIONS:denied" \
+  "gradle:connected:$FIXTURE_PACKAGE:permission=denied" \
+  "adb:install:$FIXTURE_PACKAGE" \
+  "adb:grant:$FIXTURE_PACKAGE:android.permission.POST_NOTIFICATIONS" \
+  "adb:state:$FIXTURE_PACKAGE:android.permission.POST_NOTIFICATIONS:granted"
+grep -q '^NOTIFICATION_PERMISSION_TEST_RESULT executed=1 skipped=0 failures=0 errors=0 ' \
+  "$FIXTURE_OUTPUT" || fail "base pass did not report one named executed test"
+pass "grant-first -> external revoke -> alive runner -> named 1/1 result -> external restore"
+
+echo "== External fixture: exact suffixed package and repeated order isolation =="
+run_fixture suffix-pass i1741 pass granted
+[[ "$FIXTURE_RC" -eq 0 ]] || { cat "$FIXTURE_OUTPUT"; fail "suffix fixture exited $FIXTURE_RC"; }
+[[ "$FIXTURE_PACKAGE" == "com.pocketshell.app.i1741" ]] \
+  || fail "suffix package resolution drifted: $FIXTURE_PACKAGE"
+grep -q "gradle:connected:com.pocketshell.app.i1741:permission=denied" \
+  "$FIXTURE_ROOT/state/events.log" || fail "suffixed runner did not see denied permission"
+[[ "$(cat "$FIXTURE_ROOT/state/permission-$FIXTURE_PACKAGE")" == "granted" ]] \
+  || fail "suffixed package grant was not restored for the following grant-first class"
+run_fixture repeated i1741 pass granted
+[[ "$FIXTURE_RC" -eq 0 ]] || { cat "$FIXTURE_OUTPUT"; fail "repeated fixture exited $FIXTURE_RC"; }
+pass "base/suffix identity, notification -> grant-first cleanup, and repeated invocation are isolated"
+
+echo "== External fixture: already-denied state remains non-vacuous =="
+run_fixture already-denied "" pass denied
+[[ "$FIXTURE_RC" -eq 0 ]] || { cat "$FIXTURE_OUTPUT"; fail "already-denied fixture exited $FIXTURE_RC"; }
+grep -q "gradle:connected:$FIXTURE_PACKAGE:permission=denied" \
+  "$FIXTURE_ROOT/state/events.log" || fail "already-denied case never ran instrumentation"
+pass "already-denied package still executes the real named test and restores grant"
+
+echo "== Failure controls: revoke/drift/API/package/runner/count/cleanup all hard-red =="
+run_fixture revoke-fails "" pass granted 1
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "failed revoke became green"
+if grep -q 'gradle:connected:' "$FIXTURE_ROOT/state/events.log"; then
+  fail "runner started after failed external revoke"
+fi
+[[ "$(cat "$FIXTURE_ROOT/state/permission-$FIXTURE_PACKAGE")" == "granted" ]] \
+  || fail "failed-revoke path did not run external cleanup"
+
+run_fixture denied-drift "" pass granted 0 0 1
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "granted precondition drift became green"
+if grep -q 'gradle:connected:' "$FIXTURE_ROOT/state/events.log"; then
+  fail "runner started while permission verification still said granted"
+fi
+
+run_fixture api-too-old "" pass granted 0 0 0 32
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "API <33 became green"
+
+run_fixture missing-package "" missing-package granted
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "missing installed target became green"
+grep -q 'is not installed before permission revoke' "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "missing target was not rejected by the pre-revoke installed check"; }
+if grep -q 'adb:revoke:' "$FIXTURE_ROOT/state/events.log"; then
+  fail "permission revoke was attempted against a package that is not installed"
+fi
+
+run_fixture runner-kill "" runner-kill granted
+[[ "$FIXTURE_RC" -eq 137 ]] \
+  || { cat "$FIXTURE_OUTPUT"; fail "runner signal-9 rc was not preserved (got $FIXTURE_RC)"; }
+[[ "$(cat "$FIXTURE_ROOT/state/permission-$FIXTURE_PACKAGE")" == "granted" ]] \
+  || fail "runner-kill path did not restore grant"
+
+run_fixture assertion-failure "" test-failure granted
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "instrumentation assertion failure became green"
+[[ "$(cat "$FIXTURE_ROOT/state/permission-$FIXTURE_PACKAGE")" == "granted" ]] \
+  || fail "ordinary failed-test path did not restore grant"
+
+run_fixture zero-tests "" zero-tests granted
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "zero-test XML became green"
+grep -q 'must execute exactly one test' "$FIXTURE_OUTPUT" \
+  || fail "zero-test failure did not explain its non-vacuous verdict"
+
+run_fixture cleanup-fails "" pass granted 0 1
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "cleanup failure masked a passing primary run"
+grep -q 'NOTIFICATION_PERMISSION_PRIMARY_RC=0 CLEANUP_RC=' "$FIXTURE_OUTPUT" \
+  || fail "cleanup failure did not preserve/report primary versus cleanup status"
+
+# Restore drift: pm grant exits zero while the runtime state stays denied. A
+# silently-unrestored grant would leave the next grant-first journey class on a
+# revoked permission, so verification after restore must be load-bearing.
+run_fixture restore-drift "" pass granted 0 0 0 35 1
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "silently unrestored grant became green"
+grep -q 'was not restored for' "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "restore drift was not caught by post-grant verification"; }
+pass "all wrong-state, killed-runner, zero-test, restore-drift, and cleanup mutations are hard-red"
+
+# Report identity: a dedicated invocation may never be satisfied by a foreign
+# class's green XML, nor borrow a previous invocation's report when this runner
+# produced none. Both are the exact vacuous-pass shapes issue #1741 exists to
+# stop, so they are proven against a real prior passing report on disk.
+echo "== Report identity: no borrowed prior XML, no foreign-class XML =="
+run_fixture stale-seed "" pass granted
+[[ "$FIXTURE_RC" -eq 0 ]] || { cat "$FIXTURE_OUTPUT"; fail "stale-seed fixture exited $FIXTURE_RC"; }
+run_fixture stale-reuse "" no-report granted
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "a reportless runner borrowed the previous invocation's XML"
+grep -q 'must execute exactly one test (xml=0' "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "stale report directory was not cleared before instrumentation"; }
+
+run_fixture self-skip "" self-skip granted
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "a self-skipped test rode along with the executed one"
+grep -q 'skipped 1 test(s); no-self-skip policy requires zero' "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "no-self-skip policy was not enforced on the skip count"; }
+
+run_fixture wrong-class "" wrong-class granted
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "a foreign class's green report satisfied the dedicated invocation"
+grep -q "did not contain $NOTIFICATION_CLASS#$NOTIFICATION_METHOD" "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "foreign-class report was not rejected by named-method identity"; }
+pass "reportless and foreign-class runs are hard-red; only the named test counts"
+
+# The fixture is only ever legitimate as ONE dedicated, unsharded, app-module
+# invocation of the notification class. Every other shape must be refused before
+# any permission is touched, so a sharded caller can never silently reintroduce
+# the grant-first ordering contamination this issue exists to remove.
+#
+# `run_fixture_args` resets the device-state dir per probe, so the
+# "no permission was touched" property must be asserted after EACH probe. A
+# single trailing check only ever saw the LAST probe's state, which let a
+# rejection that had been relocated to AFTER the revoke survive on any earlier
+# probe — the same "assertion whose text is broader than what it constrains"
+# shape as the nightly pins below.
+echo "== Argument contract: dedicated, unsharded, app-module, notification-only =="
+
+assert_probe_touched_no_permission() {
+  local label="$1"
+  local events="$FIXTURE_ROOT/state/events.log"
+  if grep -q 'adb:revoke:' "$events" 2>/dev/null; then
+    tr '\n' ' ' < "$events" >&2
+    echo >&2
+    fail "rejected fixture invocation '$label' still mutated the notification permission"
+  fi
+}
+
+run_fixture_args sharded --deny-notifications-before-instrumentation \
+  -Pandroid.testInstrumentationRunnerArguments.class="$NOTIFICATION_CLASS" \
+  -Pandroid.testInstrumentationRunnerArguments.numShards=3
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "sharded notification invocation was accepted"
+grep -q 'must be a dedicated unsharded invocation' "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "numShards was not rejected by the dedicated-invocation contract"; }
+assert_probe_touched_no_permission sharded
+
+run_fixture_args shard-index --deny-notifications-before-instrumentation \
+  -Pandroid.testInstrumentationRunnerArguments.class="$NOTIFICATION_CLASS" \
+  -Pandroid.testInstrumentationRunnerArguments.shardIndex=1
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "shardIndex notification invocation was accepted"
+grep -q 'must be a dedicated unsharded invocation' "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "shardIndex was not rejected by the dedicated-invocation contract"; }
+assert_probe_touched_no_permission shard-index
+
+run_fixture_args unfiltered --deny-notifications-before-instrumentation
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "unfiltered whole-suite notification fixture was accepted"
+grep -q "requires dedicated class=$NOTIFICATION_CLASS" "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "fixture did not require the dedicated notification class"; }
+assert_probe_touched_no_permission unfiltered
+
+run_fixture_args wrong-module --module shared:core-ssh \
+  --deny-notifications-before-instrumentation \
+  -Pandroid.testInstrumentationRunnerArguments.class="$NOTIFICATION_CLASS"
+[[ "$FIXTURE_RC" -ne 0 ]] || fail "non-app module notification fixture was accepted"
+grep -q 'valid only for the app module' "$FIXTURE_OUTPUT" \
+  || { cat "$FIXTURE_OUTPUT"; fail "fixture did not reject a non-app module"; }
+assert_probe_touched_no_permission wrong-module
+pass "sharded, unfiltered, and non-app invocations are refused before any permission changes"
+
+# Per-push dynamic wiring: source the real helper, but replace its bounded
+# executor with a direct call into tiny command stubs. This proves both serial
+# run_class and suffixed shard_class select the canonical flag only for #1741.
+echo "== Per-push wiring: run_class and shard_class use the canonical fixture =="
+WIRE_ROOT="$FIXTURE_ROOT/wire"
+mkdir -p "$WIRE_ROOT/scripts"
+cat > "$WIRE_ROOT/scripts/connected-test.sh" <<'WIRE_CONNECTED'
+#!/usr/bin/env bash
+printf 'connected:%s\n' "$*" >> "${WIRE_LOG:?}"
+exit 0
+WIRE_CONNECTED
+cat > "$WIRE_ROOT/gradlew" <<'WIRE_GRADLE'
+#!/usr/bin/env bash
+printf 'gradle:%s\n' "$*" >> "${WIRE_LOG:?}"
+exit 0
+WIRE_GRADLE
+chmod +x "$WIRE_ROOT/scripts/connected-test.sh" "$WIRE_ROOT/gradlew"
+
+# shellcheck source=scripts/ci-journey-budget-functions.sh
+source "$REAL_BUDGET_HELPER"
+run_bounded() {
+  shift
+  "$@"
+}
+cleanup_gradle_after_timeout() {
+  return 0
+}
+# Issue #1458 added a fail-closed per-attempt artifact lifecycle around
+# run_class. This focused #1741 wiring probe owns only command selection, so
+# replace that orthogonal lifecycle with explicit no-op stubs; the complete
+# journey-budget guard exercises the real artifact setup/snapshot/finalization.
+begin_class_attempt_artifacts() {
+  LAST_RUN_CLASS_ATTEMPT_DIR="$WIRE_ROOT/attempt"
+  mkdir -p "$LAST_RUN_CLASS_ATTEMPT_DIR"
+  : > "$LAST_RUN_CLASS_ATTEMPT_DIR/attempt.log"
+}
+snapshot_connected_test_outputs() {
+  return 0
+}
+finalize_class_attempt_manifest() {
+  return 0
+}
+REPO_ROOT="$WIRE_ROOT"
+GRADLEW="$WIRE_ROOT/gradlew"
+SUITE_START=$SECONDS
+JOURNEY_STEP_BUDGET_SECS=600
+JOURNEY_CLASS_TIMEOUT_SECS=60
+JOURNEY_NO_OUTPUT_TIMEOUT_SECS=60
+JOURNEY_CLASS_KILL_AFTER_SECS=1
+JOURNEY_GRADLE_STOP_TIMEOUT_SECS=1
+WIRE_LOG="$WIRE_ROOT/wire.log"
+export WIRE_LOG
+: > "$WIRE_LOG"
+run_class "$NOTIFICATION_CLASS" || fail "notification run_class stub failed"
+run_class "com.pocketshell.app.proof.SomeOtherE2eTest" || fail "ordinary run_class stub failed"
+shard_class 7 "$NOTIFICATION_CLASS" || fail "notification shard_class stub failed"
+shard_class 8 "com.pocketshell.app.proof.SomeOtherE2eTest" || fail "ordinary shard_class stub failed"
+
+notification_flag_count="$(grep -c 'deny-notifications-before-instrumentation' "$WIRE_LOG" || true)"
+[[ "$notification_flag_count" -eq 2 ]] \
+  || { cat "$WIRE_LOG"; fail "expected fixture flag exactly twice (serial + shard), got $notification_flag_count"; }
+grep -q "connected:--no-pool --deny-notifications-before-instrumentation .*class=$NOTIFICATION_CLASS" \
+  "$WIRE_LOG" || { cat "$WIRE_LOG"; fail "serial notification class bypassed connected-test fixture"; }
+grep -q "connected:--pool --suffix ij7 --deny-notifications-before-instrumentation .*class=$NOTIFICATION_CLASS" \
+  "$WIRE_LOG" || { cat "$WIRE_LOG"; fail "suffixed shard notification class bypassed fixture"; }
+grep -q 'gradle::app:connectedDebugAndroidTest .*class=com.pocketshell.app.proof.SomeOtherE2eTest' \
+  "$WIRE_LOG" || { cat "$WIRE_LOG"; fail "ordinary serial class no longer uses daemon-reused Gradle path"; }
+pass "serial and suffixed per-push paths select the fixture without changing ordinary classes"
+
+# Nightly structural contract: class excluded from the bulk shard, dedicated on
+# shard-0/aux only, unsharded, report-preserved, count-visible, human-red, and
+# absent from the release fault-verdict inputs.
+#
+# ANCHORING RULE (issue #1741 review round 2). Unlike the sections above — which
+# EXECUTE the real connected-test wrapper against a fixture and therefore assert
+# behaviour — the nightly contract can only be asserted structurally, by reading
+# `scripts/nightly-extensive-suite.sh`. A structural assertion is only worth its
+# message if deleting the behaviour it names makes it RED, and a bare
+# `grep -q '<token>' "$REAL_NIGHTLY"` does NOT satisfy that: the same token
+# reliably occurs on some other line (a log filename carrying the report slug, a
+# `-P...class=` argument carrying the class variable, an `echo` interpolating the
+# count variable), so the behaviour can be deleted while the guard stays green.
+# Every pin below is therefore anchored to the code construct that OWNS the
+# behaviour, in one of two ways:
+#   1. block-scoped  — `sed`-extract the array / phase / conditional that owns
+#      it and assert inside that extract only, with a non-vacuous extraction
+#      check so an empty extract can never satisfy a negative assertion; or
+#   2. whole-statement — assert against the complete command, after joining
+#      backslash continuations, so a fragment shared with an unrelated line
+#      cannot match.
+# Both forms anchor with `^[[:space:]]*` ... `$` or match a full statement, which
+# also excludes comment lines that merely mention the construct.
+echo "== Nightly phase-1b isolation and verdict wiring =="
+
+# Join backslash-continued lines so a multi-line command can be pinned as ONE
+# statement instead of as a fragment.
+nightly_joined="$FIXTURE_ROOT/nightly-joined.sh"
+awk '{
+  line = $0
+  while (sub(/[[:space:]]*\\$/, "", line) > 0) {
+    if ((getline nextline) <= 0) break
+    sub(/^[[:space:]]+/, "", nextline)
+    line = line " " nextline
+  }
+  print line
+}' "$REAL_NIGHTLY" > "$nightly_joined"
+[[ -s "$nightly_joined" ]] \
+  || fail "could not normalise line continuations in $REAL_NIGHTLY"
+
+# Assert that ONE joined statement carries a required token, so the token can
+# never be satisfied by a different line elsewhere in the same file.
+assert_statement_contains() {
+  local statement="$1" token="$2" message="$3"
+  case "$statement" in
+    *"$token"*) return 0 ;;
+  esac
+  printf '%s\n' "$statement" >&2
+  fail "$message (missing: $token)"
+}
+
+# Bulk-phase isolation — the ordering contamination this issue exists to remove.
+# Scoped to the JOURNEY_EXCLUDED_CLASSES array literal: the entry must be an
+# array element, NOT the `-P...class="$NOTIFICATION_PERMISSION_TEST_CLASS"`
+# argument of the dedicated phase-1b invocation, which carries the same token.
+journey_excluded_block="$FIXTURE_ROOT/journey-excluded-classes.txt"
+sed -n '/^JOURNEY_EXCLUDED_CLASSES=(/,/^)$/p' "$REAL_NIGHTLY" \
+  > "$journey_excluded_block"
+grep -q '^JOURNEY_EXCLUDED_CLASSES=($' "$journey_excluded_block" \
+  || fail "could not extract the nightly JOURNEY_EXCLUDED_CLASSES array literal"
+grep -q '^)$' "$journey_excluded_block" \
+  || fail "nightly JOURNEY_EXCLUDED_CLASSES array literal is unterminated"
+# shellcheck disable=SC2016
+grep -q '^[[:space:]]*"\$NOTIFICATION_PERMISSION_TEST_CLASS"[[:space:]]*$' \
+  "$journey_excluded_block" \
+  || fail "nightly bulk exclusion does not include notification class"
+
+# That array only isolates anything while it is still joined into notClass AND
+# that argument still reaches the bulk phase-1 invocation, so pin both hops.
+# shellcheck disable=SC2016
+grep -q '^JOURNEY_NOTCLASS_ARG="\$(join_by , "\${JOURNEY_EXCLUDED_CLASSES\[@\]}")"$' \
+  "$nightly_joined" \
+  || fail "nightly notClass argument is no longer built from JOURNEY_EXCLUDED_CLASSES"
+# shellcheck disable=SC2016
+journey_invocation="$(grep '^"\$GRADLEW" :app:connectedDebugAndroidTest ' \
+  "$nightly_joined" | head -1)"
+[[ -n "$journey_invocation" ]] \
+  || fail "could not locate the nightly bulk phase-1 journey invocation"
+# shellcheck disable=SC2016
+assert_statement_contains "$journey_invocation" \
+  '-Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG"' \
+  "nightly bulk phase 1 no longer excludes the JOURNEY_EXCLUDED_CLASSES set"
+
+# The dedicated phase-1b block. Every pin below reads this extract, so prove the
+# extract is non-vacuous first — otherwise the negative shard-argument assertion
+# further down would pass over an empty file.
+nightly_phase1b="$FIXTURE_ROOT/nightly-phase1b.txt"
+sed -n '/phase 1b: notification permission/,/phase 2: network-fault proofs/p' \
+  "$nightly_joined" > "$nightly_phase1b"
+[[ -s "$nightly_phase1b" ]] \
+  || fail "could not extract the nightly phase 1b block"
+
+notification_invocation="$(grep -F '/scripts/connected-test.sh' "$nightly_phase1b" \
+  | head -1)"
+[[ -n "$notification_invocation" ]] \
+  || fail "nightly phase 1b does not run the class through the connected-test wrapper"
+assert_statement_contains "$notification_invocation" '--no-pool' \
+  "nightly phase 1b invocation no longer pins the single shared emulator lane"
+assert_statement_contains "$notification_invocation" \
+  '--deny-notifications-before-instrumentation' \
+  "nightly phase 1b does not use the canonical external fixture"
+# shellcheck disable=SC2016
+assert_statement_contains "$notification_invocation" \
+  '-Pandroid.testInstrumentationRunnerArguments.class="$NOTIFICATION_PERMISSION_TEST_CLASS"' \
+  "nightly phase 1b is no longer a dedicated invocation of the notification class"
+# shellcheck disable=SC2016
+assert_statement_contains "$notification_invocation" \
+  'tee "$notification_permission_log"' \
+  "nightly phase 1b no longer tees the wrapper output into its own log"
+
+# Report preservation: pin the two-line CALL, not the bare slug — the slug also
+# appears in `notification_permission_log=...phase1b-notification-permission.log`
+# inside this very block, so a slug grep survives deleting the snapshot and the
+# phase-1b evidence is then silently clobbered by phase 2.
+# shellcheck disable=SC2016
+grep -q '^[[:space:]]*preserve_phase_reports "phase1b-notification-permission" "\$APP_BUILD_DIR" "\$PHASE_REPORTS_DIR"$' \
+  "$nightly_phase1b" \
+  || fail "nightly phase 1b does not snapshot its own report before phase 2 clobbers it"
+
+# Executed-count capture: pin the literal capture expression, not the variable
+# name — the name also appears on the initialiser, the default-fallback and two
+# echoes, so a name grep survives deleting the capture and the summary then
+# prints `executed=0` beside PASS, the exact vacuous-count shape this issue
+# exists to eliminate.
+grep -qF "sed -n 's/^NOTIFICATION_PERMISSION_TEST_RESULT executed=" "$nightly_phase1b" \
+  || fail "nightly phase 1b does not capture the executed count from the wrapper result line"
+grep -qF 'notification_permission_executed="$(' "$nightly_phase1b" \
+  || fail "nightly phase 1b executed count is not assigned from that capture"
+grep -qF 'executed=$notification_permission_executed' "$nightly_joined" \
+  || fail "nightly summary row no longer surfaces the phase 1b executed count"
+
+if grep -qE 'numShards|shardIndex|JOURNEY_SHARD_ARGS' "$nightly_phase1b"; then
+  fail "nightly one-test phase 1b incorrectly retained shard arguments"
+fi
+
+# Exit propagation: pin the ASSIGNMENT that carries the real wrapper status.
+# Pinning only the downstream `-ne 0` comparisons leaves
+# `NOTIFICATION_PERMISSION_EXIT=0` hardcodable, which silently stops a phase-1b
+# failure reddening anything a human reads.
+# shellcheck disable=SC2016
+grep -q '^[[:space:]]*NOTIFICATION_PERMISSION_EXIT=\${PIPESTATUS\[0\]}$' \
+  "$nightly_phase1b" \
+  || fail "nightly phase 1b does not propagate the wrapper's real exit code"
+# shellcheck disable=SC2016
+grep -q '^[[:space:]]*\[\[ "\$NOTIFICATION_PERMISSION_EXIT" -ne 0 \]\] && notification_permission_status="FAIL"$' \
+  "$nightly_phase1b" \
+  || fail "nightly phase 1b summary row no longer turns FAIL on a non-zero exit"
+
+# Human extensive-shard verdict, scoped to the overall_status conditional.
+overall_status_block="$FIXTURE_ROOT/nightly-overall-status.txt"
+sed -n '/^overall_status="PASS"$/,/^fi$/p' "$REAL_NIGHTLY" > "$overall_status_block"
+grep -q '^overall_status="PASS"$' "$overall_status_block" \
+  || fail "could not extract the nightly overall_status conditional"
+grep -q '^fi$' "$overall_status_block" \
+  || fail "nightly overall_status conditional is unterminated"
+# shellcheck disable=SC2016
+grep -q '"\$NOTIFICATION_PERMISSION_EXIT" -ne 0' "$overall_status_block" \
+  || fail "nightly human extensive-shard status ignores phase 1b failure"
+
+# Release fault-verdict split: the notification phase is NON-GATING, so it must
+# stay out of the machine-readable verdict while the three real inputs stay in.
+# Asserted against the single joined call so a failed extraction can never
+# satisfy the negative half by being empty.
+fault_call="$(grep -F 'write_fault_verdict_file ' "$nightly_joined" | head -1)"
+[[ -n "$fault_call" ]] \
+  || fail "could not extract the nightly release fault-verdict call"
+# shellcheck disable=SC2016
+assert_statement_contains "$fault_call" '"$nf_status" "$NETWORK_FAULT_EXIT"' \
+  "nightly release fault-verdict no longer carries the network-fault phase"
+# shellcheck disable=SC2016
+assert_statement_contains "$fault_call" '"$bootstrap_status" "$BOOTSTRAP_EXIT"' \
+  "nightly release fault-verdict no longer carries the bootstrap phase"
+# shellcheck disable=SC2016
+assert_statement_contains "$fault_call" '"$expectedfail_status" "$EXPECTED_FAIL_EXIT"' \
+  "nightly release fault-verdict no longer carries the expected-fail lane"
+case "$fault_call" in
+  *NOTIFICATION_PERMISSION*|*notification_permission*)
+    printf '%s\n' "$fault_call" >&2
+    fail "notification phase leaked into the release fault-verdict"
+    ;;
+esac
+pass "nightly bulk/order isolation, non-vacuous report/count, and verdict split are pinned"
+
+echo
+echo "ALL NOTIFICATION PERMISSION FIXTURE TESTS PASSED"


### PR DESCRIPTION
Closes #1741

## The defect

`NoNotificationPromptOnAppOpenE2eTest` revoked its own notification permission from **inside** the instrumentation process. Android responds by killing the runner. The report that came back was a synthesized empty `<failure></failure>` at `time="0.019"` — the app was dead before the Activity ever launched, so the product was never tested, while the artifact looked like a genuine product verdict.

A fixture now revokes externally and hard-verifies the denied state **before** instrumentation starts, restores afterwards on success or failure, and keeps primary and cleanup failures distinguishable. The Kotlin test hard-asserts denied permission and never touches permissions from its own process.

Reviewer-produced red→green on device, both rounds:
```
RED   Killing 12485:com.pocketshell.app.i1741rv (adj 0): permissions revoked
      <failure></failure>   testcase time="0.021"   rc=1
GREEN state=denied api=35 -> executed=1 skipped=0 failures=0
      testcase time="5.235" -> state=granted   rc=0
```
The 0.021s vs 5.235s contrast is the whole point: "runner died" versus "product actually tested".

## Two rounds, because the guard was itself vacuous

**Round 1** found the previously-reported mutation matrix had only been exercising the guard's own **stubs**. Driving 13 *live* mutants of the real `scripts/connected-test.sh` left **six survivors** — including a **reportless runner borrowing the previous invocation's green XML**, which is precisely the vacuous-pass shape this issue exists to eliminate, sitting undetected inside the test built to catch it.

**Round 1 review** then found the *nightly* half was vacuous too: four more live mutants survived, three silently, all one defect — an unanchored `grep` asserts "this token exists somewhere in the file", not "this behaviour exists". Deleting the class from `JOURNEY_EXCLUDED_CLASSES` passed because the grep also matched an unrelated line 114 lines later; deleting the executed-count capture passed and the summary then printed **`executed=0` beside `PASS`**.

**Round 2** anchored each assertion to the construct that owns the behaviour, and went further than the suggested anchors in three of four cases because the anchor alone left the *hop* unpinned. It also closed a second latent hole where an **empty** `sed` extract would silently satisfy the negative assertions.

## The G2 sweep

Rather than patching four sites, round 2 classified **all 104 assertions** and found one structural class with a clean boundary: behavioural assertions that execute the real wrapper and read its output are immune by construction; every survivor lived among the static file reads. Two static pins were already adequate and were left alone rather than churned.

The sweep found a hole neither review had flagged — `run_fixture_args` resets device state per probe, so a single trailing "no permission was touched" check only ever observed the **last** of four rejection probes. It proved the fix mattered with a mutant designed to be invisible to the old assertions:
```
M-AD vs OLD single-trailing-check form : rc=0  ALL TESTS PASSED  (SURVIVED)
M-AD vs round-2 per-probe form         : rc=1  KILLED
```

## Round-2 review

Reproduced all four original mutants RED independently (M-K −40B, M-N −115B, M-O −178B, M-P −15B), rebuilt M-AD from scratch and confirmed both directions, and ran **two controls proving the harness discriminates rather than blanket-failing**: an unrelated `echo`→`:` mutation SURVIVED, and an old-form guard revert with pristine production SURVIVED. It also confirmed the "behavioural" assertions really do execute the **real** `connected-test.sh` (only adb/gradlew/systemctl stubbed) — empirically, because its mutations to the real file were detected.

It could not independently check the implementer's `64f35854…` hash reconstruction (the round-1 fixture is not on disk anywhere), and **refused to resolve that in the implementer's favour** — instead re-driving the entire on-device red→green itself so the identity claim is not load-bearing for the verdict.

Two adversarial survivors it found are recorded as non-blocking follow-ups with exact one-line fixes: neither falsifies an acceptance criterion's load-bearing property (one breaks nightly *reporting* only, not gating; the other would still be hard-red at report validation).

## Orchestrator verification

Applied to a clean worktree off `main` (`7668de23`). **The fixture is untracked** — `git diff` omits it, so it was copied explicitly with mode verified (775). Its `tests.yml` hunk applies on top of the **already-merged #1800** with no offset and no fuzz; both guard steps coexist in the `unit` job as independent invocations (lines 223 and 260). `bash -n` clean on all five changed shell scripts, YAML parses, `git diff --check` clean, `check-test-validity.sh` and `check-ci-journey-harness.sh` green, and the candidate's own guard passes end to end including the nightly isolation/verdict pins.

`(o2)` in `scripts/test-ci-journey-budget.sh` is a **pre-existing** wall-clock flake, confirmed by running pristine base and candidate back to back under identical load (base failed twice, candidate passed). Tracked separately as #1802; not attributed here.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb