### PR TITLE
test(ci): keep app-owned IME failures loud (#1882)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
@@ -60,6 +60,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -1086,6 +1087,9 @@ class PromptComposerSaturatedImeAnchorE2eTest {
             .toList()
 
     private fun requestRealImeAndAssertVisible() {
+        if (!waitForAppWindowFocus()) {
+            fail(realImeFailure("before_show"))
+        }
         compose.activityRule.scenario.onActivity { activity ->
             val roots = activeAppWindowRoots(activity)
             val focusedView = roots.asReversed()
@@ -1097,14 +1101,46 @@ class PromptComposerSaturatedImeAnchorE2eTest {
                 ?.show(WindowInsetsCompat.Type.ime())
             inputMethodManager.showSoftInput(focusedView, InputMethodManager.SHOW_IMPLICIT)
         }
-        assertTrue(
-            "The real system input-method window never became visible.",
-            waitForPhysicalImeWindow(expected = true),
-        )
+        if (!waitForPhysicalImeWindow(expected = true)) {
+            fail(realImeFailure("after_show_timeout"))
+        }
         assertTrue(
             "The real IME never supplied a positive visible inset to an app window.",
             waitForAnyAppRootImeVisible(expected = true),
         )
+    }
+
+    /**
+     * Issue #1882: the #1800 sentence alone is app-influenceable. Establish
+     * window focus before asking the framework to show the IME, then include
+     * the active-window owner in either hard failure. The CI classifier may
+     * downgrade only a resolved non-PocketShell owner; app-owned, missing, and
+     * framework `android` owners stay loud.
+     */
+    private fun waitForAppWindowFocus(): Boolean =
+        waitForWallClock(WINDOW_FOCUS_TIMEOUT_MS) { appWindowHasFocus() }
+
+    private fun appWindowHasFocus(): Boolean {
+        var focused = false
+        compose.activityRule.scenario.onActivity { activity ->
+            focused = activeAppWindowRoots(activity).any { it.hasWindowFocus() }
+        }
+        return focused
+    }
+
+    private fun realImeFailure(stage: String): String {
+        val appFocused = appWindowHasFocus()
+        val activeWindowPackage =
+            InstrumentationRegistry.getInstrumentation()
+                .uiAutomation
+                .rootInActiveWindow
+                ?.packageName
+                ?.toString()
+                ?: ACTIVE_WINDOW_UNAVAILABLE
+        return "The real system input-method window never became visible. " +
+            "stage=$stage app_window_focused=$appFocused " +
+            "active_window_pkg=$activeWindowPackage " +
+            "physicalImeWindows=${visiblePhysicalImeWindows()}"
     }
 
     private fun hideRealImeAndAssertHidden(message: String) {
@@ -1274,7 +1310,9 @@ class PromptComposerSaturatedImeAnchorE2eTest {
         const val RETURN_GEOMETRY_SLOP_DP = 2f
         const val MINIMUM_TERMINAL_FRACTION = 0.25f
         const val REAL_IME_TIMEOUT_MS = 30_000L
+        const val WINDOW_FOCUS_TIMEOUT_MS = 10_000L
         const val PHYSICAL_IME_ABSENCE_STABILITY_MS = 500L
+        const val ACTIVE_WINDOW_UNAVAILABLE = "<unavailable>"
         const val PRODUCTION_SHEET_TAG = "issue1744-production-composer-sheet"
         const val TERMINAL_MARKER_TAG = "issue1744-terminal-marker"
         const val TERMINAL_MARKER = "agent output remains visible above the composer"

--- a/scripts/ci-journey-infra-signature.py
+++ b/scripts/ci-journey-infra-signature.py
@@ -4,25 +4,36 @@ evidence as either an environment-divergent capability precondition (INFRA) or a
 genuine product failure (RED).
 
 The ONE captured signature this recognises is the CI swiftshader AVD's inability
-to raise a *real system input-method window*:
+to raise a *real system input-method window while an explicitly identified
+foreign app owns the active window*:
 
     The real system input-method window never became visible.
+    ... active_window_pkg=com.example.foreign ...
 
-That assertion is not a product assertion. It is the physical-IME precondition
-of `PromptComposerSaturatedImeAnchorE2eTest`, i.e. exactly the
-environment-divergent capability `process.md` F3 / #780 says must be injected
-synthetically rather than required. The load-bearing anchor/containment
-properties of that class are independently asserted on its synthetic
-`Type.ime()` path with hard failures, so typing this precondition as INFRA loses
-no protection on CI.
+The message alone is NOT enough. It is emitted by a load-bearing assertion in
+`PromptComposerSaturatedImeAnchorE2eTest`, so an app-owned focus/serviceability
+regression produces the same sentence. Issue #1882 therefore requires every
+failure element carrying the sentence to also carry at least one resolvable
+`active_window_pkg=...` reading, and requires EVERY such reading to be outside
+the `com.pocketshell.app*` application-id family.
+
+`active_window_pkg=android` is deliberately unresolved, not foreign. Framework
+ANR/crash dialogs belong to package `android` whether the faulting process is a
+foreign launcher or PocketShell itself (#1879/#796), so treating it as INFRA
+would hide an app-owned ANR. Missing, malformed, `<unavailable>`, mixed
+app/foreign, and app-owned readings all stay `product_failure` (RED). The
+recurring residual-IME shape (`active=false focused=false` with non-empty
+bounds, #1818) is diagnostic only; it never substitutes for a genuinely foreign
+active-window owner.
 
 Narrowness is the whole point. The classifier reports `real_ime_precondition`
 ONLY when EVERY failing test case belonging to a class listed under the suite
-summary's "Failed BOTH attempts" section carries that exact message. A single
-containment / anchor / any other assertion failure — in the same class, in the
-same run, in any attempt — forces `product_failure`, which keeps the shard RED.
-Missing or unreadable evidence reports `unclassified`, which also keeps the
-shard RED (fail-safe toward the red verdict, never toward green).
+summary's "Failed BOTH attempts" section carries that exact message AND the
+genuinely-foreign owner proof above. A single containment / anchor / any other
+assertion failure — in the same class, in the same run, in any attempt — forces
+`product_failure`, which keeps the shard RED. Missing or unreadable evidence
+reports `unclassified`, which also keeps the shard RED (fail-safe toward the red
+verdict, never toward green).
 
 Usage:
     ci-journey-infra-signature.py SUMMARY_FILE ARTIFACT_ROOT [ARTIFACT_ROOT ...]
@@ -57,6 +68,13 @@ import xml.etree.ElementTree as ET
 REAL_IME_UNAVAILABLE_SIGNATURE = (
     "The real system input-method window never became visible."
 )
+ACTIVE_WINDOW_PACKAGE = re.compile(
+    r"(?<![\w])active_window_pkg=([^\s,;]+)",
+)
+ANDROID_PACKAGE = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+",
+)
+POCKETSHELL_APP_PACKAGE_PREFIX = "com.pocketshell.app"
 
 # `- \`com.example.Foo\`` and `- \`com.example.Foo#someMethod\`` bullets under
 # the summary's failed-both header. The suite writes BOTH forms (issue #1822);
@@ -132,6 +150,32 @@ def _failure_text(element: ET.Element) -> str:
     return "\n".join(part for part in parts if part)
 
 
+def _has_only_genuinely_foreign_active_window_owners(text: str) -> bool:
+    """Whether the failure proves every observed active-window owner is foreign.
+
+    The classifier is a one-way safety gate: absence, ambiguity, or a mixture of
+    readings keeps the failure loud. In particular, `android` is not accepted
+    even though it is outside PocketShell's package prefix: it is the framework
+    package used by both foreign-app and PocketShell ANR dialogs.
+    """
+    owners = ACTIVE_WINDOW_PACKAGE.findall(text)
+    if not owners:
+        return False
+    return all(
+        ANDROID_PACKAGE.fullmatch(owner) is not None
+        and owner != "android"
+        and not owner.startswith(POCKETSHELL_APP_PACKAGE_PREFIX)
+        for owner in owners
+    )
+
+
+def _is_real_ime_environment_failure(text: str) -> bool:
+    return (
+        REAL_IME_UNAVAILABLE_SIGNATURE in text
+        and _has_only_genuinely_foreign_active_window_owners(text)
+    )
+
+
 def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
     classes, unreadable = failed_both_section(summary_path)
     failing = 0
@@ -163,7 +207,7 @@ def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
                 failing += 1
                 covered.add(base)
                 texts = [_failure_text(problem) for problem in problems]
-                if all(REAL_IME_UNAVAILABLE_SIGNATURE in text for text in texts):
+                if all(_is_real_ime_environment_failure(text) for text in texts):
                     matches += 1
                 else:
                     offenders.append(f"{base}#{case.get('name') or '<unknown>'}")

--- a/scripts/ci-journey-infra-signature.sh
+++ b/scripts/ci-journey-infra-signature.sh
@@ -5,7 +5,9 @@
 #
 # The only classification that changes a shard's verdict is
 # `real_ime_precondition` (the captured CI swiftshader "real system
-# input-method window never became visible" precondition -> INFRA / RE-RUN).
+# input-method window never became visible" precondition, plus an explicitly
+# resolved non-PocketShell active-window owner -> INFRA / RE-RUN). The assertion
+# sentence alone is app-influenceable and stays RED (#1882).
 # Everything else — including a missing python3, missing artifacts, an
 # unreadable result file, or ANY other assertion failure — reports
 # `unclassified` or `product_failure`, both of which keep the shard RED.

--- a/scripts/ci-journey-shard-signature-verdict.sh
+++ b/scripts/ci-journey-shard-signature-verdict.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Issue #1800: decide whether an emulator-journey shard's failure evidence is
 # the ONE captured environment signature (the CI swiftshader AVD cannot raise a
-# real system input-method window) rather than a genuine journey failure.
+# real system input-method window while a resolved foreign app owns the active
+# window) rather than a genuine journey failure.
 #
 # This is the exact decision the workflow's classify step applies, extracted so
 # it can be driven — and observed — without an emulator
@@ -21,10 +22,13 @@
 #   shard_signature_detail=<per-summary classifications, space separated>
 #
 # INFRA is emitted ONLY when at least one summary was inspected AND every
-# inspected summary classified as `real_ime_precondition`. Anything else — a
-# genuine assertion failure, mixed evidence, missing/corrupt result XML, a
-# missing classifier — emits NONE, which leaves the caller's existing RED
-# branches in charge. Always exits 0.
+# inspected summary classified as `real_ime_precondition`. The classifier only
+# emits that value when every matching failure proves a genuinely foreign
+# `active_window_pkg`; app-owned, `android` (ambiguous framework ANR), missing,
+# or malformed owners remain RED (#1882). Anything else — a genuine assertion
+# failure, mixed evidence, missing/corrupt result XML, a missing classifier —
+# emits NONE, which leaves the caller's existing RED branches in charge. Always
+# exits 0.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -4,11 +4,13 @@
 # it can produce.
 #
 # The load-bearing property: a shard whose ONLY failure is the CI swiftshader
-# AVD's inability to raise a real system input-method window must aggregate to
-# RE-RUN (neutral green), while a shard carrying ANY genuine journey assertion
-# failure — including a containment/anchor failure in the SAME class, in the
-# same run — must still aggregate to RED. Both outcomes are DEMONSTRATED here by
-# driving the real classifier and then the real aggregate reducer, not argued.
+# AVD's inability to raise a real system input-method window under a resolved
+# foreign active-window owner must aggregate to RE-RUN (neutral green), while a
+# shard carrying ANY genuine journey assertion failure — including an app-owned
+# focus/serviceability failure or a containment/anchor failure in the SAME
+# class, in the same run — must still aggregate to RED. Both outcomes are
+# DEMONSTRATED here by driving the real classifier and then the real aggregate
+# reducer, not argued.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,6 +34,10 @@ SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
 REAL_IME_MESSAGE='java.lang.AssertionError: The real system input-method window never became visible.'
+APP_OWNED_REAL_IME_DETAIL='app_window_focused=false active_window_pkg=com.pocketshell.app.i1882 active_window_class=android.widget.FrameLayout composer_editor_served=false'
+FOREIGN_REAL_IME_DETAIL='app_window_focused=false active_window_pkg=com.google.android.apps.nexuslauncher active_window_class=com.android.launcher3.Launcher'
+AMBIGUOUS_ANR_REAL_IME_DETAIL='app_window_focused=false active_window_pkg=android active_window_class=com.android.server.am.AppNotRespondingDialog framework_error_dialog=android:id/aerr_wait'
+RESIDUAL_IME_DETAIL='physicalImeWindows=[package=com.google.android.inputmethod.latin active=false focused=false bounds=Rect(0, 1517 - 1080, 2400)]'
 CONTAINMENT_MESSAGE="java.lang.AssertionError: Node 'prompt-composer-send-enter' must stay above the same-root keyboard boundary. node=Rect.fromLTRB(0.0, 1500.0, 1080.0, 1654.0) keyboardTopPx=1626.0"
 SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
 
@@ -102,13 +108,48 @@ write_case_xml() {
     local spec method outcome
     for spec in "$@"; do
       method="${spec%%:*}"
-      outcome="${spec##*:}"
+      outcome="${spec#*:}"
       echo "  <testcase name=\"$method\" classname=\"$class[emulator-5554 - 15]\">"
       case "$outcome" in
         pass) ;;
         realime)
-          echo "    <failure message=\"$REAL_IME_MESSAGE\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "    <failure message=\"$REAL_IME_MESSAGE $FOREIGN_REAL_IME_DETAIL\">at org.junit.Assert.fail(Assert.java:89)"
           echo "at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:814)</failure>"
+          ;;
+        realime-app)
+          echo "    <failure message=\"$REAL_IME_MESSAGE $APP_OWNED_REAL_IME_DETAIL\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:814)</failure>"
+          ;;
+        realime-app-residual)
+          echo "    <failure message=\"$REAL_IME_MESSAGE $APP_OWNED_REAL_IME_DETAIL $RESIDUAL_IME_DETAIL\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:814)</failure>"
+          ;;
+        realime-anr-ambiguous)
+          echo "    <failure message=\"$REAL_IME_MESSAGE $AMBIGUOUS_ANR_REAL_IME_DETAIL\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:814)</failure>"
+          ;;
+        realime-foreign-residual)
+          echo "    <failure message=\"$REAL_IME_MESSAGE $FOREIGN_REAL_IME_DETAIL $RESIDUAL_IME_DETAIL\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:814)</failure>"
+          ;;
+        realime-no-owner)
+          echo "    <failure message=\"$REAL_IME_MESSAGE $RESIDUAL_IME_DETAIL\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:814)</failure>"
+          ;;
+        realime-bare)
+          echo "    <failure message=\"$REAL_IME_MESSAGE\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+          ;;
+        realime-unavailable-owner)
+          echo "    <failure message=\"$REAL_IME_MESSAGE app_window_focused=false active_window_pkg=&lt;unavailable&gt;\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+          ;;
+        realime-malformed-owner)
+          echo "    <failure message=\"$REAL_IME_MESSAGE app_window_focused=false active_window_pkg=not/a/package\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+          ;;
+        realime-prefix-owner)
+          echo "    <failure message=\"$REAL_IME_MESSAGE app_window_focused=false active_window_pkg=com.pocketshell.appspoof\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+          ;;
+        realime-mixed-owners)
+          echo "    <failure message=\"$REAL_IME_MESSAGE $FOREIGN_REAL_IME_DETAIL later_active_window_pkg=com.pocketshell.app.i1882 active_window_pkg=com.pocketshell.app.i1882\">at org.junit.Assert.fail(Assert.java:89)</failure>"
           ;;
         containment)
           echo "    <failure message=\"$CONTAINMENT_MESSAGE\">at org.junit.Assert.fail(Assert.java:89)</failure>"
@@ -274,6 +315,138 @@ run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
 [[ "$SIG_CLASS" == "product_failure" ]] \
   || { printf '%s\n' "$SIG_OUT"; fail "(h) an <error> element must be product_failure, got '$SIG_CLASS'"; }
 pass "(h) a harness <error> element -> product_failure"
+
+echo
+echo "== #1882 real-IME signature owner gate =="
+
+# (x1) LOAD-BEARING RED. The existing #1800 classifier matches only the
+# assertion sentence, so it currently swallows this concrete product failure:
+# the composer editor lost serviceability to a PocketShell-owned window. The
+# applicationIdSuffix shape is the real per-worktree CI package family.
+root="$SANDBOX/x1-app-owned"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime-app"
+write_case_xml "$root" "$SATURATED_CLASS" 2 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime-app"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(x1) an app-owned composer focus/serviceability failure must stay product_failure, got '$SIG_CLASS'"; }
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+[[ "$SHARD_TOKEN" == "RED" ]] \
+  || { printf '%s\n' "$SHARD_VERDICT_OUT"; fail "(x1) an app-owned failure must keep the shard RED, got '$SHARD_TOKEN'"; }
+verdicts="$SANDBOX/verdicts-x1"; mkdir -p "$verdicts"
+write_shard_token "$verdicts" 0 "$SHARD_TOKEN"
+write_shard_token "$verdicts" 1 CLEAN
+write_shard_token "$verdicts" 2 CLEAN
+run_agg "$verdicts"
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(x1) app-owned evidence must aggregate RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+pass "(x1) app-owned real-IME failure -> product_failure -> shard/aggregate RED"
+
+# (x2) Control: the narrowing must not delete #1800's environment relief valve.
+# An explicitly identified non-PocketShell active-window owner remains the
+# captured environmental precondition.
+root="$SANDBOX/x2-foreign"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "real_ime_precondition" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(x2) an explicitly foreign active-window owner must remain real_ime_precondition, got '$SIG_CLASS'"; }
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+[[ "$SHARD_TOKEN" == "INFRA" ]] \
+  || { printf '%s\n' "$SHARD_VERDICT_OUT"; fail "(x2) genuinely foreign evidence must remain INFRA, got '$SHARD_TOKEN'"; }
+pass "(x2) genuinely foreign active-window owner remains real_ime_precondition -> INFRA"
+
+# (x3) Fail closed for every owner shape that is not positively identifiable as
+# foreign. This includes both PocketShell applicationIdSuffixes and malformed or
+# missing diagnostics. A missing parser input is never an environmental fact.
+for unsafe_case in \
+  "realime-app:the app under test owns focus" \
+  "realime-prefix-owner:the owner shares the protected com.pocketshell.app prefix" \
+  "realime-unavailable-owner:the owner could not be read" \
+  "realime-malformed-owner:the owner is not a package" \
+  "realime-bare:no owner reading was emitted"
+do
+  outcome="${unsafe_case%%:*}"
+  why="${unsafe_case#*:}"
+  root="$SANDBOX/x3-${outcome}"; mkdir -p "$root"
+  write_summary "$root" 2338 "$SATURATED_CLASS"
+  write_case_xml "$root" "$SATURATED_CLASS" 1 \
+    "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:$outcome"
+  run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+  [[ "$SIG_CLASS" == "product_failure" ]] \
+    || { printf '%s\n' "$SIG_OUT"; fail "(x3) $why must stay product_failure, got '$SIG_CLASS'"; }
+done
+pass "(x3) app-owned, unresolved, malformed, and absent owners all stay loud"
+
+# (x4) The observed #1879 ANR shape is deliberately NOT treated as genuinely
+# foreign from active-window data alone. Framework error-dialog windows belong
+# to package `android` whether the faulting process is Pixel Launcher or
+# PocketShell itself (#796). Downgrading this ambiguous reading would hide an
+# app-owned ANR product regression.
+root="$SANDBOX/x4-anr"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime-anr-ambiguous"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(x4) active_window_pkg=android is ambiguous and must stay product_failure, got '$SIG_CLASS'"; }
+pass "(x4) observed framework ANR focus theft (active_window_pkg=android) stays loud"
+
+# (x5) The recurring #1818 residual/phantom IME shape is not itself proof of a
+# foreign focus owner. It must not launder an app-owned failure, nor compensate
+# for a missing owner reading. With a separately proven foreign active-window
+# owner, the original #1800 downgrade remains available.
+for residual_case in \
+  "realime-app-residual:product_failure" \
+  "realime-no-owner:product_failure" \
+  "realime-foreign-residual:real_ime_precondition"
+do
+  outcome="${residual_case%%:*}"
+  expected="${residual_case#*:}"
+  root="$SANDBOX/x5-${outcome}"; mkdir -p "$root"
+  write_summary "$root" 2338 "$SATURATED_CLASS"
+  write_case_xml "$root" "$SATURATED_CLASS" 1 \
+    "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:$outcome"
+  run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+  [[ "$SIG_CLASS" == "$expected" ]] \
+    || { printf '%s\n' "$SIG_OUT"; fail "(x5) residual shape $outcome expected '$expected', got '$SIG_CLASS'"; }
+done
+pass "(x5) residual-IME evidence never substitutes for a genuinely foreign owner"
+
+# (x6) Every owner reading in a failing element must be genuinely foreign. A
+# stale/earlier foreign reading cannot outvote a later app-owned focus owner.
+root="$SANDBOX/x6-mixed-owners"; mkdir -p "$root"
+write_summary "$root" 2338 "$SATURATED_CLASS"
+write_case_xml "$root" "$SATURATED_CLASS" 1 \
+  "saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide:realime-mixed-owners"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(x6) one app-owned reading among foreign readings must stay product_failure, got '$SIG_CLASS'"; }
+pass "(x6) one app-owned reading vetoes the downgrade across the whole failure"
+
+# (x7) The real journey must emit the evidence the classifier decides on and
+# hard-establish the app-window-focus precondition. Otherwise the foreign
+# control above would be a fixture-only value the production path cannot emit.
+grep -q 'private fun waitForAppWindowFocus' "$ANDROID_TEST" \
+  || fail "(x7) the real-IME journey does not hard-establish app window focus"
+grep -q 'activeAppWindowRoots(activity).any { it.hasWindowFocus() }' "$ANDROID_TEST" \
+  || fail "(x7) the precondition does not observe every app-owned window root"
+grep -q 'active_window_pkg=' "$ANDROID_TEST" \
+  || fail "(x7) the real failure does not emit the classifier's owner reading"
+grep -q 'physicalImeWindows=' "$ANDROID_TEST" \
+  || fail "(x7) the real failure does not preserve the observed #1818 residual-window shape"
+grep -q 'The real system input-method window never became visible\.' "$ANDROID_TEST" \
+  || fail "(x7) the exact #1800 signature sentence was removed"
+grep -qE '\bassume(True|False|NotNull|That)[[:space:]]*\(' "$ANDROID_TEST" \
+  && fail "(x7) no Assume self-skip may shield the load-bearing real-IME assertion"
+pass "(x7) production journey hardens focus and emits owner/residual evidence without a skip"
 
 echo
 echo "== #1822 method-scoped bullets and fail-safe-toward-RED parsing =="

--- a/scripts/test-ci-journey-summary-evidence.sh
+++ b/scripts/test-ci-journey-summary-evidence.sh
@@ -802,6 +802,8 @@ pass "(e1) #1458/#1800/#1814 preserved: all-CLEAN -> CLEAN -> aggregate CLEAN; m
 SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
 OCCLUSION_CLASS="com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
 REAL_IME_MSG="The real system input-method window never became visible."
+FOREIGN_REAL_IME_DETAIL="app_window_focused=false active_window_pkg=com.google.android.apps.nexuslauncher active_window_class=com.android.launcher3.Launcher"
+APP_OWNED_REAL_IME_DETAIL="app_window_focused=false active_window_pkg=com.pocketshell.app.i1882 active_window_class=android.widget.FrameLayout composer_editor_served=false"
 
 # write_synth_summary <ws> <failed-bullet...>
 write_synth_summary() {
@@ -834,7 +836,11 @@ write_synth_xml() {
     for spec in "$@"; do
       method="${spec%%:*}"; kind="${spec##*:}"
       case "$kind" in
-        realime) echo "  <testcase classname=\"$classname\" name=\"$method\"><failure message=\"$REAL_IME_MSG\"/></testcase>" ;;
+        realime-foreign) echo "  <testcase classname=\"$classname\" name=\"$method\"><failure message=\"$REAL_IME_MSG $FOREIGN_REAL_IME_DETAIL\"/></testcase>" ;;
+        realime-app) echo "  <testcase classname=\"$classname\" name=\"$method\"><failure message=\"$REAL_IME_MSG $APP_OWNED_REAL_IME_DETAIL\"/></testcase>" ;;
+        realime-missing) echo "  <testcase classname=\"$classname\" name=\"$method\"><failure message=\"$REAL_IME_MSG\"/></testcase>" ;;
+        realime-malformed) echo "  <testcase classname=\"$classname\" name=\"$method\"><failure message=\"$REAL_IME_MSG app_window_focused=false active_window_pkg=not/a/package\"/></testcase>" ;;
+        realime-ambiguous) echo "  <testcase classname=\"$classname\" name=\"$method\"><failure message=\"$REAL_IME_MSG app_window_focused=false active_window_pkg=android active_window_class=com.android.server.am.AppNotRespondingDialog\"/></testcase>" ;;
         *)       echo "  <testcase classname=\"$classname\" name=\"$method\"><failure message=\"androidx.compose.ui.test.ComposeTimeoutException: condition never became true\"/></testcase>" ;;
       esac
     done
@@ -851,7 +857,7 @@ snapshot_attempt1() {
 # (e2) #1800: a signature-only shard is still INFRA and still aggregates RE-RUN.
 ws="$SANDBOX/synth-infra"; make_workspace "$ws"
 write_synth_summary "$ws" "$SATURATED_CLASS"
-write_synth_xml "$ws" 1 "$SATURATED_CLASS" "realImeReachability:realime"
+write_synth_xml "$ws" 1 "$SATURATED_CLASS" "realImeReachability:realime-foreign"
 snapshot_attempt1 "$ws"
 run_journey_summary_step "$ws"
 run_classify_step "$ws" "$(classify_expressions failure "$FIRST_TIMEOUT" "$FIRST_FAILURE")"
@@ -864,12 +870,40 @@ aggregate_with "$CLASSIFY_TOKEN"
   || { printf '%s\n' "$AGG_OUT"; fail "(e2) no-RED-with-INFRA must stay RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
 pass "(e2) #1800/#1809 preserved: real-IME precondition -> INFRA -> RE-RUN neutral green (exit 0)"
 
+# (e2b) #1882: only a positively identified foreign owner may use e2's INFRA
+# relief valve. App-owned, missing, malformed, and framework-ambiguous owner
+# evidence must remain product RED through the same summary + workflow bodies.
+for unsafe_owner_case in \
+  "app:realime-app" \
+  "missing:realime-missing" \
+  "malformed:realime-malformed" \
+  "ambiguous-android:realime-ambiguous"
+do
+  unsafe_owner_label="${unsafe_owner_case%%:*}"
+  unsafe_owner_kind="${unsafe_owner_case#*:}"
+  ws="$SANDBOX/synth-real-ime-$unsafe_owner_label"; make_workspace "$ws"
+  write_synth_summary "$ws" "$SATURATED_CLASS"
+  write_synth_xml "$ws" 1 "$SATURATED_CLASS" \
+    "realImeReachability:$unsafe_owner_kind"
+  snapshot_attempt1 "$ws"
+  run_journey_summary_step "$ws"
+  run_classify_step "$ws" "$(classify_expressions failure "$FIRST_TIMEOUT" "$FIRST_FAILURE")"
+  [[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_RC" -ne 0 ]] \
+    || {
+      printf '%s\n' "$CLASSIFY_OUT"
+      fail "(e2b/$unsafe_owner_label) unsafe owner evidence must stay RED, got '$CLASSIFY_TOKEN'/exit$CLASSIFY_RC"
+    }
+  grep -q '^shard_verdict=RED$' <<<"$CLASSIFY_GH_OUTPUT" \
+    || fail "(e2b/$unsafe_owner_label) shard RED output is missing"
+done
+pass "(e2b) #1882: app-owned, missing, malformed, and android-ambiguous real-IME evidence stays RED"
+
 # (e3) #1822: the mixed summary — the IME signature entry followed by a genuine
 #      method-scoped failure — is still RED, and still fails its own shard job.
 ws="$SANDBOX/synth-mixed"; make_workspace "$ws"
 write_synth_summary "$ws" "$SATURATED_CLASS" \
   "$OCCLUSION_CLASS#shellComposerControlsAreVisibleAndReachableInBothKeyboardStates"
-write_synth_xml "$ws" 1 "$SATURATED_CLASS" "realImeReachability:realime"
+write_synth_xml "$ws" 1 "$SATURATED_CLASS" "realImeReachability:realime-foreign"
 write_synth_xml "$ws" 2 "$OCCLUSION_CLASS" \
   "shellComposerControlsAreVisibleAndReachableInBothKeyboardStates:composetimeout"
 snapshot_attempt1 "$ws"
@@ -889,7 +923,7 @@ ws="$SANDBOX/synth-unreadable"; make_workspace "$ws"
 write_synth_summary "$ws" "$SATURATED_CLASS"
 printf '%s\n' '- `9NotAnIdentifier#weird` (an entry this parser cannot read)' \
   >> "$ws/artifacts/ci-journey/summary.md"
-write_synth_xml "$ws" 1 "$SATURATED_CLASS" "realImeReachability:realime"
+write_synth_xml "$ws" 1 "$SATURATED_CLASS" "realImeReachability:realime-foreign"
 snapshot_attempt1 "$ws"
 run_journey_summary_step "$ws"
 run_classify_step "$ws" "$(classify_expressions failure "$FIRST_TIMEOUT" "$FIRST_FAILURE")"

--- a/scripts/test-ci-journey-warm-build.sh
+++ b/scripts/test-ci-journey-warm-build.sh
@@ -794,26 +794,54 @@ rm -f "$CLASSIFY_DIR/artifacts/ci-journey/summary.md"
 expect_classify "no summary at all"     INFRA emulator_never_booted         1 failure failure failure failure false false true
 pass "(x1) every classify branch writes the expected token + reason + exit code, executed from the real workflow body"
 
-# #1800's captured-signature branch must still fire, and now name itself. This
-# is the adjacency check: my edits sit in the same ladder.
+# #1800's captured-signature branch must still fire for a positively identified
+# foreign focus owner, and now name itself. Exercise the REAL workflow body for
+# both sides of #1882's owner boundary: app-owned and unsafe/ambiguous evidence
+# must remain RED rather than inheriting the foreign-owner relief valve.
 SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
-setup_classify_dir
-seed_summary \
-  '# Per-push CI journey suite — summary' \
-  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
-  "- \`$SATURATED_CLASS\`"
-signature_dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/Saturated--0123456789abcdef/attempt-1/android-test-outputs/androidTest-results/connected"
-mkdir -p "$signature_dir"
-{
-  echo '<?xml version="1.0" encoding="UTF-8"?>'
-  echo "<testsuite name=\"$SATURATED_CLASS\" tests=\"1\">"
-  echo "  <testcase name=\"saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide\" classname=\"$SATURATED_CLASS[emulator-5554 - 15]\">"
-  echo '    <failure message="java.lang.AssertionError: The real system input-method window never became visible.">at org.junit.Assert.fail(Assert.java:89)</failure>'
-  echo '  </testcase>'
-  echo '</testsuite>'
-} > "$signature_dir/TEST-emulator-5554-15_Saturated-1.xml"
+seed_real_ime_classify_fixture() {
+  local owner_detail="$1"
+  local signature_dir
+  setup_classify_dir
+  seed_summary \
+    '# Per-push CI journey suite — summary' \
+    'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
+    "- \`$SATURATED_CLASS\`"
+  signature_dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/Saturated--0123456789abcdef/attempt-1/android-test-outputs/androidTest-results/connected"
+  mkdir -p "$signature_dir"
+  {
+    echo '<?xml version="1.0" encoding="UTF-8"?>'
+    echo "<testsuite name=\"$SATURATED_CLASS\" tests=\"1\">"
+    echo "  <testcase name=\"saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide\" classname=\"${SATURATED_CLASS}[emulator-5554 - 15]\">"
+    echo "    <failure message=\"java.lang.AssertionError: The real system input-method window never became visible. $owner_detail\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+    echo '  </testcase>'
+    echo '</testsuite>'
+  } > "$signature_dir/TEST-emulator-5554-15_Saturated-1.xml"
+}
+
+seed_real_ime_classify_fixture \
+  'app_window_focused=false active_window_pkg=com.google.android.apps.nexuslauncher'
 expect_classify "#1800 real-IME signature" INFRA real_ime_precondition 1 failure failure failure failure false true true
-pass "(x1b) #1800's captured real-IME signature branch still fires (and now names itself)"
+pass "(x1b) #1800's captured real-IME signature fires only with an explicit foreign owner"
+
+seed_real_ime_classify_fixture \
+  'app_window_focused=false active_window_pkg=com.pocketshell.app.i1882'
+expect_classify "#1882 app-owned real-IME failure" RED first_attempt_journey_failure 1 failure failure failure failure false true true
+
+for unsafe_owner_case in \
+  "missing:" \
+  "malformed:active_window_pkg=not/a/package" \
+  "ambiguous:active_window_pkg=android"
+do
+  unsafe_owner_label="${unsafe_owner_case%%:*}"
+  unsafe_owner_detail="${unsafe_owner_case#*:}"
+  seed_real_ime_classify_fixture "$unsafe_owner_detail"
+  expect_classify \
+    "#1882 $unsafe_owner_label owner evidence" \
+    RED first_attempt_journey_failure 1 \
+    failure failure failure failure false true true
+done
+pass "(x1c) app-owned, missing, malformed, and ambiguous owner evidence stays RED through the real workflow body"
 
 # WITH build-phase evidence: only the failure branches switch to the
 # cold-build attribution — and their severity is UNCHANGED (still exit 1).


### PR DESCRIPTION
Closes #1882

Narrows real-IME infrastructure classification to explicit foreign window owners so app-owned product failures stay loud. Independent approval: https://github.com/alexeygrigorev/pocketshell/issues/1882#issuecomment-5140193983