### PR TITLE
scripts: rename the three Python programs with .sh names, and guard the class (#2066)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,9 +68,9 @@ jobs:
       # removed, duplicated, contradicted, or moved off the complete test graph.
       - name: CI Unit forced-execution wiring guard (issue #1897)
         run: |
-          chmod +x scripts/check-ci-unit-forced-execution.sh
-          scripts/check-ci-unit-forced-execution.sh --self-test
-          scripts/check-ci-unit-forced-execution.sh
+          chmod +x scripts/check-ci-unit-forced-execution.py
+          scripts/check-ci-unit-forced-execution.py --self-test
+          scripts/check-ci-unit-forced-execution.py
 
       # Issue #1646: the executed-test-count guard's OWN red->green self-test.
       # Proves — with synthetic result XML + synthetic Gradle console output, no
@@ -375,8 +375,16 @@ jobs:
       # and stripping of hosted toolchain/profile variables before the guard.
       - name: Forced full-JVM resource-profile guard (issue #1761)
         run: |
-          scripts/full-jvm-gate.sh --profile-guard-self-test
-          scripts/full-jvm-gate.sh --profile-guard-check
+          scripts/full-jvm-gate.py --profile-guard-self-test
+          scripts/full-jvm-gate.py --profile-guard-check
+
+      # Issue #2066: extension/shebang disagreement, and any caller that shells
+      # a non-shell program. Rationale and the exact rules live in ONE place —
+      # the script header. ~2 s, no Gradle.
+      - name: "Script interpreter hygiene guard (issue #2066)"
+        run: |
+          scripts/check-script-interpreter-hygiene.sh --self-test
+          scripts/check-script-interpreter-hygiene.sh
 
       # Issue #2067: `unit-gate` holds THREE lists nothing forced to agree —
       # `needs:`, the `env:` result mapping, and the result-checking loop. A job
@@ -478,7 +486,7 @@ jobs:
           chmod +x scripts/test-agents-pool-isolation.sh
           scripts/test-agents-pool-isolation.sh
 
-      # Issue #2007: connected-test.sh and full-jvm-gate.sh are both canonical
+      # Issue #2007: connected-test.sh and full-jvm-gate.py are both canonical
       # wrappers around ./gradlew and both rewrite the SAME app/build graph of
       # the checkout they run from. Nothing stopped them overlapping, so during
       # #893 validation a connected --rerun-tasks build and the full JVM gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ found` until these explicit paths have been tried:
 - SDK root from `local.properties`: `/home/alexey/Android/Sdk`
 - Available local AVD: `test`
 
-The canonical `scripts/full-jvm-gate.sh` does not depend on ignored
+The canonical `scripts/full-jvm-gate.py` does not depend on ignored
 `local.properties`. It validates `ANDROID_HOME` and/or `ANDROID_SDK_ROOT` (both
 must resolve to the same complete SDK), then checks the standard Linux local and
 hosted-runner locations documented in `process.md`.
@@ -395,7 +395,7 @@ are looking at before proposing a fix:
   **#882 miss (2026-06-21):** a recording-timer `while(recording){delay(50)}`
   coroutine left active spun `advanceUntilIdle` forever under `runTest` virtual
   time → the CI Unit job (`./gradlew test --no-daemon`, whole suite, 35-min cap;
-  canonical forced local repros use `scripts/full-jvm-gate.sh`)
+  canonical forced local repros use `scripts/full-jvm-gate.py`)
   hit its timeout and `main` went red, but every gate ran the filtered subset and
   never saw it. Mandatory especially when a change adds a coroutine loop / ticker /
   new `runTest` test. A CI job that ends with "timed out after N minutes" + all
@@ -528,7 +528,7 @@ are looking at before proposing a fix:
   banned: its reclaim throttle turns a clean kill into an indefinite hang.)
 
   Related trap, same root: **do not hand-roll `./gradlew` in place of
-  `scripts/full-jvm-gate.sh`.** The gate passes
+  `scripts/full-jvm-gate.py`.** The gate passes
   `-Pkotlin.daemon.jvmargs=-Xmx3072m` and `-Dorg.gradle.jvmargs=-Xmx1536m`, and
   the repo's `gradle.properties` sets **no** `kotlin.daemon.jvmargs` at all — so
   an ad-hoc invocation leaves the Kotlin daemon on its default heap and OOMs no
@@ -536,6 +536,19 @@ are looking at before proposing a fix:
   changed nothing until the run switched to the canonical gate. process.md's
   "run the task CI runs" is about the execution *profile*, not just which tests
   are selected.
+- **Run repository programs DIRECTLY; never pick an interpreter from the
+  filename. Machine-enforced by `scripts/check-script-interpreter-hygiene.sh`
+  (#2066).** `bash <a python program>` mis-executes it line by line, and
+  `import os` runs **ImageMagick's `import`**, which blocks forever on X: a
+  process that stays "active" with a ~1-line log, zero test XML, and — inside
+  the shared `flock` — the gate lock held while every sibling lane starves.
+  This was documented for months as a property of ONE named file
+  (`full-jvm-gate.sh`), which taught agents that its two equally-Python
+  siblings were safe; a briefed reviewer still `bash`-ed one and read its
+  `rc=0` as a pass. All three are now `.py`, and the guard enforces with no
+  allowlist that extensions match shebangs and that nothing shells a non-shell
+  program. Corollary for reading results: a ~1-line gate log is not a slow run
+  and not a failure — it is a run that never happened.
 - **Never pipe a long-running gate through `grep`.** The harness captures only
   what the pipeline emits, so a failing run leaves you a 2-line file with the
   task name and no error — and you must re-run the whole thing to learn anything.

--- a/app/src/test/java/com/pocketshell/app/scripts/DiskPreflightScriptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/scripts/DiskPreflightScriptTest.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit
  * a test (#1640/#1646/#1853). `tests/scripts/` accumulated twelve harnesses that
  * had never executed, four of which were failing when #1853 finally ran them.
  * Wiring this one here means it runs in the per-PR required check AND inside
- * `scripts/full-jvm-gate.sh`'s complete graph, with no workflow YAML edit to
+ * `scripts/full-jvm-gate.py`'s complete graph, with no workflow YAML edit to
  * drift out of sync.
  *
  * The harness is emulator-free, Docker-daemon-free, and disk-free: it uses a
@@ -56,7 +56,7 @@ class DiskPreflightScriptTest {
         //   * a driving gate exports AVD/output-lock acquire state, which would
         //     short-circuit the wrapper's own lock calls inside the fixtures
         //     (the #1702 lesson);
-        //   * `CI` is set in the required Unit job, and scripts/full-jvm-gate.sh
+        //   * `CI` is set in the required Unit job, and scripts/full-jvm-gate.py
         //     rejects any run with CI set outside its guard-only modes — the
         //     harness drives its real preflight probe, so CI must be absent.
         //     Removing CI also disables scripts/lib/scope-run.sh's hosted-runner

--- a/docs/handoff-2026-07-27.md
+++ b/docs/handoff-2026-07-27.md
@@ -257,7 +257,7 @@ Required next work after an explicit resume:
 
 1. Preserve or repeat exact-aad connected RED/GREEN/mutation evidence with
    nonzero XML counts.
-2. Run the canonical no-argument `scripts/full-jvm-gate.sh` to a durable child
+2. Run the canonical no-argument `scripts/full-jvm-gate.py` to a durable child
    exit and fresh totals in a quiet local lane.
 3. Re-run final forced Android-test compile and current static/harness/budget
    gates if their exact-aad provenance cannot be sealed.

--- a/docs/handoff-2026-07-28.md
+++ b/docs/handoff-2026-07-28.md
@@ -137,13 +137,16 @@ These are the substantive lessons, not process trivia.
   `exec`'s `finally` closes under `NonCancellable` through an 8s ceiling —
   2500 + 8000 ≈ the measured 10,512ms). The requested fix would have changed
   nothing.
-- **`scripts/full-jvm-gate.sh` is a Python program despite the `.sh` extension.**
+- **`scripts/full-jvm-gate.sh` was a Python program despite the `.sh` extension.**
   Running it under `bash` mis-executes it; line 3's `import os` invokes
   ImageMagick's `import`, which blocks forever on X **while holding the shared
   gate lock**, starving every sibling lane, with a ~1-line log and zero XML.
   Documented in `process.md`; it burned a lane this session and is the most
   likely explanation for the 2026-07-27 #1598 gate that "stalled" with no
-  verdict.
+  verdict. (Historic path. #2066 renamed it to `scripts/full-jvm-gate.py`,
+  along with two sibling instances the by-name documentation had hidden, and
+  added `scripts/check-script-interpreter-hygiene.sh` so the class cannot
+  return.)
 - **Cross-agent damage extends to shared FILES, not just processes.** A sibling
   overwrote another lane's `mutate.py` in the shared scratchpad, so one mutation
   run executed **unmutated production code** and reported green — which argues

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -574,7 +574,7 @@ The plan emits `UNIT_SHARED_TASKS` (module test tasks, unfiltered) and
 **two invocations**, because a single `--tests` applies to every test task in
 one invocation and would filter the shared modules to nothing. In `full` mode it
 emits the byte-identical whole-graph `test` task the Unit job runs today, which
-is what keeps `scripts/check-ci-unit-forced-execution.sh` satisfied on the full
+is what keeps `scripts/check-ci-unit-forced-execution.py` satisfied on the full
 path.
 
 `UNIT_GRADLE_FILTERS` carries **exact fully-qualified class names, never
@@ -641,7 +641,7 @@ name, a bare `@cli.group`, an unparseable `cli.py`, a missing `python3`, or a
 sibling module taking the group object so a registration could live outside
 `cli.py` — is reported by name and fails the guard. `python3` is therefore a
 hard dependency of `--verify-manifest`; it is already one for
-`scripts/check-ci-unit-forced-execution.sh` in the same job.
+`scripts/check-ci-unit-forced-execution.py` in the same job.
 
 **Why detection is receiver-agnostic, and not a list of recognised shapes.**
 Equality is only worth what the reader can *see*, and for five rounds the reader
@@ -843,7 +843,7 @@ task runs per variant, so it charged the suite twice per push on the Unit
 critical path — see the cost note below and the two consequences under "What
 this is worth, measured". If you add a guard, add a step to the job.
 
-**A local `scripts/full-jvm-gate.sh` green therefore does NOT cover these**, the
+**A local `scripts/full-jvm-gate.py` green therefore does NOT cover these**, the
 same way it does not cover `check-file-size-hygiene.sh` or
 `check-test-validity.sh`. Run the five commands above directly when you touch the
 manifest, the classification engine, the journey registry, or `cli.py`.
@@ -931,7 +931,7 @@ scripts/check-file-size-hygiene.sh --update   # only after files shrink
 runs `df`.** During #1963 validation the dev box's root filesystem hit 100%
 (436G, 24M available) and two gates died before a single test ran: a connected
 lane could not write `~/.docker/buildx` and then could not create
-`~/.gradle/caches/8.13`, and `scripts/full-jvm-gate.sh` failed in
+`~/.gradle/caches/8.13`, and `scripts/full-jvm-gate.py` failed in
 `:app:kspDebugKotlin` at 1m12s. Neither is an assertion failure, but both look
 like one, so a full disk burns a review round and gets blamed on the change
 under test.
@@ -960,7 +960,7 @@ layers. 10 GiB is roughly 3x that.
 An earlier revision set the floor at 4 GiB on the premise that these wrappers
 run on hosted CI runners where free space is tight mid-job. **That premise is
 false**, and it is recorded here so it is not rediscovered as a reason to lower
-the floor again. `scripts/full-jvm-gate.sh`'s real path never runs on a hosted
+the floor again. `scripts/full-jvm-gate.py`'s real path never runs on a hosted
 runner — `.github/workflows/tests.yml` invokes it only as
 `--profile-guard-self-test` / `--profile-guard-check`, both exempt from this
 preflight and both building nothing, and the real path additionally refuses to
@@ -978,7 +978,7 @@ timeout (75), and from the #1842 disturbed-fixture verdict (90), so "the box was
 full" is never read as "this change is red".
 
 `scripts/connected-test.sh` resolves the preflight through
-`scripts/lib/disk-preflight.sh`; `scripts/full-jvm-gate.sh` is an isolated
+`scripts/lib/disk-preflight.sh`; `scripts/full-jvm-gate.py` is an isolated
 Python program that sources no shell library, so it reimplements the identical
 thresholds and the identical statvfs arithmetic.
 `tests/scripts/disk-preflight-test.sh` pins the two halves against each other —

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 #     "Backend Internal error: Exception during IR lowering", not as an OOM;
 #   * it adds CPU contention, which is exactly what wakes the #708/#882/#1048
 #     runTest virtual-clock-vs-real-dispatcher flake class;
-#   * this file is GLOBAL — it would also re-profile scripts/full-jvm-gate.sh,
+#   * this file is GLOBAL — it would also re-profile scripts/full-jvm-gate.py,
 #     which runs the whole `test --rerun-tasks` graph inside an 8 GiB cgroup on
 #     the proven single-worker / split-heap profile that #1761 guards.
 # process.md requires an N>=20 determinism soak on a FULL :app:testReleaseUnitTest

--- a/process.md
+++ b/process.md
@@ -412,20 +412,37 @@ Minimum pre-push gate:
   still reject headless proof that only exercises plumbing (the assertion must be
   on the symptom-defining signal on the real transport, never on a seam/lambda
   having fired — the #1693 round-1 failure).
-- **`scripts/full-jvm-gate.sh` is a PYTHON program despite the `.sh` extension
-  (`#!/usr/bin/python3 -I`). Execute it directly — NEVER `bash
-  scripts/full-jvm-gate.sh`.** Under `bash` it mis-executes line by line and
-  line 3, `import os`, invokes **ImageMagick's `import`**, which blocks forever
-  waiting on X. The result is the nastiest artifact in this repo's catalogue: a
+- **Never run a repository program through an interpreter you inferred from its
+  FILENAME — run it directly. This is a CLASS, and it is now machine-enforced
+  by `scripts/check-script-interpreter-hygiene.sh` (issue #2066).** A file
+  whose extension names one language and whose shebang names another produces
+  the nastiest artifact in this repo's catalogue. The concrete mechanism:
+  `bash <a python program>` mis-executes it line by line, and `import os`
+  invokes **ImageMagick's `import`**, which blocks forever waiting on X — a
   process that stays "active" indefinitely, writes a ~1-line log, produces zero
-  test XML, and — if you wrapped it in the shared `flock` — holds the gate lock
-  the entire time, silently starving every sibling lane. On 2026-07-27 this
+  test XML, and, if you wrapped it in the shared `flock`, holds the gate lock
+  the entire time and silently starves every sibling lane. On 2026-07-27 that
   burned a full lane's gate run and starved four others; it is also the most
   likely explanation for an earlier #1598 gate that "stalled" at
   `:app:compileDebugKotlin` with no verdict. A ~1-line gate log is not a slow
   run and not a failure — it is a run that never happened. Discard it; do not
   read a verdict out of it.
-- **The canonical forced local gate is `scripts/full-jvm-gate.sh`, which runs
+
+  **Documenting this class by NAMING ONE FILE is what let it persist.** For
+  months this bullet said "`scripts/full-jvm-gate.sh` is a Python program" —
+  and `check-ci-unit-forced-execution.sh` and `check-full-jvm-gate-profile.sh`
+  sat beside it, also Python, unmentioned. Naming one file actively taught
+  readers the others were safe: during #2066 a reviewer who *had* been briefed
+  on the trap ran `bash scripts/check-ci-unit-forced-execution.sh` and read its
+  `rc=0` (with a parse error on stderr) as a pass. So the fix is not a longer
+  list. All three were renamed to `.py`, and the guard now enforces, with **no
+  allowlist**, that (1) a `*.sh` file has a shell shebang and a `*.py` file has
+  a python shebang, and (2) no tracked file invokes a non-shell program through
+  `bash`/`sh`/`source`. It runs per push in the `Static guards` job under the
+  required `Unit tests` check, with a self-test that plants a violation of each
+  rule and requires a RED. If you add a program in any language, give it that
+  language's extension; the guard will tell you before CI does.
+- **The canonical forced local gate is `scripts/full-jvm-gate.py`, which runs
   the complete `./gradlew test --rerun-tasks` graph inside the repository's
   8 GiB cgroup with the guarded single-worker / split-heap profile. Do not
   append filters, exclusions, or ad-hoc Gradle flags. The authenticated

--- a/scripts/check-ci-unit-forced-execution.py
+++ b/scripts/check-ci-unit-forced-execution.py
@@ -132,7 +132,7 @@ def main() -> None:
         return
     if len(arguments) > 1 or (arguments and arguments[0].startswith("--")):
         raise GuardFailure(
-            "usage: scripts/check-ci-unit-forced-execution.sh "
+            "usage: scripts/check-ci-unit-forced-execution.py "
             "[--self-test | WORKFLOW]"
         )
     workflow = Path(arguments[0]) if arguments else DEFAULT_WORKFLOW

--- a/scripts/check-full-jvm-gate-profile.py
+++ b/scripts/check-full-jvm-gate-profile.py
@@ -16,9 +16,9 @@ from pathlib import Path
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
-DEFAULT_ENTRYPOINT = ROOT_DIR / "scripts" / "full-jvm-gate.sh"
+DEFAULT_ENTRYPOINT = ROOT_DIR / "scripts" / "full-jvm-gate.py"
 EXPECTED_ENTRYPOINT_SHA256 = (
-    "216068796d70b6765fc21d42e831f24f31e1f4d02515e2a5f0e672aab9e5280a"
+    "b88e7bd984bd8c13ac46876d2afefe224e3472a9bcde36d70a7550898b67409e"
 )
 EXPECTED_CGROUP_RUNNER_SHA256 = (
     "6e4ce5f99cf4a6666aa9ac0c097776fb2bd4b87b2cc01744ddd06e4fee114b20"
@@ -81,7 +81,7 @@ def validate_entrypoint(entrypoint: Path) -> None:
         )
     scripts_dir = entrypoint.parent
     validate_regular_executable(
-        scripts_dir / "check-full-jvm-gate-profile.sh",
+        scripts_dir / "check-full-jvm-gate-profile.py",
         "full-JVM profile guard",
     )
     validate_regular_executable(
@@ -276,8 +276,8 @@ def self_test(
         fixture_scripts = fixture_root / "scripts"
         fixture_scripts.mkdir(parents=True)
         (fixture_scripts / "lib").mkdir()
-        copied_entrypoint = fixture_scripts / "full-jvm-gate.sh"
-        copied_guard = fixture_scripts / "check-full-jvm-gate-profile.sh"
+        copied_entrypoint = fixture_scripts / "full-jvm-gate.py"
+        copied_guard = fixture_scripts / "check-full-jvm-gate-profile.py"
         shutil.copy2(
             entrypoint.parent / "lib" / "scope-run.sh",
             fixture_scripts / "lib" / "scope-run.sh",
@@ -1237,8 +1237,8 @@ def self_test(
                 variant_java = variant_java_home / "bin" / "java"
                 variant_java.write_text(java_script)
                 variant_java.chmod(0o755)
-            variant_entrypoint = variant_scripts / "full-jvm-gate.sh"
-            variant_guard = variant_scripts / "check-full-jvm-gate-profile.sh"
+            variant_entrypoint = variant_scripts / "full-jvm-gate.py"
+            variant_guard = variant_scripts / "check-full-jvm-gate-profile.py"
             write_paired_fixture(
                 entrypoint.read_text(),
                 Path(__file__).read_text(),
@@ -1392,7 +1392,7 @@ if arguments and arguments[0] == "--verified-preflight":
     verified_preflight = True
     arguments.pop(0)
 if len(arguments) > 1:
-    fail("usage: scripts/check-full-jvm-gate-profile.sh [--self-test] [entrypoint]")
+    fail("usage: scripts/check-full-jvm-gate-profile.py [--self-test] [entrypoint]")
 target = Path(os.path.abspath(arguments[0])) if arguments else DEFAULT_ENTRYPOINT
 if self_test_requested:
     self_test(

--- a/scripts/check-release-gate-execution-profile.sh
+++ b/scripts/check-release-gate-execution-profile.sh
@@ -1323,11 +1323,11 @@ check_default_profile() {
   # keep these literals honest.
   CHECKS_RUN=$((CHECKS_RUN + 1))
   [[ "$POCKETSHELL_KOTLIN_DAEMON_HEAP_FLOOR_MIB" -ge 3072 ]] ||
-    { fail "Kotlin daemon heap floor must stay >= 3072 MiB (the canonical scripts/full-jvm-gate.sh value), got $POCKETSHELL_KOTLIN_DAEMON_HEAP_FLOOR_MIB" || rc=1; }
+    { fail "Kotlin daemon heap floor must stay >= 3072 MiB (the canonical scripts/full-jvm-gate.py value), got $POCKETSHELL_KOTLIN_DAEMON_HEAP_FLOOR_MIB" || rc=1; }
 
   CHECKS_RUN=$((CHECKS_RUN + 1))
   [[ "$POCKETSHELL_GRADLE_LAUNCHER_HEAP_FLOOR_MIB" -ge 1536 ]] ||
-    { fail "Gradle launcher heap floor must stay >= 1536 MiB (the canonical scripts/full-jvm-gate.sh value), got $POCKETSHELL_GRADLE_LAUNCHER_HEAP_FLOOR_MIB" || rc=1; }
+    { fail "Gradle launcher heap floor must stay >= 1536 MiB (the canonical scripts/full-jvm-gate.py value), got $POCKETSHELL_GRADLE_LAUNCHER_HEAP_FLOOR_MIB" || rc=1; }
 
   CHECKS_RUN=$((CHECKS_RUN + 1))
   [[ "$POCKETSHELL_RELEASE_GATE_SCOPE_MEM_FLOOR_GIB" -ge 20 ]] ||
@@ -1487,7 +1487,7 @@ self_test() {
   # script LOAD time, which hard-failed
   # `AvdLockScriptTest.avdLockHelperOwnershipHarnessPasses` and
   # `ReleaseGateScriptTest.phoneWalkthroughDispatchesEveryScenario`.
-  # `scripts/full-jvm-gate.sh` exports POCKETSHELL_TEST_MEM=8G into every unit
+  # `scripts/full-jvm-gate.py` exports POCKETSHELL_TEST_MEM=8G into every unit
   # test, and those tests drive these scripts in modes that build nothing.
   #
   # Every probe runs through `as_local`: the floor is CI-exempt, so on GitHub

--- a/scripts/check-script-interpreter-hygiene.sh
+++ b/scripts/check-script-interpreter-hygiene.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# Script interpreter hygiene guard (issue #2066).
+#
+# THE CLASS THIS EXISTS TO KILL
+#
+# A file whose EXTENSION says one language and whose SHEBANG says another. The
+# instance this repo shipped for months: `scripts/full-jvm-gate.sh` was a Python
+# program (`#!/usr/bin/python3 -I`). Run it the way the extension invites —
+# `bash scripts/full-jvm-gate.sh` — and bash mis-executes it line by line. Line
+# 3 is `import os`, and `import` on this box is IMAGEMAGICK's screen-capture
+# tool, which blocks forever waiting on an X display.
+#
+# The resulting artifact is the nastiest one in this repository's catalogue,
+# because it does not look like a failure:
+#
+#   * the process stays "active" indefinitely — no error, no exit;
+#   * it writes a ~1-line log and produces zero test XML;
+#   * wrapped in the shared `flock`, it holds the gate lock the whole time and
+#     silently starves every sibling lane.
+#
+# On 2026-07-27 that burned one lane's gate run and starved four others.
+#
+# WHY A GUARD AND NOT A PARAGRAPH
+#
+# `process.md` and `AGENTS.md` already documented this — by NAME, for exactly
+# one file. Two more instances (`check-ci-unit-forced-execution.sh`,
+# `check-full-jvm-gate-profile.sh`) sat undiscovered beside it, and naming one
+# file actively taught readers the others were safe: during the #2066 session a
+# reviewer who HAD been briefed on the trap ran
+# `bash scripts/check-ci-unit-forced-execution.sh` and read its rc=0 (with a
+# parse error on stderr) as a pass. Prose cannot enumerate a class. This can.
+#
+# WHAT IT CHECKS (over git-tracked files only)
+#
+#   1. EXTENSION/SHEBANG AGREEMENT. A `*.sh` file must have a shell shebang; a
+#      `*.py` file must have a python shebang. Zero allowlist — the durable fix
+#      for the three instances above was to rename them to `.py`, so there is
+#      nothing legitimate to exempt. An exemption list would reintroduce exactly
+#      the "these named files are special" lesson that failed.
+#
+#   2. NO SHELL-INVOCATION OF A NON-SHELL PROGRAM. No tracked file may contain
+#      `bash <path>` / `sh <path>` / `source <path>` / `. <path>` where <path>
+#      resolves to a tracked file whose shebang is not a shell. Rule 1 makes the
+#      extension honest; rule 2 stops a caller from lying about it anyway
+#      (`bash scripts/full-jvm-gate.py` is still the same hang).
+#
+# Both rules are checked against the index (`git ls-files` / `git grep -I`), so
+# binaries and untracked scratch are out of scope by construction.
+#
+# USAGE
+#
+#   scripts/check-script-interpreter-hygiene.sh [ROOT]     # check a tree
+#   scripts/check-script-interpreter-hygiene.sh --self-test
+#
+# The self-test builds throwaway git trees, plants one violation of each rule,
+# and requires the guard to go RED on each and stay GREEN on a clean tree — so a
+# guard that has silently stopped detecting anything cannot pass as protection.
+
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+
+SHELL_INTERPRETERS=" sh bash dash ksh mksh zsh ash busybox "
+PYTHON_INTERPRETERS=" python python2 python3 "
+
+# Reduce a shebang line to the bare interpreter name.
+#   "#!/usr/bin/python3 -I"        -> python3
+#   "#!/usr/bin/env bash"          -> bash
+#   "#!/usr/bin/env -S python3 -I" -> python3
+shebang_interpreter() {
+  local line="$1" first rest token
+  line="${line#\#!}"
+  # shellcheck disable=SC2206 # deliberate word split of the shebang argv.
+  local parts=($line)
+  first="${parts[0]:-}"
+  first="${first##*/}"
+  if [[ "$first" == "env" ]]; then
+    rest=("${parts[@]:1}")
+    for token in "${rest[@]}"; do
+      [[ "$token" == -* ]] && continue
+      [[ "$token" == *=* ]] && continue
+      first="${token##*/}"
+      break
+    done
+  fi
+  # python3.12 / python3.12m -> python3
+  if [[ "$first" =~ ^python([0-9]+)(\.[0-9]+)*m?$ ]]; then
+    first="python${BASH_REMATCH[1]}"
+  fi
+  printf '%s\n' "$first"
+}
+
+shebang_family() {
+  local interp="$1"
+  if [[ "$SHELL_INTERPRETERS" == *" $interp "* ]]; then
+    printf 'shell\n'
+  elif [[ "$PYTHON_INTERPRETERS" == *" $interp "* ]]; then
+    printf 'python\n'
+  else
+    printf 'other\n'
+  fi
+}
+
+# Populate SHEBANG_FAMILY[path]=shell|python|other for every tracked file whose
+# FIRST line is a shebang. One `git grep` pass, not one fork per file.
+declare -A SHEBANG_FAMILY=()
+load_shebangs() {
+  local root="$1" line path lineno text interp
+  SHEBANG_FAMILY=()
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    path="${line%%:*}"
+    line="${line#*:}"
+    lineno="${line%%:*}"
+    text="${line#*:}"
+    [[ "$lineno" == "1" ]] || continue
+    interp="$(shebang_interpreter "$text")"
+    SHEBANG_FAMILY["$path"]="$(shebang_family "$interp")|$interp"
+  done < <(git -C "$root" grep -I -n --no-color -e '^#!' -- . 2>/dev/null || true)
+}
+
+# Turn a token found in source ("$ROOT_DIR/scripts/x.py", './scripts/x.py',
+# "${root}/scripts/x.py") into a repo-relative path, or nothing.
+resolve_tracked_path() {
+  local root="$1" token="$2" candidate
+  token="${token%\"}"
+  token="${token%\'}"
+  token="${token#\"}"
+  token="${token#\'}"
+  candidate="$token"
+  while [[ "$candidate" == *"/"* ]]; do
+    if [[ -n "${TRACKED[$candidate]:-}" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    candidate="${candidate#*/}"
+  done
+  if [[ -n "${TRACKED[$candidate]:-}" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+declare -A TRACKED=()
+load_tracked() {
+  local root="$1" path
+  TRACKED=()
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    TRACKED["$path"]=1
+  done < <(git -C "$root" ls-files)
+}
+
+VIOLATIONS=0
+report() {
+  printf 'FAIL: %s\n' "$1" >&2
+  VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+check_extension_matches_shebang() {
+  local root="$1" path entry family interp
+  for path in "${!SHEBANG_FAMILY[@]}"; do
+    entry="${SHEBANG_FAMILY[$path]}"
+    family="${entry%%|*}"
+    interp="${entry##*|}"
+    case "$path" in
+      *.sh)
+        [[ "$family" == "shell" ]] || report \
+          "$path has a .sh extension but a '$interp' shebang. 'bash $path' will mis-execute it line by line (issue #2066: a python program's 'import os' runs ImageMagick's import and hangs on X forever). Rename it to the extension its shebang names."
+        ;;
+      *.py)
+        [[ "$family" == "python" ]] || report \
+          "$path has a .py extension but a '$interp' shebang. Rename it to the extension its shebang names (issue #2066)."
+        ;;
+    esac
+  done
+}
+
+check_no_shell_invocation_of_non_shell() {
+  local root="$1" line path lineno text token resolved entry family
+  local pattern='(^|[^-[:alnum:]_./])(bash|sh|source|\.)([[:space:]]+-[[:alnum:]]+)*[[:space:]]+[^[:space:];&|)]*\.(sh|py)'
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    path="${line%%:*}"
+    line="${line#*:}"
+    lineno="${line%%:*}"
+    text="${line#*:}"
+    # The guard's own source documents the banned form; it must not flag itself.
+    [[ "$path" == "scripts/check-script-interpreter-hygiene.sh" ]] && continue
+    for token in $(printf '%s\n' "$text" \
+      | grep -oE "$pattern" \
+      | grep -oE '[^[:space:]]+\.(sh|py)$' || true); do
+      resolved="$(resolve_tracked_path "$root" "$token")" || continue
+      entry="${SHEBANG_FAMILY[$resolved]:-}"
+      [[ -n "$entry" ]] || continue
+      family="${entry%%|*}"
+      [[ "$family" == "shell" ]] && continue
+      report "$path:$lineno invokes '$resolved' through a shell ('$token'), but $resolved is a ${family} program. Run it directly; a shell reading a python program mis-executes it line by line (issue #2066)."
+    done
+  done < <(git -C "$root" grep -I -n -E --no-color -e "$pattern" -- . 2>/dev/null || true)
+}
+
+check_tree() {
+  local root="$1" path
+  VIOLATIONS=0
+  load_tracked "$root"
+  for path in "${!TRACKED[@]}"; do
+    if [[ "$path" == *:* ]]; then
+      report "tracked path '$path' contains a colon; this guard parses 'path:line:text' output and cannot reason about it"
+    fi
+  done
+  load_shebangs "$root"
+  if (( ${#SHEBANG_FAMILY[@]} == 0 )); then
+    report "found zero shebang-bearing tracked files under $root; the guard would pass vacuously"
+  fi
+  check_extension_matches_shebang "$root"
+  check_no_shell_invocation_of_non_shell "$root"
+  if (( VIOLATIONS > 0 )); then
+    printf '\n%s: %d violation(s). See issue #2066.\n' "$root" "$VIOLATIONS" >&2
+    return 1
+  fi
+  printf 'OK: %d tracked shebang files agree with their extension, and no tracked caller shells a non-shell program (%s).\n' \
+    "${#SHEBANG_FAMILY[@]}" "$root"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Self-test
+# ---------------------------------------------------------------------------
+
+SELF_TEST_CASES=0
+SELF_TEST_FAILURES=0
+
+self_pass() {
+  SELF_TEST_CASES=$((SELF_TEST_CASES + 1))
+  printf 'self-test PASS: %s\n' "$1"
+}
+
+self_fail() {
+  SELF_TEST_CASES=$((SELF_TEST_CASES + 1))
+  SELF_TEST_FAILURES=$((SELF_TEST_FAILURES + 1))
+  printf 'self-test FAIL: %s\n' "$1" >&2
+}
+
+make_fixture_tree() {
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/docs"
+  printf '#!/usr/bin/env bash\necho ok\n' > "$dir/scripts/real-shell.sh"
+  printf '#!/usr/bin/python3 -I\nprint("ok")\n' > "$dir/scripts/real-python.py"
+  printf '#!/bin/sh\n. scripts/lib.sh\n' > "$dir/scripts/sourcer.sh"
+  printf '#!/usr/bin/env bash\n:\n' > "$dir/scripts/lib.sh"
+  # A legitimate shell invocation of a shell script, and prose naming a python
+  # program without shelling it. Neither may be flagged.
+  printf 'Run `bash scripts/real-shell.sh`, then scripts/real-python.py.\n' \
+    > "$dir/docs/readme.md"
+  git -C "$dir" init -q
+  git -C "$dir" add -A
+}
+
+run_guard_on() {
+  local dir="$1" out rc=0
+  out="$("$SELF_DIR/check-script-interpreter-hygiene.sh" "$dir" 2>&1)" || rc=$?
+  printf '%s\n' "$out"
+  return "$rc"
+}
+
+self_test() {
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/ps-2066-selftest-XXXXXX")"
+  # shellcheck disable=SC2064 # expand tmp now, at trap-installation time.
+  trap "rm -rf '$tmp'" EXIT
+
+  local dir out rc
+
+  # Case 1: a clean tree passes, and the legitimate `bash scripts/real-shell.sh`
+  # caller is NOT flagged (selectivity: no false positive on real shell work).
+  dir="$tmp/clean"
+  mkdir -p "$dir"
+  make_fixture_tree "$dir"
+  rc=0
+  out="$(run_guard_on "$dir")" || rc=$?
+  if (( rc == 0 )) && [[ "$out" == OK:* ]]; then
+    self_pass "a clean tree passes, and 'bash scripts/real-shell.sh' is not flagged"
+  else
+    self_fail "a clean tree should pass (rc=$rc): $out"
+  fi
+
+  # Case 2: rule 1 — a .sh file carrying a python shebang must go RED.
+  dir="$tmp/sh-is-python"
+  mkdir -p "$dir"
+  make_fixture_tree "$dir"
+  printf '#!/usr/bin/python3 -I\nimport os\n' > "$dir/scripts/liar.sh"
+  git -C "$dir" add -A
+  rc=0
+  out="$(run_guard_on "$dir")" || rc=$?
+  if (( rc != 0 )) && [[ "$out" == *"scripts/liar.sh has a .sh extension but a 'python3' shebang"* ]]; then
+    self_pass "rule 1 reddens on a .sh file with a python shebang"
+  else
+    self_fail "rule 1 did not redden on scripts/liar.sh (rc=$rc): $out"
+  fi
+  if [[ "$out" == *": 1 violation(s)"* ]]; then
+    self_pass "rule 1 reports exactly the planted violation (selectivity)"
+  else
+    self_fail "rule 1 reported more than the planted violation: $out"
+  fi
+
+  # Case 3: rule 1, the mirror — a .py file carrying a shell shebang.
+  dir="$tmp/py-is-shell"
+  mkdir -p "$dir"
+  make_fixture_tree "$dir"
+  printf '#!/usr/bin/env bash\necho nope\n' > "$dir/scripts/liar.py"
+  git -C "$dir" add -A
+  rc=0
+  out="$(run_guard_on "$dir")" || rc=$?
+  if (( rc != 0 )) && [[ "$out" == *"scripts/liar.py has a .py extension but a 'bash' shebang"* ]]; then
+    self_pass "rule 1 reddens on a .py file with a shell shebang"
+  else
+    self_fail "rule 1 did not redden on scripts/liar.py (rc=$rc): $out"
+  fi
+
+  # Case 4: rule 2 — a caller that shells an (honestly named) python program.
+  # This is the residual trap after the rename: `bash scripts/x.py` hangs too.
+  dir="$tmp/bash-invokes-python"
+  mkdir -p "$dir"
+  make_fixture_tree "$dir"
+  printf '#!/usr/bin/env bash\nbash scripts/real-python.py\n' > "$dir/scripts/caller.sh"
+  git -C "$dir" add -A
+  rc=0
+  out="$(run_guard_on "$dir")" || rc=$?
+  if (( rc != 0 )) && [[ "$out" == *"scripts/caller.sh:2 invokes 'scripts/real-python.py' through a shell"* ]]; then
+    self_pass "rule 2 reddens when a tracked caller runs a python program through bash"
+  else
+    self_fail "rule 2 did not redden on 'bash scripts/real-python.py' (rc=$rc): $out"
+  fi
+
+  # Case 5: rule 2 also catches the variable-prefixed and flagged forms the
+  # repository actually writes ("$ROOT_DIR/scripts/x.py", `bash -n x.py`).
+  dir="$tmp/bash-invokes-python-varpath"
+  mkdir -p "$dir"
+  make_fixture_tree "$dir"
+  printf '#!/usr/bin/env bash\nbash -n "$ROOT_DIR/scripts/real-python.py"\n' \
+    > "$dir/scripts/caller.sh"
+  git -C "$dir" add -A
+  rc=0
+  out="$(run_guard_on "$dir")" || rc=$?
+  if (( rc != 0 )) && [[ "$out" == *"invokes 'scripts/real-python.py' through a shell"* ]]; then
+    self_pass "rule 2 reddens on 'bash -n \"\$ROOT_DIR/scripts/x.py\"'"
+  else
+    self_fail "rule 2 missed the variable-prefixed flagged form (rc=$rc): $out"
+  fi
+
+  # Case 6: a tree with no shebang-bearing file must NOT read as a pass.
+  dir="$tmp/empty"
+  mkdir -p "$dir/docs"
+  printf 'nothing executable here\n' > "$dir/docs/readme.md"
+  git -C "$dir" init -q
+  git -C "$dir" add -A
+  rc=0
+  out="$(run_guard_on "$dir")" || rc=$?
+  if (( rc != 0 )) && [[ "$out" == *"would pass vacuously"* ]]; then
+    self_pass "a tree with zero shebang files is refused, not silently passed"
+  else
+    self_fail "a shebang-free tree passed vacuously (rc=$rc): $out"
+  fi
+
+  printf '\nself-test: %d case(s), %d failure(s)\n' \
+    "$SELF_TEST_CASES" "$SELF_TEST_FAILURES"
+  if (( SELF_TEST_CASES == 0 )); then
+    printf 'self-test executed zero cases; that is not a pass.\n' >&2
+    return 1
+  fi
+  (( SELF_TEST_FAILURES == 0 ))
+}
+
+main() {
+  case "${1:-}" in
+    --self-test)
+      self_test
+      ;;
+    -h | --help)
+      sed -n '/^# USAGE/,/^$/p' "${BASH_SOURCE[0]}"
+      ;;
+    "")
+      check_tree "$DEFAULT_ROOT"
+      ;;
+    *)
+      check_tree "$1"
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -117,7 +117,7 @@ source "$ROOT_DIR/scripts/lib/agents-pool.sh"
 # survives. Degrades to a bare invocation when user systemd is unavailable (CI).
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 # Issue #2007: the AVD lock protects the EMULATOR; nothing protected the Gradle
-# OUTPUT TREE. A connected build and scripts/full-jvm-gate.sh overlapping in one
+# OUTPUT TREE. A connected build and scripts/full-jvm-gate.py overlapping in one
 # worktree both rewrite this checkout's app/build graph, and `--rerun-tasks`
 # deletes intermediates the sibling is consuming (the #893 gate died on a
 # missing processDebugResources/R.jar). Sourcing this makes

--- a/scripts/full-jvm-gate.py
+++ b/scripts/full-jvm-gate.py
@@ -35,7 +35,7 @@ EXPECTED_SCOPE_RUNNER_SHA256 = (
     "39406248dd3de35f3b6f5c47ba1ca4c6462b296b0a4995192160b8db5d61761d"
 )
 EXPECTED_PROFILE_GUARD_SHA256 = (
-    "1200071bec8202c00a3ffa6f59e5bcfcd4746004d5b14606452c8efcdbd1b5dc"
+    "481f47c733b8130ac1c7ddda172d41790b5316d02807960b01e828deda879db9"
 )
 GRADLE_ARGS = (
     "test",
@@ -446,7 +446,7 @@ while arguments:
     argument = arguments.pop(0)
     if argument in ("--help", "-h"):
         print(
-            "Usage: scripts/full-jvm-gate.sh [--unit <name>]\n\n"
+            "Usage: scripts/full-jvm-gate.py [--unit <name>]\n\n"
             "Runs the complete forced JVM graph under the immutable issue #1761 "
             "8 GiB/single-worker/split-heap profile."
         )
@@ -472,7 +472,7 @@ if output_lock_probe:
     probe_lock_file = gradle_output_lock_file(root_dir, "", identity.pw_dir)
     acquire_gradle_output_lock(
         probe_lock_file,
-        f"full-jvm-gate.sh --output-lock-probe ({root_dir})",
+        f"full-jvm-gate.py --output-lock-probe ({root_dir})",
     )
     sys.stdout.write(f"gradle_output_lock={probe_lock_file}\n")
     sys.stdout.flush()
@@ -481,7 +481,7 @@ if output_lock_probe:
 
 if disk_preflight_probe:
     raise SystemExit(
-        disk_preflight(root_dir, "full-jvm-gate.sh --disk-preflight-probe")
+        disk_preflight(root_dir, "full-jvm-gate.py --disk-preflight-probe")
     )
 
 # Issue #1989: refuse a full-disk run before ANY expensive or shared step — the
@@ -490,7 +490,7 @@ if disk_preflight_probe:
 # workflow modes build nothing, so holding them to a build-sized free-space floor
 # would fail hosted runners for no reason.
 if profile_guard_arguments is None:
-    disk_preflight_result = disk_preflight(root_dir, f"full-jvm-gate.sh --unit {unit}")
+    disk_preflight_result = disk_preflight(root_dir, f"full-jvm-gate.py --unit {unit}")
     if disk_preflight_result != 0:
         raise SystemExit(disk_preflight_result)
 
@@ -543,7 +543,7 @@ if profile_guard_arguments is None:
     )
 
 entrypoint = Path(__file__).resolve()
-profile_guard = root_dir / "scripts" / "check-full-jvm-gate-profile.sh"
+profile_guard = root_dir / "scripts" / "check-full-jvm-gate-profile.py"
 try:
     guard_descriptor = os.open(profile_guard, os.O_RDONLY | os.O_NOFOLLOW)
     guard_metadata = os.fstat(guard_descriptor)
@@ -704,7 +704,7 @@ for descriptor, metadata, artifact, label in validated_fds:
 # survives the execve and is held for the whole run.
 acquire_gradle_output_lock(
     gradle_output_lock_file(root_dir, "", identity.pw_dir),
-    f"full-jvm-gate.sh --unit {unit} ({root_dir})",
+    f"full-jvm-gate.py --unit {unit} ({root_dir})",
 )
 
 # The repository is the trust boundary. The descriptor/inode recheck rejects

--- a/scripts/lib/disk-preflight.sh
+++ b/scripts/lib/disk-preflight.sh
@@ -10,7 +10,7 @@
 #   * connected lane i1963green1 — Docker BuildKit could not write
 #     ~/.docker/buildx/...: `no space left on device`; then Gradle could not
 #     create ~/.gradle/caches/8.13/... and the build failed in 7s.
-#   * scripts/full-jvm-gate.sh — `:app:kspDebugKotlin` failed at 1m12s.
+#   * scripts/full-jvm-gate.py — `:app:kspDebugKotlin` failed at 1m12s.
 #
 # Why that costs more than the disk: NONE of those is an assertion failure, but
 # every one of them LOOKS like a broken gate. An ENOSPC failure is
@@ -29,7 +29,7 @@
 # sits on the box's scarcest resources while it discovers that.
 #
 # TWO HALVES THAT MUST AGREE. `scripts/connected-test.sh` sources this file;
-# `scripts/full-jvm-gate.sh` is an isolated Python program that deliberately
+# `scripts/full-jvm-gate.py` is an isolated Python program that deliberately
 # does not source shell libraries, so it reimplements the identical arithmetic
 # and the identical thresholds in Python. Both halves measure with statvfs
 # semantics (`f_bavail * f_frsize`, i.e. space available to a non-root user) —
@@ -71,7 +71,7 @@
 # mid-job". THAT PREMISE IS FALSE, and it is recorded here so it is not
 # rediscovered as a reason to lower the floor again:
 #   * This gate's real path NEVER runs on a hosted runner. .github/workflows/
-#     tests.yml invokes scripts/full-jvm-gate.sh only as --profile-guard-self-test
+#     tests.yml invokes scripts/full-jvm-gate.py only as --profile-guard-self-test
 #     and --profile-guard-check (both exempt from this preflight, both building
 #     nothing), and the real path additionally refuses to run with CI set.
 #   * The one CI exposure is connected-test.sh in the emulator job, and that job
@@ -100,7 +100,7 @@
 # read as "the change under test is red".
 POCKETSHELL_DISK_PREFLIGHT_FAIL_RC=76
 
-# Keep byte-identical to full-jvm-gate.sh's DISK_PREFLIGHT_* constants.
+# Keep byte-identical to full-jvm-gate.py's DISK_PREFLIGHT_* constants.
 POCKETSHELL_DISK_PREFLIGHT_DEFAULT_MIN_FREE_MB=10240
 POCKETSHELL_DISK_PREFLIGHT_DEFAULT_WARN_FREE_MB=20480
 

--- a/scripts/lib/gradle-output-lock.sh
+++ b/scripts/lib/gradle-output-lock.sh
@@ -4,7 +4,7 @@
 # Gradle output-tree lock (issue #2007)
 #
 # THE DEFECT this exists to stop coming back. `scripts/connected-test.sh` and
-# `scripts/full-jvm-gate.sh` are both canonical wrappers around `./gradlew`, and
+# `scripts/full-jvm-gate.py` are both canonical wrappers around `./gradlew`, and
 # both write the SAME `app/build/...` output graph of the checkout they are run
 # from. Nothing stopped them overlapping. During #893 validation in
 # `.worktrees/issue-893-recurrence` a connected `--rerun-tasks` build and the
@@ -38,7 +38,7 @@
 #     from the PASSWD entry, not the environment. A caller with an unusual
 #     exported HOME must not silently get a different lock directory than its
 #     sibling — that is exactly the split-lock bug #1657 fixed for the AVD half,
-#     and the Python half of this lock (scripts/full-jvm-gate.sh) reads the
+#     and the Python half of this lock (scripts/full-jvm-gate.py) reads the
 #     passwd entry because it deliberately distrusts the inherited environment.
 #     Both halves must agree byte-for-byte or the lock protects nothing.
 #
@@ -112,7 +112,7 @@ pocketshell_gradle_output_lock_resolved_root() {
 # Lock path for one (output root, lane) pair. The digest keeps the filename
 # bounded and path-safe; the human-readable key is written INTO the file by the
 # holder. Must stay byte-identical to gradle_output_lock_file() in
-# scripts/full-jvm-gate.sh — scripts/test-gradle-output-lock.sh pins that.
+# scripts/full-jvm-gate.py — scripts/test-gradle-output-lock.sh pins that.
 pocketshell_gradle_output_lock_file() {
   local output_root="$1"
   local lane="${2:-}"

--- a/scripts/lib/gradle-profile.sh
+++ b/scripts/lib/gradle-profile.sh
@@ -72,7 +72,7 @@
 #
 # Heap sizing rationale:
 #   -Pkotlin.daemon.jvmargs=-Xmx3072m  the canonical value from
-#       scripts/full-jvm-gate.sh, proven on the complete `test --rerun-tasks`
+#       scripts/full-jvm-gate.py, proven on the complete `test --rerun-tasks`
 #       graph. Kept exactly, in BOTH profiles.
 #   -Dorg.gradle.jvmargs=-Xmx3072m     (LOCAL only) ABOVE the canonical 1536m on
 #       purpose. The canonical gate only runs `test`; the release chain also runs
@@ -108,7 +108,7 @@
 #   ./gradlew --no-daemon "${POCKETSHELL_GRADLE_RESOURCE_ARGS[@]}" :app:assembleDebug
 #
 # The asymmetry is deliberate and was learned the hard way. `POCKETSHELL_TEST_MEM`
-# is AMBIENT ENVIRONMENT, not a constant, and `scripts/full-jvm-gate.sh` exports
+# is AMBIENT ENVIRONMENT, not a constant, and `scripts/full-jvm-gate.py` exports
 # `POCKETSHELL_TEST_MEM=8G` (its MEMORY_LIMIT) into every JVM unit test. Several
 # unit tests drive these scripts through `tests/scripts/*.sh` harnesses in modes
 # that never build anything (`--help`, `PHONE_WALKTHROUGH_VERIFY_DISPATCH_ONLY=1`),

--- a/scripts/select-test-areas.sh
+++ b/scripts/select-test-areas.sh
@@ -281,7 +281,7 @@ class_selected() {
 # invocation, so a shared-module task would be filtered by an :app class name
 # and fail with "no tests found". Full mode emits the byte-identical whole-graph
 # command the Unit job runs today, which is what keeps
-# check-ci-unit-forced-execution.sh satisfied on the full path.
+# check-ci-unit-forced-execution.py satisfied on the full path.
 #
 # TWO round-1 defects are fixed here.
 #

--- a/scripts/test-gradle-output-lock.sh
+++ b/scripts/test-gradle-output-lock.sh
@@ -4,7 +4,7 @@ set -uo pipefail
 # Gradle output-tree lock harness (issue #2007).
 #
 # THE DEFECT this harness exists to stop coming back. `scripts/connected-test.sh`
-# and `scripts/full-jvm-gate.sh` are both canonical wrappers around `./gradlew`,
+# and `scripts/full-jvm-gate.py` are both canonical wrappers around `./gradlew`,
 # and both rewrite the SAME `app/build/...` output graph of the checkout they run
 # from. Nothing stopped them overlapping. During #893 validation in
 # `.worktrees/issue-893-recurrence` a connected `--rerun-tasks` build and the
@@ -107,7 +107,7 @@ make_worktree() {
   mkdir -p "$root/scripts/lib" "$root/tests/docker" \
     "$root/app/build/intermediates/processDebugResources/debug"
   local script
-  for script in connected-test.sh full-jvm-gate.sh; do
+  for script in connected-test.sh full-jvm-gate.py; do
     cp "$ROOT_DIR/scripts/$script" "$root/scripts/$script" 2>/dev/null || true
   done
   # Glob the WHOLE scripts/lib rather than enumerating it. An enumerated list
@@ -296,7 +296,7 @@ start_full_gate_style_lane() {
     PATH="$STUB_BIN:$PATH" \
     POCKETSHELL_GRADLE_OUTPUT_LOCK_DIR="$OUTPUT_LOCK_DIR" \
     "$root/scripts/lib/gradle-output-lock.sh" \
-    --output-root "$root" --label "full-jvm-gate.sh style lane" \
+    --output-root "$root" --label "full-jvm-gate.py style lane" \
     -- "$root/gradlew" test --rerun-tasks \
     > "$log" 2>&1 &
   LANE_PID="$!"
@@ -611,7 +611,7 @@ lock_path_is_machine_anchored_and_per_output_tree() {
 
 # --------------------------------------------------------------------------
 # 6. The two implementations must agree. connected-test.sh resolves the lock in
-#    Bash; scripts/full-jvm-gate.sh resolves it in Python because it distrusts
+#    Bash; scripts/full-jvm-gate.py resolves it in Python because it distrusts
 #    the inherited environment. Two wrappers that disagree about the path
 #    exclude nothing -- and the disagreement would be SILENT, which is exactly
 #    how #1657 and #1842 stayed broken.
@@ -625,7 +625,7 @@ the_gate_and_the_wrappers_resolve_one_lock_file() {
   from_bash="$(resolve_lock_file "$wt" "")" || { fail "$from_bash"; return 1; }
   from_python="$(printf '' | env -u CI \
     POCKETSHELL_GRADLE_OUTPUT_LOCK_DIR="$OUTPUT_LOCK_DIR" \
-    "$wt/scripts/full-jvm-gate.sh" --output-lock-probe 2>"$tmp/equiv.err" \
+    "$wt/scripts/full-jvm-gate.py" --output-lock-probe 2>"$tmp/equiv.err" \
     | sed -n 's/^gradle_output_lock=//p')"
 
   if [[ -z "$from_python" ]]; then
@@ -633,7 +633,7 @@ the_gate_and_the_wrappers_resolve_one_lock_file() {
     return 1
   fi
   if [[ "$from_bash" != "$from_python" ]]; then
-    fail "scripts/lib/gradle-output-lock.sh and scripts/full-jvm-gate.sh resolve DIFFERENT lock files for one output tree ($from_bash vs $from_python) -- the connected wrapper and the gate would never exclude each other (issue #2007)"
+    fail "scripts/lib/gradle-output-lock.sh and scripts/full-jvm-gate.py resolve DIFFERENT lock files for one output tree ($from_bash vs $from_python) -- the connected wrapper and the gate would never exclude each other (issue #2007)"
     return 1
   fi
   pass "the Bash wrapper half and the Python gate half resolve the identical lock file"
@@ -662,7 +662,7 @@ a_blocked_gate_reports_the_owner_and_never_starts() {
   printf '' | env -u CI \
     POCKETSHELL_GRADLE_OUTPUT_LOCK_DIR="$OUTPUT_LOCK_DIR" \
     POCKETSHELL_GRADLE_OUTPUT_LOCK_WAIT_SECONDS=2 \
-    "$wt/scripts/full-jvm-gate.sh" --output-lock-probe \
+    "$wt/scripts/full-jvm-gate.py" --output-lock-probe \
     > "$tmp/queue-gate.out" 2> "$tmp/queue-gate.err" || rc=$?
   touch "$release"; kill_group "$holder_pid"
 
@@ -793,7 +793,7 @@ a_nested_wrapper_reuses_its_ancestors_ownership() {
     POCKETSHELL_GRADLE_OUTPUT_LOCK_WAIT_SECONDS=3 \
     "$wt/scripts/lib/gradle-output-lock.sh" --output-root "$wt" \
     --label "ancestor holding for a nested gate" \
-    -- env -u CI "$wt/scripts/full-jvm-gate.sh" --output-lock-probe \
+    -- env -u CI "$wt/scripts/full-jvm-gate.py" --output-lock-probe \
     > "$tmp/nested-gate.out" 2> "$tmp/nested-gate.err" || rc=$?
 
   if [[ "$rc" != "0" ]]; then
@@ -1197,7 +1197,7 @@ the_avd_lock_stays_a_separate_concern() {
 # --------------------------------------------------------------------------
 both_canonical_wrappers_take_the_lock_before_gradle() {
   local connected="$ROOT_DIR/scripts/connected-test.sh"
-  local gate="$ROOT_DIR/scripts/full-jvm-gate.sh"
+  local gate="$ROOT_DIR/scripts/full-jvm-gate.py"
 
   # Comments ABOUT the call are not the call, at either end.
   local acquire_line first_gradle_line
@@ -1222,7 +1222,7 @@ both_canonical_wrappers_take_the_lock_before_gradle() {
   gate_acquire_line="$(grep -n '^acquire_gradle_output_lock(' "$gate" | head -n1 | cut -d: -f1)"
   gate_exec_line="$(grep -n '^os.execve(' "$gate" | head -n1 | cut -d: -f1)"
   if [[ -z "$gate_acquire_line" ]]; then
-    fail "scripts/full-jvm-gate.sh no longer acquires the gradle output lock before exec (issue #2007)"
+    fail "scripts/full-jvm-gate.py no longer acquires the gradle output lock before exec (issue #2007)"
     return 1
   fi
   if [[ -z "$gate_exec_line" ]]; then
@@ -1230,7 +1230,7 @@ both_canonical_wrappers_take_the_lock_before_gradle() {
     return 1
   fi
   if (( gate_acquire_line > gate_exec_line )); then
-    fail "scripts/full-jvm-gate.sh acquires the output lock (line $gate_acquire_line) after its exec (line $gate_exec_line)"
+    fail "scripts/full-jvm-gate.py acquires the output lock (line $gate_acquire_line) after its exec (line $gate_exec_line)"
     return 1
   fi
   pass "both canonical wrappers acquire the output lock before they run gradle"

--- a/tests/scripts/disk-preflight-test.sh
+++ b/tests/scripts/disk-preflight-test.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 # The reported defect is a dev-box root filesystem at 100% turning two canonical
 # gates into infrastructure failures that LOOK like product failures. The
 # reproduction therefore drives the REAL `scripts/connected-test.sh` and the REAL
-# `scripts/full-jvm-gate.sh` — not a stand-in — against a filesystem whose free
+# `scripts/full-jvm-gate.py` — not a stand-in — against a filesystem whose free
 # space is below the bar, and asserts they refuse to start.
 #
 # The "below the bar" condition is created by lowering the BAR, not by filling
@@ -74,7 +74,7 @@ BELOW_FLOOR_MB=999999999999
 # ---------------------------------------------------------------------------
 # 1. The two halves of the preflight must agree.
 #
-# connected-test.sh resolves the preflight in Bash and full-jvm-gate.sh (an
+# connected-test.sh resolves the preflight in Bash and full-jvm-gate.py (an
 # isolated Python program that deliberately sources no shell library) resolves
 # it in Python. Two canonical wrappers that disagree about "is there room"
 # protect nothing — the same failure mode as the #2007 lock's two halves, which
@@ -93,11 +93,11 @@ halves_agree_on_thresholds_and_rc() {
   )"
 
   python_min="$(sed -n 's/^DISK_PREFLIGHT_DEFAULT_MIN_FREE_MB = \([0-9]*\)$/\1/p' \
-    "$ROOT_DIR/scripts/full-jvm-gate.sh")"
+    "$ROOT_DIR/scripts/full-jvm-gate.py")"
   python_warn="$(sed -n 's/^DISK_PREFLIGHT_DEFAULT_WARN_FREE_MB = \([0-9]*\)$/\1/p' \
-    "$ROOT_DIR/scripts/full-jvm-gate.sh")"
+    "$ROOT_DIR/scripts/full-jvm-gate.py")"
   python_rc="$(sed -n 's/^DISK_PREFLIGHT_FAIL_RC = \([0-9]*\)$/\1/p' \
-    "$ROOT_DIR/scripts/full-jvm-gate.sh")"
+    "$ROOT_DIR/scripts/full-jvm-gate.py")"
 
   [[ -n "$python_min" && -n "$python_warn" && -n "$python_rc" ]] \
     || fail "could not read the python half's disk-preflight constants"
@@ -213,7 +213,7 @@ malformed_threshold_fails_closed() {
 
   rc=0
   output="$(POCKETSHELL_DISK_MIN_FREE_MB="10 GiB" \
-    "$ROOT_DIR/scripts/full-jvm-gate.sh" --disk-preflight-probe 2>&1)" || rc=$?
+    "$ROOT_DIR/scripts/full-jvm-gate.py" --disk-preflight-probe 2>&1)" || rc=$?
   (( rc == 76 )) || fail "python half accepted a malformed threshold (rc=$rc)"
   [[ "$output" == *"must be a whole number of MiB"* ]] \
     || fail "python half did not name the malformed threshold: $output"
@@ -221,25 +221,25 @@ malformed_threshold_fails_closed() {
 }
 
 # ---------------------------------------------------------------------------
-# 4. full-jvm-gate.sh refuses below the floor and proceeds above it.
+# 4. full-jvm-gate.py refuses below the floor and proceeds above it.
 # ---------------------------------------------------------------------------
 full_jvm_gate_probe_refuses_and_allows() {
   local rc=0 output
   output="$(POCKETSHELL_DISK_MIN_FREE_MB="$BELOW_FLOOR_MB" \
-    "$ROOT_DIR/scripts/full-jvm-gate.sh" --disk-preflight-probe 2>&1)" || rc=$?
-  (( rc == 76 )) || fail "full-jvm-gate.sh did not refuse below the floor (rc=$rc): $output"
+    "$ROOT_DIR/scripts/full-jvm-gate.py" --disk-preflight-probe 2>&1)" || rc=$?
+  (( rc == 76 )) || fail "full-jvm-gate.py did not refuse below the floor (rc=$rc): $output"
   [[ "$output" == *"=== DISK PREFLIGHT FAILED (issue #1989) ==="* ]] \
-    || fail "full-jvm-gate.sh refusal is missing the operator-facing banner: $output"
+    || fail "full-jvm-gate.py refusal is missing the operator-facing banner: $output"
   [[ "$output" == *"scripts/disk-cleanup.sh"* ]] \
-    || fail "full-jvm-gate.sh refusal does not name the cleanup path: $output"
+    || fail "full-jvm-gate.py refusal does not name the cleanup path: $output"
   [[ "$output" == *"required:  $BELOW_FLOOR_MB MiB"* ]] \
-    || fail "full-jvm-gate.sh refusal does not report the required space: $output"
+    || fail "full-jvm-gate.py refusal does not report the required space: $output"
 
   rc=0
   POCKETSHELL_DISK_MIN_FREE_MB=0 \
-    "$ROOT_DIR/scripts/full-jvm-gate.sh" --disk-preflight-probe >/dev/null 2>&1 || rc=$?
-  (( rc == 0 )) || fail "full-jvm-gate.sh refused above the floor (rc=$rc)"
-  pass_case "full-jvm-gate.sh refuses below the floor with a full report, and proceeds above it"
+    "$ROOT_DIR/scripts/full-jvm-gate.py" --disk-preflight-probe >/dev/null 2>&1 || rc=$?
+  (( rc == 0 )) || fail "full-jvm-gate.py refused above the floor (rc=$rc)"
+  pass_case "full-jvm-gate.py refuses below the floor with a full report, and proceeds above it"
 }
 
 # ---------------------------------------------------------------------------
@@ -257,7 +257,7 @@ warn_line_fires_before_the_floor() {
 
   rc=0
   output="$(POCKETSHELL_DISK_MIN_FREE_MB=0 POCKETSHELL_DISK_WARN_FREE_MB="$BELOW_FLOOR_MB" \
-    "$ROOT_DIR/scripts/full-jvm-gate.sh" --disk-preflight-probe 2>&1)" || rc=$?
+    "$ROOT_DIR/scripts/full-jvm-gate.py" --disk-preflight-probe 2>&1)" || rc=$?
   (( rc == 0 )) || fail "the python warn line must not block the run (rc=$rc)"
   [[ "$output" == *"WARN: disk preflight (issue #1989)"* ]] \
     || fail "python half did not warn below the comfort line: $output"
@@ -286,7 +286,7 @@ make_connected_sandbox() {
   export POCKETSHELL_AVD_LOCK_DIR="$sandbox/avd-locks"
   export POCKETSHELL_GRADLE_OUTPUT_LOCK_DIR="$sandbox/gradle-output-locks"
 
-  # This harness unsets CI (full-jvm-gate.sh rejects any run with CI set outside
+  # This harness unsets CI (full-jvm-gate.py rejects any run with CI set outside
   # its guard-only modes), and scripts/lib/scope-run.sh keys its hosted-runner
   # fallback off exactly that variable: with no reachable `systemd --user`
   # manager AND no CI, pocketshell_scope_run fails closed with rc 125 rather
@@ -403,7 +403,7 @@ connected_test_cleanup_mode_is_exempt() {
 # 6b. The fixtures must survive a HOSTED-RUNNER host, not just this dev box.
 #
 # This harness runs in the required `Unit tests` check, where CI=true — but it
-# must unset CI, because full-jvm-gate.sh rejects any run with CI set outside
+# must unset CI, because full-jvm-gate.py rejects any run with CI set outside
 # its guard-only modes. scripts/lib/scope-run.sh keys its bare-execution
 # fallback off exactly that variable, so unsetting CI on a host with no
 # reachable `systemd --user` manager makes pocketshell_scope_run fail closed


### PR DESCRIPTION
The trap was documented as a property of **one file**. It was never unique, and naming one file actively taught that the others were safe — a reviewer briefed on the trap still ran `check-ci-unit-forced-execution.sh` under `bash` this week and got **rc=0 with a parse error on stderr**. A fake pass, from someone who knew.

**The sweep found three, not the two the issue named.** `scripts/check-full-jvm-gate-profile.sh` is also `#!/usr/bin/python3 -I` — the hand-maintained list of special files was wrong *again*, inside the issue filed because it was wrong.

## Renamed, not allowlisted

All three become `.py`. An allowlist would exempt the only three instances that exist: it protects against nothing present and re-teaches the lesson that has now failed twice.

**The landmine:** `full-jvm-gate.py` and `check-full-jvm-gate-profile.py` cross-pin each other by SHA256, so renaming both looks like an unsolvable circular fixed point. It is solvable only because `canonical_entrypoint_digest` zeroes the circulating field. Resolved in order and re-asserted — and the reviewer recomputed both digests from **its own reimplementation of the canonicalisation**, not by calling the guard.

## The guard

`scripts/check-script-interpreter-hygiene.sh` reddens on base with **exactly 3 violations**, finding the instance nobody knew about, and passes at 163/163 on the fix. It runs in `guards-static`, confirmed present in all three `unit-gate` lists. Docs now describe a **guarded class**, not a named file.

## Symptom reproduced, not quoted

Under `xvfb-run`, `bash full-jvm-gate.sh` was **still running at the 20s bound with 107 bytes of log and zero test XML** — the hang that holds a `flock` and starves every sibling lane.

## Verification

Reviewer APPROVED. Independent: full reference sweep across tracked, untracked, workflows and dynamic name construction — zero executable references to the old names, the four remaining occurrences all deliberately historical prose; index modes `100755` so the dropped `chmod +x` is safe under `actions/checkout`; mutations against a `git checkout-index` copy each reddening exactly one violation; survives a scrubbed CI-like environment.

## Two notes

`tests.yml` lands at **130820 — only 252 bytes** under the hygiene cap. Passing, but the next change to that file has almost no room; #2069 reduces it and should land soon after.

A residual in the secondary rule is filed as a follow-up, not fixed here: it misses `/bin/bash x.py` and `bash -- x.py`, and the `/bin/bash <path>` form is **live** at `scripts/test-shared-tmux-wrapper-fixtures-selftest.sh:42,58`. Rule 1 is load-bearing and has no gap.

Closes #2066