### PR TITLE
ci(journey): price the retry as warm, and name load as the real constraint (#1833)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -239,9 +239,19 @@ jobs:
       # when the first attempt has already consumed the wall needed for a full
       # retry plus classifier/artifact teardown. Deterministic millisecond
       # boundary fixtures cover allowed/denied and malformed-clock paths.
-      - name: CI journey cold-boot retry-budget guard (issue #1458)
+      #
+      # Issue #1833 extends it with the observed shortfall from run 30383504733
+      # (all three shards refused their retry): the fixtures reproduce that
+      # refusal AND each shard's `required` to the millisecond on #1800's model,
+      # then prove the warm-retry correction restores shards 0 and 2 while shard
+      # 1 stays honestly refused. It also drives the REAL "Inspect first journey
+      # summary" and classify step bodies out of this file so the one-shot stamp
+      # is proven end to end (summary -> budget -> verdict token -> aggregate).
+      - name: CI journey cold-boot retry-budget guard (issues #1458, #1833)
         run: |
-          chmod +x scripts/ci-journey-retry-budget.sh scripts/test-ci-journey-retry-budget.sh
+          chmod +x scripts/ci-journey-retry-budget.sh \
+            scripts/ci-journey-warm-build-elapsed.sh \
+            scripts/test-ci-journey-retry-budget.sh
           scripts/test-ci-journey-retry-budget.sh
 
       # Issue #1800: the failure-SIGNATURE classifier that types the CI
@@ -1144,12 +1154,28 @@ jobs:
             )"
           fi
           [[ "$first_suite_elapsed_secs" =~ ^[0-9]+$ ]] || first_suite_elapsed_secs=""
+          # Issue #1833: the suite ALSO records the cold Gradle build it paid up
+          # front (#1814: "Warm build (issue #1814): **ok** in 464s"). That build
+          # is the one part of the suite a within-job retry does NOT repeat — the
+          # retry re-creates the AVD but reuses this runner's `~/.gradle` and
+          # `app/build`, so every assemble task is UP-TO-DATE. Feeding it to the
+          # retry-budget helper stops the model charging the cold build twice.
+          # Unreadable / non-ok warm build => empty => #1800's model unchanged.
+          first_warm_build_secs=""
+          if [[ -f "$summary" ]]; then
+            first_warm_build_secs="$(
+              bash scripts/ci-journey-warm-build-elapsed.sh "$summary" 2>/dev/null || true
+            )"
+          fi
+          [[ "$first_warm_build_secs" =~ ^[0-9]+$ ]] || first_warm_build_secs=""
           echo "first_timeout=$first_timeout" >> "$GITHUB_OUTPUT"
           echo "first_failure=$first_failure" >> "$GITHUB_OUTPUT"
           echo "first_suite_elapsed_secs=$first_suite_elapsed_secs" >> "$GITHUB_OUTPUT"
+          echo "first_warm_build_secs=$first_warm_build_secs" >> "$GITHUB_OUTPUT"
           echo "first summary timeout-only: $first_timeout"
           echo "first summary genuine failure: $first_failure"
           echo "first summary measured suite elapsed: ${first_suite_elapsed_secs:-<unmeasured>}s"
+          echo "first summary measured warm build: ${first_warm_build_secs:-<unmeasured>}s"
 
       # Preserve the first cold-boot attempt before a retry can overwrite the
       # shared artifacts/ci-journey summary or Gradle connected-test outputs.
@@ -1203,11 +1229,16 @@ jobs:
           # epoch + the suite's measured elapsed) so the requirement reflects
           # what redoing the observed work costs. Missing/invalid measurements
           # fall back to the unchanged flat worst case inside the helper.
+          # Issue #1833: also pass the measured cold build (#1814) so the suite
+          # cost is priced as the WARM retry it actually is, instead of charging
+          # a build the retry never repeats a second time. Missing/invalid warm
+          # measurement falls back to #1800's model, unchanged.
           scripts/ci-journey-retry-budget.sh \
             "${JOURNEY_JOB_START_EPOCH_MS:-}" \
             "$(date +%s%3N)" \
             "${JOURNEY_FIRST_ATTEMPT_START_EPOCH_MS:-}" \
             "${{ steps.journey_summary.outputs.first_suite_elapsed_secs }}" \
+            "${{ steps.journey_summary.outputs.first_warm_build_secs }}" \
             | tee -a "$GITHUB_OUTPUT"
 
       # Infra-retry-once: runs if the first bringup failed with a boot/adb abort
@@ -1301,6 +1332,8 @@ jobs:
           retry_remaining_ms="${{ steps.journey_retry_budget.outputs.retry_remaining_ms }}"
           retry_required_ms="${{ steps.journey_retry_budget.outputs.retry_required_ms }}"
           retry_cost_model="${{ steps.journey_retry_budget.outputs.retry_cost_model }}"
+          retry_shortfall_ms="${{ steps.journey_retry_budget.outputs.retry_shortfall_ms }}"
+          retry_warm_build_deducted_ms="${{ steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms }}"
           summary="artifacts/ci-journey/summary.md"
           # Issue #1458: record this shard's verdict token for the aggregation
           # job. CLEAN = passed; INFRA = environmental (#470 cancel / #771
@@ -1375,6 +1408,28 @@ jobs:
           echo "cold-boot retry reason: ${retry_reason:-missing_decision}"
           echo "cold-boot retry remaining/required: ${retry_remaining_ms:-0}/${retry_required_ms:-5400000}ms"
           echo "cold-boot retry cost model: ${retry_cost_model:-worst_case} (issue #1800)"
+          echo "cold-boot retry warm-build deducted: ${retry_warm_build_deducted_ms:-0}ms (issue #1833)"
+          # Issue #1833: a shard that reaches its verdict UNABLE to start a
+          # cold-boot retry ran ONE-SHOT — half the gate's resilience is gone and
+          # a single #788-class swiftshader flake reddens `main` outright instead
+          # of recovering. On run 30383504733 all three shards were in that state
+          # and every one still reported a plain CLEAN/RED: a gate that had lost
+          # its retry looked identical to one that had not. Same principle as
+          # #1814's `outer_timeout_phase` and #1827's registry — a condition that
+          # changes what the gate CAN DO must appear in the gate's own evidence.
+          # This is REPORTING only: it never changes a verdict or an exit code,
+          # and it is stamped on the token in EVERY branch below, including the
+          # CLEAN one (where the loss is otherwise completely invisible).
+          [[ "$retry_shortfall_ms" =~ ^[0-9]+$ ]] || retry_shortfall_ms=0
+          if [[ "${retry_allowed:-false}" == "true" ]]; then
+            SHARD_RETRY_AFFORDABLE="true"
+          else
+            SHARD_RETRY_AFFORDABLE="false"
+            echo "::warning title=Emulator journey shard ran ONE-SHOT — no cold-boot retry was affordable (#1833)::This shard reached its verdict unable to start a second cold boot (reason=${retry_reason:-missing_decision}, remaining=${retry_remaining_ms:-0}ms, required=${retry_required_ms:-5400000}ms, short by ${retry_shortfall_ms}ms, cost model=${retry_cost_model:-worst_case}). The verdict below is from ONE attempt: a #788-class environmental flake here reddens the aggregate instead of flake-recovering. Reported so a gate running at half resilience is never invisible (issue #1833)."
+          fi
+          SHARD_RETRY_DENIED_REASON="${retry_reason:-missing_decision}"
+          SHARD_RETRY_SHORTFALL_MS="$retry_shortfall_ms"
+          export SHARD_RETRY_AFFORDABLE SHARD_RETRY_DENIED_REASON SHARD_RETRY_SHORTFALL_MS
           if [[ "$first" == "success" ]]; then
             echo "Emulator journey passed on the first cold boot."
             write_verdict CLEAN passed_first_attempt

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -77,6 +77,9 @@ tokens=()
 provenance=()
 carried_over=()
 cold_build_shards=()
+# Issue #1833: shards that reached their verdict unable to start a cold-boot
+# retry, i.e. shards whose result came from ONE attempt.
+one_shot_shards=()
 fresh_tokens=0
 
 current_attempt="${GITHUB_RUN_ATTEMPT:-}"
@@ -124,7 +127,22 @@ if [[ -d "$verdict_dir" ]]; then
       origin="attempt unknown (token carries no #1809 provenance stamp)"
     fi
 
-    provenance+=("shard ${tok_shard}: ${token} — run ${tok_run}, ${origin}, reason ${tok_reason}")
+    # Issue #1833: did this shard still have a cold-boot retry when it reached
+    # that verdict? Absent on a token written before the stamp existed, which
+    # reads `unknown` and is reported as neither affordable nor one-shot.
+    tok_affordable="$(sed -n 's/^retry_affordable=//p' "$f" 2>/dev/null | head -n 1)"
+    [[ "$tok_affordable" == "true" || "$tok_affordable" == "false" ]] || tok_affordable="unknown"
+    tok_shortfall="$(sed -n 's/^retry_shortfall_ms=//p' "$f" 2>/dev/null | head -n 1)"
+    [[ "$tok_shortfall" =~ ^[0-9]+$ ]] || tok_shortfall="?"
+    tok_retry_reason="$(sed -n 's/^retry_denied_reason=//p' "$f" 2>/dev/null | head -n 1)"
+    [[ -n "$tok_retry_reason" ]] || tok_retry_reason="unspecified"
+
+    provenance_line="shard ${tok_shard}: ${token} — run ${tok_run}, ${origin}, reason ${tok_reason}"
+    if [[ "$tok_affordable" == "false" ]]; then
+      provenance_line+=", ONE-SHOT (no cold-boot retry affordable: ${tok_retry_reason}, short by ${tok_shortfall}ms)"
+      one_shot_shards+=("shard ${tok_shard} (${token}, short by ${tok_shortfall}ms)")
+    fi
+    provenance+=("$provenance_line")
     if [[ "$tok_reason" == "cold_build_timeout" ]]; then
       cold_build_shards+=("shard ${tok_shard} (${token})")
     fi
@@ -169,6 +187,17 @@ if (( ${#cold_build_shards[@]} > 0 )); then
   echo "::notice title=Emulator journey verdict — includes a cold-BUILD-phase timeout (#1814)::${#cold_build_shards[@]} shard verdict(s) were reported with reason 'cold_build_timeout': ${cold_build_shards[*]}. At least one attempt there hit its per-class wall cap while Gradle was still BUILDING — instrumentation never started and no JUnit XML exists, so the zero-test outer timeout is a BUILD-COST artefact, not evidence that the named journey is broken. Investigate the build cost (the cold build is paid up front by the suite's warm-build step), not the journey."
 fi
 
+# Issue #1833: a verdict reached WITHOUT the cold-boot retry available must say
+# so. The retry is what turns a single #788-class swiftshader flake into a
+# recovered run; on run 30383504733 all three shards were denied it and all three
+# still reported a plain CLEAN/RED, so the batch that then went red on a blank
+# viewport looked exactly like a healthy gate finding a real regression. Severity
+# is untouched — this changes only what the evidence SAYS about how much
+# resilience produced it.
+if (( ${#one_shot_shards[@]} > 0 )); then
+  echo "::notice title=Emulator journey verdict — ${#one_shot_shards[@]} shard(s) ran ONE-SHOT, no cold-boot retry (#1833)::${one_shot_shards[*]} reached their verdict unable to start a second cold boot, so their result comes from a SINGLE attempt. The cold-boot retry is what normally absorbs a #788-class environmental flake; without it such a flake reddens this aggregate instead of recovering. Read a RED from a one-shot shard with that in mind, and read a CLEAN as having had less protection than usual."
+fi
+
 if (( ${#carried_over[@]} > 0 )); then
   echo "::notice title=Emulator journey verdict — some shard verdicts carried over::${#carried_over[@]} shard verdict(s) come from an earlier attempt of this run (that shard was not re-run): ${carried_over[*]}. This is expected when a single shard is re-run; it is reported so the aggregate verdict's provenance is auditable (issue #1809, G5)."
 fi
@@ -207,6 +236,10 @@ emit_summary() {
       if (( ${#cold_build_shards[@]} > 0 )); then
         echo
         echo "**Cold-build-phase timeout (issue #1814):** ${cold_build_shards[*]} — an attempt there was cut while Gradle was still BUILDING (no instrumentation, no JUnit XML). That is a build-cost artefact, not a defect in the named journey."
+      fi
+      if (( ${#one_shot_shards[@]} > 0 )); then
+        echo
+        echo "**Ran ONE-SHOT — no cold-boot retry (issue #1833):** ${one_shot_shards[*]} — these shards reached their verdict unable to start a second cold boot, so their result comes from a SINGLE attempt and a #788-class environmental flake there reddens this aggregate instead of recovering."
       fi
     } >> "$GITHUB_STEP_SUMMARY"
   fi

--- a/scripts/ci-journey-retry-budget.sh
+++ b/scripts/ci-journey-retry-budget.sh
@@ -24,9 +24,79 @@
 # retries the old rule refused — never refuse one it allowed. Without usable
 # measurements the flat 5400s worst case is used unchanged (fail-safe).
 #
+# Issue #1833 — the suite cost is now priced as a WARM retry.
+#
+# #1800's `1.10 x observed suite elapsed` charges the retry for EVERYTHING the
+# first attempt's suite did. After #1814 that includes the shard's whole cold
+# Gradle build, which the suite now pays as one named, separately MEASURED
+# up-front phase ("Warm build (issue #1814): **ok** in 464s"). A within-job retry
+# does not repeat that build: it re-creates the AVD and cold-boots a fresh
+# emulator, but it runs on the SAME runner against the `~/.gradle` and
+# `app/build` the first attempt already populated, so every assemble task is
+# UP-TO-DATE the second time.
+#
+# That is observed, not assumed — run 30318408377, job 90153112226 (shard 0), the
+# one recent run where the retry actually ran, same first class on both attempts:
+#
+#   attempt 1 (cold Gradle):            4200s -> 3889s  = 311s
+#   attempt 2 (the retry, warm Gradle): 4200s -> 4179s  =  21s
+#
+# and the retry's whole suite came in 379s cheaper (1987s -> 1608s) on the
+# identical 48-class selection. Post-#1814 the same work is measured directly:
+# 373s / 464s / 489s across run 30383504733's three shards — 15-19% of each
+# shard's entire suite elapsed, charged twice by the un-corrected model. On that
+# run ALL THREE shards refused their retry with `insufficient_remaining_budget`,
+# two of them by less than the cold build they were double-charged for.
+#
+# So when the caller supplies the measured warm-build seconds the suite cost
+# becomes:
+#   1.10 x (observed suite elapsed - measured warm build)   the work that repeats
+# + 120s warm-rebuild reserve                               the UP-TO-DATE pass
+# instead of `1.10 x observed suite elapsed`. The 120s reserve is ~6x the 21s a
+# whole warm first class cost on run 30318408377, so it is generous against the
+# thing it stands in for.
+#
+# This is a CORRECTION to the estimate, not a larger budget: JOURNEY_JOB_CAP_MS,
+# JOURNEY_RETRY_REQUIRED_MS, the 4200s suite budget and the 95-minute job cap are
+# all untouched (G6). It is also strictly optional — an absent, malformed,
+# zero, or not-smaller-than-the-suite warm-build reading leaves #1800's model
+# byte-for-byte unchanged, so the fail-safe direction stays "deny the retry".
+#
+# WHAT THIS CORRECTION DOES *NOT* FIX — read this before tuning anything here.
+#
+# It is a PARTIAL. Measured against every shard-run whose budget figures are
+# still retrievable — runs 30351095421, 30339688411, 30383504733 and 30392101105,
+# twelve shard-runs, ten of them denied — the correction restores THREE and
+# leaves SEVEN denied. It also widens run 30392101105 shard 0 from a 2688ms
+# ALLOWED margin (under 3 seconds of a 95-minute job) to 391988ms, which is real
+# value, but it does not change the shape of the problem.
+#
+# Holding each shard-run's fixed costs and sweeping the suite, affordability has
+# exactly one crossing point, and across all twelve it sits in a band only ~110s
+# wide: roughly 2500-2650s of suite elapsed. SEVEN of the twelve observed suites
+# are already past their own crossing. So the retry is affordable iff the suite
+# is short enough, and the observed distribution straddles the line.
+#
+# Worse, the three restorations survive only 24s / 72s / 79s of suite growth
+# (~1-3% of their suites), because the margin decays at 2100ms per second of
+# suite elapsed — remaining falls 1000ms and required rises 1100ms. ONE
+# twice-failing journey class cost 417s on run 30383504733. So the retry comes
+# back only on runs where nothing went wrong, and a retry that is affordable
+# only when it is not needed is not resilience.
+#
+# The binding constraint is therefore PER-SHARD LOAD, not this estimate. Do not
+# respond to a future denial by tuning JOURNEY_RETRY_WARM_REBUILD_MS or the
+# headrooms — that is the constant-chasing #1833 exists to end. The levers are
+# the shard count / class distribution and the flake cost driving suite elapsed
+# (#788 / #1819 / #1820), tracked as #1850. The scoreboard, the drift budgets and
+# the crossing-point band are all asserted in
+# scripts/test-ci-journey-retry-budget.sh cases (x), (x2), (y) and (z), so this
+# conclusion cannot quietly go stale.
+#
 # Usage:
 #   ci-journey-retry-budget.sh JOB_START_EPOCH_MS NOW_EPOCH_MS \
-#     [FIRST_ATTEMPT_START_EPOCH_MS] [FIRST_SUITE_ELAPSED_SECS]
+#     [FIRST_ATTEMPT_START_EPOCH_MS] [FIRST_SUITE_ELAPSED_SECS] \
+#     [FIRST_WARM_BUILD_SECS]
 #
 # Output is GitHub-step-output-compatible key=value lines. Invalid/missing clock
 # input fails safe by denying the retry while returning success, so the workflow
@@ -40,19 +110,35 @@ readonly JOURNEY_RETRY_MIN_BOOT_RESERVE_MS=120000
 readonly JOURNEY_RETRY_BOOT_HEADROOM_NUMERATOR=3
 readonly JOURNEY_RETRY_SUITE_HEADROOM_NUMERATOR=110
 readonly JOURNEY_RETRY_SUITE_HEADROOM_DENOMINATOR=100
+# Issue #1833: what the retry's own (UP-TO-DATE) warm build is allowed to cost.
+readonly JOURNEY_RETRY_WARM_REBUILD_MS=120000
 readonly MAX_SIGNED_INT64_DECIMAL=9223372036854775807
 readonly MAX_MEASURED_SUITE_SECS=86400
 
 RETRY_REQUIRED_MS="$JOURNEY_RETRY_REQUIRED_MS"
 RETRY_COST_MODEL="worst_case"
+# Issue #1833: how much measured cold-build cost was NOT charged a second time.
+# 0 whenever the warm-build reading was absent or unusable, i.e. whenever the
+# emitted requirement is #1800's unmodified one.
+RETRY_WARM_BUILD_DEDUCTED_MS=0
 
 emit_decision() {
-  local allowed="$1" reason="$2" remaining="$3"
+  local allowed="$1" reason="$2" remaining="$3" shortfall=0
+  # Issue #1833: the shortfall is the load-bearing number for the operator — it
+  # is what separates "denied by 224s" (an estimate worth correcting) from
+  # "denied by 22 minutes" (a shard that genuinely does not fit). Reported for
+  # every denial, including the malformed-clock fail-safes, where remaining=0 and
+  # the shortfall is therefore the whole flat reserve.
+  if [[ "$allowed" != "true" ]] && (( RETRY_REQUIRED_MS > remaining )); then
+    shortfall=$((RETRY_REQUIRED_MS - remaining))
+  fi
   printf 'retry_allowed=%s\n' "$allowed"
   printf 'retry_reason=%s\n' "$reason"
   printf 'retry_remaining_ms=%s\n' "$remaining"
   printf 'retry_required_ms=%s\n' "$RETRY_REQUIRED_MS"
   printf 'retry_cost_model=%s\n' "$RETRY_COST_MODEL"
+  printf 'retry_shortfall_ms=%s\n' "$shortfall"
+  printf 'retry_warm_build_deducted_ms=%s\n' "$RETRY_WARM_BUILD_DEDUCTED_MS"
 }
 
 canonical_decimal() {
@@ -62,13 +148,18 @@ canonical_decimal() {
   return 0
 }
 
-# measured_retry_required_ms <attempt_start_ms> <suite_elapsed_secs> <now_ms>
+# measured_retry_required_ms <attempt_start_ms> <suite_elapsed_secs> <now_ms> \
+#                            [warm_build_secs]
 #
-# Echoes the measured requirement, or nothing when the evidence is unusable.
-# Never exceeds the legacy flat worst case.
+# Echoes `<required_ms> <warm_build_deducted_ms>`, or nothing when the evidence
+# is unusable. Never exceeds the legacy flat worst case. The second field is 0
+# whenever the #1833 warm-build correction did not apply, i.e. whenever the first
+# field is #1800's unmodified requirement. Both are echoed (rather than set as
+# globals) so the function stays pure and callable from `$(...)`.
 measured_retry_required_ms() {
-  local attempt_start="${1-}" suite_secs="${2-}" now_value="$3"
+  local attempt_start="${1-}" suite_secs="${2-}" now_value="$3" warm_secs="${4-}"
   local attempt_value suite_ms attempt_elapsed boot_ms boot_reserve suite_cost required
+  local warm_ms repeat_ms rebuild_reserve deducted=0
 
   canonical_decimal "$attempt_start" || return 1
   canonical_decimal "$suite_secs" || return 1
@@ -88,13 +179,43 @@ measured_retry_required_ms() {
   boot_reserve=$((boot_ms * JOURNEY_RETRY_BOOT_HEADROOM_NUMERATOR))
   (( boot_reserve < JOURNEY_RETRY_MIN_BOOT_RESERVE_MS )) &&
     boot_reserve="$JOURNEY_RETRY_MIN_BOOT_RESERVE_MS"
+
   suite_cost=$((
     suite_ms * JOURNEY_RETRY_SUITE_HEADROOM_NUMERATOR /
       JOURNEY_RETRY_SUITE_HEADROOM_DENOMINATOR
   ))
+
+  # Issue #1833: re-price the suite as the part the retry actually REPEATS. The
+  # measured cold build (#1814) is deducted and replaced by a flat UP-TO-DATE
+  # reserve. Deliberately narrow: the reading must be a canonical, in-range,
+  # non-zero count that is STRICTLY SMALLER than the suite it is a phase of.
+  # Anything else — absent, malformed, zero, or nonsensically >= the suite —
+  # leaves #1800's arithmetic untouched.
+  #
+  # The `<` comparison below is what keeps #1800's one-way guarantee intact: the
+  # correction is adopted ONLY when it lowers the requirement. Without it, a
+  # deducted build smaller than the 120s reserve (1.10 x warm < reserve) would
+  # make the model demand MORE than #1800 did and could refuse a retry the old
+  # rule allowed — the exact inversion #1800's clamp exists to prevent.
+  if canonical_decimal "$warm_secs" \
+     && ! decimal_greater_than "$warm_secs" "$MAX_MEASURED_SUITE_SECS"; then
+    warm_ms=$(( (10#$warm_secs) * 1000 ))
+    if (( warm_ms > 0 && warm_ms < suite_ms )); then
+      repeat_ms=$((suite_ms - warm_ms))
+      rebuild_reserve=$((
+        repeat_ms * JOURNEY_RETRY_SUITE_HEADROOM_NUMERATOR /
+          JOURNEY_RETRY_SUITE_HEADROOM_DENOMINATOR
+        + JOURNEY_RETRY_WARM_REBUILD_MS
+      ))
+      if (( rebuild_reserve < suite_cost )); then
+        suite_cost="$rebuild_reserve"
+        deducted="$warm_ms"
+      fi
+    fi
+  fi
   required=$((boot_reserve + suite_cost + JOURNEY_RETRY_TEARDOWN_MS))
   (( required > JOURNEY_RETRY_REQUIRED_MS )) && required="$JOURNEY_RETRY_REQUIRED_MS"
-  printf '%s' "$required"
+  printf '%s %s' "$required" "$deducted"
 }
 
 # decimal_greater_than <canonical-decimal-a> <canonical-decimal-b>
@@ -118,10 +239,11 @@ epoch_out_of_range() {
 
 journey_retry_budget_decision() {
   local start="${1-}" now="${2-}"
-  local attempt_start="${3-}" suite_secs="${4-}"
+  local attempt_start="${3-}" suite_secs="${4-}" warm_secs="${5-}"
 
   RETRY_REQUIRED_MS="$JOURNEY_RETRY_REQUIRED_MS"
   RETRY_COST_MODEL="worst_case"
+  RETRY_WARM_BUILD_DEDUCTED_MS=0
 
   if [[ -z "$start" ]]; then
     emit_decision false missing_job_start 0
@@ -173,10 +295,23 @@ journey_retry_budget_decision() {
   # Issue #1800: prefer this job's own measured retry cost over the flat
   # worst case. The helper never returns MORE than the legacy requirement, so
   # a measurement can only ever unlock a retry the flat rule refused.
-  local measured
-  if measured="$(measured_retry_required_ms "$attempt_start" "$suite_secs" "$now_value")"; then
-    RETRY_REQUIRED_MS="$measured"
-    RETRY_COST_MODEL="measured_first_attempt"
+  #
+  # Issue #1833: when the measured cold build is also supplied, the same helper
+  # prices the suite as a WARM retry. `measured_retry_required_ms` adopts that
+  # correction only when it LOWERS the requirement, so the one-way guarantee
+  # above still holds and the model name reports which arithmetic was used.
+  local measured measured_required measured_deducted
+  if measured="$(
+    measured_retry_required_ms "$attempt_start" "$suite_secs" "$now_value" "$warm_secs"
+  )"; then
+    read -r measured_required measured_deducted <<<"$measured"
+    RETRY_REQUIRED_MS="$measured_required"
+    RETRY_WARM_BUILD_DEDUCTED_MS="$measured_deducted"
+    if (( RETRY_WARM_BUILD_DEDUCTED_MS > 0 )); then
+      RETRY_COST_MODEL="measured_warm_retry"
+    else
+      RETRY_COST_MODEL="measured_first_attempt"
+    fi
   fi
 
   if (( remaining >= RETRY_REQUIRED_MS )); then
@@ -187,5 +322,5 @@ journey_retry_budget_decision() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-  journey_retry_budget_decision "${1-}" "${2-}" "${3-}" "${4-}"
+  journey_retry_budget_decision "${1-}" "${2-}" "${3-}" "${4-}" "${5-}"
 fi

--- a/scripts/ci-journey-warm-build-elapsed.sh
+++ b/scripts/ci-journey-warm-build-elapsed.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Issue #1833: read the COLD-BUILD cost the suite paid up front out of the
+# summary artifact it writes (scripts/ci-journey-summary-functions.sh).
+#
+# WHY THIS NUMBER EXISTS AS A SEPARATE READING
+# --------------------------------------------
+# Issue #1800 sizes the cold-boot retry against the first attempt's own measured
+# suite elapsed. Issue #1814 then made the shard's cold Gradle build an explicit,
+# separately measured phase INSIDE that elapsed:
+#
+#   Warm build (issue #1814): **ok** in 464s — paid before the per-class budget
+#   clock, charged to the suite budget.
+#
+# That build is the one part of the suite a within-job retry does NOT repeat.
+# The retry re-creates the AVD and cold-boots a fresh emulator, but it runs on
+# the SAME runner, against the same `~/.gradle` and the same `app/build` the
+# first attempt populated — so `:app:assembleDebug`,
+# `:app:assembleDebugAndroidTest` and `:shared:core-terminal:assembleDebugAndroidTest`
+# are UP-TO-DATE the second time.
+#
+# Observed, not assumed — run 30318408377, job 90153112226 (shard 0), the one
+# run in recent history where the cold-boot retry actually executed. Same class,
+# same job, first class on the shard, from the suite's own budget-remaining
+# stamps:
+#
+#   attempt 1 (cold Gradle):  TmuxSessionScreenArtVerifyE2eTest  4200s -> 3889s  = 311s
+#   attempt 2 (the retry, warm Gradle): same class               4200s -> 4179s  =  21s
+#
+# 290 of those 311 seconds were build, and the retry paid none of them; its whole
+# suite came in 379s cheaper (1987s -> 1608s) on the identical 48-class
+# selection. Post-#1814 that same work is the named warm-build phase, measured
+# directly at 373s / 464s / 489s across run 30383504733's three shards.
+#
+# So this reading is what lets scripts/ci-journey-retry-budget.sh price a WARM
+# retry instead of charging the cold build a second time.
+#
+# STATUS GATE: only a warm build that reports **ok** is deductible. A `failed`,
+# `skipped` or `not_run` warm build means the cold build was NOT paid as a
+# separate up-front phase — the class loop absorbed it, exactly as before #1814 —
+# so there is nothing separately measured to deduct and this exits 1, leaving the
+# caller on #1800's unmodified model. Fail-safe direction is toward DENYING the
+# retry, never toward permitting one on a guess.
+#
+# Prints the warm-build seconds on stdout and exits 0 when it can be read; prints
+# nothing and exits 1 otherwise.
+set -uo pipefail
+
+summary="${1-}"
+
+[[ -n "$summary" && -f "$summary" ]] || exit 1
+
+elapsed="$(
+  sed -n 's/^Warm build (issue #1814): \*\*ok\*\* in \([0-9][0-9]*\)s .*$/\1/p' \
+    "$summary" | head -n 1
+)"
+
+[[ "$elapsed" =~ ^[0-9]+$ ]] || exit 1
+printf '%s\n' "$elapsed"

--- a/scripts/ci-journey-write-shard-verdict.sh
+++ b/scripts/ci-journey-write-shard-verdict.sh
@@ -61,18 +61,39 @@
 # the same as softening it — softening a build-cost timeout to a re-run signal
 # would be exactly the masking D31/D32 forbid.
 #
+# Issue #1833 (retry AFFORDABILITY): the token also carries whether this shard
+# could still afford its cold-boot retry when it reached this verdict. The
+# concrete miss: on run 30383504733 ALL THREE shards were denied their retry with
+# `insufficient_remaining_budget` and every one of them still reported a plain
+# `CLEAN` / `RED` — a gate that had silently lost half its resilience was
+# indistinguishable from one that had not, until a #788-class swiftshader flake
+# landed on the shard that could no longer retry and reddened the batch. The
+# stamp is `retry_affordable` (true|false|unknown) plus the shortfall in ms, so
+# "this shard ran ONE-SHOT" is an artifact rather than a log line nobody reads.
+#
+# Like the reason, affordability NEVER changes the verdict: line 1 stays the bare
+# CLEAN|INFRA|RED token. It is `unknown` on the pre-seeded token (written at job
+# start, before any budget decision exists), which is honest — at that point the
+# shard has not yet asked.
+#
 # Usage:
 #   ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED> [REASON]
 # Env:
 #   SHARD_VERDICT_FILE                     output path (default
 #                                          artifacts/ci-journey-shard-verdict/shard-verdict.txt)
 #   SHARD_VERDICT_REASON                   fallback for the REASON argument
+#   SHARD_RETRY_AFFORDABLE                 `true` | `false` (issue #1833); any
+#                                          other value, including unset, records
+#                                          `unknown`
+#   SHARD_RETRY_DENIED_REASON              the budget helper's `retry_reason`
+#   SHARD_RETRY_SHORTFALL_MS               required-minus-remaining, in ms
 #   POCKETSHELL_JOURNEY_CI_SHARD_INDEX     shard index (set by the matrix)
 #   GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT     provenance (set by Actions)
 #   GITHUB_OUTPUT                          when set, also exports
 #                                          `shard_verdict=<token>` (so a later
-#                                          step can gate on it) and
-#                                          `shard_verdict_reason=<reason>`
+#                                          step can gate on it),
+#                                          `shard_verdict_reason=<reason>` and
+#                                          `shard_retry_affordable=<true|false|unknown>`
 set -uo pipefail
 
 verdict="${1:-}"
@@ -99,21 +120,39 @@ shard="${POCKETSHELL_JOURNEY_CI_SHARD_INDEX:-unknown}"
 run_id="${GITHUB_RUN_ID:-unknown}"
 run_attempt="${GITHUB_RUN_ATTEMPT:-unknown}"
 
+# Issue #1833: same fail-soft discipline as the reason — a malformed
+# affordability stamp must never cost the run its verdict token, so each field
+# degrades to a safe placeholder instead of rejecting the write.
+retry_affordable="${SHARD_RETRY_AFFORDABLE:-}"
+[[ "$retry_affordable" == "true" || "$retry_affordable" == "false" ]] \
+  || retry_affordable="unknown"
+retry_denied_reason="${SHARD_RETRY_DENIED_REASON:-unspecified}"
+[[ "$retry_denied_reason" =~ ^[a-z][a-z0-9_]{0,63}$ ]] || retry_denied_reason="unspecified"
+retry_shortfall_ms="${SHARD_RETRY_SHORTFALL_MS:-0}"
+[[ "$retry_shortfall_ms" =~ ^[0-9]{1,18}$ ]] || retry_shortfall_ms=0
+
 if ! {
   printf '%s\n' "$verdict"
   printf 'shard=%s\n' "$shard"
   printf 'run_id=%s\n' "$run_id"
   printf 'run_attempt=%s\n' "$run_attempt"
   printf 'verdict_reason=%s\n' "$reason"
+  printf 'retry_affordable=%s\n' "$retry_affordable"
+  printf 'retry_denied_reason=%s\n' "$retry_denied_reason"
+  printf 'retry_shortfall_ms=%s\n' "$retry_shortfall_ms"
   printf 'written_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 } > "$out"; then
   echo "ci-journey-write-shard-verdict.sh: cannot write $out" >&2
   exit 1
 fi
 
-echo "SHARD_VERDICT=$verdict (shard $shard, run $run_id attempt $run_attempt, reason $reason)"
+echo "SHARD_VERDICT=$verdict (shard $shard, run $run_id attempt $run_attempt, reason $reason, retry_affordable $retry_affordable)"
+if [[ "$retry_affordable" == "false" ]]; then
+  echo "SHARD_RETRY_UNAFFORDABLE: this shard reached its verdict on ONE attempt — a cold-boot retry did not fit (${retry_denied_reason}, short by ${retry_shortfall_ms}ms) (issue #1833)"
+fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   printf 'shard_verdict=%s\n' "$verdict" >> "$GITHUB_OUTPUT"
   printf 'shard_verdict_reason=%s\n' "$reason" >> "$GITHUB_OUTPUT"
+  printf 'shard_retry_affordable=%s\n' "$retry_affordable" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -632,7 +632,9 @@ classify_expressions() {
   "steps.journey_retry_budget.outputs.retry_reason": "sufficient_remaining_budget",
   "steps.journey_retry_budget.outputs.retry_remaining_ms": "3112241",
   "steps.journey_retry_budget.outputs.retry_required_ms": "3028613",
-  "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt"
+  "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt",
+  "steps.journey_retry_budget.outputs.retry_shortfall_ms": "0",
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0"
 }
 JSONEOF
 }

--- a/scripts/test-ci-journey-retry-budget.sh
+++ b/scripts/test-ci-journey-retry-budget.sh
@@ -3,6 +3,9 @@
 # cold-boot retry budget. A retry may start only when the absolute 95-minute job
 # deadline leaves enough wall time for shutdown/boot, the selected suite, and
 # classifier/artifact teardown.
+#
+# Issue #1833 extends this with the WARM-retry correction and the one-shot
+# surfacing. See the `#1833` sections at the bottom.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -10,6 +13,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 HELPER="${CI_JOURNEY_RETRY_BUDGET_HELPER:-$SCRIPT_DIR/ci-journey-retry-budget.sh}"
 WORKFLOW="${CI_JOURNEY_RETRY_BUDGET_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
 AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+WARM_ELAPSED="$SCRIPT_DIR/ci-journey-warm-build-elapsed.sh"
+SUITE_ELAPSED="$SCRIPT_DIR/ci-journey-suite-elapsed.sh"
+WRITER="$SCRIPT_DIR/ci-journey-write-shard-verdict.sh"
 
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
@@ -17,6 +23,9 @@ pass() { echo "  ok: $*"; }
 [[ -f "$HELPER" ]] || fail "retry-budget helper missing: $HELPER"
 [[ -f "$WORKFLOW" ]] || fail "workflow missing: $WORKFLOW"
 [[ -f "$AGG" ]] || fail "aggregate helper missing: $AGG"
+[[ -f "$WARM_ELAPSED" ]] || fail "warm-build elapsed reader missing: $WARM_ELAPSED"
+[[ -f "$SUITE_ELAPSED" ]] || fail "suite elapsed reader missing: $SUITE_ELAPSED"
+[[ -f "$WRITER" ]] || fail "shard verdict writer missing: $WRITER"
 
 run_decision() {
   local start="${1-}" now="${2-}"
@@ -164,6 +173,906 @@ agg_out="$(EXPECTED_SHARDS=3 GITHUB_STEP_SUMMARY="" bash "$AGG" "$verdict_dir" 2
 grep -q '^AGGREGATE_VERDICT=RE-RUN$' <<<"$agg_out" \
   || { printf '%s\n' "$agg_out"; fail "complete no-budget INFRA evidence did not produce RE-RUN"; }
 pass "complete INFRA shard evidence reaches aggregate RE-RUN (not cancellation)"
+
+echo
+echo "== #1833 the OBSERVED shortfall, from run 30383504733's three shard logs =="
+
+# THE REPRODUCTION. These five numbers per shard are read out of the shard job
+# logs of run 30383504733 (main @ 944b1769) — nothing here is invented:
+#
+#   shard 0, job 90365277532: "Warm build (issue #1814): **ok** in 464s",
+#     "| 49 load-bearing journey classes (shard 0/3 ...) | ... | 2512s |",
+#     "cold-boot retry remaining/required: 2992443/3216836ms"
+#   shard 1, job 90365277531: warm 373s, suite 3017s, 2396465/3752989ms
+#   shard 2, job 90365277470: warm 489s, suite 2531s, 2976238/3240868ms
+#
+# All three reported `retry_allowed=false reason=insufficient_remaining_budget`.
+# `boot_ms` below is the residual the model derives — (now - attempt start) -
+# suite — and it is pinned by requiring the 4-arg model to reproduce the observed
+# `required` EXACTLY. If that reconstruction ever stops matching, this fixture is
+# no longer describing the real run and the test says so instead of drifting.
+#
+# JOB_START is arbitrary: only `now - JOB_START` (which fixes `remaining`) and
+# `now - attempt_start` (which fixes the residual) are load-bearing.
+JOB_CAP_MS=5700000
+fixture_job_start=1000000
+
+# reconstruct_now <remaining_ms>
+reconstruct_now() { printf '%s' "$((fixture_job_start + JOB_CAP_MS - $1))"; }
+# reconstruct_attempt_start <now> <suite_secs> <boot_ms>
+reconstruct_attempt_start() { printf '%s' "$(( $1 - ($2 * 1000) - $3 ))"; }
+
+BUDGET_OUT=""
+budget_field() { sed -n "s/^$1=//p" <<<"$BUDGET_OUT" | tail -n 1; }
+run_budget() {
+  BUDGET_OUT="$(bash "$HELPER" "$@" 2>&1)" \
+    || fail "retry-budget helper exited non-zero for args: $*"
+}
+
+# shard | remaining | observed required | suite s | warm s | boot ms
+SHARD_FIXTURES=(
+  "0|2992443|3216836|2512|464|51212"
+  "1|2396465|3752989|3017|373|44763"
+  "2|2976238|3240868|2531|489|52256"
+)
+
+restored=0
+for fixture in "${SHARD_FIXTURES[@]}"; do
+  IFS='|' read -r idx remaining observed_required suite warm boot_ms <<<"$fixture"
+  now="$(reconstruct_now "$remaining")"
+  attempt_start="$(reconstruct_attempt_start "$now" "$suite" "$boot_ms")"
+
+  # (o) RED — the model as it shipped (#1800, no warm-build reading) reproduces
+  #     the observed refusal AND the observed `required` to the millisecond.
+  run_budget "$fixture_job_start" "$now" "$attempt_start" "$suite"
+  [[ "$(budget_field retry_remaining_ms)" == "$remaining" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(o/shard $idx) reconstruction gives remaining=$(budget_field retry_remaining_ms), the log says $remaining"; }
+  [[ "$(budget_field retry_required_ms)" == "$observed_required" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(o/shard $idx) the #1800 model gives required=$(budget_field retry_required_ms), the log says $observed_required — this fixture no longer describes run 30383504733"; }
+  [[ "$(budget_field retry_allowed)" == "false" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(o/shard $idx) the #1800 model must reproduce the observed REFUSAL"; }
+  [[ "$(budget_field retry_reason)" == "insufficient_remaining_budget" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(o/shard $idx) expected insufficient_remaining_budget, got $(budget_field retry_reason)"; }
+  [[ "$(budget_field retry_cost_model)" == "measured_first_attempt" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(o/shard $idx) the 4-arg path must still report measured_first_attempt — #1800 is preserved unchanged"; }
+  old_required="$(budget_field retry_required_ms)"
+  old_shortfall="$(budget_field retry_shortfall_ms)"
+  old_deducted="$(budget_field retry_warm_build_deducted_ms)"
+
+  # (p) GREEN — with the measured cold build supplied, the requirement drops by
+  #     the double-charged build and the affordability verdict is re-decided.
+  run_budget "$fixture_job_start" "$now" "$attempt_start" "$suite" "$warm"
+  new_required="$(budget_field retry_required_ms)"
+  (( new_required < old_required )) \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(p/shard $idx) the warm correction must LOWER the requirement ($new_required vs $old_required)"; }
+  [[ "$(budget_field retry_cost_model)" == "measured_warm_retry" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(p/shard $idx) the corrected path must name itself measured_warm_retry"; }
+  [[ "$(budget_field retry_warm_build_deducted_ms)" == "$((warm * 1000))" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(p/shard $idx) expected ${warm}s deducted, got $(budget_field retry_warm_build_deducted_ms)ms"; }
+  [[ "$old_deducted" == "0" ]] \
+    || fail "(p/shard $idx) the 4-arg #1800 path must deduct nothing, reported '$old_deducted'"
+  [[ "$old_shortfall" == "$((observed_required - remaining))" ]] \
+    || fail "(p/shard $idx) the #1800 shortfall '$old_shortfall' != required-minus-remaining"
+  [[ "$(budget_field retry_remaining_ms)" == "$remaining" ]] \
+    || fail "(p/shard $idx) the correction must not touch the remaining wall"
+  echo "    shard $idx: suite ${suite}s (warm build ${warm}s) — required ${old_required}ms -> ${new_required}ms against ${remaining}ms remaining => allowed=$(budget_field retry_allowed)"
+
+  if [[ "$idx" == "1" ]]; then
+    # Shard 1 is the evidenced EXCEPTION, and it is arithmetic, not opinion: its
+    # first attempt's suite alone (3017s) already exceeds the 2396s of job wall it
+    # had left. A retry that repeated the suite at EXACTLY the first attempt's
+    # cost, with a free boot, no headroom and zero teardown, would still overrun.
+    # No correction to the ESTIMATE can make this shard afford a retry; what ate
+    # its wall was the ~418s the twice-failing PreExistingMultiWindowSeedE2eTest
+    # plus ~127s of three flake retries spent INSIDE the suite. So the honest
+    # outcome here is the surfacing below, not a cheaper number.
+    [[ "$(budget_field retry_allowed)" == "false" ]] \
+      || { printf '%s\n' "$BUDGET_OUT"; fail "(p/shard 1) must NOT be talked into affording a retry it cannot run"; }
+    (( suite * 1000 > remaining )) \
+      || fail "(p/shard 1) the fixture no longer shows suite > remaining, so the unaffordability argument no longer holds"
+    (( new_required > remaining )) \
+      || fail "(p/shard 1) required must still exceed remaining"
+    pass "(p) shard 1 stays REFUSED — its 3017s suite alone exceeds the 2396s of wall it had left (unaffordable by arithmetic, not by estimate)"
+  else
+    [[ "$(budget_field retry_allowed)" == "true" ]] \
+      || { printf '%s\n' "$BUDGET_OUT"; fail "(p/shard $idx) the corrected model must restore this shard's retry"; }
+    [[ "$(budget_field retry_shortfall_ms)" == "0" ]] \
+      || fail "(p/shard $idx) an affordable retry must report zero shortfall"
+    restored=$((restored + 1))
+  fi
+done
+(( restored == 2 )) || fail "(p) expected shards 0 and 2 to regain their retry, got $restored"
+pass "(o) the #1800 model reproduces run 30383504733's refusal AND required-ms on all three shards"
+pass "(p) on run 30383504733 the warm-retry correction restores the retry on shards 0 and 2"
+
+echo
+echo "== #1833 AC2: the correction across EVERY run with retrievable figures =="
+
+# (x) THE HONEST SCOREBOARD. One run is not a population. These are all nine
+#     shard-runs for which the job logs still carry `retry_remaining_ms` /
+#     `retry_required_ms` / the summary's suite elapsed:
+#
+#       30351095421  main @ 26a43822  (post-#1814; warm builds MEASURED 353/479/434s)
+#       30339688411  main @ 8a6c04b5  (pre-#1814; no warm-build line exists)
+#       30383504733  main @ 944b1769  (post-#1814; warm builds MEASURED 464/373/489s)
+#       30392101105  main @ 45f34af8  (post-#1814; warm builds MEASURED 463/462/448s)
+#
+#     Each row's `boot residual` is derived by inverting #1800's own arithmetic
+#     from the logged `required`, and case (o2) below re-asserts that inversion
+#     against the logged number for every row — so if any figure here ever stops
+#     describing the real run, this test says so rather than drifting.
+#
+#     Run 30339688411 predates #1814, so it has no measured warm build at all.
+#     It is modelled at 489s — the LARGEST value in the whole observed 373-489s
+#     band, i.e. the most generous deduction the correction could possibly make
+#     for it. If it is refused even there, no warm measurement could have saved
+#     it.
+#
+#     The result is the number this issue's AC2 has to be judged on: the
+#     correction restores 3 of the 10 denied shard-runs, and 7 stay denied.
+#
+# run | shard | remaining | logged required (#1800) | suite s | warm s | boot residual ms
+ALL_SHARD_RUNS=(
+  "30351095421|0|3585619|2501456|1867|353|49252"
+  "30351095421|1|2862065|3384547|2654|479|55049"
+  "30351095421|2|2963004|3267938|2542|434|57246"
+  "30339688411|0|2843970|3376016|2653|489|52572"
+  "30339688411|1|2601782|3657891|2916|489|50097"
+  "30339688411|2|2573208|3719876|2968|489|51692"
+  "30383504733|0|2992443|3216836|2512|464|51212"
+  "30383504733|1|2396465|3752989|3017|373|44763"
+  "30383504733|2|2976238|3240868|2531|489|52256"
+  "30392101105|0|3104994|3102306|2367|463|66202"
+  "30392101105|1|2771142|3452850|2724|462|52150"
+  "30392101105|2|2532733|3745191|2994|448|50597"
+)
+# The verdicts this scoreboard asserts, in the same order:
+#   allow-allow  already affordable before the correction (2 rows)
+#   deny-allow   RESTORED by the correction               (3 rows)
+#   deny-deny    still denied after the correction        (7 rows)
+ALL_SHARD_EXPECTED=(
+  "allow|allow" "deny|deny" "deny|allow"
+  "deny|deny"   "deny|deny" "deny|deny"
+  "deny|allow"  "deny|deny" "deny|allow"
+  "allow|allow" "deny|deny" "deny|deny"
+)
+already=0; restored_all=0; still_denied=0
+for i in "${!ALL_SHARD_RUNS[@]}"; do
+  IFS='|' read -r run idx remaining logged_required suite warm boot_ms <<<"${ALL_SHARD_RUNS[$i]}"
+  IFS='|' read -r want_before want_after <<<"${ALL_SHARD_EXPECTED[$i]}"
+  now="$(reconstruct_now "$remaining")"
+  attempt_start="$(reconstruct_attempt_start "$now" "$suite" "$boot_ms")"
+
+  # (o2) the reconstruction must still reproduce the logged #1800 requirement.
+  run_budget "$fixture_job_start" "$now" "$attempt_start" "$suite"
+  [[ "$(budget_field retry_remaining_ms)" == "$remaining" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(o2/$run shard $idx) reconstruction gives remaining=$(budget_field retry_remaining_ms), the log says $remaining"; }
+  [[ "$(budget_field retry_required_ms)" == "$logged_required" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(o2/$run shard $idx) the #1800 model gives required=$(budget_field retry_required_ms), the log says $logged_required — this row no longer describes run $run"; }
+  got_before=deny
+  [[ "$(budget_field retry_allowed)" == "true" ]] && got_before=allow
+  [[ "$got_before" == "$want_before" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(x/$run shard $idx) #1800 verdict is $got_before, the log says $want_before"; }
+
+  # (x) the corrected model's verdict for the same shard-run.
+  run_budget "$fixture_job_start" "$now" "$attempt_start" "$suite" "$warm"
+  got_after=deny
+  [[ "$(budget_field retry_allowed)" == "true" ]] && got_after=allow
+  [[ "$got_after" == "$want_after" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(x/$run shard $idx) the corrected model says $got_after, this scoreboard records $want_after"; }
+
+  margin=$(( $(budget_field retry_remaining_ms) - $(budget_field retry_required_ms) ))
+  echo "    $run shard $idx: suite ${suite}s warm ${warm}s — ${want_before} -> ${want_after} (margin ${margin}ms)"
+  if [[ "$want_before" == "allow" ]]; then already=$((already + 1))
+  elif [[ "$want_after" == "allow" ]]; then restored_all=$((restored_all + 1))
+  else still_denied=$((still_denied + 1)); fi
+done
+(( already + restored_all + still_denied == 12 )) || fail "(x) the scoreboard lost a row"
+(( already == 2 )) \
+  || fail "(x) expected exactly 2 shard-runs that could already afford their retry, got $already"
+(( restored_all == 3 )) \
+  || fail "(x) the correction is recorded as restoring 3 of the 10 denied shard-runs; this run says $restored_all. If the model changed, the issue's AC2 conclusion must be re-derived — do not just update this number."
+(( still_denied == 7 )) \
+  || fail "(x) the correction is recorded as leaving 7 of the 10 denied shard-runs denied; this run says $still_denied"
+pass "(o2) the reconstruction reproduces the logged #1800 requirement on all 12 retrievable shard-runs"
+pass "(x) the correction restores $restored_all of the 10 denied shard-runs and leaves $still_denied denied — per-shard load, not the estimate, is what refuses the other 7"
+
+# (x2) …and the correction is still WORTH KEEPING where it does not flip a
+#      verdict. Run 30392101105 shard 0 was allowed by #1800 with a margin of
+#      2688ms — under three seconds of the 95-minute job. That is a coin flip,
+#      not health: 1.3s of extra suite would have refused it. The correction
+#      turns that into 391988ms. This is the half of AC2 the pricing fix does
+#      genuinely deliver, and it must not be lost when the load argument is made.
+now="$(reconstruct_now 3104994)"
+attempt_start="$(reconstruct_attempt_start "$now" 2367 66202)"
+run_budget "$fixture_job_start" "$now" "$attempt_start" 2367
+razor_1800=$(( $(budget_field retry_remaining_ms) - $(budget_field retry_required_ms) ))
+(( razor_1800 >= 0 && razor_1800 < 5000 )) \
+  || fail "(x2) run 30392101105 shard 0 is recorded as allowed by #1800 on a sub-5s margin; this run computes ${razor_1800}ms"
+run_budget "$fixture_job_start" "$now" "$attempt_start" 2367 463
+razor_1833=$(( $(budget_field retry_remaining_ms) - $(budget_field retry_required_ms) ))
+(( razor_1833 > razor_1800 * 100 )) \
+  || fail "(x2) the correction must widen a razor-thin ALLOWED margin by orders of magnitude, ${razor_1800}ms -> ${razor_1833}ms"
+pass "(x2) on the one already-allowed razor case the correction widens +${razor_1800}ms (1s of drift) to +${razor_1833}ms ($((razor_1833 / 2100))s of drift) — the pricing fix earns its keep even where it flips no verdict"
+
+echo
+echo "== #1833 AC2: how much suite drift each restored shard-run survives =="
+
+# (y) A restoration that survives 24 seconds is not a restoration you can rely
+#     on, and reporting it without that number would be the thin-margin claim
+#     this issue's own scope warns against.
+#
+#     Drift is modelled the way it actually happens: the suite runs δ seconds
+#     longer, so the job has spent δ more seconds of wall by the time the budget
+#     is asked (remaining -1000δ ms) and the retry is priced for a δ-longer
+#     suite (required +1100δ ms). The boot residual is held fixed. The margin
+#     therefore decays at 2100 ms per second of suite growth — but nothing here
+#     ASSUMES that: each boundary below is found by driving the REAL helper at
+#     the recorded drift and again one second past it.
+#
+# run | shard | remaining | suite s | warm s | boot ms | last affordable drift s
+RESTORED_DRIFT=(
+  "30351095421|2|2963004|2542|434|57246|24"
+  "30383504733|0|2992443|2512|464|51212|79"
+  "30383504733|2|2976238|2531|489|52256|72"
+)
+(( ${#RESTORED_DRIFT[@]} == restored_all )) \
+  || fail "(y) every restored shard-run must have its drift budget recorded; ${#RESTORED_DRIFT[@]} recorded vs $restored_all restored"
+# drift_verdict <remaining> <suite> <warm> <boot_ms> <delta_secs> -> echoes allow|deny
+drift_verdict() {
+  local remaining="$1" suite="$2" warm="$3" boot_ms="$4" delta="$5" d_now d_start
+  d_now=$(( fixture_job_start + JOB_CAP_MS - remaining + delta * 1000 ))
+  d_start=$(( d_now - (suite + delta) * 1000 - boot_ms ))
+  run_budget "$fixture_job_start" "$d_now" "$d_start" "$((suite + delta))" "$warm"
+  if [[ "$(budget_field retry_allowed)" == "true" ]]; then echo allow; else echo deny; fi
+}
+for fixture in "${RESTORED_DRIFT[@]}"; do
+  IFS='|' read -r run idx remaining suite warm boot_ms drift <<<"$fixture"
+  [[ "$(drift_verdict "$remaining" "$suite" "$warm" "$boot_ms" 0)" == "allow" ]] \
+    || fail "(y/$run shard $idx) this row is listed as restored but is refused at zero drift"
+  [[ "$(drift_verdict "$remaining" "$suite" "$warm" "$boot_ms" "$drift")" == "allow" ]] \
+    || fail "(y/$run shard $idx) recorded as surviving ${drift}s of suite drift, but the real helper refuses it there"
+  [[ "$(drift_verdict "$remaining" "$suite" "$warm" "$boot_ms" "$((drift + 1))" )" == "deny" ]] \
+    || fail "(y/$run shard $idx) recorded as flipping back at $((drift + 1))s of drift, but the real helper still allows it — the recorded margin is understated"
+  pct=$(( drift * 1000 / suite ))
+  echo "    $run shard $idx: survives ${drift}s of suite drift (${pct}‰ of its ${suite}s suite), refused at $((drift + 1))s"
+done
+# The whole point of the number: a SINGLE flaked journey class costs more than
+# any of these margins. On run 30383504733, shard 1's PreExistingMultiWindowSeed
+# failure alone cost 417s across its two attempts — 5x the largest margin here.
+worst_drift=0
+for fixture in "${RESTORED_DRIFT[@]}"; do
+  IFS='|' read -r _ _ _ _ _ _ drift <<<"$fixture"
+  (( drift > worst_drift )) && worst_drift="$drift"
+done
+(( worst_drift < 417 )) \
+  || fail "(y) the restored margins now exceed the 417s a single twice-failing class cost on run 30383504733; the 'a retry only when nothing went wrong' finding must be re-derived"
+pass "(y) every restored shard-run is within ${worst_drift}s of flipping back — less than the 417s ONE twice-failing class cost on the same run, so the retry returns only on runs that did not need it"
+
+echo
+echo "== #1833 AC2: affordability is a function of SUITE ELAPSED, and we sit on the line =="
+
+# (z) THE RELATIONSHIP, not another anecdote. Hold each shard-run's fixed costs
+#     — the pre-suite job wall, the boot residual, the measured warm build — and
+#     sweep the suite. Every row has a single crossing point: below it the
+#     corrected model allows the retry, above it the model refuses. There is no
+#     second variable; the retry is affordable iff the suite is short enough.
+#
+#     Across all twelve retrievable shard-runs that crossing sits in a band only
+#     ~110s wide, and SEVEN of the twelve observed suites are above their own
+#     crossing. That is the quantified form of "per-shard load is the binding
+#     constraint": the gate is not near a fixable estimate, it is sitting on the
+#     affordability line with the distribution straddling it.
+#
+#     Found by driving the REAL helper, not by re-deriving its arithmetic here.
+BREAKEVEN_LO=2500
+BREAKEVEN_HI=2650
+
+# breakeven_suite <remaining> <suite> <warm> <boot_ms> — largest suite (secs) at
+# which the corrected model still allows the retry, all else held fixed. Bisects
+# the REAL helper; hard-fails if the boundary is not bracketed.
+breakeven_suite() {
+  local remaining="$1" suite="$2" warm="$3" boot_ms="$4"
+  local pre_suite lo=600 hi=4200 mid b_now b_start
+  pre_suite=$(( JOB_CAP_MS - remaining - suite * 1000 ))
+  _verdict_at() {
+    b_now=$(( fixture_job_start + pre_suite + $1 * 1000 ))
+    b_start=$(( b_now - $1 * 1000 - boot_ms ))
+    run_budget "$fixture_job_start" "$b_now" "$b_start" "$1" "$warm"
+    [[ "$(budget_field retry_allowed)" == "true" ]]
+  }
+  _verdict_at "$lo" || { echo "unbracketed-low"; return; }
+  _verdict_at "$hi" && { echo "unbracketed-high"; return; }
+  while (( hi - lo > 1 )); do
+    mid=$(( (lo + hi) / 2 ))
+    if _verdict_at "$mid"; then lo="$mid"; else hi="$mid"; fi
+  done
+  echo "$lo"
+}
+
+over_the_line=0
+for entry in "${ALL_SHARD_RUNS[@]}"; do
+  IFS='|' read -r run idx remaining _logged suite warm boot_ms <<<"$entry"
+  bk="$(breakeven_suite "$remaining" "$suite" "$warm" "$boot_ms")"
+  [[ "$bk" =~ ^[0-9]+$ ]] \
+    || fail "(z/$run shard $idx) the affordability boundary is not bracketed in 600-4200s ($bk) — affordability is not the single-crossing function this conclusion assumes"
+  (( bk >= BREAKEVEN_LO && bk <= BREAKEVEN_HI )) \
+    || fail "(z/$run shard $idx) break-even suite ${bk}s falls outside the recorded ${BREAKEVEN_LO}-${BREAKEVEN_HI}s band; the AC2 conclusion is derived from that band and must be re-derived"
+  # The boundary must actually decide this row: below it allow, above it deny.
+  if (( suite > bk )); then
+    over_the_line=$((over_the_line + 1))
+    verdict=deny
+  else
+    verdict=allow
+  fi
+  now="$(reconstruct_now "$remaining")"
+  attempt_start="$(reconstruct_attempt_start "$now" "$suite" "$boot_ms")"
+  run_budget "$fixture_job_start" "$now" "$attempt_start" "$suite" "$warm"
+  got=deny; [[ "$(budget_field retry_allowed)" == "true" ]] && got=allow
+  [[ "$got" == "$verdict" ]] \
+    || fail "(z/$run shard $idx) suite ${suite}s vs break-even ${bk}s predicts $verdict but the helper says $got — affordability is not decided by suite elapsed alone, so the whole conclusion is wrong"
+  echo "    $run shard $idx: break-even ${bk}s, actual suite ${suite}s => $got"
+done
+(( over_the_line == 7 )) \
+  || fail "(z) 7 of the 12 retrievable shard-runs are recorded as running longer than their own affordability boundary; this run says $over_the_line"
+pass "(z) the retry is affordable iff suite elapsed < ~${BREAKEVEN_LO}-${BREAKEVEN_HI}s, and $over_the_line of 12 observed shard-runs are already past that line — the binding constraint is per-shard load"
+
+echo
+echo "== #1833 the correction is one-way and fail-safe =="
+
+# (q) The measured model's #1800 guarantee — it may only ever RELAX — must
+#     survive the new arithmetic. A warm build so small that 1.10x it is under
+#     the 120s rebuild reserve would otherwise INFLATE the requirement and could
+#     refuse a retry the old rule allowed.
+now="$(reconstruct_now 3000000)"
+attempt_start="$(reconstruct_attempt_start "$now" 2000 50000)"
+run_budget "$fixture_job_start" "$now" "$attempt_start" 2000
+baseline_required="$(budget_field retry_required_ms)"
+for tiny in 1 5 30 100 109; do
+  run_budget "$fixture_job_start" "$now" "$attempt_start" 2000 "$tiny"
+  (( $(budget_field retry_required_ms) <= baseline_required )) \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(q) a ${tiny}s warm build inflated the requirement to $(budget_field retry_required_ms) over $baseline_required"; }
+done
+pass "(q) a warm build too small to pay for its own reserve never RAISES the requirement"
+
+# (q2) ... and the deduction still never exceeds the flat legacy worst case.
+run_budget "$fixture_job_start" "$now" "$((now - 9000000))" 8000 500
+[[ "$(budget_field retry_required_ms)" == "5400000" ]] \
+  || { printf '%s\n' "$BUDGET_OUT"; fail "(q2) a pathologically slow attempt must still clamp to the flat 5400000ms"; }
+pass "(q2) the warm path still clamps at the legacy flat worst case"
+
+# (r) Unusable warm readings must leave #1800's output byte-for-byte alone.
+#     `2500` is >= the 2000s suite (nonsensical), `0` is a no-op measurement,
+#     and the rest are malformed. Fail-safe direction is toward DENYING.
+run_budget "$fixture_job_start" "$now" "$attempt_start" 2000
+unmeasured_out="$BUDGET_OUT"
+for bad in "" "0" "007" "not-a-number" "-5" "2500" "2000" "99999999999999999999999999"; do
+  run_budget "$fixture_job_start" "$now" "$attempt_start" 2000 "$bad"
+  [[ "$BUDGET_OUT" == "$unmeasured_out" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(r) warm reading '$bad' changed the decision; it must fall back to #1800 unchanged"; }
+done
+pass "(r) absent/zero/malformed/not-smaller-than-suite warm readings leave #1800's decision untouched"
+
+echo
+echo "== #1833 the warm-build reading comes from the suite's own summary =="
+
+warm_ws="$(mktemp -d)"
+trap 'rm -rf "$verdict_dir" "$warm_ws"' EXIT
+
+# write_real_summary <dir> <suite-secs> <warm-status> <warm-secs> [failed-class]
+#
+# DERIVED FROM THE REAL WRITER, NOT SHAPED LIKE IT. Every summary this harness
+# parses is produced by driving `finish_ci_journey_suite` in
+# scripts/ci-journey-summary-functions.sh — the same function the suite calls in
+# CI — with fixture state.
+#
+# This is deliberate, and it is the whole point. An earlier revision of this
+# helper hand-wrote a byte-shaped COPY of the writer's output. That copy passed
+# every test while being, structurally, a second maintained list: a wording or
+# number-format change at ci-journey-summary-functions.sh's `Warm build (issue
+# #1814): ...` line would have silently stopped
+# scripts/ci-journey-warm-build-elapsed.sh from parsing anything, reverting the
+# entire #1833 correction to #1800's model — with every test in this file still
+# green. That is exactly the invisible-loss shape #1833 exists to end, so the
+# fixture must not be able to disagree with the writer. Case (s4) below pins the
+# coupling from the other side: it mutates the writer and requires the reader to
+# fail loudly.
+#
+# The `unset SECONDS` is what makes SUITE_ELAPSED deterministic. `SECONDS` is a
+# special bash variable that counts wall-clock seconds; unsetting it drops that
+# attribute and leaves an ordinary variable, so `SUITE_ELAPSED=$((SECONDS -
+# SUITE_START))` inside the real writer yields exactly the requested number and
+# this harness reads no clock (#1839).
+SUMMARY_FN_SRC="$SCRIPT_DIR/ci-journey-summary-functions.sh"
+CORE_TERMINAL_FN_SRC="$SCRIPT_DIR/ci-journey-core-terminal-functions.sh"
+[[ -f "$SUMMARY_FN_SRC" ]] || fail "real summary writer missing: $SUMMARY_FN_SRC"
+[[ -f "$CORE_TERMINAL_FN_SRC" ]] || fail "core-terminal registry missing: $CORE_TERMINAL_FN_SRC"
+
+# write_summary_with_writer <summary-fn-path> <dir> <suite> <status> <secs> [failed]
+write_summary_with_writer() {
+  local writer_src="$1" root="$2" elapsed="$3" warm_status="$4" warm_secs="$5" failed="${6-}"
+  local driver="$root/.summary-driver.sh"
+  mkdir -p "$root/artifacts/ci-journey"
+  cat > "$driver" <<'DRIVEREOF'
+#!/usr/bin/env bash
+set -uo pipefail
+writer_src="$1"; summary_out="$2"; elapsed="$3"; warm_status="$4"; warm_secs="$5"
+failed="${6-}"
+# shellcheck source=/dev/null
+source "$(dirname "$writer_src")/ci-journey-core-terminal-functions.sh"
+# shellcheck source=/dev/null
+source "$writer_src"
+# Pin the writer's clock: see the comment on write_real_summary.
+unset SECONDS
+SECONDS="$elapsed"
+SUITE_START=0
+STEP_TIMEOUT_HIT=0
+PASSED_FIRST_TRY=(); RECOVERED_CLASSES=(); BUDGET_TIMEOUT_CLASSES=()
+# Every array the writer's evidence sections read. The writer runs under
+# `set -u`, so a section added later that reads a NEW array will abort here
+# rather than silently emitting nothing — see the unbound-variable branch in
+# write_summary_with_writer for what that failure says.
+BUILD_PHASE_TIMEOUT_ATTEMPTS=()   # issue #1814
+BUILD_PHASE_FAILURE_ATTEMPTS=()   # issue #1840
+FAILED_CLASSES=()
+[[ -n "$failed" ]] && FAILED_CLASSES=("$failed")
+EFFECTIVE_JOURNEY_CLASSES=()
+for _i in $(seq 1 49); do
+  EFFECTIVE_JOURNEY_CLASSES+=("com.pocketshell.app.proof.Fixture${_i}E2eTest")
+done
+JOURNEY_CI_SHARD_INDEX=1; JOURNEY_CI_SHARD_TOTAL=3
+JOURNEY_WARM_BUILD_STATUS="$warm_status"
+JOURNEY_WARM_BUILD_ELAPSED="$warm_secs"
+JOURNEY_STEP_BUDGET_SECS=4200
+SUMMARY="$summary_out"
+finish_ci_journey_suite
+DRIVEREOF
+  bash "$driver" "$writer_src" "$root/artifacts/ci-journey/summary.md" \
+    "$elapsed" "$warm_status" "$warm_secs" "$failed" > "$root/.summary-driver.log" 2>&1
+  local rc=$?
+  # A writer section that reads an array this driver does not seed aborts under
+  # `set -u`. Name that explicitly: it is a one-line fix (seed the array above),
+  # and the alternative — quietly treating it as a writer failure — would hide a
+  # perfectly ordinary sibling change behind an opaque exit code.
+  if grep -q 'unbound variable' "$root/.summary-driver.log" 2>/dev/null; then
+    cat "$root/.summary-driver.log"
+    fail "the real summary writer needs a fixture variable this driver does not seed (see above). ci-journey-summary-functions.sh has gained an evidence section reading a new array — add it to the driver's array block; do NOT go back to hand-shaping the summary."
+  fi
+  # finish_ci_journey_suite exits with the suite's own verdict: 0 clean, 1 when a
+  # class failed both attempts. Anything else means the writer itself blew up.
+  if [[ -n "$failed" ]]; then
+    (( rc == 1 )) || { cat "$root/.summary-driver.log"; fail "the real summary writer exited $rc for a failing fixture (expected 1)"; }
+  else
+    (( rc == 0 )) || { cat "$root/.summary-driver.log"; fail "the real summary writer exited $rc for a clean fixture (expected 0)"; }
+  fi
+  [[ -s "$root/artifacts/ci-journey/summary.md" ]] \
+    || { cat "$root/.summary-driver.log"; fail "the real summary writer produced no summary"; }
+}
+
+write_real_summary() {
+  write_summary_with_writer "$SUMMARY_FN_SRC" "$@"
+}
+
+root="$warm_ws/ok"; write_real_summary "$root" 3017 ok 373
+parsed="$(bash "$WARM_ELAPSED" "$root/artifacts/ci-journey/summary.md")" \
+  || fail "(s) could not read the warm build from a real-shaped summary"
+[[ "$parsed" == "373" ]] || fail "(s) warm build parsed as '$parsed', expected 373"
+[[ "$(bash "$SUITE_ELAPSED" "$root/artifacts/ci-journey/summary.md")" == "3017" ]] \
+  || fail "(s) the #1800 suite-elapsed reader must be unaffected by the warm line"
+pass "(s) the warm-build reader parses the suite's real summary line"
+
+for status in failed skipped not_run; do
+  root="$warm_ws/$status"; write_real_summary "$root" 3017 "$status" 373
+  bash "$WARM_ELAPSED" "$root/artifacts/ci-journey/summary.md" >/dev/null 2>&1 \
+    && fail "(s2) a '$status' warm build must NOT be deductible — the class loop paid that build, so there is nothing separately measured to subtract"
+done
+bash "$WARM_ELAPSED" "$warm_ws/does-not-exist.md" >/dev/null 2>&1 \
+  && fail "(s3) a missing summary must fail so the caller keeps #1800's model"
+printf 'no warm line here\n' > "$warm_ws/no-warm.md"
+bash "$WARM_ELAPSED" "$warm_ws/no-warm.md" >/dev/null 2>&1 \
+  && fail "(s3) a summary with no warm-build line must fail rather than guess"
+pass "(s2/s3) a non-ok, missing, or unreadable warm build falls back to #1800 instead of guessing"
+
+# (s4) THE COUPLING PIN — the other half of deriving the fixture from the real
+#      writer. Deriving proves the reader can parse TODAY's writer. This proves
+#      the pair is genuinely coupled: if the writer's line drifts, the reader
+#      must FAIL LOUDLY rather than quietly return nothing and revert the whole
+#      #1833 correction to #1800 with every test still green.
+#
+#      Each mutant is applied to a COPY of the real writer, and each is proven
+#      LIVE before its verdict is trusted: the mutated writer must still produce
+#      a summary, and that summary's warm-build line must actually differ from
+#      the real one. A mutation that never took effect would read exactly like a
+#      well-coupled pair, which is the mutation-testing failure mode this repo
+#      has hit before (#1641).
+mutant_dir="$warm_ws/writer-mutants"
+mkdir -p "$mutant_dir"
+cp "$CORE_TERMINAL_FN_SRC" "$mutant_dir/"
+real_root="$warm_ws/coupling-real"
+write_real_summary "$real_root" 2531 ok 489
+real_warm_line="$(grep '^Warm build' "$real_root/artifacts/ci-journey/summary.md")"
+[[ -n "$real_warm_line" ]] || fail "(s4) the real writer emitted no warm-build line at all"
+
+# apply_writer_mutant <src> <out> <literal-old> <literal-new>
+#
+# Literal, single-occurrence substitution. Exits non-zero unless <literal-old>
+# occurred EXACTLY once, so a mutant that silently matched nothing (or matched
+# a comment as well as the code) can never be mistaken for a live one.
+apply_writer_mutant() {
+  MUTANT_OLD="$3" MUTANT_NEW="$4" python3 - "$1" "$2" <<'PYEOF'
+import os, sys
+src, out = sys.argv[1], sys.argv[2]
+old, new = os.environ["MUTANT_OLD"], os.environ["MUTANT_NEW"]
+text = open(src, encoding="utf-8").read()
+if text.count(old) != 1:
+    sys.exit("mutant anchor occurred %d times, expected exactly 1" % text.count(old))
+open(out, "w", encoding="utf-8").write(text.replace(old, new))
+PYEOF
+}
+
+# label | literal old | literal new — each is a plausible future edit to the
+# writer's warm-build line, not an artificial corruption.
+# shellcheck disable=SC2016 # These are the writer's literal `${...}` source text.
+WRITER_MUTANTS=(
+  'issue tag renamed|Warm build (issue #1814):|Warm build (#1814):'
+  'status emphasis dropped|**${JOURNEY_WARM_BUILD_STATUS:-not_run}**|${JOURNEY_WARM_BUILD_STATUS:-not_run}'
+  'unit spaced off the number|in ${JOURNEY_WARM_BUILD_ELAPSED:-0}s|in ${JOURNEY_WARM_BUILD_ELAPSED:-0} s'
+  'seconds relabelled|in ${JOURNEY_WARM_BUILD_ELAPSED:-0}s|in ${JOURNEY_WARM_BUILD_ELAPSED:-0}sec'
+  'phase renamed|Warm build (issue #1814)|Up-front build (issue #1814)'
+)
+for entry in "${WRITER_MUTANTS[@]}"; do
+  label="${entry%%|*}"; rest="${entry#*|}"
+  old_text="${rest%%|*}"; new_text="${rest#*|}"
+  mutant="$mutant_dir/ci-journey-summary-functions.sh"
+  apply_writer_mutant "$SUMMARY_FN_SRC" "$mutant" "$old_text" "$new_text" \
+    || fail "(s4) the '$label' mutant's anchor is no longer present exactly once in ci-journey-summary-functions.sh. Either the writer's warm-build line has ALREADY drifted (in which case scripts/ci-journey-warm-build-elapsed.sh has stopped reading it and #1833 has silently reverted to #1800 — fix the reader), or this mutant needs re-anchoring. Do not delete the case."
+  ! cmp -s "$mutant" "$SUMMARY_FN_SRC" \
+    || fail "(s4) the '$label' mutant did not change the writer — the mutation is a no-op and its verdict would be meaningless"
+  mroot="$warm_ws/mutant-$RANDOM$RANDOM"
+  write_summary_with_writer "$mutant" "$mroot" 2531 ok 489
+  mutant_summary="$mroot/artifacts/ci-journey/summary.md"
+  # Liveness, proven from the OUTPUT rather than assumed from the edit: the
+  # mutated writer must still write a real summary, and that summary must differ
+  # from the real writer's.
+  [[ "$(bash "$SUITE_ELAPSED" "$mutant_summary")" == "2531" ]] \
+    || fail "(s4) the '$label' mutant broke the writer outright (its summary no longer carries the #1800 suite elapsed) — that models a build break, not the wording drift under test"
+  ! cmp -s "$mutant_summary" "$real_root/artifacts/ci-journey/summary.md" \
+    || fail "(s4) the '$label' mutant produced a summary IDENTICAL to the real writer's — the mutation is not live and its verdict would be meaningless"
+  if bash "$WARM_ELAPSED" "$mutant_summary" >/dev/null 2>&1; then
+    grep -n '1814' "$mutant_summary" || true
+    fail "(s4) the reader still parsed a '$label' writer — the reader and writer are NOT coupled, so a wording change to ci-journey-summary-functions.sh would silently revert #1833 to #1800 with every test green"
+  fi
+done
+pass "(s4) ${#WRITER_MUTANTS[@]} live mutations of the REAL writer's warm-build line each make the reader fail loudly — the pair cannot drift apart in silence"
+
+echo
+echo "== #1833 the workflow wires the reading through the REAL step bodies =="
+
+# extract_step_body <step-name> <out-path> <expressions-json>
+#
+# Pull the step's actual `run: |` block out of tests.yml and substitute its
+# `${{ }}` expressions from an explicit map. An UNMAPPED expression is a HARD
+# FAILURE (#1827): silently blanking one would let this harness report green
+# over a wiring it never actually exercised.
+extract_step_body() {
+  STEP_NAME="$1" CLASSIFY_EXPRESSIONS="$3" python3 - "$WORKFLOW" "$2" <<'PYEOF'
+import json
+import os
+import re
+import sys
+
+workflow, out_path = sys.argv[1], sys.argv[2]
+mapping = json.loads(os.environ["CLASSIFY_EXPRESSIONS"])
+step_name = os.environ["STEP_NAME"]
+lines = open(workflow, encoding="utf-8").read().splitlines()
+
+step_re = re.compile(r"^(\s*)- name: " + re.escape(step_name))
+start = indent = None
+for i, line in enumerate(lines):
+    m = step_re.match(line)
+    if m:
+        start, indent = i, len(m.group(1))
+        break
+if start is None:
+    sys.exit("could not find step %r in %s" % (step_name, workflow))
+
+run_idx = None
+for j in range(start + 1, len(lines)):
+    line = lines[j]
+    if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+        break
+    if re.match(r"^\s*run: \|\s*$", line):
+        run_idx = j
+        break
+if run_idx is None:
+    sys.exit("step %r has no `run: |` block" % step_name)
+
+run_indent = len(lines[run_idx]) - len(lines[run_idx].lstrip())
+body = []
+for j in range(run_idx + 1, len(lines)):
+    line = lines[j]
+    if not line.strip():
+        body.append("")
+        continue
+    if (len(line) - len(line.lstrip())) <= run_indent:
+        break
+    body.append(line)
+if not [line for line in body if line.strip()]:
+    sys.exit("step %r has an empty run block" % step_name)
+
+pad = min(len(line) - len(line.lstrip()) for line in body if line.strip())
+text = "\n".join(line[pad:] if line.strip() else "" for line in body)
+
+unknown = []
+
+
+def substitute(match):
+    expr = match.group(1).strip()
+    if expr not in mapping:
+        unknown.append(expr)
+        return ""
+    return mapping[expr]
+
+
+text = re.sub(r"\$\{\{(.*?)\}\}", substitute, text)
+if unknown:
+    sys.exit("unmapped workflow expression(s): %s" % ", ".join(sorted(set(unknown))))
+
+with open(out_path, "w", encoding="utf-8") as handle:
+    handle.write(text + "\n")
+PYEOF
+}
+
+# run_journey_summary_step <workspace> — execute the REAL "Inspect first journey
+# summary" step. Sets SUMMARY_SUITE_SECS / SUMMARY_WARM_SECS from its own
+# $GITHUB_OUTPUT, so the wiring under test is the production one.
+SUMMARY_SUITE_SECS=""; SUMMARY_WARM_SECS=""; SUMMARY_FAILURE=""
+run_journey_summary_step() {
+  local ws="$1" body="$ws/journey-summary-step.sh"
+  mkdir -p "$ws/scripts"
+  cp "$WARM_ELAPSED" "$SUITE_ELAPSED" "$ws/scripts/"
+  extract_step_body "Inspect first journey summary" "$body" '{}' \
+    || fail "could not extract the 'Inspect first journey summary' step body"
+  : > "$ws/summary-output.txt"
+  ( cd "$ws" && GITHUB_OUTPUT="$ws/summary-output.txt" \
+      bash --noprofile --norc -eo pipefail "$body" ) > "$ws/summary-step.log" 2>&1 \
+    || { cat "$ws/summary-step.log"; fail "the real journey-summary step exited non-zero"; }
+  SUMMARY_SUITE_SECS="$(sed -n 's/^first_suite_elapsed_secs=//p' "$ws/summary-output.txt" | tail -n 1)"
+  SUMMARY_WARM_SECS="$(sed -n 's/^first_warm_build_secs=//p' "$ws/summary-output.txt" | tail -n 1)"
+  SUMMARY_FAILURE="$(sed -n 's/^first_failure=//p' "$ws/summary-output.txt" | tail -n 1)"
+}
+
+# (t) End to end through the production step: shard 2's real summary must yield
+#     both measurements, and feeding them to the real helper must restore its
+#     retry — the exact hop the shard job performs.
+ws="$warm_ws/wire-shard2"
+write_real_summary "$ws" 2531 ok 489
+run_journey_summary_step "$ws"
+[[ "$SUMMARY_SUITE_SECS" == "2531" ]] \
+  || fail "(t) the real step read suite elapsed '$SUMMARY_SUITE_SECS', expected 2531"
+[[ "$SUMMARY_WARM_SECS" == "489" ]] \
+  || fail "(t) the real step read warm build '$SUMMARY_WARM_SECS', expected 489 — the #1833 output is not wired"
+now="$(reconstruct_now 2976238)"
+attempt_start="$(reconstruct_attempt_start "$now" "$SUMMARY_SUITE_SECS" 52256)"
+run_budget "$fixture_job_start" "$now" "$attempt_start" "$SUMMARY_SUITE_SECS" "$SUMMARY_WARM_SECS"
+[[ "$(budget_field retry_allowed)" == "true" ]] \
+  || { printf '%s\n' "$BUDGET_OUT"; fail "(t) the production step's own outputs must restore shard 2's retry"; }
+pass "(t) the real 'Inspect first journey summary' step emits first_warm_build_secs, and it restores shard 2's retry"
+
+# (t2) The same step over a non-ok warm build hands the helper nothing, so the
+#      decision stays exactly #1800's.
+ws="$warm_ws/wire-warmfailed"
+write_real_summary "$ws" 2531 failed 489
+run_journey_summary_step "$ws"
+[[ -z "$SUMMARY_WARM_SECS" ]] \
+  || fail "(t2) a failed warm build must produce an EMPTY first_warm_build_secs, got '$SUMMARY_WARM_SECS'"
+run_budget "$fixture_job_start" "$now" "$attempt_start" "$SUMMARY_SUITE_SECS" "$SUMMARY_WARM_SECS"
+[[ "$(budget_field retry_allowed)" == "false" && "$(budget_field retry_cost_model)" == "measured_first_attempt" ]] \
+  || { printf '%s\n' "$BUDGET_OUT"; fail "(t2) a failed warm build must leave #1800's refusal in place"; }
+pass "(t2) a failed warm build yields no reading and the decision reverts to #1800"
+
+# (t3) the retry-budget step passes BOTH measurements to the real helper.
+grep -q 'steps.journey_summary.outputs.first_warm_build_secs' "$WORKFLOW" \
+  || fail "(t3) the retry-budget step does not forward the measured warm build"
+grep -q 'first_warm_build_secs=' "$WORKFLOW" \
+  || fail "(t3) the journey-summary step does not export first_warm_build_secs"
+pass "(t3) the workflow forwards the measured warm build into the budget decision"
+
+echo
+echo "== #1833 a shard that cannot afford its retry SAYS SO =="
+
+# classify_expressions <journey-outcome> <first_timeout> <first_failure>
+#                      <retry_allowed> <retry_reason> <shortfall>
+classify_expressions() {
+  cat <<JSONEOF
+{
+  "steps.journey.outcome": "$1",
+  "steps.journey_retry.outcome": "skipped",
+  "steps.journey.conclusion": "$1",
+  "steps.journey_retry.conclusion": "skipped",
+  "steps.journey_summary.outputs.first_timeout": "$2",
+  "steps.journey_summary.outputs.first_failure": "$3",
+  "steps.journey_retry_budget.outputs.retry_allowed": "$4",
+  "steps.journey_retry_budget.outputs.retry_reason": "$5",
+  "steps.journey_retry_budget.outputs.retry_remaining_ms": "2976238",
+  "steps.journey_retry_budget.outputs.retry_required_ms": "3240868",
+  "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt",
+  "steps.journey_retry_budget.outputs.retry_shortfall_ms": "$6",
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0"
+}
+JSONEOF
+}
+
+CLASSIFY_OUT=""; CLASSIFY_RC=0; CLASSIFY_TOKEN=""; CLASSIFY_TOKEN_FILE=""
+# run_classify_step <workspace> <shard-index> <expressions-json>
+run_classify_step() {
+  local ws="$1" idx="$2" expressions="$3" body="$ws/classify-step.sh"
+  mkdir -p "$ws/scripts"
+  cp "$WRITER" "$SCRIPT_DIR/ci-journey-build-phase-timeout.sh" \
+     "$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh" \
+     "$SCRIPT_DIR/ci-journey-infra-signature.sh" "$SCRIPT_DIR/ci-journey-infra-signature.py" \
+     "$ws/scripts/"
+  extract_step_body "Classify emulator-journey result" "$body" "$expressions" \
+    || fail "could not extract+substitute the classify step body. If the step gained a new \${{ }} expression, add it to classify_expressions() here — a silently blanked expression would make this harness lie."
+  CLASSIFY_TOKEN_FILE="$ws/shard-verdict.txt"
+  rm -f "$CLASSIFY_TOKEN_FILE"
+  CLASSIFY_OUT="$(cd "$ws" && \
+    SHARD_VERDICT_FILE="$CLASSIFY_TOKEN_FILE" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+    GITHUB_RUN_ID=30383504733 \
+    GITHUB_RUN_ATTEMPT=1 \
+    GITHUB_OUTPUT="$ws/gh-output.txt" \
+    bash --noprofile --norc -eo pipefail "$body" 2>&1)"
+  CLASSIFY_RC=$?
+  CLASSIFY_TOKEN="$(head -n 1 "$CLASSIFY_TOKEN_FILE" 2>/dev/null || true)"
+}
+
+# (u) THE INVISIBILITY REPRODUCTION. Run 30383504733's shards 0 and 2 PASSED on
+#     the first attempt while unable to afford a retry, and their tokens said
+#     nothing but `CLEAN`. The verdict must stay CLEAN/exit 0 — severity is not
+#     the point — but the evidence must now name the one-shot condition.
+ws="$warm_ws/classify-clean-unaffordable"
+mkdir -p "$ws/artifacts/ci-journey"
+write_real_summary "$ws" 2531 ok 489
+run_classify_step "$ws" 2 "$(classify_expressions success false false false insufficient_remaining_budget 264630)"
+[[ "$CLASSIFY_TOKEN" == "CLEAN" && "$CLASSIFY_RC" -eq 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(u) a passing shard must stay CLEAN/exit0, got $CLASSIFY_TOKEN/exit$CLASSIFY_RC — surfacing must never change severity"; }
+grep -q '^retry_affordable=false$' "$CLASSIFY_TOKEN_FILE" \
+  || { cat "$CLASSIFY_TOKEN_FILE"; fail "(u) a CLEAN one-shot shard's token does not record retry_affordable=false — this is exactly the invisibility #1833 reports"; }
+grep -q '^retry_shortfall_ms=264630$' "$CLASSIFY_TOKEN_FILE" \
+  || { cat "$CLASSIFY_TOKEN_FILE"; fail "(u) the token does not carry the measured shortfall"; }
+grep -q '^retry_denied_reason=insufficient_remaining_budget$' "$CLASSIFY_TOKEN_FILE" \
+  || { cat "$CLASSIFY_TOKEN_FILE"; fail "(u) the token does not carry why the retry was denied"; }
+grep -q 'ran ONE-SHOT' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(u) the classifier emitted no one-shot annotation"; }
+pass "(u) a CLEAN shard that could not afford its retry now says so in its own verdict token"
+
+# (u2) The control: an AFFORDABLE shard must not cry wolf.
+ws="$warm_ws/classify-clean-affordable"
+mkdir -p "$ws/artifacts/ci-journey"
+write_real_summary "$ws" 2531 ok 489
+run_classify_step "$ws" 2 "$(classify_expressions success false false true sufficient_remaining_budget 0)"
+[[ "$CLASSIFY_TOKEN" == "CLEAN" && "$CLASSIFY_RC" -eq 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(u2) an affordable CLEAN shard must stay CLEAN/exit0"; }
+grep -q '^retry_affordable=true$' "$CLASSIFY_TOKEN_FILE" \
+  || { cat "$CLASSIFY_TOKEN_FILE"; fail "(u2) an affordable shard must record retry_affordable=true"; }
+grep -q 'ran ONE-SHOT' <<<"$CLASSIFY_OUT" \
+  && { printf '%s\n' "$CLASSIFY_OUT"; fail "(u2) an affordable shard must NOT emit the one-shot annotation"; }
+pass "(u2) an affordable shard records retry_affordable=true and emits no one-shot annotation"
+
+# (u3) Shard 1's real shape: a genuine first-attempt failure decided with no
+#      retry. It must stay RED/exit1 (D31: labelling never softens), and it must
+#      ALSO carry the one-shot stamp so a reader knows the RED came from ONE run.
+ws="$warm_ws/classify-red-unaffordable"
+mkdir -p "$ws/artifacts/ci-journey"
+write_real_summary "$ws" 3017 ok 373 "com.pocketshell.app.proof.PreExistingMultiWindowSeedE2eTest"
+run_classify_step "$ws" 1 "$(classify_expressions failure false true false insufficient_remaining_budget 1356524)"
+[[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_RC" -ne 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(u3) a genuine first-attempt failure must stay RED/exit non-zero, got $CLASSIFY_TOKEN/exit$CLASSIFY_RC"; }
+grep -q '^retry_affordable=false$' "$CLASSIFY_TOKEN_FILE" \
+  || { cat "$CLASSIFY_TOKEN_FILE"; fail "(u3) shard 1's RED token must record that it was decided with no cold-boot retry"; }
+grep -q '^retry_shortfall_ms=1356524$' "$CLASSIFY_TOKEN_FILE" \
+  || { cat "$CLASSIFY_TOKEN_FILE"; fail "(u3) shard 1's RED token must carry its 1356524ms shortfall"; }
+pass "(u3) a RED decided without a retry stays RED and records that it was one-shot"
+
+# (u4) The pre-seeded token (written at job start, before any budget decision)
+#      must read `unknown` — honest, and distinct from an actual denial.
+ws="$warm_ws/preseed"; mkdir -p "$ws"
+( cd "$ws" && SHARD_VERDICT_FILE="$ws/seed.txt" POCKETSHELL_JOURNEY_CI_SHARD_INDEX=0 \
+    GITHUB_RUN_ID=30383504733 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="" \
+    bash "$WRITER" INFRA preseeded_before_journey >/dev/null ) \
+  || fail "(u4) the writer refused the pre-seed"
+grep -q '^retry_affordable=unknown$' "$ws/seed.txt" \
+  || { cat "$ws/seed.txt"; fail "(u4) the pre-seeded token must read unknown, not a false affordability"; }
+pass "(u4) the pre-seeded token records retry_affordable=unknown (it has not asked yet)"
+
+echo
+echo "== #1833 the aggregate carries the one-shot condition, without changing it =="
+
+# (v) All three of run 30383504733's shards were one-shot; the aggregate must
+#     name them. Two CLEAN + one RED still aggregates to RED/exit1 (#1458).
+agg_dir="$(mktemp -d)"
+trap 'rm -rf "$verdict_dir" "$warm_ws" "$agg_dir"' EXIT
+seed_agg_token() {
+  local idx="$1" token="$2" affordable="$3" shortfall="$4"
+  local sub="$agg_dir/emulator-journey-verdict-shard-$idx"
+  mkdir -p "$sub"
+  SHARD_VERDICT_FILE="$sub/shard-verdict.txt" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+    GITHUB_RUN_ID=30383504733 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="" \
+    SHARD_RETRY_AFFORDABLE="$affordable" \
+    SHARD_RETRY_DENIED_REASON=insufficient_remaining_budget \
+    SHARD_RETRY_SHORTFALL_MS="$shortfall" \
+    bash "$WRITER" "$token" fixture >/dev/null \
+    || fail "(v) writer refused a $token token for shard $idx"
+}
+seed_agg_token 0 CLEAN false 224393
+seed_agg_token 1 RED   false 1356524
+seed_agg_token 2 CLEAN false 264630
+agg_rc=0
+agg_out="$(EXPECTED_SHARDS=3 GITHUB_RUN_ATTEMPT=1 GITHUB_STEP_SUMMARY="$agg_dir/step-summary.md" \
+  bash "$AGG" "$agg_dir" 2>&1)" || agg_rc=$?
+[[ "$agg_rc" -eq 1 ]] \
+  || { printf '%s\n' "$agg_out"; fail "(v) a RED shard must still turn the aggregate red (exit 1), got $agg_rc"; }
+grep -q '^AGGREGATE_VERDICT=RED$' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(v) expected AGGREGATE_VERDICT=RED"; }
+grep -q 'ran ONE-SHOT' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(v) the aggregate does not name the one-shot shards — a gate at half resilience still looks identical to a healthy one"; }
+for idx in 0 1 2; do
+  grep -q "shard ${idx} (" <<<"$agg_out" \
+    || { printf '%s\n' "$agg_out"; fail "(v) shard $idx is missing from the one-shot report"; }
+done
+grep -q 'ONE-SHOT' "$agg_dir/step-summary.md" \
+  || { cat "$agg_dir/step-summary.md"; fail "(v) the step summary does not carry the one-shot condition"; }
+pass "(v) the aggregate names every one-shot shard and still resolves RED/exit1"
+
+# (v2) An all-affordable run must be silent about it — the signal only fires on
+#      the condition it reports, or it becomes noise nobody reads.
+rm -rf "$agg_dir"; mkdir -p "$agg_dir"
+seed_agg_token 0 CLEAN true 0
+seed_agg_token 1 CLEAN true 0
+seed_agg_token 2 CLEAN true 0
+agg_rc=0
+agg_out="$(EXPECTED_SHARDS=3 GITHUB_RUN_ATTEMPT=1 GITHUB_STEP_SUMMARY="" \
+  bash "$AGG" "$agg_dir" 2>&1)" || agg_rc=$?
+[[ "$agg_rc" -eq 0 ]] && grep -q '^AGGREGATE_VERDICT=CLEAN$' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(v2) three affordable CLEAN shards must aggregate CLEAN/exit0"; }
+grep -q 'ONE-SHOT' <<<"$agg_out" \
+  && { printf '%s\n' "$agg_out"; fail "(v2) a fully-resilient run must not report a one-shot condition"; }
+pass "(v2) an all-affordable run stays CLEAN and reports no one-shot condition"
+
+# (v3) A token written before the stamp existed (no retry_affordable line) must
+#      neither be read as one-shot nor break the rollup.
+rm -rf "$agg_dir"; mkdir -p "$agg_dir/emulator-journey-verdict-shard-0"
+printf 'CLEAN\nshard=0\nrun_id=30383504733\nrun_attempt=1\nverdict_reason=passed_first_attempt\n' \
+  > "$agg_dir/emulator-journey-verdict-shard-0/shard-verdict.txt"
+agg_rc=0
+agg_out="$(EXPECTED_SHARDS=1 GITHUB_RUN_ATTEMPT=1 GITHUB_STEP_SUMMARY="" \
+  bash "$AGG" "$agg_dir" 2>&1)" || agg_rc=$?
+[[ "$agg_rc" -eq 0 ]] && grep -q '^AGGREGATE_VERDICT=CLEAN$' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(v3) an unstamped legacy token must still aggregate CLEAN/exit0"; }
+grep -q 'ONE-SHOT' <<<"$agg_out" \
+  && { printf '%s\n' "$agg_out"; fail "(v3) an unstamped token must not be reported as one-shot"; }
+pass "(v3) a token without the #1833 stamp is neither one-shot nor a parse failure"
+
+echo
+echo "== #1833 no budget or job cap was raised (G6) =="
+
+grep -q '^readonly JOURNEY_JOB_CAP_MS=5700000$' "$HELPER" \
+  || fail "(w) the 95-minute job cap changed"
+grep -q '^readonly JOURNEY_RETRY_REQUIRED_MS=5400000$' "$HELPER" \
+  || fail "(w) the legacy flat retry reserve changed"
+grep -q '^readonly JOURNEY_RETRY_TEARDOWN_MS=300000$' "$HELPER" \
+  || fail "(w) the teardown reserve changed"
+grep -q '^readonly JOURNEY_RETRY_SUITE_HEADROOM_NUMERATOR=110$' "$HELPER" \
+  || fail "(w) #1800's 10% suite headroom changed"
+grep -q '^readonly JOURNEY_RETRY_BOOT_HEADROOM_NUMERATOR=3$' "$HELPER" \
+  || fail "(w) #1800's 3x boot headroom changed"
+grep -q 'timeout-minutes: 95' "$WORKFLOW" \
+  || fail "(w) the emulator job's 95-minute cap changed"
+grep -q 'JOURNEY_STEP_BUDGET_SECS:-4200}' "$SCRIPT_DIR/ci-journey-suite.sh" \
+  || fail "(w) the #835 4200s suite budget changed"
+pass "(w) job cap, suite budget, flat reserve, teardown, and both #1800 headrooms are untouched"
 
 echo
 echo "ALL TESTS PASSED: scripts/test-ci-journey-retry-budget.sh"

--- a/scripts/test-ci-journey-summary-evidence.sh
+++ b/scripts/test-ci-journey-summary-evidence.sh
@@ -223,7 +223,9 @@ classify_expressions() {
   "steps.journey_retry_budget.outputs.retry_reason": "sufficient_remaining_budget",
   "steps.journey_retry_budget.outputs.retry_remaining_ms": "3112241",
   "steps.journey_retry_budget.outputs.retry_required_ms": "3028613",
-  "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt"
+  "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt",
+  "steps.journey_retry_budget.outputs.retry_shortfall_ms": "0",
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0"
 }
 JSONEOF
 }


### PR DESCRIPTION
Closes #1833 · files #1850

## Why the retry mattered

Every shard was refusing its cold-boot retry. On one run that meant a shard's RED was decided **with no retry at all** — and that RED was a #788-class swiftshader flake on a harness-only commit. The retry refusal is the mechanism by which an environmental flake hardens into a RED aggregate and costs a batch verdict.

## Part 1: the pricing was stale with respect to #1814

`required` priced the retry as if it must repeat the shard's cold Gradle build. A **within-job** retry never does, because #1814 moved that build ahead of the per-class clock. The model charged it twice plus 10% headroom.

From the one recent run where a retry actually ran, same first class both attempts:
```
attempt 1 (cold Gradle):            311s
attempt 2 (the retry, warm Gradle):  21s
```
The reviewer confirmed both attempts start with the same class **and the same next class**, and that the run predates #1814 (no `Warm build` line), so the cold build really was inside class 1's clock. It also showed this is better than a single observation — the whole-suite delta closes arithmetically: `379 − 290 − 67 ≈ 22s` of noise across 48 classes.

## Part 2: correct pricing is not sufficient — and that is the bigger finding

Round 1's review measured that the correction restores only **3 of 10** denied shard-runs, with margins decaying at **2100 ms per second** of suite growth, and concluded: *the restoration fails on exactly the runs where the retry is needed.* A retry affordable only when nothing went wrong is not resilience.

So round 2 quantified the real constraint. **Affordability has exactly one crossing point per shard-run** — `remaining` falls 1000 ms/s while `required` rises 1100 ms/s, both linear, so the margin is strictly decreasing and a second crossing is impossible without changing a constant that a test pins. Across all twelve shard-runs that crossing sits in a **111-second band: 2509–2620s of suite elapsed**. Observed suites are 1867–3017s (median 2654s). **Seven of twelve already run past their own crossing.**

The reviewer verified this is **derived, not fitted**: it re-implemented the arithmetic independently, reproduced all twelve logged `required` values **to the millisecond**, then swept suite elapsed at 1-second resolution from 600–4200s and found exactly one transition per row. The asserted constants are a ±20–30s tolerance envelope around the derived values.

**Priced options**, rebuilt by the reviewer from primary sources — the real 147-class array on `633318ea`, the real `i % N` round-robin rule, and per-class costs it extracted itself (arriving at a *more pessimistic* total than the implementer's): **3 shards denies in every profile and both distributions**; **4 shards is the evidenced minimum**, at one extra emulator job, with ~330–400s of drift headroom instead of 24–79s.

Filed as **#1850** rather than changed here — this issue's non-goals bound the *change*, not the *conclusion*, and AC2's second branch explicitly asks for the argument. The reviewer confirmed #1850 carries the full table, the derivation and the priced options, and is actionable without redoing the analysis.

## Part 3: a vacuous-guard hazard closed

Round 1 found the fixture was a hand-shaped **copy** of the writer, so an upstream format change would silently revert the entire correction to #1800 **with every test green**. It now **derives** from the real `finish_ci_journey_suite` (clock pinned, no wall-clock read), and case `(s4)` mutates the real writer five ways requiring the reader to fail on each.

The reviewer proved the difference with a mutation the *sibling* harnesses cannot see (`}s` → `} s`):
```
production reader                  exit 1   (silent revert to #1800)
test-ci-journey-warm-build.sh      exit 0
test-ci-journey-summary-evidence.sh exit 0
test-ci-journey-retry-budget.sh    exit 1   at (s)
```
That is discrimination, not agreement. It also confirmed `(s4)` is non-vacuous — loosening the reader turns it red with the correct diagnosis.

**And the deriving fixture immediately earned its keep**: because it actually runs the writer under `set -u`, it aborted against #1840's tree, which had grown a new `BUILD_PHASE_FAILURE_ATTEMPTS` array read. A mirrored copy could never have caught that, since it never runs the writer.

## Carried caveat, stated plainly

The 311s→21s observation is **pre-#1814**, so the 120s reserve has never been measured against a post-#1814 warm retry.

## Orchestrator verification

Applied to a clean worktree off `main` (`633318ea`, i.e. after #1840 merged, so the `set -u` interaction is exercised for real rather than in a synthetic combined tree). Seven modified plus **one untracked** file — `git diff` omits that, so it was copied explicitly with mode verified (775). `git diff --check` clean, workflow YAML parses.

**All eight journey harnesses pass on the rebased tree** — infra-signature, aggregate-verdict, warm-build, budget, artifact-packaging, retry-budget, summary-evidence, inter-attempt-cleanup — plus `check-ci-journey-harness` and `check-test-validity`. G6 verified by the reviewer constant-by-constant against `633318ea`: nothing raised, one step retitle, six neighbouring scripts byte-identical.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb