### PR TITLE
test(proof): pin the folder-list screen by tag, not a title string that moved (#1837)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdInstallE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdInstallE2eTest.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -31,6 +32,8 @@ import com.pocketshell.app.hosts.HOST_LIST_EMPTY_STATE_TAG
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SETTINGS_BUTTON_TAG
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
+import com.pocketshell.app.projects.FOLDER_LIST_TITLE_TAG
 import com.pocketshell.app.settings.ABOUT_FOOTER_TAG
 import com.pocketshell.app.settings.ABOUT_VERSION_TAG
 import com.pocketshell.app.settings.AppSettings
@@ -260,14 +263,33 @@ class ColdInstallE2eTest {
         // ---------------------------------------------------------------
         // Phase 5 — wait for the folder list (issue #171) to mount with
         // the pre-seeded session row visible inline under its folder
-        // header, then tap the session to attach. The screen title is
-        // "Folders" — the post-tap surface flipped from the picker
-        // sheet to FolderListScreen.
+        // header, then tap the session to attach. The post-tap surface
+        // flipped from the picker sheet to FolderListScreen.
+        //
+        // Issue #1837: this used to wait on the literal screen title
+        // "Folders". `FolderListScreen` stopped rendering that word on
+        // 2026-06-01 (commit 26592101, "Align project tree with compact
+        // mockup", #396) when the header became `title = hostName` with a
+        // "Flat projects"/"Workspace roots" subtitle — so the wait timed
+        // out for ~2 months and both release-gate journeys were red for a
+        // stale reason. Product copy is free to change; a journey must not
+        // be pinned to it. We now assert the two things this step actually
+        // guards, both on durable affordances:
+        //
+        //   1. [FOLDER_LIST_SCREEN_TAG] — the post-tap surface really is
+        //      FolderListScreen (what the literal title was a proxy for).
+        //   2. [FOLDER_LIST_TITLE_TAG] carries `hostName` — we landed on
+        //      the folder list of the host we just tapped, not a stale or
+        //      wrong host. `hostName` is data THIS test supplies, so no
+        //      copy rename can invalidate it, and this is strictly
+        //      stronger than the constant word it replaces.
         // ---------------------------------------------------------------
         compose.waitUntil(timeoutMillis = 30_000) {
-            compose.onAllNodesWithText("Folders", useUnmergedTree = true)
+            compose.onAllNodesWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true)
                 .fetchSemanticsNodes().isNotEmpty()
         }
+        compose.onNodeWithTag(FOLDER_LIST_TITLE_TAG, useUnmergedTree = true)
+            .assertTextEquals(hostName)
         compose.waitUntil(timeoutMillis = 20_000) {
             compose.onAllNodesWithText(sessionName, useUnmergedTree = true)
                 .fetchSemanticsNodes().isNotEmpty()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorWorkflowE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorWorkflowE2eTest.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -23,6 +24,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
+import com.pocketshell.app.projects.FOLDER_LIST_TITLE_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -194,15 +197,28 @@ class EmulatorWorkflowE2eTest {
         }
         compose.onNodeWithText(hostName, useUnmergedTree = true).assertExists()
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        // Issue #171: the post-tap surface is now the FolderListScreen,
-        // titled "Folders". Sessions render inline as visible
-        // SessionRow nodes under their folder header so callers can
-        // tap a session by its name directly.
+        // Issue #171: the post-tap surface is now the FolderListScreen.
+        // Sessions render inline as visible SessionRow nodes under their
+        // folder header so callers can tap a session by its name directly.
+        //
+        // Issue #1837: this used to wait on the literal screen title
+        // "Folders", which `FolderListScreen` stopped rendering on
+        // 2026-06-01 (commit 26592101, "Align project tree with compact
+        // mockup", #396) when the header became `title = hostName`. The
+        // wait then timed out for ~2 months. We assert the two properties
+        // this step actually guards, on durable affordances instead of
+        // product copy: [FOLDER_LIST_SCREEN_TAG] proves the post-tap
+        // surface IS FolderListScreen, and [FOLDER_LIST_TITLE_TAG] equal
+        // to `hostName` proves it is the folder list of the host row we
+        // just tapped (`hostName` is data this test supplies, so a copy
+        // rename cannot invalidate it).
         compose.waitUntil(timeoutMillis = 20_000) {
-            compose.onAllNodesWithText("Folders", useUnmergedTree = true)
+            compose.onAllNodesWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+        compose.onNodeWithTag(FOLDER_LIST_TITLE_TAG, useUnmergedTree = true)
+            .assertTextEquals(hostName)
     }
 
     private fun waitForPickerAction(text: String) {


### PR DESCRIPTION
Closes #1837

## The defect

`ColdInstallE2eTest` and `EmulatorWorkflowE2eTest` — both **release-gate** journeys — waited on a literal `"Folders"` title that `FolderListScreen` stopped rendering on **2026-06-01** (`26592101`, "Align project tree with compact mockup", Closes #396). It now sets `title = hostName`.

The assertions were introduced five days earlier in `3c83f2bd`. **Valid for 5 days, stale for ~8 weeks.**

A test failing for a stale reason is worse than a missing test, because it looks like coverage. Both now pin `FOLDER_LIST_SCREEN_TAG` plus `FOLDER_LIST_TITLE_TAG == hostName`.

## Strictly stronger, proven rather than argued

The reviewer ran a fourth case the implementer had not: **the old assertions against the M2 mutant** (title reverted to the literal `"Folders"`). The old wait **passes**, and the failure frame moves from `:267` to `:327` — 60 lines deeper into the journey.

So the regression the new assertion kills is one the old assertion sails straight through. "Strictly stronger, not merely renamed" is now empirical.

It also proved M2's mutant live **on device** rather than from a compile-task line: the failure's own semantics dump reads `Tag: 'folder-list:title'  Text = '[Folders]'`.

Base reproduction, reviewer-run on a private fixture:
```
ComposeTimeoutException after 30000 ms  @ ColdInstallE2eTest.kt:267
ComposeTimeoutException after 20000 ms  @ EmulatorWorkflowE2eTest.kt:201
tests="2" failures="2" skipped="0"
```
`ColdInstall` then green **4/4** across four independent runs, load-bearing method named in every XML.

## What fixing it exposed

`EmulatorWorkflowE2eTest` now runs *past* the folder list and into a **second, unrelated, pre-existing defect**: exactly one character is dropped from a typed terminal command, and the byte never reaches the remote (confirmed by watching the fixture container's own tmux pane independently of the app). Filed as **#1845**.

**`ColdInstall` is exposed to it too** — a mutant run died on `sh: tf: not found`, with `printf` arriving as `tf`, a multi-character drop of the same class. It was simply lucky across the four unmutated runs.

So `EmulatorWorkflowE2eTest` remains red here, deliberately. Its #1837 defect is fixed; making it green would require relaxing its echo assertion, and dropped input **is** the defect (G6, and this issue's explicit non-goal).

## Why neither class ever reported this

- Both are `KNOWN_UNWIRED` — not in the per-push allowlist, nightly-extensive phase 1 only.
- `ColdInstall` has genuinely been red there since 1 June — but the reviewer found **phase 1 is labelled non-gating**, so its redness never blocked anything.
- `EmulatorWorkflow` has not been red at all: it has been **skipping**. Nightly passes `pocketshellCi=true` and the class opens with `Assume.assumeFalse(isRunningOnCi())`. Confirmed from two nightly run logs (today's and 19 June), not from the report.

That self-skip is the F3 anti-pattern `process.md` bans. Its removal is scoped to #1845 rather than smuggled in here.

## G2

707 literal-UI-string sites across 461 literals and 123 files; the actionable cut is **59 positive `waitUntil` gates on a literal**, enumerated on the issue.

The sweep also examined four negative assertions pinning removed copy. The reviewer cleared three as reintroduction guards — weak, but they would genuinely fail if the copy returned — and corrected one of the sweep's own claims (`"Workspace roots"` does still exist, on a different screen). The fourth is a genuine defect and is filed as **#1846**: a whole `@Test` behind `assumeTrue(…, false)` with ~60 lines permanently unreachable.

## Orchestrator verification

Applied to a clean worktree off `main` (`944b1769`); two androidTest files, **no production code**, no untracked residue, `git diff --check` clean. `:app:compileDebugAndroidTestKotlin` green; `check-test-validity.sh` and `check-ci-journey-harness.sh` exit 0.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb