### PR TITLE
test(proof): decide tmux client cleanup by identity, not total count (#1994)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
@@ -37,11 +37,18 @@ import com.pocketshell.app.tmux.TMUX_SESSION_PAGER_PAGE_TAG_PREFIX
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
 import com.pocketshell.app.tmux.TmuxSessionLatencyTelemetry
+import com.pocketshell.app.proof.signals.SyntheticFocusOwnerHarness
+import com.pocketshell.app.proof.signals.activityWindowFocused
+import com.pocketshell.app.proof.signals.describeActiveWindow
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.testsupport.FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE
+import com.pocketshell.testsupport.MarkerBandCaptureVerdict
+import com.pocketshell.testsupport.evaluateMarkerBandCapture
+import com.pocketshell.testsupport.requiredMarkerSpanPx
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -145,6 +152,16 @@ class SessionSwipeSwitchE2eTest {
      */
     private val pickerReadyWaitMs: Long =
         if (TerminalTestTimeouts.isRunningOnCi()) 120_000L else 45_000L
+
+    /**
+     * Issue #1994: how long the device surface is given to actually PAINT a band
+     * the emulator model already holds. The old capture allowed 150 ms with no
+     * retry, which is not a paint barrier at all — see [captureViewport]. The
+     * pump exits the instant the band appears, so a healthy device pays one
+     * settle; only a genuinely unpainted surface spends the whole budget.
+     */
+    private val capturePaintBudgetMs: Long =
+        if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 10_000L
 
     @After
     fun closeLaunchedActivity() {
@@ -445,6 +462,203 @@ class SessionSwipeSwitchE2eTest {
 
         Unit
     } }
+
+    /**
+     * Issue #1994, arm 1 — a foreign window over the viewport must be NAMED, not
+     * mistaken for the terminal failing to paint.
+     *
+     * **This arm is CLASS COVERAGE, not the reproduction of the `1ddeadb3`
+     * red.** Round 2 re-derived that failure from the run's own per-class
+     * logcat: the app was RESUMED and in front at capture time, with no ANR,
+     * dialog or foreign-window signature — see the [captureViewport] KDoc for
+     * the timestamps. The hosted red was the single-shot 150 ms non-composition
+     * barrier, and the bounded pump fixes it.
+     *
+     * What this arm does cover is the neighbouring capture world the same shard
+     * demonstrably contains: five OTHER classes on it failed with
+     * `active_window_pkg=android active_window_class=android.widget.FrameLayout`,
+     * i.e. a framework window owning the display. A window over the app does not
+     * merely dim the frame — the captured pixels are not the app's pixels at
+     * all, so a missing band there says nothing about what PocketShell painted,
+     * and the oracle must say so rather than blame the terminal.
+     *
+     * The state is injected SYNTHETICALLY (D33: the environment cannot be asked
+     * to raise a framework error dialog on demand inside a sibling-shared AVD)
+     * using the reviewed #1985 [SyntheticFocusOwnerHarness], expanded to actually
+     * cover the display so the injection is deterministic rather than relying on
+     * the dialog's dim amount.
+     *
+     * RED on base: the capture throws "device-visible viewport did not paint the
+     * complete 'A237-READY' cell band". GREEN with the fix: it throws the
+     * foreign-owner attribution instead. Note it still THROWS — attribution is
+     * never amnesty (pinned on the JVM by `MarkerBandCaptureVerdictTest`).
+     */
+    @Test
+    fun foreignWindowOverTheViewportIsNamedInsteadOfBlamingTheTerminalPaint() { runBlocking {
+        val key = attachToSessionAForCaptureProof()
+
+        // The injected owner is a Dialog hosted by the instrumented app, so the
+        // reading it produces is `active_window_pkg=<our own package>`, not a
+        // genuinely third-party package like the hosted `android` window. What
+        // is under test is the ORACLE's rule — "the app's Activity window did not
+        // own the display, so these are not the app's pixels" — which reads
+        // `activityWindowFocused`, not the package string; the package is only
+        // carried into the message so a red shard says WHO owned the display.
+        // A real cross-package owner cannot be commanded on demand inside a
+        // sibling-shared AVD (D33: inject synthetically, hard-fail otherwise).
+        val harness = SyntheticFocusOwnerHarness(
+            scenario = requireNotNull(launchedActivity),
+            label = "issue-1994 synthetic focus owner",
+        )
+        var captureFailure: Throwable? = null
+        harness.withOwner { dialog ->
+            // Cover the whole display so the injected state is "the captured
+            // frame is not the app's", deterministically, on every device
+            // density — not "the dialog's default dim happened to be enough".
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                dialog.window?.setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                dialog.window?.decorView?.setBackgroundColor(android.graphics.Color.BLACK)
+            }
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            SystemClock.sleep(500)
+            captureFailure = runCatching {
+                captureViewport("issue1994-01-foreign-window-over-viewport", A_MARKER)
+            }.exceptionOrNull()
+        }
+
+        val failure = requireNotNull(captureFailure) {
+            "expected the viewport capture to FAIL while a foreign window owned the " +
+                "display — a green there would mean the oracle accepted a frame that " +
+                "was never the app's"
+        }
+        val message = failure.message.orEmpty()
+        assertTrue(
+            "a capture taken while a foreign window owned the display must name that " +
+                "owner, not blame the terminal's paint; got:\n$message",
+            message.contains(FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE),
+        )
+        assertTrue(
+            "the foreign-owner attribution must carry the active window reading so a " +
+                "red shard says WHO owned the display; got:\n$message",
+            message.contains("active_window_pkg="),
+        )
+        // Prove the app really is healthy afterwards: the same capture that just
+        // failed must pass once the foreign window is gone. Without this the test
+        // could pass against a genuinely broken terminal.
+        captureViewport("issue1994-02-after-foreign-window-dismissed", A_MARKER)
+        writeText(
+            "issue1994-foreign-window-attribution.txt",
+            "captured_failure_message=$message\n",
+        )
+        Unit
+    } }
+
+    /**
+     * Issue #1994, arm 2 — a device surface that has not painted the band YET
+     * must be given a bounded second look, not judged on one 150 ms shot.
+     *
+     * `waitForIdleSync()` is a main-thread barrier, not a composition barrier:
+     * it returns before SurfaceFlinger has necessarily put the frame on the
+     * display. On a hosted swiftshader emulator under a 300-test shard the model
+     * can lead the painted surface by well over the old flat 150 ms, which is
+     * how a correct app produced `matchingPixels=0`.
+     *
+     * The lag is injected SYNTHETICALLY as an opaque, NON-focusable overlay in
+     * the activity's own window (so window focus stays with the app and this arm
+     * cannot pass through arm 1's attribution path), removed after
+     * [SYNTHETIC_OCCLUSION_MS] — comfortably longer than the old single shot and
+     * far inside the bounded budget.
+     *
+     * RED on base: the single-shot capture fails with the paint message. GREEN
+     * with the fix: the pump keeps looking and captures the real frame.
+     */
+    @Test
+    fun transientlyOccludedSurfaceIsCapturedOnceItRepaints() { runBlocking {
+        attachToSessionAForCaptureProof()
+        val scenario = requireNotNull(launchedActivity)
+
+        var overlay: View? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            scenario.onActivity { activity ->
+                val cover = View(activity).apply {
+                    setBackgroundColor(android.graphics.Color.BLACK)
+                    isFocusable = false
+                    isFocusableInTouchMode = false
+                }
+                activity.addContentView(
+                    cover,
+                    ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    ),
+                )
+                overlay = cover
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertTrue(
+            "the synthetic occlusion must NOT steal window focus — otherwise this arm " +
+                "would exercise the foreign-owner attribution instead of the paint pump",
+            activityWindowFocused(scenario),
+        )
+
+        val remover = Thread {
+            SystemClock.sleep(SYNTHETIC_OCCLUSION_MS)
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                val cover = overlay ?: return@runOnMainSync
+                (cover.parent as? ViewGroup)?.removeView(cover)
+            }
+        }
+        remover.start()
+        try {
+            // Load-bearing: this must SUCCEED. On base it is evaluated once,
+            // 150 ms in, while the cover is still up, and hard-fails.
+            captureViewport("issue1994-03-transient-occlusion-repaint", A_MARKER)
+        } finally {
+            remover.join(SYNTHETIC_OCCLUSION_MS * 3)
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                val cover = overlay
+                if (cover != null) (cover.parent as? ViewGroup)?.removeView(cover)
+            }
+        }
+        Unit
+    } }
+
+    /**
+     * Shared prologue for the #1994 capture-attribution arms: seed SESSION_A,
+     * attach through the real host-row + picker journey, and wait until the
+     * emulator MODEL holds the marker. Everything after that is about what the
+     * DEVICE painted.
+     */
+    private suspend fun attachToSessionAForCaptureProof(): String {
+        val key = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedTmuxSessions(key)
+        val hostRowTag = seedDockerHost(key, "Issue1994 Capture")
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(SESSION_A, timeoutMs = pickerWaitMs)
+        compose.onNodeWithText(SESSION_A).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached()
+        selectTerminalTabForVisibleCapture()
+        waitForVisibleTerminal("session A ready") { transcript ->
+            TerminalTextMatcher.containsWrapTolerant(
+                transcript,
+                A_MARKER,
+                terminalCols = terminalGridSize().columns,
+            )
+        }
+        return key
+    }
 
     /**
      * Open the session pager with a swipe-DOWN gesture, then swipe it one page
@@ -847,61 +1061,176 @@ class SessionSwipeSwitchE2eTest {
         return grid ?: GridSize(columns = 80, rows = 24)
     }
 
+    /**
+     * Issue #1994 — the capture is a BOUNDED PUMP, not a single shot.
+     *
+     * The nightly (run 30961154855, shard 2, exact main `1ddeadb3`) failed the
+     * very FIRST capture with `magenta span=0 px … matchingPixels=0` — zero
+     * matching pixels, before any switch, on a device whose emulator model
+     * already held the marker.
+     *
+     * **Attribution, corrected in round 2 from that run's own per-class
+     * logcat.** The bundle's
+     * `logcat-…SessionSwipeSwitchE2eTest-swipeDownPagerSwitchesSessionAndActivatesCachedRuntimeOnReturn.txt`
+     * shows the app RESUMED and in front at capture time:
+     *
+     * ```
+     * 00:29:10.480 LifecycleMonitor: MainActivity … RESUMED
+     * 00:29:10.772 VRI[NexusLauncherActivity]: visibilityChanged … newVisibility=false
+     * 00:29:14.052 tmux-first-pane-output … bytes=8 elapsedMs=853
+     * 00:29:14.551 ISSUE237_VIEWPORT …issue237-01-attached-session-a-viewport.png  <-- the capture
+     * 00:29:15.390 VRI[MainActivity]: visibilityChanged … newVisibility=false      <-- teardown only
+     * ```
+     *
+     * No ANR, no dialog, no foreign-window signature anywhere in that file, and
+     * the shard's five `active_window_pkg=android` failures are at 00:04:44 and
+     * 00:31:39–00:38:29 — nowhere near this capture. **A foreign window did NOT
+     * own the display here.** The cause is the capture itself: it fired ~0.5 s
+     * after the first 8 bytes of pane output, judged ONCE, after
+     * `waitForIdleSync()` + a flat 150 ms sleep. That is a main-thread barrier,
+     * not a composition/SurfaceFlinger barrier — under hosted swiftshader load a
+     * late-but-correct paint is reported as a paint failure with no second look.
+     *
+     * The bounded pump is therefore the fix for THIS failure. The foreign-window
+     * arm below is CLASS COVERAGE for the neighbouring capture world (a dim
+     * scrim wipes the exact magenta match to zero while the band is still on the
+     * screen), not the reproduction of the `1ddeadb3` red.
+     *
+     * So the capture now:
+     *
+     *  1. re-reads the geometry, re-takes the screenshot and re-runs the pixel
+     *     oracle until it is satisfied or a CI-scaled deadline elapses (the
+     *     pump's exit condition IS the load-bearing assertion — the AGENTS.md
+     *     Shape-B bounded-pump rule); and
+     *  2. attributes a still-missing band: if the app window did not own the
+     *     display, the failure names that foreign owner
+     *     ([FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE]) rather than blaming the
+     *     terminal for a frame that was never the app's.
+     *
+     * Attribution is NEVER amnesty: a missing band fails in both worlds (pinned
+     * on the JVM by `MarkerBandCaptureVerdictTest`).
+     */
     private fun captureViewport(name: String, expectedMarker: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
-        instrumentation.waitForIdleSync()
-        SystemClock.sleep(150)
+        val startedAt = SystemClock.elapsedRealtime()
+        val deadline = startedAt + capturePaintBudgetMs
+        var attempts = 0
+        var lastVerdict: MarkerBandCaptureVerdict? = null
+        val attemptTrail = StringBuilder()
 
-        var viewportLeft = 0
-        var viewportTop = 0
-        var viewportWidth = 0
-        var viewportHeight = 0
-        var fontWidthPx = 0f
-        launchedActivity?.onActivity { activity ->
-            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
-            val location = IntArray(2)
-            view.getLocationOnScreen(location)
-            viewportLeft = location[0]
-            viewportTop = location[1]
-            viewportWidth = view.width
-            viewportHeight = view.height
-            fontWidthPx = view.mRenderer.fontWidth
+        while (true) {
+            instrumentation.waitForIdleSync()
+            SystemClock.sleep(CAPTURE_SETTLE_MS)
+            attempts++
+
+            var viewportLeft = 0
+            var viewportTop = 0
+            var viewportWidth = 0
+            var viewportHeight = 0
+            var fontWidthPx = 0f
+            launchedActivity?.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+                val location = IntArray(2)
+                view.getLocationOnScreen(location)
+                viewportLeft = location[0]
+                viewportTop = location[1]
+                viewportWidth = view.width
+                viewportHeight = view.height
+                fontWidthPx = view.mRenderer.fontWidth
+            }
+            val screen = instrumentation.uiAutomation.takeScreenshot()
+            val left = viewportLeft.coerceIn(0, screen.width)
+            val top = viewportTop.coerceIn(0, screen.height)
+            val width = viewportWidth.coerceAtMost(screen.width - left)
+            val height = viewportHeight.coerceAtMost(screen.height - top)
+            check(width > 0 && height > 0) {
+                "invalid terminal viewport crop left=$left top=$top width=$width height=$height " +
+                    "screen=${screen.width}x${screen.height}"
+            }
+            // Crop the pixels the emulator actually displayed. Drawing
+            // TerminalView into a fresh off-screen bitmap is not authoritative
+            // because its dirty renderer cache describes the already-painted
+            // device surface and can intentionally skip unchanged cells,
+            // producing a partial evidence image.
+            val bitmap = Bitmap.createBitmap(screen, left, top, width, height)
+            screen.recycle()
+
+            val band = measureMarkerBand(bitmap)
+            val bandComplete = fontWidthPx > 0f &&
+                band.spanPx >= requiredMarkerSpanPx(expectedMarker, fontWidthPx)
+            val outOfBudget = SystemClock.elapsedRealtime() >= deadline
+            // The window-owner diagnosis costs a full accessibility-tree fetch,
+            // so it is computed ONLY on the terminal failure path (the same
+            // laziness rule WindowFocusSignals documents). The per-attempt read
+            // is the cheap `hasWindowFocus()` one.
+            val focused = bandComplete || activityWindowFocused(requireNotNull(launchedActivity))
+            val focusDiagnosis = when {
+                focused -> "app_window_focused=true"
+                bandComplete || !outOfBudget -> "app_window_focused=false"
+                else -> "app_window_focused=false ${describeActiveWindow()}"
+            }
+            val verdict = evaluateMarkerBandCapture(
+                marker = expectedMarker,
+                artifactName = name,
+                paintedSpanPx = band.spanPx,
+                matchingPixels = band.matchingPixels,
+                fontWidthPx = fontWidthPx,
+                appWindowFocused = focused,
+                activeWindowDescription = focusDiagnosis,
+                attempts = attempts,
+                elapsedMs = SystemClock.elapsedRealtime() - startedAt,
+            )
+            lastVerdict = verdict
+            attemptTrail.append("attempt=").append(attempts)
+                .append(" elapsedMs=").append(SystemClock.elapsedRealtime() - startedAt)
+                .append(" outcome=").append(verdict.outcome)
+                .append(" span=").append(band.spanPx)
+                .append(" matching=").append(band.matchingPixels)
+                .append(' ').append(focusDiagnosis)
+                .append('\n')
+
+            if (verdict.painted || outOfBudget) {
+                // Persist the LAST observed frame either way: a failure must
+                // ship the evidence that produced it, not a stale earlier one.
+                writeBitmap("$name-viewport", bitmap)
+                var text = ""
+                launchedActivity?.onActivity { activity ->
+                    text = activity.window.decorView
+                        .findTerminalView()
+                        ?.currentSession
+                        ?.emulator
+                        ?.screen
+                        ?.visibleScreenText
+                        .orEmpty()
+                }
+                writeText("$name-visible-terminal.txt", text)
+                writeText(
+                    "$name-device-pixel-oracle.txt",
+                    "marker=$expectedMarker\nfont_width_px=$fontWidthPx\n" +
+                        "painted_magenta_span_px=${band.spanPx}\n" +
+                        "required_span_px=${requiredMarkerSpanPx(expectedMarker, fontWidthPx)}\n" +
+                        "matching_pixels=${band.matchingPixels}\n" +
+                        "capture_attempts=$attempts\n" +
+                        "capture_elapsed_ms=${SystemClock.elapsedRealtime() - startedAt}\n" +
+                        "outcome=${verdict.outcome}\n",
+                )
+                writeText("$name-capture-attempts.txt", attemptTrail.toString())
+                bitmap.recycle()
+                break
+            }
+            bitmap.recycle()
+            SystemClock.sleep(CAPTURE_RETRY_INTERVAL_MS)
         }
-        val screen = instrumentation.uiAutomation.takeScreenshot()
-        val left = viewportLeft.coerceIn(0, screen.width)
-        val top = viewportTop.coerceIn(0, screen.height)
-        val width = viewportWidth.coerceAtMost(screen.width - left)
-        val height = viewportHeight.coerceAtMost(screen.height - top)
-        check(width > 0 && height > 0) {
-            "invalid terminal viewport crop left=$left top=$top width=$width height=$height " +
-                "screen=${screen.width}x${screen.height}"
-        }
-        // Crop the pixels the emulator actually displayed. Drawing TerminalView
-        // into a fresh off-screen bitmap is not authoritative because its dirty
-        // renderer cache describes the already-painted device surface and can
-        // intentionally skip unchanged cells, producing a partial evidence image.
-        val bitmap = Bitmap.createBitmap(screen, left, top, width, height)
-        screen.recycle()
-        writeBitmap("$name-viewport", bitmap)
-        var text = ""
-        launchedActivity?.onActivity { activity ->
-            text = activity.window.decorView
-                .findTerminalView()
-                ?.currentSession
-                ?.emulator
-                ?.screen
-                ?.visibleScreenText
-                .orEmpty()
-        }
-        writeText("$name-visible-terminal.txt", text)
-        assertCompleteMarkerPainted(
-            bitmap = bitmap,
-            marker = expectedMarker,
-            fontWidthPx = fontWidthPx,
-            artifactName = name,
+
+        val verdict = requireNotNull(lastVerdict)
+        assertTrue(
+            "${verdict.message}\ncapture attempt trail:\n$attemptTrail",
+            verdict.painted,
         )
-        bitmap.recycle()
     }
+
+    /** Widest horizontal run of the seeded true-colour magenta cell background. */
+    private data class MarkerBand(val spanPx: Int, val matchingPixels: Int)
 
     /**
      * Device-pixel oracle for the complete marker. The seeded marker owns a
@@ -910,13 +1239,13 @@ class SessionSwipeSwitchE2eTest {
      * actually painted, independently of the emulator model text. A stale
      * #469 dirty clip that paints only `A2`/`B2` spans roughly two cells and
      * hard-fails against the full ten-cell marker width.
+     *
+     * The colour match stays EXACT (`r>=245, g<=10, b>=245`). Loosening it to
+     * survive a dim scrim would also accept a dimmed/obscured frame as proof the
+     * user can see the session — the opposite of what this oracle is for. The
+     * dim case is handled by attribution, not by tolerance.
      */
-    private fun assertCompleteMarkerPainted(
-        bitmap: Bitmap,
-        marker: String,
-        fontWidthPx: Float,
-        artifactName: String,
-    ) {
+    private fun measureMarkerBand(bitmap: Bitmap): MarkerBand {
         var minX = bitmap.width
         var maxX = -1
         var matchingPixels = 0
@@ -933,20 +1262,9 @@ class SessionSwipeSwitchE2eTest {
                 }
             }
         }
-        val paintedSpanPx = if (maxX >= minX) maxX - minX + 1 else 0
-        val requiredSpanPx = (fontWidthPx * (marker.length - 1)).toInt()
-        writeText(
-            "$artifactName-device-pixel-oracle.txt",
-            "marker=$marker\nfont_width_px=$fontWidthPx\n" +
-                "painted_magenta_span_px=$paintedSpanPx\n" +
-                "required_span_px=$requiredSpanPx\nmatching_pixels=$matchingPixels\n",
-        )
-        assertTrue(
-            "device-visible viewport did not paint the complete '$marker' cell band for " +
-                "$artifactName: magenta span=$paintedSpanPx px, required>=$requiredSpanPx px, " +
-                "fontWidth=$fontWidthPx, matchingPixels=$matchingPixels. The emulator model " +
-                "may already contain the marker, but a partial actual surface is a failure.",
-            fontWidthPx > 0f && paintedSpanPx >= requiredSpanPx,
+        return MarkerBand(
+            spanPx = if (maxX >= minX) maxX - minX + 1 else 0,
+            matchingPixels = matchingPixels,
         )
     }
 
@@ -1075,5 +1393,20 @@ class SessionSwipeSwitchE2eTest {
         // picker-ready signal.
         const val LOADING_PLACEHOLDER_STATUS: String = "loading same-host sessions"
         const val READY_CURRENT_STATUS: String = "current"
+
+        // Issue #1994 capture-pump cadence. The settle is the old flat wait kept
+        // as the FIRST attempt's delay so a healthy device behaves exactly as
+        // before; the retry interval paces the additional looks.
+        const val CAPTURE_SETTLE_MS: Long = 150L
+        const val CAPTURE_RETRY_INTERVAL_MS: Long = 250L
+
+        /**
+         * Issue #1994: how long the synthetic occlusion injected by
+         * [transientlyOccludedSurfaceIsCapturedOnceItRepaints] stays up. It must
+         * comfortably exceed the old single-shot 150 ms window (so the base
+         * capture is deterministically red) while staying far inside the bounded
+         * capture budget (so the fixed capture is deterministically green).
+         */
+        const val SYNTHETIC_OCCLUSION_MS: Long = 3_000L
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
@@ -21,23 +21,34 @@ import com.pocketshell.app.BackgroundGraceTestOverride
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.portfwd.PortForwardingTestIsolationRule
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.testsupport.TMUX_CLIENT_OWNERSHIP_FORMAT
+import com.pocketshell.testsupport.TmuxClientRecord
+import com.pocketshell.testsupport.describeOwnedDetachFailure
+import com.pocketshell.testsupport.evaluateOwnedClientDetach
+import com.pocketshell.testsupport.parseTmuxClients
+import com.pocketshell.testsupport.resolveOwnedClientNames
 import com.termux.view.TerminalView
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.connection.channel.direct.PTYMode
 import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import org.junit.After
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
@@ -114,14 +125,31 @@ import java.nio.charset.StandardCharsets
 @RunWith(AndroidJUnit4::class)
 class TmuxDetachOnBackgroundE2eTest {
 
-    @get:Rule
     val compose = createEmptyComposeRule()
 
     // Issue #470 blocker #1: grant runtime permissions before the activity
     // launches so the system GrantPermissionsActivity never steals focus
     // from the Compose hierarchy ("No compose hierarchies found").
-    @get:Rule
     val grantPermissions = PreGrantPermissionsRule()
+
+    /**
+     * Issue #1994 (round 2), class coverage with
+     * [TmuxOrphanClientCleanupE2eTest]: this journey asserts the SAME
+     * background-detach contract against the SAME shared fixture session, so it
+     * is vulnerable to the SAME leaked always-on port-forward pin. A pin makes
+     * `App.dispatchGraceElapsedIfNeeded` SUPPRESS the bounded teardown (#1159
+     * Part 3), the client stays attached BY DESIGN, and the detach assertion
+     * reports a product regression that never happened. Isolated before the
+     * background transition; also an outer rule so this class cannot leak a pin
+     * onward.
+     */
+    private val forwardingIsolation = PortForwardingTestIsolationRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(forwardingIsolation)
+        .around(grantPermissions)
+        .around(compose)
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
     private val timings = mutableListOf<String>()
@@ -142,6 +170,15 @@ class TmuxDetachOnBackgroundE2eTest {
         waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         clearLogcat()
+
+        // Issue #1994: the clients already on this SHARED fixture session before
+        // the app attaches. tmux moves (never kills) a client whose session is
+        // killed, so on the nightly's ~300-class single-process shard a stray
+        // client migrates onto this session by itself; counting it as
+        // PocketShell's would report a detach regression that never happened.
+        // Everything below is attributed by client IDENTITY instead.
+        val foreignBaseline = listClientNames(key, SEEDED_SESSION)
+        Log.i(LOG_TAG, "foreign client baseline on $SEEDED_SESSION = $foreignBaseline")
 
         val hostRowTag = seedDockerHost(key)
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
@@ -170,23 +207,37 @@ class TmuxDetachOnBackgroundE2eTest {
         // post-detach poll at the bottom of the test — without this
         // loop the round-2 reviewer observed `got 0` racing the
         // server-side registration on swiftshader (issue #235, r2).
-        var attachedClientCount = -1
+        var ownedNames = emptySet<String>()
         var attachedRawSnapshot = ""
         val preBackgroundDeadline =
             SystemClock.elapsedRealtime() + PRE_BACKGROUND_CLIENT_WAIT_MS
         while (SystemClock.elapsedRealtime() < preBackgroundDeadline) {
-            val raw = listClientsRaw(key, SEEDED_SESSION)
-            attachedRawSnapshot = raw
-            val count = raw.lines().count { it.isNotBlank() }
-            attachedClientCount = count
-            if (count >= 1) break
+            val records = listClientRecords(key, SEEDED_SESSION)
+            attachedRawSnapshot = records.joinToString("\n") { it.describe() }
+            ownedNames = resolveOwnedClientNames(foreignBaseline, records)
+            if (ownedNames.isNotEmpty()) break
             SystemClock.sleep(100)
         }
-        Log.i(LOG_TAG, "attached-state clients on $SEEDED_SESSION = $attachedClientCount")
+        Log.i(LOG_TAG, "app-owned clients on $SEEDED_SESSION = $ownedNames")
         assertTrue(
-            "expected at least one tmux client (the app's -CC connection) before background within " +
-                "${PRE_BACKGROUND_CLIENT_WAIT_MS}ms, got $attachedClientCount; raw=`$attachedRawSnapshot`",
-            attachedClientCount >= 1,
+            "expected the app's OWN tmux -CC client on $SEEDED_SESSION before background within " +
+                "${PRE_BACKGROUND_CLIENT_WAIT_MS}ms; foreignBaseline=$foreignBaseline " +
+                "current=`$attachedRawSnapshot`",
+            ownedNames.isNotEmpty(),
+        )
+
+        // ---- (2a) Issue #1994 round 2: clear any always-on port-forward pin
+        // leaked into this process by an earlier class. While a forward pins the
+        // connection, `App.dispatchGraceElapsedIfNeeded` SUPPRESSES the bounded
+        // teardown (#1159 Part 3) and the `-CC` client stays attached by design —
+        // which the detach assertion below would report as a product regression.
+        val pinBeforePrelude = portForwardPinActive()
+        forwardingIsolation.hardStopAndAssertZero("#1994 pre-background forwarding-pin isolation")
+        recordTiming("forwarding_pin_active_before_prelude", if (pinBeforePrelude) 1L else 0L)
+        assertFalse(
+            "the pre-background isolation must leave NO port-forward pin active, otherwise " +
+                "the bounded teardown stays suppressed and the detach verdict is meaningless",
+            portForwardPinActive(),
         )
 
         // ---- (2) Background the app via `moveToState(CREATED)`. Use a short
@@ -211,11 +262,13 @@ class TmuxDetachOnBackgroundE2eTest {
         // so this cannot become a test that merely delays before asserting zero.
         waitForGraceStart(POST_GRACE_MS)
         val conservativeGraceDeadline = backgroundStart + POST_GRACE_MS
-        val withinGraceRawSnapshot = listClientsRaw(key, SEEDED_SESSION)
+        val withinGraceRecords = listClientRecords(key, SEEDED_SESSION)
+        val withinGraceRawSnapshot = withinGraceRecords.joinToString("\n") { it.describe() }
         val withinGraceObservedAt = SystemClock.elapsedRealtime()
-        val clientsInsideGrace = withinGraceRawSnapshot
-            .lines()
-            .count { it.isNotBlank() }
+        // Issue #1994: count the app's OWN clients, not every client on the
+        // shared session — a foreign one would satisfy `>= 1` while the app's
+        // runtime had already been torn down.
+        val clientsInsideGrace = withinGraceRecords.count { it.name in ownedNames }
         writeText(
             "issue235-02-within-grace-clients.txt",
             buildString {
@@ -244,27 +297,40 @@ class TmuxDetachOnBackgroundE2eTest {
         // ---- (3) Poll list-clients until the post-grace detach lands. tmux
         // removes the entry within a single round-trip once `detach-client` is
         // received. The budget covers the injected grace, teardown, and CI load.
-        var orphanCount = -1
+        var detachVerdict = evaluateOwnedClientDetach(foreignBaseline, ownedNames, emptyList())
         var orphanRawSnapshot = ""
         val deadline = SystemClock.elapsedRealtime() + DETACH_TIMEOUT_MS
         while (SystemClock.elapsedRealtime() < deadline) {
-            val raw = listClientsRaw(key, SEEDED_SESSION)
-            orphanRawSnapshot = raw
-            val count = raw.lines().count { it.isNotBlank() }
-            orphanCount = count
-            if (count == 0) break
+            val records = listClientRecords(key, SEEDED_SESSION)
+            orphanRawSnapshot = records.joinToString("\n") { it.describe() }
+            detachVerdict = evaluateOwnedClientDetach(foreignBaseline, ownedNames, records)
+            if (detachVerdict.detached) break
             SystemClock.sleep(100)
         }
         recordTiming(
             "background_to_detach_ms",
             SystemClock.elapsedRealtime() - backgroundStart,
         )
-        writeText("issue235-02-after-background-clients.txt", orphanRawSnapshot)
-        assertEquals(
-            "expected zero tmux clients on $SEEDED_SESSION after bounded background grace elapsed; " +
-                "raw=`$orphanRawSnapshot`",
-            0,
-            orphanCount,
+        val pinAtVerdict = portForwardPinActive()
+        writeText(
+            "issue235-02-after-background-clients.txt",
+            buildString {
+                appendLine("foreign_baseline=$foreignBaseline")
+                appendLine("app_owned=$ownedNames")
+                appendLine("forwarding_pin_active_before_prelude=$pinBeforePrelude")
+                appendLine("forwarding_pin_active_at_verdict=$pinAtVerdict")
+                appendLine("verdict=${detachVerdict.diagnosis()}")
+                append(orphanRawSnapshot)
+            },
+        )
+        assertTrue(
+            describeOwnedDetachFailure(
+                verdict = detachVerdict,
+                portForwardPinActive = pinAtVerdict,
+                sessionName = SEEDED_SESSION,
+                rawClients = orphanRawSnapshot,
+            ).orEmpty() + " foreign_baseline=$foreignBaseline app_owned=$ownedNames",
+            detachVerdict.detached,
         )
 
         // ---- (4) Attach as the "desktop" from a sidecar SSH client
@@ -422,7 +488,15 @@ class TmuxDetachOnBackgroundE2eTest {
         }
     }
 
-    private suspend fun listClientsRaw(key: String, sessionName: String): String {
+    /**
+     * Issue #1994: parseable client rows (name + control-mode + flags) so the
+     * detach acceptance can be decided by client IDENTITY rather than by a total
+     * count that cannot tell this journey's client from a stray one.
+     */
+    private suspend fun listClientRecords(
+        key: String,
+        sessionName: String,
+    ): List<TmuxClientRecord> {
         val result = SshConnection.connect(
             host = DEFAULT_HOST,
             port = DEFAULT_PORT,
@@ -433,12 +507,30 @@ class TmuxDetachOnBackgroundE2eTest {
         ).mapCatching { session ->
             session.use {
                 it.exec(
-                    "tmux list-clients -t ${shellQuote(sessionName)} 2>/dev/null || true",
+                    "tmux list-clients -t ${shellQuote(sessionName)} " +
+                        "-F ${shellQuote(TMUX_CLIENT_OWNERSHIP_FORMAT)} 2>/dev/null || true",
                 )
             }
         }
-        return result.getOrNull()?.stdout.orEmpty()
+        return parseTmuxClients(result.getOrNull()?.stdout.orEmpty())
     }
+
+    private suspend fun listClientNames(key: String, sessionName: String): Set<String> =
+        listClientRecords(key, sessionName).map { it.name }.toSet()
+
+    private fun forwardingController(): ForwardingController =
+        EntryPointAccessors.fromApplication(
+            InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+            TestAccessEntryPoint::class.java,
+        ).forwardingController()
+
+    /**
+     * The exact predicate `App.kt` uses for `holdWhilePinned` — true while a
+     * port-forward pins the connection always-on and the bounded-grace teardown
+     * is therefore SUPPRESSED (#1159 Part 3).
+     */
+    private fun portForwardPinActive(): Boolean =
+        forwardingController().flowOfActiveHostCount().value > 0
 
     /**
      * Issue #235: open a fresh plain-ssh shell, allocate a PTY of
@@ -541,7 +633,7 @@ class TmuxDetachOnBackgroundE2eTest {
     }
 
     /**
-     * Issue #235: same shape as [listClientsRaw] but explicitly asks
+     * Issue #235: same shape as [listClientRecords] but explicitly asks
      * for the `[WIDTHxHEIGHT]` rendering tmux uses in its default
      * `list-clients` format. We rely on the default format here
      * rather than `-F '#{client_width} #{client_height}'` because

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
@@ -20,19 +20,33 @@ import com.pocketshell.app.BackgroundGraceTestOverride
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.portfwd.PortForwardingTestIsolationRule
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.testsupport.GRACE_HELD_BY_PORT_FORWARD_PIN_SIGNATURE
+import com.pocketshell.testsupport.OwnedClientDetachVerdict
+import com.pocketshell.testsupport.TMUX_CLIENT_OWNERSHIP_FORMAT
+import com.pocketshell.testsupport.TmuxClientRecord
+import com.pocketshell.testsupport.describeOwnedDetachFailure
+import com.pocketshell.testsupport.evaluateOwnedClientDetach
+import com.pocketshell.testsupport.parseTmuxClients
+import com.pocketshell.testsupport.resolveOwnedClientNames
 import com.termux.view.TerminalView
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
@@ -62,12 +76,16 @@ import java.nio.charset.StandardCharsets
  *
  *  1. Attach to `claude-main` via the normal app journey
  *     (host picker -> session picker -> Attach).
- *  2. Verify the server has exactly one client attached (the app).
+ *  2. Identify the app's OWN client by identity — the client that appeared
+ *     between the pre-attach baseline and the live attach (issue #1994).
  *  3. Force the activity to DESTROYED while the instrumented process stays
  *     alive, then let a short injected background grace elapse.
- *  4. Poll `tmux list-clients -t claude-main` until the post-grace count
- *     drops to 0 (acceptance: it must reach 0 inside
- *     [ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS]).
+ *  4. Poll `tmux list-clients -t claude-main` until every APP-OWNED client is
+ *     gone and nothing new appeared (acceptance: inside
+ *     [ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS]). A client that was already on the
+ *     shared fixture session before this journey started is reported and
+ *     ignored: it is not PocketShell's orphan, and counting it as one is the
+ *     nightly red #1994 was reopened for.
  *  5. Open a fresh non-CC interactive `tmux attach -t claude-main`
  *     from a sidecar SSH session and type a unique marker. Verify the
  *     marker reaches the running pane — proving that input flows
@@ -89,22 +107,43 @@ import java.nio.charset.StandardCharsets
 @RunWith(AndroidJUnit4::class)
 class TmuxOrphanClientCleanupE2eTest {
 
-    @get:Rule
     val compose = createEmptyComposeRule()
 
     // Issue #470 blocker #1: grant runtime permissions before the activity
     // launches so the system GrantPermissionsActivity never steals focus
     // from the Compose hierarchy ("No compose hierarchies found").
-    @get:Rule
     val grantPermissions = PreGrantPermissionsRule()
 
+    /**
+     * Issue #1994 (round 2) — the port-forward pin owner.
+     *
+     * As an OUTER rule it guarantees this class never leaks an always-on pin
+     * into a later class. Its [PortForwardingTestIsolationRule.hardStopAndAssertZero]
+     * is also called MID-journey, right before the app close, so a pin leaked
+     * INTO this class by an earlier one cannot suppress the bounded teardown and
+     * masquerade as a PocketShell orphan — the mechanism that produced the
+     * hosted red on run 30961154855 shard 2.
+     */
+    private val forwardingIsolation = PortForwardingTestIsolationRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(forwardingIsolation)
+        .around(grantPermissions)
+        .around(compose)
+
     private var launchedActivity: ActivityScenario<MainActivity>? = null
+    private var pinnedForwardHostId: Long = -1L
     private val timings = mutableListOf<String>()
 
     @After
     fun closeLaunchedActivity() {
         launchedActivity?.close()
         launchedActivity = null
+        if (pinnedForwardHostId >= 0L) {
+            runCatching { forwardingController().unregisterActiveHost(pinnedForwardHostId) }
+            pinnedForwardHostId = -1L
+        }
         BackgroundGraceTestOverride.setForTest(null)
         runBlocking {
             runCatching { cleanupRemoteTmuxSession(readFixtureKey()) }
@@ -121,6 +160,17 @@ class TmuxOrphanClientCleanupE2eTest {
         // payload is irrelevant; the test is about CLIENT lifecycle, not
         // pane content).
         seedTmuxSession(key)
+
+        // Issue #1994: snapshot the clients that already sit on this session
+        // BEFORE the app attaches. tmux does not kill a client whose session is
+        // killed — it MOVES it to another session — so on the nightly's ~300-test
+        // single-process shard a stray client from an earlier class can land on
+        // the shared fixture session by itself. Everything after this baseline is
+        // attributed by client IDENTITY so a foreign client can never be read as
+        // PocketShell's orphan (and, just as importantly, so PocketShell's own
+        // orphan can never hide behind one).
+        val foreignBaseline = listClientNames(key, SEEDED_SESSION)
+        Log.i(LOG_TAG, "foreign client baseline on $SEEDED_SESSION = $foreignBaseline")
 
         val hostRowTag = seedDockerHost(key)
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
@@ -140,14 +190,39 @@ class TmuxOrphanClientCleanupE2eTest {
         recordTiming("attach_ms", SystemClock.elapsedRealtime() - attachStart)
         captureViewport("issue215-01-attached")
 
-        // ---- (2) Confirm there is exactly one client on the server now
-        // — the app's -CC client. If this assertion fails before we
-        // teardown, the rest of the test is meaningless.
-        val attachedClientCount = listClientsCount(key, SEEDED_SESSION)
-        Log.i(LOG_TAG, "attached-state clients on $SEEDED_SESSION = $attachedClientCount")
+        // ---- (2) Identify the app's OWN client(s): whatever appeared on the
+        // session between the pre-attach baseline and now. tmux registers the
+        // `-CC` client one control-mode round-trip after the local TerminalView
+        // binds, so this is polled rather than sampled once.
+        val ownedNames = awaitOwnedClientNames(key, SEEDED_SESSION, foreignBaseline)
+        Log.i(LOG_TAG, "app-owned clients on $SEEDED_SESSION = $ownedNames")
         assertTrue(
-            "expected at least one tmux client (the app's -CC connection) before teardown, got $attachedClientCount",
-            attachedClientCount >= 1,
+            "expected the app's own tmux -CC client to register on $SEEDED_SESSION within " +
+                "${OWNED_CLIENT_REGISTRATION_TIMEOUT_MS}ms; foreignBaseline=$foreignBaseline " +
+                "current=${listClientRecords(key, SEEDED_SESSION)}",
+            ownedNames.isNotEmpty(),
+        )
+
+        // ---- (3a) Issue #1994 round 2 — HARD-ISOLATE any always-on port-forward
+        // pin before the close. `App.dispatchGraceElapsedIfNeeded` SUPPRESSES the
+        // bounded teardown while `forwardingController.flowOfActiveHostCount() > 0`
+        // (#1159 Part 3, the D21 carve-out), so a pin leaked into this process by
+        // an earlier class makes the app hold its `-CC` client BY DESIGN — and the
+        // old total-count oracle reported that as `expected:<0> but was:<1>`,
+        // pointing straight at the product. This is exactly what happened on
+        // nightly run 30961154855 shard 2 (`PsAppBgGrace:
+        // grace-window-held-by-port-forward (always-on)` at 00:30:42.881, 11
+        // classes after the forwarding tests). Isolating here removes the
+        // precondition instead of tolerating it.
+        val pinBeforePrelude = portForwardPinActive()
+        forwardingIsolation.hardStopAndAssertZero("#1994 pre-close forwarding-pin isolation")
+        val pinAfterPrelude = portForwardPinActive()
+        recordTiming("forwarding_pin_active_before_prelude", if (pinBeforePrelude) 1L else 0L)
+        recordTiming("forwarding_pin_active_after_prelude", if (pinAfterPrelude) 1L else 0L)
+        assertFalse(
+            "the pre-close isolation must leave NO port-forward pin active, otherwise the " +
+                "bounded teardown stays suppressed and any orphan verdict below is meaningless",
+            pinAfterPrelude,
         )
 
         // ---- (3) Force the activity to DESTROYED. ActivityScenario keeps the
@@ -168,31 +243,45 @@ class TmuxOrphanClientCleanupE2eTest {
         launchedActivity?.close()
         launchedActivity = null
 
-        // ---- (4) Poll `tmux list-clients -t claude-main` until the
-        // client count drops to 0 after grace. A client before the deadline is
-        // owned, not orphaned; a client surviving the deadline is the actual
-        // orphan class this proof guards.
-        var orphanCount = -1
-        var orphanRawSnapshot = ""
-        val deadline = SystemClock.elapsedRealtime() + ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS
-        while (SystemClock.elapsedRealtime() < deadline) {
-            val raw = listClientsRaw(key, SEEDED_SESSION)
-            orphanRawSnapshot = raw
-            val count = raw.lines().count { it.isNotBlank() }
-            orphanCount = count
-            if (count == 0) break
-            SystemClock.sleep(100)
-        }
+        // ---- (4) Poll until the clients THIS journey created are gone. A client
+        // before the deadline is owned, not orphaned; an APP-OWNED client
+        // surviving the deadline is the actual orphan class this proof guards,
+        // and so is a client that appeared afterwards (a post-teardown re-dial
+        // is a D21 violation). A foreign client that was already there is
+        // reported and ignored — see [evaluateOwnedClientDetach].
+        val convergence = awaitOwnedClientsDetached(
+            key = key,
+            sessionName = SEEDED_SESSION,
+            foreignBaseline = foreignBaseline,
+            ownedNames = ownedNames,
+        )
         recordTiming(
             "destroy_to_orphan_cleared_ms",
             SystemClock.elapsedRealtime() - destroyAt,
         )
-        writeText("issue215-02-after-destroy-clients.txt", orphanRawSnapshot)
-        assertEquals(
-            "expected zero tmux clients on $SEEDED_SESSION after app close grace elapsed; " +
-                "raw=`$orphanRawSnapshot`",
-            0,
-            orphanCount,
+        recordTiming("orphan_convergence_polls", convergence.polls.toLong())
+        val pinAtVerdict = portForwardPinActive()
+        writeText(
+            "issue215-02-after-destroy-clients.txt",
+            buildString {
+                appendLine("foreign_baseline=$foreignBaseline")
+                appendLine("app_owned=$ownedNames")
+                appendLine("polls=${convergence.polls}")
+                appendLine("forwarding_pin_active_before_prelude=$pinBeforePrelude")
+                appendLine("forwarding_pin_active_at_verdict=$pinAtVerdict")
+                appendLine("verdict=${convergence.verdict.diagnosis()}")
+                appendLine("--- raw tmux list-clients ---")
+                append(convergence.raw)
+            },
+        )
+        assertTrue(
+            describeOwnedDetachFailure(
+                verdict = convergence.verdict,
+                portForwardPinActive = pinAtVerdict,
+                sessionName = SEEDED_SESSION,
+                rawClients = convergence.raw,
+            ).orEmpty() + " foreign_baseline=$foreignBaseline app_owned=$ownedNames",
+            convergence.verdict.detached,
         )
 
         // ---- (5) The session itself must still be alive on the server.
@@ -231,7 +320,541 @@ class TmuxOrphanClientCleanupE2eTest {
         Unit
     } }
 
+    /**
+     * Issue #1994 — a foreign client on the SAME session must not be reported as
+     * PocketShell's orphan.
+     *
+     * Nightly run 30961154855 (shard 2, exact main `1ddeadb3`) failed this class
+     * with:
+     *
+     * ```
+     * expected zero tmux clients on claude-main after app close grace elapsed;
+     * raw=`/dev/pts/24: claude-main [62x xterm-256color] (attached,focused,control-mode,UTF-8)`
+     * expected:<0> but was:<1>
+     * ```
+     *
+     * A TOTAL count cannot tell whose client that is, and the nightly runs ~300
+     * connected classes in ONE process against ONE tmux server on the SHARED
+     * fixture session — several of them attach their own sidecar clients, and
+     * tmux MOVES (never kills) a client whose session is killed, so a stray
+     * client migrates onto this session on its own. The issue asks for exactly
+     * this discrimination: "distinguish a product detach regression from a
+     * leaked prior-test client".
+     *
+     * This test injects the contaminating state deterministically — a real
+     * second client on the very session under test, alive across the whole
+     * journey — and requires that:
+     *
+     *  * the proof still concludes PocketShell's own client detached; AND
+     *  * the naive total count at that same moment is NON-zero, i.e. the state
+     *    that produced the nightly red is genuinely present (without this the
+     *    test could pass vacuously against no contamination at all).
+     *
+     * The complementary direction — PocketShell's own client surviving is STILL
+     * a hard failure, and a client appearing after teardown is too — is pinned
+     * per-push on the JVM by `TmuxClientOwnershipTest`.
+     */
+    @Test
+    fun aForeignClientOnTheSameSessionIsNotReportedAsPocketShellsOrphan() { runBlocking {
+        val key = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedTmuxSession(key)
+
+        val foreign = attachForeignPlainClient(key, SEEDED_SESSION)
+        try {
+            val foreignBaseline = listClientNames(key, SEEDED_SESSION)
+            assertTrue(
+                "the injected foreign client must be registered on $SEEDED_SESSION before " +
+                    "the app attaches, otherwise this test proves nothing; baseline=$foreignBaseline",
+                foreignBaseline.isNotEmpty(),
+            )
+
+            val hostRowTag = seedDockerHost(key)
+            launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+            compose.waitUntil(timeoutMillis = 10_000) {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+            waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+            compose.onNodeWithText(SEEDED_SESSION).performClick()
+            compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+            waitForTerminalViewAttached()
+
+            val ownedNames = awaitOwnedClientNames(key, SEEDED_SESSION, foreignBaseline)
+            assertTrue(
+                "the app's own -CC client must be distinguishable from the injected " +
+                    "foreign client; foreignBaseline=$foreignBaseline " +
+                    "current=${listClientRecords(key, SEEDED_SESSION)}",
+                ownedNames.isNotEmpty(),
+            )
+            assertTrue(
+                "app-owned and foreign client sets must be disjoint; owned=$ownedNames " +
+                    "foreign=$foreignBaseline",
+                ownedNames.intersect(foreignBaseline).isEmpty(),
+            )
+
+            forwardingIsolation.hardStopAndAssertZero("#1994 foreign-client arm pin isolation")
+            BackgroundGraceTestOverride.setForTest(POST_CLOSE_GRACE_MS)
+            launchedActivity?.close()
+            launchedActivity = null
+
+            val convergence = awaitOwnedClientsDetached(
+                key = key,
+                sessionName = SEEDED_SESSION,
+                foreignBaseline = foreignBaseline,
+                ownedNames = ownedNames,
+            )
+            val pinAtVerdict = portForwardPinActive()
+            writeText(
+                "issue1994-foreign-client-contamination.txt",
+                buildString {
+                    appendLine("foreign_baseline=$foreignBaseline")
+                    appendLine("app_owned=$ownedNames")
+                    appendLine("polls=${convergence.polls}")
+                    appendLine("forwarding_pin_active_at_verdict=$pinAtVerdict")
+                    appendLine("verdict=${convergence.verdict.diagnosis()}")
+                    appendLine("naive_total_client_count=${convergence.records.size}")
+                    appendLine("--- raw tmux list-clients ---")
+                    append(convergence.raw)
+                },
+            )
+
+            assertTrue(
+                "PocketShell's own client must be gone even while a foreign PLAIN client " +
+                    "shares the session; " +
+                    describeOwnedDetachFailure(
+                        verdict = convergence.verdict,
+                        portForwardPinActive = pinAtVerdict,
+                        sessionName = SEEDED_SESSION,
+                        rawClients = convergence.raw,
+                    ).orEmpty(),
+                convergence.verdict.detached,
+            )
+            assertTrue(
+                "the injected sidecar must be a PLAIN client — a control-mode client is " +
+                    "never foreign on this fixture and must never be excused; " +
+                    "foreign_remaining=${convergence.verdict.foreignRemaining}",
+                convergence.verdict.foreignRemaining.none { it.controlMode },
+            )
+            // Hard proof the contaminating state was really present: the naive
+            // total-count oracle that produced the nightly red would have read a
+            // non-zero count at this exact moment.
+            assertTrue(
+                "the injected foreign client must still be attached at verdict time — " +
+                    "otherwise the contaminating state this test exists to reproduce was " +
+                    "never present; records=${convergence.records}",
+                convergence.verdict.foreignRemaining.isNotEmpty(),
+            )
+            assertTrue(
+                "a naive total tmux client count must be NON-zero here; that non-zero count " +
+                    "is exactly what the nightly reported as `expected:<0> but was:<1>`; " +
+                    "records=${convergence.records}",
+                convergence.records.isNotEmpty(),
+            )
+        } finally {
+            runCatching { foreign.shell.close() }
+            runCatching { foreign.client.disconnect() }
+        }
+        Unit
+    } }
+
+    /**
+     * Issue #1994 round 2 — the mechanism that ACTUALLY produced the hosted red.
+     *
+     * The nightly's own per-class logcat
+     * (`logcat-…TmuxOrphanClientCleanupE2eTest-closingTheAppDoesNotLeaveAnOrphanCcClient.txt`
+     * in run 30961154855 shard 2) shows:
+     *
+     * ```
+     * 00:30:40.441 Issue215OrphanClient: attached-state clients on claude-main = 1
+     * 00:30:41.381 PsAppBgGrace: grace-window-start millis=1500
+     * 00:30:41.812 LifecycleMonitor: MainActivity … DESTROYED
+     * 00:30:42.881 PsAppBgGrace: grace-window-held-by-port-forward (always-on)
+     * 00:30:58.331 failed: raw=`/dev/pts/24: claude-main [62x xterm-256color]
+     *                            (attached,focused,control-mode,UTF-8)`
+     * ```
+     *
+     * The TOTAL count at attach time was 1, so there was **no foreign client** to
+     * ignore, and the survivor is control-mode at 62 columns — exactly the app's
+     * own client geometry (`tmux-client-size-known … cols=62`). The cause is
+     * `App.kt`'s `dispatchGraceElapsedIfNeeded`: while a port-forward pins the
+     * connection always-on it SUPPRESSES the bounded teardown (#1159 Part 3), and
+     * on that shard the pin had leaked out of an earlier forwarding class in the
+     * shared instrumentation process. So the app was behaving exactly as
+     * specified; the ORACLE was reporting the wrong thing.
+     *
+     * This test drives that state deterministically on the real journey and
+     * proves all three halves of the fix:
+     *
+     *  1. **The leak is isolated.** A pin registered before the journey (standing
+     *     in for the earlier class) is cleared by the pre-close prelude, and the
+     *     unchanged journey converges — no misleading orphan red.
+     *  2. **A pin that is still active at verdict time is NAMED, not blamed on
+     *     the product** — and it is STILL a hard failure. Attribution is never
+     *     amnesty.
+     *  3. **The product itself is correct**: once the pin is released,
+     *     `BackgroundGraceController.onPinReleased` resumes the suppressed
+     *     teardown and the app's `-CC` client goes away.
+     *
+     * The pin is injected synthetically (`ForwardingController.registerActiveHost`
+     * on the singleton the app reads) because a leaked cross-class pin cannot be
+     * commanded on demand — the #780 model, hard-failing, never self-skipping. It
+     * is the SAME injection the reviewed `NotificationTapLivePinnedForegroundReseedJourneyE2eTest`
+     * uses to reach the #1159 always-on state.
+     */
+    @Test
+    fun aLeakedAlwaysOnForwardingPinIsIsolatedNamedAndReleasedInsteadOfBlamedOnTheProduct() {
+        runBlocking {
+            val key = readFixtureKey()
+            waitForSshFixtureReady(SshKey.Pem(key))
+            seedTmuxSession(key)
+            val foreignBaseline = listClientNames(key, SEEDED_SESSION)
+
+            val hostRowTag = seedDockerHost(key)
+            launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+            compose.waitUntil(timeoutMillis = 10_000) {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+            waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+            compose.onNodeWithText(SEEDED_SESSION).performClick()
+            compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+            waitForTerminalViewAttached()
+
+            val ownedNames = awaitOwnedClientNames(key, SEEDED_SESSION, foreignBaseline)
+            assertTrue(
+                "the app's own -CC client must register before the pin arms; " +
+                    "foreignBaseline=$foreignBaseline " +
+                    "current=${listClientRecords(key, SEEDED_SESSION)}",
+                ownedNames.isNotEmpty(),
+            )
+
+            // ---- (A) THE LEAK: a pin left behind by an EARLIER class. The
+            // controller is a process singleton, so who registered it is
+            // irrelevant — this is byte-for-byte the state shard 2 was in.
+            pinnedForwardHostId = LEAKED_PIN_HOST_ID
+            forwardingController().registerActiveHost(
+                hostId = LEAKED_PIN_HOST_ID,
+                hostName = "Issue1994 Leaked Pin",
+            )
+            assertTrue(
+                "the injected pin must make holdWhilePinned() true, otherwise this test " +
+                    "reproduces nothing",
+                portForwardPinActive(),
+            )
+
+            // ---- (B) The pre-close prelude must CLEAR it. Without this line the
+            // journey below reports the misleading `expected:<0> but was:<1>`.
+            forwardingIsolation.hardStopAndAssertZero("#1994 leaked-pin isolation")
+            pinnedForwardHostId = -1L
+            assertFalse(
+                "the prelude must clear the leaked pin so the bounded teardown can run",
+                portForwardPinActive(),
+            )
+
+            BackgroundGraceTestOverride.setForTest(POST_CLOSE_GRACE_MS)
+            launchedActivity?.close()
+            launchedActivity = null
+
+            val isolated = awaitOwnedClientsDetached(
+                key = key,
+                sessionName = SEEDED_SESSION,
+                foreignBaseline = foreignBaseline,
+                ownedNames = ownedNames,
+            )
+            assertTrue(
+                "with the leaked pin isolated the bounded teardown must run and the app's " +
+                    "own client must go; " +
+                    describeOwnedDetachFailure(
+                        verdict = isolated.verdict,
+                        portForwardPinActive = portForwardPinActive(),
+                        sessionName = SEEDED_SESSION,
+                        rawClients = isolated.raw,
+                    ).orEmpty(),
+                isolated.verdict.detached,
+            )
+
+            // ---- (C) Now the un-isolatable case: re-attach, arm the pin AFTER
+            // the prelude, and close. Production correctly HOLDS the client, so
+            // the journey must NAME the pin rather than report a product orphan —
+            // and the verdict must remain a failure.
+            val hostRowTag2 = seedDockerHost(key)
+            launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+            compose.waitUntil(timeoutMillis = 10_000) {
+                compose.onAllNodesWithTag(hostRowTag2, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            compose.onNodeWithTag(hostRowTag2, useUnmergedTree = true).performClick()
+            waitForText(SEEDED_SESSION, timeoutMs = 20_000)
+            compose.onNodeWithText(SEEDED_SESSION).performClick()
+            compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+            waitForTerminalViewAttached()
+
+            val pinnedBaseline = isolated.records.map { it.name }.toSet()
+            val pinnedOwned = awaitOwnedClientNames(key, SEEDED_SESSION, pinnedBaseline)
+            assertTrue(
+                "the app's own -CC client must re-register before the pinned arm; " +
+                    "baseline=$pinnedBaseline current=${listClientRecords(key, SEEDED_SESSION)}",
+                pinnedOwned.isNotEmpty(),
+            )
+
+            pinnedForwardHostId = LEAKED_PIN_HOST_ID
+            forwardingController().registerActiveHost(
+                hostId = LEAKED_PIN_HOST_ID,
+                hostName = "Issue1994 Held Pin",
+            )
+            BackgroundGraceTestOverride.setForTest(POST_CLOSE_GRACE_MS)
+            launchedActivity?.close()
+            launchedActivity = null
+
+            val held = awaitOwnedClientsDetached(
+                key = key,
+                sessionName = SEEDED_SESSION,
+                foreignBaseline = pinnedBaseline,
+                ownedNames = pinnedOwned,
+                timeoutMs = PIN_HELD_OBSERVATION_MS,
+            )
+            val pinActiveAtHeldVerdict = portForwardPinActive()
+            assertTrue(
+                "the pin must still be active at verdict time for this arm to mean anything",
+                pinActiveAtHeldVerdict,
+            )
+            assertFalse(
+                "#1159 Part 3: an active port-forward SUPPRESSES the bounded teardown, so the " +
+                    "app's -CC client is expected to survive here — if it detached, the " +
+                    "always-on carve-out itself regressed; ${held.verdict.diagnosis()}",
+                held.verdict.detached,
+            )
+            val heldFailure = describeOwnedDetachFailure(
+                verdict = held.verdict,
+                portForwardPinActive = pinActiveAtHeldVerdict,
+                sessionName = SEEDED_SESSION,
+                rawClients = held.raw,
+            )
+            assertNotNull("a non-detached verdict must produce a failure message", heldFailure)
+            assertTrue(
+                "the failure must NAME the port-forward pin as the cause instead of reporting " +
+                    "a plain PocketShell orphan — that mis-attribution is the nightly red this " +
+                    "issue was reopened for; got: $heldFailure",
+                heldFailure!!.contains(GRACE_HELD_BY_PORT_FORWARD_PIN_SIGNATURE),
+            )
+            assertFalse(
+                "with a pin active the message must not call this a genuine detach regression; " +
+                    "got: $heldFailure",
+                heldFailure.contains("genuine detach regression"),
+            )
+            // The naive total-count oracle would have read exactly the nightly's
+            // `expected:<0> but was:<1>` at this moment.
+            assertTrue(
+                "the contaminating state must be genuinely present: a naive total client " +
+                    "count here must be non-zero; records=${held.records}",
+                held.records.isNotEmpty(),
+            )
+
+            // ---- (D) The product half: releasing the pin resumes the suppressed
+            // teardown (BackgroundGraceController.onPinReleased) and the client
+            // goes away. Without this the "held" arm above could be hiding a real
+            // never-tears-down defect.
+            val releaseAt = SystemClock.elapsedRealtime()
+            forwardingController().unregisterActiveHost(LEAKED_PIN_HOST_ID)
+            pinnedForwardHostId = -1L
+            val released = awaitOwnedClientsDetached(
+                key = key,
+                sessionName = SEEDED_SESSION,
+                foreignBaseline = pinnedBaseline,
+                ownedNames = pinnedOwned,
+            )
+            recordTiming(
+                "pin_release_to_orphan_cleared_ms",
+                SystemClock.elapsedRealtime() - releaseAt,
+            )
+            writeText(
+                "issue1994-forwarding-pin-mechanism.txt",
+                buildString {
+                    appendLine("--- (B) leaked pin isolated before close ---")
+                    appendLine("owned=$ownedNames verdict=${isolated.verdict.diagnosis()}")
+                    appendLine("--- (C) pin active at verdict time ---")
+                    appendLine("owned=$pinnedOwned polls=${held.polls}")
+                    appendLine("pin_active_at_verdict=$pinActiveAtHeldVerdict")
+                    appendLine("naive_total_client_count=${held.records.size}")
+                    appendLine("verdict=${held.verdict.diagnosis()}")
+                    appendLine("failure=$heldFailure")
+                    appendLine("raw=${held.raw}")
+                    appendLine("--- (D) pin released, teardown resumes ---")
+                    appendLine("polls=${released.polls} verdict=${released.verdict.diagnosis()}")
+                    appendLine("raw=${released.raw}")
+                },
+            )
+            assertTrue(
+                "releasing the port-forward pin must resume the suppressed bounded teardown " +
+                    "(BackgroundGraceController.onPinReleased) and clear the app's own client; " +
+                    describeOwnedDetachFailure(
+                        verdict = released.verdict,
+                        portForwardPinActive = portForwardPinActive(),
+                        sessionName = SEEDED_SESSION,
+                        rawClients = released.raw,
+                    ).orEmpty(),
+                released.verdict.detached,
+            )
+            writeTimings("issue1994-forwarding-pin-timings.txt")
+            Unit
+        }
+    }
+
     // ---------------------------------------------------------------- Helpers
+
+    private fun forwardingController(): ForwardingController =
+        EntryPointAccessors.fromApplication(
+            InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+            TestAccessEntryPoint::class.java,
+        ).forwardingController()
+
+    /**
+     * The exact predicate `App.kt` uses for `holdWhilePinned` — true while a
+     * port-forward pins the connection always-on and the bounded-grace teardown
+     * is therefore SUPPRESSED (#1159 Part 3).
+     */
+    private fun portForwardPinActive(): Boolean =
+        forwardingController().flowOfActiveHostCount().value > 0
+
+    /** Result of the post-teardown convergence poll. */
+    private data class OwnedDetachConvergence(
+        val verdict: OwnedClientDetachVerdict,
+        val records: List<TmuxClientRecord>,
+        val raw: String,
+        val polls: Int,
+    )
+
+    /**
+     * Issue #1994: poll for the owned-client detach over ONE reused SSH session.
+     *
+     * The old loop called `SshConnection.connect(...)` on EVERY iteration, so a
+     * 15 s ceiling bought only a handful of looks once a hosted runner's connect
+     * cost rose — and the last look could land before the teardown had even been
+     * dispatched. One session makes the poll cheap enough that the ceiling is a
+     * real convergence budget rather than a handshake budget.
+     */
+    private suspend fun awaitOwnedClientsDetached(
+        key: String,
+        sessionName: String,
+        foreignBaseline: Set<String>,
+        ownedNames: Set<String>,
+        timeoutMs: Long = ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS,
+    ): OwnedDetachConvergence {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var polls = 0
+        var records: List<TmuxClientRecord> = emptyList()
+        var raw = ""
+        var verdict = evaluateOwnedClientDetach(foreignBaseline, ownedNames, records)
+        val connection = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+        connection.use { session ->
+            while (true) {
+                polls++
+                // ONE query per poll: the human-readable `raw` is rendered from
+                // the SAME rows the verdict is computed on. Two separate execs
+                // let the client list change between them, so a failure artifact
+                // could contradict its own verdict (observed in the #1994 red
+                // run: `raw` listed the app's client that the verdict had
+                // already, correctly, seen detach).
+                raw = session.exec(
+                    "tmux list-clients -t ${shellQuote(sessionName)} " +
+                        "-F ${shellQuote(TMUX_CLIENT_OWNERSHIP_FORMAT)} 2>/dev/null || true",
+                ).stdout
+                records = parseTmuxClients(raw)
+                verdict = evaluateOwnedClientDetach(foreignBaseline, ownedNames, records)
+                if (verdict.detached || SystemClock.elapsedRealtime() >= deadline) break
+                SystemClock.sleep(100)
+            }
+        }
+        return OwnedDetachConvergence(
+            verdict = verdict,
+            records = records,
+            raw = raw,
+            polls = polls,
+        )
+    }
+
+    /** Poll until the app's own client(s) show up on the session. */
+    private suspend fun awaitOwnedClientNames(
+        key: String,
+        sessionName: String,
+        foreignBaseline: Set<String>,
+    ): Set<String> {
+        val deadline = SystemClock.elapsedRealtime() + OWNED_CLIENT_REGISTRATION_TIMEOUT_MS
+        var owned = emptySet<String>()
+        while (SystemClock.elapsedRealtime() < deadline) {
+            owned = resolveOwnedClientNames(
+                foreignBaseline = foreignBaseline,
+                attachedSnapshot = listClientRecords(key, sessionName),
+            )
+            if (owned.isNotEmpty()) break
+            SystemClock.sleep(200)
+        }
+        return owned
+    }
+
+    private suspend fun listClientRecords(
+        key: String,
+        sessionName: String,
+    ): List<TmuxClientRecord> {
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use {
+                it.exec(
+                    "tmux list-clients -t ${shellQuote(sessionName)} " +
+                        "-F ${shellQuote(TMUX_CLIENT_OWNERSHIP_FORMAT)} 2>/dev/null || true",
+                )
+            }
+        }
+        return parseTmuxClients(result.getOrNull()?.stdout.orEmpty())
+    }
+
+    private suspend fun listClientNames(key: String, sessionName: String): Set<String> =
+        listClientRecords(key, sessionName).map { it.name }.toSet()
+
+    /**
+     * Attach a real, plain (non-`-CC`) tmux client over its own PTY and leave it
+     * attached — the deterministic stand-in for the stray client an earlier
+     * class leaves on the shared fixture session during a nightly shard. The
+     * caller owns closing the returned handle.
+     */
+    private suspend fun attachForeignPlainClient(key: String, sessionName: String): ShellHandle {
+        val handle = openShell(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+        )
+        val stdin = handle.shell.outputStream
+        stdin.write(
+            "tmux attach-session -t ${shellQuote(sessionName)}\n".toByteArray(StandardCharsets.UTF_8),
+        )
+        stdin.flush()
+        val deadline = SystemClock.elapsedRealtime() + OWNED_CLIENT_REGISTRATION_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (listClientRecords(key, sessionName).isNotEmpty()) break
+            SystemClock.sleep(200)
+        }
+        return handle
+    }
 
     private fun readFixtureKey(): String =
         InstrumentationRegistry.getInstrumentation()
@@ -347,36 +970,11 @@ class TmuxOrphanClientCleanupE2eTest {
         }
     }
 
-    /**
-     * Issue #215: return the number of clients currently attached to
-     * [sessionName] per `tmux list-clients -t <session>`. The command
-     * prints one line per attached client; with zero clients tmux
-     * prints nothing (exit 0), with a missing session tmux prints to
-     * stderr (exit non-zero, which we surface as -1 so the caller can
-     * tell apart "no clients" from "server-side error").
-     */
-    private suspend fun listClientsCount(key: String, sessionName: String): Int {
-        val raw = listClientsRaw(key, sessionName)
-        return raw.lines().count { it.isNotBlank() }
-    }
-
-    private suspend fun listClientsRaw(key: String, sessionName: String): String {
-        val result = SshConnection.connect(
-            host = DEFAULT_HOST,
-            port = DEFAULT_PORT,
-            user = DEFAULT_USER,
-            key = SshKey.Pem(key),
-            knownHosts = KnownHostsPolicy.AcceptAll,
-            timeoutMs = 15_000,
-        ).mapCatching { session ->
-            session.use {
-                it.exec(
-                    "tmux list-clients -t ${shellQuote(sessionName)} 2>/dev/null || true",
-                )
-            }
-        }
-        return result.getOrNull()?.stdout.orEmpty()
-    }
+    // Issue #1994 (D22 hard cut): the total-count helpers `listClientsCount` /
+    // `listClientsRaw` are DELETED. Counting clients is the oracle that could
+    // not tell PocketShell's orphan from a foreign sidecar or from a
+    // deliberately pin-held client; leaving them here would invite the next
+    // journey to reach for them again.
 
     private suspend fun listSessions(key: String): List<String> {
         val result = SshConnection.connect(
@@ -542,8 +1140,11 @@ class TmuxOrphanClientCleanupE2eTest {
         return file
     }
 
-    private fun writeTimings(): File {
-        val file = artifactFile("timings.txt")
+    // Each @Test gets a fresh instance, but they all share one artifact
+    // directory — so a per-test name is needed or the last writer silently wins
+    // and the earlier journey's latency evidence is lost.
+    private fun writeTimings(name: String = "timings.txt"): File {
+        val file = artifactFile(name)
         file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
         println("ISSUE215_TIMINGS ${file.absolutePath}")
         return file
@@ -596,8 +1197,47 @@ class TmuxOrphanClientCleanupE2eTest {
          * expires and the App-level owner detaches the parked runtime. The
          * budget includes ProcessLifecycleOwner's ON_STOP debounce, grace,
          * detach-client, and swiftshader/Docker contention.
+         *
+         * Issue #1994: this was a FLAT 15 s while every poll iteration opened a
+         * brand-new SSH connection (connect + auth + exec, ~1 s on an idle dev
+         * box and several seconds on a loaded hosted runner), so the ceiling was
+         * mostly a HANDSHAKE budget. Removing the per-iteration handshake (see
+         * [awaitOwnedClientsDetached], which now reuses ONE session) is the real
+         * fix and is what makes the ceiling a convergence budget.
+         *
+         * The ceiling itself is tied to the MEASURED convergence distribution
+         * rather than to making a slow state eventually pass: on an idle dev box
+         * `destroy_to_orphan_cleared_ms` measured 2786 ms and 6611 ms across the
+         * two contiguous green runs of this class, so 15 s local is ~2.3x the
+         * worst observation and 30 s CI is ~4.5x it, matching the CI scale every
+         * other budget in this file uses. It is deliberately NOT larger: a pin-
+         * held state (#1159 Part 3) never converges on its own, so a bigger
+         * ceiling could only launder that state into a slow pass. The pin is
+         * isolated before the close and named at verdict time instead.
+         * `destroy_to_orphan_cleared_ms` stays in `timings.txt` so a latency
+         * regression is visible rather than absorbed.
          */
-        const val ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS: Long = 15_000L
+        val ORPHAN_CLIENT_CLEANUP_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+
+        /** Budget for tmux to register the app's own `-CC` client server-side. */
+        val OWNED_CLIENT_REGISTRATION_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+
+        /**
+         * How long the pinned arm watches a DELIBERATELY non-converging state.
+         * A port-forward pin suppresses the teardown indefinitely, so this is an
+         * observation window, not a convergence budget — kept short so the arm
+         * does not spend the full cleanup ceiling proving a negative. It is
+         * comfortably longer than the worst measured healthy convergence
+         * (6611 ms), so a client that WOULD have detached has had its chance.
+         */
+        val PIN_HELD_OBSERVATION_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 15_000L else 10_000L
+
+        /** Synthetic host id for the injected always-on forwarding pin. */
+        const val LEAKED_PIN_HOST_ID: Long = 199_400L
+
         const val POST_CLOSE_GRACE_MS: Long = 1_500L
     }
 }

--- a/app/src/test/java/com/pocketshell/app/proof/MarkerBandCaptureVerdictTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/MarkerBandCaptureVerdictTest.kt
@@ -1,0 +1,151 @@
+package com.pocketshell.app.proof
+
+import com.pocketshell.testsupport.FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE
+import com.pocketshell.testsupport.MarkerBandCaptureOutcome
+import com.pocketshell.testsupport.evaluateMarkerBandCapture
+import com.pocketshell.testsupport.requiredMarkerSpanPx
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1994 — per-push pin for the device-pixel capture verdict.
+ *
+ * The nightly failure this guards reported `magenta span=0 px … matchingPixels=0`
+ * for the FIRST capture of `SessionSwipeSwitchE2eTest`, and named the terminal's
+ * paint as the cause. Two very different worlds produce zero magenta pixels, and
+ * only one of them is the terminal's fault. These tests pin which cause is named
+ * — and, more importantly, pin that a missing band is NEVER turned into a pass.
+ */
+class MarkerBandCaptureVerdictTest {
+
+    @Test
+    fun aCompleteBandIsPainted() {
+        val verdict = evaluate(paintedSpanPx = 170, matchingPixels = 4046, appWindowFocused = true)
+
+        assertEquals(MarkerBandCaptureOutcome.PAINTED, verdict.outcome)
+        assertTrue(verdict.painted)
+    }
+
+    @Test
+    fun aPartialBandIsNotPaintedEvenWithTheAppFocused() {
+        // The #469 dirty-clip class: only `A2` painted, ~2 cells wide.
+        val verdict = evaluate(paintedSpanPx = 34, matchingPixels = 800, appWindowFocused = true)
+
+        assertEquals(MarkerBandCaptureOutcome.NOT_PAINTED, verdict.outcome)
+        assertFalse(verdict.painted)
+    }
+
+    @Test
+    fun theExactNightlyObservationWithTheAppFocusedStaysARealPaintFailure() {
+        // span=0, matchingPixels=0, fontWidth=17.0 — run 30961154855 shard 2.
+        // With the app owning the display there is no excuse available.
+        val verdict = evaluate(paintedSpanPx = 0, matchingPixels = 0, appWindowFocused = true)
+
+        assertEquals(MarkerBandCaptureOutcome.NOT_PAINTED, verdict.outcome)
+        assertTrue(verdict.message.contains("did not paint the complete 'A237-READY'"))
+        assertFalse(verdict.message.contains(FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE))
+    }
+
+    @Test
+    fun theSameObservationUnderAForeignWindowNamesTheForeignOwnerInstead() {
+        val verdict = evaluate(
+            paintedSpanPx = 0,
+            matchingPixels = 0,
+            appWindowFocused = false,
+            activeWindowDescription =
+                "active_window_pkg=android active_window_class=android.widget.FrameLayout",
+        )
+
+        assertEquals(MarkerBandCaptureOutcome.FOREIGN_WINDOW_OWNS_DISPLAY, verdict.outcome)
+        assertFalse(verdict.painted)
+        assertTrue(verdict.message.contains(FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE))
+        assertTrue(verdict.message.contains("active_window_pkg=android"))
+    }
+
+    @Test
+    fun aForeignWindowNeverConvertsAMissingBandIntoAPass() {
+        // The whole point of naming the cause is diagnosis, not amnesty.
+        val verdict = evaluate(
+            paintedSpanPx = 0,
+            matchingPixels = 0,
+            appWindowFocused = false,
+            activeWindowDescription = "active_window_pkg=android",
+        )
+
+        assertFalse(verdict.painted)
+    }
+
+    @Test
+    fun aCompleteBandStaysPaintedEvenIfFocusWasLostAfterwards() {
+        // Pixels are the authority: if the band IS on the frame, a focus report
+        // must not manufacture a failure.
+        val verdict = evaluate(
+            paintedSpanPx = 170,
+            matchingPixels = 4046,
+            appWindowFocused = false,
+            activeWindowDescription = "active_window_pkg=android",
+        )
+
+        assertEquals(MarkerBandCaptureOutcome.PAINTED, verdict.outcome)
+    }
+
+    @Test
+    fun anUnreadTerminalRendererIsAFailureNotAPass() {
+        // fontWidth=0 makes requiredSpan 0; without the explicit guard a span of
+        // 0 would satisfy `0 >= 0` and the capture would pass having measured
+        // nothing at all.
+        val verdict = evaluate(
+            paintedSpanPx = 0,
+            matchingPixels = 0,
+            appWindowFocused = true,
+            fontWidthPx = 0f,
+        )
+
+        assertEquals(MarkerBandCaptureOutcome.NOT_PAINTED, verdict.outcome)
+    }
+
+    @Test
+    fun theRequiredSpanIsTheMarkerWidthMinusTheLastCell() {
+        // The span is measured between the first and last magenta pixel, so the
+        // trailing cell's own width is not part of it.
+        assertEquals(153, requiredMarkerSpanPx("A237-READY", 17.0f))
+        assertEquals(0, requiredMarkerSpanPx("", 17.0f))
+        assertEquals(0, requiredMarkerSpanPx("X", 17.0f))
+    }
+
+    @Test
+    fun theMessageCarriesTheAttemptTrailSoALatePaintIsDistinguishable() {
+        val verdict = evaluate(
+            paintedSpanPx = 0,
+            matchingPixels = 0,
+            appWindowFocused = true,
+            attempts = 41,
+            elapsedMs = 20_000L,
+        )
+
+        assertTrue(verdict.message.contains("attempts=41"))
+        assertTrue(verdict.message.contains("elapsedMs=20000"))
+    }
+
+    private fun evaluate(
+        paintedSpanPx: Int,
+        matchingPixels: Int,
+        appWindowFocused: Boolean,
+        activeWindowDescription: String = "app_window_focused=true",
+        fontWidthPx: Float = 17.0f,
+        attempts: Int = 1,
+        elapsedMs: Long = 150L,
+    ) = evaluateMarkerBandCapture(
+        marker = "A237-READY",
+        artifactName = "issue237-01-attached-session-a",
+        paintedSpanPx = paintedSpanPx,
+        matchingPixels = matchingPixels,
+        fontWidthPx = fontWidthPx,
+        appWindowFocused = appWindowFocused,
+        activeWindowDescription = activeWindowDescription,
+        attempts = attempts,
+        elapsedMs = elapsedMs,
+    )
+}

--- a/app/src/test/java/com/pocketshell/app/proof/TmuxClientOwnershipTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/TmuxClientOwnershipTest.kt
@@ -1,0 +1,358 @@
+package com.pocketshell.app.proof
+
+import com.pocketshell.testsupport.FOREIGN_TMUX_CLIENT_IGNORED_SIGNATURE
+import com.pocketshell.testsupport.GRACE_HELD_BY_PORT_FORWARD_PIN_SIGNATURE
+import com.pocketshell.testsupport.LEAKED_CONTROL_MODE_CLIENT_SIGNATURE
+import com.pocketshell.testsupport.TMUX_CLIENT_FIELD_SEPARATOR
+import com.pocketshell.testsupport.TMUX_CLIENT_OWNERSHIP_FORMAT
+import com.pocketshell.testsupport.UNEXPECTED_NEW_TMUX_CLIENT_SIGNATURE
+import com.pocketshell.testsupport.UNNAMED_TMUX_CLIENT
+import com.pocketshell.testsupport.describeOwnedDetachFailure
+import com.pocketshell.testsupport.evaluateOwnedClientDetach
+import com.pocketshell.testsupport.parseTmuxClients
+import com.pocketshell.testsupport.resolveOwnedClientNames
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1994 — per-push pin for the owned-vs-foreign tmux client decision.
+ *
+ * The nightly failure this guards is:
+ *
+ * ```
+ * expected zero tmux clients on claude-main after app close grace elapsed;
+ * raw=`/dev/pts/24: claude-main [62x xterm-256color] (attached,focused,control-mode,UTF-8)`
+ * expected:<0> but was:<1>
+ * ```
+ *
+ * A TOTAL count cannot say whether that client is PocketShell's orphan or a
+ * client some earlier test on the same 300-test shard left behind (tmux migrates
+ * a client to another session when its own session is killed, so a stray client
+ * lands on the shared fixture session by itself). These tests pin that the
+ * decision is made by client IDENTITY, and — critically — that it stays strict
+ * in the direction of blaming the product.
+ */
+class TmuxClientOwnershipTest {
+
+    private val sep = TMUX_CLIENT_FIELD_SEPARATOR
+
+    @Test
+    fun parsesTheOwnershipFormatIncludingControlModeAndFlags() {
+        val clients = parseTmuxClients(
+            "/dev/pts/24${sep}1${sep}attached,focused,control-mode,UTF-8\n" +
+                "/dev/pts/9${sep}0${sep}attached,UTF-8\n",
+        )
+
+        assertEquals(2, clients.size)
+        assertEquals("/dev/pts/24", clients[0].name)
+        assertTrue(clients[0].controlMode)
+        assertEquals("attached,focused,control-mode,UTF-8", clients[0].flags)
+        assertEquals("/dev/pts/9", clients[1].name)
+        assertFalse(clients[1].controlMode)
+    }
+
+    @Test
+    fun blankAndTrailingLinesAreNotCountedAsClients() {
+        // `tmux list-clients … || true` emits a trailing newline, and an empty
+        // server prints nothing. Counting those as clients is how a passing
+        // journey turns into a phantom orphan.
+        assertEquals(0, parseTmuxClients("").size)
+        assertEquals(0, parseTmuxClients("\n\n").size)
+        assertEquals(1, parseTmuxClients("/dev/pts/3${sep}1${sep}attached\n\n").size)
+    }
+
+    @Test
+    fun aRowThatDoesNotMatchTheFormatIsKeptRatherThanSilentlyDropped() {
+        // Dropping an unparsable row would convert a real orphan into a green.
+        val clients = parseTmuxClients("/dev/pts/24\n")
+
+        assertEquals(1, clients.size)
+        assertEquals("/dev/pts/24", clients[0].name)
+
+        val unnamed = parseTmuxClients("${sep}1${sep}attached,control-mode\n")
+        assertEquals(1, unnamed.size)
+        assertEquals(UNNAMED_TMUX_CLIENT, unnamed[0].name)
+        assertTrue(unnamed[0].controlMode)
+    }
+
+    @Test
+    fun controlModeIsRecognisedFromTheFlagListWhenTheBooleanFieldIsMissing() {
+        val clients = parseTmuxClients(
+            "/dev/pts/24$sep${sep}attached,focused,control-mode,UTF-8\n",
+        )
+
+        assertTrue(clients[0].controlMode)
+    }
+
+    @Test
+    fun theFieldSeparatorIsPrintableBecauseTmuxSanitisesControlCharacters() {
+        // The first cut of #1994 used a literal TAB. tmux prints list-clients
+        // output through its client message path, which replaces control
+        // characters with `_` (observed on the fixture's tmux 3.6b:
+        // `list-sessions -F '#{session_name}<TAB>X'` printed `fmtprobe2_X_$0`).
+        // The row then never splits, every field collapses into the client NAME,
+        // ownership matching silently matches nothing, and the proof degrades to
+        // nonsense while still looking structured. A printable separator is the
+        // fix, and this is the check that would have caught it.
+        assertTrue(
+            "the field separator must be printable ASCII; tmux replaces control " +
+                "characters with '_' and the row would never split",
+            TMUX_CLIENT_FIELD_SEPARATOR.isNotEmpty() &&
+                TMUX_CLIENT_FIELD_SEPARATOR.all { it.code in 0x20..0x7E },
+        )
+        assertFalse(
+            "the separator must not contain a comma — client_flags is comma-separated",
+            TMUX_CLIENT_FIELD_SEPARATOR.contains(','),
+        )
+        assertEquals(
+            "the format must carry exactly two separators (three fields)",
+            2,
+            TMUX_CLIENT_OWNERSHIP_FORMAT.split(TMUX_CLIENT_FIELD_SEPARATOR).size - 1,
+        )
+    }
+
+    @Test
+    fun aTmuxSanitisedRowDoesNotSilentlyProduceAMatchableClientName() {
+        // Exactly what the broken TAB separator produced on the device. It must
+        // not resolve to a real client name that could accidentally match a
+        // recorded baseline or owned entry.
+        val sanitised = parseTmuxClients("/dev/pts/1_0_attached,focused,UTF-8\n")
+
+        assertEquals(1, sanitised.size)
+        assertEquals("/dev/pts/1_0_attached,focused,UTF-8", sanitised[0].name)
+        assertFalse(
+            "a collapsed row must not be attributed to a real client name",
+            sanitised[0].name == "/dev/pts/1",
+        )
+    }
+
+    @Test
+    fun ownedNamesAreTheClientsThatAppearedAfterTheForeignBaseline() {
+        val owned = resolveOwnedClientNames(
+            foreignBaseline = setOf("/dev/pts/9"),
+            attachedSnapshot = parseTmuxClients(
+                "/dev/pts/9${sep}0${sep}attached\n" +
+                    "/dev/pts/24${sep}1${sep}attached,control-mode\n",
+            ),
+        )
+
+        assertEquals(setOf("/dev/pts/24"), owned)
+    }
+
+    @Test
+    fun theAppsOwnClientSurvivingIsStillAHardFailure() {
+        // The genuine #215 orphan regression must not become tolerable.
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = emptySet(),
+            ownedNames = setOf("/dev/pts/24"),
+            current = parseTmuxClients(
+                "/dev/pts/24${sep}1${sep}attached,focused,control-mode,UTF-8\n",
+            ),
+        )
+
+        assertFalse(verdict.detached)
+        assertEquals(1, verdict.ownedRemaining.size)
+        assertTrue(verdict.diagnosis().contains("/dev/pts/24"))
+    }
+
+    @Test
+    fun aForeignPlainClientLeftByAnEarlierTestDoesNotFailTheOwnedDetachProof() {
+        // Exactly one client remains on the session, but it is a PLAIN sidecar
+        // `tmux attach` this journey never created — the shape an earlier class
+        // leaves behind. Only a plain client may be ignored.
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = setOf("/dev/pts/24"),
+            ownedNames = setOf("/dev/pts/31"),
+            current = parseTmuxClients(
+                "/dev/pts/24${sep}0${sep}attached,focused,UTF-8\n",
+            ),
+        )
+
+        assertTrue(verdict.detached)
+        assertEquals(1, verdict.foreignRemaining.size)
+        assertTrue(verdict.diagnosis().contains(FOREIGN_TMUX_CLIENT_IGNORED_SIGNATURE))
+    }
+
+    @Test
+    fun aControlModeClientInTheBaselineIsNeverLaunderedIntoForeign() {
+        // #1994 round 2 — the laundering hole. On nightly shard 2 the surviving
+        // client was `[62x xterm-256color] (attached,focused,control-mode,UTF-8)`
+        // — the app's own `-CC` geometry. A baseline-only definition of "foreign"
+        // would file a `-CC` client leaked by an EARLIER class under "ignore" and
+        // pass, which is strictly worse than the total-count oracle it replaced.
+        // Nothing but PocketShell opens control mode on this fixture, so
+        // control-mode implies app-owned regardless of when it attached.
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = setOf("/dev/pts/24"),
+            ownedNames = setOf("/dev/pts/31"),
+            current = parseTmuxClients(
+                "/dev/pts/24${sep}1${sep}attached,focused,control-mode,UTF-8\n",
+            ),
+        )
+
+        assertFalse(
+            "a control-mode client present at baseline time is a leaked PocketShell " +
+                "client, not a foreign one — it must fail",
+            verdict.detached,
+        )
+        assertEquals(1, verdict.leakedControlRemaining.size)
+        assertTrue(verdict.foreignRemaining.isEmpty())
+        assertTrue(verdict.diagnosis().contains(LEAKED_CONTROL_MODE_CLIENT_SIGNATURE))
+        assertFalse(
+            "a leaked -CC client must not also be reported as ignored-foreign",
+            verdict.diagnosis().contains(FOREIGN_TMUX_CLIENT_IGNORED_SIGNATURE),
+        )
+    }
+
+    @Test
+    fun aLeakedControlClientAndAPlainForeignClientAreClassifiedSeparately() {
+        // Class coverage: both contaminations at once. The plain one is ignored,
+        // the control-mode one is fatal, and the diagnosis names both.
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = setOf("/dev/pts/9", "/dev/pts/24"),
+            ownedNames = setOf("/dev/pts/31"),
+            current = parseTmuxClients(
+                "/dev/pts/9${sep}0${sep}attached,UTF-8\n" +
+                    "/dev/pts/24${sep}1${sep}attached,control-mode,UTF-8\n",
+            ),
+        )
+
+        assertFalse(verdict.detached)
+        assertEquals(listOf("/dev/pts/24"), verdict.leakedControlRemaining.map { it.name })
+        assertEquals(listOf("/dev/pts/9"), verdict.foreignRemaining.map { it.name })
+        assertTrue(verdict.diagnosis().contains(LEAKED_CONTROL_MODE_CLIENT_SIGNATURE))
+        assertTrue(verdict.diagnosis().contains(FOREIGN_TMUX_CLIENT_IGNORED_SIGNATURE))
+    }
+
+    @Test
+    fun anActivePortForwardPinIsNamedAsTheCauseAndTheVerdictStaysAFailure() {
+        // The mechanism that actually produced the hosted red on run
+        // 30961154855 shard 2: `PsAppBgGrace: grace-window-held-by-port-forward
+        // (always-on)` fired at the grace deadline, so App.kt SUPPRESSED the
+        // bounded teardown and the app's own -CC client stayed attached by
+        // design. The oracle must name that cause instead of reporting a plain
+        // product orphan — and must STILL fail (attribution is never amnesty).
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = emptySet(),
+            ownedNames = setOf("/dev/pts/24"),
+            current = parseTmuxClients(
+                "/dev/pts/24${sep}1${sep}attached,focused,control-mode,UTF-8\n",
+            ),
+        )
+
+        assertFalse(
+            "a pin-held client is still a failure — naming the cause must never " +
+                "convert a surviving client into a pass",
+            verdict.detached,
+        )
+
+        val pinned = describeOwnedDetachFailure(
+            verdict = verdict,
+            portForwardPinActive = true,
+            sessionName = "claude-main",
+            rawClients = "/dev/pts/24: claude-main [62x xterm-256color] " +
+                "(attached,focused,control-mode,UTF-8)",
+        )
+        assertTrue(
+            "the failure must NAME the port-forward pin, not blame the product",
+            pinned!!.contains(GRACE_HELD_BY_PORT_FORWARD_PIN_SIGNATURE),
+        )
+        assertTrue(pinned.contains("port_forward_pin_active=true"))
+        assertFalse(
+            "with a pin active the message must not call this a genuine detach regression",
+            pinned.contains("genuine detach regression"),
+        )
+    }
+
+    @Test
+    fun withoutAPinTheSameSurvivingClientIsReportedAsAGenuineDetachRegression() {
+        // The other half of the discrimination the issue asks for: with no pin
+        // active there is nothing to excuse the surviving client, so the message
+        // must point at the product.
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = emptySet(),
+            ownedNames = setOf("/dev/pts/24"),
+            current = parseTmuxClients(
+                "/dev/pts/24${sep}1${sep}attached,focused,control-mode,UTF-8\n",
+            ),
+        )
+
+        val unpinned = describeOwnedDetachFailure(
+            verdict = verdict,
+            portForwardPinActive = false,
+            sessionName = "claude-main",
+            rawClients = "/dev/pts/24…",
+        )
+        assertTrue(unpinned!!.contains("genuine detach regression"))
+        assertTrue(unpinned.contains("port_forward_pin_active=false"))
+        assertFalse(unpinned.contains(GRACE_HELD_BY_PORT_FORWARD_PIN_SIGNATURE))
+    }
+
+    @Test
+    fun aCleanVerdictNeverProducesAFailureMessageEvenWhileAPinIsActive() {
+        // Guard against the inverse mistake: an active pin must not manufacture
+        // a red out of a journey whose clients really did detach.
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = setOf("/dev/pts/9"),
+            ownedNames = setOf("/dev/pts/24"),
+            current = parseTmuxClients("/dev/pts/9${sep}0${sep}attached\n"),
+        )
+
+        assertTrue(verdict.detached)
+        assertNull(
+            describeOwnedDetachFailure(
+                verdict = verdict,
+                portForwardPinActive = true,
+                sessionName = "claude-main",
+                rawClients = "…",
+            ),
+        )
+    }
+
+    @Test
+    fun aClientThatAppearedAfterTheAppAttachedIsAHardFailure() {
+        // A post-teardown re-dial is a D21 violation and must never be excused
+        // by "well, it is not the client we recorded at attach time".
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = setOf("/dev/pts/9"),
+            ownedNames = setOf("/dev/pts/24"),
+            current = parseTmuxClients("/dev/pts/77${sep}1${sep}attached,control-mode\n"),
+        )
+
+        assertFalse(verdict.detached)
+        assertEquals(1, verdict.unexpectedNew.size)
+        assertTrue(verdict.diagnosis().contains(UNEXPECTED_NEW_TMUX_CLIENT_SIGNATURE))
+    }
+
+    @Test
+    fun anEmptySessionIsDetachedAndSaysSoWithoutForeignNoise() {
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = setOf("/dev/pts/9"),
+            ownedNames = setOf("/dev/pts/24"),
+            current = parseTmuxClients(""),
+        )
+
+        assertTrue(verdict.detached)
+        assertFalse(verdict.diagnosis().contains(FOREIGN_TMUX_CLIENT_IGNORED_SIGNATURE))
+        assertFalse(verdict.diagnosis().contains(UNEXPECTED_NEW_TMUX_CLIENT_SIGNATURE))
+    }
+
+    @Test
+    fun aForeignClientAndTheAppsOwnClientTogetherStillFailOnTheOwnedOne() {
+        val verdict = evaluateOwnedClientDetach(
+            foreignBaseline = setOf("/dev/pts/9"),
+            ownedNames = setOf("/dev/pts/24"),
+            current = parseTmuxClients(
+                "/dev/pts/9${sep}0${sep}attached\n" +
+                    "/dev/pts/24${sep}1${sep}attached,control-mode\n",
+            ),
+        )
+
+        assertFalse(verdict.detached)
+        assertEquals(1, verdict.ownedRemaining.size)
+        assertEquals(1, verdict.foreignRemaining.size)
+    }
+}

--- a/shared/test-support/src/main/java/com/pocketshell/testsupport/MarkerBandCapture.kt
+++ b/shared/test-support/src/main/java/com/pocketshell/testsupport/MarkerBandCapture.kt
@@ -1,0 +1,147 @@
+package com.pocketshell.testsupport
+
+/**
+ * Issue #1994 — the pure DECISION behind "did the device actually paint the
+ * seeded marker band?".
+ *
+ * ## The failure this exists to stop misreporting
+ *
+ * `SessionSwipeSwitchE2eTest` proves the switched-to session's content is really
+ * on the device surface, not merely in the emulator's text model, by seeding a
+ * unique true-colour magenta cell background behind the marker and measuring the
+ * magenta span on the UIAutomation screenshot. On nightly run 30961154855
+ * (shard 2, exact main `1ddeadb3`) it reported:
+ *
+ * ```
+ * device-visible viewport did not paint the complete 'A237-READY' cell band …
+ * magenta span=0 px, required>=153 px, fontWidth=17.0, matchingPixels=0
+ * ```
+ *
+ * ZERO matching pixels, on the very FIRST capture — before any switch, so before
+ * any cached-runtime restore could be involved. The healthy run paints ~4046
+ * matching pixels, so "0" is not a partial paint: nothing magenta was on the
+ * captured frame at all. Two states produce exactly that, and the old oracle
+ * blamed the terminal for both:
+ *
+ *  1. **The frame had not reached the display yet.** The oracle took ONE
+ *     screenshot after `waitForIdleSync()` + a fixed 150 ms sleep. The main
+ *     thread being idle does not mean SurfaceFlinger has composited; under
+ *     hosted swiftshader load the model can legitimately lead the painted
+ *     surface by more than 150 ms. There is no retry, so a late-but-correct
+ *     paint is reported as a paint failure.
+ *  2. **A foreign window owned the display.** Any dialog — most importantly a
+ *     framework error / ANR dialog, package `android` — dims the whole screen
+ *     behind it. A dim scrim multiplies every pixel, so an exact
+ *     `r>=245, g<=10, b>=245` match drops to zero while the band is still there.
+ *     The same shard reported `active_window_pkg=android
+ *     active_window_class=android.widget.FrameLayout` for five other classes, so
+ *     that state demonstrably existed on that device.
+ *
+ * Blaming the terminal's paint for (2) is the wrong-cost failure (G6): the green
+ * assertion is on a signal that was never the app's to satisfy.
+ *
+ * ## The decision
+ *
+ * [evaluateMarkerBandCapture] is deliberately conservative **in the direction of
+ * blaming the product**: it never converts "the band is missing" into a pass. It
+ * only decides WHICH cause the failure names, and it insists the app window held
+ * focus before a missing band may be attributed to the terminal at all.
+ */
+
+/** Outcome kinds of [evaluateMarkerBandCapture]. */
+enum class MarkerBandCaptureOutcome {
+    /** The painted span covers the whole marker — the capture is authoritative. */
+    PAINTED,
+
+    /**
+     * The band is missing AND the app window did not own the display. The
+     * terminal is not the cause; the failure must name the foreign owner.
+     */
+    FOREIGN_WINDOW_OWNS_DISPLAY,
+
+    /**
+     * The band is missing while the app window owned the display for the whole
+     * bounded observation. This is the real device-paint failure.
+     */
+    NOT_PAINTED,
+}
+
+/**
+ * Stable phrase for the "a foreign window owned the display" attribution, so a
+ * red shard can be grepped for the real cause instead of the paint message.
+ */
+const val FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE: String =
+    "the captured frame was not the app's: a foreign window owned the display " +
+        "while the viewport screenshot was taken, so a missing marker band says " +
+        "nothing about what the terminal painted."
+
+/** Result of [evaluateMarkerBandCapture]. */
+data class MarkerBandCaptureVerdict(
+    val outcome: MarkerBandCaptureOutcome,
+    val message: String,
+) {
+    val painted: Boolean get() = outcome == MarkerBandCaptureOutcome.PAINTED
+}
+
+/**
+ * Decide a single bounded capture observation.
+ *
+ * @param marker the seeded marker text, e.g. `A237-READY`.
+ * @param artifactName the artifact base name, so the message points at the PNG.
+ * @param paintedSpanPx widest horizontal magenta run found on the frame.
+ * @param matchingPixels total magenta pixels found (0 distinguishes "nothing"
+ *   from "partial").
+ * @param fontWidthPx the renderer's cell width; 0 means the terminal renderer
+ *   was never read, which is itself a failure (never a pass).
+ * @param appWindowFocused whether the app window held input focus across the
+ *   observation window.
+ * @param activeWindowDescription `describeActiveWindow()` output, only meaningful
+ *   when [appWindowFocused] is false.
+ * @param attempts how many screenshots the bounded pump took.
+ * @param elapsedMs wall time the bounded pump spent.
+ */
+fun evaluateMarkerBandCapture(
+    marker: String,
+    artifactName: String,
+    paintedSpanPx: Int,
+    matchingPixels: Int,
+    fontWidthPx: Float,
+    appWindowFocused: Boolean,
+    activeWindowDescription: String,
+    attempts: Int,
+    elapsedMs: Long,
+): MarkerBandCaptureVerdict {
+    val requiredSpanPx = requiredMarkerSpanPx(marker, fontWidthPx)
+    val observation = "magenta span=$paintedSpanPx px, required>=$requiredSpanPx px, " +
+        "fontWidth=$fontWidthPx, matchingPixels=$matchingPixels, attempts=$attempts, " +
+        "elapsedMs=$elapsedMs"
+    if (fontWidthPx > 0f && paintedSpanPx >= requiredSpanPx) {
+        return MarkerBandCaptureVerdict(
+            outcome = MarkerBandCaptureOutcome.PAINTED,
+            message = "device-visible viewport painted the complete '$marker' cell band for " +
+                "$artifactName: $observation",
+        )
+    }
+    if (!appWindowFocused) {
+        return MarkerBandCaptureVerdict(
+            outcome = MarkerBandCaptureOutcome.FOREIGN_WINDOW_OWNS_DISPLAY,
+            message = "$FOREIGN_WINDOW_OVER_VIEWPORT_SIGNATURE Capture '$artifactName' for " +
+                "'$marker': $observation; $activeWindowDescription",
+        )
+    }
+    return MarkerBandCaptureVerdict(
+        outcome = MarkerBandCaptureOutcome.NOT_PAINTED,
+        message = "device-visible viewport did not paint the complete '$marker' cell band for " +
+            "$artifactName: $observation. The app window owned the display for the whole " +
+            "bounded observation, so the emulator model leading the painted surface is " +
+            "excluded — this is a real device-paint failure.",
+    )
+}
+
+/**
+ * Width, in device pixels, the marker's cell band must span. The band is
+ * measured between the first and last magenta pixel, so the last cell's own
+ * width is not part of the span — hence `length - 1`.
+ */
+fun requiredMarkerSpanPx(marker: String, fontWidthPx: Float): Int =
+    (fontWidthPx * (marker.length - 1).coerceAtLeast(0)).toInt()

--- a/shared/test-support/src/main/java/com/pocketshell/testsupport/TmuxClientOwnership.kt
+++ b/shared/test-support/src/main/java/com/pocketshell/testsupport/TmuxClientOwnership.kt
@@ -1,0 +1,323 @@
+package com.pocketshell.testsupport
+
+/**
+ * Issue #1994 — the pure DECISION behind "did PocketShell leave an orphan tmux
+ * client behind?".
+ *
+ * ## Why this decision is not simply `list-clients | wc -l`
+ *
+ * The detach/orphan journeys ran their acceptance against the *shared* Docker
+ * fixture session (`claude-main`) and asserted the TOTAL client count reached
+ * zero. That count answers a different question than the one the maintainer
+ * cares about. `tmux list-clients -t <session>` reports **every** client on the
+ * session, including clients this journey never created:
+ *
+ *  * the nightly runs ~300 connected tests in ONE instrumentation process
+ *    against ONE tmux server, and several of those tests attach their own
+ *    sidecar clients (a "desktop" `tmux attach`, a second-client input probe);
+ *  * when a session that owns a client is killed, tmux does **not** kill the
+ *    client — it moves it to another session. So one test killing its own
+ *    session can migrate a stray client onto the very session a later test is
+ *    about to assert on.
+ *
+ * A total-count assertion therefore reports `expected:<0> but was:<1>` for a
+ * *foreign* client with the identical text it uses for a genuine PocketShell
+ * leak — which is exactly the ambiguity issue #1994 asks to end ("distinguish a
+ * product detach regression from a leaked prior-test client"). Worse, the
+ * ambiguity is one-directional in the dangerous way: it manufactures a red that
+ * points at the product.
+ *
+ * ## The decision
+ *
+ * Ownership is established by *identity* **and by kind**, not by counting. The
+ * journey snapshots the client names present BEFORE it attaches (the foreign
+ * baseline), snapshots again once its own attach is live (the difference is the
+ * app-owned set), and then asks [evaluateOwnedClientDetach] whether the
+ * app-owned clients are gone.
+ *
+ *  * app-owned client still present  -> FAIL (the real orphan regression);
+ *  * **a `-CC` control-mode client in the pre-attach baseline -> FAIL**, never
+ *    laundered into "foreign". See "the laundering hole" below;
+ *  * a client that is neither foreign-baseline nor app-owned appeared
+ *    afterwards -> FAIL (a post-teardown re-dial / duplicate attach, which is a
+ *    D21 violation and must never be silently tolerated);
+ *  * foreign-baseline **plain** client still present -> IGNORED for pass/fail,
+ *    but always reported in the diagnosis so a reviewer sees it. A plain client
+ *    is the only shape that may ever be excused.
+ *
+ * ## The laundering hole this closes (issue #1994, round 2)
+ *
+ * A baseline-only definition of "foreign" is unsafe on a 300-class shard: a
+ * PocketShell `-CC` client **leaked by an EARLIER class in the same
+ * instrumentation process** is already attached when this journey takes its
+ * baseline, so a purely time-based rule would file it under "foreign" and pass.
+ * That is strictly worse than the total-count oracle it replaced — the old
+ * oracle at least went red.
+ *
+ * Nothing else in this suite opens a control-mode client: `-CC` on the fixture
+ * is PocketShell, by construction. So **control-mode implies app-owned**,
+ * regardless of when it attached, and a control-mode client in the baseline is
+ * reported as [LEAKED_CONTROL_MODE_CLIENT_SIGNATURE] and is fatal.
+ *
+ * ## Attribution is never amnesty (the port-forward pin)
+ *
+ * While a port-forward pins the connection always-on, `App.kt`'s
+ * `dispatchGraceElapsedIfNeeded` deliberately SUPPRESSES the bounded-grace
+ * teardown (#1159 Part 3, the D21 carve-out), so the app's `-CC` client stays
+ * attached by design and never converges. On nightly shard 2 of run
+ * 30961154855 a forwarding pin leaked from an earlier class and produced exactly
+ * that state — reported as a plain orphan, pointing at the product.
+ * [describeOwnedDetachFailure] NAMES the pin as the cause when it is active, but
+ * the verdict is still a FAILURE: a surviving client is never excused.
+ *
+ * ## Why it lives here rather than in `androidTest`
+ *
+ * Same reason as [parseImeServiceState]: the IO (an SSH exec against the Docker
+ * fixture) is emulator/Docker-only, but the *discrimination* it drives is the
+ * part that was wrong, and it must be pinned in the required per-PR `Unit tests`
+ * job rather than only in the nightly. `app/src/test/.../TmuxClientOwnershipTest`
+ * is that pin; the connected journeys only perform the IO.
+ */
+
+/**
+ * Field separator for [TMUX_CLIENT_OWNERSHIP_FORMAT].
+ *
+ * It MUST be printable ASCII. The first cut of #1994 used a literal TAB and it
+ * came back as `_` on the Docker fixture's tmux (3.6b), observed directly:
+ * `list-sessions -F '#{session_name}<TAB>X'` printed `fmtprobe2_X_$0`. tmux
+ * routes some `list-*` output through a message path that sanitises control
+ * characters, and whether a given separator survives depends on the tmux build
+ * and the output path — a reviewer could NOT reproduce the substitution on tmux
+ * 3.4 over an isolated socket, so treat the sanitisation as
+ * build/path-specific rather than universal. The consequence when it does bite
+ * is not: the row never splits, every field collapses into the client NAME,
+ * ownership matching silently never matches, and the proof degrades to nonsense
+ * while still looking structured. A printable separator is safe on every build,
+ * so it is the one to use. [TmuxClientOwnershipTest] pins it.
+ *
+ * `~|~` is safe against the actual field contents: `client_name` is a device
+ * path, `client_control_mode` is `0`/`1`, and `client_flags` is a comma-separated
+ * word list.
+ */
+const val TMUX_CLIENT_FIELD_SEPARATOR: String = "~|~"
+
+/**
+ * The `-F` format the journeys must pass to `tmux list-clients` so this parser
+ * has a stable, non-localised input.
+ */
+const val TMUX_CLIENT_OWNERSHIP_FORMAT: String =
+    "#{client_name}$TMUX_CLIENT_FIELD_SEPARATOR#{client_control_mode}" +
+        "$TMUX_CLIENT_FIELD_SEPARATOR#{client_flags}"
+
+/** One row of `tmux list-clients -F [TMUX_CLIENT_OWNERSHIP_FORMAT]`. */
+data class TmuxClientRecord(
+    /** `#{client_name}` — the client's tty path, e.g. `/dev/pts/24`. */
+    val name: String,
+    /** True when tmux reports the client as a `-CC` control-mode client. */
+    val controlMode: Boolean,
+    /** Raw `#{client_flags}`, e.g. `attached,focused,control-mode,UTF-8`. */
+    val flags: String,
+) {
+    fun describe(): String = "$name[${if (controlMode) "control-mode" else "plain"}|$flags]"
+}
+
+/**
+ * Emitted when the acceptance is decided while a foreign client sits on the
+ * session. Kept as a constant so a reviewer can grep one phrase to see that a
+ * green verdict knowingly ignored a client it did not create.
+ */
+const val FOREIGN_TMUX_CLIENT_IGNORED_SIGNATURE: String =
+    "foreign (not created by this journey) tmux client(s) ignored by the owned-detach oracle"
+
+/** Emitted when a client appeared that is neither foreign-baseline nor owned. */
+const val UNEXPECTED_NEW_TMUX_CLIENT_SIGNATURE: String =
+    "a tmux client that this journey never created appeared after the app attached"
+
+/**
+ * Emitted when a `-CC` control-mode client sits in the pre-attach baseline.
+ *
+ * Nothing but PocketShell opens a control-mode client against this fixture, so
+ * such a client was leaked by an EARLIER class in the same instrumentation
+ * process. It is app-owned by kind and must never be laundered into "foreign".
+ */
+const val LEAKED_CONTROL_MODE_CLIENT_SIGNATURE: String =
+    "a PocketShell -CC (control-mode) tmux client was already attached before this journey " +
+        "started — control-mode is NEVER foreign on this fixture, so it is an app client " +
+        "leaked by an EARLIER class in this instrumentation process, not a stray sidecar"
+
+/**
+ * Emitted when the acceptance is decided while a port-forward pins the
+ * connection always-on. Names the cause; never converts a failure into a pass.
+ */
+const val GRACE_HELD_BY_PORT_FORWARD_PIN_SIGNATURE: String =
+    "grace held by port-forward pin (#1159 Part 3): a port-forward was active at verdict time, " +
+        "so App.dispatchGraceElapsedIfNeeded SUPPRESSED the bounded teardown and the app's -CC " +
+        "client stayed attached BY DESIGN — this is the named cause, not a product orphan, and " +
+        "it is still a hard failure because the journey's precondition (no pin) was violated"
+
+/** Verdict of [evaluateOwnedClientDetach]. */
+data class OwnedClientDetachVerdict(
+    /** App-owned clients still attached — the genuine orphan regression. */
+    val ownedRemaining: List<TmuxClientRecord>,
+    /**
+     * Clients that are neither foreign-baseline nor app-owned — i.e. they
+     * appeared *after* the app attached. A control-mode one is a post-teardown
+     * re-dial (a D21 violation); a plain one is a sidecar the journey never
+     * created. Both are fatal.
+     */
+    val unexpectedNew: List<TmuxClientRecord>,
+    /** Foreign-baseline PLAIN clients still attached; reported, never fatal. */
+    val foreignRemaining: List<TmuxClientRecord>,
+    /**
+     * Control-mode clients present in the pre-attach baseline — PocketShell
+     * clients leaked by an earlier class. Fatal; never laundered as foreign.
+     */
+    val leakedControlRemaining: List<TmuxClientRecord> = emptyList(),
+) {
+    /**
+     * True only when every app-owned client is gone, no leaked control-mode
+     * client is attached, and nothing new appeared.
+     */
+    val detached: Boolean
+        get() = ownedRemaining.isEmpty() &&
+            unexpectedNew.isEmpty() &&
+            leakedControlRemaining.isEmpty()
+
+    fun diagnosis(): String = buildString {
+        append("owned_remaining=")
+        append(ownedRemaining.joinToString(",") { it.describe() }.ifEmpty { "<none>" })
+        append(" leaked_control_remaining=")
+        append(leakedControlRemaining.joinToString(",") { it.describe() }.ifEmpty { "<none>" })
+        append(" unexpected_new=")
+        append(unexpectedNew.joinToString(",") { it.describe() }.ifEmpty { "<none>" })
+        append(" foreign_remaining=")
+        append(foreignRemaining.joinToString(",") { it.describe() }.ifEmpty { "<none>" })
+        if (leakedControlRemaining.isNotEmpty()) {
+            append(" — ")
+            append(LEAKED_CONTROL_MODE_CLIENT_SIGNATURE)
+        }
+        if (unexpectedNew.isNotEmpty()) {
+            append(" — ")
+            append(UNEXPECTED_NEW_TMUX_CLIENT_SIGNATURE)
+        }
+        if (foreignRemaining.isNotEmpty()) {
+            append(" — ")
+            append(FOREIGN_TMUX_CLIENT_IGNORED_SIGNATURE)
+        }
+    }
+}
+
+/**
+ * The failure text a detach journey must assert with.
+ *
+ * When [portForwardPinActive] is true the message NAMES the pin (#1159 Part 3)
+ * as the cause instead of blaming the product for an orphan — but the caller
+ * still fails, because [OwnedClientDetachVerdict.detached] is unchanged. This is
+ * the same "attribution is never amnesty" rule the capture oracle uses for a
+ * foreign window: naming the owner explains a red, it never manufactures a
+ * green.
+ *
+ * Returns `null` when [verdict] is clean, so a caller cannot accidentally
+ * fabricate a failure out of a healthy verdict.
+ */
+fun describeOwnedDetachFailure(
+    verdict: OwnedClientDetachVerdict,
+    portForwardPinActive: Boolean,
+    sessionName: String,
+    rawClients: String,
+): String? {
+    if (verdict.detached) return null
+    val cause = if (portForwardPinActive) {
+        GRACE_HELD_BY_PORT_FORWARD_PIN_SIGNATURE
+    } else {
+        "PocketShell left its own tmux client attached to $sessionName after the bounded " +
+            "grace elapsed (no port-forward pin was active, so the teardown was NOT suppressed " +
+            "— this is a genuine detach regression)"
+    }
+    return "$cause; port_forward_pin_active=$portForwardPinActive " +
+        "${verdict.diagnosis()}; raw=`$rawClients`"
+}
+
+/**
+ * Parse `tmux list-clients -F [TMUX_CLIENT_OWNERSHIP_FORMAT]` output.
+ *
+ * Blank lines are dropped (tmux emits a trailing newline, and `|| true` in the
+ * journeys' shell wrapper can add an empty line when no server is running).
+ * A row with fewer fields than the format promises is kept with the fields it
+ * does have rather than dropped: silently discarding an unparsable client would
+ * turn a real orphan into a green.
+ */
+fun parseTmuxClients(listClientsStdout: String): List<TmuxClientRecord> =
+    listClientsStdout.lines()
+        .map { it.trimEnd('\r') }
+        .filter { it.isNotBlank() }
+        .map { line ->
+            val fields = line.split(TMUX_CLIENT_FIELD_SEPARATOR)
+            val name = fields.getOrNull(0)?.trim().orEmpty()
+            val controlModeField = fields.getOrNull(1)?.trim().orEmpty()
+            val flags = fields.getOrNull(2)?.trim().orEmpty()
+            TmuxClientRecord(
+                name = name.ifEmpty { UNNAMED_TMUX_CLIENT },
+                // tmux renders a boolean format variable as "1"/"0"; fall back to
+                // the flag list so a tmux build that renders it differently still
+                // classifies a control client correctly.
+                controlMode = controlModeField == "1" || flags.contains("control-mode"),
+                flags = flags,
+            )
+        }
+
+/** Placeholder name for a client row tmux emitted without a name. */
+const val UNNAMED_TMUX_CLIENT: String = "<unnamed-client>"
+
+/**
+ * Decide whether the clients THIS journey created are gone.
+ *
+ * @param foreignBaseline client names observed before the app attached.
+ * @param ownedNames client names attributed to the app's own attach.
+ * @param current the clients tmux reports right now.
+ */
+fun evaluateOwnedClientDetach(
+    foreignBaseline: Set<String>,
+    ownedNames: Set<String>,
+    current: List<TmuxClientRecord>,
+): OwnedClientDetachVerdict {
+    val owned = current.filter { it.name in ownedNames }
+    // Control-mode is app-owned BY KIND. A `-CC` client sitting in the pre-attach
+    // baseline was leaked by an EARLIER class in the same instrumentation
+    // process; classifying it as foreign because it predates our baseline is the
+    // laundering hole (#1994 round 2) and would hide the exact symptom the
+    // nightly reported.
+    val leakedControl = current.filter {
+        it.name !in ownedNames && it.controlMode && it.name in foreignBaseline
+    }
+    // Only a PLAIN client may ever be excused. A control-mode client is never
+    // foreign on this fixture.
+    val foreign = current.filter {
+        it.name in foreignBaseline && it.name !in ownedNames && !it.controlMode
+    }
+    val unexpected = current.filter {
+        it.name !in ownedNames && it.name !in foreignBaseline
+    }
+    return OwnedClientDetachVerdict(
+        ownedRemaining = owned,
+        unexpectedNew = unexpected,
+        foreignRemaining = foreign,
+        leakedControlRemaining = leakedControl,
+    )
+}
+
+/**
+ * The app-owned set: whatever appeared between the pre-attach baseline and the
+ * attached snapshot. Returned as names so a later poll can match by identity
+ * even after the count changes.
+ *
+ * The name is the client's tty path and the kernel reuses pts numbers, so a
+ * foreign pts that closes and is reallocated to the app inside one journey would
+ * be classified foreign by identity alone. That is why kind is the second axis:
+ * a reallocated pts carrying a control-mode client is still caught by
+ * [evaluateOwnedClientDetach]'s control-mode rule.
+ */
+fun resolveOwnedClientNames(
+    foreignBaseline: Set<String>,
+    attachedSnapshot: List<TmuxClientRecord>,
+): Set<String> = attachedSnapshot.map { it.name }.filterNot { it in foreignBaseline }.toSet()


### PR DESCRIPTION
Closes #1994 (REOPENED — a previous fix merged as `90c5ca82` and the symptom returned). **Test-only — no production delta.**

Both remaining exact-main nightly failures were harness defects of one kind: **an acceptance decided from a signal that was never PocketShell's to satisfy.**

## Failure 2 — the leaked control client

`TmuxOrphanClientCleanupE2eTest` counted **all** clients on the shared fixture session. tmux *moves* rather than kills a client whose session is killed, so on a ~300-class single-process shard a stray client migrates onto `claude-main` by itself and reads identically to a real PocketShell orphan.

But the survivor in the hosted red was **the app's own control-mode client at 62 columns**, left attached because a leaked port-forward pin suppressed the bounded teardown. Attribution moved twice under review before landing: not `ServerDeathReconnectNoResurrectE2eTest` (itself a victim), but a forward opened at 00:08:37 by **`PortForwardDuplicateKeyRenderTest` — a pure render test that owns no forwarding and carries no isolation rule at all.** That is why #2000's fix to the origin was insufficient, and why the new isolation is origin-agnostic.

**The fix decides on client identity:** pre-attach baseline → app-owned set → every owned client gone AND nothing new appeared. Kind is a **second axis**, so a PocketShell `-CC` client leaked by an earlier class is always fatal and can never be filed as "foreign"; only a plain client may be excused. Applied to both detach journeys (G2), plus a mid-journey pin prelude.

## Failure 1 — the zero-pixel capture

The viewport capture took one screenshot after `waitForIdleSync()` plus a flat 150 ms sleep — a **main-thread** barrier, not a **composition** barrier — and blamed the terminal's paint when the band was missing. Review established the app was RESUMED and in front at capture time and the cited foreign-window failures were 2–20 minutes away, so the barrier was the real cause.

Replaced with a bounded, hard-failing capture pump. **A missing band still hard-fails in both worlds**; attribution never converts it into a pass (G6).

## Also fixed

A literal TAB field separator was silently sanitised to `_` by tmux, collapsing every field into the client name and producing structured-looking nonsense.

## Evidence

Reviewer-run, this run: pin isolation removed → `tests=1 failures=1` with the app's own control-mode client surviving, matching the hosted `[62x xterm-256color] (attached,focused,control-mode,UTF-8)` shape; restored md5-identical → `tests=7 failures=0 errors=0 skipped=0` across all three classes. Three live JVM mutations killed five distinct pins (restoring the laundering killed both laundering tests; dropping the pin branch killed the pin-naming test; flipping `FOREIGN_WINDOW_OWNS_DISPLAY`→`PAINTED` killed both capture-attribution tests).

## Orchestrator integration gate (this exact tree, base `e2b688fe`)

Run as a transient systemd unit (`Result=success`, `ExecMainStatus=0`) so a harness-killed background shell could not fake it:

| Check | Result |
|---|---|
| `:app:testDebugUnitTest` `--rerun-tasks` | **4466 executed / 0 failures / 0 errors / 0 skipped** |
| `:app:testReleaseUnitTest` `--rerun-tasks` | **4454 executed / 0 failures / 0 errors / 0 skipped** |
| XML freshness vs run marker | 475/475 and 473/473 |
| Cache markers on either task line | none |
| `TmuxClientOwnershipTest` | 17/0 in **both** variants |
| `MarkerBandCaptureVerdictTest` | 9/0 in **both** variants |
| `:app:compileDebugAndroidTestKotlin` (forced, `--no-build-cache`) | clean — CI's `Unit` job does not compile this source set |
| `397 actionable tasks: 397 executed` | no cached test tasks |

All four untracked files copied explicitly and md5-verified; `git diff` omits them, and merging this fix without its tests would be the exact D33 failure.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/1994#issuecomment-5198937005

## Follow-ups (not in scope)

- The total-count oracle still survives in `BoundedGraceSessionHoldJourneyE2eTest`, `BackgroundGraceReconnectE2eTest` and `NetworkFaultProofBase`; the first two are in the per-PR journey suite with no pin isolation.
- #2014 — `holdWhilePinned` is host-agnostic, so a forward on host A pins every host.
