### PR TITLE
ci(journey): make a RED shard fail its own job so re-run can reach it (#1809)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,9 +229,10 @@ jobs:
       # load-bearing property WITHOUT an emulator: all-green -> CLEAN,
       # all-infra -> RE-RUN (neutral, no false red email), and a genuine
       # journey failure -> RED (never masked). Cheap (< 5 s), no emulator.
-      - name: CI journey aggregate-verdict guard (issue #1458)
+      - name: CI journey aggregate-verdict guard (issues #1458, #1809)
         run: |
-          chmod +x scripts/test-ci-journey-aggregate-verdict.sh
+          chmod +x scripts/test-ci-journey-aggregate-verdict.sh \
+            scripts/ci-journey-write-shard-verdict.sh
           scripts/test-ci-journey-aggregate-verdict.sh
 
       # Issue #1458: the 95-minute emulator job must not start a second cold boot
@@ -398,6 +399,10 @@ jobs:
           path: |
             **/build/reports/tests/
             **/build/test-results/
+          # Issue #1809: a re-run of this job replaces its OWN attempt's upload
+          # instead of hitting a duplicate-name failure; the previous attempt's
+          # artifact is in a different scope and is left intact.
+          overwrite: true
           if-no-files-found: ignore
 
   python:
@@ -519,6 +524,8 @@ jobs:
           path: |
             **/build/reports/tests/
             **/build/test-results/
+          # Issue #1809: same re-run hygiene as the unit job's upload.
+          overwrite: true
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
@@ -622,6 +629,31 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+
+      # Issue #1809 (G5 re-run): pre-seed this shard's verdict token IMMEDIATELY
+      # after checkout — before anything can fail — so EVERY attempt that starts
+      # contributes a token of its own.
+      #
+      # Artifact names are unique per run ATTEMPT, so a re-run shard's token is
+      # stored alongside (not instead of) the previous attempt's, and
+      # download-artifact resolves the name with `latest: true` — the newest
+      # upload wins. That is what makes a single-shard re-run work. The hole it
+      # left: a shard that IS re-run but dies before the classifier uploads
+      # nothing, and the aggregation job then silently consumes the PREVIOUS
+      # attempt's token as if it were the re-run's verdict. Pre-seeding makes
+      # "no token from this attempt" impossible for a shard that actually ran,
+      # so a carried-over token soundly means "this shard was not re-run" — and
+      # the stamp the writer adds lets the aggregation job say which is which.
+      #
+      # The seed is INFRA (a re-run signal), never CLEAN and never RED: an
+      # attempt that died before classifying has neither proved the gate clean
+      # nor found a regression. The classify step overwrites it with the real
+      # verdict on every normal run.
+      - name: "Pre-seed shard verdict token (issue #1809)"
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci-journey-write-shard-verdict.sh
+          scripts/ci-journey-write-shard-verdict.sh INFRA
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -1189,7 +1221,7 @@ jobs:
       # never-booted) can NEVER fail the whole `Tests` workflow on its own and
       # fire a false red-CI email. Instead, EVERY branch below writes
       # a one-word per-shard VERDICT TOKEN (CLEAN | INFRA | RED) to
-      # artifacts/ci-journey/shard-verdict.txt, which is uploaded per shard and
+      # artifacts/ci-journey-shard-verdict/shard-verdict.txt, uploaded per shard and
       # rolled up by the downstream `emulator-journey-verdict` aggregation job
       # into ONE overall verdict (CLEAN / RE-RUN / RED). The per-shard ::error /
       # ::warning annotations + red step marker are PRESERVED for forensics; the
@@ -1199,6 +1231,7 @@ jobs:
       # timeout) still produces an aggregate RED, so a real regression is never
       # masked.
       - name: Classify emulator-journey result (infra-abort vs test-failure)
+        id: classify
         if: always()
         continue-on-error: true
         run: |
@@ -1218,9 +1251,11 @@ jobs:
           # job. CLEAN = passed; INFRA = environmental (#470 cancel / #771
           # never-booted) re-run signal; RED = genuine journey failure or #835
           # budget timeout. Written in EVERY branch before its exit.
-          verdict_file="artifacts/ci-journey/shard-verdict.txt"
-          mkdir -p "$(dirname "$verdict_file")"
-          write_verdict() { printf '%s\n' "$1" > "$verdict_file"; echo "SHARD_VERDICT=$1 (shard ${{ matrix.shard }})"; }
+          # Issue #1809: the token is written by ONE helper so its provenance
+          # stamp (run id / run attempt / shard) can never drift between the
+          # pre-seed and the classifier, and so a later step can gate on the
+          # `shard_verdict` output the helper exports.
+          write_verdict() { bash scripts/ci-journey-write-shard-verdict.sh "$1"; }
           echo "first attempt outcome:  $first"
           echo "retry attempt outcome:  ${retry:-<skipped>}"
           echo "first attempt conclusion:  $first_concl"
@@ -1379,6 +1414,11 @@ jobs:
             **/build/outputs/connected_android_test_additional_output/
             artifacts/ci-journey/
             artifacts/ci-journey-attempt-1/
+            artifacts/ci-journey-shard-verdict/
+          # Issue #1809: attempt-scoped, so a re-run of THIS shard replaces its
+          # own upload while the previous attempt's reports — the infra
+          # signature G5 makes an on-call capture — survive untouched.
+          overwrite: true
           if-no-files-found: ignore
 
       - name: Upload Docker logs
@@ -1388,6 +1428,8 @@ jobs:
           # Issue #835: per-shard name so matrix legs don't collide on upload.
           name: emulator-journey-docker-logs-shard-${{ matrix.shard }}
           path: artifacts/docker/
+          # Issue #1809: same attempt-scoped re-run hygiene as the reports above.
+          overwrite: true
           if-no-files-found: ignore
 
       # Issue #1458 (AGGREGATION): upload this shard's one-word verdict token so
@@ -1399,12 +1441,49 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: emulator-journey-verdict-shard-${{ matrix.shard }}
-          path: artifacts/ci-journey/shard-verdict.txt
+          path: artifacts/ci-journey-shard-verdict/shard-verdict.txt
+          # Issue #1809: `overwrite` is scoped to the CURRENT run attempt (the
+          # delete resolves the name through the attempt's own backend id), so
+          # it removes the within-attempt duplicate-name failure class WITHOUT
+          # touching the previous attempt's artifact — the forensic evidence G5
+          # requires an on-call to keep is safe.
+          overwrite: true
           if-no-files-found: warn
 
       - name: Stop Docker fixture
         if: always()
         run: docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
+
+      # Issue #1809 (G5 clean re-run): make THIS shard's job conclusion reflect a
+      # genuine RED verdict.
+      #
+      # The defect this closes: #1458 made the classify step `continue-on-error`
+      # so an environmental shard could not fire a false red-CI email. A side
+      # effect nobody noticed is that a shard whose token is RED ALSO finishes
+      # `success` — so on a red emulator-journey run the ONLY failed job is the
+      # aggregation job, and GitHub's "Re-run failed jobs" re-runs ONLY that
+      # aggregation job. It then re-downloads the very same shard tokens and
+      # emits the very same RED: a second, identical red that proves nothing.
+      # That is the on-call's "could not produce a clean re-run" in mechanical
+      # terms (runs 30305256109 / 30314178005 / 30318408377 all show three
+      # `success` shard jobs under a `failure` aggregate).
+      #
+      # Failing the shard on RED — and ONLY on RED — makes "Re-run failed jobs"
+      # re-run the offending shard AND the aggregation job that `needs` it, so
+      # the standard button is the G5 clean-re-run path. It cannot reintroduce
+      # the #1458 false red: a RED token already turns the whole run red through
+      # the aggregation job, so the run's conclusion is unchanged. INFRA and
+      # CLEAN shards still finish green, which is the property #1458 added.
+      #
+      # Placed last so every `if: always()` artifact/teardown step above has
+      # already run; the verdict artifact is uploaded before this can fail.
+      - name: "Fail this shard on a genuine RED verdict (issue #1809)"
+        if: always() && steps.classify.outputs.shard_verdict == 'RED'
+        run: |
+          echo "This shard recorded a RED verdict (a genuine journey failure or the #835 budget timeout)."
+          echo "Failing the shard job so 'Re-run failed jobs' re-runs THIS shard plus the aggregation job (issue #1809, G5)."
+          echo "The per-shard annotations above carry the failing class(es); the aggregate verdict job owns the overall run verdict."
+          exit 1
 
   # ---------------------------------------------------------------------------
   # Issue #1458 (AGGREGATION): roll the per-shard emulator-journey verdict tokens

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -13,10 +13,35 @@
 #   ci-journey-aggregate-verdict.sh [VERDICT_DIR]
 #     VERDICT_DIR  directory holding the downloaded per-shard verdict artifacts
 #                  (default: artifacts/ci-journey-verdicts). Each shard artifact
-#                  contributes a file whose contents are a single token:
-#                  CLEAN | INFRA | RED. Files may sit directly under VERDICT_DIR
-#                  or one level down (download-artifact per-shard subdirs) — any
-#                  regular file named `shard-verdict*.txt` (recursively) counts.
+#                  contributes a file whose FIRST non-empty line is the verdict
+#                  token — CLEAN | INFRA | RED — followed by `key=value`
+#                  provenance lines (`shard`, `run_id`, `run_attempt`,
+#                  `written_at`) written by
+#                  scripts/ci-journey-write-shard-verdict.sh. Files may sit
+#                  directly under VERDICT_DIR or one level down
+#                  (download-artifact per-shard subdirs) — any regular file
+#                  named `shard-verdict*.txt` (recursively) counts.
+#
+# Issue #1809 (G5 re-run provenance): a re-run of ONE shard leaves the shards
+# that were NOT re-run reporting their earlier attempt's token — that is
+# correct, but until now it was invisible, so nobody could tell a fresh re-run
+# verdict from a replay of stale tokens. Every token is therefore stamped with
+# its `run_attempt`, and this script PRINTS, per shard, which attempt its
+# verdict came from (and says so in the step summary). Two loud cases:
+#   * some tokens carried over from an earlier attempt -> ::notice naming them,
+#     so an on-call's "clean re-run" claim is backed by an artifact, not a
+#     memory of which button was pressed;
+#   * run_attempt > 1 and NOT ONE token is from this attempt -> ::warning: the
+#     aggregation job was re-run WITHOUT re-running any shard, so this verdict
+#     is a replay of unchanged data, not a re-run result. That is exactly the
+#     "confusing second red" the on-call hit: because the per-shard classify
+#     step is `continue-on-error`, a shard whose token is RED still finishes
+#     `success`, so GitHub's "Re-run failed jobs" used to re-run ONLY this
+#     aggregation job. The shard job now fails on a RED token (see tests.yml)
+#     so the standard re-run button re-runs the offending shard too, and this
+#     warning is the backstop that names the replay if it ever happens again.
+# Provenance NEVER changes the verdict — it is reporting only. The verdict is
+# still the honest rollup of the freshest token per shard.
 #   EXPECTED_SHARDS (env, optional) the number of shards that should have
 #                  reported. When set and fewer tokens are found, the missing
 #                  shards downgrade the verdict to at least RE-RUN (a missing
@@ -49,13 +74,53 @@ have_red=0
 have_unknown=0
 count=0
 tokens=()
+provenance=()
+carried_over=()
+fresh_tokens=0
+
+current_attempt="${GITHUB_RUN_ATTEMPT:-}"
+[[ "$current_attempt" =~ ^[0-9]+$ ]] || current_attempt=""
 
 if [[ -d "$verdict_dir" ]]; then
   while IFS= read -r -d '' f; do
-    raw="$(cat "$f" 2>/dev/null || true)"
+    # The verdict is the FIRST non-empty line; everything after it is the #1809
+    # `key=value` provenance stamp. Reading only line 1 is what keeps a stamped
+    # token from being mangled into an UNKNOWN (which would fail closed to RED).
+    raw="$(awk 'NF { print; exit }' "$f" 2>/dev/null || true)"
     # Normalise: strip whitespace, upper-case.
     token="$(printf '%s' "$raw" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
     [[ -z "$token" ]] && token="UNKNOWN"
+
+    tok_shard="$(sed -n 's/^shard=//p' "$f" 2>/dev/null | head -n 1)"
+    tok_attempt="$(sed -n 's/^run_attempt=//p' "$f" 2>/dev/null | head -n 1)"
+    tok_run="$(sed -n 's/^run_id=//p' "$f" 2>/dev/null | head -n 1)"
+    if [[ -z "$tok_shard" ]]; then
+      # No stamp (a token from a job that died before the pre-seed, or a foreign
+      # artifact): fall back to the download-artifact per-shard subdir name.
+      dir_name="$(basename "$(dirname "$f")")"
+      case "$dir_name" in
+        *shard-*) tok_shard="${dir_name##*shard-}" ;;
+        *)        tok_shard="?" ;;
+      esac
+    fi
+    [[ -n "$tok_attempt" ]] || tok_attempt="?"
+    [[ -n "$tok_run" ]] || tok_run="?"
+
+    origin="attempt ${tok_attempt}"
+    if [[ -n "$current_attempt" && "$tok_attempt" =~ ^[0-9]+$ ]]; then
+      if (( tok_attempt == current_attempt )); then
+        origin="attempt ${tok_attempt} (this attempt)"
+        fresh_tokens=$((fresh_tokens + 1))
+      else
+        origin="attempt ${tok_attempt} (carried over; this run is on attempt ${current_attempt})"
+        carried_over+=("shard ${tok_shard}=${token} from attempt ${tok_attempt}")
+      fi
+    elif [[ "$tok_attempt" == "?" ]]; then
+      origin="attempt unknown (token carries no #1809 provenance stamp)"
+    fi
+
+    provenance+=("shard ${tok_shard}: ${token} — run ${tok_run}, ${origin}")
+
     count=$((count + 1))
     tokens+=("$token")
     case "$token" in
@@ -75,6 +140,26 @@ fi
 echo "per-shard verdict tokens found: ${count} ${tokens[*]:-<none>}"
 echo "  CLEAN=$have_clean  INFRA=$have_infra  RED=$have_red  UNKNOWN=$have_unknown  MISSING=$missing (expected ${expected_shards})"
 
+# Issue #1809: per-shard provenance, so a G5 "clean re-run" claim is backed by
+# the artifact rather than by which button someone remembers pressing.
+echo "verdict provenance (issue #1809; this run is on attempt ${current_attempt:-unknown}):"
+if (( count == 0 )); then
+  echo "  <no tokens>"
+else
+  for line in "${provenance[@]}"; do
+    echo "  $line"
+  done
+fi
+
+if (( ${#carried_over[@]} > 0 )); then
+  echo "::notice title=Emulator journey verdict — some shard verdicts carried over::${#carried_over[@]} shard verdict(s) come from an earlier attempt of this run (that shard was not re-run): ${carried_over[*]}. This is expected when a single shard is re-run; it is reported so the aggregate verdict's provenance is auditable (issue #1809, G5)."
+fi
+
+# The replay backstop: the aggregation job was re-run but not one shard was.
+if [[ -n "$current_attempt" ]] && (( current_attempt > 1 && count > 0 && fresh_tokens == 0 )); then
+  echo "::warning title=Emulator journey verdict — REPLAY, no shard was re-run::This is attempt ${current_attempt}, but every per-shard verdict token was produced by an earlier attempt. The aggregation job was re-run WITHOUT re-running any emulator-journey shard, so this verdict is a replay of unchanged data — it is NOT evidence that a re-run reached a different result. To satisfy G5, re-run the failing shard job itself (its job now fails on a RED token, so 'Re-run failed jobs' picks it up) and let this job aggregate the fresh token (issue #1809)."
+fi
+
 emit_summary() {
   local verdict="$1" detail="$2"
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
@@ -90,6 +175,17 @@ emit_summary() {
       echo "| RED | $have_red |"
       echo "| UNKNOWN | $have_unknown |"
       echo "| MISSING | $missing |"
+      echo
+      echo "Verdict provenance (issue #1809) — this run is on attempt ${current_attempt:-unknown}:"
+      echo
+      if (( count == 0 )); then
+        echo "- _no per-shard verdict tokens_"
+      else
+        local line
+        for line in "${provenance[@]}"; do
+          echo "- ${line}"
+        done
+      fi
     } >> "$GITHUB_STEP_SUMMARY"
   fi
 }

--- a/scripts/ci-journey-write-shard-verdict.sh
+++ b/scripts/ci-journey-write-shard-verdict.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Issue #1809: write ONE per-shard emulator-journey verdict token, stamped with
+# the provenance the aggregation job (and a G5 on-call) needs to tell a fresh
+# re-run verdict apart from a carried-over one.
+#
+# Why a stamp is needed at all — the mechanics of a single-shard re-run:
+#   * Artifact NAMES are unique per workflow-run ATTEMPT, not per run. Re-running
+#     one shard therefore does NOT collide with (and `overwrite: true` does NOT
+#     delete) the previous attempt's artifact: both are stored under the same
+#     name. Proven on this repo — run 30187024723 holds two
+#     `emulator-journey-verdict-shard-0` artifacts, 8627574488 (attempt 1,
+#     `INFRA`) and 8628504152 (attempt 2, `RED`).
+#   * `actions/download-artifact` resolves a name with `latest: true`, so the
+#     NEWEST upload wins. That is what lets a re-run shard's token supersede its
+#     own earlier one while the shards that were NOT re-run legitimately keep
+#     their earlier tokens.
+#   * The hole that leaves: a shard that IS re-run but dies before the classifier
+#     uploads NOTHING, and the aggregation job then silently consumes the
+#     PREVIOUS attempt's token as if it were the re-run's verdict. Nothing in the
+#     log says so. That is the stale reading G5 forbids.
+#
+# The fix has two halves and this script is both of them:
+#   1. The emulator-journey job PRE-SEEDS a token (INFRA) right after checkout,
+#      so every attempt that starts always contributes a token of its own. A
+#      carried-over token then soundly means "this shard was not re-run".
+#   2. Every token carries `run_id` / `run_attempt` / `shard`, so the aggregation
+#      job can PRINT which attempt each verdict came from — turning "the re-run
+#      produced this verdict" from a claim into an artifact.
+#
+# The seed value is INFRA (a re-run signal) and never CLEAN or RED: an attempt
+# that died before classifying has neither proved the gate clean nor found a
+# regression.
+#
+# Format (parsed by scripts/ci-journey-aggregate-verdict.sh):
+#   line 1        the bare verdict token: CLEAN | INFRA | RED
+#   line 2..n     `key=value` provenance lines
+# Line 1 stays the bare token so the file remains trivially greppable and the
+# aggregation parser never has to guess where the verdict is.
+#
+# The token lives in its OWN directory (`artifacts/ci-journey-shard-verdict/`),
+# deliberately NOT inside `artifacts/ci-journey/`. Issue #1781's first-attempt
+# snapshot is a byte-identical copy of `artifacts/ci-journey/` that must never
+# carry a shard token (nobody may mistake a token in the snapshot for that
+# attempt's verdict). Because the token is now pre-seeded at job start, keeping
+# it under `artifacts/ci-journey/` would put it in that snapshot; a separate
+# directory makes #1781's invariant STRUCTURAL rather than dependent on step
+# ordering. The reports upload still packages this directory, so the token stays
+# in the forensic bundle.
+#
+# Usage:
+#   ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED>
+# Env:
+#   SHARD_VERDICT_FILE                     output path (default
+#                                          artifacts/ci-journey-shard-verdict/shard-verdict.txt)
+#   POCKETSHELL_JOURNEY_CI_SHARD_INDEX     shard index (set by the matrix)
+#   GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT     provenance (set by Actions)
+#   GITHUB_OUTPUT                          when set, also exports
+#                                          `shard_verdict=<token>` so a later
+#                                          step can gate on it
+set -uo pipefail
+
+verdict="${1:-}"
+case "$verdict" in
+  CLEAN | INFRA | RED) ;;
+  *)
+    echo "usage: ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED>" >&2
+    exit 2
+    ;;
+esac
+
+out="${SHARD_VERDICT_FILE:-artifacts/ci-journey-shard-verdict/shard-verdict.txt}"
+if ! mkdir -p "$(dirname "$out")"; then
+  echo "ci-journey-write-shard-verdict.sh: cannot create $(dirname "$out")" >&2
+  exit 1
+fi
+
+shard="${POCKETSHELL_JOURNEY_CI_SHARD_INDEX:-unknown}"
+run_id="${GITHUB_RUN_ID:-unknown}"
+run_attempt="${GITHUB_RUN_ATTEMPT:-unknown}"
+
+if ! {
+  printf '%s\n' "$verdict"
+  printf 'shard=%s\n' "$shard"
+  printf 'run_id=%s\n' "$run_id"
+  printf 'run_attempt=%s\n' "$run_attempt"
+  printf 'written_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$out"; then
+  echo "ci-journey-write-shard-verdict.sh: cannot write $out" >&2
+  exit 1
+fi
+
+echo "SHARD_VERDICT=$verdict (shard $shard, run $run_id attempt $run_attempt)"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  printf 'shard_verdict=%s\n' "$verdict" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/test-ci-journey-aggregate-verdict.sh
+++ b/scripts/test-ci-journey-aggregate-verdict.sh
@@ -13,6 +13,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+WRITER="$SCRIPT_DIR/ci-journey-write-shard-verdict.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
 BUDGET_FN="$SCRIPT_DIR/ci-journey-budget-functions.sh"
@@ -22,6 +23,8 @@ pass() { echo "  ok: $*"; }
 
 [[ -f "$AGG" ]] || fail "cannot find ci-journey-aggregate-verdict.sh at $AGG"
 chmod +x "$AGG"
+[[ -f "$WRITER" ]] || fail "cannot find ci-journey-write-shard-verdict.sh at $WRITER (issue #1809)"
+chmod +x "$WRITER"
 
 SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
@@ -45,9 +48,10 @@ write_shard() {
 # run_agg <dir> <expected-shards> — run the real aggregation, capture verdict +
 # exit code into globals AGG_OUT / AGG_RC / AGG_VERDICT.
 run_agg() {
-  local dir="$1" expected="$2"
+  local dir="$1" expected="$2" attempt="${3:-}"
   set +e
-  AGG_OUT="$(EXPECTED_SHARDS="$expected" GITHUB_STEP_SUMMARY="" bash "$AGG" "$dir" 2>&1)"
+  AGG_OUT="$(EXPECTED_SHARDS="$expected" GITHUB_STEP_SUMMARY="" GITHUB_RUN_ATTEMPT="$attempt" \
+    bash "$AGG" "$dir" 2>&1)"
   AGG_RC=$?
   set -e
   AGG_VERDICT="$(printf '%s\n' "$AGG_OUT" | sed -n 's/^AGGREGATE_VERDICT=//p' | tail -n 1)"
@@ -150,6 +154,187 @@ run_agg "$d" 0
 [[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
   || { printf '%s\n' "$AGG_OUT"; fail "(h) empty/no-expected expected RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
 pass "(h) no tokens + none expected -> RE-RUN (neutral, not a false red)"
+
+echo
+echo "== #1809 single-shard re-run: verdict provenance =="
+
+# write_stamped <dir> <shard> <token> <run-attempt> — drive the REAL writer
+# (scripts/ci-journey-write-shard-verdict.sh) into the per-shard subdir layout
+# download-artifact produces, so these cases exercise the production token
+# format rather than a hand-rolled imitation of it.
+write_stamped() {
+  local dir="$1" idx="$2" token="$3" attempt="$4"
+  local sub="$dir/emulator-journey-verdict-shard-$idx"
+  mkdir -p "$sub"
+  SHARD_VERDICT_FILE="$sub/shard-verdict.txt" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+    GITHUB_RUN_ID=30318408377 \
+    GITHUB_RUN_ATTEMPT="$attempt" \
+    GITHUB_OUTPUT="" \
+    bash "$WRITER" "$token" > /dev/null \
+    || fail "writer refused to write a $token token for shard $idx"
+}
+
+# (i) THE REPRODUCTION. The stamped token the shard now writes is MULTI-LINE.
+#     The pre-#1809 aggregator read the WHOLE file, stripped whitespace and
+#     upper-cased it, so a stamped CLEAN token collapsed to
+#     `CLEANSHARD=0RUN_ID=...` -> UNKNOWN -> fail-closed RED. Running this case
+#     against the base aggregator yields RED/exit1; it must yield CLEAN/exit0.
+d="$(make_dir stamped-clean)"
+write_stamped "$d" 0 CLEAN 1; write_stamped "$d" 1 CLEAN 1; write_stamped "$d" 2 CLEAN 1
+run_agg "$d" 3 1
+[[ "$AGG_VERDICT" == "CLEAN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(i) stamped CLEAN tokens expected CLEAN/exit0, got $AGG_VERDICT/exit$AGG_RC — the aggregator must read the verdict from line 1, not the whole file"; }
+pass "(i) provenance-stamped tokens parse to their real verdict (not UNKNOWN -> false RED)"
+
+# (i') the same control in the RED direction: stamping must not swallow a real
+#      regression either.
+d="$(make_dir stamped-red)"
+write_stamped "$d" 0 CLEAN 1; write_stamped "$d" 1 RED 1; write_stamped "$d" 2 CLEAN 1
+run_agg "$d" 3 1
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(i') a stamped RED must still resolve RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(i') a stamped RED token still turns the run red — stamping never masks a regression"
+
+# (j) THE G5 CLEAN RE-RUN, end to end. Attempt 1 had shard 0 RED; the on-call
+#     re-runs ONLY shard 0 and it comes back CLEAN. Shards 1/2 legitimately keep
+#     their attempt-1 tokens (they were not re-run). The aggregate must consume
+#     the RE-RUN's shard-0 value -> CLEAN/exit0, and must SAY which verdicts are
+#     carried over, so "I produced a clean re-run" is an artifact, not a claim.
+d="$(make_dir clean-rerun)"
+write_stamped "$d" 0 CLEAN 2      # the re-run's fresh token
+write_stamped "$d" 1 CLEAN 1
+write_stamped "$d" 2 CLEAN 1
+run_agg "$d" 3 2
+[[ "$AGG_VERDICT" == "CLEAN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(j) a clean single-shard re-run expected CLEAN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+grep -q 'shard 0: CLEAN .*attempt 2 (this attempt)' <<<"$AGG_OUT" \
+  || { printf '%s\n' "$AGG_OUT"; fail "(j) the aggregate must report shard 0's verdict as coming from THIS attempt (the re-run)"; }
+grep -q 'shard 1: CLEAN .*attempt 1 (carried over' <<<"$AGG_OUT" \
+  || { printf '%s\n' "$AGG_OUT"; fail "(j) the aggregate must report shard 1's verdict as carried over from the earlier attempt"; }
+grep -q 'some shard verdicts carried over' <<<"$AGG_OUT" \
+  || { printf '%s\n' "$AGG_OUT"; fail "(j) a partial re-run must emit the carried-over ::notice so provenance is auditable"; }
+pass "(j) single-shard re-run -> CLEAN, and each verdict's originating attempt is reported"
+
+# (j') the load-bearing control for (j): the ONLY thing that made it CLEAN is the
+#      re-run shard's fresh token. Put attempt 2's shard-0 token back to RED and
+#      the aggregate must go RED — proving it read the re-run's value, not the
+#      other shards' carried-over CLEANs.
+d="$(make_dir clean-rerun-control)"
+write_stamped "$d" 0 RED 2
+write_stamped "$d" 1 CLEAN 1
+write_stamped "$d" 2 CLEAN 1
+run_agg "$d" 3 2
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(j') flipping the re-run shard's token to RED must yield RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(j') control: the re-run shard's OWN token drives the verdict"
+
+# (k) THE REPLAY BACKSTOP. On attempt 2 with every token still from attempt 1,
+#     the aggregation job was re-run WITHOUT re-running any shard — the
+#     "confusing second red" the on-call hit. The verdict is unchanged (it is the
+#     honest rollup of the data) but the run must SAY it is a replay.
+d="$(make_dir replay)"
+write_stamped "$d" 0 RED 1; write_stamped "$d" 1 CLEAN 1; write_stamped "$d" 2 CLEAN 1
+run_agg "$d" 3 2
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(k) a replay of a RED token set must still be RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+grep -q 'REPLAY, no shard was re-run' <<<"$AGG_OUT" \
+  || { printf '%s\n' "$AGG_OUT"; fail "(k) re-running ONLY the aggregation job must be reported as a replay, not presented as a re-run result"; }
+pass "(k) aggregation-only re-run is flagged REPLAY (no shard re-run) instead of reading as a fresh second red"
+
+# (k') control: on attempt 1 there is nothing to replay, so the warning must NOT
+#      fire — the signal has to mean something.
+d="$(make_dir replay-control)"
+write_stamped "$d" 0 RED 1; write_stamped "$d" 1 CLEAN 1; write_stamped "$d" 2 CLEAN 1
+run_agg "$d" 3 1
+grep -q 'REPLAY, no shard was re-run' <<<"$AGG_OUT" \
+  && { printf '%s\n' "$AGG_OUT"; fail "(k') the REPLAY warning must not fire on a first attempt"; }
+grep -q 'some shard verdicts carried over' <<<"$AGG_OUT" \
+  && { printf '%s\n' "$AGG_OUT"; fail "(k') nothing is carried over on a first attempt"; }
+pass "(k') control: no REPLAY / carried-over noise on a first attempt"
+
+# (l) the writer refuses an unknown verdict (fail closed at the source, so a
+#     typo can never become an UNKNOWN token the aggregator has to fail on).
+set +e
+"$WRITER" MAYBE > /dev/null 2>&1
+writer_rc=$?
+set -e
+[[ "$writer_rc" -ne 0 ]] || fail "(l) the writer must reject a token outside CLEAN|INFRA|RED"
+pass "(l) the verdict writer rejects an unrecognised token"
+
+# (m) the writer stamps run/attempt/shard and exports the step output the
+#     shard's RED gate reads.
+d="$(make_dir writer-output)"
+mkdir -p "$d/out"
+SHARD_VERDICT_FILE="$d/out/shard-verdict.txt" \
+  POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2 \
+  GITHUB_RUN_ID=42 GITHUB_RUN_ATTEMPT=3 \
+  GITHUB_OUTPUT="$d/out/gh-output.txt" \
+  bash "$WRITER" RED > /dev/null || fail "(m) writer failed"
+[[ "$(head -n1 "$d/out/shard-verdict.txt")" == "RED" ]] \
+  || fail "(m) line 1 of the token must be the bare verdict"
+grep -qx 'shard=2' "$d/out/shard-verdict.txt" || fail "(m) token must stamp shard="
+grep -qx 'run_id=42' "$d/out/shard-verdict.txt" || fail "(m) token must stamp run_id="
+grep -qx 'run_attempt=3' "$d/out/shard-verdict.txt" || fail "(m) token must stamp run_attempt="
+grep -qx 'shard_verdict=RED' "$d/out/gh-output.txt" \
+  || fail "(m) writer must export shard_verdict to \$GITHUB_OUTPUT for the RED gate step"
+pass "(m) writer stamps shard/run/attempt and exports shard_verdict"
+
+echo
+echo "== #1809 workflow-parity pins =="
+
+# The shard job must PRE-SEED a token right after checkout, so an attempt that
+# dies before the classifier cannot silently inherit the previous attempt's
+# verdict.
+grep -q 'name: "Pre-seed shard verdict token (issue #1809)"' "$WORKFLOW" \
+  || fail "(x1) the emulator-journey job must pre-seed a shard verdict token so every attempt reports its own"
+awk '
+  /Pre-seed shard verdict token \(issue #1809\)/ { armed=1 }
+  armed && /ci-journey-write-shard-verdict\.sh INFRA/ { found=1 }
+  armed && /^      - name: Set up JDK/ { armed=0 }
+  END { exit(found ? 0 : 1) }
+' "$WORKFLOW" \
+  || fail "(x2) the pre-seed must write INFRA (a re-run signal), never CLEAN or RED"
+# ...and it must run BEFORE the journey/classify steps (a seed written after the
+# suite would not survive a job that died during the suite).
+preseed_line="$(grep -n 'Pre-seed shard verdict token (issue #1809)' "$WORKFLOW" | head -n1 | cut -d: -f1)"
+classify_line="$(grep -n 'name: Classify emulator-journey result' "$WORKFLOW" | head -n1 | cut -d: -f1)"
+[[ -n "$preseed_line" && -n "$classify_line" && "$preseed_line" -lt "$classify_line" ]] \
+  || fail "(x3) the pre-seed step must come BEFORE the classify step (got preseed=$preseed_line classify=$classify_line)"
+pass "(x1-x3) shard verdict token is pre-seeded INFRA before the suite runs"
+
+# The classifier writes through the ONE stamped writer (no second, unstamped
+# token format can drift back in).
+grep -q 'write_verdict() { bash scripts/ci-journey-write-shard-verdict.sh' "$WORKFLOW" \
+  || fail "(x4) the classify step must write its verdict through scripts/ci-journey-write-shard-verdict.sh"
+grep -q 'verdict_file' "$WORKFLOW" \
+  && fail "(x4) the old inline, unstamped \$verdict_file writer must be gone (D22 hard cut) — one writer owns the format"
+pass "(x4) one stamped writer owns the token format"
+
+# A RED shard must fail its OWN job, so GitHub's 'Re-run failed jobs' re-runs the
+# offending shard (plus the aggregation job that needs it) instead of re-running
+# the aggregation job alone and replaying the same tokens.
+grep -q 'name: "Fail this shard on a genuine RED verdict (issue #1809)"' "$WORKFLOW" \
+  || fail "(x5) a RED shard must fail its own job so the standard re-run button re-runs that shard"
+grep -q "steps.classify.outputs.shard_verdict == 'RED'" "$WORKFLOW" \
+  || fail "(x6) the shard RED gate must trigger on the classifier's RED verdict only"
+# ...and ONLY on RED: an INFRA shard staying green is the #1458 no-false-red
+# property, so guard against the condition being widened.
+for tok in INFRA CLEAN; do
+  grep -q "steps.classify.outputs.shard_verdict == '$tok'" "$WORKFLOW" \
+    && fail "(x7) the shard job must NOT fail on a '$tok' verdict — that would reintroduce the #1458 false red-CI email"
+done
+pass "(x5-x7) RED (and only RED) fails the shard job — re-run button reaches the failing shard, #1458 stays intact"
+
+# Every artifact this job uploads must be re-runnable (overwrite within the
+# attempt). Checked across ALL uploads in the workflow, not just the verdict
+# token — fixing only the named one would be the proxy fix (G2).
+uploads="$(grep -c 'uses: actions/upload-artifact@v7' "$WORKFLOW" || true)"
+overwrites="$(grep -cE '^[[:space:]]*overwrite: true' "$WORKFLOW" || true)"
+[[ "$uploads" -gt 0 ]] || fail "(x8) expected upload-artifact steps in tests.yml"
+[[ "$overwrites" -eq "$uploads" ]] \
+  || fail "(x8) every upload-artifact step in tests.yml must set 'overwrite: true' so a re-run replaces its own attempt's artifact (found $overwrites overwrite(s) for $uploads upload(s))"
+pass "(x8) all $uploads upload-artifact steps in tests.yml are re-run safe (overwrite: true)"
 
 echo
 echo "== #1458 workflow-parity pins =="

--- a/scripts/test-ci-journey-artifact-packaging.sh
+++ b/scripts/test-ci-journey-artifact-packaging.sh
@@ -78,8 +78,21 @@ seed_fixture() {
   printf 'first-attempt metadata\n' > "$root/artifacts/ci-journey-attempt-1/attempt-metadata.md"
 }
 
+# Issue #1809: the shard verdict token lives in its OWN directory, deliberately
+# outside artifacts/ci-journey/, because it is now pre-seeded at job start and a
+# token inside artifacts/ci-journey/ would land in the #1781 first-attempt
+# snapshot. Keeping it separate makes "the snapshot never carries a shard token"
+# structural instead of ordering-dependent.
 write_current_shard_token() {
-  printf 'CLEAN\n' > "$1/artifacts/ci-journey/shard-verdict.txt"
+  mkdir -p "$1/artifacts/ci-journey-shard-verdict"
+  printf 'CLEAN\n' > "$1/artifacts/ci-journey-shard-verdict/shard-verdict.txt"
+}
+
+# The pre-seed the emulator-journey job writes right after checkout, BEFORE the
+# suite runs and therefore before the first-attempt snapshot is taken.
+write_preseeded_shard_token() {
+  mkdir -p "$1/artifacts/ci-journey-shard-verdict"
+  printf 'INFRA\n' > "$1/artifacts/ci-journey-shard-verdict/shard-verdict.txt"
 }
 
 extract_workflow_snapshot_copy() {
@@ -323,6 +336,8 @@ echo
 echo "== #1781 corrected production snapshot + module packaging =="
 fixed_root="$SANDBOX/fixed"
 seed_fixture "$fixed_root"
+# Issue #1809: model the pre-seeded token existing BEFORE the snapshot is taken.
+write_preseeded_shard_token "$fixed_root"
 current_root="$fixed_root/artifacts/ci-journey"
 snapshot_root="$fixed_root/artifacts/ci-journey-attempt-1"
 current_hashes_before="$(hash_tree "$current_root")"
@@ -354,7 +369,10 @@ run_production_snapshot "$fixed_root" || fail "production workflow snapshot path
 
 write_current_shard_token "$fixed_root"
 assert_real_attempt_paths "$fixed_root"
-[[ -f "$current_root/shard-verdict.txt" ]] || fail "current shard token missing"
+[[ -f "$fixed_root/artifacts/ci-journey-shard-verdict/shard-verdict.txt" ]] \
+  || fail "current shard token missing"
+[[ ! -e "$current_root/shard-verdict.txt" ]] \
+  || fail "the shard token must not live inside artifacts/ci-journey/ (issue #1809: it is pre-seeded, and artifacts/ci-journey/ is byte-copied into the first-attempt snapshot)"
 [[ ! -e "$snapshot_root/ci-journey/shard-verdict.txt" ]] \
   || fail "first-cold-boot snapshot incorrectly contains the later-written shard token"
 [[ -f "$current_root/summary.md" && -f "$snapshot_root/ci-journey/summary.md" ]] \
@@ -510,10 +528,14 @@ grep -Fq 'cp -a artifacts/ci-journey/. "$snapshot/ci-journey/"' <<<"$preserve_st
 if grep -q '\*\*/build' "$HELPER" || grep -q '\*\*/build' <<<"$preserve_step"; then
   fail "broad recursive Android build-output scan was restored"
 fi
-preserve_line="$(grep -n 'name: Preserve first journey attempt diagnostics' "$WORKFLOW" | cut -d: -f1)"
-verdict_line="$(grep -n 'verdict_file="artifacts/ci-journey/shard-verdict.txt"' "$WORKFLOW" | cut -d: -f1)"
-[[ "$preserve_line" =~ ^[0-9]+$ && "$verdict_line" =~ ^[0-9]+$ && "$preserve_line" -lt "$verdict_line" ]] \
-  || fail "first-attempt snapshot no longer precedes current shard-token creation"
+# Issue #1809 replaced the ordering guarantee with a STRUCTURAL one: the shard
+# token is written outside artifacts/ci-journey/, so no step order can leak it
+# into the first-attempt snapshot. Pin that instead of the old line ordering
+# (the token is now pre-seeded at job start, so an ordering pin would be false).
+grep -q 'path: artifacts/ci-journey-shard-verdict/shard-verdict.txt' "$WORKFLOW" \
+  || fail "shard verdict token upload must read artifacts/ci-journey-shard-verdict/shard-verdict.txt"
+grep -q 'artifacts/ci-journey/shard-verdict.txt' "$WORKFLOW" \
+  && fail "the shard token must not be written or uploaded from inside artifacts/ci-journey/ — it would land in the first-attempt snapshot"
 
 upload_step="$(sed -n \
   '/- name: Upload Android test reports/,/- name: Upload Docker logs/p' \
@@ -532,6 +554,8 @@ printf '%s\n' "${upload_paths[@]}" | grep -Fxq 'artifacts/ci-journey/' \
   || fail "actual Android-report upload step lost artifacts/ci-journey/"
 printf '%s\n' "${upload_paths[@]}" | grep -Fxq 'artifacts/ci-journey-attempt-1/' \
   || fail "actual Android-report upload step lost artifacts/ci-journey-attempt-1/"
+printf '%s\n' "${upload_paths[@]}" | grep -Fxq 'artifacts/ci-journey-shard-verdict/' \
+  || fail "actual Android-report upload step lost artifacts/ci-journey-shard-verdict/ (issue #1809: the token must stay in the forensic bundle)"
 
 upload_manifest="$SANDBOX/upload-manifest.txt"
 : > "$upload_manifest"
@@ -547,7 +571,7 @@ for upload_path in "${upload_paths[@]}"; do
 done
 grep -q '  artifacts/ci-journey/summary.md$' "$upload_manifest" \
   || fail "actual upload paths do not package the canonical summary"
-grep -q '  artifacts/ci-journey/shard-verdict.txt$' "$upload_manifest" \
+grep -q '  artifacts/ci-journey-shard-verdict/shard-verdict.txt$' "$upload_manifest" \
   || fail "actual upload paths do not package the current shard token"
 grep -q '  artifacts/ci-journey-attempt-1/ci-journey/summary.md$' "$upload_manifest" \
   || fail "actual upload paths do not package the first-cold-boot summary"


### PR DESCRIPTION
Closes #1809

## I filed this issue on a wrong premise; the implementer found the real defect

I claimed the shard verdict-token upload needed `overwrite: true` because a single-shard re-run would collide on artifact name. **That was wrong.** Artifact names are scoped per run **attempt** — run 30187024723 stores two `emulator-journey-verdict-shard-0` artifacts (attempt 1 `INFRA`, attempt 2 `RED`), and `download-artifact`'s `latest: true` correctly consumed the re-run's. The reviewer unzipped both to confirm.

The real defect is sharper. #1458 made the per-shard classify step `continue-on-error` so infra aborts stop firing three independent red checks. The side effect: **a RED shard job finishes `success`**. So on a red journey run the *only* failed job is the aggregate, and GitHub's *Re-run failed jobs* re-runs **only the aggregate** — replaying identical tokens into an identical red. The shard that actually needs re-running cannot be reached by the button at all.

That is why G5's clean-re-run requirement was unsatisfiable, and why an on-call recently had to record a *provisional* infra classification instead of proving one.

## The property that must not regress, and how it was checked

Making RED shards fail their own job re-opens exactly the risk #1458 closed. The reviewer verified this **without using the implementer's fixtures**, via two independent harnesses:

- an exhaustive **27-combination matrix** driving the real writer and real aggregator — `combination mismatches: 0`; all-INFRA still `RE-RUN`/exit 0; a missing token still routes to RE-RUN and CLEAN still requires `missing == 0`; garbage and empty tokens still fail closed to RED;
- a harness that extracts the classify step's **real `run:` body from the candidate YAML**, substitutes the `${{ }}` expressions, executes it and reads back the actual `$GITHUB_OUTPUT`. Both CLEAN branches and **all three** INFRA branches (#470 cancel, retry-budget denied, environmental fallthrough) leave the gate unfired → shard green; all three RED branches fire it → shard fails. Aggregate behaviour unchanged for every combination.

Reviewer-run red→green twice: the base aggregator mangles stamped tokens to `UNKNOWN`→RED, and base `tests.yml` has zero occurrences of the gate and fails the pin.

## A confirming counter-case neither of us had

The reviewer found that in run 30187024723 **attempt 1, shard 0 actually failed** (for a non-classify reason) — and attempt 2 then re-ran **shard 0 and the aggregate**. That is real-infrastructure proof of the exact mechanism this fix depends on, and it also disposes of the obvious regression worry: the aggregate is **not** skipped when a needed shard fails, because `if: !cancelled()` overrides the implicit `success()`.

## Acceptance criteria 1–2 are partly met, deliberately

The end-to-end "shard re-run flips the aggregate to CLEAN" **cannot** be demonstrated before this lands: on today's `main` the failing shard job is green and the re-run button cannot reach it. Both halves of the composition are proven on real GitHub infrastructure; only their composition needs the merge.

The reviewer accepted this rather than returning BLOCKED, and gave the reason rather than waving it: the provable half is the one that could **regress** (no-false-red, proven 27/27 and 8/8), while the unprovable half's failure mode is **benign** — we would simply be back to today's behaviour. It recorded a named post-merge obligation instead of a waiver: on the first RED shard after merge, confirm the shard job reports `failure`, press *Re-run failed jobs*, and confirm the fresh-token provenance line.

## The other half of the issue: shard 0 is not pathological

I implied it was. The data says otherwise, and the reviewer re-collected it independently from 27 runs' artifact bodies rather than accepting the summary:

- RED rates over 19 verdict runs reproduce exactly: **s0 15/19 (79%), s2 14/19 (74%), s1 10/19 (53%)** — s0 and s2 one run apart.
- The load-bearing normalisation is correct: emulator-console failures are **57/57/58 per cold boot**; shard 0's apparent `118` was **two boots** because it took its retry (59 vs 56/56).
- Round-robin reshuffles shard membership whenever the class list changes — confirmed at `scripts/ci-journey-class-selection-functions.sh:49`, and **stronger than claimed**: `BareNetworkLossRestoreReconnectE2eTest` sits on shard 1 in this tree, failed on shard 2 in one run, and appears in shard 0's list in another. One class, all three shards.

**Redirection for #1458: roughly 6 chronically flaky *classes*, not a shard.** A materially different — and enumerable — remediation target.

## Orchestrator verification

Applied to a clean worktree off `main` (`d7c34b74`). **The new `scripts/ci-journey-write-shard-verdict.sh` is untracked** — `git diff` omits it, so it was copied explicitly with mode verified (775); a non-executable guard script fails in a way that reads as a workflow error. `bash -n` clean on all four shell scripts, workflow YAML parses, `git diff --check` clean. Both of the candidate's own guards pass end to end, and `check-ci-journey-harness.sh` / `check-test-validity.sh` are green.

The two `unit`-job guard steps from recently-merged #1741 and #1800 are untouched — verified by diffing the full step-name list; the only `unit`-job change is a `chmod` line inside the *existing* aggregate-verdict guard step.

`scripts/test-ci-journey-budget.sh` `(o)` is a pre-existing contended-box timing flake reproduced on pristine `origin/main`, tracked as #1802, and not attributable here (that file is not in this diff).

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb