### PR TITLE
fix(ssh): fall back across resolved addresses (#1877)

### DIFF
--- a/shared/core-ssh/build.gradle.kts
+++ b/shared/core-ssh/build.gradle.kts
@@ -154,5 +154,16 @@ project.afterEvaluate {
             .orElse(System.getenv("DOCKER_API_VERSION") ?: "1.45")
             .get()
         systemProperty("api.version", apiVersion)
+
+        // Issue #1877: deterministic dual-family resolver fixture. The first
+        // address is an unreachable IPv6 loopback peer and the second is the
+        // IPv4 loopback where Testcontainers publishes sshd. Pinning the hosts
+        // file and family preference makes the real-transport RED independent
+        // of the developer machine's /etc/hosts and resolver policy.
+        systemProperty(
+            "jdk.net.hosts.file",
+            rootProject.file("tests/docker/issue1877-hosts").absolutePath,
+        )
+        systemProperty("java.net.preferIPv6Addresses", "true")
     }
 }

--- a/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshAddressFallbackIntegrationTest.kt
+++ b/shared/core-ssh/src/integrationTest/java/com/pocketshell/core/ssh/SshAddressFallbackIntegrationTest.kt
@@ -1,0 +1,128 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.runBlocking
+import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.File
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Issue #1877 real-transport regression.
+ *
+ * The integration-test JVM uses `tests/docker/issue1877-hosts`: the synthetic
+ * hostname resolves first to unreachable IPv6 `::2`, then to reachable IPv4
+ * `127.0.0.1`. The production [SshConnection] must try those addresses
+ * sequentially, authenticate exactly once, and return the live second session.
+ *
+ * RED on the exact issue base: sshj's string-host overload chooses only `::2`,
+ * returns `Network is unreachable`, and never reaches the real Docker sshd.
+ * GREEN: the failed address is closed before the IPv4 attempt begins, the real
+ * sshd records exactly one accepted public-key authentication, and `whoami`
+ * round-trips over the resulting [RealSshSession].
+ */
+class SshAddressFallbackIntegrationTest {
+
+    companion object {
+        private const val CONTAINER_SSH_PORT = 22
+        private const val FALLBACK_HOST = "issue1877-fallback.test"
+
+        private val projectRoot: Path by lazy { findProjectRoot() }
+
+        @Volatile
+        private var container: GenericContainer<*>? = null
+
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            val dockerAvailable = runCatching {
+                DockerClientFactory.instance().isDockerAvailable
+            }.getOrDefault(false)
+            assumeTrue("Docker not available; skipping address fallback integration test", dockerAvailable)
+
+            val dockerDir = projectRoot.resolve("tests/docker")
+            val image = ImageFromDockerfile("pocketshell-test-ssh", false)
+                .withDockerfile(dockerDir.resolve("Dockerfile.ssh"))
+            container = GenericContainer(image)
+                .withExposedPorts(CONTAINER_SSH_PORT)
+                .also { it.start() }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            container?.stop()
+            container = null
+        }
+
+        private fun findProjectRoot(): Path {
+            var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+            while (dir != null) {
+                if (dir.resolve("tests/docker/Dockerfile.ssh").toFile().exists()) return dir
+                dir = dir.parent
+            }
+            error("Could not locate tests/docker/Dockerfile.ssh")
+        }
+    }
+
+    private val privateKeyFile: File
+        get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    @Test
+    fun unreachableFirstFamilyFallsThroughSequentiallyToOneRealSshDial() = runBlocking {
+        val resolved = InetAddress.getAllByName(FALLBACK_HOST).toList()
+        assertEquals("fixture must expose exactly two ordered candidates", 2, resolved.size)
+        assertTrue("first candidate must be IPv6, got $resolved", resolved.first() is Inet6Address)
+        assertEquals("0:0:0:0:0:0:0:2", resolved.first().hostAddress)
+        assertEquals("127.0.0.1", resolved.last().hostAddress)
+
+        val acceptedBefore = acceptedPublicKeyCount()
+        val result = SshConnection.connect(
+            host = FALLBACK_HOST,
+            port = container!!.getMappedPort(CONTAINER_SSH_PORT),
+            user = "testuser",
+            key = SshKey.Path(privateKeyFile),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 8_000,
+        )
+
+        assertTrue(
+            "first-address failure must fall through to reachable IPv4; got ${result.exceptionOrNull()}",
+            result.isSuccess,
+        )
+        result.getOrThrow().use { session ->
+            assertEquals("testuser", session.exec("whoami").stdout.trim())
+            val localForwardPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1")).use { it.localPort }
+            session.openLocalPortForward(
+                remoteHost = "127.0.0.1",
+                remotePort = CONTAINER_SSH_PORT,
+                localPort = localForwardPort,
+            ).use { forward ->
+                Socket("127.0.0.1", forward.localPort).use { socket ->
+                    socket.soTimeout = 5_000
+                    val banner = socket.getInputStream().bufferedReader().readLine()
+                    assertTrue("fallback-backed port-forward must reach real sshd; got $banner", banner.startsWith("SSH-2.0-"))
+                }
+            }
+        }
+        assertEquals(
+            "sequential fallback must authenticate exactly one transport; concurrent duplicate dials are forbidden",
+            acceptedBefore + 1,
+            acceptedPublicKeyCount(),
+        )
+    }
+
+    private fun acceptedPublicKeyCount(): Int =
+        container!!.logs.lineSequence().count { it.contains("Accepted publickey for testuser") }
+}

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshConnection.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -21,6 +22,7 @@ import net.schmizz.sshj.userauth.keyprovider.KeyProvider
 import net.schmizz.sshj.userauth.password.PasswordUtils
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.io.IOException
+import java.net.SocketTimeoutException
 import java.security.Security
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
@@ -41,6 +43,9 @@ public object SshConnection {
     internal const val DEFAULT_TIMEOUT_MS: Int = 30_000
 
     private const val CANCEL_DISCONNECT_TIMEOUT_MS: Long = 2_000L
+
+    /** Never let one black-holed family consume the entire caller dial budget. */
+    internal const val MAX_PER_ADDRESS_CONNECT_TIMEOUT_MS: Int = 10_000
 
     /**
      * Wall-elapsed boot clock for the transport-liveness oracle (#1080 Doze fix):
@@ -108,6 +113,7 @@ public object SshConnection {
         knownHosts: KnownHostsPolicy = KnownHostsPolicy.AcceptAll,
         timeoutMs: Int = DEFAULT_TIMEOUT_MS,
         connector: SshConnector<C>,
+        nowNanos: () -> Long = System::nanoTime,
     ): Result<SshSession> = coroutineScope {
         // Issue #173 round-2: install the process-wide
         // UncaughtExceptionHandler guard BEFORE we spawn any sshj
@@ -158,15 +164,72 @@ public object SshConnection {
 
             worker = launch(Dispatchers.IO) {
                 try {
-                    val client = connector.createClient()
-                    liveClient.set(client)
-                    connector.applyKnownHostsPolicy(client, knownHosts)
-                    connector.connect(
-                        client,
-                        host,
-                        port,
-                        timeoutMs,
-                    )
+                    require(timeoutMs > 0) { "SSH connect timeout must be positive" }
+                    val startedNanos = nowNanos()
+                    val deadlineNanos = startedNanos + timeoutMs.toLong() * 1_000_000L
+                    val targets = connector.resolve(host)
+                    if (targets.isEmpty()) throw IOException("No SSH addresses resolved for $host")
+                    val failures = mutableListOf<Pair<SshDialTarget, Throwable>>()
+
+                    var connectedClient: C? = null
+                    var connectedTarget: SshDialTarget? = null
+                    for ((index, target) in targets.withIndex()) {
+                        coroutineContext.ensureActive()
+                        if (!continuation.isActive) throw CancellationException("SSH connect cancelled")
+
+                        val remainingMs = remainingMillis(deadlineNanos, nowNanos)
+                        if (remainingMs <= 0) {
+                            failures += target to SocketTimeoutException(
+                                "overall ${timeoutMs}ms SSH dial budget exhausted before attempt",
+                            )
+                            break
+                        }
+                        val attemptsRemaining = targets.size - index
+                        val attemptTimeoutMs = minOf(
+                            MAX_PER_ADDRESS_CONNECT_TIMEOUT_MS,
+                            maxOf(1, remainingMs / attemptsRemaining),
+                        )
+                        val client = connector.createClient(target)
+                        liveClient.set(client)
+                        connector.applyKnownHostsPolicy(client, knownHosts)
+                        try {
+                            connector.connect(
+                                client,
+                                host,
+                                port,
+                                attemptTimeoutMs,
+                            )
+                            connectedClient = client
+                            connectedTarget = target
+                            break
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (t: Throwable) {
+                            failures += target to t
+                            disconnectClientBestEffort()
+                            if (!connector.isAddressFailureRetryable(t)) throw t
+                        }
+                    }
+
+                    val client = connectedClient ?: run {
+                        // Preserve the public no-double-wrap contract for a
+                        // connector that already classified its only failure.
+                        val soleFailure = failures.singleOrNull()?.second
+                        if (soleFailure is SshException) throw soleFailure
+                        throw AllSshAddressesFailedException(
+                            host = host,
+                            port = port,
+                            failures = failures,
+                        )
+                    }
+                    val authRemainingMs = remainingMillis(deadlineNanos, nowNanos)
+                    if (authRemainingMs <= 0) {
+                        throw SocketTimeoutException(
+                            "SSH dial reached ${connectedTarget?.diagnosticLabel ?: "resolved address"} " +
+                                "but exhausted the overall ${timeoutMs}ms budget before authentication",
+                        )
+                    }
+                    connector.prepareAuthentication(client, authRemainingMs)
                     connector.authenticate(client, user, key, passphrase)
 
                     val session = connector.toSession(client)
@@ -324,6 +387,8 @@ public object SshConnection {
 
     internal interface SshConnector<C : Any> {
         fun createClient(): C
+        fun resolve(host: String): List<SshDialTarget> = listOf(SshDialTarget.unresolved(host))
+        fun createClient(target: SshDialTarget): C = createClient()
         fun applyKnownHostsPolicy(client: C, policy: KnownHostsPolicy)
         suspend fun connect(
             client: C,
@@ -331,6 +396,8 @@ public object SshConnection {
             port: Int,
             timeoutMs: Int,
         )
+        fun isAddressFailureRetryable(failure: Throwable): Boolean = true
+        fun prepareAuthentication(client: C, timeoutMs: Int) = Unit
         suspend fun authenticate(client: C, user: String, key: SshKey, passphrase: CharArray?)
         fun toSession(client: C): SshSession
         fun disconnect(client: C)
@@ -338,6 +405,11 @@ public object SshConnection {
 
     internal object RealSshConnector : SshConnector<SSHClient> {
         override fun createClient(): SSHClient = SSHClient(createSshConfig())
+
+        override fun resolve(host: String): List<SshDialTarget> = SshDialPlanner.resolve(host)
+
+        override fun createClient(target: SshDialTarget): SSHClient =
+            target.address?.let { AddressPinnedSshClient(createSshConfig(), it) } ?: createClient()
 
         override fun applyKnownHostsPolicy(client: SSHClient, policy: KnownHostsPolicy) {
             SshConnection.applyKnownHostsPolicy(client, policy)
@@ -374,6 +446,16 @@ public object SshConnection {
             client.connect(host, port)
         }
 
+        override fun isAddressFailureRetryable(failure: Throwable): Boolean =
+            failure.causeSequence().none { cause ->
+                cause is net.schmizz.sshj.common.SSHException &&
+                    cause.disconnectReason == net.schmizz.sshj.common.DisconnectReason.HOST_KEY_NOT_VERIFIABLE
+            }
+
+        override fun prepareAuthentication(client: SSHClient, timeoutMs: Int) {
+            client.timeout = timeoutMs
+        }
+
         override suspend fun authenticate(
             client: SSHClient,
             user: String,
@@ -407,4 +489,13 @@ public object SshConnection {
             client.disconnect()
         }
     }
+
+    private fun remainingMillis(deadlineNanos: Long, nowNanos: () -> Long): Int {
+        val remainingNanos = deadlineNanos - nowNanos()
+        if (remainingNanos <= 0L) return 0
+        return minOf(Int.MAX_VALUE.toLong(), (remainingNanos + 999_999L) / 1_000_000L).toInt()
+    }
+
+    private fun Throwable.causeSequence(): Sequence<Throwable> =
+        generateSequence(this) { current -> current.cause?.takeUnless { it === current } }
 }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshDialPlan.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshDialPlan.kt
@@ -1,0 +1,106 @@
+package com.pocketshell.core.ssh
+
+import net.schmizz.sshj.Config
+import net.schmizz.sshj.SSHClient
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.UnknownHostException
+
+/** One concrete network endpoint in a bounded sequential SSH dial plan. */
+internal data class SshDialTarget(
+    val address: InetAddress?,
+    val diagnosticLabel: String,
+) {
+    companion object {
+        /** Test/fake connector default: retain the legacy unresolved-host call. */
+        fun unresolved(host: String): SshDialTarget = SshDialTarget(
+            address = null,
+            diagnosticLabel = "resolver[$host]",
+        )
+    }
+}
+
+/**
+ * Resolve every candidate once and choose a deliberate, stable family order.
+ *
+ * IPv6 is attempted first. Android carriers increasingly expose an IPv6-only
+ * network with DNS64/NAT64; preferring the resolver-provided IPv6 candidate
+ * uses that native path instead of depending on optional CLAT. A broken AAAA
+ * cannot strand the connection because each address has a bounded turn and the
+ * IPv4 candidates follow sequentially. Resolver order is retained within each
+ * family, and duplicate addresses are removed without changing that order.
+ */
+internal object SshDialPlanner {
+    fun resolve(host: String): List<SshDialTarget> =
+        plan(host, InetAddress.getAllByName(host).toList())
+
+    internal fun plan(host: String, resolved: List<InetAddress>): List<SshDialTarget> {
+        if (resolved.isEmpty()) throw UnknownHostException("No addresses resolved for $host")
+
+        val unique = LinkedHashMap<String, InetAddress>()
+        resolved.forEach { address ->
+            val key = "${address.javaClass.name}:${address.hostAddress}"
+            unique.putIfAbsent(key, address)
+        }
+        val ordered = unique.values.sortedBy { address ->
+            when (address) {
+                is Inet6Address -> 0
+                is Inet4Address -> 1
+                else -> 2
+            }
+        }
+        return ordered.map { address ->
+            val family = when (address) {
+                is Inet6Address -> "IPv6"
+                is Inet4Address -> "IPv4"
+                else -> address.javaClass.simpleName
+            }
+            SshDialTarget(
+                address = address,
+                diagnosticLabel = "$family[${address.hostAddress}]",
+            )
+        }
+    }
+}
+
+/**
+ * sshj client whose TCP socket is pinned to one already-resolved address while
+ * sshj still records the ORIGINAL hostname for host-key verification.
+ *
+ * Calling sshj's `connect(InetAddress, port)` loses its private `hostname`
+ * field, so `KnownHostsPolicy.KnownHostsFile` would verify the numeric address
+ * instead of the configured host. Overriding only the protected address factory
+ * lets `connect(originalHost, port)` retain trust semantics while preventing a
+ * second hidden resolver lookup from choosing a different endpoint.
+ */
+internal class AddressPinnedSshClient(
+    config: Config,
+    private val address: InetAddress,
+) : SSHClient(config) {
+    override fun makeInetSocketAddress(hostname: String, port: Int): InetSocketAddress =
+        InetSocketAddress(address, port)
+}
+
+internal class AllSshAddressesFailedException(
+    host: String,
+    port: Int,
+    failures: List<Pair<SshDialTarget, Throwable>>,
+) : java.io.IOException(
+    buildString {
+        append("All ")
+        append(failures.size)
+        append(" resolved SSH address attempt(s) failed for ")
+        append(host)
+        append(':')
+        append(port)
+        append(": ")
+        append(
+            failures.joinToString("; ") { (target, failure) ->
+                "${target.diagnosticLabel}=${failure.javaClass.simpleName}: ${failure.message ?: "no message"}"
+            },
+        )
+    },
+    failures.lastOrNull()?.second,
+)

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshAddressFallbackTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshAddressFallbackTest.kt
@@ -1,0 +1,290 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.net.InetAddress
+
+class SshAddressFallbackTest {
+
+    @Test
+    fun `planner deliberately prefers IPv6 then IPv4 and removes duplicates stably`() {
+        val v4First = InetAddress.getByAddress("mixed.test", byteArrayOf(127, 0, 0, 1))
+        val v6 = InetAddress.getByAddress(
+            "mixed.test",
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2),
+        )
+        val v4Second = InetAddress.getByAddress("mixed.test", byteArrayOf(127, 0, 0, 2))
+
+        val planned = SshDialPlanner.plan(
+            host = "mixed.test",
+            resolved = listOf(v4First, v6, v4First, v4Second),
+        )
+
+        assertEquals(
+            listOf("IPv6[0:0:0:0:0:0:0:2]", "IPv4[127.0.0.1]", "IPv4[127.0.0.2]"),
+            planned.map { it.diagnosticLabel },
+        )
+    }
+
+    @Test
+    fun `first address failure is disconnected before one second address dial starts`() = runTest {
+        val connector = RecordingFallbackConnector(
+            outcomes = ArrayDeque(listOf(IOException("v6 unreachable"), null)),
+        )
+
+        val result = SshConnection.connect(
+            host = "dual.test",
+            port = 22,
+            user = "me",
+            key = SshKey.Pem("key"),
+            timeoutMs = 30_000,
+            connector = connector,
+            nowNanos = { 0L },
+        )
+
+        assertTrue("second address should return a live session: $result", result.isSuccess)
+        result.getOrThrow().close()
+        assertEquals(
+            listOf(
+                "create:IPv6[2001:db8:0:0:0:0:0:1]",
+                "connect:1:10000",
+                "disconnect:1",
+                "create:IPv4[192.0.2.1]",
+                "connect:2:10000",
+                "auth:2:30000",
+                "session:2",
+                "session-close:2",
+            ),
+            connector.events,
+        )
+        assertEquals(1, connector.maxConnectsInFlight)
+    }
+
+    @Test
+    fun `all address failures report every family and cause within one total budget`() = runTest {
+        var nowNanos = 0L
+        val connector = RecordingFallbackConnector(
+            outcomes = ArrayDeque(listOf(IOException("v6 blackhole"), IOException("v4 refused"))),
+            afterConnect = { timeoutMs -> nowNanos += timeoutMs.toLong() * 1_000_000L },
+        )
+
+        val result = SshConnection.connect(
+            host = "dual.test",
+            port = 2222,
+            user = "me",
+            key = SshKey.Pem("key"),
+            timeoutMs = 8_000,
+            connector = connector,
+            nowNanos = { nowNanos },
+        )
+
+        assertTrue(result.isFailure)
+        val message = result.exceptionOrNull()?.message.orEmpty()
+        assertTrue(message, message.contains("IPv6[2001:db8:0:0:0:0:0:1]=IOException: v6 blackhole"))
+        assertTrue(message, message.contains("IPv4[192.0.2.1]=IOException: v4 refused"))
+        assertEquals(listOf(4_000, 4_000), connector.connectTimeouts)
+        assertEquals(8_000_000_000L, nowNanos)
+        assertEquals(1, connector.maxConnectsInFlight)
+    }
+
+    @Test
+    fun `authentication failure does not create a duplicate address dial`() = runTest {
+        val connector = RecordingFallbackConnector(
+            outcomes = ArrayDeque(listOf(null, null)),
+            authenticationFailure = IOException("key rejected"),
+        )
+
+        val result = SshConnection.connect(
+            host = "dual.test",
+            port = 22,
+            user = "me",
+            key = SshKey.Pem("key"),
+            timeoutMs = 30_000,
+            connector = connector,
+            nowNanos = { 0L },
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals(1, connector.clientsCreated)
+        assertFalse(connector.events.any { it == "create:IPv4[192.0.2.1]" })
+    }
+
+    @Test
+    fun `non retryable trust failure stops before a second address`() = runTest {
+        val trustFailure = SshException("host key rejected")
+        val connector = RecordingFallbackConnector(
+            outcomes = ArrayDeque(listOf(trustFailure, null)),
+            retryable = { false },
+        )
+
+        val result = SshConnection.connect(
+            host = "dual.test",
+            port = 22,
+            user = "me",
+            key = SshKey.Pem("key"),
+            timeoutMs = 30_000,
+            connector = connector,
+            nowNanos = { 0L },
+        )
+
+        assertEquals(trustFailure, result.exceptionOrNull())
+        assertEquals(1, connector.clientsCreated)
+        assertEquals(listOf(10_000), connector.connectTimeouts)
+    }
+
+    @Test
+    fun `cancellation during first address disconnects it and never starts fallback`() = runTest {
+        val connector = CancellingFallbackConnector()
+        val job = launch {
+            SshConnection.connect(
+                host = "dual.test",
+                port = 22,
+                user = "me",
+                key = SshKey.Pem("key"),
+                timeoutMs = 30_000,
+                connector = connector,
+                nowNanos = { 0L },
+            )
+        }
+
+        connector.connectEntered.await()
+        job.cancelAndJoin()
+        connector.disconnectCalled.await()
+
+        assertEquals(1, connector.clientsCreated)
+        assertEquals(1, connector.connectCalls)
+    }
+
+    private class RecordingFallbackConnector(
+        outcomes: Collection<Throwable?>,
+        private val afterConnect: (Int) -> Unit = {},
+        private val authenticationFailure: IOException? = null,
+        private val retryable: (Throwable) -> Boolean = { true },
+    ) : SshConnection.SshConnector<FakeClient> {
+        private val outcomes = ArrayDeque(outcomes)
+        val events = mutableListOf<String>()
+        val connectTimeouts = mutableListOf<Int>()
+        var clientsCreated = 0
+        var connectsInFlight = 0
+        var maxConnectsInFlight = 0
+
+        private val targets = listOf(
+            SshDialTarget(
+                InetAddress.getByAddress(byteArrayOf(0x20, 0x01, 0x0d, 0xb8.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)),
+                "IPv6[2001:db8:0:0:0:0:0:1]",
+            ),
+            SshDialTarget(InetAddress.getByAddress(byteArrayOf(192.toByte(), 0, 2, 1)), "IPv4[192.0.2.1]"),
+        )
+
+        override fun resolve(host: String): List<SshDialTarget> = targets
+
+        override fun createClient(): FakeClient = error("target-aware factory required")
+
+        override fun createClient(target: SshDialTarget): FakeClient {
+            val client = FakeClient(++clientsCreated, target)
+            events += "create:${target.diagnosticLabel}"
+            return client
+        }
+
+        override fun applyKnownHostsPolicy(client: FakeClient, policy: KnownHostsPolicy) = Unit
+
+        override suspend fun connect(client: FakeClient, host: String, port: Int, timeoutMs: Int) {
+            connectsInFlight += 1
+            maxConnectsInFlight = maxOf(maxConnectsInFlight, connectsInFlight)
+            connectTimeouts += timeoutMs
+            events += "connect:${client.id}:$timeoutMs"
+            val failure = outcomes.removeFirst()
+            afterConnect(timeoutMs)
+            connectsInFlight -= 1
+            if (failure != null) throw failure
+        }
+
+        override fun prepareAuthentication(client: FakeClient, timeoutMs: Int) {
+            events += "auth:${client.id}:$timeoutMs"
+        }
+
+        override fun isAddressFailureRetryable(failure: Throwable): Boolean = retryable(failure)
+
+        override suspend fun authenticate(client: FakeClient, user: String, key: SshKey, passphrase: CharArray?) {
+            authenticationFailure?.let { throw it }
+        }
+
+        override fun toSession(client: FakeClient): SshSession {
+            events += "session:${client.id}"
+            return FakeSession(client, events)
+        }
+
+        override fun disconnect(client: FakeClient) {
+            events += "disconnect:${client.id}"
+        }
+    }
+
+    private data class FakeClient(val id: Int, val target: SshDialTarget)
+
+    private class CancellingFallbackConnector : SshConnection.SshConnector<FakeClient> {
+        val connectEntered = CompletableDeferred<Unit>()
+        val disconnectCalled = CompletableDeferred<Unit>()
+        var clientsCreated = 0
+        var connectCalls = 0
+
+        override fun resolve(host: String): List<SshDialTarget> = listOf(
+            SshDialTarget(null, "IPv6[first]"),
+            SshDialTarget(null, "IPv4[second]"),
+        )
+
+        override fun createClient(): FakeClient = error("target-aware factory required")
+
+        override fun createClient(target: SshDialTarget): FakeClient =
+            FakeClient(++clientsCreated, target)
+
+        override fun applyKnownHostsPolicy(client: FakeClient, policy: KnownHostsPolicy) = Unit
+
+        override suspend fun connect(client: FakeClient, host: String, port: Int, timeoutMs: Int) {
+            connectCalls += 1
+            connectEntered.complete(Unit)
+            CompletableDeferred<Unit>().await()
+        }
+
+        override suspend fun authenticate(client: FakeClient, user: String, key: SshKey, passphrase: CharArray?) = Unit
+
+        override fun toSession(client: FakeClient): SshSession = error("not reached")
+
+        override fun disconnect(client: FakeClient) {
+            disconnectCalled.complete(Unit)
+        }
+    }
+
+    private class FakeSession(
+        private val client: FakeClient,
+        private val events: MutableList<String>,
+    ) : SshSession {
+        override val isConnected: Boolean = true
+        override suspend fun exec(command: String): ExecResult = error("not used")
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+        override fun openLocalPortForward(remoteHost: String, remotePort: Int, localPort: Int): SshPortForward =
+            error("not used")
+        override fun startShell(): SshShell = object : SshShell {
+            override val stdin = ByteArrayOutputStream()
+            override val stdout = ByteArrayInputStream(ByteArray(0))
+            override val stderr = ByteArrayInputStream(ByteArray(0))
+            override fun close() = Unit
+        }
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(input: java.io.InputStream, length: Long, name: String, remotePath: String): String =
+            error("not used")
+        override fun close() {
+            events += "session-close:${client.id}"
+        }
+    }
+}

--- a/tests/docker/issue1877-hosts
+++ b/tests/docker/issue1877-hosts
@@ -1,0 +1,4 @@
+127.0.0.1 localhost
+::1 localhost
+::2 issue1877-fallback.test
+127.0.0.1 issue1877-fallback.test


### PR DESCRIPTION
Fixes #1877

Adds a bounded sequential sshj dial plan across all resolved addresses/families. Each attempt uses a fresh client and is synchronously closed before the next; authentication, host-key trust failures, and cancellation remain terminal.

Verification:
- exact-base real sshj RED: ordered ::2 then 127.0.0.1 spent 8s on ::2 and never reached sshd
- reviewer RED 1/1 under temporary legacy resolver
- restored GREEN 1/1 with exactly one accepted authentication and real dispatcher-backed port forward
- one address in flight, close-before-next, per-address cap inside one total budget
- unit/debug+release contracts green
- full core-ssh integration 52/52 including 90/100s corruption holds
- connected Android SSH + forced-drop reconnect 4/4
- canonical full JVM 603/603 tasks
- ONE TRANSPORT/single dispatcher preserved

Independent approval: https://github.com/alexeygrigorev/pocketshell/issues/1877#issuecomment-5145143930

Rebased unchanged onto exact main 0567636c7930a802d4e318560e76359cae5f4b1f with stable patch-id ce49105ba97477c6a3a818cfd502d69d318d0718.