### PR TITLE
ci(watcher): survive launcher pipe loss (#1873)

### DIFF
--- a/.claude/agents/oncall-engineer.md
+++ b/.claude/agents/oncall-engineer.md
@@ -39,25 +39,31 @@ Identify all `failure` runs since the last known-green commit. Group consecutive
 When the target run is still queued or in progress, run `scripts/watch-ci.py`
 once as a transient user unit. The unit survives if the agent harness kills the
 launching shell, while `--log-file` preserves both heartbeats and the watcher's
-final human summary + JSON:
+final human summary + JSON. Keep the transient service's output independent of
+the launcher: stdout and stderr go to the unit journal, never a launcher-owned
+`--pipe`:
 
 ```bash
 unit="ps-ci-watch-<RUN_ID>"
 watch_log="$PWD/build/$unit.log"
 mkdir -p "$PWD/build"
-systemd-run --user --unit="$unit" --pipe --wait \
+systemd-run --user --unit="$unit" --wait \
+  -p StandardOutput=journal \
+  -p StandardError=journal \
   "$PWD/scripts/watch-ci.py" \
   --run-id <RUN_ID> \
   --repo alexeygrigorev/pocketshell \
   --log-file "$watch_log"
 ```
 
-Do not add `--collect` to this recipe. Immediate collection can reap and reset
-the transient unit before `ExecMainStatus` is read, turning a real non-zero
-watcher status into a misleading zero. If the launching shell survives, its
-return code is useful; if it does not, read the final JSON line from
-`"$watch_log"` and the unit journal. After recording the evidence, reap a
-failed retained unit explicitly:
+Do not add `--collect` to this recipe. Do not add `--pipe` either: it makes the
+service's stdout/stderr depend on the `systemd-run` client's file descriptors,
+so a later watcher write can fail if the launching shell disappears even though
+the transient service survived. Immediate collection can reap and reset the
+unit before `ExecMainStatus` is read, turning a real non-zero watcher status
+into a misleading zero. If the launching shell survives, its return code is
+useful; if it does not, read the final JSON line from `"$watch_log"` and the unit
+journal. After recording the evidence, reap a failed retained unit explicitly:
 
 ```bash
 tail -n 30 "$watch_log"

--- a/scripts/watch-ci.py
+++ b/scripts/watch-ci.py
@@ -69,6 +69,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -1184,6 +1185,34 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _best_effort_console_print(text: str, *, stream) -> None:
+    """Emit convenience output without letting a lost reader abort the watch.
+
+    Replacing the failed descriptor matters in addition to catching the write:
+    otherwise CPython can retry the buffered flush during interpreter shutdown
+    and replace the watcher's contractual exit status with 120.
+    """
+    try:
+        print(text, file=stream, flush=True)
+        return
+    except (BrokenPipeError, OSError, ValueError):
+        pass
+
+    try:
+        stream_fd = stream.fileno()
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    except (AttributeError, OSError, ValueError):
+        return
+    try:
+        if devnull_fd != stream_fd:
+            os.dup2(devnull_fd, stream_fd)
+    except OSError:
+        pass
+    finally:
+        if devnull_fd != stream_fd:
+            os.close(devnull_fd)
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
@@ -1199,7 +1228,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     def notice(msg: str) -> None:
         if not args.quiet:
-            print(msg, file=sys.stderr, flush=True)
+            _best_effort_console_print(msg, stream=sys.stderr)
 
     watcher = Watcher(
         GhRunner(),
@@ -1231,8 +1260,11 @@ def main(argv: Optional[list[str]] = None) -> int:
             log_fh.close()
 
     # Compact, token-cheap output: human summary then the final JSON line.
-    print(summary)
-    print(final_json)
+    # Console output is a convenience, not the durable contract. In particular,
+    # a vanished `systemd-run --pipe` client must not turn a completed watch into
+    # CPython's broken-pipe exit 120 after the log-file verdict was persisted.
+    _best_effort_console_print(summary, stream=sys.stdout)
+    _best_effort_console_print(final_json, stream=sys.stdout)
     return outcome.exit_code
 
 

--- a/tools/pocketshell/tests/test_watch_ci.py
+++ b/tools/pocketshell/tests/test_watch_ci.py
@@ -715,6 +715,59 @@ def test_main_writes_final_summary_and_json_to_log_file(monkeypatch, tmp_path, c
     assert payload["run_completed"] is True
 
 
+class _LostLauncherStream:
+    """A systemd-run --pipe stream whose launcher-side reader disappeared."""
+
+    def write(self, _text):
+        raise BrokenPipeError("launcher pipe is gone")
+
+    def flush(self):
+        raise BrokenPipeError("launcher pipe is gone")
+
+
+def test_main_finishes_durable_contract_after_launcher_streams_disappear(
+    monkeypatch, tmp_path
+):
+    """Issue #1873 recurrence: console loss must not abort the durable verdict.
+
+    The live watcher survived its launching shell, then died with status 120 on
+    a later state-change write. Reproduce both lost streams before the first
+    notice and require the log-file contract to finish independently.
+    """
+    gh = FakeGh()
+    gh.queue_run_state(
+        status="in_progress",
+        conclusion=None,
+        jobs=_all_required_jobs("in_progress", None),
+    )
+    gh.queue_run_state(
+        status="completed",
+        conclusion="success",
+        jobs=_all_required_jobs(),
+    )
+    monkeypatch.setattr(wci, "GhRunner", lambda *a, **k: gh)
+    monkeypatch.setattr(wci.sys, "stdout", _LostLauncherStream())
+    monkeypatch.setattr(wci.sys, "stderr", _LostLauncherStream())
+    log_path = tmp_path / "watch.log"
+
+    rc = wci.main(
+        [
+            "--run-id",
+            "123",
+            "--interval",
+            "0",
+            "--log-file",
+            str(log_path),
+        ]
+    )
+
+    assert rc == 0
+    payload = json.loads(log_path.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert payload["result"] == "green"
+    assert payload["exit_reason"] == wci.EXIT_REASON_RUN_COMPLETED
+    assert payload["run_completed"] is True
+
+
 def test_oncall_recipe_preserves_verdict_and_requires_completed_confirmation():
     """Issue #1873: the durable operating instructions must close both traps."""
     prompt = _ONCALL_PROMPT_PATH.read_text(encoding="utf-8")
@@ -725,6 +778,17 @@ def test_oncall_recipe_preserves_verdict_and_requires_completed_confirmation():
     assert "Always confirm\n`status=completed`" in prompt
     assert "required_check_failed_fast" in prompt
     assert "artifacts are not final" in prompt
+
+
+def test_oncall_systemd_recipe_does_not_bind_watcher_output_to_launcher_pipe():
+    """Issue #1873 recurrence: the transient service must own its output sink."""
+    prompt = _ONCALL_PROMPT_PATH.read_text(encoding="utf-8")
+    recipe = prompt.split("```bash", 2)[2].split("```", 1)[0]
+
+    assert "systemd-run --user" in recipe
+    assert "--wait" in recipe
+    assert "--pipe" not in recipe
+    assert "stdout and stderr go to the unit journal" in prompt
 
 
 def test_render_human_summary_under_25_lines_on_failure():


### PR DESCRIPTION
Closes #1873

Makes the sanctioned transient watcher survive launcher exit and durably emit its final JSON/exit contract. Independent recurrence approval: https://github.com/alexeygrigorev/pocketshell/issues/1873#issuecomment-5142228855