### PR TITLE
composer: route-complete submit ack + non-poisoning head (#2056)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2056InducedSubmitAmbiguity.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2056InducedSubmitAmbiguity.kt
@@ -1,0 +1,100 @@
+package com.pocketshell.app.proof
+
+import com.pocketshell.app.tmux.AgentInputSurfaceState
+import com.pocketshell.app.tmux.agentInputSurfaceState
+import com.pocketshell.core.tmux.CommandResponse
+import org.junit.Assert.assertEquals
+
+/**
+ * Issue #2056 — DELIBERATELY INDUCED SUBMIT AMBIGUITY for the late-authority journeys
+ * in [OutboundExactlyOnceAcrossFlapE2eTest] (D33: "add the fixture that creates the
+ * non-happy state").
+ *
+ * ## Why this exists
+ *
+ * `manualRetryOfUnconfirmedSubmitWaitsForLateAuthority`,
+ * `lateAckSurvivesCloseAndRecreateWithoutDuplicate` and
+ * `busyAgentOnStableWritableWireQueuesFifoWithoutBurningAttemptBudget` all assert on the
+ * LATE-AUTHORITY path: a submit whose outcome the bounded turnover wait could not prove
+ * parks as a durable `wireSubmitAttempted` row, and only an authoritative transcript turn
+ * arriving afterwards may resolve it.
+ *
+ * Until #2056 that ambiguity happened BY ACCIDENT — the product had no pane authority at
+ * all, so a delayed transcript left the row unresolved by construction. #2056 gave the
+ * product a real pane authority (an input surface that no longer holds the payload proves
+ * the agent consumed the submit). On the readline `render_default` fake-agent surface
+ * (`> ` prompt) that authority answers on the very first late-ack poll, the row is
+ * acknowledged and pruned, and those three journeys never reach the parked state they
+ * exist to exercise — they simply time out on `rows=[]`. Their protection disappears
+ * rather than fails, which is strictly worse than a red test.
+ *
+ * ## How the ambiguity is induced — honestly
+ *
+ * The framed fake-agent surface (`┃ `, no marker glyph — the shape real Claude/Codex draw
+ * while the agent is WORKING; `tests/docker/agent-bin/pocketshell-fake-agent`,
+ * `POCKETSHELL_FAKE_AGENT_RENDER_MODE=issue1944-framed-input`) is genuinely UNDECIDABLE to
+ * [agentInputSurfaceState] both before and after Enter: the box edge is stripped as
+ * decoration and nothing behind it is a prompt marker. The late-authority chain therefore
+ * fails CLOSED on its pane arm exactly as designed, the row stays parked, and the delayed
+ * transcript remains the only authority that can resolve it.
+ *
+ * Nothing is weakened: every assertion those journeys make about exactly-once delivery,
+ * FIFO order, the attempt budget and late-ack-across-recreate still runs, on the real
+ * wire, against the real parked state.
+ *
+ * [assertPaneSubmitOracleIsUndecidable] is the HARD precondition that keeps this honest —
+ * if a future fixture or matcher change made the surface decidable, the journeys fail
+ * loudly with a named cause instead of quietly becoming happy paths.
+ */
+internal object Issue2056InducedSubmitAmbiguity {
+
+    /** The fake-agent render mode whose input surface no oracle can read. */
+    const val FRAMED_INPUT_RENDER_MODE: String = "issue1944-framed-input"
+
+    /**
+     * The events that explain an outbound row's fate. An outbound wait that times out
+     * used to report only the last ten diagnostics, which on this journey are per-frame
+     * render-heal churn — none of the row's state transitions, its route, the turnover
+     * verdict, or the late-authority verdicts.
+     */
+    val DELIVERY_EVENT_NAMES: Set<String> = setOf(
+        "row_state",
+        "composer_send",
+        "composer_tmux_send_route",
+        "agent_submit_turnover",
+        "agent_submit_transcript_baseline",
+        "agent_submit_transcript_ack",
+        "agent_submit_transcript_late_ack",
+        "outbound_late_pane_submit_ack",
+        "outbound_verify_before_resend",
+    )
+
+    /** The `env` assignment that seeds the undecidable surface, or "" for other tests. */
+    fun renderModeEnvFor(methodName: String, inducedAmbiguityTests: Set<String>): String =
+        if (methodName in inducedAmbiguityTests) {
+            "POCKETSHELL_FAKE_AGENT_RENDER_MODE=$FRAMED_INPUT_RENDER_MODE "
+        } else {
+            ""
+        }
+
+    /**
+     * Assert, against the exact production oracle and the REAL pane bytes in [capture],
+     * that the pane cannot decide whether the submit was consumed.
+     *
+     * The caller must pass a capture it has already proven non-blank (a failed sidecar
+     * read would answer Unknown for the wrong reason and hand this precondition a free
+     * pass — #1819's rule that a blank capture is a read failure, never a pane state).
+     */
+    fun assertPaneSubmitOracleIsUndecidable(label: String, payload: String, capture: String) {
+        assertEquals(
+            "$label: this journey requires an UNDECIDABLE pane submit oracle so the " +
+                "late transcript authority is the only resolver (#2056). The framed " +
+                "fake-agent surface must read Unknown; capture:\n$capture",
+            AgentInputSurfaceState.Unknown,
+            agentInputSurfaceState(
+                CommandResponse(number = 0L, output = capture.lines(), isError = false),
+                payload,
+            ),
+        )
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextClearance
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.Lifecycle
-import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
@@ -47,8 +46,6 @@ import com.pocketshell.app.composer.OutboundQueueStore
 import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.diagnostics.DiagnosticPrivacy
-import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
-import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.tmux.AgentSubmitCaptureSeams
 import com.pocketshell.app.tmux.OutboundDeliverySeams
 import com.pocketshell.app.tmux.PasteChunkSeams
@@ -75,8 +72,6 @@ import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.agents.AgentKind
-import com.pocketshell.core.storage.AppDatabase
-import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
 import dagger.hilt.android.EntryPointAccessors
 import java.io.File
@@ -124,11 +119,11 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
 
     private suspend fun seedBeforeLaunch() {
         clearLastSessionPrefs()
-        val key = readFixtureKey()
+        val key = OutboundExactlyOnceFixture.readFixtureKey()
         fixtureKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
-        seedFakeAgentSession(key)
-        hostRowTag = seedDockerHost(key)
+        OutboundExactlyOnceFixture.seedFakeAgentSession(key, testName.methodName)
+        hostRowTag = OutboundExactlyOnceFixture.seedDockerHost(key)
     }
 
     @Before
@@ -154,7 +149,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         diagnostics = null
         clearLastSessionPrefs()
         if (::fixtureKey.isInitialized) {
-            runCatching { runBlocking { cleanupRemoteTmuxSession(fixtureKey) } }
+            runCatching { runBlocking { OutboundExactlyOnceFixture.cleanupRemoteTmuxSession(fixtureKey) } }
         }
     }
 
@@ -253,6 +248,8 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         val store = composerVm.outboundQueueStore
         store.clearSession(target)
         val payload = "manual retry late authority ${SystemClock.elapsedRealtime().toString().takeLast(6)}"
+        // #2056: prove the induced ambiguity is real before relying on it.
+        assertPaneSubmitOracleIsUndecidable("manual retry", payload)
 
         openComposerAndSend(payload)
         waitForIssue1739Boundary(CONNECTED_TIMEOUT_MS, "manual send parks", {
@@ -317,6 +314,8 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         val store = composerVm.outboundQueueStore
         store.clearSession(target)
         val payload = "late authoritative ack ${SystemClock.elapsedRealtime().toString().takeLast(6)}"
+        // #2056: prove the induced ambiguity is real before relying on it.
+        assertPaneSubmitOracleIsUndecidable("late-ack", payload)
 
         openComposerAndSend(payload)
         waitForIssue1739Boundary(CONNECTED_TIMEOUT_MS, "late send parks", {
@@ -403,6 +402,8 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         store.clearSession(target)
         val nonce = SystemClock.elapsedRealtime().toString().takeLast(6)
         val payloads = listOf("busy first $nonce", "busy second $nonce")
+        // #2056: prove the induced ambiguity is real before relying on it.
+        assertPaneSubmitOracleIsUndecidable("busy", payloads[0])
 
         openComposerAndSend(payloads[0])
         waitForIssue1739Boundary(CONNECTED_TIMEOUT_MS, "busy first parks", {
@@ -416,7 +417,10 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
             outboundWaitDetails(store, target, composer)
         }) {
             val rows = store.itemsFor(target)
-            rows.size == 2 && rows.first().wireSubmitAttempted &&
+            // #2056 CONTRACT FLIP (see the ledger assertion below): BOTH rows now reach
+            // the wire. The head no longer holds the tail, so `all { wireSubmitAttempted }`
+            // replaces `first().wireSubmitAttempted` — strictly more than before.
+            rows.size == 2 && rows.all { it.wireSubmitAttempted } &&
                 rows.all { it.state == OutboundState.Queued } && !composer.uiState.value.sendInFlight
         }
         val queuedSignature = store.itemsFor(target).map { it.id to it.attemptCount }
@@ -441,18 +445,58 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         )
         assertTrue("agent output advanced throughout the healthy hold", heartbeatAfter > heartbeatBefore)
         assertTrue("the hold observed multiple completed retry/refund cycles", settledChecks >= 2)
-        assertEquals("busy agent accepted no duplicate Enter", listOf(payloads[0]), readFakeAgentSubmitLedger().map { it.second })
+        // Issue #2056 CONTRACT FLIP, stated explicitly (was `listOf(payloads[0])`).
+        //
+        // The previous expectation encoded head-of-line BLOCKING: while the head's
+        // outcome was unproven, the tail was not allowed to reach the agent. That is
+        // exactly the behaviour #2056 was filed against — "once the first message gets
+        // clogged, every following message gets clogged too, even though those
+        // following messages are in fact being delivered." An unresolvable head must
+        // not hold the tail (issue #2056 acceptance criterion 5).
+        //
+        // The flip is sound, not a relaxation: a row only reaches this ambiguous state
+        // AFTER its paste was ack-proven on the pane and tmux accepted its Enter, so
+        // the head's bytes are already on the pane. Dispatching the tail therefore
+        // cannot reorder anything — which is why the expectation below is still an
+        // EXACT list in FIFO order, and still pins exactly-once (each payload appears
+        // once, neither is re-Entered). It is strictly stronger than the old one: it
+        // now also proves the non-poisoning drain on the REAL wire, during the hold,
+        // while both durable rows are still parked awaiting the late authority.
+        assertEquals(
+            "an unresolvable head must not hold the tail, and neither payload may be " +
+                "Entered twice (#2056 / #1944)",
+            payloads,
+            readFakeAgentSubmitLedger().map { it.second },
+        )
+        assertEquals(
+            "both rows are still durably parked awaiting the late authority while their " +
+                "payloads have already reached the agent (#2056)",
+            2,
+            store.itemsFor(target).count { it.wireSubmitAttempted && it.isComposerQueueRetryable() },
+        )
         captureViewportArtifacts("issue2042-busy-stable-wire-queued")
 
         val transcript = "/home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL"
+        // Issue #2056 round 2 — the relay must stop after ONE publish, and its pid must
+        // be recorded so a crashed run cannot leave it behind.
+        //
+        // It used to break at `n >= 2`, because on the old head-of-line-BLOCKING
+        // contract the two payloads reached the staging file in two separate waves
+        // (the tail was only sent after the head resolved). Under the #2056 contract
+        // BOTH payloads are already staged before the relay starts, so one copy
+        // publishes both and `n` never reaches 2 — leaving the relay polling this
+        // shared fixture for a further 60 s, straight into the NEXT test in the class,
+        // where it published that test's staged submit and pruned the row that test
+        // was waiting to see parked (observed: manualRetry... green in isolation, red
+        // as `rows=[]` when it ran after this one).
         val relay = execRemoteSetupUntilReady(
             SshKey.Pem(fixtureKey),
             "nohup sh -c " + shellQuote(
-                "n=0; i=0; while [ \$i -lt 300 ]; do " +
+                "i=0; while [ \$i -lt 300 ]; do " +
                     "if [ -s $LATE_ACK_STAGING_JSONL ]; then cat $LATE_ACK_STAGING_JSONL >> $transcript; " +
-                    ": > $LATE_ACK_STAGING_JSONL; n=\$((n+1)); [ \$n -ge 2 ] && break; fi; " +
+                    ": > $LATE_ACK_STAGING_JSONL; break; fi; " +
                     "i=\$((i+1)); sleep .2; done",
-            ) + " >/tmp/issue2042-relay.log 2>&1 &",
+            ) + " >/tmp/issue2042-relay.log 2>&1 & echo \$! > $TRANSCRIPT_RELAY_PID_PATH",
             "issue2042 start transcript relay",
         )
         assertEquals(0, relay.exitCode)
@@ -465,7 +509,7 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
 
     @Test
     fun fallbackQueueRowsSurviveSessionSwitchAndDrainOnlyIntoSameGeneration() { runBlocking<Unit> {
-        enableIssue1944FramedFakeAgent()
+        OutboundExactlyOnceFixture.enableIssue1944FramedFakeAgent(fixtureKey)
         attachSeededTmuxSession(hostRowTag)
         waitForVisibleTerminal("initial attach") { it.contains(FAKE_AGENT_READY) }
         waitForConnected("initial attach")
@@ -2038,6 +2082,15 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         "handoff=${vm.uiState.value.outboundHandoffInProgress} " +
         "consumer=${vm.outboundSendConsumers.activeGenerationForDispatch()} " +
         "owner=${vm.outboundDrainOwnership.activeRowId()} " +
+        // #2056: the composer's CURRENT target (a changed key makes `rows=[]` mean
+        // "looked in the wrong place", not "pruned") plus a delivery-scoped event tail,
+        // because the raw tail is per-frame render-heal churn.
+        "composerTargetNow=${vm.composerTarget} expectedTarget=$target " +
+        "delivery=${boundedEventTail(
+            diagnostics!!.events.filter {
+                it.name in Issue2056InducedSubmitAmbiguity.DELIVERY_EVENT_NAMES
+            },
+        )} " +
         "events=${boundedEventTail(diagnostics!!.events)}"
 
     private fun boundedFieldValue(value: Any?): String = when (value) {
@@ -2264,152 +2317,25 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         return null
     }
 
-    // ---------------------------------------------------------------- seeding
+    // ------------------------------------------------- seeding (see OutboundExactlyOnceFixture)
 
-    private fun readFixtureKey(): String =
-        InstrumentationRegistry.getInstrumentation()
-            .context
-            .assets
-            .open("test_key")
-            .bufferedReader()
-            .use { it.readText() }
-
-    private suspend fun seedDockerHost(key: String): String {
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
-            .fallbackToDestructiveMigration(dropAllTables = true)
-            .build()
-        return try {
-            db.clearAllTables()
-            val storedKey = SshKeyStorage.persistKey(
-                context = appContext,
-                sshKeyDao = db.sshKeyDao(),
-                name = "issue1526-exactly-once-key-${System.currentTimeMillis()}",
-                content = key,
-            )
-            val hostId = db.hostDao().insert(
-                HostEntity(
-                    name = "Issue1526 ExactlyOnce",
-                    hostname = DEFAULT_HOST,
-                    port = DEFAULT_PORT,
-                    username = DEFAULT_USER,
-                    keyId = storedKey.id,
-                    tmuxInstalled = true,
-                    lastBootstrapAt = System.currentTimeMillis(),
-                ),
-            )
-            HOST_ROW_TAG_PREFIX + hostId
-        } finally {
-            db.close()
+    /** Issue #2056 HARD precondition — see [Issue2056InducedSubmitAmbiguity]. */
+    private fun assertPaneSubmitOracleIsUndecidable(label: String, payload: String) {
+        // Require the fixture's own banner in the frame first: a blank sidecar read
+        // would answer Unknown for the wrong reason. Deliberately NOT a settled-frame
+        // wait — the heartbeat fixture repaints continuously and the oracle's verdict
+        // does not depend on settling.
+        var capture = ""
+        waitForIssue1739Boundary(
+            timeoutMs = CONNECTED_TIMEOUT_MS,
+            label = "$label pane frame for the submit-oracle precondition",
+            timeoutDetails = { "lastCapture=${capture.take(DIAGNOSTIC_CAPTURE_LIMIT)} failure=$lastSidecarFailure" },
+        ) {
+            capture = runBlocking { sidecarCapturePane() }
+            capture.contains(FAKE_AGENT_READY)
         }
-    }
-
-    private suspend fun seedFakeAgentSession(key: String) {
-        val delayedTranscriptTests = setOf(
-            "manualRetryOfUnconfirmedSubmitWaitsForLateAuthority",
-            "lateAckSurvivesCloseAndRecreateWithoutDuplicate",
-            "busyAgentOnStableWritableWireQueuesFifoWithoutBurningAttemptBudget",
-        )
-        val fakeAgentTranscript =
-            if (testName.methodName in delayedTranscriptTests) {
-                LATE_ACK_STAGING_JSONL
-            } else {
-                "/home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL"
-            }
-        val heartbeatEnv = if (testName.methodName == "busyAgentOnStableWritableWireQueuesFifoWithoutBurningAttemptBudget") {
-            "POCKETSHELL_FAKE_AGENT_HEARTBEAT=1 "
-        } else ""
-        val script = buildString {
-            appendLine("set -eu")
-            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
-            appendLine("tmux kill-session -t ${shellQuote(SESSION_B)} 2>/dev/null || true")
-            appendLine("rm -f ${shellQuote(FAKE_AGENT_LEDGER_PATH)}")
-            appendLine("rm -f ${shellQuote(LATE_ACK_STAGING_JSONL)}")
-            appendLine("touch ${shellQuote(LATE_ACK_STAGING_JSONL)}")
-            appendLine("mkdir -p /home/testuser/.claude/projects/-home-testuser")
-            appendLine(
-                "cp /home/testuser/.claude/projects/-workspace-pocketshell/" +
-                    "pocketshell-claude.jsonl " +
-                    "/home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL",
-            )
-            appendLine("touch /home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL")
-            appendLine(
-                "tmux new-session -d -s ${shellQuote(SESSION_NAME)} -x 80 -y 40 " +
-                    "-c /home/testuser " +
-                    shellQuote(
-                        "POCKETSHELL_FAKE_AGENT_SUBMIT_LEDGER=$FAKE_AGENT_LEDGER_PATH " +
-                            "POCKETSHELL_FAKE_AGENT_TRANSCRIPT=$fakeAgentTranscript " +
-                            heartbeatEnv +
-                            "exec /usr/local/bin/pocketshell-fake-agent",
-                    ),
-            )
-            appendLine("tmux set-option -t ${shellQuote(SESSION_NAME)} @ps_agent_kind claude")
-            appendLine(
-                "tmux show-options -v -t ${shellQuote(SESSION_NAME)} " +
-                    "@ps_agent_kind | grep -qx claude",
-            )
-            appendLine(
-                "test -s /home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL",
-            )
-            appendLine(
-                "tmux new-session -d -s ${shellQuote(SESSION_B)} -x 80 -y 40 " +
-                    shellQuote("printf '$SESSION_B_MARKER\\n'; exec sh"),
-            )
-            appendLine("tmux set-option -t ${shellQuote(SESSION_B)} @ps_agent_kind shell")
-            appendLine("sleep 1")
-            appendLine("pid=\$(tmux display-message -p -t ${shellQuote(SESSION_NAME)} '#{pane_pid}'); tr '\\0' '\\n' < /proc/\$pid/environ | grep -Fx ${shellQuote("POCKETSHELL_FAKE_AGENT_TRANSCRIPT=$fakeAgentTranscript")}")
-            appendLine("tmux list-sessions")
-        }
-        val result = execRemoteSetupUntilReady(
-            key = SshKey.Pem(key),
-            command = script,
-            description = "issue1526 fake-agent tmux seed session",
-        )
-        assertTrue(
-            "seed failed ${result.exitCode}: ${result.stderr}",
-            result.exitCode == 0,
-        )
-    }
-
-    private suspend fun enableIssue1944FramedFakeAgent() {
-        val command =
-            "tmux respawn-pane -k -t ${shellQuote("=$SESSION_NAME:0.0")} " +
-                shellQuote(
-                    "POCKETSHELL_FAKE_AGENT_SUBMIT_LEDGER=$FAKE_AGENT_LEDGER_PATH " +
-                        "POCKETSHELL_FAKE_AGENT_TRANSCRIPT=/home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL " +
-                        "POCKETSHELL_FAKE_AGENT_RENDER_MODE=issue1944-framed-input " +
-                        "exec /usr/local/bin/pocketshell-fake-agent",
-                )
-        val result = execRemoteSetupUntilReady(
-            key = SshKey.Pem(fixtureKey),
-            command = command,
-            description = "issue1944 framed fake-agent input surface",
-        )
-        assertEquals("framed fake-agent respawn must succeed: ${result.stderr}", 0, result.exitCode)
-    }
-
-    private suspend fun cleanupRemoteTmuxSession(key: String) {
-        runCatching {
-            SshConnection.connect(
-                host = DEFAULT_HOST,
-                port = DEFAULT_PORT,
-                user = DEFAULT_USER,
-                key = SshKey.Pem(key),
-                knownHosts = KnownHostsPolicy.AcceptAll,
-                timeoutMs = 15_000,
-            ).mapCatching { session ->
-                session.use {
-                    it.exec(
-                        "tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true; " +
-                            "tmux kill-session -t ${shellQuote(SESSION_B)} 2>/dev/null || true; " +
-                            "rm -f /home/testuser/.claude/projects/-home-testuser/$SEEDED_JSONL " +
-                            "${shellQuote(FAKE_AGENT_LEDGER_PATH)} " +
-                            "${shellQuote(LATE_ACK_STAGING_JSONL)} " +
-                            "2>/dev/null || true",
-                    )
-                }
-            }
-        }
+        Issue2056InducedSubmitAmbiguity
+            .assertPaneSubmitOracleIsUndecidable(label, payload, capture)
     }
 
     // ---------------------------------------------------------------- artifacts
@@ -2527,16 +2453,18 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
     }
 
     private companion object {
-        const val DATABASE_NAME: String = "pocketshell.db"
+        // Fixture identity lives in OutboundExactlyOnceFixture (#2056 file-size split).
         const val DEVICE_DIR_NAME: String = "issue1526-exactly-once"
-        const val SESSION_NAME: String = "issue1526-exactly-once"
-        const val SESSION_B: String = "issue1944-switch-b"
-        const val SESSION_B_MARKER: String = "ISSUE1944-B-READY"
-        const val FAKE_AGENT_LEDGER_PATH: String = "/tmp/pocketshell-fake-agent-submits.log"
-        const val LATE_ACK_STAGING_JSONL: String = "/tmp/pocketshell-issue2037-delayed.jsonl"
+        const val SESSION_NAME: String = OutboundExactlyOnceFixture.SESSION_NAME
+        const val SESSION_B: String = OutboundExactlyOnceFixture.SESSION_B
+        const val SESSION_B_MARKER: String = OutboundExactlyOnceFixture.SESSION_B_MARKER
+        const val FAKE_AGENT_LEDGER_PATH: String = OutboundExactlyOnceFixture.FAKE_AGENT_LEDGER_PATH
+        const val LATE_ACK_STAGING_JSONL: String = OutboundExactlyOnceFixture.LATE_ACK_STAGING_JSONL
+        const val TRANSCRIPT_RELAY_PID_PATH: String =
+            OutboundExactlyOnceFixture.TRANSCRIPT_RELAY_PID_PATH
+        const val SEEDED_JSONL: String = OutboundExactlyOnceFixture.SEEDED_JSONL
+        const val FAKE_AGENT_READY: String = OutboundExactlyOnceFixture.FAKE_AGENT_READY
         const val BUSY_BUDGET_HOLD_MS: Long = 25_000L
-        const val SEEDED_JSONL: String = "issue1526-live-claude.jsonl"
-        const val FAKE_AGENT_READY: String = "FAKE-AGENT-READY"
         const val CONVERSATION_SEGMENT_TAG: String = TMUX_CONSOLIDATED_TAB_PILL_TAG_PREFIX + "1"
 
         val DETECTION_TIMEOUT_MS: Long =

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceFixture.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceFixture.kt
@@ -1,0 +1,222 @@
+package com.pocketshell.app.proof
+
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+
+/**
+ * Remote/DB fixture for [OutboundExactlyOnceAcrossFlapE2eTest].
+ *
+ * Extracted from the test class in issue #2056 round 2: the class had grown past the
+ * repository's 128 KiB file-size hygiene threshold, and this seeding block is a
+ * self-contained concern (tmux sessions, the fake agent's environment, the seeded
+ * transcript, the host row) with no dependency on Compose or the test's own waits.
+ * `scripts/check-file-size-hygiene.sh` explicitly asks for a split rather than a raised
+ * baseline.
+ */
+internal object OutboundExactlyOnceFixture {
+    const val DATABASE_NAME: String = "pocketshell.db"
+    const val SESSION_NAME: String = "issue1526-exactly-once"
+    const val SESSION_B: String = "issue1944-switch-b"
+    const val SESSION_B_MARKER: String = "ISSUE1944-B-READY"
+    const val FAKE_AGENT_LEDGER_PATH: String = "/tmp/pocketshell-fake-agent-submits.log"
+    const val LATE_ACK_STAGING_JSONL: String = "/tmp/pocketshell-issue2037-delayed.jsonl"
+
+    /** Issue #2056: pid of the #2042 transcript relay, so it can never outlive its test. */
+    const val TRANSCRIPT_RELAY_PID_PATH: String = "/tmp/pocketshell-issue2042-relay.pid"
+    const val SEEDED_JSONL: String = "issue1526-live-claude.jsonl"
+    const val FAKE_AGENT_READY: String = "FAKE-AGENT-READY"
+
+    private const val CLAUDE_PROJECT_DIR: String = "/home/testuser/.claude/projects/-home-testuser"
+    private val TRANSCRIPT_PATH: String = "$CLAUDE_PROJECT_DIR/$SEEDED_JSONL"
+
+    /**
+     * The three journeys whose subject is the LATE-AUTHORITY path. They get the delayed
+     * transcript AND the deliberately undecidable input surface — see
+     * [Issue2056InducedSubmitAmbiguity] for why the second half became necessary.
+     */
+    val LATE_AUTHORITY_TESTS: Set<String> = setOf(
+        "manualRetryOfUnconfirmedSubmitWaitsForLateAuthority",
+        "lateAckSurvivesCloseAndRecreateWithoutDuplicate",
+        "busyAgentOnStableWritableWireQueuesFifoWithoutBurningAttemptBudget",
+    )
+
+    private const val HEARTBEAT_TEST: String =
+        "busyAgentOnStableWritableWireQueuesFifoWithoutBurningAttemptBudget"
+
+    fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue1526-exactly-once-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue1526 ExactlyOnce",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    suspend fun seedFakeAgentSession(key: String, methodName: String) {
+        val fakeAgentTranscript =
+            if (methodName in LATE_AUTHORITY_TESTS) LATE_ACK_STAGING_JSONL else TRANSCRIPT_PATH
+        val renderModeEnv =
+            Issue2056InducedSubmitAmbiguity.renderModeEnvFor(methodName, LATE_AUTHORITY_TESTS)
+        val heartbeatEnv =
+            if (methodName == HEARTBEAT_TEST) "POCKETSHELL_FAKE_AGENT_HEARTBEAT=1 " else ""
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_B)} 2>/dev/null || true")
+            appendLine("rm -f ${shellQuote(FAKE_AGENT_LEDGER_PATH)}")
+            // #2056 round 2: a transcript relay left running by an earlier test in this
+            // class shares this fixture, and would publish THIS test's staged submit
+            // early — pruning the very row the test is waiting to observe parked. Kill
+            // any survivor before touching the staging file (defence in depth: the
+            // relay also self-terminates after one publish).
+            appendLine(killStrayTranscriptRelay())
+            appendLine("rm -f ${shellQuote(TRANSCRIPT_RELAY_PID_PATH)}")
+            appendLine("rm -f ${shellQuote(LATE_ACK_STAGING_JSONL)}")
+            appendLine("touch ${shellQuote(LATE_ACK_STAGING_JSONL)}")
+            appendLine("mkdir -p $CLAUDE_PROJECT_DIR")
+            appendLine(
+                "cp /home/testuser/.claude/projects/-workspace-pocketshell/" +
+                    "pocketshell-claude.jsonl $TRANSCRIPT_PATH",
+            )
+            appendLine("touch $TRANSCRIPT_PATH")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_NAME)} -x 80 -y 40 " +
+                    "-c /home/testuser " +
+                    shellQuote(
+                        "POCKETSHELL_FAKE_AGENT_SUBMIT_LEDGER=$FAKE_AGENT_LEDGER_PATH " +
+                            "POCKETSHELL_FAKE_AGENT_TRANSCRIPT=$fakeAgentTranscript " +
+                            renderModeEnv +
+                            heartbeatEnv +
+                            "exec /usr/local/bin/pocketshell-fake-agent",
+                    ),
+            )
+            appendLine("tmux set-option -t ${shellQuote(SESSION_NAME)} @ps_agent_kind claude")
+            appendLine(
+                "tmux show-options -v -t ${shellQuote(SESSION_NAME)} " +
+                    "@ps_agent_kind | grep -qx claude",
+            )
+            appendLine("test -s $TRANSCRIPT_PATH")
+            appendLine(
+                "tmux new-session -d -s ${shellQuote(SESSION_B)} -x 80 -y 40 " +
+                    shellQuote("printf '$SESSION_B_MARKER\\n'; exec sh"),
+            )
+            appendLine("tmux set-option -t ${shellQuote(SESSION_B)} @ps_agent_kind shell")
+            appendLine("sleep 1")
+            appendLine(
+                "pid=\$(tmux display-message -p -t ${shellQuote(SESSION_NAME)} '#{pane_pid}'); " +
+                    "tr '\\0' '\\n' < /proc/\$pid/environ | grep -Fx " +
+                    shellQuote("POCKETSHELL_FAKE_AGENT_TRANSCRIPT=$fakeAgentTranscript"),
+            )
+            if (renderModeEnv.isNotEmpty()) {
+                // #2056: fail the SEED, not a later assertion, if the induced-ambiguity
+                // render mode did not actually reach the fake agent's environment.
+                appendLine(
+                    "tr '\\0' '\\n' < /proc/\$pid/environ | grep -Fx " +
+                        shellQuote(
+                            "POCKETSHELL_FAKE_AGENT_RENDER_MODE=" +
+                                Issue2056InducedSubmitAmbiguity.FRAMED_INPUT_RENDER_MODE,
+                        ),
+                )
+            }
+            appendLine("tmux list-sessions")
+        }
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(key),
+            command = script,
+            description = "issue1526 fake-agent tmux seed session",
+        )
+        assertTrue("seed failed ${result.exitCode}: ${result.stderr}", result.exitCode == 0)
+    }
+
+    suspend fun enableIssue1944FramedFakeAgent(fixtureKey: String) {
+        val command =
+            "tmux respawn-pane -k -t ${shellQuote("=$SESSION_NAME:0.0")} " +
+                shellQuote(
+                    "POCKETSHELL_FAKE_AGENT_SUBMIT_LEDGER=$FAKE_AGENT_LEDGER_PATH " +
+                        "POCKETSHELL_FAKE_AGENT_TRANSCRIPT=$TRANSCRIPT_PATH " +
+                        "POCKETSHELL_FAKE_AGENT_RENDER_MODE=" +
+                        Issue2056InducedSubmitAmbiguity.FRAMED_INPUT_RENDER_MODE + " " +
+                        "exec /usr/local/bin/pocketshell-fake-agent",
+                )
+        val result = execRemoteSetupUntilReady(
+            key = SshKey.Pem(fixtureKey),
+            command = command,
+            description = "issue1944 framed fake-agent input surface",
+        )
+        assertEquals("framed fake-agent respawn must succeed: ${result.stderr}", 0, result.exitCode)
+    }
+
+    suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec(
+                        "tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true; " +
+                            "tmux kill-session -t ${shellQuote(SESSION_B)} 2>/dev/null || true; " +
+                            // #2056: never leave the #2042 transcript relay running for
+                            // the next test in this class (see the relay's own comment).
+                            killStrayTranscriptRelay() + " " +
+                            "rm -f $TRANSCRIPT_PATH " +
+                            "${shellQuote(FAKE_AGENT_LEDGER_PATH)} " +
+                            "${shellQuote(LATE_ACK_STAGING_JSONL)} " +
+                            "${shellQuote(TRANSCRIPT_RELAY_PID_PATH)} " +
+                            "2>/dev/null || true",
+                    )
+                }
+            }
+        }
+    }
+
+    /** The #2042 transcript relay is a background process; kill it by its recorded pid. */
+    private fun killStrayTranscriptRelay(): String =
+        "if [ -f ${shellQuote(TRANSCRIPT_RELAY_PID_PATH)} ]; then " +
+            "kill \"\$(cat ${shellQuote(TRANSCRIPT_RELAY_PID_PATH)})\" 2>/dev/null || true; fi;"
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+}

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1686QueueDrainWireOracleDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1686QueueDrainWireOracleDockerTest.kt
@@ -20,8 +20,12 @@ import com.pocketshell.app.composer.InMemoryOutboundQueueStore
 import com.pocketshell.app.composer.OUTBOUND_AUTO_RETRY_EXHAUSTED_MESSAGE
 import com.pocketshell.app.composer.OUTBOUND_MAX_AUTO_ATTEMPTS
 import com.pocketshell.app.composer.OutboundQueueStore
+import com.pocketshell.app.composer.OutboundRoute
 import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.composer.acknowledgeLateOutboundDeliveries
+import com.pocketshell.app.composer.collectPromptComposerSendRequests
 import com.pocketshell.app.composer.PromptComposerViewModel
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.app.di.WhisperClientFactory
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
@@ -30,6 +34,8 @@ import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.session.SessionTab
+import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -125,6 +131,11 @@ class Issue1686QueueDrainWireOracleDockerTest {
     @After
     fun tearDown() {
         harnessScope.cancel()
+        runCatching {
+            SharedPrefsOutboundQueueStore(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+            ).clearSession(ISSUE_2056_TARGET)
+        }
         compose.runOnUiThread {
             createdComposerVms.forEach { runCatching { it.clearForTest() } }
         }
@@ -399,6 +410,213 @@ class Issue1686QueueDrainWireOracleDockerTest {
         }
     }
 
+    /**
+     * Issue #2056 (D33/G4 connected acceptance) — "the payload was delivered but the
+     * composer queue is never cleared".
+     *
+     * Drives an AGENT-ROUTE composer send over the REAL `-CC` transport to a REAL
+     * tmux pane that has NO transcript authority at all (a plain interactive shell,
+     * exactly the `csp`-style relaunch the maintainer reported). The production
+     * delivery path runs unmodified: [TmuxSessionViewModel.sendAgentPayloadToPaneResult]
+     * with the row's durable identity, the production result -> deferral mapping in
+     * [collectPromptComposerSendRequests], the production auto-flush drain, and the
+     * production late-authority bridge.
+     *
+     * RED on base (this class, this fixture): the payload lands in the pane exactly
+     * once, and the durable row NEVER leaves the queue — the bounded turnover proof
+     * cannot read the pane's prompt, the durable submit baseline is null so #2037's
+     * transcript-only late ack can never fire, and every auto-flush dispatch reports
+     * the same unknown outcome while re-granting its retry budget, so the row also
+     * holds the FIFO head forever.
+     *
+     * GREEN: the payload still reaches the pane EXACTLY ONCE (no duplicate), the row
+     * reaches a terminal acknowledgement, the queue empties, and a second prompt
+     * queued behind it also drains.
+     */
+    @Test
+    fun deliveredAgentRouteRowLeavesTheQueueWithNoTranscriptAuthority() {
+        runBlocking {
+            val key = readFixtureKey()
+            waitForSshFixtureReady(SshKey.Pem(key))
+            seedInteractiveSession(key, prompt = "\u276f ")
+            val hostRowTag = seedDockerHost(key, "Issue2056 Delivered Row")
+
+            launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+            attachToOpencodeLab(hostRowTag)
+
+            val liveVm = liveTmuxViewModel()
+            val paneId = awaitAttachedPaneId(liveVm)
+            val identity = readTmuxSessionIdentity(key)
+
+            // The durable store the LIVE VM's delivery ledger writes its wire/submit
+            // write-ahead into is the app's SharedPreferences-backed singleton, so the
+            // journey's composer must read the SAME durable rows (Android caches one
+            // SharedPreferences instance per name per process).
+            val queue = SharedPrefsOutboundQueueStore(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+            )
+            val composer = newComposerVm(queue)
+            // A durable `tmux:` session key: the rows carry a real tmux generation, and
+            // `hasGenerationBoundRowsAwaitingPromotion` deliberately holds the drain for a
+            // generation-stamped row parked under a host/name fallback key (#1944).
+            val target = ISSUE_2056_TARGET
+            onMainUnit {
+                composer.onComposerTargetChanged(target)
+                composer.setTransportWritableProbe { liveVm.isSendTransportWritable() }
+                composer.setSendWatchdogTimeoutForTest(null)
+            }
+
+            val marker = "PS2056${System.currentTimeMillis().toString(36).takeLast(6)}"
+            val tailMarker = "PS2056T${System.currentTimeMillis().toString(36).takeLast(5)}"
+
+            // The PRODUCTION consumer: its onSend is the production agent-payload
+            // delivery, and its result -> deferral mapping is the code under test.
+            harnessScope.launch {
+                collectPromptComposerSendRequests(
+                    viewModel = composer,
+                    onSend = { request ->
+                        val rowId = request.outboundQueueItemId
+                        liveVm.sendAgentPayloadToPaneResult(
+                            paneId,
+                            request.text,
+                            AgentKind.ClaudeCode,
+                            sendToken = rowId ?: "",
+                            durableRow = rowId?.let { DurableOutboundRowIdentity(target, it) },
+                        ).toComposerSendResult()
+                    },
+                )
+            }
+            // The PRODUCTION late-authority bridge, on the same bounded cadence the
+            // composable effect uses.
+            val binding = TmuxOutboundQueueBinding(
+                targetKey = target,
+                fallbackKey = target,
+                durableKey = target,
+                tmuxSessionId = identity.first,
+                sessionCreated = identity.second,
+                generationPaneIds = setOf(paneId),
+            )
+            harnessScope.launch {
+                while (true) {
+                    reconcileLateOutboundAcks(
+                        rows = composer.outboundQueueItems.value,
+                        binding = binding,
+                        resolveAuthoritativeAck = liveVm::resolveLateAuthoritativeOutboundAck,
+                        acknowledge = { resolved ->
+                            composer.acknowledgeLateOutboundDeliveries(
+                                resolved,
+                                onAcknowledged = liveVm::consumeLateAuthoritativeOutboundAck,
+                            )
+                        },
+                    )
+                    kotlinx.coroutines.delay(500L)
+                }
+            }
+            val controller =
+                OutboundQueueAutoFlushController.boundTo(composer, clock = { SystemClock.elapsedRealtime() })
+            harnessScope.launch {
+                controller.onConnectionWindowChanged(sessionLive = true, targetSessionId = target) {}
+                runOutboundQueueAutoFlush(
+                    sessionLive = true,
+                    outboundQueueItems = composer.outboundQueueItems,
+                    controller = controller,
+                    retryNext = { excludingIds -> composer.retryNextOutboundItem(excludingIds) },
+                    transportWritable = { liveVm.isSendTransportWritable() },
+                    unparkTransportFailedRows = { composer.unparkTransportFailedRows() },
+                )
+            }
+
+            onMainUnit {
+                listOf(marker to 0L, tailMarker to 1L).forEach { (text, offset) ->
+                    queue.enqueue(
+                        sessionKey = target,
+                        cleanText = "# $text",
+                        createdAtMs = System.currentTimeMillis() + offset,
+                        paneId = paneId,
+                        route = OutboundRoute.AgentPayload,
+                        agentKind = "claude",
+                        sendKey = "sk-$text",
+                        tmuxSessionId = identity.first,
+                        tmuxSessionCreated = identity.second,
+                    )
+                }
+                composer.refreshOutboundQueueItemsFor(target)
+            }
+
+            // 1) The payload physically reaches the REAL pane.
+            val pane = waitForPaneContains(key, marker, label = "issue2056-delivered")
+            // 2) ... and the durable row must LEAVE the queue. RED on base: it never does.
+            awaitTrue("the delivered row leaves the composer queue") {
+                composer.outboundQueueItems.value.none { it.cleanText.contains(marker) }
+            }
+            // 3) The tail behind it also drains — a clogged head must not poison it.
+            val tailPane = waitForPaneContains(key, tailMarker, label = "issue2056-tail")
+            awaitTrue("the whole queue drains") { composer.outboundQueueItems.value.isEmpty() }
+
+            // Exactly once means exactly once. The assertion used to allow `<= 2` while
+            // its message claimed "exactly once" — a wording/constraint mismatch (G6)
+            // that would have accepted a genuine duplicate re-paste. The `sh -i` pane
+            // echoes each `# <marker>` comment line once and nothing re-prints it.
+            val occurrences = Regex(Regex.escape(marker)).findAll(tailPane).count()
+            assertEquals(
+                "the delivered payload must reach the pane EXACTLY once (no duplicate " +
+                    "re-paste); pane:\n$tailPane",
+                1,
+                occurrences,
+            )
+            val tailOccurrences = Regex(Regex.escape(tailMarker)).findAll(tailPane).count()
+            assertEquals(
+                "the tail payload must also reach the pane EXACTLY once; pane:\n$tailPane",
+                1,
+                tailOccurrences,
+            )
+
+            // Reviewer-usable artifacts: the app's OWN rendered terminal text next to the
+            // authoritative server-side capture, and a viewport taken with the Terminal
+            // tab selected so the PNG shows the delivered payload rather than whatever
+            // tab happened to be mounted. The user-visible queue state is written out as
+            // text because this journey's composer is a harness-owned view model that is
+            // not mounted in the activity's UI.
+            selectTerminalTabForArtifacts(liveVm, paneId)
+            writeArtifactText(
+                "issue2056-delivered-row-leaves-queue-visible-terminal.txt",
+                visibleTerminalText(),
+            )
+            writeArtifactText(
+                "issue2056-delivered-row-leaves-queue-server-capture.txt",
+                tailPane,
+            )
+            writeArtifactText(
+                "issue2056-delivered-row-leaves-queue-queue-surface.txt",
+                buildString {
+                    appendLine("composer_queue_rows=${composer.outboundQueueItems.value.size}")
+                    composer.outboundQueueItems.value.forEach { row ->
+                        appendLine("  id=${row.id} state=${row.state} text=${row.cleanText}")
+                    }
+                    appendLine("durable_rows_for_target=${queue.itemsFor(target).size}")
+                },
+            )
+            captureViewport("04-issue2056-delivered-row-leaves-queue")
+            writeSummary(
+                testName = "deliveredAgentRouteRowLeavesTheQueueWithNoTranscriptAuthority",
+                lines = listOf(
+                    "target=$target",
+                    "pane_id=$paneId",
+                    "tmux_session_id=${identity.first} created=${identity.second}",
+                    "marker=$marker tail_marker=$tailMarker",
+                    "transcript_authority=none (plain interactive shell)",
+                    "captured_pane_contains_marker=${marker in pane}",
+                    "captured_pane_contains_tail_marker=${tailMarker in tailPane}",
+                    "marker_occurrences=$occurrences",
+                    "tail_marker_occurrences=$tailOccurrences",
+                    "composer_queue_rows_after_delivery=${composer.outboundQueueItems.value.size}",
+                    "durable_rows_after_delivery=${queue.itemsFor(target).size}",
+                    "queue_empty_after_delivery=true",
+                ),
+            )
+        }
+    }
+
     // ------------------------------------------------------- Drain machinery
 
     /**
@@ -598,13 +816,20 @@ class Issue1686QueueDrainWireOracleDockerTest {
      * the drain assertion looks for. A `# <marker>` comment line echoes the token
      * without any command-not-found noise.
      */
-    private suspend fun seedInteractiveSession(key: String) {
+    private suspend fun seedInteractiveSession(key: String, prompt: String? = null) {
+        val shellCommand = if (prompt == null) {
+            "printf 'ISSUE1686-READY\\n'; exec sh -i"
+        } else {
+            // Issue #2056: an explicit prompt glyph so the pane's input surface is
+            // identifiable — that identification is exactly what the submit-turnover
+            // oracle needs, and what it could not do before this fix.
+            "printf 'ISSUE1686-READY\\n'; PS1='$prompt'; export PS1; exec sh -i"
+        }
         val script = buildString {
             appendLine("set -eu")
             appendLine("tmux kill-session -t ${shellQuote(SESSION_LAB)} 2>/dev/null || true")
             appendLine(
-                "tmux new-session -d -s ${shellQuote(SESSION_LAB)} " +
-                    shellQuote("printf 'ISSUE1686-READY\\n'; exec sh -i"),
+                "tmux new-session -d -s ${shellQuote(SESSION_LAB)} " + shellQuote(shellCommand),
             )
             appendLine("sleep 1")
             appendLine("tmux list-sessions")
@@ -625,6 +850,24 @@ class Issue1686QueueDrainWireOracleDockerTest {
                 "stderr='${exec?.stderr}'",
             exec?.exitCode == 0,
         )
+    }
+
+    /** Issue #2056: the REAL tmux generation the durable row and its binding are stamped with. */
+    private suspend fun readTmuxSessionIdentity(key: String): Pair<String, Long> {
+        val script =
+            "tmux display-message -p -t ${shellQuote(SESSION_LAB)} " +
+                shellQuote("#{session_id} #{session_created}")
+        val out = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }.getOrNull()?.stdout.orEmpty().trim()
+        val parts = out.split(Regex("\\s+"))
+        assertTrue("could not read the tmux session identity; got '$out'", parts.size >= 2)
+        return parts[0] to (parts[1].toLongOrNull() ?: 0L)
     }
 
     private suspend fun capturePane(key: String): String {
@@ -691,6 +934,54 @@ class Issue1686QueueDrainWireOracleDockerTest {
     }
 
     // ------------------------------------------------------------ Artifacts
+
+    /**
+     * Issue #2056 reviewer feedback: the journey's viewport PNG caught whatever tab
+     * happened to be mounted (a Conversation tab mid "Loading conversation…"), so it
+     * neither corroborated nor contradicted the delivery claim. Select the real
+     * Terminal tab first so the screenshot shows the delivered payload.
+     */
+    private fun selectTerminalTabForArtifacts(liveVm: TmuxSessionViewModel, paneId: String) {
+        onMainUnit { liveVm.selectSessionTab(paneId, SessionTab.Terminal) }
+        // The view-model flag alone does not repaint the chrome the screenshot shows —
+        // the first attempt at this left the PNG on "Loading conversation…". Tap the
+        // real Terminal pill and wait for the Conversation surface to actually leave
+        // the tree before capturing.
+        compose.waitUntil(timeoutMillis = 15_000) {
+            compose.onAllNodesWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = 15_000) {
+            liveVm.agentConversations.value[paneId]?.selectedTab == SessionTab.Terminal &&
+                compose.onAllNodesWithTag(TMUX_CONVERSATION_PANE_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+        }
+        compose.waitForIdle()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        SystemClock.sleep(250)
+    }
+
+    /** The text the APP itself is rendering, alongside the server-side capture. */
+    private fun visibleTerminalText(): String {
+        var text = ""
+        launchedActivity?.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun writeArtifactText(name: String, text: String) {
+        artifactFile(name).writeText(text)
+    }
 
     private fun captureViewport(name: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
@@ -774,5 +1065,8 @@ class Issue1686QueueDrainWireOracleDockerTest {
         const val SESSION_LAB: String = "opencode-lab"
 
         const val PANE_DRAIN_TIMEOUT_MS: Long = 30_000L
+
+        /** Issue #2056: a durable `tmux:` session key (see the drain-promotion guard). */
+        const val ISSUE_2056_TARGET: String = "tmux:issue2056/delivered"
     }
 }

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -391,6 +391,13 @@ public interface OutboundQueueStore {
     /** Whether Enter was attempted without a proven agent-side turnover. */
     public fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean
 
+    /**
+     * Issue #2056: durably record that the last delivery attempt for [id] resolved with
+     * an UNPROVABLE outcome (see [OutboundItem.wireOutcomeUnknown]). No-op for an
+     * unknown or already-delivered row. Returns the updated row, or `null`.
+     */
+    public fun markDeliveryOutcomeUnknown(id: String): OutboundItem?
+
     /** Transcript authority captured by the same synchronous pre-Enter write-ahead. */
     public fun wireSubmitTranscriptBaseline(
         sessionKey: String,
@@ -561,6 +568,16 @@ public fun OutboundQueueStore.asWireAttemptDurableStore(): OutboundWireAttemptDu
  * @property wireCollapsedMarkerBaselineCount issue #1739: the pre-send count of
  *   Claude's collapsed multiline-paste chips. A retry may treat a higher current
  *   count as proof that the ambiguous paste landed, then submit Enter-only.
+ * @property wireOutcomeUnknown issue #2056: the LAST delivery attempt resolved with a
+ *   genuinely UNPROVABLE outcome — the payload may well have landed (it usually has),
+ *   but no authority could confirm it. This is a first-class user-visible state, not a
+ *   failure and not "still sending": the drain must not keep re-dispatching the row
+ *   (every such dispatch can only reproduce the same unknown answer, and while it owns
+ *   the FIFO head nothing behind it can drain), and the UI must say so instead of
+ *   claiming "Queued — sending next". Cleared whenever a fresh attempt is claimed
+ *   ([claimedForAttempt]) or the user explicitly re-drives the row
+ *   ([requeueForRetry] with `resetAttempts`), so it always describes the latest
+ *   resolved attempt.
  * @property wireSubmitAttempted issue #1944: durably records that Enter was sent
  *   after the payload paste. If turnover could not be confirmed, a rebuilt VM
  *   keeps the row unresolved and must not issue another blind Enter.
@@ -597,6 +614,7 @@ public data class OutboundItem(
     val wireCollapsedMarkerBaselineCount: Int? = null,
     val wireSubmitAttempted: Boolean = false,
     val wireAttemptGeneration: Int = 0,
+    val wireOutcomeUnknown: Boolean = false,
     val wireSubmitTranscriptBaseline: OutboundSubmitTranscriptBaseline? = null,
     /** Tap-time tmux generation. Both fields are required for identity promotion. */
     val tmuxSessionId: String? = null,
@@ -864,6 +882,10 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
             state = OutboundState.Queued,
             lastError = null,
             attemptCount = existing.adjustedAttemptCount(resetAttempts, attemptDelta),
+            // Issue #2056: an explicit user re-drive ("Resend all" / per-row Retry
+            // budget reset) discards the previous attempt's unprovable verdict so the
+            // row is genuinely re-dispatched instead of staying permanently unknown.
+            wireOutcomeUnknown = if (resetAttempts) false else existing.wireOutcomeUnknown,
         )
         items[updated.id] = updated
         updated
@@ -928,6 +950,14 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
 
     override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean = synchronized(lock) {
         items[itemId]?.let { it.sessionKey == sessionKey && it.wireSubmitAttempted } == true
+    }
+
+    override fun markDeliveryOutcomeUnknown(id: String): OutboundItem? = synchronized(lock) {
+        val existing = items[id] ?: return null
+        if (existing.state == OutboundState.Delivered) return existing
+        val updated = existing.copy(wireOutcomeUnknown = true)
+        items[updated.id] = updated
+        updated
     }
 
     override fun wireSubmitTranscriptBaseline(
@@ -1022,6 +1052,7 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     ): OutboundItem? = null
 
     override fun hasWireSubmitAttempt(sessionKey: String, itemId: String): Boolean = false
+    override fun markDeliveryOutcomeUnknown(id: String): OutboundItem? = null
     override fun wireSubmitTranscriptBaseline(
         sessionKey: String,
         itemId: String,
@@ -1356,6 +1387,10 @@ public class SharedPrefsOutboundQueueStore internal constructor(
             state = OutboundState.Queued,
             lastError = null,
             attemptCount = existing.adjustedAttemptCount(resetAttempts, attemptDelta),
+            // Issue #2056: an explicit user re-drive ("Resend all" / per-row Retry
+            // budget reset) discards the previous attempt's unprovable verdict so the
+            // row is genuinely re-dispatched instead of staying permanently unknown.
+            wireOutcomeUnknown = if (resetAttempts) false else existing.wireOutcomeUnknown,
         )
         replaceAndStore(sessionKey, list, updated)
         updated
@@ -1440,6 +1475,16 @@ public class SharedPrefsOutboundQueueStore internal constructor(
         loadSession(sessionKey).any {
             it.id == itemId && it.sessionKey == sessionKey && it.wireSubmitAttempted
         }
+    }
+
+    override fun markDeliveryOutcomeUnknown(id: String): OutboundItem? = synchronized(lock) {
+        val sessionKey = sessionOf(id) ?: return null
+        val list = loadSession(sessionKey)
+        val existing = list.firstOrNull { it.id == id } ?: return null
+        if (existing.state == OutboundState.Delivered) return existing
+        val updated = existing.copy(wireOutcomeUnknown = true)
+        replaceAndStore(sessionKey, list, updated)
+        updated
     }
 
     override fun wireSubmitTranscriptBaseline(
@@ -1583,14 +1628,20 @@ private fun OutboundItem.claimedForAttempt(): OutboundItem {
     // ([OutboundQueueStore.markWireAttempted], driven by the ledger's
     // `recordWireAttempt` right before the first byte). A first send now has
     // `wireAttempted=false`, so it is delivered normally with no probe.
+    //
+    // Issue #2056: a FRESH attempt invalidates the previous attempt's unprovable
+    // verdict ([OutboundItem.wireOutcomeUnknown]) — the new attempt gets to decide
+    // for itself. Clearing it here (rather than at the deferral) is what makes a
+    // user's explicit Retry a real re-decision instead of a permanent label.
     val atMs = System.currentTimeMillis()
     return if (state == OutboundState.InFlight) {
-        copy(lastAttemptAtMs = atMs)
+        copy(lastAttemptAtMs = atMs, wireOutcomeUnknown = false)
     } else {
         copy(
             state = OutboundState.InFlight,
             attemptCount = attemptCount + 1,
             lastAttemptAtMs = atMs,
+            wireOutcomeUnknown = false,
         )
     }
 }
@@ -1671,6 +1722,7 @@ internal fun encodeOutboundItems(items: List<OutboundItem>): String =
                 ?.joinToString(separator = "\n")
                 .orEmpty(),
             item.wireAttemptGeneration.toString(),
+            if (item.wireOutcomeUnknown) "1" else "0",
         ).joinToString(separator = "\t") { escapeQueueField(it) }
     }
 
@@ -1711,6 +1763,7 @@ internal fun decodeOutboundItems(sessionKey: String, raw: String): List<Outbound
             wireSubmitAttempted = submitAttempted,
             wireAttemptGeneration = f.getOrNull(24)?.toIntOrNull()
                 ?: if (submitAttempted) 1 else 0,
+            wireOutcomeUnknown = f.getOrNull(25) == "1",
             wireSubmitTranscriptBaseline = f.getOrNull(20)
                 ?.takeIf { it.isNotEmpty() }
                 ?.let { sourcePath ->

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundQueueSelection.kt
@@ -205,6 +205,22 @@ internal const val OUTBOUND_UPLOAD_FAILURE_ATTEMPT_DELTA: Int = 1
 internal fun OutboundItem.isComposerQueueRetryable(): Boolean =
     state == OutboundState.Queued || state == OutboundState.Failed
 
+/**
+ * Issue #2056: this row's last delivery attempt resolved with a genuinely UNPROVABLE
+ * outcome — the payload very probably landed, but no authority could confirm it.
+ *
+ * Such a row is NOT auto-dispatchable. Its retry is ledger-gated
+ * (`verifyBeforeAgentResend` refuses to re-paste once the submit was attempted), so
+ * every auto-flush dispatch can only reproduce the same unknown answer — while
+ * occupying the FIFO head and starving every prompt behind it. On base that starve
+ * was permanent, because the deferral re-granted the row's whole retry budget so it
+ * could never even park: the maintainer's "once the first message gets clogged,
+ * every following message gets clogged too". It is skipped here (never dropped, and
+ * still surfaced + user-retryable) so the tail drains on its own evidence.
+ */
+internal fun OutboundItem.isComposerQueueDeliveryUnconfirmed(): Boolean =
+    isComposerQueueRetryable() && wireOutcomeUnknown
+
 internal fun OutboundItem.isComposerQueueUndelivered(): Boolean =
     state != OutboundState.Delivered
 
@@ -236,13 +252,15 @@ internal fun Iterable<OutboundItem>.firstComposerAutoFlushable(
 ): OutboundItem? {
     // Preserve physical FIFO across identity promotion. An older InFlight or
     // Uploading row may still own bytes already pasted into the same pane; it
-    // blocks every younger row until its terminal callback. Exhausted retryable
-    // rows are the sole exception: this cycle parks/surfaces them, so selection
-    // may continue to the next row without hiding a poison head forever.
+    // blocks every younger row until its terminal callback. Two retryable shapes
+    // are the exceptions, and both are surfaced rather than hidden: an exhausted
+    // row (this cycle parks it, #1602) and a delivery-unconfirmed row (#2056 — the
+    // auto-flush can never resolve it, so re-picking it only starves the tail).
     val head = firstOrNull { item ->
         item.sessionKey == sessionKey &&
             item.isComposerQueueUndelivered() &&
-            !(item.isComposerQueueRetryable() && item.attemptCount >= maxAutoAttempts)
+            !(item.isComposerQueueRetryable() && item.attemptCount >= maxAutoAttempts) &&
+            !item.isComposerQueueDeliveryUnconfirmed()
     } ?: return null
     return head.takeIf {
         it.isComposerQueueRetryable() && it.id !in excludingIds

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -188,8 +188,18 @@ internal suspend fun collectPromptComposerSendRequests(
                             onDelivered()
                         }
                     }
+                    // Issue #2056: the row is recorded as a genuinely UNKNOWN delivery
+                    // outcome — stated as such in the UI and SKIPPED by the auto-flush
+                    // drain, because every re-dispatch can only reproduce the same
+                    // unknown answer while holding the FIFO head and starving every
+                    // prompt behind it. #1944's budget re-grant is preserved: turnover
+                    // ambiguity is not a transport failure, so it burns no attempt.
                     ComposerSendResult.AuthoritativeAckPending ->
-                        viewModel.markOutboundSendDeferred(request, resetAttemptBudget = true)
+                        viewModel.markOutboundSendDeferred(
+                            request,
+                            resetAttemptBudget = true,
+                            deliveryOutcomeUnknown = true,
+                        )
                     ComposerSendResult.Failed ->
                         viewModel.markOutboundSendDeferred(
                             request,

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerQueueBanners.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerQueueBanners.kt
@@ -512,6 +512,18 @@ internal fun pendingSummarySubline(items: List<PendingTranscriptionItem>): Strin
     }
 }
 
+/**
+ * Issue #2056: a delivery whose outcome could not be proven must be STATED as
+ * unproven. "Queued — sending next" was an outright lie for these rows: nothing was
+ * being sent, nothing ever would be, and the payload had usually already run — so
+ * the user could not tell which visibly-queued prompts had already landed, and a
+ * Retry risked duplicating one the agent had already accepted.
+ */
+internal const val OUTBOUND_DELIVERY_UNCONFIRMED_SUMMARY: String = "Sent — delivery unconfirmed"
+
+internal const val OUTBOUND_DELIVERY_UNCONFIRMED_MESSAGE: String =
+    "Sent, but delivery could not be confirmed — check the terminal before retrying"
+
 internal data class OutboundQueueSummary(
     val primary: String,
     val preview: String? = null,
@@ -530,6 +542,9 @@ internal fun outboundQueueSummary(
         ?: outboundAttachmentCountLabel(oldest.attachments.size).takeIf { oldest.attachments.isNotEmpty() }
     val preview = previewText?.let { "“$it”" }
     if (items.size == 1) {
+        if (oldest.isComposerQueueDeliveryUnconfirmed()) {
+            return OutboundQueueSummary(OUTBOUND_DELIVERY_UNCONFIRMED_SUMMARY, preview, attention = true)
+        }
         val primary = when (oldest.state) {
             OutboundState.Queued -> if (connectionDegraded) {
                 "Queued — will send on reconnect"
@@ -544,7 +559,16 @@ internal fun outboundQueueSummary(
         return OutboundQueueSummary(primary, preview, oldest.state == OutboundState.Failed)
     }
 
+    val unconfirmedCount = items.count { it.isComposerQueueDeliveryUnconfirmed() }
     val failedCount = items.count { it.state == OutboundState.Failed }
+    if (unconfirmedCount > 0) {
+        return OutboundQueueSummary(
+            primary = "${items.size} queued",
+            preview = preview,
+            attention = true,
+            attentionSuffix = "$unconfirmedCount unconfirmed",
+        )
+    }
     val primary = when {
         failedCount > 0 -> "${items.size} queued"
         connectionDegraded -> "${items.size} queued · will send on reconnect"
@@ -558,7 +582,11 @@ internal fun outboundQueueSummary(
     )
 }
 
-internal fun outboundQueueStateLabel(item: OutboundItem): String = when (item.state) {
+internal fun outboundQueueStateLabel(item: OutboundItem): String = if (
+    item.isComposerQueueDeliveryUnconfirmed()
+) {
+    OUTBOUND_DELIVERY_UNCONFIRMED_MESSAGE
+} else when (item.state) {
     OutboundState.Queued -> PromptComposerViewModel.WILL_SEND_WHEN_RECONNECTED_MESSAGE
     OutboundState.Uploading -> "Uploading attachments"
     OutboundState.InFlight -> "Sending"

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -1171,6 +1171,10 @@ public class PromptComposerViewModel @Inject constructor(
         request: SendRequest,
         noRowFallbackMessage: String = "Not sent. Reconnect, then send again or discard the draft.",
         resetAttemptBudget: Boolean = false,
+        // Issue #2056: the attempt resolved with an UNPROVABLE outcome (the payload
+        // may well have landed). Recorded durably on the row so the drain stops
+        // re-dispatching it and the UI stops claiming it is "sending next".
+        deliveryOutcomeUnknown: Boolean = false,
     ) {
         // #891: disarm the watchdog (no stale "Send failed"); #971: drop the captured request.
         watchdogs.disarmSend()
@@ -1187,6 +1191,7 @@ public class PromptComposerViewModel @Inject constructor(
             restoreFailedSend(request, message = noRowFallbackMessage)
             return
         }
+        if (deliveryOutcomeUnknown) outboundQueueStore.markDeliveryOutcomeUnknown(requeued.id)
         requeued.recordQueueRowState("InFlight", "Queued", "deferred") // #1682
         DiagnosticEvents.record(
             "action",

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
@@ -471,17 +471,53 @@ internal class AgentSubmitTurnoverNotProvenException(result: String) :
  */
 internal enum class AgentInputSurfaceState { PendingPayload, Ready, Unknown }
 
+/**
+ * Issue #2056: characters an agent/shell prompt may be WRAPPED in before its
+ * marker glyph. Claude Code draws its input inside a box, so the live prompt row
+ * reads `│ > ` — its first non-blank character is the box edge, not the marker.
+ * The pre-#2056 matcher only looked at `line.trimStart()`, so it never found
+ * Claude's prompt, [agentInputSurfaceState] answered [AgentInputSurfaceState.Unknown]
+ * on every Claude frame, and the generic submit-turnover proof
+ * ([awaitAgentSubmitTurnover]) could therefore NEVER succeed for Claude Code —
+ * every send fell into the ambiguous `wireSubmitAttempted` state.
+ */
+private val AGENT_INPUT_PROMPT_DECORATION: Set<Char> =
+    setOf('│', '┃', '┆', '┊', '╎', '║', '▌', '|')
+
+/**
+ * Issue #2056: marker glyphs that introduce an interactive input line. `>` / `›`
+ * are the agent TUIs; `❯` / `➜` / `❭` are the maintainer's shell prompt, needed so
+ * a shell-hosted send (`csp`, which relaunches an agent) is decidable at all
+ * instead of being permanently unknown.
+ */
+private val AGENT_INPUT_PROMPT_GLYPHS: Set<Char> = setOf('>', '›', '❯', '➜', '❭', '$')
+
+/** The prompt line's content with any leading blanks/box decoration removed. */
+private fun agentInputPromptBody(line: String): String? {
+    var index = 0
+    while (
+        index < line.length &&
+        (line[index].isWhitespace() || line[index] in AGENT_INPUT_PROMPT_DECORATION)
+    ) {
+        index += 1
+    }
+    return line.substring(index).takeIf { it.isNotEmpty() }
+}
+
+/** Issue #2056: does [line] carry the pane's interactive input marker? */
+internal fun isAgentInputPromptLine(line: String): Boolean {
+    val body = agentInputPromptBody(line) ?: return false
+    if (body[0] !in AGENT_INPUT_PROMPT_GLYPHS) return false
+    return body.length == 1 || body[1] == ' ' || body[1] == '\t'
+}
+
 internal fun agentInputSurfaceState(
     response: CommandResponse,
     payload: String,
 ): AgentInputSurfaceState {
     if (response.isError) return AgentInputSurfaceState.Unknown
     val needle = agentSubmitAckNeedle(payload) ?: return AgentInputSurfaceState.Unknown
-    val promptIndex = response.output.indexOfLast { line ->
-        val trimmed = line.trimStart()
-        trimmed == ">" || trimmed.startsWith("> ") ||
-            trimmed == "›" || trimmed.startsWith("› ")
-    }
+    val promptIndex = response.output.indexOfLast(::isAgentInputPromptLine)
     if (promptIndex < 0) return AgentInputSurfaceState.Unknown
     val candidate = response.output.drop(promptIndex)
     val pending = agentSubmitVisibleTextContainsNeedle(candidate, needle) ||
@@ -491,9 +527,6 @@ internal fun agentInputSurfaceState(
             )
     return if (pending) AgentInputSurfaceState.PendingPayload else AgentInputSurfaceState.Ready
 }
-
-internal fun agentPaneShowsPayloadInInput(response: CommandResponse, payload: String): Boolean =
-    agentInputSurfaceState(response, payload) != AgentInputSurfaceState.Ready
 
 private fun recordAgentSubmitTurnoverCapture(
     identity: AgentSendRuntimeIdentity,

--- a/app/src/main/java/com/pocketshell/app/tmux/LateAuthoritativeSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/LateAuthoritativeSubmitAck.kt
@@ -1,25 +1,86 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+
 /**
- * Resolves a previously ambiguous submit from a transcript turn that became
- * authoritative after the original bounded turnover wait expired.
+ * Resolves a previously ambiguous submit whose proof became available after the
+ * original bounded turnover wait expired.
  *
- * The durable pre-Enter baseline keeps this fail-closed: only a newly
- * confirmed exact-payload turn on the same recorded source can acknowledge the
- * row, and a successful acknowledgement consumes the volatile attempt ledger
- * without issuing another paste or Enter.
+ * ## Why this is an authority CHAIN (issue #2056, hard cut of #2037's single arm)
+ *
+ * #2037 resolved a stuck row from ONE authority: a newly confirmed transcript turn
+ * against the durable pre-Enter baseline. That baseline is `null` whenever the pane
+ * had no live transcript source at submit time — a just-relaunched agent, a
+ * node-wrapped Claude the detector cannot bind, a catalog TUI control
+ * ([AgentSubmitDeliveryProof.TmuxEnterAccepted]) — and a `null` baseline made the
+ * bridge return `false` FOREVER. The payload had been delivered, so nothing else
+ * would ever move the row either: every retry hits `verifyBeforeAgentResend`'s
+ * submit-attempt short circuit and reports `Unknown`. That is the maintainer's
+ * "delivered, but the composer queue is never cleared".
+ *
+ * The cure is to make the terminal acknowledgement **route-complete**: when the
+ * transcript cannot speak, ask the PANE. A row only reaches this state after the
+ * paste was ack-proven on the pane and Enter was written, so "the payload is no
+ * longer pending on the pane's input surface" ([AgentInputSurfaceState.Ready]) is
+ * authoritative evidence that the submit was consumed. Everything else — a pane
+ * still holding the payload, an unreadable prompt, a failed capture — is
+ * fail-closed and preserves the durable row.
  */
-internal fun OutboundDeliveryLedger.resolveLateAuthoritativeTranscriptAck(
+internal suspend fun OutboundDeliveryLedger.resolveLateAuthoritativeSubmitAck(
     transcriptAuthority: AgentTranscriptAuthority,
     paneId: String,
     payload: String,
     sendToken: String,
     durableRow: DurableOutboundRowIdentity?,
+    capturePane: OutboundPaneCapture?,
     consumeOnSuccess: Boolean = true,
 ): Boolean {
     if (durableRow == null || !hasSubmitAttempt(paneId, sendToken, durableRow)) return false
-    val baseline = submitTranscriptBaseline(durableRow) ?: return false
-    if (!transcriptAuthority.acknowledgedFromDurableBaseline(paneId, payload, baseline)) return false
+    val acknowledged = transcriptConfirmed(transcriptAuthority, paneId, payload, durableRow) ||
+        paneConsumedSubmit(paneId, payload, capturePane)
+    if (!acknowledged) return false
     if (consumeOnSuccess) clear(paneId, sendToken)
     return true
+}
+
+/**
+ * Arm 1: the exact recorded transcript source produced a NEW confirmed user turn
+ * for this payload since the pre-Enter baseline snapshot.
+ */
+private fun OutboundDeliveryLedger.transcriptConfirmed(
+    transcriptAuthority: AgentTranscriptAuthority,
+    paneId: String,
+    payload: String,
+    durableRow: DurableOutboundRowIdentity,
+): Boolean {
+    val baseline = submitTranscriptBaseline(durableRow) ?: return false
+    return transcriptAuthority.acknowledgedFromDurableBaseline(paneId, payload, baseline)
+}
+
+/**
+ * Arm 2: no transcript authority exists (or it never confirmed). The pane itself is
+ * then the only authority the product has, and it is a real one: this row's paste
+ * was ack-proven into the input surface before Enter, so an input surface that no
+ * longer holds the payload means the agent/shell consumed the submit.
+ *
+ * Fail-closed on every uncertainty — no capture boundary, a failed/errored capture,
+ * an unreadable prompt ([AgentInputSurfaceState.Unknown]), or the payload still
+ * pending — because a false acknowledgement here silently loses a prompt.
+ */
+private suspend fun paneConsumedSubmit(
+    paneId: String,
+    payload: String,
+    capturePane: OutboundPaneCapture?,
+): Boolean {
+    val capture = capturePane ?: return false
+    val frame = capture(paneId, OUTBOUND_DELIVERY_PROBE_TIMEOUT_MS, 0) ?: return false
+    if (frame.isError) return false
+    val state = agentInputSurfaceState(frame, payload)
+    DiagnosticEvents.record(
+        "action",
+        "outbound_late_pane_submit_ack",
+        "pane" to paneId,
+        "inputState" to state.name,
+    )
+    return state == AgentInputSurfaceState.Ready
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundDeliveryGuard.kt
@@ -10,6 +10,7 @@ import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 /**
  * Issue #1526 — Slice S1: verify-before-resend for exactly-once OUTBOUND delivery.
@@ -280,6 +281,29 @@ internal suspend fun deliverRawInputWithGuard(
         ledger.clear(paneId, sendToken)
         afterDelivered(client, paneId, bytes)
     }
+}
+
+/**
+ * Issue #1944: the pre-Enter write-ahead barrier — persist "Enter was attempted"
+ * BEFORE the Enter reaches tmux, so a crash/VM-clear in that window can never turn
+ * the uncertainty into a blind second Enter. Fails closed: an unpersisted barrier
+ * means the Enter is not sent at all. Extracted out of the connection-core
+ * god-object (D28 / the #1047 downward ratchet); [ioContext] is the caller's
+ * off-Main IO hop, because the durable write is a synchronous `commit()`.
+ */
+internal suspend fun OutboundDeliveryLedger.persistSubmitWriteAhead(
+    ioContext: kotlin.coroutines.CoroutineContext,
+    paneId: String,
+    sendToken: String,
+    durableRow: DurableOutboundRowIdentity?,
+    transcriptBaseline: OutboundSubmitTranscriptBaseline?,
+) {
+    if (durableRow == null) return
+    check(
+        withContext(ioContext) {
+            recordSubmitAttempt(paneId, sendToken, durableRow, transcriptBaseline)
+        },
+    ) { "Agent submit write-ahead persistence failed; Enter not sent." }
 }
 
 /** Bounded round-trip for a verify-before-resend `capture-pane` probe. */

--- a/app/src/main/java/com/pocketshell/app/tmux/OutboundLateAckReconciler.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/OutboundLateAckReconciler.kt
@@ -9,10 +9,26 @@ import com.pocketshell.app.composer.OutboundState
 import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.composer.acknowledgeLateOutboundDeliveries
 import com.pocketshell.app.composer.appendAttachmentPaths
+import kotlinx.coroutines.delay
 
 /**
- * Foreground-only bridge from authoritative transcript turnover to the exact
- * durable composer row whose bounded submit acknowledgement arrived late.
+ * Issue #2056: the late authority is asked again on a bounded foreground cadence
+ * while a row is still awaiting it.
+ *
+ * #2037 evaluated the authority exactly once per queue/transcript snapshot change.
+ * That is enough for a streaming agent (its transcript churns), but it is nothing
+ * at all for the case this issue is about — a pane with no transcript, whose ONLY
+ * authority is its own input surface. Its evidence arrives a second or two after
+ * the bounded turnover wait gave up, and no snapshot changes in between, so the
+ * row sat unresolved forever. The loop is foreground-only (D21), self-terminating
+ * (a fixed poll bound), and stops the instant the row resolves or disappears.
+ */
+internal const val OUTBOUND_LATE_ACK_POLL_INTERVAL_MS: Long = 1_000L
+internal const val OUTBOUND_LATE_ACK_MAX_POLLS: Int = 6
+
+/**
+ * Foreground-only bridge from an authoritative late submit proof to the exact
+ * durable composer row whose bounded acknowledgement arrived late.
  */
 @Composable
 internal fun TmuxOutboundLateAckEffect(
@@ -23,31 +39,56 @@ internal fun TmuxOutboundLateAckEffect(
     val conversations by tmuxViewModel.agentConversations.collectAsState()
     val rows by composerViewModel.outboundQueueItems.collectAsState()
     LaunchedEffect(conversations, rows, binding) {
-        val resolved = resolveLateOutboundAcks(
+        reconcileLateOutboundAcks(
             rows = rows,
             binding = binding,
             resolveAuthoritativeAck = tmuxViewModel::resolveLateAuthoritativeOutboundAck,
+            acknowledge = { resolved ->
+                composerViewModel.acknowledgeLateOutboundDeliveries(
+                    resolved,
+                    onAcknowledged = tmuxViewModel::consumeLateAuthoritativeOutboundAck,
+                )
+            },
         )
-        if (resolved.isNotEmpty()) {
-            composerViewModel.acknowledgeLateOutboundDeliveries(
-                resolved,
-                onAcknowledged = tmuxViewModel::consumeLateAuthoritativeOutboundAck,
-            )
-        }
     }
 }
 
-internal fun resolveLateOutboundAcks(
+/**
+ * Poll the late authority for every binding-matched row until one batch resolves
+ * or the bounded budget is spent. Returns the acknowledged rows (empty when the
+ * authority never spoke), so a caller/test reads the outcome without the composer.
+ */
+internal suspend fun reconcileLateOutboundAcks(
     rows: List<OutboundItem>,
     binding: TmuxOutboundQueueBinding,
-    resolveAuthoritativeAck: (OutboundItem) -> Boolean,
-): List<OutboundItem> = rows
-    .asSequence()
-    .filter { it.matchesLateAckBinding(binding) }
-    .filter(resolveAuthoritativeAck)
-    .toList()
+    resolveAuthoritativeAck: suspend (OutboundItem) -> Boolean,
+    acknowledge: (List<OutboundItem>) -> Unit = {},
+    maxPolls: Int = OUTBOUND_LATE_ACK_MAX_POLLS,
+    pollIntervalMs: Long = OUTBOUND_LATE_ACK_POLL_INTERVAL_MS,
+): List<OutboundItem> {
+    val candidates = rows.filter { it.matchesLateAckBinding(binding) }
+    if (candidates.isEmpty()) return emptyList()
+    repeat(maxPolls.coerceAtLeast(1)) { poll ->
+        if (poll > 0) delay(pollIntervalMs)
+        val resolved = resolveLateOutboundAcks(candidates, binding, resolveAuthoritativeAck)
+        if (resolved.isNotEmpty()) {
+            acknowledge(resolved)
+            return resolved
+        }
+    }
+    return emptyList()
+}
 
-/** Reject stale/foreign pane, session and tmux-generation evidence before transcript inspection. */
+/** One authority pass over [rows]: the binding-matched rows the authority confirmed. */
+internal suspend fun resolveLateOutboundAcks(
+    rows: List<OutboundItem>,
+    binding: TmuxOutboundQueueBinding,
+    resolveAuthoritativeAck: suspend (OutboundItem) -> Boolean,
+): List<OutboundItem> = rows
+    .filter { it.matchesLateAckBinding(binding) }
+    .filter { resolveAuthoritativeAck(it) }
+
+/** Reject stale/foreign pane, session and tmux-generation evidence before authority inspection. */
 internal fun OutboundItem.matchesLateAckBinding(binding: TmuxOutboundQueueBinding): Boolean =
     (state == OutboundState.Queued || state == OutboundState.Failed) &&
         wireSubmitAttempted &&
@@ -60,15 +101,17 @@ internal fun OutboundItem.matchesLateAckBinding(binding: TmuxOutboundQueueBindin
         tmuxSessionId == binding.tmuxSessionId &&
         tmuxSessionCreated == binding.sessionCreated
 
-internal fun resolveLateOutboundAck(
+internal suspend fun resolveLateOutboundAck(
     ledger: OutboundDeliveryLedger,
     authority: AgentTranscriptAuthority,
     item: OutboundItem,
-): Boolean = ledger.resolveLateAuthoritativeTranscriptAck(
+    capturePane: OutboundPaneCapture?,
+): Boolean = ledger.resolveLateAuthoritativeSubmitAck(
     transcriptAuthority = authority,
     paneId = item.paneId,
     payload = appendAttachmentPaths(item.cleanText, item.attachments.map { it.remotePath }),
     sendToken = item.id,
     durableRow = DurableOutboundRowIdentity(item.sessionKey, item.id),
+    capturePane = capturePane,
     consumeOnSuccess = false,
 )

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -14143,7 +14143,9 @@ public class TmuxSessionViewModel @Inject constructor(
     internal fun setAgentTranscriptAuthorityForTest(paneId: String, active: Boolean) = agentTranscriptAuthority.setActiveForTest(paneId, active)
     @androidx.annotation.VisibleForTesting
     internal fun setAgentTranscriptAuthorityStartingForTest(paneId: String, starting: Boolean) = agentTranscriptAuthority.setStartingForTest(paneId, starting)
-    internal fun resolveLateAuthoritativeOutboundAck(item: com.pocketshell.app.composer.OutboundItem): Boolean = resolveLateOutboundAck(outboundDeliveryLedger, agentTranscriptAuthority, item)
+    // Issue #2056: the late authority may need the PANE (a row with no transcript source).
+    internal suspend fun resolveLateAuthoritativeOutboundAck(item: com.pocketshell.app.composer.OutboundItem): Boolean =
+        clientRef?.let { resolveLateOutboundAck(outboundDeliveryLedger, agentTranscriptAuthority, item, boundedPaneCapture(snapshotAgentSendRuntime(it))) } == true
     internal fun consumeLateAuthoritativeOutboundAck(item: com.pocketshell.app.composer.OutboundItem) = outboundDeliveryLedger.clear(item.paneId, item.id)
     private fun isCurrentAgentSendRuntime(
         identity: AgentSendRuntimeIdentity,
@@ -14168,6 +14170,12 @@ public class TmuxSessionViewModel @Inject constructor(
             paneRows.containsKey(paneId) ||
             _agentConversations.value.containsKey(paneId)
     }
+
+    /** Issue #1739/#2056: the caller-bounded, runtime-pinned capture boundary. */
+    private fun boundedPaneCapture(identity: AgentSendRuntimeIdentity): OutboundPaneCapture =
+        { pane, timeoutMs, lines ->
+            captureAgentPaneBounded(identity, pane, timeoutMs, lines).takeIf { it.status == AgentPaneCaptureStatus.Captured }?.response
+        }
 
     private suspend fun captureAgentPaneBounded(
         identity: AgentSendRuntimeIdentity,
@@ -14202,15 +14210,8 @@ public class TmuxSessionViewModel @Inject constructor(
         if (!isCurrentAgentSendRuntime(runtimeIdentity, paneId)) {
             return Result.failure(IllegalStateException("Agent send target is stale or foreign."))
         }
-        val boundedCapture: OutboundPaneCapture = { capturePaneId, timeoutMs, scrollbackLines ->
-            captureAgentPaneBounded(
-                identity = runtimeIdentity,
-                paneId = capturePaneId,
-                timeoutMs = timeoutMs,
-                scrollbackLines = scrollbackLines,
-            ).takeIf { it.status == AgentPaneCaptureStatus.Captured }?.response
-        }
-        if (outboundDeliveryLedger.resolveLateAuthoritativeTranscriptAck(agentTranscriptAuthority, paneId, payload, sendToken, durableRow)) return Result.success(Unit).also { requestReconcile(client, paneId, ReconcileReason.Send) }
+        val boundedCapture = boundedPaneCapture(runtimeIdentity)
+        if (outboundDeliveryLedger.resolveLateAuthoritativeSubmitAck(agentTranscriptAuthority, paneId, payload, sendToken, durableRow, boundedCapture)) return Result.success(Unit).also { requestReconcile(client, paneId, ReconcileReason.Send) }
         // Issue #1526 S1 (verify-before-resend): a PRIOR ambiguous attempt for THIS send —
         // keyed by the #1529 [sendToken], NOT the payload, so two distinct identical sends
         // never false-dedup — the paste may have run server-side (audit A1/A2). Probe (#869
@@ -14236,11 +14237,7 @@ public class TmuxSessionViewModel @Inject constructor(
                         .response ?: error("Agent submit frame unavailable before Enter; kept queued.")
                 }
                 val transcriptBaseline = agentTranscriptAuthority.baselineFor(deliveryProof, paneId, payload)
-                durableRow?.let { row ->
-                    check(withContext(seedIoDispatcher) {
-                        outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row, transcriptBaseline?.durable())
-                    }) { "Agent submit write-ahead persistence failed; Enter not sent." }
-                }
+                outboundDeliveryLedger.persistSubmitWriteAhead(seedIoDispatcher, paneId, sendToken, durableRow, transcriptBaseline?.durable())
                 sendNamedKeyToPane(client, paneId, "Enter")
                     .throwIfTmuxError("submit previously pasted agent input")
                 if (preEnterFrame != null && deliveryProof == AgentSubmitDeliveryProof.AgentTurnover) {
@@ -14355,11 +14352,7 @@ public class TmuxSessionViewModel @Inject constructor(
             }
             consumeSendResultLostSeamForTest()
             val transcriptBaseline = agentTranscriptAuthority.baselineFor(deliveryProof, paneId, payload)
-            durableRow?.let { row ->
-                check(withContext(seedIoDispatcher) {
-                    outboundDeliveryLedger.recordSubmitAttempt(paneId, sendToken, row, transcriptBaseline?.durable())
-                }) { "Agent submit write-ahead persistence failed; Enter not sent." }
-            }
+            outboundDeliveryLedger.persistSubmitWriteAhead(seedIoDispatcher, paneId, sendToken, durableRow, transcriptBaseline?.durable())
             sendNamedKeyToPane(client, paneId, "Enter")
                 .throwIfTmuxError("submit pasted agent input")
             if (durableRow != null && deliveryProof == AgentSubmitDeliveryProof.AgentTurnover) {

--- a/app/src/test/java/com/pocketshell/app/composer/Issue2056UnknownDeliveryOutcomeSurfaceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/Issue2056UnknownDeliveryOutcomeSurfaceTest.kt
@@ -1,0 +1,187 @@
+package com.pocketshell.app.composer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2056 — the "genuinely unknown delivery outcome" state.
+ *
+ * A row whose last attempt could not be proven is neither "sending next" nor a
+ * plain failure. It must (a) say so, (b) never be re-picked by the auto-flush
+ * drain (it can only reproduce the same unknown answer while starving the tail),
+ * (c) survive a process recreate, and (d) collapse through ONE identity so a
+ * manual Retry racing a late success can never double-send.
+ */
+class Issue2056UnknownDeliveryOutcomeSurfaceTest {
+
+    private val session = "tmux:1/\$7/1700"
+
+    private fun unknownRow(id: String = "row-1", createdAtMs: Long = 1L) = OutboundItem(
+        id = id,
+        sessionKey = session,
+        cleanText = "csp",
+        createdAtMs = createdAtMs,
+        state = OutboundState.Queued,
+        paneId = "%0",
+        sendKey = "sk-$id",
+        wireAttempted = true,
+        wireSubmitAttempted = true,
+        wireAttemptGeneration = 1,
+        wireOutcomeUnknown = true,
+    )
+
+    @Test
+    fun unknownDeliveryOutcomeIsStatedAsUnknownNotAsQueuedSendingNext() {
+        val unknown = unknownRow()
+
+        val summary = outboundQueueSummary(listOf(unknown), connectionDegraded = false)
+        assertEquals(
+            "the launcher summary must state the unknown delivery outcome (#2056)",
+            OUTBOUND_DELIVERY_UNCONFIRMED_SUMMARY,
+            summary.primary,
+        )
+        assertTrue("an unconfirmed delivery needs the user's attention", summary.attention)
+        assertEquals(
+            "the row label must state the unknown delivery outcome (#2056)",
+            OUTBOUND_DELIVERY_UNCONFIRMED_MESSAGE,
+            outboundQueueStateLabel(unknown),
+        )
+
+        // A degraded link must not relabel it "will send on reconnect" either: the
+        // payload has already been pushed, so that wording is equally wrong.
+        assertEquals(
+            OUTBOUND_DELIVERY_UNCONFIRMED_SUMMARY,
+            outboundQueueSummary(listOf(unknown), connectionDegraded = true).primary,
+        )
+
+        val ordinary = unknown.copy(
+            wireOutcomeUnknown = false,
+            wireSubmitAttempted = false,
+            wireAttempted = false,
+        )
+        assertEquals(
+            "an ordinary queued row keeps its existing wording",
+            "Queued — sending next",
+            outboundQueueSummary(listOf(ordinary), connectionDegraded = false).primary,
+        )
+        assertEquals(
+            PromptComposerViewModel.WILL_SEND_WHEN_RECONNECTED_MESSAGE,
+            outboundQueueStateLabel(ordinary),
+        )
+    }
+
+    @Test
+    fun aMixedBacklogSurfacesTheUnconfirmedCount() {
+        val rows = listOf(
+            unknownRow(),
+            unknownRow(id = "row-1b", createdAtMs = 2L).copy(wireOutcomeUnknown = false),
+        )
+        val summary = outboundQueueSummary(rows, connectionDegraded = false)
+        assertTrue(summary.attention)
+        assertEquals("1 unconfirmed", summary.attentionSuffix)
+    }
+
+    /** The auto-flush selection must skip the unconfirmed head and reach the tail. */
+    @Test
+    fun autoFlushSkipsAnUnconfirmedHeadAndSelectsTheTail() {
+        val head = unknownRow()
+        val tail = OutboundItem(
+            id = "row-2",
+            sessionKey = session,
+            cleanText = "follow-up",
+            createdAtMs = 2L,
+            state = OutboundState.Queued,
+            paneId = "%0",
+            sendKey = "sk-row-2",
+        )
+        val plan = listOf(head, tail).planComposerAutoFlush(session)
+        assertEquals("the deliverable tail must be selected", tail.id, plan.nextId)
+        assertTrue(
+            "an unconfirmed head is not a budget-exhausted park — it is surfaced as unknown",
+            plan.parkIds.isEmpty(),
+        )
+        assertTrue(head.isComposerQueueDeliveryUnconfirmed())
+        assertFalse(tail.isComposerQueueDeliveryUnconfirmed())
+        assertNotNull(
+            "the unconfirmed row is never dropped from the visible queue",
+            listOf(head, tail).outboundLauncherBadge(session),
+        )
+    }
+
+    /**
+     * A genuinely InFlight head still blocks the tail — the #2056 skip must be
+     * narrow (G6 negative), otherwise a live delivery could be overtaken.
+     */
+    @Test
+    fun aLiveInFlightHeadStillBlocksTheTail() {
+        val head = unknownRow().copy(state = OutboundState.InFlight, wireOutcomeUnknown = false)
+        val tail = OutboundItem(
+            id = "row-2",
+            sessionKey = session,
+            cleanText = "follow-up",
+            createdAtMs = 2L,
+            state = OutboundState.Queued,
+        )
+        assertNull(listOf(head, tail).planComposerAutoFlush(session).nextId)
+    }
+
+    @Test
+    fun unknownVerdictSurvivesEncodingAndIsClearedByAFreshAttempt() {
+        val row = unknownRow()
+        val restored = decodeOutboundItems(session, encodeOutboundItems(listOf(row)))
+        assertEquals(
+            "the unknown verdict must survive a process recreate",
+            listOf(row),
+            restored,
+        )
+
+        val queue = InMemoryOutboundQueueStore()
+        queue.enqueueExisting(row)
+        val reArmed = requireNotNull(queue.requeueForRetry(row.id, resetAttempts = true))
+        assertFalse(
+            "an explicit user resend clears the unknown verdict so the row is re-driven",
+            reArmed.wireOutcomeUnknown,
+        )
+        requireNotNull(queue.markDeliveryOutcomeUnknown(row.id))
+        assertFalse(
+            "claiming a fresh attempt clears the stale verdict so it decides for itself",
+            requireNotNull(queue.claim(row.id)).wireOutcomeUnknown,
+        )
+    }
+
+    /**
+     * Exactly-once across the manual-Retry / late-success race: the terminal ack is a
+     * compare-and-prune on the row's own identity, so a Retry that already owns the
+     * row cannot be pruned out from under it, and a repeated ack is a no-op.
+     */
+    @Test
+    fun manualRetryRacingALateSuccessCollapsesThroughOneIdentity() {
+        val queue = InMemoryOutboundQueueStore()
+        val row = queue.enqueue(sessionKey = session, cleanText = "csp", createdAtMs = 1, sendKey = "sk-head")
+        requireNotNull(queue.markWireAttempted(session, row.id))
+        val ambiguous = requireNotNull(queue.markWireSubmitAttempted(session, row.id, null))
+        requireNotNull(queue.markDeliveryOutcomeUnknown(row.id))
+
+        val claimed = requireNotNull(queue.claim(row.id))
+        assertEquals(OutboundState.InFlight, claimed.state)
+        assertFalse(
+            "a late success must NOT prune a row a manual Retry already owns",
+            queue.acknowledgeLateDelivered(row.id, ambiguous.sendKey, ambiguous.wireAttemptGeneration),
+        )
+        assertNotNull(queue.item(row.id))
+
+        requireNotNull(queue.requeueForRetry(row.id))
+        assertTrue(
+            queue.acknowledgeLateDelivered(row.id, ambiguous.sendKey, ambiguous.wireAttemptGeneration),
+        )
+        assertFalse(
+            "a repeated late ack for the same identity is a no-op",
+            queue.acknowledgeLateDelivered(row.id, ambiguous.sendKey, ambiguous.wireAttemptGeneration),
+        )
+        assertNull(queue.item(row.id))
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/Issue2056UnresolvableHeadDoesNotHoldTailTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/Issue2056UnresolvableHeadDoesNotHoldTailTest.kt
@@ -1,0 +1,214 @@
+package com.pocketshell.app.composer
+
+import androidx.lifecycle.SavedStateHandle
+import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
+import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.core.voice.WhisperClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #2056 — head-of-line poisoning by an UNRESOLVABLE row.
+ *
+ * A send whose delivery outcome cannot be proven resolves as
+ * [ComposerSendResult.AuthoritativeAckPending]. On base that deferral re-granted
+ * the row's whole bounded auto-retry budget (`resetAttemptBudget = true`), so the
+ * row's `attemptCount` was zeroed on EVERY cycle, it could never reach
+ * [OUTBOUND_MAX_AUTO_ATTEMPTS], [firstComposerAutoFlushable] re-selected it as the
+ * FIFO head forever, and no younger row was ever dispatched — the maintainer's
+ * "once the first message gets clogged, every following message gets clogged too,
+ * even though those following messages are in fact being delivered".
+ *
+ * Every assertion here compiles and runs against unmodified `origin/main`, so the
+ * reproduction is a genuine base-RED, not a compile error.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue2056UnresolvableHeadDoesNotHoldTailTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val createdViewModels = mutableListOf<PromptComposerViewModel>()
+
+    @After
+    fun tearDownViewModels() {
+        createdViewModels.forEach { it.clearForTest() }
+        createdViewModels.clear()
+    }
+
+    private class FakeVault : ApiKeyVault {
+        private var key: CharArray? = "sk-test".toCharArray()
+        override fun save(key: CharArray) { this.key = key.copyOf() }
+        override fun load(): CharArray? = this.key?.copyOf()
+        override fun clear() { this.key = null }
+    }
+
+    private class MinimalMicCapture : PromptComposerViewModel.MicCapture {
+        override fun start() = Unit
+        override fun stop(): ByteArray = ByteArray(0)
+        override fun currentAmplitude(): Float = 0f
+    }
+
+    private class MinimalVoiceSettings : PromptComposerViewModel.VoiceSettingsSnapshot {
+        override fun silenceWindowMs(): Long = PromptComposerViewModel.SILENCE_WINDOW_MS
+        override fun whisperLanguageHint(): String? = null
+        override fun transcriptionProvider(): com.pocketshell.app.settings.VoiceTranscriptionProvider =
+            com.pocketshell.app.settings.VoiceTranscriptionProvider.OpenAiWhisper
+    }
+
+    private fun newVm(store: OutboundQueueStore): PromptComposerViewModel {
+        val dispatcher = StandardTestDispatcher(mainDispatcherRule.dispatcher.scheduler)
+        val vm = PromptComposerViewModel(
+            audioRecorder = MinimalMicCapture(),
+            whisperClientFactory = WhisperClientFactory {
+                object : WhisperClient {
+                    override suspend fun transcribe(audio: ByteArray, language: String?): Result<String> =
+                        Result.success("hello")
+                }
+            },
+            apiKeyStorage = FakeVault(),
+            voiceSettings = MinimalVoiceSettings(),
+            outboundQueueStore = store,
+            savedStateHandle = SavedStateHandle(),
+        )
+        vm.samplerDispatcher = dispatcher
+        vm.outboundQueueDispatcher = dispatcher
+        vm.setSendWatchdogTimeoutForTest(null)
+        // The wire is demonstrably writable in this scenario — the payload reached
+        // the pane. Only the delivery PROOF is missing.
+        vm.setTransportWritableProbe { true }
+        createdViewModels += vm
+        return vm
+    }
+
+    /**
+     * THE reported head-of-line symptom, driven through the real
+     * [collectPromptComposerSendRequests] consumer so the production
+     * result -> deferral mapping is the code under test.
+     */
+    @Test
+    fun unresolvableHeadDoesNotStarveTheDeliverableTail() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(queue)
+        val session = "tmux:1/\$7/1700"
+        vm.onComposerTargetChanged(session)
+
+        val head = queue.enqueue(sessionKey = session, cleanText = "csp", createdAtMs = 1, sendKey = "sk-head")
+        val tail = queue.enqueue(
+            sessionKey = session,
+            cleanText = "follow-up prompt",
+            createdAtMs = 2,
+            sendKey = "sk-tail",
+        )
+        vm.refreshOutboundQueueItemsFor(session)
+
+        val dispatched = mutableListOf<String>()
+        backgroundScope.launch {
+            collectPromptComposerSendRequests(
+                viewModel = vm,
+                onSend = { request ->
+                    dispatched += request.outboundQueueItemId.orEmpty()
+                    if (request.outboundQueueItemId == head.id) {
+                        // The payload physically reached the pane, but the delivery
+                        // proof expired: the exact ambiguous outcome of #2056.
+                        ComposerSendResult.AuthoritativeAckPending
+                    } else {
+                        ComposerSendResult.Delivered
+                    }
+                },
+            )
+        }
+        runCurrent()
+
+        repeat(30) {
+            if (queue.item(tail.id) == null) return@repeat
+            vm.retryNextOutboundItem()
+            advanceUntilIdle()
+        }
+
+        assertTrue(
+            "the tail was never even dispatched — an unresolvable head starved the " +
+                "whole queue (#2056)",
+            dispatched.contains(tail.id),
+        )
+        assertNull(
+            "a deliverable tail row must drain and terminally ack on its OWN evidence " +
+                "even while the head stays unresolvable (#2056)",
+            queue.item(tail.id),
+        )
+        assertTrue(
+            "an unresolvable row must not be re-dispatched forever by the auto-flush " +
+                "drain — every such dispatch can only reproduce the same unknown outcome " +
+                "(#2056). Observed head dispatches: ${dispatched.count { it == head.id }}",
+            dispatched.count { it == head.id } <= 2,
+        )
+        assertEquals(
+            "the unresolvable head is preserved, never silently dropped",
+            "csp",
+            requireNotNull(queue.item(head.id)).cleanText,
+        )
+    }
+
+    /**
+     * Class coverage (G2): three deliverable rows behind ONE unresolvable head must
+     * all drain, in FIFO order. A single-tail proof would pass even if the fix only
+     * unblocked one row per poisoned head.
+     */
+    @Test
+    fun everyDeliverableRowBehindAnUnresolvableHeadDrainsInFifoOrder() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val vm = newVm(queue)
+        val session = "tmux:1/\$7/1700"
+        vm.onComposerTargetChanged(session)
+
+        val head = queue.enqueue(sessionKey = session, cleanText = "csp", createdAtMs = 1, sendKey = "sk-head")
+        listOf("first" to 2L, "second" to 3L, "third" to 4L).forEach { (text, at) ->
+            queue.enqueue(sessionKey = session, cleanText = text, createdAtMs = at, sendKey = "sk-$text")
+        }
+        vm.refreshOutboundQueueItemsFor(session)
+
+        val delivered = mutableListOf<String>()
+        backgroundScope.launch {
+            collectPromptComposerSendRequests(
+                viewModel = vm,
+                onSend = { request ->
+                    if (request.outboundQueueItemId == head.id) {
+                        ComposerSendResult.AuthoritativeAckPending
+                    } else {
+                        delivered += request.cleanDraft
+                        ComposerSendResult.Delivered
+                    }
+                },
+            )
+        }
+        runCurrent()
+
+        repeat(60) {
+            if (delivered.size == 3) return@repeat
+            vm.retryNextOutboundItem()
+            advanceUntilIdle()
+        }
+
+        assertEquals(
+            "every deliverable row behind the unresolvable head must drain, in FIFO order",
+            listOf("first", "second", "third"),
+            delivered,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreWireAttemptTest.kt
@@ -397,9 +397,12 @@ class OutboundQueueStoreWireAttemptTest {
             wireSubmitAttempted = true,
         )
         val untouched = submitted.copy(id = "legacy-fresh", wireSubmitAttempted = false)
+        // A row persisted BEFORE `wireAttemptGeneration` existed carries no field at
+        // index 24 or beyond (issue #2056 appended `wireOutcomeUnknown` at 25), so the
+        // legacy fixture truncates the record at that boundary.
         val legacyRaw = encodeOutboundItems(listOf(submitted, untouched))
             .lineSequence()
-            .joinToString("\n") { it.substringBeforeLast('\t') }
+            .joinToString("\n") { it.split('\t').take(24).joinToString("\t") }
         val decoded = decodeOutboundItems("legacy", legacyRaw)
 
         assertEquals(1, decoded.first { it.id == submitted.id }.wireAttemptGeneration)

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2056RouteCompleteSubmitAckTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2056RouteCompleteSubmitAckTest.kt
@@ -1,0 +1,467 @@
+package com.pocketshell.app.tmux
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.OutboundRoute
+import com.pocketshell.app.composer.OutboundState
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #2056 — "the composer queue is not cleared after the payload was
+ * delivered": the terminal acknowledgement of a durable outbound row is
+ * TRANSCRIPT-ONLY, so a row whose submit was physically consumed by the agent
+ * but which has no live transcript authority can never reach a terminal state.
+ *
+ * Two production facts combine into the maintainer's report:
+ *
+ *  1. [AgentTranscriptAuthority.baseline] returns `null` whenever the pane has
+ *     no LIVE transcript source (an agent that has just been relaunched, a
+ *     node-wrapped Claude the detector cannot bind, a `TmuxEnterAccepted`
+ *     TUI command). The durable submit write-ahead is then persisted with a
+ *     NULL transcript baseline, and #2037's transcript-only late-ack bridge
+ *     (now [resolveLateAuthoritativeSubmitAck]'s first arm) bails on that null.
+ *  2. The generic screen-turnover oracle that is supposed to cover that case
+ *     ([agentInputSurfaceState]) cannot SEE Claude Code's input prompt, because
+ *     Claude renders it inside a box (`│ > `) and the matcher only accepted a
+ *     line whose FIRST non-blank character is `>` / `›`. So the oracle reports
+ *     [AgentInputSurfaceState.Unknown] on every Claude frame, the 800 ms
+ *     turnover wait always times out, and every send lands in the ambiguous
+ *     `wireSubmitAttempted` state.
+ *
+ * Result: the payload ran (the maintainer's screenshot shows Claude launched
+ * from `csp`), the row stays `Queued` with an enabled Retry, and no authority
+ * that exists can ever resolve it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue2056RouteCompleteSubmitAckTest : TmuxSessionViewModelTestBase() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun claudeFrame(input: String): CommandResponse = CommandResponse(
+        number = 0L,
+        output = listOf(
+            "╭──────────────────────────────────────────────╮",
+            "│ > $input",
+            "╰──────────────────────────────────────────────╯",
+            "  ? for shortcuts",
+        ),
+        isError = false,
+    )
+
+    /**
+     * The WORKING shape of the same agent: the box is drawn but the input marker is
+     * replaced by the activity indicator, so no line carries a prompt glyph. Mirrors
+     * the `issue1944-framed-input` fake-agent surface used by the connected journeys.
+     * `capture-pane -p` strips trailing blanks, hence the bare frame row when the
+     * buffer is empty.
+     */
+    private fun framedWorkingFrame(input: String): CommandResponse = CommandResponse(
+        number = 0L,
+        output = listOf(
+            "FAKE-AGENT-READY",
+            "✻ Working… (esc to interrupt)",
+            if (input.isEmpty()) "┃" else "┃ $input",
+        ),
+        isError = false,
+    )
+
+    /**
+     * The oracle that is supposed to prove "the agent consumed my submit"
+     * cannot read Claude Code's boxed input prompt at all.
+     */
+    @Test
+    fun claudeBoxedInputPromptIsReadableBySubmitOracle() {
+        val payload = "run the migration now"
+
+        assertEquals(
+            "a Claude frame whose boxed input still holds the payload must read as " +
+                "PendingPayload (the submit was NOT consumed)",
+            AgentInputSurfaceState.PendingPayload,
+            agentInputSurfaceState(claudeFrame(payload), payload),
+        )
+        assertEquals(
+            "a Claude frame whose boxed input is empty must read as Ready — the agent " +
+                "consumed the submit. On base the box glyph hides the prompt and this is " +
+                "Unknown, so the turnover proof can NEVER succeed for Claude Code (#2056)",
+            AgentInputSurfaceState.Ready,
+            agentInputSurfaceState(claudeFrame(""), payload),
+        )
+    }
+
+    /** The same blindness on the shell prompt glyph the maintainer's box uses. */
+    @Test
+    fun shellPromptGlyphIsReadableBySubmitOracle() {
+        val payload = "csp"
+        val pending = CommandResponse(
+            number = 0L,
+            output = listOf("~/git/pocketshell (main)", "❯ csp"),
+            isError = false,
+        )
+        val consumed = CommandResponse(
+            number = 0L,
+            output = listOf("~/git/pocketshell (main)", "❯ "),
+            isError = false,
+        )
+        assertEquals(AgentInputSurfaceState.PendingPayload, agentInputSurfaceState(pending, payload))
+        assertEquals(
+            "an empty shell prompt after the command ran must read as Ready (#2056)",
+            AgentInputSurfaceState.Ready,
+            agentInputSurfaceState(consumed, payload),
+        )
+    }
+
+    /**
+     * The reported journey, end to end on the real delivery path: an agent-route
+     * prompt whose pane has NO live transcript authority. The paste is ack-proven,
+     * Enter is written and accepted by tmux, the bounded turnover wait expires
+     * (ambiguous), and the row is left `Queued` + `wireSubmitAttempted`.
+     *
+     * The agent then visibly consumes the submit (its input surface empties).
+     * That is authoritative evidence of delivery — and the ONLY authority the
+     * product has for this pane, because no transcript exists. On base the late
+     * ack is transcript-only, so it returns false forever and the row keeps its
+     * Retry with the payload already delivered.
+     */
+    @Test
+    fun agentRowWithoutTranscriptAuthorityIsAcknowledgedFromPaneEvidence() = runTest(scheduler) {
+        val payload = "run the migration now"
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue(
+            sessionKey = "sessA",
+            cleanText = payload,
+            paneId = "%0",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "claude",
+            sendKey = "sk-2056",
+            tmuxSessionId = "\$7",
+            tmuxSessionCreated = 1700L,
+        )
+        val durableRow = DurableOutboundRowIdentity("sessA", row.id)
+
+        val client = FakeTmuxClient()
+        // The pane keeps showing the payload in Claude's boxed input for the whole
+        // bounded turnover window: the agent has not turned over yet.
+        client.defaultCaptureResponse = claudeFrame(payload)
+        val vm = newVm(applicationContext = context, outboundQueueStore = store)
+        vm.attachClientForTest(client)
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(50)
+
+        val sent = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
+        advanceUntilIdle()
+        val outcome = sent.await()
+        assertTrue(
+            "the bounded turnover proof must expire, leaving the row ambiguous",
+            outcome.exceptionOrNull() is AgentSubmitTurnoverNotProvenException,
+        )
+        assertTrue("Enter reached tmux", client.sentCommands.contains("send-keys -t %0 Enter"))
+        val ambiguous = requireNotNull(store.item(row.id))
+        assertTrue("the row is durably marked submit-attempted", ambiguous.wireSubmitAttempted)
+        assertNull(
+            "precondition: no transcript authority exists for this pane, so #2037's " +
+                "transcript-only bridge has nothing to work with",
+            ambiguous.wireSubmitTranscriptBaseline,
+        )
+        assertEquals(OutboundState.Queued, ambiguous.state)
+
+        // The agent HAS consumed the submit: its input surface is empty again.
+        client.defaultCaptureResponse = claudeFrame("")
+
+        assertTrue(
+            "a delivered row whose agent visibly consumed the submit must reach a " +
+                "terminal acknowledgement even with no transcript authority (#2056)",
+            vm.resolveLateAuthoritativeOutboundAck(ambiguous),
+        )
+        assertTrue(
+            "the terminal ack prunes the durable row so the composer queue clears",
+            store.acknowledgeLateDelivered(
+                ambiguous.id,
+                ambiguous.sendKey,
+                ambiguous.wireAttemptGeneration,
+            ),
+        )
+        assertNull("the acknowledged row is gone from the durable queue", store.item(row.id))
+        assertTrue(
+            "a freshly rebuilt store (reconnect / composer reopen / process recreate) " +
+                "must not resurrect the acknowledged row",
+            SharedPrefsOutboundQueueStore(context).itemsFor("sessA").isEmpty(),
+        )
+    }
+
+    /**
+     * Fail-closed negative (G6): the SAME ambiguous row, but the agent is still
+     * holding the payload in its input. No authority exists, so no acknowledgement
+     * may be produced — a false ack here would silently lose the prompt.
+     */
+    @Test
+    fun paneStillHoldingThePayloadIsNeverAcknowledged() = runTest(scheduler) {
+        val payload = "deploy the staging build now"
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue(
+            sessionKey = "sessB",
+            cleanText = payload,
+            paneId = "%0",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "claude",
+            sendKey = "sk-2056b",
+            tmuxSessionId = "\$8",
+            tmuxSessionCreated = 1800L,
+        )
+        val durableRow = DurableOutboundRowIdentity("sessB", row.id)
+        val client = FakeTmuxClient()
+        client.defaultCaptureResponse = claudeFrame(payload)
+        val vm = newVm(applicationContext = context, outboundQueueStore = store)
+        vm.attachClientForTest(client)
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(50)
+
+        val sent = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
+        advanceUntilIdle()
+        assertTrue(sent.await().isFailure)
+        val ambiguous = requireNotNull(store.item(row.id))
+
+        assertFalse(
+            "the payload is STILL in the agent's input — nothing was consumed, so no " +
+                "acknowledgement may be produced",
+            vm.resolveLateAuthoritativeOutboundAck(ambiguous),
+        )
+        assertNotNull("the row must survive as a real, retryable prompt", store.item(row.id))
+    }
+
+    /**
+     * Second fail-closed arm, and the UNIT-GATE guard for the connected journeys'
+     * induced-ambiguity fixture (#2056 round 2).
+     *
+     * A working Claude/Codex draws its box WITHOUT a marker glyph — there is no `>` to
+     * anchor on either before or after Enter. The product then genuinely cannot decide
+     * whether the submit was consumed, so the pane arm must stay silent and only an
+     * authoritative transcript turn may resolve the row.
+     *
+     * `OutboundExactlyOnceAcrossFlapE2eTest`'s three late-authority journeys depend on
+     * exactly this: they seed the framed fake-agent surface
+     * (`tests/docker/agent-bin/pocketshell-fake-agent`, `issue1944-framed-input`) so the
+     * ambiguity they assert on is reachable at all. If a future change made that surface
+     * decidable, those journeys would stop exercising the late arm and merely time out
+     * on an empty store — protection lost, not merely red. This asserts the property in
+     * the fast per-push Unit gate, next to the code that owns it.
+     */
+    @Test
+    fun workingAgentBoxWithNoMarkerGlyphFailsClosedOnBothFrames() = runTest(scheduler) {
+        val payload = "restart the worker pool"
+        assertEquals(
+            "a framed working surface still echoing the payload is undecidable",
+            AgentInputSurfaceState.Unknown,
+            agentInputSurfaceState(framedWorkingFrame(payload), payload),
+        )
+        assertEquals(
+            "an EMPTY framed working surface is undecidable too — the box edge is not a " +
+                "prompt marker, so 'the payload is gone' cannot be read as 'consumed'",
+            AgentInputSurfaceState.Unknown,
+            agentInputSurfaceState(framedWorkingFrame(""), payload),
+        )
+
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue(
+            sessionKey = "sessFramed",
+            cleanText = payload,
+            paneId = "%0",
+            route = OutboundRoute.AgentPayload,
+            agentKind = "claude",
+            sendKey = "sk-2056framed",
+            tmuxSessionId = "\$9",
+            tmuxSessionCreated = 1900L,
+        )
+        val durableRow = DurableOutboundRowIdentity("sessFramed", row.id)
+        val client = FakeTmuxClient()
+        client.defaultCaptureResponse = framedWorkingFrame(payload)
+        val vm = newVm(applicationContext = context, outboundQueueStore = store)
+        vm.attachClientForTest(client)
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(50)
+
+        val sent = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                payload,
+                AgentKind.ClaudeCode,
+                sendToken = row.id,
+                durableRow = durableRow,
+            )
+        }
+        advanceUntilIdle()
+        assertTrue("the bounded turnover proof must expire", sent.await().isFailure)
+        val ambiguous = requireNotNull(store.item(row.id))
+        assertTrue(ambiguous.wireSubmitAttempted)
+
+        // The agent consumed the submit, but its working box still says nothing the
+        // oracle can read. Fail closed: only a transcript turn may resolve this row.
+        client.defaultCaptureResponse = framedWorkingFrame("")
+        assertFalse(
+            "an undecidable pane must never acknowledge — the late TRANSCRIPT authority " +
+                "is the only resolver for a working agent (#2056)",
+            vm.resolveLateAuthoritativeOutboundAck(ambiguous),
+        )
+        assertNotNull("the row must survive for the late authority", store.item(row.id))
+    }
+
+    /**
+     * The evidence for a no-transcript pane arrives a second or two AFTER the bounded
+     * turnover wait gave up, and nothing in the app changes in between — so a
+     * one-shot evaluation per snapshot never sees it. The reconciler must re-ask the
+     * authority on a bounded foreground cadence, and must terminate when it never
+     * speaks (no unbounded loop — the #1517 class).
+     */
+    @Test
+    fun lateAuthorityIsPolledUntilItSpeaksAndTerminatesWhenItNeverDoes() = runTest(scheduler) {
+        val binding = TmuxOutboundQueueBinding(
+            targetKey = "sessA",
+            fallbackKey = "1/demo",
+            durableKey = "sessA",
+            tmuxSessionId = "\$7",
+            sessionCreated = 1700L,
+            generationPaneIds = setOf("%0"),
+        )
+        val row = com.pocketshell.app.composer.OutboundItem(
+            id = "row-late",
+            sessionKey = "sessA",
+            cleanText = "run the migration now",
+            createdAtMs = 1L,
+            paneId = "%0",
+            sendKey = "sk-late",
+            wireSubmitAttempted = true,
+            wireAttemptGeneration = 1,
+            tmuxSessionId = "\$7",
+            tmuxSessionCreated = 1700L,
+        )
+
+        var asked = 0
+        val acknowledged = mutableListOf<String>()
+        val resolvedLate = reconcileLateOutboundAcks(
+            rows = listOf(row),
+            binding = binding,
+            resolveAuthoritativeAck = { asked += 1; asked >= 3 },
+            acknowledge = { batch -> acknowledged += batch.map { it.id } },
+        )
+        assertEquals(listOf("row-late"), resolvedLate.map { it.id })
+        assertEquals(listOf("row-late"), acknowledged)
+        assertTrue("the authority must be re-asked, not evaluated once", asked >= 3)
+
+        var silentAsks = 0
+        val never = reconcileLateOutboundAcks(
+            rows = listOf(row),
+            binding = binding,
+            resolveAuthoritativeAck = { silentAsks += 1; false },
+        )
+        assertTrue("a silent authority resolves nothing", never.isEmpty())
+        assertEquals(
+            "the poll is bounded — it must terminate instead of spinning (#1517 class)",
+            OUTBOUND_LATE_ACK_MAX_POLLS,
+            silentAsks,
+        )
+    }
+
+    /**
+     * Class coverage (G2) for the RAW-BYTES shell lane, which can never produce an
+     * agent transcript turn: a shell row whose delivery IS confirmable on the pane
+     * must reach a terminal acknowledged state without any transcript, and without
+     * re-running the command.
+     */
+    @Test
+    fun rawBytesShellRowReachesTerminalAckOnConfirmedDeliveryWithNoTranscript() = runTest(scheduler) {
+        val payload = "tail -n 40 /var/log/syslog"
+        val store = SharedPrefsOutboundQueueStore(context)
+        val row = store.enqueue(
+            sessionKey = "sessC",
+            cleanText = payload,
+            paneId = "%0",
+            route = OutboundRoute.RawBytes,
+            sendKey = "sk-2056c",
+        )
+        val durableRow = DurableOutboundRowIdentity("sessC", row.id)
+        val ledger = outboundDeliveryLedgerFor(store)
+        val client = FakeTmuxClient()
+        client.defaultCaptureResponse = CommandResponse(0L, listOf("❯ "), isError = false)
+
+        var writes = 0
+        var enters = 0
+        val bytes = "$payload\r".toByteArray(Charsets.UTF_8)
+
+        // Attempt 1: the bytes LAND server-side, the exec result is lost.
+        val first = deliverRawInputWithGuard(
+            ledger = ledger,
+            client = client,
+            paneId = "%0",
+            bytes = bytes,
+            localRenderText = "",
+            sendToken = row.id,
+            durableRow = durableRow,
+            send = { _, _, _ ->
+                writes += 1
+                client.defaultCaptureResponse =
+                    CommandResponse(0L, listOf("❯ $payload", "Jan  1 syslog line", "❯ "), false)
+                throw IllegalStateException("exec result lost after the bytes landed")
+            },
+            submitEnter = { _, _ -> enters += 1 },
+            afterDelivered = { _, _, _ -> },
+        )
+        assertTrue("attempt 1 surfaces the ambiguous outcome", first.isFailure)
+        assertEquals(1, writes)
+
+        // The auto-flush retry must verify (not blindly re-run the shell command) and
+        // terminally acknowledge the delivery.
+        val second = deliverRawInputWithGuard(
+            ledger = ledger,
+            client = client,
+            paneId = "%0",
+            bytes = bytes,
+            localRenderText = "",
+            sendToken = row.id,
+            durableRow = durableRow,
+            send = { _, _, _ -> writes += 1 },
+            submitEnter = { _, _ -> enters += 1 },
+            afterDelivered = { _, _, _ -> },
+        )
+        assertTrue(
+            "a RawBytes shell row whose delivery is confirmable on the pane must reach a " +
+                "terminal acknowledged state with no transcript turn (#2056 arm 1)",
+            second.isSuccess,
+        )
+        assertEquals("the shell command must not run twice", 1, writes)
+        assertTrue("the terminal ack completes the submit", enters >= 1)
+        assertTrue(store.markDelivered(row.id))
+        assertNull(store.item(row.id))
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundLateAckReconcilerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundLateAckReconcilerTest.kt
@@ -2,11 +2,14 @@ package com.pocketshell.app.tmux
 
 import com.pocketshell.app.composer.OutboundItem
 import com.pocketshell.app.composer.OutboundState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class OutboundLateAckReconcilerTest {
     private val binding = TmuxOutboundQueueBinding(
         targetKey = "1/\$42/1700",
@@ -32,7 +35,7 @@ class OutboundLateAckReconcilerTest {
     )
 
     @Test
-    fun exactGenerationAndAttemptAreResolvedOnce() {
+    fun exactGenerationAndAttemptAreResolvedOnce() = runTest {
         var calls = 0
         val resolved = resolveLateOutboundAcks(
             rows = listOf(row()),
@@ -44,7 +47,7 @@ class OutboundLateAckReconcilerTest {
     }
 
     @Test
-    fun staleOrForeignEvidenceNeverReachesTranscriptAuthority() {
+    fun staleOrForeignEvidenceNeverReachesTranscriptAuthority() = runTest {
         val rejected = listOf(
             row().copy(sessionKey = "1/other"),
             row().copy(paneId = "%8"),
@@ -66,7 +69,7 @@ class OutboundLateAckReconcilerTest {
     }
 
     @Test
-    fun missingAuthorityIsNotReturnedForDurablePrune() {
+    fun missingAuthorityIsNotReturnedForDurablePrune() = runTest {
         val resolved = resolveLateOutboundAcks(
             listOf(row()), binding,
             resolveAuthoritativeAck = { false },
@@ -75,7 +78,7 @@ class OutboundLateAckReconcilerTest {
     }
 
     @Test
-    fun activeWireAttemptNeverReachesLateAuthorityUntilItIsRequeued() {
+    fun activeWireAttemptNeverReachesLateAuthorityUntilItIsRequeued() = runTest {
         val active = listOf(
             row().copy(id = "uploading", state = OutboundState.Uploading),
             row().copy(id = "in-flight", state = OutboundState.InFlight),
@@ -93,7 +96,7 @@ class OutboundLateAckReconcilerTest {
     }
 
     @Test
-    fun mixedBacklogReturnsEveryConfirmedExactRowInFifoOrderAsOneBatch() {
+    fun mixedBacklogReturnsEveryConfirmedExactRowInFifoOrderAsOneBatch() = runTest {
         val rows = listOf(
             row().copy(id = "row-1", createdAtMs = 1L),
             row().copy(id = "foreign", paneId = "%8", createdAtMs = 2L),

--- a/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/OutboundSlashCommandFalseSuccessTest.kt
@@ -236,8 +236,12 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
         assertTrue("attempt 1 must surface the ambiguous failure", first.await().isFailure)
         assertEquals("attempt 1 pastes exactly once", 1, client.literalPasteCount(payload))
 
-        // The resend (reconnect auto-flush / manual retry) probes: count (1) exceeds
-        // the baseline (0) ⇒ AlreadyLanded ⇒ Enter-only, NO second paste.
+        // The resend (reconnect auto-flush / manual retry). Issue #2056 makes the
+        // terminal acknowledgement route-complete: the pane's input surface is now
+        // readable, it no longer holds the payload, so the ambiguous prior Enter is
+        // AUTHORITATIVELY resolved instead of wedging the row forever. The
+        // load-bearing exactly-once invariants below are unchanged and still assert
+        // that NOTHING new reached the wire — no second paste, no second Enter.
         val second = async {
             vm.sendAgentPayloadToPaneResult(
                 "%0",
@@ -249,8 +253,9 @@ class OutboundSlashCommandFalseSuccessTest : TmuxSessionViewModelTestBase() {
         }
         advanceUntilIdle()
         assertTrue(
-            "an unconfirmed prior Enter must stay unresolved without a blind second submit",
-            second.await().isFailure,
+            "an unconfirmed prior Enter must resolve from authority, never from a blind " +
+                "second submit (#2056)",
+            second.await().isSuccess,
         )
         assertEquals(
             "a genuine resend of a payload that already LANDED must be deduped to " +

--- a/tests/docker/agent-bin/pocketshell-fake-agent
+++ b/tests/docker/agent-bin/pocketshell-fake-agent
@@ -118,9 +118,31 @@ render_default() {
 # while deliberately remaining Unknown to the generic submit-turnover oracle.
 # The #1944 outage journey must therefore wait for the authoritative transcript
 # event appended on Enter, including when its tail starts after reconnect.
+#
+# Issue #2056 — WHY THIS MODE IS NOW LOAD-BEARING FOR THE LATE-AUTHORITY JOURNEYS.
+# #2056 made the PANE a real late-delivery authority: when a row's submit outcome
+# is ambiguous the product re-reads the pane, and an input surface that no longer
+# holds the payload proves the agent consumed the submit. That is correct, and it
+# is exactly what the readline `render_default` surface now reports — so a submit
+# to the DEFAULT fixture is no longer ambiguous for more than one poll.
+#
+# The framed surface models the state where the product genuinely CANNOT decide,
+# which is the real Claude/Codex shape while the agent is working: the box is
+# drawn but no marker glyph is rendered, so
+# `agentInputSurfaceState` answers Unknown BOTH before and after Enter (the frame
+# row strips to empty once the buffer clears, so there is no prompt line at all).
+# The late-authority chain then fails CLOSED on the pane arm and only an
+# authoritative transcript turn can resolve the row — which is precisely the path
+# the #1944/#2037/#1819 journeys exist to protect. Keep this surface free of any
+# `AGENT_INPUT_PROMPT_GLYPHS` marker (`> › ❯ ➜ ❭ $`); adding one would silently
+# hand those journeys a pane authority and stop them exercising the late arm.
+#
+# The heartbeat line mirrors `render_default` so the #2042 busy-agent hold can
+# prove the agent kept producing output throughout on this surface too.
 render_issue1944_framed() {
   printf '\033[H\033[2J'
   printf '%s\r\n' "$READY_MARKER"
+  [ "$HEARTBEAT" = "1" ] && printf 'FAKE-AGENT HEARTBEAT: %s\r\n' "$heartbeat_counter"
   if [ -n "$last_submitted" ]; then
     printf '%s%s\r\n' "$SUBMIT_PREFIX" "$last_submitted"
   fi


### PR DESCRIPTION
Fixes the maintainer's v0.4.41 real-device report: prompts delivered to the pane while their durable rows stayed Queued/Failed with an enabled Retry, and once the head clogged every following delivered row piled up behind it.

## Root cause (three compounding defects, agent/AgentPayload route)

1. `agentInputSurfaceState` located the prompt with `trimStart()` + a bare `">"`/`"›"` match. Claude Code draws its input inside a box (`│ > `) and the maintainer's shell prompt is `❯` — both invisible to the matcher, so the 800ms turnover proof could never succeed and every send ended ambiguous.
2. The durable submit write-ahead persisted a null transcript baseline when the pane had no live transcript source, so #2037's late-ack bridge died on `?: return false` — delivered payload, permanently unresolvable row.
3. `AuthoritativeAckPending` deferred with `resetAttemptBudget = true`, zeroing `attemptCount` every cycle, so the ambiguous head never parked and `firstComposerAutoFlushable` re-picked it forever — the tail was never dispatched. This is the head-of-line poisoning the maintainer reported.

## Journey contract changes

Three `OutboundExactlyOnceAcrossFlapE2eTest` journeys had a precondition of submits ending ambiguous *by accident*. They now induce that state deliberately (framed fake-agent surface, guarded by a runtime `capture-pane` precondition, a seed-time check, and a per-push unit test) so they still reach the parked state and still assert their invariants.

`busyAgentOnStableWritableWireQueuesFifoWithoutBurningAttemptBudget` expected head-of-line **blocking** — an expectation introduced by `f3ff5576`, the v0.4.41 commit that shipped this bug, and contradicting this issue's AC5. Flipped to the correct non-poisoning contract; `git log -S` provenance in the review.

Also fixes a fixture-isolation leak (a `nohup` transcript relay polled the shared fixture 60s into the next test and pruned its row) and splits the seeding into `OutboundExactlyOnceFixture.kt`, landing the file *smaller* than before the change.

## Verification

Reviewer APPROVED after independently reproducing the symptom red on base and confirming it gone green on the real wire. Nine connected runs, zero disturbed; full class 27/27 across 3 runs, 39/39 including Issue1686; adjacency 25/25 with executed == declared. Mutation-settled mechanism dispute (mutant D). Canonical gate `TOTAL_EXECUTED=12362 FAILED=0 SKIPPED=0`, 1314 XMLs, STALE=0, no cache markers, all 12 load-bearing classes named.

Closes #2056