### PR TITLE
test(tmux): inject the CI frame ordering into the pager coordinator proof (#1778)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxUnifiedPagerCoordinatorComposeTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxUnifiedPagerCoordinatorComposeTest.kt
@@ -160,10 +160,19 @@ class TmuxUnifiedPagerCoordinatorComposeTest {
         val acceptedPromotions = AtomicInteger(0)
         val initialAligned = AtomicBoolean(false)
         lateinit var heldState: MutableState<Boolean>
+        lateinit var replayNonce: MutableState<Int>
         lateinit var pagerState: PagerState
 
         compose.setContent {
             heldState = remember { mutableStateOf(false) }
+            // Issue #1778 CI reopen: production's settle-retry token is a
+            // composite (`UnifiedPagerSettleRetryToken`: terminalHeld PLUS the
+            // active page keys), so it can change while the reveal-hold
+            // eligibility does NOT. `replayNonce` is that second, non-hold
+            // dimension, controlled by the test so the frame-replay ordering
+            // this class must survive is injected deterministically instead of
+            // being left to device measure/apply timing (see below).
+            replayNonce = remember { mutableStateOf(0) }
             pagerState = rememberPagerState(pageCount = { initialPages.size })
             UnifiedPagerCoordinatorEffects(
                 pagerState = pagerState,
@@ -171,7 +180,10 @@ class TmuxUnifiedPagerCoordinatorComposeTest {
                 pages = initialPages,
                 sessionName = "A",
                 initialWindowIndex = null,
-                settleRetryToken = heldState.value,
+                settleRetryToken = HeldPromotionRetryToken(
+                    held = heldState.value,
+                    replay = replayNonce.value,
+                ),
             ) { _, page ->
                 if (page.key == initialPages[0].key) {
                     initialAligned.set(true)
@@ -206,24 +218,95 @@ class TmuxUnifiedPagerCoordinatorComposeTest {
             // promotes. The coordinator remains the only production writer.
             pagerState.requestScrollToPage(1)
         }
+        // The measured cached page must reach the production promotion
+        // predicate while the hold owns the surface, and must be rejected.
+        //
+        // How MANY times it is offered under one continuous hold is NOT a
+        // coordinator invariant, and pinning that count is exactly what turned
+        // `main` red (#1778 CI reopen, run 30323508796). The pager-position
+        // write and the settle-retry-token write are two snapshot writes, and
+        // whether Compose coalesces them into ONE measured `snapshotFlow` frame
+        // is device measure/apply timing, observed both ways on real devices:
+        //
+        //   dev-box AVD : Frame(page=1,key=null,token=held-false) -> no action
+        //                 Frame(page=1,key=B,   token=held-true)  -> 1 offer
+        //   CI AVD      : Frame(page=1,key=B,   token=held-false) -> 1 offer
+        //                 Frame(page=1,key=B,   token=held-true)  -> 2nd offer
+        //
+        // Both are correct: the retry token exists precisely so a replayed
+        // measured frame re-reaches the predicate when the token changes, and
+        // the production token also carries the active page keys, which change
+        // independently of the hold. So this test does NOT wait for the device
+        // to produce the multi-offer ordering — it injects it (`replayNonce`)
+        // and HARD-waits for it, the #780 synthetic-state model. The durable
+        // contracts are the three asserted below: never promoted through a
+        // hold, retried exactly once when the hold clears, and permanently
+        // deduped by acceptance.
         compose.waitUntil(timeoutMillis = 5_000) {
-            pagerState.settledPage == 1 && cachedAttempts == listOf(true)
+            pagerState.settledPage == 1 && cachedAttempts.isNotEmpty()
         }
-        assertEquals(0, acceptedPromotions.get())
+        compose.waitForIdle()
 
+        // Inject the CI ordering: replay the SAME measured pager frame under
+        // the SAME hold. A rejected key must stay retryable across that replay
+        // — a rejection that consumed it would strand the #797 promotion once
+        // the hold clears, and a replay that stopped re-offering would too.
+        var attemptsBeforeReplay = 0
+        compose.runOnIdle {
+            attemptsBeforeReplay = cachedAttempts.size
+            replayNonce.value += 1
+        }
+        compose.waitUntil(timeoutMillis = 5_000) {
+            cachedAttempts.size > attemptsBeforeReplay
+        }
+        compose.waitForIdle()
+
+        var attemptsUnderHold = 0
+        compose.runOnIdle {
+            assertTrue(
+                "every promotion offered under the hold must observe the hold",
+                cachedAttempts.isNotEmpty() && cachedAttempts.all { it },
+            )
+            assertEquals(
+                "the reveal hold must never be promoted through",
+                0,
+                acceptedPromotions.get(),
+            )
+            attemptsUnderHold = cachedAttempts.size
+            heldState.value = false
+        }
+
+        compose.waitUntil(timeoutMillis = 5_000) { acceptedPromotions.get() == 1 }
+        compose.runOnIdle {
+            assertEquals(
+                "clearing the hold must retry the rejected key exactly once",
+                listOf(false),
+                cachedAttempts.drop(attemptsUnderHold),
+            )
+        }
+
+        // Further eligibility changes AND pure frame replays both re-drive the
+        // measured pager frame, but acceptance — and only acceptance —
+        // permanently dedupes this measured B key.
+        var attemptsAfterAcceptance = 0
+        compose.runOnIdle {
+            attemptsAfterAcceptance = cachedAttempts.size
+            heldState.value = true
+        }
         compose.runOnIdle { heldState.value = false }
-        compose.waitUntil(timeoutMillis = 5_000) {
-            cachedAttempts == listOf(true, false) &&
-                acceptedPromotions.get() == 1
-        }
-
-        // Further eligibility changes replay the pager frame but acceptance,
-        // and only acceptance, permanently dedupes this measured B key.
         compose.runOnIdle { heldState.value = true }
         compose.runOnIdle { heldState.value = false }
+        compose.runOnIdle { replayNonce.value += 1 }
+        compose.runOnIdle { replayNonce.value += 1 }
         compose.waitForIdle()
-        assertEquals(listOf(true, false), cachedAttempts.toList())
-        assertEquals(1, acceptedPromotions.get())
+        compose.runOnIdle {
+            assertEquals(
+                "acceptance must permanently dedupe the measured cached key",
+                attemptsAfterAcceptance,
+                cachedAttempts.size,
+            )
+            assertEquals(1, acceptedPromotions.get())
+        }
     }
 
     @Test
@@ -564,6 +647,17 @@ class TmuxUnifiedPagerCoordinatorComposeTest {
             assertTrue(confirmedKeys.none { it == initialPages[0].key })
         }
     }
+
+    /**
+     * Issue #1778: the shape of the production settle-retry token — the reveal
+     * hold PLUS a second dimension that changes independently of it (production
+     * carries the active page keys there). `replay` lets this test replay one
+     * measured pager frame with the hold unchanged.
+     */
+    private data class HeldPromotionRetryToken(
+        val held: Boolean,
+        val replay: Int,
+    )
 
     private data class PageSpec(
         val sessionName: String,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxUnifiedPagerCoordinatorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxUnifiedPagerCoordinatorTest.kt
@@ -92,6 +92,42 @@ class TmuxUnifiedPagerCoordinatorTest {
     }
 
     @Test
+    fun repeatedRejectedCachedPromotionReplaysStayRetryableUntilAcceptance() {
+        val f = fixture()
+        val coordinator = alignedCoordinator(f)
+
+        // Issue #1778 CI reopen: the pager-position write and the
+        // eligibility-token write are two snapshot writes, and whether Compose
+        // coalesces them into one measured frame is device timing. On the CI
+        // AVD they do NOT coalesce, so the SAME measured cached page is offered
+        // more than once while one continuous reveal hold is still rejecting.
+        // Every rejection must leave the key retryable: a rejection that
+        // consumed it would strand the #797 promotion forever once the hold
+        // clears, and a replay that stopped re-offering would do the same.
+        repeat(3) { replay ->
+            val rejected = coordinator.observe(f.observation(page = 1)).singleSettle()
+            assertEquals(
+                "replay $replay must re-offer the same measured cached key",
+                f.pages[1].key,
+                rejected.pageKey,
+            )
+            assertFalse(rejected.userDrivenFromAlignedTarget)
+            coordinator.onConfirmedSettleHandled(rejected, accepted = false)
+        }
+
+        val accepted = coordinator.observe(f.observation(page = 1)).singleSettle()
+        assertEquals(f.pages[1].key, accepted.pageKey)
+        coordinator.onConfirmedSettleHandled(accepted, accepted = true)
+
+        repeat(3) { replay ->
+            assertTrue(
+                "replay $replay after acceptance must stay deduped",
+                coordinator.observe(f.observation(page = 1)).isEmpty(),
+            )
+        }
+    }
+
+    @Test
     fun dragSnapBackRearmsTargetAlignment() {
         val f = fixture()
         val coordinator = alignedCoordinator(f)


### PR DESCRIPTION
Closes #1778 · fixes the `main` red introduced by `7417c8d4`

## What happened

`TmuxUnifiedPagerCoordinatorComposeTest#heldCachedPromotionRetriesOnceAfterHoldClearsAndThenDedupes` failed 2/2 on shard 2 at its **first-ever CI execution** — the file was new in `7417c8d4` and wired into the journey suite in the same commit, so no pre-merge gate ever ran it. (That gap is now a rule, `d7c34b74`.)

## Discrimination first — because the two hypotheses had opposite fixes

Line 209 asserted a **conjunction**, and the artifact recorded only the timeout. The candidates were (1) the assertion is wrong because `settledPage` bounces back to 0, or (2) the coordinator is wrong because the held settle callback never fires. Guessing had a 50% chance of "fixing" correct production code, so nothing was touched until the failing half was identified.

**Neither was right.** The failing half is `cachedAttempts` — `settledPage` holds from ~2ms and never reverts — and the list becomes `[true, true]`: an **extra** offer, not a missing one. The two orderings differ only by whether Compose coalesces `heldState.value = true` and `requestScrollToPage(1)` into one measured frame:

```
dev-box : Frame(cur=1,key=null,token=held-false) -> no action
          Frame(cur=1,key=B,   token=held-true)  -> 1 offer   attempts=[true]      PASS
CI      : Frame(cur=1,key=B,   token=held-false) -> 1 offer   attempts=[true]
          Frame(cur=1,key=B,   token=held-true)  -> 2nd offer attempts=[true,true] TIMEOUT
```

The bounce hypothesis is unreachable **by construction**, verified by decompiling the Foundation 1.8.1 AAR: `javap -p -c PagerState$settledPage$2` gives `isScrollInProgress ? settledPageState : currentPage`. With `measuredCurrentPageKey` read in the same snapshot, `confirmedIdleSettle` is always true here, so `reduceObservation` always returns from the `completion == null && targetAligned` branch and the bottom `requestDesiredPage` is unreachable.

## Root cause: the assertion, not the coordinator

The count of *rejected* offers under one continuous hold is not an invariant. The retry token exists precisely so a replayed frame re-reaches the predicate when the token changes, and production's token also carries `activePageKeys`, which move independently of the hold.

The reviewer verified the safety of that against the **production** callback rather than the test lambda: under the hold, `tmuxSessionShouldPromoteSettledCachedPane` returns `false` on its first line (`TmuxSessionScreenRouting.kt:294`) and `settleSessionSwitchTarget` returns `null` on `!userDraggedSinceAlignment` (`TmuxSessionScreenStateHelpers.kt:611`), so a rejected offer **never** reaches `viewModel.onUnifiedPageSettled(...)`. The only repeated call is `reseedVisiblePaneIfBlank`, which self-guards on `panesSeededThisAttach` / `panesSeedInFlightThisAttach` / `visibleScreenIsBlank()`. Offers are driven by `snapshotFlow` frames, so a static hold produces no further offers — no runaway. Its stated position: had a second offer been able to produce a real side effect, it would have flipped the verdict.

## The fix makes it deterministic, not merely passing

It does **not** relax the assertion. It **injects** the CI frame ordering (the #780 model) — replaying one identical measured frame under an unchanged hold and hard-waiting for the extra offer — so the CI ordering runs on **every device, every time** instead of 1-in-6. Every wait is still `5_000`; nothing was widened.

**M3 is the load-bearing mutant**: it models the *tempting wrong fix* — suppressing token-only replays in the effect. The reviewer re-drove it and it **dies in the right place**, `ComposeTimeoutException` at the injected-replay wait (`:259`), plus a collateral kill of `sameEpochDesiredReplacementRetiresSuspendedOwnerAndRetriesNewKey` (`tests=6 failures=2`). So the injection, not device luck, is doing the work. M1 re-driven too: killed on JVM (`22 tests completed, 2 failed`).

The reviewer also built its own deterministic red by splitting the original conjunction: `cachedAttempts.size >= 2` PASSED, `settledPage == 1` PASSED, `cachedAttempts == listOf(true)` timed out with the exact CI exception. Both hypotheses refuted empirically as well as structurally.

## Test-only — confirmed independently

`git diff origin/main -- app/src/main/java/` is **0 lines**; `git diff origin/main -- scripts/ci-journey-suite.sh` is **0 lines**; md5s of both pager production files identical before and after all mutation work. Only two test files changed (+140/−10).

The original #1778 acceptance criteria are unaffected, including the drag-owner isolation round 1 verified via disjoint kill sets.

## Orchestrator verification

Applied to a clean worktree off `main` (`0c6fbd35`). `git diff --check` clean; all 16 waits still `5_000`. `:app:compileDebugAndroidTestKotlin` green.

Per the `d7c34b74` rule I did not stop at compiling: the previously-failing class was **run on a real emulator**, with `> Task :app:connectedDebugAndroidTest` unsuffixed and `Starting 6 tests` → `Finished 6 tests`, `BUILD SUCCESSFUL`. All six of the class's tests, including the one that reddened `main`.

## Separately filed

`MultiSessionSwitchJourneyE2eTest`'s attempt-1 failure in the same run is **independent** and is a gate-budget defect, not this candidate's bug: `exit 124 / outer_timeout / raw-junit count=0`, log ending at `:app:createDebugApkListingFileRedirect`, and it was the **only** one of shard 2's 47 classes whose attempt 1 ran a cold `:app:compileDebugKotlin` — it was first on the shard and ate the cold build inside its per-class budget. Filed as #1814.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb