### PR TITLE
test-infra: fold the hand-rolled settle pumps into the audited helper (#2017)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,8 +561,9 @@ are looking at before proposing a fix:
     Handler/Thread, e.g. `SshTerminalBridge`): loop `advanceUntilIdle()` +
     `shadowOf(Looper.getMainLooper()).idleFor(16ms)` + small sleep to a
     `System.currentTimeMillis()` deadline that HARD-FAILS; assert the exit
-    condition, never the loop body. Reference: `TmuxSessionWarmOpenTest.pumpUntil`
-    (`:131-150`), codex pump (`TmuxSessionViewModelTest.kt:5602-5657`). The
+    condition, never the loop body. **Never hand-roll that loop** — call the ONE
+    audited helper below and inject the drain. Reference: the codex pump
+    (`TmuxSessionViewModelTest.kt:5602-5657`). The
     drifting hand-rolled Shape-B pumps now share ONE audited helper —
     `drainMainLooperUntil` in the test-only module `:shared:test-support`
     (`shared/test-support/src/main/java/com/pocketshell/testsupport/SettlePump.kt`,
@@ -571,8 +572,19 @@ are looking at before proposing a fix:
     clock" guarantee; the per-tick drain (`runCurrent()` / `idleFor` / both) is
     injected per call site because those drains are genuinely different (idle
     nothing to spare the #793 watchdog vs idle a frame for the #803 drain vs no
-    `TestScope` at all) and must not be forced into one. Clock-advancing pumps
-    (`advanceSchedulerUntil`, `pumpUntil`) stay separate by design.
+    `TestScope` at all) and must not be forced into one. **A clock-ADVANCING
+    drain is allowed — inject it as `onTick` (#2017).** "Never touch a clock" is
+    a property of the helper's BODY, not a ban on callers; #1048 read it as a
+    carve-out and left `TmuxSessionWarmOpenTest.pumpUntil` (and its copy in
+    `Issue1574DeadReconnectTest`) hand-rolled with a **5 s** real-time budget,
+    which a contended box exhausts while the awaited continuation is merely
+    unscheduled — so those classes red only under load. Both are migrated; the
+    single budget is `GENEROUS_SETTLE_DEADLINE_MS` (30 s) as the `deadlineMs`
+    default. **Prefer the default; never "fix" a contention timeout by nudging a
+    local constant up.** Only
+    `PromptComposerOutboundSendQueueViewModelTest.advanceSchedulerUntil` stays
+    separate (its predicate is `suspend` and its loop body re-checks it between
+    four distinct clock/dispatcher nudges, so the body is load-bearing).
   - **Banned:** a single `advanceUntilIdle()`+`idle()` then assert on real-thread
     output; a bare fixed `Thread.sleep(N)` as the only sync before a load-bearing
     assert. `scripts/check-test-validity.sh`'s advisory `TIMING1` smell surfaces

--- a/app/src/test/java/com/pocketshell/app/proof/SettlePumpContentionBudgetTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/SettlePumpContentionBudgetTest.kt
@@ -1,0 +1,107 @@
+package com.pocketshell.app.proof
+
+import com.pocketshell.testsupport.GENEROUS_SETTLE_DEADLINE_MS
+import com.pocketshell.testsupport.drainMainLooperUntil
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2017 — the durable guard on the ONE audited settle-pump budget.
+ *
+ * `Issue1574DeadReconnectTest` hand-rolled a Shape-B pump with a **5 s**
+ * wall-clock budget. That budget is REAL time spent on a box whose real time is
+ * contended: at load ~13 with four parallel lanes the awaited continuation was
+ * merely unscheduled, the 5 s elapsed, and the class went red — while staying
+ * green 3/3 in isolation. A test that reds only under load is the worst kind of
+ * flake, because it is indistinguishable from a real reconnect regression at
+ * first glance (it cost a review round) and the natural "just re-run it" reflex
+ * manufactures a convincing green streak: Gradle SKIPS a passing test task on
+ * re-run while a FAILING one always re-executes.
+ *
+ * The fix is not a bigger local number — it is that
+ * [com.pocketshell.testsupport.drainMainLooperUntil] owns ONE generous budget,
+ * [GENEROUS_SETTLE_DEADLINE_MS], as its `deadlineMs` default. This class pins
+ * that so the value cannot quietly drift back down, and pins the two properties
+ * that make it safe to depend on: the pump keeps polling for the whole budget,
+ * and it still reports a HARD failure when the condition genuinely never holds.
+ *
+ * Kept deliberately cheap (~5 s, one real stall) — the scaled contract below
+ * proves the fail/pass boundary in fractions of a second, and the constant
+ * assertion carries the "5 s was too tight" regression itself.
+ */
+class SettlePumpContentionBudgetTest {
+
+    /**
+     * THE regression assertion. 5 s is the budget that reproducibly failed under
+     * contention; anything in that neighbourhood is not contention headroom. The
+     * upper bound keeps the pump's own diagnostic firing BEFORE `runTest`'s 60 s
+     * default global timeout, which would otherwise abort the whole test with no
+     * indication of what was being awaited.
+     */
+    @Test
+    fun auditedBudgetIsGenerousEnoughForAContendedBoxAndBelowTheRunTestTimeout() {
+        assertTrue(
+            "the ONE audited settle-pump budget must leave real contention headroom; " +
+                "5s is the budget that flaked #1574 under load, got ${GENEROUS_SETTLE_DEADLINE_MS}ms",
+            GENEROUS_SETTLE_DEADLINE_MS >= 20_000L,
+        )
+        assertTrue(
+            "the audited budget must stay under runTest's 60s default global timeout so the " +
+                "pump's own message fires first, got ${GENEROUS_SETTLE_DEADLINE_MS}ms",
+            GENEROUS_SETTLE_DEADLINE_MS < 60_000L,
+        )
+    }
+
+    /**
+     * The pump's fail/pass boundary, proven at a scaled-down budget so it costs
+     * fractions of a second: a stall LONGER than the budget must report failure,
+     * and a stall SHORTER than it must report success without waiting out the
+     * budget. Combined with the constant above, this is exactly "a multi-second
+     * contention stall is absorbed" — without spending multi-second wall clock.
+     */
+    @Test
+    fun aStallBeyondTheBudgetFailsAndAStallWithinItSucceeds() {
+        val beyond = drainMainLooperUntil(deadlineMs = 200L, sleepMs = 1L) { false }
+        assertFalse(
+            "a condition that never holds must exhaust the budget and report a HARD failure — " +
+                "the pump must never swallow a genuine stall",
+            beyond,
+        )
+
+        val flipAt = System.currentTimeMillis() + 100L
+        val startedAt = System.currentTimeMillis()
+        val within = drainMainLooperUntil(deadlineMs = 10_000L, sleepMs = 1L) {
+            System.currentTimeMillis() >= flipAt
+        }
+        val elapsed = System.currentTimeMillis() - startedAt
+        assertTrue("a stall inside the budget must be absorbed, not reported as a timeout", within)
+        assertTrue(
+            "the pump must return as soon as the condition holds, never wait out the whole " +
+                "budget (a healthy run must not be slowed), took ${elapsed}ms",
+            elapsed < 5_000L,
+        )
+    }
+
+    /**
+     * The one real-time arm: a stall PAST the old 5 s budget. On the pre-#2017
+     * pump this exact wait was a red `pumpUntil timed out after 5000ms`; on the
+     * audited default it is absorbed. This is the red→green of the reported
+     * defect, pinned so a future budget reduction reintroduces it as a
+     * deterministic failure rather than a load-only flake.
+     */
+    @Test
+    fun theAuditedDefaultAbsorbsAStallThatTheOldFiveSecondBudgetCouldNot() {
+        val oldBudgetMs = 5_000L
+        val stallMs = oldBudgetMs + 100L
+        val flipAt = System.currentTimeMillis() + stallMs
+
+        val settled = drainMainLooperUntil(sleepMs = 2L) { System.currentTimeMillis() >= flipAt }
+
+        assertTrue(
+            "the audited default (${GENEROUS_SETTLE_DEADLINE_MS}ms) must absorb a ${stallMs}ms " +
+                "contention stall that the old hand-rolled ${oldBudgetMs}ms budget could not",
+            settled,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1574DeadReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1574DeadReconnectTest.kt
@@ -10,6 +10,8 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.testsupport.GENEROUS_SETTLE_DEADLINE_MS
+import com.pocketshell.testsupport.drainMainLooperUntil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -83,23 +85,39 @@ class Issue1574DeadReconnectTest {
         )
 
     /**
-     * Issue #998 determinism helper (copied from TmuxSessionWarmOpenTest): the
-     * cold-restore `tmux has-session` preflight hops onto the REAL Dispatchers.IO,
-     * off the virtual clock, so `advanceUntilIdle()` can return while it is still
-     * parked. Bridge the two clocks by pumping the scheduler to idle, yielding a
-     * sliver of real time for the IO continuation to re-enqueue, and looping to a
-     * hard deadline. HARD-FAILS (never self-skips) so a real regression still reds.
+     * Issue #998 determinism helper: the cold-restore `tmux has-session`
+     * preflight hops onto the REAL Dispatchers.IO, off the virtual clock, so
+     * `advanceUntilIdle()` can return while it is still parked. Bridge the two
+     * clocks by pumping the scheduler to idle, yielding a sliver of real time for
+     * the IO continuation to re-enqueue, and looping to a hard deadline.
+     * HARD-FAILS (never self-skips) so a real regression still reds.
+     *
+     * Issue #2017: the bounded-wall-clock loop and — critically — the DEADLINE now
+     * come from the ONE audited settle-pump ([drainMainLooperUntil]) instead of a
+     * copy of `TmuxSessionWarmOpenTest`'s hand-rolled loop. That copy spent a 5 s
+     * REAL-time budget, which a contended box (load ~13, four parallel lanes)
+     * exhausts while the awaited continuation is merely unscheduled — so this
+     * class reds only under load, which reads exactly like a real reconnect
+     * regression and burns a review round. The per-tick drain stays
+     * `advanceUntilIdle()` (the injected [drainMainLooperUntil] `onTick` is
+     * precisely for a call site's genuinely-different drain; the helper itself
+     * still advances no clock), the pump's exit condition stays the load-bearing
+     * assertion, and it still HARD-FAILS on timeout — nothing here is widened
+     * except the one audited contention headroom, owned in one reviewed place.
      */
     private fun TestScope.pumpUntil(reason: String, condition: () -> Boolean) {
-        val deadlineNanos = System.nanoTime() + 5_000L * 1_000_000L
-        while (true) {
-            advanceUntilIdle()
-            if (condition()) return
-            if (System.nanoTime() >= deadlineNanos) {
-                throw AssertionError("pumpUntil timed out after 5000ms waiting for: $reason")
-            }
-            Thread.sleep(2)
-        }
+        val settled = drainMainLooperUntil(
+            sleepMs = 2L,
+            // Let the real Dispatchers.IO continuation (the preflight exec /
+            // failServerDied tryEmit) re-enqueue onto the test scheduler, then
+            // drain it. Advancing the virtual clock is this pump's whole point.
+            onTick = { advanceUntilIdle() },
+            condition = condition,
+        )
+        assertTrue(
+            "pumpUntil timed out after ${GENEROUS_SETTLE_DEADLINE_MS}ms waiting for: $reason",
+            settled,
+        )
     }
 
     private fun newVm(

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue926SeedIoOffMainTest.kt
@@ -11,6 +11,8 @@ import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.testsupport.GENEROUS_SETTLE_DEADLINE_MS
+import com.pocketshell.testsupport.drainMainLooperUntil
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -184,22 +186,24 @@ class Issue926SeedIoOffMainTest {
                     "(phase=$teardownPhase)"
             }
             try {
-                val deadlineNanos =
-                    System.nanoTime() + TEARDOWN_DRAIN_TIMEOUT_MS * NANOS_PER_MILLISECOND
-                while (true) {
-                    createdVms.forEach { it.cancelOwnScopesForTest() }
-                    val activeChildren =
-                        createdVms.sumOf { it.activeOwnScopeChildCountForTest() }
-                    if (activeChildren == 0) break
-                    if (System.nanoTime() >= deadlineNanos) {
-                        throw AssertionError(
-                            "Issue #1355: $activeChildren TmuxSessionViewModel coroutine(s) " +
-                                "did not quiesce within ${TEARDOWN_DRAIN_TIMEOUT_MS}ms; " +
-                                "resetting Dispatchers.Main now would recreate the " +
-                                "TestMainDispatcher:72 race",
-                        )
-                    }
-                    Thread.sleep(1)
+                // Issue #2017: the bounded loop + the ONE audited generous deadline
+                // come from the shared settle-pump. Re-cancelling every pass is a
+                // load-bearing SIDE EFFECT (a completion handler can re-spawn a
+                // bridgeScope child), so it is the injected per-tick drain; the
+                // zero-child exit condition stays the load-bearing assertion.
+                val quiesced = drainMainLooperUntil(
+                    sleepMs = 1L,
+                    onTick = { createdVms.forEach { it.cancelOwnScopesForTest() } },
+                ) {
+                    createdVms.sumOf { it.activeOwnScopeChildCountForTest() } == 0
+                }
+                if (!quiesced) {
+                    throw AssertionError(
+                        "Issue #1355: ${createdVms.sumOf { it.activeOwnScopeChildCountForTest() }} " +
+                            "TmuxSessionViewModel coroutine(s) did not quiesce within " +
+                            "${GENEROUS_SETTLE_DEADLINE_MS}ms; resetting Dispatchers.Main now " +
+                            "would recreate the TestMainDispatcher:72 race",
+                    )
                 }
                 assertEquals(
                     "Issue #1355: every standalone #926 VM must be quiescent before resetMain()",
@@ -439,14 +443,21 @@ class Issue926SeedIoOffMainTest {
         )
     }
 
-    private fun waitUntil(what: String, timeoutMs: Long = 5_000L, predicate: () -> Boolean) {
-        val deadline = System.nanoTime() + timeoutMs * 1_000_000
-        while (!predicate()) {
-            if (System.nanoTime() > deadline) {
-                throw AssertionError("timed out waiting for: $what")
-            }
-            Thread.sleep(5)
-        }
+    /**
+     * Issue #2017: was a hand-rolled bounded pump with a 5 s REAL-time budget —
+     * the same shape (and the same too-tight budget) that made
+     * `Issue1574DeadReconnectTest` red only under contention. The loop and the ONE
+     * audited generous deadline now come from [drainMainLooperUntil]. This class
+     * runs on `runBlocking` + real dispatchers (no `TestScope`), so its per-tick
+     * drain is a pure poll — the helper's default `onTick` no-op. The pump's exit
+     * condition stays the load-bearing assertion and still HARD-FAILS.
+     */
+    private fun waitUntil(what: String, predicate: () -> Boolean) {
+        val settled = drainMainLooperUntil(sleepMs = 5L, condition = predicate)
+        assertTrue(
+            "timed out after ${GENEROUS_SETTLE_DEADLINE_MS}ms waiting for: $what",
+            settled,
+        )
     }
 
     private fun FakeTmuxClient.withSinglePaneRowButEmptyCapture(
@@ -513,7 +524,6 @@ class Issue926SeedIoOffMainTest {
         const val SEED_IO_THREAD_NAME = "issue926-seed-io"
         const val MAIN_PROBE_BUDGET_MS = 1_000L
         const val TEARDOWN_DRAIN_TIMEOUT_MS = 30_000L
-        const val NANOS_PER_MILLISECOND = 1_000_000L
     }
 
     private enum class TeardownPhase {

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardown.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelRuleTeardown.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.tmux
 
 import androidx.lifecycle.viewModelScope
 import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.testsupport.GENEROUS_SETTLE_DEADLINE_MS
+import com.pocketshell.testsupport.drainMainLooperUntil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
@@ -183,27 +185,36 @@ internal class TmuxSessionViewModelRuleTeardown(
         cancel: () -> Unit,
         debug: () -> String = { "" },
     ) {
-        val deadlineNanos = System.nanoTime() + timeoutMs * NANOS_PER_MILLISECOND
-        while (true) {
-            cancel()
-            runCurrent()
-            val active = remaining()
-            if (active == 0) return
-            if (System.nanoTime() >= deadlineNanos) {
-                throw AssertionError(
-                    "Issue #1355: $active $description child(ren) did not quiesce within " +
-                        "${timeoutMs}ms while Main was installed; resetting Main would " +
-                        "recreate the TestMainDispatcher:72 race" +
-                        debug().takeIf(String::isNotBlank)?.let { "\n$it" }.orEmpty(),
-                )
-            }
-            Thread.sleep(1L)
+        // Issue #2017: the bounded loop + the deadline come from the ONE audited
+        // settle-pump instead of another hand-rolled `System.nanoTime()` budget.
+        // `cancel()` every pass is a load-bearing SIDE EFFECT (a completion handler
+        // can re-spawn a child), and `runCurrent()` must NEVER become virtual-time
+        // advancement here (watchdog deadlines must not move), so both are the
+        // injected per-tick drain; the zero-children exit condition stays the
+        // load-bearing assertion and a genuine leak still HARD-FAILS.
+        val quiesced = drainMainLooperUntil(
+            deadlineMs = timeoutMs,
+            sleepMs = 1L,
+            onTick = {
+                cancel()
+                runCurrent()
+            },
+        ) {
+            remaining() == 0
+        }
+        if (!quiesced) {
+            throw AssertionError(
+                "Issue #1355: ${remaining()} $description child(ren) did not quiesce within " +
+                    "${timeoutMs}ms while Main was installed; resetting Main would " +
+                    "recreate the TestMainDispatcher:72 race" +
+                    debug().takeIf(String::isNotBlank)?.let { "\n$it" }.orEmpty(),
+            )
         }
     }
 
     private companion object {
-        const val DEFAULT_TIMEOUT_MS = 30_000L
-        const val NANOS_PER_MILLISECOND = 1_000_000L
+        // Issue #2017: the ONE audited generous wall-clock budget, not a local copy.
+        const val DEFAULT_TIMEOUT_MS = GENEROUS_SETTLE_DEADLINE_MS
     }
 }
 
@@ -218,7 +229,7 @@ private fun Job.debugTree(indent: String = ""): String =
     }
 
 internal fun MainDispatcherRule.tmuxSessionViewModelTeardown(
-    timeoutMs: Long = 30_000L,
+    timeoutMs: Long = GENEROUS_SETTLE_DEADLINE_MS,
 ): TmuxSessionViewModelRuleTeardown =
     TmuxSessionViewModelRuleTeardown(
         runCurrent = ::runCurrent,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTerminalBackpressureTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTerminalBackpressureTest.kt
@@ -223,23 +223,33 @@ class TmuxSessionViewModelTerminalBackpressureTest : TmuxSessionViewModelTestBas
                 // renders. This strengthens, never weakens, the assertion: if the
                 // marker genuinely never lands the loop still times out and the
                 // assertTrue below fails.
+                //
+                // Issue #2017: the bounded loop + the deadline come from the ONE
+                // audited settle-pump instead of another hand-rolled
+                // `System.currentTimeMillis()` budget. The per-tick drain is this
+                // site's genuine one (virtual scheduler + one looper frame), the
+                // marker predicate stays the load-bearing exit condition, and the
+                // `assertTrue` below still HARD-FAILS on a genuine stall.
                 var transcript = ""
-                val markerDeadline = System.currentTimeMillis() + SLOW_FEED_DRAIN_TIMEOUT_MS
-                do {
-                    advanceUntilIdle()
-                    // Issue #803/#804: advance the virtual looper a frame so the
-                    // budgeted `postDelayed` drain-continuations fire (a bare `idle()`
-                    // never runs them), draining the queue tail and rendering the marker.
-                    shadowOf(Looper.getMainLooper())
-                        .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
-                    transcript = renderedTranscriptFrom(state)
-                    if (transcript.contains("ISSUE576-CODEX-LIKE-DONE")) break
-                    Thread.sleep(20)
-                } while (System.currentTimeMillis() < markerDeadline)
+                val markerRendered = drainMainLooperUntilShared(
+                    sleepMs = 20L,
+                    onTick = {
+                        advanceUntilIdle()
+                        // Issue #803/#804: advance the virtual looper a frame so the
+                        // budgeted `postDelayed` drain-continuations fire (a bare
+                        // `idle()` never runs them), draining the queue tail and
+                        // rendering the marker.
+                        shadowOf(Looper.getMainLooper())
+                            .idleFor(16L, java.util.concurrent.TimeUnit.MILLISECONDS)
+                        transcript = renderedTranscriptFrom(state)
+                    },
+                ) {
+                    transcript.contains("ISSUE576-CODEX-LIKE-DONE")
+                }
                 assertTrue(
                     "integrated fake tmux -> TerminalSurfaceState -> SshTerminalBridge path must render " +
                         "the final marker; tail=${transcript.takeLast(500)}",
-                    transcript.contains("ISSUE576-CODEX-LIKE-DONE"),
+                    markerRendered,
                 )
                 assertTrue(
                     "slow side-channel collector should prove the secondary output flow was subscribed",

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTestBase.kt
@@ -12,6 +12,7 @@ import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshLeaseTarget
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.TmuxClientFactory
+import com.pocketshell.testsupport.GENEROUS_SETTLE_DEADLINE_MS
 import com.pocketshell.testsupport.drainMainLooperUntil as drainMainLooperUntilShared
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.CoroutineScope
@@ -519,22 +520,31 @@ abstract class TmuxSessionViewModelTestBase {
         // (before its `resetMain()`), so every real-thread Main touch happens now
         // against a stable Main. HARD-FAIL if a VM never quiesces: a future real
         // leak is then a DETERMINISTIC red, not an inter-class flake.
-        val issue1355Deadline = System.currentTimeMillis() + SLOW_FEED_DRAIN_TIMEOUT_MS
-        while (true) {
-            vmsToDrain.forEach { it.cancelOwnScopesForTest() }
-            scheduler.runCurrent()
-            val active = vmsToDrain.sumOf { it.activeOwnScopeChildCountForTest() }
-            if (active == 0) break
-            assertTrue(
-                "Issue #1355: $active TmuxSessionViewModel coroutine(s) did not quiesce within " +
-                    "${SLOW_FEED_DRAIN_TIMEOUT_MS}ms of @After — one would survive into the next " +
-                    "test's Dispatchers.setMain and race it (TestMainDispatcher:72, the " +
-                    "leak-across-test-boundary flake). Root-cause the new un-drained " +
-                    "viewModelScope/bridgeScope launch rather than adding another point-fix.",
-                System.currentTimeMillis() < issue1355Deadline,
-            )
-            Thread.sleep(1)
+        //
+        // Issue #2017: the bounded loop and the deadline come from the ONE audited
+        // settle-pump rather than a hand-rolled `System.currentTimeMillis()` budget.
+        // The re-cancel + `runCurrent()` pair is the injected per-tick drain (it is
+        // a load-bearing side effect, and it must stay `runCurrent`, NEVER
+        // `advanceUntilIdle`); the zero-children exit condition stays the
+        // load-bearing assertion.
+        val issue1355Quiesced = drainMainLooperUntilShared(
+            sleepMs = 1L,
+            onTick = {
+                vmsToDrain.forEach { it.cancelOwnScopesForTest() }
+                scheduler.runCurrent()
+            },
+        ) {
+            vmsToDrain.sumOf { it.activeOwnScopeChildCountForTest() } == 0
         }
+        assertTrue(
+            "Issue #1355: ${vmsToDrain.sumOf { it.activeOwnScopeChildCountForTest() }} " +
+                "TmuxSessionViewModel coroutine(s) did not quiesce within " +
+                "${GENEROUS_SETTLE_DEADLINE_MS}ms of @After — one would survive into the next " +
+                "test's Dispatchers.setMain and race it (TestMainDispatcher:72, the " +
+                "leak-across-test-boundary flake). Root-cause the new un-drained " +
+                "viewModelScope/bridgeScope launch rather than adding another point-fix.",
+            issue1355Quiesced,
+        )
         defaultTeardownScope.cancel()
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -16,6 +16,8 @@ import com.pocketshell.core.terminal.bridge.SshTerminalBridge
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.tmux.TmuxClientFactory
 import com.pocketshell.core.tmux.TmuxServerDeadException
+import com.pocketshell.testsupport.GENEROUS_SETTLE_DEADLINE_MS
+import com.pocketshell.testsupport.drainMainLooperUntil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -109,32 +111,35 @@ class TmuxSessionWarmOpenTest {
      * up to a hard deadline. It HARD-FAILS (never self-skips) if the condition is
      * not met within the budget, so a genuine routing regression still reds.
      *
-     * Issue #1048: this pump is deliberately NOT migrated onto the shared
-     * `drainMainLooperUntil` settle-pump. It intentionally `advanceUntilIdle()`s
-     * the kotlinx VIRTUAL clock each tick, which is incompatible with the shared
-     * pump's "never advance/​touch a clock" invariant. Advancing the virtual clock
-     * is the whole point here (pump the scheduler to idle), so it stays separate —
-     * forcing it onto the shared helper would mask its real wait.
+     * Issue #2017: this pump WAS carved out of the #1048 consolidation on the
+     * reading that a virtual-clock drain is incompatible with the shared pump's
+     * "never touch a clock" invariant. That invariant is a property of the shared
+     * helper's BODY, not a ban on callers: the per-tick drain is INJECTED
+     * (`onTick`) exactly so a call site can supply the drain it genuinely needs,
+     * and `advanceUntilIdle()` is this one's. The carve-out's real cost was that
+     * this loop — and the copy of it in `Issue1574DeadReconnectTest` — kept a 5 s
+     * REAL-time budget, which a contended box exhausts while the awaited
+     * continuation is merely unscheduled, so the class reds only under load. The
+     * loop and its one audited generous deadline now come from
+     * [drainMainLooperUntil]; the exit condition is still the load-bearing
+     * assertion and it still HARD-FAILS on timeout.
      */
     private fun TestScope.pumpUntil(
-        timeoutMillis: Long = 5_000L,
         reason: String,
         condition: () -> Boolean,
     ) {
-        val deadlineNanos = System.nanoTime() + timeoutMillis * 1_000_000L
-        while (true) {
-            advanceUntilIdle()
-            if (condition()) return
-            if (System.nanoTime() >= deadlineNanos) {
-                throw AssertionError(
-                    "pumpUntil timed out after ${timeoutMillis}ms waiting for: $reason",
-                )
-            }
+        val settled = drainMainLooperUntil(
+            sleepMs = 2L,
             // Let the real Dispatchers.IO continuation (the preflight exec /
             // failServerDied tryEmit) make progress and re-enqueue onto the test
             // scheduler, then loop and drain it.
-            Thread.sleep(2)
-        }
+            onTick = { advanceUntilIdle() },
+            condition = condition,
+        )
+        assertTrue(
+            "pumpUntil timed out after ${GENEROUS_SETTLE_DEADLINE_MS}ms waiting for: $reason",
+            settled,
+        )
     }
 
     private fun leaseTargetFor(): SshLeaseTarget =

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1140,8 +1140,11 @@ condition.
   Handler/Thread, e.g. `SshTerminalBridge`): loop `advanceUntilIdle()` +
   `shadowOf(Looper.getMainLooper()).idleFor(16ms)` + small sleep to a
   `System.currentTimeMillis()` deadline that HARD-FAILS; assert the exit
-  condition, never the loop body. Reference: `TmuxSessionWarmOpenTest.pumpUntil`
-  (`:131-150`), codex pump (`TmuxSessionViewModelTest.kt:5602-5657`).
+  condition, never the loop body. **Do not hand-roll the loop** — call the ONE
+  audited `drainMainLooperUntil` below and inject the per-tick drain. Reference:
+  the codex pump (`TmuxSessionViewModelTest.kt:5602-5657`) and
+  `TmuxSessionWarmOpenTest.pumpUntil` (a virtual-clock drain injected as
+  `onTick`).
 
 **One shared Shape-B settle-pump (`drainMainLooperUntil`, #1048 criterion M).**
 The historically drifting, hand-rolled Shape-B pumps now converge on ONE
@@ -1156,9 +1159,27 @@ genuinely different and must NOT be forced into one: `awaitCondition` idles
 NOTHING and only `runCurrent()`s (idling would risk the #793 re-seed watchdog);
 the SshTerminalBridge-fed flood pumps `idleFor(16ms)` + `runCurrent()` for the
 #803 frame-paced drain; `SshTerminalBridgeTest` has no `TestScope` so idles the
-looper only. The two pumps that intentionally advance the virtual clock
-(`PromptComposerViewModelTest.advanceSchedulerUntil`,
-`TmuxSessionWarmOpenTest.pumpUntil`) stay separate by design.
+looper only.
+
+**A clock-ADVANCING drain is allowed — inject it as `onTick` (#2017).** The
+"never touches a clock" invariant is a property of the shared helper's BODY, not
+a ban on callers: a call site whose genuine per-tick drain is `advanceUntilIdle()`
+(bridging the virtual clock to a real `Dispatchers.IO` continuation) passes it as
+`onTick`. #1048 originally read that invariant as a carve-out and left
+`TmuxSessionWarmOpenTest.pumpUntil` — and its copy in
+`Issue1574DeadReconnectTest` — hand-rolled; both then carried a **5 s** real-time
+budget, which a contended box exhausts while the awaited continuation is merely
+unscheduled, so those classes red only under load (indistinguishable from a real
+regression, and the "just re-run it" reflex manufactures a green streak because
+Gradle skips a *passing* test task on re-run). Both are migrated. The single
+generous budget now lives in `GENEROUS_SETTLE_DEADLINE_MS` (30 s) as the
+`deadlineMs` default — **prefer the default; do not introduce a per-file
+constant, and never "fix" a contention timeout by nudging a local number up.**
+The one pump that genuinely cannot use the helper is
+`PromptComposerOutboundSendQueueViewModelTest.advanceSchedulerUntil`: its
+predicate is `suspend` and each tick re-checks it four times between distinct
+clock/dispatcher nudges, so its loop body is load-bearing rather than a drain. It
+stays separate, by design.
 
 **Banned:** a single `advanceUntilIdle()`+`idle()` then assert on real-thread
 output; a bare fixed `Thread.sleep(N)` as the only sync before a load-bearing

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -130,8 +130,9 @@
 #       together with a System.currentTimeMillis()/System.nanoTime() deadline loop),
 #       or (c) carries an inline `// JUSTIFIED:` opt-out. The two corrective shapes
 #       are Shape A (pinnable seam — SshLeaseAcquireBoundCharacterizationTest) and
-#       Shape B (wall-clock-bounded pump — TmuxSessionWarmOpenTest.pumpUntil / the
-#       codex pump). Current matches are baselined (advisory; the baseline only
+#       Shape B (wall-clock-bounded pump — the audited drainMainLooperUntil in
+#       :shared:test-support / the codex pump; #2017 migrated the hand-rolled
+#       copies onto it). Current matches are baselined (advisory; the baseline only
 #       shrinks as tests adopt a seam). The lone HARD-FAIL is the narrow,
 #       high-signal NEW case: a `runTest` test with a bare small `Thread.sleep(<N>)`
 #       immediately preceding its load-bearing assert and NO bounded-deadline loop
@@ -988,9 +989,15 @@ timing1_has_test_dispatcher() {
   grep -Eq 'StandardTestDispatcher[[:space:]]*\(|UnconfinedTestDispatcher[[:space:]]*\(' "$1"
 }
 
-# (b) the file shows the bounded-pump signature: an `idleFor(` pump AND a
-# `System.currentTimeMillis()` / `System.nanoTime()` deadline loop.
+# (b) the file shows the bounded-pump signature: either a call to the ONE
+# audited shared settle-pump (`drainMainLooperUntil`, which owns the bounded
+# loop and the generous hard deadline — issue #2017 migrated the hand-rolled
+# copies onto it, so requiring a raw `System.nanoTime()` deadline here would
+# push authors straight back to hand-rolling), or the legacy hand-rolled
+# signature: an `idleFor(` pump AND a `System.currentTimeMillis()` /
+# `System.nanoTime()` deadline loop.
 timing1_has_bounded_pump() {
+  grep -Eq 'drainMainLooperUntil[[:space:]]*\(' "$1" && return 0
   grep -Eq 'idleFor[[:space:]]*\(' "$1" \
     && grep -Eq 'System\.currentTimeMillis\(\)|System\.nanoTime\(\)' "$1"
 }
@@ -1724,8 +1731,9 @@ echo " TIMING1 Shape A: inject StandardTestDispatcher(testScheduler) for every"
 echo "        owned scope (SshLeaseAcquireBoundCharacterizationTest:191-219)."
 echo "        Shape B: drive an Android Handler/Thread worker with a bounded"
 echo "        advanceUntilIdle()+idleFor(16ms) pump to a currentTimeMillis/"
-echo "        nanoTime deadline that HARD-FAILS (TmuxSessionWarmOpenTest.pumpUntil"
-echo "        :131-150; codex pump TmuxSessionViewModelTest:5602-5657)."
+echo "        nanoTime deadline that HARD-FAILS — do NOT hand-roll it: call the"
+echo "        audited drainMainLooperUntil (:shared:test-support) and inject the"
+echo "        per-tick drain (codex pump TmuxSessionViewModelTest:5602-5657)."
 echo " V1     androidTest @Test/@Before/@After must use a VOID BLOCK body, not an"
 echo "        expression body. Change  fun x() = runBlocking { … }  to"
 echo "        fun x() { runBlocking { … } }  (the block body is always Unit; the"

--- a/shared/core-ssh/build.gradle.kts
+++ b/shared/core-ssh/build.gradle.kts
@@ -112,6 +112,11 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)
+    // Issue #2017: the ONE audited shared de-flake settle-pump
+    // (`drainMainLooperUntil`) — it owns the bounded loop AND the one generous
+    // wall-clock budget, so a real-thread wait here cannot drift back to a
+    // hand-rolled deadline that only reds under contention.
+    testImplementation(project(":shared:test-support"))
     // sshj needs a logger at test time too; reuse the nop binding.
     testRuntimeOnly(libs.slf4j.nop)
 }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.core.ssh
 
+import com.pocketshell.testsupport.drainMainLooperUntil
 import net.schmizz.sshj.DefaultConfig
 import net.schmizz.sshj.connection.Connection
 import net.schmizz.sshj.connection.channel.direct.DirectConnection
@@ -92,7 +93,7 @@ class RealSshPortForwardCountersTest {
             }
             assertTrue(
                 "accept loop should fill the active connection budget",
-                waitUntilReal(2_000L) { openCalls.get() >= 32 },
+                waitUntilReal { openCalls.get() >= 32 },
             )
             Thread.sleep(150)
             assertEquals(
@@ -266,13 +267,19 @@ class RealSshPortForwardCountersTest {
             else -> null
         }
 
-        fun waitUntilReal(timeoutMs: Long, predicate: () -> Boolean): Boolean {
-            val deadline = System.currentTimeMillis() + timeoutMs
-            while (System.currentTimeMillis() < deadline) {
-                if (predicate()) return true
-                Thread.sleep(10)
-            }
-            return predicate()
-        }
+        /**
+         * Issue #2017: was a hand-rolled bounded poll whose caller spent a **2 s**
+         * REAL-time budget — the tightest instance of the shape that made
+         * `Issue1574DeadReconnectTest` red only under contention (the accept loop
+         * here is a real background thread that a loaded box simply does not
+         * schedule promptly). The loop and the ONE audited generous deadline now
+         * come from the shared settle-pump; there is no per-tick drain to inject
+         * (no looper, no test scheduler), so the helper's default no-op `onTick` is
+         * the right pure poll. The returned boolean stays the caller's load-bearing
+         * `assertTrue`, and the following exact-count assertion still bounds the
+         * other side, so nothing is weakened.
+         */
+        fun waitUntilReal(predicate: () -> Boolean): Boolean =
+            drainMainLooperUntil(sleepMs = 10L, condition = predicate)
     }
 }

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/bridge/SshTerminalBridgeTest.kt
@@ -150,13 +150,10 @@ class SshTerminalBridgeTest {
 
             // And the producer must actually have been released (its blocked write
             // returned false on close), so no wedged producer leaks past teardown.
-            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
-                Thread.sleep(10)
-            }
+            val producerReleased = awaitProducerReleased(feed::isDone)
             assertTrue(
                 "the blocked producer must unwind once stop() closes the output queue",
-                feed.isDone,
+                producerReleased,
             )
         } finally {
             executor.shutdownNow()
@@ -242,13 +239,10 @@ class SshTerminalBridgeTest {
 
             // The blocked producer must have been unblocked (the looper drained the
             // queue so its write completed) — no wedged producer leaks.
-            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
-                Thread.sleep(10)
-            }
+            val producerReleased = awaitProducerReleased(feed::isDone)
             assertTrue(
                 "the blocked producer must unwind once the Main-thread reseed drains the queue",
-                feed.isDone,
+                producerReleased,
             )
             feed.get(1, TimeUnit.SECONDS)
 
@@ -399,13 +393,10 @@ class SshTerminalBridgeTest {
 
             // The blocked producer must have been released (the looper drained the queue
             // so its write completed) — no wedged producer leaks past the pump turn.
-            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
-                Thread.sleep(10)
-            }
+            val producerReleased = awaitProducerReleased(feed::isDone)
             assertTrue(
                 "the blocked producer must unwind once the on-looper pump drains the queue",
-                feed.isDone,
+                producerReleased,
             )
             feed.get(1, TimeUnit.SECONDS)
 
@@ -524,13 +515,10 @@ class SshTerminalBridgeTest {
                 elapsedMs < 5_000L,
             )
 
-            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
-                Thread.sleep(10)
-            }
+            val producerReleased = awaitProducerReleased(feed::isDone)
             assertTrue(
                 "the blocked producer must unwind once the on-looper gate-open drains the queue",
-                feed.isDone,
+                producerReleased,
             )
             feed.get(1, TimeUnit.SECONDS)
 
@@ -657,13 +645,10 @@ class SshTerminalBridgeTest {
 
             // The blocked producer must have been released (the looper drained the queue so
             // its write completed) — no wedged producer leaks past the backstop.
-            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
-                Thread.sleep(10)
-            }
+            val producerReleased = awaitProducerReleased(feed::isDone)
             assertTrue(
                 "the blocked producer must unwind once the on-looper acquire drains the queue",
-                feed.isDone,
+                producerReleased,
             )
             feed.get(1, TimeUnit.SECONDS)
 
@@ -768,13 +753,10 @@ class SshTerminalBridgeTest {
                 elapsedMs < 5_000L,
             )
 
-            val producerReleasedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (!feed.isDone && System.nanoTime() < producerReleasedDeadline) {
-                Thread.sleep(10)
-            }
+            val producerReleased = awaitProducerReleased(feed::isDone)
             assertTrue(
                 "the blocked multi-chunk producer must unwind once the reseed apply drains the queue",
-                feed.isDone,
+                producerReleased,
             )
             feed.get(1, TimeUnit.SECONDS)
 
@@ -1754,6 +1736,22 @@ class SshTerminalBridgeTest {
     private fun expectedDrainSlices(byteCount: Int): Int =
         (byteCount + SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES - 1) /
             SshTerminalBridge.PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES
+
+    /**
+     * Issue #2017: the six "the blocked producer must unwind" waits each
+     * hand-rolled the SAME bounded poll with a 5 s REAL-time budget — the exact
+     * shape (and the exact too-tight budget) that made `Issue1574DeadReconnectTest`
+     * red only under contention, where the producer thread is merely unscheduled
+     * rather than wedged. The loop and the ONE audited generous deadline now come
+     * from the shared settle-pump. There is no per-tick drain to inject here (the
+     * producer is a plain background thread, and this wait must NOT idle the looper
+     * — that is what the sibling [drainMainLooperUntil] wrapper is for), so the
+     * helper's default no-op `onTick` is the right pure poll. The returned boolean
+     * is the caller's load-bearing `assertTrue`, so a genuinely wedged producer
+     * still reds.
+     */
+    private fun awaitProducerReleased(isDone: () -> Boolean): Boolean =
+        drainMainLooperUntilShared(sleepMs = 10L, condition = isDone)
 
     private fun drainMainLooperUntil(done: () -> Boolean) {
         // Issue #1048: the bounded-wall-clock loop + the HARD deadline now live in

--- a/shared/test-support/src/main/java/com/pocketshell/testsupport/SettlePump.kt
+++ b/shared/test-support/src/main/java/com/pocketshell/testsupport/SettlePump.kt
@@ -1,6 +1,35 @@
 package com.pocketshell.testsupport
 
 /**
+ * The ONE audited generous wall-clock budget every Shape-B settle pump spends
+ * (issue #2017).
+ *
+ * A settle pump's deadline is a REAL-time budget being spent on a box whose real
+ * time is contended: sibling gate lanes, a cold Robolectric class load, a GC
+ * pause, or a CI runner that simply does not schedule the awaited thread for a
+ * few seconds all consume it without the awaited work being stalled at all. A
+ * budget sized for an idle box therefore reds only under load — the worst
+ * possible failure mode, because it is indistinguishable from a real regression
+ * at first glance and the "just re-run it" reflex manufactures a convincing
+ * green streak (a PASSING Gradle test task is skipped on re-run while a FAILING
+ * one always re-executes).
+ *
+ * That is exactly how `Issue1574DeadReconnectTest`'s hand-rolled 5 s pump
+ * behaved: green 3/3 in isolation, red at load ~13 with four parallel lanes. The
+ * cure is NOT nudging a local `5_000L` upward — it is that the audited helper
+ * owns ONE generous budget, so there is a single reviewed place where the
+ * project's contention headroom is decided and no per-file constant can drift
+ * back down.
+ *
+ * 30 s matches the budget the already-migrated tmux pumps converged on
+ * (`SLOW_FEED_DRAIN_TIMEOUT_MS`) and stays safely under `runTest`'s 60 s default
+ * global timeout, so the pump's own HARD-FAIL message fires first instead of
+ * `runTest` aborting the whole test with no diagnosis. It does NOT slow a
+ * healthy run: [drainMainLooperUntil] returns the instant its condition holds.
+ */
+const val GENEROUS_SETTLE_DEADLINE_MS: Long = 30_000L
+
+/**
  * The ONE audited settle-pump for the #1048 de-flake convention (Shape B —
  * wall-clock-bounded pump). It replaces 5+ hand-rolled, drifting near-duplicate
  * wall-clock pumps across the `:app` and `:shared:core-terminal` unit tests
@@ -9,9 +38,11 @@ package com.pocketshell.testsupport
  * NEXT timing flake.
  *
  * ## What this owns (the load-bearing, audited invariants)
- * - **A GENEROUS wall-clock deadline** measured on [System.currentTimeMillis].
- *   The loop returns the instant [condition] holds (no slowdown on a healthy
- *   run) and returns `false` the moment the deadline passes.
+ * - **A GENEROUS wall-clock deadline** measured on [System.currentTimeMillis],
+ *   defaulting to the ONE audited [GENEROUS_SETTLE_DEADLINE_MS] (#2017) so no
+ *   call site has to pick — or drift — its own contention headroom. The loop
+ *   returns the instant [condition] holds (no slowdown on a healthy run) and
+ *   returns `false` the moment the deadline passes.
  * - **A HARD boundary, never a silent swallow (#1102 lesson).** This function
  *   returns a `Boolean`; the deadline is the load-bearing assertion and the
  *   CALLER must `assertTrue(...)`/`throw` on `false`. It never weakens the
@@ -43,15 +74,27 @@ package com.pocketshell.testsupport
  * sites are untouched) and passes the drain it genuinely needs; the bounded
  * loop and the hard deadline live here, once.
  *
- * The two pumps that intentionally advance the kotlinx VIRTUAL clock
- * (`PromptComposerViewModelTest.advanceSchedulerUntil`, which `advanceTimeBy`s
- * and yields to real `Dispatchers.IO`, and `TmuxSessionWarmOpenTest.pumpUntil`,
- * which `advanceUntilIdle`s) are deliberately NOT migrated onto this helper —
- * advancing the virtual clock is their whole point and is incompatible with the
- * "never touch a clock" invariant above. They stay separate, by design.
+ * ## Clock-advancing drains ARE allowed — through [onTick] (revised by #2017)
+ * The "never touch a clock" invariant above is a property of THIS FUNCTION'S
+ * BODY, not a ban on callers. A call site whose genuine per-tick drain is
+ * `advanceUntilIdle()` (bridging the virtual clock to a real
+ * `Dispatchers.IO` continuation) passes it as [onTick] — that is precisely what
+ * the injected drain exists for, and the helper still advances nothing itself.
+ * #1048 originally read the invariant as a carve-out and left
+ * `TmuxSessionWarmOpenTest.pumpUntil` (and its copy in
+ * `Issue1574DeadReconnectTest`) hand-rolled; both then carried a 5 s real-time
+ * budget that reds only under contention (#2017). They are migrated.
+ *
+ * The one pump that genuinely cannot use this helper is
+ * `PromptComposerOutboundSendQueueViewModelTest.advanceSchedulerUntil`: its
+ * predicate is `suspend` (incompatible with the plain `() -> Boolean`
+ * [condition]) and each tick re-checks that predicate FOUR times between
+ * distinct clock/dispatcher nudges, so its loop body is load-bearing rather than
+ * a drain. It stays separate, by design, with its own generous 40 s budget.
  *
  * @param deadlineMs generous wall-clock budget; the pump returns `false` once it
- *   elapses without [condition] holding.
+ *   elapses without [condition] holding. Defaults to the ONE audited
+ *   [GENEROUS_SETTLE_DEADLINE_MS] — prefer the default over a per-call constant.
  * @param sleepMs real-wall-clock yield per tick so off-Main / real-IO threads
  *   get scheduling time before the next drain.
  * @param onTick the per-tick drain (see above); defaults to a no-op pure poll.
@@ -59,7 +102,7 @@ package com.pocketshell.testsupport
  * @return `true` if [condition] held within [deadlineMs]; `false` on timeout.
  */
 fun drainMainLooperUntil(
-    deadlineMs: Long,
+    deadlineMs: Long = GENEROUS_SETTLE_DEADLINE_MS,
     sleepMs: Long = 2L,
     onTick: () -> Unit = {},
     condition: () -> Boolean,


### PR DESCRIPTION
Closes #2017. **Test-only — no production delta.**

## The immediate symptom

`Issue1574DeadReconnectTest` hand-rolled a Shape-B settle pump with a **5 s wall-clock budget**. It failed at box load ~13 with `pumpUntil timed out after 5000ms waiting for: …` and was 3/3 green in isolation. A real-time budget on a contended box is exhausted while the awaited continuation is merely *unscheduled*, so the test reds under load and passes alone — which reads as a product defect until someone checks the machine. It cost a review round to attribute.

## The root cause was the documentation, not the file

This is the part worth reading.

`AGENTS.md`, `docs/testing.md` and `SettlePump`'s KDoc all said clock-advancing pumps **"stay separate by design"** and must not be folded into the audited helper. That is a **non-sequitur**, established from source during review:

`drainMainLooperUntil`'s entire body is `onTick(); if (condition()) return true; Thread.sleep(sleepMs)` inside a deadline loop (`SettlePump.kt:109-121`). It has **no clock of its own** — every drain is delegated. A caller injecting `advanceUntilIdle()` cannot violate *"the helper never touches a clock."*

#1048's own status comment says exactly that, **twice** (*"NEVER touches a clock **itself**"*, *"all draining is the injected `onTick`"*), then concludes one line later that clock-advancing pumps are "incompatible with the invariant" — and its reviewer repeated that verbatim. Meanwhile #1048's criterion M was in fact **scoped** ("consolidate the Tier-1 `SshTerminalBridge`-fed codex/flood pumps"), and it cited `TmuxSessionWarmOpenTest.pumpUntil` in the same issue as the **reference implementation** of Shape B.

So a scoping decision was retro-justified as a design incompatibility, that justification landed in the docs, and `Issue1574DeadReconnectTest`'s pump was copy-pasted from the very file the carve-out exempted — 5 s budget included. **The doc did not merely fail to prevent the bug; it authorised it.**

All three documents are corrected, naming the mechanism so it cannot re-leak.

## One carve-out survives — for a different, real reason

`advanceSchedulerUntil` (`PromptComposerAttachmentWedgeTest.kt:146-166`) stays bespoke, **not** because of clocks: its `suspend` predicate is re-checked **four times per iteration** between distinct nudges, while the helper checks once per tick. Folding it in would drop three observation points. Its loop body is load-bearing, not a drain.

The reviewer diffed every migrated drain against its predecessor — all are preserved verbatim through `onTick`. Nothing genuinely different was flattened.

## Evidence

- **Red→green (reviewer-driven):** base 5 s loop restored + an injected 7 s stall reproduced the exact reported string at **both** call sites; the migrated pump under the *identical* stall → 4/4, 0 skipped.
- **Mutation 1** (condition never holds): still **throws** at `30000ms`, selectively — the hard-fail survived migration; it did not silently become a `return`. That was the catastrophic-and-invisible failure mode to rule out.
- **Mutation 2** (`GENEROUS_SETTLE_DEADLINE_MS = 5_000L`): the new `SettlePumpContentionBudgetTest` reddens on the **behavioural 5.1 s-stall arm**, not merely on the constant — so the guard is live, and CI's required `Unit tests` job runs it.
- **Determinism:** 20/20 (app + core-terminal) and 20/20 (core-ssh), each run checked for cache markers, XML freshness, non-zero counts and the named class.
- Reviewer's full run: 9702 executed / 0 failed / 0 skipped across four modules, 1046 XML files 0 stale, all four task console lines bare.

## Orchestrator integration gate (this exact tree, base `002c8087`)

Canonical `scripts/full-jvm-gate.sh` as a transient unit — `Result=success`, `ExecMainStatus=0`, `BUILD SUCCESSFUL in 16m 35s`, `603 actionable tasks: 603 executed`:

| Check | Result |
|---|---|
| `:app:testDebugUnitTest` | **4476 executed / 0 failures / 0 skipped** |
| `:app:testReleaseUnitTest` | **4464 executed / 0 failures / 0 skipped** |
| XML freshness vs run marker | 478/478 and 476/476 |
| Cache markers on test-execution tasks | none (only `:shared:test-support` `NO-SOURCE`) |
| `SettlePumpContentionBudgetTest` | 3/0 in **both** variants |
| `Issue1574DeadReconnectTest` | 4/0 in **both** variants |

The untracked `SettlePumpContentionBudgetTest.kt` was copied explicitly and md5-verified — mutation 2 shows it is the **only** thing pinning the budget, so merging without it would drop the durable guard entirely.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2017#issuecomment-5202652072

## Residue, tracked not swept — #2026

The status comment claimed no short pumps survive outside the declared roots. The reviewer found that inaccurate: two 5 s hand-rolled pumps remain, in `ForwardingServiceObserverGenerationTest.kt` and `DeferredPrefsCorruptPrefsTest.kt`, neither scanned by `TIMING1`. The first was introduced by **#2006, merged earlier the same night** — a fresh instance of this exact class landing hours before the fix. Filed as **#2026**, including widening the `TIMING1` scan so the next one is caught mechanically rather than by a reviewer noticing.
