### PR TITLE
ci(journey): stop the classifier laundering real failures into INFRA (#1822)

### DIFF
--- a/scripts/ci-journey-infra-signature.py
+++ b/scripts/ci-journey-infra-signature.py
@@ -34,6 +34,15 @@ Output (GitHub step-output compatible key=value lines):
     journey_signature_matches=<count of those carrying the captured signature>
     journey_offending_failures=<semicolon separated "class#method" that did not match>
 
+Issue #1822: the suite registers several load-bearing journeys at `Class#method`
+granularity, so the summary's failed-both bullets can be either
+``- `com.example.Foo` `` or ``- `com.example.Foo#someMethod` ``. Both forms are
+collected here, keyed on the class (the JUnit `classname` attribute the result
+XML carries). A bullet the parser cannot read is MISSING EVIDENCE, not proof of
+an environmental cause: it reports `unclassified` (RED) rather than silently
+ending the section, which is how the original `[\\w.$]`-only pattern dropped the
+first method-scoped entry AND truncated every entry after it.
+
 Exit status is always 0: the caller decides the verdict from the classification.
 """
 
@@ -49,20 +58,37 @@ REAL_IME_UNAVAILABLE_SIGNATURE = (
     "The real system input-method window never became visible."
 )
 
-# `- \`com.example.Foo\`` bullets under the summary's failed-both header.
+# `- \`com.example.Foo\`` and `- \`com.example.Foo#someMethod\`` bullets under
+# the summary's failed-both header. The suite writes BOTH forms (issue #1822);
+# trailing prose after the closing backtick — e.g. ``(#803 append-burst proof)``
+# — is tolerated because the match is not anchored at the end of the line.
 _FAILED_HEADER = re.compile(r"Failed BOTH attempts|JOURNEY_FAILED")
-_BULLET = re.compile(r"^\s*-\s+`([A-Za-z_][\w.$]*)`")
+_BULLET = re.compile(r"^\s*-\s+`([A-Za-z_][\w.$]*)(?:#([^`\s]+))?`")
+# Anything that is written as a markdown list item. A list item inside the
+# failed-both section that `_BULLET` cannot read is an ENTRY WE FAILED TO
+# UNDERSTAND, not the end of the section.
+_ANY_BULLET = re.compile(r"^\s*[-*+]\s+\S")
 
 
-def failed_both_classes(summary_path: str) -> list[str]:
-    """FQCNs listed under the suite summary's failed-BOTH-attempts section."""
+def failed_both_section(summary_path: str) -> tuple[list[str], list[str]]:
+    """Parse the suite summary's failed-BOTH-attempts section.
+
+    Returns ``(classes, unreadable)``:
+
+    * ``classes`` — deduplicated FQCNs (the class part of each bullet, which is
+      what the JUnit result XML's ``classname`` attribute carries).
+    * ``unreadable`` — verbatim list-item lines inside the section that could not
+      be parsed. A non-empty list forces `unclassified`, i.e. RED. Fail-safe is
+      toward the red verdict, NEVER toward green.
+    """
     try:
         with open(summary_path, "r", encoding="utf-8", errors="replace") as handle:
             lines = handle.read().splitlines()
     except OSError:
-        return []
+        return [], []
 
     classes: list[str] = []
+    unreadable: list[str] = []
     in_section = False
     for line in lines:
         if _FAILED_HEADER.search(line):
@@ -78,9 +104,16 @@ def failed_both_classes(summary_path: str) -> list[str]:
             continue
         if line.strip() == "":
             continue
+        if _ANY_BULLET.match(line):
+            # A list item we cannot read. Refusing to classify is the only safe
+            # answer: treating it as "the section ended" would drop this entry
+            # AND every entry after it, which is exactly how a genuine product
+            # failure got laundered into an INFRA green (issue #1822).
+            unreadable.append(line.strip())
+            continue
         # Any other non-bullet content ends the section.
         in_section = False
-    return classes
+    return classes, unreadable
 
 
 def _iter_result_xml(roots: list[str]):
@@ -100,10 +133,11 @@ def _failure_text(element: ET.Element) -> str:
 
 
 def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
-    classes = failed_both_classes(summary_path)
+    classes, unreadable = failed_both_section(summary_path)
     failing = 0
     matches = 0
-    offenders: list[str] = []
+    offenders: list[str] = [f"<unreadable-summary-entry>#{line}" for line in unreadable]
+    covered: set[str] = set()
 
     if classes:
         wanted = set(classes)
@@ -127,13 +161,24 @@ def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
                 if not problems:
                     continue
                 failing += 1
+                covered.add(base)
                 texts = [_failure_text(problem) for problem in problems]
                 if all(REAL_IME_UNAVAILABLE_SIGNATURE in text for text in texts):
                     matches += 1
                 else:
                     offenders.append(f"{base}#{case.get('name') or '<unknown>'}")
 
-    if not classes or failing == 0:
+    # Every class the summary listed as failing BOTH attempts must be backed by
+    # at least one failing test case in the preserved evidence. A listed class
+    # with no failing evidence is missing data — downgrading the shard on the
+    # remaining classes would mask whatever that one actually did (issue #1822).
+    uncovered = [name for name in classes if name not in covered]
+    for name in uncovered:
+        offenders.append(f"{name}#<no-failing-testcase-in-evidence>")
+
+    if unreadable or uncovered:
+        classification = "unclassified"
+    elif not classes or failing == 0:
         classification = "unclassified"
     elif offenders or matches != failing:
         classification = "product_failure"

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -35,13 +35,27 @@ REAL_IME_MESSAGE='java.lang.AssertionError: The real system input-method window 
 CONTAINMENT_MESSAGE="java.lang.AssertionError: Node 'prompt-composer-send-enter' must stay above the same-root keyboard boundary. node=Rect.fromLTRB(0.0, 1500.0, 1080.0, 1654.0) keyboardTopPx=1626.0"
 SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
 
+# Issue #1822 — the two genuinely-failing, METHOD-SCOPED entries that ran on
+# shard 1 of run 30334306297 alongside the real-IME precondition, and the exact
+# Compose timeout each carried. The suite registers both of these classes at
+# `Class#method` granularity, which is what the pre-#1822 bullet pattern could
+# not read.
+OCCLUSION_CLASS="com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
+OCCLUSION_METHOD="shellComposerControlsAreVisibleAndReachableInBothKeyboardStates"
+FILEVIEWER_CLASS="com.pocketshell.app.fileviewer.FileViewerDockerTest"
+FILEVIEWER_METHOD="moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl"
+COMPOSE_TIMEOUT_MESSAGE="androidx.compose.ui.test.ComposeTimeoutException: Condition still not satisfied after 15000 ms"
+
 # ---------------------------------------------------------------------------
 # Fixture builders: a realistic suite summary + realistic connected-test JUnit
 # XML under the exact artifact layout the suite writes
 # (artifacts/ci-journey/class-attempts/<module>/<key>/attempt-N/...).
 # ---------------------------------------------------------------------------
 
-# write_summary <root> <elapsed-secs> <failed-class> [<failed-class> ...]
+# write_summary <root> <elapsed-secs> <failed-entry> [<failed-entry> ...]
+#   A <failed-entry> is written verbatim inside backticks, so it may be either a
+#   bare FQCN (`com.example.Foo`) or the method-scoped form the suite writes for
+#   the classes it registers at method granularity (`com.example.Foo#someMethod`).
 write_summary() {
   local root="$1" elapsed="$2"; shift 2
   mkdir -p "$root/ci-journey"
@@ -64,6 +78,14 @@ write_summary() {
       done
     fi
   } > "$root/ci-journey/summary.md"
+}
+
+# append_summary_line <root> <raw-line> — append a verbatim line to the end of
+# the summary. The failed-BOTH section is the LAST section the suite writes, so
+# this lands inside it. Used to model an entry the parser cannot read (#1822).
+append_summary_line() {
+  local root="$1" line="$2"
+  printf '%s\n' "$line" >> "$root/ci-journey/summary.md"
 }
 
 # write_case_xml <root> <class> <attempt> <method>:<outcome> ...
@@ -90,6 +112,12 @@ write_case_xml() {
           ;;
         containment)
           echo "    <failure message=\"$CONTAINMENT_MESSAGE\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+          ;;
+        composetimeout)
+          # Issue #1822: the exact shape of the two failures that were laundered
+          # into a green — an ordinary Compose await timeout, no IME wording.
+          echo "    <failure message=\"$COMPOSE_TIMEOUT_MESSAGE\">at androidx.compose.ui.test.ComposeUiTest.waitUntil(ComposeUiTest.kt:100)"
+          echo "at com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest.shellComposerControlsAreVisibleAndReachableInBothKeyboardStates(TmuxShellComposerOcclusionE2eTest.kt:363)</failure>"
           ;;
         error)
           echo "    <error message=\"java.lang.IllegalStateException: harness exploded\">stack</error>"
@@ -246,6 +274,165 @@ run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
 [[ "$SIG_CLASS" == "product_failure" ]] \
   || { printf '%s\n' "$SIG_OUT"; fail "(h) an <error> element must be product_failure, got '$SIG_CLASS'"; }
 pass "(h) a harness <error> element -> product_failure"
+
+echo
+echo "== #1822 method-scoped bullets and fail-safe-toward-RED parsing =="
+
+# (p) A method-scoped bullet is READ. Before #1822 the bullet pattern's
+#     `[A-Za-z_][\w.$]*` class did not contain `#`, so a `Class#method` entry
+#     matched nothing at all and the class was never collected.
+root="$SANDBOX/p"; mkdir -p "$root"
+write_summary "$root" 2870 "$OCCLUSION_CLASS#$OCCLUSION_METHOD"
+write_case_xml "$root" "$OCCLUSION_CLASS" 1 "$OCCLUSION_METHOD:composetimeout"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+grep -q "^journey_failed_classes=$OCCLUSION_CLASS\$" <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(p) a \`Class#method\` bullet must be collected as its class"; }
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(p) a method-scoped genuine failure must be product_failure, got '$SIG_CLASS'"; }
+pass "(p) a \`Class#method\` failed-both bullet is parsed and its failure is seen"
+
+# (p2) The pre-existing bare-class bullet form, and the suite's core-terminal
+#      bullets that carry trailing prose after the closing backtick, must keep
+#      parsing exactly as before — widening the pattern may not narrow it.
+root="$SANDBOX/p2"; mkdir -p "$root"
+write_summary "$root" 2870 "$SATURATED_CLASS"
+append_summary_line "$root" "- \`com.pocketshell.core.terminal.ui.CodexAppendBurstMainThreadProofTest\` (#803 append-burst proof)"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "com.pocketshell.core.terminal.ui.CodexAppendBurstMainThreadProofTest" 1 \
+  "appendBurst:containment"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+grep -q 'journey_failed_classes=.*CodexAppendBurstMainThreadProofTest' <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(p2) a bullet with trailing prose after the backtick must still parse"; }
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(p2) expected product_failure, got '$SIG_CLASS'"; }
+pass "(p2) bare-class and trailing-prose bullets keep parsing (the widening did not narrow)"
+
+# (q) THE LOAD-BEARING #1822 CASE — the exact shape of run 30334306297 shard 1.
+#     A summary carrying ONE genuine INFRA signature FOLLOWED BY method-scoped
+#     genuine product failures must classify RED (product_failure).
+#
+#     On the base classifier this returns `real_ime_precondition`: the first
+#     method-scoped bullet failed to match AND ended the section, so
+#     `journey_failed_classes` collapsed to the IME class alone, every failure
+#     attributed to it carried the signature, and matches == failing -> INFRA ->
+#     shard green -> aggregate RE-RUN -> run reported success. Two real failures
+#     laundered into a green.
+root="$SANDBOX/q"; mkdir -p "$root"
+write_summary "$root" 2870 \
+  "$SATURATED_CLASS" \
+  "$OCCLUSION_CLASS#$OCCLUSION_METHOD" \
+  "$FILEVIEWER_CLASS#$FILEVIEWER_METHOD"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "$OCCLUSION_CLASS" 1 "$OCCLUSION_METHOD:composetimeout"
+write_case_xml "$root" "$OCCLUSION_CLASS" 2 "$OCCLUSION_METHOD:composetimeout"
+write_case_xml "$root" "$FILEVIEWER_CLASS" 1 "$FILEVIEWER_METHOD:composetimeout"
+write_case_xml "$root" "$FILEVIEWER_CLASS" 2 "$FILEVIEWER_METHOD:composetimeout"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+printf '%s\n' "$SIG_OUT" | sed 's/^/    /'
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(q) one INFRA signature + genuine method-scoped failures must be product_failure, got '$SIG_CLASS'"; }
+for expected in "$SATURATED_CLASS" "$OCCLUSION_CLASS" "$FILEVIEWER_CLASS"; do
+  grep -q "journey_failed_classes=.*$expected" <<<"$SIG_OUT" \
+    || { printf '%s\n' "$SIG_OUT"; fail "(q) every failed-both entry must be collected; missing $expected"; }
+done
+grep -q "journey_offending_failures=.*$OCCLUSION_METHOD" <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(q) the genuine occlusion failure must be named as an offender"; }
+grep -q "journey_offending_failures=.*$FILEVIEWER_METHOD" <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(q) the genuine file-viewer failure must be named as an offender"; }
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+printf '%s\n' "$SHARD_VERDICT_OUT" | sed 's/^/    decision: /'
+[[ "$SHARD_TOKEN" == "RED" ]] \
+  || fail "(q) the mixed shard must be typed RED, got $SHARD_TOKEN — a genuine failure was masked as INFRA"
+pass "(q) MIXED summary (INFRA signature + genuine \`Class#method\` failures) -> product_failure -> shard RED"
+
+# (q') The load-bearing control for (q) (G6). Remove ONLY the two genuine
+#      method-scoped entries and the same shard drops to INFRA — proving it was
+#      those entries, not the fixture shape, that drove the RED.
+root="$SANDBOX/q-control"; mkdir -p "$root"
+write_summary "$root" 2870 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+[[ "$SHARD_TOKEN" == "INFRA" ]] \
+  || fail "(q') dropping the genuine entries must yield INFRA, got $SHARD_TOKEN"
+pass "(q') control: the genuine \`Class#method\` entries are what turn the shard RED"
+
+# (q2) ORDER INDEPENDENCE. The base defect was positional — the first
+#      unreadable bullet truncated everything after it, so a run whose genuine
+#      failure came FIRST was still (accidentally) caught. Both orders must be
+#      RED now, so no future entry ordering can resurrect the mask.
+root="$SANDBOX/q2"; mkdir -p "$root"
+write_summary "$root" 2870 \
+  "$OCCLUSION_CLASS#$OCCLUSION_METHOD" \
+  "$SATURATED_CLASS"
+write_case_xml "$root" "$OCCLUSION_CLASS" 1 "$OCCLUSION_METHOD:composetimeout"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(q2) genuine-failure-first ordering must also be product_failure, got '$SIG_CLASS'"; }
+pass "(q2) the verdict does not depend on where the genuine entry sits in the list"
+
+# (r) AN UNPARSEABLE IN-SECTION BULLET FAILS SAFE TO RED. A list item inside the
+#     failed-both section that the parser cannot read is MISSING EVIDENCE, not a
+#     section terminator: it must yield `unclassified` (RED), never let the
+#     surviving entries decide the shard is environmental.
+root="$SANDBOX/r"; mkdir -p "$root"
+write_summary "$root" 2870 "$SATURATED_CLASS"
+append_summary_line "$root" '- `9NotAnIdentifier#weird` (an entry this parser cannot read)'
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+printf '%s\n' "$SIG_OUT" | sed 's/^/    /'
+[[ "$SIG_CLASS" == "unclassified" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(r) an unreadable in-section bullet must be unclassified, got '$SIG_CLASS'"; }
+grep -q 'journey_offending_failures=.*unreadable-summary-entry' <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(r) the unreadable entry must be reported, not silently swallowed"; }
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+[[ "$SHARD_TOKEN" == "RED" ]] \
+  || fail "(r) an unreadable in-section bullet must keep the shard RED, got $SHARD_TOKEN"
+pass "(r) an unparseable in-section bullet -> unclassified -> shard RED (fail-safe, never green)"
+
+# (r2) Prose bullets are unreadable too — the fail-safe is not keyed on one
+#      malformed FQCN shape.
+root="$SANDBOX/r2"; mkdir -p "$root"
+write_summary "$root" 2870 "$SATURATED_CLASS"
+append_summary_line "$root" '- (none individually bucketed — budget spent during summary phase)'
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "unclassified" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(r2) a prose bullet in the section must be unclassified, got '$SIG_CLASS'"; }
+pass "(r2) any unreadable list item in the section refuses classification"
+
+# (s) A listed class with NO failing test case in the preserved evidence is
+#     missing data. The remaining classes must not be allowed to decide the
+#     shard is environmental — that is the same masking bug wearing a different
+#     hat (the evidence is absent rather than the bullet unreadable).
+root="$SANDBOX/s"; mkdir -p "$root"
+write_summary "$root" 2870 "$SATURATED_CLASS" "$OCCLUSION_CLASS#$OCCLUSION_METHOD"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "unclassified" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(s) a failed-both class with no evidence must be unclassified, got '$SIG_CLASS'"; }
+grep -q 'journey_offending_failures=.*no-failing-testcase-in-evidence' <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(s) the class with no evidence must be named"; }
+pass "(s) a failed-both class with no failing evidence -> unclassified (stays RED)"
 
 echo
 echo "== #1800 end-to-end aggregate outcomes (observed, not argued) =="
@@ -418,6 +605,245 @@ pass "classify-step branch order: CLEAN -> signature INFRA -> genuine-failure RE
 grep -q 'first_timeout:-false}" != "true"' "$WORKFLOW" \
   || fail "the signature branch does not exclude the #835 budget timeout"
 pass "the signature branch can never fire for a #835 budget timeout"
+
+echo
+echo "== #1822 the REAL classify step run: body, executed end to end =="
+
+# Greps prove the branches exist in the right ORDER; they cannot prove what the
+# step actually WRITES. This harness (the #1809 review method) extracts the
+# classify step's real `run:` block out of tests.yml, substitutes its `${{ }}`
+# expressions from an explicit map, executes it over a real canonical artifact
+# tree through the real helper scripts, and reads back the verdict token and the
+# `$GITHUB_OUTPUT` the shard's RED gate keys on. An unmapped expression is a HARD
+# failure, so a workflow edit cannot drift silently past this harness.
+
+# classify_expressions <journey-outcome> — the step-output map for one scenario.
+classify_expressions() {
+  local journey_outcome="$1"
+  cat <<JSONEOF
+{
+  "steps.journey.outcome": "$journey_outcome",
+  "steps.journey_retry.outcome": "failure",
+  "steps.journey.conclusion": "$journey_outcome",
+  "steps.journey_retry.conclusion": "failure",
+  "steps.journey_summary.outputs.first_timeout": "false",
+  "steps.journey_summary.outputs.first_failure": "true",
+  "steps.journey_retry_budget.outputs.retry_allowed": "true",
+  "steps.journey_retry_budget.outputs.retry_reason": "sufficient_remaining_budget",
+  "steps.journey_retry_budget.outputs.retry_remaining_ms": "3112241",
+  "steps.journey_retry_budget.outputs.retry_required_ms": "3028613",
+  "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt"
+}
+JSONEOF
+}
+
+CLASSIFY_OUT=""
+CLASSIFY_RC=0
+CLASSIFY_TOKEN=""
+CLASSIFY_GH_OUTPUT=""
+# run_classify_body <sandbox> <expressions-json>
+run_classify_body() {
+  local sandbox="$1" expressions="$2"
+  local body="$sandbox/classify-step-body.sh"
+  local extract_err="$sandbox/extract-error.txt"
+  CLASSIFY_EXPRESSIONS="$expressions" python3 - "$WORKFLOW" "$body" 2>"$extract_err" <<'PYEOF'
+import json
+import os
+import re
+import sys
+
+workflow, out_path = sys.argv[1], sys.argv[2]
+mapping = json.loads(os.environ["CLASSIFY_EXPRESSIONS"])
+lines = open(workflow, encoding="utf-8").read().splitlines()
+
+step_re = re.compile(r"^(\s*)- name: Classify emulator-journey result")
+start = indent = None
+for i, line in enumerate(lines):
+    m = step_re.match(line)
+    if m:
+        start, indent = i, len(m.group(1))
+        break
+if start is None:
+    sys.exit("could not find the classify step in %s" % workflow)
+
+run_idx = None
+for j in range(start + 1, len(lines)):
+    line = lines[j]
+    if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+        break
+    if re.match(r"^\s*run: \|\s*$", line):
+        run_idx = j
+        break
+if run_idx is None:
+    sys.exit("the classify step has no `run: |` block")
+
+run_indent = len(lines[run_idx]) - len(lines[run_idx].lstrip())
+body = []
+for j in range(run_idx + 1, len(lines)):
+    line = lines[j]
+    if not line.strip():
+        body.append("")
+        continue
+    if (len(line) - len(line.lstrip())) <= run_indent:
+        break
+    body.append(line)
+if not [line for line in body if line.strip()]:
+    sys.exit("the classify step's run block is empty")
+
+pad = min(len(line) - len(line.lstrip()) for line in body if line.strip())
+text = "\n".join(line[pad:] if line.strip() else "" for line in body)
+
+unknown = []
+
+
+def substitute(match):
+    expr = match.group(1).strip()
+    if expr not in mapping:
+        unknown.append(expr)
+        return ""
+    return mapping[expr]
+
+
+text = re.sub(r"\$\{\{(.*?)\}\}", substitute, text)
+if unknown:
+    sys.exit("unmapped workflow expression(s): %s" % ", ".join(sorted(set(unknown))))
+
+with open(out_path, "w", encoding="utf-8") as handle:
+    handle.write(text + "\n")
+PYEOF
+  local extract_rc=$?
+  (( extract_rc == 0 )) || {
+    cat "$extract_err" >&2
+    fail "could not extract+substitute the classify step's run body from $WORKFLOW. If the step gained a new \`\${{ }}\` expression, add it to classify_expressions() in this file — running the step body with an unknown expression silently blanked would make this harness lie."
+  }
+
+  ln -sfn "$REPO_ROOT/scripts" "$sandbox/scripts"
+  : > "$sandbox/gh-output.txt"
+  local token_file="$sandbox/artifacts/ci-journey-shard-verdict/shard-verdict.txt"
+  rm -f "$token_file"
+  mkdir -p "$(dirname "$token_file")"
+  # GitHub's default Linux `run:` shell is `bash --noprofile --norc -eo pipefail`.
+  CLASSIFY_OUT="$(cd "$sandbox" && \
+    SHARD_VERDICT_FILE="$token_file" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX=1 \
+    GITHUB_RUN_ID=30334306297 \
+    GITHUB_RUN_ATTEMPT=1 \
+    GITHUB_OUTPUT="$sandbox/gh-output.txt" \
+    bash --noprofile --norc -eo pipefail "$body" 2>&1)"
+  CLASSIFY_RC=$?
+  CLASSIFY_TOKEN="$(head -n 1 "$token_file" 2>/dev/null || true)"
+  CLASSIFY_GH_OUTPUT="$(cat "$sandbox/gh-output.txt" 2>/dev/null || true)"
+}
+
+# build_shard_artifacts <sandbox> — a canonical two-attempt artifact tree.
+#   The caller has already populated "$sandbox/artifacts/ci-journey".
+snapshot_first_attempt() {
+  local sandbox="$1"
+  rm -rf "$sandbox/artifacts/ci-journey-attempt-1"
+  mkdir -p "$sandbox/artifacts/ci-journey-attempt-1"
+  cp -a "$sandbox/artifacts/ci-journey" "$sandbox/artifacts/ci-journey-attempt-1/ci-journey"
+}
+
+# (t) #1800 PRESERVED: a signature-only shard still writes INFRA, still exits
+#     non-zero, still emits a ::warning and NEVER a ::error.
+sandbox="$SANDBOX/wf-infra"; mkdir -p "$sandbox/artifacts"
+write_summary "$sandbox/artifacts" 2338 "$SATURATED_CLASS"
+write_case_xml "$sandbox/artifacts" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+write_case_xml "$sandbox/artifacts" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+snapshot_first_attempt "$sandbox"
+run_classify_body "$sandbox" "$(classify_expressions failure)"
+[[ "$CLASSIFY_TOKEN" == "INFRA" ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(t) the real classify body must write INFRA for a signature-only shard, got '$CLASSIFY_TOKEN'"; }
+grep -q '^shard_verdict=INFRA$' <<<"$CLASSIFY_GH_OUTPUT" \
+  || { printf '%s\n' "$CLASSIFY_GH_OUTPUT"; fail "(t) the step must export shard_verdict=INFRA"; }
+grep -q '::warning title=Emulator journey INFRA' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(t) the INFRA branch must annotate as a warning"; }
+grep -q '::error' <<<"$CLASSIFY_OUT" \
+  && { printf '%s\n' "$CLASSIFY_OUT"; fail "(t) a signature-only shard must not emit ::error"; }
+infra_token_dir="$SANDBOX/wf-verdicts-infra"; rm -rf "$infra_token_dir"; mkdir -p "$infra_token_dir"
+write_shard_token "$infra_token_dir" 0 CLEAN
+write_shard_token "$infra_token_dir" 1 "$CLASSIFY_TOKEN"
+write_shard_token "$infra_token_dir" 2 CLEAN
+run_agg "$infra_token_dir"
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(t) an all-infra run must still aggregate RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(t) #1800 preserved: signature-only -> real body writes INFRA -> aggregate RE-RUN (neutral green)"
+
+# (u) THE #1822 UN-MASKING, through the real step body. The exact run
+#     30334306297 shard-1 shape: the IME signature entry FOLLOWED BY two
+#     method-scoped genuine Compose-timeout failures. On the base classifier the
+#     body wrote INFRA (shard job green, aggregate RE-RUN, run reported
+#     success). It must now write RED, emit ::error, export shard_verdict=RED
+#     (which is what #1809's "Fail this shard on a genuine RED verdict" gate
+#     keys on), and aggregate RED/exit1.
+sandbox="$SANDBOX/wf-mixed"; mkdir -p "$sandbox/artifacts"
+write_summary "$sandbox/artifacts" 2870 \
+  "$SATURATED_CLASS" \
+  "$OCCLUSION_CLASS#$OCCLUSION_METHOD" \
+  "$FILEVIEWER_CLASS#$FILEVIEWER_METHOD"
+for attempt in 1 2; do
+  write_case_xml "$sandbox/artifacts" "$SATURATED_CLASS" "$attempt" \
+    "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+  write_case_xml "$sandbox/artifacts" "$OCCLUSION_CLASS" "$attempt" "$OCCLUSION_METHOD:composetimeout"
+  write_case_xml "$sandbox/artifacts" "$FILEVIEWER_CLASS" "$attempt" "$FILEVIEWER_METHOD:composetimeout"
+done
+snapshot_first_attempt "$sandbox"
+run_classify_body "$sandbox" "$(classify_expressions failure)"
+printf '%s\n' "$CLASSIFY_OUT" | sed 's/^/    body: /'
+[[ "$CLASSIFY_TOKEN" == "RED" ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(u) the real classify body must write RED for the mixed shard, got '$CLASSIFY_TOKEN' — two genuine failures would be laundered into a green"; }
+[[ "$CLASSIFY_RC" -ne 0 ]] || fail "(u) a RED classify body must exit non-zero"
+grep -q '^shard_verdict=RED$' <<<"$CLASSIFY_GH_OUTPUT" \
+  || { printf '%s\n' "$CLASSIFY_GH_OUTPUT"; fail "(u) the step must export shard_verdict=RED so the #1809 shard RED gate fires"; }
+grep -q '::error' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(u) a genuine failure must emit ::error"; }
+grep -q '::warning title=Emulator journey INFRA' <<<"$CLASSIFY_OUT" \
+  && { printf '%s\n' "$CLASSIFY_OUT"; fail "(u) the INFRA branch must NOT fire on the mixed shard"; }
+mixed_token_dir="$SANDBOX/wf-verdicts-mixed"; rm -rf "$mixed_token_dir"; mkdir -p "$mixed_token_dir"
+write_shard_token "$mixed_token_dir" 0 CLEAN
+write_shard_token "$mixed_token_dir" 1 "$CLASSIFY_TOKEN"
+write_shard_token "$mixed_token_dir" 2 CLEAN
+run_agg "$mixed_token_dir"
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(u) the mixed shard must aggregate RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(u) #1822: mixed shard -> real body writes RED -> shard RED gate fires -> aggregate RED (exit 1)"
+
+# (v) #1822: an unreadable in-section bullet also drives the real body to RED.
+sandbox="$SANDBOX/wf-unreadable"; mkdir -p "$sandbox/artifacts"
+write_summary "$sandbox/artifacts" 2870 "$SATURATED_CLASS"
+append_summary_line "$sandbox/artifacts" '- `9NotAnIdentifier#weird` (an entry this parser cannot read)'
+write_case_xml "$sandbox/artifacts" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+snapshot_first_attempt "$sandbox"
+run_classify_body "$sandbox" "$(classify_expressions failure)"
+[[ "$CLASSIFY_TOKEN" == "RED" ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(v) an unreadable summary entry must drive the real body to RED, got '$CLASSIFY_TOKEN'"; }
+pass "(v) #1822: an unreadable failed-both entry -> the real body writes RED"
+
+# (w) #1800/#1458 PRESERVED: a run that passed on the first cold boot still
+#     writes CLEAN and exits 0 through the same body.
+sandbox="$SANDBOX/wf-clean"; mkdir -p "$sandbox/artifacts"
+write_summary "$sandbox/artifacts" 2338
+snapshot_first_attempt "$sandbox"
+run_classify_body "$sandbox" "$(classify_expressions success)"
+[[ "$CLASSIFY_TOKEN" == "CLEAN" && "$CLASSIFY_RC" -eq 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(w) a first-attempt success must write CLEAN/exit0, got '$CLASSIFY_TOKEN'/exit$CLASSIFY_RC"; }
+clean_token_dir="$SANDBOX/wf-verdicts-clean"; rm -rf "$clean_token_dir"; mkdir -p "$clean_token_dir"
+write_shard_token "$clean_token_dir" 0 CLEAN
+write_shard_token "$clean_token_dir" 1 "$CLASSIFY_TOKEN"
+write_shard_token "$clean_token_dir" 2 CLEAN
+run_agg "$clean_token_dir"
+[[ "$AGG_VERDICT" == "CLEAN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(w) an all-clean run must aggregate CLEAN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+# ...and a MISSING token still downgrades that same all-clean set to RE-RUN:
+#    `missing == 0` remains required for CLEAN (#1458).
+rm -rf "$clean_token_dir/emulator-journey-verdict-shard-2"
+run_agg "$clean_token_dir"
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(w) a missing shard token must downgrade CLEAN to RE-RUN, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(w) #1458/#1800 preserved: first-attempt success -> CLEAN -> aggregate CLEAN; a missing token still forces RE-RUN"
 
 echo
 echo "== #1800 synthetic coverage is present and wired =="


### PR DESCRIPTION
Closes #1822

## The gate was reporting real failures as green

`_BULLET = re.compile(r"^\s*-\s+`([A-Za-z_][\w.$]*)`")` — `#` is not in `[\w.$]`, so a `Class#method` bullet did not match, **and** a non-matching non-blank line ended the failed-both section. The first method-scoped bullet was therefore both **dropped** and **truncated every bullet after it**.

On run 30334306297 shard 1 that collapsed three failed-both classes to one, made `matches == failing` true, and turned two genuine `ComposeTimeoutException` failures into an INFRA green.

**It failed safe toward GREEN — the opposite of its own docstring contract**, and precisely the #657/#844 flake-masks-real trap #1458's aggregation design exists to avoid.

## Proven against the artifact that was actually masked

Both the implementer and the reviewer replayed the **real shard-1 artifact** through the **real workflow classify `run:` body**. The reviewer wrote its **own** extractor rather than trusting the candidate's, and first confirmed from the raw XML that the two masked entries carry `ComposeTimeoutException`, not the IME signature:

| | base (`origin/main`) | fixed |
|---|---|---|
| classifier | `real_ime_precondition`, 1 class, 4/4 | `product_failure`, 3 classes, 4/12 |
| real classify body | `INFRA`, `::warning`, `shard_verdict=INFRA` | `RED`, `::error`, `shard_verdict=RED` |
| real aggregator, real tokens | `RE-RUN` exit 0 | `RED` exit 1 |

`shard_verdict=RED` is what #1809's "Fail this shard on a genuine RED verdict" gate keys on, so the shard now fails its own job and the re-run button can finally reach it.

**The decisive control** the reviewer added: deleting only the two genuine entries from the real summary sends the same shard back to `INFRA` under the **fixed** classifier — so the RED is driven by those entries, not by the fix being blanket-red.

## The three changes

1. **`_BULLET` accepts an optional `#method` suffix.** Verified adversarially: the group cannot cross a backtick or whitespace, and the new pattern is a **provable superset** of the old, so it can never narrow. All **145** class entries the suite can emit parse; 0 unparseable, so the new unreadable→RED path cannot spuriously fire on real writer output.
2. **An unparseable in-section list item is recorded as unreadable, does NOT end the section**, forces `unclassified` → RED, and is named verbatim in `journey_offending_failures`. A non-blank non-list line still ends the section, which is a genuine new section in the writer's format.
3. **A fail-safe beyond the literal scope**: a class listed under "Failed BOTH attempts" with **no failing test case in evidence** also forces `unclassified`. Without it, deleting one XML reaches the same false green by a different route. It short-circuits *before* `real_ime_precondition` — the only green-ward classification — so it structurally cannot create a false green.

## A correction the reviewer made to the implementer's own claim

"Only ever moves toward RED" is imprecise. A **6,966-scenario differential sweep** found **74 red→green transitions** — all shards whose named classes carry only the IME signature, where base's `unclassified` *was itself the parsing bug*. **Zero** hide a genuine failure.

The clean statement is its 64-permutation mixed-shard sweep: **base masks 8 as false-green, fixed masks 0.**

## The hard-fail on unmapped `${{ }}`

The implementer made an unmapped expression in the classify step a **hard failure** of the new harness rather than a silent blank. The reviewer verified it fires and endorsed it: the cost is one line per new step output, and the failure mode it prevents is a harness executing a partially-blanked body and reporting green — the exact vacuous artifact this issue exists to kill.

## Merge order with #1814

**Either order is safe**, verified independently by the reviewer: #1814 touches no `ci-journey-infra-signature.*` file, its rewritten classify body has an *identical* 11-expression set, and this candidate's new guard passes against #1814's `tests.yml` (exit 0).

## Still open in the same family — not fixed here

The reviewer found a **second false-green route, through the writer rather than the parser**: `scripts/ci-journey-summary-functions.sh:16-21` makes `SURFACE_REPAINT_STATUS` (#1203) and `SHELL_SNAPSHOT_STATUS` (#1233) turn the suite red, but neither appears in the header condition at `:128-131` and neither gets a bullet. A run where only one of those fails twice writes **no** failed-both section → `first_failure=false` → the classify body falls through to `EMULATOR INFRA UNAVAILABLE` → **INFRA**. Filed separately; that file is owned by in-flight #1814.

**So emulator-gate greens are not fully trustworthy even after this lands** — that is worth stating plainly rather than declaring the family closed.

## Orchestrator verification

Applied to a clean worktree off `main` (`8a6c04b5`); exactly two modified files, no untracked residue. Python parses, `bash -n` clean, `git diff --check` clean. `test-ci-journey-infra-signature.sh`, `test-ci-journey-aggregate-verdict.sh`, and `check-ci-journey-harness.sh` all green on the integrated tree.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb