### PR TITLE
test(proof): stop an inherited focus owner voiding #1994's reopen arms (#2021)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/EnvironmentFocusOwnerCleanupE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/EnvironmentFocusOwnerCleanupE2eTest.kt
@@ -7,7 +7,7 @@ import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
 import com.pocketshell.app.proof.signals.executeFocusShellCommand
 import com.pocketshell.app.proof.signals.dismissFocusedLauncherFrameworkDialog
 import com.pocketshell.app.proof.signals.focusedFrameworkErrorPackage
-import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
+import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
 import com.pocketshell.app.proof.signals.resolveHomePackage
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import org.junit.After
@@ -28,7 +28,7 @@ class EnvironmentFocusOwnerCleanupE2eTest {
 
     @Before
     fun startFromPocketShellFocus() {
-        requirePocketShellFocusAfterLauncherDialogCleanup(
+        recordJourneyEntryFocus(
             scenario = compose.activityRule.scenario,
             context = "before issue #1985 launcher framework-dialog fixture",
         )

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -48,7 +48,9 @@ import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
 import com.pocketshell.app.proof.signals.SyntheticFocusOwnerHarness
 import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
 import com.pocketshell.app.proof.signals.requirePocketShellFocusAtJourneyBoundary
-import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
+import com.pocketshell.app.proof.signals.InheritedJourneyFocus
+import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
+import com.pocketshell.app.proof.signals.requireNoJourneyOwnedFocusRegression
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -95,6 +97,9 @@ class FileViewerDockerTest {
      * already warm must NOT advance it (no per-open ~3-4s handshake).
      */
     private lateinit var leasing: CountingLeaseManager
+
+    /** Issue #2021: the focus reading this journey inherited at its entry boundary. */
+    private var journeyEntryFocus: InheritedJourneyFocus? = null
     private val focusOwner by lazy {
         SyntheticFocusOwnerHarness(
             scenario = composeRule.activityRule.scenario,
@@ -105,7 +110,7 @@ class FileViewerDockerTest {
 
     @Before
     fun setUp(): Unit { runBlocking {
-        requirePocketShellFocusAfterLauncherDialogCleanup(
+        journeyEntryFocus = recordJourneyEntryFocus(
             scenario = composeRule.activityRule.scenario,
             context = "before FileViewer Docker journey",
         )
@@ -126,8 +131,9 @@ class FileViewerDockerTest {
     @After
     fun tearDown(): Unit { runBlocking {
         focusOwner.dismissBestEffort()
-        requirePocketShellFocusAfterLauncherDialogCleanup(
+        requireNoJourneyOwnedFocusRegression(
             scenario = composeRule.activityRule.scenario,
+            entry = journeyEntryFocus,
             context = "after FileViewer Docker journey cleanup",
         )
         if (seededPaths.isNotEmpty()) {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/InheritedFocusOwnerVerdictE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/InheritedFocusOwnerVerdictE2eTest.kt
@@ -1,0 +1,287 @@
+package com.pocketshell.app.proof
+
+import android.app.Dialog
+import android.os.SystemClock
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
+import com.pocketshell.app.proof.signals.InheritedJourneyFocus
+import com.pocketshell.app.proof.signals.SyntheticFocusOwnerHarness
+import com.pocketshell.app.proof.signals.activityWindowFocused
+import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
+import com.pocketshell.app.proof.signals.requireNoJourneyOwnedFocusRegression
+import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
+import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #2021 — an INHERITED focus owner must not void a downstream journey's
+ * verdict, and the checks that ARE this journey's to make must keep their teeth.
+ *
+ * ## The reported problem, reproduced exactly
+ *
+ * On nightly run 31074120488 (2026-08-06, `main` 6892a313) two of the seven
+ * #1994 reopen-proof arms produced **no verdict at all**. Both died at a focus
+ * pre-condition before a single product assertion ran:
+ *
+ * ```
+ * SessionSwipeSwitchE2eTest > foreignWindowOverTheViewportIsNamed… FAILED
+ *   java.lang.AssertionError: The app window never held input focus, …
+ *   before raising synthetic focus owner 'issue-1994 synthetic focus owner';
+ *   app_window_focused=false active_window_pkg=com.pocketshell.app
+ *   active_window_class=android.widget.FrameLayout
+ *   at …SyntheticFocusOwnerHarnessKt.requirePocketShellFocusAtJourneyBoundary(
+ *       SyntheticFocusOwnerHarness.kt:119)
+ * ```
+ *
+ * `active_window_pkg=com.pocketshell.app` with `focused_framework_package=<none>`
+ * is the load-bearing detail the issue did not have: this was **not** a foreign
+ * window. It is an app-owned window owning the display while the scenario's
+ * activity had no input focus — the state [inheritAppOwnedFocusWindow] below
+ * creates directly, which is why this reproduction is faithful rather than a
+ * proxy for the environment stall that produced it in the wild.
+ *
+ * ## Why the state is injected rather than waited for
+ *
+ * The hosted stall behind it (swiftshader frames up to 13.9 s across a splash
+ * window handover the framework itself logged as
+ * `Input channel object '… Splash Screen com.pocketshell.app (client)' was
+ * disposed without first being removed with the input manager!`) cannot be
+ * commanded on demand. D33: inject the failing state synthetically and HARD-fail
+ * otherwise — [assertTrue] on `waitForActivityWindowFocusLost`, never a skip.
+ *
+ * ## Selectivity
+ *
+ * [aJourneyThatLeaksItsOwnSyntheticOwnerStillFails] is the anti-amnesty control:
+ * relaxing the INHERITED case must not relax the OWNED one. Without it, "the
+ * journey reached its body" could be bought by deleting the checks entirely.
+ */
+@RunWith(AndroidJUnit4::class)
+class InheritedFocusOwnerVerdictE2eTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private var inherited: Dialog? = null
+
+    @After
+    fun dismissInheritedOwner() {
+        val dialog = inherited ?: return
+        inherited = null
+        runCatching {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                if (dialog.isShowing) dialog.dismiss()
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        // Leave the device the way the next class expects it: this class's own
+        // injected owner is gone and PocketShell owns the display again.
+        assertTrue(
+            "the inherited-owner fixture must not leak into the next journey",
+            waitForActivityWindowFocused(compose.activityRule.scenario, timeoutMs = 10_000),
+        )
+    }
+
+    /**
+     * The reproduction. RED on base: [SyntheticFocusOwnerHarness.withOwner]
+     * throws `$FOREIGN_WINDOW_FOCUS_SIGNATURE before raising synthetic focus
+     * owner …` at SyntheticFocusOwnerHarness.kt:119 and `reachedBody` stays
+     * false — exactly the nightly signature, and exactly "no verdict". GREEN
+     * with the fix: the body runs and the injected state is proven.
+     */
+    @Test
+    fun anInheritedAppOwnedFocusWindowStillLetsTheJourneyReachItsVerdict() {
+        inheritAppOwnedFocusWindow()
+
+        var reachedBody = false
+        var ownerHadFocus = false
+        var activityLostFocus = true
+        SyntheticFocusOwnerHarness(
+            scenario = compose.activityRule.scenario,
+            label = "issue-2021 downstream synthetic owner",
+            timeoutMs = 5_000,
+        ).withOwner { dialog ->
+            reachedBody = true
+            ownerHadFocus = dialog.window?.decorView?.hasWindowFocus() == true
+            activityLostFocus = !activityWindowFocused(compose.activityRule.scenario)
+        }
+
+        assertTrue(
+            "a focus owner this journey INHERITED must not stop it reaching its own " +
+                "verdict — that is the #2021 void the nightly recorded",
+            reachedBody,
+        )
+        assertTrue(
+            "the downstream harness must still hard-prove its own injection took: " +
+                "the owner it raised owns the window focus",
+            ownerHadFocus,
+        )
+        assertTrue(
+            "the downstream harness must still hard-prove the ACTIVITY reading (the one " +
+                "the #1994 capture oracle consumes) flipped to unfocused",
+            activityLostFocus,
+        )
+    }
+
+    /**
+     * Selectivity control: the relaxation is scoped to the INHERITED state. A
+     * synthetic owner this journey raised and failed to clean up is still a hard
+     * failure, so #1985's no-leak guarantee is intact.
+     */
+    @Test
+    fun aJourneyThatLeaksItsOwnSyntheticOwnerStillFails() {
+        val harness = SyntheticFocusOwnerHarness(
+            scenario = compose.activityRule.scenario,
+            label = "issue-2021 leaked synthetic owner",
+            timeoutMs = 5_000,
+        )
+        var owned: Dialog? = null
+        val leaked = runCatching {
+            harness.withOwner { dialog ->
+                owned = dialog
+                // Re-show on the way out so the harness's own dismiss cannot win:
+                // this models a journey whose owner survives its cleanup.
+                InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                    dialog.setOnDismissListener { dialog.show() }
+                }
+            }
+        }.exceptionOrNull()
+
+        // Stop the re-show loop before asserting, so a failure here still leaves
+        // the device usable for the next class.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            owned?.setOnDismissListener(null)
+            if (owned?.isShowing == true) owned?.dismiss()
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        assertNotNull(
+            "a synthetic owner that survives its own cleanup must still hard-fail — " +
+                "relaxing the INHERITED case must not become blanket amnesty",
+            leaked,
+        )
+        assertTrue(
+            "the leak failure must name the surviving owner, got: ${leaked?.message}",
+            leaked?.message.orEmpty().contains("survived its own cleanup"),
+        )
+        assertTrue(
+            "the device must be left usable for the next journey",
+            waitForActivityWindowFocused(compose.activityRule.scenario, timeoutMs = 10_000),
+        )
+    }
+
+    /**
+     * The class-boundary sibling of the reproduction: an inherited unfocused
+     * reading is recorded and reported, never converted into this journey's
+     * verdict, while a focus regression THIS journey caused still fails.
+     */
+    @Test
+    fun theJourneyBoundaryFailsOnAnOwnedRegressionAndNotOnAnInheritedOne() {
+        val scenario = compose.activityRule.scenario
+
+        // (a) inherited: entry already unfocused -> exit stays quiet.
+        inheritAppOwnedFocusWindow()
+        val inheritedEntry: InheritedJourneyFocus = recordJourneyEntryFocus(
+            scenario = scenario,
+            context = "issue #2021 inherited entry",
+            timeoutMs = 2_000,
+        )
+        assertFalse(
+            "the fixture must make the entry boundary observe an unfocused activity",
+            inheritedEntry.focused,
+        )
+        assertTrue(
+            "the inherited reading must still be REPORTED, not swallowed",
+            inheritedEntry.diagnosis.contains("app_window_focused=false") &&
+                inheritedEntry.diagnosis.contains("active_window_pkg="),
+        )
+        requireNoJourneyOwnedFocusRegression(
+            scenario = scenario,
+            entry = inheritedEntry,
+            context = "issue #2021 inherited exit",
+            timeoutMs = 2_000,
+        )
+
+        // (b) owned: entry focused, then this journey loses focus -> exit fails.
+        dismissInheritedOwner()
+        val ownedEntry = recordJourneyEntryFocus(
+            scenario = scenario,
+            context = "issue #2021 owned entry",
+            timeoutMs = 10_000,
+        )
+        assertTrue("the owned case needs a focused entry reading", ownedEntry.focused)
+        inheritAppOwnedFocusWindow()
+        val regression = runCatching {
+            requireNoJourneyOwnedFocusRegression(
+                scenario = scenario,
+                entry = ownedEntry,
+                context = "issue #2021 owned exit",
+                timeoutMs = 2_000,
+            )
+        }.exceptionOrNull()
+        assertNotNull(
+            "a focus regression this journey caused must still hard-fail at the boundary",
+            regression,
+        )
+        assertTrue(
+            "the boundary failure must keep the #1879 signature, got: ${regression?.message}",
+            regression?.message.orEmpty().contains(FOREIGN_WINDOW_FOCUS_SIGNATURE),
+        )
+    }
+
+    /**
+     * Create the exact nightly state: an app-owned window owns the display while
+     * the scenario's activity holds no input focus. HARD-asserted, never assumed.
+     */
+    private fun inheritAppOwnedFocusWindow() {
+        var shown: Dialog? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            shown = Dialog(activity).also { dialog ->
+                dialog.setContentView(
+                    TextView(activity).apply {
+                        text = "issue-2021 inherited focus owner"
+                        isFocusable = true
+                        isFocusableInTouchMode = true
+                    },
+                )
+                dialog.setCancelable(false)
+                dialog.show()
+                dialog.window?.setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        inherited = shown
+        assertTrue(
+            "the inherited-owner fixture must actually take the window focus, otherwise " +
+                "this test proves nothing about the reported state",
+            waitForInheritedOwnerFocus(requireNotNull(shown)),
+        )
+        assertTrue(
+            "the inherited-owner fixture must leave the activity WITHOUT window focus — " +
+                "that is the reported app_window_focused=false reading",
+            waitForActivityWindowFocusLost(compose.activityRule.scenario, timeoutMs = 5_000),
+        )
+    }
+
+    private fun waitForInheritedOwnerFocus(dialog: Dialog): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + 5_000
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (dialog.window?.decorView?.hasWindowFocus() == true) return true
+            SystemClock.sleep(50)
+        }
+        return dialog.window?.decorView?.hasWindowFocus() == true
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -492,6 +493,14 @@ class SessionSwipeSwitchE2eTest {
      * complete 'A237-READY' cell band". GREEN with the fix: it throws the
      * foreign-owner attribution instead. Note it still THROWS — attribution is
      * never amnesty (pinned on the JVM by `MarkerBandCaptureVerdictTest`).
+     *
+     * Issue #2021: this arm produced NO verdict on the 2026-08-06 nightly — the
+     * harness refused to start because the hosted AVD had not granted the
+     * activity window focus (`active_window_pkg=com.pocketshell.app`, i.e. the
+     * app itself owned the display; no foreign window, no ANR). The harness now
+     * records that entry reading instead of demanding it and hard-asserts the
+     * state it actually injects; every assertion below is unchanged. See
+     * [SyntheticFocusOwnerHarness] and `InheritedFocusOwnerVerdictE2eTest`.
      */
     @Test
     fun foreignWindowOverTheViewportIsNamedInsteadOfBlamingTheTerminalPaint() { runBlocking {
@@ -580,6 +589,14 @@ class SessionSwipeSwitchE2eTest {
         attachToSessionAForCaptureProof()
         val scenario = requireNotNull(launchedActivity)
 
+        // Issue #2021: the guard below is a DELTA against this reading, not a
+        // demand that the hosted AVD granted the activity focus. The property
+        // this arm needs is "adding the cover changed nothing about who owns the
+        // window focus"; requiring an absolute `true` made the arm's verdict
+        // depend on an ambient grant it neither creates nor tests, and that is
+        // what voided it on the 2026-08-06 nightly before the pump ever ran.
+        val focusBeforeOverlay = activityWindowFocused(scenario)
+
         var overlay: View? = null
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             scenario.onActivity { activity ->
@@ -599,9 +616,18 @@ class SessionSwipeSwitchE2eTest {
             }
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        assertTrue(
-            "the synthetic occlusion must NOT steal window focus — otherwise this arm " +
-                "would exercise the foreign-owner attribution instead of the paint pump",
+        assertFalse(
+            "the synthetic occlusion must not be focusable — a focusable cover would " +
+                "make this arm exercise the foreign-owner attribution, not the paint pump",
+            requireNotNull(overlay).isFocusable ||
+                requireNotNull(overlay).isFocusableInTouchMode ||
+                requireNotNull(overlay).hasFocus(),
+        )
+        assertEquals(
+            "the synthetic occlusion must NOT change who owns the window focus — " +
+                "otherwise this arm would exercise the foreign-owner attribution " +
+                "instead of the paint pump",
+            focusBeforeOverlay,
             activityWindowFocused(scenario),
         )
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/LauncherFrameworkDialogFocusBoundary.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/LauncherFrameworkDialogFocusBoundary.kt
@@ -1,47 +1,30 @@
 package com.pocketshell.app.proof.signals
 
-import android.app.Activity
 import android.os.ParcelFileDescriptor
 import android.view.accessibility.AccessibilityNodeInfo
-import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 
 private val FRAMEWORK_ERROR_FOCUS_PATTERN = Regex(
     "mCurrentFocus=.*(?:Application Not Responding|Application Error): ([A-Za-z0-9._]+)",
 )
 
-/**
- * Restores a journey from the one environment-owned focus window proven by
- * issue #1985: a framework crash/ANR dialog for the device's HOME app.
+/*
+ * Issue #1985's narrow, evidence-based cleanup of the one environment-owned
+ * focus window proven safe to close: a framework crash/ANR dialog for the
+ * device's HOME app.
  *
  * This is deliberately narrower than "package android". Framework dialogs for
- * PocketShell and app-owned dialogs remain hard failures. Only a currently
- * focused framework error whose subject is the dynamically resolved HOME
- * package is closed, and the caller's activity must then regain focus.
+ * PocketShell and app-owned dialogs are never touched.
+ *
+ * Issue #2021 removed the `requirePocketShellFocusAfterLauncherDialogCleanup`
+ * wrapper that used to sit on top of these primitives (D22 hard cut — no shim).
+ * That wrapper hard-failed a journey at its `@Before`/`@After` boundary for ANY
+ * unfocused reading, including one the journey inherited from whatever ran
+ * before it on the shard, which is how two of the seven #1994 reopen-proof arms
+ * produced no verdict at all on the 2026-08-06 nightly. The boundary rule now
+ * lives in `recordJourneyEntryFocus` / `requireNoJourneyOwnedFocusRegression`
+ * (SyntheticFocusOwnerHarness.kt), which call the primitives below.
  */
-fun requirePocketShellFocusAfterLauncherDialogCleanup(
-    scenario: ActivityScenario<out Activity>,
-    context: String,
-    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
-) {
-    if (waitForActivityWindowFocused(scenario, timeoutMs = 250)) return
-
-    val instrumentation = InstrumentationRegistry.getInstrumentation()
-    val focusedFrameworkPackage = focusedFrameworkErrorPackage()
-    val homePackage = resolveHomePackage()
-
-    if (focusedFrameworkPackage == homePackage) {
-        dismissFocusedLauncherFrameworkDialog()
-        if (waitForActivityWindowFocused(scenario, timeoutMs)) return
-    }
-
-    val outcome = awaitActivityWindowFocus(scenario, timeoutMs = 0)
-    throw AssertionError(
-        "$FOREIGN_WINDOW_FOCUS_SIGNATURE $context; ${outcome.diagnosis}; " +
-            "focused_framework_package=${focusedFrameworkPackage ?: "<none>"} " +
-            "home_package=$homePackage",
-    )
-}
 
 internal fun resolveHomePackage(): String {
     val component = executeShellCommand(

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/SyntheticFocusOwnerHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/SyntheticFocusOwnerHarness.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.proof.signals
 import android.app.Activity
 import android.app.Dialog
 import android.os.SystemClock
+import android.util.Log
 import android.widget.TextView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
@@ -15,6 +16,43 @@ import androidx.test.platform.app.InstrumentationRegistry
  * happened on nightly shard 2 in issue #1985. Cleanup always dismisses only the
  * dialog this harness created and then proves PocketShell regained focus; it
  * never acts on an unrelated window that may represent a real product failure.
+ *
+ * ## Issue #2021 — the entry state is RECORDED, not demanded
+ *
+ * [withOwner] used to refuse to run at all unless the activity ALREADY held
+ * input focus. On the 2026-08-06 nightly (run 31074120488) that refusal voided
+ * two of the seven #1994 reopen-proof arms before a single product assertion
+ * ran, with:
+ *
+ * ```
+ * app_window_focused=false active_window_pkg=com.pocketshell.app
+ *   active_window_class=android.widget.FrameLayout
+ * focused_framework_package=<none>
+ * ```
+ *
+ * i.e. **PocketShell itself owned the display** — no foreign window, no ANR.
+ * That shard's per-class logcat shows `MainActivity … RESUMED`, the launcher
+ * gone (`VRI[NexusLauncherActivity] … newVisibility=false`), no error dialog,
+ * and swiftshader frames up to 13.9 s (`app_time_stats … max=13971.95ms`)
+ * around a splash-window handover the framework itself complained about
+ * (`Input channel object '… Splash Screen com.pocketshell.app (client)' was
+ * disposed without first being removed with the input manager!`). The grant
+ * simply never arrived inside the 10 s window.
+ *
+ * A downstream journey cannot be the judge of a state it did not create, and
+ * making its verdict conditional on that state is how a reopen-proof ends up
+ * with no signal at all. So the entry reading is now recorded, and every
+ * assertion this harness makes is about state IT owns:
+ *
+ *  * the injection took — the owner window holds focus AND the activity's own
+ *    reading (the one the #1994 capture oracle consumes) flipped to unfocused;
+ *  * at exit the owner this harness created is GONE; and
+ *  * focus is restored to at least the entry state — when the activity held
+ *    focus on entry it must hold it again, which is #1985's invariant unchanged.
+ *
+ * None of that is a self-skip: nothing is skipped, the body always runs, and a
+ * failure to inject is a hard failure. See also [recordJourneyEntryFocus] /
+ * [requireNoJourneyOwnedFocusRegression] for the same rule at class boundaries.
  */
 class SyntheticFocusOwnerHarness(
     private val scenario: ActivityScenario<out Activity>,
@@ -24,23 +62,25 @@ class SyntheticFocusOwnerHarness(
     private var owner: Dialog? = null
 
     fun <T> withOwner(block: (Dialog) -> T): T {
-        requirePocketShellFocusAtJourneyBoundary(
-            scenario = scenario,
-            context = "before raising synthetic focus owner '$label'",
-            timeoutMs = timeoutMs,
-        )
+        val focusedAtEntry = waitForActivityWindowFocused(scenario, timeoutMs)
+        val entryDiagnosis = if (focusedAtEntry) {
+            "app_window_focused=true"
+        } else {
+            "app_window_focused=false ${describeActiveWindow()}"
+        }
 
         val dialog = showOwner()
         var bodyFailure: Throwable? = null
         try {
             requireOwnerFocus(dialog)
+            requireActivityLostFocusToOwner(entryDiagnosis)
             return block(dialog)
         } catch (failure: Throwable) {
             bodyFailure = failure
             throw failure
         } finally {
             try {
-                dismissAndRequirePocketShellFocus()
+                dismissAndRequireOwnerGone(dialog, focusedAtEntry, entryDiagnosis)
             } catch (cleanupFailure: Throwable) {
                 bodyFailure?.let(cleanupFailure::addSuppressed)
                 throw cleanupFailure
@@ -90,19 +130,166 @@ class SyntheticFocusOwnerHarness(
         }
     }
 
-    private fun dismissAndRequirePocketShellFocus() {
-        val dialog = owner
+    /**
+     * The #1994 capture oracle reads the ACTIVITY, not the dialog
+     * (`activityWindowFocused` feeds `evaluateMarkerBandCapture`). So the
+     * injection is hard-asserted on that same reading, not only on the owner's,
+     * or an arm could "inject" a state its own oracle never sees.
+     */
+    private fun requireActivityLostFocusToOwner(entryDiagnosis: String) {
+        if (waitForActivityWindowFocusLost(scenario, timeoutMs)) return
+        throw AssertionError(
+            "synthetic focus owner '$label' holds the window focus but the activity " +
+                "still reports focus, so the injected state never reached the reading " +
+                "the capture oracle consumes; entry_state=$entryDiagnosis; " +
+                describeActiveWindow(),
+        )
+    }
+
+    private fun dismissAndRequireOwnerGone(
+        dialog: Dialog,
+        focusedAtEntry: Boolean,
+        entryDiagnosis: String,
+    ) {
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            if (dialog?.isShowing == true) dialog.dismiss()
+            if (dialog.isShowing) dialog.dismiss()
         }
         owner = null
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-        requirePocketShellFocusAtJourneyBoundary(
-            scenario = scenario,
-            context = "after dismissing synthetic focus owner '$label'",
-            timeoutMs = timeoutMs,
+
+        // What this harness OWNS: the window it raised must be gone. This is the
+        // leak check #1985 exists for, and it holds regardless of the ambient
+        // state — a boundary reading cannot tell one app-owned window from
+        // another, but the harness knows exactly which one it created.
+        val ownerDeadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < ownerDeadline) {
+            if (!dialog.isShowing && dialog.window?.decorView?.hasWindowFocus() != true) break
+            SystemClock.sleep(50)
+        }
+        if (dialog.isShowing || dialog.window?.decorView?.hasWindowFocus() == true) {
+            throw AssertionError(
+                "synthetic focus owner '$label' survived its own cleanup and would leak " +
+                    "into the next journey; showing=${dialog.isShowing} " +
+                    "owner_focused=${dialog.window?.decorView?.hasWindowFocus()}; " +
+                    describeActiveWindow(),
+            )
+        }
+
+        // #1985 invariant, unchanged for the state this harness disturbed: if the
+        // activity held focus before the owner was raised, it must hold it again.
+        // When focus was NOT ours to begin with, the inherited owner is reported
+        // in the message of whatever the journey asserts next, not converted into
+        // this harness's verdict (issue #2021).
+        if (focusedAtEntry) {
+            requirePocketShellFocusAtJourneyBoundary(
+                scenario = scenario,
+                context = "after dismissing synthetic focus owner '$label'",
+                timeoutMs = timeoutMs,
+            )
+        } else {
+            Log.i(
+                FOCUS_BOUNDARY_LOG_TAG,
+                "synthetic-owner-exit label='$label' inherited_entry_state=$entryDiagnosis " +
+                    "restored_focus=${activityWindowFocused(scenario)}",
+            )
+        }
+    }
+}
+
+/** Log tag for the issue #2021 inherited-focus boundary trail. */
+const val FOCUS_BOUNDARY_LOG_TAG: String = "PsJourneyFocusBoundary"
+
+/**
+ * Close the ONE environment-owned focus window #1985 proved safe to close: a
+ * currently focused framework error dialog whose subject is the resolved HOME
+ * package. Nothing else is ever touched — a framework dialog for PocketShell,
+ * an app-owned dialog, or any other package stays exactly where it is so it can
+ * keep the suite red with its own diagnosis.
+ */
+private fun cleanupLauncherFrameworkDialogIfFocused(
+    scenario: ActivityScenario<out Activity>,
+) {
+    if (waitForActivityWindowFocused(scenario, timeoutMs = 250)) return
+    val focusedFramework = focusedFrameworkErrorPackage() ?: return
+    if (focusedFramework != resolveHomePackage()) return
+    dismissFocusedLauncherFrameworkDialog()
+}
+
+/**
+ * The focus reading a journey INHERITED at its entry boundary (issue #2021).
+ *
+ * Carried from `@Before` to `@After` so the exit boundary can hard-fail on a
+ * regression this journey caused while staying silent about a state it merely
+ * inherited from whatever ran before it on the shard.
+ */
+data class InheritedJourneyFocus(
+    val focused: Boolean,
+    val diagnosis: String,
+    val context: String,
+)
+
+/**
+ * Entry boundary: clean the ONE environment-owned window #1985 proved safe to
+ * close (a framework error dialog for the resolved HOME package), then RECORD
+ * the resulting focus reading.
+ *
+ * This deliberately does not throw on an inherited unfocused state. The
+ * hard-failing focus assertions stay exactly where they are load-bearing:
+ * inside the journey, immediately before the action that needs input focus
+ * (`awaitActivityWindowFocus` in the IME journeys), and inside
+ * [SyntheticFocusOwnerHarness] for the state it injects. Refusing to start
+ * turned a nightly environment stall into "no verdict" for two #1994 reopen
+ * arms; the in-journey assertions still turn the same state into a loud,
+ * signature-carrying RED — a real verdict, which is what issue #2021 asks for.
+ */
+fun recordJourneyEntryFocus(
+    scenario: ActivityScenario<out Activity>,
+    context: String,
+    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+): InheritedJourneyFocus {
+    cleanupLauncherFrameworkDialogIfFocused(scenario)
+    val outcome = awaitActivityWindowFocus(scenario, timeoutMs)
+    val inherited = InheritedJourneyFocus(
+        focused = outcome.focused,
+        diagnosis = outcome.diagnosis,
+        context = context,
+    )
+    if (!outcome.focused) {
+        Log.w(
+            FOCUS_BOUNDARY_LOG_TAG,
+            "journey-entry-inherited-foreign-focus $context; ${outcome.diagnosis}",
         )
     }
+    return inherited
+}
+
+/**
+ * Exit boundary: hard-fail only when THIS journey lost a focus it started with.
+ *
+ * [entry] is null when the journey never reached its entry boundary (an
+ * `@Before` that threw still runs `@After`); the entry failure is that run's
+ * verdict, so this boundary stays quiet rather than replacing it.
+ */
+fun requireNoJourneyOwnedFocusRegression(
+    scenario: ActivityScenario<out Activity>,
+    entry: InheritedJourneyFocus?,
+    context: String,
+    timeoutMs: Long = WINDOW_FOCUS_DEFAULT_TIMEOUT_MS,
+) {
+    if (entry == null) return
+    cleanupLauncherFrameworkDialogIfFocused(scenario)
+    if (!entry.focused) {
+        Log.w(
+            FOCUS_BOUNDARY_LOG_TAG,
+            "journey-exit-inherited-focus-not-owned $context; entry=${entry.diagnosis}",
+        )
+        return
+    }
+    requirePocketShellFocusAtJourneyBoundary(
+        scenario = scenario,
+        context = context,
+        timeoutMs = timeoutMs,
+    )
 }
 
 /**

--- a/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
@@ -36,7 +36,9 @@ import com.pocketshell.app.proof.signals.captureImeServiceState
 import com.pocketshell.app.proof.signals.describeActiveWindow
 import com.pocketshell.app.proof.signals.describeActiveWindowCallCount
 import com.pocketshell.app.proof.signals.resetDescribeActiveWindowCallCount
-import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
+import com.pocketshell.app.proof.signals.InheritedJourneyFocus
+import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
+import com.pocketshell.app.proof.signals.requireNoJourneyOwnedFocusRegression
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
@@ -184,6 +186,9 @@ class ShowKeyboardChipE2eTest {
     /** #1879: the synthetic focus stealer, torn down even when a cycle fails. */
     private var focusStealer: Dialog? = null
 
+    /** Issue #2021: the focus reading this journey inherited at its entry boundary. */
+    private var journeyEntryFocus: InheritedJourneyFocus? = null
+
     private suspend fun seedFixture() {
         clearLastSessionPrefs()
         val key = readFixtureKey()
@@ -195,7 +200,7 @@ class ShowKeyboardChipE2eTest {
 
     @Before
     fun resetSharedProbes() {
-        requirePocketShellFocusAfterLauncherDialogCleanup(
+        journeyEntryFocus = recordJourneyEntryFocus(
             scenario = compose.activityRule.scenario,
             context = "before show-keyboard IME journey",
         )
@@ -214,8 +219,9 @@ class ShowKeyboardChipE2eTest {
             }
         }
         focusStealer = null
-        requirePocketShellFocusAfterLauncherDialogCleanup(
+        requireNoJourneyOwnedFocusRegression(
             scenario = compose.activityRule.scenario,
+            entry = journeyEntryFocus,
             context = "after show-keyboard IME journey cleanup",
         )
         clearLastSessionPrefs()

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
@@ -31,7 +31,9 @@ import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
-import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
+import com.pocketshell.app.proof.signals.InheritedJourneyFocus
+import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
+import com.pocketshell.app.proof.signals.requireNoJourneyOwnedFocusRegression
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
 import com.pocketshell.app.voice.SHOW_KEYBOARD_CHIP_TAG
@@ -87,6 +89,9 @@ class Issue887TerminalFixedUnderImeE2eTest {
     val grantPermissions = PreGrantPermissionsRule()
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
+
+    /** Issue #2021: the focus reading this journey inherited at its entry boundary. */
+    private var journeyEntryFocus: InheritedJourneyFocus? = null
     private val summaryLines = mutableListOf<String>()
 
     private val pickerWaitMs: Long =
@@ -95,8 +100,9 @@ class Issue887TerminalFixedUnderImeE2eTest {
     @After
     fun cleanup() {
         launchedActivity?.let { scenario ->
-            requirePocketShellFocusAfterLauncherDialogCleanup(
+            requireNoJourneyOwnedFocusRegression(
                 scenario = scenario,
+                entry = journeyEntryFocus,
                 context = "after issue #887 IME journey cleanup",
             )
             scenario.close()
@@ -119,7 +125,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
         forceFlatHostDetailViewMode()
 
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
-        requirePocketShellFocusAfterLauncherDialogCleanup(
+        journeyEntryFocus = recordJourneyEntryFocus(
             scenario = requireNotNull(launchedActivity),
             context = "before issue #887 IME journey",
         )

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
@@ -37,7 +37,9 @@ import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
-import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
+import com.pocketshell.app.proof.signals.InheritedJourneyFocus
+import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
+import com.pocketshell.app.proof.signals.requireNoJourneyOwnedFocusRegression
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.app.proof.waitForSshFixtureReady
@@ -176,6 +178,9 @@ class TmuxSessionOpencodeInputDockerTest {
     val grantPermissions = PreGrantPermissionsRule()
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
+
+    /** Issue #2021: the focus reading this journey inherited at its entry boundary. */
+    private var journeyEntryFocus: InheritedJourneyFocus? = null
     private val timings = mutableListOf<String>()
     private val screenshots = mutableListOf<ViewportArtifact>()
     private val perStageStamps = mutableListOf<String>()
@@ -183,8 +188,9 @@ class TmuxSessionOpencodeInputDockerTest {
     @After
     fun closeLaunchedActivity() {
         launchedActivity?.let { scenario ->
-            requirePocketShellFocusAfterLauncherDialogCleanup(
+            requireNoJourneyOwnedFocusRegression(
                 scenario = scenario,
+                entry = journeyEntryFocus,
                 context = "after OpenCode input journey cleanup",
             )
             scenario.close()
@@ -606,7 +612,7 @@ class TmuxSessionOpencodeInputDockerTest {
         val hostRowTag: String = persistHost(appContext, key, sshPort)
         try {
             launchedActivity = ActivityScenario.launch(MainActivity::class.java)
-            requirePocketShellFocusAfterLauncherDialogCleanup(
+            journeyEntryFocus = recordJourneyEntryFocus(
                 scenario = requireNotNull(launchedActivity),
                 context = "before issue #1979 OpenCode IME journey",
             )

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
@@ -36,7 +36,9 @@ import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
 import com.pocketshell.app.proof.signals.awaitActivityWindowFocus
-import com.pocketshell.app.proof.signals.requirePocketShellFocusAfterLauncherDialogCleanup
+import com.pocketshell.app.proof.signals.InheritedJourneyFocus
+import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
+import com.pocketshell.app.proof.signals.requireNoJourneyOwnedFocusRegression
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
 import com.pocketshell.app.proof.waitForSshFixtureReady
@@ -104,6 +106,9 @@ class TmuxShellComposerOcclusionE2eTest {
     val grantPermissions = PreGrantPermissionsRule()
 
     private var launchedActivity: ActivityScenario<MainActivity>? = null
+
+    /** Issue #2021: the focus reading this journey inherited at its entry boundary. */
+    private var journeyEntryFocus: InheritedJourneyFocus? = null
     private var focusStealer: Dialog? = null
     private val summaryLines = mutableListOf<String>()
     private var imeRequestCount: Int = 0
@@ -114,8 +119,9 @@ class TmuxShellComposerOcclusionE2eTest {
     fun cleanup() {
         dismissSyntheticFocusStealingWindow(requireFocusReturn = false)
         launchedActivity?.let { scenario ->
-            requirePocketShellFocusAfterLauncherDialogCleanup(
+            requireNoJourneyOwnedFocusRegression(
                 scenario = scenario,
+                entry = journeyEntryFocus,
                 context = "after shell-composer IME journey cleanup",
             )
             scenario.close()
@@ -134,7 +140,7 @@ class TmuxShellComposerOcclusionE2eTest {
         val hostRowTag = seedDockerHost(key, "Issue641 Shell Composer")
 
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
-        requirePocketShellFocusAfterLauncherDialogCleanup(
+        journeyEntryFocus = recordJourneyEntryFocus(
             scenario = requireNotNull(launchedActivity),
             context = "before shell-composer IME journey",
         )

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -298,6 +298,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.usage.UsageThresholdNotificationE2eTest"  # #1618 both relative countdown + absolute reset time reach the real status-bar notification
   "com.pocketshell.app.usage.Usage1318StrictSchemaRenderE2eTest"  # #1318 on-device render acceptance for the quse-v0.0.9 strict-schem…
   "com.pocketshell.app.usage.UsageResetCreditsLayoutTest"  # #1789 reset-credit inventory remains contained and scrollable on narrow / large-font layouts
+  "$FQCN_PREFIX.InheritedFocusOwnerVerdictE2eTest"  # #2021 D31: an INHERITED app-owned focus window must not void a downstream journey's verdict (the state that voided 2 of 7 #1994 reopen arms), while an owner the journey itself leaks still hard-fails. No Docker fixture, ~15s.
 )
 
 # CI-matrix journey class selection and banner logging live in a sourced helper.


### PR DESCRIPTION
Closes #2021.  **Test-infra only — no production delta.**

## The problem

**#1994 is a REOPEN** — closed once as fixed, symptom returned, fixed again. Its regression proof is the only thing that can tell us if it comes back a third time. On the last nightly, **2 of its 7 arms produced no verdict at all**: they hard-failed at a harness precondition *before* the #1994 assertion ran.

A proof that cannot run is not a proof. That is D31's durable-fix gate failing in practice.

## The premise in the issue was wrong

The issue assumed a **foreign** window stole focus. The nightly's own failure text says otherwise: `active_window_pkg=com.pocketshell.app` with `focused_framework_package=<none>` — **PocketShell itself owned the display** while the `ActivityScenario`'s activity had no input focus. Corroborated by `MainActivity … RESUMED`, launcher gone, no ANR, EGL frames to 13.9 s, and the framework's own `Input channel object '… Splash Screen com.pocketshell.app (client)' was disposed without first being removed with the input manager!`.

So the arms were voided by an **ambient precondition they neither own nor need**.

## The fix

The harness **records** the entry reading instead of demanding it, and hard-asserts only what it *creates*: injection took on the activity reading the capture oracle consumes; its own owner is gone at exit; focus is restored to the entry state. Arm 2's guard became a before/after delta plus a non-focusable assertion.

`requirePocketShellFocusAfterLauncherDialogCleanup` is **deleted** (D22 hard cut), replaced by `recordJourneyEntryFocus` / `requireNoJourneyOwnedFocusRegression`, adopted by six sibling classes.

## Why relaxing the precondition is not vacuous — reviewer-derived

This was the review's central question, and it was settled from the code rather than accepted:

- **Arm 1** needs "the app's Activity window does not own the display at capture time". The harness now *creates* that state and hard-asserts it **twice**, including on the exact `activityWindowFocused` reading `evaluateMarkerBandCapture` consumes (`SessionSwipeSwitchE2eTest.kt:1192`).
- **Arm 2**'s load-bearing assertion is `captureViewport(...)` **succeeding**. Because the oracle computes `focused = bandComplete || activityWindowFocused(...)`, an ambient focus loss makes that arm **strictly harder**, never vacuous.

## Mutation — the assertions still discriminate

Four mutants, each live-checked, each reddening **exactly one** assertion and only that one:

| Mutant | Result |
|---|---|
| M1 attribution dead | arm 1 red |
| M2 single-shot pump | arm 2 red (`attempts=1`) |
| M3 leak check off | anti-amnesty control red |
| M4 exit boundary toothless | boundary test red |

M4 also answers the obvious worry directly: `requireNoJourneyOwnedFocusRegression` still bites on a real leak.

## A deliberate refusal

The implementer did **not** add a focus-recovery arm, citing that `WindowFocusSignals.kt`'s round-2 review deleted exactly that as a masking channel and that it would be unprovable against the real hosted cause. Declining to re-add something previously removed *for cause* is the right instinct; the reviewer agreed.

## Evidence

- **G1 red→green, reviewer-driven:** with the pre-fix precondition restored, the reproduction dies at `SyntheticFocusOwnerHarness.kt:66` with the nightly's exact signature; restored, 3/3 green. Both previously-void arms now pass with real verdicts (3/3 on an **isolated pooled fixture**).
- Implementer's G2 sweep classes — including both #1985 proofs and the #1879 attribution test — 4/4 green.
- Worktree left md5-verified with no mutant residue.

## Orchestrator integration gate (this exact tree, base `002c8087`)

| Check | Result |
|---|---|
| `check-ci-journey-harness` | OK |
| `check-test-validity` | OK |
| `check-tests-referenced` | OK |
| `check-file-size-hygiene` | OK |
| `:app:compileDebugAndroidTestKotlin` (forced, `--no-build-cache`) | clean — CI's `Unit` job does not compile this source set |

`scripts/ci-journey-suite.sh` gains **exactly one** entry (170 → 171 registered classes), with a comment stating why — that array has a documented history of drifting when two lanes touch it, so the edit was kept minimal deliberately.

The untracked `InheritedFocusOwnerVerdictE2eTest.kt` was copied explicitly and md5-verified; `git diff HEAD` omits untracked files and merging without it would be the D33 failure.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2021#issuecomment-5202348517

## Unrelated pre-existing red, recorded not fixed

While reviewing, the reviewer hit `TmuxSessionOpencodeInputDockerTest#issue303TerminalConversationPillStaysInToolbarRow` failing, reverted the worktree to `HEAD` and **reproduced it on base**, then restored with `md5sum -c`. It is already tracked as item 12 of #1966 and inventoried under #1677; the fresh reproduction is recorded there. Not caused by this change.
