### PR TITLE
Fix nightly outbound, port-forward isolation, and Docker recovery proof

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
@@ -1,5 +1,9 @@
 package com.pocketshell.app.portfwd
 
+import android.app.ActivityManager
+import android.app.NotificationManager
+import android.content.Context
+import android.os.SystemClock
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.room.Room
@@ -7,7 +11,9 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.portfwd.service.ForwardingService
 import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
 import com.pocketshell.core.portfwd.TunnelInfo
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshPortForward
@@ -16,12 +22,13 @@ import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.Dispatchers
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -73,19 +80,37 @@ class PortForwardPanelLifecycleE2eTest {
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
     private var db: AppDatabase? = null
+    private var ownedForwardingController: ForwardingController? = null
+    private var ownedForwardingHostId: Long? = null
+    private var appContext: Context? = null
+
+    private fun appForwardingController(context: Context): ForwardingController =
+        EntryPointAccessors
+            .fromApplication(context.applicationContext, TestAccessEntryPoint::class.java)
+            .forwardingController()
 
     @After
     fun tearDown() {
+        // Issue #1967: leavePanel() intentionally does NOT stop a user-owned
+        // forward. This proof enabled the app singleton directly, so the test
+        // owns its teardown as well. Await a stable zero controller + service
+        // state before the next in-process journey can start its grace timer.
+        val forwardingCleanupFailure = runCatching {
+            runBlocking { stopOwnedForwardingAndAwaitQuiescent() }
+        }.exceptionOrNull()
         launchedActivity?.close()
         launchedActivity = null
         db?.close()
         db = null
+        appContext = null
+        forwardingCleanupFailure?.let { throw it }
     }
 
     @Test
     fun lifecycleStopKeepsTunnels_lifecycleStartDoesNotReconnectThem() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
+        appContext = targetContext.applicationContext
 
         // 1. Stand up an in-memory Room DB on the main thread so the
         //    panel's autoForward + persist paths have a real DAO.
@@ -111,6 +136,7 @@ class PortForwardPanelLifecycleE2eTest {
                 enabled = false,
             ),
         )
+        ownedForwardingHostId = hostId
 
         // 3. Launch MainActivity to get a real process lifecycle.
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
@@ -121,7 +147,13 @@ class PortForwardPanelLifecycleE2eTest {
 
         // 4. Build the ViewModel on the main thread (Lifecycle.addObserver
         //    requirement) and attach ProcessLifecycleOwner.
-        val forwardingController = ForwardingController(targetContext)
+        val forwardingController = appForwardingController(targetContext)
+        ownedForwardingController = forwardingController
+        assertTrue(
+            "app-owned forwarding controller must start empty; a prior test leaked " +
+                forwardingController.activeHostIdsSnapshot(),
+            forwardingController.activeHostIdsSnapshot().isEmpty(),
+        )
         val viewModel = withContext(Dispatchers.Main) {
             PortForwardPanelViewModel(
                 hostDao = database.hostDao(),
@@ -150,10 +182,12 @@ class PortForwardPanelLifecycleE2eTest {
         viewModel.setAutoForwardEnabled(true)
 
         withTimeout(STATE_TIMEOUT_MS) {
-            waitFor("panel connected with tunnel") {
+            waitFor("app-owned panel connected with tunnel") {
                 val state = viewModel.state.value
                 state.connectionState == PortForwardConnectionState.Connected &&
-                    state.tunnels.any { it.status == TunnelInfo.Status.FORWARDING }
+                    state.tunnels.any { it.status == TunnelInfo.Status.FORWARDING } &&
+                    forwardingController.activeHostIdsSnapshot() == listOf(hostId) &&
+                    forwardingServiceRunning(targetContext)
             }
         }
         val firstSession = requireNotNull(sessionFactory.lastSession()) {
@@ -198,7 +232,73 @@ class PortForwardPanelLifecycleE2eTest {
         withContext(Dispatchers.Main) {
             viewModel.leavePanel()
         }
+        assertEquals(
+            "leavePanel must keep the user-owned forward alive; @After owns test isolation",
+            listOf(hostId),
+            forwardingController.activeHostIdsSnapshot(),
+        )
     } }
+
+    private suspend fun stopOwnedForwardingAndAwaitQuiescent() {
+        val controller = ownedForwardingController ?: return
+        val ownedHostId = ownedForwardingHostId
+        val activeBefore = controller.activeHostIdsSnapshot()
+
+        // stopAllForwarding is ownership-correct here because this test asserts
+        // the app controller was empty before adoption and registers one host.
+        // If a foreign registration appears, remove only ours and fail rather
+        // than silently stopping forwarding another test created.
+        val ownsEveryActiveHost = activeBefore.all { it == ownedHostId }
+        if (ownsEveryActiveHost) {
+            controller.stopAllForwarding()
+        } else {
+            ownedHostId?.let(controller::stopForwarding)
+        }
+
+        withTimeout(STATE_TIMEOUT_MS) {
+            var zeroSinceMs: Long? = null
+            waitFor("zero active forwarding and stopped service") {
+                val context = appContext
+                val isQuiescent = controller.flowOfActiveHostCount().value == 0 &&
+                    controller.activeHostIdsSnapshot().isEmpty() &&
+                    (context == null ||
+                        (!forwardingServiceRunning(context) && !forwardingNotificationPresent(context)))
+                if (isQuiescent) {
+                    val now = SystemClock.elapsedRealtime()
+                    val since = zeroSinceMs ?: now.also { zeroSinceMs = it }
+                    now - since >= QUIESCENT_STABLE_MS
+                } else {
+                    zeroSinceMs = null
+                    false
+                }
+            }
+        }
+
+        assertTrue(
+            "test teardown may stop only its own forwarding; activeBefore=$activeBefore owned=$ownedHostId",
+            ownsEveryActiveHost,
+        )
+        assertEquals(0, controller.flowOfActiveHostCount().value)
+        assertTrue(controller.activeHostIdsSnapshot().isEmpty())
+        ownedForwardingController = null
+        ownedForwardingHostId = null
+    }
+
+    @Suppress("DEPRECATION")
+    private fun forwardingServiceRunning(context: Context): Boolean =
+        context.getSystemService(ActivityManager::class.java)
+            .getRunningServices(Int.MAX_VALUE)
+            .any { it.service.className == ForwardingService::class.java.name }
+
+    private fun forwardingNotificationPresent(context: Context): Boolean =
+        context.getSystemService(NotificationManager::class.java)
+            .activeNotifications
+            .any {
+                it.notification.extras
+                    .getCharSequence("android.title")
+                    ?.toString()
+                    ?.contains("Port forwarding running") == true
+            }
 
     private suspend fun waitFor(label: String, predicate: () -> Boolean) {
         while (!predicate()) {
@@ -216,6 +316,7 @@ class PortForwardPanelLifecycleE2eTest {
          */
         const val STATE_TIMEOUT_MS: Long = 15_000L
         const val POLL_INTERVAL_MS: Long = 50L
+        const val QUIESCENT_STABLE_MS: Long = 1_000L
     }
 }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1739CaptureProbeHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1739CaptureProbeHarness.kt
@@ -1,0 +1,174 @@
+package com.pocketshell.app.proof
+
+import com.pocketshell.app.composer.OutboundQueueStore
+import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.tmux.AGENT_SUBMIT_ACK_TIMEOUT_MS
+import com.pocketshell.app.tmux.AgentSubmitCaptureSeams
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+
+internal class Issue1739CaptureProbe {
+    val observed = AtomicBoolean(false)
+    val firstRealCapture = AtomicReference("")
+    val routedRowId = AtomicReference("")
+    val routedSessionKey = AtomicReference("")
+    val readyOnly = CopyOnWriteArrayList<String>()
+    val rejected = CopyOnWriteArrayList<String>()
+    val matched = AtomicReference("")
+    lateinit var timeoutDetails: () -> String
+}
+
+/**
+ * Correlates the chip-bearing callback with its exact durable route, capture,
+ * pane, connection generation, and transcript-submit invocation.
+ */
+internal class Issue1739CaptureProbeHarness(
+    private val diagnostics: RecordingDiagnosticSink,
+    private val capturePane: suspend () -> String,
+    private val countCollapsedPasteChips: (String) -> Int,
+    private val boundedEventTail: (List<RecordedDiagnosticEvent>, Int) -> String,
+    private val sessionName: String,
+    private val fakeAgentReady: String,
+) {
+    suspend fun arm(
+        viewModel: TmuxSessionViewModel,
+        store: OutboundQueueStore,
+        sessionKey: String,
+        expectedClient: Int,
+        onCancelled: suspend () -> Unit,
+    ): Issue1739CaptureProbe {
+        val probe = Issue1739CaptureProbe()
+        val expectedGeneration = viewModel.currentConnectGenerationForTest()
+        val collapsedChipBaseline = countCollapsedPasteChips(capturePane())
+        val diagnosticOffset = diagnostics.events.size
+        AgentSubmitCaptureSeams.afterRealCapture = captureHook@{ observation ->
+            val capture = observation.response.output.joinToString("\n")
+            val events = diagnostics.events.drop(diagnosticOffset)
+            val routeEvent = events.lastOrNull {
+                it.name == "composer_tmux_send_route" && it.fields["rowId"] != "none"
+            }
+            val routeRowId = routeEvent?.fields?.get("rowId") as? String
+            val routeSessionKey = routeEvent?.fields?.get("sessionKey") as? String
+            val row = routeRowId?.let(store::item)
+            val claimIndex = events.indexOfFirst {
+                it.name == "row_state" &&
+                    it.fields["itemId"] == row?.id &&
+                    it.fields["toState"] == "InFlight" &&
+                    it.fields["reason"] == "claimed"
+            }
+            val routeIndex = routeEvent?.let(events::indexOf) ?: -1
+            val startIndex = events.indexOfFirst {
+                it.name == "agent_submit_capture" &&
+                    it.fields["result"] == "started" &&
+                    it.fields["captureId"] == observation.captureId &&
+                    it.fields["timeoutMs"] == observation.timeoutMs &&
+                    it.fields["pane"] == observation.paneId &&
+                    it.fields["clientHash"] == observation.clientHash &&
+                    it.fields["generation"] == observation.generation &&
+                    it.fields["session"] == observation.session
+            }
+            val chipCount = countCollapsedPasteChips(capture)
+            val identityMatches =
+                observation.scrollbackLines == 0 &&
+                    observation.timeoutMs == AGENT_SUBMIT_ACK_TIMEOUT_MS &&
+                    observation.paneId == row?.paneId &&
+                    observation.clientHash == expectedClient &&
+                    observation.generation == expectedGeneration &&
+                    observation.session == sessionName &&
+                    viewModel.currentClientIdentityForTest() == expectedClient &&
+                    viewModel.currentConnectGenerationForTest() == expectedGeneration &&
+                    viewModel.currentTargetSessionKeyForTest() == sessionKey &&
+                    row?.sessionKey == routeSessionKey
+            val ordered =
+                row != null &&
+                    row.state == OutboundState.InFlight &&
+                    row.wireAttempted &&
+                    claimIndex >= 0 &&
+                    routeIndex > claimIndex &&
+                    startIndex > routeIndex
+            val summary =
+                "captureId=${observation.captureId} pane=${observation.paneId} " +
+                    "timeout=${observation.timeoutMs} " +
+                    "client=${observation.clientHash} generation=${observation.generation} " +
+                    "session=${observation.session} row=${row?.id}/${row?.state}/" +
+                    "${row?.wireAttempted} order=$claimIndex<$routeIndex<$startIndex " +
+                    "chips=$collapsedChipBaseline->$chipCount"
+
+            if (
+                observation.scrollbackLines == 0 &&
+                capture.contains(fakeAgentReady) &&
+                chipCount == collapsedChipBaseline
+            ) {
+                probe.readyOnly.addBounded("$summary\n${capture.take(CAPTURE_LIMIT)}")
+                return@captureHook
+            }
+            if (
+                !identityMatches ||
+                !ordered ||
+                observation.response.isError ||
+                !capture.contains(fakeAgentReady) ||
+                chipCount != collapsedChipBaseline + 1
+            ) {
+                probe.rejected.addBounded("$summary\n${capture.take(CAPTURE_LIMIT)}")
+                return@captureHook
+            }
+            if (!probe.observed.compareAndSet(false, true)) return@captureHook
+            probe.firstRealCapture.set(capture)
+            probe.routedRowId.set(requireNotNull(routeRowId))
+            probe.routedSessionKey.set(requireNotNull(routeSessionKey))
+            probe.matched.set(summary.take(CAPTURE_LIMIT))
+            try {
+                CompletableDeferred<Unit>().await()
+            } catch (cancelled: CancellationException) {
+                onCancelled()
+                throw cancelled
+            }
+        }
+        probe.timeoutDetails = {
+            val rows = store.itemsFor(sessionKey)
+            val routedRows = diagnostics.events.drop(diagnosticOffset)
+                .filter { it.name == "composer_tmux_send_route" }
+                .takeLast(ROW_TAIL_COUNT)
+                .map { event ->
+                    val rowId = event.fields["rowId"] as? String
+                    val routedSession = event.fields["sessionKey"] as? String
+                    "route=$rowId@$routedSession item=${rowId?.let(store::item)} " +
+                        "routedItems=${routedSession?.let(store::itemsFor)}"
+                }
+            val rowTail = rows.takeLast(ROW_TAIL_COUNT).joinToString {
+                "id=${it.id.take(ID_LIMIT)} state=${it.state} " +
+                    "attempt=${it.attemptCount} pane=${it.paneId?.take(ID_LIMIT)} " +
+                    "wireAttempted=${it.wireAttempted}"
+            }
+            "currentClient=${viewModel.currentClientIdentityForTest()} " +
+                "currentGeneration=${viewModel.currentConnectGenerationForTest()} " +
+                "currentSession=${viewModel.currentTargetSessionKeyForTest()?.take(ID_LIMIT)} " +
+                "expected=$expectedClient/$expectedGeneration/${sessionKey.take(ID_LIMIT)} " +
+                "rowsTotal=${rows.size} rowsTail=[$rowTail] " +
+                "routedRows=$routedRows " +
+                "events=${boundedEventTail(diagnostics.events, diagnosticOffset)} " +
+                "readyOnly=${probe.readyOnly.boundedEntries()} " +
+                "rejected=${probe.rejected.boundedEntries()}"
+        }
+        return probe
+    }
+
+    private fun CopyOnWriteArrayList<String>.addBounded(value: String) {
+        if (size < CAPTURE_LIMIT_COUNT) add(value.take(CAPTURE_LIMIT))
+    }
+
+    private fun List<String>.boundedEntries(): String =
+        takeLast(CAPTURE_LIMIT_COUNT)
+            .joinToString(prefix = "[", postfix = "]") { it.take(CAPTURE_LIMIT) }
+
+    private companion object {
+        const val CAPTURE_LIMIT = 1_024
+        const val CAPTURE_LIMIT_COUNT = 3
+        const val ROW_TAIL_COUNT = 4
+        const val ID_LIMIT = 96
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
@@ -42,13 +42,12 @@ import com.pocketshell.app.composer.composerOutboundQueueItemRowTestTag
 import com.pocketshell.app.composer.OutboundState
 import com.pocketshell.app.composer.OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE
 import com.pocketshell.app.composer.OUTBOUND_MAX_AUTO_ATTEMPTS
+import com.pocketshell.app.composer.OutboundQueueStore
 import com.pocketshell.app.composer.PromptComposerViewModel
-import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.diagnostics.DiagnosticPrivacy
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
-import com.pocketshell.app.tmux.AGENT_SUBMIT_ACK_TIMEOUT_MS
 import com.pocketshell.app.tmux.AgentSubmitCaptureSeams
 import com.pocketshell.app.tmux.OutboundDeliverySeams
 import com.pocketshell.app.tmux.PasteChunkSeams
@@ -76,10 +75,8 @@ import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
 import java.io.File
 import java.util.Base64
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.runBlocking
@@ -399,9 +396,10 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         val clientBeforeOutage = vm.currentClientIdentityForTest()
         val generationBeforeOutage = vm.currentConnectGenerationForTest()
         val fallbackA = "$hostId/$renamedA"
-        val store = SharedPrefsOutboundQueueStore(
-            InstrumentationRegistry.getInstrumentation().targetContext,
-        )
+        // Observe and mutate the SAME Hilt-owned queue store that the composer
+        // drain and delivery ledger use; the journey must not create a second
+        // lock owner over production's SharedPreferences blob (#1587).
+        val store = currentPromptComposerViewModel().outboundQueueStore
         store.clearSession(fallbackA)
         store.clearSession(durableA)
 
@@ -770,9 +768,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             issue1739CaptureCleanupGate = cleanupGate
             val cleanupParked = AtomicBoolean(false)
             val cleanupRanOnMain = AtomicReference<Boolean>()
-            val store = SharedPrefsOutboundQueueStore(
-                InstrumentationRegistry.getInstrumentation().targetContext,
-            )
+            val store = currentPromptComposerViewModel().outboundQueueStore
             val sessionKey = requireNotNull(viewModel.currentTargetSessionKeyForTest()) {
                 "the connected VM must expose its exact durable queue session key"
             }
@@ -861,9 +857,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
 
             val cleanupGate = CompletableDeferred<Unit>()
             issue1739CaptureCleanupGate = cleanupGate
-            val store = SharedPrefsOutboundQueueStore(
-                InstrumentationRegistry.getInstrumentation().targetContext,
-            )
+            val store = currentPromptComposerViewModel().outboundQueueStore
             val sessionKey = requireNotNull(viewModel.currentTargetSessionKeyForTest()) {
                 "the connected VM must expose its exact durable queue session key"
             }
@@ -891,7 +885,9 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             // Authoritative intermediate evidence, while the first ack capture
             // is still parked: one durable InFlight row, wire attempted, real
             // collapsed paste visible, and NO submission/Enter.
-            val inFlightRows = store.itemsFor(sessionKey)
+            val routedSessionKey = captureProbe.routedSessionKey.get()
+            val routedRowId = captureProbe.routedRowId.get()
+            val inFlightRows = store.itemsFor(routedSessionKey)
             assertEquals(
                 "the real composer must own exactly one durable row during the wedged ack; " +
                     "rows=$inFlightRows",
@@ -899,6 +895,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
                 inFlightRows.size,
             )
             val row = inFlightRows.single()
+            assertEquals("the probe must follow the exact routed durable row", routedRowId, row.id)
             assertEquals(
                 "the row must still be InFlight while the real capture cleanup is parked",
                 OutboundState.InFlight,
@@ -1007,14 +1004,21 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
                 ),
             )
             assertInputBoxEmpty("after issue1739 same-token retry", submitted)
+            waitForIssue1739Boundary(
+                SUBMIT_AFTER_FLAP_TIMEOUT_MS,
+                "authoritative transcript ack and durable row prune",
+                timeoutDetails = { "row=${store.item(row.id)} events=${boundedEventTail(diagnostics!!.events)}" },
+            ) {
+                store.item(row.id) == null
+            }
             assertTrue(
                 "the SAME durable row/token must be Sent and pruned; id=${row.id} " +
-                    "remaining=${store.itemsFor(sessionKey)}",
-                store.item(row.id) == null && store.itemsFor(sessionKey).isEmpty(),
+                    "remaining=${store.itemsFor(routedSessionKey)}",
+                store.item(row.id) == null && store.itemsFor(routedSessionKey).isEmpty(),
             )
             writeText(
                 "issue1739-row-prune.txt",
-                "session=$sessionKey\nrowId=${row.id}\nitem=null\nsessionItems=0\n",
+                "session=$routedSessionKey\nrowId=${row.id}\nitem=null\nsessionItems=0\n",
             )
             val verifies = diagnostics!!.eventsNamed("outbound_verify_before_resend")
             assertTrue(
@@ -1961,128 +1965,20 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         )
     }
 
-    private class Issue1739CaptureProbe {
-        val observed = AtomicBoolean(false)
-        val firstRealCapture = AtomicReference("")
-        val readyOnly = CopyOnWriteArrayList<String>()
-        val rejected = CopyOnWriteArrayList<String>()
-        val matched = AtomicReference("")
-        lateinit var timeoutDetails: () -> String
-    }
-
-    /**
-     * Correlate the chip-bearing callback to its exact capture invocation.
-     * `agent_prompt_send` is asserted only as the ordered dispatch event; its
-     * production diagnostic has no runtime fields. Runtime authority comes from
-     * the identity-complete callback plus its same-capture-id `started` event.
-     */
-    private fun armIssue1739CaptureProbe(
+    private suspend fun armIssue1739CaptureProbe(
         viewModel: TmuxSessionViewModel,
-        store: SharedPrefsOutboundQueueStore,
+        store: OutboundQueueStore,
         sessionKey: String,
         expectedClient: Int,
         onCancelled: suspend () -> Unit,
-    ): Issue1739CaptureProbe {
-        val probe = Issue1739CaptureProbe()
-        val expectedGeneration = viewModel.currentConnectGenerationForTest()
-        val collapsedChipBaseline = countCollapsedPasteChips(runBlocking { sidecarCapturePane() })
-        val diagnosticOffset = diagnostics!!.events.size
-        AgentSubmitCaptureSeams.afterRealCapture = captureHook@{ observation ->
-            val capture = observation.response.output.joinToString("\n")
-            val row = store.itemsFor(sessionKey).singleOrNull()
-            val events = diagnostics!!.events.drop(diagnosticOffset)
-            val claimIndex = events.indexOfFirst {
-                it.name == "row_state" &&
-                    it.fields["itemId"] == row?.id &&
-                    it.fields["toState"] == "InFlight" &&
-                    it.fields["reason"] == "claimed"
-            }
-            val sendIndex = events.indexOfFirst {
-                it.name == "agent_prompt_send" && it.fields["pane"] == row?.paneId
-            }
-            val startIndex = events.indexOfFirst {
-                it.name == "agent_submit_capture" &&
-                    it.fields["result"] == "started" &&
-                    it.fields["captureId"] == observation.captureId &&
-                    it.fields["timeoutMs"] == observation.timeoutMs &&
-                    it.fields["pane"] == observation.paneId &&
-                    it.fields["clientHash"] == observation.clientHash &&
-                    it.fields["generation"] == observation.generation &&
-                    it.fields["session"] == observation.session
-            }
-            val chipCount = countCollapsedPasteChips(capture)
-            val identityMatches =
-                observation.scrollbackLines == 0 &&
-                    observation.timeoutMs == AGENT_SUBMIT_ACK_TIMEOUT_MS &&
-                    observation.paneId == row?.paneId &&
-                    observation.clientHash == expectedClient &&
-                    observation.generation == expectedGeneration &&
-                    observation.session == SESSION_NAME &&
-                    viewModel.currentClientIdentityForTest() == expectedClient &&
-                    viewModel.currentConnectGenerationForTest() == expectedGeneration &&
-                    viewModel.currentTargetSessionKeyForTest() == sessionKey
-            val ordered =
-                row != null &&
-                    row.state == OutboundState.InFlight &&
-                    row.wireAttempted &&
-                    claimIndex >= 0 &&
-                    sendIndex > claimIndex &&
-                    startIndex > sendIndex
-            val summary =
-                "captureId=${observation.captureId} pane=${observation.paneId} " +
-                    "timeout=${observation.timeoutMs} " +
-                    "client=${observation.clientHash} generation=${observation.generation} " +
-                    "session=${observation.session} row=${row?.id}/${row?.state}/" +
-                    "${row?.wireAttempted} order=$claimIndex<$sendIndex<$startIndex " +
-                    "chips=$collapsedChipBaseline->$chipCount"
-
-            if (
-                observation.scrollbackLines == 0 &&
-                capture.contains(FAKE_AGENT_READY) &&
-                chipCount == collapsedChipBaseline
-            ) {
-                probe.readyOnly.addBounded("$summary\n${capture.take(DIAGNOSTIC_CAPTURE_LIMIT)}")
-                return@captureHook
-            }
-            if (
-                !identityMatches ||
-                !ordered ||
-                observation.response.isError ||
-                !capture.contains(FAKE_AGENT_READY) ||
-                chipCount != collapsedChipBaseline + 1
-            ) {
-                probe.rejected.addBounded("$summary\n${capture.take(DIAGNOSTIC_CAPTURE_LIMIT)}")
-                return@captureHook
-            }
-            if (!probe.observed.compareAndSet(false, true)) return@captureHook
-            probe.firstRealCapture.set(capture)
-            probe.matched.set(summary.take(DIAGNOSTIC_CAPTURE_LIMIT))
-            try {
-                CompletableDeferred<Unit>().await()
-            } catch (cancelled: CancellationException) {
-                onCancelled()
-                throw cancelled
-            }
-        }
-        probe.timeoutDetails = {
-            val rows = store.itemsFor(sessionKey)
-            val rowTail = rows.takeLast(DIAGNOSTIC_ROW_TAIL_COUNT).joinToString {
-                "id=${it.id.take(DIAGNOSTIC_ID_LIMIT)} state=${it.state} " +
-                    "attempt=${it.attemptCount} pane=${it.paneId?.take(DIAGNOSTIC_ID_LIMIT)} " +
-                    "wireAttempted=${it.wireAttempted}"
-            }
-            "currentClient=${viewModel.currentClientIdentityForTest()} " +
-                "currentGeneration=${viewModel.currentConnectGenerationForTest()} " +
-                "currentSession=${viewModel.currentTargetSessionKeyForTest()?.take(DIAGNOSTIC_ID_LIMIT)} " +
-                "expected=$expectedClient/$expectedGeneration/" +
-                sessionKey.take(DIAGNOSTIC_ID_LIMIT) + " " +
-                "rowsTotal=${rows.size} rowsTail=[$rowTail] " +
-                "events=${boundedEventTail(diagnostics!!.events, diagnosticOffset)} " +
-                "readyOnly=${boundedCaptureEntries(probe.readyOnly)} " +
-                "rejected=${boundedCaptureEntries(probe.rejected)}"
-        }
-        return probe
-    }
+    ): Issue1739CaptureProbe = Issue1739CaptureProbeHarness(
+        diagnostics = requireNotNull(diagnostics),
+        capturePane = { sidecarCapturePane() },
+        countCollapsedPasteChips = ::countCollapsedPasteChips,
+        boundedEventTail = ::boundedEventTail,
+        sessionName = SESSION_NAME,
+        fakeAgentReady = FAKE_AGENT_READY,
+    ).arm(viewModel, store, sessionKey, expectedClient, onCancelled)
 
     private fun boundedEventTail(
         events: List<RecordedDiagnosticEvent>,
@@ -2115,12 +2011,6 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
     private fun boundedCaptureEntries(entries: List<String>): String =
         entries.takeLast(DIAGNOSTIC_CAPTURE_LIMIT_COUNT)
             .joinToString(prefix = "[", postfix = "]") { it.take(DIAGNOSTIC_CAPTURE_LIMIT) }
-
-    private fun CopyOnWriteArrayList<String>.addBounded(value: String) {
-        if (size < DIAGNOSTIC_CAPTURE_LIMIT_COUNT) {
-            add(value.take(DIAGNOSTIC_CAPTURE_LIMIT))
-        }
-    }
 
     private fun waitForIssue1739CapturePrecondition(
         label: String,
@@ -2587,8 +2477,6 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         const val DIAGNOSTIC_FIELD_COUNT: Int = 10
         const val DIAGNOSTIC_FIELD_KEY_LIMIT: Int = 64
         const val DIAGNOSTIC_FIELD_VALUE_LIMIT: Int = 160
-        const val DIAGNOSTIC_ROW_TAIL_COUNT: Int = 4
-        const val DIAGNOSTIC_ID_LIMIT: Int = 96
         val DEFERRAL_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 30_000L
 

--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
@@ -18,19 +18,24 @@ import com.pocketshell.core.tmux.TmuxClientDiagnosticSink
 import com.pocketshell.core.tmux.TmuxClientDiagnostics
 import com.pocketshell.core.tmux.TmuxClientFactory
 import java.io.File
+import java.io.IOException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -64,10 +69,14 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
 
     private val projectRoot: Path by lazy { findProjectRoot() }
     private var container: GenericContainer<*>? = null
+    private var mainDispatcher: ExecutorCoroutineDispatcher? = null
 
     @Before
     fun setUpMain() {
-        Dispatchers.setMain(Dispatchers.Unconfined)
+        mainDispatcher = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "issue1952-main").apply { isDaemon = true }
+        }.asCoroutineDispatcher()
+        Dispatchers.setMain(requireNotNull(mainDispatcher))
     }
 
     @After
@@ -76,6 +85,8 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
         runCatching { container?.stop() }
         container = null
         Dispatchers.resetMain()
+        mainDispatcher?.close()
+        mainDispatcher = null
     }
 
     @Test
@@ -83,8 +94,9 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
         startDockerOrFail()
         val fixture = requireNotNull(container)
         val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val connector = SustainedOutageLeaseConnector(DefaultSshLeaseConnector())
         val leaseManager = SshLeaseManager(
-            connector = DefaultSshLeaseConnector(),
+            connector = connector,
             scope = ioScope,
             idleTtlMillis = 60_000L,
         )
@@ -124,7 +136,11 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
                 graceMs = PASSIVE_GRACE_MS,
                 silentReattachTimeoutMs = REATTACH_TIMEOUT_MS,
             )
-            vm.forceCleanOutageForTest = true
+            // Issue #1965: hold the authoritative lease-manager connector down, not a
+            // VM-local reconnect primitive. Confirmed-dead recovery now acquires through
+            // DeadLeaseRecoveryAuthority, so the sustained outage must govern that exact
+            // manager-new transport path as well as every later retry.
+            connector.outageActive = true
             val killedPeerPids = killAuthenticatedSshdProcessesFromServer()
             assertTrue("the Docker peer fault must kill at least one sshd process", killedPeerPids.isNotEmpty())
 
@@ -145,15 +161,33 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
             assertEquals("remote_failure", journalDrop["cause"])
             assertEquals(typedReason, journalDrop["causeReason"])
 
-            val maxAttempt = awaitAttemptBeyondOne(vm)
+            val maxAttempt = awaitAttemptBeyondOne(diagnostics, connector)
             assertTrue(
                 "sustained failure must progress beyond attempt 1; maxAttempt=$maxAttempt " +
                     "state=${vm.connectionControllerStateForTest()}",
                 maxAttempt >= 2,
             )
+            assertTrue(
+                "sustained outage must reject the authoritative fresh-lease acquisition",
+                connector.blockedConnectCount > 0,
+            )
             assertExactlyOneRecoveryStart(diagnostics, firstClientHash)
 
-            vm.forceCleanOutageForTest = false
+            // The attempt-2 journal edge is emitted before the auto-ladder's blocked dial
+            // has fully terminalized. Starting manual Reconnect at that edge races the stale
+            // ladder: it can submit reconnect_gave_up after the fresh dial submits
+            // transport_live, leaving the controller Unreachable. Wait for the ladder's
+            // authoritative reconnect_gave_up projection, then cross the serialized Main
+            // dispatcher as a queue barrier before entering Reconnect there. This synchronizes
+            // on behavior and ownership quiescence, not elapsed time.
+            awaitSustainedOutageTerminalization(vm, diagnostics)
+
+            connector.outageActive = false
+            assertTrue(
+                "the explicit Reconnect entrypoint must re-enter the retained same-session target " +
+                    "after the sustained outage",
+                withContext(Dispatchers.Main.immediate) { vm.reconnect() },
+            )
             awaitCondition(RECOVERY_TIMEOUT_MS, "fresh-client recovery to Live") {
                 vm.connectionControllerStateForTest() is ConnectionState.Live &&
                     vm.liveTmuxClientForSendOrNullForTest()?.let { client ->
@@ -182,6 +216,11 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
                 firstSshIdentity.transport,
                 recoveredSshIdentity.transport,
             )
+            assertEquals(
+                "initial attach plus one recovered manager-new SSH handshake",
+                2,
+                connector.successfulConnectCount,
+            )
 
             val afterMarker = "ISSUE1952-AFTER-${System.nanoTime().toString(36)}"
             sendAndAwaitMarker(recoveredClient, afterMarker)
@@ -195,11 +234,27 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
                     "maxAttempt=$maxAttempt firstClient=$firstClientHash " +
                     "recoveredClient=${System.identityHashCode(recoveredClient)} " +
                     "firstSsh=$firstSshIdentity recoveredSsh=$recoveredSshIdentity " +
+                    "connectorAttempts=${connector.connectCount} " +
+                    "connectorBlocked=${connector.blockedConnectCount} " +
                     "peerKilledPids=$killedPeerPids",
             )
             println("ISSUE1952_REAL_TRANSCRIPT\n$transcript")
         } finally {
-            vm?.forceCleanOutageForTest = false
+            println(
+                "ISSUE1952_FINAL_DIAGNOSTICS\n" +
+                    diagnostics.events
+                        .filter { event ->
+                            event.category == ConnectionJournalSchema.CATEGORY ||
+                                event.name == "silent_reattach_start" ||
+                                event.name == "silent_reattach_failed" ||
+                                event.name == "auto_reconnect_decision" ||
+                                event.name == "dead_lease_recovery"
+                        }
+                        .joinToString("\n") { event ->
+                            "${event.category}/${event.name} ${event.fields}"
+                        },
+            )
+            connector.outageActive = false
             vm?.cancelOwnScopesForTest()
             vm?.clearForTest()
             runCatching { cleanupSession() }
@@ -558,14 +613,51 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
         return matches.single()
     }
 
-    private suspend fun awaitAttemptBeyondOne(vm: TmuxSessionViewModel): Int {
+    private suspend fun awaitAttemptBeyondOne(
+        diagnostics: RecordingDiagnosticEventSink,
+        connector: SustainedOutageLeaseConnector,
+    ): Int {
         var maxAttempt = 0
-        awaitCondition(ATTEMPT_PROGRESS_TIMEOUT_MS, "controller attempt > 1") {
-            val state = vm.connectionControllerStateForTest()
-            if (state is ConnectionState.Reconnecting) maxAttempt = maxOf(maxAttempt, state.attempt)
+        awaitCondition(ATTEMPT_PROGRESS_TIMEOUT_MS, "controller journal attempt > 1") {
+            maxAttempt = diagnostics.events
+                .asSequence()
+                .filter { event ->
+                    event.category == ConnectionJournalSchema.CATEGORY &&
+                        event.name == ConnectionJournalSchema.SUBMIT &&
+                        event.fields["event"] == "reconnect_failed"
+                }
+                .mapNotNull { event -> (event.fields["postAttempt"] as? Number)?.toInt() }
+                .maxOrNull() ?: maxAttempt
             maxAttempt >= 2
         }
+        assertTrue(
+            "controller journal must reach attempt > 1; maxAttempt=$maxAttempt " +
+                "connectorAttempts=${connector.connectCount} blocked=${connector.blockedConnectCount}",
+            maxAttempt >= 2,
+        )
         return maxAttempt
+    }
+
+    private suspend fun awaitSustainedOutageTerminalization(
+        vm: TmuxSessionViewModel,
+        diagnostics: RecordingDiagnosticEventSink,
+    ) {
+        awaitCondition(ATTEMPT_PROGRESS_TIMEOUT_MS, "sustained outage reconnect gave up") {
+            diagnostics.events.any { event ->
+                event.category == ConnectionJournalSchema.CATEGORY &&
+                    event.name == ConnectionJournalSchema.SUBMIT &&
+                    event.fields["event"] == "reconnect_gave_up"
+            }
+        }
+        // reconnect_gave_up is submitted synchronously on the dedicated test Main thread.
+        // Crossing that same dispatcher guarantees the stale recovery owner has finished its
+        // terminal projection before the test is allowed to restore and manually reconnect.
+        withContext(Dispatchers.Main.immediate) { }
+        assertTrue(
+            "the blocked auto-ladder must finish in Unreachable before manual Reconnect; " +
+                "state=${vm.connectionControllerStateForTest()}",
+            vm.connectionControllerStateForTest() is ConnectionState.Unreachable,
+        )
     }
 
     private fun assertExactlyOneRecoveryStart(
@@ -641,6 +733,42 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
                     .stackTraceToString(),
             )
             return delegate.connect(target)
+        }
+    }
+
+    /**
+     * Issue #1965 sustained-outage authority seam. Unlike the older VM-local primitive
+     * seam, this wraps the connector owned by [SshLeaseManager], so every manager-new
+     * acquisition is deterministically unavailable until the test restores the link.
+     */
+    private class SustainedOutageLeaseConnector(
+        private val delegate: SshLeaseConnector,
+    ) : SshLeaseConnector {
+        private val attempts = AtomicInteger(0)
+        private val blockedAttempts = AtomicInteger(0)
+        private val successfulAttempts = AtomicInteger(0)
+
+        @Volatile
+        var outageActive: Boolean = false
+
+        val connectCount: Int
+            get() = attempts.get()
+
+        val blockedConnectCount: Int
+            get() = blockedAttempts.get()
+
+        val successfulConnectCount: Int
+            get() = successfulAttempts.get()
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val attempt = attempts.incrementAndGet()
+            if (outageActive) {
+                blockedAttempts.incrementAndGet()
+                return Result.failure(IOException("synthetic sustained outage at connector attempt $attempt"))
+            }
+            return delegate.connect(target).also { result ->
+                if (result.isSuccess) successfulAttempts.incrementAndGet()
+            }
         }
     }
 

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -371,10 +371,20 @@ public interface OutboundQueueStore {
      * turnover has not yet been proven. A rebuilt sender must fail closed instead
      * of issuing another Enter or pruning the row from tmux write completion.
      */
-    public fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem?
+    public fun markWireSubmitAttempted(
+        sessionKey: String,
+        itemId: String,
+        transcriptBaseline: OutboundSubmitTranscriptBaseline? = null,
+    ): OutboundItem?
 
     /** Whether Enter was attempted without a proven agent-side turnover. */
     public fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean
+
+    /** Transcript authority captured by the same synchronous pre-Enter write-ahead. */
+    public fun wireSubmitTranscriptBaseline(
+        sessionKey: String,
+        itemId: String,
+    ): OutboundSubmitTranscriptBaseline?
 
     /**
      * Issue #1577: the durable [OutboundItem.wireNeedleBaselineCount] recorded for
@@ -417,9 +427,18 @@ public interface OutboundWireAttemptDurableStore {
     public fun hasWireAttempt(sessionKey: String, itemId: String): Boolean
 
     /** Returns true only after the submit latch is durably acknowledged. */
-    public fun recordWireSubmitAttempt(sessionKey: String, itemId: String): Boolean
+    public fun recordWireSubmitAttempt(
+        sessionKey: String,
+        itemId: String,
+        transcriptBaseline: OutboundSubmitTranscriptBaseline? = null,
+    ): Boolean
 
     public fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean
+
+    public fun wireSubmitTranscriptBaseline(
+        sessionKey: String,
+        itemId: String,
+    ): OutboundSubmitTranscriptBaseline?
 
     /** Issue #1577: durable pre-send needle baseline for exact row, or `null`. */
     public fun wireNeedleBaseline(sessionKey: String, itemId: String): Int?
@@ -450,11 +469,25 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
         override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean =
             this@asWireAttemptDurableStore.hasWireAttempt(sessionKey, itemId)
 
-        override fun recordWireSubmitAttempt(sessionKey: String, itemId: String): Boolean =
-            this@asWireAttemptDurableStore.markWireSubmitAttempted(sessionKey, itemId) != null
+        override fun recordWireSubmitAttempt(
+            sessionKey: String,
+            itemId: String,
+            transcriptBaseline: OutboundSubmitTranscriptBaseline?,
+        ): Boolean =
+            this@asWireAttemptDurableStore.markWireSubmitAttempted(
+                sessionKey,
+                itemId,
+                transcriptBaseline,
+            ) != null
 
         override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean =
             this@asWireAttemptDurableStore.hasWireSubmitAttempt(sessionKey, itemId)
+
+        override fun wireSubmitTranscriptBaseline(
+            sessionKey: String,
+            itemId: String,
+        ): OutboundSubmitTranscriptBaseline? =
+            this@asWireAttemptDurableStore.wireSubmitTranscriptBaseline(sessionKey, itemId)
 
         override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? =
             this@asWireAttemptDurableStore.wireNeedleBaseline(sessionKey, itemId)
@@ -525,6 +558,13 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
  * @property tmuxSessionCreated tap-time tmux creation epoch paired with
  *   [tmuxSessionId]; both fields are required for identity promotion.
  */
+public data class OutboundSubmitTranscriptBaseline(
+    val sourcePath: String,
+    val agentSessionId: String?,
+    val agentKind: String,
+    val confirmedMatchingIds: Set<String>,
+)
+
 public data class OutboundItem(
     val id: String,
     val sessionKey: String,
@@ -545,6 +585,7 @@ public data class OutboundItem(
     val wireNeedleBaselineCount: Int? = null,
     val wireCollapsedMarkerBaselineCount: Int? = null,
     val wireSubmitAttempted: Boolean = false,
+    val wireSubmitTranscriptBaseline: OutboundSubmitTranscriptBaseline? = null,
     /** Tap-time tmux generation. Both fields are required for identity promotion. */
     val tmuxSessionId: String? = null,
     val tmuxSessionCreated: Long? = null,
@@ -841,17 +882,33 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
         items[itemId]?.let { it.sessionKey == sessionKey && it.wireAttempted } == true
     }
 
-    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = synchronized(lock) {
+    override fun markWireSubmitAttempted(
+        sessionKey: String,
+        itemId: String,
+        transcriptBaseline: OutboundSubmitTranscriptBaseline?,
+    ): OutboundItem? = synchronized(lock) {
         val target = items[itemId]
             ?.takeIf { it.sessionKey == sessionKey && it.state != OutboundState.Delivered }
             ?: return null
-        val updated = target.copy(wireSubmitAttempted = true)
+        val updated = target.copy(
+            wireSubmitAttempted = true,
+            wireSubmitTranscriptBaseline = target.wireSubmitTranscriptBaseline ?: transcriptBaseline,
+        )
         items[itemId] = updated
         updated
     }
 
     override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean = synchronized(lock) {
         items[itemId]?.let { it.sessionKey == sessionKey && it.wireSubmitAttempted } == true
+    }
+
+    override fun wireSubmitTranscriptBaseline(
+        sessionKey: String,
+        itemId: String,
+    ): OutboundSubmitTranscriptBaseline? = synchronized(lock) {
+        items[itemId]
+            ?.takeIf { it.sessionKey == sessionKey && it.wireSubmitAttempted }
+            ?.wireSubmitTranscriptBaseline
     }
 
     override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = synchronized(lock) {
@@ -929,9 +986,17 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     ): OutboundItem? = null
     override fun hasWireAttempt(sessionKey: String, itemId: String): Boolean = false
 
-    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = null
+    override fun markWireSubmitAttempted(
+        sessionKey: String,
+        itemId: String,
+        transcriptBaseline: OutboundSubmitTranscriptBaseline?,
+    ): OutboundItem? = null
 
     override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean = false
+    override fun wireSubmitTranscriptBaseline(
+        sessionKey: String,
+        itemId: String,
+    ): OutboundSubmitTranscriptBaseline? = null
     override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = null
     override fun wireCollapsedMarkerBaseline(sessionKey: String, itemId: String): Int? = null
 }
@@ -1302,12 +1367,19 @@ public class SharedPrefsOutboundQueueStore internal constructor(
         }
     }
 
-    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = synchronized(lock) {
+    override fun markWireSubmitAttempted(
+        sessionKey: String,
+        itemId: String,
+        transcriptBaseline: OutboundSubmitTranscriptBaseline?,
+    ): OutboundItem? = synchronized(lock) {
         val list = loadSession(sessionKey)
         val target = list.firstOrNull {
             it.id == itemId && it.sessionKey == sessionKey && it.state != OutboundState.Delivered
         } ?: return null
-        val updated = target.copy(wireSubmitAttempted = true)
+        val updated = target.copy(
+            wireSubmitAttempted = true,
+            wireSubmitTranscriptBaseline = target.wireSubmitTranscriptBaseline ?: transcriptBaseline,
+        )
         val idx = list.indexOfFirst { it.id == updated.id }
         if (idx >= 0) list[idx] = updated else list.add(updated)
         // This one write is the pre-Enter write-ahead barrier. apply() is not an
@@ -1320,6 +1392,15 @@ public class SharedPrefsOutboundQueueStore internal constructor(
         loadSession(sessionKey).any {
             it.id == itemId && it.sessionKey == sessionKey && it.wireSubmitAttempted
         }
+    }
+
+    override fun wireSubmitTranscriptBaseline(
+        sessionKey: String,
+        itemId: String,
+    ): OutboundSubmitTranscriptBaseline? = synchronized(lock) {
+        loadSession(sessionKey).firstOrNull {
+            it.id == itemId && it.sessionKey == sessionKey && it.wireSubmitAttempted
+        }?.wireSubmitTranscriptBaseline
     }
 
     override fun wireNeedleBaseline(sessionKey: String, itemId: String): Int? = synchronized(lock) {
@@ -1502,7 +1583,7 @@ internal fun blobKey(sessionKey: String): String = "@q/$sessionKey"
 /**
  * Issue #900: encode a session's outbound items as newline-separated rows.
  * Each row is tab-delimited:
- * `id \t cleanText \t withEnter \t state \t createdAtMs \t lastAttemptAtMs \t attemptCount \t lastError \t attachmentsBlob \t paneId \t route \t agentKind \t sendKey \t wireAttempted \t wireAttemptedAtMs \t wireNeedleBaselineCount \t wireCollapsedMarkerBaselineCount \t tmuxSessionId \t tmuxSessionCreated \t wireSubmitAttempted`
+ * `id ... wireSubmitAttempted \t transcriptSource \t transcriptSession \t transcriptAgent \t transcriptBaselineIds`
  * with the same `\`-escaping [ComposerDraftStore] uses so text/paths containing
  * tabs/newlines round-trip losslessly. The attachments field reuses
  * [encodeAttachments], itself escaped as a single field. Trailing fields
@@ -1535,6 +1616,12 @@ internal fun encodeOutboundItems(items: List<OutboundItem>): String =
             item.tmuxSessionId.orEmpty(),
             item.tmuxSessionCreated?.toString().orEmpty(),
             if (item.wireSubmitAttempted) "1" else "0",
+            item.wireSubmitTranscriptBaseline?.sourcePath.orEmpty(),
+            item.wireSubmitTranscriptBaseline?.agentSessionId.orEmpty(),
+            item.wireSubmitTranscriptBaseline?.agentKind.orEmpty(),
+            item.wireSubmitTranscriptBaseline?.confirmedMatchingIds
+                ?.joinToString(separator = "\n")
+                .orEmpty(),
         ).joinToString(separator = "\t") { escapeQueueField(it) }
     }
 
@@ -1572,6 +1659,20 @@ internal fun decodeOutboundItems(sessionKey: String, raw: String): List<Outbound
             tmuxSessionId = f.getOrNull(17)?.takeIf { it.isNotEmpty() },
             tmuxSessionCreated = f.getOrNull(18)?.takeIf { it.isNotEmpty() }?.toLongOrNull(),
             wireSubmitAttempted = f.getOrNull(19) == "1",
+            wireSubmitTranscriptBaseline = f.getOrNull(20)
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { sourcePath ->
+                    OutboundSubmitTranscriptBaseline(
+                        sourcePath = sourcePath,
+                        agentSessionId = f.getOrNull(21)?.takeIf { it.isNotEmpty() },
+                        agentKind = f.getOrNull(22).orEmpty(),
+                        confirmedMatchingIds = f.getOrNull(23)
+                            ?.takeIf { it.isNotEmpty() }
+                            ?.split('\n')
+                            ?.toSet()
+                            .orEmpty(),
+                    )
+                },
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentTranscriptAuthority.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentTranscriptAuthority.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.composer.OutboundSubmitTranscriptBaseline
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.session.AgentConversationSyncStatus
 import com.pocketshell.app.session.AgentConversationUiState
@@ -26,7 +27,14 @@ internal class AgentTranscriptAuthority(
     internal data class Baseline(
         val detection: AgentDetection,
         val confirmedMatchingIds: Set<String>,
-    )
+    ) {
+        fun durable(): OutboundSubmitTranscriptBaseline = OutboundSubmitTranscriptBaseline(
+            sourcePath = detection.sourcePath,
+            agentSessionId = detection.sessionId,
+            agentKind = detection.agent.name,
+            confirmedMatchingIds = confirmedMatchingIds,
+        )
+    }
 
     private val activeOverrides = mutableSetOf<String>()
     private val startingOverrides = mutableSetOf<String>()
@@ -112,6 +120,36 @@ internal class AgentTranscriptAuthority(
             "sourceHash" to baseline.detection.sourcePath.hashCode().toUInt().toString(16),
             "agentSessionId" to baseline.detection.sessionId,
             "agent" to baseline.detection.agent.name,
+        )
+        return true
+    }
+
+    fun acknowledgedFromDurableBaseline(
+        paneId: String,
+        payload: String,
+        baseline: OutboundSubmitTranscriptBaseline,
+    ): Boolean {
+        val conversation = conversationForPane(paneId) ?: return false
+        val detection = conversation.detection ?: return false
+        if (
+            detection.sourcePath != baseline.sourcePath ||
+            detection.sessionId != baseline.agentSessionId ||
+            detection.agent.name != baseline.agentKind ||
+            !isActive(paneId, detection)
+        ) {
+            return false
+        }
+        val confirmed = conversation.events.filterIsInstance<ConversationEvent.Message>().firstOrNull {
+            it.isConfirmedTranscriptUser(payload) && it.id !in baseline.confirmedMatchingIds
+        } ?: return false
+        DiagnosticEvents.record(
+            "action",
+            "agent_submit_transcript_late_ack",
+            "pane" to paneId,
+            "eventId" to confirmed.id,
+            "sourceHash" to detection.sourcePath.hashCode().toUInt().toString(16),
+            "agentSessionId" to detection.sessionId,
+            "agent" to detection.agent.name,
         )
         return true
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/LateAuthoritativeSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/LateAuthoritativeSubmitAck.kt
@@ -1,0 +1,24 @@
+package com.pocketshell.app.tmux
+
+/**
+ * Resolves a previously ambiguous submit from a transcript turn that became
+ * authoritative after the original bounded turnover wait expired.
+ *
+ * The durable pre-Enter baseline keeps this fail-closed: only a newly
+ * confirmed exact-payload turn on the same recorded source can acknowledge the
+ * row, and a successful acknowledgement consumes the volatile attempt ledger
+ * without issuing another paste or Enter.
+ */
+internal fun OutboundDeliveryLedger.resolveLateAuthoritativeTranscriptAck(
+    transcriptAuthority: AgentTranscriptAuthority,
+    paneId: String,
+    payload: String,
+    sendToken: String,
+    durableRow: DurableOutboundRowIdentity?,
+): Boolean {
+    if (durableRow == null || !hasSubmitAttempt(paneId, sendToken, durableRow)) return false
+    val baseline = submitTranscriptBaseline(durableRow) ?: return false
+    if (!transcriptAuthority.acknowledgedFromDurableBaseline(paneId, payload, baseline)) return false
+    clear(paneId, sendToken)
+    return true
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.tmux
 
 import android.util.Log
 import com.pocketshell.app.composer.OutboundQueueStore
+import com.pocketshell.app.composer.OutboundSubmitTranscriptBaseline
 import com.pocketshell.app.composer.OutboundWireAttemptDurableStore
 import com.pocketshell.app.composer.asWireAttemptDurableStore
 import com.pocketshell.app.diagnostics.DiagnosticEvents
@@ -427,9 +428,14 @@ internal class OutboundDeliveryLedger(
         paneId: String,
         sendToken: String,
         durableRow: DurableOutboundRowIdentity? = null,
+        transcriptBaseline: OutboundSubmitTranscriptBaseline? = null,
     ): Boolean = synchronized(lock) {
         val durableAcknowledged = durableRow?.let { row ->
-            durable?.recordWireSubmitAttempt(row.sessionKey, row.rowId) == true
+            durable?.recordWireSubmitAttempt(
+                row.sessionKey,
+                row.rowId,
+                transcriptBaseline,
+            ) == true
         } ?: true
         if (!durableAcknowledged) return false
         submitAttempts += key(paneId, sendToken)
@@ -443,6 +449,12 @@ internal class OutboundDeliveryLedger(
     ): Boolean = synchronized(lock) {
         key(paneId, sendToken) in submitAttempts ||
             durableRow?.let { durable?.hasWireSubmitAttempt(it.sessionKey, it.rowId) } == true
+    }
+
+    fun submitTranscriptBaseline(
+        durableRow: DurableOutboundRowIdentity,
+    ): OutboundSubmitTranscriptBaseline? = synchronized(lock) {
+        durable?.wireSubmitTranscriptBaseline(durableRow.sessionKey, durableRow.rowId)
     }
 
     fun hasAmbiguousAttempt(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14209,21 +14209,20 @@ public class TmuxSessionViewModel @Inject constructor(
                 scrollbackLines = scrollbackLines,
             ).takeIf { it.status == AgentPaneCaptureStatus.Captured }?.response
         }
+        if (outboundDeliveryLedger.resolveLateAuthoritativeTranscriptAck(agentTranscriptAuthority, paneId, payload, sendToken, durableRow)) return Result.success(Unit).also { requestReconcile(client, paneId, ReconcileReason.Send) }
         // Issue #1526 S1 (verify-before-resend): a PRIOR ambiguous attempt for THIS send —
         // keyed by the #1529 [sendToken], NOT the payload, so two distinct identical sends
         // never false-dedup — the paste may have run server-side (audit A1/A2). Probe (#869
         // needle, #1577 baseline): landed ⇒ Enter ONLY; unknown ⇒ fail; else full send.
-        when (
-            verifyBeforeAgentResend(
-                outboundDeliveryLedger,
-                client,
-                paneId,
-                sendToken,
-                payload,
-                durableRow = durableRow,
-                capturePane = boundedCapture,
-            )
-        ) {
+        when (verifyBeforeAgentResend(
+            outboundDeliveryLedger,
+            client,
+            paneId,
+            sendToken,
+            payload,
+            durableRow = durableRow,
+            capturePane = boundedCapture,
+        )) {
             DeliveryProbeOutcome.AlreadyLanded -> return try {
                 check(isCurrentAgentSendRuntime(runtimeIdentity, paneId)) {
                     "Agent send runtime changed after verify-before-resend."
@@ -14238,7 +14237,7 @@ public class TmuxSessionViewModel @Inject constructor(
                 val transcriptBaseline = agentTranscriptAuthority.baselineFor(deliveryProof, paneId, payload)
                 durableRow?.let { row ->
                     check(withContext(seedIoDispatcher) {
-                        outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row)
+                        outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row, transcriptBaseline?.durable())
                     }) { "Agent submit write-ahead persistence failed; Enter not sent." }
                 }
                 sendNamedKeyToPane(client, paneId, "Enter")
@@ -14357,7 +14356,7 @@ public class TmuxSessionViewModel @Inject constructor(
             val transcriptBaseline = agentTranscriptAuthority.baselineFor(deliveryProof, paneId, payload)
             durableRow?.let { row ->
                 check(withContext(seedIoDispatcher) {
-                    outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row)
+                    outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row, transcriptBaseline?.durable())
                 }) { "Agent submit write-ahead persistence failed; Enter not sent." }
             }
             sendNamedKeyToPane(client, paneId, "Enter")

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreEncodingTest.kt
@@ -185,6 +185,12 @@ class OutboundQueueStoreEncodingTest {
                 wireNeedleBaselineCount = 1,
                 wireCollapsedMarkerBaselineCount = 2,
                 wireSubmitAttempted = true,
+                wireSubmitTranscriptBaseline = OutboundSubmitTranscriptBaseline(
+                    sourcePath = "/home/u/.codex/sessions/rollout.jsonl",
+                    agentSessionId = "rollout-1",
+                    agentKind = "Codex",
+                    confirmedMatchingIds = linkedSetOf("existing-1", "existing-2"),
+                ),
             ),
         )
         val decoded = decodeOutboundItems("sessA", encodeOutboundItems(items))
@@ -192,6 +198,7 @@ class OutboundQueueStoreEncodingTest {
         assertEquals(1, decoded.single().wireNeedleBaselineCount)
         assertEquals(2, decoded.single().wireCollapsedMarkerBaselineCount)
         assertTrue(decoded.single().wireSubmitAttempted)
+        assertEquals(items.single().wireSubmitTranscriptBaseline, decoded.single().wireSubmitTranscriptBaseline)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
@@ -116,14 +116,42 @@ class OutboundQueueStoreWireAttemptTest {
         store.claim(row.id)
         store.markWireAttempted("sessA", row.id, baselineCount = 0)
 
-        val attempted = requireNotNull(store.markWireSubmitAttempted("sessA", row.id))
+        val baseline = OutboundSubmitTranscriptBaseline(
+            sourcePath = "/home/u/.codex/sessions/rollout.jsonl",
+            agentSessionId = "rollout",
+            agentKind = "Codex",
+            confirmedMatchingIds = setOf("old-turn"),
+        )
+        val attempted = requireNotNull(store.markWireSubmitAttempted("sessA", row.id, baseline))
         assertTrue(attempted.wireSubmitAttempted)
         assertTrue(store.hasWireSubmitAttempt("sessA", row.id))
+        assertEquals(baseline, store.wireSubmitTranscriptBaseline("sessA", row.id))
 
         store.requeueForRetry(row.id)
         assertTrue("requeue must preserve Enter ambiguity", store.hasWireSubmitAttempt("sessA", row.id))
         store.remove(row.id)
         assertFalse("row removal drops the latch with the row", store.hasWireSubmitAttempt("sessA", row.id))
+    }
+
+    @Test
+    fun submitTranscriptBaselineSurvivesProcessRestart() {
+        val first = SharedPrefsOutboundQueueStore(context)
+        val row = first.enqueue("sess-submit-baseline", "late ack", paneId = "%0")
+        first.markWireAttempted("sess-submit-baseline", row.id, baselineCount = 0)
+        val baseline = OutboundSubmitTranscriptBaseline(
+            sourcePath = "/home/u/.claude/projects/p/session.jsonl",
+            agentSessionId = "session-1",
+            agentKind = "ClaudeCode",
+            confirmedMatchingIds = linkedSetOf("same-payload-before-enter"),
+        )
+        requireNotNull(first.markWireSubmitAttempted("sess-submit-baseline", row.id, baseline))
+
+        val afterRestart = SharedPrefsOutboundQueueStore(context)
+        assertTrue(afterRestart.hasWireSubmitAttempt("sess-submit-baseline", row.id))
+        assertEquals(
+            baseline,
+            afterRestart.wireSubmitTranscriptBaseline("sess-submit-baseline", row.id),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/proof/FakeAgentTranscriptJsonTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/FakeAgentTranscriptJsonTest.kt
@@ -1,0 +1,69 @@
+package com.pocketshell.app.proof
+
+import com.pocketshell.core.agents.ClaudeCodeParser
+import com.pocketshell.core.agents.ConversationEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+
+/** Issue #1526: the Docker submit oracle must emit parseable multiline JSONL. */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class FakeAgentTranscriptJsonTest {
+
+    @Test
+    fun multilineSubmitIsJsonEscapedAndParsedAsTheExactClaudeUserTurn() {
+        val script = projectRoot().resolve(FAKE_AGENT_SCRIPT)
+        val source = String(Files.readAllBytes(script), Charsets.UTF_8)
+        assertTrue(
+            "the live transcript write must use the tested JSON encoder",
+            source.contains("transcript_text=\$(json_escape \"\$submit_buffer\")"),
+        )
+
+        val payload = "first line\nsecond \"quoted\" \\ path\tend"
+        val command = """
+            set -eu
+            LF=${'$'}'\n'
+            CR=${'$'}'\r'
+            source <(sed -n '/^json_escape()/,/^}/p' "${'$'}1")
+            json_escape "${'$'}PAYLOAD"
+        """.trimIndent()
+        val process = ProcessBuilder("bash", "-c", command, "fake-agent-json-test", script.toString())
+            .directory(projectRoot().toFile())
+            .redirectErrorStream(true)
+            .apply { environment()["PAYLOAD"] = payload }
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        val completed = process.waitFor(10, TimeUnit.SECONDS)
+        if (!completed) process.destroyForcibly()
+        assertTrue("fixture JSON encoder timed out", completed)
+        assertEquals("fixture JSON encoder failed: $output", 0, process.exitValue())
+
+        val jsonl =
+            """{"uuid":"fake-agent-user-1","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"$output"}}"""
+        val parsed = ClaudeCodeParser().parseLine(jsonl)
+            .filterIsInstance<ConversationEvent.Message>()
+            .single()
+        assertEquals(payload, parsed.text)
+    }
+
+    private fun projectRoot(): Path {
+        var candidate: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+        while (candidate != null) {
+            if (Files.exists(candidate.resolve(FAKE_AGENT_SCRIPT))) return candidate
+            candidate = candidate.parent
+        }
+        error("Could not locate $FAKE_AGENT_SCRIPT from ${System.getProperty("user.dir")}")
+    }
+
+    private companion object {
+        const val FAKE_AGENT_SCRIPT = "tests/docker/agent-bin/pocketshell-fake-agent"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1577BurstTuiSubmitTest.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -381,6 +383,59 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
         assertTrue("ack must remain inside the 2s transcript ceiling: elapsed=$elapsed", elapsed < 2_000L)
     }
 
+    /**
+     * Issue #1526 recurrence after #1944: Enter can reach the agent while its
+     * authoritative transcript tail lands just after the bounded turnover wait.
+     * The durable submit write-ahead correctly prevents another blind Enter, but
+     * it must not wedge the row forever: a later retry can safely complete from a
+     * new confirmed turn on the exact source that was baselined before Enter.
+     */
+    @Test
+    fun lateAuthoritativeTranscriptAckCompletesSubmitAttemptWithoutSecondEnter() = runTest(scheduler) {
+        val payload = "late transcript acknowledgement"
+        lateinit var vm: TmuxSessionViewModel
+        val client = BurstTuiFakeTmuxClient(
+            footer = footer,
+            busyReadDelayCaptures = 0,
+            forceNoPromptFrames = true,
+            onEnter = {
+                backgroundScope.launch {
+                    delay(2_100L)
+                    vm.appendAgentEventsForTest(
+                        "%0",
+                        listOf(transcriptUserTurn("confirmed-after-timeout", payload)),
+                    )
+                }
+            },
+        )
+        vm = newBurstVm(client)
+        vm.setAgentTranscriptAuthorityForTest("%0", true)
+        val row = durableRow("late-ack-row", payload)
+
+        val first = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "late-ack-row",
+            durableRow = row,
+        )
+        assertTrue("the first bounded turnover wait must retain the row", first.isFailure)
+        assertEquals(1, client.sentCommands.count { it.endsWith(" Enter") })
+
+        advanceTimeBy(100L)
+        runCurrent()
+        val retry = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "late-ack-row",
+            durableRow = row,
+        )
+
+        assertTrue(retry.exceptionOrNull()?.message, retry.isSuccess)
+        assertEquals(
+            "late transcript authority proves the original Enter; retry must not duplicate it",
+            1,
+            client.sentCommands.count { it.endsWith(" Enter") },
+        )
+    }
+
     @Test
     fun preExistingOrOptimisticTranscriptTurnsDoNotAcknowledgeSubmit() = runTest(scheduler) {
         val payload = "identical prompt"
@@ -406,6 +461,14 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
         )
 
         assertTrue("no new authoritative transcript turn must retain the row", result.isFailure)
+
+        val retry = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "existing-row",
+            durableRow = DurableOutboundRowIdentity("session-a", "existing-row"),
+        )
+        assertTrue("the persisted baseline must not accept an old identical turn", retry.isFailure)
+        assertEquals(1, client.sentCommands.count { it.endsWith(" Enter") })
     }
 
     @Test
@@ -458,6 +521,14 @@ class Issue1577BurstTuiSubmitTest : TmuxSessionViewModelTestBase() {
         )
 
         assertTrue("a replacement detection/source must retain the row", result.isFailure)
+
+        val retry = vm.sendAgentPayloadToPaneResult(
+            "%0", payload, AgentKind.Codex,
+            sendToken = "wrong-source-row",
+            durableRow = DurableOutboundRowIdentity("session-a", "wrong-source-row"),
+        )
+        assertTrue("a late turn from a replacement source must not resolve the old submit", retry.isFailure)
+        assertEquals(1, client.sentCommands.count { it.endsWith(" Enter") })
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundBackNavExactlyOnceTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.composer.OutboundRoute
 import com.pocketshell.app.composer.OutboundItem
 import com.pocketshell.app.composer.OutboundQueueStore
+import com.pocketshell.app.composer.OutboundSubmitTranscriptBaseline
 import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
@@ -345,8 +346,12 @@ private class SubmitLatchFaultStore(
     private val delegate: OutboundQueueStore,
     var fault: SubmitLatchFault,
 ) : OutboundQueueStore by delegate {
-    override fun markWireSubmitAttempted(sessionKey: String, itemId: String): OutboundItem? = when (fault) {
-        SubmitLatchFault.None -> delegate.markWireSubmitAttempted(sessionKey, itemId)
+    override fun markWireSubmitAttempted(
+        sessionKey: String,
+        itemId: String,
+        transcriptBaseline: OutboundSubmitTranscriptBaseline?,
+    ): OutboundItem? = when (fault) {
+        SubmitLatchFault.None -> delegate.markWireSubmitAttempted(sessionKey, itemId, transcriptBaseline)
         SubmitLatchFault.ReturnFalse -> null
         SubmitLatchFault.Throw -> error("synthetic submit-latch persistence failure")
     }

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -92,7 +92,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
   "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
-  "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"
   "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayStaleChannelHealDockerTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -304,7 +304,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
   "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
-  "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"
   "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayStaleChannelHealDockerTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -136,6 +136,7 @@ JOURNEY_CLASSES=(
   "$FQCN_PREFIX.ServerDeathReconnectNoResurrectE2eTest"  # #998 a remote tmux SERVER death (host reboot / OOM
   "$FQCN_PREFIX.AttachmentDropReconnectRecoversE2eTest"  # #1072 attaching a file dropped the live connection AND the
   "$FQCN_PREFIX.ReconnectRepaintE2eTest"
+  "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"  # #1967 must quiesce its app-owned forward before grace journeys
   "$FQCN_PREFIX.BackgroundGraceReconnectE2eTest"  # #754 #959 this class is the per-PR-CI deterministic regression catcher…
   "$FQCN_PREFIX.BoundedGraceSessionHoldJourneyE2eTest"  # #1123 #977 #1021 #215 bounded-grace D21 update — supersedes the / indefinite-hold…
   "com.pocketshell.app.share.ShareTargetE2eTest"  # #727 #657 epic Wave 1 / S1): the share-auth journey pair

--- a/tests/docker/agent-bin/pocketshell-fake-agent
+++ b/tests/docker/agent-bin/pocketshell-fake-agent
@@ -297,7 +297,7 @@ process_byte() {
         printf '%s|%s\n' "$submit_counter" "$encoded_submit" >> "$SUBMIT_LEDGER"
       fi
       if [ -n "$TRANSCRIPT_PATH" ]; then
-        transcript_text=$(printf '%s' "$submit_buffer" | sed 's/\\/\\\\/g; s/"/\\"/g')
+        transcript_text=$(json_escape "$submit_buffer")
         printf '{"uuid":"fake-agent-user-%s","timestamp":"%s","message":{"role":"user","content":"%s"}}\n' \
           "$submit_counter" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$transcript_text" >> "$TRANSCRIPT_PATH"
       fi
@@ -337,6 +337,27 @@ flush() {
     render
     dirty=0
   fi
+}
+
+# Encode one transcript string without external jq/python dependencies (the
+# agents fixture is intentionally Alpine-minimal). Literal newlines in a JSON
+# string made multiline submits unparsable, so transcript authority could never
+# acknowledge the exact row after Enter.
+json_escape() {
+  local input="$1" output="" ch=""
+  while [ -n "$input" ]; do
+    ch="${input%"${input#?}"}"
+    input="${input#?}"
+    case "$ch" in
+      \\) output="$output\\\\" ;;
+      '"') output="$output\\\"" ;;
+      "$LF") output="$output\\n" ;;
+      "$CR") output="$output\\r" ;;
+      $'\t') output="$output\\t" ;;
+      *) output="$output$ch" ;;
+    esac
+  done
+  printf '%s' "$output"
 }
 
 while true; do


### PR DESCRIPTION
Closes #1526.
Closes #1965.
Closes #1967.

Three separately reviewed commits remove concrete exact-main CI/nightly failures:

1. `abbb9205` — durable late-authoritative acknowledgement and valid fake-agent JSONL; fixes shard-2 `rowsTotal=0` and duplicate outbound risk.
2. `c5f959af` — ownership-correct quiescent teardown for the port-forward lifecycle proof; fixes shard-1 `background_grace_held_by_port_forward` contamination without changing production `leavePanel()`.
3. `d786fddb` — deterministic authoritative sustained-outage connector proof; fixes the exact-main Docker timeout while retaining attempt-2, fresh-transport, and same-session assertions.

## Independent approvals

- #1526: https://github.com/alexeygrigorev/pocketshell/issues/1526#issuecomment-5173508096
- #1967: https://github.com/alexeygrigorev/pocketshell/issues/1967#issuecomment-5173657977
- #1965 round 2: https://github.com/alexeygrigorev/pocketshell/issues/1965#issuecomment-5173813363

All candidate hashes/scopes were rechecked byte-for-byte before their separate commits. The final exact-head PR Unit run and manually dispatched exact-head Docker integration run must pass; obsolete earlier-head runs are not evidence. Unrelated core-tmux flake is tracked as #1969.

