### PR TITLE
ci: bind foreign ANR evidence to attempts

### DIFF
--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -607,7 +607,7 @@ begin_class_attempt_artifacts() {
   local suffix="${3:-}"
   local key="$module:$fqcn"
   local attempt=$(( ${JOURNEY_CLASS_ATTEMPT_COUNTS[$key]:-0} + 1 ))
-  local artifact_key
+  local artifact_key capture_token
 
   JOURNEY_CLASS_ATTEMPT_COUNTS["$key"]="$attempt"
   artifact_key="$(journey_class_artifact_key "$fqcn")" || return 1
@@ -619,6 +619,13 @@ begin_class_attempt_artifacts() {
   LAST_RUN_CLASS_RAW_JUNIT_STATUS=""
   LAST_RUN_CLASS_RAW_JUNIT_COUNT=0
   LAST_RUN_CLASS_SNAPSHOT_STATUS=""
+  capture_token="$(
+    printf '%s\0%s\0%s\0%s\0%s\n' \
+      "$module" "$fqcn" "$attempt" "$(date +%s%N)" "$RANDOM" \
+      | sha256sum | awk '{ print $1 }'
+  )" || return 1
+  [[ "$capture_token" =~ ^[0-9a-f]{64}$ ]] || return 1
+  LAST_RUN_CLASS_CAPTURE_TOKEN="$capture_token"
   rm -rf -- "$LAST_RUN_CLASS_ATTEMPT_DIR" || return 1
   mkdir -p "$LAST_RUN_CLASS_ATTEMPT_DIR" || return 1
   : > "$LAST_RUN_CLASS_ATTEMPT_DIR/attempt.log" || return 1
@@ -628,6 +635,7 @@ begin_class_attempt_artifacts() {
     printf 'module=%s\n' "$module"
     printf 'class=%s\n' "$fqcn"
     printf 'attempt=%s\n' "$attempt"
+    printf 'capture_token=%s\n' "$capture_token"
     printf 'started_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     printf 'application_id_suffix=%s\n' "$suffix"
     printf 'status=running\n'
@@ -818,6 +826,9 @@ snapshot_connected_test_outputs() {
   local primary_classification
   local outer_timeout_phase
   local attempt_failure_phase
+  local activity_processes_sha256=""
+  local activity_processes_size_bytes=""
+  local activity_processes_captured_at_utc=""
   local -a build_roots=()
 
   mapfile -t build_roots < <(journey_module_build_roots "$module" "$suffix") || return 1
@@ -899,10 +910,32 @@ snapshot_connected_test_outputs() {
         "device process list" "$attempt_dir/device-processes.txt" \
         journey_adb -s "$serial" shell ps -A \
         || snapshot_failed=1
-      capture_required_nonempty \
-        "activity processes" "$attempt_dir/activity-processes.txt" \
-        journey_adb -s "$serial" shell dumpsys activity processes \
-        || snapshot_failed=1
+      if capture_required_nonempty \
+          "activity processes" "$attempt_dir/activity-processes.txt" \
+          journey_adb -s "$serial" shell dumpsys activity processes; then
+        # Bind the exact process dump bytes to this attempt while capture is
+        # still in progress.  The focus-ANR classifier verifies all three
+        # fields before this evidence can downgrade a product failure to INFRA;
+        # a later regular-file copy from a sibling attempt therefore fails
+        # closed just like a symlink or missing snapshot.
+        printf '\nPOCKETSHELL_ATTEMPT_CAPTURE_TOKEN=%s\n' \
+          "$LAST_RUN_CLASS_CAPTURE_TOKEN" \
+          >> "$attempt_dir/activity-processes.txt" || snapshot_failed=1
+        activity_processes_captured_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        activity_processes_sha256="$(
+          sha256sum "$attempt_dir/activity-processes.txt" | awk '{ print $1 }'
+        )" || snapshot_failed=1
+        activity_processes_size_bytes="$(
+          wc -c < "$attempt_dir/activity-processes.txt"
+        )" || snapshot_failed=1
+        activity_processes_size_bytes="${activity_processes_size_bytes//[[:space:]]/}"
+        [[ "$activity_processes_sha256" =~ ^[0-9a-f]{64}$ ]] \
+          || snapshot_failed=1
+        [[ "$activity_processes_size_bytes" =~ ^[1-9][0-9]*$ ]] \
+          || snapshot_failed=1
+      else
+        snapshot_failed=1
+      fi
       capture_required_nonempty \
         "activity top" "$attempt_dir/activity-top.txt" \
         journey_adb -s "$serial" shell dumpsys activity top \
@@ -936,6 +969,12 @@ snapshot_connected_test_outputs() {
     printf 'outer_timeout_phase=%s\n' "$outer_timeout_phase"
     printf 'attempt_failure_phase=%s\n' "$attempt_failure_phase"
     printf 'snapshotted_output_roots=%s\n' "$copied"
+    if [[ -n "$activity_processes_sha256" ]]; then
+      printf 'activity_processes_sha256=%s\n' "$activity_processes_sha256"
+      printf 'activity_processes_size_bytes=%s\n' "$activity_processes_size_bytes"
+      printf 'activity_processes_captured_at_utc=%s\n' \
+        "$activity_processes_captured_at_utc"
+    fi
     printf 'snapshot_status=%s\n' "$([[ "$snapshot_failed" -eq 0 ]] && printf complete || printf failed)"
   } >> "$attempt_dir/manifest.txt" || snapshot_failed=1
 

--- a/scripts/ci-journey-infra-signature.py
+++ b/scripts/ci-journey-infra-signature.py
@@ -66,11 +66,13 @@ Exit status is always 0: the caller decides the verdict from the classification.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 import stat
 import sys
 import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
 
 # The ONE captured environment signature (issue #1800 / run 30305256109).
 REAL_IME_UNAVAILABLE_SIGNATURE = (
@@ -86,11 +88,73 @@ ACTIVE_WINDOW_PACKAGE = re.compile(
 APP_WINDOW_FOCUS_STATE = re.compile(
     r"app_window_focused=(true|false)\s+active_window_pkg=([^\s,;.]+)",
 )
+# Issue #788 / exact-main run 30747057492: these are bounded focus-handoff
+# preconditions, not the load-bearing IME/Copy assertions themselves.  They may
+# join #1919's foreign-framework-ANR classification only when the failure also
+# says the current window belongs to `android` AND the attempt-local process
+# snapshot independently proves the sole ANR dialog belongs to a foreign app.
+# Keep the strings exact and intentionally small: an arbitrary focus, Copy, or
+# composer failure must never enter the environmental branch.
+FOCUS_HANDOFF_PRECONDITION_SIGNATURES = (
+    "the sent-snippet modal must release input focus before the "
+    "keyboard-up shell-composer phase:",
+    "file-viewer activity must regain focus after the synthetic owner is "
+    "dismissed;",
+)
 ANDROID_PACKAGE = re.compile(
     r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+",
 )
 POCKETSHELL_APP_PACKAGE_PREFIX = "com.pocketshell.app"
 ATTEMPT_DIRECTORY = re.compile(r"attempt-[1-9][0-9]*")
+CAPTURE_TOKEN = re.compile(r"[0-9a-f]{64}")
+# Run 30747057492 predates capture-time manifest digests.  Preserve only its
+# four byte-exact process dumps, pinned to their full selector, attempt, and UTC
+# interval.  New captures must carry the manifest binding written by
+# ci-journey-budget-functions.sh; this immutable legacy set exists solely so
+# the exact reviewed incident remains classifiable without making arbitrary
+# unhashed artifacts eligible.
+LEGACY_ISSUE788_ACTIVITY_PROCESS_BINDINGS = {
+    (
+        "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
+        "#shellComposerControlsAreVisibleAndReachableInBothKeyboardStates",
+        "1",
+        "2026-08-02T13:11:06Z",
+        "2026-08-02T13:11:53Z",
+    ): (
+        "a993fbf8a7cd1c74b0c5674a38e325484f0d9a1e82c58d1fb2993bd6c24975af",
+        268193,
+    ),
+    (
+        "com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest"
+        "#shellComposerControlsAreVisibleAndReachableInBothKeyboardStates",
+        "2",
+        "2026-08-02T13:11:53Z",
+        "2026-08-02T13:12:41Z",
+    ): (
+        "f5f263d38f61a5beb1a5f4ca1b9a17fc132a0900f630ec845006783f2567f3ee",
+        268681,
+    ),
+    (
+        "com.pocketshell.app.fileviewer.FileViewerDockerTest"
+        "#moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl",
+        "1",
+        "2026-08-02T13:19:45Z",
+        "2026-08-02T13:20:17Z",
+    ): (
+        "9277216eab2f2da8b7a9c4450c956424f952d1a728db198d177e0476e23b95f8",
+        268009,
+    ),
+    (
+        "com.pocketshell.app.fileviewer.FileViewerDockerTest"
+        "#moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl",
+        "2",
+        "2026-08-02T13:20:17Z",
+        "2026-08-02T13:20:49Z",
+    ): (
+        "56bdc66954f6bfeafa39799a26997a165a9e5d62679b3f608e0b679833937bda",
+        268262,
+    ),
+}
 PROCESS_HEADER = re.compile(
     r"^\s*\*APP\*.*?\bProcessRecord\{[^{}\n]*?\s+[0-9]+:([^/\s}]+)/[^\s}]+\}",
 )
@@ -244,15 +308,28 @@ def _is_real_ime_environment_failure(text: str) -> bool:
 
 def _is_framework_focus_precondition(text: str) -> bool:
     if (
-        REAL_IME_UNAVAILABLE_SIGNATURE not in text
-        and APP_WINDOW_FOCUS_SIGNATURE not in text
+        REAL_IME_UNAVAILABLE_SIGNATURE in text
+        or APP_WINDOW_FOCUS_SIGNATURE in text
+    ):
+        states = APP_WINDOW_FOCUS_STATE.findall(text)
+        return bool(states) and all(
+            focused == "false" and package == "android"
+            for focused, package in states
+        )
+
+    # The #1942/#1855 repaired journeys establish focus at a handoff boundary
+    # before exercising their real IME/Copy oracles.  Run 30747057492 caught a
+    # launcher ANR already standing above both classes in one boot.  The
+    # composer reports the full app-window state while FileViewer reports the
+    # active owner after dismissing only its own synthetic dialog.  Accept both
+    # exact causal messages here; _foreign_anr_owner() remains the independent,
+    # attempt-local ownership gate before either can affect the shard verdict.
+    if not any(
+        signature in text for signature in FOCUS_HANDOFF_PRECONDITION_SIGNATURES
     ):
         return False
-    states = APP_WINDOW_FOCUS_STATE.findall(text)
-    return bool(states) and all(
-        focused == "false" and package == "android"
-        for focused, package in states
-    )
+    owners = ACTIVE_WINDOW_PACKAGE.findall(text)
+    return bool(owners) and all(owner == "android" for owner in owners)
 
 
 def _foreign_anr_owner(snapshot_path: str) -> str | None:
@@ -317,6 +394,113 @@ def _foreign_anr_owner(snapshot_path: str) -> str | None:
     if len(ANY_ANR_DIALOG.findall(text)) != 1:
         return None
     return package
+
+
+def _attempt_provenance_matches(
+    attempt_dir: str, classname: str, snapshot_path: str
+) -> bool:
+    """Require the snapshot's own completed class-attempt manifest.
+
+    The suite deletes/recreates each attempt directory before execution, then
+    writes the process snapshot and finalises this manifest in that directory.
+    Binding the framework-ANR exception to its class, attempt number, and
+    monotonic UTC interval prevents evidence from a sibling attempt/root from
+    being copied or linked in to license a failure it did not accompany.
+    """
+    manifest_path = os.path.join(attempt_dir, "manifest.txt")
+    if not _is_readable_regular_file(manifest_path):
+        return False
+    values: dict[str, list[str]] = {}
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as handle:
+            for raw in handle:
+                line = raw.rstrip("\n")
+                if "=" not in line:
+                    return False
+                key, value = line.split("=", 1)
+                if not key:
+                    return False
+                values.setdefault(key, []).append(value)
+    except (OSError, UnicodeError):
+        return False
+
+    def last(key: str) -> str | None:
+        entries = values.get(key, [])
+        return entries[-1] if entries else None
+
+    attempt_match = ATTEMPT_DIRECTORY.fullmatch(os.path.basename(attempt_dir))
+    if attempt_match is None:
+        return False
+    selector = last("class") or ""
+    attempt = os.path.basename(attempt_dir).removeprefix("attempt-")
+    started_text = last("started_at_utc") or ""
+    finished_text = last("finished_at_utc") or ""
+    if (
+        last("format_version") != "1"
+        or last("module") != "app"
+        or selector.split("#", 1)[0] != classname
+        or last("attempt") != attempt
+        or last("snapshot_status") != "complete"
+        or last("status") != "complete"
+    ):
+        return False
+
+    try:
+        started = datetime.strptime(
+            started_text, "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=timezone.utc)
+        finished = datetime.strptime(
+            finished_text, "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return False
+    if started > finished or not _is_readable_regular_file(snapshot_path):
+        return False
+
+    try:
+        snapshot_size = os.stat(snapshot_path, follow_symlinks=False).st_size
+        with open(snapshot_path, "rb") as handle:
+            snapshot_bytes = handle.read()
+        snapshot_sha256 = hashlib.sha256(snapshot_bytes).hexdigest()
+    except OSError:
+        return False
+
+    bound_sha256 = last("activity_processes_sha256")
+    bound_size = last("activity_processes_size_bytes")
+    captured_text = last("activity_processes_captured_at_utc")
+    capture_token = last("capture_token")
+    binding_fields = (bound_sha256, bound_size, captured_text, capture_token)
+    if all(field is None for field in binding_fields):
+        return LEGACY_ISSUE788_ACTIVITY_PROCESS_BINDINGS.get(
+            (selector, attempt, started_text, finished_text)
+        ) == (snapshot_sha256, snapshot_size)
+    if any(field is None for field in binding_fields):
+        return False
+    assert capture_token is not None
+    if CAPTURE_TOKEN.fullmatch(capture_token) is None:
+        return False
+    expected_marker = (
+        f"\nPOCKETSHELL_ATTEMPT_CAPTURE_TOKEN={capture_token}\n".encode("ascii")
+    )
+    if not snapshot_bytes.endswith(expected_marker):
+        return False
+    if snapshot_bytes.count(b"POCKETSHELL_ATTEMPT_CAPTURE_TOKEN=") != 1:
+        return False
+    if not re.fullmatch(r"[0-9a-f]{64}", bound_sha256):
+        return False
+    if not re.fullmatch(r"[1-9][0-9]*", bound_size):
+        return False
+    try:
+        captured = datetime.strptime(
+            captured_text, "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return False
+    return (
+        started <= captured <= finished
+        and bound_sha256 == snapshot_sha256
+        and int(bound_size) == snapshot_size
+    )
 
 
 def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
@@ -386,9 +570,15 @@ def classify(summary_path: str, roots: list[str]) -> dict[str, object]:
                         kinds.append("real_ime")
                     elif _is_framework_focus_precondition(text):
                         if snapshot_owner is None:
-                            snapshot_owner = _foreign_anr_owner(
-                                os.path.join(attempt_dir, "activity-processes.txt"),
+                            snapshot_path = os.path.join(
+                                attempt_dir, "activity-processes.txt"
                             )
+                            if _attempt_provenance_matches(
+                                attempt_dir, base, snapshot_path
+                            ):
+                                snapshot_owner = _foreign_anr_owner(
+                                    snapshot_path,
+                                )
                         kinds.append("framework_anr" if snapshot_owner else "offender")
                     else:
                         kinds.append("offender")

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -978,6 +978,25 @@ for diagnostic in device-processes.txt activity-processes.txt activity-top.txt; 
   [[ -f "$attempt_root/attempt-1/$diagnostic" ]] \
     || fail "(artifacts) timeout attempt is missing $diagnostic"
 done
+attempt_1_process_snapshot="$attempt_root/attempt-1/activity-processes.txt"
+attempt_1_manifest="$attempt_root/attempt-1/manifest.txt"
+attempt_1_capture_token="$(sed -n 's/^capture_token=//p' "$attempt_1_manifest" | tail -n 1)"
+[[ "$attempt_1_capture_token" =~ ^[0-9a-f]{64}$ ]] \
+  || fail "(artifacts) timeout manifest is missing its per-attempt capture token"
+grep -Fqx "POCKETSHELL_ATTEMPT_CAPTURE_TOKEN=$attempt_1_capture_token" \
+  "$attempt_1_process_snapshot" \
+  || fail "(artifacts) process snapshot is not bound to its attempt token"
+grep -Fqx \
+  "activity_processes_sha256=$(sha256sum "$attempt_1_process_snapshot" | awk '{ print $1 }')" \
+  "$attempt_1_manifest" \
+  || fail "(artifacts) process snapshot digest was not sealed into its manifest"
+grep -Fqx \
+  "activity_processes_size_bytes=$(wc -c < "$attempt_1_process_snapshot")" \
+  "$attempt_1_manifest" \
+  || fail "(artifacts) process snapshot size was not sealed into its manifest"
+grep -Eq '^activity_processes_captured_at_utc=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' \
+  "$attempt_1_manifest" \
+  || fail "(artifacts) process snapshot capture time was not sealed into its manifest"
 grep -q '^primary_exit_code=124$' "$attempt_root/attempt-1/manifest.txt" \
   || fail "(artifacts) timeout manifest did not preserve the primary rc=124"
 grep -q '^application_id_suffix=i1458$' "$attempt_root/attempt-1/manifest.txt" \

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -208,6 +208,8 @@ write_issue1919_attempt() {
   local root="$1" class="$2" key="$3" attempt="$4"
   local dir="$root/ci-journey/class-attempts/app/$key/attempt-$attempt"
   local xml_dir="$dir/android-test-outputs/app/build/outputs/androidTest-results/connected/debug"
+  local snapshot_sha snapshot_size capture_token
+  capture_token="$(printf '%s' "$root|$class|$attempt" | sha256sum | awk '{ print $1 }')"
   mkdir -p "$xml_dir"
   if [[ "$class" == "$SATURATED_CLASS" ]]; then
     cat > "$xml_dir/TEST-emulator-5554 - 15-_app-.xml" <<EOF
@@ -251,6 +253,91 @@ ACTIVITY MANAGER RUNNING PROCESSES (dumpsys activity processes)
     pid=1188
     foregroundActivities=true (rep=true)
      mCrashing=false null mNotResponding=true [com.android.server.am.AppNotRespondingDialog@8fc5bd] bad=false
+EOF
+  printf '\nPOCKETSHELL_ATTEMPT_CAPTURE_TOKEN=%s\n' "$capture_token" \
+    >> "$dir/activity-processes.txt"
+  snapshot_sha="$(sha256sum "$dir/activity-processes.txt" | awk '{ print $1 }')"
+  snapshot_size="$(wc -c < "$dir/activity-processes.txt")"
+  cat > "$dir/manifest.txt" <<EOF
+format_version=1
+module=app
+class=$class
+attempt=$attempt
+capture_token=$capture_token
+started_at_utc=2026-07-31T15:00:0${attempt}Z
+status=running
+activity_processes_sha256=$snapshot_sha
+activity_processes_size_bytes=$snapshot_size
+activity_processes_captured_at_utc=2026-07-31T15:00:30Z
+snapshot_status=complete
+status=complete
+finished_at_utc=2026-07-31T15:01:0${attempt}Z
+EOF
+}
+
+# Issue #788 / exact-main run 30747057492: write the two focus-handoff
+# failures that each repeated twice in one boot while the same Pixel Launcher
+# ANR dialog remained above the app.  These are the exact causal oracle texts;
+# no generic IME timeout, Copy timeout, or product assertion is substituted.
+write_issue788_focus_handoff_attempt() {
+  local root="$1" class="$2" key="$3" attempt="$4"
+  local dir="$root/ci-journey/class-attempts/app/$key/attempt-$attempt"
+  local xml_dir="$dir/android-test-outputs/app/build/outputs/androidTest-results/connected/debug"
+  local snapshot_sha snapshot_size capture_token
+  capture_token="$(printf '%s' "$root|$class|$attempt" | sha256sum | awk '{ print $1 }')"
+  mkdir -p "$xml_dir"
+  if [[ "$class" == "$OCCLUSION_CLASS" ]]; then
+    cat > "$xml_dir/TEST-emulator-5554 - 15-_app-.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="$class" tests="1" failures="1">
+  <testcase name="$OCCLUSION_METHOD" classname="${class}[emulator-5554 - 15]">
+    <failure>java.lang.AssertionError: the sent-snippet modal must release input focus before the keyboard-up shell-composer phase: app_window_focused=false active_window_pkg=android active_window_class=android.widget.FrameLayout
+at org.junit.Assert.fail(Assert.java:89)
+at com.pocketshell.app.tmux.TmuxShellComposerOcclusionE2eTest.awaitTestOpenedSnippetPickerDismissed(TmuxShellComposerOcclusionE2eTest.kt:495)
+</failure>
+  </testcase>
+</testsuite>
+EOF
+  else
+    cat > "$xml_dir/TEST-emulator-5554 - 15-_app-.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="$class" tests="1" failures="1">
+  <testcase name="$FILEVIEWER_METHOD" classname="${class}[emulator-5554 - 15]">
+    <failure>java.lang.AssertionError: file-viewer activity must regain focus after the synthetic owner is dismissed; active_window_pkg=android active_window_class=android.widget.FrameLayout
+at org.junit.Assert.fail(Assert.java:89)
+at com.pocketshell.app.fileviewer.FileViewerDockerTest.dismissSyntheticFocusStealingWindow(FileViewerDockerTest.kt:980)
+</failure>
+  </testcase>
+</testsuite>
+EOF
+  fi
+  cat > "$dir/activity-processes.txt" <<'EOF'
+ACTIVITY MANAGER RUNNING PROCESSES (dumpsys activity processes)
+  *APP* UID 10179 ProcessRecord{19927a0 1229:com.google.android.apps.nexuslauncher/u0a179}
+    user #0 uid=10179 gids={50179, 20179, 9997}
+    packageList={com.google.android.apps.nexuslauncher}
+    pid=1229
+    foregroundActivities=true (rep=true)
+     mCrashing=false null mNotResponding=true [com.android.server.am.AppNotRespondingDialog@b1901c8] bad=false
+EOF
+  printf '\nPOCKETSHELL_ATTEMPT_CAPTURE_TOKEN=%s\n' "$capture_token" \
+    >> "$dir/activity-processes.txt"
+  snapshot_sha="$(sha256sum "$dir/activity-processes.txt" | awk '{ print $1 }')"
+  snapshot_size="$(wc -c < "$dir/activity-processes.txt")"
+  cat > "$dir/manifest.txt" <<EOF
+format_version=1
+module=app
+class=$class
+attempt=$attempt
+capture_token=$capture_token
+started_at_utc=2026-08-02T13:1${attempt}:00Z
+status=running
+activity_processes_sha256=$snapshot_sha
+activity_processes_size_bytes=$snapshot_size
+activity_processes_captured_at_utc=2026-08-02T13:1${attempt}:30Z
+snapshot_status=complete
+status=complete
+finished_at_utc=2026-08-02T13:1${attempt}:59Z
 EOF
 }
 
@@ -706,8 +793,202 @@ run_agg "$verdicts"
 [[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
   || fail "(#1919-red) exact launcher-ANR run must aggregate RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"
 pass "(#1919) exact four-attempt launcher ANR -> INFRA -> RE-RUN"
-
 ISSUE1919_FIXTURE="$root"
+
+echo
+echo "== #788 exact run 30747057492 cross-journey launcher-ANR focus handoff =="
+
+# Regression-first RED: exact main cfeafc27 classified these four failures as
+# product_failure even though every attempt-local snapshot proved the SAME sole
+# Pixel Launcher AppNotRespondingDialog owner.  Both repaired journeys therefore
+# failed twice in one boot and hardened into a RED when the cold-boot retry did
+# not fit.  The narrow handoff classifier must route that complete evidence to
+# the existing INFRA -> fresh-cold-boot path, without changing either journey's
+# real IME/Copy deadline or dismissing any window.
+root="$SANDBOX/issue788-focus-handoff"; mkdir -p "$root"
+ISSUE788_OCCLUSION_KEY="$(journey_fixture_artifact_key "$OCCLUSION_CLASS")"
+ISSUE788_FILEVIEWER_KEY="$(journey_fixture_artifact_key "$FILEVIEWER_CLASS")"
+write_summary "$root" 2910 \
+  "$OCCLUSION_CLASS#$OCCLUSION_METHOD" \
+  "$FILEVIEWER_CLASS#$FILEVIEWER_METHOD"
+for attempt in 1 2; do
+  write_issue788_focus_handoff_attempt "$root" "$OCCLUSION_CLASS" \
+    "$ISSUE788_OCCLUSION_KEY" "$attempt"
+  write_issue788_focus_handoff_attempt "$root" "$FILEVIEWER_CLASS" \
+    "$ISSUE788_FILEVIEWER_KEY" "$attempt"
+done
+run_signature "$root/ci-journey/summary.md" "$root/ci-journey"
+printf '%s\n' "$SIG_OUT" | sed 's/^/    /'
+[[ "$SIG_CLASS" == "foreign_framework_anr_focus" ]] \
+  || fail "(#788-focus) exact four-attempt handoff fixture must classify foreign_framework_anr_focus, got '$SIG_CLASS'"
+grep -q '^journey_failing_testcases=4$' <<<"$SIG_OUT" \
+  || fail "(#788-focus) all four handoff failures must be covered"
+mkdir -p "$root/ci-journey-attempt-1"
+cp -a "$root/ci-journey" "$root/ci-journey-attempt-1/ci-journey"
+shard_verdict_for "$root"
+[[ "$SHARD_TOKEN" == "INFRA" ]] \
+  || fail "(#788-focus) exact launcher-ANR handoff shard must be INFRA, got $SHARD_TOKEN"
+verdicts="$SANDBOX/verdicts-788-focus"; mkdir -p "$verdicts"
+write_shard_token "$verdicts" 0 CLEAN
+write_shard_token "$verdicts" 1 "$SHARD_TOKEN"
+write_shard_token "$verdicts" 2 CLEAN
+run_agg "$verdicts"
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || fail "(#788-focus) exact handoff run must aggregate RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"
+pass "(#788-focus) composer + FileViewer x2 in one boot -> INFRA -> RE-RUN"
+
+# Anti-mask controls specific to the new handoff wording.  Active-window text
+# alone is never enough: app ownership, a second owner, a PocketShell ANR owner,
+# or an ordinary product assertion must all stay RED.
+ISSUE788_FOCUS_FIXTURE="$root"
+issue788_focus_xml() {
+  printf '%s/ci-journey/class-attempts/app/%s/attempt-%s/android-test-outputs/app/build/outputs/androidTest-results/connected/debug/TEST-emulator-5554 - 15-_app-.xml\n' \
+    "$1" "$2" "$3"
+}
+issue788_focus_snapshot() {
+  printf '%s/ci-journey/class-attempts/app/%s/attempt-%s/activity-processes.txt\n' \
+    "$1" "$2" "$3"
+}
+rebind_issue788_focus_snapshot() {
+  local case_root="$1" key="$2" attempt="$3"
+  local snapshot manifest sha size token
+  snapshot="$(issue788_focus_snapshot "$case_root" "$key" "$attempt")"
+  manifest="$case_root/ci-journey/class-attempts/app/$key/attempt-$attempt/manifest.txt"
+  token="$(sed -n 's/^capture_token=//p' "$manifest" | tail -n 1)"
+  sed -i '/^POCKETSHELL_ATTEMPT_CAPTURE_TOKEN=/d' "$snapshot"
+  printf '\nPOCKETSHELL_ATTEMPT_CAPTURE_TOKEN=%s\n' "$token" >> "$snapshot"
+  sha="$(sha256sum "$snapshot" | awk '{ print $1 }')"
+  size="$(wc -c < "$snapshot")"
+  sed -i \
+    -e "s/^activity_processes_sha256=.*/activity_processes_sha256=$sha/" \
+    -e "s/^activity_processes_size_bytes=.*/activity_processes_size_bytes=$size/" \
+    "$manifest"
+}
+assert_issue788_focus_red() {
+  local label="$1" case_root="$2"
+  run_signature "$case_root/ci-journey/summary.md" "$case_root/ci-journey"
+  [[ "$SIG_CLASS" == "product_failure" || "$SIG_CLASS" == "unclassified" ]] \
+    || { printf '%s\n' "$SIG_OUT"; fail "(#788-focus-$label) unsafe evidence classified '$SIG_CLASS'"; }
+}
+
+case_root="$SANDBOX/issue788-focus-app-window"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+sed -i 's/active_window_pkg=android/active_window_pkg=com.pocketshell.app/g' \
+  "$(issue788_focus_xml "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+assert_issue788_focus_red app-window "$case_root"
+
+case_root="$SANDBOX/issue788-focus-mixed-window"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+sed -i 's/active_window_class=android.widget.FrameLayout/active_window_class=android.widget.FrameLayout active_window_pkg=com.pocketshell.app/' \
+  "$(issue788_focus_xml "$case_root" "$ISSUE788_FILEVIEWER_KEY" 1)"
+assert_issue788_focus_red mixed-window "$case_root"
+
+case_root="$SANDBOX/issue788-focus-app-anr"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+sed -i 's/com.google.android.apps.nexuslauncher/com.pocketshell.app.i788/g' \
+  "$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+rebind_issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1
+assert_issue788_focus_red app-anr "$case_root"
+
+case_root="$SANDBOX/issue788-focus-missing-snapshot"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+unlink "$(issue788_focus_snapshot "$case_root" "$ISSUE788_FILEVIEWER_KEY" 1)"
+assert_issue788_focus_red missing-snapshot "$case_root"
+
+case_root="$SANDBOX/issue788-focus-multiple-anr"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+snapshot="$(issue788_focus_snapshot "$case_root" "$ISSUE788_FILEVIEWER_KEY" 1)"
+cat >> "$snapshot" <<'EOF'
+  *APP* UID 10200 ProcessRecord{bbbbbbb 2200:com.example.second/u0a200}
+    mNotResponding=true [com.android.server.am.AppNotRespondingDialog@bbbbbbb]
+EOF
+rebind_issue788_focus_snapshot "$case_root" "$ISSUE788_FILEVIEWER_KEY" 1
+assert_issue788_focus_red multiple-anr "$case_root"
+
+# Exact reviewer repro: first establish a validly bound PocketShell-owned
+# attempt (3/4 environmental matches), then overwrite that regular file with
+# attempt 2's launcher dump.  Path/class/attempt metadata remains plausible,
+# but the copied bytes carry attempt 2's token/hash and must not turn 3/4 into
+# 4/4 or license INFRA.
+case_root="$SANDBOX/issue788-focus-regular-sibling-copy"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+sed -i 's/com.google.android.apps.nexuslauncher/com.pocketshell.app.i788/g' \
+  "$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+rebind_issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1
+run_signature "$case_root/ci-journey/summary.md" "$case_root/ci-journey"
+[[ "$SIG_CLASS" == "product_failure" ]] \
+  || fail "(#788-focus-regular-sibling-copy) app-owned baseline was not product_failure"
+grep -q '^journey_signature_matches=3$' <<<"$SIG_OUT" \
+  || fail "(#788-focus-regular-sibling-copy) app-owned baseline was not 3/4"
+cp "$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 2)" \
+  "$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+assert_issue788_focus_red regular-sibling-copy "$case_root"
+grep -q '^journey_signature_matches=3$' <<<"$SIG_OUT" \
+  || fail "(#788-focus-regular-sibling-copy) copied sibling snapshot laundered 3/4 evidence"
+
+case_root="$SANDBOX/issue788-focus-regular-other-class"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+cp "$(issue788_focus_snapshot "$case_root" "$ISSUE788_FILEVIEWER_KEY" 1)" \
+  "$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+assert_issue788_focus_red regular-other-class "$case_root"
+
+donor_root="$SANDBOX/issue788-focus-stale-root-donor"
+write_issue788_focus_handoff_attempt "$donor_root" "$OCCLUSION_CLASS" \
+  "$ISSUE788_OCCLUSION_KEY" 1
+case_root="$SANDBOX/issue788-focus-regular-stale-root"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+cp "$(issue788_focus_snapshot "$donor_root" "$ISSUE788_OCCLUSION_KEY" 1)" \
+  "$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+assert_issue788_focus_red regular-stale-root "$case_root"
+
+for mutation in missing-hash mismatched-hash mismatched-token stale-capture-time; do
+  case_root="$SANDBOX/issue788-focus-$mutation"; mkdir -p "$case_root"
+  cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+  manifest="$case_root/ci-journey/class-attempts/app/$ISSUE788_OCCLUSION_KEY/attempt-1/manifest.txt"
+  case "$mutation" in
+    missing-hash) sed -i '/^activity_processes_sha256=/d' "$manifest" ;;
+    mismatched-hash)
+      sed -i 's/^activity_processes_sha256=./activity_processes_sha256=0/' "$manifest"
+      ;;
+    mismatched-token)
+      sed -i 's/^capture_token=./capture_token=0/' "$manifest"
+      ;;
+    stale-capture-time)
+      sed -i 's/^activity_processes_captured_at_utc=.*/activity_processes_captured_at_utc=2026-08-02T12:00:00Z/' "$manifest"
+      ;;
+  esac
+  assert_issue788_focus_red "$mutation" "$case_root"
+done
+
+case_root="$SANDBOX/issue788-focus-attempt-root"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+snapshot="$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+unlink "$snapshot"
+ln -s "$(issue788_focus_snapshot "$case_root" "$ISSUE788_OCCLUSION_KEY" 2)" "$snapshot"
+assert_issue788_focus_red wrong-attempt-root "$case_root"
+
+for mutation in wrong-attempt inverted-time; do
+  case_root="$SANDBOX/issue788-focus-$mutation"; mkdir -p "$case_root"
+  cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+  manifest="$case_root/ci-journey/class-attempts/app/$ISSUE788_FILEVIEWER_KEY/attempt-1/manifest.txt"
+  case "$mutation" in
+    wrong-attempt) sed -i 's/^attempt=1$/attempt=2/' "$manifest" ;;
+    inverted-time)
+      sed -i \
+        -e 's/^started_at_utc=.*/started_at_utc=2026-08-02T13:59:59Z/' \
+        -e 's/^finished_at_utc=.*/finished_at_utc=2026-08-02T13:00:00Z/' \
+        "$manifest"
+      ;;
+  esac
+  assert_issue788_focus_red "$mutation" "$case_root"
+done
+
+case_root="$SANDBOX/issue788-focus-product"; mkdir -p "$case_root"
+cp -a "$ISSUE788_FOCUS_FIXTURE/ci-journey" "$case_root/ci-journey"
+sed -i 's/the sent-snippet modal must release input focus before the keyboard-up shell-composer phase:/composer launcher must be fully on-screen (keyboard up);/' \
+  "$(issue788_focus_xml "$case_root" "$ISSUE788_OCCLUSION_KEY" 1)"
+assert_issue788_focus_red ordinary-product "$case_root"
+pass "(#788-focus-a) app/mixed owners, app/multiple ANRs, copied/symlinked/cross-root or missing/mismatched/stale bindings, and ordinary product assertions stay RED"
 issue1919_snapshot() {
   printf '%s/ci-journey/class-attempts/app/%s/attempt-%s/activity-processes.txt\n' \
     "$1" "$2" "$3"


### PR DESCRIPTION
Repairs #788 exact-main classifier handling for foreign framework focus failures.

Attempt-local process evidence is now bound by capture token, SHA-256, byte size, and timestamp before it can downgrade a product failure to INFRA. Exact legacy evidence is limited to four byte-exact reviewed pins. Anti-laundering regressions cover regular copies, symlinks, stale/mismatched metadata, and app-owned or mixed failures.

Independent APPROVED review and full evidence are recorded on #788.