### PR TITLE
ci(journey): shard by class-name hash so an insertion stops reshuffling (#1862)

### DIFF
--- a/scripts/ci-journey-class-selection-functions.sh
+++ b/scripts/ci-journey-class-selection-functions.sh
@@ -17,12 +17,69 @@
 # Fix: shard the class list across a CI MATRIX of runners (.github/workflows/
 # tests.yml `strategy.matrix.shard`). Each matrix leg is its OWN runner with its
 # OWN cold-booted emulator + its OWN Docker `agents` fixtures, and runs only its
-# 1/N slice of the journey classes (round-robin by index so the heavy
-# reconnect/switch journeys at the FRONT of the list distribute evenly across
-# shards rather than all landing on one). This (a) cuts each leg's wall-clock to
-# ~1/N so it finishes comfortably inside the budget, and (b) keeps each emulator
-# far healthier (~1/N install/teardown cycles), which directly attacks the #470
+# 1/N slice of the journey classes. This (a) cuts each leg's wall-clock to ~1/N
+# so it finishes comfortably inside the budget, and (b) keeps each emulator far
+# healthier (~1/N install/teardown cycles), which directly attacks the #470
 # enumeration-stall root (a churned, degraded AVD).
+#
+# ---------------------------------------------------------------------------
+# Issue #1862: membership is assigned by HASHING THE CLASS NAME, not by the
+# entry's POSITION in the JOURNEY_CLASSES array.
+#
+# THE DEFECT THIS REMOVES
+# -----------------------
+# The original partition was round-robin by array index (`index % total`). That
+# makes a class's shard a function of how many entries happen to precede it, so
+# INSERTING ONE ENTRY re-rolls the placement of every class after it.
+#
+# Measured on the #1845 merge (commit f2aa9a8e): registering ONE new journey
+# class at index 36 moved 111 of the then-147 classes to a different shard. Two
+# of them landed on shard 2 behind ~12 co-tenants they had never run behind, hit
+# a latent timing-sensitive failure, and `main` went RED — from a commit whose
+# production diff could not reach either class. Both cold boots failed the same
+# way (4/4 per class), so it was not even re-runnable away.
+#
+# Two costs, and the second is the expensive one:
+#   * an unrelated one-line suite registration can turn `main` red, and
+#   * the red is MIS-ATTRIBUTED. The natural suspect is the commit that went in,
+#     and its diff has nothing to do with the failure — so the investigation
+#     starts from a false premise. (`ci-journey-warm-build-functions.sh` records
+#     the same mechanism producing the now-disproven "shard 0 is pathological"
+#     theory: index sharding rotates WHICH class absorbs the cold build.)
+#
+# THE FIX AND WHY THIS SHAPE
+# --------------------------
+# Assign by `hash(class_name) % total`. A class's shard then depends ONLY on its
+# own name, so adding, removing, or reordering ANY other entry leaves every
+# other class exactly where it was — the newcomer is the only class that moves.
+# Adding a journey stops being a global re-roll of the suite's placement, and a
+# red shard after a registration is real signal about the new class rather than
+# noise from 111 relocated siblings.
+#
+# The hash is FNV-1a/32 computed in pure bash over the entry's bytes: no
+# subprocess per class, no dependency on `cksum`/`md5sum`/awk availability or
+# version, and the same value on every runner and every bash >= 4. `LC_ALL=C`
+# pins byte semantics so a runner's locale cannot change the partition.
+#
+# Balance is statistical rather than exact (index round-robin was exact to +/-1).
+# That trade is deliberate and the numbers are small: over the current 148-entry
+# list the three shards get 52/48/48 against an ideal of 49.3. The suite budget
+# already carries far more slack than a couple of classes' worth, and
+# `scripts/test-ci-journey-budget.sh` pins the spread so a future list cannot
+# drift into a lopsided partition unnoticed.
+#
+# Deliberately NOT chosen:
+#   * reordering the array so the victim class moves back — that only relocates
+#     which class is next to the hostile co-tenant, and re-rolls everything again
+#     on the next insertion;
+#   * pinning classes to shards by hand — a second registry to keep in sync with
+#     the array, and it rots silently;
+#   * salting/tuning the hash so a specific class lands on a specific shard —
+#     that is the reordering hack wearing a hash costume, and it hides a real
+#     failure instead of fixing it.
+#
+# This changes WHICH shard runs a class. It does NOT change the set of classes
+# run: the partition is still disjoint and its union is still the full array.
 #
 # POCKETSHELL_JOURNEY_CI_SHARD_TOTAL / _INDEX are set by the workflow matrix.
 # Default (unset / TOTAL<=1) = the unsharded serial path, UNCHANGED — so local
@@ -32,6 +89,34 @@
 # core-terminal proofs are NOT sharded — they are cheap in-process Compose UI
 # tests (no Docker churn) and run on EVERY shard so a regression in any of them is
 # caught on every leg.
+
+# FNV-1a/32 over the bytes of "$1", printed as an unsigned decimal.
+#
+# Pure bash on purpose: this runs once per class at suite startup (~150 calls),
+# and a subprocess per class would cost more than the whole loop. Bash arithmetic
+# is 64-bit signed, so the explicit 0xFFFFFFFF masks keep it in the 32-bit
+# unsigned range that FNV-1a is defined over.
+journey_class_shard_hash() {
+  local _jcsh_s="$1"
+  local _jcsh_len=${#_jcsh_s}
+  local _jcsh_i _jcsh_byte
+  local _jcsh_h=2166136261  # FNV-1a/32 offset basis
+  local LC_ALL=C            # byte semantics, so locale cannot move a class
+  for (( _jcsh_i = 0; _jcsh_i < _jcsh_len; _jcsh_i++ )); do
+    printf -v _jcsh_byte '%d' "'${_jcsh_s:_jcsh_i:1}"
+    _jcsh_h=$(( (_jcsh_h ^ (_jcsh_byte & 255)) & 0xFFFFFFFF ))
+    _jcsh_h=$(( (_jcsh_h * 16777619) & 0xFFFFFFFF ))  # FNV-1a/32 prime
+  done
+  printf '%s' "$_jcsh_h"
+}
+
+# Shard index (0-based) this class belongs to for a given shard total.
+journey_class_shard_index() {
+  local _jcsi_total="$2"
+  (( _jcsi_total > 0 )) || _jcsi_total=1
+  printf '%s' "$(( $(journey_class_shard_hash "$1") % _jcsi_total ))"
+}
+
 select_effective_journey_classes() {
   JOURNEY_CI_SHARD_TOTAL="${POCKETSHELL_JOURNEY_CI_SHARD_TOTAL:-1}"
   JOURNEY_CI_SHARD_INDEX="${POCKETSHELL_JOURNEY_CI_SHARD_INDEX:-0}"
@@ -44,13 +129,13 @@ select_effective_journey_classes() {
   if (( JOURNEY_CI_SHARD_TOTAL <= 1 )); then
     EFFECTIVE_JOURNEY_CLASSES=("${JOURNEY_CLASSES[@]}")
   else
-    local _shard_i
-    for _shard_i in "${!JOURNEY_CLASSES[@]}"; do
-      if (( _shard_i % JOURNEY_CI_SHARD_TOTAL == JOURNEY_CI_SHARD_INDEX )); then
-        EFFECTIVE_JOURNEY_CLASSES+=("${JOURNEY_CLASSES[$_shard_i]}")
+    local _shard_class
+    for _shard_class in "${JOURNEY_CLASSES[@]}"; do
+      if (( $(journey_class_shard_hash "$_shard_class") % JOURNEY_CI_SHARD_TOTAL == JOURNEY_CI_SHARD_INDEX )); then
+        EFFECTIVE_JOURNEY_CLASSES+=("$_shard_class")
       fi
     done
-    echo ">>> CI journey shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL} (issue #835): running ${#EFFECTIVE_JOURNEY_CLASSES[@]} of ${#JOURNEY_CLASSES[@]} journey classes (round-robin), plus all 6 core-terminal proofs"
+    echo ">>> CI journey shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL} (issues #835, #1862): running ${#EFFECTIVE_JOURNEY_CLASSES[@]} of ${#JOURNEY_CLASSES[@]} journey classes (partitioned by class-name hash, so registering a journey does not re-roll the others), plus all 6 core-terminal proofs"
   fi
 }
 

--- a/scripts/ci-journey-warm-build-functions.sh
+++ b/scripts/ci-journey-warm-build-functions.sh
@@ -22,9 +22,13 @@
 #   * a first-class timeout looks EXACTLY like a genuine journey failure
 #     (`raw-junit count=0` is also what a killed runner produces), so it burns
 #     investigation time and pollutes attribution;
-#   * round-robin reshuffles shard membership whenever the class list changes,
-#     so WHICH class absorbs the cold build rotates — which is one mechanical
-#     contributor to the (now-disproven) "shard 0 is pathological" theory.
+#   * shard membership used to be round-robin by ARRAY INDEX, so it reshuffled
+#     whenever the class list changed and WHICH class absorbed the cold build
+#     rotated — one mechanical contributor to the (now-disproven) "shard 0 is
+#     pathological" theory. (Issue #1862 removed that reshuffle: membership is
+#     now derived from the class NAME, so the class that absorbs the cold build
+#     only changes when that class itself is added or removed. The accounting fix
+#     below is still the real cure — it stops any class paying for it at all.)
 #
 # THE FIX AND WHY THIS SHAPE
 # --------------------------

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -1769,15 +1769,289 @@ launched="$(grep -c '>>> JOURNEY CLASS:.*(attempt 1)' "$out2" || true)"
 pass "(neg-2) healthy run reaches a verdict for all $class_count load-bearing classes (none cut short)"
 
 # ---------------------------------------------------------------------------
+# (shard-stable) ACCEPTANCE — Issue #1862: shard membership is STABLE under
+# edits to the JOURNEY_CLASSES array.
+#
+# THE DEFECT: the partition used to be round-robin by array INDEX, so a class's
+# shard was a function of how many entries preceded it. On the #1845 merge
+# (f2aa9a8e) registering ONE class at index 36 moved 111 of 147 classes to a
+# different shard; two landed behind ~12 co-tenants they had never run behind,
+# hit a latent timing failure, and `main` went RED from a commit whose diff could
+# not reach either class. Worse than the red itself: the natural suspect is the
+# commit that went in, so the investigation starts from a false premise.
+#
+# The fix partitions by `hash(class_name) % total`, so a class's shard depends
+# only on its OWN name. This block drives the REAL helper over the REAL array and
+# asserts the load-bearing property directly: after inserting / removing an entry
+# ANYWHERE, ZERO other classes move.
+#
+# Every assertion below carries its RED CONTROL — the same fixture is re-run
+# through the OLD index reducer, which MUST move a large fraction. Without that,
+# "zero classes moved" would also pass against a hash that put everything on one
+# shard, or against a fixture that never actually differed (G6/G3).
+echo "== CI-matrix sharding: membership is stable under array insertion (#1862) =="
+
+SELECTION_HELPER="$SCRIPT_DIR/ci-journey-class-selection-functions.sh"
+[[ -f "$SELECTION_HELPER" ]] \
+  || fail "(shard-stable) cannot find ci-journey-class-selection-functions.sh at $SELECTION_HELPER"
+# shellcheck source=scripts/ci-journey-class-selection-functions.sh
+source "$SELECTION_HELPER"
+
+declare -F select_effective_journey_classes > /dev/null \
+  || fail "(shard-stable) the selection helper does not define select_effective_journey_classes"
+
+# The REAL array, parsed out of the REAL suite exactly as the harness guards do.
+mapfile -t REAL_JOURNEY_CLASSES < <(
+  awk '
+    /^JOURNEY_CLASSES=\(/ { f = 1; next }
+    /^\)/                 { f = 0 }
+    f && match($0, /"[^"]+"/) {
+      s = substr($0, RSTART + 1, RLENGTH - 2)
+      gsub(/\$FQCN_PREFIX/, "com.pocketshell.app.proof", s)
+      print s
+    }
+  ' "$REAL_SUITE"
+)
+real_class_count="${#REAL_JOURNEY_CLASSES[@]}"
+[[ "$real_class_count" -ge 80 ]] \
+  || fail "(shard-stable) parsed only $real_class_count journey classes from the real suite — enumeration changed unexpectedly"
+
+# Membership maps: "class<TAB>shard" lines, directly comparable.
+#
+# The SHIPPING map drives the REAL production entry point
+# `select_effective_journey_classes` once per shard index and records what it
+# actually selected — NOT the hash helper it happens to use internally. That
+# matters: the property under test is which classes a matrix leg RUNS, so the
+# assertion has to be on the function the suite calls (G6). If the partition is
+# ever reimplemented, this guard keeps testing the right thing.
+shard_map_shipping() {   # $1 = shard total; classes on stdin
+  local total="$1" idx
+  mapfile -t JOURNEY_CLASSES
+  for (( idx = 0; idx < total; idx++ )); do
+    EFFECTIVE_JOURNEY_CLASSES=()
+    POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$total" \
+      POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+      select_effective_journey_classes > /dev/null
+    (( ${#EFFECTIVE_JOURNEY_CLASSES[@]} > 0 )) || continue
+    printf "%s\t$idx\n" "${EFFECTIVE_JOURNEY_CLASSES[@]}"
+  done
+}
+shard_map_index() {      # RED CONTROL: the pre-#1862 `index % total` reducer
+  local total="$1" c i=0
+  while IFS= read -r c; do
+    [[ -n "$c" ]] || continue
+    printf '%s\t%s\n' "$c" "$(( i % total ))"
+    i=$((i + 1))
+  done
+}
+
+# How many of the ORIGINAL classes changed shard between two membership maps
+# (the inserted/removed class itself is excluded — it is expected to differ).
+moved_count() {       # $1 = before map file, $2 = after map file
+  join -t $'\t' -j 1 -o 1.1,1.2,2.2 \
+    <(sort -t $'\t' -k1,1 "$1") <(sort -t $'\t' -k1,1 "$2") \
+    | awk -F '\t' '$2 != $3 { n++ } END { print n + 0 }'
+}
+
+shard_total_probe=3
+NEW_ENTRY="com.pocketshell.app.proof.Issue1862SyntheticNewlyRegisteredJourneyE2eTest"
+printf '%s\n' "${REAL_JOURNEY_CLASSES[@]}" > "$SANDBOX/classes-base.txt"
+
+# The two baselines, computed ONCE.
+shard_map_shipping  "$shard_total_probe" < "$SANDBOX/classes-base.txt" > "$SANDBOX/map-hash-base.tsv"
+shard_map_index "$shard_total_probe" < "$SANDBOX/classes-base.txt" > "$SANDBOX/map-index-base.tsv"
+
+# Sanity: the baseline itself must not be degenerate — every shard must be used,
+# otherwise "nothing moved" below is trivially true.
+distinct_shards="$(cut -f2 "$SANDBOX/map-hash-base.tsv" | sort -u | wc -l)"
+[[ "$distinct_shards" -eq "$shard_total_probe" ]] \
+  || fail "(shard-stable) the hash partition used only $distinct_shards of $shard_total_probe shards on the real list — degenerate partition"
+
+# INSERTION at the head, at the #1845 position (36), and at the tail. Removal at
+# 36 too: an entry being deleted is the same class of edit and must not re-roll
+# the suite either.
+for edit in "insert:0" "insert:36" "insert:$real_class_count" "remove:36"; do
+  op="${edit%%:*}"
+  pos="${edit##*:}"
+  (( pos <= real_class_count )) || continue
+  edited="$SANDBOX/classes-$op-$pos.txt"
+  if [[ "$op" == "insert" ]]; then
+    { head -n "$pos" "$SANDBOX/classes-base.txt"
+      printf '%s\n' "$NEW_ENTRY"
+      tail -n +"$((pos + 1))" "$SANDBOX/classes-base.txt"
+    } > "$edited"
+    expected_len=$((real_class_count + 1))
+  else
+    { head -n "$pos" "$SANDBOX/classes-base.txt"
+      tail -n +"$((pos + 2))" "$SANDBOX/classes-base.txt"
+    } > "$edited"
+    expected_len=$((real_class_count - 1))
+  fi
+  [[ "$(wc -l < "$edited")" -eq "$expected_len" ]] \
+    || fail "(shard-stable) fixture build failed for $op at $pos (expected $expected_len entries)"
+  cmp -s "$edited" "$SANDBOX/classes-base.txt" \
+    && fail "(shard-stable) fixture for $op at $pos is IDENTICAL to the base list — the edit never happened, so the comparison below is vacuous"
+
+  shard_map_shipping  "$shard_total_probe" < "$edited" > "$SANDBOX/map-hash-$op-$pos.tsv"
+  shard_map_index "$shard_total_probe" < "$edited" > "$SANDBOX/map-index-$op-$pos.tsv"
+
+  moved_hash="$(moved_count "$SANDBOX/map-hash-base.tsv" "$SANDBOX/map-hash-$op-$pos.tsv")"
+  moved_index="$(moved_count "$SANDBOX/map-index-base.tsv" "$SANDBOX/map-index-$op-$pos.tsv")"
+
+  # The load-bearing assertion.
+  [[ "$moved_hash" -eq 0 ]] \
+    || fail "(shard-stable) $op at index $pos moved $moved_hash pre-existing classes to a different shard — membership must depend ONLY on the class name (#1862)"
+
+  # RED CONTROL: the same fixture through the OLD reducer must move a large
+  # fraction, proving the zero above is a real property and not a no-op fixture.
+  # A tail edit legitimately moves nothing under index sharding, so only the
+  # edits that precede other entries carry the control.
+  if [[ "$pos" -lt "$real_class_count" ]]; then
+    min_expected_moved=$(( (real_class_count - pos) / 2 ))
+    [[ "$moved_index" -ge "$min_expected_moved" ]] \
+      || fail "(shard-stable) red control is not live: the OLD index reducer moved only $moved_index classes for $op at $pos (expected >= $min_expected_moved) — the fixture cannot distinguish the two partitions"
+    echo "  ok: $op at $pos — hash moved 0, old index reducer moved $moved_index of $real_class_count (control live)"
+  else
+    echo "  ok: $op at $pos — hash moved 0 (tail edit; index reducer is trivially stable here, no control claimed)"
+  fi
+done
+pass "(shard-stable) inserting/removing a journey class anywhere moves ZERO other classes; the old index reducer re-rolls up to two thirds of the list"
+
+# (shard-stable-det) The partition must be a pure function of the class NAMES —
+# the same on every runner. Two runners disagreeing would break the disjoint/
+# complete property across the matrix (a class run twice, or never). The two
+# realistic ways that breaks are locale-dependent character semantics and a
+# dependency on evaluation order, so pin both, through the production entry
+# point rather than its internals.
+for det_locale in C C.UTF-8 en_US.UTF-8 POSIX; do
+  LC_ALL="$det_locale" shard_map_shipping "$shard_total_probe" \
+    < "$SANDBOX/classes-base.txt" > "$SANDBOX/map-det-$det_locale.tsv"
+  cmp -s <(sort "$SANDBOX/map-det-$det_locale.tsv") <(sort "$SANDBOX/map-hash-base.tsv") \
+    || fail "(shard-stable-det) the partition differs under LC_ALL=$det_locale — two runners could disagree about which shard owns a class"
+done
+# Order independence: reversing the input array must not change any assignment.
+tac "$SANDBOX/classes-base.txt" > "$SANDBOX/classes-reversed.txt"
+shard_map_shipping "$shard_total_probe" < "$SANDBOX/classes-reversed.txt" > "$SANDBOX/map-reversed.tsv"
+reversed_moved="$(moved_count "$SANDBOX/map-hash-base.tsv" "$SANDBOX/map-reversed.tsv")"
+[[ "$reversed_moved" -eq 0 ]] \
+  || fail "(shard-stable-det) reversing the array moved $reversed_moved classes — the partition still depends on position, not only on the class name"
+reversed_moved_index="$(moved_count "$SANDBOX/map-index-base.tsv" \
+  <(shard_map_index "$shard_total_probe" < "$SANDBOX/classes-reversed.txt"))"
+[[ "$reversed_moved_index" -ge $(( real_class_count / 2 )) ]] \
+  || fail "(shard-stable-det) red control is not live: reversing the array moved only $reversed_moved_index classes under the OLD index reducer"
+pass "(shard-stable-det) the partition is identical under 4 locales and under a fully reversed array (the old index reducer moves $reversed_moved_index of $real_class_count when reversed)"
+
+# (shard-balance) Hash partitioning trades EXACT balance (index round-robin was
+# +/-1) for stability. That trade must stay bounded. TWO different properties are
+# at stake and they need different bands, so both are asserted explicitly:
+#
+#   `uniform` — the hash behaves like a uniform partition at all. Band is 3
+#     standard deviations of the binomial (sd = sqrt(n*(T-1))/T), which is the
+#     right shape for a statistical partition and does NOT tighten as the list
+#     shrinks. A guard tighter than this is flaky-by-construction: a legitimate
+#     uniform draw would trip it on some future list. This is the control that
+#     actually catches a broken/collapsing hash.
+#
+#   `budget` — additionally, an UPPER cap at 125% of the ideal share, applied
+#     only to the total=3 configuration CI really runs. A shard 25% over its
+#     share spends 25% more wall-clock against the #835 suite budget, so it is
+#     worth a human look. Only the upper bound is capped: an UNDER-full shard
+#     costs nothing, and capping it too would double the false-trip surface for
+#     no benefit.
+#
+# Characterised over the REAL list at three totals and over synthetic 60/300-class
+# lists, so the property is measured across sizes rather than sampled once.
+assert_balanced() {   # $1 = label, $2 = total, $3 = budget|uniform, classes on stdin
+  local label="$1" total="$2" mode="$3" n ideal tol low high cap s count
+  local -a counts=()
+  local tmp="$SANDBOX/balance-$label-$total.tsv"
+  shard_map_shipping "$total" > "$tmp"
+  n="$(wc -l < "$tmp")"
+  ideal=$(( n / total ))
+  # 3 * sd of Binomial(n, 1/total): sd = sqrt(n*(total-1))/total.
+  tol="$(awk -v n="$n" -v t="$total" 'BEGIN { printf "%d", int(3 * sqrt(n * (t - 1)) / t) + 1 }')"
+  low=$(( ideal - tol ));  (( low < 0 )) && low=0
+  high=$(( ideal + tol ))
+  for (( s = 0; s < total; s++ )); do
+    count="$(awk -F '\t' -v s="$s" '$2 == s { n++ } END { print n + 0 }' "$tmp")"
+    counts+=("$count")
+    [[ "$count" -ge "$low" && "$count" -le "$high" ]] \
+      || fail "(shard-balance) $label total=$total: shard $s has $count of $n classes, outside the 3-sigma uniform band [$low,$high] (ideal $ideal) — the class hash is not partitioning uniformly"
+  done
+  if [[ "$mode" == "budget" ]]; then
+    cap=$(( (n * 125 + (total * 100) - 1) / (total * 100) ))
+    for (( s = 0; s < total; s++ )); do
+      [[ "${counts[$s]}" -le "$cap" ]] \
+        || fail "(shard-balance) $label total=$total: shard $s carries ${counts[$s]} of $n classes, over the $cap budget cap (125% of the $ideal ideal) — that leg spends >25% extra wall-clock against the #835 suite budget"
+    done
+    echo "  ok: balance $label total=$total -> ${counts[*]} (ideal $ideal, uniform band [$low,$high], budget cap $cap)"
+  else
+    echo "  ok: balance $label total=$total -> ${counts[*]} (ideal $ideal, uniform band [$low,$high])"
+  fi
+}
+assert_balanced "real" 3 budget  < "$SANDBOX/classes-base.txt"
+assert_balanced "real" 2 uniform < "$SANDBOX/classes-base.txt"
+assert_balanced "real" 4 uniform < "$SANDBOX/classes-base.txt"
+for synth_n in 60 300; do
+  seq 1 "$synth_n" \
+    | awk '{ printf "com.pocketshell.app.proof.Synthetic%04dJourneyE2eTest\n", $1 }' \
+      > "$SANDBOX/classes-synth-$synth_n.txt"
+  assert_balanced "synth$synth_n" 3 uniform < "$SANDBOX/classes-synth-$synth_n.txt"
+done
+# RED CONTROLS for the two bands. Each must fail, and must fail for ITS OWN
+# reason — a control that trips the other band would leave one of the two
+# assertions unproven (G6). Both shadow inside a subshell only.
+degen_out="$SANDBOX/balance-degenerate.log"
+(
+  journey_class_shard_hash() { printf '7'; }   # every class -> one shard
+  assert_balanced "degenerate" 3 uniform < "$SANDBOX/classes-base.txt"
+) > "$degen_out" 2>&1 \
+  && fail "(shard-balance) red control is not live: a hash that puts EVERY class on one shard passed the 3-sigma uniform band"
+grep -q 'uniform band' "$degen_out" \
+  || { cat "$degen_out"; fail "(shard-balance) the degenerate control failed for the wrong reason — it must trip the 3-sigma UNIFORM band"; }
+
+# A partition that is uniform-looking but ONE class over the 125% cap: it must
+# pass the 3-sigma band and still be rejected by the budget cap, proving the cap
+# is load-bearing on its own rather than shadowed by the wider uniform band.
+tilt_cap=$(( (real_class_count * 125 + 299) / 300 ))
+tilt_target=$(( tilt_cap + 1 ))
+tilt_out="$SANDBOX/balance-tilted.log"
+(
+  TILT_TARGET="$tilt_target"
+  shard_map_shipping() {
+    local _total="${1:-3}" c i=0
+    while IFS= read -r c; do
+      [[ -n "$c" ]] || continue
+      if (( i < TILT_TARGET )); then
+        printf '%s\t0\n' "$c"
+      else
+        printf '%s\t%s\n' "$c" "$(( 1 + (i % 2) ))"
+      fi
+      i=$((i + 1))
+    done
+  }
+  assert_balanced "tilted" 3 budget < "$SANDBOX/classes-base.txt"
+) > "$tilt_out" 2>&1 \
+  && fail "(shard-balance) red control is not live: a shard one class over the 125% budget cap passed the budget check"
+grep -q 'budget cap' "$tilt_out" \
+  || { cat "$tilt_out"; fail "(shard-balance) the tilted control ($tilt_target of $real_class_count on one shard) failed for the wrong reason — it must trip the 125% BUDGET CAP, not the uniform band"; }
+pass "(shard-balance) the partition is uniform to 3 sigma on the real list (totals 2/3/4) and on synthetic 60/300-class lists, and stays under the 125% budget cap at total=3; degenerate and tilted partitions are both rejected"
+
+# ---------------------------------------------------------------------------
 # (shard) ACCEPTANCE — Issue #835 (REOPENED): CI-matrix sharding partitions
-# JOURNEY_CLASSES round-robin so each leg runs a DISJOINT ~1/N slice and the
-# UNION of all legs is the FULL set. This is the structural fix that lets the
-# suite finish within the budget+cap (each leg ~1/N the wall-clock + a far
-# healthier emulator). Drive the REAL suite once per shard (instant gradle stub,
-# generous budget) and assert: (a) each shard launches ~class_count/N classes,
-# (b) the slices are pairwise DISJOINT (no class on two shards), (c) the UNION is
-# every class (none dropped), (d) the core-terminal proofs run on EVERY shard.
-echo "== CI-matrix sharding: round-robin partition is disjoint + complete =="
+# JOURNEY_CLASSES so each leg runs a DISJOINT ~1/N slice and the UNION of all
+# legs is the FULL set. This is the structural fix that lets the suite finish
+# within the budget+cap (each leg ~1/N the wall-clock + a far healthier
+# emulator). Drive the REAL suite once per shard (instant gradle stub, generous
+# budget) and assert: (a) each shard launches ~class_count/N classes, (b) the
+# slices are pairwise DISJOINT (no class on two shards), (c) the UNION is every
+# class (none dropped), (d) the core-terminal proofs run on EVERY shard.
+#
+# Issue #1862 widened (a)'s tolerance from +/-2 to +/-25%: the partition is now
+# by class-name hash, which is statistically rather than exactly balanced. The
+# tight per-shard spread is pinned separately by (shard-balance) above; what THIS
+# block owns is that the end-to-end suite really runs the partition it computes.
+echo "== CI-matrix sharding: hash partition is disjoint + complete =="
 cat > "$SANDBOX/gradlew" <<'STUB'
 #!/usr/bin/env bash
 exit 0
@@ -1802,10 +2076,10 @@ for shard_idx in 0 1 2; do
     || { sed -n '1,40p' "$shard_log"; fail "(shard) shard $shard_idx exited $rc_shard; expected clean pass on the instant stub"; }
   mapfile -t shard_classes < <(grep -E '>>> JOURNEY CLASS: [^ ]+ \(attempt 1\)' "$shard_log" | awk '{print $4}')
   shard_n="${#shard_classes[@]}"
-  lo=$(( class_count / shard_total - 2 ))
-  hi=$(( class_count / shard_total + 2 ))
+  lo=$(( class_count * 75 / (shard_total * 100) ))
+  hi=$(( (class_count * 125 + (shard_total * 100) - 1) / (shard_total * 100) ))
   [[ "$shard_n" -ge "$lo" && "$shard_n" -le "$hi" ]] \
-    || fail "(shard) shard $shard_idx launched $shard_n classes; expected ~$((class_count / shard_total)) (±2)"
+    || fail "(shard) shard $shard_idx launched $shard_n classes; expected ~$((class_count / shard_total)) (band [$lo,$hi] — #1862 hash partition)"
   for sc in "${shard_classes[@]}"; do
     [[ -z "${seen_class_shard[$sc]:-}" ]] \
       || fail "(shard) class $sc ran on BOTH shard ${seen_class_shard[$sc]} and shard $shard_idx — partition not disjoint"
@@ -1817,7 +2091,7 @@ for shard_idx in 0 1 2; do
 done
 [[ "$shard_union_count" -eq "$class_count" ]] \
   || fail "(shard) union of all shards = $shard_union_count classes, expected the full $class_count (a class ran on no shard or twice)"
-pass "(shard) round-robin partition: 3 shards each ~1/3, disjoint, union = all $class_count classes; proofs on every shard"
+pass "(shard) hash partition: 3 shards each ~1/3, disjoint, union = all $class_count classes; proofs on every shard"
 
 # ---------------------------------------------------------------------------
 # (m) ACCEPTANCE — Issue #835 (REOPENED): the six core-terminal proofs are now

--- a/scripts/test-ci-journey-inter-attempt-cleanup.sh
+++ b/scripts/test-ci-journey-inter-attempt-cleanup.sh
@@ -83,19 +83,39 @@ HELPERS=(
   ci-journey-summary-functions.sh
 )
 
-# The class this fixture wedges: the first entry of the real allowlist, read from
-# the real file so a reordering of JOURNEY_CLASSES cannot silently make this test
-# exercise a different class.
-first_entry="$(awk '
-  /^JOURNEY_CLASSES=\(/ { f=1; next }
-  /^\)/ { f=0 }
-  f && /^[[:space:]]*"/ { print; exit }
-' "$REAL_SUITE" | sed 's/^[[:space:]]*"\([^"]*\)".*/\1/')"
-WEDGE_CLASS="${first_entry##*.}"
-[[ -n "$WEDGE_CLASS" ]] || fail "(setup) could not resolve the first journey class from the allowlist"
+# The class this fixture wedges: the class SHARD 0 RUNS FIRST, read from the real
+# file so a reordering of JOURNEY_CLASSES cannot silently make this test exercise
+# a different class.
+#
+# Issue #1862: that is no longer the array's first entry. Shard membership is now
+# assigned by class-name HASH rather than array index, so `index 0 -> shard 0` no
+# longer holds — and the run below drives shard 0. Ask the REAL selection instead
+# of assuming array position, so this stays correct under any future partitioning.
 FQCN_PREFIX="$(sed -n 's/^FQCN_PREFIX="\([^"]*\)"$/\1/p' "$REAL_SUITE" | head -n 1)"
 [[ -n "$FQCN_PREFIX" ]] || fail "(setup) could not resolve FQCN_PREFIX from the suite"
-WEDGE_FQCN="${first_entry/\$FQCN_PREFIX/$FQCN_PREFIX}"
+# shellcheck source=scripts/ci-journey-class-selection-functions.sh
+source "$SCRIPT_DIR/ci-journey-class-selection-functions.sh"
+resolve_first_class_on_shard() {   # $1 = shard index, $2 = shard total
+  local -a JOURNEY_CLASSES=() EFFECTIVE_JOURNEY_CLASSES=()
+  local i
+  mapfile -t JOURNEY_CLASSES < <(
+    awk '
+      /^JOURNEY_CLASSES=\(/ { f = 1; next }
+      /^\)/                 { f = 0 }
+      f && match($0, /"[^"]+"/) { print substr($0, RSTART + 1, RLENGTH - 2) }
+    ' "$REAL_SUITE"
+  )
+  (( ${#JOURNEY_CLASSES[@]} > 0 )) || return 1
+  for i in "${!JOURNEY_CLASSES[@]}"; do
+    JOURNEY_CLASSES[$i]="${JOURNEY_CLASSES[$i]/\$FQCN_PREFIX/$FQCN_PREFIX}"
+  done
+  POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$2" POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$1" \
+    select_effective_journey_classes > /dev/null
+  printf '%s' "${EFFECTIVE_JOURNEY_CLASSES[0]:-}"
+}
+WEDGE_FQCN="$(resolve_first_class_on_shard 0 3)"
+[[ -n "$WEDGE_FQCN" ]] || fail "(setup) could not resolve the first journey class of shard 0 from the allowlist"
+WEDGE_CLASS="${WEDGE_FQCN##*.}"
 command -v setsid >/dev/null 2>&1 \
   || fail "(setup) setsid is required: the fixture must detach its orphan writer into its OWN session, because GNU timeout signals the whole process GROUP and the real Gradle/Kotlin daemons are session-detached"
 echo "   wedging the first class of shard 0: $WEDGE_FQCN"

--- a/scripts/test-ci-journey-summary-evidence.sh
+++ b/scripts/test-ci-journey-summary-evidence.sh
@@ -56,6 +56,75 @@ done
 SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
+# ---------------------------------------------------------------------------
+# The "exactly ONE journey class" selector (issue #1862).
+#
+# `run_real_suite` needs a run in which exactly ONE journey class is selected, so
+# the fixture's failing class is unambiguous and the budget cases below have no
+# second loop iteration. That used to be spelled `SHARD_TOTAL=400 / INDEX=0`,
+# which worked only because membership was `array_index % total` — index 0 was
+# the array's first entry and nothing else could land on bucket 0.
+#
+# Membership is now `hash(class_name) % total`, so bucket 0 of 400 is an
+# arbitrary (possibly empty, possibly multi-class) set. Ask the REAL selection
+# which bucket holds exactly one class, and use that bucket AND that class. The
+# fixture's intent is preserved exactly and is no longer coupled to the
+# partitioning arithmetic.
+SOLO_SHARD_TOTAL=400
+# shellcheck source=scripts/ci-journey-class-selection-functions.sh
+source "$SCRIPT_DIR/ci-journey-class-selection-functions.sh"
+declare -F journey_class_shard_hash > /dev/null \
+  || fail "(setup) the selection helper no longer exposes journey_class_shard_hash — re-derive the single-class shard below against whatever replaced it (do NOT fall back to array position, issue #1862)"
+
+SOLO_JOURNEY_CLASSES=()
+mapfile -t SOLO_JOURNEY_CLASSES < <(
+  awk '
+    /^JOURNEY_CLASSES=\(/ { f = 1; next }
+    /^\)/                 { f = 0 }
+    f && match($0, /"[^"]+"/) {
+      s = substr($0, RSTART + 1, RLENGTH - 2)
+      gsub(/\$FQCN_PREFIX/, "com.pocketshell.app.proof", s)
+      print s
+    }
+  ' "$SUITE"
+)
+(( ${#SOLO_JOURNEY_CLASSES[@]} > 0 )) \
+  || fail "(setup) could not parse JOURNEY_CLASSES out of $SUITE"
+
+# One O(N) pass to find a bucket holding exactly one class...
+declare -A solo_bucket_count=() solo_bucket_class=()
+for solo_c in "${SOLO_JOURNEY_CLASSES[@]}"; do
+  solo_b=$(( $(journey_class_shard_hash "$solo_c") % SOLO_SHARD_TOTAL ))
+  solo_bucket_count[$solo_b]=$(( ${solo_bucket_count[$solo_b]:-0} + 1 ))
+  solo_bucket_class[$solo_b]="$solo_c"
+done
+# Lowest singleton bucket, NOT the first one bash's hash order happens to yield:
+# associative-array iteration order is not guaranteed stable across bash builds,
+# and a fixture that silently tests a different class on a different runner is
+# exactly the kind of irreproducibility this suite exists to remove.
+SOLO_SHARD_INDEX=""; SOLO_CLASS=""
+for solo_b in $(printf '%s\n' "${!solo_bucket_count[@]}" | sort -n); do
+  if (( solo_bucket_count[$solo_b] == 1 )); then
+    SOLO_SHARD_INDEX="$solo_b"; SOLO_CLASS="${solo_bucket_class[$solo_b]}"
+    break
+  fi
+done
+[[ "$SOLO_SHARD_INDEX" =~ ^[0-9]+$ && -n "$SOLO_CLASS" ]] \
+  || fail "(setup) no shard of $SOLO_SHARD_TOTAL holds exactly ONE journey class — the single-class fixture below would be ambiguous"
+
+# ...then CONFIRM it against the REAL production selector, so the fixture never
+# runs on a bucket the shipping code disagrees about. A mismatch is a hard fail,
+# never a fallback.
+JOURNEY_CLASSES=("${SOLO_JOURNEY_CLASSES[@]}")
+EFFECTIVE_JOURNEY_CLASSES=()
+POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$SOLO_SHARD_TOTAL" \
+  POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$SOLO_SHARD_INDEX" \
+  select_effective_journey_classes > /dev/null
+(( ${#EFFECTIVE_JOURNEY_CLASSES[@]} == 1 )) && [[ "${EFFECTIVE_JOURNEY_CLASSES[0]}" == "$SOLO_CLASS" ]] \
+  || fail "(setup) the real selector runs ${#EFFECTIVE_JOURNEY_CLASSES[@]} class(es) on shard $SOLO_SHARD_INDEX of $SOLO_SHARD_TOTAL (${EFFECTIVE_JOURNEY_CLASSES[*]:-none}), not just $SOLO_CLASS — the single-class fixture below would be ambiguous"
+unset JOURNEY_CLASSES EFFECTIVE_JOURNEY_CLASSES
+echo "   single-class fixture: shard $SOLO_SHARD_INDEX of $SOLO_SHARD_TOTAL selects only $SOLO_CLASS"
+
 # The registry under test, read from the real helper.
 # shellcheck source=scripts/ci-journey-core-terminal-functions.sh
 source "$CORE_TERMINAL_FN"
@@ -430,8 +499,8 @@ run_real_suite() {
     JOURNEY_NO_OUTPUT_TIMEOUT_SECS=25 \
     JOURNEY_CLASS_KILL_AFTER_SECS=1 \
     JOURNEY_GRADLE_STOP_TIMEOUT_SECS=5 \
-    POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=400 \
-    POCKETSHELL_JOURNEY_CI_SHARD_INDEX=0 \
+    POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$SOLO_SHARD_TOTAL" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$SOLO_SHARD_INDEX" \
     "$@" \
     bash "$ws/scripts/ci-journey-suite.sh" > "$ws/suite.log" 2>&1
   SUITE_RC=$?
@@ -522,8 +591,9 @@ echo "== (c) the non-proof reddening conditions still carry their evidence =="
 # (c1) A journey CLASS that fails both attempts.
 ws="$SANDBOX/journey-class"
 make_workspace "$ws"
-first_class="$(sed -n 's/^  "\(com\.[A-Za-z0-9_.$#]*\)".*/\1/p;s/^  "\$FQCN_PREFIX\.\([A-Za-z0-9_.$#]*\)".*/com.pocketshell.app.proof.\1/p' "$SUITE" | head -n 1)"
-[[ -n "$first_class" ]] || fail "(c1) could not read the first journey class out of $SUITE"
+# Issue #1862: the ONE class this single-class run selects — resolved from the
+# real selection at the top of this file, not from the array's first entry.
+first_class="$SOLO_CLASS"
 run_real_suite "$ws" JOURNEY_STUB_FAIL_CLASS="$first_class"
 [[ "$SUITE_RC" -ne 0 ]] || fail "(c1) a journey class failing both attempts must redden the suite"
 grep -qE 'Failed BOTH attempts' "$ws/artifacts/ci-journey/summary.md" \
@@ -545,8 +615,8 @@ pass "(c1) FAILED_CLASSES -> failed-both section -> first_failure=true -> RED [$
 #   budget=1s elapsed=0s remaining=1s => NOT exhausted -> suite exits 0 -> FAIL
 #   budget=1s elapsed=1s remaining=0s => EXHAUSTED     -> suite RED     -> pass
 #
-# and `run_real_suite` pins POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=400 so exactly ONE
-# class is selected — there is no second loop iteration to catch the budget
+# and `run_real_suite` pins the resolved single-class shard (SOLO_SHARD_INDEX of
+# SOLO_SHARD_TOTAL, issue #1862) so exactly ONE class is selected — there is no second loop iteration to catch the budget
 # later, making a single missed tick terminal. The hosted runner lost that race
 # 2/2 (red `main` @ ae368467) while the dev box won it 5/5 on the identical
 # commit. A guard whose whole purpose is to stop the gate reporting false greens

--- a/scripts/test-ci-journey-warm-build.sh
+++ b/scripts/test-ci-journey-warm-build.sh
@@ -49,6 +49,32 @@ trap 'rm -rf "$SANDBOX"' EXIT
 COLD_SECS=6
 SHARD_TOTAL=3
 
+# Issue #1862: shard membership is derived from the CLASS NAME, not the array
+# index, so a fixture that needs "the class shard N runs first" must ASK the real
+# selection instead of assuming array position. Drive the shipping selector so
+# this stays true if the partitioning is ever changed again.
+# shellcheck source=scripts/ci-journey-class-selection-functions.sh
+source "$SCRIPT_DIR/ci-journey-class-selection-functions.sh"
+journey_first_class_on_shard() {   # $1 = shard index, $2 = shard total
+  local FQCN_PREFIX="com.pocketshell.app.proof"
+  local -a JOURNEY_CLASSES=() EFFECTIVE_JOURNEY_CLASSES=()
+  local i
+  mapfile -t JOURNEY_CLASSES < <(
+    awk '
+      /^JOURNEY_CLASSES=\(/ { f = 1; next }
+      /^\)/                 { f = 0 }
+      f && match($0, /"[^"]+"/) { print substr($0, RSTART + 1, RLENGTH - 2) }
+    ' "$REAL_SUITE"
+  )
+  (( ${#JOURNEY_CLASSES[@]} > 0 )) || return 1
+  for i in "${!JOURNEY_CLASSES[@]}"; do
+    JOURNEY_CLASSES[$i]="${JOURNEY_CLASSES[$i]/\$FQCN_PREFIX/$FQCN_PREFIX}"
+  done
+  POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$2" POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$1" \
+    select_effective_journey_classes > /dev/null
+  printf '%s' "${EFFECTIVE_JOURNEY_CLASSES[0]:-}"
+}
+
 HELPERS=(
   ci-journey-suite.sh
   ci-journey-class-selection-functions.sh
@@ -365,13 +391,15 @@ echo "== #1814 AC3: a build-phase outer timeout is distinguishable from a journe
 
 # The first class of shard 0, read from the real allowlist so a reordering of
 # JOURNEY_CLASSES cannot silently make this fixture test a different class.
-first_entry="$(awk '
-  /^JOURNEY_CLASSES=\(/ { f=1; next }
-  /^\)/ { f=0 }
-  f && /^[[:space:]]*"/ { print; exit }
-' "$REAL_SUITE" | sed 's/^[[:space:]]*"\([^"]*\)".*/\1/')"
+#
+# Issue #1862: it is no longer the array's FIRST entry. Shard membership is now
+# assigned by class-name HASH, not by array index, so `index 0 -> shard 0` no
+# longer holds. Ask the REAL selection which class shard 0 runs first — that is
+# what this fixture has always meant, and it stays correct under any future
+# partitioning rather than encoding today's arithmetic.
+first_entry="$(journey_first_class_on_shard 0 "$SHARD_TOTAL")"
 WEDGE_CLASS="${first_entry##*.}"
-[[ -n "$WEDGE_CLASS" ]] || fail "(ac3) could not resolve the first journey class from the allowlist"
+[[ -n "$WEDGE_CLASS" ]] || fail "(ac3) could not resolve the first journey class of shard 0 from the allowlist"
 echo "    wedging the first class of shard 0: $WEDGE_CLASS"
 
 # wedge_run <mode> <log> — one shard-0 run whose first class behaves per <mode>.


### PR DESCRIPTION
Closes #1862

## The defect

Journey shard membership was round-robin **by array index**, so registering **one** new class at index 36 moved **112 of 148** classes to different shards.

That is how #1845's suite registration turned `main` red: two classes moved from shard 1 to shard 2, landing behind 12 different fixture-touching co-tenants, and one then wedged. Adding a test to the suite could break `main` by rearranging everything else.

## The fix

Membership is now `hash(class_name) % total` — FNV-1a/32, pure bash, `LC_ALL=C` pinned. **0 classes move** on insert at head, index 36, tail, or on removal. Balance at total=3 is 52/48/48 against an ideal of 49.3; projected growth to n=348 keeps `max/ideal` at 1.02–1.08 and **trending down**. Hash determinism verified across four locales and against a reference implementation, including `#`, `$`, `'`, `-`, `%`, space and empty inputs.

## What this does NOT do

**It does not make `main` green.** The failing class happening to land on shard 0 under the new partition is incidental, and the implementer explicitly declined to offer it as a fix. The underlying wedge is a connection-core defect tracked separately as **#1863** — a cancelled connect resolving `ready` over a closed wire while the liveness probe is gated off by `disconnected`. That is now also implicated in the maintainer's mobile-connect failure (#1870), amplified 10–30× by RTT.

## The part worth reading

The change broke **three CI-wired sibling gates** that encoded `array index 0 == shard 0`, or used `SHARD_TOTAL=400/INDEX=0` to select exactly one class.

Each was confirmed **green on `origin/main` and red under the new selection BEFORE being touched**, then changed to *ask* the real selector rather than assume. The reviewer refused to judge the end state and built the full 2×2 instead — and the decisive cell is *new tests + old selection*: **two of the three pass under both partitionings**, which a test rewritten to fit the new arithmetic could not do. The third hard-fails loudly with an instruction rather than silently falling back to array position.

A fourth casualty the implementer's table missed — the budget gate's own `(shard)` ±2 tolerance — was **rehomed to a `(shard-balance)` block rather than loosened**.

## Verification

Red→green driven independently by the reviewer: RED at `(shard-stable) insert at index 0 moved 148 pre-existing classes`; GREEN at 0 moved across all four insertion points. Re-derived in Python that the old reducer at index 36 moves 112 of 148 and relocates exactly the reported pair.

All four sibling gates re-run green after rebase onto `d2f124ac`: `test-ci-journey-budget`, `test-ci-journey-inter-attempt-cleanup`, `test-ci-journey-summary-evidence`, `test-ci-journey-warm-build`.

Tests live in `scripts/test-ci-journey-budget.sh`, which the `Unit` job already runs — `tests.yml` untouched, which matters since three other slices contend for that file.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb