### PR TITLE
test(nightly): scope app update dismiss selector

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/AppUpdateDismissSelectorTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/AppUpdateDismissSelectorTest.kt
@@ -1,0 +1,88 @@
+package com.pocketshell.app.bootstrap
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.pocketshell.app.hosts.AppUpdateWarningBanner
+import com.pocketshell.app.hosts.HOST_LIST_APP_UPDATE_WARNING_TAG
+import com.pocketshell.app.hosts.HOST_LIST_UPDATE_CHECK_FAILED_TAG
+import com.pocketshell.app.hosts.HostListViewModel
+import com.pocketshell.app.hosts.UpdateCheckFailedBanner
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class AppUpdateDismissSelectorTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun appUpdateDismissTargetsOnlyItsBannerWhenAnotherDismissActionIsVisible() {
+        val showAppUpdate = mutableStateOf(true)
+        val showUnrelated = mutableStateOf(true)
+
+        compose.setContent {
+            PocketShellTheme {
+                Column {
+                    if (showUnrelated.value) {
+                        androidx.compose.foundation.layout.Box(
+                            modifier = Modifier.testTag(HOST_LIST_UPDATE_CHECK_FAILED_TAG),
+                        ) {
+                            UpdateCheckFailedBanner(
+                                reason = "fixture failure",
+                                onRetry = {},
+                                onDismiss = { showUnrelated.value = false },
+                            )
+                        }
+                    }
+                    if (showAppUpdate.value) {
+                        androidx.compose.foundation.layout.Box(
+                            modifier = Modifier.testTag(HOST_LIST_APP_UPDATE_WARNING_TAG),
+                        ) {
+                            AppUpdateWarningBanner(
+                                warning = HostListViewModel.AppUpdateWarning(
+                                    hostId = 1L,
+                                    remoteVersion = "9.9.9",
+                                    appVersion = "1.0.0",
+                                ),
+                                onUpdate = null,
+                                onRetry = {},
+                                onDismiss = { showAppUpdate.value = false },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        val dismissActions = compose.onAllNodesWithText("Dismiss")
+        assertEquals(
+            "fixture must render two globally ambiguous Dismiss actions",
+            2,
+            dismissActions.fetchSemanticsNodes().size,
+        )
+        dismissActions[0].assertIsDisplayed()
+        dismissActions[1].assertIsDisplayed()
+
+        dismissActionWithin(HOST_LIST_APP_UPDATE_WARNING_TAG).performClick()
+
+        compose.onNodeWithTag(HOST_LIST_APP_UPDATE_WARNING_TAG).assertDoesNotExist()
+        compose.onNodeWithTag(HOST_LIST_UPDATE_CHECK_FAILED_TAG).assertIsDisplayed()
+        dismissActionWithin(HOST_LIST_UPDATE_CHECK_FAILED_TAG).assertIsDisplayed()
+    }
+
+    private fun dismissActionWithin(ancestorTag: String) = compose.onNode(
+        hasText("Dismiss") and hasAnyAncestor(hasTestTag(ancestorTag)),
+    )
+}

--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
@@ -5,6 +5,9 @@ import android.os.SystemClock
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
@@ -212,7 +215,7 @@ class HostBootstrapScenarioSuiteTest {
 
         // Dismissible and non-blocking: tapping Dismiss removes the banner
         // and the host list stays usable (no loop, no re-prompt).
-        compose.onNodeWithText("Dismiss").performClick()
+        dismissActionWithin(HOST_LIST_APP_UPDATE_WARNING_TAG).performClick()
         compose.waitUntil(timeoutMillis = 10_000) {
             compose.onAllNodesWithTag(HOST_LIST_APP_UPDATE_WARNING_TAG)
                 .fetchSemanticsNodes()
@@ -550,6 +553,10 @@ class HostBootstrapScenarioSuiteTest {
             compose.onNodeWithTag(HOST_BOOTSTRAP_ROW_TAG_PREFIX + row).assertExists()
         }
     }
+
+    private fun dismissActionWithin(ancestorTag: String) = compose.onNode(
+        hasText("Dismiss") and hasAnyAncestor(hasTestTag(ancestorTag)),
+    )
 
     private fun assumeScenariosEnabled() {
         val enabled = InstrumentationRegistry.getArguments()

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -271,6 +271,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.fileviewer.FileViewerDockerTest#moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl"  # #1714 D33/G9/G10: exact issue-time excerpts plus synthetic mixed/deep/wide class coverage through production MarkdownView
   "com.pocketshell.app.bootstrap.HostReadyPrimaryActionTest"  # #885 #117 D32 G9): the post-update Host ready success sheet must
   "com.pocketshell.app.bootstrap.HostNotificationsReadinessTest"  # #1236 D26 / D32 G9): per-host notification readiness + the
+  "com.pocketshell.app.bootstrap.AppUpdateDismissSelectorTest"  # #1958 D32 G9: two visible Dismiss actions; app-update ancestor selector removes only its banner
   "$FQCN_PREFIX.StrictModeMainThreadIoDetectorE2eTest"  # #933 #928 #931 #926 ============================================================…
   "com.pocketshell.app.cards.SessionChecklistPushJourneyDockerTest"  # #949 #859 ============================================================…
   "com.pocketshell.app.insets.NestedImePaddingInSheetGeometryTest"  # #1872/#1821: ten real ModalBottomSheet geometry cases pin the five inline navigationBarsPadding sites as inert


### PR DESCRIPTION
Closes #1958

## Summary

- scope the bootstrap app-update `Dismiss` action to the existing app-update-warning ancestor tag
- add a deterministic two-banner Compose regression proving the unrelated dismiss action remains
- wire the regression into the journey suite

## Evidence

- independent review: https://github.com/alexeygrigorev/pocketshell/issues/1958#issuecomment-5169827869
- reviewer mutation: 1 test / 1 expected ambiguity failure / 0 skips
- reviewer final selector: 1/1 green
- reviewer canonical nightly phase 3: 4/4 green, 0 skips
- reviewer full JVM: 12,047 tests, 0 failures/errors/skips; 603/603 tasks, exit 0
