### PR TITLE
test(tmux): one shared teardown seam for standalone VM fixtures (#1765)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/AttachmentMisrouteBindToOriginTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AttachmentMisrouteBindToOriginTest.kt
@@ -8,19 +8,11 @@ import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -78,23 +70,10 @@ import java.util.Collections
 @Config(manifest = Config.NONE, sdk = [33])
 class AttachmentMisrouteBindToOriginTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(): TmuxSessionViewModel = TmuxSessionViewModel(
         tmuxClientFactory = TmuxClientFactory(factoryScope),
@@ -104,6 +83,10 @@ class AttachmentMisrouteBindToOriginTest {
             connector = com.pocketshell.core.ssh.SshLeaseConnector { target ->
                 error("unexpected SSH lease connect for ${target.leaseKey}")
             },
+            // Issue #1765: SshLeaseManager's DEFAULT scope is a fresh unowned
+            // CoroutineScope(SupervisorJob() + Dispatchers.IO) that nothing cancels.
+            // Bind it to the fixture-owned root so teardown cancels AND joins it.
+            scope = fixture.leaseScope,
             idleTtlMillis = 0L,
             connectTimeoutContext = StandardTestDispatcher(testScheduler),
             nowMillis = { testScheduler.currentTime },
@@ -111,6 +94,7 @@ class AttachmentMisrouteBindToOriginTest {
         sessionLifecycleSignals = null,
         applicationContext = ApplicationProvider.getApplicationContext(),
     ).also {
+        fixture.track(it)
         // Pin the seed-IO dispatcher to the shared virtual-clock scheduler so
         // attach/switch round-trips run inline on the test clock (#926).
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))

--- a/app/src/test/java/com/pocketshell/app/tmux/AttachmentQueueRetentionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AttachmentQueueRetentionTest.kt
@@ -17,18 +17,10 @@ import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -50,12 +42,8 @@ import java.util.concurrent.ConcurrentHashMap
 @Config(manifest = Config.NONE, sdk = [33])
 class AttachmentQueueRetentionTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     @Test
     fun issue1548_uploadPruneRetainsOldQueuedAttachmentBytesAndDeletesOldUnreferencedPeer() =
@@ -210,16 +198,7 @@ class AttachmentQueueRetentionTest {
             )
         }
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(store: InMemoryOutboundQueueStore): TmuxSessionViewModel =
         TmuxSessionViewModel(
@@ -230,6 +209,10 @@ class AttachmentQueueRetentionTest {
                 connector = SshLeaseConnector { target ->
                     error("unexpected SSH lease connect for ${target.leaseKey}")
                 },
+                // Issue #1765: SshLeaseManager's DEFAULT scope is a fresh unowned
+                // CoroutineScope(SupervisorJob() + Dispatchers.IO) that nothing cancels.
+                // Bind it to the fixture-owned root so teardown cancels AND joins it.
+                scope = fixture.leaseScope,
                 idleTtlMillis = 0L,
                 connectTimeoutContext = StandardTestDispatcher(testScheduler),
                 nowMillis = { testScheduler.currentTime },
@@ -238,6 +221,7 @@ class AttachmentQueueRetentionTest {
             applicationContext = ApplicationProvider.getApplicationContext(),
             outboundQueueStore = store,
         ).also {
+            fixture.track(it)
             it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
         }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/AttachmentUploadTeardownReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AttachmentUploadTeardownReconnectTest.kt
@@ -11,20 +11,14 @@ import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -79,26 +73,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE)
 class AttachmentUploadTeardownReconnectTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        // EPIC #792 Slice D: disable the VM LivenessProbe auto-start — its infinite
-        // periodic `delay` loop would otherwise spin `advanceUntilIdle()` forever on
-        // this virtual-clock Main (this file does not use MainDispatcherRule).
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         sshLeaseManager: SshLeaseManager,
@@ -109,6 +87,7 @@ class AttachmentUploadTeardownReconnectTest {
         sshLeaseManager = sshLeaseManager,
         sessionLifecycleSignals = null,
     ).also {
+        fixture.track(it)
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/AttachmentWaitWarmLeaseTrustTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AttachmentWaitWarmLeaseTrustTest.kt
@@ -9,19 +9,14 @@ import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -59,26 +54,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE)
 class AttachmentWaitWarmLeaseTrustTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        // EPIC #792 Slice D: disable the VM LivenessProbe auto-start — its infinite
-        // periodic `delay` loop would otherwise spin `advanceUntilIdle()` forever on
-        // this virtual-clock Main (this file does not use MainDispatcherRule).
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         sshLeaseManager: SshLeaseManager,
@@ -89,6 +68,7 @@ class AttachmentWaitWarmLeaseTrustTest {
         sshLeaseManager = sshLeaseManager,
         sessionLifecycleSignals = null,
     ).also {
+        fixture.track(it)
         // Issue #926: pin the seed-IO dispatcher (off-Main hop for the
         // attach/switch/reattach `capture-pane`/`list-panes` IO) to the shared
         // virtual-clock scheduler so the round-trips run inline on the test clock

--- a/app/src/test/java/com/pocketshell/app/tmux/BlackFrameObservedDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/BlackFrameObservedDiagnosticTest.kt
@@ -12,20 +12,12 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -80,13 +72,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class BlackFrameObservedDiagnosticTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // (1) capture_empty — capture-pane empty on a live transport, pane WAS seeded.
@@ -329,23 +316,12 @@ class BlackFrameObservedDiagnosticTest {
 
     // ------------------------------------------------------------------ Harness
 
-    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = fixture.runVmTest {
         val sink = installRecordingDiagnosticSink()
-        try {
-            body(RecordingSink(sink))
-        } finally {
-            sink.close()
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
+        // Issue #1765: the sink must close BEFORE the VMs are cleared and while
+        // Main is still installed, exactly as the pre-migration `finally` did.
+        fixture.onTeardown { sink.close() }
+        body(RecordingSink(sink))
     }
 
     /** Thin wrapper so the test body can pull black-frame events by class without imports. */
@@ -381,7 +357,7 @@ class BlackFrameObservedDiagnosticTest {
         // reveal-gate pass is the one the test drives directly — no spurious events.
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/DeadZoneBandRevealResizeHealTest.kt
@@ -10,20 +10,12 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -67,13 +59,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class DeadZoneBandRevealResizeHealTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------------------------
     // (1) SWITCH-reveal heals a dead-zone band — SHELL pane.
@@ -437,22 +424,7 @@ class DeadZoneBandRevealResizeHealTest {
 
     // ------------------------------------------------------------------ Harness
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -465,7 +437,7 @@ class DeadZoneBandRevealResizeHealTest {
         sessionLifecycleSignals = null,
     ).also {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/HealCaptureUnverifiedWatchdogTest.kt
@@ -13,21 +13,13 @@ import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -82,13 +74,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class HealCaptureUnverifiedWatchdogTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // Criterion 1 (LOAD-BEARING) — a black pane whose heal captures FAIL every tick keeps the
@@ -394,23 +381,12 @@ class HealCaptureUnverifiedWatchdogTest {
     private fun FakeTmuxClient.captureCount(): Int =
         sentCommands.count { it.startsWith("capture-pane") }
 
-    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = fixture.runVmTest {
         val sink = installRecordingDiagnosticSink()
-        try {
-            body(RecordingSink(sink))
-        } finally {
-            sink.close()
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
+        // Issue #1765: the sink must close BEFORE the VMs are cleared and while
+        // Main is still installed, exactly as the pre-migration `finally` did.
+        fixture.onTeardown { sink.close() }
+        body(RecordingSink(sink))
     }
 
     private class RecordingSink(
@@ -434,7 +410,7 @@ class HealCaptureUnverifiedWatchdogTest {
         // loop so capture counts + timings stay deterministic.
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1181LivePinnedForegroundReseedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1181LivePinnedForegroundReseedTest.kt
@@ -12,20 +12,12 @@ import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -83,30 +75,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue1181LivePinnedForegroundReseedTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -119,7 +91,7 @@ class Issue1181LivePinnedForegroundReseedTest {
         sessionLifecycleSignals = null,
     ).also {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1295WatchdogArmingLivenessTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1295WatchdogArmingLivenessTest.kt
@@ -14,21 +14,13 @@ import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -77,13 +69,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue1295WatchdogArmingLivenessTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // Deliverable 1 — POSITIVE liveness heartbeat, and its ABSENCE while backgrounded.
@@ -566,23 +553,12 @@ class Issue1295WatchdogArmingLivenessTest {
         return bridge.emulator.screen.transcriptText
     }
 
-    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = fixture.runVmTest {
         val sink = installRecordingDiagnosticSink()
-        try {
-            body(RecordingSink(sink))
-        } finally {
-            sink.close()
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
+        // Issue #1765: the sink must close BEFORE the VMs are cleared and while
+        // Main is still installed, exactly as the pre-migration `finally` did.
+        fixture.onTeardown { sink.close() }
+        body(RecordingSink(sink))
     }
 
     private class RecordingSink(
@@ -606,7 +582,7 @@ class Issue1295WatchdogArmingLivenessTest {
         // test is the SOLE opportunity; individual tests re-enable auto-arm as needed.
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
@@ -658,7 +634,7 @@ class Issue1295WatchdogArmingLivenessTest {
             it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
             it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
             it.setStaleRenderWatchdogMaxTicksForTest(1000)
-            createdVms.add(it)
+            fixture.track(it)
         }
         runCurrent()
         vm.setTmuxClientFactoryForTest { _, requested, _ -> clientFactory(requested) }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1495WatchdogCoverageTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1495WatchdogCoverageTest.kt
@@ -13,21 +13,14 @@ import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -64,13 +57,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue1495WatchdogCoverageTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // Part 2 (red→green) — the watchdog net must SURVIVE past the old tick ceiling on a
@@ -359,22 +347,7 @@ class Issue1495WatchdogCoverageTest {
         return bridge.emulator.screen.transcriptText
     }
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -391,7 +364,7 @@ class Issue1495WatchdogCoverageTest {
         // test is the SOLE opportunity; individual tests re-enable auto-arm as needed.
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1537ParkedRuntimeHealthTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1537ParkedRuntimeHealthTest.kt
@@ -13,20 +13,13 @@ import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxClientFactory
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -58,23 +51,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue1537ParkedRuntimeHealthTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun newVm(
         registry: ActiveTmuxClients,
@@ -87,6 +67,7 @@ class Issue1537ParkedRuntimeHealthTest {
         sshLeaseManager = sshLeaseManager,
         sessionLifecycleSignals = null,
     ).also {
+        fixture.track(it)
         it.setSeedIoDispatcherForTest(Dispatchers.Main)
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1543LivenessProbeAutoStartHangTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1543LivenessProbeAutoStartHangTest.kt
@@ -13,21 +13,14 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -70,27 +63,25 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue1543LivenessProbeAutoStartHangTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // RED→GREEN reproduction — a naive VM test must not silently hang forever.
     // -------------------------------------------------------------------------
 
     @Test
-    fun naiveVmConnectDoesNotHangBecauseAutoStartDefaultsOffInUnitTestRuntime() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        // DELIBERATELY do NOT call LivenessProbeTestOverride.setAutoStartEnabledForTest(false):
-        // this reproduces the naive test author who relies on the DEFAULT. Under the fix the
-        // default is OFF in the Robolectric unit-test runtime, so the probe never auto-arms and
-        // the VM's own advanceUntilIdle() can complete. On base (default ON) the probe's
-        // cancel-terminal-only delay() loop re-arms forever and this test HANGS (times out).
-        try {
+    fun naiveVmConnectDoesNotHangBecauseAutoStartDefaultsOffInUnitTestRuntime() =
+        // Issue #1765: `disableLivenessProbeAutoStart = false` is load-bearing here —
+        // this test's whole point is that the DEFAULT is safe, so the fixture must not
+        // opt out on the body's behalf. Every other standalone fixture keeps the
+        // default `true` (the per-file "EPIC #792 Slice D" opt-out this replaces).
+        fixture.runVmTest(disableLivenessProbeAutoStart = false) {
+            // DELIBERATELY do NOT call LivenessProbeTestOverride.setAutoStartEnabledForTest(false):
+            // this reproduces the naive test author who relies on the DEFAULT. Under the fix the
+            // default is OFF in the Robolectric unit-test runtime, so the probe never auto-arms and
+            // the VM's own advanceUntilIdle() can complete. On base (default ON) the probe's
+            // cancel-terminal-only delay() loop re-arms forever and this test HANGS (times out).
             val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
             // connectVm() itself calls advanceUntilIdle() internally — on base (auto-start default
             // ON) this is EXACTLY where the hang happens: connect -> attachClient ->
@@ -113,12 +104,7 @@ class Issue1543LivenessProbeAutoStartHangTest {
                 "the VM settled connect and surfaced its pane (advanceUntilIdle completed, not hung)",
                 vm.panes.value.any { it.paneId == "%1" },
             )
-        } finally {
-            teardownVms()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
         }
-    }
 
     // -------------------------------------------------------------------------
     // Production preserved — with auto-start EXPLICITLY enabled the probe loop still
@@ -126,19 +112,28 @@ class Issue1543LivenessProbeAutoStartHangTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun livenessProbeStillAutoStartsAndDetectsSilentDropWhenExplicitlyEnabled() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val sink: RecordingDiagnosticEventSink = installRecordingDiagnosticSink()
-        // Explicit opt-in (the PRODUCTION posture) + a short deterministic probe window so the
-        // drop lands within a small BOUNDED advance. We must NEVER call advanceUntilIdle() after
-        // this — the loop is intentionally infinite, so only bounded advanceTimeBy() is safe.
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(true)
-        LivenessProbeTestOverride.setForTest(
-            intervalMs = 10L,
-            perProbeTimeoutMs = 10L,
-            failureThreshold = 2,
-        )
-        try {
+    fun livenessProbeStillAutoStartsAndDetectsSilentDropWhenExplicitlyEnabled() =
+        fixture.runVmTest(disableLivenessProbeAutoStart = false) {
+            val sink: RecordingDiagnosticEventSink = installRecordingDiagnosticSink()
+            // Issue #1765: close the sink and stop the probe/gate BEFORE the fixture clears
+            // the VMs and while Main is still installed — the ordering the pre-migration
+            // `finally` had.
+            fixture.onTeardown {
+                for (vm in createdVms) {
+                    runCatching { vm.forceLivenessProbeDeadForTest = false }
+                    runCatching { vm.setProcessForegroundForClearedForTest(false) }
+                }
+                sink.close()
+            }
+            // Explicit opt-in (the PRODUCTION posture) + a short deterministic probe window so the
+            // drop lands within a small BOUNDED advance. We must NEVER call advanceUntilIdle() after
+            // this — the loop is intentionally infinite, so only bounded advanceTimeBy() is safe.
+            LivenessProbeTestOverride.setAutoStartEnabledForTest(true)
+            LivenessProbeTestOverride.setForTest(
+                intervalMs = 10L,
+                perProbeTimeoutMs = 10L,
+                failureThreshold = 2,
+            )
             val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
             val vm = connectVmBounded(client)
 
@@ -169,32 +164,18 @@ class Issue1543LivenessProbeAutoStartHangTest {
                     "recorded=${drops.size}",
                 drops.isNotEmpty(),
             )
-        } finally {
-            // Stop the probe/gate before teardown so the bounded window closes cleanly.
-            for (vm in createdVms) {
-                runCatching { vm.forceLivenessProbeDeadForTest = false }
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-            }
-            sink.close()
-            teardownVms()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
         }
-    }
 
     // ------------------------------------------------------------------ Harness
 
-    private fun TestScope.teardownVms() {
-        for (vm in createdVms) {
-            runCatching { vm.setProcessForegroundForClearedForTest(false) }
-            runCatching { vm.clearForTest() }
-        }
-        // clearForTest() may schedule teardown coroutines; drain with a bounded advance rather
-        // than advanceUntilIdle (which could hang if any probe were left auto-armed).
-        advanceTimeBy(1_000L)
-        runCurrent()
-        createdVms.clear()
-    }
+    /**
+     * Issue #1765: this file still needs its OWN VM list because
+     * [livenessProbeStillAutoStartsAndDetectsSilentDropWhenExplicitlyEnabled]
+     * has to disarm `forceLivenessProbeDeadForTest`/the foreground gate on each
+     * VM before teardown. The fixture owns the clear/cancel/drain/reset ordering;
+     * this list only feeds that pre-teardown hook.
+     */
+    private val createdVms = mutableListOf<TmuxSessionViewModel>()
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -212,6 +193,7 @@ class Issue1543LivenessProbeAutoStartHangTest {
         // idle-tick bound, so they never hang advanceUntilIdle; disabling them isolates the fix.)
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+        fixture.track(it)
         createdVms.add(it)
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/PaneOutputOverflowRecoveryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PaneOutputOverflowRecoveryTest.kt
@@ -14,20 +14,12 @@ import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
 import com.pocketshell.core.tmux.TmuxOutputBacklogOverflow
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -69,30 +61,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class PaneOutputOverflowRecoveryTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -105,7 +77,7 @@ class PaneOutputOverflowRecoveryTest {
         sessionLifecycleSignals = null,
     ).also {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/PartialBlackPaneHealTest.kt
@@ -11,20 +11,12 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
@@ -84,8 +76,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class PartialBlackPaneHealTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     @Test
     fun issue966ManualInjectionRejectsAnUnequalVisibleEmulatorOwner() = runVmTest {
@@ -200,11 +192,6 @@ class PartialBlackPaneHealTest {
         assertEquals(0, completed.automaticHealOperationsInFlight)
         assertTrue(completed.automaticHealActivityEpoch > settled.automaticHealActivityEpoch)
         assertTrue(rejected.message.orEmpty().contains("automatic render heal raced injection"))
-    }
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
     }
 
     // -------------------------------------------------------------------------
@@ -738,22 +725,7 @@ class PartialBlackPaneHealTest {
 
     // ------------------------------------------------------------------ Harness
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -766,7 +738,7 @@ class PartialBlackPaneHealTest {
         sessionLifecycleSignals = null,
     ).also {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/ReconcileReseedRaceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ReconcileReseedRaceTest.kt
@@ -13,21 +13,15 @@ import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -91,13 +85,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class ReconcileReseedRaceTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -----------------------------------------------------------------------
     // (1) THE RACE — a newer in-flight delta must survive the reseed apply.
@@ -518,22 +507,7 @@ class ReconcileReseedRaceTest {
         return !(field.getBoolean(bridge))
     }
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -550,7 +524,7 @@ class ReconcileReseedRaceTest {
         // under test (each test re-arms explicitly where it drives the periodic loop).
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/RedrawNonDestructiveReseedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RedrawNonDestructiveReseedTest.kt
@@ -12,21 +12,14 @@ import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -80,30 +73,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class RedrawNonDestructiveReseedTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -116,7 +89,7 @@ class RedrawNonDestructiveReseedTest {
         sessionLifecycleSignals = null,
     ).also {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealEventReconcileTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealEventReconcileTest.kt
@@ -10,20 +10,12 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -61,13 +53,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class RenderHealEventReconcileTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // (1) The send reconcile EVENT heals a suspect active pane (behavior preserved
@@ -235,22 +222,7 @@ class RenderHealEventReconcileTest {
         return bridge.emulator.screen.transcriptText
     }
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -265,7 +237,7 @@ class RenderHealEventReconcileTest {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealSingleFlightTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealSingleFlightTest.kt
@@ -13,21 +13,14 @@ import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -81,13 +74,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class RenderHealSingleFlightTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -----------------------------------------------------------------------
     // (1) THE RACE — two concurrent heals on ONE pane must not clobber a newer
@@ -297,22 +285,7 @@ class RenderHealSingleFlightTest {
         return !(field.getBoolean(bridge))
     }
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -327,7 +300,7 @@ class RenderHealSingleFlightTest {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/RenderHealTimeoutTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/RenderHealTimeoutTest.kt
@@ -11,11 +11,8 @@ import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -23,11 +20,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.currentTime
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -77,13 +70,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class RenderHealTimeoutTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // (1) LOOP-LIVENESS — a wedged heal capture must not freeze the watchdog loop.
@@ -276,22 +264,7 @@ class RenderHealTimeoutTest {
     private fun FakeTmuxClient.healCaptureCount(): Int =
         sentCommands.count { it.startsWith("capture-pane") && it.contains(" -e") }
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -306,7 +279,7 @@ class RenderHealTimeoutTest {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/ReseedBlankWatchdogCharacterizationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ReseedBlankWatchdogCharacterizationTest.kt
@@ -17,21 +17,15 @@ import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -90,7 +84,8 @@ class ReseedBlankWatchdogCharacterizationTest {
     private fun TmuxSessionViewModel.loadingHoldRaisedForTest(): Boolean =
         revealState.value is com.pocketshell.core.connection.RevealState.Seeding
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // Every VM created during a test is tracked so [runVmTest] can tear it down
     // deterministically INSIDE the runTest body (before runTest's uncompleted-
@@ -99,37 +94,8 @@ class ReseedBlankWatchdogCharacterizationTest {
     // scheduler), so a test that advances time past a disconnect can leave a
     // VM-owned coroutine parked on a delay — `clearForTest()` cancels the scope
     // and drains it, keeping the suite free of `UncompletedCoroutinesError`.
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        // EPIC #792 Slice D: disable the VM LivenessProbe auto-start — its infinite
-        // periodic `delay` loop would otherwise spin `advanceUntilIdle()` forever on
-        // this virtual-clock Main (this file does not use MainDispatcherRule).
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            // Tear down every VM the body created, draining its background
-            // coroutines on the virtual clock so runTest sees a quiescent scope.
-            for (vm in createdVms) {
-                // Don't park the runtime for a background grace — we want a
-                // clean, immediate teardown (cancel viewModelScope, close the
-                // connection), not a deferred handoff that keeps timers alive.
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -147,7 +113,7 @@ class ReseedBlankWatchdogCharacterizationTest {
         // clock and `advanceUntilIdle` drains them deterministically. Production
         // defaults to `Dispatchers.IO` (a real thread off the UI thread).
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/SendWaitWarmLeaseTrustTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SendWaitWarmLeaseTrustTest.kt
@@ -9,19 +9,14 @@ import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -60,23 +55,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE)
 class SendWaitWarmLeaseTrustTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         sshLeaseManager: SshLeaseManager,
@@ -87,6 +69,7 @@ class SendWaitWarmLeaseTrustTest {
         sshLeaseManager = sshLeaseManager,
         sessionLifecycleSignals = null,
     ).also {
+        fixture.track(it)
         // Issue #926: pin the seed-IO dispatcher (off-Main hop for the
         // attach/switch/reattach `capture-pane`/`list-panes` IO) to the shared
         // virtual-clock scheduler so the round-trips run inline on the test clock

--- a/app/src/test/java/com/pocketshell/app/tmux/SingleReseedPathFoldTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SingleReseedPathFoldTest.kt
@@ -13,20 +13,12 @@ import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -83,13 +75,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class SingleReseedPathFoldTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // (1) FORCED reseed (the reattach/switch/foreground/blank chokepoint) must apply
@@ -249,22 +236,7 @@ class SingleReseedPathFoldTest {
 
     // ------------------------------------------------------------------ Harness
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -277,7 +249,7 @@ class SingleReseedPathFoldTest {
         sessionLifecycleSignals = null,
     ).also {
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleRenderWatchdogGatingTest.kt
@@ -10,21 +10,13 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -92,13 +84,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class StaleRenderWatchdogGatingTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // (1) Back-off curve — the pure interval function. 4s -> 8s -> 16s -> 30s, capped.
@@ -821,22 +808,7 @@ class StaleRenderWatchdogGatingTest {
         for (line in lines) append(line).append("\r\n")
     }
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -854,7 +826,7 @@ class StaleRenderWatchdogGatingTest {
         // capture counts + timings are deterministic (and connect()'s advanceUntilIdle
         // stays cheap). Tests re-enable / re-arm as needed.
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/StandaloneTmuxVmFixture.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StandaloneTmuxVmFixture.kt
@@ -1,0 +1,336 @@
+package com.pocketshell.app.tmux
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Issue #1765 — the shared teardown seam for the *standalone* JVM fixtures that
+ * construct [TmuxSessionViewModel] directly inside a `runTest` body and then
+ * reset the process-global `Dispatchers.Main` themselves (i.e. every VM fixture
+ * that does NOT use [com.pocketshell.app.hosts.MainDispatcherRule]).
+ *
+ * ## The bug this exists to stop
+ *
+ * The #1355 recurrence was a standalone fixture of exactly this shape:
+ *
+ * ```
+ * runTest {
+ *     Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+ *     try { body() } finally {
+ *         createdVms.forEach { it.clearForTest() }   // does NOT cancel viewModelScope
+ *         advanceUntilIdle()                         // does NOT wait for real-IO children
+ *         Dispatchers.resetMain()                    // <-- races the still-live children
+ *     }
+ * }
+ * ```
+ *
+ * `clearForTest()` calls `onCleared()` DIRECTLY, so — unlike the framework's
+ * `ViewModel.clear()` — it never cancels `viewModelScope`/`bridgeScope`. Any VM
+ * launch that hopped to a REAL background dispatcher therefore survives the
+ * body, and its continuation re-dispatches onto `Dispatchers.Main` after the
+ * fixture already reset the global delegate — the `TestMainDispatcher:72` race,
+ * which surfaces as a flake in a completely unrelated test class.
+ * `factoryScope.cancel()` in `@After` has the same hole: `cancel()` only
+ * *requests* cancellation and returns before a real-IO child has unwound.
+ *
+ * ## What this fixture guarantees
+ *
+ * While Main is still installed, and only then resetting it:
+ *
+ * 1. every registered body cleanup runs (LIFO — e.g. a diagnostic sink close);
+ * 2. every tracked VM is cleared in reverse construction order;
+ * 3. every VM-owned coroutine root is cancelled;
+ * 4. every fixture-owned real-IO root ([factoryScope], [leaseScope], anything
+ *    passed to [trackRoot]) is cancelled **and joined**;
+ * 5. a generously bounded, `runCurrent`-only drain HARD-FAILS unless the active
+ *    VM-owned child count reaches zero; and
+ * 6. `Dispatchers.resetMain()` runs — guarded by a phase oracle so moving it
+ *    ahead of the drain is a deterministic RED rather than an intermittent
+ *    cross-class race.
+ *
+ * The drain itself is [TmuxSessionViewModelRuleTeardown], shared verbatim with
+ * the [com.pocketshell.app.hosts.MainDispatcherRule] consumers — this class only
+ * supplies the scheduler binding and the Main install/reset ordering.
+ *
+ * ## Invariants callers rely on
+ *
+ * - The teardown NEVER advances virtual time (no `advanceUntilIdle`, no
+ *   `advanceTimeBy`): it uses `runCurrent()` only, so a body's watchdog
+ *   deadlines and timing oracles cannot be perturbed by cleanup.
+ * - The teardown runs after the `runTest` body has completed but still INSIDE
+ *   the `runTest` block, so it cannot interleave with body assertions and it
+ *   still finishes before `runTest`'s own `advanceUntilIdleOr` cleanup (see
+ *   [runVmTest]).
+ * - A body failure stays the PRIMARY failure; later teardown failures are
+ *   attached as suppressed exceptions.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class StandaloneTmuxVmFixture(
+    timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+) {
+
+    /**
+     * The single virtual clock shared by the installed Main dispatcher, the
+     * `runTest` body, and the teardown drain.
+     */
+    val scheduler: TestCoroutineScheduler = TestCoroutineScheduler()
+
+    private val teardown = TmuxSessionViewModelRuleTeardown(
+        runCurrent = scheduler::runCurrent,
+        timeoutMs = timeoutMs,
+    )
+
+    private val bodyCleanups = mutableListOf<() -> Unit>()
+    private val oracle = MainResetPhaseOracle()
+    private var started = false
+    private var trackedVmCount = 0
+
+    /**
+     * Fixture-owned REAL-IO root for `TmuxClientFactory`. Replaces the
+     * per-fixture `private val factoryScope = CoroutineScope(SupervisorJob() +
+     * Dispatchers.IO)` + `@After { factoryScope.cancel() }` pair, which
+     * cancelled without joining.
+     *
+     * Deliberately a real `Dispatchers.IO` scope, not a test dispatcher: the
+     * production `TmuxClientFactory` runs its blocking control-channel IO off
+     * the caller's thread, and pinning it to the virtual clock would change the
+     * behaviour under test. The join in the teardown is what makes the real
+     * dispatcher safe here.
+     */
+    val factoryScope: CoroutineScope = trackRoot(
+        name = "factoryScope",
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    )
+
+    /**
+     * Fixture-owned REAL-IO root for an `SshLeaseManager` built WITHOUT an
+     * explicit `scope =` argument. `SshLeaseManager`'s default scope is a fresh
+     * unowned `CoroutineScope(SupervisorJob() + Dispatchers.IO)` that nothing
+     * ever cancels — a second leak vector alongside the VM roots. Pass this
+     * instead.
+     *
+     * Lease managers built through `TestScope.testLeaseManager(...)` default to
+     * `scope = this` (the `TestScope`), which `runTest` already owns; those do
+     * not need this root.
+     */
+    val leaseScope: CoroutineScope by lazy {
+        trackRoot(name = "leaseScope", scope = CoroutineScope(SupervisorJob() + Dispatchers.IO))
+    }
+
+    /**
+     * Registers a VM for teardown. EVERY directly constructed
+     * [TmuxSessionViewModel] in a fixture must be tracked — an untracked VM is
+     * exactly the #1355 leak, and the fixture cannot see it.
+     */
+    fun track(vm: TmuxSessionViewModel): TmuxSessionViewModel {
+        trackedVmCount++
+        teardown.track(vm)
+        return vm
+    }
+
+    /**
+     * Adapter for the teardown ordering invariant itself — the fixture's own
+     * tests register observable stand-ins here. Production-shaped callers use
+     * [track]; both paths share the exact same clear/cancel/drain implementation.
+     */
+    internal fun trackForTest(
+        clear: () -> Unit,
+        cancelOwnScopes: () -> Unit,
+        activeOwnScopeChildCount: () -> Int,
+    ) {
+        trackedVmCount++
+        teardown.track(
+            clear = clear,
+            cancelOwnScopes = cancelOwnScopes,
+            activeOwnScopeChildCount = activeOwnScopeChildCount,
+        )
+    }
+
+    /** Registers an extra fixture-owned coroutine root to cancel AND join. */
+    fun trackRoot(name: String, scope: CoroutineScope): CoroutineScope =
+        teardown.trackRoot(name, scope)
+
+    /**
+     * Registers body-scoped cleanup (e.g. `sink.close()`) that must run BEFORE
+     * the VMs are cleared and while Main is still installed. Callbacks run in
+     * reverse registration order.
+     */
+    fun onTeardown(block: () -> Unit) {
+        bodyCleanups += block
+    }
+
+    /** Number of VMs registered through [track] — used by the fixture's own tests. */
+    internal fun trackedVmCountForTest(): Int = trackedVmCount
+
+    /** The phase oracle this fixture drives — asserted directly by its own tests. */
+    internal fun phaseOracleForTest(): MainResetPhaseOracle = oracle
+
+    /**
+     * Runs [body] as a `runTest` on this fixture's scheduler with
+     * `Dispatchers.Main` installed, then performs the ordered teardown above —
+     * INSIDE the `runTest` body, exactly where the 28 hand-rolled `finally`
+     * blocks it replaces ran.
+     *
+     * That placement is load-bearing, not cosmetic. `runTest`'s OWN cleanup
+     * (`TestBuilders.kt:370`) calls `testScheduler.advanceUntilIdleOr { ... }`
+     * after the body returns, and it drains work from EVERY coroutine on the
+     * scheduler — including foreign, VM-owned ones. A VM whose self-rearming
+     * loop is still armed at that point (the #1543 liveness probe with
+     * auto-start explicitly enabled) makes that cleanup spin forever: a silent
+     * 35-minute CI hang, not an assertion failure. Draining after `runTest`
+     * returns reproduces exactly that hang, so the drain must finish first.
+     *
+     * @param disableLivenessProbeAutoStart mirrors the per-fixture "EPIC #792
+     * Slice D" opt-out. Left ON only by the fixtures that deliberately exercise
+     * the auto-start default itself (#1543).
+     */
+    fun runVmTest(
+        disableLivenessProbeAutoStart: Boolean = true,
+        body: suspend TestScope.() -> Unit,
+    ) {
+        check(!started) {
+            "Issue #1765: a StandaloneTmuxVmFixture drives exactly one test method; " +
+                "construct it as a per-test field, not a shared object"
+        }
+        started = true
+        Dispatchers.setMain(StandardTestDispatcher(scheduler))
+        if (disableLivenessProbeAutoStart) {
+            LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+        }
+
+        runTest(scheduler, timeout = TEST_TIMEOUT) {
+            var failure: Throwable? = null
+            fun capture(block: () -> Unit) {
+                try {
+                    block()
+                } catch (thrown: Throwable) {
+                    val first = failure
+                    if (first == null) {
+                        failure = thrown
+                    } else if (first !== thrown) {
+                        first.addSuppressed(thrown)
+                    }
+                }
+            }
+
+            // The body failure is recorded the same way as teardown failures so
+            // it stays PRIMARY: every later cleanup failure is attached as
+            // suppressed instead of masking what the test actually proved.
+            try {
+                body()
+            } catch (thrown: Throwable) {
+                failure = thrown
+            }
+
+            bodyCleanups.asReversed().forEach { cleanup -> capture(cleanup) }
+
+            capture {
+                oracle.beginDrain()
+                try {
+                    teardown.drain()
+                } finally {
+                    // "Complete" means the bounded drain phase returned or
+                    // hard-failed. drain()'s own zero-child assertion stays the
+                    // behavioural invariant; this transition only lets
+                    // exception-safe cleanup reset the global Main after
+                    // recording that failure, rather than stranding Main
+                    // installed for every following test class.
+                    oracle.drainComplete()
+                }
+            }
+
+            capture { LivenessProbeTestOverride.clear() }
+
+            // Phase oracle: resetting Main before the drain is the #1355 defect.
+            // Reordering this call ahead of the drain is a deterministic RED, and
+            // the oracle detects it WITHOUT having to dispatch anything onto an
+            // already-reset Main dispatcher.
+            capture { oracle.resetMain(Dispatchers::resetMain) }
+
+            failure?.let { throw it }
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_TIMEOUT_MS = 30_000L
+
+        /**
+         * `runTest`'s own wall-clock bound, raised from its 60s default only so
+         * that a hard-failing teardown drain (up to three bounded
+         * [DEFAULT_TIMEOUT_MS] phases: factory root, lease root, VM children)
+         * reports ITS diagnostic instead of being masked by an
+         * `UncompletedCoroutinesError`. A wedged body is still bounded.
+         */
+        val TEST_TIMEOUT: Duration = 150.seconds
+    }
+}
+
+/**
+ * Issue #1765 ordering oracle for "reset `Dispatchers.Main` ONLY after the VM
+ * drain".
+ *
+ * It is a separate, directly exercisable object rather than a couple of inline
+ * `check(...)` calls precisely so the RED for a premature reset is deterministic
+ * and cheap: a test (and a mutation) can drive [resetMain] without a completed
+ * drain and observe the hard failure, WITHOUT having to dispatch a coroutine
+ * onto an already-reset Main dispatcher and hope the race reproduces. The old
+ * failure mode was an intermittent `TestMainDispatcher.kt:72` crash in an
+ * unrelated later test class; that is not something a test can wait for.
+ */
+internal class MainResetPhaseOracle {
+
+    enum class Phase {
+        MAIN_INSTALLED,
+        DRAIN_COMPLETE,
+        MAIN_RESET_STARTED,
+        MAIN_RESET_COMPLETE,
+    }
+
+    var phase: Phase = Phase.MAIN_INSTALLED
+        private set
+
+    /** Hard-fails unless the drain is about to run with Main still installed. */
+    fun beginDrain() {
+        check(phase == Phase.MAIN_INSTALLED) {
+            "Issue #1765: the TmuxSessionViewModel drain must run while " +
+                "Dispatchers.Main is still installed (phase=$phase)"
+        }
+    }
+
+    /**
+     * Records that the bounded drain phase returned OR hard-failed. The drain's
+     * own zero-child assertion stays the behavioural invariant; this transition
+     * only lets exception-safe cleanup still reset the global Main after
+     * recording that failure, instead of stranding Main for the next class.
+     */
+    fun drainComplete() {
+        if (phase == Phase.MAIN_INSTALLED) {
+            phase = Phase.DRAIN_COMPLETE
+        }
+    }
+
+    /** Hard-fails unless [drainComplete] has run, then performs [reset]. */
+    fun resetMain(reset: () -> Unit) {
+        check(phase == Phase.DRAIN_COMPLETE) {
+            "Issue #1765: Dispatchers.resetMain() cannot start before the " +
+                "TmuxSessionViewModel drain completes (phase=$phase); resetting Main " +
+                "first recreates the TestMainDispatcher:72 race in an unrelated test class"
+        }
+        phase = Phase.MAIN_RESET_STARTED
+        try {
+            reset()
+        } finally {
+            phase = Phase.MAIN_RESET_COMPLETE
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/StandaloneTmuxVmFixtureTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StandaloneTmuxVmFixtureTest.kt
@@ -1,0 +1,486 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Issue #1765 — the shared standalone-fixture seam's own proof.
+ *
+ * Each test here pins one clause of the acceptance criteria for
+ * [StandaloneTmuxVmFixture], the helper that replaced 28 bespoke
+ * `runTest { setMain(...) ... finally { clear; advanceUntilIdle; resetMain } }`
+ * teardowns.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class StandaloneTmuxVmFixtureTest {
+
+    // ---------------------------------------------------------------------
+    // Ordering: clear -> cancel -> drain, all while Main is still installed.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun clearsTrackedVmsInReverseRegistrationOrderBeforeCancelling() {
+        val events = mutableListOf<String>()
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 1_000L)
+        fixture.runVmTest {
+            fixture.trackForTest(
+                clear = { events += "clear-first" },
+                cancelOwnScopes = { events += "cancel-first" },
+                activeOwnScopeChildCount = { 0 },
+            )
+            fixture.trackForTest(
+                clear = { events += "clear-second" },
+                cancelOwnScopes = { events += "cancel-second" },
+                activeOwnScopeChildCount = { 0 },
+            )
+        }
+
+        // Reverse-order clear (the second VM constructed is torn down first),
+        // then cancellation for every VM in registration order. The trailing
+        // cancel pair is the bounded drain's first (and only needed) sweep.
+        assertEquals(
+            listOf(
+                "clear-second",
+                "clear-first",
+                "cancel-first",
+                "cancel-second",
+                "cancel-first",
+                "cancel-second",
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun vmDrainRunsWhileMainIsStillInstalledAndMainIsResetOnlyAfterwards() {
+        val ranOnInstalledMainDuringDrain = AtomicBoolean(false)
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 1_000L)
+        fixture.runVmTest {
+            fixture.trackForTest(
+                clear = {},
+                cancelOwnScopes = {
+                    // If Main had already been reset this would post to the real
+                    // Android main looper and the fixture scheduler would never
+                    // run it.
+                    CoroutineScope(Dispatchers.Main).launch {
+                        ranOnInstalledMainDuringDrain.set(true)
+                    }
+                    fixture.scheduler.runCurrent()
+                },
+                activeOwnScopeChildCount = { 0 },
+            )
+        }
+
+        assertTrue(
+            "the VM drain must run while Dispatchers.Main is still the fixture dispatcher",
+            ranOnInstalledMainDuringDrain.get(),
+        )
+        assertEquals(
+            MainResetPhaseOracle.Phase.MAIN_RESET_COMPLETE,
+            fixture.phaseOracleForTest().phase,
+        )
+
+        // And Main really is reset once runVmTest returns: work posted to
+        // Dispatchers.Main no longer lands on the fixture's scheduler.
+        val ranAfterReset = AtomicBoolean(false)
+        CoroutineScope(Dispatchers.Main).launch { ranAfterReset.set(true) }
+        fixture.scheduler.runCurrent()
+        assertFalse(
+            "Dispatchers.Main must be reset once runVmTest returns",
+            ranAfterReset.get(),
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // The premature-reset oracle — deterministic RED, no dispatch required.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun resetMainBeforeTheDrainCompletesIsADeterministicHardFailure() {
+        val oracle = MainResetPhaseOracle()
+        oracle.beginDrain()
+        var reset = false
+
+        val failure = runCatching { oracle.resetMain { reset = true } }.exceptionOrNull()
+
+        assertTrue(
+            "resetting Main before the drain completes must hard-fail, got $failure",
+            failure is IllegalStateException,
+        )
+        assertTrue(
+            "the failure must name the race it prevents: ${failure?.message}",
+            failure?.message.orEmpty().contains("TestMainDispatcher:72"),
+        )
+        assertFalse("Dispatchers.resetMain() must not have run", reset)
+        assertEquals(MainResetPhaseOracle.Phase.MAIN_INSTALLED, oracle.phase)
+    }
+
+    @Test
+    fun drainMustBeginWhileMainIsStillInstalled() {
+        val oracle = MainResetPhaseOracle()
+        oracle.drainComplete()
+        oracle.resetMain { }
+
+        val failure = runCatching { oracle.beginDrain() }.exceptionOrNull()
+
+        assertTrue(
+            "draining after Main was reset must hard-fail, got $failure",
+            failure is IllegalStateException,
+        )
+    }
+
+    @Test
+    fun resetMainRunsExactlyOnceAfterTheDrainCompletes() {
+        val oracle = MainResetPhaseOracle()
+        var resets = 0
+        oracle.beginDrain()
+        oracle.drainComplete()
+
+        oracle.resetMain { resets++ }
+
+        assertEquals(1, resets)
+        assertEquals(MainResetPhaseOracle.Phase.MAIN_RESET_COMPLETE, oracle.phase)
+    }
+
+    // ---------------------------------------------------------------------
+    // The drain is load-bearing: a non-quiescing VM child is a hard RED.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun aVmChildThatNeverQuiescesHardFailsInsteadOfLeakingPastMainReset() {
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 50L)
+
+        val failure = runCatching {
+            fixture.runVmTest {
+                fixture.trackForTest(
+                    clear = {},
+                    cancelOwnScopes = {},
+                    // Models a VM launch that hopped to a REAL dispatcher and is
+                    // still unwinding: cancel() returned but the child has not.
+                    activeOwnScopeChildCount = { 1 },
+                )
+            }
+        }.exceptionOrNull()
+
+        assertTrue(
+            "an un-drained VM child must be a deterministic AssertionError, got $failure",
+            failure is AssertionError,
+        )
+        assertTrue(
+            "the failure must explain the resetMain race: ${failure?.message}",
+            failure?.message.orEmpty().contains("TestMainDispatcher:72"),
+        )
+        // Even on that failure the fixture still resets global Main, so the
+        // failure does not cascade into every following test class.
+        assertEquals(
+            MainResetPhaseOracle.Phase.MAIN_RESET_COMPLETE,
+            fixture.phaseOracleForTest().phase,
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // Owned real-IO roots are cancelled AND joined, not merely cancelled.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun ownedFactoryAndLeaseRootsAreCancelledAndJoined() {
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 5_000L)
+        val factoryStarted = AtomicBoolean(false)
+        val leaseStarted = AtomicBoolean(false)
+
+        fixture.runVmTest {
+            fixture.factoryScope.launch {
+                factoryStarted.set(true)
+                awaitCancellation()
+            }
+            fixture.leaseScope.launch {
+                leaseStarted.set(true)
+                awaitCancellation()
+            }
+            while (!factoryStarted.get() || !leaseStarted.get()) {
+                Thread.yield()
+            }
+        }
+
+        assertTrue(
+            "the fixture-owned factoryScope root must be COMPLETED, not merely cancellation-requested",
+            fixture.factoryScope.coroutineContext[Job]!!.isCompleted,
+        )
+        assertTrue(
+            "the fixture-owned leaseScope root must be COMPLETED, not merely cancellation-requested",
+            fixture.leaseScope.coroutineContext[Job]!!.isCompleted,
+        )
+    }
+
+    @Test
+    fun extraOwnedRootsRegisteredWithTrackRootAreAlsoJoined() {
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 5_000L)
+        val extra = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val started = AtomicBoolean(false)
+
+        assertSame(extra, fixture.trackRoot("extra", extra))
+        fixture.runVmTest {
+            extra.launch {
+                started.set(true)
+                awaitCancellation()
+            }
+            while (!started.get()) {
+                Thread.yield()
+            }
+        }
+
+        assertTrue(extra.coroutineContext[Job]!!.isCompleted)
+    }
+
+    // ---------------------------------------------------------------------
+    // Body cleanups, failure precedence, and clock neutrality.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun bodyCleanupsRunBeforeVmClearInReverseRegistrationOrder() {
+        val events = mutableListOf<String>()
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 1_000L)
+
+        fixture.runVmTest {
+            fixture.onTeardown { events += "cleanup-first" }
+            fixture.onTeardown { events += "cleanup-second" }
+            fixture.trackForTest(
+                clear = { events += "clear" },
+                cancelOwnScopes = {},
+                activeOwnScopeChildCount = { 0 },
+            )
+        }
+
+        assertEquals(listOf("cleanup-second", "cleanup-first", "clear"), events)
+    }
+
+    @Test
+    fun theBodyFailureStaysPrimaryAndTeardownFailuresAreSuppressed() {
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 50L)
+        val bodyFailure = IllegalArgumentException("the assertion the test actually proved")
+
+        val thrown = runCatching {
+            fixture.runVmTest {
+                fixture.onTeardown { error("cleanup blew up") }
+                fixture.trackForTest(
+                    clear = {},
+                    cancelOwnScopes = {},
+                    activeOwnScopeChildCount = { 1 },
+                )
+                throw bodyFailure
+            }
+        }.exceptionOrNull()
+
+        assertSame(
+            "the body failure must stay PRIMARY so the real defect is what the report shows",
+            bodyFailure,
+            thrown,
+        )
+        val suppressed = thrown!!.suppressed.map { it::class.java.simpleName to it.message }
+        assertTrue(
+            "the cleanup failure must be attached, not lost: $suppressed",
+            thrown.suppressed.any { it.message.orEmpty().contains("cleanup blew up") },
+        )
+        assertTrue(
+            "the un-drained VM failure must be attached, not lost: $suppressed",
+            thrown.suppressed.any { it is AssertionError },
+        )
+    }
+
+    @Test
+    fun teardownNeverAdvancesTheVirtualClock() {
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 1_000L)
+        var timeAtBodyEnd = -1L
+        var timeAtClear = -1L
+        var timeAtDrain = -1L
+
+        fixture.runVmTest {
+            // A pending delayed task the drain must NOT run: only a virtual-time
+            // advance would reach it, and that is exactly what would trip the
+            // #793 re-seed watchdog in a migrated fixture.
+            backgroundScope.launch { kotlinx.coroutines.delay(60_000L) }
+            fixture.factoryScope.launch { awaitCancellation() }
+            fixture.trackForTest(
+                clear = { timeAtClear = fixture.scheduler.currentTime },
+                cancelOwnScopes = { timeAtDrain = fixture.scheduler.currentTime },
+                activeOwnScopeChildCount = { 0 },
+            )
+            timeAtBodyEnd = fixture.scheduler.currentTime
+        }
+
+        assertEquals(
+            "clearing the tracked VMs must not advance the virtual clock",
+            timeAtBodyEnd,
+            timeAtClear,
+        )
+        assertEquals(
+            "the #1765 drain is runCurrent-only: advancing virtual time would trip " +
+                "the #793 re-seed watchdog and perturb every body timing oracle",
+            timeAtBodyEnd,
+            timeAtDrain,
+        )
+    }
+
+    @Test
+    fun aSecondRunVmTestOnTheSameFixtureIsRejected() {
+        val fixture = StandaloneTmuxVmFixture(timeoutMs = 1_000L)
+        fixture.runVmTest { }
+
+        try {
+            fixture.runVmTest { }
+            fail("a StandaloneTmuxVmFixture must drive exactly one test method")
+        } catch (expected: IllegalStateException) {
+            assertTrue(
+                expected.message.orEmpty().contains("exactly one test method"),
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // End-to-end with a REAL TmuxSessionViewModel — the property the 28
+    // migrated fixtures depend on.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun aRealConnectedViewModelIsFullyQuiescentByTheTimeMainIsReset() {
+        val fixture = StandaloneTmuxVmFixture()
+        lateinit var vm: TmuxSessionViewModel
+
+        fixture.runVmTest {
+            val client = FakeTmuxClient().apply {
+                responses.addLast(
+                    CommandResponse(
+                        number = 1L,
+                        output = listOf("%1\t@0\t\$0\twork\twork\t0"),
+                        isError = false,
+                    ),
+                )
+                capturePaneResponses.addLast(
+                    CommandResponse(number = 2L, output = listOf("work ready"), isError = false),
+                )
+                cursorQueryResponses.addLast(
+                    CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+                )
+            }
+            vm = fixture.track(
+                TmuxSessionViewModel(
+                    tmuxClientFactory = TmuxClientFactory(fixture.factoryScope),
+                    activeTmuxClients = ActiveTmuxClients(),
+                    runtimeCache = TmuxSessionRuntimeCache(),
+                    sshLeaseManager = testLeaseManager(
+                        connector = SingleLiveSessionConnector(),
+                        scope = this,
+                        idleTtlMillis = 60_000L,
+                    ),
+                    sessionLifecycleSignals = null,
+                ),
+            ).also {
+                it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+                it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+                it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+                it.setTmuxClientFactoryForTest { _, _, _ -> client }
+            }
+            vm.connect(
+                hostId = 1L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                passphrase = null,
+                sessionName = "work",
+            )
+            advanceUntilIdle()
+            assertTrue(
+                "precondition: the VM actually connected and seeded a pane",
+                vm.panes.value.any { it.paneId == "%1" },
+            )
+        }
+
+        assertEquals(
+            "no TmuxSessionViewModel-owned coroutine may survive the Main reset (#1355/#1765)",
+            0,
+            vm.activeOwnScopeChildCountForTest(),
+        )
+        assertTrue(
+            "the fixture-owned factory root must be joined, not merely cancelled",
+            fixture.factoryScope.coroutineContext[Job]!!.isCompleted,
+        )
+        assertEquals(1, fixture.trackedVmCountForTest())
+    }
+
+    // ------------------------------------------------------------------ Fakes
+
+    private class SingleLiveSessionConnector : SshLeaseConnector {
+        private val session = AlwaysLiveSession()
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysLiveSession : SshSession {
+        @Volatile
+        private var closed = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SurfaceBlackModelIntactDiagnosticTest.kt
@@ -12,20 +12,12 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -77,13 +69,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class SurfaceBlackModelIntactDiagnosticTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // GREEN — model intact (oracle healthy) but the surface last painted a BLACK
@@ -539,23 +526,12 @@ class SurfaceBlackModelIntactDiagnosticTest {
 
     // ------------------------------------------------------------------ Harness
 
-    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
+    private fun runVmTest(body: suspend TestScope.(RecordingSink) -> Unit) = fixture.runVmTest {
         val sink = installRecordingDiagnosticSink()
-        try {
-            body(RecordingSink(sink))
-        } finally {
-            sink.close()
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
+        // Issue #1765: the sink must close BEFORE the VMs are cleared and while
+        // Main is still installed, exactly as the pre-migration `finally` did.
+        fixture.onTeardown { sink.close() }
+        body(RecordingSink(sink))
     }
 
     /** Thin wrapper so the test body can pull black-frame events by class without imports. */
@@ -591,7 +567,7 @@ class SurfaceBlackModelIntactDiagnosticTest {
         // drives directly — no spurious events.
         it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
         it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCoalescedCancelRedialTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCoalescedCancelRedialTest.kt
@@ -14,20 +14,15 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -68,23 +63,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class TmuxSessionCoalescedCancelRedialTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.coalescingLeaseManager(connector: SshLeaseConnector): SshLeaseManager =
         SshLeaseManager(
@@ -108,6 +90,7 @@ class TmuxSessionCoalescedCancelRedialTest {
         sshLeaseManager = sshLeaseManager,
         sessionLifecycleSignals = null,
     ).also {
+        fixture.track(it)
         it.setSeedIoDispatcherForTest(Dispatchers.Main)
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionStaleLeaseAutoRecoverTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionStaleLeaseAutoRecoverTest.kt
@@ -10,20 +10,15 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -56,12 +51,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class TmuxSessionStaleLeaseAutoRecoverTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     /**
      * Run the test body with `Dispatchers.Main` bound to a
@@ -74,19 +65,7 @@ class TmuxSessionStaleLeaseAutoRecoverTest {
      * [advanceUntilIdle] drives the heal to completion exactly as production
      * would.
      */
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        // EPIC #792 Slice D: disable the VM LivenessProbe auto-start — its infinite
-        // periodic `delay` loop would otherwise spin `advanceUntilIdle()` forever on
-        // this virtual-clock Main (this file does not use MainDispatcherRule).
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestNewVm(
         registry: ActiveTmuxClients,
@@ -98,6 +77,7 @@ class TmuxSessionStaleLeaseAutoRecoverTest {
         sshLeaseManager = sshLeaseManager,
         sessionLifecycleSignals = null,
     ).also {
+        fixture.track(it)
         // Issue #926: pin the seed-IO dispatcher (off-Main hop for the
         // attach/switch/reattach `capture-pane`/`list-panes` IO) to the installed
         // virtual-clock test Main so the round-trips run inline on the test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardown.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardown.kt
@@ -9,13 +9,14 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 /**
- * Shared #1355 teardown for standalone [MainDispatcherRule] consumers that
- * construct [TmuxSessionViewModel].
+ * Shared #1355 teardown registry for JVM fixtures that construct
+ * [TmuxSessionViewModel] directly and later reset the process-global
+ * `Dispatchers.Main`.
  *
  * `clearForTest()` invokes `onCleared()` directly, so it does not perform the
  * framework-owned `viewModelScope` cancellation. A bare `CoroutineScope.cancel`
  * also returns before a real-IO child has necessarily unwound. Both can leave a
- * continuation that reads `Dispatchers.Main` after the rule resets the global
+ * continuation that reads `Dispatchers.Main` after the fixture resets the global
  * delegate, recreating the `TestMainDispatcher:72` race in an unrelated test.
  *
  * This registry makes the ordering structural:
@@ -23,12 +24,28 @@ import kotlinx.coroutines.withTimeout
  * 1. clear every tracked VM while Main is installed;
  * 2. cancel every VM-owned root and every explicitly owned collaborator root;
  * 3. cancel-and-join the collaborator roots;
- * 4. use only `runCurrent()` (never virtual-time advancement) to drain all VM
+ * 4. use only [runCurrent] (never virtual-time advancement) to drain all VM
  *    roots to zero; and
- * 5. return to [MainDispatcherRule], which only then resets Main.
+ * 5. return to the caller, which only then resets Main.
+ *
+ * Issue #1765: it has exactly TWO bindings, so the drain algorithm above is
+ * written once rather than copied per fixture:
+ *
+ *  - [MainDispatcherRule] consumers bind it through
+ *    [tmuxSessionViewModelTeardown], which registers [drain] on the rule's
+ *    `beforeResetMain` boundary; and
+ *  - standalone `runTest` fixtures bind it through [StandaloneTmuxVmFixture],
+ *    which owns its own `TestCoroutineScheduler` and calls [drain] after the
+ *    `runTest` body returns — still inside the `runTest` block — but before
+ *    `Dispatchers.resetMain()`.
+ *
+ * [runCurrent] is injected rather than taken from a rule because those two
+ * bindings own different schedulers; it must only run already-due work and must
+ * never advance virtual time (the #1110 lesson: advancing the clock trips the
+ * #793 re-seed watchdog).
  */
 internal class TmuxSessionViewModelRuleTeardown(
-    private val rule: MainDispatcherRule,
+    private val runCurrent: () -> Unit,
     private val timeoutMs: Long = DEFAULT_TIMEOUT_MS,
 ) {
     private data class TrackedVm(
@@ -49,7 +66,6 @@ internal class TmuxSessionViewModelRuleTeardown(
 
     init {
         require(timeoutMs > 0L) { "timeoutMs must be > 0, was $timeoutMs" }
-        rule.beforeResetMain(::drain)
     }
 
     fun track(vm: TmuxSessionViewModel): TmuxSessionViewModel =
@@ -119,7 +135,7 @@ internal class TmuxSessionViewModelRuleTeardown(
         // after starting reconnect(); cancelling first can strand that
         // reconnect inside its NonCancellable close cascade. This is
         // runCurrent-only: watchdog deadlines never advance.
-        capture(rule::runCurrent)
+        capture(runCurrent)
         vms.forEach { vm -> capture(vm.cancelOwnScopes) }
         roots.forEach { root -> capture(root.job::cancel) }
 
@@ -170,7 +186,7 @@ internal class TmuxSessionViewModelRuleTeardown(
         val deadlineNanos = System.nanoTime() + timeoutMs * NANOS_PER_MILLISECOND
         while (true) {
             cancel()
-            rule.runCurrent()
+            runCurrent()
             val active = remaining()
             if (active == 0) return
             if (System.nanoTime() >= deadlineNanos) {
@@ -205,6 +221,6 @@ internal fun MainDispatcherRule.tmuxSessionViewModelTeardown(
     timeoutMs: Long = 30_000L,
 ): TmuxSessionViewModelRuleTeardown =
     TmuxSessionViewModelRuleTeardown(
-        rule = this,
+        runCurrent = ::runCurrent,
         timeoutMs = timeoutMs,
-    )
+    ).also { registry -> beforeResetMain(registry::drain) }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -16,21 +16,15 @@ import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.TmuxClientFactory
 import com.pocketshell.core.tmux.TmuxServerDeadException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -59,28 +53,10 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class TmuxSessionWarmOpenTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
-
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        // EPIC #792 Slice D: the VM's LivenessProbe is an infinite periodic `delay`
-        // loop; auto-started on this virtual-clock Main it would make
-        // `advanceUntilIdle()` spin forever. Disable the auto-start here (this file
-        // does not use MainDispatcherRule); the probe is exercised via its dedicated
-        // pure unit test + the connected emulator proof.
-        com.pocketshell.app.tmux.LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            com.pocketshell.app.tmux.LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestNewVm(
         registry: ActiveTmuxClients,
@@ -97,6 +73,7 @@ class TmuxSessionWarmOpenTest {
         sessionLifecycleSignals = sessionLifecycleSignals,
         settingsRepository = settingsRepository,
     ).also {
+        fixture.track(it)
         // Issue #886: these warm-open / switch / never-reveal-black tests assert
         // the REVEAL-GATE's immediate behavior after advanceUntilIdle() (overlay
         // raised + seed retried for a blank pane). They are NOT testing the

--- a/app/src/test/java/com/pocketshell/app/tmux/VoiceSendSameGridRevealHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/VoiceSendSameGridRevealHealTest.kt
@@ -10,20 +10,13 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -97,13 +90,8 @@ import java.io.InputStream
 @Config(manifest = Config.NONE, sdk = [33])
 class VoiceSendSameGridRevealHealTest {
 
-    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val createdVms = mutableListOf<TmuxSessionViewModel>()
-
-    @After
-    fun tearDown() {
-        factoryScope.cancel()
-    }
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
 
     // -------------------------------------------------------------------------
     // (1) Voice-send: the active pane went BLACK on the IME transition; the
@@ -288,22 +276,7 @@ class VoiceSendSameGridRevealHealTest {
 
     // ------------------------------------------------------------------ Harness
 
-    private fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        LivenessProbeTestOverride.setAutoStartEnabledForTest(false)
-        try {
-            body()
-        } finally {
-            for (vm in createdVms) {
-                runCatching { vm.setProcessForegroundForClearedForTest(false) }
-                runCatching { vm.clearForTest() }
-            }
-            advanceUntilIdle()
-            createdVms.clear()
-            LivenessProbeTestOverride.clear()
-            Dispatchers.resetMain()
-        }
-    }
+    private fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
 
     private fun TestScope.newVm(
         registry: ActiveTmuxClients,
@@ -320,7 +293,7 @@ class VoiceSendSameGridRevealHealTest {
         // virtual-clock scheduler so the round-trips run inline on the test
         // clock. Production defaults to `Dispatchers.IO` (off the UI thread).
         it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
-        createdVms.add(it)
+        fixture.track(it)
     }
 
     private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {

--- a/scripts/check-main-dispatcher-vm-teardown.sh
+++ b/scripts/check-main-dispatcher-vm-teardown.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
-# Issue #1355: every standalone JVM test that combines MainDispatcherRule with
-# TmuxSessionViewModel must register each VM constructor with the rule-owned
-# teardown registry. Otherwise a VM continuation can outlive resetMain() and
+# Issue #1355 / #1765: every JVM test that constructs a TmuxSessionViewModel and
+# later resets the process-global Dispatchers.Main must register each VM with a
+# shared teardown seam. Otherwise a VM continuation can outlive resetMain() and
 # fail an unrelated next class at TestMainDispatcher.kt:72.
+#
+# Two seams, one per fixture shape:
+#   - MainDispatcherRule consumers  -> mainDispatcherRule.tmuxSessionViewModelTeardown()
+#                                      + teardown.track(TmuxSessionViewModel(...))  (#1355)
+#   - standalone runTest fixtures   -> StandaloneTmuxVmFixture() + fixture.track(...) (#1765)
+#
+# A standalone fixture must ALSO stop touching Dispatchers.setMain/resetMain
+# itself: the fixture owns the install/drain/reset ordering, and a file that
+# resets Main by hand can reorder the reset ahead of the drain again.
 
 set -euo pipefail
 
@@ -22,49 +31,90 @@ exemptions = {
     # its terminal-feed integration deliberately needs specialized real-IO
     # pumping. Issue #1355 migrates the standalone rule consumers only.
     Path("app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt"),
+    # Issue #926's proof pins Main and the seed-IO dispatcher to two NAMED
+    # single-thread executors so the off-Main hop is observable from the client's
+    # recorded thread name. It cannot run on the shared virtual-clock fixture, so
+    # it carries the audited #1355 drain inline (clear -> cancelOwnScopesForTest
+    # -> cancelAndJoin both real-IO roots -> bounded zero-child drain -> phased
+    # resetMain). Verified by hand; do not add further exemptions.
+    Path("app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt"),
 }
 
 constructor = re.compile(r"\bTmuxSessionViewModel\s*\(")
-tracked_constructor = re.compile(
+rule_tracked_constructor = re.compile(
     r"\bteardown\s*\.\s*track\s*\(\s*TmuxSessionViewModel\s*\(",
     re.DOTALL,
 )
-registry = re.compile(
+rule_registry = re.compile(
     r"\bmainDispatcherRule\s*\.\s*tmuxSessionViewModelTeardown\s*\("
 )
+standalone_registry = re.compile(r"\bStandaloneTmuxVmFixture\s*\(")
+standalone_tracked = re.compile(r"\bfixture\s*\.\s*track\s*\(")
+raw_main_swap = re.compile(r"\bDispatchers\s*\.\s*(setMain|resetMain)\s*\(|(?<![.\w])(setMain|resetMain)\s*\(")
+# Comments and string literals routinely NAME the banned call while explaining
+# it (the fixture's own assertion messages do). Scan executable code only.
+comment_or_string = re.compile(
+    r"/\*.*?\*/|//[^\n]*|\"\"\".*?\"\"\"|\"(?:\\.|[^\"\\\n])*\"",
+    re.DOTALL,
+)
+
+
+def executable(text: str) -> str:
+    return comment_or_string.sub("", text)
 
 failures = []
-consumers = []
+rule_consumers = []
+standalone_consumers = []
 exempt_found = 0
 for path in sorted(test_root.rglob("*.kt")):
     text = path.read_text(encoding="utf-8")
-    if "MainDispatcherRule(" not in text or not constructor.search(text):
+    if not constructor.search(text):
         continue
     relative = path.relative_to(root)
-    consumers.append(relative)
     if relative in exemptions:
         exempt_found += 1
         continue
     constructors = len(constructor.findall(text))
-    tracked = len(tracked_constructor.findall(text))
-    if not registry.search(text):
-        failures.append(f"{relative}: missing mainDispatcherRule.tmuxSessionViewModelTeardown()")
-    if tracked != constructors:
+    if "MainDispatcherRule(" in text:
+        rule_consumers.append(relative)
+        tracked = len(rule_tracked_constructor.findall(text))
+        if not rule_registry.search(text):
+            failures.append(
+                f"{relative}: missing mainDispatcherRule.tmuxSessionViewModelTeardown()"
+            )
+        if tracked != constructors:
+            failures.append(
+                f"{relative}: {constructors - tracked} of {constructors} "
+                "TmuxSessionViewModel constructor(s) are not wrapped in teardown.track(...)"
+            )
+        continue
+
+    standalone_consumers.append(relative)
+    tracked = len(standalone_tracked.findall(text))
+    if not standalone_registry.search(text):
+        failures.append(f"{relative}: missing StandaloneTmuxVmFixture()")
+    if tracked < constructors:
         failures.append(
             f"{relative}: {constructors - tracked} of {constructors} "
-            "TmuxSessionViewModel constructor(s) are not wrapped in teardown.track(...)"
+            "TmuxSessionViewModel constructor(s) are not registered with fixture.track(...)"
+        )
+    if raw_main_swap.search(executable(text)):
+        failures.append(
+            f"{relative}: resets Dispatchers.Main by hand; StandaloneTmuxVmFixture "
+            "owns the install/drain/reset ordering"
         )
 
 if failures:
-    print("FAIL: MainDispatcherRule/TmuxSessionViewModel teardown guard (#1355)")
+    print("FAIL: TmuxSessionViewModel Main-reset teardown guard (#1355/#1765)")
     for failure in failures:
         print(f"  - {failure}")
     raise SystemExit(1)
 
 print(
-    "PASS: MainDispatcherRule/TmuxSessionViewModel teardown guard "
-    f"(#1355) — {len(consumers) - exempt_found} standalone consumer(s) registered; "
-    f"{exempt_found} audited inherited-suite exemption(s)."
+    "PASS: TmuxSessionViewModel Main-reset teardown guard (#1355/#1765) — "
+    f"{len(rule_consumers)} MainDispatcherRule consumer(s) and "
+    f"{len(standalone_consumers)} standalone fixture consumer(s) registered; "
+    f"{exempt_found} audited exemption(s)."
 )
 PY
 }
@@ -82,8 +132,31 @@ trap cleanup EXIT INT TERM
 fixture_dir="$fixture_root/app/src/test/java/com/pocketshell/app/tmux"
 mkdir -p "$fixture_dir"
 
-cat > "$fixture_dir/GoodTest.kt" <<'EOF'
-class GoodTest {
+expect_fail() {
+  local label="$1"
+  shift
+  set +e
+  local output
+  output="$(POCKETSHELL_RULE_VM_GUARD_ROOT="$fixture_root" run_guard 2>&1)"
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    printf '%s\n' "$output"
+    echo "FAIL: guard self-test '$label' expected a rejection but passed"
+    exit 1
+  fi
+  local needle
+  for needle in "$@"; do
+    if [[ "$output" != *"$needle"* ]]; then
+      printf '%s\n' "$output"
+      echo "FAIL: guard self-test '$label' missing expected finding: $needle"
+      exit 1
+    fi
+  done
+}
+
+cat > "$fixture_dir/GoodRuleTest.kt" <<'EOF'
+class GoodRuleTest {
     val mainDispatcherRule = MainDispatcherRule()
     val teardown = mainDispatcherRule.tmuxSessionViewModelTeardown()
     fun newVm() = teardown.track(
@@ -91,26 +164,67 @@ class GoodTest {
     )
 }
 EOF
+
+cat > "$fixture_dir/GoodStandaloneTest.kt" <<'EOF'
+class GoodStandaloneTest {
+    private val fixture = StandaloneTmuxVmFixture()
+    fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
+    fun newVm() = TmuxSessionViewModel().also { fixture.track(it) }
+}
+EOF
 POCKETSHELL_RULE_VM_GUARD_ROOT="$fixture_root" run_guard
 
-cat > "$fixture_dir/BadTest.kt" <<'EOF'
-class BadTest {
+cat > "$fixture_dir/BadRuleTest.kt" <<'EOF'
+class BadRuleTest {
     val mainDispatcherRule = MainDispatcherRule()
     fun newVm() = TmuxSessionViewModel()
 }
 EOF
-set +e
-bad_output="$(POCKETSHELL_RULE_VM_GUARD_ROOT="$fixture_root" run_guard 2>&1)"
-bad_rc=$?
-set -e
-if [[ "$bad_rc" -eq 0 ]] ||
-   [[ "$bad_output" != *"BadTest.kt: missing mainDispatcherRule.tmuxSessionViewModelTeardown()"* ]] ||
-   [[ "$bad_output" != *"constructor(s) are not wrapped in teardown.track(...)"* ]]; then
-  printf '%s\n' "$bad_output"
-  echo "FAIL: #1355 guard self-test did not reject an unregistered constructor"
-  exit 1
-fi
+expect_fail "unregistered rule consumer" \
+  "BadRuleTest.kt: missing mainDispatcherRule.tmuxSessionViewModelTeardown()" \
+  "constructor(s) are not wrapped in teardown.track(...)"
+rm -- "$fixture_dir/BadRuleTest.kt"
 
-rm -- "$fixture_dir/BadTest.kt"
+cat > "$fixture_dir/BadStandaloneTest.kt" <<'EOF'
+class BadStandaloneTest {
+    private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    fun runVmTest(body: suspend TestScope.() -> Unit) = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        try { body() } finally { Dispatchers.resetMain() }
+    }
+    fun newVm() = TmuxSessionViewModel()
+}
+EOF
+expect_fail "unmigrated standalone fixture" \
+  "BadStandaloneTest.kt: missing StandaloneTmuxVmFixture()" \
+  "constructor(s) are not registered with fixture.track(...)" \
+  "resets Dispatchers.Main by hand"
+rm -- "$fixture_dir/BadStandaloneTest.kt"
+
+cat > "$fixture_dir/UntrackedStandaloneTest.kt" <<'EOF'
+class UntrackedStandaloneTest {
+    private val fixture = StandaloneTmuxVmFixture()
+    fun runVmTest(body: suspend TestScope.() -> Unit) = fixture.runVmTest(body = body)
+    fun newVm() = TmuxSessionViewModel()
+    fun secondVm() = TmuxSessionViewModel().also { fixture.track(it) }
+}
+EOF
+expect_fail "standalone fixture with one untracked constructor" \
+  "UntrackedStandaloneTest.kt: 1 of 2 TmuxSessionViewModel constructor(s) are not registered"
+rm -- "$fixture_dir/UntrackedStandaloneTest.kt"
+
+cat > "$fixture_dir/HandRolledResetTest.kt" <<'EOF'
+class HandRolledResetTest {
+    private val fixture = StandaloneTmuxVmFixture()
+    fun newVm() = TmuxSessionViewModel().also { fixture.track(it) }
+    fun tearDown() {
+        resetMain()
+    }
+}
+EOF
+expect_fail "standalone fixture that still resets Main by hand" \
+  "HandRolledResetTest.kt: resets Dispatchers.Main by hand"
+rm -- "$fixture_dir/HandRolledResetTest.kt"
+
 POCKETSHELL_RULE_VM_GUARD_ROOT="$fixture_root" run_guard
-echo "PASS: #1355 guard self-test rejects an omitted consumer migration"
+echo "PASS: #1355/#1765 guard self-test rejects every omitted-migration shape"


### PR DESCRIPTION
Closes #1765

## What changed

28 standalone JVM fixtures constructed a `TmuxSessionViewModel` and reset `Dispatchers.Main` without first draining VM-owned children — the exact shape that caused the #1355 recurrence. All 28 now delegate to **one** seam, `StandaloneTmuxVmFixture.runVmTest`, rather than carrying 28 near-copies of the same teardown.

While Main remains installed the seam clears every created VM, cancels VM-owned roots, cancels **and joins** test-owned lease/factory scopes, and hard-fails on a bounded drain until the active own-scope child count is zero. Main is reset only after that drain.

**Zero production code changed** — verified independently: `git status --porcelain | grep -E 'src/main|src/androidTest'` is empty.

## The finding worth reading

The implementer's **first** architecture drained *after* `runTest` returned — which is the shape the existing `MainDispatcherRule` binding already uses, so it looked like the obviously consistent choice.

It reproduced a **real 35-minute silent hang**. `runTest`'s own cleanup calls `testScheduler.advanceUntilIdleOr`, which drains *foreign* VM-owned coroutines too, so #1543's still-armed liveness-probe loop spun forever. It was found by **jstack, not by an assertion** — which is the point: this is the #882/#1517 class, where an infinite virtual-time loop presents as "timed out after N minutes" with every test line PASSED, not as a failure.

The drain now runs inside the `runTest` block, with KDoc explaining why so nobody "simplifies" it back into the hang.

## Reviewer verification

- **Drain placement correct at every site**, and structurally unrepeatable: there is exactly *one* site (`StandaloneTmuxVmFixture.kt:211-261`). It grepped all 28 sweep files for `runTest` / `Dispatchers.setMain` / `Dispatchers.resetMain`; the only hits outside KDoc are in the fixture itself.
- **Hang proven absent by whole-module completion**, not reasoning: full `:app:testDebugUnitTest --rerun-tasks --no-daemon` finished in 6m 21s against a `timeout -s KILL 3000` cap, 4211 executed / 0 failed, 441/441 XML fresh, all 28 migrated classes plus the seam test named.
- **No oracle or budget weakened anywhere in the 30-file diff** — checked mechanically rather than by spot-check, which matters because a sweep is exactly where such a change hides in volume: zero removed lines carrying `assert*`/`fail(`; zero added `@Ignore`/`assumeTrue`/`assumeFalse`; `@Test` count 171 in and 171 out. The only added timeout-ish line is #1543's *relocated, unchanged* `perProbeTimeoutMs = 10L`. Removed `runCatching { … }` wrappers are replaced by the registry's recording `capture`, which **surfaces** failures instead of swallowing them — strictly stronger.
- **Mutations, independent tooling, both asserted on disk and asserted not to have landed on a comment line before use:**
  - M1 (omitted VM cancellation): 9/18 failed, all four patterns RED with the identical measured leak — `5 TmuxSessionViewModel-owned coroutine child(ren) did not quiesce within 30000ms while Main was installed`.
  - M2 (premature Main reset): 14/18 failed, every one `IllegalStateException: Dispatchers.resetMain() cannot start before the TmuxSessionViewModel drain completes (phase=MAIN_INSTALLED)` — deterministic, with no dispatch onto a reset Main.
  - Post-restore: `grep -rn MUTANT` empty, diffstat byte-identical, then 5× debug + 1× release runs all 63/63.

## Inventory corrections

The recorded inventory was stale and was re-derived from `origin/main`: 36 VM-constructing files = 28 sweep + 6 rule + 2 audited exemptions, 29 constructors, **171** `@Test` (the issue said 159, my brief said 169), and the recorded teardown split was wrong — **9** never clear in teardown, not 7.

The #1778 overlap list came back **empty** and was independently confirmed: all of its files construct zero VMs, so no sequencing was needed between those lanes.

## Orchestrator verification

Applied to a clean worktree off `main` (`0c6fbd35`). **Two files are untracked, including the new shared seam itself** — `git diff` omits those, so they were copied explicitly with modes verified. `git diff --check` clean; test-validity, file-size hygiene, and VM-ratchet guards all exit 0; the candidate's own `check-main-dispatcher-vm-teardown.sh` passes with 6 rule consumers + 29 standalone consumers registered and 2 audited exemptions.

Full `:app:testDebugUnitTest` re-run on the integrated tree with `--rerun-tasks`: task line unsuffixed, **4,236 executed / 0 failed / 0 skipped** self-asserted, zero stale XML against the run marker, and the new `StandaloneTmuxVmFixtureTest` seam named in the results.

Five non-blocking follow-ups are listed on the issue.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb