### PR TITLE
fix(session): restore agent profile picker (#1875)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypeProfilePickerUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypeProfilePickerUiTest.kt
@@ -1,21 +1,39 @@
 package com.pocketshell.app.projects
 
+import android.graphics.Bitmap
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.lifecycle.ViewModelStore
+import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
 import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * UI proof for the multi-profile session-type picker (audit #657 Gap-3,
@@ -177,4 +195,226 @@ class SessionTypeProfilePickerUiTest {
 
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG).assertDoesNotExist()
     }
+
+    /**
+     * Issue #1875 production-path regression. A bind-time profile probe can fail
+     * transiently while the host tree itself goes on to become usable. Opening
+     * the REAL host-screen New session sheet must retry discovery, render the
+     * recovered Z.AI choice, and thread that choice into the command actually
+     * handed to [FolderListGateway.createSession].
+     *
+     * This deliberately uses [FolderListScreen], not the standalone picker
+     * content above: the old tests could stay green while the production screen
+     * supplied an empty list forever.
+     */
+    @Test
+    fun productionHostSheetRetriesTransientDiscoveryAndLaunchesSelectedProfile() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val viewModelStore = ViewModelStore()
+        val hostId = 1875L
+        runBlocking {
+            val keyId = db.sshKeyDao().insert(
+                SshKeyEntity(
+                    name = "issue1875-key",
+                    privateKeyPath = "/tmp/issue1875-key",
+                ),
+            )
+            db.hostDao().insert(
+                HostEntity(
+                    id = hostId,
+                    name = "issue1875-host",
+                    hostname = "profiles.example",
+                    port = 22,
+                    username = "alexey",
+                    keyId = keyId,
+                ),
+            )
+        }
+
+        val profilesGateway = TransientThenZaiProfilesGateway()
+        val sessionGateway = RecordingSessionGateway()
+        lateinit var viewModel: FolderListViewModel
+        instrumentation.runOnMainSync {
+            viewModel = FolderListViewModel(
+                gateway = sessionGateway,
+                hostDao = db.hostDao(),
+                projectRootDao = db.projectRootDao(),
+                sshLeaseManager = SshLeaseManager(
+                    connector = SshLeaseConnector {
+                        Result.failure(IllegalStateException("warm connect not used by fixture"))
+                    },
+                    idleTtlMillis = 0L,
+                ),
+                forwardingController = ForwardingController(context),
+                profilesGateway = profilesGateway,
+                attachLifecycle = false,
+            ).also {
+                it.setProcessStartedForTest(true)
+                viewModelStore.put("issue1875", it)
+            }
+        }
+
+        try {
+            compose.setContent {
+                PocketShellTheme {
+                    FolderListScreen(
+                        hostId = hostId,
+                        hostName = "issue1875-host",
+                        hostname = "profiles.example",
+                        port = 22,
+                        username = "alexey",
+                        keyPath = "/tmp/issue1875-key",
+                        passphrase = null,
+                        onBack = {},
+                        onOpenSession = { _, _, _, _ -> },
+                        onSessionCreated = { _, _ -> },
+                        onBrowseRepos = { _ -> },
+                        onEditEnv = { _, _, _ -> },
+                        modifier = Modifier.fillMaxSize(),
+                        viewModel = viewModel,
+                    )
+                }
+            }
+
+            compose.waitUntil(timeoutMillis = 10_000) {
+                profilesGateway.calls.get() >= 1 &&
+                    compose.onAllNodesWithTag(FOLDER_LIST_NEW_SESSION_FAB_TAG)
+                        .fetchSemanticsNodes().isNotEmpty()
+            }
+            assertTrue(
+                "the bind-time fixture must reproduce one transient profile failure",
+                viewModel.claudeProfiles.value.isEmpty(),
+            )
+
+            compose.onNodeWithTag(FOLDER_LIST_NEW_SESSION_FAB_TAG)
+                .performScrollTo()
+                .performClick()
+
+            // Load-bearing UI assertion: this can only become true when the
+            // production host-screen open path retries the transient failure.
+            compose.waitUntil(timeoutMillis = 10_000) {
+                compose.onAllNodesWithTag(
+                    "$SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG:Claude (Z.AI)",
+                    useUnmergedTree = true,
+                ).fetchSemanticsNodes().isNotEmpty()
+            }
+            compose.onNodeWithTag(
+                "$SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG:Claude (Z.AI)",
+                useUnmergedTree = true,
+            ).performScrollTo().assertIsDisplayed().performClick()
+            compose.waitForIdle()
+            captureFullDevice("issue1875-profile-picker-green.png")
+
+            compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
+            compose.waitUntil(timeoutMillis = 10_000) {
+                sessionGateway.lastStartCommand.get() != null
+            }
+            assertTrue(
+                "the command actually launched must carry the recovered Z.AI profile: " +
+                    sessionGateway.lastStartCommand.get(),
+                sessionGateway.lastStartCommand.get()
+                    ?.contains("--profile 'Claude (Z.AI)'") == true,
+            )
+            assertTrue(
+                "opening the sheet must retry after the bind-time failure",
+                profilesGateway.calls.get() >= 2,
+            )
+        } finally {
+            instrumentation.runOnMainSync { viewModel.stopPolling() }
+            viewModelStore.clear()
+            db.close()
+        }
+    }
+
+    private fun captureFullDevice(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        val bitmap: Bitmap = instrumentation.uiAutomation.takeScreenshot() ?: return
+        val root = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val directory = File(root, "additional_test_output/issue1875-profile-picker")
+            .apply { mkdirs() }
+        FileOutputStream(File(directory, name)).use {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+}
+
+private class TransientThenZaiProfilesGateway : ProfilesGateway {
+    val calls = AtomicInteger(0)
+
+    override suspend fun listProfiles(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        engine: String?,
+    ): ProfilesResult =
+        if (calls.incrementAndGet() == 1) {
+            ProfilesResult.ConnectFailed(IllegalStateException("transient bind-time failure"))
+        } else {
+            ProfilesResult.Profiles(
+                listOf(
+                    RemoteProfile(
+                        name = "Claude",
+                        engine = RemoteProfile.ENGINE_CLAUDE,
+                        default = true,
+                    ),
+                    RemoteProfile(
+                        name = "Claude (Z.AI)",
+                        engine = RemoteProfile.ENGINE_CLAUDE,
+                        configDir = "/home/alexey/.zlaude",
+                    ),
+                ),
+            )
+        }
+}
+
+private class RecordingSessionGateway : FolderListGateway {
+    val lastStartCommand = AtomicReference<String?>(null)
+
+    override suspend fun listSessionsWithFolder(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        watchedRoots: List<ProjectRootEntity>,
+    ): FolderListResult = FolderListResult.Sessions(rows = emptyList())
+
+    override suspend fun createSession(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        sessionName: String,
+        cwd: String,
+        startCommand: String?,
+        namePolicy: SessionNamePolicy,
+    ): Result<String> {
+        lastStartCommand.set(startCommand)
+        return Result.success(sessionName)
+    }
+
+    override suspend fun createEmptyProject(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        parentPath: String,
+        folderName: String,
+    ): Result<String> = Result.success("$parentPath/$folderName")
+
+    override suspend fun importFile(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        folderPath: String,
+        payload: FolderImportPayload,
+    ): Result<String> = Result.success("$folderPath/${payload.remoteName}")
+
+    override suspend fun killSession(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        sessionName: String,
+    ): Result<Unit> = Result.success(Unit)
 }

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListProfileDiscovery.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListProfileDiscovery.kt
@@ -1,0 +1,71 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.storage.dao.HostDao
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Owns host profile discovery and the profile state consumed by new-session
+ * pickers.
+ *
+ * Fetches run on bind and whenever a picker opens (#718/#1875). A monotonically
+ * increasing generation prevents an older request from overwriting a newer
+ * picker refresh, while [isCurrentHost] prevents a completed request from
+ * leaking profiles across a host switch.
+ */
+internal class FolderListProfileDiscovery(
+    private val profilesGateway: ProfilesGateway?,
+    private val hostDao: HostDao,
+    private val scope: CoroutineScope,
+    private val ioDispatcher: () -> CoroutineDispatcher,
+    private val isCurrentHost: (Long) -> Boolean,
+) {
+    private val _claudeProfiles = MutableStateFlow<List<ClaudeProfile>>(emptyList())
+    val claudeProfiles: StateFlow<List<ClaudeProfile>> = _claudeProfiles.asStateFlow()
+
+    private val _codexProfiles = MutableStateFlow<List<CodexProfile>>(emptyList())
+    val codexProfiles: StateFlow<List<CodexProfile>> = _codexProfiles.asStateFlow()
+
+    private var fetchGeneration: Long = 0L
+
+    fun refresh(params: BoundParams) {
+        val generation = ++fetchGeneration
+        val gateway = profilesGateway ?: run {
+            clearProfiles()
+            return
+        }
+        scope.launch {
+            val dispatcher = ioDispatcher()
+            val host = withContext(dispatcher) { hostDao.getById(params.hostId) }
+                ?: return@launch
+            val result = withContext(dispatcher) {
+                gateway.listProfiles(
+                    host = host,
+                    keyPath = params.keyPath,
+                    passphrase = params.passphrase,
+                )
+            }
+            if (!isCurrentHost(params.hostId) || generation != fetchGeneration) {
+                return@launch
+            }
+            when (result) {
+                is ProfilesResult.Profiles -> {
+                    val profiles = result.profiles.toFolderListProfileLists()
+                    _claudeProfiles.value = profiles.claudeProfiles
+                    _codexProfiles.value = profiles.codexProfiles
+                }
+                else -> clearProfiles()
+            }
+        }
+    }
+
+    private fun clearProfiles() {
+        _claudeProfiles.value = emptyList()
+        _codexProfiles.value = emptyList()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -265,6 +265,15 @@ fun FolderListScreen(
     var promptDictationEvent by remember { mutableStateOf<AssistantDictationTextEvent?>(null) }
     var correctionDictationEvent by remember { mutableStateOf<AssistantDictationTextEvent?>(null) }
 
+    // Issue #1875: profile discovery at bind can fail transiently while the
+    // rest of the host tree remains usable. Retry on every real picker open;
+    // the StateFlows update the already-open sheet when discovery completes.
+    LaunchedEffect(pickerFolder) {
+        if (pickerFolder != null) {
+            viewModel.refreshProfilesForPicker()
+        }
+    }
+
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted ->

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -440,26 +440,6 @@ class FolderListViewModel internal constructor(
      */
     private fun expectedPocketshellVersion(): String = expectedPocketshellVersionProvider()
 
-    /**
-     * Issue #718: Claude Code profiles for this host, DISCOVERED on the host
-     * and fetched via [ProfilesGateway] during [bind] (was the #627
-     * client-stored JSON, hard-cut per D22). Empty when the host has only the
-     * default profile, when the CLI is missing, or when the fetch fails (the
-     * picker then shows no profile selector).
-     */
-    private val _claudeProfiles: MutableStateFlow<List<ClaudeProfile>> =
-        MutableStateFlow(emptyList())
-    val claudeProfiles: StateFlow<List<ClaudeProfile>> = _claudeProfiles.asStateFlow()
-
-    /**
-     * Issue #718: Codex profiles for this host, discovered on the host and
-     * fetched via [ProfilesGateway] during [bind] (was the #631 client-stored
-     * JSON, hard-cut per D22). Empty for the default-only / unavailable cases.
-     */
-    private val _codexProfiles: MutableStateFlow<List<CodexProfile>> =
-        MutableStateFlow(emptyList())
-    val codexProfiles: StateFlow<List<CodexProfile>> = _codexProfiles.asStateFlow()
-
     private val assistant: SessionAssistantController =
         SessionAssistantController(scope = viewModelScope, sessionFactory = ::buildAssistantDeps)
     internal val assistantState: StateFlow<AssistantUiState> = assistant.state
@@ -470,7 +450,23 @@ class FolderListViewModel internal constructor(
     private var assistantSshExecutor: AssistantSshExecutor = RealAssistantSshExecutor()
 
     private var bound: BoundParams? = null
-    private var profileFetchGeneration: Long = 0L
+
+    /**
+     * Issue #718/#1875: host profile discovery and latest-request state live in
+     * one focused owner rather than adding another responsibility to this
+     * already-large tree coordinator.
+     */
+    private val profileDiscovery = FolderListProfileDiscovery(
+        profilesGateway = profilesGateway,
+        hostDao = hostDao,
+        scope = viewModelScope,
+        ioDispatcher = { ioDispatcher },
+        isCurrentHost = { hostId -> bound?.hostId == hostId },
+    )
+
+    val claudeProfiles: StateFlow<List<ClaudeProfile>> = profileDiscovery.claudeProfiles
+    val codexProfiles: StateFlow<List<CodexProfile>> = profileDiscovery.codexProfiles
+
     private var warmJob: Job? = null
     private var warmReleaseJob: Job? = null
     private var warmLease: SshLease? = null
@@ -988,7 +984,7 @@ class FolderListViewModel internal constructor(
         // SSH lease (was the #627/#631 client-stored JSON, hard-cut per D22).
         // The default-only / CLI-missing / fetch-failure cases all collapse to
         // an empty list, so the picker simply shows no profile selector.
-        fetchProfiles(params)
+        profileDiscovery.refresh(params)
 
         warmJob?.cancel()
         warmJob = viewModelScope.launch {
@@ -1027,54 +1023,12 @@ class FolderListViewModel internal constructor(
     }
 
     /**
-     * Issue #718: fetch the host-discovered agent profiles via
-     * [ProfilesGateway] and split them by engine into the picker's
-     * [claudeProfiles] / [codexProfiles] flows. Foreground, on bind and whenever
-     * a new-session picker opens. Any non-success result (CLI missing,
-     * connect/parse failure, no gateway in tests) leaves the flows empty so the
-     * picker shows no profile selector — the safe default-only behaviour.
-     */
-    private fun fetchProfiles(params: BoundParams) {
-        val generation = ++profileFetchGeneration
-        val gw = profilesGateway ?: run {
-            _claudeProfiles.value = emptyList()
-            _codexProfiles.value = emptyList()
-            return
-        }
-        viewModelScope.launch {
-            val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) } ?: return@launch
-            val result = withContext(ioDispatcher) {
-                gw.listProfiles(
-                    host = host,
-                    keyPath = params.keyPath,
-                    passphrase = params.passphrase,
-                )
-            }
-            // Ignore a stale result if the host changed while we were fetching.
-            if (bound?.hostId != params.hostId || profileFetchGeneration != generation) {
-                return@launch
-            }
-            when (result) {
-                is ProfilesResult.Profiles -> {
-                    val profileLists = result.profiles.toFolderListProfileLists()
-                    _claudeProfiles.value = profileLists.claudeProfiles
-                    _codexProfiles.value = profileLists.codexProfiles
-                }
-                else -> {
-                    _claudeProfiles.value = emptyList()
-                    _codexProfiles.value = emptyList()
-                }
-            }
-        }
-    }
-
-    /**
      * Issue #1875: retry host profile discovery at the moment the user opens a
      * new-session picker. A transient bind-time failure must not permanently
      * hide non-default profiles for the lifetime of the host screen.
      */
     fun refreshProfilesForPicker() {
-        bound?.let(::fetchProfiles)
+        bound?.let(profileDiscovery::refresh)
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -470,6 +470,7 @@ class FolderListViewModel internal constructor(
     private var assistantSshExecutor: AssistantSshExecutor = RealAssistantSshExecutor()
 
     private var bound: BoundParams? = null
+    private var profileFetchGeneration: Long = 0L
     private var warmJob: Job? = null
     private var warmReleaseJob: Job? = null
     private var warmLease: SshLease? = null
@@ -1028,12 +1029,13 @@ class FolderListViewModel internal constructor(
     /**
      * Issue #718: fetch the host-discovered agent profiles via
      * [ProfilesGateway] and split them by engine into the picker's
-     * [claudeProfiles] / [codexProfiles] flows. Foreground, on bind. Any
-     * non-success result (CLI missing, connect/parse failure, no gateway in
-     * tests) leaves the flows empty so the picker shows no profile selector —
-     * the safe default-only behaviour.
+     * [claudeProfiles] / [codexProfiles] flows. Foreground, on bind and whenever
+     * a new-session picker opens. Any non-success result (CLI missing,
+     * connect/parse failure, no gateway in tests) leaves the flows empty so the
+     * picker shows no profile selector — the safe default-only behaviour.
      */
     private fun fetchProfiles(params: BoundParams) {
+        val generation = ++profileFetchGeneration
         val gw = profilesGateway ?: run {
             _claudeProfiles.value = emptyList()
             _codexProfiles.value = emptyList()
@@ -1049,7 +1051,9 @@ class FolderListViewModel internal constructor(
                 )
             }
             // Ignore a stale result if the host changed while we were fetching.
-            if (bound?.hostId != params.hostId) return@launch
+            if (bound?.hostId != params.hostId || profileFetchGeneration != generation) {
+                return@launch
+            }
             when (result) {
                 is ProfilesResult.Profiles -> {
                     val profileLists = result.profiles.toFolderListProfileLists()
@@ -1062,6 +1066,15 @@ class FolderListViewModel internal constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Issue #1875: retry host profile discovery at the moment the user opens a
+     * new-session picker. A transient bind-time failure must not permanently
+     * hide non-default profiles for the lifetime of the host screen.
+     */
+    fun refreshProfilesForPicker() {
+        bound?.let(::fetchProfiles)
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/projects/RepoBrowserScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RepoBrowserScreen.kt
@@ -129,12 +129,21 @@ fun RepoBrowserScreen(
         )
     }
     val state by viewModel.state.collectAsState()
-    val sessionState by sessionViewModel.state.collectAsState()
+    val claudeProfiles by sessionViewModel.claudeProfiles.collectAsState()
+    val codexProfiles by sessionViewModel.codexProfiles.collectAsState()
 
     // Pre-filled repo path the picker should open on. Set once a repo tap
     // resolves (clone-then-open or already-cloned), cleared on dismiss /
     // confirm. Replaces the old direct onOpenRepo → TmuxSession bypass.
     var pickerRepoPath by remember { mutableStateOf<String?>(null) }
+
+    // Issue #1875: keep this second host-screen new-session entry point on the
+    // same open-time discovery contract as FolderListScreen.
+    LaunchedEffect(pickerRepoPath) {
+        if (pickerRepoPath != null) {
+            sessionViewModel.refreshProfilesForPicker()
+        }
+    }
 
     RepoBrowserScaffold(
         hostName = hostName,
@@ -155,6 +164,8 @@ fun RepoBrowserScreen(
             folderLabel = repoFolderLabel(repoPath),
             onDismiss = { pickerRepoPath = null },
             suggestStartDirectories = suggestStartDirectories,
+            claudeProfiles = claudeProfiles,
+            codexProfiles = codexProfiles,
             // Issue #1184: prefill the editable "Session name" field with the
             // directory-derived default for the chosen start folder.
             deriveDefaultName = { dir ->
@@ -162,9 +173,7 @@ fun RepoBrowserScreen(
             },
             onCreate = { choice ->
                 pickerRepoPath = null
-                // Issue #1820: same shape as the folder tree — this list was
-                // empty whenever `sessionState` was not `Ready`, and it is the
-                // host that must decide uniqueness at create time.
+                // Issue #1820: the host decides uniqueness at create time.
                 val newName = derivedSessionName(
                     choice = choice,
                     homeDirectory = conventionalRemoteHome(username),
@@ -172,7 +181,7 @@ fun RepoBrowserScreen(
                 sessionViewModel.createSession(
                     sessionName = newName,
                     cwd = choice.startDirectory,
-                    startCommand = choice.startCommand(),
+                    startCommand = choice.startCommand(claudeProfiles, codexProfiles),
                     // Epic #821 Workstream A: record the picked kind onto the
                     // new tree node immediately (no detection round-trip).
                     chosenKind = choice.sessionAgentKind,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelProfilesTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelProfilesTest.kt
@@ -117,6 +117,36 @@ class FolderListViewModelProfilesTest {
     }
 
     @Test
+    fun pickerOpenRetriesTransientBindFailure() = runTest(testDispatcher) {
+        val gateway = FakeProfilesGateway(
+            ProfilesResult.ConnectFailed(IllegalStateException("transient bind failure")),
+        )
+        val vm = buildViewModel(gateway)
+        try {
+            bind(vm)
+            assertTrue(vm.claudeProfiles.value.isEmpty())
+
+            gateway.result = ProfilesResult.Profiles(
+                listOf(
+                    RemoteProfile("Claude", "claude", null, default = true),
+                    RemoteProfile("Claude (Z.AI)", "claude", "/home/u/.zlaude", default = false),
+                ),
+            )
+            vm.refreshProfilesForPicker()
+
+            assertEquals(
+                listOf(
+                    ClaudeProfile("Claude", default = true),
+                    ClaudeProfile("Claude (Z.AI)", default = false),
+                ),
+                vm.claudeProfiles.value,
+            )
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    @Test
     fun noGatewayKeepsProfilesEmpty() = runTest(testDispatcher) {
         // Null gateway = unit-test path with no profile fetch.
         val vm = buildViewModel(profilesGateway = null)
@@ -162,7 +192,7 @@ class FolderListViewModelProfilesTest {
         )
     }
 
-    private class FakeProfilesGateway(private val result: ProfilesResult) : ProfilesGateway {
+    private class FakeProfilesGateway(var result: ProfilesResult) : ProfilesGateway {
         var lastHostId: Long = -1L
         var lastKeyPath: String = ""
 

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -141,6 +141,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.share.ShareTargetE2eTest"  # #727 #657 epic Wave 1 / S1): the share-auth journey pair
   "com.pocketshell.app.share.SharePassphraseDialogE2eTest"
   "com.pocketshell.app.projects.ProfileDiscoveryPickerDockerTest"  # #732 Finding B): the host server-PROFILE discovery journey. The p…
+  "com.pocketshell.app.projects.SessionTypeProfilePickerUiTest"  # #1875: production host sheet retries profile discovery, renders Z.AI, and launches with --profile; also runs the existing picker class coverage.
   "com.pocketshell.app.projects.RootProjectAddSheetKeyboardLayoutTest"  # #1742 deterministic modal-root IME layout proof
   "com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest"  # #898 reviewer Blocker B): the in-session + New session rich-sheet
   "com.pocketshell.app.composer.PromptComposerImeSquishProofTest"  # #736 #567 #638 #657 follow-up to the review): the composer keyboard-up SQUISH re…


### PR DESCRIPTION
Closes #1875

Restores the agent Profile picker in the real New Session sheet and wires its production regression into the journey gate. Independent approval: https://github.com/alexeygrigorev/pocketshell/issues/1875#issuecomment-5140281232