### PR TITLE
fix(composer): preserve queued prompts across reconnects (#1944)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
@@ -7,7 +7,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -33,6 +37,40 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class PromptComposerOutboundQueueTest {
+
+    @Test
+    fun stableQueueRowSelectorDisambiguatesPayloadAlsoPresentInDraft() {
+        val payload = "same payload in draft and queue"
+        val item = OutboundItem(
+            id = "stable-row-id",
+            sessionKey = "1/a",
+            cleanText = payload,
+            state = OutboundState.Failed,
+            createdAtMs = 1L,
+        )
+        val rowTag = composerOutboundQueueItemRowTestTag(item.id)
+        compose.setContent {
+            PocketShellTheme {
+                SheetContent(
+                    state = PromptComposerViewModel.UiState(draft = payload),
+                    onClose = {}, onDraftChange = {}, onMicTap = {}, onSend = {},
+                    outboundQueueItems = listOf(item),
+                    outboundQueueExpanded = true,
+                )
+            }
+        }
+
+        assertEquals(
+            "global payload lookup must demonstrate the ambiguous selector regression",
+            2,
+            compose.onAllNodesWithText(payload, substring = true, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        compose.onNode(
+            hasText(payload, substring = true) and hasAnyAncestor(hasTestTag(rowTag)),
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+    }
 
     @Test
     fun statusLedSingleRowsOwnCopyProgressAndResendPresentation() {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAcceptanceArtifacts.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAcceptanceArtifacts.kt
@@ -1,0 +1,52 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import java.io.FileOutputStream
+
+/** Stable same-run file/PNG/timing contract for outbound connected acceptance. */
+internal class OutboundAcceptanceArtifacts(
+    private val deviceDirName: String,
+    private val testMethodName: () -> String,
+) {
+    private val timings = mutableListOf<String>()
+
+    fun file(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$deviceDirName")
+        check(dir.exists() || dir.mkdirs()) { "could not create artifact directory ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    fun writeText(name: String, text: String): File = file(name).also {
+        it.writeText(text)
+        println("ISSUE1526_TEXT ${it.absolutePath}")
+    }
+
+    fun writeViewport(name: String, bitmap: Bitmap, event: String = "ISSUE1944_VIEWPORT"): File {
+        check(bitmap.width == 1080 && bitmap.height == 2400) {
+            "$name must be the reviewer-required 1080x2400 viewport; got ${bitmap.width}x${bitmap.height}"
+        }
+        return file("$name.png").also { output ->
+            FileOutputStream(output).use { stream ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)) {
+                    "failed to encode ${output.absolutePath}"
+                }
+            }
+            println("$event ${output.absolutePath}")
+        }
+    }
+
+    fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE1526_TIMING $line")
+    }
+
+    fun writeTimings(): File = file("timings-${testMethodName()}.txt").also {
+        it.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
+        println("ISSUE1526_TIMINGS ${it.absolutePath}")
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
@@ -11,20 +11,41 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextClearance
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.Lifecycle
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
+import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.composer.COMPOSER_DRAFT_TAG
+import com.pocketshell.app.composer.COMPOSER_OUTBOUND_QUEUE_TOGGLE_TAG
 import com.pocketshell.app.composer.COMPOSER_SEND_ENTER_TAG
+import com.pocketshell.app.composer.OutboundItem
+import com.pocketshell.app.composer.composerOutboundQueueItemRowTestTag
 import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.composer.OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE
+import com.pocketshell.app.composer.OUTBOUND_MAX_AUTO_ATTEMPTS
+import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.DiagnosticPrivacy
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.AGENT_SUBMIT_ACK_TIMEOUT_MS
@@ -33,19 +54,28 @@ import com.pocketshell.app.tmux.OutboundDeliverySeams
 import com.pocketshell.app.tmux.PasteChunkSeams
 import com.pocketshell.app.tmux.TMUX_CONSOLIDATED_TAB_PILL_TAG_PREFIX
 import com.pocketshell.app.tmux.TMUX_CONVERSATION_PANE_TAG
+import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_FULL_CHROME_BACK_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_FULL_CHROME_MORE_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_MORE_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_LIFECYCLE_DIALOG_CONFIRM_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_TAG
 import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.durableTmuxSessionKey
 import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
+import com.pocketshell.app.voice.SESSION_COMPOSER_UNSENT_BADGE_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
 import java.io.File
-import java.io.FileOutputStream
+import java.util.Base64
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -144,7 +174,8 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
 
     /** Issue #1819: the last sidecar SSH read error, so a blank frame can name its cause. */
     private var lastSidecarFailure: String? = null
-    private val timings = mutableListOf<String>()
+    private val artifacts = OutboundAcceptanceArtifacts(DEVICE_DIR_NAME) { testName.methodName }
+    private val queueViewport = OutboundQueueViewportCapture(compose, artifacts, ::visibleTerminalText)
 
     private suspend fun seedBeforeLaunch() {
         clearLastSessionPrefs()
@@ -311,6 +342,405 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             verifies.any { it.fields["outcome"] == "AlreadyLanded" },
         )
         writeTimings()
+    } }
+
+    @Test
+    fun fallbackQueueRowsSurviveSessionSwitchAndDrainOnlyIntoSameGeneration() { runBlocking<Unit> {
+        enableIssue1944FramedFakeAgent()
+        attachSeededTmuxSession(hostRowTag)
+        waitForVisibleTerminal("initial attach") { it.contains(FAKE_AGENT_READY) }
+        waitForConnected("initial attach")
+
+        val tmuxVm = currentViewModel()
+        // Cold Live/frame delivery may precede immutable tree identity binding.
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            tmuxVm.currentTargetSessionKeyForTest()?.startsWith("tmux:") == true
+        }
+        val originalDurableA = requireNotNull(tmuxVm.currentTargetSessionKeyForTest())
+        assertTrue("A must open with its durable tree identity", originalDurableA.startsWith("tmux:"))
+        val hostId = originalDurableA.removePrefix("tmux:").substringBefore(':').toLong()
+        val renamedA = "$SESSION_NAME-renamed"
+        renameCurrentSessionThroughUi(renamedA)
+        waitForConnected("rename navigation")
+        val kindResult = execRemoteSetupUntilReady(
+            key = SshKey.Pem(fixtureKey),
+            command = "tmux set-option -t ${shellQuote(renamedA)} @ps_agent_kind claude",
+            description = "issue1944 bind renamed fake-agent kind",
+        )
+        assertEquals("fake-agent kind tag must update", 0, kindResult.exitCode)
+        val durableA = requireNotNull(currentViewModel().currentTargetSessionKeyForTest())
+        assertEquals(
+            "rename navigation must carry the same immutable tmux generation",
+            originalDurableA,
+            durableA,
+        )
+        val bIdentity = execRemoteSetupUntilReady(
+            key = SshKey.Pem(fixtureKey),
+            command = "tmux display-message -p -t ${shellQuote("=$SESSION_B:")} " +
+                shellQuote("#{session_id}|#{session_created}"),
+            description = "issue1944 session-B immutable identity",
+        )
+        val bFields = bIdentity.stdout.trim().split('|')
+        assertEquals("session-B identity must contain id+created", 2, bFields.size)
+        val durableB = requireNotNull(
+            durableTmuxSessionKey(hostId, bFields[0], bFields[1].toLongOrNull()),
+        )
+        switchSessionFromMoreMenu(SESSION_B, durableB)
+        switchSessionFromMoreMenu(renamedA, durableA)
+        waitForVisibleTerminal("renamed A after recorded-kind refresh") { it.contains(FAKE_AGENT_READY) }
+        val vm = currentViewModel()
+        waitForDetectionBound(vm)
+        openConversationTab(vm)
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            vm.currentRecordedAgentRouteEvidence.value?.durableSessionKey == durableA
+        }
+        val routeEvidenceBeforeOutage = requireNotNull(vm.currentRecordedAgentRouteEvidence.value)
+        assertEquals(durableA, routeEvidenceBeforeOutage.durableSessionKey)
+        val clientBeforeOutage = vm.currentClientIdentityForTest()
+        val generationBeforeOutage = vm.currentConnectGenerationForTest()
+        val fallbackA = "$hostId/$renamedA"
+        val store = SharedPrefsOutboundQueueStore(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        )
+        store.clearSession(fallbackA)
+        store.clearSession(durableA)
+
+        val nonce = SystemClock.elapsedRealtime().toString().takeLast(6)
+        val firstPayload = "issue1944-first-$nonce"
+        val secondPayload = "issue1944-second-$nonce"
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true)
+            .performClick()
+        waitForComposerReady(expectQueue = false)
+        vm.forceUnrecoverableHostForTest = true
+        assertTrue("the clean outage must cut the live client", vm.triggerCleanPassiveDropForTest())
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            currentConnectionStatus() !is TmuxSessionViewModel.ConnectionStatus.Connected &&
+                !currentViewModel().isSendTransportWritable()
+        }
+        assertEquals(
+            "same-generation/pane recorded agent evidence must survive the outage",
+            routeEvidenceBeforeOutage,
+            vm.currentRecordedAgentRouteEvidence.value,
+        )
+        val fallbackEnqueueStartedAt = SystemClock.elapsedRealtime()
+        openComposerAndSend(firstPayload)
+        waitForIssue1739Boundary(
+            timeoutMs = UI_TIMEOUT_MS,
+            label = "first real composer send settled as queued while unavailable",
+            timeoutDetails = {
+                "rows=${store.itemsFor(fallbackA).map { Triple(it.id, it.cleanText, it.state) }} " +
+                    "sendInFlight=${currentPromptComposerViewModel().uiState.value.sendInFlight} " +
+                    "queueEvents=${diagnostics!!.events.filter { event ->
+                        event.name == "row_state" || event.name == "composer_send" ||
+                            event.name == "composer_send_deferred_to_queue" ||
+                            event.name == "drain_attempt"
+                    }.map { it.name to it.fields }} " +
+                    "events=${boundedEventTail(diagnostics!!.events)}"
+            },
+        ) {
+            val rows = store.itemsFor(fallbackA)
+            rows.size == 1 && rows.single().cleanText == firstPayload &&
+                rows.single().state == OutboundState.Queued &&
+                !currentPromptComposerViewModel().uiState.value.sendInFlight
+        }
+        openComposerAndSend(secondPayload)
+        waitForIssue1739Boundary(
+            timeoutMs = UI_TIMEOUT_MS,
+            label = "two real composer sends committed",
+            timeoutDetails = {
+                    "durable=${store.itemsFor(durableA).map { Triple(it.id, it.cleanText, it.state) }} " +
+                    "fallback=${store.itemsFor(fallbackA).map { Triple(it.id, it.cleanText, it.state) }} " +
+                    "draft=${draftText()} queueEvents=${diagnostics!!.events.filter { event ->
+                        event.name == "row_state" || event.name == "composer_send" ||
+                            event.name == "composer_send_deferred_to_queue"
+                    }.map { it.name to it.fields }} " +
+                    "events=${boundedEventTail(diagnostics!!.events)}"
+            },
+        ) {
+            val durableRows = store.itemsFor(durableA)
+            val fallbackRows = store.itemsFor(fallbackA)
+            durableRows.size + fallbackRows.size >= 2 &&
+                (durableRows + fallbackRows).all { it.state == OutboundState.Queued } &&
+                !currentPromptComposerViewModel().uiState.value.sendInFlight
+        }
+        val queued = store.itemsFor(fallbackA)
+        assertEquals(listOf(firstPayload, secondPayload), queued.map { it.cleanText })
+        assertTrue("outage rows stay Queued rather than being parked Failed", queued.all { it.state == OutboundState.Queued })
+        assertTrue("durable identity must stay empty before live generation settles", store.itemsFor(durableA).isEmpty())
+        assertTrue("fallback rows preserve exact tmux generation evidence", queued.all {
+            it.tmuxSessionId == routeEvidenceBeforeOutage.durableSessionKey
+                .removePrefix("tmux:$hostId:").substringBeforeLast(':') &&
+                it.tmuxSessionCreated != null &&
+                it.paneId == routeEvidenceBeforeOutage.paneId
+        })
+        recordTiming("fallback_two_rows_committed_ms", SystemClock.elapsedRealtime() - fallbackEnqueueStartedAt)
+        compose.onNode(
+            hasContentDescription("2 unsent") and
+                androidx.compose.ui.test.hasTestTag(SESSION_COMPOSER_UNSENT_BADGE_TAG),
+            useUnmergedTree = true,
+        ).assertExists()
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true).performClick()
+        waitForComposerReady(expectQueue = true)
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_TOGGLE_TAG, useUnmergedTree = true)
+            .performClick()
+        queueViewport.capture("issue1944-queued-before-switch", queued)
+        assertTrue(
+            "outage must remain controller-non-Connected through both sends",
+            currentConnectionStatus() !is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertFalse(
+            "outage wire oracle must remain false through both sends",
+            currentViewModel().isSendTransportWritable(),
+        )
+        val queuedIds = queued.map { it.id }
+        val serverWhileDown = runBlocking { sidecarCapturePane(renamedA) }
+        assertFalse(serverWhileDown.contains(firstPayload))
+        assertFalse(serverWhileDown.contains(secondPayload))
+
+        pressSystemBack()
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) { !hasNode(COMPOSER_DRAFT_TAG) }
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        SystemClock.sleep(250)
+        assertEquals(queuedIds, store.itemsFor(fallbackA).map { it.id })
+        assertTrue(
+            "CREATED interval must remain controller-non-Connected",
+            currentConnectionStatus() !is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertFalse(
+            "CREATED interval must remain wire-unavailable",
+            currentViewModel().isSendTransportWritable(),
+        )
+        val createdCapture = runBlocking { sidecarCapturePane(renamedA) }
+        assertFalse("foreground-only: no first delivery while CREATED", createdCapture.contains(firstPayload))
+        assertFalse("foreground-only: no second delivery while CREATED", createdCapture.contains(secondPayload))
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true).performClick()
+        waitForComposerReady(expectQueue = true)
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_TOGGLE_TAG, useUnmergedTree = true).performClick()
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        SystemClock.sleep(250)
+        assertEquals(queuedIds, store.itemsFor(fallbackA).map { it.id })
+        assertTrue("open-sheet CREATED must not submit", readFakeAgentSubmitLedger().isEmpty())
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        pressSystemBack()
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) { !hasNode(COMPOSER_DRAFT_TAG) }
+
+        clickTmuxBack()
+        vm.forceUnrecoverableHostForTest = false
+        val bOpenStartedAt = SystemClock.elapsedRealtime()
+        openSessionFromFolder(SESSION_B)
+        waitForVisibleTerminal("open B") { it.contains(SESSION_B_MARKER) }
+        assertTrue("session B must never own A rows", store.itemsFor("$hostId/$SESSION_B").isEmpty())
+        assertTrue(
+            "session B durable key must never own A rows",
+            store.itemsFor(requireNotNull(currentViewModel().currentTargetSessionKeyForTest())).isEmpty(),
+        )
+        compose.onNodeWithTag(SESSION_COMPOSER_UNSENT_BADGE_TAG, useUnmergedTree = true)
+            .assertDoesNotExist()
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) { hasNode(COMPOSER_DRAFT_TAG) }
+        assertTrue(
+            "B composer must not render A's first row",
+            compose.onAllNodesWithText(firstPayload, substring = true, useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty(),
+        )
+        assertTrue(
+            "B composer must not render A's second row",
+            compose.onAllNodesWithText(secondPayload, substring = true, useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty(),
+        )
+        captureViewportArtifacts("issue1944-b-isolated")
+        recordTiming("b_isolated_ui_ms", SystemClock.elapsedRealtime() - bOpenStartedAt)
+        pressSystemBack()
+
+        val bVm = currentViewModel()
+        val clientAtB = bVm.currentClientIdentityForTest()
+        val generationAtB = bVm.currentConnectGenerationForTest()
+        assertTrue("B must be reached through a fresh client", clientAtB != null && clientAtB != clientBeforeOutage)
+        assertTrue("the reconnect generation must advance", generationAtB > generationBeforeOutage)
+        bVm.forceUnrecoverableHostForTest = true
+        assertTrue("B transport cut must hold A offline for UI proof", bVm.triggerCleanPassiveDropForTest())
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) { !currentViewModel().isSendTransportWritable() }
+        val aReturnStartedAt = SystemClock.elapsedRealtime()
+        clickTmuxBack()
+        openSessionFromFolder(renamedA, waitForConnection = false)
+        val offlineAIntent = requireNotNull(currentViewModel().latestRestoreIntentSnapshot())
+        assertEquals("cached row must target renamed A while offline", renamedA, offlineAIntent.sessionName)
+        assertEquals(durableA.removePrefix("tmux:$hostId:").substringBeforeLast(':'), offlineAIntent.tmuxSessionId)
+        assertEquals(durableA.substringAfterLast(':').toLong(), offlineAIntent.sessionCreated)
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            store.itemsFor(fallbackA).map { it.id } == queuedIds
+        }
+        assertTrue("durable owner must stay empty before A wire truth settles", store.itemsFor(durableA).isEmpty())
+        compose.onNode(
+            hasContentDescription("2 unsent") and
+                androidx.compose.ui.test.hasTestTag(SESSION_COMPOSER_UNSENT_BADGE_TAG),
+            useUnmergedTree = true,
+        ).assertExists()
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true).performClick()
+        waitForComposerReady(expectQueue = true)
+        compose.onNodeWithTag(COMPOSER_OUTBOUND_QUEUE_TOGGLE_TAG, useUnmergedTree = true).performClick()
+        queueViewport.capture("issue1944-a-returned-queued", store.itemsFor(fallbackA))
+        val returnedOfflineRows = store.itemsFor(fallbackA)
+        assertEquals(
+            "offline retry may advance only attempt time; payload, identity, route, and wire fields must survive",
+            queued,
+            returnedOfflineRows.mapIndexed { index, row ->
+                row.copy(lastAttemptAtMs = queued[index].lastAttemptAtMs)
+            },
+        )
+        assertEquals(listOf(0, 0), returnedOfflineRows.map { it.attemptCount })
+        recordTiming("a_rows_visible_before_heal_ms", SystemClock.elapsedRealtime() - aReturnStartedAt)
+        pressSystemBack()
+
+        val healStartedAt = SystemClock.elapsedRealtime()
+        val activeAVm = currentViewModel()
+        assertTrue("the Activity must still route connectivity to its active host VM", activeAVm === bVm)
+        activeAVm.forceUnrecoverableHostForTest = false
+        SystemClock.sleep(250)
+        assertEquals("clearing the fixture alone must not deliver", queuedIds, store.itemsFor(fallbackA).map { it.id })
+        assertTrue("clearing the fixture alone must not reach the server", readFakeAgentSubmitLedger().isEmpty())
+        activeAVm.onNetworkChanged(
+            TerminalNetworkChange(
+                previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+                current = TerminalNetworkSnapshot.Validated("issue-1944-restored"),
+                previousValidated = null,
+                reason = "issue-1944-foreground-network-restored",
+                sequence = 1_944L,
+                kind = TerminalNetworkChangeKind.NetworkRestored,
+            ),
+        )
+        waitForConnected("heal returned A")
+        waitForVisibleTerminal("return to A") { it.contains(FAKE_AGENT_READY) }
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            store.itemsFor(fallbackA).isEmpty() &&
+                (store.itemsFor(durableA).map { it.id } == queuedIds || store.itemsFor(durableA).isEmpty())
+        }
+        assertTrue("promoted rows must leave no orphan fallback owner", store.itemsFor(fallbackA).isEmpty())
+        val promotion = diagnostics!!.eventsNamed("identity_promotion").single { event ->
+            event.fields["oldFingerprint"] == DiagnosticPrivacy.stableFingerprint(fallbackA) &&
+                event.fields["newFingerprint"] == DiagnosticPrivacy.stableFingerprint(durableA)
+        }
+        assertEquals(2, promotion.fields["rowCount"])
+        assertEquals(queuedIds, promotion.fields["rowIds"])
+        assertEquals(true, promotion.fields["preservedExceptOwner"])
+        assertEquals(promotion.fields["expectedRowFingerprints"], promotion.fields["rowFingerprints"])
+        waitForIssue1739Boundary(
+            timeoutMs = CONNECTED_TIMEOUT_MS,
+            label = "promoted durable rows drained after heal",
+            timeoutDetails = {
+                "durable=${store.itemsFor(durableA)} fallback=${store.itemsFor(fallbackA)} " +
+                    "sendInFlight=${currentPromptComposerViewModel().uiState.value.sendInFlight} " +
+                    "wire=${currentViewModel().isSendTransportWritable()} " +
+                    "status=${currentConnectionStatus()} " +
+                    "ledger=${runBlocking { readFakeAgentSubmitLedger() }} " +
+                    "queueEvents=${diagnostics!!.events.filter { event ->
+                        event.name == "row_state" || event.name == "drain_attempt" ||
+                            event.name == "dispatch_rejected" ||
+                            event.name == "composer_tmux_send_route" ||
+                            event.name == "agent_submit_turnover" ||
+                            event.name == "identity_promotion"
+                    }.map { it.name to it.fields }}"
+            },
+        ) {
+            store.itemsFor(durableA).isEmpty()
+        }
+        assertTrue("both stable rows must be delivered+pruned", store.itemsFor(durableA).isEmpty())
+        val clientAfterHeal = currentViewModel().currentClientIdentityForTest()
+        val generationAfterHeal = currentViewModel().currentConnectGenerationForTest()
+        assertTrue("A heal must use a fresh client", clientAfterHeal != null && clientAfterHeal != clientAtB)
+        assertTrue("A heal must advance generation", generationAfterHeal > generationAtB)
+        recordTiming("fallback_promoted_and_drained_ms", SystemClock.elapsedRealtime() - healStartedAt)
+        val routedRows = diagnostics!!.eventsNamed("composer_tmux_send_route")
+            .filter { it.fields["rowId"] in queuedIds }
+        assertEquals(
+            "both stable durable row ids must reach the tmux dispatcher",
+            queuedIds.toSet(),
+            routedRows.map { it.fields["rowId"] }.toSet(),
+        )
+        assertTrue(
+            "both recovered composer rows must use an agent route, never RawBytes; events=$routedRows",
+            routedRows.isNotEmpty() && routedRows.all { it.fields["route"] != "RawBytes" },
+        )
+        val turnovers = diagnostics!!.eventsNamed("agent_submit_turnover")
+            .filter { it.fields["result"] == "transcript_ack_observed" }
+        assertEquals(
+            "each durable row must earn exact-runtime post-Enter turnover before prune",
+            2,
+            turnovers.size,
+        )
+        assertTrue(
+            "turnover evidence must remain bound to one client generation",
+            turnovers.all {
+                it.fields["clientHash"] == it.fields["currentClientHash"] &&
+                    it.fields["generation"] == it.fields["currentGeneration"]
+            },
+        )
+        assertTrue(
+            "recorded-agent rows must not fall back to a screen-only ready oracle",
+            diagnostics!!.eventsNamed("agent_submit_turnover")
+                .none { it.fields["result"] == "ready_surface_observed" },
+        )
+        val transcriptAcks = diagnostics!!.eventsNamed("agent_submit_transcript_ack")
+        assertEquals("each row must bind to a new confirmed transcript event", 2, transcriptAcks.size)
+        assertEquals(1, transcriptAcks.map { it.fields["sourceHash"] }.toSet().size)
+        assertTrue(
+            "transcript events must stay on the exact pane/Claude source binding; events=$transcriptAcks",
+            transcriptAcks.all {
+                it.fields["pane"] == "%0" && it.fields["agent"] == AgentKind.ClaudeCode.name
+            },
+        )
+        val secondSubmitted = waitForStableSidecarCapture(renamedA)
+        val submitLedger = readFakeAgentSubmitLedger()
+        writeText(
+            "issue1944-submit-ledger.txt",
+            submitLedger.joinToString(separator = "\n", postfix = "\n") { (sequence, payload) ->
+                "$sequence|$payload"
+            },
+        )
+        assertEquals("server ledger must contain two submit Enters", listOf(1, 2), submitLedger.map { it.first })
+        assertEquals(
+            "server ledger is the authoritative exactly-once FIFO oracle",
+            listOf(firstPayload, secondPayload),
+            submitLedger.map { it.second },
+        )
+        writeText(
+            "issue1944-final-diagnostics.txt",
+            buildString {
+                appendLine("queuedIds=$queuedIds")
+                appendLine("remainingRows=${store.itemsFor(durableA)}")
+                appendLine("capture=$secondSubmitted")
+                diagnostics!!.events.filter { event ->
+                    event.name == "row_state" ||
+                        event.name == "agent_submit_ack" ||
+                        event.name == "agent_submit_turnover" ||
+                        event.name == "agent_submit_transcript_ack" ||
+                        event.name == "composer_tmux_send_route" ||
+                        event.name == "outbound_verify_before_resend" ||
+                        event.name == "dispatch_rejected" ||
+                        event.name == "drain_attempt"
+                }.forEach { appendLine("${it.name} ${it.fields}") }
+            },
+        )
+        val secondSubmittedStripped = secondSubmitted.filterNot { it.isWhitespace() }
+        val secondStripped = secondPayload.filterNot { it.isWhitespace() }
+        assertEquals(
+            "final visible frame must retain the latest submitted row and clean input; capture=$secondSubmitted",
+            1,
+            countOccurrences(
+                secondSubmittedStripped,
+                FAKE_AGENT_SUBMITTED_STRIPPED + secondStripped,
+            ),
+        )
+        val deliveredIds = diagnostics!!.eventsNamed("row_state")
+            .filter { it.fields["toState"] == "Sent" && it.fields["itemId"] in queuedIds }
+            .map { it.fields["itemId"] }
+        assertEquals("automatic drain must deliver FIFO exactly once", queuedIds, deliveredIds)
+        captureViewportArtifacts("issue1944-returned-and-drained")
+        writeText("issue1944-queue.txt", "queuedIds=$queuedIds\ndeliveredIds=$deliveredIds\n")
+        writeTimings()
+        Unit
     } }
 
     /**
@@ -946,9 +1376,15 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         // Open the composer via the launcher unless the sheet is already open
         // (a deferred send leaves it open with the queue row visible).
         if (!hasNode(COMPOSER_DRAFT_TAG)) {
+            // A successful handoff dismisses the modal asynchronously. Let the
+            // launcher become the settled foreground hit target before opening
+            // the next real composer; its semantics node is structurally present
+            // during the closing animation but a tap in that overlap is ignored.
+            pumpComposeMainFor(750)
             compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
                 hasNode(SESSION_COMPOSER_LAUNCHER_TAG)
             }
+            compose.waitForIdle()
             compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true)
                 .performClick()
             compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) { hasNode(COMPOSER_DRAFT_TAG) }
@@ -1140,7 +1576,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
      * exactly READY + the (single) SUBMITTED line + the input box, so payload
      * occurrence counts on it are deterministic.
      */
-    private suspend fun sidecarCapturePane(): String {
+    private suspend fun sidecarCapturePane(sessionName: String = SESSION_NAME): String {
         val result = SshConnection.connect(
             host = DEFAULT_HOST,
             port = DEFAULT_PORT,
@@ -1150,7 +1586,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             timeoutMs = 15_000,
         ).mapCatching { session ->
             session.use {
-                it.exec("tmux capture-pane -p -t ${shellQuote(SESSION_NAME)}")
+                it.exec("tmux capture-pane -p -t ${shellQuote(sessionName)}")
             }
         }
         // Issue #1819: remember WHY a read came back empty. A failed sidecar
@@ -1195,9 +1631,9 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
      * still fails the count assertion, but a broken sidecar can no longer
      * masquerade as one.
      */
-    private fun waitForStableSidecarCapture(): String {
+    private fun waitForStableSidecarCapture(sessionName: String = SESSION_NAME): String {
         lastSidecarFailure = null
-        var previous = runBlocking { sidecarCapturePane() }
+        var previous = runBlocking { sidecarCapturePane(sessionName) }
         repeat(20) {
             // Issue #1819 audit: pumped, and correctly so. This wait's subject is
             // "production has STOPPED changing the pane" — the inverse of waiting
@@ -1207,7 +1643,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             // [pollSidecarCaptureWhileDrivingIssue1739Main] (#1798), which already
             // pumps across the identical sidecar reads.
             pumpComposeMainFor(SIDECAR_SETTLE_STEP_MS)
-            val next = runBlocking { sidecarCapturePane() }
+            val next = runBlocking { sidecarCapturePane(sessionName) }
             if (next == previous && next.isNotBlank()) return next
             previous = next
         }
@@ -1341,6 +1777,104 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             SystemClock.sleep(100)
         }
         return requireNotNull(vm) { "TmuxSessionViewModel not available" }
+    }
+
+    private fun currentPromptComposerViewModel(): PromptComposerViewModel {
+        var vm: PromptComposerViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[PromptComposerViewModel::class.java]
+        }
+        return requireNotNull(vm) { "PromptComposerViewModel not available" }
+    }
+
+    private fun clickTmuxBack() {
+        val tag = listOf(TMUX_COMPACT_CHROME_BACK_BUTTON_TAG, TMUX_FULL_CHROME_BACK_BUTTON_TAG)
+            .firstOrNull { hasNode(it) }
+            ?: TMUX_FULL_CHROME_BACK_BUTTON_TAG
+        compose.onNodeWithTag(tag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) { !hasNode(TMUX_SESSION_SCREEN_TAG) }
+    }
+
+    private fun renameCurrentSessionThroughUi(newName: String) {
+        val moreTag = listOf(TMUX_COMPACT_CHROME_MORE_BUTTON_TAG, TMUX_FULL_CHROME_MORE_BUTTON_TAG)
+            .firstOrNull { hasNode(it) }
+            ?: TMUX_FULL_CHROME_MORE_BUTTON_TAG
+        compose.onNodeWithTag(moreTag, useUnmergedTree = true).performClick()
+        compose.onNodeWithText("Rename session", useUnmergedTree = true).performClick()
+        compose.onNode(hasSetTextAction(), useUnmergedTree = true)
+            .performTextClearance()
+        compose.onNode(hasSetTextAction(), useUnmergedTree = true)
+            .performTextInput(newName)
+        compose.onNodeWithTag(TMUX_LIFECYCLE_DIALOG_CONFIRM_TAG, useUnmergedTree = true)
+            .performClick()
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithText(newName, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+    }
+
+    private fun openSessionFromFolder(sessionName: String, waitForConnection: Boolean = true) {
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            runCatching {
+                compose.onAllNodesWithText(sessionName, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(sessionName, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) { hasNode(TMUX_SESSION_SCREEN_TAG) }
+        if (waitForConnection) waitForConnected("open $sessionName")
+    }
+
+    /** Return through the real in-session picker, which reads live tmux names. */
+    private fun switchSessionFromMoreMenu(
+        sessionName: String,
+        expectedDurableKey: String,
+        waitForConnection: Boolean = true,
+    ) {
+        openSessionSwitcher(sessionName)
+        selectSessionFromOpenSwitcher(expectedDurableKey)
+        if (waitForConnection) waitForConnected("switch to $sessionName")
+    }
+
+    private fun openSessionSwitcher(sessionName: String) {
+        val moreTag = listOf(
+            TMUX_FULL_CHROME_MORE_BUTTON_TAG,
+            TMUX_COMPACT_CHROME_MORE_BUTTON_TAG,
+        ).firstOrNull { hasNode(it) } ?: TMUX_FULL_CHROME_MORE_BUTTON_TAG
+        compose.onNodeWithTag(moreTag, useUnmergedTree = true).performClick()
+        compose.onNodeWithText("Switch session", useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            compose.onAllNodesWithText(sessionName, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun selectSessionFromOpenSwitcher(expectedDurableKey: String) {
+        // Session-switcher pages are current-first. Swipe to the adjacent live
+        // tmux page; tapping the offscreen Text semantics is not a real pager
+        // selection and does not settle the page/navigation effect.
+        compose.onNodeWithTag(TMUX_SESSION_PAGER_TAG, useUnmergedTree = true)
+            .performTouchInput { swipeLeft() }
+        compose.waitUntil(timeoutMillis = HOST_ROW_TIMEOUT_MS) {
+            currentViewModel().currentTargetSessionKeyForTest() == expectedDurableKey
+        }
+    }
+
+    private fun pressSystemBack() {
+        compose.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
+        compose.waitForIdle()
+    }
+
+    private fun waitForComposerReady(expectQueue: Boolean) {
+        compose.waitUntil(timeoutMillis = UI_TIMEOUT_MS) {
+            hasNode(COMPOSER_DRAFT_TAG) &&
+                (!expectQueue || hasNode(COMPOSER_OUTBOUND_QUEUE_TOGGLE_TAG))
+        }
     }
 
     private fun waitForConnected(label: String) {
@@ -1787,6 +2321,8 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         val script = buildString {
             appendLine("set -eu")
             appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_B)} 2>/dev/null || true")
+            appendLine("rm -f ${shellQuote(FAKE_AGENT_LEDGER_PATH)}")
             appendLine("mkdir -p /home/testuser/.claude/projects/-home-testuser")
             appendLine(
                 "cp /home/testuser/.claude/projects/-workspace-pocketshell/" +
@@ -1797,13 +2333,22 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             appendLine(
                 "tmux new-session -d -s ${shellQuote(SESSION_NAME)} -x 80 -y 40 " +
                     "-c /home/testuser " +
-                    shellQuote("exec /usr/local/bin/pocketshell-fake-agent"),
+                    shellQuote(
+                        "POCKETSHELL_FAKE_AGENT_SUBMIT_LEDGER=$FAKE_AGENT_LEDGER_PATH " +
+                            "POCKETSHELL_FAKE_AGENT_TRANSCRIPT=/home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL " +
+                            "exec /usr/local/bin/pocketshell-fake-agent",
+                    ),
             )
             // The #975/#1057 masked-live fixture shape (mirrors the proven
             // ConversationTuiCommandJourneyDockerTest seeding): the session
             // records `shell` while the fresh cwd transcript above is the
             // evidence that binds REAL live Claude detection.
             appendLine("tmux set-option -t ${shellQuote(SESSION_NAME)} @ps_agent_kind shell")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_B)} -x 80 -y 40 " +
+                    shellQuote("printf '$SESSION_B_MARKER\\n'; exec sh"),
+            )
+            appendLine("tmux set-option -t ${shellQuote(SESSION_B)} @ps_agent_kind shell")
             appendLine("sleep 1")
             appendLine("tmux list-sessions")
         }
@@ -1816,6 +2361,28 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             "expected fake-agent seeding to succeed; exit=${result.exitCode} stderr='${result.stderr}'",
             result.exitCode == 0,
         )
+    }
+
+    /**
+     * Give only the #1944 outage proof the framed Claude/Codex-shaped input.
+     * Other journeys in this class intentionally retain the legacy `>` fixture
+     * because their assertions characterize that readline surface.
+     */
+    private suspend fun enableIssue1944FramedFakeAgent() {
+        val command =
+            "tmux respawn-pane -k -t ${shellQuote("=$SESSION_NAME:0.0")} " +
+                shellQuote(
+                    "POCKETSHELL_FAKE_AGENT_SUBMIT_LEDGER=$FAKE_AGENT_LEDGER_PATH " +
+                        "POCKETSHELL_FAKE_AGENT_TRANSCRIPT=/home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL " +
+                        "POCKETSHELL_FAKE_AGENT_RENDER_MODE=issue1944-framed-input " +
+                        "exec /usr/local/bin/pocketshell-fake-agent",
+                )
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(fixtureKey),
+            command = command,
+            description = "issue1944 framed fake-agent input surface",
+        )
+        assertEquals("framed fake-agent respawn must succeed: ${result.stderr}", 0, result.exitCode)
     }
 
     private suspend fun cleanupRemoteTmuxSession(key: String) {
@@ -1831,7 +2398,9 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
                 session.use {
                     it.exec(
                         "tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true; " +
+                            "tmux kill-session -t ${shellQuote(SESSION_B)} 2>/dev/null || true; " +
                             "rm -f /home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL " +
+                            "${shellQuote(FAKE_AGENT_LEDGER_PATH)} " +
                             "2>/dev/null || true",
                     )
                 }
@@ -1843,6 +2412,21 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
 
     private fun captureArtifacts(name: String) {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+    }
+
+    /** Same-run reviewer evidence for #1944's composer and recovered terminal checkpoints. */
+    private fun captureViewportArtifacts(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        val bitmap = checkNotNull(instrumentation.uiAutomation.takeScreenshot()) {
+            "UiAutomation returned no screenshot for $name"
+        }
+        check(bitmap.width == 1080 && bitmap.height == 2400) {
+            "$name must be the reviewer-required 1080x2400 viewport; got ${bitmap.width}x${bitmap.height}"
+        }
+        artifacts.writeViewport(name, bitmap)
+        bitmap.recycle()
         writeText("$name-visible-terminal.txt", visibleTerminalText())
     }
 
@@ -1886,15 +2470,9 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             "$name must be the reviewer-required 1080x2400 viewport; " +
                 "got ${bitmap.width}x${bitmap.height}"
         }
-        val file = artifactFile("$name.png")
-        FileOutputStream(file).use { stream ->
-            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)) {
-                "failed to encode ${file.absolutePath}"
-            }
-        }
+        val file = artifacts.writeViewport(name, bitmap, event = "ISSUE1739_LIVE_VIEWPORT")
         bitmap.recycle()
         writeText("$name-visible-terminal.txt", visibleText)
-        println("ISSUE1739_LIVE_VIEWPORT ${file.absolutePath}")
         return file
     }
 
@@ -1916,22 +2494,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     }
 
-    private fun writeText(name: String, text: String): File {
-        val file = artifactFile(name)
-        file.writeText(text)
-        println("ISSUE1526_TEXT ${file.absolutePath}")
-        return file
-    }
-
-    private fun artifactFile(name: String): File {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
-        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
-        check(dir.exists() || dir.mkdirs()) {
-            "could not create artifact directory ${dir.absolutePath}"
-        }
-        return File(dir, name)
-    }
+    private fun writeText(name: String, text: String): File = artifacts.writeText(name, text)
 
     /**
      * Issue #1621 (round-three review follow-up): suffix the timings artifact with
@@ -1941,26 +2504,38 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
      * the branch-taken evidence was only recoverable by running a method in
      * isolation. Per-method files make it readable from any run.
      */
-    private fun writeTimings(): File {
-        val file = artifactFile("timings-${testName.methodName}.txt")
-        file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
-        println("ISSUE1526_TIMINGS ${file.absolutePath}")
-        return file
-    }
+    private fun writeTimings(): File = artifacts.writeTimings()
 
-    private fun recordTiming(name: String, value: Long) {
-        val line = "$name=$value"
-        timings += line
-        println("ISSUE1526_TIMING $line")
-    }
+    private fun recordTiming(name: String, value: Long) = artifacts.recordTiming(name, value)
 
     private fun shellQuote(value: String): String =
         "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private suspend fun readFakeAgentSubmitLedger(): List<Pair<Int, String>> {
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(fixtureKey),
+            command = "cat ${shellQuote(FAKE_AGENT_LEDGER_PATH)} 2>/dev/null || true",
+            description = "issue1944 append-only fake-agent submit ledger",
+        )
+        assertEquals("fake-agent ledger read must succeed", 0, result.exitCode)
+        return result.stdout.lineSequence()
+            .filter(String::isNotBlank)
+            .map { line ->
+                val fields = line.split('|', limit = 2)
+                check(fields.size == 2) { "invalid fake-agent ledger row: $line" }
+                requireNotNull(fields[0].toIntOrNull()) to
+                    String(Base64.getDecoder().decode(fields[1]), Charsets.UTF_8)
+            }
+            .toList()
+    }
 
     private companion object {
         const val DATABASE_NAME: String = "pocketshell.db"
         const val DEVICE_DIR_NAME: String = "issue1526-exactly-once"
         const val SESSION_NAME: String = "issue1526-exactly-once"
+        const val SESSION_B: String = "issue1944-switch-b"
+        const val SESSION_B_MARKER: String = "ISSUE1944-B-READY"
+        const val FAKE_AGENT_LEDGER_PATH: String = "/tmp/pocketshell-fake-agent-submits.log"
         const val SEEDED_JSONL: String = "issue1526-live-claude.jsonl"
         const val FAKE_AGENT_READY: String = "FAKE-AGENT-READY"
         const val FAKE_AGENT_SUBMITTED_STRIPPED: String = "FAKE-AGENTSUBMITTED:"

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundQueueViewportCapture.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundQueueViewportCapture.kt
@@ -1,0 +1,88 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.os.SystemClock
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.composer.OutboundItem
+import com.pocketshell.app.composer.composerOutboundQueueItemRowTestTag
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinOwningRoot
+import org.junit.Assert.assertEquals
+
+/** Captures reviewer-visible stable-id queue rows in exact FIFO order. */
+internal class OutboundQueueViewportCapture(
+    private val compose: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>,
+    private val artifacts: OutboundAcceptanceArtifacts,
+    private val visibleTerminalText: () -> String,
+) {
+    fun capture(checkpoint: String, rows: List<OutboundItem>) {
+        assertEquals("checkpoint requires both stable FIFO rows", 2, rows.size)
+        artifacts.writeText(
+            "$checkpoint-fifo.txt",
+            rows.mapIndexed { index, row ->
+                "${index + 1}|${row.id}|${composerOutboundQueueItemRowTestTag(row.id)}|${row.cleanText}"
+            }.joinToString(separator = "\n", postfix = "\n"),
+        )
+        var previousCrop: Bitmap? = null
+        try {
+            rows.forEachIndexed { index, row ->
+                val tag = composerOutboundQueueItemRowTestTag(row.id)
+                compose.onNodeWithTag(tag, useUnmergedTree = true).performScrollTo()
+                val current = captureRow(
+                    name = "$checkpoint-fifo-${index + 1}-${row.id.take(8)}",
+                    tag = tag,
+                    payload = row.cleanText,
+                    distinctFrom = previousCrop,
+                )
+                previousCrop?.recycle()
+                previousCrop = current
+            }
+        } finally {
+            previousCrop?.recycle()
+        }
+    }
+
+    private fun captureRow(name: String, tag: String, payload: String, distinctFrom: Bitmap?): Bitmap {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val deadline = SystemClock.elapsedRealtime() + 5_000L
+        while (true) {
+            compose.waitForIdle()
+            val row = compose.onNodeWithTag(tag, useUnmergedTree = true)
+            row.assertIsDisplayed()
+            compose.assertNodeFullyWithinOwningRoot(tag, useUnmergedTree = true)
+            compose.onNode(
+                hasText(payload, substring = true) and hasAnyAncestor(hasTestTag(tag)),
+                useUnmergedTree = true,
+            ).assertIsDisplayed()
+            instrumentation.waitForIdleSync()
+            val bitmap = checkNotNull(instrumentation.uiAutomation.takeScreenshot())
+            check(bitmap.width == 1080 && bitmap.height == 2400)
+            val bounds = row.fetchSemanticsNode().boundsInWindow
+            val left = kotlin.math.floor(bounds.left).toInt().coerceIn(0, bitmap.width - 1)
+            val top = kotlin.math.floor(bounds.top).toInt().coerceIn(0, bitmap.height - 1)
+            val right = kotlin.math.ceil(bounds.right).toInt().coerceIn(left + 1, bitmap.width)
+            val bottom = kotlin.math.ceil(bounds.bottom).toInt().coerceIn(top + 1, bitmap.height)
+            val crop = Bitmap.createBitmap(bitmap, left, top, right - left, bottom - top)
+            if (distinctFrom == null || !crop.sameAs(distinctFrom)) {
+                artifacts.writeViewport(name, bitmap)
+                artifacts.writeText("$name-visible-terminal.txt", visibleTerminalText())
+                bitmap.recycle()
+                return crop
+            }
+            crop.recycle()
+            bitmap.recycle()
+            if (SystemClock.elapsedRealtime() >= deadline) {
+                throw AssertionError("$name never rendered a Surface frame distinct from the preceding FIFO row")
+            }
+            SystemClock.sleep(16L)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/ComposeSignals.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/ComposeSignals.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.proof.signals
 import android.os.SystemClock
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
@@ -216,6 +217,30 @@ fun ComposeTestRule.assertNodeFullyWithinRoot(
                 "clipped even though assertIsDisplayed() passes. " +
                 "nodeBounds=$bounds rootBounds=$root slopPx=$slopPx " +
                 "(left=$withinLeft top=$withinTop right=$withinRight bottom=$withinBottom).",
+        )
+    }
+}
+
+/** Modal-safe containment: resolves the root that owns [tag] when multiple windows exist. */
+fun ComposeTestRule.assertNodeFullyWithinOwningRoot(
+    tag: String,
+    slopDp: Float = CONTAINMENT_SLOP_DP_DEFAULT,
+    useUnmergedTree: Boolean = false,
+) {
+    val slopPx = slopDp * density.density
+    val node = onNodeWithTag(tag, useUnmergedTree = useUnmergedTree).fetchSemanticsNode()
+    val root = onAllNodes(isRoot()).fetchSemanticsNodes().single { it.root === node.root }
+    val bounds = node.boundsInRoot
+    val rootBounds = root.boundsInRoot
+    if (
+        bounds.left < rootBounds.left - slopPx ||
+        bounds.top < rootBounds.top - slopPx ||
+        bounds.right > rootBounds.right + slopPx ||
+        bounds.bottom > rootBounds.bottom + slopPx
+    ) {
+        throw AssertionError(
+            "Node '$tag' is not fully within its owning Compose window root. " +
+                "nodeBounds=$bounds rootBounds=$rootBounds slopPx=$slopPx",
         )
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
@@ -347,6 +347,7 @@ class TmuxSessionVoiceSurfaceUiTest {
      */
     @Test
     fun heldTerminalHidesQuickCommandBand_keepsComposerLauncher() {
+        var composerTaps = 0
         compose.setContent {
             PocketShellTheme {
                 TmuxTerminalBottomControls(
@@ -357,7 +358,7 @@ class TmuxSessionVoiceSurfaceUiTest {
                     // Issue #1672: the terminal is held behind the "Attaching…"
                     // loader (Reconnecting / Attaching — the reported state).
                     terminalHeld = true,
-                    onDictateTap = {},
+                    onDictateTap = { composerTaps += 1 },
                     onEnterTap = {},
                     onShowKeyboardTap = {},
                     onAddSnippetTap = {},
@@ -378,8 +379,14 @@ class TmuxSessionVoiceSurfaceUiTest {
         compose.onNodeWithTag(SESSION_ADD_SNIPPET_CHIP_TAG).assertDoesNotExist()
 
         // …but the composer launcher stays present (#810) and fully within the
-        // viewport so a message can still be queued while reconnecting.
+        // viewport AND operable so a message can still be queued while
+        // reconnecting. Presence alone missed the #1944 regression: the control
+        // was rendered with disabled semantics whenever sessionLive=false.
         compose.assertNodeFullyWithinRoot(SESSION_COMPOSER_LAUNCHER_TAG)
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG)
+            .assertHasClickAction()
+            .performClick()
+        assertEquals(1, composerTaps)
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -1678,7 +1678,10 @@ private fun AppNavigator(
             initialWindowIndex = dest.initialWindowIndex,
             tmuxSessionId = dest.tmuxSessionId,
             sessionCreated = dest.sessionCreated,
-            onBack = ::back,
+            onBack = {
+                tmuxSessionViewModel.onSessionScreenLeft()
+                back()
+            },
             // Issue #666: the restored/last session no longer exists on the
             // server (killed elsewhere while backgrounded). Clear the persisted
             // snapshot so the next foreground does not retry-and-resurrect it,
@@ -1692,24 +1695,25 @@ private fun AppNavigator(
                 recoverToPreviousOrHostList()
             },
             onOpenTmuxSession = { sessionName, startDirectory ->
+                val target = tmuxSessionViewModel.navigationTargetForKnownSession(sessionName)
                 navigate(
                     dest.copy(
                         sessionName = sessionName,
                         startDirectory = startDirectory,
                         initialWindowIndex = null,
-                        tmuxSessionId = null,
-                        sessionCreated = null,
+                        tmuxSessionId = target.tmuxSessionId,
+                        sessionCreated = target.sessionCreated,
                     ),
                 )
             },
-            onReplaceTmuxSession = { sessionName ->
+            onReplaceTmuxSession = { target ->
                 replace(
                     dest.copy(
-                        sessionName = sessionName,
+                        sessionName = target.sessionName,
                         startDirectory = null,
                         initialWindowIndex = null,
-                        tmuxSessionId = null,
-                        sessionCreated = null,
+                        tmuxSessionId = target.tmuxSessionId,
+                        sessionCreated = target.sessionCreated,
                     ),
                 )
             },

--- a/app/src/main/java/com/pocketshell/app/composer/ComposerQueueDiagnostics.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/ComposerQueueDiagnostics.kt
@@ -84,6 +84,33 @@ internal object ComposerQueueDiagnostics {
         )
     }
 
+    /** A pane-proven fallback -> durable identity recovery (issue #1944). */
+    fun identityPromotion(
+        oldSessionKey: String,
+        newSessionKey: String,
+        sourceRows: List<OutboundItem>,
+        rows: List<OutboundItem>,
+        reason: String,
+    ) {
+        val sourceById = sourceRows.associateBy { it.id }
+        val expectedFingerprints = rows.mapNotNull { row ->
+            sourceById[row.id]?.copy(sessionKey = newSessionKey)?.let(::outboundPromotionFingerprint)
+        }
+        val actualFingerprints = rows.map(::outboundPromotionFingerprint)
+        record(
+            "identity_promotion",
+            "oldFingerprint" to fingerprint(oldSessionKey),
+            "newFingerprint" to fingerprint(newSessionKey),
+            "rowCount" to rows.size,
+            "rowIds" to rows.map { it.id },
+            "expectedRowFingerprints" to expectedFingerprints,
+            "rowFingerprints" to actualFingerprints,
+            "preservedExceptOwner" to
+                (expectedFingerprints.size == rows.size && expectedFingerprints == actualFingerprints),
+            "reason" to reason,
+        )
+    }
+
     /**
      * One drain tick's outcome: `dispatched` (a row went to the wire), `not_live`
      * (the gate was shut — enum not-Connected — so nothing was attempted, the
@@ -99,6 +126,8 @@ internal object ComposerQueueDiagnostics {
         suppressedCount: Int = 0,
         parkedCount: Int = 0,
         sendInFlight: Boolean = false,
+        snapshotHeadState: String? = null,
+        snapshotStateCounts: String? = null,
     ) {
         record(
             "drain_attempt",
@@ -109,6 +138,30 @@ internal object ComposerQueueDiagnostics {
             "suppressedCount" to suppressedCount,
             "parkedCount" to parkedCount,
             "sendInFlight" to sendInFlight,
+            "snapshotHeadState" to snapshotHeadState,
+            "snapshotStateCounts" to snapshotStateCounts,
+        )
+    }
+
+    /** Why an already-selected FIFO head could not acquire the dispatch pipeline. */
+    fun dispatchRejected(
+        itemId: String,
+        reason: String,
+        activeOwnerId: String?,
+        itemSessionKey: String?,
+        targetSessionKey: String?,
+        sendInFlight: Boolean,
+        sidecarInFlight: Boolean,
+    ) {
+        record(
+            "dispatch_rejected",
+            "itemId" to itemId,
+            "reason" to reason,
+            "activeOwnerId" to activeOwnerId,
+            "itemSessionFingerprint" to itemSessionKey?.let(::fingerprint),
+            "targetSessionFingerprint" to targetSessionKey?.let(::fingerprint),
+            "sendInFlight" to sendInFlight,
+            "sidecarInFlight" to sidecarInFlight,
         )
     }
 
@@ -142,9 +195,11 @@ internal object ComposerQueueDiagnostics {
      * Record one auto-flush drain cycle from the VM in a SINGLE call (keeps the
      * ratcheted VM tiny): the per-row PARK (→`Failed`, `reason=budget_exhausted`)
      * for each budget-exhausted head, then the tick outcome — `dispatched` (a row
-     * went to the wire) or `all_suppressed` (every eligible row is within its
-     * re-dispatch backoff or is budget-parked). A no-op when the target has no
-     * undelivered row, so an idle poll tick records nothing.
+     * went to the wire), `all_suppressed` (every eligible row is within its
+     * re-dispatch backoff or is budget-parked), or `blocked_by_inflight_snapshot`
+     * (the snapshot still considers the FIFO head physically owned). The latter
+     * includes state counts so a stale pre-promotion snapshot is distinguishable
+     * from a retry backoff. A no-op when the target has no undelivered row.
      */
     fun recordDrainCycle(
         sessionKey: String,
@@ -153,7 +208,8 @@ internal object ComposerQueueDiagnostics {
         suppressedCount: Int,
         dispatched: Boolean,
     ) {
-        val queueDepth = items.count { it.sessionKey == sessionKey && it.isComposerQueueUndelivered() }
+        val targetRows = items.filter { it.sessionKey == sessionKey && it.isComposerQueueUndelivered() }
+        val queueDepth = targetRows.size
         if (queueDepth == 0) return
         val byId = items.associateBy { it.id }
         plan.parkIds.forEach { id ->
@@ -162,12 +218,24 @@ internal object ComposerQueueDiagnostics {
             }
         }
         drainAttempt(
-            outcome = if (dispatched) "dispatched" else "all_suppressed",
+            outcome = when {
+                dispatched -> "dispatched"
+                plan.nextId == null && targetRows.firstOrNull()?.state == OutboundState.InFlight ->
+                    "blocked_by_inflight_snapshot"
+                else -> "all_suppressed"
+            },
             sessionKey = sessionKey,
             dispatchedId = plan.nextId.takeIf { dispatched },
             queueDepth = queueDepth,
             suppressedCount = suppressedCount,
             parkedCount = plan.parkIds.size,
+            snapshotHeadState = targetRows.firstOrNull()?.state?.name,
+            snapshotStateCounts = targetRows
+                .groupingBy { it.state.name }
+                .eachCount()
+                .toSortedMap()
+                .entries
+                .joinToString(separator = ",") { (state, count) -> "$state:$count" },
         )
     }
 
@@ -197,6 +265,10 @@ internal object ComposerQueueDiagnostics {
         DiagnosticEvents.record(CATEGORY, event, *fields)
     }
 }
+
+/** Privacy-safe exact-row proof captured before promotion-triggered drain can mutate delivery fields. */
+internal fun outboundPromotionFingerprint(item: OutboundItem): String =
+    DiagnosticPrivacy.stableFingerprint(item.toString())
 
 /**
  * Issue #1682: thin call-site shim so the byte-ratcheted `PromptComposerViewModel`

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundDrainOwnership.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundDrainOwnership.kt
@@ -1,0 +1,81 @@
+package com.pocketshell.app.composer
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicLong
+
+internal data class OutboundDrainLease(
+    val rowId: String,
+    val token: Long,
+    val acceptedByConsumer: Boolean = false,
+)
+
+/**
+ * Owns one durable outbound row during dispatch setup. Queue effects and
+ * reconnect polls may trigger concurrently; only the row that atomically
+ * acquires this lease may enter the send channel. Ownership spans the complete
+ * physical host delivery, including a session-identity promotion. It is
+ * released only by a delivered/deferred/failed terminal callback, or by the
+ * cancellation/strand cleanup path. `sendInFlight` is UI state, not a durable
+ * cross-identity serialization primitive.
+ */
+internal class OutboundDrainOwnership {
+    private val nextToken = AtomicLong(0L)
+    private val activeLease = AtomicReference<OutboundDrainLease?>(null)
+
+    fun tryAcquire(rowId: String): OutboundDrainLease? {
+        if (rowId.isBlank()) return null
+        val lease = OutboundDrainLease(rowId = rowId, token = nextToken.incrementAndGet())
+        return lease.takeIf { activeLease.compareAndSet(null, lease) }
+    }
+
+    fun acceptByConsumer(rowId: String?, token: Long?): Boolean {
+        if (rowId == null || token == null) return false
+        while (true) {
+            val current = activeLease.get() ?: return false
+            if (current.rowId != rowId || current.token != token || current.acceptedByConsumer) return false
+            if (activeLease.compareAndSet(current, current.copy(acceptedByConsumer = true))) return true
+        }
+    }
+
+    fun release(rowId: String?, token: Long?): Boolean {
+        if (rowId == null || token == null) return false
+        while (true) {
+            val current = activeLease.get() ?: return false
+            if (current.rowId != rowId || current.token != token) return false
+            if (activeLease.compareAndSet(current, null)) return true
+        }
+    }
+
+    fun release(lease: OutboundDrainLease?): Boolean =
+        release(lease?.rowId, lease?.token)
+
+    fun forceRelease(): String? = activeLease.getAndSet(null)?.rowId
+
+    fun activeRowId(): String? = activeLease.get()?.rowId
+}
+
+/**
+ * Identifies the one mounted screen consumer allowed to turn a queued request
+ * into physical host IO. A generation is stamped onto every request so an old
+ * screen collector cannot steal work emitted for its replacement.
+ */
+internal class OutboundSendConsumerRegistry {
+    private val nextGeneration = AtomicLong(0L)
+    private val activeGeneration = AtomicReference<Long?>(null)
+    @Volatile private var registrationRequired: Boolean = false
+
+    fun register(): Long {
+        registrationRequired = true
+        return nextGeneration.incrementAndGet().also(activeGeneration::set)
+    }
+
+    fun unregister(generation: Long): Boolean =
+        activeGeneration.compareAndSet(generation, null)
+
+    fun activeGenerationForDispatch(): Long? = activeGeneration.get()
+
+    fun canDispatch(): Boolean = !registrationRequired || activeGeneration.get() != null
+
+    fun accepts(generation: Long, requestGeneration: Long?): Boolean =
+        requestGeneration == generation && activeGeneration.get() == generation
+}

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -114,6 +114,8 @@ public interface OutboundQueueStore {
         route: OutboundRoute = OutboundRoute.RawBytes,
         agentKind: String? = null,
         sendKey: String = "",
+        tmuxSessionId: String? = null,
+        tmuxSessionCreated: Long? = null,
     ): OutboundItem
 
     /**
@@ -142,6 +144,24 @@ public interface OutboundQueueStore {
 
     /** All items for [sessionKey], ordered oldest-first by [OutboundItem.createdAtMs]. */
     public fun itemsFor(sessionKey: String): List<OutboundItem>
+
+    /**
+     * Atomically move undelivered rows from a temporary [fromSessionKey] to the
+     * canonical [toSessionKey], but only when each row's tap-time pane belongs
+     * to [livePaneIds]. This is the bounded identity-promotion path for a live
+     * tmux generation first opened before its durable session id was known.
+     *
+     * Pane membership is mandatory: a session name alone is never proof, since
+     * a same-name successor must not inherit the previous generation's prompts.
+     * Stable row ids and every delivery/wire field are preserved.
+     */
+    public fun promoteSessionIdentity(
+        fromSessionKey: String,
+        toSessionKey: String,
+        livePaneIds: Set<String>,
+        tmuxSessionId: String,
+        tmuxSessionCreated: Long,
+    ): List<OutboundItem>
 
     /** The item with [id], or `null` if unknown (e.g. already delivered+pruned). */
     public fun item(id: String): OutboundItem?
@@ -347,6 +367,16 @@ public interface OutboundQueueStore {
     public fun hasWireAttempt(sessionKey: String, itemId: String): Boolean
 
     /**
+     * Issue #1944: durably record that submit Enter was written, but agent-side
+     * turnover has not yet been proven. A rebuilt sender must fail closed instead
+     * of issuing another Enter or pruning the row from tmux write completion.
+     */
+    public fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem?
+
+    /** Whether Enter was attempted without a proven agent-side turnover. */
+    public fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean
+
+    /**
      * Issue #1577: the durable [OutboundItem.wireNeedleBaselineCount] recorded for
      * the exact row ([sessionKey], [itemId]), or `null` when none was captured. A
      * ledger rebuilt after a VM-clear reads this so a genuine resend can compare the
@@ -386,6 +416,11 @@ public interface OutboundWireAttemptDurableStore {
     /** Whether a durable wire attempt is recorded for exact ([sessionKey], [itemId]). */
     public fun hasWireAttempt(sessionKey: String, itemId: String): Boolean
 
+    /** Returns true only after the submit latch is durably acknowledged. */
+    public fun recordWireSubmitAttempt(sessionKey: String, itemId: String): Boolean
+
+    public fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean
+
     /** Issue #1577: durable pre-send needle baseline for exact row, or `null`. */
     public fun wireNeedleBaseline(sessionKey: String, itemId: String): Int?
 
@@ -414,6 +449,12 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
 
         override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean =
             this@asWireAttemptDurableStore.hasWireAttempt(sessionKey, itemId)
+
+        override fun recordWireSubmitAttempt(sessionKey: String, itemId: String): Boolean =
+            this@asWireAttemptDurableStore.markWireSubmitAttempted(sessionKey, itemId) != null
+
+        override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean =
+            this@asWireAttemptDurableStore.hasWireSubmitAttempt(sessionKey, itemId)
 
         override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? =
             this@asWireAttemptDurableStore.wireNeedleBaseline(sessionKey, itemId)
@@ -476,6 +517,13 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
  * @property wireCollapsedMarkerBaselineCount issue #1739: the pre-send count of
  *   Claude's collapsed multiline-paste chips. A retry may treat a higher current
  *   count as proof that the ambiguous paste landed, then submit Enter-only.
+ * @property wireSubmitAttempted issue #1944: durably records that Enter was sent
+ *   after the payload paste. If turnover could not be confirmed, a rebuilt VM
+ *   keeps the row unresolved and must not issue another blind Enter.
+ * @property tmuxSessionId tap-time tmux session id used to keep queued delivery
+ *   bound to the exact durable session generation.
+ * @property tmuxSessionCreated tap-time tmux creation epoch paired with
+ *   [tmuxSessionId]; both fields are required for identity promotion.
  */
 public data class OutboundItem(
     val id: String,
@@ -496,6 +544,10 @@ public data class OutboundItem(
     val wireAttemptedAtMs: Long? = null,
     val wireNeedleBaselineCount: Int? = null,
     val wireCollapsedMarkerBaselineCount: Int? = null,
+    val wireSubmitAttempted: Boolean = false,
+    /** Tap-time tmux generation. Both fields are required for identity promotion. */
+    val tmuxSessionId: String? = null,
+    val tmuxSessionCreated: Long? = null,
 )
 
 /** Issue #900: persisted send route selected before an item entered the durable queue. */
@@ -561,6 +613,8 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
         route: OutboundRoute,
         agentKind: String?,
         sendKey: String,
+        tmuxSessionId: String?,
+        tmuxSessionCreated: Long?,
     ): OutboundItem = synchronized(lock) {
         // Issue #961: coalesce a re-Send of the SAME logical prompt while a
         // matching un-delivered row still exists, instead of minting a second
@@ -583,6 +637,8 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
             route = route,
             agentKind = agentKind,
             sendKey = sendKey,
+            tmuxSessionId = tmuxSessionId,
+            tmuxSessionCreated = tmuxSessionCreated,
         )
         items[item.id] = item
         item
@@ -623,6 +679,31 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
         items.values
             .filter { it.sessionKey == sessionKey }
             .sortedBy { it.createdAtMs }
+    }
+
+    override fun promoteSessionIdentity(
+        fromSessionKey: String,
+        toSessionKey: String,
+        livePaneIds: Set<String>,
+        tmuxSessionId: String,
+        tmuxSessionCreated: Long,
+    ): List<OutboundItem> = synchronized(lock) {
+        if (fromSessionKey.isBlank() || toSessionKey.isBlank() ||
+            fromSessionKey == toSessionKey || livePaneIds.isEmpty()
+        ) return emptyList()
+        val promoted = items.values
+            .filter {
+                it.sessionKey == fromSessionKey &&
+                    it.state != OutboundState.Delivered &&
+                    it.paneId.isNotBlank() &&
+                    it.paneId in livePaneIds &&
+                    it.tmuxSessionId == tmuxSessionId &&
+                    it.tmuxSessionCreated == tmuxSessionCreated
+            }
+            .sortedBy { it.createdAtMs }
+            .map { it.copy(sessionKey = toSessionKey) }
+        promoted.forEach { items[it.id] = it }
+        promoted
     }
 
     override fun item(id: String): OutboundItem? = synchronized(lock) { items[id] }
@@ -760,6 +841,19 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
         items[itemId]?.let { it.sessionKey == sessionKey && it.wireAttempted } == true
     }
 
+    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = synchronized(lock) {
+        val target = items[itemId]
+            ?.takeIf { it.sessionKey == sessionKey && it.state != OutboundState.Delivered }
+            ?: return null
+        val updated = target.copy(wireSubmitAttempted = true)
+        items[itemId] = updated
+        updated
+    }
+
+    override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean = synchronized(lock) {
+        items[itemId]?.let { it.sessionKey == sessionKey && it.wireSubmitAttempted } == true
+    }
+
     override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = synchronized(lock) {
         items[itemId]
             ?.takeIf { it.sessionKey == sessionKey && it.wireAttempted }
@@ -788,6 +882,8 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
         route: OutboundRoute,
         agentKind: String?,
         sendKey: String,
+        tmuxSessionId: String?,
+        tmuxSessionCreated: Long?,
     ): OutboundItem = OutboundItem(
         id = UUID.randomUUID().toString(),
         sessionKey = sessionKey,
@@ -799,10 +895,19 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
         route = route,
         agentKind = agentKind,
         sendKey = sendKey,
+        tmuxSessionId = tmuxSessionId,
+        tmuxSessionCreated = tmuxSessionCreated,
     )
 
     override fun enqueueExisting(item: OutboundItem): OutboundItem = item
     override fun itemsFor(sessionKey: String): List<OutboundItem> = emptyList()
+    override fun promoteSessionIdentity(
+        fromSessionKey: String,
+        toSessionKey: String,
+        livePaneIds: Set<String>,
+        tmuxSessionId: String,
+        tmuxSessionCreated: Long,
+    ): List<OutboundItem> = emptyList()
     override fun item(id: String): OutboundItem? = null
     override fun claimNext(sessionKey: String): OutboundItem? = null
     override fun claim(id: String): OutboundItem? = null
@@ -823,6 +928,10 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
         collapsedMarkerBaselineCount: Int?,
     ): OutboundItem? = null
     override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean = false
+
+    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = null
+
+    override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean = false
     override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = null
     override fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int? = null
 }
@@ -845,14 +954,22 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
  * tabs/newlines round-trip losslessly.
  */
 @Singleton
-public class SharedPrefsOutboundQueueStore @Inject constructor(
-    @ApplicationContext context: Context,
+public class SharedPrefsOutboundQueueStore internal constructor(
+    private val deferredPrefs: DeferredPrefs,
 ) : OutboundQueueStore {
+
+    @Inject
+    public constructor(@ApplicationContext context: Context) : this(
+        DeferredPrefs(context, PREFS_NAME),
+    )
+
+    /** Direct prefs seam for crash-window durability tests. */
+    @VisibleForTesting
+    internal constructor(prefs: SharedPreferences) : this(DeferredPrefs(opener = { prefs }))
 
     // Issue #1125: open the prefs file off the Main thread (it is opened at
     // first-composer-open Hilt injection on Main otherwise — touched on every
     // session open via the always-present composer, #809).
-    private val deferredPrefs = DeferredPrefs(context, PREFS_NAME)
     private val prefs: SharedPreferences get() = deferredPrefs.get()
 
     @VisibleForTesting
@@ -872,8 +989,12 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         return decodeOutboundItems(sessionKey, raw).toMutableList()
     }
 
-    private fun storeSession(sessionKey: String, list: List<OutboundItem>) {
-        if (sessionKey.isEmpty()) return
+    private fun storeSession(
+        sessionKey: String,
+        list: List<OutboundItem>,
+        synchronous: Boolean = false,
+    ): Boolean {
+        if (sessionKey.isEmpty()) return false
         val editor = prefs.edit()
         if (list.isEmpty()) {
             editor.remove(blobKey(sessionKey))
@@ -882,7 +1003,12 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
             editor.putString(blobKey(sessionKey), encodeOutboundItems(list))
             editor.putStringSet(SESSION_INDEX_KEY, sessionKeys() + sessionKey)
         }
-        editor.apply()
+        return if (synchronous) {
+            editor.commit()
+        } else {
+            editor.apply()
+            true
+        }
     }
 
     /** Find the session that owns [id], or `null`. */
@@ -899,6 +1025,8 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
         route: OutboundRoute,
         agentKind: String?,
         sendKey: String,
+        tmuxSessionId: String?,
+        tmuxSessionCreated: Long?,
     ): OutboundItem = synchronized(lock) {
         val list = loadSession(sessionKey)
         // Issue #961: coalesce a re-Send of the SAME logical prompt while a
@@ -922,6 +1050,8 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
             route = route,
             agentKind = agentKind,
             sendKey = sendKey,
+            tmuxSessionId = tmuxSessionId,
+            tmuxSessionCreated = tmuxSessionCreated,
         )
         list.add(item)
         storeSession(sessionKey, list.sortedBy { it.createdAtMs })
@@ -959,6 +1089,51 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
 
     override fun itemsFor(sessionKey: String): List<OutboundItem> = synchronized(lock) {
         loadSession(sessionKey).sortedBy { it.createdAtMs }
+    }
+
+    override fun promoteSessionIdentity(
+        fromSessionKey: String,
+        toSessionKey: String,
+        livePaneIds: Set<String>,
+        tmuxSessionId: String,
+        tmuxSessionCreated: Long,
+    ): List<OutboundItem> = synchronized(lock) {
+        if (fromSessionKey.isBlank() || toSessionKey.isBlank() ||
+            fromSessionKey == toSessionKey || livePaneIds.isEmpty()
+        ) return emptyList()
+
+        val source = loadSession(fromSessionKey)
+        val promotable = source.filter {
+            it.state != OutboundState.Delivered &&
+                it.paneId.isNotBlank() &&
+                it.paneId in livePaneIds &&
+                it.tmuxSessionId == tmuxSessionId &&
+                it.tmuxSessionCreated == tmuxSessionCreated
+        }
+        if (promotable.isEmpty()) return emptyList()
+
+        val promoted = promotable.map { it.copy(sessionKey = toSessionKey) }
+        val promotedIds = promoted.mapTo(mutableSetOf()) { it.id }
+        val sourceRemaining = source.filterNot { it.id in promotedIds }
+        val target = loadSession(toSessionKey).filterNot { it.id in promotedIds }
+        val mergedTarget = (target + promoted).sortedBy { it.createdAtMs }
+
+        // One editor transaction updates both blobs and the ownership index, so
+        // a process restart can never observe a row under neither identity.
+        val index = sessionKeys().toMutableSet()
+        val editor = prefs.edit()
+        if (sourceRemaining.isEmpty()) {
+            editor.remove(blobKey(fromSessionKey))
+            index.remove(fromSessionKey)
+        } else {
+            editor.putString(blobKey(fromSessionKey), encodeOutboundItems(sourceRemaining))
+            index.add(fromSessionKey)
+        }
+        editor.putString(blobKey(toSessionKey), encodeOutboundItems(mergedTarget))
+        index.add(toSessionKey)
+        editor.putStringSet(SESSION_INDEX_KEY, index)
+        editor.apply()
+        promoted
     }
 
     override fun item(id: String): OutboundItem? = synchronized(lock) {
@@ -1124,6 +1299,26 @@ public class SharedPrefsOutboundQueueStore @Inject constructor(
     override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean = synchronized(lock) {
         loadSession(sessionKey).any {
             it.id == itemId && it.sessionKey == sessionKey && it.wireAttempted
+        }
+    }
+
+    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = synchronized(lock) {
+        val list = loadSession(sessionKey)
+        val target = list.firstOrNull {
+            it.id == itemId && it.sessionKey == sessionKey && it.state != OutboundState.Delivered
+        } ?: return null
+        val updated = target.copy(wireSubmitAttempted = true)
+        val idx = list.indexOfFirst { it.id == updated.id }
+        if (idx >= 0) list[idx] = updated else list.add(updated)
+        // This one write is the pre-Enter write-ahead barrier. apply() is not an
+        // acknowledgement: process death may drop it after Enter reached tmux.
+        // commit() is called by the suspend send path on seedIoDispatcher, never Main.
+        updated.takeIf { storeSession(sessionKey, list.sortedBy { it.createdAtMs }, synchronous = true) }
+    }
+
+    override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean = synchronized(lock) {
+        loadSession(sessionKey).any {
+            it.id == itemId && it.sessionKey == sessionKey && it.wireSubmitAttempted
         }
     }
 
@@ -1307,14 +1502,15 @@ internal fun blobKey(sessionKey: String): String = "@q/$sessionKey"
 /**
  * Issue #900: encode a session's outbound items as newline-separated rows.
  * Each row is tab-delimited:
- * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs \t wireNeedleBaselineCount \t wireCollapsedMarkerBaselineCount`
+ * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs \t wireNeedleBaselineCount \t wireCollapsedMarkerBaselineCount \t tmuxSessionId \t tmuxSessionCreated \t wireSubmitAttempted`
  * with the same `\`-escaping [ComposerDraftStore] uses so text/paths containing
  * tabs/newlines round-trip losslessly. The attachments field reuses
  * [encodeAttachments], itself escaped as a single field. Trailing fields
  * (`sendKey` #961, `wireAttempted`/`wireAttemptedAtMs` #1541,
- * `wireNeedleBaselineCount` #1577, collapsed-marker baseline #1739) are appended last so legacy rows without them
+ * `wireNeedleBaselineCount` #1577, collapsed-marker baseline #1739,
+ * durable tmux identity and `wireSubmitAttempted` #1944) are appended last so legacy rows without them
  * decode to their defaults (empty `sendKey`, `wireAttempted=false`,
- * `wireNeedleBaselineCount=null`) rather than a malformed row.
+ * `wireNeedleBaselineCount=null`, `wireSubmitAttempted=false`) rather than a malformed row.
  */
 internal fun encodeOutboundItems(items: List<OutboundItem>): String =
     items.joinToString(separator = "\n") { item ->
@@ -1336,6 +1532,9 @@ internal fun encodeOutboundItems(items: List<OutboundItem>): String =
             item.wireAttemptedAtMs?.toString().orEmpty(),
             item.wireNeedleBaselineCount?.toString().orEmpty(),
             item.wireCollapsedMarkerBaselineCount?.toString().orEmpty(),
+            item.tmuxSessionId.orEmpty(),
+            item.tmuxSessionCreated?.toString().orEmpty(),
+            if (item.wireSubmitAttempted) "1" else "0",
         ).joinToString(separator = "\t") { escapeQueueField(it) }
     }
 
@@ -1370,6 +1569,9 @@ internal fun decodeOutboundItems(sessionKey: String, raw: String): List<Outbound
             wireNeedleBaselineCount = f.getOrNull(15)?.takeIf { it.isNotEmpty() }?.toIntOrNull(),
             wireCollapsedMarkerBaselineCount =
                 f.getOrNull(16)?.takeIf { it.isNotEmpty() }?.toIntOrNull(),
+            tmuxSessionId = f.getOrNull(17)?.takeIf { it.isNotEmpty() },
+            tmuxSessionCreated = f.getOrNull(18)?.takeIf { it.isNotEmpty() }?.toLongOrNull(),
+            wireSubmitAttempted = f.getOrNull(19) == "1",
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerIdentityPromotion.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerIdentityPromotion.kt
@@ -1,0 +1,30 @@
+package com.pocketshell.app.composer
+
+/** Promote temporary host/name rows after exact live pane-generation proof. */
+internal fun PromptComposerViewModel.promoteFallbackOutboundIdentity(
+    fallbackSessionKey: String,
+    durableSessionKey: String,
+    livePaneIds: Set<String>,
+    tmuxSessionId: String,
+    tmuxSessionCreated: Long,
+): List<OutboundItem> {
+    val sourceRows = outboundQueueStore.itemsFor(fallbackSessionKey)
+    val promoted = outboundQueueStore.promoteSessionIdentity(
+        fromSessionKey = fallbackSessionKey,
+        toSessionKey = durableSessionKey,
+        livePaneIds = livePaneIds,
+        tmuxSessionId = tmuxSessionId,
+        tmuxSessionCreated = tmuxSessionCreated,
+    )
+    if (promoted.isNotEmpty()) {
+        ComposerQueueDiagnostics.identityPromotion(
+            oldSessionKey = fallbackSessionKey,
+            newSessionKey = durableSessionKey,
+            sourceRows = sourceRows,
+            rows = promoted,
+            reason = "same_generation_pane_membership",
+        )
+        refreshOutboundQueueItemsFor(durableSessionKey)
+    }
+    return promoted
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundDrain.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundDrain.kt
@@ -1,0 +1,59 @@
+package com.pocketshell.app.composer
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Acquires and transfers the single physical composer-drain lease.
+ *
+ * The ViewModel remains the state owner; this coordinator owns the dispatch
+ * race: reject while another send/sidecar owns the pipe, acquire one exact
+ * row-token, prepare sidecars, and release every pre-handoff failure. Once a
+ * [PromptComposerViewModel.SendRequest] is emitted, its terminal callback owns
+ * the lease instead.
+ */
+internal fun PromptComposerViewModel.dispatchOutboundItemThroughDrain(id: String): Boolean {
+    fun reject(reason: String): Boolean {
+        ComposerQueueDiagnostics.dispatchRejected(
+            itemId = id,
+            reason = reason,
+            activeOwnerId = outboundDrainOwnership.activeRowId(),
+            itemSessionKey = outboundQueueStore.item(id)?.sessionKey,
+            targetSessionKey = composerTarget,
+            sendInFlight = uiState.value.sendInFlight,
+            sidecarInFlight = outboundSidecarDispatchInFlight,
+        )
+        return false
+    }
+    if (uiState.value.sendInFlight) return reject("send_in_flight")
+    if (outboundSidecarDispatchInFlight) return reject("sidecar_in_flight")
+    if (!outboundSendConsumers.canDispatch()) return reject("no_send_consumer")
+    val consumerGeneration = outboundSendConsumers.activeGenerationForDispatch()
+    val lease = outboundDrainOwnership.tryAcquire(id) ?: return reject("ownership_held")
+    if (uiState.value.sendInFlight || outboundSidecarDispatchInFlight) {
+        outboundDrainOwnership.release(lease)
+        return reject("gate_changed_after_acquire")
+    }
+    outboundSidecarDispatchInFlight = true
+    launchOutboundDrain {
+        var handedOff = false
+        try {
+            val hasSidecars = outboundAttachmentSidecarStore?.refsFor(id)?.isNotEmpty() == true
+            handedOff = if (hasSidecars) {
+                dispatchPreparedOutboundItem(id, lease, consumerGeneration)
+            } else {
+                claimAndEmitOutboundItem(id, lease, consumerGeneration)
+            }
+        } catch (cancelled: CancellationException) {
+            clearStrandedSendInFlight()
+            throw cancelled
+        } catch (_: Throwable) {
+            clearStrandedSendInFlight(
+                error = "Send failed: reconnect, then send again or discard the draft.",
+            )
+        } finally {
+            outboundSidecarDispatchInFlight = false
+            if (!handedOff) outboundDrainOwnership.release(lease)
+        }
+    }
+    return true
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundMapping.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundMapping.kt
@@ -30,6 +30,8 @@ internal fun computeSendKey(
         sendTarget.paneId,
         sendTarget.route.name,
         sendTarget.agentKind.orEmpty(),
+        sendTarget.tmuxSessionId.orEmpty(),
+        sendTarget.tmuxSessionCreated?.toString().orEmpty(),
         if (withEnter) "1" else "0",
         cleanDraft,
         attachmentSignature,

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
@@ -233,13 +233,21 @@ internal fun Iterable<OutboundItem>.firstComposerAutoFlushable(
     sessionKey: String,
     excludingIds: Set<String> = emptySet(),
     maxAutoAttempts: Int,
-): OutboundItem? =
-    firstOrNull { item ->
+): OutboundItem? {
+    // Preserve physical FIFO across identity promotion. An older InFlight or
+    // Uploading row may still own bytes already pasted into the same pane; it
+    // blocks every younger row until its terminal callback. Exhausted retryable
+    // rows are the sole exception: this cycle parks/surfaces them, so selection
+    // may continue to the next row without hiding a poison head forever.
+    val head = firstOrNull { item ->
         item.sessionKey == sessionKey &&
-            item.id !in excludingIds &&
-            item.isComposerQueueRetryable() &&
-            item.attemptCount < maxAutoAttempts
+            item.isComposerQueueUndelivered() &&
+            !(item.isComposerQueueRetryable() && item.attemptCount >= maxAutoAttempts)
+    } ?: return null
+    return head.takeIf {
+        it.isComposerQueueRetryable() && it.id !in excludingIds
     }
+}
 
 /**
  * Issue #1602: retryable rows for [sessionKey] whose bounded auto-retry budget is
@@ -263,6 +271,23 @@ internal fun Iterable<OutboundItem>.autoRetryExhaustedComposerRows(
 
 /** Issue #1602: the auto-flush decision — ids to park (exhausted heads) + the next dispatchable id. */
 internal data class ComposerAutoFlushPlan(val parkIds: List<String>, val nextId: String?)
+
+/**
+ * A host/name owner is only a parking identity for a row already stamped with
+ * an exact tmux generation and pane. Let the live pane binding promote that row
+ * to its durable `tmux:` owner before any auto-flush can claim it; otherwise a
+ * Connected edge can race the pane-list update and drain the fallback row
+ * without ever proving that it still belongs to this generation (#1944).
+ */
+internal fun Iterable<OutboundItem>.hasGenerationBoundRowsAwaitingPromotion(
+    sessionKey: String,
+): Boolean = !sessionKey.startsWith("tmux:") && any { item ->
+    item.sessionKey == sessionKey &&
+        item.isComposerQueueUndelivered() &&
+        !item.paneId.isNullOrBlank() &&
+        !item.tmuxSessionId.isNullOrBlank() &&
+        item.tmuxSessionCreated != null
+}
 
 /**
  * Issue #1602: plan one auto-flush cycle for [sessionKey]. Parking (Queued→Failed)

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -14,9 +14,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 internal data class ComposerHandoffSnapshot(
     val target: String,
@@ -114,6 +116,100 @@ internal fun PromptComposerViewModel.completeHandoffAcceptanceReduction(
 
 internal fun PromptComposerViewModel.completeAllHandoffAcceptanceReductions() {
     handoffAcceptance.completeAllReductions()
+}
+
+/**
+ * Owns one mounted screen's producer-to-host send boundary. Cancellation is a
+ * non-delivering terminal result, not a false host response: unregister first
+ * so the deferral refresh cannot hand the same row back to the retiring
+ * collector, then durably requeue and rethrow.
+ */
+internal suspend fun collectPromptComposerSendRequests(
+    viewModel: PromptComposerViewModel,
+    onSend: suspend (SendRequest) -> Boolean,
+    onDelivered: () -> Unit = {},
+) {
+    val consumerGeneration = viewModel.outboundSendConsumers.register()
+    try {
+        // Rows may have stayed Queued while no screen consumer was mounted.
+        if (viewModel.isSendTransportWritable()) {
+            viewModel.retryNextOutboundItem()
+        }
+        viewModel.sendRequests.collect { request ->
+            val durableRequest = request.outboundQueueItemId != null
+            val accepted = if (!durableRequest) {
+                true
+            } else {
+                viewModel.outboundSendConsumers.accepts(
+                    generation = consumerGeneration,
+                    requestGeneration = request.outboundConsumerGeneration,
+                ) && viewModel.outboundDrainOwnership.acceptByConsumer(
+                    rowId = request.outboundQueueItemId,
+                    token = request.outboundDrainLeaseToken,
+                )
+            }
+            if (!accepted) {
+                // A retiring collector can receive an item tagged for its
+                // replacement (or vice versa). It must never perform host IO.
+                viewModel.markOutboundSendDeferred(
+                    request,
+                    resetAttemptBudget = !viewModel.isSendTransportWritable(),
+                )
+                throw CancellationException("Prompt composer send consumer was superseded")
+            }
+
+            var terminalCallbackApplied = false
+            try {
+                viewModel.awaitHandoffAcceptanceReduction(request.outboundQueueItemId)
+                val delivered = try {
+                    withTimeoutOrNull(PromptComposerViewModel.SEND_TIMEOUT_MS) {
+                        onSend(request)
+                    } == true
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (_: Throwable) {
+                    false
+                }
+                if (delivered) {
+                    viewModel.markSendDelivered(request)
+                    if (request.outboundQueueItemId == null &&
+                        viewModel.consumeQuiescenceForAutoClose(request)
+                    ) {
+                        onDelivered()
+                    }
+                } else {
+                    viewModel.markOutboundSendDeferred(
+                        request,
+                        resetAttemptBudget = !viewModel.isSendTransportWritable(),
+                    )
+                }
+                terminalCallbackApplied = true
+            } catch (cancelled: CancellationException) {
+                // The crucial ordering: close this generation before refresh.
+                viewModel.outboundSendConsumers.unregister(consumerGeneration)
+                if (!terminalCallbackApplied) {
+                    viewModel.markOutboundSendDeferred(
+                        request,
+                        resetAttemptBudget = !viewModel.isSendTransportWritable(),
+                    )
+                    terminalCallbackApplied = true
+                }
+                throw cancelled
+            } finally {
+                // Covers cancellation from any future suspension point added to
+                // the consumer without relying on a watchdog or wall-clock wait.
+                if (!terminalCallbackApplied) {
+                    viewModel.outboundSendConsumers.unregister(consumerGeneration)
+                    viewModel.markOutboundSendDeferred(
+                        request,
+                        resetAttemptBudget = !viewModel.isSendTransportWritable(),
+                    )
+                }
+            }
+        }
+    } finally {
+        viewModel.outboundSendConsumers.unregister(consumerGeneration)
+    }
 }
 
 internal fun PromptComposerViewModel.composerRevision(target: String): Long =
@@ -592,6 +688,8 @@ internal suspend fun PromptComposerViewModel.enqueueSidecarBackedSend(
         paneId = sendTarget.paneId,
         route = sendTarget.route,
         agentKind = sendTarget.agentKind,
+        tmuxSessionId = sendTarget.tmuxSessionId,
+        tmuxSessionCreated = sendTarget.tmuxSessionCreated,
         // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
         // existing un-delivered row instead of minting a duplicate.
         sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
@@ -628,6 +726,8 @@ internal suspend fun PromptComposerViewModel.enqueueOutboundSend(
         paneId = sendTarget.paneId,
         route = sendTarget.route,
         agentKind = sendTarget.agentKind,
+        tmuxSessionId = sendTarget.tmuxSessionId,
+        tmuxSessionCreated = sendTarget.tmuxSessionCreated,
         // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
         // existing un-delivered row instead of minting a duplicate.
         sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -109,7 +109,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.supervisorScope
-import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * The Phase 1 prompt composer (issue #15). Visual target:
@@ -1526,55 +1525,11 @@ public fun PromptComposerSendDispatcher(
         }
     }
     LaunchedEffect(viewModel) {
-        viewModel.sendRequests.collect { request ->
-            // A durable row may become drainable on another coroutine as soon
-            // as its queue commit lands. Keep host/TUI work behind the local
-            // acceptance reduction so a slow synchronous write cannot leave
-            // the empty sheet showing "Sending…" until terminal delivery.
-            viewModel.awaitHandoffAcceptanceReduction(request.outboundQueueItemId)
-            // Issue #745: bound the send so the in-flight state can never hang.
-            // The host `onSend` is a connect-on-action call (#548) that may kick
-            // a reconnect and await the live client; cap it at [SEND_TIMEOUT_MS]
-            // so a truly dead link resolves to the "Not sent" banner promptly
-            // instead of leaving the composer stuck on "Sending...". A null
-            // (timeout) is treated exactly like a `false` (failed) send.
-            val delivered = runCatching {
-                withTimeoutOrNull(PromptComposerViewModel.SEND_TIMEOUT_MS) {
-                    currentOnSend(request)
-                } == true
-            }.getOrDefault(false)
-            if (delivered) {
-                // Finalize the queue row without touching post-handoff input.
-                viewModel.markSendDelivered(request)
-                // Standalone/legacy callers have no durable queue acceptance
-                // boundary. Keep their established success-only dismissal;
-                // production rows close earlier from handoffAcceptances.
-                if (request.outboundQueueItemId == null &&
-                    viewModel.consumeQuiescenceForAutoClose(request)
-                ) {
-                    currentOnDelivered()
-                }
-            } else {
-                // Issue #971/#987 (maintainer decision — Option A): a failed /
-                // timed-out send on a degraded link is a connection drop, not a
-                // permanent rejection — keep the prompt QUEUED and auto-send it on
-                // reconnect (the #900 flush wired in TmuxSessionScreen) instead of
-                // returning it to the composer. markOutboundSend* falls back to a
-                // composer-restore only when there is no durable queue row, so the
-                // prompt is never silently lost.
-                //
-                // Issue #1686 (failure taxonomy — the WIRE is the oracle): classify
-                // the failure at the point of knowledge. A live, writable transport
-                // handle RIGHT NOW ⇒ the send reached the wire and was REJECTED → burn
-                // the bounded budget (parks a poison row, #1602). No writable transport
-                // ⇒ transport-class → re-grant the budget so a flapping/prolonged outage
-                // never parks the row (the #1686 clog).
-                viewModel.markOutboundSendDeferred(
-                    request,
-                    resetAttemptBudget = !viewModel.isSendTransportWritable(),
-                )
-            }
-        }
+        collectPromptComposerSendRequests(
+            viewModel = viewModel,
+            onSend = { currentOnSend(it) },
+            onDelivered = { currentOnDelivered() },
+        )
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -280,6 +280,8 @@ public class PromptComposerViewModel @Inject constructor(
     internal var outboundAttachmentUploader: (suspend (List<LocalAttachmentSidecarRef>) -> Result<List<String>>)? =
         null
     internal var outboundSidecarDispatchInFlight: Boolean = false
+    internal val outboundDrainOwnership = OutboundDrainOwnership()
+    internal val outboundSendConsumers = OutboundSendConsumerRegistry()
     internal var outboundQueueDispatcher: CoroutineDispatcher = Dispatchers.IO
     private val draftPersistence = ComposerDraftPersistence(
         store = composerDraftStore,
@@ -1014,6 +1016,7 @@ public class PromptComposerViewModel @Inject constructor(
             it.outboundQueueItemId != null && closeEpoch != composerInteractionEpoch
         }
         request?.outboundQueueItemId?.let(outboundAutoCloseEpochs::remove)
+        outboundDrainOwnership.release(request?.outboundQueueItemId, request?.outboundDrainLeaseToken)
         inFlightSendRequest = null
         _uiState.update { it.copy(sendInFlight = false) }
         markOutboundSendDelivered(request)
@@ -1046,6 +1049,7 @@ public class PromptComposerViewModel @Inject constructor(
         request: SendRequest,
         message: String = "Not sent. Reconnect, then send again or discard the draft.",
     ) {
+        outboundDrainOwnership.release(request.outboundQueueItemId, request.outboundDrainLeaseToken)
         if (request.text.isEmpty()) {
             watchdogs.disarmSend()
             inFlightSendRequest = null
@@ -1153,6 +1157,7 @@ public class PromptComposerViewModel @Inject constructor(
         watchdogs.disarmSend()
         inFlightSendRequest = null
         val id = request.outboundQueueItemId
+        outboundDrainOwnership.release(id, request.outboundDrainLeaseToken)
         id?.let(outboundAutoCloseEpochs::remove)
         val requeued = outboundQueueStore.requeueDeferredSend(
             id, request.sendTarget.sessionKey, request, outboundAttemptBudget, resetAttemptBudget,
@@ -1176,7 +1181,7 @@ public class PromptComposerViewModel @Inject constructor(
                 attachmentUpload = AttachmentUploadState.Idle,
             )
         }
-        request.sendTarget.sessionKey
+        requeued.sessionKey
             .takeIf { it.isNotBlank() }
             ?.let { refreshOutboundQueueItemsFor(it) }
     }
@@ -1260,6 +1265,7 @@ public class PromptComposerViewModel @Inject constructor(
             }
             return
         }
+        outboundDrainOwnership.forceRelease()
         _uiState.update { current ->
             if (error != null) {
                 current.copy(sendInFlight = false, error = error)
@@ -1471,6 +1477,7 @@ public class PromptComposerViewModel @Inject constructor(
         // Issue #1602: PARK an auto-retry-exhausted head (Failed, surfaced) so the
         // drain skips it and the healthy tail drains; per-row Retry re-drives it.
         val itemsSnapshot = _outboundQueueItems.value
+        if (itemsSnapshot.hasGenerationBoundRowsAwaitingPromotion(target)) return null
         val plan = itemsSnapshot.planComposerAutoFlush(target, excludingIds)
         if (plan.parkIds.isNotEmpty()) {
             plan.parkIds.forEach {
@@ -1557,57 +1564,20 @@ public class PromptComposerViewModel @Inject constructor(
     }
 
     internal fun dispatchOutboundItem(id: String): Boolean {
-        if (_uiState.value.sendInFlight) return false
-        if (outboundSidecarDispatchInFlight) return false
-        val sidecarStore = outboundAttachmentSidecarStore
-        if (sidecarStore != null) {
-            outboundSidecarDispatchInFlight = true
-            viewModelScope.launch(outboundQueueDispatcher) {
-                try {
-                    val sidecars = sidecarStore.refsFor(id)
-                    if (sidecars.isNotEmpty()) {
-                        dispatchPreparedOutboundItem(id)
-                    } else {
-                        claimAndEmitOutboundItem(id)
-                    }
-                } catch (cancelled: CancellationException) {
-                    // Issue #929: clear the in-flight gates on cancellation so a
-                    // recreated composer is not wedged, then rethrow.
-                    clearStrandedSendInFlight()
-                    throw cancelled
-                } catch (t: Throwable) {
-                    // Issue #929: an unexpected throw is a non-delivering exit —
-                    // clear the strand so the next send is not wedged.
-                    clearStrandedSendInFlight(
-                        error = "Send failed: reconnect, then send again or discard the draft.",
-                    )
-                } finally {
-                    outboundSidecarDispatchInFlight = false
-                }
-            }
-            return true
-        }
-        outboundSidecarDispatchInFlight = true
-        viewModelScope.launch(outboundQueueDispatcher) {
-            try {
-                claimAndEmitOutboundItem(id)
-            } catch (cancelled: CancellationException) {
-                clearStrandedSendInFlight()
-                throw cancelled
-            } catch (t: Throwable) {
-                clearStrandedSendInFlight(
-                    error = "Send failed: reconnect, then send again or discard the draft.",
-                )
-            } finally {
-                outboundSidecarDispatchInFlight = false
-            }
-        }
-        return true
+        return dispatchOutboundItemThroughDrain(id)
     }
 
-    internal suspend fun dispatchPreparedOutboundItem(id: String): Boolean {
+    internal fun launchOutboundDrain(block: suspend () -> Unit) {
+        viewModelScope.launch(outboundQueueDispatcher) { block() }
+    }
+
+    internal suspend fun dispatchPreparedOutboundItem(
+        id: String,
+        drainLease: OutboundDrainLease,
+        consumerGeneration: Long?,
+    ): Boolean {
         if (!uploadSidecarsForOutboundItem(id)) return false
-        return claimAndEmitOutboundItem(id)
+        return claimAndEmitOutboundItem(id, drainLease, consumerGeneration)
     }
 
     private suspend fun uploadSidecarsForOutboundItem(id: String): Boolean {
@@ -1701,7 +1671,11 @@ public class PromptComposerViewModel @Inject constructor(
         return true
     }
 
-    private fun claimAndEmitOutboundItem(id: String): Boolean {
+    internal fun claimAndEmitOutboundItem(
+        id: String,
+        drainLease: OutboundDrainLease,
+        consumerGeneration: Long?,
+    ): Boolean {
         // Issue #929: the claim lost the race (row already claimed/delivered/
         // gone). Non-delivering exit — clear the in-flight gates so the next
         // send is not wedged behind a stranded `sendInFlight`.
@@ -1731,8 +1705,12 @@ public class PromptComposerViewModel @Inject constructor(
                 paneId = active.paneId,
                 route = active.route,
                 agentKind = active.agentKind,
+                tmuxSessionId = active.tmuxSessionId,
+                tmuxSessionCreated = active.tmuxSessionCreated,
             ),
             outboundQueueItemId = active.id,
+            outboundDrainLeaseToken = drainLease.token,
+            outboundConsumerGeneration = consumerGeneration,
         )
         _uiState.update { it.copy(sendInFlight = true, error = null) }
         watchdogs.armSend()
@@ -1752,16 +1730,19 @@ public class PromptComposerViewModel @Inject constructor(
 
     private fun markOutboundSendDelivered(request: SendRequest?) {
         val id = request?.outboundQueueItemId ?: return
-        outboundQueueStore.item(id)?.recordQueueRowState("InFlight", "Sent", "delivered")
+        val currentOwner = outboundQueueStore.item(id)?.also {
+            it.recordQueueRowState("InFlight", "Sent", "delivered")
+        }?.sessionKey
         outboundQueueStore.markDelivered(id)
         launchSidecarRemoval(id)
-        request.sendTarget.sessionKey
-            .takeIf { it.isNotBlank() }
+        currentOwner
+            ?.takeIf { it.isNotBlank() }
             ?.let { refreshOutboundQueueItemsFor(it) }
     }
 
     private fun markOutboundSendFailed(request: SendRequest, message: String, keepRow: Boolean = false) {
         val id = request.outboundQueueItemId ?: return
+        val currentOwner = outboundQueueStore.item(id)?.sessionKey
         // Issue #971/#987: this is the GENUINE-permanent-failure path
         // ([restoreFailedSend]) — the prompt is returned to the composer as the
         // SINGLE representation, so REMOVE the queue row instead of leaving a
@@ -1779,8 +1760,8 @@ public class PromptComposerViewModel @Inject constructor(
             outboundQueueStore.remove(id)
             launchSidecarRemoval(id)
         }
-        request.sendTarget.sessionKey
-            .takeIf { it.isNotBlank() }
+        currentOwner
+            ?.takeIf { it.isNotBlank() }
             ?.let { refreshOutboundQueueItemsFor(it) }
     }
 
@@ -3014,20 +2995,14 @@ public class PromptComposerViewModel @Inject constructor(
         val mimeType: String? = null,
     )
 
-    /**
-     * Issue #900: tap-time snapshot of the route the Send action targeted.
-     * The composer captures this before any deferred work (dictation finish or
-     * attachment-upload wait) so the eventual [SendRequest] still points at the
-     * pane/session the user committed to when they tapped Send.
-     *
-     * Defaults are intentionally empty/safe so legacy callers can construct
-     * sends without knowing about the outbound queue metadata yet.
-     */
+    /** Tap-time route snapshot retained through deferred send work. */
     public data class SendTargetSnapshot(
         val sessionKey: String = "",
         val paneId: String = "",
         val route: OutboundRoute = OutboundRoute.RawBytes,
         val agentKind: String? = null,
+        val tmuxSessionId: String? = null,
+        val tmuxSessionCreated: Long? = null,
     )
 
     /**
@@ -3167,6 +3142,8 @@ public class PromptComposerViewModel @Inject constructor(
          */
         val sendTarget: SendTargetSnapshot = SendTargetSnapshot(),
         val outboundQueueItemId: String? = null,
+        internal val outboundDrainLeaseToken: Long? = null,
+        internal val outboundConsumerGeneration: Long? = null,
     )
 
     /**

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionListParser.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionListParser.kt
@@ -68,6 +68,7 @@ class HostTmuxSessionListParser @Inject constructor() {
         if (name.isEmpty()) return null
         return HostTmuxSessionRow(
             name = name,
+            tmuxSessionId = fields.tmuxSessionId?.trim()?.takeIf { it.isNotEmpty() },
             createdAt = fields.createdAt?.trim()?.toLongOrNull(),
             lastActivity = fields.lastActivity?.trim()?.toLongOrNull(),
             attached = (fields.attached?.trim()?.toLongOrNull() ?: fields.fallbackAttachedCount) > 0L,
@@ -87,6 +88,11 @@ class HostTmuxSessionListParser @Inject constructor() {
 
     private fun parseStructuredTmuxListSessionsFields(line: String): TmuxListSessionsFields? {
         for (separator in STRUCTURED_SEPARATORS) {
+            // Issue #1944: picker rows carry the immutable tmux generation as
+            // id + created. Parse these identity-bearing shapes first because
+            // the live form has six fields, like the dashboard state form.
+            parseStructuredIdentitySixFields(line, separator)?.let { return it }
+            parseStructuredIdentityFiveFields(line, separator)?.let { return it }
             // Issue #1237: the cross-host dashboard query appends
             // `#{@ps_agent_state}` and `#{@ps_agent_state_updated_at}` as a 5th
             // and 6th column (both controlled: an idle/waiting/working token and
@@ -110,6 +116,39 @@ class HostTmuxSessionListParser @Inject constructor() {
             )
         }
         return null
+    }
+
+    private fun parseStructuredIdentitySixFields(line: String, separator: String): TmuxListSessionsFields? {
+        val fields = line.splitFromRight(separator, expectedTailFields = 5) ?: return null
+        if (!fields[0].trim().startsWith('$') ||
+            fields[2].trim().toLongOrNull() == null ||
+            fields[3].trim().toLongOrNull() == null ||
+            fields[4].trim().toLongOrNull() == null
+        ) return null
+        return TmuxListSessionsFields(
+            tmuxSessionId = fields[0],
+            name = fields[1],
+            createdAt = fields[2],
+            lastActivity = fields[3],
+            attached = fields[4],
+            path = fields[5],
+        )
+    }
+
+    private fun parseStructuredIdentityFiveFields(line: String, separator: String): TmuxListSessionsFields? {
+        val fields = line.splitFromRight(separator, expectedTailFields = 4) ?: return null
+        if (!fields[0].trim().startsWith('$') ||
+            fields[2].trim().toLongOrNull() == null ||
+            fields[3].trim().toLongOrNull() == null ||
+            fields[4].trim().toLongOrNull() == null
+        ) return null
+        return TmuxListSessionsFields(
+            tmuxSessionId = fields[0],
+            name = fields[1],
+            createdAt = fields[2],
+            lastActivity = fields[3],
+            attached = fields[4],
+        )
     }
 
     private fun parseStructuredSixFields(line: String, separator: String): TmuxListSessionsFields? {
@@ -210,6 +249,7 @@ class HostTmuxSessionListParser @Inject constructor() {
         }.getOrNull()
 
     private data class TmuxListSessionsFields(
+        val tmuxSessionId: String? = null,
         val name: String,
         val createdAt: String?,
         val lastActivity: String?,

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerModels.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerModels.kt
@@ -4,6 +4,8 @@ import com.pocketshell.core.storage.entity.HostEntity
 
 data class HostTmuxSessionRow(
     val name: String,
+    /** Stable tmux identity (`#{session_id}`), required for safe navigation. */
+    val tmuxSessionId: String? = null,
     val createdAt: Long? = null,
     val lastActivity: Long? = null,
     val attached: Boolean = false,

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
@@ -203,7 +203,11 @@ class HostTmuxSessionPickerViewModel @Inject constructor(
         val siblings: List<HostTmuxSessionRow> = emptyList(),
     ) {
         val hasSiblingsToSwitch: Boolean
-            get() = siblings.any { it.name != currentSessionName }
+            get() = siblings.any {
+                it.name != currentSessionName &&
+                    !it.tmuxSessionId.isNullOrBlank() &&
+                    (it.createdAt ?: 0L) > 0L
+            }
     }
 
     internal companion object {

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
@@ -80,19 +80,12 @@ class SshHostTmuxSessionsGateway internal constructor(
             target = host.toLeaseSessionTarget(keyPath, passphrase),
             blockTimeoutMs = leaseBlockTimeoutMs,
         ) { session ->
-            val pocketshell = session.exec(pathAware("pocketshell sessions list --by activity"))
-            if (pocketshell.exitCode == 0) {
-                return@withSession HostTmuxSessionListResult.Sessions(
-                    parser.parsePocketshellSessionsList(pocketshell.stdout),
-                )
-            }
-
             val tmux = session.exec(
                 pathAware(
-                    // Keep this in the same structured wire shape as
-                    // the live-client dashboard poller; the shared
-                    // parser also accepts tab and fallback variants.
-                    "tmux list-sessions -F '#{session_name}::#{session_created}::#{session_activity}::#{session_attached}'",
+                    // Issue #1944: picker navigation must carry a correlated
+                    // tmux generation. A name-only proxy row is unsafe after
+                    // runtime-cache eviction, so query id + created directly.
+                    "tmux list-sessions -F '#{session_id}::#{session_name}::#{session_created}::#{session_activity}::#{session_attached}'",
                 ),
             )
             when {
@@ -101,8 +94,6 @@ class SshHostTmuxSessionsGateway internal constructor(
                     HostTmuxSessionListResult.ToolUnavailable
                 tmux.stderr.contains("no server running", ignoreCase = true) ->
                     HostTmuxSessionListResult.Sessions(emptyList())
-                pocketshell.exitCode == 127 || pocketshell.stderr.contains("not found", ignoreCase = true) ->
-                    HostTmuxSessionListResult.ToolUnavailable
                 else -> HostTmuxSessionListResult.Failed(
                     tmux.stderr.ifBlank { tmux.stdout }.ifBlank { "tmux exited ${tmux.exitCode}" },
                 )
@@ -193,7 +184,7 @@ class SshHostTmuxSessionsGateway internal constructor(
         // second SSH connect.
         const val LIVE_LIST_SESSIONS_COMMAND: String =
             "list-sessions -F " +
-                "'#{session_name}::#{session_created}::#{session_activity}::" +
+                "'#{session_id}::#{session_name}::#{session_created}::#{session_activity}::" +
                 "#{session_attached}::#{session_path}'"
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
@@ -92,6 +92,24 @@ internal const val AGENT_SUBMIT_ACK_POLL_INTERVAL_MS: Long = 40L
 internal const val AGENT_SUBMIT_ACK_TIMEOUT_MS: Long = 800L
 
 /**
+ * Issue #1944: after tmux accepts Enter, wait for the exact pane to render a
+ * different frame before declaring the durable row delivered. A successful
+ * `send-keys Enter` only acknowledges tmux's command parser; it does not prove
+ * the agent consumed the submit or reopened its input loop.
+ */
+internal const val AGENT_SUBMIT_TURNOVER_TIMEOUT_MS: Long = 800L
+
+/**
+ * Issue #1944: an authoritative JSONL acknowledgement rides remote `tail -F`.
+ * BusyBox tail polls file growth once per second, then the conversation bridge
+ * batches for 60ms. Two seconds covers one full poll phase plus batching, SSH
+ * RTT, and device scheduling. This larger ceiling is selected only when the
+ * pane has a transcript authority candidate; generic screen turnover retains
+ * the 800ms bound above.
+ */
+internal const val AGENT_TRANSCRIPT_TURNOVER_TIMEOUT_MS: Long = 2_000L
+
+/**
  * Issue #869: how many whitespace-stripped tail characters of the pasted prompt
  * the ack needle matches against `capture-pane`.
  */
@@ -254,7 +272,7 @@ internal suspend fun awaitAgentPasteIngested(
     capture: suspend (timeoutMs: Long, scrollbackLines: Int) -> AgentPaneCaptureResult,
     currentClientHash: () -> Int?,
     currentGeneration: () -> Long,
-) {
+): CommandResponse {
     val floorMs = if (agent == AgentKind.Codex) {
         maxOf(configuredFloorMs, CODEX_AGENT_SUBMIT_DELAY_MS)
     } else {
@@ -263,12 +281,16 @@ internal suspend fun awaitAgentPasteIngested(
     val needle = agentSubmitAckNeedle(payload)
     if (needle == null) {
         if (floorMs > 0L) delay(floorMs)
-        return
+        val pane = capture(ackTimeoutMs, 0)
+        return pane.response?.takeIf {
+            pane.status == AgentPaneCaptureStatus.Captured && !it.isError
+        } ?: throw IllegalStateException("Agent paste acknowledgement frame was unavailable; kept queued.")
     }
 
     val multiline = agentSubmitPayloadIsMultiLine(payload)
     var polls = 0
     var terminalResult = "ack_timeout"
+    var observedResponse: CommandResponse? = null
     val observed = withTimeoutOrNull(ackTimeoutMs.coerceAtLeast(1L)) {
         while (true) {
             val pane = capture(ackTimeoutMs, 0)
@@ -293,6 +315,110 @@ internal suspend fun awaitAgentPasteIngested(
                             currentClientHash = currentClientHash,
                             currentGeneration = currentGeneration,
                         )
+                        observedResponse = pane.response
+                        return@withTimeoutOrNull true
+                    }
+                }
+                AgentPaneCaptureStatus.TimedOut -> {
+                    terminalResult = "capture_timeout"
+                    return@withTimeoutOrNull false
+                }
+                AgentPaneCaptureStatus.Failed -> Unit
+                AgentPaneCaptureStatus.Disconnected -> {
+                    terminalResult = "disconnected"
+                    return@withTimeoutOrNull false
+                }
+                AgentPaneCaptureStatus.StaleRuntime -> {
+                    terminalResult = "stale_runtime"
+                    return@withTimeoutOrNull false
+                }
+            }
+            polls += 1
+            delay(AGENT_SUBMIT_ACK_POLL_INTERVAL_MS)
+        }
+    } == true
+    if (observed) return requireNotNull(observedResponse)
+
+    recordAgentSubmitAck(
+        identity = identity,
+        paneId = paneId,
+        result = terminalResult,
+        polls = polls,
+        currentClientHash = currentClientHash,
+        currentGeneration = currentGeneration,
+    )
+    throw IllegalStateException("Agent paste acknowledgement was not proven ($terminalResult); kept queued.")
+}
+
+/**
+ * Issue #1944: prove that the agent-side submit turn advanced after Enter. The
+ * pre-Enter frame came from [awaitAgentPasteIngested], bound to the immutable
+ * client/generation/session/pane identity. A changed authoritative capture is
+ * the narrow generic signal shared by full-screen agent TUIs and the readline
+ * fixture: the input/placeholder frame was consumed and the agent rendered its
+ * submitted/working/ready state. Timeout is ambiguous and MUST remain a durable
+ * row; callers must not translate tmux write completion into Delivered.
+ */
+internal suspend fun awaitAgentSubmitTurnover(
+    identity: AgentSendRuntimeIdentity,
+    paneId: String,
+    payload: String,
+    preEnterFrame: CommandResponse,
+    timeoutMs: Long,
+    transcriptAuthorityPresent: () -> Boolean = { false },
+    transcriptAcknowledged: () -> Boolean = { false },
+    capture: suspend (timeoutMs: Long, scrollbackLines: Int) -> AgentPaneCaptureResult,
+    currentClientHash: () -> Int?,
+    currentGeneration: () -> Long,
+) {
+    var polls = 0
+    var terminalResult = "turnover_timeout"
+    var consecutiveReadyCaptures = 0
+    val observed = withTimeoutOrNull(timeoutMs.coerceAtLeast(1L)) {
+        while (true) {
+            if (
+                transcriptAuthorityPresent() &&
+                currentClientHash() == System.identityHashCode(identity.client) &&
+                currentGeneration() == identity.generation &&
+                transcriptAcknowledged()
+            ) {
+                recordAgentSubmitTurnover(
+                    identity, paneId, "transcript_ack_observed", polls,
+                    currentClientHash, currentGeneration,
+                )
+                return@withTimeoutOrNull true
+            }
+            val pane = capture(timeoutMs, 0)
+            when (pane.status) {
+                AgentPaneCaptureStatus.Captured -> {
+                    val response = pane.response
+                    val inputState = response?.let { agentInputSurfaceState(it, payload) }
+                        ?: AgentInputSurfaceState.Unknown
+                    recordAgentSubmitTurnoverCapture(
+                        identity = identity,
+                        paneId = paneId,
+                        polls = polls,
+                        response = response,
+                        inputState = inputState,
+                        currentClientHash = currentClientHash,
+                        currentGeneration = currentGeneration,
+                    )
+                    consecutiveReadyCaptures = if (
+                        !transcriptAuthorityPresent() &&
+                        response != null &&
+                        !response.isError &&
+                        response.output != preEnterFrame.output &&
+                        inputState == AgentInputSurfaceState.Ready
+                    ) {
+                        consecutiveReadyCaptures + 1
+                    } else {
+                        0
+                    }
+                    if (consecutiveReadyCaptures >= 2) {
+                        recordAgentSubmitTurnover(
+                            identity, paneId, "ready_surface_observed", polls,
+                            currentClientHash, currentGeneration,
+                        )
                         return@withTimeoutOrNull true
                     }
                 }
@@ -315,16 +441,89 @@ internal suspend fun awaitAgentPasteIngested(
         }
     } == true
     if (observed) return
-
-    recordAgentSubmitAck(
-        identity = identity,
-        paneId = paneId,
-        result = terminalResult,
-        polls = polls,
-        currentClientHash = currentClientHash,
-        currentGeneration = currentGeneration,
+    recordAgentSubmitTurnover(
+        identity, paneId, terminalResult, polls, currentClientHash, currentGeneration,
     )
-    throw IllegalStateException("Agent paste acknowledgement was not proven ($terminalResult); kept queued.")
+    throw IllegalStateException("Agent submit turnover was not proven ($terminalResult); kept queued.")
+}
+
+/**
+ * Row-correlated #1944 turnover oracle. Agent transcripts commonly keep the
+ * submitted user text visible, so payload presence anywhere in the pane is not
+ * enough. Prefer the last conventional agent input prompt (`>` / `›`) and its
+ * wrapped tail. If no prompt can be identified, fail closed by treating payload
+ * presence anywhere as still-in-input; false negatives preserve the durable row.
+ */
+internal enum class AgentInputSurfaceState { PendingPayload, Ready, Unknown }
+
+internal fun agentInputSurfaceState(
+    response: CommandResponse,
+    payload: String,
+): AgentInputSurfaceState {
+    if (response.isError) return AgentInputSurfaceState.Unknown
+    val needle = agentSubmitAckNeedle(payload) ?: return AgentInputSurfaceState.Unknown
+    val promptIndex = response.output.indexOfLast { line ->
+        val trimmed = line.trimStart()
+        trimmed == ">" || trimmed.startsWith("> ") ||
+            trimmed == "›" || trimmed.startsWith("› ")
+    }
+    if (promptIndex < 0) return AgentInputSurfaceState.Unknown
+    val candidate = response.output.drop(promptIndex)
+    val pending = agentSubmitVisibleTextContainsNeedle(candidate, needle) ||
+        (
+            agentSubmitPayloadIsMultiLine(payload) &&
+                agentSubmitCollapsedPasteMarkerCount(candidate) > 0
+            )
+    return if (pending) AgentInputSurfaceState.PendingPayload else AgentInputSurfaceState.Ready
+}
+
+internal fun agentPaneShowsPayloadInInput(response: CommandResponse, payload: String): Boolean =
+    agentInputSurfaceState(response, payload) != AgentInputSurfaceState.Ready
+
+private fun recordAgentSubmitTurnoverCapture(
+    identity: AgentSendRuntimeIdentity,
+    paneId: String,
+    polls: Int,
+    response: CommandResponse?,
+    inputState: AgentInputSurfaceState,
+    currentClientHash: () -> Int?,
+    currentGeneration: () -> Long,
+) {
+    DiagnosticEvents.record(
+        "action",
+        "agent_submit_turnover_capture",
+        "pane" to paneId,
+        "poll" to polls,
+        "promptFound" to (inputState != AgentInputSurfaceState.Unknown),
+        "inputState" to inputState.name,
+        "frameFingerprint" to response?.output?.joinToString("\n").hashCode().toUInt().toString(16),
+        "clientHash" to System.identityHashCode(identity.client),
+        "currentClientHash" to currentClientHash(),
+        "generation" to identity.generation,
+        "currentGeneration" to currentGeneration(),
+    )
+}
+
+private fun recordAgentSubmitTurnover(
+    identity: AgentSendRuntimeIdentity,
+    paneId: String,
+    result: String,
+    polls: Int,
+    currentClientHash: () -> Int?,
+    currentGeneration: () -> Long,
+) {
+    DiagnosticEvents.record(
+        "action",
+        "agent_submit_turnover",
+        "pane" to paneId,
+        "result" to result,
+        "polls" to polls,
+        "clientHash" to System.identityHashCode(identity.client),
+        "currentClientHash" to currentClientHash(),
+        "generation" to identity.generation,
+        "currentGeneration" to currentGeneration(),
+        "session" to (identity.target?.sessionName ?: "test"),
+    )
 }
 
 private fun recordAgentSubmitAck(

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentTranscriptAuthority.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentTranscriptAuthority.kt
@@ -1,0 +1,143 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.session.AgentConversationSyncStatus
+import com.pocketshell.app.session.AgentConversationUiState
+import com.pocketshell.app.session.OPTIMISTIC_USER_MESSAGE_ID_PREFIX
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+import com.pocketshell.core.tmux.CommandResponse
+
+/**
+ * Owns the transcript-authority half of durable agent-submit acknowledgement.
+ *
+ * A terminal redraw is not proof that Enter created a new agent turn. This
+ * component snapshots confirmed transcript ids before Enter and accepts only a
+ * new confirmed user event from the exact live detection source afterward.
+ * Keeping this state here also prevents test-only authority overrides from
+ * becoming another responsibility of [TmuxSessionViewModel].
+ */
+internal class AgentTranscriptAuthority(
+    private val conversationForPane: (String) -> AgentConversationUiState?,
+    private val tailJobActive: (String) -> Boolean,
+    private val tailGenerationPresent: (String) -> Boolean,
+) {
+    internal data class Baseline(
+        val detection: AgentDetection,
+        val confirmedMatchingIds: Set<String>,
+    )
+
+    private val activeOverrides = mutableSetOf<String>()
+    private val startingOverrides = mutableSetOf<String>()
+
+    fun setActiveForTest(paneId: String, active: Boolean) {
+        if (active) {
+            activeOverrides += paneId
+            startingOverrides -= paneId
+        } else {
+            activeOverrides -= paneId
+        }
+    }
+
+    fun setStartingForTest(paneId: String, starting: Boolean) {
+        if (starting) startingOverrides += paneId else startingOverrides -= paneId
+    }
+
+    fun baseline(paneId: String, payload: String): Baseline? {
+        val conversation = conversationForPane(paneId) ?: return null
+        val detection = conversation.detection?.takeIf { it.sourcePath.isNotBlank() } ?: return null
+        val active = isActive(paneId, detection)
+        val starting = paneId in startingOverrides || tailJobActive(paneId)
+        if (!active && !starting) return null
+        return Baseline(
+            detection = detection,
+            confirmedMatchingIds = conversation.events.confirmedUserIds(payload),
+        ).also {
+            DiagnosticEvents.record(
+                "action",
+                "agent_submit_transcript_baseline",
+                "pane" to paneId,
+                "sourceHash" to detection.sourcePath.hashCode().toUInt().toString(16),
+                "authorityActive" to active,
+                "authorityStarting" to starting,
+                "confirmedBaselineCount" to it.confirmedMatchingIds.size,
+                "turnoverTimeoutMs" to AGENT_TRANSCRIPT_TURNOVER_TIMEOUT_MS,
+            )
+        }
+    }
+
+    fun timeoutMs(baseline: Baseline?): Long {
+        if (baseline != null) return AGENT_TRANSCRIPT_TURNOVER_TIMEOUT_MS
+        DiagnosticEvents.record(
+            "action",
+            "agent_submit_transcript_baseline",
+            "authorityActive" to false,
+            "authorityStarting" to false,
+            "confirmedBaselineCount" to 0,
+            "turnoverTimeoutMs" to AGENT_SUBMIT_TURNOVER_TIMEOUT_MS,
+        )
+        return AGENT_SUBMIT_TURNOVER_TIMEOUT_MS
+    }
+
+    fun isActive(paneId: String, detection: AgentDetection): Boolean {
+        val conversation = conversationForPane(paneId) ?: return false
+        if (conversation.detection != detection || conversation.syncStatus != AgentConversationSyncStatus.Live) {
+            return false
+        }
+        return paneId in activeOverrides || (tailJobActive(paneId) && tailGenerationPresent(paneId))
+    }
+
+    fun acknowledged(paneId: String, payload: String, baseline: Baseline): Boolean {
+        val conversation = conversationForPane(paneId) ?: return false
+        if (conversation.detection != baseline.detection || !isActive(paneId, baseline.detection)) return false
+        val confirmed = conversation.events.filterIsInstance<ConversationEvent.Message>().firstOrNull {
+            it.isConfirmedTranscriptUser(payload) && it.id !in baseline.confirmedMatchingIds
+        } ?: return false
+        DiagnosticEvents.record(
+            "action",
+            "agent_submit_transcript_ack",
+            "pane" to paneId,
+            "eventId" to confirmed.id,
+            "sourceHash" to baseline.detection.sourcePath.hashCode().toUInt().toString(16),
+            "agentSessionId" to baseline.detection.sessionId,
+            "agent" to baseline.detection.agent.name,
+        )
+        return true
+    }
+
+    suspend fun awaitTurnover(
+        identity: AgentSendRuntimeIdentity,
+        paneId: String,
+        payload: String,
+        preEnterFrame: CommandResponse,
+        baseline: Baseline?,
+        capture: suspend (timeoutMs: Long, scrollbackLines: Int) -> AgentPaneCaptureResult,
+        currentClientHash: () -> Int?,
+        currentGeneration: () -> Long,
+    ) {
+        awaitAgentSubmitTurnover(
+            identity = identity,
+            paneId = paneId,
+            payload = payload,
+            preEnterFrame = preEnterFrame,
+            timeoutMs = timeoutMs(baseline),
+            transcriptAuthorityPresent = { baseline?.let { isActive(paneId, it.detection) } == true },
+            transcriptAcknowledged = { baseline?.let { acknowledged(paneId, payload, it) } == true },
+            capture = capture,
+            currentClientHash = currentClientHash,
+            currentGeneration = currentGeneration,
+        )
+    }
+}
+
+private fun List<ConversationEvent>.confirmedUserIds(payload: String): Set<String> =
+    filterIsInstance<ConversationEvent.Message>()
+        .filter { it.isConfirmedTranscriptUser(payload) }
+        .mapTo(linkedSetOf()) { it.id }
+
+private fun ConversationEvent.Message.isConfirmedTranscriptUser(payload: String): Boolean =
+    role == ConversationRole.User &&
+        text == payload &&
+        sendState == com.pocketshell.core.agents.MessageSendState.Confirmed &&
+        !id.startsWith(OPTIMISTIC_USER_MESSAGE_ID_PREFIX)

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -101,6 +101,11 @@ internal data class DurableOutboundRowIdentity(
     }
 }
 
+internal fun durableAgentQueueSendMustDefer(
+    durableRow: DurableOutboundRowIdentity?,
+    transportWritable: Boolean,
+): Boolean = durableRow != null && !transportWritable
+
 /**
  * Composer-lane verify-before-resend gate: null when this (pane, payload) has no
  * ambiguous prior wire attempt (the common first-send case — no probe cost);
@@ -116,6 +121,23 @@ internal suspend fun verifyBeforeAgentResend(
     capturePane: OutboundPaneCapture? = null,
 ): DeliveryProbeOutcome? {
     if (!ledger.hasAmbiguousAttempt(paneId, sendToken, payload, durableRow)) return null
+    // Issue #1944: once Enter itself was attempted, the old payload-presence
+    // probe cannot distinguish "still typed" from "already submitted and shown
+    // in transcript". Either Enter-only or a fresh paste could duplicate/drop a
+    // turn, so fail closed and preserve the durable row for explicit recovery.
+    if (ledger.hasSubmitAttempt(paneId, sendToken, durableRow)) {
+        DiagnosticEvents.record(
+            "action",
+            "outbound_verify_before_resend",
+            "pane" to paneId,
+            "outcome" to DeliveryProbeOutcome.Unknown.name,
+            "reason" to "submit_attempt_unconfirmed",
+            "sendToken" to sendToken,
+            "durableSession" to (durableRow?.sessionKey ?: "none"),
+            "durableRowId" to (durableRow?.rowId ?: "none"),
+        )
+        return DeliveryProbeOutcome.Unknown
+    }
     // Issue #1577: compare the CURRENT needle count against the pre-send baseline
     // captured at the first wire attempt. `AlreadyLanded` requires the count to have
     // INCREASED (our paste actually added an occurrence) — so a payload that was
@@ -333,6 +355,7 @@ internal class OutboundDeliveryLedger(
     // so a VM-clear-rebuilt ledger reads it back (via [needleBaseline]).
     private val baselines = HashMap<String, Int>()
     private val collapsedMarkerBaselines = HashMap<String, Int>()
+    private val submitAttempts = HashSet<String>()
 
     // Issue #1529: the VOLATILE identity is the per-send-attempt token (pane + token),
     // NOT the payload. Two DISTINCT user sends of identical bytes get distinct tokens, so
@@ -368,6 +391,7 @@ internal class OutboundDeliveryLedger(
             entries.remove(evicted)
             baselines.remove(evicted)
             collapsedMarkerBaselines.remove(evicted)
+            submitAttempts.remove(evicted)
         }
         // Issue #1541: also persist on the durable row so the attempt survives a
         // VM-clear / back-navigation, not only this live VM. Issue #1577: the
@@ -391,6 +415,34 @@ internal class OutboundDeliveryLedger(
         entries.remove(key)
         baselines.remove(key)
         collapsedMarkerBaselines.remove(key)
+        submitAttempts.remove(key)
+    }
+
+    /**
+     * Issue #1944: Enter reached tmux, but agent-side turnover is still
+     * ambiguous. Persist before the Enter write so VM-clear/process death cannot
+     * turn that uncertainty into a blind second Enter.
+     */
+    fun recordSubmitAttempt(
+        paneId: String,
+        sendToken: String,
+        durableRow: DurableOutboundRowIdentity? = null,
+    ): Boolean = synchronized(lock) {
+        val durableAcknowledged = durableRow?.let { row ->
+            durable?.recordWireSubmitAttempt(row.sessionKey, row.rowId) == true
+        } ?: true
+        if (!durableAcknowledged) return false
+        submitAttempts += key(paneId, sendToken)
+        true
+    }
+
+    fun hasSubmitAttempt(
+        paneId: String,
+        sendToken: String,
+        durableRow: DurableOutboundRowIdentity? = null,
+    ): Boolean = synchronized(lock) {
+        key(paneId, sendToken) in submitAttempts ||
+            durableRow?.let { durable?.hasWireSubmitAttempt(it.sessionKey, it.rowId) } == true
     }
 
     fun hasAmbiguousAttempt(

--- a/app/src/main/java/com/pocketshell/app/tmux/RecordedAgentRouteEvidence.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/RecordedAgentRouteEvidence.kt
@@ -1,0 +1,108 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.uikit.model.SessionAgentKind
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal data class RecordedAgentRouteEvidence(
+    val durableSessionKey: String,
+    val paneId: String,
+    val agentKind: AgentKind,
+)
+
+internal fun retainRecordedAgentRouteEvidence(
+    existing: RecordedAgentRouteEvidence?,
+    durableSessionKey: String?,
+    paneId: String?,
+): RecordedAgentRouteEvidence? = existing?.takeIf {
+    durableSessionKey != null && paneId != null &&
+        it.durableSessionKey == durableSessionKey && it.paneId == paneId
+}
+
+internal fun recordedAgentRefreshStillCurrent(
+    requestToken: Int,
+    currentToken: Int,
+    requestedSessionKey: String?,
+    requestedPaneId: String?,
+    currentSessionKey: String?,
+    currentPaneId: String?,
+): Boolean = requestToken == currentToken &&
+    requestedSessionKey != null && requestedPaneId != null &&
+    requestedSessionKey == currentSessionKey && requestedPaneId == currentPaneId
+
+internal fun SessionAgentKind?.toRecordedAgentKindOrNull(): AgentKind? = when (this) {
+    SessionAgentKind.Claude -> AgentKind.ClaudeCode
+    SessionAgentKind.Codex -> AgentKind.Codex
+    SessionAgentKind.OpenCode -> AgentKind.OpenCode
+    SessionAgentKind.Shell,
+    SessionAgentKind.Probing,
+    SessionAgentKind.Exited,
+    SessionAgentKind.Unknown,
+    null -> null
+}
+
+internal data class RecordedAgentRouteRefresh(
+    val token: Int,
+    val durableSessionKey: String?,
+    val paneId: String?,
+)
+
+/** Correlates asynchronous option reads with one exact tmux generation/pane. */
+internal class RecordedAgentRouteTracker {
+    private val token = AtomicInteger(0)
+    private val mutableEvidence = MutableStateFlow<RecordedAgentRouteEvidence?>(null)
+    val evidence: StateFlow<RecordedAgentRouteEvidence?> = mutableEvidence.asStateFlow()
+
+    fun clear() {
+        token.incrementAndGet()
+        mutableEvidence.value = null
+    }
+
+    fun begin(durableSessionKey: String?, paneId: String?): RecordedAgentRouteRefresh {
+        mutableEvidence.value = retainRecordedAgentRouteEvidence(
+            mutableEvidence.value,
+            durableSessionKey,
+            paneId,
+        )
+        return RecordedAgentRouteRefresh(token.incrementAndGet(), durableSessionKey, paneId)
+    }
+
+    fun isCurrent(
+        request: RecordedAgentRouteRefresh,
+        durableSessionKey: String?,
+        paneId: String?,
+    ): Boolean = recordedAgentRefreshStillCurrent(
+        request.token,
+        token.get(),
+        request.durableSessionKey,
+        request.paneId,
+        durableSessionKey,
+        paneId,
+    )
+
+    fun isLatest(request: RecordedAgentRouteRefresh): Boolean = request.token == token.get()
+
+    fun accept(request: RecordedAgentRouteRefresh, kind: SessionAgentKind?) {
+        mutableEvidence.value = kind.toRecordedAgentKindOrNull()?.let { agentKind ->
+            RecordedAgentRouteEvidence(
+                durableSessionKey = requireNotNull(request.durableSessionKey),
+                paneId = requireNotNull(request.paneId),
+                agentKind = agentKind,
+            )
+        }
+    }
+}
+
+internal fun recordedRouteKey(
+    target: TmuxSessionViewModel.ConnectionTarget?,
+    pane: TmuxPaneState?,
+): String? = target?.let {
+    durableTmuxSessionKey(
+        it.hostId,
+        pane?.sessionId ?: it.tmuxSessionId,
+        pane?.sessionCreated ?: it.sessionCreated,
+    )
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxOutboundQueueBinding.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxOutboundQueueBinding.kt
@@ -1,0 +1,88 @@
+package com.pocketshell.app.tmux
+
+/** One canonical queue identity shared by badge, composer, promotion and drain. */
+internal data class TmuxOutboundQueueBinding(
+    val targetKey: String,
+    val fallbackKey: String,
+    val durableKey: String?,
+    val tmuxSessionId: String?,
+    val sessionCreated: Long?,
+    val generationPaneIds: Set<String>,
+)
+
+internal fun outboundGenerationSettled(sessionLive: Boolean, wireWritable: Boolean): Boolean =
+    sessionLive && wireWritable
+
+internal fun tmuxOutboundQueueBinding(
+    hostId: Long,
+    sessionName: String,
+    panes: List<TmuxPaneState>,
+    navigationTmuxSessionId: String?,
+    navigationSessionCreated: Long?,
+    generationSettled: Boolean,
+): TmuxOutboundQueueBinding {
+    val paneGeneration = panes.firstOrNull {
+        it.sessionId.isNotBlank() &&
+            it.sessionCreated != null &&
+            (navigationTmuxSessionId == null || it.sessionId == navigationTmuxSessionId) &&
+            (navigationSessionCreated == null || it.sessionCreated == navigationSessionCreated)
+    }
+    val sessionId = paneGeneration?.sessionId ?: navigationTmuxSessionId
+    val created = paneGeneration?.sessionCreated ?: navigationSessionCreated
+    // Navigation identity is enough to stamp the write-ahead row with exact
+    // generation evidence, but it is not enough to OWN the queue. Until a live
+    // pane row confirms that generation, badge/composer/drain stay on host/name;
+    // the screen effect promotes them atomically once this settles (#1944).
+    val durable = paneGeneration?.takeIf { generationSettled }?.let {
+        durableTmuxSessionKey(hostId, it.sessionId, it.sessionCreated)
+    }
+    val fallback = "$hostId/$sessionName"
+    val expectedId = sessionId?.trim()?.takeIf(String::isNotEmpty)
+    val paneIds = if (expectedId == null || created == null) {
+        emptySet()
+    } else {
+        panes.filter { it.sessionId == expectedId && it.sessionCreated == created }
+            .mapTo(linkedSetOf(), TmuxPaneState::paneId)
+    }
+    return TmuxOutboundQueueBinding(
+        targetKey = durable ?: fallback,
+        fallbackKey = fallback,
+        durableKey = durable,
+        tmuxSessionId = sessionId,
+        sessionCreated = created,
+        generationPaneIds = paneIds,
+    )
+}
+
+internal fun knownSessionNavigationTarget(
+    sessionName: String,
+    activeTarget: TmuxSessionViewModel.ConnectionTarget?,
+    connectingTarget: TmuxSessionViewModel.ConnectionTarget?,
+    runtimeCache: TmuxSessionRuntimeCache,
+): TmuxSessionNavigationTarget {
+    val direct = (activeTarget ?: connectingTarget)?.takeIf { it.sessionName == sessionName }
+    val durableKey = direct?.durableSessionKey() ?: activeTarget?.let { active ->
+        runtimeCache.cachedRuntimesForHost(active.hostId)
+            .firstOrNull { it.key.sessionName == sessionName }?.key?.durableSessionKey
+    }
+    val hostId = direct?.hostId ?: activeTarget?.hostId
+    val identity = hostId?.let { parseDurableTmuxSessionIdentity(it, durableKey) }
+    return TmuxSessionNavigationTarget(
+        sessionName,
+        identity?.tmuxSessionId,
+        identity?.sessionCreated,
+    )
+}
+
+internal fun knownPaneSessionNavigationTarget(
+    hostId: Long,
+    sessionName: String,
+    paneId: String,
+    runtimeCache: TmuxSessionRuntimeCache,
+): TmuxSessionNavigationTarget {
+    val identity = runtimeCache.cachedRuntimesForHost(hostId)
+        .firstOrNull { it.key.sessionName == sessionName && it.panes.any { pane -> pane.paneId == paneId } }
+        ?.key?.durableSessionKey
+        ?.let { parseDurableTmuxSessionIdentity(hostId, it) }
+    return TmuxSessionNavigationTarget(sessionName, identity?.tmuxSessionId, identity?.sessionCreated)
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneListingCommands.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneListingCommands.kt
@@ -73,7 +73,12 @@ internal fun buildTmuxPaneListingCommand(sessionName: String?): String = buildSt
     // `list-panes` reports it truthfully on every reconcile. Appended LAST so
     // older tmux that omit it leave every prior field's index unchanged (the
     // parser tolerates its absence -> alternateOn false).
-    append("#{alternate_on}'")
+    append("#{alternate_on}")
+    append(LIST_PANES_FIELD_SEPARATOR)
+    // Issue #1944: pane ids can be reused after a tmux server restart. Carry
+    // the tmux generation beside every pane so queued sends cannot be rebound
+    // to a same-name successor merely because its `%N` happens to match.
+    append("#{session_created}'")
 }
 
 private fun escapePaneListingSingleQuoted(input: String): String =

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneRows.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneRows.kt
@@ -49,6 +49,7 @@ internal fun parsePaneRow(line: String): TmuxSessionViewModel.ParsedPane? {
         // agent latch. Older tmux / legacy-format tests omit it -> false (no
         // latch), preserving the #894 no-flap invariant for a plain shell.
         alternateOn = parseTmuxBoolean(parts.getOrNull(paneIndexIndex + 6)),
+        sessionCreated = parts.getOrNull(paneIndexIndex + 7)?.trim()?.toLongOrNull(),
         sessionName = sessionName,
     )
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneState.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxPaneState.kt
@@ -51,6 +51,7 @@ public data class TmuxPaneState(
     val windowId: String,
     val windowIndex: Int? = null,
     val sessionId: String,
+    val sessionCreated: Long? = null,
     val title: String,
     val cwd: String = "",
     val currentCommand: String = "",

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxRevealController.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxRevealController.kt
@@ -8,6 +8,7 @@ import com.pocketshell.core.connection.RevealStateMachine
 import com.pocketshell.core.connection.Seed
 import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.connection.classifyFailure
+import com.pocketshell.core.connection.targetIdOrNull
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -67,6 +68,8 @@ internal class TmuxRevealController(
             tmuxSessionId = target.tmuxSessionId,
             sessionCreated = target.sessionCreated,
         )
+
+    fun currentTargetId(): SessionId? = state.value.targetIdOrNull()
 
     fun setSilentHealInFlight(value: Boolean) {
         revealStateMachine.setSilentHealInFlight(value)

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
@@ -176,7 +176,12 @@ internal fun TmuxTerminalBottomControls(
                         ConversationComposerLauncherRow(
                             onDictateTap = onDictateTap,
                             onDictateHoldSwipeUp = onDictateHoldSwipeUp,
-                            inputEnabled = sessionLive,
+                            // The composer is the durable offline-send entry point,
+                            // so reconnecting must disable only pane-bound controls,
+                            // never the launcher itself. Otherwise the first queued
+                            // send dismisses the sheet and there is no way to compose
+                            // another message until the transport heals (#1944).
+                            inputEnabled = true,
                             unsentCount = unsentCount,
                             unsentHasFailure = unsentHasFailure,
                             modifier = modifier,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionDrawer.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionDrawer.kt
@@ -57,7 +57,7 @@ internal fun TmuxSessionDrawer(
     currentSessionName: String,
     onRefresh: () -> Unit,
     onDismiss: () -> Unit,
-    onAttach: (String) -> Unit,
+    onAttach: (TmuxSessionNavigationTarget) -> Unit,
     onCreate: () -> Unit,
 ) {
     AnimatedVisibility(
@@ -184,8 +184,8 @@ internal fun TmuxSessionDrawer(
                                 TmuxSessionDrawerRow(
                                     row = row,
                                     selected = row.name == currentSessionName,
-                                    enabled = row.name != currentSessionName,
-                                    onClick = { onAttach(row.name) },
+                                    enabled = row.name != currentSessionName && row.navigationTargetOrNull() != null,
+                                    onClick = { row.navigationTargetOrNull()?.let(onAttach) },
                                 )
                             }
                         }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionIdentity.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionIdentity.kt
@@ -1,6 +1,25 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.core.connection.SessionId
+
+internal data class DurableTmuxSessionIdentity(
+    val tmuxSessionId: String,
+    val sessionCreated: Long,
+)
+
+/** Correlated navigation payload; identity travels with the user action. */
+public data class TmuxSessionNavigationTarget(
+    val sessionName: String,
+    val tmuxSessionId: String? = null,
+    val sessionCreated: Long? = null,
+)
+
+internal fun HostTmuxSessionRow.navigationTargetOrNull(): TmuxSessionNavigationTarget? {
+    val id = tmuxSessionId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val created = createdAt?.takeIf { it > 0L } ?: return null
+    return TmuxSessionNavigationTarget(name, id, created)
+}
 
 internal fun durableTmuxSessionKey(
     hostId: Long,
@@ -19,6 +38,20 @@ internal fun tmuxTargetSessionId(
     sessionCreated: Long?,
 ): SessionId =
     SessionId(durableTmuxSessionKey(hostId, tmuxSessionId, sessionCreated) ?: "$hostId/$sessionName")
+
+internal fun parseDurableTmuxSessionIdentity(
+    hostId: Long,
+    durableSessionKey: String?,
+): DurableTmuxSessionIdentity? {
+    val body = durableSessionKey?.removePrefix("tmux:$hostId:")
+        ?.takeIf { it != durableSessionKey }
+        ?: return null
+    val separator = body.lastIndexOf(':')
+    if (separator <= 0 || separator == body.lastIndex) return null
+    val id = body.substring(0, separator).trim().takeIf { it.isNotEmpty() } ?: return null
+    val created = body.substring(separator + 1).toLongOrNull()?.takeIf { it > 0L } ?: return null
+    return DurableTmuxSessionIdentity(id, created)
+}
 
 internal fun sessionCardsTargetKey(
     hostId: Long,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionOverlays.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionOverlays.kt
@@ -179,7 +179,7 @@ internal fun SessionSwitcherOverlay(
     currentSessionName: String,
     onRefresh: () -> Unit,
     onDismiss: () -> Unit,
-    onSelectSession: (String) -> Unit,
+    onSelectSession: (TmuxSessionNavigationTarget) -> Unit,
     onCreate: () -> Unit,
 ) {
     val pages = remember(state, currentSessionName) {
@@ -200,7 +200,7 @@ internal fun SessionSwitcherOverlay(
         snapshotFlow { pagerState.settledPage }.collect { page ->
             val session = pages.getOrNull(page) ?: return@collect
             if (session.name != currentSessionName && session.selectable) {
-                onSelectSession(session.name)
+                session.target?.let(onSelectSession)
             }
         }
     }
@@ -285,7 +285,7 @@ internal fun SessionSwitcherOverlay(
                             .clickable(
                                 enabled = session.selectable,
                                 role = androidx.compose.ui.semantics.Role.Tab,
-                                onClick = { onSelectSession(session.name) },
+                                onClick = { session.target?.let(onSelectSession) },
                             )
                             .padding(16.dp)
                             .testTag("$TMUX_SESSION_PAGER_PAGE_TAG_PREFIX${page + 1}"),
@@ -328,4 +328,5 @@ internal data class SessionSwitcherPage(
     val name: String,
     val statusLabel: String,
     val selectable: Boolean,
+    val target: TmuxSessionNavigationTarget? = null,
 )

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -50,6 +50,8 @@ import com.pocketshell.app.conversation.ConversationImageViewModel
 import com.pocketshell.app.conversation.LocalConversationImageLoader
 import com.pocketshell.app.conversation.rememberConversationToTerminalSwapLatch
 import com.pocketshell.app.composer.PromptComposerViewModel
+import com.pocketshell.app.composer.outboundLauncherBadge
+import com.pocketshell.app.composer.promoteFallbackOutboundIdentity
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.layout.rememberTmuxImeLayoutState
 import com.pocketshell.app.projects.conventionalRemoteHome
@@ -68,6 +70,7 @@ import com.pocketshell.app.session.conversationTapTarget
 import com.pocketshell.app.session.cwdForDetectedFilePath
 import com.pocketshell.app.sessions.HostTmuxSessionPickerRequest
 import com.pocketshell.app.sessions.HostTmuxSessionPickerState
+import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
 import com.pocketshell.app.cards.SessionCardFeedChip
 import com.pocketshell.app.cards.SessionCardInteractions
@@ -149,7 +152,7 @@ public fun TmuxSessionScreen(
     // Issue #666: the (re)attached session no longer exists on the server.
     onSessionEnded: (sessionName: String) -> Unit = { onBack() },
     onOpenTmuxSession: (sessionName: String, startDirectory: String?) -> Unit = { _, _ -> },
-    onReplaceTmuxSession: (sessionName: String) -> Unit = {},
+    onReplaceTmuxSession: (target: TmuxSessionNavigationTarget) -> Unit = {},
     onOpenJobs: () -> Unit = {},
     onOpenUsage: () -> Unit = {},
     onOpenSettings: () -> Unit = {},
@@ -209,6 +212,7 @@ public fun TmuxSessionScreen(
     val panesSel = rememberTmuxSessionPaneSelection(conn, viewModel, pagerState)
     // Epic #821 Slice 1: the active session's RECORDED `@ps_agent_kind`.
     val currentSessionRecordedKind by viewModel.currentSessionRecordedKind.collectAsState()
+    val recordedAgentRouteEvidence by viewModel.currentRecordedAgentRouteEvidence.collectAsState()
     // Issue #1085 (freeze F3 / R2): held as a `State<Map<...>>` (NOT a delegated
     // `by` read) so the screen root is never subscribed to the 60ms flush; the
     // high-frequency `events` list is read only inside `surfaceContent`.
@@ -221,6 +225,8 @@ public fun TmuxSessionScreen(
         panes = panesSel,
         agentConversationsState = agentConversationsState,
         currentSessionRecordedKind = currentSessionRecordedKind,
+        hostId = hostId,
+        recordedAgentRouteEvidence = recordedAgentRouteEvidence,
     )
     // Issue #145: gate the in-session Reconnect on whether the VM has a target.
     val canReconnect by viewModel.canReconnect.collectAsState()
@@ -232,8 +238,27 @@ public fun TmuxSessionScreen(
             emptyList()
         }
     }
-    // #1531 (RC1): DOCKED launcher unsent badge.
-    val outboundLauncherBadge = rememberOutboundLauncherBadge(promptComposerViewModel, conn.targetSessionId.value)
+    val outboundGenerationIsSettled = outboundGenerationSettled(
+        sessionLive = conn.sessionLive,
+        wireWritable = viewModel.isSendTransportWritable(),
+    )
+    val outboundQueueBinding = remember(
+        hostId, sessionName, conn.panes, tmuxSessionId, sessionCreated, outboundGenerationIsSettled,
+    ) {
+        tmuxOutboundQueueBinding(
+            hostId,
+            sessionName,
+            conn.panes,
+            tmuxSessionId,
+            sessionCreated,
+            outboundGenerationIsSettled,
+        )
+    }
+    // #1531/#1944: badge and every composer consumer share one canonical key.
+    val outboundLauncherBadge = rememberOutboundLauncherBadge(
+        promptComposerViewModel,
+        outboundQueueBinding.targetKey,
+    )
     // Issue #1158: the Terminal/Conversation tab state derived in its OWN frame.
     val tabState by rememberTmuxSessionTabState(
         viewModel = viewModel,
@@ -305,6 +330,7 @@ public fun TmuxSessionScreen(
         inlineDictationViewModel = inlineDictationViewModel,
         conn = conn,
         panesSel = panesSel,
+        outboundQueueBinding = outboundQueueBinding,
         overlay = overlay,
         pagerState = pagerState,
         unifiedPager = unifiedPager,
@@ -465,6 +491,7 @@ public fun TmuxSessionScreen(
         overlay = overlay,
         sessionCards = sessionCards,
         hostId = hostId,
+        outboundQueueBinding = outboundQueueBinding,
         onTuiCommandNoticeChange = { tuiCommandNotice = it },
         showCardFeedSheet = showCardFeedSheet,
         onShowCardFeedSheet = { showCardFeedSheet = it },
@@ -512,6 +539,7 @@ private fun TmuxSessionScreenEffects(
     inlineDictationViewModel: InlineDictationViewModel,
     conn: TmuxSessionConnectionRuntime,
     panesSel: TmuxSessionPaneSelection,
+    outboundQueueBinding: TmuxOutboundQueueBinding,
     overlay: TmuxSessionOverlayState,
     pagerState: PagerState,
     unifiedPager: UnifiedPagerModel,
@@ -541,7 +569,7 @@ private fun TmuxSessionScreenEffects(
     initialComposerPrompt: String,
     onInitialComposerPromptConsumed: () -> Unit,
     onAssistantNavigate: (com.pocketshell.app.nav.AppDestination) -> Unit,
-    onReplaceTmuxSession: (sessionName: String) -> Unit,
+    onReplaceTmuxSession: (target: TmuxSessionNavigationTarget) -> Unit,
     onSessionEnded: (sessionName: String) -> Unit,
     onBack: () -> Unit,
 ) {
@@ -603,15 +631,42 @@ private fun TmuxSessionScreenEffects(
         )
     }
 
-    val outboundQueueAutoFlushController = remember(targetSessionId.value, promptComposerViewModel) {
+    val queueTargetSessionKey = outboundQueueBinding.targetKey
+    val outboundQueueAutoFlushController = remember(queueTargetSessionKey, promptComposerViewModel) {
         // #1635-A (D4): `boundTo` BINDS the retry budget to this screen's delivery
         // window, so a send that failed with the window closed burns zero attempts. It
         // reads the budget off the composer itself — the screen never names a tracker —
         // so the wiring can be neither dropped nor misdirected.
         OutboundQueueAutoFlushController.boundTo(promptComposerViewModel)
     }
-    LaunchedEffect(targetSessionId.value) {
-        promptComposerViewModel.onComposerTargetChanged(targetSessionId.value)
+    LaunchedEffect(queueTargetSessionKey) {
+        promptComposerViewModel.onComposerTargetChanged(queueTargetSessionKey)
+    }
+    LaunchedEffect(outboundQueueBinding) {
+        val durableKey = outboundQueueBinding.durableKey ?: return@LaunchedEffect
+        if (outboundQueueBinding.generationPaneIds.isEmpty()) return@LaunchedEffect
+        val promotedRows = promptComposerViewModel.promoteFallbackOutboundIdentity(
+            fallbackSessionKey = outboundQueueBinding.fallbackKey,
+            durableSessionKey = durableKey,
+            livePaneIds = outboundQueueBinding.generationPaneIds,
+            tmuxSessionId = outboundQueueBinding.tmuxSessionId ?: return@LaunchedEffect,
+            tmuxSessionCreated = outboundQueueBinding.sessionCreated ?: return@LaunchedEffect,
+        )
+        // Refresh even when another owner already completed the idempotent
+        // promotion between composition and this effect.
+        promptComposerViewModel.onComposerTargetChanged(durableKey)
+        requestOutboundDrainAfterPromotion(
+            promotedRows = promotedRows,
+            drainGateOpen = sessionLive || viewModel.isSendTransportWritable(),
+            controller = outboundQueueAutoFlushController,
+            hasPendingWork = {
+                promptComposerViewModel.outboundQueueItems.value
+                    .outboundLauncherBadge(durableKey) != null
+            },
+            retryNext = { excludingIds ->
+                promptComposerViewModel.retryNextOutboundItem(excludingIds)
+            },
+        )
     }
     DisposableEffect(promptComposerViewModel, viewModel) {
         promptComposerViewModel.setOutboundAttachmentSidecarUploader { refs ->
@@ -625,11 +680,11 @@ private fun TmuxSessionScreenEffects(
             promptComposerViewModel.setTransportWritableProbe { false }
         }
     }
-    LaunchedEffect(sessionLive, targetSessionId.value) {
+    LaunchedEffect(sessionLive, queueTargetSessionKey) {
         promptComposerViewModel.setConnectionDegraded(!sessionLive)
         outboundQueueAutoFlushController.onConnectionWindowChanged(
             sessionLive = sessionLive,
-            targetSessionId = targetSessionId.value,
+            targetSessionId = queueTargetSessionKey,
             connectionStatusLabel = connectionStatusDiagnosticLabel(conn.rawStatus), // #1682
         ) {
             promptComposerViewModel.requeueStaleOutboundInFlight()
@@ -640,7 +695,7 @@ private fun TmuxSessionScreenEffects(
     }
     TmuxOutboundQueueAutoFlushEffect(
         sessionLive = sessionLive,
-        targetSessionKey = targetSessionId.value,
+        targetSessionKey = queueTargetSessionKey,
         promptComposerViewModel = promptComposerViewModel,
         controller = outboundQueueAutoFlushController,
         transportWritable = { viewModel.isSendTransportWritable() }, // #1686
@@ -826,7 +881,7 @@ private fun TmuxSessionHeaderRegion(
     onOpenSettings: () -> Unit,
     onOpenPortForwarding: () -> Unit,
     onBrowseFiles: (startDir: String) -> Unit,
-    onReplaceTmuxSession: (sessionName: String) -> Unit,
+    onReplaceTmuxSession: (target: TmuxSessionNavigationTarget) -> Unit,
 ) {
     val terminalHeld = conn.terminalHeld
     val surfaceState = conn.surfaceState
@@ -1008,12 +1063,14 @@ private fun TmuxSessionHeaderRegion(
                         )
                     },
                     onSwitchToSibling = { selected ->
-                        handleTmuxSessionSelection(
-                            currentSessionName = sessionName,
-                            selectedSessionName = selected,
-                            onDismiss = {},
-                            onReplace = onReplaceTmuxSession,
-                        )
+                        selected.navigationTargetOrNull()?.let { target ->
+                            handleTmuxSessionSelection(
+                                currentSessionName = sessionName,
+                                selectedTarget = target,
+                                onDismiss = {},
+                                onReplace = onReplaceTmuxSession,
+                            )
+                        }
                     },
                     connectionStatus = surfaceState.toUiStatus(),
                     forwardingState = sessionForwardingState,
@@ -1617,7 +1674,7 @@ private fun BoxScope.TmuxSessionOverlaysRegion(
     openNewSessionSheet: () -> Unit,
     onOpenFile: (path: String, cwd: String?) -> Unit,
     onOpenTmuxSession: (sessionName: String, startDirectory: String?) -> Unit,
-    onReplaceTmuxSession: (sessionName: String) -> Unit,
+    onReplaceTmuxSession: (target: TmuxSessionNavigationTarget) -> Unit,
     onBack: () -> Unit,
     onOpenPortForwardingWithPort: (remotePort: Int, autoOpenLocalhostUrl: LocalhostUrl?) -> Unit,
 ) {
@@ -1640,7 +1697,12 @@ private fun BoxScope.TmuxSessionOverlaysRegion(
                     TmuxDialogMode.RenameSession -> {
                         val name = overlay.dialogText.trim()
                         viewModel.renameCurrentSession(name)
-                        if (name.isNotEmpty()) onReplaceTmuxSession(name)
+                        if (name.isNotEmpty()) {
+                            val activeIdentity = currentPane?.let { pane ->
+                                TmuxSessionNavigationTarget(name, pane.sessionId, pane.sessionCreated)
+                            } ?: viewModel.navigationTargetForKnownSession(name)
+                            onReplaceTmuxSession(activeIdentity)
+                        }
                     }
                     TmuxDialogMode.StopSession -> {
                         viewModel.killCurrentSession(currentPane?.windowIndex)
@@ -1725,10 +1787,10 @@ private fun BoxScope.TmuxSessionOverlaysRegion(
             overlay.showSessionSwitcher = false
             sessionPickerViewModel.dismiss()
         },
-        onSelectSession = { selectedSessionName ->
+        onSelectSession = { selectedTarget ->
             handleTmuxSessionSelection(
                 currentSessionName = sessionName,
-                selectedSessionName = selectedSessionName,
+                selectedTarget = selectedTarget,
                 onDismiss = {
                     overlay.showSessionSwitcher = false
                     sessionPickerViewModel.dismiss()
@@ -1752,10 +1814,10 @@ private fun BoxScope.TmuxSessionOverlaysRegion(
             overlay.showSessionDrawer = false
             sessionPickerViewModel.dismiss()
         },
-        onAttach = { selectedSessionName ->
+        onAttach = { selectedTarget ->
             handleTmuxSessionSelection(
                 currentSessionName = sessionName,
-                selectedSessionName = selectedSessionName,
+                selectedTarget = selectedTarget,
                 onDismiss = {
                     overlay.showSessionDrawer = false
                     sessionPickerViewModel.dismiss()
@@ -1816,6 +1878,7 @@ private fun TmuxSessionSheetsRegion(
     overlay: TmuxSessionOverlayState,
     sessionCards: List<com.pocketshell.app.cards.SessionCardsRemoteSource.SessionCard>,
     hostId: Long,
+    outboundQueueBinding: TmuxOutboundQueueBinding,
     onTuiCommandNoticeChange: (String?) -> Unit,
     showCardFeedSheet: Boolean,
     onShowCardFeedSheet: (Boolean) -> Unit,
@@ -1827,7 +1890,7 @@ private fun TmuxSessionSheetsRegion(
     val currentSelectedTab = agent.currentSelectedTab
     val paletteAgent = agent.paletteAgent
     val presumedAgentKind = agent.presumedAgentKind
-
+    val composerQueueSessionKey = outboundQueueBinding.targetKey
     val sessionCardInteractions = remember(viewModel) {
         object : SessionCardInteractions {
             override fun onToggleChecklistItem(cardId: String, itemId: String, checked: Boolean) {
@@ -1845,7 +1908,7 @@ private fun TmuxSessionSheetsRegion(
     val composerSendHandler: suspend (PromptComposerViewModel.SendRequest) -> Boolean = { request ->
         tmuxComposerSendResult(
             request = request,
-            targetSessionId = targetSessionId.value,
+            targetSessionId = composerQueueSessionKey,
             fallbackPaneId = surfacePane?.paneId.orEmpty(),
             sendAgentPayload = { paneId, text, agentKind, sendToken, durableRow ->
                 viewModel.sendAgentPayloadToPaneResult(
@@ -1888,7 +1951,7 @@ private fun TmuxSessionSheetsRegion(
         showMicSheet = overlay.showMicSheet,
         promptComposerViewModel = promptComposerViewModel,
         composerAgentKind = paletteAgent ?: presumedAgentKind,
-        composerTargetKey = targetSessionId.value,
+        composerTargetKey = composerQueueSessionKey,
         micSheetAutoStartRecording = overlay.micSheetAutoStartRecording,
         onDismissMicSheet = {
             overlay.showMicSheet = false
@@ -1898,20 +1961,70 @@ private fun TmuxSessionSheetsRegion(
         sendTargetSnapshotProvider = { withEnter ->
             val pane = surfacePane
             val liveAgent = currentDetection?.agent
+            // Read the liveness + durable host verdict at the instant Send is
+            // tapped. An already-open sheet can legitimately retain an older
+            // composition lambda across the disconnect recomposition boundary;
+            // queue routing must not snapshot that stale `sessionLive=true`.
+            val transportWritableNow = viewModel.isSendTransportWritable()
+            val latestRecordedEvidence = viewModel.currentRecordedAgentRouteEvidence.value
+            val evidenceDurableKey = durableTmuxSessionKey(
+                hostId,
+                outboundQueueBinding.tmuxSessionId,
+                outboundQueueBinding.sessionCreated,
+            )
+            val snapshotPaneId = tmuxComposerPaneIdForSnapshot(
+                surfacePaneId = pane?.paneId,
+                recordedEvidence = latestRecordedEvidence,
+                durableSessionKey = evidenceDurableKey ?: composerQueueSessionKey,
+            )
+            val disconnectedAgentKindNow = tmuxDisconnectedAgentKind(
+                currentDetection = currentDetection,
+                recordedEvidence = latestRecordedEvidence,
+                durableSessionKey = evidenceDurableKey ?: composerQueueSessionKey,
+                paneId = snapshotPaneId,
+            )
             val viewingConversationNow = currentDetection != null &&
                 currentSelectedTab == SessionTab.Conversation
-            val route = tmuxComposerSendRoute(
+            // Issue #1944: the Conversation row/tab can disappear with the
+            // transport while its exact-pane agent identity remains known.
+            // Snapshot a durable agent payload route for the queued row; do
+            // not let the live-Terminal RawBytes compatibility branch
+            // reinterpret a dictated prompt after reconnect.
+            val route = tmuxComposerSendRouteForConnection(
+                sessionLive = transportWritableNow,
+                disconnectedAgentKind = disconnectedAgentKindNow,
                 viewingConversation = viewingConversationNow,
                 liveAgent = liveAgent,
                 presumedAgentKind = presumedAgentKind,
                 withEnter = withEnter,
             )
-            tmuxComposerSendTargetSnapshot(
-                sessionKey = targetSessionId.value,
-                paneId = pane?.paneId,
-                route = route,
-                agentKind = liveAgent ?: presumedAgentKind,
+            DiagnosticEvents.record(
+                "action",
+                "composer_send_snapshot",
+                "composedSessionLive" to sessionLive,
+                "transportWritableNow" to transportWritableNow,
+                "sessionKey" to composerQueueSessionKey,
+                "surfacePaneId" to (pane?.paneId ?: "none"),
+                "snapshotPaneId" to (snapshotPaneId ?: "none"),
+                "evidenceSessionKey" to (latestRecordedEvidence?.durableSessionKey ?: "none"),
+                "evidencePaneId" to (latestRecordedEvidence?.paneId ?: "none"),
+                "evidenceAgentKind" to (latestRecordedEvidence?.agentKind?.name ?: "none"),
+                "detectionAgentKind" to (liveAgent?.name ?: "none"),
+                "route" to route.name,
             )
+            val currentTarget = tmuxComposerSendTargetSnapshot(
+                sessionKey = composerQueueSessionKey,
+                paneId = snapshotPaneId,
+                tmuxSessionId = pane?.sessionId ?: outboundQueueBinding.tmuxSessionId,
+                tmuxSessionCreated = pane?.sessionCreated ?: outboundQueueBinding.sessionCreated,
+                route = route,
+                agentKind = if (!transportWritableNow) {
+                    disconnectedAgentKindNow
+                } else {
+                    liveAgent ?: presumedAgentKind
+                },
+            )
+            currentTarget
         },
         onSend = composerSendHandler,
         composerHostId = hostId.takeIf { it != 0L },

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.tmux
 import com.pocketshell.app.agentcommands.AgentCommandCatalog
 import com.pocketshell.app.composer.OutboundRoute
 import com.pocketshell.app.composer.PromptComposerViewModel
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.session.AgentConversationUiState
 import com.pocketshell.app.session.ConversationLoadState
 import com.pocketshell.app.session.SessionTab
@@ -502,6 +503,19 @@ internal fun tmuxComposerSendRoute(
     else -> TmuxComposerSendRoute.RawBytes
 }
 
+internal fun tmuxComposerSendRouteForConnection(
+    sessionLive: Boolean,
+    disconnectedAgentKind: AgentKind?,
+    viewingConversation: Boolean,
+    liveAgent: AgentKind?,
+    presumedAgentKind: AgentKind?,
+    withEnter: Boolean,
+): TmuxComposerSendRoute = if (!sessionLive && disconnectedAgentKind != null) {
+    TmuxComposerSendRoute.AgentPayload
+} else {
+    tmuxComposerSendRoute(viewingConversation, liveAgent, presumedAgentKind, withEnter)
+}
+
 /**
  * Issue #1584: extract the leading `/word` command ROOT from [text], or `null`
  * when [text] is not a well-formed slash-command token. The grammar is
@@ -644,6 +658,16 @@ internal suspend fun tmuxComposerSendResult(
             rowId = rowId,
         )
     }
+    DiagnosticEvents.record(
+        "action",
+        "composer_tmux_send_route",
+        "route" to target.route.name,
+        "rowId" to (request.outboundQueueItemId ?: "none"),
+        "panePresent" to paneId.isNotBlank(),
+        "agentKind" to (target.agentKind ?: "none"),
+        "sessionKey" to target.sessionKey,
+        "paneId" to paneId,
+    )
     return when (target.route) {
         OutboundRoute.AgentConversation ->
             tmuxAgentConversationSendResult(
@@ -713,23 +737,27 @@ internal fun tmuxComposerAgentKindFromToken(token: String?): AgentKind? = when (
 internal fun tmuxComposerSendTargetSnapshot(
     sessionKey: String,
     paneId: String?,
+    tmuxSessionId: String? = null,
+    tmuxSessionCreated: Long? = null,
     route: TmuxComposerSendRoute,
     agentKind: AgentKind?,
 ): PromptComposerViewModel.SendTargetSnapshot =
     PromptComposerViewModel.SendTargetSnapshot(
         sessionKey = sessionKey,
         paneId = paneId.orEmpty(),
+        tmuxSessionId = tmuxSessionId,
+        tmuxSessionCreated = tmuxSessionCreated,
         route = tmuxComposerOutboundRoute(route),
         agentKind = tmuxComposerAgentToken(agentKind),
     )
 
 internal fun handleTmuxSessionSelection(
     currentSessionName: String,
-    selectedSessionName: String,
+    selectedTarget: TmuxSessionNavigationTarget,
     onDismiss: () -> Unit,
-    onReplace: (String) -> Unit,
+    onReplace: (TmuxSessionNavigationTarget) -> Unit,
 ) {
-    if (selectedSessionName == currentSessionName) return
+    if (selectedTarget.sessionName == currentSessionName) return
     onDismiss()
-    onReplace(selectedSessionName)
+    onReplace(selectedTarget)
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
@@ -208,6 +208,49 @@ internal class TmuxSessionAgentSignals(
     val quickReplyInputEligible: Boolean,
 )
 
+internal fun tmuxPresumedAgentKind(
+    currentDetection: AgentDetection?,
+    paletteAgent: AgentKind?,
+    recordedEvidence: RecordedAgentRouteEvidence?,
+    durableSessionKey: String?,
+    paneId: String?,
+): AgentKind? = when {
+    currentDetection != null -> null
+    paletteAgent != null -> paletteAgent
+    durableSessionKey != null &&
+        paneId != null &&
+        recordedEvidence?.durableSessionKey == durableSessionKey &&
+        recordedEvidence.paneId == paneId -> recordedEvidence.agentKind
+    else -> null
+}
+
+internal fun tmuxDisconnectedAgentKind(
+    currentDetection: AgentDetection?,
+    recordedEvidence: RecordedAgentRouteEvidence?,
+    durableSessionKey: String?,
+    paneId: String?,
+): AgentKind? {
+    val exactRecorded = recordedEvidence?.takeIf {
+        durableSessionKey != null &&
+            paneId != null &&
+            recordedEvidence.durableSessionKey == durableSessionKey &&
+            recordedEvidence.paneId == paneId
+    } ?: return null
+    // Detection rows are pane-id keyed and carry no tmux generation. They may
+    // choose the engine only after authoritative evidence proves that this is
+    // still the exact durable session+pane, never on pane id alone.
+    return currentDetection?.agent ?: exactRecorded.agentKind
+}
+
+internal fun tmuxComposerPaneIdForSnapshot(
+    surfacePaneId: String?,
+    recordedEvidence: RecordedAgentRouteEvidence?,
+    durableSessionKey: String,
+): String? = surfacePaneId?.takeIf { it.isNotBlank() }
+    ?: recordedEvidence?.paneId?.takeIf {
+        it.isNotBlank() && recordedEvidence.durableSessionKey == durableSessionKey
+    }
+
 @Composable
 internal fun rememberTmuxSessionAgentSignals(
     viewModel: TmuxSessionViewModel,
@@ -215,6 +258,8 @@ internal fun rememberTmuxSessionAgentSignals(
     panes: TmuxSessionPaneSelection,
     agentConversationsState: State<Map<String, AgentConversationUiState>>,
     currentSessionRecordedKind: SessionAgentKind?,
+    hostId: Long,
+    recordedAgentRouteEvidence: RecordedAgentRouteEvidence?,
 ): TmuxSessionAgentSignals {
     val surfaceConversationPaneId = panes.surfaceConversationPaneId
     val surfacePane = panes.surfacePane
@@ -273,11 +318,29 @@ internal fun rememberTmuxSessionAgentSignals(
             stickyAgent = paletteAgent,
             confirmedShell = surfacePane.paneId in confirmedShellPaneIds,
         )
-    val presumedAgentKind: AgentKind? = if (currentDetection == null) {
-        paletteAgent
-    } else {
-        null
-    }
+    // Issue #1944: the conversation row and composition-local sticky map can
+    // both disappear during a reconnect boundary while the composer remains
+    // usable. The host-recorded kind is authoritative for this exact active
+    // tmux generation and keeps a disconnected dictation on AgentPayload
+    // instead of silently downgrading it to RawBytes.
+    // During a transport outage the cached surface row may temporarily lose
+    // its generation fields even though the navigation/reveal target still
+    // owns the exact durable identity. Prefer that target identity; never
+    // synthesize evidence from the human session name.
+    val recordedEvidenceSessionKey = conn.targetSessionId.value.takeIf {
+        parseDurableTmuxSessionIdentity(hostId, it) != null
+    } ?: durableTmuxSessionKey(
+        hostId = hostId,
+        tmuxSessionId = surfacePane?.sessionId,
+        sessionCreated = surfacePane?.sessionCreated,
+    )
+    val presumedAgentKind = tmuxPresumedAgentKind(
+        currentDetection = currentDetection,
+        paletteAgent = paletteAgent,
+        recordedEvidence = recordedAgentRouteEvidence,
+        durableSessionKey = recordedEvidenceSessionKey,
+        paneId = surfacePane?.paneId,
+    )
     return TmuxSessionAgentSignals(
         surfaceChrome = surfaceChrome,
         currentDetection = currentDetection,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenStateHelpers.kt
@@ -11,6 +11,7 @@ import com.pocketshell.app.composer.ComposerQueueDiagnostics
 import com.pocketshell.app.composer.OutboundAttemptBudgetTracker
 import com.pocketshell.app.composer.OutboundDeliveryWindow
 import com.pocketshell.app.composer.OutboundLauncherBadge
+import com.pocketshell.app.composer.OutboundItem
 import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.composer.outboundLauncherBadge
 import com.pocketshell.app.session.AgentConversationUiState
@@ -135,6 +136,18 @@ internal fun rememberOutboundLauncherBadge(
 ): OutboundLauncherBadge? {
     val items by promptComposerViewModel.outboundQueueItems.collectAsState()
     return remember(items, targetSessionKey) { items.outboundLauncherBadge(targetSessionKey) }
+}
+
+/** Close the promotion-before-snapshot race through the canonical drain owner. */
+internal fun requestOutboundDrainAfterPromotion(
+    promotedRows: List<OutboundItem>,
+    drainGateOpen: Boolean,
+    controller: OutboundQueueAutoFlushController,
+    hasPendingWork: () -> Boolean,
+    retryNext: (excludingIds: Set<String>) -> String?,
+): String? {
+    if (promotedRows.isEmpty()) return null
+    return controller.onQueueSnapshotChanged(drainGateOpen, hasPendingWork, retryNext)
 }
 
 @Composable
@@ -529,18 +542,21 @@ internal fun sessionSwitcherPages(
         -> listOf(current.copy(statusLabel = "loading same-host sessions"))
         is HostTmuxSessionPickerState.Ready -> {
             val rows = state.rows.map { row ->
+                val target = row.navigationTargetOrNull()
                 SessionSwitcherPage(
                     name = row.name,
                     statusLabel = when {
                         row.name == currentSessionName -> "current"
                         row.attached -> "attached"
+                        target == null -> "identity unavailable"
                         else -> "available"
                     },
-                    selectable = true,
+                    selectable = target != null,
+                    target = target,
                 )
             }
             val currentPage = rows.firstOrNull { it.name == currentSessionName }
-                ?.copy(statusLabel = "current", selectable = false)
+                ?.copy(statusLabel = "current", selectable = false, target = null)
                 ?: current
             listOf(currentPage) + rows.filterNot { it.name == currentSessionName }
         }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -9,6 +9,7 @@ import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.connection.ConnectionState
 import com.pocketshell.core.connection.LivenessProbe
+import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.terminal.input.BracketedPaste
@@ -1287,6 +1288,52 @@ internal val TmuxConnectTrigger.isReconnectTrigger: Boolean
         TmuxConnectTrigger.FastSwitch,
         -> false
     }
+
+/** Test-only outage contract consumed by the VM dial boundary. */
+internal fun syntheticUnrecoverableHostRejectsDial(
+    armed: Boolean,
+    trigger: TmuxConnectTrigger,
+): Boolean {
+    if (!armed) return false
+    return when (trigger) {
+        TmuxConnectTrigger.UserTap,
+        TmuxConnectTrigger.OpenExisting,
+        TmuxConnectTrigger.LifecycleReattach,
+        TmuxConnectTrigger.ColdRestore,
+        TmuxConnectTrigger.FastSwitch,
+        TmuxConnectTrigger.Reconnect,
+        TmuxConnectTrigger.AutoReconnect,
+        TmuxConnectTrigger.NetworkReconnect,
+        -> true
+    }
+}
+
+/** Test-only gate: an armed total outage may not reuse any warm transport. */
+internal fun syntheticUnrecoverableHostAllowsTransportReuse(armed: Boolean): Boolean = !armed
+
+internal fun acceptedRestoreTargetIsCurrent(
+    intentGeneration: Long,
+    currentGeneration: Long,
+    intentTargetId: SessionId,
+    displayedTargetId: SessionId?,
+): Boolean = intentGeneration == currentGeneration && intentTargetId == displayedTargetId
+
+internal fun TmuxSessionViewModel.connectAcceptedNetworkRestore(target: ConnectionTarget) {
+    connect(
+        hostId = target.hostId,
+        hostName = target.hostName,
+        host = target.host,
+        port = target.port,
+        user = target.user,
+        keyPath = target.keyPath,
+        passphrase = target.passphrase,
+        sessionName = target.sessionName,
+        startDirectory = target.startDirectory,
+        tmuxSessionId = target.tmuxSessionId,
+        sessionCreated = target.sessionCreated,
+        trigger = TmuxConnectTrigger.NetworkReconnect,
+    )
+}
 
 public data class TmuxRestoreIntentSnapshot(
     val hostId: Long,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionTopChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionTopChrome.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.sp
 import com.pocketshell.app.portfwd.ForwardingGlyph
 import com.pocketshell.app.portfwd.SessionForwardingIndicatorState
 import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
+import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.uikit.components.KebabTrigger
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -179,7 +180,7 @@ internal fun ConsolidatedTopChrome(
     projectSwitcher: HostTmuxSessionPickerViewModel.ProjectSwitcherState =
         HostTmuxSessionPickerViewModel.ProjectSwitcherState(),
     onProjectSwitcherOpen: () -> Unit = {},
-    onSwitchToSibling: (String) -> Unit = {},
+    onSwitchToSibling: (HostTmuxSessionRow) -> Unit = {},
     // Issues #177 / #249: the live connection state, surfaced through the
     // breadcrumb's status dot (amber pulse while reconnecting, red while
     // disconnected) plus a compact "Reconnecting" / "Disconnected" pill.
@@ -361,7 +362,7 @@ private fun ProjectSwitcherCrumb(
     projectLabel: String,
     switcher: HostTmuxSessionPickerViewModel.ProjectSwitcherState,
     onOpen: () -> Unit,
-    onSwitchToSibling: (String) -> Unit,
+    onSwitchToSibling: (HostTmuxSessionRow) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -420,11 +421,12 @@ private fun ProjectSwitcherCrumb(
             val rows = switcher.siblings
             rows.forEach { row ->
                 val isCurrent = row.name == switcher.currentSessionName
+                val hasGenerationIdentity = row.navigationTargetOrNull() != null
                 DropdownMenuItem(
-                    enabled = !isCurrent,
+                    enabled = !isCurrent && hasGenerationIdentity,
                     onClick = {
                         expanded = false
-                        if (!isCurrent) onSwitchToSibling(row.name)
+                        if (!isCurrent) row.navigationTargetOrNull()?.let { onSwitchToSibling(row) }
                     },
                     modifier = Modifier.testTag(TMUX_PROJECT_SWITCHER_ROW_TAG_PREFIX + row.name),
                     text = {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -628,9 +628,9 @@ public class TmuxSessionViewModel @Inject constructor(
      * a pane belonging to a different tmux session. The Screen collects this
      * and calls `onReplaceTmuxSession` to trigger the warm switch.
      */
-    private val _sessionSwitchRequest: MutableSharedFlow<String> =
+    private val _sessionSwitchRequest: MutableSharedFlow<TmuxSessionNavigationTarget> =
         MutableSharedFlow(extraBufferCapacity = 4)
-    public val sessionSwitchRequest: SharedFlow<String> =
+    internal val sessionSwitchRequest: SharedFlow<TmuxSessionNavigationTarget> =
         _sessionSwitchRequest.asSharedFlow()
 
     /**
@@ -720,7 +720,9 @@ public class TmuxSessionViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            _sessionSwitchRequest.emit(paneSessionName)
+            _sessionSwitchRequest.emit(
+                knownPaneSessionNavigationTarget(active.hostId, paneSessionName, settled.paneId, runtimeCache),
+            )
         }
     }
 
@@ -1255,6 +1257,7 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun triggerCleanPassiveDropForTest(): Boolean {
         val client = clientRef ?: return false
         if (passiveTransportDropEffects.classify(client) == PassiveDropArm.Ignore) return false
+        runCatching { client.close() }
         connectionManager.reportRemoteDrop("test_clean_outage_seam")
         projectStatusFromController()
         handlePassiveClientDisconnect(
@@ -2059,7 +2062,9 @@ public class TmuxSessionViewModel @Inject constructor(
         MutableStateFlow(null)
     public val currentSessionRecordedKind: StateFlow<SessionAgentKind?> =
         _currentSessionRecordedKind.asStateFlow()
-
+    private val recordedAgentRouteTracker = RecordedAgentRouteTracker()
+    internal val currentRecordedAgentRouteEvidence: StateFlow<RecordedAgentRouteEvidence?> =
+        recordedAgentRouteTracker.evidence
     /**
      * Issue #898: the host-discovered Claude / Codex agent profiles, projected
      * for the in-session "+ New session" [com.pocketshell.app.projects.SessionTypePickerSheet]'s
@@ -2570,6 +2575,8 @@ public class TmuxSessionViewModel @Inject constructor(
         // without preflighting a second time. Never set by external callers.
         skipExistencePreflight: Boolean = false,
     ) {
+        val testTransportAvailable =
+            syntheticUnrecoverableHostAllowsTransportReuse(forceUnrecoverableHostForTest)
         // Issue #666: a foreground cold-restore must NOT resurrect a session
         // killed elsewhere while the app was backgrounded. Before we attach —
         // and crucially BEFORE we can activate a stale warm/cached runtime
@@ -2581,7 +2588,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // resume-from-persisted-last-session path); [OpenExisting] preflights too,
         // but only for a genuine COLD open (handled below, after the warm-path
         // determination).
-        if (trigger == TmuxConnectTrigger.ColdRestore && !skipExistencePreflight) {
+        if (trigger == TmuxConnectTrigger.ColdRestore && !skipExistencePreflight && testTransportAvailable) {
             preflightSessionExistence(
                 hostId = hostId,
                 hostName = hostName,
@@ -2643,7 +2650,7 @@ public class TmuxSessionViewModel @Inject constructor(
 
         val previousActiveTarget = activeTarget
         val previousSession = sessionRef
-        val willFastSwitch = previousActiveTarget != null &&
+        val willFastSwitch = testTransportAvailable && previousActiveTarget != null &&
             previousSession != null &&
             previousSession.isConnected &&
             isSameHost(previousActiveTarget, target) &&
@@ -2659,8 +2666,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // skips the probe (no added latency to the maintainer's instant switch), and
         // any AMBIGUOUS probe (no lease / exec error) FAILS OPEN to the normal
         // attach — so a transient reconnect blip never triggers the prompt.
-        if (trigger == TmuxConnectTrigger.OpenExisting &&
-            !skipExistencePreflight &&
+        if (trigger == TmuxConnectTrigger.OpenExisting && !skipExistencePreflight && testTransportAvailable &&
             !willFastSwitch &&
             !runtimeCache.contains(target.toRuntimeKey())
         ) {
@@ -2769,7 +2775,7 @@ public class TmuxSessionViewModel @Inject constructor(
             )
         }
 
-        val cachedActivation = if (shouldForceFreshLease(effectiveTrigger)) {
+        val cachedActivation = if (shouldForceFreshLease(effectiveTrigger) || !testTransportAvailable) {
             null
         } else {
             takeCachedRuntimeForActivation(
@@ -2823,7 +2829,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // blanking [Connecting] overlay (see the slow-path branch below).
                 // Issue #620: also warm when host detail's lease handshake is
                 // still in flight — this open coalesces onto it, no second dial.
-                val warmOpen = !shouldForceFreshLease(effectiveTrigger) &&
+                val warmOpen = testTransportAvailable && !shouldForceFreshLease(effectiveTrigger) &&
                     sshLeaseManager.hasLiveOrConnectingLease(target.toSshLeaseTarget().leaseKey)
                 setConnectionState(
                     if (warmOpen) {
@@ -2884,7 +2890,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // coroutine re-confirms authoritatively and downgrades to [Connecting]
         // if the lease turned out to be gone. A reconnect / network-reattach
         // deliberately forces a fresh transport, so it is never a warm open.
-        val warmOpenHint = !willFastSwitch &&
+        val warmOpenHint = testTransportAvailable && !willFastSwitch &&
             !shouldForceFreshLease(effectiveTrigger) &&
             liveLeaseKeys.contains(target.toSshLeaseTarget().leaseKey)
         setConnectionState(
@@ -3037,7 +3043,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     // detail's warm-lease handshake) ALSO counts as a warm open —
                     // the acquire below coalesces onto it, so no second SSH dial
                     // happens and the attach is instant.
-                    val warmOpen = !shouldForceFreshLease(effectiveTrigger) &&
+                    val warmOpen = testTransportAvailable && !shouldForceFreshLease(effectiveTrigger) &&
                         sshLeaseManager.hasLiveOrConnectingLease(target.toSshLeaseTarget().leaseKey)
                     if (warmOpen) {
                         recordWarmSwitchMilestone(
@@ -4618,10 +4624,8 @@ public class TmuxSessionViewModel @Inject constructor(
                 generation = intent.generation,
             )
         }
-
-    internal fun setForegroundReattachForTest(handler: (() -> Unit)?) {
-        foregroundReattachForTest = handler
-    }
+    public fun onSessionScreenLeft() { latestConnectIntent = null }
+    internal fun setForegroundReattachForTest(handler: (() -> Unit)?) { foregroundReattachForTest = handler }
 
     internal fun setProcessForegroundForClearedForTest(isForeground: Boolean?) {
         processForegroundForClearedOverrideForTest = isForeground
@@ -4801,6 +4805,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     windowId = pane.windowId,
                     windowIndex = pane.windowIndex,
                     sessionId = pane.sessionId,
+                    sessionCreated = pane.sessionCreated,
                     title = pane.title,
                     cwd = pane.cwd,
                     currentCommand = pane.currentCommand,
@@ -5028,7 +5033,8 @@ public class TmuxSessionViewModel @Inject constructor(
      * waiting for sshj's reader to discover that the old TCP path died.
      */
     public fun onNetworkChanged(change: TerminalNetworkChange) {
-        val target = activeTarget ?: connectingTarget
+        val target = activeTarget ?: connectingTarget ?: latestConnectIntent?.takeIf { acceptedRestoreTargetIsCurrent(it.generation, connectGeneration, revealController.sessionId(it.target), revealController.currentTargetId()) }?.target
+        if (change.kind == com.pocketshell.app.connectivity.TerminalNetworkChangeKind.NetworkRestored && target != null && clientRef == null && sessionRef == null) return connectAcceptedNetworkRestore(target)
         // EPIC #792 Slice E: feed the AUTHORITATIVE controller the #548 validated-handoff
         // signal it suppresses on (computed identically to the inline reducer).
         //
@@ -6327,14 +6333,13 @@ public class TmuxSessionViewModel @Inject constructor(
         lastConnectFailureCause = null
         lastSuppressedDropDiagnostic = null
         try {
-            // Issue #1098 item 3 test seam: a GENUINELY-unrecoverable host fails every
-            // fresh-dial of the auto-reconnect ladder (a reconnect trigger), so the
-            // bounded ladder exhausts and the honest "Disconnected from …" band
-            // surfaces — modelling sshd dead / port blackholed / a network cut that
-            // stays cut. The cold OPEN (a non-reconnect trigger) is left alone so the
-            // test's initial attach still succeeds. Production never arms it; the throw
-            // routes through the same `catch` a real connection-refused does.
-            if (forceUnrecoverableHostForTest && trigger.isReconnectTrigger) {
+            // Issue #1098 item 3 test seam: once armed AFTER the fixture's initial
+            // attach, a GENUINELY-unrecoverable host fails every fresh dial. This
+            // includes a cold Open reached through main-screen navigation: a dead
+            // host does not become reachable merely because that navigation emits a
+            // different trigger kind. Production never arms it; the throw routes
+            // through the same `catch` a real connection-refused does.
+            if (syntheticUnrecoverableHostRejectsDial(forceUnrecoverableHostForTest, trigger)) {
                 throw IOException(
                     "synthetic unrecoverable host: connection refused (issue #1098 item 3 test seam)",
                 )
@@ -9721,6 +9726,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     windowId = p.windowId,
                     windowIndex = p.windowIndex,
                     sessionId = p.sessionId,
+                    sessionCreated = p.sessionCreated,
                     title = p.title,
                     cwd = p.cwd,
                     currentCommand = p.currentCommand,
@@ -14095,6 +14101,9 @@ public class TmuxSessionViewModel @Inject constructor(
         sendToken: String = newOutboundDeliveryToken(),
         durableRow: DurableOutboundRowIdentity? = null,
     ): Result<Unit> {
+        if (durableAgentQueueSendMustDefer(durableRow, isSendTransportWritable())) {
+            return Result.failure(IllegalStateException("Session is disconnected; kept queued."))
+        }
         val client = awaitLiveTmuxClientForSend()
             ?: return Result.failure(IllegalStateException("Session is disconnected."))
         return sendAgentPayloadToPaneResult(
@@ -14110,7 +14119,6 @@ public class TmuxSessionViewModel @Inject constructor(
     // Issue #1526 S1 / #1541 / #1587: verify-before-resend ledger, durable-backed by
     // the injected @Singleton store (see [outboundDeliveryLedgerFor]). Null ⇒ base S1.
     private val outboundDeliveryLedger = outboundDeliveryLedgerFor(outboundQueueStore)
-
     private fun consumeSendResultLostSeamForTest() {
         if (!OutboundDeliverySeams.consumeSendResultLostBeforeSubmitEnter()) return
         // The seam models the audit's cut point (c): the paste ran server-side,
@@ -14123,12 +14131,19 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     private fun snapshotAgentSendRuntime(client: TmuxClient): AgentSendRuntimeIdentity =
-        AgentSendRuntimeIdentity(
-            client = client,
-            generation = connectGeneration,
-            target = activeTarget,
-        )
+        AgentSendRuntimeIdentity(client = client, generation = connectGeneration, target = activeTarget)
 
+    private val agentTranscriptAuthority = AgentTranscriptAuthority(
+        conversationForPane = { _agentConversations.value[it] },
+        tailJobActive = { paneAgentJobs[it]?.isActive == true },
+        tailGenerationPresent = { paneAgentTailGenerations[it] != null },
+    )
+    @androidx.annotation.VisibleForTesting
+    internal fun setAgentTranscriptAuthorityForTest(paneId: String, active: Boolean) =
+        agentTranscriptAuthority.setActiveForTest(paneId, active)
+    @androidx.annotation.VisibleForTesting
+    internal fun setAgentTranscriptAuthorityStartingForTest(paneId: String, starting: Boolean) =
+        agentTranscriptAuthority.setStartingForTest(paneId, starting)
     private fun isCurrentAgentSendRuntime(
         identity: AgentSendRuntimeIdentity,
         paneId: String,
@@ -14216,8 +14231,30 @@ public class TmuxSessionViewModel @Inject constructor(
                 check(!client.disconnected.value) {
                     "Tmux client disconnected after verify-before-resend."
                 }
+                val preEnterFrame = durableRow?.let {
+                    captureAgentPaneBounded(runtimeIdentity, paneId, AGENT_SUBMIT_TURNOVER_TIMEOUT_MS, 0)
+                        .response ?: error("Agent submit frame unavailable before Enter; kept queued.")
+                }
+                val transcriptBaseline = durableRow?.let { agentTranscriptAuthority.baseline(paneId, payload) }
+                durableRow?.let { row ->
+                    check(withContext(seedIoDispatcher) {
+                        outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row)
+                    }) { "Agent submit write-ahead persistence failed; Enter not sent." }
+                }
                 sendNamedKeyToPane(client, paneId, "Enter")
                     .throwIfTmuxError("submit previously pasted agent input")
+                if (preEnterFrame != null) {
+                    agentTranscriptAuthority.awaitTurnover(
+                        identity = runtimeIdentity,
+                        paneId = paneId,
+                        payload = payload,
+                        preEnterFrame = preEnterFrame,
+                        baseline = transcriptBaseline,
+                        capture = { timeoutMs, lines -> captureAgentPaneBounded(runtimeIdentity, paneId, timeoutMs, lines) },
+                        currentClientHash = { clientRef?.let { System.identityHashCode(it) } },
+                        currentGeneration = { connectGeneration },
+                    )
+                }
                 outboundDeliveryLedger.clear(paneId, sendToken)
                 requestReconcile(client, paneId, ReconcileReason.Send)
                 Result.success(Unit)
@@ -14290,7 +14327,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     ?: settingsRepository?.settings?.value?.agentSubmitEnterDelayMs
                     ?: com.pocketshell.app.settings.AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS
                 ).toLong()
-            awaitAgentPasteIngested(
+            val preEnterFrame = awaitAgentPasteIngested(
                 identity = runtimeIdentity,
                 paneId = paneId,
                 payload = payload,
@@ -14317,8 +14354,26 @@ public class TmuxSessionViewModel @Inject constructor(
                 "Tmux client disconnected after paste acknowledgement."
             }
             consumeSendResultLostSeamForTest()
+            val transcriptBaseline = durableRow?.let { agentTranscriptAuthority.baseline(paneId, payload) }
+            durableRow?.let { row ->
+                check(withContext(seedIoDispatcher) {
+                    outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row)
+                }) { "Agent submit write-ahead persistence failed; Enter not sent." }
+            }
             sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
+            if (durableRow != null) {
+                agentTranscriptAuthority.awaitTurnover(
+                    identity = runtimeIdentity,
+                    paneId = paneId,
+                    payload = payload,
+                    preEnterFrame = preEnterFrame,
+                    baseline = transcriptBaseline,
+                    capture = { timeoutMs, lines -> captureAgentPaneBounded(runtimeIdentity, paneId, timeoutMs, lines) },
+                    currentClientHash = { clientRef?.let { System.identityHashCode(it) } },
+                    currentGeneration = { connectGeneration },
+                )
+            }
             outboundDeliveryLedger.clear(paneId, sendToken)
             // Issue #941/#1353 R4: after the submit Enter a full-screen agent TUI can overpaint
             // the active pane partial-black; a guarded heal EVENT re-checks and re-seeds.
@@ -16277,12 +16332,17 @@ public class TmuxSessionViewModel @Inject constructor(
     public fun refreshCurrentSessionRecordedKind() {
         val target = activeTarget?.sessionName?.trim()?.takeIf { it.isNotEmpty() } ?: run {
             _currentSessionRecordedKind.value = null
+            recordedAgentRouteTracker.clear()
             _currentSessionRecordedProfile.value = null
             return
         }
+        val targetSnapshot = activeTarget ?: return
+        val paneSnapshot = activeVisiblePane()
+        val routeRefresh = recordedAgentRouteTracker.begin(
+            durableSessionKey = recordedRouteKey(targetSnapshot, paneSnapshot),
+            paneId = paneSnapshot?.paneId,
+        )
         val session = sessionRef ?: return
-        // Issue #1820 [TmuxTarget]: EXACT pane target — a bare `-t <name>` prefix-matches, so with
-        // `<name>-2` alive this would read the NEIGHBOUR's recorded kind/profile.
         val optionTarget = "'${escapeSingleQuoted(TmuxTarget.pane(target))}'"
         bridgeScope.launch {
             val raw = withContext(Dispatchers.IO) {
@@ -16291,32 +16351,27 @@ public class TmuxSessionViewModel @Inject constructor(
                 }.getOrNull()
             }
             val recordedKind = sessionAgentKindFromOption(raw)
+            val stillCurrentPane = activeVisiblePane()
+            val stillCurrentKey = recordedRouteKey(activeTarget, stillCurrentPane)
+            val stillSameTarget = activeTarget?.let { sameSessionIdentity(it, targetSnapshot) } == true
+            if (!stillSameTarget || !recordedAgentRouteTracker.isLatest(routeRefresh)) return@launch
             _currentSessionRecordedKind.value = recordedKind
-            // Issue #894 (Slice C): feed the durable shell verdict into the
-            // per-pane confirmed-shell signal. The active session's panes share
-            // one `sessionId` (`$N`); mark/un-mark it so the seed skips a
-            // confirmed shell and the screen collapses its presumed-agent
-            // surface. A recorded SHELL also drops any auto-seeded placeholder
-            // that raced ahead of this read (the first-open flash). A null
-            // (foreign/unknown) verdict is NOT a confirmed shell — leave it
-            // presumed-agent so the #878 cure is intact.
-            activeSessionId()?.let { sessionId ->
-                applyRecordedShellVerdict(
-                    sessionId = sessionId,
-                    isShell = recordedKind == SessionAgentKind.Shell,
-                )
+            if (recordedAgentRouteTracker.isCurrent(routeRefresh, stillCurrentKey, stillCurrentPane?.paneId)) {
+                recordedAgentRouteTracker.accept(routeRefresh, recordedKind)
             }
-            // Issue #858: read the recorded profile over the SAME warm session
-            // (D21 — no new connection) so the "What is this session?" sheet can
-            // show the provider/profile. A blank/absent option (default /
-            // non-profiled / legacy session) leaves the profile null.
+            activeSessionId()?.let { sessionId ->
+                applyRecordedShellVerdict(sessionId, recordedKind == SessionAgentKind.Shell)
+            }
             val rawProfile = withContext(Dispatchers.IO) {
                 runCatching {
                     session.exec("tmux show-options -v -t $optionTarget @ps_agent_profile 2>/dev/null || true").stdout
                 }.getOrNull()
             }
-            _currentSessionRecordedProfile.value =
-                rawProfile?.trim()?.takeIf { it.isNotEmpty() }
+            if (activeTarget?.let { sameSessionIdentity(it, targetSnapshot) } == true &&
+                recordedAgentRouteTracker.isLatest(routeRefresh)
+            ) {
+                _currentSessionRecordedProfile.value = rawProfile?.trim()?.takeIf { it.isNotEmpty() }
+            }
         }
     }
 
@@ -17326,16 +17381,12 @@ public class TmuxSessionViewModel @Inject constructor(
         return _panes.value.any { it.paneId == pane.paneId }
     }
 
-    /**
-     * Issue #894 (Slice C): the active session's tmux `sessionId` (`$N`), read
-     * off the current pane rows (all active panes share it). Null when no pane
-     * is attached yet. Used to key the durable confirmed-shell verdict so it
-     * matches the conversation-open cache's `sessionId` key.
-     */
+    internal fun navigationTargetForKnownSession(sessionName: String): TmuxSessionNavigationTarget =
+        knownSessionNavigationTarget(sessionName, activeTarget, connectingTarget, runtimeCache)
+
+    /** Active panes' shared tmux session id, or null before attachment. */
     private fun activeSessionId(): String? =
         _panes.value.firstOrNull()?.sessionId?.trim()?.takeIf { it.isNotEmpty() }
-
-    // ---- End Issue #626 helpers ----
 
     /**
      * Internal value type used by the reconcile path. Visible to tests so
@@ -17369,13 +17420,11 @@ public class TmuxSessionViewModel @Inject constructor(
         // launched directly inside a `@ps_agent_kind=shell` session. Defaults
         // false for older tmux / tests that omit the field.
         val alternateOn: Boolean = false,
+        val sessionCreated: Long? = null,
         val sessionName: String = "",
     )
 
-    // Issue #722: visibility widened from `private` to `internal` (no behavior
-    // change) so it can appear as a property of the now-`internal`
-    // [RuntimeRefreshGuard] carried opaquely across the characterization-test
-    // seam boundary. Tests never name or construct it.
+    /** Runtime target identity shared with connection-effect helpers and tests. */
     internal data class ConnectionTarget(
         val hostId: Long,
         val hostName: String,

--- a/app/src/test/java/com/pocketshell/app/composer/ComposerQueueDiagnosticsHostMirrorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/ComposerQueueDiagnosticsHostMirrorTest.kt
@@ -265,6 +265,33 @@ class ComposerQueueDiagnosticsHostMirrorTest {
         assertEquals(1L, drain.getJSONObject("metadata").getLong("suppressedCount"))
     }
 
+    /** A stale promoted snapshot must not masquerade as retry suppression. */
+    @Test
+    fun `an inflight snapshot head records its blocking state`() = runTest {
+        val recorder = newRecorder()
+        val items = listOf(
+            item(id = "old-head", state = OutboundState.InFlight),
+            item(id = "queued-tail", state = OutboundState.Queued),
+        )
+        val plan = items.planComposerAutoFlush(sessionPath)
+        assertEquals(null, plan.nextId)
+
+        ComposerQueueDiagnostics.recordDrainCycle(
+            sessionKey = sessionPath,
+            items = items,
+            plan = plan,
+            suppressedCount = 0,
+            dispatched = false,
+        )
+
+        val metadata = recorder.connectionLogJsonl().mirroredLines()
+            .single { it.getString("name") == "drain_attempt" }
+            .getJSONObject("metadata")
+        assertEquals("blocked_by_inflight_snapshot", metadata.getString("outcome"))
+        assertEquals("InFlight", metadata.getString("snapshotHeadState"))
+        assertEquals("InFlight:1,Queued:1", metadata.getString("snapshotStateCounts"))
+    }
+
     /** row_state transitions reach the host log with reason + post-transition budget. */
     @Test
     fun `a row_state transition reaches the host log`() = runTest {

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
@@ -184,12 +184,14 @@ class OutboundQueueStoreEncodingTest {
                 wireAttemptedAtMs = 1_700_000_009_000,
                 wireNeedleBaselineCount = 1,
                 wireCollapsedMarkerBaselineCount = 2,
+                wireSubmitAttempted = true,
             ),
         )
         val decoded = decodeOutboundItems("sessA", encodeOutboundItems(items))
         assertEquals(items, decoded)
         assertEquals(1, decoded.single().wireNeedleBaselineCount)
         assertEquals(2, decoded.single().wireCollapsedMarkerBaselineCount)
+        assertTrue(decoded.single().wireSubmitAttempted)
     }
 
     @Test
@@ -201,6 +203,7 @@ class OutboundQueueStoreEncodingTest {
         val decoded = decodeOutboundItems("sessA", raw).single()
         assertTrue(decoded.wireAttempted)
         assertEquals(null, decoded.wireNeedleBaselineCount)
+        assertFalse(decoded.wireSubmitAttempted)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
@@ -13,6 +13,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
@@ -37,6 +39,104 @@ import java.util.concurrent.atomic.AtomicInteger
 class OutboundQueueStoreTest {
 
     private fun store() = InMemoryOutboundQueueStore()
+
+    /**
+     * Issue #1944 RED characterization: the same live tmux generation can first
+     * be bound through the pre-identity fallback and later through its durable
+     * identity after A -> home -> B -> A. Exact-key lookup used to hide both
+     * rows at that boundary even though neither had been delivered or pruned.
+     */
+    @Test
+    fun sameGenerationFallbackToDurableTransitionKeepsRowsVisibleAndFifo() {
+        val store = store()
+        val fallbackA = "7/project-a"
+        val durableA = "tmux:7:\$12:1700000000"
+        val durableB = "tmux:7:\$13:1700000001"
+        val first = store.enqueue(fallbackA, "first dictated prompt", createdAtMs = 10, paneId = "%192", tmuxSessionId = "\$12", tmuxSessionCreated = 1700000000)
+        store.claimNext(fallbackA)
+        store.markFailed(first.id, "transport unavailable", lastAttemptAtMs = 11)
+        store.requeueForRetry(first.id)
+        val second = store.enqueue(fallbackA, "second dictated prompt", createdAtMs = 20, paneId = "%192", tmuxSessionId = "\$12", tmuxSessionCreated = 1700000000)
+
+        assertTrue("session B must never see A rows", store.itemsFor(durableB).isEmpty())
+        val promoted = store.promoteSessionIdentity(fallbackA, durableA, setOf("%192"), "\$12", 1700000000)
+        assertEquals(listOf(first.id, second.id), promoted.map { it.id })
+        val reboundA = store.itemsFor(durableA)
+        assertEquals(
+            "old key has ${store.itemsFor(fallbackA).size}; rebound A has ${reboundA.size}",
+            listOf(first.id, second.id),
+            reboundA.map { it.id },
+        )
+        assertEquals(first.id, store.claimNext(durableA)?.id)
+        assertEquals(second.id, store.claimNext(durableA)?.id)
+    }
+
+    @Test
+    fun identityPromotionNeverUsesNameAloneOrMovesForeignPaneRows() {
+        val store = store()
+        val fallbackA = "7/project-a"
+        val sameNameSuccessor = "tmux:7:\$99:1800000000"
+        val old = store.enqueue(fallbackA, "belongs to old generation", paneId = "%192")
+
+        assertTrue(store.promoteSessionIdentity(fallbackA, sameNameSuccessor, emptySet(), "\$99", 1800000000).isEmpty())
+        assertTrue(store.promoteSessionIdentity(fallbackA, sameNameSuccessor, setOf("%999"), "\$99", 1800000000).isEmpty())
+        assertEquals(old, store.itemsFor(fallbackA).single())
+        assertTrue(store.itemsFor(sameNameSuccessor).isEmpty())
+    }
+
+    @Test
+    fun identityPromotionRejectsReusedPaneFromDifferentTmuxGeneration() {
+        val store = store()
+        val fallback = "7/work"
+        val destination = "tmux:7:\$9:200"
+        val staleServer = store.enqueue(fallback, "old server", paneId = "%1", tmuxSessionId = "\$9", tmuxSessionCreated = 100)
+        val sameCreatedDifferentId = store.enqueue(fallback, "other id", paneId = "%1", tmuxSessionId = "\$8", tmuxSessionCreated = 200)
+        val legacyUnproven = store.enqueue(fallback, "legacy", paneId = "%1")
+        val exact = store.enqueue(fallback, "exact", paneId = "%1", tmuxSessionId = "\$9", tmuxSessionCreated = 200)
+        val delivered = store.enqueueExisting(
+            OutboundItem(
+                id = "already-delivered",
+                sessionKey = fallback,
+                cleanText = "done",
+                state = OutboundState.Delivered,
+                createdAtMs = 5,
+                paneId = "%1",
+                tmuxSessionId = "\$9",
+                tmuxSessionCreated = 200,
+            ),
+        )
+
+        assertEquals(
+            listOf(exact.id),
+            store.promoteSessionIdentity(fallback, destination, setOf("%1"), "\$9", 200).map { it.id },
+        )
+        assertEquals(
+            listOf(delivered.id, staleServer.id, sameCreatedDifferentId.id, legacyUnproven.id),
+            store.itemsFor(fallback).map { it.id },
+        )
+    }
+
+    @Test
+    fun concurrentIdentityPromotionIsAtomicAndIdempotent() {
+        val store = store()
+        val fallback = "7/work"
+        val durable = "tmux:7:\$9:200"
+        val row = store.enqueue(fallback, "once", paneId = "%1", tmuxSessionId = "\$9", tmuxSessionCreated = 200)
+        val start = CountDownLatch(1)
+        val results = Collections.synchronizedList(mutableListOf<List<String>>())
+        val workers = List(2) {
+            Thread {
+                start.await()
+                results += store.promoteSessionIdentity(fallback, durable, setOf("%1"), "\$9", 200).map { it.id }
+            }.also { it.start() }
+        }
+        start.countDown()
+        workers.forEach { it.join() }
+
+        assertEquals(listOf(emptyList(), listOf(row.id)), results.sortedBy { it.size })
+        assertEquals(listOf(row.id), store.itemsFor(durable).map { it.id })
+        assertTrue(store.itemsFor(fallback).isEmpty())
+    }
 
     // --- Enqueue mints a stable id (the durable idempotency key) -----------
 

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
@@ -110,6 +110,23 @@ class OutboundQueueStoreWireAttemptTest {
     }
 
     @Test
+    fun submitAttemptSurvivesRequeueUntilRowLeavesQueue() {
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue("sessA", "ambiguous submit", paneId = "%0")
+        store.claim(row.id)
+        store.markWireAttempted("sessA", row.id, baselineCount = 0)
+
+        val attempted = requireNotNull(store.markWireSubmitAttempted("sessA", row.id))
+        assertTrue(attempted.wireSubmitAttempted)
+        assertTrue(store.hasWireSubmitAttempt("sessA", row.id))
+
+        store.requeueForRetry(row.id)
+        assertTrue("requeue must preserve Enter ambiguity", store.hasWireSubmitAttempt("sessA", row.id))
+        store.remove(row.id)
+        assertFalse("row removal drops the latch with the row", store.hasWireSubmitAttempt("sessA", row.id))
+    }
+
+    @Test
     fun markWireAttemptedRequiresExactSessionAndRowId() {
         val store = InMemoryOutboundQueueStore()
         val row = store.enqueue("sessA", "ship the notes", paneId = "%0")

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerDrainOwnershipTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerDrainOwnershipTest.kt
@@ -1,0 +1,259 @@
+package com.pocketshell.app.composer
+
+import androidx.lifecycle.SavedStateHandle
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.settings.VoiceTranscriptionProvider
+import com.pocketshell.app.tmux.OutboundQueueAutoFlushController
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Issue #1944 physical drain ownership, promotion, and screen-consumer turnover. */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class PromptComposerDrainOwnershipTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val viewModels = mutableListOf<PromptComposerViewModel>()
+
+    @After
+    fun tearDown() {
+        viewModels.forEach { it.clearForTest() }
+        viewModels.clear()
+    }
+
+    private fun newVm(dispatcher: TestDispatcher, queue: OutboundQueueStore): PromptComposerViewModel =
+        PromptComposerViewModel(
+            audioRecorder = object : PromptComposerViewModel.MicCapture {
+                override fun start() = Unit
+                override fun stop(): ByteArray = byteArrayOf(1)
+                override fun currentAmplitude(): Float = 0f
+            },
+            whisperClientFactory = WhisperClientFactory { null },
+            apiKeyStorage = object : ApiKeyVault {
+                override fun save(key: CharArray) = Unit
+                override fun load(): CharArray? = null
+                override fun clear() = Unit
+            },
+            voiceSettings = object : PromptComposerViewModel.VoiceSettingsSnapshot {
+                override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+                override fun whisperLanguageHint(): String? = null
+                override fun transcriptionProvider(): VoiceTranscriptionProvider =
+                    VoiceTranscriptionProvider.OpenAiWhisper
+            },
+            outboundQueueStore = queue,
+            savedStateHandle = SavedStateHandle(),
+        ).also {
+            it.samplerDispatcher = dispatcher
+            it.outboundQueueDispatcher = dispatcher
+            it.setSendWatchdogTimeoutForTest(null)
+            viewModels += it
+        }
+
+    private fun TestScope.collectSendRequests(
+        vm: PromptComposerViewModel,
+    ): MutableList<PromptComposerViewModel.SendRequest> {
+        val requests = java.util.Collections.synchronizedList(
+            mutableListOf<PromptComposerViewModel.SendRequest>(),
+        )
+        backgroundScope.launch { vm.sendRequests.collect { requests += it } }
+        runCurrent()
+        return requests
+    }
+
+    @Test
+    fun fallbackPhysicalOwnerSurvivesPromotionUntilDeferredThenDurableFifoRetries() = runTest {
+        val fallback = "1/session-a"
+        val durable = "tmux:1:\$0:1944"
+        val queue = InMemoryOutboundQueueStore()
+        val first = queue.enqueue(sessionKey = fallback, cleanText = "first dictated prompt", createdAtMs = 1L, paneId = "%1", tmuxSessionId = "\$0", tmuxSessionCreated = 1944L)
+        val second = queue.enqueue(sessionKey = fallback, cleanText = "second dictated prompt", createdAtMs = 2L, paneId = "%1", tmuxSessionId = "\$0", tmuxSessionCreated = 1944L)
+        val vm = newVm(StandardTestDispatcher(testScheduler), queue)
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged(fallback)
+
+        assertTrue(vm.dispatchOutboundItem(first.id))
+        advanceUntilIdle()
+        val fallbackRequest = sent.single()
+        assertEquals(first.id, fallbackRequest.outboundQueueItemId)
+        assertEquals(
+            "handoff must retain the physical row owner across identity promotion",
+            first.id,
+            vm.outboundDrainOwnership.activeRowId(),
+        )
+        val promoted = vm.promoteFallbackOutboundIdentity(
+            fallback, durable, setOf("%1"), "\$0", 1944L,
+        )
+        assertEquals(listOf(first.id, second.id), promoted.map { it.id })
+        assertEquals(OutboundState.InFlight, queue.item(first.id)!!.state)
+        assertNull(queue.itemsFor(durable).planComposerAutoFlush(durable).nextId)
+        assertFalse(vm.dispatchOutboundItem(second.id))
+        vm.onComposerTargetChanged(durable)
+
+        vm.markOutboundSendDeferred(fallbackRequest, resetAttemptBudget = true)
+        assertFalse(vm.uiState.value.sendInFlight)
+        assertEquals(0, queue.item(first.id)!!.attemptCount)
+        assertNull(vm.outboundDrainOwnership.activeRowId())
+        assertEquals(
+            listOf(OutboundState.Queued, OutboundState.Queued),
+            vm.outboundQueueItems.value.map { it.state },
+        )
+        assertTrue(queue.itemsFor(fallback).isEmpty())
+        assertEquals(first.id, vm.retryNextOutboundItem())
+        advanceUntilIdle()
+        runCurrent()
+        assertEquals(listOf(first.id, first.id), sent.map { it.outboundQueueItemId })
+        assertEquals(OutboundState.InFlight, queue.item(first.id)!!.state)
+        assertEquals(OutboundState.Queued, queue.item(second.id)!!.state)
+    }
+
+    @Test
+    fun exactGenerationFallbackRowCannotDrainBeforeDurableIdentityPromotion() = runTest {
+        val fallback = "1/renamed-a"
+        val durable = "tmux:1:\$0:1944"
+        val queue = InMemoryOutboundQueueStore()
+        val row = queue.enqueue(
+            sessionKey = fallback,
+            cleanText = "dictated while disconnected",
+            createdAtMs = 1L,
+            paneId = "%0",
+            tmuxSessionId = "\$0",
+            tmuxSessionCreated = 1944L,
+        )
+        val vm = newVm(StandardTestDispatcher(testScheduler), queue)
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged(fallback)
+
+        assertNull(
+            "a live fallback window must wait for pane-proven durable ownership",
+            vm.retryNextOutboundItem(),
+        )
+        advanceUntilIdle()
+        assertTrue(sent.isEmpty())
+        assertEquals(OutboundState.Queued, queue.item(row.id)?.state)
+
+        vm.promoteFallbackOutboundIdentity(fallback, durable, setOf("%0"), "\$0", 1944L)
+        vm.onComposerTargetChanged(durable)
+        assertEquals(row.id, vm.retryNextOutboundItem())
+        advanceUntilIdle()
+        runCurrent()
+        assertEquals(listOf(row.id), sent.map { it.outboundQueueItemId })
+    }
+
+    @Test
+    fun preHandoffClaimLossReleasesOwnerWithoutEmittingRequest() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val row = queue.enqueue(sessionKey = "1/session-a", cleanText = "must remain retryable", createdAtMs = 1L)
+        val vm = newVm(StandardTestDispatcher(testScheduler), queue)
+        val sent = collectSendRequests(vm)
+        vm.onComposerTargetChanged("1/session-a")
+
+        assertTrue(vm.dispatchOutboundItem(row.id))
+        assertEquals(row.id, vm.outboundDrainOwnership.activeRowId())
+        assertTrue(queue.remove(row.id))
+        advanceUntilIdle()
+
+        assertTrue(sent.isEmpty())
+        assertNull(vm.outboundDrainOwnership.activeRowId())
+        assertFalse(vm.uiState.value.sendInFlight)
+    }
+
+    @Test
+    fun issue1944_consumerMountDoesNotBypassClosedTransportDrainWindow() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val row = queue.enqueue(sessionKey = "1/session-a", cleanText = "wait for the wire", createdAtMs = 1L)
+        val vm = newVm(dispatcher, queue)
+        vm.setTransportWritableProbe { false }
+        vm.onComposerTargetChanged("1/session-a")
+        var physicalSendCount = 0
+        val consumer = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            collectPromptComposerSendRequests(vm, onSend = { physicalSendCount++; true })
+        }
+        runCurrent()
+
+        assertEquals(OutboundState.Queued, queue.item(row.id)!!.state)
+        assertNull(vm.outboundDrainOwnership.activeRowId())
+        assertFalse(vm.uiState.value.sendInFlight)
+        assertEquals(0, physicalSendCount)
+        consumer.cancel()
+    }
+
+    @Test
+    fun issue1944_cancelledScreenConsumerDefersBeforeReplacementRetriesExactlyOnce() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(dispatcher, queue)
+        vm.setTransportWritableProbe { true }
+        val target = PromptComposerViewModel.SendTargetSnapshot(sessionKey = "1/session-a")
+        val firstPhysicalSendStarted = CompletableDeferred<Unit>()
+        val firstPhysicalSendNeverReturns = CompletableDeferred<Boolean>()
+        val acceptedPayloads = mutableListOf<String>()
+        vm.onComposerTargetChanged(target.sessionKey)
+        val autoFlush = OutboundQueueAutoFlushController.boundTo(vm)
+        val flushJob = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            vm.outboundQueueItems.collect {
+                autoFlush.onQueueSnapshotChanged(sessionLive = true) { excluded ->
+                    vm.retryNextOutboundItem(excluded)
+                }
+            }
+        }
+        val acceptanceJob = backgroundScope.launch {
+            vm.handoffAcceptances.collect(vm::completeHandoffAcceptanceReduction)
+        }
+        val retiringConsumer = launch {
+            collectPromptComposerSendRequests(vm, onSend = {
+                firstPhysicalSendStarted.complete(Unit)
+                firstPhysicalSendNeverReturns.await()
+            })
+        }
+        runCurrent()
+        vm.onDraftChange("keep this across screen turnover")
+        vm.requestSend(withEnter = true, sendTarget = target)
+        runCurrent()
+        firstPhysicalSendStarted.await()
+        val rowId = requireNotNull(queue.itemsFor(target.sessionKey).singleOrNull()?.id)
+
+        retiringConsumer.cancel(CancellationException("screen target turned over"))
+        retiringConsumer.join()
+        runCurrent()
+        assertEquals(OutboundState.Queued, requireNotNull(queue.item(rowId)).state)
+        assertFalse(vm.uiState.value.sendInFlight)
+        assertNull(vm.outboundDrainOwnership.activeRowId())
+
+        val replacement = launch {
+            collectPromptComposerSendRequests(vm, onSend = { acceptedPayloads += it.cleanDraft; true })
+        }
+        advanceUntilIdle()
+        assertEquals(listOf("keep this across screen turnover"), acceptedPayloads)
+        assertTrue(queue.itemsFor(target.sessionKey).isEmpty())
+        assertFalse(vm.uiState.value.sendInFlight)
+        assertNull(vm.outboundDrainOwnership.activeRowId())
+        replacement.cancelAndJoin()
+        acceptanceJob.cancelAndJoin()
+        flushJob.cancelAndJoin()
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerFifoDrainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerFifoDrainTest.kt
@@ -1,0 +1,106 @@
+package com.pocketshell.app.composer
+
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PromptComposerFifoDrainTest {
+    @Test
+    fun temporarilySuppressedHeadBlocksTailInsteadOfInvertingFifo() {
+        val session = "1/session-a"
+        val first = OutboundItem(
+            id = "first",
+            sessionKey = session,
+            cleanText = "first payload",
+            createdAtMs = 1L,
+            attemptCount = 1,
+        )
+        val second = OutboundItem(
+            id = "second",
+            sessionKey = session,
+            cleanText = "second payload",
+            createdAtMs = 2L,
+        )
+
+        val plan = listOf(first, second).planComposerAutoFlush(
+            sessionKey = session,
+            excludingIds = setOf(first.id),
+        )
+
+        assertNull(
+            "a live-window backoff may pause the FIFO, never send a later row first",
+            plan.nextId,
+        )
+    }
+
+    @Test
+    fun concurrentTriggersCannotAcquireTailWhileHeadOwnsDrain() {
+        val ownership = OutboundDrainOwnership()
+
+        val firstLease = requireNotNull(ownership.tryAcquire("first"))
+        val outcomes = (1..32).map { index ->
+            Thread {
+                if (index % 2 == 0) {
+                    ownership.tryAcquire("second")
+                } else {
+                    ownership.tryAcquire("first")
+                }
+            }.apply { start() }
+        }
+        outcomes.forEach(Thread::join)
+
+        assertEquals("first", ownership.activeRowId())
+        assertNull(ownership.tryAcquire("second"))
+        assertTrue(ownership.release(firstLease))
+        assertEquals("first", requireNotNull(ownership.tryAcquire("first")).rowId)
+    }
+
+    @Test
+    fun promotedInFlightHeadBlocksQueuedTailUntilTerminalCallback() {
+        val durable = "tmux:1:\$0:1944"
+        val first = OutboundItem(
+            id = "first",
+            sessionKey = durable,
+            cleanText = "first payload already on the pane wire",
+            state = OutboundState.InFlight,
+            createdAtMs = 1L,
+        )
+        val second = OutboundItem(
+            id = "second",
+            sessionKey = durable,
+            cleanText = "second payload",
+            state = OutboundState.Queued,
+            createdAtMs = 2L,
+        )
+
+        assertNull(
+            "promotion must not skip an older physical delivery and paste B into A's input",
+            listOf(first, second).planComposerAutoFlush(durable).nextId,
+        )
+    }
+
+    @Test
+    fun cancellationOrStrandCleanupReleasesPhysicalOwner() {
+        val ownership = OutboundDrainOwnership()
+        requireNotNull(ownership.tryAcquire("first"))
+        assertEquals("first", ownership.forceRelease())
+        assertNull(ownership.activeRowId())
+        val retryLease = ownership.tryAcquire("first")
+        assertEquals("the same FIFO head can be retried after cleanup", "first", retryLease?.rowId)
+        assertTrue(ownership.release(retryLease))
+    }
+
+    @Test
+    fun staleSameRowTerminalCallbackCannotReleaseReplacementAttempt() {
+        val ownership = OutboundDrainOwnership()
+        val firstAttempt = requireNotNull(ownership.tryAcquire("first"))
+        assertTrue(ownership.release(firstAttempt))
+        val replacementAttempt = requireNotNull(ownership.tryAcquire("first"))
+
+        assertFalse("row id alone must not create an ABA release", ownership.release(firstAttempt))
+        assertEquals("first", ownership.activeRowId())
+        assertTrue(ownership.release(replacementAttempt))
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -17,6 +17,7 @@ import com.pocketshell.core.voice.AudioRecorderException
 import com.pocketshell.core.voice.SpeechAudioGuard
 import com.pocketshell.core.voice.WhisperClient
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -1912,7 +1913,7 @@ class PromptComposerOutboundSendQueueViewModelTest {
     }
 
     @Test
-    fun retryNextOutboundItemClaimsOldestCurrentTargetAndHonorsLiveWindowExclusions() = runTest {
+    fun retryNextOutboundItemPausesBehindExcludedHeadAndNeverLetsTailOvertake() = runTest {
         val queue = InMemoryOutboundQueueStore()
         val first = queue.enqueue(
             sessionKey = "1/session-a",
@@ -1947,14 +1948,26 @@ class PromptComposerOutboundSendQueueViewModelTest {
         assertEquals(OutboundState.Queued, queue.item(second.id)!!.state)
         assertEquals(OutboundState.Queued, queue.item(otherSession.id)!!.state)
 
-        vm.restoreFailedSend(sent.single(), message = "still disconnected")
+        vm.markOutboundSendDeferred(sent.single())
 
-        val retriedSecond = vm.retryNextOutboundItem(excludingIds = setOf(first.id))
+        val blockedByFirst = vm.retryNextOutboundItem(excludingIds = setOf(first.id))
         advanceUntilIdle()
         runCurrent()
 
-        assertEquals(second.id, retriedSecond)
-        assertEquals(2, sent.size)
+        assertNull(blockedByFirst)
+        assertEquals(1, sent.size)
+        assertEquals(OutboundState.Queued, queue.item(first.id)!!.state)
+        assertEquals(OutboundState.Queued, queue.item(second.id)!!.state)
+
+        assertEquals(first.id, vm.retryNextOutboundItem())
+        advanceUntilIdle()
+        assertEquals(OutboundState.InFlight, queue.item(first.id)!!.state)
+        waitForSendCount(sent, 2)
+        assertEquals(first.id, sent.last().outboundQueueItemId)
+
+        vm.markSendDelivered(sent.last())
+        advanceUntilIdle()
+        waitForSendCount(sent, 3)
         assertEquals(second.id, sent.last().outboundQueueItemId)
         assertEquals(OutboundState.InFlight, queue.item(second.id)!!.state)
         assertEquals(OutboundState.Queued, queue.item(otherSession.id)!!.state)
@@ -2763,93 +2776,4 @@ class PromptComposerOutboundSendQueueViewModelTest {
         assertFalse(vm.uiState.value.sendInFlight)
     }
 
-    // --- Issue #1532 (RC-A / audit D1): dispatcher cancel budget vs connect budget ---
-
-    /**
-     * Issue #1532 (RC-A / audit D1 — the S2 budget inversion). The composer's
-     * `PromptComposerSendDispatcher` bounds the host `onSend` in
-     * `withTimeoutOrNull(SEND_TIMEOUT_MS)`. That cap MUST NOT be shorter than the
-     * connect-wait budget it gates
-     * ([com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS], 30s) — else any
-     * reconnect that takes 12–30s is ALWAYS cancelled-and-deferred at the cap even
-     * though the inner wait would have delivered. Guards against re-introducing the
-     * inversion (they now derive from one source so they cannot drift).
-     *
-     * RED on base (SEND_TIMEOUT_MS = 12_000): 12_000 >= 30_000 is false.
-     */
-    @Test
-    fun dispatcherSendBudgetIsNotShorterThanConnectWaitBudget() {
-        assertTrue(
-            "the dispatcher SEND_TIMEOUT_MS (${PromptComposerViewModel.SEND_TIMEOUT_MS}ms) must be " +
-                ">= the connect-wait budget SEND_SESSION_WAIT_TIMEOUT_MS " +
-                "(${com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS}ms) it gates, or a 12–30s " +
-                "reconnect is always cancelled-and-deferred (audit D1)",
-            PromptComposerViewModel.SEND_TIMEOUT_MS >=
-                com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS,
-        )
-        // Issue #1532 (Finding 2 — #891 budget-sum invariant). The whole-send
-        // watchdog OVERALL_SEND_TIMEOUT_MS must stay strictly ABOVE the WORST-CASE
-        // SEQUENTIAL LEG SUM (attachment upload leg + onSend leg), not merely above
-        // one leg. When RC-A grew SEND_TIMEOUT_MS to 50s, the leg sum became
-        // 90s + 50s = 140s; a flat 110s ceiling would sit BELOW it, reopening the
-        // spurious-fail / duplicate-dispatch window this epic targets. Assert the
-        // leg-sum invariant WITH headroom so the overall watchdog remains a pure
-        // last-resort backstop that fires only after every per-leg bound has.
-        val worstCaseLegSum =
-            PromptComposerViewModel.ATTACHMENT_UPLOAD_TIMEOUT_MS +
-                PromptComposerViewModel.SEND_TIMEOUT_MS
-        assertTrue(
-            "the #891 budget-sum invariant is broken: the worst-case leg sum " +
-                "(upload ${PromptComposerViewModel.ATTACHMENT_UPLOAD_TIMEOUT_MS}ms + onSend " +
-                "${PromptComposerViewModel.SEND_TIMEOUT_MS}ms = ${worstCaseLegSum}ms) must stay " +
-                "strictly below the whole-send watchdog OVERALL_SEND_TIMEOUT_MS " +
-                "(${PromptComposerViewModel.OVERALL_SEND_TIMEOUT_MS}ms), or exceeding it opens a " +
-                "spurious-fail / duplicate-dispatch window (audit Finding 2)",
-            worstCaseLegSum < PromptComposerViewModel.OVERALL_SEND_TIMEOUT_MS,
-        )
-        // OUTBOUND_IN_FLIGHT_STALE_MS (when an InFlight row is treated as abandoned
-        // and requeued) must never be below the longest a legit send can take, or a
-        // still-live send is duplicated — the same class this epic targets.
-        assertTrue(
-            "OUTBOUND_IN_FLIGHT_STALE_MS (${PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS}ms) " +
-                "must be >= the worst-case leg sum (${worstCaseLegSum}ms) so a live send is never " +
-                "requeued-and-duplicated",
-            PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS >= worstCaseLegSum,
-        )
-    }
-
-    /**
-     * Issue #1532 (RC-A) behavioural proof: model the dispatcher's exact
-     * `withTimeoutOrNull(SEND_TIMEOUT_MS) { onSend() }` where the host `onSend`
-     * spends ~15s (12s < t < 30s) waiting for a slow reconnect to become live and
-     * THEN delivers. The dispatcher must NOT cancel it before the connect budget
-     * elapses.
-     *
-     * RED on base (SEND_TIMEOUT_MS = 12_000): the 12s cap fires before the 15s
-     * connect-wait completes ⇒ `withTimeoutOrNull` returns null ⇒ delivered=false
-     * (cancelled-and-deferred). GREEN with the fix: the derived cap (50s) covers
-     * the wait ⇒ delivered.
-     */
-    @Test
-    fun sendDuringSlowReconnectIsNotCancelledBeforeConnectBudget() = runTest {
-        val connectWaitMs = 15_000L // 12s < t < the 30s connect-wait budget
-        var onSendReachedDelivery = false
-
-        val delivered = kotlinx.coroutines.withTimeoutOrNull(
-            PromptComposerViewModel.SEND_TIMEOUT_MS,
-        ) {
-            // The connect-on-action host onSend: awaitLiveTmuxClientForSend polls up
-            // to SEND_SESSION_WAIT_TIMEOUT_MS for the reconnect to land, then delivers.
-            kotlinx.coroutines.delay(connectWaitMs)
-            onSendReachedDelivery = true
-            true
-        } == true
-
-        assertTrue(
-            "a send whose reconnect completes at t=15s (inside the 30s connect budget) must " +
-                "NOT be cancelled by the dispatcher cap and must deliver (audit D1)",
-            delivered,
-        )
-        assertTrue("onSend must have reached its delivery leg, not been cancelled mid-wait", onSendReachedDelivery)
-    }
 }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerSendBudgetTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerSendBudgetTest.kt
@@ -1,0 +1,35 @@
+package com.pocketshell.app.composer
+
+import com.pocketshell.app.tmux.SEND_SESSION_WAIT_TIMEOUT_MS
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Timeout invariants kept separate from the outbound queue behavior fixture. */
+class PromptComposerSendBudgetTest {
+    @Test
+    fun dispatcherSendBudgetIsNotShorterThanConnectWaitBudget() {
+        assertTrue(
+            PromptComposerViewModel.SEND_TIMEOUT_MS >= SEND_SESSION_WAIT_TIMEOUT_MS,
+        )
+        val worstCaseLegSum =
+            PromptComposerViewModel.ATTACHMENT_UPLOAD_TIMEOUT_MS +
+                PromptComposerViewModel.SEND_TIMEOUT_MS
+        assertTrue(worstCaseLegSum < PromptComposerViewModel.OVERALL_SEND_TIMEOUT_MS)
+        assertTrue(PromptComposerViewModel.OUTBOUND_IN_FLIGHT_STALE_MS >= worstCaseLegSum)
+    }
+
+    @Test
+    fun sendDuringSlowReconnectIsNotCancelledBeforeConnectBudget() = runTest {
+        var reachedDelivery = false
+        val delivered = withTimeoutOrNull(PromptComposerViewModel.SEND_TIMEOUT_MS) {
+            delay(15_000L)
+            reachedDelivery = true
+            true
+        } == true
+        assertTrue(delivered)
+        assertTrue(reachedDelivery)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerSendPipeliningTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerSendPipeliningTest.kt
@@ -659,6 +659,8 @@ class PromptComposerSendPipeliningTest {
                 route: OutboundRoute,
                 agentKind: String?,
                 sendKey: String,
+                tmuxSessionId: String?,
+                tmuxSessionCreated: Long?,
             ): OutboundItem {
                 if (cleanText == "prompt B") error("synthetic enqueue rejection")
                 return super.enqueue(
@@ -671,6 +673,8 @@ class PromptComposerSendPipeliningTest {
                     route,
                     agentKind,
                     sendKey,
+                    tmuxSessionId,
+                    tmuxSessionCreated,
                 )
             }
         }

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerWireOracleClogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerWireOracleClogTest.kt
@@ -5,7 +5,9 @@ import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
 import com.pocketshell.app.di.WhisperClientFactory
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.tmux.OUTBOUND_DEFERRED_REDISPATCH_BACKOFF_MS
+import com.pocketshell.app.tmux.DurableOutboundRowIdentity
 import com.pocketshell.app.tmux.OutboundQueueAutoFlushController
+import com.pocketshell.app.tmux.durableAgentQueueSendMustDefer
 import com.pocketshell.app.tmux.outboundBudgetTestComposer
 import com.pocketshell.app.tmux.runOutboundQueueAutoFlush
 import com.pocketshell.core.voice.WhisperClient
@@ -177,6 +179,41 @@ class PromptComposerWireOracleClogTest {
             dispatched,
         )
         job.cancelAndJoin()
+    }
+
+    @Test
+    fun wireDropsAfterDrainReadinessBeforeDurableAgentDispatch() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(queue)
+        val session = "tmux:1:\$1:100"
+        vm.onComposerTargetChanged(session)
+        val row = queue.enqueue(session, "dictated during outage", createdAtMs = 1L)
+        vm.refreshOutboundQueueItemsFor(session)
+
+        // Scheduling observed a writable wire and claimed the row.
+        var transportWritable = true
+        val claimedId = vm.retryNextOutboundItem()
+        advanceUntilIdle()
+        assertEquals(row.id, claimedId)
+        val request = requireNotNull(vm.inFlightSendRequest)
+
+        // The exact race: the wire dies after readiness but immediately before
+        // the agent delivery call. The durable lane must fail fast without IO,
+        // then the real dispatcher failure branch re-arms the same row.
+        transportWritable = false
+        var networkCalls = 0
+        val mustDefer = durableAgentQueueSendMustDefer(
+            DurableOutboundRowIdentity(session, row.id),
+            transportWritable,
+        )
+        if (!mustDefer) networkCalls += 1
+        assertTrue(mustDefer)
+        vm.resolveFailureLikeDispatcher(request)
+        advanceUntilIdle()
+
+        assertEquals("a dead wire must not be touched", 0, networkCalls)
+        assertEquals(OutboundState.Queued, requireNotNull(queue.item(row.id)).state)
+        assertTrue(vm.uiState.value.sendInFlight.not())
     }
 
     // -------- Layer 2: the failure taxonomy --------

--- a/app/src/test/java/com/pocketshell/app/composer/SharedPrefsOutboundQueueStoreDurabilityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/SharedPrefsOutboundQueueStoreDurabilityTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.composer
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -295,5 +296,107 @@ class SharedPrefsOutboundQueueStoreDurabilityTest {
         val afterRestart = newStore()
         assertTrue(afterRestart.itemsFor("sessA").isEmpty())
         assertNull(afterRestart.item("anything"))
+    }
+
+    @Test
+    fun paneProvenIdentityPromotionIsAtomicAndPreservesDeliveryLedgerAcrossRestart() {
+        val fallback = "1944/project-a"
+        val durable = "tmux:1944:\$12:1700000000"
+        val store = newStore()
+        val first = store.enqueue(
+            fallback,
+            "first",
+            attachments = listOf(DurableAttachmentRef("/remote/a", "a.txt", "text/plain")),
+            withEnter = false,
+            createdAtMs = 10,
+            paneId = "%192",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "claude",
+            sendKey = "logical-first",
+            tmuxSessionId = "\$12",
+            tmuxSessionCreated = 1700000000,
+        )
+        store.claimNext(fallback)
+        store.markWireAttempted(fallback, first.id, 12, 3, 1)
+        store.markFailed(first.id, "deferred", 13)
+        store.requeueForRetry(first.id)
+        val second = store.enqueue(fallback, "second", createdAtMs = 20, paneId = "%192", tmuxSessionId = "\$12", tmuxSessionCreated = 1700000000)
+        val foreign = store.enqueue(fallback, "foreign", createdAtMs = 30, paneId = "%777")
+        val expectedFirst = requireNotNull(store.item(first.id))
+
+        assertEquals(
+            listOf(first.id, second.id),
+            store.promoteSessionIdentity(fallback, durable, setOf("%192"), "\$12", 1700000000).map { it.id },
+        )
+
+        val restarted = newStore()
+        val rebound = restarted.itemsFor(durable)
+        assertEquals(listOf(first.id, second.id), rebound.map { it.id })
+        assertEquals(listOf("first", "second"), rebound.map { it.cleanText })
+        assertTrue(rebound.first().wireAttempted)
+        assertEquals(3, rebound.first().wireNeedleBaselineCount)
+        assertEquals(expectedFirst.copy(sessionKey = durable), rebound.first())
+        assertEquals("\$12", rebound.first().tmuxSessionId)
+        assertEquals(1700000000L, rebound.first().tmuxSessionCreated)
+        assertEquals(listOf(foreign.id), restarted.itemsFor(fallback).map { it.id })
+        assertTrue(restarted.promoteSessionIdentity(fallback, durable, setOf("%192"), "\$12", 1700000000).isEmpty())
+        assertEquals(first.id, restarted.claimNext(durable)?.id)
+        assertEquals(second.id, restarted.claimNext(durable)?.id)
+    }
+
+    @Test
+    fun submitLatchIsSynchronouslyCommittedBeforeCrashAndVisibleAfterRestart() {
+        val backing = context.getSharedPreferences("issue1944-submit-latch", Context.MODE_PRIVATE)
+        backing.edit().clear().commit()
+        val row = SharedPrefsOutboundQueueStore(backing).enqueue("sessA", "must not submit twice")
+        // Wait for the ordinary enqueue apply before opening the deliberate crash window.
+        backing.edit().commit()
+        val crashWindowPrefs = ApplyLosingSharedPreferences(backing)
+        val store = SharedPrefsOutboundQueueStore(crashWindowPrefs)
+
+        val latched = store.markWireSubmitAttempted("sessA", row.id)
+
+        assertEquals("submit latch must use synchronous commit", 1, crashWindowPrefs.commitCount)
+        assertEquals("submit latch must not rely on async apply", 0, crashWindowPrefs.applyCount)
+        assertEquals(true, latched?.wireSubmitAttempted)
+        val afterCrash = SharedPrefsOutboundQueueStore(backing)
+        assertTrue(afterCrash.hasWireSubmitAttempt("sessA", row.id))
+        assertTrue(
+            "the exact restart-visible row carries the fail-closed submit latch",
+            afterCrash.item(row.id)?.wireSubmitAttempted == true,
+        )
+    }
+}
+
+/** Simulates process death dropping every asynchronous apply while preserving commit writes. */
+private class ApplyLosingSharedPreferences(
+    private val delegate: SharedPreferences,
+) : SharedPreferences by delegate {
+    var applyCount: Int = 0
+        private set
+    var commitCount: Int = 0
+        private set
+
+    override fun edit(): SharedPreferences.Editor = Editor(delegate.edit())
+
+    private inner class Editor(
+        private val delegateEditor: SharedPreferences.Editor,
+    ) : SharedPreferences.Editor {
+        override fun putString(key: String?, value: String?) = apply { delegateEditor.putString(key, value) }
+        override fun putStringSet(key: String?, values: MutableSet<String>?) =
+            apply { delegateEditor.putStringSet(key, values) }
+        override fun putInt(key: String?, value: Int) = apply { delegateEditor.putInt(key, value) }
+        override fun putLong(key: String?, value: Long) = apply { delegateEditor.putLong(key, value) }
+        override fun putFloat(key: String?, value: Float) = apply { delegateEditor.putFloat(key, value) }
+        override fun putBoolean(key: String?, value: Boolean) = apply { delegateEditor.putBoolean(key, value) }
+        override fun remove(key: String?) = apply { delegateEditor.remove(key) }
+        override fun clear() = apply { delegateEditor.clear() }
+        override fun commit(): Boolean {
+            commitCount += 1
+            return delegateEditor.commit()
+        }
+        override fun apply() {
+            applyCount += 1
+        }
     }
 }

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionListParserTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionListParserTest.kt
@@ -129,6 +129,20 @@ class HostTmuxSessionListParserTest {
     }
 
     @Test
+    fun parseTmuxListSessionsCarriesFullGenerationIdentityFromPickerShapes() {
+        val rows = parser.parseTmuxListSessions(
+            "\$7::renamed::1779520800::1779521400::1::/srv/project\n" +
+                "\$8::other::1779510000::1779510500::0\n",
+        )
+
+        assertEquals(listOf("renamed", "other"), rows.map { it.name })
+        assertEquals(listOf("\$7", "\$8"), rows.map { it.tmuxSessionId })
+        assertEquals(listOf(1779520800L, 1779510000L), rows.map { it.createdAt })
+        assertEquals("/srv/project", rows[0].path)
+        assertNull(rows[1].path)
+    }
+
+    @Test
     fun parseTmuxListSessionsReadsSessionPathFromFiveFieldShape() {
         // Issue #463: the warm live-client query appends `#{session_path}`.
         val rows = parser.parseTmuxListSessions(

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModelTest.kt
@@ -180,10 +180,10 @@ class HostTmuxSessionPickerViewModelTest {
                 result = HostTmuxSessionListResult.Sessions(emptyList()),
                 liveResult = HostTmuxSessionListResult.Sessions(
                     listOf(
-                        HostTmuxSessionRow(name = "a", lastActivity = 10L, path = "/proj"),
-                        HostTmuxSessionRow(name = "b", lastActivity = 30L, path = "/proj"),
-                        HostTmuxSessionRow(name = "other", lastActivity = 99L, path = "/elsewhere"),
-                        HostTmuxSessionRow(name = "c", lastActivity = 20L, path = "/proj/"),
+                        HostTmuxSessionRow(name = "a", tmuxSessionId = "\$1", createdAt = 1L, lastActivity = 10L, path = "/proj"),
+                        HostTmuxSessionRow(name = "b", tmuxSessionId = "\$2", createdAt = 2L, lastActivity = 30L, path = "/proj"),
+                        HostTmuxSessionRow(name = "other", tmuxSessionId = "\$3", createdAt = 3L, lastActivity = 99L, path = "/elsewhere"),
+                        HostTmuxSessionRow(name = "c", tmuxSessionId = "\$4", createdAt = 4L, lastActivity = 20L, path = "/proj/"),
                     ),
                 ),
             ),

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
@@ -39,8 +39,8 @@ class HostTmuxSessionsGatewayTest {
         client.responses += CommandResponse(
             number = 1L,
             output = listOf(
-                "beta::101::301::1::/home/alexey/git/pocketshell",
-                "alpha::100::300::0::/home/alexey/git/other",
+                "\$2::beta::101::301::1::/home/alexey/git/pocketshell",
+                "\$1::alpha::100::300::0::/home/alexey/git/other",
             ),
             isError = false,
         )
@@ -60,6 +60,7 @@ class HostTmuxSessionsGatewayTest {
         assertTrue(result is HostTmuxSessionListResult.Sessions)
         val rows = (result as HostTmuxSessionListResult.Sessions).rows
         assertEquals(listOf("beta", "alpha"), rows.map { it.name })
+        assertEquals(listOf("\$2", "\$1"), rows.map { it.tmuxSessionId })
         assertEquals(
             listOf("/home/alexey/git/pocketshell", "/home/alexey/git/other"),
             rows.map { it.path },
@@ -68,7 +69,7 @@ class HostTmuxSessionsGatewayTest {
         assertEquals(
             listOf(
                 "list-sessions -F " +
-                    "'#{session_name}::#{session_created}::#{session_activity}::" +
+                    "'#{session_id}::#{session_name}::#{session_created}::#{session_activity}::" +
                     "#{session_attached}::#{session_path}'",
             ),
             client.sentCommands,
@@ -80,10 +81,8 @@ class HostTmuxSessionsGatewayTest {
         val session = FakeSshSession(
             responses = ArrayDeque(
                 listOf(
-                    ExecResult(stdout = "", stderr = "not found", exitCode = 127),
-                    ExecResult(stdout = "alpha::100::300::0\n", stderr = "", exitCode = 0),
-                    ExecResult(stdout = "", stderr = "not found", exitCode = 127),
-                    ExecResult(stdout = "beta::101::301::1\n", stderr = "", exitCode = 0),
+                    ExecResult(stdout = "\$1::alpha::100::300::0\n", stderr = "", exitCode = 0),
+                    ExecResult(stdout = "\$2::beta::101::301::1\n", stderr = "", exitCode = 0),
                 ),
             ),
         )
@@ -112,10 +111,8 @@ class HostTmuxSessionsGatewayTest {
             assertFalse(session.closed)
             assertEquals(
                 listOf(
-                    "pocketshell sessions list --by activity",
-                    "tmux list-sessions -F '#{session_name}::#{session_created}::#{session_activity}::#{session_attached}'",
-                    "pocketshell sessions list --by activity",
-                    "tmux list-sessions -F '#{session_name}::#{session_created}::#{session_activity}::#{session_attached}'",
+                    "tmux list-sessions -F '#{session_id}::#{session_name}::#{session_created}::#{session_activity}::#{session_attached}'",
+                    "tmux list-sessions -F '#{session_id}::#{session_name}::#{session_created}::#{session_activity}::#{session_attached}'",
                 ).map { ReposRemoteSource.pathAwareCommand(it) },
                 session.execCommands,
             )
@@ -141,8 +138,7 @@ class HostTmuxSessionsGatewayTest {
         val session = FakeSshSession(
             responses = ArrayDeque(
                 listOf(
-                    ExecResult(stdout = "", stderr = "not found", exitCode = 127),
-                    ExecResult(stdout = "lease::100::300::0\n", stderr = "", exitCode = 0),
+                    ExecResult(stdout = "\$3::lease::100::300::0\n", stderr = "", exitCode = 0),
                 ),
             ),
         )
@@ -173,7 +169,7 @@ class HostTmuxSessionsGatewayTest {
             assertEquals(
                 listOf(
                     "list-sessions -F " +
-                        "'#{session_name}::#{session_created}::#{session_activity}::" +
+                        "'#{session_id}::#{session_name}::#{session_created}::#{session_activity}::" +
                         "#{session_attached}::#{session_path}'",
                 ),
                 client.sentCommands,

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
@@ -2,11 +2,18 @@ package com.pocketshell.app.tmux
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import com.pocketshell.app.composer.OutboundItem
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+import com.pocketshell.core.agents.MessageSendState
 import com.pocketshell.core.tmux.CommandResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -54,6 +61,7 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
     private val context: Context = ApplicationProvider.getApplicationContext()
 
     private val footer = "gpt-5.6-sol medium · Context 42% · Goal blocked (/goal resume)"
+    private lateinit var durableStore: InMemoryOutboundQueueStore
 
     private fun codexDetection(): AgentDetection = AgentDetection(
         agent = AgentKind.Codex,
@@ -63,7 +71,8 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
     )
 
     private fun newBurstVm(client: BurstTuiFakeTmuxClient): TmuxSessionViewModel {
-        val vm = newVm(applicationContext = context)
+        durableStore = InMemoryOutboundQueueStore()
+        val vm = newVm(applicationContext = context, outboundQueueStore = durableStore)
         vm.attachClientForTest(client)
         vm.startAgentConversationForTest("%0", codexDetection())
         vm.setAgentSubmitEnterDelayForTest(0)
@@ -74,6 +83,33 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
         vm.localRenderTextOverrideForTest["%0"] = footer
         return vm
     }
+
+    private fun durableRow(id: String, payload: String): DurableOutboundRowIdentity {
+        durableStore.enqueueExisting(
+            OutboundItem(
+                id = id,
+                sessionKey = "session-a",
+                cleanText = payload,
+                paneId = "%0",
+                createdAtMs = 1L,
+            ),
+        )
+        return DurableOutboundRowIdentity("session-a", id)
+    }
+
+    private fun transcriptUserTurn(
+        id: String,
+        payload: String,
+        sendState: MessageSendState = MessageSendState.Confirmed,
+    ): ConversationEvent.Message =
+        ConversationEvent.Message(
+            id = id,
+            agent = AgentKind.Codex,
+            atMillis = 1L,
+            role = ConversationRole.User,
+            text = payload,
+            sendState = sendState,
+        )
 
     /**
      * Route A (Terminal tab, gated submit) — the maintainer's Codex Send+Enter. On a
@@ -189,6 +225,296 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
     }
 
     /**
+     * Issue #1944: a successful tmux Enter write is not yet proof that the TUI has
+     * consumed that Enter and reopened its input loop. The durable FIFO worker used
+     * to prune row A and paste row B immediately. On a redraw/debounce boundary the
+     * TUI can echo B (so the pre-Enter paste ack succeeds) while still consuming A;
+     * B's Enter is then swallowed even though tmux reports success, and both durable
+     * rows are pruned.
+     *
+     * This fake requires one clean post-submit observation before it accepts the next
+     * turn's Enter. RED on the #1944 implementation before the submit-turnover gate:
+     * both calls return success, but only the first command is submitted.
+     */
+    @Test
+    fun consecutiveQueuedPromptsWaitForPreviousSubmitTurnover() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            requirePostSubmitObservationBeforeNextEnter = true,
+        )
+        val vm = newBurstVm(client)
+
+        assertTrue(
+            vm.sendAgentPayloadToPaneResult(
+                "%0", "first queued prompt", AgentKind.Codex,
+                sendToken = "row-a",
+                durableRow = durableRow("row-a", "first queued prompt"),
+            ).isSuccess,
+        )
+        assertTrue(
+            vm.sendAgentPayloadToPaneResult(
+                "%0", "second queued prompt", AgentKind.Codex,
+                sendToken = "row-b",
+                durableRow = durableRow("row-b", "second queued prompt"),
+            ).isSuccess,
+        )
+
+        assertEquals(
+            "the FIFO worker must not prune B until the TUI has consumed A's submit and " +
+                "reopened the input turn",
+            listOf("first queued prompt", "second queued prompt"),
+            client.submittedCommands,
+        )
+    }
+
+    @Test
+    fun transientNoPromptRedrawCannotAuthorizeNextQueuedPaste() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            transientNoPromptBeforeEnterConsumption = true,
+        )
+        val vm = newBurstVm(client)
+
+        val firstResult = vm.sendAgentPayloadToPaneResult(
+                "%0", "first queued prompt", AgentKind.Codex,
+                sendToken = "transient-row-a",
+                durableRow = durableRow("transient-row-a", "first queued prompt"),
+            )
+        assertTrue(firstResult.exceptionOrNull()?.message, firstResult.isSuccess)
+        assertTrue(
+            vm.sendAgentPayloadToPaneResult(
+                "%0", "second queued prompt", AgentKind.Codex,
+                sendToken = "transient-row-b",
+                durableRow = durableRow("transient-row-b", "second queued prompt"),
+            ).isSuccess,
+        )
+
+        assertFalse(
+            "row B must not be pasted while row A's Enter is still unconsumed",
+            client.pastedBeforePreviousEnterConsumed,
+        )
+        assertEquals(listOf("first queued prompt", "second queued prompt"), client.submittedCommands)
+    }
+
+    @Test
+    fun newConfirmedTranscriptTurnAcknowledgesFramedPromptlessSubmit() = runTest(scheduler) {
+        val payload = "recorded prompt"
+        lateinit var vm: TmuxSessionViewModel
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            forceNoPromptFrames = true,
+            onEnter = {
+                vm.appendAgentEventsForTest("%0", listOf(transcriptUserTurn("confirmed-new", payload)))
+            },
+        )
+        vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityForTest("%0", true)
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "transcript-row",
+            durableRow = durableRow("transcript-row", payload),
+        )
+
+        assertTrue(result.exceptionOrNull()?.message, result.isSuccess)
+    }
+
+    @Test
+    fun transcriptAuthorityMayBecomeActiveAfterSubmitBaseline() = runTest(scheduler) {
+        val payload = "reconnect tail startup prompt"
+        lateinit var vm: TmuxSessionViewModel
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            forceNoPromptFrames = true,
+            onEnter = {
+                vm.setAgentTranscriptAuthorityForTest("%0", true)
+                vm.appendAgentEventsForTest("%0", listOf(transcriptUserTurn("confirmed-after-start", payload)))
+            },
+        )
+        vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityStartingForTest("%0", true)
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "tail-start-row",
+            durableRow = durableRow("tail-start-row", payload),
+        )
+
+        assertTrue(result.exceptionOrNull()?.message, result.isSuccess)
+    }
+
+    @Test
+    fun transcriptTurnAfterGenericCeilingStillAcknowledgesWithinTailBound() = runTest(scheduler) {
+        val payload = "tail poll phase prompt"
+        lateinit var vm: TmuxSessionViewModel
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            forceNoPromptFrames = true,
+            onEnter = {
+                backgroundScope.launch {
+                    delay(1_200L)
+                    vm.appendAgentEventsForTest(
+                        "%0",
+                        listOf(transcriptUserTurn("confirmed-after-tail-poll", payload)),
+                    )
+                }
+            },
+        )
+        vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityForTest("%0", true)
+        val startedAt = testScheduler.currentTime
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "tail-poll-row",
+            durableRow = durableRow("tail-poll-row", payload),
+        )
+
+        val elapsed = testScheduler.currentTime - startedAt
+        assertTrue(result.exceptionOrNull()?.message, result.isSuccess)
+        assertTrue("ack must arrive after the generic 800ms ceiling: elapsed=$elapsed", elapsed > 800L)
+        assertTrue("ack must remain inside the 2s transcript ceiling: elapsed=$elapsed", elapsed < 2_000L)
+    }
+
+    @Test
+    fun preExistingOrOptimisticTranscriptTurnsDoNotAcknowledgeSubmit() = runTest(scheduler) {
+        val payload = "identical prompt"
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            forceNoPromptFrames = true,
+        )
+        val vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityForTest("%0", true)
+        vm.appendAgentEventsForTest(
+            "%0",
+            listOf(
+                transcriptUserTurn("confirmed-existing", payload),
+                transcriptUserTurn("pending-non-prefix", payload, MessageSendState.Pending),
+            ),
+        )
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "existing-row",
+            durableRow = durableRow("existing-row", payload),
+        )
+
+        assertTrue("no new authoritative transcript turn must retain the row", result.isFailure)
+    }
+
+    @Test
+    fun confirmedTurnFromWrongPaneDoesNotAcknowledgeSubmit() = runTest(scheduler) {
+        val payload = "pane-bound prompt"
+        lateinit var vm: TmuxSessionViewModel
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            forceNoPromptFrames = true,
+            onEnter = {
+                vm.appendAgentEventsForTest("%1", listOf(transcriptUserTurn("wrong-pane", payload)))
+            },
+        )
+        vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityForTest("%0", true)
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "wrong-pane-row",
+            durableRow = durableRow("wrong-pane-row", payload),
+        )
+
+        assertTrue("a foreign pane transcript must retain the row", result.isFailure)
+    }
+
+    @Test
+    fun confirmedTurnAfterDetectionSourceChangeDoesNotAcknowledgeSubmit() = runTest(scheduler) {
+        val payload = "source-bound prompt"
+        lateinit var vm: TmuxSessionViewModel
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            forceNoPromptFrames = true,
+            onEnter = {
+                vm.startAgentConversationForTest(
+                    "%0",
+                    codexDetection().copy(sourcePath = "/home/u/.codex/sessions/other.jsonl"),
+                    listOf(transcriptUserTurn("wrong-source", payload)),
+                )
+            },
+        )
+        vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityForTest("%0", true)
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "wrong-source-row",
+            durableRow = durableRow("wrong-source-row", payload),
+        )
+
+        assertTrue("a replacement detection/source must retain the row", result.isFailure)
+    }
+
+    /**
+     * Issue #1944's false-success discriminator: tmux accepts Enter, but the
+     * agent never consumes it and its pane never advances. The send result must
+     * remain ambiguous/failure so the composer cannot mark the durable row Sent
+     * and prune it.
+     */
+    @Test
+    fun enterWriteWithoutAgentTurnoverIsNotDeliverySuccess() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            neverConsumesEnter = true,
+        )
+        val vm = newBurstVm(client)
+        val startedAt = testScheduler.currentTime
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0",
+            "durable prompt must remain queued",
+            AgentKind.Codex,
+            sendToken = "durable-row",
+            durableRow = durableRow("durable-row", "durable prompt must remain queued"),
+        )
+
+        assertTrue("tmux write completion without pane turnover is ambiguous", result.isFailure)
+        assertTrue("the fake must have accepted the Enter command", client.sentCommands.any { it.endsWith(" Enter") })
+        assertTrue("the agent did not semantically submit the row", client.submittedCommands.isEmpty())
+        val elapsed = testScheduler.currentTime - startedAt
+        assertTrue("generic turnover must retain its 800ms ceiling: elapsed=$elapsed", elapsed < 1_000L)
+    }
+
+    /** An animated spinner/footer is not row-correlated submit evidence. */
+    @Test
+    fun unrelatedFrameChangeWhilePayloadRemainsInInputIsNotDeliverySuccess() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            neverConsumesEnter = true,
+            animateUnrelatedFrame = true,
+        )
+        val vm = newBurstVm(client)
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0",
+            "payload still visible in agent input",
+            AgentKind.Codex,
+            sendToken = "animated-row",
+            durableRow = durableRow("animated-row", "payload still visible in agent input"),
+        )
+
+        assertTrue("unrelated animation must not authorize durable prune", result.isFailure)
+        assertTrue(client.submittedCommands.isEmpty())
+    }
+
+    /**
      * Class coverage — the footer-present FALSE-MATCH itself: when the pane NEVER
      * renders the typed input (a fully wedged busy Codex), the ack gate must NOT
      * confirm on the permanent footer occurrence. It fails within the bounded
@@ -243,12 +569,24 @@ internal class BurstTuiFakeTmuxClient(
     private val footer: String,
     private val busyReadDelayCaptures: Int,
     private val neverRenders: Boolean = false,
+    private val requirePostSubmitObservationBeforeNextEnter: Boolean = false,
+    private val neverConsumesEnter: Boolean = false,
+    private val animateUnrelatedFrame: Boolean = false,
+    private val transientNoPromptBeforeEnterConsumption: Boolean = false,
+    private val forceNoPromptFrames: Boolean = false,
+    private val onEnter: (() -> Unit)? = null,
 ) : FakeTmuxClient() {
 
     private var pendingText: String? = null
     private var textRendered: Boolean = false
     private var capturesSincePaste: Int = 0
     private var submitted: Boolean = false
+    private var previousSubmitStillTurningOver: Boolean = false
+    private var renderedFrame: Int = 0
+    private var pendingEnter: Boolean = false
+    private var transientNoPromptEmitted: Boolean = false
+    var pastedBeforePreviousEnterConsumed: Boolean = false
+        private set
     val submittedCommands: MutableList<String> = mutableListOf()
 
     private val literalRegex = Regex("^send-keys -l -t \\S+ -- '(.*)'$")
@@ -258,20 +596,34 @@ internal class BurstTuiFakeTmuxClient(
 
     private fun interpret(cmd: String) {
         literalRegex.find(cmd)?.let { m ->
-            pendingText = m.groupValues[1].replace("'\\''", "'")
+            val pasted = m.groupValues[1].replace("'\\''", "'")
+            if (pendingEnter) {
+                pastedBeforePreviousEnterConsumed = true
+                pendingText = pendingText.orEmpty() + pasted
+            } else {
+                pendingText = pasted
+            }
             textRendered = false
             submitted = false
             capturesSincePaste = 0
             return
         }
         if (enterRegex.matches(cmd)) {
+            onEnter?.invoke()
+            if (neverConsumesEnter) return
+            if (transientNoPromptBeforeEnterConsumption) {
+                pendingEnter = true
+                transientNoPromptEmitted = false
+                return
+            }
             val text = pendingText
-            if (text != null && textRendered && !submitted) {
+            if (text != null && textRendered && !submitted && !previousSubmitStillTurningOver) {
                 // The text was read+rendered in a PRIOR read ⇒ this CR is its own read
                 // ⇒ Codex submits. If the text is still unread (textRendered == false),
                 // the CR batches with it and the paste-burst heuristic swallows it.
                 submitted = true
                 submittedCommands.add(text)
+                previousSubmitStillTurningOver = requirePostSubmitObservationBeforeNextEnter
             }
         }
     }
@@ -287,10 +639,14 @@ internal class BurstTuiFakeTmuxClient(
     }
 
     private fun renderLines(): List<String> {
-        val lines = mutableListOf(footer)
+        if (forceNoPromptFrames && submitted) return listOf("agent framed input redraw")
+        val lines = mutableListOf(
+            if (animateUnrelatedFrame) "$footer · spinner ${renderedFrame++}" else footer,
+        )
         val text = pendingText
         if (submitted && text != null) {
             lines.add("■ submitted $text: thread/goal set")
+            lines.add("›")
         } else if (textRendered && text != null) {
             lines.add("› $text")
         }
@@ -314,7 +670,27 @@ internal class BurstTuiFakeTmuxClient(
     ): CommandResponse {
         capturePaneTextViaExecCalls += paneId
         capturePaneTextViaExecScrollbackLines += scrollbackLines
+        if (pendingEnter && !transientNoPromptEmitted) {
+            transientNoPromptEmitted = true
+            return CommandResponse(
+                number = 0L,
+                output = listOf("redrawing agent input surface"),
+                isError = false,
+            )
+        }
+        if (pendingEnter) {
+            pendingEnter = false
+            submitted = true
+            pendingText?.let(submittedCommands::add)
+        }
         advanceCodexReadOnCapture()
-        return CommandResponse(number = 0L, output = renderLines(), isError = false)
+        val response = CommandResponse(number = 0L, output = renderLines(), isError = false)
+        // A clean observation after Enter models the TUI finishing its submitted-turn
+        // redraw and reopening the input loop. A capture performed only after the next
+        // paste is too late: that next turn is already sharing the busy boundary.
+        if (submitted && previousSubmitStillTurningOver) {
+            previousSubmitStillTurningOver = false
+        }
+        return response
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1587SingleStoreWiringTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1587SingleStoreWiringTest.kt
@@ -86,6 +86,11 @@ class Issue1587SingleStoreWiringTest : TmuxSessionViewModelTestBase() {
             // The ack gate sees the pasted payload immediately (fresh payload ⇒ baseline 0).
             defaultCaptureResponse =
                 CommandResponse(number = 0L, output = listOf("> $payload"), isError = false)
+            onCommandSent = { command ->
+                if (command == "send-keys -t $paneId Enter") {
+                    defaultCaptureResponse = CommandResponse(0L, listOf(">"), false)
+                }
+            }
         }
         val vm = newVm(applicationContext = context, outboundQueueStore = store)
         vm.attachClientForTest(client)

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1778SettleIdentityReachesViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1778SettleIdentityReachesViewModelTest.kt
@@ -80,7 +80,7 @@ class Issue1778SettleIdentityReachesViewModelTest : TmuxSessionViewModelTestBase
                     "switch after unifiedPanes republished under the measured index",
                 firstSwitch.isCompleted,
             )
-            assertEquals("deploy", firstSwitch.await())
+            assertEquals("deploy", firstSwitch.await().sessionName)
         }
 
     @Test
@@ -116,9 +116,9 @@ class Issue1778SettleIdentityReachesViewModelTest : TmuxSessionViewModelTestBase
             assertFalse(
                 "the confirmed release page must never route to the sibling " +
                     "cached session that drifted into its old index",
-                switched == "deploy",
+                switched.sessionName == "deploy",
             )
-            assertEquals("release", switched)
+            assertEquals("release", switched.sessionName)
         }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue895SwitchWhileBlackDropTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue895SwitchWhileBlackDropTest.kt
@@ -143,6 +143,12 @@ class Issue895SwitchWhileBlackDropTest {
         )
 
         val fired = vm.triggerCleanPassiveDropForTest()
+
+        assertTrue("clean-drop fixture must latch the selected client disconnected", client.disconnected.value)
+        assertTrue(
+            "clean-drop fixture must make the wire oracle unavailable immediately",
+            vm.liveTmuxClientForSendOrNullForTest() == null,
+        )
         advanceUntilIdle()
 
         assertTrue("drop should have been dispatched", fired)

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundAttachmentBackNavExactlyOnceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundAttachmentBackNavExactlyOnceTest.kt
@@ -116,6 +116,11 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
             output = composed.split('\n'),
             isError = false,
         )
+        onCommandSent = { command ->
+            if (command == "send-keys -t %0 Enter") {
+                defaultCaptureResponse = CommandResponse(0L, listOf(">"), false)
+            }
+        }
     }
 
     private fun ref(path: String): DurableAttachmentRef =
@@ -193,7 +198,7 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
             )
         }
         advanceUntilIdle()
-        assertTrue("the verified resend must succeed", second.await().isSuccess)
+        assertTrue("an unconfirmed prior Enter must remain unresolved", second.await().isFailure)
 
         // THE assertion (#1554 AC): the rebuilt VM must NOT re-paste the attachment
         // payload. On base (cleanText-only needle) VM #2 has no matching durable
@@ -201,11 +206,11 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
         // attachment-aware needle ⇒ 0 (Enter-only, occurrence 1).
         assertEquals(
             "attachment back-navigation mid-delivery must NOT duplicate: the rebuilt " +
-                "VM recognizes the landed composed payload and submits Enter only",
+                "VM recognizes the landed composed payload and never pastes it again",
             0,
             client2.bracketedPasteCount(composed),
         )
-        assertTrue("the rebuilt VM must still submit the pending row (Enter-only)", client2.enterCount() >= 1)
+        assertEquals("the rebuilt VM must not send a second ambiguous Enter", 0, client2.enterCount())
     }
 
     /**
@@ -266,13 +271,13 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
             )
         }
         advanceUntilIdle()
-        assertTrue(second.await().isSuccess)
+        assertTrue(second.await().isFailure)
         assertEquals(
             "multi-attachment back-navigation must NOT duplicate the composed payload",
             0,
             client2.bracketedPasteCount(composed),
         )
-        assertTrue(client2.enterCount() >= 1)
+        assertEquals(0, client2.enterCount())
     }
 
     /**
@@ -395,15 +400,17 @@ class OutboundAttachmentBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() 
             )
         }
         advanceUntilIdle()
-        assertTrue(second.await().isSuccess)
+        assertTrue(second.await().isFailure)
         assertEquals(
             "text-only back-navigation must remain exactly-once (no #1541 regression)",
             0,
             client2.literalPasteCount(payload),
         )
-        assertTrue(client2.enterCount() >= 1)
-        // And a delivered+pruned text row drops the durable flag (not falsely suppressed later).
-        store.markDelivered(row.id)
-        assertFalse(store.hasWireAttempt("sessT", row.id))
+        assertEquals(0, client2.enterCount())
+        assertTrue("the unresolved text row keeps its wire evidence", store.hasWireAttempt("sessT", row.id))
+        assertTrue(
+            "the unresolved text row keeps the Enter-ambiguity latch",
+            store.hasWireSubmitAttempt("sessT", row.id),
+        )
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
@@ -3,6 +3,8 @@ package com.pocketshell.app.tmux
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.OutboundItem
+import com.pocketshell.app.composer.OutboundQueueStore
 import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
@@ -61,8 +63,11 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         sentCommands.count { it == "send-keys -t %0 Enter" }
 
     /** A VM whose delivery ledger is durable-backed (real app context). */
-    private fun newDurableConnectedVm(client: FakeTmuxClient): TmuxSessionViewModel {
-        val vm = newVm(applicationContext = context)
+    private fun newDurableConnectedVm(
+        client: FakeTmuxClient,
+        store: OutboundQueueStore? = null,
+    ): TmuxSessionViewModel {
+        val vm = newVm(applicationContext = context, outboundQueueStore = store ?: SharedPrefsOutboundQueueStore(context))
         vm.attachClientForTest(client)
         vm.startAgentConversationForTest("%0", claudeDetection())
         vm.setAgentSubmitEnterDelayForTest(0)
@@ -72,6 +77,14 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
 
     private fun clientShowing(vararg lines: String): FakeTmuxClient = FakeTmuxClient().apply {
         defaultCaptureResponse = CommandResponse(number = 0L, output = lines.toList(), isError = false)
+        onCommandSent = { command ->
+            when {
+                command.startsWith("send-keys -l -t %0") ->
+                    defaultCaptureResponse = CommandResponse(0L, lines.toList(), false)
+                command == "send-keys -t %0 Enter" ->
+                    defaultCaptureResponse = CommandResponse(0L, listOf(">"), false)
+            }
+        }
     }
 
     /**
@@ -114,6 +127,7 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         assertEquals("attempt 1 pastes exactly once", 1, client1.pasteCount(payload))
         // The wire attempt is now DURABLE on the row (survives the VM-clear).
         assertTrue(store.hasWireAttempt("sessA", row.id))
+        assertTrue("the pre-Enter latch is restart-visible", store.hasWireSubmitAttempt("sessA", row.id))
 
         // The user taps BACK mid-delivery → VM #1 is cleared (its volatile ledger
         // dies). #780 model: a synthetic VM-clear, not process death.
@@ -123,7 +137,9 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
         // flag. The reconnect auto-flush re-dispatches the SAME row; the pane still
         // shows the landed payload.
         val client2 = clientShowing("> $payload")
-        val vm2 = newDurableConnectedVm(client2)
+        val restartedStore = SharedPrefsOutboundQueueStore(context)
+        assertTrue(restartedStore.hasWireSubmitAttempt("sessA", row.id))
+        val vm2 = newDurableConnectedVm(client2, restartedStore)
         val second = async {
             vm2.sendAgentPayloadToPaneResult(
                 "%0",
@@ -134,7 +150,10 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
             )
         }
         advanceUntilIdle()
-        assertTrue("the verified resend must succeed", second.await().isSuccess)
+        assertTrue(
+            "an unconfirmed prior Enter must stay queued without a blind second submit",
+            second.await().isFailure,
+        )
 
         // THE assertion (#1541 AC): the rebuilt VM must NOT re-paste. On base
         // (volatile ledger only) VM #2 has no memory and blindly re-pastes ⇒ 1
@@ -145,7 +164,7 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
             0,
             client2.pasteCount(payload),
         )
-        assertTrue("the rebuilt VM must still submit the pending row (Enter-only)", client2.enterCount() >= 1)
+        assertEquals("the rebuilt VM must not submit another ambiguous Enter", 0, client2.enterCount())
     }
 
     /**
@@ -257,5 +276,78 @@ class OutboundBackNavExactlyOnceTest : TmuxSessionViewModelTestBase() {
             2,
             client.pasteCount(payload),
         )
+    }
+
+    @Test
+    fun freshPasteCommitFailureSendsNoEnterAndAddsNoVolatileSuccessMarker() = runTest(scheduler) {
+        val payload = "commit barrier before fresh Enter"
+        val delegate = SharedPrefsOutboundQueueStore(context)
+        val row = delegate.enqueue("sess-submit-fresh", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+        val store = SubmitLatchFaultStore(delegate, SubmitLatchFault.ReturnFalse)
+        val client = clientShowing("> $payload")
+        val vm = newDurableConnectedVm(client, store)
+        val durableRow = DurableOutboundRowIdentity(row.sessionKey, row.id)
+
+        val failed = async {
+            vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode, row.id, durableRow)
+        }
+        advanceUntilIdle()
+        assertTrue(failed.await().isFailure)
+        assertEquals(1, client.pasteCount(payload))
+        assertEquals("commit=false must stop before Enter", 0, client.enterCount())
+        assertFalse(delegate.hasWireSubmitAttempt(row.sessionKey, row.id))
+        assertTrue("row remains durable and unresolved", delegate.item(row.id) != null)
+
+        store.fault = SubmitLatchFault.None
+        val retry = async {
+            vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode, row.id, durableRow)
+        }
+        advanceUntilIdle()
+        assertTrue("no volatile success marker may block the acknowledged retry", retry.await().isSuccess)
+        assertEquals("retry verifies the paste and sends one Enter only", 1, client.enterCount())
+        assertEquals("retry never re-pastes", 1, client.pasteCount(payload))
+    }
+
+    @Test
+    fun alreadyLandedCommitExceptionSendsNoEnterAndAddsNoVolatileSuccessMarker() = runTest(scheduler) {
+        val payload = "commit barrier before recovery Enter"
+        val delegate = SharedPrefsOutboundQueueStore(context)
+        val row = delegate.enqueue("sess-submit-recovery", payload, paneId = "%0", route = OutboundRoute.AgentConversation)
+        delegate.markWireAttempted(row.sessionKey, row.id, baselineCount = 0)
+        val store = SubmitLatchFaultStore(delegate, SubmitLatchFault.Throw)
+        val client = clientShowing("> $payload")
+        val vm = newDurableConnectedVm(client, store)
+        val durableRow = DurableOutboundRowIdentity(row.sessionKey, row.id)
+
+        val failed = async {
+            vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode, row.id, durableRow)
+        }
+        advanceUntilIdle()
+        assertTrue(failed.await().isFailure)
+        assertEquals(0, client.pasteCount(payload))
+        assertEquals("persistence exception must stop recovery before Enter", 0, client.enterCount())
+        assertFalse(delegate.hasWireSubmitAttempt(row.sessionKey, row.id))
+
+        store.fault = SubmitLatchFault.None
+        val retry = async {
+            vm.sendAgentPayloadToPaneResult("%0", payload, AgentKind.ClaudeCode, row.id, durableRow)
+        }
+        advanceUntilIdle()
+        assertTrue("failed persistence must not poison the volatile ledger", retry.await().isSuccess)
+        assertEquals(1, client.enterCount())
+        assertEquals(0, client.pasteCount(payload))
+    }
+}
+
+private enum class SubmitLatchFault { None, ReturnFalse, Throw }
+
+private class SubmitLatchFaultStore(
+    private val delegate: OutboundQueueStore,
+    var fault: SubmitLatchFault,
+) : OutboundQueueStore by delegate {
+    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = when (fault) {
+        SubmitLatchFault.None -> delegate.markWireSubmitAttempted(sessionKey, itemId)
+        SubmitLatchFault.ReturnFalse -> null
+        SubmitLatchFault.Throw -> error("synthetic submit-latch persistence failure")
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundDeliveryGuardTest.kt
@@ -35,6 +35,18 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, sdk = [33])
 class OutboundDeliveryGuardTest {
+    @Test
+    fun durableAgentQueueDefersImmediatelyUntilTransportIsWritable() {
+        val row = DurableOutboundRowIdentity("tmux:1:\$1:100", "row-1")
+
+        assertTrue(durableAgentQueueSendMustDefer(row, transportWritable = false))
+        assertFalse(durableAgentQueueSendMustDefer(row, transportWritable = true))
+        assertFalse(
+            "non-queued direct sends retain connect-on-action behavior",
+            durableAgentQueueSendMustDefer(null, transportWritable = false),
+        )
+    }
+
 
     @After
     fun tearDown() {
@@ -530,6 +542,34 @@ class OutboundDeliveryGuardTest {
             ledger.hasAmbiguousAttempt("%0", row.id, "unacked payload", durableRow),
         )
         assertTrue(store.hasWireAttempt("sessA", row.id))
+    }
+
+    @Test
+    fun persistedSubmitAttemptFailsClosedWithoutBlindEnterOrRepaste() = runTest {
+        val store = com.pocketshell.app.composer.InMemoryOutboundQueueStore()
+        val paneId = "%0"
+        val payload = "ambiguous agent submit"
+        val row = store.enqueue("sessA", payload, paneId = paneId)
+        store.claim(row.id)
+        store.markWireAttempted("sessA", row.id, baselineCount = 0)
+        store.markWireSubmitAttempted("sessA", row.id)
+        val durableRow = DurableOutboundRowIdentity("sessA", row.id)
+
+        val rebuilt = OutboundDeliveryLedger(durable = store.asWireAttemptDurableStore())
+        val outcome = verifyBeforeAgentResend(
+            rebuilt,
+            captureShowing("> $payload", "spinner changed"),
+            paneId,
+            row.id,
+            payload,
+            durableRow,
+        )
+
+        assertEquals(
+            "once Enter was attempted, payload visibility cannot distinguish typed from submitted",
+            DeliveryProbeOutcome.Unknown,
+            outcome,
+        )
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundPromotionDrainOrderingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundPromotionDrainOrderingTest.kt
@@ -1,0 +1,76 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OutboundPromotionDrainOrderingTest {
+    @Test
+    fun promotionAfterEmptyDurableSnapshotTriggersCanonicalFifoDrainExactlyOnce() {
+        val fallback = "1/renamed-a"
+        val durable = "tmux:1:\$0:123"
+        val store = InMemoryOutboundQueueStore()
+        val first = enqueueGenerationRow(store, fallback, "first", 1L)
+        val second = enqueueGenerationRow(store, fallback, "second", 2L)
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
+        val delivered = mutableListOf<String>()
+        val retryNext = canonicalStoreDrain(store, durable, delivered)
+
+        assertNull(controller.onQueueSnapshotChanged(sessionLive = true, retryNext = retryNext))
+        val promoted = store.promoteSessionIdentity(fallback, durable, setOf("%0"), "\$0", 123L)
+
+        requestOutboundDrainAfterPromotion(promoted, true, controller, { true }, retryNext)
+        controller.onQueueSnapshotChanged(sessionLive = true, retryNext = retryNext)
+        assertNull(controller.onQueueSnapshotChanged(sessionLive = true, retryNext = retryNext))
+
+        assertEquals(listOf(first.id, second.id), delivered)
+        assertEquals(2, delivered.toSet().size)
+        assertEquals(emptyList<com.pocketshell.app.composer.OutboundItem>(), store.itemsFor(durable))
+    }
+
+    @Test
+    fun promotionWithClosedWireWaitsForLaterCanonicalAvailabilityTrigger() {
+        val fallback = "1/renamed-a"
+        val durable = "tmux:1:\$0:123"
+        val store = InMemoryOutboundQueueStore()
+        val row = enqueueGenerationRow(store, fallback, "first", 1L)
+        val controller = OutboundQueueAutoFlushController.boundTo(outboundBudgetTestComposer())
+        val delivered = mutableListOf<String>()
+        val retryNext = canonicalStoreDrain(store, durable, delivered)
+        val promoted = store.promoteSessionIdentity(fallback, durable, setOf("%0"), "\$0", 123L)
+
+        assertNull(requestOutboundDrainAfterPromotion(promoted, false, controller, { true }, retryNext))
+        assertEquals(emptyList<String>(), delivered)
+        controller.onQueueSnapshotChanged(sessionLive = true, retryNext = retryNext)
+
+        assertEquals(listOf(row.id), delivered)
+    }
+
+    private fun canonicalStoreDrain(
+        store: InMemoryOutboundQueueStore,
+        durable: String,
+        delivered: MutableList<String>,
+    ): (Set<String>) -> String? = { excluded ->
+        val next = store.itemsFor(durable).firstOrNull { it.id !in excluded }
+        val claimed = next?.let { store.claim(it.id) }
+        claimed?.id?.also { id ->
+            delivered += id
+            store.remove(id)
+        }
+    }
+
+    private fun enqueueGenerationRow(
+        store: InMemoryOutboundQueueStore,
+        sessionKey: String,
+        text: String,
+        createdAtMs: Long,
+    ) = store.enqueue(
+        sessionKey = sessionKey,
+        cleanText = text,
+        createdAtMs = createdAtMs,
+        paneId = "%0",
+        tmuxSessionId = "\$0",
+        tmuxSessionCreated = 123L,
+    )
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
@@ -78,6 +78,11 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
 
     private fun clientShowing(vararg lines: String): FakeTmuxClient = FakeTmuxClient().apply {
         defaultCaptureResponse = CommandResponse(number = 0L, output = lines.toList(), isError = false)
+        onCommandSent = { command ->
+            if (command == "send-keys -t %0 Enter") {
+                defaultCaptureResponse = CommandResponse(0L, listOf(">"), false)
+            }
+        }
     }
 
     /**
@@ -243,13 +248,16 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
             )
         }
         advanceUntilIdle()
-        assertTrue("the verified resend must succeed", second.await().isSuccess)
+        assertTrue(
+            "an unconfirmed prior Enter must stay unresolved without a blind second submit",
+            second.await().isFailure,
+        )
         assertEquals(
             "a genuine resend of a payload that already LANDED must be deduped to " +
                 "exactly ONE paste (the baseline-aware probe still catches real duplicates)",
             1,
             client.literalPasteCount(payload),
         )
-        assertTrue("the resend must still submit (Enter-only)", client.enterCount() >= 2)
+        assertEquals("only the ambiguous first Enter reaches the wire", 1, client.enterCount())
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxOutboundQueueBindingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxOutboundQueueBindingTest.kt
@@ -1,0 +1,164 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.app.composer.InMemoryOutboundQueueStore
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.uikit.model.SessionAgentKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TmuxOutboundQueueBindingTest {
+    @Test
+    fun nameOnlyTargetPromotesBadgeComposerAndDrainToOneDurableKey() {
+        val fallback = tmuxOutboundQueueBinding(7L, "work", emptyList(), null, null, false)
+        assertEquals("7/work", fallback.targetKey)
+        assertNull(fallback.durableKey)
+
+        val correlatedNavigation = tmuxOutboundQueueBinding(7L, "work", emptyList(), "\$9", 123L, false)
+        assertEquals("7/work", correlatedNavigation.targetKey)
+        assertNull(correlatedNavigation.durableKey)
+        assertEquals("\$9", correlatedNavigation.tmuxSessionId)
+        assertEquals(123L, correlatedNavigation.sessionCreated)
+
+        val pane = TmuxPaneState(
+            paneId = "%3",
+            windowId = "@1",
+            sessionId = "\$9",
+            sessionCreated = 123L,
+            title = "work",
+            terminalState = TerminalSurfaceState(),
+        )
+        val cachedWhileDown = tmuxOutboundQueueBinding(7L, "work", listOf(pane), null, null, false)
+        assertEquals("7/work", cachedWhileDown.targetKey)
+        assertEquals("\$9", cachedWhileDown.tmuxSessionId)
+        assertEquals(123L, cachedWhileDown.sessionCreated)
+
+        val settled = tmuxOutboundQueueBinding(7L, "work", listOf(pane), null, null, true)
+
+        assertEquals("tmux:7:\$9:123", settled.targetKey)
+        assertEquals(settled.targetKey, settled.durableKey)
+        assertEquals(setOf("%3"), settled.generationPaneIds)
+        assertEquals("7/work", settled.fallbackKey)
+    }
+
+    @Test
+    fun staleLiveStatusCannotPromoteUntilWireTruthSettlesThenPromotionIsExactAndIdempotent() {
+        val pane = TmuxPaneState(
+            paneId = "%3",
+            windowId = "@1",
+            sessionId = "\$9",
+            sessionCreated = 123L,
+            title = "work",
+            terminalState = TerminalSurfaceState(),
+        )
+        assertFalse(outboundGenerationSettled(sessionLive = true, wireWritable = false))
+        val held = tmuxOutboundQueueBinding(
+            7L, "work", listOf(pane), "\$9", 123L,
+            outboundGenerationSettled(sessionLive = true, wireWritable = false),
+        )
+        assertEquals("7/work", held.targetKey)
+        assertNull(held.durableKey)
+
+        val store = InMemoryOutboundQueueStore()
+        val row = store.enqueue(
+            sessionKey = held.targetKey,
+            cleanText = "dictated while wire down",
+            paneId = "%3",
+            tmuxSessionId = "\$9",
+            tmuxSessionCreated = 123L,
+        )
+        assertEquals(listOf(row), store.itemsFor("7/work"))
+        assertTrue(store.itemsFor("tmux:7:\$9:123").isEmpty())
+
+        assertTrue(outboundGenerationSettled(sessionLive = true, wireWritable = true))
+        val live = tmuxOutboundQueueBinding(
+            7L, "work", listOf(pane), "\$9", 123L,
+            outboundGenerationSettled(sessionLive = true, wireWritable = true),
+        )
+        val first = store.promoteSessionIdentity(
+            held.targetKey, requireNotNull(live.durableKey), live.generationPaneIds, "\$9", 123L,
+        )
+        val second = store.promoteSessionIdentity(
+            held.targetKey, requireNotNull(live.durableKey), live.generationPaneIds, "\$9", 123L,
+        )
+        assertEquals(listOf(row.id), first.map { it.id })
+        assertTrue(second.isEmpty())
+        assertEquals(row.copy(sessionKey = live.targetKey), store.itemsFor(live.targetKey).single())
+        assertTrue(store.itemsFor(held.targetKey).isEmpty())
+    }
+
+    @Test
+    fun disconnectedRecordedRouteIsExactGenerationAndPaneBound() {
+        val evidence = RecordedAgentRouteEvidence("tmux:1:\$1:100", "%3", AgentKind.ClaudeCode)
+        assertEquals(
+            AgentKind.ClaudeCode,
+            tmuxPresumedAgentKind(null, null, evidence, "tmux:1:\$1:100", "%3"),
+        )
+        assertEquals(evidence, retainRecordedAgentRouteEvidence(evidence, "tmux:1:\$1:100", "%3"))
+        assertNull(retainRecordedAgentRouteEvidence(evidence, "tmux:1:\$1:200", "%3"))
+        assertNull(retainRecordedAgentRouteEvidence(evidence, "tmux:1:\$1:100", "%9"))
+        assertNull(tmuxPresumedAgentKind(null, null, evidence, "tmux:1:\$1:200", "%3"))
+        assertNull(tmuxPresumedAgentKind(null, null, evidence, "tmux:1:\$1:100", "%9"))
+        assertNull(SessionAgentKind.Unknown.toRecordedAgentKindOrNull())
+        assertNull(SessionAgentKind.Shell.toRecordedAgentKindOrNull())
+
+        val detection = AgentDetection(
+            AgentKind.Codex,
+            "/tmp/codex.jsonl",
+            "codex",
+            AgentDetection.Confidence.ProcessConfirmed,
+        )
+        assertEquals(
+            AgentKind.Codex,
+            tmuxDisconnectedAgentKind(detection, evidence, "tmux:1:\$1:100", "%3"),
+        )
+        assertEquals(
+            AgentKind.ClaudeCode,
+            tmuxDisconnectedAgentKind(null, evidence, "tmux:1:\$1:100", "%3"),
+        )
+        assertNull(tmuxDisconnectedAgentKind(detection, evidence, "tmux:1:\$1:200", "%3"))
+        assertNull(tmuxDisconnectedAgentKind(detection, evidence, null, "%3"))
+        assertEquals("%3", tmuxComposerPaneIdForSnapshot(null, evidence, "tmux:1:\$1:100"))
+        assertNull(tmuxComposerPaneIdForSnapshot(null, evidence, "tmux:1:\$1:200"))
+    }
+
+    @Test
+    fun disconnectedKnownAgentSnapshotsAgentRouteButLiveTerminalKeepsRawBytes() {
+        assertEquals(
+            TmuxComposerSendRoute.AgentPayload,
+            tmuxComposerSendRouteForConnection(
+                false, AgentKind.ClaudeCode, false, AgentKind.ClaudeCode, null, true,
+            ),
+        )
+        assertEquals(
+            TmuxComposerSendRoute.RawBytes,
+            tmuxComposerSendRouteForConnection(
+                true, AgentKind.ClaudeCode, false, AgentKind.ClaudeCode, null, true,
+            ),
+        )
+    }
+
+    @Test
+    fun delayedRecordedKindReadsCannotOverwriteNewerAAfterABA() {
+        assertFalse(recordedAgentRefreshStillCurrent(1, 3, "tmux:1:\$1:100", "%3", "tmux:1:\$1:100", "%3"))
+        assertFalse(recordedAgentRefreshStillCurrent(2, 3, "tmux:1:\$2:200", "%9", "tmux:1:\$1:100", "%3"))
+        assertTrue(recordedAgentRefreshStillCurrent(3, 3, "tmux:1:\$1:100", "%3", "tmux:1:\$1:100", "%3"))
+    }
+
+    @Test
+    fun latestRecordedKindTokenDoesNotRequireDurableRouteEvidence() {
+        val tracker = RecordedAgentRouteTracker()
+        val nameOnly = tracker.begin(durableSessionKey = null, paneId = "%3")
+
+        assertTrue(tracker.isLatest(nameOnly))
+        assertFalse(tracker.isCurrent(nameOnly, durableSessionKey = null, paneId = "%3"))
+
+        val newer = tracker.begin(durableSessionKey = null, paneId = "%3")
+        assertFalse(tracker.isLatest(nameOnly))
+        assertTrue(tracker.isLatest(newer))
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxPaneAlternateOnParseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxPaneAlternateOnParseTest.kt
@@ -33,24 +33,26 @@ class TmuxPaneAlternateOnParseTest {
         inMode: String = "0",
         panePid: Long = 4321L,
         alternateOn: String = "1",
+        sessionCreated: Long = 1_700_000_123L,
     ): String = listOf(
         paneId, windowId, windowIndex.toString(), sessionId, sessionName, title,
         paneIndex.toString(), cwd, currentCommand, paneTty, inMode, panePid.toString(),
         alternateOn,
+        sessionCreated.toString(),
     ).joinToString(LIST_PANES_FIELD_SEPARATOR)
 
     @Test
-    fun listingCommandRequestsAlternateOnAsLastField() {
+    fun listingCommandRequestsAlternateOnAndGenerationAsFinalFields() {
         val command = buildTmuxPaneListingCommand("work")
         assertTrue(
             "the reconcile must request the SERVER-TRUTH alt-buffer flag",
             "#{alternate_on}" in command,
         )
-        // `#{alternate_on}` is the LAST field so an older tmux that omits it leaves
-        // every earlier field's index unchanged (parser tolerates its absence).
+        // Generation is appended after alternate_on so every earlier field keeps
+        // its historical index.
         assertTrue(
-            "alternate_on must be the final requested field",
-            command.trimEnd().endsWith("#{alternate_on}'"),
+            "session_created must be the final requested field",
+            command.trimEnd().endsWith("#{session_created}'"),
         )
         assertTrue("pane_pid must still precede alternate_on", "#{pane_pid}" in command)
     }
@@ -68,6 +70,7 @@ class TmuxPaneAlternateOnParseTest {
         assertEquals(4321L, parsed.panePid)
         assertEquals("node", parsed.currentCommand)
         assertEquals("/dev/pts/5", parsed.paneTty)
+        assertEquals(1_700_000_123L, parsed.sessionCreated)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionIdentityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionIdentityTest.kt
@@ -2,9 +2,21 @@ package com.pocketshell.app.tmux
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class TmuxSessionIdentityTest {
+    @Test
+    fun durableIdentityRoundTripsForNavigationWithoutNameFallback() {
+        val key = durableTmuxSessionKey(7, "\$12", 1_700_000_000)
+        assertEquals(
+            DurableTmuxSessionIdentity("\$12", 1_700_000_000),
+            parseDurableTmuxSessionIdentity(7, key),
+        )
+        assertNull(parseDurableTmuxSessionIdentity(8, key))
+        assertNull(parseDurableTmuxSessionIdentity(7, "7/project-a"))
+    }
+
     @Test
     fun sessionCardsTargetKeyTrimsSessionName() {
         assertEquals(

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -167,8 +167,8 @@ class TmuxSessionScreenTest {
             state = HostTmuxSessionPickerState.Ready(
                 request = pickerRequest(),
                 rows = listOf(
-                    HostTmuxSessionRow(name = "work"),
-                    HostTmuxSessionRow(name = "logs", attached = true),
+                    HostTmuxSessionRow(name = "work", tmuxSessionId = "\$1", createdAt = 100L),
+                    HostTmuxSessionRow(name = "logs", tmuxSessionId = "\$2", createdAt = 200L, attached = true),
                 ),
             ),
             currentSessionName = "work",
@@ -177,7 +177,12 @@ class TmuxSessionScreenTest {
         assertEquals(
             listOf(
                 SessionSwitcherPage(name = "work", statusLabel = "current", selectable = false),
-                SessionSwitcherPage(name = "logs", statusLabel = "attached", selectable = true),
+                SessionSwitcherPage(
+                    name = "logs",
+                    statusLabel = "attached",
+                    selectable = true,
+                    target = TmuxSessionNavigationTarget("logs", "\$2", 200L),
+                ),
             ),
             pages,
         )
@@ -188,7 +193,7 @@ class TmuxSessionScreenTest {
         val pages = sessionSwitcherPages(
             state = HostTmuxSessionPickerState.Ready(
                 request = pickerRequest(),
-                rows = listOf(HostTmuxSessionRow(name = "logs")),
+                rows = listOf(HostTmuxSessionRow(name = "logs", tmuxSessionId = "\$2", createdAt = 200L)),
             ),
             currentSessionName = "work",
         )
@@ -196,10 +201,30 @@ class TmuxSessionScreenTest {
         assertEquals(
             listOf(
                 SessionSwitcherPage(name = "work", statusLabel = "current", selectable = false),
-                SessionSwitcherPage(name = "logs", statusLabel = "available", selectable = true),
+                SessionSwitcherPage(
+                    name = "logs",
+                    statusLabel = "available",
+                    selectable = true,
+                    target = TmuxSessionNavigationTarget("logs", "\$2", 200L),
+                ),
             ),
             pages,
         )
+    }
+
+    @Test
+    fun sessionSwitcherPagesFailClosedWhenGenerationIdentityIsUnavailable() {
+        val pages = sessionSwitcherPages(
+            state = HostTmuxSessionPickerState.Ready(
+                request = pickerRequest(),
+                rows = listOf(HostTmuxSessionRow(name = "legacy-name-only", createdAt = 200L)),
+            ),
+            currentSessionName = "work",
+        )
+
+        assertEquals("identity unavailable", pages[1].statusLabel)
+        assertFalse(pages[1].selectable)
+        assertNull(pages[1].target)
     }
 
     @Test
@@ -208,8 +233,8 @@ class TmuxSessionScreenTest {
             state = HostTmuxSessionPickerState.Ready(
                 request = pickerRequest(),
                 rows = listOf(
-                    HostTmuxSessionRow(name = "logs", attached = true),
-                    HostTmuxSessionRow(name = "work"),
+                    HostTmuxSessionRow(name = "logs", tmuxSessionId = "\$2", createdAt = 200L, attached = true),
+                    HostTmuxSessionRow(name = "work", tmuxSessionId = "\$1", createdAt = 100L),
                 ),
             ),
             currentSessionName = "work",
@@ -218,7 +243,12 @@ class TmuxSessionScreenTest {
         assertEquals(
             listOf(
                 SessionSwitcherPage(name = "work", statusLabel = "current", selectable = false),
-                SessionSwitcherPage(name = "logs", statusLabel = "attached", selectable = true),
+                SessionSwitcherPage(
+                    name = "logs",
+                    statusLabel = "attached",
+                    selectable = true,
+                    target = TmuxSessionNavigationTarget("logs", "\$2", 200L),
+                ),
             ),
             pages,
         )
@@ -252,7 +282,7 @@ class TmuxSessionScreenTest {
 
         handleTmuxSessionSelection(
             currentSessionName = "work",
-            selectedSessionName = "work",
+            selectedTarget = TmuxSessionNavigationTarget("work"),
             onDismiss = { events += "dismiss" },
             onReplace = { events += "replace:$it" },
         )
@@ -266,9 +296,9 @@ class TmuxSessionScreenTest {
 
         handleTmuxSessionSelection(
             currentSessionName = "work",
-            selectedSessionName = "logs",
+            selectedTarget = TmuxSessionNavigationTarget("logs"),
             onDismiss = { events += "dismiss" },
-            onReplace = { events += "replace:$it" },
+            onReplace = { events += "replace:${it.sessionName}" },
         )
 
         assertEquals(listOf("dismiss", "replace:logs"), events)

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
@@ -1,10 +1,12 @@
 package com.pocketshell.app.tmux
 
 import com.pocketshell.app.connectivity.TerminalNetworkChange
+import com.pocketshell.app.connectivity.TerminalNetworkChangeKind
 import com.pocketshell.app.connectivity.TerminalNetworkSnapshot
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshKey
@@ -36,6 +38,86 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TmuxSessionViewModelReconnectTest : TmuxSessionViewModelTestBase() {
+    @Test
+    fun unrecoverableHostSeamBlocksColdOpenAndReconnectWhileArmed() {
+        assertTrue(syntheticUnrecoverableHostRejectsDial(true, TmuxConnectTrigger.OpenExisting))
+        assertTrue(syntheticUnrecoverableHostRejectsDial(true, TmuxConnectTrigger.AutoReconnect))
+    }
+
+    @Test
+    fun unrecoverableHostSeamAllowsColdOpenAndReconnectAfterClear() {
+        assertFalse(syntheticUnrecoverableHostRejectsDial(false, TmuxConnectTrigger.OpenExisting))
+        assertFalse(syntheticUnrecoverableHostRejectsDial(false, TmuxConnectTrigger.AutoReconnect))
+    }
+
+    @Test
+    fun unrecoverableHostSeamBlocksWarmLeaseAndFastSwitchReuseWhileArmed() {
+        assertFalse(syntheticUnrecoverableHostAllowsTransportReuse(true))
+    }
+
+    @Test
+    fun unrecoverableHostSeamRestoresWarmLeaseAndFastSwitchReuseAfterClear() {
+        assertTrue(syntheticUnrecoverableHostAllowsTransportReuse(false))
+    }
+
+    @Test
+    fun networkRestoreRedialsAcceptedColdOpenAfterItsTargetsWereCleared() = runTest(scheduler) {
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(sshLeaseManager = testLeaseManager(connector = connector, scope = this))
+        vm.setTmuxClientFactoryForTest { _, _, _ -> FakeTmuxClient().withSinglePane("work", "%1") }
+        vm.forceUnrecoverableHostForTest = true
+
+        vm.connect(7L, "alpha", "alpha.example", 22, "alex", "/keys/a", null, "work")
+        advanceUntilIdle()
+        assertEquals(0, connector.connectCount)
+        assertEquals("work", vm.latestRestoreIntentSnapshot()?.sessionName)
+        assertEquals(null, vm.activeSessionNameForTest())
+        assertEquals(null, vm.connectingSessionNameForTest())
+
+        vm.forceUnrecoverableHostForTest = false
+        vm.onNetworkChanged(
+            networkChange(reason = "network-restored").copy(
+                previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+                kind = TerminalNetworkChangeKind.NetworkRestored,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(1, connector.connectCount)
+        assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+    }
+
+    @Test
+    fun acceptedRestoreTargetRejectsStaleGenerationAndSupersededScreen() {
+        val a = SessionId("tmux:7:a:1")
+        val b = SessionId("tmux:7:b:2")
+        assertFalse(acceptedRestoreTargetIsCurrent(4L, 5L, a, a))
+        assertFalse(acceptedRestoreTargetIsCurrent(5L, 5L, a, b))
+        assertTrue(acceptedRestoreTargetIsCurrent(5L, 5L, b, b))
+    }
+
+    @Test
+    fun leavingFailedSessionScreenClearsAcceptedRestoreAndNetworkCannotReviveIt() = runTest(scheduler) {
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(sshLeaseManager = testLeaseManager(connector = connector, scope = this))
+        vm.forceUnrecoverableHostForTest = true
+        vm.connect(7L, "alpha", "alpha.example", 22, "alex", "/keys/a", null, "work")
+        advanceUntilIdle()
+
+        vm.onSessionScreenLeft()
+        vm.forceUnrecoverableHostForTest = false
+        vm.onNetworkChanged(
+            networkChange(reason = "network-restored").copy(
+                previous = TerminalNetworkSnapshot.NoValidatedNetwork,
+                kind = TerminalNetworkChangeKind.NetworkRestored,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(null, vm.latestRestoreIntentSnapshot())
+        assertEquals(0, connector.connectCount)
+    }
+
     @Test
     fun networkReconnectEvictsConnectedIdleLeaseBeforeReattaching() = runTest(scheduler) {
         val registry = ActiveTmuxClients()

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelUnifiedPanesTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelUnifiedPanesTest.kt
@@ -81,6 +81,7 @@ class TmuxSessionViewModelUnifiedPanesTest : TmuxSessionViewModelTestBase() {
         sessionName: String,
         hostId: Long,
         paneIds: List<String>,
+        durableSessionKey: String? = null,
     ): CachedTmuxRuntime =
         CachedTmuxRuntime(
             key = TmuxRuntimeKey(
@@ -90,6 +91,7 @@ class TmuxSessionViewModelUnifiedPanesTest : TmuxSessionViewModelTestBase() {
                 username = "alex",
                 keyPath = "/keys/a",
                 sessionName = sessionName,
+                durableSessionKey = durableSessionKey,
             ),
             hostName = "alpha",
             startDirectory = null,
@@ -107,6 +109,65 @@ class TmuxSessionViewModelUnifiedPanesTest : TmuxSessionViewModelTestBase() {
             remoteRows = 0,
             lease = null,
         )
+
+    @Test
+    fun navigationPreservesDurableIdentityForActiveAndWarmCachedSessions() = runTest(scheduler) {
+        val runtimeCache = TmuxSessionRuntimeCache()
+        val vm = newVm(runtimeCache = runtimeCache)
+        runtimeCache.put(
+            foreignSessionRuntime(
+                sessionName = "deploy",
+                hostId = 1L,
+                paneIds = listOf("%5"),
+                durableSessionKey = "tmux:1:\$5:1700000005",
+            ),
+        )
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+            tmuxSessionId = "\$4",
+            sessionCreated = 1_700_000_004,
+        )
+        vm.applyParsedPanesForTest(
+            listOf(
+                TmuxSessionViewModel.ParsedPane(
+                    paneId = "%4",
+                    windowId = "@4",
+                    sessionId = "\$4",
+                    title = "work",
+                    paneIndex = 0,
+                    sessionName = "work",
+                ),
+            ),
+        )
+
+        assertEquals(
+            TmuxSessionNavigationTarget("work", "\$4", 1_700_000_004),
+            vm.navigationTargetForKnownSession("work"),
+        )
+        val cachedDeployPane = vm.unifiedPanes.value.first { it.paneId == "%5" }
+        val correlatedRequest = async { vm.sessionSwitchRequest.first() }
+        runCurrent()
+        vm.settleOn(cachedDeployPane)
+        runCurrent()
+        assertEquals(
+            TmuxSessionNavigationTarget("deploy", "\$5", 1_700_000_005),
+            correlatedRequest.await(),
+        )
+        assertEquals(
+            TmuxSessionNavigationTarget("deploy", "\$5", 1_700_000_005),
+            vm.navigationTargetForKnownSession("deploy"),
+        )
+        // Resolution is race-safe and repeatable; it is not a consumptive side channel.
+        assertEquals(TmuxSessionNavigationTarget("deploy", "\$5", 1_700_000_005), vm.navigationTargetForKnownSession("deploy"))
+        assertEquals(TmuxSessionNavigationTarget("same-name-unknown"), vm.navigationTargetForKnownSession("same-name-unknown"))
+    }
 
     @Test
     fun unifiedPanesExcludesDriftedTwinOfActiveSessionSoNoPhantomPage() = runTest(scheduler) {
@@ -249,7 +310,7 @@ class TmuxSessionViewModelUnifiedPanesTest : TmuxSessionViewModelTestBase() {
         // session, never the foreign/random twin.
         vm.settleOn(deployPane)
         advanceUntilIdle()
-        assertEquals("deploy", firstSwitch.await())
+        assertEquals("deploy", firstSwitch.await().sessionName)
     }
 
     @Test

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -438,6 +438,43 @@ if [[ "$USE_POOL" == "1" && -z "${POCKETSHELL_AGENTS_PORT:-}" ]]; then
   printf 'Pool mode: agents fixture on host port %s\n' "${POCKETSHELL_AGENTS_PORT:-?}" >&2
 fi
 
+# Optional same-run fixture evidence. The capture happens while this wrapper still
+# owns BOTH the emulator and agents-port locks, so the container fingerprint,
+# readiness probe, Docker logs, and instrumentation outputs describe one coherent
+# run rather than a later inspection of a reusable pool container.
+CONNECTED_EVIDENCE_DIR="${POCKETSHELL_CONNECTED_EVIDENCE_DIR:-}"
+CONNECTED_EVIDENCE_STARTED_AT=""
+CONNECTED_EVIDENCE_RUN_ID=""
+if [[ -n "$CONNECTED_EVIDENCE_DIR" ]]; then
+  mkdir -p "$CONNECTED_EVIDENCE_DIR"
+  CONNECTED_EVIDENCE_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  CONNECTED_EVIDENCE_RUN_ID="${SUFFIX:-base}-${ANDROID_SERIAL:-unknown}-$$"
+  evidence_container="$(pocketshell_agents_container_for_port "${POCKETSHELL_AGENTS_PORT:-2222}")"
+  {
+    printf 'run_id=%s\n' "$CONNECTED_EVIDENCE_RUN_ID"
+    printf 'started_at=%s\n' "$CONNECTED_EVIDENCE_STARTED_AT"
+    printf 'android_serial=%s\n' "${ANDROID_SERIAL:-unknown}"
+    printf 'agents_port=%s\n' "${POCKETSHELL_AGENTS_PORT:-2222}"
+    printf 'container=%s\n' "$evidence_container"
+    printf 'claim_fingerprint=%s\n' "${POCKETSHELL_AGENTS_FIXTURE_IDENTITY:-unknown}"
+  } > "$CONNECTED_EVIDENCE_DIR/run-manifest-start.txt"
+  pocketshell_run_without_avd_lock_fd docker inspect "$evidence_container" \
+    > "$CONNECTED_EVIDENCE_DIR/docker-inspect-start.json" 2>&1
+  pocketshell_run_without_avd_lock_fd docker ps --no-trunc --filter "name=^/${evidence_container}$" \
+    > "$CONNECTED_EVIDENCE_DIR/docker-ps-start.txt" 2>&1
+  evidence_ssh_key="$(mktemp "${TMPDIR:-/tmp}/pocketshell-connected-evidence-key.XXXXXX")"
+  cp "$ROOT_DIR/tests/docker/test_key" "$evidence_ssh_key"
+  chmod 600 "$evidence_ssh_key"
+  {
+    printf '[%s] health=%s\n' "$(date -Is)" "$(docker inspect --format='{{.State.Health.Status}}' "$evidence_container")"
+    ssh -i "$evidence_ssh_key" -p "${POCKETSHELL_AGENTS_PORT:-2222}" \
+      -o BatchMode=yes -o ConnectTimeout=3 -o ConnectionAttempts=1 \
+      -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+      testuser@127.0.0.1 "printf 'issue1944 ssh ready '; tmux -V"
+  } > "$CONNECTED_EVIDENCE_DIR/docker-ssh-readiness.log" 2>&1
+  rm -f "$evidence_ssh_key"
+fi
+
 resolved_serial_lock=""
 if [[ -n "${ANDROID_SERIAL:-}" && -z "${POCKETSHELL_AVD_LOCK_ACQUIRED:-}" ]]; then
   # The caller-pinned path is resolved before its serial FD is opened.
@@ -934,6 +971,38 @@ NOTIFICATION_PERMISSION_TARGET_APK="$NOTIFICATION_PERMISSION_BUILD_DIR/outputs/a
 # shellcheck disable=SC2317
 pocketshell_connected_test_exit_cleanup() {
   local original_rc=$?
+  if [[ -n "${CONNECTED_EVIDENCE_DIR:-}" && -n "${CONNECTED_EVIDENCE_STARTED_AT:-}" ]]; then
+    local evidence_port evidence_container evidence_final_identity evidence_output_root
+    evidence_port="${POCKETSHELL_AGENTS_PORT:-2222}"
+    evidence_container="$(pocketshell_agents_container_for_port "$evidence_port")"
+    evidence_final_identity="$(pocketshell_agents_fixture_identity "$evidence_port")"
+    pocketshell_run_without_avd_lock_fd docker inspect "$evidence_container" \
+      > "$CONNECTED_EVIDENCE_DIR/docker-inspect-end.json" 2>&1 || true
+    pocketshell_run_without_avd_lock_fd docker logs --timestamps \
+      --since "$CONNECTED_EVIDENCE_STARTED_AT" "$evidence_container" \
+      > "$CONNECTED_EVIDENCE_DIR/docker-agents.log" 2>&1 || true
+    pocketshell_run_without_avd_lock_fd docker ps --no-trunc --filter "name=^/${evidence_container}$" \
+      > "$CONNECTED_EVIDENCE_DIR/docker-ps-end.txt" 2>&1 || true
+    {
+      printf 'run_id=%s\n' "$CONNECTED_EVIDENCE_RUN_ID"
+      printf 'started_at=%s\n' "$CONNECTED_EVIDENCE_STARTED_AT"
+      printf 'ended_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      printf 'android_serial=%s\n' "${ANDROID_SERIAL:-unknown}"
+      printf 'agents_port=%s\n' "$evidence_port"
+      printf 'container=%s\n' "$evidence_container"
+      printf 'claim_fingerprint=%s\n' "${POCKETSHELL_AGENTS_FIXTURE_IDENTITY:-unknown}"
+      printf 'final_fingerprint=%s\n' "$evidence_final_identity"
+      printf 'wrapper_exit_rc=%s\n' "$original_rc"
+    } > "$CONNECTED_EVIDENCE_DIR/run-manifest-end.txt"
+    find "$CONNECTED_EVIDENCE_DIR" -maxdepth 1 -type f ! -name SHA256SUMS -print0 \
+      | sort -z \
+      | xargs -0 -r sha256sum \
+      > "$CONNECTED_EVIDENCE_DIR/SHA256SUMS" 2>/dev/null || true
+    evidence_output_root="$ROOT_DIR/app/build${SUFFIX:+/lane-$SUFFIX}/outputs/connected_android_test_additional_output"
+    while IFS= read -r evidence_target; do
+      cp -a "$CONNECTED_EVIDENCE_DIR" "$evidence_target/fixture-run-bundle"
+    done < <(find "$evidence_output_root" -type d -name issue1526-exactly-once 2>/dev/null || true)
+  fi
   if [[ "$NOTIFICATION_PERMISSION_RESTORE_NEEDED" == "1" \
         && -n "$NOTIFICATION_PERMISSION_SCRATCH" ]]; then
     notification_permission_restore \

--- a/tests/docker/agent-bin/pocketshell-fake-agent
+++ b/tests/docker/agent-bin/pocketshell-fake-agent
@@ -57,7 +57,10 @@ PROMPT_PREFIX="> "
 SUBMIT_PREFIX="FAKE-AGENT SUBMITTED: "
 READY_MARKER="FAKE-AGENT-READY"
 RENDER_MODE="${POCKETSHELL_FAKE_AGENT_RENDER_MODE:-default}"
+SUBMIT_LEDGER="${POCKETSHELL_FAKE_AGENT_SUBMIT_LEDGER:-}"
+TRANSCRIPT_PATH="${POCKETSHELL_FAKE_AGENT_TRANSCRIPT:-}"
 ISSUE1153_RENDER_MODE="issue1153-incremental"
+ISSUE1944_RENDER_MODE="issue1944-framed-input"
 ISSUE1153_FRAME_MARKER="ISSUE1153-FRAME"
 ISSUE1153_FRAME_ROWS=20
 issue1153_full_render_count=0
@@ -90,6 +93,7 @@ last_submitted=""
 last_submitted_display=""
 # Issue #1687: session-relative paste counter, mirroring Claude Code's `#N`.
 paste_counter=0
+submit_counter=0
 
 # Redraw the whole viewport cleanly: home + clear screen, print the readiness
 # marker, the most-recent submitted line (if any), then the input box. Clearing
@@ -104,6 +108,20 @@ render_default() {
     printf '%s%s\r\n' "$SUBMIT_PREFIX" "$last_submitted"
   fi
   printf '%s%s' "$PROMPT_PREFIX" "$buffer"
+}
+
+# The real Claude/Codex input surface is framed rather than a readline `>`
+# prompt. This mode keeps pasted text observable to the paste-ingestion gate,
+# while deliberately remaining Unknown to the generic submit-turnover oracle.
+# The #1944 outage journey must therefore wait for the authoritative transcript
+# event appended on Enter, including when its tail starts after reconnect.
+render_issue1944_framed() {
+  printf '\033[H\033[2J'
+  printf '%s\r\n' "$READY_MARKER"
+  if [ -n "$last_submitted" ]; then
+    printf '%s%s\r\n' "$SUBMIT_PREFIX" "$last_submitted"
+  fi
+  printf '┃ %s' "$buffer"
 }
 
 # Initial #1769 frame: the SAME dense marker shape the journey previously
@@ -153,6 +171,8 @@ render_issue1153_incremental() {
 render() {
   if [ "$RENDER_MODE" = "$ISSUE1153_RENDER_MODE" ]; then
     render_issue1153_incremental
+  elif [ "$RENDER_MODE" = "$ISSUE1944_RENDER_MODE" ]; then
+    render_issue1944_framed
   else
     render_default
   fi
@@ -160,6 +180,8 @@ render() {
 
 if [ "$RENDER_MODE" = "$ISSUE1153_RENDER_MODE" ]; then
   render_issue1153_initial
+elif [ "$RENDER_MODE" = "$ISSUE1944_RENDER_MODE" ]; then
+  render_issue1944_framed
 else
   render_default
 fi
@@ -267,6 +289,18 @@ process_byte() {
       # paste still lands its real multi-line body.
       last_submitted="$submit_buffer"
       last_submitted_display="$buffer"
+      if [ -n "$SUBMIT_LEDGER" ] || [ -n "$TRANSCRIPT_PATH" ]; then
+        submit_counter=$((submit_counter + 1))
+      fi
+      if [ -n "$SUBMIT_LEDGER" ]; then
+        encoded_submit=$(printf '%s' "$submit_buffer" | base64 | tr -d '\r\n')
+        printf '%s|%s\n' "$submit_counter" "$encoded_submit" >> "$SUBMIT_LEDGER"
+      fi
+      if [ -n "$TRANSCRIPT_PATH" ]; then
+        transcript_text=$(printf '%s' "$submit_buffer" | sed 's/\\/\\\\/g; s/"/\\"/g')
+        printf '{"uuid":"fake-agent-user-%s","timestamp":"%s","message":{"role":"user","content":"%s"}}\n' \
+          "$submit_counter" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$transcript_text" >> "$TRANSCRIPT_PATH"
+      fi
       buffer=""
       submit_buffer=""
       dirty=1

--- a/tests/scripts/avd-pool-test.sh
+++ b/tests/scripts/avd-pool-test.sh
@@ -218,6 +218,86 @@ failed_run_still_releases_and_propagates_rc() {
     || fail "failed run leaked a pool serial: claimable=$claimable expected=$expected"
 }
 
+# Issue #1944: the optional evidence capture must run before either lane lock is
+# released, on success and failure, and must preserve the wrapper result.
+same_run_evidence_is_captured_under_lock_for_success_and_failure() {
+  local sandbox="$1"
+  local pool_serials="emulator-5570"
+  make_sandbox "$sandbox" "$pool_serials"
+  local sroot="$sandbox/root"
+  mkdir -p "$sroot/tests/docker"
+  printf 'fake-key\n' > "$sroot/tests/docker/test_key"
+  local serial_lock
+  serial_lock="$(
+    source "$sroot/scripts/lib/avd-lock.sh"
+    pocketshell_avd_lock_file_for_serial "$sroot" "emulator-5570"
+  )"
+
+  cat > "$sandbox/bin/docker" <<'DOCKER'
+#!/usr/bin/env bash
+lock_state=free
+if ! flock -n "$EXPECTED_SERIAL_LOCK" true; then lock_state=held; fi
+printf '%s|lock=%s\n' "$*" "$lock_state" >> "$FAKE_DOCKER_CALLS"
+case "${1:-}" in
+  inspect)
+    if [[ "$*" == *Health.Status* ]]; then printf 'healthy\n'
+    elif [[ "$*" == *State.StartedAt* ]]; then printf 'fixture-id 2026-08-02T00:00:00Z\n'
+    else printf '[{"Id":"fixture-id","State":{"StartedAt":"2026-08-02T00:00:00Z"}}]\n'
+    fi
+    ;;
+  ps) printf 'fixture-id pocketshell-test-agents\n' ;;
+  logs) printf '2026-08-02T00:00:01Z fixture same-run log\n' ;;
+esac
+DOCKER
+  cat > "$sandbox/bin/ssh" <<'SSH'
+#!/usr/bin/env bash
+printf 'issue1944 ssh ready tmux 3.4\n'
+SSH
+  chmod +x "$sandbox/bin/docker" "$sandbox/bin/ssh"
+
+  local wanted_rc
+  for wanted_rc in 0 7; do
+    local evidence="$sandbox/evidence-$wanted_rc"
+    local calls="$sandbox/docker-$wanted_rc.calls"
+    set +e
+    PATH="$sandbox/bin:$PATH" \
+      ADB="$sandbox/bin/adb" \
+      ANDROID_SDK="$sandbox" \
+      POCKETSHELL_POOL_WAIT_SECONDS=5 \
+      POCKETSHELL_POOL_SERIALS="$pool_serials" \
+      POCKETSHELL_AGENTS_PORT=2222 \
+      POCKETSHELL_AGENTS_FIXTURE_IDENTITY="fixture-id 2026-08-02T00:00:00Z" \
+      POCKETSHELL_CONNECTED_EVIDENCE_DIR="$evidence" \
+      EXPECTED_SERIAL_LOCK="$serial_lock" \
+      FAKE_DOCKER_CALLS="$calls" \
+      STUB_GRADLEW_ARGS_FILE="$sandbox/args-$wanted_rc.txt" \
+      STUB_GRADLEW_MARKER="$sandbox/marker-$wanted_rc.txt" \
+      STUB_GRADLEW_RC="$wanted_rc" \
+      bash "$sroot/scripts/connected-test.sh" --pool --suffix "evidence$wanted_rc" \
+      > "$sandbox/evidence-$wanted_rc.out" 2> "$sandbox/evidence-$wanted_rc.err"
+    local actual_rc=$?
+    set -e
+
+    [[ "$actual_rc" == "$wanted_rc" ]] \
+      || fail "evidence run rc=$actual_rc, expected $wanted_rc"
+    [[ -s "$evidence/docker-ssh-readiness.log" ]] || fail "missing readiness evidence for rc=$wanted_rc"
+    [[ -s "$evidence/docker-inspect-start.json" ]] || fail "missing start inspect for rc=$wanted_rc"
+    [[ -s "$evidence/docker-inspect-end.json" ]] || fail "missing end inspect for rc=$wanted_rc"
+    [[ -s "$evidence/docker-agents.log" ]] || fail "missing Docker log for rc=$wanted_rc"
+    [[ -s "$evidence/SHA256SUMS" ]] || fail "missing evidence hashes for rc=$wanted_rc"
+    grep -q "wrapper_exit_rc=$wanted_rc" "$evidence/run-manifest-end.txt" \
+      || fail "manifest lost wrapper rc=$wanted_rc"
+    grep -q 'claim_fingerprint=fixture-id 2026-08-02T00:00:00Z' "$evidence/run-manifest-end.txt" \
+      || fail "manifest lost claim fingerprint"
+    grep -q 'final_fingerprint=fixture-id 2026-08-02T00:00:00Z' "$evidence/run-manifest-end.txt" \
+      || fail "manifest lost final fingerprint"
+    if grep -q 'lock=free' "$calls"; then
+      fail "evidence command escaped serial ownership before exit (rc=$wanted_rc)"
+    fi
+    flock -n "$serial_lock" true || fail "evidence run leaked serial lock for rc=$wanted_rc"
+  done
+}
+
 # Issue #1737: the default non-pool path must resolve the one online emulator
 # and acquire/release the SAME per-serial ownership lock used by --pool. The old
 # global base lock was a split domain: pool and legacy could both mutate one AVD.
@@ -266,6 +346,7 @@ run_case() {
 
 run_case reclaim_after_full_pool_run
 run_case failed_run_still_releases_and_propagates_rc
+run_case same_run_evidence_is_captured_under_lock_for_success_and_failure
 run_case non_pool_suffix_run_acquires_and_releases_serial_lock
 
 printf 'PASS: avd-pool claim/release\n'


### PR DESCRIPTION
Closes #1944.

## Summary

- persist dictated/text prompts before any terminal Enter and preserve them across session navigation, reconnect, and process recreation
- bind queue draining to exact tmux generation/pane identity, with one physical drain owner and FIFO promotion from fallback to durable identity
- require exact agent transcript turnover for delivery acknowledgement; never treat a generic ready surface as proof
- keep queued rows visible in the composer on switch-away/return and retain stable evidence identifiers
- split queue/drain and transcript-authority responsibilities out of the oversized composer/session view models without raising ratchet baselines

## Regression evidence

- cancellation/consumer handoff, pre-handoff claim loss, stale promotion callback, and crash-before-Enter tests were reproduced red then green
- accept44 exposed an additional real race: exact-generation fallback rows could auto-drain before durable identity promotion; a deterministic red test now guards it
- focused queue/promotion/delivery suite: 127 tests, 0 failures/errors/skips
- authoritative connected accept45: 1/1 green; queue IDs equal delivered IDs in FIFO order; server ledger exactly two submissions; `remainingRows=[]`; two exact `%0` Claude transcript acknowledgements; six 1080x2400 screenshots; fixture hashes/fingerprints verified

## Verification

- independent reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/1944#issuecomment-5160765822
- implementer evidence — https://github.com/alexeygrigorev/pocketshell/issues/1944#issuecomment-5160741656
- `scripts/check-file-size-hygiene.sh`
- `scripts/check-connection-vm-ratchet.sh` (`TmuxSessionViewModel.kt` exactly 17,621 lines)
- `scripts/check-test-validity.sh`
- `scripts/check-ci-journey-harness.sh`
- `scripts/check-tests-referenced.sh`
- `git diff --check`
- unit + AndroidTest Kotlin compilation
- focused 127-test integration gate
- canonical full JVM integration gate: 603/603 tasks executed, `BUILD SUCCESSFUL in 18m41s`
