### PR TITLE
Recover nightly fixture state and classify offline emulators

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -492,5 +492,9 @@ jobs:
             echo "PASS: the fault-injection safety journeys (network-fault + bootstrap) passed on this HEAD."
             exit 0
           fi
+          if [[ "$verdict" == "INFRA" ]]; then
+            echo "BLOCK-INFRA: a gating phase lost the emulator/device; preserved UTP evidence did not contain a substantive product assertion. Re-run on a healthy AVD before release."
+            exit 1
+          fi
           echo "BLOCK: fault_verdict=$verdict — a fault-injection safety phase failed on this HEAD."
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -429,6 +429,15 @@ jobs:
           chmod +x scripts/lib/nightly-phase-reports.sh
           scripts/lib/nightly-phase-reports.sh --self-test
 
+      # Issue #1991: fast report-fixture proof that an empty UTP failure with
+      # the exact APK-installer + ddmlib device-offline signature is INFRA, a
+      # substantive assertion remains product-red, and product-red dominates a
+      # later offline teardown. No emulator, Gradle, retry, or network.
+      - name: Nightly phase device-offline classification guard (issue #1991)
+        run: |
+          chmod +x scripts/test-nightly-phase-classification.sh
+          scripts/test-nightly-phase-classification.sh
+
       # Issue #1581: gate the Build workflow's corrupted-NDK-download retry
       # wrapper (scripts/ci-assemble-with-ndk-retry.sh) so its clear-and-retry
       # logic cannot silently regress. Fast, JVM-free shell test (fake build cmd,

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -202,7 +202,13 @@ class FileViewerDockerTest {
                 throw injectedFailure
             }
         }.exceptionOrNull()
-        assertTrue("the injected body failure must escape unchanged", escaped === injectedFailure)
+        if (escaped !== injectedFailure) {
+            // Issue #1991: cleanup failure intentionally dominates the injected
+            // body failure in SyntheticFocusOwnerHarness. Preserve that causal
+            // focus diagnosis instead of replacing it with a generic identity
+            // assertion; the injected failure remains attached as suppressed.
+            throw escaped ?: AssertionError("synthetic owner body returned without its injected failure")
+        }
 
         requirePocketShellFocusAtJourneyBoundary(
             scenario = composeRule.activityRule.scenario,

--- a/app/src/androidTest/java/com/pocketshell/app/hosts/HostEditFromKebabE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/HostEditFromKebabE2eTest.kt
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.usage.UsageScheduler
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import java.io.File
@@ -24,6 +25,7 @@ import java.io.FileOutputStream
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -55,11 +57,13 @@ class HostEditFromKebabE2eTest {
     val grantPermissions = PreGrantPermissionsRule()
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
+    private var usageScheduler: UsageScheduler? = null
     private var hostId: Long? = null
     private var keyId: Long? = null
 
     @After
     fun tearDown() {
+        val scheduler = usageScheduler
         launchedActivity?.close()
         launchedActivity = null
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
@@ -72,6 +76,23 @@ class HostEditFromKebabE2eTest {
         } finally {
             db.close()
         }
+        // Issue #1992: this test deliberately gives the process-singleton
+        // UsageScheduler an eligible Docker host. Its real fixture response
+        // includes Claude at 85%, so merely deleting the Room row leaves a
+        // warning snapshot cached for later classes in the same shard. Drain
+        // against the now-empty host table before handing the instrumentation
+        // process to the next test; this is the owning fixture's cleanup, not
+        // a smoke-test bypass of the real warning UI.
+        runBlocking {
+            scheduler?.refreshNow()
+        }
+        scheduler?.snapshots?.value?.let { snapshots ->
+            assertTrue(
+                "HostEditFromKebabE2eTest must not leak process-wide usage snapshots",
+                snapshots.isEmpty(),
+            )
+        }
+        usageScheduler = null
     }
 
     @Test
@@ -82,6 +103,9 @@ class HostEditFromKebabE2eTest {
         val id = requireNotNull(hostId)
 
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        launchedActivity!!.onActivity { activity ->
+            usageScheduler = activity.usageScheduler
+        }
         launchedActivity!!.moveToState(Lifecycle.State.RESUMED)
 
         // Land on the host list — the seeded row is present.

--- a/scripts/lib/nightly-fault-verdict.sh
+++ b/scripts/lib/nightly-fault-verdict.sh
@@ -36,21 +36,32 @@
 # ---------------------------------------------------------------------------
 # compute_fault_verdict <network_fault_status> <bootstrap_status>
 #
-# The two arguments are the PASS/FAIL results of the network-fault (phase 2) and
+# The two arguments are the PASS/FAIL/INFRA results of the network-fault (phase 2) and
 # bootstrap (phase 3) phases. The journey phase (phase 1) and the #822
 # expected-fail lane are DELIBERATELY not arguments — they must never influence
 # the fault-injection safety verdict.
 #
-# Prints "PASS" / "FAIL"; returns 0 (pass) / 1 (fail).
+# FAIL dominates INFRA so a real assertion can never be downgraded by a later
+# device loss. Otherwise INFRA is preserved as a distinct blocking verdict.
+# Prints "PASS" / "FAIL" / "INFRA"; returns 0 / 1 / 2.
 # ---------------------------------------------------------------------------
 compute_fault_verdict() {
   local network_fault_status="$1"
   local bootstrap_status="$2"
 
+  if [[ "$network_fault_status" == "FAIL" || "$bootstrap_status" == "FAIL" ]]; then
+    echo "FAIL"
+    return 1
+  fi
+  if [[ "$network_fault_status" == "INFRA" || "$bootstrap_status" == "INFRA" ]]; then
+    echo "INFRA"
+    return 2
+  fi
   if [[ "$network_fault_status" == "PASS" && "$bootstrap_status" == "PASS" ]]; then
     echo "PASS"
     return 0
   fi
+  # Unknown status is never a release-green signal.
   echo "FAIL"
   return 1
 }
@@ -122,6 +133,11 @@ _fault_verdict_self_test() {
   assert_verdict "nf red"                             FAIL 1 FAIL PASS
   assert_verdict "bootstrap red"                      FAIL 1 PASS FAIL
   assert_verdict "both gating red"                    FAIL 1 FAIL FAIL
+  # Exact #1991 direction: infra is distinct unless a substantive product
+  # failure also exists, in which case product-red dominates.
+  assert_verdict "network-fault device offline"       INFRA 2 INFRA PASS
+  assert_verdict "bootstrap device offline"           INFRA 2 PASS INFRA
+  assert_verdict "product red dominates infra"        FAIL 1 FAIL INFRA
 
   # THE load-bearing #1201 direction, at the FILE level: the journey suite and
   # the #822 expected-fail lane are red, but the fault phases passed -> the
@@ -136,6 +152,19 @@ _fault_verdict_self_test() {
     echo "ok   [file] fault_verdict=PASS despite expected-fail lane red"
   else
     echo "FAIL [file] fault_verdict should be PASS despite expected-fail lane red"
+    failures=$((failures + 1))
+  fi
+  rm -f "$tmp"
+
+  echo
+  echo "--- file-level dry run: fault phase device-offline -> verdict INFRA ---"
+  tmp="$(mktemp)"
+  write_fault_verdict_file "$tmp" INFRA 1 PASS 0 FAIL 1
+  cat "$tmp"
+  if grep -q '^fault_verdict=INFRA$' "$tmp"; then
+    echo "ok   [file] fault_verdict=INFRA for device-offline fault phase"
+  else
+    echo "FAIL [file] fault_verdict should distinguish device-offline infrastructure"
     failures=$((failures + 1))
   fi
   rm -f "$tmp"

--- a/scripts/lib/nightly-phase-classification.sh
+++ b/scripts/lib/nightly-phase-classification.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Fail-safe connected-phase classification for Nightly Extensive (#1991).
+#
+# This file is intentionally pure: it reads a preserved report tree and emits a
+# classification. It never invokes adb, retries instrumentation, or changes the
+# measured budgets of the product journeys.
+
+nightly_phase_has_device_offline_signature() {
+  local report_root="$1"
+  [[ -d "$report_root" ]] || return 1
+
+  # Require BOTH the UTP lifecycle context and ddmlib's exact cause. A generic
+  # "offline" emitted by a product assertion or fixture is not enough to
+  # downgrade a release-gating test failure.
+  grep -R -a -q \
+    'AndroidTestApkInstallerPlugin.*device offline' "$report_root" 2>/dev/null &&
+    grep -R -a -q \
+      'com[.]android[.]ddmlib[.]AdbCommandRejectedException: device offline' \
+      "$report_root" 2>/dev/null
+}
+
+nightly_phase_has_substantive_junit_failure() {
+  local report_root="$1"
+  local xml flattened
+  [[ -d "$report_root" ]] || return 1
+
+  while IFS= read -r -d '' xml; do
+    # UTP represents a device disappearance as an empty `<failure></failure>`.
+    # Flatten only JUnit XML and require non-whitespace body text. This keeps a
+    # real assertion load-bearing even if the device subsequently goes offline.
+    flattened="$(tr '\n\r' '  ' < "$xml")"
+    if printf '%s\n' "$flattened" |
+      grep -E -q '<failure([^>]*)>[[:space:]]*[^<[:space:]]'; then
+      return 0
+    fi
+  done < <(find "$report_root" -type f -name 'TEST-*.xml' -print0 2>/dev/null)
+  return 1
+}
+
+# classify_nightly_phase <exit-code> <preserved-report-root>
+#
+# PRODUCT_AND_INFRA is deliberately distinct and remains product-red. Infra is
+# allowed to own the phase only when the phase has the strong two-part offline
+# signature and no substantive JUnit assertion/error body.
+classify_nightly_phase() {
+  local exit_code="$1"
+  local report_root="$2"
+  local offline=no substantive=no
+
+  if [[ "$exit_code" -eq 0 ]]; then
+    printf 'PASS\n'
+    return 0
+  fi
+  nightly_phase_has_device_offline_signature "$report_root" && offline=yes
+  nightly_phase_has_substantive_junit_failure "$report_root" && substantive=yes
+
+  if [[ "$substantive" == yes && "$offline" == yes ]]; then
+    printf 'PRODUCT_AND_INFRA\n'
+  elif [[ "$substantive" == yes ]]; then
+    printf 'PRODUCT_FAILURE\n'
+  elif [[ "$offline" == yes ]]; then
+    printf 'INFRA_DEVICE_OFFLINE\n'
+  else
+    # Unknown/empty failures fail closed. Only the exact strong signature earns
+    # an infrastructure classification.
+    printf 'PRODUCT_FAILURE\n'
+  fi
+}
+
+write_nightly_phase_classification() {
+  local output="$1"
+  local phase="$2"
+  local exit_code="$3"
+  local report_root="$4"
+  local classification offline=no substantive=no
+
+  classification="$(classify_nightly_phase "$exit_code" "$report_root")"
+  nightly_phase_has_device_offline_signature "$report_root" && offline=yes
+  nightly_phase_has_substantive_junit_failure "$report_root" && substantive=yes
+  mkdir -p "$(dirname "$output")"
+  {
+    printf 'phase=%s\n' "$phase"
+    printf 'exit=%s\n' "$exit_code"
+    printf 'classification=%s\n' "$classification"
+    printf 'device_offline_signature=%s\n' "$offline"
+    printf 'substantive_junit_failure=%s\n' "$substantive"
+    printf 'report_root=%s\n' "$report_root"
+  } > "$output"
+}
+
+nightly_phase_status() {
+  case "$1" in
+    PASS) printf 'PASS\n' ;;
+    INFRA_DEVICE_OFFLINE) printf 'INFRA\n' ;;
+    PRODUCT_FAILURE|PRODUCT_AND_INFRA) printf 'FAIL\n' ;;
+    *) printf 'FAIL\n' ;;
+  esac
+}
+
+# Read-only boundary evidence. This deliberately does not `adb reconnect`,
+# restart the emulator, or rerun a phase: doing so would add an unmeasured retry
+# budget and could hide the first failure. A transiently recovered device is
+# recorded as such and the next phase may proceed; the failed phase keeps its
+# preserved classification.
+capture_nightly_device_boundary() {
+  local output="$1"
+  local phase="$2"
+  local adb_bin="${ADB:-adb}"
+  local adb_target=("$adb_bin")
+  [[ -n "${ANDROID_SERIAL:-}" ]] && adb_target+=( -s "$ANDROID_SERIAL" )
+  mkdir -p "$(dirname "$output")"
+  {
+    printf 'phase=%s\n' "$phase"
+    printf 'android_serial=%s\n' "${ANDROID_SERIAL:-<unset>}"
+    printf '%s\n' '--- adb devices -l ---'
+    timeout 5s "$adb_bin" devices -l 2>&1 || true
+    printf '%s\n' '--- adb get-state ---'
+    timeout 5s "${adb_target[@]}" get-state 2>&1 || true
+    printf '%s\n' '--- sys.boot_completed ---'
+    timeout 5s "${adb_target[@]}" shell getprop sys.boot_completed 2>&1 || true
+  } > "$output"
+}

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -246,6 +246,13 @@ source "$REPO_ROOT/scripts/lib/nightly-phase-reports.sh"
 PHASE_REPORTS_DIR="$ARTIFACT_DIR/phase-reports"
 APP_BUILD_DIR="$REPO_ROOT/app/build"
 
+# Issue #1991: distinguish a substantive assertion from UTP assigning an empty
+# test failure because its APK-installer teardown lost an offline device. The
+# classifier reads only preserved phase evidence and never retries/restarts.
+# shellcheck source=scripts/lib/nightly-phase-classification.sh
+source "$REPO_ROOT/scripts/lib/nightly-phase-classification.sh"
+PHASE_CLASSIFICATIONS_DIR="$ARTIFACT_DIR/phase-classifications"
+
 # ---------------------------------------------------------------------------
 # Sharding (issue #835 follow-up): the full connected journey/E2E suite is
 # ~680 tests. Run serially on ONE swiftshader AVD it cannot finish inside the
@@ -301,6 +308,14 @@ echo "phase 1 (journey/E2E) exit code: $JOURNEY_EXIT"
 # Snapshot phase 1's report BEFORE the phase-2 gradle invocation overwrites it
 # (issue #1293). Observability only — never affects JOURNEY_EXIT.
 preserve_phase_reports "phase1-journey" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+write_nightly_phase_classification \
+  "$PHASE_CLASSIFICATIONS_DIR/phase1-journey.txt" \
+  "phase1-journey" "$JOURNEY_EXIT" "$PHASE_REPORTS_DIR/phase1-journey"
+capture_nightly_device_boundary \
+  "$PHASE_CLASSIFICATIONS_DIR/phase1-journey-device.txt" "phase1-journey"
+JOURNEY_CLASSIFICATION="$(
+  classify_nightly_phase "$JOURNEY_EXIT" "$PHASE_REPORTS_DIR/phase1-journey"
+)"
 
 # Default the dedicated/aux phases to SKIPPED; only shard 0 owns them.
 NOTIFICATION_PERMISSION_EXIT=0
@@ -312,6 +327,10 @@ notification_permission_executed=0
 nf_status="SKIP"
 bootstrap_status="SKIP"
 expectedfail_status="SKIP"
+notification_permission_classification="SKIP"
+nf_classification="SKIP"
+bootstrap_classification="SKIP"
+expectedfail_classification="SKIP"
 
 if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   echo "=========================================================="
@@ -343,9 +362,21 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
     "phase1b-notification-permission" \
     "$APP_BUILD_DIR" \
     "$PHASE_REPORTS_DIR"
-
-  notification_permission_status="PASS"
-  [[ "$NOTIFICATION_PERMISSION_EXIT" -ne 0 ]] && notification_permission_status="FAIL"
+  write_nightly_phase_classification \
+    "$PHASE_CLASSIFICATIONS_DIR/phase1b-notification-permission.txt" \
+    "phase1b-notification-permission" "$NOTIFICATION_PERMISSION_EXIT" \
+    "$PHASE_REPORTS_DIR/phase1b-notification-permission"
+  capture_nightly_device_boundary \
+    "$PHASE_CLASSIFICATIONS_DIR/phase1b-notification-permission-device.txt" \
+    "phase1b-notification-permission"
+  notification_permission_classification="$(
+    classify_nightly_phase \
+      "$NOTIFICATION_PERMISSION_EXIT" \
+      "$PHASE_REPORTS_DIR/phase1b-notification-permission"
+  )"
+  notification_permission_status="$(
+    nightly_phase_status "$notification_permission_classification"
+  )"
 
   echo "=========================================================="
   echo "Nightly Extensive Tests — phase 2: network-fault proofs (un-gated, GATING)"
@@ -377,6 +408,17 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   # DisconnectBlackhole / NatIdle failing assertions unrecoverable. Observability
   # only — never affects NETWORK_FAULT_EXIT.
   preserve_phase_reports "phase2-network-fault" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+  write_nightly_phase_classification \
+    "$PHASE_CLASSIFICATIONS_DIR/phase2-network-fault.txt" \
+    "phase2-network-fault" "$NETWORK_FAULT_EXIT" \
+    "$PHASE_REPORTS_DIR/phase2-network-fault"
+  capture_nightly_device_boundary \
+    "$PHASE_CLASSIFICATIONS_DIR/phase2-network-fault-device.txt" \
+    "phase2-network-fault"
+  nf_classification="$(
+    classify_nightly_phase \
+      "$NETWORK_FAULT_EXIT" "$PHASE_REPORTS_DIR/phase2-network-fault"
+  )"
 
   echo "=========================================================="
   echo "Nightly Extensive Tests — phase 2b: #822 expected-fail lane (NON-GATING)"
@@ -400,6 +442,17 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   # Snapshot phase 2b's report BEFORE the phase-3 gradle invocation overwrites it
   # (issue #1293). Observability only — never affects EXPECTED_FAIL_EXIT.
   preserve_phase_reports "phase2b-expected-fail" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+  write_nightly_phase_classification \
+    "$PHASE_CLASSIFICATIONS_DIR/phase2b-expected-fail.txt" \
+    "phase2b-expected-fail" "$EXPECTED_FAIL_EXIT" \
+    "$PHASE_REPORTS_DIR/phase2b-expected-fail"
+  capture_nightly_device_boundary \
+    "$PHASE_CLASSIFICATIONS_DIR/phase2b-expected-fail-device.txt" \
+    "phase2b-expected-fail"
+  expectedfail_classification="$(
+    classify_nightly_phase \
+      "$EXPECTED_FAIL_EXIT" "$PHASE_REPORTS_DIR/phase2b-expected-fail"
+  )"
 
   echo "=========================================================="
   echo "Nightly Extensive Tests — phase 3: bootstrap setup scenarios (opt-in, GATING)"
@@ -423,13 +476,18 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   # per-phase set complete + uniform (and future-proofs adding a phase 4).
   # Observability only — never affects BOOTSTRAP_EXIT.
   preserve_phase_reports "phase3-bootstrap" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+  write_nightly_phase_classification \
+    "$PHASE_CLASSIFICATIONS_DIR/phase3-bootstrap.txt" \
+    "phase3-bootstrap" "$BOOTSTRAP_EXIT" "$PHASE_REPORTS_DIR/phase3-bootstrap"
+  capture_nightly_device_boundary \
+    "$PHASE_CLASSIFICATIONS_DIR/phase3-bootstrap-device.txt" "phase3-bootstrap"
+  bootstrap_classification="$(
+    classify_nightly_phase "$BOOTSTRAP_EXIT" "$PHASE_REPORTS_DIR/phase3-bootstrap"
+  )"
 
-  nf_status="PASS"
-  [[ "$NETWORK_FAULT_EXIT" -ne 0 ]] && nf_status="FAIL"
-  bootstrap_status="PASS"
-  [[ "$BOOTSTRAP_EXIT" -ne 0 ]] && bootstrap_status="FAIL"
-  expectedfail_status="PASS"
-  [[ "$EXPECTED_FAIL_EXIT" -ne 0 ]] && expectedfail_status="FAIL"
+  nf_status="$(nightly_phase_status "$nf_classification")"
+  bootstrap_status="$(nightly_phase_status "$bootstrap_classification")"
+  expectedfail_status="$(nightly_phase_status "$expectedfail_classification")"
 
   # Issue #1201: emit the authoritative, machine-readable fault-injection safety
   # verdict from the network-fault + bootstrap phases ONLY. The journey suite
@@ -454,8 +512,7 @@ else
   echo "=========================================================="
 fi
 
-journey_status="PASS"
-[[ "$JOURNEY_EXIT" -ne 0 ]] && journey_status="FAIL"
+journey_status="$(nightly_phase_status "$JOURNEY_CLASSIFICATION")"
 
 # `overall_status` is the human/summary verdict for the whole extensive shard. It
 # includes the journey suite and both GATING fault phases, but NOT the #822
@@ -483,11 +540,11 @@ fi
   echo
   echo "| Phase | Selection | Args | Exit | Result |"
   echo "| --- | --- | --- | --- | --- |"
-  echo "| Journey / E2E (non-gating) | full connected suite minus network-fault + expected-fail + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** |"
-  echo "| Notification permission (NON-GATING) | dedicated unsharded $NOTIFICATION_PERMISSION_TEST_CLASS; executed=$notification_permission_executed | external revoke/verify before instrumentation; external grant/verify after | $NOTIFICATION_PERMISSION_EXIT | **$notification_permission_status** |"
-  echo "| Network-fault proofs (GATING) | ${#NETWORK_FAULT_CLASSES[@]} Toxiproxy-backed classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** |"
-  echo "| #822 expected-fail lane (NON-GATING) | ${#EXPECTED_FAIL_CLASSES[@]} Slice C/D TDD spec class(es) | \`pocketshellNetworkFaultProofs=true\` | $EXPECTED_FAIL_EXIT | **$expectedfail_status** |"
-  echo "| Bootstrap setup scenarios (GATING) | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** |"
+  echo "| Journey / E2E (non-gating) | full connected suite minus network-fault + expected-fail + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** ($JOURNEY_CLASSIFICATION) |"
+  echo "| Notification permission (NON-GATING) | dedicated unsharded $NOTIFICATION_PERMISSION_TEST_CLASS; executed=$notification_permission_executed | external revoke/verify before instrumentation; external grant/verify after | $NOTIFICATION_PERMISSION_EXIT | **$notification_permission_status** ($notification_permission_classification) |"
+  echo "| Network-fault proofs (GATING) | ${#NETWORK_FAULT_CLASSES[@]} Toxiproxy-backed classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** ($nf_classification) |"
+  echo "| #822 expected-fail lane (NON-GATING) | ${#EXPECTED_FAIL_CLASSES[@]} Slice C/D TDD spec class(es) | \`pocketshellNetworkFaultProofs=true\` | $EXPECTED_FAIL_EXIT | **$expectedfail_status** ($expectedfail_classification) |"
+  echo "| Bootstrap setup scenarios (GATING) | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** ($bootstrap_classification) |"
   echo
   echo "**Extensive-shard overall (non-gating summary): $overall_status**"
   echo
@@ -496,6 +553,8 @@ fi
   echo "longer overwrites an earlier phase's JUnit XML / HTML report / device"
   echo "output before the artifact upload. Read the GATING phase-2 assertions at"
   echo "\`artifacts/nightly-extensive/phase-reports/phase2-network-fault/\`."
+  echo "Phase classifications and read-only adb boundary evidence are under"
+  echo "\`artifacts/nightly-extensive/phase-classifications/\`."
   echo
   echo "## Fault-injection safety verdict (issue #1201 — the RELEASE-GATING signal)"
   echo

--- a/scripts/test-nightly-phase-classification.sh
+++ b/scripts/test-nightly-phase-classification.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Regression for issue #1991: a UTP device-offline teardown must not be
+# presented as a product network-fault assertion, while any substantive JUnit
+# failure in the same phase must remain product-red.
+# shellcheck disable=SC2016 # literal source-wiring assertions below
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/lib/nightly-phase-classification.sh
+source "$SCRIPT_DIR/lib/nightly-phase-classification.sh"
+# shellcheck source=scripts/lib/nightly-fault-verdict.sh
+source "$SCRIPT_DIR/lib/nightly-fault-verdict.sh"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+write_report() {
+  local name="$1"
+  local failure_body="$2"
+  local system_err="$3"
+  local root="$SANDBOX/$name"
+  mkdir -p "$root"
+  {
+    printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+    printf '%s\n' '<testsuite tests="1" failures="1" errors="0" skipped="0">'
+    printf '%s\n' '  <testcase name="loadBearing" classname="com.pocketshell.Proof">'
+    printf '    <failure>%s</failure>\n' "$failure_body"
+    printf '%s\n' '  </testcase>'
+    printf '  <system-err>%s</system-err>\n' "$system_err"
+    printf '%s\n' '</testsuite>'
+  } > "$root/TEST-device.xml"
+  printf '%s\n' "$root"
+}
+
+offline_signature='Exception thrown during onAfterAll invocation of plugin AndroidTestApkInstallerPlugin: device offline
+Caused by: com.android.ddmlib.AdbCommandRejectedException: device offline'
+
+offline_only="$(write_report offline-only '' "$offline_signature")"
+product_only="$(write_report product-only 'java.lang.AssertionError: exact product invariant' '')"
+mixed="$(write_report mixed 'java.lang.AssertionError: exact product invariant' "$offline_signature")"
+empty_only="$(write_report empty-only '' '')"
+
+failures=0
+assert_classification() {
+  local label="$1" expected="$2" exit_code="$3" report_root="$4"
+  local actual
+  actual="$(classify_nightly_phase "$exit_code" "$report_root")"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'FAIL [%s]: expected %s, got %s\n' "$label" "$expected" "$actual"
+    failures=$((failures + 1))
+  else
+    printf 'ok   [%s] -> %s\n' "$label" "$actual"
+  fi
+}
+
+assert_classification "green phase" PASS 0 "$empty_only"
+assert_classification "UTP offline + empty failure" INFRA_DEVICE_OFFLINE 1 "$offline_only"
+assert_classification "substantive assertion" PRODUCT_FAILURE 1 "$product_only"
+assert_classification "product assertion dominates later offline" PRODUCT_AND_INFRA 1 "$mixed"
+assert_classification "unclassified empty failure stays red" PRODUCT_FAILURE 1 "$empty_only"
+
+evidence="$SANDBOX/classification.txt"
+write_nightly_phase_classification "$evidence" phase2-network-fault 1 "$offline_only"
+grep -Fqx 'phase=phase2-network-fault' "$evidence" || failures=$((failures + 1))
+grep -Fqx 'classification=INFRA_DEVICE_OFFLINE' "$evidence" || failures=$((failures + 1))
+grep -Fqx 'device_offline_signature=yes' "$evidence" || failures=$((failures + 1))
+grep -Fqx 'substantive_junit_failure=no' "$evidence" || failures=$((failures + 1))
+
+# Release-verdict integration: INFRA blocks distinctly; a real product failure
+# still wins if the other gating phase is infrastructure-red.
+verdict="$(compute_fault_verdict INFRA PASS)" && verdict_rc=0 || verdict_rc=$?
+[[ "$verdict" == INFRA && "$verdict_rc" -eq 2 ]] || failures=$((failures + 1))
+verdict="$(compute_fault_verdict FAIL INFRA)" && verdict_rc=0 || verdict_rc=$?
+[[ "$verdict" == FAIL && "$verdict_rc" -eq 1 ]] || failures=$((failures + 1))
+
+# Gate wiring: pin the phase-2 preserved report -> classification -> status
+# chain and the dedicated workflow message. These assertions complement the
+# behavioural fixture above; neither can green if the production call site is
+# disconnected from the tested helper.
+suite="$REPO_ROOT/scripts/nightly-extensive-suite.sh"
+workflow="$REPO_ROOT/.github/workflows/nightly-extensive.yml"
+# These are intentionally literal source-wiring needles, not shell expansions.
+grep -Fq '"$PHASE_CLASSIFICATIONS_DIR/phase2-network-fault.txt"' "$suite" \
+  || failures=$((failures + 1))
+grep -Fq '"$NETWORK_FAULT_EXIT" "$PHASE_REPORTS_DIR/phase2-network-fault"' "$suite" \
+  || failures=$((failures + 1))
+grep -Fq 'nf_status="$(nightly_phase_status "$nf_classification")"' "$suite" \
+  || failures=$((failures + 1))
+grep -Fq 'if [[ "$verdict" == "INFRA" ]]' "$workflow" \
+  || failures=$((failures + 1))
+grep -Fq 'BLOCK-INFRA:' "$workflow" || failures=$((failures + 1))
+
+if [[ "$failures" -ne 0 ]]; then
+  printf 'NIGHTLY PHASE CLASSIFICATION SELF-TEST FAIL: %s failure(s)\n' "$failures"
+  exit 1
+fi
+echo 'NIGHTLY PHASE CLASSIFICATION SELF-TEST PASS'

--- a/scripts/test-notification-permission-fixture.sh
+++ b/scripts/test-notification-permission-fixture.sh
@@ -696,10 +696,23 @@ fi
 grep -q '^[[:space:]]*NOTIFICATION_PERMISSION_EXIT=\${PIPESTATUS\[0\]}$' \
   "$nightly_phase1b" \
   || fail "nightly phase 1b does not propagate the wrapper's real exit code"
+# Issue #1991: the summary status now comes from the preserved-report
+# classifier, so a strong UTP device-offline signature is surfaced as INFRA
+# while every other non-zero phase stays FAIL. Pin both the real exit/report
+# inputs and the classification-to-status mapping instead of the superseded
+# direct `-ne 0` assignment.
 # shellcheck disable=SC2016
-grep -q '^[[:space:]]*\[\[ "\$NOTIFICATION_PERMISSION_EXIT" -ne 0 \]\] && notification_permission_status="FAIL"$' \
+grep -q 'classify_nightly_phase.*"\$NOTIFICATION_PERMISSION_EXIT"' \
   "$nightly_phase1b" \
-  || fail "nightly phase 1b summary row no longer turns FAIL on a non-zero exit"
+  || fail "nightly phase 1b classification no longer consumes the real exit code"
+# shellcheck disable=SC2016
+grep -q '"\$PHASE_REPORTS_DIR/phase1b-notification-permission"' \
+  "$nightly_phase1b" \
+  || fail "nightly phase 1b classification no longer consumes its preserved report"
+# shellcheck disable=SC2016
+grep -q 'nightly_phase_status "\$notification_permission_classification"' \
+  "$nightly_phase1b" \
+  || fail "nightly phase 1b summary no longer maps its fail-safe classification"
 
 # Human extensive-shard verdict, scoped to the overall_status conditional.
 overall_status_block="$FIXTURE_ROOT/nightly-overall-status.txt"

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshSession.kt
@@ -1038,10 +1038,8 @@ internal class RealSshSession(
             //  - Genuine programming errors (NPE, IAE, ...) still
             //    propagate to the supervisor scope so they aren't
             //    silently swallowed.
-            // Channel open + the `tail -F` exec write are transport-mutating
-            // packets — serialise them through the dispatcher (issue #847). The
-            // long-lived line READ below runs OUTSIDE the dispatcher so the
-            // follow loop never wedges the `-CC` write or other ops.
+            // Dispatch channel open + exec writes; keep the long-lived read
+            // outside so tail cannot wedge other transport operations (#847).
             val sessionChannelRef = AtomicReference<Session?>()
             var cmd: Command? = null
             val cancelHandle = coroutineJob?.invokeOnCompletion(onCancelling = true) {
@@ -1054,8 +1052,7 @@ internal class RealSshSession(
                 }
             }
             try {
-                // -F follows by name, surviving rotation. Quote the path so
-                // weird filenames don't break the shell parsing.
+                // -F survives rotation; quote unusual paths for the shell.
                 val quoted = shellSingleQuote(path)
                 val lineArg = if (fromLineExclusive >= 0) {
                     "-n +${fromLineExclusive + 1}"
@@ -1064,7 +1061,13 @@ internal class RealSshSession(
                 }
                 cmd = try {
                     dispatcher.run {
-                        val channel = client.startSession()
+                        val channel = try {
+                            client.startSession()
+                        } catch (t: Throwable) {
+                            if (!isSshjDisconnect(t)) throw t
+                            logTailRecoverableFailure(path, t)
+                            return@run null
+                        }
                         sessionChannelRef.set(channel)
                         channel.exec("tail -F $lineArg $quoted")
                     }
@@ -1072,14 +1075,13 @@ internal class RealSshSession(
                     logTailRecoverableFailure(path, e)
                     return@launch
                 } catch (e: IOException) {
-                    // Channel-open / exec race against transport drop —
-                    // same recoverable-disconnect story as the
-                    // startSession() catch above.
+                    // Channel-open / exec raced a recoverable transport drop.
                     logTailRecoverableFailure(path, e)
                     return@launch
                 } catch (t: Throwable) {
                     throw SshException("Failed to start tail session for `$path`: ${t.message}", t)
                 }
+                if (cmd == null) return@launch
                 BufferedReader(InputStreamReader(cmd!!.inputStream, Charsets.UTF_8)).use { reader ->
                     while (isActive) {
                         val line = try {

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TailStartFailure.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/TailStartFailure.kt
@@ -1,0 +1,5 @@
+package com.pocketshell.core.ssh
+
+/** sshj's untyped sentinel when startSession races a transport disconnect. */
+internal fun isSshjDisconnect(error: Throwable): Boolean =
+    error is IllegalStateException && error.message == "Not connected"

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTailRecoverableFailureTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshSessionTailRecoverableFailureTest.kt
@@ -4,14 +4,29 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.LoggerFactory
+import net.schmizz.sshj.common.Message
+import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.common.SSHPacket
 import net.schmizz.sshj.connection.ConnectionException
+import net.schmizz.sshj.connection.channel.Channel
+import net.schmizz.sshj.connection.channel.direct.PTYMode
+import net.schmizz.sshj.connection.channel.direct.Session
+import net.schmizz.sshj.connection.channel.direct.Signal
 import net.schmizz.sshj.transport.TransportException
 import net.schmizz.sshj.common.DisconnectReason
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.IOException
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.SocketException
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
 
 /**
  * Issue #239 — `RealSshSession.tail()` must NOT propagate transport
@@ -53,11 +68,18 @@ import java.net.SocketException
  *     cleanly.
  *  4. `startSession()` throws `IOException` (catch-all parent of the
  *     sshj/socket families) → tail job completes cleanly.
- *  5. Negative case: `startSession()` throws a genuine programming
+ *  5. Issue #1963 recurrence: sshj's `checkConnected()` races a transport
+ *     cut and throws `IllegalStateException("Not connected")` from
+ *     `startSession()` → tail job completes cleanly like the typed transport
+ *     failures above.
+ *  6. Negative case: `startSession()` throws any other genuine programming
  *     error (`IllegalStateException`) → wrapped in `SshException` and
  *     surfaced via the job's completion exception (so genuine bugs
  *     still get reported).
- *  6. Issue #621: an unconnected session is a RECOVERABLE transport drop,
+ *  7. Negative source-boundary case: `startSession()` succeeds, then
+ *     `Session.exec()` throws the same `IllegalStateException("Not connected")`
+ *     text → wrapped and surfaced, never mistaken for sshj's start sentinel.
+ *  8. Issue #621: an unconnected session is a RECOVERABLE transport drop,
  *     not a programmer error. `tail()` on a disconnected session must NOT
  *     throw synchronously into the caller (that crashed the main thread via
  *     `startAgentConversationForPane` → `tailEventsFromLine` in app v0.3.29).
@@ -106,6 +128,17 @@ class RealSshSessionTailRecoverableFailureTest {
     }
 
     @Test
+    fun `tail swallows sshj Not connected race from startSession`() {
+        // Issue #1963: exact Nightly shard-2 crash after an intentional
+        // reconnect. The transport died after tail()'s optimistic connected
+        // check but before sshj's startSession(); SSHClient.checkConnected()
+        // reports that ordinary disconnect race as an IllegalStateException.
+        runTailJobCompletesCleanly(
+            IllegalStateException("Not connected"),
+        )
+    }
+
+    @Test
     fun `tail propagates genuine programming errors from startSession`() {
         // Negative case: a non-IOException Throwable is still wrapped in
         // SshException and surfaces to the coroutine root. We do NOT
@@ -146,6 +179,15 @@ class RealSshSessionTailRecoverableFailureTest {
             Thread.setDefaultUncaughtExceptionHandler(previousHandler)
             session.close()
         }
+    }
+
+    @Test
+    fun `tail propagates exact Not connected programming error from exec`() {
+        // The #1963 exception is recoverable only at SSHClient.startSession().
+        // Identical text from downstream channel logic remains a fatal bug.
+        runTailJobSurfacesWrappedSshException(
+            ConnectedSessionClient(ThrowingExecSession()),
+        )
     }
 
     @Test
@@ -224,6 +266,33 @@ class RealSshSessionTailRecoverableFailureTest {
         }
     }
 
+    private fun runTailJobSurfacesWrappedSshException(client: SSHClient) {
+        val session = RealSshSession(client)
+        val capturedExceptions = mutableListOf<Throwable>()
+        val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, throwable ->
+            capturedExceptions += throwable
+        }
+        try {
+            val job = session.tail("/agent.jsonl") { /* unreachable */ }
+            runBlocking {
+                withTimeout(5_000) { job.join() }
+            }
+            assertTrue(
+                "expected exact-message exec failure to surface as SshException; " +
+                    "captured=$capturedExceptions",
+                capturedExceptions.any { e ->
+                    e is SshException &&
+                        e.cause is IllegalStateException &&
+                        e.cause?.message == "Not connected"
+                },
+            )
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previousHandler)
+            session.close()
+        }
+    }
+
     /**
      * `SSHClient` that reports as connected + authenticated (so the
      * `ensureConnected()` precondition passes) and throws the
@@ -250,6 +319,59 @@ class RealSshSessionTailRecoverableFailureTest {
             // invokes `super.disconnect()` which would NPE walking
             // uninitialised connection state.
         }
+    }
+
+    private class ConnectedSessionClient(
+        private val sessionChannel: Session,
+    ) : SSHClient() {
+        override fun isConnected(): Boolean = true
+        override fun isAuthenticated(): Boolean = true
+        override fun startSession(): Session = sessionChannel
+        override fun disconnect() = Unit
+    }
+
+    private class ThrowingExecSession : FakeChannel(), Session {
+        override fun exec(command: String): Session.Command =
+            throw IllegalStateException("Not connected")
+
+        override fun allocateDefaultPTY() = Unit
+        override fun allocatePTY(
+            term: String,
+            cols: Int,
+            rows: Int,
+            width: Int,
+            height: Int,
+            modes: MutableMap<PTYMode, Int>,
+        ) = Unit
+
+        override fun reqX11Forwarding(host: String, proto: String, cookie: Int) = Unit
+        override fun setEnvVar(name: String, value: String) = Unit
+        override fun startShell(): Session.Shell = throw UnsupportedOperationException("not used")
+        override fun startSubsystem(name: String): Session.Subsystem =
+            throw UnsupportedOperationException("not used")
+    }
+
+    private abstract class FakeChannel : Channel {
+        override fun close() = Unit
+        override fun getAutoExpand(): Boolean = false
+        override fun getID(): Int = 1
+        override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+        override fun getLocalMaxPacketSize(): Int = 32 * 1024
+        override fun getLocalWinSize(): Long = 0L
+        override fun getOutputStream(): OutputStream = ByteArrayOutputStream()
+        override fun getRecipient(): Int = 1
+        override fun getRemoteCharset(): Charset = StandardCharsets.UTF_8
+        override fun getRemoteMaxPacketSize(): Int = 32 * 1024
+        override fun getRemoteWinSize(): Long = 0L
+        override fun getType(): String = "session"
+        override fun isOpen(): Boolean = true
+        override fun setAutoExpand(autoExpand: Boolean) = Unit
+        override fun join() = Unit
+        override fun join(timeout: Long, unit: TimeUnit) = Unit
+        override fun isEOF(): Boolean = false
+        override fun getLoggerFactory(): LoggerFactory = LoggerFactory.DEFAULT
+        override fun handle(message: Message, packet: SSHPacket) = Unit
+        override fun notifyError(error: SSHException) = Unit
     }
 
     /**


### PR DESCRIPTION
Fixes #1991.
Fixes #1992.
Fixes #1963.

- classify UTP/device-offline phase failures separately from product assertions while preserving mixed failures as red
- isolate the Claude usage-warning fixture owner before the walkthrough smoke journey
- treat only sshj `startSession()` exact `Not connected` as a recoverable tail-start disconnect; downstream identical-message exceptions remain fatal

Review evidence is linked on each issue. Combined local `scripts/full-jvm-gate.sh`: 605/605 tasks, BUILD SUCCESSFUL in 19m33s. Root working tree retained the unrelated untracked `ssh` file.