### PR TITLE
composer: reclaim the sheet's dead band and the self-inflicted keyboard budget (#1622)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/ComposerResendAllImeProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/ComposerResendAllImeProofTest.kt
@@ -20,11 +20,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -167,12 +167,8 @@ class ComposerResendAllImeProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/Issue1622ComposerSheetGeometryProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/Issue1622ComposerSheetGeometryProofTest.kt
@@ -1,0 +1,564 @@
+package com.pocketshell.app.composer
+
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.insets.SyntheticImeStage
+import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1622 — the composer sheet's DEAD BAND, measured on the real production
+ * `ModalBottomSheet`, in both keyboard states.
+ *
+ * ## The reported problem
+ *
+ * The maintainer reported this seven times (#567 -> #615 -> #682 -> #765 ->
+ * #790 -> #801 -> #1622) and again on-device on v0.4.42. Measured by pixel scan
+ * of his two 1080x2400 screenshots (density 2.625): the distance from the sheet's
+ * top edge to the top of the grabber bar is **176 px = 67 dp in BOTH keyboard
+ * states**, against Material's designed 22 dp. And keyboard-up the draft field
+ * was 54 dp inside a 204 dp sheet — 26 % editor, the rest chrome and emptiness.
+ *
+ * Three mechanisms, all asserted here:
+ *
+ *  - **A** — `contentWindowInsets` carried `Top`, and `windowInsetsPadding` is
+ *    not position aware, so a sheet floating far below the status bar still paid
+ *    the device's full 45 dp top inset as painted nothing.
+ *  - **B** — Material's default drag handle spends 48 dp on a 4 dp bar.
+ *  - **C** — `SheetContent` capped its body to `maxHeight - (ime - navBars)`
+ *    while material3 1.3.2 had **already** IME-padded the sheet container
+ *    (`ModalBottomSheetKt$ModalBottomSheet$3`). The keyboard was subtracted
+ *    twice, holding the body to ~173 dp of a genuinely available ~485 dp. The
+ *    famous "~175 dp is all there is" budget the whole chain divided up was
+ *    self-inflicted.
+ *
+ * ## Why this test had to be written this way (the July false-negative)
+ *
+ * A previous audit pass declared mechanism A a non-defect after measuring 22 dp
+ * on an AVD. It was right about the AVD and wrong about the app: **a modal's
+ * window on a plain emulator reports a ~0 top inset**, so mechanism A is
+ * invisible there and an emulator-default screenshot passes with the bug fully
+ * present. That is the G4/#780 class of proof failure.
+ *
+ * So this proof does not rely on the device producing the failing state. It
+ * mounts the PRODUCTION [ComposerModalBottomSheet] (real Material sheet, its own
+ * window, real `contentWindowInsets`, real drag handle, real #1744 anchor
+ * policy) and drives the state through [SyntheticImeStage], which dispatches a
+ * synthetic status-bar / nav-bar / `Type.ime()` inset set to **every attached
+ * app window root including the modal's own**, and HARD-asserts the dispatch
+ * landed. No `assumeTrue`, no skip: an environment that cannot reach the state
+ * fails.
+ *
+ * ## What is asserted, and why these are the load-bearing numbers
+ *
+ *  1. **Chrome** = `sheet surface height - sheet content height`. That is
+ *     precisely "everything painted above the first line of composer content",
+ *     i.e. mechanisms A + B together, and it is placement-independent (it does
+ *     not care where the anchor put the sheet). It must equal
+ *     [ComposerDragHandleBlockHeight] — asserted from BOTH sides, so deleting
+ *     the grabber to win the number fails too. On base this reads
+ *     `48 + statusBarInset` in every state.
+ *  2. **Editor ceiling**, keyboard-up, saturated (long draft + Offline banner +
+ *     staged attachments): the draft field must reach its designed 220 dp cap.
+ *     On base mechanism C holds it to roughly 100 dp in the same state.
+ *  3. **The four constraints that have each already cost a regression** —
+ *     #1619 (the editor is the weighted element and keeps native caret-follow),
+ *     #567/#682/#1744 (Send / mic / attach stay fully above the keyboard,
+ *     containment not `assertIsDisplayed`), #1613 (status banners stay in the
+ *     bounded region ABOVE the draft), #2057 (attachment tiles stay BELOW it).
+ *     Reclaiming space is only a fix if it does not re-break these.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(AndroidJUnit4::class)
+class Issue1622ComposerSheetGeometryProofTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val stage by lazy { SyntheticImeStage(compose) }
+
+    /** Material's real Surface height, read through the same seam #1744 uses. */
+    @Volatile
+    private var sheetSurfaceHeightPx: Int = 0
+
+    @Volatile
+    private var sheetState: SheetState? = null
+
+    @Volatile
+    private var sheetScope: CoroutineScope? = null
+
+    @After
+    fun releaseSyntheticInsets() {
+        runCatching { stage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = false) }
+        runCatching { stage.hideRealImeBestEffort() }
+    }
+
+    // ------------------------------------------------------------------
+    // Mechanisms A + B — the standing chrome, both keyboard states
+    // ------------------------------------------------------------------
+
+    @Test
+    fun emptyComposerSpendsOnlyTheGrabberOnChromeKeyboardDown() {
+        val geometry = mountAndMeasure(state = emptyDraftState(), keyboardUp = false)
+        assertChromeIsGrabberOnly(geometry)
+        // Keyboard-down the header is the browse/decide affordance and stays.
+        assertTrue(
+            "Keyboard-down the composer header must still render. ${geometry.log}",
+            nodeExists(COMPOSER_CLOSE_TAG),
+        )
+        assertControlsReachable(geometry)
+    }
+
+    @Test
+    fun emptyComposerSpendsOnlyTheGrabberOnChromeKeyboardUp() {
+        val geometry = mountAndMeasure(state = emptyDraftState(), keyboardUp = true)
+        assertChromeIsGrabberOnly(geometry)
+        assertControlsReachable(geometry)
+    }
+
+    /**
+     * Keyboard-DOWN with a draft long enough that the sheet is taller than half
+     * the screen. Material then offers a `PartiallyExpanded` anchor and, per #234,
+     * the composer deliberately RESTS there so the terminal stays visible behind
+     * it — the tail of the sheet hangs below the screen until the user swipes up.
+     *
+     * So this case performs that swipe (`SheetState.expand()`, the same anchor the
+     * user's drag lands on) when the sheet is resting partially, and HARD-asserts
+     * the Expanded anchor either way before judging reachability. It is not an
+     * excuse for a failing assertion: on base this sheet sits 111 px past the
+     * screen bottom BY DESIGN, and asserting nav-bar clearance on a state the
+     * product intends to be off-screen would be asserting the wrong thing.
+     *
+     * Worth recording: after #1622 this sheet is short enough that Material offers
+     * no partial anchor at all here, so the swipe is now a no-op on this device —
+     * the reclaimed chrome moved a saturated keyboard-down composer from
+     * "hangs off the bottom until you drag it" to "fits". The branch stays because
+     * a taller font scale or a shorter screen puts it back over the threshold. The
+     * chrome measurement is anchor-independent and is taken in the same run.
+     */
+    @Test
+    fun longDraftComposerSpendsOnlyTheGrabberOnChromeKeyboardDown() {
+        val geometry = mountAndMeasure(
+            state = longDraftState(),
+            keyboardUp = false,
+            expandPartialAnchor = true,
+        )
+        assertChromeIsGrabberOnly(geometry)
+        assertControlsReachable(geometry)
+    }
+
+    // ------------------------------------------------------------------
+    // Mechanism C — the reclaimed room reaches the DRAFT, keyboard-up
+    // ------------------------------------------------------------------
+
+    @Test
+    fun longDraftEditorReachesItsDesignedCeilingKeyboardUp() {
+        val geometry = mountAndMeasure(state = longDraftState(), keyboardUp = true)
+        assertChromeIsGrabberOnly(geometry)
+        assertEditorReachesDesignedCeiling(geometry)
+        assertControlsReachable(geometry)
+    }
+
+    /**
+     * The saturated keyboard-up state — long draft, Offline banner in the status
+     * region, two staged attachments below the field. This is the state every
+     * previous round tuned constants against on the phantom ~175 dp budget, so it
+     * is where mechanism C bites hardest and where the four regression
+     * constraints are most likely to be traded away for room.
+     */
+    @Test
+    fun saturatedComposerKeepsCeilingBannersTilesAndControlsKeyboardUp() {
+        val geometry = mountAndMeasure(state = saturatedState(), keyboardUp = true)
+
+        assertChromeIsGrabberOnly(geometry)
+        assertEditorReachesDesignedCeiling(geometry)
+        assertControlsReachable(geometry)
+
+        // #1613: the Offline banner lives in the bounded status region ABOVE the
+        // draft, never in the sticky bottom chrome and never below the editor.
+        val banner = boundsHeightAwareOf(COMPOSER_CONNECTION_LOST_TAG)
+        val draft = boundsHeightAwareOf(COMPOSER_DRAFT_TAG)
+        assertTrue(
+            "#1613: the Offline banner must sit ABOVE the draft field. " +
+                "bannerBottom=${banner.bottom} draftTop=${draft.top} ${geometry.log}",
+            banner.bottom <= draft.top + geometry.slopPx,
+        )
+        stage.assertFullyAboveKeyboard(
+            COMPOSER_CONNECTION_LOST_TAG,
+            geometry.modalRoot,
+            geometry.keyboardTopPx,
+        )
+
+        // #2057: staged tiles stay BELOW the draft field.
+        val tiles = boundsHeightAwareOf(COMPOSER_ATTACHMENT_VIEWPORT_TAG)
+        assertTrue(
+            "#2057: staged attachment tiles must sit BELOW the draft field. " +
+                "tilesTop=${tiles.top} draftBottom=${draft.bottom} ${geometry.log}",
+            tiles.top >= draft.bottom - geometry.slopPx,
+        )
+        stage.assertFullyAboveKeyboard(
+            COMPOSER_ATTACHMENT_VIEWPORT_TAG,
+            geometry.modalRoot,
+            geometry.keyboardTopPx,
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Assertions
+    // ------------------------------------------------------------------
+
+    /**
+     * Mechanisms A + B. `surface - content` is everything Material paints above
+     * the composer's first pixel: the `contentWindowInsets` padding plus the drag
+     * handle block. After #1622 the only legitimate occupant is the grabber.
+     *
+     * Both bounds are load bearing. The upper bound is the fix; the lower bound
+     * stops "reclaim" from being achieved by deleting the grabber, which is the
+     * one visible cue that swipe-down dismisses.
+     */
+    private fun assertChromeIsGrabberOnly(geometry: SheetGeometry) {
+        val expected = ComposerDragHandleBlockHeight.value
+        assertTrue(
+            "Issue #1622: the sheet must spend NOTHING above its content except the " +
+                "grabber block (${expected}dp). Anything more is the dead band the " +
+                "maintainer measured at 67dp: a non-position-aware top safe-area pad " +
+                "(mechanism A) and/or Material's 48dp default handle (mechanism B). " +
+                "${geometry.log}",
+            geometry.chromeDp <= expected + CHROME_SLOP_DP,
+        )
+        assertTrue(
+            "Issue #1622: the grabber must still be painted — it is the only visible " +
+                "swipe-down-to-dismiss cue. Reclaiming chrome by deleting it is not the " +
+                "fix. ${geometry.log}",
+            geometry.chromeDp >= expected - CHROME_SLOP_DP,
+        )
+        assertTrue(
+            "The grabber bar itself must be present in the sheet. ${geometry.log}",
+            nodeExists(COMPOSER_DRAG_HANDLE_TAG),
+        )
+    }
+
+    /**
+     * Mechanism C. `ComposerDraftField` binds the editor to `heightIn(max = 220.dp)`
+     * (`PromptComposerSheet.kt`), so with a draft far longer than that the field
+     * measures exactly its ceiling whenever the room exists. Under the double
+     * subtraction the room did not exist and it measured roughly 100 dp in this
+     * state, so this is the assertion that fails on base and passes on the fix.
+     */
+    private fun assertEditorReachesDesignedCeiling(geometry: SheetGeometry) {
+        val draftHeightDp = boundsHeightAwareOf(COMPOSER_DRAFT_TAG).heightPx / geometry.density
+        assertTrue(
+            "Issue #1622: with a long draft the editor must be able to reach its " +
+                "designed ${COMPOSER_EDITOR_CEILING_DP}dp ceiling keyboard-up. A smaller " +
+                "value means the body is still capped against a keyboard the sheet " +
+                "container had already excluded (mechanism C, the double subtraction). " +
+                "draftHeightDp=$draftHeightDp ${geometry.log}",
+            draftHeightDp >= COMPOSER_EDITOR_CEILING_DP - EDITOR_SLOP_DP,
+        )
+    }
+
+    /**
+     * #567/#682/#1744. Containment in the sheet's OWN Compose root, and fully
+     * above the keyboard boundary keyboard-up / the nav bar keyboard-down — never
+     * `assertIsDisplayed()`, which a control shoved under the keyboard still
+     * satisfies (F2/F3).
+     */
+    private fun assertControlsReachable(geometry: SheetGeometry) {
+        val boundary = if (geometry.keyboardUp) geometry.keyboardTopPx else geometry.navBarTopPx
+        listOf(COMPOSER_SEND_ENTER_TAG, COMPOSER_MIC_TAG, COMPOSER_ATTACH_TAG).forEach { tag ->
+            if (geometry.keyboardUp) {
+                stage.assertFullyAboveKeyboard(tag, geometry.modalRoot, boundary)
+            } else {
+                stage.assertFullyAboveNavigationBar(tag, geometry.modalRoot, boundary)
+            }
+        }
+        // #1619: the draft field itself must remain reachable, not merely present —
+        // a caret the user cannot see is the symptom that issue is about.
+        if (geometry.keyboardUp) {
+            stage.assertFullyAboveKeyboard(
+                COMPOSER_DRAFT_TAG,
+                geometry.modalRoot,
+                geometry.keyboardTopPx,
+            )
+        } else {
+            stage.assertFullyAboveNavigationBar(
+                COMPOSER_DRAFT_TAG,
+                geometry.modalRoot,
+                geometry.navBarTopPx,
+            )
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Harness
+    // ------------------------------------------------------------------
+
+    private fun mountAndMeasure(
+        state: PromptComposerViewModel.UiState,
+        keyboardUp: Boolean,
+        expandPartialAnchor: Boolean = false,
+    ): SheetGeometry {
+        stage.startEdgeToEdge()
+        compose.setContent {
+            PocketShellTheme {
+                ProductionComposerSheet(state)
+            }
+        }
+
+        assertTrue(
+            "The production composer sheet must mount and settle.",
+            stage.awaitStable(SHEET_CONTENT_TAG),
+        )
+        stage.hideRealImeAndAssertHidden(
+            "Issue #1622 synthetic sheet geometry cannot be measured while a real IME is up.",
+        )
+
+        val imeBottomPx = if (keyboardUp) stage.imeBottomPx else 0
+        stage.dispatch(imeBottomPx = imeBottomPx, requireExtraWindowRoot = true)
+        assertTrue(
+            "Sheet geometry must settle after the synthetic inset dispatch " +
+                "(keyboardUp=$keyboardUp).",
+            stage.awaitStable(SHEET_CONTENT_TAG) && stage.awaitStable(COMPOSER_SEND_ENTER_TAG),
+        )
+
+        if (expandPartialAnchor) {
+            val settled = requireNotNull(sheetState) { "The production sheet state must exist." }
+            val scope = requireNotNull(sheetScope) { "The sheet composition scope must exist." }
+            // Per #234 a composer taller than half the container RESTS at
+            // `PartiallyExpanded` with its tail below the screen, and the user
+            // swipes up. Do that swipe when the sheet is actually there. Whether it
+            // was or not, the state judged below is HARD-asserted to be the Expanded
+            // anchor, so this branch cannot quietly excuse a sheet that failed to
+            // reach it.
+            if (settled.currentValue == SheetValue.PartiallyExpanded) {
+                compose.runOnUiThread { scope.launch { settled.expand() } }
+                compose.waitUntil(EXPAND_TIMEOUT_MS) {
+                    settled.currentValue == SheetValue.Expanded &&
+                        settled.targetValue == SheetValue.Expanded
+                }
+            }
+            assertTrue(
+                "Reachability keyboard-down is judged on the Expanded anchor — either the " +
+                    "sheet already fits (no #234 partial anchor) or the user's swipe-up " +
+                    "must land it there. currentValue=${settled.currentValue} " +
+                    "hasPartial=${settled.hasPartiallyExpandedState}",
+                settled.currentValue == SheetValue.Expanded,
+            )
+            assertTrue(
+                "Expanded sheet geometry must settle before it is captured.",
+                stage.awaitStable(COMPOSER_SEND_ENTER_TAG),
+            )
+        }
+
+        val modalRoot = stage.owningRootOf(SHEET_CONTENT_TAG)
+        val density = stage.density
+        val contentHeightPx = boundsHeightAwareOf(SHEET_CONTENT_TAG).heightPx
+        val surfaceHeightPx = sheetSurfaceHeightPx
+        val chromeDp = (surfaceHeightPx - contentHeightPx) / density
+        val geometry = SheetGeometry(
+            keyboardUp = keyboardUp,
+            density = density,
+            chromeDp = chromeDp,
+            modalRoot = modalRoot,
+            keyboardTopPx = modalRoot.boundsInRoot.bottom - imeBottomPx,
+            navBarTopPx = modalRoot.boundsInRoot.bottom - stage.navBarBottomPx,
+            slopPx = CHROME_SLOP_DP * density,
+            log = "ISSUE1622_SHEET_GEOMETRY keyboardUp=$keyboardUp " +
+                "surfaceHeightPx=$surfaceHeightPx contentHeightPx=$contentHeightPx " +
+                "chromeDp=$chromeDp expectedChromeDp=${ComposerDragHandleBlockHeight.value} " +
+                "imeBottomPx=$imeBottomPx navBarBottomPx=${stage.navBarBottomPx} " +
+                "modalRoot=${modalRoot.boundsInRoot} " +
+                "content=${boundsHeightAwareOf(SHEET_CONTENT_TAG)} " +
+                "draft=${runCatching { boundsHeightAwareOf(COMPOSER_DRAFT_TAG) }.getOrNull()} " +
+                "send=${runCatching { boundsHeightAwareOf(COMPOSER_SEND_ENTER_TAG) }.getOrNull()} " +
+                "status=${runCatching { boundsHeightAwareOf(COMPOSER_STATUS_VIEWPORT_TAG) }.getOrNull()} " +
+                "draftViewport=${runCatching { boundsHeightAwareOf(COMPOSER_DRAFT_VIEWPORT_TAG) }.getOrNull()} " +
+                "headerPresent=${nodeExists(COMPOSER_CLOSE_TAG)} " +
+                "density=$density",
+        )
+        // Publish BEFORE any assertion so even a red run carries its evidence.
+        Log.i(GEOMETRY_LOG_TAG, geometry.log)
+
+        // The synthetic boundary must be real, or every measurement below is a
+        // keyboard-down layout wearing a keyboard-up label (the #780 hard rule).
+        if (keyboardUp) {
+            assertTrue(
+                "The synthetic keyboard must be nonzero for a keyboard-up measurement.",
+                imeBottomPx > 0,
+            )
+        }
+        assertTrue(
+            "Material's real sheet Surface must have been measured; a zero height means " +
+                "the production chrome wrapper never composed. ${geometry.log}",
+            surfaceHeightPx > 0,
+        )
+        assertTrue(
+            "The sheet content must have nonzero height. ${geometry.log}",
+            contentHeightPx > 0,
+        )
+        return geometry
+    }
+
+    /**
+     * The production sheet chrome, not a hand copy of it. [ComposerModalBottomSheet]
+     * is the same composable `PromptComposerSheet` delegates to, so
+     * `contentWindowInsets`, the drag handle and the #1744 anchor policy are the
+     * real ones. Only the Hilt view model is replaced — `SheetContent` is the
+     * pure renderer and takes its state as a parameter.
+     */
+    @Composable
+    private fun ProductionComposerSheet(state: PromptComposerViewModel.UiState) {
+        // Production default (#234): partial expand is available, and the #1744
+        // policy inside the wrapper corrects it when it would put the sheet under
+        // the keyboard. Hoisted so a case can drive the user's swipe-to-expand.
+        val hoistedState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+        val scope = rememberCoroutineScope()
+        sheetState = hoistedState
+        sheetScope = scope
+        ComposerModalBottomSheet(
+            onDismissRequest = {},
+            sheetState = hoistedState,
+            modifier = Modifier.onGloballyPositioned { coordinates ->
+                sheetSurfaceHeightPx = coordinates.size.height
+            },
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(SHEET_CONTENT_TAG),
+            ) {
+                SheetContent(
+                    state = state,
+                    onClose = {},
+                    onDraftChange = {},
+                    onMicTap = {},
+                    onSend = {},
+                    onAttachFiles = {},
+                )
+            }
+        }
+    }
+
+    private fun nodeExists(tag: String): Boolean =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
+
+    /**
+     * Layout geometry that survives clipping. `SemanticsNode.boundsInRoot` is
+     * CLIPPED to the root, so a sheet whose tail runs past the window edge would
+     * report a short content box and make the chrome measurement lie. `size` is
+     * the unclipped layout size, so heights come from it and only ordering /
+     * containment comes from the clipped rect.
+     */
+    private fun boundsHeightAwareOf(tag: String): NodeGeometry {
+        val node = compose.onNodeWithTag(tag, useUnmergedTree = true).fetchSemanticsNode()
+        val bounds = node.boundsInRoot
+        return NodeGeometry(
+            top = bounds.top,
+            bottom = bounds.bottom,
+            heightPx = node.size.height.toFloat(),
+        )
+    }
+
+    private data class NodeGeometry(val top: Float, val bottom: Float, val heightPx: Float)
+
+    private data class SheetGeometry(
+        val keyboardUp: Boolean,
+        val density: Float,
+        val chromeDp: Float,
+        val modalRoot: SemanticsNode,
+        val keyboardTopPx: Float,
+        val navBarTopPx: Float,
+        val slopPx: Float,
+        val log: String,
+    )
+
+    // ------------------------------------------------------------------
+    // Fixtures
+    // ------------------------------------------------------------------
+
+    private fun emptyDraftState() = PromptComposerViewModel.UiState(
+        draft = "",
+        recording = PromptComposerViewModel.RecordingState.Idle,
+    )
+
+    private fun longDraftState() = PromptComposerViewModel.UiState(
+        draft = LONG_DRAFT,
+        recording = PromptComposerViewModel.RecordingState.Idle,
+    )
+
+    private fun saturatedState() = PromptComposerViewModel.UiState(
+        draft = LONG_DRAFT,
+        recording = PromptComposerViewModel.RecordingState.Idle,
+        connectionDegraded = true,
+        attachments = listOf(
+            PromptComposerViewModel.StagedAttachment(
+                remotePath = "/tmp/Screenshot_20260809-101501.png",
+                displayName = "Screenshot_20260809-101501.png",
+            ),
+            PromptComposerViewModel.StagedAttachment(
+                remotePath = "/tmp/Screenshot_20260809-101533.png",
+                displayName = "Screenshot_20260809-101533.png",
+            ),
+        ),
+    )
+
+    private companion object {
+        /**
+         * Instrumentation `println` never reaches the Gradle console on a
+         * connected run, so the evidence line is logged and read back from logcat.
+         */
+        const val GEOMETRY_LOG_TAG = "Issue1622Geometry"
+
+        const val SHEET_CONTENT_TAG = "issue1622:composer:sheet-content"
+
+        /**
+         * `ComposerDraftField(maxHeight = 220.dp)` in `SheetContent`. Kept as a
+         * literal so a silent shrink of the production ceiling is a red test
+         * rather than a moving target.
+         */
+        const val COMPOSER_EDITOR_CEILING_DP = 220f
+
+        /** Generous "this is hung, not slow" ceiling for the expand animation. */
+        const val EXPAND_TIMEOUT_MS = 10_000L
+
+        /** Sub-dp rounding wobble on the chrome measurement. */
+        const val CHROME_SLOP_DP = 3f
+
+        /**
+         * Rounding slack only. A draft far longer than the ceiling makes the
+         * editor measure the `heightIn(max)` bound exactly (220.19 dp observed at
+         * density 2.625), so no text-line quantisation applies and a wide band
+         * would only blunt the assertion: with the double subtraction restored the
+         * same state measures 195 dp (saturated) / 190 dp (long draft), so 4 dp of
+         * slack still separates fixed from broken by ~21 dp.
+         */
+        const val EDITOR_SLOP_DP = 4f
+
+        /** Far longer than the 220 dp ceiling at any sane font scale. */
+        val LONG_DRAFT = (1..40).joinToString("\n") {
+            "line $it — reduce the connector cell width and re-run the journey suite"
+        }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/composer/Issue1622DeadBandScreenshotHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/Issue1622DeadBandScreenshotHarness.kt
@@ -1,0 +1,149 @@
+package com.pocketshell.app.composer
+
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.SyntheticImeStage
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1622 — SCREENSHOT STAGING HARNESS (not a regression gate).
+ *
+ * Holds the production composer sheet on screen, with a device-representative
+ * status-bar inset and (per case) a synthetic keyboard, long enough for a
+ * host-side `adb exec-out screencap` to capture the before/after evidence the
+ * issue asks for. Every method no-ops unless `issue1622HoldMs` is passed, so
+ * normal and CI runs never block on it — the same opt-in shape as
+ * [PromptComposerImeDeadSpaceScreenshotHarness].
+ *
+ * ## Why this cannot simply raise the real keyboard
+ *
+ * The sibling #790 harness raises the REAL soft IME. That is the right shape for
+ * the #790 symptom, and the wrong one here: a modal sheet's window on a bare AVD
+ * reports a ~0 top inset, so mechanism A — the dead 45 dp of `safeDrawing.Top`
+ * padding the maintainer measured on his Pixel — is simply ABSENT from any
+ * default-emulator screenshot. That absence is exactly what made the July
+ * re-audit call mechanism A a non-defect. So this harness drives the state
+ * through [SyntheticImeStage], which dispatches the status-bar / nav-bar / ime
+ * insets into the modal's OWN window and hard-asserts the dispatch landed.
+ *
+ * The keyboard-up cases carry a synthetic ime INSET, so the bottom strip of the
+ * screenshot is empty rather than showing painted keys — the sheet's own
+ * geometry above that boundary is what the picture is for.
+ *
+ * No assertion about geometry is made here.
+ * [Issue1622ComposerSheetGeometryProofTest] is the gate; this only stages the
+ * picture.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@RunWith(AndroidJUnit4::class)
+class Issue1622DeadBandScreenshotHarness {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val stage by lazy { SyntheticImeStage(compose) }
+
+    @After
+    fun releaseSyntheticInsets() {
+        runCatching { stage.dispatch(imeBottomPx = 0, requireExtraWindowRoot = false) }
+    }
+
+    @Test
+    fun emptyDraftKeyboardDownHold() { stageAndHold(draft = "", keyboardUp = false) }
+
+    @Test
+    fun emptyDraftKeyboardUpHold() { stageAndHold(draft = "", keyboardUp = true) }
+
+    @Test
+    fun longDraftKeyboardUpHold() { stageAndHold(draft = LONG_DRAFT, keyboardUp = true) }
+
+    private fun stageAndHold(draft: String, keyboardUp: Boolean) {
+        val holdMs = InstrumentationRegistry.getArguments()
+            .getString("issue1622HoldMs")?.toLongOrNull() ?: 0L
+        if (holdMs <= 0L) return
+
+        stage.startEdgeToEdge()
+        compose.setContent {
+            PocketShellTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(PocketShellColors.Background),
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    FauxTerminalBackdrop()
+                    ComposerModalBottomSheet(
+                        onDismissRequest = {},
+                        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false),
+                    ) {
+                        Box(modifier = Modifier.fillMaxWidth().testTag(STAGE_TAG)) {
+                            SheetContent(
+                                state = PromptComposerViewModel.UiState(
+                                    draft = draft,
+                                    recording = PromptComposerViewModel.RecordingState.Idle,
+                                ),
+                                onClose = {},
+                                onDraftChange = {},
+                                onMicTap = {},
+                                onSend = {},
+                                onAttachFiles = {},
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        assertTrue(
+            "The composer sheet must mount before it is photographed.",
+            stage.awaitStable(STAGE_TAG),
+        )
+        stage.hideRealImeAndAssertHidden(
+            "Issue #1622 staging must not mix a real keyboard with the synthetic boundary.",
+        )
+        stage.dispatch(
+            imeBottomPx = if (keyboardUp) stage.imeBottomPx else 0,
+            requireExtraWindowRoot = true,
+        )
+        assertTrue("Staged geometry must settle before the hold.", stage.awaitStable(STAGE_TAG))
+
+        Log.i(HOLD_LOG_TAG, "ISSUE1622_HOLD_BEGIN keyboardUp=$keyboardUp draft=${draft.length} ms=$holdMs")
+        android.os.SystemClock.sleep(holdMs)
+        Log.i(HOLD_LOG_TAG, "ISSUE1622_HOLD_END")
+    }
+
+    @Composable
+    private fun FauxTerminalBackdrop() {
+        Text(
+            text = "alex@pocketshell:~$ tail -f deploy.log\n[ok] migrate complete",
+            color = PocketShellColors.Text,
+        )
+    }
+
+    private companion object {
+        const val HOLD_LOG_TAG = "Issue1622Hold"
+        const val STAGE_TAG = "issue1622:staging:sheet-content"
+        val LONG_DRAFT = (1..40).joinToString("\n") {
+            "line $it — reduce the connector cell width and re-run the journey suite"
+        }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/composer/Issue2057AttachmentTilesBelowDraftProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/Issue2057AttachmentTilesBelowDraftProofTest.kt
@@ -38,6 +38,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinOwningRoot
@@ -651,12 +652,8 @@ class Issue2057AttachmentTilesBelowDraftProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDraftLossOnFinalizeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerDraftLossOnFinalizeE2eTest.kt
@@ -46,6 +46,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.core.voice.WhisperClient
@@ -531,26 +532,49 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
         )
         val keyboardTopPx = modalRoot.boundsInRoot.bottom - syntheticIme.observedImeBottomPx
         val keyboardUpDraftHeight = draftNode.boundsInRoot.height
-        val requiredDraftCompression =
-            syntheticIme.observedImeBottomPx * MINIMUM_DRAFT_COMPRESSION_FRACTION
+        val keyboardUpDraftHeightDp = keyboardUpDraftHeight / displayDensity()
 
         assertNoPhysicalImeWindow(
             "Physical IME appeared before the final #1743 geometry and screenshot proof.",
         )
-        // This cap-specific oracle intentionally precedes the broader keyboard-
-        // boundary checks below. With the cap neutralized, both describe the same
-        // bad geometry, but the overflowing editor's failure must identify the
-        // missing available-above-keyboard cap directly.
+        // Issue #1622 rewrote this oracle, and the rewrite is the point rather
+        // than a constant nudge.
+        //
+        // It used to require the keyboard-up editor to be at least 8% of the ime
+        // inset SHORTER than keyboard-down — "the production
+        // available-above-keyboard cap must bind". That cap was `maxHeight -
+        // (ime - navBars)` in `SheetContent`, and #1622 proved it subtracted a
+        // keyboard material3 1.3.2 had already excluded (the modal's container is
+        // `Box(Modifier.fillMaxSize().imePadding())`). Deleting it is the whole
+        // fix, so this assertion had become a demand that the DEFECT still be
+        // present: measured on emulator API 35 / 1080x2400 / density 2.625, the
+        // editor is 578 px in BOTH states with the fix and this line failed at
+        // `requiredCompression=61.92`, while the pre-#1622 tree passed it.
+        //
+        // What the old wording was actually reaching for — in its own words, "the
+        // overflowing editor must not take room the sticky Send needs" — is
+        // BOUNDEDNESS, not shrinkage. So assert exactly that, in both directions:
+        // this deliberately overflowing real editor must stop at its designed
+        // ceiling (it cannot grow into the room Send and the banners need) and
+        // must not be crushed below a usable multi-line height. The named mutation
+        // that reddens it is deleting `maxHeight = 220.dp` from the production
+        // `ComposerDraftField` call, which lets the overflowing draft consume the
+        // ~485 dp of genuine keyboard-up room.
         assertTrue(
-            "The exact nonzero modal IME inset must make the production " +
-                "available-above-keyboard cap bind: this deliberately overflowing " +
-                "real editor must surrender measurable viewport height while sticky " +
-                "Send remains reachable. keyboardDownDraftHeight=" +
-                "${keyboardDown.draftHeightPx} keyboardUpDraftHeight=$keyboardUpDraftHeight " +
-                "requiredCompression=$requiredDraftCompression observedImeBottomPx=" +
-                "${syntheticIme.observedImeBottomPx} draft=${draftNode.boundsInRoot} " +
-                "send=${sendNode.boundsInRoot}",
-            keyboardDown.draftHeightPx - keyboardUpDraftHeight >= requiredDraftCompression,
+            "The deliberately overflowing real editor must stop at its designed " +
+                "${COMPOSER_EDITOR_CEILING_DP}dp ceiling keyboard-up, so the sticky " +
+                "Send row and the status stack keep their room. " +
+                "keyboardDownDraftHeight=${keyboardDown.draftHeightPx} " +
+                "keyboardUpDraftHeightDp=$keyboardUpDraftHeightDp " +
+                "observedImeBottomPx=${syntheticIme.observedImeBottomPx} " +
+                "draft=${draftNode.boundsInRoot} send=${sendNode.boundsInRoot}",
+            keyboardUpDraftHeightDp <= COMPOSER_EDITOR_CEILING_DP + EDITOR_CEILING_SLOP_DP,
+        )
+        assertTrue(
+            "The keyboard-up editor must stay usable, not crushed to a sliver. " +
+                "keyboardUpDraftHeightDp=$keyboardUpDraftHeightDp " +
+                "minimumDp=$MINIMUM_USABLE_DRAFT_HEIGHT_DP draft=${draftNode.boundsInRoot}",
+            keyboardUpDraftHeightDp >= MINIMUM_USABLE_DRAFT_HEIGHT_DP,
         )
         assertTrue(
             "Queue banner must be contained by the #1619 status viewport in the same " +
@@ -748,7 +772,6 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
             .setVisible(WindowInsetsCompat.Type.ime(), imeBottomPx > 0)
             .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, 0))
             .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, 0, 0, 0))
-            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 0, 0, 0))
             .build()
         compose.activityRule.scenario.onActivity { activity ->
             val roots = activeAppWindowRoots(activity)
@@ -765,7 +788,7 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
                     "modalCount=${modalRoots.size} " +
                     "roots=${roots.map { "${it.javaClass.name}:${it.width}x${it.height}" }}",
             )
-            roots.forEach { root -> ViewCompat.dispatchApplyWindowInsets(root, insets) }
+            roots.forEach { root -> dispatchSyntheticWindowInsets(root, insets) }
         }
     }
 
@@ -924,7 +947,37 @@ class PromptComposerDraftLossOnFinalizeE2eTest {
     private companion object {
         const val SYNTHETIC_IME_HEIGHT_DP = 295f
         const val MINIMUM_LIFT_FRACTION = 0.5f
-        const val MINIMUM_DRAFT_COMPRESSION_FRACTION = 0.08f
+
+        /**
+         * `ComposerDraftField(maxHeight = 220.dp)` in `SheetContent`. Kept as a
+         * literal — the same convention (and the same value) as
+         * [Issue1622ComposerSheetGeometryProofTest] — so a silent shrink of the
+         * production ceiling is a red test rather than a moving target.
+         *
+         * Issue #1622 replaced the `MINIMUM_DRAFT_COMPRESSION_FRACTION = 0.08f`
+         * that used to sit here. That constant demanded the keyboard-up editor be
+         * SHORTER than keyboard-down, which only held while `SheetContent`
+         * subtracted the keyboard a second time from an already-IME-padded modal
+         * container. It is deleted rather than retuned: no value of it expresses a
+         * property the fixed layout has.
+         */
+        const val COMPOSER_EDITOR_CEILING_DP = 220f
+
+        /**
+         * Rounding slack only. An overflowing draft makes the editor measure the
+         * `heightIn(max)` bound exactly (220.19 dp observed at density 2.625), so
+         * there is no text-line quantisation to absorb and a wide band would only
+         * blunt the assertion.
+         */
+        const val EDITOR_CEILING_SLOP_DP = 4f
+
+        /**
+         * The editor's keyboard-up floor is a 24 dp `minHeight` plus the field's
+         * own padding; this is comfortably above a one-line sliver and far below
+         * the 220 dp observed, so it catches a crush without pinning the exact
+         * measured value.
+         */
+        const val MINIMUM_USABLE_DRAFT_HEIGHT_DP = 40f
         const val ROOT_SLOP_PX = 2f
         const val REAL_IME_TIMEOUT_MS = 30_000L
         const val PHYSICAL_IME_ABSENCE_STABILITY_MS = 500L

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeEmptyDraftDeadSpaceProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeEmptyDraftDeadSpaceProofTest.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -116,12 +116,21 @@ class PromptComposerImeEmptyDraftDeadSpaceProofTest {
                         text = "alex@pocketshell:~$ tail -f deploy.log",
                         color = PocketShellColors.Text,
                     )
-                    // Fixed-height host modelling the composer window exactly as
-                    // production sees it (#780 note): the ModalBottomSheet window
-                    // does NOT reposition above the keyboard; its content is
-                    // top-anchored and the body is capped to the room above the
-                    // keyboard. All geometry below is measured RELATIVE to this
-                    // tagged container.
+                    // Fixed-height host that the keyboard OVERLAPS; its content is
+                    // top-anchored.
+                    //
+                    // Issue #1622 correction — the #780-era note here claimed this
+                    // "models the composer window exactly as production sees it"
+                    // because "the ModalBottomSheet window does NOT reposition above
+                    // the keyboard". That is FALSE on material3 1.3.2, which wraps
+                    // the modal's window content in
+                    // `Box(Modifier.fillMaxSize().imePadding())` — the real window IS
+                    // resized. Nor is the body "capped to the room above the
+                    // keyboard": that second subtraction was the #1622 double-count
+                    // and is deleted. This host is the harsher UN-resized shape, kept
+                    // as a containment guard; the real-window measurement lives in
+                    // [Issue1622ComposerSheetGeometryProofTest]. All geometry below is
+                    // measured RELATIVE to this tagged container.
                     Box(
                         modifier = Modifier
                             .width(CONTAINER_WIDTH_DP.dp)
@@ -254,12 +263,8 @@ class PromptComposerImeEmptyDraftDeadSpaceProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeShortDraftDeadSpaceProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeShortDraftDeadSpaceProofTest.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.core.agents.AgentKind
@@ -276,12 +276,8 @@ class PromptComposerImeShortDraftDeadSpaceProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeSquishProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeSquishProofTest.kt
@@ -28,6 +28,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertTrue
@@ -43,12 +44,19 @@ import org.junit.runner.RunWith
  *
  * The maintainer's keyboard-up screenshot showed the draft field crushed to a
  * single line and the Send/attach row crammed together (Send half-clipped) while
- * the keyboard was up. The #567 fix is the single-subtract
- * `availableAboveKeyboard = maxHeight - (ime - navBars)` in [SheetContent]'s
- * `BoxWithConstraints` (with NO additional `imePadding()`). This test asserts the
- * composer body is NOT squished when the keyboard is up: the "Prompt Composer"
- * header stays on-screen, the body fits within the room above the keyboard, and
- * Send + attach stay reachable just above the keyboard with only a small gap.
+ * the keyboard was up. This test asserts the composer body is NOT squished when
+ * the keyboard is up: the body fits within the room above the keyboard, and Send +
+ * attach stay reachable just above the keyboard with only a small gap.
+ *
+ * Issue #1622 correction: the #567-era subtraction this comment used to name
+ * (`availableAboveKeyboard = maxHeight - (ime - navBars)`) is GONE from
+ * [SheetContent]. material3 1.3.2's modal container is already IME-padded, so that
+ * subtraction was counting the keyboard twice; the body is now bounded only by the
+ * top safe-area cap. This class keeps its value as an UN-resized-host containment
+ * guard — a 740dp host whose bottom the keyboard overlaps, which is a shape the
+ * production window is not, and never was after material3 started resizing it. The
+ * production-window measurement lives in
+ * [Issue1622ComposerSheetGeometryProofTest].
  *
  * ## Why this is CI-DETERMINISTIC (the #780 fix)
  *
@@ -60,8 +68,8 @@ import org.junit.runner.RunWith
  *
  * Instead we:
  *  - compose the PRODUCTION [SheetContent] (the exact pure-renderer that
- *    [PromptComposerSheet] delegates to — same `availableAboveKeyboard` math,
- *    same pinned-header / sticky-controls layout) directly in the activity
+ *    [PromptComposerSheet] delegates to — same body-bound math, same
+ *    pinned-header / sticky-controls layout) directly in the activity
  *    window (NOT inside a `ModalBottomSheet` dialog window, so its
  *    `WindowInsets.ime` / `.navigationBars` / `.statusBars` consumers read the
  *    activity decor insets we control);
@@ -139,17 +147,26 @@ class PromptComposerImeSquishProofTest {
                     contentAlignment = Alignment.TopCenter,
                 ) {
                     FauxTerminalBackdrop()
-                    // Fixed-height host modelling the composer's WINDOW exactly as
-                    // production sees it: the `ModalBottomSheet` dialog window does
-                    // NOT reposition above the soft keyboard (#567 note) — its
-                    // bottom sits at screen-bottom-minus-navbar, partly BEHIND the
-                    // keyboard, and the content is TOP-anchored within it. So this
-                    // container is the un-resized window area and SheetContent's
-                    // BoxWithConstraints sees `maxHeight = CONTAINER_HEIGHT_DP`,
-                    // then caps its body to `maxHeight - (ime - navBars)` to keep it
-                    // above the keyboard — the exact #567 lever. All geometry below
-                    // is measured RELATIVE to this tagged container, never relative
-                    // to the device decor (which varies per AVD).
+                    // Fixed-height host that the keyboard OVERLAPS: its bottom sits
+                    // at screen-bottom-minus-navbar, partly behind the keyboard, and
+                    // the content is TOP-anchored within it.
+                    //
+                    // Issue #1622 correction — this used to claim the host modelled
+                    // "the composer's WINDOW exactly as production sees it", because
+                    // the #567-era note said the `ModalBottomSheet` dialog window
+                    // does NOT reposition above the soft keyboard. That is FALSE on
+                    // material3 1.3.2: the modal wraps its window content in
+                    // `Box(Modifier.fillMaxSize().imePadding())`, so the real
+                    // production window IS resized to the room above the keyboard.
+                    // This host is therefore the UN-resized shape, which production
+                    // is not — a deliberately harsher containment case, not a model
+                    // of the real window. Nor does `SheetContent` cap its body to
+                    // `maxHeight - (ime - navBars)` any more; that second subtraction
+                    // was the #1622 double-count and is deleted. The real-window
+                    // measurement lives in [Issue1622ComposerSheetGeometryProofTest].
+                    // All geometry below is measured RELATIVE to this tagged
+                    // container, never relative to the device decor (which varies per
+                    // AVD).
                     Box(
                         modifier = Modifier
                             .width(CONTAINER_WIDTH_DP.dp)
@@ -215,11 +232,11 @@ class PromptComposerImeSquishProofTest {
             .fetchSemanticsNode()
             .boundsInRoot
 
-        // The keyboard intrudes into this window by (ime - navBars); the room left
-        // above it is measured from the container bottom up — exactly the lever
-        // SheetContent's `availableAboveKeyboard = maxHeight - (ime - navBars)`
-        // uses. `imeTop` is the top edge of that synthetic keyboard within the
-        // container's coordinate space.
+        // The keyboard intrudes into this un-resized window by (ime - navBars);
+        // `imeTop` is the top edge of that synthetic keyboard within the container's
+        // coordinate space. Since #1622 SheetContent no longer subtracts it — the
+        // production host does — so what this class still proves is that the body
+        // wraps compactly and leaves the controls reachable, not that a cap fires.
         val keyboardIntrusionPx = (imeBottomPx - navBottomPx).coerceAtLeast(0)
         val containerTop = containerBounds.top
         val containerBottom = containerBounds.bottom
@@ -228,9 +245,14 @@ class PromptComposerImeSquishProofTest {
 
         val draftHeightDp = draftBounds.height / density
         // Issue #801: the "Prompt Composer" header (its close × is COMPOSER_CLOSE_TAG)
-        // is HIDDEN when the keyboard is up — on a real Pixel only ~175dp is
-        // available above the keyboard, and the header would steal ~58dp of it. So
-        // keyboard-up the body now starts at the draft, not a header.
+        // is HIDDEN when the keyboard is up, so keyboard-up the body starts at the
+        // draft, not a header.
+        //
+        // Issue #1622 correction: #801's stated reason — "on a real Pixel only
+        // ~175dp is available above the keyboard" — was the double-subtracted
+        // budget, not the device. With the second subtraction gone the real sheet
+        // has ~485dp keyboard-up. Hiding the header keyboard-up is kept because it
+        // is decoration while typing, NOT because room is scarce.
         val bodyTopPx = draftBounds.top
         val bodyBottomPx = maxOf(sendBounds.bottom, attachBounds.bottom)
         val bodyHeightPx = bodyBottomPx - bodyTopPx
@@ -301,12 +323,14 @@ class PromptComposerImeSquishProofTest {
             draftHeightDp >= MIN_DRAFT_HEIGHT_DP,
         )
 
-        // 4) Issue #801: keyboard-UP the header is intentionally HIDDEN to reclaim
-        //    its ~58dp for the draft in the ~175dp above the keyboard. Assert it is
-        //    ABSENT (the close × node does not exist while the keyboard is up) — the
-        //    inverse of the old "header must be on-screen" guard, updated for the
-        //    #801 compact keyboard-up layout. The draft body must still start at or
-        //    below the container top (never clipped above it).
+        // 4) Issue #801: keyboard-UP the header is intentionally HIDDEN. Assert it
+        //    is ABSENT (the close × node does not exist while the keyboard is up) —
+        //    the inverse of the old "header must be on-screen" guard, updated for
+        //    the #801 compact keyboard-up layout. (#1622: the "~175dp above the
+        //    keyboard" this used to cite as the reason was the double-subtracted
+        //    budget; the header stays hidden because it is decoration while typing.)
+        //    The draft body must still start at or below the container top (never
+        //    clipped above it).
         assertTrue(
             "Composer body clipped above the top of the sheet (squish). " +
                 "bodyTop=$bodyTopPx containerTop=$containerTop statusTopPx=$statusTopPx",
@@ -374,12 +398,8 @@ class PromptComposerImeSquishProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeTightScreenSquishProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeTightScreenSquishProofTest.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.core.agents.AgentKind
@@ -52,8 +52,18 @@ import org.junit.runner.RunWith
  * left no room for a full draft + the sticky control row, so the reserve-and-floor
  * math fired and crushed the field to one line and the controls into a sliver —
  * the #567 double-subtract, re-introduced because the sheet's resize behaviour was
- * mis-modelled. The #801 fix uses `maxHeight` directly (no second subtraction) and
- * weights the scroll region to the genuine room.
+ * mis-modelled.
+ *
+ * Issue #1622 correction: this paragraph described the intended #801 shape, and
+ * the code did NOT match it. `SheetContent` kept `maxHeight - (ime - navBars)`
+ * until #1622 removed it, so "uses `maxHeight` directly (no second subtraction)"
+ * only became true then — and this proof stayed green throughout, because a 470dp
+ * host with a 3-line draft never presses on either budget. The load-bearing
+ * red->green for the double subtraction is
+ * [Issue1622ComposerSheetGeometryProofTest], which measures the REAL
+ * `ModalBottomSheet`; this class remains the tight-host containment guard it is
+ * good at. It now also documents the correct model rather than a claim about code
+ * that had not landed.
  *
  * ## Why a NEW test next to [PromptComposerImeSquishProofTest]
  *
@@ -135,11 +145,10 @@ class PromptComposerImeTightScreenSquishProofTest {
                     // 470dp). The keyboard sits at this host's BOTTOM edge — the
                     // sheet window already resized to it — so the room above the
                     // keyboard is exactly HOST_HEIGHT_DP. SheetContent's
-                    // BoxWithConstraints sees `maxHeight = HOST_HEIGHT_DP` and (post
-                    // #801) uses it DIRECTLY as the room above the keyboard. Pre-#801
-                    // it subtracted `(ime - navBars)` again, collapsing the usable
-                    // room to ~176dp → the squish. All geometry is measured RELATIVE
-                    // to this tagged host.
+                    // BoxWithConstraints sees `maxHeight = HOST_HEIGHT_DP` and (since
+                    // #1622, not #801 — see the class comment) uses it directly, less
+                    // only the top safe-area cap. All geometry is measured RELATIVE to
+                    // this tagged host.
                     Box(
                         modifier = Modifier
                             .width(HOST_WIDTH_DP.dp)
@@ -286,12 +295,8 @@ class PromptComposerImeTightScreenSquishProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 
@@ -318,9 +323,10 @@ class PromptComposerImeTightScreenSquishProofTest {
         const val HOST_WIDTH_DP = 392f
 
         // The synthetic IME inset only needs to make WindowInsets.ime report
-        // keyboard-up (the production `keyboardUp` branch). Its magnitude no longer
-        // feeds the room math post #801, but a realistic value keeps the model
-        // honest.
+        // keyboard-up (the production `keyboardUp` branch). Since #1622 its
+        // magnitude genuinely no longer feeds the room math (before #1622 it still
+        // did, contrary to the note that used to sit here), but a realistic value
+        // keeps the model honest.
         const val IME_HEIGHT_DP = 343f
         const val NAV_BAR_DP = 48f
         const val STATUS_BAR_DP = 52f

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerLongDraftCaretVisibleTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerLongDraftCaretVisibleTest.kt
@@ -36,13 +36,13 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.di.WhisperClientFactory
 import com.pocketshell.app.insets.SyntheticImeStage
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.core.voice.WhisperClient
@@ -634,10 +634,6 @@ class PromptComposerLongDraftCaretVisibleTest {
                 WindowInsetsCompat.Type.statusBars(),
                 Insets.of(0, statusBarTopPx, 0, 0),
             )
-            .setInsets(
-                WindowInsetsCompat.Type.systemBars(),
-                Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-            )
             .build()
         compose.activityRule.scenario.onActivity { activity ->
             val roots = activeAppWindowRoots(activity)
@@ -655,7 +651,7 @@ class PromptComposerLongDraftCaretVisibleTest {
                     "roots=${roots.map { "${it.javaClass.name}:${it.width}x${it.height}" }}",
             )
             roots.forEach { root ->
-                ViewCompat.dispatchApplyWindowInsets(root, insets)
+                dispatchSyntheticWindowInsets(root, insets)
             }
         }
     }

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOfflineComposeUsableProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOfflineComposeUsableProofTest.kt
@@ -32,11 +32,11 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.core.agents.AgentKind
@@ -61,8 +61,14 @@ import org.junit.runner.RunWith
  * the maintainer actually hit — and `performTextInput` bypasses viewport
  * reachability, so it passes even when the field is invisible on-device.
  *
- * The REAL blocker is a LAYOUT crush. Keyboard-up in the resized `ModalBottomSheet`
- * window there is only ~175dp above the keyboard (measured pixel_7, #801). When the
+ * The REAL blocker is a LAYOUT crush. This proof stages a DELIBERATELY TIGHT host
+ * (see [HOST_HEIGHT_DP]) so the crush is reachable at all. Issue #1622 correction:
+ * the "only ~175dp above the keyboard (measured pixel_7, #801)" this paragraph used
+ * to assert as a property of the device was the DOUBLE-SUBTRACTED budget, not the
+ * room a Pixel has — `SheetContent` subtracted the keyboard a second time from an
+ * already-IME-padded modal container. The real sheet has ~485dp keyboard-up. The
+ * tight host below is therefore a synthetic worst case that keeps this banner
+ * ordering honest, not a model of the maintainer's phone. When the
  * link is down the sticky "Connection lost — Send will retry once reconnected."
  * banner ([PromptComposerSheet.kt] ~:1254) wraps to TWO lines and, together with
  * the sticky control row, consumes almost the whole budget — crushing the
@@ -141,11 +147,18 @@ class PromptComposerOfflineComposeUsableProofTest {
                     contentAlignment = Alignment.TopCenter,
                 ) {
                     FauxTerminalBackdrop()
-                    // RESIZED-sheet host (measured real pixel_7, #801): its height
-                    // IS the room above the keyboard, the keyboard sits at its
-                    // bottom edge. SheetContent's BoxWithConstraints reads
-                    // `maxHeight = HOST_HEIGHT_DP` and subtracts the keyboard
-                    // intrusion to land on the genuine ~175dp above the keyboard.
+                    // RESIZED-sheet host: its height IS the room above the keyboard,
+                    // the keyboard sits at its bottom edge, and SheetContent's
+                    // BoxWithConstraints reads `maxHeight = HOST_HEIGHT_DP`.
+                    //
+                    // Issue #1622 correction: the note here said the body then
+                    // "subtracts the keyboard intrusion to land on the genuine
+                    // ~175dp above the keyboard". Both halves are now wrong —
+                    // `SheetContent` no longer subtracts anything keyboard-derived
+                    // (that was the #1622 double-count), and ~175dp was the product
+                    // of that double-count rather than a real Pixel budget. This
+                    // host stays small ON PURPOSE so the banner-ordering crush is
+                    // reachable at all; see [HOST_HEIGHT_DP].
                     Box(
                         modifier = Modifier
                             .width(HOST_WIDTH_DP.dp)
@@ -330,12 +343,8 @@ class PromptComposerOfflineComposeUsableProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 
@@ -386,15 +395,19 @@ class PromptComposerOfflineComposeUsableProofTest {
     private companion object {
         const val HOST_TAG = "issue1613-offline-sheet-host"
 
-        // Model the maintainer's real keyboard-up state faithfully. On a real
-        // pixel_7 the resized sheet leaves ~175dp of room above the keyboard, and
-        // keyboard-up the nav bar is COVERED by the keyboard so `WindowInsets.
-        // navigationBars` reads 0 (the composer's `navigationBarsPadding()`
-        // contributes nothing keyboard-up). We reproduce those EFFECTIVE inputs:
-        // NAV = 0 (no nav padding stealing room), a small IME inset so `keyboardUp`
-        // is true (the field uses its 24dp keyboard-up min) while the intrusion
-        // subtracted from the host is small. `availableAboveKeyboard ≈ HOST - IME`,
-        // which we size into the crush→usable band (see below).
+        // A deliberately TIGHT keyboard-up host. Keyboard-up the nav bar is COVERED
+        // by the keyboard so `WindowInsets.navigationBars` reads 0 (the composer's
+        // `navigationBarsPadding()` contributes nothing keyboard-up), which is why
+        // NAV = 0 here, with a small IME inset so `keyboardUp` is true (the field
+        // uses its 24dp keyboard-up min).
+        //
+        // Issue #1622 correction: this block used to justify the numbers as
+        // "modelling the maintainer's real keyboard-up state faithfully — on a real
+        // pixel_7 the resized sheet leaves ~175dp above the keyboard". That budget
+        // was the double-subtraction inside `SheetContent`, now deleted; the real
+        // sheet has ~485dp keyboard-up, where this banner ordering cannot crush
+        // anything. The host is kept small BECAUSE the crush must stay reachable —
+        // it is an honest worst case, not a claim about the device.
         const val HOST_HEIGHT_DP = 470f
 
         // A narrow content width (the sheet's inner width after its 18dp side
@@ -404,12 +417,17 @@ class PromptComposerOfflineComposeUsableProofTest {
         // base, crushes the weighted draft region below one line.
         const val HOST_WIDTH_DP = 360f
 
-        // Small IME (keyboardUp true) with NAV 0. `availableAboveKeyboard ≈ 188-48 =
-        // 140dp`. On base the sticky two-line offline banner (~56dp) + control row
-        // (~48dp) + bottom padding (~26dp) leave the weighted draft region ~10dp —
-        // a sub-line crush (editor → ~0). The #1613 fix moves the banner into the
-        // scroll region, so the sticky chrome is just the control row (~74dp) and the
-        // draft region is ~66dp — the one-line field is fully visible.
+        // Small IME (keyboardUp true) with NAV 0. On base the sticky two-line
+        // offline banner (~56dp) + control row (~48dp) + bottom padding (~26dp)
+        // leave the weighted draft region a sub-line sliver (editor → ~0). The
+        // #1613 fix moves the banner into the scroll region, so the sticky chrome
+        // is just the control row and the one-line field is fully visible.
+        //
+        // Issue #1622 correction: the arithmetic here was written as
+        // `availableAboveKeyboard ≈ 188-48 = 140dp`, naming a variable that no
+        // longer exists — `SheetContent` does not derive any bound from the ime
+        // inset. The body now sees the host height less only the top safe-area cap,
+        // so the numbers above are the layout's own stack, not a keyboard budget.
         const val IME_HEIGHT_DP = 295f
         const val NAV_BAR_DP = 0f
         const val STATUS_BAR_DP = 52f

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingRowFitProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerRecordingRowFitProofTest.kt
@@ -22,11 +22,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -252,12 +252,8 @@ class PromptComposerRecordingRowFitProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSaturatedImeAnchorE2eTest.kt
@@ -46,6 +46,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.di.WhisperClientFactory
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.core.voice.WhisperClient
@@ -1040,7 +1041,6 @@ class PromptComposerSaturatedImeAnchorE2eTest {
             .setVisible(WindowInsetsCompat.Type.ime(), imeBottomPx > 0)
             .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, 0))
             .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, 0, 0, 0))
-            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 0, 0, 0))
             .build()
         compose.activityRule.scenario.onActivity { activity ->
             val roots = activeAppWindowRoots(activity)
@@ -1070,7 +1070,7 @@ class PromptComposerSaturatedImeAnchorE2eTest {
             // synthetic inset, so the activity remains an independent physical-
             // IME sentinel and screenshots can never silently mix LatinIME with
             // the synthetic boundary.
-            modalRoots.forEach { ViewCompat.dispatchApplyWindowInsets(it, insets) }
+            modalRoots.forEach { dispatchSyntheticWindowInsets(it, insets) }
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSheetImeReachabilityTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSheetImeReachabilityTest.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -167,12 +167,8 @@ class PromptComposerSheetImeReachabilityTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSlashDropdownImeContainmentProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerSlashDropdownImeContainmentProofTest.kt
@@ -24,12 +24,12 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.agentcommands.AgentCommandCatalog
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.core.agents.AgentKind
@@ -239,12 +239,8 @@ class PromptComposerSlashDropdownImeContainmentProofTest {
                     WindowInsetsCompat.Type.statusBars(),
                     Insets.of(0, statusBarTopPx, 0, 0),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticImeStage.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticImeStage.kt
@@ -217,6 +217,21 @@ internal class SyntheticImeStage(
         // nonzero one can, so the same before/after mutation that classifies
         // `imePadding()` also classifies `navigationBarsPadding()`.
         val navBarBottomPx = this.navBarBottomPx
+        // Issue #1622: there is deliberately NO `setInsets(Type.systemBars(), …)`
+        // call here, and adding one back is a bug. `systemBars()` is a COMPOUND
+        // mask and `Builder.setInsets` copies the value into every constituent
+        // slot, so this builder used to end by overwriting `navigationBars` with
+        // `(0, 52dp, 0, 48dp)` — a navigation bar with a TOP edge, which no device
+        // reports. `SheetContent`'s `navigationBarsPadding()` pads every edge of
+        // that inset, so the phantom became a real 52 dp dead band inside the
+        // composer the moment #1622 stopped an ancestor consuming the top inset:
+        // a fixture defect presenting exactly as a product defect.
+        //
+        // The compound value is not lost by deleting the call —
+        // `getInsets(systemBars())` returns the union of the three constituents
+        // that ARE set below. [dispatchSyntheticWindowInsets] hard-fails if the
+        // call is ever re-added; see its KDoc for the full mechanism and the
+        // measured 136 px blast radius.
         val insets = WindowInsetsCompat.Builder()
             .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
             .setVisible(WindowInsetsCompat.Type.ime(), imeBottomPx > 0)
@@ -226,10 +241,6 @@ internal class SyntheticImeStage(
             )
             .setVisible(WindowInsetsCompat.Type.navigationBars(), true)
             .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, statusBarTopPx, 0, 0))
-            .setInsets(
-                WindowInsetsCompat.Type.systemBars(),
-                Insets.of(0, statusBarTopPx, 0, navBarBottomPx),
-            )
             .build()
         repeat(INSET_DISPATCH_REPEATS) {
             scenario.onActivity { activity ->
@@ -256,7 +267,7 @@ internal class SyntheticImeStage(
                 // `StandaloneContentImePaddingLivenessTest` cases stayed green
                 // (their content lives in the activity's own window). That is
                 // the non-vacuity guarantee for this whole oracle.
-                roots.forEach { root -> ViewCompat.dispatchApplyWindowInsets(root, insets) }
+                roots.forEach { root -> dispatchSyntheticWindowInsets(root, insets) }
                 // ---------------------------------------------------------------
             }
             compose.waitForIdle()

--- a/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticWindowInsetsDispatch.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticWindowInsetsDispatch.kt
@@ -1,0 +1,108 @@
+package com.pocketshell.app.insets
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * Issue #1622 — the ONE way an androidTest dispatches a synthetic
+ * [WindowInsetsCompat] into an app window, and the guard that makes a
+ * physically-impossible inset set impossible to ship.
+ *
+ * ## The defect this exists to kill
+ *
+ * `WindowInsetsCompat.Type.systemBars()` is a COMPOUND mask
+ * (`statusBars | navigationBars | captionBar`), and
+ * `WindowInsetsCompat.Builder.setInsets` writes the given `Insets` into EVERY
+ * constituent slot — `androidx.core.view.WindowInsetsCompat$BuilderImpl.setInsets`
+ * loops `for (i = 1; i <= 512; i <<= 1) { if (mask & i) mInsetsTypeMask[indexOf(i)]
+ * = insets }`. Twelve fixtures in this tree set the compound mask **after** the
+ * specific single-edge types, so the compound value silently overwrote them:
+ *
+ *  - `setInsets(systemBars(), Insets.of(0, statusTop, 0, navBottom))` last left
+ *    `navigationBars = (0, statusTop, 0, navBottom)` — a navigation bar with a
+ *    **top** edge, which no device reports — and `statusBars = (0, statusTop, 0,
+ *    navBottom)`, a status bar with a **bottom** edge, likewise impossible.
+ *  - `setInsets(systemBars(), Insets.of(0, 0, 0, navBottom))` last (with no
+ *    `statusBars` call at all) left `statusBars = (0, 0, 0, navBottom)`.
+ *
+ * Those phantom edges are not academic. `SheetContent` calls
+ * `navigationBarsPadding()`, which pads **every** edge of the nav-bar inset, so
+ * the fabricated 52 dp top edge became a 52 dp dead band **inside** the composer
+ * the moment #1622 stopped an ancestor from consuming the top inset — a defect of
+ * the FIXTURE presenting exactly as a defect of the product. The #1622 reviewer
+ * measured the blast radius on the real emulator: restoring the compound-last
+ * ordering at a single site grew every sheet by exactly 136 px (51.8 dp) **and
+ * all five geometry cases still passed**, so nothing in the suite could see it.
+ *
+ * ## The fix, and why it is a deletion rather than a reordering
+ *
+ * Every explicit compound `setInsets(systemBars(), …)` call is now DELETED from
+ * this tree's fixtures (D22 hard-cut, not a reordering). Setting a compound mask
+ * alongside its constituents can only do one of two things — agree, in which case
+ * it is dead weight, or disagree, in which case it fabricates geometry — because
+ * `WindowInsetsCompat.getInsets(systemBars())` already returns the UNION of
+ * `statusBars`, `navigationBars` and `captionBar`. A reader who "fixes" a
+ * `systemBars` value by re-adding the call is re-arming the trap; the guard below
+ * is what stops them.
+ *
+ * ## The guard (the witness the round-1 fix did not have)
+ *
+ * [dispatchSyntheticWindowInsets] hard-fails on an inset set no device could
+ * produce, BEFORE it reaches a window. It rides on the dispatch call rather than
+ * living in one fixture, so a new proof copied from a sibling inherits it. Named
+ * mutation: re-add `.setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0,
+ * statusBarTopPx, 0, navBarBottomPx))` as the last builder call at any site and
+ * that site goes red here, with the offending slot named — instead of quietly
+ * inflating every measured surface by the status-bar height.
+ */
+internal fun dispatchSyntheticWindowInsets(root: View, insets: WindowInsetsCompat) {
+    insets.requirePhysicallyPossible()
+    ViewCompat.dispatchApplyWindowInsets(root, insets)
+}
+
+/**
+ * Hard-fails unless every synthetic inset in [this] is one a real device could
+ * report. Only the invariants that hold on EVERY device and orientation are
+ * asserted, so a legitimate fixture is never blocked:
+ *
+ *  - the status bar runs along the top edge only (a left/right/bottom status-bar
+ *    inset does not exist);
+ *  - the navigation bar never has a TOP edge (it is bottom in portrait, and
+ *    left/right for a landscape 3-button bar — both allowed here);
+ *  - the soft keyboard only ever intrudes from the bottom.
+ *
+ * Deliberately NOT asserted: the caption bar (freeform-window chrome genuinely
+ * sits at the top, and no fixture here reads it), and any relationship between
+ * the ime and nav insets (a keyboard-up nav inset is device policy, not geometry).
+ */
+private fun WindowInsetsCompat.requirePhysicallyPossible() {
+    val statusBars = getInsets(WindowInsetsCompat.Type.statusBars())
+    val navigationBars = getInsets(WindowInsetsCompat.Type.navigationBars())
+    val ime = getInsets(WindowInsetsCompat.Type.ime())
+    val violations = buildList {
+        if (statusBars.bottom != 0 || statusBars.left != 0 || statusBars.right != 0) {
+            add(
+                "statusBars=$statusBars has a non-top edge; the status bar is a TOP-edge " +
+                    "inset on every device.",
+            )
+        }
+        if (navigationBars.top != 0) {
+            add(
+                "navigationBars=$navigationBars has a TOP edge; no device reports a " +
+                    "navigation bar above the content.",
+            )
+        }
+        if (ime.top != 0 || ime.left != 0 || ime.right != 0) {
+            add("ime=$ime has a non-bottom edge; the soft keyboard only intrudes upward.")
+        }
+    }
+    check(violations.isEmpty()) {
+        "Issue #1622: refusing to dispatch a physically impossible synthetic inset set. " +
+            "This is almost always a COMPOUND `Type.systemBars()` (or another multi-type " +
+            "mask) written AFTER the specific types it contains — `Builder.setInsets` " +
+            "copies it into every constituent slot. Delete the compound call; " +
+            "`getInsets(systemBars())` is already the union. Violations: " +
+            violations.joinToString("; ")
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetKeyboardLayoutTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RootProjectAddSheetKeyboardLayoutTest.kt
@@ -33,6 +33,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.waitForComposeLayoutStable
 import com.pocketshell.app.proof.signals.waitForInputMethodVisible
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -403,10 +404,6 @@ class RootProjectAddSheetKeyboardLayoutTest {
                 WindowInsetsCompat.Type.statusBars(),
                 Insets.of(0, statusBarTopPx, 0, 0),
             )
-            .setInsets(
-                WindowInsetsCompat.Type.systemBars(),
-                Insets.of(0, statusBarTopPx, 0, 0),
-            )
             .build()
         compose.activityRule.scenario.onActivity { activity ->
             val roots = activeAppWindowRoots(activity)
@@ -434,7 +431,7 @@ class RootProjectAddSheetKeyboardLayoutTest {
             // tree keeps observing ime=0 and the exact-inset oracle above goes
             // red before any geometry is judged.
             roots.forEach { root ->
-                ViewCompat.dispatchApplyWindowInsets(root, insets)
+                dispatchSyntheticWindowInsets(root, insets)
             }
             // -----------------------------------------------------------------
         }

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentQuickReplyBandContainmentProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentQuickReplyBandContainmentProofTest.kt
@@ -23,11 +23,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
@@ -289,12 +289,8 @@ class AgentQuickReplyBandContainmentProofTest {
                     WindowInsetsCompat.Type.navigationBars(),
                     Insets.of(0, 0, 0, navBarBottomPx),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, 0, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ComposerOpenDuringCodexBurstProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ComposerOpenDuringCodexBurstProofTest.kt
@@ -23,6 +23,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.core.terminal.ui.TerminalKeyboardMode
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.termux.view.TerminalView
@@ -362,7 +363,7 @@ class Issue796ComposerOpenDuringCodexBurstProofTest {
             val insets = WindowInsetsCompat.Builder()
                 .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ImeRecompositionProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ImeRecompositionProofTest.kt
@@ -26,6 +26,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
@@ -356,7 +357,7 @@ class Issue796ImeRecompositionProofTest {
             val insets = WindowInsetsCompat.Builder()
                 .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
             observed = ViewCompat.getRootWindowInsets(decor)
                 ?.getInsets(WindowInsetsCompat.Type.ime())
                 ?.bottom

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeProofTest.kt
@@ -25,11 +25,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.layout.TmuxImeLayoutState
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -370,12 +370,8 @@ class Issue887TerminalFixedUnderImeProofTest {
                     WindowInsetsCompat.Type.navigationBars(),
                     Insets.of(0, 0, 0, navBarBottomPx),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, 0, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ReservedTmuxTerminalBottomBandTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ReservedTmuxTerminalBottomBandTest.kt
@@ -26,10 +26,10 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
@@ -273,7 +273,7 @@ class ReservedTmuxTerminalBottomBandTest {
                     visibleNavBottomPx > 0,
                 )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt
@@ -22,11 +22,11 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_EXPAND_TAG
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -144,7 +144,7 @@ class TerminalHotkeysPanelScreenshotHarness {
             val insets = WindowInsetsCompat.Builder()
                 .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxHotkeysLauncherImeProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxHotkeysLauncherImeProofTest.kt
@@ -20,11 +20,11 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.insets.dispatchSyntheticWindowInsets
 import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -155,12 +155,8 @@ class TmuxHotkeysLauncherImeProofTest {
                     WindowInsetsCompat.Type.navigationBars(),
                     Insets.of(0, 0, 0, navBarBottomPx),
                 )
-                .setInsets(
-                    WindowInsetsCompat.Type.systemBars(),
-                    Insets.of(0, 0, 0, navBarBottomPx),
-                )
                 .build()
-            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+            dispatchSyntheticWindowInsets(decor, insets)
         }
     }
 

--- a/app/src/main/java/com/pocketshell/app/composer/ComposerSheetChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/ComposerSheetChrome.kt
@@ -1,0 +1,140 @@
+package com.pocketshell.app.composer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.theme.PocketShellColors
+
+/**
+ * Issue #1622 — the composer sheet's own Material chrome, in ONE place.
+ *
+ * ## Why this exists
+ *
+ * The composer's `ModalBottomSheet` parameters used to be inline in
+ * [PromptComposerSheet], and every geometry proof re-declared them by hand.
+ * `ComposerPartialExpandE2eTest` even carried a comment begging future readers
+ * to "keep it in lockstep" with production, because #615 shipped a regression
+ * precisely when the harness copy drifted. A copy that must be kept in lockstep
+ * by hand is a copy that will drift, so there is now exactly one declaration and
+ * the proofs mount THIS.
+ *
+ * ## What it fixes (the measured #1622 dead band)
+ *
+ * Two of the three mechanisms behind the ~67 dp of chrome the maintainer
+ * measured above the grabber — in BOTH keyboard states — live here.
+ *
+ * **Mechanism A — the top inset was dead padding.** The old call passed
+ * `contentWindowInsets = safeDrawing.only(Top + Horizontal)`. Material applies
+ * that with `windowInsetsPadding` on the sheet's internal column
+ * (`ModalBottomSheetKt$ModalBottomSheetContent$7`, verified in the 1.3.2
+ * bytecode), and `InsetsPaddingModifier` is **not position aware** — it applies
+ * the raw `getTop()` with no clipping against where the element actually sits.
+ * So a sheet floating ~1400 px below the status bar still paid the device's full
+ * status-bar/cutout inset (118 px = 45 dp on the maintainer's Pixel), as a band
+ * of nothing between the sheet's top edge and the grabber. Dropping `Top` here
+ * removes it. The genuine concern it was standing in for — a pathologically tall
+ * sheet growing up under the status bar — is now handled where it belongs, as a
+ * height CAP on the body in [SheetContent] (`maxHeight - safeDrawing.top`), which
+ * costs nothing until the sheet actually gets that tall.
+ *
+ * **Mechanism B — the default drag handle spends 48 dp on a 4 dp bar.**
+ * Material's `BottomSheetDefaults.DragHandle` pads the bar by
+ * `DragHandleVerticalPadding = 22.dp` top and bottom. [ComposerDragHandle] keeps
+ * the identical 32x4 dp bar (so the affordance reads the same) with
+ * [ComposerDragHandleVerticalPadding] instead, for a ~22 dp visual block.
+ *
+ * Nothing about the drag or dismiss affordance changes. In material3 1.3.2 the
+ * drag gesture lives on the sheet Surface (`anchoredDraggable`), not on the
+ * handle, and the accessibility dismiss/expand/collapse actions live on the
+ * `Box` that `ModalBottomSheetContent` wraps around whatever `dragHandle`
+ * composable it is given — this one included. The handle is a visual cue with a
+ * semantics wrapper, so shrinking its padding removes painted emptiness and no
+ * interaction.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ComposerModalBottomSheet(
+    onDismissRequest: () -> Unit,
+    sheetState: SheetState,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = PocketShellColors.Surface,
+        contentColor = PocketShellColors.Text,
+        // Issue #1744: measure Material's real Surface and move a settled partial
+        // anchor only when that Surface crosses this modal root's exact IME
+        // boundary. The policy owns only expansions it initiated, so a
+        // user-expanded sheet is never collapsed when the keyboard hides. It is
+        // applied HERE rather than at the call site so a proof that mounts this
+        // wrapper gets the real anchor behaviour and cannot silently prove
+        // geometry against a sheet that never corrects its partial anchor.
+        modifier = modifier.composerImeAnchorPolicy(sheetState),
+        dragHandle = { ComposerDragHandle() },
+        // Issue #1622 (mechanism A). HORIZONTAL ONLY. The cutout/status clearance
+        // this used to include never applied to a sheet that does not reach the
+        // top of the screen, but `windowInsetsPadding` charged for it anyway; see
+        // the block comment above. `Bottom` is deliberately absent too: Material's
+        // own container is already IME-padded, and the keyboard-DOWN nav-bar
+        // clearance is taken by `navigationBarsPadding()` inside [SheetContent].
+        contentWindowInsets = {
+            WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
+        },
+        content = content,
+    )
+}
+
+/**
+ * The composer's grabber: Material's exact 32x4 dp bar, with the painted dead
+ * space around it cut from 22 dp to [ComposerDragHandleVerticalPadding].
+ *
+ * See [ComposerModalBottomSheet] for why this costs no affordance.
+ */
+@Composable
+internal fun ComposerDragHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .padding(vertical = ComposerDragHandleVerticalPadding)
+            .size(width = ComposerDragHandleBarWidth, height = ComposerDragHandleBarHeight)
+            .background(
+                color = PocketShellColors.TextSecondary,
+                shape = RoundedCornerShape(percent = 50),
+            )
+            .testTag(COMPOSER_DRAG_HANDLE_TAG),
+    )
+}
+
+/**
+ * Issue #1622: the grabber's painted block, top edge to bottom edge —
+ * `2 * `[ComposerDragHandleVerticalPadding]` + `[ComposerDragHandleBarHeight].
+ * Material's default is 48 dp for the same 4 dp bar.
+ *
+ * Proofs assert the sheet's total chrome against this rather than a literal, so
+ * a future padding change moves the expectation with it instead of silently
+ * eating the reclaimed room.
+ */
+internal val ComposerDragHandleBlockHeight: Dp
+    get() = ComposerDragHandleVerticalPadding * 2 + ComposerDragHandleBarHeight
+
+internal val ComposerDragHandleVerticalPadding = 9.dp
+internal val ComposerDragHandleBarWidth = 32.dp
+internal val ComposerDragHandleBarHeight = 4.dp
+
+internal const val COMPOSER_DRAG_HANDLE_TAG = "prompt-composer-drag-handle"

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerSheet.kt
@@ -19,12 +19,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -43,7 +40,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
@@ -116,7 +112,8 @@ import kotlinx.coroutines.supervisorScope
  *
  * Layout, top to bottom inside the [ModalBottomSheet]:
  *
- *  1. Grabber bar (drawn by Material 3's `ModalBottomSheet` itself).
+ *  1. Grabber bar (issue #1622's compact [ComposerDragHandle], passed to
+ *     Material 3's `ModalBottomSheet` in place of the 48dp-tall default).
  *  2. Header: title `Prompt Composer` + close `×` button.
  *  3. Editable text area (`composer-text`) — `OutlinedTextField` styled to
  *     match the mockup's surface-elev fill.
@@ -411,41 +408,21 @@ public fun PromptComposerSheet(
         onDismiss()
     }
 
-    ModalBottomSheet(
+    // Issue #682: the composer is a CONTENT-HEIGHT (wrap-content) sheet that sits
+    // directly above the soft keyboard, like a normal chat composer. #615
+    // reworked this into a fully-expanded sheet + a host-window IME inset read +
+    // an explicit `padding(bottom = hostImeBottomPx)` on the sheet body; that
+    // over-sized the sheet, pushed the controls to the top of the screen and
+    // opened a keyboard-height void. It stays wrap-content.
+    //
+    // Issue #1622: the Material chrome (content insets, drag handle) now lives in
+    // ONE place — `ComposerModalBottomSheet` — because every geometry proof used
+    // to re-declare it by hand and the copies drifted. That file's block comment
+    // carries the measured dead-band diagnosis.
+    ComposerModalBottomSheet(
         onDismissRequest = dismissComposer,
         sheetState = sheetState,
-        containerColor = PocketShellColors.Surface,
-        contentColor = PocketShellColors.Text,
-        // Issue #1744: measure Material's real Surface and move a settled partial
-        // anchor only when that Surface crosses this modal root's exact IME
-        // boundary. The policy owns only expansions it initiated, so a
-        // user-expanded sheet is never collapsed when the keyboard hides.
-        modifier = modifier.composerImeAnchorPolicy(sheetState),
-        // Issue #682: the composer is a CONTENT-HEIGHT (wrap-content) sheet that
-        // sits directly above the soft keyboard, like a normal chat composer.
-        //
-        // #615 reworked this into a fully-expanded sheet + a host-window IME
-        // inset read + an explicit `padding(bottom = hostImeBottomPx)` on the
-        // sheet body. That over-sized the sheet and grew the content height by the
-        // keyboard height — pushing the controls up to the top of the screen (the
-        // jump-to-top + cut-off) and opening a keyboard-height empty void.
-        //
-        // Reserve only the TOP + horizontal safe area here. That keeps the status
-        // bar / cutout clear at the top while letting the sheet's own dialog
-        // window resize for the soft keyboard: when the IME shows, the window
-        // (and so `BoxWithConstraints.maxHeight` inside `SheetContent`) shrinks by
-        // the keyboard height and the sheet sits directly above the keyboard.
-        //
-        // Issue #567: `SheetContent` therefore caps the body to that ALREADY
-        // IME-resized `maxHeight` and does NOT additionally `imePadding()` or
-        // subtract `WindowInsets.ime` — doing either double-counted the keyboard
-        // height and crushed the composer into a thin strip. See the long note in
-        // `SheetContent`.
-        contentWindowInsets = {
-            WindowInsets.safeDrawing.only(
-                WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
-            )
-        },
+        modifier = modifier,
     ) {
         SheetContent(
             state = state,
@@ -586,7 +563,7 @@ public fun PromptComposerSheet(
  * whenever `currentValue` / `targetValue` changes during an animation.
  */
 @OptIn(ExperimentalMaterial3Api::class)
-private fun Modifier.composerImeAnchorPolicy(
+internal fun Modifier.composerImeAnchorPolicy(
     sheetState: SheetState,
 ): Modifier = composed {
     val density = LocalDensity.current
@@ -934,88 +911,108 @@ internal fun SheetContent(
             commitAndSend()
         }
     }
-    // Issue #682 / #567: bound the composer body to the room ABOVE the keyboard.
+    // Issue #682 / #567 / #1622: bound the composer body to the room this sheet's
+    // host actually gives it.
     //
-    // KEY FACT (measured on-device, issue #567): the `ModalBottomSheet`'s dialog
-    // window does NOT reposition itself above the soft keyboard, and `imePadding()`
-    // does NOT lift content inside this sheet's window. The sheet content stays
-    // top-anchored in a window whose bottom sits at the screen bottom (partly
-    // behind the keyboard). So the only reliable lever is a height CAP that clips
-    // the body to the room left above the keyboard — see the `availableAboveKeyboard`
-    // note below. The scrollable upper region then absorbs a long draft / a stack
-    // of attachment tiles + banners so the sticky Send row always stays on-screen
-    // above the keyboard (the #682 long-content cut-off).
+    // KEY FACT (issue #1622, replacing the #567-era one that stood here for six
+    // rounds): **the host has ALREADY excluded the keyboard.** material3 1.3.2's
+    // `ModalBottomSheet` wraps its whole window content in
+    // `Box(Modifier.fillMaxSize().imePadding())` — verified in the 1.3.2 bytecode,
+    // `ModalBottomSheetKt$ModalBottomSheet$3`, and visible on the maintainer's
+    // device as a sheet whose bottom edge sits exactly on the keyboard top. So the
+    // `maxHeight` this `BoxWithConstraints` receives is the room ABOVE the
+    // keyboard already; there is nothing left to subtract.
     //
-    // History (issue #567 squish): the prior code applied BOTH `heightIn(max =
-    // maxHeight - ime)` AND `imePadding()` on the SAME Column. `.heightIn().
-    // imePadding()` on one element makes the IME padding eat INTO the cap, so the
-    // usable content area collapsed to `maxHeight - 2*ime`, crushing the 96dp
-    // draft to ~36dp, clipping the "Prompt Composer" header, and pushing the
-    // attachment tiles off-screen. Removing `imePadding()` and capping to exactly
-    // the room above the keyboard subtracts the keyboard height once, so the
-    // composer renders full-size above the keyboard.
+    // The comment this replaces asserted the opposite — that the dialog window
+    // "does NOT reposition itself above the soft keyboard" and that a height cap
+    // against `maxHeight - (ime - navBars)` was "the only reliable lever". That was
+    // true of some older material3, but on 1.3.2 it made the code subtract the
+    // keyboard TWICE, which is what held the body to ~173 dp of a genuinely
+    // available ~485 dp. Its own recorded numbers already contained the
+    // contradiction: a `maxHeight` of 470 dp on a 914 dp-tall Pixel 7 only
+    // arithmetics if the container is IME-resized (un-resized it would have been
+    // ~820 dp). Every patch in the chain (#567 -> #615 -> #682 -> #765 -> #790 ->
+    // #801) was a different way of dividing too little room, and **the room was
+    // never that little** — it was self-inflicted. Do not reintroduce an
+    // `ime`-derived subtraction here; if a future material3 stops IME-padding its
+    // container, `Issue1622ComposerSheetGeometryProofTest` goes red on the real
+    // sheet and says so.
+    //
+    // History worth keeping (issue #567 squish): the code before that applied BOTH
+    // `heightIn(max = maxHeight - ime)` AND `imePadding()` on the SAME Column.
+    // `.heightIn().imePadding()` on one element makes the padding eat INTO the cap,
+    // so the usable area collapsed to `maxHeight - 2*ime`. Neither is present now:
+    // the cap below is not keyboard-derived at all, and there is no `imePadding()`
+    // in this subtree (it would be a no-op anyway — the sheet consumed the inset;
+    // issue #1812).
     val density = LocalDensity.current
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
-        // Room above the keyboard, MEASURED on a real pixel_7 inside this
-        // `ModalBottomSheet` dialog window (issue #801 diagnostic):
-        //
-        //   sheet maxHeight       = 470dp     (the sheet content area, IME up)
-        //   sheet content TOP     = ~1100px   (where the body is anchored)
-        //   keyboard TOP          = 1499px    (decorHeight - ime)
-        //   genuine room above kb = maxHeight - (ime - navBars) ≈ 175dp
-        //
-        // KEY FINDING: the `ModalBottomSheet` content area is only ~470dp tall when
-        // the keyboard is up (the sheet window is IME-resized), and its body is
-        // top-anchored LOW, so the usable room ABOVE the keyboard is only ~175dp —
-        // and the sheet CANNOT be expanded past that (the Expanded anchor is itself
-        // the IME-resized maxHeight; `expand()` is a no-op when the keyboard is up).
-        // So ~175dp is genuinely all the vertical room there is. The earlier code
-        // tried to fit the pinned header + a 96..220dp draft + the control row into
-        // that 175dp and crushed — and every patch (#567 → #615 → #682 → #765 →
-        // #790 → #784) was a different way of dividing too little room.
-        //
-        // The `maxHeight - (ime - navBars)` room formula is CORRECT (it lands on the
-        // genuine ~175dp). What was wrong was trying to keep ALL the keyboard-DOWN
-        // chrome in that tight budget. `WindowInsets.ime` is read here only to find
-        // that room + the keyboard-up flag.
+        // `WindowInsets.ime` is read here for the keyboard-up FLAG only (which
+        // chrome to show, which floor to use) — never to size the body. A raw
+        // inset read is unaffected by the host's consumption, so the flag is
+        // correct inside the IME-padded sheet.
         val imeBottomDp = with(density) { WindowInsets.ime.getBottom(this).toDp() }
-        val navBarsBottomDp = with(density) {
-            WindowInsets.navigationBars.getBottom(this).toDp()
-        }
-        val keyboardIntrusionDp = (imeBottomDp - navBarsBottomDp).coerceAtLeast(0.dp)
         val keyboardUp = imeBottomDp > 0.dp
-        val availableAboveKeyboard = (maxHeight - keyboardIntrusionDp).coerceAtLeast(0.dp)
+        // Issue #1622 (mechanism A's real requirement). Dropping `Top` from the
+        // sheet's `contentWindowInsets` removed 45 dp of dead padding that was
+        // charged in every state; what that padding was incidentally protecting is
+        // a saturated sheet growing up UNDER the status bar / cutout. This cap is
+        // that protection, and only that: it costs nothing until the body would
+        // actually reach the unsafe strip, whereas the padding cost 45 dp always.
+        val safeDrawingTopDp = with(density) {
+            WindowInsets.safeDrawing.getTop(this).toDp()
+        }
+        val bodyMaxHeight = (maxHeight - safeDrawingTopDp).coerceAtLeast(0.dp)
         // Issue #801 (clean rebuild of the keyboard-up sizing; supersedes the
         // #790/#765 reserve-constant approach, D22 hard-cut):
         //
-        // Given that only ~175dp is available above the keyboard, the layout is a
-        // proper chat-composer: a WEIGHTED scrollable draft that takes exactly the
-        // room left after the fixed control row, and — keyboard-up only — the
-        // "Prompt Composer" header is DROPPED (it is not needed while actively
-        // typing; the close affordance is swipe-down / back / scrim, and the header
-        // returns the moment the keyboard hides). Dropping the ~58dp header reclaims
-        // it for the draft, so in ~175dp the draft gets ~3 readable lines and the
-        // full-size control row sits below it, above the keyboard — instead of the
-        // old reserve-and-floor that crushed the field to one line and crammed the
-        // controls into a sliver. The `weight(1f)` region replaces the brittle
-        // hand-estimated `PROMPT_SCROLL_REGION_IME_CHROME_RESERVE`/floor pair (both
-        // deleted): no constant to drift, the control row always lays out, and a
-        // long draft scrolls WITHIN the weighted region (the #682 long-draft
-        // invariant) rather than pushing the controls off-screen.
+        // The layout is a proper chat-composer: a WEIGHTED scrollable draft that
+        // takes exactly the room left after the fixed control row, and — keyboard-up
+        // only — the "Prompt Composer" header is DROPPED (it is not needed while
+        // actively typing; the close affordance is swipe-down / back / scrim, and
+        // the header returns the moment the keyboard hides). The `weight(1f)` region
+        // replaces the brittle hand-estimated
+        // `PROMPT_SCROLL_REGION_IME_CHROME_RESERVE`/floor pair (both deleted): no
+        // constant to drift, the control row always lays out, and a long draft grows
+        // WITHIN the weighted region (the #682 long-content invariant) rather than
+        // pushing the controls off-screen.
+        //
+        // Issue #1622 amends #801's PREMISE, not its shape. #801 reasoned from
+        // "only ~175dp is available above the keyboard"; that budget was the
+        // double-subtraction, not the device. With it gone the same weighted layout
+        // has ~485dp keyboard-up, so the editor's designed 220dp ceiling is
+        // reachable for the first time instead of being clipped at ~119dp. Hiding
+        // the header keyboard-up stays — it is decoration while typing — but it is
+        // no longer load-bearing triage.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                // The nav-bar clearance only matters when the keyboard is DOWN
-                // (the keyboard covers the nav bar when up); it contributes 0
-                // under the IME.
+                // The nav-bar clearance only matters when the keyboard is DOWN. With
+                // the keyboard up, Material's container `imePadding()` has already
+                // consumed a bottom inset larger than the nav bar, so
+                // `windowInsetsPadding` applies 0 here (issue #1812).
+                //
+                // Issue #1622 considered narrowing this to
+                // `windowInsetsPadding(navigationBars.only(Bottom))` after a TEST
+                // FIXTURE fabricated a nav-bar inset with a top edge and this call —
+                // which pads every edge — turned it into a visible dead band. That
+                // narrowing is deliberately NOT taken. No device reports a nav bar
+                // above the content, and the horizontal edges (a landscape 3-button
+                // bar) are already consumed by the sheet's
+                // `contentWindowInsets = safeDrawing.only(Horizontal)`, so `.only(
+                // Bottom)` is a no-op on every real device — production shaped
+                // around a broken fixture, with no gate able to tell the two forms
+                // apart. The fixture is fixed at the fixture, and
+                // `dispatchSyntheticWindowInsets` now hard-fails any impossible
+                // inset set before it reaches a window.
                 .navigationBarsPadding()
-                // Cap to the room above the keyboard (see note above). The sheet
-                // content is top-anchored within its window and the window extends
-                // behind the keyboard, so clipping the body to this room is what
-                // keeps the sticky Send row above the keyboard. The scrollable
-                // upper region absorbs a long draft / a stack of attachment tiles +
-                // banners (the #682 long-content cut-off).
-                .heightIn(max = availableAboveKeyboard)
+                // Issue #1622: the ONLY height bound on the body, and it is not
+                // keyboard-derived — `maxHeight` already excludes the keyboard (see
+                // the KEY FACT above). This keeps a saturated sheet from growing up
+                // under the status bar / cutout. The weighted region below absorbs a
+                // long draft / a stack of tiles + banners so the sticky Send row is
+                // never pushed off (the #682 long-content cut-off).
+                .heightIn(max = bodyMaxHeight)
                 .background(PocketShellColors.Surface)
                 .padding(horizontal = 18.dp)
                 // Keyboard-down keeps the visual breathing room above the nav
@@ -1044,13 +1041,17 @@ internal fun SheetContent(
             // it is NOT inside the scroll region below — so a focused draft can't
             // auto-scroll it off the top.
             //
-            // Issue #801: keyboard-UP the header is HIDDEN. On a real Pixel only
-            // ~175dp is available above the keyboard, and the header ("Prompt
-            // Composer" title + close ×) costs ~58dp of it — the difference between
-            // a one-line crushed draft and a usable ~3-line one. The header is not
-            // needed while actively typing: the user can dismiss via swipe-down /
-            // system back / scrim tap, and the header returns the instant the
-            // keyboard hides. So it renders only when the keyboard is DOWN.
+            // Issue #801: keyboard-UP the header is HIDDEN. The header ("Prompt
+            // Composer" title + close ×) costs ~58dp, and it is decoration while
+            // actively typing: the user can dismiss via swipe-down / system back /
+            // scrim tap, and the header returns the instant the keyboard hides. So
+            // it renders only when the keyboard is DOWN.
+            //
+            // Issue #1622: #801 justified this by "only ~175dp is available above
+            // the keyboard". That budget was a double-subtraction of the keyboard,
+            // not a device limit, and is gone. The hide stays on the design
+            // argument above — reclaiming ~58dp for the draft is still the right
+            // trade while typing — but it is no longer triage.
             if (!keyboardUp) {
                 Row(
                     modifier = Modifier
@@ -1097,11 +1098,15 @@ internal fun SheetContent(
                     // Issue #1619: status content owns a SEPARATE bounded scroll
                     // ABOVE the editor. It may scroll internally when several
                     // banners/tiles are present, but it can no longer make the
-                    // 220dp editor a child of a smaller clipping viewport. In the
-                    // measured ~175dp keyboard-up budget, 48dp is enough for the
-                    // standalone two-line Offline banner while still reserving a
-                    // complete editable line plus the sticky controls. Keyboard-
-                    // down keeps a roomier 96dp status history.
+                    // 220dp editor a child of a smaller clipping viewport. 48dp
+                    // keyboard-up is the standalone two-line Offline banner, whole.
+                    // Keyboard-down keeps a roomier 96dp status history.
+                    //
+                    // Issue #1622 deliberately did NOT grow these caps with the
+                    // reclaimed room: the whole point of the slice is that the
+                    // reclaimed space goes to the DRAFT. A bounded status region is
+                    // also the #1613 contract — banners stay a bounded strip above
+                    // the field, never a growing stack that pushes it down.
                     .fillMaxWidth()
                     .heightIn(
                         max = if (keyboardUp) {
@@ -1301,11 +1306,15 @@ internal fun SheetContent(
         // strip can be capped at exactly "whatever is left above the editor's
         // one-line floor". The editor is then the weighted child INSIDE, so it
         // absorbs the remainder and keeps BasicTextField's native caret-follow as
-        // the only editor scroll (#1619). Result, on the measured ~175dp keyboard-up
-        // budget: with no banners the strip shows a full tile row and the editor
-        // keeps its line; with the Offline banner also up the strip shrinks to a
-        // scrollable sliver rather than crushing the editor. Neither case can move
-        // the controls row.
+        // the only editor scroll (#1619). With no banners the strip shows a full
+        // tile row and the editor takes the rest; with the Offline banner also up
+        // the strip shrinks to a scrollable sliver rather than crushing the editor.
+        // Neither case can move the controls row.
+        //
+        // Issue #1622: keyboard-up this area went from ~125dp of flexible room to
+        // ~425dp once the double-subtracted keyboard was removed, so the editor's
+        // designed 220dp ceiling is now reachable with the tile strip still at its
+        // cap — the two no longer compete on a real draft.
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
@@ -2286,20 +2295,28 @@ internal const val COMPOSER_CANCEL_RECORDING_TAG = "prompt-composer-cancel-recor
 internal const val COMPOSER_CANCEL_TRANSCRIPTION_TAG = "prompt-composer-cancel-transcription"
 
 // Issue #1619: status banners/tiles scroll independently above the weighted
-// editor. The tight keyboard-up cap was calibrated against the measured 175dp
-// budget: a 48dp two-line Offline banner remains whole while one complete editor
-// line and the sticky controls still fit. Keyboard-down can show two status rows
-// before this region scrolls, without changing the editor's 220dp cap.
+// editor. 48dp keyboard-up is exactly the two-line Offline banner, whole.
+// Keyboard-down can show two status rows before this region scrolls, without
+// changing the editor's 220dp cap.
+//
+// Issue #1622 kept both numbers where they are. They were originally sized
+// against the double-subtracted ~175dp budget, but they are not a share of a
+// budget — they are the deliberate BOUND on how much of the sheet status chrome
+// may ever own (#1613). The room #1622 reclaimed goes to the draft, so growing
+// these would spend the fix on the thing the fix was taking room back from.
 private val PromptComposerStatusRegionImeMaxHeight = 48.dp
 private val PromptComposerStatusRegionMaxHeight = 96.dp
 
 // Issue #2057: upper bound on the staged-attachment strip below the editor.
 // Keyboard-DOWN there is room for two full 64dp tile rows plus the 8dp FlowRow
 // gap; keyboard-UP the strip is deliberately smaller than one tile (the tile top
-// with its remove control stays visible and the strip scrolls) because 40dp is
-// the most it can take on the measured ~175dp budget while the editor still
-// keeps the multi-line height the #801 tight-screen squish proof pins. Beyond
-// these bounds the strip scrolls internally instead of growing.
+// with its remove control stays visible and the strip scrolls). Beyond these
+// bounds the strip scrolls internally instead of growing.
+//
+// Issue #1622 kept the keyboard-up 40dp. It no longer has to contend with the
+// editor at all — the flexible area is ~425dp keyboard-up, so 220dp of editor
+// plus a 40dp strip both fit — but a taller strip would take the reclaimed room
+// straight back off the draft, which is the opposite of this slice.
 private val PromptComposerAttachmentRegionImeMaxHeight = 40.dp
 private val PromptComposerAttachmentRegionMaxHeight = 144.dp
 

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -148,6 +148,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.projects.RootProjectAddSheetKeyboardLayoutTest"  # #1742 deterministic modal-root IME layout proof
   "com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest"  # #898 reviewer Blocker B): the in-session + New session rich-sheet
   "com.pocketshell.app.tmux.TmuxCreateAfterAttachFailureDockerTest"  # #1832 failed attach then Create must fail visibly, never silently create nothing
+  "com.pocketshell.app.composer.Issue1622ComposerSheetGeometryProofTest"  # #1622 #567 #615 #682 #765 #790 #801 D33/G10: the REAL ModalBottomSheet's standing chrome (top-inset dead pad + 48dp default handle) and the double-subtracted keyboard budget, measured through a synthetic status-bar/ime inset dispatched into the modal's own window — the AVD cannot reproduce the device inset unaided
   "com.pocketshell.app.composer.PromptComposerImeSquishProofTest"  # #736 #567 #638 #657 follow-up to the review): the composer keyboard-up SQUISH re…
   "com.pocketshell.app.composer.PromptComposerLongDraftCaretVisibleTest"  # #1619/#765 D33/G10: synthetic + real-IME long-draft caret containment above sticky controls
   "com.pocketshell.app.composer.PromptComposerImeTightScreenSquishProofTest"  # #801 #567 #780 #657 the keyboard-up squish on a REALISTIC TIGHT screen


### PR DESCRIPTION
Closes a chain the maintainer has reported **seven times**: #567 → #615 → #682 → #765 → #790 → #801 → #1622, and again on-device on v0.4.42. Reopened siblings **#682**, **#790**, **#801** close with it.

## Why it kept coming back

A comment from the #567 era stated the modal sheet does not reposition above the keyboard, so the layout capped itself with `maxHeight - keyboardIntrusion`. **material3 1.3.2 already IME-resizes the container** (verified in bytecode by both implementer and reviewer; the maintainer's own screenshot shows the sheet bottom exactly at the keyboard top). So the keyboard was subtracted twice and the body capped to ~173dp when **~485dp was available**.

Six rounds of engineers nudged dp values inside a budget that was wrong by a factor of three. That premise — not any individual layout bug — is the class.

## Three mechanisms, measured

| | Before | After |
|---|---|---|
| Sheet chrome, all five states | 100.19dp | **22.48dp** |
| Editor, keyboard-up saturated | 117.3dp | **220.2dp** (designed cap, reached for the first time) |

- **A** — the sheet paid the device's full 118px top inset while floating ~1400px below it; Compose's inset modifier has no position awareness.
- **B** — Material's 48dp default drag handle.
- **C** — the double subtraction.

## A fixture defect the fix exposed

`SyntheticImeStage` set the compound `systemBars()` mask last, and `setInsets` writes a compound mask into **every** constituent slot — so `navigationBars` carried a fabricated top edge worth **51.8dp inside every sheet**, invisible while the sheet still consumed the top inset. Removed at all **18** sites (reordering would not have fixed three of them), with a witness the reviewer re-broke at a site the author never touched — reddening on a second axis the author's own mutations never exercised.

## A test that required the bug

`PromptComposerDraftLossOnFinalizeE2eTest` asserted the keyboard-up editor must be **shorter** — encoding the double subtraction as a requirement. Attribution proven against the pre-fix base (reverting mechanism C alone turns the old oracle green). Rewritten to boundedness, with witnesses for both ceiling and floor — the reviewer built the floor witness after finding it missing.

## Verification

Reviewer APPROVED after two rounds. Independently reproduced: red→green 5/5 at `chromeDp=100.190475` → `22.47619`; material3 bytecode verified for all three mechanisms; the `.only(Bottom)` no-op reasoning verified across four bytecode links; adjacency **65/65** across all 26 touched classes; full JVM gate 12362 executed / 0 failed, 0/1314 stale XML, no cache markers.

The stale premise is corrected in **all four** files that carried it — leaving a copy is how the next round inherits it.

## Not certifiable by emulator

Two criteria remain the maintainer's: the ~71dp reading on his real Pixel (the AVD does not reproduce his 118px top inset — **that environment gap is how this got closed as fixed before**), and whether the keyboard-up composer now feels right to type into.

Closes #1622
Closes #682
Closes #790
Closes #801