### PR TITLE
ci(watcher): make termination reasons unambiguous (#1873)

### DIFF
--- a/.claude/agents/oncall-engineer.md
+++ b/.claude/agents/oncall-engineer.md
@@ -34,6 +34,63 @@ gh run list --repo alexeygrigorev/pocketshell --limit 20
 
 Identify all `failure` runs since the last known-green commit. Group consecutive failures — if 10 pushes in a row all fail at the same step, that's ONE infra problem, not 10 commit defects.
 
+### 1.1 Wait with the sanctioned watcher and preserve its evidence
+
+When the target run is still queued or in progress, run `scripts/watch-ci.py`
+once as a transient user unit. The unit survives if the agent harness kills the
+launching shell, while `--log-file` preserves both heartbeats and the watcher's
+final human summary + JSON:
+
+```bash
+unit="ps-ci-watch-<RUN_ID>"
+watch_log="$PWD/build/$unit.log"
+mkdir -p "$PWD/build"
+systemd-run --user --unit="$unit" --pipe --wait \
+  "$PWD/scripts/watch-ci.py" \
+  --run-id <RUN_ID> \
+  --repo alexeygrigorev/pocketshell \
+  --log-file "$watch_log"
+```
+
+Do not add `--collect` to this recipe. Immediate collection can reap and reset
+the transient unit before `ExecMainStatus` is read, turning a real non-zero
+watcher status into a misleading zero. If the launching shell survives, its
+return code is useful; if it does not, read the final JSON line from
+`"$watch_log"` and the unit journal. After recording the evidence, reap a
+failed retained unit explicitly:
+
+```bash
+tail -n 30 "$watch_log"
+systemctl --user show "$unit" -p ExecMainStatus -p SubState
+journalctl --user -u "$unit" -n 30 --no-pager
+systemctl --user reset-failed "$unit"
+```
+
+The watcher exit is never by itself proof that the GitHub Actions run finished.
+It deliberately fails fast when a required check fails. Always confirm
+`status=completed` directly before treating the conclusion or downloaded
+artifacts as final:
+
+```bash
+gh run view <RUN_ID> --repo alexeygrigorev/pocketshell \
+  --json status,conclusion,url
+```
+
+The final JSON's `exit_reason` and process exit code identify why watching
+stopped:
+
+| Exit | `exit_reason` | Meaning |
+|------|---------------|---------|
+| 0/1/4/5 | `run_completed` | The run completed; `result` distinguishes green, failed, superseded, or no-verdict |
+| 2 | `hang_detected` | No job-state progress for the effective timeout |
+| 3 | `unresolved` | The run or GitHub inputs could not be resolved |
+| 6 | `required_check_failed_fast` | A required check failed but the run is still in flight; artifacts are not final |
+| 7 | `wall_clock_timeout` | The watcher reached its wall-clock cap while the run was still in flight |
+
+For a single-job rerun, do not lower `--no-progress-timeout`. That shape has no
+intermediate job transition during the whole job; the watcher detects it and
+raises an unsafe short value to its job-cap-safe default.
+
 ### 2. Inspect the most-recent failed run
 
 ```bash
@@ -164,12 +221,8 @@ If the failure isn't small-fix material:
 ### 7. Verify your fix (if you pushed one)
 
 ```bash
-# Watch the latest run
+# Resolve the latest run, then use the transient-unit watcher recipe in §1.1.
 gh run list --repo alexeygrigorev/pocketshell --limit 3
-
-# Optionally block until done — the runtime notifies on completion if you use Monitor;
-# otherwise check periodically (NOT in a tight loop)
-gh run watch --repo alexeygrigorev/pocketshell --exit-status
 ```
 
 If new run passes:

--- a/scripts/watch-ci.py
+++ b/scripts/watch-ci.py
@@ -38,15 +38,15 @@ Design goals (see issue #952):
    one. This matches the workflow's own classifier, which already states a
    cancelled attempt "is NOT ... a genuine ... regression".
 
-Exit-code contract (also the final JSON's `result`):
+Final JSON contract: `result` is the semantic CI outcome; `exit_code` and `exit_reason` identify why the watcher stopped, and `run_completed` says whether artifacts are final.
+
+Process exit-code contract (`exit_code`; the semantic `result` may be shared by
+more than one termination path):
 
     0  green       — all REQUIRED checks concluded `success` (or appropriately
                      skipped) and the run is complete.
-    1  failed      — a required check GENUINELY failed (`failure`/`timed_out`/
-                     `startup_failure`/`action_required`). A real failure
-                     outranks a later cancel: red CI is never softened.
-    2  hang         — no job-state progress for --no-progress-timeout, OR the run
-                     exceeded --max-wall-clock. Never wait forever.
+    1  failed      — the RUN COMPLETED with a genuine failure.
+    2  hang         — no job-state progress for --no-progress-timeout.
     3  unresolved  — the run / inputs couldn't be resolved, or `gh` stayed broken
                      past the retry budget.
     4  superseded  — the run was cancelled because a NEWER run for the same
@@ -55,6 +55,10 @@ Exit-code contract (also the final JSON's `result`):
     5  no_verdict  — the run was cancelled (user/API, or we could not tell why),
                      so it produced NO trustworthy verdict. Not a pass, not a
                      failure — unknown. Re-run to get a verdict.
+    6  failed_fast — a required check failed while the RUN IS STILL IN FLIGHT.
+                     Artifacts are not final; confirm the completed run.
+    7  wall_timeout — the watcher reached --max-wall-clock while the run was
+                      still in flight.
 
 This module is import-safe and dependency-injectable: tests construct a Watcher
 with a fake `gh` runner and a fake clock, so the whole state machine (including
@@ -114,6 +118,20 @@ EXIT_CODE = {
     RESULT_SUPERSEDED: 4,
     RESULT_NO_VERDICT: 5,
 }
+
+# Termination paths that deliberately cannot share the result-based codes above.
+# Issue #1873: an exit code must say WHY the watcher stopped, not merely suggest
+# a verdict. In particular, 1 means completed-red while 6 means failed-fast with
+# the run and its artifacts still in flight; 2 and 7 split the two timeout
+# mechanisms.
+EXIT_REQUIRED_CHECK_FAILED_FAST = 6
+EXIT_WALL_CLOCK_TIMEOUT = 7
+
+EXIT_REASON_RUN_COMPLETED = "run_completed"
+EXIT_REASON_REQUIRED_CHECK_FAILED_FAST = "required_check_failed_fast"
+EXIT_REASON_HANG_DETECTED = "hang_detected"
+EXIT_REASON_WALL_CLOCK_TIMEOUT = "wall_clock_timeout"
+EXIT_REASON_UNRESOLVED = "unresolved"
 
 # Terminal (completed) conclusions that mean the job GENUINELY failed.
 #
@@ -550,11 +568,15 @@ class WatchOutcome:
     run_id: Optional[str]
     polls: int
     elapsed_s: float
+    exit_reason: str = EXIT_REASON_RUN_COMPLETED
+    run_completed: bool = True
 
     def to_json(self) -> dict:
         return {
             "result": self.result,
             "exit_code": self.exit_code,
+            "exit_reason": self.exit_reason,
+            "run_completed": self.run_completed,
             "run_id": self.run_id,
             "required": {
                 name: {"status": rc.status, "conclusion": rc.conclusion}
@@ -829,6 +851,8 @@ class Watcher:
         last_state_key: Optional[tuple] = None
         last_progress_at = start
         polls = 0
+        effective_no_progress_timeout_s = self.no_progress_timeout_s
+        single_job_adjustment_reported = False
 
         while True:
             now = self._clock()
@@ -841,6 +865,8 @@ class Watcher:
                     start,
                     polls,
                     last_required={},
+                    exit_code=EXIT_WALL_CLOCK_TIMEOUT,
+                    exit_reason=EXIT_REASON_WALL_CLOCK_TIMEOUT,
                 )
 
             try:
@@ -853,6 +879,29 @@ class Watcher:
             jobs = data.get("jobs") or []
             run_status = str(data.get("status", ""))
             run_conclusion = data.get("conclusion") or None
+
+            # A one-job re-run normally has exactly one transition (running →
+            # completed), so there may be no observable progress for the whole
+            # job duration. Defensively reject a shorter caller override and use
+            # the #1650 job-cap-safe default. The adjustment is explicit so the
+            # caller knows its requested timeout was not applied.
+            if (
+                run_status != "completed"
+                and len(jobs) == 1
+                and effective_no_progress_timeout_s
+                < DEFAULT_NO_PROGRESS_TIMEOUT_S
+            ):
+                effective_no_progress_timeout_s = DEFAULT_NO_PROGRESS_TIMEOUT_S
+                if not single_job_adjustment_reported:
+                    adjustment = (
+                        "watch-ci: single-job rerun detected; raising unsafe "
+                        f"--no-progress-timeout from {self.no_progress_timeout_s:.0f}s "
+                        f"to {effective_no_progress_timeout_s:.0f}s because a "
+                        "single job has no intermediate state transitions"
+                    )
+                    self._notice(adjustment)
+                    self._heartbeat(adjustment)
+                    single_job_adjustment_reported = True
 
             state_key = job_state_key(jobs)
             if state_key != last_state_key:
@@ -868,15 +917,17 @@ class Watcher:
                 return self._finalize(verdict, jobs, run_id, start, polls, run=data)
 
             # No-progress timeout (catches queued-forever / no-runner too).
-            if now - last_progress_at >= self.no_progress_timeout_s:
+            if now - last_progress_at >= effective_no_progress_timeout_s:
                 return self._hang(
                     "no job-state progress for "
-                    f"--no-progress-timeout ({self.no_progress_timeout_s:.0f}s); "
+                    f"--no-progress-timeout ({effective_no_progress_timeout_s:.0f}s); "
                     f"run still {run_status or 'unknown'}",
                     run_id,
                     start,
                     polls,
                     last_required=verdict.required,
+                    exit_code=EXIT_CODE[RESULT_HANG],
+                    exit_reason=EXIT_REASON_HANG_DETECTED,
                 )
 
             self._sleep(self.interval_s)
@@ -888,6 +939,8 @@ class Watcher:
         reason = verdict.reason
         signature = None
         likely_infra = False
+        run_completed = str((run or {}).get("status") or "") == "completed"
+        failed_fast = result == RESULT_FAILED and not run_completed
 
         # A signature is ONLY ever captured for a genuine failure. A cancelled /
         # superseded run has no failure to diagnose, so any signature attached
@@ -915,7 +968,11 @@ class Watcher:
 
         return WatchOutcome(
             result=result,
-            exit_code=EXIT_CODE[result],
+            exit_code=(
+                EXIT_REQUIRED_CHECK_FAILED_FAST
+                if failed_fast
+                else EXIT_CODE[result]
+            ),
             required=verdict.required,
             failing_jobs=verdict.failing_jobs,
             signature=signature,
@@ -924,12 +981,28 @@ class Watcher:
             run_id=run_id,
             polls=polls,
             elapsed_s=self._clock() - start,
+            exit_reason=(
+                EXIT_REASON_REQUIRED_CHECK_FAILED_FAST
+                if failed_fast
+                else EXIT_REASON_RUN_COMPLETED
+            ),
+            run_completed=run_completed,
         )
 
-    def _hang(self, reason, run_id, start, polls, last_required) -> WatchOutcome:
+    def _hang(
+        self,
+        reason,
+        run_id,
+        start,
+        polls,
+        last_required,
+        *,
+        exit_code,
+        exit_reason,
+    ) -> WatchOutcome:
         return WatchOutcome(
             result=RESULT_HANG,
-            exit_code=EXIT_CODE[RESULT_HANG],
+            exit_code=exit_code,
             required=last_required,
             failing_jobs=[],
             signature=None,
@@ -938,6 +1011,8 @@ class Watcher:
             run_id=run_id,
             polls=polls,
             elapsed_s=self._clock() - start,
+            exit_reason=exit_reason,
+            run_completed=False,
         )
 
     def _unresolved(self, reason, run_id, start, polls) -> WatchOutcome:
@@ -952,6 +1027,8 @@ class Watcher:
             run_id=run_id,
             polls=polls,
             elapsed_s=self._clock() - start,
+            exit_reason=EXIT_REASON_UNRESOLVED,
+            run_completed=False,
         )
 
 
@@ -997,6 +1074,15 @@ def render_human_summary(outcome: WatchOutcome) -> str:
         ),
     }[outcome.result]
     lines.append(f"watch-ci: {headline}")
+    if outcome.exit_reason == EXIT_REASON_REQUIRED_CHECK_FAILED_FAST:
+        lines.append(
+            "  WARNING: RUN IS STILL IN FLIGHT; this is a required-check "
+            "failed-fast exit, and artifacts are not final."
+        )
+        lines.append(
+            "  action: confirm the run reaches status=completed before treating "
+            "its conclusion or artifacts as authoritative."
+        )
     if outcome.run_id:
         lines.append(
             f"  run: {outcome.run_id}  ({outcome.polls} polls, {outcome.elapsed_s:.0f}s)"
@@ -1036,10 +1122,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
         description=(
             "Token-free, hang-proof GitHub Actions run watcher. Runs ONCE, blocks "
             "while the run is in flight (zero LLM tokens while waiting), then prints "
-            "a compact summary + a final JSON line. Exit: 0 green / 1 real-fail / "
+            "a compact summary + a final JSON line. The JSON result is the CI "
+            "semantic outcome; exit_code and exit_reason identify why watching "
+            "stopped. Exit: 0 green / 1 real-fail / "
             "2 hang / 3 unresolved / 4 superseded (a newer run replaced this one — "
             "routine on main, NOT a failure) / 5 no-verdict (cancelled, so nothing "
-            "was decided)."
+            "was decided) / 6 required-check failed-fast (run still in flight) / "
+            "7 wall-clock timeout."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -1065,13 +1154,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=float,
         default=DEFAULT_NO_PROGRESS_TIMEOUT_S,
         help="Exit 2 (hang) if no job changes state for this many seconds "
-        "(also catches queued-forever / no-runner).",
+        "(also catches queued-forever / no-runner). Unsafe shorter values are "
+        "raised to the job-cap-safe default when a single-job rerun is detected.",
     )
     p.add_argument(
         "--max-wall-clock",
         type=float,
         default=DEFAULT_MAX_WALL_CLOCK_S,
-        help="Exit 2 (hang) if the run exceeds this many seconds total.",
+        help="Exit 7 (wall-clock timeout) if the run exceeds this many seconds total.",
     )
     p.add_argument(
         "--required-check",
@@ -1128,13 +1218,21 @@ def main(argv: Optional[list[str]] = None) -> int:
             branch=args.branch,
             workflow=args.workflow,
         )
+        summary = render_human_summary(outcome)
+        final_json = json.dumps(outcome.to_json(), sort_keys=True)
+        if log_fh is not None:
+            # Issue #1873: the launching shell / `systemd-run --pipe` may vanish
+            # while the transient unit survives. Persist the verdict in the
+            # same durable file as the heartbeats before closing it.
+            log_fh.write(f"{summary}\n{final_json}\n")
+            log_fh.flush()
     finally:
         if log_fh is not None:
             log_fh.close()
 
     # Compact, token-cheap output: human summary then the final JSON line.
-    print(render_human_summary(outcome))
-    print(json.dumps(outcome.to_json(), sort_keys=True))
+    print(summary)
+    print(final_json)
     return outcome.exit_code
 
 

--- a/tools/pocketshell/tests/test_watch_ci.py
+++ b/tools/pocketshell/tests/test_watch_ci.py
@@ -10,10 +10,12 @@ Exit-code contract under test:
 
     0  green       — all required checks passed
     1  failed      — a required check GENUINELY failed
-    2  hang         — no progress past --no-progress-timeout OR wall-clock cap
+    2  hang         — no progress past --no-progress-timeout
     3  unresolved  — run / inputs couldn't be resolved (or gh stayed broken)
     4  superseded  — a newer run replaced this one (routine concurrency-cancel)
     5  no_verdict  — cancelled, so no verdict was reached (issue #1650)
+    6  failed_fast  — required check failed while the run is still in flight
+    7  wall_timeout — max wall-clock reached while the run is still in flight
 
 The load-bearing case is the HANG one: a run whose jobs NEVER change state must
 exit 2, not loop forever. The test drives a virtual clock so a stalled run is
@@ -33,6 +35,7 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WATCH_CI_PATH = _REPO_ROOT / "scripts" / "watch-ci.py"
+_ONCALL_PROMPT_PATH = _REPO_ROOT / ".claude" / "agents" / "oncall-engineer.md"
 
 
 def _load_module():
@@ -193,11 +196,37 @@ def test_required_failure_exits_1_and_names_job():
     outcome = watcher.watch(run_id="123")
     assert outcome.result == wci.RESULT_FAILED
     assert outcome.exit_code == 1
+    assert outcome.exit_reason == wci.EXIT_REASON_RUN_COMPLETED
+    assert outcome.run_completed is True
     assert "Unit tests" in outcome.failing_jobs
     # Signature captured from the failed-step log.
     assert outcome.signature is not None
     assert "FAILED" in outcome.signature
     assert outcome.likely_infra is False
+
+
+def test_required_failure_while_run_in_progress_has_distinct_fail_fast_exit():
+    """Issue #1873: an early required-check failure is not a completed run.
+
+    The distinct exit code + cause prevent an on-call from treating the
+    watcher's exit as evidence that artifacts are final.
+    """
+    gh = FakeGh()
+    jobs = _all_required_jobs("in_progress", None)
+    jobs[0] = _job("Unit tests", "completed", "failure", db_id=99)
+    gh.queue_run_state(status="in_progress", conclusion=None, jobs=jobs)
+    gh.log_text = "Unit tests\tRun pytest\t2026-07-29T10:00:00Z BUILD FAILED\n"
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="123")
+
+    assert outcome.result == wci.RESULT_FAILED
+    assert outcome.exit_code == wci.EXIT_REQUIRED_CHECK_FAILED_FAST
+    assert outcome.exit_reason == wci.EXIT_REASON_REQUIRED_CHECK_FAILED_FAST
+    assert outcome.run_completed is False
+    summary = wci.render_human_summary(outcome)
+    assert "RUN IS STILL IN FLIGHT" in summary
+    assert "artifacts are not final" in summary
 
 
 def test_cancelled_run_is_not_a_failure():
@@ -246,6 +275,8 @@ def test_no_progress_stall_exits_2_does_not_loop_forever():
     outcome = watcher.watch(run_id="123")
     assert outcome.result == wci.RESULT_HANG
     assert outcome.exit_code == 2
+    assert outcome.exit_reason == wci.EXIT_REASON_HANG_DETECTED
+    assert outcome.run_completed is False
     assert "no job-state progress" in outcome.reason
     # Proven bounded: it stopped well before the wall-clock cap.
     assert clock.now() < 200.0
@@ -269,12 +300,11 @@ def test_progress_then_stall_resets_no_progress_window():
     assert outcome.exit_code == 2
 
 
-# ── 2 hang: wall-clock cap ───────────────────────────────────────────────────
+# ── 7 wall-clock timeout ─────────────────────────────────────────────────────
 
 
-def test_over_wall_clock_exits_2():
-    """A run that keeps making progress but never finishes hits the wall-clock
-    cap and exits 2 — never waits forever even while 'progressing'."""
+def test_over_wall_clock_exits_7():
+    """A progressing run that never finishes gets the distinct wall-time code."""
     gh = FakeGh()
     # Each poll reports a DIFFERENT job state so the no-progress timer keeps
     # resetting; only the wall-clock cap can stop it.
@@ -289,9 +319,47 @@ def test_over_wall_clock_exits_2():
     )
     outcome = watcher.watch(run_id="123")
     assert outcome.result == wci.RESULT_HANG
-    assert outcome.exit_code == 2
+    assert outcome.exit_code == wci.EXIT_WALL_CLOCK_TIMEOUT
+    assert outcome.exit_reason == wci.EXIT_REASON_WALL_CLOCK_TIMEOUT
     assert "wall-clock" in outcome.reason
     assert clock.now() >= 50.0
+
+
+def test_single_job_rerun_defensively_raises_too_short_no_progress_timeout():
+    """Issue #1873: a one-job rerun has no intermediate transitions.
+
+    A caller-provided 3000s timeout must not falsely classify a healthy
+    52-minute job as hung; detecting the one-job shape raises the effective
+    guard to the watcher-safe default.
+    """
+    gh = FakeGh()
+    single_job = [_job("Unit tests", "in_progress", None, db_id=99)]
+    for _ in range(313):
+        gh.queue_run_state(
+            status="in_progress",
+            conclusion=None,
+            jobs=single_job,
+        )
+    gh.queue_run_state(
+        status="completed",
+        conclusion="success",
+        jobs=[_job("Unit tests", "completed", "success", db_id=99)],
+    )
+    notices: list[str] = []
+    watcher, clock = _make_watcher(
+        gh,
+        interval_s=10.0,
+        no_progress_timeout_s=3000.0,
+        max_wall_clock_s=10000.0,
+        notice=notices.append,
+    )
+
+    outcome = watcher.watch(run_id="123")
+
+    assert clock.now() > 3000.0
+    assert outcome.result == wci.RESULT_GREEN
+    assert any("single-job rerun" in notice for notice in notices)
+    assert any("6000s" in notice for notice in notices)
 
 
 # ── 3 unresolved ─────────────────────────────────────────────────────────────
@@ -567,6 +635,39 @@ def test_help_documents_flags(capsys):
         assert flag in help_text
 
 
+def test_help_states_exact_wall_clock_exit_and_json_field_relationship():
+    """Reviewer follow-up: public wording is part of the exit contract.
+
+    Merely asserting that the flags exist let contradictory exit-2/exit-7 help
+    stay green. Assert the option and JSON-field contract at their sources so
+    argparse wrapping cannot weaken the check.
+    """
+    parser = wci.build_arg_parser()
+    max_wall_clock = next(
+        action
+        for action in parser._actions
+        if "--max-wall-clock" in action.option_strings
+    )
+
+    assert max_wall_clock.help == (
+        "Exit 7 (wall-clock timeout) if the run exceeds this many seconds total."
+    )
+    assert (
+        "The JSON result is the CI semantic outcome; exit_code and exit_reason "
+        "identify why watching stopped."
+    ) in parser.description
+
+
+def test_module_header_distinguishes_semantic_result_from_termination_contract():
+    """The module-level public contract must not equate result with exit cause."""
+    assert (
+        "Final JSON contract: `result` is the semantic CI outcome; `exit_code` "
+        "and `exit_reason` identify why the watcher stopped, and `run_completed` "
+        "says whether artifacts are final."
+    ) in wci.__doc__
+    assert "Exit-code contract (also the final JSON's `result`)" not in wci.__doc__
+
+
 def test_main_prints_compact_summary_and_json(monkeypatch, capsys):
     """main() should print a human summary + a final parseable JSON line and
     return the contract exit code, with stdout staying compact."""
@@ -589,6 +690,43 @@ def test_main_prints_compact_summary_and_json(monkeypatch, capsys):
     assert "required" in payload
 
 
+def test_main_writes_final_summary_and_json_to_log_file(monkeypatch, tmp_path, capsys):
+    """Issue #1873 owner follow-up: stdout may disappear with its wrapper.
+
+    The durable log must therefore contain the exact final human summary and
+    machine-readable JSON verdict, not only polling heartbeats.
+    """
+    gh = FakeGh()
+    gh.queue_run_state(status="completed", conclusion="success", jobs=_all_required_jobs())
+    monkeypatch.setattr(wci, "GhRunner", lambda *a, **k: gh)
+    log_path = tmp_path / "watch.log"
+
+    rc = wci.main(
+        ["--run-id", "123", "--quiet", "--log-file", str(log_path)]
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out.strip()
+    durable = log_path.read_text(encoding="utf-8")
+    assert stdout in durable
+    payload = json.loads(durable.strip().splitlines()[-1])
+    assert payload["result"] == "green"
+    assert payload["exit_reason"] == wci.EXIT_REASON_RUN_COMPLETED
+    assert payload["run_completed"] is True
+
+
+def test_oncall_recipe_preserves_verdict_and_requires_completed_confirmation():
+    """Issue #1873: the durable operating instructions must close both traps."""
+    prompt = _ONCALL_PROMPT_PATH.read_text(encoding="utf-8")
+
+    assert "Do not add `--collect`" in prompt
+    assert "--log-file" in prompt
+    assert "systemctl --user reset-failed" in prompt
+    assert "Always confirm\n`status=completed`" in prompt
+    assert "required_check_failed_fast" in prompt
+    assert "artifacts are not final" in prompt
+
+
 def test_render_human_summary_under_25_lines_on_failure():
     outcome = wci.WatchOutcome(
         result=wci.RESULT_FAILED,
@@ -601,6 +739,8 @@ def test_render_human_summary_under_25_lines_on_failure():
         run_id="123",
         polls=4,
         elapsed_s=42.0,
+        exit_reason=wci.EXIT_REASON_RUN_COMPLETED,
+        run_completed=True,
     )
     text = wci.render_human_summary(outcome)
     assert text.count("\n") < 25

--- a/tools/pocketshell/tests/test_watch_ci_cancelled.py
+++ b/tools/pocketshell/tests/test_watch_ci_cancelled.py
@@ -526,7 +526,7 @@ def test_healthy_long_running_emulator_shard_is_not_a_hang():
     assert outcome.exit_code == 0
 
 
-# ── The exit-code contract stays a single source of truth ────────────────────
+# ── The exit-code contract stays complete and distinct ───────────────────────
 
 
 def test_exit_code_contract_is_complete_and_distinct():
@@ -537,6 +537,15 @@ def test_exit_code_contract_is_complete_and_distinct():
     assert codes[wci.RESULT_UNRESOLVED] == 3
     assert codes[wci.RESULT_SUPERSEDED] == 4
     assert codes[wci.RESULT_NO_VERDICT] == 5
+    assert wci.EXIT_REQUIRED_CHECK_FAILED_FAST == 6
+    assert wci.EXIT_WALL_CLOCK_TIMEOUT == 7
+    assert len(
+        {
+            *codes.values(),
+            wci.EXIT_REQUIRED_CHECK_FAILED_FAST,
+            wci.EXIT_WALL_CLOCK_TIMEOUT,
+        }
+    ) == 8
     # Every result must render a headline (no KeyError on a new verdict).
     for result in codes:
         outcome = wci.WatchOutcome(


### PR DESCRIPTION
Closes #1873

Implements the independently approved watcher exit-contract, durable-log, and transient-unit recipe corrections. Final approval: https://github.com/alexeygrigorev/pocketshell/issues/1873#issuecomment-5122732258