### PR TITLE
release: v0.4.42 (versionCode 89)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 88
-        versionName = "0.4.41"
+        versionCode = 89
+        versionName = "0.4.42"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.41"
+version = "0.4.42"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for v0.4.42. Version-only commit — no behavioral change.

`versionName` 0.4.41 → **0.4.42**, `versionCode` 88 → **89**, `tools/pocketshell/pyproject.toml` 0.4.41 → **0.4.42** in lockstep (`scripts/check-version-coupling.sh` OK).

## What ships

Both fixes for the maintainer's real-device composer report on v0.4.41:

- **#2056** — composer queue not cleared after delivery. Prompts reached the pane while their durable rows stayed Queued with an enabled Retry, and once the head clogged every following delivered row piled up behind it. Three compounding defects: the submit-turnover oracle could not read Claude Code's boxed `│ > ` prompt or the shell's `❯`; the durable write-ahead persisted a null transcript baseline so #2037's late-ack bridge could never resolve; and `AuthoritativeAckPending` reset the attempt budget so the ambiguous head never parked and the tail was never dispatched.
- **#2057** — staged attachment tiles render below the draft field again (regressed by #1619).

## Quality gate on the base commit

`main` @ `e6a12b78` is green: [run 31292976490](https://github.com/alexeygrigorev/pocketshell/actions/runs/31292976490) — all 7 jobs success, `AGGREGATE_VERDICT=CLEAN` (3/3 shards, no INFRA), 453 emulator tests across 173 classes all passing on attempt 1, Unit 12362 executed with no cache markers on either `:app` variant.

Both watched-for failure signatures were absent from the full run log: zero `rows=[]`/`waitForIssue1739Boundary` (the #2056 symptom did not return) and zero `composer_send did not dispatch` (the pre-existing flake did not fire).

Caveat recorded for the release notes: all three shards ran **one-shot** (`insufficient_remaining_budget`), so the cold-boot retry that normally absorbs a #788-class flake was unaffordable. The CLEAN is real but thinner than usual. Tracked on #1458; the 4th-shard fix is #2060.