### PR TITLE
fix(composer): restore queued command completion

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
@@ -60,11 +60,10 @@ class PromptComposerOutboundQueueTest {
             }
         }
 
-        assertEquals(
-            "global payload lookup must demonstrate the ambiguous selector regression",
-            2,
+        assertTrue(
+            "global payload lookup must remain ambiguous so the stable row selector is load-bearing",
             compose.onAllNodesWithText(payload, substring = true, useUnmergedTree = true)
-                .fetchSemanticsNodes().size,
+                .fetchSemanticsNodes().size > 1,
         )
         compose.onNode(
             hasText(payload, substring = true) and hasAnyAncestor(hasTestTag(rowTag)),

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundDrainOwnership.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundDrainOwnership.kt
@@ -77,5 +77,10 @@ internal class OutboundSendConsumerRegistry {
     fun canDispatch(): Boolean = !registrationRequired || activeGeneration.get() != null
 
     fun accepts(generation: Long, requestGeneration: Long?): Boolean =
-        requestGeneration == generation && activeGeneration.get() == generation
+        activeGeneration.get() == generation &&
+            // Before the first screen registers, dispatch is intentionally
+            // allowed and carries no generation. Only the active consumer may
+            // adopt that bootstrap request; concrete generations stay exact so
+            // a replacement cannot steal work emitted for a retired screen.
+            (requestGeneration == null || requestGeneration == generation)
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
@@ -110,6 +110,18 @@ internal const val AGENT_SUBMIT_TURNOVER_TIMEOUT_MS: Long = 800L
 internal const val AGENT_TRANSCRIPT_TURNOVER_TIMEOUT_MS: Long = 2_000L
 
 /**
+ * The proof required after tmux accepts the submit Enter. Normal prompts must
+ * advance an authoritative agent surface/transcript before their durable row is
+ * pruned. Catalog-approved TUI-only controls intentionally create no transcript
+ * turn; for those, the acknowledged tmux Enter is the terminal delivery proof
+ * and the write-ahead submit ledger still prevents a blind resend after a crash.
+ */
+internal enum class AgentSubmitDeliveryProof {
+    AgentTurnover,
+    TmuxEnterAccepted,
+}
+
+/**
  * Issue #869: how many whitespace-stripped tail characters of the pasted prompt
  * the ack needle matches against `capture-pane`.
  */

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentTranscriptAuthority.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentTranscriptAuthority.kt
@@ -67,6 +67,16 @@ internal class AgentTranscriptAuthority(
         }
     }
 
+    fun baselineFor(
+        deliveryProof: AgentSubmitDeliveryProof,
+        paneId: String,
+        payload: String,
+    ): Baseline? = if (deliveryProof == AgentSubmitDeliveryProof.AgentTurnover) {
+        baseline(paneId, payload)
+    } else {
+        null
+    }
+
     fun timeoutMs(baseline: Baseline?): Long {
         if (baseline != null) return AGENT_TRANSCRIPT_TURNOVER_TIMEOUT_MS
         DiagnosticEvents.record(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1910,13 +1910,14 @@ private fun TmuxSessionSheetsRegion(
             request = request,
             targetSessionId = composerQueueSessionKey,
             fallbackPaneId = surfacePane?.paneId.orEmpty(),
-            sendAgentPayload = { paneId, text, agentKind, sendToken, durableRow ->
+            sendAgentPayload = { paneId, text, agentKind, sendToken, durableRow, deliveryProof ->
                 viewModel.sendAgentPayloadToPaneResult(
                     paneId,
                     text,
                     agentKind,
                     sendToken,
                     durableRow,
+                    deliveryProof,
                 ).isSuccess
             },
             sendToAgent = { paneId, text, sendToken, durableRow ->

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
@@ -592,14 +592,16 @@ internal fun tmuxAgentConversationSend(
 internal suspend fun tmuxAgentConversationSendResult(
     text: String,
     agentToken: String?,
-    sendAgentPayload: suspend (String, AgentKind) -> Boolean,
+    sendAgentPayload: suspend (String, AgentKind, AgentSubmitDeliveryProof) -> Boolean,
     sendToAgent: suspend (String) -> Boolean,
     setTuiNotice: (String) -> Unit,
 ): Boolean {
     val agentKind = tmuxComposerAgentKindFromToken(agentToken)
     return when (tmuxAgentConversationSend(text, agentKind)) {
         TmuxAgentConversationSend.TuiCommandNoEcho -> {
-            val ok = agentKind?.let { sendAgentPayload(text, it) } ?: false
+            val ok = agentKind?.let {
+                sendAgentPayload(text, it, AgentSubmitDeliveryProof.TmuxEnterAccepted)
+            } ?: false
             if (ok) setTuiNotice(text.trim())
             ok
         }
@@ -629,6 +631,7 @@ internal suspend fun tmuxComposerSendResult(
         agent: AgentKind,
         sendToken: String,
         durableRow: DurableOutboundRowIdentity?,
+        deliveryProof: AgentSubmitDeliveryProof,
     ) -> Boolean,
     sendToAgent: suspend (
         paneId: String,
@@ -673,15 +676,22 @@ internal suspend fun tmuxComposerSendResult(
             tmuxAgentConversationSendResult(
                 request.text,
                 target.agentKind,
-                { text, agent ->
-                    sendAgentPayload(paneId, text, agent, sendToken, durableRow)
+                { text, agent, deliveryProof ->
+                    sendAgentPayload(paneId, text, agent, sendToken, durableRow, deliveryProof)
                 },
                 { text -> sendToAgent(paneId, text, sendToken, durableRow) },
                 setTuiNotice,
             )
         OutboundRoute.AgentPayload ->
             tmuxComposerAgentKindFromToken(target.agentKind)?.let { agent ->
-                sendAgentPayload(paneId, request.text, agent, sendToken, durableRow)
+                sendAgentPayload(
+                    paneId,
+                    request.text,
+                    agent,
+                    sendToken,
+                    durableRow,
+                    AgentSubmitDeliveryProof.AgentTurnover,
+                )
             } ?: false
         OutboundRoute.RawBytes -> {
             val payload = if (request.withEnter) request.text + "\r" else request.text

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14099,7 +14099,7 @@ public class TmuxSessionViewModel @Inject constructor(
         payload: String,
         agent: AgentKind,
         sendToken: String = newOutboundDeliveryToken(),
-        durableRow: DurableOutboundRowIdentity? = null,
+        durableRow: DurableOutboundRowIdentity? = null, deliveryProof: AgentSubmitDeliveryProof = AgentSubmitDeliveryProof.AgentTurnover,
     ): Result<Unit> {
         if (durableAgentQueueSendMustDefer(durableRow, isSendTransportWritable())) {
             return Result.failure(IllegalStateException("Session is disconnected; kept queued."))
@@ -14112,7 +14112,7 @@ public class TmuxSessionViewModel @Inject constructor(
             payload,
             agent,
             sendToken,
-            durableRow,
+            durableRow, deliveryProof,
         )
     }
 
@@ -14191,7 +14191,7 @@ public class TmuxSessionViewModel @Inject constructor(
         payload: String,
         agent: AgentKind,
         sendToken: String,
-        durableRow: DurableOutboundRowIdentity?,
+        durableRow: DurableOutboundRowIdentity?, deliveryProof: AgentSubmitDeliveryProof,
     ): Result<Unit> {
         val payloadBytes = payload.toByteArray(Charsets.UTF_8)
         val runtimeIdentity = snapshotAgentSendRuntime(client)
@@ -14235,7 +14235,7 @@ public class TmuxSessionViewModel @Inject constructor(
                     captureAgentPaneBounded(runtimeIdentity, paneId, AGENT_SUBMIT_TURNOVER_TIMEOUT_MS, 0)
                         .response ?: error("Agent submit frame unavailable before Enter; kept queued.")
                 }
-                val transcriptBaseline = durableRow?.let { agentTranscriptAuthority.baseline(paneId, payload) }
+                val transcriptBaseline = agentTranscriptAuthority.baselineFor(deliveryProof, paneId, payload)
                 durableRow?.let { row ->
                     check(withContext(seedIoDispatcher) {
                         outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row)
@@ -14243,7 +14243,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 }
                 sendNamedKeyToPane(client, paneId, "Enter")
                     .throwIfTmuxError("submit previously pasted agent input")
-                if (preEnterFrame != null) {
+                if (preEnterFrame != null && deliveryProof == AgentSubmitDeliveryProof.AgentTurnover) {
                     agentTranscriptAuthority.awaitTurnover(
                         identity = runtimeIdentity,
                         paneId = paneId,
@@ -14354,7 +14354,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 "Tmux client disconnected after paste acknowledgement."
             }
             consumeSendResultLostSeamForTest()
-            val transcriptBaseline = durableRow?.let { agentTranscriptAuthority.baseline(paneId, payload) }
+            val transcriptBaseline = agentTranscriptAuthority.baselineFor(deliveryProof, paneId, payload)
             durableRow?.let { row ->
                 check(withContext(seedIoDispatcher) {
                     outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row)
@@ -14362,7 +14362,7 @@ public class TmuxSessionViewModel @Inject constructor(
             }
             sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
-            if (durableRow != null) {
+            if (durableRow != null && deliveryProof == AgentSubmitDeliveryProof.AgentTurnover) {
                 agentTranscriptAuthority.awaitTurnover(
                     identity = runtimeIdentity,
                     paneId = paneId,

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerDrainOwnershipTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerDrainOwnershipTest.kt
@@ -85,6 +85,33 @@ class PromptComposerDrainOwnershipTest {
     }
 
     @Test
+    fun issue1944_firstConsumerAcceptsRequestBufferedBeforeRegistration() {
+        val registry = OutboundSendConsumerRegistry()
+
+        assertTrue(registry.canDispatch())
+        assertNull(registry.activeGenerationForDispatch())
+
+        val firstConsumer = registry.register()
+
+        assertTrue(registry.accepts(firstConsumer, requestGeneration = null))
+    }
+
+    @Test
+    fun issue1944_replacementConsumerRejectsRequestsOwnedByRetiredGeneration() {
+        val registry = OutboundSendConsumerRegistry()
+        val retiredConsumer = registry.register()
+        assertTrue(registry.accepts(retiredConsumer, retiredConsumer))
+        assertTrue(registry.unregister(retiredConsumer))
+        assertFalse(registry.canDispatch())
+
+        val replacementConsumer = registry.register()
+
+        assertFalse(registry.accepts(retiredConsumer, retiredConsumer))
+        assertFalse(registry.accepts(replacementConsumer, retiredConsumer))
+        assertTrue(registry.accepts(replacementConsumer, replacementConsumer))
+    }
+
+    @Test
     fun fallbackPhysicalOwnerSurvivesPromotionUntilDeferredThenDurableFifoRetries() = runTest {
         val fallback = "1/session-a"
         val durable = "tmux:1:\$0:1944"

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
@@ -491,6 +491,34 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
         assertTrue("generic turnover must retain its 800ms ceiling: elapsed=$elapsed", elapsed < 1_000L)
     }
 
+    /**
+     * Issue #1944 / #1207: a catalog-approved TUI-only control has no transcript
+     * turn by contract. Its acknowledged tmux Enter therefore completes the
+     * durable control row without weakening the turnover oracle for prompts.
+     */
+    @Test
+    fun tuiOnlyControlUsesAcknowledgedEnterInsteadOfImpossibleTranscriptTurn() = runTest(scheduler) {
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            neverConsumesEnter = true,
+        )
+        val vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityForTest("%0", true)
+
+        val result = vm.sendAgentPayloadToPaneResult(
+            "%0",
+            "/model",
+            AgentKind.ClaudeCode,
+            sendToken = "tui-control-row",
+            durableRow = durableRow("tui-control-row", "/model"),
+            deliveryProof = AgentSubmitDeliveryProof.TmuxEnterAccepted,
+        )
+
+        assertTrue(result.isSuccess)
+        assertTrue(client.sentCommands.any { it.endsWith(" Enter") })
+    }
+
     /** An animated spinner/footer is not row-correlated submit evidence. */
     @Test
     fun unrelatedFrameChangeWhilePayloadRemainsInInputIsNotDeliverySuccess() = runTest(scheduler) {

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1739DurableTokenRoutingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1739DurableTokenRoutingTest.kt
@@ -30,6 +30,7 @@ class Issue1739DurableTokenRoutingTest {
                 ),
                 expectedLane = "agent-payload",
                 expectedPayload = "agent payload",
+                expectedDeliveryProof = AgentSubmitDeliveryProof.AgentTurnover,
             ),
             RouteCase(
                 name = "conversation echo",
@@ -50,6 +51,7 @@ class Issue1739DurableTokenRoutingTest {
                 ),
                 expectedLane = "agent-payload",
                 expectedPayload = "/model",
+                expectedDeliveryProof = AgentSubmitDeliveryProof.TmuxEnterAccepted,
             ),
             RouteCase(
                 name = "raw bytes",
@@ -80,6 +82,9 @@ class Issue1739DurableTokenRoutingTest {
                 DurableOutboundRowIdentity(SESSION_ID, DURABLE_ROW_ID),
                 calls.single().durableRow,
             )
+            case.expectedDeliveryProof?.let {
+                assertEquals("${case.name} must use its route-specific delivery proof", it, calls.single().deliveryProof)
+            }
         }
     }
 
@@ -307,8 +312,9 @@ class Issue1739DurableTokenRoutingTest {
             agent: AgentKind,
             sendToken: String,
             durableRow: DurableOutboundRowIdentity?,
-        ) -> Boolean = { paneId, text, _, sendToken, durableRow ->
-            calls += WireCall("agent-payload", paneId, text, sendToken, durableRow)
+            deliveryProof: AgentSubmitDeliveryProof,
+        ) -> Boolean = { paneId, text, _, sendToken, durableRow, deliveryProof ->
+            calls += WireCall("agent-payload", paneId, text, sendToken, durableRow, deliveryProof)
             true
         },
     ): Boolean =
@@ -340,8 +346,15 @@ class Issue1739DurableTokenRoutingTest {
         calls: MutableList<WireCall>,
         onPaste: () -> Unit,
         onEnter: () -> Unit,
-    ): suspend (String, String, AgentKind, String, DurableOutboundRowIdentity?) -> Boolean =
-        { paneId, text, _, sendToken, durableRow ->
+    ): suspend (
+        String,
+        String,
+        AgentKind,
+        String,
+        DurableOutboundRowIdentity?,
+        AgentSubmitDeliveryProof,
+    ) -> Boolean =
+        { paneId, text, _, sendToken, durableRow, _ ->
             calls += WireCall("agent-payload", paneId, text, sendToken, durableRow)
             when (
                 verifyBeforeAgentResend(
@@ -379,6 +392,7 @@ class Issue1739DurableTokenRoutingTest {
         val request: PromptComposerViewModel.SendRequest,
         val expectedLane: String,
         val expectedPayload: String,
+        val expectedDeliveryProof: AgentSubmitDeliveryProof? = null,
     )
 
     private data class WireCall(
@@ -387,6 +401,7 @@ class Issue1739DurableTokenRoutingTest {
         val payload: String,
         val sendToken: String,
         val durableRow: DurableOutboundRowIdentity?,
+        val deliveryProof: AgentSubmitDeliveryProof? = null,
     )
 
     private companion object {


### PR DESCRIPTION
Closes #1944

Repairs the three exact-main regressions found after #1950:

- allow the first active composer consumer to adopt a pre-registration queued request without weakening concrete generation ownership
- keep stable queue-row selection while correcting its false global-count test oracle
- use accepted tmux Enter as delivery proof only for catalog-classified TUI controls such as `/model`; ordinary prompts still require transcript turnover and the write-ahead/no-blind-resend guard remains intact

Evidence:
- independent reviewer: APPROVED
- `/model` exact journey: 2/2; full TUI class: 3/3
- outbound queue class: 12/12; pipelining class: 2/2
- static ratchets and Android-test compilation: pass
- canonical full JVM gate on clean integration worktree: 603/603 tasks, 18m

The unrelated reconnect failures from the same exact-main run remain tracked in #1680.