### PR TITLE
ci: host-CLI/area coverage guard suite, off the critical path (#2063 #2067)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,8 @@ jobs:
   # Issue #2060 (CI Phase A): the ~25 SERIAL guard steps this job used to carry in
   # front of the Gradle run (~20 min unrelated to the tests) now run CONCURRENTLY
   # in `guards-static`, `guards-ci-harness` and `dex`, all still blocking through
-  # `unit-gate` below.
+  # `unit-gate` below. Issue #2067 added `guards-test-selection` on the same
+  # principle, for #2063's coverage guards.
   unit:
     name: JVM unit tests
     runs-on: ubuntu-latest
@@ -377,6 +378,18 @@ jobs:
           scripts/full-jvm-gate.sh --profile-guard-self-test
           scripts/full-jvm-gate.sh --profile-guard-check
 
+      # Issue #2067: `unit-gate` holds THREE lists nothing forced to agree —
+      # `needs:`, the `env:` result mapping, and the result-checking loop. A job
+      # in the first but not the third RUNS, can go RED, and the required check
+      # stays GREEN: the silent-gate failure #2060 exists to prevent. #2060 left
+      # that pairing to a comment; this makes it mechanical. Eleven self-test
+      # cases, own-count-asserted. Detail in the script header. ~1 s, no Gradle.
+      - name: "Unit-gate wiring guard (issue #2067)"
+        run: |
+          chmod +x scripts/check-unit-gate-wiring.sh
+          scripts/check-unit-gate-wiring.sh --self-test
+          scripts/check-unit-gate-wiring.sh
+
   # ---------------------------------------------------------------------------
   # Issue #2060 (CI Phase A): CI/harness fixture guards, split out of the `unit`
   # job. They drive the real emulator-journey / nightly / release harness scripts
@@ -687,6 +700,30 @@ jobs:
           scripts/test-ci-ndk-retry.sh
 
   # ---------------------------------------------------------------------------
+  # Issue #2067: the #2063 test-area coverage guards, as a DEDICATED job. Reached
+  # through a JVM test they were paid TWICE per push (both variants) on the Unit
+  # critical path for work that compiles nothing, which cancelled the scheme's
+  # own saving; here they are paid once, in parallel, still blocking through
+  # `unit-gate`. The JVM driver is deleted, not duplicated (D22). No
+  # JDK/Gradle/SDK/Docker, so a depth-1 checkout is the whole setup, and
+  # `timeout-minutes` is a hang guard rather than the budget (the suite's wall
+  # clock varies 33% run to run, so the script reports its seconds instead of
+  # asserting them). Rationale: scripts/ci-test-selection-guards.sh, docs/testing.md.
+  guards-test-selection:
+    name: Test-selection coverage guards
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: "Run the #2063 test-area coverage guards"
+        run: |
+          chmod +x scripts/ci-test-selection-guards.sh
+          scripts/ci-test-selection-guards.sh
+
+  # ---------------------------------------------------------------------------
   # Issue #2060 (CI Phase A): the dex ratchet needs a real `:app:assembleDebug` —
   # ~5 min of the old `unit` job's serial prefix and the ONLY guard step that
   # compiles anything. Splitting it out takes it off the Unit critical path AND
@@ -749,17 +786,24 @@ jobs:
   # ---------------------------------------------------------------------------
   # Issue #2060 (CI Phase A): the protected-branch required check. `main`'s
   # ruleset requires a check literally named `Unit tests`; splitting the old
-  # monolithic job into four would have silently DEMOTED every guard to
+  # monolithic job into several would have silently DEMOTED every guard to
   # non-blocking until someone edited the ruleset by hand — a real loss of
   # enforcement dressed up as a speed-up. This ~10-second aggregator keeps the
-  # name and fails unless all four jobs succeeded, so the blocking contract is
-  # bit-for-bit the same with zero admin action. `if: always()` so it still
-  # reports (as a failure) when a dependency fails, is cancelled or is skipped —
-  # a `needs:` job that never reports would leave it pending forever.
+  # name and fails unless every unit-lane job succeeded, so the blocking
+  # contract is bit-for-bit the same with zero admin action. `if: always()` so it
+  # still reports (as a failure) when a dependency fails, is cancelled or is
+  # skipped — a `needs:` job that never reports would leave it pending forever.
+  #
+  # Issue #2067 — THIS JOB HAS THREE LISTS AND THEY MUST AGREE: `needs:`, the
+  # `env:` mapping, and the loop. A job in `needs:` but not in the loop runs, can
+  # go RED, and this gate stays GREEN — the silent-gate failure #2060 exists to
+  # prevent; a loop entry with no `needs:` reads an empty result and is equally
+  # useless. Do not hand-verify: `scripts/check-unit-gate-wiring.sh` (per push,
+  # in `guards-static`) asserts it. A comment did not stop it the first time.
   unit-gate:
     name: Unit tests
     runs-on: ubuntu-latest
-    needs: [unit, guards-static, guards-ci-harness, dex]
+    needs: [unit, guards-static, guards-ci-harness, guards-test-selection, dex]
     if: always()
     timeout-minutes: 5
     steps:
@@ -768,6 +812,7 @@ jobs:
           UNIT: ${{ needs.unit.result }}
           GUARDS_STATIC: ${{ needs.guards-static.result }}
           GUARDS_CI_HARNESS: ${{ needs.guards-ci-harness.result }}
+          GUARDS_TEST_SELECTION: ${{ needs.guards-test-selection.result }}
           DEX: ${{ needs.dex.result }}
         run: |
           set -euo pipefail
@@ -775,6 +820,7 @@ jobs:
           for pair in "JVM unit tests:$UNIT" \
                       "Static guards:$GUARDS_STATIC" \
                       "CI harness guards:$GUARDS_CI_HARNESS" \
+                      "Test-selection coverage guards:$GUARDS_TEST_SELECTION" \
                       "Dex register-pressure ratchet:$DEX"; do
             job="${pair%%:*}"
             result="${pair##*:}"
@@ -784,10 +830,10 @@ jobs:
             fi
           done
           if (( failed )); then
-            echo "::error title=Unit lane failed::A unit-lane job did not succeed (#2060). The required \`Unit tests\` check covers all four; open the failing job above for the diagnosis."
+            echo "::error title=Unit lane failed::A unit-lane job did not succeed (#2060). The required \`Unit tests\` check covers all of them; open the failing job above for the diagnosis."
             exit 1
           fi
-          echo "All four unit-lane jobs succeeded."
+          echo "All unit-lane jobs succeeded."
 
   python:
     name: Python utility tests (pocketshell)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -387,6 +387,529 @@ command for cwd `/workspace/pocketshell` finds it via `find ... -mmin -5`.
 | Instrumented UI / smoke | `app/src/androidTest/` on emulator | Compose screen tests, navigation, local emulator-to-Docker agent smoke |
 | Manual smoke | Emulator + Docker | Issue-based implementer/reviewer flow, with reviewer emulator evidence before approval |
 
+## Host-CLI / area coverage guard suite, with area-scoped selection (issue #2063)
+
+The maintainer's directive: *"split our test set into different areas and run
+those areas depending on the part we're changing, and run all the tests before
+we release … the goal is not to increase the speed, the goal is to increase the
+speed while maintaining the quality — I still want the same coverage."*
+
+**Coverage is invariant. Only the *when* is granular.** Every test still runs on
+a bounded cadence; nothing is deleted, weakened, or skipped to hit a number.
+
+### What this is worth, measured — read this before treating it as a speed feature
+
+It is **not** a speed feature. It is a coverage-guard suite that also scopes
+selection, and that is the honest headline. Measured over the last 104 `main`
+commits, reproduced independently by the reviewer:
+
+| Measurement | Value |
+|---|---|
+| commits that force-full | **58–62%** (51 of the 88 with a file list; empty diffs force-full too) |
+| journeys selected, average | **143.6 of 161 — 89%** |
+| `:app` unit classes selected, average | **567.6 of 659 — 86%** |
+| emulator lane | **1.09x** (~45 min → ~41 min through the #2059 model) |
+| Unit lane | **neutral to slightly negative** — ~14% of unit test-case time saved on the 42% of commits that scope, against the guards' own cost on the rest |
+| the guards' own cost | **~170–195 s per Unit variant** on a loaded box, i.e. **+6.1 min on a full Unit run** |
+
+Nothing here is over-force-fulling: the big buckets (`scripts/*`, a non-`*Test`
+file in a test source set) are coarse but each is defensible, and no bucket has
+an obvious narrower correct answer. The selection is simply *nearly full* on a
+typical commit, because this codebase's production graph is strongly connected.
+
+**What earns the merge is the safety half.** Building this found, mechanically,
+coverage holes nothing else in the repo could see: 183 of 1047 classes resolving
+to no area through a second resolver; four `@Test`-bearing files invisible to
+every registry and Gradle filter (the #1851 shape, now baselined so a NEW one
+fails — and one promptly did: #1622's `Issue1622DeadBandScreenshotHarness.kt`
+reached `main` hours later carrying three invisible `@Test` methods and this
+guard caught it before it merged, so the baseline is five; #2065 owns
+rename-vs-exempt for all five); 29 journeys compiling against connection-core
+that a connection-core change did not run; and `:shared:core-usage:test` — the
+deliberately fail-loud reader of `pocketshell usage --json` — having no
+mechanical link to the Python that produces it. The ledger guard is the first
+mechanism here that can answer
+"did every registered class actually execute in a bounded window", which is
+exactly how #1851/#1853/#1859 were all missed until someone tripped over them.
+
+Two consequences, stated so nobody has to re-derive them:
+
+- **The guards do not run inside `./gradlew test` — they are their own CI job**
+  (`guards-test-selection`, added by **#2067**, which landed in the same batch as
+  this slice for exactly this reason). Wired into a JVM test they were paid TWICE
+  per push (debug + release) on the Unit critical path for work that touches no
+  Kotlin: `+6.1 min on every Unit job and nothing faster`, which over the last
+  104 `main` commits exactly cancelled the scoped saving. Note the cost grew as
+  the guards got stricter (~100 s → ~137 s when the B9 vocabulary mutations were
+  added, → ~155–205 s once the receiver-agnostic registrar census and the round-6
+  non-registrar-attribute case were added — a range that is mostly box load, see
+  below), which is the other reason these belong in a cheap job that runs ONCE
+  rather than inside a test task that runs per variant. **Never move them back
+  into a Gradle test task**; if a new guard needs a home, add a step to that job.
+- **The selection plan is still not consumed by CI — nothing is skipped yet.**
+  Every push remains a full run. This slice plus #2067 buy the *safety* half (the
+  coverage guards, now blocking and off the critical path) and pay for it once
+  instead of twice; the *speed* half arrives only when a later, deliberate step
+  wires the emitted plan into the test invocation. That step is where the four
+  Known limits below stop being a reporting gap and become a real coverage hole
+  (a host-CLI change whose consumer is reachable only through one of the four
+  would select a narrow set and genuinely not run the protecting test — the
+  #847 / v0.4.10 class). Re-weigh all four *for skipping* before enabling it.
+- The remaining speed is in narrowing the `scripts/*` (18 commits) and
+  test-infrastructure (15) force-full rules — 41 of the 65 force-fulls. That is
+  its own issue with its own escape oracle, not a widening inside this one.
+
+### The four pieces
+
+| Piece | What it is |
+|---|---|
+| `scripts/test-areas.txt` | the manifest — the whole taxonomy, as data |
+| `scripts/lib/test-areas.sh` | the shared classification engine every consumer reads |
+| `scripts/select-test-areas.sh` | changed paths → areas → the run plan, plus the manifest/coverage guards |
+| `scripts/check-test-execution-ledger.sh` | proves, from real JUnit results, that every class still executes |
+
+### The rule for a NEW test (do not re-litigate this)
+
+> A test's area is the area of its Gradle module, or — inside `:app` — of its
+> top-level `com.pocketshell.app.<pkg>` package.
+
+Add a test to an existing package and it inherits that package's area with **no
+manifest edit at all**. Only three things need an edit:
+
+1. a NEW top-level package or Gradle module → add a `src` + `test` row;
+2. a class whose regression class belongs to a DIFFERENT area than its package
+   → add a `class` row (today the only case is the conversation-source cluster,
+   which lives in `com.pocketshell.app.tmux` but belongs to
+   `conversation-agents`);
+3. a new production path with cross-area blast radius → add a `full` row.
+
+Forget all three and the guard fails with **"unmapped path"** while the run
+falls back to FULL. The map can only lag loudly, never silently.
+
+### Areas and tiers
+
+Nineteen areas, keyed to the existing module/package structure. Four are
+**`always`** — they run on every push regardless of the diff — and they are the
+D28/G8 worst-reopen areas plus the app shell:
+
+| always-tier area | Why it never becomes conditional |
+|---|---|
+| `connection-core` | SSH transport / lease / reconnect / grace / `tmux -CC` — D28, the #1 regression source |
+| `terminal-render` | terminal emulation + the #796/#803 drain-scheduler ANR class |
+| `conversation-agents` | conversation-source binding + agent detection — the #819/#825/#962/#1057 reopen cluster |
+| `app-shell` | App / MainActivity / DI / nav / startup / test-access seams |
+
+The other fifteen (`tmux-session`, `composer-voice`, `projects-tree`, `portfwd`,
+`files`, `hosts-settings`, `share`, `usage-costs`, `bootstrap`, `notifications`,
+`release-update`, `diagnostics-crash`, `ui-shell`, `ci-harness`, `host-cli`) are
+**`changed`**: they run when their area, an area coupled to them, or a
+force-full path is in the diff — plus nightly, plus the release gate.
+
+### Cadence — what runs when
+
+| Tier | Trigger | Scope |
+|---|---|---|
+| per-PR / per-push | every push | always-tier + affected areas + their couplings |
+| nightly | `nightly-extensive.yml` cron | everything |
+| release gate | `scripts/release-emulator-validation.sh` | everything, unchanged |
+
+### Force-full triggers (blast-radius escapes)
+
+A change whose effect leaves its own area must never silently skip the test that
+would have caught it. Any of these ⇒ run **everything**:
+
+- `.github/**`, `scripts/**`, `tests/**` — the harnesses that decide what runs
+- `gradle/**`, `**/*.gradle*`, `gradle.properties`, `gradlew*`, `cgroups.toml`,
+  `debug.keystore`, `app/lint.xml`, `app/*.pro`
+- `shared/test-support/**` — the one audited settle pump
+- `app/src/main/**/di/**`, `nav/**`, `startup/**`, `testaccess/**`, `layout/**`,
+  `App.kt`, `MainActivity.kt`, `AppTeardownScope.kt`, `MainThreadConfinement.kt`
+- `app/src/main/**/tmux/TmuxSessionViewModel.kt` — the D28 god-object seam
+  (#766 residue) where cross-area wedge bugs hide
+- `app/src/main/res/**`, both `AndroidManifest.xml`s, `app/src/debug/**`
+- **any file inside a test source set that is not itself a `*Test.kt` /
+  `*Test.java`** — a shared fixture's blast radius is exactly as unknown as a DI
+  module's
+- **any path the manifest does not match at all** (fail-safe)
+
+`shared/ui-kit/**` is an area rather than a force-full trigger, but it *couples*
+to every UI-bearing area, so a design-token change is near-full in practice.
+That is deliberate — the #453/#641 "one token, every screen" class.
+
+### The fail-safe direction is structural, not a convention
+
+`pocketshell_test_area_classify` sets its verdict to `full` **before it looks at
+anything**, and every narrower answer requires an explicit manifest row to have
+matched. There is no code path ending in "nothing matched, so run nothing": the
+fall-through *is* `full`. Deleting a rule, mistyping a glob, or dropping a whole
+record type all degrade toward running MORE. Three more one-way ratchets sit on
+top: a manifest that fails to load ⇒ full; an empty diff ⇒ full; and the
+always tier is unioned in unconditionally and last, so the smallest possible
+selection is the always tier, never the empty set.
+
+`scripts/select-test-areas-selftest.sh` proves each of those by mutating the
+input rather than asserting it in prose.
+
+### Running it
+
+```bash
+scripts/select-test-areas.sh                      # plan for the current branch diff
+scripts/select-test-areas.sh --print-plan-only    # machine-readable KEY=VALUE
+scripts/select-test-areas.sh --journeys           # every journey class + area + tier
+scripts/select-test-areas.sh --verify-manifest    # guard: the manifest is total
+scripts/select-test-areas.sh --coverage-invariant # guard: coverage is invariant
+```
+
+```bash
+scripts/select-test-areas.sh --list-classes       # every class + area + module + deps
+```
+
+`--coverage-invariant --only I8,I9` runs a subset. It exists so a self-test
+mutation can drive the one invariant it targets without paying for the other
+nine; **it is never a CI mode**, and a filtered run says so in its own verdict
+line so a partial pass cannot be read as the whole guard.
+
+The plan emits `UNIT_SHARED_TASKS` (module test tasks, unfiltered) and
+`UNIT_GRADLE_TASKS` + `UNIT_GRADLE_FILTERS` (`:app:test` with `--tests`) as
+**two invocations**, because a single `--tests` applies to every test task in
+one invocation and would filter the shared modules to nothing. In `full` mode it
+emits the byte-identical whole-graph `test` task the Unit job runs today, which
+is what keeps `scripts/check-ci-unit-forced-execution.sh` satisfied on the full
+path.
+
+`UNIT_GRADLE_FILTERS` carries **exact fully-qualified class names, never
+patterns**. Gradle's `--tests` wildcard crosses package dots — `--tests
+"com.pocketshell.app.*UsageWindowLabelTest"` really does run
+`com.pocketshell.app.usage.UsageWindowLabelTest` — so a package-shaped pattern
+silently runs far more than the plan reports. `--coverage-invariant`'s **I10**
+asserts the emitted filter set is exactly the selected `:app` unit class set and
+contains no glob metacharacter, so the reported number and the executed command
+cannot drift apart again.
+
+`UNIT_SHARED_TASKS` is derived from the selected classes' own module paths, not
+from an area→task table. **I11** asserts every shared module is run by a change
+to its own source, which is the check a hardcoded table did not have.
+
+### What actually decides that a test runs
+
+| # | Rule | Where it comes from |
+|---|---|---|
+| 1 | the run is FULL | force-full path, unmapped path, manifest load failure |
+| 2 | the class's area is `always`-tier | `area … always` rows |
+| 3 | the class's area is in the diff, or in the `couple` closure of the diff | `couple` rows |
+| 4 | the class **imports** production code of an area in the diff | the class's own `import com.pocketshell.…` lines |
+| 5 | the class sits in — or imports — a package on the host-CLI **wire seam**, and `tools/pocketshell/**` changed | the seam, derived at **both ends** |
+
+Rules 4 and 5 are the reason `couple` rows are now few and behavioural. A
+compile-level dependency must **not** get a `couple` row: rule 4 already has it,
+per class, derived from the compile graph rather than from anybody's memory.
+
+**Rule 5 exists because of #847 / v0.4.10.** `tools/pocketshell/**` is Python, so
+no Kotlin import can see it, and host-CLI/client version is a *runtime* lockstep
+— a new client calling a new subcommand against an older host CLI hangs.
+
+**A wire contract has two ends, and marking only the invoker misses half of it.**
+The first version of this seam marked "packages that invoke the CLI". No shared
+module ever shells out, so that seam had *zero* reach into `shared/*` — and
+`shared/core-usage`, whose `PocketshellUsageJsonParser` is the deliberately
+STRICT, fail-loud reader of the NDJSON `tools/pocketshell/.../usage.py` emits,
+was therefore not run by a change to the code that produces it. Every check and
+every invariant stayed green. A production package is now on the seam when any
+of these holds, each derived mechanically:
+
+| End | Rule | Reaches (examples) |
+|---|---|---|
+| **producer** | a file in it invokes the CLI (`PocketshellCommand`, literal `pocketshell …`) | `app.usage`, `app.projects`, `app.tmux` … (15 packages) |
+| **consumer** | an *invoking file* imports it — one hop; the invoker hands the reply to something, and that something is in its import set | `core.usage` (the parser), `core.storage.entity` (the CLI lockstep version columns), `uikit.model` (`HostSetupState`) … (21) |
+| **vocabulary** | a file in it names a real subcommand, where the list is read out of the producer's own top-level registrations — **every** form, through Python's `ast` | `app.settings`, which parses the `pocketshell qr-share` payload although nothing in the app ever invokes it — the payload arrives by QR scan, so no import edge exists to follow (20) |
+
+**Why the vocabulary is read with a parser and not a grep (finding B9).** That
+list used to come from one grep for `cli.add_command(…, name="…")` — *one* of
+the forms click offers. `cli.py` already registers `daemon` as
+`@cli.group(name="daemon")`, so the reader was under-reading the producer on the
+shipped tree while the guard printed a healthy-looking "16 subcommands".
+Converting four more registrations to the form `daemon` already used dropped
+`usage`, `tree`, `agents` and `qr-share` from the vocabulary, took
+`com.pocketshell.app.settings` — the one package this end exists for — **off the
+seam**, cut unit selection 570 → 560, and left **every floor green**. A floor
+cannot see that: under-reading produces a plausible number. So the reader is now
+`ast` over `cli.py` (the producer's own grammar), and it is fail-closed twice
+over: it counts registration **sites** independently of the names it resolves
+and check 7 asserts **names == sites**, and anything it cannot decode — a
+registration inside a loop or function, a `name=` behind a constant, an omitted
+name, a bare `@cli.group`, an unparseable `cli.py`, a missing `python3`, or a
+sibling module taking the group object so a registration could live outside
+`cli.py` — is reported by name and fails the guard. `python3` is therefore a
+hard dependency of `--verify-manifest`; it is already one for
+`scripts/check-ci-unit-forced-execution.sh` in the same job.
+
+**Why detection is receiver-agnostic, and not a list of recognised shapes.**
+Equality is only worth what the reader can *see*, and for five rounds the reader
+saw a registration only when its receiver was the literal name `cli`. Anything
+reached through a different binding — `_g = cli; _g.add_command(…)`, or a helper
+that takes the group as a parameter — was neither a SITE nor a NAME, so
+`names == sites` held vacuously at 13 == 13 while four subcommands vanished, the
+seam dropped from 32 packages / 820 classes to 31 / 809, and the guard printed
+a healthy-looking "13 subcommands read from 13 registration sites". Six rounds
+closed six spellings one at a time, which does not converge: the ways to name an
+object are unbounded.
+
+The reader therefore takes a **census**. It collects every `add_command` /
+`group` / `command` call node in `cli.py` whatever the receiver, resolves each
+receiver through a module-level binding environment, and gives each node exactly
+one verdict: it registers on the root group (must yield a literal name), it
+registers on a provably different object (a sub-group such as `daemon_group`, or
+the `@click.group` that defines the root — neither adds a top-level word), or the
+receiver does not resolve at all — which is UNREADABLE, because that call might
+be adding a top-level subcommand. The shipped tree reads **22 registrar calls =
+17 top-level sites + 5 non-root + 0 unresolved**, and check 7 asserts that
+identity so a node cannot silently fall out of the census. An alias is now *read
+correctly* rather than refused: reddening on it would only force the producer
+into one writing style, and the property we need is a complete vocabulary.
+
+Two escapes remain once the file itself is fully censused, and both are closed
+because the group **object** can leave `cli.py`: by import (any sibling module
+that binds this module or the root name, including `from pocketshell import cli`,
+`from .cli import *` and a run-time `importlib` — an `ast` walk, because the
+round-4 regex over import lines let all three through), and **as a value** handed
+to a helper. The second is not hypothetical: `cli.py` already does
+`register_push_card_commands(push_group)`, whose body in `cards.py` runs
+`@push_group.command("checklist")`, so passing the *root* group the same way is
+one character away. The scope is deliberate — a whole-package receiver-agnostic
+scan is unsound in the other direction, since nine `re.Match.group(…)` calls in
+this package have local receivers that no environment can resolve, and each would
+become a permanent false red. Exhaustive over the module that owns the group,
+plus a hard trip the moment the group can leave it, is the narrowest sound rule.
+
+**Round 6 corrected a false claim in that "exhaustive" premise, and the
+correction is the reason the rule is now stated as an inversion.** The census
+covers registrar *calls*, and round 5 additionally waved through every attribute
+access on the root binding on the grounds that "registrar attributes are already
+in the census". That is true of `add_command`/`group`/`command` and false of
+every other attribute — and `click.Group.commands` is a **plain dict**
+(`add_command` is literally `self.commands[name] = cmd`), so
+`cli.commands["x"] = cmd` and `cli.commands.update({…})` register a top-level
+subcommand through a path that is not a registrar call at all. Neither entered
+the census; the identity balanced over a smaller file (18 = 13 + 5 + 0) with zero
+UNREADABLE, `com.pocketshell.app.settings` fell off the seam again (32 -> 31
+packages, 820 -> 809 classes, unit selection 570 -> 560), and `--verify-manifest`
+returned rc=0. The group never left `cli.py`, so no escape check could see it.
+
+The fix applies the same inversion the receiver resolution already uses: the
+reader allows only the four attributes it can *prove* inert — `add_command`,
+`group` and `command`, each of which the census collects as an `ast.Attribute`
+node whether or not it is called, plus `main`, click's invocation entry — and
+reports **every other attribute read of the root by name**, including ones nobody
+has thought of. Adding `commands` to the registrar list was rejected: that is one
+more entry on a list of recognised spellings, which is the pattern that produced
+seven of them. Case 16g-l pins it, with `result_callback` alongside the four
+`commands` forms so the case fails if the check ever narrows back to one name.
+
+Correspondingly, the guard's OK line no longer claims it read *all* registration
+sites. It says it read the sites **it could see**, which is the claim the reader
+can actually support; the completeness argument lives in the census identity,
+the non-registrar-attribute trip, the value-escape trip and the cross-module
+trip, each of which is separately asserted and separately self-tested.
+
+**Known limits — four spellings that are still silent, measured not assumed.**
+Round 6 searched for an eighth spelling instead of waiting for one, and found
+four, all reproducing the same signature as the seventh (census 18 = 13 + 5 + 0,
+zero UNREADABLE, `com.pocketshell.app.settings` off the seam, 820 -> 809 classes,
+unit selection 570 -> 560, `--verify-manifest` rc=0). They are NOT closed, on
+purpose: the spelling-by-spelling game does not converge, and the honest move is
+to state the bound rather than buy another round.
+
+- `sys.modules[__name__].cli.commands["x"] = cmd`
+- `importlib.import_module(__name__).cli.commands["x"] = cmd`
+- `globals()["cli"].commands["x"] = cmd`
+- `@click.group(cls=DynGroup)` where the subclass's `list_commands` /
+  `get_command` synthesise entries that are never stored in `commands` at all
+
+The first three share one axis the reader cannot reach by construction: every
+check from step 1b onward is anchored on a module-level *binding*, so an
+expression that reaches the group object without ever producing an `ast.Name`
+that resolves to the root is invisible to all of them. The fourth is a different
+axis again — there is no registration to see, static or otherwise, because the
+command table is computed at run time.
+
+Closing either axis properly means the reader stops being a static reader:
+importing `cli.py` and asking the live `Group` object for `list_commands()` would
+cover all four at once, and would make the census, the escape checks and the
+cross-module scan largely redundant. That is a different design, not a patch, and
+it costs a Python import of the package inside a shell guard. Until someone makes
+that call, treat the vocabulary end as sound against every spelling that names
+the group and unsound against the four above, and read the guard's own OK line
+literally: it read the sites **it could see**.
+
+The one hop is deliberately unfiltered: it also marks collaborators that are not
+wire consumers (theme tokens imported by an invoking Composable). That
+over-selection costs time on a `tools/pocketshell/**` change *only* — `host-cli`
+is a changed-tier area nothing else puts in the diff — and a false negative
+there is #847. Measured consequence: a host-CLI change now selects **158 of 161
+journeys and 570 of 659 unit classes**, i.e. effectively a full run. That is the
+right answer for this class of change.
+
+`--verify-manifest` check 7 floors **each end separately** — producer ≥ 12,
+consumer ≥ 15, vocabulary ≥ 14, registration sites ≥ 12, seam packages under
+`shared/` ≥ 8, host-CLI-coupled classes ≥ 600 — plus the four non-floor
+assertions the vocabulary end needs (`names == sites`, `undecodable == 0`,
+`unresolved receivers == 0`, and the census identity
+`scanned == sites + non-root + unresolved`),
+because a floor is the wrong instrument for under-reading and the site floor's
+only remaining job is catching a *totally dead* reader, where the equality is
+vacuous at 0 == 0. A total-only floor is
+exactly what hid the missing end (15 packages looked healthy at zero shared
+reach), and a `>= 1` floor detects only a *totally dead* mechanism: dropping the
+two string-literal alternatives from the invoke marker used to cut the seam 15→9
+packages / 569→210 classes with nothing noticing.
+`--coverage-invariant`'s **I9** pins both journeys
+(`FolderListHostOutdatedTreeVersionDaemonDockerTest` #1509 G10,
+`FolderListOldCliHydrateDockerTest`) **and unit consumers**
+(`PocketshellUsageJsonParserTest`, `AppDatabaseTest`,
+`SessionAgentKindOptionTest`) to it by name — and for a unit pin it additionally
+asserts the emitted plan really carries that class's `:shared:…:test` task,
+because "selected" and "executed" are not the same claim.
+
+**The bound this design accepts, stated rather than hidden.** Rule 4 is the
+*direct* compile edge. It does not chase transitive production dependencies
+(test → `fileviewer` → `core-ssh`). Two stronger designs were measured on this
+tree and both degenerate: derived area-level edges applied transitively make the
+19-area graph strongly connected (every change selects 17 areas), and the
+production-to-production graph is strongly connected too (93 edges,
+composer-voice ⇄ connection-core ⇄ hosts-settings). A fully sound
+dependency-based selection on this codebase *is* "run everything". The backstops
+for the bound are the always tier, the nightly full run, and the release gate.
+
+### The executed-classes ledger — the mechanism that PROVES the invariant
+
+`check-executed-test-counts.sh` (#1646) proves a test *task* executed more than
+zero tests. That is one level too low to see this repo's recurring failure: a
+class that belongs to no suite, so nothing ever runs it, unnoticed for months
+(#1851's `ColdInstallE2eTest` / `EmulatorWorkflowE2eTest`, #1853's twelve dead
+harnesses, #1859's shard truncating at 98 of 226). All three were found
+*incidentally*. Area selection makes that class strictly more dangerous, because
+"this test did not run in this job" becomes normal and stops being suspicious.
+
+```bash
+# after any test tier, credit what actually executed
+scripts/check-test-execution-ledger.sh --record build/test-results --tier unit
+
+# fail when any registered class is unmapped, never executed, or stale
+scripts/check-test-execution-ledger.sh --verify --max-age-days 7
+```
+
+"Executed" means *appeared in a JUnit result as a testcase that was not
+skipped*. A class whose every case is `<skipped/>` is recorded as
+seen-but-skipped and does **not** satisfy the guard — an all-skipped class is
+the G3 vacuous pass, and the 72-entry
+`KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES` baseline currently invites exactly
+that mistake. A missing or empty ledger **fails**: a guard that passes with no
+evidence is decoration.
+
+The ledger is a plain TSV (`<fqcn>\t<epoch>\t<tier>`); where it is persisted is
+the CI wiring's business, not the guard's. `--verify` resolves each registered
+class through **the same single resolver** the manifest guard uses. There used
+to be two — one keyed on tracked file paths, one on FQCNs against a hardcoded
+list of source roots that contained no `shared/*/src/test/java` — and the second
+reported 183 of 1047 classes as belonging to no area, so the guard was red on
+the real tree while its self-test (synthetic `app/src/test` trees only) was
+green. Seed a complete ledger from `--list-classes` if you need one:
+
+```bash
+scripts/select-test-areas.sh --list-classes |
+  awk -v n="$(date +%s)" -F'\t' '{print $1"\t"n"\tseed"}' > build/test-execution-ledger.tsv
+```
+
+### Self-tests (all wired into the `guards-test-selection` CI job)
+
+```bash
+scripts/select-test-areas.sh --verify-manifest
+scripts/select-test-areas.sh --coverage-invariant
+scripts/select-test-areas-selftest.sh
+scripts/check-test-execution-ledger-selftest.sh
+scripts/dev-fast-gate-parity-selftest.sh
+```
+
+Those five are exactly the steps of the **`guards-test-selection`** job in
+`.github/workflows/tests.yml` (#2067). The job is a dependency of the `unit-gate`
+aggregator, which carries the literal `Unit tests` check name branch protection
+requires — so these guards are **blocking on every push**, for the same reason
+`AvdLockScriptTest` exists: a guard no lane runs is not a guard. They are NOT a
+Gradle test: no JDK, no Gradle, no Android SDK, no Docker in that job.
+
+They were briefly driven from a JVM test (`SmartTestSelectionScriptTest`) so
+`./gradlew test` would pick them up. That is deleted. Do not recreate it: a test
+task runs per variant, so it charged the suite twice per push on the Unit
+critical path — see the cost note below and the two consequences under "What
+this is worth, measured". If you add a guard, add a step to the job.
+
+**A local `scripts/full-jvm-gate.sh` green therefore does NOT cover these**, the
+same way it does not cover `check-file-size-hygiene.sh` or
+`check-test-validity.sh`. Run the five commands above directly when you touch the
+manifest, the classification engine, the journey registry, or `cli.py`.
+
+**Where its cost lands.** The five invocations take **~155–205 s**, now paid
+ONCE per push in a parallel job instead of once per Unit variant on the critical
+path. Four measurements, all at 46 cases except the first:
+
+| Run | Cases | debug | release | box load |
+|---|---|---|---|---|
+| round 5 (in `./gradlew test`) | 45 | 169.5 s | 196.1 s | ~18 |
+| round 6, run 1 (in `./gradlew test`) | 46 | 205.3 s | (not reached) | ~12–14 |
+| round 6, run 2 (in `./gradlew test`) | 46 | 154.2 s | 165.3 s | ~12 |
+| #2067, as the five direct invocations | 46 | 164.4 s (once) | — | ~12–16 |
+
+**Read the absolute number as noise-dominated, not as a budget.** The round-6
+runs are the SAME tree at the SAME case count and differ by 51 s (33%) on the
+debug variant, so a wall-clock delta cannot measure the cost of adding a case.
+The meaningful figure is structural: each mutation case rebuilds the dependency
+index once, ~11.6 s, and there are ~20 such builds across the suite. Budget by
+that, not by a stopwatch reading. The selection self-test is ~80% of the total
+and grows by one index build per case added.
+
+**The ceiling, so a later round has a number instead of drift.** The dedicated
+job's ceiling is **5 minutes wall clock**, because beyond that it becomes the
+critical path on a docs-only push. #2067 did **not** remove the ~11.6 s marginal
+cost of a mutation case — it removed the x2-variant and critical-path factors
+only. So a round that wants more than ~2 new index-rebuilding cases must
+share/cache the dependency-index build across cases FIRST. The job prints its
+per-guard and total seconds into the GitHub step summary so that drift is
+visible; that is deliberately a *reported* number and not an asserted one,
+because a 33%-variance quantity makes a terrible assertion (G6). The job also
+runs unconditionally on every push — it is a workflow job, so no area selection
+spares it, and there is no selection consumption in CI to spare it with. The
+dominant term inside it is the dependency index, rebuilt in ~20 subprocesses
+across the self-tests, which is why the import scan is one awk pass rather than a
+5709-iteration bash loop (~1.9 s → ~0.9 s per build).
+
+### The `unit-gate` aggregator has three lists, and a guard keeps them equal
+
+`unit-gate` is the job named `Unit tests`. Adding a job to the unit lane means
+touching it in **three** places — `needs:`, the `env:` mapping of
+`${{ needs.<job>.result }}`, and the `for pair in "Label:$VAR"` result loop. A
+job in the first but not the third runs, can go **RED**, and the required check
+stays **GREEN**: a red job under a green required check, which is the silent-gate
+failure #2060 exists to prevent.
+
+`scripts/check-unit-gate-wiring.sh` (run per push in `guards-static`) makes that
+mechanical instead of a comment:
+
+```bash
+scripts/check-unit-gate-wiring.sh --self-test   # eleven red->green cases
+scripts/check-unit-gate-wiring.sh               # check the real workflow
+```
+
+It asserts the check name is still literally `Unit tests`, that the three lists
+are the same set, that each env var name is its job key upper-snake-cased (so a
+label cannot be printed next to a different job's result while all three lists
+still "agree"), that every needed job exists, and that every workflow job is
+either wired into the gate or in a short named exempt list — so a NEW job cannot
+be added ungated by accident. Its C9 check additionally refuses to let the five
+selection guards above be reached from a Gradle test source or build script,
+which is the one way a well-meaning later round would silently put the ~165 s
+suite back on the Unit critical path at twice the cost. The self-test asserts its
+own case count, so the anti-vacuous guard cannot itself pass vacuously.
+
 ### Fast Static Guards
 
 `scripts/check-file-size-hygiene.sh` is a cheap repo-wide `git ls-files` guard
@@ -763,8 +1286,21 @@ scripts/dev-fast-gate.sh --profile fish-user-local-path   # scope setup-detectio
 It diffs the branch against the `origin/main` merge base, maps the changed
 paths to a minimal stage set, and calls the existing building blocks directly
 (`scripts/phone-walkthrough.sh <scenarios>` and/or
-`scripts/pre-release-confidence-gate.sh`). Mapping (default-to-full when in
-doubt):
+`scripts/pre-release-confidence-gate.sh`).
+
+Since #2063 the mapping is **data, not inline case arms**: it reads the
+`devgate` column of `scripts/test-areas.txt` through
+`scripts/lib/test-areas.sh`, so the local fast path and CI area selection can no
+longer disagree about what a path is. `devgate` is a per-ROW column rather than
+a per-AREA one precisely because the old arms split some areas across stages
+(`shared/core-ssh` was `terminal` while `shared/core-connection` fell through to
+force-full), and that is what let the refactor keep every decision unchanged.
+`scripts/dev-fast-gate-parity-selftest.sh` re-runs the original case arms
+alongside the manifest over every tracked file and asserts (a) no path became
+less conservative and (b) the paths that became MORE conservative are exactly a
+pinned, reasoned set — the `TmuxSessionViewModel.kt` seam, the Docker fixtures,
+`shared/test-support`, `app/.../layout/`, test-infrastructure files, and
+markdown. Mapping (default-to-full when in doubt):
 
 | Changed area | Stages run |
 |---|---|

--- a/scripts/check-test-execution-ledger-selftest.sh
+++ b/scripts/check-test-execution-ledger-selftest.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check-test-execution-ledger.sh (#2063).
+#
+# The guard's whole value is its RED. Every case below drives it into a
+# specific red and asserts that exact red — a stale class, an unmapped class, a
+# never-executed class, an all-skipped class, an absent ledger — and each is
+# paired with the green it is a mutation of, so "it always says FAIL" cannot
+# masquerade as coverage either.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/check-test-execution-ledger.sh"
+
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf 'ok   %s\n' "$*"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Synthetic repo: two mapped test classes plus one that no rule covers.
+# ---------------------------------------------------------------------------
+mkdir -p \
+  "$SANDBOX/scripts/lib" \
+  "$SANDBOX/app/src/test/java/com/pocketshell/app/alpha" \
+  "$SANDBOX/app/src/test/java/com/pocketshell/app/beta" \
+  "$SANDBOX/results"
+
+cp "$SCRIPT_DIR/lib/test-areas.sh" "$SANDBOX/scripts/lib/test-areas.sh"
+cp "$GUARD" "$SANDBOX/scripts/check-test-execution-ledger.sh"
+
+cat > "$SANDBOX/app/src/test/java/com/pocketshell/app/alpha/AlphaTest.kt" <<'KT'
+package com.pocketshell.app.alpha
+class AlphaTest
+KT
+cat > "$SANDBOX/app/src/test/java/com/pocketshell/app/beta/BetaTest.kt" <<'KT'
+package com.pocketshell.app.beta
+class BetaTest
+KT
+
+cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+JOURNEY_CLASSES=()
+SH
+
+MANIFEST="$SANDBOX/scripts/test-areas.txt"
+cat > "$MANIFEST" <<'MF'
+area   alpha   always   alpha area
+area   beta    changed  beta area
+
+full   scripts/*   harnesses
+
+test   app/src/*/java/com/pocketshell/app/alpha/*   alpha   full
+test   app/src/*/java/com/pocketshell/app/beta/*    beta    full
+MF
+
+git -C "$SANDBOX" init -q 2>/dev/null
+git -C "$SANDBOX" add -A >/dev/null 2>&1
+git -C "$SANDBOX" -c user.email=t@t -c user.name=t commit -qm init >/dev/null 2>&1
+
+NOW=1800000000
+DAY=86400
+
+run_guard() {
+  POCKETSHELL_TEST_AREAS_REPO_ROOT="$SANDBOX" \
+  POCKETSHELL_TEST_AREAS_MANIFEST="$MANIFEST" \
+  POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$SANDBOX/scripts/ci-journey-suite.sh" \
+  bash "$SANDBOX/scripts/check-test-execution-ledger.sh" "$@"
+}
+
+write_ledger() {
+  : > "$SANDBOX/ledger.tsv"
+  local entry
+  for entry in "$@"; do
+    printf '%s\n' "$entry" >> "$SANDBOX/ledger.tsv"
+  done
+}
+
+FRESH_ALPHA="com.pocketshell.app.alpha.AlphaTest	$NOW	unit"
+FRESH_BETA="com.pocketshell.app.beta.BetaTest	$NOW	unit"
+
+# ===========================================================================
+# CASE 1 (the GREEN this suite mutates from): both classes executed today.
+# ===========================================================================
+write_ledger "$FRESH_ALPHA" "$FRESH_BETA"
+if out="$(run_guard --verify --ledger "$SANDBOX/ledger.tsv" --now "$NOW" 2>&1)"; then
+  ok "1 a fully fresh ledger passes"
+else
+  bad "1 fresh ledger should pass:\n$out"
+fi
+
+# ===========================================================================
+# CASE 2 — a class STALE past the window reddens. (Explicitly required by the
+# issue: "proven to redden when a class goes unexecuted past the threshold".)
+# ===========================================================================
+write_ledger "$FRESH_ALPHA" "com.pocketshell.app.beta.BetaTest	$((NOW - 8 * DAY))	unit"
+if out="$(run_guard --verify --ledger "$SANDBOX/ledger.tsv" --now "$NOW" --max-age-days 7 2>&1)"; then
+  bad "2 an 8-day-stale class did NOT redden the guard:\n$out"
+elif grep -q 'have not executed within 7 day' <<<"$out" && grep -q 'BetaTest' <<<"$out"; then
+  ok "2 a class last executed 8 days ago reddens the guard, naming the class"
+else
+  bad "2 guard failed for the wrong reason:\n$out"
+fi
+
+# ===========================================================================
+# CASE 3 — the SAME ledger passes with a wider window. Proves case 2 is the
+# age threshold doing the work, not some unrelated failure.
+# ===========================================================================
+if out="$(run_guard --verify --ledger "$SANDBOX/ledger.tsv" --now "$NOW" --max-age-days 30 2>&1)"; then
+  ok "3 the same 8-day-stale ledger passes at --max-age-days 30 (the threshold is what reddened)"
+else
+  bad "3 widening the window should have passed:\n$out"
+fi
+
+# ===========================================================================
+# CASE 4 — a class that has NEVER executed reddens (the #1851 shape).
+# ===========================================================================
+write_ledger "$FRESH_ALPHA"
+if out="$(run_guard --verify --ledger "$SANDBOX/ledger.tsv" --now "$NOW" 2>&1)"; then
+  bad "4 a never-executed class did NOT redden the guard:\n$out"
+elif grep -q 'NEVER executed' <<<"$out" && grep -q 'BetaTest' <<<"$out"; then
+  ok "4 a registered class with no ledger entry reddens the guard (#1851 class)"
+else
+  bad "4 guard failed for the wrong reason:\n$out"
+fi
+
+# ===========================================================================
+# CASE 5 — a class in NO area reddens. (Explicitly required by the issue.)
+# ===========================================================================
+mkdir -p "$SANDBOX/app/src/test/java/com/pocketshell/app/orphan"
+cat > "$SANDBOX/app/src/test/java/com/pocketshell/app/orphan/OrphanTest.kt" <<'KT'
+package com.pocketshell.app.orphan
+class OrphanTest
+KT
+git -C "$SANDBOX" add -A >/dev/null 2>&1
+write_ledger "$FRESH_ALPHA" "$FRESH_BETA" "com.pocketshell.app.orphan.OrphanTest	$NOW	unit"
+if out="$(run_guard --verify --ledger "$SANDBOX/ledger.tsv" --now "$NOW" 2>&1)"; then
+  bad "5 a class belonging to no area did NOT redden the guard:\n$out"
+elif grep -q 'belong to NO area' <<<"$out" && grep -q 'OrphanTest' <<<"$out"; then
+  ok "5 a class in no area reddens the guard even though it executed today"
+else
+  bad "5 guard failed for the wrong reason:\n$out"
+fi
+git -C "$SANDBOX" rm -q --cached "app/src/test/java/com/pocketshell/app/orphan/OrphanTest.kt" >/dev/null 2>&1
+rm -rf "$SANDBOX/app/src/test/java/com/pocketshell/app/orphan"
+
+# ===========================================================================
+# CASE 6 — a MISSING ledger reddens. A guard with no evidence must not pass.
+# ===========================================================================
+rm -f "$SANDBOX/ledger.tsv"
+if out="$(run_guard --verify --ledger "$SANDBOX/ledger.tsv" --now "$NOW" 2>&1)"; then
+  bad "6 a missing ledger did NOT redden the guard:\n$out"
+elif grep -q 'ledger is missing or empty' <<<"$out"; then
+  ok "6 a missing ledger reddens the guard (no evidence is not a pass)"
+else
+  bad "6 guard failed for the wrong reason:\n$out"
+fi
+
+# ===========================================================================
+# CASE 7 — an ALL-SKIPPED class is not recorded as executed, so a later verify
+# still reports it as never-executed. This is the G3 vacuous-pass trap applied
+# to the ledger: "the class appeared in the XML" is not "the class ran".
+# ===========================================================================
+cat > "$SANDBOX/results/TEST-mixed.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="mixed" tests="3">
+  <testcase name="a" classname="com.pocketshell.app.alpha.AlphaTest" time="0.01"/>
+  <testcase name="b" classname="com.pocketshell.app.beta.BetaTest" time="0"><skipped/></testcase>
+  <testcase name="c" classname="com.pocketshell.app.beta.BetaTest" time="0"><skipped message="assumption"/></testcase>
+</testsuite>
+XML
+rm -f "$SANDBOX/ledger.tsv"
+if ! out="$(run_guard --record "$SANDBOX/results" --ledger "$SANDBOX/ledger.tsv" --tier unit --now "$NOW" 2>&1)"; then
+  bad "7 --record failed:\n$out"
+elif grep -q 'AlphaTest' "$SANDBOX/ledger.tsv" && ! grep -q 'BetaTest' "$SANDBOX/ledger.tsv"; then
+  ok "7 --record credits the class that ran and NOT the all-skipped class"
+else
+  bad "7 record credited the wrong classes:\n$(cat "$SANDBOX/ledger.tsv")"
+fi
+if out="$(run_guard --verify --ledger "$SANDBOX/ledger.tsv" --now "$NOW" 2>&1)"; then
+  bad "8 an all-skipped class satisfied the ledger — the G3 hole is open:\n$out"
+elif grep -q 'NEVER executed' <<<"$out" && grep -q 'BetaTest' <<<"$out"; then
+  ok "8 the all-skipped class is still reported as never executed"
+else
+  bad "8 guard failed for the wrong reason:\n$out"
+fi
+
+# ===========================================================================
+# CASE 9 — a --record over a result set with no testcases at all is refused,
+# rather than silently leaving a stale ledger for verify to misread.
+# ===========================================================================
+mkdir -p "$SANDBOX/empty-results"
+cat > "$SANDBOX/empty-results/TEST-none.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="none" tests="0"></testsuite>
+XML
+if out="$(run_guard --record "$SANDBOX/empty-results" --ledger "$SANDBOX/ledger.tsv" --now "$NOW" 2>&1)"; then
+  bad "9 recording a zero-testcase result set was accepted:\n$out"
+elif grep -q 'refusing to record an empty run' <<<"$out"; then
+  ok "9 recording a zero-testcase result set is refused"
+else
+  bad "9 record failed for the wrong reason:\n$out"
+fi
+
+# ===========================================================================
+# CASE 10 — --record MERGES: a later tier's results must not erase an earlier
+# tier's entries. The real cadence records unit, emulator and nightly
+# separately; a clobbering record would make every non-latest tier look stale.
+# ===========================================================================
+write_ledger "com.pocketshell.app.beta.BetaTest	$((NOW - DAY))	emulator"
+mkdir -p "$SANDBOX/unit-results"
+cat > "$SANDBOX/unit-results/TEST-unit.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="unit" tests="1">
+  <testcase name="a" classname="com.pocketshell.app.alpha.AlphaTest" time="0.01"/>
+</testsuite>
+XML
+run_guard --record "$SANDBOX/unit-results" --ledger "$SANDBOX/ledger.tsv" --tier unit --now "$NOW" >/dev/null 2>&1
+if grep -q 'AlphaTest' "$SANDBOX/ledger.tsv" && grep -q 'BetaTest' "$SANDBOX/ledger.tsv"; then
+  ok "10 --record merges tiers instead of clobbering the previous tier's entries"
+else
+  bad "10 record clobbered the ledger:\n$(cat "$SANDBOX/ledger.tsv")"
+fi
+
+# ===========================================================================
+# CASES 11-13 — THE REAL TREE.
+#
+# Cases 1-10 all run against synthetic app-style temp trees, and that is exactly
+# how round 1 shipped a guard that was RED on the real repository: the FQCN
+# resolver probed a hardcoded list of source roots that contained no
+# `shared/*/src/test/java`, so 183 of 1047 registered classes — every shared
+# module unit test, including all 49 core-ssh and 22 core-connection D28
+# classes — reported "belongs to NO area". The synthetic cases could not see it
+# because every class in them lives under `app/src/test/java`.
+#
+# So the real tree is now a case, and it is paired with two mutations so it is
+# not merely "a guard that says OK".
+# ===========================================================================
+SELECT="$SCRIPT_DIR/select-test-areas.sh"
+REAL_NOW=1800000000
+REAL_LEDGER="$SANDBOX/real-ledger.tsv"
+
+bash "$SELECT" --list-classes 2>/dev/null |
+  awk -v n="$REAL_NOW" -F'\t' '{print $1"\t"n"\tunit"}' > "$REAL_LEDGER"
+real_count="$(wc -l < "$REAL_LEDGER" | tr -d ' ')"
+
+if [[ "$real_count" -lt 500 ]]; then
+  bad "11 could not build a real-tree ledger (only $real_count classes) — the class listing is broken"
+elif out="$(bash "$GUARD" --verify --ledger "$REAL_LEDGER" --now "$REAL_NOW" 2>&1)"; then
+  ok "11 a complete fresh ledger of all $real_count REAL registered classes passes --verify"
+else
+  bad "11 --verify is RED against a complete fresh real-tree ledger:\n$out"
+fi
+
+# CASE 12 — selectivity for case 11: drop ONE real class and the guard must name
+# it. Without this, case 11 could pass with the guard doing nothing.
+dropped="com.pocketshell.core.ssh.SshLeaseManagerTest"
+grep -v "^${dropped}	" "$REAL_LEDGER" > "$SANDBOX/real-ledger-minus.tsv"
+if out="$(bash "$GUARD" --verify --ledger "$SANDBOX/real-ledger-minus.tsv" --now "$REAL_NOW" 2>&1)"; then
+  bad "12 dropping $dropped from the real ledger did NOT redden the guard:\n$out"
+elif grep -q 'NEVER executed' <<<"$out" && grep -q "$dropped" <<<"$out"; then
+  ok "12 dropping one real shared-module class reddens the guard, naming it"
+else
+  bad "12 guard failed for the wrong reason:\n$out"
+fi
+
+# CASE 13 — the EXACT round-1 defect, reproduced through the FQCN resolver on
+# the real tree: with the core-ssh rules removed from the manifest, every
+# core-ssh class must be reported as belonging to NO area. Round 1 produced this
+# red from an intact manifest, because the resolver could not find the files.
+real_mut="$SANDBOX/real-manifest-no-core-ssh.txt"
+grep -v '^src    shared/core-ssh/\*' "$SCRIPT_DIR/test-areas.txt" |
+  grep -v '^test   shared/core-ssh/\*' > "$real_mut"
+if out="$(POCKETSHELL_TEST_AREAS_MANIFEST="$real_mut" \
+          bash "$GUARD" --verify --ledger "$REAL_LEDGER" --now "$REAL_NOW" 2>&1)"; then
+  bad "13 removing the core-ssh manifest rules did NOT redden the real-tree area check:\n$out"
+elif grep -q 'belong to NO area' <<<"$out" && grep -q 'com.pocketshell.core.ssh.' <<<"$out"; then
+  ok "13 removing the core-ssh rules reddens the real-tree 'no area' check, naming core-ssh classes"
+else
+  bad "13 guard failed for the wrong reason:\n$out"
+fi
+
+# CASE 14 — the round-1 defect ITSELF, replayed as a code mutation: a resolver
+# that only knows about `app/src/**` roots. That is precisely what
+# POCKETSHELL_TA_CLASS_SEARCH_ROOTS was, and it made this guard red for 183
+# classes while every synthetic case stayed green. The mutation must reproduce
+# that exact red, and it must be proven LIVE first.
+MUTDIR="$SANDBOX/mut-scripts"
+mkdir -p "$MUTDIR/lib"
+cp "$GUARD" "$MUTDIR/check-test-execution-ledger.sh"
+cp "$SCRIPT_DIR/lib/test-areas.sh" "$MUTDIR/lib/test-areas.sh"
+cp "$SCRIPT_DIR/test-areas.txt" "$MUTDIR/test-areas.txt"
+sed -i '/registry entries$/a\  if [[ "$fqcn" != com.pocketshell.app.* ]]; then printf ""; return 1; fi' \
+  "$MUTDIR/lib/test-areas.sh"
+if ! grep -q 'if \[\[ "\$fqcn" != com.pocketshell.app.\* \]\]; then printf ""; return 1; fi' "$MUTDIR/lib/test-areas.sh"; then
+  bad "14 MUTATION DID NOT APPLY — the app-only resolver mutant is not live, so 14's verdict would be meaningless"
+else
+  out="$(POCKETSHELL_TEST_AREAS_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" \
+         POCKETSHELL_TEST_AREAS_MANIFEST="$MUTDIR/test-areas.txt" \
+         POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$SCRIPT_DIR/ci-journey-suite.sh" \
+         bash "$MUTDIR/check-test-execution-ledger.sh" --verify --ledger "$REAL_LEDGER" --now "$REAL_NOW" 2>&1)"
+  if grep -q 'belong to NO area' <<<"$out" &&
+     grep -q 'com.pocketshell.core.ssh.' <<<"$out" &&
+     grep -q 'com.pocketshell.core.connection.' <<<"$out"; then
+    ok "14 an app-only class resolver (the round-1 shape) reddens the real-tree guard for core-ssh and core-connection"
+  else
+    bad "14 the app-only-roots resolver did NOT reproduce the round-1 red:\n$(grep -E 'OK:|FAIL:' <<<"$out")"
+  fi
+fi
+
+# CASE 15 (round-2 finding B7b) — THE GUARD MUST READ THE SINGLE RESOLVER, NOT
+# A COPY OF ITS CHAIN.
+#
+# Round 2 re-inlined `${CLASS_AREA:-${CLASS_RESOLVED:-${PKG_TEST_AREA:-}}}` at
+# this guard's call site — at the exact spot of the round-1 B4 two-resolver
+# defect. The reviewer correctly called it LATENT: the inline copy is equivalent
+# to the resolver *today*, so no mutation of the tree as it stands can tell them
+# apart. What distinguishes them is a FOURTH fallback added to the resolver, so
+# this case builds exactly that and runs BOTH shapes against it:
+#
+#   15a  resolver gains a 4th fallback, guard reads the resolver's global  -> GREEN
+#   15b  same 4th fallback, guard re-inlines the 3-term chain              -> RED
+#
+# 15b is the round-2 code. Without 15a the mutation would just look broken; with
+# both, the pair proves the routing itself is load-bearing.
+B7DIR="$SANDBOX/mut-b7b"
+mkdir -p "$B7DIR/lib"
+cp "$GUARD" "$B7DIR/check-test-execution-ledger.sh"
+cp "$SCRIPT_DIR/lib/test-areas.sh" "$B7DIR/lib/test-areas.sh"
+cp "$SCRIPT_DIR/test-areas.txt" "$B7DIR/test-areas.txt"
+
+# The 4th fallback: force one real shared-module class out of all three existing
+# maps, and answer it only from a new last-resort table.
+python3 - "$B7DIR/lib/test-areas.sh" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+anchor = '  [[ -z "$POCKETSHELL_TEST_AREA_FOR_CLASS" ]] && POCKETSHELL_TEST_AREA_FOR_CLASS="${POCKETSHELL_TA_PKG_TEST_AREA[$pkg]:-}"'
+assert s.count(anchor) == 1, "B7b anchor not unique"
+inject = (
+    '  # MUTANT 15: hide one class from all three existing maps ...\n'
+    '  if [[ "$fqcn" == com.pocketshell.core.usage.PocketshellUsageJsonParserTest ]]; then\n'
+    '    unset "POCKETSHELL_TA_CLASS_AREA[$fqcn]"\n'
+    '    unset "POCKETSHELL_TA_CLASS_RESOLVED[$fqcn]"\n'
+    '    unset "POCKETSHELL_TA_PKG_TEST_AREA[$pkg]"\n'
+    '    # ... and answer it only from a FOURTH fallback the resolver alone knows.\n'
+    '    POCKETSHELL_TEST_AREA_FOR_CLASS="usage-costs"\n'
+    '  fi\n'
+)
+s = s.replace(anchor, anchor + '\n' + inject)
+open(p, "w").write(s)
+PY
+grep -q 'MUTANT 15' "$B7DIR/lib/test-areas.sh" ||
+  bad "15 MUTATION DID NOT APPLY — the fourth-fallback resolver is not live, so 15's verdict would be meaningless"
+
+run_b7() {
+  POCKETSHELL_TEST_AREAS_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" \
+  POCKETSHELL_TEST_AREAS_MANIFEST="$B7DIR/test-areas.txt" \
+  POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$SCRIPT_DIR/ci-journey-suite.sh" \
+  bash "$B7DIR/check-test-execution-ledger.sh" --verify --ledger "$REAL_LEDGER" --now "$REAL_NOW" 2>&1
+}
+
+out="$(run_b7)"
+if grep -q 'every registered class belongs to an area' <<<"$out"; then
+  ok "15a the SHIPPED guard follows a fourth resolver fallback (it reads POCKETSHELL_TEST_AREA_FOR_CLASS, not a copy of the chain)"
+else
+  bad "15a the shipped guard did not follow the resolver's fourth fallback:\n$(grep -E 'OK:|FAIL:' <<<"$out")"
+fi
+
+# 15b — put the round-2 inlined chain back and watch the same tree go red.
+python3 - "$B7DIR/check-test-execution-ledger.sh" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+anchor = '    pocketshell_test_area_for_class "$cls" >/dev/null && area="$POCKETSHELL_TEST_AREA_FOR_CLASS"'
+assert s.count(anchor) == 1, "B7b guard anchor not unique"
+s = s.replace(anchor,
+  '    pocketshell_test_area_for_class "$cls" >/dev/null && \\\n'
+  '      area="${POCKETSHELL_TA_CLASS_AREA[${cls%%#*}]:-${POCKETSHELL_TA_CLASS_RESOLVED[${cls%%#*}]:-${POCKETSHELL_TA_PKG_TEST_AREA[${cls%.*}]:-}}}"  # MUTANT 15b\n')
+open(p, "w").write(s)
+PY
+grep -q 'MUTANT 15b' "$B7DIR/check-test-execution-ledger.sh" ||
+  bad "15b MUTATION DID NOT APPLY — the re-inlined chain is not live in the copy"
+out="$(run_b7)"
+if grep -q 'belong to NO area' <<<"$out" &&
+   grep -q 'com.pocketshell.core.usage.PocketshellUsageJsonParserTest' <<<"$out"; then
+  ok "15b re-inlining the resolution chain (the round-2 shape) makes the SAME tree red — the single-resolver routing is load-bearing, not cosmetic"
+else
+  bad "15b the re-inlined chain behaved identically, so 15a proves nothing:\n$(grep -E 'OK:|FAIL:' <<<"$out")"
+fi
+
+echo
+echo "check-test-execution-ledger selftest: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/check-test-execution-ledger.sh
+++ b/scripts/check-test-execution-ledger.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# Executed-classes ledger guard (issue #2063, analysis #2059).
+#
+# THE CLASS THIS EXISTS TO KILL
+#
+# `check-executed-test-counts.sh` (#1646) proves a test TASK executed more than
+# zero tests. That is one level too low to see the failure this repo keeps
+# hitting: a test class that belongs to NO suite, so nothing ever runs it, and
+# nobody notices for months. #1851 found `ColdInstallE2eTest` and
+# `EmulatorWorkflowE2eTest` in that state by accident. #1853 found twelve dead
+# shell harnesses the same way. #1859 found a nightly shard silently truncating
+# at 98 of 226 tests — which leaves 128 classes unexecuted while every task-level
+# count check stays green. All three were found INCIDENTALLY. None was found by
+# a guard.
+#
+# Area-scoped selection (#2063) makes that class strictly more dangerous,
+# because "this test did not run in this job" becomes NORMAL and therefore stops
+# being suspicious. The coverage invariant — every test still runs on a bounded
+# cadence — cannot rest on the manifest being correct; it has to be OBSERVED.
+# This guard is that observation: it reads what actually executed, and fails
+# when a registered class has not been seen inside the cadence window.
+#
+# WHAT "EXECUTED" MEANS HERE
+#
+# Appearing in a JUnit result XML as a testcase that was NOT skipped. A class
+# whose every case is `<skipped/>` is recorded as SEEN-BUT-SKIPPED and does NOT
+# satisfy the guard: an all-skipped class is the G3 vacuous pass, and treating it
+# as coverage is exactly the mistake the 72-entry
+# KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES baseline currently invites.
+#
+# USAGE
+#   check-test-execution-ledger.sh --record <results-root> [--tier NAME]
+#       Scan <results-root> recursively for TEST-*.xml / *.xml JUnit results and
+#       upsert `class -> last executed at` into the ledger.
+#
+#   check-test-execution-ledger.sh --verify [--max-age-days N]
+#       Fail when any registered test class (a) belongs to no area, or (b) has
+#       not executed within N days (default 7).
+#
+#   --ledger PATH     ledger file (default $POCKETSHELL_TEST_LEDGER or
+#                     build/test-execution-ledger.tsv)
+#   --now EPOCH       pin "now" (tests and reproducible runs)
+#   --report          print findings, always exit 0
+#   --allow-empty     verify against an absent/empty ledger without failing.
+#                     ONE-TIME seeding only; see the comment at is_ledger_usable.
+#
+# LEDGER FORMAT (tab-separated, sorted, human-diffable)
+#   <fqcn>\t<epoch-seconds>\t<tier>
+#
+# WHERE THE LEDGER LIVES
+#
+# Deliberately not decided by this script. It is a plain file; the CI wiring
+# restores it from an Actions cache (rolling key) before `--record` and saves it
+# after, and the release gate verifies it. Keeping persistence out of the guard
+# is what lets the self-test drive it entirely from temp directories.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${POCKETSHELL_TEST_AREAS_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+MANIFEST="${POCKETSHELL_TEST_AREAS_MANIFEST:-$SCRIPT_DIR/test-areas.txt}"
+JOURNEY_SUITE="${POCKETSHELL_TEST_AREAS_JOURNEY_SUITE:-$SCRIPT_DIR/ci-journey-suite.sh}"
+
+# shellcheck source=lib/test-areas.sh
+source "$SCRIPT_DIR/lib/test-areas.sh"
+POCKETSHELL_TA_REPO_ROOT="$REPO_ROOT"
+
+MODE=""
+RESULTS_ROOT=""
+TIER="unspecified"
+LEDGER="${POCKETSHELL_TEST_LEDGER:-$REPO_ROOT/build/test-execution-ledger.tsv}"
+MAX_AGE_DAYS=7
+NOW="$(date +%s)"
+REPORT_ONLY=0
+ALLOW_EMPTY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --record) MODE="record"; RESULTS_ROOT="$2"; shift 2 ;;
+    --verify) MODE="verify"; shift ;;
+    --tier) TIER="$2"; shift 2 ;;
+    --ledger) LEDGER="$2"; shift 2 ;;
+    --max-age-days) MAX_AGE_DAYS="$2"; shift 2 ;;
+    --now) NOW="$2"; shift 2 ;;
+    --report) REPORT_ONLY=1; shift ;;
+    --allow-empty) ALLOW_EMPTY=1; shift ;;
+    -h|--help) sed -n '2,50p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "error: one of --record <dir> or --verify is required" >&2
+  exit 1
+fi
+if ! [[ "$MAX_AGE_DAYS" =~ ^[0-9]+$ ]]; then
+  echo "error: --max-age-days must be a non-negative integer" >&2
+  exit 1
+fi
+if ! [[ "$NOW" =~ ^[0-9]+$ ]]; then
+  echo "error: --now must be epoch seconds" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# JUnit XML -> "<classname>\t<ran|skipped>"
+#
+# The XML is re-split so every tag starts a line, which makes both the
+# self-closing `<testcase .../>` form and the `<testcase>…<skipped/></testcase>`
+# form parseable without an XML library. A class counts as RAN as soon as one of
+# its cases ran; all-skipped classes are reported separately and do NOT count.
+# ---------------------------------------------------------------------------
+parse_results() {
+  local root="$1"
+  [[ -d "$root" ]] || return 0
+  find "$root" -type f -name '*.xml' -print0 2>/dev/null |
+    xargs -0 -r sed 's/</\n</g' 2>/dev/null |
+    awk '
+      /^<testcase/ {
+        cls = ""
+        if (match($0, /classname="[^"]*"/)) {
+          cls = substr($0, RSTART + 11, RLENGTH - 12)
+        }
+        if (cls == "") { next }
+        if ($0 ~ /\/>[[:space:]]*$/) { print cls "\tran"; cur = ""; next }
+        cur = cls; skipped = 0
+        next
+      }
+      /^<skipped/ { if (cur != "") skipped = 1; next }
+      /^<\/testcase/ {
+        if (cur != "") { print cur "\t" (skipped ? "skipped" : "ran"); cur = "" }
+        next
+      }
+    '
+}
+
+# ---------------------------------------------------------------------------
+# Registered classes: every tracked *Test.kt across every test source set, plus
+# every journey-registry entry (some registry entries name a second class that
+# lives inside a sibling's file, so the registry is not a strict subset).
+# ---------------------------------------------------------------------------
+# Reads THE index (scripts/lib/test-areas.sh) rather than re-deriving the class
+# set. Round 1 had two derivations and two resolvers; the FQCN-side one probed a
+# hardcoded list of source roots that omitted every `shared/*/src/test/java`, so
+# 183 of 1047 registered classes — all 49 core-ssh and 22 core-connection D28
+# classes among them — reported "belongs to NO area" and this guard was red on
+# the real tree while its self-test (synthetic app-style trees only) stayed
+# green. One derivation, one resolver, and a real-tree self-test case now.
+registered_classes() {
+  pocketshell_test_areas_build_index
+  local fqcn
+  printf '%s\n' "${!POCKETSHELL_TA_CLASS_PATH[@]}"
+
+  if [[ -f "$JOURNEY_SUITE" ]]; then
+    sed -nE \
+      -e 's/.*"\$FQCN_PREFIX\.([A-Za-z0-9_]+)(#[^"]*)?".*/com.pocketshell.app.proof.\1/p' \
+      -e 's/.*"(com\.pocketshell\.app\.[A-Za-z0-9_.]+)(#[^"]*)?".*/\1/p' \
+      "$JOURNEY_SUITE" | grep -E '\.[A-Z][A-Za-z0-9_]*$'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# record
+# ---------------------------------------------------------------------------
+do_record() {
+  if [[ ! -d "$RESULTS_ROOT" ]]; then
+    echo "::error title=Test-execution ledger (issue #2063)::results root not found: $RESULTS_ROOT"
+    return 1
+  fi
+
+  local -A ran=()
+  local -A seen=()
+  local cls state
+  while IFS=$'\t' read -r cls state; do
+    [[ -z "$cls" ]] && continue
+    seen["$cls"]=1
+    [[ "$state" == "ran" ]] && ran["$cls"]=1
+  done < <(parse_results "$RESULTS_ROOT")
+
+  if [[ "${#seen[@]}" -eq 0 ]]; then
+    # A record pass that saw zero testcases is the vacuous-green shape
+    # process.md catalogues: it would leave the ledger untouched and the next
+    # verify would blame the age threshold instead of the empty result set.
+    echo "::error title=Test-execution ledger (issue #2063)::no JUnit testcases found under $RESULTS_ROOT — refusing to record an empty run"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$LEDGER")"
+  local -A merged=()
+  local -A merged_tier=()
+  if [[ -f "$LEDGER" ]]; then
+    local l_cls l_at l_tier
+    while IFS=$'\t' read -r l_cls l_at l_tier; do
+      [[ -z "$l_cls" ]] && continue
+      merged["$l_cls"]="$l_at"
+      merged_tier["$l_cls"]="$l_tier"
+    done < "$LEDGER"
+  fi
+  for cls in "${!ran[@]}"; do
+    merged["$cls"]="$NOW"
+    merged_tier["$cls"]="$TIER"
+  done
+
+  local tmp
+  tmp="$(mktemp)"
+  for cls in "${!merged[@]}"; do
+    printf '%s\t%s\t%s\n' "$cls" "${merged[$cls]}" "${merged_tier[$cls]:-unspecified}"
+  done | LC_ALL=C sort > "$tmp"
+  mv "$tmp" "$LEDGER"
+
+  local skipped_only=0
+  for cls in "${!seen[@]}"; do
+    [[ -z "${ran[$cls]:-}" ]] && skipped_only=$((skipped_only + 1))
+  done
+  echo "recorded ${#ran[@]} executed class(es) into $LEDGER (tier=$TIER, now=$NOW)"
+  echo "  ${#seen[@]} class(es) present in results; $skipped_only were ALL-SKIPPED and were NOT recorded as executed"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# verify
+#
+# A missing or empty ledger FAILS. That direction is deliberate and it is the
+# whole point: a guard that passes when it has no evidence is decoration, and
+# an absent ledger is exactly the state a broken record step produces. Seeding
+# is an explicit, visible `--allow-empty` run against a known full-suite result
+# set, not a silent default.
+# ---------------------------------------------------------------------------
+is_ledger_usable() {
+  [[ -s "$LEDGER" ]]
+}
+
+do_verify() {
+  local failures=0
+  echo "== test-execution ledger =="
+  echo "ledger:  $LEDGER"
+  echo "window:  ${MAX_AGE_DAYS} day(s)  (now=$NOW)"
+
+  if ! pocketshell_test_areas_load "$MANIFEST"; then
+    echo "FAIL: area manifest did not load:"
+    printf '  %s\n' "${POCKETSHELL_TA_LOAD_ERRORS[@]}"
+    failures=$((failures + 1))
+  fi
+
+  local have_ledger=1
+  if ! is_ledger_usable; then
+    have_ledger=0
+    if [[ "$ALLOW_EMPTY" -eq 1 ]]; then
+      echo "WARN: ledger is missing/empty and --allow-empty was passed (one-time seeding)."
+    else
+      echo "FAIL: ledger is missing or empty — there is NO evidence that any test executed."
+      failures=$((failures + 1))
+    fi
+  fi
+
+  local -A last=()
+  if [[ "$have_ledger" -eq 1 ]]; then
+    local l_cls l_at l_tier
+    while IFS=$'\t' read -r l_cls l_at l_tier; do
+      [[ -z "$l_cls" ]] && continue
+      last["$l_cls"]="$l_at"
+    done < "$LEDGER"
+  fi
+
+  # Build the index HERE, in this shell. `area="$(pocketshell_test_area_for_class …)"`
+  # forks, and a lazily-built index inside that fork is discarded on every
+  # class — an O(n) index rebuilt n times, which is a two-minute hang rather
+  # than a wrong answer, but a hang is still a guard nobody will keep enabled.
+  pocketshell_test_areas_build_index
+
+  local cutoff=$(( NOW - MAX_AGE_DAYS * 86400 ))
+  local -a no_area=() never=() stale=()
+  local -A seen_registered=()
+  local cls area at total=0
+  while IFS= read -r cls; do
+    [[ -z "$cls" ]] && continue
+    [[ -n "${seen_registered[$cls]:-}" ]] && continue
+    seen_registered["$cls"]=1
+    total=$((total + 1))
+
+    # THE resolver, read through its published global. Round-2 finding B7b: this
+    # line used to re-inline the resolution chain right here — at the exact site
+    # of the round-1 B4 two-resolver defect — so a fourth fallback added to
+    # pocketshell_test_area_for_class would silently not apply in the one guard
+    # whose whole job is to prove no class is unreachable.
+    area=""
+    pocketshell_test_area_for_class "$cls" >/dev/null && area="$POCKETSHELL_TEST_AREA_FOR_CLASS"
+    if [[ -z "$area" ]]; then
+      no_area+=("$cls")
+    fi
+
+    at="${last[$cls]:-}"
+    if [[ -z "$at" ]]; then
+      never+=("$cls")
+    elif [[ "$at" -lt "$cutoff" ]]; then
+      stale+=("$cls (last executed $(( (NOW - at) / 86400 ))d ago)")
+    fi
+  done < <(registered_classes)
+
+  echo "classes: $total registered"
+
+  if [[ "${#no_area[@]}" -gt 0 ]]; then
+    echo
+    echo "FAIL: ${#no_area[@]} registered class(es) belong to NO area — area selection can never choose them:"
+    printf '  %s\n' "${no_area[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK: every registered class belongs to an area"
+  fi
+
+  if [[ "$have_ledger" -eq 1 ]]; then
+    if [[ "${#never[@]}" -gt 0 ]]; then
+      echo
+      echo "FAIL: ${#never[@]} registered class(es) have NEVER executed in the ledger (#1851 class):"
+      printf '  %s\n' "${never[@]}"
+      failures=$((failures + 1))
+    fi
+    if [[ "${#stale[@]}" -gt 0 ]]; then
+      echo
+      echo "FAIL: ${#stale[@]} registered class(es) have not executed within ${MAX_AGE_DAYS} day(s):"
+      printf '  %s\n' "${stale[@]}"
+      failures=$((failures + 1))
+    fi
+    if [[ "${#never[@]}" -eq 0 && "${#stale[@]}" -eq 0 ]]; then
+      echo "OK: every registered class executed within the ${MAX_AGE_DAYS}-day window"
+    fi
+  fi
+
+  if [[ "$REPORT_ONLY" -eq 1 ]]; then
+    echo
+    echo "Report mode (--report): findings printed; guard does not fail."
+    return 0
+  fi
+  if [[ "$failures" -gt 0 ]]; then
+    echo
+    echo "::error title=Test-execution ledger (issue #2063)::$failures ledger check(s) failed. A registered test class is unmapped, never executed, or has fallen outside the ${MAX_AGE_DAYS}-day cadence window. Coverage is NOT invariant until this is green."
+    return 1
+  fi
+  echo
+  echo "PASS: every registered test class executed inside the cadence window."
+  return 0
+}
+
+case "$MODE" in
+  record) do_record; exit $? ;;
+  verify) do_verify; exit $? ;;
+esac

--- a/scripts/check-unit-gate-wiring.sh
+++ b/scripts/check-unit-gate-wiring.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# check-unit-gate-wiring.sh — issue #2067
+#
+# THE HAZARD THIS EXISTS FOR
+#
+# `main`'s ruleset requires one check literally named `Unit tests`. Since #2060
+# that name belongs to the ~10-second `unit-gate` aggregator, which fans out to
+# the real unit-lane jobs. The aggregator carries the blocking contract in THREE
+# separate lists that nothing forced to agree:
+#
+#   1. `needs: [...]`                      — which jobs must finish first
+#   2. `env: VAR: ${{ needs.<job>.result }}` — which results are read
+#   3. the `for pair in "Label:$VAR"` loop  — which results are checked
+#
+# A job present in (1) but missing from (2)/(3) RUNS, can go RED, and the
+# required check stays GREEN — a red job under a green required check, which is
+# the precise silent-gate failure #2060 was created to prevent. A job present in
+# (3) but not (1) reads an empty string and is equally decorative. And a job
+# added to the workflow but wired into none of them is simply not gated at all.
+#
+# So this guard asserts, mechanically, per push:
+#
+#   C1  the aggregator is still named exactly `Unit tests`     (the ruleset contract)
+#   C2  its `needs:` list is non-empty                          (no vacuous gate)
+#   C3  every needed job actually exists in the workflow
+#   C4  set(needs) == set(jobs read in `env:`)                  (list 1 == list 2)
+#   C5  each env var name is its job key upper-snake-cased      (no crossed wires)
+#   C6  set(env var names) == set(vars consumed by the loop)    (list 2 == list 3)
+#   C7  every workflow job is either wired into the gate or explicitly exempt
+#   C8  every exempt name still exists                          (the list cannot rot)
+#   C9  the #2063 selection guards are NOT reachable from a Gradle test task
+#
+# C5 is the subtle one: without it `GUARDS_STATIC: ${{ needs.guards-ci-harness.result }}`
+# passes C4 and C6 while the loop prints one job's label next to another job's
+# result — every list "agrees" and the gate silently checks the wrong thing twice
+# while never checking a third.
+#
+# C7's exempt set is deliberately small and named, so adding ANY new job forces a
+# conscious decision: wire it into the required check, or say out loud why it is
+# not part of it.
+#
+# C9 is the other half of #2067 and the one a future round is most likely to
+# undo by good intentions. #2063 originally reached its coverage guards through a
+# JVM test so `./gradlew test` would run them. That is correct instinct and the
+# wrong lane: `test` runs BOTH variants, so the ~165 s suite was charged twice per
+# push, on the Unit critical path, for work that compiles nothing — measured over
+# 104 `main` commits as exactly cancelling the scheme's own saving. They now live
+# in the `guards-test-selection` job. C9 makes "do not put them back" mechanical
+# rather than a comment in a doc nobody re-reads.
+#
+#   scripts/check-unit-gate-wiring.sh              # check the real workflow
+#   scripts/check-unit-gate-wiring.sh --self-test  # prove the checks can go red
+#
+# No JVM, no Gradle, no network. Runs in `guards-static`, which is itself one of
+# the jobs this guard requires to be wired in.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+DEFAULT_WORKFLOW="$ROOT_DIR/.github/workflows/tests.yml"
+
+# The aggregator that carries the protected-branch check name.
+GATE_JOB="unit-gate"
+GATE_CHECK_NAME="Unit tests"
+
+# Jobs that are deliberately NOT part of the `Unit tests` required check.
+# Each one is either its own required context or a batched heavy lane.
+EXEMPT_JOBS=(
+  "unit-gate"                # the aggregator itself
+  "python"                   # separate required check: Python utility tests (pocketshell)
+  "integration"              # batched Docker lane, not a per-PR blocker
+  "emulator-journey"         # batched emulator lane, verdict-gated below
+  "emulator-journey-verdict" # the emulator lane's own aggregate verdict
+)
+
+# C9: the #2063 coverage guards belong to `guards-test-selection`, never to a
+# Gradle test task. Matched against unit/instrumentation test sources and build
+# scripts — the two places from which a Gradle test could shell out to them.
+SELECTION_GUARD_SCRIPTS='select-test-areas\.sh|select-test-areas-selftest\.sh|check-test-execution-ledger\.sh|check-test-execution-ledger-selftest\.sh|dev-fast-gate-parity-selftest\.sh'
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# --- parsing -----------------------------------------------------------------
+# The workflow's shape is fixed and small, so these are targeted extractors, not
+# a YAML parser. Every one of them fails loudly when it finds nothing: "I could
+# not read it" must never read the same as "it is fine".
+
+job_keys() {
+  # Top-level job keys: exactly two spaces of indent, inside the `jobs:` mapping.
+  awk '
+    !injobs { if ($0 ~ /^jobs:[[:space:]]*$/) injobs = 1; next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
+      key = $0
+      sub(/^  /, "", key)
+      sub(/:.*$/, "", key)
+      print key
+    }
+  ' "$1"
+}
+
+job_block() {
+  # Everything under job `$2`, up to the next top-level job key.
+  awk -v want="$2" '
+    !injobs { if ($0 ~ /^jobs:[[:space:]]*$/) injobs = 1; next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
+      key = $0
+      sub(/^  /, "", key)
+      sub(/:.*$/, "", key)
+      inblock = (key == want)
+      next
+    }
+    inblock { print }
+  ' "$1"
+}
+
+sorted_unique() {
+  # stdin -> newline-separated, sorted, de-duplicated, blanks dropped.
+  # `|| true` on the grep: empty input is a legitimate (and interesting) state
+  # here — an emptied `needs:` list must reach the C2 check with its message,
+  # not die silently under `set -euo pipefail` on grep's no-match exit 1.
+  { grep -v '^[[:space:]]*$' || true; } | LC_ALL=C sort -u
+}
+
+upper_snake() {
+  printf '%s' "$1" | tr '[:lower:]-' '[:upper:]_'
+}
+
+check_workflow() {
+  local workflow="$1"
+  [ -f "$workflow" ] || fail "workflow not found: $workflow"
+
+  local all_jobs
+  all_jobs="$(job_keys "$workflow" | sorted_unique)"
+  [ -n "$all_jobs" ] || fail "no top-level jobs parsed out of $workflow — the extractor is broken or the file changed shape"
+
+  printf '%s\n' "$all_jobs" | grep -qx "$GATE_JOB" ||
+    fail "the aggregator job \`$GATE_JOB\` is gone from $workflow; the required \`$GATE_CHECK_NAME\` check has no owner"
+
+  local block
+  block="$(job_block "$workflow" "$GATE_JOB")"
+  [ -n "$block" ] || fail "could not read the \`$GATE_JOB\` block out of $workflow"
+
+  # --- C1: the ruleset-visible check name --------------------------------
+  local gate_name
+  gate_name="$(printf '%s\n' "$block" | sed -n 's/^    name:[[:space:]]*\(.*[^[:space:]]\)[[:space:]]*$/\1/p' | head -1)"
+  [ -n "$gate_name" ] || fail "C1: \`$GATE_JOB\` has no \`name:\`"
+  if [ "$gate_name" != "$GATE_CHECK_NAME" ]; then
+    fail "C1: \`$GATE_JOB\` is named '$gate_name', but branch protection requires the literal check name '$GATE_CHECK_NAME'. Renaming it silently demotes every unit-lane guard to non-blocking."
+  fi
+
+  # --- C2/C3: the needs list ---------------------------------------------
+  local needs_line
+  needs_line="$(printf '%s\n' "$block" | sed -n 's/^    needs:[[:space:]]*\[\(.*\)\][[:space:]]*$/\1/p' | head -1)"
+  if ! printf '%s\n' "$block" | grep -qE '^    needs:[[:space:]]*\['; then
+    fail "C2: \`$GATE_JOB\` has no flow-sequence \`needs: [...]\` line. This guard reads that exact form on purpose — if the list is reformatted, update the guard rather than letting it read nothing."
+  fi
+  local needs
+  needs="$(printf '%s' "$needs_line" | tr ',' '\n' | tr -d ' ' | sorted_unique)"
+  [ -n "$needs" ] || fail "C2: \`$GATE_JOB\` needs nothing — the required check would pass with no unit-lane job gated"
+
+  local missing_job=""
+  local j
+  while IFS= read -r j; do
+    printf '%s\n' "$all_jobs" | grep -qx "$j" || missing_job="$missing_job $j"
+  done <<< "$needs"
+  [ -z "$missing_job" ] && : || fail "C3: \`$GATE_JOB\` needs job(s) that do not exist in the workflow:$missing_job"
+
+  # --- list 2: the env mapping -------------------------------------------
+  local env_pairs
+  env_pairs="$(printf '%s\n' "$block" |
+    sed -n 's/^          \([A-Z0-9_]\{1,\}\):[[:space:]]*\${{[[:space:]]*needs\.\([A-Za-z0-9_-]\{1,\}\)\.result[[:space:]]*}}[[:space:]]*$/\1 \2/p')"
+  [ -n "$env_pairs" ] || fail "C4: no \`VAR: \${{ needs.<job>.result }}\` env entries found in \`$GATE_JOB\`"
+
+  local env_jobs env_vars
+  env_jobs="$(printf '%s\n' "$env_pairs" | awk '{print $2}' | sorted_unique)"
+  env_vars="$(printf '%s\n' "$env_pairs" | awk '{print $1}' | sorted_unique)"
+
+  # --- C4: needs == env-read jobs ----------------------------------------
+  local only_needs only_env
+  only_needs="$(comm -23 <(printf '%s\n' "$needs") <(printf '%s\n' "$env_jobs") | tr '\n' ' ')"
+  only_env="$(comm -13 <(printf '%s\n' "$needs") <(printf '%s\n' "$env_jobs") | tr '\n' ' ')"
+  if [ -n "${only_needs// /}" ]; then
+    fail "C4: job(s) in \`needs:\` whose result the gate never reads: ${only_needs% }. They run, they can go RED, and the required \`$GATE_CHECK_NAME\` check stays GREEN."
+  fi
+  if [ -n "${only_env// /}" ]; then
+    fail "C4: the gate reads results for job(s) it does not \`need\`: ${only_env% }. Those results are empty strings, not verdicts."
+  fi
+
+  # --- C5: env var name is the job key, upper-snake-cased -----------------
+  local var job expected crossed=""
+  while read -r var job; do
+    [ -n "$var" ] || continue
+    expected="$(upper_snake "$job")"
+    [ "$var" = "$expected" ] || crossed="$crossed
+  $var -> needs.$job.result (expected var name $expected)"
+  done <<< "$env_pairs"
+  if [ -n "$crossed" ]; then
+    fail "C5: env var name does not match the job it reads, so a label can be paired with another job's result:$crossed"
+  fi
+
+  # --- list 3: the vars the result loop actually checks --------------------
+  local loop_vars
+  loop_vars="$(printf '%s\n' "$block" |
+    grep -oE '"[^"]*:\$[A-Z0-9_]+"' |
+    sed -E 's/.*:\$([A-Z0-9_]+)"/\1/' | sorted_unique)"
+  [ -n "$loop_vars" ] || fail "C6: found no \"Label:\$VAR\" entries in \`$GATE_JOB\`'s result-checking loop"
+
+  # --- C6: env vars == loop-consumed vars ---------------------------------
+  local only_declared only_checked
+  only_declared="$(comm -23 <(printf '%s\n' "$env_vars") <(printf '%s\n' "$loop_vars") | tr '\n' ' ')"
+  only_checked="$(comm -13 <(printf '%s\n' "$env_vars") <(printf '%s\n' "$loop_vars") | tr '\n' ' ')"
+  if [ -n "${only_declared// /}" ]; then
+    fail "C6: env var(s) declared but never checked by the loop: ${only_declared% }. The job is needed and its result is read, and then thrown away — still a red job under a green required check."
+  fi
+  if [ -n "${only_checked// /}" ]; then
+    fail "C6: the loop checks var(s) with no \`env:\` declaration: ${only_checked% }. Those expand to the empty string, which is not 'success', so this would red the gate for a job nobody wired in."
+  fi
+
+  # --- C7/C8: every job is gated or explicitly exempt ---------------------
+  local exempt_list
+  exempt_list="$(printf '%s\n' "${EXEMPT_JOBS[@]}" | sorted_unique)"
+
+  local stale_exempt=""
+  local e
+  while IFS= read -r e; do
+    printf '%s\n' "$all_jobs" | grep -qx "$e" || stale_exempt="$stale_exempt $e"
+  done <<< "$exempt_list"
+  [ -z "$stale_exempt" ] || fail "C8: EXEMPT_JOBS names job(s) that no longer exist:$stale_exempt (remove them so the exemption list cannot silently cover a future job of the same name)"
+
+  local ungated
+  ungated="$(comm -23 <(printf '%s\n' "$all_jobs") <(cat <(printf '%s\n' "$needs") <(printf '%s\n' "$exempt_list") | sorted_unique) | tr '\n' ' ')"
+  if [ -n "${ungated// /}" ]; then
+    fail "C7: workflow job(s) neither wired into \`$GATE_JOB\` nor listed as exempt: ${ungated% }. Add it to the gate's needs+env+loop, or add it to EXEMPT_JOBS in this script with a reason."
+  fi
+
+  # --- C9: the selection guards stay out of the Gradle test graph ----------
+  local scan_root="${SCAN_ROOT:-$ROOT_DIR}"
+  if [ -d "$scan_root/.git" ] || git -C "$scan_root" rev-parse --git-dir >/dev/null 2>&1; then
+    local candidates offenders
+    candidates="$(git -C "$scan_root" ls-files |
+      grep -E '(/src/(test|androidTest)/|(^|/)build\.gradle(\.kts)?$)' || true)"
+    offenders=""
+    if [ -n "$candidates" ]; then
+      offenders="$(cd "$scan_root" && printf '%s\n' "$candidates" |
+        tr '\n' '\0' | xargs -0 -r grep -lE "$SELECTION_GUARD_SCRIPTS" 2>/dev/null || true)"
+    fi
+    if [ -n "$offenders" ]; then
+      fail "C9: the #2063 selection guards are reachable from the Gradle test graph again:
+$(printf '%s\n' "$offenders" | sed 's/^/  /')
+They belong to the \`guards-test-selection\` job (#2067). A test task runs per
+variant, so wiring them there charges the ~165 s suite TWICE per push on the Unit
+critical path for work that compiles nothing — the regression #2067 removed. Add
+a step to that job instead."
+    fi
+  else
+    fail "C9: \`$scan_root\` is not a git checkout, so the Gradle-test-graph scan could not run. 'I could not check' is not 'I checked and it is fine'."
+  fi
+
+  echo "OK: \`$GATE_JOB\` is named '$GATE_CHECK_NAME' and its three lists agree."
+  echo "    needs      : $(printf '%s' "$needs" | tr '\n' ' ')"
+  echo "    env reads  : $(printf '%s' "$env_vars" | tr '\n' ' ')"
+  echo "    loop checks: $(printf '%s' "$loop_vars" | tr '\n' ' ')"
+  echo "    exempt     : $(printf '%s' "$exempt_list" | tr '\n' ' ')"
+  echo "OK: the #2063 selection guards are not reachable from any Gradle test source or build script."
+}
+
+# --- self-test ---------------------------------------------------------------
+# Each case mutates a COPY of the real workflow and asserts this guard goes red
+# for the intended reason. The pass count is asserted at the end, so the
+# anti-vacuous guard cannot itself pass vacuously.
+
+SELFTEST_EXPECTED_CASES=11
+selftest_passed=0
+selftest_failed=0
+# Overridden per case so C9's scan can be pointed at a sandbox checkout instead
+# of the real tree (planting a file in the real worktree would be cross-agent
+# damage of exactly the kind the process catalogue warns about).
+EXPECT_SCAN_ROOT=""
+
+st_ok() {
+  echo "  ok   $*"
+  selftest_passed=$((selftest_passed + 1))
+}
+
+st_bad() {
+  echo "  FAIL $*" >&2
+  selftest_failed=$((selftest_failed + 1))
+}
+
+run_guard_under_test() {
+  # $1 = workflow path; honours EXPECT_SCAN_ROOT for the C9 scan.
+  if [ -n "$EXPECT_SCAN_ROOT" ]; then
+    SCAN_ROOT="$EXPECT_SCAN_ROOT" "${BASH_SOURCE[0]}" --workflow "$1" 2>&1
+  else
+    "${BASH_SOURCE[0]}" --workflow "$1" 2>&1
+  fi
+}
+
+expect_red() {
+  # expect_red <label> <expected-substring> <mutated-workflow>
+  local label="$1" want="$2" file="$3" out rc
+  set +e
+  out="$(run_guard_under_test "$file")"
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    st_bad "$label: guard stayed GREEN on the mutated workflow"
+    return
+  fi
+  case "$out" in
+    *"$want"*) st_ok "$label (red, matched '$want')" ;;
+    *) st_bad "$label: red, but for the wrong reason — wanted '$want', got:
+$out" ;;
+  esac
+}
+
+expect_green() {
+  local label="$1" file="$2" out rc
+  set +e
+  out="$(run_guard_under_test "$file")"
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    st_ok "$label (green)"
+  else
+    st_bad "$label: guard went RED on an unmutated workflow:
+$out"
+  fi
+}
+
+self_test() {
+  local src="$DEFAULT_WORKFLOW"
+  [ -f "$src" ] || fail "self-test needs the real workflow at $src"
+  # Global, not `local`: the EXIT trap fires after this function has returned,
+  # and a `local` would be unbound there — which under `set -u` turns a PASSING
+  # self-test into exit 1 from the cleanup handler.
+  SELFTEST_SANDBOX="$(mktemp -d)"
+  trap 'rm -rf "${SELFTEST_SANDBOX:-}"' EXIT
+  local sandbox="$SELFTEST_SANDBOX"
+
+  echo "== check-unit-gate-wiring self-test =="
+
+  # Case 0 — the real workflow must be green, or every red below is meaningless.
+  expect_green "0 real workflow" "$src"
+
+  # Case 1 — a job in the loop and env but dropped from `needs:` (list 1 gap).
+  local m1="$sandbox/m1.yml"
+  sed 's/^    needs: \[unit, guards-static, guards-ci-harness, guards-test-selection, dex\]$/    needs: [unit, guards-static, guards-ci-harness, dex]/' "$src" > "$m1"
+  cmp -s "$src" "$m1" && st_bad "1 mutation did not apply" || \
+    expect_red "1 job dropped from needs:" "C4" "$m1"
+
+  # Case 2 — a needed job whose result the gate never reads (list 2 gap).
+  local m2="$sandbox/m2.yml"
+  grep -v '^          GUARDS_TEST_SELECTION: ' "$src" > "$m2"
+  cmp -s "$src" "$m2" && st_bad "2 mutation did not apply" || \
+    expect_red "2 env mapping removed" "C4" "$m2"
+
+  # Case 3 — THE HEADLINE CASE: needed, result read, never checked (list 3 gap).
+  #          This is the shape that produces a red job under a green gate.
+  local m3="$sandbox/m3.yml"
+  grep -v '"Test-selection coverage guards:\$GUARDS_TEST_SELECTION" \\' "$src" > "$m3"
+  cmp -s "$src" "$m3" && st_bad "3 mutation did not apply" || \
+    expect_red "3 loop entry removed" "C6" "$m3"
+
+  # Case 4 — the required check name renamed out from under branch protection.
+  local m4="$sandbox/m4.yml"
+  awk '
+    /^  unit-gate:$/ { ingate = 1 }
+    ingate && /^    name: Unit tests$/ { print "    name: Unit tests (fast)"; ingate = 0; next }
+    { print }
+  ' "$src" > "$m4"
+  cmp -s "$src" "$m4" && st_bad "4 mutation did not apply" || \
+    expect_red "4 gate renamed" "C1" "$m4"
+
+  # Case 5 — crossed wires: the var names swapped between two real jobs. Every
+  #          list still "agrees" as a set; only the pairing is wrong.
+  local m5="$sandbox/m5.yml"
+  sed -e 's/^          GUARDS_STATIC: \${{ needs.guards-static.result }}$/          GUARDS_STATIC: ${{ needs.guards-ci-harness.result }}/' \
+      -e 's/^          GUARDS_CI_HARNESS: \${{ needs.guards-ci-harness.result }}$/          GUARDS_CI_HARNESS: ${{ needs.guards-static.result }}/' \
+      "$src" > "$m5"
+  cmp -s "$src" "$m5" && st_bad "5 mutation did not apply" || \
+    expect_red "5 env var paired with the wrong job" "C5" "$m5"
+
+  # Case 6 — a brand-new workflow job wired into nothing.
+  local m6="$sandbox/m6.yml"
+  awk '
+    /^  unit-gate:$/ && !done {
+      print "  brand-new-guard:"
+      print "    name: Brand new guard"
+      print "    runs-on: ubuntu-latest"
+      print "    steps:"
+      print "      - run: echo hi"
+      print ""
+      done = 1
+    }
+    { print }
+  ' "$src" > "$m6"
+  cmp -s "$src" "$m6" && st_bad "6 mutation did not apply" || \
+    expect_red "6 new job gated nowhere" "C7" "$m6"
+
+  # Case 7 — an empty needs list: every list agrees, and nothing is gated.
+  local m7="$sandbox/m7.yml"
+  awk '
+    /^    needs: \[unit, guards-static/ { print "    needs: []"; next }
+    { print }
+  ' "$src" > "$m7"
+  cmp -s "$src" "$m7" && st_bad "7 mutation did not apply" || \
+    expect_red "7 empty needs list" "C2" "$m7"
+
+  # Case 8 — a needed job that does not exist, wired consistently into all three
+  #          lists, so ONLY the existence check can catch it.
+  local m8="$sandbox/m8.yml"
+  sed -e 's/^    needs: \[unit, guards-static, guards-ci-harness, guards-test-selection, dex\]$/    needs: [unit, guards-static, guards-ci-harness, guards-test-selection, dex, ghost-job]/' \
+      -e 's/^          DEX: \${{ needs.dex.result }}$/          DEX: ${{ needs.dex.result }}\n          GHOST_JOB: ${{ needs.ghost-job.result }}/' \
+      -e 's|^                      "Dex register-pressure ratchet:\$DEX"; do$|                      "Dex register-pressure ratchet:$DEX" \\\n                      "Ghost:$GHOST_JOB"; do|' \
+      "$src" > "$m8"
+  cmp -s "$src" "$m8" && st_bad "8 mutation did not apply" || \
+    expect_red "8 needs a nonexistent job" "C3" "$m8"
+
+  # Cases 9 and 10 exercise C9 against a SANDBOX checkout. Planting a file in the
+  # real worktree to test a `git ls-files` scan would be exactly the shared-file
+  # cross-agent damage the process catalogue documents, so the sandbox is its own
+  # tiny git repository instead.
+  local scan_sandbox="$sandbox/scan-repo"
+  mkdir -p "$scan_sandbox/app/src/test/java/com/pocketshell/app/scripts" "$scan_sandbox/scripts"
+  git -C "$scan_sandbox" init -q
+  git -C "$scan_sandbox" config user.email selftest@example.invalid
+  git -C "$scan_sandbox" config user.name selftest
+  # A plain script referencing the guards is legitimate and must NOT trip C9.
+  printf 'bash scripts/select-test-areas-selftest.sh\n' > "$scan_sandbox/scripts/some-wrapper.sh"
+  git -C "$scan_sandbox" add -A
+  git -C "$scan_sandbox" commit -qm base
+
+  EXPECT_SCAN_ROOT="$scan_sandbox"
+  expect_green "9 a non-test script may reference the guards" "$src"
+
+  # Case 10 — the regression #2067 removed: a JVM test shelling out to the guards,
+  # which puts the ~165 s suite back inside `./gradlew test`, once per variant.
+  printf 'class SmartTestSelectionScriptTest { fun t() { runShell("scripts/select-test-areas-selftest.sh") } }\n' \
+    > "$scan_sandbox/app/src/test/java/com/pocketshell/app/scripts/SmartTestSelectionScriptTest.kt"
+  git -C "$scan_sandbox" add -A
+  expect_red "10 a Gradle test task reaching the guards again" "C9" "$src"
+  EXPECT_SCAN_ROOT=""
+
+  echo
+  echo "$selftest_passed passed, $selftest_failed failed"
+  if [ "$selftest_failed" -ne 0 ]; then
+    fail "self-test had $selftest_failed failing case(s)"
+  fi
+  if [ "$selftest_passed" -ne "$SELFTEST_EXPECTED_CASES" ]; then
+    fail "self-test ran $selftest_passed case(s), expected exactly $SELFTEST_EXPECTED_CASES — a case was skipped or silently dropped"
+  fi
+  echo "OK: all $SELFTEST_EXPECTED_CASES self-test cases behaved as expected."
+}
+
+# --- entrypoint ---------------------------------------------------------------
+MODE="check"
+WORKFLOW="$DEFAULT_WORKFLOW"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-test) MODE="selftest"; shift ;;
+    --workflow) WORKFLOW="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+case "$MODE" in
+  selftest) self_test ;;
+  check) check_workflow "$WORKFLOW" ;;
+esac

--- a/scripts/ci-test-selection-guards.sh
+++ b/scripts/ci-test-selection-guards.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# ci-test-selection-guards.sh — issue #2067
+#
+# The five #2063 test-area coverage guards, as ONE command. This is the body of
+# the `guards-test-selection` job in `.github/workflows/tests.yml`, and the same
+# thing to run locally when you touch the manifest, the classification engine,
+# the journey registry, or `tools/pocketshell/src/pocketshell/cli.py`.
+#
+# WHY A DEDICATED JOB RATHER THAN A GRADLE TEST. #2063 first reached these
+# guards through a JVM test (`SmartTestSelectionScriptTest`) so `./gradlew test`
+# would run them — right instinct (a guard no lane runs is not a guard), wrong
+# lane. `test` runs BOTH variants, so the ~165 s suite was charged twice per
+# push, on the Unit critical path, for work that compiles nothing: +5 to +7 min
+# on every Unit run, which over 104 `main` commits exactly cancelled the
+# scheme's own saving. Here it is paid ONCE, in parallel, and is still blocking
+# because `unit-gate` — the job that carries the required `Unit tests` check
+# name — needs it. `scripts/check-unit-gate-wiring.sh` asserts both halves of
+# that: the gate wiring (C1–C8) and that these guards have not crept back into a
+# Gradle test task (C9).
+#
+# WHY IT IS CHEAP. Pure filesystem + `git ls-files` + awk/python3. No JDK, no
+# Gradle, no Android SDK, no Docker, no emulator. `git ls-files` reads the index,
+# so a depth-1 checkout is enough (the guards never diff against a base ref; the
+# diff path is a different mode, and it fails safe to a full run anyway).
+#
+# BUDGET. ~165 s total, ~80% of it the selection self-test. Read the total as
+# noise-dominated — four same-content observations spanned 154.2–205.3 s (33%).
+# The meaningful figure is structural: ~11.6 s per index-rebuilding mutation
+# case, ~2 cases of headroom before the dependency-index build must be shared.
+# The per-guard seconds are REPORTED into the job summary, deliberately not
+# asserted: a 33%-variance quantity makes a terrible assertion (G6). The job
+# ceiling is 5 min wall clock, past which it becomes the critical path on a
+# docs-only push. Detail: docs/testing.md, "Self-tests".
+
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+
+# The guards must read the COMMITTED manifest and the real journey registry.
+# These variables are the self-tests' own sandbox knobs; `SmartTestSelectionScriptTest`
+# scrubbed them before invoking, and that scrub moves here with the guards rather
+# than being dropped on the floor. Nothing sets them on a hosted runner today, but
+# a future workflow-level `env:` would silently point a guard at a sandbox.
+for _v in $(compgen -e || true); do
+  case "$_v" in
+    POCKETSHELL_TEST_AREAS_*|POCKETSHELL_TA_*|POCKETSHELL_TEST_LEDGER) unset "$_v" ;;
+  esac
+done
+unset _v
+
+chmod +x scripts/select-test-areas.sh \
+         scripts/select-test-areas-selftest.sh \
+         scripts/check-test-execution-ledger.sh \
+         scripts/check-test-execution-ledger-selftest.sh \
+         scripts/dev-fast-gate-parity-selftest.sh
+
+TIMINGS="$(mktemp)"
+trap 'rm -f "$TIMINGS"' EXIT
+
+run_guard() {
+  local label="$1"; shift
+  local start end
+  [ -n "${GITHUB_ACTIONS:-}" ] && echo "::group::$label" || echo "== $label"
+  start=$(date +%s)
+  "$@"
+  end=$(date +%s)
+  [ -n "${GITHUB_ACTIONS:-}" ] && echo "::endgroup::" || true
+  printf '%-46s %4ss\n' "$label" "$((end - start))" >> "$TIMINGS"
+}
+
+suite_start=$(date +%s)
+
+# The manifest is TOTAL over the tracked tree and internally consistent.
+run_guard "select-test-areas --verify-manifest" \
+  bash scripts/select-test-areas.sh --verify-manifest
+
+# The coverage invariant the whole scheme rests on, including I8 (blast-radius
+# escapes), I10 (the emitted command IS the plan) and I11 (every shared module is
+# run by its own change).
+run_guard "select-test-areas --coverage-invariant" \
+  bash scripts/select-test-areas.sh --coverage-invariant
+
+# Selection mechanics + the mutations proving each real-tree guard can go red.
+run_guard "select-test-areas-selftest" \
+  bash scripts/select-test-areas-selftest.sh
+
+# Execution-ledger guard reds, synthetic AND real-tree.
+run_guard "check-test-execution-ledger-selftest" \
+  bash scripts/check-test-execution-ledger-selftest.sh
+
+# dev-fast-gate's classifier still agrees with the shared manifest.
+run_guard "dev-fast-gate-parity-selftest" \
+  bash scripts/dev-fast-gate-parity-selftest.sh
+
+suite_end=$(date +%s)
+printf '%-46s %4ss\n' "TOTAL" "$((suite_end - suite_start))" >> "$TIMINGS"
+
+echo
+cat "$TIMINGS"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Test-selection coverage guards (#2063 / #2067)"
+    echo
+    echo '```'
+    cat "$TIMINGS"
+    echo '```'
+    echo
+    echo "Budget is marginal (~11.6 s per index-rebuilding case), not an absolute"
+    echo "wall-clock ceiling — four same-content observations of this suite spanned"
+    echo "33%. Read the trend, not one number. Job ceiling: 5 min."
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/dev-fast-gate-parity-selftest.sh
+++ b/scripts/dev-fast-gate-parity-selftest.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Parity self-test for the scripts/dev-fast-gate.sh classifier refactor (#2063).
+#
+# WHY THIS EXISTS
+#
+# #2063 replaced dev-fast-gate's inline `classify_path` case arms with the
+# shared, manifest-driven engine in scripts/lib/test-areas.sh. That refactor is
+# only safe if it cannot have QUIETLY LOOSENED the local gate: a path that used
+# to demand the full emulator set and now selects one cheap stage is a hole, and
+# it would be invisible — the gate would still pass, faster.
+#
+# So this is not a spot check. It re-implements the ORIGINAL case arms verbatim
+# below (`legacy_classify_path`, copied from the pre-#2063 file), runs BOTH
+# classifiers over EVERY tracked file in the repository, and asserts:
+#
+#   P1  no path became LESS conservative
+#       (old != force-full  =>  new == old)
+#   P2  the set of paths that became MORE conservative is exactly the pinned
+#       expectation below — so the refactor's cost is enumerated, reviewable,
+#       and cannot grow without this test going red
+#   P3  the legacy classifier is actually live: mutating the manifest must
+#       change the new classifier's answer. A parity test whose "new" side is
+#       accidentally the old side would pass over any refactor at all.
+#
+# P3 is the mutation check process.md asks for: name the mutation that must
+# redden this assertion, then apply it. Here it is applied in-process.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/test-areas.sh
+source "$SCRIPT_DIR/lib/test-areas.sh"
+
+# ---------------------------------------------------------------------------
+# The ORIGINAL classifier, verbatim from scripts/dev-fast-gate.sh before #2063
+# (commit 0248d0ee, lines 108-158). Do not "improve" it — its only job is to be
+# the historical oracle.
+# ---------------------------------------------------------------------------
+legacy_classify_path() {
+  local p="$1"
+
+  case "$p" in
+    *build.gradle.kts|*.gradle|*.gradle.kts|gradle.properties|settings.gradle|settings.gradle.kts)
+      echo "force-full"; return ;;
+    gradle/*|*/gradle/*)
+      echo "force-full"; return ;;
+    scripts/*)
+      echo "force-full"; return ;;
+    .github/*)
+      echo "force-full"; return ;;
+  esac
+
+  case "$p" in
+    *[Mm]igration*|*/schemas/*|*schemas/*.json)
+      echo "migration"; return ;;
+  esac
+
+  case "$p" in
+    app/src/main/*/bootstrap/*|*/bootstrap/*)
+      echo "bootstrap"; return ;;
+    tests/docker/*bootstrap*|tests/docker/*[Bb]ootstrap*)
+      echo "bootstrap"; return ;;
+  esac
+
+  case "$p" in
+    shared/core-terminal/*|shared/core-ssh/*|shared/core-tmux/*)
+      echo "terminal"; return ;;
+    app/src/main/*/terminal/*|app/src/main/*/ssh/*|app/src/main/*/tmux/*)
+      echo "terminal"; return ;;
+  esac
+
+  case "$p" in
+    shared/ui-kit/*)
+      echo "ui"; return ;;
+    app/src/main/*/projects/*)
+      echo "ui"; return ;;
+  esac
+
+  echo "force-full"
+}
+
+# The NEW classifier, in the same shape dev-fast-gate.sh now uses.
+new_classify_path() {
+  local p="$1"
+  pocketshell_test_area_classify "$p"
+  if [[ "$POCKETSHELL_TEST_AREA_KIND" == "full" ]]; then
+    echo "force-full"; return
+  fi
+  case "$p" in
+    *[Mm]igration*|*/schemas/*|*schemas/*.json)
+      echo "migration"; return ;;
+  esac
+  case "$POCKETSHELL_TEST_AREA_DEVGATE" in
+    ui|bootstrap|terminal) echo "$POCKETSHELL_TEST_AREA_DEVGATE"; return ;;
+    *) echo "force-full"; return ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# P2's pinned expectation: the paths where the manifest is deliberately MORE
+# conservative than the old arms. Three groups, each with a stated reason.
+# Anything outside them fails P2 — so the cost of the refactor stays bounded
+# and reviewable instead of creeping.
+# ---------------------------------------------------------------------------
+declare -a TIGHTENED_GLOBS=(
+  # The D28 god-object seam (#766 residue): old arms called it `terminal`
+  # because it lives under app/.../tmux/. Cross-area wedge bugs hide here, so
+  # the manifest force-fulls it by name.
+  "app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt"
+  # Docker fixtures and shell harnesses every journey depends on. The old arms
+  # sent tests/docker/*bootstrap* to the bootstrap stage alone.
+  "tests/*"
+  # The ONE audited settle pump; every runTest consumer depends on it.
+  "shared/test-support/*"
+  # Shared layout scaffolding used by every screen.
+  "app/src/main/java/com/pocketshell/app/layout/*"
+)
+
+is_pinned_tightening() {
+  local p="$1" g
+  for g in "${TIGHTENED_GLOBS[@]}"; do
+    # shellcheck disable=SC2053
+    [[ "$p" == $g ]] && return 0
+  done
+  # GROUP 2 — test infrastructure. A fixture / helper / base class / resource
+  # inside a test source set has an unknown blast radius (the whole point of
+  # the manifest's rule 2). The old arms happened to classify the ones under
+  # shared/core-terminal and shared/ui-kit by their MODULE prefix, which is
+  # exactly the too-narrow behaviour this refactor removes.
+  if pocketshell_test_areas_is_test_path "$p" &&
+     ! pocketshell_test_areas_is_test_class_file "$p"; then
+    return 0
+  fi
+  # GROUP 3 — prose. The manifest makes docs `noop`, and dev-fast-gate maps
+  # noop to the full set (matching the old repo-root default). Only the two
+  # markdown files that happened to sit under shared/core-terminal and
+  # shared/ui-kit differ from the old behaviour.
+  case "$p" in *.md) return 0 ;; esac
+  return 1
+}
+
+fail_count=0
+note() { printf '%s\n' "$*"; }
+
+if ! pocketshell_test_areas_load "$ROOT_DIR/scripts/test-areas.txt"; then
+  note "FAIL: manifest did not load:"
+  printf '  %s\n' "${POCKETSHELL_TA_LOAD_ERRORS[@]}"
+  exit 1
+fi
+
+declare -a LOOSENED=()
+declare -a UNPINNED_TIGHTENING=()
+declare -a PINNED_TIGHTENING=()
+checked=0
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  checked=$((checked + 1))
+  old="$(legacy_classify_path "$path")"
+  new="$(new_classify_path "$path")"
+  [[ "$old" == "$new" ]] && continue
+  if [[ "$new" == "force-full" ]]; then
+    if is_pinned_tightening "$path"; then
+      PINNED_TIGHTENING+=("$path ($old -> force-full)")
+    else
+      UNPINNED_TIGHTENING+=("$path ($old -> force-full)")
+    fi
+  else
+    LOOSENED+=("$path ($old -> $new)")
+  fi
+done < <(git -C "$ROOT_DIR" ls-files)
+
+note "== dev-fast-gate classifier parity =="
+note "checked: $checked tracked paths"
+note
+
+# P1 — nothing got looser.
+if [[ "${#LOOSENED[@]}" -gt 0 ]]; then
+  note "FAIL P1: ${#LOOSENED[@]} path(s) became LESS conservative than before #2063:"
+  printf '  %s\n' "${LOOSENED[@]}"
+  fail_count=$((fail_count + 1))
+else
+  note "OK P1: no path became less conservative (old != force-full => new == old)"
+fi
+
+# P2 — the tightened set is exactly what is pinned.
+if [[ "${#UNPINNED_TIGHTENING[@]}" -gt 0 ]]; then
+  note
+  note "FAIL P2: ${#UNPINNED_TIGHTENING[@]} path(s) became MORE conservative without being pinned in TIGHTENED_GLOBS:"
+  printf '  %s\n' "${UNPINNED_TIGHTENING[@]}"
+  note "  (this is safe for correctness but slows the local fast path — pin it with a reason, or fix the manifest)"
+  fail_count=$((fail_count + 1))
+else
+  note "OK P2: ${#PINNED_TIGHTENING[@]} tightened path(s), all pinned in TIGHTENED_GLOBS"
+fi
+
+# P3 — the new classifier is genuinely manifest-driven. Mutate the manifest so
+#      shared/ui-kit stops being `ui` and assert the new answer MOVES. If it
+#      does not, the "new" side is not reading the manifest and P1/P2 are
+#      vacuous.
+mutant="$(mktemp)"
+sed 's|^src    shared/ui-kit/\*               ui-shell             ui|src    shared/ui-kit/*               ui-shell             full|' \
+  "$ROOT_DIR/scripts/test-areas.txt" > "$mutant"
+probe="shared/ui-kit/src/main/java/com/pocketshell/uikit/theme/Theme.kt"
+before="$(new_classify_path "$probe")"
+if pocketshell_test_areas_load "$mutant"; then
+  after="$(new_classify_path "$probe")"
+else
+  after="LOAD_FAILED"
+fi
+rm -f "$mutant"
+pocketshell_test_areas_load "$ROOT_DIR/scripts/test-areas.txt" >/dev/null
+note
+if [[ "$before" == "ui" && "$after" == "force-full" ]]; then
+  note "OK P3: mutating the manifest moved the classifier ($probe: ui -> force-full), so the parity above is live"
+else
+  note "FAIL P3: the manifest mutation did not move the classifier (before='$before' after='$after')."
+  note "        The 'new' side is not reading scripts/test-areas.txt — P1/P2 prove nothing."
+  fail_count=$((fail_count + 1))
+fi
+
+note
+if [[ "$fail_count" -gt 0 ]]; then
+  note "FAIL: $fail_count parity check(s) failed."
+  exit 1
+fi
+note "PASS: dev-fast-gate classifier parity holds."
+exit 0

--- a/scripts/dev-fast-gate.sh
+++ b/scripts/dev-fast-gate.sh
@@ -104,56 +104,61 @@ compute_changed_paths() {
 #   bootstrap    host setup-detection / bootstrap
 #   terminal     terminal/SSH/tmux render path
 #   migration    Room schema / migrations / install-update path
+#
+# ISSUE #2063: the case arms that used to live here are now DATA, in
+# scripts/test-areas.txt, read through scripts/lib/test-areas.sh. The same
+# manifest drives CI area selection and the coverage guard, so the local fast
+# path and CI can no longer disagree about what a path is.
+#
+# Two things are preserved exactly and one is deliberately tightened:
+#   * the ORDER (force-full -> migration -> area allowlist -> force-full
+#     default) is unchanged; only the last two steps read the manifest;
+#   * every stage decision this script made before is unchanged for every
+#     tracked file in the repo, EXCEPT paths that the manifest force-fulls more
+#     aggressively than the old arms did (TmuxSessionViewModel.kt, the Docker
+#     bootstrap fixtures, shared/test-support). Those move toward MORE
+#     validation, never less.
+# scripts/dev-fast-gate-parity-selftest.sh proves both statements over every
+# tracked file, and pins the tightened set so it cannot grow unnoticed.
 # ---------------------------------------------------------------------------
+# shellcheck source=lib/test-areas.sh
+source "$ROOT_DIR/scripts/lib/test-areas.sh"
+
+if ! pocketshell_test_areas_load "${POCKETSHELL_TEST_AREAS_MANIFEST:-$ROOT_DIR/scripts/test-areas.txt}"; then
+  echo "error: scripts/test-areas.txt failed to load:" >&2
+  printf '  %s\n' "${POCKETSHELL_TA_LOAD_ERRORS[@]}" >&2
+  echo "error: refusing to guess — run the FULL gate (scripts/release-emulator-validation.sh)" >&2
+  exit 2
+fi
+
 classify_path() {
   local p="$1"
 
+  pocketshell_test_area_classify "$p"
+
   # ---- FORCE FULL (fail-safe). Evaluated first; any match => full gate. ----
-  case "$p" in
-    # build files
-    *build.gradle.kts|*.gradle|*.gradle.kts|gradle.properties|settings.gradle|settings.gradle.kts)
-      echo "force-full"; return ;;
-    gradle/*|*/gradle/*)
-      echo "force-full"; return ;;
-    # tooling / CI / scripts
-    scripts/*)
-      echo "force-full"; return ;;
-    .github/*)
-      echo "force-full"; return ;;
-  esac
+  # The manifest's `full` rows are a strict superset of the old inline arms
+  # (build files, gradle, scripts/, .github/) and add the blast-radius escapes
+  # the old arms reached only via the unmatched default.
+  if [[ "$POCKETSHELL_TEST_AREA_KIND" == "full" ]]; then
+    echo "force-full"; return
+  fi
 
   # Room schema / migrations / install-update path -> needs pre-release gate.
+  # Stays inline: `migration` is a release/DB concern that cuts across every
+  # test area, so it is not expressible as an area and must keep its original
+  # position — after force-full, before the allowlist.
   case "$p" in
     *[Mm]igration*|*/schemas/*|*schemas/*.json)
       echo "migration"; return ;;
   esac
 
-  # ---- bootstrap / setup-detection ----
-  case "$p" in
-    app/src/main/*/bootstrap/*|*/bootstrap/*)
-      echo "bootstrap"; return ;;
-    tests/docker/*bootstrap*|tests/docker/*[Bb]ootstrap*)
-      echo "bootstrap"; return ;;
+  # ---- the allowlist, now read from the manifest's `devgate` column ----
+  # `full` here is the old "not on the conservative allowlist" default.
+  case "$POCKETSHELL_TEST_AREA_DEVGATE" in
+    ui|bootstrap|terminal) echo "$POCKETSHELL_TEST_AREA_DEVGATE"; return ;;
+    *) echo "force-full"; return ;;
   esac
-
-  # ---- terminal / SSH / tmux render path ----
-  case "$p" in
-    shared/core-terminal/*|shared/core-ssh/*|shared/core-tmux/*)
-      echo "terminal"; return ;;
-    app/src/main/*/terminal/*|app/src/main/*/ssh/*|app/src/main/*/tmux/*)
-      echo "terminal"; return ;;
-  esac
-
-  # ---- UI-only (no SSH/tmux/bootstrap surface) ----
-  case "$p" in
-    shared/ui-kit/*)
-      echo "ui"; return ;;
-    app/src/main/*/projects/*)
-      echo "ui"; return ;;
-  esac
-
-  # Anything not on the conservative allowlist -> full gate.
-  echo "force-full"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/test-areas.sh
+++ b/scripts/lib/test-areas.sh
@@ -1,0 +1,1638 @@
+#!/usr/bin/env bash
+# Shared area-classification engine behind the #2063 coverage-guard suite (and,
+# as a by-product, its area-scoped selection). Analysis: #2059.
+#
+# Not a speed mechanism — measured at 1.09x on the emulator lane and
+# neutral-to-slightly-negative on Unit; docs/testing.md carries the table. What
+# it buys is a checkable answer to "is every test class mapped, reachable and
+# actually executed", plus the host-CLI wire seam that #1509/#847 needed.
+#
+# WHAT THIS IS
+#
+# One data-driven classifier, loaded from `scripts/test-areas.txt`, that answers
+# three questions about a repo-relative path:
+#
+#   1. Does changing it force a FULL run?  (blast-radius escapes)
+#   2. If not, which test AREA does it belong to?
+#   3. Which coarse emulator stage does `scripts/dev-fast-gate.sh` want for it?
+#      (the `devgate` column; this engine is the promotion of that script's
+#      inline `classify_path` case arms into shared, testable data)
+#
+# WHY A LIBRARY AND NOT INLINE CASE ARMS
+#
+# `scripts/dev-fast-gate.sh:108` already proved the SHAPE — ordered force-full
+# arms first, a conservative allowlist second, and force-full for anything
+# unmatched. What it could not do is be reused: the arms are inline, so CI
+# selection, the coverage guard, and the local fast path would each have grown
+# their own copy of the taxonomy and drifted apart. The taxonomy is now one
+# committed file; every consumer reads it.
+#
+# THE FAIL-SAFE DIRECTION IS STRUCTURAL, NOT A CONVENTION
+#
+# `pocketshell_test_area_classify` sets POCKETSHELL_TEST_AREA_KIND to `full`
+# BEFORE it looks at anything, and every non-`full` outcome requires an explicit
+# manifest row to have matched. There is no code path that ends in
+# "nothing matched, so run nothing": the fall-through IS `full`. A future edit
+# that deletes a rule, mistypes a glob, or drops a whole record type degrades
+# toward running MORE, never less. `scripts/select-test-areas-selftest.sh`
+# mutates the manifest to prove that direction (unknown path, empty manifest,
+# manifest with every rule removed) rather than asserting it in a comment.
+#
+# MANIFEST GRAMMAR (scripts/test-areas.txt)
+#
+#   area   <name>  <tier>  <description...>       tier = always | changed
+#   full   <glob>  <reason...>                    changing this => run everything
+#   noop   <glob>  <reason...>                    provably cannot affect any test
+#   src    <glob>  <area>  <devgate>              production path -> area
+#   test   <glob>  <area>  <devgate>              test path -> area
+#   class  <fqcn>  <area>                         per-class override (beats globs)
+#   couple <area>  <area,area,...>                selecting <area> also selects these
+#
+# Globs are matched with bash `[[ path == glob ]]`, in which `*` crosses `/`
+# (the same semantics `dev-fast-gate.sh` relies on). Rows are evaluated in file
+# order within their record type; first match wins.
+#
+# EVALUATION ORDER (single source of truth; mirrored by the docs and the tests)
+#
+#   1. `full` rows                      -> full
+#   2. test-infrastructure code rule    -> full
+#      (a path inside a test source set whose basename is not `*Test.kt` /
+#      `*Test.java` is a shared fixture/helper/resource; its blast radius is
+#      unknown)
+#   3. `noop` rows                      -> noop
+#   4. `class` overrides (test paths)   -> area
+#   5. `test` rows                      -> area
+#   6. `src` rows                       -> area
+#   7. fall-through                     -> full (unmapped; reported loudly)
+#
+# Rule 2 is deliberately code, not a glob: "every file in these directories
+# except the ones named *Test.kt" is not expressible as an ordered glob list,
+# and enumerating today's 66 helper files would rot the moment someone adds the
+# 67th.
+#
+# Rule 2's known bound, stated rather than hidden: it recognises test classes by
+# the repo's `*Test.kt` / `*Test.java` naming convention. Four @Test-bearing
+# classes do not follow it (three screenshot harnesses plus the ui-kit
+# DesignRenders render target). They are force-fulled here (safe) and
+# `select-test-areas.sh --verify-manifest` fails on any NEW one, so the set
+# cannot grow silently.
+
+# Guard against double-sourcing.
+if [[ -n "${POCKETSHELL_TEST_AREAS_LIB_LOADED:-}" ]]; then
+  return 0 2>/dev/null || true
+fi
+POCKETSHELL_TEST_AREAS_LIB_LOADED=1
+
+POCKETSHELL_TEST_AREAS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Parallel arrays, populated by pocketshell_test_areas_load.
+declare -a POCKETSHELL_TA_FULL_GLOB=()
+declare -a POCKETSHELL_TA_FULL_REASON=()
+declare -a POCKETSHELL_TA_NOOP_GLOB=()
+declare -a POCKETSHELL_TA_NOOP_REASON=()
+declare -a POCKETSHELL_TA_SRC_GLOB=()
+declare -a POCKETSHELL_TA_SRC_AREA=()
+declare -a POCKETSHELL_TA_SRC_DEVGATE=()
+declare -a POCKETSHELL_TA_TEST_GLOB=()
+declare -a POCKETSHELL_TA_TEST_AREA=()
+declare -a POCKETSHELL_TA_TEST_DEVGATE=()
+declare -a POCKETSHELL_TA_AREAS=()
+# Globs whose LAST path segment is not exactly `*`, i.e. rules that read the
+# file NAME rather than its directory. The index has to classify those files
+# individually instead of reusing their directory's answer; computing the set
+# from the manifest (rather than hardcoding "the :app root row") means a future
+# file-shaped row cannot be silently averaged away.
+declare -a POCKETSHELL_TA_FILE_SHAPED_GLOB=()
+declare -A POCKETSHELL_TA_AREA_TIER=()
+declare -A POCKETSHELL_TA_AREA_DESC=()
+declare -A POCKETSHELL_TA_CLASS_AREA=()
+declare -A POCKETSHELL_TA_COUPLE=()
+
+POCKETSHELL_TA_MANIFEST=""
+declare -a POCKETSHELL_TA_LOAD_ERRORS=()
+
+# Outputs of pocketshell_test_area_classify (set as globals, not echoed, so the
+# hot loop over thousands of paths never forks a subshell).
+POCKETSHELL_TEST_AREA_KIND=""     # full | noop | area
+POCKETSHELL_TEST_AREA_NAME=""     # area name when KIND=area, else empty
+POCKETSHELL_TEST_AREA_REASON=""   # matched glob / rule name
+POCKETSHELL_TEST_AREA_DEVGATE=""  # ui | bootstrap | terminal | full
+
+# Outputs of the FQCN resolvers, published the same way for the same reason: a
+# `$(...)` call site forks, and the guards ask these questions a thousand times
+# per run. Callers in a hot loop read the global; one-shot callers use the
+# printed value. ONE implementation either way — a second copy of the
+# resolution chain inlined at a call site is exactly the round-1 B4 defect.
+POCKETSHELL_TEST_AREA_FOR_CLASS=""
+POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS=""
+
+pocketshell_test_areas_default_manifest() {
+  printf '%s/../test-areas.txt\n' "$POCKETSHELL_TEST_AREAS_LIB_DIR"
+}
+
+# Load the manifest. Returns non-zero (and populates POCKETSHELL_TA_LOAD_ERRORS)
+# when the file is missing or a row is malformed. Callers MUST treat a load
+# failure as "force full", never as "no rules, so nothing to run".
+pocketshell_test_areas_load() {
+  # extglob so a manifest row can express "must not cross a path segment"
+  # (`+([A-Za-z0-9_])`). Plain `*` crosses `/` in `[[ ]]`, which is right for
+  # almost every rule and catastrophically wrong for the :app root-level test
+  # rule — without extglob that row would silently swallow every future
+  # unmapped subpackage instead of failing it loudly.
+  shopt -s extglob
+
+  local manifest="${1:-$(pocketshell_test_areas_default_manifest)}"
+  POCKETSHELL_TA_MANIFEST="$manifest"
+  POCKETSHELL_TA_LOAD_ERRORS=()
+
+  POCKETSHELL_TA_FULL_GLOB=(); POCKETSHELL_TA_FULL_REASON=()
+  POCKETSHELL_TA_NOOP_GLOB=(); POCKETSHELL_TA_NOOP_REASON=()
+  POCKETSHELL_TA_SRC_GLOB=(); POCKETSHELL_TA_SRC_AREA=(); POCKETSHELL_TA_SRC_DEVGATE=()
+  POCKETSHELL_TA_TEST_GLOB=(); POCKETSHELL_TA_TEST_AREA=(); POCKETSHELL_TA_TEST_DEVGATE=()
+  POCKETSHELL_TA_AREAS=()
+  POCKETSHELL_TA_FILE_SHAPED_GLOB=()
+  POCKETSHELL_TA_AREA_TIER=(); POCKETSHELL_TA_AREA_DESC=()
+  POCKETSHELL_TA_CLASS_AREA=(); POCKETSHELL_TA_COUPLE=()
+  POCKETSHELL_TA_INDEX_BUILT=0
+  POCKETSHELL_TA_PROD_PKG_AREA=(); POCKETSHELL_TA_PROD_PKG_HOSTCLI=()
+  POCKETSHELL_TA_PROD_PKG_SHARED=(); POCKETSHELL_TA_HOSTCLI_END=()
+  POCKETSHELL_TA_CLASS_PATH=(); POCKETSHELL_TA_CLASS_RESOLVED=(); POCKETSHELL_TA_CLASS_DEPS=()
+  POCKETSHELL_TA_PKG_TEST_AREA=(); POCKETSHELL_TA_PKG_TEST_DEPS=()
+  POCKETSHELL_TA_CLASS_MODULE=(); POCKETSHELL_TA_CLASS_SOURCESET=()
+  POCKETSHELL_TA_RESOLVE_CACHE=(); POCKETSHELL_TA_DEPS_CACHE=()
+  POCKETSHELL_TA_INDEX_CLASSES=0; POCKETSHELL_TA_INDEX_IMPORT_LINES=0
+  POCKETSHELL_TA_INDEX_CROSS_AREA_CLASSES=0; POCKETSHELL_TA_INDEX_PROD_PKGS=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_PKGS=0; POCKETSHELL_TA_INDEX_HOSTCLI_CLASSES=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS=0; POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS=0; POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_SUBCOMMANDS=0
+
+  if [[ ! -f "$manifest" ]]; then
+    POCKETSHELL_TA_LOAD_ERRORS+=("manifest not found: $manifest")
+    return 1
+  fi
+
+  local lineno=0 line kind a b c rest
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    lineno=$((lineno + 1))
+    line="${line%%$'\r'}"
+    [[ "$line" =~ ^[[:space:]]*(#.*)?$ ]] && continue
+    read -r kind a b c rest <<<"$line"
+    case "$kind" in
+      area)
+        if [[ -z "$a" || -z "$b" ]]; then
+          POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: 'area' needs <name> <tier> <desc>")
+          continue
+        fi
+        if [[ "$b" != "always" && "$b" != "changed" ]]; then
+          POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: unknown tier '$b' (want always|changed)")
+          continue
+        fi
+        if [[ -n "${POCKETSHELL_TA_AREA_TIER[$a]:-}" ]]; then
+          POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: duplicate area '$a'")
+          continue
+        fi
+        POCKETSHELL_TA_AREAS+=("$a")
+        POCKETSHELL_TA_AREA_TIER["$a"]="$b"
+        POCKETSHELL_TA_AREA_DESC["$a"]="${c} ${rest}"
+        ;;
+      full)
+        [[ -z "$a" ]] && { POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: 'full' needs <glob> <reason>"); continue; }
+        POCKETSHELL_TA_FULL_GLOB+=("$a")
+        POCKETSHELL_TA_FULL_REASON+=("${b} ${c} ${rest}")
+        [[ "${a##*/}" == "*" ]] || POCKETSHELL_TA_FILE_SHAPED_GLOB+=("$a")
+        ;;
+      noop)
+        [[ -z "$a" ]] && { POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: 'noop' needs <glob> <reason>"); continue; }
+        POCKETSHELL_TA_NOOP_GLOB+=("$a")
+        POCKETSHELL_TA_NOOP_REASON+=("${b} ${c} ${rest}")
+        ;;
+      src|test)
+        if [[ -z "$a" || -z "$b" || -z "$c" ]]; then
+          POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: '$kind' needs <glob> <area> <devgate>")
+          continue
+        fi
+        case "$c" in
+          ui|bootstrap|terminal|full) : ;;
+          *) POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: unknown devgate '$c' (want ui|bootstrap|terminal|full)"); continue ;;
+        esac
+        if [[ "$kind" == "src" ]]; then
+          POCKETSHELL_TA_SRC_GLOB+=("$a"); POCKETSHELL_TA_SRC_AREA+=("$b"); POCKETSHELL_TA_SRC_DEVGATE+=("$c")
+        else
+          POCKETSHELL_TA_TEST_GLOB+=("$a"); POCKETSHELL_TA_TEST_AREA+=("$b"); POCKETSHELL_TA_TEST_DEVGATE+=("$c")
+          [[ "${a##*/}" == "*" ]] || POCKETSHELL_TA_FILE_SHAPED_GLOB+=("$a")
+        fi
+        ;;
+      class)
+        if [[ -z "$a" || -z "$b" ]]; then
+          POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: 'class' needs <fqcn> <area>")
+          continue
+        fi
+        POCKETSHELL_TA_CLASS_AREA["$a"]="$b"
+        ;;
+      couple)
+        if [[ -z "$a" || -z "$b" ]]; then
+          POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: 'couple' needs <area> <area,area,...>")
+          continue
+        fi
+        POCKETSHELL_TA_COUPLE["$a"]="${POCKETSHELL_TA_COUPLE[$a]:+${POCKETSHELL_TA_COUPLE[$a]},}$b"
+        ;;
+      *)
+        POCKETSHELL_TA_LOAD_ERRORS+=("$manifest:$lineno: unknown record type '$kind'")
+        ;;
+    esac
+  done < "$manifest"
+
+  # Referential integrity: every area named by a src/test/class/couple row must
+  # be declared. A typo'd area name would otherwise create a silent ghost area
+  # whose tests are selected by nothing.
+  local i name
+  for i in "${!POCKETSHELL_TA_SRC_AREA[@]}"; do
+    name="${POCKETSHELL_TA_SRC_AREA[$i]}"
+    [[ -n "${POCKETSHELL_TA_AREA_TIER[$name]:-}" ]] || \
+      POCKETSHELL_TA_LOAD_ERRORS+=("src rule '${POCKETSHELL_TA_SRC_GLOB[$i]}' names undeclared area '$name'")
+  done
+  for i in "${!POCKETSHELL_TA_TEST_AREA[@]}"; do
+    name="${POCKETSHELL_TA_TEST_AREA[$i]}"
+    [[ -n "${POCKETSHELL_TA_AREA_TIER[$name]:-}" ]] || \
+      POCKETSHELL_TA_LOAD_ERRORS+=("test rule '${POCKETSHELL_TA_TEST_GLOB[$i]}' names undeclared area '$name'")
+  done
+  for name in "${!POCKETSHELL_TA_CLASS_AREA[@]}"; do
+    [[ -n "${POCKETSHELL_TA_AREA_TIER[${POCKETSHELL_TA_CLASS_AREA[$name]}]:-}" ]] || \
+      POCKETSHELL_TA_LOAD_ERRORS+=("class override '$name' names undeclared area '${POCKETSHELL_TA_CLASS_AREA[$name]}'")
+  done
+  local from to
+  for from in "${!POCKETSHELL_TA_COUPLE[@]}"; do
+    [[ -n "${POCKETSHELL_TA_AREA_TIER[$from]:-}" ]] || \
+      POCKETSHELL_TA_LOAD_ERRORS+=("couple source '$from' is not a declared area")
+    local IFS=','
+    for to in ${POCKETSHELL_TA_COUPLE[$from]}; do
+      [[ -n "${POCKETSHELL_TA_AREA_TIER[$to]:-}" ]] || \
+        POCKETSHELL_TA_LOAD_ERRORS+=("couple '$from' -> undeclared area '$to'")
+    done
+  done
+
+  if [[ "${#POCKETSHELL_TA_AREAS[@]}" -eq 0 ]]; then
+    POCKETSHELL_TA_LOAD_ERRORS+=("manifest declares no areas")
+  fi
+
+  [[ "${#POCKETSHELL_TA_LOAD_ERRORS[@]}" -eq 0 ]]
+}
+
+# True when the path lives inside a Gradle test source set.
+pocketshell_test_areas_is_test_path() {
+  case "$1" in
+    */src/test/*|*/src/androidTest/*|*/src/integrationTest/*|*/src/testDebug/*|*/src/testRelease/*)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True when the basename follows the repo's test-class naming convention.
+#
+# Every registry, guard and Gradle filter in this repo keys off that
+# convention, so it is the definition used here too. Kotlin AND Java: the
+# vendored Termux terminal suite under shared/core-terminal is `*Test.java`,
+# and treating those 19 classes as "not tests" silently force-fulled them and
+# left them out of the ledger's registered set.
+pocketshell_test_areas_is_test_class_file() {
+  case "$1" in
+    *Test.kt|*Test.java|*Tests.kt|*Tests.java) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Repo-relative test source path -> fully-qualified class name, or empty when
+# the path is not a Kotlin/Java test class file.
+pocketshell_test_areas_fqcn_for_path() {
+  local p="$1" rel
+  pocketshell_test_areas_is_test_path "$p" || { printf ''; return 1; }
+  pocketshell_test_areas_is_test_class_file "$p" || { printf ''; return 1; }
+  # Strip everything up to and including the source set + source-root dir.
+  case "$p" in
+    */src/androidTest/*)     rel="${p##*/src/androidTest/}" ;;
+    */src/integrationTest/*) rel="${p##*/src/integrationTest/}" ;;
+    */src/testDebug/*)       rel="${p##*/src/testDebug/}" ;;
+    */src/testRelease/*)     rel="${p##*/src/testRelease/}" ;;
+    *)                       rel="${p##*/src/test/}" ;;
+  esac
+  rel="${rel#java/}"
+  rel="${rel#kotlin/}"
+  rel="${rel%.kt}"
+  rel="${rel%.java}"
+  printf '%s\n' "${rel//\//.}"
+}
+
+# THE classifier. Sets the POCKETSHELL_TEST_AREA_* globals.
+#
+# Note the very first assignment: `full`. Every later branch must actively
+# prove a narrower answer. Deleting any branch below makes the classifier more
+# conservative, never less.
+pocketshell_test_area_classify() {
+  local p="$1"
+  POCKETSHELL_TEST_AREA_KIND="full"
+  POCKETSHELL_TEST_AREA_NAME=""
+  POCKETSHELL_TEST_AREA_REASON="unmapped-path"
+  POCKETSHELL_TEST_AREA_DEVGATE="full"
+
+  local i
+  # 1. Explicit force-full rows.
+  for i in "${!POCKETSHELL_TA_FULL_GLOB[@]}"; do
+    # shellcheck disable=SC2053
+    if [[ "$p" == ${POCKETSHELL_TA_FULL_GLOB[$i]} ]]; then
+      POCKETSHELL_TEST_AREA_REASON="full-rule:${POCKETSHELL_TA_FULL_GLOB[$i]}"
+      return 0
+    fi
+  done
+
+  # 2. Test infrastructure: anything in a test source set that is not itself a
+  #    test class is a shared fixture, helper, rule, base class or resource.
+  if pocketshell_test_areas_is_test_path "$p"; then
+    if ! pocketshell_test_areas_is_test_class_file "$p"; then
+      POCKETSHELL_TEST_AREA_REASON="test-infrastructure(non-*Test file in a test source set)"
+      return 0
+    fi
+  fi
+
+  # 3. Provably inert paths.
+  for i in "${!POCKETSHELL_TA_NOOP_GLOB[@]}"; do
+    # shellcheck disable=SC2053
+    if [[ "$p" == ${POCKETSHELL_TA_NOOP_GLOB[$i]} ]]; then
+      POCKETSHELL_TEST_AREA_KIND="noop"
+      POCKETSHELL_TEST_AREA_REASON="noop-rule:${POCKETSHELL_TA_NOOP_GLOB[$i]}"
+      POCKETSHELL_TEST_AREA_DEVGATE="full"
+      return 0
+    fi
+  done
+
+  # 4. Per-class overrides (a test class pinned to an area other than its
+  #    package's default, e.g. the conversation-source cluster that lives in
+  #    the app.tmux package but belongs to the conversation-agents area).
+  local fqcn=""
+  if pocketshell_test_areas_is_test_path "$p"; then
+    fqcn="$(pocketshell_test_areas_fqcn_for_path "$p")" || fqcn=""
+    if [[ -n "$fqcn" && -n "${POCKETSHELL_TA_CLASS_AREA[$fqcn]:-}" ]]; then
+      POCKETSHELL_TEST_AREA_KIND="area"
+      POCKETSHELL_TEST_AREA_NAME="${POCKETSHELL_TA_CLASS_AREA[$fqcn]}"
+      POCKETSHELL_TEST_AREA_REASON="class-override:$fqcn"
+      POCKETSHELL_TEST_AREA_DEVGATE="full"
+      # Fall through to the test globs only to pick up the devgate stage.
+      for i in "${!POCKETSHELL_TA_TEST_GLOB[@]}"; do
+        # shellcheck disable=SC2053
+        if [[ "$p" == ${POCKETSHELL_TA_TEST_GLOB[$i]} ]]; then
+          POCKETSHELL_TEST_AREA_DEVGATE="${POCKETSHELL_TA_TEST_DEVGATE[$i]}"
+          break
+        fi
+      done
+      return 0
+    fi
+    # 5. Test globs.
+    for i in "${!POCKETSHELL_TA_TEST_GLOB[@]}"; do
+      # shellcheck disable=SC2053
+      if [[ "$p" == ${POCKETSHELL_TA_TEST_GLOB[$i]} ]]; then
+        POCKETSHELL_TEST_AREA_KIND="area"
+        POCKETSHELL_TEST_AREA_NAME="${POCKETSHELL_TA_TEST_AREA[$i]}"
+        POCKETSHELL_TEST_AREA_REASON="test-rule:${POCKETSHELL_TA_TEST_GLOB[$i]}"
+        POCKETSHELL_TEST_AREA_DEVGATE="${POCKETSHELL_TA_TEST_DEVGATE[$i]}"
+        return 0
+      fi
+    done
+    # A test file that matches no test rule stays `full` (the initial value).
+    POCKETSHELL_TEST_AREA_REASON="unmapped-test-path"
+    return 0
+  fi
+
+  # 6. Production globs.
+  for i in "${!POCKETSHELL_TA_SRC_GLOB[@]}"; do
+    # shellcheck disable=SC2053
+    if [[ "$p" == ${POCKETSHELL_TA_SRC_GLOB[$i]} ]]; then
+      POCKETSHELL_TEST_AREA_KIND="area"
+      POCKETSHELL_TEST_AREA_NAME="${POCKETSHELL_TA_SRC_AREA[$i]}"
+      POCKETSHELL_TEST_AREA_REASON="src-rule:${POCKETSHELL_TA_SRC_GLOB[$i]}"
+      POCKETSHELL_TEST_AREA_DEVGATE="${POCKETSHELL_TA_SRC_DEVGATE[$i]}"
+      return 0
+    fi
+  done
+
+  # 7. Fall-through: full. (Already set at the top of the function.)
+  return 0
+}
+
+# ===========================================================================
+# THE INDEX — ONE resolver, and the import-derived dependency sets
+#
+# WHY THIS REPLACED TWO RESOLVERS (#2063 round-1 finding B4)
+#
+# Round 1 shipped two disagreeing resolvers: `--verify-manifest` resolved a test
+# class from its tracked FILE PATH (correct for every module), while the ledger
+# guard resolved from the FQCN by probing a hardcoded list of source roots. That
+# list omitted every `shared/*/src/test/java` root, so 183 of 1047 registered
+# classes — all 49 core-ssh and all 22 core-connection D28 classes among them —
+# resolved to NO area and the ledger guard was red on the real tree while its
+# self-test (synthetic app-style trees only) stayed green. Two resolvers is the
+# defect; there is now exactly one, and it is built from `git ls-files`, so a new
+# module or source set cannot be missed by a list nobody remembered to extend.
+#
+# WHY THE INDEX ALSO CARRIES IMPORT-DERIVED DEPENDENCIES (finding B2)
+#
+# Round 1 decided what to run purely from hand-written `couple` rows between
+# areas. Two of those rows were CLAIMED in the write-up and absent from the
+# manifest, so 29 registered journeys that compile against connection-core
+# production types — `ForwardingNetworkRideThroughE2eTest` (drives the real
+# `TerminalNetworkObserver`), `ConnectionLogHostMirrorReconnectDockerTest` (#969,
+# constructs `ActiveTmuxClients()`), `Issue1876FolderListMobileRttDockerTest`
+# (#1876, D34) — were NOT selected by a connection-core change. Under D28 that is
+# the worst possible place to under-select.
+#
+# The cure is to stop hand-listing compile-level coupling. Every test class now
+# carries a DEPENDENCY SET derived from its own `import com.pocketshell.…` lines:
+# the areas of the production packages it actually compiles against. A class is
+# selected when any area it depends on changed, whether or not anybody wrote a
+# `couple` row. The hand rows remain for BEHAVIOURAL coupling that no import can
+# express (composer-always-present across screens, ui-kit tokens reaching every
+# surface) — they are additive, never the only mechanism.
+#
+# WHY DEPENDENCIES ARE PER-CLASS AND ONE HOP, STATED RATHER THAN HIDDEN
+#
+# Two stronger-looking designs were measured on this tree and both degenerate:
+#
+#   * area-level derived edges, applied transitively: the 79 derived edges make
+#     the area graph strongly connected, so EVERY change selects 17 of 19 areas.
+#   * production-to-production transitive closure (test -> prodA -> prodX): the
+#     93-edge production area graph is strongly connected too (composer-voice ⇄
+#     connection-core ⇄ hosts-settings ⇄ …), so it also degenerates to full.
+#
+# So the rule is deliberately the DIRECT compile edge, applied per test CLASS:
+# "if area X changed, run every test class that imports X's production code."
+# It does not chase transitive production dependencies — a test that only
+# imports `fileviewer`, whose implementation imports `core-ssh`, is not selected
+# by a core-ssh change through that chain. That bound is real, it is the reason
+# the numbers are what they are, and the backstops are the always tier, the
+# nightly full run and the release gate. Do not silently widen or narrow it;
+# change it deliberately and re-measure.
+#
+# HOST CLI: THE ONE COUPLING NO KOTLIN IMPORT CAN EXPRESS (finding B1)
+#
+# `tools/pocketshell/**` is Python. No Kotlin file imports it, so the import
+# graph says a host-CLI change affects nothing — which is exactly how round 1
+# let a `tools/pocketshell/src/pocketshell/tree.py` change run ZERO of the
+# journeys built to catch host-CLI/client mismatch, including
+# `FolderListHostOutdatedTreeVersionDaemonDockerTest` (#1509, G10). That is the
+# #847 / v0.4.10 class: host-CLI/client version is a RUNTIME lockstep, and a new
+# client calling a new subcommand against an older host CLI hangs.
+#
+# A WIRE CONTRACT HAS TWO ENDS, AND ROUND 2 MARKED ONLY ONE (finding B6)
+#
+# Round 2's seam was "packages that INVOKE the CLI". That is the PRODUCER end of
+# the request. It marked 15 :app packages and — structurally, not by accident —
+# ZERO packages in `shared/*`, because no shared module ever shells out. So
+# `shared/core-usage`, whose `PocketshellUsageJsonParser` is the deliberately
+# STRICT / fail-loud reader of the NDJSON that `tools/pocketshell/.../usage.py`
+# emits, was not on the seam and `:shared:core-usage:test` did not run on a
+# host-CLI change. Same shape as #1509, moved from `tree` to `usage`: the
+# instance was fixed and the class survived.
+#
+# The seam now marks BOTH ends, each derived mechanically:
+#
+#   (a) PRODUCER / INVOKER end — a production file that invokes the CLI
+#       (`PocketshellCommand`, or a literal `pocketshell …` command string).
+#       Its package is on the seam. Unchanged from round 2.
+#
+#   (b) CONSUMER / REPLY end — a production package that an INVOKING FILE
+#       imports. The invoker builds the request and hands the reply to
+#       something; that something is in the invoking file's own import set.
+#       This is what reaches `com.pocketshell.core.usage` (UsageRemoteSource
+#       imports PocketshellUsageJsonParser), `com.pocketshell.core.storage.entity`
+#       (HostEntity carries the CLI lockstep version columns) and
+#       `com.pocketshell.uikit.model` (HostSetupState renders the CLI
+#       missing/incompatible states) — the three holes the round-2 review named,
+#       plus the rest of their class.
+#
+#       ONE HOP, no transitive closure — the same bound rule 4 accepts and for
+#       the same measured reason (the production graph is strongly connected, so
+#       a closure degenerates to "run everything"). Deliberately unfiltered: the
+#       hop also picks up collaborators that are not wire consumers (theme
+#       tokens imported by an invoking Composable). That over-selection costs
+#       test time on a `tools/pocketshell/**` change only, because `host-cli` is
+#       a changed-tier area that nothing else puts in the diff. A false positive
+#       there is minutes; a false negative is #847.
+#
+#   (c) VOCABULARY end — a production package whose source NAMES a real host-CLI
+#       subcommand (`pocketshell <subcommand>`), where the subcommand vocabulary
+#       is extracted from the PRODUCER ITSELF: the top-level registrations on the
+#       `click` group in `tools/pocketshell/src/pocketshell/cli.py`.
+#
+#       (b) cannot be the whole consumer rule because a wire contract does not
+#       need an in-app invoker at all. `com.pocketshell.app.settings` parses the
+#       payload that `pocketshell qr-share` produces, and that payload arrives by
+#       QR scan / clipboard — no exec, so no invoking file imports the settings
+#       package and no import edge exists to follow. (c) is what catches that
+#       category. Taking the vocabulary from the Python side rather than from a
+#       loose grep is what keeps it honest: `pocketshell-voice-secrets` (a
+#       DataStore file name) and "the `pocketshell` daemon registry" (prose) are
+#       not subcommands and do not match.
+#
+#       ROUND-3 FINDING B9 — WHY THIS READS THE PRODUCER'S GRAMMAR, NOT ITS TEXT.
+#       This extraction used to be one grep for `add_command(…, name="…")`, i.e.
+#       ONE of the registration forms click offers. `cli.py` already uses a
+#       second one — `daemon` is `@cli.group(name="daemon")` — so the extractor
+#       under-read the producer *on the shipped tree* while the guard printed
+#       "16 subcommands" as though that were the producer's list. Converting four
+#       more registrations to the form `daemon` already uses dropped `usage`,
+#       `tree`, `agents` and `qr-share` from the vocabulary, took
+#       `com.pocketshell.app.settings` — the ONE package this end exists to
+#       catch — off the seam, cut unit selection 570 -> 560, and left every floor
+#       green. That is the #847 class wearing its fourth spelling, and a floor
+#       cannot see it: a floor detects a SMALLER number, and under-reading
+#       produces a number that looks fine.
+#
+#       So the reader is `python3 -c ast` over `cli.py` — the producer's own
+#       grammar — and it is FAIL-CLOSED on two axes:
+#
+#         * it counts registration SITES (`cli.add_command(...)`, `@cli.group(…)`,
+#           `@cli.command(…)`, in any shape, anywhere in the module) and the
+#           NAMES it could resolve, and `--verify-manifest` check 7 asserts
+#           names == sites. Equality is the instrument a floor could not be:
+#           a form the reader cannot decode raises the site count without
+#           raising the name count, so it is LOUD instead of silently narrowing.
+#         * anything it cannot decode — a registration inside a loop / function /
+#           conditional (the shape `agents.py:880` already uses one level down),
+#           a `name=` that is a constant rather than a literal, an omitted name,
+#           a bare `@cli.group`, a `cli.py` it cannot parse, a missing `python3` —
+#           is reported as UNREADABLE and check 7 fails on it by name.
+#
+#       The floor on the site count stays, with a narrower job than before: it
+#       is the only thing that can catch a TOTALLY dead reader, because the
+#       equality check is vacuous at 0 == 0.
+#
+# A package on the seam by ANY of the three contributes `host-cli` to the
+# dependency set of every test that imports it or sits in it.
+#
+# Each end has its OWN substantive floor in `--verify-manifest` check 7,
+# including a floor on how far the seam reaches into `shared/*`, because the
+# round-2 defect was invisible to a total-only floor: the total was 15 packages
+# / 569 classes while the shared reach was zero.
+POCKETSHELL_TA_HOSTCLI_MARKER="${POCKETSHELL_TA_HOSTCLI_MARKER:-PocketshellCommand|\"pocketshell |pocketshell --}"
+# The producer-side source of the subcommand vocabulary for end (c). Overridable
+# only so the self-test can kill it, or point it at a mutated `cli.py`, and watch
+# the guard redden. An absolute path is used as-is; a relative one is resolved
+# against the repo root, so a self-test mutant can live in its own sandbox
+# instead of inside the tree it is measuring.
+POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="${POCKETSHELL_TA_HOSTCLI_CLI_SOURCE:-tools/pocketshell/src/pocketshell/cli.py}"
+
+declare -A POCKETSHELL_TA_PROD_PKG_AREA=()      # production package -> area
+declare -A POCKETSHELL_TA_PROD_PKG_HOSTCLI=()   # production package -> 1 when on the CLI wire seam
+declare -A POCKETSHELL_TA_HOSTCLI_END=()        # production package -> "invoker" | "consumer" | "vocabulary" (first end that marked it)
+declare -A POCKETSHELL_TA_PROD_PKG_SHARED=()    # production package -> 1 when it lives under shared/
+declare -A POCKETSHELL_TA_CLASS_PATH=()         # test FQCN -> tracked path
+declare -A POCKETSHELL_TA_CLASS_RESOLVED=()     # test FQCN -> area
+declare -A POCKETSHELL_TA_CLASS_DEPS=()         # test FQCN -> " area area … "
+declare -A POCKETSHELL_TA_PKG_TEST_AREA=()      # test package -> area (sibling fallback)
+declare -A POCKETSHELL_TA_PKG_TEST_DEPS=()      # test package -> union deps (sibling fallback)
+declare -A POCKETSHELL_TA_RESOLVE_CACHE=()      # test FQCN -> resolved area (memo of THE resolver)
+declare -A POCKETSHELL_TA_DEPS_CACHE=()         # test FQCN -> dep set (memo of THE deps resolver)
+declare -A POCKETSHELL_TA_CLASS_MODULE=()       # test FQCN -> gradle project path
+declare -A POCKETSHELL_TA_CLASS_SOURCESET=()    # test FQCN -> test | androidTest | integrationTest
+
+POCKETSHELL_TA_INDEX_BUILT=0
+POCKETSHELL_TA_INDEX_CLASSES=0
+POCKETSHELL_TA_INDEX_IMPORT_LINES=0
+POCKETSHELL_TA_INDEX_CROSS_AREA_CLASSES=0
+POCKETSHELL_TA_INDEX_PROD_PKGS=0
+POCKETSHELL_TA_INDEX_HOSTCLI_PKGS=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CLASSES=0
+POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS=0
+POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS=0
+POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS=0
+POCKETSHELL_TA_INDEX_HOSTCLI_SUBCOMMANDS=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CLI_NONROOT=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SCANNED=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE=0
+POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG=""
+
+# Mark ONE production package as on the host-CLI wire seam, attributed to the
+# end that found it first, and keep that end's counter. Attribution exists so
+# `--verify-manifest` check 7 can floor each end separately: the round-2 defect
+# (finding B6) was a seam whose TOTAL looked healthy at 15 packages while one
+# whole end — and with it all of `shared/*` — contributed zero.
+_pocketshell_hostcli_mark() {
+  local p="$1" end="$2"
+  [[ -n "${POCKETSHELL_TA_PROD_PKG_AREA[$p]:-}" ]] || return 0
+  POCKETSHELL_TA_PROD_PKG_HOSTCLI["$p"]=1
+  # Ends ACCUMULATE rather than first-wins: each end needs its own honest count,
+  # or a floor on end X silently passes because end Y happened to mark the same
+  # package first. (That shadowing is a miniature of the B6 defect itself.)
+  [[ " ${POCKETSHELL_TA_HOSTCLI_END[$p]:-} " == *" $end "* ]] || \
+    POCKETSHELL_TA_HOSTCLI_END["$p"]="${POCKETSHELL_TA_HOSTCLI_END[$p]:+${POCKETSHELL_TA_HOSTCLI_END[$p]} }$end"
+  return 0
+}
+
+# Recount the per-end and shared-reach seam totals from the accumulated ends.
+_pocketshell_hostcli_recount() {
+  local p e
+  POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS=0
+  for p in "${!POCKETSHELL_TA_PROD_PKG_HOSTCLI[@]}"; do
+    for e in ${POCKETSHELL_TA_HOSTCLI_END[$p]:-}; do
+      case "$e" in
+        invoker)    POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS=$((POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS + 1)) ;;
+        consumer)   POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS=$((POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS + 1)) ;;
+        vocabulary) POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS=$((POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS + 1)) ;;
+      esac
+    done
+    [[ -n "${POCKETSHELL_TA_PROD_PKG_SHARED[$p]:-}" ]] && \
+      POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS=$((POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS + 1))
+  done
+  POCKETSHELL_TA_INDEX_HOSTCLI_PKGS="${#POCKETSHELL_TA_PROD_PKG_HOSTCLI[@]}"
+  return 0
+}
+
+# Read the host-CLI subcommand vocabulary out of the producer (finding B9).
+#
+# $1 = absolute path to `cli.py`. Emits a line-oriented protocol on stdout:
+#
+#   SCANNED <n>          every registrar call node in the file, ANY receiver
+#   SITES <n>            of those, registrations on the TOP-LEVEL group
+#   NONROOT <n>          of those, registrations PROVEN to be on something else
+#   UNCLASSIFIED <n>     of those, ones whose receiver could not be resolved
+#   NAME <subcommand>    one per SITE whose name the reader could resolve
+#   UNREADABLE <reason>  one per site (or condition) it could NOT decode
+#   END                  the reader ran to completion
+#
+# `SCANNED == SITES + NONROOT + UNCLASSIFIED` is an accounting identity the
+# caller re-checks: no registrar call in the file can fall out of the census.
+#
+# The caller treats a MISSING `END` as unreadable, which is what makes "python3
+# is not installed", "python3 crashed" and "the reader was killed" fail the same
+# closed way as a registration form it does not understand. Nothing here ever
+# returns a smaller-but-plausible vocabulary: under-reading is an ERROR, because
+# a smaller number is exactly what a floor cannot distinguish from normal drift.
+_pocketshell_hostcli_read_cli_vocabulary() {
+  local src="$1"
+  if [[ ! -f "$src" ]]; then
+    printf 'UNREADABLE no such CLI source: %s\nSITES 0\nEND\n' "$src"
+    return 0
+  fi
+  python3 - "$src" 2>/dev/null <<'PY'
+import ast
+import os
+import re
+import sys
+
+path = sys.argv[1]
+# A subcommand token the vocabulary regex can safely carry. Anything else is
+# reported UNREADABLE rather than dropped: a name with regex metacharacters
+# would either corrupt the seam scan or silently shrink the vocabulary, and
+# "silently shrink" is the whole defect this reader exists to end.
+SUBCOMMAND_TOKEN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+names = []
+unreadable = []
+sites = 0
+nonroot = 0
+unclassified = 0
+scanned = 0
+
+
+def emit_and_exit():
+    for line in unreadable:
+        print("UNREADABLE " + line.replace("\n", " "))
+    for n in names:
+        print("NAME " + n)
+    print("SITES %d" % sites)
+    print("NONROOT %d" % nonroot)
+    print("UNCLASSIFIED %d" % unclassified)
+    print("SCANNED %d" % scanned)
+    print("END")
+    raise SystemExit(0)
+
+
+try:
+    tree = ast.parse(open(path, encoding="utf-8").read(), filename=path)
+except Exception as exc:  # noqa: BLE001 - any parse problem must fail closed
+    unreadable.append("cannot parse %s: %s: %s" % (path, type(exc).__name__, exc))
+    emit_and_exit()
+
+
+def string_literal(node):
+    """The plain string a node denotes, or None when it is not a literal."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def decorator_target(dec):
+    return dec.func if isinstance(dec, ast.Call) else dec
+
+
+# 1. Identify the ONE top-level click group. Everything below is anchored on its
+#    binding name, so a rename cannot leave the reader silently reading nothing.
+roots = []
+for node in tree.body:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        for dec in node.decorator_list:
+            target = decorator_target(dec)
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "group"
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "click"
+            ):
+                roots.append(node.name)
+if len(roots) != 1:
+    unreadable.append(
+        "expected exactly one module-level @click.group in %s, found %d"
+        % (path, len(roots))
+    )
+    emit_and_exit()
+root = roots[0]
+
+REGISTRARS = ("add_command", "group", "command")
+accounted = set()
+
+# ---------------------------------------------------------------------------
+# 1b. Resolve every module-level BINDING in this file to one of three kinds:
+#
+#       "root"    — provably the top-level group object: the decorated def
+#                   itself, and anything transitively assigned from it
+#                   (`_g = cli`, `_h = _g`).
+#       "nonroot" — provably a DIFFERENT object: an imported module or name, an
+#                   undecorated def/class, or a def whose decorators are all
+#                   click's own factories (which return a fresh Group/Command
+#                   or the fresh function itself, never some other object).
+#       "unknown" — everything else, INCLUDING every name bound inside a
+#                   function (parameters, locals, loop targets, comprehension
+#                   variables) and every name bound by a top-level for/if/with.
+#
+# This is what makes the reader receiver-AGNOSTIC, and it is the round-5 fix.
+# Rounds 1-5 keyed detection on the receiver being the literal name `cli`, so a
+# registration reached through ANY other binding was neither a SITE nor a NAME:
+# `names == sites` held vacuously and the vocabulary shrank in silence. Five
+# spellings were closed one at a time and a sixth (`_g = cli; _g.add_command(…)`,
+# and a helper taking the group as a parameter) was still silent, because the
+# space of ways to name an object is unbounded and cannot be enumerated.
+#
+# So the reader no longer recognises a list of shapes. It looks at EVERY
+# registrar call in this file, whatever the receiver, and each one must either
+# resolve to the root group (and then to a literal name) or be proven to be
+# something else. Anything it cannot place is UNREADABLE — loud, never absent.
+# ---------------------------------------------------------------------------
+CLICK_FACTORY_ATTRS = ("group", "command")
+env = {}
+root_rebound = []
+star_imports = []
+
+
+def decorator_is_binding_safe(dec):
+    """True when a decorator cannot make its target BE the root group object.
+
+    click's `@click.*` decorators and `@<group>.group` / `@<group>.command`
+    factories return either a fresh Group/Command or the fresh function they
+    were handed. An unrecognised decorator could return anything at all —
+    including `cli` itself — so it leaves the binding "unknown" rather than
+    letting the reader guess.
+    """
+    target = decorator_target(dec)
+    if not isinstance(target, ast.Attribute) or not isinstance(target.value, ast.Name):
+        return False
+    if target.value.id == "click":
+        return True
+    return target.attr in CLICK_FACTORY_ATTRS and env.get(target.value.id) in (
+        "root",
+        "nonroot",
+    )
+
+
+def bind(name, kind, lineno):
+    if name == root and kind != "root":
+        root_rebound.append(lineno)
+    env[name] = kind
+
+
+def value_kind(node):
+    # Only a bare Name propagates a known kind. A call, attribute, subscript or
+    # literal is "unknown": the reader will not guess that `click.Group()` or
+    # `_make_group()` is not the root group, it will say so.
+    if isinstance(node, ast.Name):
+        return env.get(node.id, "unknown")
+    return "unknown"
+
+
+def bind_targets(target, kind, lineno):
+    if isinstance(target, ast.Name):
+        bind(target.id, kind, lineno)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            bind_targets(elt, "unknown", lineno)
+    elif isinstance(target, ast.Starred):
+        bind_targets(target.value, "unknown", lineno)
+    # Attribute/Subscript targets bind no module-level name.
+
+
+for node in tree.body:
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            bind(alias.asname or alias.name.split(".")[0], "nonroot", node.lineno)
+    elif isinstance(node, ast.ImportFrom):
+        for alias in node.names:
+            if alias.name == "*":
+                star_imports.append(node.lineno)
+            else:
+                bind(alias.asname or alias.name, "nonroot", node.lineno)
+    elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if node.name == root:
+            env[node.name] = "root"
+        elif all(decorator_is_binding_safe(d) for d in node.decorator_list):
+            bind(node.name, "nonroot", node.lineno)
+        else:
+            bind(node.name, "unknown", node.lineno)
+    elif isinstance(node, ast.Assign):
+        kind = value_kind(node.value)
+        for target in node.targets:
+            bind_targets(target, kind, node.lineno)
+    elif isinstance(node, ast.AnnAssign):
+        bind_targets(
+            node.target,
+            value_kind(node.value) if node.value is not None else "unknown",
+            node.lineno,
+        )
+    elif isinstance(node, ast.AugAssign):
+        bind_targets(node.target, "unknown", node.lineno)
+    else:
+        # A top-level for/if/with/try can bind names too, and the reader trusts
+        # none of them: every name they store becomes "unknown", so registering
+        # through one is UNREADABLE rather than invisible.
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Store):
+                bind(sub.id, "unknown", getattr(sub, "lineno", node.lineno))
+
+# A `global` inside a function can rebind a module-level name after import time.
+for sub in ast.walk(tree):
+    if isinstance(sub, ast.Global):
+        for nm in sub.names:
+            if nm == root:
+                unreadable.append(
+                    "the root binding %r is declared `global` at line %d, so a "
+                    "function can point it at another object" % (root, sub.lineno)
+                )
+            else:
+                env[nm] = "unknown"
+for line in sorted(set(root_rebound)):
+    unreadable.append(
+        "the root binding %r is reassigned at line %d, so which object the "
+        "registrations below land on is not decidable from the source" % (root, line)
+    )
+for line in sorted(set(star_imports)):
+    unreadable.append(
+        "%s does a star import at line %d, which can bind arbitrary names this "
+        "reader cannot resolve" % (os.path.basename(path), line)
+    )
+
+
+def receiver_of(node):
+    """(kind, human description) of the object a registrar is invoked on."""
+    recv = node.value
+    if isinstance(recv, ast.Name):
+        return env.get(recv.id, "unknown"), recv.id
+    return "unknown", "<%s expression>" % type(recv).__name__
+
+
+def accept(where, value):
+    if not SUBCOMMAND_TOKEN.match(value):
+        unreadable.append("%s: %r is not a plain subcommand token" % (where, value))
+    else:
+        names.append(value)
+
+
+def take_name(where, kwargs, positional, index):
+    """Resolve one site's subcommand name, or record why it cannot be resolved."""
+    global sites
+    sites += 1
+    for kw in kwargs:
+        if kw.arg == "name":
+            value = string_literal(kw.value)
+            if value is None:
+                unreadable.append(
+                    "%s: name= is not a plain string literal (%s)"
+                    % (where, type(kw.value).__name__)
+                )
+            else:
+                accept(where, value)
+            return
+        if kw.arg is None:
+            unreadable.append("%s: **kwargs registration cannot be read" % where)
+            return
+    if len(positional) > index:
+        value = string_literal(positional[index])
+        if value is None:
+            unreadable.append(
+                "%s: positional name is not a plain string literal (%s)"
+                % (where, type(positional[index]).__name__)
+            )
+        else:
+            accept(where, value)
+        return
+    unreadable.append(
+        "%s: no explicit name — click would derive it from the decorated object, "
+        "which this reader deliberately does not guess" % where
+    )
+
+
+# 2. THE CENSUS. Every registrar call node in the file, whatever its receiver.
+#    Nothing below filters by receiver name; the receiver is RESOLVED instead.
+registrar_nodes = [
+    n for n in ast.walk(tree) if isinstance(n, ast.Attribute) and n.attr in REGISTRARS
+]
+scanned = len(registrar_nodes)
+
+# 3. The two forms the reader can fully decode, both at module top level and
+#    both anchored on a receiver that RESOLVES to the root group — so an alias
+#    (`_g = cli`) is read correctly rather than vanishing.
+for node in tree.body:
+    # (i) `<root>.add_command(cmd, name="x")`
+    if (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "add_command"
+    ):
+        kind, who = receiver_of(node.value.func)
+        if kind == "root":
+            accounted.add(id(node.value.func))
+            take_name(
+                "%s.add_command line %d" % (who, node.lineno),
+                node.value.keywords,
+                node.value.args,
+                1,
+            )
+        continue
+    # (ii) `@<root>.group(name="x")` / `@<root>.command("x")` on a top-level def
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        for dec in node.decorator_list:
+            target = decorator_target(dec)
+            if not isinstance(target, ast.Attribute) or target.attr not in (
+                "group",
+                "command",
+            ):
+                continue
+            kind, who = receiver_of(target)
+            if kind != "root":
+                continue
+            accounted.add(id(target))
+            where = "@%s.%s line %d" % (who, target.attr, dec.lineno)
+            if isinstance(dec, ast.Call):
+                take_name(where, dec.keywords, dec.args, 0)
+            else:
+                sites += 1
+                unreadable.append(
+                    "%s: bare decorator with no name — click would derive it from "
+                    "the function name, which this reader deliberately does not guess"
+                    % where
+                )
+
+# 4. Every remaining node in the census gets a verdict. There are exactly three,
+#    and together with step 3 they partition the census — see the identity below.
+#
+#      root      -> the receiver resolves to the top-level group, but the call
+#                   is not in a form step 3 can place: a module-level loop or
+#                   conditional, a nested def, a comprehension, or a function
+#                   body that names the group through its module-level binding.
+#                   Counts as a SITE and is UNREADABLE, so both the equality
+#                   check and the decode check fire on it.
+#                   (A function that receives the group as a PARAMETER is not
+#                   this case — its receiver does not resolve at all, so it
+#                   lands in `unknown` below. Round 4's comment claimed step 3
+#                   caught "inside a function"; for the parameter form that was
+#                   false, and the silence was the round-5 blocker.)
+#      nonroot   -> it registers on a provably different object: a sub-group
+#                   (`@daemon_group.command`, 4 of these ship today), or it is
+#                   the `@click.group` that DEFINES the root. Neither puts a word
+#                   in the TOP-LEVEL vocabulary, so there is no name to owe.
+#      unknown   -> the receiver could not be resolved (a parameter, a local, a
+#                   subscript, a call result). This is the round-5 blocker: such
+#                   a call might be adding a top-level subcommand, and the reader
+#                   says so instead of leaving it out of both counters.
+for node in registrar_nodes:
+    if id(node) in accounted:
+        continue
+    kind, who = receiver_of(node)
+    line = getattr(node, "lineno", 0)
+    if kind == "root":
+        sites += 1
+        unreadable.append(
+            "%s.%s at line %d registers on the top-level group but is not a "
+            "module-top-level registration this reader can decode" % (who, node.attr, line)
+        )
+    elif kind == "nonroot":
+        nonroot += 1
+    else:
+        unclassified += 1
+        unreadable.append(
+            "%s.%s at line %d: the receiver %r resolves to neither the top-level "
+            "group nor a provably different object, so this reader cannot tell "
+            "whether it registers a top-level subcommand (bind the group to a "
+            "module-level name so it can)" % (who, node.attr, line, who)
+        )
+
+# The partition must be exact, or a registrar node fell out of the census and
+# the equality check above it would be measuring less than the whole file.
+if scanned != sites + nonroot + unclassified:
+    unreadable.append(
+        "internal accounting error in %s: %d registrar nodes scanned but "
+        "%d site + %d non-root + %d unresolved classified"
+        % (path, scanned, sites, nonroot, unclassified)
+    )
+
+# 4b. The census above is total over THIS file, so the only way a registration
+#     can still hide is for the group OBJECT to leave the file. Step 5 catches
+#     it leaving by import; this catches it leaving as a VALUE — handed to a
+#     helper, returned, stashed in a container. That is not hypothetical: this
+#     package already does exactly that one level down
+#     (`register_push_card_commands(push_group)` in cli.py, whose body in
+#     cards.py runs `@push_group.command("checklist")`), so `…(cli)` is one
+#     character away from registering a top-level subcommand out of sight.
+#
+#     Round 5 allowed EVERY attribute access on the root binding, on the claim
+#     that "registrar attrs are already in the census". That claim was false for
+#     a NON-registrar attribute, and it was the round-5 blocker (the SEVENTH
+#     spelling): `click.Group.commands` is a plain dict — `add_command` is
+#     literally `self.commands[name] = cmd` — so `cli.commands["x"] = cmd` and
+#     `cli.commands.update({…})` register a top-level subcommand through a path
+#     that is not a registrar CALL at all. They never entered the census, the
+#     identity balanced over a smaller file (18 = 13 + 5 + 0), and the guard
+#     printed PASS while `com.pocketshell.app.settings` fell off the seam.
+#
+#     So this step is INVERTED, the same way step 1b inverted receiver
+#     detection: instead of naming the shapes that are forbidden, it names the
+#     four attributes that are PROVEN unable to hide a registration and reports
+#     every other one — including attributes nobody has thought of yet.
+#
+#       add_command / group / command — the census at step 2 collects EVERY
+#           `ast.Attribute` node with these names, called or not, and step 3/4
+#           give each one a verdict. Nothing can hide behind them; a bare
+#           `_add = cli.add_command` is already a SITE with no name, so the
+#           equality check fires on it.
+#       main — click's invocation entry (`BaseCommand.main`). It parses argv and
+#           runs the CLI; it does not mutate the command table.
+#
+#     The remaining two allowances are unchanged and are not attribute reads:
+#     the root as the function being CALLED, and as the right-hand side of a
+#     module-level assignment (the alias, which the environment tracks).
+#     Anything else — attribute or not — is UNREADABLE.
+#
+#     Deliberately NOT the fix: adding `commands` to REGISTRARS. That is one
+#     more entry on a list of recognised spellings, which is the pattern that
+#     produced seven of them.
+parents = {}
+for n in ast.walk(tree):
+    for c in ast.iter_child_nodes(n):
+        parents[id(c)] = n
+alias_rhs = set()
+for st in tree.body:
+    if isinstance(st, ast.Assign):
+        alias_rhs.add(id(st.value))
+    elif isinstance(st, ast.AnnAssign) and st.value is not None:
+        alias_rhs.add(id(st.value))
+for n in ast.walk(tree):
+    if not (isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)):
+        continue
+    if env.get(n.id) != "root":
+        continue
+    par = parents.get(id(n))
+    if isinstance(par, ast.Attribute):
+        if par.attr in REGISTRARS or par.attr == "main":
+            continue
+        unreadable.append(
+            "the top-level group %r is read through the non-registrar attribute "
+            "%r at line %d; click's Group.commands is a plain dict, so an "
+            "attribute this reader has not proven inert can add a top-level "
+            "subcommand the census never sees"
+            % (n.id, par.attr, getattr(n, "lineno", 0))
+        )
+        continue
+    if isinstance(par, ast.Call) and par.func is n:
+        continue
+    if id(n) in alias_rhs:
+        continue
+    unreadable.append(
+        "the top-level group %r escapes as a value at line %d (inside %s); it "
+        "could be registered on anywhere, so this reader cannot claim to have "
+        "seen every top-level subcommand"
+        % (n.id, getattr(n, "lineno", 0), type(par).__name__ if par else "module")
+    )
+
+# 5. CROSS-MODULE. Steps 1b-4 are exhaustive over THIS file, and that is enough
+#    for the whole package only because the root group object cannot be NAMED in
+#    a sibling module without being imported from here. This step is what makes
+#    that premise true rather than assumed: any sibling that so much as gains
+#    access to this module or to the root binding trips, so no registration can
+#    happen out of the census's sight. Nothing does it today — `__main__.py`
+#    imports `main`, the entry function, not the group.
+#
+#    It is an AST scan, not a text scan, for the same reason step 4 stopped
+#    matching receivers by name: a regex over import lines recognises the import
+#    spellings someone thought of. `from pocketshell import cli`,
+#    `from .cli import *` and `importlib.import_module("pocketshell.cli")` all
+#    slipped past the round-4 regex. The AST sees every form at once.
+#
+#    (A module OUTSIDE this package could still import the group. That is not
+#    reachable here — the package is self-contained and its entry point is
+#    `cli:main` — and would need the reader to be pointed at a wider tree.)
+package_dir = os.path.dirname(os.path.abspath(path))
+self_name = os.path.basename(path)
+module_stem = os.path.splitext(self_name)[0]
+
+
+def targets_this_module(mod):
+    return mod == module_stem or mod.endswith("." + module_stem)
+
+
+def trip(entry, why):
+    unreadable.append(
+        "%s takes the top-level group object from %s (%s); a registration there "
+        "would be invisible to this reader" % (entry, self_name, why)
+    )
+
+
+for entry in sorted(os.listdir(package_dir)):
+    if not entry.endswith(".py") or entry == self_name:
+        continue
+    sibling = os.path.join(package_dir, entry)
+    try:
+        sib = ast.parse(open(sibling, encoding="utf-8").read(), filename=sibling)
+    except Exception as exc:  # noqa: BLE001 - an unreadable sibling fails closed
+        unreadable.append(
+            "cannot read sibling module %s: %s: %s" % (entry, type(exc).__name__, exc)
+        )
+        continue
+    reason = None
+    for node in ast.walk(sib):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if targets_this_module(alias.name):
+                    reason = "imports the %s module" % module_stem
+                elif alias.name == "importlib" or alias.name.startswith("importlib."):
+                    reason = "can import by name at run time (importlib)"
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            for alias in node.names:
+                if alias.name == "*" and targets_this_module(mod):
+                    reason = "star-imports everything from %s" % self_name
+                elif alias.name in (root, module_stem):
+                    reason = "binds the name %r" % alias.name
+                elif mod == "importlib" and alias.name == "import_module":
+                    reason = "can import by name at run time (importlib)"
+        elif isinstance(node, ast.Name) and node.id == "__import__":
+            reason = "can import by name at run time (__import__)"
+        elif isinstance(node, ast.Attribute) and node.attr == "import_module":
+            reason = "can import by name at run time (importlib)"
+        if reason is not None:
+            break
+    if reason is not None:
+        trip(entry, reason)
+
+emit_and_exit()
+PY
+}
+
+# Build (once) the whole index. Idempotent; call it before any FQCN lookup.
+pocketshell_test_areas_build_index() {
+  [[ "$POCKETSHELL_TA_INDEX_BUILT" -eq 1 ]] && return 0
+  POCKETSHELL_TA_INDEX_BUILT=1
+
+  local root="${POCKETSHELL_TA_REPO_ROOT:-.}"
+  local f d pkg fqcn area
+
+  # 1. production package -> area, by classifying a synthetic probe file in each
+  #    production directory. A directory whose probe classifies force-full (di/,
+  #    nav/, …) is intentionally absent: importing from it cannot narrow a run.
+  local -a prod_dirs=()
+  mapfile -t prod_dirs < <(
+    git -C "$root" ls-files 2>/dev/null |
+      grep -E '/src/main/(java|kotlin)/.*\.(kt|java)$' |
+      sed 's|/[^/]*$||' | LC_ALL=C sort -u
+  )
+  for d in "${prod_dirs[@]}"; do
+    [[ -z "$d" ]] && continue
+    pkg="$d"; pkg="${pkg#*/src/main/java/}"; pkg="${pkg#*/src/main/kotlin/}"
+    pocketshell_test_area_classify "$d/PocketshellAreaProbe.kt"
+    [[ "$POCKETSHELL_TEST_AREA_KIND" == "area" ]] || continue
+    POCKETSHELL_TA_PROD_PKG_AREA["${pkg//\//.}"]="$POCKETSHELL_TEST_AREA_NAME"
+    [[ "$d" == shared/* ]] && POCKETSHELL_TA_PROD_PKG_SHARED["${pkg//\//.}"]=1
+  done
+  POCKETSHELL_TA_INDEX_PROD_PKGS="${#POCKETSHELL_TA_PROD_PKG_AREA[@]}"
+
+  # 2. the host-CLI wire seam — BOTH ENDS of the contract (see the block comment
+  #    above for why one end is not enough). Each end is derived mechanically and
+  #    counted separately so its own floor can catch its own erosion.
+  local -a prod_files=()
+  mapfile -t prod_files < <(
+    git -C "$root" ls-files 2>/dev/null | grep -E '/src/main/(java|kotlin)/.*\.(kt|java)$'
+  )
+
+  # (a) PRODUCER end: files that invoke the CLI. Their packages are the seam,
+  #     and the file list is also the anchor for end (b).
+  local -a invoker_files=()
+  if [[ "${#prod_files[@]}" -gt 0 ]]; then
+    mapfile -t invoker_files < <(
+      printf '%s\n' "${prod_files[@]}" |
+        (cd "$root" && xargs -d '\n' -r grep -lE "$POCKETSHELL_TA_HOSTCLI_MARKER" 2>/dev/null) || true
+    )
+  fi
+  for f in "${invoker_files[@]}"; do
+    [[ -z "$f" ]] && continue
+    d="${f%/*}"
+    pkg="$d"; pkg="${pkg#*/src/main/java/}"; pkg="${pkg#*/src/main/kotlin/}"
+    _pocketshell_hostcli_mark "${pkg//\//.}" invoker
+  done
+
+  # (b) CONSUMER end: the production packages an INVOKING FILE imports. One hop.
+  if [[ "${#invoker_files[@]}" -gt 0 ]]; then
+    local impline imp
+    while IFS= read -r impline; do
+      imp="${impline#*:}"
+      imp="${imp#"${imp%%[![:space:]]*}"}"
+      imp="${imp#import }"
+      imp="${imp#"${imp%%[![:space:]]*}"}"
+      imp="${imp%%[!A-Za-z0-9_.]*}"
+      [[ "$imp" == *.* ]] || continue
+      _pocketshell_hostcli_mark "${imp%.*}" consumer
+    done < <(
+      printf '%s\n' "${invoker_files[@]}" |
+        (cd "$root" && xargs -d '\n' -r grep -hE '^[[:space:]]*import[[:space:]]+com\.pocketshell\.' 2>/dev/null) || true
+    )
+  fi
+
+  # (c) VOCABULARY end: packages naming a real subcommand, where "real" comes
+  #     from the producer's own registration sites, read through the producer's
+  #     own grammar (finding B9 — see the block comment above for why a grep for
+  #     ONE registration form was already under-reading the shipped `cli.py`).
+  local cli_src="$POCKETSHELL_TA_HOSTCLI_CLI_SOURCE"
+  [[ "$cli_src" == /* ]] || cli_src="$root/$cli_src"
+  POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_CLI_NONROOT=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SCANNED=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE=0
+  POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG=""
+  local -a subcommands=() vocab_lines=()
+  local vline saw_end=0
+  mapfile -t vocab_lines < <(_pocketshell_hostcli_read_cli_vocabulary "$cli_src")
+  for vline in "${vocab_lines[@]}"; do
+    case "$vline" in
+      END) saw_end=1 ;;
+      "SITES "*)        POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES="${vline#SITES }" ;;
+      "NONROOT "*)      POCKETSHELL_TA_INDEX_HOSTCLI_CLI_NONROOT="${vline#NONROOT }" ;;
+      "UNCLASSIFIED "*) POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED="${vline#UNCLASSIFIED }" ;;
+      "SCANNED "*)      POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SCANNED="${vline#SCANNED }" ;;
+      "NAME "*)       subcommands+=("${vline#NAME }") ;;
+      "UNREADABLE "*)
+        POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE=$((POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE + 1))
+        POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG="${POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG:+$POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG; }${vline#UNREADABLE }"
+        ;;
+    esac
+  done
+  if [[ "$saw_end" -ne 1 ]]; then
+    # No terminator => the reader never finished (no python3, a crash, a kill).
+    # Discard whatever partial output arrived rather than seeding the seam from
+    # half a vocabulary: a partial read is the exact failure this end exists to
+    # make loud.
+    subcommands=()
+    POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES=0
+    POCKETSHELL_TA_INDEX_HOSTCLI_CLI_NONROOT=0
+    POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED=0
+    POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SCANNED=0
+    POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE=$((POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE + 1))
+    POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG="${POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG:+$POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG; }the vocabulary reader did not finish for $cli_src (python3 missing, crashed, or killed)"
+  fi
+  # Counted BEFORE dedup so it can be compared with the site count: two sites
+  # registering the same name is a producer bug, not a reason to under-report.
+  POCKETSHELL_TA_INDEX_HOSTCLI_SUBCOMMANDS="${#subcommands[@]}"
+  if [[ "${#subcommands[@]}" -gt 0 && "${#prod_files[@]}" -gt 0 ]]; then
+    # Longest-first so `agent-log` cannot be shadowed by `agent`.
+    local vocab_re="" sc
+    while IFS= read -r sc; do
+      [[ -z "$sc" ]] && continue
+      vocab_re="${vocab_re:+$vocab_re|}$sc"
+    done < <(printf '%s\n' "${subcommands[@]}" | LC_ALL=C sort -u | awk '{print length"\t"$0}' | LC_ALL=C sort -rn | cut -f2-)
+    while IFS= read -r f; do
+      [[ -z "$f" ]] && continue
+      d="${f%/*}"
+      pkg="$d"; pkg="${pkg#*/src/main/java/}"; pkg="${pkg#*/src/main/kotlin/}"
+      _pocketshell_hostcli_mark "${pkg//\//.}" vocabulary
+    done < <(
+      printf '%s\n' "${prod_files[@]}" |
+        (cd "$root" && xargs -d '\n' -r grep -lE "pocketshell +($vocab_re)([^A-Za-z0-9_-]|\$)" 2>/dev/null) || true
+    )
+  fi
+  _pocketshell_hostcli_recount
+
+  # 3. test class -> area.
+  #
+  #    Classified per DIRECTORY (111 of them, not 1042 files) and only per FILE
+  #    where a file-name-shaped rule could actually change the answer — the :app
+  #    root `+([A-Za-z0-9_])Test.kt` row is the one such rule today, and
+  #    POCKETSHELL_TA_FILE_SHAPED_GLOB is computed from the manifest rather than
+  #    hardcoded so a future file-shaped row cannot be silently averaged away by
+  #    its directory's answer. Everything here is fork-free on purpose: a
+  #    command substitution per file is 3000 forks and dominates the runtime.
+  local -a test_files=()
+  mapfile -t test_files < <(
+    git -C "$root" ls-files 2>/dev/null |
+      grep -E '/src/(test|androidTest|integrationTest|testDebug|testRelease)/(java|kotlin)/.*(Test|Tests)\.(kt|java)$'
+  )
+  local -A dir_area=() dir_exact=()
+  local g rel pre srcset pa
+  for f in "${test_files[@]}"; do
+    [[ -z "$f" ]] && continue
+    d="${f%/*}"
+    if [[ -z "${dir_area[$d]+x}" ]]; then
+      pocketshell_test_area_classify "$d/PocketshellAreaProbeTest.kt"
+      if [[ "$POCKETSHELL_TEST_AREA_KIND" == "area" ]]; then
+        dir_area["$d"]="$POCKETSHELL_TEST_AREA_NAME"
+      else
+        dir_area["$d"]=""
+      fi
+      # If the directory probe itself was decided by a file-shaped rule, no
+      # directory-wide answer exists here; every file must be classified.
+      dir_exact["$d"]=0
+      for g in "${POCKETSHELL_TA_FILE_SHAPED_GLOB[@]:-}"; do
+        [[ -z "$g" ]] && continue
+        # shellcheck disable=SC2053
+        if [[ "$d/PocketshellAreaProbeTest.kt" == $g ]]; then dir_exact["$d"]=1; break; fi
+      done
+    fi
+    area="${dir_area[$d]}"
+    if [[ "${dir_exact[$d]}" -eq 1 ]]; then
+      area=""
+      pocketshell_test_area_classify "$f"
+      [[ "$POCKETSHELL_TEST_AREA_KIND" == "area" ]] && area="$POCKETSHELL_TEST_AREA_NAME"
+    else
+      for g in "${POCKETSHELL_TA_FILE_SHAPED_GLOB[@]:-}"; do
+        [[ -z "$g" ]] && continue
+        # shellcheck disable=SC2053
+        if [[ "$f" == $g ]]; then
+          area=""
+          pocketshell_test_area_classify "$f"
+          [[ "$POCKETSHELL_TEST_AREA_KIND" == "area" ]] && area="$POCKETSHELL_TEST_AREA_NAME"
+          break
+        fi
+      done
+    fi
+
+    # inline fqcn / module / source-set derivation (no forks)
+    case "$f" in
+      */src/androidTest/*)     rel="${f##*/src/androidTest/}";     srcset="androidTest" ;;
+      */src/integrationTest/*) rel="${f##*/src/integrationTest/}"; srcset="integrationTest" ;;
+      */src/testDebug/*)       rel="${f##*/src/testDebug/}";       srcset="testDebug" ;;
+      */src/testRelease/*)     rel="${f##*/src/testRelease/}";     srcset="testRelease" ;;
+      *)                       rel="${f##*/src/test/}";            srcset="test" ;;
+    esac
+    rel="${rel#java/}"; rel="${rel#kotlin/}"; rel="${rel%.kt}"; rel="${rel%.java}"
+    fqcn="${rel//\//.}"
+    [[ -z "$fqcn" ]] && continue
+    # `class` overrides beat everything, including the directory answer.
+    [[ -n "${POCKETSHELL_TA_CLASS_AREA[$fqcn]:-}" ]] && area="${POCKETSHELL_TA_CLASS_AREA[$fqcn]}"
+    pre="${f%%/src/*}"
+
+    POCKETSHELL_TA_CLASS_PATH["$fqcn"]="$f"
+    POCKETSHELL_TA_CLASS_RESOLVED["$fqcn"]="$area"
+    POCKETSHELL_TA_CLASS_DEPS["$fqcn"]="${area:+ $area }"
+    POCKETSHELL_TA_CLASS_MODULE["$fqcn"]=":${pre//\//:}"
+    POCKETSHELL_TA_CLASS_SOURCESET["$fqcn"]="$srcset"
+    pkg="${fqcn%.*}"
+    [[ -n "$area" ]] && POCKETSHELL_TA_PKG_TEST_AREA["$pkg"]="$area"
+
+    # SAME-PACKAGE production access needs no `import` line, so the import scan
+    # alone cannot see it. That is not a corner case: it is exactly why round 1
+    # missed `FolderListHostOutdatedTreeVersionDaemonDockerTest` (#1509) — the
+    # test sits in `com.pocketshell.app.projects` and reaches `TreeRemoteSource`
+    # in the same package, so no import line mentions the host-CLI wire seam.
+    if [[ -n "${POCKETSHELL_TA_PROD_PKG_AREA[$pkg]:-}" ]]; then
+      pa="${POCKETSHELL_TA_PROD_PKG_AREA[$pkg]}"
+      [[ "${POCKETSHELL_TA_CLASS_DEPS[$fqcn]}" == *" $pa "* ]] || \
+        POCKETSHELL_TA_CLASS_DEPS["$fqcn"]="${POCKETSHELL_TA_CLASS_DEPS[$fqcn]:- }$pa "
+    fi
+    if [[ -n "${POCKETSHELL_TA_PROD_PKG_HOSTCLI[$pkg]:-}" ]]; then
+      [[ "${POCKETSHELL_TA_CLASS_DEPS[$fqcn]}" == *" host-cli "* ]] || \
+        POCKETSHELL_TA_CLASS_DEPS["$fqcn"]="${POCKETSHELL_TA_CLASS_DEPS[$fqcn]:- }host-cli "
+    fi
+  done
+  POCKETSHELL_TA_INDEX_CLASSES="${#POCKETSHELL_TA_CLASS_PATH[@]}"
+
+  # 4. import-derived dependency sets. ONE grep over every test class file.
+  if [[ "${#test_files[@]}" -gt 0 ]]; then
+    local line imp p pa path_to_fqcn
+    local -A file_fqcn=()
+    for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+      file_fqcn["${POCKETSHELL_TA_CLASS_PATH[$fqcn]}"]="$fqcn"
+    done
+    # THE HOTTEST LOOP IN THE INDEX, and why it is awk.
+    #
+    # 5709 import lines x (peel the dotted name, look up the area, dedupe into
+    # the class's dep set) is ~1.0s of the index's ~1.9s in pure bash, and the
+    # guards rebuild the index in ~20 subprocesses per Unit variant. Folding the
+    # per-LINE work into one awk pass that emits one deduped line per FILE takes
+    # the bash side from 5709 iterations to <=1046 — same answer, and the guard's
+    # cost on the Unit job is what the round-2 review (rightly) pushed back on.
+    #
+    # awk gets the production-package map as its FIRST input and the grep stream
+    # as its second. It emits:  <path> TAB <import-count> TAB <area> <area> …
+    local awk_map
+    awk_map=""
+    for p in "${!POCKETSHELL_TA_PROD_PKG_AREA[@]}"; do
+      awk_map+="M	$p	${POCKETSHELL_TA_PROD_PKG_AREA[$p]}	${POCKETSHELL_TA_PROD_PKG_HOSTCLI[$p]:-}"$'\n'
+    done
+    local areas_for_file count_for_file
+    while IFS=$'\t' read -r f count_for_file areas_for_file; do
+      [[ -z "$f" ]] && continue
+      fqcn="${file_fqcn[$f]:-}"
+      [[ -z "$fqcn" ]] && continue
+      POCKETSHELL_TA_INDEX_IMPORT_LINES=$((POCKETSHELL_TA_INDEX_IMPORT_LINES + count_for_file))
+      for pa in $areas_for_file; do
+        [[ "${POCKETSHELL_TA_CLASS_DEPS[$fqcn]}" == *" $pa "* ]] || \
+          POCKETSHELL_TA_CLASS_DEPS["$fqcn"]="${POCKETSHELL_TA_CLASS_DEPS[$fqcn]}$pa "
+      done
+    done < <(
+      {
+        printf '%s' "$awk_map"
+        printf '%s\n' "${test_files[@]}" |
+          (cd "$root" && xargs -d '\n' -r grep -HE '^[[:space:]]*import[[:space:]]+com\.pocketshell\.' 2>/dev/null) || true
+      } | awk -F'\t' '
+        NR == FNR && $1 == "M" { area[$2] = $3; if ($4 != "") hc[$2] = 1; next }
+        {
+          line = $0
+          ci = index(line, ":")
+          if (ci == 0) next
+          f = substr(line, 1, ci - 1)
+          imp = substr(line, ci + 1)
+          sub(/^[ \t]*import[ \t]+/, "", imp)
+          gsub(/[^A-Za-z0-9_.].*$/, "", imp)
+          if (imp == "") next
+          n[f]++
+          if (!(imp in memo)) {
+            p = imp; a = ""; h = ""
+            while ((d = match(p, /\.[^.]*$/)) > 0) {
+              p = substr(p, 1, d - 1)
+              if (p in area) { a = area[p]; if (p in hc) h = "host-cli"; break }
+            }
+            memo[imp] = a; memoh[imp] = h
+          }
+          a = memo[imp]
+          if (a == "") next
+          key = f SUBSEP a
+          if (!(key in seen)) { seen[key] = 1; out[f] = out[f] " " a }
+          if (memoh[imp] != "") {
+            key = f SUBSEP "host-cli"
+            if (!(key in seen)) { seen[key] = 1; out[f] = out[f] " host-cli" }
+          }
+        }
+        END { for (f in n) printf "%s\t%d\t%s\n", f, n[f], (f in out ? out[f] : "") }
+      '
+    )
+  fi
+
+  # 5. per-test-package union deps, for a registered class that has no file of
+  #    its own (Kotlin allows several public classes per file, and
+  #    `PortForwardDuplicateKeyRenderTest` lives inside
+  #    `PortForwardDuplicateKeyCrashTest.kt`).
+  local dep
+  for fqcn in "${!POCKETSHELL_TA_CLASS_DEPS[@]}"; do
+    pkg="${fqcn%.*}"
+    for dep in ${POCKETSHELL_TA_CLASS_DEPS[$fqcn]}; do
+      [[ "${POCKETSHELL_TA_PKG_TEST_DEPS[$pkg]:-}" == *" $dep "* ]] || \
+        POCKETSHELL_TA_PKG_TEST_DEPS["$pkg"]="${POCKETSHELL_TA_PKG_TEST_DEPS[$pkg]:- }$dep "
+    done
+    # A class whose deps name an area other than its own is the evidence that
+    # the import scan actually ran; the guard asserts this count is large.
+    local own="${POCKETSHELL_TA_CLASS_RESOLVED[$fqcn]:-}"
+    for dep in ${POCKETSHELL_TA_CLASS_DEPS[$fqcn]}; do
+      if [[ "$dep" != "$own" ]]; then
+        POCKETSHELL_TA_INDEX_CROSS_AREA_CLASSES=$((POCKETSHELL_TA_INDEX_CROSS_AREA_CLASSES + 1))
+        break
+      fi
+    done
+    [[ "${POCKETSHELL_TA_CLASS_DEPS[$fqcn]}" == *" host-cli "* ]] && \
+      POCKETSHELL_TA_INDEX_HOSTCLI_CLASSES=$((POCKETSHELL_TA_INDEX_HOSTCLI_CLASSES + 1))
+  done
+  return 0
+}
+
+# FQCN -> area. THE resolver (see the index comment above). Order:
+#   1. the explicit `class` override table;
+#   2. the index built from tracked files;
+#   3. the class's test package, when the class shares a file with a sibling.
+# Fails (non-zero, empty output) when none of the three answers, so a genuinely
+# unmapped class is loud rather than silently unselectable.
+pocketshell_test_area_for_class() {
+  local fqcn="$1" pkg
+  fqcn="${fqcn%%#*}"   # `Class#method` registry entries
+  POCKETSHELL_TEST_AREA_FOR_CLASS=""
+  pocketshell_test_areas_build_index
+  # MEMOISED, not duplicated. The invariants ask this question ~20k times per
+  # run (19 areas x 1046 classes), so the answer is cached — but it is still
+  # computed by THIS function and nowhere else, which is the property finding B4
+  # (and its round-2 echo B7b) is about. A cache in front of one implementation
+  # is not a second implementation.
+  if [[ -n "${POCKETSHELL_TA_RESOLVE_CACHE[$fqcn]+x}" ]]; then
+    POCKETSHELL_TEST_AREA_FOR_CLASS="${POCKETSHELL_TA_RESOLVE_CACHE[$fqcn]}"
+    [[ -z "$POCKETSHELL_TEST_AREA_FOR_CLASS" ]] && return 1
+    printf '%s\n' "$POCKETSHELL_TEST_AREA_FOR_CLASS"
+    return 0
+  fi
+  pkg="${fqcn%.*}"
+  POCKETSHELL_TEST_AREA_FOR_CLASS="${POCKETSHELL_TA_CLASS_AREA[$fqcn]:-}"
+  [[ -z "$POCKETSHELL_TEST_AREA_FOR_CLASS" ]] && POCKETSHELL_TEST_AREA_FOR_CLASS="${POCKETSHELL_TA_CLASS_RESOLVED[$fqcn]:-}"
+  [[ -z "$POCKETSHELL_TEST_AREA_FOR_CLASS" ]] && POCKETSHELL_TEST_AREA_FOR_CLASS="${POCKETSHELL_TA_PKG_TEST_AREA[$pkg]:-}"
+  POCKETSHELL_TA_RESOLVE_CACHE["$fqcn"]="$POCKETSHELL_TEST_AREA_FOR_CLASS"
+  [[ -z "$POCKETSHELL_TEST_AREA_FOR_CLASS" ]] && return 1
+  printf '%s\n' "$POCKETSHELL_TEST_AREA_FOR_CLASS"
+  return 0
+}
+
+# FQCN -> " area area … ": every area whose PRODUCTION code this test class
+# compiles against, plus its own area, plus `host-cli` when it imports a package
+# on the CLI wire seam. Falls back to the union over its test package for a
+# class that shares a file with a sibling, and to the class's own area when even
+# that is unknown.
+pocketshell_test_area_deps_for_class() {
+  local fqcn="$1" pkg
+  fqcn="${fqcn%%#*}"
+  pocketshell_test_areas_build_index
+  if [[ -n "${POCKETSHELL_TA_DEPS_CACHE[$fqcn]+x}" ]]; then
+    POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS="${POCKETSHELL_TA_DEPS_CACHE[$fqcn]}"
+    printf '%s\n' "$POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS"
+    return 0
+  fi
+  pkg="${fqcn%.*}"
+  POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS="${POCKETSHELL_TA_CLASS_DEPS[$fqcn]:-}"
+  if [[ -z "$POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS" ]]; then
+    POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS="${POCKETSHELL_TA_PKG_TEST_DEPS[$pkg]:-}"
+  fi
+  if [[ -z "$POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS" ]]; then
+    pocketshell_test_area_for_class "$fqcn" >/dev/null
+    POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS="${POCKETSHELL_TEST_AREA_FOR_CLASS:+ $POCKETSHELL_TEST_AREA_FOR_CLASS }"
+  fi
+  POCKETSHELL_TA_DEPS_CACHE["$fqcn"]="$POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS"
+  printf '%s\n' "$POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS"
+  return 0
+}
+
+# Expand a set of CHANGED areas over the `couple` edges to a fixpoint, then
+# union in every `always`-tier area.
+#
+# ORDER MATTERS, in both directions:
+#
+#   * The always-tier union happens LAST and unconditionally, which is what
+#     makes "select nothing" unreachable — any selection, from any input,
+#     contains at least the always tier.
+#   * The coupling closure runs over the SEED areas only, NOT over the always
+#     tier. A `couple` edge means "a CHANGE here has broken there"; an area
+#     that is present merely because it is always-on did not change, so it has
+#     nothing to fan out. Seeding the closure with the always tier instead
+#     dragged tmux-session and composer-voice (the two largest suites) into
+#     every run via the conversation-agents coupling and silently erased most
+#     of the saving while proving nothing extra.
+#
+# Reads: the space-separated seed areas in $1. Prints the sorted result.
+pocketshell_test_areas_expand() {
+  local -A seen=()
+  local a
+  for a in $(pocketshell_test_areas_expand_seeds "$1"); do seen["$a"]=1; done
+  for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+    [[ "${POCKETSHELL_TA_AREA_TIER[$a]}" == "always" ]] && seen["$a"]=1
+  done
+  printf '%s\n' "${!seen[@]}" | LC_ALL=C sort
+}
+
+# The CHANGED half of the same expansion: the seeds plus their `couple` closure,
+# WITHOUT the always tier unioned in. Callers need this separately because the
+# per-class import-dependency test must ask "did an area this class depends on
+# actually CHANGE?" — an always-tier area sitting in the selection merely as the
+# floor did not change, and matching against it would drag every class that
+# imports connection-core into every push.
+pocketshell_test_areas_expand_seeds() {
+  local -A seen=()
+  local -a queue=()
+  local a to
+  for a in $1; do
+    [[ -z "$a" ]] && continue
+    if [[ -z "${seen[$a]:-}" ]]; then seen["$a"]=1; queue+=("$a"); fi
+  done
+  local idx=0
+  while (( idx < ${#queue[@]} )); do
+    a="${queue[$idx]}"; idx=$((idx + 1))
+    [[ -z "${POCKETSHELL_TA_COUPLE[$a]:-}" ]] && continue
+    local IFS=','
+    for to in ${POCKETSHELL_TA_COUPLE[$a]}; do
+      [[ -z "$to" ]] && continue
+      if [[ -z "${seen[$to]:-}" ]]; then seen["$to"]=1; queue+=("$to"); fi
+    done
+  done
+  [[ "${#seen[@]}" -eq 0 ]] && return 0
+  printf '%s\n' "${!seen[@]}" | LC_ALL=C sort
+}

--- a/scripts/select-test-areas-selftest.sh
+++ b/scripts/select-test-areas-selftest.sh
@@ -1,0 +1,1058 @@
+#!/usr/bin/env bash
+# Self-test for scripts/select-test-areas.sh and scripts/lib/test-areas.sh (#2063).
+#
+# WHAT THIS PROVES, AND WHY EACH CASE EXISTS
+#
+# The selection engine's one safety property is that its failure mode points at
+# running MORE, never less. A guard whose negative case was never exercised is
+# decoration (process.md, G6), so every case below MUTATES the input — deletes a
+# rule, empties the manifest, invents an unmapped path — and asserts the answer
+# moves the safe way. Nothing here asserts "it still says full" over an input
+# that was already full for another reason.
+#
+# The sandbox is a synthetic mini-repo with its own manifest, so the cases stay
+# readable and cannot be perturbed by real-tree churn. The real tree is covered
+# by --verify-manifest / --coverage-invariant, which this script also runs last.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELECT="$SCRIPT_DIR/select-test-areas.sh"
+
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf 'ok   %s\n' "$*"; }
+bad()  { FAIL=$((FAIL + 1)); printf 'FAIL %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Synthetic repo
+# ---------------------------------------------------------------------------
+mkdir -p \
+  "$SANDBOX/scripts/lib" \
+  "$SANDBOX/app/src/main/java/com/pocketshell/app/alpha" \
+  "$SANDBOX/app/src/main/java/com/pocketshell/app/beta" \
+  "$SANDBOX/app/src/main/java/com/pocketshell/app/di" \
+  "$SANDBOX/app/src/test/java/com/pocketshell/app/alpha" \
+  "$SANDBOX/app/src/test/java/com/pocketshell/app/beta" \
+  "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof" \
+  "$SANDBOX/docs"
+
+cp "$SCRIPT_DIR/lib/test-areas.sh" "$SANDBOX/scripts/lib/test-areas.sh"
+cp "$SELECT" "$SANDBOX/scripts/select-test-areas.sh"
+
+cat > "$SANDBOX/app/src/main/java/com/pocketshell/app/alpha/Alpha.kt" <<'KT'
+package com.pocketshell.app.alpha
+KT
+cat > "$SANDBOX/app/src/main/java/com/pocketshell/app/beta/Beta.kt" <<'KT'
+package com.pocketshell.app.beta
+KT
+cat > "$SANDBOX/app/src/main/java/com/pocketshell/app/di/Module.kt" <<'KT'
+package com.pocketshell.app.di
+KT
+cat > "$SANDBOX/app/src/test/java/com/pocketshell/app/alpha/AlphaTest.kt" <<'KT'
+package com.pocketshell.app.alpha
+class AlphaTest
+KT
+cat > "$SANDBOX/app/src/test/java/com/pocketshell/app/beta/BetaTest.kt" <<'KT'
+package com.pocketshell.app.beta
+class BetaTest
+KT
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/AlwaysE2eTest.kt" <<'KT'
+package com.pocketshell.app.proof
+class AlwaysE2eTest
+KT
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/proof/SharedFixture.kt" <<'KT'
+package com.pocketshell.app.proof
+object SharedFixture
+KT
+echo "# docs" > "$SANDBOX/docs/notes.md"
+
+cat > "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+#!/usr/bin/env bash
+FQCN_PREFIX="com.pocketshell.app.proof"
+JOURNEY_CLASSES=(
+  "$FQCN_PREFIX.AlwaysE2eTest"
+  "com.pocketshell.app.beta.BetaTest"
+)
+SH
+
+BASE_MANIFEST="$SANDBOX/scripts/test-areas.txt"
+cat > "$BASE_MANIFEST" <<'MF'
+area   pcore   always   always-on core area
+area   alpha   changed  alpha area
+area   beta    changed  beta area
+
+full   scripts/*                                          harnesses
+full   app/src/main/java/com/pocketshell/app/di/*          DI graph
+
+noop   docs/*                                             prose
+noop   *.md                                               prose
+
+src    app/src/main/java/com/pocketshell/app/alpha/*       alpha   ui
+src    app/src/main/java/com/pocketshell/app/beta/*        beta    full
+
+test   app/src/*/java/com/pocketshell/app/proof/*          pcore   full
+test   app/src/*/java/com/pocketshell/app/alpha/*          alpha   full
+test   app/src/*/java/com/pocketshell/app/beta/*           beta    full
+
+couple alpha  beta
+MF
+
+git -C "$SANDBOX" init -q 2>/dev/null
+git -C "$SANDBOX" add -A >/dev/null 2>&1
+git -C "$SANDBOX" -c user.email=t@t -c user.name=t commit -qm init >/dev/null 2>&1
+
+run_select() {
+  # $1 = manifest, rest = changed paths
+  local manifest="$1"; shift
+  printf '%s\n' "$@" |
+    POCKETSHELL_TEST_AREAS_REPO_ROOT="$SANDBOX" \
+    POCKETSHELL_TEST_AREAS_MANIFEST="$manifest" \
+    POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$SANDBOX/scripts/ci-journey-suite.sh" \
+    bash "$SANDBOX/scripts/select-test-areas.sh" --changed-stdin --print-plan-only 2>&1
+}
+
+field() { sed -n "s/^$2=//p" <<<"$1" | head -1; }
+
+# ===========================================================================
+# CASE 1 (baseline, so later mutations are meaningful): a mapped path scopes.
+# ===========================================================================
+out="$(run_select "$BASE_MANIFEST" "app/src/main/java/com/pocketshell/app/alpha/Alpha.kt")"
+if [[ "$(field "$out" MODE)" == "scoped" ]] &&
+   [[ "$(field "$out" AREAS)" == "alpha beta pcore" ]]; then
+  ok "1 mapped alpha path scopes to alpha + its couple + the always tier"
+else
+  bad "1 expected scoped 'alpha beta pcore', got MODE=$(field "$out" MODE) AREAS=$(field "$out" AREAS)"
+fi
+
+# ===========================================================================
+# CASE 2 — THE fail-safe: an UNMAPPED path forces full AND is reported.
+#
+# Mutation: a path no rule mentions. The bug this catches is the one the issue
+# names explicitly — "no area matched, run nothing".
+# ===========================================================================
+out="$(run_select "$BASE_MANIFEST" "app/src/main/java/com/pocketshell/app/brandnew/New.kt")"
+if [[ "$(field "$out" MODE)" == "full" ]] && [[ "$(field "$out" UNMAPPED_COUNT)" == "1" ]]; then
+  ok "2 unmapped path => MODE=full and UNMAPPED_COUNT=1 (loud, not silent)"
+else
+  bad "2 unmapped path did not fail safe: MODE=$(field "$out" MODE) UNMAPPED_COUNT=$(field "$out" UNMAPPED_COUNT)"
+fi
+
+# ===========================================================================
+# CASE 3 — deleting the rule that made a path safe must UN-scope it.
+#
+# This is the selectivity check: case 1 must depend on the alpha src rule.
+# ===========================================================================
+mut="$SANDBOX/mut-no-alpha.txt"
+grep -v 'app/pocketshell/app/alpha' "$BASE_MANIFEST" |
+  grep -v 'src    app/src/main/java/com/pocketshell/app/alpha' > "$mut"
+out="$(run_select "$mut" "app/src/main/java/com/pocketshell/app/alpha/Alpha.kt")"
+if [[ "$(field "$out" MODE)" == "full" ]]; then
+  ok "3 deleting the alpha src rule turns the same path into a full run"
+else
+  bad "3 alpha path still scoped with its rule deleted: MODE=$(field "$out" MODE)"
+fi
+
+# ===========================================================================
+# CASE 4 — an EMPTY manifest forces full. A load failure must never read as
+# "no rules, therefore nothing to run".
+# ===========================================================================
+: > "$SANDBOX/mut-empty.txt"
+out="$(run_select "$SANDBOX/mut-empty.txt" "app/src/main/java/com/pocketshell/app/alpha/Alpha.kt")"
+if [[ "$(field "$out" MODE)" == "full" ]]; then
+  ok "4 empty manifest => MODE=full"
+else
+  bad "4 empty manifest did not force full: MODE=$(field "$out" MODE)"
+fi
+
+# ===========================================================================
+# CASE 5 — a MISSING manifest forces full.
+# ===========================================================================
+out="$(run_select "$SANDBOX/does-not-exist.txt" "app/src/main/java/com/pocketshell/app/alpha/Alpha.kt")"
+if [[ "$(field "$out" MODE)" == "full" ]]; then
+  ok "5 missing manifest => MODE=full"
+else
+  bad "5 missing manifest did not force full: MODE=$(field "$out" MODE)"
+fi
+
+# ===========================================================================
+# CASE 6 — an EMPTY diff forces full. "Nothing changed" is indistinguishable
+# from "the diff could not be computed", and only one of those is safe to skip.
+# ===========================================================================
+out="$(printf '' |
+  POCKETSHELL_TEST_AREAS_REPO_ROOT="$SANDBOX" \
+  POCKETSHELL_TEST_AREAS_MANIFEST="$BASE_MANIFEST" \
+  POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$SANDBOX/scripts/ci-journey-suite.sh" \
+  bash "$SANDBOX/scripts/select-test-areas.sh" --changed-stdin --print-plan-only 2>&1)"
+if [[ "$(field "$out" MODE)" == "full" ]]; then
+  ok "6 empty changed-path set => MODE=full"
+else
+  bad "6 empty diff did not force full: MODE=$(field "$out" MODE)"
+fi
+
+# ===========================================================================
+# CASE 7 — the always tier is a FLOOR: a noop-only diff is scoped, non-empty,
+# and contains the always-tier area and its journeys.
+# ===========================================================================
+out="$(run_select "$BASE_MANIFEST" "docs/notes.md")"
+if [[ "$(field "$out" MODE)" == "scoped" ]] &&
+   [[ "$(field "$out" AREAS)" == "pcore" ]] &&
+   [[ "$(field "$out" JOURNEY_CLASSES)" == "com.pocketshell.app.proof.AlwaysE2eTest" ]]; then
+  ok "7 docs-only diff still runs the always tier (floor is non-empty)"
+else
+  bad "7 docs-only floor wrong: MODE=$(field "$out" MODE) AREAS=$(field "$out" AREAS) J=$(field "$out" JOURNEY_CLASSES)"
+fi
+
+# ===========================================================================
+# CASE 8 — removing the `always` tier from the floor area must SHRINK the
+# docs-only selection to nothing-but-itself. Proves case 7's floor is produced
+# by the tier, not by an accident of the couple graph.
+# ===========================================================================
+sed 's/^area   pcore   always/area   pcore   changed/' "$BASE_MANIFEST" > "$SANDBOX/mut-no-always.txt"
+out="$(run_select "$SANDBOX/mut-no-always.txt" "docs/notes.md")"
+if [[ "$(field "$out" AREAS)" == "" ]]; then
+  ok "8 demoting the always tier empties the docs-only selection (the floor is the tier)"
+else
+  bad "8 expected an empty selection after demoting always, got AREAS=$(field "$out" AREAS)"
+fi
+
+# ===========================================================================
+# CASE 9 — force-full rows win over area rows, and a force-full path selects
+# EVERY area (not just its own).
+# ===========================================================================
+out="$(run_select "$BASE_MANIFEST" "app/src/main/java/com/pocketshell/app/di/Module.kt")"
+if [[ "$(field "$out" MODE)" == "full" ]] &&
+   [[ "$(field "$out" AREAS)" == "alpha beta pcore" ]] &&
+   [[ "$(field "$out" UNIT_MODE)" == "full" ]] &&
+   [[ "$(field "$out" UNIT_GRADLE_TASKS)" == "test" ]]; then
+  ok "9 a DI change forces full: all areas, whole-graph 'test' task, no --tests filter"
+else
+  bad "9 DI force-full wrong: MODE=$(field "$out" MODE) AREAS=$(field "$out" AREAS) UNIT=$(field "$out" UNIT_MODE)/$(field "$out" UNIT_GRADLE_TASKS)"
+fi
+
+# ===========================================================================
+# CASE 10 — test INFRASTRUCTURE (a non-*Test file inside a test source set)
+# forces full, while a sibling *Test.kt in the same directory only scopes.
+# Both directions, because either alone would pass with the rule inverted.
+# ===========================================================================
+out_fixture="$(run_select "$BASE_MANIFEST" "app/src/androidTest/java/com/pocketshell/app/proof/SharedFixture.kt")"
+out_test="$(run_select "$BASE_MANIFEST" "app/src/androidTest/java/com/pocketshell/app/proof/AlwaysE2eTest.kt")"
+if [[ "$(field "$out_fixture" MODE)" == "full" ]] && [[ "$(field "$out_test" MODE)" == "scoped" ]]; then
+  ok "10 a shared fixture forces full; its sibling *Test.kt in the same dir does not"
+else
+  bad "10 infra rule wrong: fixture=$(field "$out_fixture" MODE) test=$(field "$out_test" MODE)"
+fi
+
+# ===========================================================================
+# CASE 11 — a `class` override beats the package glob.
+# ===========================================================================
+cat "$BASE_MANIFEST" > "$SANDBOX/mut-override.txt"
+echo "class  com.pocketshell.app.beta.BetaTest  pcore" >> "$SANDBOX/mut-override.txt"
+before="$(run_select "$BASE_MANIFEST" "docs/notes.md")"
+after="$(run_select "$SANDBOX/mut-override.txt" "docs/notes.md")"
+if [[ "$(field "$before" JOURNEY_CLASSES)" != *"com.pocketshell.app.beta.BetaTest"* ]] &&
+   [[ "$(field "$after" JOURNEY_CLASSES)" == *"com.pocketshell.app.beta.BetaTest"* ]]; then
+  ok "11 a class override moves BetaTest into the always tier (it now runs on a docs-only diff)"
+else
+  bad "11 class override had no effect: before=$(field "$before" JOURNEY_CLASSES) after=$(field "$after" JOURNEY_CLASSES)"
+fi
+
+# ===========================================================================
+# CASE 12 — an undeclared area name in a rule is a LOAD error, which forces
+# full. A typo must not silently create a ghost area whose tests nothing picks.
+# ===========================================================================
+sed 's/^src    app\/src\/main\/java\/com\/pocketshell\/app\/alpha\/\*       alpha   ui/src    app\/src\/main\/java\/com\/pocketshell\/app\/alpha\/*       alhpa   ui/' \
+  "$BASE_MANIFEST" > "$SANDBOX/mut-typo.txt"
+out="$(run_select "$SANDBOX/mut-typo.txt" "app/src/main/java/com/pocketshell/app/alpha/Alpha.kt")"
+if [[ "$(field "$out" MODE)" == "full" ]]; then
+  ok "12 a typo'd area name fails the load and forces full"
+else
+  bad "12 typo'd area name did not force full: MODE=$(field "$out" MODE)"
+fi
+
+# ===========================================================================
+# CASE 13 — the real tree's own guards. These are the ones wired into CI; the
+# synthetic cases above only prove the mechanism.
+# ===========================================================================
+if bash "$SELECT" --verify-manifest >/dev/null 2>&1; then
+  ok "13a --verify-manifest passes on the real tree"
+else
+  bad "13a --verify-manifest FAILED on the real tree (run it for detail)"
+fi
+# 13b is deliberately the I5 FLOOR only, not the whole invariant set: the full
+# --coverage-invariant already runs as its own @Test in SmartTestSelectionScriptTest,
+# and re-running all ten here cost ~7s of duplicated work per Unit variant for a
+# verdict CI already has. What 13b must carry is the GREEN half of case 15's
+# mutation, which is I5.
+if bash "$SELECT" --coverage-invariant --only I5 >/dev/null 2>&1; then
+  ok "13b the I5 always-tier floor passes on the real tree (the green half of case 15)"
+else
+  bad "13b the I5 floor FAILED on the real tree (run --coverage-invariant for detail)"
+fi
+
+# ===========================================================================
+# CASE 14 — the real --verify-manifest must be capable of RED. Introduce an
+# unmapped path into a copy of the real manifest and assert the guard reddens.
+# Without this, 13a is just "a guard that says OK".
+# ===========================================================================
+real_mut="$SANDBOX/real-manifest-mutant.txt"
+grep -v '^src    shared/core-ssh/\*' "$SCRIPT_DIR/test-areas.txt" |
+  grep -v '^test   shared/core-ssh/\*' > "$real_mut"
+if POCKETSHELL_TEST_AREAS_MANIFEST="$real_mut" bash "$SELECT" --verify-manifest >/dev/null 2>&1; then
+  bad "14 removing the core-ssh rules did NOT redden --verify-manifest — the guard is decorative"
+else
+  ok "14 removing the core-ssh rules reddens --verify-manifest (guard is live)"
+fi
+
+# ===========================================================================
+# CASE 15 — the real --coverage-invariant must be capable of RED. Demote every
+# always-tier area and assert I5's floor check fires.
+# ===========================================================================
+cov_mut="$SANDBOX/real-coverage-mutant.txt"
+sed 's/^\(area   [a-z-]*  *\)always/\1changed/' "$SCRIPT_DIR/test-areas.txt" > "$cov_mut"
+if POCKETSHELL_TEST_AREAS_MANIFEST="$cov_mut" bash "$SELECT" --coverage-invariant --only I5 >/dev/null 2>&1; then
+  bad "15 demoting every always-tier area did NOT redden --coverage-invariant"
+else
+  ok "15 demoting every always-tier area reddens --coverage-invariant (I5 floor is live)"
+fi
+
+# ===========================================================================
+# CASES 16-20 — the round-1 review findings, each with the mutation that must
+# redden the check that now covers it.
+#
+# The reviewer found all four blockers by building its own oracle, which is the
+# definition of a gap in these self-tests. Every case below names the mutation,
+# applies it to a COPY inside this sandbox (never the tree), and asserts the
+# specific check reddens.
+# ===========================================================================
+
+# A private copy of the scripts, so a code mutation can never touch the tree.
+MUTDIR="$SANDBOX/mut-scripts"
+mkdir -p "$MUTDIR/lib"
+cp "$SCRIPT_DIR/select-test-areas.sh" "$MUTDIR/select-test-areas.sh"
+cp "$SCRIPT_DIR/lib/test-areas.sh" "$MUTDIR/lib/test-areas.sh"
+cp "$SCRIPT_DIR/test-areas.txt" "$MUTDIR/test-areas.txt"
+cp "$SCRIPT_DIR/ci-journey-suite.sh" "$MUTDIR/ci-journey-suite.sh"
+
+run_mut() {  # run the MUTATED copy against the REAL tree
+  POCKETSHELL_TEST_AREAS_REPO_ROOT="$SCRIPT_DIR/.." \
+  POCKETSHELL_TEST_AREAS_MANIFEST="${MUT_MANIFEST:-$MUTDIR/test-areas.txt}" \
+  POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$MUTDIR/ci-journey-suite.sh" \
+  bash "$MUTDIR/select-test-areas.sh" "$@" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# CASE 16 (B1 + B6 + B7a) — the host-CLI lockstep coupling is load-bearing, at
+# BOTH ends of the wire, and cannot be quietly narrowed.
+#
+# Round 1: `tools/pocketshell/**` selected `host-cli` (0 Kotlin classes) plus
+# the always tier and NOTHING else, so a host-CLI change ran zero of the
+# journeys built to catch host-CLI/client mismatch — the #847 / v0.4.10 class.
+#
+# Round 2 fixed that with an INVOKER-only seam, which structurally could not
+# reach `shared/*` (no shared module shells out). So `:shared:core-usage:test` —
+# the STRICT, fail-loud reader of the NDJSON `tools/pocketshell/.../usage.py`
+# emits — still did not run on a host-CLI change, with all 8 checks and all 10
+# invariants green. 16a-2 is that exact symptom as an assertion; 16e/16f are its
+# mutations.
+#
+# Round 2 also floored the seam at `>= 1`, so the reviewer cut it from 15
+# packages / 569 classes to 9 / 210 without reddening anything. 16d replays that
+# exact erosion.
+# ---------------------------------------------------------------------------
+hostcli_plan="$(printf 'tools/pocketshell/src/pocketshell/tree.py\n' |
+  bash "$SELECT" --changed-stdin --print-plan-only 2>/dev/null)"
+before_hostcli="$(sed -n 's/^JOURNEY_CLASSES=//p' <<<"$hostcli_plan")"
+if [[ "$before_hostcli" == *"FolderListHostOutdatedTreeVersionDaemonDockerTest"* ]] &&
+   [[ "$before_hostcli" == *"FolderListOldCliHydrateDockerTest"* ]]; then
+  ok "16a a tools/pocketshell change runs the old-host-CLI journeys (#1509 G10, #847 class)"
+else
+  bad "16a a host-CLI change does NOT run the old-CLI journeys: $before_hostcli"
+fi
+hostcli_tasks="$(sed -n 's/^UNIT_SHARED_TASKS=//p' <<<"$hostcli_plan")"
+if [[ " $hostcli_tasks " == *" :shared:core-usage:test "* ]] &&
+   [[ " $hostcli_tasks " == *" :shared:core-storage:test "* ]] &&
+   [[ " $hostcli_tasks " == *" :shared:ui-kit:test "* ]]; then
+  ok "16a-2 a tools/pocketshell change runs the SHARED-module readers of the wire (core-usage / core-storage / ui-kit) — the round-2 B6 hole"
+else
+  bad "16a-2 a host-CLI change does NOT run the shared-module wire readers: $hostcli_tasks"
+fi
+out="$(POCKETSHELL_TA_HOSTCLI_MARKER='ZZ_NO_SUCH_HOST_CLI_MARKER_ZZ' bash "$SELECT" --verify-manifest 2>&1)"
+if grep -q 'wire-seam PRODUCER packages = 0' <<<"$out" &&
+   grep -q 'wire-seam CONSUMER packages = 0' <<<"$out"; then
+  ok "16b breaking the invoke marker reddens the PRODUCER and CONSUMER floors (the consumer end is anchored on the invoker file list)"
+else
+  bad "16b a dead invoke marker did NOT redden the per-end floors:\n$out"
+fi
+out="$(POCKETSHELL_TA_HOSTCLI_MARKER='ZZ_NO_SUCH_HOST_CLI_MARKER_ZZ' \
+       POCKETSHELL_TA_HOSTCLI_CLI_SOURCE='tools/pocketshell/no_such_cli.py' \
+       bash "$SELECT" --coverage-invariant --only I9 2>&1)"
+if grep -q 'FAIL I9' <<<"$out" && grep -q 'FolderListHostOutdatedTreeVersionDaemonDockerTest' <<<"$out"; then
+  ok "16c killing every end of the seam reddens the #1509 lockstep pin by name"
+else
+  bad "16c the #1509 pin survived a completely dead wire seam:\n$(grep -E '^(OK|FAIL) I9' <<<"$out")"
+fi
+# 16d — the ROUND-2 REVIEWER'S EXACT EROSION. Dropping the two string-literal
+# alternatives from the invoke marker took the seam from 15 packages / 569
+# classes to 9 / 210 and NOTHING noticed, because both host-CLI floors were
+# `>= 1`. It must be loud now.
+out="$(POCKETSHELL_TA_HOSTCLI_MARKER='PocketshellCommand' bash "$SELECT" --verify-manifest 2>&1)"
+if grep -q 'the import-dependency index looks broken' <<<"$out" &&
+   grep -q 'wire-seam PRODUCER packages = 9' <<<"$out"; then
+  ok "16d the reviewer's 15->9 seam erosion now reddens --verify-manifest (round-2 B7a: it was silently green)"
+else
+  bad "16d the 15->9 seam erosion is STILL green — the floors are not substantive:\n$out"
+fi
+
+# 16e / 16f — CODE mutations, on their own private copies so case 17's mutation
+# of MUTDIR cannot interact with them.
+mut_copy() {  # $1 = dir name -> echoes a runner-ready dir
+  local d="$SANDBOX/$1"
+  mkdir -p "$d/lib"
+  cp "$SCRIPT_DIR/select-test-areas.sh" "$d/select-test-areas.sh"
+  cp "$SCRIPT_DIR/lib/test-areas.sh"    "$d/lib/test-areas.sh"
+  cp "$SCRIPT_DIR/test-areas.txt"       "$d/test-areas.txt"
+  cp "$SCRIPT_DIR/ci-journey-suite.sh"  "$d/ci-journey-suite.sh"
+  printf '%s\n' "$d"
+}
+run_copy() {  # $1 = dir, rest = args
+  local d="$1"; shift
+  POCKETSHELL_TEST_AREAS_REPO_ROOT="$SCRIPT_DIR/.." \
+  POCKETSHELL_TEST_AREAS_MANIFEST="$d/test-areas.txt" \
+  POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$d/ci-journey-suite.sh" \
+  bash "$d/select-test-areas.sh" "$@" 2>&1
+}
+
+# 16e (B6) — delete the CONSUMER end of the seam, i.e. reproduce round 2's
+# invoker-only design exactly. The shared-reach floor is the check that exists
+# for this and it must be the one that fires.
+B6DIR="$(mut_copy mut-b6-consumer)"
+sed -i 's|^      _pocketshell_hostcli_mark "${imp%.\*}" consumer$|      : # MUTANT 16e: consumer end deleted|' \
+  "$B6DIR/lib/test-areas.sh"
+if grep -q 'MUTANT 16e: consumer end deleted' "$B6DIR/lib/test-areas.sh"; then
+  : # mutant confirmed live before its verdict is read (#1641)
+else
+  bad "16e MUTATION DID NOT APPLY — the consumer-end call is still present in the copy, so 16e's verdict would be meaningless"
+fi
+out="$(run_copy "$B6DIR" --verify-manifest)"
+if grep -q 'wire-seam CONSUMER packages = 0' <<<"$out" &&
+   grep -q 'wire-seam packages under shared/ = 3' <<<"$out"; then
+  ok "16e deleting the CONSUMER end reddens the shared-reach floor — the round-2 seam (invoker-only, 0 shared packages) can no longer be green"
+else
+  bad "16e the round-2 invoker-only seam is still green:\n$out"
+fi
+out="$(printf 'tools/pocketshell/src/pocketshell/usage.py\n' |
+  POCKETSHELL_TEST_AREAS_REPO_ROOT="$SCRIPT_DIR/.." \
+  POCKETSHELL_TEST_AREAS_MANIFEST="$B6DIR/test-areas.txt" \
+  POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$B6DIR/ci-journey-suite.sh" \
+  bash "$B6DIR/select-test-areas.sh" --changed-stdin --print-plan-only 2>&1 |
+  sed -n 's/^UNIT_SHARED_TASKS=//p')"
+# Assert on the modules the CONSUMER end is the SOLE route to. core-usage,
+# core-storage and ui-kit survive 16e because the vocabulary end also names
+# them — the two ends deliberately overlap on the holes the reviewer found, and
+# a check that ignored that would be measuring nothing.
+if [[ " $out " != *" :shared:core-portfwd:test "* ]] &&
+   [[ " $out " != *" :shared:core-assistant:test "* ]]; then
+  ok "16e-2 with the consumer end deleted, a host-CLI change stops running the reply-side modules only that end reaches (:shared:core-portfwd:test, :shared:core-assistant:test) — the mutation moves the real plan"
+else
+  bad "16e-2 the consumer-end mutation changed nothing about the emitted plan, so 16e proves nothing: $out"
+fi
+
+# 16f (B6, selectivity) — drop exactly ONE package from the seam: the shared
+# module whose parser IS the wire contract. Every floor stays above its bound
+# (this is the round-2 shape: green totals, one real hole), so the UNIT pin has
+# to be what catches it — including the "the plan actually runs that module"
+# half, which is the literal symptom the reviewer measured.
+B6BDIR="$(mut_copy mut-b6-onepkg)"
+python3 - "$B6BDIR/lib/test-areas.sh" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+anchor = '  local p="$1" end="$2"\n  [[ -n "${POCKETSHELL_TA_PROD_PKG_AREA[$p]:-}" ]] || return 0'
+assert s.count(anchor) == 1, "16f anchor not unique"
+s = s.replace(anchor, anchor + '\n  [[ "$p" == com.pocketshell.core.usage ]] && return 0  # MUTANT 16f')
+open(p, "w").write(s)
+PY
+if grep -q 'MUTANT 16f' "$B6BDIR/lib/test-areas.sh"; then
+  : # live
+else
+  bad "16f MUTATION DID NOT APPLY"
+fi
+out="$(run_copy "$B6BDIR" --verify-manifest)"
+if grep -q '^PASS: manifest verified' <<<"$out"; then
+  ok "16f-a dropping one seam package leaves every --verify-manifest floor GREEN (this is exactly how the round-2 hole hid)"
+else
+  bad "16f-a the one-package mutation reddened a floor, so 16f-b would not prove the pin is load-bearing:\n$out"
+fi
+out="$(run_copy "$B6BDIR" --coverage-invariant)"
+if grep -q 'FAIL I9' <<<"$out" &&
+   grep -q 'does NOT select unit class com.pocketshell.core.usage.PocketshellUsageJsonParserTest' <<<"$out" &&
+   [[ "$(grep -c '^FAIL I' <<<"$out")" -eq 1 ]]; then
+  ok "16f-b ...and the I9 UNIT pin reddens by name, and ONLY I9 reddens (the round-2 hole is now caught by exactly one check)"
+else
+  bad "16f-b the usage-parser unit pin is not load-bearing / not selective:\n$(grep -E '^(OK|FAIL) I' <<<"$out")"
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 16g (B9) — the VOCABULARY end reads EVERY registration form `cli.py`
+# uses, and anything it cannot decode is loud instead of a smaller number.
+#
+# Round 3 extracted the vocabulary with one grep for `cli.add_command(…,
+# name="…")`. `cli.py` already registers `daemon` as `@cli.group(name="daemon")`,
+# so that reader was UNDER-READING the producer on the shipped tree while the
+# guard printed a healthy-looking "16 subcommands". Converting four more
+# registrations to the form `daemon` already used dropped `usage`, `tree`,
+# `agents` and `qr-share` from the vocabulary, took `com.pocketshell.app.settings`
+# — the ONE package that end exists to catch — OFF the seam, cut unit selection
+# 570 -> 560, and left every floor GREEN. A floor cannot catch under-reading:
+# under-reading yields a plausible number.
+#
+# 16g-a is that exact refactor and must now be a NO-OP for the seam.
+# 16g-b/c/d are forms the reader cannot decode and must be RED.
+# 16g-e re-inlines the round-3 single-form reader and must be RED, so a revert
+# to a text heuristic cannot land quietly.
+# ---------------------------------------------------------------------------
+CLIDIR="$SANDBOX/cli"
+mkdir -p "$CLIDIR"
+REAL_CLI="$SCRIPT_DIR/../tools/pocketshell/src/pocketshell/cli.py"
+if python3 - "$REAL_CLI" "$CLIDIR" <<'PY'
+import pathlib
+import sys
+
+src = pathlib.Path(sys.argv[1]).read_text()
+out = pathlib.Path(sys.argv[2])
+
+# (a) the reviewer's exact B9 refactor: four registrations moved to the
+#     `@cli.group(name=...)` decorator form `daemon` already uses.
+a = src
+for sub, obj in (
+    ("usage", "usage_command"),
+    ("tree", "tree_group"),
+    ("agents", "agents_group"),
+    ("qr-share", "qr_share_command"),
+):
+    old = 'cli.add_command(%s, name="%s")' % (obj, sub)
+    assert a.count(old) == 1, "anchor missing: " + old
+    a = a.replace(
+        old,
+        '@cli.group(name="%s")\ndef _%s_shim() -> None:\n    """decorator-form registration"""\n'
+        % (sub, sub.replace("-", "_")),
+    )
+(out / "decorators.py").write_text(a)
+
+# (b) registration through a module-level loop — the shape `agents.py:880`
+#     already uses one level down.
+block = "\n".join(
+    'cli.add_command(%s, name="%s")' % (o, n)
+    for o, n in (("usage_command", "usage"), ("agent_group", "agent"))
+)
+assert src.count(block) == 1, "loop anchor missing"
+(out / "loop.py").write_text(
+    src.replace(
+        block,
+        "for _cmd, _name in ((usage_command, \"usage\"), (agent_group, \"agent\")):\n"
+        "    cli.add_command(_cmd, name=_name)",
+    )
+)
+
+# (c) name omitted — click derives it from the command object.
+c = src.replace('cli.add_command(tree_group, name="tree")', "cli.add_command(tree_group)")
+assert c != src, "noname anchor missing"
+(out / "noname.py").write_text(c)
+
+# (d) name behind a module constant.
+d = src.replace(
+    'cli.add_command(usage_command, name="usage")',
+    '_USAGE_NAME = "usage"\ncli.add_command(usage_command, name=_USAGE_NAME)',
+)
+assert d != src, "constant anchor missing"
+(out / "constant.py").write_text(d)
+
+# ---------------------------------------------------------------------------
+# ROUND-5 (the SIXTH spelling): the reader used to key detection on the
+# receiver being the literal name `cli`, so a registration reached through any
+# other binding was neither a SITE nor a NAME and `names == sites` held
+# vacuously. These three mutants are the shapes that were silent.
+# ---------------------------------------------------------------------------
+SET = (
+    ("usage", "usage_command"),
+    ("tree", "tree_group"),
+    ("agents", "agents_group"),
+    ("qr-share", "qr_share_command"),
+)
+FIRST = 'cli.add_command(usage_command, name="usage")'
+
+# (e) ALIAS — the reviewer's exact reproduction. This one must be READ, not
+#     merely refused: the vocabulary stays 17 and the seam does not move.
+e = src.replace(FIRST, "_g = cli\n" + FIRST, 1)
+for sub, obj in SET:
+    old = 'cli.add_command(%s, name="%s")' % (obj, sub)
+    assert e.count(old) == 1, "alias anchor missing: " + old
+    e = e.replace(old, '_g.add_command(%s, name="%s")' % (obj, sub))
+(out / "alias.py").write_text(e)
+
+# (f) THREE receivers that cannot be resolved, in one file so one index build
+#     covers the class: a function PARAMETER, a subscript, and a loop variable.
+#     Each must be reported by name; none may be silently absent.
+u = src.replace(
+    FIRST,
+    "def _register(group, cmd, name):\n    group.add_command(cmd, name=name)\n\n\n"
+    '_GROUPS = {"root": cli}\n' + FIRST,
+    1,
+)
+u = u.replace(
+    'cli.add_command(usage_command, name="usage")',
+    '_register(cli, usage_command, "usage")',
+)
+u = u.replace(
+    'cli.add_command(tree_group, name="tree")',
+    '_GROUPS["root"].add_command(tree_group, name="tree")',
+)
+u = u.replace(
+    'cli.add_command(agents_group, name="agents")',
+    'for _grp in (cli,):\n    _grp.add_command(agents_group, name="agents")',
+)
+for probe in ("group.add_command", '_GROUPS["root"].add_command', "_grp.add_command"):
+    assert probe in u, "unresolved anchor missing: " + probe
+(out / "unresolved.py").write_text(u)
+
+# (g) The group ESCAPING as a value. `cli.py` already hands a group to a helper
+#     in a sibling module (`register_push_card_commands(push_group)`, whose body
+#     in cards.py does `@push_group.command(...)`), so passing the ROOT group the
+#     same way is one character away and would register out of the census's sight.
+g = src.replace(FIRST, "register_more_commands(cli)\n" + FIRST, 1)
+assert g != src, "escape anchor missing"
+(out / "escape.py").write_text(g)
+
+# ---------------------------------------------------------------------------
+# ROUND-6 (the SEVENTH spelling): `click.Group.commands` is a plain dict —
+# `add_command` is literally `self.commands[name] = cmd` — so mutating it
+# registers a top-level subcommand through a path that is NOT a registrar call
+# and therefore never entered the census at all. Five forms in ONE file so the
+# whole class costs one index build: two writes (subscript, `.update`), a read,
+# a loop, and one attribute nobody has thought of (`result_callback`, a real
+# click API) which proves the check closes the CLASS rather than the spelling.
+# ---------------------------------------------------------------------------
+h = src.replace(
+    FIRST,
+    "_cb = cli.result_callback\n_TABLE = cli.commands\nfor _k in cli.commands:\n    pass\n" + FIRST,
+    1,
+)
+for sub, obj, form in (
+    ("usage", "usage_command", "item"),
+    ("agents", "agents_group", "item"),
+    ("tree", "tree_group", "update"),
+    ("qr-share", "qr_share_command", "update"),
+):
+    old = 'cli.add_command(%s, name="%s")' % (obj, sub)
+    assert h.count(old) == 1, "commands-table anchor missing: " + old
+    h = h.replace(
+        old,
+        'cli.commands["%s"] = %s' % (sub, obj)
+        if form == "item"
+        else 'cli.commands.update({"%s": %s})' % (sub, obj),
+    )
+(out / "commands_table.py").write_text(h)
+PY
+then
+  # Every mutant is grep-verified LIVE before any verdict is read (#1641).
+  for _m in 'decorators:@cli.group(name="qr-share")' 'loop:for _cmd, _name in' \
+            'noname:cli.add_command(tree_group)' 'constant:name=_USAGE_NAME' \
+            'alias:_g.add_command(qr_share_command' 'unresolved:group.add_command(cmd, name=name)' \
+            'escape:register_more_commands(cli)' 'commands_table:cli.commands.update({"qr-share"'; do
+    if ! grep -qF "${_m#*:}" "$CLIDIR/${_m%%:*}.py"; then
+      bad "16g MUTANT ${_m%%:*} DID NOT APPLY — its verdict would be meaningless"
+    fi
+  done
+
+  cli_probe() {  # $1 = cli source (absolute) -> "<settings-on-seam?> <unit-class-count>"
+    local on_seam count
+    on_seam="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$1" bash -c '
+      source "'"$SCRIPT_DIR"'/lib/test-areas.sh"
+      POCKETSHELL_TA_REPO_ROOT="'"$SCRIPT_DIR"'/.."
+      pocketshell_test_areas_load "'"$SCRIPT_DIR"'/test-areas.txt" >/dev/null
+      pocketshell_test_areas_build_index
+      [[ -n "${POCKETSHELL_TA_PROD_PKG_HOSTCLI[com.pocketshell.app.settings]:-}" ]] &&
+        echo ON-SEAM || echo OFF-SEAM')"
+    count="$(printf 'tools/pocketshell/src/pocketshell/qr_share.py\n' |
+      POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$1" bash "$SELECT" --changed-stdin --print-plan-only 2>/dev/null |
+      sed -n 's/^UNIT_GRADLE_FILTERS=//p' | wc -w)"
+    printf '%s %s\n' "$on_seam" "$count"
+  }
+  real_probe="$(cli_probe "$REAL_CLI")"
+  deco_probe="$(cli_probe "$CLIDIR/decorators.py")"
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/decorators.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if [[ "$deco_probe" == "$real_probe" ]] && [[ "$deco_probe" == ON-SEAM\ * ]] &&
+     grep -q '^PASS: manifest verified' <<<"$out"; then
+    ok "16g-a the decorator-form refactor is a NO-OP for the seam ($deco_probe, unchanged) — round 3 dropped app.settings OFF the seam here and stayed green"
+  else
+    bad "16g-a the decorator-form refactor still moves the seam: real=[$real_probe] decorators=[$deco_probe]\n$out"
+  fi
+
+  # 16g-h (ROUND 5, the SIXTH spelling) — a registration reached through an
+  # ALIAS of the root group. `is_root_registrar` used to require the receiver to
+  # be the literal name `cli`, so `_g = cli; _g.add_command(…)` was neither a
+  # SITE nor a NAME: `names == sites` held vacuously at 13 == 13, the guard
+  # printed "read from all 13 registration sites", and the seam quietly lost
+  # `com.pocketshell.app.settings` (32 -> 31 packages, 820 -> 809 classes, unit
+  # selection 570 -> 560) — byte-for-byte the B9 symptom.
+  #
+  # The right answer is to READ it, not to refuse it: an alias is unambiguous,
+  # and reddening on it would just force the producer into one writing style.
+  # So the assertion here is a NO-OP, exactly like 16g-a. 16g-k below is the
+  # paired proof that this assertion is load-bearing rather than decorative:
+  # revert the resolver to receiver-keyed detection and this probe moves.
+  alias_probe="$(cli_probe "$CLIDIR/alias.py")"
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/alias.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if [[ "$alias_probe" == "$real_probe" ]] && [[ "$alias_probe" == ON-SEAM\ * ]] &&
+     grep -q '^PASS: manifest verified' <<<"$out" &&
+     grep -q 'over 17 subcommands read from the 17 top-level registration sites this reader could see' <<<"$out"; then
+    ok "16g-h a registration through an ALIAS of the root group is READ correctly, and is a NO-OP for the seam ($alias_probe, unchanged) — receiver-keyed detection dropped 4 subcommands here and stayed green"
+  else
+    bad "16g-h the aliased registration moves the seam or is not read: real=[$real_probe] alias=[$alias_probe]\n$out"
+  fi
+
+  # 16g-i — three receivers the reader CANNOT resolve, in one file: a function
+  # parameter (the reviewer's P6), a subscript, and a loop variable. None of
+  # them may be silently absent; each must be named. This is the half of the
+  # receiver-agnostic census that fails CLOSED, and it is why the reader no
+  # longer needs to recognise a list of shapes.
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/unresolved.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if grep -q 'could not resolve the receiver of 3 registrar call(s)' <<<"$out" &&
+     grep -qF "the receiver 'group' resolves to neither" <<<"$out" &&
+     grep -qF "the receiver '<Subscript expression>' resolves to neither" <<<"$out" &&
+     grep -qF "the receiver '_grp' resolves to neither" <<<"$out"; then
+    ok "16g-i all three unresolvable receivers (function parameter, subscript, loop variable) redden --verify-manifest BY NAME — an unrecognised way of naming the group is loud, not absent"
+  else
+    bad "16g-i an unresolvable registrar receiver was not reported by name:\n$out"
+  fi
+
+  # 16g-j — the group ESCAPING this file as a value. The census is total over
+  # cli.py, so the remaining hole is the object leaving; 16g-f covers it leaving
+  # by import, this covers it being handed to a helper. The package already does
+  # exactly this one level down (`register_push_card_commands(push_group)`).
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/escape.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if grep -q "escapes as a value at line" <<<"$out"; then
+    ok "16g-j handing the root group to a helper reddens --verify-manifest — the reader will not claim a complete vocabulary once the object can be registered on elsewhere"
+  else
+    bad "16g-j the root group escaping as a call argument is invisible to the guard:\n$out"
+  fi
+
+  # 16g-l (ROUND 6, the SEVENTH spelling) — `click.Group.commands` is a plain
+  # dict (`add_command` is literally `self.commands[name] = cmd`), so mutating
+  # it registers a top-level subcommand through a path that is NOT a registrar
+  # CALL and never entered the census at all. Round 5 waved every attribute
+  # access on the root through on the false claim that "registrar attrs are
+  # already in the census"; the measured consequence on the SAME four
+  # subcommands was byte-for-byte the round-3/round-4 symptom — census
+  # 22 = 17 + 5 + 0 collapsing to 18 = 13 + 5 + 0 over a smaller file, zero
+  # UNREADABLE, zero UNCLASSIFIED, `com.pocketshell.app.settings` OFF the seam
+  # (32 -> 31 packages, 820 -> 809 classes), UNIT_SELECTED_UNIT_CLASSES
+  # 570 -> 560, and `--verify-manifest` rc=0 whose OK line positively claimed
+  # it had read every registration site.
+  #
+  # The fix is round 5's own inversion applied to that allow-list: only the
+  # four attributes proven unable to hide a registration pass, everything else
+  # is reported. So this one file carries the whole class in one index build:
+  # four writes (two `commands["x"] = cmd`, two `commands.update({…})`), a bare
+  # read, a loop, and `result_callback` — a real click attribute nobody has
+  # thought of — seven diagnostics, each named with its line.
+  # `result_callback` is the load-bearing one:
+  # it is what distinguishes closing the CLASS from adding `commands` to
+  # REGISTRARS, which is the list-of-spellings pattern that produced seven of
+  # them and is explicitly NOT the fix.
+  #
+  # The control is 16g-h/16g-a above: the real cli.py and the aliased copy stay
+  # ON-SEAM at 17/17 and PASS through this same check, because the shipped file
+  # touches the root through exactly `add_command`, `group` and `main`.
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/commands_table.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if grep -q 'could not decode 7 registration(s)' <<<"$out" &&
+     [[ "$(grep -o "non-registrar attribute 'commands' at line" <<<"$out" | wc -l)" -eq 6 ]] &&
+     grep -qF "non-registrar attribute 'result_callback' at line" <<<"$out" &&
+     ! grep -q '^PASS: manifest verified' <<<"$out"; then
+    ok "16g-l mutating the root group's \`commands\` dict — the SEVENTH spelling, and not a registrar call at all — reddens --verify-manifest BY NAME on all six write/read/loop reads, and an unrelated non-registrar attribute (result_callback) reddens too, so the check closes the CLASS rather than the spelling"
+  else
+    bad "16g-l a non-registrar attribute on the root group did not redden the guard by name (this is the 18 = 13 + 5 + 0 silent under-read):\n$out"
+  fi
+
+  for _case in loop:'not a module-top-level registration' \
+               noname:'no explicit name' \
+               constant:'name= is not a plain string literal'; do
+    out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/${_case%%:*}.py" bash "$SELECT" --verify-manifest 2>&1)"
+    if grep -q 'the reader is UNDER-READING the producer' <<<"$out" &&
+       grep -qF "${_case#*:}" <<<"$out"; then
+      ok "16g-b/${_case%%:*} a registration form the reader cannot decode reddens --verify-manifest by name (fail-closed, not a smaller vocabulary)"
+    else
+      bad "16g-b/${_case%%:*} an undecodable registration form did NOT redden the guard:\n$out"
+    fi
+  done
+
+  # 16g-f — the FIFTH spelling the implementer went looking for: the reader
+  # reads ONE file, so a top-level registration made from a SIBLING module would
+  # keep names == sites and stay silent. Nothing does that today, so the reader
+  # trips on a sibling merely taking the group object.
+  mkdir -p "$CLIDIR/pkg"
+  cp "$REAL_CLI" "$CLIDIR/pkg/cli.py"
+  printf 'from pocketshell.cli import cli\n\ncli.add_command(None, name="ghost")\n' > "$CLIDIR/pkg/ghost.py"
+  if ! grep -q 'from pocketshell.cli import cli' "$CLIDIR/pkg/ghost.py"; then
+    bad "16g-f MUTANT DID NOT APPLY"
+  fi
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/pkg/cli.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if grep -q 'takes the top-level group object from cli.py' <<<"$out"; then
+    ok "16g-f a SIBLING module taking the top-level group reddens --verify-manifest — a registration outside cli.py cannot be silently invisible"
+  else
+    bad "16g-f a sibling module holding the group object is invisible to the guard:\n$out"
+  fi
+  # ...and the unmutated copy of the same file, in a directory with no such
+  # sibling, is green — so 16g-f is measuring the sibling, not the copy.
+  rm -f "$CLIDIR/pkg/ghost.py"
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/pkg/cli.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if grep -q '^PASS: manifest verified' <<<"$out"; then
+    ok "16g-f2 ...and the same cli.py without that sibling is GREEN (16g-f measures the sibling, not the copy)"
+  else
+    bad "16g-f2 the unmutated cli.py copy is red, so 16g-f proves nothing:\n$out"
+  fi
+
+  # 16g-f3 (ROUND 5) — three MORE import spellings, all of which the round-4
+  # regex sibling scan let through: an absolute `from pocketshell import cli`,
+  # a star import, and a run-time `importlib` import. The scan is an AST walk
+  # now for the same reason the receiver check stopped matching names: a regex
+  # recognises the spellings someone thought of. All three ghosts live in one
+  # package dir so a single index build covers the class.
+  printf 'from pocketshell import cli\n\ncli.add_command(None, name="a")\n' > "$CLIDIR/pkg/ghost_abs.py"
+  printf 'from .cli import *\n\ncli.add_command(None, name="b")\n'          > "$CLIDIR/pkg/ghost_star.py"
+  printf 'import importlib\n\nimportlib.import_module("pocketshell.cli")\n' > "$CLIDIR/pkg/ghost_dyn.py"
+  for _g in abs:'from pocketshell import cli' star:'from .cli import *' dyn:'import importlib'; do
+    if ! grep -qF "${_g#*:}" "$CLIDIR/pkg/ghost_${_g%%:*}.py"; then
+      bad "16g-f3 MUTANT ghost_${_g%%:*} DID NOT APPLY"
+    fi
+  done
+  out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/pkg/cli.py" bash "$SELECT" --verify-manifest 2>&1)"
+  if grep -qF "ghost_abs.py takes the top-level group object from cli.py (binds the name 'cli')" <<<"$out" &&
+     grep -qF "ghost_star.py takes the top-level group object from cli.py (star-imports everything from cli.py)" <<<"$out" &&
+     grep -qF "ghost_dyn.py takes the top-level group object from cli.py (can import by name at run time (importlib))" <<<"$out"; then
+    ok "16g-f3 the absolute, star and importlib import spellings ALL redden --verify-manifest by name (the round-4 regex scan passed on all three)"
+  else
+    bad "16g-f3 a sibling import spelling is invisible to the guard:\n$out"
+  fi
+  # The control for 16g-f3 is 16g-f2 above: it ran the same copy in the same
+  # directory with no sibling present and was GREEN, so the three ghosts are the
+  # whole delta. Restore that state rather than paying for a second index build.
+  rm -f "$CLIDIR/pkg/ghost_abs.py" "$CLIDIR/pkg/ghost_star.py" "$CLIDIR/pkg/ghost_dyn.py"
+
+  # 16g-g — the reader itself not finishing (no python3, a crash, a kill). A
+  # half-read vocabulary must be an ERROR, never a smaller-but-plausible one.
+  mkdir -p "$SANDBOX/nopy"
+  printf '#!/bin/sh\nexit 127\n' > "$SANDBOX/nopy/python3"
+  chmod +x "$SANDBOX/nopy/python3"
+  if ! "$SANDBOX/nopy/python3"; then : ; fi   # shim confirmed non-functional
+  out="$(PATH="$SANDBOX/nopy:$PATH" bash "$SELECT" --verify-manifest 2>&1)"
+  if grep -q 'the vocabulary reader did not finish' <<<"$out" &&
+     grep -q 'registration SITES found in' <<<"$out"; then
+    ok "16g-g a vocabulary reader that cannot run at all reddens --verify-manifest (missing/crashed python3 is an error, not a smaller vocabulary)"
+  else
+    bad "16g-g a dead vocabulary reader did not redden the guard:\n$out"
+  fi
+
+  # 16g-e — re-inline the round-3 single-form reader. A revert to a text
+  # heuristic that reports no site count must be RED, or B9 comes back.
+  B9DIR="$(mut_copy mut-b9-oneform)"
+  python3 - "$B9DIR/lib/test-areas.sh" <<'PY'
+import sys
+
+p = sys.argv[1]
+s = open(p).read()
+anchor = '  mapfile -t vocab_lines < <(_pocketshell_hostcli_read_cli_vocabulary "$cli_src")'
+assert s.count(anchor) == 1, "16g-e anchor not unique"
+s = s.replace(anchor, """  mapfile -t vocab_lines < <(  # MUTANT 16g-e: round-3 add_command-only reader
+    grep -oE 'add_command\\\\([^)]*name="[a-z0-9][a-z0-9-]*"' "$cli_src" 2>/dev/null |
+      grep -oE 'name="[a-z0-9][a-z0-9-]*"' | sed 's/name="//; s/"$//' | LC_ALL=C sort -u |
+      sed 's/^/NAME /'
+    printf 'END\\\\n'
+  )""")
+open(p, "w").write(s)
+PY
+  if ! grep -q 'MUTANT 16g-e' "$B9DIR/lib/test-areas.sh"; then
+    bad "16g-e MUTATION DID NOT APPLY"
+  fi
+  out="$(run_copy "$B9DIR" --verify-manifest)"
+  if grep -q 'the import-dependency index looks broken' <<<"$out" &&
+     grep -q 'registration SITES found in' <<<"$out"; then
+    ok "16g-e reverting the vocabulary reader to the round-3 single-form grep reddens --verify-manifest (it reports no registration sites, so the equality check has nothing to stand on)"
+  else
+    bad "16g-e the round-3 single-form reader is STILL green — B9 can come back:\n$out"
+  fi
+
+  # 16g-k (ROUND 5) — the paired proof that 16g-h is load-bearing. Revert the
+  # receiver resolution to round 4's receiver-keyed form (only the literal name
+  # `cli` is the root; anything else is treated as some other object) and run it
+  # against the SAME aliased cli.py. It must under-read: 17 subcommands become
+  # 13 while the guard still says PASS. That is precisely the silent failure the
+  # equality check cannot see, and 16g-h is the assertion that catches it — so
+  # if someone reverts the resolver, 16g-h goes red and this case explains why.
+  R5DIR="$(mut_copy mut-r5-receiver-keyed)"
+  python3 - "$R5DIR/lib/test-areas.sh" <<'PY'
+import sys
+
+p = sys.argv[1]
+s = open(p).read()
+anchor = '''def receiver_of(node):
+    """(kind, human description) of the object a registrar is invoked on."""
+    recv = node.value
+    if isinstance(recv, ast.Name):
+        return env.get(recv.id, "unknown"), recv.id
+    return "unknown", "<%s expression>" % type(recv).__name__'''
+assert s.count(anchor) == 1, "16g-k anchor not unique"
+s = s.replace(anchor, '''def receiver_of(node):  # MUTANT 16g-k: round-4 receiver-keyed detection
+    recv = node.value
+    if isinstance(recv, ast.Name) and recv.id == root:
+        return "root", recv.id
+    return "nonroot", "mutant"''')
+open(p, "w").write(s)
+PY
+  if ! grep -q 'MUTANT 16g-k' "$R5DIR/lib/test-areas.sh"; then
+    bad "16g-k MUTATION DID NOT APPLY"
+  fi
+  # Not `run_copy`: a variable prefix on a shell FUNCTION is not exported to the
+  # child process, so the mutant copy would silently read the real cli.py.
+  out="$(POCKETSHELL_TEST_AREAS_REPO_ROOT="$SCRIPT_DIR/.." \
+         POCKETSHELL_TEST_AREAS_MANIFEST="$R5DIR/test-areas.txt" \
+         POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$R5DIR/ci-journey-suite.sh" \
+         POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/alias.py" \
+         bash "$R5DIR/select-test-areas.sh" --verify-manifest 2>&1)"
+  if grep -q '^PASS: manifest verified' <<<"$out" &&
+     grep -q 'over 13 subcommands read from the 13 top-level registration sites this reader could see' <<<"$out"; then
+    ok "16g-k receiver-keyed detection silently under-reads the SAME aliased cli.py (17 -> 13 subcommands, still PASS) — so 16g-h's no-op assertion is the thing standing between us and the sixth spelling"
+  else
+    bad "16g-k could not reproduce the receiver-keyed under-read, so 16g-h's no-op assertion is unproven:\n$out"
+  fi
+else
+  bad "16g could not build the cli.py mutants from $REAL_CLI — the B9 cases did not run, so their silence proves nothing"
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 17 (B2) — the import-derived dependency edges are load-bearing.
+#
+# Round 1 relied on hand-written area couples, two of which were claimed in the
+# write-up and absent from the manifest; 29 journeys importing connection-core
+# production types were not selected by a connection-core change. Mutation:
+# neuter the import scan so every class depends only on its own area. I8's
+# independent re-scan and the D28 pins must both redden.
+# ---------------------------------------------------------------------------
+sed -i "s|import\[\[:space:\]\]+com\\\\.pocketshell\\\\.|import[[:space:]]+zz_no_such_package_zz\\\\.|" \
+  "$MUTDIR/lib/test-areas.sh"
+# PROVE THE MUTANT IS LIVE before reading anything into the result. #1641 spent a
+# round on a mutation that had landed inside a KDoc block and killed nothing —
+# "the mutation survived" and "the mutation never happened" look identical.
+if grep -q 'zz_no_such_package_zz' "$MUTDIR/lib/test-areas.sh" &&
+   [[ "$(POCKETSHELL_TEST_AREAS_REPO_ROOT="$SCRIPT_DIR/.." \
+         POCKETSHELL_TEST_AREAS_MANIFEST="$MUTDIR/test-areas.txt" \
+         POCKETSHELL_TEST_AREAS_JOURNEY_SUITE="$MUTDIR/ci-journey-suite.sh" \
+         bash "$MUTDIR/select-test-areas.sh" --verify-manifest 2>&1 |
+         grep -c 'import lines scanned = 0')" -eq 1 ]]; then
+  : # mutant confirmed live: zero import lines reach the dependency index
+else
+  bad "17 MUTATION DID NOT APPLY — the import scan is still live in the copy, so 17's verdict would be meaningless"
+fi
+out="$(run_mut --coverage-invariant --only I8,I9)"
+if grep -q 'FAIL I8' <<<"$out" && grep -qE 'ForwardingNetworkRideThroughE2eTest|ConnectionLogHostMirrorReconnectDockerTest|Issue1876FolderListMobileRttDockerTest' <<<"$out"; then
+  ok "17 disabling the import-derived deps reddens I8, naming the escaping journeys"
+else
+  bad "17 the escape scan survived a disabled import derivation:\n$(grep -E '^(OK|FAIL) I[89]' <<<"$out")"
+fi
+cp "$SCRIPT_DIR/lib/test-areas.sh" "$MUTDIR/lib/test-areas.sh"   # restore
+
+# ---------------------------------------------------------------------------
+# CASE 18 (B3) — the emitted `--tests` filter must BE the plan.
+#
+# Round 1 emitted `com.pocketshell.app.*Test`; Gradle's `*` crosses package
+# dots, so the command ran all 485 :app unit classes while the plan reported a
+# fraction of them. Mutation: reinstate that wildcard. I10 must redden.
+# ---------------------------------------------------------------------------
+filters="$(printf 'app/src/main/java/com/pocketshell/app/usage/UsageScreen.kt\n' |
+  bash "$SELECT" --changed-stdin --print-plan-only 2>/dev/null |
+  sed -n 's/^UNIT_GRADLE_FILTERS=//p')"
+if [[ -n "$filters" && "$filters" != *"*"* ]]; then
+  ok "18a the emitted :app filter is exact class names, with no glob metacharacter"
+else
+  bad "18a emitted filter still contains a wildcard: $filters"
+fi
+sed -i 's|^      app_unit+=("$fqcn")$|      app_unit+=("com.pocketshell.app.*Test")|' \
+  "$MUTDIR/select-test-areas.sh"
+grep -q 'com.pocketshell.app.\*Test' "$MUTDIR/select-test-areas.sh" ||
+  bad "18b MUTATION DID NOT APPLY — the wildcard mutant is not live in the copy"
+out="$(run_mut --coverage-invariant --only I10)"
+if grep -q 'FAIL I10' <<<"$out" && grep -q 'glob metacharacter' <<<"$out"; then
+  ok "18b reinstating the package wildcard reddens I10 (plan and command must agree)"
+else
+  bad "18b the wildcard filter survived I10:\n$(grep -E '^(OK|FAIL) I10' <<<"$out")"
+fi
+cp "$SCRIPT_DIR/select-test-areas.sh" "$MUTDIR/select-test-areas.sh"   # restore
+
+# ---------------------------------------------------------------------------
+# CASE 19 (B5) — the area -> Gradle-task map.
+#
+# Round 1's map was a hardcoded `case`; the reviewer renamed one area token
+# (`usage-costs` -> `usage-panel`) and BOTH guards stayed green while
+# `:shared:core-usage:test` silently dropped out. 19a replays that exact rename
+# and asserts the task survives it (the map is derived from class paths now);
+# 19b drops a module from the derivation and asserts I11 reddens, so 19a is not
+# vacuous.
+# ---------------------------------------------------------------------------
+renamed="$SANDBOX/manifest-usage-renamed.txt"
+sed 's/usage-costs/usage-panel/g' "$SCRIPT_DIR/test-areas.txt" > "$renamed"
+tasks="$(printf 'shared/core-usage/src/main/java/com/pocketshell/core/usage/Probe.kt\n' |
+  POCKETSHELL_TEST_AREAS_MANIFEST="$renamed" bash "$SELECT" --changed-stdin --print-plan-only 2>/dev/null |
+  sed -n 's/^UNIT_SHARED_TASKS=//p')"
+if [[ " $tasks " == *" :shared:core-usage:test "* ]]; then
+  ok "19a renaming the usage area token no longer drops :shared:core-usage:test"
+else
+  bad "19a the reviewer's rename mutation still drops the module task: $tasks"
+fi
+sed -i 's|^      shared_tasks\["$mod:test"\]=1$|      case "$mod" in :shared:core-usage) : ;; *) shared_tasks["$mod:test"]=1 ;; esac|' \
+  "$MUTDIR/select-test-areas.sh"
+grep -q ':shared:core-usage) : ;;' "$MUTDIR/select-test-areas.sh" ||
+  bad "19b MUTATION DID NOT APPLY — the dropped-module mutant is not live in the copy"
+out="$(run_mut --coverage-invariant --only I9,I11)"
+if grep -q 'FAIL I11' <<<"$out" && grep -q ':shared:core-usage:test' <<<"$out"; then
+  ok "19b dropping one module from the task derivation reddens I11 by name"
+else
+  bad "19b a module silently missing from the task map survived I11:\n$(grep -E '^(OK|FAIL) I11' <<<"$out")"
+fi
+# The OTHER half of the I9 unit pin: the class is still SELECTED (its area is
+# unchanged) but the emitted plan no longer runs its module. That is the exact
+# shape of the B6 symptom the reviewer measured — a green selection over a
+# command that does not include the task — so the pin must catch it too.
+if grep -q 'FAIL I9' <<<"$out" &&
+   grep -q 'does NOT run :shared:core-usage:test' <<<"$out"; then
+  ok "19c ...and the I9 unit pin reddens on the same mutant because the emitted plan no longer runs :shared:core-usage:test (selected != executed)"
+else
+  bad "19c the unit pin did not notice that the plan stopped running the pinned class's module:\n$(grep -E '^(OK|FAIL) I9' <<<"$out")"
+fi
+cp "$SCRIPT_DIR/select-test-areas.sh" "$MUTDIR/select-test-areas.sh"   # restore
+
+# ---------------------------------------------------------------------------
+# CASE 20 (B4 sibling) — ONE resolver. The FQCN resolver and the path resolver
+# must agree on the real tree, which is the property whose absence made the
+# ledger guard red for 183 classes while --verify-manifest was green.
+# ---------------------------------------------------------------------------
+mismatch=0
+while IFS=$'\t' read -r fq area _mod _ss _deps; do
+  [[ -z "$fq" ]] && continue
+  [[ "$area" == "__NONE__" ]] && { mismatch=$((mismatch + 1)); echo "  unresolved: $fq"; }
+done < <(bash "$SELECT" --list-classes 2>/dev/null)
+if [[ "$mismatch" -eq 0 ]]; then
+  ok "20 every registered class resolves by FQCN on the real tree (one resolver, no shared-module blind spot)"
+else
+  bad "20 $mismatch registered class(es) resolve to no area by FQCN"
+fi
+
+echo
+echo "select-test-areas selftest: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/select-test-areas.sh
+++ b/scripts/select-test-areas.sh
@@ -1,0 +1,1203 @@
+#!/usr/bin/env bash
+# Host-CLI / area COVERAGE GUARD, which also scopes selection (issue #2063,
+# analysis #2059).
+#
+# Turns a set of changed paths into a run plan: which unit test tasks, which
+# `--tests` filters, and which journey classes. Coverage is INVARIANT — every
+# test still runs on a bounded cadence (affected areas per push, always-tier on
+# every push, full suite nightly and at the release gate); only the *when*
+# becomes granular.
+#
+# WHAT THIS IS FOR — MEASURED, SO NOBODY READS IT AS A SPEED FEATURE
+#
+# Over the last 104 `main` commits: 58-62% force-full, and a typical commit
+# still selects 89% of the journeys and 86% of the `:app` unit classes. That is
+# **1.09x on the emulator lane and NEUTRAL-TO-SLIGHTLY-NEGATIVE on the Unit
+# lane** once these guards' own ~100 s/variant (+3.3 min per full Unit run) is
+# counted. Do not describe this as making tests faster, and do not tune it as
+# if that were the goal.
+#
+# What it IS is the mechanism that can answer "is every test class still
+# reachable, mapped, and actually executed" — the question behind #1851 (two
+# classes in no suite), #1853 (twelve dead harnesses), #1859 (a shard truncating
+# at 98 of 226) and #1509/#847 (the host-CLI wire seam). Its guards are the
+# deliverable; the selection plan is a by-product of having the taxonomy.
+# See docs/testing.md for the full measurement table and the merge-ordering
+# constraint (#2067 must land the cheap-job step, or this is pure cost).
+#
+# MODES
+#   (default)            print a human-readable plan for the current diff
+#   --changed-file F     read changed paths from F (one per line) instead of git
+#   --changed-stdin      read changed paths from stdin
+#   --base REF           git base for the diff (default: merge-base origin/main)
+#   --github-output      also append key=value lines to $GITHUB_OUTPUT
+#   --print-plan-only    machine-readable KEY=VALUE plan on stdout, nothing else
+#   --journeys           list every registered journey class with area + tier
+#   --list-classes       TSV of every registered class: fqcn, area, module,
+#                        source set, and its import-derived dependency areas
+#   --verify-manifest    guard: the manifest is TOTAL and internally consistent
+#   --coverage-invariant guard: prove the union over the cadence == all tests
+#   --only I8,I9         run only those invariants (self-test mutations only —
+#                        NEVER a CI mode; a filtered run says so in its verdict)
+#   --self-check         --verify-manifest and --coverage-invariant together
+#
+# EXIT CODES
+#   0  success
+#   1  guard failure (verify/coverage modes) or usage error
+#
+# WHY THE FAIL-SAFE CANNOT BE INVERTED
+#
+# `pocketshell_test_area_classify` starts every path at `full` and only narrows
+# on an explicit manifest match (scripts/lib/test-areas.sh). This script then
+# adds three more one-way ratchets:
+#   * a manifest that fails to load  => MODE=full;
+#   * any path classified `full`     => MODE=full (no early exit — we keep
+#     scanning so the plan can report EVERY reason, but the decision is latched);
+#   * an empty diff                  => MODE=full.
+# and the selected area set always contains every `always`-tier area, so the
+# smallest possible selection is the always tier, never the empty set. The
+# selftest mutates the manifest (delete rules, empty file, unknown path) and
+# asserts the result is MORE running, never less.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${POCKETSHELL_TEST_AREAS_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+MANIFEST="${POCKETSHELL_TEST_AREAS_MANIFEST:-$SCRIPT_DIR/test-areas.txt}"
+JOURNEY_SUITE="${POCKETSHELL_TEST_AREAS_JOURNEY_SUITE:-$SCRIPT_DIR/ci-journey-suite.sh}"
+
+# shellcheck source=lib/test-areas.sh
+source "$SCRIPT_DIR/lib/test-areas.sh"
+
+POCKETSHELL_TA_REPO_ROOT="$REPO_ROOT"
+
+MODE="plan"
+CHANGED_FILE=""
+CHANGED_STDIN=0
+BASE_REF=""
+EMIT_GITHUB_OUTPUT=0
+ONLY_INVARIANTS=""
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --changed-file) CHANGED_FILE="$2"; shift 2 ;;
+    --changed-stdin) CHANGED_STDIN=1; shift ;;
+    --base) BASE_REF="$2"; shift 2 ;;
+    --github-output) EMIT_GITHUB_OUTPUT=1; shift ;;
+    --print-plan-only) MODE="plan-only"; shift ;;
+    --journeys) MODE="journeys"; shift ;;
+    --list-classes) MODE="list-classes"; shift ;;
+    --verify-manifest) MODE="verify"; shift ;;
+    --coverage-invariant) MODE="coverage"; shift ;;
+    --only) ONLY_INVARIANTS="$2"; shift 2 ;;
+    --self-check) MODE="selfcheck"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Manifest load. A load failure is a FULL run, loudly.
+# ---------------------------------------------------------------------------
+MANIFEST_OK=1
+if ! pocketshell_test_areas_load "$MANIFEST"; then
+  MANIFEST_OK=0
+fi
+
+# ---------------------------------------------------------------------------
+# Repo inventory helpers
+# ---------------------------------------------------------------------------
+tracked_files() {
+  git -C "$REPO_ROOT" ls-files 2>/dev/null
+}
+
+# Journey registry entries, normalised to FQCNs (the `Class#method` split
+# entries collapse to their class). Parsed with the SAME sed shape
+# check-ci-journey-harness.sh uses, so the two guards cannot disagree about
+# what the registry contains.
+journey_registry_classes() {
+  [[ -f "$JOURNEY_SUITE" ]] || return 0
+  sed -nE \
+    -e 's/.*"\$FQCN_PREFIX\.([A-Za-z0-9_]+)(#[^"]*)?".*/com.pocketshell.app.proof.\1/p' \
+    -e 's/.*"(com\.pocketshell\.app\.[A-Za-z0-9_.]+)(#[^"]*)?".*/\1/p' \
+    "$JOURNEY_SUITE" |
+    # Drop the `FQCN_PREFIX="com.pocketshell.app.proof"` assignment itself: a
+    # class simple name always starts uppercase, a package segment never does.
+    grep -E '\.[A-Z][A-Za-z0-9_]*$' |
+    LC_ALL=C sort -u
+}
+
+# ---------------------------------------------------------------------------
+# Changed paths
+# ---------------------------------------------------------------------------
+compute_changed_paths() {
+  if [[ -n "$CHANGED_FILE" ]]; then
+    cat "$CHANGED_FILE"
+    return 0
+  fi
+  if [[ "$CHANGED_STDIN" -eq 1 ]]; then
+    cat
+    return 0
+  fi
+  local base="$BASE_REF"
+  if [[ -z "$base" ]]; then
+    base="$(git -C "$REPO_ROOT" merge-base origin/main HEAD 2>/dev/null)" || base=""
+  fi
+  if [[ -z "$base" ]]; then
+    echo "select-test-areas: cannot compute a diff base (run 'git fetch origin main')" >&2
+    # No base => we cannot know what changed => full run. Emit a sentinel path
+    # that is guaranteed to classify as unmapped/full rather than an empty diff
+    # that could be mistaken for "nothing to do".
+    printf '%s\n' "__NO_DIFF_BASE__"
+    return 0
+  fi
+  git -C "$REPO_ROOT" diff --name-only "$base"...HEAD 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+SELECT_MODE=""          # full | scoped
+declare -a SELECT_FULL_REASONS=()
+declare -a SELECT_UNMAPPED=()
+declare -a SELECT_CLASSIFICATION=()
+SELECT_AREAS=""         # everything selected: seed closure + the always tier
+SELECT_SEED_AREAS=""    # only what actually CHANGED (seeds + `couple` closure)
+
+run_selection() {
+  local -a paths=()
+  local p
+  while IFS= read -r p; do
+    p="${p%%$'\r'}"
+    [[ -z "${p// /}" ]] && continue
+    paths+=("$p")
+  done
+
+  SELECT_MODE="scoped"
+  SELECT_FULL_REASONS=()
+  SELECT_UNMAPPED=()
+  SELECT_CLASSIFICATION=()
+
+  if [[ "$MANIFEST_OK" -ne 1 ]]; then
+    SELECT_MODE="full"
+    SELECT_FULL_REASONS+=("manifest failed to load: ${POCKETSHELL_TA_LOAD_ERRORS[*]:-unknown}")
+  fi
+
+  if [[ "${#paths[@]}" -eq 0 ]]; then
+    SELECT_MODE="full"
+    SELECT_FULL_REASONS+=("empty changed-path set — cannot prove which areas are safe to skip")
+  fi
+
+  local -A seed=()
+  for p in "${paths[@]:-}"; do
+    [[ -z "$p" ]] && continue
+    pocketshell_test_area_classify "$p"
+    SELECT_CLASSIFICATION+=("$(printf '%-6s %-20s %s' \
+      "$POCKETSHELL_TEST_AREA_KIND" "${POCKETSHELL_TEST_AREA_NAME:--}" "$p")")
+    case "$POCKETSHELL_TEST_AREA_KIND" in
+      full)
+        # Latch, but keep scanning so the plan reports every reason.
+        SELECT_MODE="full"
+        SELECT_FULL_REASONS+=("$p [$POCKETSHELL_TEST_AREA_REASON]")
+        case "$POCKETSHELL_TEST_AREA_REASON" in
+          unmapped-path|unmapped-test-path) SELECT_UNMAPPED+=("$p") ;;
+        esac
+        ;;
+      area) seed["$POCKETSHELL_TEST_AREA_NAME"]=1 ;;
+      noop) : ;;
+    esac
+  done
+
+  if [[ "$SELECT_MODE" == "full" ]]; then
+    SELECT_AREAS="$(printf '%s\n' "${POCKETSHELL_TA_AREAS[@]}" | LC_ALL=C sort | tr '\n' ' ')"
+    SELECT_SEED_AREAS="$SELECT_AREAS"
+  else
+    SELECT_AREAS="$(pocketshell_test_areas_expand "${!seed[*]}" | tr '\n' ' ')"
+    SELECT_SEED_AREAS="$(pocketshell_test_areas_expand_seeds "${!seed[*]}" | tr '\n' ' ')"
+  fi
+  SELECT_AREAS="${SELECT_AREAS% }"
+  SELECT_SEED_AREAS="${SELECT_SEED_AREAS% }"
+}
+
+area_selected() {
+  local a="$1" s
+  for s in $SELECT_AREAS; do [[ "$s" == "$a" ]] && return 0; done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# THE per-CLASS selection predicate.
+#
+# A test class runs when ANY of these holds:
+#   * the run is FULL;
+#   * its area cannot be resolved            (ratchet: unknown => run it);
+#   * its area is `always`-tier              (the floor);
+#   * its own area actually changed;
+#   * it IMPORTS the production code of an area that actually changed.
+#
+# The last clause is the round-1 fix (finding B2): coupling is read off the
+# compile graph per class instead of from hand-written area edges that were
+# claimed in prose and missing from the manifest. Matching is against
+# SELECT_SEED_AREAS — what changed — and NOT against the always tier, or every
+# class importing connection-core would run on every push and the selection
+# would collapse to full.
+# ---------------------------------------------------------------------------
+# Source sets the JVM unit tasks (`test`, `:app:test`, `:shared:X:test`) run.
+# `testDebug` / `testRelease` are variant-only unit source sets and they DO
+# exist here (2 classes in :app, 2 in :shared:core-connection); treating only
+# `test` as "unit" silently drops them from the emitted --tests filter.
+is_unit_source_set() {
+  case "$1" in test|testDebug|testRelease) return 0 ;; *) return 1 ;; esac
+}
+
+class_selected() {
+  local fqcn="${1%%#*}" area dep
+  [[ "$SELECT_MODE" == "full" ]] && return 0
+  # THE resolver, called for its globals so the hot loop does not fork. Do not
+  # inline its chain here: two copies of "how a class resolves" is finding B4.
+  pocketshell_test_area_for_class "$fqcn" >/dev/null
+  area="$POCKETSHELL_TEST_AREA_FOR_CLASS"
+  [[ -z "$area" ]] && return 0
+  [[ "${POCKETSHELL_TA_AREA_TIER[$area]:-always}" == "always" ]] && return 0
+  [[ " $SELECT_SEED_AREAS " == *" $area "* ]] && return 0
+  pocketshell_test_area_deps_for_class "$fqcn" >/dev/null
+  for dep in $POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS; do
+    [[ " $SELECT_SEED_AREAS " == *" $dep "* ]] && return 0
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Plan rendering
+# ---------------------------------------------------------------------------
+
+# Gradle unit selection.
+#
+# TWO invocations on purpose: `--tests` applies to every test task in one
+# invocation, so a shared-module task would be filtered by an :app class name
+# and fail with "no tests found". Full mode emits the byte-identical whole-graph
+# command the Unit job runs today, which is what keeps
+# check-ci-unit-forced-execution.sh satisfied on the full path.
+#
+# TWO round-1 defects are fixed here.
+#
+# B3 — the emitted `:app` filter was `com.pocketshell.app.*Test`, and Gradle's
+# `*` CROSSES package dots (the reviewer proved it: `--tests
+# "com.pocketshell.app.*UsageWindowLabelTest"` ran
+# `com.pocketshell.app.usage.UsageWindowLabelTest`). That one pattern therefore
+# matched all 485 `:app` unit classes — 74% of unit test-case time — on every
+# push, including the docs-only floor, so the plan's reported class count was
+# not the number the command executed. There are no wildcards left: the plan
+# emits EXACT fully-qualified class names, which cannot over- or under-match.
+#
+# B5 — the area -> `:shared:…:test` map was a hardcoded `case` no guard covered,
+# so renaming one area token silently dropped a module's tests while both guards
+# stayed green. Module tasks are now derived from the selected classes' own
+# paths, so a module can only drop out by having no selected class.
+plan_gradle_unit() {
+  if [[ "$SELECT_MODE" == "full" ]]; then
+    printf 'UNIT_MODE=full\n'
+    printf 'UNIT_GRADLE_TASKS=test\n'
+    printf 'UNIT_GRADLE_FILTERS=\n'
+    printf 'UNIT_SHARED_TASKS=\n'
+    printf 'UNIT_SELECTED_UNIT_CLASSES=%s\n' "$(unit_class_total)"
+    printf 'UNIT_TOTAL_UNIT_CLASSES=%s\n' "$(unit_class_total)"
+    return
+  fi
+  pocketshell_test_areas_build_index
+  local -A shared_tasks=()
+  local -a app_unit=()
+  local fqcn mod total=0
+  for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+    # `test` / `:app:test` runs the JVM unit source sets only; androidTest and
+    # integrationTest classes belong to the emulator and Docker lanes.
+    is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$fqcn]}" || continue
+    total=$((total + 1))
+    class_selected "$fqcn" || continue
+    mod="${POCKETSHELL_TA_CLASS_MODULE[$fqcn]}"
+    if [[ "$mod" == ":app" ]]; then
+      app_unit+=("$fqcn")
+    else
+      shared_tasks["$mod:test"]=1
+    fi
+  done
+  printf 'UNIT_MODE=scoped\n'
+  printf 'UNIT_SHARED_TASKS=%s\n' \
+    "$( [[ "${#shared_tasks[@]}" -gt 0 ]] && printf '%s\n' "${!shared_tasks[@]}" | LC_ALL=C sort | tr '\n' ' ' | sed 's/ $//' )"
+  # No selected :app unit class => NO :app task. `--tests` with a filter that
+  # matches nothing makes Gradle fail the task ("No tests found for given
+  # includes"), and a CI job that dies on an empty selection is a worse failure
+  # mode than running too much.
+  if [[ "${#app_unit[@]}" -gt 0 ]]; then
+    printf 'UNIT_GRADLE_TASKS=:app:test\n'
+  else
+    printf 'UNIT_GRADLE_TASKS=\n'
+  fi
+  printf 'UNIT_GRADLE_FILTERS=%s\n' \
+    "$( [[ "${#app_unit[@]}" -gt 0 ]] && printf '%s\n' "${app_unit[@]}" | LC_ALL=C sort | tr '\n' ' ' | sed 's/ $//' )"
+  printf 'UNIT_SELECTED_UNIT_CLASSES=%s\n' "$(( ${#app_unit[@]} + $(shared_selected_unit_class_count) ))"
+  printf 'UNIT_TOTAL_UNIT_CLASSES=%s\n' "$total"
+}
+
+unit_class_total() {
+  pocketshell_test_areas_build_index
+  local fqcn n=0
+  for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+    is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$fqcn]}" && n=$((n + 1))
+  done
+  printf '%s\n' "$n"
+}
+
+# Shared-module unit classes actually reached by the emitted module tasks: the
+# task is unfiltered, so EVERY unit class in a selected module runs.
+shared_selected_unit_class_count() {
+  local fqcn mod n=0
+  local -A mods=()
+  for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+    is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$fqcn]}" || continue
+    mod="${POCKETSHELL_TA_CLASS_MODULE[$fqcn]}"
+    [[ "$mod" == ":app" ]] && continue
+    class_selected "$fqcn" && mods["$mod"]=1
+  done
+  for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+    is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$fqcn]}" || continue
+    mod="${POCKETSHELL_TA_CLASS_MODULE[$fqcn]}"
+    [[ -n "${mods[$mod]:-}" ]] && n=$((n + 1))
+  done
+  printf '%s\n' "$n"
+}
+
+# Journey classes selected for this run.
+plan_journeys() {
+  pocketshell_test_areas_build_index
+  local fqcn
+  while IFS= read -r fqcn; do
+    [[ -z "$fqcn" ]] && continue
+    class_selected "$fqcn" && printf '%s\n' "$fqcn"
+  done < <(journey_registry_classes)
+}
+
+print_plan() {
+  echo "== select-test-areas: changed-path classification =="
+  if [[ "${#SELECT_CLASSIFICATION[@]}" -eq 0 ]]; then
+    echo "  (no changed paths)"
+  else
+    printf '  %s\n' "${SELECT_CLASSIFICATION[@]}"
+  fi
+  echo
+  echo "== decision: ${SELECT_MODE^^} =="
+  if [[ "${#SELECT_FULL_REASONS[@]}" -gt 0 ]]; then
+    echo "  force-full reasons:"
+    printf '    %s\n' "${SELECT_FULL_REASONS[@]}"
+  fi
+  if [[ "${#SELECT_UNMAPPED[@]}" -gt 0 ]]; then
+    echo
+    echo "::error title=Unmapped path (issue #2063)::These paths match no rule in scripts/test-areas.txt. The run fell back to FULL (fail-safe), but the manifest must be extended so the map lags loudly rather than silently:"
+    printf '    %s\n' "${SELECT_UNMAPPED[@]}"
+  fi
+  echo
+  echo "== selected areas =="
+  printf '  %s\n' $SELECT_AREAS
+  echo "  (changed: ${SELECT_SEED_AREAS:-<none — always-tier floor only>})"
+  echo
+  echo "== unit plan =="
+  plan_gradle_unit | sed 's/^/  /'
+  echo
+  local -a j=()
+  mapfile -t j < <(plan_journeys)
+  local total
+  total="$(journey_registry_classes | wc -l | tr -d ' ')"
+  echo "== journey plan =="
+  echo "  ${#j[@]} of $total registered journey classes"
+  printf '    %s\n' "${j[@]:-}"
+}
+
+print_plan_only() {
+  printf 'MODE=%s\n' "$SELECT_MODE"
+  printf 'AREAS=%s\n' "$SELECT_AREAS"
+  printf 'CHANGED_AREAS=%s\n' "$SELECT_SEED_AREAS"
+  printf 'UNMAPPED_COUNT=%s\n' "${#SELECT_UNMAPPED[@]}"
+  plan_gradle_unit
+  printf 'JOURNEY_CLASSES=%s\n' "$(plan_journeys | tr '\n' ',' | sed 's/,$//')"
+}
+
+# ---------------------------------------------------------------------------
+# GUARD: --verify-manifest
+#
+# The manifest must be TOTAL over the tracked tree. Anything it does not
+# classify falls back to FULL at runtime, which is safe but silent; this guard
+# is what makes it loud instead.
+# ---------------------------------------------------------------------------
+verify_manifest() {
+  local failures=0
+  echo "== verify-manifest =="
+  echo "manifest: $MANIFEST"
+
+  if [[ "$MANIFEST_OK" -ne 1 ]]; then
+    printf 'FAIL: manifest did not load:\n'
+    printf '  %s\n' "${POCKETSHELL_TA_LOAD_ERRORS[@]}"
+    return 1
+  fi
+
+  # 1. Totality over every tracked file.
+  local -a unmapped=()
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    pocketshell_test_area_classify "$f"
+    case "$POCKETSHELL_TEST_AREA_REASON" in
+      unmapped-path|unmapped-test-path) unmapped+=("$f") ;;
+    esac
+  done < <(tracked_files)
+  if [[ "${#unmapped[@]}" -gt 0 ]]; then
+    echo "FAIL: ${#unmapped[@]} tracked path(s) match no manifest rule (they fall back to FULL):"
+    printf '  %s\n' "${unmapped[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK: manifest is total over $(tracked_files | wc -l | tr -d ' ') tracked paths"
+  fi
+
+  # 2. Every test class resolves to exactly one area — asked of the SAME
+  #    resolver the ledger guard uses (finding B4: round 1 had two resolvers,
+  #    this one green by path and the ledger's red by FQCN for 183 classes).
+  pocketshell_test_areas_build_index
+  local -a classless=()
+  local fqcn path
+  for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+    if ! pocketshell_test_area_for_class "$fqcn" >/dev/null; then
+      classless+=("$fqcn (${POCKETSHELL_TA_CLASS_PATH[$fqcn]})")
+    fi
+  done
+  if [[ "${#classless[@]}" -gt 0 ]]; then
+    echo "FAIL: ${#classless[@]} test class(es) belong to no area:"
+    printf '  %s\n' "${classless[@]}" | LC_ALL=C sort
+    failures=$((failures + 1))
+  else
+    echo "OK: every tracked test class resolves to exactly one area (${POCKETSHELL_TA_INDEX_CLASSES} classes, one resolver)"
+  fi
+
+  # 3. Every registered journey class resolves to an area.
+  local -a journeyless=()
+  while IFS= read -r fqcn; do
+    [[ -z "$fqcn" ]] && continue
+    if ! pocketshell_test_area_for_class "$fqcn" >/dev/null; then
+      journeyless+=("$fqcn")
+    fi
+  done < <(journey_registry_classes)
+  if [[ "${#journeyless[@]}" -gt 0 ]]; then
+    echo "FAIL: ${#journeyless[@]} registered journey class(es) resolve to no area:"
+    printf '  %s\n' "${journeyless[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK: every registered journey class resolves to an area ($(journey_registry_classes | wc -l | tr -d ' ') classes)"
+  fi
+
+  # 4. No declared area is a ghost (declared but reachable from nothing).
+  local -A reachable=()
+  local i
+  for i in "${!POCKETSHELL_TA_SRC_AREA[@]}"; do reachable["${POCKETSHELL_TA_SRC_AREA[$i]}"]=1; done
+  for i in "${!POCKETSHELL_TA_TEST_AREA[@]}"; do reachable["${POCKETSHELL_TA_TEST_AREA[$i]}"]=1; done
+  local -a ghosts=() a
+  for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+    [[ -z "${reachable[$a]:-}" ]] && ghosts+=("$a")
+  done
+  if [[ "${#ghosts[@]}" -gt 0 ]]; then
+    echo "FAIL: declared area(s) named by no src/test rule: ${ghosts[*]}"
+    failures=$((failures + 1))
+  else
+    echo "OK: all ${#POCKETSHELL_TA_AREAS[@]} declared areas are reachable from a rule"
+  fi
+
+  # 5. Hidden test classes. Every registry, guard and Gradle filter in this
+  #    repo keys off the `*Test.kt` / `*Test.java` naming convention, so a
+  #    @Test-bearing class that does not follow it is invisible to all of them —
+  #    the #1851 shape. Five exist today (four screenshot harnesses and the
+  #    ui-kit render target); they are baselined by name so a NEW one fails.
+  #    Baselining is per FILE, deliberately, not by a `*Harness.kt` suffix rule:
+  #    a suffix would be a self-serve escape hatch (name a real regression test
+  #    `…Harness.kt` and it hides), whereas a name list forces a reviewed
+  #    decision each time. #2065 tracks the general problem.
+  local -a KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES=(
+    "app/src/androidTest/java/com/pocketshell/app/composer/Issue1622DeadBandScreenshotHarness.kt"
+    "app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeDeadSpaceScreenshotHarness.kt"
+    "app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt"
+    "app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherLargeFontScreenshotHarness.kt"
+    "shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt"
+  )
+  local -a hidden_new=() hidden_stale=()
+  local -A hidden_seen=()
+  local known
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    pocketshell_test_areas_is_test_path "$f" || continue
+    pocketshell_test_areas_is_test_class_file "$f" && continue
+    grep -qE '^[[:space:]]*@Test([[:space:]]|\(|$)' "$REPO_ROOT/$f" 2>/dev/null || continue
+    hidden_seen["$f"]=1
+    local pinned=0
+    for known in "${KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES[@]}"; do
+      [[ "$f" == "$known" ]] && pinned=1 && break
+    done
+    [[ "$pinned" -eq 0 ]] && hidden_new+=("$f")
+  done < <(tracked_files)
+  for known in "${KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES[@]}"; do
+    [[ -z "${hidden_seen[$known]:-}" ]] && hidden_stale+=("$known")
+  done
+  if [[ "${#hidden_new[@]}" -gt 0 ]]; then
+    echo "FAIL: ${#hidden_new[@]} @Test-bearing file(s) do not follow the *Test.kt/*Test.java convention, so no registry or filter can see them:"
+    printf '  %s\n' "${hidden_new[@]}"
+    failures=$((failures + 1))
+  elif [[ "${#hidden_stale[@]}" -gt 0 ]]; then
+    echo "FAIL: stale baseline — these no longer carry @Test or no longer exist; drop them from KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES:"
+    printf '  %s\n' "${hidden_stale[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK: no new @Test-bearing file outside the *Test.kt/*Test.java convention (${#KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES[@]} baselined)"
+  fi
+
+  # 6. The `noop` premise: no test source reads a repo doc/markdown file at
+  #    runtime. If one ever does, docs stop being inert and the noop rows are
+  #    wrong — fail here rather than skip that test forever.
+  local doc_readers
+  # Every test source set, including the integrationTest sets round 1's version
+  # of this grep missed (a completeness nit the reviewer flagged; the premise
+  # holds either way, but a guard with a blind spot is how premises rot).
+  doc_readers="$(grep -rnE --include='*.kt' --include='*.java' \
+    '(File|Paths\.get|resolve)\([^)]*"(docs/|mockups/|AGENTS\.md|process\.md|README\.md|CLAUDE\.md)' \
+    "$REPO_ROOT"/app/src/test "$REPO_ROOT"/app/src/androidTest "$REPO_ROOT"/app/src/integrationTest \
+    "$REPO_ROOT"/shared/*/src/test "$REPO_ROOT"/shared/*/src/androidTest \
+    "$REPO_ROOT"/shared/*/src/integrationTest 2>/dev/null || true)"
+  if [[ -n "$doc_readers" ]]; then
+    echo "FAIL: a test reads a repo doc at runtime, so 'noop docs/*' is no longer true:"
+    printf '  %s\n' "$doc_readers"
+    failures=$((failures + 1))
+  else
+    echo "OK: no test source reads a repo doc/markdown file at runtime (noop premise holds)"
+  fi
+
+  # 7. The dependency index actually RAN and is populated.
+  #
+  #    Everything the selection now narrows on rests on this index. If the grep
+  #    silently matched nothing (marker renamed, source layout moved, `xargs`
+  #    behaving differently), every dependency set would collapse to "own area
+  #    only" and the selection would quietly go back to being under-inclusive —
+  #    green, and wrong, which is exactly the round-1 shape. These floors are
+  #    deliberately far below today's values: they detect a broken mechanism,
+  #    not normal drift.
+  #
+  #    ROUND-2 FINDING B7: the two host-CLI floors used to be `>= 1`, and the
+  #    reviewer cut the seam from 15 packages / 569 classes to 9 / 210 — a 63%
+  #    narrowing of the coupling that protects the single most expensive break in
+  #    this repo's history — with every check and every invariant still green. A
+  #    `>= 1` floor only detects a TOTALLY dead mechanism, and a heuristic over
+  #    source text is the component most likely to narrow quietly. Every floor
+  #    below is now in the same spirit as its siblings, and the seam is floored
+  #    PER END, because the round-2 defect (B6) was precisely a healthy-looking
+  #    total (15 packages) hiding one whole end at zero — nothing in `shared/*`.
+  local -a index_fail=()
+  [[ "$POCKETSHELL_TA_INDEX_CLASSES"      -ge 500 ]] || index_fail+=("indexed test classes = $POCKETSHELL_TA_INDEX_CLASSES (< 500)")
+  [[ "$POCKETSHELL_TA_INDEX_PROD_PKGS"    -ge 30  ]] || index_fail+=("production packages mapped = $POCKETSHELL_TA_INDEX_PROD_PKGS (< 30)")
+  [[ "$POCKETSHELL_TA_INDEX_IMPORT_LINES" -ge 1000 ]] || index_fail+=("com.pocketshell import lines scanned = $POCKETSHELL_TA_INDEX_IMPORT_LINES (< 1000)")
+  [[ "$POCKETSHELL_TA_INDEX_CROSS_AREA_CLASSES" -ge 200 ]] || index_fail+=("test classes with a cross-area production dependency = $POCKETSHELL_TA_INDEX_CROSS_AREA_CLASSES (< 200)")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS" -ge 12 ]] || index_fail+=("host-CLI wire-seam PRODUCER packages = $POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS (< 12) — the invoke marker /$POCKETSHELL_TA_HOSTCLI_MARKER/ has narrowed (#847 lockstep coupling)")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS" -ge 15 ]] || index_fail+=("host-CLI wire-seam CONSUMER packages = $POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS (< 15) — the reply end of the wire has narrowed (finding B6)")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS" -ge 14 ]] || index_fail+=("host-CLI wire-seam VOCABULARY packages = $POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS (< 14) — packages naming a real subcommand have narrowed")
+  # ROUND-3 FINDING B9. A floor on the extracted count cannot see the failure
+  # that actually happened: the extractor read ONE of the registration forms
+  # `cli.py` uses, so it under-read the producer on the shipped tree while
+  # printing a healthy-looking 16. Four more registrations moved to the form
+  # `daemon` already used would have dropped `usage`/`tree`/`agents`/`qr-share`
+  # from the vocabulary, taken `com.pocketshell.app.settings` off the seam and
+  # cut unit selection 570 -> 560 with every floor still green. Under-reading
+  # produces a plausible number, and no floor distinguishes a plausible number
+  # from the right one. EQUALITY does: the reader counts registration SITES
+  # independently of the names it resolves, so a form it cannot decode raises
+  # one and not the other.
+  #
+  # The site floor survives with a narrower job — it is the only thing that
+  # catches a totally dead reader, because `names == sites` is vacuous at 0 == 0.
+  #
+  # ROUND-5 FINDING. Equality was still satisfiable vacuously by a whole class of
+  # registration: the reader keyed detection on the receiver being the literal
+  # name `cli`, so `_g = cli; _g.add_command(…)` — or a helper taking the group
+  # as a parameter — was neither a SITE nor a NAME. Six rounds closed six
+  # spellings one at a time; the space of ways to name an object is unbounded, so
+  # the reader is now receiver-AGNOSTIC: it takes a CENSUS of every registrar call
+  # in the file and each one must resolve to the root group, be proven to be on a
+  # different object, or be reported unresolved. This identity is what says the
+  # census is total — if it holds, no registrar call escaped all three counters.
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SCANNED" -eq $((POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES + POCKETSHELL_TA_INDEX_HOSTCLI_CLI_NONROOT + POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED)) ]] || index_fail+=("host-CLI registrar census in $POCKETSHELL_TA_HOSTCLI_CLI_SOURCE does not balance: $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SCANNED calls scanned but $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES top-level + $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_NONROOT non-root + $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED unresolved classified — a registration fell out of the census, which is how under-reading stays silent")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED" -eq 0 ]] || index_fail+=("host-CLI vocabulary reader could not resolve the receiver of $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED registrar call(s) in $POCKETSHELL_TA_HOSTCLI_CLI_SOURCE — each one might be registering a top-level subcommand the seam cannot see")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES" -ge 12 ]] || index_fail+=("host-CLI registration SITES found in $POCKETSHELL_TA_HOSTCLI_CLI_SOURCE = $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES (< 12) — the producer-side vocabulary reader is dead, so the vocabulary end of the seam is blind")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_SUBCOMMANDS" -eq "$POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES" ]] || index_fail+=("host-CLI subcommand names read = $POCKETSHELL_TA_INDEX_HOSTCLI_SUBCOMMANDS but registration SITES in $POCKETSHELL_TA_HOSTCLI_CLI_SOURCE = $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES — the reader is UNDER-READING the producer (finding B9), so part of the wire vocabulary is invisible to the seam")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE" -eq 0 ]] || index_fail+=("host-CLI vocabulary reader could not decode $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNREADABLE registration(s) in $POCKETSHELL_TA_HOSTCLI_CLI_SOURCE: $POCKETSHELL_TA_INDEX_HOSTCLI_CLI_DIAG")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS" -ge 8 ]] || index_fail+=("host-CLI wire-seam packages under shared/ = $POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS (< 8) — this is EXACTLY the B6 defect: it was 0 while the total looked healthy, and :shared:core-usage:test (the strict parser of \`pocketshell usage --json\`) did not run on a host-CLI change")
+  [[ "$POCKETSHELL_TA_INDEX_HOSTCLI_CLASSES" -ge 600 ]] || index_fail+=("test classes depending on the host CLI = $POCKETSHELL_TA_INDEX_HOSTCLI_CLASSES (< 600) — #1509 / the usage parser would stop running on a tools/pocketshell change")
+  if [[ "${#index_fail[@]}" -gt 0 ]]; then
+    echo "FAIL: the import-dependency index looks broken, so selection would under-run:"
+    printf '  %s\n' "${index_fail[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK: dependency index populated (${POCKETSHELL_TA_INDEX_CLASSES} classes, ${POCKETSHELL_TA_INDEX_PROD_PKGS} production packages, ${POCKETSHELL_TA_INDEX_IMPORT_LINES} imports, ${POCKETSHELL_TA_INDEX_CROSS_AREA_CLASSES} cross-area, ${POCKETSHELL_TA_INDEX_HOSTCLI_CLASSES} host-CLI-dependent via ${POCKETSHELL_TA_INDEX_HOSTCLI_PKGS} wire-seam packages = ${POCKETSHELL_TA_INDEX_HOSTCLI_INVOKER_PKGS} producer / ${POCKETSHELL_TA_INDEX_HOSTCLI_CONSUMER_PKGS} consumer / ${POCKETSHELL_TA_INDEX_HOSTCLI_VOCAB_PKGS} vocabulary over ${POCKETSHELL_TA_INDEX_HOSTCLI_SUBCOMMANDS} subcommands read from the ${POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SITES} top-level registration sites this reader could see in ${POCKETSHELL_TA_HOSTCLI_CLI_SOURCE} — a census of ${POCKETSHELL_TA_INDEX_HOSTCLI_CLI_SCANNED} registrar calls, ${POCKETSHELL_TA_INDEX_HOSTCLI_CLI_NONROOT} of them resolved to a non-root receiver and ${POCKETSHELL_TA_INDEX_HOSTCLI_CLI_UNCLASSIFIED} unresolved — ${POCKETSHELL_TA_INDEX_HOSTCLI_SHARED_PKGS} of them under shared/)"
+  fi
+
+  # 8. Every Gradle test task the planner can emit is a real Gradle project.
+  #
+  #    Finding B5: the area -> module-task map used to be a hardcoded `case` no
+  #    guard covered, so renaming one area token dropped `:shared:core-usage:test`
+  #    while both guards stayed green. The map is derived from class paths now,
+  #    and this check closes the other end: a derived task name that no
+  #    `include(...)` backs would fail the CI run, not this guard, so assert it
+  #    here where it is cheap.
+  local -a task_fail=() derived_tasks=()
+  local -A modules=()
+  for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+    is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$fqcn]}" || continue
+    modules["${POCKETSHELL_TA_CLASS_MODULE[$fqcn]}"]=1
+  done
+  local m
+  for m in "${!modules[@]}"; do
+    derived_tasks+=("$m")
+    grep -qF "include(\"$m\")" "$REPO_ROOT/settings.gradle.kts" 2>/dev/null || \
+      task_fail+=("$m:test — no include(\"$m\") in settings.gradle.kts")
+  done
+  if [[ "${#task_fail[@]}" -gt 0 ]]; then
+    echo "FAIL: ${#task_fail[@]} derived unit test task(s) name a project Gradle does not have:"
+    printf '  %s\n' "${task_fail[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK: all ${#derived_tasks[@]} derived unit test module(s) exist in settings.gradle.kts"
+  fi
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo
+    echo "::error title=Test-area manifest (issue #2063)::$failures manifest check(s) failed. Extend scripts/test-areas.txt."
+    return 1
+  fi
+  echo
+  echo "PASS: manifest verified."
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# GUARD: --coverage-invariant
+#
+# The maintainer's non-negotiable: "I still want the same coverage." This
+# asserts it mechanically instead of eyeballing it.
+#
+#   I1  every test class belongs to exactly one area          (verify-manifest)
+#   I2  the union of per-area test sets == every test class
+#   I3  touching an area selects that area's own tests
+#   I4  the FULL selection == every test class and every journey
+#   I5  the smallest possible selection (a noop-only diff) is still non-empty
+#       and contains every always-tier test
+#   I6  the union over the whole cadence window == every test class
+# ---------------------------------------------------------------------------
+# Invariant filter. Exists ONLY so a self-test mutation can drive the one
+# invariant it targets without paying for the other nine; the guard as CI runs
+# it is always unfiltered, and a filtered run labels itself in the verdict so a
+# partial pass can never be mistaken for the whole thing.
+want_inv() {
+  [[ -z "$ONLY_INVARIANTS" ]] && return 0
+  [[ ",$ONLY_INVARIANTS," == *",$1,"* ]]
+}
+
+coverage_invariant() {
+  local failures=0
+  echo "== coverage-invariant =="
+  if [[ -n "$ONLY_INVARIANTS" ]]; then
+    echo "FILTERED to: $ONLY_INVARIANTS (self-test mutation mode — NOT the full guard)"
+    local want
+    for want in ${ONLY_INVARIANTS//,/ }; do
+      case "$want" in
+        I2|I3|I4|I5|I6|I7|I8|I9|I10|I11) : ;;
+        *) echo "FAIL: --only names unknown invariant '$want'"; return 1 ;;
+      esac
+    done
+  fi
+
+  if [[ "$MANIFEST_OK" -ne 1 ]]; then
+    echo "FAIL: manifest did not load"
+    return 1
+  fi
+
+  # Build class -> area once, from THE resolver.
+  pocketshell_test_areas_build_index
+  local -A class_area=()
+  local -A area_classes=()
+  local fqcn path a2
+  local total_classes=0
+  for fqcn in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+    total_classes=$((total_classes + 1))
+    pocketshell_test_area_for_class "$fqcn" >/dev/null
+    a2="$POCKETSHELL_TEST_AREA_FOR_CLASS"
+    if [[ -z "$a2" ]]; then
+      class_area["$fqcn"]="__NONE__"
+      continue
+    fi
+    class_area["$fqcn"]="$a2"
+    area_classes["$a2"]="${area_classes[$a2]:-} $fqcn"
+  done
+
+if want_inv I2; then
+    # I2: union of per-area sets == all classes.
+    local union=0 a
+    for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+      # shellcheck disable=SC2086
+      set -- ${area_classes[$a]:-}
+      union=$((union + $#))
+    done
+    if [[ "$union" -ne "$total_classes" ]]; then
+      echo "FAIL I2: union of per-area test sets is $union, but the repo has $total_classes test classes"
+      failures=$((failures + 1))
+    else
+      echo "OK I2: union of the ${#POCKETSHELL_TA_AREAS[@]} per-area test sets == all $total_classes test classes"
+    fi
+  fi
+
+
+  # I3: for every area, a change to one of its own paths selects it (and hence
+  #     its whole test set). Driven through the REAL selection function, using
+  #     a real tracked path per area, so this cannot pass on a stub.
+  #     One representative per area, found by classifying each tracked
+  #     DIRECTORY's first file rather than all 2079 files (same answer, a third
+  #     of the time, and this guard runs several times per self-test).
+  local -A rep=() dir_seen=()
+  local f d
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    d="${f%/*}"
+    [[ -n "${dir_seen[$d]:-}" ]] && continue
+    dir_seen["$d"]=1
+    pocketshell_test_area_classify "$f"
+    [[ "$POCKETSHELL_TEST_AREA_KIND" == "area" ]] || continue
+    [[ -z "${rep[$POCKETSHELL_TEST_AREA_NAME]:-}" ]] && rep["$POCKETSHELL_TEST_AREA_NAME"]="$f"
+  done < <(tracked_files)
+  local -a i3_fail=()
+  for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+    if [[ -z "${rep[$a]:-}" ]]; then i3_fail+=("$a (no tracked path resolves to it)"); continue; fi
+    run_selection <<<"${rep[$a]}"
+    area_selected "$a" || i3_fail+=("$a (changing ${rep[$a]} did not select it)")
+  done
+  if [[ "${#i3_fail[@]}" -gt 0 ]]; then
+    echo "FAIL I3: ${#i3_fail[@]} area(s) are not selected by a change to their own paths:"
+    printf '  %s\n' "${i3_fail[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK I3: every area is selected by a change to one of its own tracked paths"
+  fi
+
+  # I4: the FULL selection covers every class and every journey.
+  run_selection <<<"scripts/ci-journey-suite.sh"
+  if [[ "$SELECT_MODE" != "full" ]]; then
+    echo "FAIL I4: a scripts/ change did not force a full run"
+    failures=$((failures + 1))
+  fi
+  local full_area_count=0
+  for a in $SELECT_AREAS; do full_area_count=$((full_area_count + 1)); done
+  if [[ "$full_area_count" -ne "${#POCKETSHELL_TA_AREAS[@]}" ]]; then
+    echo "FAIL I4: full mode selected $full_area_count areas, expected ${#POCKETSHELL_TA_AREAS[@]}"
+    failures=$((failures + 1))
+  fi
+  local full_journeys registry_journeys
+  full_journeys="$(plan_journeys | wc -l | tr -d ' ')"
+  registry_journeys="$(journey_registry_classes | wc -l | tr -d ' ')"
+  if [[ "$full_journeys" -ne "$registry_journeys" ]]; then
+    echo "FAIL I4: full mode selected $full_journeys journeys, registry has $registry_journeys"
+    failures=$((failures + 1))
+  else
+    echo "OK I4: full mode selects all ${#POCKETSHELL_TA_AREAS[@]} areas and all $registry_journeys registered journeys"
+  fi
+
+  # I5: the smallest possible selection. A docs-only diff is the minimum, and
+  #     it must still be non-empty and contain the whole always tier.
+  run_selection <<<"docs/testing.md"
+  if [[ "$SELECT_MODE" != "scoped" ]]; then
+    echo "FAIL I5: a docs-only diff did not produce a scoped run (got $SELECT_MODE)"
+    failures=$((failures + 1))
+  fi
+  local -a i5_fail=()
+  local min_count=0
+  for a in $SELECT_AREAS; do min_count=$((min_count + 1)); done
+  [[ "$min_count" -eq 0 ]] && i5_fail+=("the minimum selection is EMPTY — 'run nothing' is reachable")
+  for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+    [[ "${POCKETSHELL_TA_AREA_TIER[$a]}" == "always" ]] || continue
+    area_selected "$a" || i5_fail+=("always-tier area '$a' missing from the minimum selection")
+  done
+  if [[ "${#i5_fail[@]}" -gt 0 ]]; then
+    printf 'FAIL I5: %s\n' "${i5_fail[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK I5: the minimum selection is $min_count areas and contains every always-tier area"
+  fi
+
+  # I6: the cadence union. For every tracked path, the selection it triggers is
+  #     computed and its area set unioned; that union must be every area (hence
+  #     every test class, by I2). This is the mechanical statement of "coverage
+  #     is invariant, only the *when* changed".
+  #
+  #     Computed over one representative path per area plus one force-full path
+  #     plus the always tier — the selection function is a pure function of the
+  #     area set, so per-area representatives are exhaustive over its range.
+  local -A cadence=()
+  for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+    [[ -z "${rep[$a]:-}" ]] && continue
+    run_selection <<<"${rep[$a]}"
+    local s
+    for s in $SELECT_AREAS; do cadence["$s"]=1; done
+  done
+  local -a missing=()
+  for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+    [[ -z "${cadence[$a]:-}" ]] && missing+=("$a")
+  done
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    echo "FAIL I6: over the per-push cadence window these areas are never selected: ${missing[*]}"
+    echo "        (they would only ever run nightly / at the release gate)"
+    failures=$((failures + 1))
+  else
+    echo "OK I6: over the per-push cadence window the selected-area union == all ${#POCKETSHELL_TA_AREAS[@]} areas == all $total_classes test classes"
+  fi
+
+if want_inv I7; then
+    # I7: the same statement at CLASS granularity. Selection is now per test
+    #     class, so an area-level union is no longer the thing that has to be
+    #     total — every individual CLASS must be selected by at least one change
+    #     inside the per-push cadence window, or it only ever runs nightly.
+    local -A cadence_classes=()
+    local c
+    for a in "${POCKETSHELL_TA_AREAS[@]}"; do
+      [[ -z "${rep[$a]:-}" ]] && continue
+      run_selection <<<"${rep[$a]}"
+      for c in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+        [[ -n "${cadence_classes[$c]:-}" ]] && continue
+        class_selected "$c" && cadence_classes["$c"]=1
+      done
+    done
+    local -a never_selected=()
+    for c in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+      [[ -z "${cadence_classes[$c]:-}" ]] && never_selected+=("$c")
+    done
+    if [[ "${#never_selected[@]}" -gt 0 ]]; then
+      echo "FAIL I7: ${#never_selected[@]} test class(es) are selected by NO change in the per-push cadence window:"
+      printf '  %s\n' "${never_selected[@]}" | LC_ALL=C sort | head -40
+      failures=$((failures + 1))
+    else
+      echo "OK I7: every one of the $total_classes test classes is selected by at least one per-push change"
+    fi
+  fi
+
+
+if want_inv I8; then
+    # I8: INDEPENDENT blast-radius escape scan (the reviewer's B2 oracle, promoted
+    #     into the guard). For every registered journey this re-greps the class's
+    #     own imports and re-maps them through `pocketshell_test_area_classify` —
+    #     it does NOT read the dependency index — then asserts a change to that
+    #     production area actually selects the journey. If the index ever stops
+    #     being built, or someone reverts to hand-listed area couples, this goes
+    #     red naming the escape.
+    local -A area_selection_cache=()
+    local -a escapes=()
+    local j jf imp p pa probe
+    while IFS= read -r j; do
+      [[ -z "$j" ]] && continue
+      jf="${POCKETSHELL_TA_CLASS_PATH[$j]:-}"
+      [[ -z "$jf" || ! -f "$REPO_ROOT/$jf" ]] && continue
+      while IFS= read -r imp; do
+        imp="${imp#*import }"
+        imp="${imp%%[!A-Za-z0-9_.]*}"
+        p="$imp"; pa=""
+        while [[ "$p" == *.* ]]; do
+          p="${p%.*}"
+          if [[ -n "${POCKETSHELL_TA_PROD_PKG_AREA[$p]:-}" ]]; then pa="${POCKETSHELL_TA_PROD_PKG_AREA[$p]}"; break; fi
+        done
+        [[ -z "$pa" ]] && continue
+        probe="${rep[$pa]:-}"
+        [[ -z "$probe" ]] && continue
+        if [[ -z "${area_selection_cache[$pa]:-}" ]]; then
+          run_selection <<<"$probe"
+          area_selection_cache["$pa"]="$SELECT_SEED_AREAS"
+        fi
+        SELECT_MODE="scoped"
+        SELECT_SEED_AREAS="${area_selection_cache[$pa]}"
+        class_selected "$j" || escapes+=("$j is NOT selected by a change to '$pa', which it imports ($imp)")
+      done < <(grep -hE '^[[:space:]]*import[[:space:]]+com\.pocketshell\.' "$REPO_ROOT/$jf" 2>/dev/null)
+    done < <(journey_registry_classes)
+    if [[ "${#escapes[@]}" -gt 0 ]]; then
+      printf '%s\n' "${escapes[@]}" | LC_ALL=C sort -u > /dev/null
+      echo "FAIL I8: $(printf '%s\n' "${escapes[@]}" | LC_ALL=C sort -u | wc -l | tr -d ' ') blast-radius escape(s) — a journey compiles against an area whose change does not run it:"
+      printf '%s\n' "${escapes[@]}" | LC_ALL=C sort -u | head -40 | sed 's/^/  /'
+      failures=$((failures + 1))
+    else
+      echo "OK I8: no registered journey escapes an area it imports (independent re-scan of every journey's imports)"
+    fi
+  fi
+
+
+  # I9: named regression pins. Each is a journey that a REAL past break needed,
+  #     paired with the area whose change must run it. I8 is the general rule;
+  #     these are the specific ones a future refactor must never silently lose,
+  #     and they fail loudly if the class is renamed or deleted rather than
+  #     quietly dropping out of the check.
+  #
+  #     Round-2 finding B6: this pin set was JOURNEYS ONLY, which is why nothing
+  #     stopped a UNIT-level lockstep consumer escaping. The strict, fail-loud
+  #     reader of `pocketshell usage --json` is a plain JVM test in a shared
+  #     module, and it was not run by a change to the Python that produces that
+  #     NDJSON. UNIT_PINS below closes that half; they are checked against the
+  #     indexed class set rather than the journey registry.
+  local -a UNIT_PINS=(
+    # #1318 / #847: PocketshellUsageJsonParser is deliberately STRICT — any
+    # schema drift in tools/pocketshell/src/pocketshell/usage.py throws and the
+    # whole usage panel errors. The producer of that NDJSON must run it.
+    "com.pocketshell.core.usage.PocketshellUsageJsonParserTest|host-cli"
+    # core-storage: HostEntity carries the CLI lockstep version columns
+    # (pocketshellCliVersion / pocketshellExpectedCliVersion) and its schema
+    # test is what a version-contract change breaks. The round-2 reviewer asked
+    # for this to be audited rather than assumed; it resolves through the
+    # consumer end (core.storage.entity), not by hand.
+    "com.pocketshell.core.storage.AppDatabaseTest|host-cli"
+    # ui-kit: the models that mirror what the CLI writes — HostSetupState
+    # (CLI missing / incompatible) and SessionAgentKind (the `pocketshell agent`
+    # strings), both in com.pocketshell.uikit.model.
+    "com.pocketshell.uikit.model.SessionAgentKindOptionTest|host-cli"
+  )
+  local -a PINS=(
+    # #1509 G10 + #847 / v0.4.10: host-CLI/client version is a RUNTIME lockstep.
+    "com.pocketshell.app.projects.FolderListHostOutdatedTreeVersionDaemonDockerTest|host-cli"
+    "com.pocketshell.app.projects.FolderListOldCliHydrateDockerTest|host-cli"
+    # D28 connection core: journeys that drive transport production types.
+    "com.pocketshell.app.portfwd.ForwardingNetworkRideThroughE2eTest|connection-core"
+    "com.pocketshell.app.diagnostics.ConnectionLogHostMirrorReconnectDockerTest|connection-core"
+    "com.pocketshell.app.projects.Issue1876FolderListMobileRttDockerTest|connection-core"
+    "com.pocketshell.app.projects.ProfileChipRelaunchDockerTest|connection-core"
+    "com.pocketshell.app.hosts.HostResumeLastSessionE2eTest|connection-core"
+    "com.pocketshell.app.tmux.TmuxConnectingStatesScreenshotTest|connection-core"
+    "com.pocketshell.app.tmux.Issue1686QueueDrainWireOracleDockerTest|connection-core"
+  )
+  local -A registry=()
+  while IFS= read -r j; do [[ -n "$j" ]] && registry["$j"]=1; done < <(journey_registry_classes)
+  local -a pin_fail=() pin
+  for pin in "${PINS[@]}"; do
+    j="${pin%%|*}"; a="${pin##*|}"
+    if [[ -z "${registry[$j]:-}" ]]; then
+      pin_fail+=("$j is no longer in the journey registry — re-pin it or state why the coverage is gone")
+      continue
+    fi
+    probe="${rep[$a]:-}"
+    if [[ -z "$probe" ]]; then pin_fail+=("no tracked path represents area '$a'"); continue; fi
+    run_selection <<<"$probe"
+    class_selected "$j" || pin_fail+=("a change to '$a' ($probe) does NOT select $j")
+  done
+  # The UNIT half. Existence is checked against the indexed class set (these are
+  # plain JVM classes, not journey-registry entries), and the selection question
+  # is identical: a change to the pinned area must run them.
+  for pin in "${UNIT_PINS[@]}"; do
+    j="${pin%%|*}"; a="${pin##*|}"
+    if [[ -z "${POCKETSHELL_TA_CLASS_PATH[$j]:-}" ]]; then
+      pin_fail+=("$j is no longer a tracked test class — re-pin it or state why the coverage is gone")
+      continue
+    fi
+    probe="${rep[$a]:-}"
+    if [[ -z "$probe" ]]; then pin_fail+=("no tracked path represents area '$a'"); continue; fi
+    run_selection <<<"$probe"
+    if ! class_selected "$j"; then
+      pin_fail+=("a change to '$a' ($probe) does NOT select unit class $j")
+    elif is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$j]:-}"; then
+      # Selection is necessary but not sufficient: the emitted plan must also
+      # carry the class's Gradle module, or the guard is green while the run
+      # never touches it. That IS the concrete B6 symptom —
+      # `:shared:core-usage:test` absent from a `tools/pocketshell/**` plan.
+      local pin_mod="${POCKETSHELL_TA_CLASS_MODULE[$j]:-}"
+      local pin_tasks
+      pin_tasks="$(plan_gradle_unit | sed -n 's/^UNIT_SHARED_TASKS=//p')"
+      if [[ "$pin_mod" == :shared:* && " $pin_tasks " != *" ${pin_mod}:test "* ]]; then
+        pin_fail+=("a change to '$a' ($probe) selects $j but the emitted plan does NOT run ${pin_mod}:test")
+      fi
+    fi
+  done
+  if [[ "${#pin_fail[@]}" -gt 0 ]]; then
+    echo "FAIL I9: ${#pin_fail[@]} pinned blast-radius regression(s):"
+    printf '  %s\n' "${pin_fail[@]}"
+    failures=$((failures + 1))
+  else
+    echo "OK I9: all ${#PINS[@]} pinned lockstep/transport journeys and all ${#UNIT_PINS[@]} pinned unit lockstep consumers run on a change to the area that breaks them (unit pins also assert their module's task is in the emitted plan)"
+  fi
+
+if want_inv I10; then
+    # I10: THE EMITTED COMMAND IS THE PLAN.
+    #
+    #      Finding B3: round 1 reported a selected class count while emitting
+    #      `--tests com.pocketshell.app.*Test`, and Gradle's `*` crosses package
+    #      dots, so the command ran all 485 :app unit classes on every push. The
+    #      count and the command disagreed and nothing noticed. This asserts they
+    #      are the SAME set: every emitted `:app` filter is an exact FQCN of a
+    #      selected :app unit class, every selected :app unit class is emitted,
+    #      and no filter contains a glob metacharacter at all.
+    local -a i10_fail=()
+    local probe_path filters tok
+    for probe_path in "docs/testing.md" "${rep[usage-costs]:-}" "${rep[portfwd]:-}" "${rep[connection-core]:-}"; do
+      [[ -z "$probe_path" ]] && continue
+      run_selection <<<"$probe_path"
+      [[ "$SELECT_MODE" == "scoped" ]] || continue
+      filters="$(plan_gradle_unit | sed -n 's/^UNIT_GRADLE_FILTERS=//p')"
+      local -A emitted=()
+      local n_emitted=0 n_both_variants=0
+      for tok in $filters; do
+        case "$tok" in
+          *'*'*|*'?'*|*'['*)
+            i10_fail+=("[$probe_path] emitted filter '$tok' contains a glob metacharacter — Gradle's '*' crosses package dots (B3)")
+            continue ;;
+        esac
+        if [[ "${POCKETSHELL_TA_CLASS_MODULE[$tok]:-}" != ":app" ]] || \
+           ! is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$tok]:-}"; then
+          i10_fail+=("[$probe_path] emitted filter '$tok' is not an :app unit test class")
+          continue
+        fi
+        emitted["$tok"]=1
+        n_emitted=$((n_emitted + 1))
+        [[ "${POCKETSHELL_TA_CLASS_SOURCESET[$tok]}" == "test" ]] && n_both_variants=$((n_both_variants + 1))
+      done
+      # `:app:test` runs testDebugUnitTest AND testReleaseUnitTest with the SAME
+      # --tests set. A set consisting only of `testDebug`/`testRelease`-only
+      # classes would make the other variant fail with "No tests found for given
+      # includes" — CI red for a selection that is otherwise correct. At least one
+      # filter must name a class present in both variants.
+      if [[ "$n_emitted" -gt 0 && "$n_both_variants" -eq 0 ]]; then
+        i10_fail+=("[$probe_path] every emitted filter is variant-only; the other :app unit variant would fail with 'No tests found'")
+      fi
+      for c in "${!POCKETSHELL_TA_CLASS_PATH[@]}"; do
+        [[ "${POCKETSHELL_TA_CLASS_MODULE[$c]}" == ":app" ]] || continue
+        is_unit_source_set "${POCKETSHELL_TA_CLASS_SOURCESET[$c]}" || continue
+        if class_selected "$c"; then
+          [[ -n "${emitted[$c]:-}" ]] || i10_fail+=("[$probe_path] $c is selected but NOT in the emitted --tests filter")
+        else
+          [[ -z "${emitted[$c]:-}" ]] || i10_fail+=("[$probe_path] $c is emitted but not selected")
+        fi
+      done
+      unset emitted
+    done
+    if [[ "${#i10_fail[@]}" -gt 0 ]]; then
+      echo "FAIL I10: ${#i10_fail[@]} plan/command mismatch(es) — the reported selection is not what Gradle would run:"
+      printf '  %s\n' "${i10_fail[@]}" | head -20
+      failures=$((failures + 1))
+    else
+      echo "OK I10: the emitted :app --tests filter is exactly the selected :app unit class set, with no wildcards"
+    fi
+  fi
+
+
+if want_inv I11; then
+    # I11: every shared module is reachable by its OWN change.
+    #
+    #      Finding B5: the area -> `:shared:…:test` map was a hardcoded `case`, so
+    #      renaming an area token silently dropped `:shared:core-usage:test` while
+    #      --verify-manifest and --coverage-invariant both stayed green. Asserting
+    #      it per MODULE (not per area) is what makes the map's shape irrelevant.
+    local -A module_rep=()
+    while IFS= read -r f; do
+      [[ -z "$f" ]] && continue
+      case "$f" in shared/*/src/main/*) : ;; *) continue ;; esac
+      m="${f%%/src/*}"; m=":${m//\//:}"
+      [[ -z "${module_rep[$m]:-}" ]] && module_rep["$m"]="$f"
+    done < <(tracked_files)
+    local -a i11_fail=()
+    local tasks
+    for m in "${!module_rep[@]}"; do
+      # test-support publishes the settle pump and has no tests of its own.
+      [[ "$m" == ":shared:test-support" ]] && continue
+      run_selection <<<"${module_rep[$m]}"
+      if [[ "$SELECT_MODE" == "full" ]]; then continue; fi
+      tasks="$(plan_gradle_unit | sed -n 's/^UNIT_SHARED_TASKS=//p')"
+      [[ " $tasks " == *" $m:test "* ]] || \
+        i11_fail+=("changing ${module_rep[$m]} does not run $m:test (got: ${tasks:-<none>})")
+    done
+    if [[ "${#i11_fail[@]}" -gt 0 ]]; then
+      echo "FAIL I11: ${#i11_fail[@]} shared module(s) are not run by a change to their own source:"
+      printf '  %s\n' "${i11_fail[@]}"
+      failures=$((failures + 1))
+    else
+      echo "OK I11: every shared module's own change emits its own :test task (${#module_rep[@]} modules)"
+    fi
+  fi
+
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo
+    echo "::error title=Coverage invariant (issue #2063)::$failures invariant(s) failed — area selection would reduce what is ever executed."
+    return 1
+  fi
+  echo
+  if [[ -n "$ONLY_INVARIANTS" ]]; then
+    echo "PASS: invariants $ONLY_INVARIANTS hold (FILTERED run — not the full coverage guard)."
+  else
+    echo "PASS: coverage invariant holds."
+  fi
+  return 0
+}
+
+list_journeys() {
+  local fqcn area tier
+  printf '%-8s %-22s %s\n' "TIER" "AREA" "CLASS"
+  while IFS= read -r fqcn; do
+    [[ -z "$fqcn" ]] && continue
+    area="$(pocketshell_test_area_for_class "$fqcn")" || area="UNRESOLVED"
+    tier="${POCKETSHELL_TA_AREA_TIER[$area]:-always}"
+    printf '%-8s %-22s %s\n' "$tier" "$area" "$fqcn"
+  done < <(journey_registry_classes)
+}
+
+# Every class the cadence is responsible for: tracked test files UNION the
+# journey registry (a registry entry can name a second class living inside a
+# sibling's file). Same union the ledger guard registers, printed here so the
+# ledger's real-tree self-test can seed a complete ledger without a second,
+# divergent derivation of the class set.
+list_classes() {
+  pocketshell_test_areas_build_index
+  local fqcn area deps
+  {
+    printf '%s\n' "${!POCKETSHELL_TA_CLASS_PATH[@]}"
+    journey_registry_classes
+  } | LC_ALL=C sort -u | while IFS= read -r fqcn; do
+    [[ -z "$fqcn" ]] && continue
+    pocketshell_test_area_for_class "$fqcn" >/dev/null
+    area="${POCKETSHELL_TEST_AREA_FOR_CLASS:-__NONE__}"
+    pocketshell_test_area_deps_for_class "$fqcn" >/dev/null
+    deps="$POCKETSHELL_TEST_AREA_DEPS_FOR_CLASS"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "$fqcn" "$area" \
+      "${POCKETSHELL_TA_CLASS_MODULE[$fqcn]:-__NONE__}" \
+      "${POCKETSHELL_TA_CLASS_SOURCESET[$fqcn]:-__NONE__}" \
+      "$(echo $deps)"
+  done
+}
+
+case "$MODE" in
+  verify)   verify_manifest; exit $? ;;
+  list-classes) list_classes; exit 0 ;;
+  coverage) coverage_invariant; exit $? ;;
+  selfcheck)
+    rc=0
+    verify_manifest || rc=1
+    echo
+    coverage_invariant || rc=1
+    exit "$rc"
+    ;;
+  journeys) list_journeys; exit 0 ;;
+esac
+
+run_selection < <(compute_changed_paths)
+
+if [[ "$MODE" == "plan-only" ]]; then
+  print_plan_only
+else
+  print_plan
+fi
+
+if [[ "$EMIT_GITHUB_OUTPUT" -eq 1 && -n "${GITHUB_OUTPUT:-}" ]]; then
+  print_plan_only >> "$GITHUB_OUTPUT"
+fi
+
+exit 0

--- a/scripts/test-areas.txt
+++ b/scripts/test-areas.txt
@@ -1,0 +1,409 @@
+# PocketShell test-area manifest — the coverage-guard taxonomy (issue #2063).
+#
+# This taxonomy exists to make coverage MECHANICALLY CHECKABLE (is every class
+# mapped, reachable, and actually executed within a bounded window — the
+# #1851/#1853/#1859/#1509 class), and it scopes CI selection as a by-product.
+# It is not a speed feature: measured over 104 `main` commits it is 1.09x on the
+# emulator lane and neutral-to-slightly-negative on Unit. docs/testing.md has
+# the numbers. Edit this file to keep the map honest, not to chase a runtime.
+#
+# ONE data file drives all four consumers, so the taxonomy cannot drift:
+#   * scripts/select-test-areas.sh            — changed paths -> areas -> what to run
+#   * scripts/check-test-execution-ledger.sh  — proves every class still executes
+#   * scripts/dev-fast-gate.sh                — local emulator fast path (devgate col)
+#   * docs/testing.md                         — the documented rule for a NEW test
+#
+# GRAMMAR (whitespace-separated; the last column may contain spaces)
+#
+#   area   <name>  <tier>  <description...>     tier = always | changed
+#   full   <glob>  <reason...>                  changing this => run EVERYTHING
+#   noop   <glob>  <reason...>                  provably cannot affect any test
+#   src    <glob>  <area>  <devgate>            production path -> area
+#   test   <glob>  <area>  <devgate>            test path      -> area
+#   class  <fqcn>  <area>                       per-class override (beats globs)
+#   couple <area>  <area,area,...>              selecting <area> also selects these
+#
+# Globs are bash `[[ path == glob ]]` patterns with extglob on, so `*` crosses
+# `/` and `+(...)` / `!(...)` are available where a rule must NOT cross a path
+# segment. Rows are first-match-wins IN FILE ORDER within their record type.
+# Evaluation order across types is fixed in scripts/lib/test-areas.sh:
+#
+#   full -> test-infrastructure rule -> noop -> class -> test -> src -> FULL
+#
+# THE RULE FOR A NEW TEST (this is the whole rule; do not re-litigate)
+#
+#   A test's area is the area of its Gradle module, or — inside :app — of its
+#   top-level `com.pocketshell.app.<pkg>` package. Add a test to an existing
+#   package and it inherits that package's area with no manifest edit at all.
+#   Only three things need a manifest edit:
+#     1. a NEW top-level package or Gradle module  -> add a src + test row;
+#     2. a class whose regression class belongs to a DIFFERENT area than its
+#        package (rare; the conversation-source cluster living in app.tmux is
+#        the only case today) -> add a `class` row;
+#     3. a new production path with cross-area blast radius -> add a `full` row.
+#   Forget all three and the guard fails with "unmapped path" while the run
+#   falls back to FULL: the map can only lag LOUDLY, never silently.
+#
+# TIERS
+#   always  — this area's tests run on EVERY push regardless of the diff. Held
+#             for the D28/G8 worst-reopen areas (connection/reconnect/lease,
+#             conversation-source/agent-detection, terminal render/ANR) plus the
+#             app shell. Per-area justification: docs/testing.md.
+#   changed — runs when the area (or something coupled to it, or a force-full
+#             path) is in the diff, plus nightly, plus the release gate.
+#
+# WHAT DECIDES THAT A TEST RUNS (read this before adding a `couple` row)
+#
+# A test CLASS runs on a push when any of these holds:
+#
+#   1. the run is FULL (force-full path, unmapped path, manifest load failure);
+#   2. its area is `always`-tier;
+#   3. its own area is in the diff, or in the `couple` closure of the diff;
+#   4. it IMPORTS the production code of an area that is in the diff — derived
+#      from the class's own `import com.pocketshell.…` lines, NOT from any row
+#      in this file;
+#   5. it lives in — or imports — a package on the host-CLI WIRE SEAM, and
+#      `tools/pocketshell/**` is in the diff.
+#
+# THE WIRE SEAM MARKS BOTH ENDS OF THE CONTRACT (rule 5, round-2 finding B6)
+#
+# A wire contract has a producer and a consumer, and marking only the invoking
+# end left the entire `shared/*` half of the tree outside the seam by
+# construction — no shared module ever shells out. That is how
+# `:shared:core-usage:test`, the STRICT / fail-loud reader of the NDJSON
+# `tools/pocketshell/src/pocketshell/usage.py` emits, was not run by a change to
+# the code that produces it, with every guard green. A production package is on
+# the seam when ANY of these holds:
+#
+#   (a) PRODUCER  — a file in it invokes the CLI (`PocketshellCommand`, or a
+#                   literal `pocketshell …` command string);
+#   (b) CONSUMER  — an INVOKING FILE imports it (one hop): the invoker builds the
+#                   request and hands the reply to something, and that something
+#                   is in the invoking file's own import set;
+#   (c) VOCABULARY— a file in it NAMES a real host-CLI subcommand, where the
+#                   subcommand list is extracted from the producer itself
+#                   (`cli.add_command(…, name="…")` in
+#                   tools/pocketshell/src/pocketshell/cli.py). This is the case
+#                   with no in-app invoker at all: the settings QR importer
+#                   parses what `pocketshell qr-share` emits, and that payload
+#                   arrives by QR scan, so no import edge exists to follow.
+#
+# Rules 4 and 5 are computed in scripts/lib/test-areas.sh; that file's index
+# comment carries the full rationale, the two stronger designs that were
+# measured and rejected (both degenerate to "run everything" because the
+# production import graph is strongly connected), and the bound this one accepts
+# (direct compile edges only — transitive production dependencies are not
+# chased; the always tier, nightly and the release gate are the backstops).
+# `--verify-manifest` check 7 floors each seam END separately, including how far
+# the seam reaches into `shared/*`, because a total-only floor is exactly what
+# hid B6: 15 packages looked healthy while one whole end was at zero.
+#
+# So `couple` rows exist ONLY for BEHAVIOURAL coupling that no import expresses:
+# composer-always-present across screens, ui-kit tokens reaching every surface,
+# a host record the tree reads. Do not add a `couple` row for a compile-level
+# dependency — rule 4 already has it, and a hand row that duplicates the import
+# graph is how round 1 ended up asserting two edges it did not have.
+#
+# devgate is consumed ONLY by scripts/dev-fast-gate.sh, whose coarse emulator
+# stages (ui | bootstrap | terminal | full) answer a different question from the
+# test areas. It is a per-ROW column, not a per-AREA one, precisely because the
+# old inline arms split some areas across stages (shared/core-ssh was
+# `terminal` while shared/core-connection fell through to force-full). Keeping
+# it per-row is what let dev-fast-gate move onto this manifest with every one of
+# its decisions unchanged — proven over every tracked file by
+# scripts/dev-fast-gate-parity-selftest.sh.
+
+# ---------------------------------------------------------------------------
+# AREAS
+# ---------------------------------------------------------------------------
+area   connection-core      always   SSH transport, lease, reconnect, grace, tmux -CC control protocol (D28 core)
+area   terminal-render      always   Terminal emulation, parsing, render and the drain scheduler (#796/#803 ANR class)
+area   conversation-agents  always   Agent detection, conversation source binding and the parsed transcript (#819/#825 class)
+area   app-shell            always   Application entry, DI graph, navigation, startup and test-access seams
+area   tmux-session         changed  The tmux session screen, chrome, pager and session UI state
+area   composer-voice       changed  Prompt composer, outbound queue, dictation, voice assistant and messaging
+area   projects-tree        changed  Session tree, folders, repos and git surfaces
+area   portfwd              changed  Port forwarding core, panel and forwarding service
+area   files                changed  File viewer and file explorer
+area   hosts-settings       changed  Hosts, settings, preferences and local storage
+area   share                changed  Share target and attachment intake
+area   usage-costs          changed  Usage panel, provider quotas and cost reporting
+area   bootstrap            changed  Host setup detection, server bootstrap and the host CLI wrapper
+area   notifications        changed  Notifications and system surfaces
+area   release-update       changed  In-app update, release checks and APK install
+area   diagnostics-crash    changed  Diagnostics, crash reporting, env and snippets
+area   ui-shell             changed  Shared ui-kit design system, layout, insets and branding
+area   ci-harness           changed  JVM-driven shell harness tests for the CI scripts
+# host-cli has ZERO Kotlin test classes of its own (its unit tests are the
+# separate `Python utility tests` job). It matters because host-CLI/client
+# version is a RUNTIME lockstep — #847 / v0.4.10, the most expensive break this
+# repo has shipped. Its coupling to the Kotlin tests is derived from the
+# two-ended wire seam (rule 5 above), not from a `couple` row, and I9 in
+# --coverage-invariant pins both journeys (#1509, FolderListOldCliHydrateDockerTest)
+# and UNIT consumers (PocketshellUsageJsonParserTest, AppDatabaseTest,
+# SessionAgentKindOptionTest) to it by name. Measured consequence, stated rather
+# than buried: with both ends marked, a `tools/pocketshell/**` change selects
+# 158 of 161 journeys and 570 of 659 unit classes — a host-CLI change is now
+# effectively a full run. That is the deliberate answer for the #847 class.
+area   host-cli             changed  The host-side `pocketshell` Python CLI
+
+# ---------------------------------------------------------------------------
+# FORCE-FULL — blast-radius escapes. Evaluated FIRST, in this order.
+#
+# The test that would have caught a cross-area change must never be skipped, so
+# anything whose effect provably leaves its own area runs everything. Every row
+# here is a deliberate cost, and every one is cheaper than a missed regression.
+# ---------------------------------------------------------------------------
+full   .github/*                     CI workflow definitions decide what runs at all
+full   scripts/*                     the gate harnesses, including this manifest and its consumers
+full   tests/*                       Docker fixtures and shell harnesses every journey depends on
+full   gradle/*                      version catalogue and wrapper properties
+full   */gradle/*                    nested gradle directories
+full   gradlew*                      the wrapper entry points
+full   *build.gradle.kts             module build configuration
+full   *.gradle.kts                  any Gradle Kotlin script
+full   *.gradle                      any Gradle Groovy script
+full   gradle.properties             daemon/heap/parallelism config changes every test task
+full   cgroups.toml                  local run confinement used by the gates
+full   debug.keystore                signing input for every built APK
+full   shared/test-support/*         the ONE audited settle pump; every runTest consumer depends on it
+full   app/src/main/java/com/pocketshell/app/di/*             the Hilt/DI graph wires every area together
+full   app/src/main/java/com/pocketshell/app/nav/*            the navigation graph reaches every screen
+full   app/src/main/java/com/pocketshell/app/startup/*        process startup ordering affects every surface
+full   app/src/main/java/com/pocketshell/app/testaccess/*     the seams every androidTest drives the app through
+full   app/src/main/java/com/pocketshell/app/layout/*         shared layout scaffolding used by every screen
+full   app/src/main/java/com/pocketshell/app/App.kt           application object: lifecycle fan-out to every surface
+full   app/src/main/java/com/pocketshell/app/MainActivity.kt  single activity host for every destination
+full   app/src/main/java/com/pocketshell/app/AppTeardownScope.kt      global teardown ordering
+full   app/src/main/java/com/pocketshell/app/MainThreadConfinement.kt main-thread policy enforced app-wide
+full   app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt  D28 god-object seam (#766 residue) where cross-area wedge bugs hide
+full   app/src/main/res/*            theme tokens, strings and drawables reach every screen (#453/#641 class)
+full   app/src/main/AndroidManifest.xml        components, permissions and exported surfaces
+full   app/src/androidTest/AndroidManifest.xml instrumentation manifest for every connected test
+full   app/src/debug/*               debug-variant instrumentation seams (Hilt host activity, Toxiproxy control) every journey builds against
+full   app/lint.xml                  lint configuration applied to every module build
+full   app/*.pro                     R8/ProGuard rules change every release-variant test
+
+# ---------------------------------------------------------------------------
+# NOOP — provably cannot affect any test.
+#
+# Narrow on purpose: prose only. No Gradle test and no journey reads a repo
+# markdown file at runtime, and `select-test-areas.sh --verify-manifest`
+# re-proves that on every run by scanning the test trees for doc-file reads, so
+# this row set cannot quietly become wrong. A noop-only diff still runs the
+# always tier — "select nothing" is unreachable by construction (the always-tier
+# union in lib/test-areas.sh happens last and unconditionally).
+# ---------------------------------------------------------------------------
+noop   *.md                          prose; no test reads a markdown file at runtime
+noop   docs/*                        planning docs and mockups
+noop   mockups/*                     static HTML mockups
+noop   .claude/*                     agent role prompts
+noop   .gitignore                    ignore rules
+
+# ---------------------------------------------------------------------------
+# PRODUCTION PATHS -> AREA. Ordered specific-before-general.
+# ---------------------------------------------------------------------------
+
+# -- shared modules --
+src    shared/core-ssh/*             connection-core      terminal
+src    shared/core-tmux/*            connection-core      terminal
+src    shared/core-connection/*      connection-core      full
+src    shared/core-terminal/*        terminal-render      terminal
+src    shared/core-agents/*          conversation-agents  full
+src    shared/core-voice/*           composer-voice       full
+src    shared/core-assistant/*       composer-voice       full
+src    shared/core-portfwd/*         portfwd              full
+src    shared/core-storage/*         hosts-settings       full
+src    shared/core-usage/*           usage-costs          full
+src    shared/ui-kit/*               ui-shell             ui
+
+# -- :app production packages --
+src    app/src/main/java/com/pocketshell/app/ssh/*            connection-core      terminal
+src    app/src/main/java/com/pocketshell/app/sessions/*       connection-core      full
+src    app/src/main/java/com/pocketshell/app/session/*        connection-core      full
+src    app/src/main/java/com/pocketshell/app/connectivity/*   connection-core      full
+src    app/src/main/java/com/pocketshell/app/jobs/*           connection-core      full
+src    app/src/main/java/com/pocketshell/app/terminal/*       terminal-render      terminal
+src    app/src/main/java/com/pocketshell/app/tmux/*           tmux-session         terminal
+src    app/src/main/java/com/pocketshell/app/composer/*       composer-voice       full
+src    app/src/main/java/com/pocketshell/app/voice/*          composer-voice       full
+src    app/src/main/java/com/pocketshell/app/assistant/*      composer-voice       full
+src    app/src/main/java/com/pocketshell/app/messaging/*      composer-voice       full
+src    app/src/main/java/com/pocketshell/app/conversation/*   conversation-agents  full
+src    app/src/main/java/com/pocketshell/app/agents/*         conversation-agents  full
+src    app/src/main/java/com/pocketshell/app/agentcommands/*  conversation-agents  full
+src    app/src/main/java/com/pocketshell/app/cards/*          conversation-agents  full
+src    app/src/main/java/com/pocketshell/app/projects/*       projects-tree        ui
+src    app/src/main/java/com/pocketshell/app/repos/*          projects-tree        full
+src    app/src/main/java/com/pocketshell/app/git/*            projects-tree        full
+src    app/src/main/java/com/pocketshell/app/portfwd/*        portfwd              full
+src    app/src/main/java/com/pocketshell/app/fileviewer/*     files                full
+src    app/src/main/java/com/pocketshell/app/fileexplorer/*   files                full
+src    app/src/main/java/com/pocketshell/app/hosts/*          hosts-settings       full
+src    app/src/main/java/com/pocketshell/app/settings/*       hosts-settings       full
+src    app/src/main/java/com/pocketshell/app/prefs/*          hosts-settings       full
+src    app/src/main/java/com/pocketshell/app/share/*          share                full
+src    app/src/main/java/com/pocketshell/app/usage/*          usage-costs          full
+src    app/src/main/java/com/pocketshell/app/costs/*          usage-costs          full
+src    app/src/main/java/com/pocketshell/app/bootstrap/*      bootstrap            bootstrap
+src    app/src/main/java/com/pocketshell/app/pocketshell/*    bootstrap            full
+src    app/src/main/java/com/pocketshell/app/notifications/*  notifications        full
+src    app/src/main/java/com/pocketshell/app/systemsurfaces/* notifications        full
+src    app/src/main/java/com/pocketshell/app/release/*        release-update       full
+src    app/src/main/java/com/pocketshell/app/diagnostics/*    diagnostics-crash    full
+src    app/src/main/java/com/pocketshell/app/crash/*          diagnostics-crash    full
+src    app/src/main/java/com/pocketshell/app/env/*            diagnostics-crash    full
+src    app/src/main/java/com/pocketshell/app/snippets/*       diagnostics-crash    full
+
+# -- host CLI --
+src    tools/pocketshell/*           host-cli             full
+
+# ---------------------------------------------------------------------------
+# TEST PATHS -> AREA. Ordered specific-before-general.
+#
+# Files in a test source set that are NOT named *Test.kt never reach these
+# rows: the test-infrastructure rule in lib/test-areas.sh force-fulls them
+# first, because a shared fixture's blast radius is exactly as unknown as a DI
+# module's.
+# ---------------------------------------------------------------------------
+
+# -- shared module test trees --
+test   shared/core-ssh/*             connection-core      terminal
+test   shared/core-tmux/*            connection-core      terminal
+test   shared/core-connection/*      connection-core      full
+test   shared/core-terminal/*        terminal-render      terminal
+test   shared/core-agents/*          conversation-agents  full
+test   shared/core-voice/*           composer-voice       full
+test   shared/core-assistant/*       composer-voice       full
+test   shared/core-portfwd/*         portfwd              full
+test   shared/core-storage/*         hosts-settings       full
+test   shared/core-usage/*           usage-costs          full
+test   shared/ui-kit/*               ui-shell             ui
+
+# -- :app test packages (unit + androidTest share one taxonomy) --
+test   app/src/*/java/com/pocketshell/app/proof/*           connection-core      full
+test   app/src/*/java/com/pocketshell/app/ssh/*             connection-core          full
+test   app/src/*/java/com/pocketshell/app/sessions/*        connection-core      full
+test   app/src/*/java/com/pocketshell/app/session/*         connection-core      full
+test   app/src/*/java/com/pocketshell/app/connectivity/*    connection-core      full
+test   app/src/*/java/com/pocketshell/app/jobs/*            connection-core      full
+test   app/src/*/java/com/pocketshell/app/terminal/*        terminal-render          full
+test   app/src/*/java/com/pocketshell/app/tmux/*            tmux-session             full
+test   app/src/*/java/com/pocketshell/app/composer/*        composer-voice       full
+test   app/src/*/java/com/pocketshell/app/voice/*           composer-voice       full
+test   app/src/*/java/com/pocketshell/app/assistant/*       composer-voice       full
+test   app/src/*/java/com/pocketshell/app/messaging/*       composer-voice       full
+test   app/src/*/java/com/pocketshell/app/conversation/*    conversation-agents  full
+test   app/src/*/java/com/pocketshell/app/agents/*          conversation-agents  full
+test   app/src/*/java/com/pocketshell/app/agentcommands/*   conversation-agents  full
+test   app/src/*/java/com/pocketshell/app/cards/*           conversation-agents  full
+test   app/src/*/java/com/pocketshell/app/projects/*        projects-tree        full
+test   app/src/*/java/com/pocketshell/app/repos/*           projects-tree        full
+test   app/src/*/java/com/pocketshell/app/git/*             projects-tree        full
+test   app/src/*/java/com/pocketshell/app/portfwd/*         portfwd              full
+test   app/src/*/java/com/pocketshell/app/fileviewer/*      files                full
+test   app/src/*/java/com/pocketshell/app/fileexplorer/*    files                full
+test   app/src/*/java/com/pocketshell/app/hosts/*           hosts-settings       full
+test   app/src/*/java/com/pocketshell/app/settings/*        hosts-settings       full
+test   app/src/*/java/com/pocketshell/app/prefs/*           hosts-settings       full
+test   app/src/*/java/com/pocketshell/app/share/*           share                full
+test   app/src/*/java/com/pocketshell/app/usage/*           usage-costs          full
+test   app/src/*/java/com/pocketshell/app/costs/*           usage-costs          full
+test   app/src/*/java/com/pocketshell/app/bootstrap/*       bootstrap            bootstrap
+test   app/src/*/java/com/pocketshell/app/pocketshell/*     bootstrap            full
+test   app/src/*/java/com/pocketshell/app/docker/*          bootstrap            full
+test   app/src/*/java/com/pocketshell/app/notifications/*   notifications        full
+test   app/src/*/java/com/pocketshell/app/systemsurfaces/*  notifications        full
+test   app/src/*/java/com/pocketshell/app/release/*         release-update       full
+test   app/src/*/java/com/pocketshell/app/diagnostics/*     diagnostics-crash    full
+test   app/src/*/java/com/pocketshell/app/crash/*           diagnostics-crash    full
+test   app/src/*/java/com/pocketshell/app/env/*             diagnostics-crash    full
+test   app/src/*/java/com/pocketshell/app/snippets/*        diagnostics-crash    full
+test   app/src/*/java/com/pocketshell/app/ui/*              ui-shell             full
+test   app/src/*/java/com/pocketshell/app/insets/*          ui-shell             full
+test   app/src/*/java/com/pocketshell/app/branding/*        ui-shell             full
+test   app/src/*/java/com/pocketshell/app/scripts/*         ci-harness           full
+test   app/src/*/java/com/pocketshell/app/nav/*             app-shell            full
+test   app/src/*/java/com/pocketshell/app/di/*              app-shell            full
+test   app/src/*/java/com/pocketshell/app/testaccess/*      app-shell            full
+test   app/src/*/java/com/pocketshell/app/test/*            app-shell            full
+# :app ROOT-level test classes (App / MainActivity / lease lifecycle / back trap).
+# `+([A-Za-z0-9_])` cannot cross `/`, so this row matches only files sitting
+# directly in the `app` package — a test in a NEW subpackage falls through to
+# unmapped => FULL + a loud guard failure, which is the point.
+test   app/src/*/java/com/pocketshell/app/+([A-Za-z0-9_])Test.kt  app-shell  full
+
+# -- host CLI tests --
+test   tools/pocketshell/tests/*     host-cli             full
+
+# ---------------------------------------------------------------------------
+# PER-CLASS OVERRIDES
+#
+# The conversation-source cluster lives in the com.pocketshell.app.tmux package
+# (it drives the tmux session screen) but its regression class is
+# conversation-source binding — the #819/#825/#962/#1057 worst-reopen area. It
+# must run on every push, so it is pinned to the always-tier
+# conversation-agents area instead of the changed-tier tmux-session area.
+# ---------------------------------------------------------------------------
+class  com.pocketshell.app.tmux.AgentConversationReconnectDockerTest  conversation-agents
+class  com.pocketshell.app.tmux.ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest  conversation-agents
+class  com.pocketshell.app.tmux.ConversationStaysReachableAfterDetectionDropsDockerTest  conversation-agents
+class  com.pocketshell.app.tmux.ConversationTuiCommandJourneyDockerTest  conversation-agents
+class  com.pocketshell.app.tmux.TmuxChromeConversationTogglePresentTest  conversation-agents
+class  com.pocketshell.app.tmux.TmuxConversationBottomComposerScreenshotTest  conversation-agents
+
+# ---------------------------------------------------------------------------
+# AREA COUPLING — BEHAVIOURAL edges only.
+#
+# Selecting the left area also selects everything on the right, transitively.
+# Each edge exists because a change on the left has repeatedly broken the right
+# in a way NO import expresses — a screen-level invariant, a shared design
+# token, a record one surface writes and another reads.
+#
+# Compile-level coupling is NOT listed here and must not be added here: it is
+# derived per test class from the import graph (rule 4 in the header). Round 1
+# hand-listed compile coupling, claimed two edges the file did not contain, and
+# 29 journeys that compile against connection-core production types were not
+# run by a connection-core change.
+# ---------------------------------------------------------------------------
+# The AGENTS.md coupling invariant: composer-always-present and
+# conversation-default are one seam; ComposerAlwaysPresentSwitchJourneyE2eTest
+# breaks across all three.
+couple composer-voice       tmux-session,conversation-agents
+couple tmux-session         composer-voice,conversation-agents,terminal-render
+couple conversation-agents  tmux-session,composer-voice
+# The two always-tier engine areas fan OUT to the session screen when they
+# actually change. Note this is not redundant with their `always` tier: the
+# closure in lib/test-areas.sh runs over the CHANGED seed areas only and unions
+# the always tier afterwards, so these edges fire on a real connection/terminal
+# change and stay silent when those areas are merely the always-on floor.
+# Without them a pure connection-core change would skip
+# TmuxConnectingStatesScreenshotTest (#750, a D31 third occurrence) and
+# Issue1686QueueDrainWireOracleDockerTest (#1686), both of which live in the
+# app.tmux package but are driven by the transport.
+couple connection-core      tmux-session
+couple terminal-render      tmux-session
+# ui-kit tokens reach every screen (#453/#641): a design-system change selects
+# every UI-bearing area. Deliberately near-full — do not try to be clever here.
+couple ui-shell             tmux-session,composer-voice,projects-tree,files,hosts-settings,share,usage-costs,bootstrap,notifications,release-update,diagnostics-crash,portfwd,conversation-agents
+# The tree creates and resumes sessions and lands on the session screen
+# (#889 ProfileChipRelaunchDockerTest, #881 FolderListScreenE2eTest profiles).
+couple projects-tree        tmux-session
+# The file viewer is reached from the session screen's path tap and more-menu
+# (TmuxMoreMenuOpenFileTest lives in the tmux package), so a viewer change must
+# run those. There is deliberately NO projects-tree <-> files edge: no journey
+# crosses that boundary, and inventing the edge would cost ~200 classes per
+# tree change for nothing.
+couple files                tmux-session
+# Host setup writes the host record the tree and sessions read.
+couple hosts-settings       bootstrap,projects-tree
+couple bootstrap            hosts-settings
+# The forwarding service is observed through its notification. BOTH directions:
+# #1198/#1487/#2006 are forwarding-notification regressions, so a change on
+# either side must run the other's journeys.
+couple portfwd              notifications
+couple notifications        portfwd
+# Share hands its payload to the composer, and the composer renders it. Both
+# directions for the same reason.
+couple share                composer-voice
+couple composer-voice       share


### PR DESCRIPTION
**A guard suite, not a speed feature.** Batched because #2063's scripts and #2067's job cannot land apart — a `tests.yml` job cannot run scripts absent from the tree, and #2063 alone costs **+5m30s on every push**. Together they are **critical-path-neutral**: the guards run in their own ~167s job hidden behind the ~19min unit job.

The issue originally projected ~1.12×. That assumed selection consuming the plan to skip tests, which this slice deliberately does not do. **The honest number today is 1.00×**, and the title no longer sells a speed win.

## What it buys

PocketShell's host CLI and its Android consumers are a **runtime lockstep** — a client calling a host subcommand against an older CLI hangs, which is how v0.4.10 broke. Nothing verified that a change to `tools/pocketshell` selected the tests protecting its consumers.

Building that verification **defeated a static reader seven times**: the `@cli.group` decorator form (missing `daemon`), sibling-module registration, a non-root receiver, an alias binding, the group passed as a value into another file, `cli.commands["x"] = cmd` (a dict assignment, not a call), and four further shapes reaching the object without producing a resolvable `ast.Name`.

Each fix was sound; the class survived because a parser must anticipate every way a Python object can be named. The reader now takes a **census of every registrar call regardless of receiver**, under an asserted accounting identity, and the four shapes it provably cannot see are **documented as limits rather than claimed as coverage**. #2070 proposes the sound alternative — import `cli.py` and ask the live `click.Group`.

## It has already earned itself

The executed-classes ledger closes the #1851 hole where tests sit in no suite at all. The **#1622 composer merge added a third `@Test`-bearing file with a non-conventional name hours after the baseline was written** — and the guard caught it, reddening this very PR's predecessor. That blocker *is* the proof.

## Safety

- **Selection skips nothing.** The four limits are a *reporting* gap today; they become a coverage hole only when CI consumes the plan. The condition for re-weighing them before that happens is recorded in `docs/testing.md`.
- **`unit-gate` has three lists** — `needs:`, `env:` and the result loop. A job in only some is a red job under a green required check. A new guard enforces all three agree, verified reddening on each omission independently.

## Verification

Reviewer APPROVED. It **re-did the hand-merge itself** rather than spot-checking — sourcing base/theirs from git and running its own `git merge-file --diff3`; `tests.yml` came out byte-identical, `docs/testing.md` differed by exactly the disclosed docs edit, all of main's added lines present, all deletions absent, anchors in main's exact order.

It also **proved its own round-1 finding was wrong**: a controlled experiment showed `GIT_INDEX_FILE` leaking into the selftest sandbox reproduced its 10/6 exactly, while a clean env gives 16/16. It named itself as the contaminant.

Gate verified from artifacts: zero `FROM-CACHE` in the whole log, **12362/0** parsed from its own XML, 0 stale of 1314, and the 24 tasks confirmed as **both** variants across all 12 modules — the task CI requires, not the debug-only proxy that reddened `main` at v0.4.37.

`tests.yml` is **656 bytes** under the hygiene cap. Ruled acceptable because the breach mode is loud, blocking and pre-merge rather than a silent cliff; the named reduction lever is ~800 bytes of inline rationale that belongs in the script header.

Closes #2063
Closes #2067