### PR TITLE
Fix typed passive-drop recovery

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/CleanOutageReattachResilienceE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/CleanOutageReattachResilienceE2eTest.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.proof
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
@@ -15,6 +17,7 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.TMUX_PULL_TO_RECONNECT_TAG
@@ -22,11 +25,14 @@ import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.connection.ConnectionJournalSchema
+import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.tmux.TmuxClientDiagnostics
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -87,6 +93,8 @@ class CleanOutageReattachResilienceE2eTest {
 
     private var seededKey: String? = null
     private var seededHostRowTag: String? = null
+    private var diagnostics: RecordingDiagnosticSink? = null
+    private var tmuxDiagnostics: RecordingTmuxDiagnosticSink? = null
 
     private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
         object : Statement() {
@@ -106,6 +114,8 @@ class CleanOutageReattachResilienceE2eTest {
     @Before
     fun setUp() {
         clearLastSessionPrefs()
+        diagnostics = RecordingDiagnosticSink().also { DiagnosticEvents.install(it) }
+        tmuxDiagnostics = RecordingTmuxDiagnosticSink().also { TmuxClientDiagnostics.install(it) }
     }
 
     @After
@@ -116,6 +126,8 @@ class CleanOutageReattachResilienceE2eTest {
         runCatching {
             currentViewModel().forceCleanOutageForTest = false
         }
+        diagnostics?.close()
+        tmuxDiagnostics?.close()
         clearLastSessionPrefs()
         seededKey?.let { key ->
             runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }
@@ -172,7 +184,16 @@ class CleanOutageReattachResilienceE2eTest {
         // a single failed fresh-transport attempt it could only retry the warm
         // reattach, which can never succeed once the failed transport nulled the SSH
         // session — so the session never recovered for the rest of the grace window).
-        SystemClock.sleep(SILENT_OUTAGE_MS)
+        val highestAttempt = observeSustainedOutageAndAssertOneTypedCause(
+            vm = vm,
+            droppedClientIdentity = requireNotNull(clientBeforeDrop),
+        )
+        recordTiming("clean_outage_highest_attempt", highestAttempt.toLong())
+        assertTrue(
+            "A sustained clean outage must advance the controller beyond attempt 1; " +
+                "highestAttempt=$highestAttempt state=${vm.connectionControllerStateForTest()}",
+            highestAttempt >= 2,
+        )
 
         // ---- 2) AUTO-RECOVERY, NO SWITCH DANCE ----
         // Restore the link: the very next grace-loop re-dial of a fresh transport
@@ -219,8 +240,70 @@ class CleanOutageReattachResilienceE2eTest {
                 "dance). status=${currentConnectionStatus()}",
             roundTripped,
         )
+        captureJourneyArtifacts("clean-outage-recovered")
         writeTimings()
     } }
+
+    /**
+     * Issue #1952 cause-consistency oracle. The physical fault must be observed by the
+     * real tmux reader, then the SAME typed reason must enter the controller. The
+     * passive effect may start once, and only once, for that fault. The old seam is RED:
+     * it closes the client as `explicit_close`, separately journals
+     * `remote_failure/test_clean_outage_seam`, and starts zero effects.
+     */
+    private fun observeSustainedOutageAndAssertOneTypedCause(
+        vm: TmuxSessionViewModel,
+        droppedClientIdentity: Int,
+    ): Int {
+        val deadline = SystemClock.elapsedRealtime() + SILENT_OUTAGE_MS
+        var highestAttempt = 0
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val state = vm.connectionControllerStateForTest()
+            if (state is CoreConnectionState.Reconnecting) {
+                highestAttempt = maxOf(highestAttempt, state.attempt)
+            }
+            SystemClock.sleep(50)
+        }
+
+        val readerExits = requireNotNull(tmuxDiagnostics).eventsNamed("tmux_client_reader_exit")
+            .filter { it.fields["clientHash"] == droppedClientIdentity }
+        assertTrue(
+            "The CleanOutage fault must produce one real tmux reader EOF/down signal; exits=$readerExits",
+            readerExits.size == 1,
+        )
+        val readerReason = readerExits.single().fields["disconnectReason"] as? String
+        assertTrue(
+            "The fault must be remote reader EOF/failure, never an app ExplicitClose; reason=$readerReason",
+            readerReason == "reader_eof" || readerReason == "reader_exception",
+        )
+
+        val expectedCauseReason = when (readerReason) {
+            "reader_eof" -> "readereof"
+            "reader_exception" -> "readerexception"
+            else -> error("unreachable reader reason $readerReason")
+        }
+        val journalDrops = requireNotNull(diagnostics).events
+            .filter { event ->
+                event.category == ConnectionJournalSchema.CATEGORY &&
+                    event.name == ConnectionJournalSchema.SUBMIT &&
+                    event.fields["event"] == "transport_dropped" &&
+                    event.fields["causeReason"] == expectedCauseReason
+            }
+        assertTrue(
+            "The controller must receive the reader's same typed remote cause exactly once; " +
+                "expected=$expectedCauseReason journal=$journalDrops",
+            journalDrops.size == 1 && journalDrops.single().fields["cause"] == "remote_failure",
+        )
+
+        val recoveryStarts = requireNotNull(diagnostics).eventsNamed("silent_reattach_start")
+            .filter { it.fields["clientHash"] == droppedClientIdentity }
+        assertTrue(
+            "One accepted remote fault must start exactly one passive recovery effect; " +
+                "starts=$recoveryStarts",
+            recoveryStarts.size == 1,
+        )
+        return highestAttempt
+    }
 
     // -- user-visible recovery helpers (parity with the Slice D specs) -------------
 
@@ -450,6 +533,49 @@ class CleanOutageReattachResilienceE2eTest {
         file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
         println("ISSUE833_CLEAN_OUTAGE_TIMINGS ${file.absolutePath}")
         return file
+    }
+
+    /** Issue #1952 terminal-review evidence from the same successful journey run. */
+    private fun captureJourneyArtifacts(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150L)
+        var terminalBitmap: Bitmap? = null
+        var terminalText: String? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = checkNotNull(activity.window.decorView.findTerminalView()) {
+                "could not find TerminalView for $name"
+            }
+            check(view.width > 0 && view.height > 0) {
+                "TerminalView is not laid out for $name: ${view.width}x${view.height}"
+            }
+            terminalText = view.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+            terminalBitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also {
+                view.draw(Canvas(it))
+            }
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(checkNotNull(terminalText))
+        val bitmap = checkNotNull(terminalBitmap) { "could not render $name TerminalView" }
+        try {
+            artifactFile("$name-viewport.png").outputStream().use { output ->
+                assertTrue(
+                    "could not encode $name viewport",
+                    bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, output),
+                )
+            }
+        } finally {
+            bitmap.recycle()
+        }
+        instrumentation.uiAutomation.takeScreenshot()?.let { deviceBitmap ->
+            try {
+                artifactFile("$name-device-diagnostic.png").outputStream().use { output ->
+                    check(deviceBitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+                }
+            } finally {
+                deviceBitmap.recycle()
+            }
+        }
+        artifactFile("$name-timings.txt").writeText(timings.joinToString(separator = "\n", postfix = "\n"))
     }
 
     private fun artifactFile(name: String): File {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.proof
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import android.view.View
@@ -132,6 +134,7 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
         waitForConnected("initial attach")
+        captureJourneyArtifacts("switch-pre-drop-live")
 
         // Drive the VM into the Switching (Attaching) window — the window a
         // same-host fast switch holds before the Live flip. inlineConnectionStatus
@@ -175,6 +178,7 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
             "#895: the session screen must remain mounted (no freeze/restart)",
             hasTag(TMUX_SESSION_SCREEN_TAG),
         )
+        captureBandDiagnosticArtifacts("switch-drop-escapable-band")
         writeTimings()
     } }
 
@@ -258,6 +262,7 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
                 "probe interval; logcat tail:\n$oracleLog",
             oracleLog.contains(REPLACEMENT_ORACLE),
         )
+        captureJourneyArtifacts("closed-channel-replacement-oracle")
         writeTimings()
     } }
 
@@ -495,6 +500,75 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
         file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
         println("ISSUE895_BAND_TIMINGS ${file.absolutePath}")
         return file
+    }
+
+    /** Issue #1952 terminal-review evidence from the same successful journey run. */
+    private fun captureJourneyArtifacts(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150L)
+        var terminalBitmap: Bitmap? = null
+        var terminalText: String? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = checkNotNull(activity.window.decorView.findTerminalView()) {
+                "could not find TerminalView for $name"
+            }
+            check(view.width > 0 && view.height > 0) {
+                "TerminalView is not laid out for $name: ${view.width}x${view.height}"
+            }
+            terminalText = view.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+            terminalBitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also {
+                view.draw(Canvas(it))
+            }
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(checkNotNull(terminalText))
+        val bitmap = checkNotNull(terminalBitmap) { "could not render $name TerminalView" }
+        try {
+            artifactFile("$name-viewport.png").outputStream().use { output ->
+                assertTrue(
+                    "could not encode $name viewport",
+                    bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, output),
+                )
+            }
+        } finally {
+            bitmap.recycle()
+        }
+        instrumentation.uiAutomation.takeScreenshot()?.let { deviceBitmap ->
+            try {
+                artifactFile("$name-device-diagnostic.png").outputStream().use { output ->
+                    check(deviceBitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+                }
+            } finally {
+                deviceBitmap.recycle()
+            }
+        }
+        artifactFile("$name-timings.txt").writeText(timings.joinToString(separator = "\n", postfix = "\n"))
+    }
+
+    /**
+     * The escapable-band reducer intentionally removes TerminalView while it shows the
+     * full-screen reconnect affordance. Its evidence is therefore explicitly a DEVICE
+     * diagnostic, never mislabeled as an authoritative terminal viewport. The same test
+     * already hard-captures the live pre-drop TerminalView above.
+     */
+    private fun captureBandDiagnosticArtifacts(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150L)
+        val bitmap = checkNotNull(instrumentation.uiAutomation.takeScreenshot()) {
+            "could not capture $name device diagnostic"
+        }
+        try {
+            artifactFile("$name-device-diagnostic.png").outputStream().use { output ->
+                assertTrue(
+                    "could not encode $name device diagnostic",
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, output),
+                )
+            }
+        } finally {
+            bitmap.recycle()
+        }
+        artifactFile("$name-timings.txt").writeText(timings.joinToString(separator = "\n", postfix = "\n"))
     }
 
     private fun artifactFile(name: String): File {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
@@ -1,6 +1,8 @@
 package com.pocketshell.app.proof
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
@@ -203,6 +205,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
                     "(no switch dance). status=${currentConnectionStatus()}",
                 roundTripped,
             )
+            captureJourneyArtifacts("synthetic-drop-recovered")
             writeTimings()
         } }
 
@@ -307,6 +310,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
                     "(status=${currentConnectionStatus()}).",
                 recovered,
             )
+            captureJourneyArtifacts("slow-live-recovered")
             writeTimings()
         } }
 
@@ -561,6 +565,49 @@ class SilentDropSyntheticSeamJourneyE2eTest {
         file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
         println("ISSUE792_SLICED_TIMINGS ${file.absolutePath}")
         return file
+    }
+
+    /** Issue #1952 terminal-review evidence from the same successful journey run. */
+    private fun captureJourneyArtifacts(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150L)
+        var terminalBitmap: Bitmap? = null
+        var terminalText: String? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = checkNotNull(activity.window.decorView.findTerminalView()) {
+                "could not find TerminalView for $name"
+            }
+            check(view.width > 0 && view.height > 0) {
+                "TerminalView is not laid out for $name: ${view.width}x${view.height}"
+            }
+            terminalText = view.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+            terminalBitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also {
+                view.draw(Canvas(it))
+            }
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(checkNotNull(terminalText))
+        val bitmap = checkNotNull(terminalBitmap) { "could not render $name TerminalView" }
+        try {
+            artifactFile("$name-viewport.png").outputStream().use { output ->
+                assertTrue(
+                    "could not encode $name viewport",
+                    bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, output),
+                )
+            }
+        } finally {
+            bitmap.recycle()
+        }
+        instrumentation.uiAutomation.takeScreenshot()?.let { deviceBitmap ->
+            try {
+                artifactFile("$name-device-diagnostic.png").outputStream().use { output ->
+                    check(deviceBitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+                }
+            } finally {
+                deviceBitmap.recycle()
+            }
+        }
+        artifactFile("$name-timings.txt").writeText(timings.joinToString(separator = "\n", postfix = "\n"))
     }
 
     private fun artifactFile(name: String): File {

--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
@@ -1,0 +1,437 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.RecordingDiagnosticEventSink
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.connection.ConnectionJournalSchema
+import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.ssh.DefaultSshLeaseConnector
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxClientDiagnosticSink
+import com.pocketshell.core.tmux.TmuxClientDiagnostics
+import com.pocketshell.core.tmux.TmuxClientFactory
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Issue #1952 D34 primary proof: one physical peer-side transport death is observed by
+ * the real sshj/tmux reader, enters the controller and passive effect with one typed cause,
+ * advances the controller beyond attempt 1 during sustained failure, and recovers the same
+ * tmux session over a fresh transport/client with a real marker round-trip.
+ *
+ * This is deliberately a hard Docker gate: it never substitutes a callback-count fake and
+ * never skips when Docker is missing. The container kills its authenticated sshd children —
+ * the app does not call close/disconnect — and the load-bearing signal is the real reader
+ * EOF/down plus marker continuity through replacement SSH and tmux objects.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1952TypedPassiveDropRealTransportIntegrationTest {
+
+    private val projectRoot: Path by lazy { findProjectRoot() }
+    private var container: GenericContainer<*>? = null
+
+    @Before
+    fun setUpMain() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @After
+    fun tearDownMain() {
+        TmuxClientDiagnostics.install(TmuxClientDiagnosticSink.Noop)
+        runCatching { container?.stop() }
+        container = null
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun realReaderDropKeepsOneTypedCauseAndRecoversSameSessionOnFreshTransport() = runBlocking {
+        startDockerOrFail()
+        val fixture = requireNotNull(container)
+        val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val leaseManager = SshLeaseManager(
+            connector = DefaultSshLeaseConnector(),
+            scope = ioScope,
+            idleTtlMillis = 60_000L,
+        )
+        val diagnostics = installRecordingDiagnosticSink()
+        val tmuxDiagnostics = RecordingTmuxDiagnostics().also { TmuxClientDiagnostics.install(it) }
+        var vm: TmuxSessionViewModel? = null
+        try {
+            seedSession()
+            vm = TmuxSessionViewModel(
+                tmuxClientFactory = TmuxClientFactory(ioScope),
+                activeTmuxClients = ActiveTmuxClients(),
+                sshLeaseManager = leaseManager,
+            )
+            vm.connect(
+                hostId = 1952L,
+                hostName = "issue1952-docker",
+                host = fixture.host,
+                port = fixture.getMappedPort(SSH_PORT),
+                user = SSH_USER,
+                keyPath = privateKeyFile.absolutePath,
+                passphrase = null,
+                sessionName = SESSION_NAME,
+            )
+
+            awaitCondition(INITIAL_CONNECT_TIMEOUT_MS, "initial VM Live attach") {
+                vm.connectionControllerStateForTest() is ConnectionState.Live &&
+                    vm.liveTmuxClientForSendOrNullForTest() != null &&
+                    vm.panes.value.isNotEmpty()
+            }
+            val firstClient = requireNotNull(vm.liveTmuxClientForSendOrNullForTest())
+            val firstClientHash = System.identityHashCode(firstClient)
+            val firstSshIdentity = currentSshIdentity(vm)
+            val initialMarker = "ISSUE1952-BEFORE-${System.nanoTime().toString(36)}"
+            sendAndAwaitMarker(firstClient, initialMarker)
+
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = PASSIVE_GRACE_MS,
+                silentReattachTimeoutMs = REATTACH_TIMEOUT_MS,
+            )
+            vm.forceCleanOutageForTest = true
+            val killedPeerPids = killAuthenticatedSshdProcessesFromServer()
+            assertTrue("the Docker peer fault must kill at least one sshd process", killedPeerPids.isNotEmpty())
+
+            val readerExit = awaitReaderExit(tmuxDiagnostics, firstClientHash)
+            val readerReason = readerExit["disconnectReason"] as? String
+            assertTrue(
+                "D34: the real reader must report remote EOF/failure, never ExplicitClose; " +
+                    "exit=$readerExit",
+                readerReason == "reader_eof" || readerReason == "reader_exception",
+            )
+            val typedReason = when (readerReason) {
+                "reader_eof" -> "readereof"
+                "reader_exception" -> "readerexception"
+                else -> error("unexpected reader reason $readerReason")
+            }
+
+            val journalDrop = awaitSingleTypedJournalDrop(diagnostics, typedReason)
+            assertEquals("remote_failure", journalDrop["cause"])
+            assertEquals(typedReason, journalDrop["causeReason"])
+
+            val maxAttempt = awaitAttemptBeyondOne(vm)
+            assertTrue(
+                "sustained failure must progress beyond attempt 1; maxAttempt=$maxAttempt " +
+                    "state=${vm.connectionControllerStateForTest()}",
+                maxAttempt >= 2,
+            )
+            assertExactlyOneRecoveryStart(diagnostics, firstClientHash)
+
+            vm.forceCleanOutageForTest = false
+            awaitCondition(RECOVERY_TIMEOUT_MS, "fresh-client recovery to Live") {
+                vm.connectionControllerStateForTest() is ConnectionState.Live &&
+                    vm.liveTmuxClientForSendOrNullForTest()?.let { client ->
+                        !client.disconnected.value && System.identityHashCode(client) != firstClientHash
+                    } == true
+            }
+            val recoveredClient = requireNotNull(vm.liveTmuxClientForSendOrNullForTest())
+            val recoveredSshIdentity = currentSshIdentity(vm)
+            assertNotEquals(
+                "recovery must install a different control client",
+                firstClientHash,
+                System.identityHashCode(recoveredClient),
+            )
+            assertNotEquals(
+                "recovery must install a different SshSession",
+                firstSshIdentity.session,
+                recoveredSshIdentity.session,
+            )
+            assertNotEquals(
+                "recovery must install a different sshj SSHClient",
+                firstSshIdentity.client,
+                recoveredSshIdentity.client,
+            )
+            assertNotEquals(
+                "recovery must install a different sshj Transport",
+                firstSshIdentity.transport,
+                recoveredSshIdentity.transport,
+            )
+
+            val afterMarker = "ISSUE1952-AFTER-${System.nanoTime().toString(36)}"
+            sendAndAwaitMarker(recoveredClient, afterMarker)
+            val transcript = captureTranscript(recoveredClient)
+            assertTrue("same-session transcript must preserve the pre-drop marker", transcript.contains(initialMarker))
+            assertTrue("same-session transcript must contain the post-recovery marker", transcript.contains(afterMarker))
+            assertExactlyOneRecoveryStart(diagnostics, firstClientHash)
+
+            println(
+                "ISSUE1952_REAL_TRANSPORT reader=$readerExit journal=$journalDrop " +
+                    "maxAttempt=$maxAttempt firstClient=$firstClientHash " +
+                    "recoveredClient=${System.identityHashCode(recoveredClient)} " +
+                    "firstSsh=$firstSshIdentity recoveredSsh=$recoveredSshIdentity " +
+                    "peerKilledPids=$killedPeerPids",
+            )
+            println("ISSUE1952_REAL_TRANSCRIPT\n$transcript")
+        } finally {
+            vm?.forceCleanOutageForTest = false
+            vm?.cancelOwnScopesForTest()
+            vm?.clearForTest()
+            runCatching { cleanupSession() }
+            diagnostics.close()
+            TmuxClientDiagnostics.install(TmuxClientDiagnosticSink.Noop)
+            leaseManager.close()
+            ioScope.cancel()
+        }
+    }
+
+    private fun startDockerOrFail() {
+        check(DockerClientFactory.instance().isDockerAvailable) {
+            "#1952 D34 hard gate requires Docker; start Docker and rerun"
+        }
+        val imageName = "pocketshell-test:agents-issue1952"
+        val build = ProcessBuilder(
+            "docker",
+            "build",
+            "-t",
+            imageName,
+            "-f",
+            projectRoot.resolve("tests/docker/Dockerfile.agents").toString(),
+            projectRoot.toString(),
+        ).redirectErrorStream(true).start()
+        val output = build.inputStream.bufferedReader().readText()
+        check(build.waitFor() == 0) { "Failed to build $imageName:\n$output" }
+        container = GenericContainer(DockerImageName.parse(imageName))
+            .withExposedPorts(SSH_PORT)
+            .also { it.start() }
+    }
+
+    private suspend fun seedSession() {
+        connectFixture().use { session ->
+            val command =
+                "tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true; " +
+                    "tmux new-session -d -s '$SESSION_NAME' 'exec sh -i'"
+            val result = session.exec(command)
+            check(result.exitCode == 0) { "seed failed: $result" }
+        }
+    }
+
+    private suspend fun cleanupSession() {
+        connectFixture().use { session ->
+            session.exec("tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true")
+        }
+    }
+
+    private suspend fun connectFixture(): SshSession {
+        val fixture = requireNotNull(container)
+        return SshConnection.connect(
+            host = fixture.host,
+            port = fixture.getMappedPort(SSH_PORT),
+            user = SSH_USER,
+            key = SshKey.Path(privateKeyFile),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+    }
+
+    /**
+     * Kill the authenticated fixture-side sshd processes while leaving the Docker
+     * container, listening sshd, and tmux server alive. Docker exec is the peer-side
+     * control plane; it does not touch the app's sshj client or its local socket.
+     */
+    private fun killAuthenticatedSshdProcessesFromServer(): List<Int> {
+        val fixture = requireNotNull(container)
+        val result = fixture.execInContainer(
+            "sh",
+            "-lc",
+            """
+                pids="${'$'}(ps -eo pid=,comm=,args= | awk '(${'$'}2 == "sshd" || ${'$'}2 == "sshd-session") && index(${'$'}0, ": $SSH_USER") { print ${'$'}1 }')"
+                test -n "${'$'}pids" || {
+                    echo "NO_AUTHENTICATED_SSHD process table follows" >&2
+                    ps -eo pid=,comm=,args= >&2
+                    exit 41
+                }
+                echo "KILLED_PIDS=${'$'}pids"
+                for pid in ${'$'}pids; do kill -KILL "${'$'}pid" 2>/dev/null || true; done
+            """.trimIndent(),
+        )
+        check(result.exitCode == 0) {
+            "D34 peer-side sshd kill failed exit=${result.exitCode} stdout=${result.stdout} stderr=${result.stderr}"
+        }
+        val rawPids = result.stdout.lineSequence()
+            .firstOrNull { it.startsWith("KILLED_PIDS=") }
+            ?.substringAfter('=')
+            .orEmpty()
+        val pids = rawPids.trim().split(Regex("\\s+")).mapNotNull(String::toIntOrNull)
+        check(pids.isNotEmpty()) { "D34 peer-side sshd kill reported no PIDs: ${result.stdout}" }
+        return pids
+    }
+
+    /** Test-only identity probe; no production API is added for this D34 assertion. */
+    private fun currentSshIdentity(vm: TmuxSessionViewModel): SshObjectIdentity {
+        val sessionField = TmuxSessionViewModel::class.java.getDeclaredField("sessionRef").apply {
+            isAccessible = true
+        }
+        val session = checkNotNull(sessionField.get(vm)) { "D34 requires a real SshSession" }
+        val clientField = session.javaClass.getDeclaredField("client").apply { isAccessible = true }
+        val client = checkNotNull(clientField.get(session)) { "D34 requires a real sshj SSHClient" }
+        val transport = checkNotNull(client.javaClass.getMethod("getTransport").invoke(client)) {
+            "D34 requires a real sshj Transport"
+        }
+        return SshObjectIdentity(
+            session = System.identityHashCode(session),
+            client = System.identityHashCode(client),
+            transport = System.identityHashCode(transport),
+        )
+    }
+
+    private data class SshObjectIdentity(
+        val session: Int,
+        val client: Int,
+        val transport: Int,
+    )
+
+    private suspend fun sendAndAwaitMarker(client: TmuxClient, marker: String) {
+        val response = client.sendKeysViaExec(
+            "send-keys -t '$SESSION_NAME' 'printf \\\"$marker\\\\n\\\"' Enter",
+        )
+        assertTrue("send-keys failed for $marker: ${response.output}", !response.isError)
+        awaitCondition(MARKER_TIMEOUT_MS, "marker $marker in real pane") {
+            runCatching { captureTranscript(client).contains(marker) }.getOrDefault(false)
+        }
+    }
+
+    private suspend fun captureTranscript(client: TmuxClient): String {
+        val response = client.capturePaneTextViaExec(
+            SESSION_NAME,
+            timeoutMs = 4_000L,
+            scrollbackLines = 200,
+        )
+        check(!response.isError) { "capture-pane failed: ${response.output}" }
+        return response.output.joinToString("\n")
+    }
+
+    private suspend fun awaitReaderExit(
+        diagnostics: RecordingTmuxDiagnostics,
+        clientHash: Int,
+    ): Map<String, Any?> {
+        var match: Map<String, Any?>? = null
+        awaitCondition(READER_EXIT_TIMEOUT_MS, "real tmux reader exit") {
+            match = diagnostics.events
+                .filter { it.first == "tmux_client_reader_exit" }
+                .map { it.second }
+                .singleOrNull { it["clientHash"] == clientHash }
+            match != null
+        }
+        return requireNotNull(match)
+    }
+
+    private suspend fun awaitSingleTypedJournalDrop(
+        diagnostics: RecordingDiagnosticEventSink,
+        causeReason: String,
+    ): Map<String, Any?> {
+        var allDrops = emptyList<Map<String, Any?>>()
+        awaitCondition(READER_EXIT_TIMEOUT_MS, "controller transport drop") {
+            allDrops = diagnostics.events
+                .filter { event ->
+                    event.category == ConnectionJournalSchema.CATEGORY &&
+                        event.name == ConnectionJournalSchema.SUBMIT &&
+                        event.fields["event"] == "transport_dropped"
+                }
+                .map { it.fields }
+            allDrops.isNotEmpty()
+        }
+        val matches = allDrops.filter { it["causeReason"] == causeReason }
+        assertEquals(
+            "one fault must submit its typed reader cause exactly once; " +
+                "expected=$causeReason allDrops=$allDrops",
+            1,
+            matches.size,
+        )
+        return matches.single()
+    }
+
+    private suspend fun awaitAttemptBeyondOne(vm: TmuxSessionViewModel): Int {
+        var maxAttempt = 0
+        awaitCondition(ATTEMPT_PROGRESS_TIMEOUT_MS, "controller attempt > 1") {
+            val state = vm.connectionControllerStateForTest()
+            if (state is ConnectionState.Reconnecting) maxAttempt = maxOf(maxAttempt, state.attempt)
+            maxAttempt >= 2
+        }
+        return maxAttempt
+    }
+
+    private fun assertExactlyOneRecoveryStart(
+        diagnostics: RecordingDiagnosticEventSink,
+        clientHash: Int,
+    ) {
+        val starts = diagnostics.eventsNamed("silent_reattach_start")
+            .filter { it.fields["clientHash"] == clientHash }
+        assertEquals("one physical fault must start exactly one passive recovery effect: $starts", 1, starts.size)
+    }
+
+    private suspend fun awaitCondition(
+        timeoutMs: Long,
+        label: String,
+        condition: suspend () -> Boolean,
+    ) {
+        withTimeout(timeoutMs) {
+            while (!condition()) delay(50L)
+        }
+        assertTrue("condition must hold after wait: $label", condition())
+    }
+
+    private val privateKeyFile: File
+        get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    private fun findProjectRoot(): Path {
+        var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+        while (dir != null) {
+            if (dir.resolve("tests/docker/Dockerfile.agents").toFile().exists()) return dir
+            dir = dir.parent
+        }
+        error("Could not locate project root from ${System.getProperty("user.dir")}")
+    }
+
+    private class RecordingTmuxDiagnostics : TmuxClientDiagnosticSink {
+        val events = CopyOnWriteArrayList<Pair<String, Map<String, Any?>>>()
+
+        override fun record(event: String, fields: Map<String, Any?>) {
+            events += event to fields
+        }
+    }
+
+    private companion object {
+        const val SSH_PORT = 22
+        const val SSH_USER = "testuser"
+        const val SESSION_NAME = "issue1952-typed-drop"
+        const val INITIAL_CONNECT_TIMEOUT_MS = 30_000L
+        const val PASSIVE_GRACE_MS = 30_000L
+        const val REATTACH_TIMEOUT_MS = 1_000L
+        const val READER_EXIT_TIMEOUT_MS = 10_000L
+        const val ATTEMPT_PROGRESS_TIMEOUT_MS = 12_000L
+        const val RECOVERY_TIMEOUT_MS = 30_000L
+        const val MARKER_TIMEOUT_MS = 10_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -85,7 +85,12 @@ import com.pocketshell.app.tmux.connection.KeepaliveDeathRedialAmortizer
 import com.pocketshell.app.tmux.connection.NetworkLossBandDebouncer
 import com.pocketshell.app.tmux.connection.ParkedRuntimeHealthEffects
 import com.pocketshell.app.tmux.connection.ParkedRuntimeDeathSignal
+import com.pocketshell.app.tmux.connection.PassiveDropArm
+import com.pocketshell.app.tmux.connection.PassiveTransportDrop
+import com.pocketshell.app.tmux.connection.PassiveTransportDropEffects
+import com.pocketshell.app.tmux.connection.isPassiveRecoveryEligible
 import com.pocketshell.app.tmux.connection.isSameIdentityNetworkRestore
+import com.pocketshell.app.tmux.connection.observePassiveTransportDrop
 import com.pocketshell.app.tmux.connection.recordNetworkRestoreReconnectStart
 import com.pocketshell.app.tmux.connection.recordNetworkRestoreRideThrough
 import com.pocketshell.app.tmux.connection.recordPassiveDisconnect
@@ -94,8 +99,6 @@ import com.pocketshell.app.tmux.connection.recordSilentReattachStart
 import com.pocketshell.app.tmux.connection.recordNetworkLossBandPainted
 import com.pocketshell.app.tmux.connection.recordNetworkLossBandSuppressed
 import com.pocketshell.app.tmux.connection.recordNetworkLossHold
-import com.pocketshell.app.tmux.connection.PassiveDropArm
-import com.pocketshell.app.tmux.connection.PassiveTransportDropEffects
 import com.pocketshell.app.tmux.connection.preferFreshTransportForPassiveReattach
 import com.pocketshell.app.tmux.connection.ReconnectRungFailureSource
 import com.pocketshell.app.tmux.connection.RestoreReaderActivityVerdict
@@ -138,6 +141,7 @@ import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshSessionCloseCause
+import com.pocketshell.core.ssh.SshSessionTestControl
 import com.pocketshell.core.terminal.bridge.TerminalSeedGateOverflowException
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.entity.ProjectRootEntity
@@ -989,10 +993,10 @@ public class TmuxSessionViewModel @Inject constructor(
             // the driver submits TransportDropped to the controller (#630), while still
             // keeping the submit itself inside the driver-owned path.
             controlChannelDrops = connectionTmuxPort.disconnectedClients,
-            shouldSubmitControlChannelDrop = { client ->
-                passiveTransportDropEffects.classify(client) != PassiveDropArm.Ignore
+            shouldSubmitControlChannelDrop = { drop ->
+                passiveTransportDropEffects.classify(drop) != PassiveDropArm.Ignore
             },
-            controlChannelDroppedEffect = { client -> onControllerTransportDropped(client) },
+            controlChannelDroppedEffect = { drop -> onControllerTransportDropped(drop) },
             // Issue #972: on the current host's lease coming back `Up` after a
             // reconnect, mirror the recorded reconnect-cause trail to the host's
             // `~/.pocketshell/connection-log.jsonl` over the now-warm lease so the
@@ -1247,28 +1251,16 @@ public class TmuxSessionViewModel @Inject constructor(
     internal var preservePaneRuntimeOnBackgroundTeardownForTest: Boolean = false
 
     /**
-     * EPIC #792 #833 test seam: fire the CLEAN passive-disconnect path directly —
-     * the body the EOF oracle (`TmuxClient.disconnected` true-edge with a
-     * [TmuxDisconnectReason.ReaderEof]) drives. This is the clean-drop analogue of
-     * [triggerLivenessProbeDropForTest], letting a connected proof exercise the
-     * sustained-clean-outage reattach ladder without waiting on a real reader EOF or
-     * the toxiproxy proxy family. Returns false (no-op) if there is no current client.
+     * EPIC #792/#833/#1952 test seam: kill the real SSH transport so the ordinary reader
+     * emits the typed clean drop. Returns false when no real current transport exists.
      */
     internal fun triggerCleanPassiveDropForTest(): Boolean {
-        val client = clientRef ?: return false
-        if (passiveTransportDropEffects.classify(client) == PassiveDropArm.Ignore) return false
-        runCatching { client.close() }
-        connectionManager.reportRemoteDrop("test_clean_outage_seam")
-        projectStatusFromController()
-        handlePassiveClientDisconnect(
-            client = client,
-            disconnectEvent = TmuxDisconnectEvent(
-                reason = TmuxDisconnectReason.ReaderEof,
-                source = "test_clean_outage_seam",
-                intent = "synthetic_clean_drop",
-            ),
-        )
-        return true
+        clientRef ?: return false
+        val session = sessionRef ?: return false
+        // Issue #1952: raw transport fault injection, not TmuxClient.close(). The real reader
+        // produces ReaderEof/ReaderException and the ordinary typed driver
+        // path owns controller submission + recovery exactly as it does in production.
+        return SshSessionTestControl.forceTransportDeath(session)
     }
 
     /**
@@ -7877,14 +7869,16 @@ public class TmuxSessionViewModel @Inject constructor(
             client.disconnected.collect { dead ->
                 if (!dead) return@collect
                 val target = activeTarget ?: connectingTarget
-                val disconnectEvent = disconnectEventOrFallback(client)
+                // #1952: breadcrumb and classification share one immutable wire snapshot.
+                val drop = observePassiveTransportDrop(client)
+                val disconnectEvent = drop.disconnectEvent
                 // Recovery is fired from [ConnectionEffectDriver.controlChannelDroppedEffect]
                 // after the real current-client drop has moved the controller. This
                 // per-client observer stays only as a stale-client breadcrumb. The
                 // driver-owned handler records the canonical `passive_disconnect`
                 // diagnostic so silent reattach cannot cancel this collector before
                 // observability lands.
-                val decision = passiveTransportDropEffects.classify(client)
+                val decision = passiveTransportDropEffects.classify(drop)
                 if (decision == PassiveDropArm.Ignore) {
                     DiagnosticEvents.record(
                         "connection",
@@ -7909,8 +7903,8 @@ public class TmuxSessionViewModel @Inject constructor(
         }
     }
 
-    private fun onControllerTransportDropped(client: TmuxClient) {
-        handlePassiveClientDisconnect(client, disconnectEventOrFallback(client))
+    private fun onControllerTransportDropped(drop: PassiveTransportDrop) {
+        handlePassiveClientDisconnect(drop)
     }
 
     private fun recordPassiveDisconnectDiagnostic(
@@ -7935,10 +7929,9 @@ public class TmuxSessionViewModel @Inject constructor(
         )
     }
 
-    private fun handlePassiveClientDisconnect(
-        client: TmuxClient,
-        disconnectEvent: TmuxDisconnectEvent = disconnectEventOrFallback(client),
-    ) {
+    private fun handlePassiveClientDisconnect(drop: PassiveTransportDrop) {
+        val client = drop.client
+        val disconnectEvent = drop.disconnectEvent
         // Issue #895 (#766 down-payment): the passive-disconnect handler is
         // STATUS-AGNOSTIC. The old `inlineConnectionStatus as? Connected ?: return`
         // gate SWALLOWED a drop that landed while the VM was `Switching`
@@ -8008,7 +8001,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // Classify the drop FIRST (status-agnostic — #895/#766). `Ignore` means the
         // dropped client is not the current one (a stale `-CC` close on a healthy
         // fast switch, the #635 spurious-band case) — for that we surface NOTHING.
-        val decision = passiveTransportDropEffects.classify(client)
+        val decision = passiveTransportDropEffects.classify(drop)
         if (decision == PassiveDropArm.Ignore) {
             projectStatusFromController()
             return
@@ -8173,7 +8166,13 @@ public class TmuxSessionViewModel @Inject constructor(
         return withTimeoutOrNull<Boolean>(passiveDisconnectGraceMs) {
             while (true) {
                 if (!appActive) return@withTimeoutOrNull false
-                if (inlineConnectionStatus !is ConnectionStatus.Connected) return@withTimeoutOrNull false
+                // Issue #1952: recovery eligibility belongs to the authoritative controller,
+                // not the projected display status. An accepted remote drop deliberately
+                // projects Reconnecting, so the old `inline Connected` gate cancelled the
+                // recovery effect it was meant to drive.
+                if (!isPassiveRecoveryEligible(connectionManager.state)) {
+                    return@withTimeoutOrNull false
+                }
                 val currentClient = clientRef
                 if (currentClient !== staleClient && currentClient?.disconnected?.value != true) {
                     return@withTimeoutOrNull true

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriver.kt
@@ -187,8 +187,8 @@ class ConnectionEffectDriver(
     private val foregroundReconnectEffect: () -> Unit = {},
     private val onControllerTransition: () -> Unit = {},
     private val controlChannelDrops: Flow<TmuxClient>? = null,
-    private val shouldSubmitControlChannelDrop: (TmuxClient) -> Boolean = { true },
-    private val controlChannelDroppedEffect: (TmuxClient) -> Unit = {},
+    private val shouldSubmitControlChannelDrop: (PassiveTransportDrop) -> Boolean = { true },
+    private val controlChannelDroppedEffect: (PassiveTransportDrop) -> Unit = {},
     // EPIC #687 P2 (J1/#635): the SINGLE-GRACE-OWNER gate. When this returns true, the
     // driver SUPPRESSES the `TransportDropped` submission for a control-channel drop —
     // i.e. it does NOT walk the controller down the reconnect ladder. The VM supplies a
@@ -327,10 +327,13 @@ class ConnectionEffectDriver(
     private suspend fun collectControlChannelDrops(drops: Flow<TmuxClient>) {
         drops.collect { client ->
             record(Observation.Disconnected(true))
+            // Issue #1952: snapshot event + typed cause ONCE. The controller and effect
+            // consume this same value; neither re-reads mutable client authority later.
+            val drop = observePassiveTransportDrop(client)
             if (suppressTransportDrops()) {
                 onDropSuppressed(suppressedControlChannelDiagnostic(client))
                 record(Observation.DropSuppressed)
-            } else if (shouldSubmitControlChannelDrop(client)) {
+            } else if (shouldSubmitControlChannelDrop(drop)) {
                 val wasTargetless = isTargetless()
                 val changed = submitTransport(
                     // Issue #1666: carry the TYPED cause derived at the single close authority
@@ -338,12 +341,10 @@ class ConnectionEffectDriver(
                     // self-inflicted `-CC` close (the lease edge's `locallyInitiated` gate is
                     // the lease side), so typing it here + the reducer's refusal is what makes
                     // a self-inflicted control-channel close structurally inert.
-                    ConnectionEvent.TransportDropped(
-                        SelfInflictedClose.dropCauseForControlChannelClose(client.disconnectEvent.value),
-                    ),
+                    ConnectionEvent.TransportDropped(drop.cause),
                 )
                 if (changed || wasTargetless) {
-                    controlChannelDroppedEffect(client)
+                    controlChannelDroppedEffect(drop)
                 }
             }
         }

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffects.kt
@@ -1,6 +1,38 @@
 package com.pocketshell.app.tmux.connection
 
+import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.connection.DropCause
 import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxDisconnectEvent
+import com.pocketshell.core.tmux.TmuxDisconnectReason
+
+/**
+ * Issue #1952 — one immutable observation of one control-channel drop.
+ *
+ * [disconnectEvent] is read from the client exactly once at the wire/driver edge and [cause]
+ * is derived from that same value by [SelfInflictedClose]. The controller submit and passive
+ * recovery classifier receive this object together, so neither can re-read a later,
+ * contradictory client event.
+ */
+data class PassiveTransportDrop(
+    val client: TmuxClient,
+    val disconnectEvent: TmuxDisconnectEvent,
+    val cause: DropCause,
+)
+
+/** Observe and type one client drop at its source boundary. */
+fun observePassiveTransportDrop(client: TmuxClient): PassiveTransportDrop {
+    val event = client.disconnectEvent.value ?: TmuxDisconnectEvent(
+        reason = TmuxDisconnectReason.Unknown,
+        source = "boolean_disconnected",
+        intent = "unknown",
+    )
+    return PassiveTransportDrop(
+        client = client,
+        disconnectEvent = event,
+        cause = SelfInflictedClose.dropCauseForControlChannelClose(event),
+    )
+}
 
 /**
  * EPIC #687 Slice 2 (#1047) — the PASSIVE-TRANSPORT-DROP classification, the THIRD of the
@@ -120,6 +152,18 @@ fun preferFreshTransportForPassiveReattach(
 ): Boolean = warmLeaseHeld && !transportVouchedAlive
 
 /**
+ * Issue #1952 — controller-owned eligibility for the passive recovery effect.
+ * A real drop first moves `Live -> Reattaching`; subsequent failed cycles live in
+ * `Reconnecting`, and controller exhaustion may reach `Unreachable` before this already-started,
+ * grace-bounded effect completes. Presentation status is deliberately absent, so projecting or
+ * exhausting the numbered ladder cannot cancel the IO that still owns the bounded passive episode.
+ */
+fun isPassiveRecoveryEligible(state: ConnectionState): Boolean =
+    state is ConnectionState.Reattaching ||
+        state is ConnectionState.Reconnecting ||
+        state is ConnectionState.Unreachable
+
+/**
  * The connection-core passive-transport-drop authority: the SINGLE owner of the passive
  * `-CC` drop classification. Every passive-drop call site (the driver's
  * `shouldSubmitControlChannelDrop` stale-client gate, the clean-drop test seam, the
@@ -142,17 +186,13 @@ class PassiveTransportDropEffects(
      * (the caller — `handlePassiveClientDisconnect` — owns the per-arm recovery IO with its
      * handler-local `target`/`reason`/`disconnectEvent`).
      */
-    fun classify(client: TmuxClient): PassiveDropArm =
+    fun classify(drop: PassiveTransportDrop): PassiveDropArm =
         selectPassiveDropArm(
-            // Issue #1632: the self-inflicted answer comes from the ONE authority
-            // ([SelfInflictedClose]) that also answers for the lease edge. The
-            // injectable `isSelfInflictedClose` lambda this used to take — the narrow
-            // #1568 `-CC`-only filter, inlined in `TmuxSessionViewModel` — is DELETED
-            // (D22 hard-cut): two independently-maintained filters is precisely how the
-            // lease edge silently never got one and the #1610 storm survived #1568.
-            isSelfInflictedClose =
-                SelfInflictedClose.isSelfInflictedControlChannelClose(client.disconnectEvent.value),
-            isCurrentClient = isCurrentClient(client),
+            // Issue #1952: do not re-read client.disconnectEvent here. The driver already
+            // derived this typed cause from the observed wire event and submits the SAME
+            // immutable value to the controller and this effect authority.
+            isSelfInflictedClose = drop.cause is DropCause.SelfInflicted,
+            isCurrentClient = isCurrentClient(drop.client),
             hasTarget = hasTarget(),
             screenStartedForCleared = screenStartedForCleared(),
             navigatingToDifferentSession = navigatingToDifferentSession(),

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue895SwitchWhileBlackDropTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue895SwitchWhileBlackDropTest.kt
@@ -142,7 +142,13 @@ class Issue895SwitchWhileBlackDropTest {
             vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
         )
 
-        val fired = vm.triggerCleanPassiveDropForTest()
+        client.markDisconnectedForTest(
+            com.pocketshell.core.tmux.TmuxDisconnectEvent(
+                reason = com.pocketshell.core.tmux.TmuxDisconnectReason.ReaderEof,
+                source = "eof",
+                intent = "unknown",
+            ),
+        )
 
         assertTrue("clean-drop fixture must latch the selected client disconnected", client.disconnected.value)
         assertTrue(
@@ -151,7 +157,6 @@ class Issue895SwitchWhileBlackDropTest {
         )
         advanceUntilIdle()
 
-        assertTrue("drop should have been dispatched", fired)
         assertTrue(
             "BASELINE: a Connected-state drop MUST surface an escapable band " +
                 "(Failed/Reconnecting); got ${vm.connectionStatus.value}",
@@ -190,10 +195,14 @@ class Issue895SwitchWhileBlackDropTest {
         )
 
         // Transport drops mid-switch (the black/wedged-channel EOF case).
-        val fired = vm.triggerCleanPassiveDropForTest()
+        client.markDisconnectedForTest(
+            com.pocketshell.core.tmux.TmuxDisconnectEvent(
+                reason = com.pocketshell.core.tmux.TmuxDisconnectReason.ReaderEof,
+                source = "eof",
+                intent = "unknown",
+            ),
+        )
         advanceUntilIdle()
-
-        assertTrue("drop should have been dispatched", fired)
 
         // Load-bearing assertion: the Switching-window drop SURFACES an escapable
         // band, matching the Connected baseline — the user is never left stuck on

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCloseCascadeNoCrashTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCloseCascadeNoCrashTest.kt
@@ -296,7 +296,13 @@ class TmuxSessionCloseCascadeNoCrashTest {
         // A genuine drop kicks the within-grace silent reattach loop (the
         // viewModelScope grace launch). While it is in flight, a sibling
         // cascade collector throws against the dead transport.
-        vm.triggerCleanPassiveDropForTest()
+        client.markDisconnectedForTest(
+            com.pocketshell.core.tmux.TmuxDisconnectEvent(
+                reason = com.pocketshell.core.tmux.TmuxDisconnectReason.ReaderEof,
+                source = "eof",
+                intent = "unknown",
+            ),
+        )
         client.throwFromEventsCollectorOnNextEmit = theBoom
         client.emittedEvents.emit(ControlEvent.Output("%1", "x".toByteArray()))
         advanceUntilIdle()

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/ConnectionEffectDriverTest.kt
@@ -662,18 +662,20 @@ class ConnectionEffectDriverTest {
         val typedDrops = MutableSharedFlow<FakeTmuxClient>(extraBufferCapacity = 16)
         val accepted = mutableListOf<FakeTmuxClient>()
         val effects = mutableListOf<Pair<FakeTmuxClient, ConnectionState>>()
+        val effectCauses = mutableListOf<DropCause>()
         val driver = ConnectionEffectDriver(
             controller = controller,
             tmuxPort = tmuxPort,
             transportPort = transportPort,
             scope = scope,
             controlChannelDrops = typedDrops,
-            shouldSubmitControlChannelDrop = { client ->
-                accepted += client as FakeTmuxClient
+            shouldSubmitControlChannelDrop = { drop ->
+                accepted += drop.client as FakeTmuxClient
                 true
             },
-            controlChannelDroppedEffect = { client ->
-                effects += Pair(client as FakeTmuxClient, controller.state.value)
+            controlChannelDroppedEffect = { drop ->
+                effects += Pair(drop.client as FakeTmuxClient, controller.state.value)
+                effectCauses += drop.cause
             },
         ).also { it.start() }
 
@@ -681,7 +683,15 @@ class ConnectionEffectDriverTest {
         controller.submit(ConnectionEvent.SeedLanded(sessionA, paneId = "%0"))
         assertEquals(listOf("Idle", "Attaching", "Live"), stateNamesOf(driver))
 
-        val client = FakeTmuxClient()
+        val client = FakeTmuxClient().apply {
+            markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "eof",
+                    intent = "unknown",
+                ),
+            )
+        }
         typedDrops.emit(client)
 
         assertEquals(listOf(client), accepted)
@@ -691,6 +701,11 @@ class ConnectionEffectDriverTest {
             stateNamesOf(driver),
         )
         assertEquals(listOf(client to controller.state.value), effects)
+        assertEquals(
+            "the effect must receive the exact cause derived for the controller submit",
+            listOf(DropCause.RemoteFailure("ReaderEof")),
+            effectCauses,
+        )
         assertTrue(controller.state.value is ConnectionState.Reattaching)
         scope.cancel()
     }
@@ -711,8 +726,8 @@ class ConnectionEffectDriverTest {
             scope = scope,
             controlChannelDrops = typedDrops,
             onControllerTransition = { projections += 1 },
-            controlChannelDroppedEffect = { client ->
-                effects += Pair(client as FakeTmuxClient, controller.state.value)
+            controlChannelDroppedEffect = { drop ->
+                effects += Pair(drop.client as FakeTmuxClient, controller.state.value)
             },
         ).also { it.start() }
 
@@ -765,7 +780,7 @@ class ConnectionEffectDriverTest {
             scope = scope,
             controlChannelDrops = typedDrops,
             shouldSubmitControlChannelDrop = { false },
-            controlChannelDroppedEffect = { client -> effects += client as FakeTmuxClient },
+            controlChannelDroppedEffect = { drop -> effects += drop.client as FakeTmuxClient },
         ).also { it.start() }
 
         controller.submit(ConnectionEvent.Enter(host, sessionA))
@@ -849,7 +864,7 @@ class ConnectionEffectDriverTest {
             transportPort = transportPort,
             scope = scope,
             onControllerTransition = { projections += 1 },
-            controlChannelDroppedEffect = { client -> typedRecoveryEffects += client as FakeTmuxClient },
+            controlChannelDroppedEffect = { drop -> typedRecoveryEffects += drop.client as FakeTmuxClient },
         ).also { it.start() }
 
         controller.submit(ConnectionEvent.Enter(host, sessionA))

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/PassiveTransportDropEffectsTest.kt
@@ -1,10 +1,16 @@
 package com.pocketshell.app.tmux.connection
 
 import com.pocketshell.app.tmux.FakeTmuxClient
+import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.connection.DropCause
+import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.tmux.TmuxClient
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -248,7 +254,7 @@ class PassiveTransportDropEffectsTest {
                 ),
             )
         }
-        assertEquals(PassiveDropArm.Ignore, effects().classify(detached))
+        assertEquals(PassiveDropArm.Ignore, effects().classify(observePassiveTransportDrop(detached)))
     }
 
     /**
@@ -267,7 +273,7 @@ class PassiveTransportDropEffectsTest {
                 ),
             )
         }
-        assertEquals(PassiveDropArm.Ignore, effects().classify(closed))
+        assertEquals(PassiveDropArm.Ignore, effects().classify(observePassiveTransportDrop(closed)))
     }
 
     /**
@@ -287,15 +293,60 @@ class PassiveTransportDropEffectsTest {
         }
         assertEquals(
             PassiveDropArm.SilentReattachWithinGrace,
-            effects(hasTarget = { false }).classify(eofed),
+            effects(hasTarget = { false }).classify(observePassiveTransportDrop(eofed)),
         )
+    }
+
+    /**
+     * Issue #1952 regression: one wire observation remains authoritative even if the
+     * mutable client later records a teardown event. The controller and effect both hold
+     * [drop], so a later ExplicitClose cannot contradict/reclassify the original EOF.
+     */
+    @Test
+    fun classify_usesTheSameTypedCauseSnapshotAfterClientEventChanges() {
+        val mutableClient = FakeTmuxClient().apply {
+            markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "eof",
+                    intent = "unknown",
+                ),
+            )
+        }
+        val drop = observePassiveTransportDrop(mutableClient)
+        mutableClient.markDisconnectedForTest(
+            TmuxDisconnectEvent(
+                reason = TmuxDisconnectReason.ExplicitClose,
+                source = "teardown",
+                intent = "local_close",
+            ),
+        )
+
+        assertEquals(TmuxDisconnectReason.ReaderEof, drop.disconnectEvent.reason)
+        assertEquals("eof", drop.disconnectEvent.source)
+        assertEquals("unknown", drop.disconnectEvent.intent)
+        assertEquals(DropCause.RemoteFailure("ReaderEof"), drop.cause)
+        assertEquals(
+            PassiveDropArm.SilentReattachWithinGrace,
+            effects(hasTarget = { false }).classify(drop),
+        )
+    }
+
+    @Test
+    fun acceptedPassiveEpisodeRemainsEligibleThroughControllerExhaustionButLiveIsNot() {
+        val host = HostKey("host")
+        val target = SessionId("session")
+        assertTrue(isPassiveRecoveryEligible(ConnectionState.Reattaching(host, target)))
+        assertTrue(isPassiveRecoveryEligible(ConnectionState.Reconnecting(host, target, attempt = 2)))
+        assertTrue(isPassiveRecoveryEligible(ConnectionState.Unreachable(host, target)))
+        assertFalse(isPassiveRecoveryEligible(ConnectionState.Live(host, target)))
     }
 
     @Test
     fun classify_currentClient_navigating_skips() {
         assertEquals(
             PassiveDropArm.SkipInAppNavigation,
-            effects(navigatingToDifferentSession = { true }).classify(client),
+            effects(navigatingToDifferentSession = { true }).classify(observePassiveTransportDrop(client)),
         )
     }
 
@@ -303,7 +354,7 @@ class PassiveTransportDropEffectsTest {
     fun classify_currentClient_screenStopped_pauses() {
         assertEquals(
             PassiveDropArm.PauseUntilForeground,
-            effects().classify(client),
+            effects().classify(observePassiveTransportDrop(client)),
         )
     }
 
@@ -311,7 +362,7 @@ class PassiveTransportDropEffectsTest {
     fun classify_currentClient_foreground_silentReattach() {
         assertEquals(
             PassiveDropArm.SilentReattachWithinGrace,
-            effects(screenStartedForCleared = { true }).classify(client),
+            effects(screenStartedForCleared = { true }).classify(observePassiveTransportDrop(client)),
         )
     }
 
@@ -329,11 +380,11 @@ class PassiveTransportDropEffectsTest {
         val fx = effects(isCurrentClient = { it === currentClient })
 
         // While oldClient is current, its drop recovers (no target/screenStopped -> here pause).
-        assertEquals(PassiveDropArm.PauseUntilForeground, fx.classify(oldClient))
+        assertEquals(PassiveDropArm.PauseUntilForeground, fx.classify(observePassiveTransportDrop(oldClient)))
         // A fast switch swaps in newClient: the OLD client's late close is now a stale drop.
         currentClient = newClient
-        assertEquals(PassiveDropArm.Ignore, fx.classify(oldClient))
+        assertEquals(PassiveDropArm.Ignore, fx.classify(observePassiveTransportDrop(oldClient)))
         // The new current client's drop still recovers.
-        assertEquals(PassiveDropArm.PauseUntilForeground, fx.classify(newClient))
+        assertEquals(PassiveDropArm.PauseUntilForeground, fx.classify(observePassiveTransportDrop(newClient)))
     }
 }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSessionTestControl.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSessionTestControl.kt
@@ -30,7 +30,9 @@ public object SshSessionTestControl {
      * [RealSshSession.forceTransportDeathForTest]; a no-op on any other
      * [SshSession] implementation.
      */
-    public fun forceTransportDeath(session: SshSession) {
-        (session as? RealSshSession)?.forceTransportDeathForTest()
+    public fun forceTransportDeath(session: SshSession): Boolean {
+        val real = session as? RealSshSession ?: return false
+        real.forceTransportDeathForTest()
+        return true
     }
 }


### PR DESCRIPTION
Closes #1952

Follow-up slice A from #1680. This preserves one immutable typed passive-transport-drop cause from the controller event through the selected effect, removes the remaining mutable disconnect-breadcrumb reread, and makes legacy VM recovery eligibility follow the controller's Reattaching/Reconnecting/Unreachable states.

## Architecture

- `ConnectionEffectDriver` captures one `PassiveTransportDrop` and passes the same value to controller and effect.
- Passive recovery effects never reread mutable client disconnect state.
- The VM snapshots its diagnostic breadcrumb once.
- Existing controller/effect ownership remains intact: no new reducer, flag, clock, counter, job, arbiter, recovery owner, or direct SSH owner.
- The D34 proof kills the authenticated server-side `sshd` child, observes real EOF/reader failure, and requires fresh SSH/tmux identities on recovery.

## Review

Independent reviewer: **APPROVED**
https://github.com/alexeygrigorev/pocketshell/issues/1952#issuecomment-5166564040

Reviewer independently verified exact-base peer-side RED and final GREEN, focused JVM, core-ssh, AndroidTest compile, full JVM, and emulator adjacency.

## Coordinator verification

Frozen lexical 12-file source hash:
`33d920faf55d36de4bfff5e802e374cf88626eef1fcd7891ddaa03f4836dad62`

- `git diff --check` — green
- file-size hygiene — green; VM shrank
- connection VM ratchet — green (`17620` lines; IO 17, runBlocking 13, variants 0)
- test-validity and CI-journey harness checks — green
- core-ssh: 52/52
- peer-side real-transport D34: 1/1, zero skips
- AndroidTest compile — green
- CleanOutage journey: 1/1 twice independently, zero skips
- SilentDrop adjacency: 2/2, zero skips
- Issue895 black-band adjacency: 2/2, zero skips
- canonical `scripts/full-jvm-gate.sh`: `BUILD SUCCESSFUL in 18m 17s`, 603/603 tasks executed

The first two attached-shell canonical attempts were SIGTERM-interrupted by the bounded caller, not test failures; #1956 records that test-infrastructure gap. The successful verdict above is the unchanged canonical script run in an isolated non-default tmux socket with durable exit status.

Known outbound adjacency failures remain tracked separately in #1926/#1819 and are not attributed to this patch. Follow-up serial connection slices are #1953 and #1954.
