### PR TITLE
Isolate synthetic focus owners between journeys

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -1,7 +1,6 @@
 package com.pocketshell.app.fileviewer
 
 import android.app.Activity
-import android.app.Dialog
 import android.app.Instrumentation
 import android.content.Intent
 import android.content.RecordingClipboardManager
@@ -10,8 +9,8 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.pdf.PdfDocument
 import android.util.Base64
-import android.widget.TextView
 import androidx.activity.ComponentActivity
+import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,10 +45,9 @@ import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
 import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
+import com.pocketshell.app.proof.signals.SyntheticFocusOwnerHarness
 import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
-import com.pocketshell.app.proof.signals.describeActiveWindow
-import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
-import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
+import com.pocketshell.app.proof.signals.requirePocketShellFocusAtJourneyBoundary
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -96,7 +94,13 @@ class FileViewerDockerTest {
      * already warm must NOT advance it (no per-open ~3-4s handshake).
      */
     private lateinit var leasing: CountingLeaseManager
-    private var focusStealer: Dialog? = null
+    private val focusOwner by lazy {
+        SyntheticFocusOwnerHarness(
+            scenario = composeRule.activityRule.scenario,
+            label = "issue-1942 synthetic focus owner",
+            timeoutMs = 5_000,
+        )
+    }
 
     @Before
     fun setUp(): Unit { runBlocking {
@@ -116,7 +120,7 @@ class FileViewerDockerTest {
 
     @After
     fun tearDown(): Unit { runBlocking {
-        dismissSyntheticFocusStealingWindow(requireFocus = false)
+        focusOwner.dismissBestEffort()
         if (seededPaths.isNotEmpty()) {
             withTimeout(15_000) {
                 connect()?.use { session ->
@@ -179,6 +183,34 @@ class FileViewerDockerTest {
         composeRule.onNodeWithTag(FILE_VIEWER_IMAGE_TAG).assertExists()
         WalkthroughScreenshotArtifacts.capture("issue497-file-viewer-image")
     } }
+
+    /** Issue #1985: an assertion exit cannot leak synthetic focus into the next journey. */
+    @Test
+    fun failedSyntheticOwnerBodyRestoresFocusBeforeNextImeJourney() {
+        composeRule.setContent { Text("issue #1985 focus restoration surface") }
+        composeRule.onNodeWithText("issue #1985 focus restoration surface").assertIsDisplayed()
+        val injectedFailure = AssertionError("issue1985 injected owner-body failure")
+        val harness = SyntheticFocusOwnerHarness(
+            scenario = composeRule.activityRule.scenario,
+            label = "issue-1985 synthetic focus owner",
+            timeoutMs = 5_000,
+        )
+        val escaped = runCatching {
+            harness.withOwner { owner ->
+                assertTrue("synthetic owner must remain visible during its body", owner.isShowing)
+                WalkthroughScreenshotArtifacts.capture("issue1985-synthetic-focus-owner")
+                throw injectedFailure
+            }
+        }.exceptionOrNull()
+        assertTrue("the injected body failure must escape unchanged", escaped === injectedFailure)
+
+        requirePocketShellFocusAtJourneyBoundary(
+            scenario = composeRule.activityRule.scenario,
+            context = "issue #1985 next IME journey boundary",
+            timeoutMs = 1_000,
+        )
+        WalkthroughScreenshotArtifacts.capture("issue1985-focus-restored-next-ime-boundary")
+    }
 
     @Test
     fun viewsRemoteTextFromFixture(): Unit { runBlocking {
@@ -761,42 +793,34 @@ class FileViewerDockerTest {
         // visible. The failure must name that pre-condition instead of timing
         // out as though Markdown selection were broken.
         composeRule.onNodeWithTag(unorderedBody).performTouchInput { longClick() }
-        raiseSyntheticFocusStealingWindow()
-        val focusLost = waitForActivityWindowFocusLost(
-            scenario = composeRule.activityRule.scenario,
-            timeoutMs = 5_000,
-        )
-        assertTrue(
-            "synthetic focus owner must take focus or the #1942 regression is vacuous",
-            focusLost,
-        )
-        WalkthroughScreenshotArtifacts.capture("issue1942-fileviewer-foreign-focus-owner")
-        val foreignFocusStartedAt = android.os.SystemClock.elapsedRealtime()
-        val foreignFocusFailure = runCatching {
-            assertFileViewerWindowFocused()
-        }.exceptionOrNull()
-        val foreignFocusFailureMs =
-            android.os.SystemClock.elapsedRealtime() - foreignFocusStartedAt
-        val foreignFocusMessage = foreignFocusFailure?.message.orEmpty()
-        assertTrue(
-            "foreign focus must be reported as the cause instead of a generic Copy timeout; " +
-                "got: $foreignFocusMessage",
-            foreignFocusMessage.contains(FOREIGN_WINDOW_FOCUS_SIGNATURE),
-        )
-        assertTrue(
-            "causal focus failure must name the active window; got: $foreignFocusMessage",
-            foreignFocusMessage.contains("active_window_pkg="),
-        )
-        assertTrue(
-            "focus pre-condition must fail before the old 5s Copy timeout; observed " +
-                "${foreignFocusFailureMs}ms",
-            foreignFocusFailureMs < 5_000,
-        )
-        assertTrue(
-            "the focus owner must remain visible; the journey must diagnose, not recover",
-            focusStealer?.isShowing == true,
-        )
-        dismissSyntheticFocusStealingWindow(requireFocus = true)
+        focusOwner.withOwner { owner ->
+            WalkthroughScreenshotArtifacts.capture("issue1942-fileviewer-foreign-focus-owner")
+            val foreignFocusStartedAt = android.os.SystemClock.elapsedRealtime()
+            val foreignFocusFailure = runCatching {
+                assertFileViewerWindowFocused()
+            }.exceptionOrNull()
+            val foreignFocusFailureMs =
+                android.os.SystemClock.elapsedRealtime() - foreignFocusStartedAt
+            val foreignFocusMessage = foreignFocusFailure?.message.orEmpty()
+            assertTrue(
+                "foreign focus must be reported as the cause instead of a generic Copy timeout; " +
+                    "got: $foreignFocusMessage",
+                foreignFocusMessage.contains(FOREIGN_WINDOW_FOCUS_SIGNATURE),
+            )
+            assertTrue(
+                "causal focus failure must name the active window; got: $foreignFocusMessage",
+                foreignFocusMessage.contains("active_window_pkg="),
+            )
+            assertTrue(
+                "focus pre-condition must fail before the old 5s Copy timeout; observed " +
+                    "${foreignFocusFailureMs}ms",
+                foreignFocusFailureMs < 5_000,
+            )
+            assertTrue(
+                "the app-owned focus thief must stay visible until harness cleanup",
+                owner.isShowing,
+            )
+        }
 
         // The real production SelectionContainer must still select and copy
         // Markdown text. Use the platform Copy key action after long-pressing
@@ -946,43 +970,6 @@ class FileViewerDockerTest {
 
     private fun assertMarkerText(path: String, expected: String) {
         assertEquals(expected, annotatedText(listMarkerTag(path)).text)
-    }
-
-    private fun raiseSyntheticFocusStealingWindow() {
-        composeRule.activityRule.scenario.onActivity { activity ->
-            val dialog = Dialog(activity)
-            val label = TextView(activity).apply {
-                text = "issue-1942 synthetic focus owner"
-                isFocusableInTouchMode = true
-                isFocusable = true
-            }
-            dialog.setContentView(label)
-            dialog.setCancelable(false)
-            dialog.setOnDismissListener { focusStealer = null }
-            dialog.show()
-            focusStealer = dialog
-        }
-        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    }
-
-    private fun dismissSyntheticFocusStealingWindow(requireFocus: Boolean) {
-        val dialog = focusStealer
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            if (dialog?.isShowing == true) dialog.dismiss()
-        }
-        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        if (requireFocus) {
-            val regained = waitForActivityWindowFocused(
-                scenario = composeRule.activityRule.scenario,
-                timeoutMs = 5_000,
-            )
-            if (!regained) {
-                fail(
-                    "file-viewer activity must regain focus after the synthetic owner is " +
-                        "dismissed; ${describeActiveWindow()}",
-                )
-            }
-        }
     }
 
     private fun assertFileViewerWindowFocused(timeoutMs: Long = 1_000) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/SyntheticFocusOwnerHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/SyntheticFocusOwnerHarness.kt
@@ -1,0 +1,123 @@
+package com.pocketshell.app.proof.signals
+
+import android.app.Activity
+import android.app.Dialog
+import android.os.SystemClock
+import android.widget.TextView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+
+/**
+ * Owns the complete lifetime of a focus-stealing test window.
+ *
+ * The owner-specific focus check is intentional. Merely observing that the
+ * activity lost focus can be satisfied by an unrelated system ANR window, as
+ * happened on nightly shard 2 in issue #1985. Cleanup always dismisses only the
+ * dialog this harness created and then proves PocketShell regained focus; it
+ * never acts on an unrelated window that may represent a real product failure.
+ */
+class SyntheticFocusOwnerHarness(
+    private val scenario: ActivityScenario<out Activity>,
+    private val label: String,
+    private val timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+) {
+    private var owner: Dialog? = null
+
+    fun <T> withOwner(block: (Dialog) -> T): T {
+        requirePocketShellFocusAtJourneyBoundary(
+            scenario = scenario,
+            context = "before raising synthetic focus owner '$label'",
+            timeoutMs = timeoutMs,
+        )
+
+        val dialog = showOwner()
+        var bodyFailure: Throwable? = null
+        try {
+            requireOwnerFocus(dialog)
+            return block(dialog)
+        } catch (failure: Throwable) {
+            bodyFailure = failure
+            throw failure
+        } finally {
+            try {
+                dismissAndRequirePocketShellFocus()
+            } catch (cleanupFailure: Throwable) {
+                bodyFailure?.let(cleanupFailure::addSuppressed)
+                throw cleanupFailure
+            }
+        }
+    }
+
+    /** Belt-and-braces teardown; load-bearing calls use [withOwner]. */
+    fun dismissBestEffort() {
+        val dialog = owner
+        runCatching {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                if (dialog?.isShowing == true) dialog.dismiss()
+            }
+        }
+        owner = null
+    }
+
+    private fun showOwner(): Dialog {
+        var shown: Dialog? = null
+        scenario.onActivity { activity ->
+            shown = Dialog(activity).also { dialog ->
+                dialog.setContentView(TextView(activity).apply {
+                    text = label
+                    isFocusable = true
+                    isFocusableInTouchMode = true
+                })
+                dialog.setCancelable(false)
+                dialog.show()
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        return requireNotNull(shown).also { owner = it }
+    }
+
+    private fun requireOwnerFocus(dialog: Dialog) {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (dialog.window?.decorView?.hasWindowFocus() == true) return
+            SystemClock.sleep(50)
+        }
+        if (dialog.window?.decorView?.hasWindowFocus() != true) {
+            throw AssertionError(
+                "synthetic dialog '$label' never became the actual focus owner; " +
+                    "activity focus loss alone is not proof; ${describeActiveWindow()}",
+            )
+        }
+    }
+
+    private fun dismissAndRequirePocketShellFocus() {
+        val dialog = owner
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            if (dialog?.isShowing == true) dialog.dismiss()
+        }
+        owner = null
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        requirePocketShellFocusAtJourneyBoundary(
+            scenario = scenario,
+            context = "after dismissing synthetic focus owner '$label'",
+            timeoutMs = timeoutMs,
+        )
+    }
+}
+
+/**
+ * Hard inter-test/journey focus invariant. Observation only: a genuine app or
+ * system focus thief stays visible and keeps the suite red with its diagnosis.
+ */
+fun requirePocketShellFocusAtJourneyBoundary(
+    scenario: ActivityScenario<out Activity>,
+    context: String,
+    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+) {
+    val outcome = awaitActivityWindowFocus(scenario, timeoutMs)
+    if (!outcome.focused) {
+        throw AssertionError(
+            "$FOREIGN_WINDOW_FOCUS_SIGNATURE $context; ${outcome.diagnosis}",
+        )
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -272,6 +272,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#cannotPreviewWithLocateCandidatesOffersOpenRows"
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#markdownRenderedPipeTableShowsCellsNotRawDelimiter"  # #921 D32 G9): rendered Markdown shows GFM pipe tables as
   "com.pocketshell.app.fileviewer.FileViewerDockerTest#reopeningAChangedTextFileShowsTheFreshHostContent"  # #1713 D33/G10: reopening a text file whose host content changed over the same warm lease must show the FRESH body, not the stale one (bind() no longer early-returns on the identical settled request)
+  "com.pocketshell.app.fileviewer.FileViewerDockerTest#failedSyntheticOwnerBodyRestoresFocusBeforeNextImeJourney"  # #1985 D32/G9: assertion exits always dismiss the owned synthetic window and prove PocketShell focus before the next IME journey
   "com.pocketshell.app.fileviewer.FileViewerDockerTest#moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl"  # #1714 D33/G9/G10: exact issue-time excerpts plus synthetic mixed/deep/wide class coverage through production MarkdownView
   "com.pocketshell.app.bootstrap.HostReadyPrimaryActionTest"  # #885 #117 D32 G9): the post-update Host ready success sheet must
   "com.pocketshell.app.bootstrap.HostNotificationsReadinessTest"  # #1236 D26 / D32 G9): per-host notification readiness + the


### PR DESCRIPTION
Closes #1985

## What changed
- replace the loose focus-loss oracle with an owner-specific synthetic-focus harness
- always dismiss the owned dialog in `finally` and hard-prove PocketShell focus restoration
- preserve genuine foreign/system focus owners as explicit failures
- wire the regression immediately before Show Keyboard in the canonical journey suite

## Evidence
- deterministic base regression: injected assertion exits with app-owned focus still leaked
- candidate regression→Show Keyboard: 2/2 green, zero skips
- ordered focus subset: FileViewer, Show Keyboard, terminal IME, shell composer green; independent OpenCode readiness routed to #1979
- nonblank owner/restoration artifacts visually audited
- full JVM: 603/603 green
- independent reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/1985#issuecomment-5177231389

## Current-main integration
- test-validity and journey-harness guards passed
- Android-test compilation passed