### PR TITLE
test(ime): attribute keyboard focus failures correctly (#1879)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -333,6 +333,12 @@ dependencies {
     // `:shared:core-storage`'s own DAO tests.
     testImplementation(libs.room.testing)
 
+    // Issue #1879: the IME-service-state discriminator's DECISION is a pure
+    // function so it can be pinned by a fast JVM test in the required per-PR
+    // `Unit tests` job (`ImeServiceStateSignatureTest`), while the connected
+    // journey only does the `dumpsys` IO. Both source sets therefore need the
+    // shared test-only module.
+    androidTestImplementation(project(":shared:test-support"))
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/ImeServiceStateSignals.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/ImeServiceStateSignals.kt
@@ -1,0 +1,51 @@
+package com.pocketshell.app.proof.signals
+
+import android.os.ParcelFileDescriptor
+import android.provider.Settings
+import android.view.inputmethod.InputMethodManager
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.testsupport.ImeServiceState
+import com.pocketshell.testsupport.parseImeServiceState
+
+/**
+ * Issue #1879: the IO half of the **captured IME-service-state signature**.
+ *
+ * The decision logic is pure and lives in
+ * `shared/test-support/.../ImeServiceState.kt`, pinned by
+ * `ImeServiceStateSignatureTest` in the required per-PR `Unit tests` job. This
+ * file only collects the three real inputs:
+ *
+ *  * `dumpsys input_method` — the service-side facts (`mSystemReady`,
+ *    `mCurMethodId`, `mCurMethod`, `mHaveConnection`);
+ *  * `Settings.Secure.DEFAULT_INPUT_METHOD` — the configured IME;
+ *  * `InputMethodManager.getEnabledInputMethodList()` — whether any IME exists
+ *    to be raised at all.
+ *
+ * **Call it only on a failure path.** The dump is a shell round-trip costing
+ * tens of milliseconds and producing thousands of lines; running it per cycle
+ * on the happy path would be the same class of cross-test cost this issue is
+ * about.
+ */
+fun captureImeServiceState(): ImeServiceState = parseImeServiceState(
+    dumpsysInputMethod = runCatching { executeShellCommand("dumpsys input_method") }.getOrNull(),
+    defaultInputMethod = runCatching {
+        Settings.Secure.getString(
+            InstrumentationRegistry.getInstrumentation().targetContext.contentResolver,
+            Settings.Secure.DEFAULT_INPUT_METHOD,
+        )
+    }.getOrNull(),
+    enabledInputMethodIds = runCatching {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val manager = context.getSystemService(InputMethodManager::class.java)
+        manager?.enabledInputMethodList?.map { it.id }
+    }.getOrNull(),
+)
+
+private fun executeShellCommand(command: String): String {
+    val descriptor = InstrumentationRegistry.getInstrumentation()
+        .uiAutomation
+        .executeShellCommand(command)
+    return ParcelFileDescriptor.AutoCloseInputStream(descriptor).use { stream ->
+        stream.readBytes().toString(Charsets.UTF_8)
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/WindowFocusSignals.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/WindowFocusSignals.kt
@@ -1,0 +1,268 @@
+package com.pocketshell.app.proof.signals
+
+import android.app.Activity
+import android.os.SystemClock
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+
+/**
+ * Issue #1879: window-focus pre-condition signals for journeys that assert on
+ * the **real** system soft keyboard.
+ *
+ * ## Why this exists
+ *
+ * `InputMethodManager.showSoftInput(view)` is not merely "slow" when the app
+ * window does not hold input focus — the framework **refuses it outright**:
+ *
+ * ```
+ * W InputMethodManager: Ignoring showSoftInput() as view=com.termux.view.TerminalView{…} is not served.
+ * I ImeTracker: com.pocketshell.app:…: onFailed at PHASE_CLIENT_VIEW_SERVED
+ * ```
+ *
+ * The "served view" is established by `ViewRootImpl` only for the window that
+ * currently holds input focus. So while ANY other window owns focus — most
+ * commonly a framework error dialog such as `AppNotRespondingDialog`
+ * ("<app> isn't responding" / Close app / Wait) raised for an unrelated system
+ * app — the IME is unreachable **in both directions**: neither `showSoftInput`
+ * nor `hideSoftInputFromWindow` does anything at all.
+ *
+ * That is exactly what reddened `ShowKeyboardChipE2eTest` on shard 2 of run
+ * 30454838433: an ANR dialog raised for `com.google.android.apps.nexuslauncher`
+ * stood over the session screen for the whole class (visible in both the
+ * before-tap and after-tap artifacts of both attempts), so the chip tap could
+ * never raise the keyboard. The test then reported
+ * `ime_visible_after_tap=false raisedMs=45052` — a message that blames the chip
+ * for a state the chip was never given.
+ *
+ * Note the package there is the app the dialog was ABOUT, read from logcat. The
+ * dialog's own **window** belongs to `android`, which is what
+ * [describeActiveWindow] reports and why that reading cannot be used to decide
+ * whose fault a failure is — see [FOREIGN_WINDOW_FOCUS_SIGNATURE].
+ *
+ * ## What this does, and what it deliberately does NOT do
+ *
+ * It **observes and reports**. It never acts on the UI.
+ *
+ * A keyboard-down pre-condition is satisfied by two very different states:
+ *
+ *  * (A) the reported user state — the app window is focused and the keyboard
+ *    is simply down, so a chip tap MUST raise it; and
+ *  * (B) a degenerate state — no app window holds focus at all, so the IME is
+ *    unreachable and nothing about the chip can be observed.
+ *
+ * Only (A) is the maintainer's scenario. [awaitActivityWindowFocus] pins the
+ * journey to (A): it waits, bounded, for focus, and when focus does not arrive
+ * it hands the caller an accurate diagnosis naming the window that owns it so
+ * the caller can HARD-FAIL with the real cause. There is no `assumeTrue` here
+ * and callers must not add one (F3): a self-skip would mean only a healthy
+ * dev-box AVD ever asserts.
+ *
+ * ## Why there is no recovery arm (round-2 review of #1879)
+ *
+ * The first cut of this file tried to *clear* a foreign focus owner — click a
+ * framework ANR-dialog button (an id owned by package `android`), else send a
+ * global BACK. The global BACK had no owner check, and
+ * `TmuxSessionAuxiliaryModals` renders BACK-dismissible `AlertDialog`s on the
+ * very screen under test. So a product regression that popped a spurious modal
+ * over the live session — which the framework refuses `showSoftInput` for in
+ * exactly the same way — would have been dismissed after a wait and the journey
+ * would have gone **green**. That is a masking channel added to a load-bearing
+ * journey, and the artifacts proved the focus owner can be the app itself
+ * (`active_window_pkg=com.pocketshell.app.i1879`).
+ *
+ * Gating the recovery on "the owner is genuinely foreign" closes that specific
+ * hole, but only by adding a branch that decides, on a load-bearing journey,
+ * when a failure is allowed to disappear. A recovery arm is a masking channel
+ * whatever it is gated on, and this one would be reached rarely enough that a
+ * mistake in the gate could sit unnoticed for releases. So the recovery is
+ * **deleted** (D22 hard cut), not shimmed, and this file observes only.
+ *
+ * (An earlier revision of this comment justified the deletion by claiming a
+ * real system error dialog "cannot be manufactured on demand". That is false —
+ * `am crash <pkg>` raises a genuine framework error dialog, package `android`,
+ * with `android:id/aerr_*` nodes. The deletion is right, but for the reason
+ * above, not that one.)
+ *
+ * The environment case is handled where it belongs: the failure is loud and
+ * carries [FOREIGN_WINDOW_FOCUS_SIGNATURE] plus `active_window_pkg=`, so a
+ * human reading the red shard can see immediately that no app window held
+ * focus and who did. It is **not** auto-classified as infrastructure — see the
+ * note on [FOREIGN_WINDOW_FOCUS_SIGNATURE].
+ *
+ * ## No shared-state mutation (round-2 review of #1879)
+ *
+ * Nothing here reads or writes the shared automation service's configuration.
+ * The first cut OR-ed `FLAG_REPORT_VIEW_IDS | FLAG_RETRIEVE_INTERACTIVE_WINDOWS`
+ * into it — a process-wide accessibility reconfiguration that was never
+ * restored, so every later class on the shard inherited it. On an issue whose
+ * subject is one class's environment leaking into another's verdict, that was
+ * the wrong direction. [describeActiveWindow] reads `rootInActiveWindow` only,
+ * which needs no flags, and it is called **only on a failure path** —
+ * [describeActiveWindowCallCount] exists so a test can prove that.
+ */
+
+/**
+ * Stable prefix emitted by callers when the app window never held focus. Kept
+ * as a constant so a CI failure carries one greppable phrase distinguishing
+ * "the environment never let the IME be reachable" from "the control under
+ * test did not work".
+ *
+ * ## Deliberately NOT an auto-INFRA signature (round-3 review of #1879)
+ *
+ * This is a **label**, not a classifier key. `scripts/ci-journey-infra-signature.py`
+ * does not recognise it and must not be taught to, because the only value that
+ * could gate it does not discriminate.
+ *
+ * [describeActiveWindow] reports the package of the **window** that owns focus.
+ * A framework error dialog's window belongs to `android` — never to the app the
+ * dialog is about. Observed on a live API-35 AVD by crashing an unrelated app:
+ *
+ * ```
+ * mCurrentFocus=Window{f0c7097 u0 Application Error: com.android.settings}
+ * package="android"  resource-id="android:id/aerr_close"
+ * ```
+ *
+ * So `active_window_pkg=android` is emitted identically when the launcher ANRs
+ * (environment) and when **PocketShell** ANRs — issue #796, the recurring Codex
+ * terminal freeze, this project's worst recurring product defect. A downgrade
+ * keyed on that value would silently re-run #796 away. Naming the faulting app
+ * instead does not rescue it: the dialog's node tree carries only the localised
+ * app label ("Settings keeps stopping"), never the package, and logcat's
+ * `am_anr`/`am_crash` records are device-global and retain hours, so they say
+ * nothing about who owns focus at the moment of this failure.
+ *
+ * The relief valve is the human one G5 already specifies — the signature is
+ * captured in the failure text and the summary, and the on-call re-runs the
+ * shard deliberately. `scripts/test-ci-journey-infra-signature.sh` pins every
+ * producible owner reading, `android` included, to RED.
+ */
+const val FOREIGN_WINDOW_FOCUS_SIGNATURE: String =
+    "The app window never held input focus, so the system refused every " +
+        "showSoftInput() call (\"is not served\")."
+
+/** Default ceiling for the app window to (re)gain input focus. */
+internal const val WINDOW_FOCUS_DEFAULT_TIMEOUT_MS: Long = 10_000L
+
+/** Emitted when the active window cannot be read at all. */
+const val ACTIVE_WINDOW_UNAVAILABLE: String = "<unavailable>"
+
+@Volatile
+private var describeCalls: Int = 0
+
+/**
+ * How many times [describeActiveWindow] has run in this process. The diagnosis
+ * costs a full accessibility tree fetch, so a journey asserts this stays 0
+ * across its happy path — that is the mechanical proof the diagnosis is lazy
+ * rather than interpolated into an eagerly-evaluated assertion message.
+ */
+fun describeActiveWindowCallCount(): Int = describeCalls
+
+/** Reset the [describeActiveWindowCallCount] baseline for one test. */
+fun resetDescribeActiveWindowCallCount() {
+    describeCalls = 0
+}
+
+/**
+ * Result of [awaitActivityWindowFocus]. [diagnosis] is cheap and constant on
+ * the success path; the expensive active-window description is computed only
+ * when focus was NOT obtained.
+ */
+data class WindowFocusOutcome(
+    val focused: Boolean,
+    val diagnosis: String,
+)
+
+/** One-shot read of `Activity.hasWindowFocus()` on the scenario's activity. */
+fun activityWindowFocused(scenario: ActivityScenario<out Activity>): Boolean {
+    var focused = false
+    runCatching { scenario.onActivity { focused = it.hasWindowFocus() } }
+    return focused
+}
+
+/**
+ * Polls [activityWindowFocused] at 50 ms intervals until the activity's window
+ * holds input focus or [timeoutMs] elapses. Returns the final observed state.
+ * A [timeoutMs] of 0 degenerates to a single immediate read.
+ */
+fun waitForActivityWindowFocused(
+    scenario: ActivityScenario<out Activity>,
+    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+): Boolean {
+    val deadline = SystemClock.elapsedRealtime() + timeoutMs
+    while (SystemClock.elapsedRealtime() < deadline) {
+        if (activityWindowFocused(scenario)) return true
+        SystemClock.sleep(50)
+    }
+    return activityWindowFocused(scenario)
+}
+
+/**
+ * The mirror of [waitForActivityWindowFocused]: polls until the activity's
+ * window has LOST input focus, or [timeoutMs] elapses.
+ *
+ * A test that injects a focus-stealing window needs this, not
+ * `!waitForActivityWindowFocused(...)`: that call returns `true` at the FIRST
+ * poll where focus is still held, so it reports "not stolen" before the
+ * stealer's window has even been attached. Getting this backwards makes the
+ * injection silently fail to reproduce anything.
+ */
+fun waitForActivityWindowFocusLost(
+    scenario: ActivityScenario<out Activity>,
+    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+): Boolean {
+    val deadline = SystemClock.elapsedRealtime() + timeoutMs
+    while (SystemClock.elapsedRealtime() < deadline) {
+        if (!activityWindowFocused(scenario)) return true
+        SystemClock.sleep(50)
+    }
+    return !activityWindowFocused(scenario)
+}
+
+/**
+ * Establish the "app window holds input focus" pre-condition — the bounded,
+ * hard-failing wait the issue asks for on the pre-condition side.
+ *
+ * Observes only. Never throws, never skips, never touches the UI: the caller
+ * asserts on [WindowFocusOutcome.focused] and reports
+ * [WindowFocusOutcome.diagnosis].
+ */
+fun awaitActivityWindowFocus(
+    scenario: ActivityScenario<out Activity>,
+    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+): WindowFocusOutcome {
+    if (waitForActivityWindowFocused(scenario, timeoutMs)) {
+        return WindowFocusOutcome(focused = true, diagnosis = "app_window_focused=true")
+    }
+    // Failure path only — see the laziness note in the file header.
+    return WindowFocusOutcome(
+        focused = false,
+        diagnosis = "app_window_focused=false ${describeActiveWindow()}",
+    )
+}
+
+/**
+ * Describe the window that currently owns the active (focused) accessibility
+ * window: its owning package and root class. Used to name the real cause in a
+ * failure message, and parsed by the CI classifier's foreignness gate.
+ *
+ * Reads `rootInActiveWindow` only — no automation-service flag is read, set, or
+ * restored, so nothing about the shared automation service changes.
+ */
+fun describeActiveWindow(): String {
+    describeCalls++
+    val root = runCatching {
+        InstrumentationRegistry.getInstrumentation().uiAutomation.rootInActiveWindow
+    }.getOrNull()
+        ?: return "active_window_pkg=$ACTIVE_WINDOW_UNAVAILABLE " +
+            "active_window_class=$ACTIVE_WINDOW_UNAVAILABLE"
+    return try {
+        val pkg = root.packageName?.toString()?.takeIf { it.isNotBlank() }
+            ?: ACTIVE_WINDOW_UNAVAILABLE
+        val cls = root.className?.toString()?.takeIf { it.isNotBlank() }
+            ?: ACTIVE_WINDOW_UNAVAILABLE
+        "active_window_pkg=$pkg active_window_class=$cls"
+    } finally {
+        @Suppress("DEPRECATION")
+        runCatching { root.recycle() }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
@@ -1,11 +1,13 @@
 package com.pocketshell.app.session
 
+import android.app.Dialog
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -28,6 +30,14 @@ import com.pocketshell.app.proof.SeedBeforeLaunchRule
 import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.clearLastSessionPrefs
 import com.pocketshell.app.proof.execRemoteSetupUntilReady
+import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
+import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
+import com.pocketshell.app.proof.signals.captureImeServiceState
+import com.pocketshell.app.proof.signals.describeActiveWindow
+import com.pocketshell.app.proof.signals.describeActiveWindowCallCount
+import com.pocketshell.app.proof.signals.resetDescribeActiveWindowCallCount
+import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
+import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
@@ -35,10 +45,14 @@ import com.pocketshell.app.voice.SHOW_KEYBOARD_CHIP_TAG
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.testsupport.IME_SERVICE_UNAVAILABLE_SIGNATURE
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -47,8 +61,8 @@ import java.io.File
 import java.io.FileOutputStream
 
 /**
- * Issue #131 / #1846: connected validation for the show-keyboard chip on the
- * live tmux session screen.
+ * Issue #131 / #1846 / #1879: connected validation for the show-keyboard chip on
+ * the live tmux session screen.
  *
  * ## What this pins
  *
@@ -62,9 +76,9 @@ import java.io.FileOutputStream
  *
  * ## Why the test looks like this (issue #1846)
  *
- * The original body was gated behind `Assume.assumeTrue(…, false)` — an
- * unconditional skip — so roughly 60 lines of it could never execute anywhere,
- * under any configuration. The stated justification was that the raw-SSH
+ * The original body was gated behind an unconditional `Assume` self-skip, so
+ * roughly 60 lines of it could never execute anywhere, under any
+ * configuration. The stated justification was that the raw-SSH
  * "Continue with SSH" escape hatch it navigated through had been deleted by
  * #171 (D22) and that "`ShowKeyboardChipDockerTest` already covers the
  * tmux-attach chip behaviour". The navigation half of that was true; the
@@ -97,19 +111,31 @@ import java.io.FileOutputStream
  *  - the cycle runs **twice**, so a one-shot artefact of initial focus cannot
  *    masquerade as the chip working.
  *
- * ## Signal choice
+ * ## Issue #1879 — the surviving vacuity, and what replaced it
  *
- * The IME-visibility check uses `waitForInputMethodVisible` from the
- * `com.pocketshell.app.proof.signals` package (#140). That helper polls
- * `WindowInsetsCompat.Type.ime()` on the activity decor view — the same signal
- * app code uses for keyboard-aware layouts, and the one the framework
- * propagates as soon as the IME window attaches its insets to the focused
- * window. `dumpsys input_method | grep mInputShown` is deliberately avoided: the
- * IME process updates `mInputShown` asynchronously *after* the insets have
- * already landed, which makes dumpsys lag visibly on swiftshader CI emulators.
+ * `ime_visible_after_tap=false` is emitted by three different worlds, and #1846
+ * closed only one of them:
  *
- * Per F3 there is no `assumeTrue` / `assumeFalse(isRunningOnCi())` anywhere in
- * this test: every assertion is a hard failure on every device.
+ *  1. **the chip is broken** — window focused, IME service healthy, request
+ *     accepted, keyboard still down. The contract failing. Must stay RED;
+ *  2. **no app window holds input focus** — a foreign error dialog owns it, so
+ *     the framework REFUSES `showSoftInput` outright
+ *     (`Ignoring showSoftInput() as view=… is not served`) and the IME is
+ *     unreachable in both directions. Nothing about the chip is observable;
+ *  3. **the IME service itself never raises** — unbound, restarting, or no
+ *     enabled/default IME on the AVD at all.
+ *
+ * On shard 2 of run 30454838433 this class failed BOTH attempts in world 2 — a
+ * `com.google.android.apps.nexuslauncher` ANR dialog stood over the session
+ * screen for the whole class — and reported world 1. So each cycle now
+ * establishes app-window focus the same way it establishes keyboard-down, and
+ * every failure names the state it actually observed. See
+ * `proof/signals/WindowFocusSignals.kt` and
+ * `shared/test-support/.../ImeServiceState.kt`.
+ *
+ * Per F3 there is no `Assume`-based self-skip anywhere in this test — not on
+ * CI, not on a dev-box AVD: every assertion is a hard failure on every
+ * device, and no pre-condition acts on the UI to make a failure go away.
  *
  * ## Artifacts
  *
@@ -123,6 +149,11 @@ import java.io.FileOutputStream
  *  - `03-second-cycle-after-tap-viewport.png` — the repeat cycle.
  *  - `summary.txt` — observed IME-visibility values per cycle, tap→visible
  *    latencies, and the chip-row tag.
+ *  - `04-foreign-focus-owner-stolen-viewport.png` — the #1879 injected state,
+ *    captured once it has settled (a clean "stolen" frame).
+ *  - `05-…` / `06-…` and `summary-foreign-focus-owner.txt` — the recovered
+ *    cycle of the #1879 reproduction. Each `@Test` writes its OWN summary; a
+ *    shared `summary.txt` meant the second silently clobbered the first.
  */
 @RunWith(AndroidJUnit4::class)
 class ShowKeyboardChipE2eTest {
@@ -149,6 +180,9 @@ class ShowKeyboardChipE2eTest {
     private var seededHostRowTag: String? = null
     private val summaryLines = mutableListOf<String>()
 
+    /** #1879: the synthetic focus stealer, torn down even when a cycle fails. */
+    private var focusStealer: Dialog? = null
+
     private suspend fun seedFixture() {
         clearLastSessionPrefs()
         val key = readFixtureKey()
@@ -158,8 +192,23 @@ class ShowKeyboardChipE2eTest {
         seededHostRowTag = seedDockerHost(key)
     }
 
+    @Before
+    fun resetSharedProbes() {
+        resetDescribeActiveWindowCallCount()
+    }
+
     @After
     fun tearDown() {
+        // #1879: never leave a focus-stealing window standing for the next
+        // class on the shard — that is precisely the leak this issue is about.
+        focusStealer?.let { dialog ->
+            runCatching {
+                InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                    if (dialog.isShowing) dialog.dismiss()
+                }
+            }
+        }
+        focusStealer = null
         clearLastSessionPrefs()
         seededKey?.let { key ->
             runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }
@@ -173,18 +222,19 @@ class ShowKeyboardChipE2eTest {
         summaryLines += "chip_test_tag=$SHOW_KEYBOARD_CHIP_TAG"
         summaryLines += "host=$DEFAULT_HOST port=$DEFAULT_PORT user=$DEFAULT_USER"
 
+        // #1879 blocker 2: the accessibility service is PROCESS-wide shared
+        // state. The first cut of the focus diagnosis OR-ed flags into it on
+        // every cycle and never restored them, so every later class on the
+        // shard inherited a reconfigured automation service. Snapshot it here
+        // and prove below it came back untouched.
+        val automationFlagsBefore = uiAutomationServiceFlags()
+        summaryLines += "automation_service_flags_before=$automationFlagsBefore"
+
         attachSeededTmuxSession(hostRowTag)
 
         // The chip only renders once the session screen has reached the live
         // band; wait for the production node rather than a fixed sleep.
-        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
-            runCatching {
-                compose.onAllNodesWithTag(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }.getOrDefault(false)
-        }
-        compose.onNodeWithTag(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true).assertExists()
+        awaitShowKeyboardChip()
 
         // Cycle 1 — the maintainer's reported scenario: keyboard down, one tap,
         // keyboard up.
@@ -203,7 +253,210 @@ class ShowKeyboardChipE2eTest {
             afterArtifact = "03-second-cycle-after-tap-viewport.png",
         )
 
+        // #1879 blocker 2, part 1: the expensive active-window diagnosis is
+        // computed ONLY on a failure path. Interpolating it into an
+        // `assertTrue` message evaluates it eagerly on every cycle — an
+        // accessibility tree dump per cycle of every test in this class.
+        val describeCalls = describeActiveWindowCallCount()
+        summaryLines += "describe_active_window_calls=$describeCalls"
+        assertEquals(
+            "the active-window diagnosis must not run on the happy path (it is an " +
+                "accessibility tree fetch); observed $describeCalls call(s)",
+            0,
+            describeCalls,
+        )
+
+        // #1879 blocker 2, part 2: nothing here may reconfigure the shared
+        // automation service for the rest of the instrumentation process.
+        val automationFlagsAfter = uiAutomationServiceFlags()
+        summaryLines += "automation_service_flags_after=$automationFlagsAfter"
+        assertEquals(
+            "this class must not mutate the process-wide UiAutomation service flags — " +
+                "every later class on the shard inherits them. before=" +
+                "$automationFlagsBefore after=$automationFlagsAfter",
+            automationFlagsBefore,
+            automationFlagsAfter,
+        )
+
         writeSummary()
+    }
+
+    /**
+     * Issue #1879: with a **focus-stealing window over the live session
+     * screen**, the failure must name the window that owns input focus instead
+     * of blaming the show-keyboard chip — and the chip must still work once
+     * that window is gone.
+     *
+     * ## The state this reproduces
+     *
+     * On shard 2 of run 30454838433 this class failed both attempts with
+     * `ime_visible_after_tap=false raisedMs=45052`. The captured artifacts show
+     * why, and it is not the chip: a `com.google.android.apps.nexuslauncher`
+     * **"Pixel Launcher isn't responding"** `AppNotRespondingDialog` stood over
+     * the session screen for the whole class — visible in `01-before-tap` AND
+     * `02-after-tap` of BOTH attempts, the same dialog instance
+     * (`AppNotRespondingDialog@8fb399b`) in each `activity-processes.txt` dump.
+     * With that dialog holding focus the framework refuses the request outright:
+     *
+     * ```
+     * W InputMethodManager: Ignoring showSoftInput() as view=com.termux.view.TerminalView{…} is not served.
+     * ```
+     *
+     * The IME was unreachable in BOTH directions — the cycle's own
+     * `forceHideSoftInput()` also failed at `PHASE_CLIENT_VIEW_SERVED` — so the
+     * keyboard-down pre-condition passed **vacuously** and the post-tap
+     * assertion then blamed the chip for a state it was never given.
+     *
+     * ## Why the injection is synthetic, and why it is faithful
+     *
+     * A third-party launcher cannot be made to ANR on demand, so the state is
+     * injected the #780 way: a focusable window is raised over the activity so
+     * `Activity.hasWindowFocus()` goes false while the activity stays RESUMED
+     * and visible. That geometry — not the dialog's identity — is what produces
+     * the framework's "is not served" refusal, and the reproduction was
+     * confirmed byte-identical to the CI failure (same message, same
+     * `onFailed at PHASE_CLIENT_VIEW_SERVED`, same `is not served` line, same
+     * `VFED.V... .F....ID` view flags, same burn-the-whole-budget shape).
+     *
+     * The stealer is deliberately **not cancelable**: nothing incidental — a
+     * stray BACK, a global action, a swipe — can make it go away. If the
+     * journey were ever to recover from it, that could only be a deliberate act
+     * of the harness, and there is none.
+     *
+     * ## Why the app package is the STRICTER case (round-2 review)
+     *
+     * This stealer is drawn by the app under test, so the diagnosis reports
+     * `active_window_pkg=<the app>`. That is the exact shape of a *product*
+     * regression — a spurious modal over the live session, e.g. one of
+     * `TmuxSessionAuxiliaryModals`' `AlertDialog`s. The harness must therefore
+     * stay RED here and must never dismiss it; both are asserted below.
+     *
+     * No `active_window_pkg` reading gets the shard off RED: the signature is a
+     * label, not an auto-INFRA key, because a framework error dialog's window
+     * reads `android` whether PocketShell ANR'd (#796) or the launcher did. See
+     * the `FOREIGN_WINDOW_FOCUS_SIGNATURE` KDoc; pinned by
+     * `scripts/test-ci-journey-infra-signature.sh`.
+     *
+     * ## What it pins
+     *
+     * RED before the fix: the cycle burns the full show budget and reports
+     * `ime_visible_after_tap=false`, i.e. the #1879 misattribution — the
+     * signature assertion below fails. GREEN after: the cycle fails fast,
+     * naming the focus owner and explicitly not blaming the chip; and once the
+     * stealer is gone the chip raises the keyboard on ONE tap exactly as it
+     * does with no dialog present. The post-tap assertion is untouched and
+     * still hard; only the pre-condition got stricter.
+     */
+    @Test
+    fun foreignFocusOwnerIsNamedAsTheCauseInsteadOfBlamingTheChip() {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "host row was not seeded" }
+        summaryLines += "issue=1879 scenario=show-keyboard-chip-foreign-focus-owner"
+
+        attachSeededTmuxSession(hostRowTag)
+        awaitShowKeyboardChip()
+
+        // Inject the reported state, and HARD-assert the injection landed. A
+        // stealer that failed to take focus would make everything below pass
+        // for the wrong reason (the #780 rule: never let the injection
+        // self-skip).
+        raiseSyntheticFocusStealingWindow()
+        val stolen = waitForActivityWindowFocusLost(
+            scenario = compose.activityRule.scenario,
+            timeoutMs = FOCUS_STEAL_SETTLE_MS,
+        )
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val stolenWindow = describeActiveWindow()
+        summaryLines += "focus_steal.app_window_focus_lost=$stolen"
+        summaryLines += "focus_steal.active_window=$stolenWindow"
+        captureFullDevice(
+            File(ensureArtifactDir(), "04-foreign-focus-owner-stolen-viewport.png"),
+        )
+        if (!stolen) {
+            writeSummary(name = "summary-foreign-focus-owner.txt")
+            fail(
+                "the synthetic focus stealer must actually take input focus away from " +
+                    "the activity window, otherwise this test cannot reproduce #1879; " +
+                    "observed app_window_focus_lost=false $stolenWindow",
+            )
+        }
+
+        val startedAt = SystemClock.elapsedRealtime()
+        val thrown = runCatching {
+            runShowKeyboardCycle(cycle = 1, beforeArtifact = null, afterArtifact = null)
+        }.exceptionOrNull()
+        val failFastMs = SystemClock.elapsedRealtime() - startedAt
+        summaryLines += "focus_steal.cycle_failed=${thrown != null}"
+        summaryLines += "focus_steal.fail_fast_ms=$failFastMs"
+        summaryLines += "focus_steal.failure_message=${thrown?.message?.replace('\n', ' ')}"
+
+        val message = thrown?.message.orEmpty()
+        if (thrown == null) {
+            writeSummary(name = "summary-foreign-focus-owner.txt")
+            fail(
+                "a cycle run while another window owns input focus MUST fail: the chip " +
+                    "cannot be measured in that state. It reported success instead, which " +
+                    "would mean the pre-condition is vacuous again (#1879).",
+            )
+        }
+
+        // THE load-bearing assertion (G6). Before the fix this message read
+        // "expected the soft keyboard to be VISIBLE after ONE tap … raisedMs=30038"
+        // — a chip accusation for a state the chip was never given.
+        assertTrue(
+            "the failure must name the window that owns input focus, not the chip. " +
+                "Expected the #1879 signature; got: $message",
+            message.contains(FOREIGN_WINDOW_FOCUS_SIGNATURE),
+        )
+        assertTrue(
+            "the failure must name the window that owns focus so a human reading the red " +
+                "shard can see who took it; got: $message",
+            message.contains("active_window_pkg="),
+        )
+        assertTrue(
+            "the failure must NOT blame the chip when the chip was never given the " +
+                "state it is contracted to act on; got: $message",
+            !message.contains(CHIP_ACCUSATION),
+        )
+
+        // Blocker 1 (round-2 review): the focus owner here is a window the APP
+        // drew — the exact shape of a spurious-modal product regression. The
+        // harness must not dismiss it, retry past it, or otherwise recover: it
+        // must stay red and say whose window it is.
+        val targetPackage = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+        assertTrue(
+            "an app-owned focus thief is a PRODUCT signal and must be reported as such, " +
+                "never cleared by the harness; expected active_window_pkg=$targetPackage " +
+                "in: $message",
+            message.contains("active_window_pkg=$targetPackage"),
+        )
+        assertTrue(
+            "the stealer must still be standing — nothing in the pre-condition may act " +
+                "on the UI to make a failure go away (that is the masking channel this " +
+                "round removed)",
+            focusStealer?.isShowing == true,
+        )
+
+        // The #1879 failure MODE was "burned the whole show budget and then
+        // blamed the chip". Failing on the pre-condition is strictly faster
+        // than the show budget it no longer reaches.
+        assertTrue(
+            "the pre-condition must fail fast instead of burning the IME show budget " +
+                "(that burn is what produced the misleading raisedMs=45052); " +
+                "observed ${failFastMs}ms vs show budget ${IME_SHOW_TIMEOUT_MS}ms",
+            failFastMs < IME_SHOW_TIMEOUT_MS,
+        )
+
+        // Now remove the injected state and prove the chip itself is fine — the
+        // control that keeps this test from passing merely because everything
+        // is broken (G6).
+        dismissSyntheticFocusStealingWindow()
+        runShowKeyboardCycle(
+            cycle = 2,
+            beforeArtifact = "05-focus-owner-cleared-before-tap-viewport.png",
+            afterArtifact = "06-focus-owner-cleared-after-tap-viewport.png",
+        )
+
+        writeSummary(name = "summary-foreign-focus-owner.txt")
     }
 
     /**
@@ -218,8 +471,39 @@ class ShowKeyboardChipE2eTest {
     private fun runShowKeyboardCycle(
         cycle: Int,
         beforeArtifact: String?,
-        afterArtifact: String,
+        afterArtifact: String?,
     ) {
+        // Issue #1879 — pin the REPORTED state before anything else.
+        //
+        // "The keyboard is down" is satisfied by two different worlds: the
+        // maintainer's (app window focused, keyboard simply down, so a tap MUST
+        // raise it) and a degenerate one (no app window holds focus at all, so
+        // the framework refuses every showSoftInput as "not served" and the IME
+        // is unreachable in BOTH directions). Only the first is the contract
+        // under test; in the second the keyboard-down check passes vacuously and
+        // the post-tap assertion below would blame the chip for a state it was
+        // never given — which is exactly how run 30454838433 reddened behind a
+        // Pixel Launcher ANR dialog.
+        //
+        // So wait for focus the same way forceHideSoftInput() establishes
+        // keyboard-down, and HARD-fail with the real cause when it does not
+        // arrive. No `Assume` self-skip (F3), and no action on the UI: an unfocusable
+        // window is reported, never cleared and never skipped.
+        val focus = awaitActivityWindowFocus(
+            scenario = compose.activityRule.scenario,
+            timeoutMs = WINDOW_FOCUS_TIMEOUT_MS,
+        )
+        summaryLines += "cycle$cycle.app_window_focused_before_tap=${focus.focused}"
+        summaryLines += "cycle$cycle.window_focus_diagnosis=${focus.diagnosis}"
+        if (!focus.focused) {
+            // Built only here — the diagnosis is an accessibility tree fetch.
+            fail(
+                "$FOREIGN_WINDOW_FOCUS_SIGNATURE The show-keyboard chip cannot be " +
+                    "measured in that state, so this is NOT a chip failure " +
+                    "(cycle $cycle): ${focus.diagnosis}.",
+            )
+        }
+
         forceHideSoftInput()
         val downObserved = waitForInputMethodVisible(
             scenario = compose.activityRule.scenario,
@@ -256,18 +540,72 @@ class ShowKeyboardChipE2eTest {
         summaryLines += "cycle$cycle.tap_to_ime_visible_ms=$raisedMs"
 
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        captureFullDevice(File(ensureArtifactDir(), afterArtifact))
+        afterArtifact?.let { captureFullDevice(File(ensureArtifactDir(), it)) }
 
         // The #131 acceptance: the IME must be visible after a single tap.
-        assertTrue(
-            "expected the soft keyboard to be VISIBLE after ONE tap on the show-keyboard " +
-                "chip (cycle $cycle); observed ime_visible_before_tap=$downObserved " +
-                "ime_visible_after_tap=$shown raisedMs=$raisedMs",
-            shown,
+        if (!shown) {
+            fail(describePostTapFailure(cycle, downObserved, raisedMs))
+        }
+    }
+
+    /**
+     * Issue #1879 — the post-tap failure diagnosis, built ONLY when the tap did
+     * not raise the keyboard.
+     *
+     * `ime_visible_after_tap=false` is not one state, it is three (see the class
+     * KDoc). This re-reads the two facts that discriminate them at the moment of
+     * failure, so a future CI red is readable from the message alone:
+     *
+     *  - **focus, re-read now.** The pre-condition checked it before the tap; a
+     *    dialog arriving *after* that check (the organic timing) would otherwise
+     *    still produce the old misleading wording. This closes that residue.
+     *  - **the IME service state.** Window focused, request accepted, but the
+     *    input-method service unbound / not ready / with no enabled IME is the
+     *    third world. The decision is a pure function pinned by
+     *    `ImeServiceStateSignatureTest` in the required Unit job, and it is
+     *    deliberately conservative: unreadable evidence reports UNKNOWN and the
+     *    ordinary chip wording stands, so no environmental excuse is ever
+     *    invented for a genuine defect.
+     *
+     * The IME-service signature is a *label*, not an auto-INFRA net: it is not
+     * registered in `scripts/ci-journey-infra-signature.py`, so it never
+     * downgrades a shard.
+     */
+    private fun describePostTapFailure(cycle: Int, downObserved: Boolean, raisedMs: Long): String {
+        val lateFocus = awaitActivityWindowFocus(
+            scenario = compose.activityRule.scenario,
+            timeoutMs = 0L,
         )
+        val imeService = captureImeServiceState()
+        summaryLines += "cycle$cycle.window_focus_after_tap=${lateFocus.diagnosis}"
+        summaryLines += "cycle$cycle.ime_service_state=${imeService.describe()}"
+
+        val prefix = when {
+            !lateFocus.focused ->
+                "$FOREIGN_WINDOW_FOCUS_SIGNATURE Focus was lost AFTER the pre-condition " +
+                    "check, so the chip was never given the state it acts on: " +
+                    "${lateFocus.diagnosis}. "
+            imeService.serviceUnavailable ->
+                "$IME_SERVICE_UNAVAILABLE_SIGNATURE Observed ${imeService.describe()}. "
+            else -> ""
+        }
+        return prefix + CHIP_ACCUSATION + " (cycle $cycle); observed " +
+            "ime_visible_before_tap=$downObserved ime_visible_after_tap=false " +
+            "raisedMs=$raisedMs ${imeService.describe()}"
     }
 
     // --- Navigation --------------------------------------------------------
+
+    private fun awaitShowKeyboardChip() {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true).assertExists()
+    }
 
     private fun attachSeededTmuxSession(hostRowTag: String) {
         compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
@@ -313,6 +651,56 @@ class ShowKeyboardChipE2eTest {
         }
     }
 
+    // --- #1879 synthetic focus stealer -------------------------------------
+
+    /**
+     * Raise a focusable window over the activity so `hasWindowFocus()` goes
+     * false while the activity stays RESUMED and visible — the geometry that
+     * makes the framework refuse `showSoftInput` with "is not served".
+     *
+     * Not cancelable on purpose: only [dismissSyntheticFocusStealingWindow] and
+     * teardown can remove it, so "the journey recovered from it" can never
+     * happen by accident.
+     */
+    private fun raiseSyntheticFocusStealingWindow() {
+        compose.activityRule.scenario.onActivity { activity ->
+            val dialog = Dialog(activity)
+            val label = TextView(activity).apply {
+                text = "issue-1879 synthetic focus owner"
+                // Focusable content, so the stealer's window is the natural
+                // input-focus target the moment it attaches.
+                isFocusableInTouchMode = true
+                isFocusable = true
+            }
+            dialog.setContentView(label)
+            dialog.setCancelable(false)
+            dialog.setOnDismissListener { focusStealer = null }
+            dialog.show()
+            focusStealer = dialog
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun dismissSyntheticFocusStealingWindow() {
+        val dialog = focusStealer
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            if (dialog?.isShowing == true) dialog.dismiss()
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val regained = waitForActivityWindowFocused(
+            scenario = compose.activityRule.scenario,
+            timeoutMs = WINDOW_FOCUS_TIMEOUT_MS,
+        )
+        summaryLines += "focus_steal.app_window_focus_regained=$regained"
+        if (!regained) {
+            fail(
+                "the activity window must regain input focus once the synthetic stealer " +
+                    "is dismissed, otherwise the control cycle below would not be a " +
+                    "control at all; observed ${describeActiveWindow()}",
+            )
+        }
+    }
+
     // --- IME control -------------------------------------------------------
 
     /**
@@ -336,6 +724,11 @@ class ShowKeyboardChipE2eTest {
             }
         }
     }
+
+    private fun uiAutomationServiceFlags(): Int =
+        runCatching {
+            InstrumentationRegistry.getInstrumentation().uiAutomation.serviceInfo?.flags
+        }.getOrNull() ?: -1
 
     // --- Host / session seeding -------------------------------------------
 
@@ -421,8 +814,14 @@ class ShowKeyboardChipE2eTest {
         return dir
     }
 
-    private fun writeSummary() {
-        val file = File(ensureArtifactDir(), "summary.txt")
+    /**
+     * Each `@Test` writes its OWN summary file. The class has two tests that
+     * both produce a summary, and a shared `summary.txt` meant the second run
+     * silently clobbered the first — the artifact review would then be reading
+     * a different test's numbers than it thought (#1879).
+     */
+    private fun writeSummary(name: String = "summary.txt") {
+        val file = File(ensureArtifactDir(), name)
         file.writeText(summaryLines.joinToString(separator = "\n", postfix = "\n"))
         println("SHOW_KEYBOARD_CHIP_SUMMARY ${file.absolutePath}")
         summaryLines.forEach { println("SHOW_KEYBOARD_CHIP_SUMMARY_LINE $it") }
@@ -463,6 +862,14 @@ class ShowKeyboardChipE2eTest {
         const val READY_MARKER: String = "ISSUE131-SHOW-KEYBOARD-READY"
 
         /**
+         * The #131 acceptance wording. Held as a constant because #1879's
+         * reproduction asserts it is ABSENT when the chip was never given the
+         * state it acts on — the exact misattribution that reddened shard 2.
+         */
+        const val CHIP_ACCUSATION: String =
+            "expected the soft keyboard to be VISIBLE after ONE tap on the show-keyboard chip"
+
+        /**
          * Budget for the keyboard to go DOWN. Generous enough that a slow
          * swiftshader emulator never trips it, tight enough that a keyboard
          * that will not dismiss is reported as a failure rather than absorbed.
@@ -478,5 +885,18 @@ class ShowKeyboardChipE2eTest {
          */
         val IME_SHOW_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 30_000L
+
+        /**
+         * Issue #1879: budget for the app window to (re)gain input focus.
+         * Generous enough to cover a slow swiftshader window transition, short
+         * enough that a standing foreign error dialog is reported as such
+         * rather than eating the IME budget and being misread as a chip
+         * failure.
+         */
+        val WINDOW_FOCUS_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 15_000L else 10_000L
+
+        /** Settle budget for the synthetic stealer to take focus. */
+        const val FOCUS_STEAL_SETTLE_MS: Long = 5_000L
     }
 }

--- a/app/src/test/java/com/pocketshell/app/proof/ImeServiceStateSignatureTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/ImeServiceStateSignatureTest.kt
@@ -1,0 +1,251 @@
+package com.pocketshell.app.proof
+
+import com.pocketshell.testsupport.IME_SERVICE_UNAVAILABLE_SIGNATURE
+import com.pocketshell.testsupport.ImeServiceHealth
+import com.pocketshell.testsupport.parseImeServiceState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1879 — the acceptance test for the issue's "captured IME-service-state
+ * signature" item.
+ *
+ * ## Why this test exists on the JVM rather than on the emulator
+ *
+ * The state it discriminates — the input-method SERVICE itself unable to raise
+ * a window — cannot be produced on the shared AVD without disabling the
+ * emulator's IME, which would corrupt every sibling journey lane running on the
+ * same device. So the *decision* is a pure function over the real
+ * `dumpsys input_method` text (fixtures below are verbatim excerpts from a real
+ * API-35 emulator dump), pinned here in the required per-PR `Unit tests` job,
+ * and the androidTest side only performs the IO.
+ *
+ * ## The property under test
+ *
+ * `ime_visible_after_tap=false` is emitted by three different worlds (see
+ * `ImeServiceState.kt`). This decides ONLY the third — "the service could not
+ * have raised a keyboard for anyone" — and it must be **conservative in the
+ * direction of blaming the product**: an unreadable, truncated, or merely
+ * client-side-negative dump must NOT excuse a failing chip, because a wrong
+ * environmental label on a genuine defect is exactly the misattribution #1879
+ * is about, pointed the other way.
+ */
+class ImeServiceStateSignatureTest {
+
+    @Test
+    fun healthyServiceDoesNotExcuseAFailingChip() {
+        val state = parseImeServiceState(
+            dumpsysInputMethod = HEALTHY_DUMP,
+            defaultInputMethod = LATIN_IME,
+            enabledInputMethodIds = listOf(LATIN_IME),
+        )
+
+        assertEquals(
+            "a bound, ready service with an enabled default IME is AVAILABLE; " +
+                "anything else would hand a real chip failure an environmental excuse. " +
+                state.describe(),
+            ImeServiceHealth.AVAILABLE,
+            state.health,
+        )
+        assertFalse(state.describe(), state.serviceUnavailable)
+        assertEquals(LATIN_IME, state.curMethodId)
+        assertTrue(state.describe(), state.curMethodBound == true)
+        assertTrue(state.describe(), state.systemReady == true)
+    }
+
+    /**
+     * The #1879 state-2 guard. `mBoundToMethod` / `mInputShown` also read false
+     * when a foreign window owns input focus and no view is served, so they must
+     * NOT decide. If they did, a focus-loss — or a genuine chip failure that
+     * never established an input connection — would be relabelled "the IME
+     * service is broken".
+     */
+    @Test
+    fun clientSideNegativesAloneDoNotBlameTheService() {
+        val dump = HEALTHY_DUMP.replace("mBoundToMethod=true", "mBoundToMethod=false")
+        val state = parseImeServiceState(
+            dumpsysInputMethod = dump,
+            defaultInputMethod = LATIN_IME,
+            enabledInputMethodIds = listOf(LATIN_IME),
+        )
+
+        assertEquals(
+            "mBoundToMethod is a CLIENT-side fact: it reads false whenever no view " +
+                "is served, which is also true when a foreign window stole focus and " +
+                "when the chip itself is broken. " + state.describe(),
+            ImeServiceHealth.AVAILABLE,
+            state.health,
+        )
+        assertFalse(state.describe(), state.serviceUnavailable)
+        assertTrue(state.describe(), state.boundToMethod == false)
+        assertTrue(state.describe(), state.inputShown == false)
+    }
+
+    @Test
+    fun noEnabledInputMethodIsTheServiceSignature() {
+        val state = parseImeServiceState(
+            dumpsysInputMethod = HEALTHY_DUMP,
+            defaultInputMethod = null,
+            enabledInputMethodIds = emptyList(),
+        )
+
+        assertEquals(state.describe(), ImeServiceHealth.UNAVAILABLE, state.health)
+        assertTrue(state.describe(), state.serviceUnavailable)
+        assertTrue(state.describe(), state.reasons.contains("no_enabled_input_methods"))
+        assertTrue(state.describe(), state.reasons.contains("no_default_input_method"))
+    }
+
+    @Test
+    fun serviceNotReadyIsTheServiceSignature() {
+        val state = parseImeServiceState(
+            dumpsysInputMethod = HEALTHY_DUMP.replace("mSystemReady=true", "mSystemReady=false"),
+            defaultInputMethod = LATIN_IME,
+            enabledInputMethodIds = listOf(LATIN_IME),
+        )
+
+        assertTrue(state.describe(), state.serviceUnavailable)
+        assertTrue(state.describe(), state.reasons.contains("input_method_service_not_ready"))
+    }
+
+    /** The crash-looping / restarting IME: selected, but nothing bound to it. */
+    @Test
+    fun unboundServiceIsTheServiceSignature() {
+        val dump = HEALTHY_DUMP
+            .replace("mHaveConnection=true", "mHaveConnection=false")
+            .replace(
+                "mCurMethod=com.android.server.inputmethod.IInputMethodInvoker@1c0ac1d",
+                "mCurMethod=null",
+            )
+        val state = parseImeServiceState(
+            dumpsysInputMethod = dump,
+            defaultInputMethod = LATIN_IME,
+            enabledInputMethodIds = listOf(LATIN_IME),
+        )
+
+        assertTrue(state.describe(), state.serviceUnavailable)
+        assertTrue(state.describe(), state.reasons.contains("input_method_service_not_bound"))
+    }
+
+    /**
+     * Asymmetry guard (the conservative direction): IMMS legitimately drops the
+     * binding when no client needs it, so ONE negative binding signal while the
+     * other is positive must NOT be called broken.
+     */
+    @Test
+    fun oneNegativeBindingSignalAloneIsNotEnoughToBlameTheService() {
+        val state = parseImeServiceState(
+            dumpsysInputMethod = HEALTHY_DUMP.replace("mHaveConnection=true", "mHaveConnection=false"),
+            defaultInputMethod = LATIN_IME,
+            enabledInputMethodIds = listOf(LATIN_IME),
+        )
+
+        assertEquals(state.describe(), ImeServiceHealth.AVAILABLE, state.health)
+        assertFalse(state.describe(), state.serviceUnavailable)
+    }
+
+    @Test
+    fun noCurrentInputMethodSelectedIsTheServiceSignature() {
+        val state = parseImeServiceState(
+            dumpsysInputMethod = HEALTHY_DUMP.replace(
+                "mCurMethodId=com.android.inputmethod.latin/.LatinIME",
+                "mCurMethodId=null",
+            ),
+            defaultInputMethod = LATIN_IME,
+            enabledInputMethodIds = listOf(LATIN_IME),
+        )
+
+        assertTrue(state.describe(), state.serviceUnavailable)
+        assertTrue(state.describe(), state.reasons.contains("no_current_input_method_selected"))
+    }
+
+    /**
+     * Fail-safe toward RED. Missing, truncated, or format-drifted evidence is
+     * UNKNOWN — never UNAVAILABLE — so the caller keeps the ordinary
+     * chip-blaming wording rather than inventing an environmental excuse.
+     */
+    @Test
+    fun missingOrUnreadableEvidenceIsUnknownAndNeverAnExcuse() {
+        val noEvidence = parseImeServiceState(null, null, null)
+        assertEquals(noEvidence.describe(), ImeServiceHealth.UNKNOWN, noEvidence.health)
+        assertFalse(noEvidence.describe(), noEvidence.serviceUnavailable)
+        assertTrue(noEvidence.describe(), noEvidence.reasons.contains("no_ime_service_evidence"))
+
+        val driftedFormat = parseImeServiceState(
+            dumpsysInputMethod = "Current Input Method Manager state:\n  someFutureKey=42\n",
+            defaultInputMethod = null,
+            enabledInputMethodIds = null,
+        )
+        assertEquals(driftedFormat.describe(), ImeServiceHealth.UNKNOWN, driftedFormat.health)
+        assertFalse(driftedFormat.describe(), driftedFormat.serviceUnavailable)
+        assertTrue(
+            driftedFormat.describe(),
+            driftedFormat.reasons.contains("ime_service_dump_unreadable"),
+        )
+    }
+
+    /**
+     * The signature phrase must be stable and self-describing: it is what a
+     * future CI red is grepped for, and it must read as "not a chip failure"
+     * without needing this file open.
+     */
+    @Test
+    fun theSignaturePhraseNamesTheServiceAndClearsTheChip() {
+        assertTrue(
+            IME_SERVICE_UNAVAILABLE_SIGNATURE,
+            IME_SERVICE_UNAVAILABLE_SIGNATURE.contains("input-method SERVICE"),
+        )
+        assertTrue(
+            IME_SERVICE_UNAVAILABLE_SIGNATURE,
+            IME_SERVICE_UNAVAILABLE_SIGNATURE.contains("NOT a show-keyboard-chip failure"),
+        )
+    }
+
+    /** The one-line rendering must carry every field an artifact review needs. */
+    @Test
+    fun describeCarriesEveryDiscriminatingField() {
+        val state = parseImeServiceState(HEALTHY_DUMP, LATIN_IME, listOf(LATIN_IME))
+        val described = state.describe()
+        listOf(
+            "ime_service_health=",
+            "cur_method_id=",
+            "cur_method_bound=",
+            "system_ready=",
+            "bound_to_method=",
+            "input_shown=",
+            "default_ime=",
+            "enabled_ime_count=",
+        ).forEach { key ->
+            assertTrue("summary line must carry $key; got: $described", described.contains(key))
+        }
+    }
+
+    private companion object {
+        const val LATIN_IME = "com.android.inputmethod.latin/.LatinIME"
+
+        /**
+         * Verbatim excerpt of a real `dumpsys input_method` state block from the
+         * API-35 emulator this suite runs on (`emulator-5554`, 2026-07-29). Using
+         * the real text — not a hand-written approximation — is what makes the
+         * parser's key names load-bearing: a format drift breaks the fixture
+         * rather than silently returning "healthy".
+         */
+        val HEALTHY_DUMP: String = """
+              mCurrentUserId=0
+              mCurMethodId=com.android.inputmethod.latin/.LatinIME
+              mCurClient=ClientState{399e510 mUid=10121 mPid=1229 mSelfReportedDisplayId=0} mCurSeq=9627
+              mFocusedWindow()=android.os.BinderProxy@7702f31
+              softInputMode=STATE_UNSPECIFIED|ADJUST_NOTHING
+              mCurId=com.android.inputmethod.latin/.LatinIME mHaveConnection=true mBoundToMethod=true mVisibleBound=false
+              mCurToken=android.os.Binder@e9ad5ca
+              mCurTokenDisplayId=0
+              mCurMethod=com.android.server.inputmethod.IInputMethodInvoker@1c0ac1d
+              mRequestedShowExplicitly=false mShowForced=false
+              mImeHiddenByDisplayPolicy=false
+              mInputShown=false
+              mInFullscreenMode=false
+              mSystemReady=true mInteractive=true
+        """.trimIndent()
+    }
+}

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -22,6 +22,9 @@ RETRY_BUDGET="$SCRIPT_DIR/ci-journey-retry-budget.sh"
 AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
 WORKFLOW="${CI_JOURNEY_INFRA_SIGNATURE_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
 ANDROID_TEST="$REPO_ROOT/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt"
+SHOW_KEYBOARD_TEST="$REPO_ROOT/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt"
+WINDOW_FOCUS_SIGNALS="$REPO_ROOT/app/src/androidTest/java/com/pocketshell/app/proof/signals/WindowFocusSignals.kt"
+CLASSIFIER_PY="$SCRIPT_DIR/ci-journey-infra-signature.py"
 
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
@@ -38,8 +41,12 @@ APP_OWNED_REAL_IME_DETAIL='app_window_focused=false active_window_pkg=com.pocket
 FOREIGN_REAL_IME_DETAIL='app_window_focused=false active_window_pkg=com.google.android.apps.nexuslauncher active_window_class=com.android.launcher3.Launcher'
 AMBIGUOUS_ANR_REAL_IME_DETAIL='app_window_focused=false active_window_pkg=android active_window_class=com.android.server.am.AppNotRespondingDialog framework_error_dialog=android:id/aerr_wait'
 RESIDUAL_IME_DETAIL='physicalImeWindows=[package=com.google.android.inputmethod.latin active=false focused=false bounds=Rect(0, 1517 - 1080, 2400)]'
+FOREIGN_FOCUS_SIGNATURE_XML='The app window never held input focus, so the system refused every showSoftInput() call (&quot;is not served&quot;).'
+FOREIGN_FOCUS_TAIL='The show-keyboard chip cannot be measured in that state, so this is NOT a chip failure (cycle 1): app_window_focused=false'
 CONTAINMENT_MESSAGE="java.lang.AssertionError: Node 'prompt-composer-send-enter' must stay above the same-root keyboard boundary. node=Rect.fromLTRB(0.0, 1500.0, 1080.0, 1654.0) keyboardTopPx=1626.0"
 SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
+SHOW_KEYBOARD_CLASS="com.pocketshell.app.session.ShowKeyboardChipE2eTest"
+SHOW_KEYBOARD_METHOD="foreignFocusOwnerIsNamedAsTheCauseInsteadOfBlamingTheChip"
 
 # Issue #1822 — the two genuinely-failing, METHOD-SCOPED entries that ran on
 # shard 1 of run 30334306297 alongside the real-IME precondition, and the exact
@@ -105,7 +112,7 @@ write_case_xml() {
   {
     echo '<?xml version="1.0" encoding="UTF-8"?>'
     echo "<testsuite name=\"$class\" tests=\"$#\">"
-    local spec method outcome
+    local spec method outcome owner
     for spec in "$@"; do
       method="${spec%%:*}"
       outcome="${spec#*:}"
@@ -150,6 +157,14 @@ write_case_xml() {
           ;;
         realime-mixed-owners)
           echo "    <failure message=\"$REAL_IME_MESSAGE $FOREIGN_REAL_IME_DETAIL later_active_window_pkg=com.pocketshell.app.i1882 active_window_pkg=com.pocketshell.app.i1882\">at org.junit.Assert.fail(Assert.java:89)</failure>"
+          ;;
+        focus:*)
+          owner="${outcome#focus:}"
+          echo "    <failure message=\"java.lang.AssertionError: $FOREIGN_FOCUS_SIGNATURE_XML $FOREIGN_FOCUS_TAIL active_window_pkg=$owner active_window_class=android.widget.FrameLayout.\">at org.junit.Assert.fail(Assert.java:89)"
+          echo "at com.pocketshell.app.session.ShowKeyboardChipE2eTest.runShowKeyboardCycle(ShowKeyboardChipE2eTest.kt:547)</failure>"
+          ;;
+        focus-no-owner)
+          echo "    <failure message=\"java.lang.AssertionError: $FOREIGN_FOCUS_SIGNATURE_XML $FOREIGN_FOCUS_TAIL\">at org.junit.Assert.fail(Assert.java:89)</failure>"
           ;;
         containment)
           echo "    <failure message=\"$CONTAINMENT_MESSAGE\">at org.junit.Assert.fail(Assert.java:89)</failure>"
@@ -447,6 +462,135 @@ grep -q 'The real system input-method window never became visible\.' "$ANDROID_T
 grep -qE '\bassume(True|False|NotNull|That)[[:space:]]*\(' "$ANDROID_TEST" \
   && fail "(x7) no Assume self-skip may shield the load-bearing real-IME assertion"
 pass "(x7) production journey hardens focus and emits owner/residual evidence without a skip"
+
+echo
+echo "== #1879 foreign-window focus is a loud label, never auto-INFRA =="
+
+# The #1879 diagnosis has a different safety contract from #1882's real-IME
+# signature. It reports the package of the WINDOW owning focus. A framework
+# ANR/crash dialog belongs to `android` whether the faulting process is the
+# launcher or PocketShell itself (#796), so no owner value can safely license
+# an automatic INFRA downgrade for this message. Every producible owner shape
+# therefore stays product_failure/RED.
+for owner_case in \
+  "android:framework error dialog, ambiguous between launcher and PocketShell ANR" \
+  "com.pocketshell.app.i1879:app-owned focus thief" \
+  "com.android.launcher3:foreign app own window" \
+  "&lt;unavailable&gt;:owner could not be read"
+do
+  owner="${owner_case%%:*}"
+  why="${owner_case#*:}"
+  root="$SANDBOX/n1-${owner//[^A-Za-z0-9]/_}"; mkdir -p "$root"
+  write_summary "$root" 2338 "$SHOW_KEYBOARD_CLASS"
+  write_case_xml "$root" "$SHOW_KEYBOARD_CLASS" 1 \
+    "$SHOW_KEYBOARD_METHOD:focus:$owner"
+  write_case_xml "$root" "$SHOW_KEYBOARD_CLASS" 2 \
+    "$SHOW_KEYBOARD_METHOD:focus:$owner"
+  run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+  [[ "$SIG_CLASS" == "product_failure" ]] \
+    || { printf '%s\n' "$SIG_OUT"; fail "(n1) active_window_pkg=$owner ($why) must stay product_failure, got '$SIG_CLASS'"; }
+  mkdir -p "$root/ci-journey-attempt-1"
+  cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+  shard_verdict_for "$root"
+  [[ "$SHARD_TOKEN" == "RED" ]] \
+    || { printf '%s\n' "$SHARD_VERDICT_OUT"; fail "(n1) active_window_pkg=$owner ($why) must keep the shard RED, got '$SHARD_TOKEN'"; }
+done
+pass "(n1) every producible #1879 active-window owner, including android, stays RED"
+
+root="$SANDBOX/n2-no-owner"; mkdir -p "$root"
+write_summary "$root" 2338 "$SHOW_KEYBOARD_CLASS"
+write_case_xml "$root" "$SHOW_KEYBOARD_CLASS" 1 \
+  "$SHOW_KEYBOARD_METHOD:focus-no-owner"
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(n2) the #1879 label without an owner must stay product_failure, got '$SIG_CLASS'"; }
+pass "(n2) the #1879 label without owner evidence stays RED"
+
+# Extract the production Kotlin constant, then prove the #1882-authoritative
+# classifier does not register it. AST string constants catch a future
+# split/implicitly-concatenated Python literal without tripping on comments.
+[[ -f "$WINDOW_FOCUS_SIGNALS" ]] || fail "(n3) missing $WINDOW_FOCUS_SIGNALS"
+KOTLIN_SIGNATURE="$(python3 - "$WINDOW_FOCUS_SIGNALS" <<'PYEOF'
+import re
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+match = re.search(
+    r'const val FOREIGN_WINDOW_FOCUS_SIGNATURE: String =\s*(.*?)\n\n',
+    text,
+    re.S,
+)
+if not match:
+    sys.exit("could not read FOREIGN_WINDOW_FOCUS_SIGNATURE")
+pieces = re.findall(r'"((?:[^"\\]|\\.)*)"', match.group(1))
+if not pieces:
+    sys.exit("the Kotlin constant has no string literal parts")
+print("".join(piece.replace('\\"', '"') for piece in pieces))
+PYEOF
+)" || fail "(n3) could not extract the Kotlin #1879 signature"
+python3 - "$CLASSIFIER_PY" "$KOTLIN_SIGNATURE" <<'PYEOF' \
+  || fail "(n3) the #1879 label was registered in the #1882 classifier; it must stay RED"
+import ast
+import sys
+
+source_path, signature = sys.argv[1], sys.argv[2]
+tree = ast.parse(open(source_path, encoding="utf-8").read())
+docstring_node = None
+if tree.body and isinstance(tree.body[0], ast.Expr):
+    value = tree.body[0].value
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        docstring_node = value
+for node in ast.walk(tree):
+    if node is docstring_node:
+        continue
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        if signature in node.value:
+            raise SystemExit(1)
+PYEOF
+
+# The verdict layer must likewise refuse a hypothetical #1879 classification,
+# while retaining #1882's explicit-foreign real_ime_precondition control.
+root="$SANDBOX/n3-verdict"; mkdir -p "$root/ci-journey"
+: >"$root/ci-journey/summary.md"
+stub="$SANDBOX/stub-foreign-window-classifier.sh"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'echo journey_failure_classification=foreign_window_focus' >"$stub"
+chmod +x "$stub"
+stub_out="$(CI_JOURNEY_INFRA_SIGNATURE="$stub" bash "$SHARD_VERDICT" "$root")"
+[[ "$(sed -n 's/^shard_signature_verdict=//p' <<<"$stub_out" | tail -n 1)" != "INFRA" ]] \
+  || fail "(n3) foreign_window_focus must not downgrade a shard"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'echo journey_failure_classification=real_ime_precondition' >"$stub"
+stub_out="$(CI_JOURNEY_INFRA_SIGNATURE="$stub" bash "$SHARD_VERDICT" "$root")"
+[[ "$(sed -n 's/^shard_signature_verdict=//p' <<<"$stub_out" | tail -n 1)" == "INFRA" ]] \
+  || fail "(n3) #1882 real_ime_precondition control no longer reaches INFRA"
+pass "(n3) #1879 is unregistered while #1882 explicit-foreign real-IME stays live"
+
+# The precondition observes and diagnoses only. Acting on the UI or mutating
+# process-wide UiAutomation flags can dismiss an app-owned modal and mask a
+# genuine session-screen product regression.
+for banned in 'performGlobalAction' 'GLOBAL_ACTION_' 'ACTION_CLICK' 'performAction' 'serviceInfo'; do
+  grep -q "$banned" "$WINDOW_FOCUS_SIGNALS" \
+    && fail "(n4) $WINDOW_FOCUS_SIGNALS must observe only; found '$banned'"
+done
+pass "(n4) #1879 focus precondition has no UI action or shared-service mutation"
+
+[[ -f "$SHOW_KEYBOARD_TEST" ]] || fail "(n5) missing $SHOW_KEYBOARD_TEST"
+grep -qE '\bassume(True|False|NotNull|That)[[:space:]]*\(' "$SHOW_KEYBOARD_TEST" \
+  && fail "(n5) no Assume self-skip may guard the ShowKeyboardChip proof"
+grep -q 'expected the soft keyboard to be VISIBLE after ONE tap on the show-keyboard chip' \
+  "$SHOW_KEYBOARD_TEST" \
+  || fail "(n5) the hard post-tap acceptance assertion is gone"
+grep -q 'expected the soft keyboard to be HIDDEN before tapping the show-keyboard' \
+  "$SHOW_KEYBOARD_TEST" \
+  || fail "(n5) the hard keyboard-down precondition is gone"
+[[ "$(grep -c 'SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true).performClick()' "$SHOW_KEYBOARD_TEST")" == "1" ]] \
+  || fail "(n5) the chip must be tapped from exactly one production site"
+grep -q "fun $SHOW_KEYBOARD_METHOD" "$SHOW_KEYBOARD_TEST" \
+  || fail "(n5) the #1879 connected reproduction is missing"
+grep -q "$SHOW_KEYBOARD_CLASS" "$REPO_ROOT/scripts/ci-journey-suite.sh" \
+  || fail "(n5) the #1879 class is not wired into the per-push journey gate"
+pass "(n5) hard assertions remain and the #1879 reproduction is gate-wired"
 
 echo
 echo "== #1822 method-scoped bullets and fail-safe-toward-RED parsing =="

--- a/shared/test-support/build.gradle.kts
+++ b/shared/test-support/build.gradle.kts
@@ -4,10 +4,16 @@ plugins {
 }
 
 // Test-only support module (issue #1048). It is consumed exclusively as a
-// `testImplementation` dependency by other modules' unit-test source sets, so
-// nothing here ever ships into the app APK. It holds the ONE audited de-flake
-// settle-pump (`drainMainLooperUntil`) shared across modules so the historically
-// drifting hand-rolled wall-clock pumps converge on a single, reviewed boundary.
+// `testImplementation` / `androidTestImplementation` dependency by other
+// modules' TEST source sets, so nothing here ever ships into the app APK. It
+// holds the ONE audited de-flake settle-pump (`drainMainLooperUntil`) shared
+// across modules so the historically drifting hand-rolled wall-clock pumps
+// converge on a single, reviewed boundary.
+//
+// Issue #1879 added a second kind of tenant: a pure DECISION that both a JVM
+// unit test and a connected journey must agree on. `ImeServiceState.kt` parses
+// `dumpsys input_method` text, so the emulator-only IO stays in `androidTest`
+// while the discrimination it drives is pinned in the required per-PR Unit job.
 //
 // The pump itself is pure JVM (Long deadlines + lambdas) — it deliberately does
 // NOT depend on Robolectric or kotlinx-coroutines-test. The per-tick drain

--- a/shared/test-support/src/main/java/com/pocketshell/testsupport/ImeServiceState.kt
+++ b/shared/test-support/src/main/java/com/pocketshell/testsupport/ImeServiceState.kt
@@ -1,0 +1,236 @@
+package com.pocketshell.testsupport
+
+/**
+ * Issue #1879: the **captured IME-service-state signature**.
+ *
+ * ## The state this exists to name
+ *
+ * A journey that asserts "one tap on the show-keyboard chip raises the REAL
+ * soft keyboard" can fail with the byte-identical message
+ * `ime_visible_after_tap=false raisedMs=45052` in at least three different
+ * worlds, only one of which is a product defect:
+ *
+ *  1. **The chip is broken.** The app window holds input focus, the system
+ *     input-method service is healthy and bound, `showSoftInput` is accepted —
+ *     and the keyboard still does not come up. This is the contract failing,
+ *     and it must stay RED.
+ *  2. **No app window holds input focus** (a foreign error dialog owns it), so
+ *     the framework *refuses* `showSoftInput` outright with
+ *     `Ignoring showSoftInput() as view=… is not served`. Named by
+ *     `FOREIGN_WINDOW_FOCUS_SIGNATURE` on the androidTest side.
+ *  3. **The IME service itself never raises.** The window IS focused, the
+ *     request IS accepted client-side — but the input-method service is
+ *     unbound, still starting, crash-looping, or there is no enabled/default
+ *     IME at all. Nothing about the chip is observable in that world either.
+ *
+ * State 3 is live on the CI AVD fleet, not hypothetical: the failing attempt of
+ * run 30454838433 carried repeated
+ * `ApkAssets: Deleting an ApkAssets object … LatinIMEGooglePrebuilt.apk` churn,
+ * and #1800 exists precisely because that emulator sometimes cannot raise a
+ * physical IME window at all.
+ *
+ * This file is the pure, dependency-free half of the discriminator so it can be
+ * pinned by a fast JVM unit test in the required per-PR `Unit tests` job. The
+ * androidTest side (`ImeServiceStateSignals.kt`) only does the IO —
+ * `dumpsys input_method`, `Settings.Secure.DEFAULT_INPUT_METHOD`, and the
+ * enabled-IME list — and hands the text here.
+ *
+ * ## Deliberately NOT an auto-INFRA signature
+ *
+ * [IME_SERVICE_UNAVAILABLE_SIGNATURE] is a *diagnosis carried in the failure
+ * message and the summary artifact*. It is NOT registered in
+ * `scripts/ci-journey-infra-signature.py`, so it can never downgrade a shard to
+ * INFRA. Every additional auto-INFRA net is a masking risk; this one would be
+ * keyed on state the app itself can influence, so it stays loud. Its job is to
+ * make the next red *readable*, not to make it disappear.
+ *
+ * ## Which fields decide "unavailable", and which are diagnostics only
+ *
+ * Only **service-side** facts decide: `mSystemReady`, the enabled-IME list, the
+ * configured default IME, and whether the input-method manager service is
+ * currently bound to an IME (`mCurMethodId` / `mCurMethod` / `mHaveConnection`).
+ *
+ * `mBoundToMethod` and `mInputShown` are recorded but deliberately do NOT
+ * decide, because they are **client**-side: they also read false in state 2,
+ * where no window is served at all. Letting them decide would relabel a
+ * focus-loss (or a genuine chip failure that never established an input
+ * connection) as "the IME service is broken", i.e. exactly the misattribution
+ * #1879 is about, pointed the other way.
+ */
+
+/**
+ * Stable, greppable prefix emitted when the input-method SERVICE could not have
+ * raised a keyboard for anyone. Kept as a constant so a CI failure carries one
+ * phrase distinguishing "this AVD has no working IME" from "the control under
+ * test did not work".
+ */
+const val IME_SERVICE_UNAVAILABLE_SIGNATURE: String =
+    "The system input-method SERVICE could not have raised a keyboard for any " +
+        "app (no enabled/default IME, or the service is not bound or not ready), " +
+        "so this is NOT a show-keyboard-chip failure."
+
+/** Verdict on whether the IME service was in a position to raise a window. */
+enum class ImeServiceHealth {
+    /** The service is ready and bound to an enabled IME. */
+    AVAILABLE,
+
+    /** The service provably could not have raised a window. */
+    UNAVAILABLE,
+
+    /**
+     * The evidence was missing or unreadable. Treated as "not an excuse": the
+     * caller keeps the ordinary product-failure wording. Fail-safe is toward
+     * RED, never toward a green-looking excuse.
+     */
+    UNKNOWN,
+}
+
+/** Parsed, presentation-ready view of `dumpsys input_method` + IME settings. */
+data class ImeServiceState(
+    val health: ImeServiceHealth,
+    val reasons: List<String>,
+    val curMethodId: String?,
+    val curMethodBound: Boolean?,
+    val systemReady: Boolean?,
+    val boundToMethod: Boolean?,
+    val inputShown: Boolean?,
+    val defaultInputMethod: String?,
+    val enabledInputMethodIds: List<String>,
+) {
+    /** True only when the service provably could not have raised a window. */
+    val serviceUnavailable: Boolean get() = health == ImeServiceHealth.UNAVAILABLE
+
+    /** One-line, artifact-friendly rendering for a summary file or a message. */
+    fun describe(): String = buildString {
+        append("ime_service_health=").append(health.name.lowercase())
+        append(" cur_method_id=").append(curMethodId ?: "<absent>")
+        append(" cur_method_bound=").append(curMethodBound?.toString() ?: "<absent>")
+        append(" system_ready=").append(systemReady?.toString() ?: "<absent>")
+        append(" bound_to_method=").append(boundToMethod?.toString() ?: "<absent>")
+        append(" input_shown=").append(inputShown?.toString() ?: "<absent>")
+        append(" default_ime=").append(defaultInputMethod ?: "<absent>")
+        append(" enabled_ime_count=").append(enabledInputMethodIds.size)
+        if (reasons.isNotEmpty()) {
+            append(" reasons=").append(reasons.joinToString(separator = ","))
+        }
+    }
+}
+
+private val BOOLEAN_KEYS = listOf("mSystemReady", "mBoundToMethod", "mInputShown", "mHaveConnection")
+
+/**
+ * Parse the service-side IME state.
+ *
+ * @param dumpsysInputMethod raw `dumpsys input_method` text, or null when the
+ *   dump could not be taken.
+ * @param defaultInputMethod `Settings.Secure.DEFAULT_INPUT_METHOD`, or null.
+ * @param enabledInputMethodIds ids from `InputMethodManager.getEnabledInputMethodList()`,
+ *   or null when the list could not be read (which is *unknown*, not empty).
+ */
+fun parseImeServiceState(
+    dumpsysInputMethod: String?,
+    defaultInputMethod: String?,
+    enabledInputMethodIds: List<String>?,
+): ImeServiceState {
+    val dump = dumpsysInputMethod?.takeIf { it.isNotBlank() }
+    val curMethodId = dump?.let { readValue(it, "mCurMethodId") }
+    val curMethod = dump?.let { readValue(it, "mCurMethod") }
+    val booleans = BOOLEAN_KEYS.associateWith { key -> dump?.let { readBoolean(it, key) } }
+    val systemReady = booleans["mSystemReady"]
+    val boundToMethod = booleans["mBoundToMethod"]
+    val inputShown = booleans["mInputShown"]
+    val haveConnection = booleans["mHaveConnection"]
+
+    // `mCurMethod` is the live binder to the IME process; `mHaveConnection` is
+    // the service connection to it. Deliberately asymmetric: EITHER reading
+    // positive counts as bound, and only BOTH reading known-negative counts as
+    // unbound. A transiently-unbound-but-healthy service (IMMS drops the
+    // binding when no client needs it) must not be reported as broken — a
+    // wrong environmental label on a genuine chip failure would be this
+    // issue's own misattribution pointed the other way.
+    val curMethodBound: Boolean? = when {
+        haveConnection == null && curMethod == null -> null
+        else -> (haveConnection == true) || curMethod.isPresent()
+    }
+
+    val normalisedDefault = defaultInputMethod?.trim()?.takeIf { it.isNotEmpty() && it != "null" }
+    val reasons = mutableListOf<String>()
+
+    // Evidence sufficiency first: with no dump AND no enabled-IME list there is
+    // nothing to reason from, and inventing an excuse would be worse than
+    // saying so (the caller then keeps the ordinary product-failure wording).
+    val haveEvidence = dump != null || enabledInputMethodIds != null
+    if (!haveEvidence) {
+        return ImeServiceState(
+            health = ImeServiceHealth.UNKNOWN,
+            reasons = listOf("no_ime_service_evidence"),
+            curMethodId = null,
+            curMethodBound = null,
+            systemReady = null,
+            boundToMethod = null,
+            inputShown = null,
+            defaultInputMethod = normalisedDefault,
+            enabledInputMethodIds = emptyList(),
+        )
+    }
+
+    if (enabledInputMethodIds != null && enabledInputMethodIds.isEmpty()) {
+        reasons += "no_enabled_input_methods"
+    }
+    if (enabledInputMethodIds != null && normalisedDefault == null) {
+        reasons += "no_default_input_method"
+    }
+    if (systemReady == false) {
+        reasons += "input_method_service_not_ready"
+    }
+    // Only meaningful when the key is actually PRESENT and reads null/none. A
+    // dump whose format no longer carries the key at all is unreadable
+    // evidence, not proof that no IME is selected.
+    if (dump != null && dump.contains("mCurMethodId=") && !curMethodId.isPresent()) {
+        reasons += "no_current_input_method_selected"
+    }
+    if (curMethodBound == false) {
+        reasons += "input_method_service_not_bound"
+    }
+
+    val health = when {
+        reasons.isNotEmpty() -> ImeServiceHealth.UNAVAILABLE
+        // A readable dump with none of the service-side keys present is not
+        // evidence of health — the format changed or the dump was truncated.
+        dump != null && systemReady == null && curMethodId == null && curMethodBound == null ->
+            ImeServiceHealth.UNKNOWN
+        else -> ImeServiceHealth.AVAILABLE
+    }
+    val finalReasons = if (health == ImeServiceHealth.UNKNOWN && reasons.isEmpty()) {
+        listOf("ime_service_dump_unreadable")
+    } else {
+        reasons.toList()
+    }
+
+    return ImeServiceState(
+        health = health,
+        reasons = finalReasons,
+        curMethodId = curMethodId,
+        curMethodBound = curMethodBound,
+        systemReady = systemReady,
+        boundToMethod = boundToMethod,
+        inputShown = inputShown,
+        defaultInputMethod = normalisedDefault,
+        enabledInputMethodIds = enabledInputMethodIds.orEmpty(),
+    )
+}
+
+private fun String?.isPresent(): Boolean =
+    this != null && isNotBlank() && this != "null" && this != "none"
+
+private fun readValue(dump: String, key: String): String? {
+    val regex = Regex("""\b${Regex.escape(key)}=(\S+)""")
+    return regex.find(dump)?.groupValues?.get(1)
+}
+
+private fun readBoolean(dump: String, key: String): Boolean? =
+    when (readValue(dump, key)?.lowercase()) {
+        "true" -> true
+        "false" -> false
+        else -> null
+    }


### PR DESCRIPTION
Fixes #1879

Replaces the timeout-based keyboard-chip accusation with independent window-focus and IME-service state signals, while preserving the byte-authoritative #1882 classifier contract.

Evidence:
- current-main RED reproduced the 30-second false attribution
- candidate connected GREEN twice
- independent reviewer GREEN→RED→GREEN
- parser matrix 10/10
- canonical full JVM gate 603/603 tasks
- #1882 classifier, verdict, and workflow files remain byte-identical

Independent approval: https://github.com/alexeygrigorev/pocketshell/issues/1879#issuecomment-5142896487

This PR is based on exact main e07c782581ed7fb941c950e94f61a414acbc659e and will be rebased/revalidated if main moves before merge.