### PR TITLE
ci(journey): warm the build before the first class's clock starts (#1814)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -261,6 +261,22 @@ jobs:
             scripts/test-ci-journey-infra-signature.sh
           scripts/test-ci-journey-infra-signature.sh
 
+      # Issue #1814: the first journey class on a shard used to pay for the cold
+      # `:app:compileDebugKotlin` INSIDE its own per-class budget, so it could
+      # time out for a reason unrelated to the test — and an `exit 124 /
+      # outer_timeout / raw-junit count=0` build-phase timeout is
+      # indistinguishable from a genuine journey failure. This guard drives the
+      # REAL suite with a gradle stub that models a cold build, MEASURES
+      # first-class vs mid-shard elapsed on all three shards, proves the same
+      # fixture is RED against a mutant with the warm-build call removed, and
+      # observes the build-phase attribution end to end (suite -> manifest ->
+      # verdict token -> aggregate). Cheap (no emulator, no Gradle, no JVM).
+      - name: CI journey warm-build + build-phase attribution guard (issue #1814)
+        run: |
+          chmod +x scripts/ci-journey-build-phase-timeout.sh \
+            scripts/test-ci-journey-warm-build.sh
+          scripts/test-ci-journey-warm-build.sh
+
       # Issue #1781: fast, JVM-free artifact packaging fixture. Proves the
       # first-cold-boot preservation scan keeps real module Android outputs and
       # canonical per-attempt evidence without recursively nesting
@@ -653,7 +669,9 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x scripts/ci-journey-write-shard-verdict.sh
-          scripts/ci-journey-write-shard-verdict.sh INFRA
+          # Issue #1814: the seed carries its own reason so a carried-over token
+          # says why it exists ("this attempt died before classifying").
+          scripts/ci-journey-write-shard-verdict.sh INFRA preseed_before_classify
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -1255,7 +1273,37 @@ jobs:
           # stamp (run id / run attempt / shard) can never drift between the
           # pre-seed and the classifier, and so a later step can gate on the
           # `shard_verdict` output the helper exports.
-          write_verdict() { bash scripts/ci-journey-write-shard-verdict.sh "$1"; }
+          # Issue #1814: the token also carries WHY it has this value. Every
+          # branch below passes a short machine reason; the aggregation job
+          # prints it per shard. The reason NEVER changes severity.
+          write_verdict() { bash scripts/ci-journey-write-shard-verdict.sh "$1" "${2:-unspecified}"; }
+          # Issue #1814: an attempt cut by its per-class wall cap while Gradle
+          # was still BUILDING writes `exit 124 / outer_timeout / raw-junit
+          # count=0` — byte-for-byte what a killed mid-journey runner writes. On
+          # run 30323508796 shard 2 that ambiguity sent an investigation after a
+          # healthy journey class. Read the suite's own per-attempt manifests so
+          # this shard's verdict can NAME the build-cost case instead of leaving
+          # it looking like a product defect. Reporting only: the verdict's
+          # severity is unchanged (a build that outgrows its bound is a real
+          # problem and must stay visible — softening it would be #1458-style
+          # masking in reverse).
+          build_phase_out="$(bash scripts/ci-journey-build-phase-timeout.sh artifacts 2>&1 || true)"
+          printf '%s\n' "$build_phase_out" | sed 's/^/journey build-phase timeout: /'
+          build_phase_attempts="$(sed -n 's/^build_phase_timeout_attempts=//p' <<<"$build_phase_out" | tail -n 1)"
+          [[ "$build_phase_attempts" =~ ^[0-9]+$ ]] || build_phase_attempts=0
+          build_phase_classes="$(sed -n 's/^build_phase_timeout_classes=//p' <<<"$build_phase_out" | tail -n 1)"
+          if (( build_phase_attempts > 0 )); then
+            echo "::warning title=Emulator journey — an attempt was cut during the Gradle BUILD phase (#1814)::${build_phase_attempts} attempt(s) on this shard hit their per-class wall cap while Gradle was still BUILDING: ${build_phase_classes:-<unnamed>}. Instrumentation never started, so there is no JUnit XML and the zero-test outer timeout is a BUILD-COST artefact — it is NOT evidence that the named journey is broken. The cold build is paid up front by the suite's warm-build step, so a recurrence means the build outgrew its bound; investigate the build, not the journey."
+          fi
+          # verdict_reason_for <fallback> — prefer the cold-build attribution
+          # when this shard carries that evidence, else the branch's own reason.
+          verdict_reason_for() {
+            if (( build_phase_attempts > 0 )); then
+              printf 'cold_build_timeout\n'
+            else
+              printf '%s\n' "$1"
+            fi
+          }
           echo "first attempt outcome:  $first"
           echo "retry attempt outcome:  ${retry:-<skipped>}"
           echo "first attempt conclusion:  $first_concl"
@@ -1268,12 +1316,12 @@ jobs:
           echo "cold-boot retry cost model: ${retry_cost_model:-worst_case} (issue #1800)"
           if [[ "$first" == "success" ]]; then
             echo "Emulator journey passed on the first cold boot."
-            write_verdict CLEAN
+            write_verdict CLEAN passed_first_attempt
             exit 0
           fi
           if [[ "$retry" == "success" ]]; then
             echo "::warning title=Emulator infra flake recovered::The first emulator bringup failed but a second cold boot passed (issue #760). Treating as a recovered infra flake, NOT a test failure. Watch for a degrading trend."
-            write_verdict CLEAN
+            write_verdict CLEAN infra_flake_recovered
             exit 0
           fi
           # Issue #1800: ONE captured environment signature is not a product
@@ -1300,19 +1348,19 @@ jobs:
           signature_verdict="$(sed -n 's/^shard_signature_verdict=//p' <<<"$signature_out" | tail -n 1)"
           if [[ "$signature_verdict" == "INFRA" && "${first_timeout:-false}" != "true" ]]; then
             echo "::warning title=Emulator journey INFRA — real system IME unavailable on this AVD::The ONLY failure(s) on this shard were the physical input-method-window PRECONDITION (\"The real system input-method window never became visible.\"), which the CI swiftshader AVD cannot satisfy. This is a captured environment signature (G5), NOT a product regression: the same class's anchor/containment properties are asserted with hard failures on its synthetic Type.ime() path, which ran in this same suite. Typed INFRA so aggregation requests RE-RUN. Any containment/anchor assertion failure would have stayed RED (issue #1800)."
-            write_verdict INFRA
+            write_verdict INFRA real_ime_precondition
             exit 1
           fi
           if [[ "${first_failure:-false}" == "true" ]]; then
             echo "::error title=Emulator journey FAILED — first attempt genuine failure::The first cold boot wrote a JOURNEY_FAILED / Failed BOTH attempts summary, and the retry did not pass cleanly. Refusing to downgrade this run to advisory timeout even if the retry overwrote summary.md with a timeout-only artifact."
-            write_verdict RED
+            write_verdict RED "$(verdict_reason_for first_attempt_journey_failure)"
             exit 1
           fi
           if [[ "${first_timeout:-false}" == "true" ]]; then
             timed_out_classes="$(awk '/JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted/{f=1} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
             echo "::error title=Emulator journey TIMEOUT — load-bearing classes cut short (#835/#470)::The journey suite booted and ran, but exhausted its own 4200s time budget before every load-bearing class reached a verdict (issue #835 / #470). This is now a HARD RED durable guard (#835 REOPENED, D31): a budget timeout means a load-bearing class was silently cut short, which used to be masked as advisory-green. The retry is skipped because a budget timeout is deterministic. Either the enumeration stall has returned or the selection no longer fits the budget — investigate; do NOT treat as a flake. Class(es) cut short / not run:"
             [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
-            write_verdict RED
+            write_verdict RED "$(verdict_reason_for suite_budget_timeout)"
             exit 1
           fi
           # Issue #1458: no trustworthy first-attempt verdict and insufficient
@@ -1323,7 +1371,7 @@ jobs:
           # their existing RED semantics.
           if [[ "${retry_allowed:-false}" != "true" ]]; then
             echo "::warning title=Emulator journey retry skipped — insufficient remaining job wall::The first attempt did not produce a clean verdict, but a complete fresh-cold-boot retry no longer fits before the absolute 95-minute job deadline (reason=${retry_reason:-missing_decision}, remaining=${retry_remaining_ms:-0}ms, required=${retry_required_ms:-5400000}ms). The retry was not started; this shard is typed INFRA so aggregation requests RE-RUN, while classifier and artifacts retain time to finish (issue #1458)."
-            write_verdict INFRA
+            write_verdict INFRA retry_wall_exhausted
             exit 1
           fi
           # If a cold-boot attempt was cancelled, do not trust summary.md for a
@@ -1332,7 +1380,7 @@ jobs:
           # attempt did not produce a trustworthy final suite verdict.
           if [[ "$first" == "cancelled" || "$retry" == "cancelled" || "$first_concl" == "cancelled" || "$retry_concl" == "cancelled" ]]; then
             echo "::error title=Emulator journey TIMEOUT — step cancelled (#470 stall)::A journey cold-boot attempt was CANCELLED before producing a trustworthy final suite verdict. Any existing artifacts/ci-journey/summary.md may be stale from an earlier attempt, so this is NOT reported as a genuine failed-on-both-cold-boots test regression. This is the recurring enumeration-stall/step-timeout infra class (issue #835 / #470). Re-run."
-            write_verdict INFRA
+            write_verdict INFRA attempt_cancelled
             exit 1
           fi
           # Both attempts failed — classify from the suite's own summary artifact.
@@ -1343,7 +1391,7 @@ jobs:
             failed_classes="$(awk '/Failed BOTH attempts/{f=1; next} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
             echo "::error title=Emulator journey FAILED — genuine test failure::A load-bearing journey class failed on BOTH cold-boot attempts AFTER the emulator booted and the suite ran to a verdict. This is a real test regression (NOT a #771 emulator-infra abort). Failing class(es):"
             [[ -n "$failed_classes" ]] && printf '%s\n' "$failed_classes"
-            write_verdict RED
+            write_verdict RED "$(verdict_reason_for journey_failure_both_attempts)"
             exit 1
           fi
           # Issue #835 (REOPENED, DURABLE GUARD): the suite ran (the emulator
@@ -1362,7 +1410,7 @@ jobs:
             timed_out_classes="$(awk '/JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted/{f=1} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
             echo "::error title=Emulator journey TIMEOUT — load-bearing classes cut short (#835/#470)::The journey suite booted and ran, but exhausted its 4200s time budget before every load-bearing class reached a verdict (issue #835 / #470). This is now a HARD RED durable guard (#835 REOPENED, D31), NOT an advisory-green: a budget timeout means a load-bearing class was silently cut short. Either the in-emulator enumeration stall has returned or the selection no longer fits the budget — investigate. This is distinct from a never-booted emulator (#771) and from a genuine test regression. Class(es) cut short / not run:"
             [[ -n "$timed_out_classes" ]] && printf '%s\n' "$timed_out_classes"
-            write_verdict RED
+            write_verdict RED "$(verdict_reason_for suite_budget_timeout)"
             exit 1
           fi
           # No suite summary at all: the script aborted before any class reached
@@ -1370,7 +1418,7 @@ jobs:
           # so gradle could not run. This is the EMULATOR INFRA UNAVAILABLE
           # class (#771).
           echo "::error title=EMULATOR INFRA UNAVAILABLE::Both cold-boot attempts failed and the journey suite wrote NO summary (artifacts/ci-journey/summary.md missing), so no journey class ever ran to a verdict — the emulator never reached 'device' / adb never came up (boot/adb infra, issue #771). This is an infra abort, NOT a test regression."
-          write_verdict INFRA
+          write_verdict INFRA emulator_never_booted
           exit 1
 
       - name: Collect Docker logs

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -76,6 +76,7 @@ count=0
 tokens=()
 provenance=()
 carried_over=()
+cold_build_shards=()
 fresh_tokens=0
 
 current_attempt="${GITHUB_RUN_ATTEMPT:-}"
@@ -94,6 +95,10 @@ if [[ -d "$verdict_dir" ]]; then
     tok_shard="$(sed -n 's/^shard=//p' "$f" 2>/dev/null | head -n 1)"
     tok_attempt="$(sed -n 's/^run_attempt=//p' "$f" 2>/dev/null | head -n 1)"
     tok_run="$(sed -n 's/^run_id=//p' "$f" 2>/dev/null | head -n 1)"
+    # Issue #1814: WHY this shard has this verdict. Absent on a token written
+    # before the reason existed, which stays a plain `unspecified`.
+    tok_reason="$(sed -n 's/^verdict_reason=//p' "$f" 2>/dev/null | head -n 1)"
+    [[ -n "$tok_reason" ]] || tok_reason="unspecified"
     if [[ -z "$tok_shard" ]]; then
       # No stamp (a token from a job that died before the pre-seed, or a foreign
       # artifact): fall back to the download-artifact per-shard subdir name.
@@ -119,7 +124,10 @@ if [[ -d "$verdict_dir" ]]; then
       origin="attempt unknown (token carries no #1809 provenance stamp)"
     fi
 
-    provenance+=("shard ${tok_shard}: ${token} — run ${tok_run}, ${origin}")
+    provenance+=("shard ${tok_shard}: ${token} — run ${tok_run}, ${origin}, reason ${tok_reason}")
+    if [[ "$tok_reason" == "cold_build_timeout" ]]; then
+      cold_build_shards+=("shard ${tok_shard} (${token})")
+    fi
 
     count=$((count + 1))
     tokens+=("$token")
@@ -149,6 +157,16 @@ else
   for line in "${provenance[@]}"; do
     echo "  $line"
   done
+fi
+
+# Issue #1814: a verdict caused (at least in part) by an attempt that was cut
+# short while Gradle was still BUILDING must SAY so. Such an attempt reports
+# `exit 124 / outer_timeout / raw-junit count=0` — indistinguishable from a
+# killed mid-journey runner — and on run 30323508796 that ambiguity sent an
+# investigation after a healthy journey class. The verdict's SEVERITY is
+# untouched (naming a failure is not softening it); only its readability is.
+if (( ${#cold_build_shards[@]} > 0 )); then
+  echo "::notice title=Emulator journey verdict — includes a cold-BUILD-phase timeout (#1814)::${#cold_build_shards[@]} shard verdict(s) were reported with reason 'cold_build_timeout': ${cold_build_shards[*]}. At least one attempt there hit its per-class wall cap while Gradle was still BUILDING — instrumentation never started and no JUnit XML exists, so the zero-test outer timeout is a BUILD-COST artefact, not evidence that the named journey is broken. Investigate the build cost (the cold build is paid up front by the suite's warm-build step), not the journey."
 fi
 
 if (( ${#carried_over[@]} > 0 )); then
@@ -185,6 +203,10 @@ emit_summary() {
         for line in "${provenance[@]}"; do
           echo "- ${line}"
         done
+      fi
+      if (( ${#cold_build_shards[@]} > 0 )); then
+        echo
+        echo "**Cold-build-phase timeout (issue #1814):** ${cold_build_shards[*]} — an attempt there was cut while Gradle was still BUILDING (no instrumentation, no JUnit XML). That is a build-cost artefact, not a defect in the named journey."
       fi
     } >> "$GITHUB_STEP_SUMMARY"
   fi

--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -47,6 +47,12 @@ LAST_RUN_CLASS_PRIMARY_CLASSIFICATION=""
 LAST_RUN_CLASS_RAW_JUNIT_STATUS=""
 LAST_RUN_CLASS_RAW_JUNIT_COUNT=0
 LAST_RUN_CLASS_SNAPSHOT_STATUS=""
+# Issue #1814: which PHASE an outer-timeout attempt died in. A zero-test
+# `outer_timeout` reads identically whether the runner was killed mid-journey or
+# Gradle was still BUILDING, and that ambiguity is what made the shard-2
+# first-class timeout on run 30323508796 expensive to diagnose.
+LAST_RUN_CLASS_OUTER_TIMEOUT_PHASE=""
+BUILD_PHASE_TIMEOUT_ATTEMPTS=()
 JOURNEY_ABORT_ISOLATION_FAILED=0
 JOURNEY_HARNESS_FAILURE_RC=125
 declare -A JOURNEY_CLASS_ATTEMPT_COUNTS=()
@@ -61,6 +67,58 @@ class_attempt_hit_time_budget() {
 
 needs_gradle_cleanup_after_class_abort() {
   [[ "$1" -eq 124 || "$1" -eq 137 ]]
+}
+
+# journey_attempt_timeout_phase <attempt-log> <classification> — issue #1814.
+#
+# An `outer_timeout` with `raw-junit count=0` is produced by two very different
+# situations that used to be indistinguishable in the artifacts:
+#   * the Gradle BUILD was still running when the wall cap fired (nothing about
+#     the journey was ever exercised — a build-cost artefact, not a verdict), and
+#   * instrumentation started and then wedged (a real on-device signal).
+# The attempt log is the only evidence that separates them, so read it: Gradle
+# prints `> Task :…` headers as it executes, and the connected-test task /
+# runner announce themselves when instrumentation begins.
+#
+# Fail-SAFE by construction: `build` is claimed only on POSITIVE evidence of
+# build activity WITH no instrumentation marker. No evidence at all stays
+# `unknown`, which is never downgraded or specially labelled — so this can only
+# ever add attribution, never remove a failure signal.
+journey_attempt_timeout_phase() {
+  local log="$1"
+  local classification="$2"
+
+  if [[ "$classification" != "outer_timeout" ]]; then
+    printf 'not_applicable\n'
+    return 0
+  fi
+  if [[ ! -f "$log" ]]; then
+    printf 'unknown\n'
+    return 0
+  fi
+  if grep -qE '> Task :[^[:space:]]*:connected[A-Za-z]*AndroidTest|Starting [0-9]+ tests on|Installing APK|Installed on ' "$log"; then
+    printf 'instrumentation\n'
+    return 0
+  fi
+  if grep -qE '> Task :' "$log"; then
+    printf 'build\n'
+    return 0
+  fi
+  printf 'unknown\n'
+}
+
+# record_build_phase_timeout_attempt <selector> — issue #1814.
+#
+# Name a build-phase timeout LOUDLY and greppably at the moment it happens, and
+# collect it for its own summary section, so nobody has to reverse-engineer
+# "exit 124 / count=0" into "the build had not finished yet" again. This is
+# attribution only: the attempt's pass/fail bucket is untouched.
+record_build_phase_timeout_attempt() {
+  local fqcn="$1"
+
+  [[ "${LAST_RUN_CLASS_OUTER_TIMEOUT_PHASE:-}" == "build" ]] || return 0
+  echo "JOURNEY_BUILD_PHASE_TIMEOUT: $fqcn attempt ${LAST_RUN_CLASS_ATTEMPT} was cut while Gradle was still BUILDING — instrumentation never started, so there is no raw JUnit XML (raw-junit count=${LAST_RUN_CLASS_RAW_JUNIT_COUNT}). Read this as a build-cost timeout, NOT as a journey verdict or a product defect (issue #1814)."
+  BUILD_PHASE_TIMEOUT_ATTEMPTS+=("$fqcn (attempt ${LAST_RUN_CLASS_ATTEMPT})")
 }
 
 journey_class_artifact_key() {
@@ -478,6 +536,7 @@ snapshot_connected_test_outputs() {
   local raw_junit_count=0
   local raw_junit_status
   local primary_classification
+  local outer_timeout_phase
   local -a build_roots=()
 
   mapfile -t build_roots < <(journey_module_build_roots "$module" "$suffix") || return 1
@@ -530,6 +589,11 @@ snapshot_connected_test_outputs() {
   else
     primary_classification="failure"
   fi
+  # Issue #1814: attribute an outer timeout to the phase it died in, from this
+  # attempt's own streamed log.
+  outer_timeout_phase="$(
+    journey_attempt_timeout_phase "$attempt_dir/attempt.log" "$primary_classification"
+  )"
 
   if serial="$(journey_resolve_device_serial)"; then
     if capture_required_nonempty \
@@ -582,10 +646,12 @@ snapshot_connected_test_outputs() {
     printf 'primary_classification=%s\n' "$primary_classification"
     printf 'raw_junit_status=%s\n' "$raw_junit_status"
     printf 'raw_junit_count=%s\n' "$raw_junit_count"
+    printf 'outer_timeout_phase=%s\n' "$outer_timeout_phase"
     printf 'snapshotted_output_roots=%s\n' "$copied"
     printf 'snapshot_status=%s\n' "$([[ "$snapshot_failed" -eq 0 ]] && printf complete || printf failed)"
   } >> "$attempt_dir/manifest.txt" || snapshot_failed=1
 
+  LAST_RUN_CLASS_OUTER_TIMEOUT_PHASE="$outer_timeout_phase"
   LAST_RUN_CLASS_PRIMARY_CLASSIFICATION="$primary_classification"
   LAST_RUN_CLASS_RAW_JUNIT_STATUS="$raw_junit_status"
   LAST_RUN_CLASS_RAW_JUNIT_COUNT="$raw_junit_count"
@@ -830,6 +896,7 @@ run_class() {
   LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=0
   LAST_RUN_CLASS_GRADLE_CLEANUP_RC="not_run"
   LAST_RUN_CLASS_DEVICE_CLEANUP_RC="not_run"
+  LAST_RUN_CLASS_OUTER_TIMEOUT_PHASE=""
   if [[ -n "$app_id_suffix" ]]; then
     [[ "$app_id_suffix" =~ ^[A-Za-z0-9._]+$ ]] || {
       echo "JOURNEY_INVOCATION_IDENTITY_FAILED: invalid application id suffix '$app_id_suffix'" >&2
@@ -896,6 +963,8 @@ run_class() {
     LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
     JOURNEY_ABORT_ISOLATION_FAILED=1
   fi
+  # Issue #1814: name a still-building outer timeout for what it is.
+  record_build_phase_timeout_attempt "$fqcn"
   cleanup_status="not_required"
   if needs_gradle_cleanup_after_class_abort "$rc"; then
     cleanup_status="failed"
@@ -940,6 +1009,7 @@ run_ct_class() {
   LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=0
   LAST_RUN_CLASS_GRADLE_CLEANUP_RC="not_run"
   LAST_RUN_CLASS_DEVICE_CLEANUP_RC="not_run"
+  LAST_RUN_CLASS_OUTER_TIMEOUT_PHASE=""
   remaining="$(budget_remaining)"
   cap="$JOURNEY_CLASS_TIMEOUT_SECS"
   (( remaining < cap )) && cap="$remaining"
@@ -976,6 +1046,8 @@ run_ct_class() {
     LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED=1
     JOURNEY_ABORT_ISOLATION_FAILED=1
   fi
+  # Issue #1814: name a still-building outer timeout for what it is.
+  record_build_phase_timeout_attempt "$fqcn"
   cleanup_status="not_required"
   if needs_gradle_cleanup_after_class_abort "$rc"; then
     cleanup_status="failed"

--- a/scripts/ci-journey-build-phase-timeout.sh
+++ b/scripts/ci-journey-build-phase-timeout.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Issue #1814: report whether ANY preserved attempt on this shard died while
+# Gradle was still BUILDING, so the shard verdict can say so instead of leaving
+# a build-cost timeout looking exactly like a genuine journey failure.
+#
+# Why this exists: an attempt cut by the per-class wall cap during the build
+# phase writes `primary_classification=outer_timeout` with `raw_junit_count=0`
+# — byte-for-byte identical to what a killed mid-journey runner writes. On run
+# 30323508796 shard 2 that ambiguity sent an investigation after a healthy
+# journey class (`MultiSessionSwitchJourneyE2eTest`) when the real cause was
+# that the first class on the shard was paying the cold `:app:compileDebugKotlin`
+# inside its own per-class budget.
+#
+# The evidence is the per-attempt manifest the suite already writes
+# (`outer_timeout_phase=`, added by scripts/ci-journey-budget-functions.sh).
+# This reads BOTH the live artifact tree and the preserved first-attempt
+# snapshot, exactly like scripts/ci-journey-shard-signature-verdict.sh, so a
+# retry cannot hide the first attempt's evidence.
+#
+# Usage:
+#   ci-journey-build-phase-timeout.sh [ARTIFACTS_DIR]      (default: artifacts)
+#
+# Output (key=value on stdout; always exits 0 so a caller can never be broken by
+# missing evidence — absence of evidence reports zero, never an error):
+#   build_phase_timeout_attempts=<N>
+#   build_phase_timeout_classes=<comma-separated FQCNs, or empty>
+#
+# Reporting only: this NEVER changes a verdict's severity. A build-phase timeout
+# still counts exactly as much as it did before — it is merely named. Softening
+# it to a re-run signal would be the masking D31/D32 exist to prevent (a build
+# that reliably outgrows its bound is a real problem that must stay visible).
+set -uo pipefail
+
+artifacts_dir="${1:-artifacts}"
+
+attempts=0
+classes=""
+
+if [[ -d "$artifacts_dir" ]]; then
+  while IFS= read -r -d '' manifest; do
+    grep -Fqx 'outer_timeout_phase=build' "$manifest" 2>/dev/null || continue
+    attempts=$((attempts + 1))
+    class="$(sed -n 's/^class=//p' "$manifest" 2>/dev/null | head -n 1)"
+    [[ -n "$class" ]] || class="<unnamed>"
+    case ",$classes," in
+      *",$class,"*) ;;
+      *) classes="${classes:+$classes,}$class" ;;
+    esac
+  done < <(find "$artifacts_dir" -type f -name 'manifest.txt' -print0 2>/dev/null)
+fi
+
+printf 'build_phase_timeout_attempts=%s\n' "$attempts"
+printf 'build_phase_timeout_classes=%s\n' "$classes"

--- a/scripts/ci-journey-class-loop-functions.sh
+++ b/scripts/ci-journey-class-loop-functions.sh
@@ -41,6 +41,14 @@ run_journey_classes_with_retry() {
   echo ">>> Suite-level time budget (issue #835): ${JOURNEY_STEP_BUDGET_SECS}s"
   echo "    (per-class attempt cap: ${JOURNEY_CLASS_TIMEOUT_SECS}s; workflow job cap: 95 min)"
 
+  # Issue #1814: pay the cold Gradle build ONCE, here, BEFORE the first class's
+  # per-class clock starts. The suite budget clock (SUITE_START, just above) is
+  # already running, so this does NOT move build time out of the suite budget —
+  # it only stops the first class from being charged for shared, once-per-shard
+  # work no later class pays. Non-fatal by design (see the helper's FAIL-SAFE
+  # note): a failed warm build leaves the class loop exactly as it was.
+  warm_journey_build
+
   local fqcn class_start rc retry_start
   for fqcn in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
     # Issue #835: stop launching new classes once the suite-level budget is spent.

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -376,8 +376,19 @@ print_journey_class_selection
 #   JOURNEY_CLASS_KILL_AFTER_SECS
 #                              — SIGKILL backstop after the per-class timeout
 #                                sends TERM (default 30s).
+#   JOURNEY_WARM_BUILD_TIMEOUT_SECS
+#                              — issue #1814: hard cap for the ONE up-front warm
+#                                build (default 900s). The cold Gradle build is
+#                                paid BEFORE the per-class clock starts so the
+#                                FIRST class on a shard is not charged for
+#                                `:app:compileDebugKotlin` inside its own
+#                                per-class budget. It is charged to the SUITE
+#                                budget (where that build time already lived),
+#                                so the job-cap arithmetic above is unchanged,
+#                                and NO per-class budget is raised.
 JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-4200}"
 JOURNEY_CLASS_TIMEOUT_SECS="${JOURNEY_CLASS_TIMEOUT_SECS:-420}"
+JOURNEY_WARM_BUILD_TIMEOUT_SECS="${JOURNEY_WARM_BUILD_TIMEOUT_SECS:-900}"
 JOURNEY_GRADLE_STOP_TIMEOUT_SECS="${JOURNEY_GRADLE_STOP_TIMEOUT_SECS:-60}"
 JOURNEY_CLASS_KILL_AFTER_SECS="${JOURNEY_CLASS_KILL_AFTER_SECS:-30}"
 
@@ -428,6 +439,16 @@ if [[ "${POCKETSHELL_JOURNEY_SHARD:-0}" == "1" ]]; then
     exit 1
   fi
 fi
+
+# Issue #1814: the up-front warm build lives in its own sourced helper. It runs
+# INSIDE the suite budget but OUTSIDE every per-class cap, so the first class on
+# a shard is no longer charged for the cold `:app:compileDebugKotlin`.
+# shellcheck source=scripts/ci-journey-warm-build-functions.sh
+CI_JOURNEY_WARM_BUILD_HELPER="$REPO_ROOT/scripts/ci-journey-warm-build-functions.sh"
+if [[ ! -f "$CI_JOURNEY_WARM_BUILD_HELPER" && -f "$INVOCATION_DIR/scripts/ci-journey-warm-build-functions.sh" ]]; then
+  CI_JOURNEY_WARM_BUILD_HELPER="$INVOCATION_DIR/scripts/ci-journey-warm-build-functions.sh"
+fi
+source "$CI_JOURNEY_WARM_BUILD_HELPER"
 
 # Journey class retry loop and result buckets live in a sourced helper. The
 # helper preserves the existing budget log phrase "workflow job cap: 95 min",

--- a/scripts/ci-journey-summary-functions.sh
+++ b/scripts/ci-journey-summary-functions.sh
@@ -53,6 +53,10 @@ finish_ci_journey_suite() {
     echo "| --- | --- | --- | --- | --- |"
     echo "| ${#EFFECTIVE_JOURNEY_CLASSES[@]} load-bearing journey classes (shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL}; per-class retry-once) | \`pocketshellCi=true\` | $JOURNEY_EXIT | ${SUITE_ELAPSED}s | **$journey_status** |"
     echo
+    # Issue #1814: the cold Gradle build is paid ONCE, up front, so the first
+    # class on this shard is measured on the same terms as every later class.
+    echo "Warm build (issue #1814): **${JOURNEY_WARM_BUILD_STATUS:-not_run}** in ${JOURNEY_WARM_BUILD_ELAPSED:-0}s — paid before the per-class budget clock, charged to the suite budget."
+    echo
     echo "Classes exercised:"
     for c in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
       echo "- \`$c\`"
@@ -88,6 +92,31 @@ finish_ci_journey_suite() {
       echo
       echo "Recovered on retry (CI-AVD flake — \`JOURNEY_FLAKE_RECOVERED\`):"
       for c in "${RECOVERED_CLASSES[@]}"; do
+        echo "- \`$c\`"
+      done
+    fi
+    # Issue #1814: name every attempt whose outer timeout fired while Gradle was
+    # still BUILDING. Such an attempt reports `exit 124 / outer_timeout /
+    # raw-junit count=0` — byte-for-byte what a killed mid-journey runner
+    # reports — so without this section a build-cost timeout reads exactly like a
+    # genuine journey failure (that ambiguity is what made run 30323508796's
+    # shard-2 first-class timeout expensive to diagnose).
+    #
+    # This section is deliberately emitted BEFORE the STEP_TIMEOUT / Failed-BOTH
+    # sections: the workflow classifier's `awk` arms on those headers and then
+    # prints every following `- ` line, so a section placed after them would be
+    # mis-read as a failing class. Its wording also contains none of the
+    # classifier's trigger strings, so it can never flip a verdict — it is
+    # attribution only.
+    if [[ "${#BUILD_PHASE_TIMEOUT_ATTEMPTS[@]}" -gt 0 ]]; then
+      echo
+      echo "Attempts cut short while Gradle was still BUILDING (\`JOURNEY_BUILD_PHASE_TIMEOUT\` — issue #1814):"
+      echo "These attempts hit their per-class wall cap before instrumentation ever started, so they"
+      echo "produced no raw JUnit XML. Read them as build-cost timeouts, NOT as journey verdicts and"
+      echo "NOT as product defects. The cold build is paid up front (see \"Warm build\" above), so a"
+      echo "recurrence here means the build itself outgrew its bound — investigate the build, not the"
+      echo "listed journey."
+      for c in "${BUILD_PHASE_TIMEOUT_ATTEMPTS[@]}"; do
         echo "- \`$c\`"
       done
     fi

--- a/scripts/ci-journey-warm-build-functions.sh
+++ b/scripts/ci-journey-warm-build-functions.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Warm-build helper for scripts/ci-journey-suite.sh — issue #1814.
+#
+# THE DEFECT THIS REMOVES
+# -----------------------
+# Every journey class attempt is hard-capped at JOURNEY_CLASS_TIMEOUT_SECS by
+# `run_bounded`. That cap is meant to bound ONE class's on-device work. But the
+# very first `:app:connectedDebugAndroidTest` invocation on a freshly-booted
+# shard also has to do the whole COLD Gradle build (`:app:compileDebugKotlin`,
+# dexing, packaging, `:app:createDebugApkListingFileRedirect`, …) before a
+# single assertion runs — so the FIRST class on a shard was measured against a
+# budget that included work no later class pays.
+#
+# Observed on run 30323508796, shard 2: `MultiSessionSwitchJourneyE2eTest` was
+# first on the shard and its attempt-1 verdict was `exit 124 / outer_timeout /
+# raw-junit count=0`, with the log ending at
+# `:app:createDebugApkListingFileRedirect` — still BUILDING. It was the only one
+# of that shard's 47 classes whose attempt 1 ran a cold `:app:compileDebugKotlin`
+# and it passes locally. The class was fine; the accounting was not.
+#
+# Two reasons that mattered more than one odd-looking class:
+#   * a first-class timeout looks EXACTLY like a genuine journey failure
+#     (`raw-junit count=0` is also what a killed runner produces), so it burns
+#     investigation time and pollutes attribution;
+#   * round-robin reshuffles shard membership whenever the class list changes,
+#     so WHICH class absorbs the cold build rotates — which is one mechanical
+#     contributor to the (now-disproven) "shard 0 is pathological" theory.
+#
+# THE FIX AND WHY THIS SHAPE
+# --------------------------
+# The per-class budget exists to bound ONE class's work, so the honest fix is to
+# stop putting shared, once-per-shard work inside it: assemble the APKs ONCE,
+# up front, and let the class loop measure every class — first and last — on
+# equal terms. Deliberately NOT chosen:
+#   * raising JOURNEY_CLASS_TIMEOUT_SECS — that makes the symptom rarer without
+#     making the measurement correct, and slackens the bound for all ~47 classes
+#     to fix an artefact affecting one (G6);
+#   * granting the first class a special larger allowance — that encodes the
+#     problem instead of removing it, and leaves the first class still measured
+#     differently from its siblings.
+#
+# BUDGET ACCOUNTING (why the warm build is INSIDE the suite budget)
+# ----------------------------------------------------------------
+# The cold build is real work the shard must do either way; today it is already
+# spent inside the #835 suite budget (during class 1). Warming it AFTER
+# SUITE_START keeps that total unchanged, so the documented job-cap arithmetic
+# (5700s cap - 900s worst-case boot - 4200s suite budget = 600s slack) is
+# untouched. Only the PER-CLASS clock changes: it no longer starts before the
+# build. The warm build is itself bounded (JOURNEY_WARM_BUILD_TIMEOUT_SECS,
+# clamped to the remaining suite budget) and streams through `run_bounded`, so
+# the #1056 silence watchdog covers it exactly like a class attempt.
+#
+# FAIL-SAFE: a failed or timed-out warm build is NON-fatal. It is a
+# pre-payment, not a gate: on failure the class loop simply builds as it did
+# before, and a genuinely broken build still surfaces as failing classes. Making
+# it fatal would add a brand-new way for the gate to go red, which is the
+# opposite of this issue's intent.
+
+# warm_journey_build — assemble the APKs the class loop needs, before the
+# per-class budget clock starts. Always returns 0 (see FAIL-SAFE above).
+# shellcheck disable=SC2034  # JOURNEY_WARM_BUILD_STATUS / _ELAPSED are read by
+# scripts/ci-journey-summary-functions.sh (a separately sourced helper).
+warm_journey_build() {
+  local cap remaining rc start elapsed
+  local app_id_suffix="${POCKETSHELL_APP_ID_SUFFIX:-}"
+  local -a app_id_args=()
+
+  JOURNEY_WARM_BUILD_STATUS="skipped"
+  JOURNEY_WARM_BUILD_ELAPSED=0
+
+  if [[ -n "$app_id_suffix" ]]; then
+    if [[ ! "$app_id_suffix" =~ ^[A-Za-z0-9._]+$ ]]; then
+      echo "JOURNEY_WARM_BUILD_SKIPPED: invalid application id suffix '$app_id_suffix' — leaving the build to the class loop (issue #1814)" >&2
+      return 0
+    fi
+    # Bind the SAME applicationId the class loop will use, or the warm outputs
+    # would belong to a different variant and every class would rebuild anyway.
+    app_id_args+=("-PpocketshellAppIdSuffix=$app_id_suffix")
+  fi
+
+  remaining="$(budget_remaining)"
+  cap="$JOURNEY_WARM_BUILD_TIMEOUT_SECS"
+  (( remaining < cap )) && cap="$remaining"
+  if (( cap <= 0 )); then
+    echo "JOURNEY_WARM_BUILD_SKIPPED: no suite budget remains for the warm build (issue #1814)"
+    return 0
+  fi
+
+  echo "=========================================================="
+  echo ">>> WARM BUILD (issue #1814): assembling the debug + androidTest APKs"
+  echo "    BEFORE the per-class budget clock starts, so the FIRST class on this"
+  echo "    shard is measured on the same terms as every later class."
+  echo "    (cap ${cap}s; charged to the suite budget, NOT to any class)"
+  echo "=========================================================="
+  start=$SECONDS
+  # Daemon reuse is preserved (no --no-daemon) and --max-workers=2 matches the
+  # class-loop invocations, so this is the very same build the first class used
+  # to trigger — just paid outside anyone's per-class cap.
+  run_bounded "$cap" \
+    "$GRADLEW" \
+    :app:assembleDebug \
+    :app:assembleDebugAndroidTest \
+    :shared:core-terminal:assembleDebugAndroidTest \
+    "${app_id_args[@]}" \
+    --max-workers=2 \
+    --stacktrace
+  rc=$?
+  elapsed=$((SECONDS - start))
+  JOURNEY_WARM_BUILD_ELAPSED="$elapsed"
+
+  if [[ $rc -eq 0 ]]; then
+    JOURNEY_WARM_BUILD_STATUS="ok"
+    echo "JOURNEY_WARM_BUILD: cold build paid up front in ${elapsed}s (rc=0) — every class on this shard now starts from a warm build (issue #1814)"
+    return 0
+  fi
+
+  JOURNEY_WARM_BUILD_STATUS="failed"
+  echo "JOURNEY_WARM_BUILD_FAILED: warm build exited ${rc} after ${elapsed}s. This is NOT fatal — the class loop will build as before; a genuinely broken build still surfaces as failing classes (issue #1814)." >&2
+  if needs_gradle_cleanup_after_class_abort "$rc"; then
+    # Same #918 discipline as an aborted class: a killed Gradle invocation can
+    # leave a poisoned file-hash lock that would break every following class.
+    cleanup_gradle_after_timeout "warm-build"
+  fi
+  return 0
+}

--- a/scripts/ci-journey-write-shard-verdict.sh
+++ b/scripts/ci-journey-write-shard-verdict.sh
@@ -47,26 +47,47 @@
 # ordering. The reports upload still packages this directory, so the token stays
 # in the forensic bundle.
 #
+# Issue #1814 (verdict REASON): the token now also carries WHY it has the value
+# it has. The concrete miss: an `exit 124 / outer_timeout / raw-junit count=0`
+# attempt is what a killed mid-journey runner produces AND what a class cut
+# short while Gradle was still BUILDING produces, so a shard RED caused by the
+# cold build read exactly like a product defect (run 30323508796, shard 2). The
+# reason is a short machine token (`cold_build_timeout`,
+# `journey_failure_both_attempts`, `emulator_never_booted`, …) that the
+# aggregation job prints per shard.
+#
+# The reason NEVER changes the verdict: line 1 stays the bare CLEAN|INFRA|RED
+# token and every consumer's severity is unchanged. Labelling a failure is not
+# the same as softening it — softening a build-cost timeout to a re-run signal
+# would be exactly the masking D31/D32 forbid.
+#
 # Usage:
-#   ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED>
+#   ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED> [REASON]
 # Env:
 #   SHARD_VERDICT_FILE                     output path (default
 #                                          artifacts/ci-journey-shard-verdict/shard-verdict.txt)
+#   SHARD_VERDICT_REASON                   fallback for the REASON argument
 #   POCKETSHELL_JOURNEY_CI_SHARD_INDEX     shard index (set by the matrix)
 #   GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT     provenance (set by Actions)
 #   GITHUB_OUTPUT                          when set, also exports
-#                                          `shard_verdict=<token>` so a later
-#                                          step can gate on it
+#                                          `shard_verdict=<token>` (so a later
+#                                          step can gate on it) and
+#                                          `shard_verdict_reason=<reason>`
 set -uo pipefail
 
 verdict="${1:-}"
 case "$verdict" in
   CLEAN | INFRA | RED) ;;
   *)
-    echo "usage: ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED>" >&2
+    echo "usage: ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED> [REASON]" >&2
     exit 2
     ;;
 esac
+
+# The reason is advisory metadata, so it fails SOFT to `unspecified` rather than
+# rejecting the write: a typo'd label must never cost the run its verdict token.
+reason="${2:-${SHARD_VERDICT_REASON:-unspecified}}"
+[[ "$reason" =~ ^[a-z][a-z0-9_]{0,63}$ ]] || reason="unspecified"
 
 out="${SHARD_VERDICT_FILE:-artifacts/ci-journey-shard-verdict/shard-verdict.txt}"
 if ! mkdir -p "$(dirname "$out")"; then
@@ -83,14 +104,16 @@ if ! {
   printf 'shard=%s\n' "$shard"
   printf 'run_id=%s\n' "$run_id"
   printf 'run_attempt=%s\n' "$run_attempt"
+  printf 'verdict_reason=%s\n' "$reason"
   printf 'written_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 } > "$out"; then
   echo "ci-journey-write-shard-verdict.sh: cannot write $out" >&2
   exit 1
 fi
 
-echo "SHARD_VERDICT=$verdict (shard $shard, run $run_id attempt $run_attempt)"
+echo "SHARD_VERDICT=$verdict (shard $shard, run $run_id attempt $run_attempt, reason $reason)"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   printf 'shard_verdict=%s\n' "$verdict" >> "$GITHUB_OUTPUT"
+  printf 'shard_verdict_reason=%s\n' "$reason" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/test-ci-journey-warm-build.sh
+++ b/scripts/test-ci-journey-warm-build.sh
@@ -1,0 +1,784 @@
+#!/usr/bin/env bash
+# Issue #1814: deterministic, JVM-free, emulator-free proof for
+#   (1) the first class on a shard is no longer charged for the cold
+#       `:app:compileDebugKotlin` inside its own per-class budget, and
+#   (2) a build-phase `outer_timeout` is distinguishable from a genuine journey
+#       failure in the shard verdict and the suite summary.
+#
+# THE REPRODUCTION (why this test is shaped this way)
+# --------------------------------------------------
+# Run 30323508796, shard 2: `MultiSessionSwitchJourneyE2eTest` was FIRST on the
+# shard and its attempt-1 verdict was `exit 124 / outer_timeout / raw-junit
+# count=0`, with the log ending at `:app:createDebugApkListingFileRedirect` —
+# still building. It was the only one of that shard's 47 classes whose attempt 1
+# ran a cold `:app:compileDebugKotlin`, and it passes locally. So the fixture
+# below models exactly that: a gradle stub where the FIRST invocation that has
+# to produce the APKs pays a cold-build cost and every later invocation is
+# up-to-date. Against a mutant of the real suite with the warm-build call
+# removed, the first class visibly absorbs that cost (RED); against the real
+# suite it does not (GREEN). Both numbers are MEASURED from the suite's own
+# `JOURNEY_PASS: … (elapsed Ns)` lines and printed, so the comparison is an
+# observation rather than an argument.
+#
+# Everything here drives the REAL scripts — the real ci-journey-suite.sh and its
+# real helpers, the real verdict writer, the real aggregate reducer, the real
+# build-phase scanner — with stubbed gradle/adb. No logic is re-implemented.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
+REAL_SUITE="$SCRIPT_DIR/ci-journey-suite.sh"
+CLASS_LOOP="$SCRIPT_DIR/ci-journey-class-loop-functions.sh"
+WARM_HELPER="$SCRIPT_DIR/ci-journey-warm-build-functions.sh"
+BUILD_PHASE="$SCRIPT_DIR/ci-journey-build-phase-timeout.sh"
+WRITER="$SCRIPT_DIR/ci-journey-write-shard-verdict.sh"
+AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+for required in "$REAL_SUITE" "$CLASS_LOOP" "$WARM_HELPER" "$BUILD_PHASE" \
+  "$WRITER" "$AGG" "$WORKFLOW"; do
+  [[ -f "$required" ]] || fail "missing required file: $required"
+done
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+COLD_SECS=6
+SHARD_TOTAL=3
+
+HELPERS=(
+  ci-journey-suite.sh
+  ci-journey-class-selection-functions.sh
+  ci-journey-budget-functions.sh
+  ci-journey-warm-build-functions.sh
+  ci-journey-class-loop-functions.sh
+  ci-journey-core-terminal-functions.sh
+  ci-journey-summary-functions.sh
+)
+
+# ---------------------------------------------------------------------------
+# Sandbox "repo root": the REAL suite + helpers, a gradle stub that models a
+# cold build, and stub adb/connected-test. The suite derives REPO_ROOT from
+# BASH_SOURCE, so running the copy makes the sandbox the repo.
+# ---------------------------------------------------------------------------
+STUBBIN="$SANDBOX/stubbin"
+mkdir -p "$STUBBIN"
+cat > "$STUBBIN/adb" <<'STUB'
+#!/usr/bin/env bash
+set -u
+emit_valid_png() {
+  printf '\211\120\116\107\015\012\032\012\000\000\000\015\111\110\104\122\000\000\000\001\000\000\000\001\010\006\000\000\000\037\025\304\211\000\000\000\015\111\104\101\124\170\234\143\140\140\140\370\017\000\001\004\001\000\137\345\303\113\000\000\000\000\111\105\116\104\256\102\140\202'
+}
+if [[ "${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\nemulator-5554\tdevice\n'
+  exit 0
+fi
+if [[ "${1:-}" == "-s" ]]; then shift 2; fi
+case "${1:-}" in
+  logcat)  [[ "${2:-}" == "-c" ]] || printf 'stub-logcat\n' ;;
+  exec-out) emit_valid_png ;;
+  shell)
+    case "${2:-}" in
+      ps) printf 'PID NAME\n' ;;
+      dumpsys) printf 'stub dumpsys\n' ;;
+    esac
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$STUBBIN/adb"
+
+# make_repo <dir> — a sandbox repo root with the real suite + helpers.
+make_repo() {
+  local root="$1"
+  rm -rf "$root"
+  mkdir -p "$root/scripts"
+  local helper
+  for helper in "${HELPERS[@]}"; do
+    cp "$SCRIPT_DIR/$helper" "$root/scripts/$helper"
+  done
+  chmod +x "$root/scripts/ci-journey-suite.sh"
+
+  # Gradle stub: models the COLD BUILD. The first invocation that has to produce
+  # the APKs pays WARM_STUB_COLD_SECS; every later invocation is up-to-date —
+  # exactly the asymmetry that charged the first class for the cold build.
+  cat > "$root/gradlew" <<'STUB'
+#!/usr/bin/env bash
+set -u
+state="${WARM_STUB_DIR:?}"
+mkdir -p "$state"
+printf '%s\n' "$*" >> "$state/args.log"
+if [[ "${1:-}" == "--stop" ]]; then
+  printf 'stop\n' >> "$state/stop.log"
+  exit 0
+fi
+
+module_build_root() {
+  if [[ "$*" == *":shared:core-terminal:"* ]]; then
+    printf '%s\n' "$PWD/shared/core-terminal/build"
+  else
+    printf '%s\n' "$PWD/app/build"
+  fi
+}
+write_result_xml() {
+  local outcome="$1" root
+  root="$(module_build_root "$@")/outputs/androidTest-results/connected/debug"
+  mkdir -p "$root"
+  if [[ "$outcome" == failure ]]; then
+    printf '<testsuite tests="1" failures="1"><testcase name="t"><failure message="boom"/></testcase></testsuite>\n' \
+      > "$root/TEST-stub.xml"
+  else
+    printf '<testsuite tests="1" failures="0"><testcase name="t"/></testsuite>\n' \
+      > "$root/TEST-stub.xml"
+  fi
+}
+
+cold="${WARM_STUB_COLD_SECS:-0}"
+echo "> Task :app:preBuild"
+if [[ ! -e "$state/built" ]]; then
+  echo "> Task :app:compileDebugKotlin"
+  if [[ "$cold" -gt 0 ]]; then sleep "$cold"; fi
+  : > "$state/built"
+else
+  echo "> Task :app:compileDebugKotlin UP-TO-DATE"
+fi
+echo "> Task :app:createDebugApkListingFileRedirect"
+
+wedge="${WARM_STUB_WEDGE_CLASS:-}"
+mode="${WARM_STUB_WEDGE_MODE:-none}"
+if [[ -n "$wedge" && "$*" == *"$wedge"* && "$*" == *connectedDebugAndroidTest* ]]; then
+  case "$mode" in
+    build)
+      # Still BUILDING when the cap fires: NO instrumentation marker is ever
+      # emitted. This is the run-30323508796 shape.
+      echo "> Task :app:mergeDebugAssets"
+      exec sleep 120
+      ;;
+    instrumentation)
+      # Instrumentation DID start and then wedged — the same exit 124 /
+      # count=0 verdict, a genuinely different cause.
+      echo "> Task :app:connectedDebugAndroidTest"
+      echo "Starting 1 tests on emulator-5554"
+      exec sleep 120
+      ;;
+    failure)
+      echo "> Task :app:connectedDebugAndroidTest"
+      echo "Starting 1 tests on emulator-5554"
+      write_result_xml failure "$@"
+      echo "Finished 1 tests on emulator-5554"
+      exit 1
+      ;;
+  esac
+fi
+
+case "$*" in
+  *connectedDebugAndroidTest*)
+    echo "> Task :app:connectedDebugAndroidTest"
+    echo "Starting 1 tests on emulator-5554"
+    write_result_xml pass "$@"
+    echo "Finished 1 tests on emulator-5554"
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "$root/gradlew"
+
+  cat > "$root/scripts/connected-test.sh" <<'STUB'
+#!/usr/bin/env bash
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$root_dir/gradlew" :app:connectedDebugAndroidTest "$@"
+STUB
+  chmod +x "$root/scripts/connected-test.sh"
+}
+
+FIXED_REPO="$SANDBOX/fixed"
+MUTANT_REPO="$SANDBOX/mutant"
+make_repo "$FIXED_REPO"
+make_repo "$MUTANT_REPO"
+
+# THE MUTANT: the real suite with ONLY the warm-build call removed. Everything
+# else — budgets, caps, retry, artifacts — is byte-identical, so any measured
+# difference is attributable to that one line and nothing else.
+sed -i '/^  warm_journey_build$/d' "$MUTANT_REPO/scripts/ci-journey-class-loop-functions.sh"
+grep -q '^  warm_journey_build$' "$FIXED_REPO/scripts/ci-journey-class-loop-functions.sh" \
+  || fail "(setup) the real class loop no longer calls warm_journey_build — the fixture would prove nothing"
+if grep -q '^  warm_journey_build$' "$MUTANT_REPO/scripts/ci-journey-class-loop-functions.sh"; then
+  fail "(setup) the mutant still calls warm_journey_build — the red control is not live"
+fi
+pass "(setup) mutant differs from the real suite by exactly the warm-build call"
+
+# run_suite <repo> <shard> <log> <state-dir> [env assignments...]
+RUN_RC=0
+run_suite() {
+  local repo="$1" shard="$2" log="$3" state="$4"; shift 4
+  rm -rf "$state"
+  mkdir -p "$state"
+  # NOTE: deliberately no `set -e`/`set +e` dance here. This harness runs with
+  # errexit OFF and asserts explicitly with `|| fail`; a stray `set -e` made a
+  # later `var="$(script-that-exits-1)"` abort the run with no message at all.
+  env PATH="$STUBBIN:$PATH" \
+    WARM_STUB_DIR="$state" \
+    JOURNEY_STEP_BUDGET_SECS=900 \
+    JOURNEY_CLASS_TIMEOUT_SECS=30 \
+    JOURNEY_NO_OUTPUT_TIMEOUT_SECS=25 \
+    JOURNEY_CLASS_KILL_AFTER_SECS=1 \
+    JOURNEY_GRADLE_STOP_TIMEOUT_SECS=5 \
+    POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$SHARD_TOTAL" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$shard" \
+    "$@" \
+    bash "$repo/scripts/ci-journey-suite.sh" > "$log" 2>&1
+  RUN_RC=$?
+}
+
+# passed_elapsed <log> — "class elapsed" pairs, in launch order.
+passed_elapsed() {
+  sed -n 's/^JOURNEY_PASS: \([^ ]*\) passed on attempt 1 (elapsed \([0-9]*\)s)$/\1 \2/p' "$1"
+}
+
+echo "== #1814 AC1/AC4: the first class on a shard is not charged for the cold build =="
+echo "   (gradle stub: the first APK-producing invocation costs ${COLD_SECS}s, later ones are up-to-date)"
+
+for shard in 0 1 2; do
+  fixed_log="$SANDBOX/fixed-shard-$shard.log"
+  mutant_log="$SANDBOX/mutant-shard-$shard.log"
+  run_suite "$FIXED_REPO" "$shard" "$fixed_log" "$SANDBOX/state-fixed-$shard" \
+    WARM_STUB_COLD_SECS="$COLD_SECS"
+  fixed_rc="$RUN_RC"
+  run_suite "$MUTANT_REPO" "$shard" "$mutant_log" "$SANDBOX/state-mutant-$shard" \
+    WARM_STUB_COLD_SECS="$COLD_SECS"
+  mutant_rc="$RUN_RC"
+
+  [[ "$fixed_rc" -eq 0 ]] \
+    || { sed -n '1,40p' "$fixed_log"; fail "(ac1/shard $shard) the healthy fixed run exited $fixed_rc"; }
+  [[ "$mutant_rc" -eq 0 ]] \
+    || { sed -n '1,40p' "$mutant_log"; fail "(ac1/shard $shard) the mutant run exited $mutant_rc (it must differ only in TIMING)"; }
+
+  mapfile -t fixed_pairs < <(passed_elapsed "$fixed_log")
+  mapfile -t mutant_pairs < <(passed_elapsed "$mutant_log")
+  # G3: a vacuous run proves nothing — require a real, comparable class count.
+  [[ "${#fixed_pairs[@]}" -ge 10 ]] \
+    || fail "(ac1/shard $shard) only ${#fixed_pairs[@]} classes reached a verdict — nothing to compare"
+  [[ "${#fixed_pairs[@]}" -eq "${#mutant_pairs[@]}" ]] \
+    || fail "(ac1/shard $shard) fixed ran ${#fixed_pairs[@]} classes, mutant ran ${#mutant_pairs[@]} — not a like-for-like comparison"
+
+  mid_index=$(( ${#fixed_pairs[@]} / 2 ))
+  fixed_first_class="${fixed_pairs[0]%% *}";   fixed_first="${fixed_pairs[0]##* }"
+  fixed_mid_class="${fixed_pairs[$mid_index]%% *}"; fixed_mid="${fixed_pairs[$mid_index]##* }"
+  mutant_first="${mutant_pairs[0]##* }"
+  mutant_mid="${mutant_pairs[$mid_index]##* }"
+
+  echo "    shard $shard first class: $fixed_first_class"
+  echo "      REAL   : first=${fixed_first}s  mid(#$mid_index $fixed_mid_class)=${fixed_mid}s"
+  echo "      MUTANT : first=${mutant_first}s mid(#$mid_index)=${mutant_mid}s   (warm-build call removed)"
+
+  # RED (mutant): the first class absorbs the whole cold build; a mid-shard class
+  # does not. This is the reported defect, observed.
+  (( mutant_first >= COLD_SECS )) \
+    || fail "(ac1/shard $shard) RED control did not reproduce: mutant first-class elapsed ${mutant_first}s < cold build ${COLD_SECS}s"
+  (( mutant_first - mutant_mid >= COLD_SECS - 1 )) \
+    || fail "(ac1/shard $shard) RED control did not reproduce: mutant first=${mutant_first}s vs mid=${mutant_mid}s"
+
+  # GREEN (real): the first class is measured on the same terms as a mid-shard
+  # class, and cannot have paid the cold build.
+  (( fixed_first < COLD_SECS )) \
+    || fail "(ac1/shard $shard) the first class still paid the cold build (${fixed_first}s >= ${COLD_SECS}s)"
+  (( fixed_first - fixed_mid <= 1 )) \
+    || fail "(ac1/shard $shard) first class (${fixed_first}s) is still measured differently from mid-shard (${fixed_mid}s)"
+
+  # The cold build did happen — it was paid by the warm step, before the loop.
+  # NOTE: no `| head`/`| grep -m1` anywhere in this file — a reader that closes
+  # the pipe early SIGPIPEs the writer, which under `set -o pipefail` made this
+  # harness die silently mid-run (exit 141) instead of reporting a verdict.
+  warm_elapsed="$(sed -n 's/^JOURNEY_WARM_BUILD: cold build paid up front in \([0-9]*\)s.*/\1/p' "$fixed_log")"
+  warm_elapsed="${warm_elapsed%%$'\n'*}"
+  [[ "$warm_elapsed" =~ ^[0-9]+$ ]] \
+    || { sed -n '1,40p' "$fixed_log"; fail "(ac1/shard $shard) no JOURNEY_WARM_BUILD line — the cold build was not paid up front"; }
+  (( warm_elapsed >= COLD_SECS )) \
+    || fail "(ac1/shard $shard) warm build took ${warm_elapsed}s but the cold build costs ${COLD_SECS}s — it did not do the build"
+  if grep -q 'JOURNEY_WARM_BUILD' "$mutant_log"; then
+    fail "(ac1/shard $shard) the mutant emitted a warm-build line — the control is contaminated"
+  fi
+
+  # ...and it ran BEFORE the first class's per-class clock started.
+  warm_line="$(grep -n 'WARM BUILD (issue #1814)' "$fixed_log" | cut -d: -f1)"
+  warm_line="${warm_line%%$'\n'*}"
+  first_class_line="$(grep -n '>>> JOURNEY CLASS: ' "$fixed_log" | cut -d: -f1)"
+  first_class_line="${first_class_line%%$'\n'*}"
+  [[ -n "$warm_line" && -n "$first_class_line" && "$warm_line" -lt "$first_class_line" ]] \
+    || fail "(ac1/shard $shard) the warm build did not run before the first class (warm=$warm_line first=$first_class_line)"
+
+  # ...and it is charged to the SUITE budget, not moved outside it: the first
+  # class starts with the budget already reduced by the build. This is what
+  # keeps the documented job-cap arithmetic (5700 - 900 - 4200 = 600s) intact.
+  first_remaining="$(sed -n 's/.*>>> JOURNEY CLASS: .*\[budget remaining: \([0-9]*\)s\]$/\1/p' "$fixed_log")"
+  first_remaining="${first_remaining%%$'\n'*}"
+  [[ "$first_remaining" =~ ^[0-9]+$ ]] \
+    || fail "(ac1/shard $shard) could not read the first class's remaining budget"
+  (( first_remaining <= 900 - COLD_SECS )) \
+    || fail "(ac1/shard $shard) the warm build was NOT charged to the suite budget (remaining ${first_remaining}s of 900s after a ${COLD_SECS}s build)"
+
+  grep -q 'Warm build (issue #1814): \*\*ok\*\*' "$FIXED_REPO/artifacts/ci-journey/summary.md" \
+    || { cat "$FIXED_REPO/artifacts/ci-journey/summary.md"; fail "(ac1/shard $shard) the summary does not report the warm build"; }
+
+  pass "(ac1/shard $shard) first=${fixed_first}s vs mid=${fixed_mid}s (was ${mutant_first}s vs ${mutant_mid}s) — cold build paid up front in ${warm_elapsed}s"
+done
+pass "(ac4) verified on all $SHARD_TOTAL shards, each with its own first class"
+
+echo
+echo "== #1814 AC2: no per-class budget was raised =="
+# shellcheck disable=SC2016
+class_cap="$(sed -n 's/^JOURNEY_CLASS_TIMEOUT_SECS="${JOURNEY_CLASS_TIMEOUT_SECS:-\([0-9][0-9]*\)}"$/\1/p' "$REAL_SUITE")"
+# shellcheck disable=SC2016
+suite_budget="$(sed -n 's/^JOURNEY_STEP_BUDGET_SECS="${JOURNEY_STEP_BUDGET_SECS:-\([0-9][0-9]*\)}"$/\1/p' "$REAL_SUITE")"
+# shellcheck disable=SC2016
+warm_cap="$(sed -n 's/^JOURNEY_WARM_BUILD_TIMEOUT_SECS="${JOURNEY_WARM_BUILD_TIMEOUT_SECS:-\([0-9][0-9]*\)}"$/\1/p' "$REAL_SUITE")"
+[[ "$class_cap" -eq 420 ]] \
+  || fail "(ac2) the per-class cap is ${class_cap}s, not the unchanged 420s — the fix must not buy headroom by raising it (G6)"
+[[ "$suite_budget" -eq 4200 ]] \
+  || fail "(ac2) the suite budget is ${suite_budget}s, not the unchanged 4200s — the job-cap arithmetic would change"
+[[ "$warm_cap" =~ ^[0-9]+$ ]] \
+  || fail "(ac2) the warm build has no bounded default cap"
+job_cap_min="$(awk '
+  /^  emulator-journey:/ { in_job=1; next }
+  in_job && /^  [A-Za-z0-9_-]+:/ { in_job=0 }
+  in_job && /timeout-minutes:/ { print $2; exit }
+' "$WORKFLOW")"
+[[ "$job_cap_min" -eq 95 ]] || fail "(ac2) emulator-journey job cap changed to ${job_cap_min} min"
+slack=$(( job_cap_min * 60 - 900 - suite_budget ))
+[[ "$slack" -ge 600 ]] \
+  || fail "(ac2) post-boot slack dropped to ${slack}s (< 600s)"
+# The warm build must be charged INSIDE the suite budget (after SUITE_START), or
+# it would silently eat that slack.
+awk '
+  /SUITE_START=\$SECONDS/ { seen_start=1 }
+  /^  warm_journey_build$/ { if (seen_start) found=1; else early=1 }
+  END { exit((found && !early) ? 0 : 1) }
+' "$CLASS_LOOP" \
+  || fail "(ac2) warm_journey_build must be called AFTER SUITE_START so its cost stays inside the suite budget"
+pass "(ac2) per-class cap still ${class_cap}s, suite budget still ${suite_budget}s, slack ${slack}s; warm build bounded at ${warm_cap}s inside the suite budget"
+
+echo
+echo "== #1814 AC3: a build-phase outer timeout is distinguishable from a journey failure =="
+
+# The first class of shard 0, read from the real allowlist so a reordering of
+# JOURNEY_CLASSES cannot silently make this fixture test a different class.
+first_entry="$(awk '
+  /^JOURNEY_CLASSES=\(/ { f=1; next }
+  /^\)/ { f=0 }
+  f && /^[[:space:]]*"/ { print; exit }
+' "$REAL_SUITE" | sed 's/^[[:space:]]*"\([^"]*\)".*/\1/')"
+WEDGE_CLASS="${first_entry##*.}"
+[[ -n "$WEDGE_CLASS" ]] || fail "(ac3) could not resolve the first journey class from the allowlist"
+echo "    wedging the first class of shard 0: $WEDGE_CLASS"
+
+# wedge_run <mode> <log> — one shard-0 run whose first class behaves per <mode>.
+# The cold cost is 0 here: this fixture is about ATTRIBUTION, not accounting.
+wedge_run() {
+  local mode="$1" log="$2"
+  run_suite "$FIXED_REPO" 0 "$log" "$SANDBOX/state-wedge-$mode" \
+    WARM_STUB_COLD_SECS=0 \
+    WARM_STUB_WEDGE_CLASS="$WEDGE_CLASS" \
+    WARM_STUB_WEDGE_MODE="$mode" \
+    JOURNEY_CLASS_TIMEOUT_SECS=4 \
+    JOURNEY_NO_OUTPUT_TIMEOUT_SECS=2
+}
+
+manifest_phases() {
+  # every recorded phase for the wedged class, across attempts
+  find "$FIXED_REPO/artifacts/ci-journey/class-attempts" -type f -name manifest.txt \
+    -exec grep -l "^class=.*$WEDGE_CLASS$" {} + 2>/dev/null \
+    | tr '\n' '\0' \
+    | xargs -r -0 sed -n 's/^outer_timeout_phase=//p' | sort -u | tr '\n' ' '
+}
+
+# (b1) THE REPORTED SHAPE: cut while Gradle was still building.
+wedge_run build "$SANDBOX/wedge-build.log"
+build_log="$SANDBOX/wedge-build.log"
+summary="$FIXED_REPO/artifacts/ci-journey/summary.md"
+grep -q "JOURNEY_BUILD_PHASE_TIMEOUT: .*$WEDGE_CLASS attempt 1" "$build_log" \
+  || { sed -n '1,60p' "$build_log"; fail "(b1) a still-building outer timeout was not named at the moment it happened"; }
+phases="$(manifest_phases)"
+[[ "$phases" == "build " ]] \
+  || fail "(b1) manifests recorded phases '$phases', expected only 'build'"
+grep -q 'Attempts cut short while Gradle was still BUILDING' "$summary" \
+  || { cat "$summary"; fail "(b1) the summary has no build-phase section"; }
+grep -q "^- \`.*$WEDGE_CLASS (attempt 1)\`$" "$summary" \
+  || { cat "$summary"; fail "(b1) the summary's build-phase section does not name the class/attempt"; }
+# It is NOT reported as a genuine twice-failed journey regression.
+if grep -q 'Failed BOTH attempts' "$summary"; then
+  cat "$summary"
+  fail "(b1) a build-phase timeout was reported as a genuine failed-both journey regression"
+fi
+# The scanner the workflow classifier calls sees the same evidence.
+scan_out="$(bash "$BUILD_PHASE" "$FIXED_REPO/artifacts")"
+scan_attempts="$(sed -n 's/^build_phase_timeout_attempts=//p' <<<"$scan_out")"
+scan_classes="$(sed -n 's/^build_phase_timeout_classes=//p' <<<"$scan_out")"
+[[ "$scan_attempts" -ge 1 ]] \
+  || { printf '%s\n' "$scan_out"; fail "(b1) the build-phase scanner found no evidence"; }
+[[ "$scan_classes" == *"$WEDGE_CLASS"* ]] \
+  || { printf '%s\n' "$scan_out"; fail "(b1) the scanner did not name the class"; }
+pass "(b1) still-building timeout -> loud marker + manifest phase + its own summary section + scanner evidence ($scan_attempts attempt(s))"
+
+# (b2) CLASS COVERAGE: the SAME exit 124 / count=0 verdict, but instrumentation
+#      HAD started. It must NOT be attributed to the build.
+wedge_run instrumentation "$SANDBOX/wedge-instr.log"
+instr_log="$SANDBOX/wedge-instr.log"
+if grep -q 'JOURNEY_BUILD_PHASE_TIMEOUT' "$instr_log"; then
+  sed -n '1,60p' "$instr_log"
+  fail "(b2) an instrumentation-phase wedge was mislabelled as a build-phase timeout"
+fi
+phases="$(manifest_phases)"
+[[ "$phases" == "instrumentation " ]] \
+  || fail "(b2) manifests recorded phases '$phases', expected only 'instrumentation'"
+scan_out="$(bash "$BUILD_PHASE" "$FIXED_REPO/artifacts")"
+grep -qx 'build_phase_timeout_attempts=0' <<<"$scan_out" \
+  || { printf '%s\n' "$scan_out"; fail "(b2) the scanner claimed build-phase evidence for an instrumentation wedge"; }
+if grep -q 'Attempts cut short while Gradle was still BUILDING' "$FIXED_REPO/artifacts/ci-journey/summary.md"; then
+  fail "(b2) the summary emitted a build-phase section for an instrumentation wedge"
+fi
+pass "(b2) an instrumentation-phase wedge with the same exit 124 / count=0 verdict is NOT attributed to the build"
+
+# (b3) THE LOAD-BEARING CONTROL (G6): a genuine journey failure must stay a
+#      genuine journey failure — the attribution must never swallow one.
+wedge_run failure "$SANDBOX/wedge-failure.log"
+failure_log="$SANDBOX/wedge-failure.log"
+summary="$FIXED_REPO/artifacts/ci-journey/summary.md"
+grep -q "JOURNEY_FAILED: .*$WEDGE_CLASS failed twice" "$failure_log" \
+  || { sed -n '1,60p' "$failure_log"; fail "(b3) the genuine failure control did not fail twice"; }
+grep -q 'Failed BOTH attempts' "$summary" \
+  || { cat "$summary"; fail "(b3) a genuine journey failure lost its Failed BOTH attempts section"; }
+if grep -q 'JOURNEY_BUILD_PHASE_TIMEOUT' "$failure_log"; then
+  fail "(b3) a genuine journey failure was labelled a build-phase timeout"
+fi
+phases="$(manifest_phases)"
+[[ "$phases" == "not_applicable " ]] \
+  || fail "(b3) manifests recorded phases '$phases', expected only 'not_applicable'"
+scan_out="$(bash "$BUILD_PHASE" "$FIXED_REPO/artifacts")"
+grep -qx 'build_phase_timeout_attempts=0' <<<"$scan_out" \
+  || { printf '%s\n' "$scan_out"; fail "(b3) the scanner claimed build-phase evidence for a genuine failure"; }
+pass "(b3) a genuine journey failure keeps its Failed BOTH attempts verdict and is never labelled build-phase"
+
+echo
+echo "== #1814 AC3: the shard verdict token and the aggregate carry the reason =="
+
+write_token() {
+  local dir="$1" idx="$2" token="$3" reason="$4"
+  local sub="$dir/emulator-journey-verdict-shard-$idx"
+  mkdir -p "$sub"
+  SHARD_VERDICT_FILE="$sub/shard-verdict.txt" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+    GITHUB_RUN_ID=30323508796 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="" \
+    bash "$WRITER" "$token" "$reason" > /dev/null \
+    || fail "writer refused $token/$reason for shard $idx"
+}
+run_agg() {
+  AGG_OUT="$(EXPECTED_SHARDS=3 GITHUB_STEP_SUMMARY="" GITHUB_RUN_ATTEMPT=1 \
+    bash "$AGG" "$1" 2>&1)"
+  AGG_RC=$?
+  AGG_VERDICT="$(sed -n 's/^AGGREGATE_VERDICT=//p' <<<"$AGG_OUT" | tail -n 1)"
+}
+
+# (c1) a RED caused by the cold build is NAMED as such...
+d="$SANDBOX/verdicts-cold"; rm -rf "$d"; mkdir -p "$d"
+write_token "$d" 2 RED cold_build_timeout
+write_token "$d" 0 CLEAN passed_first_attempt
+write_token "$d" 1 CLEAN passed_first_attempt
+grep -qx 'verdict_reason=cold_build_timeout' "$d/emulator-journey-verdict-shard-2/shard-verdict.txt" \
+  || fail "(c1) the token does not stamp the verdict reason"
+[[ "$(head -n1 "$d/emulator-journey-verdict-shard-2/shard-verdict.txt")" == "RED" ]] \
+  || fail "(c1) line 1 must stay the bare verdict token"
+run_agg "$d"
+printf '%s\n' "$AGG_OUT" | sed 's/^/    /'
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || fail "(c1) naming the cause must NOT soften the verdict; got $AGG_VERDICT/exit$AGG_RC"
+grep -q 'includes a cold-BUILD-phase timeout' <<<"$AGG_OUT" \
+  || fail "(c1) the aggregate does not distinguish the cold-build cause"
+grep -q 'shard 2: RED .*reason cold_build_timeout' <<<"$AGG_OUT" \
+  || fail "(c1) the aggregate does not report the per-shard reason"
+pass "(c1) a cold-build RED is named in the aggregate AND still exits 1 (severity unchanged)"
+
+# (c2) ...and an ordinary journey RED is NOT, so the label means something.
+d="$SANDBOX/verdicts-journey"; rm -rf "$d"; mkdir -p "$d"
+write_token "$d" 2 RED journey_failure_both_attempts
+write_token "$d" 0 CLEAN passed_first_attempt
+write_token "$d" 1 CLEAN passed_first_attempt
+run_agg "$d"
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || fail "(c2) a genuine journey RED must stay RED/exit1, got $AGG_VERDICT/exit$AGG_RC"
+if grep -q 'includes a cold-BUILD-phase timeout' <<<"$AGG_OUT"; then
+  printf '%s\n' "$AGG_OUT"
+  fail "(c2) the cold-build notice fired for a genuine journey failure — the label would be meaningless"
+fi
+grep -q 'shard 2: RED .*reason journey_failure_both_attempts' <<<"$AGG_OUT" \
+  || fail "(c2) the aggregate does not report the genuine-failure reason"
+pass "(c2) a genuine journey RED is reported as such, with no cold-build notice"
+
+# (c3) #1800 / #1809 properties are untouched by the added reason line: an
+#      unstamped legacy token, an all-INFRA run and an all-CLEAN run must behave
+#      exactly as before.
+d="$SANDBOX/verdicts-legacy"; rm -rf "$d"; mkdir -p "$d"
+for idx in 0 1 2; do
+  mkdir -p "$d/emulator-journey-verdict-shard-$idx"
+  printf 'INFRA\n' > "$d/emulator-journey-verdict-shard-$idx/shard-verdict.txt"
+done
+run_agg "$d"
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || fail "(c3) all-INFRA (unstamped legacy tokens) must stay RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"
+grep -q '::error' <<<"$AGG_OUT" \
+  && fail "(c3) an all-INFRA run must not emit ::error (#1458 no-false-red)"
+grep -q 'reason unspecified' <<<"$AGG_OUT" \
+  || fail "(c3) a token without a reason must read as 'unspecified', never as corrupt"
+d="$SANDBOX/verdicts-clean"; rm -rf "$d"; mkdir -p "$d"
+for idx in 0 1 2; do write_token "$d" "$idx" CLEAN passed_first_attempt; done
+run_agg "$d"
+[[ "$AGG_VERDICT" == "CLEAN" && "$AGG_RC" -eq 0 ]] \
+  || fail "(c3) an all-CLEAN run must stay CLEAN/exit0, got $AGG_VERDICT/exit$AGG_RC"
+pass "(c3) unstamped legacy tokens, all-INFRA RE-RUN and all-CLEAN behaviour are unchanged"
+
+# (c4) the reason fails SOFT: a malformed label must never cost the token.
+d="$SANDBOX/verdicts-bad-reason"; rm -rf "$d"; mkdir -p "$d/out"
+SHARD_VERDICT_FILE="$d/out/shard-verdict.txt" POCKETSHELL_JOURNEY_CI_SHARD_INDEX=0 \
+  GITHUB_RUN_ID=1 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="$d/out/gh.txt" \
+  bash "$WRITER" RED 'Not A Reason!' > /dev/null \
+  || fail "(c4) a malformed reason must not fail the write"
+grep -qx 'verdict_reason=unspecified' "$d/out/shard-verdict.txt" \
+  || fail "(c4) a malformed reason must degrade to 'unspecified'"
+grep -qx 'shard_verdict=RED' "$d/out/gh.txt" \
+  || fail "(c4) the RED gate output must survive a malformed reason"
+grep -qx 'shard_verdict_reason=unspecified' "$d/out/gh.txt" \
+  || fail "(c4) the reason must be exported to \$GITHUB_OUTPUT"
+bash "$WRITER" MAYBE cold_build_timeout > /dev/null 2>&1
+writer_rc=$?
+[[ "$writer_rc" -ne 0 ]] || fail "(c4) the writer must still reject a verdict outside CLEAN|INFRA|RED"
+pass "(c4) the reason fails soft to 'unspecified'; an unknown VERDICT is still rejected"
+
+echo
+echo "== #1814 workflow wiring =="
+grep -q 'scripts/ci-journey-build-phase-timeout.sh artifacts' "$WORKFLOW" \
+  || fail "(w1) the classify step does not read the build-phase evidence"
+grep -q 'write_verdict() { bash scripts/ci-journey-write-shard-verdict.sh "\$1" "\${2:-unspecified}"; }' "$WORKFLOW" \
+  || fail "(w2) the classify step does not pass a reason to the one stamped writer"
+grep -q "verdict_reason_for" "$WORKFLOW" \
+  || fail "(w3) the classify step has no cold-build reason resolution"
+# Every verdict branch must now carry a reason: no bare `write_verdict X` may
+# survive, or a branch would silently report 'unspecified'.
+if grep -qE '^\s*write_verdict (CLEAN|INFRA|RED)\s*$' "$WORKFLOW"; then
+  grep -nE '^\s*write_verdict (CLEAN|INFRA|RED)\s*$' "$WORKFLOW"
+  fail "(w4) a classify branch still writes its verdict without a reason"
+fi
+grep -q 'name: CI journey warm-build + build-phase attribution guard (issue #1814)' "$WORKFLOW" \
+  || fail "(w5) this guard is not wired into the Unit job — an unrun test is no test (G9)"
+grep -q 'scripts/test-ci-journey-warm-build.sh' "$WORKFLOW" \
+  || fail "(w6) the Unit job does not execute this guard"
+# #1809's properties must be intact.
+grep -q 'ci-journey-write-shard-verdict.sh INFRA' "$WORKFLOW" \
+  || fail "(w7) the #1809 pre-seed must still write INFRA"
+grep -q "steps.classify.outputs.shard_verdict == 'RED'" "$WORKFLOW" \
+  || fail "(w8) the #1809 RED shard gate must be intact"
+pass "(w) classify reads build-phase evidence, every branch stamps a reason, guard is wired, #1809 wiring intact"
+
+echo
+echo "== #1814 the REAL classify step, executed (the #1809 method) =="
+#
+# Grepping the workflow proves the text is there; it does not prove the step
+# RUNS. The classify step is shell embedded in YAML, so a typo in it reaches
+# only CI. Following #1809's precedent: EXTRACT the classify step's real `run:`
+# body out of tests.yml, substitute the `${{ }}` expressions with fixture
+# values, EXECUTE it against real scripts and real artifacts, and read back the
+# token it wrote and the `$GITHUB_OUTPUT` the #1809 RED gate depends on.
+
+CLASSIFY_BODY="$SANDBOX/classify-step.sh"
+python3 - "$WORKFLOW" "$CLASSIFY_BODY" <<'PY' || fail "(x) could not extract the classify step body from tests.yml"
+import re
+import sys
+
+workflow, out = sys.argv[1], sys.argv[2]
+lines = open(workflow).read().split("\n")
+
+start = next(
+    (i for i, l in enumerate(lines)
+     if l.strip() == "- name: Classify emulator-journey result (infra-abort vs test-failure)"),
+    None,
+)
+assert start is not None, "classify step not found in the workflow"
+run_at = next(
+    (i for i in range(start, min(start + 40, len(lines))) if lines[i].strip() == "run: |"),
+    None,
+)
+assert run_at is not None, "classify step has no `run: |` block"
+
+indent = len(lines[run_at]) - len(lines[run_at].lstrip())
+body = []
+for line in lines[run_at + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if len(line) - len(line.lstrip()) <= indent:
+        break
+    body.append(line[indent + 2:])
+assert body, "classify step body is empty"
+
+# `${{ steps.a.b }}` -> `${CLASSIFY_steps_a_b:-}` so the harness can inject each
+# workflow expression as an ordinary environment variable.
+src = re.sub(
+    r"\$\{\{([^}]*)\}\}",
+    lambda m: "${CLASSIFY_" + m.group(1).strip().replace(".", "_") + ":-}",
+    "\n".join(body),
+)
+assert "${{" not in src, "an unsubstituted workflow expression survived"
+open(out, "w").write(src + "\n")
+PY
+bash -n "$CLASSIFY_BODY" \
+  || fail "(x) the classify step's real run: body is not valid bash"
+
+CLASSIFY_DIR="$SANDBOX/classify-run"
+setup_classify_dir() {
+  rm -rf "$CLASSIFY_DIR"
+  mkdir -p "$CLASSIFY_DIR/scripts" "$CLASSIFY_DIR/artifacts/ci-journey"
+  cp "$WRITER" "$BUILD_PHASE" "$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh" \
+    "$SCRIPT_DIR/ci-journey-infra-signature.sh" "$SCRIPT_DIR/ci-journey-infra-signature.py" \
+    "$CLASSIFY_DIR/scripts/"
+}
+
+# seed_build_phase_manifest — one preserved attempt manifest carrying the
+# build-phase evidence, in the canonical per-attempt layout.
+seed_build_phase_manifest() {
+  local dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/Wedge--0123456789abcdef/attempt-1"
+  mkdir -p "$dir"
+  printf 'class=com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest\nprimary_classification=outer_timeout\nraw_junit_count=0\nouter_timeout_phase=build\n' \
+    > "$dir/manifest.txt"
+}
+
+seed_summary() {
+  printf '%s\n' "$@" > "$CLASSIFY_DIR/artifacts/ci-journey/summary.md"
+}
+
+# run_classify <first> <retry> <first_concl> <retry_concl> <first_timeout>
+#              <first_failure> <retry_allowed>
+CLASSIFY_TOKEN=""
+CLASSIFY_REASON=""
+CLASSIFY_RC=0
+CLASSIFY_OUT=""
+run_classify() {
+  local gh="$CLASSIFY_DIR/gh-output.txt"
+  local tok="$CLASSIFY_DIR/shard-verdict.txt"
+  : > "$gh"
+  rm -f "$tok"
+  CLASSIFY_OUT="$(
+    cd "$CLASSIFY_DIR" && env \
+      CLASSIFY_steps_journey_outcome="$1" \
+      CLASSIFY_steps_journey_retry_outcome="$2" \
+      CLASSIFY_steps_journey_conclusion="$3" \
+      CLASSIFY_steps_journey_retry_conclusion="$4" \
+      CLASSIFY_steps_journey_summary_outputs_first_timeout="$5" \
+      CLASSIFY_steps_journey_summary_outputs_first_failure="$6" \
+      CLASSIFY_steps_journey_retry_budget_outputs_retry_allowed="$7" \
+      CLASSIFY_steps_journey_retry_budget_outputs_retry_reason=fixture \
+      CLASSIFY_steps_journey_retry_budget_outputs_retry_remaining_ms=1 \
+      CLASSIFY_steps_journey_retry_budget_outputs_retry_required_ms=2 \
+      CLASSIFY_steps_journey_retry_budget_outputs_retry_cost_model=measured_first_attempt \
+      SHARD_VERDICT_FILE="$tok" \
+      POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2 \
+      GITHUB_RUN_ID=30323508796 GITHUB_RUN_ATTEMPT=1 \
+      GITHUB_OUTPUT="$gh" \
+      bash "$CLASSIFY_BODY" 2>&1
+  )"
+  CLASSIFY_RC=$?
+  CLASSIFY_TOKEN="$(sed -n 's/^shard_verdict=//p' "$gh")"
+  CLASSIFY_REASON="$(sed -n 's/^shard_verdict_reason=//p' "$gh")"
+}
+
+# expect_classify <label> <token> <reason> <exit> — with the args after that
+# forwarded to run_classify.
+expect_classify() {
+  local label="$1" want_token="$2" want_reason="$3" want_rc="$4"; shift 4
+  run_classify "$@"
+  [[ "$CLASSIFY_TOKEN" == "$want_token" ]] \
+    || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x/$label) token '$CLASSIFY_TOKEN', expected '$want_token'"; }
+  [[ "$CLASSIFY_REASON" == "$want_reason" ]] \
+    || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x/$label) reason '$CLASSIFY_REASON', expected '$want_reason'"; }
+  [[ "$CLASSIFY_RC" -eq "$want_rc" ]] \
+    || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x/$label) exit $CLASSIFY_RC, expected $want_rc"; }
+  # The token FILE and the step OUTPUT must agree — the #1809 RED gate reads the
+  # output, the aggregation job reads the file.
+  [[ "$(head -n1 "$CLASSIFY_DIR/shard-verdict.txt")" == "$want_token" ]] \
+    || fail "(x/$label) the written token file disagrees with the step output"
+  grep -qx "verdict_reason=$want_reason" "$CLASSIFY_DIR/shard-verdict.txt" \
+    || fail "(x/$label) the written token file lost the reason"
+  echo "    $label -> $CLASSIFY_TOKEN / $CLASSIFY_REASON (exit $CLASSIFY_RC)"
+}
+
+FAILED_BOTH_SUMMARY=(
+  '# Per-push CI journey suite — summary'
+  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):'
+  '- `com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest`'
+)
+TIMEOUT_SUMMARY=(
+  '# Per-push CI journey suite — summary'
+  'Suite step time budget exhausted — JOURNEY_STEP_TIMEOUT (issue #835 / #470 stall — job red):'
+  '- `com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest`'
+)
+CLEAN_SUMMARY=('# Per-push CI journey suite — summary' 'Classes exercised:')
+
+# WITHOUT build-phase evidence: every branch keeps its own reason, and every
+# token/exit code is exactly what #1458/#1809 established.
+setup_classify_dir; seed_summary "${CLEAN_SUMMARY[@]}"
+expect_classify "first-attempt pass"    CLEAN passed_first_attempt          0 success ''      success ''      false false true
+expect_classify "retry recovered"       CLEAN infra_flake_recovered         0 failure success failure success false false true
+setup_classify_dir; seed_summary "${FAILED_BOTH_SUMMARY[@]}"
+expect_classify "first genuine failure" RED   first_attempt_journey_failure 1 failure failure failure failure false true  true
+expect_classify "failed both attempts"  RED   journey_failure_both_attempts 1 failure failure failure failure false false true
+setup_classify_dir; seed_summary "${TIMEOUT_SUMMARY[@]}"
+expect_classify "first budget timeout"  RED   suite_budget_timeout          1 failure failure failure failure true  false true
+expect_classify "both-failed timeout"   RED   suite_budget_timeout          1 failure failure failure failure false false true
+setup_classify_dir; seed_summary "${CLEAN_SUMMARY[@]}"
+expect_classify "retry wall exhausted"  INFRA retry_wall_exhausted          1 failure ''      failure ''      false false false
+expect_classify "attempt cancelled"     INFRA attempt_cancelled             1 cancelled '' cancelled ''      false false true
+setup_classify_dir
+rm -f "$CLASSIFY_DIR/artifacts/ci-journey/summary.md"
+expect_classify "no summary at all"     INFRA emulator_never_booted         1 failure failure failure failure false false true
+pass "(x1) every classify branch writes the expected token + reason + exit code, executed from the real workflow body"
+
+# #1800's captured-signature branch must still fire, and now name itself. This
+# is the adjacency check: my edits sit in the same ladder.
+SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
+setup_classify_dir
+seed_summary \
+  '# Per-push CI journey suite — summary' \
+  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
+  "- \`$SATURATED_CLASS\`"
+signature_dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/Saturated--0123456789abcdef/attempt-1/android-test-outputs/androidTest-results/connected"
+mkdir -p "$signature_dir"
+{
+  echo '<?xml version="1.0" encoding="UTF-8"?>'
+  echo "<testsuite name=\"$SATURATED_CLASS\" tests=\"1\">"
+  echo "  <testcase name=\"saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide\" classname=\"$SATURATED_CLASS[emulator-5554 - 15]\">"
+  echo '    <failure message="java.lang.AssertionError: The real system input-method window never became visible.">at org.junit.Assert.fail(Assert.java:89)</failure>'
+  echo '  </testcase>'
+  echo '</testsuite>'
+} > "$signature_dir/TEST-emulator-5554-15_Saturated-1.xml"
+expect_classify "#1800 real-IME signature" INFRA real_ime_precondition 1 failure failure failure failure false true true
+pass "(x1b) #1800's captured real-IME signature branch still fires (and now names itself)"
+
+# WITH build-phase evidence: only the failure branches switch to the
+# cold-build attribution — and their severity is UNCHANGED (still exit 1).
+setup_classify_dir; seed_summary "${FAILED_BOTH_SUMMARY[@]}"; seed_build_phase_manifest
+expect_classify "cold build + first failure" RED cold_build_timeout 1 failure failure failure failure false true  true
+expect_classify "cold build + failed both"   RED cold_build_timeout 1 failure failure failure failure false false true
+grep -q 'an attempt was cut during the Gradle BUILD phase' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x2) the classify step does not announce the build-phase cause"; }
+grep -q 'MultiSessionSwitchJourneyE2eTest' <<<"$CLASSIFY_OUT" \
+  || fail "(x2) the build-phase annotation does not name the affected class"
+setup_classify_dir; seed_summary "${TIMEOUT_SUMMARY[@]}"; seed_build_phase_manifest
+expect_classify "cold build + budget timeout" RED cold_build_timeout 1 failure failure failure failure true false true
+# ...while a CLEAN shard is never relabelled: the attribution explains a
+# failure, it does not invent one.
+setup_classify_dir; seed_summary "${CLEAN_SUMMARY[@]}"; seed_build_phase_manifest
+expect_classify "cold build + clean pass"     CLEAN passed_first_attempt 0 success '' success '' false false true
+pass "(x2) build-phase evidence renames the CAUSE of a red shard without changing its severity, and never touches a CLEAN one"
+
+echo
+echo "ALL TESTS PASSED: scripts/test-ci-journey-warm-build.sh"


### PR DESCRIPTION
Closes #1814

## Why this is the highest-value fix in the gate backlog

The first class on a shard paid for the cold `:app:compileDebugKotlin` **inside its own per-class budget**. A #1458 enumeration spike measured the cost: **612–706s in 23 of 27 recent shard-instances**, roughly **15% of every shard budget**.

It also wore three different names — `TmuxSessionScreenArtVerify`, `DeepLinkSessionSwitch`, `MultiSessionSwitch` are exactly `JOURNEY_CLASSES[0..2]` — because round-robin reshuffles membership whenever the class list changes. That is why it read as "rotating victims" and helped sustain a since-disproven "shard 0 is pathological" theory.

And it was **indistinguishable from a real failure**: a cold-build kill and a genuine journey failure both present as `exit 124 / raw-junit count=0`, with the log simply ending at a Gradle task line. That ambiguity cost real investigation time.

## The fix

The per-class budget bounds *one class's* work, so shared once-per-shard work no longer sits inside it. `run_journey_classes_with_retry` calls `warm_journey_build` immediately after `SUITE_START` — before the first class's clock starts, but **inside** the #835 suite budget, which is where that time already lived.

Separately, an `outer_timeout` is now attributed to the phase it died in (`outer_timeout_phase=build|instrumentation|unknown`), surfaced as a `verdict_reason=cold_build_timeout` on the shard token and a per-shard reason in the aggregate — **without changing any verdict's severity**.

## "Moved, not newly excluded" — answered empirically

This is the question that decides whether the change is a fix or a quiet slackening, and the reviewer answered it by measurement rather than by reading code:

- **Numerically**: `JOURNEY_STEP_BUDGET_SECS=4200`, `JOURNEY_CLASS_TIMEOUT_SECS=420`, `JOURNEY_GRADLE_STOP_TIMEOUT_SECS=60`, `JOURNEY_CLASS_KILL_AFTER_SECS=30`, `JOURNEY_NO_OUTPUT_TIMEOUT_SECS=300`, job cap 95 min — all byte-identical to `HEAD`. The only new number is `JOURNEY_WARM_BUILD_TIMEOUT_SECS=900`, clamped to `budget_remaining()`.
- **Empirically**: with a 9s modelled cold build against a 900s suite budget, the first class starts at `budget remaining: 891s` in the real suite versus `900s` in the mutant — and `summary.md` reports **17s suite elapsed in both**. The cost is still inside the #835 budget; only the per-class clock changed. Total bounded time did not increase anywhere.

## Independent measurement, all three shards

The reviewer built its own harness with a different mutation shape:

| shard | first class | real | mutant |
|---|---|---|---|
| 0 | `TmuxSessionScreenArtVerifyE2eTest` | first=1s mid=0s | first=**9s** mid=0s |
| 1 | `DeepLinkSessionSwitchE2eTest` | first=0s mid=0s | first=**9s** mid=0s |
| 2 | `MultiSessionSwitchJourneyE2eTest` | first=0s mid=1s | first=**10s** mid=1s |

It also drove the candidate's own guard red three ways, the important one being **body gutted with the call kept** — which makes the *load-bearing elapsed assertion* fail (`the first class still paid the cold build (6s >= 6s)`) rather than a structural proxy (G6).

Task graph re-derived independently: **414 warm / 379 connected**, the only uncovered task being `:app:connectedDebugAndroidTest` itself. It additionally checked a module the implementer had not (`:shared:core-terminal`, 67 tasks) — same result.

## #1800 and #1809 severities provably unchanged

The reviewer extracted the classify `run:` body from **both base and head** and ran the same 14 fixtures through each: **MISMATCHES=0** on (token, exit code), including `#1800 real-IME → INFRA/1` and every #1809 RED/CLEAN/INFRA branch. Both misattribution controls hold in both directions — an instrumentation-phase wedge with the identical `exit 124 / count=0` verdict is not attributed to the build, and a genuine twice-failing class keeps its `Failed BOTH attempts` verdict.

It also exercised the warm-build **fail** and **hang** paths for real (both leave the suite green with all 48 classes running — no new way to go red), and verified the new summary text cannot match any classifier grep and sits *before* the STEP_TIMEOUT / Failed-BOTH `awk` arms.

## Sibling steps intact

Full `- name:` list diff is exactly `18a19` (81 → 82 steps). Parsed `unit`-job indices: 14 = #1741 notification guard, 17 = #1800 infra-signature, **18 = new #1814**, 19 = #1781 packaging; #1809's pre-seed and RED gate unmoved.

## Orchestrator verification

Applied to a clean worktree off `main` (`8a6c04b5`). **Three of the ten files are untracked** — `git diff` omits them, so they were copied explicitly with modes verified. `bash -n` clean on all nine shell scripts, workflow YAML parses, `git diff --check` clean.

The candidate's own guard passes, and every sibling guard stays green on the integrated tree: `test-ci-journey-warm-build.sh`, `test-ci-journey-infra-signature.sh`, `test-ci-journey-aggregate-verdict.sh`, `test-ci-journey-budget.sh`, plus `check-ci-journey-harness.sh` and `check-test-validity.sh`.

Note the `(o2)` interference reported during review has resolved itself — #1817 merged as `8a6c04b5`, and `test-ci-journey-budget.sh` now passes on the integrated tree.

Five non-blocking follow-ups are listed on the issue.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb