### PR TITLE
test(projects): bind the folder-list VM on Main, as the screen does (#1823)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListClientCacheInstantRenderDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListClientCacheInstantRenderDockerTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.projects
 
+import android.os.Looper
 import androidx.lifecycle.ViewModelStore
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -46,6 +47,32 @@ import java.io.FileOutputStream
  * 2. The silent reconcile against the LIVE Docker `agents` fixture then converges
  *    the tree on the authoritative session set (the cached session is confirmed),
  *    proving the cache is ADVISORY, not the source of truth.
+ *
+ * ## Issue #1823 — `bind` + the first-frame capture MUST run on the Main thread
+ *
+ * [FolderListViewModel] is Main-confined: its `viewModelScope` is
+ * `Dispatchers.Main.immediate`, `applyReadyProjection` writes `_state` and is
+ * documented "Must run on Main", and the ONE production caller is
+ * `FolderListScreen`'s `LaunchedEffect { viewModel.bind(...) }` — the Main thread.
+ * The instant render is only an invariant under that confinement, because the
+ * synchronous cold seed's `++emitGeneration` … `buildProjection` … staleness-check
+ * sequence is atomic only when nothing else can run on Main meanwhile.
+ *
+ * This test used to call `bind` from the INSTRUMENTATION thread, so the view
+ * model's own Main-dispatched coroutines ran CONCURRENTLY with that sequence. When
+ * the `init` block's `forwardingController.flowOfHostSnapshots()` collector landed
+ * its `emitReady()` inside the ~1 ms window, it bumped `emitGeneration` first, the
+ * synchronous seed then saw its own generation as stale and DISCARDED its
+ * projection, and `_state` stayed `Loading` — a first frame the real screen can
+ * never see. Measured over 120 consecutive cold binds: 28 `Loading` first frames
+ * off Main (23%) versus 0 on Main; the client-cache `peek` HIT on every one of
+ * them, so the failure was never a cold cache.
+ *
+ * So the bind + capture below runs inside `runOnMainSync`, exactly as the sibling
+ * [FolderListScaleAnrStrictModeDockerTest] does and exactly as the screen does.
+ * The assertion is unchanged and NOT weakened: it is still the FIRST state after
+ * `bind`, with no wait, no retry and no widened bound — just observed on the
+ * thread the screen actually composes on.
  *
  * Docker service: `agents` on host port `2222` (the standard journey fixture the
  * `emulator-journey` CI workflow already starts), so this runs on CI with no new
@@ -188,20 +215,43 @@ class FolderListClientCacheInstantRenderDockerTest {
         // A FRESH view model = a cold app start. Bind the cached host.
         val vm = newViewModel()
         vm.setProcessStartedForTest(true)
-        vm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
 
-        // LOAD-BEARING: the FIRST state after bind (before any SSH round-trip) is
-        // already Ready with the cached session — the instant render. The
-        // pre-#867 behaviour would be Loading here (the empty rebuild flash).
-        val firstState = vm.state.value
+        // Issue #1823: drive `bind` and capture the FIRST state on the MAIN thread,
+        // exactly as `FolderListScreen`'s `LaunchedEffect` does in production (and
+        // as the sibling FolderListScaleAnrStrictModeDockerTest already does). Off
+        // Main the view model's own Main-dispatched coroutines interleave with
+        // bind's synchronous cold seed and can discard it as stale — a first frame
+        // the real screen can never observe. See this class's KDoc.
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val capturedOnMain = arrayOfNulls<FolderListUiState>(1)
+        val captureThreadWasMain = booleanArrayOf(false)
+        instrumentation.runOnMainSync {
+            captureThreadWasMain[0] = Looper.myLooper() === Looper.getMainLooper()
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+            // LOAD-BEARING: the FIRST state after bind (before any SSH round-trip)
+            // is already Ready with the cached session — the instant render. The
+            // pre-#867 behaviour would be Loading here (the empty rebuild flash).
+            // Captured INSIDE the same Main runnable as `bind`, so this really is
+            // the first frame the screen would compose, not a later one.
+            capturedOnMain[0] = vm.state.value
+        }
+        // HARD guard (never a skip): if this ever stops running on Main the
+        // instant-render assertion below is no longer the invariant it claims to
+        // test, so fail loudly instead of measuring a race (issue #1823).
+        assertTrue(
+            "the instant-render capture must run on the Main thread (production " +
+                "binds from FolderListScreen's LaunchedEffect) — issue #1823",
+            captureThreadWasMain[0],
+        )
+        val firstState = capturedOnMain[0]!!
         assertTrue(
             "cold connect must render the cached tree INSTANTLY (Ready, not the " +
                 "Loading rebuild flash) — state=$firstState",


### PR DESCRIPTION
Closes #1823

## The issue title was wrong — the cache never missed

I filed this as a cold `TreeClientCache.peek` MISS. It isn't. Across 160+ instrumented cold binds the peek hit every time (`hydrate MISS` count = **0**).

The reviewer went further and proved it **structurally** rather than trusting the tally: `TreeClientCache.parsed` is a `ConcurrentHashMap` (`:107`), `write` populates it synchronously for a non-empty tree (`:181-189`), `peek` is a pure map read (`:132`), and the test calls `cache.write(...)` on the **same instance it injects**, before `bind`. A MISS is **unreachable in this test**, not merely rare.

## The real mechanism

The test drove a **Main-confined ViewModel from the instrumentation thread**, so `bind()`'s synchronous cold seed raced the VM's own Main-dispatched coroutines and discarded itself as stale:

```
12.048 [Instr thread] emitReady enter sync=true bound=true snap=true gen=0
12.049 [main  thread] emitReady enter sync=false ... <- FolderListViewModel.kt:669
12.049 [Instr thread] emitReady SYNC-DROPPED myGen=1 nowGen=2 bound=true
```

`emitReady(synchronous = true)` does `++emitGeneration`, computes the projection, then re-checks the counter. **On Main that sequence is atomic; off Main it is not** — the `init` block's `flowOfHostSnapshots()` collector bumps the counter inside a ~1 ms window, `applyReadyProjection` never runs, and `_state` stays `Loading`. Ten `SYNC-DROPPED` events, ten `Loading` first frames.

**Production cannot reach it.** The only `bind(` caller in `app/src/main` is `FolderListScreen.kt:209` inside a `LaunchedEffect`. The reviewer additionally traced the enclosing scope of **all 21** `emitReady(` call sites — every one is a non-suspend VM method or a `viewModelScope.launch`, including the one inside `suspend fun runReconcile`, whose `withContext(ioDispatcher)` wraps only the DAO read and whose sole caller is a `viewModelScope.launch`. No off-Main writer of `emitGeneration` exists.

And the correct pattern was already established next door: `FolderListScaleAnrStrictModeDockerTest:171` does `runOnMainSync { vm.bind(…) }` with the comment *"drive the REAL bind() on Main, exactly as the screen's LaunchedEffect does"*. This class simply did not follow it.

## Determinism by pinning extremes, not sampling

The outcome is **monotonic** in "can a Main-dispatched `emitReady` land inside the window", so both extremes were pinned rather than sampled:

- implementer: off-Main **10/40** and **28/120** fail (23–25%); on-Main **0/40**, **0/120**
- reviewer, independently: off-Main **12/120** RED; on-Main **0/120** GREEN; fixed class **12/12** clean, each run audited for cache suffixes and `Starting`/`Finished 1 tests`

The reviewer justified the method more strongly than the implementer did: the on-Main arm is deterministic **by construction**, not merely observed at 0/120 — `buildProjection` is a non-suspend pure function and `bind` is non-suspend, so `++emitGeneration → buildProjection → re-check` is straight-line single-threaded code with no interleaving point.

## Not vacuous

A fix that moves `bind` onto Main could pass simply by no longer exercising anything, so both sides mutated. The implementer forced the #1109 regression in `hydrateFromClientCache`, proved the mutant live via logcat, and the fixed test went RED with the exact reported message. The reviewer ran its **own** live mutation (`Ps1823RevMut`, confirmed in logcat) with the same result. Restores verified by md5 and empty `git diff --stat`.

**Stated plainly by the reviewer as what it could NOT produce:** 25 runs of the reverted shipped class yielded 0 reproductions — underpowered at the ~10% per-run base rate, consistent with the implementer's own report rather than contradicting it.

## Scope

**Test-only, one file.** `bind` and the first-state capture move into a single `runOnMainSync` block, plus a hard "this ran on Main" guard and a KDoc. No bound widened, no retry added, no assertion relaxed — one assertion **added**.

## Flagged, deliberately not fixed here

`FolderListViewModel`'s Main confinement is enforced by nothing — no `@MainThread`, no assertion, `emitGeneration` a non-`volatile` `Long`. Filed as #1829, with the reviewer's sharpening: a bare `@MainThread` would **not** have caught this (lint does not flag instrumentation-thread callers), and `@Volatile` would be **actively misleading** since the defect is check-then-act, not visibility. Real enforcement is a runtime `Looper` assertion — a production change needing its own red→green. It also found **six sibling classes bind off Main**, safe only because they assert eventual convergence; the first synchronous assertion added to any of them brings this back.

## Merge hazard, avoided

`process.md`'s "copy every untracked file" rule would have swept in the candidate's `repro/` evidence tree. It is evidence, not deliverable — the merge is exactly **one tracked file, zero untracked**, verified before applying.

## Orchestrator verification

Applied to a clean worktree off `main` (`8a6c04b5`); one modified file, no untracked residue, `git diff --check` clean. `:app:compileDebugAndroidTestKotlin` re-run with `--rerun-tasks -Dorg.gradle.caching=false` (not accepting a `FROM-CACHE` hit): 176/176 executed, `BUILD SUCCESSFUL`. Test-validity, journey-harness, file-size hygiene, and VM-ratchet guards all exit 0.

The full JVM gate is deliberately skipped and the reviewer ruled that correct: CI's `Unit tests` job runs `./gradlew test`, which compiles `main` + unit `test` only — `androidTest` is not in that graph, and this diff touches exactly one `androidTest` file.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb