### PR TITLE
CI: remove rg dependency from tmux fixture guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -273,6 +273,15 @@ jobs:
           chmod +x scripts/test-agents-pool-isolation.sh
           scripts/test-agents-pool-isolation.sh
 
+      # Issue #1937 recurrence: ubuntu-latest does not guarantee ripgrep. Run
+      # the real guard under a minimal no-rg PATH and prove it still discovers
+      # both a valid consumer and a dynamically added broken fourth consumer.
+      - name: "Shared tmux-wrapper discovery self-test (issue #1937)"
+        run: |
+          chmod +x scripts/test-shared-tmux-wrapper-fixtures.sh \
+            scripts/test-shared-tmux-wrapper-fixtures-selftest.sh
+          scripts/test-shared-tmux-wrapper-fixtures-selftest.sh
+
       # Issue #1458: fast, JVM-free fixture test for the emulator-journey
       # aggregate verdict (scripts/ci-journey-aggregate-verdict.sh) + the
       # per-shard token-writing / aggregation wiring in tests.yml. Proves the

--- a/scripts/test-shared-tmux-wrapper-fixtures-selftest.sh
+++ b/scripts/test-shared-tmux-wrapper-fixtures-selftest.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Self-test the shared tmux-wrapper consumer discovery without optional tools.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_GUARD="$SCRIPT_DIR/test-shared-tmux-wrapper-fixtures.sh"
+
+fail() {
+  printf 'SELFTEST FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -x "$REAL_GUARD" ]] || fail "missing executable guard: $REAL_GUARD"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+repo="$tmp_dir/repo"
+minimal_bin="$tmp_dir/minimal-bin"
+mkdir -p "$repo/scripts" "$repo/tests/docker" "$minimal_bin"
+cp "$REAL_GUARD" "$repo/scripts/test-shared-tmux-wrapper-fixtures.sh"
+chmod +x "$repo/scripts/test-shared-tmux-wrapper-fixtures.sh"
+
+# Model ubuntu-latest's required baseline tools while deliberately excluding
+# ripgrep. The guard must not depend on optional developer-machine tooling.
+for tool in dirname find grep sort; do
+  tool_path="$(command -v "$tool")"
+  [[ -x "$tool_path" ]] || fail "required baseline tool is unavailable: $tool"
+  ln -s "$tool_path" "$minimal_bin/$tool"
+done
+if PATH="$minimal_bin" /bin/bash -c 'command -v rg' >/dev/null 2>&1; then
+  fail "minimal PATH unexpectedly exposes rg"
+fi
+
+cat > "$repo/tests/docker/Dockerfile.agents" <<'DOCKERFILE'
+FROM scratch
+RUN mv /usr/bin/tmux /usr/bin/tmux.real
+COPY tests/docker/agent-bin/ /usr/local/bin/
+RUN ln -sf /usr/local/bin/tmux /usr/bin/tmux
+DOCKERFILE
+
+valid_output="$tmp_dir/valid-output.log"
+PATH="$minimal_bin" /bin/bash "$repo/scripts/test-shared-tmux-wrapper-fixtures.sh" \
+  >"$valid_output" 2>&1 \
+  || { cat "$valid_output" >&2; fail "guard failed without rg on a valid consumer"; }
+grep -Fq 'Static shared-tmux invariant passed for 1 consumers.' "$valid_output" \
+  || { cat "$valid_output" >&2; fail "guard did not discover the valid consumer"; }
+printf '  ok: no-rg PATH discovered and accepted the valid consumer\n'
+
+# Add a fourth-style future consumer after the first run. Discovery must be
+# dynamic, and the missing delegate/symlink invariant must be load-bearing.
+cat > "$repo/tests/docker/Dockerfile.future-shared-wrapper" <<'DOCKERFILE'
+FROM scratch
+COPY tests/docker/agent-bin/tmux /usr/local/bin/tmux
+DOCKERFILE
+
+broken_output="$tmp_dir/broken-output.log"
+set +e
+PATH="$minimal_bin" /bin/bash "$repo/scripts/test-shared-tmux-wrapper-fixtures.sh" \
+  >"$broken_output" 2>&1
+broken_rc=$?
+set -e
+[[ "$broken_rc" -ne 0 ]] || fail "guard accepted a dynamically added broken consumer"
+grep -Fq 'Dockerfile.future-shared-wrapper copies the shared tmux shim but does not preserve real tmux' \
+  "$broken_output" \
+  || { cat "$broken_output" >&2; fail "guard failed for the wrong reason"; }
+printf '  ok: dynamically added broken consumer rejected (rc=%d)\n' "$broken_rc"
+
+printf 'Shared tmux-wrapper discovery self-test passed without rg.\n'

--- a/scripts/test-shared-tmux-wrapper-fixtures.sh
+++ b/scripts/test-shared-tmux-wrapper-fixtures.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SHARED_TMUX_COPY_REGEX='^COPY[[:space:]]+tests/docker/agent-bin/(?:[[:space:]]|tmux[[:space:]])'
+SHARED_TMUX_COPY_REGEX='^COPY[[:space:]]+tests/docker/agent-bin/([[:space:]]|tmux[[:space:]])'
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -15,7 +15,8 @@ fail() {
 }
 
 mapfile -t consumers < <(
-  rg -l "$SHARED_TMUX_COPY_REGEX" "$ROOT_DIR/tests/docker"/Dockerfile.* | sort
+  find "$ROOT_DIR/tests/docker" -maxdepth 1 -type f -name 'Dockerfile.*' \
+    -exec grep -El "$SHARED_TMUX_COPY_REGEX" {} + | sort
 )
 
 [[ ${#consumers[@]} -gt 0 ]] || fail "no Dockerfile consumers of the shared agent-bin/tmux shim found"


### PR DESCRIPTION
Closes #1937

The exact-main repair guard failed before its Docker smokes because `ubuntu-latest` does not guarantee `rg`. This recurrence replaces discovery with baseline `find`/`grep` and adds a required no-`rg` self-test that also proves dynamic broken-consumer rejection.

Review evidence: https://github.com/alexeygrigorev/pocketshell/issues/1937#issuecomment-5152926843