### PR TITLE
ui(insets): remove redundant nested IME padding (#1821)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/cards/SessionChecklistPushJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/cards/SessionChecklistPushJourneyDockerTest.kt
@@ -52,10 +52,17 @@ import java.io.FileOutputStream
  *  2. The app reads it through the PRODUCTION [SessionCardsRemoteSource.getCards]
  *     over the SAME warm [SshSession] (D21 — no new connection) and parses it to
  *     a [SessionCardsRemoteSource.ChecklistCard].
- *  3. The PRODUCTION checklist chip + bottom-sheet ([ChecklistChip] /
- *     [ChecklistCardsContent], the same composables the session screen mounts)
- *     render that real feed; the test asserts the card + its items ACTUALLY
- *     appear in the rendered feed (not a fabricated in-memory card).
+ *  3. [ChecklistChip] / [ChecklistCardsContent] render that real feed; the test
+ *     asserts the card + its items ACTUALLY appear in the rendered feed (not a
+ *     fabricated in-memory card). Correction (#1821): those two are NOT what the
+ *     session screen mounts — it mounts [SessionCardFeedSheet] ->
+ *     `SessionCardFeedContent` (`TmuxSessionSheets.kt:77`), and neither
+ *     [ChecklistChip] nor [ChecklistCardsContent] has any production caller. The
+ *     rows are drawn by the same [ChecklistCardRenderer] either way, so this
+ *     journey is not vacuous, but it proves that renderer through a wrapper the
+ *     product does not ship. Repointing it at `SessionCardFeedContent` is a
+ *     follow-up; it is a behavioural change to a gate-wired journey and was
+ *     deliberately kept out of #1821.
  *  4. Tapping an item drives the PRODUCTION
  *     [SessionCardsRemoteSource.setChecklistItemChecked] tick exec over the same
  *     warm session.

--- a/app/src/androidTest/java/com/pocketshell/app/insets/NestedImePaddingInSheetGeometryTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/insets/NestedImePaddingInSheetGeometryTest.kt
@@ -1,0 +1,507 @@
+package com.pocketshell.app.insets
+
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.cards.SESSION_CARD_FEED_SHEET_TAG
+import com.pocketshell.app.cards.SESSION_CHECKLIST_ITEM_TAG_PREFIX
+import com.pocketshell.app.cards.SessionCardFeedSheet
+import com.pocketshell.app.cards.SessionCardInteractions
+import com.pocketshell.app.cards.SessionCardsRemoteSource
+import com.pocketshell.app.fileviewer.FILE_VIEWER_ANNOTATE_ATTACH_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_ANNOTATE_SAVED_SHEET_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_REVIEW_FILE_SHEET_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_REVIEW_LINE_SHEET_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_REVIEW_SAVED_DONE_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_REVIEW_SAVED_SHEET_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_REVIEW_SAVE_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_REVIEW_SUBMIT_TAG
+import com.pocketshell.app.fileviewer.FILE_VIEWER_REVIEW_TRAY_SHEET_TAG
+import com.pocketshell.app.fileviewer.AnnotationSavedSheet
+import com.pocketshell.app.fileviewer.ReviewSheet
+import com.pocketshell.app.fileviewer.ReviewSheets
+import com.pocketshell.app.fileviewer.ReviewState
+import com.pocketshell.app.fileviewer.ReviewSubmittedSheet
+import com.pocketshell.app.git.GIT_CREATE_ISSUE_SHEET_TAG
+import com.pocketshell.app.git.GIT_CREATE_ISSUE_SUBMIT_TAG
+import com.pocketshell.app.git.GIT_ISSUES_TAB_TAG
+import com.pocketshell.app.git.GIT_NEW_ISSUE_TAG
+import com.pocketshell.app.git.GitBranch
+import com.pocketshell.app.git.GitCommit
+import com.pocketshell.app.git.GitHistoryScaffold
+import com.pocketshell.app.git.GitHistoryUiState
+import com.pocketshell.app.git.GitRepoOverview
+import com.pocketshell.app.git.GitRepoStatus
+import com.pocketshell.app.git.GitWorktree
+import com.pocketshell.app.projects.FOLDER_CONTEXT_EMPTY_PROJECT_TAG
+import com.pocketshell.app.projects.FOLDER_CONTEXT_SHEET_TAG
+import com.pocketshell.app.projects.FolderContextActionSheet
+import com.pocketshell.app.projects.SESSION_TYPE_PICKER_CREATE_TAG
+import com.pocketshell.app.projects.SESSION_TYPE_PICKER_SHEET_TAG
+import com.pocketshell.app.projects.SessionTypePickerSheet
+import com.pocketshell.app.snippets.SnippetPickerContent
+import com.pocketshell.app.snippets.snippetSendChipTag
+import com.pocketshell.core.storage.entity.SnippetEntity
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1821 — the per-site keyboard-geometry oracle for every remaining
+ * nested `.navigationBarsPadding().imePadding()` site that lives inside a
+ * Material3 `ModalBottomSheet`.
+ *
+ * ## What this proves, and why the issue needed it
+ *
+ * #1812 established the mechanism: `ModalBottomSheet` wraps its window content
+ * in `Box(Modifier.fillMaxSize().imePadding())` (`ModalBottomSheet.kt:169`, and
+ * again via `contentWindowInsets = safeDrawing.only(Bottom)` at `:291`), and
+ * `windowInsetsPadding` **consumes** the inset for its subtree. So a
+ * content-level `imePadding()` inside the sheet resolves to exactly zero. That
+ * argument is Compose common code and cannot vary by API level — but #1812
+ * deliberately refused to sweep the remaining sites on the strength of a source
+ * reading, because **none of them had a keyboard-geometry oracle to measure
+ * against**. This class is that oracle.
+ *
+ * Each test mounts the PRODUCTION sheet (the real `ModalBottomSheet`, its own
+ * window), dispatches a synthetic `Type.ime()` inset to every attached app
+ * window root, and records the sheet's bottom-most control geometry with the
+ * keyboard down and up. The recorded `ISSUE1821_SHEET_GEOMETRY` line is the
+ * before/after evidence used to classify each site inert (byte-identical with
+ * and without the modifier) or live.
+ *
+ * ## What it durably asserts
+ *
+ * Two hard assertions per site, neither of which the surfaces had before:
+ *
+ *  1. **The sheet lifts by essentially the whole keyboard.** This is what makes
+ *     the measurement non-vacuous: it fails if the synthetic inset never
+ *     reached the modal window, and it fails if Material3 ever stops handling
+ *     the ime inset for sheet content. With the duplicate content-level
+ *     `imePadding()` deleted, that second regression can no longer be masked —
+ *     the lift can only come from Material's own handling.
+ *
+ *     The first half is mutation-proven: in #1821 round 2 (run R2E) narrowing
+ *     `SyntheticImeStage.dispatch` to the activity decor only turned **all 10**
+ *     of these cases red at `liftPx=0.0`, while the 5 standalone cases stayed
+ *     green; the #1821 reviewer reproduced it (run V5).
+ *
+ *     The second half — the Material3-upgrade unmasking — is **mechanism, not a
+ *     measured claim**: nothing here simulates a Material3 that stops consuming
+ *     the ime inset, so it rests on #1812's source reading of
+ *     `ModalBottomSheet.kt:169` plus the fact that this file's own measurements
+ *     show the sheet lifting with no content-level `imePadding()` present.
+ *  2. **The bottom-most control stays fully ABOVE the keyboard**, asserted as
+ *     `boundsInRoot` containment in the sheet's OWN Compose root, not
+ *     `assertIsDisplayed()` (F2/F3 — a control under the keyboard still reports
+ *     "displayed"). `GitHistoryScaffoldTest`'s "create-issue form (issue #650)"
+ *     block records exactly this gap ("we keep `assertIsDisplayed()` for the
+ *     sheet-internal controls because `assertNodeFullyWithinRoot` reads a single
+ *     `onRoot()`"); binding against the owning modal root closes it.
+ *
+ * ## Why no `file:line` in the site labels
+ *
+ * They used to carry one (`SessionChecklistUi.kt:168-169`), and #1821's own
+ * round-2 comments in those production files shifted every one of them out of
+ * date within the same change — the site labels pointed at the comment block
+ * above the modifier instead of the modifier. A citation that rots the moment
+ * anyone edits the file is the same defect this issue is about, one layer up, so
+ * the labels name the composable instead, which does not rot. Library
+ * references (`ModalBottomSheet.kt:169`) keep their line numbers: that file is
+ * pinned by the dependency version.
+ *
+ * No `assumeTrue` / `assumeFalse`: an environment that cannot reach the state
+ * fails hard.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(AndroidJUnit4::class)
+class NestedImePaddingInSheetGeometryTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val stage by lazy { SyntheticImeStage(compose) }
+
+    @After
+    fun releaseSyntheticInsets() {
+        runCatching { stage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = false) }
+        runCatching { stage.hideRealImeBestEffort() }
+    }
+
+    // -- SessionChecklistUi.kt — SessionCardFeedContent ----------------------------
+
+    @Test
+    fun sessionCardFeedSheetLiftsAndKeepsLastCardAboveKeyboard() {
+        measureSheet(
+            site = "SessionChecklistUi.SessionCardFeedContent",
+            sheetTag = SESSION_CARD_FEED_SHEET_TAG,
+            probeTag = SESSION_CHECKLIST_ITEM_TAG_PREFIX + "cl:build-0",
+        ) {
+            SessionCardFeedSheet(
+                cards = listOf(checklistCard()),
+                interactions = NoopInteractions,
+                onDismiss = {},
+            )
+        }
+    }
+
+    // -- FileViewerReviewUi.kt — CommentSheet (line) -------------------------------
+
+    @Test
+    fun fileViewerLineCommentSheetLiftsAndKeepsSaveAboveKeyboard() {
+        measureSheet(
+            site = "FileViewerReviewUi.CommentSheet(line)",
+            sheetTag = FILE_VIEWER_REVIEW_LINE_SHEET_TAG,
+            probeTag = FILE_VIEWER_REVIEW_SAVE_TAG,
+        ) {
+            ReviewSheetsHost(ReviewSheet.Line(2))
+        }
+    }
+
+    // -- FileViewerReviewUi.kt — CommentSheet (whole file) -------------------------
+
+    @Test
+    fun fileViewerFileCommentSheetLiftsAndKeepsSaveAboveKeyboard() {
+        measureSheet(
+            site = "FileViewerReviewUi.CommentSheet(file)",
+            sheetTag = FILE_VIEWER_REVIEW_FILE_SHEET_TAG,
+            probeTag = FILE_VIEWER_REVIEW_SAVE_TAG,
+        ) {
+            ReviewSheetsHost(ReviewSheet.File)
+        }
+    }
+
+    // -- FileViewerReviewUi.kt — PendingTraySheet ----------------------------------
+
+    @Test
+    fun fileViewerReviewTraySheetLiftsAndKeepsSubmitAboveKeyboard() {
+        measureSheet(
+            site = "FileViewerReviewUi.PendingTraySheet",
+            sheetTag = FILE_VIEWER_REVIEW_TRAY_SHEET_TAG,
+            probeTag = FILE_VIEWER_REVIEW_SUBMIT_TAG,
+        ) {
+            ReviewSheetsHost(ReviewSheet.Tray)
+        }
+    }
+
+    // -- FileViewerReviewUi.kt — ReviewSubmittedSheet ------------------------------
+
+    @Test
+    fun fileViewerReviewSubmittedSheetLiftsAndKeepsDoneAboveKeyboard() {
+        measureSheet(
+            site = "FileViewerReviewUi.ReviewSubmittedSheet",
+            sheetTag = FILE_VIEWER_REVIEW_SAVED_SHEET_TAG,
+            probeTag = FILE_VIEWER_REVIEW_SAVED_DONE_TAG,
+        ) {
+            ReviewSubmittedSheet(
+                host = "agents",
+                count = 2,
+                savedPath = "/root/inbox/pocketshell/reviews/main-kt-20260729.yaml",
+                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                onCopyPath = {},
+                onAttach = {},
+                onDismiss = {},
+            )
+        }
+    }
+
+    // -- FileViewerReviewUi.kt — AnnotationSavedSheet ------------------------------
+
+    @Test
+    fun fileViewerAnnotationSavedSheetLiftsAndKeepsAttachAboveKeyboard() {
+        measureSheet(
+            site = "FileViewerReviewUi.AnnotationSavedSheet",
+            sheetTag = FILE_VIEWER_ANNOTATE_SAVED_SHEET_TAG,
+            probeTag = FILE_VIEWER_ANNOTATE_ATTACH_TAG,
+        ) {
+            AnnotationSavedSheet(
+                host = "agents",
+                savedPath = "/root/inbox/pocketshell/annotations/shot-20260729.png",
+                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                onCopyPath = {},
+                onAttach = {},
+                onDismiss = {},
+            )
+        }
+    }
+
+    // -- GitHistoryScreen.kt — CreateIssueSheet ------------------------------------
+
+    @Test
+    fun gitCreateIssueSheetLiftsAndKeepsSubmitAboveKeyboard() {
+        measureSheet(
+            site = "GitHistoryScreen.CreateIssueSheet",
+            sheetTag = GIT_CREATE_ISSUE_SHEET_TAG,
+            probeTag = GIT_CREATE_ISSUE_SUBMIT_TAG,
+            openSheet = {
+                compose.onNodeWithTag(GIT_ISSUES_TAB_TAG).performClick()
+                compose.onNodeWithTag(GIT_NEW_ISSUE_TAG).performClick()
+            },
+        ) {
+            GitHistoryScaffold(
+                hostName = "agents",
+                state = gitReadyState(),
+                onBack = {},
+                onRetry = {},
+            )
+        }
+    }
+
+    // -- FolderContextActionSheet.kt — FolderContextActionContent ------------------
+
+    @Test
+    fun folderContextSheetLiftsAndKeepsLastRowAboveKeyboard() {
+        measureSheet(
+            site = "FolderContextActionSheet.FolderContextActionContent",
+            sheetTag = FOLDER_CONTEXT_SHEET_TAG,
+            probeTag = FOLDER_CONTEXT_EMPTY_PROJECT_TAG,
+        ) {
+            FolderContextActionSheet(
+                folderLabel = "projects",
+                folderPath = "/root/projects",
+                onDismiss = {},
+                onNewSession = {},
+                onImport = {},
+                onCloneGitProject = {},
+                onEmptyProject = {},
+            )
+        }
+    }
+
+    // -- SessionTypePickerSheet.kt — SessionTypePickerContent ----------------------
+
+    @Test
+    fun sessionTypePickerSheetLiftsAndKeepsCreateAboveKeyboard() {
+        measureSheet(
+            site = "SessionTypePickerSheet.SessionTypePickerContent",
+            sheetTag = SESSION_TYPE_PICKER_SHEET_TAG,
+            probeTag = SESSION_TYPE_PICKER_CREATE_TAG,
+        ) {
+            SessionTypePickerSheet(
+                folderPath = "/root/projects/demo",
+                folderLabel = "demo",
+                onDismiss = {},
+                onCreate = {},
+            )
+        }
+    }
+
+    // -- SnippetPickerSheet.kt — SnippetPickerContent ------------------------------
+
+    /**
+     * `SnippetPickerSheet` itself resolves two `hiltViewModel()`s, and this
+     * module's `androidTest` variant has no Hilt test application, so the sheet
+     * wrapper cannot be composed here. This mounts the PRODUCTION content
+     * composable inside a real `ModalBottomSheet` — the identical composition
+     * shape the wrapper produces — `SnippetPickerSheet`'s own
+     * `ModalBottomSheet { SnippetPickerContent(...) }` — with only
+     * the view-model plumbing replaced. The property under test is purely the
+     * inset relationship between the sheet window and its content, which that
+     * plumbing does not participate in.
+     */
+    @Test
+    fun snippetPickerSheetLiftsAndKeepsSendChipAboveKeyboard() {
+        measureSheet(
+            site = "SnippetPickerSheet.SnippetPickerContent",
+            sheetTag = SNIPPET_PICKER_PROBE_SHEET_TAG,
+            probeTag = snippetSendChipTag(SNIPPET_FIXTURE.id, withEnter = true),
+        ) {
+            SnippetPickerContentInSheet()
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Harness
+    // ------------------------------------------------------------------------
+
+    /**
+     * Mounts [content], settles it, then samples [probeTag]'s geometry with the
+     * synthetic keyboard down and up and asserts the two load-bearing
+     * properties. [openSheet] runs after the content is composed for surfaces
+     * whose sheet is opened by a user action rather than mounted directly.
+     */
+    private fun measureSheet(
+        site: String,
+        sheetTag: String,
+        probeTag: String,
+        openSheet: (() -> Unit)? = null,
+        content: @Composable () -> Unit,
+    ) {
+        stage.startEdgeToEdge()
+        compose.setContent { PocketShellTheme { content() } }
+        openSheet?.invoke()
+
+        assertTrue(
+            "The production sheet '$sheetTag' must mount and settle for site $site.",
+            stage.awaitStable(sheetTag),
+        )
+        // A focus-requesting field inside a sheet can raise the real keyboard;
+        // the synthetic boundary is only meaningful with it provably gone.
+        stage.hideRealImeAndAssertHidden(
+            "Issue #1821 synthetic sheet-geometry proof cannot start while a real IME is up " +
+                "(site=$site).",
+        )
+
+        stage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = true)
+        assertTrue(
+            "Keyboard-down geometry must settle before it is captured (site=$site).",
+            stage.awaitStable(probeTag),
+        )
+        val down = stage.boundsOf(probeTag)
+
+        val imeBottomPx = stage.imeBottomPx
+        stage.dispatch(imeBottomPx = imeBottomPx, requireExtraWindowRoot = true)
+        assertTrue(
+            "Keyboard-up geometry must settle before it is captured (site=$site).",
+            stage.awaitStable(probeTag),
+        )
+        val up = stage.boundsOf(probeTag)
+        val modalRoot = stage.owningRootOf(probeTag)
+        val liftPx = down.bottom - up.bottom
+        val keyboardTopPx = modalRoot.boundsInRoot.bottom - imeBottomPx
+
+        // Publish BEFORE asserting so even a red run carries the evidence — every
+        // assertion, including the nonzero-keyboard guard below, which used to
+        // sit above this line and would have cost a red run its geometry line
+        // (the same wrinkle the #1821 reviewer found in the standalone proof).
+        Log.i(
+            GEOMETRY_LOG_TAG,
+            "ISSUE1821_SHEET_GEOMETRY site=$site imeBottomPx=$imeBottomPx liftPx=$liftPx " +
+                "keyboardDownProbe=$down keyboardUpProbe=$up " +
+                "modalRoot=${modalRoot.boundsInRoot} keyboardTopPx=$keyboardTopPx " +
+                "density=${stage.density}",
+        )
+
+        assertTrue("The synthetic keyboard must be nonzero.", imeBottomPx > 0)
+        assertTrue(
+            "The production sheet must lift its content by essentially the whole keyboard; " +
+                "a zero lift means the synthetic inset never reached the modal window, or " +
+                "Material3 stopped handling the ime inset for sheet content. " +
+                "site=$site liftPx=$liftPx imeBottomPx=$imeBottomPx down=$down up=$up",
+            liftPx >= imeBottomPx * SyntheticImeStage.MINIMUM_LIFT_FRACTION,
+        )
+        stage.assertFullyAboveKeyboard(probeTag, modalRoot, keyboardTopPx)
+    }
+
+    private object NoopInteractions : SessionCardInteractions {
+        override fun onToggleChecklistItem(cardId: String, itemId: String, checked: Boolean) = Unit
+        override fun onSetNoteRead(cardId: String, read: Boolean) = Unit
+    }
+
+    @Composable
+    private fun ReviewSheetsHost(activeSheet: ReviewSheet) {
+        ReviewSheets(
+            activeSheet = activeSheet,
+            reviewState = ReviewState(
+                active = true,
+                lineComments = mapOf(2 to "needs a null check"),
+                fileComment = "overall looks fine",
+            ),
+            lines = listOf("package demo", "fun main() {", "}"),
+            onDismiss = {},
+            onSetLineComment = { _, _ -> },
+            onDeleteLineComment = {},
+            onSetFileComment = {},
+            onDeleteFileComment = {},
+            onOpenLine = {},
+            onSubmitReview = {},
+        )
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    private fun SnippetPickerContentInSheet() {
+        ModalBottomSheet(
+            onDismissRequest = {},
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = PocketShellColors.Surface,
+            contentColor = PocketShellColors.Text,
+        ) {
+            Column(modifier = Modifier.testTag(SNIPPET_PICKER_PROBE_SHEET_TAG)) {
+                SnippetPickerContent(
+                    snippets = listOf(SNIPPET_FIXTURE),
+                    totalCount = 1,
+                    query = "",
+                    onQueryChange = {},
+                    onSnippetSend = { _, _ -> },
+                    onManageTap = {},
+                    onClose = {},
+                )
+            }
+        }
+    }
+
+    private companion object {
+        /**
+         * Instrumentation `println` never reaches the Gradle console for a
+         * connected run, so the per-site geometry evidence is logged and read
+         * back from logcat.
+         */
+        const val GEOMETRY_LOG_TAG = "Issue1821Geometry"
+
+        const val SNIPPET_PICKER_PROBE_SHEET_TAG = "issue1821:snippet-picker:sheet"
+
+        val SNIPPET_FIXTURE = SnippetEntity(
+            id = 1,
+            hostId = 1,
+            label = "deploy api",
+            body = "kubectl rollout restart deploy/api",
+            kind = "command",
+        )
+
+        fun checklistCard() = SessionCardsRemoteSource.ChecklistCard(
+            id = "cl",
+            title = "Deploy",
+            createdAt = null,
+            updatedAt = null,
+            items = listOf(SessionCardsRemoteSource.ChecklistItem("build-0", "Build")),
+            checkedIds = emptySet(),
+        )
+
+        fun gitReadyState() = GitHistoryUiState.Ready(
+            dir = "/root/git/demo",
+            commits = listOf(GitCommit("a1b2c3d", "Ada Lovelace", "2 hours ago", "Add timeline")),
+            truncated = false,
+            overview = GitRepoOverview(
+                status = GitRepoStatus(
+                    currentBranch = "main",
+                    upstream = "origin/main",
+                    ahead = 0,
+                    behind = 0,
+                    dirty = false,
+                    changedFiles = 0,
+                    lastCommit = "a1b2c3d Add timeline",
+                    hasNoCommits = false,
+                ),
+                branches = listOf(
+                    GitBranch("main", current = true, upstream = "origin/main", subject = "Add timeline"),
+                ),
+                worktrees = listOf(
+                    GitWorktree(
+                        "/root/git/demo",
+                        branch = "main",
+                        head = "a1b2c3d",
+                        bare = false,
+                        detached = false,
+                    ),
+                ),
+            ),
+            issues = emptyList(),
+            ghHint = null,
+        )
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/insets/StandaloneContentImePaddingLivenessTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/insets/StandaloneContentImePaddingLivenessTest.kt
@@ -1,0 +1,358 @@
+package com.pocketshell.app.insets
+
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.cards.ChecklistCardsContent
+import com.pocketshell.app.cards.SESSION_CHECKLIST_ITEM_TAG_PREFIX
+import com.pocketshell.app.cards.SessionCardFeedContent
+import com.pocketshell.app.cards.SessionCardInteractions
+import com.pocketshell.app.cards.SessionCardsRemoteSource
+import com.pocketshell.app.projects.FOLDER_CONTEXT_EMPTY_PROJECT_TAG
+import com.pocketshell.app.projects.FolderContextActionContent
+import com.pocketshell.app.projects.SESSION_TYPE_PICKER_CREATE_TAG
+import com.pocketshell.app.projects.SessionTypePickerContent
+import com.pocketshell.app.snippets.SnippetPickerContent
+import com.pocketshell.app.snippets.snippetSendChipTag
+import com.pocketshell.core.storage.entity.SnippetEntity
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1821 — the LIVE half of the nested-`imePadding()` sweep.
+ *
+ * ## Why these five sites are not deleted with the others
+ *
+ * Ten sites carried the copy-pasted `.navigationBarsPadding().imePadding()`
+ * idiom. Five of them are written inline inside a `ModalBottomSheet` content
+ * lambda, so the sheet is their ONLY possible composition and the modifier is
+ * structurally unreachable — those are deleted (D22 hard cut).
+ *
+ * The other five are **extracted content composables** that are also composed
+ * **standalone**, outside any `ModalBottomSheet`:
+ *
+ *  - `SessionCardFeedContent`  — `SessionCardFeedRegistryTest`
+ *  - `ChecklistCardsContent`   — `SessionChecklistUiInteractionTest`,
+ *                                `SessionChecklistPushJourneyDockerTest`
+ *  - `FolderContextActionContent` — `FolderContextActionSheetScreenshotTest`
+ *  - `SessionTypePickerContent` — `SessionTypePickerNameFieldUiTest` and three
+ *                                 sibling picker tests
+ *                                 (`SessionTypePickerSkipPermissionsUiTest`,
+ *                                 `SessionTypeProfilePickerUiTest`,
+ *                                 `RepoBrowserSessionPickerTest`)
+ *  - `SnippetPickerContent`    — `SnippetPickerSendButtonsTest`,
+ *                                `SnippetPickerBodyPreviewTest`
+ *
+ * Outside a sheet nothing has consumed the ime or navigation-bar insets, so for
+ * these composables `.imePadding()` and `.navigationBarsPadding()` are the ONLY
+ * things keeping their bottom controls clear of the keyboard and the nav bar.
+ * Deleting them "by analogy with #1812" would have been wrong — which is the
+ * entire reason #1821 exists as a per-site sweep rather than a blanket one.
+ *
+ * ## What each test asserts
+ *
+ * The content is mounted **bottom-anchored** and a synthetic inset set (a 295 dp
+ * `Type.ime()` and a 48 dp `Type.navigationBars()`) is dispatched. Three hard
+ * assertions per site, deliberately split across BOTH keyboard states because
+ * the two modifiers are only visible in different ones:
+ *
+ *  1. keyboard **UP** — the bottom-most control **lifts by essentially the whole
+ *     keyboard**, and
+ *  2. keyboard **UP** — it is **fully contained above the keyboard boundary**
+ *     (`boundsInRoot` containment, not `assertIsDisplayed()` — F2/F3).
+ *     1 and 2 go RED when the site's `.imePadding()` is removed (lift 648 → 0).
+ *  3. keyboard **DOWN** — it is **fully contained above the navigation-bar
+ *     boundary**. This one goes RED when the site's `.navigationBarsPadding()`
+ *     is removed (the control drops 126 px, straight under the nav bar).
+ *
+ * Assertion 3 is not decoration. With the keyboard up the ime inset subsumes the
+ * nav bar, so 1 and 2 **structurally cannot see** a missing
+ * `navigationBarsPadding()` — the #1821 reviewer removed exactly that modifier
+ * from a kept site and this suite came back 15/15 green while the bottom row sat
+ * under the nav bar. Only the keyboard-down state, where the ime inset is zero,
+ * has bite. #1812 and #1742 could say nothing about `navigationBarsPadding()`
+ * for precisely this reason: their oracle dispatched a ZERO nav-bar inset.
+ *
+ * Together the three make the "keep" decision durable for BOTH modifiers: before
+ * this class, nothing in the tree distinguished a live site from an inert one,
+ * so the next reader had no way to tell them apart.
+ *
+ * ## One honest qualifier: no EXISTING caller depends on these modifiers
+ *
+ * "LIVE" here is a **precautionary invariant** about what these modifiers do
+ * when the content is composed outside a sheet — not a claim that some existing
+ * on-device journey depends on them today. That was checked, not assumed:
+ *
+ *  - Most standalone callers mount the content **top-anchored with no IME**,
+ *    where a missing bottom inset is geometrically invisible.
+ *  - The one exception is `SessionTypePickerSkipPermissionsUiTest`
+ *    `folderSuggestionStaysAboveImeAndCanBeSelected` (#613), which DOES mount
+ *    `SessionTypePickerContent` bottom-anchored (`Alignment.BottomCenter` in a
+ *    `fillMaxSize` Box) with the REAL soft IME raised — the same shape this
+ *    proof uses. Even so, it does not depend on the modifier: deleting
+ *    `.imePadding()` from `SessionTypePickerContent` left all 6 of that class's
+ *    cases green (#1821 round 2, runs R2F0/R2F1). Its assertions do not read
+ *    the geometry the modifier moves.
+ *
+ * So the bottom-anchored mount below is the faithful standalone analogue of a
+ * bottom sheet and the arrangement in which the modifier is observable at all —
+ * which is why the proof uses it — but it is this class, and only this class,
+ * that turns "keep it" into something a gate can enforce.
+ *
+ * The `site=` labels name `File.Composable` and deliberately carry no line
+ * number: #1821's own round-2 comments shifted every line number these labels
+ * used to cite, inside the same change (see
+ * [NestedImePaddingInSheetGeometryTest], "Why no `file:line` in the site
+ * labels").
+ *
+ * No `assumeTrue` / `assumeFalse`: an environment that cannot reach the state
+ * fails hard.
+ */
+@RunWith(AndroidJUnit4::class)
+class StandaloneContentImePaddingLivenessTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val stage by lazy { SyntheticImeStage(compose) }
+
+    @After
+    fun releaseSyntheticInsets() {
+        runCatching { stage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = false) }
+        runCatching { stage.hideRealImeBestEffort() }
+    }
+
+    @Test
+    fun sessionCardFeedContentLiftsItsLastCardAboveTheKeyboard() {
+        measureStandalone(
+            site = "SessionChecklistUi.SessionCardFeedContent",
+            probeTag = SESSION_CHECKLIST_ITEM_TAG_PREFIX + "cl:build-0",
+        ) {
+            SessionCardFeedContent(
+                cards = listOf(checklistCard()),
+                interactions = NoopInteractions,
+                onClose = {},
+            )
+        }
+    }
+
+    @Test
+    fun checklistCardsContentLiftsItsLastItemAboveTheKeyboard() {
+        measureStandalone(
+            site = "SessionChecklistUi.ChecklistCardsContent",
+            probeTag = SESSION_CHECKLIST_ITEM_TAG_PREFIX + "cl:build-0",
+        ) {
+            ChecklistCardsContent(
+                cards = listOf(checklistCard()),
+                onToggle = { _, _, _ -> },
+                onClose = {},
+            )
+        }
+    }
+
+    @Test
+    fun folderContextActionContentLiftsItsLastRowAboveTheKeyboard() {
+        measureStandalone(
+            site = "FolderContextActionSheet.FolderContextActionContent",
+            probeTag = FOLDER_CONTEXT_EMPTY_PROJECT_TAG,
+        ) {
+            FolderContextActionContent(
+                folderLabel = "projects",
+                folderPath = "/root/projects",
+                onNewSession = {},
+                onImport = {},
+                onCloneGitProject = {},
+                onEmptyProject = {},
+            )
+        }
+    }
+
+    @Test
+    fun sessionTypePickerContentLiftsCreateAboveTheKeyboard() {
+        measureStandalone(
+            site = "SessionTypePickerSheet.SessionTypePickerContent",
+            probeTag = SESSION_TYPE_PICKER_CREATE_TAG,
+        ) {
+            SessionTypePickerContent(
+                folderPath = "/root/projects/demo",
+                folderLabel = "demo",
+                onCancel = {},
+                onCreate = {},
+            )
+        }
+    }
+
+    @Test
+    fun snippetPickerContentLiftsItsSendChipAboveTheKeyboard() {
+        measureStandalone(
+            site = "SnippetPickerSheet.SnippetPickerContent",
+            probeTag = snippetSendChipTag(SNIPPET_FIXTURE.id, withEnter = true),
+        ) {
+            SnippetPickerContent(
+                snippets = listOf(SNIPPET_FIXTURE),
+                totalCount = 1,
+                query = "",
+                onQueryChange = {},
+                onSnippetSend = { _, _ -> },
+                onManageTap = {},
+                onClose = {},
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Harness
+    // ------------------------------------------------------------------------
+
+    private fun measureStandalone(
+        site: String,
+        probeTag: String,
+        content: @Composable () -> Unit,
+    ) {
+        stage.startEdgeToEdge()
+        compose.setContent {
+            PocketShellTheme {
+                // Bottom-anchored: the standalone analogue of a bottom sheet,
+                // and the arrangement where a missing bottom inset actually
+                // pushes controls under the keyboard.
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.BottomStart,
+                ) {
+                    content()
+                }
+            }
+        }
+
+        assertTrue(
+            "The standalone content must mount and settle for site $site.",
+            stage.awaitStable(probeTag),
+        )
+        stage.hideRealImeAndAssertHidden(
+            "Issue #1821 standalone liveness proof cannot start while a real IME is up " +
+                "(site=$site).",
+        )
+
+        stage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = false)
+        assertTrue(
+            "Keyboard-down geometry must settle before it is captured (site=$site).",
+            stage.awaitStable(probeTag),
+        )
+        val down = stage.boundsOf(probeTag)
+
+        val imeBottomPx = stage.imeBottomPx
+        val navBarBottomPx = stage.navBarBottomPx
+        stage.dispatch(imeBottomPx = imeBottomPx, requireExtraWindowRoot = false)
+        assertTrue(
+            "Keyboard-up geometry must settle before it is captured (site=$site).",
+            stage.awaitStable(probeTag),
+        )
+        val up = stage.boundsOf(probeTag)
+        val root = stage.owningRootOf(probeTag)
+        val liftPx = down.bottom - up.bottom
+        val keyboardTopPx = root.boundsInRoot.bottom - imeBottomPx
+        val navBarTopPx = root.boundsInRoot.bottom - navBarBottomPx
+
+        // Publish BEFORE asserting so even a red run carries the evidence. That
+        // is why the two non-vacuity guards below sit AFTER this line and not
+        // before it: in #1821 round 2 the nav-bar guard preceded the log, so the
+        // run that mutated the nav bar to zero shipped 10 geometry lines instead
+        // of 15 — a red run that dropped a third of its own evidence.
+        Log.i(
+            GEOMETRY_LOG_TAG,
+            "ISSUE1821_STANDALONE_GEOMETRY site=$site imeBottomPx=$imeBottomPx " +
+                "navBarBottomPx=$navBarBottomPx liftPx=$liftPx " +
+                "keyboardDownProbe=$down keyboardUpProbe=$up root=${root.boundsInRoot} " +
+                "keyboardTopPx=$keyboardTopPx navBarTopPx=$navBarTopPx " +
+                "density=${stage.density}",
+        )
+
+        assertTrue("The synthetic keyboard must be nonzero.", imeBottomPx > 0)
+        // A zero nav-bar inset is what made #1812/#1742 unable to say anything
+        // about `navigationBarsPadding()`: the boundary assertion below would be
+        // satisfied by the root's own bottom edge and would prove nothing.
+        assertTrue(
+            "The synthetic navigation bar must be nonzero, or the keyboard-down " +
+                "containment assertion below is vacuous.",
+            navBarBottomPx > 0,
+        )
+
+        // ---- what `.imePadding()` protects: the keyboard-UP state ------------
+        assertTrue(
+            "Composed OUTSIDE a ModalBottomSheet nothing has consumed the ime inset, so this " +
+                "content's own imePadding() is the only thing lifting it off the keyboard. " +
+                "A zero lift means that modifier is gone. " +
+                "site=$site liftPx=$liftPx imeBottomPx=$imeBottomPx down=$down up=$up",
+            liftPx >= imeBottomPx * SyntheticImeStage.MINIMUM_LIFT_FRACTION,
+        )
+        stage.assertFullyAboveKeyboard(probeTag, root, keyboardTopPx)
+
+        // ---- what `.navigationBarsPadding()` protects: the keyboard-DOWN state
+        // Re-enter the keyboard-down state and assert LIVE geometry there. This
+        // half cannot be folded into the assertions above: with the keyboard up
+        // the 295 dp ime inset subsumes the 48 dp nav bar, so removing
+        // `navigationBarsPadding()` leaves every keyboard-up assertion green
+        // while the bottom control drops a full nav-bar height out of reach.
+        // (Found by the #1821 reviewer: 15/15 green with the modifier deleted.)
+        stage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = false)
+        assertTrue(
+            "Keyboard-down geometry must settle again before the navigation-bar " +
+                "containment assertion (site=$site).",
+            stage.awaitStable(probeTag),
+        )
+        val downAgain = stage.boundsOf(probeTag)
+        assertTrue(
+            "Re-entering the keyboard-down state must reproduce the geometry captured " +
+                "at the start of this measurement, or the two halves of this proof are " +
+                "reading different layouts. site=$site first=$down second=$downAgain",
+            kotlin.math.abs(downAgain.bottom - down.bottom) <= 1f,
+        )
+        val downRoot = stage.owningRootOf(probeTag)
+        stage.assertFullyAboveNavigationBar(
+            probeTag,
+            downRoot,
+            downRoot.boundsInRoot.bottom - navBarBottomPx,
+        )
+    }
+
+    private object NoopInteractions : SessionCardInteractions {
+        override fun onToggleChecklistItem(cardId: String, itemId: String, checked: Boolean) = Unit
+        override fun onSetNoteRead(cardId: String, read: Boolean) = Unit
+    }
+
+    private companion object {
+        /**
+         * Instrumentation `println` never reaches the Gradle console for a
+         * connected run, so the per-site geometry evidence is logged and read
+         * back from logcat.
+         */
+        const val GEOMETRY_LOG_TAG = "Issue1821Geometry"
+
+        val SNIPPET_FIXTURE = SnippetEntity(
+            id = 1,
+            hostId = 1,
+            label = "deploy api",
+            body = "kubectl rollout restart deploy/api",
+            kind = "command",
+        )
+
+        fun checklistCard() = SessionCardsRemoteSource.ChecklistCard(
+            id = "cl",
+            title = "Deploy",
+            createdAt = null,
+            updatedAt = null,
+            items = listOf(SessionCardsRemoteSource.ChecklistItem("build-0", "Build")),
+            checkedIds = emptySet(),
+        )
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticImeStage.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticImeStage.kt
@@ -1,0 +1,544 @@
+package com.pocketshell.app.insets
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
+import android.os.Build
+import android.os.SystemClock
+import android.view.View
+import android.view.accessibility.AccessibilityWindowInfo
+import android.view.inputmethod.InputMethodManager
+import android.view.inspector.WindowInspector
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.android.ComposeNotIdleException
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+
+/**
+ * Issue #1821 — the keyboard-geometry oracle the nested-`imePadding()` sites did
+ * not have.
+ *
+ * #1812 proved that a content-level `Modifier.imePadding()` inside a Material3
+ * `ModalBottomSheet` is a no-op (the sheet's own
+ * `Box(Modifier.fillMaxSize().imePadding())` at `ModalBottomSheet.kt:169` has
+ * already CONSUMED the ime inset), and deleted the one site that had a
+ * gate-wired oracle to measure against (`RootProjectAddSheet`, #1742). The
+ * remaining ten sites had **no oracle at all**, which is why #1812 listed them
+ * rather than sweeping them: an unmeasured deletion is exactly the
+ * confident-argument-without-measurement shape this repo's process exists to
+ * catch.
+ *
+ * This is the shared harness those sites needed. It is the #1742 / #780 model
+ * distilled:
+ *
+ *  1. Hard-require that **no physical IME window** is visible, so a synthetic
+ *     boundary can never be silently mixed with a real keyboard.
+ *  2. Dispatch a synthetic `Type.ime()` inset to **every attached app-owned
+ *     window root** — activity decor *and* any `ModalBottomSheet` window.
+ *     Dispatching to the activity alone leaves a modal's Compose
+ *     `WindowInsets.ime` at zero, which is a one-line mutation away from a
+ *     vacuous green.
+ *  3. Read geometry as `boundsInRoot` in the **owning** Compose root's
+ *     coordinate space, and assert **containment** (never `assertIsDisplayed()`,
+ *     which is satisfied by layout participation, not viewport containment).
+ *
+ * There is no `assumeTrue` / `assumeFalse` anywhere: an environment that cannot
+ * reach the required state fails hard (F3).
+ */
+internal class SyntheticImeStage(
+    private val compose: AndroidComposeTestRule<
+        ActivityScenarioRule<ComponentActivity>,
+        ComponentActivity,
+        >,
+) {
+
+    /** The synthetic keyboard height, in px on the device under test. */
+    val imeBottomPx: Int
+        get() = (SYNTHETIC_IME_HEIGHT_DP * displayDensity()).toInt()
+
+    /**
+     * The synthetic navigation-bar height, in px on the device under test. It is
+     * dispatched in BOTH keyboard states (see [dispatch]), so it is the boundary
+     * that gives `navigationBarsPadding()` bite in the keyboard-DOWN state —
+     * where the ime inset is zero and therefore cannot subsume it.
+     */
+    val navBarBottomPx: Int
+        get() = (SYNTHETIC_NAV_BAR_HEIGHT_DP * displayDensity()).toInt()
+
+    val density: Float
+        get() = compose.density.density
+
+    private val scenario: ActivityScenario<ComponentActivity>
+        get() = compose.activityRule.scenario
+
+    /**
+     * Opts the ACTIVITY window out of decor inset fitting, and hard-requires the
+     * API level [activeAppWindowRoots] needs.
+     *
+     * ## What this call is actually for — measured, not argued
+     *
+     * The previous version of this comment asserted a counterfactual ("without
+     * it the decor consumes them and every measurement below would read zero").
+     * The #1821 reviewer falsified it in one run on API 35, so it was re-derived
+     * by deleting the call and running the whole suite on two API levels
+     * (#1821 round 3, runs A/B/C/D):
+     *
+     * | device                  | this call | in-sheet (10) | standalone (5)  |
+     * |-------------------------|-----------|---------------|-----------------|
+     * | API 35 `test-2`         | present   | PASS          | PASS liftPx=648 |
+     * | API 35 `test-2`         | DELETED   | PASS          | PASS liftPx=648 |
+     * | API 34 `ps-api34-i1197` | present   | PASS          | PASS liftPx=648 |
+     * | API 34 `ps-api34-i1197` | DELETED   | PASS          | FAIL liftPx=0.0 |
+     *
+     * So it is load-bearing for exactly ONE half, on exactly SOME devices:
+     *
+     *  - **Standalone content (the activity's own window) on API <= 34 — LOAD
+     *    BEARING.** With decor fitting left on, the content view consumes the
+     *    dispatched insets before Compose reads them: all 5 standalone cases
+     *    failed at `liftPx=0.0` on API 34 with this call deleted (run D).
+     *  - **API 35 with `targetSdk = 35` — INERT.** Android 15 enforces
+     *    edge-to-edge for apps targeting 35, so the window is already opted out
+     *    and deleting the call changed nothing: 15/15 green with all 15 geometry
+     *    lines byte-identical to the run with it (run B vs run A).
+     *  - **In-sheet content — never depends on it, at any API level.** A
+     *    `ModalBottomSheet` draws in its OWN window, which the activity's decor
+     *    setting does not touch: all 10 in-sheet cases stayed green in run D.
+     *
+     * It is kept, rather than hard-cut as a no-op, because this class admits
+     * every device from API 29 up (the [check] below) and 29..34 is precisely
+     * the range where run D shows it has bite. It is NOT kept "just in case".
+     *
+     * The [check] is a separate, independent precondition: [activeAppWindowRoots]
+     * reads `WindowInspector.getGlobalWindowViews()`, which the platform added in
+     * API 29 (`api-versions.xml`: `<class name="android/view/inspector/
+     * WindowInspector" since="29">`).
+     */
+    fun startEdgeToEdge() {
+        check(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            "Issue #1821 synthetic-inset oracle requires API 29+ WindowInspector; " +
+                "deviceApi=${Build.VERSION.SDK_INT}"
+        }
+        scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+    }
+
+    /**
+     * Drives the real IME down and HARD-asserts it is gone, in three steps that
+     * are exactly what the body does — two independent signals plus a stability
+     * re-check of the first:
+     *
+     *  1. no accessibility `TYPE_INPUT_METHOD` window is visible;
+     *  2. no app window root reports a visible positive REAL ime inset;
+     *  3. signal 1 stays empty for [PHYSICAL_IME_ABSENCE_STABILITY_MS] (a
+     *     keyboard mid-dismissal must not read as "already gone").
+     *
+     * No skip — an emulator that refuses to put the keyboard away fails loudly
+     * instead of silently measuring a mixed real/synthetic boundary.
+     *
+     * (Mechanism, not a measured claim: no #1821 run has driven signal 1 to a
+     * POSITIVE, because none of these tests raises the real keyboard. What is
+     * structural, and checkable by reading, is that it cannot self-skip — every
+     * step is an `assertTrue`, never an `assumeTrue`.)
+     */
+    fun hideRealImeAndAssertHidden(message: String) {
+        hideRealImeBestEffort()
+        assertTrue(
+            "$message Physical input-method window remained visible: " +
+                visiblePhysicalImeWindows(),
+            waitForWallClock(REAL_IME_TIMEOUT_MS) { visiblePhysicalImeWindows().isEmpty() },
+        )
+        assertTrue(
+            "$message An app root still reports a visible positive real-IME inset.",
+            waitForWallClock(REAL_IME_TIMEOUT_MS) { !readAnyAppRootImeVisible() },
+        )
+        assertNoPhysicalImeWindow(message)
+    }
+
+    fun hideRealImeBestEffort() {
+        runCatching {
+            scenario.onActivity { activity ->
+                val inputMethodManager =
+                    activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                activeAppWindowRoots(activity).forEach { root ->
+                    ViewCompat.getWindowInsetsController(root)
+                        ?.hide(WindowInsetsCompat.Type.ime())
+                    root.windowToken?.let { token ->
+                        inputMethodManager.hideSoftInputFromWindow(token, 0)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Dispatches the synthetic inset set to every attached app-owned window
+     * root and settles Compose, [INSET_DISPATCH_REPEATS] times.
+     *
+     * The repeat is unproven race-hardening, NOT a measured necessity, and this
+     * comment says so because #1821 round 3 measured it: dropping
+     * [INSET_DISPATCH_REPEATS] to `1` left all 15 cases green with all 15
+     * geometry lines byte-identical (run G, API 35). The hypothesis it guards —
+     * a `ModalBottomSheet` attaching its window between the first dispatch and
+     * the first layout pass — is one a single green run cannot rule out, so a
+     * second cheap dispatch is kept; what is NOT claimed is that anything here
+     * has ever needed it.
+     *
+     * @param imeBottomPx the synthetic keyboard height (0 for keyboard-down).
+     * @param requireExtraWindowRoot when `true`, hard-fails unless at least one
+     *   non-decor app window root (i.e. the mounted modal) is attached. This is
+     *   a precondition check on the FIXTURE, and it is NOT the mutation anchor —
+     *   the anchor is the `roots.forEach` dispatch below, whose narrowing to the
+     *   activity decor is what has been driven red (see the block comment
+     *   there). Nothing has mutated this guard itself; it is green because the
+     *   sheet window is present, and its bite would only show if a sheet
+     *   silently stopped owning a window.
+     */
+    fun dispatch(imeBottomPx: Int, requireExtraWindowRoot: Boolean) {
+        assertNoPhysicalImeWindow(
+            "Issue #1821 synthetic dispatch must never be mixed with a real IME window.",
+        )
+        val statusBarTopPx = (SYNTHETIC_STATUS_BAR_HEIGHT_DP * displayDensity()).toInt()
+        // Issue #1821 gives the NAV-BAR inset bite too. #1742's oracle dispatched
+        // `navigationBars = Insets.of(0,0,0,0)`, which is exactly why #1812 could
+        // say nothing about the sibling `navigationBarsPadding()` on these lines:
+        // a zero inset cannot distinguish "redundant" from "load-bearing". A
+        // nonzero one can, so the same before/after mutation that classifies
+        // `imePadding()` also classifies `navigationBarsPadding()`.
+        val navBarBottomPx = this.navBarBottomPx
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
+            .setVisible(WindowInsetsCompat.Type.ime(), imeBottomPx > 0)
+            .setInsets(
+                WindowInsetsCompat.Type.navigationBars(),
+                Insets.of(0, 0, 0, navBarBottomPx),
+            )
+            .setVisible(WindowInsetsCompat.Type.navigationBars(), true)
+            .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, statusBarTopPx, 0, 0))
+            .setInsets(
+                WindowInsetsCompat.Type.systemBars(),
+                Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
+            )
+            .build()
+        repeat(INSET_DISPATCH_REPEATS) {
+            scenario.onActivity { activity ->
+                val roots = activeAppWindowRoots(activity)
+                val activityDecor = activity.window.decorView
+                check(roots.any { it === activityDecor }) {
+                    "Active app roots must include the activity decor."
+                }
+                if (requireExtraWindowRoot) {
+                    check(roots.any { it !== activityDecor }) {
+                        "The mounted ModalBottomSheet window root disappeared before " +
+                            "inset dispatch; the sheet must own its own window for this " +
+                            "measurement to mean anything."
+                    }
+                }
+                // ---- ROOT-CAUSE MUTATION ANCHOR (issue #1742/#1821) ----------
+                // EVERY attached app-owned window root gets the inset, because a
+                // ModalBottomSheet's content lives in its OWN window. Narrowing
+                // this to `activityDecor` leaves the modal Compose tree at ime=0
+                // and the lift assertions go red. Not a guess — mutation-proven
+                // in #1821 round 2 (run R2E): with this line reduced to the
+                // decor, all 10 `NestedImePaddingInSheetGeometryTest` cases
+                // failed at `liftPx=0.0`, while the 5
+                // `StandaloneContentImePaddingLivenessTest` cases stayed green
+                // (their content lives in the activity's own window). That is
+                // the non-vacuity guarantee for this whole oracle.
+                roots.forEach { root -> ViewCompat.dispatchApplyWindowInsets(root, insets) }
+                // ---------------------------------------------------------------
+            }
+            compose.waitForIdle()
+        }
+    }
+
+    /** Bounds of the node tagged [tag], in its own Compose root's space. */
+    fun boundsOf(tag: String): Rect =
+        compose.onNodeWithTag(tag, useUnmergedTree = true).fetchSemanticsNode().boundsInRoot
+
+    /**
+     * Waits until the node tagged [tag] exists AND its rect has been unchanged
+     * for [stableWindowMs].
+     *
+     * The load-bearing half is the WAIT-UNTIL-IT-EXISTS half plus the hard
+     * `false`-on-timeout return, which every caller asserts on. The stability
+     * WINDOW is unproven hardening, and the original text here overstated it
+     * ("`waitForIdle()` alone can return mid-flight ... a geometry sample taken
+     * then is meaningless"). Measured in #1821 round 3: collapsing
+     * [LAYOUT_STABLE_WINDOW_MS] to `0` — i.e. sampling the first rect that reads
+     * back twice, with no settling — left all 15 cases green with all 15
+     * geometry lines byte-identical (run H, API 35). On that device the
+     * `waitForIdle()` inside `fetchSemanticsNodes` already covers the sheet's
+     * slide-in, so the window is kept as cheap insurance for a slower emulator,
+     * not because any run here has needed it.
+     *
+     * Returns `false` on timeout; every caller treats that as a HARD failure.
+     */
+    fun awaitStable(
+        tag: String,
+        stableWindowMs: Long = LAYOUT_STABLE_WINDOW_MS,
+        timeoutMs: Long = LAYOUT_STABLE_TIMEOUT_MS,
+    ): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var last: Rect? = readRectOrNull(tag)
+        var lastChangedAt = SystemClock.elapsedRealtime()
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val now = SystemClock.elapsedRealtime()
+            val current = readRectOrNull(tag)
+            when {
+                current == null -> {
+                    last = null
+                    lastChangedAt = now
+                }
+                current != last -> {
+                    last = current
+                    lastChangedAt = now
+                }
+                now - lastChangedAt >= stableWindowMs -> return true
+            }
+            SystemClock.sleep(50)
+        }
+        return false
+    }
+
+    private fun readRectOrNull(tag: String): Rect? = try {
+        val nodes = compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes()
+        if (nodes.isEmpty()) null else nodes.first().boundsInRoot
+    } catch (_: AssertionError) {
+        null
+    } catch (_: ComposeNotIdleException) {
+        // A busy tree is the same "rect unknown right now" condition as an
+        // absent node, so the poll retries rather than failing.
+        //
+        // This catch is not redundant with the two below, and the comment that
+        // used to sit here ("Compose's ComposeNotIdleException is not visible
+        // from here") was wrong twice over (#1821 round 3): the type IS public
+        // and importable, and it extends `java.lang.Exception` DIRECTLY —
+        // `public final class androidx.compose.ui.test.junit4.android.
+        // ComposeNotIdleException extends java.lang.Exception` — so neither
+        // `IllegalStateException` nor `RuntimeException` ever caught it. The
+        // false comment was hiding a real hole in this poll.
+        null
+    } catch (_: IllegalStateException) {
+        null
+    } catch (_: RuntimeException) {
+        null
+    }
+
+    /**
+     * The Compose root that OWNS the node tagged [tag]. For a `ModalBottomSheet`
+     * this is the modal's own window root, not the activity's — mixing the two
+     * coordinate spaces is how a containment assertion silently stops meaning
+     * anything.
+     */
+    fun owningRootOf(tag: String): SemanticsNode {
+        val node = compose.onNodeWithTag(tag, useUnmergedTree = true).fetchSemanticsNode()
+        val root = compose.onAllNodes(isRoot()).fetchSemanticsNodes()
+            .single { it.root === node.root }
+        assertTrue(
+            "The owning Compose root must have nonzero geometry; bounds=${root.boundsInRoot}",
+            root.boundsInRoot.width > 0f && root.boundsInRoot.height > 0f,
+        )
+        return root
+    }
+
+    /**
+     * Containment assertion (F2/F3): the node tagged [tag] must lie fully inside
+     * [root] AND fully above [keyboardTopPx], both in [root]'s coordinate space.
+     *
+     * This is deliberately NOT `assertIsDisplayed()`: a control shoved under the
+     * keyboard still reports "displayed".
+     *
+     * Read it in the keyboard-UP state: that is the state whose boundary this is.
+     */
+    fun assertFullyAboveKeyboard(tag: String, root: SemanticsNode, keyboardTopPx: Float) =
+        assertFullyAboveBoundary(
+            tag = tag,
+            root = root,
+            boundaryTopPx = keyboardTopPx,
+            boundaryName = "keyboard",
+        )
+
+    /**
+     * The keyboard-DOWN sibling of [assertFullyAboveKeyboard]: the node tagged
+     * [tag] must stay fully above the top edge of the synthetic navigation bar.
+     *
+     * This exists because the keyboard-up assertion **structurally cannot see**
+     * a missing `navigationBarsPadding()`. With the keyboard up the ime inset
+     * (295 dp) already subsumes the nav bar (48 dp), so dropping the nav padding
+     * only *increases* the measured lift and every keyboard-up assertion stays
+     * green while the bottom control sits 126 px under the nav bar. That exact
+     * hole was found by the #1821 reviewer, who removed `navigationBarsPadding()`
+     * from a kept site and got 15/15 green. Only the keyboard-down state, where
+     * the ime inset is zero, exposes it.
+     *
+     * Call it while the keyboard-DOWN inset set is the one currently dispatched.
+     */
+    fun assertFullyAboveNavigationBar(tag: String, root: SemanticsNode, navBarTopPx: Float) =
+        assertFullyAboveBoundary(
+            tag = tag,
+            root = root,
+            boundaryTopPx = navBarTopPx,
+            boundaryName = "navigation bar",
+        )
+
+    private fun assertFullyAboveBoundary(
+        tag: String,
+        root: SemanticsNode,
+        boundaryTopPx: Float,
+        boundaryName: String,
+    ) {
+        val node = compose.onNodeWithTag(tag, useUnmergedTree = true).fetchSemanticsNode()
+        val bounds = node.boundsInRoot
+        val rootBounds = root.boundsInRoot
+        val slop = CONTAINMENT_SLOP_DP * density
+        assertTrue(
+            "Node '$tag' must belong to the same Compose coordinate root as the " +
+                "root it is judged against.",
+            node.root === root.root,
+        )
+        assertTrue(
+            "Node '$tag' must have nonzero geometry. bounds=$bounds",
+            bounds.width > 0f && bounds.height > 0f,
+        )
+        assertTrue(
+            "Node '$tag' must be fully contained in its owning root. " +
+                "node=$bounds root=$rootBounds",
+            bounds.left >= rootBounds.left - slop &&
+                bounds.top >= rootBounds.top - slop &&
+                bounds.right <= rootBounds.right + slop &&
+                bounds.bottom <= rootBounds.bottom + slop,
+        )
+        assertTrue(
+            "Node '$tag' must stay fully ABOVE the $boundaryName boundary. " +
+                "node=$bounds ${boundaryName.replace(' ', '_')}TopPx=$boundaryTopPx " +
+                "root=$rootBounds",
+            bounds.bottom <= boundaryTopPx + slop,
+        )
+    }
+
+    fun activeAppWindowRoots(activity: ComponentActivity): List<View> =
+        WindowInspector.getGlobalWindowViews()
+            .asSequence()
+            .map { it.rootView }
+            .distinctBy { System.identityHashCode(it) }
+            .filter { root ->
+                root.isAttachedToWindow &&
+                    root.context.applicationContext.packageName ==
+                    activity.applicationContext.packageName
+            }
+            .toList()
+
+    private fun assertNoPhysicalImeWindow(message: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val deadline = SystemClock.elapsedRealtime() + PHYSICAL_IME_ABSENCE_STABILITY_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            instrumentation.waitForIdleSync()
+            val windows = visiblePhysicalImeWindows()
+            assertTrue("$message visibleImeWindows=$windows", windows.isEmpty())
+            SystemClock.sleep(50)
+        }
+    }
+
+    private fun waitForWallClock(timeoutMs: Long, predicate: () -> Boolean): Boolean {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            instrumentation.waitForIdleSync()
+            if (predicate()) return true
+            SystemClock.sleep(50)
+        }
+        return predicate()
+    }
+
+    private fun readAnyAppRootImeVisible(): Boolean {
+        var visible = false
+        scenario.onActivity { activity ->
+            visible = activeAppWindowRoots(activity).any { root ->
+                val insets = ViewCompat.getRootWindowInsets(root)
+                insets?.isVisible(WindowInsetsCompat.Type.ime()) == true &&
+                    insets.getInsets(WindowInsetsCompat.Type.ime()).bottom > 0
+            }
+        }
+        return visible
+    }
+
+    /**
+     * Accessibility exposes the physical IME as a distinct
+     * [AccessibilityWindowInfo.TYPE_INPUT_METHOD] window. That signal is
+     * independent of the synthetic [WindowInsetsCompat] object dispatched to the
+     * app roots, so it can catch a green synthetic boundary drawn while a real
+     * keyboard is still covering the surface.
+     *
+     * (Mechanism, not a measured claim: the independence is structural — this
+     * reads `uiAutomation.windows`, which the dispatched `WindowInsetsCompat`
+     * cannot influence — but no #1821 run has observed a non-empty result,
+     * because no test here raises the real keyboard.)
+     */
+    private fun visiblePhysicalImeWindows(): List<String> =
+        InstrumentationRegistry.getInstrumentation()
+            .uiAutomation
+            .let { automation ->
+                val serviceInfo = automation.serviceInfo
+                if (
+                    serviceInfo.flags and
+                    AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS == 0
+                ) {
+                    serviceInfo.flags =
+                        serviceInfo.flags or
+                        AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
+                    automation.serviceInfo = serviceInfo
+                }
+                automation.windows
+                    .filter { it.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD }
+                    .map { window ->
+                        "active=${window.isActive} focused=${window.isFocused} bounds=" +
+                            "${android.graphics.Rect().also(window::getBoundsInScreen)}"
+                    }
+            }
+
+    private fun displayDensity(): Float =
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext.resources.displayMetrics.density
+
+    companion object {
+        const val SYNTHETIC_IME_HEIGHT_DP = 295f
+        const val SYNTHETIC_STATUS_BAR_HEIGHT_DP = 52f
+
+        /**
+         * A deliberately NONZERO gesture-nav bar, so `navigationBarsPadding()`
+         * has bite in the same measurement (see [dispatch]).
+         */
+        const val SYNTHETIC_NAV_BAR_HEIGHT_DP = 48f
+        const val CONTAINMENT_SLOP_DP = 2f
+        const val INSET_DISPATCH_REPEATS = 2
+        const val REAL_IME_TIMEOUT_MS = 30_000L
+        const val PHYSICAL_IME_ABSENCE_STABILITY_MS = 300L
+        const val LAYOUT_STABLE_WINDOW_MS = 250L
+
+        /**
+         * Generous "this is hung, not slow" ceiling. A CI swiftshader emulator
+         * can stretch a sheet slide-in plus an inset relayout well past a
+         * healthy device's ~500 ms.
+         */
+        const val LAYOUT_STABLE_TIMEOUT_MS = 10_000L
+
+        /**
+         * A bottom-anchored surface must move up by essentially the whole
+         * keyboard. Half the inset is a generous floor that is still zero for
+         * any layout that ignores the inset entirely.
+         */
+        const val MINIMUM_LIFT_FRACTION = 0.5f
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/cards/SessionChecklistUi.kt
+++ b/app/src/main/java/com/pocketshell/app/cards/SessionChecklistUi.kt
@@ -165,6 +165,20 @@ internal fun SessionCardFeedContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            // Issue #1821 — LOAD-BEARING, do not delete by analogy with #1812.
+            // Inside [SessionCardFeedSheet]'s `ModalBottomSheet` these two are
+            // redundant (Material3 consumes both insets before the content is
+            // composed — measured byte-identical geometry with and without).
+            // But this content is ALSO composed STANDALONE, outside any sheet
+            // (`SessionCardFeedRegistryTest`), and there nothing has consumed
+            // them, so they are the only thing keeping the last card clear of
+            // the keyboard and the nav bar.
+            // `StandaloneContentImePaddingLivenessTest` goes RED if EITHER is
+            // removed, and it takes BOTH keyboard states to see that: dropping
+            // `imePadding()` collapses the keyboard-UP lift 648px -> 0px;
+            // dropping `navigationBarsPadding()` drops the last card 126px
+            // under the nav bar in the keyboard-DOWN state (invisible with the
+            // keyboard up, where the ime inset subsumes the nav bar).
             .navigationBarsPadding()
             .imePadding()
             .padding(horizontal = PocketShellSpacing.lg)
@@ -212,6 +226,19 @@ internal fun ChecklistCardsContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            // Issue #1821 — LOAD-BEARING, do not delete by analogy with #1812.
+            // This composable has NO production caller at all: it is composed
+            // only STANDALONE, from `SessionChecklistUiInteractionTest` and the
+            // gate-wired `SessionChecklistPushJourneyDockerTest`. Outside a
+            // `ModalBottomSheet` nothing has consumed these insets, so they are
+            // the only thing keeping the last item clear of the keyboard and the
+            // nav bar. `StandaloneContentImePaddingLivenessTest` goes RED if
+            // EITHER is removed, and it takes BOTH keyboard states to see that:
+            // dropping `imePadding()` collapses the keyboard-UP lift
+            // 648px -> 0px; dropping `navigationBarsPadding()` drops the last
+            // item 126px under the nav bar in the keyboard-DOWN state
+            // (invisible with the keyboard up, where the ime inset subsumes the
+            // nav bar).
             .navigationBarsPadding()
             .imePadding()
             .padding(horizontal = PocketShellSpacing.lg)

--- a/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerReviewUi.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerReviewUi.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -170,9 +169,24 @@ private fun CommentableLineRow(
 
 /**
  * Renders whichever review sheet is open (issue #714). Split out so the scaffold
- * stays readable; each sheet is a `ModalBottomSheet` that floats above the soft
- * keyboard (`imePadding` + `navigationBarsPadding`) so the input is reachable
- * with the keyboard up (#641/#567 IME-occlusion rigor).
+ * stays readable; each sheet is a `ModalBottomSheet`, which floats its own
+ * content above the soft keyboard so the input is reachable with the keyboard up
+ * (#641/#567 IME-occlusion rigor).
+ *
+ * Issue #1821: that lift comes from Material3 itself — `ModalBottomSheet` wraps
+ * its window content in `Box(Modifier.fillMaxSize().imePadding())` and CONSUMES
+ * the inset — not from a content-level `imePadding()`. This KDoc used to credit
+ * one, and the sheets below used to carry one; measured on-device it changed
+ * nothing (byte-identical geometry with and without, four sheets), so it was
+ * deleted. Do NOT re-add an ime modifier to a sheet content column here: it
+ * resolves to zero today, and it would MASK a real regression tomorrow. The
+ * load-bearing assertion in `NestedImePaddingInSheetGeometryTest` is that the
+ * sheet lifts its bottom control by essentially the whole keyboard; a
+ * content-level `imePadding()` on a bottom-anchored column can supply that lift
+ * by itself, so it would keep the assertion green even if a Material3 upgrade
+ * stopped consuming the inset. With it gone, only Material can supply the lift,
+ * so that regression has to show up as a red test. (Mechanism, not a measured
+ * claim — nobody has run a Material3 that behaves that way.)
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -264,7 +278,6 @@ private fun CommentSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .imePadding()
                 .padding(horizontal = PocketShellSpacing.lg)
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(testTag),
@@ -368,7 +381,6 @@ private fun PendingTraySheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .imePadding()
                 .padding(horizontal = PocketShellSpacing.lg)
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(FILE_VIEWER_REVIEW_TRAY_SHEET_TAG),
@@ -468,7 +480,6 @@ internal fun ReviewSubmittedSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .imePadding()
                 .padding(horizontal = PocketShellSpacing.lg)
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(FILE_VIEWER_REVIEW_SAVED_SHEET_TAG),
@@ -571,7 +582,6 @@ internal fun AnnotationSavedSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .imePadding()
                 .padding(horizontal = PocketShellSpacing.lg)
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(FILE_VIEWER_ANNOTATE_SAVED_SHEET_TAG),

--- a/app/src/main/java/com/pocketshell/app/git/GitHistoryScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/git/GitHistoryScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -995,7 +994,6 @@ private fun CreateIssueSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .navigationBarsPadding()
-                .imePadding()
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = PocketShellSpacing.lg, vertical = PocketShellSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),

--- a/app/src/main/java/com/pocketshell/app/projects/FolderContextActionSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderContextActionSheet.kt
@@ -87,6 +87,20 @@ internal fun FolderContextActionContent(
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            // Issue #1821 — LOAD-BEARING, do not delete by analogy with #1812.
+            // Inside [FolderContextActionSheet]'s `ModalBottomSheet` these two
+            // are redundant (Material3 consumes both insets before the content
+            // is composed — measured byte-identical geometry with and without).
+            // But this content is ALSO composed STANDALONE, in a plain `Box`
+            // (`FolderContextActionSheetScreenshotTest:39`), and there nothing
+            // has consumed them, so they are the only thing keeping the bottom
+            // "New empty project" row clear of the keyboard and the nav bar.
+            // `StandaloneContentImePaddingLivenessTest` goes RED if EITHER is
+            // removed, and it takes BOTH keyboard states to see that: dropping
+            // `imePadding()` collapses the keyboard-UP lift 648px -> 0px;
+            // dropping `navigationBarsPadding()` drops that row 126px under the
+            // nav bar in the keyboard-DOWN state (invisible with the keyboard
+            // up, where the ime inset subsumes the nav bar).
             .navigationBarsPadding()
             .imePadding()
             .padding(horizontal = PocketShellSpacing.lg, vertical = PocketShellSpacing.lg),

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -203,6 +203,22 @@ internal fun SessionTypePickerContent(
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            // Issue #1821 — LOAD-BEARING, do not delete by analogy with #1812.
+            // Inside [SessionTypePickerSheet]'s `ModalBottomSheet` these two are
+            // redundant (Material3 consumes both insets before the content is
+            // composed — measured byte-identical geometry with and without).
+            // But this content is ALSO composed STANDALONE by four sibling
+            // tests (`SessionTypePickerNameFieldUiTest`,
+            // `SessionTypePickerSkipPermissionsUiTest`,
+            // `SessionTypeProfilePickerUiTest`, `RepoBrowserSessionPickerTest`),
+            // and there nothing has consumed them, so they are the only thing
+            // keeping the Cancel/Create row clear of the keyboard and the nav
+            // bar. `StandaloneContentImePaddingLivenessTest` goes RED if EITHER
+            // is removed, and it takes BOTH keyboard states to see that:
+            // dropping `imePadding()` collapses the keyboard-UP lift
+            // 648px -> 0px; dropping `navigationBarsPadding()` drops that row
+            // 126px under the nav bar in the keyboard-DOWN state (invisible
+            // with the keyboard up, where the ime inset subsumes the nav bar).
             .navigationBarsPadding()
             .imePadding()
             .fillMaxHeight(SESSION_TYPE_PICKER_HEIGHT_FRACTION)

--- a/app/src/main/java/com/pocketshell/app/snippets/SnippetPickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/snippets/SnippetPickerSheet.kt
@@ -216,14 +216,30 @@ internal fun SnippetPickerContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            // Issue #253: consume the bottom system insets inside the sheet
-            // content so the lower snippet rows (the explicit Send / Send + ↵
-            // chips) are never drawn under the system navigation bar or the
-            // IME / terminal key-bar region. Without this the sheet content
-            // ran to the very bottom edge and the bottom-most chips rendered
-            // *behind* the bottom controls. `navigationBarsPadding` covers the
-            // gesture / 3-button nav bar; `imePadding` lifts the whole sheet
-            // above the soft keyboard when it is raised.
+            // Issue #253: consume the bottom system insets inside this content
+            // so the lower snippet rows (the explicit Send / Send + ↵ chips) are
+            // never drawn under the system navigation bar or the IME / terminal
+            // key-bar region. Without this the content ran to the very bottom
+            // edge and the bottom-most chips rendered *behind* the bottom
+            // controls. `navigationBarsPadding` covers the gesture / 3-button
+            // nav bar; `imePadding` lifts the content above the soft keyboard.
+            //
+            // Issue #1821 — LOAD-BEARING, do not delete by analogy with #1812.
+            // Inside [SnippetPickerSheet]'s `ModalBottomSheet` these two are
+            // redundant (Material3 consumes both insets before the content is
+            // composed — measured byte-identical geometry with and without), so
+            // in production it is Material, not this line, that delivers #253.
+            // But this content is ALSO composed STANDALONE
+            // (`SnippetPickerSendButtonsTest`, `SnippetPickerBodyPreviewTest`),
+            // and there nothing has consumed them, so they are the only thing
+            // keeping the send chips clear of the keyboard and the nav bar.
+            // `StandaloneContentImePaddingLivenessTest` goes RED if EITHER is
+            // removed, and it takes BOTH keyboard states to see that: dropping
+            // `imePadding()` collapses the keyboard-UP lift 648px -> 0px;
+            // dropping `navigationBarsPadding()` drops the send chips 126px
+            // under the nav bar in the keyboard-DOWN state (invisible with the
+            // keyboard up, where the ime inset subsumes the nav bar) — which is
+            // the #253 symptom above, so that modifier is not decorative here.
             .navigationBarsPadding()
             .imePadding()
             .padding(horizontal = PocketShellSpacing.lg)


### PR DESCRIPTION
Closes #1821

Implements the approved per-site IME-padding sweep and its gate-wired geometry/liveness proofs. Reviewer approval and emulator evidence: https://github.com/alexeygrigorev/pocketshell/issues/1821#issuecomment-5117231299