### PR TITLE
connection: wait for tmux reveal before publishing live (#1887)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionManager.kt
@@ -319,11 +319,16 @@ class ConnectionManager(
 
     /**
      * Within-grace foreground reattach promotion: the warm `-CC` channel was NEVER torn down,
-     * so [ConnectionEvent.TransportLive] promotes [ConnectionState.Reattaching] →
-     * [ConnectionState.Live] WITHOUT any handshake. Idempotent for an already-Live target.
+     * so this explicit control-channel confirmation promotes [ConnectionState.Reattaching] →
+     * [ConnectionState.Live] WITHOUT any handshake. Issue #1887 deliberately does NOT use
+     * [ConnectionEvent.TransportLive] here: that event is the SSH lease-up signal and now
+     * stops at [ConnectionState.Attaching] until tmux is confirmed. A target-tagged synthetic
+     * seed is valid on this one preserved-runtime path because the already-rendered pane and
+     * its control channel both survived the grace window. Idempotent for an already-Live target.
      */
     fun observeForegroundReattachLive() {
-        controller.submit(ConnectionEvent.TransportLive)
+        val target = controller.state.value.targetIdOrNull() ?: return
+        controller.submit(ConnectionEvent.SeedLanded(target, paneId = "preserved-control-channel"))
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
@@ -739,9 +739,11 @@ class ConnectionEffectDriverTest {
         )
 
         transportPort.transportEventsFlow.emit(TransportUpDown.Up(host))
+        assertEquals(ConnectionState.Attaching(host, sessionA), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(sessionA, "%0"))
         assertEquals(ConnectionState.Live(host, sessionA), controller.state.value)
         assertEquals(
-            "healing lease Up returns to Live for the same target without re-firing recovery",
+            "target-tagged seed returns to Live without re-firing recovery",
             listOf(client to ConnectionState.Reattaching(host, sessionA)),
             effects,
         )
@@ -873,9 +875,11 @@ class ConnectionEffectDriverTest {
 
         transportPort.transportEventsFlow.emit(TransportUpDown.Up(host))
 
+        assertEquals(ConnectionState.Attaching(host, sessionA), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(sessionA, "%0"))
         assertEquals(ConnectionState.Live(host, sessionA), controller.state.value)
         assertEquals(
-            "the Down and the healing Up each re-project once; no duplicate Down effect",
+            "the Down and healing Up each re-project once; seed confirmation is controller-owned",
             2,
             projections,
         )
@@ -1005,6 +1009,51 @@ class ConnectionEffectDriverTest {
         h.controller.submit(ConnectionEvent.TransportDropped(DropCause.RemoteFailure("keepalive"))) // -> Reattaching
 
         assertEquals(listOf("Idle", "Attaching", "Live", "Reattaching"), h.stateNames())
+        scope.cancel()
+    }
+
+    /**
+     * Issue #1887 — a recovered SSH lease is only the carrier for the next tmux
+     * control-channel attach. It must not claim the session is Live before that
+     * attach has seeded/revealed its pane.
+     *
+     * #1863 made the race visible: the dead-channel probe correctly moved Live
+     * to Reattaching, then the reconnect acquired a fresh SSH lease while its
+     * replacement `-CC` attach was still in flight. The driver's lease-Up feed
+     * promoted Reattaching straight back to Live, so the UI briefly reclaimed
+     * Connected over the dead/unfinished control channel. Under full-suite load
+     * that false-Live window was where the one-interval oracle landed.
+     */
+    @Test
+    fun leaseUpDuringRecoveryWaitsInAttachingUntilTmuxReveal() = runTest {
+        val scope = driverScope()
+        val h = Harness(scope, TestClock(), warm = true)
+
+        h.controller.submit(ConnectionEvent.Enter(host, sessionA))
+        h.controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0"))
+        h.controller.submit(
+            ConnectionEvent.TransportDropped(DropCause.RemoteFailure("dead_control_channel")),
+        )
+        assertTrue(h.controller.state.value is ConnectionState.Reattaching)
+
+        // RED on the #1863 base: lease Up was treated as a completed recovery
+        // and jumped directly to Live, before any replacement tmux seed landed.
+        h.transportPort.transportEventsFlow.emit(TransportUpDown.Up(host))
+
+        assertTrue(
+            "issue #1887: SSH lease Up must wait in Attaching; only the replacement " +
+                "tmux attach/reveal may publish Live — got ${h.controller.state.value}",
+            h.controller.state.value is ConnectionState.Attaching,
+        )
+        assertEquals(
+            listOf("Idle", "Attaching", "Live", "Reattaching", "Attaching"),
+            h.stateNames(),
+        )
+
+        // The real attach's target-tagged seed remains the sole successful-recovery
+        // reveal and still promotes the same target to Live.
+        h.controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%1"))
+        assertTrue(h.controller.state.value is ConnectionState.Live)
         scope.cancel()
     }
 

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionController.kt
@@ -701,16 +701,27 @@ class ConnectionController(
     }
 
     /**
-     * Transport healed / lease connected. Reattaching and Reconnecting resolve to
-     * [Live] on the same target (silent recovery). A spurious live signal in
-     * another state is ignored.
+     * The SSH transport connected. This proves only that the carrier for the tmux
+     * control channel is available; it does NOT prove that the replacement `-CC`
+     * attach has completed or that a pane is safe to reveal.
+     *
+     * Issue #1887: recovery used to map Reattaching/Reconnecting straight to
+     * [ConnectionState.Live]. A fresh lease therefore reclaimed displayed
+     * `Connected` while the replacement tmux attach was still in flight — exactly
+     * the false-live window #1863's one-interval proof caught under full-suite load.
+     * Every transport-up path now waits in [ConnectionState.Attaching]. The
+     * target-tagged [ConnectionEvent.SeedLanded] (or the facade's explicit
+     * preserved-control-channel confirmation) is the sole recovery promotion to
+     * [ConnectionState.Live].
+     *
+     * A spurious live signal in another state is ignored.
      */
     private fun onTransportLive(current: ConnectionState): ConnectionState =
         when (current) {
-            // Issue #1633: entering Live starts the stability window — it does NOT commit
-            // the episode. "The dial succeeded" is not "the connection recovered".
-            is ConnectionState.Reattaching -> liveAt(current.host, current.targetId)
-            is ConnectionState.Reconnecting -> liveAt(current.host, current.targetId)
+            is ConnectionState.Reattaching ->
+                ConnectionState.Attaching(current.host, current.targetId)
+            is ConnectionState.Reconnecting ->
+                ConnectionState.Attaching(current.host, current.targetId)
             is ConnectionState.Connecting -> ConnectionState.Attaching(current.host, current.targetId)
             else -> current
         }

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerCoverageFirstTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerCoverageFirstTest.kt
@@ -114,8 +114,10 @@ class ConnectionControllerCoverageFirstTest {
         // error band; the live channel heals.
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
-        // And it resolves back to Live with no band ever shown.
+        // SSH recovery alone cannot reveal a dead/unattached control channel.
         controller.submit(ConnectionEvent.TransportLive)
+        assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(ConnectionState.Live(host, a), controller.state.value)
     }
 
@@ -134,6 +136,9 @@ class ConnectionControllerCoverageFirstTest {
         assertEquals(RevealDecision.Hold(a), controller.revealGate.value)
 
         controller.submit(ConnectionEvent.TransportLive)
+        assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
+        assertEquals(RevealDecision.Hold(a), controller.revealGate.value)
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(ConnectionState.Live(host, a), controller.state.value)
         assertEquals(RevealDecision.Reveal(a, inputEnabled = true), controller.revealGate.value)
     }
@@ -164,8 +169,10 @@ class ConnectionControllerCoverageFirstTest {
         assertEquals(a, controller.state.value.targetIdOrNull())
 
         controller.submit(ConnectionEvent.TransportLive)
+        assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(
-            "transport recovery must return to Live on the original target",
+            "target-tagged control-channel recovery must return to Live on the original target",
             ConnectionState.Live(host, a),
             controller.state.value,
         )

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerNetworkChangedTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerNetworkChangedTest.kt
@@ -60,8 +60,11 @@ class ConnectionControllerNetworkChangedTest {
         // Proactive silent reconnect via the Reconnecting ladder — NOT Unreachable.
         assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1), controller.state.value)
 
-        // And it resolves back to Live with no error band ever shown.
+        // SSH is available again, but the replacement control channel is not
+        // displayable until its target-tagged seed lands.
         controller.submit(ConnectionEvent.TransportLive)
+        assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(ConnectionState.Live(host, a), controller.state.value)
     }
 

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/ConnectionControllerTest.kt
@@ -93,8 +93,11 @@ class ConnectionControllerTest {
         controller.submit(ConnectionEvent.Foreground)
 
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
-        // It heals silently to Live, never entering Reconnecting.
+        // It heals silently, never entering Reconnecting. The preserved control
+        // channel must still be confirmed before the target is revealed.
         controller.submit(ConnectionEvent.TransportLive)
+        assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(ConnectionState.Live(host, a), controller.state.value)
     }
 
@@ -127,8 +130,11 @@ class ConnectionControllerTest {
         controller.submit(ConnectionEvent.Foreground)
 
         assertEquals(ConnectionState.Reconnecting(host, a, attempt = 1), controller.state.value)
-        // Silent: no error band; resolves to Live on transport-live.
+        // Silent: no error band. SSH-up waits for the replacement control
+        // channel's target-tagged seed before resolving to Live.
         controller.submit(ConnectionEvent.TransportLive)
+        assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(ConnectionState.Live(host, a), controller.state.value)
     }
 
@@ -251,6 +257,8 @@ class ConnectionControllerTest {
         assertEquals(ConnectionState.Reattaching(host, a), controller.state.value)
 
         controller.submit(ConnectionEvent.TransportLive)
+        assertEquals(ConnectionState.Attaching(host, a), controller.state.value)
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0"))
         assertEquals(ConnectionState.Live(host, a), controller.state.value)
     }
 
@@ -318,7 +326,10 @@ class ConnectionControllerTest {
         controller.submit(ConnectionEvent.Foreground) // Reconnecting
         assertEquals(RevealDecision.Hold(a), controller.revealGate.value)
 
-        controller.submit(ConnectionEvent.TransportLive) // Live
+        controller.submit(ConnectionEvent.TransportLive) // Attaching
+        assertEquals(RevealDecision.Hold(a), controller.revealGate.value)
+
+        controller.submit(ConnectionEvent.SeedLanded(a, "%0")) // Live
         assertEquals(RevealDecision.Reveal(a, inputEnabled = true), controller.revealGate.value)
     }
 


### PR DESCRIPTION
Closes #1887

Urgent main-red recovery. Prevents a recovery SSH lease from publishing displayed Live before the tmux attach/reveal has landed. Independent approval and red→green/full-gate/real-transport/emulator evidence: https://github.com/alexeygrigorev/pocketshell/issues/1887#issuecomment-5124386713