### PR TITLE
test: stabilize full-suite coroutine teardown (#1615, #1887, #1892)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.hosts
 import com.pocketshell.app.tmux.LivenessProbeTestOverride
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -34,7 +35,12 @@ import org.junit.runner.Description
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(
-    internal val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+    // Give every default rule its own scheduler explicitly. The implicit
+    // constructor adopts an already-installed test Main scheduler, which can
+    // bind a newly constructed test class to another class's clock in the
+    // long-lived full-suite worker (#1892).
+    internal val dispatcher: TestDispatcher =
+        UnconfinedTestDispatcher(TestCoroutineScheduler()),
 ) : TestRule {
     private val beforeResetMain = mutableListOf<() -> Unit>()
 

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRuleTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRuleTest.kt
@@ -1,0 +1,49 @@
+package com.pocketshell.app.hosts
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRuleTest {
+
+    @Test
+    fun defaultDispatcherDoesNotAdoptMainSchedulerInstalledDuringRuleConstruction() {
+        // Issue #1892 recurrence: a focused ShareViewModelTest is green, but the
+        // long-lived full-suite fork can construct its rule while another class
+        // still owns process-global Main. The implicit dispatcher constructor
+        // adopts that foreign scheduler, so runTest and ViewModel work no longer
+        // share one live clock and the later test hits UncompletedCoroutinesError.
+        repeat(100) { iteration ->
+            val foreignDispatcher = StandardTestDispatcher()
+            Dispatchers.setMain(foreignDispatcher)
+            val rule = try {
+                MainDispatcherRule()
+            } finally {
+                Dispatchers.resetMain()
+            }
+
+            val assertion = object : Statement() {
+                override fun evaluate() {
+                    assertNotSame(
+                        "iteration $iteration: a default rule created while another test owns " +
+                            "Main must not inherit that test's scheduler",
+                        foreignDispatcher.scheduler,
+                        rule.dispatcher.scheduler,
+                    )
+                }
+            }
+
+            rule.apply(
+                assertion,
+                Description.createTestDescription(javaClass, "foreign-main-construction-$iteration"),
+            ).evaluate()
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1863DeadWireAfterCancelledConnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1863DeadWireAfterCancelledConnectTest.kt
@@ -16,6 +16,7 @@ import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
+import com.pocketshell.testsupport.drainMainLooperUntil
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -111,9 +112,23 @@ class Issue1863DeadWireAfterCancelledConnectTest {
     fun connectMustNotPublishLiveWhenTheControlChannelDiedMidAttach() = fixture.runVmTest {
         val dying = FakeTmuxClient().withSinglePaneRow("work", "%1")
         val parked = dying.parkAttachAt(ATTACH_PARK_PREFIX, ATTACH_PARK_OCCURRENCE)
+        // Production creates a FRESH control client for the recovery. The old
+        // fixture returned `dying` forever, forcing every replacement attach over
+        // the same closed fake and leaving its recovery coroutine in teardown.
+        // Park a healthy replacement so the body can first assert the false-Live
+        // window is closed, then explicitly release and drain the spawned recovery.
+        val recovery = FakeTmuxClient().withSinglePaneRow("work", "%1")
+        val recoveryParked = recovery.parkAttachAt(ATTACH_PARK_PREFIX, occurrence = 1)
+        val recoveryFactoryCalled = CompletableDeferred<Unit>()
+        val clients = ArrayDeque(listOf(dying, recovery))
 
         val vm = freshVmForForegrounded()
-        vm.setTmuxClientFactoryForTest { _, _, _ -> dying }
+        vm.setTmuxClientFactoryForTest { _, _, _ ->
+            val client =
+                clients.removeFirstOrNull() ?: error("unexpected extra tmux client factory call")
+            if (client === recovery) recoveryFactoryCalled.complete(Unit)
+            client
+        }
         vm.doConnect()
         advanceUntilIdle()
 
@@ -127,13 +142,17 @@ class Issue1863DeadWireAfterCancelledConnectTest {
         advanceUntilIdle()
 
         assertTheReportedTerminalStateIsUnreachable(vm, dying)
-        drainRecoveryBeforeTheQuiescenceOracle(vm)
         // COLD-PATH-ONLY, and discriminating here (see the helper's KDoc): on base the
         // reveal lit the green dot over the corpse. This is the user-visible symptom.
         assertFalse(
             "issue #1863: a connect that resolved over a CLOSED control channel must not " +
                 "publish a live session — got ${vm.connectionStatus.value}",
             vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        completeSpawnedRecoveryBeforeTheQuiescenceOracle(
+            vm,
+            recoveryFactoryCalled,
+            recoveryParked,
         )
     }
 
@@ -145,11 +164,17 @@ class Issue1863DeadWireAfterCancelledConnectTest {
         val first = FakeTmuxClient().withSinglePaneRow("work", "%1")
         val dying = FakeTmuxClient().withSinglePaneRow("other", "%2")
         val parked = dying.parkAttachAt(ATTACH_PARK_PREFIX, ATTACH_PARK_OCCURRENCE)
-        val clients = ArrayDeque(listOf(first, dying))
+        val recovery = FakeTmuxClient().withSinglePaneRow("other", "%2")
+        val recoveryParked = recovery.parkAttachAt(ATTACH_PARK_PREFIX, occurrence = 1)
+        val recoveryFactoryCalled = CompletableDeferred<Unit>()
+        val clients = ArrayDeque(listOf(first, dying, recovery))
 
         val vm = freshVmForForegrounded()
         vm.setTmuxClientFactoryForTest { _, _, _ ->
-            clients.removeFirstOrNull() ?: error("unexpected extra tmux client factory call")
+            val client =
+                clients.removeFirstOrNull() ?: error("unexpected extra tmux client factory call")
+            if (client === recovery) recoveryFactoryCalled.complete(Unit)
+            client
         }
         vm.doConnect(sessionName = "work")
         advanceUntilIdle()
@@ -168,31 +193,70 @@ class Issue1863DeadWireAfterCancelledConnectTest {
         advanceUntilIdle()
 
         assertTheReportedTerminalStateIsUnreachable(vm, dying)
-        drainRecoveryBeforeTheQuiescenceOracle(vm)
+        completeSpawnedRecoveryBeforeTheQuiescenceOracle(
+            vm,
+            recoveryFactoryCalled,
+            recoveryParked,
+        )
     }
 
     /**
-     * Drain the recovery this journey deliberately provokes, BEFORE the fixture's #1355
-     * quiescence oracle runs.
+     * Prove the reveal-guard journey itself is complete, then release and drain the
+     * explicitly parked healthy recovery BEFORE the fixture's #1355 quiescence oracle.
      *
-     * Both journeys deliberately end with the connection core mid-recovery, and the
-     * fixture's drain loops `cancelOwnScopes()` + `runCurrent()` — it never ADVANCES the
-     * virtual clock. So any teardown work the cancellation schedules at a future virtual
-     * time can never complete there, and the oracle hard-fails on a still-`Cancelling`
-     * child after burning its 30s wall-clock budget. Measured, not theorised: with only
-     * `cancelConnect()` + `advanceUntilIdle()` in the body this failed 2 of 8 consecutive
-     * FULL `:app:testReleaseUnitTest` runs while passing every run in isolation.
+     * The pre-recurrence fixture returned the already-closed [FakeTmuxClient] for every
+     * factory call. Production never does that: recovery creates a fresh control client.
+     * The point-in-time reveal assertions therefore finished while a SECOND attach over
+     * the same corpse churned in the background. Release/full-graph ordering handed that
+     * job to generic teardown, where it intermittently stayed `Cancelling` for 30s.
      *
-     * `onTeardown` callbacks run INSIDE the `runTest` body (before the drain, while Main
-     * is installed), so this is the one place that can both cancel and advance the clock.
-     * Registered per test, after the assertions, so it can never mask one.
+     * The assertions below make both halves load-bearing: the false-Live assertions
+     * remain first, then recovery MUST be observed at the fresh-client factory before
+     * the VM's existing explicit own-scope cancel seam releases it for the generic
+     * drain. Both real-IO boundaries use the shared audited bounded pump and HARD-FAIL;
+     * no existing timeout is widened and no child is swallowed.
      */
-    private fun TestScope.drainRecoveryBeforeTheQuiescenceOracle(vm: TmuxSessionViewModel) {
-        fixture.onTeardown {
-            vm.cancelConnect()
-            vm.cancelOwnScopesForTest()
-            advanceUntilIdle()
+    private fun TestScope.completeSpawnedRecoveryBeforeTheQuiescenceOracle(
+        vm: TmuxSessionViewModel,
+        recoveryFactoryCalled: CompletableDeferred<Unit>,
+        recoveryParked: CompletableDeferred<Unit>,
+    ) {
+        val recoverySpawned = drainMainLooperUntil(
+            deadlineMs = RECOVERY_DRAIN_DEADLINE_MS,
+            sleepMs = 1L,
+            onTick = { runCurrent() },
+        ) {
+            recoveryFactoryCalled.isCompleted
         }
+        assertTrue(
+            "issue #1887 harness: the dead-channel guard must actually spawn its " +
+                "production recovery at the fresh-client factory",
+            recoverySpawned,
+        )
+        vm.cancelOwnScopesForTest()
+        recoveryParked.complete(Unit)
+        val vmReachedZeroChildren = drainMainLooperUntil(
+            deadlineMs = RECOVERY_DRAIN_DEADLINE_MS,
+            sleepMs = 1L,
+            onTick = { runCurrent() },
+        ) {
+            !vm.connectJobActiveForTest() && vm.activeOwnScopeChildCountForTest() == 0
+        }
+        assertTrue(
+            "issue #1887: explicit VM cancellation must drain the recovery and every " +
+                "VM-owned child before the #1355 quiescence boundary",
+            vmReachedZeroChildren,
+        )
+        assertFalse(
+            "issue #1887: the cancelled recovery must no longer be published as active " +
+                "before the #1355 quiescence boundary",
+            vm.connectJobActiveForTest(),
+        )
+        assertEquals(
+            "issue #1887: teardown handoff must start from zero VM-owned children",
+            0,
+            vm.activeOwnScopeChildCountForTest(),
+        )
     }
 
     /**
@@ -736,6 +800,9 @@ class Issue1863DeadWireAfterCancelledConnectTest {
          * measured GREEN on the guard-removed baseline.
          */
         const val ATTACH_PARK_OCCURRENCE = 2
+
+        /** Hard wall-clock bound for the real-IO recovery start and cancellation drain. */
+        const val RECOVERY_DRAIN_DEADLINE_MS = 10_000L
 
         /** Short, deterministic probe cadence for the post-guard half. */
         const val PROBE_INTERVAL_MS = 10L

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentSendTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentSendTest.kt
@@ -1768,6 +1768,17 @@ class TmuxSessionAgentSendTest : TmuxSessionViewModelTestBase() {
             "reconnect scenario factory/tail/teardown scope must be fully cancelled",
             scenarioRoot.children.none { it.isActive },
         )
+        // Issue #1615 recurrence: joining an iteration's roots made it
+        // coroutine-quiescent, but the base harness still retained that entire
+        // dead VM until @After. Release only after the structural zero-work
+        // assertions above, so iteration N+1 begins with neither live work nor
+        // a strong reference to iteration N.
+        releaseDrainedViewModelForTest(vm)
+        assertEquals(
+            "a drained reconnect scenario must not remain strongly retained by the class harness",
+            0,
+            trackedViewModelCountForTest(),
+        )
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux
 
+import androidx.lifecycle.viewModelScope
 import com.pocketshell.app.cards.SessionCardsRemoteSource
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.projects.FolderListGateway
@@ -124,6 +125,32 @@ abstract class TmuxSessionViewModelTestBase {
     // Cancelled in `@After` alongside the other per-test-instance scopes.
     private val leaseScope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(scheduler))
     private val createdViewModels = mutableListOf<TmuxSessionViewModel>()
+
+    protected fun trackedViewModelCountForTest(): Int = createdViewModels.size
+
+    /**
+     * Relinquish the class harness's safety-net reference after a scenario has
+     * already performed its stricter, iteration-local drain.
+     *
+     * The class-level list exists so ordinary tests cannot forget teardown. A
+     * stress test that explicitly clears, cancels, and joins a VM every
+     * iteration must remove that already-dead VM, though: retaining the whole
+     * batch until `@After` makes later iterations pay for an ever-growing object
+     * graph and repeats `clearForTest()` over every dead VM at method teardown.
+     */
+    protected fun releaseDrainedViewModelForTest(vm: TmuxSessionViewModel) {
+        check(!vm.viewModelScope.coroutineContext.job.isActive) {
+            "cannot release a TmuxSessionViewModel whose owned root is still active"
+        }
+        check(vm.activeOwnScopeChildCountForTest() == 0) {
+            "cannot release a TmuxSessionViewModel that still owns active children"
+        }
+        val trackedIndex = createdViewModels.indexOfFirst { it === vm }
+        check(trackedIndex >= 0) {
+            "cannot release an untracked TmuxSessionViewModel"
+        }
+        createdViewModels.removeAt(trackedIndex)
+    }
 
     protected fun newVm(
         registry: ActiveTmuxClients = ActiveTmuxClients(),


### PR DESCRIPTION
Integrates three independently reviewed full-suite determinism fixes on exact current main:

- #1615: release fully drained, identity-tracked reconnect ViewModels between stress iterations.
- #1892: give every default MainDispatcherRule an explicit fresh TestCoroutineScheduler so test construction cannot inherit a foreign Main clock.
- #1887: model recovery with a fresh control client and deterministically drain the dead-channel recovery before generic teardown.

Independent approvals:
- #1615: https://github.com/alexeygrigorev/pocketshell/issues/1615#issuecomment-5131833708
- #1892: https://github.com/alexeygrigorev/pocketshell/issues/1892#issuecomment-5134274778
- #1887: https://github.com/alexeygrigorev/pocketshell/issues/1887#issuecomment-5134478131

Combined exact-head local evidence at 85a252c7:
- release adjacency: 80/80 (both #1615 stress methods, #1887 7/7, #1892 rule, Share 45/45, Snippets 25/25)
- canonical scripts/full-jvm-gate.sh: BUILD SUCCESSFUL in 17m09s; 603/603 tasks executed
- diff: five test-only files, three reviewed commits, no production source changes.