### PR TITLE
fix: dismiss accepted empty composer immediately (#695)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDraftLossOnFinalizeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDraftLossOnFinalizeE2eTest.kt
@@ -52,6 +52,7 @@ import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -140,6 +141,149 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
         outboundQueueStore = queue,
     ).also { viewModel = it }
 
+    /**
+     * Issue #695 recurrence: the production screen-scoped dispatcher must close
+     * the empty real sheet at local queue acceptance, not after the host's slow
+     * suspend delivery callback.
+     */
+    @Test
+    fun acceptedPromptDismissesBeforeTenSecondHostDeliveryCompletes() {
+        val drafts = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newViewModel(drafts, queue)
+        val visible = mutableStateOf(true)
+        val sendEntered = CompletableDeferred<Unit>()
+        val sendCompleted = CompletableDeferred<Unit>()
+        val targetKey = "1/session-a"
+
+        compose.setContent {
+            PocketShellTheme {
+                Box(Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    PromptComposerSendDispatcher(
+                        viewModel = vm,
+                        onSend = {
+                            sendEntered.complete(Unit)
+                            delay(10_000)
+                            sendCompleted.complete(Unit)
+                            true
+                        },
+                        onDelivered = { visible.value = false },
+                    )
+                    if (visible.value) {
+                        PromptComposerSheet(
+                            onDismiss = { visible.value = false },
+                            onSend = { error("screen-scoped dispatcher owns delivery") },
+                            composerTargetKey = targetKey,
+                            sendTargetSnapshotProvider = {
+                                PromptComposerViewModel.SendTargetSnapshot(sessionKey = targetKey)
+                            },
+                            viewModel = vm,
+                            collectSendRequests = false,
+                        )
+                    }
+                }
+            }
+        }
+        compose.waitUntil(5_000) { vm.composerTarget == targetKey }
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
+            .performClick()
+            .performTextInput("send without waiting")
+        val tappedAt = SystemClock.elapsedRealtime()
+        compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, true).performClick()
+
+        compose.waitUntil(2_000) { !visible.value }
+        val dismissedAfterMs = SystemClock.elapsedRealtime() - tappedAt
+        assertTrue(
+            "local acceptance must dismiss promptly, took ${dismissedAfterMs}ms",
+            dismissedAfterMs < 2_000,
+        )
+        compose.waitUntil(2_000) { sendEntered.isCompleted }
+        assertTrue("host delivery must have started", sendEntered.isCompleted)
+        assertFalse("dismissal must not await the injected 10s host callback", sendCompleted.isCompleted)
+        assertEquals("", vm.uiState.value.draft)
+        assertEquals(1, queue.itemsFor(targetKey).size)
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true).assertDoesNotExist()
+    }
+
+    /**
+     * The local acceptance event and the dismissal reduction are distinct main
+     * loop turns. New typing in that window owns the sheet and must survive
+     * exactly, even while the accepted row continues delivering.
+     */
+    @Test
+    fun newDraftBeforeAcceptanceDismissReductionKeepsSheetOpenExactly() {
+        val drafts = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newViewModel(drafts, queue)
+        val visible = mutableStateOf(true)
+        val reductionEntered = CompletableDeferred<Unit>()
+        val releaseReduction = CompletableDeferred<Unit>()
+        val releaseDelivery = CompletableDeferred<Unit>()
+        val targetKey = "1/session-a"
+        vm.beforeHandoffAutoCloseReductionForTest = {
+            reductionEntered.complete(Unit)
+            releaseReduction.await()
+        }
+
+        compose.setContent {
+            PocketShellTheme {
+                Box(Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    PromptComposerSendDispatcher(
+                        viewModel = vm,
+                        onSend = {
+                            releaseDelivery.await()
+                            true
+                        },
+                        onDelivered = { visible.value = false },
+                    )
+                    if (visible.value) {
+                        PromptComposerSheet(
+                            onDismiss = { visible.value = false },
+                            onSend = { error("screen-scoped dispatcher owns delivery") },
+                            composerTargetKey = targetKey,
+                            sendTargetSnapshotProvider = {
+                                PromptComposerViewModel.SendTargetSnapshot(sessionKey = targetKey)
+                            },
+                            viewModel = vm,
+                            collectSendRequests = false,
+                        )
+                    }
+                }
+            }
+        }
+        compose.waitUntil(5_000) { vm.composerTarget == targetKey }
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
+            .performClick()
+            .performTextInput("accepted prompt")
+        compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, true).performClick()
+        compose.waitUntil(5_000) {
+            reductionEntered.isCompleted &&
+                vm.uiState.value.draft.isEmpty() &&
+                queue.itemsFor(targetKey).size == 1
+        }
+
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
+            .performClick()
+            .performTextInput("brand new draft")
+        compose.waitUntil(5_000) {
+            vm.uiState.value.draft == "brand new draft" &&
+                drafts.load(targetKey) == "brand new draft"
+        }
+        releaseReduction.complete(Unit)
+        compose.waitForIdle()
+
+        assertTrue("new input must retain ownership of the real sheet", visible.value)
+        assertEquals("brand new draft", vm.uiState.value.draft)
+        assertEquals("brand new draft", drafts.load(targetKey))
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
+            .assertIsDisplayed()
+            .assertTextContains("brand new draft", substring = true)
+        releaseDelivery.complete(Unit)
+        compose.waitUntil(5_000) { !vm.uiState.value.sendInFlight }
+        assertTrue("post-acceptance completion must not close over the new draft", visible.value)
+        assertEquals("brand new draft", vm.uiState.value.draft)
+    }
+
     @Test
     fun finalizingPreviousSendKeepsNewDraftVisibleDurableAndSheetOpen() {
         val drafts = InMemoryComposerDraftStore()
@@ -148,7 +292,13 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
         val visible = mutableStateOf(true)
         val sendEntered = CompletableDeferred<Unit>()
         val releaseDelivery = CompletableDeferred<Unit>()
+        val reductionEntered = CompletableDeferred<Unit>()
+        val releaseReduction = CompletableDeferred<Unit>()
         val targetKey = "1/session-a"
+        vm.beforeHandoffAutoCloseReductionForTest = {
+            reductionEntered.complete(Unit)
+            releaseReduction.await()
+        }
 
         compose.activityRule.scenario.onActivity { activity ->
             WindowCompat.setDecorFitsSystemWindows(activity.window, false)
@@ -205,7 +355,9 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, useUnmergedTree = true)
             .performClick()
         compose.waitUntil(timeoutMillis = 5_000) {
-            sendEntered.isCompleted && vm.uiState.value.sendInFlight
+            sendEntered.isCompleted &&
+                reductionEntered.isCompleted &&
+                vm.uiState.value.sendInFlight
         }
         // The #971 handoff is real: prompt A moved into exactly one queue row,
         // leaving the editor empty and ready for prompt B.
@@ -218,6 +370,9 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
             vm.uiState.value.draft == "I can still report" &&
                 drafts.load(targetKey) == "I can still report"
         }
+        releaseReduction.complete(Unit)
+        compose.waitForIdle()
+        assertTrue("new typing must defeat the pending acceptance dismissal", visible.value)
         WalkthroughScreenshotArtifacts.capture("issue-1616-01-new-draft-during-send")
 
         // Previous prompt A finalizes in the background.

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSendDismissE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSendDismissE2eTest.kt
@@ -259,7 +259,8 @@ class PromptComposerSendDismissE2eTest {
             .assertIsDisplayed()
             .performClick()
         compose.waitUntil(timeoutMillis = 5_000) {
-            vm.uiState.value.attachments.isNotEmpty()
+            vm.uiState.value.attachments.isNotEmpty() &&
+                vm.uiState.value.attachmentUpload is PromptComposerViewModel.AttachmentUploadState.Idle
         }
         assertEquals(1, vm.uiState.value.attachments.size)
         assertEquals("", vm.uiState.value.draft)

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSendPipeliningE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSendPipeliningE2eTest.kt
@@ -60,12 +60,8 @@ class PromptComposerSendPipeliningE2eTest {
         compose.setContent {
             PocketShellTheme {
                 Box(Modifier.fillMaxSize().background(PocketShellColors.Background)) {
-                    if (visible.value) {
-                        PromptComposerSheet(
-                        onDismiss = {
-                            dismissCount.incrementAndGet()
-                            visible.value = false
-                        },
+                    PromptComposerSendDispatcher(
+                        viewModel = vm,
                         onSend = { request ->
                             val payload = request.cleanDraft
                             callbackOrder.add(payload)
@@ -82,12 +78,22 @@ class PromptComposerSendPipeliningE2eTest {
                             }
                             true
                         },
-                        composerTargetKey = target,
-                        sendTargetSnapshotProvider = {
-                            PromptComposerViewModel.SendTargetSnapshot(sessionKey = target)
+                        onDelivered = {
+                            dismissCount.incrementAndGet()
+                            visible.value = false
                         },
-                        viewModel = vm,
                     )
+                    if (visible.value) {
+                        PromptComposerSheet(
+                            onDismiss = { visible.value = false },
+                            onSend = { error("screen-scoped dispatcher owns delivery") },
+                            composerTargetKey = target,
+                            sendTargetSnapshotProvider = {
+                                PromptComposerViewModel.SendTargetSnapshot(sessionKey = target)
+                            },
+                            viewModel = vm,
+                            collectSendRequests = false,
+                        )
                     }
                 }
             }
@@ -96,8 +102,18 @@ class PromptComposerSendPipeliningE2eTest {
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
             .performClick().performTextInput("prompt A")
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, true).performClick()
-        compose.waitUntil(5_000) { firstEntered.isCompleted && vm.uiState.value.sendInFlight }
+        compose.waitUntil(5_000) {
+            firstEntered.isCompleted &&
+                vm.uiState.value.sendInFlight &&
+                dismissCount.get() == 1 &&
+                !visible.value
+        }
 
+        // Local acceptance closes the empty composer promptly. Reopening it
+        // while A is still delivering preserves #1621 pipelining: B can still
+        // enqueue behind A and closes promptly on its own acceptance.
+        compose.runOnUiThread { visible.value = true }
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true).assertExists()
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
             .performClick().performTextInput("prompt B")
         compose.waitUntil(5_000) { vm.uiState.value.draft == "prompt B" }
@@ -109,8 +125,8 @@ class PromptComposerSendPipeliningE2eTest {
         assertEquals(listOf("prompt A", "prompt B"), queue.itemsFor(target).map { it.cleanText })
         assertEquals(listOf(OutboundState.InFlight, OutboundState.Queued), queue.itemsFor(target).map { it.state })
         assertEquals(listOf("prompt A"), callbackOrder.toList())
-        assertEquals(0, dismissCount.get())
-        assertTrue(visible.value)
+        assertEquals(2, dismissCount.get())
+        assertTrue(!visible.value)
         WalkthroughScreenshotArtifacts.capture("issue-1621-green-second-prompt-queued-during-first")
 
         releaseFirst.complete(Unit)
@@ -121,19 +137,17 @@ class PromptComposerSendPipeliningE2eTest {
         assertTrue(vm.uiState.value.sendInFlight)
         assertEquals(listOf("prompt A", "prompt B"), callbackOrder.toList())
         assertEquals(mapOf("prompt A" to 1, "prompt B" to 1), callbackOrder.groupingBy { it }.eachCount())
-        assertEquals(0, dismissCount.get())
-        assertTrue(visible.value)
+        assertEquals(2, dismissCount.get())
+        assertTrue(!visible.value)
         WalkthroughScreenshotArtifacts.capture("issue-1621-green-fifo-second-delivering")
         releaseSecond.complete(Unit)
         compose.waitUntil(5_000) {
             !vm.uiState.value.sendInFlight &&
-                queue.itemsFor(target).isEmpty() &&
-                dismissCount.get() == 1 &&
-                !visible.value
+                queue.itemsFor(target).isEmpty()
         }
         assertEquals(listOf("prompt A", "prompt B"), callbackOrder.toList())
         assertEquals(mapOf("prompt A" to 1, "prompt B" to 1), callbackOrder.groupingBy { it }.eachCount())
-        assertEquals(1, dismissCount.get())
+        assertEquals(2, dismissCount.get())
         assertEquals("", vm.uiState.value.draft)
         assertTrue(vm.uiState.value.attachments.isEmpty())
         assertTrue(queue.itemsFor(target).isEmpty())
@@ -161,31 +175,37 @@ class PromptComposerSendPipeliningE2eTest {
         compose.setContent {
             PocketShellTheme {
                 Box(Modifier.fillMaxSize().background(PocketShellColors.Background)) {
+                    PromptComposerSendDispatcher(
+                        viewModel = vm,
+                        onSend = { request ->
+                            when (request.cleanDraft) {
+                                "older queued prompt" -> {
+                                    olderEntered.complete(Unit)
+                                    releaseOlder.await()
+                                }
+                                "prompt B" -> {
+                                    newerEntered.complete(Unit)
+                                    releaseNewer.await()
+                                }
+                                else -> error("unexpected ${request.cleanDraft}")
+                            }
+                            true
+                        },
+                        onDelivered = {
+                            dismissCount.incrementAndGet()
+                            visible.value = false
+                        },
+                    )
                     if (visible.value) {
                         PromptComposerSheet(
-                            onDismiss = {
-                                dismissCount.incrementAndGet()
-                                visible.value = false
-                            },
-                            onSend = { request ->
-                                when (request.cleanDraft) {
-                                    "older queued prompt" -> {
-                                        olderEntered.complete(Unit)
-                                        releaseOlder.await()
-                                    }
-                                    "prompt B" -> {
-                                        newerEntered.complete(Unit)
-                                        releaseNewer.await()
-                                    }
-                                    else -> error("unexpected ${request.cleanDraft}")
-                                }
-                                true
-                            },
+                            onDismiss = { visible.value = false },
+                            onSend = { error("screen-scoped dispatcher owns delivery") },
                             composerTargetKey = target,
                             sendTargetSnapshotProvider = {
                                 PromptComposerViewModel.SendTargetSnapshot(sessionKey = target)
                             },
                             viewModel = vm,
+                            collectSendRequests = false,
                         )
                     }
                 }
@@ -203,9 +223,15 @@ class PromptComposerSendPipeliningE2eTest {
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
             .performClick().performTextInput("older queued prompt")
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, true).performClick()
-        compose.waitUntil(5_000) { vm.uiState.value.draft.isEmpty() }
+        compose.waitUntil(5_000) {
+            vm.uiState.value.draft.isEmpty() &&
+                dismissCount.get() == 1 &&
+                !visible.value
+        }
         assertTrue(queue.itemsFor(target).isEmpty())
-        assertEquals(0, dismissCount.get())
+        assertEquals(1, dismissCount.get())
+
+        compose.runOnUiThread { visible.value = true }
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true).assertExists()
 
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
@@ -213,8 +239,8 @@ class PromptComposerSendPipeliningE2eTest {
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, true).performClick()
         compose.waitUntil(5_000) { newerEntered.isCompleted }
         releaseNewer.complete(Unit)
-        compose.waitUntil(5_000) { dismissCount.get() == 1 && !visible.value }
-        assertEquals(1, dismissCount.get())
+        compose.waitUntil(5_000) { dismissCount.get() == 2 && !visible.value }
+        assertEquals(2, dismissCount.get())
     }
 
     private fun newViewModel(queue: OutboundQueueStore): PromptComposerViewModel =

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -32,6 +33,40 @@ internal class ComposerRevisionTracker {
     }
 }
 
+internal data class ComposerHandoffAcceptance(
+    val target: String,
+    val interactionEpoch: Long,
+    val outboundQueueItemId: String?,
+)
+
+/**
+ * One-shot local-acceptance events, split out of the already oversized
+ * composer ViewModel. The channel bridges the tiny commit-to-Compose gap; the
+ * epoch check below prevents a stale event from closing new composition.
+ */
+internal class ComposerHandoffAcceptanceCoordinator {
+    private val channel = kotlinx.coroutines.channels.Channel<ComposerHandoffAcceptance>(
+        capacity = kotlinx.coroutines.channels.Channel.UNLIMITED,
+    )
+    val events = channel.receiveAsFlow()
+
+    @androidx.annotation.VisibleForTesting
+    var beforeAutoCloseReductionForTest: suspend () -> Unit = {}
+
+    fun publish(acceptance: ComposerHandoffAcceptance) {
+        channel.trySend(acceptance)
+    }
+}
+
+internal val PromptComposerViewModel.handoffAcceptances
+    get() = handoffAcceptance.events
+
+internal var PromptComposerViewModel.beforeHandoffAutoCloseReductionForTest: suspend () -> Unit
+    get() = handoffAcceptance.beforeAutoCloseReductionForTest
+    set(value) {
+        handoffAcceptance.beforeAutoCloseReductionForTest = value
+    }
+
 internal fun PromptComposerViewModel.composerRevision(target: String): Long =
     composerRevisionTracker.revision(target)
 
@@ -42,6 +77,57 @@ internal fun PromptComposerViewModel.recordComposerMutation(target: String? = co
 
 internal fun PromptComposerViewModel.onComposerOpened() {
     composerInteractionEpoch++
+}
+
+internal fun PromptComposerViewModel.publishHandoffAcceptance(
+    target: String,
+    outboundQueueItemId: String?,
+) {
+    handoffAcceptance.publish(
+        ComposerHandoffAcceptance(
+            target = target,
+            interactionEpoch = composerInteractionEpoch,
+            outboundQueueItemId = outboundQueueItemId,
+        ),
+    )
+}
+
+/**
+ * Legacy delivery-quiescence query retained for queue/background-finalize
+ * callers and its class matrix. Issue #695 moves actual dismissal to the local
+ * acceptance reduction below.
+ */
+public fun PromptComposerViewModel.consumeQuiescenceForAutoClose(
+    request: SendRequest? = null,
+): Boolean {
+    val state = _uiState.value
+    val requestEpoch = request?.outboundQueueItemId?.let(outboundAutoCloseEpochs::remove)
+        ?: legacyAutoCloseEpoch.also { legacyAutoCloseEpoch = null }
+    val ownsCurrentInteraction = request == null || requestEpoch == composerInteractionEpoch
+    return ownsCurrentInteraction && state.draft.isEmpty() &&
+        state.attachments.isEmpty() &&
+        state.recording == PromptComposerViewModel.RecordingState.Idle &&
+        !state.outboundHandoffInProgress &&
+        composerTarget?.let { target ->
+            outboundQueueStore.itemsFor(target).none { it.state != OutboundState.Delivered }
+        } != false
+}
+
+/**
+ * Consume a local-acceptance event for prompt composer dismissal without
+ * waiting for its durable queue row to deliver or prune.
+ */
+internal fun PromptComposerViewModel.consumeHandoffAcceptanceForAutoClose(
+    acceptance: ComposerHandoffAcceptance,
+): Boolean {
+    val state = _uiState.value
+    val ownsCurrentTarget = acceptance.target.isBlank() || acceptance.target == composerTarget
+    return ownsCurrentTarget &&
+        acceptance.interactionEpoch == composerInteractionEpoch &&
+        state.draft.isEmpty() &&
+        state.attachments.isEmpty() &&
+        state.recording == PromptComposerViewModel.RecordingState.Idle &&
+        !state.outboundHandoffInProgress
 }
 
 internal fun PromptComposerViewModel.finishOutboundHandoff(
@@ -160,6 +246,10 @@ internal fun PromptComposerViewModel.emitSendRequest(
                 activeRequest.outboundQueueItemId?.let {
                     outboundAutoCloseEpochs[it] = composerInteractionEpoch
                 }
+                publishHandoffAcceptance(
+                    target = durableTarget,
+                    outboundQueueItemId = activeRequest.outboundQueueItemId,
+                )
             }
             return
         }
@@ -173,9 +263,15 @@ internal fun PromptComposerViewModel.emitSendRequest(
                 backgroundDelivery.sendTarget,
             )
         ) {
-            clearComposerForHandoff(
+            val acknowledged = clearComposerForHandoff(
                 ComposerHandoffSnapshot(durableTarget, composerRevision(durableTarget)),
             )
+            if (acknowledged) {
+                publishHandoffAcceptance(
+                    target = durableTarget,
+                    outboundQueueItemId = backgroundDelivery.outboundQueueItemId,
+                )
+            }
             backgroundDeliveredRequest = null
             return
         }
@@ -214,10 +310,17 @@ internal fun PromptComposerViewModel.emitSendRequest(
                 }
                 withContext(Dispatchers.Main.immediate) {
                     if (outboundHandoffJob !== owner) return@withContext
-                    if (clearComposerForHandoff(snapshot)) {
+                    val acknowledged = clearComposerForHandoff(snapshot)
+                    if (acknowledged) {
                         queuedItem?.let { outboundAutoCloseEpochs[it.id] = composerInteractionEpoch }
                     }
                     finishOutboundHandoff(owner)
+                    if (acknowledged && queuedItem != null) {
+                        publishHandoffAcceptance(
+                            target = durableTarget,
+                            outboundQueueItemId = queuedItem.id,
+                        )
+                    }
                     refreshOutboundQueueItemsFor(durableTarget)
                     // The queue drain, never the handoff, claims delivery. If an
                     // older row is active this is intentionally a no-op; its

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -1489,10 +1489,25 @@ internal fun SheetContent(
 public fun PromptComposerSendDispatcher(
     viewModel: PromptComposerViewModel,
     onSend: suspend (PromptComposerViewModel.SendRequest) -> Boolean,
+    // Historical name retained for source-compatible standalone harnesses.
+    // Durable production rows now invoke it at local handoff acceptance;
+    // no-store fallback rows still invoke it on successful delivery.
     onDelivered: () -> Unit = {},
 ) {
     val currentOnSend by rememberUpdatedState(onSend)
     val currentOnDelivered by rememberUpdatedState(onDelivered)
+    LaunchedEffect(viewModel) {
+        viewModel.handoffAcceptances.collect { acceptance ->
+            // Issue #695 recurrence: dismissal belongs to local acceptance,
+            // not the 5–10s host delivery callback. Pauseable test seam makes
+            // the post-acceptance/new-draft race deterministic; production is
+            // a no-op and reduces immediately.
+            viewModel.beforeHandoffAutoCloseReductionForTest()
+            if (viewModel.consumeHandoffAcceptanceForAutoClose(acceptance)) {
+                currentOnDelivered()
+            }
+        }
+    }
     LaunchedEffect(viewModel) {
         viewModel.sendRequests.collect { request ->
             // Issue #745: bound the send so the in-flight state can never hang.
@@ -1509,8 +1524,12 @@ public fun PromptComposerSendDispatcher(
             if (delivered) {
                 // Finalize the queue row without touching post-handoff input.
                 viewModel.markSendDelivered(request)
-                // A background finalize must not dismiss active composition.
-                if (viewModel.consumeQuiescenceForAutoClose(request)) {
+                // Standalone/legacy callers have no durable queue acceptance
+                // boundary. Keep their established success-only dismissal;
+                // production rows close earlier from handoffAcceptances.
+                if (request.outboundQueueItemId == null &&
+                    viewModel.consumeQuiescenceForAutoClose(request)
+                ) {
                     currentOnDelivered()
                 }
             } else {

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -255,6 +255,7 @@ public class PromptComposerViewModel @Inject constructor(
      */
     internal val _sendRequests = Channel<SendRequest>(capacity = Channel.BUFFERED)
     public val sendRequests: Flow<SendRequest> = _sendRequests.receiveAsFlow()
+    internal val handoffAcceptance = ComposerHandoffAcceptanceCoordinator()
 
     /**
      * Issue #211: one-shot Send queued by the user while the FSM was
@@ -1012,6 +1013,7 @@ public class PromptComposerViewModel @Inject constructor(
         backgroundDeliveredRequest = request?.takeIf {
             it.outboundQueueItemId != null && closeEpoch != composerInteractionEpoch
         }
+        request?.outboundQueueItemId?.let(outboundAutoCloseEpochs::remove)
         inFlightSendRequest = null
         _uiState.update { it.copy(sendInFlight = false) }
         markOutboundSendDelivered(request)
@@ -1020,30 +1022,6 @@ public class PromptComposerViewModel @Inject constructor(
         // on an outer screen's queue observer leaves an enqueue-behind row stuck
         // when the composer is mounted in another host/lifecycle boundary.
         if (!outboundHandoffInProgress) retryNextOutboundItem()
-    }
-
-    /**
-     * A delivery may auto-close only when no new composition is active.
-     *
-     * CONSUMING, not a pure query (issue #1621, round-three review follow-up: the
-     * old name `isQuiescentForAutoClose` promised purity it never had). Answering
-     * CONSUMES [request]'s auto-close epoch — the one-shot token proving this
-     * delivery, and not a newer composition, owns the current interaction — so a
-     * second call for the same request answers differently by design. Call it
-     * exactly ONCE per resolved delivery, right after [markSendDelivered].
-     */
-    public fun consumeQuiescenceForAutoClose(request: SendRequest? = null): Boolean {
-        val state = _uiState.value
-        val requestEpoch = request?.outboundQueueItemId?.let(outboundAutoCloseEpochs::remove)
-            ?: legacyAutoCloseEpoch.also { legacyAutoCloseEpoch = null }
-        val ownsCurrentInteraction = request == null || requestEpoch == composerInteractionEpoch
-        return ownsCurrentInteraction && state.draft.isEmpty() &&
-            state.attachments.isEmpty() &&
-            state.recording == RecordingState.Idle &&
-            !state.outboundHandoffInProgress &&
-            composerTarget?.let { target ->
-                outboundQueueStore.itemsFor(target).none { it.state != OutboundState.Delivered }
-            } != false
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerAcceptanceDismissalTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerAcceptanceDismissalTest.kt
@@ -1,0 +1,214 @@
+package com.pocketshell.app.composer
+
+import androidx.lifecycle.SavedStateHandle
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.settings.VoiceTranscriptionProvider
+import com.pocketshell.core.voice.WhisperClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #695 recurrence: dismissal belongs to local outbound acceptance, not
+ * the later host-delivery result.
+ *
+ * The connected sibling mounts the real sheet and injects the reported 10s
+ * callback. This deterministic matrix covers the state boundary itself:
+ * accepted/empty, accepted then newly edited, failure before local acceptance,
+ * and failure after acceptance with/without a newer draft.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PromptComposerAcceptanceDismissalTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val createdViewModels = mutableListOf<PromptComposerViewModel>()
+
+    @After
+    fun tearDown() {
+        createdViewModels.forEach { it.clearForTest() }
+        createdViewModels.clear()
+    }
+
+    @Test
+    fun durableAcceptanceMakesEmptyComposerDismissibleBeforeDeliveryResult() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(StandardTestDispatcher(testScheduler), queue)
+        val accepted = collectAcceptances(vm)
+        val sent = collectSends(vm)
+        val target = target()
+        vm.onComposerTargetChanged(target.sessionKey)
+        vm.onDraftChange("slow host prompt")
+
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+
+        assertEquals("", vm.uiState.value.draft)
+        assertEquals(1, queue.itemsFor(target.sessionKey).size)
+        assertEquals(1, accepted.size)
+        assertEquals(1, sent.size)
+        assertTrue(vm.uiState.value.sendInFlight)
+        assertTrue(vm.consumeHandoffAcceptanceForAutoClose(accepted.single()))
+    }
+
+    @Test
+    fun newDraftBeforeAcceptanceReductionRejectsDismissalAndSurvivesDelivery() = runTest {
+        val drafts = InMemoryComposerDraftStore()
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(StandardTestDispatcher(testScheduler), queue, drafts)
+        val accepted = collectAcceptances(vm)
+        val sent = collectSends(vm)
+        val target = target()
+        vm.onComposerTargetChanged(target.sessionKey)
+        vm.onDraftChange("submitted")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+        assertEquals(1, accepted.size)
+
+        vm.onDraftChange("new draft")
+        assertFalse(vm.consumeHandoffAcceptanceForAutoClose(accepted.single()))
+        vm.markSendDelivered(sent.single())
+
+        assertEquals("new draft", vm.uiState.value.draft)
+        assertEquals("new draft", drafts.load(target.sessionKey))
+        assertTrue(queue.itemsFor(target.sessionKey).isEmpty())
+    }
+
+    @Test
+    fun failureBeforeLocalAcceptanceEmitsNoDismissalAndRestoresSubmittedDraft() = runTest {
+        val vm = newVm(
+            dispatcher = StandardTestDispatcher(testScheduler),
+            queue = DisabledOutboundQueueStore,
+        )
+        val accepted = collectAcceptances(vm)
+        vm._sendRequests.close()
+        vm.onDraftChange("not accepted")
+
+        vm.requestSend(withEnter = true)
+        runCurrent()
+
+        assertTrue(accepted.isEmpty())
+        assertEquals("not accepted", vm.uiState.value.draft)
+        assertFalse(vm.uiState.value.sendInFlight)
+        assertTrue(vm.uiState.value.error.orEmpty().contains("Not sent"))
+    }
+
+    @Test
+    fun failureAfterAcceptanceKeepsRowQueuedAndDoesNotRestoreOverEmptyEditor() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(StandardTestDispatcher(testScheduler), queue)
+        val accepted = collectAcceptances(vm)
+        val sent = collectSends(vm)
+        val target = target()
+        vm.onComposerTargetChanged(target.sessionKey)
+        vm.onDraftChange("accepted then offline")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+
+        vm.markOutboundSendDeferred(sent.single(), resetAttemptBudget = true)
+
+        assertEquals(1, accepted.size)
+        assertEquals("", vm.uiState.value.draft)
+        assertEquals(OutboundState.Queued, queue.itemsFor(target.sessionKey).single().state)
+        assertFalse(vm.uiState.value.sendInFlight)
+    }
+
+    @Test
+    fun failureAfterAcceptanceNeverOverwritesNewDraft() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val drafts = InMemoryComposerDraftStore()
+        val vm = newVm(StandardTestDispatcher(testScheduler), queue, drafts)
+        val sent = collectSends(vm)
+        val target = target()
+        vm.onComposerTargetChanged(target.sessionKey)
+        vm.onDraftChange("accepted prompt")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        advanceUntilIdle()
+        vm.onDraftChange("new work")
+
+        vm.markOutboundSendDeferred(sent.single(), resetAttemptBudget = true)
+
+        assertEquals("new work", vm.uiState.value.draft)
+        assertEquals("new work", drafts.load(target.sessionKey))
+        assertEquals(OutboundState.Queued, queue.itemsFor(target.sessionKey).single().state)
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.collectAcceptances(
+        vm: PromptComposerViewModel,
+    ): MutableList<ComposerHandoffAcceptance> {
+        val accepted = mutableListOf<ComposerHandoffAcceptance>()
+        backgroundScope.launch { vm.handoffAcceptances.collect { accepted += it } }
+        runCurrent()
+        return accepted
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.collectSends(
+        vm: PromptComposerViewModel,
+    ): MutableList<PromptComposerViewModel.SendRequest> {
+        val sent = mutableListOf<PromptComposerViewModel.SendRequest>()
+        backgroundScope.launch { vm.sendRequests.collect { sent += it } }
+        runCurrent()
+        return sent
+    }
+
+    private fun target() =
+        PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+
+    private fun newVm(
+        dispatcher: TestDispatcher,
+        queue: OutboundQueueStore,
+        drafts: ComposerDraftStore = InMemoryComposerDraftStore(),
+    ): PromptComposerViewModel {
+        val vm = PromptComposerViewModel(
+            audioRecorder = object : PromptComposerViewModel.MicCapture {
+                override fun start() = Unit
+                override fun stop(): ByteArray = ByteArray(0)
+                override fun currentAmplitude(): Float = 0f
+            },
+            whisperClientFactory = WhisperClientFactory {
+                object : WhisperClient {
+                    override suspend fun transcribe(
+                        audio: ByteArray,
+                        language: String?,
+                    ): Result<String> = Result.success("")
+                }
+            },
+            apiKeyStorage = object : PromptComposerViewModel.ApiKeyVault {
+                override fun save(key: CharArray) = Unit
+                override fun load(): CharArray = "sk-test".toCharArray()
+                override fun clear() = Unit
+            },
+            voiceSettings = object : PromptComposerViewModel.VoiceSettingsSnapshot {
+                override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+                override fun whisperLanguageHint(): String? = null
+                override fun transcriptionProvider(): VoiceTranscriptionProvider =
+                    VoiceTranscriptionProvider.OpenAiWhisper
+            },
+            composerDraftStore = drafts,
+            outboundQueueStore = queue,
+            savedStateHandle = SavedStateHandle(),
+        )
+        vm.samplerDispatcher = dispatcher
+        vm.outboundQueueDispatcher = dispatcher
+        vm.setSendWatchdogTimeoutForTest(null)
+        createdViewModels += vm
+        return vm
+    }
+}


### PR DESCRIPTION
Fixes #695.

After Send reaches durable local queue acceptance, an empty prompt composer now dismisses immediately instead of waiting 5–10 seconds for remote host delivery. If the user starts typing a new draft before the acceptance reduction arrives, the composer stays open and the new draft survives exactly.

The change preserves pre-acceptance failure restoration, post-acceptance queued failure behavior, and FIFO/pipelined sends.

Exact-head verification:
- independent review: APPROVED
- focused acceptance/draft/FIFO matrix: 44/44
- reviewer fresh connected core journeys: 2/2, unskipped
- previously reviewed connected adjacency: 8/8 with exact feature/test blobs unchanged
- forced Android-test compilation: 176/176 tasks
- canonical full JVM graph: 603/603 tasks, green
- all 7 blobs, stable patch-id, and binary diff match the original approved implementation
