### PR TITLE
Fix nightly reconnect, lifecycle, and synthetic IME fixtures

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerLongDraftCaretVisibleTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerLongDraftCaretVisibleTest.kt
@@ -42,6 +42,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.insets.SyntheticImeStage
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.core.voice.WhisperClient
@@ -98,6 +99,7 @@ class PromptComposerLongDraftCaretVisibleTest {
     val compose = createAndroidComposeRule<ComponentActivity>()
 
     private val observedImeBottomPx = mutableStateOf(0)
+    private val syntheticImeStage by lazy { SyntheticImeStage(compose) }
 
     private class TestMicCapture : PromptComposerViewModel.MicCapture {
         override fun start() {}
@@ -528,15 +530,15 @@ class PromptComposerLongDraftCaretVisibleTest {
     )
 
     private fun applySyntheticKeyboardDownAndReadSendBottom(): Float {
-        repeat(2) {
-            applySyntheticInsets(
-                imeBottomPx = 0,
-                navBarBottomPx = 0,
-                statusBarTopPx = (SYNTHETIC_STATUS_BAR_DP * displayDensity()).toInt(),
-                requireModalRoot = true,
-            )
-            compose.waitForIdle()
-        }
+        // performTextInput focuses the production editor and may finish showing Gboard only
+        // after Compose has gone idle. Dispatching ime=0 into that in-flight transition lets
+        // the physical IME overwrite the synthetic baseline (the nightly #1677 recurrence
+        // observed 883 px). The shared stage waits for both the physical IME window and every
+        // app-root real inset to disappear before it permits a synthetic measurement.
+        syntheticImeStage.hideRealImeAndAssertHidden(
+            "Issue #1677 keyboard-down baseline must start without a physical IME.",
+        )
+        syntheticImeStage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = true)
         val observedIme = compose.onNodeWithTag(PRODUCTION_SHEET_TAG, useUnmergedTree = true)
             .fetchSemanticsNode()
             .config
@@ -569,15 +571,10 @@ class PromptComposerLongDraftCaretVisibleTest {
     }
 
     private fun applySyntheticImeAndAssertObservedInProductionSheet(): SyntheticImeGeometry {
-        repeat(2) {
-            applySyntheticInsets(
-                imeBottomPx = (SYNTHETIC_IME_HEIGHT_DP * displayDensity()).toInt(),
-                navBarBottomPx = 0,
-                statusBarTopPx = (SYNTHETIC_STATUS_BAR_DP * displayDensity()).toInt(),
-                requireModalRoot = true,
-            )
-            compose.waitForIdle()
-        }
+        syntheticImeStage.dispatch(
+            imeBottomPx = (SYNTHETIC_IME_HEIGHT_DP * displayDensity()).toInt(),
+            requireExtraWindowRoot = true,
+        )
 
         val sheetNode = compose.onNodeWithTag(PRODUCTION_SHEET_TAG, useUnmergedTree = true)
             .fetchSemanticsNode()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectStormLivelockE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectStormLivelockE2eTest.kt
@@ -26,6 +26,8 @@ import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.connection.ConnectionController
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
@@ -159,6 +161,9 @@ class ReconnectStormLivelockE2eTest {
     private var seededHostRowTag: String? = null
     private var tmuxServerPid: String? = null
     private var serverStalled: Boolean = false
+    private var decoySshSession: SshSession? = null
+    private var decoyShell: SshShell? = null
+    private var decoyControlClientPid: String? = null
     private val diagnostics = RecordingDiagnosticSink()
     private val timings = mutableListOf<String>()
 
@@ -182,6 +187,7 @@ class ReconnectStormLivelockE2eTest {
         // Un-stall the tmux server FIRST so the fixture is never left frozen for a
         // sibling test, even when an assertion above threw.
         runCatching { runBlocking { resumeTmuxServer() } }
+        runCatching { runBlocking { cleanupDecoyControlClient() } }
         runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
         runCatching { diagnostics.close() }
         clearLastSessionPrefs()
@@ -209,6 +215,7 @@ class ReconnectStormLivelockE2eTest {
     fun slowTailOnAProvenLinkNeitherKillsHandshakenTransportsNorSpinsForever() {
         runBlocking<Unit> {
             val key = requireNotNull(seededKey)
+            seedOlderUnrelatedControlClient(key)
             attachSeededTmuxSession(requireNotNull(seededHostRowTag))
             waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
             waitForConnected("initial attach")
@@ -317,14 +324,16 @@ class ReconnectStormLivelockE2eTest {
             val failure = runCatching {
                 stallTmuxServerAndDropControlChannel(
                     key = key,
-                    controlClientLookup = "true",
+                    targetControlClientLookup = "true",
                 )
             }.exceptionOrNull()
 
             assertTrue(
                 "fixture must enter the exact missing-control-client rejection; got=$failure",
                 failure is AssertionError &&
-                    failure.message.orEmpty().contains("could not resolve the app's live `tmux -CC`"),
+                    failure.message.orEmpty().contains(
+                        "expected exactly one live `tmux -CC` client attached to $SESSION_NAME",
+                    ),
             )
 
             resumeTmuxServer()
@@ -354,6 +363,7 @@ class ReconnectStormLivelockE2eTest {
     fun slowTailThatClearsHealsTheSameSessionWithoutKillingTheHandshakenTransport() {
         runBlocking<Unit> {
             val key = requireNotNull(seededKey)
+            seedOlderUnrelatedControlClient(key)
             attachSeededTmuxSession(requireNotNull(seededHostRowTag))
             waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
             waitForConnected("initial attach")
@@ -475,6 +485,86 @@ class ReconnectStormLivelockE2eTest {
     // -- the fixture: stall the tail, keep the dial healthy ------------------------------
 
     /**
+     * Reproduce #1996's hosted topology deterministically: another live `tmux -CC` process
+     * exists before PocketShell attaches the target session. A process-global
+     * `pgrep ... | head -1` therefore names this older, unrelated client and leaves the
+     * app's control channel alive. The real fixture must resolve the client from the target
+     * session instead of depending on process age or shard history.
+     */
+    private suspend fun seedOlderUnrelatedControlClient(key: String) {
+        val session = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+        val shell = session.startShell()
+        decoySshSession = session
+        decoyShell = shell
+
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(DECOY_SESSION_NAME)} 2>/dev/null || true")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(DECOY_SESSION_NAME)} " +
+                    shellQuote("exec sh -i"),
+            )
+        }
+        val seedResult = execRemote(key, script)
+        assertTrue(
+            "expected to seed the unrelated tmux session; exit=${seedResult.exitCode} " +
+                "stdout='${seedResult.stdout}' stderr='${seedResult.stderr}'",
+            seedResult.exitCode == 0,
+        )
+
+        // Use the same PTY-backed SSH shell shape as PocketShell's real TmuxClient. A plain
+        // background exec has no TTY and tmux rejects it with `tcgetattr failed`.
+        shell.writeStdin(
+            ("exec tmux -CC attach-session -t ${shellQuote(DECOY_SESSION_NAME)}\n")
+                .toByteArray(),
+        )
+
+        val lookupScript = buildString {
+            appendLine("set -u")
+            appendLine("CC=")
+            appendLine("for ignored in \$(seq 1 50); do")
+            appendLine(
+                "  CC=\$(tmux list-clients -t ${shellQuote(DECOY_SESSION_NAME)} " +
+                    "-F '#{client_pid}' 2>/dev/null | head -1)",
+            )
+            appendLine("  [ -n \"\$CC\" ] && break")
+            appendLine("  sleep 0.1")
+            appendLine("done")
+            appendLine("echo \"decoy_client_pid=\$CC\"")
+        }
+        val result = execRemote(key, lookupScript)
+        val decoyClientPid =
+            Regex("decoy_client_pid=(\\d+)").find(result.stdout)?.groupValues?.get(1)
+        decoyControlClientPid = decoyClientPid
+        assertTrue(
+            "expected an older unrelated tmux -CC client before PocketShell attaches; " +
+                "exit=${result.exitCode} stdout='${result.stdout}' stderr='${result.stderr}'",
+            result.exitCode == 0 && decoyClientPid != null,
+        )
+        recordTiming("fixture_decoy_client_pid", decoyClientPid!!.toLong())
+    }
+
+    private suspend fun cleanupDecoyControlClient() {
+        runCatching { decoyShell?.close() }
+        runCatching { decoySshSession?.close() }
+        decoyShell = null
+        decoySshSession = null
+        decoyControlClientPid = null
+        val key = seededKey ?: return
+        execRemote(
+            key,
+            "tmux kill-session -t ${shellQuote(DECOY_SESSION_NAME)} 2>/dev/null || true",
+        )
+    }
+
+    /**
      * Enter the maintainer's state in ONE remote round-trip so there is no window in which
      * the loop could heal before the tail is stalled:
      *
@@ -482,26 +572,27 @@ class ReconnectStormLivelockE2eTest {
      *  2. `kill -STOP` it — every later `-CC attach` / `list-panes` / `capture-pane` now
      *     blocks on a server that never answers, while `sshd` (a different process) keeps
      *     completing fresh dials + handshakes exactly as the maintainer's link did;
-     *  3. `pkill -f 'tmux -CC'` — kill the app's live control client so its channel EOFs and
-     *     the REAL passive-drop classifier fires. Ordering matters: stall first, then drop,
-     *     or the loop can heal in the gap.
+     *  3. resolve the ONE client attached to [SESSION_NAME] through tmux's own client table,
+     *     then kill that client so its channel EOFs and the REAL passive-drop classifier
+     *     fires. Process-global `pgrep | head -1` is forbidden: #1996 proved it selects an
+     *     unrelated older/orphan client under hosted shard history. Ordering matters: stall
+     *     first, then drop, or the loop can heal in the gap.
      */
     private suspend fun stallTmuxServerAndDropControlChannel(
         key: String,
-        controlClientLookup: String = "pgrep -f 'tmux(\\.real)?[ ]-CC' | head -1",
+        targetControlClientLookup: String =
+            "tmux list-clients -t ${shellQuote(SESSION_NAME)} -F '#{client_pid}' 2>/dev/null",
     ) {
-        // Match both the normal binary and the fixture wrapper's delegated
-        // `/usr/bin/tmux.real -CC` process. Keep `[ ]` in the regex: a plain literal
-        // `tmux -CC` also matches the shell running THIS script (its command line contains
-        // the lookup text), so it kills itself and the exec returns empty output. The
-        // bracketed form matches neither its own source text nor the shell command line.
         val script = buildString {
             appendLine("set -u")
             // Resolve BEFORE stalling: `#{pid}` needs a responsive server, and it is the
             // SERVER's pid (never a client's).
             appendLine("PID=\$(tmux display-message -p -t ${shellQuote(SESSION_NAME)} '#{pid}')")
             appendLine("echo \"tmux_server_pid=\$PID\"")
-            appendLine("CC=\$($controlClientLookup)")
+            appendLine("CCS=\$($targetControlClientLookup)")
+            appendLine("CC_COUNT=\$(printf '%s\\n' \"\$CCS\" | sed '/^\$/d' | wc -l | tr -d ' ')")
+            appendLine("CC=\$(printf '%s\\n' \"\$CCS\" | head -1)")
+            appendLine("echo \"cc_client_count=\$CC_COUNT\"")
             appendLine("echo \"cc_client_pid=\$CC\"")
             // The app spawns `tmux -CC new-session -A -s <name>` by writing into an SSH
             // SHELL channel, so the control channel EOFs (and `disconnected` latches) when
@@ -516,6 +607,10 @@ class ReconnectStormLivelockE2eTest {
         }
         val result = execRemote(key, script)
         tmuxServerPid = Regex("tmux_server_pid=(\\d+)").find(result.stdout)?.groupValues?.get(1)
+        val controlClientCount =
+            Regex("cc_client_count=(\\d+)").find(result.stdout)?.groupValues?.get(1)?.toIntOrNull()
+        val controlClientPid =
+            Regex("cc_client_pid=(\\d+)").find(result.stdout)?.groupValues?.get(1)
         // Record the cleanup debt BEFORE validating anything that happened after SIGSTOP.
         // Exact-main #1940 reached this point with a valid server pid but an empty CC pid;
         // the assertion below threw while serverStalled was still false, making @After's
@@ -533,10 +628,16 @@ class ReconnectStormLivelockE2eTest {
                 tmuxServerPid != null,
             )
             assertTrue(
-                "could not resolve the app's live `tmux -CC` control-client pid from " +
-                    "'${result.stdout}' — without dropping it there is no passive disconnect " +
-                    "and the grace loop never runs",
-                Regex("cc_client_pid=(\\d+)").containsMatchIn(result.stdout),
+                "expected exactly one live `tmux -CC` client attached to $SESSION_NAME, got " +
+                    "count=$controlClientCount from '${result.stdout}' — without identifying " +
+                    "the target session's client unambiguously there is no trustworthy passive " +
+                    "disconnect and the grace loop may never run",
+                controlClientCount == 1 && controlClientPid != null,
+            )
+            assertTrue(
+                "target-session lookup selected the unrelated decoy client " +
+                    "pid=$controlClientPid instead of $SESSION_NAME; stdout='${result.stdout}'",
+                controlClientPid != decoyControlClientPid,
             )
         } catch (failure: Throwable) {
             // Restore immediately as well as retaining @After as a second line of defence.
@@ -544,6 +645,8 @@ class ReconnectStormLivelockE2eTest {
             runCatching { resumeTmuxServer() }
             throw failure
         }
+        recordTiming("fixture_target_control_client_pid", controlClientPid!!.toLong())
+        recordTiming("fixture_target_control_client_count", controlClientCount!!.toLong())
         recordTiming("fixture_tmux_server_pid", tmuxServerPid!!.toLong())
     }
 
@@ -825,6 +928,7 @@ class ReconnectStormLivelockE2eTest {
         const val DATABASE_NAME: String = "pocketshell.db"
         const val DEVICE_DIR_NAME: String = "issue1652-storm-livelock"
         const val SESSION_NAME: String = "issue1652-storm"
+        const val DECOY_SESSION_NAME: String = "issue1996-unrelated-control"
         const val READY_MARKER: String = "ISSUE1652-STORM-READY"
         const val MARKER: String = "issue1652storm"
         const val POLL_MS: Long = 250L

--- a/app/src/androidTest/java/com/pocketshell/app/release/UpdateCheckSchedulerE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/release/UpdateCheckSchedulerE2eTest.kt
@@ -1,6 +1,8 @@
 package com.pocketshell.app.release
 
 import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
@@ -10,8 +12,10 @@ import com.pocketshell.app.notifications.UpdateNotifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -37,8 +41,22 @@ import java.util.concurrent.atomic.AtomicInteger
 @RunWith(AndroidJUnit4::class)
 class UpdateCheckSchedulerE2eTest {
 
+    private companion object {
+        const val TEST_PREFS_NAME = "update_check_throttle_issue_698_e2e"
+    }
+
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context: Context = ApplicationProvider.getApplicationContext()
+    // The instrumentation process runs the real App, whose singleton scheduler observes the
+    // same ProcessLifecycleOwner. Give this test scheduler a separate ledger so the App's
+    // earlier ON_START observer cannot consume this scheduler's throttle window.
+    private val isolatedStoreContext: Context = object : ContextWrapper(context) {
+        override fun getApplicationContext(): Context = this
+
+        override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences =
+            context.getSharedPreferences(TEST_PREFS_NAME, mode)
+    }
+    private var activeScheduler: UpdateCheckScheduler? = null
 
     private val sampleInfo = ReleaseInfo(
         tagName = "v9.9.9",
@@ -63,25 +81,65 @@ class UpdateCheckSchedulerE2eTest {
 
     @Before
     fun resetThrottleStore() {
-        context.getSharedPreferences("update_check_throttle", Context.MODE_PRIVATE)
+        restoreProcessLifecycleStarted()
+        context.getSharedPreferences(TEST_PREFS_NAME, Context.MODE_PRIVATE)
             .edit().clear().commit()
     }
 
     @After
     fun cleanup() {
-        context.getSharedPreferences("update_check_throttle", Context.MODE_PRIVATE)
-            .edit().clear().commit()
+        val scheduler = activeScheduler
+        try {
+            scheduler?.let {
+                instrumentation.runOnMainSync {
+                    it.stopObservingProcessLifecycleForTest(ProcessLifecycleOwner.get())
+                }
+            }
+        } finally {
+            try {
+                // The tests below mutate the process-global owner. Restore it even when the
+                // body or an early hard assertion throws, before any sibling test can start.
+                restoreProcessLifecycleStarted()
+            } finally {
+                scheduler?.scope?.cancel()
+                activeScheduler = null
+                context.getSharedPreferences(TEST_PREFS_NAME, Context.MODE_PRIVATE)
+                    .edit().clear().commit()
+            }
+        }
+    }
+
+    private fun restoreProcessLifecycleStarted() {
+        instrumentation.runOnMainSync {
+            val registry = ProcessLifecycleOwner.get().lifecycle as androidx.lifecycle.LifecycleRegistry
+            if (!registry.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                registry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+            }
+        }
+    }
+
+    private inline fun <T> withStoppedProcessLifecycle(body: () -> T): T {
+        return try {
+            instrumentation.runOnMainSync {
+                (ProcessLifecycleOwner.get().lifecycle as androidx.lifecycle.LifecycleRegistry)
+                    .handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+            }
+            body()
+        } finally {
+            restoreProcessLifecycleStarted()
+        }
     }
 
     private fun newScheduler(checker: ReleaseChecker, notifier: UpdateNotifier): UpdateCheckScheduler {
         val s = UpdateCheckScheduler(
             applicationContext = context,
             releaseChecker = checker,
-            store = UpdateCheckStore(context),
+            store = UpdateCheckStore(isolatedStoreContext),
             updateNotifier = notifier,
         )
         s.scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         s.currentVersionProvider = { "0.3.0" }
+        activeScheduler = s
         return s
     }
 
@@ -122,54 +180,72 @@ class UpdateCheckSchedulerE2eTest {
         val notifier = RecordingNotifier()
         val scheduler = newScheduler(checker, notifier)
 
-        // Attach to the REAL ProcessLifecycleOwner, exactly as App.onCreate
-        // does. Drive the lifecycle from CREATED → STARTED on the main thread
-        // so the observer receives ON_START (the foreground-resume trigger).
-        instrumentation.runOnMainSync {
-            scheduler.observeProcessLifecycle(ProcessLifecycleOwner.get())
-        }
+        withStoppedProcessLifecycle {
+            // Attach while stopped so the attach-time cold-start seed cannot satisfy the
+            // load-bearing resume assertion.
+            instrumentation.runOnMainSync {
+                scheduler.observeProcessLifecycle(ProcessLifecycleOwner.get())
+            }
+            assertTrue(
+                "the lifecycle observer should attach within the bounded pump",
+                pollUntil { scheduler.lifecycleObserverAttached },
+            )
 
-        // Background then foreground the process so an ON_START is delivered.
-        instrumentation.runOnMainSync {
-            val registry = ProcessLifecycleOwner.get().lifecycle
-            // currentState mutation is restricted to LifecycleRegistry; the
-            // process owner is a LifecycleRegistry under the hood. Toggle via
-            // the standard handleLifecycleEvent path used by tests.
-            (registry as androidx.lifecycle.LifecycleRegistry)
-                .handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-        }
-        instrumentation.runOnMainSync {
-            (ProcessLifecycleOwner.get().lifecycle as androidx.lifecycle.LifecycleRegistry)
-                .handleLifecycleEvent(Lifecycle.Event.ON_START)
-        }
+            // Foreground the process so the attached observer receives the real ON_START event.
+            instrumentation.runOnMainSync {
+                (ProcessLifecycleOwner.get().lifecycle as androidx.lifecycle.LifecycleRegistry)
+                    .handleLifecycleEvent(Lifecycle.Event.ON_START)
+            }
 
+            assertTrue(
+                "foreground resume (ON_START) should fire the update check",
+                pollUntil { scheduler.checkCount >= 1L },
+            )
+            assertTrue(
+                "the first lifecycle request should settle within the bounded pump",
+                pollUntil { scheduler.settledRequestCount >= 1L },
+            )
+
+            val firstCount = scheduler.checkCount
+            val firstSettledRequestCount = scheduler.settledRequestCount
+
+            // A second immediate resume within the throttle window must NOT fire another call.
+            instrumentation.runOnMainSync {
+                val registry =
+                    ProcessLifecycleOwner.get().lifecycle as androidx.lifecycle.LifecycleRegistry
+                registry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+                registry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+            }
+            assertTrue(
+                "the second lifecycle request should settle within the bounded pump",
+                pollUntil { scheduler.settledRequestCount > firstSettledRequestCount },
+            )
+            assertEquals(
+                "a resume within the throttle window must not re-check",
+                firstCount,
+                scheduler.checkCount,
+            )
+        }
+    }
+
+    @Test
+    fun stoppedProcessLifecycle_isRestoredWhenTestBodyThrows() {
+        val sentinel = IllegalStateException("issue-698-sentinel")
+
+        val thrown = runCatching {
+            withStoppedProcessLifecycle {
+                assertEquals(
+                    Lifecycle.State.CREATED,
+                    ProcessLifecycleOwner.get().lifecycle.currentState,
+                )
+                throw sentinel
+            }
+        }.exceptionOrNull()
+
+        assertSame("the sentinel body failure must propagate", sentinel, thrown)
         assertTrue(
-            "foreground resume (ON_START) should fire the update check",
-            pollUntil { scheduler.checkCount >= 1L },
+            "a thrown test body must leave the shared process owner STARTED",
+            ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED),
         )
-
-        val firstCount = scheduler.checkCount
-
-        // A second immediate resume within the throttle window must NOT fire
-        // another GitHub call.
-        instrumentation.runOnMainSync {
-            val registry = ProcessLifecycleOwner.get().lifecycle as androidx.lifecycle.LifecycleRegistry
-            registry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-            registry.handleLifecycleEvent(Lifecycle.Event.ON_START)
-        }
-        // Give any (incorrect) extra check a chance to run, then assert it did not.
-        Thread.sleep(500)
-        assertEquals(
-            "a resume within the throttle window must not re-check",
-            firstCount,
-            scheduler.checkCount,
-        )
-
-        // Restore the process owner to STARTED so the shared AVD lifecycle is
-        // left in a sane state for sibling tests.
-        instrumentation.runOnMainSync {
-            (ProcessLifecycleOwner.get().lifecycle as androidx.lifecycle.LifecycleRegistry)
-                .handleLifecycleEvent(Lifecycle.Event.ON_START)
-        }
     }
 }

--- a/app/src/main/java/com/pocketshell/app/release/UpdateCheckScheduler.kt
+++ b/app/src/main/java/com/pocketshell/app/release/UpdateCheckScheduler.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -140,6 +141,11 @@ public class UpdateCheckScheduler @Inject constructor(
     public val checkCount: Long
         get() = _checkCount.get()
 
+    /** Completed throttled requests, including requests suppressed by the throttle. */
+    private val _settledRequestCount = AtomicLong(0L)
+    internal val settledRequestCount: Long
+        get() = _settledRequestCount.get()
+
     private val processLifecycleObserver = LifecycleEventObserver { _: LifecycleOwner, event ->
         if (event == Lifecycle.Event.ON_START) {
             // Foreground resume — the maintainer's most common entry point
@@ -149,6 +155,9 @@ public class UpdateCheckScheduler @Inject constructor(
     }
 
     private var lifecycleAttached: Boolean = false
+    private val _lifecycleObserverAttached = AtomicBoolean(false)
+    internal val lifecycleObserverAttached: Boolean
+        get() = _lifecycleObserverAttached.get()
 
     /**
      * Attach a [ProcessLifecycleOwner] (or any [LifecycleOwner]) so a
@@ -169,9 +178,19 @@ public class UpdateCheckScheduler @Inject constructor(
         scope.launch {
             val alreadyStarted = withContext(Dispatchers.Main) {
                 owner.lifecycle.addObserver(processLifecycleObserver)
+                _lifecycleObserverAttached.set(true)
                 owner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
             }
             if (alreadyStarted) requestCheck(TRIGGER_FOREGROUND)
+        }
+    }
+
+    /** Detach the process-global observer so connected tests do not leak it to sibling tests. */
+    internal fun stopObservingProcessLifecycleForTest(owner: LifecycleOwner) {
+        owner.lifecycle.removeObserver(processLifecycleObserver)
+        _lifecycleObserverAttached.set(false)
+        synchronized(this) {
+            lifecycleAttached = false
         }
     }
 
@@ -205,7 +224,13 @@ public class UpdateCheckScheduler @Inject constructor(
     }
 
     private fun requestCheck(trigger: String) {
-        scope.launch { runCheck(trigger, force = false) }
+        scope.launch {
+            try {
+                runCheck(trigger, force = false)
+            } finally {
+                _settledRequestCount.incrementAndGet()
+            }
+        }
     }
 
     private suspend fun runCheck(trigger: String, force: Boolean) {

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -169,7 +169,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.proof.WarmLeaseReuseBatchCDockerTest"
   "com.pocketshell.app.proof.WarmLeaseReuseDockerTest"
   "com.pocketshell.app.proof.WithinGraceResumeRideThroughE2eTest"
-  "com.pocketshell.app.release.UpdateCheckSchedulerE2eTest"
   "com.pocketshell.app.sessions.service.SessionConnectionServiceE2eTest"
   "com.pocketshell.app.session.ConversationToolResultPairingE2eTest"
   "com.pocketshell.app.settings.ConversationFontSizeSettingE2eTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -344,7 +344,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.proof.WarmLeaseReuseBatchCDockerTest"
   "com.pocketshell.app.proof.WarmLeaseReuseDockerTest"
   "com.pocketshell.app.proof.WithinGraceResumeRideThroughE2eTest"
-  "com.pocketshell.app.release.UpdateCheckSchedulerE2eTest"
   "com.pocketshell.app.session.ConversationToolResultPairingE2eTest"
   "com.pocketshell.app.sessions.service.SessionConnectionServiceE2eTest"
   "com.pocketshell.app.settings.ConversationFontSizeSettingE2eTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -137,6 +137,7 @@ JOURNEY_CLASSES=(
   "$FQCN_PREFIX.AttachmentDropReconnectRecoversE2eTest"  # #1072 attaching a file dropped the live connection AND the
   "$FQCN_PREFIX.ReconnectRepaintE2eTest"
   "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"  # #1967/#1984 failure-preserving hard cleanup + zero-forward post-test invariant before grace journeys
+  "com.pocketshell.app.release.UpdateCheckSchedulerE2eTest"  # #698 real ProcessLifecycle resume/throttle plus thrown-body global-state restoration
   "$FQCN_PREFIX.BackgroundGraceReconnectE2eTest"  # #754 #959 this class is the per-PR-CI deterministic regression catcher…
   "$FQCN_PREFIX.BoundedGraceSessionHoldJourneyE2eTest"  # #1123 #977 #1021 #215 bounded-grace D21 update — supersedes the / indefinite-hold…
   "com.pocketshell.app.share.ShareTargetE2eTest"  # #727 #657 epic Wave 1 / S1): the share-auth journey pair


### PR DESCRIPTION
## Outcome

Adds two independently reviewed deterministic nightly fixes found in exact-main run 30933911811:

- #1996 makes the reconnect-storm fault target the intended tmux session's authoritative control-client PID instead of a process-global oldest client. The original >=5 storm and >=2 heal thresholds/timeouts remain unchanged; no product connection code changes.
- #698 isolates the update scheduler E2E throttle ledger from the instrumentation App singleton, replaces fixed-sleep synchronization with bounded settlement signals, restores the process-global lifecycle on every success/failure path, adds the thrown-body cleanup proof, and wires the class into the regular journey suite.

## Evidence

### #1996

- Controlled red: older unrelated PTY-backed `tmux -CC` decoy + old selector reproduced 0 cycles.
- Candidate connected class: 3/3; storm 5/5 handshaken cycles, heal 2/2 plus terminal round trip.
- Independent fresh connected class: 3/3 in 5m35s.
- Canonical full JVM: 603/603 tasks, 12,112 tests, zero failures/skips.
- Review: https://github.com/alexeygrigorev/pocketshell/issues/1996#issuecomment-5185953347

### #698

- Exact hosted red: lifecycle foreground check remained 0.
- Candidate/reviewer connected class: 3/3, including thrown-body lifecycle restoration.
- Canonical full JVM: 603/603 tasks, 12,112 tests, zero failures/skips.
- Journey validity/harness/budget guards green; integrated branch androidTest compilation green.
- Review: https://github.com/alexeygrigorev/pocketshell/issues/698#issuecomment-5185962082

## Scope

Two small commits, preserving rollback boundaries. The unrelated local untracked `ssh` file is not included.

Related: #1966, #1751.
