### PR TITLE
Stabilize Nightly focus, conversation, and forwarding journeys

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/EnvironmentFocusOwnerCleanupE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/EnvironmentFocusOwnerCleanupE2eTest.kt
@@ -1,0 +1,97 @@
+package com.pocketshell.app.fileviewer
+
+import android.os.SystemClock
+import androidx.activity.ComponentActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
+import com.pocketshell.app.proof.signals.executeFocusShellCommand
+import com.pocketshell.app.proof.signals.dismissFocusedLauncherFrameworkDialog
+import com.pocketshell.app.proof.signals.focusedFrameworkErrorPackage
+import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
+import com.pocketshell.app.proof.signals.resolveHomePackage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import org.junit.After
+import org.junit.Before
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Exact Android-owned focus-cascade regression for reopened issue #1985. */
+@RunWith(AndroidJUnit4::class)
+class EnvironmentFocusOwnerCleanupE2eTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun startFromPocketShellFocus() {
+        requirePocketShellFocusAfterLauncherDialogCleanup(
+            scenario = compose.activityRule.scenario,
+            context = "before issue #1985 launcher framework-dialog fixture",
+        )
+    }
+
+    @After
+    fun restoreFocusEvenWhenTheJourneyBodyExits() {
+        val ownerAtCleanup = focusedFrameworkErrorPackage()
+        if (ownerAtCleanup != null) {
+            assertTrue(
+                "the assertion-exit boundary must dismiss the exact launcher framework dialog",
+                dismissFocusedLauncherFrameworkDialog(),
+            )
+        }
+        val cleanupDeadline = SystemClock.elapsedRealtime() + 5_000
+        var escapedOwner: String?
+        do {
+            escapedOwner = focusedFrameworkErrorPackage()
+            if (escapedOwner == null) break
+            SystemClock.sleep(50)
+        } while (SystemClock.elapsedRealtime() < cleanupDeadline)
+        assertNull(
+            "no Android launcher framework focus owner may escape into the next IME journey",
+            escapedOwner,
+        )
+        WalkthroughScreenshotArtifacts.capture("issue1985-launcher-dialog-focus-restored")
+    }
+
+    @Test
+    fun launcherFrameworkDialogAtPriorJourneyExitCannotPoisonNextImeJourney() {
+        val homePackage = resolveHomePackage()
+        val oldShowFirst = executeFocusShellCommand(
+            "settings get global show_first_crash_dialog",
+        ).trim()
+        try {
+            executeFocusShellCommand("settings put global show_first_crash_dialog 1")
+            executeFocusShellCommand("input keyevent HOME")
+            SystemClock.sleep(1_500)
+            executeFocusShellCommand("am crash $homePackage")
+        } finally {
+            if (oldShowFirst == "null" || oldShowFirst.isBlank()) {
+                executeFocusShellCommand("settings delete global show_first_crash_dialog")
+            } else {
+                executeFocusShellCommand(
+                    "settings put global show_first_crash_dialog $oldShowFirst",
+                )
+            }
+        }
+
+        val deadline = SystemClock.elapsedRealtime() + 5_000
+        var focusedPackage: String? = null
+        while (SystemClock.elapsedRealtime() < deadline) {
+            focusedPackage = focusedFrameworkErrorPackage()
+            if (focusedPackage != null) break
+            SystemClock.sleep(50)
+        }
+        assertEquals(
+            "the fixture must raise a genuine package-android framework error for HOME",
+            homePackage,
+            focusedPackage,
+        )
+        WalkthroughScreenshotArtifacts.capture("issue1985-launcher-framework-focus-owner")
+        // No body cleanup. The @After boundary is the load-bearing finally
+        // path; without it this Android-owned window poisons the next journey.
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -48,6 +48,7 @@ import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
 import com.pocketshell.app.proof.signals.SyntheticFocusOwnerHarness
 import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
 import com.pocketshell.app.proof.signals.requirePocketShellFocusAtJourneyBoundary
+import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -104,6 +105,10 @@ class FileViewerDockerTest {
 
     @Before
     fun setUp(): Unit { runBlocking {
+        requirePocketShellFocusAfterLauncherDialogCleanup(
+            scenario = composeRule.activityRule.scenario,
+            context = "before FileViewer Docker journey",
+        )
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
@@ -121,6 +126,10 @@ class FileViewerDockerTest {
     @After
     fun tearDown(): Unit { runBlocking {
         focusOwner.dismissBestEffort()
+        requirePocketShellFocusAfterLauncherDialogCleanup(
+            scenario = composeRule.activityRule.scenario,
+            context = "after FileViewer Docker journey cleanup",
+        )
         if (seededPaths.isNotEmpty()) {
             withTimeout(15_000) {
                 connect()?.use { session ->

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingResumeOnLaunchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingResumeOnLaunchE2eTest.kt
@@ -25,9 +25,9 @@ import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.entity.HostEntity
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
@@ -70,10 +70,8 @@ import java.io.FileOutputStream
 @RunWith(AndroidJUnit4::class)
 class ForwardingResumeOnLaunchE2eTest {
 
-    @get:Rule
     val compose = createEmptyComposeRule()
 
-    @get:Rule
     val grantPermissions = PreGrantPermissionsRule()
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
@@ -87,15 +85,25 @@ class ForwardingResumeOnLaunchE2eTest {
 
     private fun controller(): ForwardingController = entryPoint().forwardingController()
 
-    @After
-    fun teardown() {
-        // Stop the resumed forward so the foreground service + notification
-        // clear and a sibling test starts clean.
-        runCatching { controller().stopAllForwarding() }
-        seededHostId = null
-        launchedActivity?.close()
-        launchedActivity = null
-    }
+    // Issue #2000: stopping only the runtime left this test's persisted
+    // `enabled=true` intent behind. A later process ON_START could therefore
+    // re-adopt the real tunnel and pin an unrelated reconnect journey forever.
+    // The shared hard-isolation owner disables that intent first, stops the
+    // singleton runtime, and refuses to return until controller/service/
+    // notification state is stably zero.
+    private val forwardingIsolation = PortForwardingTestIsolationRule(
+        afterStop = {
+            seededHostId = null
+            launchedActivity?.close()
+            launchedActivity = null
+        },
+    )
+
+    @get:Rule
+    val rules: RuleChain = RuleChain
+        .outerRule(forwardingIsolation)
+        .around(grantPermissions)
+        .around(compose)
 
     @Test
     fun persistedEnabledHost_resumesForwardingAndShowsIndicatorOnLaunch() {

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardingTestIsolationRule.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/PortForwardingTestIsolationRule.kt
@@ -38,7 +38,7 @@ internal class PortForwardingTestIsolationRule(
                 val cleanupFailures = mutableListOf<Throwable>()
 
                 runCatching { beforeStop() }.exceptionOrNull()?.let(cleanupFailures::add)
-                runCatching { hardStopAndAssertZero(description) }
+                runCatching { hardStopAndAssertZero(description.displayName) }
                     .exceptionOrNull()
                     ?.let(cleanupFailures::add)
                 runCatching { afterStop() }.exceptionOrNull()?.let(cleanupFailures::add)
@@ -54,7 +54,8 @@ internal class PortForwardingTestIsolationRule(
             }
         }
 
-    private fun hardStopAndAssertZero(description: Description) {
+    /** Run the same hard isolation mid-journey before a later `ON_START`. */
+    internal fun hardStopAndAssertZero(testName: String) {
         val context = androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
             .targetContext
@@ -108,17 +109,17 @@ internal class PortForwardingTestIsolationRule(
 
         runCatching {
             check(controller.flowOfActiveHostCount().value == 0) {
-                "post-test forwarding count must be zero for ${description.displayName}"
+                "post-test forwarding count must be zero for $testName"
             }
             check(controller.activeHostIdsSnapshot().isEmpty()) {
-                "post-test active forwards must be empty for ${description.displayName}: " +
+                "post-test active forwards must be empty for $testName: " +
                     controller.activeHostIdsSnapshot()
             }
             check(
                 !forwardingServiceRunningForTest(context) &&
                     !forwardingNotificationPresentForTest(context),
             ) {
-                "post-test forwarding service/notification must be absent for ${description.displayName}"
+                "post-test forwarding service/notification must be absent for $testName"
             }
         }.exceptionOrNull()?.let(cleanupFailures::add)
         MultipleFailureException.assertEmpty(cleanupFailures)
@@ -126,10 +127,10 @@ internal class PortForwardingTestIsolationRule(
         DiagnosticEvents.record(
             "test",
             "port_forward_post_test_zero",
-            "test" to description.displayName,
+            "test" to testName,
             "activeHostCount" to 0,
         )
-        Log.i(TAG, "post-test-zero test=${description.displayName}")
+        Log.i(TAG, "post-test-zero test=$testName")
     }
 
     private companion object {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
@@ -10,21 +10,23 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
-import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.BackgroundGraceTestOverride
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.portfwd.PortForwardingTestIsolationRule
 import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
-import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -85,14 +87,18 @@ class ServerDeathReconnectNoResurrectE2eTest {
 
     val compose = createAndroidComposeRule<MainActivity>()
 
+    private val forwardingIsolation = PortForwardingTestIsolationRule()
+
     @get:Rule
     val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
-        .outerRule(PreGrantPermissionsRule())
+        .outerRule(forwardingIsolation)
+        .around(PreGrantPermissionsRule())
         .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
         .around(compose)
 
     private lateinit var fixtureKey: String
     private lateinit var hostRowTag: String
+    private var forwardingHostId: Long = -1L
     private val timings = mutableListOf<String>()
 
     @After
@@ -127,6 +133,39 @@ class ServerDeathReconnectNoResurrectE2eTest {
     @Test
     fun serverDeathOnReconnectDropsToListAndNeverResurrects() { runBlocking {
         val key = fixtureKey
+
+        // #2000 recurrence prelude, in THIS instrumentation process: launch
+        // with real persisted forwarding intent, let production ON_START adopt
+        // it, hard-isolate it, then give a second real ON_START an opportunity
+        // to re-adopt stale intent. Neutralizing the hard isolation leaves the
+        // always-on pin active and the unchanged server-death consumer below
+        // times out after 30s with `grace-window-held-by-port-forward`.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        delay(PROCESS_LIFECYCLE_DRAIN_MS)
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        compose.waitUntil(timeoutMillis = FORWARDING_RESUME_TIMEOUT_MS) {
+            testAccess().forwardingController().isHostActive(forwardingHostId)
+        }
+        val controller = testAccess().forwardingController()
+        recordTiming(
+            "forwarding_active_before_cleanup",
+            if (controller.isHostActive(forwardingHostId)) 1L else 0L,
+        )
+
+        forwardingIsolation.hardStopAndAssertZero("#2000 same-process forwarding owner")
+
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        delay(PROCESS_LIFECYCLE_DRAIN_MS)
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        delay(FORWARDING_READOPTION_OBSERVATION_MS)
+        recordTiming(
+            "forwarding_active_after_readoption_opportunity",
+            if (controller.isHostActive(forwardingHostId)) 1L else 0L,
+        )
+        recordTiming(
+            "persisted_enabled_after_cleanup",
+            testAccess().appDatabase().hostDao().getEnabled().first().size.toLong(),
+        )
 
         // ---- (1) Attach to the primary seeded session via the normal journey.
         waitForHostRowPresent(hostRowTag)
@@ -204,6 +243,18 @@ class ServerDeathReconnectNoResurrectE2eTest {
             sessionScreenStillUp,
         )
 
+        // Supplemental owner-side oracle. The consumer above stays load-bearing:
+        // with cleanup neutralized, it first fails via the unchanged 30s list
+        // timeout while the re-adopted forward pins grace.
+        assertTrue(
+            "#2000 cleanup must leave no persisted enabled forwarding intent",
+            testAccess().appDatabase().hostDao().getEnabled().first().isEmpty(),
+        )
+        assertFalse(
+            "#2000 cleanup must prevent a later ON_START from re-adopting forwarding",
+            controller.isHostActive(forwardingHostId),
+        )
+
         writeTimings()
         Unit
     } }
@@ -246,32 +297,34 @@ class ServerDeathReconnectNoResurrectE2eTest {
 
     private suspend fun seedDockerHost(key: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
-            .fallbackToDestructiveMigration(dropAllTables = true)
-            .build()
-        return try {
-            db.clearAllTables()
-            val storedKey = SshKeyStorage.persistKey(
-                context = appContext,
-                sshKeyDao = db.sshKeyDao(),
-                name = "issue998-key-${System.currentTimeMillis()}",
-                content = key,
-            )
-            val hostId = db.hostDao().insert(
-                HostEntity(
-                    name = "Issue998 ServerDeath",
-                    hostname = DEFAULT_HOST,
-                    port = DEFAULT_PORT,
-                    username = DEFAULT_USER,
-                    keyId = storedKey.id,
-                    tmuxInstalled = true,
-                    lastBootstrapAt = System.currentTimeMillis(),
-                ),
-            )
-            HOST_ROW_TAG_PREFIX + hostId
-        } finally {
-            db.close()
-        }
+        val db = testAccess().appDatabase()
+        db.clearAllTables()
+        val storedKey = SshKeyStorage.persistKey(
+            context = appContext,
+            sshKeyDao = db.sshKeyDao(),
+            name = "issue998-key-${System.currentTimeMillis()}",
+            content = key,
+        )
+        forwardingHostId = db.hostDao().insert(
+            HostEntity(
+                name = "Issue998 ServerDeath",
+                hostname = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                username = DEFAULT_USER,
+                keyId = storedKey.id,
+                tmuxInstalled = true,
+                lastBootstrapAt = System.currentTimeMillis(),
+                // #2000: this journey owns the exact persisted intent that can
+                // be re-adopted later and pin the reconnect grace forever.
+                enabled = true,
+            ),
+        )
+        return HOST_ROW_TAG_PREFIX + forwardingHostId
+    }
+
+    private fun testAccess(): TestAccessEntryPoint {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        return EntryPointAccessors.fromApplication(context, TestAccessEntryPoint::class.java)
     }
 
     private suspend fun seedTmuxSessions(key: String) {
@@ -394,7 +447,6 @@ class ServerDeathReconnectNoResurrectE2eTest {
         "'" + value.replace("'", "'\"'\"'") + "'"
 
     private companion object {
-        const val DATABASE_NAME: String = "pocketshell.db"
         const val LOG_TAG: String = "Issue998ServerDeath"
         const val DEVICE_DIR_NAME: String = "issue998-server-death-reconnect"
 
@@ -409,5 +461,8 @@ class ServerDeathReconnectNoResurrectE2eTest {
         // without the user-facing 30s minimum.
         const val POST_GRACE_MS: Long = 1_200L
         const val RECONNECT_TIMEOUT_MS: Long = 30_000L
+        const val PROCESS_LIFECYCLE_DRAIN_MS: Long = 1_000L
+        const val FORWARDING_RESUME_TIMEOUT_MS: Long = 30_000L
+        const val FORWARDING_READOPTION_OBSERVATION_MS: Long = 2_000L
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/LauncherFrameworkDialogFocusBoundary.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/LauncherFrameworkDialogFocusBoundary.kt
@@ -1,0 +1,106 @@
+package com.pocketshell.app.proof.signals
+
+import android.app.Activity
+import android.os.ParcelFileDescriptor
+import android.view.accessibility.AccessibilityNodeInfo
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+
+private val FRAMEWORK_ERROR_FOCUS_PATTERN = Regex(
+    "mCurrentFocus=.*(?:Application Not Responding|Application Error): ([A-Za-z0-9._]+)",
+)
+
+/**
+ * Restores a journey from the one environment-owned focus window proven by
+ * issue #1985: a framework crash/ANR dialog for the device's HOME app.
+ *
+ * This is deliberately narrower than "package android". Framework dialogs for
+ * PocketShell and app-owned dialogs remain hard failures. Only a currently
+ * focused framework error whose subject is the dynamically resolved HOME
+ * package is closed, and the caller's activity must then regain focus.
+ */
+fun requirePocketShellFocusAfterLauncherDialogCleanup(
+    scenario: ActivityScenario<out Activity>,
+    context: String,
+    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+) {
+    if (waitForActivityWindowFocused(scenario, timeoutMs = 250)) return
+
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val focusedFrameworkPackage = focusedFrameworkErrorPackage()
+    val homePackage = resolveHomePackage()
+
+    if (focusedFrameworkPackage == homePackage) {
+        dismissFocusedLauncherFrameworkDialog()
+        if (waitForActivityWindowFocused(scenario, timeoutMs)) return
+    }
+
+    val outcome = awaitActivityWindowFocus(scenario, timeoutMs = 0)
+    throw AssertionError(
+        "$FOREIGN_WINDOW_FOCUS_SIGNATURE $context; ${outcome.diagnosis}; " +
+            "focused_framework_package=${focusedFrameworkPackage ?: "<none>"} " +
+            "home_package=$homePackage",
+    )
+}
+
+internal fun resolveHomePackage(): String {
+    val component = executeShellCommand(
+        "cmd package resolve-activity --brief " +
+            "-a android.intent.action.MAIN -c android.intent.category.HOME",
+    ).lineSequence().lastOrNull { '/' in it }.orEmpty().trim()
+    val pkg = component.substringBefore('/')
+    if (pkg.isBlank()) {
+        throw AssertionError("issue #1985 could not resolve the device HOME package: '$component'")
+    }
+    return pkg
+}
+
+internal fun focusedFrameworkErrorPackage(): String? = FRAMEWORK_ERROR_FOCUS_PATTERN
+    .find(executeShellCommand("dumpsys window"))
+    ?.groupValues
+    ?.get(1)
+
+internal fun executeFocusShellCommand(command: String): String = executeShellCommand(command)
+
+/** Closes only a currently focused framework error for the resolved HOME app. */
+internal fun dismissFocusedLauncherFrameworkDialog(): Boolean {
+    val focusedPackage = focusedFrameworkErrorPackage() ?: return false
+    val homePackage = resolveHomePackage()
+    if (focusedPackage != homePackage) return false
+    val closeButton = waitForUniqueFrameworkCloseButton(timeoutMs = 5_000)
+        ?: throw AssertionError(
+            "issue #1985 recognized the environment-owned launcher framework " +
+                "dialog but could not find its unique aerr_close action; " +
+                "home_package=$homePackage",
+        )
+    if (!closeButton.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
+        throw AssertionError(
+            "issue #1985 could not invoke the environment-owned launcher " +
+                "framework dialog's aerr_close action; home_package=$homePackage",
+        )
+    }
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    return true
+}
+
+private fun waitForUniqueFrameworkCloseButton(timeoutMs: Long): AccessibilityNodeInfo? {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val deadline = android.os.SystemClock.elapsedRealtime() + timeoutMs
+    do {
+        val buttons = instrumentation.uiAutomation.rootInActiveWindow
+            ?.findAccessibilityNodeInfosByViewId("android:id/aerr_close")
+            .orEmpty()
+        if (buttons.size == 1) return buttons.single()
+        android.os.SystemClock.sleep(50)
+    } while (android.os.SystemClock.elapsedRealtime() < deadline)
+    return null
+}
+
+private fun executeShellCommand(command: String): String {
+    val descriptor = InstrumentationRegistry.getInstrumentation()
+        .uiAutomation
+        .executeShellCommand(command)
+    return ParcelFileDescriptor.AutoCloseInputStream(descriptor)
+        .bufferedReader()
+        .use { it.readText() }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
@@ -36,6 +36,7 @@ import com.pocketshell.app.proof.signals.captureImeServiceState
 import com.pocketshell.app.proof.signals.describeActiveWindow
 import com.pocketshell.app.proof.signals.describeActiveWindowCallCount
 import com.pocketshell.app.proof.signals.resetDescribeActiveWindowCallCount
+import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
@@ -194,6 +195,10 @@ class ShowKeyboardChipE2eTest {
 
     @Before
     fun resetSharedProbes() {
+        requirePocketShellFocusAfterLauncherDialogCleanup(
+            scenario = compose.activityRule.scenario,
+            context = "before show-keyboard IME journey",
+        )
         resetDescribeActiveWindowCallCount()
     }
 
@@ -209,6 +214,10 @@ class ShowKeyboardChipE2eTest {
             }
         }
         focusStealer = null
+        requirePocketShellFocusAfterLauncherDialogCleanup(
+            scenario = compose.activityRule.scenario,
+            context = "after show-keyboard IME journey cleanup",
+        )
         clearLastSessionPrefs()
         seededKey?.let { key ->
             runCatching { runBlocking { cleanupRemoteTmuxSession(key) } }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
@@ -560,18 +560,38 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
     private suspend fun seedMaskedLiveClaudeSession(key: String): String {
         val suffix = unique()
         val sessionName = "issue975-masked-claude-$suffix"
+        val panePidFile = "/tmp/$sessionName-pane-pid"
+        val transcriptPath =
+            "/home/testuser/.claude/projects/-home-testuser/issue975-live-claude.jsonl"
+        val maskedProcessCommand =
+            "TRANSCRIPT_PATH=${shellQuote(transcriptPath)} exec sh -c " +
+                shellQuote(
+                    "exec 9< \"\$TRANSCRIPT_PATH\"; " +
+                        "printf 'issue975-masked-ready\\r\\n'; " +
+                        "POCKETSHELL_FAKE_AGENT_TRANSCRIPT=\"\$TRANSCRIPT_PATH\" " +
+                        "exec /usr/local/bin/pocketshell-fake-agent",
+                )
+        cleanupCommands +=
+            "pane_pid=\$(cat ${shellQuote(panePidFile)} 2>/dev/null || true); " +
+                "rm -f /tmp/pocketshell-agents-kind-unknown-pids/\$pane_pid " +
+                "${shellQuote(panePidFile)} 2>/dev/null || true"
         cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
         cleanupCommands +=
             "rm -f /home/testuser/.claude/projects/-home-testuser/" +
                 "issue975-live-claude.jsonl 2>/dev/null || true"
         // Seed a FRESH live Claude transcript in the cwd-encoded Claude project
         // dir for a writable cwd (`/home/testuser` → encoded `-home-testuser`), and
-        // attach the tmux session to that SAME cwd. (`/workspace` is not writable by
-        // testuser in the fixture; the encoded transcript dir is what the detector
-        // enumerates, and the cwd must be a real accessible dir for `pane.cwd` to
-        // match.) Record it `@ps_agent_kind=shell` (the durable verdict that hides
-        // the toggle). The daemon's classify returns `unknown` for this pane (no
-        // cgroup scope in the non-systemd container) — the masked-live-agent state.
+        // attach the tmux session to that SAME cwd. The pane runs the fixture's
+        // deterministic live agent TUI through a quiet wrapper whose command line
+        // contains no Claude/Codex/OpenCode kind token, while holding the real
+        // transcript open. This is a genuinely live masked-agent process plus
+        // live transcript evidence, not the old copied-file-only stand-in. Record
+        // it `@ps_agent_kind=shell` (the stale
+        // durable verdict that hides the toggle), then explicitly make this ONE
+        // live pane unreadable to the fixture classifier. The fixture hard-checks
+        // `/proc`, fd ownership, and the returned `unknown` verdict before launch,
+        // so a missing/non-live/misclassified setup fails rather than vacuously
+        // exercising the optimistic Conversation window.
         execRemote(
             key,
             buildString {
@@ -593,10 +613,26 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
                 appendLine(
                     "tmux new-session -d -x 80 -y 24 -s ${shellQuote(sessionName)} " +
                         "-c /home/testuser " +
-                        "\"printf 'issue975-masked-ready\\r\\n'; exec sh\"",
+                        shellQuote(maskedProcessCommand),
                 )
                 appendLine("tmux set-option -t ${shellQuote(sessionName)} @ps_agent_kind shell")
-                appendLine("sleep 1")
+                appendLine(
+                    "pane_pid=\$(tmux list-panes -t ${shellQuote(sessionName)} " +
+                        "-F '#{pane_pid}' | head -n 1)",
+                )
+                appendLine("test -n \"\$pane_pid\" && test -d \"/proc/\$pane_pid\"")
+                appendLine(
+                    "readlink -f /proc/\$pane_pid/fd/9 | " +
+                        "grep -Fx ${shellQuote(transcriptPath)} >/dev/null",
+                )
+                appendLine("printf '%s\\n' \"\$pane_pid\" > ${shellQuote(panePidFile)}")
+                appendLine("mkdir -p /tmp/pocketshell-agents-kind-unknown-pids")
+                appendLine("touch \"/tmp/pocketshell-agents-kind-unknown-pids/\$pane_pid\"")
+                appendLine(
+                    "printf '{\"panes\":[{\"pane_id\":\"%%0\",\"pane_pid\":%s}]}' " +
+                        "\"\$pane_pid\" | pocketshell agents kind | " +
+                        "grep '\"agent_kind\":\"unknown\"' >/dev/null",
+                )
             },
         )
         return sessionName

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
@@ -31,6 +31,7 @@ import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
+import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
 import com.pocketshell.app.voice.SHOW_KEYBOARD_CHIP_TAG
@@ -93,7 +94,13 @@ class Issue887TerminalFixedUnderImeE2eTest {
 
     @After
     fun cleanup() {
-        launchedActivity?.close()
+        launchedActivity?.let { scenario ->
+            requirePocketShellFocusAfterLauncherDialogCleanup(
+                scenario = scenario,
+                context = "after issue #887 IME journey cleanup",
+            )
+            scenario.close()
+        }
         launchedActivity = null
         runBlocking {
             runCatching { cleanupSeededSessions(readFixtureKey()) }
@@ -112,6 +119,10 @@ class Issue887TerminalFixedUnderImeE2eTest {
         forceFlatHostDetailViewMode()
 
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        requirePocketShellFocusAfterLauncherDialogCleanup(
+            scenario = requireNotNull(launchedActivity),
+            context = "before issue #887 IME journey",
+        )
 
         // Host row -> folder list -> picker -> attach to the seeded shell session.
         compose.waitUntil(timeoutMillis = 10_000) {

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
@@ -37,6 +37,7 @@ import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
+import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.app.proof.waitForSshFixtureReady
@@ -49,6 +50,7 @@ import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_CLOSE_TAG
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -180,7 +182,13 @@ class TmuxSessionOpencodeInputDockerTest {
 
     @After
     fun closeLaunchedActivity() {
-        launchedActivity?.close()
+        launchedActivity?.let { scenario ->
+            requirePocketShellFocusAfterLauncherDialogCleanup(
+                scenario = scenario,
+                context = "after OpenCode input journey cleanup",
+            )
+            scenario.close()
+        }
         launchedActivity = null
     }
 
@@ -598,6 +606,10 @@ class TmuxSessionOpencodeInputDockerTest {
         val hostRowTag: String = persistHost(appContext, key, sshPort)
         try {
             launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+            requirePocketShellFocusAfterLauncherDialogCleanup(
+                scenario = requireNotNull(launchedActivity),
+                context = "before issue #1979 OpenCode IME journey",
+            )
             compose.waitUntil(timeoutMillis = 10_000) {
                 compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
                     .fetchSemanticsNodes()
@@ -650,6 +662,20 @@ class TmuxSessionOpencodeInputDockerTest {
             }
             recordTiming("issue297_ctrl_d_double_tap_to_exit_ms", SystemClock.elapsedRealtime() - ctrlDAt)
             captureArtifact("issue297-03-ctrl-d-exited")
+
+            // The dedicated hotkeys sheet is test-owned. Close exactly that
+            // surface before the class boundary; otherwise its app window
+            // remains the focus owner and contaminates the next IME journey.
+            compose.onNodeWithTag(
+                TERMINAL_HOTKEYS_PANEL_CLOSE_TAG,
+                useUnmergedTree = true,
+            ).performClick()
+            compose.waitUntil(timeoutMillis = 5_000) {
+                compose.onAllNodesWithTag(
+                    TERMINAL_HOTKEYS_PANEL_TAG,
+                    useUnmergedTree = true,
+                ).fetchSemanticsNodes().isEmpty()
+            }
 
             writeTimings()
             writeIssue297Summary()

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
@@ -36,6 +36,7 @@ import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
 import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
+import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
 import com.pocketshell.app.proof.waitForSshFixtureReady
@@ -112,7 +113,13 @@ class TmuxShellComposerOcclusionE2eTest {
     @After
     fun cleanup() {
         dismissSyntheticFocusStealingWindow(requireFocusReturn = false)
-        launchedActivity?.close()
+        launchedActivity?.let { scenario ->
+            requirePocketShellFocusAfterLauncherDialogCleanup(
+                scenario = scenario,
+                context = "after shell-composer IME journey cleanup",
+            )
+            scenario.close()
+        }
         launchedActivity = null
         runBlocking {
             runCatching { cleanupSeededSessions(readFixtureKey()) }
@@ -127,6 +134,10 @@ class TmuxShellComposerOcclusionE2eTest {
         val hostRowTag = seedDockerHost(key, "Issue641 Shell Composer")
 
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        requirePocketShellFocusAfterLauncherDialogCleanup(
+            scenario = requireNotNull(launchedActivity),
+            context = "before shell-composer IME journey",
+        )
 
         // Host row -> picker -> attach to the seeded shell session.
         compose.waitUntil(timeoutMillis = 10_000) {

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -91,7 +91,6 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.hosts.HostEditFromKebabE2eTest"
   "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
-  "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
   "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayStaleChannelHealDockerTest"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -303,7 +303,6 @@ J1_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=(
   "com.pocketshell.app.hosts.HostEditFromKebabE2eTest"
   "com.pocketshell.app.notifications.UpdateAvailableNotificationE2eTest"
   "com.pocketshell.app.portfwd.ForwardingIndicatorE2eTest"
-  "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"
   "com.pocketshell.app.projects.AgentLaunchCommandDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayDockerTest"
   "com.pocketshell.app.projects.FolderListGatewayStaleChannelHealDockerTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -274,6 +274,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#cannotPreviewWithLocateCandidatesOffersOpenRows"
   "com.pocketshell.app.fileviewer.FileViewerScaffoldTest#markdownRenderedPipeTableShowsCellsNotRawDelimiter"  # #921 D32 G9): rendered Markdown shows GFM pipe tables as
   "com.pocketshell.app.fileviewer.FileViewerDockerTest#reopeningAChangedTextFileShowsTheFreshHostContent"  # #1713 D33/G10: reopening a text file whose host content changed over the same warm lease must show the FRESH body, not the stale one (bind() no longer early-returns on the identical settled request)
+  "com.pocketshell.app.fileviewer.EnvironmentFocusOwnerCleanupE2eTest#launcherFrameworkDialogAtPriorJourneyExitCannotPoisonNextImeJourney"  # #1985 recurrence: a genuine Android launcher framework dialog is owner-scoped cleanup, then the next IME journey starts focused
   "com.pocketshell.app.fileviewer.FileViewerDockerTest#failedSyntheticOwnerBodyRestoresFocusBeforeNextImeJourney"  # #1985 D32/G9: assertion exits always dismiss the owned synthetic window and prove PocketShell focus before the next IME journey
   "com.pocketshell.app.fileviewer.FileViewerDockerTest#moduleOneArticleListsRenderIntactAndContinuedLinkOpensExactUrl"  # #1714 D33/G9/G10: exact issue-time excerpts plus synthetic mixed/deep/wide class coverage through production MarkdownView
   "com.pocketshell.app.bootstrap.HostReadyPrimaryActionTest"  # #885 #117 D32 G9): the post-update Host ready success sheet must

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -133,7 +133,8 @@ JOURNEY_CLASSES=(
   "$FQCN_PREFIX.BackThenOpenSecondSessionReusesWarmLeaseE2eTest"  # #758 the maintainer's priority- back→open-another-session reconne…
   "$FQCN_PREFIX.ColdRestoreGoneSessionNoResurrectE2eTest"
   "$FQCN_PREFIX.LifecycleReattachGoneSessionNoResurrectE2eTest"  # #666 #998 a session killed on the host must NOT be
-  "$FQCN_PREFIX.ServerDeathReconnectNoResurrectE2eTest"  # #998 a remote tmux SERVER death (host reboot / OOM
+  "com.pocketshell.app.portfwd.ForwardingResumeOnLaunchE2eTest"  # #2000 forwarding owner uses persisted-intent + runtime hard isolation
+  "$FQCN_PREFIX.ServerDeathReconnectNoResurrectE2eTest"  # #998 #2000 one-process forwarding cleanup -> ON_START -> server-death consumer
   "$FQCN_PREFIX.AttachmentDropReconnectRecoversE2eTest"  # #1072 attaching a file dropped the live connection AND the
   "$FQCN_PREFIX.ReconnectRepaintE2eTest"
   "com.pocketshell.app.portfwd.PortForwardPanelLifecycleE2eTest"  # #1967/#1984 failure-preserving hard cleanup + zero-forward post-test invariant before grace journeys

--- a/tests/docker/agent-bin/pocketshell
+++ b/tests/docker/agent-bin/pocketshell
@@ -162,6 +162,14 @@ case "${1:-}" in
     # owned by the live fixture, not by the synthetic canned table: resolve it
     # to `none`. PocketShell-launched fixture agents remain covered by their
     # authoritative recorded @ps_agent_kind and never take this foreign path.
+    #
+    # Issue #975: one connected regression deliberately models the narrower
+    # real-host failure where a LIVE pane is unreadable to the classifier while
+    # its transcript is still trustworthy evidence. The seeder opts that exact
+    # pid into `unknown` by creating
+    # `/tmp/pocketshell-agents-kind-unknown-pids/<pid>`.  This is explicit
+    # per-pane state, never pid-range inference, so the #1973 live-shell rule
+    # remains authoritative for every unmarked live process.
     shift
     if [ "${1:-}" != "kind" ]; then
       printf 'pocketshell agents fixture supports: kind\n' >&2
@@ -226,6 +234,7 @@ case "${1:-}" in
       function classify(pid,   n) {
         if (pid !~ /^[0-9]+$/) return "unknown\tnull"
         n = pid + 0
+        if (system("test -f /tmp/pocketshell-agents-kind-unknown-pids/" n) == 0) return "unknown\tnull"
         if (system("test -d /proc/" n) == 0) return "none\tpocketshell-fixture-live.scope"
         if (n >= 1000 && n < 2000) return "claude\ttmuxctl-claude-main.scope"
         if (n >= 2000 && n < 3000) return "codex\ttmuxctl-codex.scope"


### PR DESCRIPTION
Closes #1985.
Closes #975.
Closes #2000.

Three independently reviewed Nightly fixes:
- isolate launcher-owned ANR dialogs from app IME journeys
- make the masked live-agent conversation fixture authoritative after #1973
- hard-clear persisted forwarding intent and gate the exact same-process server-death contamination

All issue-specific reviewer evidence and full-gate results are linked on the issues.