### PR TITLE
projects: type the session-create outcome so a failed agent launch is reported (#1928)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/hosts/HostAndFolderListScrollE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/HostAndFolderListScrollE2eTest.kt
@@ -34,6 +34,7 @@ import com.pocketshell.app.projects.FolderListViewModel
 import com.pocketshell.app.projects.FolderSessionRow
 import com.pocketshell.app.projects.folderDetailRowTestTag
 import com.pocketshell.app.projects.folderListFlatRowTestTag
+import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.app.proof.clearLastSessionPrefs
 import com.pocketshell.app.settings.HostDetailViewMode
 import com.pocketshell.core.storage.AppDatabase
@@ -362,7 +363,7 @@ private class OverflowFolderListGateway(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> = Result.success(sessionName)
+    ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
     override suspend fun createEmptyProject(
         host: HostEntity,

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchVersionMismatchHintE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchVersionMismatchHintE2eTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.proof.FakeOldHostSshSession
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -20,16 +21,22 @@ import java.io.File
  * This runs the REAL production wiring
  * ([SshFolderListGateway.createSessionOnSession], the same code the picker
  * confirm path calls) on the Android runtime, against an on-device fake
- * [SshSession] that injects the outdated-host `agent --help` probe output via a
- * test seam. The fake stands in for an outdated remote so the proof is
- * deterministic and needs no separate Docker fixture (the deterministic
- * `agents` fixture ships a CURRENT `pocketshell` that DOES have `agent`).
+ * [com.pocketshell.core.ssh.SshSession] that injects the outdated-host
+ * `agent --help` probe output via a test seam. The fake stands in for an
+ * outdated remote so the proof is deterministic and needs no separate Docker
+ * fixture (the deterministic `agents` fixture ships a CURRENT `pocketshell`
+ * that DOES have `agent`) — it is the non-happy-host fixture G10 asks for.
  *
- * The friendly hint is exactly the `RuntimeException` message that
- * `createSession` surfaces as `Result.failure`, which the folder-list view
- * model renders to the user as "Couldn't create session: <hint>"
- * (FolderListViewModel#createSession). Asserting the thrown message therefore
- * asserts the on-screen text.
+ * ## Issue #1928: the same hint, correctly ACCOUNTED FOR
+ *
+ * The version pre-flight runs AFTER the tmux session has been created, and it
+ * used to THROW — so this exact scenario reported "Couldn't create session:
+ * <hint>" while an empty session sat on the host, unmentioned. It is now the
+ * reason of a [SessionCreateOutcome.LaunchFailed]: same words, but the outcome
+ * says the session EXISTS, and the surfaces render it as "Session “…” was
+ * created, but the agent didn't start: <hint>". This class asserts the whole
+ * shape — the outcome type, the session it names, the hint, the doomed line NOT
+ * being typed, and the created session NOT being cleaned up.
  *
  * The captured before/after + recorded commands are written under the app's
  * external files dir (`agent-version-mismatch/`) per the artifact rules.
@@ -46,7 +53,7 @@ class AgentLaunchVersionMismatchHintE2eTest {
         // the `agent` subcommand — the #759 maintainer dogfood host.
         val session = FakeOldHostSshSession()
 
-        val error = runCatching {
+        val outcome = runCatching {
             gateway.createSessionOnSession(
                 session = session,
                 sessionName = "issue759-outdated",
@@ -56,13 +63,27 @@ class AgentLaunchVersionMismatchHintE2eTest {
                 startCommand = "pocketshell agent claude --dir '/home/alexey/tmp/test'",
                 namePolicy = SessionNamePolicy.UniqueOnHost,
             )
-        }.exceptionOrNull()
+        }
 
-        val hint = error?.message.orEmpty()
+        // Issue #1928: an outdated host is a LAUNCH failure, not a create
+        // failure — the tmux session was created one step earlier and is the
+        // user's to keep. Reporting it as a create failure left an orphan
+        // session the user was never told about.
+        val value = outcome.getOrNull()
+        assertTrue(
+            "an outdated host must not fail the CREATE — the session exists; got $outcome",
+            value is SessionCreateOutcome.LaunchFailed,
+        )
+        val launchFailed = value as SessionCreateOutcome.LaunchFailed
+        assertEquals(
+            "the outcome must name the session that exists on the host",
+            "issue759-outdated",
+            launchFailed.sessionName,
+        )
+        val hint = launchFailed.detail
 
         // The friendly, actionable hint — names the installed version, the
         // required minimum, and a copyable update command.
-        assertTrue("expected a surfaced failure, got $error", error is RuntimeException)
         assertTrue(
             "hint must name installed version: $hint",
             hint.contains(FakeOldHostSshSession.DEFAULT_OLD_VERSION),
@@ -97,11 +118,26 @@ class AgentLaunchVersionMismatchHintE2eTest {
             "must have pre-flighted `pocketshell agent --help`: ${session.execCommands}",
             session.execCommands.any { it.contains("pocketshell agent --help") },
         )
+        // Issue #1928: the session really was created, and the failed launch
+        // must not have taken it away again.
+        assertTrue(
+            "the tmux session must have been created before the launch: ${session.execCommands}",
+            session.execCommands.any { it.contains("create-detached") || it.contains("new-session") },
+        )
+        assertFalse(
+            "a failed launch must never kill the created session: ${session.execCommands}",
+            session.execCommands.any { it.contains("kill-session") },
+        )
 
-        writeArtifact(hint, session.execCommands)
+        // And the sentence the user actually reads names the session AND the hint.
+        val userMessage = sessionLaunchFailedMessage(launchFailed.sessionName, hint)
+        assertTrue(userMessage, userMessage.contains("issue759-outdated"))
+        assertTrue(userMessage, userMessage.contains(AgentLaunchVersionCheck.UPDATE_COMMAND))
+
+        writeArtifact(hint, userMessage, session.execCommands)
     } }
 
-    private fun writeArtifact(hint: String, commands: List<String>) {
+    private fun writeArtifact(hint: String, userMessage: String, commands: List<String>) {
         val dir = File(
             InstrumentationRegistry.getInstrumentation().targetContext
                 .getExternalFilesDir(null),
@@ -113,10 +149,13 @@ class AgentLaunchVersionMismatchHintE2eTest {
                 appendLine("--- raw Click error the OLD behaviour would have shown ---")
                 appendLine("Error: No such command 'agent'. (Did you mean one of: 'agent-log', 'usage'?)")
                 appendLine()
-                appendLine("--- friendly hint surfaced to the user (createSession failure) ---")
+                appendLine("--- launch-failure reason carried by SessionCreateOutcome.LaunchFailed ---")
                 appendLine(hint)
                 appendLine()
-                appendLine("--- commands the gateway issued over the lease (no send-keys) ---")
+                appendLine("--- issue #1928 sentence the user reads (session kept, agent absent) ---")
+                appendLine(userMessage)
+                appendLine()
+                appendLine("--- commands the gateway issued over the lease (no send-keys, no kill) ---")
                 commands.forEach { appendLine(it) }
             },
         )

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
@@ -2186,7 +2186,7 @@ private class MutableFolderListGateway(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> = Result.success(sessionName)
+    ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
     override suspend fun createEmptyProject(
         host: HostEntity,
@@ -2252,7 +2252,7 @@ private class OpenFailedThenRecoveringGateway(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> = Result.success(sessionName)
+    ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
     override suspend fun createEmptyProject(
         host: HostEntity,
@@ -2336,7 +2336,7 @@ private class FakeFolderListGateway(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> = Result.success(sessionName)
+    ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
     override suspend fun createEmptyProject(
         host: HostEntity,

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionClickTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionClickTest.kt
@@ -685,7 +685,7 @@ private class StaticGateway(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> = Result.success(sessionName)
+    ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
     override suspend fun createEmptyProject(
         host: HostEntity,

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListStopSessionTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListStopSessionTest.kt
@@ -592,7 +592,7 @@ class FolderListStopSessionTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = Result.success(sessionName)
+        ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFlowTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFlowTest.kt
@@ -416,7 +416,7 @@ private class HostDetailAssistantGateway(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> = Result.success(sessionName)
+    ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
     override suspend fun createEmptyProject(
         host: HostEntity,

--- a/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFolderDisambiguationTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/HostDetailAssistantFolderDisambiguationTest.kt
@@ -453,9 +453,9 @@ private class DisambiguationGateway(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> {
+    ): Result<SessionCreateOutcome> {
         createdSessions += cwd
-        return Result.success(sessionName)
+        return Result.success(SessionCreateOutcome.Created(sessionName))
     }
 
     override suspend fun createEmptyProject(

--- a/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypeProfilePickerUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypeProfilePickerUiTest.kt
@@ -390,9 +390,9 @@ private class RecordingSessionGateway : FolderListGateway {
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> {
+    ): Result<SessionCreateOutcome> {
         lastStartCommand.set(startCommand)
-        return Result.success(sessionName)
+        return Result.success(SessionCreateOutcome.Created(sessionName))
     }
 
     override suspend fun createEmptyProject(

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
@@ -23,6 +23,7 @@ import com.pocketshell.app.projects.SESSION_TYPE_PICKER_CONTENT_TAG
 import com.pocketshell.app.projects.SESSION_TYPE_PICKER_CREATE_TAG
 import com.pocketshell.app.projects.SESSION_TYPE_PICKER_CWD_TAG
 import com.pocketshell.app.projects.SESSION_TYPE_PICKER_SHELL_TAG
+import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.app.projects.SessionNamePolicy
 import com.pocketshell.app.projects.SshFolderListGateway
 import com.pocketshell.app.proof.DEFAULT_HOST
@@ -40,6 +41,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -243,9 +245,10 @@ class TmuxInSessionNewSessionCollisionDockerTest {
                 )
             }
             summary.appendLine("shell_requested=$baseName resolved=$shellResolved")
+            // Issue #1928: a no-launch create can only ever be a full success.
             assertEquals(
                 "[host] a colliding Shell create must resolve to the '-2' name, not the base",
-                "$baseName-2",
+                SessionCreateOutcome.Created("$baseName-2"),
                 shellResolved,
             )
             assertEquals(
@@ -270,7 +273,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
             summary.appendLine("launch_requested=$baseName resolved=$launchResolved")
             assertEquals(
                 "[host] a colliding LAUNCH create must walk past '-2' to '-3'",
-                "$baseName-3",
+                SessionCreateOutcome.Created("$baseName-3"),
                 launchResolved,
             )
             assertEquals(
@@ -303,7 +306,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
             summary.appendLine("exact_requested=$recoveryName resolved=$exactResolved")
             assertEquals(
                 "[host] ExactName must return the requested name verbatim",
-                recoveryName,
+                SessionCreateOutcome.Created(recoveryName),
                 exactResolved,
             )
             assertEquals(
@@ -324,6 +327,159 @@ class TmuxInSessionNewSessionCollisionDockerTest {
         )
         Log.i(LOG_TAG, "[host] issue1820 resolution: $summary")
     } }
+
+    /**
+     * Issue #1928 — the post-create agent launch, on a REAL tmux over real SSH.
+     *
+     * `createSessionOnSession` created the session, ran the optional agent
+     * launch (`tmux send-keys …`) and **threw the result away**. A launch that
+     * exited non-zero still came back as `Result.success(<name>)`, so the app
+     * announced a working Claude/Codex session and handed the user an empty
+     * shell (or, worse, routed them to a session that no longer existed).
+     *
+     * ## Why this is real rather than a scripted fake
+     *
+     * The failing exec is a REAL `tmux send-keys` answered by the REAL tmux
+     * server in the Docker fixture, over a REAL sshj transport. Only the TIMING
+     * is made deterministic: production hits this when the pane target stops
+     * matching between the create and the launch — another device or `t kill`
+     * removing the session, a `rename-session`, or the systemd login-scope
+     * teardown that takes the whole tmux server with it. That window is a real
+     * race we cannot schedule, so [MutateBeforeSendKeysSession] performs the
+     * mutation on the same real host in the instant before the launch is
+     * forwarded (the #780 synthetic-state model). Nothing about the failure
+     * itself is simulated — tmux really does refuse, with its own exit code and
+     * its own stderr.
+     *
+     * ## Class coverage (G2): the two shapes have OPPOSITE session outcomes
+     *
+     *  - **KILLED** — the session is gone by the time the launch runs. Pre-fix
+     *    this was reported as full success and the caller navigated into
+     *    nothing.
+     *  - **RENAMED** — the session is very much alive under another name. The
+     *    launch still fails, and the gateway must report that WITHOUT cleaning
+     *    up the session it created (issue #1928 non-goal). This is the half
+     *    that proves "keep the session" rather than merely "report a failure".
+     */
+    @Test
+    fun failedPostCreateLaunchIsReportedAsPartialSuccessOnARealHost() { runBlocking {
+        val key = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        val suffix = "issue1928-${System.nanoTime().toString().takeLast(6)}"
+        val folder = "/tmp/$suffix"
+        createdFolders += folder
+        val killedName = "tmp-$suffix-killed"
+        val renamedName = "tmp-$suffix-renamed"
+        listOf(killedName, renamedName, "$renamedName-moved").forEach { createdSessions += it }
+        sshExec("mkdir -p '$folder'")
+
+        val gateway = SshFolderListGateway()
+        val summary = StringBuilder()
+
+        // (1) The session is REMOVED between create and launch.
+        val killedOutcome = withSshSession { real ->
+            gateway.createSessionOnSession(
+                session = MutateBeforeSendKeysSession(real, "tmux kill-session -t '=$killedName'"),
+                sessionName = killedName,
+                cwd = folder,
+                startCommand = "printf 'issue1928 launch\\n'",
+                namePolicy = SessionNamePolicy.ExactName,
+            )
+        }
+        summary.appendLine("killed_outcome=$killedOutcome")
+        summary.appendLine("killed_sessions_after=${listSessionsMatching(killedName)}")
+        // THE LOAD-BEARING ASSERTION (pre-fix: SessionCreateOutcome.Created, and
+        // before the type existed, a bare success carrying the name).
+        assertTrue(
+            "[host] a real non-zero `send-keys` must be reported as a partial success, " +
+                "not as a fully successful create; got $killedOutcome",
+            killedOutcome is SessionCreateOutcome.LaunchFailed,
+        )
+        assertEquals(
+            "[host] the outcome must name the session the create asked for",
+            killedName,
+            killedOutcome.sessionName,
+        )
+        assertTrue(
+            "[host] the reason must be the REAL tmux error, not an invented one: " +
+                (killedOutcome as SessionCreateOutcome.LaunchFailed).detail,
+            killedOutcome.detail.contains("find", ignoreCase = true) ||
+                killedOutcome.detail.contains("no server", ignoreCase = true) ||
+                killedOutcome.detail.contains("send-keys"),
+        )
+
+        // (2) The session is RENAMED between create and launch: the launch fails
+        //     and the created session is STILL THERE. The gateway must not tidy
+        //     it away, and must not create a replacement.
+        val renamedOutcome = withSshSession { real ->
+            val session = MutateBeforeSendKeysSession(
+                real,
+                "tmux rename-session -t '=$renamedName' '$renamedName-moved'",
+            )
+            val result = gateway.createSessionOnSession(
+                session = session,
+                sessionName = renamedName,
+                cwd = folder,
+                startCommand = "printf 'issue1928 launch\\n'",
+                namePolicy = SessionNamePolicy.ExactName,
+            )
+            assertFalse(
+                "[host] the gateway must never kill the session it created: " +
+                    session.gatewayCommands,
+                session.gatewayCommands.any { it.contains("kill-session") },
+            )
+            result
+        }
+        summary.appendLine("renamed_outcome=$renamedOutcome")
+        val survivors = listSessionsMatching(renamedName)
+        summary.appendLine("renamed_sessions_after=$survivors")
+        assertTrue(
+            "[host] a failed launch on a LIVE session must still be a partial success; " +
+                "got $renamedOutcome",
+            renamedOutcome is SessionCreateOutcome.LaunchFailed,
+        )
+        assertEquals(
+            "[host] the created session must SURVIVE a failed launch — it is the " +
+                "user's session and issue #1928 explicitly refuses to delete it",
+            listOf("$renamedName-moved"),
+            survivors,
+        )
+
+        artifactFile("issue1928-launch-failure.txt").writeText(
+            buildString {
+                appendLine("host=$DEFAULT_HOST port=$DEFAULT_PORT user=$DEFAULT_USER")
+                appendLine("folder=$folder")
+                append(summary)
+            },
+        )
+        Log.i(LOG_TAG, "[host] issue1928 launch accounting: $summary")
+    } }
+
+    /**
+     * Issue #1928: forwards every exec to the REAL host, but runs [mutation] on
+     * that same real host immediately before the gateway's `send-keys` — the
+     * deterministic stand-in for the real race where the pane target stops
+     * matching between the create and the launch.
+     *
+     * [gatewayCommands] records only what the GATEWAY asked for, so an assertion
+     * about what the gateway did (e.g. "it never killed the session") is not
+     * polluted by the mutation this class injects.
+     */
+    private class MutateBeforeSendKeysSession(
+        private val delegate: SshSession,
+        private val mutation: String,
+    ) : SshSession by delegate {
+        val gatewayCommands: MutableList<String> =
+            java.util.Collections.synchronizedList(mutableListOf<String>())
+
+        override suspend fun exec(command: String): com.pocketshell.core.ssh.ExecResult {
+            gatewayCommands += command
+            if (command.contains("send-keys")) {
+                delegate.exec(mutation)
+            }
+            return delegate.exec(command)
+        }
+    }
 
     /**
      * Name the step a thrown create failure came from. Without this a

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -67,6 +67,9 @@ import com.pocketshell.app.projects.RepoBrowserScreen
 import com.pocketshell.app.projects.STALE_SESSION_CONFIRM_TAG
 import com.pocketshell.app.projects.STALE_SESSION_DIALOG_TAG
 import com.pocketshell.app.projects.STALE_SESSION_GO_HOME_TAG
+import com.pocketshell.app.projects.SessionCreateOutcome
+import com.pocketshell.app.projects.fold
+import com.pocketshell.app.projects.sessionLaunchFailedMessage
 import com.pocketshell.app.projects.WatchedFoldersScreen
 import com.pocketshell.app.projects.WatchedFoldersViewModel
 import com.pocketshell.app.session.InlineDictationViewModel
@@ -1921,12 +1924,28 @@ private fun AppNavigator(
 }
 
 internal suspend fun recreateStaleSession(
-    create: suspend () -> Result<String>,
+    create: suspend () -> Result<SessionCreateOutcome>,
     onSuccess: (String) -> Unit,
     onFailure: (String) -> Unit,
 ) {
     runCatching { create().getOrThrow() }.fold(
-        onSuccess = onSuccess,
+        onSuccess = { outcome ->
+            outcome.fold(
+                onCreated = onSuccess,
+                // Issue #1928: recovery asks for no start command, so this is
+                // unreachable today — but it is handled rather than assumed away.
+                // Attaching on a partial success would put the user back into a
+                // session that is not the agent they were recovering, so it takes
+                // the same visible-error path a failed recreate takes.
+                onLaunchFailed = { name, detail ->
+                    Log.w(
+                        "MainActivity",
+                        "stale-session-recreate-launch-failed name=$name reason=$detail",
+                    )
+                    onFailure(sessionLaunchFailedMessage(name, detail))
+                },
+            )
+        },
         onFailure = { error ->
             val message = error.message?.takeIf { it.isNotBlank() }
                 ?: "The host did not report a reason."

--- a/app/src/main/java/com/pocketshell/app/assistant/AppAssistantActions.kt
+++ b/app/src/main/java/com/pocketshell/app/assistant/AppAssistantActions.kt
@@ -4,6 +4,8 @@ import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.FolderListResult
 import com.pocketshell.app.projects.SessionNamePolicy
+import com.pocketshell.app.projects.fold
+import com.pocketshell.app.projects.sessionLaunchFailedMessage
 import com.pocketshell.app.repos.ReposRemoteSource
 import com.pocketshell.app.sessions.LeaseSessionExec
 import com.pocketshell.app.sessions.LeaseSessionTarget
@@ -326,21 +328,33 @@ internal class AppAssistantActions(
             namePolicy = SessionNamePolicy.UniqueOnHost,
         )
         return result.fold(
-            onSuccess = { resolved ->
-                bridge.navigate(
-                    AppDestination.TmuxSession(
-                        hostId = params.hostId,
-                        hostName = params.hostName,
-                        hostname = params.hostname,
-                        port = params.port,
-                        username = params.username,
-                        keyPath = params.keyPath,
-                        passphrase = params.passphrase,
-                        sessionName = resolved,
-                        startDirectory = cwd,
-                    ),
+            onSuccess = { outcome ->
+                outcome.fold(
+                    onCreated = { resolved ->
+                        bridge.navigate(
+                            AppDestination.TmuxSession(
+                                hostId = params.hostId,
+                                hostName = params.hostName,
+                                hostname = params.hostname,
+                                port = params.port,
+                                username = params.username,
+                                keyPath = params.keyPath,
+                                passphrase = params.passphrase,
+                                sessionName = resolved,
+                                startDirectory = cwd,
+                            ),
+                        )
+                        ActionResult.ok("Started $agent session \"$resolved\" in $cwd on $host.")
+                    },
+                    // Issue #1928: the tmux session exists — say so, name it, and
+                    // do NOT navigate. Reporting `ok` here is the exact lie this
+                    // issue is about ("your Codex session is ready" → empty shell),
+                    // and reporting a bare create failure would be the mirror lie:
+                    // the assistant would leave an orphan session unmentioned.
+                    onLaunchFailed = { name, detail ->
+                        ActionResult.error(sessionLaunchFailedMessage(name, detail))
+                    },
                 )
-                ActionResult.ok("Started $agent session \"$resolved\" in $cwd on $host.")
             },
             onFailure = { ActionResult.error("Failed to start session: ${it.message}") },
         )

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -323,8 +323,14 @@ interface FolderListGateway {
      * [SessionNamePolicy]; it is deliberately required at every call site so a
      * new caller has to state its intent rather than inherit a default.
      *
-     * Returns the RESOLVED session name — which for [SessionNamePolicy.UniqueOnHost]
-     * may carry a `-2`/`-3` suffix the caller did not ask for — or a failure.
+     * Issue #1928: returns a [SessionCreateOutcome], not a bare name. A create
+     * has two halves and the optional launch half can fail on its own, so the
+     * result must distinguish full success ([SessionCreateOutcome.Created]),
+     * create failure (`Result.failure`) and PARTIAL success
+     * ([SessionCreateOutcome.LaunchFailed] — the tmux session exists, the
+     * requested agent did not start). The outcome carries the RESOLVED session
+     * name in both states, which for [SessionNamePolicy.UniqueOnHost] may carry
+     * a `-2`/`-3` suffix the caller did not ask for.
      */
     suspend fun createSession(
         host: HostEntity,
@@ -334,7 +340,7 @@ interface FolderListGateway {
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String>
+    ): Result<SessionCreateOutcome>
 
     suspend fun createEmptyProject(
         host: HostEntity,
@@ -1152,7 +1158,7 @@ class SshFolderListGateway internal constructor(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): Result<String> {
+    ): Result<SessionCreateOutcome> {
         return withLeaseSession(host, keyPath, passphrase) { session ->
             createSessionOnSession(
                 session = session,
@@ -1193,6 +1199,26 @@ class SshFolderListGateway internal constructor(
      *
      * Exposed as `internal` so the create + both fallback layers are covered by
      * JVM tests driving a fake [SshSession] (see FolderListGatewayFallbackTest).
+     *
+     * ## Issue #1928: the create half throws, the LAUNCH half never does
+     *
+     * Everything up to and including the tmux create still fails loudly: on
+     * those paths nothing exists on the host, so a thrown `RuntimeException`
+     * that surfaces as `Result.failure` is the honest answer. From the moment
+     * the session EXISTS the contract flips — the session is the user's and we
+     * keep it (issue #1928 non-goal: never kill a created session because its
+     * optional launch failed), so every launch-half failure is reported as
+     * [SessionCreateOutcome.LaunchFailed] instead.
+     *
+     * That covers all three ways the launch half can fail, which used to be
+     * mis-reported in two different directions:
+     *  - a NON-ZERO `send-keys` (pane target gone between create and send) was
+     *    DISCARDED entirely and reported as full success — the reported defect;
+     *  - the #759 outdated-host pre-flight and a bounded-exec timeout THREW,
+     *    reporting "couldn't create session" while an orphan session sat on the
+     *    host. The timeout was worse than cosmetic: `FolderListExecTimeoutException`
+     *    is a stale-channel symptom, so `withLeaseSession` retried the WHOLE
+     *    block on a fresh lease and created a SECOND session.
      */
     internal suspend fun createSessionOnSession(
         session: SshSession,
@@ -1200,7 +1226,7 @@ class SshFolderListGateway internal constructor(
         cwd: String,
         startCommand: String?,
         namePolicy: SessionNamePolicy,
-    ): String {
+    ): SessionCreateOutcome {
         if (session.execBounded(remoteStartDirectoryExistsCommand(cwd)).exitCode != 0) {
             throw RuntimeException(
                 startDirectoryMissingMessage(
@@ -1289,34 +1315,72 @@ class SshFolderListGateway internal constructor(
         // modal so the agent is immediately usable. The app just types
         // the one short line verbatim.
         if (startCommand != null) {
-            // Issue #759: an agent launch types the SHORT server-side wrapper
-            // line `pocketshell agent <kind> --dir …`. The `agent` subcommand
-            // only exists in pocketshell >= 0.3.34; on an OUTDATED host Click
-            // answers `No such command 'agent'`. Because the line is typed into
-            // a DETACHED pane via send-keys, that raw Click error would scroll
-            // past inside the pane and the user would just see a dead session
-            // with no idea why. So for agent launches we PRE-FLIGHT the same
-            // warm lease session (D21 — no new connection) with
-            // `pocketshell agent --help`: if the subcommand is missing we throw
-            // the actionable update hint, which surfaces through the normal
-            // createSession failure path instead of the cryptic Click error.
-            if (AgentLaunchVersionCheck.isAgentLaunchCommand(startCommand)) {
-                ensureAgentSubcommandAvailable(session)
+            val failure = launchStartCommand(session, resolvedName, startCommand)
+            if (failure != null) {
+                // Issue #1928: the session EXISTS. Log the resolved name and the
+                // host's reason (never the launch command — it can carry a
+                // profile / provider argument) and hand the caller the partial
+                // outcome so the user is told the truth.
+                Log.w(
+                    PROBE_LOG_TAG,
+                    "session-create-launch-failed name=$resolvedName reason=$failure",
+                )
+                return SessionCreateOutcome.LaunchFailed(resolvedName, failure)
             }
-            val quotedCommand = shellQuote(startCommand)
+        }
+        return SessionCreateOutcome.Created(resolvedName)
+    }
+
+    /**
+     * Issue #1928: run the post-create agent launch and REPORT its outcome —
+     * `null` when the agent really started, otherwise the host's reason.
+     *
+     * Nothing in here throws (except cancellation): by the time it runs the
+     * tmux session already exists, and a thrown failure would be reported to
+     * the user as "couldn't create session" for a session that is sitting right
+     * there. See the [createSessionOnSession] KDoc for the three failure shapes
+     * this collapses into one honest answer.
+     */
+    private suspend fun launchStartCommand(
+        session: SshSession,
+        resolvedName: String,
+        startCommand: String,
+    ): String? {
+        // Issue #759: an agent launch types the SHORT server-side wrapper
+        // line `pocketshell agent <kind> --dir …`. The `agent` subcommand
+        // only exists in pocketshell >= 0.3.34; on an OUTDATED host Click
+        // answers `No such command 'agent'`. Because the line is typed into
+        // a DETACHED pane via send-keys, that raw Click error would scroll
+        // past inside the pane and the user would just see a dead session
+        // with no idea why. So for agent launches we PRE-FLIGHT the same
+        // warm lease session (D21 — no new connection) with
+        // `pocketshell agent --help`: if the subcommand is missing we report
+        // the actionable update hint as the launch failure and never type the
+        // doomed line.
+        try {
+            if (AgentLaunchVersionCheck.isAgentLaunchCommand(startCommand)) {
+                agentSubcommandUnavailableHint(session)?.let { return it }
+            }
             // Issue #1820: EXACT pane target. A bare `-t <name>` prefix-matches,
             // so with `<name>-2` alive and `<name>` gone the launch line would be
             // typed into the NEIGHBOUR's pane — the #976 misroute, one line below
             // the guard that exists to prevent it. `=<name>:` is the exact form
             // for a pane target (see [TmuxTarget]).
-            session.execBounded(
+            val sent = session.execBounded(
                 pathAware(
                     "tmux send-keys -t ${shellQuote(TmuxTarget.pane(resolvedName))} " +
-                        "$quotedCommand Enter",
+                        "${shellQuote(startCommand)} Enter",
                 ),
             )
+            if (sent.exitCode == 0) return null
+            return sent.stderr.trim().ifBlank { sent.stdout.trim() }
+                .ifBlank { "tmux send-keys exited ${sent.exitCode}" }
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            return error.message?.trim()?.ifBlank { null }
+                ?: error.javaClass.simpleName
         }
-        return resolvedName
     }
 
     /**
@@ -1360,16 +1424,21 @@ class SshFolderListGateway internal constructor(
      * Issue #759: pre-flight version guard for an agent launch. Probes the host
      * (over the already-warm lease [session]) for the `pocketshell agent`
      * subcommand; if it is missing — the host's `pocketshell` predates 0.3.34 —
-     * throws the actionable "update pocketshell on the host" hint instead of
+     * returns the actionable "update pocketshell on the host" hint instead of
      * letting the cryptic `No such command 'agent'` Click error scroll past
      * inside the detached pane.
      *
-     * When the probe succeeds (current host) this is a no-op. The version is
-     * fetched best-effort only when the probe shows a mismatch, so the hint can
-     * name the concrete installed version; a probe/version failure to fetch
-     * never blocks a healthy launch.
+     * Returns `null` when the probe succeeds (current host), i.e. the launch may
+     * proceed. The version is fetched best-effort only when the probe shows a
+     * mismatch, so the hint can name the concrete installed version; a
+     * probe/version failure to fetch never blocks a healthy launch.
+     *
+     * Issue #1928 hard-cut (D22): this used to THROW the hint, which surfaced to
+     * the user as "couldn't create session" even though the session had already
+     * been created one step earlier. The hint is now the launch-failure reason
+     * of a [SessionCreateOutcome.LaunchFailed] — same words, honest accounting.
      */
-    private suspend fun ensureAgentSubcommandAvailable(session: SshSession) {
+    private suspend fun agentSubcommandUnavailableHint(session: SshSession): String? {
         val probe = session.execBounded(pathAware(AgentLaunchVersionCheck.AGENT_PROBE_COMMAND))
         if (!AgentLaunchVersionCheck.isAgentSubcommandMissing(
                 stdout = probe.stdout,
@@ -1377,7 +1446,7 @@ class SshFolderListGateway internal constructor(
                 exitCode = probe.exitCode,
             )
         ) {
-            return
+            return null
         }
         // Outdated host: best-effort fetch of the installed version so the hint
         // can be concrete ("this host's pocketshell is 0.3.33").
@@ -1387,14 +1456,12 @@ class SshFolderListGateway internal constructor(
                 version.stdout.ifBlank { version.stderr },
             )
         }.getOrNull()
-        throw RuntimeException(
-            AgentLaunchVersionCheck.mapLaunchFailureToHint(
-                stdout = probe.stdout,
-                stderr = probe.stderr,
-                exitCode = probe.exitCode,
-                installedVersion = installedVersion,
-            ) ?: AgentLaunchVersionCheck.outdatedHint(installedVersion),
-        )
+        return AgentLaunchVersionCheck.mapLaunchFailureToHint(
+            stdout = probe.stdout,
+            stderr = probe.stderr,
+            exitCode = probe.exitCode,
+            installedVersion = installedVersion,
+        ) ?: AgentLaunchVersionCheck.outdatedHint(installedVersion)
     }
 
     override suspend fun killSession(

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -1064,11 +1064,11 @@ class FolderListViewModel internal constructor(
      * [startCommand] inside it via `send-keys` — invoked from the
      * [SessionTypePickerSheet] confirm path.
      *
-     * On success [onResolved] fires with the resolved tmux session name
-     * so the caller can route to `AppDestination.TmuxSession`. On
-     * failure the screen keeps the current list visible and shows the error
-     * through [actionStatus] (so the user sees what went wrong instead of a
-     * silent "nothing happened").
+     * On full success [onResolved] fires with the resolved tmux session name
+     * so the caller can route to `AppDestination.TmuxSession`. On failure —
+     * and on issue #1928's PARTIAL success, where the session exists but the
+     * agent did not start — the screen keeps the list visible and reports the
+     * reason through [actionStatus], not a silent "nothing happened".
      */
     fun createSession(
         sessionName: String,
@@ -1107,7 +1107,13 @@ class FolderListViewModel internal constructor(
                     namePolicy = SessionNamePolicy.UniqueOnHost,
                 )
                 result.fold(
-                    onSuccess = { resolvedName ->
+                    onSuccess = { outcome ->
+                        val resolvedName = outcome.sessionName
+                        // Issue #1928: a LaunchFailed session is a plain shell —
+                        // stamping the CHOSEN agent kind on it would put a Claude
+                        // badge on a session with no Claude in it. Fall back to
+                        // Probing so the reconcile settles the truth.
+                        val launched = outcome is SessionCreateOutcome.Created
                         // EPIC #679 (#678 create side): the app KNOWS it just created
                         // this session, so insert it into the maintained tree by id
                         // immediately — optimistically — instead of waiting for the
@@ -1133,13 +1139,28 @@ class FolderListViewModel internal constructor(
                                 sessionName = resolvedName,
                                 lastActivity = System.currentTimeMillis(),
                                 attached = false,
-                                agentKind = chosenKind ?: SessionAgentKind.Probing,
+                                agentKind = chosenKind?.takeIf { launched }
+                                    ?: SessionAgentKind.Probing,
                             ),
                             folderPath = cwd,
                         )
                         emitReady()
-                        _actionStatus.value = FolderActionStatus.Idle
-                        onResolved(resolvedName)
+                        // Issue #1928: the created session is inserted above in
+                        // BOTH states — it exists and stays. Only a full success
+                        // routes the user into it; a launch failure keeps them
+                        // here with the new row visible plus the reason, instead
+                        // of dropping them into a shell they asked to be an agent.
+                        outcome.fold(
+                            onCreated = {
+                                _actionStatus.value = FolderActionStatus.Idle
+                                onResolved(resolvedName)
+                            },
+                            onLaunchFailed = { name, detail ->
+                                _actionStatus.value = FolderActionStatus.Failed(
+                                    sessionLaunchFailedMessage(name, detail),
+                                )
+                            },
+                        )
                         refresh()
                     },
                     onFailure = { error ->

--- a/app/src/main/java/com/pocketshell/app/projects/SessionCreateOutcome.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionCreateOutcome.kt
@@ -1,0 +1,85 @@
+package com.pocketshell.app.projects
+
+/**
+ * Issue #1928: what a [FolderListGateway.createSession] call ACTUALLY achieved.
+ *
+ * A create has two independent halves — make the tmux session, then (optionally)
+ * launch the requested agent inside it with `send-keys`. Before this type the
+ * gateway returned `Result<String>`, which can only express two states, so the
+ * second half had nowhere to go: [SshFolderListGateway.createSessionOnSession]
+ * ran the launch and **discarded its result**. A launch that exited non-zero
+ * (the pane target vanished between create and send, the host's `pocketshell`
+ * predates the `agent` subcommand, the bounded exec timed out on a degraded
+ * link) still produced `Result.success(resolvedName)`, so the app told the user
+ * "your Claude session is ready" and handed them an empty shell.
+ *
+ * The three states are now distinct and a caller cannot reach the resolved name
+ * without deciding which one it is handling (see [fold]):
+ *
+ *  - **create failure** — `Result.failure`. Nothing exists on the host; the
+ *    thrown message is the actionable reason (missing start directory, launch
+ *    collision, tmux/systemd error).
+ *  - **[Created]** — full success. The session exists and, when a start command
+ *    was requested, it was typed into the new pane.
+ *  - **[LaunchFailed]** — PARTIAL success. The tmux session exists and MUST be
+ *    kept (issue #1928 non-goal: never delete a session just because the
+ *    optional launch failed), but the requested agent did not start. The user
+ *    has a plain shell under [sessionName] and needs to be told so.
+ *
+ * D22 hard cut: the `Result<String>` shape is gone, not deprecated. There is no
+ * overload, no `sessionNameOrNull()` convenience, and no default branch — every
+ * call site states what it does with a partial success or does not compile.
+ */
+sealed interface SessionCreateOutcome {
+
+    /** The tmux session that exists on the host. Real in BOTH states. */
+    val sessionName: String
+
+    /** Session created; the requested start command (if any) was launched. */
+    data class Created(override val sessionName: String) : SessionCreateOutcome
+
+    /**
+     * Session created, requested agent launch FAILED.
+     *
+     * [detail] is the host's own reason (tmux stderr, the #759 outdated-CLI
+     * update hint, or the bounded-exec timeout), already trimmed. It never
+     * carries the launch command itself, so a profile/API-key-bearing wrapper
+     * line cannot leak into a banner or a log line.
+     */
+    data class LaunchFailed(
+        override val sessionName: String,
+        val detail: String,
+    ) : SessionCreateOutcome
+}
+
+/**
+ * Consume a [SessionCreateOutcome] by handling BOTH states.
+ *
+ * This exists so that "collapse partial success into full success" is not
+ * something a caller can do by accident — the compiler requires both lambdas,
+ * and neither branch can be reached without naming it. Prefer this over a
+ * `when` + `.sessionName` read at the call sites the sweep in issue #1928
+ * covers (folder tree, in-session, assistant, stale-session recovery).
+ */
+inline fun <T> SessionCreateOutcome.fold(
+    onCreated: (sessionName: String) -> T,
+    onLaunchFailed: (sessionName: String, detail: String) -> T,
+): T = when (this) {
+    is SessionCreateOutcome.Created -> onCreated(sessionName)
+    is SessionCreateOutcome.LaunchFailed -> onLaunchFailed(sessionName, detail)
+}
+
+/**
+ * The ONE user-facing sentence for a [SessionCreateOutcome.LaunchFailed] —
+ * issue #1928.
+ *
+ * It has to say three things, because all three are actionable: the session
+ * DOES exist (so the user does not create a second one), the agent did NOT
+ * start (so they do not sit waiting for a prompt that never appears), and what
+ * to do next. Shared by every surface so the folder tree, the in-session sheet,
+ * the assistant and the stale-session recovery all report the same thing.
+ */
+fun sessionLaunchFailedMessage(sessionName: String, detail: String): String =
+    "Session “$sessionName” was created, but the agent didn't start: " +
+        "${detail.ifBlank { "the host gave no reason" }}. " +
+        "Open the session and start the agent from there."

--- a/app/src/main/java/com/pocketshell/app/tmux/SessionCreateOutcomeReporting.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/SessionCreateOutcomeReporting.kt
@@ -1,0 +1,49 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.projects.SessionCreateOutcome
+import com.pocketshell.app.projects.fold
+import com.pocketshell.app.projects.sessionLaunchFailedMessage
+
+/**
+ * Issue #1928: the in-session "+ New session" surface's reading of a
+ * [SessionCreateOutcome].
+ *
+ * It lives OUT of [TmuxSessionViewModel] on purpose. The VM is the D28
+ * god-object under a downward-only line/byte ratchet
+ * (`scripts/check-connection-vm-ratchet.sh`), so the three-state accounting the
+ * gateway now returns is expressed here and the VM keeps only the two lambdas
+ * that are genuinely its own — the success log/attach and its existing
+ * `reportSessionCreateFailure` breadcrumb.
+ *
+ * The split it enforces is the whole point of the issue:
+ *
+ *  - [onCreated] — full success. The session exists AND the requested agent
+ *    started, so attaching the user to it is honest.
+ *  - [onProblem] — everything else, with a `reason` token for the log and the
+ *    user-facing `message`. It covers BOTH a create failure (nothing on the
+ *    host, `reason = gateway_failure`, the throwable carried through) and issue
+ *    #1928's partial success (`reason = launch_failed`, the session exists and
+ *    is KEPT, the agent did not start). A partial success must never reach
+ *    [onCreated]: attaching would drop the user into a plain shell they asked
+ *    to be a Claude/Codex session, which is exactly the lie this issue is about.
+ */
+internal inline fun Result<SessionCreateOutcome>.reportSessionCreate(
+    onCreated: (sessionName: String) -> Unit,
+    onProblem: (reason: String, message: String, error: Throwable?) -> Unit,
+): Unit = fold(
+    onSuccess = { outcome ->
+        outcome.fold(
+            onCreated = onCreated,
+            onLaunchFailed = { name, detail ->
+                onProblem("launch_failed", sessionLaunchFailedMessage(name, detail), null)
+            },
+        )
+    },
+    onFailure = { error ->
+        onProblem(
+            "gateway_failure",
+            error.message?.takeIf { it.isNotBlank() } ?: "Couldn't create the session.",
+            error,
+        )
+    },
+)

--- a/app/src/main/java/com/pocketshell/app/tmux/StaleSessionPromptController.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/StaleSessionPromptController.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.tmux
 
 import com.pocketshell.app.projects.FolderListGateway
+import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.app.projects.SessionNamePolicy
 import com.pocketshell.core.storage.dao.HostDao
 import kotlinx.coroutines.CoroutineDispatcher
@@ -133,6 +134,15 @@ class StaleSessionPromptController internal constructor(
      * recreates in the host home directory (`~`), so the user always recovers —
      * never a blank/error. Returns a failure when no create seam is wired (a bare
      * test controller) or the host row / create exec fails.
+     *
+     * Issue #1928: this returns the gateway's [SessionCreateOutcome] verbatim
+     * rather than flattening it back to a name. Recovery passes
+     * `startCommand = null`, so it should only ever see
+     * [SessionCreateOutcome.Created] — but "should" is exactly how a partial
+     * success gets collapsed into a full one. The caller
+     * (`MainActivity.recreateStaleSession`) decides, so if a start command is
+     * ever added here the compiler makes that decision explicit instead of
+     * silently attaching the user to an agent-less session.
      */
     suspend fun createSessionInFolder(
         hostId: Long,
@@ -140,7 +150,7 @@ class StaleSessionPromptController internal constructor(
         passphrase: CharArray?,
         sessionName: String,
         folderPath: String?,
-    ): Result<String> {
+    ): Result<SessionCreateOutcome> {
         val gateway = this.gateway
         val hostDao = this.hostDao
         if (gateway == null || hostDao == null) {

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -16003,8 +16003,8 @@ public class TmuxSessionViewModel @Inject constructor(
      * created session honours every chosen option identically: the picker
      * synthesises [startCommand] (`pocketshell agent <kind> --dir … [--profile …]
      * [--no-skip-permissions]`) and the gateway `send-keys`-launches it inside
-     * the new pane. On success [onResolved] fires with the resolved session name
-     * so the screen can attach to it via navigation.
+     * the new pane. On FULL success [onResolved] fires with the resolved session
+     * name so the screen attaches; issue #1928's partial success does not.
      *
      * Creation requires the production gateway, host DAO, and an attached target.
      * A missing dependency or target is an explicit failure: this method never
@@ -16060,8 +16060,9 @@ public class TmuxSessionViewModel @Inject constructor(
                 startCommand = startCommand,
                 namePolicy = SessionNamePolicy.UniqueOnHost,
             )
-            result.fold(
-                onSuccess = { resolvedName ->
+            // Issue #1928: [reportSessionCreate] owns the three-state accounting.
+            result.reportSessionCreate(
+                onCreated = { resolvedName ->
                     Log.i(
                         ISSUE_464_KILL_TAG,
                         "create-session-ok host=${current.hostId} name=$resolvedName " +
@@ -16069,14 +16070,13 @@ public class TmuxSessionViewModel @Inject constructor(
                     )
                     onResolved(resolvedName)
                 },
-                onFailure = { error ->
+                onProblem = { reason, message, error ->
                     reportSessionCreateFailure(
-                        reason = "gateway_failure",
+                        reason = reason,
                         creation = creation,
                         hostId = current.hostId,
                         error = error,
-                        message = error.message?.takeIf { it.isNotBlank() }
-                            ?: "Couldn't create the session.",
+                        message = message,
                     )
                 },
             )

--- a/app/src/test/java/com/pocketshell/app/MainActivityStaleSessionRecreateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/MainActivityStaleSessionRecreateTest.kt
@@ -1,8 +1,10 @@
 package com.pocketshell.app
 
+import com.pocketshell.app.projects.SessionCreateOutcome
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MainActivityStaleSessionRecreateTest {
@@ -42,12 +44,45 @@ class MainActivityStaleSessionRecreateTest {
         var visibleFailure: String? = null
 
         recreateStaleSession(
-            create = { Result.success("work-2") },
+            create = { Result.success(SessionCreateOutcome.Created("work-2")) },
             onSuccess = { navigatedTo = it },
             onFailure = { visibleFailure = it },
         )
 
         assertEquals("work-2", navigatedTo)
         assertNull(visibleFailure)
+    }
+
+    /**
+     * Issue #1928 — the stale-session-recovery half of the caller sweep.
+     *
+     * Recovery must not treat a PARTIAL success as a full one. If it navigated
+     * on [SessionCreateOutcome.LaunchFailed] the user would be attached to a
+     * session that is not the agent they were recovering, with nothing on screen
+     * saying so — the same lie the folder tree and the in-session sheet used to
+     * tell. The visible reason must name the session AND the host's cause.
+     */
+    @Test
+    fun launchFailedStaleRecreateReportsInsteadOfNavigating() = runTest {
+        var navigatedTo: String? = null
+        var visibleFailure: String? = null
+
+        recreateStaleSession(
+            create = {
+                Result.success(
+                    SessionCreateOutcome.LaunchFailed("work-2", "can't find pane: =work-2:"),
+                )
+            },
+            onSuccess = { navigatedTo = it },
+            onFailure = { visibleFailure = it },
+        )
+
+        assertNull("a launch failure must not navigate as if the agent started", navigatedTo)
+        val message = visibleFailure.orEmpty()
+        assertTrue("must name the created session: $message", message.contains("work-2"))
+        assertTrue(
+            "must carry the host's reason: $message",
+            message.contains("can't find pane: =work-2:"),
+        )
     }
 }

--- a/app/src/test/java/com/pocketshell/app/assistant/AppAssistantActionsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/assistant/AppAssistantActionsTest.kt
@@ -5,6 +5,7 @@ import com.pocketshell.app.projects.FolderImportPayload
 import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.FolderListResult
 import com.pocketshell.app.projects.SessionNamePolicy
+import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.app.repos.ReposJsonParser
 import com.pocketshell.app.repos.ReposRemoteSource
 import com.pocketshell.core.ssh.ExecResult
@@ -119,6 +120,11 @@ class AppAssistantActionsTest {
      */
     private class NameResolvingGateway(
         liveSessions: Set<String> = emptySet(),
+        /**
+         * Issue #1928: when set, every create reports PARTIAL success — the tmux
+         * session exists but its agent launch failed with this reason.
+         */
+        private val launchFailureDetail: String? = null,
     ) : FolderListGateway {
         val live = liveSessions.toMutableSet()
         val policies = mutableListOf<SessionNamePolicy>()
@@ -139,7 +145,7 @@ class AppAssistantActionsTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> {
+        ): Result<SessionCreateOutcome> {
             policies += namePolicy
             val resolved = when (namePolicy) {
                 SessionNamePolicy.ExactName -> sessionName
@@ -161,7 +167,11 @@ class AppAssistantActionsTest {
             }
             live += resolved
             createdNames += resolved
-            return Result.success(resolved)
+            return Result.success(
+                launchFailureDetail
+                    ?.let { SessionCreateOutcome.LaunchFailed(resolved, it) }
+                    ?: SessionCreateOutcome.Created(resolved),
+            )
         }
 
         override suspend fun createEmptyProject(
@@ -207,7 +217,7 @@ class AppAssistantActionsTest {
                 cwd: String,
                 startCommand: String?,
                 namePolicy: SessionNamePolicy,
-            ): Result<String> = Result.success(sessionName)
+            ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
 
             override suspend fun createEmptyProject(
                 host: HostEntity,
@@ -427,7 +437,7 @@ class AppAssistantActionsTest {
                 cwd: String,
                 startCommand: String?,
                 namePolicy: SessionNamePolicy,
-            ): Result<String> = Result.success(sessionName)
+            ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
             override suspend fun createEmptyProject(
                 host: HostEntity,
                 keyPath: String,
@@ -517,6 +527,52 @@ class AppAssistantActionsTest {
         assertEquals("proj-2", destination.sessionName)
     }
 
+    /**
+     * Issue #1928 — the ASSISTANT caller of the partial-success outcome.
+     *
+     * "Start a Claude session in ~/proj" that creates the session but fails to
+     * launch Claude used to answer `ok` ("Started claude session …") and
+     * navigate — the assistant confidently reporting an agent that is not there.
+     * Reporting a plain create failure would be the opposite lie: an orphan
+     * session on the host that the answer never mentions. The answer must name
+     * the session that exists AND say the agent did not start.
+     */
+    @Test
+    fun startSessionLaunchFailureIsReportedAsAProblemNamingTheCreatedSession() = runTest {
+        val gateway = NameResolvingGateway(launchFailureDetail = "can't find pane: =proj:")
+        val bridge = RecordingBridge()
+        val actions = actions(
+            bridge = bridge,
+            responder = { ExecResult("", "", 0) },
+            gateway = gateway,
+        )
+
+        val result = actions.startSession(host = "dev", cwd = "/home/dev/proj", agent = "claude")
+
+        assertFalse(
+            "an agent that never started must not be reported as ok: ${result.message}",
+            result.ok,
+        )
+        assertTrue("must name the created session: ${result.message}", result.message.contains("proj"))
+        assertTrue(
+            "must say the session WAS created: ${result.message}",
+            result.message.contains("was created"),
+        )
+        assertTrue(
+            "must carry the host's reason: ${result.message}",
+            result.message.contains("can't find pane: =proj:"),
+        )
+        assertTrue(
+            "must not navigate into a session whose agent never started",
+            bridge.navigated.none { it is AppDestination.TmuxSession },
+        )
+        assertEquals(
+            "the created session must be left alone on the host",
+            listOf("proj"),
+            gateway.createdNames,
+        )
+    }
+
     @Test
     fun startSessionAsksTheHostToResolveTheName() = runTest {
         val gateway = NameResolvingGateway()
@@ -594,7 +650,7 @@ class AppAssistantActionsTest {
                 cwd: String,
                 startCommand: String?,
                 namePolicy: SessionNamePolicy,
-            ): Result<String> = Result.failure(RuntimeException("start directory does not exist"))
+            ): Result<SessionCreateOutcome> = Result.failure(RuntimeException("start directory does not exist"))
             override suspend fun createEmptyProject(
                 host: HostEntity,
                 keyPath: String,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListAutoExpandTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListAutoExpandTest.kt
@@ -248,7 +248,7 @@ class FolderListAutoExpandTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayCreateDaemonFdTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayCreateDaemonFdTest.kt
@@ -71,7 +71,7 @@ class FolderListGatewayCreateDaemonFdTest {
             )
 
             // Create returned promptly with no false timeout.
-            assertEquals(SESSION_NAME, name)
+            assertEquals(SessionCreateOutcome.Created(SESSION_NAME), name)
             // The capped create ran with the daemon-fd redirect (the fix marker).
             val capped = session.execCommands.single {
                 it.contains("create-detached") && it.contains(" -c ")
@@ -112,7 +112,7 @@ class FolderListGatewayCreateDaemonFdTest {
                 namePolicy = SessionNamePolicy.ExactName,
             )
 
-            assertEquals(SESSION_NAME, name)
+            assertEquals(SessionCreateOutcome.Created(SESSION_NAME), name)
             val sendKeys = session.execCommands.single { it.contains("send-keys") }
             assertTrue(
                 "send-keys must type the shell command into the new session: $sendKeys",
@@ -144,7 +144,7 @@ class FolderListGatewayCreateDaemonFdTest {
                 namePolicy = SessionNamePolicy.ExactName,
             )
 
-            assertEquals(SESSION_NAME, name)
+            assertEquals(SessionCreateOutcome.Created(SESSION_NAME), name)
             assertTrue(
                 "existing-server create must still launch the agent",
                 session.execCommands.any { it.contains("send-keys") && it.contains("agent codex") },

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
@@ -91,7 +91,7 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.ExactName,
         )
 
-        assertEquals(SESSION_NAME, name)
+        assertEquals(SessionCreateOutcome.Created(SESSION_NAME), name)
         val capped = session.execCommands.single { it.contains("create-detached") }
         // The recorded command is wrapped by pathAware (`/bin/sh -lc '<PATH=…;
         // body>'`), which re-escapes every inner single quote to `'"'"'`. Build
@@ -153,7 +153,7 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.ExactName,
         )
 
-        assertEquals(SESSION_NAME, name)
+        assertEquals(SessionCreateOutcome.Created(SESSION_NAME), name)
         val fallback = session.execCommands.single { it.contains("new-session -A -d") }
         // Same pathAware wrapping applies to the raw fallback create; assert the
         // EXACT wrapped string from the production builder.
@@ -199,7 +199,7 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.ExactName,
         )
 
-        assertEquals(SESSION_NAME, name)
+        assertEquals(SessionCreateOutcome.Created(SESSION_NAME), name)
         assertTrue(
             "verb-absent host must fall back to raw new-session, not error",
             session.execCommands.any {
@@ -346,6 +346,10 @@ class FolderListGatewayFallbackTest {
         // raw Click "No such command 'agent'" error. The launch must abort with
         // the actionable update hint, and must NOT type the doomed agent line
         // into the pane (no send-keys).
+        //
+        // Issue #1928: the pre-flight runs AFTER the session was created, so the
+        // hint is now the reason of a LAUNCH failure rather than a thrown CREATE
+        // failure — same words, and it no longer claims nothing was created.
         val session = CreateSessionFake(
             results = listOf(
                 CreateSessionFake.Rule(match = "create-detached", result = ok()),
@@ -371,18 +375,19 @@ class FolderListGatewayFallbackTest {
         )
         val gateway = SshFolderListGateway()
 
-        val ex = runCatching {
-            gateway.createSessionOnSession(
-                session = session,
-                sessionName = SESSION_NAME,
-                cwd = CWD,
-                startCommand = "pocketshell agent claude --dir '/home/me/proj dir'",
-                namePolicy = SessionNamePolicy.ExactName,
-            )
-        }.exceptionOrNull()
+        val outcome = gateway.createSessionOnSession(
+            session = session,
+            sessionName = SESSION_NAME,
+            cwd = CWD,
+            startCommand = "pocketshell agent claude --dir '/home/me/proj dir'",
+            namePolicy = SessionNamePolicy.ExactName,
+        )
 
-        assertTrue("expected a surfaced RuntimeException, got $ex", ex is RuntimeException)
-        val message = ex?.message.orEmpty()
+        assertTrue(
+            "an outdated host is a LAUNCH failure — the session exists; got $outcome",
+            outcome is SessionCreateOutcome.LaunchFailed,
+        )
+        val message = (outcome as SessionCreateOutcome.LaunchFailed).detail
         // The friendly hint: names the concrete installed version, the required
         // minimum, and a copyable update command.
         assertTrue("hint must name installed version: $message", message.contains("0.3.33"))
@@ -444,18 +449,18 @@ class FolderListGatewayFallbackTest {
         )
         val gateway = SshFolderListGateway()
 
-        val ex = runCatching {
-            gateway.createSessionOnSession(
-                session = session,
-                sessionName = SESSION_NAME,
-                cwd = CWD,
-                startCommand = "pocketshell agent claude --dir '/home/me/proj dir'",
-                namePolicy = SessionNamePolicy.ExactName,
-            )
-        }.exceptionOrNull()
+        val outcome = gateway.createSessionOnSession(
+            session = session,
+            sessionName = SESSION_NAME,
+            cwd = CWD,
+            startCommand = "pocketshell agent claude --dir '/home/me/proj dir'",
+            namePolicy = SessionNamePolicy.ExactName,
+        )
 
-        assertTrue("expected a surfaced RuntimeException, got $ex", ex is RuntimeException)
-        val message = ex?.message.orEmpty()
+        // Issue #1928: the hint arrives as a LAUNCH failure on a session that
+        // was created, not as a create failure.
+        assertTrue("expected a launch failure, got $outcome", outcome is SessionCreateOutcome.LaunchFailed)
+        val message = (outcome as SessionCreateOutcome.LaunchFailed).detail
         // Reached the version pre-flight: the hint names the installed version.
         assertTrue("must reach the version hint (installed version): $message", message.contains("0.3.33"))
         // The collision guard must NOT have short-circuited the launch.
@@ -501,18 +506,16 @@ class FolderListGatewayFallbackTest {
         )
         val gateway = SshFolderListGateway()
 
-        val ex = runCatching {
-            gateway.createSessionOnSession(
-                session = session,
-                sessionName = SESSION_NAME,
-                cwd = CWD,
-                startCommand = "pocketshell agent codex --dir '/home/me/proj dir'",
-                namePolicy = SessionNamePolicy.ExactName,
-            )
-        }.exceptionOrNull()
+        val outcome = gateway.createSessionOnSession(
+            session = session,
+            sessionName = SESSION_NAME,
+            cwd = CWD,
+            startCommand = "pocketshell agent codex --dir '/home/me/proj dir'",
+            namePolicy = SessionNamePolicy.ExactName,
+        )
 
-        assertTrue("expected a surfaced RuntimeException, got $ex", ex is RuntimeException)
-        val message = ex?.message.orEmpty()
+        assertTrue("expected a launch failure, got $outcome", outcome is SessionCreateOutcome.LaunchFailed)
+        val message = (outcome as SessionCreateOutcome.LaunchFailed).detail
         assertTrue("hint must fall back to generic phrasing: $message", message.contains("too old"))
         assertTrue(
             "hint must still name required minimum: $message",
@@ -781,7 +784,7 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.UniqueOnHost,
         )
 
-        assertEquals("$SESSION_NAME-2", resolved)
+        assertEquals(SessionCreateOutcome.Created("$SESSION_NAME-2"), resolved)
         val create = session.execCommands.single { it.contains("create-detached") }
         assertTrue(
             "the create must target the host-resolved name, got: $create",
@@ -819,7 +822,7 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.UniqueOnHost,
         )
 
-        assertEquals("$SESSION_NAME-3", resolved)
+        assertEquals(SessionCreateOutcome.Created("$SESSION_NAME-3"), resolved)
         val sendKeys = session.execCommands.single { it.contains("send-keys") }
         // The command is wrapped in `/bin/sh -lc '...'`, so the inner single
         // quotes are shell-escaped; match the quoted NAME token rather than the
@@ -860,7 +863,7 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.ExactName,
         )
 
-        assertEquals(SESSION_NAME, resolved)
+        assertEquals(SessionCreateOutcome.Created(SESSION_NAME), resolved)
         assertFalse(
             "ExactName must not run the free-name walk",
             session.execCommands.any { it.contains("__ps_n=") },
@@ -891,7 +894,7 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.UniqueOnHost,
         )
 
-        assertEquals(SESSION_NAME, resolved)
+        assertEquals(SessionCreateOutcome.Created(SESSION_NAME), resolved)
         assertTrue(
             "a failed probe must still create",
             session.execCommands.any { it.contains("create-detached") },

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGroupingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGroupingTest.kt
@@ -1191,7 +1191,7 @@ class FolderListGroupingTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelClientCacheTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelClientCacheTest.kt
@@ -772,7 +772,7 @@ class FolderListViewModelClientCacheTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelConnectTimeoutInversionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelConnectTimeoutInversionTest.kt
@@ -388,7 +388,7 @@ class FolderListViewModelConnectTimeoutInversionTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
@@ -222,6 +222,72 @@ class FolderListViewModelCreateSessionTest {
         }
     }
 
+    /**
+     * Issue #1928 — the FOLDER-TREE caller of the partial-success outcome.
+     *
+     * The user picked "Agent → Codex" and the tmux session was created, but the
+     * launch failed on the host. Before the typed outcome this reported full
+     * success: the tree stamped a Codex badge on the row and the screen routed
+     * the user straight into a plain shell. All four properties below are the
+     * user-visible consequences of that lie, so all four are asserted here:
+     *
+     *  - the created session IS shown (it exists on the host and is kept),
+     *  - it is NOT badged with the agent that never started,
+     *  - the screen does NOT navigate into it as if the agent were running,
+     *  - and the reason is on screen, naming the session and what to do.
+     */
+    @Test
+    fun launchFailureKeepsTheSessionVisibleAndReportsInsteadOfNavigating() = runTest {
+        val gateway = StubGateway(
+            rows = listOf(sessionRow("alpha")),
+            launchFailureDetail = "can't find pane: =git-beta:",
+        )
+        val vm = newViewModel(gateway)
+        var resolved: String? = null
+        try {
+            bind(vm)
+            runCurrent()
+
+            vm.createSession(
+                sessionName = "git-beta",
+                cwd = "/home/alexey/git/beta",
+                startCommand = "pocketshell agent codex --dir '/home/alexey/git/beta'",
+                chosenKind = SessionAgentKind.Codex,
+                onResolved = { resolved = it },
+            )
+            runCurrent()
+
+            assertEquals(
+                "the created session must stay visible — it exists on the host",
+                setOf("alpha", "git-beta"),
+                readySessionNames(vm),
+            )
+            val row = (vm.state.value as FolderListUiState.Ready)
+                .flatSessions.first { it.sessionName == "git-beta" }
+            assertEquals(
+                "a session whose agent never started must not wear that agent's badge",
+                SessionAgentKind.Probing,
+                row.agentKind,
+            )
+            assertEquals(
+                "a launch failure must not route the user into the session",
+                null,
+                resolved,
+            )
+            val status = vm.actionStatus.value
+            assertTrue("expected a visible failure, got $status", status is FolderActionStatus.Failed)
+            val message = (status as FolderActionStatus.Failed).message
+            assertTrue("must name the created session: $message", message.contains("git-beta"))
+            assertTrue("must say it WAS created: $message", message.contains("was created"))
+            assertTrue(
+                "must carry the host's reason: $message",
+                message.contains("can't find pane: =git-beta:"),
+            )
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
     @Test
     fun createShellSessionWithoutChosenKindStaysProbingUntilProbe() = runTest {
         // A shell session (no agent kind) keeps the optimistic Probing
@@ -296,7 +362,7 @@ class FolderListViewModelCreateSessionTest {
 
     @Test
     fun createSessionShowsRunningStatusUntilGatewayReturns() = runTest {
-        val pendingCreate = CompletableDeferred<Result<String>>()
+        val pendingCreate = CompletableDeferred<Result<SessionCreateOutcome>>()
         val gateway = StubGateway(
             rows = listOf(sessionRow("alpha")),
             createResult = pendingCreate,
@@ -324,7 +390,7 @@ class FolderListViewModelCreateSessionTest {
                 (running as FolderActionStatus.Running).message,
             )
 
-            pendingCreate.complete(Result.success("beta"))
+            pendingCreate.complete(Result.success(SessionCreateOutcome.Created("beta")))
             runCurrent()
 
             assertEquals(FolderActionStatus.Idle, vm.actionStatus.value)
@@ -501,7 +567,13 @@ class FolderListViewModelCreateSessionTest {
     private class StubGateway(
         @Volatile var rows: List<FolderSessionRow>,
         @Volatile var createSucceeds: Boolean = true,
-        private val createResult: CompletableDeferred<Result<String>>? = null,
+        /**
+         * Issue #1928: when set, the gateway reports PARTIAL success — the tmux
+         * session was created but the requested agent launch failed with this
+         * reason. `null` keeps the full-success behaviour.
+         */
+        @Volatile var launchFailureDetail: String? = null,
+        private val createResult: CompletableDeferred<Result<SessionCreateOutcome>>? = null,
         // When true, a successful create makes the gateway's probe start
         // reporting the created session (i.e. the probe observed it).
         @Volatile var reportCreatedSession: Boolean = false,
@@ -531,7 +603,7 @@ class FolderListViewModelCreateSessionTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> {
+        ): Result<SessionCreateOutcome> {
             createCalls += 1
             // Issue #1820: record the policy the PRODUCTION caller chose. The
             // whole fix is "each call site declares its intent", so a fake that
@@ -557,7 +629,11 @@ class FolderListViewModelCreateSessionTest {
                     agentKind = SessionAgentKind.Shell,
                 )
             }
-            return Result.success(sessionName)
+            return Result.success(
+                launchFailureDetail
+                    ?.let { SessionCreateOutcome.LaunchFailed(sessionName, it) }
+                    ?: SessionCreateOutcome.Created(sessionName),
+            )
         }
 
         override suspend fun createEmptyProject(

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
@@ -570,7 +570,7 @@ class FolderListViewModelHostUpgradeTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelKillSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelKillSessionTest.kt
@@ -411,7 +411,7 @@ class FolderListViewModelKillSessionTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelOldCliHydrateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelOldCliHydrateTest.kt
@@ -284,7 +284,7 @@ class FolderListViewModelOldCliHydrateTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelOpenFailedRecoveryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelOpenFailedRecoveryTest.kt
@@ -414,7 +414,7 @@ class FolderListViewModelOpenFailedRecoveryTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,
@@ -467,7 +467,7 @@ class FolderListViewModelOpenFailedRecoveryTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelPayloadVersionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelPayloadVersionTest.kt
@@ -252,7 +252,7 @@ class FolderListViewModelPayloadVersionTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelPrewarmLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelPrewarmLeaseTest.kt
@@ -188,7 +188,7 @@ class FolderListViewModelPrewarmLeaseTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelProfilesTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelProfilesTest.kt
@@ -224,7 +224,7 @@ class FolderListViewModelProfilesTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelReconcileThrowGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelReconcileThrowGuardTest.kt
@@ -202,7 +202,7 @@ class FolderListViewModelReconcileThrowGuardTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelReconcileTimeoutTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelReconcileTimeoutTest.kt
@@ -189,7 +189,7 @@ class FolderListViewModelReconcileTimeoutTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelSessionTreeSetupTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelSessionTreeSetupTest.kt
@@ -359,7 +359,7 @@ class FolderListViewModelSessionTreeSetupTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelSessionsChangedTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelSessionsChangedTest.kt
@@ -315,7 +315,7 @@ class FolderListViewModelSessionsChangedTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
@@ -224,9 +224,9 @@ class FolderListViewModelStaleSessionTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> {
+        ): Result<SessionCreateOutcome> {
             createdSessions.add(sessionName to cwd)
-            return Result.success(sessionName)
+            return Result.success(SessionCreateOutcome.Created(sessionName))
         }
 
         override suspend fun createEmptyProject(

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelTransientEofHealTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelTransientEofHealTest.kt
@@ -348,7 +348,7 @@ class FolderListViewModelTransientEofHealTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelTreeDurabilityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelTreeDurabilityTest.kt
@@ -481,7 +481,7 @@ class FolderListViewModelTreeDurabilityTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelWindowCloseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelWindowCloseTest.kt
@@ -651,7 +651,7 @@ class FolderListViewModelWindowCloseTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/Issue1829MainThreadConfinementTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/Issue1829MainThreadConfinementTest.kt
@@ -667,7 +667,7 @@ class Issue1829MainThreadConfinementTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/Issue1928LaunchFailureAccountingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/Issue1928LaunchFailureAccountingTest.kt
@@ -1,0 +1,553 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.repos.ReposJsonParser
+import com.pocketshell.app.repos.ReposRemoteSource
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.sessions.HostTmuxSessionListParser
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.storage.entity.HostEntity
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #1928 — the post-create agent launch must be ACCOUNTED FOR.
+ *
+ * ## The reported defect
+ *
+ * `SshFolderListGateway.createSessionOnSession` created the tmux session, then
+ * ran the optional agent launch (`tmux send-keys …`) and **discarded its
+ * result**. A launch that exited non-zero still produced
+ * `Result.success(resolvedName)`, so the app reported a working Claude/Codex
+ * session while the user actually had an empty shell.
+ *
+ * ## Why these tests go red on a live mutant, not on a base checkout
+ *
+ * The fix changes the gateway's return TYPE (`Result<String>` →
+ * `Result<SessionCreateOutcome>`, D22 hard cut), so a base checkout cannot even
+ * compile this file. The reproduction is therefore a LIVE MUTANT: restore the
+ * pre-fix body of `launchStartCommand` (run the send-keys, ignore the result,
+ * `return null`) and every "must report LaunchFailed" test below fails while
+ * the negative controls stay green. The mutation and its red output are
+ * recorded on the issue.
+ *
+ * ## Class coverage (G2) — the launch half fails in THREE ways, and all three
+ * were mis-reported, in two opposite directions
+ *
+ *  1. **non-zero `send-keys`** (pane target gone between create and send) —
+ *     silently DISCARDED, reported as full success. The reported instance.
+ *  2. **the #759 outdated-host pre-flight** — THREW, so the user was told
+ *     "couldn't create session" while an orphan session sat on the host.
+ *  3. **a bounded-exec timeout on the send-keys** — THREW
+ *     `FolderListExecTimeoutException`, which is a stale-channel symptom, so
+ *     `withLeaseSession` retried the WHOLE block on a fresh lease and created a
+ *     SECOND session.
+ *
+ * Each has its own test here, plus the negative controls that stop the fix
+ * degenerating into "always report a launch failure" (G6).
+ */
+class Issue1928LaunchFailureAccountingTest {
+
+    // ---------------------------------------------------------------- (1) exit code
+
+    /**
+     * THE reported defect. The host really did refuse the launch (`send-keys`
+     * exit 1, "can't find pane"), so the agent never started — the outcome must
+     * say so instead of handing the caller a name as if all was well.
+     */
+    @Test
+    fun nonZeroSendKeysIsReportedAsLaunchFailedNotSuccess() = runBlocking {
+        val session = LaunchFake(
+            sendKeys = ExecResult(
+                stdout = "",
+                stderr = "can't find pane: =git-pocketshell:",
+                exitCode = 1,
+            ),
+        )
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = session,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = CLAUDE_LAUNCH,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertEquals(
+            "a non-zero launch must be a partial success, not a full one; got $outcome",
+            SessionCreateOutcome.LaunchFailed(SESSION, "can't find pane: =git-pocketshell:"),
+            outcome,
+        )
+    }
+
+    /**
+     * The created session is the user's and MUST survive (issue #1928 non-goal:
+     * do not delete a created session because its optional launch failed). The
+     * gateway must not "clean up" after itself, and must not create a second
+     * session either.
+     */
+    @Test
+    fun launchFailureNeitherKillsNorDuplicatesTheCreatedSession() = runBlocking {
+        val session = LaunchFake(sendKeys = ExecResult("", "server exited unexpectedly", 1))
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = session,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = CLAUDE_LAUNCH,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertTrue("expected a partial success, got $outcome", outcome is SessionCreateOutcome.LaunchFailed)
+        assertEquals(
+            "the outcome must name the session that EXISTS on the host",
+            SESSION,
+            outcome.sessionName,
+        )
+        assertFalse(
+            "a failed launch must never kill the created session: ${session.execCommands}",
+            session.execCommands.any { it.contains("kill-session") },
+        )
+        assertEquals(
+            "exactly one create must have run: ${session.execCommands}",
+            1,
+            session.execCommands.count { it.contains("create-detached") },
+        )
+    }
+
+    /**
+     * The reason has to reach the user, so it has to reach the outcome. A blank
+     * stderr falls back to stdout and then to the exit code — never an empty
+     * "the agent didn't start: ." sentence.
+     */
+    @Test
+    fun launchFailureCarriesTheHostReasonAndFallsBackToTheExitCode() = runBlocking {
+        val withStdout = LaunchFake(sendKeys = ExecResult("no current client", "", 1))
+        val silent = LaunchFake(sendKeys = ExecResult("", "   ", 3))
+        val gateway = SshFolderListGateway()
+
+        val fromStdout = gateway.createSessionOnSession(
+            session = withStdout,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = CLAUDE_LAUNCH,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+        val fromExitCode = gateway.createSessionOnSession(
+            session = silent,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = CLAUDE_LAUNCH,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertEquals(
+            SessionCreateOutcome.LaunchFailed(SESSION, "no current client"),
+            fromStdout,
+        )
+        assertEquals(
+            SessionCreateOutcome.LaunchFailed(SESSION, "tmux send-keys exited 3"),
+            fromExitCode,
+        )
+    }
+
+    /**
+     * The launch line can carry a `--profile` (and, for OpenCode, a long
+     * env-stripping prelude). The reason we surface is the HOST's, never the
+     * command, so nothing from the launch line can leak into a banner or a log.
+     */
+    @Test
+    fun launchFailureDetailNeverEchoesTheLaunchCommand() = runBlocking {
+        val session = LaunchFake(sendKeys = ExecResult("", "can't find pane", 1))
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = session,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = "pocketshell agent claude --dir '$CWD' --profile 'Claude (Z.AI)'",
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        val detail = (outcome as SessionCreateOutcome.LaunchFailed).detail
+        assertFalse("detail must not echo the launch line: $detail", detail.contains("--profile"))
+        assertFalse("detail must not echo the launch line: $detail", detail.contains("pocketshell agent"))
+        assertFalse(
+            "the user-facing sentence must not echo it either",
+            sessionLaunchFailedMessage(outcome.sessionName, detail).contains("--profile"),
+        )
+    }
+
+    // ------------------------------------------------------ (2) outdated host CLI
+
+    /**
+     * Issue #759's outdated-host pre-flight runs AFTER the session has been
+     * created, so throwing its hint reported "couldn't create session" for a
+     * session that exists. Same words, honest accounting: it is now the reason
+     * of a partial success, and the doomed line is still never typed.
+     */
+    @Test
+    fun outdatedHostPreflightIsALaunchFailureNotACreateFailure() = runBlocking {
+        val session = LaunchFake(agentSubcommandMissing = true)
+
+        val outcome = runCatching {
+            SshFolderListGateway().createSessionOnSession(
+                session = session,
+                sessionName = SESSION,
+                cwd = CWD,
+                startCommand = CLAUDE_LAUNCH,
+                namePolicy = SessionNamePolicy.ExactName,
+            )
+        }
+
+        val value = outcome.getOrNull()
+        assertTrue(
+            "an outdated host must NOT fail the create — the session exists; got $outcome",
+            value is SessionCreateOutcome.LaunchFailed,
+        )
+        val detail = (value as SessionCreateOutcome.LaunchFailed).detail
+        assertTrue(
+            "must keep the actionable update hint: $detail",
+            detail.contains(AgentLaunchVersionCheck.MIN_AGENT_POCKETSHELL_VERSION) &&
+                detail.contains(AgentLaunchVersionCheck.UPDATE_COMMAND),
+        )
+        assertFalse("raw Click jargon must not leak: $detail", detail.contains("No such command"))
+        assertTrue(
+            "the session must still have been created: ${session.execCommands}",
+            session.execCommands.any { it.contains("create-detached") },
+        )
+        assertFalse(
+            "must not type a launch that is known to fail: ${session.execCommands}",
+            session.execCommands.any { it.contains("send-keys") },
+        )
+    }
+
+    // ------------------------------------------------------- (3) send-keys timeout
+
+    /**
+     * A send-keys that never returns used to throw `FolderListExecTimeoutException`.
+     * That is a stale-channel symptom, so `withLeaseSession` evicted the lease and
+     * retried the WHOLE create block — creating a SECOND tmux session while telling
+     * the user the create had failed.
+     *
+     * This drives the full lease path (`createSession`, not
+     * `createSessionOnSession`) precisely so the retry is reachable: exactly one
+     * create must run, and the answer must be the partial success.
+     */
+    @Test
+    fun wedgedSendKeysReportsLaunchFailedAndDoesNotRetryTheWholeCreate() = runBlocking {
+        val session = LaunchFake(wedgeSendKeys = true)
+        val gateway = gatewayWith(session, execReadTimeoutMs = 250L)
+
+        val result = gateway.createSession(
+            host = HOST,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = CLAUDE_LAUNCH,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        val outcome = result.getOrNull()
+        assertTrue(
+            "a wedged launch must be a partial success, not a create failure; got $result",
+            outcome is SessionCreateOutcome.LaunchFailed,
+        )
+        assertEquals(SESSION, outcome!!.sessionName)
+        assertEquals(
+            "the whole create must NOT be retried on a launch timeout — that is how " +
+                "an orphan duplicate session appeared: ${session.execCommands}",
+            1,
+            session.execCommands.count { it.contains("create-detached") },
+        )
+    }
+
+    /**
+     * The launch step must not turn a thrown transport error into a create
+     * failure either — the session is already on the host.
+     */
+    @Test
+    fun thrownSendKeysErrorIsReportedAsLaunchFailed() = runBlocking {
+        val session = LaunchFake(sendKeysThrows = IllegalStateException("SSH channel closed"))
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = session,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = CLAUDE_LAUNCH,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertEquals(
+            SessionCreateOutcome.LaunchFailed(SESSION, "SSH channel closed"),
+            outcome,
+        )
+    }
+
+    // ------------------------------------------------------------ negative controls
+
+    /**
+     * G6 guard: the fix must not report a launch failure for a launch that
+     * WORKED, and the launch line must still be typed verbatim — including the
+     * env-stripped OpenCode form, which has to reach the pane unaltered or the
+     * agent bills per token instead of using the subscription.
+     */
+    @Test
+    fun successfulLaunchIsStillReportedAsCreatedAndTypedVerbatim() = runBlocking {
+        val session = LaunchFake()
+        val opencode = "env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY opencode"
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = session,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = opencode,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertEquals(SessionCreateOutcome.Created(SESSION), outcome)
+        val sendKeys = session.execCommands.single { it.contains("send-keys") }
+        assertTrue(
+            "the env-stripped OpenCode line must reach the pane verbatim: $sendKeys",
+            sendKeys.contains("env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY opencode"),
+        )
+    }
+
+    /** A plain shell create asks for no launch, so it can never be partial. */
+    @Test
+    fun shellCreateWithNoStartCommandIsAlwaysCreated() = runBlocking {
+        val session = LaunchFake(sendKeys = ExecResult("", "should never run", 1))
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = session,
+            sessionName = SESSION,
+            cwd = CWD,
+            startCommand = null,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertEquals(SessionCreateOutcome.Created(SESSION), outcome)
+        assertFalse(
+            "no launch was requested, so nothing may be typed: ${session.execCommands}",
+            session.execCommands.any { it.contains("send-keys") },
+        )
+    }
+
+    /**
+     * The CREATE half still fails loudly. Nothing exists on the host on this
+     * path, so reporting a partial success would be the mirror-image lie —
+     * the tree would insert a row for a session that was never made.
+     */
+    @Test
+    fun aFailedCreateIsStillAThrownFailureNotAPartialSuccess() = runBlocking {
+        val session = LaunchFake(createResult = ExecResult("", "no space left on device", 1))
+
+        val failure = runCatching {
+            SshFolderListGateway().createSessionOnSession(
+                session = session,
+                sessionName = SESSION,
+                cwd = CWD,
+                startCommand = CLAUDE_LAUNCH,
+                namePolicy = SessionNamePolicy.ExactName,
+            )
+        }.exceptionOrNull()
+
+        assertTrue("a create failure must still throw, got $failure", failure is RuntimeException)
+        assertTrue(
+            "must carry the host's create reason: ${failure?.message}",
+            failure?.message.orEmpty().contains("no space left on device"),
+        )
+        assertFalse(
+            "a create that failed must not type a launch: ${session.execCommands}",
+            session.execCommands.any { it.contains("send-keys") },
+        )
+    }
+
+    /** The shared user-facing sentence has to say all three actionable things. */
+    @Test
+    fun theUserFacingSentenceNamesTheSessionTheFailureAndWhatToDo() {
+        val message = sessionLaunchFailedMessage("git-pocketshell", "can't find pane")
+
+        assertTrue(message, message.contains("git-pocketshell"))
+        assertTrue(message, message.contains("was created"))
+        assertTrue(message, message.contains("can't find pane"))
+        assertTrue(message, message.contains("Open the session"))
+        assertTrue(
+            "a host that gave no reason must still read sensibly",
+            sessionLaunchFailedMessage("s", "  ").contains("no reason"),
+        )
+    }
+
+    /**
+     * The typed outcome exists so nobody can read the session name without
+     * choosing a branch — [fold] requires both, and neither branch is optional.
+     */
+    @Test
+    fun foldForcesBothBranchesToBeHandled() {
+        val seen = mutableListOf<String>()
+        SessionCreateOutcome.Created("a").fold(
+            onCreated = { seen += "created:$it" },
+            onLaunchFailed = { name, detail -> seen += "failed:$name:$detail" },
+        )
+        SessionCreateOutcome.LaunchFailed("b", "why").fold(
+            onCreated = { seen += "created:$it" },
+            onLaunchFailed = { name, detail -> seen += "failed:$name:$detail" },
+        )
+
+        assertEquals(listOf("created:a", "failed:b:why"), seen)
+    }
+
+    /**
+     * Issue #1928 caller sweep — the DASHBOARD.
+     *
+     * The acceptance criteria name the sessions dashboard alongside the folder
+     * tree, the in-session sheet, the assistant and stale-session recovery. It
+     * is the one surface with nothing to change: it does not use
+     * [FolderListGateway] at all (it creates over the already-attached `-CC`
+     * exec lane) and its create cannot request an agent launch, so it has no
+     * partial success to collapse.
+     *
+     * "It doesn't apply" is exactly the kind of claim that silently stops being
+     * true, so it is asserted rather than written down: wiring a
+     * [FolderListGateway] into the dashboard, or giving its create a start
+     * command, fails here and forces that new call site through the same
+     * three-state handling as the other four.
+     */
+    @Test
+    fun theSessionsDashboardHasNoGatewayCreateSeamToCollapse() {
+        val dashboard = com.pocketshell.app.sessions.SessionsDashboardViewModel::class.java
+
+        val injected = dashboard.declaredConstructors.flatMap { it.parameterTypes.toList() } +
+            dashboard.declaredFields.map { it.type }
+        assertFalse(
+            "the dashboard gained a FolderListGateway seam — its create must now " +
+                "handle SessionCreateOutcome explicitly (issue #1928 caller sweep)",
+            injected.any { FolderListGateway::class.java.isAssignableFrom(it) },
+        )
+
+        val createParams = dashboard.declaredMethods
+            .filter { it.name == "createSession" }
+            .flatMap { it.parameterTypes.toList() }
+        assertTrue(
+            "the dashboard must still have a create to reason about",
+            createParams.isNotEmpty(),
+        )
+        assertEquals(
+            "the dashboard create takes (entry, name, startDirectory) and no start " +
+                "command; a launch parameter here means it can now fail partially",
+            listOf("Entry", "String", "String"),
+            createParams.map { it.simpleName },
+        )
+    }
+
+    // ------------------------------------------------------------------- helpers
+
+    private fun gatewayWith(session: SshSession, execReadTimeoutMs: Long): SshFolderListGateway =
+        SshFolderListGateway(
+            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+            activeTmuxClients = ActiveTmuxClients(),
+            sshLeaseManager = SshLeaseManager(
+                connector = object : SshLeaseConnector {
+                    override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+                        Result.success(session)
+                },
+                idleTtlMillis = 0L,
+            ),
+            sessionListParser = HostTmuxSessionListParser(),
+            execReadTimeoutMs = execReadTimeoutMs,
+        )
+
+    /**
+     * A fake host for the create+launch path: the directory exists, the launch
+     * target is free (so the #976 collision guard passes), the capped create
+     * answers [createResult], and the launch answers whichever failure mode the
+     * test asked for.
+     */
+    private class LaunchFake(
+        private val createResult: ExecResult = OK,
+        private val sendKeys: ExecResult = OK,
+        private val sendKeysThrows: Throwable? = null,
+        private val wedgeSendKeys: Boolean = false,
+        private val agentSubcommandMissing: Boolean = false,
+    ) : SshSession {
+        val execCommands: MutableList<String> =
+            java.util.Collections.synchronizedList(mutableListOf<String>())
+
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            execCommands += command
+            return when {
+                command.contains("pocketshell agent --help") ->
+                    if (agentSubcommandMissing) {
+                        ExecResult("", "Error: No such command 'agent'.", 2)
+                    } else {
+                        OK
+                    }
+                command.contains("pocketshell --version") ->
+                    ExecResult("pocketshell, version 0.3.33", "", 0)
+                command.contains("test -d") -> OK
+                // Free target: the launch guard must not fire.
+                command.contains("has-session") -> ExecResult("", "can't find session", 1)
+                command.contains("create-detached") || command.contains("new-session") ->
+                    createResult
+                command.contains("send-keys") -> {
+                    sendKeysThrows?.let { throw it }
+                    if (wedgeSendKeys) awaitCancellation()
+                    sendKeys
+                }
+                else -> OK
+            }
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() = Unit
+    }
+
+    private companion object {
+        val OK = ExecResult(stdout = "", stderr = "", exitCode = 0)
+        const val SESSION = "git-pocketshell"
+        const val CWD = "/home/alexey/git/pocketshell"
+        const val CLAUDE_LAUNCH = "pocketshell agent claude --dir '/home/alexey/git/pocketshell'"
+        const val KEY_PATH = "/data/keys/id_ed25519"
+
+        val HOST = HostEntity(
+            id = 7L,
+            name = "Docker",
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "testuser",
+            keyId = 3L,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
@@ -5,6 +5,7 @@ import com.pocketshell.app.projects.FolderImportPayload
 import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.FolderListResult
 import com.pocketshell.app.projects.SessionNamePolicy
+import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.ProjectRootEntity
@@ -198,7 +199,10 @@ class StaleSessionPromptControllerTest {
         )
 
         assertTrue("gateway create must succeed", result.isSuccess)
-        assertEquals("work", result.getOrNull())
+        // Issue #1928: recovery returns the gateway's typed outcome verbatim, so
+        // the caller (MainActivity.recreateStaleSession) is the one that decides
+        // what a partial success means instead of inheriting a flattened name.
+        assertEquals(SessionCreateOutcome.Created("work"), result.getOrNull())
         assertEquals("the gateway must be asked to create the gone session name", "work", gateway.lastSessionName)
         // Issue #1820: RECOVERY must recreate the EXACT gone name. This is the
         // one call site where `UniqueOnHost` would be wrong — a stray `-2` would
@@ -300,13 +304,13 @@ class StaleSessionPromptControllerTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> {
+        ): Result<SessionCreateOutcome> {
             called = true
             lastSessionName = sessionName
             lastCwd = cwd
             lastStartCommand = startCommand
             lastNamePolicy = namePolicy
-            return Result.success(resolvedName)
+            return Result.success(SessionCreateOutcome.Created(resolvedName))
         }
 
         override suspend fun listSessionsWithFolder(

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCloseCascadeNoCrashTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionCloseCascadeNoCrashTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.tmux
 
 import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.SessionNamePolicy
+import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.app.session.AgentConversationRepository
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.ssh.ExecResult
@@ -668,7 +669,7 @@ class TmuxSessionCloseCascadeNoCrashTest {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> = error("not used")
+        ): Result<SessionCreateOutcome> = error("not used")
 
         override suspend fun createEmptyProject(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionGatewayActionsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionGatewayActionsTest.kt
@@ -5,6 +5,7 @@ import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.FolderListResult
 import com.pocketshell.app.projects.SessionNamePolicy
 import com.pocketshell.app.projects.WindowKillOutcome
+import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.ssh.ExecResult
@@ -21,10 +22,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -274,6 +277,80 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
                 "sent=${client.sentCommands}",
             client.sentCommands.any { it.startsWith("new-session") },
         )
+    }
+
+    /**
+     * Issue #1928 — the IN-SESSION caller of the partial-success outcome.
+     *
+     * The in-session "+ New session" sheet's success branch attaches the user to
+     * the new session. On a partial success that would drop them into a plain
+     * shell they asked to be a Codex session, silently — the create was reported
+     * as fully successful, so nothing on screen said otherwise. The sheet must
+     * instead surface the reason through the same `sessionCreateError` channel a
+     * real create failure uses, and must NOT resolve.
+     */
+    @Test
+    fun createSessionLaunchFailureReportsInsteadOfAttaching() = runTest(scheduler) {
+        val gateway = RecordingStopGateway(
+            killSucceeds = true,
+            createResolvedName = "git-codex",
+            createLaunchFailureDetail = "can't find pane: =git-codex:",
+        )
+        val vm = newVm(
+            folderListGateway = gateway,
+            hostDao = StopHostDao(hostId = 7L),
+        )
+        val client = FakeTmuxClient()
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "docker",
+            host = "10.0.2.2",
+            port = 2222,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = client,
+        )
+        runCurrent()
+        val failure = async { vm.sessionCreateError.first() }
+        runCurrent()
+
+        val attached = CompletableDeferred<String>()
+        vm.createSession(
+            name = "git-codex",
+            cwd = "/home/alex/git",
+            startCommand = "pocketshell agent codex --dir '/home/alex/git'",
+            chosenKind = SessionAgentKind.Codex,
+            onResolved = { attached.complete(it) },
+        )
+        // The create hops through a REAL Dispatchers.IO for the host lookup, so
+        // `advanceUntilIdle()` alone can return before the gateway call lands
+        // (the #708 virtual-clock-vs-real-dispatcher class). Racing the two
+        // outcomes is the deterministic sync point in BOTH directions: with the
+        // fix the error arrives; a caller that collapses the partial success
+        // attaches instead, and this fails immediately with that name rather
+        // than parking until the runTest timeout.
+        val message = select<String> {
+            failure.onAwait { it }
+            attached.onAwait { attachedName ->
+                fail(
+                    "a launch failure must not attach the user to the session; " +
+                        "attached to $attachedName",
+                )
+                ""
+            }
+        }
+        failure.cancel()
+        advanceUntilIdle()
+
+        assertFalse("a launch failure must not attach", attached.isCompleted)
+        assertTrue("must name the created session: $message", message.contains("git-codex"))
+        assertTrue("must say it WAS created: $message", message.contains("was created"))
+        assertTrue(
+            "must carry the host's reason: $message",
+            message.contains("can't find pane: =git-codex:"),
+        )
+        assertEquals("exactly one create must have run", 1, gateway.createCalls.size)
     }
 
     @Test
@@ -582,6 +659,12 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
         private val windowKillSessionSurvived: Boolean? = null,
         private val windowKillSucceeds: Boolean = true,
         private val createResolvedName: String? = null,
+        /**
+         * Issue #1928: when set, the gateway reports PARTIAL success — the tmux
+         * session [createResolvedName] exists but its agent launch failed with
+         * this reason. `null` keeps the full-success behaviour.
+         */
+        private val createLaunchFailureDetail: String? = null,
     ) : FolderListGateway {
         val killedSessionNames = mutableListOf<String>()
         val killedWindowTargets = mutableListOf<String>()
@@ -615,9 +698,14 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
             cwd: String,
             startCommand: String?,
             namePolicy: SessionNamePolicy,
-        ): Result<String> {
+        ): Result<SessionCreateOutcome> {
             createCalls += CreateCall(sessionName, cwd, startCommand, namePolicy)
-            return createResolvedName?.let { Result.success(it) } ?: error("not used")
+            val name = createResolvedName ?: error("not used")
+            return Result.success(
+                createLaunchFailureDetail
+                    ?.let { SessionCreateOutcome.LaunchFailed(name, it) }
+                    ?: SessionCreateOutcome.Created(name),
+            )
         }
 
         override suspend fun createEmptyProject(


### PR DESCRIPTION
Closes #1928. **Production contract change on a user-facing flow.**

## The reported defect

`SshFolderListGateway.createSessionOnSession` ignored the post-create `send-keys` result. If the agent launch exited non-zero the caller still got `Result.success(resolvedName)`, so the UI reported a successful agent session when only an **empty tmux session** existed. You ask for a Claude or Codex session, the app says it worked, and you get a bare shell.

## It was three defects, mis-reported in two opposite directions

The launch half could fail three ways, and only one of them was the reported one:

1. **non-zero `send-keys` discarded as success** — the reported bug;
2. the **#759 outdated-host pre-flight threw** → "couldn't create session" for a session that *did* exist;
3. a **bounded-exec timeout threw** → same mis-report, and worse.

**(3) silently created a second session.** `FolderListExecTimeoutException` is a stale-channel symptom (`FolderListGateway.kt:885`), so `withLeaseSession` (`:766-773`) re-ran the whole block. Ask for one session, get two.

That third defect was **not in the issue**, and the implementer's own evidence did not actually demonstrate it — its red output stopped at the outcome-type assertion. The reviewer reordered the assertion under the pre-fix mutant and got `expected:<1> but was:<2>`: two `tmuxctl create-detached` executions on a wedged `send-keys`. The fix is structural — the launch half can no longer throw into that retry — not a re-label.

## The contract

A typed `SessionCreateOutcome` with three states — `Result.failure` (create failure), `Created` (full success), `LaunchFailed(sessionName, detail)`. `Result<String>` is **deleted** (D22 hard cut).

One honest correction to an earlier framing: this is **not** a compile-time guarantee against collapsing partial into full. `sessionName` sits on the sealed interface and `FolderListViewModel:1108` reads it without folding. The real guard is the mutation-proven caller tests below.

## Evidence

- **Mutation 1** (pre-fix gateway body): **10 reds** — 7 in the new class *plus 3 in the swept `FolderListGatewayFallbackTest`*. That third group is the load-bearing bit: it proves the 13 pre-existing tests the implementer had to touch were **adapted to the new contract**, not edited until green. Negative controls stayed green.
- **Mutation 2** (collapse partial→full at all four callers): **exactly 4 reds**, only the caller-sweep tests.
- **16 connected tests across four `--pool` runs**, 0 failures, no `rc 90`, including a real-host artifact showing a genuinely failed `tmux send-keys` with the created session **still alive** — reproduced twice. That satisfies G10: the fixture can actually enter the failing state.
- Adjacency: #1832 and the stale-recovery journey re-run on device, 11/11 green.
- The reviewer caught `:app:compileDebugAndroidTestKotlin` returning `FROM-CACHE` on its first attempt and forced it fresh.

## Orchestrator integration gate (this exact tree, base `9182419b`)

Canonical `scripts/full-jvm-gate.sh` as a transient unit — `Result=success`, `ExecMainStatus=0`, `BUILD SUCCESSFUL in 18m 3s`, `603 actionable tasks: 603 executed`:

| Check | Result |
|---|---|
| `:app:testDebugUnitTest` | **4491 executed / 0 failures / 0 skipped** |
| `:app:testReleaseUnitTest` | **4479 executed / 0 failures / 0 skipped** |
| XML freshness vs run marker | 479/479 and 477/477 |
| Cache markers on test-execution tasks | none (only `:shared:test-support` `NO-SOURCE`) |
| `Issue1928LaunchFailureAccountingTest` | 13/0 in **both** variants |
| `FolderListGatewayFallbackTest` (swept) | 23/0 in **both** variants |
| `:app:compileDebugAndroidTestKotlin` (forced, `--no-build-cache`) | clean |
| `check-connection-vm-ratchet` / `check-file-size-hygiene` / `check-test-validity` / `check-tests-referenced` / `check-ci-journey-harness` | all rc 0 |

The androidTest compile matters here specifically: this removes a **public return type**, which is the exact #1720 break shape, and CI's required `Unit` job does not compile that source set.

`TmuxSessionViewModel.kt`'s delta is a net-zero **8 insertions / 8 deletions** — the new in-session reading lives in a separate `SessionCreateOutcomeReporting.kt` to stay out of the ratcheted god object, and the ratchet confirms it.

All three untracked files copied explicitly and md5-verified.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/1928#issuecomment-5202826526

## Follow-ups recorded, not fixed here

1. The "compile error" framing above is overstated — corrected in this description; the caller tests are the real guard.
2. Swallowing the launch-half timeout also skips the poisoned-lease eviction (bounded; self-heals on the next op via #680).
3. No connected screenshot of the launch-failed banner itself — the last link in that criterion rests on existing on-device proof that `FolderActionStatus.Failed` renders.
