### PR TITLE
connection: revive probes after cancelled attach (#1863)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -68,7 +68,13 @@ import com.pocketshell.app.tmux.connection.selectBackgroundArm
 import com.pocketshell.app.tmux.connection.ConnectionManager
 import com.pocketshell.app.tmux.connection.ConnectionEffectDriver
 import com.pocketshell.app.tmux.connection.ConnectionStatusProjection
+import com.pocketshell.app.tmux.connection.controlChannelAliveForReveal
 import com.pocketshell.app.tmux.connection.CurrentClientTmuxPort
+import com.pocketshell.app.tmux.connection.keepAliveProvenAliveRecently
+import com.pocketshell.app.tmux.connection.LivenessProbeGate
+import com.pocketshell.app.tmux.connection.livenessProbeIo
+import com.pocketshell.app.tmux.connection.requireControlChannelAliveForReveal
+import com.pocketshell.app.tmux.connection.selectLivenessProbeGate
 import com.pocketshell.app.tmux.connection.ForegroundReturnEffects
 import com.pocketshell.app.tmux.connection.debounceReconnectUi
 import com.pocketshell.app.tmux.connection.GraceEffects
@@ -1049,17 +1055,12 @@ public class TmuxSessionViewModel @Inject constructor(
         if (livenessProbe != null) return
         if (!LivenessProbeTestOverride.autoStartEnabled) return
         val probe = LivenessProbe(
-            io = object : LivenessProbe.ProbeIo {
-                override fun shouldProbe(): Boolean = shouldRunLivenessProbe()
-
-                override suspend fun probe(): Boolean = runLivenessProbePing()
-
-                override fun onProbeFailed(consecutiveFailures: Int) =
-                    onLivenessProbeDeclaredDrop(consecutiveFailures)
-
-                override fun transportProvenAliveRecently(): Boolean =
-                    isTransportKeepAliveProvenAliveRecently()
-            },
+            io = livenessProbeIo(
+                gate = ::livenessProbeGate,
+                ping = { runLivenessProbePing() },
+                onDrop = ::onLivenessProbeDeclaredDrop,
+                keepAliveProvenAlive = ::isTransportKeepAliveProvenAliveRecently,
+            ),
             intervalMs = LivenessProbeTestOverride.intervalMs(),
             perProbeTimeoutMs = LivenessProbeTestOverride.perProbeTimeoutMs(),
             failureThreshold = LivenessProbeTestOverride.failureThreshold(),
@@ -1069,29 +1070,30 @@ public class TmuxSessionViewModel @Inject constructor(
         probe.start(viewModelScope)
     }
 
-    /**
-     * The probe gate (no-false-positive guard 1): probe ONLY when the session is
-     * genuinely FOREGROUNDED + `Live` on the CURRENT, non-disconnected control
-     * client. A backgrounded app, an in-grace detach, an in-flight
-     * attach/reconnect (controller not `Live`), or no client all return false, so
-     * the probe never competes with a reconnect, never trips while backgrounded,
-     * and never fights the single grace owner.
-     */
-    private fun shouldRunLivenessProbe(): Boolean {
+    /** The probe gate — the pure decision + why each term exists lives in [selectLivenessProbeGate]. */
+    private fun livenessProbeGate(): LivenessProbeGate {
         val bg = isProcessBackgroundedForGraceOwner()
         val hasClient = clientRef != null
         val disconnected = clientRef?.disconnected?.value ?: true
         val ctrl = connectionManager.state
-        val open = !bg && appActive && hasClient && !disconnected && ctrl is CoreConnectionState.Live
-        if (!open) {
+        val gate = selectLivenessProbeGate(
+            backgrounded = bg,
+            appActive = appActive,
+            hasClient = hasClient,
+            controlChannelDisconnected = disconnected,
+            controllerLive = ctrl is CoreConnectionState.Live,
+        )
+        if (gate == LivenessProbeGate.Closed) {
             Log.i(
                 LIVENESS_PROBE_TAG,
                 "gate closed bg=$bg appActive=$appActive hasClient=$hasClient " +
                     "disconnected=$disconnected ctrl=${ctrl::class.simpleName}",
             )
         }
-        return open
+        return gate
     }
+
+    private fun shouldRunLivenessProbe(): Boolean = livenessProbeGate() != LivenessProbeGate.Closed
 
     /**
      * One liveness ping over the warm control channel. Best-effort + non-fatal:
@@ -1119,40 +1121,18 @@ public class TmuxSessionViewModel @Inject constructor(
         return runCatching { client.probeLiveness(requireAnsweredRoundTrip) }.getOrDefault(false)
     }
 
-    /**
-     * Issue #964 — the keepalive-coordination guard the [LivenessProbe] consults
-     * before declaring a drop. Reports whether the always-on transport keepalive
-     * ([com.pocketshell.core.ssh.TransportKeepAlive], #945) has seen inbound
-     * transport activity within its ride-through window — i.e. the LINK is provably
-     * alive even though the tmux control-channel probe is momentarily failing. When
-     * true the probe DEFERS rather than force-redialing, so a slow-but-live link is
-     * ridden through by the single keepalive budget instead of two competing ones.
-     *
-     * Reads the live [sessionRef] (the transport the warm lease holds). No session
-     * → no keepalive signal → false, so the probe keeps its own authority exactly
-     * as before whenever there is no live transport to defer to.
-     */
-    private fun isTransportKeepAliveProvenAliveRecently(): Boolean {
-        // Test seam: a connected/unit proof can pin the keepalive "alive" state
-        // (a live-but-slow link) without driving the real 90s ride-through window.
-        // An EXPLICIT pin always wins (the #964 slow-but-live phase deliberately
-        // sets it true WHILE the `-CC` dead-seam is armed).
-        forceTransportProvenAliveForTest?.let { return it }
-        // Issue #866 / #822: the synthetic SILENT-drop seam ([forceLivenessProbeDeadForTest])
-        // models a genuine half-open link death — the dominant real #822 where BOTH the
-        // tmux `-CC` channel AND the SSH transport keepalive die together. Without this,
-        // arming only the `-CC` dead-seam on a healthy `agents:2222` fixture left the REAL
-        // keepalive "proven alive", so the #982/#984 deferral suppressed the drop forever
-        // and the connection-lost indicator never surfaced (the #822 detection contract
-        // regressed to a no-op on the deterministic fixture). When the `-CC` dead-seam is
-        // armed and no EXPLICIT keepalive verdict is pinned, the transport is NOT proven
-        // alive either — a silent drop is a WHOLE-link death. Production-neutral: the seam
-        // is test-only (always false in production), so this never changes real behaviour.
-        if (forceLivenessProbeDeadForTest) return false
-        val session = sessionRef ?: return false
-        return runCatching { session.isTransportProvenAliveWithinKeepAliveWindow() }
-            .getOrDefault(false)
-    }
+    /** Issue #964 keepalive-coordination guard — rationale + seam order in [keepAliveProvenAliveRecently]. */
+    private fun isTransportKeepAliveProvenAliveRecently(): Boolean =
+        keepAliveProvenAliveRecently(
+            pinnedVerdict = forceTransportProvenAliveForTest,
+            syntheticChannelDeathArmed = forceLivenessProbeDeadForTest,
+            transportKeepAliveAlive = {
+                sessionRef?.let { session ->
+                    runCatching { session.isTransportProvenAliveWithinKeepAliveWindow() }
+                        .getOrDefault(false)
+                } == true
+            },
+        )
 
     /**
      * Issue #1568 (P0-2): vouch the SSH transport alive (connected + async-close not initiated;
@@ -5603,6 +5583,15 @@ public class TmuxSessionViewModel @Inject constructor(
         target: ConnectionTarget,
         cause: String,
     ) {
+        // Issue #1863 (G2): the ride-through re-asserts Live on the SURVIVING client. If that
+        // client is already CLOSED there is nothing to ride through, and clearing the band
+        // would republish the dead-wire lie the connect paths are guarded against. Bail before
+        // touching any state: the band stays up and `lifecycleReattachNetworkCoalesce` is left
+        // intact (no redial happened, so its coalescing window still stands). Recovery stays
+        // with whoever is ALREADY armed — the auto-reconnect ladder when the controller is off
+        // Live, otherwise the probe's DeadChannel arm within one interval. Nothing new is
+        // scheduled here (D28: no second writer).
+        clientRef?.let { if (!controlChannelAliveForReveal(it)) return }
         val reason = change.reason
         lifecycleReattachNetworkCoalesce = null
         Log.i(
@@ -6492,6 +6481,10 @@ public class TmuxSessionViewModel @Inject constructor(
             // keep the calm "Attaching…" hold and hand off to
             // [armConnectedBlankWatchdog].
             val activePaneSeeded = awaitActivePaneSeededOrLoading(blankReseedGuard)
+            // Issue #1863: never declare a wire live that died while this attach was
+            // in flight — the throw routes into the catch below as a stale-channel
+            // symptom (single ladder), instead of publishing `ready` over a corpse.
+            requireControlChannelAliveForReveal(client, target.sessionName, "connect")
             // EPIC #687 P1: when the active pane is seeded non-blank, the inline path
             // reveals the target's surface — promote the reveal machine to Live for
             // the target so the NEW-path reveal gate releases in lockstep.
@@ -7040,6 +7033,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 client = client,
             )
             val activePaneSeeded = awaitActivePaneSeededOrLoading(fastSwitchRevealGuard)
+            // Issue #1863: same guard on the warm entry point (G2) — the fast-switch
+            // catch below already routes a stale-channel symptom into the single ladder.
+            requireControlChannelAliveForReveal(client, target.sessionName, "fast switch")
             // EPIC #687 P1: the fast-switch reveal shows the target's seeded pane —
             // promote the reveal machine to Live for the target so the NEW-path reveal
             // gate releases in the same mutation (never holds on a warm switch).
@@ -8355,6 +8351,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 return false
             }
             reseedVisiblePanesForPassiveReattach(target, replacement, budgets)
+            requireControlChannelAliveForReveal(replacement, target.sessionName, "silent reattach") // #1863 G2
             clientRegistration = activeTmuxClients.register(
                 hostId = target.hostId,
                 hostName = target.hostName,
@@ -8589,6 +8586,7 @@ public class TmuxSessionViewModel @Inject constructor(
             }
             val newClient = replacement ?: return false
             reseedVisiblePanesForPassiveReattach(target, newClient, budgets)
+            requireControlChannelAliveForReveal(newClient, target.sessionName, "transport reconnect") // #1863 G2
             clientRegistration = activeTmuxClients.register(
                 hostId = target.hostId,
                 hostName = target.hostName,

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ControlChannelRevealGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ControlChannelRevealGuard.kt
@@ -1,0 +1,87 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxClientException
+
+/**
+ * Issue #1863 — the reveal-time control-channel liveness guard.
+ *
+ * An attach that resolves is not the same as an attach that resolved over a LIVE
+ * wire. The reported ordering:
+ *
+ * ```
+ * 34.529  tmux-command-write-failed cause=JobCancellationException
+ * 34.540  tmux-refresh-client-size-error ... TmuxClientException: client is closed
+ * 34.571  app-navigator-current destination=FolderList          <- the back-press
+ * 34.957  tmux-connect-ready attempt=1                          <- over the corpse
+ * ```
+ *
+ * The connect coroutine was NOT cancelled — a different, screen-scoped caller was
+ * — so it walked to the end of its happy path and published `tmux-connect-ready`
+ * + `ConnectionState.Live` over a client whose `disconnected` latch was already
+ * set. Downstream that reads as a healthy session: the next open of the same
+ * identity is deduped as a no-op (`inlineConnectionStatus is Connected &&
+ * activeTarget == target`, which is why `tmux-connect-attempt` stayed at 1), and
+ * the liveness gate was closed by the very `disconnected` flag it should have
+ * been reacting to.
+ *
+ * The rule: a connect/attach/reattach may only declare the wire live if the wire
+ * is still there at the moment it declares it. [requireControlChannelAliveForReveal]
+ * runs on four of the five production paths that publish `Live` after an attach — the
+ * two cold/warm connect paths immediately before the reveal, and the two
+ * passive-recovery rungs before the host registration + lifecycle-hook install, so a
+ * dead replacement leaves no registration applied (the same exit shape as those rungs'
+ * `!ready` arms; the throw lands in their existing catch, which restores the stale
+ * client, closes the replacement and advances the ladder). The network ride-through
+ * uses the non-throwing [controlChannelAliveForReveal] instead, because it reports
+ * through an early return rather than an exception.
+ *
+ * The fifth publisher, `restoreCachedRuntime`, is deliberately NOT guarded here and it
+ * is not an oversight: `takeCachedRuntimeForActivation` already checks
+ * `cached.client.disconnected.value` and `tryActivateCachedRuntime` re-checks
+ * `cachedRuntimeControlChannelHealthy`, and every function between those checks and the
+ * reveal is non-`suspend`, so there is no in-flight window for the channel to die in.
+ * Adding a second check there would be a duplicate authority, not extra safety.
+ *
+ * ## What this guard structurally CANNOT do
+ *
+ * It is a POINT-IN-TIME check. It closes the reported window — the channel died
+ * BEFORE the reveal decision (in the report, ~0.4s before `tmux-connect-ready`) —
+ * and nothing more. A channel that dies strictly AFTER the check and before the user
+ * notices is not, and cannot be, caught here: there is no suspension-free way to make
+ * "still alive" hold across the reveal. That half of the class is owned by the
+ * liveness probe's `DeadChannel` arm
+ * ([com.pocketshell.app.tmux.connection.LivenessProbeGate.DeadChannel]), which bounds
+ * it at one probe interval. Both halves are pinned by
+ * `Issue1863DeadWireAfterCancelledConnectTest` — the guard half by the two
+ * gate-parked connect/fast-switch tests, the probe half by
+ * `deadWireAfterTheRevealGuardIsDeclaredByTheProbeWithinOneInterval`. Neither is
+ * sufficient alone.
+ *
+ * The failure is raised as a [TmuxClientException] whose message carries
+ * `control channel closed`, so
+ * [com.pocketshell.app.tmux.TmuxSessionFailureClassifiers.isStaleChannelSymptom]
+ * already classifies it: the cold path routes it through `failConnectAttempt`
+ * (poisoned lease evicted, single auto-reconnect ladder, actionable band) and the
+ * fast-switch path through its existing stale-channel re-dial arm. No new
+ * recovery writer is introduced (D28).
+ */
+fun controlChannelClosedBeforeReveal(session: String, stage: String): TmuxClientException =
+    TmuxClientException(
+        "control channel closed before the $stage could reveal session `$session` as live",
+    )
+
+/**
+ * Throws [controlChannelClosedBeforeReveal] when [client] is already
+ * disconnected. Call immediately before publishing `Live` for [session].
+ */
+fun requireControlChannelAliveForReveal(client: TmuxClient, session: String, stage: String) {
+    if (client.disconnected.value) throw controlChannelClosedBeforeReveal(session, stage)
+}
+
+/**
+ * Non-throwing sibling for the recovery paths that report success/failure with a
+ * `Boolean` rather than an exception (the passive silent-reattach rungs). Returns
+ * true when [client] is still usable for a reveal.
+ */
+fun controlChannelAliveForReveal(client: TmuxClient): Boolean = !client.disconnected.value

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/LivenessProbeGate.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/LivenessProbeGate.kt
@@ -1,0 +1,154 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.LivenessProbe
+
+/**
+ * Issue #1863 — the liveness-probe gate, extracted out of `TmuxSessionViewModel`
+ * as a PURE decision (the #1047 ratchet direction: decisions leave the
+ * connection-core god-object, they do not accumulate inside it).
+ *
+ * ## What the old gate was — and what its `!disconnected` term protected
+ *
+ * The probe gate arrived with the probe itself (EPIC #792 Slice D, the #822
+ * silent-drop fix) as "no-false-positive guard 1": probe ONLY when the session is
+ * genuinely FOREGROUNDED + `Live` on the CURRENT, non-disconnected control client.
+ * Each term earns its place:
+ *
+ *  - `!backgrounded` — D21 (no background work) and the #635 single-grace-owner
+ *    rule: a within-grace detach is owned by the App-level grace window, never by
+ *    the probe.
+ *  - `appActive` — the same, for the explicit-leave path.
+ *  - `hasClient` — nothing to ping.
+ *  - `controllerLive` — an in-flight attach / reconnect owns the channel; probing
+ *    there would race the single reconnect ladder (D28: never a second writer).
+ *  - `!controlChannelDisconnected` — the term #1863 is about. It covered TWO
+ *    different states that happen to share one predicate:
+ *      (a) the TRANSIENT window between `TmuxClient.disconnected` flipping true and
+ *          the effect driver moving the controller off `Live` (the driver's own
+ *          `disconnected` collection latency, called out at the probe's construction
+ *          site). This occurs on EVERY genuine passive drop. Here a probe is
+ *          guaranteed to fail, and the driver is about to declare the drop anyway.
+ *      (b) the TERMINAL state where the driver will NEVER move the controller —
+ *          because the close was self-inflicted and the passive-drop classifier
+ *          deliberately ignores it (#1568/#1610), or any other path that leaves
+ *          `controllerLive && controlChannelDisconnected` standing. The app believes
+ *          it holds a live wire over a closed one, no re-dial ever happens, and the
+ *          ONE mechanism that exists to notice a dead wire is switched off by the
+ *          wire being dead. That is the "green dot, black pane, nothing happens"
+ *          class (#822/#823) the maintainer's standing direction — detect drops and
+ *          SHOW them — exists to end.
+ *
+ * The predicate cannot tell (a) from (b) — that is exactly why the bug was
+ * unrecoverable — so the split is deliberately made on the observable state, and
+ * BOTH now return [DeadChannel].
+ *
+ * **What this costs, stated honestly.** In case (a) the behaviour changes from
+ * "never act" to "act on this tick, with the N-consecutive threshold, the #982/#984
+ * keepalive deferral and the 180s wedge backstop all bypassed". That is a real
+ * change, not a preserved protection. It is judged acceptable — not free — because
+ * the window is ONE Main-dispatch hop against a 7s probe cadence, and every WIDE
+ * version of it is closed by a different term: the connect path submits
+ * `submitControllerOpen` / `submitControllerSwitch` BEFORE `closeCurrentConnection
+ * AndJoin`, so the controller is off `Live` for the whole `detachCleanly` teardown;
+ * leave clears `appActive`; background sets `bg`. And if the probe does declare
+ * inside that hop, `shouldSuppressTransportDropsForSingleGraceOwner()` suppresses
+ * the driver's duplicate, so the worst case is the heavier reconnect ladder instead
+ * of the calm within-grace silent reattach — never two writers (D28). Narrowing the
+ * arm to "self-inflicted closes only" was considered and rejected: the same
+ * dead-wire signature has been observed from more entry paths than the one #1863
+ * reported, so a narrow predicate would leave the bug reachable.
+ *
+ * The probe still never competes with a reconnect (that is `controllerLive`), never
+ * runs backgrounded, and never fights the grace owner — but it can finally observe
+ * the condition it exists to detect.
+ */
+enum class LivenessProbeGate {
+    /**
+     * Not probing. Backgrounded / not app-active / no client / the controller is
+     * not `Live` (an attach, reconnect or grace window owns the channel).
+     */
+    Closed,
+
+    /**
+     * The controller says `Live` and the current control client is provably
+     * CLOSED. Usually that is the terminal #1863 state, where nothing else is
+     * going to say so; it is ALSO briefly true on a normal passive drop before
+     * the driver collects `disconnected` (see the class KDoc — the two are not
+     * distinguishable from here, by design). Either way the wire is dead: the
+     * probe runs, fails immediately, and — because a closed channel is not the
+     * AMBIGUOUS signal the N-consecutive / keepalive-deferral machinery exists to
+     * disambiguate — declares the drop on that tick. The duplicate-declaration
+     * risk in the transient case is bounded by
+     * `shouldSuppressTransportDropsForSingleGraceOwner()`, not by this gate.
+     */
+    DeadChannel,
+
+    /** The normal case: foregrounded, `Live`, on a control client believed alive. */
+    Probe,
+}
+
+/**
+ * The pure gate selector. Term order is deliberate: every "we must not probe at
+ * all" reason is evaluated BEFORE the dead-channel split, so [DeadChannel] can
+ * only be reached in the foregrounded + controller-`Live` state.
+ */
+fun selectLivenessProbeGate(
+    backgrounded: Boolean,
+    appActive: Boolean,
+    hasClient: Boolean,
+    controlChannelDisconnected: Boolean,
+    controllerLive: Boolean,
+): LivenessProbeGate = when {
+    backgrounded || !appActive || !hasClient || !controllerLive -> LivenessProbeGate.Closed
+    controlChannelDisconnected -> LivenessProbeGate.DeadChannel
+    else -> LivenessProbeGate.Probe
+}
+
+/**
+ * Issue #964 — the keepalive-coordination guard the [LivenessProbe] consults before
+ * declaring a drop. Reports whether the always-on transport keepalive
+ * ([com.pocketshell.core.ssh.TransportKeepAlive], #945) has seen inbound transport
+ * activity within its ride-through window — i.e. the LINK is provably alive even
+ * though the tmux control-channel probe is momentarily failing. When true the probe
+ * DEFERS rather than force-redialing, so a slow-but-live link is ridden through by
+ * the single keepalive budget instead of two competing ones.
+ *
+ * Seam order is load-bearing:
+ *  - [pinnedVerdict] (the #964 test seam) ALWAYS wins — the slow-but-live phase
+ *    deliberately pins it true WHILE the `-CC` dead-seam is armed.
+ *  - [syntheticChannelDeathArmed] (the #866/#822 synthetic silent-drop seam) models a
+ *    genuine half-open link death — the dominant real #822 where BOTH the tmux `-CC`
+ *    channel and the SSH transport keepalive die together. Without it, arming only the
+ *    `-CC` dead-seam on a healthy `agents:2222` fixture left the REAL keepalive
+ *    "proven alive", so the #982/#984 deferral suppressed the drop forever and the
+ *    connection-lost indicator never surfaced. Production-neutral (test-only seam).
+ *  - Otherwise the live transport answers. No session → no keepalive signal → false,
+ *    so the probe keeps its own authority whenever there is no transport to defer to.
+ */
+fun keepAliveProvenAliveRecently(
+    pinnedVerdict: Boolean?,
+    syntheticChannelDeathArmed: Boolean,
+    transportKeepAliveAlive: () -> Boolean,
+): Boolean {
+    pinnedVerdict?.let { return it }
+    if (syntheticChannelDeathArmed) return false
+    return transportKeepAliveAlive()
+}
+
+/**
+ * Build the [LivenessProbe.ProbeIo] adapter from the view model's seams. Lives
+ * here (not inline in the god-object) so the gate decision and the adapter that
+ * consumes it stay together and are directly unit-testable.
+ */
+fun livenessProbeIo(
+    gate: () -> LivenessProbeGate,
+    ping: suspend () -> Boolean,
+    onDrop: (Int) -> Unit,
+    keepAliveProvenAlive: () -> Boolean,
+): LivenessProbe.ProbeIo = object : LivenessProbe.ProbeIo {
+    override fun shouldProbe(): Boolean = gate() != LivenessProbeGate.Closed
+    override suspend fun probe(): Boolean = ping()
+    override fun onProbeFailed(consecutiveFailures: Int) = onDrop(consecutiveFailures)
+    override fun transportProvenAliveRecently(): Boolean = keepAliveProvenAlive()
+    override fun channelDefinitivelyClosed(): Boolean = gate() == LivenessProbeGate.DeadChannel
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1574DeadReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1574DeadReconnectTest.kt
@@ -234,10 +234,23 @@ class Issue1574DeadReconnectTest {
         // fixture let this method return with reconnect parked inside its
         // NonCancellable teardown, which is the #1355 leak seen by the next
         // rule reset.
-        val client = FakeTmuxClient()
-            .withSinglePaneRow("work", "%1")
-            .withSinglePaneRow("work", "%1")
-        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        //
+        // Issue #1863: hand the RECONNECT its own fresh client, as production does.
+        // `TmuxSessionViewModel.createTmuxClient` builds a NEW `RealTmuxClient` per
+        // attach, and the reconnect's teardown (`closeCurrentConnectionAndJoin`)
+        // closes the outgoing one. Re-serving the SAME `FakeTmuxClient` instance made
+        // the reconnect attach a client whose `disconnected` latch was already set —
+        // a state no real reconnect can produce, and one the #1863 reveal guard now
+        // (correctly) refuses to publish as live.
+        val clients = ArrayDeque(
+            listOf(
+                FakeTmuxClient().withSinglePaneRow("work", "%1"),
+                FakeTmuxClient().withSinglePaneRow("work", "%1"),
+            ),
+        )
+        vm.setTmuxClientFactoryForTest { _, _, _ ->
+            clients.removeFirstOrNull() ?: error("unexpected extra tmux client factory call")
+        }
         vm.connect(
             hostId = 1L,
             hostName = "alpha",

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1863DeadWireAfterCancelledConnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1863DeadWireAfterCancelledConnectTest.kt
@@ -1,0 +1,783 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.tmux.connection.LivenessProbeGate
+import com.pocketshell.app.tmux.connection.selectLivenessProbeGate
+import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1863 — back-press during an in-flight tmux connect leaves a permanently
+ * dead wire.
+ *
+ * ## The reported ordering
+ *
+ * ```
+ * 34.529  tmux-command-write-failed cause=JobCancellationException
+ * 34.540  tmux-refresh-client-size-error ... TmuxClientException: client is closed
+ * 34.571  app-navigator-current destination=FolderList          <- the back-press
+ * 34.957  tmux-connect-ready attempt=1                          <- the corpse published as ready
+ * 40.572  gate closed ... hasClient=true disconnected=true ctrl=Live   (x26, over 180s)
+ * ```
+ *
+ * Three things compose into a wire that can never recover:
+ *
+ * 1. **The producer** (root cause, fixed in `core-tmux`): a caller-side coroutine
+ *    cancellation inside `RealTmuxClient.sendCommandInternal` was treated as a
+ *    write FAILURE and `close()`d the shared `-CC` control client. Covered by
+ *    `TmuxClientTest."caller cancelled before its write completes must not close
+ *    the control channel (issue 1863)"`.
+ * 2. **The lie** (this file, [connectMustNotPublishLiveWhenTheControlChannelDiedMidAttach]
+ *    + the fast-switch sibling): the connect coroutine was NOT cancelled, so it
+ *    walked to the end of its happy path and published `Live` over a client whose
+ *    `disconnected` latch was already set.
+ * 3. **The terminal state** (this file, [livenessProbeGateIsReachableOnADeadWire] +
+ *    [deadWireDeclaresADropAndDrivesRecovery]): the one mechanism that detects a
+ *    dead wire — the liveness probe — was gated OFF by `!disconnected`, i.e. by the
+ *    exact condition it exists to detect.
+ *
+ * ## The two halves of the class, and which test owns which
+ *
+ * The reveal guard is a POINT-IN-TIME check. It closes "the channel died BEFORE the
+ * reveal decision" — the reported ordering — and structurally cannot close "the
+ * channel died AFTER it". Saying otherwise would be exactly the kind of coverage
+ * claim this issue is about, so the two halves are pinned separately:
+ *
+ *  - **before the reveal** — [connectMustNotPublishLiveWhenTheControlChannelDiedMidAttach]
+ *    and [fastSwitchMustNotPublishLiveWhenTheControlChannelDiedMidAttach], which SUSPEND
+ *    the attach mid-flight and close the channel from the test thread, so the ordering
+ *    is a fact rather than a race (see `assertAttachIsSuspendedStrictlyBeforeTheReveal`);
+ *  - **after the reveal** — [deadWireAfterTheRevealGuardIsDeclaredByTheProbeWithinOneInterval],
+ *    which connects HEALTHY (the guard passes honestly), then kills the channel and
+ *    drives the REAL probe loop, bounded to one interval against the production
+ *    4-failure threshold.
+ *
+ * The two passive-recovery rungs' guards are covered in the sibling
+ * `Issue1863PassiveRungRevealGuardTest`; the network ride-through's in
+ * `TmuxSessionViewModelRestoreRideThroughTest`.
+ *
+ * The close in (1) is SELF-INFLICTED (`TmuxDisconnectReason.ExplicitClose`), which
+ * the passive-drop classifier deliberately ignores (#1568/#1610 reconnect-storm
+ * guard) — so no recovery was ever armed. That is why `tmux-connect-attempt` stayed
+ * at 1: downstream saw `Connected` + the same `activeTarget`, deduped the next open
+ * into a no-op, and nothing re-dialled. This is the #822/#823 "green dot, black
+ * pane, nothing happens" class.
+ *
+ * Every test here models the client dying with `ExplicitClose` — the shape that
+ * NOTHING else recovers from — because a happy fixture that can enter only the
+ * already-handled `passive drop` state proves nothing (the #847/D33 lesson).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue1863DeadWireAfterCancelledConnectTest {
+
+    private val fixture = StandaloneTmuxVmFixture()
+    private val factoryScope get() = fixture.factoryScope
+
+    // ------------------------------------------------------------------------
+    // (2) The lie — a connect that resolved over a corpse must not publish Live.
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun connectMustNotPublishLiveWhenTheControlChannelDiedMidAttach() = fixture.runVmTest {
+        val dying = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val parked = dying.parkAttachAt(ATTACH_PARK_PREFIX, ATTACH_PARK_OCCURRENCE)
+
+        val vm = freshVmForForegrounded()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> dying }
+        vm.doConnect()
+        advanceUntilIdle()
+
+        assertAttachIsSuspendedStrictlyBeforeTheReveal(dying)
+
+        // The back-press tore down a screen-scoped caller that had a command in flight;
+        // on base that caller's cancellation close()d the SHARED `-CC` channel. The
+        // connect coroutine itself was NOT cancelled — release it and let it finish.
+        dying.killChannelAsIfACancelledCallerHadClosedIt()
+        parked.complete(Unit)
+        advanceUntilIdle()
+
+        assertTheReportedTerminalStateIsUnreachable(vm, dying)
+        drainRecoveryBeforeTheQuiescenceOracle(vm)
+        // COLD-PATH-ONLY, and discriminating here (see the helper's KDoc): on base the
+        // reveal lit the green dot over the corpse. This is the user-visible symptom.
+        assertFalse(
+            "issue #1863: a connect that resolved over a CLOSED control channel must not " +
+                "publish a live session — got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+    }
+
+    @Test
+    fun fastSwitchMustNotPublishLiveWhenTheControlChannelDiedMidAttach() = fixture.runVmTest {
+        // G2 class coverage: the WARM entry point (`runFastSessionSwitch`) has its own
+        // attach + reveal and its own `tmux-connect-ready`. The same race lands there
+        // whenever the user backs out mid-switch. Same deterministic park-then-kill seam.
+        val first = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val dying = FakeTmuxClient().withSinglePaneRow("other", "%2")
+        val parked = dying.parkAttachAt(ATTACH_PARK_PREFIX, ATTACH_PARK_OCCURRENCE)
+        val clients = ArrayDeque(listOf(first, dying))
+
+        val vm = freshVmForForegrounded()
+        vm.setTmuxClientFactoryForTest { _, _, _ ->
+            clients.removeFirstOrNull() ?: error("unexpected extra tmux client factory call")
+        }
+        vm.doConnect(sessionName = "work")
+        advanceUntilIdle()
+        assertTrue(
+            "precondition: the first session connected warm",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        vm.doConnect(sessionName = "other")
+        advanceUntilIdle()
+
+        assertAttachIsSuspendedStrictlyBeforeTheReveal(dying)
+
+        dying.killChannelAsIfACancelledCallerHadClosedIt()
+        parked.complete(Unit)
+        advanceUntilIdle()
+
+        assertTheReportedTerminalStateIsUnreachable(vm, dying)
+        drainRecoveryBeforeTheQuiescenceOracle(vm)
+    }
+
+    /**
+     * Drain the recovery this journey deliberately provokes, BEFORE the fixture's #1355
+     * quiescence oracle runs.
+     *
+     * Both journeys deliberately end with the connection core mid-recovery, and the
+     * fixture's drain loops `cancelOwnScopes()` + `runCurrent()` — it never ADVANCES the
+     * virtual clock. So any teardown work the cancellation schedules at a future virtual
+     * time can never complete there, and the oracle hard-fails on a still-`Cancelling`
+     * child after burning its 30s wall-clock budget. Measured, not theorised: with only
+     * `cancelConnect()` + `advanceUntilIdle()` in the body this failed 2 of 8 consecutive
+     * FULL `:app:testReleaseUnitTest` runs while passing every run in isolation.
+     *
+     * `onTeardown` callbacks run INSIDE the `runTest` body (before the drain, while Main
+     * is installed), so this is the one place that can both cancel and advance the clock.
+     * Registered per test, after the assertions, so it can never mask one.
+     */
+    private fun TestScope.drainRecoveryBeforeTheQuiescenceOracle(vm: TmuxSessionViewModel) {
+        fixture.onTeardown {
+            vm.cancelConnect()
+            vm.cancelOwnScopesForTest()
+            advanceUntilIdle()
+        }
+    }
+
+    /**
+     * The symptom-gone assertion, shared by both entry points — stated as the ORACLE the
+     * on-call derived from the report rather than as one particular end state.
+     *
+     * ## Why not `connectionStatus !is Connected`
+     *
+     * It reads as the natural assertion and it is the wrong cost (G6). Measured on both
+     * paths rather than assumed:
+     *  - COLD connect: on base the reveal publishes `Connected` over the corpse (the green
+     *    dot); with the fix the status stays `Connecting`. Discriminating — so it IS
+     *    asserted, but only on that path.
+     *  - FAST SWITCH: the previous session's `Connected(alpha.example, 22, alex)` is
+     *    byte-identical to the one the switch would publish and legitimately survives a
+     *    failed switch, so the status is `Connected` on BOTH sides. Asserting it there
+     *    would be a green structural proxy over nothing. Round 1 asserted exactly that,
+     *    and its fast-switch "red on base" was an artifact of its racy fixture, not the
+     *    guard. Called out rather than quietly dropped.
+     *
+     * ## Why not "the gate must be DeadChannel" either
+     *
+     * That was round 2's first attempt and it FAILED once in a full-module
+     * `:app:testDebugUnitTest` run while passing in isolation — because it over-specifies.
+     * After a dead-channel fast switch the recovery may or may not have already moved the
+     * controller off `Live` by the time the drain returns, and BOTH outcomes are correct:
+     * `DeadChannel` means "armed, the probe will declare within one interval"; controller
+     * off `Live` means "recovery is already under way". Pinning one of them makes the
+     * proof flaky by construction — the exact defect this round exists to remove — so it
+     * is not pinned.
+     *
+     * ## What IS asserted
+     *
+     * The bug is not a status enum and not one state: it is the app left believing it
+     * holds a live wire that is dead **with nothing left that can ever notice**. The
+     * report names that state exactly — `gate closed ... hasClient=true disconnected=true
+     * ctrl=Live`, 26 times over 180s, `tmux-connect-attempt` frozen at 1. So assert that
+     * conjunction is UNREACHABLE:
+     *
+     *     controller Live  AND  bound to a closed client  AND  the probe gate shut
+     *
+     * On base all three hold (`shouldRunLivenessProbe()` requires `!disconnected`), so it
+     * is red. With the fix it cannot hold: if the controller is still `Live` over a closed
+     * client the gate selects [LivenessProbeGate.DeadChannel] and is open. It is 1:1 with
+     * the on-call's CI oracle, it is deterministic, it is not retry-maskable, and it does
+     * not care which correct outcome the run happens to reach.
+     *
+     * That the armed state then actually RECOVERS is not assumed either — it is the
+     * separate real-probe proof in
+     * [deadWireAfterTheRevealGuardIsDeclaredByTheProbeWithinOneInterval] and
+     * [deadWireDeclaresADropAndDrivesRecovery]. The two compose into "the wire comes
+     * back"; neither is claimed to do it alone.
+     */
+    private fun assertTheReportedTerminalStateIsUnreachable(
+        vm: TmuxSessionViewModel,
+        dying: FakeTmuxClient,
+    ) {
+        assertTrue(
+            "harness: the mid-attach close must have latched — otherwise nothing under " +
+                "test was exercised",
+            dying.disconnectedSignal.value,
+        )
+        val ctrl = vm.connectionControllerStateForTest()
+        val boundToAClosedClient = vm.clientDisconnectedForTest()
+        val probeGateShut = !vm.shouldRunLivenessProbeForTest()
+        assertFalse(
+            "issue #1863: the app must never come to rest in the reported terminal state — " +
+                "controller Live over a CLOSED control client with the liveness gate SHUT. " +
+                "That is `gate closed ... hasClient=true disconnected=true ctrl=Live` from " +
+                "the report: nothing re-dials, every later open of the same identity is " +
+                "deduped into a no-op, and the wire is dead for good. " +
+                "got ctrl=$ctrl boundToAClosedClient=$boundToAClosedClient " +
+                "probeGateShut=$probeGateShut",
+            ctrl is CoreConnectionState.Live && boundToAClosedClient && probeGateShut,
+        )
+    }
+
+    // ------------------------------------------------------------------------
+    // (3) The terminal state — the probe must be able to see a dead wire.
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun livenessProbeGateIsReachableOnADeadWire() = fixture.runVmTest {
+        val vm = connectedVmWithDeadWireHiddenBehindALiveController()
+
+        assertTrue(
+            "precondition: this is the impossible state — controller Live over a closed client",
+            vm.connectionControllerStateForTest() is CoreConnectionState.Live &&
+                vm.clientDisconnectedForTest(),
+        )
+        // RED on base: `shouldRunLivenessProbe()` required `!disconnected`, so the
+        // detector was switched off by the very condition it exists to detect and the
+        // session stayed dead forever (the log's 26 repeats of `gate closed ...
+        // hasClient=true disconnected=true ctrl=Live` over 180s).
+        assertTrue(
+            "issue #1863: the liveness gate MUST be reachable while the current control " +
+                "client is disconnected — otherwise nothing can ever notice the dead wire",
+            vm.shouldRunLivenessProbeForTest(),
+        )
+    }
+
+    @Test
+    fun deadWireDeclaresADropAndDrivesRecovery() = fixture.runVmTest {
+        val vm = connectedVmWithDeadWireHiddenBehindALiveController()
+
+        // The probe's confirmed-drop handler re-checks the gate before acting, so on
+        // base this is a NO-OP: the session stays "Connected" forever with a dead wire.
+        vm.triggerLivenessProbeDropForTest(consecutiveFailures = 2)
+        // NOT a bare `runCurrent()`: the drop walks the controller through the effect
+        // driver, and a single scheduler step lost that race under FULL-module load while
+        // passing in isolation (the #708/#1048 virtual-clock fragility class). Drain to
+        // idle instead — safe here because this test does not run the probe loop.
+        advanceUntilIdle()
+
+        assertFalse(
+            "issue #1863: after the race the session must NOT keep claiming a live " +
+                "connection — got controller ${vm.connectionControllerStateForTest()}",
+            vm.connectionControllerStateForTest() is CoreConnectionState.Live,
+        )
+        assertFalse(
+            "issue #1863: the user must see an actionable connection-lost state, not a " +
+                "green dot over a dead wire — got ${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        // POSITIVE half (AC3). The two assertions above are negative, and "not Connected"
+        // is also satisfied by a session stuck in some third state forever — which would be
+        // the same dead end wearing a different label. Recovery must actually be DRIVEN:
+        // `onLivenessProbeDeclaredDrop` walks the controller Live -> Reattaching
+        // (`reportRemoteDrop`, the #822 DETECTION half) and then schedules the single
+        // auto-reconnect ladder (the RECOVERY half). Assert we landed in one of those
+        // recovering states, not merely "somewhere that is not Live".
+        val state = vm.connectionControllerStateForTest()
+        assertTrue(
+            "issue #1863 (AC3): recovery must be DRIVEN, not merely 'not Live' — the controller " +
+                "must be walking Reattaching/Reconnecting (or have reached the honest terminal " +
+                "Unreachable), which is what surfaces the actionable connection-lost state. " +
+                "got $state",
+            state is CoreConnectionState.Reattaching ||
+                state is CoreConnectionState.Reconnecting ||
+                state is CoreConnectionState.Unreachable,
+        )
+    }
+
+    // ------------------------------------------------------------------------
+    // The other half of the class: the channel dies AFTER the reveal guard.
+    // ------------------------------------------------------------------------
+
+    /**
+     * The reveal guard is a POINT-IN-TIME check — it cannot catch a channel that dies
+     * after it runs, and pretending otherwise would be exactly the kind of coverage
+     * claim this issue is about. That half belongs to the probe's `DeadChannel` arm,
+     * and this test is its proof: connect HEALTHY (so the guard passes honestly), then
+     * kill the channel, then let the REAL [com.pocketshell.core.connection.LivenessProbe]
+     * loop tick.
+     *
+     * The bound is load-bearing. `failureThreshold` is pinned to the production 4, and
+     * the advance is ONE interval + one per-probe timeout. Without the `DeadChannel`
+     * arm the threshold path needs FOUR such ticks, so this window is too short and the
+     * test is RED; with it, detection is bounded at one interval. It therefore proves
+     * the arm, not merely "a drop was eventually declared".
+     */
+    @Test
+    fun deadWireAfterTheRevealGuardIsDeclaredByTheProbeWithinOneInterval() =
+        fixture.runVmTest(disableLivenessProbeAutoStart = false) {
+            val sink = installRecordingDiagnosticSink()
+            fixture.onTeardown { sink.close() }
+            LivenessProbeTestOverride.setAutoStartEnabledForTest(true)
+            LivenessProbeTestOverride.setForTest(
+                intervalMs = PROBE_INTERVAL_MS,
+                perProbeTimeoutMs = PROBE_TIMEOUT_MS,
+                // The PRODUCTION threshold. Lowering it to 1 would make this test pass
+                // without the #1863 arm and prove nothing (G6).
+                failureThreshold = 4,
+            )
+
+            val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+            val vm = freshVmFor()
+            vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+            vm.doConnect()
+            // Bounded, never advanceUntilIdle: the probe loop is intentionally infinite
+            // (#1517/#1543), so draining to idle would hang forever.
+            repeat(24) { advanceTimeBy(500L); runCurrent() }
+            vm.setProcessForegroundForClearedForTest(true)
+            vm.setScreenInteractiveForTest(true)
+            runCurrent()
+            assertTrue(
+                "precondition: a HEALTHY connect reached Live — the reveal guard passed " +
+                    "honestly, so what follows is strictly the post-guard window",
+                vm.connectionControllerStateForTest() is CoreConnectionState.Live,
+            )
+            // The #982/#984 keepalive would otherwise vouch for the still-alive SSH
+            // transport forever (only the `-CC` channel dies in this bug), so pin the
+            // vouch TRUE: the arm must act in spite of it.
+            vm.forceTransportProvenAliveForTest = true
+            fixture.onTeardown { runCatching { vm.forceTransportProvenAliveForTest = null } }
+
+            client.killChannelAsIfACancelledCallerHadClosedIt()
+            // ONE interval + ONE per-probe timeout, plus a single tick of slack for the
+            // scheduling boundary. Four thresholds' worth would be 4x this.
+            advanceTimeBy(PROBE_INTERVAL_MS + PROBE_TIMEOUT_MS + PROBE_INTERVAL_MS)
+            runCurrent()
+
+            assertTrue(
+                "issue #1863: a channel that dies AFTER the reveal guard must be declared by " +
+                    "the probe's DeadChannel arm within ONE probe interval — the guard " +
+                    "structurally cannot catch this half. recorded=" +
+                    "${sink.eventsNamed("liveness_probe_silent_drop").size}",
+                sink.eventsNamed("liveness_probe_silent_drop").isNotEmpty(),
+            )
+            assertFalse(
+                "issue #1863: and the session must stop claiming a live connection — " +
+                    "got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+            )
+        }
+
+    @Test
+    fun keepAliveCannotVetoADefinitivelyClosedControlChannel() = fixture.runVmTest {
+        val vm = connectedVmWithDeadWireHiddenBehindALiveController()
+        // The #982/#984 deferral is the reason a threshold-based probe could never have
+        // rescued this state: only the `-CC` CHANNEL was closed, the SSH transport under
+        // it is perfectly alive, so the keepalive keeps vouching and the probe keeps
+        // deferring. Pin that vouch TRUE — the definitive-closed arm must still act.
+        vm.forceTransportProvenAliveForTest = true
+        fixture.onTeardown { runCatching { vm.forceTransportProvenAliveForTest = null } }
+
+        assertEquals(
+            "a CLOSED control channel is not an ambiguous slow one — the gate must report " +
+                "the dead-channel arm so the probe declares immediately",
+            LivenessProbeGate.DeadChannel,
+            selectLivenessProbeGate(
+                backgrounded = false,
+                appActive = true,
+                hasClient = true,
+                controlChannelDisconnected = true,
+                controllerLive = true,
+            ),
+        )
+        vm.triggerLivenessProbeDropForTest(consecutiveFailures = 1)
+        // See the sibling above: drain to idle, not one step.
+        advanceUntilIdle()
+        assertFalse(
+            "issue #1863: a live transport keepalive must not veto recovery from a " +
+                "CLOSED control channel — got ${vm.connectionControllerStateForTest()}",
+            vm.connectionControllerStateForTest() is CoreConnectionState.Live,
+        )
+    }
+
+    // ------------------------------------------------------------------------
+    // The pure gate — full term coverage (G2).
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun gateClosesForEveryReasonItMustAndOnlySplitsTheDeadChannelCase() {
+        // Backgrounded (D21 + the #635 single grace owner).
+        assertEquals(
+            LivenessProbeGate.Closed,
+            selectLivenessProbeGate(true, appActive = true, hasClient = true, controlChannelDisconnected = false, controllerLive = true),
+        )
+        // Explicit leave.
+        assertEquals(
+            LivenessProbeGate.Closed,
+            selectLivenessProbeGate(false, appActive = false, hasClient = true, controlChannelDisconnected = false, controllerLive = true),
+        )
+        // Nothing to ping.
+        assertEquals(
+            LivenessProbeGate.Closed,
+            selectLivenessProbeGate(false, appActive = true, hasClient = false, controlChannelDisconnected = false, controllerLive = true),
+        )
+        // In-flight attach / reconnect owns the channel — the probe must never race the
+        // single ladder (D28). This is what the `!disconnected` term was ALSO doing, and
+        // it stays intact.
+        assertEquals(
+            LivenessProbeGate.Closed,
+            selectLivenessProbeGate(false, appActive = true, hasClient = true, controlChannelDisconnected = true, controllerLive = false),
+        )
+        assertEquals(
+            LivenessProbeGate.Closed,
+            selectLivenessProbeGate(false, appActive = true, hasClient = true, controlChannelDisconnected = false, controllerLive = false),
+        )
+        // The #1863 split: foregrounded + controller Live + a CLOSED client.
+        assertEquals(
+            LivenessProbeGate.DeadChannel,
+            selectLivenessProbeGate(false, appActive = true, hasClient = true, controlChannelDisconnected = true, controllerLive = true),
+        )
+        // The healthy steady state is unchanged.
+        assertEquals(
+            LivenessProbeGate.Probe,
+            selectLivenessProbeGate(false, appActive = true, hasClient = true, controlChannelDisconnected = false, controllerLive = true),
+        )
+    }
+
+    // ------------------------------------------------------------------------
+    // Harness
+    // ------------------------------------------------------------------------
+
+    /**
+     * Reach the exact terminal state the report ends in: the controller says `Live`,
+     * the app is foregrounded, and the current `-CC` client is CLOSED by a
+     * self-inflicted [TmuxDisconnectReason.ExplicitClose] — the shape the passive-drop
+     * classifier ignores, so nothing else is going to recover it.
+     */
+    private fun TestScope.connectedVmWithDeadWireHiddenBehindALiveController(): TmuxSessionViewModel {
+        val client = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val vm = connectVm(client)
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        runCurrent()
+        assertTrue(
+            "precondition: a healthy connect reached Live",
+            vm.connectionControllerStateForTest() is CoreConnectionState.Live,
+        )
+        client.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ExplicitClose,
+                source = "local",
+                intent = "local_close",
+            ),
+        )
+        runCurrent()
+        return vm
+    }
+
+    private fun TestScope.connectVm(client: FakeTmuxClient): TmuxSessionViewModel {
+        val vm = freshVmFor()
+        vm.setTmuxClientFactoryForTest { _, _, _ -> client }
+        vm.doConnect()
+        advanceUntilIdle()
+        return vm
+    }
+
+    /**
+     * A VM in the state the report was made from: the app IS foregrounded and the screen
+     * IS on (the user pressed Back inside the app, they did not background it). That is
+     * load-bearing, not decoration — `appActive` gates the recovery ladder, so a
+     * non-foregrounded fixture could never observe recovery being driven and the proof
+     * would silently degrade into "nothing happened", which is the bug.
+     */
+    private fun TestScope.freshVmForForegrounded(): TmuxSessionViewModel {
+        val vm = freshVmFor()
+        vm.setProcessForegroundForClearedForTest(true)
+        vm.setScreenInteractiveForTest(true)
+        runCurrent()
+        return vm
+    }
+
+    private fun TestScope.freshVmFor(): TmuxSessionViewModel {
+        val connector = SingleSessionConnector(AlwaysConnectedSession())
+        val leaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 60_000L)
+        val vm = newVm(sshLeaseManager = leaseManager)
+        runCurrent()
+        return vm
+    }
+
+    private fun TestScope.newVm(sshLeaseManager: SshLeaseManager): TmuxSessionViewModel =
+        TmuxSessionViewModel(
+            tmuxClientFactory = TmuxClientFactory(factoryScope),
+            activeTmuxClients = ActiveTmuxClients(),
+            runtimeCache = TmuxSessionRuntimeCache(),
+            sshLeaseManager = sshLeaseManager,
+            sessionLifecycleSignals = null,
+        ).also {
+            it.setSeedIoDispatcherForTest(StandardTestDispatcher(testScheduler))
+            it.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+            it.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+            fixture.track(it)
+        }
+
+    private fun TmuxSessionViewModel.doConnect(sessionName: String = "work") = connect(
+        hostId = 1L,
+        hostName = "alpha",
+        host = "alpha.example",
+        port = 22,
+        user = "alex",
+        keyPath = "/keys/a",
+        passphrase = null,
+        sessionName = sessionName,
+    )
+
+    /**
+     * SUSPEND the in-flight attach at the first command starting with [prefix] and
+     * hand back the latch that releases it.
+     *
+     * This is the ordering seam, and it is deliberate. Round 1 killed the channel
+     * from an `onCommandSent` hook and hoped the killing command was issued before
+     * `requireControlChannelAliveForReveal` ran. It is not guaranteed to be:
+     * `awaitActivePaneSeededOrLoading` can return on its already-non-blank branch
+     * without issuing a capture at all, the seed IO runs on its own dispatcher, and
+     * the deferred blank-pane reseed can issue one AFTER the reveal. So the test was
+     * flaky by construction — 2 red / 3 green on `:app:testReleaseUnitTest` — and,
+     * worse, its own `clientDisconnectedForTest()` precondition was evaluated after
+     * `advanceUntilIdle()`, so it asserted a state it had never actually forced at
+     * the moment under test.
+     *
+     * Parking instead makes the order a fact rather than a race: `advanceUntilIdle()`
+     * returns with the attach SUSPENDED here (a suspended coroutine is not a pending
+     * task), the test closes the channel from the test thread, and only then releases
+     * the attach. No timing, no dispatcher ordering, nothing to lose on a contended
+     * CI box. The caller HARD-asserts both that the park was reached and that the
+     * reveal has not happened yet, so a fixture that stops parking fails loudly
+     * instead of silently testing the post-reveal case.
+     */
+    /**
+     * The ORDERING PROOF, and the whole point of round 2.
+     *
+     * Round 1 killed the channel from an `onCommandSent` hook and *hoped* the killing
+     * command was issued before `requireControlChannelAliveForReveal` ran. It is not
+     * guaranteed to be: `awaitActivePaneSeededOrLoading` can return on its
+     * already-non-blank branch without capturing at all, the seed IO runs on its own
+     * dispatcher, and the deferred blank-pane reseed can capture AFTER the reveal. The
+     * proof was flaky by construction — 2 red / 3 green on `:app:testReleaseUnitTest`
+     * — and when it went red the criterion was genuinely violated in that run.
+     *
+     * This asserts the ordering as a FACT about the observable command stream instead:
+     *
+     *  - the attach reached the parked command ([ATTACH_PARK_OCCURRENCE] of them), and
+     *  - it is SUSPENDED there: the parked command is the last one issued, and the
+     *    cursor query that always follows a `capture-pane` has NOT been issued.
+     *
+     * The seed's `capture-pane` -> `display-message ... cursor` pair is issued from the
+     * attach's own `reseedAllVisiblePanes` / seed pass, which the connect and fast-switch
+     * paths both `await` BEFORE the reveal guard. So "the pair is incomplete" is a
+     * checkable statement that the guard has not run yet. Combined with
+     * `advanceUntilIdle()` having returned (a suspended coroutine is not a pending task),
+     * the close that follows provably lands strictly before the reveal decision — no
+     * timing, no dispatcher ordering, nothing to lose on a contended CI box.
+     *
+     * If the fixture ever stops parking there, this fails LOUDLY rather than silently
+     * degrading into "the channel died after the reveal" — which is a real but DIFFERENT
+     * case, owned by [deadWireAfterTheRevealGuardIsDeclaredByTheProbeWithinOneInterval].
+     */
+    private fun assertAttachIsSuspendedStrictlyBeforeTheReveal(client: FakeTmuxClient) {
+        val sent = client.sentCommands
+        val captures = sent.count { it.trimStart().startsWith(ATTACH_PARK_PREFIX) }
+        val cursorQueries = sent.count { it.startsWith("display-message") && it.contains("cursor") }
+        assertEquals(
+            "harness: the attach must have reached seed capture #$ATTACH_PARK_OCCURRENCE " +
+                "and parked there. sent=$sent",
+            ATTACH_PARK_OCCURRENCE,
+            captures,
+        )
+        assertTrue(
+            "harness: the parked `$ATTACH_PARK_PREFIX` must be the LAST command issued — " +
+                "if anything ran after it the attach is not suspended. sent=$sent",
+            sent.last().trimStart().startsWith(ATTACH_PARK_PREFIX),
+        )
+        assertEquals(
+            "harness: the parked capture's cursor query must NOT have been issued — that " +
+                "incomplete pair is what proves the seed pass (and therefore the reveal " +
+                "guard that awaits it) has not run yet. sent=$sent",
+            ATTACH_PARK_OCCURRENCE - 1,
+            cursorQueries,
+        )
+        assertFalse(
+            "harness: the channel must still be ALIVE at the park — the test closes it " +
+                "MID-attach, which is the reported ordering",
+            client.disconnectedSignal.value,
+        )
+    }
+
+    private fun FakeTmuxClient.parkAttachAt(
+        prefix: String,
+        occurrence: Int,
+    ): CompletableDeferred<Unit> {
+        val latch = CompletableDeferred<Unit>()
+        var seen = 0
+        // `handleCommand` invokes `onCommandSent` and only THEN consults
+        // `sendCommandGatePrefix`, in the same call — so arming the gate from here on
+        // the Nth match parks exactly that command and no earlier one.
+        onCommandSent = { command ->
+            if (command.trimStart().startsWith(prefix)) {
+                seen += 1
+                if (seen == occurrence) {
+                    sendCommandGatePrefix = prefix
+                    sendCommandGate = latch
+                }
+            }
+        }
+        return latch
+    }
+
+    /**
+     * Close the fake `-CC` client the way the reported bug closed the real one: a
+     * screen-scoped caller was cancelled mid-write and `RealTmuxClient`'s #244 arm
+     * called `close()`, which is [TmuxDisconnectReason.ExplicitClose]. That reason is
+     * the load-bearing part — the passive-drop classifier deliberately IGNORES a
+     * self-inflicted close (#1568/#1610 storm guard), so no existing recovery arm
+     * fires and the state is genuinely terminal. A fixture that closed with a passive
+     * `ReaderEof` would enter an already-handled state and prove nothing (#847/D33).
+     */
+    private fun FakeTmuxClient.killChannelAsIfACancelledCallerHadClosedIt() {
+        markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ExplicitClose,
+                source = "local",
+                intent = "local_close",
+            ),
+        )
+    }
+
+    private fun FakeTmuxClient.withSinglePaneRow(
+        sessionName: String,
+        paneId: String,
+        title: String = sessionName,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$title\t0"),
+                isError = false,
+            ),
+        )
+        capturePaneResponses.addLast(
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false),
+        )
+        cursorQueryResponses.addLast(
+            CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+        )
+    }
+
+    private companion object {
+        /**
+         * The command the attach is parked at. `capture-pane` is the seed round-trip
+         * every attach path issues while it is still in flight — the same window the
+         * report's `tmux-command-write-failed` landed in.
+         */
+        const val ATTACH_PARK_PREFIX = "capture-pane"
+
+        /**
+         * WHICH `capture-pane` to park on, and why it is the 2nd rather than the 1st.
+         *
+         * A cold attach issues `list-panes`, then `capture-pane`+cursor as the
+         * PANES-READY preload, then `capture-pane`+cursor as the pre-reveal seed. The
+         * reported window is between panes-ready and the reveal: in the report the
+         * attach had already got its panes (it went on to log `tmux-connect-ready`) and
+         * the channel died underneath it. Parking on the FIRST capture instead lands
+         * inside panes-ready, where a closed channel makes the attach fail HONESTLY
+         * (`Failed(Timed out waiting for tmux panes)` / `Unreachable`) — a state the app
+         * already handles, so the guard is never reached and the proof would pass on
+         * base for the wrong reason. Verified, not assumed: parking at occurrence 1 was
+         * measured GREEN on the guard-removed baseline.
+         */
+        const val ATTACH_PARK_OCCURRENCE = 2
+
+        /** Short, deterministic probe cadence for the post-guard half. */
+        const val PROBE_INTERVAL_MS = 10L
+        const val PROBE_TIMEOUT_MS = 10L
+    }
+
+    private class SingleSessionConnector(
+        private val session: SshSession,
+    ) : SshLeaseConnector {
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            Result.success(session)
+    }
+
+    private class AlwaysConnectedSession : SshSession {
+        override val isConnected: Boolean get() = true
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job().apply { complete() }
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() = Unit
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1863PassiveRungRevealGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1863PassiveRungRevealGuardTest.kt
@@ -1,0 +1,291 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1863 (AC5 / G2) — the reveal guard on the TWO PASSIVE-RECOVERY rungs.
+ *
+ * `requireControlChannelAliveForReveal` is called at five production sites. Three of
+ * them (cold connect, fast switch, network ride-through) are covered by
+ * `Issue1863DeadWireAfterCancelledConnectTest` and
+ * `TmuxSessionViewModelRestoreRideThroughTest`. The other two —
+ * `silentlyReattachAfterPassiveDisconnect` (the channel-only rung over a still-live
+ * transport) and `silentlyReconnectTransportAfterPassiveDisconnect` (the
+ * fresh-transport rung) — shipped in round 1 with NO triggering test: a mutation
+ * deleting either line survived the whole suite. That is a G9 hole, and this file
+ * closes it.
+ *
+ * ## The property, and why it is asserted on the REGISTRY
+ *
+ * Round 1 placed both guards AFTER `activeTmuxClients.register(...)` /
+ * `installLifecycleHooks` / `activeTarget = target`. So a replacement whose `-CC`
+ * channel died during its own attach was published to the host registry FIRST and only
+ * then rejected — leaving the app's registry pointing at a corpse while the rung
+ * reported failure, which the sibling `!ready` early-return in the same function is
+ * careful never to do. Round 2 moves both guards ABOVE that registration.
+ *
+ * The assertion is therefore: after a passive drop whose every replacement dies
+ * mid-attach, `ActiveTmuxClients` must never have been re-pointed at a dead
+ * replacement. That is red with the guard in its round-1 position (and red with the
+ * guard absent entirely), green with it above the registration — and it is the state
+ * other surfaces read, not an internal flag.
+ *
+ * Both rungs are driven through the REAL passive-grace loop
+ * (`handlePassiveClientDisconnect` -> the bounded grace window), selected by the
+ * transport vouch exactly as production selects them: a vouched-ALIVE stale transport
+ * takes the channel-only rung, a DEAD one takes the fresh-transport rung. Nothing here
+ * calls the rung directly.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1863PassiveRungRevealGuardTest : TmuxSessionViewModelTestBase() {
+
+    @Test
+    fun channelOnlyRungMustNotRegisterAReplacementWhoseChannelDiedMidAttach() =
+        runTest(scheduler) {
+            // A LIVE stale transport => `preferFreshTransportNow()` is false => the grace
+            // loop takes `silentlyReattachAfterPassiveDisconnect` (the channel-only rung).
+            val f = Fixture(this, staleTransportAlive = true)
+            f.start()
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            f.assertTheRungRanAndNeverRegisteredACorpse()
+        }
+
+    @Test
+    fun freshTransportRungMustNotRegisterAReplacementWhoseChannelDiedMidAttach() =
+        runTest(scheduler) {
+            // A DEAD stale transport => the fresh-transport rung
+            // (`silentlyReconnectTransportAfterPassiveDisconnect`) is preferred.
+            val f = Fixture(this, staleTransportAlive = false)
+            f.start()
+            f.dropControlChannelPassively()
+
+            advanceTimeBy(f.graceMs + 1_000L)
+            runCurrent()
+
+            f.assertTheRungRanAndNeverRegisteredACorpse()
+        }
+
+    // ------------------------------------------------------------------ fixture
+
+    private inner class Fixture(
+        private val scope: kotlinx.coroutines.test.TestScope,
+        private val staleTransportAlive: Boolean,
+    ) {
+        val registry = ActiveTmuxClients()
+        val graceMs: Long = 20_000L
+
+        /** Every replacement the rungs built, in build order. All of them die mid-attach. */
+        val replacements = mutableListOf<FakeTmuxClient>()
+
+        lateinit var vm: TmuxSessionViewModel
+        private lateinit var staleClient: FakeTmuxClient
+
+        suspend fun start() {
+            TMUX_CONNECT_ATTEMPTS.set(1)
+            vm = newVm(
+                registry = registry,
+                sshLeaseManager = with(scope) {
+                    testLeaseManager(
+                        connector = SshLeaseConnector { Result.success(FakeSshSession()) },
+                        scope = scope,
+                        idleTtlMillis = 60_000L,
+                    )
+                },
+            )
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = graceMs,
+                silentReattachTimeoutMs = 5_000L,
+            )
+            vm.setAutoReconnectDelaysForTest(listOf(0L))
+            // Orthogonal rolling watchdogs; they re-arm forever under the virtual clock
+            // (#1517) and have nothing to do with the reveal guard.
+            vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+            vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+
+            // EVERY replacement dies during its own attach, the #1863 shape: the `-CC`
+            // channel is closed by a SELF-INFLICTED `ExplicitClose` (what a cancelled
+            // caller's `close()` produces), which the passive-drop classifier ignores —
+            // so nothing else recovers it and the rung must reject it itself.
+            vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+                newReplacementThatDiesMidAttach(sessionName)
+            }
+
+            staleClient = FakeTmuxClient()
+            vm.replaceClientForTest(
+                hostId = HOST_ID,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = staleClient,
+                session = FakeSshSession(isConnectedValue = staleTransportAlive),
+            )
+            scope.runCurrent()
+            vm.setActiveLeaseRefWarmForTest()
+            scope.runCurrent()
+            assertSameClientRegistered(
+                staleClient,
+                "precondition: the stale client is the registered one before the drop",
+            )
+        }
+
+        fun dropControlChannelPassively() {
+            staleClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "network_starvation",
+                    intent = "unknown",
+                ),
+            )
+            scope.runCurrent()
+        }
+
+        fun assertTheRungRanAndNeverRegisteredACorpse() {
+            // HARD precondition: without this the assertion below would pass vacuously on
+            // a fixture where the rung never ran at all.
+            assertTrue(
+                "precondition: the passive-grace loop must have actually run a recovery rung " +
+                    "and built at least one replacement — otherwise the guard under test was " +
+                    "never reached. replacements=${replacements.size}",
+                replacements.isNotEmpty(),
+            )
+            assertTrue(
+                "precondition: every replacement must have died mid-attach (that is the " +
+                    "state under test)",
+                replacements.all { it.disconnectedSignal.value },
+            )
+            // LOAD-BEARING. Red with the guard in its round-1 position (after the
+            // registration) and red with no guard at all: the corpse becomes the host's
+            // registered client, which is what every other surface reads.
+            val registered = registry.clients.value[HOST_ID]?.client
+            for (corpse in replacements) {
+                assertNotSame(
+                    "issue #1863 (AC5/G2): a passive-recovery rung must NEVER register a " +
+                        "replacement whose control channel died during its own attach — the " +
+                        "guard has to run BEFORE activeTmuxClients.register(), like the " +
+                        "sibling `!ready` early return does. registered=$registered",
+                    corpse,
+                    registered,
+                )
+            }
+            assertFalse(
+                "issue #1863 (AC5/G2): and the rung must not have revealed the corpse as a " +
+                    "live session either — got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected &&
+                    vm.clientDisconnectedForTest(),
+            )
+        }
+
+        private fun assertSameClientRegistered(expected: TmuxClient, why: String) {
+            assertTrue("$why (registered=${registry.clients.value[HOST_ID]?.client})",
+                registry.clients.value[HOST_ID]?.client === expected)
+        }
+
+        private fun newReplacementThatDiesMidAttach(sessionName: String): FakeTmuxClient {
+            val client = FakeTmuxClient()
+            // Sticky fixtures: a rung may re-issue these on a retry.
+            repeat(8) {
+                client.responses.addLast(
+                    CommandResponse(
+                        number = 1L,
+                        output = listOf("%1\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                        isError = false,
+                    ),
+                )
+                client.cursorQueryResponses.addLast(
+                    CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+                )
+            }
+            client.defaultCaptureResponse =
+                CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false)
+            // The kill point: the panes have already come back (`list-panes` answered), so
+            // the attach is PAST readiness and on its way to the registration + reveal —
+            // the reported window. Closing on the seed capture, which the rung's
+            // `reseedVisiblePanesForPassiveReattach` awaits before the registration, keeps
+            // the ordering on the rung's own coroutine with no dispatcher race.
+            client.onCommandSent = { command ->
+                if (command.trimStart().startsWith("capture-pane") &&
+                    !client.disconnectedSignal.value
+                ) {
+                    client.markDisconnectedForTest(
+                        TmuxDisconnectEvent(
+                            reason = TmuxDisconnectReason.ExplicitClose,
+                            source = "local",
+                            intent = "local_close",
+                        ),
+                    )
+                }
+            }
+            replacements += client
+            return client
+        }
+    }
+
+    private class FakeSshSession(
+        private val isConnectedValue: Boolean = true,
+    ) : SshSession {
+        @Volatile
+        var closed: Boolean = false
+
+        override val isConnected: Boolean get() = isConnectedValue && !closed
+
+        override fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean = isConnected
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError("not needed")
+
+        override fun startShell(): SshShell = throw NotImplementedError("not needed")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = remotePath
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = remotePath
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        const val HOST_ID = 7L
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRestoreRideThroughTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRestoreRideThroughTest.kt
@@ -152,6 +152,85 @@ class TmuxSessionViewModelRestoreRideThroughTest : TmuxSessionViewModelTestBase(
             }
         }
 
+    // ---- 1b. #1863 G2: the ride-through must not re-assert Live over a CLOSED client ----
+
+    @Test
+    fun restoreRideThroughMustNotClearTheBandWhenTheControlChannelIsAlreadyClosed() =
+        runTest(scheduler) {
+            // Issue #1863 (G2 sweep of every `revealControllerLive()` publisher).
+            //
+            // The reader-activity vouch ([RestoreReaderActivityVerdict.isAlive]) reads ONLY
+            // `millisSinceLastReaderActivity` — it never consults `disconnected`. So a `-CC`
+            // client that was CLOSED moments ago (the #1863 cancelled-write close, whose
+            // self-inflicted `ExplicitClose` the passive-drop classifier deliberately
+            // ignores) still carries recent reader activity and still takes the ride-through
+            // arm. On base the ride-through then republished `ConnectionState.Live` over that
+            // corpse — the same dead-wire lie the connect paths were guarded against, reached
+            // through a different door.
+            val registry = ActiveTmuxClients()
+            val connector = QueueLeaseConnector(FakeSshSession())
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+            )
+            vm.setAutoReconnectDelaysForTest(listOf(0L))
+            val closedButRecentlyActiveClient = FakeTmuxClient().apply {
+                millisSinceLastReaderActivityValue = 100L
+            }
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = closedButRecentlyActiveClient,
+            )
+            runCurrent()
+            // The #1863 state: the control channel is closed by OUR OWN code, so the
+            // passive-drop classifier ignores it and nothing else arms recovery.
+            closedButRecentlyActiveClient.markDisconnectedForTest(
+                com.pocketshell.core.tmux.TmuxDisconnectEvent(
+                    reason = com.pocketshell.core.tmux.TmuxDisconnectReason.ExplicitClose,
+                    source = "local",
+                    intent = "local_close",
+                ),
+            )
+            runCurrent()
+
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                val hook = registry.lifecycleHooksSnapshot().single()
+                hook.onNetworkChanged(networkLoss())
+                runCurrent()
+                hook.onNetworkChanged(networkRestore())
+                runCurrent()
+
+                // The load-bearing signal is the ride-through EFFECT itself: on base
+                // `rideThroughNetworkRestore` runs and records this diagnostic on its way
+                // to `revealControllerLive()` + `setConnectionState(Live)`. With the
+                // #1863 guard it returns before either. (The displayed status is not a
+                // discriminator here — the #1522 loss band is debounced, so it never left
+                // `Connected` in this window; the bug is precisely that the ride-through
+                // RE-ASSERTS liveness over a corpse.)
+                assertTrue(
+                    "issue #1863: the network-restore ride-through must NOT re-assert a " +
+                        "live connection over an already-CLOSED control channel; events=" +
+                        diagnostics.events.map { it.name },
+                    diagnostics.eventsNamed("network_restore_ride_through").isEmpty(),
+                )
+                assertSame(
+                    "the closed client is still the registered one — the guard suppresses the " +
+                        "false reveal, it does not swap or tear anything down",
+                    closedButRecentlyActiveClient,
+                    registry.clients.value[7L]?.client,
+                )
+            } finally {
+                diagnostics.close()
+            }
+        }
+
     // ---- 2. same-identity, actually-dead → AMORTIZED redial (not immediate unconditional) ----
 
     @Test

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt
@@ -96,6 +96,17 @@ import kotlinx.coroutines.withTimeoutOrNull
  *     well under the two 60s transport-liveness windows (lease idle TTL,
  *     passive grace), and below the controller's 90s foreground grace.
  *
+ * **The one deliberate bypass (#1863).** Guards 2 and 3 — and the #982/#984
+ * keepalive deferral and the [absoluteWedgeBudgetMs] backstop — all exist to
+ * disambiguate a MISSED ping. [ProbeIo.channelDefinitivelyClosed] reports the one
+ * state where there is nothing to disambiguate: the channel the probe pings is
+ * already provably CLOSED. When it is true for a failed probe the loop declares on
+ * that tick and ALL of that machinery is skipped. This cannot false-positive on a
+ * slow-but-live channel (an open channel never reports closed), but it is a real
+ * bypass and the caller owns keeping the predicate honest — the app's gate returns
+ * it only for a foregrounded, controller-`Live` session over a latched-closed
+ * client. Guard 1 still applies: the bypass is unreachable while the gate is shut.
+ *
  * ## Determinism (the test seam)
  * The loop's cadence is driven entirely by [delay] on the [CoroutineScope]'s
  * dispatcher, so a `TestScope` virtual clock advances the probe window with zero
@@ -203,6 +214,27 @@ class LivenessProbe(
          * keepalive liveness.
          */
         fun transportProvenAliveRecently(): Boolean = false
+
+        /**
+         * Issue #1863 — the DEFINITIVE-death oracle: true iff the control channel
+         * the probe pings is already provably CLOSED (the current client's
+         * `disconnected` latch is set), not merely unanswering.
+         *
+         * The whole N-consecutive-failure + keepalive-deferral machinery above
+         * exists because a missed ping is an AMBIGUOUS signal — a busy channel, a
+         * slow link, one lost reply. A closed client is not ambiguous: the channel
+         * is gone, there is nothing to ride through, and no number of further ticks
+         * will make it answer. Conflating the two is what made the #1863 dead wire
+         * unrecoverable in practice — the keepalive still vouched for the SSH
+         * transport (only the `-CC` channel had been closed), so the #982/#984
+         * deferral would have suppressed the drop indefinitely.
+         *
+         * When this returns `true` for a failed probe the loop declares the drop on
+         * that tick: no threshold, no deferral. Detection is bounded by ONE probe
+         * interval. Default `false` so a probe fake that models a live-but-slow
+         * channel keeps the full ambiguity machinery.
+         */
+        fun channelDefinitivelyClosed(): Boolean = false
     }
 
     private var job: Job? = null
@@ -282,6 +314,29 @@ class LivenessProbe(
                     // A successful `-CC` probe clears the failure run: the control
                     // channel is answering again, so the slow-but-live blip is over
                     // and the absolute-wedge clock resets.
+                    consecutiveFailures = 0
+                    wedgedFailureTicks = 0
+                } else if (io.channelDefinitivelyClosed()) {
+                    // Issue #1863 — the control channel is provably CLOSED, not slow.
+                    // Skip the N-consecutive threshold AND the keepalive deferral: both
+                    // exist to disambiguate a MISSED ping, and there is nothing here to
+                    // disambiguate. Declaring now bounds detection of the "controller says
+                    // Live over a dead client" state at one probe interval instead of
+                    // leaving it terminal (the keepalive would keep vouching for the still
+                    // alive SSH transport forever).
+                    consecutiveFailures += 1
+                    log(
+                        "liveness-probe DECLARED DROP (control channel definitively closed) " +
+                            "consecutive=$consecutiveFailures",
+                    )
+                    ConnectionDiagnostics.record(
+                        "liveness_probe_tick",
+                        "result" to "channel_closed",
+                        "latencyMs" to latencyMs,
+                        "consecutiveMisses" to consecutiveFailures,
+                        "failureThreshold" to failureThreshold,
+                    )
+                    io.onProbeFailed(consecutiveFailures)
                     consecutiveFailures = 0
                     wedgedFailureTicks = 0
                 } else {

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/LivenessProbeTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/LivenessProbeTest.kt
@@ -75,6 +75,15 @@ class LivenessProbeTest {
         }
 
         override fun transportProvenAliveRecently(): Boolean = transportProvenAliveRecently
+
+        /**
+         * Issue #1863 — the control channel is provably CLOSED (not merely
+         * unanswering). Default `false` so every existing case keeps exercising the
+         * ambiguity machinery (N-consecutive + keepalive deferral) unchanged.
+         */
+        var channelDefinitivelyClosed: Boolean = false
+
+        override fun channelDefinitivelyClosed(): Boolean = channelDefinitivelyClosed
     }
 
     @Test
@@ -762,6 +771,82 @@ class LivenessProbeTest {
             assertEquals(
                 "a %output-burst-parked probe with a provably-alive keepalive must NOT " +
                     "redial mid-work within the deferral bound (#964)",
+                0,
+                io.onProbeFailedCount,
+            )
+            probe.stop()
+        }
+
+    @Test
+    fun `issue 1863 a definitively CLOSED control channel declares the drop on the first failed tick`() =
+        runTest(StandardTestDispatcher()) {
+            // Issue #1863: the N-consecutive threshold + the #982/#984 keepalive
+            // deferral both exist to disambiguate a MISSED ping. A closed client is
+            // not ambiguous — the channel is gone and no further tick will make it
+            // answer. Detection must be bounded by ONE interval, not by a threshold.
+            val io = FakeProbeIo()
+            io.enqueue(false)
+            io.channelDefinitivelyClosed = true
+            val probe =
+                LivenessProbe(io, intervalMs = 100, perProbeTimeoutMs = 1_000, failureThreshold = 4)
+            probe.start(this)
+
+            advanceTimeBy(110) // exactly ONE interval
+            runCurrent()
+
+            assertEquals(
+                "issue #1863: a CLOSED control channel must declare the drop on the first " +
+                    "failed probe, without waiting out failureThreshold=4",
+                1,
+                io.onProbeFailedCount,
+            )
+            probe.stop()
+        }
+
+    @Test
+    fun `issue 1863 a live transport keepalive cannot veto a definitively CLOSED control channel`() =
+        runTest(StandardTestDispatcher()) {
+            // The #1863 state is exactly the one the keepalive vetoes forever: only the
+            // tmux `-CC` CHANNEL was closed, the SSH transport under it is perfectly
+            // alive, so `transportProvenAliveRecently` keeps returning true and the
+            // #982/#984 deferral would suppress the drop indefinitely. The
+            // definitively-closed arm must bypass that veto.
+            val io = FakeProbeIo(transportProvenAliveRecently = true)
+            io.enqueue(false, false, false)
+            io.channelDefinitivelyClosed = true
+            val probe =
+                LivenessProbe(io, intervalMs = 100, perProbeTimeoutMs = 1_000, failureThreshold = 2)
+            probe.start(this)
+
+            advanceTimeBy(110)
+            runCurrent()
+
+            assertEquals(
+                "issue #1863: a healthy transport keepalive must NOT keep a CLOSED control " +
+                    "channel alive on paper — the dead wire has to be declared",
+                1,
+                io.onProbeFailedCount,
+            )
+            probe.stop()
+        }
+
+    @Test
+    fun `issue 1863 an unanswering but OPEN channel still uses the full ambiguity machinery`() =
+        runTest(StandardTestDispatcher()) {
+            // Guard-rail (G6): the #1863 arm must NOT weaken the no-false-positive
+            // behaviour for a merely-slow channel. With `channelDefinitivelyClosed`
+            // false the threshold + keepalive deferral apply exactly as before.
+            val io = FakeProbeIo(transportProvenAliveRecently = true)
+            io.enqueue(false, false, false, false)
+            val probe =
+                LivenessProbe(io, intervalMs = 100, perProbeTimeoutMs = 1_000, failureThreshold = 2)
+            probe.start(this)
+
+            advanceTimeBy(450)
+            runCurrent()
+
+            assertEquals(
+                "a slow-but-OPEN channel with a live keepalive must still ride through",
                 0,
                 io.onProbeFailedCount,
             )

--- a/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
+++ b/shared/core-tmux/src/main/java/com/pocketshell/core/tmux/TmuxClient.kt
@@ -5,6 +5,7 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.protocol.ControlEvent
 import com.pocketshell.core.tmux.protocol.ControlEventStream
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -1643,6 +1644,39 @@ internal class RealTmuxClient(
                     abandonPendingResponse(pendingCmd, commandWasWritten = writeCompleted.get())
                 }
                 writeJob.cancel()
+                // Issue #1863 — a CALLER-side cancellation is NOT a transport failure, and
+                // must never tear down the connection every other surface shares.
+                //
+                // The #244 `close()` below exists for a STALLED/broken write ("fail stalled
+                // tmux send commands visibly"): the bytes could not reach tmux, so the wire
+                // is suspect and downstream recovery should see a drop. But this catch also
+                // fires when OUR CALLER simply went away — the user pressed Back while a
+                // `[wN]` connect was in flight, so a composition/pane-scoped coroutine that
+                // happened to have a command in flight was cancelled before its write
+                // completed. On base that logged
+                // `tmux-command-write-failed cause=JobCancellationException` and CLOSED the
+                // whole `-CC` client. Worse, that close is SELF-INFLICTED
+                // (`ReaderExitIntent.LocalClose` → `ExplicitClose`), so the passive-drop
+                // classifier deliberately IGNORES it (#1568/#1610 storm guard) — nothing
+                // recovers — while the still-running connect job goes on to publish
+                // `tmux-connect-ready` over the corpse. Permanently dead wire, no re-dial.
+                //
+                // Discriminated on the CALLER's own liveness, not merely on the exception
+                // type: `writeResult` can also complete exceptionally with a cancellation
+                // raised by OUR clientScope during teardown, and that path must keep the
+                // old behaviour (the client is already closing anyway).
+                //
+                // A genuinely wedged write is still covered: the transport dispatcher's
+                // per-op wall-clock ceiling fails it with a NON-cancellation
+                // `TransportOpTimeoutException`, which still closes here.
+                if (t is CancellationException && !currentCoroutineContext().isActive) {
+                    Log.w(
+                        ISSUE_244_DIAG_TAG,
+                        "tmux-command-caller-cancelled kind=${commandKind(cmd)} " +
+                            "writeCompleted=${writeCompleted.get()} (channel kept — #1863)",
+                    )
+                    throw t
+                }
                 if (!writeCompleted.get()) {
                     val kind = commandKind(cmd)
                     Log.w(

--- a/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
+++ b/shared/core-tmux/src/test/java/com/pocketshell/core/tmux/TmuxClientTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeout
@@ -238,6 +239,114 @@ class TmuxClientTest {
                 )
                 assertFalse(result.isError)
                 assertEquals(listOf("session 0: 1 windows"), result.output)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `caller cancelled before its write completes must not close the control channel (issue 1863)`() =
+        runBlocking {
+            // Issue #1863 — THE ROOT CAUSE of the permanently-dead wire.
+            //
+            // Production shape: the user presses Back while a `[wN]` connect is still
+            // in flight. A composition/pane-scoped caller that had a tmux command in
+            // flight is cancelled while parked in `writeResult.await()`, i.e. BEFORE
+            // its line reached the wire (`writeCompleted == false`).
+            //
+            // On BASE the generic write-failure arm then treats that CALLER-side
+            // cancellation as a transport failure and calls `close()` on the SHARED
+            // `-CC` control client:
+            //
+            //   tmux-command-write-failed kind=... cause=JobCancellationException
+            //   tmux-refresh-client-size-error ... TmuxClientException: client is closed
+            //
+            // Because that close is self-inflicted (`ExplicitClose`), the passive-drop
+            // classifier IGNORES it (#1568/#1610 storm guard), so nothing recovers —
+            // and the still-running connect job goes on to publish `tmux-connect-ready`
+            // over the corpse. The wire is dead forever.
+            //
+            // ONE command's caller going away must never tear down the connection every
+            // other surface shares. RED on base (`disconnected` flips true and the
+            // follow-up command fails with "client is closed"); GREEN with the fix.
+            val shell = FakeShell()
+            val session = FakeSession(shell)
+            val client = RealTmuxClient(session, scope)
+            try {
+                client.connect()
+                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.resetStdin()
+
+                // Park the NEXT stdin write so the caller is cancelled strictly BEFORE
+                // its bytes reach the wire — the `writeCompleted == false` arm.
+                shell.blockFutureStdinWrites()
+                val cancelledCaller = scope.launch { client.sendCommand("list-panes") }
+                assertTrue(
+                    "the cancelled caller must actually reach the parked stdin write",
+                    shell.awaitBlockedStdinWrite(ASYNC_AWAIT_TIMEOUT_MS),
+                )
+                cancelledCaller.cancelAndJoin()
+                shell.unblockFutureStdinWrites()
+
+                assertFalse(
+                    "issue #1863: cancelling ONE command's caller must NOT close the shared " +
+                        "tmux -CC control channel — that is the permanently-dead wire",
+                    client.disconnected.value,
+                )
+
+                // ...and the channel is still USABLE: a follow-up command writes and
+                // correlates its own response block.
+                shell.resetStdin()
+                val followUp = scope.async { client.sendCommand("list-sessions") }
+                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                    while (!shell.stdinAsString().contains("list-sessions")) { yield(); delay(5) }
+                }
+                shell.feed(
+                    "%begin 1700000000 7 0\n" +
+                        "session 0: 1 windows\n" +
+                        "%end 1700000000 7 0\n",
+                )
+                val result = withTimeout(ASYNC_AWAIT_TIMEOUT_MS) { followUp.await() }
+                assertEquals(
+                    "the surviving control channel must correlate the follow-up command's " +
+                        "own response block",
+                    7L,
+                    result.number,
+                )
+                assertEquals(listOf("session 0: 1 windows"), result.output)
+            } finally {
+                client.close()
+            }
+        }
+
+    @Test
+    fun `a genuine write failure still closes the control channel (issue 244 preserved)`() =
+        runBlocking {
+            // Issue #1863 guard-rail: the #1863 fix narrows the write-failure close to
+            // NON-cancellation causes only. A REAL write failure (the #244 "fail stalled
+            // tmux send commands visibly" contract) must still close the channel so the
+            // recovery machinery sees a genuine drop. Without this the fix could silently
+            // turn every dead-wire write into an invisible no-op — the opposite mistake.
+            val shell = FakeShell()
+            val session = FakeSession(shell)
+            val client = RealTmuxClient(session, scope)
+            try {
+                client.connect()
+                withTimeout(ASYNC_AWAIT_TIMEOUT_MS) {
+                    while (shell.stdinBytes().isEmpty()) { yield(); delay(10) }
+                }
+                shell.failFutureStdinWrites()
+                val failure = runCatching { client.sendCommand("list-panes") }
+                assertTrue(
+                    "a real write failure must surface to the caller",
+                    failure.exceptionOrNull() is TmuxClientException,
+                )
+                assertTrue(
+                    "a real write failure must still close the control channel (#244)",
+                    client.disconnected.value,
+                )
             } finally {
                 client.close()
             }
@@ -2242,6 +2351,9 @@ class TmuxClientTest {
         fun blockFutureStdinWrites() {
             stdinCapture.blockFutureWrites()
         }
+        fun unblockFutureStdinWrites() {
+            stdinCapture.unblockFutureWrites()
+        }
         fun awaitBlockedStdinWrite(timeoutMs: Long): Boolean =
             stdinCapture.awaitBlockedWrite(timeoutMs)
     }
@@ -2297,6 +2409,18 @@ class TmuxClientTest {
 
         fun blockFutureWrites() {
             blockWrites = true
+        }
+
+        /**
+         * Release a write parked by [blockFutureWrites] (issue #1863) so the same
+         * fake shell can serve a follow-up command after the parked caller was
+         * cancelled — the proof that the control channel survived the cancel.
+         */
+        fun unblockFutureWrites() {
+            synchronized(blockLock) {
+                blockWrites = false
+                blockLock.notifyAll()
+            }
         }
 
         fun awaitBlockedWrite(timeoutMs: Long): Boolean =


### PR DESCRIPTION
Closes #1863

Implements the approved dead-wire/cancelled-connect liveness fix and its class-covering regression coverage. Reviewer approval and D33 evidence: https://github.com/alexeygrigorev/pocketshell/issues/1863#issuecomment-5121083501