### PR TITLE
ci: de-serialize shards, parallelize guards, right-size the runner (#2060)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Issue #2060 (CI Phase A): the ~25 SERIAL guard steps this job used to carry in
+  # front of the Gradle run (~20 min unrelated to the tests) now run CONCURRENTLY
+  # in `guards-static`, `guards-ci-harness` and `dex`, all still blocking through
+  # `unit-gate` below.
   unit:
-    name: Unit tests
+    name: JVM unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -55,6 +59,139 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
+      # Issue #1897: the #1646 result guard correctly rejects FROM-CACHE test
+      # tasks, but it cannot force the preceding Gradle invocation to execute.
+      # Keep the required Unit command aligned with the canonical forced local
+      # gate: rerun every task and disable cache restoration. The cheap
+      # self-test proves this wiring guard fails closed when either flag is
+      # removed, duplicated, contradicted, or moved off the complete test graph.
+      - name: CI Unit forced-execution wiring guard (issue #1897)
+        run: |
+          chmod +x scripts/check-ci-unit-forced-execution.sh
+          scripts/check-ci-unit-forced-execution.sh --self-test
+          scripts/check-ci-unit-forced-execution.sh
+
+      # Issue #1646: the executed-test-count guard's OWN red->green self-test.
+      # Proves — with synthetic result XML + synthetic Gradle console output, no
+      # Gradle, no Android SDK, no emulator — that the guard FAILS a vacuous run
+      # (missing task / UP-TO-DATE / FROM-CACHE / all-skipped / below-floor) and
+      # PASSES a genuine one, and that NO-SOURCE on a genuinely test-free module
+      # does not trip it. Runs BEFORE the Gradle step so a broken guard is caught
+      # in seconds, not 20 minutes in. The self-test asserts its own check count,
+      # so the anti-vacuous-test guard cannot itself pass vacuously.
+      - name: Executed-test-count guard self-test (issue #1646)
+        run: |
+          chmod +x scripts/check-executed-test-counts.sh
+          scripts/check-executed-test-counts.sh --self-test
+
+      # Issue #1646: mark the start of the test run. Any TEST-*.xml older than
+      # this marker is a leftover from an earlier run whose task was skipped as
+      # UP-TO-DATE, not evidence from THIS run.
+      - name: Mark test-run start (issue #1646)
+        run: |
+          touch "${RUNNER_TEMP}/unit-test-run-start"
+
+      # Issue #760: the unit job occasionally failed with ALL visible tests
+      # PASSED — a gradle-daemon/runner OOM abort, not a real assertion failure.
+      # Unbounded gradle worker fan-out plus an oversized test JVM heap can push
+      # the runner into the OOM-killer, which kills the gradle process mid-run
+      # AFTER the tests reported green. Bound BOTH the gradle worker count and
+      # the JVM heaps so the job stays inside the runner's memory budget: the
+      # explicit -Dorg.gradle.jvmargs caps the gradle daemon/launcher heap while
+      # -Pkotlin/test forks inherit the project's modest -Xmx. This is infra
+      # robustness only — no test is removed, skipped, or weakened.
+      #
+      # Issue #2060 (CI Phase A): the #760 note above sized --max-workers=2 for
+      # "7 GB RAM and 2 cores". That box is gone (public-repo runners have been
+      # 4 vCPU / 16 GB since Jan 2024), so the job ran at half of it. This raises
+      # CONCURRENCY, not memory: `org.gradle.parallel` stays false, so at most ONE
+      # Test task (one 1536m fork) is alive at a time and only intra-task Worker
+      # API actions (AGP dexing/resources) widen. `--parallel`/`maxParallelForks`
+      # WOULD multiply live forks and feed the #708/#882 virtual-clock flake
+      # class, so they are deliberately NOT bundled here. One variable at a time —
+      # the AGENTS.md memory trap surfaces as a fake "Backend Internal error:
+      # Exception during IR lowering", not as an OOM.
+      #
+      # Issue #1646: tee the console to a log (--console=plain) so the count
+      # guard below can see which test tasks actually EXECUTED vs came back
+      # UP-TO-DATE / FROM-CACHE / NO-SOURCE. pipefail keeps Gradle's exit code
+      # authoritative through the tee.
+      - name: Run JVM unit tests
+        id: unit_tests
+        timeout-minutes: 35
+        run: |
+          set -o pipefail
+          ./gradlew test --rerun-tasks --no-build-cache \
+            --no-daemon --stacktrace --console=plain \
+            --max-workers=4 \
+            -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" \
+            2>&1 | tee "${RUNNER_TEMP}/unit-test-gradle.log"
+
+      # Issue #1646: a green Gradle run that executed ZERO tests is not evidence.
+      # Gradle prints test counts ONLY on failure, so before this step a green
+      # run had no log line and no artifact proving any test ran. Parse the
+      # result XML, hard-fail any expected test task that executed 0 tests (or
+      # fell below its floor), and ECHO the per-task counts into the job log and
+      # the job summary so a human/agent certifying a PR can read them without
+      # downloading an artifact.
+      #
+      # Runs whenever the test step itself ran — on GREEN (the point of the
+      # issue) and on RED alike, since "killed mid-run but reported exit 0"
+      # (incident 3) is a case where the count is the only thing that exposes the
+      # truth. Scoped to the test step's own conclusion rather than a bare
+      # always() so an earlier guard failing (Gradle never ran, no log written)
+      # does not add a confusing second red about a missing log file.
+      - name: Assert tests actually executed (issue #1646)
+        if: always() && steps.unit_tests.conclusion != 'skipped'
+        run: |
+          chmod +x scripts/check-executed-test-counts.sh
+          scripts/check-executed-test-counts.sh \
+            --newer-than "${RUNNER_TEMP}/unit-test-run-start" \
+            --gradle-log "${RUNNER_TEMP}/unit-test-gradle.log"
+
+      # Issue #1646: upload ALWAYS, not just on failure. A green run's result XML
+      # IS the evidence that the run was real; throwing it away and keeping only
+      # failures is precisely why CI could not prove a green run executed
+      # anything.
+      - name: Upload unit test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-reports
+          path: |
+            **/build/reports/tests/
+            **/build/test-results/
+          # Issue #1809: a re-run of this job replaces its OWN attempt's upload
+          # instead of hitting a duplicate-name failure; the previous attempt's
+          # artifact is in a different scope and is left intact.
+          overwrite: true
+          if-no-files-found: ignore
+
+
+  # ---------------------------------------------------------------------------
+  # Issue #2060 (CI Phase A): static source-tree guards, split out of the `unit`
+  # job so they run in PARALLEL with the Gradle test graph instead of in front of
+  # it. Every guard is byte-identical to the step it replaced — same script, same
+  # self-test, same failure semantics — and still blocking, since `unit-gate`
+  # (named `Unit tests`) fails if this job fails. No Gradle, so no Gradle cache.
+  guards-static:
+    name: Static guards
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
       # Issue #1766: render PNGs are direct test side effects, so Gradle can
       # otherwise return FROM-CACHE/UP-TO-DATE for a second, differently
       # filtered DesignRenders method without creating its PNG. This fake-Gradle
@@ -75,7 +212,8 @@ jobs:
       # (a small baseline allowlists the catalogued-but-not-yet-rewritten cases,
       # and an inline `// JUSTIFIED:` comment opts a legitimate non-IME guard
       # out), so it adds protection without reddening CI for tests it is not its
-      # job to fix. Runs BEFORE the Gradle test step. This is the machine backstop
+      # job to fix. Runs in `guards-static`, alongside rather than in front of the
+      # Gradle test step (#2060). This is the machine backstop
       # for the process.md "Regression-proof validity rules" (F2/F3) so the rule
       # does not rely solely on reviewer memory. Additive — it does not touch the
       # existing Unit/Python/Integration/emulator jobs. The guard now also carries
@@ -87,6 +225,12 @@ jobs:
       # assumeTrue("x", false) mutant plus legal block/newline-comment callee
       # trivia, so literal-boolean self-skips cannot hide behind the older
       # IME/keyboard vocabulary filter or raw-source call formatting.
+      #
+      # Issue #2060 — COST NOTE. ~281 s on CI, and "it grew a full-tree scan,
+      # scope it" is the WRONG diagnosis: one real-tree pass is ~30 s; the bulk is
+      # the SELF-TEST re-running the guard once per planted fixture state (#1430
+      # already memoized ~30 runs to ~1 per state), so cutting it deletes detector
+      # coverage. The cost stays and moves off the critical path instead.
       - name: Test-validity guard (issue #657/#848/#1048/#1154/#1430/#1857)
         run: |
           chmod +x scripts/check-test-validity.sh scripts/check-test-validity-selftest.sh
@@ -141,9 +285,10 @@ jobs:
       # per-file baseline of the raw `AlertDialog(` / `CircularProgressIndicator(`
       # / `TextButton(` call-sites that remain and FAILS only when a file gains a
       # NEW one (or a new file ships with any). Stops the migrated backlog from
-      # silently re-growing. Cheap (< 1 s grep), no emulator — belongs in the Unit
-      # job. Re-baseline with `scripts/check-component-drift.sh --update` after a
-      # screen migrates (lowering a count is encouraged).
+      # silently re-growing. Cheap (< 1 s grep), no emulator — runs in the
+      # parallel `guards-static` job (#2060). Re-baseline with
+      # `scripts/check-component-drift.sh --update` after a screen migrates
+      # (lowering a count is encouraged).
       - name: Raw-component drift guard (issue #865)
         run: |
           chmod +x scripts/check-component-drift.sh
@@ -157,7 +302,7 @@ jobs:
       # literal (or a new file ships with any). The script existed but was never
       # wired in, so the Conversation view silently drifted to hardcoded 4/6.dp
       # radii and 10/12.sp text undetected. Cheap (< 1 s grep), no emulator —
-      # belongs in the Unit job. Re-baseline with
+      # runs in the parallel `guards-static` job (#2060). Re-baseline with
       # `scripts/check-design-tokens.sh --update` after a screen migrates.
       - name: Design-token ladder guard (issue #901)
         run: |
@@ -187,36 +332,62 @@ jobs:
       #   with `scripts/check-connection-vm-ratchet.sh --update` only after an
       #   extraction slice LOWERS a count (S4-S8 of the consolidation roadmap).
       #   --self-test first proves the guard's own red->green logic, then the
-      #   bare run checks the real VM. Cheap (< 1 s grep), no emulator — belongs
-      #   in the Unit job.
+      #   bare run checks the real VM. Cheap (< 1 s grep), no emulator — runs in
+      #   the parallel `guards-static` job (#2060).
       - name: Connection-VM ratchet guard (issue #1047)
         run: |
           chmod +x scripts/check-connection-vm-ratchet.sh
           scripts/check-connection-vm-ratchet.sh --self-test
           scripts/check-connection-vm-ratchet.sh
 
-      # Issue #1685: dex register-pressure ratchet for the TmuxSessionScreen
-      # composable family. TmuxSessionScreen is the app's MAIN screen and a single
-      # enormous composable; when its compiled dex method frame crosses ART's
-      # 256-register WIDE-REGISTER cliff the class fails on-device verification
-      # (java.lang.VerifyError) and the screen crashes at load — invisible to the
-      # JVM unit tests. This has recurred THREE times (#1158/#1362/#1685). The
-      # existing on-device proof (TmuxSessionScreenArtVerifyE2eTest) only runs in
-      # the batched post-merge emulator lane, which is exactly why recurrence #3
-      # shipped. This guard runs PER-PR in the cheap Unit lane: it dexes the debug
-      # APK and asserts every TmuxSessionScreen* method stays under a budget (200)
-      # that keeps a hard margin below the 256 cliff, so a creep back toward the
-      # cliff is a per-PR RED here instead of a phone crash later. --self-test
-      # proves the parser/budget red->green logic (no APK) first; then a debug
-      # build + the real check. dexdump comes from the runner's Android build-tools.
-      - name: Dex register-pressure ratchet (issue #1685)
+      # Issue #1724: the hosted release-confidence gate reproducibly exhausted
+      # the Kotlin compiler heap before any journey ran because debug + release
+      # compilation shared a 2 GiB daemon concurrently. Pin the hosted-only
+      # single-worker / split-heap budget, and prove the guard rejects renewed
+      # parallelism or either missing heap bound.
+      - name: Release-emulator compiler-memory guard (issue #1724)
         run: |
-          chmod +x scripts/check-dex-register-pressure.sh
-          scripts/check-dex-register-pressure.sh --self-test
-          ./gradlew :app:assembleDebug --no-daemon --stacktrace \
-            --max-workers=2 \
-            -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8"
-          scripts/check-dex-register-pressure.sh
+          chmod +x scripts/check-release-emulator-memory-budget.sh
+          scripts/check-release-emulator-memory-budget.sh --self-test
+          scripts/check-release-emulator-memory-budget.sh
+
+      # Issue #1761: the local forced full-JVM gate hit Kotlin compiler OOM when
+      # Worker API sessions overlapped inside the 8 GiB scope. Keep its complete
+      # `test --rerun-tasks` graph on the proven single-worker / split-heap
+      # profile, and reject missing, duplicated, or conflicting resource flags.
+      # The 119-check direct / 118-check authenticated nested fake matrix also
+      # proves local/GitHub Android SDK discovery, fail-closed invalid roots,
+      # and stripping of hosted toolchain/profile variables before the guard.
+      - name: Forced full-JVM resource-profile guard (issue #1761)
+        run: |
+          scripts/full-jvm-gate.sh --profile-guard-self-test
+          scripts/full-jvm-gate.sh --profile-guard-check
+
+  # ---------------------------------------------------------------------------
+  # Issue #2060 (CI Phase A): CI/harness fixture guards, split out of the `unit`
+  # job. They drive the real emulator-journey / nightly / release harness scripts
+  # against stubbed gradle/adb/docker. Several are intentionally WALL-CLOCK bound
+  # (`test-ci-journey-budget.sh` ~5 min models timeouts/wedges/stalls with real
+  # `sleep`s — a kernel timer is the only host-throughput-independent way to
+  # prove a timeout fires), so stop paying that on the critical path rather than
+  # shortening the sleeps. Same contract as `guards-static`.
+  guards-ci-harness:
+    name: CI harness guards
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
 
       # Issue #835: gate the emulator-journey suite's OWN budget/labelling logic
       # so the #470-stall hardening cannot silently regress. This is a fast
@@ -226,7 +397,14 @@ jobs:
       # REOPENED, the DURABLE GUARD) that the workflow classifier now routes that
       # summary to a HARD-RED timeout verdict — NOT advisory-green and NOT the
       # #771 EMULATOR INFRA UNAVAILABLE branch — so a cut-short load-bearing class
-      # can never again be masked. Cheap (< 15 s), no emulator.
+      # can never again be masked. No emulator, no JVM, no Gradle.
+      #
+      # Issue #2060 — COST CORRECTION. "Cheap (< 15 s)" had long been untrue: it
+      # is ~286 s on CI, the priciest step in the old serial Unit job after the
+      # dex assemble. NOT scan bloat to optimise away — it proves TIMEOUT
+      # behaviour, and the only host-throughput-independent way to fire a timeout
+      # is a kernel timer, so its ~20 `sleep`s ARE the proof. Structural fix: it
+      # now overlaps the Gradle graph in parallel.
       - name: CI journey-suite budget guard (issue #835)
         run: |
           chmod +x scripts/test-ci-journey-budget.sh
@@ -311,6 +489,19 @@ jobs:
           chmod +x scripts/test-shared-tmux-wrapper-fixtures.sh \
             scripts/test-shared-tmux-wrapper-fixtures-selftest.sh
           scripts/test-shared-tmux-wrapper-fixtures-selftest.sh
+
+      # Issue #2060: the #1876/#1458 guards and the #835 balance cap derive the
+      # shard count from the matrix via this helper instead of pinning a literal,
+      # so 3 -> 6 cannot silently orphan a hash bucket no shard selects. They are
+      # only as good as the helper, so prove it fails closed. The second is the
+      # downward-only ratchet: it reddens when a journey-CI guard grows a
+      # hardcoded shard total in one of three known shapes. (< 2 s)
+      - name: "Journey shard-count helper + hardcoded-total ratchet (issue #2060)"
+        run: |
+          chmod +x scripts/ci-journey-shard-count.sh scripts/check-journey-shard-literals.sh
+          scripts/ci-journey-shard-count.sh --self-test
+          scripts/check-journey-shard-literals.sh --self-test
+          scripts/check-journey-shard-literals.sh
 
       # Issue #1458: fast, JVM-free fixture test for the emulator-journey
       # aggregate verdict (scripts/ci-journey-aggregate-verdict.sh) + the
@@ -481,126 +672,108 @@ jobs:
           chmod +x scripts/ci-assemble-with-ndk-retry.sh scripts/test-ci-ndk-retry.sh
           scripts/test-ci-ndk-retry.sh
 
-      # Issue #1724: the hosted release-confidence gate reproducibly exhausted
-      # the Kotlin compiler heap before any journey ran because debug + release
-      # compilation shared a 2 GiB daemon concurrently. Pin the hosted-only
-      # single-worker / split-heap budget, and prove the guard rejects renewed
-      # parallelism or either missing heap bound.
-      - name: Release-emulator compiler-memory guard (issue #1724)
-        run: |
-          chmod +x scripts/check-release-emulator-memory-budget.sh
-          scripts/check-release-emulator-memory-budget.sh --self-test
-          scripts/check-release-emulator-memory-budget.sh
+  # ---------------------------------------------------------------------------
+  # Issue #2060 (CI Phase A): the dex ratchet needs a real `:app:assembleDebug` —
+  # ~5 min of the old `unit` job's serial prefix and the ONLY guard step that
+  # compiles anything. Splitting it out takes it off the Unit critical path AND
+  # gives the workflow a cheap "the tree compiles and packages" signal ~6 min in,
+  # which is what `emulator-journey` gates on (see its `needs:` note).
+  dex:
+    name: Dex register-pressure ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-      # Issue #1761: the local forced full-JVM gate hit Kotlin compiler OOM when
-      # Worker API sessions overlapped inside the 8 GiB scope. Keep its complete
-      # `test --rerun-tasks` graph on the proven single-worker / split-heap
-      # profile, and reject missing, duplicated, or conflicting resource flags.
-      # The 119-check direct / 118-check authenticated nested fake matrix also
-      # proves local/GitHub Android SDK discovery, fail-closed invalid roots,
-      # and stripping of hosted toolchain/profile variables before the guard.
-      - name: Forced full-JVM resource-profile guard (issue #1761)
-        run: |
-          scripts/full-jvm-gate.sh --profile-guard-self-test
-          scripts/full-jvm-gate.sh --profile-guard-check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      # Issue #1897: the #1646 result guard correctly rejects FROM-CACHE test
-      # tasks, but it cannot force the preceding Gradle invocation to execute.
-      # Keep the required Unit command aligned with the canonical forced local
-      # gate: rerun every task and disable cache restoration. The cheap
-      # self-test proves this wiring guard fails closed when either flag is
-      # removed, duplicated, contradicted, or moved off the complete test graph.
-      - name: CI Unit forced-execution wiring guard (issue #1897)
-        run: |
-          chmod +x scripts/check-ci-unit-forced-execution.sh
-          scripts/check-ci-unit-forced-execution.sh --self-test
-          scripts/check-ci-unit-forced-execution.sh
-
-      # Issue #1646: the executed-test-count guard's OWN red->green self-test.
-      # Proves — with synthetic result XML + synthetic Gradle console output, no
-      # Gradle, no Android SDK, no emulator — that the guard FAILS a vacuous run
-      # (missing task / UP-TO-DATE / FROM-CACHE / all-skipped / below-floor) and
-      # PASSES a genuine one, and that NO-SOURCE on a genuinely test-free module
-      # does not trip it. Runs BEFORE the Gradle step so a broken guard is caught
-      # in seconds rather than 20 minutes in. The self-test asserts its own check
-      # count, so the anti-vacuous-test guard cannot itself pass vacuously.
-      - name: Executed-test-count guard self-test (issue #1646)
-        run: |
-          chmod +x scripts/check-executed-test-counts.sh
-          scripts/check-executed-test-counts.sh --self-test
-
-      # Issue #1646: mark the start of the test run. Any TEST-*.xml older than
-      # this marker is a leftover from an earlier run whose task was skipped as
-      # UP-TO-DATE, not evidence from THIS run.
-      - name: Mark test-run start (issue #1646)
-        run: |
-          touch "${RUNNER_TEMP}/unit-test-run-start"
-
-      # Issue #760: the unit job occasionally failed with ALL visible tests
-      # PASSED — a gradle-daemon/runner OOM abort, not a real assertion failure.
-      # ubuntu-latest gives 7 GB RAM and 2 cores; unbounded gradle worker fan-out
-      # plus an oversized test JVM heap can push the runner into the OOM-killer,
-      # which kills the gradle process mid-run AFTER the tests reported green.
-      # Bound BOTH the gradle worker count and the JVM heaps so the job stays
-      # inside the runner's memory budget: --max-workers=2 matches the 2 vCPUs,
-      # and the explicit -Dorg.gradle.jvmargs caps the gradle daemon/launcher
-      # heap while -Pkotlin/test forks inherit the project's modest -Xmx. This is
-      # infra robustness only — no test is removed, skipped, or weakened.
-      #
-      # Issue #1646: tee the console to a log (--console=plain) so the count
-      # guard below can see which test tasks actually EXECUTED vs came back
-      # UP-TO-DATE / FROM-CACHE / NO-SOURCE. pipefail keeps Gradle's exit code
-      # authoritative through the tee.
-      - name: Run JVM unit tests
-        id: unit_tests
-        timeout-minutes: 35
-        run: |
-          set -o pipefail
-          ./gradlew test --rerun-tasks --no-build-cache \
-            --no-daemon --stacktrace --console=plain \
-            --max-workers=2 \
-            -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" \
-            2>&1 | tee "${RUNNER_TEMP}/unit-test-gradle.log"
-
-      # Issue #1646: a green Gradle run that executed ZERO tests is not evidence.
-      # Gradle prints test counts ONLY on failure, so before this step a green
-      # run had no log line and no artifact proving any test ran. Parse the
-      # result XML, hard-fail any expected test task that executed 0 tests (or
-      # fell below its floor), and ECHO the per-task counts into the job log and
-      # the job summary so a human/agent certifying a PR can read them without
-      # downloading an artifact.
-      #
-      # Runs whenever the test step itself ran — on GREEN (the point of the
-      # issue) and on RED alike, since "killed mid-run but reported exit 0"
-      # (incident 3) is a case where the count is the only thing that exposes the
-      # truth. Scoped to the test step's own conclusion rather than a bare
-      # always() so an earlier guard failing (Gradle never ran, no log written)
-      # does not add a confusing second red about a missing log file.
-      - name: Assert tests actually executed (issue #1646)
-        if: always() && steps.unit_tests.conclusion != 'skipped'
-        run: |
-          chmod +x scripts/check-executed-test-counts.sh
-          scripts/check-executed-test-counts.sh \
-            --newer-than "${RUNNER_TEMP}/unit-test-run-start" \
-            --gradle-log "${RUNNER_TEMP}/unit-test-gradle.log"
-
-      # Issue #1646: upload ALWAYS, not just on failure. A green run's result XML
-      # IS the evidence that the run was real; throwing it away and keeping only
-      # failures is precisely why CI could not prove a green run executed
-      # anything.
-      - name: Upload unit test reports
-        if: always()
-        uses: actions/upload-artifact@v7
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
         with:
-          name: unit-test-reports
+          distribution: temurin
+          java-version: "17"
+
+      - name: Cache Gradle
+        uses: actions/cache@v5
+        with:
           path: |
-            **/build/reports/tests/
-            **/build/test-results/
-          # Issue #1809: a re-run of this job replaces its OWN attempt's upload
-          # instead of hitting a duplicate-name failure; the previous attempt's
-          # artifact is in a different scope and is left intact.
-          overwrite: true
-          if-no-files-found: ignore
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle*', '**/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      # Issue #1685: dex register-pressure ratchet for the TmuxSessionScreen
+      # composable family. TmuxSessionScreen is the app's MAIN screen and a single
+      # enormous composable; when its compiled dex method frame crosses ART's
+      # 256-register WIDE-REGISTER cliff the class fails on-device verification
+      # (java.lang.VerifyError) and the screen crashes at load — invisible to the
+      # JVM unit tests. This has recurred THREE times (#1158/#1362/#1685). The
+      # existing on-device proof (TmuxSessionScreenArtVerifyE2eTest) only runs in
+      # the batched post-merge emulator lane, which is exactly why recurrence #3
+      # shipped. This guard runs PER-PR in the cheap Unit lane: it dexes the debug
+      # APK and asserts every TmuxSessionScreen* method stays under a budget (200)
+      # that keeps a hard margin below the 256 cliff, so a creep back toward the
+      # cliff is a per-PR RED here instead of a phone crash later. --self-test
+      # proves the parser/budget red->green logic (no APK) first; then a debug
+      # build + the real check. dexdump comes from the runner's Android build-tools.
+      - name: Dex register-pressure ratchet (issue #1685)
+        run: |
+          chmod +x scripts/check-dex-register-pressure.sh
+          scripts/check-dex-register-pressure.sh --self-test
+          # Issue #2060: --max-workers matches the real 4-vCPU runner (was 2,
+          # sized for the pre-2024 box). AGP dexing/resources are Worker API tasks
+          # that genuinely fan out; peak memory is unchanged (parallel=false).
+          ./gradlew :app:assembleDebug --no-daemon --stacktrace \
+            --max-workers=4 \
+            -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8"
+          scripts/check-dex-register-pressure.sh
+
+  # ---------------------------------------------------------------------------
+  # Issue #2060 (CI Phase A): the protected-branch required check. `main`'s
+  # ruleset requires a check literally named `Unit tests`; splitting the old
+  # monolithic job into four would have silently DEMOTED every guard to
+  # non-blocking until someone edited the ruleset by hand — a real loss of
+  # enforcement dressed up as a speed-up. This ~10-second aggregator keeps the
+  # name and fails unless all four jobs succeeded, so the blocking contract is
+  # bit-for-bit the same with zero admin action. `if: always()` so it still
+  # reports (as a failure) when a dependency fails, is cancelled or is skipped —
+  # a `needs:` job that never reports would leave it pending forever.
+  unit-gate:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    needs: [unit, guards-static, guards-ci-harness, dex]
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Require every unit-lane job to have succeeded
+        env:
+          UNIT: ${{ needs.unit.result }}
+          GUARDS_STATIC: ${{ needs.guards-static.result }}
+          GUARDS_CI_HARNESS: ${{ needs.guards-ci-harness.result }}
+          DEX: ${{ needs.dex.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for pair in "JVM unit tests:$UNIT" \
+                      "Static guards:$GUARDS_STATIC" \
+                      "CI harness guards:$GUARDS_CI_HARNESS" \
+                      "Dex register-pressure ratchet:$DEX"; do
+            job="${pair%%:*}"
+            result="${pair##*:}"
+            printf '%-32s %s\n' "$job" "$result"
+            if [[ "$result" != "success" ]]; then
+              failed=1
+            fi
+          done
+          if (( failed )); then
+            echo "::error title=Unit lane failed::A unit-lane job did not succeed (#2060). The required \`Unit tests\` check covers all four; open the failing job above for the diagnosis."
+            exit 1
+          fi
+          echo "All four unit-lane jobs succeeded."
 
   python:
     name: Python utility tests (pocketshell)
@@ -784,35 +957,75 @@ jobs:
   emulator-journey:
     name: Emulator journey subset (load-bearing, Docker agents)
     if: github.event_name != 'pull_request'
-    needs: [unit, python, integration]
+    # Issue #2060 (CI Phase A) — THE ACTIONS-BUDGET DECISION, recorded here
+    # because this one line owned ~37 of `main`'s ~99-minute wall clock. It was
+    # `needs: [unit, python, integration]`, so the shards could not start until
+    # the ~39-min Unit job finished though they share nothing with it but the
+    # checkout. That gate was NOT pointless: it stopped a red commit burning one
+    # emulator runner per shard for ~40 min each against a 20-concurrent-job
+    # ceiling (process.md). Peak `main`-push concurrency goes ~3 -> ~10 (unit +
+    # both guard jobs + integration overlapping the 6 shards); a PR runs no
+    # shards, so its peak is the 6-job unit lane.
+    #
+    # Option (a) was to drop `needs:` and accept the emulator spend on red runs.
+    # We took option (b): a CHEAP fast-fail dependency recovering almost all of
+    # the 37 min while keeping the cost protection. `dex` is it — the ~6-min
+    # `:app:assembleDebug`, proof the tree COMPILES AND PACKAGES, the failure
+    # class that would otherwise waste every runner (each ~8 min into the suite's
+    # warm build before hitting the same break). `python` is ~1 min and fully
+    # overlapped by `dex`, so it is free and keeps fail-fast on version coupling.
+    # Given up deliberately: a commit whose TESTS are red but which compiles still
+    # spends the runners. Bounded — `main` pushes already passed the required
+    # `Unit tests` check on their PR head (G7), and the main-push concurrency
+    # group cancels superseded runs.
+    needs: [dex, python]
     runs-on: ubuntu-latest
     # Issue #835 (REOPENED, SHARD): the right-size-only fix (#1055, 45->95 cap +
     # 4200s budget + Gradle daemon reuse) STILL could not finish the full
     # selection serially on ONE swiftshader AVD — its own validation run
-    # (98384e91, run 28307686762) ran the full 95 min and was CANCELLED. ~83
-    # journey classes + 6 proofs run serially is ~69+ min of wall-clock AND
-    # degrades the single emulator (the #470 enumeration stall worsens the more
-    # the one AVD is churned). Fix: SHARD the journey class list across a matrix
-    # of runners — each leg is its OWN runner + cold-booted emulator + Docker
-    # `agents` fixtures and runs only its 1/N round-robin slice (the suite reads
-    # POCKETSHELL_JOURNEY_CI_SHARD_INDEX/_TOTAL; see scripts/ci-journey-suite.sh).
-    # That cuts each leg's wall-clock to ~1/N (comfortably inside the budget) and
-    # keeps each emulator far healthier (~1/N install/teardown cycles), attacking
-    # the #470 root. `fail-fast: false` so one shard's failure does not cancel the
-    # others (we want every shard's verdict). The 6 core-terminal proofs are NOT
-    # sharded — they run on every leg (cheap in-process Compose UI tests).
+    # (98384e91, run 28307686762) ran the full 95 min and was CANCELLED, and the
+    # churn on that one AVD worsens the #470 enumeration stall. Fix: SHARD the
+    # class list across a matrix of runners — each leg its OWN runner +
+    # cold-booted emulator + Docker `agents` fixtures, running only its slice
+    # (the suite reads POCKETSHELL_JOURNEY_CI_SHARD_INDEX/_TOTAL; see
+    # scripts/ci-journey-suite.sh), so each leg's wall clock drops and each
+    # emulator stays healthier (~1/N install/teardown cycles). `fail-fast: false`
+    # so one shard's failure does not cancel the others. The 6 core-terminal
+    # proofs run on every leg (cheap Compose UI tests), not sharded.
+    #
+    # Issue #2060 (CI Phase A): 3 -> 6 shards, as much a RELIABILITY fix as a
+    # speed one. The registry has grown to 173 entries and on BOTH recent green
+    # `main` runs all three shards reported `retry_affordable=false /
+    # insufficient_remaining_budget` — the #1850 hole is live: at that per-shard
+    # load the cold-boot retry that IS this gate's flake resilience is
+    # unaffordable, so one swiftshader flake reddens `main` instead of recovering.
+    # Sharding changes only WHICH runner a class lands on: membership is by
+    # class-name hash (#1862), every class still runs on every push.
+    #
+    # SIX is chosen on #1850's OWN bar — every leg's drift headroom must exceed
+    # one twice-failing class (~420s) — not on "affordable on a clean run". Five
+    # leaves three legs under that bar and its tightest hosts the 330s
+    # ReconnectStormLivelockE2eTest; six gives every leg >= 488s. Six is the
+    # FIRST total clearing it, NOT the fastest — 8/9 beat it by ~1.4 min for +2/3
+    # runners. Tables/headroom/flakes: scripts/ci-journey-shard-count.sh, which
+    # owns this number. The three places that must agree on it — matrix.shard,
+    # POCKETSHELL_JOURNEY_CI_SHARD_TOTAL and the aggregation job's
+    # EXPECTED_SHARDS — were "keep in sync" comments; they are now cross-checked
+    # from the matrix by that helper, and check-journey-shard-literals.sh is a
+    # downward-only ratchet over three shapes a new hardcoded total takes.
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2]
+        shard: [0, 1, 2, 3, 4, 5]
     env:
-      # Set by the matrix; the suite partitions JOURNEY_CLASSES round-robin by
-      # (index % total). Keep _TOTAL in sync with the length of matrix.shard.
+      # Set by the matrix; the suite partitions JOURNEY_CLASSES by class-name
+      # hash into (index % total). _TOTAL must equal len(matrix.shard).
       POCKETSHELL_JOURNEY_CI_SHARD_INDEX: ${{ matrix.shard }}
-      POCKETSHELL_JOURNEY_CI_SHARD_TOTAL: 3
+      POCKETSHELL_JOURNEY_CI_SHARD_TOTAL: 6
     # Issue #835 (REOPENED, RIGHT-SIZE): raised 45 -> 95 originally so the FULL
-    # serial selection could finish; with sharding each leg runs ~1/3 the classes
-    # and finishes well under this cap. `timeout-minutes` is a CAP, not a fixed
+    # serial selection could finish; with sharding each leg runs ~1/N the classes
+    # (#2060: ~38 min modelled worst leg at 6) and finishes well under this cap.
+    # `timeout-minutes` is a CAP, not a fixed
     # duration: the job ENDS when the suite ends (early on a healthy run), so this
     # only bounds the absolute worst case. The suite owns its OWN 4200s budget and
     # bails cleanly before this cap; the arithmetic is
@@ -1865,8 +2078,11 @@ jobs:
 
       - name: Aggregate the per-shard verdicts into ONE verdict
         env:
-          # Keep in sync with the length of the emulator-journey matrix.shard.
-          EXPECTED_SHARDS: 3
+          # Must equal the length of the emulator-journey matrix.shard. Issue
+          # #2060 replaced the "keep in sync" honour system with a machine
+          # cross-check: test-ci-journey-aggregate-verdict.sh (w9) derives the
+          # matrix length via ci-journey-shard-count.sh and fails on disagreement.
+          EXPECTED_SHARDS: 6
           # Issue #1913: a failed matrix with no RED token means the classifier
           # lost a commit-bound failure. Genuine typed INFRA shards finish green,
           # so their matrix result is success and remains neutral RE-RUN.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,20 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# Issue #2060 (CI Phase A) deliberately LEFT THIS FALSE. Turning on project-level
+# parallelism is the single biggest remaining unit-test speed lever, and it is
+# also the one that cannot be landed unmeasured:
+#   * it multiplies LIVE test forks (each :app fork is 1536m — app/build.gradle.kts
+#     #1518), and undersized memory here surfaces as a fake
+#     "Backend Internal error: Exception during IR lowering", not as an OOM;
+#   * it adds CPU contention, which is exactly what wakes the #708/#882/#1048
+#     runTest virtual-clock-vs-real-dispatcher flake class;
+#   * this file is GLOBAL — it would also re-profile scripts/full-jvm-gate.sh,
+#     which runs the whole `test --rerun-tasks` graph inside an 8 GiB cgroup on
+#     the proven single-worker / split-heap profile that #1761 guards.
+# process.md requires an N>=20 determinism soak on a FULL :app:testReleaseUnitTest
+# module run before that variable moves. #2060 therefore changed exactly one
+# runner-sizing variable — --max-workers on the CI invocations, which raises
+# concurrency without raising peak memory while this stays false — and left this
+# one for a separately measured follow-up.
 org.gradle.parallel=false
 org.gradle.caching=true
 

--- a/scripts/check-journey-shard-literals.sh
+++ b/scripts/check-journey-shard-literals.sh
@@ -1,0 +1,490 @@
+#!/usr/bin/env bash
+#
+# check-journey-shard-literals.sh — hardcoded emulator-journey shard-total
+# ratchet (issue #2060).
+#
+# WHY THIS EXISTS. The emulator-journey shard count is owned by ONE place, the
+# `matrix.shard` list in .github/workflows/tests.yml, and every guard that
+# asserts something about the SHIPPED configuration is supposed to read it from
+# there via scripts/ci-journey-shard-count.sh. In practice literals kept
+# accumulating: going 3 -> 6 in #2060 uncovered FOUR guards still pinned to 3,
+# found one at a time over three review rounds —
+#
+#   1. test-ci-journey-aggregate-verdict.sh  EXPECTED_SHARDS pin      (round 1)
+#   2. test-ci-journey-budget.sh              the 125% balance cap     (round 2)
+#   3. test-ci-journey-budget.sh              the (shard) ACCEPTANCE   (round 3)
+#   4. test-ci-journey-warm-build.sh          the #1814 per-shard loop (round 3)
+#
+# Each was individually harmless-looking and each silently narrowed a guard to a
+# configuration CI no longer runs. #4 is the shape that matters most: it derived
+# SHARD_TOTAL correctly, printed "verified on all $SHARD_TOTAL shards", and had
+# enumerated only 0/1/2 — a truthful-looking pass over a third of the legs.
+# Fixing the instance you were handed does not stop the fifth, so this is a
+# ratchet: it fails when a literal appears in a shape it recognises, and its
+# --update is downward-only so it cannot be silenced by re-baselining.
+#
+# WHAT IT SCANS (see `scan` below): the journey-CI shell family — every
+# scripts/*ci-journey*.sh plus scripts/test-ci-mobile-rtt-readiness.sh, which is
+# a journey-matrix guard without "journey" in its name.
+#
+# WHAT IT LOOKS FOR — three shapes, each pinned by its own self-test case:
+#   A. a shard-TOTAL noun assigned a NUMERIC LITERAL  ->  `EXPECTED_SHARDS=3`,
+#      `POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=3`, `shard_total=3`, `shard_count=6`,
+#      `NUM_SHARDS=6`, `SOLO_SHARD_TOTAL=400`, singular `EXPECTED_SHARD=3`
+#   B. the same noun pinned through a DEFAULT EXPANSION  ->
+#      `SHARD_TOTAL="${SHARD_TOTAL:-3}"`. This is the nastiest of the three: it
+#      READS like a derived value while hardcoding the total on exactly the
+#      mis-wired job where the env var is missing.
+#   C. a loop ENUMERATED over literal 0-based indices  ->  `for shard in 0 1 2`
+#      (#4's shape, which carries no `total` token at all), and also
+#      `for idx in 0 1 2` / `for leg in 0 1 2` / `for x in {0..5}` /
+#      `for x in $(seq 0 5)` — the enumeration itself is the tell, because a
+#      loop-variable-name-only pattern is one rename from blind.
+# A form that DERIVES its value — `SHARD_TOTAL="$(... ci-journey-shard-count.sh
+# ...)"`, `for (( i = 0; i < SHARD_TOTAL; i++ ))`, `$(seq 0 "$((TOTAL-1))")` —
+# has no numeric literal and therefore never matches. Comment lines are skipped:
+# prose ABOUT a literal (this file, and the #2060 notes explaining what was
+# removed) is not a literal.
+#
+# WHAT IT DOES NOT CATCH — stated so the boundary is known rather than assumed.
+# This is a grep over three named shapes, not a proof that no literal exists:
+#   - a total assembled at runtime (`t=$((2+4))`, a literal read from a file or
+#     a `case` arm), or one written in a language this scan does not read;
+#   - a literal on a `shard`-free identifier (`EXPECTED=3`, `LEGS=6`) — nothing
+#     in the text ties it to the matrix;
+#   - shard INDEX literals and `=0` (see the out-of-scope list below).
+# So: a partial backstop, honestly bounded. The load-bearing protection is still
+# that every SHIPPED-configuration assertion derives its total from
+# scripts/ci-journey-shard-count.sh; this ratchet catches the regression shapes
+# that have actually occurred here, four times.
+#
+# DELIBERATELY OUT OF SCOPE, so the boundary is stated rather than accidental:
+#   - .github/workflows/tests.yml itself. It is the SOURCE of the number; its
+#     three sites are already machine-cross-checked against each other by
+#     ci-journey-shard-count.sh + the #1876/#1458 guards. Baselining them here
+#     would re-encode the count in a fourth place — the very drift being removed
+#     — and force a baseline edit on every count change.
+#   - the nightly suite's POCKETSHELL_NIGHTLY_SHARD_* mechanism
+#     (.github/workflows/nightly-extensive.yml + scripts/nightly-extensive-suite.sh).
+#     That is AndroidJUnitRunner numShards/shardIndex, a separate matrix that is
+#     internally consistent at its own total.
+#   - shard INDEX literals (`shard=0`, `SHARD_INDEX=2`, `${SHARD_INDEX:-0}`). An
+#     index is bounded by the total the guards already validate; totals and
+#     enumerated loops are the drift class #2060 hit.
+#   - a literal ZERO (`shard_union_count=0`, `${EXPECTED_SHARDS:-0}`). Zero is
+#     never a shard total: it is an accumulator initialiser or an "unset"
+#     fail-safe, so matching it added noise and no protection.
+#
+# The accepted sites live in scripts/journey-shard-literal-baseline.txt with a
+# one-line reason each. They are all self-contained sandbox fixtures: the guard
+# builds N synthetic inputs and tells the code under test to expect N, so the
+# property is total-invariant and 3 is just a cheap sample. A site that asserts
+# something about the SHIPPED configuration does NOT belong in the baseline — it
+# belongs on ci-journey-shard-count.sh.
+#
+# Usage:
+#   scripts/check-journey-shard-literals.sh            # check against the baseline
+#   scripts/check-journey-shard-literals.sh --update   # re-bake the baseline;
+#       DOWNWARD-ONLY — it lowers an accepted count or drops a file, and REFUSES
+#       to raise a count or admit a new file. A ratchet whose --update can
+#       re-baseline upward is not a ratchet, it is a suggestion.
+#   scripts/check-journey-shard-literals.sh --self-test
+#
+# Exit codes:
+#   0  no NEW hardcoded shard total          [also: --update / --self-test ok]
+#   1  a NEW hardcoded shard total appeared, the update was refused as upward,
+#      or the scan itself is broken
+#
+# Cheap: one grep per scanned file over ~31 files, well under a second.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+BASELINE_FILE="scripts/journey-shard-literal-baseline.txt"
+
+# A "shard TOTAL" identifier. Deliberately noun-shaped rather than "any
+# identifier containing shard", so shard INDEX spellings (`shard`, `shard_idx`,
+# `SHARD_INDEX`) — an out-of-scope class, see above — do not match:
+#   shard...total / shard...count   SHARD_TOTAL, JOURNEY_CI_SHARD_TOTAL,
+#                                   SHARD_TOTALS, shard_total_probe, SHARD_COUNT,
+#                                   shard_count  (the spelling a future author is
+#                                   most likely to pick: the helper is named
+#                                   ci-journey-shard-count.sh)
+#   ...shards                       EXPECTED_SHARDS, NUM_SHARDS, TOTAL_SHARDS
+#   expected|num|total|count|max + shard   also in the SINGULAR: EXPECTED_SHARD=3
+RE_SHARD_NOUN='(([a-z0-9_]*shard[a-z0-9_]*(total|count)[a-z0-9_]*)|([a-z0-9_]*shards)|((expected|num|total|count|max)[a-z0-9_]*shard[a-z0-9_]*))'
+# The literal must be >= 1. Zero is never a shard total: `=0` is an accumulator
+# initialiser (`shard_union_count=0`) or an "unset" fail-safe (`${VAR:-0}`), and
+# matching it produced only noise.
+RE_NUM='[1-9][0-9]*'
+# A. the noun assigned a numeric literal.
+RE_TOTAL="${RE_SHARD_NOUN}[[:space:]]*=[[:space:]]*${RE_NUM}"
+# B. the noun pinned through a DEFAULT EXPANSION — `SHARD_TOTAL="${SHARD_TOTAL:-3}"`.
+#    This shape *looks* derived (it reads an env var) while hardcoding the total
+#    whenever the env var is absent, which on a mis-wired job is exactly when it
+#    matters. Matched on either side, so `TOTAL="${JOURNEY_CI_SHARD_TOTAL:-3}"`
+#    and `SHARD_COUNT="${FOO:-3}"` both trip.
+RE_DEFAULT="(${RE_SHARD_NOUN}[[:space:]]*=[[:space:]]*\"?\\\$\\{[a-z0-9_]*:-${RE_NUM}\\})|(=[[:space:]]*\"?\\\$\\{$RE_SHARD_NOUN:-${RE_NUM}\\})"
+# C. a shard loop ENUMERATED over literal indices, in all four spellings. The
+#    first keys on the loop VARIABLE (`for shard in 0`, `for shard_idx in 0`);
+#    the rest key on the 0-BASED LITERAL ENUMERATION itself, because #4's shape
+#    happened to use `shard` and a future `for leg in 0 1 2` would walk straight
+#    through a variable-name-only pattern.
+#      for x in 0 1 2      for x in {0..5}      for x in $(seq 0 5)
+#    `$(seq 0 "$((N-1)))"` and `for (( i = 0; i < N; i++ ))` are DERIVED and
+#    deliberately do not match — the upper bound must be a literal.
+RE_LOOP='(for[[:space:]]+[a-z0-9_]*shard[a-z0-9_]*[[:space:]]+in[[:space:]]+[0-9]+)|(for[[:space:]]+[a-z0-9_]+[[:space:]]+in[[:space:]]+0[[:space:]]+1([[:space:]]|;|$))|(for[[:space:]]+[a-z0-9_]+[[:space:]]+in[[:space:]]+\{0\.\.[0-9]+\})|(for[[:space:]]+[a-z0-9_]+[[:space:]]+in[[:space:]]+\$\(seq[[:space:]]+0[[:space:]]+[0-9]+)'
+# The one expression every scan uses, so `scan` and `scan_verbose` can never drift.
+RE_ANY="($RE_TOTAL)|($RE_DEFAULT)|($RE_LOOP)"
+
+# Emit "<file>\t<count>" for every scanned file holding at least one literal,
+# sorted. Comment lines are dropped first.
+scan() {
+  local root="$1" f
+  local -a files=()
+  # shellcheck disable=SC2231
+  for f in "$root"/scripts/*ci-journey*.sh "$root"/scripts/test-ci-mobile-rtt-readiness.sh; do
+    [[ -f "$f" ]] && files+=("$f")
+  done
+  (( ${#files[@]} > 0 )) || { echo "check-journey-shard-literals: scanned ZERO files under $root" >&2; return 2; }
+  for f in "${files[@]}"; do
+    local n
+    n="$(
+      grep -vE '^[[:space:]]*#' "$f" \
+        | grep -coiE "$RE_ANY"
+    )"
+    (( n > 0 )) && printf '%s\t%s\n' "${f#"$root"/}" "$n"
+  done | sort
+  return 0
+}
+
+# Same, but with file:line:text so a failure can name the offending site.
+scan_verbose() {
+  local root="$1" f
+  for f in "$root"/scripts/*ci-journey*.sh "$root"/scripts/test-ci-mobile-rtt-readiness.sh; do
+    [[ -f "$f" ]] || continue
+    grep -nvE '^[[:space:]]*#' "$f" \
+      | grep -iE "$RE_ANY" \
+      | sed "s|^|${f#"$root"/}:|"
+  done
+}
+
+do_check() {
+  local root="${1:-$REPO_ROOT}" quiet="${2:-}"
+  local current
+  current="$(scan "$root")" || return 2
+  [[ -f "$root/$BASELINE_FILE" ]] || { echo "missing baseline $BASELINE_FILE" >&2; return 1; }
+
+  local -A base=()
+  load_baseline "$root/$BASELINE_FILE" base
+
+  local file count
+  local bad=0 improved=0
+  while IFS=$'\t' read -r file count; do
+    [[ -n "$file" ]] || continue
+    local allowed="${base[$file]:-0}"
+    if (( count > allowed )); then
+      echo "NEW hardcoded shard total in $file: $count literal(s), baseline $allowed" >&2
+      bad=1
+    elif (( count < allowed )); then
+      improved=$((improved + 1))
+    fi
+  done <<<"$current"
+
+  if (( bad )); then
+    echo >&2
+    echo "Every shard-total literal below must either be derived from" >&2
+    echo "scripts/ci-journey-shard-count.sh (the matrix is the single source of" >&2
+    echo "truth) or, if it is a self-contained sandbox fixture, be added to" >&2
+    echo "$BASELINE_FILE with a one-line reason:" >&2
+    scan_verbose "$root" >&2
+    echo >&2
+    echo "check-journey-shard-literals: FAIL" >&2
+    return 1
+  fi
+  if [[ -z "$quiet" ]]; then
+    if (( improved )); then
+      echo "check-journey-shard-literals: OK — no new hardcoded shard totals ($improved file(s) improved; re-baseline with --update)."
+    else
+      echo "check-journey-shard-literals: OK — no new hardcoded shard totals."
+    fi
+  fi
+  return 0
+}
+
+# Read "<file>\t<count>" baseline rows into the caller's associative array.
+load_baseline() {  # $1 = baseline path, $2 = name of an associative array
+  local path="$1" file count
+  local -n _out="$2"
+  _out=()
+  [[ -f "$path" ]] || return 0
+  while IFS=$'\t' read -r file count; do
+    [[ -n "$file" ]] && _out["$file"]="$count"
+  done < <(grep -vE '^[[:space:]]*(#|$)' "$path" | sort)
+}
+
+# DOWNWARD-ONLY, in the idiom of the two ratchets this script models itself on:
+# scripts/check-connection-vm-ratchet.sh ("REFUSE: ... downward-only ratchet")
+# and scripts/check-file-size-hygiene.sh ("--update only ratchets downward").
+# --update may LOWER an accepted count or DROP a file; it may NOT raise a count
+# or admit a new file. Without this, a fifth literal is one documented command
+# away from green — `--update` would silently re-baseline the very drift the
+# ratchet exists to stop, and the header's claim would be false.
+do_update() {
+  local root="${1:-$REPO_ROOT}"
+  local baseline="$root/$BASELINE_FILE"
+  local current
+  current="$(scan "$root")" || return 2
+
+  local -A base=()
+  load_baseline "$baseline" base
+
+  local refused=0 file count allowed
+  while IFS=$'\t' read -r file count; do
+    [[ -n "$file" ]] || continue
+    if [[ -z "${base[$file]+set}" ]]; then
+      echo "REFUSE: $file is not in the baseline and holds $count literal(s) — downward-only ratchet." >&2
+      refused=1
+      continue
+    fi
+    allowed="${base[$file]}"
+    if (( count > allowed )); then
+      echo "REFUSE: $file holds $count literal(s), baseline $allowed — downward-only ratchet." >&2
+      refused=1
+    fi
+  done <<<"$current"
+
+  if (( refused )); then
+    echo >&2
+    echo "update refused: a current count EXCEEDS the baseline (or a new file appeared)." >&2
+    echo "Derive the total from scripts/ci-journey-shard-count.sh, then re-run --update;" >&2
+    echo "the ratchet never raises. Admitting a genuinely new self-contained sandbox" >&2
+    echo "fixture — or absorbing a WIDENED detector — is a deliberate hand edit of" >&2
+    echo "$BASELINE_FILE with its one-line reason, never this command:" >&2
+    scan_verbose "$root" >&2
+    return 1
+  fi
+
+  {
+    sed -n '1,/^# regenerate with:/p' "$baseline"
+    printf '%s\n' "$current"
+  } > "$baseline.tmp"
+  mv "$baseline.tmp" "$baseline"
+  echo "rewrote $BASELINE_FILE (downward-only)"
+}
+
+# ---------------------------------------------------------------------------
+# Self-test. A ratchet that cannot see a new literal is worse than none: it
+# reports OK forever. Each case plants a state in a throwaway copy of the tree
+# and asserts the verdict, so the detector is proven live rather than assumed.
+self_test() {
+  local sandbox checks=0
+  sandbox="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$sandbox'" EXIT
+
+  mkdir -p "$sandbox/scripts"
+  cp "$REPO_ROOT/scripts"/*ci-journey*.sh "$sandbox/scripts/"
+  cp "$REPO_ROOT/scripts/test-ci-mobile-rtt-readiness.sh" "$sandbox/scripts/"
+  cp "$REPO_ROOT/$BASELINE_FILE" "$sandbox/$BASELINE_FILE"
+
+  local victim="$sandbox/scripts/ci-journey-suite.sh"
+  local pristine="$sandbox/pristine-victim"
+  cp "$victim" "$pristine"
+
+  expect() {  # $1 = expected rc, $2 = label
+    local want="$1" label="$2" rc=0
+    do_check "$sandbox" quiet >/dev/null 2>&1 || rc=$?
+    [[ "$rc" == "$want" ]] \
+      || { echo "FAIL self-test [$label]: rc=$rc, expected $want" >&2; exit 1; }
+    checks=$((checks + 1))
+  }
+
+  expect 0 "clean tree matches its baseline"
+
+  # A NEW total literal must redden.
+  printf 'EXPECTED_SHARDS=3\n' >> "$victim"
+  expect 1 "a new EXPECTED_SHARDS=<n> literal"
+  cp "$pristine" "$victim"
+  expect 0 "restored"
+
+  # ...in either spelling.
+  printf 'POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=4\n' >> "$victim"
+  expect 1 "a new _SHARD_TOTAL=<n> literal"
+  cp "$pristine" "$victim"
+
+  printf 'shard_total=6\n' >> "$victim"
+  expect 1 "a new lowercase shard_total=<n> literal"
+  cp "$pristine" "$victim"
+
+  # `shard_count` is the spelling a future author is MOST likely to reach for,
+  # because the helper that owns the number is named ci-journey-shard-count.sh —
+  # and the round-3 pattern (`shard` + `total`|`s`) could not match it.
+  printf 'SHARD_COUNT=6\n' >> "$victim"
+  expect 1 "a new SHARD_COUNT=<n> literal"
+  cp "$pristine" "$victim"
+  printf 'shard_count=6\n' >> "$victim"
+  expect 1 "a new lowercase shard_count=<n> literal"
+  cp "$pristine" "$victim"
+  printf 'NUM_SHARDS=6\n' >> "$victim"
+  expect 1 "a new NUM_SHARDS=<n> literal"
+  cp "$pristine" "$victim"
+  # ...including the SINGULAR noun, which no plural/total pattern reaches.
+  printf 'EXPECTED_SHARD=3\n' >> "$victim"
+  expect 1 "a new singular EXPECTED_SHARD=<n> literal"
+  cp "$pristine" "$victim"
+
+  # THE DEFAULT-EXPANSION SHAPE: reads as derived, pins a literal whenever the
+  # env var is absent — i.e. on exactly the mis-wired job where it matters. This
+  # is the "the guard presets the variable it exists to exercise" trap that has
+  # bitten this repo repeatedly.
+  printf 'SHARD_TOTAL="${SHARD_TOTAL:-3}"\n' >> "$victim"
+  expect 1 "a new \${SHARD_TOTAL:-3} default-expansion pin"
+  cp "$pristine" "$victim"
+  printf 'total="${JOURNEY_CI_SHARD_TOTAL:-3}"\n' >> "$victim"
+  expect 1 "a new default-expansion pin named only on the inner var"
+  cp "$pristine" "$victim"
+  printf 'SHARD_COUNT="${SOME_OTHER_VAR:-3}"\n' >> "$victim"
+  expect 1 "a new default-expansion pin named only on the outer var"
+  cp "$pristine" "$victim"
+  expect 0 "restored"
+
+  # THE #4 SHAPE: an enumerated shard loop, which carries no `total` token.
+  # A total-only pattern passes this and it is the one that produced a
+  # truthful-looking "verified on all N shards" over three of them.
+  printf 'for shard in 0 1 2; do :; done\n' >> "$victim"
+  expect 1 "a new enumerated 'for shard in 0 1 2' loop"
+  cp "$pristine" "$victim"
+  printf 'for shard_idx in 0 1 2 3; do :; done\n' >> "$victim"
+  expect 1 "a new enumerated 'for shard_idx in ...' loop"
+  cp "$pristine" "$victim"
+  # ...and the same enumeration under a loop variable that says nothing about
+  # shards. #4 happened to use `shard`; `for leg in 0 1 2` is one rename away and
+  # a variable-name-only pattern is blind to it.
+  printf 'for idx in 0 1 2; do :; done\n' >> "$victim"
+  expect 1 "a new enumerated 'for idx in 0 1 2' loop"
+  cp "$pristine" "$victim"
+  printf 'for leg in 0 1 2; do :; done\n' >> "$victim"
+  expect 1 "a new enumerated 'for leg in 0 1 2' loop"
+  cp "$pristine" "$victim"
+  # ...and the two compact spellings of the same enumeration.
+  printf 'for shard in {0..5}; do :; done\n' >> "$victim"
+  expect 1 "a new brace-expansion 'for shard in {0..5}' loop"
+  cp "$pristine" "$victim"
+  printf 'for shard in $(seq 0 5); do :; done\n' >> "$victim"
+  expect 1 "a new 'for shard in \$(seq 0 5)' loop"
+  cp "$pristine" "$victim"
+  expect 0 "restored"
+
+  # SELECTIVITY — the derived forms this guard exists to encourage must NOT trip
+  # it, or the ratchet would push authors back toward literals.
+  printf 'SHARD_TOTAL="$(bash "$SCRIPT_DIR/ci-journey-shard-count.sh")"\n' >> "$victim"
+  printf 'for (( shard = 0; shard < SHARD_TOTAL; shard++ )); do :; done\n' >> "$victim"
+  expect 0 "derived total + derived loop bound are not literals"
+  cp "$pristine" "$victim"
+  # A `seq`/brace loop whose UPPER BOUND is derived is the encouraged form of the
+  # shape just banned; only a literal bound may match.
+  printf 'for idx in $(seq 0 "$((SHARD_TOTAL - 1))"); do :; done\n' >> "$victim"
+  expect 0 "a derived-bound seq loop is not a literal enumeration"
+  cp "$pristine" "$victim"
+  # Index spellings and zero are deliberately out of scope; matching them added
+  # noise (a `_MS` variable, an accumulator init) and no protection.
+  printf 'SHARD_INDEX="${SHARD_INDEX:-0}"\nshard_union_count=0\n' >> "$victim"
+  expect 0 "a shard INDEX default and a zero-valued counter are not totals"
+  cp "$pristine" "$victim"
+
+  # Prose about a literal is not a literal, or every explanatory comment (this
+  # file included) would be a violation.
+  printf '# this block used to pin shard_total=3 / for shard_idx in 0 1 2\n' >> "$victim"
+  expect 0 "a comment mentioning the old literal"
+  cp "$pristine" "$victim"
+
+  # A baselined site may go DOWN, never up.
+  local baselined="$sandbox/scripts/test-ci-journey-retry-budget.sh"
+  local before_n
+  before_n="$(grep -vE '^[[:space:]]*#' "$baselined" | grep -coiE "$RE_ANY")"
+  (( before_n > 0 )) \
+    || { echo "FAIL self-test: the baselined fixture file has no literals to lower" >&2; exit 1; }
+  printf 'EXPECTED_SHARDS=3\n' >> "$baselined"
+  expect 1 "a baselined file exceeding its accepted count"
+  # (removing the added line restores it; lowering below the baseline is fine)
+  sed -i '$d' "$baselined"
+  expect 0 "back at the accepted count"
+  checks=$((checks + 1))
+
+  # ---- --update is DOWNWARD-ONLY ------------------------------------------
+  # Without these three cases the ratchet is a suggestion: plant a literal, run
+  # the documented --update, and the violation is absorbed into the baseline —
+  # rc back to 0 with the offending file silently accepted.
+  local sb_baseline="$sandbox/$BASELINE_FILE"
+  local baseline_md5 rc
+
+  # (a) a NEW file must be refused, and the baseline left byte-identical.
+  baseline_md5="$(md5sum < "$sb_baseline")"
+  printf 'EXPECTED_SHARDS=3\n' >> "$victim"
+  rc=0; do_update "$sandbox" >/dev/null 2>&1 || rc=$?
+  (( rc != 0 )) \
+    || { echo "FAIL self-test: --update ACCEPTED a new file into the baseline" >&2; exit 1; }
+  [[ "$(md5sum < "$sb_baseline")" == "$baseline_md5" ]] \
+    || { echo "FAIL self-test: --update rewrote the baseline while refusing" >&2; exit 1; }
+  checks=$((checks + 1))
+  cp "$pristine" "$victim"
+
+  # (b) a RAISED count on an ALREADY-baselined file must be refused too — the
+  #     likelier drift, since every baselined file is a place literals live.
+  printf 'EXPECTED_SHARDS=3\n' >> "$baselined"
+  rc=0; do_update "$sandbox" >/dev/null 2>&1 || rc=$?
+  (( rc != 0 )) \
+    || { echo "FAIL self-test: --update RAISED a baselined file's accepted count" >&2; exit 1; }
+  [[ "$(md5sum < "$sb_baseline")" == "$baseline_md5" ]] \
+    || { echo "FAIL self-test: --update rewrote the baseline while refusing a raise" >&2; exit 1; }
+  checks=$((checks + 1))
+  sed -i '$d' "$baselined"
+
+  # (c) it must still RATCHET: removing a literal lowers the accepted count, so
+  #     the refusal above is downward-only rather than a dead command.
+  local lowered_from lowered_to
+  lowered_from="$(awk -F'\t' '$1=="scripts/test-ci-journey-retry-budget.sh"{print $2}' "$sb_baseline")"
+  sed -i '0,/^for shard in 0 1 2; do$/s//for shard in $(all_shards); do/' "$baselined"
+  rc=0; do_update "$sandbox" >/dev/null 2>&1 || rc=$?
+  (( rc == 0 )) \
+    || { echo "FAIL self-test: --update refused a genuine DOWNWARD move (rc=$rc)" >&2; exit 1; }
+  lowered_to="$(awk -F'\t' '$1=="scripts/test-ci-journey-retry-budget.sh"{print $2}' "$sb_baseline")"
+  (( lowered_to < lowered_from )) \
+    || { echo "FAIL self-test: --update did not lower the count ($lowered_from -> $lowered_to)" >&2; exit 1; }
+  checks=$((checks + 1))
+  # Restore the sandbox baseline so the real-tree checks below are unaffected.
+  cp "$REPO_ROOT/$BASELINE_FILE" "$sb_baseline"
+  cp "$REPO_ROOT/scripts/test-ci-journey-retry-budget.sh" "$baselined"
+  expect 0 "sandbox restored after the --update cases"
+
+  # A scan that silently matches nothing would make the guard vacuous forever.
+  local empty="$sandbox/empty-root"
+  mkdir -p "$empty/scripts"
+  local rc=0
+  scan "$empty" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" == 2 ]] \
+    || { echo "FAIL self-test: an empty scan set did not fail closed (rc=$rc)" >&2; exit 1; }
+  checks=$((checks + 1))
+
+  # The REAL tree must be clean, and must actually have found something to scan.
+  do_check "$REPO_ROOT" quiet >/dev/null \
+    || { echo "FAIL self-test: the real tree does not match its baseline" >&2; exit 1; }
+  checks=$((checks + 1))
+  local real_files
+  real_files="$(scan "$REPO_ROOT" | wc -l)"
+  (( real_files >= 5 )) \
+    || { echo "FAIL self-test: only $real_files file(s) carry literals — the scan looks broken" >&2; exit 1; }
+  checks=$((checks + 1))
+
+  (( checks == 34 )) \
+    || { echo "FAIL: self-test ran $checks checks, expected 34" >&2; exit 1; }
+  echo "PASS: check-journey-shard-literals self-test ($checks checks; $real_files baselined file(s))"
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  --update)    do_update ;;
+  --*)         echo "usage: check-journey-shard-literals.sh [--update | --self-test]" >&2; exit 1 ;;
+  *)           do_check "$REPO_ROOT" || exit 1 ;;
+esac

--- a/scripts/ci-journey-shard-count.sh
+++ b/scripts/ci-journey-shard-count.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Issue #2060 (CI Phase A): print the emulator-journey shard count, parsed from
+# the workflow matrix itself.
+#
+# WHY THIS EXISTS. Three independent places must agree on how many emulator
+# shards there are:
+#
+#   1. `.github/workflows/tests.yml` -> emulator-journey `matrix.shard`
+#   2. the same job's `POCKETSHELL_JOURNEY_CI_SHARD_TOTAL` env (the suite
+#      partitions JOURNEY_CLASSES by `hash % total`, so a _TOTAL that is LESS
+#      than the matrix length means the extra shards duplicate work, and a
+#      _TOTAL that is GREATER means some classes are SELECTED BY NOBODY and
+#      silently never run — a vacuous green of the worst kind)
+#   3. the aggregation job's `EXPECTED_SHARDS` (a count that is too low lets a
+#      missing shard's verdict go unnoticed)
+#
+# Until #2060 all three were kept aligned by hand-written "keep in sync"
+# comments, and the guards that checked them pinned the LITERAL 3. Going 3 -> 6
+# therefore meant editing the pins to a new literal, which just re-arms the same
+# drift for the next change. This helper makes the matrix the single source of
+# truth: the guards ask for the count and cross-check the other two sites
+# against it, so the assertion stays load-bearing at any N. It is also what
+# scripts/test-ci-journey-budget.sh's 125% balance cap, its (shard) end-to-end
+# acceptance block, and test-ci-journey-warm-build.sh's per-shard #1814 loop
+# read, so each polices the SHIPPED configuration rather than a total CI no
+# longer runs. scripts/check-journey-shard-literals.sh is the partial backstop:
+# a downward-only ratchet that reddens when a literal reappears in one of three
+# recognised shapes (a shard-total noun assigned a number, a `${VAR:-N}` default
+# pin, a 0-based literal loop enumeration). It is a grep over named shapes, not
+# a proof that no literal exists — its own header states what it cannot see.
+#
+# ---------------------------------------------------------------------------
+# HOW THE SHIPPED COUNT (6) WAS CHOSEN — the full derivation, kept here rather
+# than in the workflow because this file is what owns the number.
+#
+# The critical path across a matrix is the MAX leg, not the mean, and the max is
+# set by TIME, not class count: membership is by class-name hash (#1862) and
+# per-class cost spans ~6s..~363s, so legs are far less equal in seconds than in
+# count. Driving the PRODUCTION selector (select_effective_journey_classes) over
+# the real JOURNEY_CLASSES array, with each entry weighted by its measured cost
+# from `main` run 31292976490 (173 entries, 7206s of instrumentation total):
+#
+#   total  classes per leg               instrumentation per leg (s)        MAX
+#     3    61/56/56                      2716/1913/2577                    2716s
+#     4    39/41/40/53                   1957/1668/1822/1759               1957s
+#     5    37/34/29/38/35                1455/1304/1449/1766/1232          1766s
+#     6    26/27/24/35/29/32             1378/785/1273/1338/1128/1304      1378s
+#     7    19/21/20/25/40/25/23          811/1111/800/947/1655/974/908     1655s
+#     8    24/21/16/24/15/20/24/29       1295/860/1030/829/662/808/792/930 1295s
+#     9    19/19/16/19/14/19/23/23/21    1240 max (760/655/514/716/370/    1240s
+#                                        1015/1240/888/1048)
+#
+# The trap that made an earlier 4-shard proposal wrong: at total=4 the heaviest
+# leg by COUNT (53 classes) is NOT the heaviest by TIME (the 39-class leg 0, at
+# 1957s). A count-based estimate therefore picks the wrong leg AND the wrong
+# number. The cost model validates: at total=3 it predicts 60.4/47.0/58.1 min
+# against the baseline's actual 60.7/47.0/57.7, and the per-leg residual (fixed
+# overhead) is 906s +/- 23s while instrumentation varies by 42% across legs.
+#
+# SIX IS A CHOSEN TRADE-OFF, NOT THE MEASURED OPTIMUM. The ladder is not
+# monotonic — 7 is genuinely WORSE than 6 (hash clustering drops 40 classes and
+# 1655s on one leg, and it fails #1850 AC2 below) — but it does not stop
+# improving at 6 either: 8 (1295s max leg, tightest headroom 571s) and 9 (1240s,
+# 626s) both beat 6 on max leg AND both still clear #1850's bar. Six is chosen
+# because it is the FIRST point that clears every bar, and because what more
+# buys is small and what it costs is not: 8 saves ~1.4 min of max-leg wall clock
+# (36.7 vs 38.1 min, since the ~908s fixed per-leg overhead dominates from here)
+# for +2 concurrent runners against an explicitly budgeted 20-job Actions
+# ceiling. Do not read this as "adding shards no longer helps" — read it as
+# "past 6 the wall-clock return per runner stops being worth it".
+#
+# Fixed per-leg overhead, measured: warm build ~480s + intra-suite ~200s + job
+# setup ~230s ~= 15 min. So the max leg is 60.4 -> 47.8 -> 44.6 -> 38.1 min for
+# total 3/4/5/6, and `main` (dex ~6.3 + max leg + aggregate verdict ~0.3) is
+# ~67 -> ~54 -> ~51 -> ~44 min. The <=55 min target is missed by 3 shards, sat
+# essentially ON by 4, and cleared by 5 and 6.
+#
+# #1850 (cold-boot retry affordability) is what picks 6 over 5, and it is worth
+# being exact about WHY, because "every leg reports retry_affordable=true" is
+# NOT #1850's bar. Its AC2 is:
+#
+#   "Every shard's post-change drift headroom is measured and is larger than the
+#    cost of one twice-failing journey class on that shard"   (body scale ~420s)
+#
+# Driving the PRODUCTION scripts/ci-journey-retry-budget.sh — which reproduces
+# all three baseline shards' published required/remaining byte-for-byte — with
+# the WORST observed value of every fixed constant, and MEASURING headroom by
+# adding instrumentation to a leg until the script flips the verdict:
+#
+#   total=3  all three legs affordable=false (as observed on real runs)
+#   total=4  leg 0 needs 49.9 min vs 46.7 remaining -> STILL false
+#   total=5  every leg affordable, but headroom 411/562/417/100/634 s —
+#            THREE legs under the ~420s bar, and the 100s leg is the one hosting
+#            the 330s ReconnectStormLivelockE2eTest, so a single in-suite flake
+#            of that class puts it straight back to
+#            insufficient_remaining_budget. #1850 documents exactly this
+#            anti-correlation: the run that needs the retry is the run that
+#            cannot afford it. Five is "affordable when nothing goes wrong",
+#            which #1850 explicitly rejects as not-resilience.
+#   total=6  headroom 488/1081/593/528/738/562 s — EVERY leg over the bar, and
+#            every leg survives its own heaviest class running twice (leg 0
+#            carries the 330s storm test and still has 488s).
+#   total=7  headroom 211s on leg 4 — NOT MET, and that leg cannot afford its
+#            own heaviest class twice. Seven fails #1850 outright.
+#   total=8  571s   total=9  626s — both MET, see the trade-off note above.
+#
+# So 6, not 5, is what actually closes #1850 AC2. Growth headroom at 6 is ~488s
+# on the tightest leg (~35% of that leg's instrumentation) before the retry
+# becomes unaffordable again; that is the number to watch as the registry grows.
+#
+# HONEST CAVEAT, because #1850 AC2 says MEASURED. Everything above is arithmetic:
+# the PRODUCTION selector and the PRODUCTION retry-budget script, but driven over
+# one run's (31292976490) per-class costs plus worst-case fixed constants — a
+# projection, not an observation of six shards. It is a well-grounded one (the
+# model reproduces all three of that run's published required/remaining values to
+# under 10 ms, and the constants used are at or beyond the worst observed), and
+# it is the strongest evidence obtainable before six shards have ever run. But
+# the genuinely measured per-shard `retry_remaining_ms` at total=6 only exists
+# after the first 6-shard `main` run. Read those numbers before treating #1850's
+# AC2 as observed rather than projected.
+#
+# It fails CLOSED. An unreadable, missing, empty, or non-contiguous matrix is an
+# error, never a silent default — a helper that guessed would turn every caller
+# into a vacuous check.
+#
+# Usage:  scripts/ci-journey-shard-count.sh [WORKFLOW]
+#         scripts/ci-journey-shard-count.sh --self-test
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+DEFAULT_WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
+
+die() { echo "ci-journey-shard-count: $*" >&2; exit 1; }
+
+shard_count() {
+  local workflow="$1"
+  [[ -f "$workflow" ]] || die "workflow not found: $workflow"
+
+  # Slice the emulator-journey job so a matrix belonging to some other job (now
+  # or later) can never be read by mistake.
+  local job
+  job="$(
+    awk '
+      /^  emulator-journey:$/            { in_job = 1; next }
+      in_job && /^  [A-Za-z0-9_-]+:$/    { in_job = 0 }
+      in_job                             { print }
+    ' "$workflow"
+  )"
+  [[ -n "$job" ]] || die "could not locate the emulator-journey job in $workflow"
+
+  local raw
+  raw="$(printf '%s\n' "$job" | sed -n 's/^ *shard: *\[\(.*\)\] *$/\1/p')"
+  [[ -n "$raw" ]] \
+    || die "emulator-journey has no inline 'shard: [...]' matrix in $workflow"
+  [[ "$(printf '%s\n' "$raw" | wc -l)" -eq 1 ]] \
+    || die "emulator-journey declares more than one 'shard: [...]' matrix"
+
+  local -a shards=()
+  local token
+  IFS=',' read -r -a shards <<<"$raw"
+  local i=0
+  for token in "${shards[@]}"; do
+    token="${token//[[:space:]]/}"
+    [[ "$token" =~ ^[0-9]+$ ]] \
+      || die "non-numeric shard id '$token' in matrix [$raw]"
+    # The suite selects with `hash % total == index`, so the ids MUST be exactly
+    # 0..N-1. A gap or a duplicate silently drops or doubles a slice.
+    (( token == i )) \
+      || die "shard matrix must be contiguous 0..N-1, got [$raw] (expected $i at position $i)"
+    (( i++ ))
+  done
+  (( i > 0 )) || die "empty shard matrix in $workflow"
+  printf '%s\n' "$i"
+}
+
+self_test() {
+  local sandbox checks=0
+  sandbox="$(mktemp -d)"
+  # EXIT, not RETURN: `die` exits the whole script, so a RETURN trap would leak
+  # the sandbox on exactly the paths the self-test is exercising.
+  # shellcheck disable=SC2064
+  trap "rm -rf '$sandbox'" EXIT
+
+  write_wf() {
+    printf 'jobs:\n  other-job:\n    strategy:\n      matrix:\n        shard: [0, 1, 2, 3, 4, 5, 6]\n  emulator-journey:\n    strategy:\n      matrix:\n        shard: [%s]\n  emulator-journey-verdict:\n    steps: []\n' \
+      "$1" > "$sandbox/wf.yml"
+  }
+
+  expect_count() {   # $1 = matrix body, $2 = expected count
+    write_wf "$1"
+    local got
+    got="$(shard_count "$sandbox/wf.yml")" \
+      || { echo "FAIL: self-test could not parse matrix [$1]" >&2; exit 1; }
+    [[ "$got" == "$2" ]] \
+      || { echo "FAIL: matrix [$1] parsed as $got, expected $2" >&2; exit 1; }
+    checks=$((checks + 1))
+  }
+
+  expect_reject() {  # $1 = matrix body
+    write_wf "$1"
+    # `die` calls `exit`, which would terminate this SCRIPT even from an `if`
+    # condition — the subshell is what makes the rejection observable instead of
+    # silently ending the self-test early (and reading as a pass-shaped exit).
+    if ( shard_count "$sandbox/wf.yml" ) >/dev/null 2>&1; then
+      echo "FAIL: self-test ACCEPTED an invalid matrix [$1]" >&2
+      exit 1
+    fi
+    checks=$((checks + 1))
+  }
+
+  expect_count "0, 1, 2" 3
+  expect_count "0, 1, 2, 3" 4
+  expect_count "0" 1
+  # Fail-closed cases. Each of these, if it silently returned a number, would
+  # make every caller's cross-check vacuous.
+  expect_reject "0, 1, 3"        # gap -> a hash bucket nobody runs
+  expect_reject "1, 2, 3"        # does not start at 0
+  expect_reject "0, 1, 1"        # duplicate
+  expect_reject "0, x"           # non-numeric
+  expect_reject ""               # empty
+
+  # A missing emulator-journey job must be an error, not a default.
+  printf 'jobs:\n  unit:\n    steps: []\n' > "$sandbox/wf.yml"
+  if ( shard_count "$sandbox/wf.yml" ) >/dev/null 2>&1; then
+    echo "FAIL: self-test ACCEPTED a workflow with no emulator-journey job" >&2
+    exit 1
+  fi
+  checks=$((checks + 1))
+
+  # The real workflow must parse.
+  local real
+  real="$(shard_count "$DEFAULT_WORKFLOW")" || exit 1
+  (( real >= 3 )) || { echo "FAIL: real workflow reports $real shards" >&2; exit 1; }
+  checks=$((checks + 1))
+
+  (( checks == 10 )) \
+    || { echo "FAIL: self-test ran $checks checks, expected 10" >&2; exit 1; }
+  echo "PASS: ci-journey-shard-count self-test ($checks checks; real workflow = $real shards)"
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  --*)         die "usage: ci-journey-shard-count.sh [WORKFLOW | --self-test]" ;;
+  *)           shard_count "${1:-$DEFAULT_WORKFLOW}" ;;
+esac

--- a/scripts/journey-shard-literal-baseline.txt
+++ b/scripts/journey-shard-literal-baseline.txt
@@ -1,0 +1,49 @@
+# hardcoded emulator-journey shard-total baseline (issue #2060)
+# format: <file>\t<accepted-shard-total-literal-count>
+#
+# The shard count is owned by `matrix.shard` in .github/workflows/tests.yml and
+# read via scripts/ci-journey-shard-count.sh. Every site below is a SELF-
+# CONTAINED SANDBOX FIXTURE: the guard builds N synthetic inputs and tells the
+# code under test to expect N, so the property is total-invariant and the number
+# is a cheap sample rather than a claim about the shipped configuration.
+#
+#   ci-journey-class-selection-functions.sh   the production selector's own
+#       fail-safe defaults (JOURNEY_CI_SHARD_TOTAL=1 when the env var is unset,
+#       non-numeric, or < 1) — an unsharded run, not a shard count.
+#   test-ci-journey-infra-signature.sh        3 synthetic shard verdict dirs
+#   test-ci-journey-pre-journey-classification.sh   ditto
+#   test-ci-journey-retry-budget.sh           ditto (+ an EXPECTED_SHARDS=1
+#       single-shard case, a display-string fixture, and two `for … in 0 1 2`
+#       loops that walk the SAME 3 synthetic dirs the case just seeded)
+#   test-ci-journey-summary-evidence.sh       ditto, plus SOLO_SHARD_TOTAL=400,
+#       a deliberately huge total chosen so exactly ONE class is selected
+#   test-ci-journey-warm-build.sh             3 synthetic shard verdict dirs for
+#       the aggregate reducer, seeded and walked by `for idx in 0 1 2` under a
+#       matching EXPECTED_SHARDS=3 (its per-shard SHIPPED-configuration loop,
+#       the #1814 one, derives the real total and is NOT here)
+#   test-ci-journey-inter-attempt-cleanup.sh  a two-run cleanup fixture
+#   test-ci-journey-budget.sh                 shard_total_probe=3, the
+#       hash-stability probe — the property (stable, disjoint, complete under
+#       edits) holds at any total; its shipped-configuration assertions (the
+#       125% balance cap and the (shard) end-to-end block) read the matrix.
+#
+# A site that asserts something about the SHIPPED configuration does NOT belong
+# here — it belongs on scripts/ci-journey-shard-count.sh.
+#
+# regenerate with: scripts/check-journey-shard-literals.sh --update
+# That command is DOWNWARD-ONLY: it lowers a count or drops a file and REFUSES
+# to raise one, so a new literal cannot be absorbed by running it. The counts
+# below were last hand-raised deliberately in #2060 round 4, when the DETECTOR
+# was widened (default-expansion pins `${SHARD_TOTAL:-3}`, `shard_count=`, and
+# 0-based enumerations under any loop variable): +1 selection-functions (the
+# `:-1` fail-safe), +1 retry-budget and +2 warm-build (`for idx in 0 1 2` over
+# synthetic verdict dirs). Widening the detector is the only reason to hand-raise
+# a number here; a raise because the CODE grew a literal is the drift itself.
+scripts/ci-journey-class-selection-functions.sh	3
+scripts/test-ci-journey-budget.sh	1
+scripts/test-ci-journey-infra-signature.sh	1
+scripts/test-ci-journey-inter-attempt-cleanup.sh	1
+scripts/test-ci-journey-pre-journey-classification.sh	1
+scripts/test-ci-journey-retry-budget.sh	7
+scripts/test-ci-journey-summary-evidence.sh	3
+scripts/test-ci-journey-warm-build.sh	3

--- a/scripts/test-ci-journey-aggregate-verdict.sh
+++ b/scripts/test-ci-journey-aggregate-verdict.sh
@@ -368,8 +368,16 @@ grep -q 'emulator-journey-verdict-shard-' "$WORKFLOW" \
   || fail "(w7) each shard must upload an emulator-journey-verdict-shard-<N> token artifact"
 grep -q 'pattern: emulator-journey-verdict-shard-\*' "$WORKFLOW" \
   || fail "(w8) aggregation job must download the shard verdict artifacts by pattern"
-grep -q 'EXPECTED_SHARDS: 3' "$WORKFLOW" \
-  || fail "(w9) aggregation job must pass EXPECTED_SHARDS matching the 3-shard matrix"
+# Issue #2060: this used to pin the LITERAL `EXPECTED_SHARDS: 3`, so changing
+# the matrix meant editing the pin to a new literal — which re-arms the same
+# drift every time. Derive the matrix length instead and CROSS-CHECK the
+# aggregation job's expectation against it, so the assertion keeps its force at
+# any shard count. An EXPECTED_SHARDS below the matrix length would let a
+# missing shard's verdict pass unnoticed (the #1458 rollup's whole job).
+workflow_shards="$(bash "$SCRIPT_DIR/ci-journey-shard-count.sh" "$WORKFLOW")" \
+  || fail "(w9) could not derive the emulator-journey shard count from the matrix"
+grep -q "EXPECTED_SHARDS: ${workflow_shards}\$" "$WORKFLOW" \
+  || fail "(w9) aggregation job must pass EXPECTED_SHARDS: ${workflow_shards} to match the ${workflow_shards}-shard matrix (found: $(grep -n 'EXPECTED_SHARDS:' "$WORKFLOW" | tr '\n' ' '))"
 pass "(w) classify continue-on-error + verdict tokens + aggregation job wired in tests.yml"
 
 # The #1458 budget-neutral emulator/Gradle contention cuts. Count only the

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -1972,11 +1972,18 @@ pass "(shard-stable-det) the partition is identical under 4 locales and under a 
 #     actually catches a broken/collapsing hash.
 #
 #   `budget` — additionally, an UPPER cap at 125% of the ideal share, applied
-#     only to the total=3 configuration CI really runs. A shard 25% over its
-#     share spends 25% more wall-clock against the #835 suite budget, so it is
-#     worth a human look. Only the upper bound is capped: an UNDER-full shard
-#     costs nothing, and capping it too would double the false-trip surface for
-#     no benefit.
+#     to the configuration CI really runs. A shard 25% over its share spends 25%
+#     more wall-clock against the #835 suite budget, so it is worth a human look.
+#     Only the upper bound is capped: an UNDER-full shard costs nothing, and
+#     capping it too would double the false-trip surface for no benefit.
+#
+#     Issue #2060: that total used to be the literal `3`, so when the matrix went
+#     to 5 the SHIPPED configuration would have been left covered by the loose
+#     3-sigma band and by NO budget cap at all — the guard would have kept
+#     asserting balance for a total CI no longer runs. The shipped total is now
+#     read from the matrix itself via scripts/ci-journey-shard-count.sh, so the
+#     cap follows the workflow and cannot drift off it again. (That helper is
+#     itself self-tested in the same `guards-ci-harness` job.)
 #
 # Characterised over the REAL list at three totals and over synthetic 60/300-class
 # lists, so the property is measured across sizes rather than sampled once.
@@ -2008,8 +2015,14 @@ assert_balanced() {   # $1 = label, $2 = total, $3 = budget|uniform, classes on 
     echo "  ok: balance $label total=$total -> ${counts[*]} (ideal $ideal, uniform band [$low,$high])"
   fi
 }
-assert_balanced "real" 3 budget  < "$SANDBOX/classes-base.txt"
+# Issue #2060: the budget cap applies to whatever the matrix actually ships.
+shipped_shard_total="$("$SCRIPT_DIR/ci-journey-shard-count.sh")" \
+  || fail "(shard-balance) could not read the shipped shard total from the tests.yml matrix"
+[[ "$shipped_shard_total" =~ ^[0-9]+$ && "$shipped_shard_total" -ge 2 ]] \
+  || fail "(shard-balance) implausible shipped shard total '$shipped_shard_total' from the tests.yml matrix"
+assert_balanced "real(shipped)" "$shipped_shard_total" budget < "$SANDBOX/classes-base.txt"
 assert_balanced "real" 2 uniform < "$SANDBOX/classes-base.txt"
+assert_balanced "real" 3 uniform < "$SANDBOX/classes-base.txt"
 assert_balanced "real" 4 uniform < "$SANDBOX/classes-base.txt"
 for synth_n in 60 300; do
   seq 1 "$synth_n" \
@@ -2054,7 +2067,7 @@ tilt_out="$SANDBOX/balance-tilted.log"
   && fail "(shard-balance) red control is not live: a shard one class over the 125% budget cap passed the budget check"
 grep -q 'budget cap' "$tilt_out" \
   || { cat "$tilt_out"; fail "(shard-balance) the tilted control ($tilt_target of $real_class_count on one shard) failed for the wrong reason — it must trip the 125% BUDGET CAP, not the uniform band"; }
-pass "(shard-balance) the partition is uniform to 3 sigma on the real list (totals 2/3/4) and on synthetic 60/300-class lists, and stays under the 125% budget cap at total=3; degenerate and tilted partitions are both rejected"
+pass "(shard-balance) the partition is uniform to 3 sigma on the real list (totals 2/3/4) and on synthetic 60/300-class lists, and stays under the 125% budget cap at the SHIPPED total read from the tests.yml matrix (currently $shipped_shard_total); degenerate and tilted partitions are both rejected"
 
 # ---------------------------------------------------------------------------
 # (shard) ACCEPTANCE — Issue #835 (REOPENED): CI-matrix sharding partitions
@@ -2070,6 +2083,13 @@ pass "(shard-balance) the partition is uniform to 3 sigma on the real list (tota
 # by class-name hash, which is statistically rather than exactly balanced. The
 # tight per-shard spread is pinned separately by (shard-balance) above; what THIS
 # block owns is that the end-to-end suite really runs the partition it computes.
+#
+# Issue #2060: "the partition it computes" means the SHIPPED one. This block used
+# to pin `shard_total=3` / `for shard_idx in 0 1 2` — 70 lines below the balance
+# cap that had the same literal — so after the matrix grew it would have driven
+# the end-to-end suite over a 3-way partition CI no longer runs, leaving the real
+# upper legs never exercised end-to-end. It now reads the shipped total from the
+# matrix like every other shipped-configuration assertion in this file.
 echo "== CI-matrix sharding: hash partition is disjoint + complete =="
 cat > "$SANDBOX/gradlew" <<'STUB'
 #!/usr/bin/env bash
@@ -2077,10 +2097,12 @@ exit 0
 STUB
 chmod +x "$SANDBOX/gradlew"
 
-shard_total=3
+shard_total="$shipped_shard_total"
+[[ "$shard_total" =~ ^[0-9]+$ && "$shard_total" -ge 2 ]] \
+  || fail "(shard) implausible shipped shard total '$shard_total' — refusing to drive the suite over an unknown partition"
 declare -A seen_class_shard=()
 shard_union_count=0
-for shard_idx in 0 1 2; do
+for (( shard_idx = 0; shard_idx < shard_total; shard_idx++ )); do
   shard_log="$SANDBOX/run-shard-$shard_idx.log"
   set +e
   PATH="$STUBBIN:$PATH" \
@@ -2110,7 +2132,7 @@ for shard_idx in 0 1 2; do
 done
 [[ "$shard_union_count" -eq "$class_count" ]] \
   || fail "(shard) union of all shards = $shard_union_count classes, expected the full $class_count (a class ran on no shard or twice)"
-pass "(shard) hash partition: 3 shards each ~1/3, disjoint, union = all $class_count classes; proofs on every shard"
+pass "(shard) hash partition: the SHIPPED $shard_total shards each ~1/$shard_total, disjoint, union = all $class_count classes; proofs on every shard"
 
 # ---------------------------------------------------------------------------
 # (m) ACCEPTANCE — Issue #835 (REOPENED): the six core-terminal proofs are now

--- a/scripts/test-ci-journey-warm-build.sh
+++ b/scripts/test-ci-journey-warm-build.sh
@@ -48,7 +48,12 @@ SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
 COLD_SECS=6
-SHARD_TOTAL=3
+# Issue #2060: mirror the REAL matrix instead of a hardcoded 3. This fixture
+# asserts the #1814 warm-build property once per shard, each with its own first
+# class — so with a hardcoded total it would have stopped covering the shard the
+# 3 -> 4 change added, and a per-shard regression there would be invisible.
+SHARD_TOTAL="$(bash "$SCRIPT_DIR/ci-journey-shard-count.sh" "$WORKFLOW")" \
+  || { echo "TEST FAIL: could not derive the shard count from the matrix" >&2; exit 1; }
 
 # Issue #1862: shard membership is derived from the CLASS NAME, not the array
 # index, so a fixture that needs "the class shard N runs first" must ASK the real
@@ -268,7 +273,12 @@ passed_elapsed() {
 echo "== #1814 AC1/AC4: the first class on a shard is not charged for the cold build =="
 echo "   (gradle stub: the first APK-producing invocation costs ${COLD_SECS}s, later ones are up-to-date)"
 
-for shard in 0 1 2; do
+# Issue #2060: the loop bound is the SHIPPED total, not a literal 0 1 2. Deriving
+# SHARD_TOTAL above while still enumerating three shards here would have made the
+# `(ac4) verified on all $SHARD_TOTAL shards` line below assert something it had
+# not done — it would print "all 6 shards" having exercised 0/1/2 only, and a
+# regression on the upper legs would be invisible behind a truthful-looking pass.
+for (( shard = 0; shard < SHARD_TOTAL; shard++ )); do
   fixed_log="$SANDBOX/fixed-shard-$shard.log"
   mutant_log="$SANDBOX/mutant-shard-$shard.log"
   run_suite "$FIXED_REPO" "$shard" "$fixed_log" "$SANDBOX/state-fixed-$shard" \

--- a/scripts/test-ci-mobile-rtt-readiness.sh
+++ b/scripts/test-ci-mobile-rtt-readiness.sh
@@ -15,19 +15,36 @@ pass() { echo "PASS: $*"; }
 
 [[ -f "$WORKFLOW" ]] || fail "workflow not found: $WORKFLOW"
 
-# The readiness step must remain inside the three-shard emulator job and before
-# the action that launches ci-journey-suite.sh. One shared matrix job definition
-# means this ordering is exercised independently by shards 0, 1, and 2.
-python3 - "$WORKFLOW" <<'PY' || fail "mobile-RTT readiness is not on the exact three-shard journey path"
+# The readiness step must remain inside the SHARDED emulator job and before the
+# action that launches ci-journey-suite.sh. One shared matrix job definition
+# means this ordering is exercised independently by every shard.
+#
+# Issue #2060: this used to assert the literal `shard: [0, 1, 2]`, which the
+# 3 -> 4 shard change would simply have re-pinned to a new literal. It now takes
+# the matrix length from scripts/ci-journey-shard-count.sh (which itself rejects
+# a gapped / non-zero-based / duplicated matrix) and CROSS-CHECKS the job's
+# POCKETSHELL_JOURNEY_CI_SHARD_TOTAL against it. That pairing is the property
+# that actually matters and nothing checked before: the suite selects classes
+# with `hash % TOTAL == INDEX`, so a _TOTAL LARGER than the matrix leaves whole
+# hash buckets SELECTED BY NO SHARD — every class in them silently stops running
+# while the gate still reports green.
+shard_total="$(bash "$SCRIPT_DIR/ci-journey-shard-count.sh" "$WORKFLOW")" \
+  || fail "could not derive the emulator-journey shard count from the matrix"
+python3 - "$WORKFLOW" "$shard_total" <<'PY' || fail "mobile-RTT readiness is not on the exact sharded journey path"
 import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text()
+shard_total = int(sys.argv[2])
 job_start = text.index("\n  emulator-journey:\n")
 job_end = text.index("\n  emulator-journey-verdict:\n", job_start)
 job = text[job_start:job_end]
 
-assert "shard: [0, 1, 2]" in job
+assert shard_total >= 3, f"emulator-journey must stay sharded, got {shard_total}"
+assert f"POCKETSHELL_JOURNEY_CI_SHARD_TOTAL: {shard_total}" in job, (
+    "POCKETSHELL_JOURNEY_CI_SHARD_TOTAL must equal the matrix length "
+    f"({shard_total}); a mismatch silently drops or duplicates journey classes"
+)
 readiness = job.index(
     "- name: Start Docker fixture (mobile RTT packet-loss proxy, issue #1876)"
 )


### PR DESCRIPTION
Phase A of the #2059 test-speed analysis: **workflow and config changes only — zero tests removed, skipped, retimed, or weakened.**

## What was wrong

Measured on the green v0.4.42 run ([31292976490](https://github.com/alexeygrigorev/pocketshell/actions/runs/31292976490)), ~99 min wall clock:

- `emulator-journey` had `needs: [unit, python, integration]`, so the shards did not start until the ~39-min Unit job finished — **~37 min of pure queueing**.
- The Unit job was ~19 min of Gradle plus **~20 min of ~25 serial guard steps**, three of which are documented as "cheap (<15s)" and had grown to ~5 min each.
- Both CI invocations were sized for "7 GB RAM and 2 cores" — the runner GitHub retired for public repos in early 2024.

## What changed

- Emulator shards gate on a cheap `dex` fast-fail (assembleDebug + dex ratchet, extracted from Unit) instead of the full test run. Keeps the cost protection; recovers the queueing.
- Guards split into `guards-static` / `guards-ci-harness` / `dex`, with a ~10s `unit-gate` job carrying the literal name `Unit tests` that branch protection requires. **Renaming that job would have silently demoted every guard to non-blocking** until someone hand-edited the ruleset.
- `--max-workers=2 → 4`; `org.gradle.parallel` stays false so peak memory is unchanged. `--parallel`/`maxParallelForks` deliberately not bundled (they multiply live forks — the fake `IR lowering` OOM class).
- **Six shards.** The critical path is the slowest leg by *time*, not class count. #1850 AC2 requires headroom larger than one twice-failing class (~420s); five leaves three legs under it, six gives every leg ≥488s and survives its heaviest class double-running.

## Four hardcoded shard literals

Including `test-ci-journey-warm-build.sh` printing `(ac4) verified on all 6 shards` having exercised three — a false claim in a pass line. Pinned by a new downward-only ratchet catching both the totals and enumerated-loop spellings.

## Honest limits

`main` ~44 min and per-PR ~21 min are **derived estimates**; the payoff is only observable post-merge. Six is a cost/benefit choice, **not** a measured optimum — 8 and 9 are faster and also meet AC2, at +2/+3 runners. The #1850 AC2 arithmetic closes at six but AC2 says *measured*, so **#1850 stays open** pending the first 6-shard `main` run.

## Verification

Reviewer APPROVED after four rounds. Independently reproduced: the three-way `12362 / 24` coverage invariant (CI-shape run = canonical gate = v0.4.42 baseline, per-task identical); the `unit-gate` 16/16 matrix including skipped/cancelled → rc=1; 40/40 base steps present; the cost model validated against published baseline retry values to <10 ms; six attacks on the ratchet all refused with the baseline md5 unchanged; the three baseline raises mechanically audited as detector-widening only.

Closes #2060