### PR TITLE
fix(composer): dismiss accepted prompts before delivery (#695)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDraftLossOnFinalizeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDraftLossOnFinalizeE2eTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
@@ -50,6 +51,7 @@ import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.core.voice.WhisperClient
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
@@ -152,9 +154,17 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
         val queue = InMemoryOutboundQueueStore()
         val vm = newViewModel(drafts, queue)
         val visible = mutableStateOf(true)
+        val reductionEntered = CompletableDeferred<Unit>()
+        val releaseReduction = CompletableDeferred<Unit>()
         val sendEntered = CompletableDeferred<Unit>()
         val sendCompleted = CompletableDeferred<Unit>()
+        val sheetMounted = AtomicBoolean(false)
+        val sheetMountedAtSendStart = AtomicReference<Boolean>()
         val targetKey = "1/session-a"
+        vm.beforeHandoffAutoCloseReductionForTest = {
+            reductionEntered.complete(Unit)
+            releaseReduction.await()
+        }
 
         compose.setContent {
             PocketShellTheme {
@@ -162,6 +172,7 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
                     PromptComposerSendDispatcher(
                         viewModel = vm,
                         onSend = {
+                            sheetMountedAtSendStart.set(sheetMounted.get())
                             sendEntered.complete(Unit)
                             delay(10_000)
                             sendCompleted.complete(Unit)
@@ -170,6 +181,10 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
                         onDelivered = { visible.value = false },
                     )
                     if (visible.value) {
+                        DisposableEffect(Unit) {
+                            sheetMounted.set(true)
+                            onDispose { sheetMounted.set(false) }
+                        }
                         PromptComposerSheet(
                             onDismiss = { visible.value = false },
                             onSend = { error("screen-scoped dispatcher owns delivery") },
@@ -188,21 +203,36 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true)
             .performClick()
             .performTextInput("send without waiting")
-        val tappedAt = SystemClock.elapsedRealtime()
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, true).performClick()
 
+        compose.waitUntil(5_000) { reductionEntered.isCompleted }
+        assertFalse(
+            "downstream delivery must not overtake durable local-acceptance dismissal",
+            sendEntered.isCompleted,
+        )
+        assertTrue("the screen owner must remain until acceptance is reduced", visible.value)
+        assertEquals("", vm.uiState.value.draft)
+        WalkthroughScreenshotArtifacts.capture("issue-695-01-accepted-empty-before-reduction")
+
+        val releasedAt = SystemClock.elapsedRealtime()
+        releaseReduction.complete(Unit)
         compose.waitUntil(2_000) { !visible.value }
-        val dismissedAfterMs = SystemClock.elapsedRealtime() - tappedAt
+        val dismissedAfterMs = SystemClock.elapsedRealtime() - releasedAt
         assertTrue(
             "local acceptance must dismiss promptly, took ${dismissedAfterMs}ms",
             dismissedAfterMs < 2_000,
         )
         compose.waitUntil(2_000) { sendEntered.isCompleted }
         assertTrue("host delivery must have started", sendEntered.isCompleted)
+        assertFalse(
+            "the accepted empty sheet must leave composition before host delivery starts",
+            sheetMountedAtSendStart.get() ?: true,
+        )
         assertFalse("dismissal must not await the injected 10s host callback", sendCompleted.isCompleted)
         assertEquals("", vm.uiState.value.draft)
         assertEquals(1, queue.itemsFor(targetKey).size)
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, true).assertDoesNotExist()
+        WalkthroughScreenshotArtifacts.capture("issue-695-02-dismissed-before-delivery")
     }
 
     /**
@@ -355,10 +385,10 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
         compose.onNodeWithTag(COMPOSER_SEND_ENTER_TAG, useUnmergedTree = true)
             .performClick()
         compose.waitUntil(timeoutMillis = 5_000) {
-            sendEntered.isCompleted &&
-                reductionEntered.isCompleted &&
+            reductionEntered.isCompleted &&
                 vm.uiState.value.sendInFlight
         }
+        assertFalse("delivery must wait for the close-or-keep decision", sendEntered.isCompleted)
         // The #971 handoff is real: prompt A moved into exactly one queue row,
         // leaving the editor empty and ready for prompt B.
         assertEquals("", vm.uiState.value.draft)
@@ -371,7 +401,7 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
                 drafts.load(targetKey) == "I can still report"
         }
         releaseReduction.complete(Unit)
-        compose.waitForIdle()
+        compose.waitUntil(timeoutMillis = 5_000) { sendEntered.isCompleted }
         assertTrue("new typing must defeat the pending acceptance dismissal", visible.value)
         WalkthroughScreenshotArtifacts.capture("issue-1616-01-new-draft-during-send")
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
@@ -170,10 +170,10 @@ class PromptComposerSaturatedImeAnchorE2eTest {
             .performClick()
         compose.waitUntil(5_000) {
             reductionEntered.isCompleted &&
-                sendEntered.isCompleted &&
                 vm.uiState.value.sendInFlight &&
                 queue.itemsFor(targetKey).size == 1
         }
+        assertFalse("delivery must wait for the saturated sheet's close-or-keep decision", sendEntered.isCompleted)
 
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
             .performClick()
@@ -183,7 +183,7 @@ class PromptComposerSaturatedImeAnchorE2eTest {
                 drafts.load(targetKey) == LONG_DRAFT_B
         }
         reductionGate.complete(Unit)
-        compose.waitForIdle()
+        compose.waitUntil(5_000) { sendEntered.isCompleted }
         assertTrue("draft B must retain ownership of the saturated sheet", visible.value)
         assertPromptAExactlyOnce(queue, targetKey)
         hideRealImeAndAssertHidden(
@@ -542,10 +542,10 @@ class PromptComposerSaturatedImeAnchorE2eTest {
             .performClick()
         compose.waitUntil(5_000) {
             reductionEntered.isCompleted &&
-                sendEntered.isCompleted &&
                 vm.uiState.value.sendInFlight &&
                 queue.itemsFor(targetKey).size == 1
         }
+        assertFalse("delivery must wait for the saturated sheet's close-or-keep decision", sendEntered.isCompleted)
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG, useUnmergedTree = true)
             .performClick()
             .performTextInput(LONG_DRAFT_B)
@@ -554,7 +554,7 @@ class PromptComposerSaturatedImeAnchorE2eTest {
                 drafts.load(targetKey) == LONG_DRAFT_B
         }
         reductionGate.complete(Unit)
-        compose.waitForIdle()
+        compose.waitUntil(5_000) { sendEntered.isCompleted }
         assertTrue("draft B must retain ownership of the saturated sheet", visible.value)
         assertPromptAExactlyOnce(queue, targetKey)
         hideRealImeAndAssertHidden(

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -8,6 +8,7 @@ import com.pocketshell.app.composer.PromptComposerViewModel.StagedAttachment
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import java.util.UUID
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -41,20 +42,52 @@ internal data class ComposerHandoffAcceptance(
 
 /**
  * One-shot local-acceptance events, split out of the already oversized
- * composer ViewModel. The channel bridges the tiny commit-to-Compose gap; the
- * epoch check below prevents a stale event from closing new composition.
+ * composer ViewModel. The channel bridges the tiny commit-to-Compose gap; each
+ * durable row also owns a reduction barrier so its wire delivery cannot
+ * overtake the close-or-keep decision. The epoch check below prevents a stale
+ * event from closing new composition.
  */
 internal class ComposerHandoffAcceptanceCoordinator {
     private val channel = kotlinx.coroutines.channels.Channel<ComposerHandoffAcceptance>(
         capacity = kotlinx.coroutines.channels.Channel.UNLIMITED,
     )
+    private val pendingReductions = mutableMapOf<String, CompletableDeferred<Unit>>()
     val events = channel.receiveAsFlow()
 
     @androidx.annotation.VisibleForTesting
     var beforeAutoCloseReductionForTest: suspend () -> Unit = {}
 
     fun publish(acceptance: ComposerHandoffAcceptance) {
-        channel.trySend(acceptance)
+        val queueItemId = acceptance.outboundQueueItemId
+        if (queueItemId != null) {
+            synchronized(pendingReductions) {
+                pendingReductions.getOrPut(queueItemId) { CompletableDeferred() }
+            }
+        }
+        if (channel.trySend(acceptance).isFailure) {
+            completeReduction(queueItemId)
+        }
+    }
+
+    suspend fun awaitReduction(outboundQueueItemId: String?) {
+        val reduction = outboundQueueItemId?.let { queueItemId ->
+            synchronized(pendingReductions) { pendingReductions[queueItemId] }
+        }
+        reduction?.await()
+    }
+
+    fun completeReduction(outboundQueueItemId: String?) {
+        val reduction = outboundQueueItemId?.let { queueItemId ->
+            synchronized(pendingReductions) { pendingReductions.remove(queueItemId) }
+        }
+        reduction?.complete(Unit)
+    }
+
+    fun completeAllReductions() {
+        val reductions = synchronized(pendingReductions) {
+            pendingReductions.values.toList().also { pendingReductions.clear() }
+        }
+        reductions.forEach { it.complete(Unit) }
     }
 }
 
@@ -66,6 +99,22 @@ internal var PromptComposerViewModel.beforeHandoffAutoCloseReductionForTest: sus
     set(value) {
         handoffAcceptance.beforeAutoCloseReductionForTest = value
     }
+
+internal suspend fun PromptComposerViewModel.awaitHandoffAcceptanceReduction(
+    outboundQueueItemId: String?,
+) {
+    handoffAcceptance.awaitReduction(outboundQueueItemId)
+}
+
+internal fun PromptComposerViewModel.completeHandoffAcceptanceReduction(
+    acceptance: ComposerHandoffAcceptance,
+) {
+    handoffAcceptance.completeReduction(acceptance.outboundQueueItemId)
+}
+
+internal fun PromptComposerViewModel.completeAllHandoffAcceptanceReductions() {
+    handoffAcceptance.completeAllReductions()
+}
 
 internal fun PromptComposerViewModel.composerRevision(target: String): Long =
     composerRevisionTracker.revision(target)

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -1497,19 +1498,40 @@ public fun PromptComposerSendDispatcher(
     val currentOnSend by rememberUpdatedState(onSend)
     val currentOnDelivered by rememberUpdatedState(onDelivered)
     LaunchedEffect(viewModel) {
-        viewModel.handoffAcceptances.collect { acceptance ->
-            // Issue #695 recurrence: dismissal belongs to local acceptance,
-            // not the 5–10s host delivery callback. Pauseable test seam makes
-            // the post-acceptance/new-draft race deterministic; production is
-            // a no-op and reduces immediately.
-            viewModel.beforeHandoffAutoCloseReductionForTest()
-            if (viewModel.consumeHandoffAcceptanceForAutoClose(acceptance)) {
-                currentOnDelivered()
+        try {
+            viewModel.handoffAcceptances.collect { acceptance ->
+                try {
+                    // Issue #695 recurrence: dismissal belongs to local acceptance,
+                    // not the 5–10s host delivery callback. Pauseable test seam makes
+                    // the post-acceptance/new-draft race deterministic; production is
+                    // a no-op and reduces immediately.
+                    viewModel.beforeHandoffAutoCloseReductionForTest()
+                    if (viewModel.consumeHandoffAcceptanceForAutoClose(acceptance)) {
+                        currentOnDelivered()
+                        // The state write above only schedules recomposition. Do not
+                        // let a synchronous host write monopolise Main before the
+                        // screen owner has removed the accepted empty sheet.
+                        withFrameNanos { }
+                    }
+                } finally {
+                    // Target changes and newer drafts intentionally reject close;
+                    // that decision must release wire delivery immediately.
+                    viewModel.completeHandoffAcceptanceReduction(acceptance)
+                }
             }
+        } finally {
+            // Screen disposal cancels both collectors. Never strand a durable
+            // row behind a reduction whose UI owner no longer exists.
+            viewModel.completeAllHandoffAcceptanceReductions()
         }
     }
     LaunchedEffect(viewModel) {
         viewModel.sendRequests.collect { request ->
+            // A durable row may become drainable on another coroutine as soon
+            // as its queue commit lands. Keep host/TUI work behind the local
+            // acceptance reduction so a slow synchronous write cannot leave
+            // the empty sheet showing "Sending…" until terminal delivery.
+            viewModel.awaitHandoffAcceptanceReduction(request.outboundQueueItemId)
             // Issue #745: bound the send so the in-flight state can never hang.
             // The host `onSend` is a connect-on-action call (#548) that may kick
             // a reconnect and await the live client; cap it at [SEND_TIMEOUT_MS]

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerAcceptanceDismissalTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerAcceptanceDismissalTest.kt
@@ -150,6 +150,37 @@ class PromptComposerAcceptanceDismissalTest {
         assertEquals(OutboundState.Queued, queue.itemsFor(target.sessionKey).single().state)
     }
 
+    @Test
+    fun deliveryBarrierReleasesAfterDecisionAndWhenScreenOwnerDisposes() = runTest {
+        val coordinator = ComposerHandoffAcceptanceCoordinator()
+        val decided = ComposerHandoffAcceptance("1/session-a", 1L, "decided")
+        val disposed = ComposerHandoffAcceptance("1/session-a", 2L, "disposed")
+        var decidedDeliveryReleased = false
+        var disposedDeliveryReleased = false
+        coordinator.publish(decided)
+        coordinator.publish(disposed)
+        backgroundScope.launch {
+            coordinator.awaitReduction(decided.outboundQueueItemId)
+            decidedDeliveryReleased = true
+        }
+        backgroundScope.launch {
+            coordinator.awaitReduction(disposed.outboundQueueItemId)
+            disposedDeliveryReleased = true
+        }
+        runCurrent()
+
+        assertFalse(decidedDeliveryReleased)
+        assertFalse(disposedDeliveryReleased)
+        coordinator.completeReduction(decided.outboundQueueItemId)
+        runCurrent()
+        assertTrue(decidedDeliveryReleased)
+        assertFalse(disposedDeliveryReleased)
+
+        coordinator.completeAllReductions()
+        runCurrent()
+        assertTrue(disposedDeliveryReleased)
+    }
+
     private fun kotlinx.coroutines.test.TestScope.collectAcceptances(
         vm: PromptComposerViewModel,
     ): MutableList<ComposerHandoffAcceptance> {


### PR DESCRIPTION
Fixes #695

Closes the empty prompt composer at durable local queue acceptance before downstream host/TUI delivery begins, while preserving a newer draft typed during the acceptance race.

Real-device recurrence evidence:
- empty sheet remained in Sending, then closed only after Claude received the prompt
- preserved at /home/alexey/pocketshell-evidence/issue-695-real-device-recurrence-20260731/

Verification:
- reviewer-owned RED 1/1 when the per-row acceptance barrier is bypassed
- restored real-sheet GREEN 1/1
- saturated IME class 4/4
- broad composer adjacency 13/13
- focused JVM 45/45
- canonical full JVM 603/603 tasks
- forced androidTest compile 176/176 tasks
- static, lifecycle, deadlock, and visual audits green

Independent approval: https://github.com/alexeygrigorev/pocketshell/issues/695#issuecomment-5143289566

The approved patch was rebased onto exact main 0d0432b0a36d22968e64398cfc9827e788a5304e with stable patch-id 9eedf197bbc5662c59aa5ad82a3da3b7c7706745.