### PR TITLE
release: v0.4.41

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 87
-        versionName = "0.4.40"
+        versionCode = 88
+        versionName = "0.4.41"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.40"
+version = "0.4.41"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release

Bumps PocketShell Android and host CLI in lockstep to **v0.4.41** (`versionCode 88`).

## Included urgent composer work

- durable prompt acceptance / queue preservation: #2034, #2036, #2037, #2042
- composer closes immediately after accepted send while slow delivery continues: #2048
- SSH startup cancellation prerequisite: #2043
- exact-main release-gate corrections: #1819, #1977, #2049, #2051
- ancillary exact-main CI correction: #2046, #2047

## Evidence

- exact pre-bump `main`: `e2759143681124dd5428418ecd22f7841a514758`
- exact-main Tests run: https://github.com/alexeygrigorev/pocketshell/actions/runs/31239259979
- final matrix: Unit/Docker/Python green; emulator shards `CLEAN=3 INFRA=0 RED=0`; aggregate CLEAN
- local full JVM: 605 tasks green (`/tmp/composer-release-r2-full-jvm.log`)
- local cold-boot connected changed paths: 12/12, zero skip/fail (`/tmp/composer-release-r2-connected.log`)
- `scripts/check-version-coupling.sh`: PASS at 0.4.41

Release emulator validation and guarded tag remain post-merge gates.
