### PR TITLE
release: v0.4.40

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 86
-        versionName = "0.4.39"
+        versionCode = 87
+        versionName = "0.4.40"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.39"
+version = "0.4.40"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for **v0.4.40**. No behaviour change — `versionName` 0.4.39 → 0.4.40, `versionCode` 86 → 87, and `tools/pocketshell` in lockstep.

The `#948` coupling guard (in the required `Python utility tests` check) hard-fails if the app `versionName` and the `tools/pocketshell` package version drift. Verified locally: `scripts/check-version-coupling.sh` → `OK: app versionName and tools/pocketshell version are aligned (0.4.40)`.

## Validation of the code being released

Base `6e16ba0f` is fully validated by `Tests` run [31104272271](https://github.com/alexeygrigorev/pocketshell/actions/runs/31104272271) — **7/7 jobs green**, `AGGREGATE_VERDICT=CLEAN`, `CLEAN=3 INFRA=0 RED=0 UNKNOWN=0 MISSING=0`. Shard 2 went red on attempt 1 with a known, already-tracked flake (#1819, signature byte-identical to an occurrence predating this batch) and was clean on a targeted re-run of that job only.

## What ships in v0.4.40

### Crashes and user-visible defects

- **#2003** — the #1443 pixel-truth probe recycled its destination bitmap regardless of whether the async `PixelCopy` had completed. Since `toBitmap` is `LOG_ALWAYS_FATAL` on a recycled bitmap, **every probe that stopped waiting aborted the whole app process** — and it fired more readily the more loaded the device was. Confirmed by a reproduction whose tombstone backtrace matched the maintainer's `tombstone_16` byte-for-byte across frames #00–#12.
- **#2006** — an active port-forward could sit indefinitely showing `Running in the background · Connecting…` instead of `host:port`. The notification observer was restarted from `observeJob?.isActive` rather than from the notification generation, so a start landing inside the close window armed an observer on a generation invalidated one instruction later; every publish was then dropped as `drop_stale` and nothing re-armed.
- **#1953** — the kebab **Reconnect** was disabled for `SessionSurfaceState.Reconnecting`, which is the state both automatic-recovery paths project to. The documented escape hatch was unreachable exactly while the automatic ladder was wedged.
- **#1928** — session create reported success when the post-create agent launch failed, so the UI showed an agent session when only an empty tmux session existed. Two further mis-reports in the opposite direction were found in the same path, including a **bounded-exec timeout that threw into the lease retry and silently created a second session**.

### Terminal correctness

- **#1961** — OSC 8 hyperlink provenance survives DECCARA/DECRARA rectangular attribute mutations. Losing it made the hard-wrap repair decline to join, costing the click target on a long link.

### Test and CI durability

- **#1994** — tmux client cleanup is decided by client **identity** rather than a total count, so a PocketShell `-CC` client leaked by an earlier class can never be excused as foreign.
- **#2021** — an inherited app-owned focus window no longer voids #1994's reopen arms; the harness records the entry state instead of demanding it.
- **#2007** — both canonical wrappers serialise on the gradle output tree, so a connected build and the full JVM gate can no longer race and delete a generated `R.jar` mid-run.
- **#1989** — the canonical gates fail early (rc 76) when free disk is below the floor, plus a serialized safe-list cleanup that refuses to remove a worktree holding uncommitted work — including work that is only untracked.
- **#2017** — the hand-rolled settle pumps fold into the audited `drainMainLooperUntil`; the `AGENTS.md` carve-out that authorised the 5-second hand-rolled budget is corrected.
- **#1969** — the backlog-drain proof barriers against the reader rather than the writer.
- **#2016** — the sustained-outage proof waits for the initial connect before injecting its fault.

Also closed during the wave without new code, having been fixed and merged but left open: #1999, #2002, #1996, #1995, #1993, #1992.

## Not in this release

**#2029** (a `core-ssh` test-fixture happens-before race) is reviewed and approved but held by the release freeze. It is test-only and lands next.

Note that run 31104272271 shows `:shared:core-ssh:integrationTest` as `FROM-CACHE`, so it executed zero tests there — that run is **not** evidence about #2029 either way. Neither merge in the batch changes `core-ssh` behaviour.
