### PR TITLE
fix(connection): own within-grace dead lease recovery

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
@@ -1,18 +1,25 @@
 package com.pocketshell.app.proof
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.BackgroundGraceTestOverride
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.tmux.TMUX_CONNECT_ATTEMPTS
 import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -20,6 +27,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.FileOutputStream
 
 /**
  * Issue #635 / #636 / #754 (slice 1c-iv-c): brief-background-within-grace ride-through.
@@ -198,29 +206,20 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
      * confirmed-dead within-grace foreground NEVER paints "Attaching…" and NEVER runs the
      * inline probe.
      *
-     * WHAT A CLEAN CUT ACTUALLY DOES (verified from the connection lifecycle diagnostics
-     * in this run): `proxy.disable()` kills the SSH socket near-instantly, so the
-     * transport-drop oracle (`tmux_client_reader_exit` / `passive_disconnect`) fires
-     * BEFORE the within-grace foreground. By the time the foreground is processed the
-     * `-CC` lease is already gone, so `canReseedWithinGraceForeground()` correctly
-     * DECLINES the reseed-only fast-path (the within-grace foreground records
-     * `background_grace foreground_preserved`/`foreground_reattach outcome=dispatch`,
-     * `gateDecision=suppress`, `activeTmuxClientCount=0`) and the connection honestly
-     * falls into its drop/reconnect ladder. That honest reconnect of a genuinely-dead
-     * socket is correct (and is the slice-1c-iv-f ladder's concern), NOT a #754 violation.
+     * Issue #1954 tightens the confirmed-dead arm: the foreground grace heal owns the
+     * target/client, invalidates the proven-dead active lease through [SshLeaseManager],
+     * and performs exactly one fresh transport acquisition. Liveness is deferred while
+     * that owner is active, so no competing auto-reconnect ladder can reuse the corpse or
+     * emit `Attaching`.
      *
-     * The #754 invariant this test PINS — and the OLD inline path VIOLATED — is therefore:
+     * The combined #754/#1954 invariant this test pins is therefore:
      *  - the confirmed-dead within-grace foreground NEVER paints `TMUX_SWITCHING_LOADING_TAG`
      *    / "Attaching…" (the EXACT surface the maintainer reported);
      *  - the DELETED inline probe (`tmux_probe_result` cause-trail /
-     *    `foreground_runtime_probe_failed` diagnostic) NEVER runs even on a confirmed-dead
-     *    channel inside grace.
-     *
-     * It does NOT assert a reseed-only fast-path (a dead lease correctly declines it) nor
-     * the absence of a Disconnect band (a clean-cut socket is genuinely dead and honestly
-     * reconnects) — asserting either would either be racy or mask real behavior. FAILS on
-     * `main` (the overlay appears + a `tmux_probe_result` cause-trail is recorded) and
-     * PASSES after the fix.
+     *    `foreground_runtime_probe_failed` diagnostic) NEVER runs;
+     *  - one typed grace owner performs one dead-lease invalidation/fresh acquisition,
+     *    while liveness starts zero recovery effects;
+     *  - the prior marker remains revealed and the recovered channel accepts new input.
      */
     @Test
     fun withinGraceForegroundConfirmedDeadDoesNotShowAttachingOverlayOrReconnect() { runBlocking {
@@ -247,6 +246,9 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
         waitForVisibleTerminalText("before-confdead") { "BEFORE-$marker" in it }
         assertNoExtraConnectAttempts(attemptsBefore, expectedDelta = 1, label = "initial attach")
         waitForConnected("initial attach")
+        val firstClientHash = System.identityHashCode(
+            requireNotNull(currentViewModel().liveTmuxClientForSendOrNullForTest()),
+        )
         diagnostics!!.clear()
 
         // Short grace override so the resume lands well within grace.
@@ -271,9 +273,14 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
                 it.fields["withinGrace"] == true
             }
             // The exact window the old probe→connect ran (and any subsequent honest
-            // ladder): the confirmed-dead within-grace foreground must NEVER paint the
+            // recovery): the confirmed-dead within-grace foreground must NEVER paint the
             // "Attaching…" overlay. Watched continuously, not sampled once.
             assertNeverAttachingOverlayDuring("confdead_during_cut", OVERLAY_WATCH_MS)
+            val heldText = captureTerminalViewport("issue1954-confdead-post-resume-no-overlay")
+            assertTrue(
+                "the no-overlay viewport must still reveal the prior marker; text=$heldText",
+                "BEFORE-$marker" in heldText,
+            )
         } finally {
             proxy.enable()
             recordTiming("confdead_cut_total_ms", SystemClock.elapsedRealtime() - cycleStart)
@@ -285,6 +292,18 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
         // invariant holds across the whole confirmed-dead journey, not just the foreground
         // instant.
         assertNeverAttachingOverlayDuring("confdead_after_restore", POST_RESTORE_SETTLE_MS)
+        waitForDiagnostic("dead_lease_recovery", "confirmed-dead lease replacement")
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            currentViewModel().liveTmuxClientForSendOrNullForTest()?.let { client ->
+                System.identityHashCode(client) != firstClientHash && !client.disconnected.value
+            } == true
+        }
+        waitForConnected("confirmed-dead within-grace recovery")
+        assertNoExtraConnectAttempts(
+            attemptsBefore,
+            expectedDelta = 1,
+            label = "single grace-owned recovery without reconnect ladder",
+        )
 
         // #754 INVARIANT — the deleted inline foreground probe NEVER runs, even on a
         // confirmed-dead channel inside grace. (We do NOT assert a reseed-only fast-path:
@@ -312,6 +331,25 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
             },
         )
 
+        val deadLeaseRecovery = diagnostics!!.eventsNamed("dead_lease_recovery")
+        assertEquals(
+            "the grace owner must invalidate/acquire the dead lease exactly once",
+            1,
+            deadLeaseRecovery.size,
+        )
+        assertEquals(true, deadLeaseRecovery.single().fields["invalidatedLease"])
+        assertEquals(true, deadLeaseRecovery.single().fields["freshTransport"])
+        assertEquals(
+            "liveness must not start a competing recovery effect for the owned client",
+            0,
+            diagnostics!!.eventsNamed("liveness_probe_silent_drop").size,
+        )
+
+        val afterMarker = "AFTER-$marker"
+        sendCommandThroughTerminalInput("printf '$afterMarker\\n'", "after-confdead")
+        waitForVisibleTerminalText("after-confdead") { afterMarker in it }
+        captureTerminalViewport("issue1954-confdead-recovered")
+
         writeSummary(
             testName = "WithinGraceForegroundConfirmedDeadE2eTest",
             lines = listOf(
@@ -319,8 +357,11 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
                 "marker=$marker",
                 "scenario=clean cut (proxy disable), background within grace, foreground while cut",
                 "grace_override_ms=$WITHIN_GRACE_MS",
-                "expectation=no Attaching overlay + no inline probe on a confirmed-dead within-grace foreground",
+                "expectation=one grace-owned fresh recovery, no liveness owner, no Attaching overlay",
                 "connect_attempt_delta=${TMUX_CONNECT_ATTEMPTS.get() - attemptsBefore}",
+                "dead_lease_recoveries=${deadLeaseRecovery.size}",
+                "liveness_recovery_starts=" +
+                    diagnostics!!.eventsNamed("liveness_probe_silent_drop").size,
                 "probe_results=" + causeTrail.count { it.fields["stage"] == "tmux_probe_result" },
                 "foreground_reattach_outcomes=" + causeTrail
                     .filter { it.fields["stage"] == "foreground_reattach" }
@@ -372,14 +413,56 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
     }
 
     private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
-        var status: TmuxSessionViewModel.ConnectionStatus =
-            TmuxSessionViewModel.ConnectionStatus.Idle
+        return currentViewModel().connectionStatus.value
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
         launchedActivity?.onActivity { activity ->
-            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-                .connectionStatus
-                .value
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
         }
-        return status
+        return requireNotNull(vm) { "MainActivity/TmuxSessionViewModel unavailable" }
+    }
+
+    /** Direct TerminalView draw + same-view text: authoritative in-app viewport evidence. */
+    private fun captureTerminalViewport(name: String): String {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+
+        var bitmap: Bitmap? = null
+        var visibleText = ""
+        launchedActivity?.onActivity { activity ->
+            val view = requireNotNull(activity.window.decorView.findTerminalView()) {
+                "TerminalView missing while capturing $name"
+            }
+            check(view.width > 0 && view.height > 0) {
+                "TerminalView has invalid dimensions ${view.width}x${view.height} for $name"
+            }
+            bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888).also {
+                view.draw(Canvas(it))
+            }
+            visibleText = view.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+        val captured = requireNotNull(bitmap) { "MainActivity unavailable while capturing $name" }
+        val png = artifactFile("$name-viewport.png")
+        FileOutputStream(png).use { output ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                "failed to write $png"
+            }
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(visibleText)
+        captured.recycle()
+        return visibleText
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            getChildAt(index).findTerminalView()?.let { return it }
+        }
+        return null
     }
 
     private fun waitForDiagnostic(

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
@@ -202,6 +202,10 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
         // foreground into the reconnect ladder, which paints a
         // Reconnecting/Disconnected surface — this watch goes RED there.
         watchNoVisibleReconnect("within-grace after socket drop", OVERLAY_WATCH_MS)
+        // Issue #1954: authoritative in-app proof at the actual no-overlay watch point,
+        // before waiting for recovery completion. This is a direct TerminalView draw plus
+        // same-view visible text; the generic harness failure screenshot is not evidence.
+        captureViewport("issue1954-02-post-resume-no-overlay")
 
         // DEVICE-TRUTH assertion (1): the pane VIEWPORT is RE-SEEDED — non-blank
         // AND shows the prior content. The user must not be left on a blank
@@ -219,10 +223,31 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
                 "pane content ('$READY_MARKER'); visible terminal was:\n$visibleAfter",
             visibleAfter.contains(READY_MARKER),
         )
+        val deadLeaseRecovery = diagnostics!!.eventsNamed("dead_lease_recovery")
+        assertEquals(
+            "the within-grace owner must invalidate/acquire the dead lease exactly once",
+            1,
+            deadLeaseRecovery.size,
+        )
+        assertEquals(true, deadLeaseRecovery.single().fields["invalidatedLease"])
+        assertEquals(true, deadLeaseRecovery.single().fields["freshTransport"])
+        assertEquals(
+            "liveness must stay deferred while the within-grace owner heals the dead client",
+            0,
+            diagnostics!!.eventsNamed("liveness_probe_silent_drop").size,
+        )
+
+        // The recovered channel must accept real input, not merely repaint an old marker.
+        val recoveredClient = requireNotNull(currentViewModel().liveTmuxClientForSendOrNullForTest())
+        val send = recoveredClient.sendKeysViaExec(
+            "send-keys -t ${shellQuote(SESSION_NAME)} ${shellQuote("printf '$AFTER_MARKER\\n'")} Enter",
+        )
+        assertTrue("post-recovery input failed: ${send.output}", !send.isError)
+        waitForVisibleTerminal("within-grace post-recovery input") { it.contains(AFTER_MARKER) }
         // And the band stays absent through the settle (a late reconnect band
         // would still be the #635 regression).
         watchNoVisibleReconnect("within-grace settle after re-seed", POST_RESTORE_SETTLE_MS)
-        captureViewport("issue635-02-within-grace-reseeded")
+        captureViewport("issue1954-03-within-grace-reseeded")
 
         // The session screen is still up (a cleared pane that also lost the
         // screen would be a teardown/reconnect, not a within-grace ride-through).
@@ -279,14 +304,15 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
     }
 
     private fun currentConnectionStatus(): TmuxSessionViewModel.ConnectionStatus {
-        var status: TmuxSessionViewModel.ConnectionStatus =
-            TmuxSessionViewModel.ConnectionStatus.Idle
+        return currentViewModel().connectionStatus.value
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
         launchedActivity?.onActivity { activity ->
-            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-                .connectionStatus
-                .value
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
         }
-        return status
+        return requireNotNull(vm) { "MainActivity/TmuxSessionViewModel is not available" }
     }
 
     private fun waitForVisibleTerminal(
@@ -429,7 +455,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
             appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
             appendLine(
                 "tmux new-session -d -s ${shellQuote(SESSION_NAME)} " +
-                    shellQuote("printf '$READY_MARKER\\n'; exec sleep 600"),
+                    shellQuote("printf '$READY_MARKER\\n'; exec sh -i"),
             )
             appendLine("sleep 1")
             appendLine("tmux list-sessions")
@@ -543,7 +569,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
             "summary.txt",
             buildString {
                 appendLine("test=WithinGraceSocketDropForegroundJourneyE2eTest")
-                appendLine("issue=635")
+                appendLine("issue=1954")
                 appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
                 appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
                 appendLine("session=$SESSION_NAME")
@@ -555,6 +581,13 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
                 appendLine(
                     "expectation=pane re-seeded (non-blank, prior content), " +
                         "no Reconnecting/Disconnected/Attaching surface",
+                )
+                appendLine(
+                    "liveness_recovery_starts=" +
+                        diagnostics!!.eventsNamed("liveness_probe_silent_drop").size,
+                )
+                appendLine(
+                    "dead_lease_recoveries=" + diagnostics!!.eventsNamed("dead_lease_recovery").size,
                 )
                 appendLine("timings:")
                 timings.forEach { appendLine("  $it") }
@@ -596,6 +629,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
         const val DEVICE_DIR_NAME: String = "issue635-within-grace-socket-drop"
         const val SESSION_NAME: String = "issue635-socketdrop-proof"
         const val READY_MARKER: String = "ISSUE635-SOCKETDROP-READY"
+        const val AFTER_MARKER: String = "ISSUE1954-SOCKETDROP-AFTER"
 
         const val WITHIN_GRACE_MS: Long = 8_000L
         const val BACKGROUND_HOLD_MS: Long = 1_500L

--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
@@ -9,7 +9,9 @@ import com.pocketshell.core.ssh.DefaultSshLeaseConnector
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.tmux.TmuxClient
 import com.pocketshell.core.tmux.TmuxClientDiagnosticSink
@@ -19,6 +21,7 @@ import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,6 +34,7 @@ import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -196,6 +200,188 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
             println("ISSUE1952_REAL_TRANSCRIPT\n$transcript")
         } finally {
             vm?.forceCleanOutageForTest = false
+            vm?.cancelOwnScopesForTest()
+            vm?.clearForTest()
+            runCatching { cleanupSession() }
+            diagnostics.close()
+            TmuxClientDiagnostics.install(TmuxClientDiagnosticSink.Noop)
+            leaseManager.close()
+            ioScope.cancel()
+        }
+    }
+
+    /**
+     * Issue #1954 D34 proof: kill the real authenticated sshd worker while the app is in its
+     * bounded background grace, then foreground through the production grace-heal entrypoint.
+     * The symptom-defining assertions are on the real reader death, the absence of a competing
+     * liveness owner, the lease-authority invalidation record, object identities, connect count,
+     * and the real same-session transcript.
+     */
+    @Test
+    fun realReaderDropWithinGraceHasOneOwnerAndOneFreshHandshake() = runBlocking {
+        LivenessProbeTestOverride.setAutoStartEnabledForTest(true)
+        LivenessProbeTestOverride.setForTest(
+            intervalMs = 250L,
+            perProbeTimeoutMs = 250L,
+            failureThreshold = 1,
+        )
+        startDockerOrFail()
+        val fixture = requireNotNull(container)
+        val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val connector = CountingLeaseConnector(DefaultSshLeaseConnector())
+        val leaseManager = SshLeaseManager(
+            connector = connector,
+            scope = ioScope,
+            idleTtlMillis = 60_000L,
+        )
+        val diagnostics = installRecordingDiagnosticSink()
+        val tmuxDiagnostics = RecordingTmuxDiagnostics().also { TmuxClientDiagnostics.install(it) }
+        var vm: TmuxSessionViewModel? = null
+        try {
+            seedSession()
+            vm = TmuxSessionViewModel(
+                tmuxClientFactory = TmuxClientFactory(ioScope),
+                activeTmuxClients = ActiveTmuxClients(),
+                sshLeaseManager = leaseManager,
+            )
+            vm.connect(
+                hostId = 1954L,
+                hostName = "issue1954-docker",
+                host = fixture.host,
+                port = fixture.getMappedPort(SSH_PORT),
+                user = SSH_USER,
+                keyPath = privateKeyFile.absolutePath,
+                passphrase = null,
+                sessionName = SESSION_NAME,
+            )
+            awaitCondition(INITIAL_CONNECT_TIMEOUT_MS, "initial within-grace VM Live attach") {
+                vm.connectionControllerStateForTest() is ConnectionState.Live &&
+                    vm.liveTmuxClientForSendOrNullForTest() != null &&
+                    vm.panes.value.isNotEmpty()
+            }
+            awaitCondition(INITIAL_CONNECT_TIMEOUT_MS, "initial within-grace connect job completion") {
+                !vm.connectJobActiveForTest()
+            }
+            assertEquals("precondition: one initial SSH handshake", 1, connector.connectCount)
+            val firstClient = requireNotNull(vm.liveTmuxClientForSendOrNullForTest())
+            val firstClientHash = System.identityHashCode(firstClient)
+            val firstSshIdentity = currentSshIdentity(vm)
+            val beforeMarker = "ISSUE1954-BEFORE-${System.nanoTime().toString(36)}"
+            sendAndAwaitMarker(firstClient, beforeMarker)
+
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = WITHIN_GRACE_RECOVERY_MS,
+                silentReattachTimeoutMs = WITHIN_GRACE_REATTACH_TIMEOUT_MS,
+            )
+            // ProcessLifecycle ON_STOP starts the App-level grace without dispatching the VM's
+            // grace-elapsed `onAppBackgrounded()` teardown. This is the production within-grace
+            // state: the warm runtime stays attached, while the process-level liveness/drop gates
+            // close. The initial connect must be fully complete first so its stale-attach fallback
+            // cannot own a peer death that belongs to this later lifecycle interval.
+            vm.setProcessForegroundForClearedForTest(false)
+            assertFalse(
+                "precondition: process background must close the liveness probe gate",
+                vm.shouldRunLivenessProbeForTest(),
+            )
+            val killedPeerPids = killAuthenticatedSshdProcessesFromServer()
+            val readerExit = awaitReaderExit(tmuxDiagnostics, firstClientHash)
+            assertTrue(
+                "D34: the background-grace fault must be a real remote reader death: $readerExit",
+                readerExit["disconnectReason"] == "reader_eof" ||
+                    readerExit["disconnectReason"] == "reader_exception",
+            )
+            // The real drop is deferred while backgrounded. No replacement handshake may start
+            // before the foreground grace owner claims the target/client.
+            delay(500L)
+            val preForegroundEvents = diagnostics.events
+            println(
+                "ISSUE1954_PRE_FOREGROUND_CONNECTORS\n" +
+                    connector.invocations.joinToString("\n") { it.render() },
+            )
+            println(
+                "ISSUE1954_PRE_FOREGROUND_DIAGNOSTICS\n" +
+                    preForegroundEvents.joinToString("\n") { event ->
+                        "${event.category}/${event.name} ${event.fields}"
+                    },
+            )
+            println(
+                "ISSUE1954_PRE_FOREGROUND_TMUX_EVENTS\n" +
+                    tmuxDiagnostics.events.joinToString("\n") { (event, fields) ->
+                        "$event $fields"
+                    },
+            )
+            assertEquals(
+                "backgrounded drop must not start recovery; " +
+                    "connectors=${connector.invocations.map { it.summary() }}; " +
+                    "diagnostics=$preForegroundEvents",
+                1,
+                connector.connectCount,
+            )
+
+            vm.setProcessForegroundForClearedForTest(true)
+            vm.onAppForegrounded(resumedWithinGrace = true)
+
+            awaitCondition(RECOVERY_TIMEOUT_MS, "within-grace fresh-client recovery completion") {
+                val currentClient = vm.liveTmuxClientForSendOrNullForTest()
+                val currentHash = currentClient?.let(System::identityHashCode)
+                vm.connectionControllerStateForTest() is ConnectionState.Live &&
+                    currentClient?.disconnected?.value == false &&
+                    currentHash != null &&
+                    currentHash != firstClientHash &&
+                    diagnostics.eventsNamed("reconnect_success").any { event ->
+                        event.fields["source"] == "silent_transport_reattach" &&
+                            event.fields["clientHash"] == currentHash
+                    }
+            }
+            val recoveredClient = requireNotNull(vm.liveTmuxClientForSendOrNullForTest())
+            val recoveredSshIdentity = currentSshIdentity(vm)
+            val leaseRecovery = diagnostics.eventsNamed("dead_lease_recovery")
+            assertEquals("the grace owner invalidates/acquires exactly once", 1, leaseRecovery.size)
+            assertEquals(true, leaseRecovery.single().fields["invalidatedLease"])
+            assertEquals(true, leaseRecovery.single().fields["freshTransport"])
+            assertEquals(
+                "one initial + exactly one recovery handshake",
+                2,
+                connector.connectCount,
+            )
+            assertTrue(
+                "the competing liveness owner must stay deferred for the owned dead client: " +
+                    diagnostics.eventsNamed("liveness_probe_silent_drop"),
+                diagnostics.eventsNamed("liveness_probe_silent_drop").isEmpty(),
+            )
+            assertNotEquals(firstClientHash, System.identityHashCode(recoveredClient))
+            assertNotEquals(firstSshIdentity.session, recoveredSshIdentity.session)
+            assertNotEquals(firstSshIdentity.client, recoveredSshIdentity.client)
+            assertNotEquals(firstSshIdentity.transport, recoveredSshIdentity.transport)
+
+            val afterMarker = "ISSUE1954-AFTER-${System.nanoTime().toString(36)}"
+            sendAndAwaitMarker(recoveredClient, afterMarker)
+            val transcript = captureTranscript(recoveredClient)
+            assertTrue(transcript.contains(beforeMarker))
+            assertTrue(transcript.contains(afterMarker))
+            assertFalse("recovered client must remain connected", recoveredClient.disconnected.value)
+
+            println(
+                "ISSUE1954_REAL_TRANSPORT owner=within_grace livenessStarts=0 " +
+                    "connectCount=${connector.connectCount} leaseRecovery=${leaseRecovery.single().fields} " +
+                    "firstClient=$firstClientHash recoveredClient=${System.identityHashCode(recoveredClient)} " +
+                    "firstSsh=$firstSshIdentity recoveredSsh=$recoveredSshIdentity " +
+                    "peerKilledPids=$killedPeerPids reader=$readerExit",
+            )
+            println("ISSUE1954_REAL_TRANSCRIPT\n$transcript")
+        } finally {
+            println(
+                "ISSUE1954_FINAL_CONNECTORS\n" +
+                    connector.invocations.joinToString("\n") { it.render() },
+            )
+            println(
+                "ISSUE1954_FINAL_DIAGNOSTICS\n" +
+                    diagnostics.events.joinToString("\n") { event ->
+                        "${event.category}/${event.name} ${event.fields}"
+                    },
+            )
+            LivenessProbeTestOverride.clear()
+            vm?.setProcessForegroundForClearedForTest(null)
             vm?.cancelOwnScopesForTest()
             vm?.clearForTest()
             runCatching { cleanupSession() }
@@ -422,6 +608,42 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
         }
     }
 
+    private class CountingLeaseConnector(
+        private val delegate: SshLeaseConnector,
+    ) : SshLeaseConnector {
+        data class Invocation(
+            val order: Int,
+            val startedAtNanos: Long,
+            val target: String,
+            val thread: String,
+            val callerStack: String,
+        ) {
+            fun summary(): String =
+                "#$order at=$startedAtNanos target=$target thread=$thread"
+
+            fun render(): String = "${summary()}\n$callerStack"
+        }
+
+        private val sequence = AtomicInteger(0)
+        val invocations = CopyOnWriteArrayList<Invocation>()
+
+        val connectCount: Int
+            get() = sequence.get()
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val order = sequence.incrementAndGet()
+            invocations += Invocation(
+                order = order,
+                startedAtNanos = System.nanoTime(),
+                target = target.leaseKey.toString(),
+                thread = Thread.currentThread().name,
+                callerStack = Throwable("physical SSH connector invocation #$order")
+                    .stackTraceToString(),
+            )
+            return delegate.connect(target)
+        }
+    }
+
     private companion object {
         const val SSH_PORT = 22
         const val SSH_USER = "testuser"
@@ -433,5 +655,7 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
         const val ATTEMPT_PROGRESS_TIMEOUT_MS = 12_000L
         const val RECOVERY_TIMEOUT_MS = 30_000L
         const val MARKER_TIMEOUT_MS = 10_000L
+        const val WITHIN_GRACE_RECOVERY_MS = 10_000L
+        const val WITHIN_GRACE_REATTACH_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxRevealController.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxRevealController.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.tmux
 
 import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
 import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
+import com.pocketshell.core.connection.ConnectionProjection
 import com.pocketshell.core.connection.HostKey
 import com.pocketshell.core.connection.RevealState
 import com.pocketshell.core.connection.RevealStateMachine
@@ -71,8 +72,8 @@ internal class TmuxRevealController(
 
     fun currentTargetId(): SessionId? = state.value.targetIdOrNull()
 
-    fun setSilentHealInFlight(value: Boolean) {
-        revealStateMachine.setSilentHealInFlight(value)
+    fun setConnectionProjection(value: ConnectionProjection) {
+        revealStateMachine.setConnectionProjection(value)
     }
 
     fun driveTerminalError(target: ConnectionTarget, cause: Throwable?) {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -70,14 +70,18 @@ import com.pocketshell.app.tmux.connection.ConnectionEffectDriver
 import com.pocketshell.app.tmux.connection.ConnectionStatusProjection
 import com.pocketshell.app.tmux.connection.controlChannelAliveForReveal
 import com.pocketshell.app.tmux.connection.CurrentClientTmuxPort
+import com.pocketshell.app.tmux.connection.DeadLeaseRecoveryAuthority
 import com.pocketshell.app.tmux.connection.keepAliveProvenAliveRecently
 import com.pocketshell.app.tmux.connection.LivenessProbeGate
 import com.pocketshell.app.tmux.connection.livenessProbeIo
 import com.pocketshell.app.tmux.connection.requireControlChannelAliveForReveal
+import com.pocketshell.app.tmux.connection.selectCurrentClientLivenessProbeGate
 import com.pocketshell.app.tmux.connection.selectLivenessProbeGate
 import com.pocketshell.app.tmux.connection.ForegroundReturnEffects
 import com.pocketshell.app.tmux.connection.debounceReconnectUi
 import com.pocketshell.app.tmux.connection.GraceEffects
+import com.pocketshell.app.tmux.connection.WithinGraceRecoveryClaim
+import com.pocketshell.app.tmux.connection.graceClientId
 import com.pocketshell.app.tmux.connection.NetworkChangeArm
 import com.pocketshell.app.tmux.connection.NetworkChangeEffects
 import com.pocketshell.app.tmux.connection.KEEPALIVE_DEATH_REDIAL_QUIET_RESET_MS
@@ -111,6 +115,7 @@ import com.pocketshell.app.tmux.connection.shouldReportValidatedHandoffToControl
 import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.connection.ConnectionEvent as CoreConnectionEvent
 import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
+import com.pocketshell.core.connection.ConnectionProjection
 import com.pocketshell.core.connection.HostKey
 import com.pocketshell.core.connection.LivenessProbe
 import com.pocketshell.core.connection.RevealState
@@ -1078,27 +1083,16 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /** The probe gate — the pure decision + why each term exists lives in [selectLivenessProbeGate]. */
-    private fun livenessProbeGate(): LivenessProbeGate {
-        val bg = isProcessBackgroundedForGraceOwner()
-        val hasClient = clientRef != null
-        val disconnected = clientRef?.disconnected?.value ?: true
-        val ctrl = connectionManager.state
-        val gate = selectLivenessProbeGate(
-            backgrounded = bg,
+    private fun livenessProbeGate(): LivenessProbeGate =
+        selectCurrentClientLivenessProbeGate(
+            backgrounded = isProcessBackgroundedForGraceOwner(),
             appActive = appActive,
-            hasClient = hasClient,
-            controlChannelDisconnected = disconnected,
-            controllerLive = ctrl is CoreConnectionState.Live,
+            client = clientRef,
+            controllerState = connectionManager.state,
+            graceEffects = graceEffects,
+            targetId = (activeTarget ?: connectingTarget)?.let(::controllerSessionId),
+            logTag = LIVENESS_PROBE_TAG,
         )
-        if (gate == LivenessProbeGate.Closed) {
-            Log.i(
-                LIVENESS_PROBE_TAG,
-                "gate closed bg=$bg appActive=$appActive hasClient=$hasClient " +
-                    "disconnected=$disconnected ctrl=${ctrl::class.simpleName}",
-            )
-        }
-        return gate
-    }
 
     private fun shouldRunLivenessProbe(): Boolean = livenessProbeGate() != LivenessProbeGate.Closed
 
@@ -1627,7 +1621,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private fun projectStatusFromController(inlineState: ConnectionState) {
         val projected = connectionStatusForController(connectionManager.state, inlineState)
         _connectionStatus.value =
-            if (withinGraceSilentHealInFlight && projected is ConnectionStatus.Reconnecting) {
+            if (graceEffects.isWithinGraceRecoveryActive() && projected is ConnectionStatus.Reconnecting) {
                 // Issue #1098 (item 4 / #635): the within-grace SILENT heal re-opens the
                 // dropped `-CC` (controller `Reattaching`/`Reconnecting`), but a brief
                 // background→foreground ride-through must read the CALM `Connected` — never
@@ -3333,23 +3327,7 @@ public class TmuxSessionViewModel @Inject constructor(
     private var backgroundDetachJob: Job? = null
     private var lastSuppressedDropDiagnostic: SuppressedDropDiagnostic? = null
 
-    // Issue #1098 (item 4 / #635): true while the SINGLE-GRACE-OWNER within-grace
-    // SILENT heal of a dropped `-CC` socket is in flight. The heal MUST re-open the
-    // transport (controller `Live -> Reattaching -> Live`), but the user must see the
-    // CALM `Connected` ride-through with NO reconnect surface at all — no top
-    // Reconnecting bar, no "Attaching…" overlay, no disconnect band. While set, the
-    // displayed-status projection ([projectStatusFromController]) holds `Connected`
-    // and the [RevealStateMachine] holds the live frame (see
-    // [RevealStateMachine.setSilentHealInFlight]). Issue #754 (re-fix): armed at the within-grace
-    // foreground DECISION POINT ([armWithinGraceSilentHealHold]), released once after the bounded
-    // grace window (NOT tied to a single recovery job), so the ride-through covers BOTH the
-    // reseed_only path AND the confirmed-dead heal path whose failed single-shot heal hands off to
-    // the loud auto-reconnect ladder — else that ladder's Reconnecting paints the overlay WITHIN
-    // grace. A real BEYOND-grace drop still surfaces once the bounded release fires.
-    private var withinGraceSilentHealInFlight: Boolean = false
-
-    // Issue #754 (re-fix): SINGLE-OWNER bounded release of the hold above. A fresh within-grace
-    // foreground cancels + restarts it; only the CURRENT job's completion clears the hold.
+    // #754/#1954: bounded release of the one typed claim shared by status, reveal, and liveness.
     private var withinGraceSilentHealReleaseJob: Job? = null
 
     // EPIC #687 slice 1c-iv-b-B1 (#738): the `preserveConnectingTarget` computed
@@ -3917,9 +3895,11 @@ public class TmuxSessionViewModel @Inject constructor(
      * drop still surfaces its reconnect band the instant the release fires.
      */
     private fun armWithinGraceSilentHealHold() {
+        val target = activeTarget ?: pausedAutoReconnect?.target ?: pendingReattach?.target ?: return
+        val claim = WithinGraceRecoveryClaim(controllerSessionId(target), clientRef?.graceClientId())
         val previous = withinGraceSilentHealReleaseJob
-        withinGraceSilentHealInFlight = true
-        revealController.setSilentHealInFlight(true)
+        graceEffects.beginWithinGraceRecovery(claim)
+        revealController.setConnectionProjection(ConnectionProjection.SilentWithinGraceRecovery)
         val job = launchContainedTeardown {
             delay(passiveDisconnectGraceMs.coerceAtLeast(1L))
         }
@@ -3927,8 +3907,8 @@ public class TmuxSessionViewModel @Inject constructor(
         job.invokeOnCompletion {
             if (withinGraceSilentHealReleaseJob === job) {
                 withinGraceSilentHealReleaseJob = null
-                withinGraceSilentHealInFlight = false
-                revealController.setSilentHealInFlight(false)
+                graceEffects.endWithinGraceRecovery(claim)
+                revealController.setConnectionProjection(ConnectionProjection.Normal)
                 // Re-drive the reveal from the CURRENT controller state so a still-failing
                 // BEYOND-grace reconnect surfaces its band the instant the hold lifts (the ongoing
                 // Reconnecting was emitted while gated and the state flow dedupes it); a recovered
@@ -4283,30 +4263,37 @@ public class TmuxSessionViewModel @Inject constructor(
             // eviction), else fall through to the lease-evicting fresh dial (a real death fails
             // the vouch, so it still escalates). `clientRef` may be null; the fresh dial is null-safe.
             val staleClient = clientRef
-            val recovered =
+            val recoveryClaim = WithinGraceRecoveryClaim(controllerSessionId(target), staleClient?.graceClientId())
+            val deadLeaseAuthority = leaseRef?.let(DeadLeaseRecoveryAuthority::held)
+            val recovered = graceEffects.retryWithinGraceRecovery(
+                claim = recoveryClaim,
+                timeoutMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
+                retryDelayMs = PASSIVE_DISCONNECT_SILENT_REATTACH_RETRY_MS,
+            ) { firstAttempt ->
+                val currentStaleClient = clientRef
                 (
-                    transportVouchedAlive() && staleClient != null &&
+                    firstAttempt && transportVouchedAlive() && currentStaleClient != null &&
                         silentlyReattachAfterPassiveDisconnect(
-                            staleClient = staleClient,
+                            staleClient = currentStaleClient,
                             target = target,
                             budgets = passiveReattachStageBudgets(
-                                dialHandshakeMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
+                                dialHandshakeMs = silentReattachTimeoutMs.coerceAtLeast(1L),
                             ),
                         )
-                ) ||
-                    silentlyReconnectTransportAfterPassiveDisconnect(
-                        staleClient = clientRef,
-                        target = target,
-                        timeoutMs = passiveDisconnectGraceMs.coerceAtLeast(1L),
-                    )
+                ) || silentlyReconnectTransportAfterPassiveDisconnect(
+                    staleClient = currentStaleClient,
+                    target = target,
+                    timeoutMs = silentReattachTimeoutMs.coerceAtLeast(1L),
+                    deadLeaseAuthority = deadLeaseAuthority,
+                )
+            }
             if (!recovered) {
-                // The within-grace silent heal could not re-open the channel in time.
-                // Fall back to the normal auto-reconnect ladder — still SILENT (no manual
-                // "Tap Reconnect" band): [scheduleAutoReconnect] walks the calm
-                // Reconnecting ladder. The single-grace-owner contract requires the
-                // band-free within-grace ride-through when the heal succeeds; an honest
-                // failure to re-reach the host still surfaces through the calm reconnect
-                // path, not a scary disconnect band.
+                // Only bounded exhaustion of THIS owner may hand off to the normal ladder.
+                // If another target/client superseded the claim, this stale coroutine is
+                // inert and must not schedule recovery for the abandoned target.
+                if (graceEffects.recoveryWasSuperseded(recoveryClaim)) {
+                    return@launchContainedTeardown
+                }
                 scheduleAutoReconnect(
                     target = target,
                     reason = "Reattaching to ${target.user}@${target.host}:${target.port}.",
@@ -8152,6 +8139,14 @@ public class TmuxSessionViewModel @Inject constructor(
         // by the 60s grace `withTimeoutOrNull` + per-attempt timeout + 250ms retry spacing (no
         // hot loop); never short-circuits a HEALTHY warm reattach (#635/#553).
         var transportReattachAttempts = 0
+        val deadLeaseAuthority = leaseRef?.let(DeadLeaseRecoveryAuthority::held)
+        suspend fun attemptFreshTransportReattach(): Boolean =
+            silentlyReconnectTransportAfterPassiveDisconnect(
+                staleClient = staleClient,
+                target = target,
+                timeoutMs = silentReattachTimeoutMs.coerceAtLeast(1L),
+                deadLeaseAuthority = deadLeaseAuthority,
+            )
         recordSilentReattachStart(
             target = target,
             staleClientHash = System.identityHashCode(staleClient),
@@ -8186,12 +8181,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 val freshTransportPreferred = preferFreshTransportNow()
                 if (freshTransportPreferred) {
                     transportReattachAttempts += 1
-                    if (silentlyReconnectTransportAfterPassiveDisconnect(
-                            staleClient = staleClient,
-                            target = target,
-                            timeoutMs = silentReattachTimeoutMs.coerceAtLeast(1L),
-                        )
-                    ) {
+                    if (attemptFreshTransportReattach()) {
                         return@withTimeoutOrNull true
                     }
                 }
@@ -8212,12 +8202,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 // transport and keep re-dialling it for the same sustained-outage resilience.
                 if (!freshTransportPreferred) {
                     transportReattachAttempts += 1
-                    if (silentlyReconnectTransportAfterPassiveDisconnect(
-                            staleClient = staleClient,
-                            target = target,
-                            timeoutMs = silentReattachTimeoutMs.coerceAtLeast(1L),
-                        )
-                    ) {
+                    if (attemptFreshTransportReattach()) {
                         return@withTimeoutOrNull true
                     }
                 }
@@ -8456,7 +8441,11 @@ public class TmuxSessionViewModel @Inject constructor(
             if (lease == null || leaseRef === lease) leaseRef = null
             // The lease is the SHARED per-host transport: only a genuine death reaches this.
             withContext(NonCancellable) {
-                runCatching { sshLeaseManager.disconnect(leaseKey) }
+                if (lease != null) {
+                    runCatching { sshLeaseManager.invalidateDead(lease) }
+                } else {
+                    runCatching { sshLeaseManager.disconnect(leaseKey) }
+                }
             }
         } else {
             leaseRef = lease
@@ -8473,6 +8462,7 @@ public class TmuxSessionViewModel @Inject constructor(
         staleClient: TmuxClient?,
         target: ConnectionTarget,
         timeoutMs: Long,
+        deadLeaseAuthority: DeadLeaseRecoveryAuthority?,
     ): Boolean {
         // EPIC #792 #833 test seam: while a synthetic clean outage is armed, the
         // fresh-transport re-dial fails as if the link were down (clean FIN /
@@ -8497,20 +8487,30 @@ public class TmuxSessionViewModel @Inject constructor(
         val budgets = passiveReattachStageBudgets(dialHandshakeMs = timeoutMs)
         val leaseTarget = target.toSshLeaseTarget()
         return try {
+            val authority = requireNotNull(deadLeaseAuthority) {
+                "proven-dead recovery requires exact held-or-invalidated lease authority"
+            }
             // ---- Stage 1: DIAL + HANDSHAKE (fast-fail, amortized — unchanged bound) ----
             val lease = withTimeoutOrNull(budgets.dialHandshakeMs) {
                 // Issue #866: DETACH the current-client port BEFORE tearing the stale transport
-                // down. `disconnect(leaseKey)` EOFs the stale `-CC` reader, and
+                // down. Dead-lease invalidation EOFs the stale `-CC` reader, and
                 // [CurrentClientTmuxPort.disconnectedClients] flatMapLatest-follows the current
                 // client — so unless we re-point first, that EOF re-enters the driver's
                 // control-channel-drop path (still the current client) and CANCELS this very
                 // grace loop: the cancel storm that wedged the silent reattach. Detaching to null
                 // makes the stale teardown emit nothing; the success path re-points below.
                 connectionTmuxPort.setClient(null)
-                withContext(NonCancellable) {
-                    runCatching { sshLeaseManager.disconnect(leaseTarget.leaseKey) }
-                }
-                sshLeaseManager.acquire(leaseTarget).getOrThrow()
+                authority.acquireSuccessor(
+                    manager = sshLeaseManager,
+                    target = leaseTarget,
+                    currentLease = { leaseRef },
+                    onDeadLeaseInvalidated = {
+                        sessionRef = null
+                        leaseRef = null
+                    },
+                    diagnosticHostId = target.hostId,
+                    diagnosticSessionName = target.sessionName,
+                )
             }
             if (lease == null) {
                 // #1539: never handshook -> not a live link -> abandoned (the preserved
@@ -8636,6 +8636,7 @@ public class TmuxSessionViewModel @Inject constructor(
             )
             true
         } catch (t: Throwable) {
+            if (DeadLeaseRecoveryAuthority.shouldHandOffSuccessorCancellation(t, replacement, clientRef, acquiredLease, leaseRef, target, activeTarget)) throw t
             // Issue #1653 — THE OTHER kill site, the one #1539 missed: a stalled tail's INNER
             // sshj timeout beats the OUTER stage budget, so the same "slow tail on a proven-up
             // link" arrives here THROWN instead of as `!ready`. This evicted unconditionally, so

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/DeadLeaseRecoveryAuthority.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/DeadLeaseRecoveryAuthority.kt
@@ -1,0 +1,98 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.tmux.TmuxClient
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+/** Coroutine-local authority to replace one exact manager-held dead lease. */
+internal class DeadLeaseRecoveryAuthority private constructor(private var state: State) {
+    private sealed interface State {
+        data class Held(val lease: SshLease) : State
+
+        data class Invalidated(
+            val priorSession: SshSession,
+            val recoveryRecorded: Boolean = false,
+        ) : State
+    }
+
+    /**
+     * Invalidates the exact corpse once, then acquires one identity-different manager-new
+     * successor. Later attempts reuse that exact live successor without another refcount bump.
+     */
+    suspend fun acquireSuccessor(
+        manager: SshLeaseManager,
+        target: SshLeaseTarget,
+        currentLease: () -> SshLease?,
+        onDeadLeaseInvalidated: () -> Unit,
+        diagnosticHostId: Long,
+        diagnosticSessionName: String,
+    ): SshLease {
+        val invalidated = when (val current = state) {
+            is State.Held -> {
+                val removed = withContext(NonCancellable) { manager.invalidateDead(current.lease) }
+                check(removed) { "proven-dead SSH lease was no longer current" }
+                onDeadLeaseInvalidated()
+                State.Invalidated(current.lease.session).also { state = it }
+            }
+            is State.Invalidated -> current
+        }
+        val pooledSuccessor = currentLease().takeIf { candidate ->
+            candidate != null &&
+                candidate.key == target.leaseKey &&
+                candidate.session !== invalidated.priorSession &&
+                manager.isCurrentLiveLease(candidate)
+        }
+        val acquired = pooledSuccessor ?: manager.acquire(target).getOrThrow()
+        if (pooledSuccessor == null) {
+            check(acquired.isNewConnection) { "proven-dead recovery reused a pooled SSH transport" }
+            check(acquired.session !== invalidated.priorSession) {
+                "proven-dead SSH lease was reused during fresh recovery"
+            }
+        }
+        val recordRecovery = pooledSuccessor == null && !invalidated.recoveryRecorded
+        if (recordRecovery) {
+            state = invalidated.copy(recoveryRecorded = true)
+            DiagnosticEvents.record(
+                "connection",
+                "dead_lease_recovery",
+                "hostId" to diagnosticHostId,
+                "session" to diagnosticSessionName,
+                "invalidatedLease" to true,
+                "freshTransport" to acquired.isNewConnection,
+                "oldSshSessionHash" to System.identityHashCode(invalidated.priorSession),
+                "newSshSessionHash" to System.identityHashCode(acquired.session),
+            )
+        }
+        return acquired
+    }
+
+    companion object {
+        fun held(lease: SshLease): DeadLeaseRecoveryAuthority =
+            DeadLeaseRecoveryAuthority(State.Held(lease))
+
+        /** A new drop owner superseded this cancelled owner but retained its exact corpse. */
+        fun shouldHandOffSuccessorCancellation(
+            cause: Throwable,
+            replacement: TmuxClient?,
+            currentClient: TmuxClient?,
+            acquiredLease: SshLease?,
+            currentLease: SshLease?,
+            target: ConnectionTarget,
+            activeTarget: ConnectionTarget?,
+        ): Boolean =
+            cause is CancellationException &&
+                replacement != null &&
+                currentClient === replacement &&
+                replacement.disconnected.value &&
+                acquiredLease != null &&
+                currentLease === acquiredLease &&
+                activeTarget == target
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/GraceEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/GraceEffects.kt
@@ -1,5 +1,35 @@
 package com.pocketshell.app.tmux.connection
 
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.tmux.TmuxClient
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+
+/** Stable identity of the control client a within-grace recovery was claimed for. */
+@JvmInline
+value class GraceClientId(val value: Int)
+
+fun TmuxClient.graceClientId(): GraceClientId = GraceClientId(System.identityHashCode(this))
+
+/**
+ * Typed ownership token for the bounded within-grace recovery window.
+ *
+ * The target and client are both captured at the foreground decision point. Liveness may only
+ * defer when the token still names its current target/client; a later replacement client is not
+ * accidentally hidden behind stale grace ownership.
+ */
+data class WithinGraceRecoveryClaim(
+    val targetId: SessionId,
+    val clientId: GraceClientId?,
+)
+
+/** The single typed owner state shared by grace dispatch, liveness, status, and reveal. */
+sealed interface GraceRecoveryOwnership {
+    data object Idle : GraceRecoveryOwnership
+
+    data class WithinGrace(val claim: WithinGraceRecoveryClaim) : GraceRecoveryOwnership
+}
+
 /**
  * EPIC #792 Slice B — the GRACE IO owner (background detach + within-grace foreground
  * reattach/heal).
@@ -18,14 +48,58 @@ package com.pocketshell.app.tmux.connection
  * driver seam and the lifecycle entrypoints now route through this one object, so the
  * inline twin invocation is DELETED (D22 hard-cut — no dual-write, single path).
  *
- * Behaviour is byte-identical: each method calls the SAME [GraceIo] body the inline path
- * called, in the same order, with the same guards. Only the dispatch owner changed.
+ * Dispatch behaviour remains direct: each method calls the same [GraceIo] body the inline
+ * path called. Issue #1954 additionally keeps the bounded recovery claim here so liveness,
+ * status, and reveal consult the same controller-adjacent owner.
  *
  * @param io the VM-implemented capability that performs the actual (deeply VM-coupled)
  *   grace teardown/reseed/heal IO. [GraceEffects] never touches transport/lease/client
- *   state directly — it owns only the effect dispatch.
+ *   state directly; it owns effect dispatch plus the typed bounded recovery claim.
  */
 class GraceEffects(private val io: GraceIo) {
+
+    var recoveryOwnership: GraceRecoveryOwnership = GraceRecoveryOwnership.Idle
+        private set
+
+    /** Claim the bounded recovery window before either the reseed or dead-socket arm starts. */
+    fun beginWithinGraceRecovery(claim: WithinGraceRecoveryClaim) {
+        recoveryOwnership = GraceRecoveryOwnership.WithinGrace(claim)
+    }
+
+    /** Release only the claim whose bounded owner timer completed; stale timers are inert. */
+    fun endWithinGraceRecovery(claim: WithinGraceRecoveryClaim) {
+        if (recoveryOwnership == GraceRecoveryOwnership.WithinGrace(claim)) {
+            recoveryOwnership = GraceRecoveryOwnership.Idle
+        }
+    }
+
+    /** True only for the target/client whose grace recovery currently owns the channel. */
+    fun ownsRecovery(targetId: SessionId, clientId: GraceClientId): Boolean {
+        val owned = (recoveryOwnership as? GraceRecoveryOwnership.WithinGrace)?.claim ?: return false
+        return owned.targetId == targetId && owned.clientId == clientId
+    }
+
+    fun isWithinGraceRecoveryActive(): Boolean =
+        recoveryOwnership is GraceRecoveryOwnership.WithinGrace
+
+    fun recoveryWasSuperseded(claim: WithinGraceRecoveryClaim): Boolean =
+        (recoveryOwnership as? GraceRecoveryOwnership.WithinGrace)?.claim?.let { it != claim } == true
+
+    /** Retry only while this exact claim remains the single bounded recovery owner. */
+    suspend fun retryWithinGraceRecovery(
+        claim: WithinGraceRecoveryClaim,
+        timeoutMs: Long,
+        retryDelayMs: Long,
+        attempt: suspend (firstAttempt: Boolean) -> Boolean,
+    ): Boolean = withTimeoutOrNull(timeoutMs) {
+        var firstAttempt = true
+        while (recoveryOwnership == GraceRecoveryOwnership.WithinGrace(claim)) {
+            if (attempt(firstAttempt)) return@withTimeoutOrNull true
+            firstAttempt = false
+            delay(retryDelayMs)
+        }
+        false
+    } == true
 
     /**
      * The clean background-detach teardown. Fired by the [ConnectionEffectDriver] when

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/LivenessProbeGate.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/LivenessProbeGate.kt
@@ -1,6 +1,10 @@
 package com.pocketshell.app.tmux.connection
 
+import android.util.Log
+import com.pocketshell.core.connection.ConnectionState
 import com.pocketshell.core.connection.LivenessProbe
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.tmux.TmuxClient
 
 /**
  * Issue #1863 — the liveness-probe gate, extracted out of `TmuxSessionViewModel`
@@ -21,6 +25,8 @@ import com.pocketshell.core.connection.LivenessProbe
  *  - `hasClient` — nothing to ping.
  *  - `controllerLive` — an in-flight attach / reconnect owns the channel; probing
  *    there would race the single reconnect ladder (D28: never a second writer).
+ *  - `!withinGraceRecoveryOwnsClient` — issue #1954: the typed foreground grace
+ *    owner is already healing this exact target/client, so liveness must defer.
  *  - `!controlChannelDisconnected` — the term #1863 is about. It covered TWO
  *    different states that happen to share one predicate:
  *      (a) the TRANSIENT window between `TmuxClient.disconnected` flipping true and
@@ -50,8 +56,12 @@ import com.pocketshell.core.connection.LivenessProbe
  * version of it is closed by a different term: the connect path submits
  * `submitControllerOpen` / `submitControllerSwitch` BEFORE `closeCurrentConnection
  * AndJoin`, so the controller is off `Live` for the whole `detachCleanly` teardown;
- * leave clears `appActive`; background sets `bg`. And if the probe does declare
- * inside that hop, `shouldSuppressTransportDropsForSingleGraceOwner()` suppresses
+ * leave clears `appActive`; background sets `bg`; and the #1954 typed recovery claim
+ * closes the gate for the exact grace-owned target/client. [LivenessProbe] re-checks
+ * this gate at its verdict boundary, including the definitive-close fast arm, so a
+ * read that began before ownership changed is deferred. If a foreground passive drop
+ * still declares inside the ordinary driver hop,
+ * `shouldSuppressTransportDropsForSingleGraceOwner()` suppresses
  * the driver's duplicate, so the worst case is the heavier reconnect ladder instead
  * of the calm within-grace silent reattach — never two writers (D28). Narrowing the
  * arm to "self-inflicted closes only" was considered and rejected: the same
@@ -65,7 +75,7 @@ import com.pocketshell.core.connection.LivenessProbe
 enum class LivenessProbeGate {
     /**
      * Not probing. Backgrounded / not app-active / no client / the controller is
-     * not `Live` (an attach, reconnect or grace window owns the channel).
+     * not `Live`, or the typed within-grace owner owns this target/client.
      */
     Closed,
 
@@ -98,10 +108,46 @@ fun selectLivenessProbeGate(
     hasClient: Boolean,
     controlChannelDisconnected: Boolean,
     controllerLive: Boolean,
+    withinGraceRecoveryOwnsClient: Boolean = false,
 ): LivenessProbeGate = when {
-    backgrounded || !appActive || !hasClient || !controllerLive -> LivenessProbeGate.Closed
+    backgrounded || !appActive || !hasClient || !controllerLive || withinGraceRecoveryOwnsClient ->
+        LivenessProbeGate.Closed
     controlChannelDisconnected -> LivenessProbeGate.DeadChannel
     else -> LivenessProbeGate.Probe
+}
+
+/** Bind the pure selector to the current typed grace owner and emit its closed-gate diagnostic. */
+fun selectCurrentClientLivenessProbeGate(
+    backgrounded: Boolean,
+    appActive: Boolean,
+    client: TmuxClient?,
+    controllerState: ConnectionState,
+    graceEffects: GraceEffects,
+    targetId: SessionId?,
+    logTag: String,
+): LivenessProbeGate {
+    val disconnected = client?.disconnected?.value ?: true
+    val graceOwnsClient = targetId != null && client != null && graceEffects.ownsRecovery(
+        targetId,
+        GraceClientId(System.identityHashCode(client)),
+    )
+    val gate = selectLivenessProbeGate(
+        backgrounded = backgrounded,
+        appActive = appActive,
+        hasClient = client != null,
+        controlChannelDisconnected = disconnected,
+        controllerLive = controllerState is ConnectionState.Live,
+        withinGraceRecoveryOwnsClient = graceOwnsClient,
+    )
+    if (gate == LivenessProbeGate.Closed) {
+        Log.i(
+            logTag,
+            "gate closed bg=$backgrounded appActive=$appActive hasClient=${client != null} " +
+                "disconnected=$disconnected ctrl=${controllerState::class.simpleName} " +
+                "withinGraceRecoveryOwnsClient=$graceOwnsClient",
+        )
+    }
+    return gate
 }
 
 /**

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1538ForegroundHealWithinGraceRideThroughTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1538ForegroundHealWithinGraceRideThroughTest.kt
@@ -9,6 +9,7 @@ import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -25,6 +26,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
 
 /**
@@ -292,6 +294,259 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
             )
         }
 
+    /**
+     * Issue #1954: a confirmed-dead foreground heal owns the whole bounded grace window.
+     * A failed first physical dial must stay inside that typed owner and retry there; handing
+     * off immediately to the normal auto-reconnect ladder removes the held TerminalView and
+     * reintroduces the visible reconnect/Attaching journey while still within grace.
+     */
+    @Test
+    fun withinGraceDeadHealRetainsAuthorityAcrossFailedDialUntilFreshRetrySucceeds() =
+        runTest(scheduler) {
+            TMUX_CONNECT_ATTEMPTS.set(1)
+            val registry = ActiveTmuxClients()
+            val deadSession = FakeSshSession()
+            val freshSession = FakeSshSession()
+            val connector = ScriptedLeaseConnector(
+                listOf(
+                    Result.success(deadSession),
+                    Result.failure(IOException("first recovery dial is still inside the outage")),
+                    Result.success(freshSession),
+                ),
+            )
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(
+                    connector = connector,
+                    scope = this,
+                    idleTtlMillis = 60_000L,
+                ),
+            )
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = 5_000L,
+                silentReattachTimeoutMs = 100L,
+            )
+            vm.setAutoReconnectDelaysForTest(listOf(60_000L))
+            vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+            vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+
+            val replacementClient = FakeTmuxClient().withSinglePane("work", "%1")
+            vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
+                assertSame(freshSession, session)
+                assertEquals("work", sessionName)
+                replacementClient
+            }
+
+            val droppedCcClient = FakeTmuxClient()
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = droppedCcClient,
+                session = deadSession,
+            )
+            vm.setActiveLeaseRefWarmForTest()
+            runCurrent()
+            assertEquals("one setup lease", 1, connector.connectCount)
+            deadSession.markDisconnected()
+
+            vm.setProcessForegroundForClearedForTest(false)
+            droppedCcClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "device_background",
+                    intent = "unknown",
+                ),
+            )
+            runCurrent()
+
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                vm.setProcessForegroundForClearedForTest(true)
+                vm.onAppForegrounded(resumedWithinGrace = true)
+                runCurrent()
+
+                assertEquals("setup + failed first recovery dial", 2, connector.connectCount)
+                assertTrue(
+                    "the bounded grace owner must keep the projected status calm after the " +
+                        "first dial fails",
+                    vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+                )
+                assertTrue(
+                    "the first failed dial must not hand off to the visible auto-reconnect ladder",
+                    diagnostics.eventsNamed("reconnect_start").isEmpty(),
+                )
+
+                advanceTimeBy(1_000L)
+                runCurrent()
+                assertEquals("the same owner must perform the paced fresh retry", 3, connector.connectCount)
+                awaitCondition {
+                    registry.clients.value[7L]?.client === replacementClient &&
+                        vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+                }
+
+                assertEquals("one setup + two paced recovery dials", 3, connector.connectCount)
+                assertTrue("the exact dead manager-owned lease must be closed", deadSession.closed)
+                assertFalse("the fresh replacement transport must stay live", freshSession.closed)
+                assertEquals(
+                    "the hidden foreground owner must never enter connect()/the user-visible ladder",
+                    1,
+                    TMUX_CONNECT_ATTEMPTS.get(),
+                )
+                assertTrue(diagnostics.eventsNamed("reconnect_start").isEmpty())
+                val recovery = diagnostics.eventsNamed("dead_lease_recovery")
+                assertEquals("one successful typed recovery diagnostic", 1, recovery.size)
+                assertEquals(true, recovery.single().fields["invalidatedLease"])
+                assertEquals(true, recovery.single().fields["freshTransport"])
+            } finally {
+                diagnostics.close()
+            }
+        }
+
+    /**
+     * Issue #1954 / #1653 interop: once the exact corpse has been invalidated and a fresh,
+     * identity-different successor has handshaken, a slow tmux tail does not make that successor
+     * dead. The same bounded owner must retry the tmux attach over that manager-held successor;
+     * acquiring the key again either leaks a lease ref or misclassifies the valid pooled result as
+     * a failed "fresh" recovery and disconnects it by key.
+     */
+    @Test
+    fun withinGraceDeadHealReusesFreshSuccessorAfterSlowTailWithoutAnotherAcquire() =
+        runTest(scheduler) {
+            TMUX_CONNECT_ATTEMPTS.set(1)
+            val registry = ActiveTmuxClients()
+            val deadSession = FakeSshSession()
+            val freshSuccessor = FakeSshSession()
+            val connector = QueueLeaseConnector(deadSession, freshSuccessor)
+            val leaseManager = testLeaseManager(
+                connector = connector,
+                scope = this,
+                idleTtlMillis = 60_000L,
+            )
+            val vm = newVm(registry = registry, sshLeaseManager = leaseManager)
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = 5_000L,
+                silentReattachTimeoutMs = 1_000L,
+            )
+            vm.setAutoReconnectDelaysForTest(listOf(60_000L))
+            vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+            vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+
+            val slowTailClient = FakeTmuxClient().apply {
+                connectThrows = TmuxClientException("tmux tail remained slow after SSH handshake")
+            }
+            val recoveredClient = FakeTmuxClient().withStickySinglePane("work", "%1")
+            val factorySessions = mutableListOf<SshSession>()
+            val recoveryClients = ArrayDeque(listOf(slowTailClient, recoveredClient))
+            vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
+                assertEquals("work", sessionName)
+                factorySessions += session
+                recoveryClients.removeFirstOrNull() ?: error("unexpected recovery client")
+            }
+
+            val droppedCcClient = FakeTmuxClient()
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = droppedCcClient,
+                session = deadSession,
+            )
+            vm.setActiveLeaseRefWarmForTest()
+            runCurrent()
+            assertEquals("one setup acquire owns the exact corpse", 1, connector.connectCount)
+            deadSession.markDisconnected()
+
+            vm.setProcessForegroundForClearedForTest(false)
+            droppedCcClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "device_background",
+                    intent = "unknown",
+                ),
+            )
+            runCurrent()
+
+            val diagnostics = installRecordingDiagnosticSink()
+            try {
+                vm.setProcessForegroundForClearedForTest(true)
+                vm.onAppForegrounded(resumedWithinGrace = true)
+                runCurrent()
+
+                assertEquals("the exact corpse is invalidated before one fresh successor dial", 2, connector.connectCount)
+                assertTrue("the exact corpse must be closed once", deadSession.closed)
+                assertFalse(
+                    "a slow tmux tail must vouch and keep the freshly handshaken successor",
+                    freshSuccessor.closed,
+                )
+                assertEquals(listOf(freshSuccessor), factorySessions)
+
+                advanceTimeBy(500L)
+                runCurrent()
+                assertEquals(
+                    "the bounded owner must start one successor-reuse tmux retry after the slow tail",
+                    2,
+                    factorySessions.size,
+                )
+                assertEquals(
+                    "successor reuse must not acquire/dial again before the tmux retry settles",
+                    2,
+                    connector.connectCount,
+                )
+                assertFalse(
+                    "successor reuse must not key-disconnect the vouched-alive transport",
+                    freshSuccessor.closed,
+                )
+
+                val settleDeadlineMs = scheduler.currentTime + 3_000L
+                var settled = false
+                while (!settled && scheduler.currentTime < settleDeadlineMs) {
+                    advanceTimeBy(100L)
+                    runCurrent()
+                    settled = registry.clients.value[7L]?.client === recoveredClient &&
+                        vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
+                }
+                assertTrue(
+                    "successor-reuse tmux retry did not settle before the bounded virtual-time " +
+                        "deadline; status=${vm.connectionStatus.value} clients=${registry.clients.value}",
+                    settled,
+                )
+
+                assertEquals(
+                    "the retry must reuse the manager-held successor without another acquire/dial",
+                    2,
+                    connector.connectCount,
+                )
+                assertEquals(
+                    "both tmux attach attempts must use the same identity-different successor",
+                    listOf(freshSuccessor, freshSuccessor),
+                    factorySessions,
+                )
+                assertFalse(
+                    "the kept successor must never be key-disconnected as an alleged pooled corpse",
+                    freshSuccessor.closed,
+                )
+                assertSame(recoveredClient, registry.clients.value[7L]?.client)
+                assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+                assertTrue(diagnostics.eventsNamed("reconnect_start").isEmpty())
+                assertEquals(
+                    "only the original corpse-to-successor transition is a dead-lease recovery",
+                    1,
+                    diagnostics.eventsNamed("dead_lease_recovery").size,
+                )
+            } finally {
+                diagnostics.close()
+            }
+        }
+
     // ---- helpers ----
 
     private fun FakeTmuxClient.withSinglePane(
@@ -313,6 +568,26 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
         )
     }
 
+    private fun FakeTmuxClient.withStickySinglePane(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        repeat(8) {
+            responses.addLast(
+                CommandResponse(
+                    number = 1L,
+                    output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                    isError = false,
+                ),
+            )
+            cursorQueryResponses.addLast(
+                CommandResponse(number = 3L, output = listOf("0,0"), isError = false),
+            )
+        }
+        defaultCaptureResponse =
+            CommandResponse(number = 2L, output = listOf("$sessionName ready"), isError = false)
+    }
+
     private class QueueLeaseConnector(
         private vararg val sessions: FakeSshSession,
     ) : SshLeaseConnector {
@@ -327,22 +602,43 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
         }
     }
 
+    private class ScriptedLeaseConnector(
+        private val results: List<Result<SshSession>>,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+            private set
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val next = results.getOrNull(connectCount)
+                ?: error("unexpected lease connect $connectCount for ${target.leaseKey}")
+            connectCount += 1
+            return next
+        }
+    }
+
     private class FakeSshSession(
-        private val isConnectedValue: Boolean = true,
+        isConnectedValue: Boolean = true,
         // The #1222 async-close staleness window — `isConnected` may still lie true while a
         // close has been initiated. The transport vouch must FAIL there.
         private val isCloseInitiatedValue: Boolean = false,
     ) : SshSession {
         @Volatile
+        private var connected: Boolean = isConnectedValue
+
+        @Volatile
         var closed: Boolean = false
 
         override val isConnected: Boolean
-            get() = isConnectedValue && !closed
+            get() = connected && !closed
 
         override val isCloseInitiated: Boolean
             get() = isCloseInitiatedValue
 
         override fun isTransportProvenAliveWithinKeepAliveWindow(): Boolean = isConnected
+
+        fun markDisconnected() {
+            connected = false
+        }
 
         override suspend fun exec(command: String): ExecResult =
             ExecResult(stdout = "", stderr = "", exitCode = 0)

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1863DeadWireAfterCancelledConnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1863DeadWireAfterCancelledConnectTest.kt
@@ -537,6 +537,19 @@ class Issue1863DeadWireAfterCancelledConnectTest {
             LivenessProbeGate.Closed,
             selectLivenessProbeGate(false, appActive = true, hasClient = true, controlChannelDisconnected = false, controllerLive = false),
         )
+        // Issue #1954: a within-grace recovery already owns this exact target/client.
+        // Even a definitively closed channel stays deferred to that one typed owner.
+        assertEquals(
+            LivenessProbeGate.Closed,
+            selectLivenessProbeGate(
+                backgrounded = false,
+                appActive = true,
+                hasClient = true,
+                controlChannelDisconnected = true,
+                controllerLive = true,
+                withinGraceRecoveryOwnsClient = true,
+            ),
+        )
         // The #1863 split: foregrounded + controller Live + a CLOSED client.
         assertEquals(
             LivenessProbeGate.DeadChannel,

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue754ReseedSilentHealHoldTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue754ReseedSilentHealHoldTest.kt
@@ -299,10 +299,9 @@ class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
     // (3) CONFIRMED-DEAD / dispatch class (D31/G2): the reviewer's reopened gap. On a CLEAN
     //     CUT the `-CC` socket is already dead by foreground time, so
     //     `canReseedWithinGraceForeground()` DECLINES the reseed and the within-grace foreground
-    //     takes the HEAL / dispatch path — NOT the reseed_only path. The single-shot heal
-    //     fast-fails a dead/unreachable host and hands off to the loud auto-reconnect ladder,
-    //     whose `Reconnecting` projection paints RevealState.Seeding ("Attaching…") — WITHIN
-    //     grace — because the reveal hold was released the instant the heal job completed.
+    //     takes the HEAL / dispatch path — NOT the reseed_only path. Issue #1954 makes that
+    //     heal the bounded retry owner: a dead/unreachable host stays inside the silent owner
+    //     for the grace window instead of handing off immediately to the visible ladder.
     //     LOAD-BEARING: the within-grace confirmed-dead foreground must RIDE THROUGH — NO
     //     RevealState.Seeding overlay while the honest reconnect runs underneath, for the whole
     //     bounded grace window. RED on base (Seeding), GREEN with the whole-window hold.
@@ -369,14 +368,18 @@ class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
                     it.fields["stage"] == "foreground_reattach" && it.fields["outcome"] == "reseed_only"
                 },
             )
-            // Drive the heal to its FAILURE + the loud auto-reconnect ladder engaging — the exact
-            // window the reopened overlay painted. On base the hold is already released here.
-            awaitCondition {
-                diagnostics.eventsNamed("auto_reconnect_decision").any {
-                    it.fields["decision"] == "scheduled"
-                }
-            }
+            // Drive more than one paced owner attempt. The old one-shot implementation had
+            // already scheduled the normal ladder here; #1954 requires that ladder to remain
+            // absent for the whole bounded grace window.
+            advanceTimeBy(500L)
             runCurrent()
+            assertTrue(
+                "the confirmed-dead foreground owner must not hand off to auto reconnect " +
+                    "within grace; events=${diagnostics.eventsNamed("auto_reconnect_decision")}",
+                diagnostics.eventsNamed("auto_reconnect_decision").none {
+                    it.fields["decision"] == "scheduled"
+                },
+            )
 
             // LOAD-BEARING: the confirmed-dead within-grace foreground must RIDE THROUGH — the
             // honest reconnect runs underneath but the reveal HOLDS the live frame: NO
@@ -441,14 +444,15 @@ class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
                         it.fields["outcome"] == "silent_heal_within_grace"
                 }
             }
-            awaitCondition {
-                diagnostics.eventsNamed("auto_reconnect_decision").any {
-                    it.fields["decision"] == "scheduled"
-                }
-            }
-            // WITHIN grace: the ongoing (failing) reconnect is HELD on the live frame (proves the
-            // hold is genuinely masking the ladder — non-vacuous negative).
+            // WITHIN grace: the failing recovery remains owned here, with no visible ladder.
+            advanceTimeBy(500L)
             runCurrent()
+            assertTrue(
+                "the bounded owner must not schedule auto reconnect before grace expiry",
+                diagnostics.eventsNamed("auto_reconnect_decision").none {
+                    it.fields["decision"] == "scheduled"
+                },
+            )
             assertFalse(
                 "precondition: WITHIN grace the confirmed-dead reconnect must be HELD silent (no " +
                     "Seeding) — else the beyond-grace surfacing below proves nothing; got " +
@@ -458,6 +462,11 @@ class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
             // Advance PAST the grace window so the bounded whole-window hold is released.
             advanceTimeBy(graceMs + 500L)
             runCurrent()
+            awaitCondition {
+                diagnostics.eventsNamed("auto_reconnect_decision").any {
+                    it.fields["decision"] == "scheduled"
+                }
+            }
 
             assertTrue(
                 "after the grace window the whole-window hold must be released, so a still-unreachable " +

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionKeepaliveDeathAmortizationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionKeepaliveDeathAmortizationTest.kt
@@ -98,17 +98,19 @@ class TmuxSessionKeepaliveDeathAmortizationTest : TmuxSessionViewModelTestBase()
             if (recoveries == 0) initialSession else sessions[recoveries - 1]
     }
 
-    private fun TestScope.buildRig(): Rig {
+    private suspend fun TestScope.buildRig(): Rig {
         val registry = ActiveTmuxClients()
+        val initialSession = FakeSshSession()
         val sessions = List(4) { FakeSshSession() }
-        val connector = QueueLeaseConnector(*sessions.toTypedArray())
+        val connector = QueueLeaseConnector(initialSession, *sessions.toTypedArray())
+        val leaseManager = testLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = 60_000L,
+        )
         val vm = newVm(
             registry = registry,
-            sshLeaseManager = testLeaseManager(
-                connector = connector,
-                scope = this,
-                idleTtlMillis = 60_000L,
-            ),
+            sshLeaseManager = leaseManager,
         )
         vm.setPassiveDisconnectRecoveryForTest(
             graceMs = 60_000L,
@@ -124,7 +126,6 @@ class TmuxSessionKeepaliveDeathAmortizationTest : TmuxSessionViewModelTestBase()
             assertEquals("work", sessionName)
             replacementQueue.removeFirstOrNull() ?: error("unexpected tmux client factory call")
         }
-        val initialSession = FakeSshSession()
         val initialClient = FakeTmuxClient()
         vm.replaceClientForTest(
             hostId = 7L,
@@ -137,7 +138,14 @@ class TmuxSessionKeepaliveDeathAmortizationTest : TmuxSessionViewModelTestBase()
             client = initialClient,
             session = initialSession,
         )
+        // Issue #1954: proven-dead recovery owns an EXACT manager-held lease; an injected
+        // session with no lease identity is not a production-reachable starting state. Seed
+        // that exact lease before the first EOF, then zero only the observation counter so
+        // every assertion below keeps measuring recovery dials (not fixture setup).
+        vm.setActiveLeaseRefWarmForTest()
         runCurrent()
+        assertEquals("fixture setup must acquire the exact initial lease once", 1, connector.connectCount)
+        connector.beginRecoveryObservation()
         return Rig(
             vm = vm,
             registry = registry,
@@ -245,6 +253,22 @@ class TmuxSessionKeepaliveDeathAmortizationTest : TmuxSessionViewModelTestBase()
                 episodes.map { it.fields["graceMs"] },
             )
             assertEquals(listOf(1, 2, 3), episodes.map { it.fields["episode"] })
+
+            // Issue #1954 regression: Connected may be observed while the prior grace job is
+            // finishing. An immediate EOF of that successor must hand its exact manager-held
+            // lease to the next owner; the stale owner must not force-evict it during cancellation.
+            val exactRecoveries = diagnostics.eventsNamed("dead_lease_recovery")
+            assertEquals("each accepted dead successor must have one exact recovery owner", 3, exactRecoveries.size)
+            assertEquals(
+                "episode 2 must invalidate the exact successor produced by episode 1",
+                exactRecoveries[0].fields["newSshSessionHash"],
+                exactRecoveries[1].fields["oldSshSessionHash"],
+            )
+            assertEquals(
+                "episode 3 must invalidate the exact successor produced by episode 2",
+                exactRecoveries[1].fields["newSshSessionHash"],
+                exactRecoveries[2].fields["oldSshSessionHash"],
+            )
         } finally {
             diagnostics.close()
         }
@@ -357,14 +381,20 @@ class TmuxSessionKeepaliveDeathAmortizationTest : TmuxSessionViewModelTestBase()
     private class QueueLeaseConnector(
         private vararg val sessions: FakeSshSession,
     ) : SshLeaseConnector {
+        private var nextSessionIndex: Int = 0
         var connectCount: Int = 0
             private set
 
         override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
-            val next = sessions.getOrNull(connectCount)
-                ?: error("unexpected lease connect $connectCount for ${target.leaseKey}")
+            val next = sessions.getOrNull(nextSessionIndex)
+                ?: error("unexpected lease connect $nextSessionIndex for ${target.leaseKey}")
+            nextSessionIndex += 1
             connectCount += 1
             return Result.success(next)
+        }
+
+        fun beginRecoveryObservation() {
+            connectCount = 0
         }
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPassiveReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPassiveReconnectTest.kt
@@ -738,7 +738,11 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
     fun passiveEofShowsReconnectOnlyAfterSilentGraceExpires() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(0)
         val registry = ActiveTmuxClients()
-        val connector = FailingLeaseConnector(IOException("network still unavailable"))
+        val deadSession = FakeSshSession(isConnectedValue = false)
+        val connector = FailingLeaseConnector(
+            failure = IOException("network still unavailable"),
+            initialSession = deadSession,
+        )
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
@@ -775,9 +779,12 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             keyPath = "/keys/a",
             sessionName = "work",
             client = deadClient,
-            session = FakeSshSession(isConnectedValue = false),
+            session = deadSession,
         )
+        vm.setActiveLeaseRefWarmForTest()
         runCurrent()
+        val setupConnectCount = connector.connectCount
+        assertEquals("precondition: the VM owns the exact dead lease", 1, setupConnectCount)
 
         deadClient.disconnectedSignal.value = true
         advanceTimeBy(499L)
@@ -803,16 +810,18 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
         // the loop re-dials more than once before grace expires — proving the
         // resilience fix — while still BOUNDED by the grace window (no hot loop /
         // infinite re-dial: the count is small, paced by the retry delay).
+        val recoveryConnectCount = connector.connectCount - setupConnectCount
         assertTrue(
             "silent fresh-transport probing must RE-DIAL across a sustained outage " +
-                "(resilience #833), got connectCount=${connector.connectCount}",
-            connector.connectCount >= 2,
+                "(resilience #833), got recoveryConnectCount=$recoveryConnectCount",
+            recoveryConnectCount >= 2,
         )
         assertTrue(
             "silent fresh-transport probing must stay BOUNDED by the grace window " +
-                "(no hot loop), got connectCount=${connector.connectCount}",
-            connector.connectCount <= 4,
+                "(no hot loop), got recoveryConnectCount=$recoveryConnectCount",
+            recoveryConnectCount <= 4,
         )
+        assertTrue("the exact manager-owned corpse must be invalidated", deadSession.closed)
 
         advanceTimeBy(2L)
         runCurrent()
@@ -1031,7 +1040,8 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
         // but every capture is empty, so the reattached pane is BLACK on green.
         TMUX_CONNECT_ATTEMPTS.set(1)
         val registry = ActiveTmuxClients()
-        val connector = QueueLeaseConnector(FakeSshSession())
+        val deadSession = FakeSshSession(isConnectedValue = false)
+        val connector = QueueLeaseConnector(deadSession, FakeSshSession())
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
@@ -1075,8 +1085,9 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             keyPath = "/keys/a",
             sessionName = "work",
             client = deadClient,
-            session = FakeSshSession(isConnectedValue = false),
+            session = deadSession,
         )
+        vm.setActiveLeaseRefWarmForTest()
         runCurrent()
 
         deadClient.disconnectedSignal.value = true
@@ -1088,7 +1099,7 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             replacementClient,
             registry.clients.value[7L]?.client,
         )
-        assertEquals("a fresh transport was reacquired", 1, connector.connectCount)
+        assertEquals("one setup acquire + one fresh transport reacquire", 2, connector.connectCount)
         val pane = vm.panes.value.single { it.paneId == "%1" }
         assertTrue(
             "the fresh-transport reattach's seed stayed empty -> black on a live transport",
@@ -1202,7 +1213,8 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
     fun passiveEofSilentlyReacquiresTransportWhenOldSessionIsBroken() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(1)
         val registry = ActiveTmuxClients()
-        val connector = QueueLeaseConnector(FakeSshSession())
+        val deadSession = FakeSshSession(isConnectedValue = false)
+        val connector = QueueLeaseConnector(deadSession, FakeSshSession())
         val vm = newVm(
             registry = registry,
             sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
@@ -1223,14 +1235,15 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             keyPath = "/keys/a",
             sessionName = "work",
             client = deadClient,
-            session = FakeSshSession(isConnectedValue = false),
+            session = deadSession,
         )
+        vm.setActiveLeaseRefWarmForTest()
         runCurrent()
 
         deadClient.disconnectedSignal.value = true
         advanceUntilIdle()
 
-        assertEquals(1, connector.connectCount)
+        assertEquals("one setup acquire + one fresh recovery acquire", 2, connector.connectCount)
         assertSame(replacementClient, registry.clients.value[7L]?.client)
         assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
         assertEquals(
@@ -1239,15 +1252,58 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             TMUX_CONNECT_ATTEMPTS.get(),
         )
         assertTrue(replacementClient.connectCalled)
+
+        advanceTimeBy(2_000L)
+        runCurrent()
+        assertEquals(
+            "a successful recovery must terminate the bounded retry owner",
+            2,
+            connector.connectCount,
+        )
+    }
+
+    @Test
+    fun provenDeadFreshRecoveryWithoutExactLeaseFailsClosedWithoutDial() = runTest(scheduler) {
+        val connector = QueueLeaseConnector(FakeSshSession())
+        val vm = newVm(
+            registry = ActiveTmuxClients(),
+            sshLeaseManager = testLeaseManager(connector = connector, scope = this, idleTtlMillis = 0L),
+        )
+        vm.setPassiveDisconnectRecoveryForTest(graceMs = 100L, silentReattachTimeoutMs = 1L)
+        vm.setAutoReconnectDelaysForTest(emptyList())
+        val deadClient = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = deadClient,
+            // Deliberately sessionRef-only: no exact manager-owned SshLease authority.
+            session = FakeSshSession(isConnectedValue = false),
+        )
+        runCurrent()
+
+        deadClient.disconnectedSignal.value = true
+        advanceUntilIdle()
+
+        assertEquals(
+            "an unproven null lease must fail closed before any physical SSH dial",
+            0,
+            connector.connectCount,
+        )
     }
 
     @Test
     fun failedSilentTransportReattachEvictsLeaseSoManualReconnectUsesFreshSession() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(1)
         val registry = ActiveTmuxClients()
+        val deadSession = FakeSshSession(isConnectedValue = false)
         val failedReconnectSession = FakeSshSession()
         val manualReconnectSession = FakeSshSession()
-        val connector = QueueLeaseConnector(failedReconnectSession, manualReconnectSession)
+        val connector = QueueLeaseConnector(deadSession, failedReconnectSession, manualReconnectSession)
         val manager = testLeaseManager(
             connector = connector,
             scope = this,
@@ -1277,8 +1333,9 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             keyPath = "/keys/a",
             sessionName = "work",
             client = deadClient,
-            session = FakeSshSession(isConnectedValue = false),
+            session = deadSession,
         )
+        vm.setActiveLeaseRefWarmForTest()
         runCurrent()
 
         deadClient.disconnectedSignal.value = true
@@ -1296,14 +1353,14 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             "failed hidden reattach must evict the acquired SSH lease instead of idling it",
             failedReconnectSession.closed,
         )
-        assertEquals(1, connector.connectCount)
+        assertEquals("one setup acquire + one failed hidden recovery acquire", 2, connector.connectCount)
 
         assertTrue("manual reconnect should be available after failed hidden reattach", vm.reconnect())
         advanceUntilIdle()
 
         assertEquals(
             "manual reconnect must open a fresh SSH session, not reuse the failed hidden lease",
-            2,
+            3,
             connector.connectCount,
         )
         assertEquals(
@@ -1312,15 +1369,17 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
         )
         assertSame(manualReconnectClient, registry.clients.value[7L]?.client)
         assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+
     }
 
     @Test
     fun manualReconnectCancelsInFlightSilentTransportReattachAndUsesFreshSession() = runTest(scheduler) {
         TMUX_CONNECT_ATTEMPTS.set(1)
         val registry = ActiveTmuxClients()
+        val deadSession = FakeSshSession(isConnectedValue = false)
         val hiddenReconnectSession = FakeSshSession()
         val manualReconnectSession = FakeSshSession()
-        val connector = QueueLeaseConnector(hiddenReconnectSession, manualReconnectSession)
+        val connector = QueueLeaseConnector(deadSession, hiddenReconnectSession, manualReconnectSession)
         val manager = testLeaseManager(
             connector = connector,
             scope = this,
@@ -1354,8 +1413,9 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             keyPath = "/keys/a",
             sessionName = "work",
             client = deadClient,
-            session = FakeSshSession(isConnectedValue = false),
+            session = deadSession,
         )
+        vm.setActiveLeaseRefWarmForTest()
         runCurrent()
 
         deadClient.disconnectedSignal.value = true
@@ -1365,7 +1425,7 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
             "hidden reattach should be stalled while waiting for panes",
             hiddenAttachClient.sentCommands.any { it.startsWith("list-panes") },
         )
-        assertEquals(1, connector.connectCount)
+        assertEquals("one setup acquire + one in-flight hidden acquire", 2, connector.connectCount)
 
         assertTrue("manual reconnect should be accepted while hidden reattach is in flight", vm.reconnect())
         advanceUntilIdle()
@@ -1380,7 +1440,7 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
         )
         assertEquals(
             "manual reconnect must open a fresh SSH session after interrupting hidden reattach",
-            2,
+            3,
             connector.connectCount,
         )
         assertEquals(
@@ -1389,6 +1449,15 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
         )
         assertSame(manualReconnectClient, registry.clients.value[7L]?.client)
         assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
+
+        val connectorCountAfterSupersedingReconnect = connector.connectCount
+        advanceTimeBy(60_001L)
+        runCurrent()
+        assertEquals(
+            "the cancelled grace owner must not continue acquiring after manual reconnect supersedes it",
+            connectorCountAfterSupersedingReconnect,
+            connector.connectCount,
+        )
     }
 
 
@@ -1679,12 +1748,16 @@ class TmuxSessionViewModelPassiveReconnectTest : TmuxSessionViewModelTestBase() 
 
     private class FailingLeaseConnector(
         private val failure: Throwable,
+        private val initialSession: FakeSshSession? = null,
     ) : SshLeaseConnector {
         var connectCount: Int = 0
             private set
 
         override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
             connectCount += 1
+            if (connectCount == 1 && initialSession != null) {
+                return Result.success(initialSession)
+            }
             return Result.failure(failure)
         }
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/connection/GraceEffectsRecoveryOwnershipTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/GraceEffectsRecoveryOwnershipTest.kt
@@ -1,0 +1,36 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.core.connection.SessionId
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GraceEffectsRecoveryOwnershipTest {
+
+    private val effects = GraceEffects(
+        object : GraceEffects.GraceIo {
+            override fun launchBackgroundDetachTeardown() = Unit
+            override fun launchForegroundReattachReseed() = Unit
+            override fun launchForegroundHealWithinGrace() = Unit
+        },
+    )
+
+    @Test
+    fun `ownership is target and client keyed and stale release cannot clear successor`() {
+        val target = SessionId("target")
+        val first = WithinGraceRecoveryClaim(target, GraceClientId(1))
+        val successor = WithinGraceRecoveryClaim(target, GraceClientId(2))
+
+        effects.beginWithinGraceRecovery(first)
+        assertTrue(effects.ownsRecovery(target, GraceClientId(1)))
+        assertFalse(effects.ownsRecovery(target, GraceClientId(2)))
+        assertFalse(effects.ownsRecovery(SessionId("other-target"), GraceClientId(1)))
+
+        effects.beginWithinGraceRecovery(successor)
+        effects.endWithinGraceRecovery(first)
+        assertTrue("a stale owner timer must not release its successor", effects.ownsRecovery(target, GraceClientId(2)))
+
+        effects.endWithinGraceRecovery(successor)
+        assertFalse(effects.isWithinGraceRecoveryActive())
+    }
+}

--- a/scripts/test-ci-journey-dead-channel-oracle.sh
+++ b/scripts/test-ci-journey-dead-channel-oracle.sh
@@ -6,7 +6,6 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 ORACLE="$SCRIPT_DIR/ci-journey-dead-channel-oracle.py"
-VM="$REPO_ROOT/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt"
 GATE="$REPO_ROOT/app/src/main/java/com/pocketshell/app/tmux/connection/LivenessProbeGate.kt"
 PROBE="$REPO_ROOT/shared/core-connection/src/main/java/com/pocketshell/core/connection/LivenessProbe.kt"
 
@@ -14,7 +13,7 @@ fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
 [[ -f "$ORACLE" ]] || fail "oracle missing: $ORACLE"
-for source in "$VM" "$GATE" "$PROBE"; do
+for source in "$GATE" "$PROBE"; do
   [[ -f "$source" ]] || fail "production source missing: $source"
 done
 
@@ -96,13 +95,16 @@ grep -Fqx $'com.pocketshell.app.proof.ReconnectStormLivelockE2eTest\t1\t0\t0\t0\
 pass "canonical-only, max-of-sources, per-attempt measurement and specificity"
 
 # Structural red control: after #1863, foreground Live+disconnected selects
-# DeadChannel, while the obsolete text is emitted only for Closed. Therefore an
-# old foreground `gate closed` grep is guaranteed to miss the repaired path.
+# DeadChannel, while the obsolete text is emitted only for Closed by the same
+# gate authority. Therefore an old foreground `gate closed` grep is guaranteed
+# to miss the repaired path.
 grep -q 'controlChannelDisconnected -> LivenessProbeGate.DeadChannel' "$GATE" \
   || fail "foreground disconnected channel no longer selects DeadChannel"
-closed_block="$(sed -n '/if (gate == LivenessProbeGate.Closed)/,/^[[:space:]]*}/p' "$VM")"
+closed_block="$(sed -n '/if (gate == LivenessProbeGate.Closed)/,/^[[:space:]]*}/p' "$GATE")"
 grep -q '"gate closed bg=' <<<"$closed_block" \
   || fail "could not prove old message is confined to the Closed branch"
+[[ "$(grep -c '"gate closed bg=' "$GATE")" -eq "$(grep -c '"gate closed bg=' <<<"$closed_block")" ]] \
+  || fail "old message escaped the Closed branch in the gate authority"
 grep -Fq "$signal" "$PROBE" \
   || fail "replacement signal no longer exists at the definitive-close decision"
 old_foreground_count="$(grep -c 'gate closed bg=false appActive=true hasClient=true disconnected=true ctrl=Live' \

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
@@ -73,16 +73,15 @@ class RevealStateMachine {
      * unexpected foreground drop) keeps the prior calm-loading behaviour
      * ([ConnectionState.Reattaching] -> [RevealState.Seeding]).
      */
-    private var silentHealInFlight = false
+    private var connectionProjection: ConnectionProjection = ConnectionProjection.Normal
 
     /**
-     * Issue #1098 (item 4): mark/unmark a within-grace SILENT heal as in flight. While
-     * in flight, a [ConnectionState.Reattaching]/[ConnectionState.Reconnecting]
-     * projection holds the current reveal (no "Attaching…" overlay) — see
-     * [silentHealInFlight].
+     * Issue #1098/#1954: select the typed projection for a within-grace SILENT recovery.
+     * While selected, `Attaching`/`Reattaching`/`Reconnecting` are recovery plumbing and
+     * the projection holds the current reveal (no "Attaching…" overlay).
      */
-    fun setSilentHealInFlight(value: Boolean) {
-        silentHealInFlight = value
+    fun setConnectionProjection(value: ConnectionProjection) {
+        connectionProjection = value
     }
 
     /**
@@ -148,8 +147,14 @@ class RevealStateMachine {
             -> _state.value // no reveal change
 
             is ConnectionState.Connecting,
-            is ConnectionState.Attaching,
             -> RevealState.Seeding(target, targetName)
+
+            is ConnectionState.Attaching ->
+                if (connectionProjection == ConnectionProjection.SilentWithinGraceRecovery) {
+                    _state.value
+                } else {
+                    RevealState.Seeding(target, targetName)
+                }
 
             is ConnectionState.Reattaching,
             is ConnectionState.Reconnecting,
@@ -158,7 +163,7 @@ class RevealStateMachine {
                 // transport re-open WITHOUT an "Attaching…" overlay — hold the current
                 // (live) frame. Every other reattach/reconnect keeps the calm-loading
                 // Seeding surface.
-                if (silentHealInFlight) {
+                if (connectionProjection == ConnectionProjection.SilentWithinGraceRecovery) {
                     _state.value
                 } else {
                     RevealState.Seeding(target, targetName)
@@ -275,6 +280,12 @@ class RevealStateMachine {
         val live = _state.value as? RevealState.Live ?: return
         _state.value = live.copy(agentName = agentName)
     }
+}
+
+/** Typed connection-to-reveal projection policy; presentation never infers recovery ownership. */
+enum class ConnectionProjection {
+    Normal,
+    SilentWithinGraceRecovery,
 }
 
 /**

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
@@ -210,11 +210,12 @@ class RevealStateMachineTest {
 
         // The VM marks the within-grace SILENT heal in flight BEFORE the transport
         // teardown moves the controller off Live (the #635/item-4 ride-through).
-        m.setSilentHealInFlight(true)
+        m.setConnectionProjection(ConnectionProjection.SilentWithinGraceRecovery)
 
-        // The silent heal necessarily walks Live -> Reattaching -> (Reconnecting) while it
-        // re-opens the dropped `-CC`. With the heal in flight these MUST NOT drop the reveal
-        // to Seeding (which the screen renders as the full-surface "Attaching…" overlay).
+        // The silent heal can legitimately walk Live -> Reattaching -> Reconnecting ->
+        // Attaching while it replaces a proven-dead transport. With the heal in flight
+        // NONE of those typed recovery states may drop the reveal to Seeding (which the
+        // screen renders as the full-surface "Attaching…" overlay).
         m.onConnectionState(ConnectionState.Reattaching(host, a))
         assertEquals(
             "within-grace Reattaching must hold the live frame, not show the Attaching overlay",
@@ -227,10 +228,16 @@ class RevealStateMachineTest {
             liveBefore,
             m.state.value,
         )
+        m.onConnectionState(ConnectionState.Attaching(host, a))
+        assertEquals(
+            "within-grace Attaching must hold the live frame, not show the Attaching overlay",
+            liveBefore,
+            m.state.value,
+        )
 
         // Heal succeeds: the transport re-promotes Live and the reseed lands; reveal is Live.
         m.onConnectionState(ConnectionState.Live(host, a))
-        m.setSilentHealInFlight(false)
+        m.setConnectionProjection(ConnectionProjection.Normal)
         assertTrue(m.state.value is RevealState.Live)
     }
 
@@ -248,8 +255,8 @@ class RevealStateMachineTest {
         // unexpected reattach again shows the calm loading surface (the hold cannot get
         // stuck on).
         m.onConnectionState(ConnectionState.Live(host, a))
-        m.setSilentHealInFlight(true)
-        m.setSilentHealInFlight(false)
+        m.setConnectionProjection(ConnectionProjection.SilentWithinGraceRecovery)
+        m.setConnectionProjection(ConnectionProjection.Normal)
         m.onConnectionState(ConnectionState.Reattaching(host, a))
         assertEquals(RevealState.Seeding(a, "session-A"), m.state.value)
     }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -512,6 +512,51 @@ public class SshLeaseManager(
     }
 
     /**
+     * Invalidate the exact actively-held lease whose transport has been proven dead.
+     *
+     * Unlike [evictIdle], this is allowed to remove a non-zero-ref entry: once the physical
+     * transport is known dead, every holder already owns the same corpse and retaining it can
+     * only make a force-fresh acquire reuse that corpse. The lease's entry id is load-bearing:
+     * a late recovery claim can never close a newer replacement registered under the same key.
+     * Stale [SshLease.release] calls are already ignored by the entry-id guard in [release].
+     *
+     * This is the single lease-authority boundary for proven-dead active transports. Callers do
+     * not close [SshSession] directly.
+     *
+     * @return true only when [lease] still names the current pooled entry and it was invalidated.
+     */
+    public suspend fun invalidateDead(lease: SshLease): Boolean {
+        val entry = mutex.withLock {
+            val current = entries[lease.key] ?: return@withLock null
+            if (current.id != lease.entryId) return@withLock null
+            entries.remove(lease.key)
+            emitStateLocked(
+                key = lease.key,
+                state = SshLeaseConnectionState.Closed,
+                closeReason = SshLeaseCloseReason.ForceRefresh,
+            )
+            current
+        } ?: return false
+        entry.close()
+        return true
+    }
+
+    /**
+     * Whether [lease] still names the exact current, reusable pool entry.
+     *
+     * This is the non-mutating sibling of [invalidateDead]. Recovery code that already replaced
+     * an exact dead lease uses it before retrying a later tmux stage over the live successor. The
+     * entry-id and session-identity checks prevent a stale lease from vouching for a replacement
+     * that happened to reuse the same key.
+     */
+    public suspend fun isCurrentLiveLease(lease: SshLease): Boolean = mutex.withLock {
+        val current = entries[lease.key] ?: return@withLock false
+        current.id == lease.entryId &&
+            current.session === lease.session &&
+            current.session.isLiveForLease()
+    }
+
+    /**
      * Apply the app process background policy for warm SSH transports.
      *
      * Active leases are left alone because the owning foreground flow must
@@ -865,7 +910,7 @@ public class SshLease internal constructor(
     public val key: SshLeaseKey,
     public val session: SshSession,
     public val isNewConnection: Boolean,
-    private val entryId: Long,
+    internal val entryId: Long,
     private val releaseAction: suspend (SshLeaseKey, Long) -> Unit,
 ) {
     private val releaseMutex = Mutex()

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseManagerTest.kt
@@ -598,6 +598,51 @@ class SshLeaseManagerTest {
     }
 
     @Test
+    fun `proven-dead invalidation closes the exact active lease and next acquire is fresh`() = runTest {
+        val dead = FakeSshSession()
+        val fresh = FakeSshSession()
+        val connector = QueueLeaseConnector(dead, fresh)
+        val manager = leaseManager(connector = connector, idleTtlMillis = 60_000)
+
+        val activeDeadLease = manager.acquire(TARGET).getOrThrow()
+
+        assertTrue(manager.isCurrentLiveLease(activeDeadLease))
+        assertTrue(manager.invalidateDead(activeDeadLease))
+        assertFalse(manager.isCurrentLiveLease(activeDeadLease))
+        assertTrue("the proven-dead transport must be closed", dead.closed)
+        val replacement = manager.acquire(TARGET).getOrThrow()
+        assertTrue("replacement must be a genuine new handshake", replacement.isNewConnection)
+        assertTrue(manager.isCurrentLiveLease(replacement))
+        assertSame(fresh, replacement.session)
+        assertEquals(2, connector.connectCount)
+
+        // Releasing the invalidated holder is stale and cannot disturb the replacement.
+        activeDeadLease.release()
+        assertFalse(fresh.closed)
+        replacement.release()
+    }
+
+    @Test
+    fun `late proven-dead invalidation cannot close a newer replacement`() = runTest {
+        val dead = FakeSshSession()
+        val fresh = FakeSshSession()
+        val connector = QueueLeaseConnector(dead, fresh)
+        val manager = leaseManager(connector = connector, idleTtlMillis = 60_000)
+
+        val staleClaim = manager.acquire(TARGET).getOrThrow()
+        assertTrue(manager.invalidateDead(staleClaim))
+        val replacement = manager.acquire(TARGET).getOrThrow()
+
+        assertFalse("a stale entry-id claim must not invalidate the replacement", manager.invalidateDead(staleClaim))
+        assertFalse(fresh.closed)
+        assertSame(fresh, replacement.session)
+        assertEquals(2, connector.connectCount)
+
+        staleClaim.release()
+        replacement.release()
+    }
+
+    @Test
     fun `evict idle leaves a transport a second active holder still owns`() = runTest {
         // Issue #758 (back -> open-another-session reconnect): the FolderList
         // picker poll and an active TmuxSessionViewModel ride the SAME lease key.


### PR DESCRIPTION
Closes #1954.

Implements typed within-grace recovery ownership, exact dead-lease invalidation/fresh successor acquisition, liveness exclusion, and silent reveal hold through attaching states.

Review approval and full verification: https://github.com/alexeygrigorev/pocketshell/issues/1954#issuecomment-5172416331