### PR TITLE
test(projects): repair stale folder journeys

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/hosts/HostAndFolderListScrollE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/HostAndFolderListScrollE2eTest.kt
@@ -261,16 +261,18 @@ class FolderListScrollE2eTest {
         compose.onNodeWithTag(lastRowTag, useUnmergedTree = true).assertIsDisplayed()
         captureFullDevice("04-folder-tree-bottom-viewport.png")
 
-        // Flat view (#485): an ungrouped list of every session — the session
-        // detail rows that the tree path renders are gone, replaced by flat
-        // rows keyed by session name. `session-01` is the oldest session so it
-        // sorts to the bottom of the recency-ordered flat list.
-        val lastFlatRowTag = folderListFlatRowTestTag(rows.first().sessionName)
+        // Flat view (#485/#489): every session is partitioned into Active
+        // (agents) and Idle (shells), with recency order preserved inside each
+        // section. The oldest shell is therefore the final session row.
+        val oldestShell = rows
+            .filter { it.agentKind == SessionAgentKind.Shell }
+            .minBy { it.lastActivity ?: Long.MIN_VALUE }
+        val lastFlatRowTag = folderListFlatRowTestTag(oldestShell.sessionName)
         compose.runOnIdle { hostDetailViewMode = HostDetailViewMode.Flat }
-        compose.waitUntil(timeoutMillis = 5_000) {
-            compose.onAllNodesWithTag(lastFlatRowTag, useUnmergedTree = true)
-                .fetchSemanticsNodes().isNotEmpty()
-        }
+        // Issue #1868: do not wait for the target row before scrolling.
+        // Active/Idle grouping (#489) makes the final row an off-screen lazy
+        // item, so its semantics node cannot exist yet. Scroll to the explicit
+        // bottom destination first, then assert the final session row.
         compose.onNodeWithTag(FOLDER_LIST_CONTENT_TAG, useUnmergedTree = true)
             .performScrollToNode(hasTestTag(FOLDER_LIST_BOTTOM_SPACER_TAG))
         compose.waitForIdle()

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionClickTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionClickTest.kt
@@ -383,13 +383,14 @@ class FolderListSessionClickTest {
 
     @Test
     fun multiWindowAgentSessionDoesNotRepeatAgentTypeOrBadges() {
-        // #675: a session with TWO Claude windows (w0, w1) is broken out into
+        // #675/#782: a session with TWO Claude windows (w0, w1) is broken out into
         // per-window child rows. The agent type used to render THREE times: the
         // parent's inline `w0 Claude · idle · w1 Claude` summary, the parent
         // badge, and each window-row badge. After the fix the parent drops the
         // summary + badge and the window rows drop their badges, so "Claude"
-        // appears once per window (in the `w0 claude` / `w1 claude` titles) and
-        // NO capitalized "Claude" badge/summary text survives.
+        // appears once per window as the command hint in the canonical
+        // `<session> [wN] <hint>` title, and NO capitalized "Claude"
+        // badge/summary text survives.
         runBlocking {
             db.projectRootDao().insert(
                 ProjectRootEntity(
@@ -466,7 +467,8 @@ class FolderListSessionClickTest {
             ).fetchSemanticsNodes().isNotEmpty()
         }
 
-        // Both window rows are present, each titled `w<n> claude`.
+        // Both window rows are present, each using the #782 external-window
+        // title contract: `<session> [wN] <hint>`.
         compose.onNodeWithTag(
             folderSessionWindowRowTestTag(projectPath, sessionName, 0, "claude"),
             useUnmergedTree = true,
@@ -475,8 +477,8 @@ class FolderListSessionClickTest {
             folderSessionWindowRowTestTag(projectPath, sessionName, 1, "claude"),
             useUnmergedTree = true,
         ).assertExists()
-        compose.onNodeWithText("w0 claude").assertExists()
-        compose.onNodeWithText("w1 claude").assertExists()
+        compose.onNodeWithText("$sessionName [w0] claude").assertExists()
+        compose.onNodeWithText("$sessionName [w1] claude").assertExists()
 
         // The parent's trailing agent badge is gone.
         assertTrue(
@@ -488,8 +490,9 @@ class FolderListSessionClickTest {
         )
 
         // No capitalized "Claude" badge / inline-summary text survives — the
-        // agent type is conveyed only via the lowercase `w0 claude` titles and
-        // the status dots. (Window titles use the lowercase command.)
+        // agent type is conveyed only via the lowercase command hint in the
+        // `[wN]` titles and the status dots. (Window titles use the lowercase
+        // command.)
         assertTrue(
             "capitalized Claude badge/summary text should not appear thrice",
             compose.onAllNodesWithText("Claude", useUnmergedTree = true)

--- a/app/src/androidTest/java/com/pocketshell/app/projects/RepoBrowserSessionPickerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RepoBrowserSessionPickerTest.kt
@@ -58,6 +58,13 @@ class RepoBrowserSessionPickerTest {
                     folderLabel = repoFolderLabel(repoPath),
                     onCancel = {},
                     onCreate = { choice = it },
+                    // Mirror RepoBrowserScreen's production picker wiring.
+                    // The standalone content fallback is only the trailing
+                    // basename and stopped representing this path when the
+                    // editable session-name field landed (#1184/#1868).
+                    deriveDefaultName = { path ->
+                        defaultSessionBaseName(path, conventionalRemoteHome("alexey"))
+                    },
                 )
             }
         }
@@ -101,6 +108,11 @@ class RepoBrowserSessionPickerTest {
                     folderLabel = repoFolderLabel(repoPath),
                     onCancel = {},
                     onCreate = { choice = it },
+                    // Keep this content-only fixture on the exact production
+                    // RepoBrowserScreen name-prefill path (#1184/#1868).
+                    deriveDefaultName = { path ->
+                        defaultSessionBaseName(path, conventionalRemoteHome("alexey"))
+                    },
                 )
             }
         }


### PR DESCRIPTION
Closes #1868.

Repairs the four persistent Android journey failures after reproducing and bisecting each against exact main. Changes are confined to the three stale test files; candidate evidence is 9/9 with zero skips.

Review approval: https://github.com/alexeygrigorev/pocketshell/issues/1868#issuecomment-5147958457
Nightly-consumption follow-up: https://github.com/alexeygrigorev/pocketshell/issues/1859#issuecomment-5147909564