### PR TITLE
Fix taps on long wrapped terminal links

### DIFF
--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/AgentPaneLinkAffordanceOffMainProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/AgentPaneLinkAffordanceOffMainProofTest.kt
@@ -100,6 +100,113 @@ class AgentPaneLinkAffordanceOffMainProofTest {
     val compose = createAndroidComposeRule<ComponentActivity>()
 
     /**
+     * Issue #558 (reopened): the exact long DataTalksClub URL from maintainer
+     * dogfood is painted across two rows in an agent Terminal, but the tap
+     * callback can still hold an older/empty affordance snapshot. Exercise the
+     * real TerminalView gesture recognizer with ONE physical tap per fragment;
+     * tap retries would hide the snapshot-generation bug this test guards.
+     */
+    @Test
+    fun wrappedDogfoodUrlRoutesWholeTargetFromEitherFragmentWithOneGesture() { runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val state = TerminalSurfaceState()
+        val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 1)
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = stdout,
+            remoteStdin = null,
+        )
+        val tappedUrls = mutableListOf<String>()
+        val url =
+            "https://github.com/DataTalksClub/playbooks/blob/main/campaigns/" +
+                "ml-zoomcamp-2026/copy-bank/events/pre-course-live-qa.md"
+
+        // Preload the viewport before mounting the agent Terminal. This is the
+        // dogfood shape: switching into Terminal reveals already-rendered agent
+        // output; there need not be a later output tick to heal tap routing.
+        try {
+            state.appendRemoteOutput("Pre-course Q&A\r\n$url\r\n".toByteArray(Charsets.US_ASCII))
+
+            compose.setContent {
+                TerminalSurface(
+                    state = state,
+                    modifier = Modifier,
+                    urlsEnabled = true,
+                    onUrlTap = { tappedUrls.add(it) },
+                    affordanceScannersEnabled = false,
+                    agentPaneLinkAffordancesEnabled = true,
+                )
+            }
+            compose.waitForIdle()
+            val view = waitForTerminalView()
+            val client = view.mClient as PocketShellTerminalViewClient
+
+            val regions = AtomicReference<List<UrlRegion>>(emptyList())
+            withTimeout(8_000) {
+                while (regions.get().count { it.url == url } < 2) {
+                    delay(20)
+                    instrumentation.runOnMainSync {
+                        regions.set(findVisibleUrls(view))
+                    }
+                }
+            }
+            val wrapped = regions.get().filter { it.url == url }.sortedBy { it.row }
+            assertTrue("dogfood URL must wrap across visual rows: $wrapped", wrapped.size >= 2)
+
+            val published = AtomicReference<List<UrlRegion>>(emptyList())
+            var firstGestureDispatched = false
+            withTimeout(8_000) {
+                while (!firstGestureDispatched) {
+                    delay(20)
+                    instrumentation.runOnMainSync {
+                        published.set(client.publishedUrlsForTesting?.invoke().orEmpty())
+                        if (published.get().filter { it.url == url }.size >= 2) {
+                            // Deliberately dispatch in the SAME main-loop turn that
+                            // first observes the overlay publication. The old
+                            // captured-list callback needed another recomposition,
+                            // so this one physical tap was lost despite paint.
+                            dispatchPhysicalTap(view, wrapped.first())
+                            firstGestureDispatched = true
+                        }
+                    }
+                }
+            }
+            assertEquals(
+                "the gesture callback must expose the exact generation carrying the painted fragments",
+                wrapped,
+                published.get().filter { it.url == url }.sortedBy { it.row },
+            )
+
+            // GestureDetector may confirm a single-tap asynchronously. Wait for
+            // delivery, but never send another tap — retries are exactly what hid
+            // this regression in the older proofs.
+            withTimeout(1_500) {
+                while (tappedUrls.size < 1) delay(10)
+            }
+            assertEquals("first wrapped fragment must route on its first gesture", listOf(url), tappedUrls)
+            delay(400)
+            instrumentation.runOnMainSync { dispatchPhysicalTap(view, wrapped.last()) }
+            withTimeout(1_500) {
+                while (tappedUrls.size < 2) delay(10)
+            }
+
+            assertEquals(
+                "one user gesture on each painted fragment must route the exact full URL once",
+                listOf(url, url),
+                tappedUrls,
+            )
+
+            captureViewport(view, "issue558-dogfood-wrapped-url")
+            writeIssue558RoutedUrl(instrumentation, view, url, tappedUrls)
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    } }
+
+    /**
      * Issue #871 / G2 class coverage — CODEX agent pane: a project-relative PNG
      * path (`tmp/…png`) and a schemed URL the way Codex prints them. RED on base
      * (the agent pane wired no scanner), GREEN with the off-main overlay.
@@ -517,6 +624,22 @@ class AgentPaneLinkAffordanceOffMainProofTest {
         return r.fontLineSpacingAndAscent + (region.row - view.topRow + 0.5f) * r.fontLineSpacing
     }
 
+    /** Must be called on the instrumentation main thread. */
+    private fun dispatchPhysicalTap(view: TerminalView, region: UrlRegion) {
+        val x = centreX(region, view)
+        val y = centreY(region, view)
+        val downAt = SystemClock.uptimeMillis()
+        val down = MotionEvent.obtain(downAt, downAt, MotionEvent.ACTION_DOWN, x, y, 0)
+        val up = MotionEvent.obtain(downAt, downAt + 40, MotionEvent.ACTION_UP, x, y, 0)
+        try {
+            view.dispatchTouchEvent(down)
+            view.dispatchTouchEvent(up)
+        } finally {
+            down.recycle()
+            up.recycle()
+        }
+    }
+
     private fun visibleTerminalText(view: TerminalView): String {
         var text = ""
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
@@ -551,6 +674,43 @@ class AgentPaneLinkAffordanceOffMainProofTest {
         artifactFile(ctx, "$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 
+    private fun writeIssue558RoutedUrl(
+        instrumentation: android.app.Instrumentation,
+        view: TerminalView,
+        expectedUrl: String,
+        tappedUrls: List<String>,
+    ) {
+        val root = view.rootView
+        var bitmap: Bitmap? = null
+        instrumentation.runOnMainSync {
+            if (root.width > 0 && root.height > 0) {
+                bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888).also {
+                    root.draw(Canvas(it))
+                }
+            }
+        }
+        bitmap?.let { captured ->
+            val screenshot = artifactFile(instrumentation.targetContext, "issue558-pixel7-wrapped-url-root.png")
+            FileOutputStream(screenshot).use { out ->
+                check(captured.compress(Bitmap.CompressFormat.PNG, 100, out))
+            }
+            println("ISSUE558_PIXEL7_VIEWPORT ${screenshot.absolutePath}")
+            captured.recycle()
+        }
+        val routed = artifactFile(instrumentation.targetContext, "issue558-routed-url.txt")
+        routed.writeText(
+            buildString {
+                appendLine("scenario=#558 exact wrapped DataTalksClub URL, real TerminalView gestures")
+                appendLine("pixel_width=${root.width}")
+                appendLine("terminal_width=${view.width}")
+                appendLine("columns=${view.mEmulator?.mColumns}")
+                appendLine("expected=$expectedUrl")
+                tappedUrls.forEachIndexed { index, value -> appendLine("routed_${index + 1}=$value") }
+            },
+        )
+        println("ISSUE558_ROUTED_URL ${routed.absolutePath}")
+    }
+
     private fun writeTimings(
         instrumentation: android.app.Instrumentation,
         lines: List<String>,
@@ -562,7 +722,12 @@ class AgentPaneLinkAffordanceOffMainProofTest {
     }
 
     private fun artifactFile(context: android.content.Context, name: String): File {
-        val dir = File(testArtifactsRoot(context), "terminal-lab").apply { mkdirs() }
+        val argDir = InstrumentationRegistry.getArguments().getString("additionalTestOutputDir")
+        val dir = if (!argDir.isNullOrBlank()) {
+            File(argDir, "terminal-lab").apply { mkdirs() }
+        } else {
+            File(testArtifactsRoot(context), "terminal-lab").apply { mkdirs() }
+        }
         return File(dir, name)
     }
 

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/ShellPaneAffordanceOverlay.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/ShellPaneAffordanceOverlay.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.Layout
+import com.termux.terminal.TerminalSession
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -35,6 +36,7 @@ import kotlin.coroutines.CoroutineContext
  * @property engineCommands tappable engine-command regions (hit-test + underline).
  */
 internal data class ShellPaneAffordanceRegions(
+    val viewport: ViewportRowsSnapshot = ViewportRowsSnapshot.EMPTY,
     val urls: List<UrlRegion> = emptyList(),
     val filePaths: List<FilePathRegion> = emptyList(),
     val matches: List<TerminalMatchRegion> = emptyList(),
@@ -101,6 +103,7 @@ internal suspend fun collectShellPaneAffordances(
             // ~4× per frame on the UI thread.
             val result = withContext(scanContext) {
                 ShellPaneAffordanceRegions(
+                    viewport = snapshot,
                     urls = if (scanUrls) {
                         runCatching { urlRegionsForRows(snapshot.rows, snapshot.columns) }.getOrDefault(emptyList())
                     } else {
@@ -173,6 +176,14 @@ public fun ShellPaneAffordanceOverlay(
     onFilePathsChanged: (List<FilePathRegion>) -> Unit = {},
     onMatchesChanged: (List<TerminalMatchRegion>) -> Unit = {},
     onEngineCommandsChanged: (List<EngineCommandRegion>) -> Unit = {},
+    onAffordancesPublished: (
+        TerminalView?,
+        TerminalSession?,
+        ViewportRowsSnapshot,
+        List<UrlRegion>,
+        List<FilePathRegion>,
+        List<EngineCommandRegion>,
+    ) -> Unit = { _, _, _, _, _, _ -> },
     scanDispatcher: CoroutineDispatcher = Dispatchers.Default,
     modifier: Modifier = Modifier,
 ) {
@@ -184,6 +195,7 @@ public fun ShellPaneAffordanceOverlay(
     val latestOnPaths by rememberUpdatedState(onFilePathsChanged)
     val latestOnMatches by rememberUpdatedState(onMatchesChanged)
     val latestOnCommands by rememberUpdatedState(onEngineCommandsChanged)
+    val latestOnAffordancesPublished by rememberUpdatedState(onAffordancesPublished)
 
     LaunchedEffect(
         view,
@@ -204,6 +216,14 @@ public fun ShellPaneAffordanceOverlay(
             latestOnPaths(emptyList())
             latestOnMatches(emptyList())
             latestOnCommands(emptyList())
+            latestOnAffordancesPublished(
+                null,
+                null,
+                ViewportRowsSnapshot.EMPTY,
+                emptyList(),
+                emptyList(),
+                emptyList(),
+            )
             return@LaunchedEffect
         }
         // Issue #1260 (mirrored from [AgentPaneAffordanceOverlay]): pin the collect
@@ -212,9 +232,13 @@ public fun ShellPaneAffordanceOverlay(
         // otherwise the coalescer's `delay` window stalls for a whole `%output`
         // burst on a non-invalidating surface and the affordance never repopulates.
         val mainDispatcher = Dispatchers.Main.immediate
+        var sourceSession: TerminalSession? = null
         collectShellPaneAffordances(
             renderRequests = renderRequests,
-            extractSnapshot = { extractVisibleViewportRows(view) },
+            extractSnapshot = {
+                sourceSession = view.currentSession
+                extractVisibleViewportRows(view)
+            },
             matcher = matcher,
             knownCommands = knownCommands,
             scanUrls = scanUrls,
@@ -238,6 +262,17 @@ public fun ShellPaneAffordanceOverlay(
                 commands = result.engineCommands
                 latestOnCommands(result.engineCommands)
             }
+            // Commit marker after every region list has been staged. The parent
+            // can now expose this exact painted generation to gesture routing
+            // without waiting for another recomposition (#558 reopened).
+            latestOnAffordancesPublished(
+                view,
+                sourceSession,
+                result.viewport,
+                result.urls,
+                result.filePaths,
+                result.engineCommands,
+            )
         }
     }
 

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SmartSelectionAffordanceOverlay.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SmartSelectionAffordanceOverlay.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.unit.Constraints
+import com.termux.terminal.TerminalSession
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -66,6 +67,14 @@ public fun AgentPaneAffordanceOverlay(
     viewportChangeKey: Any? = Unit,
     onFilePathsChanged: (List<FilePathRegion>) -> Unit,
     onUrlsChanged: (List<UrlRegion>) -> Unit,
+    onAffordancesPublished: (
+        TerminalView?,
+        TerminalSession?,
+        ViewportRowsSnapshot,
+        List<UrlRegion>,
+        List<FilePathRegion>,
+        List<EngineCommandRegion>,
+    ) -> Unit = { _, _, _, _, _, _ -> },
     scanDispatcher: CoroutineDispatcher = Dispatchers.Default,
     modifier: Modifier = Modifier,
 ) {
@@ -73,6 +82,7 @@ public fun AgentPaneAffordanceOverlay(
     var urls by remember { mutableStateOf<List<UrlRegion>>(emptyList()) }
     val latestOnPathsChanged by rememberUpdatedState(onFilePathsChanged)
     val latestOnUrlsChanged by rememberUpdatedState(onUrlsChanged)
+    val latestOnAffordancesPublished by rememberUpdatedState(onAffordancesPublished)
 
     LaunchedEffect(view, renderRequests, viewportChangeKey, scanDispatcher) {
         if (view == null) {
@@ -80,6 +90,14 @@ public fun AgentPaneAffordanceOverlay(
             urls = emptyList()
             latestOnPathsChanged(emptyList())
             latestOnUrlsChanged(emptyList())
+            latestOnAffordancesPublished(
+                null,
+                null,
+                ViewportRowsSnapshot.EMPTY,
+                emptyList(),
+                emptyList(),
+                emptyList(),
+            )
             return@LaunchedEffect
         }
         // The Main dispatcher. The cheap viewport extraction and the Compose-state
@@ -109,7 +127,9 @@ public fun AgentPaneAffordanceOverlay(
             renderRequests.onStart { emit(Unit) }.conflate().collect {
                 // CHEAP, on Main: copy the live, non-thread-safe viewport into a
                 // plain-data snapshot.
-                val snapshot = withContext(mainDispatcher) { extractVisibleViewportRows(view) }
+                val (sourceSession, snapshot) = withContext(mainDispatcher) {
+                    view.currentSession to extractVisibleViewportRows(view)
+                }
                 // EXPENSIVE, OFF Main: regex + wrapped-line reassembly. This is the
                 // per-frame cost that caused the #803/#866 ANR; here it never touches
                 // the UI thread.
@@ -131,6 +151,17 @@ public fun AgentPaneAffordanceOverlay(
                         urls = freshUrls
                         latestOnUrlsChanged(freshUrls)
                     }
+                    // Commit marker: callbacks above stage every region list;
+                    // publishing the source viewport LAST makes paint + hit-test
+                    // one atomic main-thread generation (#558 reopened).
+                    latestOnAffordancesPublished(
+                        view,
+                        sourceSession,
+                        snapshot,
+                        freshUrls,
+                        freshPaths,
+                        emptyList(),
+                    )
                 }
             }
         }

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -35,6 +35,8 @@ import com.pocketshell.core.terminal.selection.safeLayoutDimension
 import com.pocketshell.core.terminal.selection.TerminalMatch
 import com.pocketshell.core.terminal.selection.TerminalMatchRegion
 import com.pocketshell.core.terminal.selection.UrlRegion
+import com.pocketshell.core.terminal.selection.ViewportRowsSnapshot
+import com.pocketshell.core.terminal.selection.extractVisibleViewportRows
 import com.pocketshell.core.terminal.selection.hitTestEngineCommand
 import com.pocketshell.core.terminal.selection.hitTestFilePath
 import com.pocketshell.core.terminal.selection.hitTestUrl
@@ -136,6 +138,72 @@ internal const val CLIPBOARD_LABEL_TERMINAL: String = "PocketShell terminal"
  * truncating to a sane prefix keeps the toast on-screen for a single line.
  */
 internal const val TOAST_PREVIEW_CHARS: Int = 60
+
+/**
+ * The exact affordance generation currently painted by a terminal overlay.
+ *
+ * This is deliberately a plain main-thread holder, not Compose state: overlay
+ * publication and TerminalView gesture dispatch both happen on Main, and the
+ * tap path must become live synchronously with publication rather than waiting
+ * for another recomposition. The Compose-state mirrors remain the inputs for
+ * overlays whose drawing lives outside their scanner.
+ */
+internal class PublishedTapAffordances {
+    private var publishedView: TerminalView? = null
+    private var publishedSession: TerminalSession? = null
+    private var publishedViewport: ViewportRowsSnapshot = ViewportRowsSnapshot.EMPTY
+    private var publishedUrls: List<UrlRegion> = emptyList()
+    private var publishedFilePaths: List<FilePathRegion> = emptyList()
+    private var publishedEngineCommands: List<EngineCommandRegion> = emptyList()
+
+    fun publish(
+        view: TerminalView,
+        session: TerminalSession,
+        viewport: ViewportRowsSnapshot,
+        urls: List<UrlRegion>,
+        filePaths: List<FilePathRegion>,
+        engineCommands: List<EngineCommandRegion>,
+    ) {
+        publishedView = view
+        publishedSession = session
+        publishedViewport = viewport
+        publishedUrls = urls
+        publishedFilePaths = filePaths
+        publishedEngineCommands = engineCommands
+    }
+
+    fun clear() {
+        publishedView = null
+        publishedSession = null
+        publishedViewport = ViewportRowsSnapshot.EMPTY
+        publishedUrls = emptyList()
+        publishedFilePaths = emptyList()
+        publishedEngineCommands = emptyList()
+    }
+
+    fun currentFor(
+        view: TerminalView,
+        currentViewport: ViewportRowsSnapshot? = null,
+    ): PublishedTapAffordanceRegions? {
+        if (publishedView !== view) return null
+        // TerminalView is deliberately reused across session attachment. View
+        // identity and even viewport bytes can therefore remain unchanged while
+        // the routing target changes. Bind every generation to the session that
+        // was present when its viewport was extracted (#558 reviewer G2).
+        if (publishedSession == null || view.currentSession !== publishedSession) return null
+        // A tap is infrequent; one cheap row-copy here is acceptable and keeps
+        // stale paint/hit regions from routing after scroll, resize, output, or
+        // session replacement. Regex/reassembly remains off Main and off-frame.
+        if ((currentViewport ?: extractVisibleViewportRows(view)) != publishedViewport) return null
+        return PublishedTapAffordanceRegions(publishedUrls, publishedFilePaths, publishedEngineCommands)
+    }
+}
+
+internal data class PublishedTapAffordanceRegions(
+    val urls: List<UrlRegion>,
+    val filePaths: List<FilePathRegion>,
+    val engineCommands: List<EngineCommandRegion>,
+)
 
 /**
  * Fire `Intent.ACTION_VIEW` for [url] from [context]. We add
@@ -273,6 +341,7 @@ fun TerminalSurface(
     viewClient.onTerminalSurfaceError = onLocalTerminalError
     var terminalView by remember { mutableStateOf<TerminalView?>(null) }
     var viewportTick by remember { mutableStateOf(0L) }
+    val publishedTapAffordances = remember { PublishedTapAffordances() }
 
     val context = LocalContext.current
 
@@ -355,6 +424,13 @@ fun TerminalSurface(
     }
 
     DisposableEffect(state, terminalView) {
+        // A new View or session surface must earn a fresh overlay publication;
+        // never let the previous pane's coordinates route during attachment.
+        publishedTapAffordances.clear()
+        onDispose { publishedTapAffordances.clear() }
+    }
+
+    DisposableEffect(state, terminalView) {
         val view = terminalView
         state.setSmartTextStagingBridge(
             if (view == null) {
@@ -404,6 +480,7 @@ fun TerminalSurface(
         withContext(Dispatchers.Main.immediate) {
             snapshotFlow { state.session }.collect { session ->
                 if (view.currentSession !== session) {
+                    publishedTapAffordances.clear()
                     runCatching {
                         view.attachSession(session)
                         if (session != null) {
@@ -540,10 +617,15 @@ fun TerminalSurface(
     // this composable (and not in TerminalSurfaceState) because URLs are a
     // view-coordinate concept, not a transcript-bytes concept — the same
     // session can render different URL sets at different sizes.
-    var visibleUrls by remember { mutableStateOf<List<UrlRegion>>(emptyList()) }
-    var visibleFilePaths by remember { mutableStateOf<List<FilePathRegion>>(emptyList()) }
-    var visibleEngineCommands by remember { mutableStateOf<List<EngineCommandRegion>>(emptyList()) }
     var visibleMatchRegions by remember { mutableStateOf<List<TerminalMatchRegion>>(emptyList()) }
+    // Issue #558 (reopened): the overlay owns the paintable affordance regions,
+    // while a parent recomposition used to copy those regions into the gesture
+    // callback. That extra apply turn created a real split generation: a wrapped
+    // URL could already be underlined across both rows while onTapMaybeUrl still
+    // captured the previous empty/truncated list. Keep one stable, main-thread
+    // publication object instead. Each overlay writes it in the SAME publish
+    // turn that changes its painted regions; the gesture callback reads it at
+    // tap time, so no recomposition is required to make a painted target live.
     // Issue #770: engine-command detection is active only when the host both
     // supplies a tap sink and a non-empty command set for the detected engine.
     // Issue #796: an agent pane runs NO per-frame viewport scanner, so the
@@ -570,7 +652,7 @@ fun TerminalSurface(
             agentPaneLinkAffordancesEnabled &&
             (onFilePathTap != null || effectiveUrlTap != null)
     // The file-path tap is live when EITHER the shell-pane single-snapshot overlay
-    // OR the agent-pane off-main overlay is feeding `visibleFilePaths`.
+    // OR the agent-pane off-main overlay publishes tap affordances.
     val filePathTapActive =
         onFilePathTap != null && (filePathScannerEnabled || agentLinkOverlayEnabled)
     // Issue #1233: the ONE consolidated shell / non-agent affordance overlay
@@ -585,13 +667,12 @@ fun TerminalSurface(
             (effectiveUrlTap != null || matchScannerEnabled || filePathScannerEnabled || engineCommandsEnabled)
 
     // Issue #1233: the URL / smart-selection / file-path / engine-command hit-test
-    // snapshots (`visibleUrls` / `visibleMatchRegions` / `visibleFilePaths` /
-    // `visibleEngineCommands`) are all fed by [ShellPaneAffordanceOverlay] (shell
-    // pane) or [AgentPaneAffordanceOverlay] (agent pane) below, each from a SINGLE
-    // per-frame viewport extraction — no standalone per-frame URL scan here.
+    // painted + hit-test snapshots are fed by [ShellPaneAffordanceOverlay]
+    // (shell pane) or [AgentPaneAffordanceOverlay] (agent pane) below, each from
+    // a SINGLE per-frame viewport extraction — no standalone URL scan here.
 
-    // Install the tap-hook on the view client every time `visibleUrls`,
-    // `terminalView`, or `effectiveUrlTap` changes. The hook receives a tap
+    // Install one stable tap-hook for the current view/callback configuration.
+    // The hook receives a tap
     // in view-local pixels and returns true if the tap landed on a URL —
     // PocketShellTerminalViewClient.onSingleTapUp then lets the host handle
     // that gesture and suppresses the plain terminal tap fall-through.
@@ -599,9 +680,6 @@ fun TerminalSurface(
     DisposableEffect(
         viewClient,
         terminalView,
-        visibleUrls,
-        visibleFilePaths,
-        visibleEngineCommands,
         effectiveUrlTap,
         onFilePathTap,
         filePathTapActive,
@@ -609,20 +687,26 @@ fun TerminalSurface(
     ) {
         val view = terminalView
         val tap = effectiveUrlTap
-        // The file-path tap is live when EITHER the shell-pane on-main overlay
-        // (#500) OR the agent-pane off-main overlay (#871) is feeding
-        // `visibleFilePaths`. When neither is, the tap stays inert (its snapshot
-        // is empty and the affordance lives in Conversation, #809/#818).
+        // The file-path tap is live when EITHER the shell-pane overlay (#500) OR
+        // the agent-pane off-main overlay (#871) publishes tap affordances. When
+        // neither is active, the tap stays inert (the affordance lives in
+        // Conversation, #809/#818).
         val pathTapMaybe = if (filePathTapActive) onFilePathTap else null
         if (view == null || (tap == null && pathTapMaybe == null && engineCommandTap == null)) {
             viewClient.onTapMaybeUrl = null
+            viewClient.publishedUrlsForTesting = null
         } else {
-            val urlsSnapshot = visibleUrls
-            val pathsSnapshot = visibleFilePaths
-            val commandsSnapshot = visibleEngineCommands
             val pathTap = pathTapMaybe
             val cmdTap = engineCommandTap
-            viewClient.onTapMaybeUrl = { x, y ->
+            viewClient.onTapMaybeUrl = tapHandler@{ x, y ->
+                // Read the overlay's current published generation at gesture
+                // time. Capturing the Compose-state lists here required a later
+                // parent recomposition and was the #558 painted-but-dead link.
+                val snapshot = publishedTapAffordances.currentFor(view)
+                    ?: return@tapHandler false
+                val urlsSnapshot = snapshot.urls
+                val pathsSnapshot = snapshot.filePaths
+                val commandsSnapshot = snapshot.engineCommands
                 // URLs first: a URL's `/path` tail is already excluded from
                 // file-path detection, but keeping URL precedence here is
                 // belt-and-braces and matches the established browser route.
@@ -652,8 +736,17 @@ fun TerminalSurface(
                     }
                 }
             }
+            // A read-only test oracle for the generation the gesture callback
+            // will consult. Unlike re-running findVisibleUrls(view), this proves
+            // the callback and the painted overlay share the publication.
+            viewClient.publishedUrlsForTesting = {
+                publishedTapAffordances.currentFor(view)?.urls.orEmpty()
+            }
         }
-        onDispose { viewClient.onTapMaybeUrl = null }
+        onDispose {
+            viewClient.onTapMaybeUrl = null
+            viewClient.publishedUrlsForTesting = null
+        }
     }
 
     // Layer the vendored TerminalView under the optional SelectionOverlay
@@ -722,16 +815,27 @@ fun TerminalSurface(
                     knownCommands = if (engineCommandsEnabled) engineCommands else emptySet(),
                     scanUrls = effectiveUrlTap != null,
                     scanFilePaths = filePathScannerEnabled,
-                    onUrlsChanged = { visibleUrls = it },
-                    onFilePathsChanged = { visibleFilePaths = it },
                     onMatchesChanged = { visibleMatchRegions = it },
-                    onEngineCommandsChanged = { visibleEngineCommands = it },
+                    onAffordancesPublished = { sourceView, sourceSession, viewport, urls, paths, commands ->
+                        if (sourceView != null && sourceSession != null) {
+                            publishedTapAffordances.publish(
+                                sourceView,
+                                sourceSession,
+                                viewport,
+                                urls,
+                                paths,
+                                commands,
+                            )
+                        } else {
+                            publishedTapAffordances.clear()
+                        }
+                    },
                 )
             }
             // Issue #871: an agent pane (Codex/Claude) gets tappable file paths +
             // URLs via the OFF-main, debounced overlay — never the per-frame
-            // on-main scan. It feeds BOTH `visibleFilePaths` and `visibleUrls` for
-            // the tap hit-test and paints the affordance hairlines. The match +
+            // on-main scan. It publishes BOTH path and URL regions for the tap
+            // hit-test and paints the affordance hairlines. The match +
             // engine-command scanners stay off for an agent pane (Conversation,
             // #818, is the richer surface).
             if (agentLinkOverlayEnabled) {
@@ -739,8 +843,22 @@ fun TerminalSurface(
                     view = terminalView,
                     renderRequests = coalescedRenderRequests,
                     viewportChangeKey = viewportTick,
-                    onFilePathsChanged = { visibleFilePaths = it },
-                    onUrlsChanged = { visibleUrls = it },
+                    onFilePathsChanged = {},
+                    onUrlsChanged = {},
+                    onAffordancesPublished = { sourceView, sourceSession, viewport, urls, paths, commands ->
+                        if (sourceView != null && sourceSession != null) {
+                            publishedTapAffordances.publish(
+                                sourceView,
+                                sourceSession,
+                                viewport,
+                                urls,
+                                paths,
+                                commands,
+                            )
+                        } else {
+                            publishedTapAffordances.clear()
+                        }
+                    },
                 )
             }
         },
@@ -879,6 +997,9 @@ internal class PocketShellTerminalViewClient : TerminalViewClient, TerminalSessi
      * matching overlay code rather than being hard-coded in this client.
      */
     var onTapMaybeUrl: ((tapX: Float, tapY: Float) -> Boolean)? = null
+
+    @androidx.annotation.VisibleForTesting
+    internal var publishedUrlsForTesting: (() -> List<UrlRegion>)? = null
 
     fun bind(view: TerminalView) {
         terminalView = view

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/PublishedTapAffordancesTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/PublishedTapAffordancesTest.kt
@@ -1,0 +1,167 @@
+package com.pocketshell.core.terminal.ui
+
+import android.content.Context
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.terminal.selection.UrlRegion
+import com.pocketshell.core.terminal.selection.ViewportRowsSnapshot
+import com.pocketshell.core.terminal.selection.VisualRow
+import com.termux.view.TerminalView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Issue #558: stale painted regions must never route in another viewport. */
+@RunWith(RobolectricTestRunner::class)
+class PublishedTapAffordancesTest {
+
+    @Test
+    fun sameViewSessionRebindRequiresFreshPublicationEvenForIdenticalViewport() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val first = TerminalSurfaceState()
+        val firstScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val firstJob = first.attachExternalProducer(
+            firstScope,
+            MutableSharedFlow<ByteArray>(extraBufferCapacity = 1),
+            null,
+        )
+        val second = TerminalSurfaceState()
+        val secondScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val secondJob = second.attachExternalProducer(
+            secondScope,
+            MutableSharedFlow<ByteArray>(extraBufferCapacity = 1),
+            null,
+        )
+        try {
+            val view = laidOutView(context, first)
+            val viewport = ViewportRowsSnapshot(
+                rows = listOf(VisualRow(row = 0, text = "https://example.com/same", wrapsToNext = false)),
+                columns = 24,
+            )
+            val urls = listOf(UrlRegion("https://example.com/same", 0, 0, 24))
+            val holder = PublishedTapAffordances().apply {
+                publish(view, requireNotNull(first.session), viewport, urls, emptyList(), emptyList())
+            }
+
+            assertNotNull(holder.currentFor(view, viewport))
+
+            view.attachSession(null)
+            assertNull(
+                "session A publication must not survive the same view detaching",
+                holder.currentFor(view, viewport),
+            )
+
+            view.attachSession(requireNotNull(second.session))
+            assertNull(
+                "session A publication must not route in byte-identical session B viewport",
+                holder.currentFor(view, viewport),
+            )
+
+            holder.publish(view, requireNotNull(second.session), viewport, urls, emptyList(), emptyList())
+            assertNotNull(
+                "session B becomes tappable only after earning its own publication",
+                holder.currentFor(view, viewport),
+            )
+        } finally {
+            firstJob.cancel()
+            secondJob.cancel()
+            firstScope.cancel()
+            secondScope.cancel()
+            first.detachExternalProducer()
+            second.detachExternalProducer()
+        }
+    }
+
+    @Test
+    fun publicationIsBoundToExactViewAndViewportGeneration() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val first = TerminalSurfaceState()
+        val firstScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val firstJob = first.attachExternalProducer(
+            firstScope,
+            MutableSharedFlow<ByteArray>(extraBufferCapacity = 1),
+            null,
+        )
+        val second = TerminalSurfaceState()
+        val secondScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val secondJob = second.attachExternalProducer(
+            secondScope,
+            MutableSharedFlow<ByteArray>(extraBufferCapacity = 1),
+            null,
+        )
+        try {
+            val firstView = laidOutView(context, first)
+            val viewport = ViewportRowsSnapshot(
+                rows = listOf(
+                    VisualRow(row = 0, text = "https://example.com/", wrapsToNext = true),
+                    VisualRow(row = 1, text = "one", wrapsToNext = false),
+                ),
+                columns = 24,
+            )
+            val holder = PublishedTapAffordances().apply {
+                publish(
+                    view = firstView,
+                    session = requireNotNull(first.session),
+                    viewport = viewport,
+                    urls = listOf(UrlRegion("https://example.com/one", 0, 0, 23)),
+                    filePaths = emptyList(),
+                    engineCommands = emptyList(),
+                )
+            }
+
+            assertNotNull(
+                "the exact published view+viewport must be tappable",
+                holder.currentFor(firstView, viewport),
+            )
+
+            val secondView = laidOutView(context, second)
+            assertNull(
+                "a replacement TerminalView must not inherit old coordinates",
+                holder.currentFor(secondView, viewport),
+            )
+
+            val scrolledViewport = viewport.copy(
+                rows = viewport.rows.map { it.copy(row = it.row - 1) },
+            )
+            assertNull(
+                "a scroll generation must invalidate old painted coordinates",
+                holder.currentFor(firstView, scrolledViewport),
+            )
+            val changedViewport = viewport.copy(
+                rows = viewport.rows.mapIndexed { index, row ->
+                    if (index == viewport.rows.lastIndex) row.copy(text = row.text + "changed") else row
+                },
+            )
+            assertNull(
+                "new terminal output must invalidate the old viewport generation",
+                holder.currentFor(firstView, changedViewport),
+            )
+        } finally {
+            firstJob.cancel()
+            secondJob.cancel()
+            firstScope.cancel()
+            secondScope.cancel()
+            first.detachExternalProducer()
+            second.detachExternalProducer()
+        }
+    }
+
+    private fun laidOutView(context: Context, state: TerminalSurfaceState): TerminalView =
+        TerminalView(context, null).also { view ->
+            view.applyPocketShellDefaults(PocketShellTerminalViewClient())
+            view.attachSession(requireNotNull(state.session))
+            view.measure(
+                View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY),
+            )
+            view.layout(0, 0, view.measuredWidth, view.measuredHeight)
+        }
+}


### PR DESCRIPTION
Closes #558

Keeps terminal affordance painting and tap routing on one atomic view/session/viewport generation, so a visibly wrapped URL opens in full from either fragment on the first gesture.

Also rejects stale regions across scroll, output, view replacement, and same-view session rebinds. Session B must publish its own regions before they become tappable.

Evidence:
- independent reviewer APPROVED
- connected emulator exact + adjacency: 7/7
- core-terminal JVM: 498/498
- current-main integration: focused publication tests 2/2, app and AndroidTest compilation green
- test validity, journey harness, file-size, and diff guards green