### PR TITLE
core-tmux: don't correlate tmux's own attach block to a pending command (#1810)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
@@ -25,6 +25,7 @@ import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -143,7 +144,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
         val sessionName = "issue783-$suffix"
 
         // 0. Seed a real session with TWO windows on the host.
-        withTimeout(20_000) {
+        stage("seed-connect") { withTimeout(20_000) {
             SshConnection.connect(
                 host = DEFAULT_HOST,
                 port = DEFAULT_PORT,
@@ -157,7 +158,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
                 s.exec("tmux new-window -t $sessionName -c $folder")
                 createdSessions += sessionName
             }
-        }
+        } }
 
         val keyId = db.sshKeyDao().insert(
             SshKeyEntity(name = "issue783-key", privateKeyPath = keyFile.absolutePath),
@@ -177,7 +178,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
         //    (the same wiring TmuxSessionViewModel uses) and register it. This is
         //    the SOLE `-CC` connection — the prune below reuses it (D21).
         val registry = ActiveTmuxClients()
-        val session = withTimeout(20_000) {
+        val session = stage("cc-session-connect") { withTimeout(20_000) {
             SshConnection.connect(
                 host = DEFAULT_HOST,
                 port = DEFAULT_PORT,
@@ -186,14 +187,14 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
                 knownHosts = KnownHostsPolicy.AcceptAll,
                 timeoutMs = 15_000,
             ).getOrThrow()
-        }
+        } }
         ccSession = session
         val client = TmuxClientFactory(tmuxClientScope).create(
             session = session,
             sessionName = sessionName,
         )
         ccClient = client
-        withTimeout(20_000) { client.connect() }
+        stage("cc-client-connect") { withTimeout(20_000) { client.connect() } }
         registry.register(
             hostId = host.id,
             hostName = host.name,
@@ -231,7 +232,18 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
         )
 
         // Cold-open reconcile settles: the session shows both windows.
-        awaitWindowCount(vm, sessionName, expected = 2)
+        //
+        // Issue #1810: this is the bound the wedge expired. It is the FIRST
+        // consumer of the live `-CC` client, so it is what a mis-correlated
+        // attach block silently broke — the enumeration resolved with an EMPTY,
+        // non-error `list-sessions`, the tree went `Ready` with ZERO sessions,
+        // and nothing else ever happened on the wire (the "20 seconds of
+        // complete silence"). The failure message carries the observed state so
+        // "wedged in setup" is never again an unattributed `DefaultExecutor`
+        // frame.
+        stage("await-window-count-2") {
+            awaitWindowCount(vm, sessionName, expected = 2)
+        }
         val windowIdsBefore = windowIds(vm, sessionName)
         assertEquals(
             "the seeded session must have two windows before the close; ids=$windowIdsBefore",
@@ -249,7 +261,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
 
         // 4. Close ONE window ON THE HOST from a SEPARATE plain SSH connection
         //    (NOT the app). tmux emits %window-close on the live `-CC` client.
-        withTimeout(20_000) {
+        stage("kill-window-connect") { withTimeout(20_000) {
             SshConnection.connect(
                 host = DEFAULT_HOST,
                 port = DEFAULT_PORT,
@@ -260,12 +272,14 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
             ).getOrThrow().use { s ->
                 s.exec("tmux kill-window -t $targetWindowId")
             }
-        }
+        } }
 
         // 5. The closed window's node must disappear from the tree within
         //    seconds — NO manual refresh, NO resume — while its sibling survives.
         val startedAt = System.currentTimeMillis()
-        awaitWindowGone(vm, sessionName, targetWindowId!!, timeoutMs = 25_000L)
+        stage("await-window-gone") {
+            awaitWindowGone(vm, sessionName, targetWindowId!!, timeoutMs = 25_000L)
+        }
         val elapsedMs = System.currentTimeMillis() - startedAt
         assertTrue(
             "the host-closed window must be pruned within seconds (event-driven), not the " +
@@ -284,6 +298,25 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
         )
     } }
 
+    /**
+     * Issue #1810: run one bounded step under a LABEL.
+     *
+     * This test has five 20 s bounds. When one expired, JUnit reported a bare
+     * `TimeoutCancellationException: Timed out waiting for 20000 ms` on a
+     * `DefaultExecutor` frame that named none of them, so "it wedges in setup"
+     * could not be attributed without re-instrumenting. Re-throwing with the
+     * stage name (and, for the tree waits, the observed UI state) makes the
+     * report self-describing.
+     *
+     * This changes NO bound and weakens NO assertion — it only renames the
+     * failure.
+     */
+    private suspend fun <T> stage(name: String, block: suspend () -> T): T = try {
+        block()
+    } catch (e: TimeoutCancellationException) {
+        throw AssertionError("stage `$name` timed out; ${e.message}", e)
+    }
+
     private fun windowIds(vm: FolderListViewModel, sessionName: String): List<String?> {
         val state = vm.state.value as? FolderListUiState.Ready ?: return emptyList()
         return state.flatSessions
@@ -299,12 +332,32 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
         expected: Int,
         timeoutMs: Long = 20_000L,
     ) {
-        withTimeout(timeoutMs) {
-            while (windowIds(vm, sessionName).size != expected) {
-                delay(200L)
+        try {
+            withTimeout(timeoutMs) {
+                while (windowIds(vm, sessionName).size != expected) {
+                    delay(200L)
+                }
             }
+        } catch (e: TimeoutCancellationException) {
+            // Issue #1810: report WHAT the tree actually held. An empty
+            // `Ready` here means the enumeration answered (wrongly) with zero
+            // sessions rather than that the host never came up.
+            throw AssertionError(
+                "session `$sessionName` never showed $expected windows within ${timeoutMs}ms; " +
+                    "observed ${describeState(vm)}",
+                e,
+            )
         }
     }
+
+    private fun describeState(vm: FolderListViewModel): String =
+        when (val state = vm.state.value) {
+            is FolderListUiState.Ready ->
+                "Ready(sessions=[" +
+                    state.flatSessions.joinToString { "${it.sessionName}:${it.windows.size}w" } +
+                    "] refreshing=${state.isRefreshing})"
+            else -> state.toString().take(240)
+        }
 
     private suspend fun awaitWindowGone(
         vm: FolderListViewModel,

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -2169,7 +2169,12 @@ internal class RealTmuxClient(
                 when (event) {
                     is ControlEvent.Begin -> {
                         val match = synchronized(responseCorrelationLock) {
-                            if (staleResponseBlocksToIgnore > 0) {
+                            if (event.controlModePreamble) {
+                                // #1810: tmux's own attach reply, owed to no
+                                // caller — see the flag's KDoc.
+                                ignoredResponseNumber = event.number
+                                null
+                            } else if (staleResponseBlocksToIgnore > 0) {
                                 staleResponseBlocksToIgnore -= 1
                                 ignoredResponseNumber = event.number
                                 null

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlEvent.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlEvent.kt
@@ -134,6 +134,26 @@ public sealed interface ControlEvent {
         val time: Long,
         val number: Long,
         val flags: Int,
+        /**
+         * Issue #1810: `true` when this `%begin` line arrived carrying the
+         * control-mode DCS preamble (`ESC P 1000 p`), i.e. it is the FIRST block
+         * of the `-CC` stream — tmux's own answer to the
+         * `tmux -CC new-session …` command line that started control mode:
+         *
+         * ```
+         * ESC P1000p%begin 1785219223 305 0
+         * %end 1785219223 305 0
+         * %session-changed $0 probe
+         * ```
+         *
+         * That block carries an EMPTY payload and is owed to NO caller, so it
+         * must never be correlated with a queued command. tmux opens the DCS
+         * passthrough string exactly once, at the start of the control-mode
+         * stream, so this flag identifies that block and nothing else — the
+         * marker is self-describing rather than positional, which is what makes
+         * the skip safe regardless of when the reader happens to parse it.
+         */
+        val controlModePreamble: Boolean = false,
     ) : ControlEvent
 
     /** Closes a [Begin] block on success. */

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlEventStream.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlEventStream.kt
@@ -93,6 +93,9 @@ public class ControlEventStream(
         var openBlockBytes = 0L
 
         lines.collect { rawLine ->
+            // Issue #1810: ask BEFORE normalising — the strip below removes the
+            // marker that identifies tmux's control-mode preamble block.
+            val dcsPreamble = hasDcsPreamble(rawLine)
             // Byte-level DCS strip; the parser re-strips defensively but we
             // need the normalized bytes for the String-decoded payload path.
             val lineBytes = normalizeControlLine(rawLine)
@@ -144,7 +147,7 @@ public class ControlEventStream(
                     openBlockBytes = 0L
                     // Re-process this same line as if it arrived outside a
                     // block. `parsed` is the parse of `lineBytes`, so reuse it.
-                    val event = parsed ?: return@collect
+                    val event = (parsed ?: return@collect).withPreambleFlag(dcsPreamble)
                     if (event is ControlEvent.Begin) {
                         openBlock = event.number
                     }
@@ -162,7 +165,7 @@ public class ControlEventStream(
             }
 
             // Outside any block: parse normally.
-            val event = parser.parse(lineBytes) ?: return@collect
+            val event = (parser.parse(lineBytes) ?: return@collect).withPreambleFlag(dcsPreamble)
             if (event is ControlEvent.Begin) {
                 openBlock = event.number
                 openBlockLines = 0
@@ -172,3 +175,13 @@ public class ControlEventStream(
         }
     }
 }
+
+/**
+ * Issue #1810: carry "this line opened the control-mode DCS passthrough" onto the
+ * parsed [ControlEvent.Begin]. The parser is byte-level and re-strips the wrapper
+ * defensively, so the marker has to be re-attached here, where the RAW line is
+ * still in hand. Only `%begin` can be the preamble block; every other event is
+ * returned unchanged.
+ */
+private fun ControlEvent.withPreambleFlag(dcsPreamble: Boolean): ControlEvent =
+    if (dcsPreamble && this is ControlEvent.Begin) copy(controlModePreamble = true) else this

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlModeParser.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/protocol/ControlModeParser.kt
@@ -254,6 +254,19 @@ public class ControlModeParser {
 }
 
 /**
+ * Issue #1810: does this raw line carry the control-mode DCS passthrough OPENER
+ * (`ESC P ... p`)? tmux emits it exactly once, on the very first line of the
+ * `-CC` stream, so it uniquely identifies the attach block — the `%begin`/`%end`
+ * pair tmux sends as its answer to the `tmux -CC new-session ...` command line
+ * itself. [normalizeControlLine] strips the wrapper, so callers that need to know
+ * must ask BEFORE normalising.
+ */
+internal fun hasDcsPreamble(line: ByteArray): Boolean =
+    line.size >= DCS_PREFIX_BYTES.size &&
+        line[0] == DCS_PREFIX_BYTES[0] &&
+        line[1] == DCS_PREFIX_BYTES[1]
+
+/**
  * Strip a terminal DCS passthrough wrapper (`ESC P ... ESC \`) off a raw
  * control-mode line at the byte level. The DCS framing bytes are all ASCII
  * (`0x1b`, `'P'`, `'%'`, `'\'`), so byte-level stripping is safe even when

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxAttachResponseBlockCorrelationTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxAttachResponseBlockCorrelationTest.kt
@@ -1,0 +1,313 @@
+package com.pocketshell.core.tmux
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.protocol.ControlEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.charset.StandardCharsets
+
+/**
+ * Issue #1810 — the ATTACH response block must never be correlated with a
+ * caller's command, in EITHER arrival order.
+ *
+ * tmux control mode answers the command line that started it
+ * (`tmux -CC new-session -A -s <name>`) with one `%begin`/`%end` pair carrying an
+ * EMPTY payload, DCS-wrapped as `ESC P1000p%begin <t> <n> 0`. Captured verbatim
+ * off the Docker `agents` fixture (tmux 3.6b), for both a freshly created and an
+ * attached-to-existing session:
+ *
+ * ```
+ * $ tmux -CC new-session -A -s probe
+ * ESC P1000p%begin 1785219223 305 0
+ * %end 1785219223 305 0
+ * %session-changed $0 probe
+ * ```
+ *
+ * The reader's `%begin` branch pops [pendingQueue] unconditionally, so before the
+ * fix whether that empty block was harmless depended purely on arrival order:
+ *
+ *  * attach block parsed BEFORE any command was queued — polls null, ignored
+ *    (the fast, "everything works" ordering, [attachBlockArrivingBeforeAnyCommandIsIgnored]);
+ *  * attach block parsed AFTER a command was queued — it STOLE that command's
+ *    slot, so the caller got the empty attach payload and every later block was
+ *    shifted by one, the last one dropped ([attachBlockArrivingAfterCommandsAreQueuedMustNotStealTheirResponses]).
+ *
+ * The second ordering is what the folder-list live `-CC` enumeration hit on a
+ * loaded emulator in >25% of runs: `list-sessions` resolved EMPTY (not an error),
+ * so the host reported zero sessions and the project tree stayed empty with no
+ * retry. That is the wedge behind
+ * `FolderListWindowCloseAfterStopPollingDockerTest`'s 20 s setup timeout.
+ *
+ * These tests force BOTH orderings deterministically by driving the fake shell's
+ * stdout by hand — no sleeps, no sampling.
+ */
+class TmuxAttachResponseBlockCorrelationTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    /**
+     * THE REPORTED ORDERING (red before the fix). The enumeration is queued and
+     * written first; tmux's attach block only reaches the reader afterwards.
+     *
+     * Before the fix: `responses[0].output` was EMPTY (the attach block's payload)
+     * and `responses[1]` carried the `list-sessions` rows — the exact off-by-one
+     * observed on the emulator
+     * (`liveEnum listSessions(err=false n=0 num=281) listPanes(err=false n=1 num=286)`).
+     */
+    @Test
+    fun attachBlockArrivingAfterCommandsAreQueuedMustNotStealTheirResponses() = runBlocking {
+        val shell = FakeShell()
+        val client = RealTmuxClient(FakeSession(shell), scope, sessionName = "issue1810")
+        try {
+            client.connect()
+            awaitWrittenLines(shell, expected = 1)
+
+            val enumeration = async {
+                client.sendChainedCommands(listOf(LIST_SESSIONS, LIST_PANES))
+            }
+            // Both chained commands are on the wire; tmux has still not been heard
+            // from at all. This is the state the loaded emulator reproduces.
+            awaitWrittenLines(shell, expected = 2)
+
+            // NOW tmux's output arrives, attach block first, in one batch.
+            shell.feed(ATTACH_BLOCK)
+            shell.feed("%begin 1785219223 306 1\n$SESSION_ROW\n%end 1785219223 306 1\n")
+            shell.feed("%begin 1785219223 307 1\n$PANE_ROW\n%end 1785219223 307 1\n")
+
+            val responses = withTimeout(RESPONSE_TIMEOUT_MS) { enumeration.await() }
+
+            assertEquals(
+                "list-sessions must receive the list-sessions block, not the empty attach block",
+                listOf(SESSION_ROW),
+                responses[0].output,
+            )
+            assertEquals(
+                "list-panes must receive the list-panes block, not the shifted list-sessions block",
+                listOf(PANE_ROW),
+                responses[1].output,
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    /**
+     * THE ALREADY-WORKING ORDERING, pinned so the fix cannot over-swallow. The
+     * attach block is fully consumed before any command is queued; the
+     * reservation must be spent on it and NOT on the first real command.
+     *
+     * Sequencing is deterministic: the `%session-changed` that tmux emits
+     * immediately after the attach block is observed on [TmuxClient.events], which
+     * proves the reader has already passed the attach `%begin`/`%end`.
+     */
+    @Test
+    fun attachBlockArrivingBeforeAnyCommandIsIgnored() = runBlocking {
+        val shell = FakeShell()
+        val client = RealTmuxClient(FakeSession(shell), scope, sessionName = "issue1810")
+        try {
+            client.connect()
+            awaitWrittenLines(shell, expected = 1)
+
+            val sessionChanged = async {
+                client.events.first { it is ControlEvent.SessionChanged }
+            }
+            // The attach block goes on the wire FIRST and exactly once; stdout is
+            // ordered, so the reader must pass it before anything fed later.
+            shell.feed(ATTACH_BLOCK)
+            // `events` is a replay-0 hot flow, so the collector above may not have
+            // subscribed yet. Re-feed the (idempotent, structural) notification
+            // until it is observed — a bounded, HARD-failing pump whose exit
+            // condition is the load-bearing signal that the reader has already
+            // consumed the attach `%begin`/`%end`.
+            withTimeout(RESPONSE_TIMEOUT_MS) {
+                while (!sessionChanged.isCompleted) {
+                    shell.feed("%session-changed \$0 issue1810\n")
+                    delay(20)
+                }
+            }
+            sessionChanged.await()
+
+            val enumeration = async {
+                client.sendChainedCommands(listOf(LIST_SESSIONS, LIST_PANES))
+            }
+            awaitWrittenLines(shell, expected = 2)
+            shell.feed("%begin 1785219223 306 1\n$SESSION_ROW\n%end 1785219223 306 1\n")
+            shell.feed("%begin 1785219223 307 1\n$PANE_ROW\n%end 1785219223 307 1\n")
+
+            val responses = withTimeout(RESPONSE_TIMEOUT_MS) { enumeration.await() }
+
+            assertEquals(listOf(SESSION_ROW), responses[0].output)
+            assertEquals(listOf(PANE_ROW), responses[1].output)
+        } finally {
+            client.close()
+        }
+    }
+
+    /**
+     * A single `sendCommand` is the same class of caller as the chained
+     * enumeration (G2): it registers one pending BEFORE writing, so it is
+     * equally exposed to the attach block in the late-arrival ordering.
+     */
+    @Test
+    fun attachBlockArrivingAfterASingleCommandMustNotStealItsResponse() = runBlocking {
+        val shell = FakeShell()
+        val client = RealTmuxClient(FakeSession(shell), scope, sessionName = "issue1810")
+        try {
+            client.connect()
+            awaitWrittenLines(shell, expected = 1)
+
+            val response = async { client.sendCommand(LIST_SESSIONS) }
+            awaitWrittenLines(shell, expected = 2)
+
+            shell.feed(ATTACH_BLOCK)
+            shell.feed("%begin 1785219223 306 1\n$SESSION_ROW\n%end 1785219223 306 1\n")
+
+            assertEquals(
+                listOf(SESSION_ROW),
+                withTimeout(RESPONSE_TIMEOUT_MS) { response.await() }.output,
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    /**
+     * Poll until the fake shell has seen [expected] newline-terminated writes.
+     * Bounded and hard-failing: the assertion is the loop's exit condition, never
+     * a fixed sleep (see AGENTS.md "wall-clock-bounded pump").
+     */
+    private suspend fun awaitWrittenLines(shell: FakeShell, expected: Int) {
+        withTimeout(WRITE_TIMEOUT_MS) {
+            while (shell.stdinAsString().count { it == '\n' } < expected) {
+                yield()
+                delay(5)
+            }
+        }
+    }
+
+    private class FakeSession(private val shell: SshShell) : SshSession {
+        @Volatile
+        private var closed = false
+
+        override val isConnected: Boolean get() = !closed
+
+        override fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean = true
+
+        override suspend fun exec(command: String): ExecResult =
+            error("exec not used in this test")
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            error("not used in this test")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used in this test")
+
+        override fun startShell(): SshShell {
+            check(!closed) { "session closed" }
+            return shell
+        }
+
+        override suspend fun uploadFile(file: java.io.File, remotePath: String): String =
+            error("not used in this test")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used in this test")
+
+        override fun close() {
+            closed = true
+            shell.close()
+        }
+    }
+
+    private class FakeShell : SshShell {
+        private val pipeOut = PipedOutputStream()
+        private val pipeIn = PipedInputStream(pipeOut, 64 * 1024)
+        private val stdinCapture = SynchronizedByteArrayOutputStream()
+
+        @Volatile
+        private var closed: Boolean = false
+
+        override val stdin: OutputStream = stdinCapture
+        override val stdout: InputStream = pipeIn
+        override val stderr: InputStream = object : InputStream() {
+            override fun read(): Int = -1
+        }
+
+        override fun close() {
+            if (closed) return
+            closed = true
+            runCatching { pipeOut.close() }
+            runCatching { pipeIn.close() }
+            runCatching { stdinCapture.close() }
+        }
+
+        fun feed(data: String) {
+            check(!closed) { "shell closed" }
+            pipeOut.write(data.toByteArray(StandardCharsets.UTF_8))
+            pipeOut.flush()
+        }
+
+        fun stdinAsString(): String = String(stdinCapture.snapshot(), StandardCharsets.UTF_8)
+    }
+
+    private class SynchronizedByteArrayOutputStream : ByteArrayOutputStream() {
+        override fun write(b: Int) {
+            synchronized(this) { super.write(b) }
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            synchronized(this) { super.write(b, off, len) }
+        }
+
+        fun snapshot(): ByteArray = synchronized(this) { toByteArray() }
+    }
+
+    private companion object {
+        /**
+         * tmux's answer to the attach command line itself — DCS-wrapped, EMPTY
+         * payload. Captured verbatim from the Docker `agents` fixture (tmux 3.6b).
+         */
+        const val ATTACH_BLOCK: String =
+            "\u001bP1000p%begin 1785219223 305 0\n%end 1785219223 305 0\n"
+
+        const val LIST_SESSIONS: String = "list-sessions -F '#{session_name}'"
+        const val LIST_PANES: String = "list-panes -a -F '#{session_name}'"
+        const val SESSION_ROW: String = "issue1810-session-row"
+        const val PANE_ROW: String = "issue1810-pane-row"
+
+        const val WRITE_TIMEOUT_MS: Long = 10_000L
+        const val RESPONSE_TIMEOUT_MS: Long = 15_000L
+    }
+}


### PR DESCRIPTION
Closes #1810

## This was filed as a flaky test. It is a shipped product defect.

`tmux -CC` answers the **attach command line itself** with an empty DCS-wrapped `%begin`/`%end` pair. `ControlModeParser` strips the DCS wrapper, so it parsed as a genuine `Begin`, and the reader's `%begin` branch popped `pendingQueue` **unconditionally**.

Whether that was harmless was **arrival-order luck**. Parsed late — a loaded reader draining both blocks in one batch — it steals the folder-list enumeration's slot. `list-sessions` then resolves **empty and non-error**.

The reviewer traced the consequence on the production path rather than accepting the claim: `FolderListGateway.kt:1744-1755` parses an empty non-error `list-sessions` into a **non-null `emptyList()`**, and `:502-505` returns it authoritatively while **skipping the SSH-lease fallback** — because `null` is the fallback signal and empty is not. `TmuxSessionViewModel.kt:9255` connects and issues `-CC` traffic in the same breath.

**So real users are exposed: an empty project tree until pull-to-refresh.** That is the "20 seconds of silence" the test observed — the app had already answered, wrongly, and there is no retry.

Captured from a failing run: `BEGIN number=281 matched=TRUE queueRemaining=1` / `END number=281 outputLines=0`, versus `matched=false` when it passes.

## Could a legitimate response block now be wrongly skipped?

This is the risk direction that matters — over-skipping would silently drop a real response, the same class of bug one level down. The reviewer verified it against **real tmux through a pty**, on both the Docker fixture's **3.6b** (the version connected tests actually talk to) and local **3.4**:

- Line 1 is `ESC P1000p%begin … 0` immediately followed by `%end` — empty payload, flags=0.
- **Every** legitimate command block afterwards carries no DCS prefix (flags=1).

tmux's `-CC` client prints `ESC P 1000 p` exactly once at stream start, and the closing `ESC \` is a *suffix*, so it cannot trip a prefix check. The only theoretical over-skip is a nested `ESC Ptmux;` wrapper, which is unreachable because `tmux new-session` refuses with `$TMUX` set. And the check **fails in the safe direction** — a missed marker degrades to the old behaviour, never dropping a real response.

## Evidence

- **JVM red→green, deterministic**: neutralising `hasDcsPreamble` in place (`cp` backup/restore, never `git checkout`) gives 2 of 3 FAIL — `expected:<[issue1810-session-row]> but was:<[]>`; restored gives 211/0/0 on **both** variants with the load-bearing class named in both XMLs.
- **Emulator base rate measured, not assumed**: 2 red in 14 runs = **14.3%**, both at 26.2/26.8s naming `await-window-count-2` with `observed Ready(sessions=[] refreshing=false)` — `kill-window-connect` never reached.
- **Emulator fixed: 22/22** by the reviewer, on top of the implementer's md5-verified **40/40** — **62 consecutive passes**, roughly 1-in-14,000 by luck at p=0.143. The implementer chose 40 rather than the 20 asked for, on the strength of its own measured rate.
- `:shared:core-tmux:integrationTest` **12/0** and `:shared:core-ssh:integrationTest` **51/0** — required because this changes a transport correlation contract, and those suites only run in the batched Docker job (#1144 → #1149).

## Design choices

The cheaper `staleResponseBlocksToIgnore += 1` variant was **rejected**: it broke 22 sibling tests and assumes tmux always volunteers exactly one attach block.

No retry was added on an empty enumeration — deliberately, because a retry would mask the next correlation bug rather than expose it. The reviewer endorsed that.

## G2

`FolderListOutOfBandSessionDockerTest` **shares the wedge** — reproduced on base at 26.721s with the identical signature, 12/12 after the fix. It is **not** wired into the journey suite, and the reviewer recommends wiring it **as a separate change** (it sits on the pre-existing `check-ci-journey-harness.sh:99` baseline, a gap this change did not create). I will file that.

`FolderListClientCacheInstantRenderDockerTest` is **independent** — still fails with this fix, at 4.7s, on a cold `TreeClientCache.peek` MISS. Filed as #1823.

## Orchestrator verification

Applied to a clean worktree off `main` (`8a6c04b5`). The candidate carries a large untracked `repro/` evidence tree alongside one untracked **source** file — I copied only `TmuxAttachResponseBlockCorrelationTest.kt` and deliberately excluded `repro/`, per the reviewer's merge note. Integrated tree is exactly 5 modified + 1 new, `git diff --check` clean.

Both variants re-run with `--rerun-tasks`: task lines unsuffixed, **211 executed / 0 failed / 0 skipped each**, zero stale XML against the run marker, and the new correlation test named in both.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb