### PR TITLE
connection: let manual Reconnect preempt a wedged automatic ladder (#1953)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
@@ -1,8 +1,12 @@
 package com.pocketshell.app.proof
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -16,6 +20,8 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEventSink
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.TMUX_RECONNECT_BUTTON_TAG
@@ -31,6 +37,7 @@ import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -41,6 +48,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.junit.runners.model.Statement
 import java.io.File
+import java.io.FileOutputStream
 
 /**
  * Issue #993 — DEVICE-TRUTH journey for the new kebab **"Reconnect"** action, on the
@@ -69,18 +77,58 @@ import java.io.File
  *    #900 outbound-queue auto-flush relies on; the flush-on-`sessionLive` wiring itself is
  *    pinned by the JVM `TmuxSessionScreenTest` controller tests).
  *
+ * ## Issue #1953 — the WEDGED-LADDER state this journey now enters deterministically
+ *
+ * In exact-main run 30787372084 this journey failed BOTH attempts stuck in
+ * `Reconnecting(attempt=1)`: the kebab item existed in the semantics tree but was DISABLED for
+ * `SessionSurfaceState.Reconnecting`, so `performClick()` invoked nothing — no
+ * `reconnect_tapped`, no manual trigger, no transport replacement. The escape hatch was locked
+ * out by the very state it exists for.
+ *
+ * That state used to be reached only by luck (whether automatic recovery happened to be asleep
+ * when the kebab opened). It is now created ON PURPOSE, because a happy fixture that heals
+ * before the user can reach for the hatch proves nothing (G10/D33):
+ *
+ *  - the auto-reconnect ladder is re-installed with a [WEDGED_LADDER_DELAY_MS] backoff, so
+ *    once entered it PARKS with nothing on the wire — a physically wedged ladder — while
+ *    STILL waking inside this journey if nothing cancels it (round 2; see below);
+ *  - the bounded passive-grace recovery is collapsed to 1ms, so it cannot heal the drop
+ *    before escalating into that ladder (a dial can never complete a TCP+KEX+auth handshake in
+ *    1ms — deterministic, not a race). Only the AUTOMATIC recovery budgets are shortened; the
+ *    manual reconnect the user then taps runs on full production timeouts.
+ *
+ * The journey then HARD-asserts the reported state is live (`ConnectionStatus.Reconnecting`),
+ * that the kebab node is **enabled and exposes a click action BEFORE the click**, and that the
+ * one tap produced exactly one `reconnect_tapped` / one `trigger=reconnect` job, a fresh `-CC`
+ * client, the same screen, and a round-tripping post-reconnect send.
+ *
+ * ## Issue #1953 round 2 — the tap must PREEMPT the parked rung, held past its wake instant
+ *
+ * AC2 also requires the one tap to cancel/preempt the automatic job. Round 1 asserted that
+ * over a wedge of 600_000ms x 6, so the parked rung was ~10 minutes from waking and NOTHING
+ * after the tap could contradict it — green with or without
+ * `TmuxSessionViewModel.startReconnectForSendBody`'s `autoReconnectJob?.cancel()`. It is not a
+ * formality: the ladder body re-checks `connectionManager.state` only at the TOP of its loop,
+ * so a rung that was not cancelled wakes straight into `closeCurrentConnectionAndJoin(...)` +
+ * `runConnect(...)` against the HEALTHY session the user just recovered — they tap Reconnect,
+ * get their session back, and lose it again. The rung is now sized to wake INSIDE this journey
+ * ([WEDGED_LADDER_DELAY_MS], bounded by [MAX_OBSERVABLE_WEDGE_BACKOFF_MS]), its wake instant is
+ * stamped from the ladder's own `reconnect_start{trigger=auto-reconnect, retryDelayMs}`, and
+ * the survival assertions (same `-CC` client, still Connected, no second auto job, a send that
+ * still round-trips) are held [PREEMPTION_MARGIN_MS] PAST that instant.
+ *
  * ## Fail-first (G10/D33)
  *
- * WITHOUT the kebab Reconnect item (the `onReconnect` → `viewModel.reconnect()` wiring) there
- * is NO in-session affordance to recover the dropped session — the [TMUX_RECONNECT_BUTTON_TAG]
- * node does not exist, so `tapKebabReconnect()` cannot find/click it and the session stays on
- * the connection-lost band: RED. WITH the fix the tap drives the VM's single
+ * On the unfixed gate the wedged `Reconnecting` surface disables the item, so
+ * `assertIsEnabled()` fails before the click is even attempted (and, if that assertion were
+ * removed, the tap would invoke nothing and the recovery/round-trip assertions would fail):
+ * RED. WITH the fix the item is actionable, the tap drives the VM's single
  * [TmuxSessionViewModel.reconnect] / TransportEffects entrypoint, the same session recovers in
  * place, and the post-reconnect send round-trips: GREEN.
  *
  * Uses ONLY the deterministic `agents` fixture and the synthetic clean-drop seam (no
  * toxiproxy, no `Assume.assumeFalse(isRunningOnCi())` on any load-bearing assertion), so it
- * RUNS on the per-PR CI emulator-journey job once wired into `scripts/ci-journey-suite.sh`.
+ * RUNS on the per-PR CI emulator-journey job (wired in `scripts/ci-journey-suite.sh`).
  */
 @RunWith(AndroidJUnit4::class)
 class ReconnectKebabInPlaceJourneyE2eTest {
@@ -96,6 +144,8 @@ class ReconnectKebabInPlaceJourneyE2eTest {
 
     private var seededKey: String? = null
     private var seededHostRowTag: String? = null
+    private val diagnostics = RecordingDiagnosticSink()
+    private val timings = mutableListOf<String>()
 
     private fun seedFixtureRule(): TestRule = TestRule { base, _ ->
         object : Statement() {
@@ -119,6 +169,7 @@ class ReconnectKebabInPlaceJourneyE2eTest {
 
     @After
     fun tearDown() {
+        DiagnosticEvents.install(DiagnosticEventSink.Noop)
         runCatching {
             compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
         }
@@ -144,27 +195,106 @@ class ReconnectKebabInPlaceJourneyE2eTest {
             currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
         )
         val clientBeforeDrop = currentViewModel().currentClientIdentityForTest()
+        captureViewport("issue1953-01-attached")
+
+        // ---- Issue #1953: build the WEDGED automatic ladder the escape hatch is for ----
+        // The [WEDGED_LADDER_DELAY_MS] backoff makes the ladder PARK once entered (nothing on
+        // the wire) for the whole tap + recovery, while still waking inside this journey so the
+        // preemption assertions can fail; the 1ms passive-grace budget means automatic recovery
+        // cannot heal the drop before escalating into that ladder. Only the AUTOMATIC recovery
+        // budgets are shortened — the manual reconnect the user taps below runs on full
+        // production timeouts.
+        currentViewModel().setAutoReconnectDelaysForTest(List(LADDER_RUNGS) { WEDGED_LADDER_DELAY_MS })
+        currentViewModel().setPassiveDisconnectRecoveryForTest(
+            graceMs = 1L,
+            silentReattachTimeoutMs = 1L,
+        )
+        DiagnosticEvents.install(diagnostics)
+        diagnostics.clear()
 
         // ---- DROP: the maintainer's "I'm in a session and it disconnects" ----
         // Fire the CLEAN passive-disconnect path directly (the same body a real reader EOF
         // drives). The session can no longer round-trip and a USER-VISIBLE connection-lost
         // band surfaces — the stuck state the maintainer has no in-session escape from.
+        val dropAtMs = SystemClock.elapsedRealtime()
         val dropped = currentViewModel().triggerCleanPassiveDropForTest()
         assertTrue("expected the clean-drop seam to fire on a live client", dropped)
         val bandShown = waitForConnectionLostIndicator(DROP_DETECT_WINDOW_MS)
+        recordTiming("drop_to_connection_lost_ms", SystemClock.elapsedRealtime() - dropAtMs)
         assertTrue(
             "expected a USER-VISIBLE connection-lost band after the drop " +
                 "(status=${currentConnectionStatus()})",
             bandShown,
         )
 
-        // ---- TAP KEBAB → RECONNECT (the new escape hatch) ----
-        // The user opens the kebab and taps the new "Reconnect" item. This drives the VM's
-        // single reconnect entrypoint to re-dial THIS session in place — NO navigation to
-        // another session and back.
+        // ---- The EXACT reported state: wedged in the automatic ladder ----
+        // Run 30787372084 died here, stuck in `Reconnecting(attempt=1)`. Wait on the DISPLAYED
+        // (debounced, #876) status — that is what the screen's surface state, and therefore
+        // the kebab's enablement, derives from.
+        val wedged = waitForDisplayedReconnecting(WEDGE_WINDOW_MS)
+        recordTiming("drop_to_wedged_reconnecting_ms", SystemClock.elapsedRealtime() - dropAtMs)
+        assertTrue(
+            "expected the session to be WEDGED in the automatic recovery ladder — the exact " +
+                "state issue #1953 reports the escape hatch being disabled in " +
+                "(displayed=${currentDisplayedStatus()} raw=${currentConnectionStatus()})",
+            wedged,
+        )
+        assertTrue(
+            "the VM must still know a target to reconnect to while wedged",
+            currentCanReconnect(),
+        )
+
+        // ---- Anchor the PARKED RUNG in time (issue #1953 round 2) ----
+        // The ladder emits `reconnect_start{trigger=auto-reconnect, retryDelayMs}` immediately
+        // before its own `delay(retryDelayMs)`, so observing that event gives an upper bound on
+        // when an UNCANCELLED rung would wake, tear this session down and re-dial. Everything
+        // after the tap is bracketed against that instant, which is what makes the "one tap
+        // preempts the automatic job" limb of AC2 capable of failing at all. (Round 1 wedged
+        // with a 600_000ms ladder and never observed a wake, so its non-duplication assertion
+        // was green whether or not the ladder was cancelled.)
+        val parkedRung = awaitParkedLadderRung(WEDGE_WINDOW_MS)
+        val parkedBackoffMs = parkedRung.retryDelayMs
+        assertTrue(
+            "issue #1953 round 2 (G6): the wedge must park on a rung short enough that an " +
+                "UNCANCELLED rung would wake INSIDE this journey's observation window, or the " +
+                "preemption assertions below cannot fail. observed retryDelayMs=" +
+                "$parkedBackoffMs (max=$MAX_OBSERVABLE_WEDGE_BACKOFF_MS, nominal rung=" +
+                "$WEDGED_LADDER_DELAY_MS +/-20% jitter)",
+            parkedBackoffMs in 1..MAX_OBSERVABLE_WEDGE_BACKOFF_MS,
+        )
+        val rungWakeByMs = parkedRung.observedAtMs + parkedBackoffMs
+        recordTiming("parked_rung_backoff_ms", parkedBackoffMs)
+        captureViewport("issue1953-02-wedged-reconnecting")
+
+        // ---- TAP KEBAB → RECONNECT (the escape hatch) ----
+        // The user opens the kebab and taps the "Reconnect" item. `tapKebabReconnect()` asserts
+        // the node is ENABLED and exposes a click action BEFORE clicking — on the unfixed gate
+        // that is exactly where this goes red, instead of silently clicking a dead item.
+        val tapAtMs = SystemClock.elapsedRealtime()
+        val autoDialsBeforeTap = autoLadderDials().size
         tapKebabReconnect()
 
+        // AC2: ONE tap → exactly one `reconnect_tapped`, routed through the single
+        // trigger=reconnect entrypoint, and exactly ONE trigger=reconnect connect job. Not two
+        // owners, not a second ladder.
+        val taps = waitForDiagnostic("reconnect_tapped", TAP_DIAGNOSTIC_WINDOW_MS)
+        assertEquals("one tap must emit exactly one reconnect_tapped: $taps", 1, taps.size)
+        assertEquals(
+            "the tap must route through the single manual reconnect trigger",
+            "reconnect",
+            taps.single().fields["trigger"],
+        )
+        val manualStarts = diagnostics.eventsNamed("reconnect_start")
+            .filter { it.fields["requestedTrigger"] == "reconnect" }
+        assertEquals(
+            "one tap must start exactly one trigger=reconnect job: $manualStarts",
+            1,
+            manualStarts.size,
+        )
+
         val recovered = waitForSessionRecovered(RECOVER_WINDOW_MS)
+        val recoveredCapturedAtMs = SystemClock.elapsedRealtime()
+        recordTiming("tap_to_recovered_ms", recoveredCapturedAtMs - tapAtMs)
         assertTrue(
             "expected the SAME session to recover to Connected IN PLACE after tapping the " +
                 "kebab Reconnect — no switch dance (status=${currentConnectionStatus()}).",
@@ -202,6 +332,79 @@ class ReconnectKebabInPlaceJourneyE2eTest {
                 "(no switch dance). status=${currentConnectionStatus()}",
             roundTripped,
         )
+        // AC3: SAME session, not a re-created one — the pre-drop live marker is still in the
+        // recovered pane's transcript alongside the post-reconnect one.
+        val recoveredTranscript = visibleTerminalText()
+        assertTrue(
+            "the recovered pane must be the SAME session (the pre-drop marker must survive); " +
+                "transcript=\n$recoveredTranscript",
+            recoveredTranscript.contains("LIVE-$MARKER"),
+        )
+        captureViewport("issue1953-03-recovered")
+
+        // ---- AC2: the one tap PREEMPTED the automatic job, held past its wake instant ----
+        // The rung the tap preempted was due to wake at `rungWakeByMs`. The ladder body
+        // re-checks `connectionManager.state` only at the TOP of its loop, so a rung that was
+        // NOT cancelled wakes straight into `closeCurrentConnectionAndJoin(...)` +
+        // `runConnect(...)` against the healthy session the user just recovered — the user
+        // taps Reconnect, gets their session back, and then loses it again. Holding past the
+        // wake instant is the only way this journey can observe that.
+        assertTrue(
+            "issue #1953 round 2: the preempted rung must still have been PENDING when the " +
+                "recovered client was captured, or the hold below observes nothing. " +
+                "rungWakeBy=$rungWakeByMs recoveredCapturedAt=$recoveredCapturedAtMs " +
+                "tapAt=$tapAtMs (remaining after recovery=" +
+                "${rungWakeByMs - recoveredCapturedAtMs}ms)",
+            rungWakeByMs > recoveredCapturedAtMs,
+        )
+        val holdUntilMs = rungWakeByMs + PREEMPTION_MARGIN_MS
+        while (SystemClock.elapsedRealtime() < holdUntilMs) SystemClock.sleep(250)
+        recordTiming("preemption_hold_past_wake_ms", SystemClock.elapsedRealtime() - tapAtMs)
+        assertEquals(
+            "the preempted automatic ladder must NOT wake up and DIAL after the manual tap — " +
+                "a surviving rung re-dials inside its own loop iteration, emitting exactly " +
+                "this connect-attempt reconnect_start{requestedTrigger=auto-reconnect}",
+            autoDialsBeforeTap,
+            autoLadderDials().size,
+        )
+        assertEquals(
+            "no further automatic rung may be scheduled after the manual tap either",
+            1,
+            autoLadderRungsScheduled().size,
+        )
+        assertEquals(
+            "one tap must still be exactly one reconnect_tapped after the wake instant",
+            1,
+            diagnostics.eventsNamed("reconnect_tapped").size,
+        )
+        assertEquals(
+            "the manually-recovered `-CC` client must SURVIVE the parked rung's wake instant " +
+                "— a surviving rung closes it and re-dials",
+            clientAfter,
+            currentViewModel().currentClientIdentityForTest(),
+        )
+        assertTrue(
+            "the session must still be healthily Connected after the parked rung's wake " +
+                "instant (status=${currentConnectionStatus()})",
+            sessionHealthyConnected(),
+        )
+        // And it must still be USABLE: a second marker round-trips through the same channel
+        // after the instant a surviving rung would have torn it down.
+        emitMarkerIntoPane(key, "POSTWAKE-$MARKER")
+        val postWakeRoundTripped = runCatching {
+            waitForVisibleTerminal(
+                "post-wake",
+                timeoutMillis = ROUND_TRIP_WINDOW_MS,
+            ) { it.contains("POSTWAKE-$MARKER") }
+            true
+        }.getOrDefault(false)
+        assertTrue(
+            "expected a send to still round-trip AFTER the preempted rung's wake instant — " +
+                "that is the user keeping the session they just recovered. " +
+                "status=${currentConnectionStatus()}",
+            postWakeRoundTripped,
+        )
+        captureViewport("issue1953-04-survived-preempted-rung-wake")
 
         writeSummary()
     } }
@@ -217,11 +420,94 @@ class ReconnectKebabInPlaceJourneyE2eTest {
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
-        // AC1: the Reconnect item is present + reachable, then tap it.
+        // AC1 + issue #1953: the Reconnect item must be present, ENABLED and expose a click
+        // action BEFORE the tap. Merely existing is what run 30787372084 had — the node was in
+        // the semantics tree and `performClick()` invoked NOTHING because the item was
+        // disabled for the wedged `Reconnecting` surface. Asserting enablement first turns
+        // that silent no-op into a hard, legible failure.
         compose.onNodeWithTag(TMUX_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
             .assertExists()
+        // Capture the OPEN kebab BEFORE the enablement assertion, so the artifact exists for
+        // BOTH verdicts: on the unfixed gate it shows the greyed-out (disabled) Reconnect item
+        // the user cannot tap, and with the fix it shows the actionable one.
+        captureScreen("issue1953-02b-kebab-open-reconnect-enabled")
+        compose.onNodeWithTag(TMUX_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
+            .assertIsEnabled()
+            .assertHasClickAction()
+        compose.onNodeWithTag(TMUX_RECONNECT_BUTTON_TAG, useUnmergedTree = true)
             .performClick()
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    /**
+     * Issue #1953: wait for the DISPLAYED (debounced, #876) status to be `Reconnecting` — the
+     * status the screen's [com.pocketshell.core.connection.SessionSurfaceState], and therefore
+     * the kebab's enablement, is derived from. Both controller automatic-recovery states
+     * (`Reattaching` heal and the numbered ladder) project here.
+     */
+    private fun waitForDisplayedReconnecting(timeoutMillis: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (currentDisplayedStatus() is TmuxSessionViewModel.ConnectionStatus.Reconnecting) {
+                return true
+            }
+            SystemClock.sleep(100)
+        }
+        return currentDisplayedStatus() is TmuxSessionViewModel.ConnectionStatus.Reconnecting
+    }
+
+    /**
+     * Issue #1953 round 2: the AUTOMATIC ladder's own rung-scheduled signal. The ladder body
+     * records `reconnect_start{trigger=auto-reconnect, retryDelayMs}` immediately BEFORE its
+     * `delay(retryDelayMs)`, so this both proves a rung is genuinely parked and stamps the
+     * instant its backoff started.
+     */
+    private fun autoLadderRungsScheduled(): List<RecordedDiagnosticEvent> =
+        diagnostics.eventsNamed("reconnect_start")
+            .filter { it.fields["trigger"] == "auto-reconnect" && it.fields["retryDelayMs"] != null }
+
+    /**
+     * Issue #1953 round 2: the automatic ladder actually DIALLING. Distinct from
+     * [autoLadderRungsScheduled] — a rung that wakes from its `delay(...)` re-dials WITHIN the
+     * same loop iteration, so it never re-emits a rung-scheduled event; it emits the
+     * connect-attempt `reconnect_start{requestedTrigger=auto-reconnect}`. That is the event a
+     * surviving (uncancelled) rung produces when it tears the recovered session down.
+     */
+    private fun autoLadderDials(): List<RecordedDiagnosticEvent> =
+        diagnostics.eventsNamed("reconnect_start")
+            .filter { it.fields["requestedTrigger"] == "auto-reconnect" }
+
+    private data class ParkedRung(val retryDelayMs: Long, val observedAtMs: Long)
+
+    private fun awaitParkedLadderRung(timeoutMillis: Long): ParkedRung {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val rung = autoLadderRungsScheduled().firstOrNull()
+            if (rung != null) {
+                return ParkedRung(
+                    retryDelayMs = (rung.fields["retryDelayMs"] as Number).toLong(),
+                    observedAtMs = SystemClock.elapsedRealtime(),
+                )
+            }
+            SystemClock.sleep(100)
+        }
+        throw AssertionError(
+            "issue #1953: the automatic ladder never scheduled a rung, so the wedged state " +
+                "this journey depends on was never entered. reconnect_start events=" +
+                diagnostics.eventsNamed("reconnect_start").map { it.fields },
+        )
+    }
+
+    private fun waitForDiagnostic(
+        name: String,
+        timeoutMillis: Long,
+    ): List<RecordedDiagnosticEvent> {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (diagnostics.eventsNamed(name).isNotEmpty()) break
+            SystemClock.sleep(100)
+        }
+        return diagnostics.eventsNamed(name)
     }
 
     private fun waitForConnectionLostIndicator(timeoutMillis: Long): Boolean {
@@ -342,6 +628,28 @@ class ReconnectKebabInPlaceJourneyE2eTest {
         return status
     }
 
+    /** The status the SCREEN renders (debounced, #876) — the kebab's enablement source. */
+    private fun currentDisplayedStatus(): TmuxSessionViewModel.ConnectionStatus {
+        var status: TmuxSessionViewModel.ConnectionStatus =
+            TmuxSessionViewModel.ConnectionStatus.Idle
+        compose.activityRule.scenario.onActivity { activity ->
+            status = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .displayConnectionStatus
+                .value
+        }
+        return status
+    }
+
+    private fun currentCanReconnect(): Boolean {
+        var canReconnect = false
+        compose.activityRule.scenario.onActivity { activity ->
+            canReconnect = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .canReconnect
+                .value
+        }
+        return canReconnect
+    }
+
     private fun waitForVisibleTerminal(
         label: String,
         timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
@@ -455,22 +763,138 @@ class ReconnectKebabInPlaceJourneyE2eTest {
         file.writeText(
             buildString {
                 appendLine("test=ReconnectKebabInPlaceJourneyE2eTest")
-                appendLine("issue=993")
+                appendLine("issues=#993,#1953")
                 appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
                 appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
                 appendLine("session=$SESSION_NAME")
                 appendLine(
-                    "scenario=attach a live session, drop it via the clean-passive seam, then " +
-                        "open the kebab and tap the new Reconnect item",
+                    "scenario=attach a live session, WEDGE automatic recovery (1ms passive " +
+                        "grace + a ${WEDGED_LADDER_DELAY_MS}ms x $LADDER_RUNGS ladder), drop it " +
+                        "via the clean-passive seam, wait for the wedged Reconnecting state, " +
+                        "then open the kebab and tap Reconnect",
                 )
                 appendLine(
-                    "expectation=the SAME session recovers to Connected in place (fresh `-CC` " +
-                        "client, no switch dance) and a post-reconnect send round-trips",
+                    "expectation=the kebab Reconnect item is ENABLED + clickable in the wedged " +
+                        "Reconnecting state; one tap emits exactly one reconnect_tapped " +
+                        "(trigger=reconnect) and exactly one trigger=reconnect job; the SAME " +
+                        "session recovers to Connected in place on a fresh `-CC` client (no " +
+                        "switch dance) and a post-reconnect send round-trips; and the tap " +
+                        "PREEMPTED the parked ladder rung — held past that rung's wake " +
+                        "instant, the same `-CC` client is still installed, the session is " +
+                        "still Connected, no second automatic job started, and a further send " +
+                        "still round-trips",
+                )
+                appendLine("wedged_ladder_delay_ms=$WEDGED_LADDER_DELAY_MS")
+                appendLine("wedged_ladder_rungs=$LADDER_RUNGS")
+                appendLine("max_observable_wedge_backoff_ms=$MAX_OBSERVABLE_WEDGE_BACKOFF_MS")
+                appendLine("preemption_margin_past_wake_ms=$PREEMPTION_MARGIN_MS")
+                appendLine(
+                    "auto_ladder_rungs_scheduled=" +
+                        autoLadderRungsScheduled().map { it.fields["retryDelayMs"] },
+                )
+                // 0 in a passing run: the parked rung was preempted before it ever dialled.
+                appendLine("auto_ladder_dials_total=" + autoLadderDials().size)
+                timings.forEach { appendLine(it) }
+                appendLine(
+                    "reconnect_tapped=" +
+                        diagnostics.eventsNamed("reconnect_tapped").map { it.fields["trigger"] },
+                )
+                appendLine(
+                    "reconnect_start_triggers=" +
+                        diagnostics.eventsNamed("reconnect_start")
+                            .map { it.fields["requestedTrigger"] ?: it.fields["trigger"] },
+                )
+                appendLine(
+                    "reconnect_success=" +
+                        diagnostics.eventsNamed("reconnect_success").map { it.fields["trigger"] },
+                )
+                appendLine(
+                    "auto_reconnect_decisions=" +
+                        diagnostics.eventsNamed("auto_reconnect_decision")
+                            .map { it.fields["decision"] },
                 )
             },
         )
         println("ISSUE993_SUMMARY ${file.absolutePath}")
         return file
+    }
+
+    /**
+     * Issue #1953 (terminal-artifact review): capture the AUTHORITATIVE terminal viewport
+     * bitmap + the visible transcript text at each stage, so the review can inspect the real
+     * terminal content instead of a full-device screenshot.
+     */
+    private fun captureViewport(name: String) {
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        var terminalPresent = false
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            terminalPresent = true
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { captured ->
+            writeBitmap("$name-viewport", captured)
+            captured.recycle()
+        }
+        val transcript = visibleTerminalText()
+        val textFile = artifactFile("$name-visible-terminal.txt")
+        textFile.writeText(
+            if (terminalPresent) {
+                transcript
+            } else {
+                // Not a blank/stale authoritative capture: during the wedged Reconnecting
+                // hold the surface intentionally paints the centered "Attaching…" placeholder
+                // and the Termux TerminalView is NOT in the tree, so there is no terminal
+                // viewport to render. The full-screen capture below is the evidence for this
+                // stage; the terminal viewport artifacts bracket it (01 attached / 03
+                // recovered).
+                "NO_TERMINAL_VIEW_ATTACHED terminal_view_present=false " +
+                    "displayed_status=${currentDisplayedStatus()} " +
+                    "raw_status=${currentConnectionStatus()} " +
+                    "can_reconnect=${currentCanReconnect()}\n"
+            },
+        )
+        println("ISSUE1953_TEXT ${textFile.absolutePath}")
+        // A full-screen capture at every stage so the reviewer can see the actual app screen
+        // (the "Reconnecting" chrome for the wedged stage, where no terminal view exists).
+        captureScreen(name)
+    }
+
+    /**
+     * Full-SCREEN (advisory) capture of the real device screen at this stage. Uses
+     * `UiAutomation.takeScreenshot()` rather than a decorView draw, because the kebab is a
+     * `DropdownMenu` in its OWN popup window — a decorView capture would miss the very menu
+     * this journey is about.
+     */
+    private fun captureScreen(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        val bitmap: Bitmap = instrumentation.uiAutomation.takeScreenshot() ?: return
+        writeBitmap("$name-screen", bitmap)
+        bitmap.recycle()
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE1953_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun recordTiming(name: String, value: Long) {
+        val line = "$name=$value"
+        timings += line
+        println("ISSUE1953_TIMING $line")
     }
 
     private fun artifactFile(name: String): File {
@@ -503,8 +927,37 @@ class ReconnectKebabInPlaceJourneyE2eTest {
         const val READY_MARKER: String = "ISSUE993-READY"
         const val MARKER: String = "issue993reconnect"
 
+        // Issue #1953 round 2: the ladder rung the wedge parks on. It must satisfy BOTH
+        // halves, and round 1 only satisfied one:
+        //  - long enough to be genuinely WEDGED: the rung must still be parked (nothing on
+        //    the wire, the user with no other way out) when the kebab is opened and tapped,
+        //    and still parked when the manual recovery completes;
+        //  - short enough to be OBSERVABLE: an UNCANCELLED rung must wake INSIDE this
+        //    journey, or the "one tap preempts the automatic job" limb of AC2 is green
+        //    whether or not the ladder was cancelled. Round 1's 600_000ms rung was ~10
+        //    minutes from waking and nothing after the tap could ever contradict it.
+        // Jitter is +/-20% (`ConnectionController.RETRY_JITTER_FRACTION`).
+        val WEDGED_LADDER_DELAY_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 30_000L
+        const val LADDER_RUNGS: Int = 6
+
+        /**
+         * Upper bound on the observed (post-jitter) backoff the wedge may park on — 1.35x the
+         * nominal rung. Restore a long ladder and the journey fails LOUDLY at the fixture
+         * instead of passing over assertions that can no longer fire.
+         */
+        val MAX_OBSERVABLE_WEDGE_BACKOFF_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 61_000L else 41_000L
+
+        /** How far PAST the preempted rung's wake instant the survival assertions are held. */
+        const val PREEMPTION_MARGIN_MS: Long = 6_000L
+
         val DROP_DETECT_WINDOW_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 12_000L
+        val WEDGE_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 40_000L else 20_000L
+        val TAP_DIAGNOSTIC_WINDOW_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 15_000L else 8_000L
         val RECOVER_WINDOW_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 45_000L
         val ROUND_TRIP_WINDOW_MS: Long =

--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1953ManualReconnectPreemptsWedgedLadderIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1953ManualReconnectPreemptsWedgedLadderIntegrationTest.kt
@@ -1,0 +1,813 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.diagnostics.RecordingDiagnosticEventSink
+import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.connection.SessionSurfaceState
+import com.pocketshell.core.connection.sessionSurfaceState
+import com.pocketshell.core.connection.targetIdOrNull
+import com.pocketshell.core.ssh.DefaultSshLeaseConnector
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxClientDiagnosticSink
+import com.pocketshell.core.tmux.TmuxClientDiagnostics
+import com.pocketshell.core.tmux.TmuxClientFactory
+import java.io.File
+import java.io.IOException
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Issue #1953 D34 companion — **the manual escape hatch must preempt a WEDGED automatic
+ * ladder, on a real transport.**
+ *
+ * ## What is different from the #1952 companion
+ *
+ * `Issue1952TypedPassiveDropRealTransportIntegrationTest` drives the manual entrypoint only
+ * AFTER the automatic ladder has terminalised (`reconnect_gave_up` → `Unreachable`). That is
+ * a quiescent machine. #1953's reported defect is the opposite state: automatic recovery is
+ * STILL OWNED and asleep between rungs (`ConnectionState.Reconnecting`), the user is looking
+ * at a "Reconnecting" surface that will not move for the whole backoff, and the kebab escape
+ * hatch is the only way out. This test therefore holds the controller IN automatic recovery
+ * and invokes the manual intent THERE.
+ *
+ * ## The fixture that creates the reported state (G10 — a happy fixture proves nothing)
+ *
+ *  1. A real Docker `agents` fixture, a real attach, a real pre-drop marker round-trip.
+ *  2. The auto-reconnect ladder is re-installed with a [WEDGED_LADDER_DELAY_MS] backoff, so
+ *     once the ladder is entered it PARKS in `delay(retryDelayMs)` — a physically wedged
+ *     ladder, not a simulated one — while STILL waking inside this test's observation window
+ *     if nothing cancels it (see [MAX_OBSERVABLE_WEDGE_BACKOFF_MS]).
+ *  3. The lease connector is held down and the fixture's authenticated `sshd` children are
+ *     KILLED from inside the container (peer-side; the app never calls close/disconnect), so
+ *     the real sshj/tmux reader dies and the bounded passive-grace recovery genuinely fails
+ *     and escalates into that ladder.
+ *
+ * ## The load-bearing assertions (G6 — the symptom-defining signals, not a seam)
+ *
+ *  - **The gate, against a physically-produced state (RED on base).** At the wedged moment
+ *    the test fuses the VM's REAL `revealState` + REAL `connectionStatus` through the
+ *    production `sessionSurfaceState(...)` and asserts (a) it is
+ *    [SessionSurfaceState.Reconnecting] — the reported state — and (b) the production
+ *    predicate `reconnectKebabEnabled(...)` says the escape hatch is actionable. On the
+ *    unfixed gate (b) is false: the escape hatch is locked out exactly when it is needed.
+ *  - **Preemption on the real transport.** After invoking the PUBLIC
+ *    [TmuxSessionViewModel.reconnect] intent, the controller reaches `Live` over exactly ONE
+ *    new successful SSH handshake, with different `SshSession` / sshj `SSHClient` /
+ *    `Transport` / [TmuxClient] identities — a real transport replacement, never a stale hold.
+ *  - **Same session.** The recovered pane's transcript still carries the pre-drop marker AND
+ *    a fresh post-reconnect marker round-trips through the replaced channel.
+ *  - **One job, not two — asserted PAST the preempted rung's wake instant (round 2).** The
+ *    parked rung's absolute wake instant is upper-bounded from the LADDER's own
+ *    rung-scheduled stamp (`rungScheduledObservedAtMs + retryDelayMs`), the fixture is guarded
+ *    to park only on a rung short enough for that instant to fall inside this test, and the
+ *    assertions are held past it:
+ *    exactly one `reconnect_tapped`, exactly two handshakes, no further dial ATTEMPT, still
+ *    `Live`, and the manually-recovered [TmuxClient] still the installed one.
+ *
+ *    This is what round 1 got wrong. It wedged with a 600_000ms x 6 ladder and asserted
+ *    non-duplication over a 5s settle, so the parked rung was ~524s from waking: green
+ *    identically with and without [TmuxSessionViewModel]'s
+ *    `startReconnectForSendBody -> autoReconnectJob?.cancel()`. It is not a formality — the
+ *    ladder body re-checks `connectionManager.state` only at the TOP of its loop, so an
+ *    uncancelled rung waking after a successful manual reconnect runs
+ *    `closeCurrentConnectionAndJoin(...)` + `runConnect(...)` against a HEALTHY session and
+ *    tears it back down.
+ *
+ * Hard Docker gate: it never skips when Docker is missing and never substitutes a callback
+ * count for the real reader/transport signals.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue1953ManualReconnectPreemptsWedgedLadderIntegrationTest {
+
+    private val projectRoot: Path by lazy { findProjectRoot() }
+    private var container: GenericContainer<*>? = null
+    private var mainDispatcher: ExecutorCoroutineDispatcher? = null
+
+    @Before
+    fun setUpMain() {
+        mainDispatcher = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "issue1953-main").apply { isDaemon = true }
+        }.asCoroutineDispatcher()
+        Dispatchers.setMain(requireNotNull(mainDispatcher))
+    }
+
+    @After
+    fun tearDownMain() {
+        TmuxClientDiagnostics.install(TmuxClientDiagnosticSink.Noop)
+        runCatching { container?.stop() }
+        container = null
+        Dispatchers.resetMain()
+        mainDispatcher?.close()
+        mainDispatcher = null
+    }
+
+    @Test
+    fun manualReconnectPreemptsAWedgedLadderAndReplacesTheRealTransport() = runBlocking {
+        startDockerOrFail()
+        val fixture = requireNotNull(container)
+        val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val connector = SustainedOutageLeaseConnector(DefaultSshLeaseConnector())
+        val leaseManager = SshLeaseManager(
+            connector = connector,
+            scope = ioScope,
+            idleTtlMillis = 60_000L,
+        )
+        val diagnostics = installRecordingDiagnosticSink()
+        val tmuxDiagnostics = RecordingTmuxDiagnostics().also { TmuxClientDiagnostics.install(it) }
+        var vm: TmuxSessionViewModel? = null
+        try {
+            seedSession()
+            vm = TmuxSessionViewModel(
+                tmuxClientFactory = TmuxClientFactory(ioScope),
+                activeTmuxClients = ActiveTmuxClients(),
+                sshLeaseManager = leaseManager,
+            )
+            // HARNESS ARTIFACT, not a product behaviour (issue #1953 round 2). The #886
+            // blank-pane watchdog surfaces `Unreachable` ("Session attach stalled") when the
+            // active pane renders no frame for 20 x 500ms on a Connected channel. This is a
+            // HEADLESS harness: there is no TerminalView, so the pane's visible screen is
+            // ALWAYS blank (`black_frame_observed ... renderedChars=0`) and the watchdog
+            // exhausts ~10s after EVERY attach regardless of transport health. Round 1 never
+            // saw it only because its 5s settle finished first; the round-2 hold outlives it.
+            // Suppressing the auto-arm is the established convention for a headless VM harness
+            // (`TmuxSessionWarmOpenTest`, `ReseedBlankWatchdogCharacterizationTest`,
+            // `Issue1495WatchdogCoverageTest`, ...). Nothing on the transport/lease/ladder path
+            // under test is touched, and session health is still asserted DIRECTLY below from
+            // the real transport: SSH/client identities, `disconnected`, controller state, and
+            // real `capture-pane` marker round-trips — never from the blank-pane proxy.
+            vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+            vm.connect(
+                hostId = HOST_ID,
+                hostName = "issue1953-docker",
+                host = fixture.host,
+                port = fixture.getMappedPort(SSH_PORT),
+                user = SSH_USER,
+                keyPath = privateKeyFile.absolutePath,
+                passphrase = null,
+                sessionName = SESSION_NAME,
+            )
+            awaitCondition(INITIAL_CONNECT_TIMEOUT_MS, "initial VM Live attach") {
+                vm.connectionControllerStateForTest() is ConnectionState.Live &&
+                    vm.liveTmuxClientForSendOrNullForTest() != null &&
+                    vm.panes.value.isNotEmpty()
+            }
+            awaitCondition(INITIAL_CONNECT_TIMEOUT_MS, "initial connect job completion") {
+                !vm.connectJobActiveForTest()
+            }
+            assertEquals("precondition: exactly one initial SSH handshake", 1, connector.successfulConnectCount)
+
+            val firstClient = requireNotNull(vm.liveTmuxClientForSendOrNullForTest())
+            val firstClientHash = System.identityHashCode(firstClient)
+            val firstSshIdentity = currentSshIdentity(vm)
+            val beforeMarker = "ISSUE1953-BEFORE-${System.nanoTime().toString(36)}"
+            sendAndAwaitMarker(firstClient, beforeMarker)
+
+            // ---- Build the WEDGE: a ladder that parks, a grace that cannot heal ----
+            // A very long backoff means that once the ladder is entered it sits in
+            // `delay(retryDelayMs)` with nothing on the wire. That IS the maintainer's
+            // reported state: a "Reconnecting" surface that will not move on its own.
+            vm.setAutoReconnectDelaysForTest(List(LADDER_RUNGS) { WEDGED_LADDER_DELAY_MS })
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = PASSIVE_GRACE_MS,
+                silentReattachTimeoutMs = REATTACH_TIMEOUT_MS,
+            )
+            connector.outageActive = true
+
+            val killedPeerPids = killAuthenticatedSshdProcessesFromServer()
+            assertTrue("the Docker peer fault must kill at least one sshd process", killedPeerPids.isNotEmpty())
+
+            val readerExit = awaitReaderExit(tmuxDiagnostics, firstClientHash)
+            val readerReason = readerExit["disconnectReason"] as? String
+            assertTrue(
+                "D34: the wedge must start from a REAL remote reader death, never an " +
+                    "ExplicitClose; exit=$readerExit",
+                readerReason == "reader_eof" || readerReason == "reader_exception",
+            )
+
+            // ---- HOLD in automatic recovery: the controller owns recovery and is asleep ----
+            awaitCondition(WEDGE_TIMEOUT_MS, "controller parked in automatic recovery") {
+                vm.connectionControllerStateForTest() is ConnectionState.Reconnecting
+            }
+            val wedgedState = vm.connectionControllerStateForTest()
+            assertTrue(
+                "precondition: the controller must OWN automatic recovery at the moment the " +
+                    "user reaches for the escape hatch; state=$wedgedState",
+                wedgedState is ConnectionState.Reconnecting,
+            )
+            val parkedRung = wedgedState as ConnectionState.Reconnecting
+
+            // ---- Anchor the parked rung IN TIME, on the LADDER's own stamp ----
+            // The wake instant must be an UPPER bound or the hold below can stop short of it
+            // and observe nothing. The controller reaches `Reconnecting` BEFORE the ladder
+            // coroutine does (`reconnect_failed` -> reconnecting at journal seq 12, then
+            // `reconnect_ladder_entered` at seq 14), so stamping the controller state yields a
+            // LOWER bound — measured 2.5s short on this box, which would silently shrink the
+            // discriminating window. The ladder emits `reconnect_start{trigger=auto-reconnect,
+            // retryDelayMs}` from `recordReconnectRungScheduled` IMMEDIATELY before its
+            // `delay(delayMs)`, and we observe that at-or-after it fires, so
+            // `observedAt + retryDelayMs` is a true upper bound on the wake.
+            var rungScheduled: Map<String, Any?>? = null
+            var rungScheduledObservedAtMs = 0L
+            awaitCondition(WEDGE_TIMEOUT_MS, "the ladder rung parked on its backoff") {
+                val hit = diagnostics.eventsNamed("reconnect_start")
+                    .map { it.fields }
+                    .firstOrNull { fields ->
+                        fields["trigger"] == "auto-reconnect" && fields["retryDelayMs"] != null
+                    }
+                if (hit != null && rungScheduled == null) {
+                    rungScheduled = hit
+                    rungScheduledObservedAtMs = System.currentTimeMillis()
+                }
+                rungScheduled != null
+            }
+            val parkedBackoffMs =
+                (requireNotNull(rungScheduled)["retryDelayMs"] as Number).toLong()
+            assertEquals(
+                "the ladder's parked rung must be the rung the controller is reporting",
+                parkedRung.retryDelayMs,
+                parkedBackoffMs,
+            )
+            // ---- G6 ANTI-VACUITY GUARD (issue #1953 round 2) ----
+            // Round 1 wedged the ladder with a 600_000ms x 6 backoff and then asserted
+            // non-duplication across a 5s settle. The parked rung was ~524s from waking, so
+            // that assertion was green IDENTICALLY with and without
+            // `TmuxSessionViewModel.startReconnectForSendBody`'s `autoReconnectJob?.cancel()`
+            // — it never constrained the property it was captioned with. The fixture must
+            // park on a rung SHORT enough that an uncancelled rung would wake INSIDE this
+            // test's observation window, and this guard fails loudly if anyone lengthens it
+            // back out of that window.
+            assertTrue(
+                "issue #1953 round 2 (G6): the wedge must park on a rung whose backoff is short " +
+                    "enough that an UNCANCELLED rung would wake inside this test's observation " +
+                    "window — otherwise the preemption assertion below cannot fail and is a " +
+                    "wrong-cost proxy. observed retryDelayMs=$parkedBackoffMs " +
+                    "(max=$MAX_OBSERVABLE_WEDGE_BACKOFF_MS, nominal rung=$WEDGED_LADDER_DELAY_MS " +
+                    "+/-${(ConnectionController.RETRY_JITTER_FRACTION * 100).toInt()}% jitter)",
+                parkedBackoffMs in 1..MAX_OBSERVABLE_WEDGE_BACKOFF_MS,
+            )
+            // Prove it is WEDGED (asleep), not mid-dial: the connector sees no new attempt
+            // across a window far longer than a rung would take if one were running.
+            val attemptsAtWedge = connector.connectCount
+            delay(WEDGE_QUIESCENCE_MS)
+            assertEquals(
+                "the automatic ladder must be PARKED on its backoff (no dial on the wire) — " +
+                    "that is the wedged window the user has no other way out of",
+                attemptsAtWedge,
+                connector.connectCount,
+            )
+            val stillWedged = vm.connectionControllerStateForTest()
+            assertTrue(
+                "the controller must still own automatic recovery after the quiescence window; " +
+                    "state=$stillWedged",
+                stillWedged is ConnectionState.Reconnecting,
+            )
+            assertEquals(
+                "the SAME rung must still be parked across the quiescence window, so the wake " +
+                    "instant computed above still describes the pending rung",
+                parkedRung.attempt,
+                (stillWedged as ConnectionState.Reconnecting).attempt,
+            )
+
+            // ---- THE GATE, against the physically-produced state (RED on base) ----
+            val surfaceAtWedge = fusedSurfaceState(vm)
+            assertTrue(
+                "precondition: the production fusion must render the reported Reconnecting " +
+                    "surface for a wedged ladder; surface=$surfaceAtWedge " +
+                    "reveal=${vm.revealState.value} status=${vm.connectionStatus.value}",
+                surfaceAtWedge is SessionSurfaceState.Reconnecting,
+            )
+            assertTrue(
+                "precondition: the VM must still know a target to reconnect to",
+                vm.canReconnect.value,
+            )
+            assertTrue(
+                "ISSUE #1953: the kebab Reconnect escape hatch must be ACTIONABLE while the " +
+                    "automatic ladder is wedged. On the unfixed gate this is false, so the " +
+                    "menu item is greyed out and the tap invokes nothing — no reconnect_tapped, " +
+                    "no manual trigger, no transport replacement (exact-main run 30787372084). " +
+                    "surface=$surfaceAtWedge",
+                reconnectKebabEnabled(
+                    canReconnect = vm.canReconnect.value,
+                    surfaceState = surfaceAtWedge,
+                ),
+            )
+
+            // ---- The user taps it: the PUBLIC manual intent, invoked in the wedged state ----
+            connector.outageActive = false
+            val tappedBefore = manualReconnectTaps(diagnostics).size
+            assertEquals("precondition: no manual reconnect yet", 0, tappedBefore)
+            val tapAtMs = System.currentTimeMillis()
+            assertTrue(
+                "the explicit manual Reconnect intent must be accepted while the automatic " +
+                    "ladder owns recovery",
+                withContext(Dispatchers.Main.immediate) { vm.reconnect() },
+            )
+
+            awaitCondition(RECOVERY_TIMEOUT_MS, "manual-intent recovery to Live on a fresh client") {
+                vm.connectionControllerStateForTest() is ConnectionState.Live &&
+                    vm.liveTmuxClientForSendOrNullForTest()?.let { client ->
+                        !client.disconnected.value && System.identityHashCode(client) != firstClientHash
+                    } == true
+            }
+
+            // ---- ONE new transport, not a stale hold and not two ladders ----
+            val recoveredCapturedAtMs = System.currentTimeMillis()
+            val recoveredClient = requireNotNull(vm.liveTmuxClientForSendOrNullForTest())
+            val recoveredSshIdentity = currentSshIdentity(vm)
+            assertNotEquals(
+                "the manual reconnect must install a DIFFERENT control client",
+                firstClientHash,
+                System.identityHashCode(recoveredClient),
+            )
+            assertNotEquals(
+                "the manual reconnect must install a different SshSession",
+                firstSshIdentity.session,
+                recoveredSshIdentity.session,
+            )
+            assertNotEquals(
+                "the manual reconnect must install a different sshj SSHClient",
+                firstSshIdentity.client,
+                recoveredSshIdentity.client,
+            )
+            assertNotEquals(
+                "the manual reconnect must install a different sshj Transport (the known-dead " +
+                    "transport is evicted, not reused)",
+                firstSshIdentity.transport,
+                recoveredSshIdentity.transport,
+            )
+            assertEquals(
+                "the initial attach plus EXACTLY ONE manual-recovery handshake",
+                2,
+                connector.successfulConnectCount,
+            )
+
+            val taps = manualReconnectTaps(diagnostics)
+            assertEquals("one tap must emit exactly one reconnect_tapped: $taps", 1, taps.size)
+            assertEquals(
+                "the manual tap must run through the single trigger=reconnect entrypoint",
+                "reconnect",
+                taps.single()["trigger"],
+            )
+
+            // ---- Same session: continuity across the replaced transport ----
+            val afterMarker = "ISSUE1953-AFTER-${System.nanoTime().toString(36)}"
+            sendAndAwaitMarker(recoveredClient, afterMarker)
+            val transcript = captureTranscript(recoveredClient)
+            assertTrue(
+                "the recovered pane must be the SAME session (pre-drop marker preserved)",
+                transcript.contains(beforeMarker),
+            )
+            assertTrue(
+                "a post-reconnect send must round-trip through the replaced channel",
+                transcript.contains(afterMarker),
+            )
+            assertFalse("the recovered client must remain connected", recoveredClient.disconnected.value)
+
+            // ---- THE PREEMPTION ASSERTION, held PAST the parked rung's wake instant ----
+            // The rung the manual intent preempted was due to wake at
+            // `wedgeObservedAtMs + parkedBackoffMs`. If `startReconnectForSendBody`'s
+            // `autoReconnectJob?.cancel()` did not fire, that rung is still holding a live
+            // coroutine which, on waking, runs `closeCurrentConnectionAndJoin(...)` +
+            // `runConnect(...)` with NO "already Live" re-check (TmuxSessionViewModel.kt
+            // ladder body) — it TEARS DOWN the healthy, manually-recovered session and dials
+            // a THIRD transport. Holding past that instant is what makes this assertion
+            // capable of failing.
+            val rungWakeByMs = rungScheduledObservedAtMs + parkedBackoffMs
+            assertTrue(
+                "issue #1953 round 2: the preempted rung must still have been PENDING when the " +
+                    "user tapped, or this assertion observes nothing. rungWakeBy=$rungWakeByMs " +
+                    "tapAt=$tapAtMs (remaining at tap=${rungWakeByMs - tapAtMs}ms)",
+                rungWakeByMs > tapAtMs,
+            )
+            assertTrue(
+                "issue #1953 round 2: the wake instant must fall in a CLEAN window AFTER the " +
+                    "recovered client was captured, so 'this exact client survived the wake' is " +
+                    "what the hold below observes. rungWakeBy=$rungWakeByMs " +
+                    "recoveredCapturedAt=$recoveredCapturedAtMs " +
+                    "(remaining after recovery=${rungWakeByMs - recoveredCapturedAtMs}ms)",
+                rungWakeByMs > recoveredCapturedAtMs,
+            )
+            val attemptsAfterRecovery = connector.connectCount
+            val holdUntilMs = rungWakeByMs + PREEMPTION_MARGIN_MS
+            // Trace the hold so the review can SEE the wake instant pass with the session
+            // untouched, rather than inferring it from a single end-of-window assertion.
+            val holdTrace = StringBuilder()
+            while (System.currentTimeMillis() < holdUntilMs) {
+                val now = System.currentTimeMillis()
+                holdTrace.append(
+                    "\n  t+${now - tapAtMs}ms " +
+                        "${if (now >= rungWakeByMs) "POST-WAKE" else "pre-wake "} " +
+                        "state=${vm.connectionControllerStateForTest()::class.simpleName} " +
+                        "clientDisconnected=${recoveredClient.disconnected.value} " +
+                        "connectorAttempts=${connector.connectCount} " +
+                        "handshakes=${connector.successfulConnectCount}",
+                )
+                delay(500L)
+            }
+            println("ISSUE1953_HOLD_TRACE (rung wake at t+${rungWakeByMs - tapAtMs}ms)$holdTrace")
+            val heldForMs = System.currentTimeMillis() - tapAtMs
+            assertEquals(
+                "the preempted automatic ladder must NOT wake up and dial a second transport " +
+                    "(held ${heldForMs}ms past the tap, ${PREEMPTION_MARGIN_MS}ms past the " +
+                    "parked rung's wake instant)",
+                2,
+                connector.successfulConnectCount,
+            )
+            assertEquals(
+                "the preempted ladder must not even ATTEMPT a dial after its rung's wake " +
+                    "instant (a failed wake dial is still a woken ladder)",
+                attemptsAfterRecovery,
+                connector.connectCount,
+            )
+            assertEquals(
+                "one tap must still be exactly one reconnect_tapped after the hold",
+                1,
+                manualReconnectTaps(diagnostics).size,
+            )
+            assertTrue(
+                "the session must still be Live after the parked rung's wake instant; " +
+                    "state=${vm.connectionControllerStateForTest()}",
+                vm.connectionControllerStateForTest() is ConnectionState.Live,
+            )
+            // The user-visible symptom of a surviving rung: the session they just got back is
+            // torn down again. Pin the recovered client's SURVIVAL, not just a dial count.
+            assertEquals(
+                "the manually-recovered `-CC` client must SURVIVE the parked rung's wake " +
+                    "instant — a surviving rung closes it and re-dials, which is the user " +
+                    "tapping Reconnect, getting their session back, and losing it again",
+                System.identityHashCode(recoveredClient),
+                vm.liveTmuxClientForSendOrNullForTest()?.let { System.identityHashCode(it) },
+            )
+            assertFalse(
+                "the manually-recovered client must not have been torn down by a woken rung",
+                recoveredClient.disconnected.value,
+            )
+
+            println(
+                "ISSUE1953_PREEMPTION parkedRungAttempt=${parkedRung.attempt} " +
+                    "parkedBackoffMs=$parkedBackoffMs rungScheduledObservedAtMs=$rungScheduledObservedAtMs " +
+                    "tapAtMs=$tapAtMs rungWakeByMs=$rungWakeByMs " +
+                    "remainingAtTapMs=${rungWakeByMs - tapAtMs} heldPastTapMs=$heldForMs",
+            )
+            println(
+                "ISSUE1953_REAL_TRANSPORT wedgedState=$wedgedState surfaceAtWedge=$surfaceAtWedge " +
+                    "reader=$readerExit peerKilledPids=$killedPeerPids " +
+                    "firstClient=$firstClientHash recoveredClient=${System.identityHashCode(recoveredClient)} " +
+                    "firstSsh=$firstSshIdentity recoveredSsh=$recoveredSshIdentity " +
+                    "connectorAttempts=${connector.connectCount} " +
+                    "connectorBlocked=${connector.blockedConnectCount} " +
+                    "connectorSucceeded=${connector.successfulConnectCount}",
+            )
+            println("ISSUE1953_REAL_TRANSCRIPT\n$transcript")
+        } finally {
+            println(
+                "ISSUE1953_FINAL_DIAGNOSTICS\n" +
+                    diagnostics.events
+                        .filter { event ->
+                            event.name == "reconnect_tapped" ||
+                                event.name == "reconnect_start" ||
+                                event.name == "reconnect_success" ||
+                                event.name == "auto_reconnect_decision" ||
+                                event.name == "silent_reattach_start" ||
+                                event.name == "silent_reattach_failed" ||
+                                // #1953 round 2: the signals that would betray a surviving
+                                // ladder rung (a dial after the wake instant) or a session
+                                // torn back down during the hold.
+                                event.name == "reconnect_rung_dial_attempt" ||
+                                event.name == "attach_reveal_stuck"
+                        }
+                        .joinToString("\n") { event -> "${event.category}/${event.name} ${event.fields}" },
+            )
+            connector.outageActive = false
+            vm?.cancelOwnScopesForTest()
+            vm?.clearForTest()
+            runCatching { cleanupSession() }
+            diagnostics.close()
+            TmuxClientDiagnostics.install(TmuxClientDiagnosticSink.Noop)
+            leaseManager.close()
+            ioScope.cancel()
+        }
+    }
+
+    /**
+     * Fuse the VM's REAL reveal state and REAL connection status through the SAME production
+     * reducer the session screen runs (`rememberTmuxSessionConnectionRuntime`), so the gate is
+     * evaluated against a physically-produced surface state, not a hand-built one.
+     */
+    private fun fusedSurfaceState(vm: TmuxSessionViewModel): SessionSurfaceState {
+        val reveal = vm.revealState.value
+        return sessionSurfaceState(
+            reveal = reveal,
+            phase = connectionPhaseOf(vm.connectionStatus.value),
+            targetId = reveal.targetIdOrNull(),
+        )
+    }
+
+    private fun manualReconnectTaps(
+        diagnostics: RecordingDiagnosticEventSink,
+    ): List<Map<String, Any?>> =
+        diagnostics.eventsNamed("reconnect_tapped").map { it.fields }
+
+    private fun startDockerOrFail() {
+        check(DockerClientFactory.instance().isDockerAvailable) {
+            "#1953 D34 hard gate requires Docker; start Docker and rerun"
+        }
+        val imageName = "pocketshell-test:agents-issue1953"
+        val build = ProcessBuilder(
+            "docker",
+            "build",
+            "-t",
+            imageName,
+            "-f",
+            projectRoot.resolve("tests/docker/Dockerfile.agents").toString(),
+            projectRoot.toString(),
+        ).redirectErrorStream(true).start()
+        val output = build.inputStream.bufferedReader().readText()
+        check(build.waitFor() == 0) { "Failed to build $imageName:\n$output" }
+        container = GenericContainer(DockerImageName.parse(imageName))
+            .withExposedPorts(SSH_PORT)
+            .also { it.start() }
+    }
+
+    private suspend fun seedSession() {
+        connectFixture().use { session ->
+            val command =
+                "tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true; " +
+                    "tmux new-session -d -s '$SESSION_NAME' 'exec sh -i'"
+            val result = session.exec(command)
+            check(result.exitCode == 0) { "seed failed: $result" }
+        }
+    }
+
+    private suspend fun cleanupSession() {
+        connectFixture().use { session ->
+            session.exec("tmux kill-session -t '$SESSION_NAME' 2>/dev/null || true")
+        }
+    }
+
+    private suspend fun connectFixture(): SshSession {
+        val fixture = requireNotNull(container)
+        return SshConnection.connect(
+            host = fixture.host,
+            port = fixture.getMappedPort(SSH_PORT),
+            user = SSH_USER,
+            key = SshKey.Path(privateKeyFile),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).getOrThrow()
+    }
+
+    /**
+     * Kill the authenticated fixture-side sshd processes while leaving the container, the
+     * listening sshd and the tmux server alive. Docker exec is the peer-side control plane;
+     * it never touches the app's sshj client or its local socket.
+     */
+    private fun killAuthenticatedSshdProcessesFromServer(): List<Int> {
+        val fixture = requireNotNull(container)
+        val result = fixture.execInContainer(
+            "sh",
+            "-lc",
+            """
+                pids="${'$'}(ps -eo pid=,comm=,args= | awk '(${'$'}2 == "sshd" || ${'$'}2 == "sshd-session") && index(${'$'}0, ": $SSH_USER") { print ${'$'}1 }')"
+                test -n "${'$'}pids" || {
+                    echo "NO_AUTHENTICATED_SSHD process table follows" >&2
+                    ps -eo pid=,comm=,args= >&2
+                    exit 41
+                }
+                echo "KILLED_PIDS=${'$'}pids"
+                for pid in ${'$'}pids; do kill -KILL "${'$'}pid" 2>/dev/null || true; done
+            """.trimIndent(),
+        )
+        check(result.exitCode == 0) {
+            "D34 peer-side sshd kill failed exit=${result.exitCode} stdout=${result.stdout} stderr=${result.stderr}"
+        }
+        val rawPids = result.stdout.lineSequence()
+            .firstOrNull { it.startsWith("KILLED_PIDS=") }
+            ?.substringAfter('=')
+            .orEmpty()
+        val pids = rawPids.trim().split(Regex("\\s+")).mapNotNull(String::toIntOrNull)
+        check(pids.isNotEmpty()) { "D34 peer-side sshd kill reported no PIDs: ${result.stdout}" }
+        return pids
+    }
+
+    /** Test-only identity probe; no production API is added for this D34 assertion. */
+    private fun currentSshIdentity(vm: TmuxSessionViewModel): SshObjectIdentity {
+        val sessionField = TmuxSessionViewModel::class.java.getDeclaredField("sessionRef").apply {
+            isAccessible = true
+        }
+        val session = checkNotNull(sessionField.get(vm)) { "D34 requires a real SshSession" }
+        val clientField = session.javaClass.getDeclaredField("client").apply { isAccessible = true }
+        val client = checkNotNull(clientField.get(session)) { "D34 requires a real sshj SSHClient" }
+        val transport = checkNotNull(client.javaClass.getMethod("getTransport").invoke(client)) {
+            "D34 requires a real sshj Transport"
+        }
+        return SshObjectIdentity(
+            session = System.identityHashCode(session),
+            client = System.identityHashCode(client),
+            transport = System.identityHashCode(transport),
+        )
+    }
+
+    private data class SshObjectIdentity(
+        val session: Int,
+        val client: Int,
+        val transport: Int,
+    )
+
+    private suspend fun sendAndAwaitMarker(client: TmuxClient, marker: String) {
+        val response = client.sendKeysViaExec(
+            "send-keys -t '$SESSION_NAME' 'printf \\\"$marker\\\\n\\\"' Enter",
+        )
+        assertTrue("send-keys failed for $marker: ${response.output}", !response.isError)
+        awaitCondition(MARKER_TIMEOUT_MS, "marker $marker in real pane") {
+            runCatching { captureTranscript(client).contains(marker) }.getOrDefault(false)
+        }
+    }
+
+    private suspend fun captureTranscript(client: TmuxClient): String {
+        val response = client.capturePaneTextViaExec(
+            SESSION_NAME,
+            timeoutMs = 4_000L,
+            scrollbackLines = 200,
+        )
+        check(!response.isError) { "capture-pane failed: ${response.output}" }
+        return response.output.joinToString("\n")
+    }
+
+    private suspend fun awaitReaderExit(
+        diagnostics: RecordingTmuxDiagnostics,
+        clientHash: Int,
+    ): Map<String, Any?> {
+        var match: Map<String, Any?>? = null
+        awaitCondition(READER_EXIT_TIMEOUT_MS, "real tmux reader exit") {
+            match = diagnostics.events
+                .filter { it.first == "tmux_client_reader_exit" }
+                .map { it.second }
+                .firstOrNull { it["clientHash"] == clientHash }
+            match != null
+        }
+        return requireNotNull(match)
+    }
+
+    private suspend fun awaitCondition(
+        timeoutMs: Long,
+        label: String,
+        condition: suspend () -> Boolean,
+    ) {
+        withTimeout(timeoutMs) {
+            while (!condition()) delay(50L)
+        }
+        assertTrue("condition must hold after wait: $label", condition())
+    }
+
+    private val privateKeyFile: File
+        get() = projectRoot.resolve("tests/docker/test_key").toFile()
+
+    private fun findProjectRoot(): Path {
+        var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+        while (dir != null) {
+            if (dir.resolve("tests/docker/Dockerfile.agents").toFile().exists()) return dir
+            dir = dir.parent
+        }
+        error("Could not locate project root from ${System.getProperty("user.dir")}")
+    }
+
+    private class RecordingTmuxDiagnostics : TmuxClientDiagnosticSink {
+        val events = CopyOnWriteArrayList<Pair<String, Map<String, Any?>>>()
+
+        override fun record(event: String, fields: Map<String, Any?>) {
+            events += event to fields
+        }
+    }
+
+    /**
+     * Holds every manager-new SSH acquisition down while [outageActive], so the bounded
+     * passive-grace recovery genuinely fails and escalates into the (long-backoff) ladder
+     * instead of healing before the wedge can form.
+     */
+    private class SustainedOutageLeaseConnector(
+        private val delegate: SshLeaseConnector,
+    ) : SshLeaseConnector {
+        private val attempts = AtomicInteger(0)
+        private val blockedAttempts = AtomicInteger(0)
+        private val successfulAttempts = AtomicInteger(0)
+
+        @Volatile
+        var outageActive: Boolean = false
+
+        val connectCount: Int
+            get() = attempts.get()
+
+        val blockedConnectCount: Int
+            get() = blockedAttempts.get()
+
+        val successfulConnectCount: Int
+            get() = successfulAttempts.get()
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val attempt = attempts.incrementAndGet()
+            if (outageActive) {
+                blockedAttempts.incrementAndGet()
+                return Result.failure(IOException("synthetic sustained outage at connector attempt $attempt"))
+            }
+            return delegate.connect(target).also { result ->
+                if (result.isSuccess) successfulAttempts.incrementAndGet()
+            }
+        }
+    }
+
+    private companion object {
+        const val SSH_PORT = 22
+        const val SSH_USER = "testuser"
+        const val HOST_ID = 1953L
+        const val SESSION_NAME = "issue1953-wedged-ladder"
+
+        /**
+         * Issue #1953 round 2 — the ladder rung the wedge parks on.
+         *
+         * It has to satisfy BOTH halves of the fixture, and round 1 only satisfied one:
+         *
+         *  - **long enough to be genuinely WEDGED**: an entered rung must sit in
+         *    `delay(retryDelayMs)` with nothing on the wire across [WEDGE_QUIESCENCE_MS] AND
+         *    across the tap, so the user really has no other way out. Jitter is +/-20%
+         *    (`ConnectionController.RETRY_JITTER_FRACTION`), so the shortest possible rung is
+         *    9_600ms — 3.2x the 3_000ms quiescence window.
+         *  - **short enough to be OBSERVABLE**: an UNCANCELLED rung must wake INSIDE this
+         *    test's observation window, or the preemption assertion is green whether or not
+         *    the manual intent cancelled the ladder (the round-1 defect: a 600_000ms rung was
+         *    ~524s from waking under a 5s settle). The longest possible rung is 24_000ms, and
+         *    the test holds past it.
+         *
+         * 20_000ms leaves ~13-21s of backoff still pending at the tap, which comfortably
+         * outlasts the manual recovery + marker round-trip (~7s observed), so the wake instant
+         * falls in a CLEAN window after the recovered client was captured — asserted, not
+         * assumed, by the `rungWakeByMs > recoveredCapturedAtMs` guard.
+         */
+        const val WEDGED_LADDER_DELAY_MS = 20_000L
+        const val LADDER_RUNGS = 6
+
+        /**
+         * Upper bound on the observed (post-jitter) backoff the wedge may park on. Guards the
+         * round-1 defect mechanically: restore a long ladder and the test fails LOUDLY at the
+         * fixture instead of passing over an assertion that can no longer fire.
+         * `20_000 * 1.2 = 24_000`, so this is the jitter ceiling with headroom.
+         */
+        const val MAX_OBSERVABLE_WEDGE_BACKOFF_MS = 28_000L
+
+        /** How far PAST the parked rung's wake instant the preemption assertions are held. */
+        const val PREEMPTION_MARGIN_MS = 6_000L
+
+        /** Short bounded grace so the passive recovery escalates into the ladder quickly. */
+        const val PASSIVE_GRACE_MS = 2_000L
+        const val REATTACH_TIMEOUT_MS = 500L
+
+        const val INITIAL_CONNECT_TIMEOUT_MS = 30_000L
+        const val READER_EXIT_TIMEOUT_MS = 15_000L
+        const val WEDGE_TIMEOUT_MS = 30_000L
+
+        /** Far longer than a live rung would take — proves the ladder is asleep. */
+        const val WEDGE_QUIESCENCE_MS = 3_000L
+        const val RECOVERY_TIMEOUT_MS = 45_000L
+        const val MARKER_TIMEOUT_MS = 15_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
@@ -44,20 +44,51 @@ import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellType
 
 /**
- * Issue #993: whether the kebab's "Reconnect" item is actionable right now.
+ * Issue #993 / #1953: whether the kebab's "Reconnect" item is actionable right now.
  *
  * The manual reconnect escape hatch is the half-measure for a dropped session whose
- * auto-reconnect didn't fire. It is only meaningful when:
- *  - there IS a known target to reconnect to ([canReconnect] — the same gate the
- *    in-session Reconnect band uses, so a tap never silently no-ops), AND
- *  - a connect/reconnect is NOT already in flight (Connecting/Switching/Reconnecting),
- *    so the tap is never a redundant re-dial that would yank an already-recovering
- *    session.
+ * auto-reconnect didn't fire. It requires a known target to reconnect to ([canReconnect] —
+ * the same gate the in-session Reconnect band uses, so a tap never silently no-ops).
  *
- * A `Connected` (possibly stale) or `Failed`/`Idle` session with a target stays
+ * ## Issue #1953: the wedged-ladder lockout (the state the hatch EXISTS for)
+ *
+ * The original #993 gate ALSO disabled the item for [SessionSurfaceState.Reconnecting], on
+ * the reasoning that "a reconnect is already in flight, so a tap would be a redundant
+ * re-dial". That reasoning is wrong for this state, and it disabled the escape hatch in
+ * exactly the situation it was built for:
+ *
+ *  - [SessionSurfaceState.Reconnecting] is what BOTH controller automatic-recovery states
+ *    project to — the pre-numbered silent heal (`ConnectionState.Reattaching` → calm
+ *    attempt-1) and the numbered ladder (`ConnectionState.Reconnecting(n)`). See
+ *    `ConnectionStatusProjection`'s §1 seam table.
+ *  - The ladder spends most of its life ASLEEP in `delay(retryDelayMs)` between rungs, so
+ *    "Reconnecting" on screen is NOT "a dial is on the wire right now". A wedged ladder can
+ *    sit in this state indefinitely with nothing on the wire at all.
+ *  - Exact-main run 30787372084 caught the consequence: the journey failed both attempts
+ *    stuck in `Reconnecting(attempt=1)` — the kebab node was present in semantics but
+ *    disabled, so `performClick()` invoked nothing (no `reconnect_tapped`, no manual
+ *    trigger, no transport replacement).
+ *
+ * So an explicit manual Reconnect is treated as a HIGHER-PRIORITY user intent that PREEMPTS
+ * automatic recovery, routed through the SINGLE existing manual effect
+ * ([TmuxSessionViewModel.reconnect] → `TransportEffects.onManualReconnect()`, which cancels
+ * the auto ladder, forces a fresh lease that evicts the known-dead transport, and re-enters
+ * `connect(trigger = Reconnect)` — the #1072 dedup guard already exempts that trigger). No
+ * second reconnect implementation and no second retry ladder (D28).
+ *
+ * ## What stays protected (issue #1953 acceptance criterion 4)
+ *
+ *  - [SessionSurfaceState.Connecting] — the INITIAL cold dial. There is no prior session to
+ *    escape from; a tap would restart a handshake the user just started.
+ *  - [SessionSurfaceState.Attaching] — an ACTIVE target switch (warm same-host reveal).
+ *    Yanking an in-flight switch is the #890 redundant-chrome/regression class.
+ *
+ * A `Connected` (possibly stale) or `Failed`/`Gone`/`Idle` session with a target stays
  * enabled — that is exactly the maintainer's "it dropped but the app still thinks it's
  * connected / it's sitting on Failed and nothing recovers it" case the button exists for.
- * Pure so the wiring is a unit-testable predicate rather than an inline boolean (G9).
+ * Pure so the wiring is a unit-testable predicate rather than an inline boolean (G9); pinned
+ * by [com.pocketshell.app.tmux.Issue1953ManualReconnectEscapeHatchTest] and driven on the
+ * real path by `ReconnectKebabInPlaceJourneyE2eTest`.
  */
 internal fun reconnectKebabEnabled(
     canReconnect: Boolean,
@@ -65,8 +96,7 @@ internal fun reconnectKebabEnabled(
 ): Boolean =
     canReconnect &&
         surfaceState !is SessionSurfaceState.Connecting &&
-        surfaceState !is SessionSurfaceState.Attaching &&
-        surfaceState !is SessionSurfaceState.Reconnecting
+        surfaceState !is SessionSurfaceState.Attaching
 
 /**
  * Issue #750 (4th occurrence — the beyond-grace RECONNECT path): the single

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionMoreMenu.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionMoreMenu.kt
@@ -60,10 +60,14 @@ internal fun TmuxMoreMenu(
     // place (the manual escape hatch when auto-reconnect doesn't fire). Defaulted so
     // existing direct callers / tests of TmuxMoreMenu stay source-compatible.
     onReconnect: () -> Unit = {},
-    // Issue #993: gate the "Reconnect" item — disabled while there is no target to
-    // reconnect to OR a connect/reconnect is already in flight, so a tap is never a
-    // silent no-op nor a redundant re-dial. Defaulted true so existing callers/tests
-    // stay source-compatible.
+    // Issue #993/#1953: gate the "Reconnect" item — disabled while there is no target to
+    // reconnect to, or while the INITIAL cold dial / an ACTIVE target switch is in flight,
+    // so a tap is never a silent no-op nor a redundant re-dial. It stays ENABLED while
+    // automatic recovery is running (`Reconnecting`, which covers the controller's
+    // Reattaching heal AND its numbered ladder): an explicit manual Reconnect is a
+    // higher-priority user intent that PREEMPTS a wedged automatic ladder — see
+    // [reconnectKebabEnabled]. Defaulted true so existing callers/tests stay
+    // source-compatible.
     reconnectEnabled: Boolean = true,
 ) {
     DropdownMenu(
@@ -120,8 +124,10 @@ internal fun TmuxMoreMenu(
         // didn't fire — force an immediate reconnect of THIS session in place (no
         // session-switch dance), reusing the VM's single TransportEffects reconnect
         // entrypoint. On reconnect the #900 outbound queue auto-flushes the pending
-        // message. Disabled (greyed) when there is no target or a reconnect is already
-        // in flight so the tap is never a silent no-op / redundant re-dial.
+        // message. Issue #1953: it stays actionable while the automatic ladder is
+        // running/wedged (that is precisely when the user needs it) and is disabled
+        // (greyed) only when there is no target, or during the initial cold dial / an
+        // active target switch, so the tap is never a silent no-op / redundant re-dial.
         DropdownMenuItem(
             text = { Text("Reconnect") },
             onClick = onReconnect,

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1953ManualReconnectEscapeHatchTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1953ManualReconnectEscapeHatchTest.kt
@@ -1,0 +1,192 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.connection.ConnectionPhase
+import com.pocketshell.core.connection.FailureReason
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.SessionSurfaceState
+import com.pocketshell.core.connection.sessionSurfaceState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #1953 — **Manual Reconnect must preempt a WEDGED automatic ladder.**
+ *
+ * ## The reported defect
+ *
+ * In exact-main run 30787372084 `ReconnectKebabInPlaceJourneyE2eTest` failed BOTH attempts
+ * stuck in `Reconnecting(attempt=1)`. The kebab item existed in the semantics tree, but
+ * [reconnectKebabEnabled] disabled it for [SessionSurfaceState.Reconnecting], so
+ * `performClick()` invoked nothing: no `reconnect_tapped`, no manual trigger, no transport
+ * replacement. The action is documented as the escape hatch *for when automatic reconnect
+ * does not fire* — and the wedged automatic state disabled that very escape hatch.
+ *
+ * ## Why `Reconnecting` is the wedged state (not "already recovering")
+ *
+ * The controller projects BOTH of its automatic-recovery states onto the SAME view state:
+ * `ConnectionState.Reattaching` (the pre-numbered silent heal) and
+ * `ConnectionState.Reconnecting(n)` (the numbered ladder) both project to
+ * `ConnectionStatus.Reconnecting` (see `ConnectionStatusProjection`'s §1 seam table), which
+ * fuses to [SessionSurfaceState.Reconnecting]. So "Reconnecting" on screen does NOT mean "a
+ * dial is on the wire right now" — the ladder spends most of its life asleep in
+ * `delay(retryDelayMs)` between rungs, and a wedged ladder can sit there indefinitely. The
+ * old gate read that state as "a reconnect is already in flight, a tap would be redundant"
+ * and locked the user out for the whole window.
+ *
+ * ## The contract this pins
+ *
+ *  - [SessionSurfaceState.Reconnecting] with a target → **ENABLED** at every attempt number
+ *    (including the pre-numbered attempt-1 heal the controller's `Reattaching` projects to).
+ *    This is the escape hatch; it may never be an indefinitely disabled state.
+ *  - [SessionSurfaceState.Connecting] (the initial cold dial) → still disabled. There is no
+ *    prior session to escape from; a tap would restart a handshake the user just started.
+ *  - [SessionSurfaceState.Attaching] (an ACTIVE target switch / warm reveal) → still
+ *    disabled. Issue #1953's acceptance explicitly permits keeping the switch protected from
+ *    redundant taps, and yanking an in-flight switch is the #890 regression class.
+ *  - No target ([canReconnect] false) → disabled everywhere, so a tap is never a silent
+ *    no-op.
+ *
+ * The states are built through the REAL production fusion ([sessionSurfaceState] over a real
+ * [RevealState] + [ConnectionPhase]) wherever the fusion is what produces the reported state,
+ * so this is not a hand-built stand-in for a state production can't reach.
+ */
+class Issue1953ManualReconnectEscapeHatchTest {
+
+    private val sid = SessionId("host/work")
+
+    /**
+     * THE REGRESSION (red on the unfixed gate): the maintainer's reported state — a known
+     * target, the surface wedged in the automatic ladder — must expose an ENABLED escape
+     * hatch. Covers the pre-numbered heal (attempt 1, the `Reattaching` projection) and every
+     * numbered rung, because the ladder can wedge on any of them.
+     */
+    @Test
+    fun reconnectKebabEnabledWhileTheAutomaticLadderIsWedged() {
+        (1..MAX_ATTEMPTS).forEach { attempt ->
+            val wedged = SessionSurfaceState.Reconnecting(
+                targetId = sid,
+                targetName = "work",
+                host = "h",
+                port = 22,
+                user = "u",
+                attempt = attempt,
+                maxAttempts = MAX_ATTEMPTS,
+                // A wedged ladder is ASLEEP between rungs — a long backoff is exactly the
+                // window in which the user has no other way out.
+                retryDelayMs = 30_000L,
+            )
+            assertTrue(
+                "issue #1953: a wedged automatic ladder (attempt $attempt/$MAX_ATTEMPTS) must " +
+                    "NOT disable the manual Reconnect escape hatch — that is the state the " +
+                    "escape hatch exists for",
+                reconnectKebabEnabled(canReconnect = true, surfaceState = wedged),
+            )
+        }
+    }
+
+    /**
+     * Same regression, but the state is produced by the REAL production fusion from a
+     * reveal-machine hold + the controller's Reconnecting phase — the exact
+     * `(RevealState, ConnectionPhase) -> SessionSurfaceState` path the screen runs. This is
+     * the "controller Reattaching OR Reconnecting" limb of the acceptance criterion: both
+     * controller states project to [ConnectionPhase.Reconnecting], so both fuse here.
+     */
+    @Test
+    fun reconnectKebabEnabledForTheFusedControllerRecoveryState() {
+        listOf(
+            // The pre-numbered silent heal (controller `Reattaching` → calm attempt-1).
+            ConnectionPhase.Reconnecting("h", 22, "u", 1, MAX_ATTEMPTS, 0L),
+            // The numbered ladder asleep on its backoff (controller `Reconnecting(2)`).
+            ConnectionPhase.Reconnecting("h", 22, "u", 2, MAX_ATTEMPTS, 8_000L),
+        ).forEach { phase ->
+            val fused = sessionSurfaceState(
+                reveal = RevealState.Seeding(sid, "work"),
+                phase = phase,
+                targetId = sid,
+            )
+            assertTrue(
+                "precondition: the production fusion must produce the reported Reconnecting " +
+                    "surface for $phase, got $fused",
+                fused is SessionSurfaceState.Reconnecting,
+            )
+            assertTrue(
+                "issue #1953: the fused controller-recovery surface must enable the manual " +
+                    "Reconnect escape hatch ($phase)",
+                reconnectKebabEnabled(canReconnect = true, surfaceState = fused),
+            )
+        }
+    }
+
+    /**
+     * The other half of the contract (acceptance criterion 4): the initial cold dial and an
+     * ACTIVE target switch stay protected from a redundant tap. Widening the gate must not
+     * turn into "always enabled".
+     */
+    @Test
+    fun reconnectKebabStillProtectedDuringInitialConnectAndActiveSwitch() {
+        val protectedStates = mapOf(
+            "initial cold dial" to SessionSurfaceState.Connecting(sid, "work", "h", 22, "u"),
+            "active target switch / warm reveal" to
+                SessionSurfaceState.Attaching(sid, "work", "h", 22, "u"),
+        )
+        protectedStates.forEach { (label, state) ->
+            assertEquals(
+                "issue #1953: $label must stay protected from a redundant manual re-dial",
+                false,
+                reconnectKebabEnabled(canReconnect = true, surfaceState = state),
+            )
+        }
+        // And the same via the real fusion, so the protection is pinned on the states the
+        // screen actually produces (a cold `Connecting` phase and a `Warm` switch phase).
+        assertEquals(
+            "the fused cold-dial surface must stay protected",
+            false,
+            reconnectKebabEnabled(
+                canReconnect = true,
+                surfaceState = sessionSurfaceState(
+                    reveal = RevealState.Seeding(sid, "work"),
+                    phase = ConnectionPhase.Connecting("h", 22, "u"),
+                    targetId = sid,
+                ),
+            ),
+        )
+        assertEquals(
+            "the fused warm-switch surface must stay protected",
+            false,
+            reconnectKebabEnabled(
+                canReconnect = true,
+                surfaceState = sessionSurfaceState(
+                    reveal = RevealState.Seeding(sid, "work"),
+                    phase = ConnectionPhase.Warm("h", 22, "u"),
+                    targetId = sid,
+                ),
+            ),
+        )
+    }
+
+    /**
+     * Widening the gate must not make a targetless tap a silent no-op — including in the
+     * newly-enabled Reconnecting state.
+     */
+    @Test
+    fun reconnectKebabStillDisabledWithoutATarget() {
+        listOf(
+            SessionSurfaceState.Idle,
+            SessionSurfaceState.Reconnecting(sid, "work", "h", 22, "u", 1, MAX_ATTEMPTS, 0L),
+            SessionSurfaceState.Failed(sid, "work", FailureReason.Unreachable(retryable = true)),
+            SessionSurfaceState.Gone(sid, "work"),
+            SessionSurfaceState.Live(sid, "work", emptyList()),
+        ).forEach { state ->
+            assertEquals(
+                "no target → Reconnect disabled for $state (a tap must never be a silent no-op)",
+                false,
+                reconnectKebabEnabled(canReconnect = false, surfaceState = state),
+            )
+        }
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 4
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -2702,14 +2702,20 @@ class TmuxSessionScreenTest {
     }
 
     @Test
-    fun reconnectKebabDisabledWhileReconnectAlreadyInFlight() {
-        // A connect/reconnect is already running — a manual reconnect would be a
-        // redundant re-dial that yanks an already-recovering session, so the item is
-        // disabled even with a target present (AC: "sensible state mid-reconnect").
+    fun reconnectKebabDisabledWhileInitialConnectOrSwitchInFlight() {
+        // The INITIAL cold dial and an ACTIVE target switch are protected from a redundant
+        // re-dial that would yank a connect the user just started (AC: "sensible state
+        // mid-connect").
+        //
+        // Issue #1953 (D22 hard cut of the old contract): `Reconnecting` is deliberately NOT
+        // in this list any more. It is the state BOTH controller automatic-recovery states
+        // project to (`Reattaching` heal + numbered ladder), and the ladder is asleep between
+        // rungs — so disabling here locked the user out of the escape hatch for the whole
+        // wedged window (exact-main run 30787372084). See
+        // [Issue1953ManualReconnectEscapeHatchTest] for the positive contract.
         listOf(
             SessionSurfaceState.Connecting(sid, "work", "h", 22, "u"),
             SessionSurfaceState.Attaching(sid, "work", "h", 22, "u"),
-            SessionSurfaceState.Reconnecting(sid, "work", "h", 22, "u", 1, 3, 0L),
         ).forEach { state ->
             assertEquals(
                 "in-flight → Reconnect disabled for $state",
@@ -2717,6 +2723,13 @@ class TmuxSessionScreenTest {
                 reconnectKebabEnabled(canReconnect = true, surfaceState = state),
             )
         }
+        assertTrue(
+            "issue #1953: a wedged automatic ladder must keep the manual escape hatch actionable",
+            reconnectKebabEnabled(
+                canReconnect = true,
+                surfaceState = SessionSurfaceState.Reconnecting(sid, "work", "h", 22, "u", 1, 3, 0L),
+            ),
+        )
     }
 
     // ---- Issue #1672: hide the quick-command chip band while the terminal is held ----


### PR DESCRIPTION
Closes #1953. Parent: #1680 (EPIC: PocketShell still unusable). **Changes production code** on the D28 connection cluster.

## The defect

The kebab **Reconnect** is documented as the escape hatch for when automatic reconnect does not fire. `reconnectKebabEnabled` disabled it for `SessionSurfaceState.Reconnecting` — **the wedged state disabled the very escape hatch meant to rescue it.**

`Reconnecting` is the state *both* controller automatic-recovery states project to (the `Reattaching` heal and the numbered ladder), and the ladder spends most of its life asleep in `delay(retryDelayMs)`. The gate read that as "a reconnect is already in flight" and locked the user out for the entire wedged window.

In exact-main run 30787372084 the node existed in semantics but `performClick()` invoked nothing — no `reconnect_tapped`, no manual trigger, no transport replacement. Reviewer-reproduced verbatim: `Tag: 'tmux:session:reconnect-button' [Disabled] Actions = [OnClick]`.

Everything downstream of the tap was already correct — cancel-ladder, `reconnect_tapped`, fresh-lease eviction, the `trigger=Reconnect` dedup exemption. **Only the UI gate was wrong.**

## Round 1 was rejected, and the rejection mattered

Criterion 2's preemption assertion **could not fail**. The wedge used a `600_000 ms × 6` ladder while asserting over a 5 s settle; the reviewer's own run caught the parked rung at `retryDelayMs=523897` — ~524 s from waking. The assertion was green with or without `autoReconnectJob?.cancel()`.

Round 2 fixed it three ways: the wedge now parks on a rung sized to wake **inside** the test (20s D34 / 30s local / 45s CI); the wake instant is stamped from the ladder's own `reconnect_start{trigger=auto-reconnect, retryDelayMs}` rather than controller state; and two guards (`parkedBackoffMs <= MAX_OBSERVABLE_WEDGE_BACKOFF_MS`, `rungWakeByMs > recoveredCapturedAtMs`) **fail loudly if anyone lengthens the ladder back out of the window** — so round 1's exact defect cannot return silently. The reviewer confirmed that guard fires: restoring `600_000L` fails at the fixture with `observed retryDelayMs=516974 (max=28000…)`.

## A premise from round 1 that turned out to be wrong

Round 1 claimed enabling the kebab made the manual-vs-ladder interleaving reachable *for the first time*. The implementer disputed it; the re-reviewer settled it **against its own earlier position**: `sessionLive = rawStatus is ConnectionStatus.Connected`, and its wedged-stage artifact records `can_reconnect=true` with status `Reconnecting`, so `pullToReconnectActive` is already true while the ladder is parked and `PullToRefreshBox(onRefresh = onReconnect)` wires straight to `viewModel.reconnect()`. **The interleaving pre-dates this change**; the kebab adds an entry point to an existing class. (The implementer's second citation, a "Retry now" button, did *not* hold — that band is the unreachable live-frame fallback per its own KDoc. One claim from each side was wrong; both were corrected.)

## The deleted test was a rename, not a removal

Only the `SessionSurfaceState.Reconnecting` entry left the loop in `TmuxSessionScreenTest`. The `Connecting` / `Attaching` protections it legitimately carried are still asserted there **and** re-asserted through the real fusion in the new test. Criterion 4 genuinely holds — the JVM red was 3/127 with **the two protection assertions staying green on base**, so the tests discriminate the fix rather than track it.

## Evidence

Reviewer-driven, this run: neutralising `autoReconnectJob?.cancel()` (`TmuxSessionViewModel.kt:3215`) turns **both** gates red — the D34 companion on `expected:<2> but was:<3>`, the emulator journey on the recovered `-CC` client being replaced — with the hold trace capturing the damage at the wake instant (`clientDisconnected` false→true, handshakes 2→3). Restored, both green.

The mutant is live *because* the adjacent `autoReconnectJob = null` at `:3216` orphans the reference, so `connect()`'s own cancel at `:2599` no-ops — liveness established by mechanism, not assertion.

The #886 blank-pane watchdog suppression in the D34 harness is the established seam (`setConnectedBlankWatchdogAutoArmEnabledForTest(false)`, production default `true`, 8 sibling headless harnesses); every surviving assertion is on the real transport, with the emulator journey — real pane, no suppression — green as cross-check.

## Orchestrator integration gate (this exact tree, base `6892a313`)

Canonical `scripts/full-jvm-gate.sh` as a transient unit — `Result=success`, `ExecMainStatus=0`, `BUILD SUCCESSFUL in 24m 18s`, `603 actionable tasks: 603 executed`:

| Check | Result |
|---|---|
| `:app:testDebugUnitTest` | **4473 executed / 0 failures / 0 errors / 0 skipped** |
| `:app:testReleaseUnitTest` | **4461 executed / 0 failures / 0 errors / 0 skipped** |
| XML freshness vs run marker | 477/477 and 475/475 |
| Cache markers on test-execution tasks | none (only `:shared:test-support` `NO-SOURCE`, the documented exemption) |
| `Issue1953ManualReconnectEscapeHatchTest` | 4/0 in **both** variants |
| `:app:compileDebugAndroidTestKotlin` (forced, `--no-build-cache`) | clean — CI's `Unit` job does not compile this source set |
| `check-file-size-hygiene` / `check-connection-vm-ratchet` / `check-test-validity` / `check-tests-referenced` / `check-ci-journey-harness` | all rc 0 |

Both untracked files copied explicitly and md5-verified against the reviewed worktree.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/1953#issuecomment-5200392002

## Residual handed over, not fixed — #2019

A tap landing while a rung is **mid-dial** hits `withContext(NonCancellable) { closeCurrentConnectionAndJoin(...) }` (`TmuxSessionViewModel.kt:8918-8920`), where cancellation is deferred — the cancel does not cover that window. It needs an "already Live" re-check inside the ladder body, which is D28 serial-lane production work. Tracked in **#2019** together with the mirror-image finding from #2016 (the transparent re-dial pre-empting a *live* ladder); both are the #1545 two-writer class.
