### PR TITLE
ci(journey): make the suite budget clock injectable so (c2) is deterministic (#1839)

### DIFF
--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -1,9 +1,55 @@
 #!/usr/bin/env bash
 # Budget and bounded-run helpers for scripts/ci-journey-suite.sh.
 
+# ---------------------------------------------------------------------------
+# The suite-budget clock seam (issue #1839).
+#
+# Production measures elapsed suite time with bash's `$SECONDS`, which advances
+# in whole INTEGER seconds. That is fine for the real 4200s budget, but it made
+# the guard that drives a tiny budget (scripts/test-ci-journey-summary-evidence.sh
+# `(c2)`) flaky-BY-CONSTRUCTION: with a 1s budget the verdict hinged on whether a
+# `$SECONDS` tick happened to land in the sub-second window between SUITE_START
+# and the first `budget_exhausted` check. Whether that tick lands is a property
+# of the MACHINE, not of the budget logic — the hosted runner lost it 2/2 (red
+# `main` @ ae368467, run 30368416112) while the contended dev box won it 5/5 on
+# the identical commit.
+#
+# The cure is a pinnable seam, not a bigger number (process.md: "the tuning knob
+# must be injectable/seedable so tests are deterministic while production keeps
+# real randomness — never widen the assertion into a band that no longer
+# constrains behaviour", G6). `JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE` pins the
+# elapsed reading so a budget test is decided by the budget ARITHMETIC alone, on
+# any hardware, at either extreme of the tick.
+#
+# Safety, because a pinned clock that leaked into production would silently
+# DISABLE the #835 budget:
+#   * It is validated HERE, once, at source time in the suite's own shell — a
+#     malformed value is a hard `exit 2`, never a silently ignored override
+#     (`budget_remaining` runs inside `$(...)`, where an exit could only kill the
+#     subshell and would read as "not exhausted").
+#   * scripts/test-ci-journey-budget.sh asserts the production default path still
+#     measures `$SECONDS - SUITE_START`, and that neither the workflow nor the
+#     suite ever sets the override.
+if [[ -n "${JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE:-}" ]]; then
+  if [[ ! "${JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE}" =~ ^[0-9]+$ ]]; then
+    echo "JOURNEY_BUDGET_CLOCK_INVALID: JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE='${JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE}' is not a non-negative integer — refusing to run with an unreadable suite-budget clock (issue #1839)" >&2
+    exit 2
+  fi
+fi
+
+# journey_budget_elapsed — seconds of suite budget consumed so far.
+journey_budget_elapsed() {
+  if [[ -n "${JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE:-}" ]]; then
+    printf '%s\n' "$JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE"
+    return 0
+  fi
+  printf '%s\n' "$((SECONDS - SUITE_START))"
+}
+
 # budget_remaining — seconds left in the suite-level budget (never negative).
 budget_remaining() {
-  local elapsed=$((SECONDS - SUITE_START))
+  local elapsed
+  elapsed="$(journey_budget_elapsed)"
   local remaining=$((JOURNEY_STEP_BUDGET_SECS - elapsed))
   (( remaining < 0 )) && remaining=0
   echo "$remaining"

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -187,6 +187,52 @@ fi
 pass "(pre-1458) raw console-count classifier + classifier-only capture plumbing are absent"
 
 # ---------------------------------------------------------------------------
+# Issue #1839: the suite-budget clock seam must stay TEST-ONLY.
+#
+# `JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE` exists so a budget assertion is decided
+# by the budget arithmetic instead of by whether an integer `$SECONDS` tick
+# happened to land (the flaky-by-construction `(c2)` that reddened `main` at
+# ae368467). A pinned clock that reached PRODUCTION would silently disable the
+# whole #835 budget, so pin three things mechanically:
+#   * the production default path still measures `$SECONDS - SUITE_START`;
+#   * the override is validated (a malformed pin is a hard abort, never ignored);
+#   * neither the workflow nor the suite itself ever SETS the override.
+BUDGET_FUNCTIONS="$SCRIPT_DIR/ci-journey-budget-functions.sh"
+[[ -f "$BUDGET_FUNCTIONS" ]] || fail "(pre-1839) cannot find ci-journey-budget-functions.sh"
+grep -q 'printf .%s\\n. "\$((SECONDS - SUITE_START))"' "$BUDGET_FUNCTIONS" \
+  || fail "(pre-1839) the production suite-budget clock must still measure \$SECONDS - SUITE_START"
+grep -q 'JOURNEY_BUDGET_CLOCK_INVALID' "$BUDGET_FUNCTIONS" \
+  || fail "(pre-1839) a malformed JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE must abort, not silently disable the #835 budget"
+if grep -qE '^[^#]*JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE=' "$WORKFLOW" "$REAL_SUITE"; then
+  fail "(pre-1839) the suite-budget clock override is TEST-ONLY — it must never be set by tests.yml or the suite"
+fi
+# The seam is load-bearing only if the override actually governs. Drive the real
+# helper at both extremes of the exhaustion boundary, with no wall clock involved.
+budget_clock_probe() {
+  JOURNEY_STEP_BUDGET_SECS=900 JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE="$1" \
+    bash -c 'source "$0"; SUITE_START=$SECONDS; budget_exhausted && echo exhausted || echo live' \
+    "$BUDGET_FUNCTIONS"
+}
+[[ "$(budget_clock_probe 0)" == "live" ]] \
+  || fail "(pre-1839) pinned elapsed=0 of 900s must NOT be exhausted"
+[[ "$(budget_clock_probe 900)" == "exhausted" ]] \
+  || fail "(pre-1839) pinned elapsed=900 of 900s must be exhausted (the boundary is <= 0 remaining)"
+[[ "$(budget_clock_probe 901)" == "exhausted" ]] \
+  || fail "(pre-1839) pinned elapsed beyond the budget must be exhausted"
+# BEHAVIOURAL, not just a grep for the message: a malformed pin must ABORT the
+# sourcing shell with exit 2. A structural grep alone survives a mutation that
+# guts the validation while leaving its error string in place.
+budget_clock_invalid_out="$(mktemp)"
+budget_clock_probe not-a-number > "$budget_clock_invalid_out" 2>&1
+invalid_rc=$?
+[[ "$invalid_rc" -eq 2 ]] \
+  || { cat "$budget_clock_invalid_out"; fail "(pre-1839) a malformed budget-clock pin must abort with exit 2, got $invalid_rc"; }
+grep -q 'JOURNEY_BUDGET_CLOCK_INVALID' "$budget_clock_invalid_out" \
+  || { cat "$budget_clock_invalid_out"; fail "(pre-1839) a malformed budget-clock pin must abort greppably"; }
+rm -f "$budget_clock_invalid_out"
+pass "(pre-1839) suite-budget clock: production reads \$SECONDS, the test-only pin governs at 0/900/901, a malformed pin aborts (exit 2), and it is never set in tests.yml or the suite"
+
+# ---------------------------------------------------------------------------
 # Build a sandbox "repo root": a copy of the suite script + a stub gradlew that
 # SLEEPS (modelling a #470-stalling class) + stub scripts the suite shells out
 # to. REPO_ROOT in the suite is derived from BASH_SOURCE, so we run the COPY

--- a/scripts/test-ci-journey-summary-evidence.sh
+++ b/scripts/test-ci-journey-summary-evidence.sh
@@ -534,21 +534,88 @@ run_classify_step "$ws" "$(classify_expressions failure "$FIRST_TIMEOUT" "$FIRST
 pass "(c1) FAILED_CLASSES -> failed-both section -> first_failure=true -> RED [$first_class]"
 
 # (c2) The #835 suite-budget timeout: its own JOURNEY_STEP_TIMEOUT evidence.
-ws="$SANDBOX/budget-timeout"
-make_workspace "$ws"
-JOURNEY_STEP_BUDGET_SECS_OVERRIDE=1 run_real_suite "$ws"
-[[ "$SUITE_RC" -ne 0 ]] || fail "(c2) an exhausted suite budget must redden the suite"
+#
+# DETERMINISM (issue #1839). This case used to drive the real suite with a
+# ONE-SECOND budget and rely on bash's INTEGER `$SECONDS` having ticked before
+# the suite's first `budget_exhausted` check. Whether that tick lands is a
+# property of the MACHINE, not of the budget logic:
+#
+#   budget=1s elapsed=0s remaining=1s => NOT exhausted -> suite exits 0 -> FAIL
+#   budget=1s elapsed=1s remaining=0s => EXHAUSTED     -> suite RED     -> pass
+#
+# and `run_real_suite` pins POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=400 so exactly ONE
+# class is selected — there is no second loop iteration to catch the budget
+# later, making a single missed tick terminal. The hosted runner lost that race
+# 2/2 (red `main` @ ae368467) while the dev box won it 5/5 on the identical
+# commit. A guard whose whole purpose is to stop the gate reporting false greens
+# was itself flaky-by-construction.
+#
+# The budget clock is now a pinnable seam (`JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE`,
+# scripts/ci-journey-budget-functions.sh), so elapsed time is INJECTED rather
+# than raced. The budget is NOT widened — widening only narrows the same race
+# (G6). `budget_exhausted` is monotone in elapsed, so pinning BOTH extremes plus
+# the exact boundary covers the whole distribution — strictly stronger than N
+# sampled runs. The complementary "budget burns down over real wall time and
+# trips mid-loop" shape is covered end-to-end by scripts/test-ci-journey-budget.sh,
+# whose stub gradle `sleep`s are a hard FLOOR (faster hardware cannot lose it).
+BUDGET_CLOCK_BUDGET_SECS=900
+
+# run_budget_clock_arm <workspace> <pinned-elapsed-secs>
+run_budget_clock_arm() {
+  local ws="$1" elapsed="$2"
+  make_workspace "$ws"
+  JOURNEY_STEP_BUDGET_SECS_OVERRIDE="$BUDGET_CLOCK_BUDGET_SECS" \
+    run_real_suite "$ws" JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE="$elapsed"
+}
+
+# (c2a) elapsed = 0 — the MINIMUM extreme, i.e. the "no tick landed" arm the
+#       hosted runner deterministically hit. The budget is NOT spent, so the
+#       suite must stay green and write NO timeout evidence. This turns the
+#       losing side of the old coin flip into an explicit assertion, and it is
+#       what makes (c2b)/(c2c) discriminating rather than vacuous (G6).
+ws="$SANDBOX/budget-clock-unexhausted"
+run_budget_clock_arm "$ws" 0
+[[ "$SUITE_RC" -eq 0 ]] \
+  || { sed -n '1,40p' "$ws/suite.log"; fail "(c2a) elapsed=0 of a ${BUDGET_CLOCK_BUDGET_SECS}s budget is NOT exhausted, but the suite exited $SUITE_RC"; }
 grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$ws/artifacts/ci-journey/summary.md" \
-  || { cat "$ws/artifacts/ci-journey/summary.md"; fail "(c2) no JOURNEY_STEP_TIMEOUT evidence for a budget timeout"; }
+  && { cat "$ws/artifacts/ci-journey/summary.md"; fail "(c2a) an unspent budget must write NO timeout evidence"; }
 run_journey_summary_step "$ws"
-[[ "$FIRST_TIMEOUT" == "true" ]] || fail "(c2) first_timeout=$FIRST_TIMEOUT, expected true"
-run_classify_step "$ws" "$(classify_expressions failure "$FIRST_TIMEOUT" "$FIRST_FAILURE")"
-[[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_RC" -ne 0 ]] \
-  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(c2) a #835 budget timeout must stay a hard RED, got '$CLASSIFY_TOKEN'"; }
-aggregate_with "$CLASSIFY_TOKEN"
-[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
-  || { printf '%s\n' "$AGG_OUT"; fail "(c2) expected aggregate RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
-pass "(c2) #835 budget timeout -> JOURNEY_STEP_TIMEOUT -> first_timeout=true -> RED (unchanged)"
+[[ "$FIRST_TIMEOUT" == "false" ]] || fail "(c2a) first_timeout=$FIRST_TIMEOUT, expected false"
+pass "(c2a) pinned elapsed=0s of ${BUDGET_CLOCK_BUDGET_SECS}s -> not exhausted -> green, no timeout evidence"
+
+# (c2b) elapsed = budget — the EXACT exhaustion boundary (`remaining <= 0`), and
+#       (c2c) elapsed > budget — beyond it, through the negative-clamp. Both must
+#       produce the #835 hard RED with classifier-readable evidence.
+for arm in "boundary:$BUDGET_CLOCK_BUDGET_SECS:c2b" \
+           "beyond:$((BUDGET_CLOCK_BUDGET_SECS + 1)):c2c"; do
+  IFS=':' read -r arm_name arm_elapsed arm_id <<<"$arm"
+  ws="$SANDBOX/budget-clock-$arm_name"
+  run_budget_clock_arm "$ws" "$arm_elapsed"
+  [[ "$SUITE_RC" -ne 0 ]] \
+    || { sed -n '1,40p' "$ws/suite.log"; fail "($arm_id) an exhausted suite budget must redden the suite (pinned elapsed=${arm_elapsed}s of ${BUDGET_CLOCK_BUDGET_SECS}s)"; }
+  grep -qE 'JOURNEY_STEP_TIMEOUT|Suite step time budget exhausted' "$ws/artifacts/ci-journey/summary.md" \
+    || { cat "$ws/artifacts/ci-journey/summary.md"; fail "($arm_id) no JOURNEY_STEP_TIMEOUT evidence for a budget timeout"; }
+  run_journey_summary_step "$ws"
+  [[ "$FIRST_TIMEOUT" == "true" ]] || fail "($arm_id) first_timeout=$FIRST_TIMEOUT, expected true"
+  run_classify_step "$ws" "$(classify_expressions failure "$FIRST_TIMEOUT" "$FIRST_FAILURE")"
+  [[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_RC" -ne 0 ]] \
+    || { printf '%s\n' "$CLASSIFY_OUT"; fail "($arm_id) a #835 budget timeout must stay a hard RED, got '$CLASSIFY_TOKEN'"; }
+  aggregate_with "$CLASSIFY_TOKEN"
+  [[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+    || { printf '%s\n' "$AGG_OUT"; fail "($arm_id) expected aggregate RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+  pass "($arm_id) pinned elapsed=${arm_elapsed}s of ${BUDGET_CLOCK_BUDGET_SECS}s ($arm_name) -> JOURNEY_STEP_TIMEOUT -> first_timeout=true -> RED (unchanged)"
+done
+
+# (c2d) The seam must not be able to DISABLE the budget silently: a malformed
+#       pin is a hard, greppable abort, not an ignored override.
+ws="$SANDBOX/budget-clock-invalid"
+make_workspace "$ws"
+run_real_suite "$ws" JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE=not-a-number
+[[ "$SUITE_RC" -eq 2 ]] \
+  || { sed -n '1,20p' "$ws/suite.log"; fail "(c2d) a malformed budget-clock pin must abort with exit 2, got $SUITE_RC"; }
+grep -q 'JOURNEY_BUDGET_CLOCK_INVALID' "$ws/suite.log" \
+  || { sed -n '1,20p' "$ws/suite.log"; fail "(c2d) a malformed budget-clock pin must say so greppably"; }
+pass "(c2d) a malformed JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE aborts the suite instead of disabling the #835 budget"
 
 # ---------------------------------------------------------------------------
 # (d) The FAIL-SAFE backstop: a red suite whose summary carries no


### PR DESCRIPTION
Closes #1839 · **unblocks `main` and every open PR**

## Blast radius

The #1827 red-evidence guard runs at `tests.yml:303-304` inside the **`unit` job** — one of the two *required* per-PR checks. So this reddened `main` **and every open PR regardless of what it changed**. PR #1841 and #1820's forthcoming PR are both stuck behind it.

## The defect

`(c2)` drove the real suite with a **1-second** budget while `budget_exhausted()` measures elapsed with bash's **integer `$SECONDS`**:

```
budget=1s elapsed=0s => NOT exhausted -> suite exits 0 -> (c2) FAILS
budget=1s elapsed=1s => EXHAUSTED     -> suite RED     -> (c2) PASSES
```

`run_real_suite` sets `SHARD_TOTAL=400`, so the sandbox runs exactly **one** class — no second loop iteration to catch the budget later, so one missed tick is terminal. The CI log confirms it: `run_real_suite` returned in **under a second** with `SUITE_RC=0`, i.e. the suite exited without launching a class at all.

Hosted runner **2/2 RED**, dev box **5/5 green** on the identical commit. That environment split is why my own pre-merge gate passed it — **a local green could not have caught a race that only loses on faster hardware**, which is worth recording as a gap in how I verify shell guards.

## The fix

`budget_remaining` now reads through a new `journey_budget_elapsed`, returning `$SECONDS - SUITE_START` in production and a **pinned integer** under `JOURNEY_BUDGET_ELAPSED_SECS_OVERRIDE`. **No budget widened** — the 4200s/420s defaults are untouched and still pinned by the warm-build guard's `ac2`. Widening to 2s was explicitly rejected: it narrows the same race rather than removing it (G6).

Three deterministic arms replace the coin flip — elapsed 0 (green, the arm the runner deterministically hit), 900 (boundary → RED), 901 (beyond → RED) — plus `(c2d)` asserting that a **malformed pin aborts** rather than silently disabling the #835 budget. A silently-disabled budget is exactly the vacuous-guard shape this repo keeps rediscovering.

## Reviewer verification

**No arm reads a wall clock — proven by behaviour, not grep.** It preserved the sandbox and read the boundary arm's own `suite.log`: **0 journey classes launched, 0 core-terminal proofs launched**, `JOURNEY_WARM_BUILD_SKIPPED: no suite budget remains`, 11 `JOURNEY_STEP_TIMEOUT` markers. Nothing spawns `timeout(1)` in the exhausted arms, so there is no quantity a faster CPU can change. The contrast workspace launched 10 stages and went green.

**Production path genuinely unchanged**, confirmed empirically rather than by reading: `SECONDS` survives the added nested command substitution (bash inherits it into subshells) — elapsed reads 0/2/5 in real time and `budget_exhausted` flips at the right boundary. Nothing outside the two test scripts sets the override.

**Three mutants, each proven live, all killed** — and one deserves naming. **M2′** was built specifically to defeat the guard's *structural* greps: it guts the seam while leaving both the production `printf` line and the `JOURNEY_BUDGET_CLOCK_INVALID` string in place. Both greps still passed; only the **behavioural** probe killed it. Likewise M1's kill lands on `first_timeout=false, expected true` — the `JOURNEY_STEP_TIMEOUT` grep and the `SUITE_RC != 0` check both still passed under M1, so only the classifier-visible signal caught it. That is G6 satisfied on evidence rather than wording.

**RED reproduced twice**: by reverting the fix in a scratch tree, and end-to-end on pristine `origin/main` with the threshold shifted, producing **character-for-character** `TEST FAIL: (c2) an exhausted suite budget must redden the suite`.

## No second repo-wide blocker

I asked specifically whether another `unit`-job guard shares this shape. Clock-read census across all eight: **six have zero live clock reads**; `budget.sh` has four (three exit-code-only fixtures plus `wedge_elapsed`, labelled and confirmed never asserted). Every other timing dependency is a `sleep` — a hard **floor**, so faster hardware cannot lose it.

The reviewer added a correction in the implementer's favour on the one residual: `first_remaining <= 900 - COLD_SECS` *looks* like an upper bound but is a **floor in disguise** (it requires `elapsed >= 6`, and `floor(a+6) − floor(a) ∈ {6,7}`). Only two genuine upper bounds remain, both measuring a *warm* stub class, so a faster runner drives them toward 0 and widens the margin — contended-box direction only. Filed as a follow-up, not a blocker.

## Orchestrator verification

Applied to a clean worktree off `main` (`ae368467`); three modified files, no untracked residue, `tests.yml` untouched, `git diff --check` clean.

**The guard that is currently blocking `main` now passes**, and every sibling guard stays green on the integrated tree: infra-signature, aggregate-verdict, warm-build, budget, artifact-packaging, retry-budget, plus `check-ci-journey-harness` and `check-test-validity`.

The disclosed exit-143 discard was legitimate — the reviewer re-ran `check-test-validity-selftest.sh` itself to a real 51/0.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb