### PR TITLE
test(projects): make the RootProjectAddSheet IME proof modal-root deterministic (#1742)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetKeyboardLayoutTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetKeyboardLayoutTest.kt
@@ -1,29 +1,51 @@
 package com.pocketshell.app.projects
 
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
+import android.os.Build
+import android.os.SystemClock
+import android.view.View
+import android.view.accessibility.AccessibilityWindowInfo
+import android.view.inputmethod.InputMethodManager
+import android.view.inspector.WindowInspector
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.proof.signals.waitForComposeLayoutStable
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Issue #613 — the reported screen.
+ * Issue #613 — the reported screen. Issue #1742 — the deterministic proof.
  *
- * The maintainer's dogfood screenshot shows the root project picker
+ * The maintainer's feedback screenshot shows the root project picker
  * ("Search projects" + "Empty project" / "Clone git repo" quick actions +
  * a "workshops" suggestion) with the soft keyboard up: the filtered project
  * row is occluded by the keyboard. That screen is the [RootProjectAddSheet]
@@ -31,17 +53,47 @@ import org.junit.runner.RunWith
  * fixing.
  *
  * This test mounts the REAL [RootProjectAddSheet] (the full `ModalBottomSheet`,
- * so the sheet's own height constraint + IME interaction match production),
- * raises the REAL soft keyboard, types a filter so a single project matches,
- * and asserts the matched project row + the search field both stay ABOVE the
- * keyboard top.
+ * so the sheet's own height constraint + IME interaction match production) and
+ * types through the real focused field.
  *
- * On the unfixed layout (a partially-expanded sheet whose content is a single
- * `verticalScroll` Column ending in a fixed-height results LazyColumn) the
- * matched row is pushed below the keyboard and this assertion fails — i.e. it
- * is a genuine regression guard. The fix (fully-expanded sheet + pinned header
- * + weighted, scrolling results LazyColumn under `imePadding`) keeps the match
- * visible above the IME and the search field on screen.
+ * ## Why the fixture changed in #1742
+ *
+ * A `ModalBottomSheet` lives in its **own window**. The previous fixture asked
+ * `WindowInsetsControllerCompat(activity.window, activity.decorView)` to show
+ * the real IME and then polled *activity-decor* insets, while the focused
+ * search field it was judging lived in the modal window. Both audited nightly
+ * runs therefore failed at that real-IME precondition — before a single
+ * character was typed and before any geometry was measured — with every show
+ * request stuck at `PHASE_CLIENT_REQUEST_IME_SHOW`. That was fixture drift,
+ * not a production layout regression.
+ *
+ * The durable shape (the merged #780/#1734/#1800 model) is:
+ *
+ * 1. Keep the production modal mounted and keep the real click + text input.
+ * 2. Hard-require that no physical IME window is visible, so the deterministic
+ *    boundary can never be silently mixed with a real keyboard.
+ * 3. Dispatch a synthetic `Type.ime()` inset to **every** attached app-owned
+ *    window root (activity decor + the modal root). Dispatching to the
+ *    activity only leaves the modal's Compose `WindowInsets.ime` at zero —
+ *    that is the exact root cause, and it is a one-line mutation away.
+ * 4. Observe that inset from inside the modal's own Compose tree via a
+ *    test-only semantics key, and require exact equality with a nonzero value.
+ * 5. Keep every geometry assertion in the **owning modal Compose root**'s
+ *    coordinate space, asserting containment (not `assertIsDisplayed()`), and
+ *    require the production sheet layout to materially lift AND shrink the
+ *    results viewport, so a published-but-ignored inset cannot pass.
+ *
+ * Mutation note (#1742): removing `imePadding()` from `RootProjectAddSheetContent`
+ * changes nothing measurable here — Material3's `ModalBottomSheet` already
+ * resolves the ime inset for its own window, so that call is redundant. The
+ * assertion with proven bite is the SHRINK bound: replacing the bounded,
+ * shrinkable content column with a fixed `requiredHeight` (the pre-#613 shape)
+ * drops the viewport response to 127px against a 774px keyboard and turns this
+ * proof red. Deliberately NOT deleting the redundant `imePadding()` here: #1742
+ * is a fixture/oracle slice with an explicit "no layout behavior change" scope.
+ *
+ * There is no `assumeTrue`/`assumeFalse` anywhere: an environment that cannot
+ * reach the required state fails hard.
  */
 @RunWith(AndroidJUnit4::class)
 class RootProjectAddSheetKeyboardLayoutTest {
@@ -51,6 +103,10 @@ class RootProjectAddSheetKeyboardLayoutTest {
 
     @Test
     fun matchedProjectStaysAboveKeyboardWhileTyping() {
+        compose.activityRule.scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+
         // Many candidates so the results list is long enough that, on the old
         // layout, the matched row lands under the keyboard.
         val candidates = (1..20).map { i ->
@@ -82,6 +138,7 @@ class RootProjectAddSheetKeyboardLayoutTest {
                     onStartSession = {},
                     onCreateEmptyProject = {},
                     onCloneGitProject = {},
+                    modifier = Modifier.observeSheetIme(),
                 )
             }
         }
@@ -94,108 +151,447 @@ class RootProjectAddSheetKeyboardLayoutTest {
 
         try {
             compose.onNodeWithTag(ROOT_PROJECT_ADD_SEARCH_TAG).performClick()
-            compose.activity.runOnUiThread {
-                val window = compose.activity.window
-                WindowInsetsControllerCompat(window, window.decorView)
-                    .show(WindowInsetsCompat.Type.ime())
-            }
-
-            val imeVisible = waitForInputMethodVisible(
-                scenario = compose.activityRule.scenario,
-                expected = true,
-                timeoutMs = 30_000L,
-            )
-            assertTrue(
-                "IME must be visible for the keyboard-occlusion regression test",
-                imeVisible,
-            )
 
             // Filter to the single "workshops" match — the maintainer's exact
             // scenario (type to filter, one folder matches).
             compose.onNodeWithTag(ROOT_PROJECT_ADD_SEARCH_TAG).performTextInput("worksh")
+            compose.onNodeWithTag(ROOT_PROJECT_ADD_SEARCH_TAG)
+                .assertTextContains("worksh", substring = true)
             compose.waitUntil(timeoutMillis = 5_000) {
-                compose.onAllNodesWithTag(matchTag).fetchSemanticsNodes().isNotEmpty()
+                compose.onAllNodesWithTag(matchTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes().size == 1
             }
             assertTrue(
-                "matched row should settle before the IME overlap check",
+                "The exact workshops row must settle after real text input.",
                 waitForComposeLayoutStable(compose, matchTag),
             )
-            compose.onNodeWithTag(matchTag).assertIsDisplayed()
+            // `worksh` -> `workshops` must be the ONLY surviving candidate: no
+            // other project row, and no "create folder" offer standing in for
+            // the match.
+            candidates
+                .filterNot { it.path == matchPath }
+                .forEach { candidate ->
+                    compose.onAllNodesWithTag(
+                        rootProjectCandidateTestTag(candidate.path),
+                        useUnmergedTree = true,
+                    ).assertCountEquals(0)
+                }
+            compose.onAllNodesWithTag(
+                ROOT_PROJECT_ADD_CREATE_MATCH_TAG,
+                useUnmergedTree = true,
+            ).assertCountEquals(0)
 
-            val imeBottomInset = imeBottomInsetPx()
-            assertTrue(
-                "IME must report a positive bottom inset for the overlap check",
-                imeBottomInset > 0,
+            // The deterministic boundary is only meaningful when no physical
+            // keyboard window is competing with it.
+            hideRealImeAndAssertHidden(
+                "Issue #1742 synthetic modal-root proof cannot start while a real IME is up.",
             )
 
-            // The sheet renders as a full-screen overlay window, so node
-            // `boundsInRoot` are screen-relative. The keyboard top in those same
-            // screen coordinates is the window height minus the IME inset. This
-            // is an ABSOLUTE screen line, independent of the scrollable content's
-            // own measured bounds — so a matched row that is scrolled/clipped
-            // below the keyboard (the bug on the partially-expanded sheet) is
-            // genuinely caught, instead of passing because the scrollable
-            // content's bounds happen to extend behind the keyboard.
-            val windowHeightPx = windowHeightPx()
-            val keyboardTop = windowHeightPx - imeBottomInset
+            // Capture keyboard-down geometry only after filtering, so the
+            // before/after viewport comparison owns the exact same content.
+            val keyboardDownListBounds = applyKeyboardDownAndReadListBounds()
+            val syntheticIme = applyKeyboardUpAndReadModalGeometry()
+            assertTrue(
+                "The filtered result must settle after the modal-root IME layout pass.",
+                waitForComposeLayoutStable(compose, matchTag),
+            )
+            val keyboardTop =
+                syntheticIme.modalRoot.boundsInRoot.bottom - syntheticIme.observedImeBottomPx
 
-            val matchBounds = compose.onNodeWithTag(matchTag)
+            // Measure + publish the layout response BEFORE the containment
+            // assertions so every run — including a red one that stops at the
+            // first containment failure — carries the geometry evidence.
+            val keyboardUpListBounds = compose
+                .onNodeWithTag(ROOT_PROJECT_ADD_LIST_TAG, useUnmergedTree = true)
                 .fetchSemanticsNode()
                 .boundsInRoot
-            val searchBounds = compose.onNodeWithTag(ROOT_PROJECT_ADD_SEARCH_TAG)
-                .fetchSemanticsNode()
-                .boundsInRoot
-
-            assertTrue(
-                "search field must stay visible above the keyboard while typing " +
-                    "(search bottom=${searchBounds.bottom}, keyboard top=$keyboardTop)",
-                searchBounds.bottom <= keyboardTop + 0.5f,
-            )
-            assertTrue(
-                "matched project row must stay above the keyboard while typing " +
-                    "(match bottom=${matchBounds.bottom}, keyboard top=$keyboardTop)",
-                matchBounds.bottom <= keyboardTop + 0.5f,
+            val liftPx = keyboardDownListBounds.bottom - keyboardUpListBounds.bottom
+            val shrinkPx = keyboardDownListBounds.height - keyboardUpListBounds.height
+            println(
+                "ISSUE1742_LAYOUT_RESPONSE observedImeBottomPx=" +
+                    "${syntheticIme.observedImeBottomPx} liftPx=$liftPx shrinkPx=$shrinkPx " +
+                    "keyboardDownList=$keyboardDownListBounds " +
+                    "keyboardUpList=$keyboardUpListBounds keyboardTopPx=$keyboardTop " +
+                    "modalRoot=${syntheticIme.modalRoot.boundsInRoot} " +
+                    "density=${compose.density.density}",
             )
 
-            // Optional hold so a reviewer/implementer can grab an external
-            // `adb exec-out screencap` of the exact keyboard-up frame on
-            // emulators where UiAutomation.takeScreenshot() returns null
-            // (SwiftShader / headless). Gated by an instrumentation arg so CI
-            // never waits:
-            //   -Pandroid.testInstrumentationRunnerArguments.issue613KeyboardHoldMs=12000
-            val holdMs = InstrumentationRegistry.getArguments()
-                .getString("issue613KeyboardHoldMs")?.toLongOrNull() ?: 0L
-            if (holdMs > 0L) {
-                android.os.SystemClock.sleep(holdMs)
+            listOf(
+                ROOT_PROJECT_ADD_SEARCH_TAG,
+                ROOT_PROJECT_ADD_EMPTY_PROJECT_TAG,
+                ROOT_PROJECT_ADD_CLONE_TAG,
+                ROOT_PROJECT_ADD_ROOT_SESSION_TAG,
+                ROOT_PROJECT_ADD_LIST_TAG,
+                matchTag,
+            ).forEach { tag ->
+                assertFullyContainedAboveKeyboard(
+                    tag = tag,
+                    modalRoot = syntheticIme.modalRoot,
+                    keyboardTopPx = keyboardTop,
+                )
             }
+
+            assertTrue(
+                "The #613 keyboard-aware sheet layout must materially LIFT the results viewport; " +
+                    "keyboardDown=$keyboardDownListBounds keyboardUp=$keyboardUpListBounds " +
+                    "liftPx=$liftPx observedImeBottomPx=${syntheticIme.observedImeBottomPx}",
+                liftPx >= syntheticIme.observedImeBottomPx * MINIMUM_LIFT_FRACTION,
+            )
+            assertTrue(
+                "The #613 keyboard-aware sheet layout must materially SHRINK the results viewport; " +
+                    "keyboardDown=$keyboardDownListBounds keyboardUp=$keyboardUpListBounds " +
+                    "shrinkPx=$shrinkPx observedImeBottomPx=${syntheticIme.observedImeBottomPx}",
+                shrinkPx >= syntheticIme.observedImeBottomPx * MINIMUM_SHRINK_FRACTION,
+            )
         } finally {
-            compose.activity.runOnUiThread {
-                WindowInsetsControllerCompat(
-                    compose.activity.window,
-                    compose.activity.window.decorView,
-                ).hide(WindowInsetsCompat.Type.ime())
+            applySyntheticInsets(
+                imeBottomPx = 0,
+                requireModalRoot = false,
+                requireNoPhysicalIme = false,
+            )
+            hideRealImeBestEffort()
+            compose.waitForIdle()
+        }
+    }
+
+    private data class SyntheticImeGeometry(
+        val observedImeBottomPx: Int,
+        val modalRoot: SemanticsNode,
+    )
+
+    private fun applyKeyboardDownAndReadListBounds(): Rect {
+        repeat(INSET_DISPATCH_REPEATS) {
+            applySyntheticInsets(imeBottomPx = 0, requireModalRoot = true)
+            compose.waitForIdle()
+        }
+        val observedIme = sheetObservedImeBottomPx()
+        assertTrue(
+            "Keyboard-down baseline must be observed as exact zero inside the mounted " +
+                "modal Compose root; observedImeBottomPx=$observedIme",
+            observedIme == 0,
+        )
+        assertTrue(
+            "The results viewport must settle before keyboard-down geometry is captured.",
+            waitForComposeLayoutStable(compose, ROOT_PROJECT_ADD_LIST_TAG),
+        )
+        return compose.onNodeWithTag(ROOT_PROJECT_ADD_LIST_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+    }
+
+    private fun applyKeyboardUpAndReadModalGeometry(): SyntheticImeGeometry {
+        val expectedImeBottomPx = syntheticImeBottomPx()
+        repeat(INSET_DISPATCH_REPEATS) {
+            applySyntheticInsets(
+                imeBottomPx = expectedImeBottomPx,
+                requireModalRoot = true,
+            )
+            compose.waitForIdle()
+        }
+
+        val sheetNode = compose
+            .onNodeWithTag(ROOT_PROJECT_ADD_SHEET_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+        val observedImeBottomPx =
+            sheetNode.config.getOrNull(ROOT_PROJECT_ADD_SHEET_IME_BOTTOM_PX) ?: -1
+        assertTrue(
+            "Synthetic ime() inset must be exact and nonzero in the mounted " +
+                "RootProjectAddSheet modal Compose root; activity-only dispatch or a zero " +
+                "mutation must fail here. observedImeBottomPx=$observedImeBottomPx " +
+                "expectedImeBottomPx=$expectedImeBottomPx",
+            expectedImeBottomPx > 0 && observedImeBottomPx == expectedImeBottomPx,
+        )
+
+        val modalRoot = compose.onAllNodes(isRoot()).fetchSemanticsNodes()
+            .single { it.root === sheetNode.root }
+        assertTrue(
+            "The owning modal Compose root must have nonzero geometry; " +
+                "bounds=${modalRoot.boundsInRoot}",
+            modalRoot.boundsInRoot.width > 0f && modalRoot.boundsInRoot.height > 0f,
+        )
+        println(
+            "ISSUE1742_MODAL_GEOMETRY root=${modalRoot.boundsInRoot} " +
+                "observedImeBottomPx=$observedImeBottomPx " +
+                "rootIdentity=${System.identityHashCode(modalRoot.root)} " +
+                "sheetRootIdentity=${System.identityHashCode(sheetNode.root)}",
+        )
+        return SyntheticImeGeometry(
+            observedImeBottomPx = observedImeBottomPx,
+            modalRoot = modalRoot,
+        )
+    }
+
+    private fun assertFullyContainedAboveKeyboard(
+        tag: String,
+        modalRoot: SemanticsNode,
+        keyboardTopPx: Float,
+    ) {
+        val node = compose.onNodeWithTag(tag, useUnmergedTree = true).fetchSemanticsNode()
+        val bounds = node.boundsInRoot
+        val rootBounds = modalRoot.boundsInRoot
+        val slop = CONTAINMENT_SLOP_DP * compose.density.density
+        assertTrue(
+            "Node '$tag' must belong to the same modal Compose coordinate root.",
+            node.root === modalRoot.root,
+        )
+        assertTrue(
+            "Node '$tag' must have nonzero geometry. bounds=$bounds",
+            bounds.width > 0f && bounds.height > 0f,
+        )
+        assertTrue(
+            "Node '$tag' must be fully contained in its owning modal root. " +
+                "node=$bounds root=$rootBounds",
+            bounds.left >= rootBounds.left - slop &&
+                bounds.top >= rootBounds.top - slop &&
+                bounds.right <= rootBounds.right + slop &&
+                bounds.bottom <= rootBounds.bottom + slop,
+        )
+        assertTrue(
+            "Node '$tag' must stay fully above the keyboard boundary in the same modal " +
+                "coordinate root. node=$bounds keyboardTopPx=$keyboardTopPx root=$rootBounds",
+            bounds.bottom <= keyboardTopPx + slop,
+        )
+    }
+
+    private fun Modifier.observeSheetIme(): Modifier = composed {
+        val density = LocalDensity.current
+        val imeBottomPx = WindowInsets.ime.getBottom(density)
+        semantics {
+            this[ROOT_PROJECT_ADD_SHEET_IME_BOTTOM_PX] = imeBottomPx
+        }
+    }
+
+    private fun sheetObservedImeBottomPx(): Int =
+        compose.onNodeWithTag(ROOT_PROJECT_ADD_SHEET_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .config
+            .getOrNull(ROOT_PROJECT_ADD_SHEET_IME_BOTTOM_PX)
+            ?: -1
+
+    private fun applySyntheticInsets(
+        imeBottomPx: Int,
+        requireModalRoot: Boolean,
+        requireNoPhysicalIme: Boolean = true,
+    ) {
+        check(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            "Issue #1742 modal-root IME proof requires API 29+ WindowInspector; " +
+                "deviceApi=${Build.VERSION.SDK_INT}"
+        }
+        if (requireNoPhysicalIme) {
+            assertNoPhysicalImeWindow(
+                "Issue #1742 synthetic dispatch must never be mixed with a real IME window.",
+            )
+        }
+        val statusBarTopPx = (SYNTHETIC_STATUS_BAR_HEIGHT_DP * displayDensity()).toInt()
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(
+                WindowInsetsCompat.Type.ime(),
+                Insets.of(0, 0, 0, imeBottomPx),
+            )
+            .setVisible(WindowInsetsCompat.Type.ime(), imeBottomPx > 0)
+            .setInsets(
+                WindowInsetsCompat.Type.navigationBars(),
+                Insets.of(0, 0, 0, 0),
+            )
+            .setInsets(
+                WindowInsetsCompat.Type.statusBars(),
+                Insets.of(0, statusBarTopPx, 0, 0),
+            )
+            .setInsets(
+                WindowInsetsCompat.Type.systemBars(),
+                Insets.of(0, statusBarTopPx, 0, 0),
+            )
+            .build()
+        compose.activityRule.scenario.onActivity { activity ->
+            val roots = activeAppWindowRoots(activity)
+            val activityDecor = activity.window.decorView
+            val modalRoots = roots.filterNot { it === activityDecor }
+            check(roots.any { it === activityDecor }) {
+                "Active app roots must include the activity decor."
+            }
+            if (requireModalRoot) {
+                check(modalRoots.isNotEmpty()) {
+                    "Mounted RootProjectAddSheet modal root disappeared before inset dispatch."
+                }
+            }
+            println(
+                "ISSUE1742_SYNTHETIC_WINDOW_ROOTS count=${roots.size} " +
+                    "modalCount=${modalRoots.size} imeBottomPx=$imeBottomPx " +
+                    "roots=${roots.map { "${it.javaClass.name}:${it.width}x${it.height}" }}",
+            )
+
+            // ---- ROOT-CAUSE MUTATION ANCHOR (issue #1742) -------------------
+            // Every attached app-owned window root gets the inset, because the
+            // focused search field lives in the ModalBottomSheet's OWN window.
+            // Replacing this line with a dispatch to `activityDecor` only
+            // reproduces the original nightly root cause: the modal Compose
+            // tree keeps observing ime=0 and the exact-inset oracle above goes
+            // red before any geometry is judged.
+            roots.forEach { root ->
+                ViewCompat.dispatchApplyWindowInsets(root, insets)
+            }
+            // -----------------------------------------------------------------
+        }
+    }
+
+    private fun activeAppWindowRoots(activity: ComponentActivity): List<View> =
+        WindowInspector.getGlobalWindowViews()
+            .asSequence()
+            .map { it.rootView }
+            .distinctBy { System.identityHashCode(it) }
+            .filter { root ->
+                root.isAttachedToWindow &&
+                    root.context.applicationContext.packageName ==
+                    activity.applicationContext.packageName
+            }
+            .toList()
+
+    /**
+     * Drives the real IME down and HARD-asserts it is gone from every signal we
+     * have: the accessibility input-method window, every app root's real ime
+     * inset, and the framework decor visibility flag. No skip — an emulator that
+     * refuses to put the keyboard away fails this proof loudly instead of
+     * silently measuring a mixed real/synthetic boundary.
+     */
+    private fun hideRealImeAndAssertHidden(message: String) {
+        hideRealImeBestEffort()
+        assertTrue(
+            "$message Physical input-method window remained visible: " +
+                visiblePhysicalImeWindows(),
+            waitForWallClock(REAL_IME_TIMEOUT_MS) { visiblePhysicalImeWindows().isEmpty() },
+        )
+        assertTrue(
+            "$message An app root still reports a visible positive real-IME inset.",
+            waitForWallClock(REAL_IME_TIMEOUT_MS) { !readAnyAppRootImeVisible() },
+        )
+        assertFalse(
+            "$message Activity decor did not report IME visibility=false.",
+            waitForInputMethodVisible(
+                scenario = compose.activityRule.scenario,
+                expected = false,
+                timeoutMs = REAL_IME_TIMEOUT_MS,
+            ),
+        )
+        assertNoPhysicalImeWindow(message)
+    }
+
+    private fun hideRealImeBestEffort() {
+        runCatching {
+            compose.activityRule.scenario.onActivity { activity ->
+                val inputMethodManager =
+                    activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                activeAppWindowRoots(activity).forEach { root ->
+                    ViewCompat.getWindowInsetsController(root)
+                        ?.hide(WindowInsetsCompat.Type.ime())
+                    root.windowToken?.let { token ->
+                        inputMethodManager.hideSoftInputFromWindow(token, 0)
+                    }
+                }
+                ViewCompat.getWindowInsetsController(activity.window.decorView)
+                    ?.hide(WindowInsetsCompat.Type.ime())
             }
         }
     }
 
-    private fun imeBottomInsetPx(): Int {
-        var bottom = 0
-        compose.activityRule.scenario.onActivity { activity ->
-            val decor = activity.window.decorView
-            bottom = ViewCompat.getRootWindowInsets(decor)
-                ?.getInsets(WindowInsetsCompat.Type.ime())
-                ?.bottom
-                ?: 0
+    private fun assertNoPhysicalImeWindow(message: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val deadline = SystemClock.elapsedRealtime() + PHYSICAL_IME_ABSENCE_STABILITY_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            instrumentation.waitForIdleSync()
+            val windows = visiblePhysicalImeWindows()
+            assertTrue("$message visibleImeWindows=$windows", windows.isEmpty())
+            SystemClock.sleep(50)
         }
-        return bottom
     }
 
-    /** Full window (decor view) height in px — the screen-coordinate baseline. */
-    private fun windowHeightPx(): Float {
-        var height = 0
-        compose.activityRule.scenario.onActivity { activity ->
-            height = activity.window.decorView.height
+    private fun waitForWallClock(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            instrumentation.waitForIdleSync()
+            if (predicate()) return true
+            SystemClock.sleep(50)
         }
-        return height.toFloat()
+        return predicate()
+    }
+
+    private fun readAnyAppRootImeVisible(): Boolean {
+        var visible = false
+        compose.activityRule.scenario.onActivity { activity ->
+            visible = activeAppWindowRoots(activity).any { root ->
+                val insets = ViewCompat.getRootWindowInsets(root)
+                insets?.isVisible(WindowInsetsCompat.Type.ime()) == true &&
+                    insets.getInsets(WindowInsetsCompat.Type.ime()).bottom > 0
+            }
+        }
+        return visible
+    }
+
+    /**
+     * Accessibility exposes the physical IME as a distinct
+     * [AccessibilityWindowInfo.TYPE_INPUT_METHOD] window. That signal is
+     * independent of the synthetic [WindowInsetsCompat] object dispatched to the
+     * app roots, so it catches a green synthetic boundary drawn while a real
+     * keyboard is still covering the sheet.
+     */
+    private fun visiblePhysicalImeWindows(): List<String> =
+        InstrumentationRegistry.getInstrumentation()
+            .uiAutomation
+            .let { automation ->
+                val serviceInfo = automation.serviceInfo
+                if (
+                    serviceInfo.flags and
+                    AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS == 0
+                ) {
+                    serviceInfo.flags =
+                        serviceInfo.flags or
+                        AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
+                    automation.serviceInfo = serviceInfo
+                }
+                automation.windows
+                    .filter { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD }
+                    .map { window ->
+                        val rootPackage = runCatching {
+                            window.root?.packageName?.toString()
+                        }.getOrNull()
+                        "package=$rootPackage active=${window.isActive} " +
+                            "focused=${window.isFocused} bounds=" +
+                            "${android.graphics.Rect().also(window::getBoundsInScreen)}"
+                    }
+            }
+
+    private fun syntheticImeBottomPx(): Int =
+        (SYNTHETIC_IME_HEIGHT_DP * displayDensity()).toInt()
+
+    private fun displayDensity(): Float =
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext.resources.displayMetrics.density
+
+    private companion object {
+        const val SYNTHETIC_IME_HEIGHT_DP = 295f
+        const val SYNTHETIC_STATUS_BAR_HEIGHT_DP = 52f
+
+        /**
+         * The results viewport must move up by essentially the whole keyboard
+         * (the sheet is bottom-anchored, so `imePadding()` translates it by the
+         * full inset). Half the inset is a generous floor that still goes red
+         * the moment the #613 layout stops responding.
+         */
+        const val MINIMUM_LIFT_FRACTION = 0.5f
+
+        /**
+         * The viewport must also genuinely SHRINK, not merely translate — a
+         * sheet that slides up without shrinking pushes its header off the top.
+         * The shrink is bounded by the sheet's `heightIn(max = 640.dp)` cap, so
+         * this floor is lower than the lift floor by construction while still
+         * being zero for any layout that ignores the inset.
+         */
+        const val MINIMUM_SHRINK_FRACTION = 0.25f
+        const val CONTAINMENT_SLOP_DP = 2f
+        const val INSET_DISPATCH_REPEATS = 2
+        const val REAL_IME_TIMEOUT_MS = 30_000L
+        const val PHYSICAL_IME_ABSENCE_STABILITY_MS = 500L
+        val ROOT_PROJECT_ADD_SHEET_IME_BOTTOM_PX =
+            SemanticsPropertyKey<Int>("RootProjectAddSheetImeBottomPx")
     }
 }

--- a/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
@@ -52,6 +52,7 @@ fun RootProjectAddSheet(
     onCreateEmptyProject: () -> Unit,
     onCloneGitProject: () -> Unit,
     onCreateNamedProject: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
 ) {
     // Issue #613: the search field auto-focuses, so the soft keyboard opens
     // immediately. Use a fully-expanded sheet (not a partial one) so the
@@ -63,7 +64,7 @@ fun RootProjectAddSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         containerColor = PocketShellColors.Surface,
-        modifier = Modifier.testTag(ROOT_PROJECT_ADD_SHEET_TAG),
+        modifier = modifier.testTag(ROOT_PROJECT_ADD_SHEET_TAG),
     ) {
         RootProjectAddSheetContent(
             root = root,

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -141,6 +141,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.share.ShareTargetE2eTest"  # #727 #657 epic Wave 1 / S1): the share-auth journey pair
   "com.pocketshell.app.share.SharePassphraseDialogE2eTest"
   "com.pocketshell.app.projects.ProfileDiscoveryPickerDockerTest"  # #732 Finding B): the host server-PROFILE discovery journey. The p…
+  "com.pocketshell.app.projects.RootProjectAddSheetKeyboardLayoutTest"  # #1742 deterministic modal-root IME layout proof
   "com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest"  # #898 reviewer Blocker B): the in-session + New session rich-sheet
   "com.pocketshell.app.composer.PromptComposerImeSquishProofTest"  # #736 #567 #638 #657 follow-up to the review): the composer keyboard-up SQUISH re…
   "com.pocketshell.app.composer.PromptComposerLongDraftCaretVisibleTest"  # #1619/#765 D33/G10: synthetic + real-IME long-draft caret containment above sticky controls


### PR DESCRIPTION
Closes #1742

## Why

A `ModalBottomSheet` lives in its **own window**, so an inset dispatched to the activity root never reaches it. A proof that dispatches to the activity only will pass while the real sheet is still squished — the F2 proxy trap. The proof now dispatches the synthetic `ime()` inset to every app window root and asserts owning-root identity and the exact modal inset, so it measures the window the user actually sees.

Production change is a **test seam only**: a default-valued `modifier` parameter on `RootProjectAddSheet`. No layout behaviour change.

## Two techniques worth reading, both verified by the reviewer

**1. `adb shell ime disable <id>` is not durable.** Android silently re-enables the last IME, and the base test still passes. The reviewer confirmed this directly: with only `ime disable`, the pre-run probe showed `mCurMethodId=null` and `enabled_input_methods=null`, and **the base test still passed in 4.26s** — Android re-enabled the IME the moment the app asked for input.

`pm disable-user --user 0 com.android.inputmethod.latin` **is** durable. Under it the base test gives `tests="1" failures="1"`, `AssertionError: IME must be visible...` at `RootProjectAddSheetKeyboardLayoutTest.kt:108`, `time="31.828"` — the full 30s activity-decor wait burned, dying **before** `performTextInput` and before any geometry.

This closes a gap #1800 explicitly declared unmodellable; recorded there too.

**2. Three mutations survived, and were chased rather than written off.** A surviving mutant is ambiguous — it can mean the test is inadequate *or* that the mutated code is inert. Getting that backwards invites weakening the code under test.

Removing `.imePadding()` from `RootProjectAddSheetContent` (`RootProjectAddSheet.kt:128`) changes the measured geometry by **nothing**. The reviewer confirmed independently: with it deleted, geometry was byte-identical to unmutated (`liftPx=774.0 shrinkPx=712.0`, same rects). Material3's `ModalBottomSheet` already resolves the ime inset for its own window, so the modifier is a no-op. It is **not** deleted here — this slice's scope is "no layout behaviour change" — and is filed as #1812.

The kill comes from the lever that actually carries #613: the bounded shrinkable content column → `requiredHeight(640.dp)`, dropping the shrink to 127px (0.16) against the 0.25 floor.

## Reviewer-produced mutations

- **Root-cause RED** (`roots.forEach` → `listOf(activityDecor).forEach`): mutant provably live (4 dispatches logged), activity got 774, the modal Compose tree stayed **0**, red at `:297` before geometry. This is the proxy trap reproduced on demand.
- **M2** (`requiredHeight(640.dp)`): live (keyboard-down list top moved 1125 → 1411), red at `:240`.
- **Zero-inset** (`SYNTHETIC_IME_HEIGHT_DP = 0f`): red at `:297` on the `expected > 0` clause.

The reviewer also **added a mutation of its own** (`requiredHeight(900.dp)`), which survived — and explained why rather than calling the test weak: `keyboardUpList.bottom = 1626.0` is *exactly* `keyboardTop`, because the sheet bottom-anchors against its own ime inset, so the content bottom lands on the keyboard boundary regardless of content height. Semantically benign, but it means SHRINK is the only assertion carrying the #613 behaviour, and a top-side bound is missing (that mutant moved the list top 1063 → 454 with nothing catching it). Filed as a follow-up.

## LIFT/SHRINK subsumption — accepted on arithmetic, not prose

The implementer declared honestly that SHRINK has a demonstrated kill while LIFT is a companion bound. The reviewer verified the subsumption rather than accepting the wording: containment pins `list.bottom <= 1626 + 5.25`; LIFT needs `keyboardDownBottom - keyboardUpBottom >= 387`; given containment already forces `keyboardUpBottom <= 1631`, LIFT can only add bite when the keyboard-**down** baseline ends above y≈2018 — >380px of dead space under a bottom-anchored sheet with no keyboard. Degenerate. Under M2, LIFT passed at 742 (0.96) while SHRINK went red, confirming empirically which bound carries #613. G6 is satisfied because the load-bearing bound is the green one *and* has a demonstrated kill.

## Hygiene during review

The reviewer held IME disable→run→restore inside the machine-wide per-serial flock, so no sibling lane ever saw a disabled IME on the shared AVD, and the post-work IME state matches the pre-work snapshot exactly. 9 connected runs, **zero** signal-9. Three unmutated greens — one with no IME installed, two with a real IME — produced byte-identical geometry.

## Orchestrator verification

Applied to a clean worktree off `main` (`0c6fbd35`). `git diff --check` clean; test-validity and journey-harness guards green. `scripts/ci-journey-suite.sh` gained exactly one line and #1778's `TmuxUnifiedPagerCoordinatorComposeTest` entry is intact — that file drifts and has been clobbered before.

**This registers a NEW journey class**, so per the rule added in `d7c34b74` I did not stop at compiling it: `:app:compileDebugAndroidTestKotlin` green, **and** the class run on a real emulator through `scripts/connected-test.sh` — `Tests 1/1 completed. (0 skipped) (0 failed)`. That is precisely the check whose absence let #1778's newly-registered class redden `main` at its first CI execution.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb