### PR TITLE
test(cold-install): make input oracle byte-exact

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdInstallE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdInstallE2eTest.kt
@@ -45,6 +45,7 @@ import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
 import com.termux.view.TerminalView
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
@@ -55,6 +56,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 /**
  * Cold-install end-to-end coverage (issue #144).
@@ -88,10 +90,11 @@ import org.junit.runner.RunWith
  *    `opencode-lab`). We also pre-create a real tmux session with the
  *    same name via direct SSH so the subsequent attach has a live remote
  *    pane to join. This drops the user into [TmuxSessionScreen].
- * 7. Type `printf 'cold-install-pass\n'` through the live TerminalView
- *    `InputConnection`. Assert the marker shows up in the visible
- *    terminal text using [TerminalTextMatcher.containsWrapTolerant] so the
- *    assertion survives a soft-wrap at the right margin.
+ * 7. Type `printf 'cold-install-pass-<run>\n'` through the live TerminalView
+ *    `InputConnection`. Keep the visible-terminal assertion, then independently
+ *    inspect the real Docker pane over SSH: the echoed line must end with the
+ *    exact typed command, no bracketed-paste marker may leak into it, and a
+ *    separate pane line must equal the marker (proving `printf` actually ran).
  * 8. Re-launch the activity into the host list, open Settings, and
  *    assert the default settings snapshot matches [AppSettings] defaults
  *    (terminal font = 14sp, tmux-on-attach = true,
@@ -107,14 +110,17 @@ import org.junit.runner.RunWith
  *   navigation (would regress if a tmux-installed host stopped routing to
  *   the picker).
  * - `TmuxSessionScreen` attach + remote PTY plumbing (would regress if the
- *   typed command stopped reaching the remote pane).
+ *   typed command stopped reaching the remote pane byte-exactly or stopped
+ *   executing).
  * - `SettingsRepository` cold-read defaults (would regress if a default
  *   value drifted from [AppSettings]).
  *
  * Test infra it relies on:
  *
- * - `TerminalTextMatcher.containsWrapTolerant` (#139) for the command
- *   visibility assertion across soft-wrap boundaries.
+ * - `TerminalTextMatcher.containsWrapTolerant` (#139) for the user-visible
+ *   command assertion across soft-wrap boundaries. Issue #1871 deliberately
+ *   does NOT treat that substring as an execution oracle: under #1854 the
+ *   corrupt echo `tf '<marker>\\n'` retained the marker and passed 3/3.
  * - `waitForSshFixtureReady` from [AndroidSshTestFixtures.kt] so the test
  *   fails fast and loudly when the `agents` Docker fixture is not up,
  *   rather than burning the visibility deadline on a connect that never
@@ -137,6 +143,7 @@ class ColdInstallE2eTest {
     val grantPermissions = PreGrantPermissionsRule()
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
+    private val inputOracleObservations = mutableListOf<String>()
 
     /**
      * Issue #177: clear the fast-resume `last_session` snapshot before and
@@ -154,6 +161,7 @@ class ColdInstallE2eTest {
 
     @After
     fun closeLaunchedActivity() {
+        writeInputOracleReport()
         launchedActivity?.close()
         launchedActivity = null
         clearLastSessionPrefs()
@@ -324,11 +332,15 @@ class ColdInstallE2eTest {
 
         // ---------------------------------------------------------------
         // Phase 6 — send the command through the TerminalView input
-        // connection and assert the marker reaches the visible terminal
-        // text.
+        // connection. The visible marker remains a user-facing assertion, but
+        // is NOT sufficient evidence that the command arrived whole or ran:
+        // #1854 produced `tf '<marker>\\n'`, whose terminal echo still contains
+        // the marker. The independent Docker-pane oracle below makes exact
+        // received bytes and intended execution load-bearing.
         // ---------------------------------------------------------------
-        val marker = "cold-install-pass"
-        val command = "printf '$marker\\n'\n"
+        val marker = "cold-install-pass-${System.currentTimeMillis().toString(36).takeLast(6)}"
+        val typedCommand = "printf '$marker\\n'"
+        val command = "$typedCommand\n"
         val sendStart = SystemClock.elapsedRealtime()
         val committed = terminalInputConnection().commitText(command, 1)
         assertTrue("expected terminal input connection to commit the marker command", committed)
@@ -350,6 +362,14 @@ class ColdInstallE2eTest {
             "expected visible terminal text to contain '$marker' within deadline; " +
                 "elapsed_ms=$sendElapsed visible_terminal_text=`${lastVisible.take(500)}`",
             visible,
+        )
+        recordInputOracle("visible_terminal_text=\n$lastVisible")
+
+        assertExactCommandReceivedAndRan(
+            key = key,
+            sessionName = sessionName,
+            marker = marker,
+            typedCommand = typedCommand,
         )
 
         // ---------------------------------------------------------------
@@ -568,6 +588,124 @@ class ColdInstallE2eTest {
             exec?.exitCode == 0,
         )
     }
+
+    /**
+     * Issue #1871: observe the receiving pane through a second real SSH
+     * session that the app does not own. `capture-pane -J` joins soft-wrapped
+     * rows, so comparisons are against logical shell lines instead of the
+     * Android terminal grid.
+     *
+     * The assertions are intentionally complementary:
+     *
+     * 1. an echo ending with [typedCommand] proves the pane received every
+     *    leading byte in order;
+     * 2. a separate line equal to [marker] proves the intended command ran;
+     * 3. no raw paste marker proves framing bytes did not leak into the input.
+     *
+     * The old marker-substring assertion satisfied none of these contracts: a
+     * corrupt, never-executed echo still contained the marker.
+     */
+    private suspend fun assertExactCommandReceivedAndRan(
+        key: String,
+        sessionName: String,
+        marker: String,
+        typedCommand: String,
+    ) {
+        val observer = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 20_000,
+        ).getOrThrow()
+        try {
+            val deadline = SystemClock.elapsedRealtime() + inputOracleTimeoutMs
+            var lastCapture = ""
+            var echoLine: String? = null
+            var ranLine: String? = null
+            while (SystemClock.elapsedRealtime() < deadline) {
+                lastCapture = capturePane(observer, sessionName)
+                val lines = lastCapture.lineSequence().toList()
+                echoLine = lines.lastOrNull { line -> line.contains("$marker\\n'") }
+                ranLine = lines.lastOrNull { line -> line.trim() == marker }
+                if (echoLine != null && ranLine != null) break
+                SystemClock.sleep(250)
+            }
+
+            val paneTail = lastCapture.lines()
+                .filter { it.isNotBlank() }
+                .takeLast(8)
+                .joinToString(" | ")
+            recordInputOracle(
+                "marker=$marker\n" +
+                    "typed_command=$typedCommand\n" +
+                    "echo_line=${echoLine ?: "<none>"}\n" +
+                    "ran_line=${ranLine ?: "<none>"}\n" +
+                    "pane_tail=$paneTail",
+            )
+
+            assertTrue(
+                "the cold-install command never RAN on the remote pane; expected a " +
+                    "standalone line equal to `$marker`. A marker in the command echo " +
+                    "does not prove execution (issue #1871). pane_tail=$paneTail",
+                ranLine != null,
+            )
+            val exactEcho = echoLine
+            assertTrue(
+                "the remote pane never echoed the marker-scoped command; " +
+                    "pane_tail=$paneTail",
+                exactEcho != null,
+            )
+            requireNotNull(exactEcho)
+            assertTrue(
+                "the cold-install command reached the remote pane with corrupted bytes; " +
+                    "expected the echoed line to end with `$typedCommand`, got `$exactEcho`",
+                exactEcho.trimEnd().endsWith(typedCommand),
+            )
+            assertTrue(
+                "raw bracketed-paste framing leaked into the cold-install command echo: " +
+                    "`$exactEcho`",
+                "[200~" !in exactEcho && "[201~" !in exactEcho,
+            )
+        } finally {
+            runCatching { observer.close() }
+        }
+    }
+
+    private suspend fun capturePane(session: SshSession, sessionName: String): String {
+        val result = session.exec("tmux capture-pane -p -J -t ${shellQuote(sessionName)}")
+        assertTrue(
+            "expected independent tmux capture-pane to succeed, exit=${result.exitCode} " +
+                "stderr=`${result.stderr}`",
+            result.exitCode == 0,
+        )
+        return result.stdout
+    }
+
+    private fun recordInputOracle(value: String) {
+        inputOracleObservations += value
+        println("COLD_INSTALL_INPUT_ORACLE $value")
+    }
+
+    private fun writeInputOracleReport() {
+        if (inputOracleObservations.isEmpty()) return
+        runCatching {
+            val dir = File(
+                com.pocketshell.app.test.testArtifactsRoot(
+                    InstrumentationRegistry.getInstrumentation().targetContext,
+                ),
+                "additional_test_output/cold-install",
+            )
+            check(dir.exists() || dir.mkdirs()) { "could not create ${dir.absolutePath}" }
+            val report = File(dir, "exact-input-oracle.txt")
+            report.writeText(inputOracleObservations.joinToString("\n---\n", postfix = "\n"))
+            println("COLD_INSTALL_INPUT_ORACLE_REPORT ${report.absolutePath}")
+        }
+    }
+
+    private val inputOracleTimeoutMs: Long
+        get() = if (TerminalTestTimeouts.isRunningOnCi()) 90_000L else 30_000L
 
     private fun shellQuote(value: String): String =
         "'" + value.replace("'", "'\"'\"'") + "'"

--- a/app/src/test/java/com/pocketshell/app/proof/ColdInstallExactInputOracleSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/ColdInstallExactInputOracleSourceGuardTest.kt
@@ -1,0 +1,370 @@
+package com.pocketshell.app.proof
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #1871 source guard for the false-green journey-oracle class.
+ *
+ * The real behavioral proof remains `ColdInstallE2eTest` on emulator + Docker.
+ * This both-variant Unit guard makes its receiver oracle load-bearing between
+ * journey runs: it checks the oracle contracts and structurally verifies that
+ * the cold-install test invokes the helper with values from that same run.
+ */
+class ColdInstallExactInputOracleSourceGuardTest {
+
+    @Test
+    fun `cold install invokes its exact receiver oracle with this run values`() {
+        val path = COLD_INSTALL_PATH
+        val source = source(path)
+
+        assertEquals(
+            "the cold-install journey must keep its exact receiver oracle attached",
+            emptyList<String>(),
+            exactOracleViolations(source),
+        )
+    }
+
+    @Test
+    fun `retained helper text cannot satisfy the gate when its invocation is disconnected`() {
+        val source = source(COLD_INSTALL_PATH)
+        val disconnected = disconnectOracleInvocation(source)
+
+        assertTrue(
+            "the regression mutation must retain the complete helper body",
+            exactOracleContractViolations(disconnected).isEmpty(),
+        )
+        assertTrue(
+            "deleting only the journey invocation must fail the attachment gate",
+            exactOracleViolations(disconnected).any { it.contains("does not invoke") },
+        )
+        assertEquals(
+            "G2 must reject a marker-only journey even when a dead oracle helper remains",
+            listOf(COLD_INSTALL_PATH),
+            g2Offenders(mapOf(COLD_INSTALL_PATH to disconnected)),
+        )
+    }
+
+    @Test
+    fun `no direct commitText journey repeats the combined-command marker-only oracle`() {
+        val root = projectRoot()
+        val sources = File(root, "app/src/androidTest")
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .associate { it.relativeTo(root).path to it.readText() }
+
+        assertEquals(
+            "a journey commits a command variable directly but accepts only its marker " +
+                "substring; terminal echo can satisfy that oracle without execution",
+            emptyList<String>(),
+            g2Offenders(sources),
+        )
+    }
+
+    private fun exactOracleViolations(source: String): List<String> = buildList {
+        addAll(exactOracleContractViolations(source))
+        val journey = function(source, COLD_INSTALL_TEST)
+        if (journey == null) {
+            add("missing $COLD_INSTALL_TEST")
+        } else if (!journey.hasExactOracleInvocation()) {
+            add(
+                "$COLD_INSTALL_TEST does not invoke $ORACLE_HELPER with " +
+                    "key, sessionName, marker, and typedCommand from its run",
+            )
+        }
+    }
+
+    private fun exactOracleContractViolations(source: String): List<String> = buildList {
+        val helper = function(source, ORACLE_HELPER)
+        if (helper == null) {
+            add("missing $ORACLE_HELPER")
+            return@buildList
+        }
+        val body = helper.raw
+        if (!Regex("line\\s*\\.\\s*trim\\s*\\(\\s*\\)\\s*==\\s*marker").containsMatchIn(body)) {
+            add("oracle must require a pane line equal to marker")
+        }
+        if (!Regex(
+                "exactEcho\\s*\\.\\s*trimEnd\\s*\\(\\s*\\)\\s*" +
+                    "\\.\\s*endsWith\\s*\\(\\s*typedCommand\\s*\\)",
+            ).containsMatchIn(body)
+        ) {
+            add("oracle must require the marker-scoped echo to end with typedCommand")
+        }
+        if (!Regex(
+                "\"\\[200~\"\\s*!in\\s*exactEcho\\s*&&\\s*" +
+                    "\"\\[201~\"\\s*!in\\s*exactEcho",
+            ).containsMatchIn(body)
+        ) {
+            add("oracle must reject leaked bracketed-paste framing")
+        }
+        if (!helper.calls("capturePane").any { call ->
+                call.positionalArguments == listOf("observer", "sessionName")
+            }
+        ) {
+            add("oracle must capture the receiving pane through its observer session")
+        }
+
+        val capture = function(source, "capturePane")
+        if (capture == null ||
+            !Regex("tmux\\s+capture-pane\\s+-p\\s+-J\\s+-t").containsMatchIn(capture.raw)
+        ) {
+            add("pane observer must execute tmux capture-pane -p -J -t")
+        }
+    }
+
+    private fun g2Offenders(sources: Map<String, String>): List<String> = sources.flatMap {
+            (path, source) ->
+        functions(source)
+            .map { it.block }
+            .filter { it.hasCombinedCommandMarkerOnlyGesture() }
+            .filterNot { it.hasExactOracleInvocation() }
+            .map { path }
+    }.distinct().sorted()
+
+    private fun FunctionBlock.hasCombinedCommandMarkerOnlyGesture(): Boolean =
+        Regex("\\bcommitText\\s*\\(\\s*command\\s*,\\s*1\\s*\\)").containsMatchIn(masked) &&
+            Regex(
+                "\\bcontainsWrapTolerant\\s*\\(\\s*lastVisible\\s*,\\s*marker\\b",
+            ).containsMatchIn(masked)
+
+    private fun FunctionBlock.hasExactOracleInvocation(): Boolean =
+        calls(ORACLE_HELPER).any { call ->
+            call.namedArguments == mapOf(
+                "key" to "key",
+                "sessionName" to "sessionName",
+                "marker" to "marker",
+                "typedCommand" to "typedCommand",
+            )
+        }
+
+    /** Remove only the live call; the helper and every contract string remain. */
+    private fun disconnectOracleInvocation(source: String): String {
+        val journey = requireNotNull(function(source, COLD_INSTALL_TEST))
+        val call = journey.calls(ORACLE_HELPER).single()
+        return source.replaceRange(call.startOffset, call.endOffsetExclusive, "Unit")
+    }
+
+    private inner class FunctionBlock(
+        val raw: String,
+        val masked: String,
+        val bodyStartOffset: Int,
+    ) {
+        fun calls(name: String): List<Call> {
+            val matcher = Regex("\\b${Regex.escape(name)}\\s*\\(").findAll(masked)
+            return matcher.map { match ->
+                val open = masked.indexOf('(', match.range.first)
+                val close = matchingDelimiter(masked, open, '(', ')')
+                val arguments = splitTopLevel(masked.substring(open + 1, close))
+                val named = arguments.mapNotNull { argument ->
+                    val equals = topLevelEquals(argument)
+                    if (equals < 0) null else {
+                        argument.substring(0, equals).trim() to
+                            argument.substring(equals + 1).trim()
+                    }
+                }.toMap()
+                Call(
+                    startOffset = bodyStartOffset + match.range.first,
+                    endOffsetExclusive = bodyStartOffset + close + 1,
+                    namedArguments = named,
+                    positionalArguments = arguments.filter { topLevelEquals(it) < 0 }
+                        .map(String::trim),
+                )
+            }.toList()
+        }
+    }
+
+    private data class Call(
+        val startOffset: Int,
+        val endOffsetExclusive: Int,
+        val namedArguments: Map<String, String>,
+        val positionalArguments: List<String>,
+    )
+
+    private fun function(source: String, name: String): FunctionBlock? =
+        functions(source).singleOrNull { it.name == name }?.block
+
+    private data class NamedFunction(val name: String, val block: FunctionBlock)
+
+    private fun functions(source: String): List<NamedFunction> {
+        val masked = maskCommentsAndStrings(source)
+        return Regex("\\bfun\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(")
+            .findAll(masked)
+            .mapNotNull { match ->
+                val name = match.groupValues[1]
+                val parameterOpen = masked.indexOf('(', match.range.first)
+                val parameterClose = matchingDelimiter(masked, parameterOpen, '(', ')')
+                val bodyOpen = masked.indexOf('{', parameterClose + 1)
+                if (bodyOpen < 0) return@mapNotNull null
+                val bodyClose = matchingDelimiter(masked, bodyOpen, '{', '}')
+                val start = bodyOpen + 1
+                NamedFunction(
+                    name,
+                    FunctionBlock(
+                        raw = source.substring(start, bodyClose),
+                        masked = masked.substring(start, bodyClose),
+                        bodyStartOffset = start,
+                    ),
+                )
+            }.toList()
+    }
+
+    private fun matchingDelimiter(text: String, open: Int, left: Char, right: Char): Int {
+        require(open >= 0 && text[open] == left)
+        var depth = 0
+        for (index in open until text.length) {
+            when (text[index]) {
+                left -> depth++
+                right -> if (--depth == 0) return index
+            }
+        }
+        error("unclosed $left at $open")
+    }
+
+    private fun splitTopLevel(value: String): List<String> {
+        val result = mutableListOf<String>()
+        var start = 0
+        var round = 0
+        var square = 0
+        var curly = 0
+        value.forEachIndexed { index, char ->
+            when (char) {
+                '(' -> round++
+                ')' -> round--
+                '[' -> square++
+                ']' -> square--
+                '{' -> curly++
+                '}' -> curly--
+                ',' -> if (round == 0 && square == 0 && curly == 0) {
+                    result += value.substring(start, index).trim()
+                    start = index + 1
+                }
+            }
+        }
+        val tail = value.substring(start).trim()
+        if (tail.isNotEmpty()) result += tail
+        return result
+    }
+
+    private fun topLevelEquals(value: String): Int {
+        var round = 0
+        var square = 0
+        var curly = 0
+        value.forEachIndexed { index, char ->
+            when (char) {
+                '(' -> round++
+                ')' -> round--
+                '[' -> square++
+                ']' -> square--
+                '{' -> curly++
+                '}' -> curly--
+                '=' -> if (round == 0 && square == 0 && curly == 0) return index
+            }
+        }
+        return -1
+    }
+
+    /**
+     * Preserve offsets and syntax delimiters while blanking comments and
+     * strings, so call/function parsing cannot match documentation or literals.
+     */
+    private fun maskCommentsAndStrings(source: String): String {
+        val chars = source.toCharArray()
+        var index = 0
+        while (index < chars.size) {
+            when {
+                index + 1 < chars.size && chars[index] == '/' && chars[index + 1] == '/' -> {
+                    while (index < chars.size && chars[index] != '\n') chars[index++] = ' '
+                }
+                index + 1 < chars.size && chars[index] == '/' && chars[index + 1] == '*' -> {
+                    chars[index++] = ' '
+                    chars[index++] = ' '
+                    var depth = 1
+                    while (index < chars.size && depth > 0) {
+                        when {
+                            index + 1 < chars.size && chars[index] == '/' && chars[index + 1] == '*' -> {
+                                chars[index++] = ' '
+                                chars[index++] = ' '
+                                depth++
+                            }
+                            index + 1 < chars.size && chars[index] == '*' && chars[index + 1] == '/' -> {
+                                chars[index++] = ' '
+                                chars[index++] = ' '
+                                depth--
+                            }
+                            chars[index] != '\n' -> chars[index++] = ' '
+                            else -> index++
+                        }
+                    }
+                }
+                chars[index] == '"' -> {
+                    val triple = index + 2 < chars.size &&
+                        chars[index + 1] == '"' && chars[index + 2] == '"'
+                    val quoteCount = if (triple) 3 else 1
+                    repeat(quoteCount) { chars[index++] = ' ' }
+                    while (index < chars.size) {
+                        if (triple && index + 2 < chars.size &&
+                            chars[index] == '"' && chars[index + 1] == '"' &&
+                            chars[index + 2] == '"'
+                        ) {
+                            repeat(3) { chars[index++] = ' ' }
+                            break
+                        }
+                        if (!triple && chars[index] == '"') {
+                            chars[index++] = ' '
+                            break
+                        }
+                        if (!triple && chars[index] == '\\' && index + 1 < chars.size) {
+                            chars[index++] = ' '
+                            if (chars[index] != '\n') chars[index] = ' '
+                            index++
+                        } else if (chars[index] != '\n') {
+                            chars[index++] = ' '
+                        } else {
+                            index++
+                        }
+                    }
+                }
+                chars[index] == '\'' -> {
+                    chars[index++] = ' '
+                    while (index < chars.size) {
+                        if (chars[index] == '\\' && index + 1 < chars.size) {
+                            chars[index++] = ' '
+                            chars[index++] = ' '
+                        } else if (chars[index] == '\'') {
+                            chars[index++] = ' '
+                            break
+                        } else if (chars[index] != '\n') {
+                            chars[index++] = ' '
+                        } else {
+                            index++
+                        }
+                    }
+                }
+                else -> index++
+            }
+        }
+        return String(chars)
+    }
+
+    private fun source(path: String): String = File(projectRoot(), path).readText()
+
+    private fun projectRoot(): File {
+        var cursor = File(System.getProperty("user.dir")).absoluteFile
+        repeat(8) {
+            if (File(cursor, "settings.gradle.kts").isFile) return cursor
+            cursor = cursor.parentFile ?: return@repeat
+        }
+        error("Cannot locate project root from ${System.getProperty("user.dir")}")
+    }
+
+    private companion object {
+        const val COLD_INSTALL_PATH =
+            "app/src/androidTest/java/com/pocketshell/app/proof/ColdInstallE2eTest.kt"
+        const val COLD_INSTALL_TEST =
+            "coldInstallJourney_addsHost_attachesTmuxSession_runsCommand_andDefaultsAreSane"
+        const val ORACLE_HELPER = "assertExactCommandReceivedAndRan"
+    }
+}


### PR DESCRIPTION
Closes #1871.

Makes the cold-install journey independently verify the exact command received by the real tmux pane and prove the marker command executed, rather than accepting a marker substring from a corrupt shell echo. Adds a structural guard that keeps the oracle invocation load-bearing, including the prior disconnected-helper regression.

Review evidence: https://github.com/alexeygrigorev/pocketshell/issues/1871#issuecomment-5146400340