### PR TITLE
fix(terminal): recover OSC 8 wrapped links

### DIFF
--- a/scripts/ci-journey-core-terminal-functions.sh
+++ b/scripts/ci-journey-core-terminal-functions.sh
@@ -71,6 +71,13 @@ run_core_terminal_shell_snapshot() {
   run_ct_class "$CORE_TERMINAL_SHELL_SNAPSHOT_CLASS"
 }
 
+CORE_TERMINAL_HARD_WRAPPED_URL_CLASS="com.pocketshell.core.terminal.ui.WrappedUrlReassemblyInstrumentedTest"
+HARD_WRAPPED_URL_STATUS="PASS"
+
+run_core_terminal_hard_wrapped_url() {
+  run_ct_class "$CORE_TERMINAL_HARD_WRAPPED_URL_CLASS"
+}
+
 # ---------------------------------------------------------------------------
 # Issue #1827: THE registry of core-terminal proofs.
 #
@@ -108,4 +115,5 @@ CORE_TERMINAL_PROOFS=(
   "OVERLAY_UNBOUNDED_STATUS|CORE_TERMINAL_OVERLAY_UNBOUNDED_CLASS|Core-terminal v0.4.17 overlay-unbounded-measure crash proof"
   "SURFACE_REPAINT_STATUS|CORE_TERMINAL_SURFACE_REPAINT_CLASS|Core-terminal #1203 surface-only-black recovery proof"
   "SHELL_SNAPSHOT_STATUS|CORE_TERMINAL_SHELL_SNAPSHOT_CLASS|Core-terminal #1233 shell-pane single-snapshot affordance-scan proof"
+  "HARD_WRAPPED_URL_STATUS|CORE_TERMINAL_HARD_WRAPPED_URL_CLASS|Core-terminal #1955 hard-wrapped URL target proof"
 )

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -827,4 +827,35 @@ else
   fi
 fi
 
+# --------------------------------------------------------------------------
+# Issue #1955 hard-wrapped URL target proof (core-terminal androidTest).
+# Agent TUIs can paint a URL to the final grid column and resume it at column
+# zero without preserving Termux's soft-wrap bit. The proof reproduces the
+# maintainer's exact 60-column `campaig` / `ns/...` split, hard-asserts both
+# source wrap flags are false, taps BOTH fragments through the production
+# TerminalViewClient route, and requires two ACTION_VIEW intents carrying the
+# exact complete GitHub URI. It also pins the continuation not being exposed as
+# a local file path. Uses NO Docker fixture (in-process real TerminalView).
+if budget_exhausted; then
+  STEP_TIMEOUT_HIT=1
+  HARD_WRAPPED_URL_STATUS="SKIPPED"
+  echo "JOURNEY_STEP_TIMEOUT: skipping #1955 hard-wrapped URL proof — suite budget exhausted (issue #835 / #470 stall)"
+else
+  echo "=========================================================="
+  echo ">>> CORE-TERMINAL #1955 HARD-WRAPPED URL PROOF: $CORE_TERMINAL_HARD_WRAPPED_URL_CLASS (attempt 1)"
+  echo "=========================================================="
+  hard_wrapped_url_start=$SECONDS
+  if run_core_terminal_hard_wrapped_url; then
+    echo "HARD_WRAPPED_URL_PASS: passed on attempt 1 (elapsed $((SECONDS - hard_wrapped_url_start))s)"
+  else
+    echo ">>> HARD-WRAPPED URL PROOF FAILED attempt 1 — retrying once (CI-AVD infra flake / sibling-install)"
+    if run_core_terminal_hard_wrapped_url; then
+      echo "HARD_WRAPPED_URL_FLAKE_RECOVERED: passed on retry (attempt 2)"
+    else
+      echo "HARD_WRAPPED_URL_FAILED: #1955 proof failed twice"
+      HARD_WRAPPED_URL_STATUS="FAIL"
+    fi
+  fi
+fi
+
 finish_ci_journey_suite

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/WrappedUrlReassemblyInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/WrappedUrlReassemblyInstrumentedTest.kt
@@ -1,13 +1,23 @@
 package com.pocketshell.core.terminal.ui
 
+import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.net.Uri
+import android.os.SystemClock
+import android.view.MotionEvent
 import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.core.terminal.selection.TerminalMatch
 import com.pocketshell.core.terminal.selection.TerminalMatchRegion
 import com.pocketshell.core.terminal.selection.UrlRegion
+import com.pocketshell.core.terminal.selection.extractVisibleViewportRows
+import com.pocketshell.core.terminal.selection.findVisibleFilePaths
 import com.pocketshell.core.terminal.selection.findVisibleTerminalMatches
 import com.pocketshell.core.terminal.selection.findVisibleUrls
 import com.pocketshell.core.terminal.selection.hitTestUrl
@@ -20,6 +30,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,6 +55,204 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class WrappedUrlReassemblyInstrumentedTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun issue1955HardWrappedExactGithubUrlBothRowsDispatchCompleteUri() { runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = compose.activity
+        val state = TerminalSurfaceState()
+        val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 1)
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = stdout,
+            remoteStdin = null,
+        )
+        val client = PocketShellTerminalViewClient()
+        val url =
+            "https://github.com/DataTalksClub/playbooks/blob/main/" +
+                "campaigns/ml-zoomcamp-2026/copy-bank/events/pre-course-live-qa.md"
+        val splitAt = url.indexOf("campaigns") + "campaig".length
+        val firstFragment = url.take(splitAt)
+        val continuationFragment = url.drop(splitAt)
+        assertEquals("the reported Pixel-7 terminal grid is 60 columns", 60, splitAt)
+
+        Intents.init()
+        try {
+            Intents.intending(hasAction(Intent.ACTION_VIEW))
+                .respondWith(android.app.Instrumentation.ActivityResult(0, null))
+
+            val viewRef = arrayOfNulls<TerminalView>(1)
+            instrumentation.runOnMainSync {
+                val view = TerminalView(context, null)
+                view.applyPocketShellDefaults(client)
+                view.attachSession(requireNotNull(state.session))
+
+                // Initialise renderer metrics, then size the REAL TerminalView
+                // to the 60-column Pixel-7 viewport captured in the report.
+                view.measure(
+                    View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY),
+                )
+                view.layout(0, 0, view.measuredWidth, view.measuredHeight)
+                val fontWidth = requireNotNull(view.mRenderer).fontWidth
+                val sixtyColumnWidth = (fontWidth * 60.5f).toInt()
+                view.measure(
+                    View.MeasureSpec.makeMeasureSpec(sixtyColumnWidth, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY),
+                )
+                view.layout(0, 0, view.measuredWidth, view.measuredHeight)
+                assertEquals(60, requireNotNull(view.mEmulator).mColumns)
+                viewRef[0] = view
+            }
+            val view = requireNotNull(viewRef[0])
+
+            // Claude Code emits long response URLs as OSC 8 hyperlinks. Disable
+            // VT auto-wrap and position the cursor explicitly for row 2 to paint
+            // the exact screenshot shape while leaving BOTH line-wrap bits false.
+            // The OSC 8 remains active across the cursor move, which gives the
+            // terminal a structural continuation signal without guessing from
+            // the visible `campaig` / `ns/...` text.
+            val hardWrappedPaint = buildString {
+                append("\u001b[?7l")
+                append("\u001b]8;;$url\u001b\\")
+                append(firstFragment)
+                append("\u001b[2;1H")
+                append(continuationFragment)
+                append("\u001b]8;;\u001b\\")
+                append("\u001b[?7h")
+            }
+            state.appendRemoteOutput(hardWrappedPaint.toByteArray(Charsets.US_ASCII))
+
+            val snapshotRef = arrayOfNulls<com.pocketshell.core.terminal.selection.ViewportRowsSnapshot>(1)
+            withTimeout(5_000) {
+                while (true) {
+                    delay(20)
+                    instrumentation.runOnMainSync {
+                        snapshotRef[0] = extractVisibleViewportRows(view)
+                    }
+                    val snapshot = snapshotRef[0] ?: continue
+                    val first = snapshot.rows.firstOrNull { it.row == 0 }?.text?.take(60)
+                    val second = snapshot.rows.firstOrNull { it.row == 1 }?.text
+                    if (first == firstFragment && second?.startsWith(continuationFragment) == true) break
+                }
+            }
+            val snapshot = requireNotNull(snapshotRef[0])
+            val sourceRows = snapshot.rows.filter { it.row == 0 || it.row == 1 }
+            assertEquals(listOf(false, false), sourceRows.map { it.wrapsToNext })
+            assertTrue(
+                "first row's last cell must retain OSC 8 provenance",
+                sourceRows[0].endsWithOsc8Hyperlink,
+            )
+            assertTrue(
+                "continuation row's first cell must retain OSC 8 provenance",
+                sourceRows[1].startsWithOsc8Hyperlink,
+            )
+            assertFalse(
+                "continuation must not be a newly opened independent OSC 8 link",
+                sourceRows[1].startsNewOsc8Hyperlink,
+            )
+
+            val urlsRef = arrayOfNulls<List<UrlRegion>>(1)
+            val pathsRef = arrayOfNulls<List<com.pocketshell.core.terminal.selection.FilePathRegion>>(1)
+            val matchesRef = arrayOfNulls<List<TerminalMatchRegion>>(1)
+            instrumentation.runOnMainSync {
+                urlsRef[0] = findVisibleUrls(view)
+                pathsRef[0] = findVisibleFilePaths(view)
+                matchesRef[0] = findVisibleTerminalMatches(view)
+            }
+            val urls = requireNotNull(urlsRef[0]).filter { it.url == url }.sortedBy { it.row }
+            assertEquals("both visual fragments must share one complete target", listOf(0, 1), urls.map { it.row })
+            assertTrue(urls.all { it.url == url })
+            assertFalse(
+                "the continuation must not be exposed to the local file viewer",
+                requireNotNull(pathsRef[0]).any { it.row == 1 },
+            )
+            val decorations = requireNotNull(matchesRef[0])
+                .filter { it.match is TerminalMatch.Url && it.match.value == url }
+                .sortedBy { it.row }
+            assertEquals("both URL fragments must be decorated", listOf(0, 1), decorations.map { it.row })
+
+            // Use the same TerminalViewClient single-tap hook shape as the
+            // production TerminalSurface, including the real ACTION_VIEW bridge.
+            client.onTapMaybeUrl = { x, y ->
+                val hit = hitTestUrl(view, urls, x, y)
+                if (hit == null) {
+                    false
+                } else {
+                    openUrlWithFallback(context, hit.url)
+                    true
+                }
+            }
+            try {
+                for (region in urls) {
+                    val before = Intents.getIntents().count {
+                        it.action == Intent.ACTION_VIEW && it.data == Uri.parse(url)
+                    }
+                    instrumentation.runOnMainSync {
+                        val now = SystemClock.uptimeMillis()
+                        val event = MotionEvent.obtain(
+                            now,
+                            now,
+                            MotionEvent.ACTION_UP,
+                            centerX(region, view),
+                            centerY(region, view),
+                            0,
+                        )
+                        try {
+                            client.onSingleTapUp(event)
+                        } finally {
+                            event.recycle()
+                        }
+                    }
+                    val after = Intents.getIntents().count {
+                        it.action == Intent.ACTION_VIEW && it.data == Uri.parse(url)
+                    }
+                    assertEquals(
+                        "tap on row ${region.row} must dispatch the exact complete URI once",
+                        before + 1,
+                        after,
+                    )
+                }
+            } finally {
+                client.onTapMaybeUrl = null
+            }
+
+            val exactIntentCount = Intents.getIntents().count {
+                it.action == Intent.ACTION_VIEW && it.data == Uri.parse(url)
+            }
+            val artifactSummary = buildString {
+                appendLine("url=$url")
+                appendLine("columns=${snapshot.columns}")
+                appendLine("source_wrap_flags=${sourceRows.map { it.wrapsToNext }}")
+                appendLine(
+                    "source_osc8_boundary=" +
+                        "[${sourceRows[0].endsWithOsc8Hyperlink}, " +
+                        "${sourceRows[1].startsWithOsc8Hyperlink}]",
+                )
+                appendLine("continuation_starts_new_osc8=${sourceRows[1].startsNewOsc8Hyperlink}")
+                appendLine("url_region_rows=${urls.map { it.row }}")
+                appendLine("url_region_targets=${urls.map { it.url }}")
+                appendLine("file_path_regions=${pathsRef[0]}")
+                appendLine("action_view_exact_uri_count=$exactIntentCount")
+            }
+            instrumentation.runOnMainSync {
+                saveIssue1955Artifacts(
+                    view = view,
+                    visibleText = sourceRows.joinToString("\n") { it.text.trimEnd() },
+                    summary = artifactSummary,
+                )
+            }
+        } finally {
+            Intents.release()
+            producerJob.cancel()
+            producerScope.cancel()
+            state.detachExternalProducer()
+        }
+    } }
 
     @Test
     fun urlWrappedAcrossRowsIsReassembledIntoOneFullTarget() { runBlocking {
@@ -169,5 +380,28 @@ class WrappedUrlReassemblyInstrumentedTest {
             }
             println("ISSUE558_VIEWPORT ${outFile.absolutePath}")
         }
+    }
+
+    private fun saveIssue1955Artifacts(
+        view: TerminalView,
+        visibleText: String,
+        summary: String,
+    ) {
+        val width = view.width.coerceAtLeast(1)
+        val height = view.height.coerceAtLeast(1)
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        view.draw(Canvas(bitmap))
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val dir = File(testArtifactsRoot(ctx), "additional_test_output/issue-1955")
+        check(dir.exists() || dir.mkdirs()) { "could not create issue-1955 artifact directory: $dir" }
+        val viewport = File(dir, "issue1955-hard-wrapped-url-viewport.png")
+        FileOutputStream(viewport).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "could not encode #1955 viewport artifact"
+            }
+        }
+        File(dir, "issue1955-visible-terminal.txt").writeText(visibleText)
+        File(dir, "issue1955-summary.txt").writeText(summary)
+        println("ISSUE1955_ARTIFACTS ${dir.absolutePath}")
     }
 }

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/FilePathScanner.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/FilePathScanner.kt
@@ -111,7 +111,8 @@ internal fun filePathRegionsForRows(
     if (columns <= 0 || visualRows.isEmpty()) return emptyList()
 
     val out = mutableListOf<FilePathRegion>()
-    for (logical in reassemble(markFilePathContinuationWraps(visualRows))) {
+    val rows = markFilePathContinuationWraps(markHardWrappedUrlContinuations(visualRows, columns))
+    for (logical in reassemble(rows)) {
         val line = logical.text
         for (detected in detectFilePathsInLine(line, urlSpans(line))) {
             for (span in logical.mapSpanToRows(detected.start, detected.endExclusive)) {

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SelectionScanner.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/SelectionScanner.kt
@@ -48,11 +48,12 @@ internal fun terminalMatchRegionsForRows(
 
     val out = mutableListOf<TerminalMatchRegion>()
     // The terminal's wrap flag is authoritative when present, but some
-    // agent-emitted file paths have shown up as adjacent visual rows without a
-    // wrap marker. Keep generic smart-selection affordances aligned with the
-    // file-path tap overlay for the conservative generated-image/attachment
-    // shapes that scanner already knows how to join.
-    for (logical in reassemble(markFilePathContinuationWraps(visualRows))) {
+    // agent-emitted URLs and file paths have shown up as adjacent visual rows
+    // without a wrap marker. Keep generic smart-selection affordances aligned
+    // with both tap overlays for the conservative continuation shapes those
+    // scanners already know how to join.
+    val rows = markFilePathContinuationWraps(markHardWrappedUrlContinuations(visualRows, columns))
+    for (logical in reassemble(rows)) {
         for (span in matchSpansForLine(logical.text, matcher)) {
             for (rowSpan in logical.mapSpanToRows(span.start, span.endExclusive)) {
                 val startCol = rowSpan.startCol.coerceAtLeast(0)

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/UrlScanner.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/UrlScanner.kt
@@ -102,7 +102,7 @@ public data class UrlRegion(
  * typically <30 rows on a phone.
  */
 public fun findVisibleUrls(view: TerminalView): List<UrlRegion> {
-    // Issue #558 bug 2 / #1233: read every visible row WITH its line-wrap flag —
+    // Issue #558 bug 2 / #1233/#1955: read every visible row WITH its line-wrap flag —
     // via the shared [extractVisibleViewportRows] primitive so a URL the emulator
     // soft-wrapped across rows is reassembled into one logical line before
     // matching, AND so the four shell-pane affordance scanners share ONE viewport
@@ -133,7 +133,9 @@ public fun urlRegionsForRows(
 ): List<UrlRegion> {
     if (columns <= 0 || visualRows.isEmpty()) return emptyList()
     val out = mutableListOf<UrlRegion>()
-    for (logical in reassemble(visualRows)) {
+    // #1955 conservatively restores the missing wrap metadata some agent TUIs
+    // lose; this remains a pure pass over the one immutable viewport snapshot.
+    for (logical in reassemble(markHardWrappedUrlContinuations(visualRows, columns))) {
         val line = logical.text
 
         // Columns already claimed by a URL on this logical line, so the loopback

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/ViewportTextExtraction.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/ViewportTextExtraction.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.core.terminal.selection
 
+import com.termux.terminal.TextStyle
 import com.termux.view.TerminalView
 
 /**
@@ -70,7 +71,32 @@ public fun extractVisibleViewportRows(view: TerminalView): ViewportRowsSnapshot 
         } catch (_: Throwable) {
             false
         }
-        visualRows += VisualRow(row = row, text = line, wrapsToNext = wraps)
+        // OSC 8 provenance is stored in a rendering-neutral cell-style bit.
+        // Copy only the two boundary cells needed for hard-wrap repair: this
+        // remains the same one-pass main-thread snapshot and adds at most two
+        // constant-time terminal reads per visible row.
+        val firstCellStyle = try {
+            screen.getStyleAt(row, 0)
+        } catch (_: Throwable) {
+            0L
+        }
+        val startsWithOsc8Hyperlink =
+            firstCellStyle and TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK != 0L
+        val startsNewOsc8Hyperlink =
+            firstCellStyle and TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START != 0L
+        val endsWithOsc8Hyperlink = try {
+            screen.getStyleAt(row, columns - 1) and TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK != 0L
+        } catch (_: Throwable) {
+            false
+        }
+        visualRows += VisualRow(
+            row = row,
+            text = line,
+            wrapsToNext = wraps,
+            startsWithOsc8Hyperlink = startsWithOsc8Hyperlink,
+            endsWithOsc8Hyperlink = endsWithOsc8Hyperlink,
+            startsNewOsc8Hyperlink = startsNewOsc8Hyperlink,
+        )
     }
     return ViewportRowsSnapshot(rows = visualRows, columns = columns)
 }

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/WrappedLineReassembly.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/selection/WrappedLineReassembly.kt
@@ -27,11 +27,23 @@ package com.pocketshell.core.terminal.selection
  *   `getSelectedText` returns it).
  * @property wrapsToNext `true` when the emulator's line-wrap flag is set for
  *   this row — i.e. the next visual row continues the same logical line.
+ * @property startsWithOsc8Hyperlink whether column zero was emitted inside an
+ *   OSC 8 hyperlink. This immutable terminal provenance is intentionally
+ *   separate from visual SGR colour/style.
+ * @property endsWithOsc8Hyperlink whether the final grid column was emitted
+ *   inside an OSC 8 hyperlink.
+ * @property startsNewOsc8Hyperlink whether column zero is the first cell after
+ *   an OSC 8 opener. A true value distinguishes an adjacent independent OSC 8
+ *   link from a continuation whose hyperlink remained active across the row
+ *   boundary.
  */
 public data class VisualRow(
     val row: Int,
     val text: String,
     val wrapsToNext: Boolean,
+    val startsWithOsc8Hyperlink: Boolean = false,
+    val endsWithOsc8Hyperlink: Boolean = false,
+    val startsNewOsc8Hyperlink: Boolean = false,
 )
 
 /**
@@ -111,3 +123,87 @@ public fun reassemble(rows: List<VisualRow>): List<LogicalLine> {
     if (current.isNotEmpty()) out += LogicalLine(current)
     return out
 }
+
+/**
+ * Restores URL continuation metadata for agent TUIs that hard-wrap an OSC 8
+ * hyperlink but do not preserve Termux's [VisualRow.wrapsToNext] bit (#1955).
+ *
+ * This deliberately does **not** inspect a live terminal.  It runs over the
+ * immutable, single-extraction viewport snapshot used by the off-main overlay
+ * scanners (#796/#871/#1233). Text + width + a false wrap bit cannot distinguish
+ * the reported `campaig` / `ns/...` split from a complete extensionless URL
+ * followed by an independent path. Therefore this pass never guesses from text
+ * shape. It repairs only a boundary whose last/first cells both carry the
+ * emulator's OSC 8 provenance marker and whose next row does not start a newly
+ * opened hyperlink. SGR colour continuity is deliberately not enough:
+ * independent newline rows can use the same colour and attributes.
+ */
+internal fun markHardWrappedUrlContinuations(
+    rows: List<VisualRow>,
+    columns: Int,
+): List<VisualRow> {
+    if (rows.size < 2 || columns <= 0) return rows
+
+    val out = rows.toMutableList()
+    var changed = false
+    var index = 0
+    while (index < rows.lastIndex) {
+        if (out[index].wrapsToNext) {
+            index += 1
+            continue
+        }
+        val continuationEnd = osc8HardWrappedUrlContinuationEnd(rows, index, columns)
+        if (continuationEnd == null) {
+            index += 1
+            continue
+        }
+        for (joinIndex in index until continuationEnd) {
+            if (!out[joinIndex].wrapsToNext) {
+                out[joinIndex] = out[joinIndex].copy(wrapsToNext = true)
+                changed = true
+            }
+        }
+        index = continuationEnd
+    }
+    return if (changed) out else rows
+}
+
+private fun osc8HardWrappedUrlContinuationEnd(
+    rows: List<VisualRow>,
+    startIndex: Int,
+    columns: Int,
+): Int? {
+    val first = rows[startIndex].text.take(columns)
+    if (first.length != columns || first.lastOrNull()?.isWhitespace() != false) return null
+
+    val httpStart = first.lastIndexOf("http://", ignoreCase = true)
+    val httpsStart = first.lastIndexOf("https://", ignoreCase = true)
+    val schemeStart = maxOf(httpStart, httpsStart)
+    if (schemeStart < 0) return null
+    val firstFragment = first.substring(schemeStart)
+    if (firstFragment.any { it in OSC8_WRAP_URL_DELIMITERS }) return null
+
+    var index = startIndex
+    while (index < rows.lastIndex) {
+        val current = rows[index]
+        val next = rows[index + 1]
+        if (
+            !current.endsWithOsc8Hyperlink ||
+            !next.startsWithOsc8Hyperlink ||
+            next.startsNewOsc8Hyperlink
+        ) {
+            break
+        }
+        index += 1
+
+        val continuation = next.text.takeWhile { it !in OSC8_WRAP_URL_DELIMITERS }
+        val visualText = next.text.take(columns)
+        val fillsGrid = visualText.length == columns && continuation.length >= columns
+        if (!fillsGrid) break
+    }
+    return index.takeIf { it > startIndex }
+}
+
+private val OSC8_WRAP_URL_DELIMITERS: Set<Char> = setOf(
+    ' ', '\t', '\n', '\r', '`', '"', '\'', '<', '>',
+)

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -268,6 +268,11 @@ public final class TerminalEmulator {
     /** Current {@link TextStyle} effect. */
     int mEffect;
 
+    /** True between an OSC 8 hyperlink opener and its empty-URI closer. */
+    private boolean mOsc8HyperlinkActive;
+    /** True until the first printable cell after an OSC 8 opener is emitted. */
+    private boolean mOsc8HyperlinkStartPending;
+
     /**
      * The number of scrolled lines since last calling {@link #clearScrollCounter()}. Used for moving selection up along
      * with the scrolling text.
@@ -2090,6 +2095,16 @@ public final class TerminalEmulator {
                     if (endOfInput) break;
                 }
                 break;
+            case 8:
+                // OSC 8 ; params ; URI ST. The URI itself is deliberately not
+                // retained: PocketShell only needs durable per-cell provenance
+                // that adjacent painted fragments belonged to an explicitly
+                // declared hyperlink. An empty URI closes the hyperlink.
+                int uriSeparator = textParameter.indexOf(';');
+                mOsc8HyperlinkActive = uriSeparator >= 0 &&
+                    uriSeparator + 1 < textParameter.length();
+                mOsc8HyperlinkStartPending = mOsc8HyperlinkActive;
+                break;
             case 10: // Set foreground color.
             case 11: // Set background color.
             case 12: // Set cursor color.
@@ -2182,7 +2197,10 @@ public final class TerminalEmulator {
     }
 
     private long getStyle() {
-        return TextStyle.encode(mForeColor, mBackColor, mEffect);
+        long style = TextStyle.encode(mForeColor, mBackColor, mEffect);
+        if (mOsc8HyperlinkActive) style |= TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK;
+        if (mOsc8HyperlinkStartPending) style |= TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START;
+        return style;
     }
 
     /** "CSI P_m h" for set or "CSI P_m l" for reset ANSI mode. */
@@ -2507,6 +2525,7 @@ public final class TerminalEmulator {
         // TODO: Check if there are thread synchronization issues with mCursorCol and mCursorRow, possibly causing others bugs too.
         if (column < 0) column = 0;
         mScreen.setChar(column, mCursorRow, codePoint, getStyle());
+        if (displayWidth > 0) mOsc8HyperlinkStartPending = false;
 
         markCarriageReturnOverwriteOutput(displayWidth);
 
@@ -2609,6 +2628,8 @@ public final class TerminalEmulator {
         mBottomMargin = mRows;
         mRightMargin = mColumns;
         mAboutToAutoWrap = false;
+        mOsc8HyperlinkActive = false;
+        mOsc8HyperlinkStartPending = false;
         mForeColor = mSavedStateMain.mSavedForeColor = mSavedStateAlt.mSavedForeColor = TextStyle.COLOR_INDEX_FOREGROUND;
         mBackColor = mSavedStateMain.mSavedBackColor = mSavedStateAlt.mSavedBackColor = TextStyle.COLOR_INDEX_BACKGROUND;
         setDefaultTabStops();

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TextStyle.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TextStyle.java
@@ -35,6 +35,16 @@ public final class TextStyle {
     private final static int CHARACTER_ATTRIBUTE_TRUECOLOR_FOREGROUND = 1 << 9;
     /** If true (24-bit) color is used for the cell for foreground. */
     private final static int CHARACTER_ATTRIBUTE_TRUECOLOR_BACKGROUND= 1 << 10;
+    /**
+     * PocketShell-only provenance marker for a cell emitted while an OSC 8
+     * hyperlink was active. Bits 11..15 are unused by Termux's effect and
+     * colour encoding; keeping this outside {@link #decodeEffect(long)} makes
+     * it rendering neutral while allowing viewport scanners to distinguish a
+     * declared hyperlink continuation from same-colour newline text (#1955).
+     */
+    public final static long CHARACTER_ATTRIBUTE_OSC8_HYPERLINK = 1L << 11;
+    /** Marks only the first cell emitted after an OSC 8 hyperlink opener. */
+    public final static long CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START = 1L << 12;
 
     public final static int COLOR_INDEX_FOREGROUND = 256;
     public final static int COLOR_INDEX_BACKGROUND = 257;

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/selection/WrappedLineReassemblyTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/selection/WrappedLineReassemblyTest.kt
@@ -3,12 +3,251 @@ package com.pocketshell.core.terminal.selection
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 /**
  * Unit tests for soft-wrap reassembly + span mapping used to detect a URL/path
  * wrapped across terminal rows as one logical target (issue #558 bug 2).
  */
+@RunWith(RobolectricTestRunner::class)
 class WrappedLineReassemblyTest {
+
+    /**
+     * Issue #1955 exact real-device row shape: the agent TUI painted a URL to
+     * the final grid column, continued it at column zero, but neither row kept
+     * Termux's soft-wrap bit.  The screenshot split `campaigns` as
+     * `campaig` / `ns/...` in a 60-column viewport.
+     */
+    @Test
+    fun `issue 1955 hard wrapped exact github URL is one target and not a path`() {
+        val url =
+            "https://github.com/DataTalksClub/playbooks/blob/main/" +
+                "campaigns/ml-zoomcamp-2026/copy-bank/events/pre-course-live-qa.md"
+        val splitAt = url.indexOf("campaigns") + "campaig".length
+        val columns = splitAt
+        val rows = listOf(
+            VisualRow(
+                row = 0,
+                text = url.take(splitAt),
+                wrapsToNext = false,
+                endsWithOsc8Hyperlink = true,
+            ),
+            VisualRow(
+                row = 1,
+                text = url.drop(splitAt),
+                wrapsToNext = false,
+                startsWithOsc8Hyperlink = true,
+            ),
+        )
+
+        assertEquals("the screenshot's first fragment must fill the grid", columns, rows[0].text.length)
+        assertEquals("campaig", rows[0].text.takeLast("campaig".length))
+        assertTrue(rows[1].text.startsWith("ns/ml-zoomcamp"))
+
+        val urlRegions = urlRegionsForRows(rows, columns)
+        assertEquals("both visible fragments must be tappable", listOf(0, 1), urlRegions.map { it.row })
+        assertTrue(
+            "both fragments must carry the complete exact URI: $urlRegions",
+            urlRegions.all { it.url == url },
+        )
+
+        val decorated = terminalMatchRegionsForRows(rows, columns, DefaultTerminalMatcher())
+        val decoratedUrls = decorated.filter { it.match is TerminalMatch.Url }
+        assertEquals("both fragments must have URL decoration", listOf(0, 1), decoratedUrls.map { it.row })
+        assertTrue(
+            "every decoration must carry the same complete URI: $decoratedUrls",
+            decoratedUrls.all { it.match.value == url },
+        )
+        assertTrue(
+            "the continuation must not become a local-file target: $decorated",
+            decorated.none { it.match is TerminalMatch.Path },
+        )
+        assertTrue(
+            "the continuation must not be exposed by the file viewer overlay",
+            filePathRegionsForRows(rows, columns).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `issue 1955 second reported course launch URL follows the same hard wrap contract`() {
+        val url =
+            "https://github.com/DataTalksClub/playbooks/blob/main/" +
+                "campaigns/ml-zoomcamp-2026/copy-bank/events/course-launch.md"
+        val splitAt = url.indexOf("campaigns") + "campaig".length
+        val rows = listOf(
+            VisualRow(
+                row = 2,
+                text = url.take(splitAt),
+                wrapsToNext = false,
+                endsWithOsc8Hyperlink = true,
+            ),
+            VisualRow(
+                row = 3,
+                text = url.drop(splitAt),
+                wrapsToNext = false,
+                startsWithOsc8Hyperlink = true,
+            ),
+        )
+
+        val urls = urlRegionsForRows(rows, columns = splitAt)
+        assertEquals(listOf(2, 3), urls.map { it.row })
+        assertTrue(urls.all { it.url == url })
+        assertTrue(filePathRegionsForRows(rows, columns = splitAt).isEmpty())
+    }
+
+    @Test
+    fun `hard wrap inference does not join a full-width URL to newline prose`() {
+        val first = "https://example.com/" + "a".repeat(40)
+        val rows = listOf(
+            VisualRow(row = 4, text = first, wrapsToNext = false),
+            VisualRow(row = 5, text = "follow-up prose is a genuine new paragraph.", wrapsToNext = false),
+        )
+
+        val urls = urlRegionsForRows(rows, columns = first.length)
+
+        assertEquals(listOf(UrlRegion(first, row = 4, startCol = 0, endColExclusive = first.length)), urls)
+    }
+
+    @Test
+    fun `hard wrap inference does not join adjacent independent links`() {
+        val first = "https://example.com/" + "a".repeat(40)
+        val second = "https://github.com/DataTalksClub/playbooks"
+        val rows = listOf(
+            VisualRow(row = 6, text = first, wrapsToNext = false),
+            VisualRow(row = 7, text = second, wrapsToNext = false),
+        )
+
+        val urls = urlRegionsForRows(rows, columns = first.length)
+
+        assertEquals(listOf(first, second), urls.map { it.url })
+        assertEquals(listOf(6, 7), urls.map { it.row })
+    }
+
+    @Test
+    fun `adjacent independent OSC8 links do not become one target`() {
+        val first = "https://example.com/" + "a".repeat(40)
+        val second = "https://github.com/DataTalksClub/playbooks"
+        val rows = listOf(
+            VisualRow(
+                row = 8,
+                text = first,
+                wrapsToNext = false,
+                endsWithOsc8Hyperlink = true,
+            ),
+            VisualRow(
+                row = 9,
+                text = second,
+                wrapsToNext = false,
+                startsWithOsc8Hyperlink = true,
+                startsNewOsc8Hyperlink = true,
+            ),
+        )
+
+        assertEquals(listOf(first, second), urlRegionsForRows(rows, first.length).map { it.url })
+        assertEquals(listOf(8, 9), urlRegionsForRows(rows, first.length).map { it.row })
+    }
+
+    @Test
+    fun `issue 1955 does not join a full width URL to newline docs path prose`() {
+        assertHardWrapRowsStayIndependent(
+            second = "docs/readme.md is the next paragraph",
+            expectedPaths = listOf("docs/readme.md"),
+        )
+    }
+
+    @Test
+    fun `issue 1955 does not join a full width URL to newline namespace prose`() {
+        assertHardWrapRowsStayIndependent(
+            second = "ns/ml-zoomcamp is prose but looks path-like",
+            expectedPaths = emptyList(),
+        )
+    }
+
+    @Test
+    fun `issue 1955 does not join punctuation led newline path prose`() {
+        assertHardWrapRowsStayIndependent(
+            second = "(docs/readme.md) begins with punctuation",
+            expectedPaths = listOf("docs/readme.md"),
+        )
+    }
+
+    @Test
+    fun `issue 1955 does not join an unrelated full width path row`() {
+        val first = fullWidthStandaloneUrl()
+        val second = "unrelated/full-width/row.md".padEnd(first.length, 'x')
+        assertHardWrapRowsStayIndependent(
+            second = second,
+            expectedPaths = emptyList(),
+        )
+    }
+
+    @Test
+    fun `issue 1955 complete github blob URL does not absorb a deep newline path`() {
+        val first = "https://github.com/org/repo/blob/main/docs/readme.md"
+        assertHardWrapRowsStayIndependent(
+            first = first,
+            second = "ns/a/b/next-file.md is a separate row",
+            expectedPaths = listOf("ns/a/b/next-file.md"),
+        )
+    }
+
+    @Test
+    fun `issue 1955 short newline path is not inferred as a continuation`() {
+        val first = "https://github.com/org/repo/blob/main/guide"
+        assertHardWrapRowsStayIndependent(
+            first = first,
+            second = "ns/file.md is a separate row",
+            expectedPaths = listOf("ns/file.md"),
+        )
+    }
+
+    @Test
+    fun `issue 1955 extensionless blob URL does not absorb a deep newline path`() {
+        assertHardWrapRowsStayIndependent(
+            first = "https://github.com/org/repo/blob/main/guide",
+            second = "ns/a/b/next-file.md is a separate row",
+            expectedPaths = listOf("ns/a/b/next-file.md"),
+        )
+    }
+
+    @Test
+    fun `issue 1955 extensionless blob URL does not absorb a path-only row`() {
+        assertHardWrapRowsStayIndependent(
+            first = "https://github.com/org/repo/blob/main/campaign",
+            second = "ns/a/b/c.txt",
+            expectedPaths = listOf("ns/a/b/c.txt"),
+        )
+    }
+
+    @Test
+    fun `issue 1955 query-bearing URL does not absorb a deep newline path`() {
+        assertHardWrapRowsStayIndependent(
+            first = "https://github.com/org/repo/blob/main/guide?x",
+            second = "ns/a/b/next-file.md is separate",
+            expectedPaths = listOf("ns/a/b/next-file.md"),
+        )
+    }
+
+    @Test
+    fun `issue 1955 extensionless blob URL does not absorb a mixed-case path`() {
+        assertHardWrapRowsStayIndependent(
+            first = "https://github.com/org/repo/blob/main/guide",
+            second = "ns/a/b/README.md",
+            expectedPaths = listOf("ns/a/b/README.md"),
+        )
+    }
+
+    @Test
+    fun `matching visual style without OSC8 provenance does not join newline rows`() {
+        // SGR colour/effect equality is intentionally absent from VisualRow's
+        // continuation contract: two independent rows can have identical SGR.
+        assertHardWrapRowsStayIndependent(
+            first = "https://github.com/org/repo/blob/main/guide",
+            second = "ns/a/b/README.md",
+            expectedPaths = listOf("ns/a/b/README.md"),
+        )
+    }
 
     @Test
     fun `non-wrapping rows become one logical line each`() {
@@ -21,6 +260,33 @@ class WrappedLineReassemblyTest {
         assertEquals("first", logical[0].text)
         assertEquals("second", logical[1].text)
     }
+
+    private fun assertHardWrapRowsStayIndependent(
+        first: String = fullWidthStandaloneUrl(),
+        second: String,
+        expectedPaths: List<String>,
+    ) {
+        val rows = listOf(
+            VisualRow(row = 80, text = first, wrapsToNext = false),
+            VisualRow(row = 81, text = second, wrapsToNext = false),
+        )
+
+        val repaired = markHardWrappedUrlContinuations(rows, columns = first.length)
+        assertEquals("genuine newline metadata must remain unchanged", listOf(false, false), repaired.map { it.wrapsToNext })
+        assertEquals("genuine newline rows must remain separate", listOf(first, second), reassemble(repaired).map { it.text })
+        assertEquals(
+            "the first row must retain only its own complete URL",
+            listOf(UrlRegion(first, row = 80, startCol = 0, endColExclusive = first.length)),
+            urlRegionsForRows(rows, columns = first.length),
+        )
+        assertEquals(
+            "the second row must retain its independent file target or no target",
+            expectedPaths,
+            filePathRegionsForRows(rows, columns = first.length).map { it.path },
+        )
+    }
+
+    private fun fullWidthStandaloneUrl(): String = "https://example.com/" + "a".repeat(40)
 
     @Test
     fun `wrapped rows join into one logical line`() {

--- a/shared/core-terminal/src/test/java/com/termux/terminal/OperatingSystemControlTest.java
+++ b/shared/core-terminal/src/test/java/com/termux/terminal/OperatingSystemControlTest.java
@@ -9,6 +9,72 @@ import java.util.Random;
 /** "ESC ]" is the Operating System Command. */
 public class OperatingSystemControlTest extends TerminalTestCase {
 
+	public void testOsc8HyperlinkProvenanceStartsEndsAndResets() throws Exception {
+		withTerminalSized(20, 4);
+
+		// ST-terminated opener, BEL-terminated closer. Params may be non-empty.
+		enterString("\033]8;id=issue1955;https://example.com/path\033\\link\033]8;;\007plain");
+		for (int column = 0; column < 4; column++) {
+			assertTrue(
+				"OSC 8 link cell " + column + " must retain provenance",
+				(mTerminal.getScreen().getStyleAt(0, column) &
+					TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK) != 0L
+			);
+		}
+		assertTrue(
+			"the first emitted link cell must carry the opener marker",
+			(mTerminal.getScreen().getStyleAt(0, 0) &
+				TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START) != 0L
+		);
+		for (int column = 1; column < 4; column++) {
+			assertEquals(
+				"only the first emitted link cell carries the opener marker",
+				0L,
+				mTerminal.getScreen().getStyleAt(0, column) &
+					TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START
+			);
+		}
+		for (int column = 4; column < 9; column++) {
+			assertEquals(
+				"closer must remove provenance from following text",
+				0L,
+				mTerminal.getScreen().getStyleAt(0, column) &
+					TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK
+			);
+		}
+
+		enterString("\033]8;;https://example.com/reset\007x");
+		mTerminal.reset();
+		enterString("y");
+		int yColumn = mTerminal.getCursorCol() - 1;
+		assertEquals(
+			"terminal reset must close any active OSC 8 hyperlink",
+			0L,
+			mTerminal.getScreen().getStyleAt(0, yColumn) &
+				TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK
+		);
+	}
+
+	public void testMatchingSgrAcrossExplicitRowsIsNotHyperlinkProvenance() throws Exception {
+		withTerminalSized(60, 4);
+		String first = "https://github.com/org/repo/blob/main/guide";
+		String second = "ns/a/b/README.md";
+		enterString("\033[38;5;99m" + first + "\033[2;1H" + second);
+
+		assertEquals(
+			"matching SGR at the previous row edge is not OSC 8 provenance",
+			0L,
+			mTerminal.getScreen().getStyleAt(0, 59) &
+				TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK
+		);
+		assertEquals(
+			"matching SGR at the next row start is not OSC 8 provenance",
+			0L,
+			mTerminal.getScreen().getStyleAt(1, 0) &
+				TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK
+		);
+	}
+
 	public void testSetTitle() throws Exception {
 		List<ChangedTitle> expectedTitleChanges = new ArrayList<>();
 

--- a/shared/core-terminal/src/test/java/com/termux/terminal/TextStyleTest.java
+++ b/shared/core-terminal/src/test/java/com/termux/terminal/TextStyleTest.java
@@ -22,6 +22,26 @@ public class TextStyleTest extends TestCase {
 		}
 	}
 
+	public void testOsc8ProvenanceBitDoesNotCollideWithStyleEncoding() {
+		long encoded = TextStyle.encode(0xFF123456, 0xFF654321, 0x7FF);
+		assertEquals(0L, encoded & TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK);
+		assertEquals(0L, encoded & TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START);
+		assertEquals(
+			"OSC 8 provenance must sit below the background field",
+			0L,
+			TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK & 0xFFFFFFFFFFFF0000L
+		);
+		assertEquals(
+			"renderer-visible effects occupy bits 0 through 10 only",
+			0,
+			TextStyle.decodeEffect(TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK)
+		);
+		assertEquals(
+			0,
+			TextStyle.decodeEffect(TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START)
+		);
+	}
+
 	public void testEncoding24Bit() {
 		int[] values = {255, 240, 127, 1, 0};
 		for (int red : values) {


### PR DESCRIPTION
Closes #1955

## Summary

- preserve OSC 8 active/opener provenance in terminal cell styles without storing hyperlink URIs
- repair a missing wrap flag only when the adjacent visual rows share one continuous OSC 8 hyperlink
- reuse the repaired immutable viewport rows for URL selection/file-path exclusion
- add exact screenshot, false-join, parser, style, emulator tap, and CI journey coverage

## Evidence

- independent approval: https://github.com/alexeygrigorev/pocketshell/issues/1955#issuecomment-5169956285
- reviewer connected: 2/2 (#1955 + #558), exact URI twice, no file-path target
- focused: 48/48
- module: 517/517 debug + 517/517 release
- full JVM: 603/603, exit 0
- frozen/rebased file hash: `e8ae08ee63c9c6f08f42a3516dcc7daaec5bc1b61a8baee303679b145213b78b`

Nonblocking exotic rectangular-attribute preservation follow-up: #1961.
