### PR TITLE
terminal: don't recycle a bitmap HWUI still owns in the pixel probe (#2003)

### DIFF
--- a/scripts/ci-journey-core-terminal-functions.sh
+++ b/scripts/ci-journey-core-terminal-functions.sh
@@ -78,6 +78,13 @@ run_core_terminal_hard_wrapped_url() {
   run_ct_class "$CORE_TERMINAL_HARD_WRAPPED_URL_CLASS"
 }
 
+CORE_TERMINAL_PIXEL_PROBE_ABANDON_CLASS="com.termux.view.TerminalViewPixelProbeAbandonedCopyInstrumentedTest"
+PIXEL_PROBE_ABANDON_STATUS="PASS"
+
+run_core_terminal_pixel_probe_abandon() {
+  run_ct_class "$CORE_TERMINAL_PIXEL_PROBE_ABANDON_CLASS"
+}
+
 # ---------------------------------------------------------------------------
 # Issue #1827: THE registry of core-terminal proofs.
 #
@@ -116,4 +123,5 @@ CORE_TERMINAL_PROOFS=(
   "SURFACE_REPAINT_STATUS|CORE_TERMINAL_SURFACE_REPAINT_CLASS|Core-terminal #1203 surface-only-black recovery proof"
   "SHELL_SNAPSHOT_STATUS|CORE_TERMINAL_SHELL_SNAPSHOT_CLASS|Core-terminal #1233 shell-pane single-snapshot affordance-scan proof"
   "HARD_WRAPPED_URL_STATUS|CORE_TERMINAL_HARD_WRAPPED_URL_CLASS|Core-terminal #1955 hard-wrapped URL target proof"
+  "PIXEL_PROBE_ABANDON_STATUS|CORE_TERMINAL_PIXEL_PROBE_ABANDON_CLASS|Core-terminal #2003 abandoned-PixelCopy RenderThread abort proof"
 )

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -867,4 +867,43 @@ else
   fi
 fi
 
+# --------------------------------------------------------------------------
+# Issue #2003 abandoned-PixelCopy RenderThread abort proof (core-terminal
+# androidTest). The #1443 diagnostic pixel-truth probe recycled its PixelCopy
+# destination bitmap in a `finally` that ALSO ran when the caller abandoned the
+# wait (the 250 ms `latch.await` timing out on a loaded device, or the probing
+# IO thread being interrupted). `PixelCopy.request` is asynchronous, so HWUI
+# resolved that same bitmap later on the RenderThread
+# (`Readback::copySurfaceInto` -> `CopyRequestAdapter::getDestinationBitmap` ->
+# `android::bitmap::toBitmap`), and `toBitmap` is LOG_ALWAYS_FATAL on a recycled
+# bitmap: "Error, cannot access an invalid/free'd bitmap here!" -> SIGABRT ->
+# the WHOLE APP PROCESS died. It killed a Conversation journey mid-run on `main`
+# base 20ec66b1 (device tombstone_16, pid 9555 tid 9598 RenderThread). This
+# proof drives the REAL production TerminalSurface + REAL PixelCopy against a
+# real window and abandons in-flight copies both ways (timeout + interrupt);
+# with the base recycle it dies as "Process crashed", with the ownership fix the
+# process survives and the probe still works. A diagnostic must never be able to
+# abort the app, so it stays guarded per-push. Uses NO Docker fixture.
+if budget_exhausted; then
+  STEP_TIMEOUT_HIT=1
+  PIXEL_PROBE_ABANDON_STATUS="SKIPPED"
+  echo "JOURNEY_STEP_TIMEOUT: skipping #2003 abandoned-PixelCopy proof — suite budget exhausted (issue #835 / #470 stall)"
+else
+  echo "=========================================================="
+  echo ">>> CORE-TERMINAL #2003 ABANDONED-PIXELCOPY PROOF: $CORE_TERMINAL_PIXEL_PROBE_ABANDON_CLASS (attempt 1)"
+  echo "=========================================================="
+  pixel_probe_abandon_start=$SECONDS
+  if run_core_terminal_pixel_probe_abandon; then
+    echo "PIXEL_PROBE_ABANDON_PASS: passed on attempt 1 (elapsed $((SECONDS - pixel_probe_abandon_start))s)"
+  else
+    echo ">>> ABANDONED-PIXELCOPY PROOF FAILED attempt 1 — retrying once (CI-AVD infra flake / sibling-install)"
+    if run_core_terminal_pixel_probe_abandon; then
+      echo "PIXEL_PROBE_ABANDON_FLAKE_RECOVERED: passed on retry (attempt 2)"
+    else
+      echo "PIXEL_PROBE_ABANDON_FAILED: #2003 proof failed twice"
+      PIXEL_PROBE_ABANDON_STATUS="FAIL"
+    fi
+  fi
+fi
+
 finish_ci_journey_suite

--- a/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewPixelProbeAbandonedCopyInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewPixelProbeAbandonedCopyInstrumentedTest.kt
@@ -1,0 +1,387 @@
+package com.termux.view
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.core.terminal.ui.TerminalSurface
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.terminal.ui.testArtifactsRoot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Issue #2003 — REAL-PATH regression for the app-process ABORT caused by the
+ * #1443 diagnostic pixel probe recycling a bitmap the HWUI RenderThread still owns.
+ *
+ * ## The reported symptom (a real process death, not a test artefact)
+ *
+ * During a connected Conversation journey on `main` base `20ec66b1` the app
+ * process died:
+ *
+ * ```
+ * F HWUI  : Error, cannot access an invalid/free'd bitmap here!
+ * F libc  : Fatal signal 6 (SIGABRT) ... tid 9598 (RenderThread)
+ * I Zygote: Process 9555 exited due to signal 6 (Aborted)
+ * ```
+ *
+ * The device's `tombstone_16` names the mechanism exactly:
+ *
+ * ```
+ * Cmdline: com.pocketshell.app.i1995
+ * pid: 9555, tid: 9598, name: RenderThread
+ * Abort message: 'Error, cannot access an invalid/free'd bitmap here!'
+ *   #04 libhwui.so android::bitmap::toBitmap(long)
+ *   #05 libhwui.so android::CopyRequestAdapter::getDestinationBitmap(int, int)
+ *   #06 libhwui.so android::uirenderer::Readback::copySurfaceInto(...)
+ *   #07 libhwui.so RenderProxy::copySurfaceInto(...)
+ *   #08 libhwui.so android::uirenderer::WorkQueue::process()
+ *   #09 libhwui.so RenderThread::threadLoop()
+ * ```
+ *
+ * That is `PixelCopy` — and PocketShell has exactly ONE `PixelCopy` call site:
+ * [TerminalView.sampleSurfaceNearUniformBlack], the #1443 diagnostic
+ * pixel-truth probe bound by `TerminalSurface` as the
+ * `TerminalSurfaceState.SurfacePixelSampler`. `PixelCopy.request` is
+ * ASYNCHRONOUS: it hands the destination bitmap to HWUI, which resolves it later
+ * on the RenderThread via `getDestinationBitmap` -> `toBitmap`, and `toBitmap` is
+ * `LOG_ALWAYS_FATAL` on a recycled bitmap. The base probe recycled the
+ * destination in a `finally` that ALSO ran when the caller abandoned the wait —
+ * so any probe whose 250 ms `latch.await` timed out on a loaded device (or whose
+ * thread was interrupted) armed a guaranteed SIGABRT of the whole app process.
+ * A diagnostic that must "NEVER destabilise the terminal" was killing the app.
+ *
+ * ## Red -> green (this test, on the REAL path)
+ *
+ * The production `TerminalSurface` is mounted in a real Activity window and the
+ * probe is driven through the REAL `TerminalView.sampleSurfaceNearUniformBlack`
+ * against the REAL window surface (no stand-in sampler — the whole symptom lives
+ * in the native readback, so a fake sampler proves nothing, F2).
+ *
+ *  - PRECONDITION (hard, never skipped): a generous-timeout probe returns
+ *    non-null, proving `PixelCopy` on this device actually reaches
+ *    `getDestinationBitmap` with the destination bitmap. Without this the
+ *    reproduction below could pass vacuously (G3).
+ *  - RED: each abandoned probe (the caller stops waiting while the copy is still
+ *    queued) recycles the destination on base, so the RenderThread aborts the
+ *    process — the run dies with `Process crashed` and the same tombstone.
+ *  - GREEN: with the ownership fix nothing recycles a bitmap HWUI still owns, the
+ *    process survives every abandoned copy, and the probe still works afterwards.
+ *
+ * ## Class coverage (G2)
+ *
+ * Both ways the caller can abandon an in-flight copy through that one `finally`
+ * are exercised: the `await` TIMEOUT (what the maintainer's run hit) and an
+ * INTERRUPT of the probing thread (the probe runs on `Dispatchers.IO` under
+ * `withContext`, so a cancelled watchdog scope interrupts it the same way).
+ * A third path — `await` returning normally — must still recycle, and is covered
+ * by the post-abandon probe still succeeding (the shared handler thread and
+ * sampler stay healthy).
+ *
+ * Uses NO Docker fixture (in-process real TerminalSurface + real window).
+ * Wired into `scripts/ci-journey-suite.sh` via the core-terminal proof registry.
+ */
+@RunWith(AndroidJUnit4::class)
+class TerminalViewPixelProbeAbandonedCopyInstrumentedTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun abandonedPixelProbeNeverRecyclesTheBitmapTheRenderThreadStillOwns() { runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val state = TerminalSurfaceState()
+        val stdout = MutableSharedFlow<ByteArray>(extraBufferCapacity = 8)
+        val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val producerJob = state.attachExternalProducer(
+            scope = producerScope,
+            stdout = stdout,
+            remoteStdin = null,
+        )
+        val timeline = mutableListOf<String>()
+
+        try {
+            // The REAL production surface — the same composable that binds
+            // `SurfacePixelSampler { view.sampleSurfaceNearUniformBlack() }`.
+            compose.setContent {
+                TerminalSurface(state = state, modifier = Modifier)
+            }
+            compose.waitForIdle()
+            val view = waitForTerminalView()
+
+            // Paint real content so the window has a genuine queued buffer for
+            // PixelCopy to read back (an empty window can make the readback fail
+            // early, before it ever resolves the destination bitmap).
+            state.appendRemoteOutput(
+                buildString {
+                    repeat(12) { row -> append("ISSUE2003 pixel probe row %02d abcdefghij\r\n".format(row)) }
+                }.toByteArray(Charsets.US_ASCII),
+            )
+            withTimeout(8_000) {
+                while (true) {
+                    compose.waitForIdle()
+                    if (visibleTerminalText(view).contains("ISSUE2003 pixel probe row 00")) break
+                    delay(40)
+                }
+            }
+            compose.waitForIdle()
+            instrumentation.waitForIdleSync()
+            SystemClock.sleep(500)
+
+            // ----------------------------------------------------------------
+            // PRECONDITION (hard-fails; never an assume/skip): the production
+            // probe really does drive PixelCopy to a SUCCESSful readback on this
+            // device. If this is null the abandoned-probe reproduction below
+            // could never have armed the abort and the whole red->green would be
+            // vacuous (G3). A generous wait is used so a contended emulator's
+            // slow readback cannot turn a real capability into a false skip.
+            val baseline = withContext(Dispatchers.IO) {
+                view.sampleSurfaceNearUniformBlack(GENEROUS_WAIT_MS)
+            }
+            assertNotNull(
+                "#2003 precondition: the REAL PixelCopy probe must complete on this device " +
+                    "(non-null) — otherwise the readback never resolves the destination bitmap " +
+                    "and the abandoned-copy reproduction below would pass vacuously",
+                baseline,
+            )
+            timeline += "precondition_probe_completed near_uniform_black=$baseline"
+
+            // ----------------------------------------------------------------
+            // REPRODUCTION A — the TIMEOUT abandon (the maintainer's run).
+            // A 0 ms wait ALWAYS returns before the copy can finish: the request
+            // has been handed to HWUI and is still queued on the RenderThread's
+            // WorkQueue. On base the `finally` recycled the destination right
+            // here, so `getDestinationBitmap` -> `toBitmap` aborted the process.
+            repeat(ABANDONED_PROBES) { i ->
+                val abandoned = withContext(Dispatchers.IO) {
+                    view.sampleSurfaceNearUniformBlack(0L)
+                }
+                assertNull(
+                    "#2003 reproduction A probe $i must have ABANDONED an in-flight PixelCopy " +
+                        "(a 0 ms wait cannot outlast the RenderThread hop). A non-null result " +
+                        "means the copy completed synchronously and the abort window was never " +
+                        "entered — the reproduction would be vacuous",
+                    abandoned,
+                )
+            }
+            timeline += "timeout_abandoned_probes=$ABANDONED_PROBES"
+            settleRenderThread(instrumentation, view)
+            timeline += "survived_timeout_abandon"
+
+            // ----------------------------------------------------------------
+            // REPRODUCTION B — the INTERRUPT abandon. The production probe runs
+            // inside `withContext(Dispatchers.IO)` from a cancellable watchdog
+            // scope, so cancellation interrupts the blocked `latch.await` and
+            // exits through the SAME `finally`. Pre-setting the interrupt makes
+            // `await` throw immediately and deterministically, with the copy
+            // certainly still in flight.
+            repeat(ABANDONED_PROBES) { i ->
+                val result = AtomicReference<Any?>(NOT_SET)
+                val worker = Thread({
+                    Thread.currentThread().interrupt()
+                    result.set(view.sampleSurfaceNearUniformBlack(GENEROUS_WAIT_MS))
+                }, "issue2003-interrupt-probe-$i")
+                worker.start()
+                worker.join(WORKER_JOIN_MS)
+                assertTrue(
+                    "#2003 reproduction B probe $i: the interrupted probe must return promptly " +
+                        "instead of blocking (it exits through the same abandon path)",
+                    !worker.isAlive,
+                )
+                assertNull(
+                    "#2003 reproduction B probe $i must have ABANDONED an in-flight PixelCopy " +
+                        "via InterruptedException — a non-null result means the interrupt never " +
+                        "landed and the reproduction would be vacuous",
+                    result.get(),
+                )
+            }
+            timeline += "interrupt_abandoned_probes=$ABANDONED_PROBES"
+            settleRenderThread(instrumentation, view)
+            timeline += "survived_interrupt_abandon"
+
+            // ----------------------------------------------------------------
+            // GREEN — reaching here at all means the RenderThread drained every
+            // abandoned CopyRequest WITHOUT hitting a freed bitmap: on base this
+            // process is already dead (SIGABRT) and no assertion below can run.
+            // The probe must also still be functional, proving the fix did not
+            // simply disable the diagnostic or wedge its shared handler thread.
+            val afterAbandon = withContext(Dispatchers.IO) {
+                view.sampleSurfaceNearUniformBlack(GENEROUS_WAIT_MS)
+            }
+            assertNotNull(
+                "#2003 GREEN: the #1443 pixel probe must still complete after abandoned copies " +
+                    "— the fix is about bitmap ownership, not about disabling the diagnostic",
+                afterAbandon,
+            )
+            timeline += "post_abandon_probe_completed near_uniform_black=$afterAbandon"
+
+            // The terminal itself must be unharmed: the surface still carries the
+            // painted content the probe was sampling.
+            assertTrue(
+                "#2003: the terminal must still render its content after the abandoned probes",
+                visibleTerminalText(view).contains("ISSUE2003 pixel probe row 00"),
+            )
+            timeline += "terminal_content_intact"
+
+            captureViewport(view, "issue2003-pixel-probe-abandoned-copy")
+            writeArtifact(
+                "issue2003-acceptance.txt",
+                buildString {
+                    appendLine("issue=2003")
+                    appendLine("probe_call_site=TerminalView.sampleSurfaceNearUniformBlack (the only PixelCopy in the app)")
+                    appendLine("abandoned_probes_per_path=$ABANDONED_PROBES")
+                    appendLine("timeout_abandon_survived=true")
+                    appendLine("interrupt_abandon_survived=true")
+                    appendLine("probe_still_functional_after_abandon=true")
+                    timeline.forEach { appendLine("timeline=$it") }
+                },
+            )
+        } finally {
+            producerJob.cancel()
+            producerScope.cancel()
+        }
+        Unit
+    } }
+
+    /**
+     * Give the HWUI RenderThread ample opportunity to dequeue and run every
+     * pending `CopyRequest`. On base the abort lands inside this window — the
+     * process dies and nothing after it executes.
+     */
+    private fun settleRenderThread(
+        instrumentation: android.app.Instrumentation,
+        view: TerminalView,
+    ) {
+        repeat(RENDER_SETTLE_FRAMES) {
+            instrumentation.runOnMainSync { view.invalidate() }
+            instrumentation.waitForIdleSync()
+            SystemClock.sleep(RENDER_SETTLE_STEP_MS)
+        }
+    }
+
+    private suspend fun waitForTerminalView(): TerminalView {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val ref = arrayOfNulls<TerminalView>(1)
+        withTimeout(15_000) {
+            while (ref[0] == null) {
+                instrumentation.runOnMainSync {
+                    ref[0] = findTerminalView(compose.activity.window.decorView)
+                }
+                if (ref[0] == null) delay(20)
+            }
+        }
+        val view = requireNotNull(ref[0])
+        withTimeout(15_000) {
+            while (true) {
+                var sized = false
+                instrumentation.runOnMainSync { sized = view.width > 0 && view.height > 0 }
+                if (sized) break
+                delay(20)
+            }
+        }
+        return view
+    }
+
+    private fun findTerminalView(root: View): TerminalView? {
+        if (root is TerminalView) return root
+        if (root is ViewGroup) {
+            for (i in 0 until root.childCount) {
+                val hit = findTerminalView(root.getChildAt(i))
+                if (hit != null) return hit
+            }
+        }
+        return null
+    }
+
+    private fun visibleTerminalText(view: TerminalView): String {
+        var text = ""
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            text = view.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+        return text
+    }
+
+    private fun captureViewport(view: TerminalView, name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        instrumentation.runOnMainSync {
+            if (view.width > 0 && view.height > 0) {
+                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+                view.draw(Canvas(b))
+                bitmap = b
+            }
+        }
+        bitmap?.let { b ->
+            val file = artifactFile("$name-viewport.png")
+            FileOutputStream(file).use { out ->
+                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                    "failed to write bitmap to ${file.absolutePath}"
+                }
+            }
+            println("ISSUE2003_VIEWPORT ${file.absolutePath}")
+            b.recycle()
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(visibleTerminalText(view))
+    }
+
+    private fun writeArtifact(name: String, text: String) {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE2003_ARTIFACT ${file.absolutePath}")
+        // Mirror into logcat too: the instrumentation APK (and its external media
+        // dir) is uninstalled when the run ends, so logcat is the evidence that
+        // outlives the run and shows the assertions were not vacuous.
+        for (line in text.trim().lines()) android.util.Log.i(LOG_TAG, line)
+    }
+
+    private fun artifactFile(name: String): File {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val dir = File(testArtifactsRoot(context), "terminal-lab").apply { mkdirs() }
+        return File(dir, name)
+    }
+
+    private companion object {
+        const val LOG_TAG = "Issue2003PixelProbe"
+
+        /** How many abandoned probes to fire per abandon path. */
+        const val ABANDONED_PROBES = 8
+
+        /**
+         * A wait long enough that a contended swiftshader emulator's readback
+         * cannot be mistaken for "PixelCopy does not work here" (the precondition
+         * and the GREEN probe must never self-skip).
+         */
+        const val GENEROUS_WAIT_MS = 15_000L
+
+        const val WORKER_JOIN_MS = 30_000L
+        const val RENDER_SETTLE_FRAMES = 12
+        const val RENDER_SETTLE_STEP_MS = 150L
+
+        /** Sentinel so "the worker never assigned a result" is distinguishable from `null`. */
+        val NOT_SET = Any()
+    }
+}

--- a/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
+++ b/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
@@ -43,6 +43,7 @@ import android.widget.Scroller;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 
 import com.pocketshell.core.terminal.input.BracketedPaste;
 import com.termux.terminal.KeyHandler;
@@ -286,6 +287,21 @@ public final class TerminalView extends View {
      */
     @Nullable
     public Boolean sampleSurfaceNearUniformBlack() {
+        return sampleSurfaceNearUniformBlack(PIXEL_SAMPLE_TIMEOUT_MS);
+    }
+
+    /**
+     * Issue #2003 — the timeout-parameterised body of {@link #sampleSurfaceNearUniformBlack()}.
+     *
+     * <p>The parameter exists ONLY so
+     * {@code TerminalViewPixelProbeAbandonedCopyInstrumentedTest} can force the
+     * abandon-while-in-flight path deterministically (a 0 ms wait always leaves the
+     * {@link PixelCopy} request queued on the HWUI RenderThread). Production always
+     * calls the no-arg overload with {@value #PIXEL_SAMPLE_TIMEOUT_MS} ms.
+     */
+    @VisibleForTesting
+    @Nullable
+    Boolean sampleSurfaceNearUniformBlack(long timeoutMs) {
         try {
             final int width = getWidth();
             final int height = getHeight();
@@ -302,6 +318,29 @@ public final class TerminalView extends View {
             // view's on-screen size — never a per-pixel full-surface scan (#1296/#1164).
             final Bitmap dest =
                 Bitmap.createBitmap(PIXEL_SAMPLE_DIM, PIXEL_SAMPLE_DIM, Bitmap.Config.ARGB_8888);
+            // Issue #2003 — RenderThread OWNERSHIP of `dest`, not "always recycle".
+            //
+            // `PixelCopy.request` is ASYNCHRONOUS: it hands `dest` to HWUI, which
+            // resolves it on the RenderThread inside `Readback::copySurfaceInto` ->
+            // `CopyRequestAdapter::getDestinationBitmap` -> `android::bitmap::toBitmap`.
+            // `toBitmap` is `LOG_ALWAYS_FATAL` on a recycled bitmap ("Error, cannot
+            // access an invalid/free'd bitmap here!"), so recycling `dest` while the
+            // request is still queued ABORTS THE WHOLE APP PROCESS (SIGABRT on
+            // RenderThread) — a diagnostic probe killing the app, the exact inverse of
+            // "must NEVER destabilise the terminal". That is what the #2003 tombstone
+            // (`tombstone_16`, pid 9555 tid 9598 RenderThread) recorded, reached via
+            // the 250 ms `latch.await` timing out on a loaded device while the copy was
+            // still in flight.
+            //
+            // The callback firing is the ONLY signal that HWUI is done with `dest`
+            // (`Readback::copySurfaceInto` invokes it after the readback, on every
+            // result including errors). So recycle IF AND ONLY IF the latch was
+            // counted down. On the timeout / interrupt paths we simply drop the
+            // reference: the in-flight `CopyRequest` holds its own ref, so the GC frees
+            // the (1 KB, PIXEL_SAMPLE_DIM^2 ARGB_8888) sample only once HWUI is truly
+            // finished with it. `Bitmap.recycle()` is documented as not normally
+            // needed; a 1 KB deferred free is not worth a process abort.
+            boolean copyFinished = false;
             try {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final int[] status = {PixelCopy.ERROR_UNKNOWN};
@@ -311,7 +350,8 @@ public final class TerminalView extends View {
                     status[0] = copyResult;
                     latch.countDown();
                 }, pixelProbeHandler());
-                if (!latch.await(PIXEL_SAMPLE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                copyFinished = latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+                if (!copyFinished) {
                     return null;
                 }
                 if (status[0] != PixelCopy.SUCCESS) {
@@ -319,9 +359,7 @@ public final class TerminalView extends View {
                 }
                 return Boolean.valueOf(isBitmapNearUniformBackground(dest));
             } finally {
-                // Always recycle — including the timeout / error / exception paths — so a
-                // probe failure never leaks the sample bitmap.
-                dest.recycle();
+                if (copyFinished) dest.recycle();
             }
         } catch (Throwable t) {
             // A diagnostic probe must NEVER destabilise the terminal: any failure


### PR DESCRIPTION
Closes #2003.

**A real crash on real devices.** PocketShell's own #1443 pixel-truth diagnostic was aborting the app process.

## The bug

```java
if (!latch.await(PIXEL_SAMPLE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
    return null;          // the copy is STILL QUEUED on the RenderThread
}
...
} finally {
    dest.recycle();       // frees a bitmap HWUI has not finished with
}
```

`PixelCopy.request` is **asynchronous** — it hands `dest` to HWUI, which resolves it on the RenderThread via `Readback::copySurfaceInto` → `CopyRequestAdapter::getDestinationBitmap` → `android::bitmap::toBitmap`. `toBitmap` is `LOG_ALWAYS_FATAL` on a recycled bitmap.

So **every probe that stopped waiting** — the 250 ms `latch.await` timing out on a loaded device, or an interrupt of the `Dispatchers.IO` probe thread — armed a guaranteed `SIGABRT` of the entire app. A diagnostic documented to "NEVER destabilise the terminal" was killing the app, and it fired *more* readily the more loaded the device was.

## The fix

The callback firing is the only signal HWUI is done with `dest` (`Readback::copySurfaceInto` invokes it on every result, including errors), so **recycle if and only if the latch counted down**. The timeout/interrupt paths drop the reference instead: the in-flight `CopyRequest` holds its own, and the 1 KB 16×16 `ARGB_8888` sample is freed by `NativeAllocationRegistry` (minSdk 26) once HWUI is truly finished. A deferred 1 KB free is not worth a process abort.

## Why it reached `main`

**#1443 shipped with zero on-device coverage of the real `PixelCopy` path** — every existing test injects a fake sampler. The one path that could abort the process was the one never exercised on a device. The new instrumented test drives the real path and forces the abandon-while-in-flight case deterministically (a 0 ms wait always leaves the request queued).

## Evidence

The maintainer's original `tombstone_16` was still on `emulator-5556` and was recovered. Reviewer-produced, this run:

- **Red:** neutralising only the recycle condition in place → `Process crashed`, `F HWUI: Error, cannot access an invalid/free'd bitmap here!`, **Fatal signal 6 (SIGABRT)** on `RenderThread`, fresh `tombstone_18`.
- **Green:** restored → **7/7 consecutive**, each with its own verified XML (`tests="1" failures="0"`, load-bearing test named, fresher than run start).
- **Symptom gone, not just an assertion passing:** `ls /data/tombstones` shows exactly one entry for the day — the reviewer's own red run. Zero from all seven greens.
- **Controlled attribution:** the red tombstone's frames `#00`–`#12` are byte-identical to the maintainer's `tombstone_16`.
- Emulator confirmed `-no-window -gpu swiftshader_indirect` — the exact CI renderer.
- **No crash-for-leak trade:** timeout, interrupt and request-throw paths all checked; sample is rate-bounded to one per 2 s.
- **Class coverage (G2):** exactly one production `PixelCopy` site repo-wide; the three other `src/main` `recycle()` calls are synchronous; all 226 test-source `recycle()` calls scanned for an async handoff — zero hits.
- Reviewer's full JVM gate, executed directly: `BUILD SUCCESSFUL in 18m 46s`, `603 actionable tasks: 603 executed`, no cache markers on any test task, **12118 executed / 0 failed** asserted from XML.

## Orchestrator integration gate (this exact tree)

All four files md5-verified byte-identical to the reviewed worktree. `:shared:core-terminal:testDebugUnitTest` + `:testReleaseUnitTest` with `--rerun-tasks`: **517 executed / 0 failures each**, 53/53 XML newer than the run marker, no cache marker on either task line. `:shared:core-terminal:compileDebugAndroidTestKotlin` forced with `--rerun-tasks --no-build-cache` (the source set CI's `Unit` job does *not* compile) — clean.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2003#issuecomment-5198270445