### PR TITLE
Fix nightly port-forward isolation and offset-resume proof

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
@@ -27,11 +27,11 @@ import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.entity.HostEntity
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -70,15 +70,31 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class ForwardingNetworkRideThroughE2eTest {
 
-    @get:Rule
     val compose = createEmptyComposeRule()
-
-    @get:Rule
-    val grantPermissions = PreGrantPermissionsRule()
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
     private var seededHostId: Long? = null
     private var diagnostics: RecordingDiagnosticSink? = null
+
+    private val forwardingIsolation = PortForwardingTestIsolationRule(
+        beforeStop = {
+            observer().ignoreRealNetworkCallbacksForTest = false
+            controller().forceTransportProvenAliveForTest = null
+        },
+        afterStop = {
+            diagnostics?.close()
+            diagnostics = null
+            seededHostId = null
+            launchedActivity?.close()
+            launchedActivity = null
+        },
+    )
+
+    @get:Rule
+    val rules: RuleChain = RuleChain
+        .outerRule(forwardingIsolation)
+        .around(PreGrantPermissionsRule())
+        .around(compose)
 
     private fun appContext(): Context =
         InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
@@ -89,21 +105,6 @@ class ForwardingNetworkRideThroughE2eTest {
     private fun controller(): ForwardingController = entryPoint().forwardingController()
 
     private fun observer(): TerminalNetworkObserver = entryPoint().terminalNetworkObserver()
-
-    @After
-    fun teardown() {
-        // Issue #1356: re-enable real network callbacks for any sibling test
-        // sharing this singleton observer in the same instrumentation process
-        // (mirrors BareNetworkLossRestoreReconnectE2eTest#tearDown, #1098 item 5).
-        runCatching { observer().ignoreRealNetworkCallbacksForTest = false }
-        runCatching { controller().forceTransportProvenAliveForTest = null }
-        runCatching { controller().stopAllForwarding() }
-        diagnostics?.close()
-        diagnostics = null
-        seededHostId = null
-        launchedActivity?.close()
-        launchedActivity = null
-    }
 
     @Test
     fun cellularHandoffLossRestoreRidesThroughWhenTunnelSurvived_redialsWhenDead() {

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardPanelLifecycleE2eTest.kt
@@ -1,9 +1,6 @@
 package com.pocketshell.app.portfwd
 
-import android.app.ActivityManager
-import android.app.NotificationManager
 import android.content.Context
-import android.os.SystemClock
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.room.Room
@@ -11,7 +8,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
-import com.pocketshell.app.portfwd.service.ForwardingService
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.testaccess.TestAccessEntryPoint
 import com.pocketshell.core.portfwd.TunnelInfo
@@ -25,16 +21,15 @@ import com.pocketshell.core.storage.entity.SshKeyEntity
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -75,42 +70,32 @@ class PortForwardPanelLifecycleE2eTest {
     // Issue #470 blocker #1: grant runtime permissions before the activity
     // launches so the system GrantPermissionsActivity never steals focus
     // from MainActivity at launch.
-    @get:Rule
-    val grantPermissions = PreGrantPermissionsRule()
-
     private var launchedActivity: ActivityScenario<MainActivity>? = null
     private var db: AppDatabase? = null
-    private var ownedForwardingController: ForwardingController? = null
-    private var ownedForwardingHostId: Long? = null
-    private var appContext: Context? = null
+
+    private val forwardingIsolation = PortForwardingTestIsolationRule(
+        afterStop = {
+            launchedActivity?.close()
+            launchedActivity = null
+            db?.close()
+            db = null
+        },
+    )
+
+    @get:Rule
+    val rules: RuleChain = RuleChain
+        .outerRule(forwardingIsolation)
+        .around(PreGrantPermissionsRule())
 
     private fun appForwardingController(context: Context): ForwardingController =
         EntryPointAccessors
             .fromApplication(context.applicationContext, TestAccessEntryPoint::class.java)
             .forwardingController()
 
-    @After
-    fun tearDown() {
-        // Issue #1967: leavePanel() intentionally does NOT stop a user-owned
-        // forward. This proof enabled the app singleton directly, so the test
-        // owns its teardown as well. Await a stable zero controller + service
-        // state before the next in-process journey can start its grace timer.
-        val forwardingCleanupFailure = runCatching {
-            runBlocking { stopOwnedForwardingAndAwaitQuiescent() }
-        }.exceptionOrNull()
-        launchedActivity?.close()
-        launchedActivity = null
-        db?.close()
-        db = null
-        appContext = null
-        forwardingCleanupFailure?.let { throw it }
-    }
-
     @Test
     fun lifecycleStopKeepsTunnels_lifecycleStartDoesNotReconnectThem() { runBlocking {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val targetContext = instrumentation.targetContext
-        appContext = targetContext.applicationContext
 
         // 1. Stand up an in-memory Room DB on the main thread so the
         //    panel's autoForward + persist paths have a real DAO.
@@ -136,8 +121,6 @@ class PortForwardPanelLifecycleE2eTest {
                 enabled = false,
             ),
         )
-        ownedForwardingHostId = hostId
-
         // 3. Launch MainActivity to get a real process lifecycle.
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
         launchedActivity!!.moveToState(Lifecycle.State.RESUMED)
@@ -148,7 +131,6 @@ class PortForwardPanelLifecycleE2eTest {
         // 4. Build the ViewModel on the main thread (Lifecycle.addObserver
         //    requirement) and attach ProcessLifecycleOwner.
         val forwardingController = appForwardingController(targetContext)
-        ownedForwardingController = forwardingController
         assertTrue(
             "app-owned forwarding controller must start empty; a prior test leaked " +
                 forwardingController.activeHostIdsSnapshot(),
@@ -187,7 +169,7 @@ class PortForwardPanelLifecycleE2eTest {
                 state.connectionState == PortForwardConnectionState.Connected &&
                     state.tunnels.any { it.status == TunnelInfo.Status.FORWARDING } &&
                     forwardingController.activeHostIdsSnapshot() == listOf(hostId) &&
-                    forwardingServiceRunning(targetContext)
+                    forwardingServiceRunningForTest(targetContext)
             }
         }
         val firstSession = requireNotNull(sessionFactory.lastSession()) {
@@ -239,71 +221,8 @@ class PortForwardPanelLifecycleE2eTest {
         )
     } }
 
-    private suspend fun stopOwnedForwardingAndAwaitQuiescent() {
-        val controller = ownedForwardingController ?: return
-        val ownedHostId = ownedForwardingHostId
-        val activeBefore = controller.activeHostIdsSnapshot()
-
-        // stopAllForwarding is ownership-correct here because this test asserts
-        // the app controller was empty before adoption and registers one host.
-        // If a foreign registration appears, remove only ours and fail rather
-        // than silently stopping forwarding another test created.
-        val ownsEveryActiveHost = activeBefore.all { it == ownedHostId }
-        if (ownsEveryActiveHost) {
-            controller.stopAllForwarding()
-        } else {
-            ownedHostId?.let(controller::stopForwarding)
-        }
-
-        withTimeout(STATE_TIMEOUT_MS) {
-            var zeroSinceMs: Long? = null
-            waitFor("zero active forwarding and stopped service") {
-                val context = appContext
-                val isQuiescent = controller.flowOfActiveHostCount().value == 0 &&
-                    controller.activeHostIdsSnapshot().isEmpty() &&
-                    (context == null ||
-                        (!forwardingServiceRunning(context) && !forwardingNotificationPresent(context)))
-                if (isQuiescent) {
-                    val now = SystemClock.elapsedRealtime()
-                    val since = zeroSinceMs ?: now.also { zeroSinceMs = it }
-                    now - since >= QUIESCENT_STABLE_MS
-                } else {
-                    zeroSinceMs = null
-                    false
-                }
-            }
-        }
-
-        assertTrue(
-            "test teardown may stop only its own forwarding; activeBefore=$activeBefore owned=$ownedHostId",
-            ownsEveryActiveHost,
-        )
-        assertEquals(0, controller.flowOfActiveHostCount().value)
-        assertTrue(controller.activeHostIdsSnapshot().isEmpty())
-        ownedForwardingController = null
-        ownedForwardingHostId = null
-    }
-
-    @Suppress("DEPRECATION")
-    private fun forwardingServiceRunning(context: Context): Boolean =
-        context.getSystemService(ActivityManager::class.java)
-            .getRunningServices(Int.MAX_VALUE)
-            .any { it.service.className == ForwardingService::class.java.name }
-
-    private fun forwardingNotificationPresent(context: Context): Boolean =
-        context.getSystemService(NotificationManager::class.java)
-            .activeNotifications
-            .any {
-                it.notification.extras
-                    .getCharSequence("android.title")
-                    ?.toString()
-                    ?.contains("Port forwarding running") == true
-            }
-
     private suspend fun waitFor(label: String, predicate: () -> Boolean) {
-        while (!predicate()) {
-            delay(POLL_INTERVAL_MS)
-        }
+        while (!predicate()) kotlinx.coroutines.delay(POLL_INTERVAL_MS)
     }
 
     private companion object {
@@ -316,7 +235,6 @@ class PortForwardPanelLifecycleE2eTest {
          */
         const val STATE_TIMEOUT_MS: Long = 15_000L
         const val POLL_INTERVAL_MS: Long = 50L
-        const val QUIESCENT_STABLE_MS: Long = 1_000L
     }
 }
 

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardingTestIsolationRule.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardingTestIsolationRule.kt
@@ -1,0 +1,155 @@
+package com.pocketshell.app.portfwd
+
+import android.app.ActivityManager
+import android.app.NotificationManager
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.portfwd.service.ForwardingService
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.MultipleFailureException
+import org.junit.runners.model.Statement
+
+/**
+ * Issue #1984: hard post-test isolation for journeys that can own real forwards.
+ *
+ * The cleanup is an outer rule rather than an `@After`: if the test body already
+ * failed, a cleanup failure is attached as suppressed evidence and the original
+ * causal assertion remains the test's primary throwable. The rule also disables
+ * persisted auto-forward intent before stopping the singleton controller, so a
+ * later activity `ON_START` cannot resurrect the just-cleaned tunnel.
+ */
+internal class PortForwardingTestIsolationRule(
+    private val beforeStop: () -> Unit = {},
+    private val afterStop: () -> Unit = {},
+) : TestRule {
+    override fun apply(base: Statement, description: Description): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                val primaryFailure = runCatching { base.evaluate() }.exceptionOrNull()
+                val cleanupFailures = mutableListOf<Throwable>()
+
+                runCatching { beforeStop() }.exceptionOrNull()?.let(cleanupFailures::add)
+                runCatching { hardStopAndAssertZero(description) }
+                    .exceptionOrNull()
+                    ?.let(cleanupFailures::add)
+                runCatching { afterStop() }.exceptionOrNull()?.let(cleanupFailures::add)
+
+                val cleanupFailure = runCatching {
+                    MultipleFailureException.assertEmpty(cleanupFailures)
+                }.exceptionOrNull()
+                if (primaryFailure != null) {
+                    cleanupFailure?.let(primaryFailure::addSuppressed)
+                    throw primaryFailure
+                }
+                cleanupFailure?.let { throw it }
+            }
+        }
+
+    private fun hardStopAndAssertZero(description: Description) {
+        val context = androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .targetContext
+            .applicationContext
+        val entryPoint = EntryPointAccessors.fromApplication(
+            context,
+            TestAccessEntryPoint::class.java,
+        )
+        val controller = entryPoint.forwardingController()
+        val cleanupFailures = mutableListOf<Throwable>()
+
+        runBlocking {
+            // The instrumentation process owns its app DB. Disable every persisted
+            // auto-forward intent before stopping runtime state; otherwise a later
+            // MainActivity ON_START can re-adopt the same real tunnel (#1984).
+            runCatching {
+                withTimeout(CLEANUP_TIMEOUT_MS) {
+                    entryPoint.appDatabase().hostDao().getEnabled().first().forEach { host ->
+                        entryPoint.appDatabase().hostDao().update(host.copy(enabled = false))
+                    }
+                }
+            }.exceptionOrNull()?.let(cleanupFailures::add)
+
+            // A persistence failure must not prevent the runtime stop attempt.
+            runCatching {
+                withTimeout(CLEANUP_TIMEOUT_MS) {
+                    controller.stopAllForwarding()
+                }
+            }.exceptionOrNull()?.let(cleanupFailures::add)
+
+            runCatching {
+                withTimeout(CLEANUP_TIMEOUT_MS) {
+                    var zeroSinceMs: Long? = null
+                    while (true) {
+                        val quiescent = controller.flowOfActiveHostCount().value == 0 &&
+                            controller.activeHostIdsSnapshot().isEmpty() &&
+                            !forwardingServiceRunningForTest(context) &&
+                            !forwardingNotificationPresentForTest(context)
+                        if (quiescent) {
+                            val now = SystemClock.elapsedRealtime()
+                            val since = zeroSinceMs ?: now.also { zeroSinceMs = it }
+                            if (now - since >= QUIESCENT_STABLE_MS) break
+                        } else {
+                            zeroSinceMs = null
+                        }
+                        delay(POLL_INTERVAL_MS)
+                    }
+                }
+            }.exceptionOrNull()?.let(cleanupFailures::add)
+        }
+
+        runCatching {
+            check(controller.flowOfActiveHostCount().value == 0) {
+                "post-test forwarding count must be zero for ${description.displayName}"
+            }
+            check(controller.activeHostIdsSnapshot().isEmpty()) {
+                "post-test active forwards must be empty for ${description.displayName}: " +
+                    controller.activeHostIdsSnapshot()
+            }
+            check(
+                !forwardingServiceRunningForTest(context) &&
+                    !forwardingNotificationPresentForTest(context),
+            ) {
+                "post-test forwarding service/notification must be absent for ${description.displayName}"
+            }
+        }.exceptionOrNull()?.let(cleanupFailures::add)
+        MultipleFailureException.assertEmpty(cleanupFailures)
+
+        DiagnosticEvents.record(
+            "test",
+            "port_forward_post_test_zero",
+            "test" to description.displayName,
+            "activeHostCount" to 0,
+        )
+        Log.i(TAG, "post-test-zero test=${description.displayName}")
+    }
+
+    private companion object {
+        const val TAG: String = "PsPortForwardTestIsolation"
+        const val CLEANUP_TIMEOUT_MS: Long = 15_000L
+        const val QUIESCENT_STABLE_MS: Long = 1_000L
+        const val POLL_INTERVAL_MS: Long = 50L
+    }
+}
+
+@Suppress("DEPRECATION")
+internal fun forwardingServiceRunningForTest(context: Context): Boolean =
+    context.getSystemService(ActivityManager::class.java)
+        .getRunningServices(Int.MAX_VALUE)
+        .any { it.service.className == ForwardingService::class.java.name }
+
+internal fun forwardingNotificationPresentForTest(context: Context): Boolean =
+    context.getSystemService(NotificationManager::class.java)
+        .activeNotifications
+        .any { notification ->
+            notification.packageName == context.packageName &&
+                notification.notification.channelId.startsWith("pocketshell_forwarding_status")
+        }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
@@ -465,6 +465,15 @@ class OutboundAttachmentOffsetResumeJourneyE2eTest {
                     Issue1733JourneyContract.xmlSafeFailureText(liveCapture),
                 liveCapture.contains(LIVE_INPUT_MARKER),
             )
+            val visibleCatchupStarted = SystemClock.elapsedRealtime()
+            waitForVisibleTerminalViewport(
+                label = "post-resume live input",
+                timeoutMs = INPUT_TIMEOUT_MS,
+            ) { it.contains(LIVE_INPUT_MARKER) }
+            recordTiming(
+                "live_input_visible_catchup_ms",
+                SystemClock.elapsedRealtime() - visibleCatchupStarted,
+            )
             captureViewport(
                 name = "03-resumed-delivered-live",
                 requiredVisibleText = LIVE_INPUT_MARKER,
@@ -1016,6 +1025,49 @@ class OutboundAttachmentOffsetResumeJourneyE2eTest {
         return text
     }
 
+    /**
+     * The remote pane accepting input is only the first half of the final proof:
+     * control-mode output is delivered asynchronously to the app's terminal model.
+     * Wait for that exact marker to reach the visible rows before taking the
+     * same-frame screenshot. This remains a viewport oracle (never scrollback or
+     * a server-only substitute) and retains a hard wall-clock failure bound.
+     */
+    private fun waitForVisibleTerminalViewport(
+        label: String,
+        timeoutMs: Long,
+        predicate: (String) -> Boolean,
+    ): String {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            compose.activityRule.scenario.onActivity { activity ->
+                last = activity.window.decorView.findTerminalView()
+                    ?.currentSession?.emulator?.screen?.visibleScreenText.orEmpty()
+            }
+            if (predicate(last)) return last
+            SystemClock.sleep(VISIBLE_VIEWPORT_POLL_MS)
+        }
+
+        val visible = writeText("03-visible-catchup-failure-visible-terminal.txt", last)
+        val diagnostic = writeText(
+            "03-visible-catchup-failure-diagnostics.txt",
+            diagnosticSummary().ifEmpty { "<no diagnostics>\n" },
+        )
+        preserveArtifacts(
+            phase = "03-visible-catchup-failure",
+            visible.name,
+            diagnostic.name,
+        )
+        assertTrue(
+            "$label did not reach the authoritative visible terminal viewport within " +
+                "${timeoutMs}ms; status=${currentConnectionStatus()} text=\n" +
+                Issue1733JourneyContract.xmlSafeFailureText(last),
+            predicate(last),
+        )
+        return last
+    }
+
     private fun View.findTerminalView(): TerminalView? {
         if (this is TerminalView) return this
         if (this !is ViewGroup) return null
@@ -1273,6 +1325,7 @@ class OutboundAttachmentOffsetResumeJourneyE2eTest {
         const val CUT_AFTER_BYTES = 512L * 1024
         const val REQUIRED_STABLE_REMOTE_READS = 8
         const val DELIVERY_MAIN_CLOCK_STEP_MS = 20L
+        const val VISIBLE_VIEWPORT_POLL_MS = 100L
         const val AUTO_RETRY_WINDOW_MS = 5_000L
         const val HOOK_TIMEOUT_MS = 90_000L
         const val SSHD_SNAPSHOT = "ps -o pid,ppid,stat,cmd -u testuser | grep '[s]shd' || true"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -136,7 +136,7 @@ JOURNEY_CLASSES=(
   "$FQCN_PREFIX.ServerDeathReconnectNoResurrectE2eTest"  # #998 a remote tmux SERVER death (host reboot / OOM
   "$FQCN_PREFIX.AttachmentDropReconnectRecoversE2eTest"  # #1072 attaching a file dropped the live connection AND the
   "$FQCN_PREFIX.ReconnectRepaintE2eTest"
-  "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"  # #1967 must quiesce its app-owned forward before grace journeys
+  "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"  # #1967/#1984 failure-preserving hard cleanup + zero-forward post-test invariant before grace journeys
   "$FQCN_PREFIX.BackgroundGraceReconnectE2eTest"  # #754 #959 this class is the per-PR-CI deterministic regression catcher…
   "$FQCN_PREFIX.BoundedGraceSessionHoldJourneyE2eTest"  # #1123 #977 #1021 #215 bounded-grace D21 update — supersedes the / indefinite-hold…
   "com.pocketshell.app.share.ShareTargetE2eTest"  # #727 #657 epic Wave 1 / S1): the share-auth journey pair
@@ -235,7 +235,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.conversation.ConversationCodeBlockCopyJourneyTest"  # #1888 D33/G9/G10: every fenced Conversation block has a fixed, accessible 48dp Copy action; two raw payloads + long horizontal-scroll line + whole-message Copy preservation
   "com.pocketshell.app.portfwd.PortForwardDuplicateKeyCrashTest"  # #931 D33/G10 reproduce-first): the port-forward panel LazyColumn…
   "com.pocketshell.app.portfwd.PortForwardDuplicateKeyRenderTest"
-  "com.pocketshell.app.portfwd.ForwardingNetworkRideThroughE2eTest"  # #1058 #843 #981 #997 audit R1, trigger T11 / coverage gap C1, D33/G10
+  "com.pocketshell.app.portfwd.ForwardingNetworkRideThroughE2eTest"  # #1058/#1984 real ride-through plus persisted-intent/runtime hard cleanup
   "com.pocketshell.app.portfwd.ForwardingNotificationE2eTest#sessionPinnedForForward_hasExactlyOneForwardNotification_andStopTearsDownTunnels"  # #1202 #1198 D31/D32 durable-fix gate, on-device regression): the port-fo…
   "com.pocketshell.app.portfwd.ForwardingNotificationE2eTest#liveUpdateContract_isApi36Promotable_pre36Ordinary_andStopClears"  # #1487 actual ForwardingService notification contract: API36 promoted request + short text + promotable shape, pre36 ordinary ongoing FGS, and Stop/zero-forward clears
   "$FQCN_PREFIX.SilentDropSyntheticSeamJourneyE2eTest"  # #792 #822 #823 #964 epic Slice D, /V7a + — D31 durable-fix gate


### PR DESCRIPTION
Closes #1984
Closes #1986

Two independently approved fixes, preserved as separate commits.

## #1984 — port-forward isolation
- disable persisted enabled hosts, stop real singleton forwards, and await stable zero controller/service/notification state in failure-preserving `finally` cleanup
- exact ordered base: 2 grace failures with `background_grace_held_by_port_forward`
- exact ordered candidate: 4/4 green, zero skips, stable `post-test-zero`
- full JVM: 603/603 green
- APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1984#issuecomment-5177375461

## #1986 — authoritative viewport catch-up
- boundedly await local `visibleScreenText` after offset resume while retaining the same-frame screenshot oracle
- exact prompt/path/live marker, 16MiB offset/byte/SHA/checkpoint/fresh-client proof preserved
- focused and ordered #1986 green; full JVM 603/603 green
- independent #1751 phase failure disclosed and untouched
- APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1986#issuecomment-5177294667

## Combined current-main verification
- test-validity guard passed
- journey-harness guard passed
- Android-test compilation passed