### PR TITLE
test-infra: account the unconventional test files rather than hide them (#2065)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -423,8 +423,9 @@ to no area through a second resolver; four `@Test`-bearing files invisible to
 every registry and Gradle filter (the #1851 shape, now baselined so a NEW one
 fails — and one promptly did: #1622's `Issue1622DeadBandScreenshotHarness.kt`
 reached `main` hours later carrying three invisible `@Test` methods and this
-guard caught it before it merged, so the baseline is five; #2065 owns
-rename-vs-exempt for all five); 29 journeys compiling against connection-core
+guard caught it before it merged, so the baseline is five; #2065 then resolved
+all five — see "The five unconventional `@Test` files" below); 29 journeys
+compiling against connection-core
 that a connection-core change did not run; and `:shared:core-usage:test` — the
 deliberately fail-loud reader of `pocketshell usage --json` — having no
 mechanical link to the Python that produces it. The ledger guard is the first
@@ -459,7 +460,7 @@ Two consequences, stated so nobody has to re-derive them:
   test-infrastructure (15) force-full rules — 41 of the 65 force-fulls. That is
   its own issue with its own escape oracle, not a widening inside this one.
 
-### The four pieces
+### The five pieces
 
 | Piece | What it is |
 |---|---|
@@ -467,6 +468,67 @@ Two consequences, stated so nobody has to re-derive them:
 | `scripts/lib/test-areas.sh` | the shared classification engine every consumer reads |
 | `scripts/select-test-areas.sh` | changed paths → areas → the run plan, plus the manifest/coverage guards |
 | `scripts/check-test-execution-ledger.sh` | proves, from real JUnit results, that every class still executes |
+| `scripts/test-unconventional-test-files.txt` | the reviewed exemptions for `@Test`-bearing files outside the naming convention (#2065) |
+
+### The five unconventional `@Test` files (#2065)
+
+Five files carry `@Test` methods without matching `*Test.kt` / `*Test.java`, so
+no registry that keys off the filename — the journey registry, the area
+manifest, the executed-classes ledger, the validity guards — can see them.
+#2063 baselined them as a flat array of paths inside `select-test-areas.sh`, so
+a NEW one fails. #2065 is the other half: a decision per file.
+
+**The premise the decision had to correct first.** "Zero hits in
+`scripts/ci-journey-suite.sh`" was read as "does not execute". It is not.
+Nightly-extensive **phase 1 runs `:app:connectedDebugAndroidTest` wholesale**,
+with only a `notClass` exclusion list — so an androidTest class in no explicit
+suite still executes every night. And `DesignRenders` runs 68 testcases in
+`:shared:ui-kit:testDebugUnitTest` on every push. All five execute. The
+non-conventional name never opted them out of *execution*; it opted them out of
+*accounting*, which is the harm and is what the rows now fix.
+
+| File | Executes | Decision |
+|---|---|---|
+| `render/DesignRenders.kt` | `:shared:ui-kit:testDebugUnitTest`, 68 cases/push | exempt — `render.sh` already enumerates it per `@Test` **method** |
+| `Issue1622DeadBandScreenshotHarness.kt` | nightly wholesale (inert without `issue1622HoldMs`) | exempt — gate is `Issue1622ComposerSheetGeometryProofTest` |
+| `PromptComposerImeDeadSpaceScreenshotHarness.kt` | nightly wholesale (inert without `issue790HoldMs`) | exempt — gate is `PromptComposerImeEmptyDraftDeadSpaceProofTest` |
+| `TerminalHotkeysPanelScreenshotHarness.kt` | nightly wholesale | exempt — gate is `TerminalHotkeysPanelNoTruncationTest` |
+| `TmuxComposerLauncherLargeFontScreenshotHarness.kt` | nightly wholesale | exempt — gate is `TmuxComposerLauncherNarrowFontClipProofTest` |
+
+None was renamed, and the reason is not convenience. Four are screenshot
+*staging* harnesses: two are inert without an instrumentation argument, and the
+other two only `assertExists()` to prove the bitmap they are about to save is
+not of an empty screen. Renaming those to `*Test.kt` would put four vacuous or
+artifact-producing classes into every registry **as though they were gates** —
+the same "looks like coverage, contributes nothing" deception this issue exists
+to end, pointed the other way. `DesignRenders` is the one that genuinely runs a
+gate's worth of work, and it already has a *stronger* registry than renaming
+would give it: `scripts/render.sh` parses every `@Test` method out of the source
+and hard-fails when one lacks a `render("label")` mapping — per-method
+accounting, pinned per push by `render-selftest.sh` — while the module's
+execution is separately ledger-observed through the sibling conventional
+`DesignRenderStaticLoadingPolicyTest`.
+
+**What makes these exemptions different from a baseline.** Each row in
+`scripts/test-unconventional-test-files.txt` is
+`<path>TAB<executor>TAB<gate>TAB<reason>`, and the guard checks the first three:
+
+- `<executor>` is `unit-source-set` (path must be under `*/src/test/`) or
+  `nightly-connected` (path must be under `app/src/androidTest/`, **and** the
+  class's simple name must appear nowhere in `nightly-extensive-suite.sh` —
+  fail-closed, so naming it there for any reason forces the claim to be
+  re-argued). An executor the guard cannot check is rejected, not believed.
+- `<gate>` is either a FQCN, resolved through the **same class index** the area
+  manifest and the ledger use — so "the real assertion lives over there" cannot
+  point at a name that does not exist or at another invisible file — or
+  `enumerated-by:<script>`, which must exist and reference the path.
+- `<reason>` is mandatory and non-empty.
+
+It is deliberately **not** a `*Harness.kt` suffix rule. A suffix is a self-serve
+escape hatch: name a real regression test `…Harness.kt` and it hides itself with
+no reviewer in the loop. Cases 21a–21h of `select-test-areas-selftest.sh` mutate
+each claim and assert its specific red, including the load-bearing one — an
+unpinned unconventional `@Test` file reddens by name.
 
 ### The rule for a NEW test (do not re-litigate this)
 

--- a/scripts/select-test-areas-selftest.sh
+++ b/scripts/select-test-areas-selftest.sh
@@ -338,6 +338,11 @@ cp "$SCRIPT_DIR/select-test-areas.sh" "$MUTDIR/select-test-areas.sh"
 cp "$SCRIPT_DIR/lib/test-areas.sh" "$MUTDIR/lib/test-areas.sh"
 cp "$SCRIPT_DIR/test-areas.txt" "$MUTDIR/test-areas.txt"
 cp "$SCRIPT_DIR/ci-journey-suite.sh" "$MUTDIR/ci-journey-suite.sh"
+# The copies resolve their data relative to their own dir, so a copy that is not
+# given these reads a MISSING exemption list / nightly suite and reddens for a
+# reason that has nothing to do with the mutation under test (#2065).
+cp "$SCRIPT_DIR/test-unconventional-test-files.txt" "$MUTDIR/test-unconventional-test-files.txt"
+cp "$SCRIPT_DIR/nightly-extensive-suite.sh" "$MUTDIR/nightly-extensive-suite.sh"
 
 run_mut() {  # run the MUTATED copy against the REAL tree
   POCKETSHELL_TEST_AREAS_REPO_ROOT="$SCRIPT_DIR/.." \
@@ -418,6 +423,10 @@ mut_copy() {  # $1 = dir name -> echoes a runner-ready dir
   cp "$SCRIPT_DIR/lib/test-areas.sh"    "$d/lib/test-areas.sh"
   cp "$SCRIPT_DIR/test-areas.txt"       "$d/test-areas.txt"
   cp "$SCRIPT_DIR/ci-journey-suite.sh"  "$d/ci-journey-suite.sh"
+  # See the MUTDIR note: without these a copy fails on missing #2065 data
+  # rather than on the mutation the case is about.
+  cp "$SCRIPT_DIR/test-unconventional-test-files.txt" "$d/test-unconventional-test-files.txt"
+  cp "$SCRIPT_DIR/nightly-extensive-suite.sh" "$d/nightly-extensive-suite.sh"
   printf '%s\n' "$d"
 }
 run_copy() {  # $1 = dir, rest = args
@@ -1050,6 +1059,184 @@ if [[ "$mismatch" -eq 0 ]]; then
   ok "20 every registered class resolves by FQCN on the real tree (one resolver, no shared-module blind spot)"
 else
   bad "20 $mismatch registered class(es) resolve to no area by FQCN"
+fi
+
+# ---------------------------------------------------------------------------
+# CASE 21 (#2065) — the unconventional-@Test-file guard, and the exemption rows
+# that keep it honest.
+#
+# #2063 proved a NEW offender fails. #2065 added the other half: an exemption is
+# only allowed when the guard can CHECK how the file executes and what accounts
+# for it. Every row below mutates one of those claims and asserts the specific
+# red — because a baseline whose justifications are prose is a baseline that can
+# say anything (G6: name the mutation that must redden this assertion, then
+# actually apply it).
+#
+# These run against the REAL tree deliberately: the property under test is about
+# the real exemption list and the real files it pins, and a synthetic mini-repo
+# would only prove the parser parses. Only the exemption file (and, for 21f, the
+# nightly suite) is swapped for a mutated copy; everything else is the shipped
+# guard reading the shipped tree. The verdict is read from the specific FAIL
+# line, not the exit code, since the real tree emits many other checks.
+# ---------------------------------------------------------------------------
+UNCONV_REAL="$SCRIPT_DIR/test-unconventional-test-files.txt"
+UNCONVDIR="$SANDBOX/unconventional"
+mkdir -p "$UNCONVDIR"
+
+run_unconv() {  # $1 = exemption file, $2 = nightly suite (optional)
+  POCKETSHELL_TEST_AREAS_UNCONVENTIONAL="$1" \
+  POCKETSHELL_TEST_AREAS_NIGHTLY_SUITE="${2:-$SCRIPT_DIR/nightly-extensive-suite.sh}" \
+  bash "$SELECT" --verify-manifest 2>&1
+}
+
+if [[ ! -f "$UNCONV_REAL" ]]; then
+  bad "21 the exemption file is missing: $UNCONV_REAL"
+else
+  out="$(run_unconv "$UNCONV_REAL")"
+  if grep -q 'OK: no new @Test-bearing file outside' <<<"$out"; then
+    ok "21 the shipped exemption list is green on the real tree (every row's executor and gate check out)"
+  else
+    bad "21 the shipped exemption list is RED on the real tree:\n$(grep -E 'convention|exemption' <<<"$out")"
+  fi
+
+  # 21a — A NEW offender. Dropping a row makes its file unpinned, which is the
+  # SAME code path a newly added unconventional @Test file takes: this is the
+  # #1851 shape, and it is the one red that must never be losable.
+  grep -v '^shared/ui-kit' "$UNCONV_REAL" > "$UNCONVDIR/no-designrenders.txt"
+  if grep -q 'DesignRenders' "$UNCONVDIR/no-designrenders.txt"; then
+    bad "21a MUTATION DID NOT APPLY — the DesignRenders row is still in the copy, so 21a's verdict would be meaningless"
+  fi
+  out="$(run_unconv "$UNCONVDIR/no-designrenders.txt")"
+  if grep -q 'FAIL: 1 @Test-bearing file(s) do not follow' <<<"$out" &&
+     grep -q 'render/DesignRenders.kt' <<<"$out"; then
+    ok "21a an unpinned @Test-bearing file outside the convention reddens BY NAME (the #1851 shape)"
+  else
+    bad "21a an unpinned unconventional @Test file did NOT redden:\n$(grep -E 'convention|exemption' <<<"$out")"
+  fi
+
+  # 21b — Anti-rot the other way: a row that no longer pins a hidden file (the
+  # file was renamed to the convention, or deleted) must fail rather than sit
+  # there forever pretending to justify something.
+  { cat "$UNCONV_REAL"
+    printf 'app/src/test/java/com/pocketshell/app/GhostHarness.kt\tunit-source-set\tenumerated-by:scripts/render.sh\tstale row\n'
+  } > "$UNCONVDIR/stale.txt"
+  out="$(run_unconv "$UNCONVDIR/stale.txt")"
+  if grep -q 'FAIL: stale exemption' <<<"$out" && grep -q 'GhostHarness.kt' <<<"$out"; then
+    ok "21b a row that no longer pins a hidden @Test file reddens as stale (the list cannot rot into a lie)"
+  else
+    bad "21b a stale exemption row survived:\n$(grep -E 'convention|exemption' <<<"$out")"
+  fi
+
+  # 21c — The reason is mandatory. "Recorded exemption" means recorded; an empty
+  # justification is the baseline-by-default #2065 exists to stop.
+  sed 's|\(render/DesignRenders.kt\tunit-source-set\tenumerated-by:scripts/render.sh\t\).*|\1|' \
+    "$UNCONV_REAL" > "$UNCONVDIR/no-reason.txt"
+  if grep -qP 'DesignRenders\.kt\tunit-source-set\tenumerated-by:scripts/render\.sh\t.' \
+       "$UNCONVDIR/no-reason.txt"; then
+    bad "21c MUTATION DID NOT APPLY — the DesignRenders reason is still present in the copy"
+  fi
+  out="$(run_unconv "$UNCONVDIR/no-reason.txt")"
+  if grep -q 'FAIL: 1 unconventional-test-file exemption' <<<"$out" &&
+     grep -q 'expected <path>TAB<executor>TAB<gate>TAB<reason>' <<<"$out"; then
+    ok "21c an exemption with no recorded reason reddens"
+  else
+    bad "21c an exemption with no reason survived:\n$(grep -E 'convention|exemption' <<<"$out")"
+  fi
+
+  # 21d — The executor claim must match the path. Claiming the unit source set
+  # for an androidTest file would assert `./gradlew test` runs it, which is the
+  # exact false "it executes somewhere" this guard is supposed to refuse.
+  sed 's|\(TerminalHotkeysPanelScreenshotHarness.kt\t\)nightly-connected|\1unit-source-set|' \
+    "$UNCONV_REAL" > "$UNCONVDIR/wrong-executor.txt"
+  out="$(run_unconv "$UNCONVDIR/wrong-executor.txt")"
+  if grep -q "executor 'unit-source-set' but the path is not under \*/src/test/" <<<"$out"; then
+    ok "21d claiming the unit source set for an androidTest path reddens"
+  else
+    bad "21d a false unit-source-set executor claim survived:\n$(grep -E 'exemption' -A3 <<<"$out")"
+  fi
+
+  # 21e — An executor the guard cannot check is rejected, not believed. This is
+  # the "I could not check" != "I checked and it is fine" rule.
+  sed 's|\(TerminalHotkeysPanelScreenshotHarness.kt\t\)nightly-connected|\1runs-somewhere-trust-me|' \
+    "$UNCONV_REAL" > "$UNCONVDIR/unknown-executor.txt"
+  out="$(run_unconv "$UNCONVDIR/unknown-executor.txt")"
+  if grep -q "unknown executor 'runs-somewhere-trust-me'" <<<"$out"; then
+    ok "21e an unverifiable executor claim is rejected rather than believed"
+  else
+    bad "21e an unknown executor claim survived:\n$(grep -E 'exemption' -A3 <<<"$out")"
+  fi
+
+  # 21f — `nightly-connected` rests on nightly phase 1 running
+  # :app:connectedDebugAndroidTest WHOLESALE. The moment a class is named in the
+  # nightly suite (exclusion, shard pin, even a comment) that claim stops being
+  # inherited and has to be re-argued. Fail-closed on the simple name.
+  cp "$SCRIPT_DIR/nightly-extensive-suite.sh" "$UNCONVDIR/nightly.sh"
+  printf '\n# MUTANT 21f\nJOURNEY_EXCLUDED_CLASSES+=("$FQCN_PREFIX.TerminalHotkeysPanelScreenshotHarness")\n' \
+    >> "$UNCONVDIR/nightly.sh"
+  if ! grep -q 'MUTANT 21f' "$UNCONVDIR/nightly.sh"; then
+    bad "21f MUTATION DID NOT APPLY — the nightly exclusion is not live in the copy"
+  fi
+  out="$(run_unconv "$UNCONV_REAL" "$UNCONVDIR/nightly.sh")"
+  if grep -q "executor 'nightly-connected' claims the wholesale nightly run reaches it" <<<"$out" &&
+     grep -q 'TerminalHotkeysPanelScreenshotHarness' <<<"$out"; then
+    ok "21f excluding an exempted harness from the nightly wholesale run reddens its executor claim"
+  else
+    bad "21f a harness excluded from nightly kept its 'nightly-connected' claim:\n$(grep -E 'exemption' -A3 <<<"$out")"
+  fi
+
+  # 21i / 21j — The PREMISE under `nightly-connected`, not just the per-row
+  # check. "The class is not excluded" only implies "it runs" while phase 1 is a
+  # WHOLESALE run minus a notClass list. Flip phase 1 to an allowlist, or drop
+  # the subtraction, and every row would silently start lying with the per-row
+  # check still green — the G6 shape where the assertion survives the bug.
+  sed 's|\(-Pandroid.testInstrumentationRunnerArguments.notClass="\$JOURNEY_NOTCLASS_ARG" \\\)|\1\n  -Pandroid.testInstrumentationRunnerArguments.class="com.pocketshell.app.proof.Allowlisted" \\|' \
+    "$SCRIPT_DIR/nightly-extensive-suite.sh" > "$UNCONVDIR/nightly-allowlist.sh"
+  if [[ "$(sed -n '/phase 1: journey\/E2E/,/^JOURNEY_EXIT=/p' "$UNCONVDIR/nightly-allowlist.sh" |
+           grep -c 'RunnerArguments.class=')" -ne 1 ]]; then
+    bad "21i MUTATION DID NOT APPLY — phase 1 in the copy is not an allowlist, so 21i's verdict would be meaningless"
+  fi
+  out="$(run_unconv "$UNCONV_REAL" "$UNCONVDIR/nightly-allowlist.sh")"
+  if grep -q 'phase 1 now restricts what it runs' <<<"$out"; then
+    ok "21i turning nightly phase 1 into a class= allowlist reddens every nightly-connected row's premise"
+  else
+    bad "21i phase 1 became an allowlist and the nightly-connected rows stayed green:\n$(grep -E 'exemption' -A3 <<<"$out")"
+  fi
+
+  sed '/phase 1: journey\/E2E/,/^JOURNEY_EXIT=/ s|^  -Pandroid.testInstrumentationRunnerArguments.notClass=.*|  \\|' \
+    "$SCRIPT_DIR/nightly-extensive-suite.sh" > "$UNCONVDIR/nightly-noexclude.sh"
+  if [[ "$(sed -n '/phase 1: journey\/E2E/,/^JOURNEY_EXIT=/p' "$UNCONVDIR/nightly-noexclude.sh" |
+           grep -c 'RunnerArguments.notClass=')" -ne 0 ]]; then
+    bad "21j MUTATION DID NOT APPLY — phase 1 in the copy still subtracts a notClass list"
+  fi
+  out="$(run_unconv "$UNCONV_REAL" "$UNCONVDIR/nightly-noexclude.sh")"
+  if grep -q 'phase 1 no longer runs :app:connectedDebugAndroidTest minus a notClass list' <<<"$out"; then
+    ok "21j losing the wholesale-minus-notClass shape reddens the nightly-connected premise"
+  else
+    bad "21j the wholesale premise survived losing its shape:\n$(grep -E 'exemption' -A3 <<<"$out")"
+  fi
+
+  # 21g — The gate must be a class the registries can actually see. Resolved
+  # through the SAME class index the area manifest and the ledger use, so
+  # "the real assertion lives over there" cannot point at a name that does not
+  # exist, or at another invisible file.
+  sed 's|com.pocketshell.app.tmux.TerminalHotkeysPanelNoTruncationTest|com.pocketshell.app.tmux.TotallyFineGateTest|' \
+    "$UNCONV_REAL" > "$UNCONVDIR/ghost-gate.txt"
+  out="$(run_unconv "$UNCONVDIR/ghost-gate.txt")"
+  if grep -q "gate 'com.pocketshell.app.tmux.TotallyFineGateTest' is not a known test class" <<<"$out"; then
+    ok "21g a gate naming a class no registry knows reddens"
+  else
+    bad "21g a ghost gate class survived:\n$(grep -E 'exemption' -A3 <<<"$out")"
+  fi
+
+  # 21h — An `enumerated-by:` registry must actually enumerate THIS file.
+  sed 's|enumerated-by:scripts/render.sh|enumerated-by:scripts/ci-journey-suite.sh|' \
+    "$UNCONV_REAL" > "$UNCONVDIR/wrong-enumerator.txt"
+  out="$(run_unconv "$UNCONVDIR/wrong-enumerator.txt")"
+  if grep -q 'does not reference this path, so it cannot be enumerating it' <<<"$out"; then
+    ok "21h an enumerated-by: script that never mentions the file reddens"
+  else
+    bad "21h a bogus enumerated-by: claim survived:\n$(grep -E 'exemption' -A3 <<<"$out")"
+  fi
 fi
 
 echo

--- a/scripts/select-test-areas.sh
+++ b/scripts/select-test-areas.sh
@@ -65,6 +65,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${POCKETSHELL_TEST_AREAS_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 MANIFEST="${POCKETSHELL_TEST_AREAS_MANIFEST:-$SCRIPT_DIR/test-areas.txt}"
 JOURNEY_SUITE="${POCKETSHELL_TEST_AREAS_JOURNEY_SUITE:-$SCRIPT_DIR/ci-journey-suite.sh}"
+# Reviewed exemptions for @Test-bearing files outside the naming convention
+# (#2065). Data, not an inline array, so each row carries a checkable
+# justification and so the guard's own reds are self-testable.
+UNCONVENTIONAL="${POCKETSHELL_TEST_AREAS_UNCONVENTIONAL:-$SCRIPT_DIR/test-unconventional-test-files.txt}"
+NIGHTLY_SUITE="${POCKETSHELL_TEST_AREAS_NIGHTLY_SUITE:-$SCRIPT_DIR/nightly-extensive-suite.sh}"
 
 # shellcheck source=lib/test-areas.sh
 source "$SCRIPT_DIR/lib/test-areas.sh"
@@ -515,47 +520,159 @@ verify_manifest() {
   # 5. Hidden test classes. Every registry, guard and Gradle filter in this
   #    repo keys off the `*Test.kt` / `*Test.java` naming convention, so a
   #    @Test-bearing class that does not follow it is invisible to all of them —
-  #    the #1851 shape. Five exist today (four screenshot harnesses and the
-  #    ui-kit render target); they are baselined by name so a NEW one fails.
-  #    Baselining is per FILE, deliberately, not by a `*Harness.kt` suffix rule:
-  #    a suffix would be a self-serve escape hatch (name a real regression test
-  #    `…Harness.kt` and it hides), whereas a name list forces a reviewed
-  #    decision each time. #2065 tracks the general problem.
-  local -a KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES=(
-    "app/src/androidTest/java/com/pocketshell/app/composer/Issue1622DeadBandScreenshotHarness.kt"
-    "app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeDeadSpaceScreenshotHarness.kt"
-    "app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt"
-    "app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherLargeFontScreenshotHarness.kt"
-    "shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt"
-  )
-  local -a hidden_new=() hidden_stale=()
-  local -A hidden_seen=()
-  local known
+  #    the #1851 shape. #2063 baselined the offenders here as a flat array of
+  #    paths so a NEW one fails; #2065 moved that baseline into
+  #    scripts/test-unconventional-test-files.txt and gave every row a
+  #    justification this guard CHECKS: how the file's @Test methods actually
+  #    reach a runner, and what accounts for the file given no registry can see
+  #    it. The list stays per FILE, deliberately, and is NOT a `*Harness.kt`
+  #    suffix rule — a suffix would be a self-serve escape hatch (name a real
+  #    regression test `…Harness.kt` and it hides itself), whereas a row with a
+  #    checked executor and a checked gate keeps a human decision in the path
+  #    and rots loudly in every direction.
+  local -a hidden_new=() hidden_stale=() exempt_bad=()
+  local -A hidden_seen=() exempt_exec=() exempt_gate=() exempt_reason=()
+  local -a exempt_paths=()
+  if [[ ! -f "$UNCONVENTIONAL" ]]; then
+    echo "FAIL: unconventional-test-file exemptions not found: $UNCONVENTIONAL"
+    failures=$((failures + 1))
+  else
+    local line lineno=0 e_path e_exec e_gate e_reason rest
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      lineno=$((lineno + 1))
+      [[ -z "${line//[[:space:]]/}" ]] && continue
+      [[ "$line" == \#* ]] && continue
+      IFS=$'\t' read -r e_path e_exec e_gate rest <<<"$line"
+      e_reason="${rest%%$'\t'*}"
+      if [[ -z "$e_path" || -z "$e_exec" || -z "$e_gate" || -z "${e_reason//[[:space:]]/}" ]]; then
+        exempt_bad+=("line $lineno: expected <path>TAB<executor>TAB<gate>TAB<reason>, got: $line")
+        continue
+      fi
+      if [[ -n "${exempt_exec[$e_path]:-}" ]]; then
+        exempt_bad+=("$e_path: listed twice")
+        continue
+      fi
+      exempt_paths+=("$e_path")
+      exempt_exec["$e_path"]="$e_exec"
+      exempt_gate["$e_path"]="$e_gate"
+      exempt_reason["$e_path"]="$e_reason"
+    done < "$UNCONVENTIONAL"
+  fi
+
   while IFS= read -r f; do
     [[ -z "$f" ]] && continue
     pocketshell_test_areas_is_test_path "$f" || continue
     pocketshell_test_areas_is_test_class_file "$f" && continue
     grep -qE '^[[:space:]]*@Test([[:space:]]|\(|$)' "$REPO_ROOT/$f" 2>/dev/null || continue
     hidden_seen["$f"]=1
-    local pinned=0
-    for known in "${KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES[@]}"; do
-      [[ "$f" == "$known" ]] && pinned=1 && break
-    done
-    [[ "$pinned" -eq 0 ]] && hidden_new+=("$f")
+    [[ -z "${exempt_exec[$f]:-}" ]] && hidden_new+=("$f")
   done < <(tracked_files)
-  for known in "${KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES[@]}"; do
-    [[ -z "${hidden_seen[$known]:-}" ]] && hidden_stale+=("$known")
+
+  # The PREMISE under every `nightly-connected` row, checked ONCE: nightly
+  # phase 1 runs :app:connectedDebugAndroidTest WHOLESALE and subtracts a
+  # `notClass` list. Without this, a per-row "the class is not excluded" check
+  # is a green assertion over a property that no longer holds — flip phase 1 to
+  # a `class=` allowlist and every row would silently start lying while the
+  # guard stayed green (G6). Checked only when a row actually depends on it.
+  local nightly_wholesale=1 nightly_phase1=""
+  local -a nightly_rows=()
+  local e_path
+  for e_path in "${exempt_paths[@]}"; do
+    [[ "${exempt_exec[$e_path]}" == "nightly-connected" ]] && nightly_rows+=("$e_path")
   done
+  if [[ "${#nightly_rows[@]}" -gt 0 && -f "$NIGHTLY_SUITE" ]]; then
+    nightly_phase1="$(sed -n '/phase 1: journey\/E2E/,/^JOURNEY_EXIT=/p' "$NIGHTLY_SUITE")"
+    if [[ -z "$nightly_phase1" ]]; then
+      nightly_wholesale=0
+      exempt_bad+=("$(basename "$NIGHTLY_SUITE"): phase-1 invocation block not found, so the wholesale premise behind every 'nightly-connected' row is unverifiable")
+    elif ! grep -Fq ':app:connectedDebugAndroidTest' <<<"$nightly_phase1" ||
+         ! grep -Fq 'RunnerArguments.notClass=' <<<"$nightly_phase1"; then
+      nightly_wholesale=0
+      exempt_bad+=("$(basename "$NIGHTLY_SUITE"): phase 1 no longer runs :app:connectedDebugAndroidTest minus a notClass list — the 'nightly-connected' rows rest on that shape")
+    elif grep -Eq 'RunnerArguments\.(class|package|annotation)=' <<<"$nightly_phase1"; then
+      nightly_wholesale=0
+      exempt_bad+=("$(basename "$NIGHTLY_SUITE"): phase 1 now restricts what it runs (class/package/annotation filter) — it is an allowlist, so 'nightly-connected' no longer follows from merely not being excluded")
+    fi
+  fi
+
+  for e_path in "${exempt_paths[@]}"; do
+    if [[ -z "${hidden_seen[$e_path]:-}" ]]; then
+      hidden_stale+=("$e_path")
+      continue
+    fi
+    # The executor claim answers "does it execute in any gate?" — the question
+    # #2065 exists to force per file. Only the SHAPE of each claim is machine-
+    # checkable, and that is exactly what is checked: an unverifiable claim is
+    # rejected rather than believed.
+    case "${exempt_exec[$e_path]}" in
+      unit-source-set)
+        case "$e_path" in
+          */src/test/*) : ;;
+          *) exempt_bad+=("$e_path: executor 'unit-source-set' but the path is not under */src/test/, so \`./gradlew test\` does not run it") ;;
+        esac
+        ;;
+      nightly-connected)
+        case "$e_path" in
+          app/src/androidTest/*) : ;;
+          *) exempt_bad+=("$e_path: executor 'nightly-connected' but the path is not under app/src/androidTest/") ;;
+        esac
+        if [[ ! -f "$NIGHTLY_SUITE" ]]; then
+          exempt_bad+=("$e_path: executor 'nightly-connected' cannot be checked — nightly suite not found: $NIGHTLY_SUITE")
+        elif [[ "$nightly_wholesale" -eq 1 ]]; then
+          # Nightly phase 1 runs :app:connectedDebugAndroidTest WHOLESALE with a
+          # `notClass` exclusion list, which is why a class in no explicit suite
+          # still executes. Fail-closed on ANY mention of the simple name: an
+          # exclusion, a shard pin or even a comment means the wholesale claim
+          # has to be argued again rather than inherited.
+          local simple="${e_path##*/}"; simple="${simple%.kt}"; simple="${simple%.java}"
+          if grep -Fq "$simple" "$NIGHTLY_SUITE"; then
+            exempt_bad+=("$e_path: executor 'nightly-connected' claims the wholesale nightly run reaches it, but $simple is named in $(basename "$NIGHTLY_SUITE") — re-argue the claim")
+          fi
+        fi
+        ;;
+      *)
+        exempt_bad+=("$e_path: unknown executor '${exempt_exec[$e_path]}' (expected unit-source-set or nightly-connected)")
+        ;;
+    esac
+    # The gate is what accounts for the file. A FQCN is resolved through the
+    # SAME class index the area manifest and the ledger use, so a gate is
+    # provably a registered, area-resolved class rather than a name that reads
+    # well; an `enumerated-by:` script must actually reference the path.
+    case "${exempt_gate[$e_path]}" in
+      enumerated-by:*)
+        local script="${exempt_gate[$e_path]#enumerated-by:}"
+        if [[ ! -f "$REPO_ROOT/$script" ]]; then
+          exempt_bad+=("$e_path: gate 'enumerated-by:$script' names a script that does not exist")
+        elif ! grep -Fq "$e_path" "$REPO_ROOT/$script"; then
+          exempt_bad+=("$e_path: gate 'enumerated-by:$script' does not reference this path, so it cannot be enumerating it")
+        fi
+        ;;
+      *)
+        if [[ -z "${POCKETSHELL_TA_CLASS_PATH[${exempt_gate[$e_path]}]:-}" ]]; then
+          exempt_bad+=("$e_path: gate '${exempt_gate[$e_path]}' is not a known test class — a gate must be a conventional, area-resolved class the registries can see")
+        fi
+        ;;
+    esac
+  done
+
   if [[ "${#hidden_new[@]}" -gt 0 ]]; then
     echo "FAIL: ${#hidden_new[@]} @Test-bearing file(s) do not follow the *Test.kt/*Test.java convention, so no registry or filter can see them:"
     printf '  %s\n' "${hidden_new[@]}"
+    echo "  Rename to *Test.kt, or add a justified row to ${UNCONVENTIONAL#"$REPO_ROOT/"} (read its header first — a row is not a formality)."
     failures=$((failures + 1))
-  elif [[ "${#hidden_stale[@]}" -gt 0 ]]; then
-    echo "FAIL: stale baseline — these no longer carry @Test or no longer exist; drop them from KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES:"
+  fi
+  if [[ "${#hidden_stale[@]}" -gt 0 ]]; then
+    echo "FAIL: stale exemption(s) — these no longer carry @Test, no longer exist, or now follow the convention; drop them from ${UNCONVENTIONAL#"$REPO_ROOT/"}:"
     printf '  %s\n' "${hidden_stale[@]}"
     failures=$((failures + 1))
-  else
-    echo "OK: no new @Test-bearing file outside the *Test.kt/*Test.java convention (${#KNOWN_UNCONVENTIONAL_TEST_CLASS_FILES[@]} baselined)"
+  fi
+  if [[ "${#exempt_bad[@]}" -gt 0 ]]; then
+    echo "FAIL: ${#exempt_bad[@]} unconventional-test-file exemption(s) are not justified:"
+    printf '  %s\n' "${exempt_bad[@]}"
+    failures=$((failures + 1))
+  fi
+  if [[ "${#hidden_new[@]}" -eq 0 && "${#hidden_stale[@]}" -eq 0 && "${#exempt_bad[@]}" -eq 0 ]]; then
+    echo "OK: no new @Test-bearing file outside the *Test.kt/*Test.java convention (${#exempt_paths[@]} exempted, each with a checked executor and gate)"
   fi
 
   # 6. The `noop` premise: no test source reads a repo doc/markdown file at

--- a/scripts/test-unconventional-test-files.txt
+++ b/scripts/test-unconventional-test-files.txt
@@ -1,0 +1,76 @@
+# Reviewed exemptions: @Test-bearing files outside the *Test.kt / *Test.java
+# naming convention (issue #2065, mechanism from #2063).
+#
+# WHY THIS FILE EXISTS
+#
+# Every registry, guard and Gradle filter in this repo keys off the *Test.kt /
+# *Test.java convention: the journey registry (scripts/ci-journey-suite.sh), the
+# area manifest (scripts/test-areas.txt via pocketshell_test_areas_fqcn_for_path),
+# the executed-classes ledger (scripts/check-test-execution-ledger.sh) and the
+# validity guards. A @Test-bearing file that does not follow it is invisible to
+# all of them — the #1851 shape, and worse than a missing test because it looks
+# like coverage in the tree and in review.
+#
+# #2063 baselined the offenders inside select-test-areas.sh as a flat array of
+# paths, so a NEW one fails. #2065 is the other half: each existing file gets a
+# decision, and the decision is recorded here in a form the guard can CHECK
+# rather than a comment it has to be trusted about.
+#
+# IT IS DELIBERATELY NOT A `*Harness.kt` SUFFIX RULE. A suffix would be a
+# self-serve escape hatch — name a real regression test `…Harness.kt` and it
+# hides itself, with no reviewer in the loop. A per-file row with a machine-
+# checked justification keeps a human decision in the path.
+#
+# FORMAT — four TAB-separated fields, one row per file. `#` comments and blank
+# lines are ignored.
+#
+#   <path>  <executor>  <gate>  <reason>
+#
+# <path>     repo-relative. Must be tracked, live in a test source set, carry
+#            @Test, and NOT match the naming convention — otherwise the row is
+#            stale and the guard fails (an exemption that has outlived its file
+#            is how a baseline rots into a lie).
+#
+# <executor> HOW the file's @Test methods actually reach a runner. Answering
+#            "does it execute in any gate?" per file is the whole point of
+#            #2065; a claim is only allowed if the guard can confirm its shape.
+#              unit-source-set    the path is under */src/test/, so
+#                                 `./gradlew test` — the required `Unit tests`
+#                                 check — runs it unconditionally.
+#              nightly-connected  the path is under app/src/androidTest/ and
+#                                 nightly-extensive phase 1 runs
+#                                 :app:connectedDebugAndroidTest WHOLESALE with
+#                                 only a `notClass` exclusion list, so the class
+#                                 executes even though it is in no explicit
+#                                 suite. The guard asserts the class's simple
+#                                 name appears NOWHERE in
+#                                 scripts/nightly-extensive-suite.sh, which is
+#                                 fail-closed: the moment somebody names it
+#                                 there (exclusion, shard pin, comment) the
+#                                 executor claim has to be re-argued.
+#
+# <gate>     WHAT accounts for the file, given no registry can see it.
+#              <FQCN>                 a conventional test class that carries the
+#                                     load-bearing assertion for the same
+#                                     behaviour. The guard resolves it through
+#                                     the SAME class index the area manifest and
+#                                     the ledger use, so the gate is provably a
+#                                     registered, area-resolved, ledger-visible
+#                                     class — not just a name that reads well.
+#              enumerated-by:<script> a purpose-built registry that enumerates
+#                                     THIS file's @Test methods. The guard
+#                                     asserts the script exists and references
+#                                     the path.
+#
+# <reason>   free text, required. Why renaming is the wrong answer for this
+#            file.
+#
+# ADDING A ROW IS NOT A FORMALITY. If the file's @Test methods carry the
+# load-bearing assertion for anything, the answer is to RENAME it, not to list
+# it here.
+#
+shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt	unit-source-set	enumerated-by:scripts/render.sh	Fast design-render harness (#555). Observed executing 68 testcases, 0 skipped, in :shared:ui-kit:testDebugUnitTest, so it is not silently dead. It is also the ONE file here with a stronger registry than the ledger could give it: scripts/render.sh parses every @Test method out of this source and hard-fails when one has no `fun m() = render("label")` mapping — per-METHOD accounting, pinned per push by scripts/render-selftest.sh in the guards-static job ("missing test-to-label mapping is rejected"). The module's execution is separately ledger-observed through the sibling conventional DesignRenderStaticLoadingPolicyTest in this same package. Renaming would break render.sh's RENDER_CLASS/RENDER_SOURCE constants, ~10 render-selftest.sh fixtures and four docs that name the file as the design-iteration entry point, and buy no accounting that is not already there.
+app/src/androidTest/java/com/pocketshell/app/composer/Issue1622DeadBandScreenshotHarness.kt	nightly-connected	com.pocketshell.app.composer.Issue1622ComposerSheetGeometryProofTest	Screenshot STAGING harness (#1622), inert by construction: every method reads the `issue1622HoldMs` instrumentation argument and returns before composing anything when it is absent, so a normal or nightly run passes without asserting. Renaming it would put a deliberately vacuous class into every registry as though it were a gate — the same "looks like coverage, contributes nothing" deception #2065 exists to end, pointed the other way. The geometry it stages a picture of is HARD-asserted by the gate class, which is conventional and wired into scripts/ci-journey-suite.sh.
+app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerImeDeadSpaceScreenshotHarness.kt	nightly-connected	com.pocketshell.app.composer.PromptComposerImeEmptyDraftDeadSpaceProofTest	Screenshot STAGING harness (#790), inert by construction: gated on the `issue790HoldMs` instrumentation argument, and additionally assumeTrue-skipped when the AVD cannot raise the real soft IME — both justified in the file because the load-bearing dead-space assertion lives in the gate class, which drives a synthetic ime() inset and cannot skip. Renaming would present a skip-prone staging harness as a gate.
+app/src/androidTest/java/com/pocketshell/app/tmux/TerminalHotkeysPanelScreenshotHarness.kt	nightly-connected	com.pocketshell.app.tmux.TerminalHotkeysPanelNoTruncationTest	Screenshot harness (#755): it renders the redesigned hotkeys panel and the keyboard-up launcher chip to PNGs under additional_test_output/ for the maintainer. Its two assertExists() calls only prove the bitmap it is about to save is not of an empty screen; the no-truncation property is asserted by the gate class, and the launcher-above-the-IME property by com.pocketshell.app.tmux.TmuxHotkeysLauncherImeProofTest. An artifact producer named like a gate is the wrong signal to leave in the tree.
+app/src/androidTest/java/com/pocketshell/app/tmux/TmuxComposerLauncherLargeFontScreenshotHarness.kt	nightly-connected	com.pocketshell.app.tmux.TmuxComposerLauncherNarrowFontClipProofTest	Screenshot harness (#813): renders the production bottom controls at the maintainer's 412dp / 1.5x-font profile, keyboard down and up, to PNGs for the issue. Same shape as #755 — its assertExists() calls guard the bitmap, not the geometry. The containment proof is the gate class, which is conventional and wired into scripts/ci-journey-suite.sh.


### PR DESCRIPTION
Five files carry `@Test` methods with names no registry keys off. The assumption — inherited from #2063 and #1851 — was that they therefore never execute.

**That is wrong, and it reverses the framing of three issues.** `scripts/nightly-extensive-suite.sh:299-304` runs `:app:connectedDebugAndroidTest` **wholesale** with only a `notClass` *exclusion* list; none of the five is excluded. `DesignRenders` executes 68 testcases per push.

The reviewer confirmed it **observationally**, not structurally: it pulled preserved phase-1 JUnit XML from nightly runs `31293334919` and `31354438824` and found all four androidTest harnesses executing, unskipped and passing. The decisive figure is the runner's own enumeration — `Expected 318 tests` / `Expected 321 tests`, ~957 across three shards against 978 `@Test` methods in the tree. **A filename cannot opt a class out of that.**

So the defect is **accounting, not wiring**: these run unaccounted.

## Exempt, not renamed — decided per file

Four are screenshot *staging* harnesses: two inert before any composition (`if (holdMs <= 0L) return`, with #790's `assumeTrue` sitting *after* that return so it is never reached), two whose `assertExists()` sits one line before `save(...)` and only guards the bitmap. Renaming them into `*Test.kt` would place vacuous classes into every registry **as though they were gates** — the same deception pointed the other way.

`DesignRenders` does real work but already has a stronger registry than renaming would give it: `scripts/render.sh` enumerates every `@Test` **method** and hard-fails on an unmapped one.

## The exemptions are earned

`scripts/test-unconventional-test-files.txt` carries `path / executor / gate / reason`, and the guard verifies the executor's shape and resolves the gate through the same class index the ledger uses. It also pins **the premise itself** — that nightly phase 1 is wholesale-minus-`notClass` — so this inference cannot rot again.

That check earned itself immediately: its first version matched `runnerArguments.notClass=` while the real argument is `testInstrumentationRunnerArguments`, so it **went red on the real tree instead of passing vacuously.**

## Verification

Nine attempts to defeat the manifest all rejected, including the two that mattered — a gate pointing at another *invisible* harness, and a gate pointing at a production class. Six reviewer premise-mutations all reddened selectively. Selftest 57/57, guards suite rc=0.

**A trap the reviewer recorded:** reading only the 08-10 nightly shows two harnesses *absent*, which reads exactly like "the exemption rests on a false premise" — they are absent because both shards truncated (`received 101` of 318). Evidence that looked like a product finding was device flake.

Closes #2065