### PR TITLE
ci(journey): classify proven foreign framework ANRs (#1919)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -300,15 +300,16 @@ jobs:
             scripts/test-ci-journey-retry-budget.sh
           scripts/test-ci-journey-retry-budget.sh
 
-      # Issue #1800: the failure-SIGNATURE classifier that types the CI
+      # Issues #1800/#1919: the failure-SIGNATURE classifier that types the CI
       # swiftshader "real system input-method window never became visible"
       # PRECONDITION as INFRA (-> RE-RUN) while keeping every genuine journey
       # assertion failure — including a containment/anchor failure in the SAME
       # class — hard RED. Drives the real classifier + the real aggregate
       # reducer over fixture artifacts so BOTH outcomes are observed, and pins
       # the measured cold-boot retry-cost model against the observed shard-0
-      # numbers from run 30305256109. Cheap (< 5 s), no emulator.
-      - name: CI journey infra-signature + measured retry-budget guard (issue #1800)
+      # numbers from run 30305256109, plus strict attempt-local ProcessRecord
+      # ownership for foreign framework ANRs. Cheap (< 15 s), no emulator.
+      - name: CI journey infra-signature + measured retry-budget guard (issues #1800, #1919)
         run: |
           chmod +x scripts/ci-journey-infra-signature.sh \
             scripts/ci-journey-infra-signature.py \
@@ -364,11 +365,12 @@ jobs:
             scripts/test-ci-journey-inter-attempt-cleanup.sh
           scripts/test-ci-journey-inter-attempt-cleanup.sh
 
-      # Issue #1781: fast, JVM-free artifact packaging fixture. Proves the
+      # Issues #1781/#1919: fast, JVM-free artifact packaging fixture. Proves the
       # first-cold-boot preservation scan keeps real module Android outputs and
       # canonical per-attempt evidence without recursively nesting
-      # artifacts/ci-journey or artifacts/ci-journey-attempt-1.
-      - name: CI journey artifact packaging guard (issue #1781)
+      # artifacts/ci-journey or artifacts/ci-journey-attempt-1, and keeps each
+      # activity-processes snapshot beside its correct attempt XML.
+      - name: CI journey artifact packaging guard (issues #1781, #1919)
         run: |
           chmod +x scripts/ci-journey-preserve-android-outputs.sh scripts/test-ci-journey-artifact-packaging.sh
           scripts/test-ci-journey-artifact-packaging.sh
@@ -1558,8 +1560,13 @@ jobs:
           printf '%s\n' "$signature_out" | sed 's/^/journey failure signature: /'
           signature_verdict="$(sed -n 's/^shard_signature_verdict=//p' <<<"$signature_out" | tail -n 1)"
           if [[ "$signature_verdict" == "INFRA" && "${first_timeout:-false}" != "true" ]]; then
-            echo "::warning title=Emulator journey INFRA — real system IME unavailable on this AVD::The ONLY failure(s) on this shard were the physical input-method-window PRECONDITION (\"The real system input-method window never became visible.\"), which the CI swiftshader AVD cannot satisfy. This is a captured environment signature (G5), NOT a product regression: the same class's anchor/containment properties are asserted with hard failures on its synthetic Type.ime() path, which ran in this same suite. Typed INFRA so aggregation requests RE-RUN. Any containment/anchor assertion failure would have stayed RED (issue #1800)."
-            write_verdict INFRA real_ime_precondition
+            if grep -q '=foreign_framework_anr_focus' <<<"$signature_out"; then
+              echo "::warning title=Emulator journey INFRA — foreign framework ANR owned focus::Every covered precondition failure was paired with its own readable class-attempt activity-processes.txt proving one non-PocketShell ProcessRecord owned the sole AppNotRespondingDialog. This is captured attempt-local foreign-framework-ANR evidence (G5), NOT a product regression. Typed INFRA so aggregation requests RE-RUN. PocketShell/applicationIdSuffix ANRs, ambiguous/multiple owners, missing or cross-attempt snapshots, and any containment/anchor/chip/unrelated failure stay RED (issue #1919)."
+              write_verdict INFRA foreign_framework_anr_focus
+            else
+              echo "::warning title=Emulator journey INFRA — real system IME unavailable on this AVD::The ONLY failure(s) on this shard were the physical input-method-window PRECONDITION (\"The real system input-method window never became visible.\"), which the CI swiftshader AVD cannot satisfy. This is a captured environment signature (G5), NOT a product regression: the same class's anchor/containment properties are asserted with hard failures on its synthetic Type.ime() path, which ran in this same suite. Typed INFRA so aggregation requests RE-RUN. Any containment/anchor assertion failure would have stayed RED (issue #1800)."
+              write_verdict INFRA real_ime_precondition
+            fi
             exit 1
           fi
           if [[ "${first_failure:-false}" == "true" ]]; then

--- a/scripts/ci-journey-infra-signature.py
+++ b/scripts/ci-journey-infra-signature.py
@@ -3,9 +3,9 @@
 evidence as either an environment-divergent capability precondition (INFRA) or a
 genuine product failure (RED).
 
-The ONE captured signature this recognises is the CI swiftshader AVD's inability
-to raise a *real system input-method window while an explicitly identified
-foreign app owns the active window*:
+The original captured signature is the CI swiftshader AVD's inability to raise
+a *real system input-method window while an explicitly identified foreign app
+owns the active window*:
 
     The real system input-method window never became visible.
     ... active_window_pkg=com.example.foreign ...
@@ -26,20 +26,27 @@ recurring residual-IME shape (`active=false focused=false` with non-empty
 bounds, #1818) is diagnostic only; it never substitutes for a genuinely foreign
 active-window owner.
 
-Narrowness is the whole point. The classifier reports `real_ime_precondition`
+Issue #1919 adds one separate, equally narrow signature for framework-owned
+focus theft. `active_window_pkg=android` remains insufficient: every eligible
+failure must live in a canonical class-attempt bundle whose sibling
+`activity-processes.txt` proves exactly one valid non-PocketShell
+`ProcessRecord` owns the sole current `mNotResponding=true
+[AppNotRespondingDialog@id]`. Evidence from another class, attempt, summary,
+screenshot, or shard-global copy is never consulted.
+
+Narrowness is the whole point. The classifier reports an environmental value
 ONLY when EVERY failing test case belonging to a class listed under the suite
-summary's "Failed BOTH attempts" section carries that exact message AND the
-genuinely-foreign owner proof above. A single containment / anchor / any other
-assertion failure — in the same class, in the same run, in any attempt — forces
-`product_failure`, which keeps the shard RED. Missing or unreadable evidence
-reports `unclassified`, which also keeps the shard RED (fail-safe toward the red
-verdict, never toward green).
+summary's "Failed BOTH attempts" section satisfies one of those two complete
+proofs. A single containment / anchor / chip / any other assertion failure — in
+the same class, in the same run, in any attempt — forces `product_failure`,
+which keeps the shard RED. Missing or unreadable evidence also stays RED
+(fail-safe toward the red verdict, never toward green).
 
 Usage:
     ci-journey-infra-signature.py SUMMARY_FILE ARTIFACT_ROOT [ARTIFACT_ROOT ...]
 
 Output (GitHub step-output compatible key=value lines):
-    journey_failure_classification=real_ime_precondition|product_failure|unclassified
+    journey_failure_classification=real_ime_precondition|foreign_framework_anr_focus|product_failure|unclassified
     journey_failed_classes=<space separated FQCNs from the summary>
     journey_failing_testcases=<count of failing test cases attributed to them>
     journey_signature_matches=<count of those carrying the captured signature>
@@ -61,6 +68,7 @@ from __future__ import annotations
 
 import os
 import re
+import stat
 import sys
 import xml.etree.ElementTree as ET
 
@@ -68,13 +76,30 @@ import xml.etree.ElementTree as ET
 REAL_IME_UNAVAILABLE_SIGNATURE = (
     "The real system input-method window never became visible."
 )
+APP_WINDOW_FOCUS_SIGNATURE = (
+    "The app window never held input focus, so the system refused every "
+    'showSoftInput() call ("is not served").'
+)
 ACTIVE_WINDOW_PACKAGE = re.compile(
     r"(?<![\w])active_window_pkg=([^\s,;]+)",
+)
+APP_WINDOW_FOCUS_STATE = re.compile(
+    r"app_window_focused=(true|false)\s+active_window_pkg=([^\s,;.]+)",
 )
 ANDROID_PACKAGE = re.compile(
     r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+",
 )
 POCKETSHELL_APP_PACKAGE_PREFIX = "com.pocketshell.app"
+ATTEMPT_DIRECTORY = re.compile(r"attempt-[1-9][0-9]*")
+PROCESS_HEADER = re.compile(
+    r"^\s*\*APP\*.*?\bProcessRecord\{[^{}\n]*?\s+[0-9]+:([^/\s}]+)/[^\s}]+\}",
+)
+ANY_PROCESS_HEADER = re.compile(r"^\s*\*APP\*.*?\bProcessRecord\{")
+ANR_DIALOG = re.compile(
+    r"mNotResponding=true\s+\[com\.android\.server\.am\."
+    r"AppNotRespondingDialog@[0-9A-Fa-f]+\]",
+)
+ANY_ANR_DIALOG = re.compile(r"AppNotRespondingDialog@")
 
 # `- \`com.example.Foo\`` and `- \`com.example.Foo#someMethod\`` bullets under
 # the summary's failed-both header. The suite writes BOTH forms (issue #1822);
@@ -134,20 +159,61 @@ def failed_both_section(summary_path: str) -> tuple[list[str], list[str]]:
     return classes, unreadable
 
 
-def _iter_result_xml(roots: list[str]):
+def _iter_attempt_bundles(roots: list[str]):
+    """Yield canonical class-attempt bundles, never shard-global XML copies.
+
+    A result XML may license only the sibling ``activity-processes.txt`` under
+    its own ``class-attempts/<module>/<key>/attempt-N`` directory. Restricting
+    discovery to that shape also excludes the copied module-wide Android
+    outputs that previously made the recursive scan see the same XML again.
+    """
+    seen: set[str] = set()
     for root in roots:
         if not os.path.isdir(root):
             continue
-        for dirpath, _dirnames, filenames in os.walk(root):
-            for name in filenames:
-                if name.startswith("TEST-") and name.endswith(".xml"):
-                    yield os.path.join(dirpath, name)
+        for dirpath, dirnames, _filenames in os.walk(root):
+            if not ATTEMPT_DIRECTORY.fullmatch(os.path.basename(dirpath)):
+                continue
+            parts = os.path.normpath(dirpath).split(os.sep)
+            if len(parts) < 4 or parts[-4] != "class-attempts":
+                continue
+            real = os.path.realpath(dirpath)
+            if real in seen:
+                dirnames[:] = []
+                continue
+            seen.add(real)
+            xml_paths: list[str] = []
+            for nested, _nested_dirs, filenames in os.walk(dirpath):
+                for name in filenames:
+                    if name.startswith("TEST-") and name.endswith(".xml"):
+                        xml_paths.append(os.path.join(nested, name))
+            yield dirpath, parts[-2], sorted(xml_paths)
+            dirnames[:] = []
+
+
+def _artifact_key_may_hold_class(key: str, classname: str) -> bool:
+    simple = classname.rsplit(".", 1)[-1]
+    return (
+        key == simple
+        or key.startswith(f"{simple}_")
+        or key == classname
+        or key.startswith(f"{classname}--")
+        or key.startswith(f"{classname}_")
+    )
 
 
 def _failure_text(element: ET.Element) -> str:
     """Full failure text: the `message` attribute plus the element body."""
     parts = [element.get("message") or "", element.text or ""]
     return "\n".join(part for part in parts if part)
+
+
+def _is_readable_regular_file(path: str) -> bool:
+    try:
+        mode = os.stat(path, follow_symlinks=False).st_mode
+    except OSError:
+        return False
+    return stat.S_ISREG(mode) and bool(mode & 0o444)
 
 
 def _has_only_genuinely_foreign_active_window_owners(text: str) -> bool:
@@ -176,16 +242,108 @@ def _is_real_ime_environment_failure(text: str) -> bool:
     )
 
 
+def _is_framework_focus_precondition(text: str) -> bool:
+    if (
+        REAL_IME_UNAVAILABLE_SIGNATURE not in text
+        and APP_WINDOW_FOCUS_SIGNATURE not in text
+    ):
+        return False
+    states = APP_WINDOW_FOCUS_STATE.findall(text)
+    return bool(states) and all(
+        focused == "false" and package == "android"
+        for focused, package in states
+    )
+
+
+def _foreign_anr_owner(snapshot_path: str) -> str | None:
+    """Return the sole proven foreign ANR owner, otherwise fail closed.
+
+    Ownership comes only from an ``*APP* ... ProcessRecord`` block whose own
+    body contains the exact ``mNotResponding=true [AppNotRespondingDialog@id]``
+    state. A dialog outside a parsed block, a second not-responding process, or
+    any package ambiguity returns ``None``.
+    """
+    if not _is_readable_regular_file(snapshot_path):
+        return None
+    try:
+        with open(snapshot_path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    except (OSError, UnicodeError):
+        return None
+    if not text.strip():
+        return None
+
+    blocks: list[tuple[str | None, str]] = []
+    current_package: str | None = None
+    current_lines: list[str] = []
+    outside_lines: list[str] = []
+    for line in text.splitlines():
+        header = PROCESS_HEADER.match(line)
+        if ANY_PROCESS_HEADER.match(line):
+            if current_lines:
+                blocks.append((current_package, "\n".join(current_lines)))
+            current_package = None
+            current_lines = [line]
+            if header:
+                current_package = header.group(1).split(":", 1)[0]
+            continue
+        if current_lines and line and not line[0].isspace():
+            blocks.append((current_package, "\n".join(current_lines)))
+            current_package = None
+            current_lines = []
+        if current_lines:
+            current_lines.append(line)
+        else:
+            outside_lines.append(line)
+    if current_lines:
+        blocks.append((current_package, "\n".join(current_lines)))
+
+    if ANY_ANR_DIALOG.search("\n".join(outside_lines)):
+        return None
+    not_responding = [
+        (package, block)
+        for package, block in blocks
+        if "mNotResponding=true" in block
+    ]
+    if len(not_responding) != 1:
+        return None
+    package, block = not_responding[0]
+    if package is None or ANDROID_PACKAGE.fullmatch(package) is None:
+        return None
+    if package == "android" or package.startswith(POCKETSHELL_APP_PACKAGE_PREFIX):
+        return None
+    if len(ANR_DIALOG.findall(block)) != 1:
+        return None
+    if len(ANY_ANR_DIALOG.findall(text)) != 1:
+        return None
+    return package
+
+
 def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
     classes, unreadable = failed_both_section(summary_path)
     failing = 0
     matches = 0
     offenders: list[str] = [f"<unreadable-summary-entry>#{line}" for line in unreadable]
     covered: set[str] = set()
+    framework_matches = 0
 
     if classes:
         wanted = set(classes)
-        for xml_path in _iter_result_xml(roots):
+        for attempt_dir, artifact_key, xml_paths in _iter_attempt_bundles(roots):
+            possible = {
+                name for name in wanted if _artifact_key_may_hold_class(artifact_key, name)
+            }
+            if not possible:
+                continue
+            if len(xml_paths) != 1:
+                offenders.append(
+                    f"<invalid-attempt-xml-count>#{artifact_key}/{os.path.basename(attempt_dir)}"
+                )
+                continue
+            xml_path = xml_paths[0]
+            if not _is_readable_regular_file(xml_path):
+                offenders.append(f"<unreadable>#{os.path.basename(xml_path)}")
+                continue
             try:
                 tree = ET.parse(xml_path)
             except (ET.ParseError, OSError):
@@ -199,16 +357,45 @@ def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
                 # Parameterised runners append the device label, e.g.
                 # `com.example.Foo[emulator-5554 - 15]`.
                 base = classname.split("[", 1)[0].strip()
-                if base not in wanted:
-                    continue
                 problems = list(case.findall("failure")) + list(case.findall("error"))
+                if base not in possible:
+                    offenders.append(
+                        "<artifact-key-classname-mismatch>#"
+                        f"{artifact_key}/{os.path.basename(attempt_dir)}:"
+                        f"{base or '<missing-classname>'}#"
+                        f"{case.get('name') or '<unknown>'}",
+                    )
+                    # Keep a mismatched wanted failure visible in the totals and
+                    # out of `uncovered`: its XML exists, but its attempt-local
+                    # ownership proof is invalid. It is therefore a definite
+                    # product offender, not evidence that may borrow this
+                    # bundle's sibling activity-processes snapshot.
+                    if base in wanted and problems:
+                        failing += 1
+                        covered.add(base)
+                    continue
                 if not problems:
                     continue
                 failing += 1
                 covered.add(base)
                 texts = [_failure_text(problem) for problem in problems]
-                if all(_is_real_ime_environment_failure(text) for text in texts):
+                kinds: list[str] = []
+                snapshot_owner: str | None = None
+                for text in texts:
+                    if _is_real_ime_environment_failure(text):
+                        kinds.append("real_ime")
+                    elif _is_framework_focus_precondition(text):
+                        if snapshot_owner is None:
+                            snapshot_owner = _foreign_anr_owner(
+                                os.path.join(attempt_dir, "activity-processes.txt"),
+                            )
+                        kinds.append("framework_anr" if snapshot_owner else "offender")
+                    else:
+                        kinds.append("offender")
+                if all(kind != "offender" for kind in kinds):
                     matches += 1
+                    if "framework_anr" in kinds:
+                        framework_matches += 1
                 else:
                     offenders.append(f"{base}#{case.get('name') or '<unknown>'}")
 
@@ -226,6 +413,8 @@ def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
         classification = "unclassified"
     elif offenders or matches != failing:
         classification = "product_failure"
+    elif framework_matches:
+        classification = "foreign_framework_anr_focus"
     else:
         classification = "real_ime_precondition"
 

--- a/scripts/ci-journey-infra-signature.sh
+++ b/scripts/ci-journey-infra-signature.sh
@@ -3,11 +3,14 @@
 # classifier. Emits GitHub-step-output-compatible key=value lines and ALWAYS
 # exits 0; the caller decides the shard verdict from the classification.
 #
-# The only classification that changes a shard's verdict is
-# `real_ime_precondition` (the captured CI swiftshader "real system
-# input-method window never became visible" precondition, plus an explicitly
-# resolved non-PocketShell active-window owner -> INFRA / RE-RUN). The assertion
-# sentence alone is app-influenceable and stays RED (#1882).
+# The caller maps exactly two explicit environmental classifications to shard
+# INFRA / aggregate RE-RUN: `real_ime_precondition` (the captured CI swiftshader
+# "real system input-method window never became visible" precondition plus an
+# explicitly resolved non-PocketShell active-window owner, #1800/#1882), and
+# `foreign_framework_anr_focus` (attempt-local ProcessRecord evidence proving a
+# non-PocketShell process owns the framework ANR dialog, #1919). Either assertion
+# sentence without its complete ownership proof remains app-influenceable and
+# stays RED.
 # Everything else — including a missing python3, missing artifacts, an
 # unreadable result file, or ANY other assertion failure — reports
 # `unclassified` or `product_failure`, both of which keep the shard RED.

--- a/scripts/ci-journey-shard-signature-verdict.sh
+++ b/scripts/ci-journey-shard-signature-verdict.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Issue #1800: decide whether an emulator-journey shard's failure evidence is
-# the ONE captured environment signature (the CI swiftshader AVD cannot raise a
-# real system input-method window while a resolved foreign app owns the active
-# window) rather than a genuine journey failure.
+# Issues #1800/#1919: decide whether an emulator-journey shard's failure evidence
+# is one of the two explicit captured environment signatures: the CI swiftshader
+# AVD cannot raise a real system input-method window while a resolved foreign app
+# owns the active window, or attempt-local ProcessRecord evidence proves a
+# foreign app owns the framework ANR dialog that stole focus.
 #
 # This is the exact decision the workflow's classify step applies, extracted so
 # it can be driven — and observed — without an emulator
@@ -22,13 +23,13 @@
 #   shard_signature_detail=<per-summary classifications, space separated>
 #
 # INFRA is emitted ONLY when at least one summary was inspected AND every
-# inspected summary classified as `real_ime_precondition`. The classifier only
-# emits that value when every matching failure proves a genuinely foreign
-# `active_window_pkg`; app-owned, `android` (ambiguous framework ANR), missing,
-# or malformed owners remain RED (#1882). Anything else — a genuine assertion
-# failure, mixed evidence, missing/corrupt result XML, a missing classifier —
-# emits NONE, which leaves the caller's existing RED branches in charge. Always
-# exits 0.
+# inspected summary is one of the explicit environmental classifications:
+# `real_ime_precondition` (#1800/#1882) or
+# `foreign_framework_anr_focus` (#1919). The latter requires attempt-local
+# ProcessRecord ownership proof; ambiguous `android` focus alone stays RED.
+# Anything else — a genuine assertion failure, mixed evidence, missing/corrupt
+# result XML, a missing classifier — emits NONE, which leaves the caller's
+# existing RED branches in charge. Always exits 0.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -47,13 +48,14 @@ if [[ -n "$artifacts" && -d "$artifacts" && -f "$SIGNATURE" ]]; then
     "$artifacts/ci-journey/summary.md"; do
     [[ -f "$summary" ]] || continue
     out="$(bash "$SIGNATURE" "$summary" \
-      "$artifacts/ci-journey" \
-      "$artifacts/ci-journey-attempt-1" 2>/dev/null || true)"
+      "$(dirname "$summary")" 2>/dev/null || true)"
     classification="$(sed -n 's/^journey_failure_classification=//p' <<<"$out" | tail -n 1)"
     [[ -n "$classification" ]] || classification="unclassified"
     seen=$((seen + 1))
     detail="${detail:+$detail }${summary}=${classification}"
-    [[ "$classification" == "real_ime_precondition" ]] || all_signature=false
+    [[ "$classification" == "real_ime_precondition" \
+      || "$classification" == "foreign_framework_anr_focus" ]] \
+      || all_signature=false
   done
   if (( seen > 0 )) && [[ "$all_signature" == "true" ]]; then
     verdict="INFRA"

--- a/scripts/test-ci-journey-artifact-packaging.sh
+++ b/scripts/test-ci-journey-artifact-packaging.sh
@@ -11,6 +11,7 @@ HELPER="${CI_JOURNEY_ARTIFACT_HELPER:-$SCRIPT_DIR/ci-journey-preserve-android-ou
 SETTINGS_PARSER="${CI_JOURNEY_SETTINGS_PARSER:-$SCRIPT_DIR/ci-journey-settings-project-dirs.py}"
 WORKFLOW="${CI_JOURNEY_ARTIFACT_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
 SETTINGS="${CI_JOURNEY_SETTINGS_FILE:-$REPO_ROOT/settings.gradle.kts}"
+BUDGET_FUNCTIONS="$SCRIPT_DIR/ci-journey-budget-functions.sh"
 
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
@@ -31,6 +32,7 @@ hash_tree() {
 seed_fixture() {
   local root="$1"
   local attempt="$root/artifacts/ci-journey/class-attempts/app/com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest--dca691208a3658f4/attempt-1"
+  local focus_attempt="$root/artifacts/ci-journey/class-attempts/app/com.pocketshell.app.session.ShowKeyboardChipE2eTest--8569a6475d403956/attempt-2"
 
   mkdir -p \
     "$root/build/reports/androidTests/connected/debug" \
@@ -40,6 +42,7 @@ seed_fixture() {
     "$attempt/android-test-outputs/app/build/reports/androidTests/connected/debug" \
     "$attempt/android-test-outputs/app/build/outputs/androidTest-results/connected/debug" \
     "$attempt/android-test-outputs/app/build/outputs/connected_android_test_additional_output/debugAndroidTest/connected/emulator-5554 - 15/agent-conversation-reconnect" \
+    "$focus_attempt/android-test-outputs/app/build/outputs/androidTest-results/connected/debug" \
     "$root/artifacts/ci-journey-attempt-1"
 
   {
@@ -74,6 +77,10 @@ seed_fixture() {
     echo 'device_cleanup_exit_code=1'
     echo 'status=complete'
   } > "$attempt/manifest.txt"
+  printf '<testsuite name="ShowKeyboardChipE2eTest" tests="1" failures="1"/>\n' \
+    > "$focus_attempt/android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-emulator-5554 - 15-_app-.xml"
+  printf 'foreign launcher ANR owned dialog for show-keyboard attempt 2\n' \
+    > "$focus_attempt/activity-processes.txt"
   printf 'journey summary\n' > "$root/artifacts/ci-journey/summary.md"
   printf 'first-attempt metadata\n' > "$root/artifacts/ci-journey-attempt-1/attempt-metadata.md"
 }
@@ -169,6 +176,20 @@ assert_real_attempt_paths() {
     || fail "cleanup status was not modeled in the real manifest path"
   grep -qx 'device_cleanup_exit_code=1' "$first/manifest.txt" \
     || fail "cleanup exit evidence changed in the first-cold-boot manifest"
+
+  local focus_current="$root/artifacts/ci-journey/class-attempts/app/com.pocketshell.app.session.ShowKeyboardChipE2eTest--8569a6475d403956/attempt-2"
+  local focus_first="$root/artifacts/ci-journey-attempt-1/ci-journey/class-attempts/app/com.pocketshell.app.session.ShowKeyboardChipE2eTest--8569a6475d403956/attempt-2"
+  local focus_xml="android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-emulator-5554 - 15-_app-.xml"
+  [[ -f "$focus_current/$focus_xml" && -f "$focus_current/activity-processes.txt" ]] \
+    || fail "current #1919 class-attempt lost its paired XML/process snapshot"
+  [[ -f "$focus_first/$focus_xml" && -f "$focus_first/activity-processes.txt" ]] \
+    || fail "preserved #1919 class-attempt lost its paired XML/process snapshot"
+  cmp -s "$focus_current/$focus_xml" "$focus_first/$focus_xml" \
+    || fail "preserved #1919 class-attempt XML bytes changed"
+  cmp -s "$focus_current/activity-processes.txt" "$focus_first/activity-processes.txt" \
+    || fail "preserved #1919 attempt-local process snapshot bytes changed"
+  cmp -s "$current/activity-processes.txt" "$focus_current/activity-processes.txt" \
+    && fail "distinct class-attempt process snapshots were cross-associated"
 }
 
 echo "== #1781 legacy recursion reproduction =="
@@ -386,7 +407,7 @@ module_output_root_count="$(find "$snapshot_root/android-test-outputs" \
              -o -path '*/build/outputs/connected_android_test_additional_output' \) | wc -l)"
 fixed_archive_files="$(find "$fixed_root/artifacts" -type f | wc -l)"
 fixed_archive_bytes="$(du -sb "$fixed_root/artifacts" | awk '{print $1}')"
-[[ "$current_attempt_count" -eq 1 && "$first_attempt_count" -eq 1 ]] \
+[[ "$current_attempt_count" -eq 2 && "$first_attempt_count" -eq 2 ]] \
   || fail "canonical attempt counts changed: current=$current_attempt_count first=$first_attempt_count"
 [[ "$module_output_root_count" -eq 4 ]] \
   || fail "expected four checked-project output roots, got $module_output_root_count"
@@ -394,7 +415,7 @@ fixed_archive_bytes="$(du -sb "$fixed_root/artifacts" | awk '{print $1}')"
   || fail "corrected archive did not shrink: legacy=$legacy_archive_files/$legacy_archive_bytes fixed=$fixed_archive_files/$fixed_archive_bytes"
 pass "deep/space project and root project copied; hashes unchanged; recursive roots=0"
 pass "byte digests: attempt_tree_files=$current_tree_files attempt_tree=$current_tree_digest timings=$timings_hash root=$root_report_hash app=$app_report_hash deep_raw=$deep_raw_hash deep_logcat=$deep_logcat_hash"
-pass "archive counts: current_attempts=1 first_attempts=1 module_output_roots=4 legacy_files=$legacy_archive_files fixed_files=$fixed_archive_files"
+pass "archive counts: current_attempts=2 first_attempts=2 module_output_roots=4 legacy_files=$legacy_archive_files fixed_files=$fixed_archive_files"
 pass "archive bytes: legacy=$legacy_archive_bytes fixed=$fixed_archive_bytes"
 
 echo
@@ -516,6 +537,12 @@ pass "all pre-existing missing-evidence marker semantics are unchanged"
 
 echo
 echo "== #1781 actual workflow snapshot/upload guards =="
+[[ -f "$BUDGET_FUNCTIONS" ]] || fail "missing attempt capture helper: $BUDGET_FUNCTIONS"
+grep -Fq '"activity processes" "$attempt_dir/activity-processes.txt"' "$BUDGET_FUNCTIONS" \
+  || fail "failed attempts no longer capture activity-processes.txt inside their own class-attempt directory"
+grep -Fq 'journey_adb -s "$serial" shell dumpsys activity processes' "$BUDGET_FUNCTIONS" \
+  || fail "attempt-local activity-processes.txt is no longer sourced from dumpsys activity processes"
+pass "#1919 process ownership snapshot is captured inside each failed class-attempt bundle"
 preserve_step="$(sed -n \
   '/- name: Preserve first journey attempt diagnostics/,/- name: Check remaining job wall before journey retry/p' \
   "$WORKFLOW")"

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -20,6 +20,7 @@ SHARD_VERDICT="$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh"
 ELAPSED="$SCRIPT_DIR/ci-journey-suite-elapsed.sh"
 RETRY_BUDGET="$SCRIPT_DIR/ci-journey-retry-budget.sh"
 AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+BUDGET_FN="$SCRIPT_DIR/ci-journey-budget-functions.sh"
 WORKFLOW="${CI_JOURNEY_INFRA_SIGNATURE_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
 ANDROID_TEST="$REPO_ROOT/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt"
 SHOW_KEYBOARD_TEST="$REPO_ROOT/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt"
@@ -29,9 +30,21 @@ CLASSIFIER_PY="$SCRIPT_DIR/ci-journey-infra-signature.py"
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
-for required in "$SIGNATURE" "$SHARD_VERDICT" "$ELAPSED" "$RETRY_BUDGET" "$AGG" "$WORKFLOW"; do
+for required in "$SIGNATURE" "$SHARD_VERDICT" "$ELAPSED" "$RETRY_BUDGET" "$AGG" "$WORKFLOW" "$BUDGET_FN"; do
   [[ -f "$required" ]] || fail "missing required file: $required"
 done
+
+journey_fixture_artifact_key() {
+  local classname="$1" key suffix
+  key="$(
+    bash -c 'source "$1"; journey_class_artifact_key "$2"' \
+      _ "$BUDGET_FN" "$classname"
+  )" || fail "could not derive the production artifact key for $classname"
+  suffix="${key#"$classname"--}"
+  [[ "$key" == "$classname"--* && "$suffix" =~ ^[0-9a-f]{16}$ ]] \
+    || fail "malformed production artifact key for $classname: $key"
+  printf '%s\n' "$key"
+}
 
 SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
@@ -105,8 +118,9 @@ append_summary_line() {
 #   outcome: pass | realime | containment | error
 write_case_xml() {
   local root="$1" class="$2" attempt="$3"; shift 3
-  local key="${class##*.}"
-  local dir="$root/ci-journey/class-attempts/app/$key/attempt-$attempt/android-test-outputs/androidTest-results/connected"
+  local key dir
+  key="$(journey_fixture_artifact_key "$class")"
+  dir="$root/ci-journey/class-attempts/app/$key/attempt-$attempt/android-test-outputs/app/build/outputs/androidTest-results/connected/debug"
   mkdir -p "$dir"
   local file="$dir/TEST-emulator-5554-15_$key-$attempt.xml"
   {
@@ -664,12 +678,14 @@ echo "== #1919 exact run 30665705369 foreign-framework-ANR fixture =="
 # own class-attempt activity-processes.txt and that snapshot proves the one
 # foreign ProcessRecord owns the framework AppNotRespondingDialog.
 root="$SANDBOX/issue1919-exact"; mkdir -p "$root"
+ISSUE1919_SAT_KEY="$(journey_fixture_artifact_key "$SATURATED_CLASS")"
+ISSUE1919_SHOW_KEY="$(journey_fixture_artifact_key "$SHOW_KEYBOARD_CLASS")"
 write_summary "$root" 2910 "$SATURATED_CLASS" "$SHOW_KEYBOARD_CLASS"
 for attempt in 1 2; do
   write_issue1919_attempt "$root" "$SATURATED_CLASS" \
-    "$SATURATED_CLASS--0301db8306ddbe3e" "$attempt"
+    "$ISSUE1919_SAT_KEY" "$attempt"
   write_issue1919_attempt "$root" "$SHOW_KEYBOARD_CLASS" \
-    "$SHOW_KEYBOARD_CLASS--8569a6475d403956" "$attempt"
+    "$ISSUE1919_SHOW_KEY" "$attempt"
 done
 run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
 printf '%s\n' "$SIG_OUT" | sed 's/^/    /'
@@ -692,8 +708,6 @@ run_agg "$verdicts"
 pass "(#1919) exact four-attempt launcher ANR -> INFRA -> RE-RUN"
 
 ISSUE1919_FIXTURE="$root"
-ISSUE1919_SAT_KEY="$SATURATED_CLASS--0301db8306ddbe3e"
-ISSUE1919_SHOW_KEY="$SHOW_KEYBOARD_CLASS--8569a6475d403956"
 issue1919_snapshot() {
   printf '%s/ci-journey/class-attempts/app/%s/attempt-%s/activity-processes.txt\n' \
     "$1" "$2" "$3"

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -116,7 +116,7 @@ write_case_xml() {
     for spec in "$@"; do
       method="${spec%%:*}"
       outcome="${spec#*:}"
-      echo "  <testcase name=\"$method\" classname=\"$class[emulator-5554 - 15]\">"
+      echo "  <testcase name=\"$method\" classname=\"${class}[emulator-5554 - 15]\">"
       case "$outcome" in
         pass) ;;
         realime)
@@ -184,6 +184,60 @@ write_case_xml() {
     done
     echo '</testsuite>'
   } > "$file"
+}
+
+# Issue #1919: write one of the four minimal class-attempt bundles preserved
+# from exact-main run 30665705369. The failure text and the decisive
+# ProcessRecord/mNotResponding ownership lines are byte-for-byte faithful to
+# that run; unrelated dumpsys/report noise is deliberately omitted.
+write_issue1919_attempt() {
+  local root="$1" class="$2" key="$3" attempt="$4"
+  local dir="$root/ci-journey/class-attempts/app/$key/attempt-$attempt"
+  local xml_dir="$dir/android-test-outputs/app/build/outputs/androidTest-results/connected/debug"
+  mkdir -p "$xml_dir"
+  if [[ "$class" == "$SATURATED_CLASS" ]]; then
+    cat > "$xml_dir/TEST-emulator-5554 - 15-_app-.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="$class" tests="1" failures="1">
+  <testcase name="saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide" classname="${class}[emulator-5554 - 15]">
+    <failure>java.lang.AssertionError: The real system input-method window never became visible. stage=before_show app_window_focused=false active_window_pkg=android physicalImeWindows=[]
+at org.junit.Assert.fail(Assert.java:89)
+at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.requestRealImeAndAssertVisible(PromptComposerSaturatedImeAnchorE2eTest.kt:1091)
+at com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest.saturatedDraftAndAllActionsStayReachableWithRealImeThenRestoreAfterActualHide(PromptComposerSaturatedImeAnchorE2eTest.kt:762)
+</failure>
+  </testcase>
+</testsuite>
+EOF
+  else
+    cat > "$xml_dir/TEST-emulator-5554 - 15-_app-.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="$class" tests="2" failures="2">
+  <testcase name="showKeyboardChipBringsUpSoftInput" classname="${class}[emulator-5554 - 15]">
+    <failure>java.lang.AssertionError: The app window never held input focus, so the system refused every showSoftInput() call (&quot;is not served&quot;). The show-keyboard chip cannot be measured in that state, so this is NOT a chip failure (cycle 1): app_window_focused=false active_window_pkg=android active_window_class=android.widget.FrameLayout.
+at org.junit.Assert.fail(Assert.java:89)
+at com.pocketshell.app.session.ShowKeyboardChipE2eTest.runShowKeyboardCycle(ShowKeyboardChipE2eTest.kt:500)
+at com.pocketshell.app.session.ShowKeyboardChipE2eTest.showKeyboardChipBringsUpSoftInput(ShowKeyboardChipE2eTest.kt:241)
+</failure>
+  </testcase>
+  <testcase name="foreignFocusOwnerIsNamedAsTheCauseInsteadOfBlamingTheChip" classname="${class}[emulator-5554 - 15]">
+    <failure>java.lang.AssertionError: an app-owned focus thief is a PRODUCT signal and must be reported as such, never cleared by the harness; expected active_window_pkg=com.pocketshell.app in: The app window never held input focus, so the system refused every showSoftInput() call (&quot;is not served&quot;). The show-keyboard chip cannot be measured in that state, so this is NOT a chip failure (cycle 1): app_window_focused=false active_window_pkg=android active_window_class=android.widget.FrameLayout.
+at org.junit.Assert.fail(Assert.java:89)
+at org.junit.Assert.assertTrue(Assert.java:42)
+at com.pocketshell.app.session.ShowKeyboardChipE2eTest.foreignFocusOwnerIsNamedAsTheCauseInsteadOfBlamingTheChip(ShowKeyboardChipE2eTest.kt:426)
+</failure>
+  </testcase>
+</testsuite>
+EOF
+  fi
+  cat > "$dir/activity-processes.txt" <<'EOF'
+ACTIVITY MANAGER RUNNING PROCESSES (dumpsys activity processes)
+  *APP* UID 10179 ProcessRecord{194efbc 1188:com.google.android.apps.nexuslauncher/u0a179}
+    user #0 uid=10179 gids={50179, 20179, 9997}
+    packageList={com.google.android.apps.nexuslauncher}
+    pid=1188
+    foregroundActivities=true (rep=true)
+     mCrashing=false null mNotResponding=true [com.android.server.am.AppNotRespondingDialog@8fc5bd] bad=false
+EOF
 }
 
 # run_signature <summary> <root> [<root>...] -> SIG_CLASS / SIG_OUT
@@ -506,9 +560,10 @@ run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
   || { printf '%s\n' "$SIG_OUT"; fail "(n2) the #1879 label without an owner must stay product_failure, got '$SIG_CLASS'"; }
 pass "(n2) the #1879 label without owner evidence stays RED"
 
-# Extract the production Kotlin constant, then prove the #1882-authoritative
-# classifier does not register it. AST string constants catch a future
-# split/implicitly-concatenated Python literal without tripping on comments.
+# Extract the production Kotlin constant, then prove the classifier registers
+# exactly that label. #1919 permits it only when the same class-attempt bundle
+# also proves foreign ProcessRecord ownership; the owner-less (n1/n2) cases
+# above remain the load-bearing anti-mask controls.
 [[ -f "$WINDOW_FOCUS_SIGNALS" ]] || fail "(n3) missing $WINDOW_FOCUS_SIGNALS"
 KOTLIN_SIGNATURE="$(python3 - "$WINDOW_FOCUS_SIGNALS" <<'PYEOF'
 import re
@@ -529,7 +584,7 @@ print("".join(piece.replace('\\"', '"') for piece in pieces))
 PYEOF
 )" || fail "(n3) could not extract the Kotlin #1879 signature"
 python3 - "$CLASSIFIER_PY" "$KOTLIN_SIGNATURE" <<'PYEOF' \
-  || fail "(n3) the #1879 label was registered in the #1882 classifier; it must stay RED"
+  || fail "(n3) the classifier does not use the production #1879 label"
 import ast
 import sys
 
@@ -540,16 +595,19 @@ if tree.body and isinstance(tree.body[0], ast.Expr):
     value = tree.body[0].value
     if isinstance(value, ast.Constant) and isinstance(value.value, str):
         docstring_node = value
+found = False
 for node in ast.walk(tree):
     if node is docstring_node:
         continue
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         if signature in node.value:
-            raise SystemExit(1)
+            found = True
+if not found:
+    raise SystemExit(1)
 PYEOF
 
-# The verdict layer must likewise refuse a hypothetical #1879 classification,
-# while retaining #1882's explicit-foreign real_ime_precondition control.
+# The verdict layer refuses the old owner-only hypothetical value, while
+# admitting only #1882 and #1919's explicit typed classifications.
 root="$SANDBOX/n3-verdict"; mkdir -p "$root/ci-journey"
 : >"$root/ci-journey/summary.md"
 stub="$SANDBOX/stub-foreign-window-classifier.sh"
@@ -564,7 +622,12 @@ printf '%s\n' '#!/usr/bin/env bash' \
 stub_out="$(CI_JOURNEY_INFRA_SIGNATURE="$stub" bash "$SHARD_VERDICT" "$root")"
 [[ "$(sed -n 's/^shard_signature_verdict=//p' <<<"$stub_out" | tail -n 1)" == "INFRA" ]] \
   || fail "(n3) #1882 real_ime_precondition control no longer reaches INFRA"
-pass "(n3) #1879 is unregistered while #1882 explicit-foreign real-IME stays live"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'echo journey_failure_classification=foreign_framework_anr_focus' >"$stub"
+stub_out="$(CI_JOURNEY_INFRA_SIGNATURE="$stub" bash "$SHARD_VERDICT" "$root")"
+[[ "$(sed -n 's/^shard_signature_verdict=//p' <<<"$stub_out" | tail -n 1)" == "INFRA" ]] \
+  || fail "(n3) #1919 foreign_framework_anr_focus does not reach INFRA"
+pass "(n3) owner-only focus stays RED; only #1882/#1919 typed values reach INFRA"
 
 # The precondition observes and diagnoses only. Acting on the UI or mutating
 # process-wide UiAutomation flags can dismiss an app-owned modal and mask a
@@ -591,6 +654,250 @@ grep -q "fun $SHOW_KEYBOARD_METHOD" "$SHOW_KEYBOARD_TEST" \
 grep -q "$SHOW_KEYBOARD_CLASS" "$REPO_ROOT/scripts/ci-journey-suite.sh" \
   || fail "(n5) the #1879 class is not wired into the per-push journey gate"
 pass "(n5) hard assertions remain and the #1879 reproduction is gate-wired"
+
+echo
+echo "== #1919 exact run 30665705369 foreign-framework-ANR fixture =="
+
+# Regression-first: exact main 76f0c401 classified this four-attempt fixture as
+# product_failure because active_window_pkg=android is correctly ambiguous in
+# isolation. It may turn green only when each failure is associated with its
+# own class-attempt activity-processes.txt and that snapshot proves the one
+# foreign ProcessRecord owns the framework AppNotRespondingDialog.
+root="$SANDBOX/issue1919-exact"; mkdir -p "$root"
+write_summary "$root" 2910 "$SATURATED_CLASS" "$SHOW_KEYBOARD_CLASS"
+for attempt in 1 2; do
+  write_issue1919_attempt "$root" "$SATURATED_CLASS" \
+    "$SATURATED_CLASS--0301db8306ddbe3e" "$attempt"
+  write_issue1919_attempt "$root" "$SHOW_KEYBOARD_CLASS" \
+    "$SHOW_KEYBOARD_CLASS--8569a6475d403956" "$attempt"
+done
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+printf '%s\n' "$SIG_OUT" | sed 's/^/    /'
+[[ "$SIG_CLASS" == "foreign_framework_anr_focus" ]] \
+  || fail "(#1919-red) exact four-attempt launcher-ANR fixture must classify foreign_framework_anr_focus, got '$SIG_CLASS'"
+grep -q '^journey_failing_testcases=6$' <<<"$SIG_OUT" \
+  || fail "(#1919-red) all six failure elements across the four attempts must be covered"
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+[[ "$SHARD_TOKEN" == "INFRA" ]] \
+  || fail "(#1919-red) exact launcher-ANR shard must be INFRA, got $SHARD_TOKEN"
+verdicts="$SANDBOX/verdicts-1919"; mkdir -p "$verdicts"
+write_shard_token "$verdicts" 0 CLEAN
+write_shard_token "$verdicts" 1 "$SHARD_TOKEN"
+write_shard_token "$verdicts" 2 CLEAN
+run_agg "$verdicts"
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || fail "(#1919-red) exact launcher-ANR run must aggregate RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"
+pass "(#1919) exact four-attempt launcher ANR -> INFRA -> RE-RUN"
+
+ISSUE1919_FIXTURE="$root"
+ISSUE1919_SAT_KEY="$SATURATED_CLASS--0301db8306ddbe3e"
+ISSUE1919_SHOW_KEY="$SHOW_KEYBOARD_CLASS--8569a6475d403956"
+issue1919_snapshot() {
+  printf '%s/ci-journey/class-attempts/app/%s/attempt-%s/activity-processes.txt\n' \
+    "$1" "$2" "$3"
+}
+issue1919_xml() {
+  printf '%s/ci-journey/class-attempts/app/%s/attempt-%s/android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-emulator-5554 - 15-_app-.xml\n' \
+    "$1" "$2" "$3"
+}
+clone_issue1919_fixture() {
+  mkdir -p "$1"
+  cp -a "$ISSUE1919_FIXTURE/ci-journey" "$1/ci-journey"
+}
+assert_issue1919_red() {
+  local label="$1" case_root="$2"
+  run_signature "$case_root/ci-journey/summary.md" "$case_root/ci-journey"
+  [[ "$SIG_CLASS" == "product_failure" || "$SIG_CLASS" == "unclassified" ]] \
+    || { printf '%s\n' "$SIG_OUT"; fail "(#1919-$label) unsafe evidence classified '$SIG_CLASS'"; }
+  mkdir -p "$case_root/ci-journey-attempt-1"
+  cp -a "$case_root/ci-journey" "$case_root/ci-journey-attempt-1/ci-journey"
+  shard_verdict_for "$case_root"
+  [[ "$SHARD_TOKEN" == "RED" ]] \
+    || fail "(#1919-$label) unsafe evidence must keep shard RED, got $SHARD_TOKEN"
+}
+
+# PocketShell itself, including arbitrary connected-test applicationIdSuffix
+# variants, can own the same framework dialog (#796). They are never infra.
+for owner in com.pocketshell.app com.pocketshell.app.i1919; do
+  case_root="$SANDBOX/issue1919-owner-${owner##*.}"
+  clone_issue1919_fixture "$case_root"
+  sed -i "s/com.google.android.apps.nexuslauncher/$owner/g" \
+    "$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+  assert_issue1919_red "app-owner-${owner##*.}" "$case_root"
+done
+pass "(#1919-a) PocketShell and applicationIdSuffix ANR owners stay RED"
+
+# Every ownership ambiguity fails closed: a second app/foreign owner, malformed
+# ProcessRecord package, dialog outside the owner block, false not-responding
+# state, or missing dialog identity.
+case_root="$SANDBOX/issue1919-mixed-owner"; clone_issue1919_fixture "$case_root"
+snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+cat >> "$snapshot" <<'EOF'
+  *APP* UID 10200 ProcessRecord{bbbbbbb 2200:com.pocketshell.app.i1919/u0a200}
+    mNotResponding=true [com.android.server.am.AppNotRespondingDialog@bbbbbbb]
+EOF
+assert_issue1919_red mixed-owner "$case_root"
+
+case_root="$SANDBOX/issue1919-two-foreign"; clone_issue1919_fixture "$case_root"
+snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+cat >> "$snapshot" <<'EOF'
+  *APP* UID 10201 ProcessRecord{ccccccc 2201:com.example.second/u0a201}
+    mNotResponding=true [com.android.server.am.AppNotRespondingDialog@ccccccc]
+EOF
+assert_issue1919_red two-foreign "$case_root"
+
+for mutation in malformed false missing-id; do
+  case_root="$SANDBOX/issue1919-$mutation"; clone_issue1919_fixture "$case_root"
+  snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+  case "$mutation" in
+    malformed) sed -i 's/com.google.android.apps.nexuslauncher/not-a-package/g' "$snapshot" ;;
+    false) sed -i 's/mNotResponding=true/mNotResponding=false/' "$snapshot" ;;
+    missing-id) sed -i 's/AppNotRespondingDialog@8fc5bd/AppNotRespondingDialog/' "$snapshot" ;;
+  esac
+  assert_issue1919_red "$mutation" "$case_root"
+done
+
+case_root="$SANDBOX/issue1919-dialog-outside"; clone_issue1919_fixture "$case_root"
+snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+sed -i 's/mNotResponding=true \[com.android.server.am.AppNotRespondingDialog@8fc5bd\]/mNotResponding=true/' "$snapshot"
+sed -i '1i mNotResponding=true [com.android.server.am.AppNotRespondingDialog@8fc5bd]' "$snapshot"
+assert_issue1919_red dialog-outside "$case_root"
+pass "(#1919-b) mixed/multiple/malformed/out-of-block ownership stays RED"
+
+# Missing, empty, malformed, and cross-attempt evidence cannot borrow another
+# bundle's valid launcher snapshot.
+for mutation in missing empty malformed-bytes; do
+  case_root="$SANDBOX/issue1919-snapshot-$mutation"; clone_issue1919_fixture "$case_root"
+  snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+  case "$mutation" in
+    missing) rm "$snapshot" ;;
+    empty) : > "$snapshot" ;;
+    malformed-bytes) printf '\377\376\375' > "$snapshot" ;;
+  esac
+  assert_issue1919_red "snapshot-$mutation" "$case_root"
+done
+case_root="$SANDBOX/issue1919-snapshot-unreadable"; clone_issue1919_fixture "$case_root"
+snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+chmod 000 "$snapshot"
+run_signature "$case_root/ci-journey/summary.md" "$case_root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || fail "(#1919-snapshot-unreadable) unreadable snapshot must be product_failure"
+chmod 600 "$snapshot"
+mkdir -p "$case_root/ci-journey-attempt-1"
+cp -a "$case_root/ci-journey" "$case_root/ci-journey-attempt-1/ci-journey"
+chmod 000 "$snapshot" \
+  "$case_root/ci-journey-attempt-1/ci-journey/class-attempts/app/$ISSUE1919_SAT_KEY/attempt-1/activity-processes.txt"
+shard_verdict_for "$case_root"
+[[ "$SHARD_TOKEN" == "RED" ]] \
+  || fail "(#1919-snapshot-unreadable) unreadable snapshot must keep shard RED"
+for app_attempt in 1 2; do
+  case_root="$SANDBOX/issue1919-attempt-$app_attempt-app"; clone_issue1919_fixture "$case_root"
+  snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" "$app_attempt")"
+  sed -i 's/com.google.android.apps.nexuslauncher/com.pocketshell.app.i1919/g' "$snapshot"
+  assert_issue1919_red "attempt-$app_attempt-app" "$case_root"
+done
+case_root="$SANDBOX/issue1919-cross-class"; clone_issue1919_fixture "$case_root"
+rm "$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+assert_issue1919_red cross-class "$case_root"
+
+# A testcase may consume only the snapshot beside its OWN canonical class key.
+# This is deliberately one bundle: the SaturatedIme attempt XML is poisoned
+# with a wanted ShowKeyboard testcase while no ShowKeyboard attempt exists. A
+# classifier that checks only "testcase is wanted" launders both failures
+# through SaturatedIme's one valid launcher snapshot and incorrectly emits INFRA.
+case_root="$SANDBOX/issue1919-wrong-bundle-classname"
+mkdir -p "$case_root"
+write_summary "$case_root" 2910 "$SATURATED_CLASS" "$SHOW_KEYBOARD_CLASS"
+write_issue1919_attempt "$case_root" "$SATURATED_CLASS" "$ISSUE1919_SAT_KEY" 1
+xml="$(issue1919_xml "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+python3 - "$xml" "$SHOW_KEYBOARD_CLASS" <<'PYEOF'
+import sys
+import xml.etree.ElementTree as ET
+
+path, classname = sys.argv[1:]
+tree = ET.parse(path)
+suite = tree.getroot()
+case = ET.SubElement(
+    suite,
+    "testcase",
+    {
+        "name": "showKeyboardChipBringsUpSoftInput",
+        "classname": f"{classname}[emulator-5554 - 15]",
+    },
+)
+failure = ET.SubElement(case, "failure")
+failure.text = (
+    "java.lang.AssertionError: The app window never held input focus, so the "
+    "system refused every showSoftInput() call (\"is not served\"). The "
+    "show-keyboard chip cannot be measured in that state, so this is NOT a "
+    "chip failure (cycle 1): app_window_focused=false "
+    "active_window_pkg=android active_window_class=android.widget.FrameLayout."
+)
+suite.set("tests", "2")
+suite.set("failures", "2")
+tree.write(path, encoding="UTF-8", xml_declaration=True)
+PYEOF
+run_signature "$case_root/ci-journey/summary.md" "$case_root/ci-journey"
+printf '%s\n' "$SIG_OUT" | sed 's/^/    wrong-bundle: /'
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || { printf '%s\n' "$SIG_OUT"; fail "(#1919-wrong-bundle-classname) mismatched testcase must be product_failure, got '$SIG_CLASS'"; }
+grep -q '^journey_failing_testcases=2$' <<<"$SIG_OUT" \
+  || fail "(#1919-wrong-bundle-classname) both failing testcases must remain visible"
+grep -q 'artifact-key-classname-mismatch.*ShowKeyboardChipE2eTest' <<<"$SIG_OUT" \
+  || { printf '%s\n' "$SIG_OUT"; fail "(#1919-wrong-bundle-classname) mismatch offender is not explicit"; }
+mkdir -p "$case_root/ci-journey-attempt-1"
+cp -a "$case_root/ci-journey" "$case_root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$case_root"
+[[ "$SHARD_TOKEN" == "RED" ]] \
+  || fail "(#1919-wrong-bundle-classname) mismatched testcase must keep shard RED, got $SHARD_TOKEN"
+
+case_root="$SANDBOX/issue1919-cross-attempt-symlink"; clone_issue1919_fixture "$case_root"
+snapshot="$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+rm "$snapshot"
+ln -s "$(issue1919_snapshot "$case_root" "$ISSUE1919_SAT_KEY" 2)" "$snapshot"
+assert_issue1919_red cross-attempt-symlink "$case_root"
+pass "(#1919-c) missing/malformed/wrong-attempt/cross-class/wrong-bundle evidence stays RED"
+
+# XML coverage remains all-or-nothing. Duplicate or corrupt attempt XML,
+# containment/anchor/chip/timeout text, and unrelated or uncovered classes all
+# veto the downgrade even beside valid foreign ANR snapshots.
+case_root="$SANDBOX/issue1919-duplicate-xml"; clone_issue1919_fixture "$case_root"
+xml="$(issue1919_xml "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+cp "$xml" "${xml%/*}/TEST-duplicate.xml"
+assert_issue1919_red duplicate-xml "$case_root"
+
+case_root="$SANDBOX/issue1919-corrupt-xml"; clone_issue1919_fixture "$case_root"
+xml="$(issue1919_xml "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+printf '<testsuite><testcase>' > "$xml"
+assert_issue1919_red corrupt-xml "$case_root"
+
+for mutation in containment chip timeout; do
+  case_root="$SANDBOX/issue1919-failure-$mutation"; clone_issue1919_fixture "$case_root"
+  if [[ "$mutation" == containment ]]; then
+    xml="$(issue1919_xml "$case_root" "$ISSUE1919_SAT_KEY" 1)"
+    sed -i 's/The real system input-method window never became visible\./Composer anchor escaped keyboard containment./' "$xml"
+  else
+    xml="$(issue1919_xml "$case_root" "$ISSUE1919_SHOW_KEY" 1)"
+    if [[ "$mutation" == chip ]]; then
+      sed -i '0,/The app window never held input focus/{s/The app window never held input focus/Show-keyboard chip remained hidden while the app window held focus/}' "$xml"
+    else
+      sed -i '0,/The app window never held input focus/{s/The app window never held input focus/androidx.compose.ui.test.ComposeTimeoutException: Condition still not satisfied after 15000 ms/}' "$xml"
+    fi
+  fi
+  assert_issue1919_red "failure-$mutation" "$case_root"
+done
+
+case_root="$SANDBOX/issue1919-unrelated"; clone_issue1919_fixture "$case_root"
+append_summary_line "$case_root" '- `com.pocketshell.app.proof.SomeOtherJourneyE2eTest`'
+write_case_xml "$case_root" com.pocketshell.app.proof.SomeOtherJourneyE2eTest 1 'unrelated:containment'
+assert_issue1919_red unrelated "$case_root"
+
+case_root="$SANDBOX/issue1919-uncovered"; clone_issue1919_fixture "$case_root"
+append_summary_line "$case_root" '- `com.pocketshell.app.proof.MissingJourneyE2eTest`'
+assert_issue1919_red uncovered "$case_root"
+pass "(#1919-d) corrupt/duplicate/uncovered and genuine co-located failures stay RED"
 
 echo
 echo "== #1822 method-scoped bullets and fail-safe-toward-RED parsing =="
@@ -934,17 +1241,18 @@ echo "== #1822 the REAL classify step run: body, executed end to end =="
 # `$GITHUB_OUTPUT` the shard's RED gate keys on. An unmapped expression is a HARD
 # failure, so a workflow edit cannot drift silently past this harness.
 
-# classify_expressions <journey-outcome> — the step-output map for one scenario.
+# classify_expressions <journey-outcome> [first-timeout] [first-failure] — the
+# step-output map for one scenario.
 classify_expressions() {
-  local journey_outcome="$1"
+  local journey_outcome="$1" first_timeout="${2:-false}" first_failure="${3:-true}"
   cat <<JSONEOF
 {
   "steps.journey.outcome": "$journey_outcome",
   "steps.journey_retry.outcome": "failure",
   "steps.journey.conclusion": "$journey_outcome",
   "steps.journey_retry.conclusion": "failure",
-  "steps.journey_summary.outputs.first_timeout": "false",
-  "steps.journey_summary.outputs.first_failure": "true",
+  "steps.journey_summary.outputs.first_timeout": "$first_timeout",
+  "steps.journey_summary.outputs.first_failure": "$first_failure",
   "steps.journey_retry_budget.outputs.retry_allowed": "true",
   "steps.journey_retry_budget.outputs.retry_reason": "sufficient_remaining_budget",
   "steps.journey_retry_budget.outputs.retry_remaining_ms": "3112241",
@@ -1090,6 +1398,31 @@ run_agg "$infra_token_dir"
   || { printf '%s\n' "$AGG_OUT"; fail "(t) an all-infra run must still aggregate RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
 pass "(t) #1800 preserved: signature-only -> real body writes INFRA -> aggregate RE-RUN (neutral green)"
 
+# (#1919-t2) The exact four-attempt fixture must traverse the REAL workflow
+# body, receive the new typed reason/warning, and remain timeout-ineligible.
+sandbox="$SANDBOX/wf-foreign-framework-anr"; mkdir -p "$sandbox/artifacts"
+cp -a "$ISSUE1919_FIXTURE/ci-journey" "$sandbox/artifacts/ci-journey"
+snapshot_first_attempt "$sandbox"
+run_classify_body "$sandbox" "$(classify_expressions failure)"
+[[ "$CLASSIFY_TOKEN" == "INFRA" && "$CLASSIFY_RC" -ne 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(#1919-t2) real body must write INFRA/nonzero for proven foreign ANR"; }
+grep -q '^shard_verdict_reason=foreign_framework_anr_focus$' <<<"$CLASSIFY_GH_OUTPUT" \
+  || { printf '%s\n' "$CLASSIFY_GH_OUTPUT"; fail "(#1919-t2) workflow lost the typed foreign-ANR reason"; }
+grep -q '::warning title=Emulator journey INFRA — foreign framework ANR owned focus' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(#1919-t2) workflow lost the typed foreign-ANR warning"; }
+grep -q '::error' <<<"$CLASSIFY_OUT" \
+  && fail "(#1919-t2) proven foreign ANR emitted a RED annotation"
+
+sandbox="$SANDBOX/wf-foreign-framework-anr-timeout"; mkdir -p "$sandbox/artifacts"
+cp -a "$ISSUE1919_FIXTURE/ci-journey" "$sandbox/artifacts/ci-journey"
+snapshot_first_attempt "$sandbox"
+run_classify_body "$sandbox" "$(classify_expressions failure true true)"
+[[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_RC" -ne 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(#1919-t2) timeout must override foreign-ANR evidence and stay RED"; }
+grep -q 'foreign framework ANR owned focus' <<<"$CLASSIFY_OUT" \
+  && fail "(#1919-t2) timeout entered the foreign-ANR INFRA branch"
+pass "(#1919-t2) real workflow maps proven foreign ANR to INFRA, while timeout stays RED"
+
 # (u) THE #1822 UN-MASKING, through the real step body. The exact run
 #     30334306297 shard-1 shape: the IME signature entry FOLLOWED BY two
 #     method-scoped genuine Compose-timeout failures. On the base classifier the
@@ -1146,7 +1479,7 @@ pass "(v) #1822: an unreadable failed-both entry -> the real body writes RED"
 sandbox="$SANDBOX/wf-clean"; mkdir -p "$sandbox/artifacts"
 write_summary "$sandbox/artifacts" 2338
 snapshot_first_attempt "$sandbox"
-run_classify_body "$sandbox" "$(classify_expressions success)"
+run_classify_body "$sandbox" "$(classify_expressions success false false)"
 [[ "$CLASSIFY_TOKEN" == "CLEAN" && "$CLASSIFY_RC" -eq 0 ]] \
   || { printf '%s\n' "$CLASSIFY_OUT"; fail "(w) a first-attempt success must write CLEAN/exit0, got '$CLASSIFY_TOKEN'/exit$CLASSIFY_RC"; }
 clean_token_dir="$SANDBOX/wf-verdicts-clean"; rm -rf "$clean_token_dir"; mkdir -p "$clean_token_dir"

--- a/scripts/test-ci-journey-summary-evidence.sh
+++ b/scripts/test-ci-journey-summary-evidence.sh
@@ -45,13 +45,26 @@ SUITE="$SCRIPT_DIR/ci-journey-suite.sh"
 CORE_TERMINAL_FN="$SCRIPT_DIR/ci-journey-core-terminal-functions.sh"
 SUMMARY_FN="$SCRIPT_DIR/ci-journey-summary-functions.sh"
 AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+BUDGET_FN="$SCRIPT_DIR/ci-journey-budget-functions.sh"
 
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
-for required in "$WORKFLOW" "$SUITE" "$CORE_TERMINAL_FN" "$SUMMARY_FN" "$AGG"; do
+for required in "$WORKFLOW" "$SUITE" "$CORE_TERMINAL_FN" "$SUMMARY_FN" "$AGG" "$BUDGET_FN"; do
   [[ -f "$required" ]] || fail "missing required file: $required"
 done
+
+journey_fixture_artifact_key() {
+  local classname="$1" key suffix
+  key="$(
+    bash -c 'source "$1"; journey_class_artifact_key "$2"' \
+      _ "$BUDGET_FN" "$classname"
+  )" || fail "could not derive the production artifact key for $classname"
+  suffix="${key#"$classname"--}"
+  [[ "$key" == "$classname"--* && "$suffix" =~ ^[0-9a-f]{16}$ ]] \
+    || fail "malformed production artifact key for $classname: $key"
+  printf '%s\n' "$key"
+}
 
 SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
@@ -828,7 +841,9 @@ write_synth_summary() {
 # write_synth_xml <ws> <attempt> <classname> <method:kind>...
 write_synth_xml() {
   local ws="$1" attempt="$2" classname="$3"; shift 3
-  local dir="$ws/artifacts/ci-journey/class-attempts/app/synthetic-$attempt-${classname##*.}"
+  local key dir
+  key="$(journey_fixture_artifact_key "$classname")"
+  dir="$ws/artifacts/ci-journey/class-attempts/app/$key/attempt-$attempt/android-test-outputs/app/build/outputs/androidTest-results/connected/debug"
   mkdir -p "$dir"
   {
     echo "<testsuite tests=\"$#\" failures=\"$#\">"

--- a/scripts/test-ci-journey-warm-build.sh
+++ b/scripts/test-ci-journey-warm-build.sh
@@ -32,13 +32,14 @@ REAL_SUITE="$SCRIPT_DIR/ci-journey-suite.sh"
 CLASS_LOOP="$SCRIPT_DIR/ci-journey-class-loop-functions.sh"
 WARM_HELPER="$SCRIPT_DIR/ci-journey-warm-build-functions.sh"
 BUILD_PHASE="$SCRIPT_DIR/ci-journey-build-phase-timeout.sh"
+BUILD_FAILURE="$SCRIPT_DIR/ci-journey-build-phase-failure.sh"
 WRITER="$SCRIPT_DIR/ci-journey-write-shard-verdict.sh"
 AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
 
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
-for required in "$REAL_SUITE" "$CLASS_LOOP" "$WARM_HELPER" "$BUILD_PHASE" \
+for required in "$REAL_SUITE" "$CLASS_LOOP" "$WARM_HELPER" "$BUILD_PHASE" "$BUILD_FAILURE" \
   "$WRITER" "$AGG" "$WORKFLOW"; do
   [[ -f "$required" ]] || fail "missing required file: $required"
 done
@@ -690,7 +691,8 @@ CLASSIFY_DIR="$SANDBOX/classify-run"
 setup_classify_dir() {
   rm -rf "$CLASSIFY_DIR"
   mkdir -p "$CLASSIFY_DIR/scripts" "$CLASSIFY_DIR/artifacts/ci-journey"
-  cp "$WRITER" "$BUILD_PHASE" "$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh" \
+  cp "$WRITER" "$BUILD_PHASE" "$BUILD_FAILURE" \
+    "$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh" \
     "$SCRIPT_DIR/ci-journey-infra-signature.sh" "$SCRIPT_DIR/ci-journey-infra-signature.py" \
     "$CLASSIFY_DIR/scripts/"
 }
@@ -739,6 +741,11 @@ run_classify() {
       bash "$CLASSIFY_BODY" 2>&1
   )"
   CLASSIFY_RC=$?
+  if grep -Fq 'ci-journey-build-phase-failure.sh: No such file or directory' \
+      <<<"$CLASSIFY_OUT"; then
+    printf '%s\n' "$CLASSIFY_OUT"
+    fail "(x) extracted classify body could not run the production build-phase-failure helper"
+  fi
   CLASSIFY_TOKEN="$(sed -n 's/^shard_verdict=//p' "$gh")"
   CLASSIFY_REASON="$(sed -n 's/^shard_verdict_reason=//p' "$gh")"
 }
@@ -799,6 +806,12 @@ pass "(x1) every classify branch writes the expected token + reason + exit code,
 # both sides of #1882's owner boundary: app-owned and unsafe/ambiguous evidence
 # must remain RED rather than inheriting the foreign-owner relief valve.
 SATURATED_CLASS="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
+SATURATED_KEY="$(
+  bash -c 'source "$1"; journey_class_artifact_key "$2"' \
+    _ "$SCRIPT_DIR/ci-journey-budget-functions.sh" "$SATURATED_CLASS"
+)" || fail "(x/#1800) could not derive the production artifact key for $SATURATED_CLASS"
+[[ "$SATURATED_KEY" == "$SATURATED_CLASS"--[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f] ]] \
+  || fail "(x/#1800) malformed production artifact key: $SATURATED_KEY"
 seed_real_ime_classify_fixture() {
   local owner_detail="$1"
   local signature_dir
@@ -807,7 +820,7 @@ seed_real_ime_classify_fixture() {
     '# Per-push CI journey suite — summary' \
     'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
     "- \`$SATURATED_CLASS\`"
-  signature_dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/Saturated--0123456789abcdef/attempt-1/android-test-outputs/androidTest-results/connected"
+  signature_dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/$SATURATED_KEY/attempt-1/android-test-outputs/app/build/outputs/androidTest-results/connected/debug"
   mkdir -p "$signature_dir"
   {
     echo '<?xml version="1.0" encoding="UTF-8"?>'


### PR DESCRIPTION
Closes #1919

## Summary
- classify framework-owned focus theft as INFRA only when the same canonical class-attempt bundle proves exactly one foreign ProcessRecord owns the sole ANR dialog
- fail closed for PocketShell/suffix ANRs, ambiguous owners, mismatched bundle classes, missing or cross-attempt evidence, timeouts, and genuine assertion failures
- preserve attempt-local activity process evidence and cover classifier, shard, aggregate, workflow, and packaging behavior

## Verification
- exact run 30665705369 four-attempt fixture: foreign_framework_anr_focus -> INFRA -> RE-RUN
- strict negative matrix remains product_failure/unclassified -> RED
- full infra-signature and artifact-packaging harnesses pass
- shell syntax/shellcheck/Python compile/diff checks pass
- independent reviewer: APPROVED