### PR TITLE
test: serialize process-global Main dispatcher ownership (#1880)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundQueueClogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundQueueClogTest.kt
@@ -74,7 +74,7 @@ class PromptComposerOutboundQueueClogTest {
     private fun newVm(
         outboundQueueStore: OutboundQueueStore,
     ): PromptComposerViewModel {
-        val dispatcher = StandardTestDispatcher()
+        val dispatcher = StandardTestDispatcher(mainDispatcherRule.dispatcher.scheduler)
         val vm = PromptComposerViewModel(
             audioRecorder = MinimalMicCapture(),
             whisperClientFactory = WhisperClientFactory { fakeWhisperClient() },

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerWireOracleClogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerWireOracleClogTest.kt
@@ -91,7 +91,8 @@ class PromptComposerWireOracleClogTest {
             com.pocketshell.app.settings.VoiceTranscriptionProvider.OpenAiWhisper
     }
 
-    private fun runTestDispatcher() = StandardTestDispatcher()
+    private fun runTestDispatcher() =
+        StandardTestDispatcher(mainDispatcherRule.dispatcher.scheduler)
 
     private fun newVm(outboundQueueStore: OutboundQueueStore): PromptComposerViewModel {
         val dispatcher = runTestDispatcher()

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
@@ -47,7 +47,7 @@ class MainDispatcherRule(
     override fun apply(base: Statement, description: Description): Statement =
         object : Statement() {
             override fun evaluate() {
-                synchronized(mainDispatcherLock) {
+                MainDispatcherTestIsolation.withOwnership {
                     Dispatchers.setMain(dispatcher)
                     // EPIC #792 Slice D: the LivenessProbe is an infinite periodic
                     // `delay` loop. Under `runTest` + the virtual-clock Main set above,
@@ -108,7 +108,4 @@ class MainDispatcherRule(
         dispatcher.scheduler.runCurrent()
     }
 
-    private companion object {
-        private val mainDispatcherLock = Any()
-    }
 }

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRuleTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRuleTest.kt
@@ -3,15 +3,143 @@ package com.pocketshell.app.hosts
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRuleTest {
+
+    @Test
+    fun directMainOwnerCannotOverlapRuleOwner() {
+        val ruleEntered = CountDownLatch(1)
+        val releaseRule = CountDownLatch(1)
+        val directOwnerEntered = CountDownLatch(1)
+        val failure = AtomicReference<Throwable?>()
+
+        val ruleThread = Thread {
+            try {
+                MainDispatcherRule(
+                    StandardTestDispatcher(kotlinx.coroutines.test.TestCoroutineScheduler()),
+                ).apply(
+                    object : Statement() {
+                        override fun evaluate() {
+                            ruleEntered.countDown()
+                            check(releaseRule.await(5, TimeUnit.SECONDS))
+                        }
+                    },
+                    Description.createTestDescription(javaClass, "rule-owner"),
+                ).evaluate()
+            } catch (thrown: Throwable) {
+                failure.compareAndSet(null, thrown)
+            }
+        }
+        val directOwnerThread = Thread {
+            try {
+                check(ruleEntered.await(5, TimeUnit.SECONDS))
+                MainDispatcherOwnershipRule().apply(
+                    object : Statement() {
+                        override fun evaluate() {
+                            directOwnerEntered.countDown()
+                            val directDispatcher =
+                                StandardTestDispatcher(TestCoroutineScheduler())
+                            Dispatchers.setMain(directDispatcher)
+                            try {
+                                Dispatchers.Main.immediate
+                            } finally {
+                                Dispatchers.resetMain()
+                            }
+                        }
+                    },
+                    Description.createTestDescription(javaClass, "direct-owner"),
+                ).evaluate()
+            } catch (thrown: Throwable) {
+                failure.compareAndSet(null, thrown)
+            }
+        }
+
+        ruleThread.start()
+        directOwnerThread.start()
+        assertTrue("the rule owner must enter", ruleEntered.await(5, TimeUnit.SECONDS))
+        try {
+            assertFalse(
+                "a direct Main owner must wait until the active rule releases process-global Main",
+                directOwnerEntered.await(250, TimeUnit.MILLISECONDS),
+            )
+        } finally {
+            releaseRule.countDown()
+            ruleThread.join(5_000)
+            directOwnerThread.join(5_000)
+        }
+        assertFalse("rule owner thread must terminate", ruleThread.isAlive)
+        assertFalse("direct owner thread must terminate", directOwnerThread.isAlive)
+        assertTrue("direct owner must run after the rule releases", directOwnerEntered.await(1, TimeUnit.SECONDS))
+        assertNull(failure.get()?.stackTraceToString(), failure.get())
+    }
+
+    @Test
+    fun appTestsNeverConstructAZeroArgumentTestDispatcher() {
+        val testRoot = appTestRoot()
+        val zeroArgumentConstructor =
+            Regex("""\b(?:Standard|Unconfined)TestDispatcher\(\)""")
+        val offenders = testRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                file.readLines().asSequence().mapIndexedNotNull { index, line ->
+                    if (zeroArgumentConstructor.containsMatchIn(line.substringBefore("//"))) {
+                        "${file.relativeTo(testRoot)}:${index + 1}"
+                    } else {
+                        null
+                    }
+                }
+            }
+            .toList()
+
+        assertTrue(
+            "zero-argument TestDispatcher construction can read process-global Main during " +
+                "JUnit instance construction and recreate TestMainDispatcher:72; offenders=$offenders",
+            offenders.isEmpty(),
+        )
+    }
+
+    @Test
+    fun appTestsRouteEveryMainSwapThroughTheSharedOwnershipSeam() {
+        val ownershipMarkers = listOf(
+            "MainDispatcherRule",
+            "MainDispatcherOwnershipRule",
+            "MainDispatcherTestIsolation",
+            "StandaloneTmuxVmFixture",
+        )
+        val offenders = appTestRoot().walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { file ->
+                val source = file.readText()
+                val swapsMain =
+                    "Dispatchers.setMain(" in source ||
+                        "Dispatchers.resetMain(" in source ||
+                        "Dispatchers::resetMain" in source
+                swapsMain && ownershipMarkers.none(source::contains)
+            }
+            .map { it.relativeTo(appTestRoot()).path }
+            .toList()
+
+        assertTrue(
+            "every process-global Main swap must share the full-statement ownership seam; " +
+                "offenders=$offenders",
+            offenders.isEmpty(),
+        )
+    }
 
     @Test
     fun defaultDispatcherDoesNotAdoptMainSchedulerInstalledDuringRuleConstruction() {
@@ -21,29 +149,38 @@ class MainDispatcherRuleTest {
         // adopts that foreign scheduler, so runTest and ViewModel work no longer
         // share one live clock and the later test hits UncompletedCoroutinesError.
         repeat(100) { iteration ->
-            val foreignDispatcher = StandardTestDispatcher()
-            Dispatchers.setMain(foreignDispatcher)
-            val rule = try {
-                MainDispatcherRule()
-            } finally {
-                Dispatchers.resetMain()
-            }
-
-            val assertion = object : Statement() {
-                override fun evaluate() {
-                    assertNotSame(
-                        "iteration $iteration: a default rule created while another test owns " +
-                            "Main must not inherit that test's scheduler",
-                        foreignDispatcher.scheduler,
-                        rule.dispatcher.scheduler,
-                    )
+            MainDispatcherTestIsolation.withOwnership {
+                val foreignDispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+                Dispatchers.setMain(foreignDispatcher)
+                val rule = try {
+                    MainDispatcherRule()
+                } finally {
+                    Dispatchers.resetMain()
                 }
-            }
 
-            rule.apply(
-                assertion,
-                Description.createTestDescription(javaClass, "foreign-main-construction-$iteration"),
-            ).evaluate()
+                val assertion = object : Statement() {
+                    override fun evaluate() {
+                        assertNotSame(
+                            "iteration $iteration: a default rule created while another test owns " +
+                                "Main must not inherit that test's scheduler",
+                            foreignDispatcher.scheduler,
+                            rule.dispatcher.scheduler,
+                        )
+                    }
+                }
+
+                rule.apply(
+                    assertion,
+                    Description.createTestDescription(javaClass, "foreign-main-construction-$iteration"),
+                ).evaluate()
+            }
         }
     }
+
+    private fun appTestRoot(): File =
+        sequenceOf(
+            File("app/src/test/java"),
+            File("src/test/java"),
+        ).firstOrNull(File::isDirectory)
+            ?: error("cannot locate app src/test/java")
 }

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherTestIsolation.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherTestIsolation.kt
@@ -1,0 +1,38 @@
+package com.pocketshell.app.hosts
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Process-wide ownership boundary for tests that install or reset
+ * `Dispatchers.Main`.
+ *
+ * Coroutine test dispatchers can read the current Main dispatcher while they
+ * are constructed, so every custom Main owner must share this lock with
+ * [MainDispatcherRule].
+ */
+internal object MainDispatcherTestIsolation {
+    private val ownershipMonitor = Any()
+
+    fun <T> withOwnership(block: () -> T): T =
+        synchronized(ownershipMonitor) {
+            block()
+        }
+}
+
+/**
+ * Holds [MainDispatcherTestIsolation] ownership across a complete JUnit
+ * statement, including its `@Before` and `@After` methods.
+ *
+ * Custom fixtures that must manage their own Main dispatcher use this rule;
+ * ordinary tests should use [MainDispatcherRule].
+ */
+class MainDispatcherOwnershipRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                MainDispatcherTestIsolation.withOwnership(base::evaluate)
+            }
+        }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelProfilesTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelProfilesTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -45,7 +46,7 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE, sdk = [33])
 class FolderListViewModelProfilesTest {
 
-    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule(testDispatcher)

--- a/app/src/test/java/com/pocketshell/app/release/UpdateCheckSchedulerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/release/UpdateCheckSchedulerTest.kt
@@ -5,20 +5,19 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.notifications.UpdateNotifier
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -43,7 +42,10 @@ import org.robolectric.annotation.Config
 class UpdateCheckSchedulerTest {
 
     private lateinit var context: Context
-    private val dispatcher = StandardTestDispatcher()
+    private val dispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(dispatcher)
 
     private fun release(tag: String) = ReleaseInfo(
         tagName = tag,
@@ -93,14 +95,8 @@ class UpdateCheckSchedulerTest {
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        Dispatchers.setMain(dispatcher)
         context.getSharedPreferences("update_check_throttle", Context.MODE_PRIVATE)
             .edit().clear().commit()
-    }
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.hosts.MainDispatcherOwnershipRule
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshLeaseConnector
@@ -27,6 +28,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -74,6 +76,9 @@ import java.util.concurrent.Executors
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
 class Issue926SeedIoOffMainTest {
+
+    @get:Rule
+    val mainDispatcherOwnershipRule = MainDispatcherOwnershipRule()
 
     private val mainExecutor = Executors.newSingleThreadExecutor { r ->
         Thread(r, MAIN_THREAD_NAME)

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.projects.FolderImportPayload
 import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.FolderListResult
@@ -7,22 +8,20 @@ import com.pocketshell.app.projects.SessionNamePolicy
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.ProjectRootEntity
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -56,10 +55,10 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE, sdk = [33])
 class StaleSessionPromptControllerTest {
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+    private val mainDispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(mainDispatcher)
 
     private val goneFolder = "/home/alex/git/pocketshell"
 
@@ -71,8 +70,7 @@ class StaleSessionPromptControllerTest {
      * recovery, instead of the silent recreate.
      */
     @Test
-    fun coldRestoreStaleEmitSurfacesPromptWithNoTreeBound() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun coldRestoreStaleEmitSurfacesPromptWithNoTreeBound() = runTest(mainDispatcher) {
         val signals = SessionLifecycleSignals()
         val controller = StaleSessionPromptController(signals)
         runCurrent()
@@ -99,8 +97,7 @@ class StaleSessionPromptControllerTest {
      * a second dialog.
      */
     @Test
-    fun openExistingStaleEmitSurfacesPrompt() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun openExistingStaleEmitSurfacesPrompt() = runTest(mainDispatcher) {
         val signals = SessionLifecycleSignals()
         val controller = StaleSessionPromptController(signals)
         runCurrent()
@@ -118,8 +115,7 @@ class StaleSessionPromptControllerTest {
      * dialog falls its label back to "home" and recreates in the host home dir.
      */
     @Test
-    fun nullFolderStaleEmitStillSurfacesPrompt() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun nullFolderStaleEmitStillSurfacesPrompt() = runTest(mainDispatcher) {
         val signals = SessionLifecycleSignals()
         val controller = StaleSessionPromptController(signals)
         runCurrent()
@@ -141,8 +137,7 @@ class StaleSessionPromptControllerTest {
      * at the delivery layer.
      */
     @Test
-    fun noBroadcastMeansNoPrompt() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun noBroadcastMeansNoPrompt() = runTest(mainDispatcher) {
         val signals = SessionLifecycleSignals()
         val controller = StaleSessionPromptController(signals)
         runCurrent()
@@ -157,8 +152,7 @@ class StaleSessionPromptControllerTest {
 
     /** The user resolving the prompt (recreate / go home) clears it. */
     @Test
-    fun clearResetsPrompt() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun clearResetsPrompt() = runTest(mainDispatcher) {
         val signals = SessionLifecycleSignals()
         val controller = StaleSessionPromptController(signals)
         runCurrent()
@@ -186,8 +180,7 @@ class StaleSessionPromptControllerTest {
      * cold-restore navigate no-op could not do. Returns the resolved session name.
      */
     @Test
-    fun createSessionInFolderCreatesInTheStaleFolderViaGateway() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun createSessionInFolderCreatesInTheStaleFolderViaGateway() = runTest(mainDispatcher) {
         val gateway = RecordingGateway(resolvedName = "work")
         val controller = StaleSessionPromptController(
             SessionLifecycleSignals(),
@@ -230,8 +223,7 @@ class StaleSessionPromptControllerTest {
      * gateway falls back to `~`.
      */
     @Test
-    fun createSessionInFolderNullFolderFallsBackToHome() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun createSessionInFolderNullFolderFallsBackToHome() = runTest(mainDispatcher) {
         val gateway = RecordingGateway(resolvedName = "orphan")
         val controller = StaleSessionPromptController(
             SessionLifecycleSignals(),
@@ -258,8 +250,7 @@ class StaleSessionPromptControllerTest {
      * nothing.
      */
     @Test
-    fun createSessionInFolderFailsWhenHostMissing() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+    fun createSessionInFolderFailsWhenHostMissing() = runTest(mainDispatcher) {
         val gateway = RecordingGateway(resolvedName = "x")
         val controller = StaleSessionPromptController(
             SessionLifecycleSignals(),

--- a/app/src/test/java/com/pocketshell/app/tmux/StandaloneTmuxVmFixture.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StandaloneTmuxVmFixture.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.hosts.MainDispatcherTestIsolation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -196,6 +197,15 @@ internal class StandaloneTmuxVmFixture(
      */
     fun runVmTest(
         disableLivenessProbeAutoStart: Boolean = true,
+        body: suspend TestScope.() -> Unit,
+    ) {
+        MainDispatcherTestIsolation.withOwnership {
+            runVmTestWithMainOwnership(disableLivenessProbeAutoStart, body)
+        }
+    }
+
+    private fun runVmTestWithMainOwnership(
+        disableLivenessProbeAutoStart: Boolean,
         body: suspend TestScope.() -> Unit,
     ) {
         check(!started) {

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTeardownRaceProofTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTeardownRaceProofTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -166,7 +167,8 @@ class ConnectionEffectDriverTeardownRaceProofTest {
         fun totalRecoveryWriters(): Int = reattachReseedCount + pendingReplayCount
     }
 
-    private fun scope(): CoroutineScope = CoroutineScope(Job() + UnconfinedTestDispatcher())
+    private fun scope(): CoroutineScope =
+        CoroutineScope(Job() + UnconfinedTestDispatcher(TestCoroutineScheduler()))
 
     /**
      * BASE-RED (characterization): a `Foreground` during a post-grace teardown-in-flight

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/TransportEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/TransportEffectsTest.kt
@@ -9,6 +9,7 @@ import com.pocketshell.core.connection.SessionId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -102,7 +103,7 @@ class TransportEffectsTest {
 
     @Test
     fun livenessProbeDeclaredDropWalksControllerAndDispatchesAutoReconnectOnly() {
-        runTest(StandardTestDispatcher()) {
+        runTest(StandardTestDispatcher(TestCoroutineScheduler())) {
             val host = HostKey("alice@example.com:22/7")
             val target = SessionId("7/main")
             val manager = ConnectionManager(warmSnapshot = { true })


### PR DESCRIPTION
Closes #1880

Routes every bespoke test Dispatchers.Main owner through one reentrant isolation layer and eliminates implicit scheduler adoption. Independent recurrence approval: https://github.com/alexeygrigorev/pocketshell/issues/1880#issuecomment-5141126652