### PR TITLE
ci(nightly): route attachment resume through toxiproxy

### DIFF
--- a/scripts/check-ci-journey-harness-selftest.sh
+++ b/scripts/check-ci-journey-harness-selftest.sh
@@ -18,6 +18,23 @@ mkdir -p \
   "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/costs" \
   "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof"
 
+cat > "$SANDBOX/scripts/nightly-extensive-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+NETWORK_FAULT_CLASSES=(
+  "$FQCN_PREFIX.OutboundAttachmentOffsetResumeJourneyE2eTest"
+)
+JOURNEY_EXCLUDED_CLASSES=(
+  "${NETWORK_FAULT_CLASSES[@]}"
+)
+NETWORK_FAULT_CLASS_ARG="classes"
+echo "phase 2: network-fault proofs"
+gradle \
+  -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true \
+  -Pandroid.testInstrumentationRunnerArguments.class="$NETWORK_FAULT_CLASS_ARG"
+echo "phase 2b: expected fail"
+SH
+
 cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
 #!/usr/bin/env bash
 FQCN_PREFIX="com.pocketshell.app.proof"
@@ -204,6 +221,52 @@ if [[ "$rc" -eq 0 ]]; then
 else
   note_fail "guard should pass after removing bad fixtures (got exit $rc)"
 fi
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.pocketshell.app.MainActivity
+class OutboundAttachmentOffsetResumeJourneyE2eTest {
+    val compose = createAndroidComposeRule<MainActivity>()
+    val seed = SeedBeforeLaunchRule {
+        assertTrue(
+            "issue #1733 requires the explicitly opted-in Toxiproxy fixture",
+            true,
+        )
+    }
+}
+KT
+cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+JOURNEY_CLASSES=(
+  "$FQCN_PREFIX.OutboundAttachmentOffsetResumeJourneyE2eTest"
+  "$FQCN_PREFIX.GoodLaunchOwnedE2eTest"
+  "$FQCN_PREFIX.ExemptManualHarnessE2eTest"
+  "com.pocketshell.app.proof.DirectProofEntryE2eTest#singleMethod"
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"
+)
+SH
+sed -i '/OutboundAttachmentOffsetResumeJourneyE2eTest/d' "$SANDBOX/scripts/nightly-extensive-suite.sh"
+
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$out" | grep -q 'is not in nightly NETWORK_FAULT_CLASSES'; then
+  note_pass "#1733 class selected without nightly Toxiproxy routing is a hard failure"
+else
+  note_fail "missing #1733 nightly fixture routing should fail (got exit $rc)"
+fi
+
+sed -i '/NETWORK_FAULT_CLASSES=(/a\  "$FQCN_PREFIX.OutboundAttachmentOffsetResumeJourneyE2eTest"' \
+  "$SANDBOX/scripts/nightly-extensive-suite.sh"
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  note_pass "#1733 class passes when routed to the fixture-backed gating phase"
+else
+  note_fail "fixture-backed #1733 nightly routing should pass (got exit $rc)"
+fi
+rm -f "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt"
 
 cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
 #!/usr/bin/env bash

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -25,6 +25,7 @@ cd "$REPO_ROOT" || exit 1
 
 SUITE="${POCKETSHELL_JOURNEY_HARNESS_SUITE:-scripts/ci-journey-suite.sh}"
 ANDROID_TEST_ROOT="${POCKETSHELL_JOURNEY_HARNESS_ANDROID_TEST_ROOT:-app/src/androidTest/java}"
+NIGHTLY_SUITE="${POCKETSHELL_JOURNEY_HARNESS_NIGHTLY_SUITE:-scripts/nightly-extensive-suite.sh}"
 REPORT_MODE=0
 if [[ "${1:-}" == "--report" ]]; then
   REPORT_MODE=1
@@ -292,6 +293,7 @@ declare -a MISSING_REQUIRED_PER_PUSH=()
 declare -a UNWIRED_ANDROID_E2E_DOCKER_NEW=()
 declare -a UNWIRED_ANDROID_E2E_DOCKER_KNOWN=()
 declare -a STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=()
+declare -a NIGHTLY_FIXTURE_ROUTING_FAILURE=()
 
 if [[ "${#JOURNEY_CLASSES[@]}" -eq 0 ]]; then
   PARSER_FAILURE+=("NO_PROOF_CLASSES_PARSED")
@@ -309,6 +311,42 @@ for fqcn in "${REQUIRED_PER_PUSH_ANDROID_TEST_CLASSES[@]}"; do
     REQUIRED_PER_PUSH_WIRED+=("$fqcn")
   fi
 done
+
+# Issue #1866: this class has a deliberate hard precondition on the Toxiproxy
+# opt-in. Nightly phase 1 does not supply that fixture contract, so selecting it
+# there creates a guaranteed red with zero product signal. Pin the deliberate
+# routing decision: keep it hard-failing when the fixture is absent, include it
+# in the release-GATING phase-2 network-fault set, and exclude that whole set
+# from phase 1. This is intentionally specific to #1733 and does not broaden the
+# unrelated nightly selection.
+OUTBOUND_OFFSET_FQCN="com.pocketshell.app.proof.OutboundAttachmentOffsetResumeJourneyE2eTest"
+OUTBOUND_OFFSET_SOURCE="$(android_class_file_for "$OUTBOUND_OFFSET_FQCN")"
+if [[ -f "$OUTBOUND_OFFSET_SOURCE" ]]; then
+  if [[ ! -f "$NIGHTLY_SUITE" ]]; then
+    NIGHTLY_FIXTURE_ROUTING_FAILURE+=("missing nightly suite: $NIGHTLY_SUITE")
+  else
+    network_fault_block="$(sed -n '/^NETWORK_FAULT_CLASSES=(/,/^)$/p' "$NIGHTLY_SUITE")"
+    journey_excluded_block="$(sed -n '/^JOURNEY_EXCLUDED_CLASSES=(/,/^)$/p' "$NIGHTLY_SUITE")"
+    phase_two_block="$(sed -n '/phase 2: network-fault proofs/,/phase 2b:/p' "$NIGHTLY_SUITE")"
+
+    if ! grep -Fq '"$FQCN_PREFIX.OutboundAttachmentOffsetResumeJourneyE2eTest"' <<<"$network_fault_block"; then
+      NIGHTLY_FIXTURE_ROUTING_FAILURE+=("$OUTBOUND_OFFSET_FQCN is not in nightly NETWORK_FAULT_CLASSES")
+    fi
+    if ! grep -Fq '"${NETWORK_FAULT_CLASSES[@]}"' <<<"$journey_excluded_block"; then
+      NIGHTLY_FIXTURE_ROUTING_FAILURE+=("nightly phase 1 no longer excludes NETWORK_FAULT_CLASSES")
+    fi
+    if ! grep -Fq 'pocketshellNetworkFaultProofs=true' <<<"$phase_two_block" ||
+       ! grep -Fq 'class="$NETWORK_FAULT_CLASS_ARG"' <<<"$phase_two_block"; then
+      NIGHTLY_FIXTURE_ROUTING_FAILURE+=("nightly phase 2 no longer selects NETWORK_FAULT_CLASSES with the Toxiproxy opt-in")
+    fi
+  fi
+
+  outbound_precondition_block="$(grep -B 3 -A 6 -F 'issue #1733 requires the explicitly opted-in Toxiproxy fixture' "$OUTBOUND_OFFSET_SOURCE" || true)"
+  if ! grep -Fq 'assertTrue(' <<<"$outbound_precondition_block" ||
+     grep -Fq 'assumeTrue(' <<<"$outbound_precondition_block"; then
+    NIGHTLY_FIXTURE_ROUTING_FAILURE+=("$OUTBOUND_OFFSET_FQCN no longer hard-fails its missing-Toxiproxy precondition")
+  fi
+fi
 
 while IFS= read -r file; do
   [[ -z "${file:-}" ]] && continue
@@ -449,6 +487,7 @@ print_list "MISSING REQUIRED - #848 per-push androidTest class not wired" "${MIS
 print_list "NEW FAIL - manual ActivityScenario/createEmptyComposeRule harness" "${MANUAL_NEW[@]:-}"
 print_list "NEW FAIL - createAndroidComposeRule without SeedBeforeLaunchRule" "${MISSING_SHARED_SEED_NEW[@]:-}"
 print_list "NEW FAIL - androidTest E2e/Docker class not wired into ci-journey-suite.sh" "${UNWIRED_ANDROID_E2E_DOCKER_NEW[@]:-}"
+print_list "FIXTURE ROUTING FAIL - #1733 nightly selection" "${NIGHTLY_FIXTURE_ROUTING_FAILURE[@]:-}"
 
 hard_fail=()
 for item in \
@@ -458,6 +497,7 @@ for item in \
   "${MANUAL_NEW[@]:-}" \
   "${MISSING_SHARED_SEED_NEW[@]:-}" \
   "${UNWIRED_ANDROID_E2E_DOCKER_NEW[@]:-}" \
+  "${NIGHTLY_FIXTURE_ROUTING_FAILURE[@]:-}" \
   "${STALE_BASELINE[@]:-}" \
   "${STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]:-}"; do
   [[ -n "$item" ]] && hard_fail+=("$item")

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -27,7 +27,7 @@
 #      nightly-only as that issue requires, and it reuses the `agents` fixture
 #      this workflow already starts (no new fixture).
 #
-#   2) NETWORK-FAULT proofs — ONLY the NetworkFaultProofBase subclasses, run
+#   2) NETWORK-FAULT proofs — ONLY the fixture-backed network-fault classes, run
 #      WITHOUT `pocketshellCi=true` (so `isRunningOnCi()` is false and the
 #      `assumeFalse(isRunningOnCi())` guard passes) and WITH
 #      `pocketshellNetworkFaultProofs=true` (so the `assumeTrue(...)` opt-in
@@ -61,8 +61,10 @@ SUMMARY="$ARTIFACT_DIR/summary.md"
 
 GRADLEW="$REPO_ROOT/gradlew"
 
-# The NetworkFaultProofBase subclasses (toxiproxy proofs). Keep this list in
-# sync with `grep -rl NetworkFaultProofBase app/src/androidTest/.../proof/`.
+# The Toxiproxy-backed proofs. This is primarily the NetworkFaultProofBase
+# subclasses, plus explicitly documented fixture users such as issue #1733.
+# Keep the subclasses in sync with
+# `grep -rl NetworkFaultProofBase app/src/androidTest/.../proof/`.
 FQCN_PREFIX="com.pocketshell.app.proof"
 NETWORK_FAULT_CLASSES=(
   "$FQCN_PREFIX.RideThroughInterruptionE2eTest"
@@ -72,6 +74,15 @@ NETWORK_FAULT_CLASSES=(
   "$FQCN_PREFIX.DisconnectBlackholeE2eTest"
   "$FQCN_PREFIX.NetworkLatencyModelE2eTest"
   "$FQCN_PREFIX.PacketLossNetworkFaultE2eTest"
+  # Issue #1866 / #1733: durable queued-attachment correctness under real app
+  # SSH-worker death. The class hard-asserts the explicit Toxiproxy opt-in, so
+  # selecting it in phase 1 (which has no opt-in) is a guaranteed fixture red.
+  # Deliberate decision: this IS release-GATING in phase 2 because checkpoint-N
+  # resume, SHA-identical atomic promotion, and once-only prompt+Enter are
+  # durable-queue safety invariants, not an expected-fail/TDD spec. It reuses
+  # network-fault-proxy:2228 + toxiproxy API:8474; no fixture or unrelated
+  # nightly scope is added.
+  "$FQCN_PREFIX.OutboundAttachmentOffsetResumeJourneyE2eTest"
   # Issue #1064 (R4 / #843 round-2 T10/C4): slow COLD-DIAL robustness. A
   # NetworkFaultProofBase toxiproxy proof that applies jitter-latency +
   # bandwidth-limit (and, in the class-coverage variant, a half-open blackhole)
@@ -456,7 +467,7 @@ fi
   echo "| --- | --- | --- | --- | --- |"
   echo "| Journey / E2E (non-gating) | full connected suite minus network-fault + expected-fail + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** |"
   echo "| Notification permission (NON-GATING) | dedicated unsharded $NOTIFICATION_PERMISSION_TEST_CLASS; executed=$notification_permission_executed | external revoke/verify before instrumentation; external grant/verify after | $NOTIFICATION_PERMISSION_EXIT | **$notification_permission_status** |"
-  echo "| Network-fault proofs (GATING) | ${#NETWORK_FAULT_CLASSES[@]} NetworkFaultProofBase classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** |"
+  echo "| Network-fault proofs (GATING) | ${#NETWORK_FAULT_CLASSES[@]} Toxiproxy-backed classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** |"
   echo "| #822 expected-fail lane (NON-GATING) | ${#EXPECTED_FAIL_CLASSES[@]} Slice C/D TDD spec class(es) | \`pocketshellNetworkFaultProofs=true\` | $EXPECTED_FAIL_EXIT | **$expectedfail_status** |"
   echo "| Bootstrap setup scenarios (GATING) | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** |"
   echo


### PR DESCRIPTION
Closes #1866.

Moves OutboundAttachmentOffsetResumeJourneyE2eTest out of fixtureless nightly phase 1 and into the explicitly gating Toxiproxy phase 2, with permanent two-arm routing guards. The test remains hard-failing and load-bearing.

Review approval: https://github.com/alexeygrigorev/pocketshell/issues/1866#issuecomment-5148028570