### PR TITLE
projects: drop the no-op .imePadding() inside RootProjectAddSheet (#1812)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetKeyboardLayoutTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetKeyboardLayoutTest.kt
@@ -84,13 +84,19 @@ import org.junit.runner.RunWith
  *    results viewport, so a published-but-ignored inset cannot pass.
  *
  * Mutation note (#1742): removing `imePadding()` from `RootProjectAddSheetContent`
- * changes nothing measurable here — Material3's `ModalBottomSheet` already
- * resolves the ime inset for its own window, so that call is redundant. The
- * assertion with proven bite is the SHRINK bound: replacing the bounded,
- * shrinkable content column with a fixed `requiredHeight` (the pre-#613 shape)
- * drops the viewport response to 127px against a 774px keyboard and turns this
- * proof red. Deliberately NOT deleting the redundant `imePadding()` here: #1742
- * is a fixture/oracle slice with an explicit "no layout behavior change" scope.
+ * changed nothing measurable here — Material3's `ModalBottomSheet` wraps its
+ * window content in `Modifier.fillMaxSize().imePadding()` and so has already
+ * CONSUMED the ime inset before the sheet content is composed. #1812 confirmed
+ * that on API 33/34/35 (byte-identical geometry with and without the modifier)
+ * and deleted it, which makes THIS proof strictly sharper: the lift it measures
+ * can now only come from Material's own sheet handling, so a Material3 upgrade
+ * that stopped consuming the ime inset turns this test red instead of being
+ * masked by a duplicate content-level `imePadding()`.
+ *
+ * The assertion with proven bite for the #613 mechanism itself is the SHRINK
+ * bound: replacing the bounded, shrinkable content column with a fixed
+ * `requiredHeight` (the pre-#613 shape) drops the viewport response to 127px
+ * against a 774px keyboard and turns this proof red.
  *
  * There is no `assumeTrue`/`assumeFalse` anywhere: an environment that cannot
  * reach the required state fails hard.
@@ -573,9 +579,10 @@ class RootProjectAddSheetKeyboardLayoutTest {
 
         /**
          * The results viewport must move up by essentially the whole keyboard
-         * (the sheet is bottom-anchored, so `imePadding()` translates it by the
-         * full inset). Half the inset is a generous floor that still goes red
-         * the moment the #613 layout stops responding.
+         * (the sheet is bottom-anchored, and Material3's own
+         * `ModalBottomSheet` ime padding translates it by the full inset).
+         * Half the inset is a generous floor that still goes red the moment the
+         * #613 layout stops responding.
          */
         const val MINIMUM_LIFT_FRACTION = 0.5f
 

--- a/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RootProjectAddSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -117,15 +116,23 @@ internal fun RootProjectAddSheetContent(
     // The fix splits the sheet into a PINNED header (label, path, search field,
     // quick actions, "New session here") that always stays visible while
     // typing, and a single weighted results LazyColumn that takes the remaining
-    // space and scrolls. `imePadding()` on the bounded-height outer Column
-    // shrinks that remaining space to sit right above the keyboard, so the
-    // matched folders stay visible and scrollable above the IME and the search
-    // field never scrolls away.
+    // space and scrolls.
+    //
+    // Issue #1812: the keyboard LIFT is Material3's, not this Column's.
+    // `ModalBottomSheet` wraps its whole window content in
+    // `Modifier.fillMaxSize().imePadding()` (ModalBottomSheet.kt:169 in
+    // material3 1.3.2), which CONSUMES the ime inset for everything below it,
+    // so a second content-level `imePadding()` here resolved to zero on every
+    // supported API level. What this Column contributes is the BOUND and the
+    // shrinkability — `fillMaxHeight(fraction)` + `heightIn(max)` over a
+    // `weight(1f)` results list — so the already-lifted sheet body spends its
+    // remaining height on the matched folders instead of overflowing them off
+    // the bottom. That is the lever #613 actually needs; do not re-add an ime
+    // modifier here to "make the keyboard work".
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .navigationBarsPadding()
-            .imePadding()
             .fillMaxHeight(ROOT_PROJECT_ADD_HEIGHT_FRACTION)
             .heightIn(max = ROOT_PROJECT_ADD_MAX_HEIGHT)
             .padding(horizontal = PocketShellSpacing.lg)


### PR DESCRIPTION
Closes #1812

## The mechanism, traced rather than assumed

`ModalBottomSheet.kt:169` (material3 1.3.2) is verbatim `Box(modifier = Modifier.fillMaxSize().imePadding().semantics { … })`, and `SheetDefaults.kt:316-317` makes the default `contentWindowInsets` a **second** consumer (`safeDrawing.only(Bottom)`, whose bottom includes ime).

The decisive step is in `foundation-layout` **commonMain** — `InsetsPaddingModifier.onModifierLocalsUpdated` (`WindowInsetsPadding.kt:394-399`): `unconsumedInsets = insets.exclude(consumed)`, with `ExcludeInsets.getBottom` = `(included - excluded).coerceAtLeast(0)`. With `consumed ⊇ ime` that is exactly zero — pure shared-code arithmetic, **no platform branch anywhere on the path**, so it genuinely cannot vary by API level.

The reviewer resolved the real artifact versions from the build and read both sources jars rather than trusting quoted line numbers.

## Geometry byte-identical — and the scalar oracle alone would have missed it

Measured before/after on API 33/34/35, compared as whole rect strings:

```
observedImeBottomPx=774 liftPx=774.0 shrinkPx=712.0
keyboardDownList=Rect.fromLTRB(42.0, 1125.0, 1038.0, 2368.0)
keyboardUpList  =Rect.fromLTRB(42.0, 1063.0, 1038.0, 1594.0)
keyboardTopPx=1626.0  modalRoot=Rect.fromLTRB(0.0, 0.0, 1080.0, 2400.0)  density=2.625
```

The reviewer then proved the oracle is not blind, with a temporary live mutant (`.padding(bottom = 40.dp)` at the same modifier slot) that moved both rects by exactly 105px = 40dp × 2.625. **Critically, under that mutant `liftPx`/`shrinkPx` stayed 774.0/712.0** — a uniform translation cancels out of both scalars. So the whole-rect-string comparison was not merely thorough, it was **necessary**; a scalar-only check would have passed a real regression.

## The comment was part of the bug

The #613 block comment credited `imePadding()` with the keyboard behaviour. Deleting the modifier while leaving that text would have preserved the exact confusion this issue removes, one line above the deletion — so it is rewritten to name Material3 as the lifter. Two KDoc statements in the test that the change makes false are corrected. **No assertion was touched.**

## A sensitivity gain, recorded as an expectation not a proof

While the duplicate was present, a Material3 upgrade that **stopped** consuming the ime inset would have been *masked* — our content-level modifier would go live and keep the lift green. Now that regression turns the test red. The reviewer noted this is analytic reasoning it could not measure without patching Material3, and recorded it as a well-founded expectation rather than a basis for approval. That distinction is right.

## The 7-site deferral: endorsed, and a blanket sweep would have been wrong

The G2 sweep found more nested `.imePadding()` sites, and the implementer deliberately left them alone — none has a keyboard-geometry oracle, so "geometry unchanged" cannot be demonstrated for them, and deleting on source-reading alone is the confident-argument-without-measurement shape.

The reviewer went further and found **three** standalone-composed contents where the modifier is genuinely **live**, not two: `SessionTypePickerContent`, `SessionCardFeedContent`/`ChecklistCardsContent`, and **`FolderContextActionContent`** (standalone in a plain `Box` at `FolderContextActionSheetScreenshotTest.kt:39`), which the implementer's note had missed. So a sweep would have been actively **wrong**, not merely unproven. Tracked as #1821 with the corrected enumeration.

## API coverage

33/34/35, not down to `minSdk` 26 — and the reviewer ruled a lower-API run buys nothing: the cancellation is `(x − x).coerceAtLeast(0)` in commonMain with no API branch, so if a lower API reports ime as zero the modifier is inert trivially, and if nonzero the outer `Box` consumes it and the nested one subtracts to zero. Both branches inert. The three profiles already varied the only two things that can vary at the Compose layer (density 2.75/2.625, height 2340/2400).

## Orchestrator verification

Applied to a clean worktree off `main` (`8a6c04b5`); two tracked files, no untracked residue, `git diff --check` clean. File-size hygiene, VM ratchet, and test-validity guards all exit 0. `:app:compileDebugAndroidTestKotlin` green.

`RootProjectAddSheetKeyboardLayoutTest` — the #1742 oracle, and the thing that would fail if geometry moved — run on a real emulator: `> Task :app:connectedDebugAndroidTest` unsuffixed, `Starting 1 tests` → `Finished 1 tests`, `BUILD SUCCESSFUL`. Its pass *is* the geometry proof; the reviewer independently verified the rects byte-identical with `cmp` and matching md5s.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb