### PR TITLE
terminal: keep OSC 8 provenance across rectangular attribute mutations (#1961)

### DIFF
--- a/shared/core-terminal/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -554,7 +554,11 @@ public final class TerminalBuffer {
                 } else {
                     effect &= ~bits;
                 }
-                line.mStyle[x] = TextStyle.encode(foreColor, backColor, effect);
+                // This mutates an already-painted cell, so it must carry the cell's OSC 8
+                // provenance across the decode/re-encode round trip (#1961). A plain
+                // TextStyle.encode() would drop it and make the hard-wrap link repair
+                // decline to join a wrapped hyperlink after any rectangular attribute change.
+                line.mStyle[x] = TextStyle.encodePreservingProvenance(foreColor, backColor, effect, currentStyle);
             }
             // Style was written directly (bypassing TerminalRow.setChar), so the
             // renderer's dirty-region cache must see this row as changed (#469).

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TextStyle.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TextStyle.java
@@ -45,6 +45,12 @@ public final class TextStyle {
     public final static long CHARACTER_ATTRIBUTE_OSC8_HYPERLINK = 1L << 11;
     /** Marks only the first cell emitted after an OSC 8 hyperlink opener. */
     public final static long CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START = 1L << 12;
+    /**
+     * Every bit that carries PocketShell OSC 8 provenance rather than a rendered attribute. These
+     * bits are pure marker provenance: no hyperlink URI payload is ever stored in a cell.
+     */
+    public final static long OSC8_PROVENANCE_MASK =
+        CHARACTER_ATTRIBUTE_OSC8_HYPERLINK | CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START;
 
     public final static int COLOR_INDEX_FOREGROUND = 256;
     public final static int COLOR_INDEX_BACKGROUND = 257;
@@ -74,6 +80,20 @@ public final class TextStyle {
         }
 
         return result;
+    }
+
+    /**
+     * Re-encodes colours and effects for a cell that already exists on screen, carrying its OSC 8
+     * provenance across.
+     * <p>
+     * {@link #encode(int, int, int)} builds a style from scratch and therefore returns zero in bits
+     * 11..12. Post-paint mutations that decode-then-re-encode an existing cell (DECCARA / DECRARA
+     * rectangular attribute changes) must use this instead, or the rectangular change erases the
+     * marker and #1955's hard-wrap link repair silently declines to join the wrapped link (#1961).
+     * </p>
+     */
+    static long encodePreservingProvenance(int foreColor, int backColor, int effect, long previousStyle) {
+        return encode(foreColor, backColor, effect) | (previousStyle & OSC8_PROVENANCE_MASK);
     }
 
     public static int decodeForeColor(long style) {

--- a/shared/core-terminal/src/test/java/com/termux/terminal/RectangularAreasTest.java
+++ b/shared/core-terminal/src/test/java/com/termux/terminal/RectangularAreasTest.java
@@ -114,4 +114,117 @@ public class RectangularAreasTest extends TerminalTestCase {
 		assertEffectAttributesSet(effectLine(b, u, 0), effectLine(bu, bu, 0), effectLine(0, 0, 0));
 	}
 
+	private static final long OSC8_ACTIVE = TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK;
+	private static final long OSC8_OPENER = TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START;
+	/**
+	 * Deliberately spelled out from the two public bit constants rather than reusing a production
+	 * mask helper, so mutating that helper cannot silently move this test's expectation too.
+	 */
+	private static final long OSC8_PROVENANCE = OSC8_ACTIVE | OSC8_OPENER;
+
+	/**
+	 * Paints, on row 0 of an 8x4 terminal, columns 0..5 as:
+	 * <pre>
+	 *   col 0 'A' - first cell of hyperlink #1 (active + opener)
+	 *   col 1 'B' - continuation of hyperlink #1 (active only)
+	 *   col 2 'C' - after the closer, plain text (no provenance)
+	 *   col 3 'D' - first cell of an adjacent, independent hyperlink #2 (active + opener)
+	 *   col 4 'E' - continuation of hyperlink #2 (active only)
+	 *   col 5 'F' - after the second closer, plain text (no provenance)
+	 * </pre>
+	 * Foreground colour index 99 is applied throughout so the re-encode's colour path is exercised.
+	 */
+	private void paintTwoAdjacentOsc8LinksWithCloses() {
+		withTerminalSized(8, 4).enterString("\033[38;5;99m"
+			+ "\033]8;id=one;https://example.com/first\033\\AB\033]8;;\007"
+			+ "C"
+			+ "\033]8;id=two;https://example.com/second\033\\DE\033]8;;\007"
+			+ "F");
+		assertOsc8ProvenanceLayoutIntact("before the rectangular attribute mutation");
+	}
+
+	private void assertOsc8ProvenanceLayoutIntact(String when) {
+		assertEquals("col 0 must stay the opener cell of hyperlink #1 " + when,
+			OSC8_ACTIVE | OSC8_OPENER, getStyleAt(0, 0) & OSC8_PROVENANCE);
+		assertEquals("col 1 must stay an active continuation, never a second opener " + when,
+			OSC8_ACTIVE, getStyleAt(0, 1) & OSC8_PROVENANCE);
+		assertEquals("col 2 follows the closer and must carry no provenance " + when,
+			0L, getStyleAt(0, 2) & OSC8_PROVENANCE);
+		assertEquals("col 3 must stay the opener cell of the adjacent hyperlink #2 " + when,
+			OSC8_ACTIVE | OSC8_OPENER, getStyleAt(0, 3) & OSC8_PROVENANCE);
+		assertEquals("col 4 must stay an active continuation of hyperlink #2 " + when,
+			OSC8_ACTIVE, getStyleAt(0, 4) & OSC8_PROVENANCE);
+		assertEquals("col 5 follows the second closer and must carry no provenance " + when,
+			0L, getStyleAt(0, 5) & OSC8_PROVENANCE);
+		assertEquals("untouched blank rows must never gain provenance " + when,
+			0L, getStyleAt(1, 0) & OSC8_PROVENANCE);
+	}
+
+	private void assertRectangleWasActuallyMutatedToBold() {
+		for (int column = 0; column < 6; column++) {
+			assertTrue("column " + column + " must have received the requested bold bit; without a real"
+					+ " mutation the provenance assertions would pass vacuously",
+				(TextStyle.decodeEffect(getStyleAt(0, column)) & TextStyle.CHARACTER_ATTRIBUTE_BOLD) != 0);
+			assertEquals("column " + column + " must keep its foreground colour through the re-encode",
+				99, TextStyle.decodeForeColor(getStyleAt(0, column)));
+		}
+	}
+
+	/**
+	 * DECCARA re-encodes each cell's colours and effects. Regression for #1961: the re-encode must
+	 * carry the OSC 8 provenance bits (11/12) across, or #1955's hard-wrap link repair silently
+	 * declines to join a wrapped long link after any rectangular attribute change.
+	 * http://vt100.net/docs/vt510-rm/DECCARA
+	 */
+	public void testChangeAttributesInRectangularAreaPreservesOsc8Provenance() {
+		paintTwoAdjacentOsc8LinksWithCloses();
+		// DECSACE rectangular ("${CSI}2*x"), then DECCARA bold over rows 1..3, columns 1..8.
+		enterString("\033[2*x\033[1;1;3;8;1$r");
+		assertRectangleWasActuallyMutatedToBold();
+		assertOsc8ProvenanceLayoutIntact("after DECCARA");
+	}
+
+	/**
+	 * Same invariant through the stream (non-rectangular, DECSACE default) DECCARA path.
+	 * http://vt100.net/docs/vt510-rm/DECCARA
+	 */
+	public void testChangeAttributesInStreamAreaPreservesOsc8Provenance() {
+		paintTwoAdjacentOsc8LinksWithCloses();
+		enterString("\033[1;1;2;1;1$r");
+		assertRectangleWasActuallyMutatedToBold();
+		assertOsc8ProvenanceLayoutIntact("after stream-mode DECCARA");
+	}
+
+	/**
+	 * DECRARA takes the same re-encode path with reverse semantics.
+	 * http://www.vt100.net/docs/vt510-rm/DECRARA
+	 */
+	public void testReverseAttributesInRectangularAreaPreservesOsc8Provenance() {
+		paintTwoAdjacentOsc8LinksWithCloses();
+		// DECSACE rectangular, then DECRARA reversing bold (cells start non-bold, so they end bold).
+		enterString("\033[2*x\033[1;1;3;8;1$t");
+		assertRectangleWasActuallyMutatedToBold();
+		assertOsc8ProvenanceLayoutIntact("after DECRARA");
+	}
+
+	/**
+	 * A rectangular attribute mutation must not disturb the close/reset semantics either: after the
+	 * mutation, a still-open hyperlink cleared by {@link TerminalEmulator#reset()} must stop marking
+	 * newly painted cells.
+	 */
+	public void testRectangularAttributeMutationKeepsOsc8CloseAndResetSemantics() {
+		paintTwoAdjacentOsc8LinksWithCloses();
+		enterString("\033[2*x\033[1;1;3;8;1$r");
+		assertOsc8ProvenanceLayoutIntact("after DECCARA");
+
+		// Open a hyperlink, mutate the rectangle again, then reset: reset still closes it.
+		enterString("\033]8;;https://example.com/open-across-reset\033\\");
+		enterString("\033[2*x\033[1;1;3;8;1$r");
+		mTerminal.reset();
+		enterString("z");
+		int zColumn = mTerminal.getCursorCol() - 1;
+		assertEquals("terminal reset must still close an OSC 8 hyperlink that spanned a DECCARA",
+			0L, getStyleAt(0, zColumn) & OSC8_PROVENANCE);
+	}
+
 }

--- a/shared/core-terminal/src/test/java/com/termux/terminal/TextStyleTest.java
+++ b/shared/core-terminal/src/test/java/com/termux/terminal/TextStyleTest.java
@@ -42,6 +42,55 @@ public class TextStyleTest extends TestCase {
 		);
 	}
 
+	/**
+	 * #1961: a post-paint re-encode of an existing cell must change only the requested colours and
+	 * effects and carry the OSC 8 provenance bits through untouched.
+	 */
+	public void testEncodePreservingProvenanceKeepsOsc8BitsAndOnlyThose() {
+		long previous = TextStyle.encode(99, 7, TextStyle.CHARACTER_ATTRIBUTE_ITALIC)
+			| TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK
+			| TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START;
+
+		long reencoded = TextStyle.encodePreservingProvenance(12, 34,
+			TextStyle.CHARACTER_ATTRIBUTE_BOLD, previous);
+
+		assertEquals("requested foreground must be applied", 12, TextStyle.decodeForeColor(reencoded));
+		assertEquals("requested background must be applied", 34, TextStyle.decodeBackColor(reencoded));
+		assertEquals("only the requested effect bits must survive",
+			TextStyle.CHARACTER_ATTRIBUTE_BOLD, TextStyle.decodeEffect(reencoded));
+		assertEquals("both OSC 8 provenance bits must be carried across",
+			TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK | TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START,
+			reencoded & TextStyle.OSC8_PROVENANCE_MASK);
+		assertEquals("the re-encode must add nothing beyond the requested style plus provenance",
+			TextStyle.encode(12, 34, TextStyle.CHARACTER_ATTRIBUTE_BOLD)
+				| TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK
+				| TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START,
+			reencoded);
+	}
+
+	/** A cell with no provenance must not gain any from a re-encode. */
+	public void testEncodePreservingProvenanceDoesNotInventProvenance() {
+		long previous = TextStyle.encode(1, 2, TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE);
+		assertEquals(0L, previous & TextStyle.OSC8_PROVENANCE_MASK);
+
+		long reencoded = TextStyle.encodePreservingProvenance(3, 4,
+			TextStyle.CHARACTER_ATTRIBUTE_BOLD, previous);
+
+		assertEquals("a plain cell must stay plain", 0L, reencoded & TextStyle.OSC8_PROVENANCE_MASK);
+		assertEquals(TextStyle.encode(3, 4, TextStyle.CHARACTER_ATTRIBUTE_BOLD), reencoded);
+	}
+
+	/** Only the opener bit set (no active bit) must be carried through independently. */
+	public void testEncodePreservingProvenanceCarriesEachBitIndependently() {
+		long onlyActive = TextStyle.encode(0, 0, 0) | TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK;
+		assertEquals(TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK,
+			TextStyle.encodePreservingProvenance(5, 6, 0, onlyActive) & TextStyle.OSC8_PROVENANCE_MASK);
+
+		long onlyOpener = TextStyle.encode(0, 0, 0) | TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START;
+		assertEquals(TextStyle.CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START,
+			TextStyle.encodePreservingProvenance(5, 6, 0, onlyOpener) & TextStyle.OSC8_PROVENANCE_MASK);
+	}
+
 	public void testEncoding24Bit() {
 		int[] values = {255, 240, 127, 1, 0};
 		for (int red : values) {


### PR DESCRIPTION
Closes #1961. Follow-up from the #1955 review — completes the terminal metadata invariant.

## The hole

`TerminalBuffer.setOrClearEffect` (DECCARA / DECRARA rectangular attribute mutation) decoded a painted cell's colours and effects, then re-encoded via `TextStyle.encode(...)`. That builds a style from scratch and returns zero in bits 11/12, **erasing the #1955 OSC 8 provenance**.

## Severity — deliberately not overstated

This does **not** create a false browser target. Losing provenance makes #1955's hard-wrap repair *decline to join*, so the failure mode is a **missed long-link affordance**, never a wrong link. It is not on the reported Claude OSC 8 paint path and was explicitly non-blocking for #1955. The fix is scoped accordingly: minimal, not a redesign.

## The fix

A new `TextStyle.encodePreservingProvenance(fore, back, effect, previousStyle)` ORs the cell's own `OSC8_PROVENANCE_MASK` bits back on. **Marker bits only — no URI payload enters a cell**, and the OSC 8 parser is untouched.

## Why it is preserve-*without*-inventing

The correct behaviour is asymmetric, and both directions are constrained:

- provenance present on the previous style must survive the mutation
- provenance **absent** must not be fabricated

A mask OR that is too broad would pass the headline test while corrupting clean cells. The reviewer wrote that mutant specifically (`| OSC8_PROVENANCE_MASK` unconditionally) and it dies on 6 tests, including `a plain cell must stay plain expected:<0> but was:<6144>` and `col 1 must stay an active continuation, never a second opener`.

A second reviewer mutant — `return previousStyle` (blanket copy) — dies on 7, including two **pre-existing** rectangular tests, confirming "only the requested visual bits change" is real rather than assumed.

## Evidence

- **Red first:** 4 tests written before the fix, red on unfixed code with `col 0 must stay the opener cell of hyperlink #1 ... expected:<6144> but was:<0>` (521 completed, 4 failed).
- **Implementer mutation:** three live mutants (call site reverted; helper's OR removed; mask narrowed to drop the opener bit) killed 4, 6 and 6 tests **selectively** — M1 moved only the 4 new rectangular tests, and `testEncodePreservingProvenanceDoesNotInventProvenance` correctly **stayed green** under M2.
- **Reviewer, independently:** re-derived M1–M3, added M4/M5 above, and swept every `TextStyle.encode` call site — `TerminalBuffer.java:561` is the only post-paint re-encode of an existing cell. `decodeEffect` masks to bits 0..10 and `TerminalRenderer:570` is its only consumer, so bits 11/12 are rendering-neutral (which is why JVM-only acceptance is honest here rather than a G4 `BLOCKED`). The OSC 8 parser at `TerminalEmulator.java:2103-2107` still discards the URI. `TerminalView.java` — changed tonight by #2003 — is untouched.
- Both restored their mutations via `cp` backup with md5 byte-identity and zero `MUTANT` markers remaining.

## Orchestrator integration gate (this exact tree, base `04a5b362`)

`:shared:core-terminal:testDebugUnitTest` + `:testReleaseUnitTest`, `--rerun-tasks --no-build-cache`:

| Check | Result |
|---|---|
| executed / failures / skipped | **524 / 0 / 0** in *both* variants |
| XML freshness vs run marker | 53/53 and 53/53 |
| Cache markers on either task line | none |
| Provenance tests named in results | 10 in each variant |

No untracked files in this change — the whole diff is four modified files.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/1961#issuecomment-5201813562
