### PR TITLE
Fix nightly conversation fixtures and composer timer threading

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingTimerAndTailTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingTimerAndTailTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.composer
 
+import android.os.Looper
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -15,6 +16,8 @@ import com.pocketshell.app.settings.VoiceTranscriptionProvider
 import com.pocketshell.core.voice.SpeechAudioGuard
 import com.pocketshell.core.voice.WhisperClient
 import com.pocketshell.uikit.theme.PocketShellTheme
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -109,7 +112,17 @@ class PromptComposerRecordingTimerAndTailTest {
             voiceSettings = AndroidSpeechSettings(),
             speechRecognitionProvider = speech,
         )
-        vm.clock = { nowMs }
+        // The production ticker reads clock() and immediately updates _uiState
+        // in the same coroutine, with no suspension between those operations.
+        // Therefore this records the actual Compose-observed writer context,
+        // while the rendered timer assertions below prove that ticker ran.
+        val offMainTickerClockReads = AtomicInteger(0)
+        vm.clock = {
+            if (Looper.myLooper() != Looper.getMainLooper()) {
+                offMainTickerClockReads.incrementAndGet()
+            }
+            nowMs
+        }
 
         compose.setContent {
             PocketShellTheme {
@@ -150,6 +163,11 @@ class PromptComposerRecordingTimerAndTailTest {
                 compose.onNodeWithTag(COMPOSER_TIMER_TAG).assertTextEquals("00:21")
             }.isSuccess
         }
+        assertEquals(
+            "the production ticker must read and publish elapsed state on Android main",
+            0,
+            offMainTickerClockReads.get(),
+        )
 
         // #870 — feed a long live partial through the real recognizer listener.
         // The production applyLiveSpeechTranscript stores the raw growing partial;

--- a/app/src/androidTest/java/com/pocketshell/app/hosts/HostEditFromKebabE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/HostEditFromKebabE2eTest.kt
@@ -17,7 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.proof.PreGrantPermissionsRule
-import com.pocketshell.app.usage.UsageScheduler
+import com.pocketshell.app.usage.UsageSchedulerTestIsolationRule
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import java.io.File
@@ -25,9 +25,9 @@ import java.io.FileOutputStream
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 /**
@@ -47,52 +47,24 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class HostEditFromKebabE2eTest {
 
-    @get:Rule
     val compose = createEmptyComposeRule()
 
     // Issue #470 blocker #1: grant runtime permissions before the activity
     // launches so the system GrantPermissionsActivity never steals focus
     // from the Compose hierarchy ("No compose hierarchies found").
     @get:Rule
-    val grantPermissions = PreGrantPermissionsRule()
+    val rules: RuleChain = RuleChain
+        .outerRule(UsageSchedulerTestIsolationRule())
+        .around(PreGrantPermissionsRule())
+        .around(compose)
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
-    private var usageScheduler: UsageScheduler? = null
     private var hostId: Long? = null
-    private var keyId: Long? = null
 
     @After
     fun tearDown() {
-        val scheduler = usageScheduler
         launchedActivity?.close()
         launchedActivity = null
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val db = openDb(appContext)
-        try {
-            runBlocking {
-                hostId?.let { db.hostDao().deleteById(it) }
-                keyId?.let { db.sshKeyDao().deleteById(it) }
-            }
-        } finally {
-            db.close()
-        }
-        // Issue #1992: this test deliberately gives the process-singleton
-        // UsageScheduler an eligible Docker host. Its real fixture response
-        // includes Claude at 85%, so merely deleting the Room row leaves a
-        // warning snapshot cached for later classes in the same shard. Drain
-        // against the now-empty host table before handing the instrumentation
-        // process to the next test; this is the owning fixture's cleanup, not
-        // a smoke-test bypass of the real warning UI.
-        runBlocking {
-            scheduler?.refreshNow()
-        }
-        scheduler?.snapshots?.value?.let { snapshots ->
-            assertTrue(
-                "HostEditFromKebabE2eTest must not leak process-wide usage snapshots",
-                snapshots.isEmpty(),
-            )
-        }
-        usageScheduler = null
     }
 
     @Test
@@ -103,9 +75,6 @@ class HostEditFromKebabE2eTest {
         val id = requireNotNull(hostId)
 
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
-        launchedActivity!!.onActivity { activity ->
-            usageScheduler = activity.usageScheduler
-        }
         launchedActivity!!.moveToState(Lifecycle.State.RESUMED)
 
         // Land on the host list — the seeded row is present.
@@ -188,7 +157,6 @@ class HostEditFromKebabE2eTest {
                     name = "edit-kebab-key-${System.nanoTime()}",
                     content = key,
                 )
-                keyId = storedKey.id
                 hostId = db.hostDao().insert(
                     HostEntity(
                         name = hostName,

--- a/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorDockerSshSmokeTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorDockerSshSmokeTest.kt
@@ -38,6 +38,7 @@ import com.pocketshell.app.tmux.TMUX_CONVERSATION_DETECTING_TAG
 import com.pocketshell.app.tmux.TMUX_CONVERSATION_PANE_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
+import com.pocketshell.app.usage.UsageSchedulerTestIsolationRule
 import com.pocketshell.app.usage.usageBannerTagFor
 import com.pocketshell.app.session.AgentConversationRepository
 import com.pocketshell.core.agents.AgentDetection
@@ -56,6 +57,7 @@ import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
@@ -73,14 +75,16 @@ import java.io.FileOutputStream
 @RunWith(AndroidJUnit4::class)
 class EmulatorDockerSshSmokeTest {
 
-    @get:Rule
     val compose = createEmptyComposeRule()
 
     // Issue #470 blocker #1: grant runtime permissions before the activity
     // launches so the system GrantPermissionsActivity never steals focus
     // from the Compose hierarchy ("No compose hierarchies found").
     @get:Rule
-    val grantPermissions = PreGrantPermissionsRule()
+    val rules: RuleChain = RuleChain
+        .outerRule(UsageSchedulerTestIsolationRule())
+        .around(PreGrantPermissionsRule())
+        .around(compose)
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiHostSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiHostSessionE2eTest.kt
@@ -8,15 +8,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
-import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToString
 import androidx.room.Room
-import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
@@ -39,6 +39,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
@@ -61,27 +62,37 @@ import java.io.FileOutputStream
 @RunWith(AndroidJUnit4::class)
 class MultiHostSessionE2eTest {
 
-    @get:Rule
-    val compose = createEmptyComposeRule()
+    // Issue #1993: the former createEmptyComposeRule + ActivityScenario harness
+    // let InstrumentationActivityInvoker$EmptyActivity retake foreground between
+    // the host tap and the folder assertion in the long hosted shard, destroying
+    // MainActivity. The launch-owned rule keeps the production surface alive;
+    // SeedBeforeLaunchRule establishes both remote sessions and Room rows before
+    // MainActivity's first composition.
+    val compose = createAndroidComposeRule<MainActivity>()
 
-    // Issue #470 blocker #1: grant runtime permissions before the activity
-    // launches so the system GrantPermissionsActivity never steals focus
-    // from the Compose hierarchy ("No compose hierarchies found").
     @get:Rule
-    val grantPermissions = PreGrantPermissionsRule()
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
 
-    private var launchedActivity: ActivityScenario<MainActivity>? = null
     private val timings = mutableListOf<String>()
     private var sessionA: String = ""
     private var sessionB: String = ""
+    private var fixtureKey: String? = null
+    private var seededHosts: SeededHosts? = null
+    private var expectedHostA: String? = null
+    private var expectedHostB: String? = null
+    private var baselineHostA: Int? = null
+    private var baselineHostB: Int? = null
+    private var navigationAttempt: Int = 0
 
     @After
     fun tearDown() {
-        launchedActivity?.close()
-        launchedActivity = null
+        clearLastSessionPrefs()
         runBlocking {
             runCatching {
-                val key = readFixtureKey()
+                val key = fixtureKey ?: readFixtureKey()
                 cleanupSession(key, AGENTS_PORT, sessionA)
                 cleanupSession(key, TMUX_PORT, sessionB)
             }
@@ -90,26 +101,14 @@ class MultiHostSessionE2eTest {
 
     @Test
     fun switchingBetweenHostsPreservesRemoteSessionTranscript() { runBlocking {
-        val key = readFixtureKey()
-        val pem = SshKey.Pem(key)
-        waitForSshFixtureReady(pem, port = AGENTS_PORT)
-        waitForSshFixtureReady(pem, port = TMUX_PORT)
-
-        val suffix = System.currentTimeMillis().toString().takeLast(6)
-        sessionA = "issue147-a-$suffix"
-        sessionB = "issue147-b-$suffix"
-        val expectedHostA = seedSession(key, AGENTS_PORT, sessionA, "HOST-A-READY")
-        val expectedHostB = seedSession(key, TMUX_PORT, sessionB, "HOST-B-READY")
-        val baselineA = sshdProcessCount(key, AGENTS_PORT)
-        val baselineB = sshdProcessCount(key, TMUX_PORT)
-        Log.i(LOG_TAG, "sshd baseline: hostA=$baselineA hostB=$baselineB")
-
-        val hosts = seedDockerHosts(key)
-        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        val key = requireNotNull(fixtureKey) { "seed-before-launch fixture key missing" }
+        val hosts = requireNotNull(seededHosts) { "seed-before-launch hosts missing" }
+        val hostAHostname = requireNotNull(expectedHostA) { "seed-before-launch host A marker missing" }
+        val hostBHostname = requireNotNull(expectedHostB) { "seed-before-launch host B marker missing" }
 
         attachFromHostList(hosts.hostARowTag, hosts.hostAName, sessionA)
         waitForPtyReady("host A initial attach")
-        val hostAMarker = "host-a:$expectedHostA"
+        val hostAMarker = "host-a:$hostAHostname"
         sendCommandThroughTerminalInput(
             command = "printf 'host-a:%s\\n' \"\$(hostname)\"",
             label = "host A hostname marker",
@@ -128,7 +127,7 @@ class MultiHostSessionE2eTest {
 
         attachFromHostList(hosts.hostBRowTag, hosts.hostBName, sessionB)
         waitForPtyReady("host B attach")
-        val hostBMarker = "host-b:$expectedHostB"
+        val hostBMarker = "host-b:$hostBHostname"
         sendCommandThroughTerminalInput(
             command = "printf 'host-b:%s\\n' \"\$(hostname)\"",
             label = "host B hostname marker",
@@ -158,12 +157,31 @@ class MultiHostSessionE2eTest {
         }
         captureViewport("03-host-a-marker-preserved")
 
-        bestEffortAssertNoRunawaySshdChildren(key, AGENTS_PORT, baselineA, "host A")
-        bestEffortAssertNoRunawaySshdChildren(key, TMUX_PORT, baselineB, "host B")
+        bestEffortAssertNoRunawaySshdChildren(key, AGENTS_PORT, baselineHostA, "host A")
+        bestEffortAssertNoRunawaySshdChildren(key, TMUX_PORT, baselineHostB, "host B")
 
         writeTimings()
         Unit
     } }
+
+    private suspend fun seedBeforeLaunch() {
+        clearLastSessionPrefs()
+        val key = readFixtureKey()
+        fixtureKey = key
+        val pem = SshKey.Pem(key)
+        waitForSshFixtureReady(pem, port = AGENTS_PORT)
+        waitForSshFixtureReady(pem, port = TMUX_PORT)
+
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        sessionA = "issue147-a-$suffix"
+        sessionB = "issue147-b-$suffix"
+        expectedHostA = seedSession(key, AGENTS_PORT, sessionA, "HOST-A-READY")
+        expectedHostB = seedSession(key, TMUX_PORT, sessionB, "HOST-B-READY")
+        baselineHostA = sshdProcessCount(key, AGENTS_PORT)
+        baselineHostB = sshdProcessCount(key, TMUX_PORT)
+        Log.i(LOG_TAG, "sshd baseline: hostA=$baselineHostA hostB=$baselineHostB")
+        seededHosts = seedDockerHosts(key)
+    }
 
     private fun readFixtureKey(): String =
         InstrumentationRegistry.getInstrumentation()
@@ -197,6 +215,10 @@ class MultiHostSessionE2eTest {
                     pocketshellInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
                     pocketshellLastDetectedAt = System.currentTimeMillis(),
+                    // This journey owns host/session switching, not bootstrap.
+                    // Keep the setup cache internally complete so HostList does
+                    // not route the tmux-only host-B fixture into a setup sheet.
+                    pocketshellVersionCompatible = true,
                 )
 
             val hostAName = "Issue147 Host A"
@@ -275,6 +297,13 @@ class MultiHostSessionE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        navigationAttempt += 1
+        captureNavigationState("host-tap-$navigationAttempt-$sessionName")
+        compose.waitUntil(timeoutMillis = 15_000) {
+            compose.onAllNodesWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
         compose.onNodeWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForText(hostName, timeoutMs = 10_000)
         waitForText(sessionName, timeoutMs = folderListWaitMs())
@@ -284,8 +313,13 @@ class MultiHostSessionE2eTest {
     }
 
     private fun returnToHostList() {
-        launchedActivity?.onActivity { activity ->
-            (activity as ComponentActivity).onBackPressedDispatcher.onBackPressed()
+        compose.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
+        compose.waitUntil(timeoutMillis = 15_000) {
+            compose.onAllNodesWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
         }
         compose.onNodeWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true).assertExists()
         compose.onNodeWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true).performClick()
@@ -351,7 +385,7 @@ class MultiHostSessionE2eTest {
     private fun waitForTerminalViewAttached() {
         compose.waitUntil(timeoutMillis = 30_000) {
             var attached = false
-            launchedActivity?.onActivity { activity ->
+            compose.activityRule.scenario.onActivity { activity ->
                 val view = activity.window.decorView.findTerminalView()
                 attached = view?.currentSession != null && view.mEmulator != null
             }
@@ -397,7 +431,7 @@ class MultiHostSessionE2eTest {
 
     private fun terminalInputConnection(): InputConnection {
         var connection: InputConnection? = null
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             val view = requireNotNull(activity.window.decorView.findTerminalView()) {
                 "TerminalView was not found"
             }
@@ -410,7 +444,7 @@ class MultiHostSessionE2eTest {
 
     private fun visibleTerminalText(): String {
         var text = ""
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             text = activity.window.decorView
                 .findTerminalView()
                 ?.currentSession
@@ -424,7 +458,7 @@ class MultiHostSessionE2eTest {
 
     private fun terminalGridSize(): GridSize {
         var grid: GridSize? = null
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             activity.window.decorView
                 .findTerminalView()
                 ?.currentSession
@@ -477,7 +511,7 @@ class MultiHostSessionE2eTest {
         SystemClock.sleep(150)
 
         var bitmap: Bitmap? = null
-        launchedActivity?.onActivity { activity ->
+        compose.activityRule.scenario.onActivity { activity ->
             val view = activity.window.decorView.findTerminalView() ?: return@onActivity
             if (view.width <= 0 || view.height <= 0) return@onActivity
             val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
@@ -496,6 +530,14 @@ class MultiHostSessionE2eTest {
         val bitmap = instrumentation.uiAutomation.takeScreenshot()
         writeBitmap(name, bitmap)
         bitmap.recycle()
+    }
+
+    private fun captureNavigationState(name: String) {
+        captureFullScreen(name)
+        writeText(
+            "$name-semantics.txt",
+            compose.onRoot(useUnmergedTree = true).printToString(maxDepth = 12),
+        )
     }
 
     private fun writeBitmap(name: String, bitmap: Bitmap): File {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
@@ -1,7 +1,6 @@
 package com.pocketshell.app.proof
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.os.SystemClock
 import android.util.Log
 import android.view.View
@@ -30,10 +29,14 @@ import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.SSH_HANDSHAKE_ATTEMPTS
 import com.pocketshell.app.tmux.TMUX_CONNECT_ATTEMPTS
 import com.pocketshell.app.tmux.TMUX_CONSOLIDATED_SESSION_LABEL_TAG
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_DETECTING_TAG
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_PANE_TAG
 import com.pocketshell.app.tmux.TMUX_FULL_BREADCRUMB_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_OVERLAY_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_PAGE_TAG_PREFIX
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
+import com.pocketshell.app.tmux.TmuxSessionLatencyTelemetry
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -65,7 +68,7 @@ import java.io.FileOutputStream
  * swipe-DOWN on the top chrome opens a [HorizontalPager] of same-host
  * sessions ([TMUX_SESSION_PAGER_OVERLAY_TAG]); choosing a session
  * lazy-attaches it. This test exercises the path end-to-end on the
- * deterministic Docker `agents` fixture and pins four contracts:
+ * deterministic Docker `agents` fixture and pins five contracts:
  *
  *  1. **The switch happens.** A horizontal swipe switches the app AWAY from
  *     SESSION_A onto the adjacent same-host session: SESSION_A's unique
@@ -78,15 +81,21 @@ import java.io.FileOutputStream
  *     not fire a fresh SSH handshake; [SSH_HANDSHAKE_ATTEMPTS] must not
  *     advance across the switch. A fresh socket would be the 2-5s
  *     `kex_exchange_identification` regression the fast-switch path deleted.
- *  3. **Previous tmux client detached** (#235 / #215). After swiping away
- *     from SESSION_A, `tmux list-clients -t SESSION_A` reports zero clients
- *     — the previous `-CC` control client was `detachCleanly()`'d, so no
- *     orphan lingers to hit the size-lock issue.
+ *  3. **Exactly one previous tmux client remains owned by the warm cache.**
+ *     Since #626, a same-host switch deliberately parks SESSION_A's live
+ *     runtime so switch-back is a pointer swap. `tmux list-clients` must
+ *     therefore report exactly one client on SESSION_A: zero would mean the
+ *     warm-switch contract was lost; more than one would be a real duplicate
+ *     / orphan regression (#235 / #215).
  *  4. **The swipe debounces.** The pager's settle path can emit spurious
  *     `settledPage` values (the spike's flagged risk); if the overlay acted
  *     on them the logical tmux connect counter would advance more than once
  *     for the single swipe. We assert exactly one logical tmux connect fires
  *     for that swipe, so a spurious double-fire is caught.
+ *  5. **Switch-back activates the cached runtime.** A second pager swipe from
+ *     B back to A must atomically restore A's marker, record one cache
+ *     activation, open no fresh tmux control client or SSH transport, and
+ *     leave exactly one owned client on each runtime.
  *
  * Gesture note: BOTH gestures are driven as real touch input — the
  * swipe-DOWN that opens the session pager AND the horizontal swipe-LEFT that
@@ -149,7 +158,7 @@ class SessionSwipeSwitchE2eTest {
     }
 
     @Test
-    fun swipeDownPagerSwitchesSessionReusingSshAndDetaching() { runBlocking {
+    fun swipeDownPagerSwitchesSessionAndActivatesCachedRuntimeOnReturn() { runBlocking {
         val key = readFixtureKey()
         waitForSshFixtureReady(SshKey.Pem(key))
 
@@ -169,6 +178,7 @@ class SessionSwipeSwitchE2eTest {
         compose.onNodeWithText(SESSION_A).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
+        selectTerminalTabForVisibleCapture()
 
         // Confirm SESSION_A's content is actually on screen before we
         // switch — otherwise a "switch" assertion later could pass against
@@ -180,7 +190,7 @@ class SessionSwipeSwitchE2eTest {
                 terminalCols = terminalGridSize().columns,
             )
         }
-        captureViewport("issue237-01-attached-session-a")
+        captureViewport("issue237-01-attached-session-a", A_MARKER)
 
         // ---- (2) The app is attached to SESSION_A; confirm exactly one
         // client is registered for it server-side. This is the baseline
@@ -201,6 +211,13 @@ class SessionSwipeSwitchE2eTest {
         val tmuxConnectBefore = TMUX_CONNECT_ATTEMPTS.get()
         Log.i(LOG_TAG, "snapshot-before handshake=$handshakeBefore tmuxConnect=$tmuxConnectBefore")
 
+        // Make the test-owned B session the first non-current page. The shared
+        // Docker fixture may contain unrelated sessions, and the picker sorts
+        // them by second-resolution activity before name. Updating B immediately
+        // before opening the pager makes A -> B deterministic without deleting
+        // any foreign session.
+        bumpSessionActivity(key, SESSION_B)
+
         // ---- (3) Swipe the session pager FORWARD one page, switching away
         // from SESSION_A — the exact horizontal session-swipe the maintainer
         // asked for. The deterministic `agents` fixture is SHARED and the
@@ -211,10 +228,10 @@ class SessionSwipeSwitchE2eTest {
         // specific name (that would require killing foreign sessions and
         // racing sibling worktrees). We verify the GESTURE CONTRACT: a
         // forward swipe switches the app to the adjacent session — its content
-        // replaces SESSION_A's, the previous tmux client detaches, and the SSH
-        // transport is reused — proving two distinct sessions' content render
-        // via the swipe gesture (SESSION_A's marker before, the adjacent
-        // session's shell after).
+        // replaces SESSION_A's, the previous runtime is parked as the single
+        // owned cache entry, and the SSH transport is reused — proving two
+        // distinct sessions' content render via the swipe gesture (SESSION_A's
+        // marker before, the adjacent session's shell after).
         val switchAt = SystemClock.elapsedRealtime()
         val forwardSession = swipeSessionPagerForwardOnce(
             previousSession = SESSION_A,
@@ -222,10 +239,11 @@ class SessionSwipeSwitchE2eTest {
         )
         captureFullFrame("issue237-03-swiped-forward-to-$forwardSession-fullframe")
         assertTrue(
-            "a forward session-pager swipe must switch AWAY from $SESSION_A to a " +
-                "different same-host session; landed on '$forwardSession'",
-            forwardSession != SESSION_A,
+            "the first forward pager page must be the freshly-active test-owned " +
+                "$SESSION_B session; landed on '$forwardSession'",
+            forwardSession == SESSION_B,
         )
+        selectTerminalTabForVisibleCapture()
         // The adjacent session's content replaces SESSION_A's: SESSION_A's
         // unique marker must no longer be on screen.
         waitForVisibleTerminal("forward swipe left SESSION_A (A-marker gone)") { transcript ->
@@ -274,36 +292,135 @@ class SessionSwipeSwitchE2eTest {
             tmuxConnectsForward,
         )
 
-        // (c) Previous tmux client detached (#235 / #215). After swiping away
-        // from SESSION_A its previous `-CC` control client must have been
-        // `detachCleanly()`'d, so `tmux list-clients -t SESSION_A` drops to
-        // zero. We poll because the `detach-client` round-trip races the new
-        // attach; the count must settle to zero within the budget.
-        val orphanClients = pollListClientsUntilZero(key, SESSION_A)
-        writeText("issue237-clients-on-a-after-forward-swipe.txt", "clients=$orphanClients\n")
+        // (c) The previous runtime is deliberately cached, but never duplicated.
+        // #626 changed the fast-switch contract from detach-on-leave to a bounded
+        // process-owned warm cache. The nightly used to assert the superseded zero
+        // count and therefore failed on the one healthy cached client. Exactly one
+        // is the class-covering signal: it proves the warm owner exists and catches
+        // the actual duplicate/orphan accumulation class (>1).
+        val cachedClients = listClientsCount(key, SESSION_A)
+        writeText("issue237-clients-on-a-after-forward-swipe.txt", "clients=$cachedClients\n")
         assertEquals(
-            "after swiping away from $SESSION_A its previous tmux -CC client " +
-                "must be detached (no orphan lingering for the size-lock issue, " +
-                "#235/#215); tmux list-clients -t $SESSION_A reported $orphanClients " +
-                "clients",
-            0,
-            orphanClients,
+            "after swiping away from $SESSION_A the bounded warm-runtime cache must own " +
+                "exactly one tmux -CC client (zero loses instant switch-back; more than one " +
+                "is a duplicate/orphan, #235/#215); tmux list-clients reported $cachedClients",
+            1,
+            cachedClients,
         )
 
-        // ---- (5) The adjacent session renders its OWN content (not a blank
-        // screen, and not SESSION_A's). Capture its visible terminal so the
-        // reviewer can confirm two distinct sessions' content render across
-        // the swipe (SESSION_A's `A-READY` in issue237-01-*, the adjacent
-        // session's shell prompt here).
-        compose.waitUntil(timeoutMillis = pickerWaitMs) {
-            visibleTerminalText().isNotBlank()
+        // ---- (5) B renders its OWN seeded content (not a blank screen, and
+        // not SESSION_A's stale frame).
+        waitForVisibleTerminal("session B marker after A-to-B swipe") { transcript ->
+            TerminalTextMatcher.containsWrapTolerant(
+                transcript,
+                B_MARKER,
+                terminalCols = terminalGridSize().columns,
+            )
         }
-        assertTrue(
-            "the session swiped onto ('$forwardSession') must render its own " +
-                "terminal content, not a blank screen",
-            visibleTerminalText().isNotBlank(),
+        captureViewport("issue237-04-adjacent-session-content", B_MARKER)
+
+        // ---- (6) Swipe from B back to A. Refresh A's tmux activity just before
+        // opening the pager so it is deterministically the first non-current
+        // page even when the shared fixture contains foreign sessions. A is
+        // already live in the runtime cache; this remote send-keys only affects
+        // picker ordering and does not create an app SSH/tmux runtime.
+        bumpSessionActivity(key, SESSION_A)
+        val returnHandshakeBefore = SSH_HANDSHAKE_ATTEMPTS.get()
+        val returnTmuxLogicalBefore = TMUX_CONNECT_ATTEMPTS.get()
+        val returnTelemetryBefore = TmuxSessionLatencyTelemetry.snapshot()
+        val returnAt = SystemClock.elapsedRealtime()
+        val returnedSession = swipeSessionPagerForwardOnce(
+            previousSession = forwardSession,
+            captureOpenAs = "issue237-05-return-pager-open-fullframe",
         )
-        captureViewport("issue237-04-adjacent-session-content")
+        assertEquals(
+            "second pager swipe must return from $forwardSession to cached $SESSION_A",
+            SESSION_A,
+            returnedSession,
+        )
+        selectTerminalTabForVisibleCapture()
+        waitForVisibleTerminal("cached A marker after B-to-A switch-back") { transcript ->
+            TerminalTextMatcher.containsWrapTolerant(
+                transcript,
+                A_MARKER,
+                terminalCols = terminalGridSize().columns,
+            )
+        }
+        val returnSwitchMs = SystemClock.elapsedRealtime() - returnAt
+        val returnHandshakeAfter = SSH_HANDSHAKE_ATTEMPTS.get()
+        val returnTmuxLogicalAfter = TMUX_CONNECT_ATTEMPTS.get()
+        val returnTelemetry = TmuxSessionLatencyTelemetry.snapshot().drop(returnTelemetryBefore.size)
+        val returnCacheActivations = returnTelemetry.filter { it.name == "runtime_cache_activate" }
+        val returnControlAttaches = returnTelemetry.filter { it.name == "tmux_control_attach_count" }
+
+        assertEquals(
+            "cached B-to-A pointer swap must not perform another SSH handshake",
+            returnHandshakeBefore,
+            returnHandshakeAfter,
+        )
+        assertEquals(
+            "cached B-to-A pointer swap must activate exactly one cached runtime; " +
+                "events=$returnTelemetry",
+            1,
+            returnCacheActivations.size,
+        )
+        assertTrue(
+            "cached B-to-A pointer swap must not attach a fresh tmux -CC client; " +
+                "events=$returnTelemetry",
+            returnControlAttaches.isEmpty(),
+        )
+        assertEquals(
+            "B-to-A gesture must be accepted exactly once as a logical connect; " +
+                "the separate tmux_control_attach_count oracle proves that this " +
+                "logical activation did not open a new -CC connection",
+            1,
+            returnTmuxLogicalAfter - returnTmuxLogicalBefore,
+        )
+
+        val clientsOnAAfterReturn = listClientsCount(key, SESSION_A)
+        val clientsOnBAfterReturn = listClientsCount(key, forwardSession)
+        writeText(
+            "issue237-clients-after-return-swipe.txt",
+            "clients_on_A=$clientsOnAAfterReturn\n" +
+                "clients_on_B=$clientsOnBAfterReturn\n",
+        )
+        assertEquals(
+            "active $SESSION_A must still have exactly one owned -CC client after " +
+                "cached activation (no duplicate attach)",
+            1,
+            clientsOnAAfterReturn,
+        )
+        assertEquals(
+            "switched-away $forwardSession must have exactly one cache-owned -CC " +
+                "client after return (no orphan/duplicate accumulation)",
+            1,
+            clientsOnBAfterReturn,
+        )
+        // The cached frame is published synchronously, followed by a legitimate
+        // asynchronous remote refresh. Wait for that refresh to settle before
+        // taking the authoritative bitmap so a mid-row draw cannot produce a
+        // misleading partial-marker screenshot even though the screen grid is
+        // already correct.
+        SystemClock.sleep(1_000L)
+        waitForVisibleTerminal("stable visible A marker before return capture") { transcript ->
+            TerminalTextMatcher.containsWrapTolerant(
+                transcript,
+                A_MARKER,
+                terminalCols = terminalGridSize().columns,
+            )
+        }
+        captureViewport("issue237-06-returned-to-session-a", A_MARKER)
+        recordTiming("return_swipe_switch_ms", returnSwitchMs)
+        recordTiming(
+            "ssh_handshakes_during_return",
+            (returnHandshakeAfter - returnHandshakeBefore).toLong(),
+        )
+        recordTiming(
+            "logical_tmux_connects_during_return",
+            (returnTmuxLogicalAfter - returnTmuxLogicalBefore).toLong(),
+        )
+        recordTiming("runtime_cache_activations_during_return", returnCacheActivations.size.toLong())
+        recordTiming("tmux_control_attaches_during_return", returnControlAttaches.size.toLong())
 
         writeTimings()
         writeText(
@@ -313,8 +430,16 @@ class SessionSwipeSwitchE2eTest {
                 appendLine("forward_swipe_session=$forwardSession")
                 appendLine("ssh_handshakes_during_forward=${handshakeAfter - handshakeBefore}")
                 appendLine("tmux_connects_during_forward=$tmuxConnectsForward")
-                appendLine("clients_on_A_after_forward=$orphanClients")
+                appendLine("owned_cached_clients_on_A_after_forward=$cachedClients")
                 appendLine("forward_swipe_switch_ms=$forwardSwitchMs")
+                appendLine("return_swipe_session=$returnedSession")
+                appendLine("ssh_handshakes_during_return=${returnHandshakeAfter - returnHandshakeBefore}")
+                appendLine("logical_tmux_connects_during_return=${returnTmuxLogicalAfter - returnTmuxLogicalBefore}")
+                appendLine("runtime_cache_activations_during_return=${returnCacheActivations.size}")
+                appendLine("tmux_control_attaches_during_return=${returnControlAttaches.size}")
+                appendLine("clients_on_A_after_return=$clientsOnAAfterReturn")
+                appendLine("clients_on_B_after_return=$clientsOnBAfterReturn")
+                appendLine("return_swipe_switch_ms=$returnSwitchMs")
             },
         )
 
@@ -465,11 +590,11 @@ class SessionSwipeSwitchE2eTest {
             appendLine("tmux kill-session -t ${shellQuote(SESSION_B)} 2>/dev/null || true")
             appendLine(
                 "tmux new-session -d -s ${shellQuote(SESSION_A)} " +
-                    shellQuote("printf '$A_MARKER\\n'; exec sh"),
+                    shellQuote("printf '$PIXEL_MARKER_ANSI$A_MARKER$PIXEL_MARKER_RESET\\n'; exec sh"),
             )
             appendLine(
                 "tmux new-session -d -s ${shellQuote(SESSION_B)} " +
-                    shellQuote("printf '$B_MARKER\\n'; exec sh"),
+                    shellQuote("printf '$PIXEL_MARKER_ANSI$B_MARKER$PIXEL_MARKER_RESET\\n'; exec sh"),
             )
             appendLine("tmux list-sessions")
         }
@@ -536,18 +661,36 @@ class SessionSwipeSwitchE2eTest {
     }
 
     /**
-     * Poll `tmux list-clients -t <session>` until it reports zero clients
-     * or the budget elapses. Returns the final observed count.
+     * Move a test-owned session to the front of the picker's activity ordering
+     * without changing the app's active runtime. `Space` + `BSpace` leaves the
+     * shell command line unchanged while tmux updates `session_activity`.
      */
-    private suspend fun pollListClientsUntilZero(key: String, sessionName: String): Int {
-        val deadline = SystemClock.elapsedRealtime() +
-            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L
-        var count = listClientsCount(key, sessionName)
-        while (count != 0 && SystemClock.elapsedRealtime() < deadline) {
-            SystemClock.sleep(500)
-            count = listClientsCount(key, sessionName)
+    private suspend fun bumpSessionActivity(key: String, sessionName: String) {
+        // tmux exposes session activity at one-second resolution. Crossing a
+        // second boundary makes the ordering deterministic against sessions
+        // touched earlier in this journey.
+        SystemClock.sleep(1_100L)
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use {
+                it.exec(
+                    "tmux send-keys -t ${shellQuote(sessionName)} Space BSpace; " +
+                        "tmux display-message -p -t ${shellQuote(sessionName)} '#{session_activity}'",
+                )
+            }
         }
-        return count
+        val exec = result.getOrNull()
+        assertTrue(
+            "failed to refresh picker activity for $sessionName: " +
+                "exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
     }
 
     private fun waitForText(text: String, timeoutMs: Long) {
@@ -568,6 +711,35 @@ class SessionSwipeSwitchE2eTest {
             attached
         }
     }
+
+    /** Ensure screenshots observe the real Terminal surface, not the #818
+     * Conversation default used while a presumed-agent transcript loads. */
+    private fun selectTerminalTabForVisibleCapture() {
+        val deadline = SystemClock.elapsedRealtime() + 20_000L
+        while (SystemClock.elapsedRealtime() < deadline) {
+            compose.waitForIdle()
+            val conversationVisible =
+                hasTag(TMUX_CONVERSATION_DETECTING_TAG) || hasTag(TMUX_CONVERSATION_PANE_TAG)
+            if (!conversationVisible) return
+            if (hasTag(TMUX_TERMINAL_TAB_TAG)) {
+                compose.onNodeWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true)
+                    .performClick()
+            }
+            SystemClock.sleep(250L)
+        }
+        assertTrue(
+            "Terminal surface was not selected before the authoritative viewport capture; " +
+                "conversationDetecting=${hasTag(TMUX_CONVERSATION_DETECTING_TAG)} " +
+                "conversationPane=${hasTag(TMUX_CONVERSATION_PANE_TAG)} " +
+                "terminalTab=${hasTag(TMUX_TERMINAL_TAB_TAG)}",
+            false,
+        )
+    }
+
+    private fun hasTag(tag: String): Boolean =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
 
     /**
      * Read the session name currently shown in the top chrome's session
@@ -655,7 +827,7 @@ class SessionSwipeSwitchE2eTest {
                 ?.currentSession
                 ?.emulator
                 ?.screen
-                ?.transcriptText
+                ?.visibleScreenText
                 .orEmpty()
         }
         return text
@@ -675,20 +847,42 @@ class SessionSwipeSwitchE2eTest {
         return grid ?: GridSize(columns = 80, rows = 24)
     }
 
-    private fun captureViewport(name: String) {
+    private fun captureViewport(name: String, expectedMarker: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         instrumentation.waitForIdleSync()
         SystemClock.sleep(150)
 
-        var bitmap: Bitmap? = null
+        var viewportLeft = 0
+        var viewportTop = 0
+        var viewportWidth = 0
+        var viewportHeight = 0
+        var fontWidthPx = 0f
         launchedActivity?.onActivity { activity ->
             val view = activity.window.decorView.findTerminalView() ?: return@onActivity
-            if (view.width <= 0 || view.height <= 0) return@onActivity
-            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-            view.draw(Canvas(b))
-            bitmap = b
+            val location = IntArray(2)
+            view.getLocationOnScreen(location)
+            viewportLeft = location[0]
+            viewportTop = location[1]
+            viewportWidth = view.width
+            viewportHeight = view.height
+            fontWidthPx = view.mRenderer.fontWidth
         }
-        bitmap?.let { writeBitmap("$name-viewport", it) }
+        val screen = instrumentation.uiAutomation.takeScreenshot()
+        val left = viewportLeft.coerceIn(0, screen.width)
+        val top = viewportTop.coerceIn(0, screen.height)
+        val width = viewportWidth.coerceAtMost(screen.width - left)
+        val height = viewportHeight.coerceAtMost(screen.height - top)
+        check(width > 0 && height > 0) {
+            "invalid terminal viewport crop left=$left top=$top width=$width height=$height " +
+                "screen=${screen.width}x${screen.height}"
+        }
+        // Crop the pixels the emulator actually displayed. Drawing TerminalView
+        // into a fresh off-screen bitmap is not authoritative because its dirty
+        // renderer cache describes the already-painted device surface and can
+        // intentionally skip unchanged cells, producing a partial evidence image.
+        val bitmap = Bitmap.createBitmap(screen, left, top, width, height)
+        screen.recycle()
+        writeBitmap("$name-viewport", bitmap)
         var text = ""
         launchedActivity?.onActivity { activity ->
             text = activity.window.decorView
@@ -696,11 +890,64 @@ class SessionSwipeSwitchE2eTest {
                 ?.currentSession
                 ?.emulator
                 ?.screen
-                ?.transcriptText
+                ?.visibleScreenText
                 .orEmpty()
         }
         writeText("$name-visible-terminal.txt", text)
-        bitmap?.recycle()
+        assertCompleteMarkerPainted(
+            bitmap = bitmap,
+            marker = expectedMarker,
+            fontWidthPx = fontWidthPx,
+            artifactName = name,
+        )
+        bitmap.recycle()
+    }
+
+    /**
+     * Device-pixel oracle for the complete marker. The seeded marker owns a
+     * unique true-colour magenta cell background; the span of those pixels on
+     * the UIAutomation screenshot therefore measures what the TerminalView
+     * actually painted, independently of the emulator model text. A stale
+     * #469 dirty clip that paints only `A2`/`B2` spans roughly two cells and
+     * hard-fails against the full ten-cell marker width.
+     */
+    private fun assertCompleteMarkerPainted(
+        bitmap: Bitmap,
+        marker: String,
+        fontWidthPx: Float,
+        artifactName: String,
+    ) {
+        var minX = bitmap.width
+        var maxX = -1
+        var matchingPixels = 0
+        for (y in 0 until bitmap.height) {
+            for (x in 0 until bitmap.width) {
+                val color = bitmap.getPixel(x, y)
+                val red = android.graphics.Color.red(color)
+                val green = android.graphics.Color.green(color)
+                val blue = android.graphics.Color.blue(color)
+                if (red >= 245 && green <= 10 && blue >= 245) {
+                    minX = minOf(minX, x)
+                    maxX = maxOf(maxX, x)
+                    matchingPixels++
+                }
+            }
+        }
+        val paintedSpanPx = if (maxX >= minX) maxX - minX + 1 else 0
+        val requiredSpanPx = (fontWidthPx * (marker.length - 1)).toInt()
+        writeText(
+            "$artifactName-device-pixel-oracle.txt",
+            "marker=$marker\nfont_width_px=$fontWidthPx\n" +
+                "painted_magenta_span_px=$paintedSpanPx\n" +
+                "required_span_px=$requiredSpanPx\nmatching_pixels=$matchingPixels\n",
+        )
+        assertTrue(
+            "device-visible viewport did not paint the complete '$marker' cell band for " +
+                "$artifactName: magenta span=$paintedSpanPx px, required>=$requiredSpanPx px, " +
+                "fontWidth=$fontWidthPx, matchingPixels=$matchingPixels. The emulator model " +
+                "may already contain the marker, but a partial actual surface is a failure.",
+            fontWidthPx > 0f && paintedSpanPx >= requiredSpanPx,
+        )
     }
 
     /**
@@ -796,6 +1043,8 @@ class SessionSwipeSwitchE2eTest {
         const val SESSION_B: String = "issue237-session-b"
         const val A_MARKER: String = "A237-READY"
         const val B_MARKER: String = "B237-READY"
+        const val PIXEL_MARKER_ANSI: String = "\\033[48;2;255;0;255m"
+        const val PIXEL_MARKER_RESET: String = "\\033[0m"
 
         // Highest pager page tag index probed when locating the on-screen
         // card; comfortably above any realistic same-host session count on

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
@@ -17,6 +17,7 @@ import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
@@ -43,9 +44,9 @@ import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 
 /**
- * Issue #235 — auto-detach the tmux `-CC` control client on lifecycle
- * background so the desktop terminal opening the same session is not
- * pinned to the phone's small viewport.
+ * Issue #235 — auto-detach the tmux `-CC` control client after the bounded
+ * lifecycle-background grace so a desktop terminal opening the same session
+ * is not pinned to the phone's small viewport.
  *
  * Symptom (maintainer dogfood, v0.2.8): PocketShell attaches to a
  * tmux session at ~85x30, desktop terminal attaches at 200x50, tmux
@@ -71,10 +72,10 @@ import java.nio.charset.StandardCharsets
  *     real device (Activity → STOPPED → ProcessLifecycleOwner
  *     `ON_STOP`), but without an extra `uiautomator` dependency and
  *     without depending on launcher-availability on swiftshader.
- *     The `App` observer (#235) fans the event into every registered
- *     `TmuxSessionViewModel`'s `onAppBackgrounded` hook, which runs
- *     `detachCleanly()` against the live `-CC` client.
- *  5. Poll `tmux list-clients -t claude-main` until the count
+ *     The App-level grace owner intentionally retains the client inside the
+ *     short injected grace, then fans the elapsed event into every registered
+ *     `TmuxSessionViewModel`'s `onAppBackgrounded` clean-detach hook.
+ *  5. Poll `tmux list-clients -t claude-main` after grace until the count
  *     reaches 0 — proves the `-CC` client is gone and the size lock
  *     is released.
  *  6. Open a sidecar plain-ssh `tmux attach -t claude-main` over a
@@ -129,6 +130,7 @@ class TmuxDetachOnBackgroundE2eTest {
     fun closeLaunchedActivity() {
         launchedActivity?.close()
         launchedActivity = null
+        BackgroundGraceTestOverride.setForTest(null)
         runBlocking {
             runCatching { cleanupRemoteTmuxSession(readFixtureKey()) }
         }
@@ -187,8 +189,12 @@ class TmuxDetachOnBackgroundE2eTest {
             attachedClientCount >= 1,
         )
 
-        // ---- (2) Background the app via `moveToState(CREATED)`. This
-        // walks the Activity through `onPause` + `onStop`, which the
+        // ---- (2) Background the app via `moveToState(CREATED)`. Use a short
+        // test-only grace so this proof exercises the production D21 contract
+        // without waiting the full 90 seconds: the client remains owned inside
+        // grace, then cleanly detaches when grace expires.
+        BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
+        // This walks the Activity through `onPause` + `onStop`, which the
         // [ProcessLifecycleOwner] observer in [com.pocketshell.app.App]
         // translates into the `ON_STOP` event the #235 fanout reads
         // off. Same lifecycle journey `UiDevice.pressHome()` produces
@@ -199,10 +205,45 @@ class TmuxDetachOnBackgroundE2eTest {
         val backgroundStart = SystemClock.elapsedRealtime()
         launchedActivity?.moveToState(Lifecycle.State.CREATED)
 
-        // ---- (3) Poll list-clients until the detach lands. tmux
-        // removes the entry within a single round-trip once
-        // `detach-client` is received; 6s is generous CI headroom and
-        // also covers ProcessLifecycleOwner's 700ms ON_STOP debounce.
+        // A quick app switch deliberately retains the live runtime. The old
+        // nightly assertion polled for immediate zero and contradicted the
+        // bounded-grace decision (#1123/#1159). Pin the within-grace half first
+        // so this cannot become a test that merely delays before asserting zero.
+        waitForGraceStart(POST_GRACE_MS)
+        val conservativeGraceDeadline = backgroundStart + POST_GRACE_MS
+        val withinGraceRawSnapshot = listClientsRaw(key, SEEDED_SESSION)
+        val withinGraceObservedAt = SystemClock.elapsedRealtime()
+        val clientsInsideGrace = withinGraceRawSnapshot
+            .lines()
+            .count { it.isNotBlank() }
+        writeText(
+            "issue235-02-within-grace-clients.txt",
+            buildString {
+                appendLine("background_start_elapsed_realtime_ms=$backgroundStart")
+                appendLine("conservative_grace_deadline_elapsed_realtime_ms=$conservativeGraceDeadline")
+                appendLine("client_observation_completed_elapsed_realtime_ms=$withinGraceObservedAt")
+                appendLine("observation_completed_before_conservative_deadline=${withinGraceObservedAt < conservativeGraceDeadline}")
+                appendLine("clients=$clientsInsideGrace")
+                append(withinGraceRawSnapshot)
+            },
+        )
+        assertTrue(
+            "within-grace client observation crossed even the conservative deadline: " +
+                "backgroundStart=$backgroundStart graceMs=$POST_GRACE_MS " +
+                "observedAt=$withinGraceObservedAt. The real grace starts after " +
+                "backgroundStart, so completing before backgroundStart+grace is a " +
+                "hard monotonic proof that teardown could not yet be due.",
+            withinGraceObservedAt < conservativeGraceDeadline,
+        )
+        assertTrue(
+            "the active -CC client must remain owned inside bounded grace; got " +
+                "$clientsInsideGrace clients; raw=`$withinGraceRawSnapshot`",
+            clientsInsideGrace >= 1,
+        )
+
+        // ---- (3) Poll list-clients until the post-grace detach lands. tmux
+        // removes the entry within a single round-trip once `detach-client` is
+        // received. The budget covers the injected grace, teardown, and CI load.
         var orphanCount = -1
         var orphanRawSnapshot = ""
         val deadline = SystemClock.elapsedRealtime() + DETACH_TIMEOUT_MS
@@ -220,7 +261,8 @@ class TmuxDetachOnBackgroundE2eTest {
         )
         writeText("issue235-02-after-background-clients.txt", orphanRawSnapshot)
         assertEquals(
-            "expected zero tmux clients on $SEEDED_SESSION after background; raw=`$orphanRawSnapshot`",
+            "expected zero tmux clients on $SEEDED_SESSION after bounded background grace elapsed; " +
+                "raw=`$orphanRawSnapshot`",
             0,
             orphanCount,
         )
@@ -660,6 +702,20 @@ class TmuxDetachOnBackgroundE2eTest {
         runCatching { ProcessBuilder("logcat", "-c").start().waitFor() }
     }
 
+    private fun waitForGraceStart(expectedMillis: Long) {
+        val deadline = SystemClock.elapsedRealtime() + 10_000L
+        var logcat = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            logcat = dumpLogcat()
+            if (logcat.contains("grace-window-start millis=$expectedMillis")) return
+            SystemClock.sleep(100)
+        }
+        throw AssertionError(
+            "expected bounded grace to start with millis=$expectedMillis before checking " +
+                "the within-grace client owner; logcat tail:\n${logcat.takeLast(4_000)}",
+        )
+    }
+
     private fun dumpLogcat(): String =
         ProcessBuilder(
             "logcat",
@@ -668,6 +724,7 @@ class TmuxDetachOnBackgroundE2eTest {
             "threadtime",
             "PsTmuxLifecycle:I",
             "PsTmuxReconnect:I",
+            "PsAppBgGrace:I",
             "*:S",
         )
             .redirectErrorStream(true)
@@ -702,14 +759,18 @@ class TmuxDetachOnBackgroundE2eTest {
         const val DESKTOP_PTY_ROWS: Int = 50
 
         /**
-         * After we drive the lifecycle background, the detach must
-         * land in well under this ceiling. The single-client detach
-         * round-trip on a healthy fixture is sub-100ms;
-         * ProcessLifecycleOwner adds a 700ms ON_STOP debounce; 6s is
-         * generous CI headroom for swiftshader emulator + Docker
-         * compose overhead, matching the #215 sibling test's budget.
+         * After we drive lifecycle background, the injected grace and clean
+         * detach must land inside this ceiling. The budget includes the
+         * ProcessLifecycleOwner debounce and swiftshader/Docker load.
          */
-        const val DETACH_TIMEOUT_MS: Long = 6_000L
+        const val DETACH_TIMEOUT_MS: Long = 60_000L
+        /**
+         * The within-grace oracle includes logcat confirmation plus a fresh real
+         * SSH connect/list-clients round trip. Give that observation enough room
+         * under contended hosted runners, then hard-check its completion against
+         * the conservative monotonic deadline derived before ON_STOP.
+         */
+        const val POST_GRACE_MS: Long = 30_000L
 
         /**
          * Issue #235 r2: the local `TerminalView` binds to its session

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
@@ -26,12 +26,15 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.TERMINAL_HOTKEYS_LAUNCHER_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TmuxHotkeyCtrlModifierLabel
 import com.pocketshell.app.tmux.TmuxHotkeyEnterLabel
 import com.pocketshell.uikit.components.HotkeyModifierActiveKey
+import com.pocketshell.uikit.components.HotkeyPanelExpandedKey
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_EXPAND_TAG
 import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -126,7 +129,7 @@ class TmuxKeyBarCtrlComboE2eTest {
         }
         val attachAt = SystemClock.elapsedRealtime()
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        waitForSessionInPicker(rule = compose, sessionName = SESSION_NAME, timeoutMs = 20_000)
+        waitForSeededSessionInPicker(hostRowTag)
         compose.onNodeWithText(SESSION_NAME).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
@@ -144,16 +147,15 @@ class TmuxKeyBarCtrlComboE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true).performClick()
-        // The panel shows EVERY key at once in a tidy grid — Esc / Tab / ⇧Tab /
-        // Enter, the de-duped Ctrl combos incl. the restored ^B (tmux prefix) AND
-        // the #1091-filled nano/TUI control keys (^G ^J ^K ^O ^T ^U ^W ^X ^\), the
-        // re-homed doubled interrupt/EOF chords, the sticky `Ctrl` modifier, and
-        // the clean arrow glyphs. No `…` overflow, no duplicate `/`.
+        // Issue #1332: the panel opens with only the common keys. Expand it
+        // before auditing or using the full catalog (⇧Tab, all Ctrl combos,
+        // doubled controls, sticky Ctrl, and letters).
         compose.waitUntil(timeoutMillis = 10_000) {
             compose.onAllNodesWithText("^C", useUnmergedTree = true)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+        expandHotkeysPanel()
         // Issue #787: doubled interrupt/EOF controls; issue #893: ⇧Tab; issue
         // #1091: the previously-missing nano/TUI control keys are now present too.
         listOf(
@@ -194,6 +196,11 @@ class TmuxKeyBarCtrlComboE2eTest {
         // (the terminal-only viewport capture does not include the Compose sheet).
         captureFullDevice("issue784-02b-hotkeys-panel-fulldevice")
 
+        // Return to #1332 compact mode before exercising the common ^C key.
+        // Expanded mode intentionally contains an equivalent second ^C in the
+        // CTRL COMBOS catalog; compact mode makes the interaction unambiguous.
+        collapseHotkeysPanel()
+
         // ===== Start a long-running process in the pane =====
         // A ticking loop is the canonical "is it still running?" process:
         // it keeps emitting until interrupted, but at a measured rate so the
@@ -213,7 +220,11 @@ class TmuxKeyBarCtrlComboE2eTest {
 
         // ===== Tap the panel ^C to interrupt =====
         val interruptAt = SystemClock.elapsedRealtime()
-        compose.onNodeWithText("^C", useUnmergedTree = true).performClick()
+        compose.onNode(
+            hasText("^C")
+                .and(hasClickAction())
+                .and(hasAnyAncestor(hasTestTag(TERMINAL_HOTKEYS_PANEL_TAG))),
+        ).performClick()
         // After the interrupt, the flood stops and a fresh shell prompt
         // returns. We detect "stopped" by sampling the transcript twice
         // with a settle gap and confirming the flood-line count no longer
@@ -248,6 +259,7 @@ class TmuxKeyBarCtrlComboE2eTest {
         // `Ctrl-D ×2`) was hard-cut; those controls moved into the hotkeys panel's
         // INTERRUPT / EOF section. Prove the doubled control still interrupts a
         // live process: start a fresh flood, tap `^C×2`, confirm it stops.
+        expandHotkeysPanel()
         SystemClock.sleep(750)
         sendCommandThroughTerminalInput(
             "i=0; while true; do i=\$((i+1)); echo $FLOOD_MARKER-\$i; sleep 0.3; done",
@@ -385,7 +397,7 @@ class TmuxKeyBarCtrlComboE2eTest {
         }
         val attachAt = SystemClock.elapsedRealtime()
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        waitForSessionInPicker(rule = compose, sessionName = SESSION_NAME, timeoutMs = 20_000)
+        waitForSeededSessionInPicker(hostRowTag)
         compose.onNodeWithText(SESSION_NAME).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
@@ -400,13 +412,10 @@ class TmuxKeyBarCtrlComboE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true).performClick()
-        // The #1091-filled nano control keys (incl. `^O` Write Out, `^X` Exit)
-        // must be present as direct buttons.
-        compose.waitUntil(timeoutMillis = 10_000) {
-            compose.onAllNodesWithText("^X", useUnmergedTree = true)
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        }
+        // Issue #1332 moved the full Ctrl catalog into the extended section.
+        // Reveal it through the production panel control before requiring the
+        // #1091 nano keys (`^O` Write Out and `^X` Exit among them).
+        expandHotkeysPanel()
         listOf("^G", "^J", "^K", "^O", "^T", "^U", "^W", "^X", "^\\").forEach { label ->
             assertTrue(
                 "expected the hotkeys panel to expose the nano control key '$label'",
@@ -540,6 +549,72 @@ class TmuxKeyBarCtrlComboE2eTest {
         ).performClick()
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         SystemClock.sleep(150)
+    }
+
+    /**
+     * Issue #1332 made the hotkeys panel progressively disclosed. Extended
+     * keys are deliberately absent until the user taps "Show more keys", so
+     * every E2E leg that audits or uses those keys must perform that real user
+     * action instead of waiting for a node that cannot exist in compact mode.
+     */
+    private fun expandHotkeysPanel() {
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(
+                TERMINAL_HOTKEYS_PANEL_EXPAND_TAG,
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(
+            TERMINAL_HOTKEYS_PANEL_EXPAND_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+        compose.waitForIdle()
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodes(
+                SemanticsMatcher.expectValue(HotkeyPanelExpandedKey, true),
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /** Restore compact mode and prove its common ^C interaction is unique. */
+    private fun collapseHotkeysPanel() {
+        compose.onNodeWithTag(
+            TERMINAL_HOTKEYS_PANEL_EXPAND_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+        compose.waitForIdle()
+        compose.waitUntil(timeoutMillis = 10_000) {
+            val collapsed = compose.onAllNodes(
+                SemanticsMatcher.expectValue(HotkeyPanelExpandedKey, false),
+            ).fetchSemanticsNodes().isNotEmpty()
+            if (!collapsed) return@waitUntil false
+            compose.onAllNodes(
+                hasText("^C")
+                    .and(hasClickAction())
+                    .and(hasAnyAncestor(hasTestTag(TERMINAL_HOTKEYS_PANEL_TAG))),
+            ).fetchSemanticsNodes().size == 1
+        }
+    }
+
+    /**
+     * Keep this hotkey journey behind the shared, bounded #470 readiness gate.
+     * A stalled first enumeration gets the standard host-detail re-poke and
+     * hosted timeout, while a genuinely absent seeded session still hard-fails
+     * with the helper's enumeration diagnostics before any hotkey assertion.
+     */
+    private fun waitForSeededSessionInPicker(hostRowTag: String) {
+        waitForSessionInPicker(
+            rule = compose,
+            sessionName = SESSION_NAME,
+            onStateNote = { note -> Log.i(LOG_TAG, "session picker: $note") },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                    onStateNote = { note -> Log.i(LOG_TAG, "session picker: $note") },
+                )
+            },
+        )
     }
 
     private fun buildSummary(

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
@@ -16,6 +16,7 @@ import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
@@ -45,17 +46,14 @@ import java.nio.charset.StandardCharsets
  *  >  close it and then I open it on so the app I I stop using right and
  *  >  then I open it in my other computer and then I cannot type anything"
  *
- * The hypothesis (confirmed locally before this test landed): closing the
- * PocketShell app while attached to a tmux session via `tmux -CC` leaves
- * an orphan control client registered server-side until tmux notices the
- * SSH socket drop independently. A laptop attaching to the same session
- * in that window lands alongside the orphan and finds the session in an
- * input-broken state.
+ * The original bug left an orphan control client registered server-side after
+ * PocketShell stopped owning it. Since #1123/#1159, an Activity close while
+ * the instrumented process remains alive deliberately parks that runtime only
+ * for bounded background grace. The actual regression signal is therefore a
+ * client that survives the grace deadline, not a still-owned client inside it.
  *
  * The fix is in [com.pocketshell.core.tmux.TmuxClient.detachCleanly] and
- * its wire-up inside [com.pocketshell.app.tmux.TmuxSessionViewModel]'s
- * three close paths (suspending teardown, same-host fast-switch
- * teardown, and synchronous `onCleared` teardown).
+ * its wire-up inside the elapsed-grace teardown path.
  *
  * This test runs against the deterministic `agents:2222` Docker fixture
  * (already required by the rest of the connected suite — no new fixture
@@ -65,12 +63,9 @@ import java.nio.charset.StandardCharsets
  *  1. Attach to `claude-main` via the normal app journey
  *     (host picker -> session picker -> Attach).
  *  2. Verify the server has exactly one client attached (the app).
- *  3. Force the activity to DESTROYED to drive
- *     [com.pocketshell.app.tmux.TmuxSessionViewModel.onCleared] — the
- *     pathological case the maintainer reported, where PocketShell is
- *     closed (back press / process finish) while the tmux session
- *     stays alive remotely.
- *  4. Poll `tmux list-clients -t claude-main` until the orphan count
+ *  3. Force the activity to DESTROYED while the instrumented process stays
+ *     alive, then let a short injected background grace elapse.
+ *  4. Poll `tmux list-clients -t claude-main` until the post-grace count
  *     drops to 0 (acceptance: it must reach 0 inside
  *     [ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS]).
  *  5. Open a fresh non-CC interactive `tmux attach -t claude-main`
@@ -84,8 +79,8 @@ import java.nio.charset.StandardCharsets
  *    proof the app attached cleanly before the test exercised the
  *    teardown.
  *  - `issue215-02-after-destroy-clients.txt` — output of
- *    `tmux list-clients -t claude-main` immediately after the activity
- *    destruction, captured for the orphan-count assertion.
+ *    `tmux list-clients -t claude-main` after activity destruction + grace,
+ *    captured for the orphan-count assertion.
  *  - `issue215-03-second-client-pane.txt` — text the second
  *    (non-CC) client typed-and-read, proving input round-trips.
  *  - `timings.txt` — attach time, destroy-to-orphan-cleared latency,
@@ -110,6 +105,7 @@ class TmuxOrphanClientCleanupE2eTest {
     fun closeLaunchedActivity() {
         launchedActivity?.close()
         launchedActivity = null
+        BackgroundGraceTestOverride.setForTest(null)
         runBlocking {
             runCatching { cleanupRemoteTmuxSession(readFixtureKey()) }
         }
@@ -154,11 +150,17 @@ class TmuxOrphanClientCleanupE2eTest {
             attachedClientCount >= 1,
         )
 
-        // ---- (3) Force the activity to DESTROYED. ActivityScenario's
+        // ---- (3) Force the activity to DESTROYED. ActivityScenario keeps the
+        // instrumented app process alive, so this is a background transition,
+        // not an OS process kill. Since #1123/#1159 the ViewModel parks its
+        // runtime during bounded grace and the App-level grace owner performs
+        // the clean detach after the deadline. Inject a short deadline rather
+        // than asserting the superseded synchronous-onCleared contract.
+        BackgroundGraceTestOverride.setForTest(POST_CLOSE_GRACE_MS)
+        // ActivityScenario's
         // `close()` walks the lifecycle through stopped + destroyed,
-        // which invokes [TmuxSessionViewModel.onCleared] and the
-        // synchronous `closeCurrentConnection()` path that now sends
-        // `detach-client` via a brief runBlocking(Dispatchers.IO) hop.
+        // which invokes [TmuxSessionViewModel.onCleared], parks the runtime,
+        // and leaves the process-scoped grace owner responsible for teardown.
         // This is the exact code path the maintainer's "close the
         // app" sequence exercises on a real phone (back-out of the
         // session screen -> back-out of the app).
@@ -167,12 +169,9 @@ class TmuxOrphanClientCleanupE2eTest {
         launchedActivity = null
 
         // ---- (4) Poll `tmux list-clients -t claude-main` until the
-        // orphan count drops to 0. Without the fix the count stays at
-        // >=1 for as long as the tmux server takes to independently
-        // observe the SSH socket close (variable; up to 10+ seconds
-        // depending on the kernel TCP timeout). With the fix the
-        // detach-client round-trip removes the entry in well under
-        // 100ms on a healthy Docker fixture.
+        // client count drops to 0 after grace. A client before the deadline is
+        // owned, not orphaned; a client surviving the deadline is the actual
+        // orphan class this proof guards.
         var orphanCount = -1
         var orphanRawSnapshot = ""
         val deadline = SystemClock.elapsedRealtime() + ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS
@@ -190,7 +189,8 @@ class TmuxOrphanClientCleanupE2eTest {
         )
         writeText("issue215-02-after-destroy-clients.txt", orphanRawSnapshot)
         assertEquals(
-            "expected zero tmux clients on $SEEDED_SESSION after app close; raw=`$orphanRawSnapshot`",
+            "expected zero tmux clients on $SEEDED_SESSION after app close grace elapsed; " +
+                "raw=`$orphanRawSnapshot`",
             0,
             orphanCount,
         )
@@ -592,14 +592,12 @@ class TmuxOrphanClientCleanupE2eTest {
         const val SEEDED_SESSION: String = "claude-main"
 
         /**
-         * After we destroy the activity, we wait up to this long for
-         * `tmux list-clients -t claude-main` to drop to zero. The fix
-         * removes the client in <100ms on a healthy fixture (the
-         * `detach-client` round-trip is sub-millisecond on localhost
-         * + the runBlocking hop is bounded by [SYNC_DETACH_TIMEOUT_MS]
-         * = 600ms). 6s is generous CI headroom for swiftshader
-         * emulator + Docker compose overhead.
+         * After we destroy the activity, the short injected bounded grace
+         * expires and the App-level owner detaches the parked runtime. The
+         * budget includes ProcessLifecycleOwner's ON_STOP debounce, grace,
+         * detach-client, and swiftshader/Docker contention.
          */
-        const val ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS: Long = 6_000L
+        const val ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS: Long = 15_000L
+        const val POST_CLOSE_GRACE_MS: Long = 1_500L
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
@@ -74,11 +74,10 @@ import java.io.FileOutputStream
  * ### Real-path red→green (D33/G10)
  *
  * [conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript]:
- *  1. Attach to a recorded `@ps_agent_kind=shell` session whose cwd holds a fresh
- *     Claude transcript (the #975 masked-live-agent fixture shape) — the daemon
- *     classify is `unknown`, so the ONLY way detection binds is the #975
- *     transcript-evidence fallback. Detection binds → the transcript tails into
- *     `events` → the Terminal/Conversation toggle is up. (REAL VM, REAL transcript.)
+ *  1. Attach to a session explicitly recorded as Claude whose cwd holds a fresh
+ *     Claude transcript. The authoritative recorded identity selects the real
+ *     Claude source, the transcript tails into `events`, and the
+ *     Terminal/Conversation toggle appears. (REAL VM, REAL transcript.)
  *  2. Tap the Conversation segment → the real [TMUX_CONVERSATION_PANE_TAG]
  *     transcript pane renders (AC2 — tap-to-switch on the real screen, the gap
  *     #975's "toggle exists" assertion left open).
@@ -164,15 +163,14 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
 
         val vm = currentViewModel()
 
-        // STEP 1 — REAL detection binds (the #975 transcript-evidence fallback,
-        // the only way to bind for a recorded-shell pane the daemon classifies
-        // `unknown`) AND the transcript tails into `events`. This is the genuine
+        // STEP 1 — REAL detection binds from the authoritative recorded Claude
+        // identity AND the transcript tails into `events`. This is the genuine
         // conversation that EXISTS on the pane — not hand-constructed state.
         val paneId = waitForLoadedConversationPane(vm)
         assertNotNull(
             "#1057 precondition: a live conversation with loaded transcript events " +
-                "must bind on the real path (detection via the #975 transcript " +
-                "fallback, then the transcript tails into events). " +
+                "must bind on the real path (recorded Claude identity, then the " +
+                "transcript tails into events). " +
                 "agentConversations=${describeConversations(vm)}",
             paneId,
         )
@@ -420,11 +418,10 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
     }
 
     /**
-     * The #975 masked-live-claude fixture shape: a session recorded
-     * `@ps_agent_kind=shell` whose cwd holds a FRESH Claude transcript (copied
-     * from the fixture seed), with the daemon classify returning `unknown`. The
-     * #975 transcript-evidence fallback binds detection and the transcript tails
-     * into events — the genuine conversation #1057 needs to keep reachable.
+     * A session explicitly recorded as Claude whose cwd holds a FRESH Claude
+     * transcript copied from the fixture seed. The recorded identity and JSONL
+     * are both asserted remotely so this test cannot silently become a readable
+     * shell fixture that never binds a Conversation row.
      */
     private suspend fun seedMaskedLiveClaudeSession(key: String): String {
         val suffix = unique()
@@ -454,7 +451,15 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
                         "-c /home/testuser " +
                         "\"printf 'issue1057-ready\\r\\n'; exec sh\"",
                 )
-                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind claude")
+                appendLine(
+                    "tmux show-options -v -t ${shellQuote(sessionName)} " +
+                        "@ps_agent_kind | grep -qx claude",
+                )
+                appendLine(
+                    "test -s /home/testuser/.claude/projects/-home-testuser/" +
+                        "issue1057-live-claude.jsonl",
+                )
                 appendLine("sleep 1")
             },
         )

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
@@ -90,10 +90,10 @@ import java.io.FileOutputStream
  * ### Real-path red→green (D33/G10)
  *
  * [modelCommandFromConversationShowsNoticeNoEchoBubbleThenTapOpensTerminal]:
- *  1. Attach to a masked-live-claude session (the #975/#1057 fixture shape: a
- *     recorded-shell whose cwd holds a fresh Claude transcript; the #975
- *     transcript-evidence fallback binds live detection and the transcript tails
- *     into `events`). The composer route is AgentConversation only when
+ *  1. Attach to a session explicitly recorded as Claude whose cwd holds a fresh
+ *     Claude transcript. The authoritative identity selects the real Claude
+ *     source and the transcript tails into `events`. The composer route is
+ *     AgentConversation only when
  *     `currentDetection != null` on the Conversation tab, so a REAL bound
  *     detection is required — a presumed-only pane routes AgentPayload and never
  *     reaches the notice path.
@@ -173,8 +173,8 @@ class ConversationTuiCommandJourneyDockerTest {
 
         val vm = currentViewModel()
 
-        // STEP 1 — REAL detection binds (the #975 transcript-evidence fallback)
-        // AND the transcript tails into `events`. A bound detection is what makes
+        // STEP 1 — REAL detection binds from the authoritative recorded Claude
+        // identity AND the transcript tails into `events`. A bound detection is what makes
         // the composer route AgentConversation (the notice path); a presumed-only
         // pane routes AgentPayload and never reaches it.
         val boundPaneId = requireNotNull(waitForDetectionBoundConversationPane(vm)) {
@@ -555,7 +555,12 @@ class ConversationTuiCommandJourneyDockerTest {
                     "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} " +
                         "-c /home/testuser \"printf 'issue1890-ready\\r\\n'; exec sh\"",
                 )
-                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind claude")
+                appendLine(
+                    "tmux show-options -v -t ${shellQuote(sessionName)} " +
+                        "@ps_agent_kind | grep -qx claude",
+                )
+                appendLine("test -s ${shellQuote(transcript)}")
                 appendLine("sleep 1")
             },
         )
@@ -563,12 +568,10 @@ class ConversationTuiCommandJourneyDockerTest {
     }
 
     /**
-     * The #975/#1057 masked-live-claude fixture shape: a session recorded
-     * `@ps_agent_kind=shell` whose cwd holds a FRESH Claude transcript (copied
-     * from the fixture seed). The daemon classify returns `unknown`, so the ONLY
-     * way detection binds is the #975 transcript-evidence fallback — which is what
-     * we need: a bound live detection whose transcript tails into events so the
-     * composer routes AgentConversation.
+     * A session explicitly recorded as Claude whose cwd holds a FRESH Claude
+     * transcript copied from the fixture seed. The recorded identity and JSONL
+     * are both asserted remotely so this test cannot silently become a readable
+     * shell fixture that never binds the Conversation composer route.
      */
     private suspend fun seedMaskedLiveClaudeSession(key: String): String {
         val suffix = unique()
@@ -598,7 +601,15 @@ class ConversationTuiCommandJourneyDockerTest {
                         "-c /home/testuser " +
                         "\"printf 'issue1207-ready\\r\\n'; exec sh\"",
                 )
-                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
+                appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind claude")
+                appendLine(
+                    "tmux show-options -v -t ${shellQuote(sessionName)} " +
+                        "@ps_agent_kind | grep -qx claude",
+                )
+                appendLine(
+                    "test -s /home/testuser/.claude/projects/-home-testuser/" +
+                        "issue1207-live-claude.jsonl",
+                )
                 appendLine("sleep 1")
             },
         )

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionDrawerUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionDrawerUiTest.kt
@@ -1,13 +1,22 @@
 package com.pocketshell.app.tmux
 
+import android.graphics.Bitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.app.sessions.HostTmuxSessionPickerRequest
 import com.pocketshell.app.sessions.HostTmuxSessionPickerState
 import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.core.storage.entity.HostEntity
+import java.io.File
+import java.io.FileOutputStream
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -28,12 +37,14 @@ class TmuxSessionDrawerUiTest {
                     rows = listOf(
                         HostTmuxSessionRow(
                             name = "codex",
+                            tmuxSessionId = "\$0",
                             createdAt = 1_000L,
                             lastActivity = 2_000L,
                             attached = true,
                         ),
                         HostTmuxSessionRow(
                             name = "fresh-work",
+                            tmuxSessionId = "\$1",
                             createdAt = 900L,
                             lastActivity = 1_500L,
                             attached = false,
@@ -45,7 +56,7 @@ class TmuxSessionDrawerUiTest {
                 currentSessionName = "codex",
                 onRefresh = { events += "refresh" },
                 onDismiss = { events += "dismiss" },
-                onAttach = { events += "attach:$it" },
+                onAttach = { events += "attach:${it.sessionName}" },
                 onCreate = { events += "create" },
             )
         }
@@ -105,7 +116,7 @@ class TmuxSessionDrawerUiTest {
     @Test
     fun longSessionNameKeepsTrailingAttachVisibleAndRowClickable() {
         val longName = "feature/sync-audit-with-extra-long-branch-name-and-retry-investigation"
-        val events = mutableListOf<String>()
+        var attachedTarget: TmuxSessionNavigationTarget? = null
         compose.setContent {
             TmuxSessionDrawer(
                 visible = true,
@@ -114,12 +125,14 @@ class TmuxSessionDrawerUiTest {
                     rows = listOf(
                         HostTmuxSessionRow(
                             name = "codex",
+                            tmuxSessionId = "\$0",
                             createdAt = 1_000L,
                             lastActivity = 2_000L,
                             attached = true,
                         ),
                         HostTmuxSessionRow(
                             name = longName,
+                            tmuxSessionId = "\$1",
                             createdAt = 900L,
                             lastActivity = 1_500L,
                             attached = false,
@@ -131,15 +144,65 @@ class TmuxSessionDrawerUiTest {
                 currentSessionName = "codex",
                 onRefresh = {},
                 onDismiss = {},
-                onAttach = { events += "attach:$it" },
+                onAttach = { attachedTarget = it },
                 onCreate = {},
             )
         }
 
-        compose.onNodeWithText("Attach").assertExists()
-        compose.onNodeWithText(longName).performClick()
+        val actionTag = tmuxSessionDrawerActionTag(longName)
+        compose.assertNodeFullyWithinRoot(actionTag, useUnmergedTree = true)
 
-        assertEquals(listOf("attach:$longName"), events)
+        // ListRow must allocate the fixed trailing slot before the title. The
+        // full text remains in semantics for accessibility while its measured
+        // visual bounds stop before the reachable Attach action.
+        val titleBounds = compose
+            .onNodeWithText(longName, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val attachBounds = compose
+            .onNodeWithTag(actionTag, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        assertTrue(
+            "Long session title must yield width to Attach: title=$titleBounds attach=$attachBounds",
+            titleBounds.right <= attachBounds.left,
+        )
+
+        captureDrawer("issue-2002-long-session-attach.png")
+
+        compose.onNodeWithText(longName)
+            .assertHasClickAction()
+            .performClick()
+
+        assertEquals(
+            TmuxSessionNavigationTarget(
+                sessionName = longName,
+                tmuxSessionId = "\$1",
+                sessionCreated = 900L,
+            ),
+            attachedTarget,
+        )
+    }
+
+    private fun captureDrawer(fileName: String) {
+        val bitmap = compose.onRoot().captureToImage().asAndroidBitmap()
+        try {
+            val instrumentation = InstrumentationRegistry.getInstrumentation()
+            val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+            val dir = File(mediaRoot, "additional_test_output/issue-2002-session-drawer")
+            check(dir.exists() || dir.mkdirs()) {
+                "Could not create #2002 screenshot dir: ${dir.absolutePath}"
+            }
+            val file = File(dir, fileName)
+            FileOutputStream(file).use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "Could not write #2002 screenshot: ${file.absolutePath}"
+                }
+            }
+            println("ISSUE2002_SESSION_DRAWER_SCREENSHOT ${file.absolutePath}")
+        } finally {
+            bitmap.recycle()
+        }
     }
 
     private fun request(): HostTmuxSessionPickerRequest =

--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageSchedulerTestIsolationRule.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageSchedulerTestIsolationRule.kt
@@ -1,0 +1,125 @@
+package com.pocketshell.app.usage
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.App
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.runBlocking
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.MultipleFailureException
+import org.junit.runners.model.Statement
+
+/**
+ * Class-fixture boundary for connected tests that render the host-list usage UI.
+ *
+ * AndroidJUnitRunner keeps the target application (and therefore the Hilt
+ * [UsageScheduler] singleton) alive across test classes. Clearing Room in a
+ * later class does not clear snapshots already published by that singleton,
+ * while an owner that leaves an eligible host can repopulate the snapshots on
+ * the scheduler's five-minute cadence. Reset both halves of that state before
+ * and after the owning class so isolation does not depend on naming every
+ * earlier test in a shard.
+ */
+internal class UsageSchedulerTestIsolationRule(
+    private val boundaryOverride: UsageSchedulerTestBoundary? = null,
+) : TestRule {
+    override fun apply(base: Statement, description: Description): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                val primaryFailure = runCatching {
+                    reset(description, "before")
+                    base.evaluate()
+                }.exceptionOrNull()
+                val afterFailure = runCatching {
+                    reset(description, "after")
+                }.exceptionOrNull()
+
+                if (primaryFailure != null) {
+                    afterFailure?.let(primaryFailure::addSuppressed)
+                    throw primaryFailure
+                }
+                afterFailure?.let { throw it }
+            }
+        }
+
+    private fun reset(description: Description, boundary: String) {
+        (boundaryOverride ?: realBoundary()).reset(description, boundary)
+    }
+
+    private fun realBoundary(): UsageSchedulerTestBoundary {
+        val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val app = targetContext.applicationContext as App
+        val database = EntryPointAccessors.fromApplication(
+            targetContext,
+            TestAccessEntryPoint::class.java,
+        ).appDatabase()
+
+        return UsageSchedulerTestBoundary(
+            stop = { runBlocking { app.usageScheduler.stop() } },
+            clear = { runBlocking { database.clearAllTables() } },
+            refresh = { runBlocking { app.usageScheduler.refreshNow() } },
+            snapshotKeys = { app.usageScheduler.snapshots.value.keys },
+            start = app.usageScheduler::start,
+            logEmpty = { test, edge ->
+                println(
+                    "USAGE_TEST_ISOLATION class=${test.className} " +
+                        "boundary=$edge snapshots=0",
+                )
+            },
+        )
+    }
+}
+
+/** Injectable lifecycle core so failure semantics are deterministic to test. */
+internal class UsageSchedulerTestBoundary(
+    private val stop: () -> Unit,
+    private val clear: () -> Unit,
+    private val refresh: () -> Unit,
+    private val snapshotKeys: () -> Set<*>,
+    private val start: () -> Unit,
+    private val logEmpty: (Description, String) -> Unit = { _, _ -> },
+) {
+    fun reset(description: Description, boundary: String) {
+        val failures = mutableListOf<Throwable>()
+        var stopCompleted = false
+        try {
+            runCatching { stop() }
+                .onSuccess { stopCompleted = true }
+                .exceptionOrNull()
+                ?.let(failures::add)
+
+            if (stopCompleted) {
+                // Keep attempting the complete drain after an individual
+                // failure so the boundary gathers all useful cleanup evidence.
+                runCatching { clear() }.exceptionOrNull()?.let(failures::add)
+                runCatching { refresh() }.exceptionOrNull()?.let(failures::add)
+
+                val keys = runCatching { snapshotKeys() }
+                    .onFailure(failures::add)
+                    .getOrNull()
+                if (keys != null) {
+                    val emptyFailure = runCatching {
+                        check(keys.isEmpty()) {
+                            "${description.className} leaked usage snapshots at the " +
+                                "$boundary class boundary: $keys"
+                        }
+                    }.exceptionOrNull()
+                    emptyFailure?.let(failures::add)
+                    if (emptyFailure == null) {
+                        runCatching { logEmpty(description, boundary) }
+                            .exceptionOrNull()
+                            ?.let(failures::add)
+                    }
+                }
+            }
+        } finally {
+            // Once stop() has completed, no drain/assertion/logging failure may
+            // poison every later class by leaving the process singleton down.
+            if (stopCompleted) {
+                runCatching { start() }.exceptionOrNull()?.let(failures::add)
+            }
+        }
+        MultipleFailureException.assertEmpty(failures)
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageSchedulerTestIsolationRuleTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageSchedulerTestIsolationRuleTest.kt
@@ -1,0 +1,152 @@
+package com.pocketshell.app.usage
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class UsageSchedulerTestIsolationRuleTest {
+    private val description = Description.createTestDescription(javaClass, "fixture")
+
+    @Test
+    fun successfulBoundaryStopsBeforeDrainAssertsEmptyAndRestarts() {
+        val events = mutableListOf<String>()
+        val rule = rule(events = events)
+
+        rule.apply(statement { events += "test" }, description).evaluate()
+
+        assertEquals(
+            listOf(
+                "stop", "clear", "refresh", "assert-empty", "log-before", "start",
+                "test",
+                "stop", "clear", "refresh", "assert-empty", "log-after", "start",
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun clearFailureStillRestartsScheduler() {
+        assertFailureStillRestarts(failingEvent = "clear")
+    }
+
+    @Test
+    fun refreshFailureStillRestartsScheduler() {
+        assertFailureStillRestarts(failingEvent = "refresh")
+    }
+
+    @Test
+    fun nonEmptySnapshotAssertionStillRestartsScheduler() {
+        assertFailureStillRestarts(failingEvent = "assert-empty")
+    }
+
+    @Test
+    fun protectedTestFailureRemainsPrimaryWhenAfterBoundaryAlsoFails() {
+        val primary = IllegalStateException("protected test failed")
+        val cleanup = IllegalArgumentException("after refresh failed")
+        var refreshCount = 0
+        val events = mutableListOf<String>()
+        val rule = rule(
+            events = events,
+            throwAt = { event ->
+                if (event == "refresh" && ++refreshCount == 2) cleanup else null
+            },
+        )
+
+        val thrown = assertThrows(IllegalStateException::class.java) {
+            rule.apply(statement { throw primary }, description).evaluate()
+        }
+
+        assertSame(primary, thrown)
+        assertEquals(listOf(cleanup), thrown.suppressed.toList())
+        assertEquals(2, events.count { it == "start" })
+    }
+
+    @Test
+    fun protectedTestFailureRemainsPrimaryWhenAfterBoundaryRestartFails() {
+        val primary = IllegalStateException("protected test failed")
+        val restart = IllegalArgumentException("after restart failed")
+        var startCount = 0
+        val events = mutableListOf<String>()
+        val rule = rule(
+            events = events,
+            throwAt = { event ->
+                if (event == "start" && ++startCount == 2) restart else null
+            },
+        )
+
+        val thrown = assertThrows(IllegalStateException::class.java) {
+            rule.apply(statement { throw primary }, description).evaluate()
+        }
+
+        assertSame(primary, thrown)
+        assertEquals(listOf(restart), thrown.suppressed.toList())
+        assertEquals(2, events.count { it == "start" })
+    }
+
+    private fun assertFailureStillRestarts(failingEvent: String) {
+        val failure = IllegalStateException("$failingEvent failed")
+        val events = mutableListOf<String>()
+        val boundary = boundary(
+            events = events,
+            throwAt = { event ->
+                if (event == failingEvent && failingEvent != "assert-empty") failure else null
+            },
+            snapshotKeys = if (failingEvent == "assert-empty") setOf("claude") else emptySet(),
+        )
+
+        val thrown = assertThrows(Throwable::class.java) {
+            boundary.reset(description, "after")
+        }
+
+        if (failingEvent == "assert-empty") {
+            check(thrown.message.orEmpty().contains("leaked usage snapshots"))
+        } else {
+            assertSame(failure, thrown)
+        }
+        assertEquals(
+            "scheduler must restart after $failingEvent failure",
+            1,
+            events.count { it == "start" },
+        )
+    }
+
+    private fun rule(
+        events: MutableList<String>,
+        throwAt: (String) -> Throwable? = { null },
+    ): UsageSchedulerTestIsolationRule = UsageSchedulerTestIsolationRule(
+        boundaryOverride = boundary(events, throwAt),
+    )
+
+    private fun boundary(
+        events: MutableList<String>,
+        throwAt: (String) -> Throwable? = { null },
+        snapshotKeys: Set<String> = emptySet(),
+    ): UsageSchedulerTestBoundary = UsageSchedulerTestBoundary(
+        stop = operation("stop", events, throwAt),
+        clear = operation("clear", events, throwAt),
+        refresh = operation("refresh", events, throwAt),
+        snapshotKeys = {
+            events += "assert-empty"
+            throwAt("assert-empty")?.let { throw it }
+            snapshotKeys
+        },
+        start = operation("start", events, throwAt),
+        logEmpty = { _, edge -> events += "log-$edge" },
+    )
+
+    private fun operation(
+        name: String,
+        events: MutableList<String>,
+        throwAt: (String) -> Throwable?,
+    ): () -> Unit = {
+        events += name
+        throwAt(name)?.let { throw it }
+    }
+
+    private fun statement(block: () -> Unit): Statement = object : Statement() {
+        override fun evaluate() = block()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -2051,13 +2051,15 @@ public class PromptComposerViewModel @Inject constructor(
      * anchored at [recordingStartedAtMs], independent of any audio-capture/PCM
      * source. Used by the Android SpeechRecognizer recording path, whose
      * listener-driven flow never runs the Whisper amplitude sampler that
-     * otherwise advances the timer. Runs on [samplerDispatcher] so tests drive
-     * it under virtual time; cancelled by [stopRecordingTimerTicker] when
-     * recording ends.
+     * otherwise advances the timer. Runs on `viewModelScope`'s pinnable
+     * `Dispatchers.Main.immediate` context because each tick publishes state
+     * observed by Compose; dispatching that mutation through the background
+     * sampler context can invalidate the Android view hierarchy off main.
+     * Cancelled by [stopRecordingTimerTicker] when recording ends.
      */
     private fun startRecordingTimerTicker() {
         recordingTimerJob?.cancel()
-        recordingTimerJob = viewModelScope.launch(samplerDispatcher) {
+        recordingTimerJob = viewModelScope.launch {
             while (kotlinx.coroutines.currentCoroutineContext().isActive) {
                 if (_uiState.value.recording != RecordingState.Recording) break
                 val elapsedMs = (clock() - recordingStartedAtMs).coerceAtLeast(0L)

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionDrawer.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionDrawer.kt
@@ -301,7 +301,9 @@ private fun TmuxSessionDrawerRow(
             },
             trailing = {
                 Box(
-                    modifier = Modifier.defaultMinSize(minWidth = PocketShellDensity.tapTargetMin),
+                    modifier = Modifier
+                        .defaultMinSize(minWidth = PocketShellDensity.tapTargetMin)
+                        .testTag(tmuxSessionDrawerActionTag(row.name)),
                     contentAlignment = Alignment.CenterEnd,
                 ) {
                     Badge(
@@ -327,3 +329,6 @@ internal const val TMUX_SESSION_SWITCHER_TAG = "tmux:session-switcher"
 internal const val TMUX_SESSION_DRAWER_CLOSE_TAG = "tmux:session-drawer:close"
 internal const val TMUX_SESSION_DRAWER_CREATE_TAG = "tmux:session-drawer:create"
 internal const val TMUX_SESSION_DRAWER_REFRESH_TAG = "tmux:session-drawer:refresh"
+
+internal fun tmuxSessionDrawerActionTag(sessionName: String): String =
+    "tmux:session-drawer:action:$sessionName"

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
@@ -100,6 +100,7 @@ public class TmuxSessionRuntimeCache @Inject constructor() {
         val evicted = mutableListOf<CachedTmuxRuntime>()
         evicted += evictExpiredLocked(now)
         val runtime = runtimes.remove(key)?.runtime
+            ?: removeNameOnlyPrewarmLocked(key)
         // Issue #681: when a session becomes active, drop any key-drifted TWIN
         // of that same session still parked under a different key. Otherwise
         // the active session ends up with a duplicate cache entry that surfaces
@@ -112,8 +113,36 @@ public class TmuxSessionRuntimeCache @Inject constructor() {
         )
     }
 
+    /**
+     * A picker prewarm is intentionally keyed only by host + session name,
+     * because the picker callback does not provide durable tmux identity. When
+     * the selected row subsequently supplies that identity, promote the single
+     * name-only prewarm instead of opening a second control client. Never fall
+     * back to another non-null durable identity: a killed/recreated same-name
+     * session must remain a cache miss.
+     */
+    private fun removeNameOnlyPrewarmLocked(key: TmuxRuntimeKey): CachedTmuxRuntime? {
+        if (key.durableSessionKey == null) return null
+        val entry = runtimes.entries.firstOrNull { candidate ->
+            candidate.key.hostId == key.hostId &&
+                candidate.key.sessionName == key.sessionName &&
+                candidate.key.durableSessionKey == null
+        } ?: return null
+        runtimes.remove(entry.key)
+        return entry.value.runtime
+    }
+
     internal fun contains(key: TmuxRuntimeKey): Boolean = synchronized(this) {
         runtimes.containsKey(key)
+    }
+
+    /**
+     * Session-picker prewarm receives only a host-scoped tmux session name, not
+     * the durable tmux identity. Match that deliberately narrower namespace so
+     * a parked runtime with a durable key is not prewarmed a second time.
+     */
+    internal fun containsSession(hostId: Long, sessionName: String): Boolean = synchronized(this) {
+        runtimes.keys.any { it.hostId == hostId && it.sessionName == sessionName }
     }
 
     internal fun containsExact(binding: RuntimeHealthBinding): Boolean = synchronized(this) {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeModels.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeModels.kt
@@ -93,6 +93,14 @@ internal fun ConnectionTarget.toRuntimeKey(): TmuxRuntimeKey =
         durableSessionKey = durableSessionKey(),
     )
 
+/** Picker rows provide names only, so a derived target must not inherit another session's identity. */
+internal fun ConnectionTarget.toNameOnlyPrewarmTarget(sessionName: String): ConnectionTarget = copy(
+    sessionName = sessionName,
+    startDirectory = null,
+    tmuxSessionId = null,
+    sessionCreated = null,
+)
+
 internal fun targetLogFields(target: ConnectionTarget): String = buildString {
     append("hostId=")
     append(target.hostId)

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4649,8 +4649,8 @@ public class TmuxSessionViewModel @Inject constructor(
             .map { it.trim() }
             .filter { it.isNotEmpty() && it != baseTarget.sessionName }
             .distinct()
-            .map { sessionName -> baseTarget.copy(sessionName = sessionName, startDirectory = null) }
-            .filterNot { runtimeCache.contains(it.toRuntimeKey()) }
+            .map(baseTarget::toNameOnlyPrewarmTarget)
+            .filterNot { runtimeCache.containsSession(it.hostId, it.sessionName) }
             .take(TMUX_SESSION_PREWARM_MAX_TARGETS)
             .toList()
         if (targets.isEmpty()) return
@@ -4660,7 +4660,7 @@ public class TmuxSessionViewModel @Inject constructor(
             for (target in targets) {
                 if (!isActive) return@launch
                 if (activeTarget?.let { isSameHost(it, target) } != true) return@launch
-                if (runtimeCache.contains(target.toRuntimeKey())) continue
+                if (runtimeCache.containsSession(target.hostId, target.sessionName)) continue
                 prewarmRuntime(target, foregroundSession)
             }
         }
@@ -5891,8 +5891,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // different session never inherits a stale shell verdict.
         confirmedShellSessionIds.clear()
         _confirmedShellPaneIds.value = emptySet()
-        // Issue #1158: drop the sticky alt-buffer agent latch with the other
-        // per-runtime caches so a different session never inherits a stale verdict.
+        // Issue #1158: clear the sticky alt-buffer latch before another session restores.
         altBufferAgentSessionIds.clear()
         _altBufferAgentPaneIds.value = emptySet()
         clearAgentConversations()
@@ -6065,6 +6064,7 @@ public class TmuxSessionViewModel @Inject constructor(
         bindClientObservers(runtime.client)
         rebindRestoredRuntimePaneJobsIfNeeded(runtime.client, runtime.panes)
         _panes.value = runtime.panes
+        runtime.panes.forEach { it.terminalState.requestSurfaceRepaint() }
         rebuildUnifiedPanes()
         restartAgentConversationsForRestoredRuntime(runtime)
         clientRegistration = activeTmuxClients.register(

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentDetectionStateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionAgentDetectionStateTest.kt
@@ -910,6 +910,24 @@ class TmuxSessionAgentDetectionStateTest : TmuxSessionViewModelTestBase() {
     }
 
     @Test
+    fun cacheRestoreForcesFullSurfaceRepaintBoundaryForReusedTerminal() = runTest(scheduler) {
+        val vm = newVm()
+        vm.connectPresumedAgentPaneWithDroppedRowForTest(FakeSshSession())
+        runCurrent()
+        val terminalState = vm.panes.value.single().terminalState
+        val repaintsBefore = terminalState.surfaceRepaintRequestCountForTest()
+
+        vm.parkAndRestoreActiveRuntimeForTest()
+
+        assertEquals(
+            "a cached activation must force exactly one surface repaint boundary so the " +
+                "reused or remounted TerminalView invalidates its #469 dirty cache",
+            repaintsBefore + 1,
+            terminalState.surfaceRepaintRequestCountForTest(),
+        )
+    }
+
+    @Test
     fun cacheRestoreReseedsDroppedRowWithoutScreenRefresh() = runTest(scheduler) {
         // G10 reproduce-first: a presumed-agent pane whose Conversation row was
         // dropped (the R3-B 2-null collapse), then PARKED and RESTORED on a warm

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCacheTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCacheTest.kt
@@ -93,6 +93,21 @@ class TmuxSessionRuntimeCacheTest {
     }
 
     @Test
+    fun durableSelectionActivatesNameOnlyPrewarmForSameHostAndSession() {
+        val cache = TmuxSessionRuntimeCache(maxEntries = 4, nowMs = { 0L })
+        val nameOnlyPrewarm = cachedRuntime("work")
+        val selectedKey = nameOnlyPrewarm.key.copy(durableSessionKey = "tmux:1:\$7:700")
+
+        cache.put(nameOnlyPrewarm)
+
+        assertEquals(
+            CacheActivation(runtime = nameOnlyPrewarm, evicted = emptyList()),
+            cache.activate(selectedKey),
+        )
+        assertEquals(emptyList<TmuxRuntimeKey>(), cache.snapshotKeys())
+    }
+
+    @Test
     fun removeExactStaleBindingCannotRemoveSameSessionReplacement() {
         val cache = TmuxSessionRuntimeCache(maxEntries = 4, nowMs = { 0L })
         val old = cachedRuntime("work")

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPrewarmSeedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelPrewarmSeedTest.kt
@@ -28,6 +28,74 @@ import java.io.InputStream
 @OptIn(ExperimentalCoroutinesApi::class)
 class TmuxSessionViewModelPrewarmSeedTest : TmuxSessionViewModelTestBase() {
     @Test
+    fun nameOnlyPrewarmDoesNotDuplicateParkedSessionWithDurableIdentity() = runTest(scheduler) {
+        val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 4)
+        val parkedClient = FakeTmuxClient()
+        runtimeCache.put(
+            CachedTmuxRuntime(
+                key = TmuxRuntimeKey(
+                    hostId = 1L,
+                    hostname = "alpha.example",
+                    port = 22,
+                    username = "alex",
+                    keyPath = "/keys/a",
+                    sessionName = "session-a",
+                    durableSessionKey = durableTmuxSessionKey(1L, "@1", 101L),
+                ),
+                hostName = "alpha",
+                startDirectory = null,
+                lease = null,
+                session = null,
+                client = parkedClient,
+                panes = emptyList(),
+                paneRows = emptyMap(),
+                paneProducerJobs = emptyMap(),
+                paneInputQueues = emptyMap(),
+                paneInputJobs = emptyMap(),
+                paneAgentJobs = emptyMap(),
+                paneAgentInputs = emptyMap(),
+                agentConversations = emptyMap(),
+                remoteColumns = 0,
+                remoteRows = 0,
+            ),
+        )
+        val vm = newVm(
+            runtimeCache = runtimeCache,
+            sshLeaseManager = testLeaseManager(
+                connector = QueueLeaseConnector(FakeSshSession()),
+                scope = this,
+                idleTtlMillis = 0L,
+            ),
+        )
+        val duplicateClient = FakeTmuxClient().withSinglePane("session-a", "%1")
+        vm.setTmuxClientFactoryForTest { _, _, _ -> duplicateClient }
+        vm.replaceClientForTest(
+            hostId = 1L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "session-b",
+            client = FakeTmuxClient(),
+            session = FakeSshSession(),
+            tmuxSessionId = "@2",
+            sessionCreated = 202L,
+        )
+
+        // The picker supplies names only. Deriving A from active B must neither
+        // inherit B's durable identity nor attach a second client for parked A.
+        vm.prewarmLikelySwitchTargets(listOf("session-a"))
+        advanceUntilIdle()
+
+        assertFalse(
+            "name-only prewarm must reuse the parked A runtime instead of opening duplicate -CC",
+            duplicateClient.connectCalled,
+        )
+        assertEquals(listOf(parkedClient), runtimeCache.cachedRuntimesForHost(1L).map { it.client })
+    }
+
+    @Test
     fun sessionSwitcherPrewarmCachesOnlyBoundedLikelyTargets() = runTest(scheduler) {
         val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 4)
         val connector = QueueLeaseConnector(FakeSshSession(), FakeSshSession(), FakeSshSession())


### PR DESCRIPTION
## Summary

Seven independently reviewed fixes from exact-main Nightly Extensive run 30933911811:

- #1995 authoritative Claude conversation fixtures
- #1999 composer timer state publication on Main
- #1992 failure-safe class-boundary usage scheduler isolation
- #1994 cached tmux runtime durable-identity promotion + restored-surface repaint, with corrected grace/cache journeys
- #893 progressive-disclosure-aware Ctrl/nano hotkey journey
- #2002 durable drawer fixture + contained Attach action proof
- #1993 real-activity multi-host journey harness/fixture

## Evidence

- every issue has independent `APPROVED` review with regression red→green evidence
- #1994: two contiguous A→B→A emulator/Docker runs with original-pixel A/B/A markers, A=1/B=1 clients, zero redial/new return attach
- #893: full connected class 2/2 with Ctrl-C, duplicated expanded Ctrl-C, Enter, GNU nano write/exit/cat artifacts
- #1992: failure-path lifecycle red 4/5 → green 6/6; exact hosted 129-test order keeps usage boundaries empty
- #1993: focused 1/1 + exact hosted neighbors 5/5, sshd 0→0
- #2002: connected class 3/3 and contained long-name Attach screenshot
- per-issue full JVM gates green at 603/603 tasks; static validity/harness/ratchet checks green

Separate failures discovered during triage remain tracked (#2003, #2006, reopened #1876/#1042, #470, #1737/#2007) and are not hidden by this PR.
