### PR TITLE
ci: recalibrate dead-channel recurrence oracle (#1883)

### DIFF
--- a/.claude/agents/oncall-engineer.md
+++ b/.claude/agents/oncall-engineer.md
@@ -105,6 +105,72 @@ Look for the actual failure signal, not the framework chrome. Common patterns:
 - **Build failure (Kotlin compile error, missing import)** — almost always a commit defect from the last push. Easy to spot.
 - **Flaky network-dependent test** — repeatable across reruns means infra, one-off means flake. Use `gh run rerun <RUN_ID>` to confirm; if a rerun goes green, file as flake (or comment on existing flake-tracker issue) and exit.
 
+#### 2.1 Definitive dead-channel measurement (issue #1883)
+
+The former #1863 wedge oracle — foreground
+`gate closed bg=false appActive=true hasClient=true disconnected=true ctrl=Live`
+— is obsolete. After #1863, foreground `Live + disconnected` selects
+`LivenessProbeGate.DeadChannel`; `gate closed` is logged only for
+`LivenessProbeGate.Closed`. A zero count from the old grep therefore says
+nothing about whether the dead-wire state occurred.
+
+Use the surviving recovery-declaration signal:
+
+```text
+liveness-probe DECLARED DROP (control channel definitively closed)
+```
+
+After downloading one Android-report shard artifact into `<REPORT_ROOT>`, run:
+
+```bash
+scripts/ci-journey-dead-channel-oracle.py <REPORT_ROOT>
+```
+
+The counter deliberately enforces these evidence rules:
+
+- It scans only
+  `<REPORT_ROOT>/artifacts/ci-journey/class-attempts`. Do not also scan the
+  uploaded `artifacts/ci-journey-attempt-1` snapshot: that is a duplicate of
+  evidence already present in the canonical class-attempt tree.
+- A missing/empty canonical tree, or any attempt with neither a readable
+  `device-logcat.txt` nor readable per-method UTP logcat, is **no observation**,
+  not zero events. The tool exits non-zero; do not replace that error with a
+  hand-written zero row.
+- For each class attempt, count the signal in `device-logcat.txt`; separately
+  aggregate it across that attempt's per-method UTP `logcat-*.txt` files; report
+  the maximum of those two counts. Neither source is a guaranteed superset of
+  the other, and adding them double-counts events captured in both.
+- Keep attempts as separate rows. Never sum attempt 1 and attempt 2, and never
+  turn a retry pair into one larger number.
+- `ReconnectStormLivelockE2eTest` is the specificity control. Its expected
+  count is zero even when it emits many raw `gate closed` lines; a nonzero count
+  needs line-level inspection before any product claim.
+
+Empirical post-fix specificity evidence is preserved in exact-main run
+`30602512103`: ReconnectStorm attempt 1 has 40 raw `gate closed` lines in
+`device-logcat.txt`, 40 across its UTP method logcats (max = 40, never summed),
+and zero replacement events. The same green run's StableWifi and LongRunning
+healthy attempts also have zero replacement events.
+
+The post-#1863 scale is deliberately binary event presence:
+
+- `ZERO_OBSERVED` — zero definitive-close declarations in the observed attempt.
+  This is **not** a global “healthy” verdict; it only says this event was absent
+  from the available logs.
+- `DEAD_CHANNEL_OBSERVED` — one or more definitive-close declarations. The raw
+  count is the number of declarations, not a severity score.
+
+Calibration evidence: the production-faithful connected
+`Issue895SwitchWhileBlackBandJourneyE2eTest#definitiveClosedControlChannelEmitsReplacementOracle`
+waits for the real `tmux-connect-ready` milestone plus reveal/controller
+`Live`, then closes that Docker-backed `-CC` client. Five consecutive
+repository-wrapper attempts pass 1/1 with zero skips; each UTP log contains
+exactly one replacement declaration. The final attempt measures device=1 /
+aggregate UTP=1 / max=1: `DEAD_CHANNEL_OBSERVED`. Exact-main run
+`30602512103` supplies both zero controls named above. The old 26 / 4 / 0
+thresholds measured repeated emissions from a different, now-unreachable gate
+and must never be reused or mapped onto these categories.
+
 ### 3. Classify the failure
 
 #### 3.0 Diff-aware guard — run this BEFORE the table (mandatory, #806)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -308,6 +308,17 @@ jobs:
             scripts/test-ci-journey-infra-signature.sh
           scripts/test-ci-journey-infra-signature.sh
 
+      # Issue #1883: #1863 made the old foreground `gate closed` wedge oracle
+      # structurally impossible. This pure fixture pins the surviving definitive
+      # dead-channel signal, canonical-only artifact traversal, max-of-log-sources
+      # rule, per-attempt output, ReconnectStorm specificity, fail-closed missing
+      # evidence, and the calibrated binary event-presence scale.
+      - name: CI journey dead-channel measurement-oracle guard (issue #1883)
+        run: |
+          chmod +x scripts/ci-journey-dead-channel-oracle.py \
+            scripts/test-ci-journey-dead-channel-oracle.sh
+          scripts/test-ci-journey-dead-channel-oracle.sh
+
       # Issue #1814: the first journey class on a shard used to pay for the cold
       # `:app:compileDebugKotlin` INSIDE its own per-class budget, so it could
       # time out for a reason unrelated to the test — and an `exit 124 /

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.proof
 
+import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
@@ -17,11 +18,13 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.LivenessProbeTestOverride
 import com.pocketshell.app.tmux.TMUX_PULL_TO_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.connection.RevealState
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -101,6 +104,14 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
     @Before
     fun setUp() {
         clearLastSessionPrefs()
+        LivenessProbeTestOverride.setForTest(
+            intervalMs = PROBE_INTERVAL_MS,
+            perProbeTimeoutMs = PROBE_TIMEOUT_MS,
+            // #1863 bypasses this threshold only because the client is
+            // definitively closed. Keep the production value so the journey
+            // cannot pass through the ambiguous missed-ping path.
+            failureThreshold = 4,
+        )
     }
 
     @After
@@ -108,6 +119,7 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
         runCatching {
             compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         }
+        LivenessProbeTestOverride.clear()
         clearLastSessionPrefs()
         seededKey?.let { key ->
             runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }
@@ -166,6 +178,89 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
         writeTimings()
     } }
 
+    /**
+     * Issue #1883 empirical calibration: enter the exact post-#1863 foreground
+     * state the old oracle can no longer see — controller Live over a locally
+     * closed `-CC` client — and require the production liveness loop to emit its
+     * surviving declaration. This uses the real Docker SSH/tmux client and the
+     * real Android log, not a parser fixture or a copied message.
+     */
+    @Test
+    fun definitiveClosedControlChannelEmitsReplacementOracle() { runBlocking<Unit> {
+        val hostRowTag = requireNotNull(seededHostRowTag)
+        // Clear before attach so the production milestone below can only belong
+        // to this test's connect attempt.
+        execShellCommand("logcat -c")
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("definitive-close baseline") { it.contains(READY_MARKER) }
+        waitForConnected("definitive-close baseline")
+
+        // Controller Live is projected before the attach coroutine has finished
+        // revealing the session. Observe the real end-of-connect milestone, then
+        // independently require the public reveal/controller states, so the
+        // self-inflicted close cannot race the client handoff being calibrated.
+        val readyLog = waitForLogcatLine(
+            CONNECT_READY_MILESTONE,
+            CONNECTED_TIMEOUT_MS,
+            RECONNECT_LOG_FILTER,
+        )
+        assertTrue(
+            "precondition: the production attach pipeline must emit " +
+                "$CONNECT_READY_MILESTONE before the client is closed; logcat tail:\n$readyLog",
+            readyLog.contains(CONNECT_READY_MILESTONE),
+        )
+        val vm = currentViewModel()
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            vm.revealState.value is RevealState.Live &&
+                currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+        }
+        assertTrue(
+            "precondition: connect-ready must leave reveal/controller Live; " +
+                "reveal=${vm.revealState.value}, status=${currentConnectionStatus()}",
+            vm.revealState.value is RevealState.Live &&
+                currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+
+        var liveClient: com.pocketshell.core.tmux.TmuxClient? = null
+        compose.activityRule.scenario.onActivity {
+            liveClient = vm.liveTmuxClientForSendOrNullForTest()
+        }
+        // This is the #1863 self-inflicted ExplicitClose shape: the passive
+        // drop classifier deliberately ignores it, leaving the controller Live
+        // until the DeadChannel probe arm observes the closed wire. Close off
+        // main just as production teardown does.
+        val clientToClose = requireNotNull(liveClient) {
+            "precondition: Connected must own a live tmux control client"
+        }
+        assertTrue(
+            "precondition: connect-ready must own a connected control client",
+            !clientToClose.disconnected.value,
+        )
+        // Isolate the replacement-oracle observation from the readiness proof.
+        execShellCommand("logcat -c")
+        clientToClose.close()
+        compose.waitUntil(timeoutMillis = ORACLE_WINDOW_MS) {
+            vm.clientDisconnectedForTest()
+        }
+        assertTrue(
+            "precondition: the real control client must be definitively closed",
+            vm.clientDisconnectedForTest(),
+        )
+
+        val oracleLog = waitForLogcatLine(
+            REPLACEMENT_ORACLE,
+            ORACLE_WINDOW_MS,
+            LIVENESS_LOG_FILTER,
+        )
+        assertTrue(
+            "issue #1883: a foreground Live-over-closed-control-channel attempt " +
+                "must emit the surviving replacement oracle within one shortened " +
+                "probe interval; logcat tail:\n$oracleLog",
+            oracleLog.contains(REPLACEMENT_ORACLE),
+        )
+        writeTimings()
+    } }
+
     // -- escapable-band helpers ----------------------------------------------------
 
     private fun waitForEscapableBand(timeoutMillis: Long): Boolean {
@@ -200,6 +295,30 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
         compose.onAllNodesWithTag(tag, useUnmergedTree = true)
             .fetchSemanticsNodes()
             .isNotEmpty()
+
+    private fun waitForLogcatLine(
+        needle: String,
+        timeoutMillis: Long,
+        logcatFilter: String,
+    ): String {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            last = execShellCommand("logcat -d -v threadtime -s $logcatFilter")
+            if (last.contains(needle)) return last
+            SystemClock.sleep(200)
+        }
+        return execShellCommand("logcat -d -v threadtime -s $logcatFilter")
+    }
+
+    private fun execShellCommand(command: String): String {
+        val descriptor = InstrumentationRegistry.getInstrumentation()
+            .uiAutomation
+            .executeShellCommand(command)
+        return ParcelFileDescriptor.AutoCloseInputStream(descriptor)
+            .bufferedReader()
+            .use { it.readText() }
+    }
 
     // -- attach helpers ------------------------------------------------------------
 
@@ -414,8 +533,17 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
         const val DEVICE_DIR_NAME: String = "issue895-switch-while-black-band"
         const val SESSION_NAME: String = "issue895-band-proof"
         const val READY_MARKER: String = "ISSUE895-BAND-READY"
+        const val CONNECT_READY_MILESTONE: String = "tmux-connect-ready"
+        const val RECONNECT_LOG_FILTER: String = "PsTmuxReconnect:I"
+        const val LIVENESS_LOG_FILTER: String = "PsTmuxLiveness:I"
+        const val REPLACEMENT_ORACLE: String =
+            "liveness-probe DECLARED DROP (control channel definitively closed)"
+        const val PROBE_INTERVAL_MS: Long = 1_000L
+        const val PROBE_TIMEOUT_MS: Long = 2_000L
 
         val BAND_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 12_000L
+        val ORACLE_WINDOW_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 12_000L
         val HOST_ROW_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L

--- a/scripts/ci-journey-dead-channel-oracle.py
+++ b/scripts/ci-journey-dead-channel-oracle.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Count the post-#1863 definitive-dead-channel signal per journey attempt.
+
+This is deliberately an event-observation tool, not a health/severity
+classifier.  Its post-#1863 calibration is binary: zero declarations means
+ZERO_OBSERVED; one or more means DEAD_CHANNEL_OBSERVED.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+SIGNAL = "liveness-probe DECLARED DROP (control channel definitively closed)"
+
+
+class MeasurementError(RuntimeError):
+    """The artifact cannot support an observed-zero measurement."""
+
+
+def count_signal(path: Path) -> int:
+    try:
+        return sum(
+            line.count(SIGNAL)
+            for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+        )
+    except OSError as error:
+        raise MeasurementError(f"cannot read log source {path}: {error}") from error
+
+
+def manifest_value(attempt_dir: Path, key: str, fallback: str) -> str:
+    manifest = attempt_dir / "manifest.txt"
+    try:
+        for line in manifest.read_text(encoding="utf-8", errors="replace").splitlines():
+            name, separator, value = line.partition("=")
+            if separator and name == key:
+                return value
+    except OSError:
+        pass
+    return fallback
+
+
+def attempt_number(attempt_dir: Path) -> int:
+    value = manifest_value(
+        attempt_dir,
+        "attempt",
+        attempt_dir.name.removeprefix("attempt-"),
+    )
+    try:
+        return int(value)
+    except ValueError:
+        return sys.maxsize
+
+
+def canonical_attempt_root(report_root: Path) -> Path:
+    return report_root / "artifacts" / "ci-journey" / "class-attempts"
+
+
+def measure(report_root: Path) -> list[tuple[str, int, int, int, int, str]]:
+    attempts_root = canonical_attempt_root(report_root)
+    if not attempts_root.is_dir():
+        raise FileNotFoundError(
+            f"canonical journey attempts missing: {attempts_root} "
+            "(the ci-journey-attempt-1 snapshot is intentionally excluded)"
+        )
+
+    rows: list[tuple[str, int, int, int, int, str]] = []
+    attempt_dirs = sorted(
+        path
+        for path in attempts_root.glob("*/*/attempt-*")
+        if path.is_dir()
+    )
+    if not attempt_dirs:
+        raise MeasurementError(
+            f"canonical journey attempts tree is empty: {attempts_root}"
+        )
+
+    for attempt_dir in attempt_dirs:
+        fallback_class = attempt_dir.parent.name.split("--", 1)[0]
+        class_name = manifest_value(attempt_dir, "class", fallback_class)
+        attempt = attempt_number(attempt_dir)
+
+        device_log = attempt_dir / "device-logcat.txt"
+        has_device_log = device_log.is_file()
+        device_count = count_signal(device_log) if has_device_log else 0
+
+        # UTP writes one logcat per test method.  Aggregate those method logs,
+        # then take the maximum against device-logcat: neither source is a
+        # guaranteed superset of the other, while summing them double-counts.
+        utp_logs = [
+            path
+            for path in attempt_dir.glob("android-test-outputs/**/logcat-*.txt")
+            if path.is_file()
+        ]
+        if not has_device_log and not utp_logs:
+            raise MeasurementError(
+                f"attempt has no readable device or UTP logcat source: {attempt_dir}"
+            )
+        utp_count = sum(
+            count_signal(path)
+            for path in utp_logs
+        )
+        event_count = max(device_count, utp_count)
+        scale = (
+            "DEAD_CHANNEL_OBSERVED"
+            if event_count > 0
+            else "ZERO_OBSERVED"
+        )
+        rows.append(
+            (
+                class_name,
+                attempt,
+                device_count,
+                utp_count,
+                event_count,
+                scale,
+            )
+        )
+    return sorted(rows, key=lambda row: (row[0], row[1]))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Count definitive-dead-channel recovery events in the canonical "
+            "CI journey class-attempt tree. No severity verdict is emitted."
+        )
+    )
+    parser.add_argument(
+        "report_root",
+        type=Path,
+        help="downloaded Android-report root containing artifacts/ci-journey",
+    )
+    args = parser.parse_args()
+
+    try:
+        rows = measure(args.report_root)
+    except (FileNotFoundError, MeasurementError) as error:
+        parser.error(str(error))
+
+    print("class\tattempt\tdevice_logcat\tutp_method_logcats\tevents\tscale")
+    for row in rows:
+        print("\t".join(str(value) for value in row))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-ci-journey-dead-channel-oracle.sh
+++ b/scripts/test-ci-journey-dead-channel-oracle.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Issue #1883: regression fixture for the post-#1863 dead-channel oracle.
+# Pure filesystem/Python test: no Gradle, emulator, Docker, or tmux.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+ORACLE="$SCRIPT_DIR/ci-journey-dead-channel-oracle.py"
+VM="$REPO_ROOT/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt"
+GATE="$REPO_ROOT/app/src/main/java/com/pocketshell/app/tmux/connection/LivenessProbeGate.kt"
+PROBE="$REPO_ROOT/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+[[ -f "$ORACLE" ]] || fail "oracle missing: $ORACLE"
+for source in "$VM" "$GATE" "$PROBE"; do
+  [[ -f "$source" ]] || fail "production source missing: $source"
+done
+
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+canonical="$sandbox/artifacts/ci-journey/class-attempts/app"
+signal='liveness-probe DECLARED DROP (control channel definitively closed)'
+
+make_attempt() {
+  local key="$1" class="$2" attempt="$3"
+  local dir="$canonical/$key/attempt-$attempt"
+  mkdir -p "$dir"
+  {
+    printf 'format_version=1\n'
+    printf 'module=app\n'
+    printf 'class=%s\n' "$class"
+    printf 'attempt=%s\n' "$attempt"
+  } > "$dir/manifest.txt"
+  printf '%s' "$dir"
+}
+
+wedge1="$(make_attempt KnownWedged--aaaaaaaaaaaaaaaa com.pocketshell.KnownWedged 1)"
+printf '%s\n%s\n' "$signal consecutive=1" "$signal consecutive=1" > "$wedge1/device-logcat.txt"
+mkdir -p "$wedge1/android-test-outputs/results"
+printf '%s\n%s\n%s\n' "$signal" "$signal" "$signal" \
+  > "$wedge1/android-test-outputs/results/logcat-com.pocketshell.KnownWedged-first.txt"
+printf '%s\n' "$signal" \
+  > "$wedge1/android-test-outputs/results/logcat-com.pocketshell.KnownWedged-second.txt"
+
+wedge2="$(make_attempt KnownWedged--aaaaaaaaaaaaaaaa com.pocketshell.KnownWedged 2)"
+printf '%s\n' "$signal consecutive=1" > "$wedge2/device-logcat.txt"
+
+control="$(make_attempt ReconnectStormLivelockE2eTest--bbbbbbbbbbbbbbbb com.pocketshell.app.proof.ReconnectStormLivelockE2eTest 1)"
+{
+  for _ in $(seq 1 4); do
+    printf '%s\n' 'gate closed bg=false appActive=true hasClient=true disconnected=false ctrl=Reattaching'
+  done
+  for _ in $(seq 1 18); do
+    printf '%s\n' 'gate closed bg=false appActive=true hasClient=true disconnected=false ctrl=Attaching'
+  done
+  for _ in $(seq 1 18); do
+    printf '%s\n' 'gate closed bg=false appActive=true hasClient=true disconnected=false ctrl=Reconnecting'
+  done
+} > "$control/device-logcat.txt"
+
+# The artifact upload also carries this duplicate snapshot. It must never be
+# scanned, or attempt 1 is counted twice (and retry totals become nonsense).
+duplicate="$sandbox/artifacts/ci-journey-attempt-1/ci-journey/class-attempts/app/Duplicate--cccccccccccccccc/attempt-1"
+mkdir -p "$duplicate"
+for _ in $(seq 1 99); do printf '%s\n' "$signal"; done > "$duplicate/device-logcat.txt"
+
+# RED control: substitute the obsolete foreground signature into the real
+# counter. It misses both the synthetic post-fix dead-channel attempts and the
+# faithful current ReconnectStorm control shapes. Its blindness to the known
+# positive rows is the load-bearing mutation failure.
+mutant="$sandbox/old-gate-closed-oracle.py"
+sed 's|^SIGNAL = .*|SIGNAL = "gate closed bg=false appActive=true hasClient=true disconnected=true ctrl=Live"|' \
+  "$ORACLE" > "$mutant"
+mutant_output="$(python3 "$mutant" "$sandbox")" || fail "old-oracle mutant did not run"
+grep -Fqx $'com.pocketshell.KnownWedged\t1\t0\t0\t0\tZERO_OBSERVED' <<<"$mutant_output" \
+  || fail "RED control: old oracle unexpectedly saw the post-fix dead-channel fixture"
+grep -Fqx $'com.pocketshell.app.proof.ReconnectStormLivelockE2eTest\t1\t0\t0\t0\tZERO_OBSERVED' <<<"$mutant_output" \
+  || fail "RED control: old oracle unexpectedly matched a faithful current control shape"
+pass "RED control: obsolete foreground oracle misses the post-#1863 known positive"
+
+output="$("$ORACLE" "$sandbox")" || fail "oracle exited non-zero"
+printf '%s\n' "$output"
+
+grep -Fqx $'com.pocketshell.KnownWedged\t1\t2\t4\t4\tDEAD_CHANNEL_OBSERVED' <<<"$output" \
+  || fail "attempt 1 must use max(device=2, aggregate UTP=4), not sum or one source"
+grep -Fqx $'com.pocketshell.KnownWedged\t2\t1\t0\t1\tDEAD_CHANNEL_OBSERVED' <<<"$output" \
+  || fail "attempt 2 must remain a separate row"
+grep -Fqx $'com.pocketshell.app.proof.ReconnectStormLivelockE2eTest\t1\t0\t0\t0\tZERO_OBSERVED' <<<"$output" \
+  || fail "ReconnectStorm faithful current high-emission control must score zero"
+[[ "$(grep -c '^com.pocketshell.KnownWedged' <<<"$output")" -eq 2 ]] \
+  || fail "attempts were summed or duplicate snapshot was scanned"
+! grep -q 'Duplicate' <<<"$output" \
+  || fail "obsolete ci-journey-attempt-1 snapshot entered the measurement"
+pass "canonical-only, max-of-sources, per-attempt measurement and specificity"
+
+# Structural red control: after #1863, foreground Live+disconnected selects
+# DeadChannel, while the obsolete text is emitted only for Closed. Therefore an
+# old foreground `gate closed` grep is guaranteed to miss the repaired path.
+grep -q 'controlChannelDisconnected -> LivenessProbeGate.DeadChannel' "$GATE" \
+  || fail "foreground disconnected channel no longer selects DeadChannel"
+closed_block="$(sed -n '/if (gate == LivenessProbeGate.Closed)/,/^[[:space:]]*}/p' "$VM")"
+grep -q '"gate closed bg=' <<<"$closed_block" \
+  || fail "could not prove old message is confined to the Closed branch"
+grep -Fq "$signal" "$PROBE" \
+  || fail "replacement signal no longer exists at the definitive-close decision"
+old_foreground_count="$(grep -c 'gate closed bg=false appActive=true hasClient=true disconnected=true ctrl=Live' \
+  "$wedge1/device-logcat.txt" || true)"
+new_dead_channel_count="$(grep -cF "$signal" "$wedge1/device-logcat.txt" || true)"
+[[ "$old_foreground_count" -eq 0 && "$new_dead_channel_count" -gt 0 ]] \
+  || fail "post-#1863 dead-channel fixture did not reproduce old=0 / replacement>0"
+pass "old foreground oracle is structurally blind; replacement survives"
+
+# The post-fix scale is event presence, not the obsolete severity ladder:
+# exact connected calibration gives known-dead-wire=1 while real healthy and
+# high-emission ReconnectStorm controls give 0.
+[[ "$(grep -c $'\tDEAD_CHANNEL_OBSERVED$' <<<"$output")" -eq 2 ]] \
+  || fail "positive attempts must use the calibrated event-presence category"
+[[ "$(grep -c $'\tZERO_OBSERVED$' <<<"$output")" -eq 1 ]] \
+  || fail "zero-event control must use ZERO_OBSERVED"
+! grep -Eq $'\t(healthy|degraded|wedged)$' <<<"$output" \
+  || fail "oracle laundered event presence into an unsupported severity verdict"
+pass "new binary event-presence scale never reuses obsolete severity thresholds"
+
+if "$ORACLE" "$sandbox/artifacts/ci-journey-attempt-1" >/dev/null 2>&1; then
+  fail "snapshot root must be rejected instead of silently measured"
+fi
+pass "non-canonical/snapshot input fails closed"
+
+empty_report="$sandbox/empty-report"
+mkdir -p "$empty_report/artifacts/ci-journey/class-attempts"
+empty_error=""
+if empty_error="$("$ORACLE" "$empty_report" 2>&1)"; then
+  fail "canonical tree with zero attempts must fail, not print a header-only zero observation"
+fi
+grep -Fq 'canonical journey attempts tree is empty' <<<"$empty_error" \
+  || fail "empty-tree failure did not identify missing observation evidence"
+pass "canonical tree with zero attempts fails closed"
+
+missing_logs_report="$sandbox/missing-logs-report"
+missing_logs_root="$missing_logs_report/artifacts/ci-journey/class-attempts/app/MissingLogs--dddddddddddddddd/attempt-1"
+mkdir -p "$missing_logs_root"
+{
+  printf 'format_version=1\n'
+  printf 'module=app\n'
+  printf 'class=com.pocketshell.MissingLogs\n'
+  printf 'attempt=1\n'
+} > "$missing_logs_root/manifest.txt"
+missing_logs_error=""
+if missing_logs_error="$("$ORACLE" "$missing_logs_report" 2>&1)"; then
+  fail "attempt with neither device nor UTP logcat must fail, not emit an observed zero"
+fi
+grep -Fq 'attempt has no readable device or UTP logcat source' <<<"$missing_logs_error" \
+  || fail "missing-log failure did not identify missing observation evidence"
+pass "attempt with no readable log source fails closed"


### PR DESCRIPTION
Closes #1883

Replaces the obsolete foreground gate-closed counter with a fail-closed, production-observable dead-channel replacement oracle and binary-presence calibration. Independent approval: https://github.com/alexeygrigorev/pocketshell/issues/1883#issuecomment-5141379758