### PR TITLE
app: enforce Main confinement at 19 view-model entry points (#1829)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileexplorer/FileExplorerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileexplorer/FileExplorerDockerTest.kt
@@ -70,6 +70,18 @@ class FileExplorerDockerTest {
     private fun newExplorerViewModel(): FileExplorerViewModel =
         FileExplorerViewModel(leaseManager)
 
+    /**
+     * Issue #1829: `FileExplorerViewModel.start` is Main-confined and now
+     * ENFORCES it — it check-then-acts on the plain `request` field and clears
+     * the non-thread-safe `listingCache` in the same window. The production
+     * caller is `FileExplorerScreen`'s `LaunchedEffect { viewModel.start(...) }`,
+     * i.e. Main; these test bodies are `runBlocking` on the instrumentation
+     * thread, so drive `start` through the screen's actual thread.
+     */
+    private fun startOnMain(viewModel: FileExplorerViewModel, request: FileExplorerViewModel.Request) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { viewModel.start(request) }
+    }
+
     @Before
     fun setUp(): Unit { runBlocking {
         val keyText = InstrumentationRegistry.getInstrumentation()
@@ -180,7 +192,8 @@ class FileExplorerDockerTest {
         }
 
         val viewModel = newExplorerViewModel()
-        viewModel.start(
+        startOnMain(
+            viewModel,
             FileExplorerViewModel.Request(
                 hostId = TEST_HOST_ID,
                 hostname = DEFAULT_HOST,
@@ -322,7 +335,8 @@ class FileExplorerDockerTest {
         assertEquals("pre-warm dials exactly one handshake", 1, afterWarm)
 
         val viewModel = newExplorerViewModel()
-        viewModel.start(
+        startOnMain(
+            viewModel,
             FileExplorerViewModel.Request(
                 hostId = TEST_HOST_ID,
                 hostname = DEFAULT_HOST,

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
@@ -133,7 +133,15 @@ class PortForwardPanelLifecycleE2eTest {
             ).also { it.observeProcessLifecycle(ProcessLifecycleOwner.get()) }
         }
 
-        viewModel.load(hostId, "/tmp/e2e-key")
+        // #1829: `load` is Main-confined — it bumps the plain `loadGeneration`
+        // counter and check-then-acts on `currentHostId`, exactly as the
+        // screen's `LaunchedEffect { viewModel.load(...) }` does on Main. This
+        // test body is `runBlocking` on the instrumentation thread, so drive it
+        // through the same Main hop the ViewModel construction above already
+        // uses. This is the production thread, not a workaround.
+        withContext(Dispatchers.Main) {
+            viewModel.load(hostId, "/tmp/e2e-key")
+        }
 
         withTimeout(STATE_TIMEOUT_MS) {
             waitFor("panel host loaded") { viewModel.state.value.host?.id == hostId }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
@@ -248,8 +248,13 @@ class FolderListDurableTreeDaemonDockerTest {
             alphaFolder in ready1.expandedProjectPaths,
         )
 
-        // The user collapses the alpha folder.
-        vm1.toggleProjectExpanded(alphaFolder)
+        // The user collapses the alpha folder. #1829: `toggleProjectExpanded`
+        // calls `emitReady()` SYNCHRONOUSLY, and `emitReady` is the Main-confined
+        // check-then-act seam over `emitGeneration` — so this needs the same Main
+        // hop the `bind` helper below uses. In production this is a Compose tap
+        // callback (`FolderListScreen.kt` `onToggleProjectExpanded`), i.e. Main;
+        // running it on the instrumentation thread was never the real path.
+        onMain { vm1.toggleProjectExpanded(alphaFolder) }
         // The collapse is reflected locally immediately.
         withTimeout(10_000) {
             while (alphaFolder in readyExpanded(vm1)) delay(100L)
@@ -378,16 +383,32 @@ class FolderListDurableTreeDaemonDockerTest {
         )
     } }
 
+    /**
+     * Issue #1829: run a Main-confined view-model entry point on Main, the way
+     * every production caller does. Used for `bind` AND for the non-suspend
+     * members that reach `emitReady()` synchronously (`toggleProjectExpanded`).
+     */
+    private fun onMain(block: () -> Unit) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+    }
+
     private fun bind(vm: FolderListViewModel, host: HostEntity) {
-        vm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        onMain {
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
     }
 
     private fun readyExpanded(vm: FolderListViewModel): Set<String> =

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListHostOutdatedTreeVersionDaemonDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListHostOutdatedTreeVersionDaemonDockerTest.kt
@@ -252,15 +252,22 @@ class FolderListHostOutdatedTreeVersionDaemonDockerTest {
     } }
 
     private fun bind(vm: FolderListViewModel, host: HostEntity) {
-        vm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
     }
 
     /** True when the tree envelope's `cli_version` parses and is below [ceiling]. */

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
@@ -173,15 +173,22 @@ class FolderListKillSessionDockerTest {
             attachLifecycle = false,
         ).also { viewModelStore.put("FolderListViewModel", it) }
         folderVm.setProcessStartedForTest(true)
-        folderVm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            folderVm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
         awaitSession(folderVm, keep)
         awaitSession(folderVm, doomed)
 

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
@@ -185,15 +185,22 @@ class FolderListKillWindowDockerTest {
             attachLifecycle = false,
         ).also { viewModelStore.put("FolderListViewModel", it) }
         folderVm.setProcessStartedForTest(true)
-        folderVm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            folderVm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
         awaitWindowCount(folderVm, multi, expected = 2)
 
         // 3. Attach a real session view model and confirm a Stop on window 0.

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOldCliHydrateDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOldCliHydrateDockerTest.kt
@@ -185,15 +185,22 @@ class FolderListOldCliHydrateDockerTest {
         // cold-start hydrate runs against the old CLI — the exact bug path.
         val vm = newViewModel()
         vm.setProcessStartedForTest(true)
-        vm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
 
         // The load-bearing assertion: the app must leave Loading and render the
         // live tree (the seeded session) — NOT hang on "loading tree".

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOutOfBandSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOutOfBandSessionDockerTest.kt
@@ -222,15 +222,22 @@ class FolderListOutOfBandSessionDockerTest {
             attachLifecycle = false,
         ).also { viewModelStore.put("FolderListViewModel", it) }
         vm.setProcessStartedForTest(true)
-        vm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
 
         // Cold-open reconcile settles: the anchor session is shown, the
         // out-of-band one is NOT yet present.

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionResumeDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionResumeDockerTest.kt
@@ -210,15 +210,22 @@ class FolderListSessionResumeDockerTest {
     }
 
     private fun bind(vm: FolderListViewModel, host: HostEntity) {
-        vm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
     }
 
     private fun hasSession(vm: FolderListViewModel, sessionName: String): Boolean {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListTreeStopSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListTreeStopSessionDockerTest.kt
@@ -158,15 +158,22 @@ class FolderListTreeStopSessionDockerTest {
             attachLifecycle = false,
         ).also { viewModelStore.put("FolderListViewModel", it) }
         folderVm.setProcessStartedForTest(true)
-        folderVm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            folderVm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
         try {
             awaitSession(folderVm, keep)
             awaitSession(folderVm, doomed)

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
@@ -221,15 +221,22 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
             attachLifecycle = false,
         ).also { viewModelStore.put("FolderListViewModel", it) }
         vm.setProcessStartedForTest(true)
-        vm.bind(
-            hostId = host.id,
-            hostName = host.name,
-            hostname = host.hostname,
-            port = host.port,
-            username = host.username,
-            keyPath = keyFile.absolutePath,
-            passphrase = null,
-        )
+        // Issue #1829: FolderListViewModel is Main-confined and now ENFORCES it.
+        // Drive the REAL bind() on Main, exactly as FolderListScreen's
+        // LaunchedEffect does — off Main, bind()'s synchronous cold seed races
+        // the view model's own Main-dispatched emitReady and is dropped as
+        // stale (#1823: 23-25% of binds), leaving the #867/#1109 Loading flash.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
 
         // Cold-open reconcile settles: the session shows both windows.
         //

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseBatchCDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseBatchCDockerTest.kt
@@ -111,16 +111,21 @@ class WarmLeaseReuseBatchCDockerTest {
                 reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
                 sshLeaseManager = leaseManager,
             )
-            repoVm.bind(
-                RepoBrowserViewModel.SshCredentials(
-                    hostId = HOST_ID,
-                    hostname = DEFAULT_HOST,
-                    port = DEFAULT_PORT,
-                    username = DEFAULT_USER,
-                    keyPath = keyPath,
-                    passphrase = null,
-                ),
-            )
+            // Issue #1829: the screen-scoped view models are Main-confined and
+            // now ENFORCE it. Drive bind() on Main, exactly as the screen's
+            // LaunchedEffect does.
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                repoVm.bind(
+                    RepoBrowserViewModel.SshCredentials(
+                        hostId = HOST_ID,
+                        hostname = DEFAULT_HOST,
+                        port = DEFAULT_PORT,
+                        username = DEFAULT_USER,
+                        keyPath = keyPath,
+                        passphrase = null,
+                    ),
+                )
+            }
             // Wait until the load settles to a terminal state (Ready / Failed /
             // ToolUnavailable) so the enumeration actually ran over the lease.
             withTimeout(30_000L) {
@@ -135,17 +140,20 @@ class WarmLeaseReuseBatchCDockerTest {
                 projectRootDao = db.projectRootDao(),
                 sshLeaseManager = leaseManager,
             )
-            watchedVm.bind(
-                hostId = HOST_ID,
-                hostName = host.name,
-                sshCredentials = WatchedFoldersViewModel.SshCredentials(
-                    hostname = DEFAULT_HOST,
-                    port = DEFAULT_PORT,
-                    username = DEFAULT_USER,
-                    keyPath = keyPath,
-                    passphrase = null,
-                ),
-            )
+            // Issue #1829: Main-confined bind (see the repo-browser note above).
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                watchedVm.bind(
+                    hostId = HOST_ID,
+                    hostName = host.name,
+                    sshCredentials = WatchedFoldersViewModel.SshCredentials(
+                        hostname = DEFAULT_HOST,
+                        port = DEFAULT_PORT,
+                        username = DEFAULT_USER,
+                        keyPath = keyPath,
+                        passphrase = null,
+                    ),
+                )
+            }
             watchedVm.discoverFromRemote()
             // Wait until discovery finishes (the discovering flag drops).
             withTimeout(30_000L) {

--- a/app/src/main/java/com/pocketshell/app/MainThreadConfinement.kt
+++ b/app/src/main/java/com/pocketshell/app/MainThreadConfinement.kt
@@ -1,0 +1,79 @@
+package com.pocketshell.app
+
+import android.os.Looper
+
+/**
+ * Thrown when a Main-confined view-model entry point is entered from a thread
+ * that is not the Android main thread (issue #1829).
+ *
+ * An [IllegalStateException] rather than a bespoke hierarchy: an off-Main call
+ * into a Main-confined reducer is a programming error at the CALL SITE, not a
+ * recoverable runtime condition. Fix the caller (dispatch to Main); never
+ * catch this.
+ */
+internal class MainThreadConfinementViolation(
+    message: String,
+) : IllegalStateException(message)
+
+/**
+ * Issue #1829 — runtime enforcement of PocketShell's Main-thread confinement
+ * contract for view-model entry points.
+ *
+ * ## Why a runtime throw and not something cheaper
+ *
+ * The per-screen view models are Main-confined **by construction**:
+ * `viewModelScope` is `Dispatchers.Main.immediate`, their `bind` / emit entry
+ * points are non-suspend straight-line code, and their bookkeeping is plain,
+ * non-`@Volatile` state (`emitGeneration`, `bound`, `params`, `lastRequest`,
+ * `hostId`, …) mutated with **check-then-act** sequences. On Main such a
+ * sequence — e.g. `FolderListViewModel.emitReady(synchronous = true)`'s
+ * `++emitGeneration` → `HostTreeModel.buildProjection` → re-check — is atomic,
+ * because there is no suspension point and nothing else can run on Main in
+ * between. Off Main it is not atomic at all.
+ *
+ * Until this guard existed, that confinement was enforced by **nothing**: no
+ * annotation, no assertion, no memory barrier. #1823 measured the consequence
+ * on a real device — an off-Main `bind` loses its synchronous cold-start seed
+ * to a concurrent Main-dispatched `emitReady` in **23–25%** of binds (10/40 and
+ * 28/120; on Main: 0/120), so `_state` stays `Loading`. That is the
+ * user-visible #867 / #1109 rebuild flash, arriving **silently** — no crash, no
+ * log, just an occasional wrong first frame. A rare wrong render is far harder
+ * to diagnose than an immediate, unmissable throw, so the contract fails loudly
+ * at the seam instead.
+ *
+ * ## Alternatives considered and deliberately rejected
+ *
+ *  - **`@MainThread` alone.** Lint-only. It does not flag an instrumentation
+ *    thread calling `bind`, which is precisely where every real off-Main caller
+ *    came from (nine `androidTest` sites at the time of writing). It would buy
+ *    the appearance of enforcement without the substance.
+ *  - **`@Volatile` on the generation counter.** The defect is check-then-act,
+ *    not visibility. Volatile narrows the window without closing the contract,
+ *    and a narrower race is *harder* to diagnose, not safer.
+ *
+ * ## The one place this is a no-op, and why that is safe
+ *
+ * Returns without checking when there is no main looper at all. That happens
+ * only under an `android.os.Looper` **stub** — a plain, non-Robolectric JVM
+ * unit test running with the app module's
+ * `testOptions.unitTests.isReturnDefaultValues = true`, where
+ * `Looper.getMainLooper()` returns `null` and there is no thread identity to
+ * compare against. Production and Robolectric always have a real main looper,
+ * so the guard is live on every path that can reach a user. The regression
+ * suite (`Issue1829MainThreadConfinementTest`) is a Robolectric class for
+ * exactly that reason: it exercises the real comparison, not the stub.
+ *
+ * @param entryPoint the `Class.method` label reported in the failure message.
+ */
+internal fun requireMainThread(entryPoint: String) {
+    val mainLooper = Looper.getMainLooper() ?: return
+    if (Looper.myLooper() === mainLooper) return
+    throw MainThreadConfinementViolation(
+        "issue #1829: $entryPoint is Main-confined but was called from thread " +
+            "'${Thread.currentThread().name}'. It mutates plain non-@Volatile " +
+            "view-model state with check-then-act sequences that are atomic only " +
+            "on Main; off Main they silently drop state updates (the #867/#1109 " +
+            "Loading flash). Dispatch to Main first — a Compose LaunchedEffect, " +
+            "viewModelScope, or Instrumentation.runOnMainSync in a test.",
+    )
+}

--- a/app/src/main/java/com/pocketshell/app/env/EnvViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/env/EnvViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.env
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.storage.dao.HostDao
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -127,6 +128,7 @@ class EnvViewModel @Inject constructor(
         folderLabel: String,
         copySources: List<EnvCopySourceFolder>,
     ) {
+        requireMainThread("EnvViewModel.bind")
         val next = BoundParams(hostId, keyPath, passphrase, directory)
         if (params == next && _state.value.directory == directory) return
         params = next

--- a/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileexplorer/FileExplorerViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.fileexplorer
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.app.sessions.LeaseSessionExec
 import com.pocketshell.app.sessions.LeaseSessionTarget
 import com.pocketshell.core.ssh.RemoteEntry
@@ -167,6 +168,9 @@ class FileExplorerViewModel @Inject constructor(
      * the same [Request] so a recomposition doesn't reset the user's navigation.
      */
     fun start(request: Request) {
+        // #1829: check-then-act over `request`, and `listingCache` is a plain
+        // LinkedHashMap (not thread-safe) cleared inside the same window.
+        requireMainThread("FileExplorerViewModel.start")
         if (this.request == request) return
         this.request = request
         currentDir = ""

--- a/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.app.sessions.LeaseSessionExec
 import com.pocketshell.app.sessions.LeaseSessionTarget
 import com.pocketshell.app.share.FilenameSanitiser
@@ -545,6 +546,7 @@ class FileViewerViewModel @Inject constructor(
      * A different request (fresh navigation) always loads.
      */
     fun bind(request: Request) {
+        requireMainThread("FileViewerViewModel.bind")
         val sameRequest = request == lastRequest
         lastRequest = request
         if (sameRequest && loadJob?.isActive == true) return

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryViewModel.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.git
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocketshell.app.AppTeardownScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLease
@@ -208,6 +209,10 @@ class GitHistoryViewModel @Inject constructor(
      * the same [Request] so a recomposition doesn't re-fetch.
      */
     fun start(request: Request) {
+        // #1829: structurally identical to RepoBrowserViewModel.bind — a
+        // check-then-act over the plain `request` field that decides whether
+        // the screen loads at all.
+        requireMainThread("GitHistoryViewModel.start")
         if (this.request == request) return
         this.request = request
         load()

--- a/app/src/main/java/com/pocketshell/app/hosts/AddEditHostViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/AddEditHostViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.hosts
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.SshKeyDao
 import com.pocketshell.core.storage.entity.HostEntity
@@ -154,6 +155,11 @@ class AddEditHostViewModel @Inject constructor(
      * with the same id is a no-op the second time.
      */
     fun loadHost(hostId: Long) {
+        // #1829: guard-return on the bound identity, then install it — the same
+        // binding-seam shape as RepoBrowserViewModel.bind. Off Main the second
+        // caller can slip past the guard and double-load the form, clobbering
+        // the dirty-state `baseline`.
+        requireMainThread("AddEditHostViewModel.loadHost")
         if (editingHostId == hostId) return
         editingHostId = hostId
         viewModelScope.launch {
@@ -200,6 +206,9 @@ class AddEditHostViewModel @Inject constructor(
      * recomposition that happens before the user submits again.
      */
     fun consumeFirstInvalidField() {
+        // #1829: read-modify-write on `_state` from a LaunchedEffect. Off Main
+        // a concurrent form edit between the read and the write is lost.
+        requireMainThread("AddEditHostViewModel.consumeFirstInvalidField")
         val s = _state.value
         if (s.firstInvalidField != null) {
             _state.value = s.copy(firstInvalidField = null)
@@ -221,6 +230,9 @@ class AddEditHostViewModel @Inject constructor(
      * the save signal a true one-shot event.
      */
     fun consumeSaved() {
+        // #1829: same read-modify-write shape as consumeFirstInvalidField, on
+        // the one-shot save/navigate signal.
+        requireMainThread("AddEditHostViewModel.consumeSaved")
         val s = _state.value
         if (s.saved || s.savedHostId != null) {
             _state.value = s.copy(saved = false, savedHostId = null)

--- a/app/src/main/java/com/pocketshell/app/hosts/FirstHostTestConnectScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/FirstHostTestConnectScreen.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.viewModelScope
 import com.pocketshell.app.bootstrap.BootstrapTool
 import com.pocketshell.app.bootstrap.HostBootstrapSheet
 import com.pocketshell.app.bootstrap.HostBootstrapSheetState
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -289,6 +290,11 @@ class FirstHostTestConnectViewModel @Inject constructor(
     private var testingHostId: Long? = null
 
     fun start(hostId: Long, force: Boolean = false) {
+        // #1829: the guard reads `testingHostId` AND `_state.value`, then does
+        // a read-modify-write on the StateFlow (`current.copy(...)`) — the
+        // lost-update shape cited as the reason to guard
+        // WatchedFoldersViewModel.bind.
+        requireMainThread("FirstHostTestConnectViewModel.start")
         val current = _state.value
         if (!force &&
             testingHostId == hostId &&

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -18,6 +18,7 @@ import com.pocketshell.app.bootstrap.compareSemver
 import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.notifications.DefaultUpdateNotifier
 import com.pocketshell.app.notifications.UpdateNotifier
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.app.session.LastSessionStore
 import com.pocketshell.app.release.ReleaseCheckResult
 import com.pocketshell.app.release.ReleaseChecker
@@ -751,6 +752,9 @@ class HostListViewModel internal constructor(
      * until the user manually taps "Re-check setup".
      */
     fun reprobeUnknownHostsOnce() {
+        // #1829: `autoReprobeKicked` is a plain non-@Volatile once-latch read
+        // and written in the same window; off Main two callers both kick.
+        requireMainThread("HostListViewModel.reprobeUnknownHostsOnce")
         if (autoReprobeKicked) return
         autoReprobeKicked = true
         StartupTiming.mark("hostlist-reprobe-kicked")

--- a/app/src/main/java/com/pocketshell/app/jobs/RecurringJobsViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/jobs/RecurringJobsViewModel.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.jobs
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocketshell.app.AppTeardownScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.ssh.SshLease
@@ -95,6 +96,7 @@ public class RecurringJobsViewModel @Inject constructor(
         passphrase: CharArray?,
         sessionName: String,
     ) {
+        requireMainThread("RecurringJobsViewModel.load")
         val next = Target(hostId, hostName, hostname, port, username, keyPath, passphrase, sessionName)
         if (next == target) return
         targetGeneration += 1L

--- a/app/src/main/java/com/pocketshell/app/portfwd/PortForwardPanelViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/portfwd/PortForwardPanelViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.portfwd.AutoForwarderSupervisor
 import com.pocketshell.core.portfwd.PortScanner
 import com.pocketshell.core.portfwd.RemotePort
@@ -191,6 +192,7 @@ class PortForwardPanelViewModel @Inject constructor(
         // we don't open two SSH sessions for the same host on entry.
         prefillRemotePort: Int? = null,
     ) {
+        requireMainThread("PortForwardPanelViewModel.load")
         if (
             currentHostId == hostId &&
             requestedKeyPath == initialKeyPath &&

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -23,6 +23,7 @@ import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.portfwd.ForwardingHostSnapshot
 import com.pocketshell.app.portfwd.InterestingPortFilter
 import com.pocketshell.app.repos.ReposRemoteSource
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.core.assistant.AssistantLlmClientFactory
 import com.pocketshell.core.ssh.SshLease
@@ -885,6 +886,7 @@ class FolderListViewModel internal constructor(
         keyPath: String,
         passphrase: CharArray?,
     ) {
+        requireMainThread("FolderListViewModel.bind")
         val params = BoundParams(
             hostId = hostId,
             hostName = hostName,
@@ -2446,11 +2448,6 @@ class FolderListViewModel internal constructor(
     }
 
     /**
-     * Rebuild [FolderListUiState.Ready] from the most recent gateway
-     * snapshot + watched-folder overlay. Idempotent: every change in
-     * either input re-runs the grouping.
-     */
-    /**
      * EPIC #679: project the maintained [HostTreeModel] into
      * [FolderListUiState.Ready]. The visuals stay byte-identical because the
      * projection feeds the SAME pure builders (`groupSessionsIntoFolders` /
@@ -2459,6 +2456,8 @@ class FolderListViewModel internal constructor(
      * intrinsic to the held tree (no per-emit re-derivation, no flash).
      */
     private fun emitReady(synchronous: Boolean = false) {
+        // #1829: the Main-confined check-then-act seam over emitGeneration.
+        requireMainThread("FolderListViewModel.emitReady")
         if (bound == null) return
         if (!tree.hasSnapshot) return
         // Issue #965 (ANR off-Main): take a CHEAP immutable snapshot of the held
@@ -2498,12 +2497,13 @@ class FolderListViewModel internal constructor(
      * Apply a freshly-built [HostTreeModel.ProjectionResult] to the held tree and
      * publish the [FolderListUiState.Ready] state. Shared by the synchronous
      * cold-start seed ([hydrateFromClientCache]) and the off-Main reconcile-driven
-     * emit ([emitReady]). Must run on Main (it writes [_state]).
+     * emit ([emitReady]). Must run on Main (it writes [_state]) — #1829.
      */
     private fun applyReadyProjection(
         result: HostTreeModel.ProjectionResult,
         refreshing: Boolean,
     ) {
+        requireMainThread("FolderListViewModel.applyReadyProjection")
         tree.applyProjection(result)
         _state.value = folderListReadyState(
             projection = result.projection,

--- a/app/src/main/java/com/pocketshell/app/projects/RepoBrowserViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RepoBrowserViewModel.kt
@@ -6,6 +6,7 @@ import com.pocketshell.app.repos.RepoEntry
 import com.pocketshell.app.repos.RepoPathResult
 import com.pocketshell.app.repos.ReposListResult
 import com.pocketshell.app.repos.ReposRemoteSource
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.app.sessions.LeaseSessionExec
 import com.pocketshell.app.sessions.LeaseSessionTarget
 import com.pocketshell.core.ssh.SshLeaseManager
@@ -116,6 +117,7 @@ class RepoBrowserViewModel @Inject constructor(
      * visible list or an in-flight clone.
      */
     fun bind(credentials: SshCredentials) {
+        requireMainThread("RepoBrowserViewModel.bind")
         if (this.credentials == credentials) return
         this.credentials = credentials
         refresh()

--- a/app/src/main/java/com/pocketshell/app/projects/WatchedFoldersChipsViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/WatchedFoldersChipsViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.projects
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.entity.ProjectRootEntity
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,6 +48,7 @@ class WatchedFoldersChipsViewModel @Inject constructor(
     private var hostId: Long? = null
 
     fun bind(hostId: Long?) {
+        requireMainThread("WatchedFoldersChipsViewModel.bind")
         if (this.hostId == hostId) return
         this.hostId = hostId
         observeJob?.cancel()

--- a/app/src/main/java/com/pocketshell/app/projects/WatchedFoldersViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/WatchedFoldersViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.projects
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.app.sessions.LeaseSessionExec
 import com.pocketshell.app.sessions.LeaseSessionTarget
 import com.pocketshell.core.ssh.SshLeaseManager
@@ -92,6 +93,7 @@ class WatchedFoldersViewModel @Inject constructor(
      * session), the screen renders the hint instead.
      */
     fun bind(hostId: Long, hostName: String, sshCredentials: SshCredentials? = null) {
+        requireMainThread("WatchedFoldersViewModel.bind")
         if (this.hostId == hostId && this.sshCredentials == sshCredentials) {
             // Same target — only refresh the display name in case it changed.
             if (_state.value.hostName != hostName) {

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.sessions
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.app.requireMainThread
 import com.pocketshell.core.storage.entity.HostEntity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -34,6 +35,12 @@ class HostTmuxSessionPickerViewModel @Inject constructor(
     private var projectSwitcherJob: Job? = null
 
     fun load(request: HostTmuxSessionPickerRequest) {
+        // #1829: DECIDED IN (the review left this one open). The check-then-act
+        // has no `if`, which is exactly why a guard-shaped scan misses it: the
+        // `loadJob?.cancel()` … `loadJob = launch{}` pair IS the check-then-act,
+        // the same job-swap race cited for WatchedFoldersChipsViewModel.bind.
+        // Off Main two loads can both survive the cancel and race `_state`.
+        requireMainThread("HostTmuxSessionPickerViewModel.load")
         loadJob?.cancel()
         _state.value = HostTmuxSessionPickerState.Loading(request)
         loadJob = viewModelScope.launch {
@@ -120,6 +127,10 @@ class HostTmuxSessionPickerViewModel @Inject constructor(
         currentSessionName: String,
         projectPath: String?,
     ) {
+        // #1829: same job-swap shape as [load], on the sibling list. Guarded
+        // together with it — splitting the pair would be exactly the
+        // enumerate-by-name mistake this round exists to fix.
+        requireMainThread("HostTmuxSessionPickerViewModel.refreshProjectSiblings")
         projectSwitcherJob?.cancel()
         projectSwitcherJob = viewModelScope.launch {
             val result = gateway.listSessionsFromLiveClient(host, keyPath)

--- a/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt
@@ -158,6 +158,52 @@ class HostListViewModelTest {
         db.close()
     }
 
+    /**
+     * Issue #1829 (G2 class coverage). `reprobeUnknownHostsOnce` is in the
+     * Main-confinement class enumerated in
+     * [com.pocketshell.app.projects.Issue1829MainThreadConfinementTest]: it is a
+     * non-suspend, `LaunchedEffect`-driven entry point (`HostListScreen.kt:356`)
+     * whose check-then-act runs over the plain, non-`@Volatile`
+     * `autoReprobeKicked` once-latch — read and written in the same window, so
+     * off Main two callers both pass the guard and both kick a startup probe
+     * sweep. It is proven here rather than in the sibling table because this
+     * class already owns the ten-dependency construction harness.
+     *
+     * The load-bearing assertion is the loud failure itself; the guard must
+     * also fire BEFORE the latch is set, so a rejected off-Main call leaves a
+     * subsequent legitimate on-Main call still able to do its work.
+     */
+    @Test
+    fun reprobeUnknownHostsOnceFromOffMainFailsLoudlyBecauseTheOnceLatchIsMainConfined() = runTest {
+        val viewModel = newViewModel()
+
+        val captured = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
+        val worker = Thread({
+            try {
+                viewModel.reprobeUnknownHostsOnce()
+            } catch (t: Throwable) {
+                captured.set(t)
+            }
+        }, "issue1829-off-main-hostlist")
+        worker.start()
+        // Bounded, HARD-failing join (process.md `runTest` convention, Shape B):
+        // the exit condition is asserted, never assumed.
+        worker.join(30_000L)
+        assertEquals(
+            "issue #1829: the off-Main reprobeUnknownHostsOnce call must finish within 30s — " +
+                "it is still running, so nothing asserted below would mean anything",
+            false,
+            worker.isAlive,
+        )
+
+        assertTrue(
+            "issue #1829: reprobeUnknownHostsOnce is Main-confined (plain autoReprobeKicked " +
+                "once-latch) and must fail loudly off Main. Got " +
+                "${captured.get() ?: "no exception at all"}",
+            captured.get() is com.pocketshell.app.MainThreadConfinementViolation,
+        )
+    }
+
     private fun newViewModel(
         applicationContext: Context = context,
         hostDao: HostDao = db.hostDao(),

--- a/app/src/test/java/com/pocketshell/app/portfwd/PortForwardPanelViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/PortForwardPanelViewModelTest.kt
@@ -78,6 +78,52 @@ class PortForwardPanelViewModelTest {
         db.close()
     }
 
+    /**
+     * Issue #1829 (G2 class coverage). [PortForwardPanelViewModel.load] is the
+     * same shape as the `FolderListViewModel.bind` defect this issue was filed
+     * for: a non-suspend, Main-confined entry point that does a check-then-act
+     * (`if (currentHostId == hostId && …) return`) and then bumps a plain,
+     * non-`@Volatile` generation counter (`++loadGeneration`) which a later
+     * resume re-checks to decide whether its result is stale. On Main that
+     * sequence is atomic; off Main a concurrent `load` / `leavePanel` can move
+     * the counter inside the window and the in-flight load silently discards
+     * itself, leaving the panel on a stale state with no crash and no log.
+     *
+     * That confinement used to be enforced by nothing. This proves it now fails
+     * loudly instead. RED before the guard: the off-Main `load` returns
+     * normally. The bounded, hard-failing join is the `process.md` `runTest`
+     * convention (Shape B) — the exit condition is asserted, never assumed.
+     */
+    @Test
+    fun loadFromOffMainFailsLoudlyBecauseTheGenerationCounterIsMainConfined() = runTest {
+        val hostId = insertHost(maxAutoPort = 4000, skipPortsBelow = 1000)
+        val viewModel = newViewModel(FakeConnector(Result.success(FakeSshSession(ssOutput = ""))))
+
+        val captured = java.util.concurrent.atomic.AtomicReference<Throwable?>(null)
+        val worker = Thread({
+            try {
+                viewModel.load(hostId, "/tmp/key")
+            } catch (t: Throwable) {
+                captured.set(t)
+            }
+        }, "issue1829-off-main-portfwd")
+        worker.start()
+        worker.join(30_000L)
+        assertFalse(
+            "issue #1829: the off-Main load() must finish within 30s — it is still running, " +
+                "so nothing asserted below would mean anything",
+            worker.isAlive,
+        )
+
+        val failure = captured.get()
+        assertTrue(
+            "issue #1829: PortForwardPanelViewModel.load is Main-confined (it does a " +
+                "check-then-act over the non-@Volatile loadGeneration) and must fail LOUDLY " +
+                "off Main. Got ${failure ?: "no exception at all"}",
+            failure is com.pocketshell.app.MainThreadConfinementViolation,
+        )
+    }
+
     @Test
     fun enablingAutoForward_connectsAndPublishesTunnelRows() = runTest {
         val hostId = insertHost(maxAutoPort = 4000, skipPortsBelow = 1000)

--- a/app/src/test/java/com/pocketshell/app/projects/Issue1829MainThreadConfinementTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/Issue1829MainThreadConfinementTest.kt
@@ -1,0 +1,798 @@
+package com.pocketshell.app.projects
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.lifecycle.ViewModelStore
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.MainThreadConfinementViolation
+import com.pocketshell.app.env.EnvFileTarget
+import com.pocketshell.app.env.EnvGateway
+import com.pocketshell.app.env.EnvListResult
+import com.pocketshell.app.env.EnvOpResult
+import com.pocketshell.app.env.EnvViewModel
+import com.pocketshell.app.fileexplorer.FileExplorerViewModel
+import com.pocketshell.app.fileviewer.FileViewerViewModel
+import com.pocketshell.app.git.GitHistoryViewModel
+import com.pocketshell.app.hosts.AddEditHostViewModel
+import com.pocketshell.app.hosts.FirstHostConnectionTester
+import com.pocketshell.app.hosts.FirstHostTestConnectViewModel
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.jobs.PocketshellJobsRemoteSource
+import com.pocketshell.app.jobs.RecurringJobsParser
+import com.pocketshell.app.jobs.RecurringJobsViewModel
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.repos.ReposJsonParser
+import com.pocketshell.app.repos.ReposRemoteSource
+import com.pocketshell.app.sessions.HostTmuxSessionListResult
+import com.pocketshell.app.sessions.HostTmuxSessionPickerRequest
+import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
+import com.pocketshell.app.sessions.HostTmuxSessionsGateway
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.storage.dao.HostDao
+import com.pocketshell.core.storage.dao.ProjectRootDao
+import com.pocketshell.core.storage.dao.SshKeyDao
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.uikit.model.SessionAgentKind
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Issue #1829 — [FolderListViewModel]'s Main-thread confinement must be
+ * ENFORCED, not merely conventional.
+ *
+ * ## What this class pins
+ *
+ * `FolderListViewModel` is Main-confined by construction: `viewModelScope` is
+ * `Dispatchers.Main.immediate`, `bind` is non-suspend straight-line code, and
+ * `emitReady(synchronous = true)` performs a **check-then-act** sequence
+ * (`++emitGeneration` → `HostTreeModel.buildProjection` → re-check the counter)
+ * over a plain, non-`@Volatile` `Long`. On Main that sequence is atomic —
+ * there is no suspension point, so nothing else can run in between. Off Main it
+ * is not: a concurrent Main-dispatched `emitReady` bumps the counter inside the
+ * window, the synchronous cold seed concludes it is stale, `applyReadyProjection`
+ * never runs, and `_state` stays `Loading` — the user-visible #867 / #1109
+ * rebuild flash. #1823 measured that at **23–25%** of off-Main binds (10/40 and
+ * 28/120) versus **0/120** on Main.
+ *
+ * Until #1829 that confinement was enforced by **nothing**: no `@MainThread`,
+ * no assertion, no barrier. Production could not reach it (both call sites are
+ * Compose `LaunchedEffect` bodies — `FolderListScreen.kt:209` and
+ * `RepoBrowserScreen.kt:121` — which run on `AndroidUiDispatcher.Main`), but
+ * nine `androidTest` sites did, and the failure mode is silent. This suite
+ * makes the violation LOUD and deterministic.
+ *
+ * ## Why the assertions are shaped this way
+ *
+ * The 23–25% race is a poor thing to assert on — a test that samples it is
+ * flaky by construction. The *confinement violation underneath it* is 100%
+ * deterministic: an off-Main `bind` on a warm cache mutates `emitGeneration`
+ * and writes `_state` from the foreign thread on **every** call. So the
+ * load-bearing assertion is that the off-Main call fails loudly and leaves the
+ * confined state untouched — which is exactly the property that makes the race
+ * unreachable, asserted without sampling it.
+ *
+ * These are Robolectric tests deliberately: [requireMainThread] compares
+ * against a real `Looper.getMainLooper()`, and a plain JVM unit test would get
+ * the `isReturnDefaultValues` stub (`null`), where the guard is a documented
+ * no-op and would prove nothing.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1829MainThreadConfinementTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val viewModelStore = ViewModelStore()
+    private var nextViewModelKey: Int = 0
+    private lateinit var testCacheFilesDir: File
+
+    @Before
+    fun setUpIsolatedCacheDir() {
+        testCacheFilesDir =
+            java.nio.file.Files.createTempDirectory("issue1829-tree-cache").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        viewModelStore.clear()
+        testCacheFilesDir.deleteRecursively()
+    }
+
+    // ---- the reported defect: an off-Main bind must fail LOUDLY --------------
+
+    /**
+     * Issue #1829 (reproduce-first, G10). RED before the guard: the off-Main
+     * `bind` returns normally — no exception, no log — while having hydrated the
+     * client cache, bumped `emitGeneration` and written `_state` to `Ready` from
+     * a foreign thread. That silent success IS the defect: nothing prevents a
+     * future caller from binding off Main, and when one appears the #867/#1109
+     * Loading flash comes back with no signal at all.
+     *
+     * GREEN with the guard: the call throws [MainThreadConfinementViolation]
+     * BEFORE touching any confined state, so the violation is impossible to
+     * miss and impossible to half-apply.
+     */
+    @Test
+    fun bindFromOffMainFailsLoudlyInsteadOfSilentlyMutatingTheConfinedColdSeed() = runTest {
+        val cache = newCache()
+        // The #867/#1109 cold-start shape: a warm client cache, so `bind` takes
+        // the SYNCHRONOUS seed path (`hydrateFromClientCache` ->
+        // `emitReady(synchronous = true)`) — the exact check-then-act sequence
+        // whose atomicity depends on Main confinement.
+        writeNodes(cache, node("alpha", 0, folderPath("alpha")))
+        val vm = newViewModel(StubGateway(listOf(sessionRow("alpha"))), cache)
+
+        assertTrue(
+            "precondition: a fresh view model starts at Loading, so any later Ready " +
+                "observed from the foreign thread was written BY that thread",
+            vm.state.value is FolderListUiState.Loading,
+        )
+
+        // Read back inside the foreign thread. `Dispatchers.Main` is a
+        // StandardTestDispatcher and the test thread does not pump between
+        // start and join, so NOTHING on Main can run during the call — any
+        // state change observed here was written by this thread.
+        val observedOffMain = AtomicReference<FolderListUiState?>(null)
+        val failure = runOffMainAndJoin("FolderListViewModel.bind") {
+            bind(vm)
+            observedOffMain.set(vm.state.value)
+        }
+
+        assertTrue(
+            "issue #1829: an off-Main bind() must fail LOUDLY. Instead it " +
+                "${if (failure == null) "returned normally" else "threw $failure"} and the " +
+                "confined state it wrote off Main was ${observedOffMain.get()}. With no " +
+                "enforcement, the #867/#1109 Loading-flash race is one careless caller away " +
+                "and arrives silently.",
+            failure is MainThreadConfinementViolation,
+        )
+        assertNull(
+            "issue #1829: the guard must fire BEFORE bind mutates emitGeneration / _state — " +
+                "a half-applied bind off Main is exactly the corrupted state the confinement " +
+                "exists to prevent",
+            observedOffMain.get(),
+        )
+        assertTrue(
+            "issue #1829: after a rejected off-Main bind the view model must still hold its " +
+                "untouched Loading seed — got ${vm.state.value}",
+            vm.state.value is FolderListUiState.Loading,
+        )
+    }
+
+    /**
+     * Issue #1829 class coverage inside [FolderListViewModel]: the confinement
+     * belongs to the EMIT seam, not just to `bind`. `emitReady` is reached from
+     * 21 call sites; guarding only `bind` would leave every one of them able to
+     * bump `emitGeneration` off Main. Drive a public emit-producing entry point
+     * (`toggleProjectExpanded`, the user's folder collapse tap) from a foreign
+     * thread after a legitimate on-Main bind and require the same loud failure.
+     */
+    @Test
+    fun emitProducingEntryPointFromOffMainFailsLoudly() = runTest {
+        val cache = newCache()
+        writeNodes(cache, node("alpha", 0, folderPath("alpha")))
+        val vm = newViewModel(StubGateway(listOf(sessionRow("alpha"))), cache)
+
+        // The production shape: bind on Main (this IS the Robolectric main thread).
+        bind(vm)
+        runCurrent()
+        assertTrue(
+            "precondition: the on-Main bind must have produced a Ready projection, so the " +
+                "off-Main toggle below really reaches emitReady",
+            vm.state.value is FolderListUiState.Ready,
+        )
+
+        val failure = runOffMainAndJoin("FolderListViewModel.toggleProjectExpanded") {
+            vm.toggleProjectExpanded(folderPath("alpha"))
+        }
+
+        assertTrue(
+            "issue #1829: every emit-producing entry point is Main-confined, not just bind() " +
+                "— an off-Main toggle bumps the same non-@Volatile emitGeneration counter. " +
+                "Got ${failure ?: "no exception at all"}",
+            failure is MainThreadConfinementViolation,
+        )
+    }
+
+    /**
+     * Issue #1829 acceptance criterion 2: the on-Main path must be unchanged in
+     * every observable way. This is the #867/#1109 instant-render promise —
+     * a warm cache paints `Ready` SYNCHRONOUSLY inside `bind`, before any
+     * coroutine runs. If the guard were misplaced (or threw on Main) this is
+     * what would break.
+     */
+    @Test
+    fun onMainBindStillRendersTheCachedTreeInstantlyWithNoLoadingFlash() = runTest {
+        val cache = newCache()
+        writeNodes(
+            cache,
+            node("alpha", 0, folderPath("alpha")),
+            node("beta", 1, folderPath("beta")),
+        )
+        val vm = newViewModel(StubGateway(listOf(sessionRow("alpha"), sessionRow("beta"))), cache)
+
+        bind(vm)
+
+        val first = vm.state.value
+        assertTrue(
+            "issue #1829 must not change the on-Main path: a warm cache still paints Ready " +
+                "synchronously inside bind (no Loading flash) — got $first",
+            first is FolderListUiState.Ready,
+        )
+        assertEquals(
+            listOf("alpha", "beta"),
+            (first as FolderListUiState.Ready).flatSessions.map { it.sessionName },
+        )
+    }
+
+    // ---- G2: the sibling view models that share the shape --------------------
+
+    /**
+     * Issue #1829 acceptance criterion 4 (G2) — the sibling table, enumerated
+     * **BY SHAPE, NOT BY NAME**.
+     *
+     * ## How the enumeration was done (so the next reader can redo it)
+     *
+     * Round 1 of this issue defined the class correctly and then enumerated it
+     * by grepping the method names `bind` and `load` — so three members called
+     * `start` fell straight out. The enumeration is now three mechanical
+     * properties checked against the source rather than against a name:
+     *
+     *  - **S1** the declaring type is a screen-scoped state holder (a
+     *    `ViewModel` supertype, or it owns a `MutableStateFlow` a composable
+     *    collects).
+     *  - **S2** the member is non-suspend, non-private, and is not itself a
+     *    whole-body `viewModelScope.launch { }` (which is Main by construction).
+     *  - **S3** the body does check-then-act over plain, non-`@Volatile`,
+     *    non-`Atomic` state in ONE of four sub-shapes: **(a)** a guard-return
+     *    that reads a plain `var` followed by a write to one; **(b)** a
+     *    read-modify-write on a `MutableStateFlow` (`_x.value = current.copy(…)`,
+     *    not the atomic `.update {}`); **(c)** a generation-counter bump
+     *    (`++f` / `f += 1`); **(d)** a **job swap** (`job?.cancel()` … `job =
+     *    launch{}`) — which has no `if` at all, and is exactly why
+     *    `HostTmuxSessionPickerViewModel.load` is invisible to a guard-shaped
+     *    scan.
+     *
+     * That yields 95 candidates, dominated by gesture callbacks. Two further
+     * splits, also mechanical:
+     *
+     *  - **call-site shape** — a candidate is a *binding seam* when at least one
+     *    call site sits inside a Compose `LaunchedEffect(…) { }` block, i.e. the
+     *    screen drives it with its route parameters and the check-then-act
+     *    decides *whether the load happens at all*. Losing that race drops the
+     *    screen's content (the reported #867/#1109 symptom). The remaining 56
+     *    are gesture callbacks: same field shape, but their only possible
+     *    invoker is Compose input dispatch, and losing the race drops one
+     *    gesture, not the first frame.
+     *  - **already-solved** — an entry point whose body hops to Main itself
+     *    (`withContext(Dispatchers.Main)`) or serialises under `synchronized` is
+     *    out of the class by construction. The four `observeProcessLifecycle`
+     *    members are the former and their KDoc states that contract in words
+     *    ("safe … from a coroutine on `Dispatchers.IO`") — guarding them would
+     *    contradict a deliberate, documented design.
+     *
+     * ## The class, in full
+     *
+     * | entry point | check-then-act sub-shape | consequence off Main |
+     * |---|---|---|
+     * | `FolderListViewModel.bind` / `emitReady` / `applyReadyProjection` | (a)+(c)+(d) `++emitGeneration` → `buildProjection` → re-check | **the reported one** — dropped cold seed, #867/#1109 Loading flash |
+     * | `EnvViewModel.bind` | (a) `if (params == next && …) return` then assign + `_state.value = …` | a duplicated or dropped `refresh()` and a lost `_state` write |
+     * | `FileViewerViewModel.bind` | (a) `lastRequest` read/write + `loadJob?.isActive` | two concurrent loads, or a dropped one |
+     * | `RepoBrowserViewModel.bind` | (a) `if (credentials == …) return` then assign + `refresh()` | duplicate/dropped enumeration |
+     * | `WatchedFoldersChipsViewModel.bind` | (a)+(d) `if (hostId == …) return` then assign + job swap | an orphaned collector on the old host |
+     * | `WatchedFoldersViewModel.bind` | (b)+(d) plus `_state.value = _state.value.copy(…)` | a lost-update read-modify-write on the StateFlow |
+     * | `PortForwardPanelViewModel.load` | (a)+(c)+(d) `if (currentHostId == …) return` then `++loadGeneration` | a stale load generation, so a superseded result is applied |
+     * | `RecurringJobsViewModel.load` | (a)+(c) `if (next == target) return` then `targetGeneration += 1` | the same stale-generation drop, on the jobs list |
+     * | `FileExplorerViewModel.start` | (a) `if (request == …) return` then assign + a plain `LinkedHashMap.clear()` | a dropped navigation, plus a non-thread-safe map cleared mid-read |
+     * | `GitHistoryViewModel.start` | (a) `if (request == …) return` then assign + `load()` | structurally identical to `RepoBrowserViewModel.bind` |
+     * | `FirstHostTestConnectViewModel.start` | (a)+(b) guard on `testingHostId` + `_state.value`, then `current.copy(…)` | a lost first-run connect result |
+     * | `AddEditHostViewModel.loadHost` | (a) `if (editingHostId == …) return` then assign | a double-load that clobbers the dirty-state `baseline` |
+     * | `AddEditHostViewModel.consumeFirstInvalidField` | (b) read `_state.value` then write `s.copy(…)` | a concurrent form edit lost between read and write |
+     * | `AddEditHostViewModel.consumeSaved` | (b) same, on the one-shot save/navigate signal | a re-firing navigation signal (the #1243 dead end) |
+     * | `HostListViewModel.reprobeUnknownHostsOnce` | (a) plain `autoReprobeKicked` once-latch | two startup probe sweeps instead of one |
+     * | `HostTmuxSessionPickerViewModel.load` | (d) `loadJob?.cancel()` … `loadJob = launch{}` | two loads race `_state`; the picker shows the wrong host's sessions |
+     * | `HostTmuxSessionPickerViewModel.refreshProjectSiblings` | (b)+(d) same job swap on the sibling list | a stale project-switcher dropdown |
+     *
+     * ## Out of the class, with the reason (not silence)
+     *
+     *  - **56 gesture callbacks** (`toggleWordWrap`, `addFolder`,
+     *    `dismissBanner`, `setSort`, …): the shape without the binding seam —
+     *    see the call-site split above.
+     *  - **`PortForwardPanelViewModel` / `SessionsDashboardViewModel` /
+     *    `UpdateCheckScheduler` / `UsageScheduler` `.observeProcessLifecycle`,
+     *    and `UsageScheduler.start` / `.cancel`**: self-dispatched or
+     *    `synchronized` — already solved, see above.
+     *  - **`TerminalLabActivity`'s `TerminalLabController.connect`**: not a
+     *    screen view model and not `LaunchedEffect`-driven — it is called once
+     *    from the debug lab activity's `onCreate` with an explicit
+     *    `CoroutineScope` argument.
+     *  - **`TmuxSessionViewModel`** (`connect`, `reconnect`,
+     *    `prewarmLikelySwitchTargets`, `cancelTmuxSessionPrewarm`,
+     *    `refreshActiveSessionCards`): genuinely in the shape, but it is the
+     *    D28 connection-core serial lane and is deliberately untouched here.
+     *    Recorded so the omission is a decision, not an oversight.
+     *
+     * This test proves each guard is LIVE, and names **every** entry point that
+     * fails to enforce rather than stopping at the first.
+     * `HostListViewModel.reprobeUnknownHostsOnce` is proven in
+     * `HostListViewModelTest` and `PortForwardPanelViewModel.load` in
+     * `PortForwardPanelViewModelTest`, where each already has a harness.
+     */
+    @Test
+    fun everySiblingViewModelWithABindEntryPointAlsoEnforcesMainConfinement() = runTest {
+        val leaseManager = SshLeaseManager(
+            connector = SshLeaseConnector { Result.success(NoopTreeSshSession()) },
+            scope = this,
+            idleTtlMillis = 0L,
+            connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            nowMillis = { testScheduler.currentTime },
+        )
+        val context: Context = ApplicationProvider.getApplicationContext()
+
+        val envViewModel = EnvViewModel(gateway = NoopEnvGateway, hostDao = FakeHostDao(HOST))
+        val fileViewerViewModel = FileViewerViewModel(
+            appContext = context,
+            sshLeaseManager = leaseManager,
+        )
+        val repoBrowserViewModel = RepoBrowserViewModel(
+            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+            sshLeaseManager = leaseManager,
+        )
+        val chipsViewModel = WatchedFoldersChipsViewModel(FakeProjectRootDao())
+        val watchedFoldersViewModel = WatchedFoldersViewModel(
+            projectRootDao = FakeProjectRootDao(),
+            sshLeaseManager = leaseManager,
+        )
+        val recurringJobsViewModel = RecurringJobsViewModel(
+            remoteSource = PocketshellJobsRemoteSource(RecurringJobsParser()),
+            connector = object : RecurringJobsViewModel.RecurringJobsSshConnector {
+                override suspend fun acquire(
+                    target: RecurringJobsViewModel.Target,
+                ): Result<SshLease> = Result.failure(IllegalStateException("no lease in this test"))
+            },
+        )
+        val fileExplorerViewModel = FileExplorerViewModel(leaseManager)
+        val gitHistoryViewModel = GitHistoryViewModel(leaseManager)
+        val addEditHostViewModel = AddEditHostViewModel(
+            hostDao = FakeHostDao(HOST),
+            sshKeyDao = FakeSshKeyDao,
+        )
+        val firstHostTestConnectViewModel = FirstHostTestConnectViewModel(
+            hostDao = FakeHostDao(HOST),
+            sshKeyDao = FakeSshKeyDao,
+            // Never invoked: every guard fires before any work runs, which is
+            // itself part of what the assertions below pin.
+            tester = FirstHostConnectionTester(),
+        )
+        val sessionPickerViewModel = HostTmuxSessionPickerViewModel(NoopSessionsGateway)
+        val pickerRequest = HostTmuxSessionPickerRequest(
+            host = HOST,
+            keyPath = KEY_PATH,
+            passphrase = null,
+        )
+
+        val siblings: List<Pair<String, () -> Unit>> = listOf(
+            "EnvViewModel.bind" to {
+                envViewModel.bind(
+                    hostId = HOST.id,
+                    keyPath = KEY_PATH,
+                    passphrase = null,
+                    directory = "/home/alexey/git/alpha",
+                    folderLabel = "alpha",
+                    copySources = emptyList(),
+                )
+            },
+            "FileViewerViewModel.bind" to {
+                fileViewerViewModel.bind(
+                    FileViewerViewModel.Request(
+                        hostId = HOST.id,
+                        hostname = HOST.hostname,
+                        port = HOST.port,
+                        username = HOST.username,
+                        keyPath = KEY_PATH,
+                        passphrase = null,
+                        path = "README.md",
+                        cwd = null,
+                    ),
+                )
+            },
+            "RepoBrowserViewModel.bind" to {
+                repoBrowserViewModel.bind(
+                    RepoBrowserViewModel.SshCredentials(
+                        hostId = HOST.id,
+                        hostname = HOST.hostname,
+                        port = HOST.port,
+                        username = HOST.username,
+                        keyPath = KEY_PATH,
+                        passphrase = null,
+                    ),
+                )
+            },
+            "WatchedFoldersChipsViewModel.bind" to { chipsViewModel.bind(HOST.id) },
+            "WatchedFoldersViewModel.bind" to {
+                watchedFoldersViewModel.bind(hostId = HOST.id, hostName = HOST.name)
+            },
+            // The closest analogue of the reported defect: like
+            // FolderListViewModel.emitReady this bumps a plain generation
+            // counter and re-checks it later, so off Main the counter is
+            // exactly the value that can be lost.
+            "RecurringJobsViewModel.load" to {
+                recurringJobsViewModel.load(
+                    hostId = HOST.id,
+                    hostName = HOST.name,
+                    hostname = HOST.hostname,
+                    port = HOST.port,
+                    username = HOST.username,
+                    keyPath = KEY_PATH,
+                    passphrase = null,
+                    sessionName = "alpha",
+                )
+            },
+            // ---- round 2: the members the by-NAME sweep missed --------------
+            "FileExplorerViewModel.start" to {
+                fileExplorerViewModel.start(
+                    FileExplorerViewModel.Request(
+                        hostId = HOST.id,
+                        hostname = HOST.hostname,
+                        port = HOST.port,
+                        username = HOST.username,
+                        keyPath = KEY_PATH,
+                        passphrase = null,
+                        startDir = "/home/alexey/git/alpha",
+                    ),
+                )
+            },
+            "GitHistoryViewModel.start" to {
+                gitHistoryViewModel.start(
+                    GitHistoryViewModel.Request(
+                        hostId = HOST.id,
+                        hostname = HOST.hostname,
+                        port = HOST.port,
+                        username = HOST.username,
+                        keyPath = KEY_PATH,
+                        passphrase = null,
+                        dir = "/home/alexey/git/alpha",
+                    ),
+                )
+            },
+            "FirstHostTestConnectViewModel.start" to {
+                firstHostTestConnectViewModel.start(HOST.id)
+            },
+            "AddEditHostViewModel.loadHost" to { addEditHostViewModel.loadHost(HOST.id) },
+            "AddEditHostViewModel.consumeFirstInvalidField" to {
+                addEditHostViewModel.consumeFirstInvalidField()
+            },
+            "AddEditHostViewModel.consumeSaved" to { addEditHostViewModel.consumeSaved() },
+            // The job-swap sub-shape: no `if` at all, which is exactly why a
+            // guard-shaped scan cannot see it.
+            "HostTmuxSessionPickerViewModel.load" to {
+                sessionPickerViewModel.load(pickerRequest)
+            },
+            "HostTmuxSessionPickerViewModel.refreshProjectSiblings" to {
+                sessionPickerViewModel.refreshProjectSiblings(
+                    host = HOST,
+                    keyPath = KEY_PATH,
+                    currentSessionName = "alpha",
+                    projectPath = "/home/alexey/git/alpha",
+                )
+            },
+        )
+
+        val unenforced = siblings.mapNotNull { (label, invoke) ->
+            val failure = runOffMainAndJoin(label, invoke)
+            if (failure is MainThreadConfinementViolation) {
+                null
+            } else {
+                "$label -> ${failure ?: "no exception at all"}"
+            }
+        }
+
+        assertEquals(
+            "issue #1829 (G2): every screen-scoped view model with a non-suspend bind() " +
+                "check-then-act must enforce Main confinement the same way FolderListViewModel " +
+                "does. These did not fail loudly off Main: $unenforced",
+            emptyList<String>(),
+            unenforced,
+        )
+    }
+
+    // ---- helpers ------------------------------------------------------------
+
+    /**
+     * Runs [block] on a real foreign thread and waits for it with a bounded,
+     * HARD-failing join (the `process.md` `runTest` convention, Shape B): the
+     * join's exit condition is asserted, never assumed, so a wedged call can
+     * never be mistaken for "the guard did not throw". Returns whatever the
+     * block threw, or `null` when it completed normally.
+     */
+    private fun runOffMainAndJoin(label: String, block: () -> Unit): Throwable? {
+        val captured = AtomicReference<Throwable?>(null)
+        val worker = Thread({
+            try {
+                block()
+            } catch (t: Throwable) {
+                captured.set(t)
+            }
+        }, "issue1829-off-main")
+        worker.start()
+        worker.join(OFF_MAIN_JOIN_TIMEOUT_MS)
+        assertFalse(
+            "issue #1829: the off-Main $label call must finish within " +
+                "${OFF_MAIN_JOIN_TIMEOUT_MS}ms — it is still running, so nothing asserted " +
+                "below would mean anything",
+            worker.isAlive,
+        )
+        return captured.get()
+    }
+
+    private fun bind(vm: FolderListViewModel) {
+        vm.bind(
+            hostId = HOST.id,
+            hostName = HOST.name,
+            hostname = HOST.hostname,
+            port = HOST.port,
+            username = HOST.username,
+            keyPath = KEY_PATH,
+            passphrase = null,
+        )
+    }
+
+    private fun folderPath(name: String): String =
+        FolderListViewModel.canonicalisePath("/home/alexey/git/$name")
+
+    private fun node(name: String, order: Int, path: String): TreeRemoteSource.TreeNode =
+        TreeRemoteSource.TreeNode(
+            session = name,
+            order = order,
+            folderPath = path,
+            collapsed = false,
+        )
+
+    private fun writeNodes(cache: TreeClientCache, vararg nodes: TreeRemoteSource.TreeNode) {
+        cache.write(HOST.name, TreeClientCache.CachedTree(nodes = nodes.toList()))
+    }
+
+    private fun sessionRow(name: String): FolderSessionRow =
+        FolderSessionRow(
+            sessionName = name,
+            lastActivity = 1_000L,
+            attached = true,
+            cwd = "/home/alexey/git/$name",
+            agentKind = SessionAgentKind.Shell,
+        )
+
+    private fun newCache(): TreeClientCache =
+        TreeClientCache(
+            object : ContextWrapper(ApplicationProvider.getApplicationContext()) {
+                override fun getFilesDir(): File = testCacheFilesDir
+            },
+        )
+
+    private fun TestScope.newViewModel(
+        gateway: FolderListGateway,
+        cache: TreeClientCache,
+    ): FolderListViewModel {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        val manager = SshLeaseManager(
+            connector = SshLeaseConnector { Result.success(NoopTreeSshSession()) },
+            scope = this,
+            idleTtlMillis = 0L,
+            connectTimeoutContext = dispatcher,
+            nowMillis = { testScheduler.currentTime },
+        )
+        return FolderListViewModel(
+            gateway = gateway,
+            hostDao = FakeHostDao(HOST),
+            projectRootDao = FakeProjectRootDao(),
+            sshLeaseManager = manager,
+            forwardingController = ForwardingController(ApplicationProvider.getApplicationContext()),
+            treeRemoteSource = null,
+            treeClientCache = cache,
+            attachLifecycle = false,
+        ).also {
+            it.ioDispatcher = dispatcher
+            it.treeDispatcher = dispatcher
+            it.setProcessStartedForTest(true)
+            viewModelStore.put("FolderListViewModel-${nextViewModelKey++}", it)
+        }
+    }
+
+    private class NoopTreeSshSession : SshSession {
+        override val isConnected: Boolean = true
+        override suspend fun exec(command: String): ExecResult = ExecResult("", "no daemon", 127)
+        override fun tail(path: String, onLine: (String) -> Unit) = error("unused")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("unused")
+        override fun startShell(): SshShell = error("unused")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("unused")
+        override suspend fun uploadStream(
+            input: java.io.InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("unused")
+        override fun close() = Unit
+    }
+
+    private class StubGateway(
+        @Volatile var rows: List<FolderSessionRow>?,
+    ) : FolderListGateway {
+        override suspend fun listSessionsWithFolder(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            watchedRoots: List<ProjectRootEntity>,
+        ): FolderListResult = FolderListResult.Sessions(
+            rows = rows ?: error("gateway probe must not be called"),
+            projectFoldersByRoot = emptyMap(),
+            resolvedWatchedRootPaths = emptyMap(),
+        )
+
+        override suspend fun createSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+            cwd: String,
+            startCommand: String?,
+            namePolicy: SessionNamePolicy,
+        ): Result<String> = error("not used")
+
+        override suspend fun createEmptyProject(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            parentPath: String,
+            folderName: String,
+        ): Result<String> = error("not used")
+
+        override suspend fun importFile(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            folderPath: String,
+            payload: FolderImportPayload,
+        ): Result<String> = error("not used")
+
+        override suspend fun killSession(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sessionName: String,
+        ): Result<Unit> = error("not used")
+    }
+
+    private object NoopEnvGateway : EnvGateway {
+        override suspend fun listKeys(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            directory: String,
+        ): EnvListResult = EnvListResult.Keys(emptyList())
+
+        override suspend fun getValue(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            directory: String,
+            key: String,
+        ): EnvOpResult = error("not used")
+
+        override suspend fun setKeys(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            directory: String,
+            file: EnvFileTarget,
+            updates: Map<String, String>,
+        ): EnvOpResult = error("not used")
+
+        override suspend fun copyKeys(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+            sourceDirectory: String,
+            destinationDirectory: String,
+            file: EnvFileTarget,
+            keys: List<String>,
+        ): EnvOpResult = error("not used")
+    }
+
+    private class FakeHostDao(private val host: HostEntity) : HostDao {
+        override fun getAll(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun getById(id: Long): HostEntity? = host.takeIf { it.id == id }
+        override fun getEnabled(): Flow<List<HostEntity>> = flowOf(listOf(host))
+        override suspend fun insert(host: HostEntity): Long = error("not used")
+        override suspend fun update(host: HostEntity) = error("not used")
+        override suspend fun delete(host: HostEntity) = error("not used")
+        override suspend fun deleteById(id: Long) = error("not used")
+    }
+
+    /**
+     * Every method errors on purpose: the Main guard must fire BEFORE any of
+     * these entry points touches a DAO, so a call reaching one is itself a
+     * failure the test should surface rather than absorb.
+     */
+    private object FakeSshKeyDao : SshKeyDao {
+        override fun getAll(): Flow<List<SshKeyEntity>> = flowOf(emptyList())
+        override suspend fun getById(id: Long): SshKeyEntity? = null
+        override suspend fun getByName(name: String): SshKeyEntity? = null
+        override suspend fun getByFingerprint(fingerprint: String): SshKeyEntity? = null
+        override suspend fun insert(key: SshKeyEntity): Long = error("not used")
+        override suspend fun delete(key: SshKeyEntity) = error("not used")
+        override suspend fun deleteById(id: Long) = error("not used")
+    }
+
+    private object NoopSessionsGateway : HostTmuxSessionsGateway {
+        override suspend fun listSessions(
+            host: HostEntity,
+            keyPath: String,
+            passphrase: CharArray?,
+        ): HostTmuxSessionListResult = HostTmuxSessionListResult.Sessions(emptyList())
+
+        override suspend fun listSessionsFromLiveClient(
+            host: HostEntity,
+            keyPath: String,
+        ): HostTmuxSessionListResult? = null
+    }
+
+    private class FakeProjectRootDao : ProjectRootDao {
+        private val roots = MutableStateFlow<List<ProjectRootEntity>>(emptyList())
+        override fun getByHostId(hostId: Long): Flow<List<ProjectRootEntity>> = roots
+        override suspend fun insert(root: ProjectRootEntity): Long = error("not used")
+        override suspend fun update(root: ProjectRootEntity) = error("not used")
+        override suspend fun delete(root: ProjectRootEntity) = error("not used")
+    }
+
+    private companion object {
+        const val KEY_PATH: String = "/tmp/pocketshell-test-key"
+
+        /**
+         * Generous relative to the work being waited on (a `bind` that either
+         * throws immediately or completes a purely in-memory hydrate), so a
+         * contended CI box cannot turn a correct run red — while still hard
+         * failing rather than hanging if the call genuinely wedges.
+         */
+        const val OFF_MAIN_JOIN_TIMEOUT_MS: Long = 30_000L
+
+        val HOST: HostEntity = HostEntity(
+            id = 42L,
+            name = "hetzner",
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "testuser",
+            keyId = 7L,
+        )
+    }
+}


### PR DESCRIPTION
Closes #1829

## Verdict: hardening, not a live defect

`FolderListViewModel`'s Main confinement was correct and **enforced by nothing** — an off-Main `bind()` would silently restore the #867/#1109 Loading flash.

An off-Main `bind()` is **not reachable in production**, and that was settled at the bytecode level rather than by argument: `HandlerContext.isDispatchNeeded` returns false **only** when `invokeImmediately && Looper.myLooper() == handler.getLooper()`, so a `Main.immediate`-rooted continuation resumed from a foreign thread is always re-posted. All 8 entry points and all **21** `emitReady()` sites were enumerated, including three non-obvious ones; every production caller is a `LaunchedEffect` body.

## The nearest miss is not `bind()`

`AppAssistantActions.cloneRepo` reaches `emitReady()` from inside `sshExecutor.withSession { … }` — landing on Main **only because** `LeaseSessionExec.withSession` has no dispatcher of its own and inherits `viewModelScope`. One `withContext` away from being off-Main. Now guarded.

## The class was wider than the issue framed it

"Non-suspend screen-scoped check-then-act over plain non-`@Volatile` fields" pulls in `PortForwardPanelViewModel.load` and `RecurringJobsViewModel.load`, which bump a generation counter the same way.

Enumerating by **name** (`bind`/`load`) missed three more — `FileExplorerViewModel.start`, `GitHistoryViewModel.start`, `FirstHostTestConnectScreen`. And `HostTmuxSessionPickerViewModel.load` has **no `if` at all**, so no guard-shaped scan could ever see it; rather than hand-adding it, the scanner grew a **job-swap sub-shape** (`job?.cancel()` … `job = launch{}`), which then surfaced `AddEditHostViewModel.loadHost` that nobody had listed. **19 guards total.**

## Guarding an entry point obliges sweeping its callers

**247 call sites audited, 4 off-Main → 0.** Two were found only by the sweep and **break under the new guard** — so guarding without sweeping would have reshipped the identical defect in a different file. The reviewer had independently found one of them by running the emulator, which is how round 1 was returned.

Two sweep bugs were caught by disbelieving results: a match on `viewModel.bind(...)` quoted inside a **KDoc block**, and a wrong-receiver false positive among the `src/main` hits.

## On completeness

The reviewer found a **fifth sub-shape the scanner structurally cannot see** — the elvis guard-return — then hunted all three blind spots across every ViewModel and established that **no blind spot hides a binding seam**: zero `when`-guards, zero `val`-collection cases, and every real elvis instance outside the connection VM is an already-documented Compose callback. Substantively complete; "mechanical end to end" is overstated, and that wording is corrected.

The 19 runtime throws were re-ruled at the widened set: every production call site is a `LaunchedEffect` body or input callback; Robolectric passes on the real main looper; Looper-less JVM tests hit the documented no-op; no `@VisibleForTesting`/harness path trips it, and no correctly-off-Main caller was caught.

## Verification

Full JVM gate audited on all four `process.md` points: **11741 executed / 0 failed / 0 skipped**, **1240 of 1240** XML files fresh from this run, no cache markers on any test task, load-bearing test in **both** debug and release. `check-file-size-hygiene.sh` and `check-connection-vm-ratchet.sh` both pass (they run in the `Unit` job but are not Gradle tests).

Four unrelated pre-existing failures surfaced during the sweep and reproduce on the stashed base tree with byte-identical messages — filed as **#1868**, not attributed here.

https://claude.ai/code/session_01NAgYxtJoJ47gbKmyhKtvxb