### PR TITLE
ci: shard the unit lane by build variant (#2069)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,20 @@ jobs:
   # in `guards-static`, `guards-ci-harness` and `dex`, all still blocking through
   # `unit-gate` below. Issue #2067 added `guards-test-selection` on the same
   # principle, for #2063's coverage guards.
+  #
+  # Issue #2069 (CI Phase B): after that, ONE Gradle step WAS the whole critical
+  # path (18m04s) and --max-workers 2->4 bought 57s. Sharded by variant: the
+  # union of the two legs is exactly the old `./gradlew test` graph. Rationale +
+  # the coverage-invariant proof: scripts/check-ci-unit-forced-execution.sh and
+  # the shard partition check in scripts/check-executed-test-counts.sh.
   unit:
     name: JVM unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [Debug, Release]
 
     steps:
       - name: Checkout
@@ -92,26 +102,9 @@ jobs:
         run: |
           touch "${RUNNER_TEMP}/unit-test-run-start"
 
-      # Issue #760: the unit job occasionally failed with ALL visible tests
-      # PASSED — a gradle-daemon/runner OOM abort, not a real assertion failure.
-      # Unbounded gradle worker fan-out plus an oversized test JVM heap can push
-      # the runner into the OOM-killer, which kills the gradle process mid-run
-      # AFTER the tests reported green. Bound BOTH the gradle worker count and
-      # the JVM heaps so the job stays inside the runner's memory budget: the
-      # explicit -Dorg.gradle.jvmargs caps the gradle daemon/launcher heap while
-      # -Pkotlin/test forks inherit the project's modest -Xmx. This is infra
-      # robustness only — no test is removed, skipped, or weakened.
-      #
-      # Issue #2060 (CI Phase A): the #760 note above sized --max-workers=2 for
-      # "7 GB RAM and 2 cores". That box is gone (public-repo runners have been
-      # 4 vCPU / 16 GB since Jan 2024), so the job ran at half of it. This raises
-      # CONCURRENCY, not memory: `org.gradle.parallel` stays false, so at most ONE
-      # Test task (one 1536m fork) is alive at a time and only intra-task Worker
-      # API actions (AGP dexing/resources) widen. `--parallel`/`maxParallelForks`
-      # WOULD multiply live forks and feed the #708/#882 virtual-clock flake
-      # class, so they are deliberately NOT bundled here. One variable at a time —
-      # the AGENTS.md memory trap surfaces as a fake "Backend Internal error:
-      # Exception during IR lowering", not as an OOM.
+      # Issues #760/#2060/#2069: why --max-workers=4 and the capped heaps, why
+      # `--parallel`/`maxParallelForks` are deliberately absent, and the measured
+      # cost of each knob — docs/testing.md "CI Unit lane: sizing and sharding".
       #
       # Issue #1646: tee the console to a log (--console=plain) so the count
       # guard below can see which test tasks actually EXECUTED vs came back
@@ -122,7 +115,8 @@ jobs:
         timeout-minutes: 35
         run: |
           set -o pipefail
-          ./gradlew test --rerun-tasks --no-build-cache \
+          ./gradlew "test${{ matrix.variant }}UnitTest" \
+            --rerun-tasks --no-build-cache \
             --no-daemon --stacktrace --console=plain \
             --max-workers=4 \
             -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" \
@@ -147,6 +141,7 @@ jobs:
         run: |
           chmod +x scripts/check-executed-test-counts.sh
           scripts/check-executed-test-counts.sh \
+            --variant "${{ matrix.variant }}" \
             --newer-than "${RUNNER_TEMP}/unit-test-run-start" \
             --gradle-log "${RUNNER_TEMP}/unit-test-gradle.log"
 
@@ -158,7 +153,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: unit-test-reports
+          name: unit-test-reports-${{ matrix.variant }}
           path: |
             **/build/reports/tests/
             **/build/test-results/
@@ -817,7 +812,7 @@ jobs:
         run: |
           set -euo pipefail
           failed=0
-          for pair in "JVM unit tests:$UNIT" \
+          for pair in "JVM unit tests (both shards):$UNIT" \
                       "Static guards:$GUARDS_STATIC" \
                       "CI harness guards:$GUARDS_CI_HARNESS" \
                       "Test-selection coverage guards:$GUARDS_TEST_SELECTION" \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1844,6 +1844,96 @@ loop.
 
 ---
 
+## CI Unit lane: sizing and sharding (issues #760, #2060, #2069)
+
+The required `Unit tests` check is the `unit-gate` aggregator over five jobs
+(`unit` × 2 shards, `guards-static`, `guards-ci-harness`, `guards-test-selection`,
+`dex`). This section is the long-form rationale that used to sit inline in
+`.github/workflows/tests.yml`, which is close to the 128 KiB hygiene cap.
+
+### Heap and worker caps (#760, #2060)
+
+`#760`: the job occasionally failed with ALL visible tests PASSED — a
+gradle-daemon/runner OOM abort, not an assertion failure. Unbounded gradle
+worker fan-out plus an oversized test JVM heap pushes the runner into the
+OOM-killer, which kills gradle mid-run *after* the tests reported green. Both
+the worker count and the JVM heaps are bounded so the job stays inside the
+runner's memory budget: the explicit `-Dorg.gradle.jvmargs` caps the gradle
+daemon/launcher heap while the test forks inherit the project's modest `-Xmx`.
+Infra robustness only — no test is removed, skipped or weakened.
+
+`#2060`: #760 sized `--max-workers=2` for "7 GB RAM and 2 cores". That box is
+gone (public-repo runners have been 4 vCPU / 16 GB since Jan 2024), so the job
+ran at half of it. Raising it to 4 raises CONCURRENCY, not memory:
+`org.gradle.parallel` stays false, so at most ONE `Test` task (one 1536m fork)
+is alive at a time and only intra-task Worker API actions (AGP dexing/resources)
+widen. `--parallel` / `maxParallelForks` WOULD multiply live forks and feed the
+#708/#882 virtual-clock flake class, so they are deliberately NOT bundled. One
+variable at a time — and note the AGENTS.md memory trap surfaces as a fake
+`Backend Internal error: Exception during IR lowering`, not as an OOM.
+
+### Why more workers is the wrong next knob (#2069)
+
+Measured on [run 31319201177](https://github.com/alexeygrigorev/pocketshell/actions/runs/31319201177):
+`--max-workers 2 -> 4` moved the Gradle test step **1141s -> 1084s, ~57s (5%)**.
+The suite does not parallelize further on a 4-vCPU runner. Do not spend another
+round on workers, `--parallel`, or `maxParallelForks`; the step is not
+core-starved.
+
+Where the time actually goes, derived from the `main` run 31339684629 result XML
+plus its console timestamps (sum of per-task deltas = 1089s of a 1125s step):
+
+| Bucket | Debug | Release | Variant-neutral |
+| --- | ---: | ---: | ---: |
+| Test execution | 398s | 376s | — |
+| Build (compile/resources/KSP) | 114s | 177s | 25s |
+
+`:app` alone is 285.4s + 283.9s of the 863.9s total test-case time (66%), across
+24 test tasks / 12362 tests. Both halves are close to balanced, and nearly all
+the non-test cost is variant-specific, so splitting by variant halves both.
+
+### The split, and why two shards and not six
+
+`unit` is a `strategy.matrix.variant: [Debug, Release]` job: one leg runs
+`./gradlew testDebugUnitTest`, the other `testReleaseUnitTest`. It is a matrix
+rather than two hand-written jobs on purpose — `needs.unit.result` aggregates
+every leg, so the `unit-gate` three-list wiring (`needs:` / `env:` / the result
+loop) is untouched and the #2067 silent-gate hazard cannot apply.
+
+Two, not more, because the unit job stops being the critical path at that point:
+`guards-ci-harness` runs 644–666s across recent `main` runs, so once `unit` is
+near that it is the floor. A third or fourth shard would shrink `unit` further
+and leave the lane exactly where two shards put it, while paying #2060's
+measured ~38s per-job checkout/JDK/cache overhead each time. That is the knee.
+
+### The coverage invariant, and how it is proved
+
+`./gradlew test` ran everything; `testDebugUnitTest` + `testReleaseUnitTest` runs
+everything **only while every module's test task is one of those two**. Today it
+is (all 13 modules apply an Android plugin), and `./gradlew test --dry-run`
+versus `./gradlew testDebugUnitTest testReleaseUnitTest --dry-run` differ by
+exactly the 13 no-op `:module:test` lifecycle aggregators — no executing task is
+lost. But one plain `kotlin("jvm")` module with tests would get a bare `test`
+task that neither shard names, and its tests would stop running with the
+required check still green.
+
+Two guards hold the invariant, and neither is sufficient alone:
+
+- `scripts/check-ci-unit-forced-execution.sh` — the workflow asks for both
+  halves: the task argument is the matrix expression (not a hardcoded variant,
+  which would make both legs run the same half) and the shard list is exactly
+  `[Debug, Release]`. Its `--self-test` rejects 13 mutations, including a
+  dropped shard, a duplicated shard, lowercase names, and a matrix belonging to
+  a different job.
+- `scripts/check-executed-test-counts.sh` — the two halves together are
+  everything. `--variant Debug|Release` scopes each shard's expected-task set,
+  and an unconditional **shard partition check** fails when a required module
+  expects a task outside the two. Its `--self-test` asserts
+  `union(Debug, Release) == the unsharded task set` and that the halves are
+  disjoint, plus the plain-`test`-module red case.
+
+---
+
 ## CI matrix
 
 GitHub Actions runs:

--- a/scripts/check-ci-unit-forced-execution.sh
+++ b/scripts/check-ci-unit-forced-execution.sh
@@ -1,6 +1,32 @@
 #!/usr/bin/python3 -I
-"""Fail closed when the required CI Unit command can reuse cached test tasks."""
+"""Fail closed when the required CI Unit command can reuse cached test tasks.
 
+Issue #2069 widened this guard from "forces execution" to "forces execution of
+the WHOLE graph". Since #2069 the Unit job is a two-way matrix — one job runs
+`testDebugUnitTest`, the other `testReleaseUnitTest` — because the single Gradle
+step WAS the entire 18-minute critical path and `--max-workers 2 -> 4` bought
+only ~57 s. Splitting by variant is what makes the union trivially the old
+`./gradlew test` graph, but it also introduces a new way to be quietly wrong:
+drop a shard, hardcode one variant, or misspell the matrix values, and CI runs
+half the tests with the required `Unit tests` check still green.
+
+So the shape of the sharded command is asserted here, mechanically:
+
+  * exactly one `Run JVM unit tests` step with exactly one `./gradlew` command;
+  * its task argument is the matrix expression, not a hardcoded variant, so the
+    two jobs cannot silently run the same half;
+  * the `unit` job's `strategy.matrix.variant` is exactly `[Debug, Release]` —
+    the two shards whose union is the complete graph;
+  * `--rerun-tasks` / `--no-build-cache` are still present exactly once.
+
+That covers "the workflow asks for both halves". The other half of the coverage
+invariant — "both halves together are everything a module can produce" — is the
+shard partition check in `check-executed-test-counts.sh`, which fails when any
+required module expects a task outside those two. The two guards together are
+the proof; neither is sufficient alone.
+"""
+
+import re
 import shlex
 import sys
 from pathlib import Path
@@ -10,6 +36,14 @@ ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_WORKFLOW = ROOT / ".github" / "workflows" / "tests.yml"
 STEP_NAME = "Run JVM unit tests"
 REQUIRED_FLAGS = ("--rerun-tasks", "--no-build-cache")
+UNIT_JOB = "unit"
+# The task argument must stay the matrix expression. A hardcoded task name would
+# make both matrix legs run the same half of the graph.
+SHARD_TASK = "test${{ matrix.variant }}UnitTest"
+# The shard names, which are also the Gradle variant names the expression above
+# interpolates into. Capitalised because `test<Variant>UnitTest` is.
+SHARD_VARIANTS = ("Debug", "Release")
+JOB_KEY = re.compile(r"^  ([A-Za-z0-9_-]+):[ \t]*(#.*)?$")
 
 
 class GuardFailure(ValueError):
@@ -65,14 +99,97 @@ def extract_gradle_arguments(step: str) -> tuple[str, ...]:
     except ValueError:
         pipe_index = len(tokens)
     gradle_tokens = tuple(tokens[:pipe_index])
-    if gradle_tokens[:2] != ("./gradlew", "test"):
+    if gradle_tokens[:2] != ("./gradlew", SHARD_TASK):
         raise GuardFailure(
-            f"{STEP_NAME!r} must invoke the complete './gradlew test' graph"
+            f"{STEP_NAME!r} must invoke './gradlew \"{SHARD_TASK}\"' so the two "
+            "matrix legs run DIFFERENT halves of the test graph and their union "
+            "is the complete graph (issue #2069). A hardcoded task name makes "
+            "both legs run the same half while the required check stays green."
         )
     return gradle_tokens[2:]
 
 
+def indented_block(lines: list[str], header: str, indent: int) -> list[str]:
+    """Lines under the single `header` line, up to the next line at <= indent."""
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if line == " " * indent + header
+    ]
+    if len(starts) != 1:
+        raise GuardFailure(
+            f"expected exactly one {header!r} at indent {indent}, "
+            f"found {len(starts)}"
+        )
+    start = starts[0]
+    end = next(
+        (
+            index
+            for index in range(start + 1, len(lines))
+            if lines[index].strip()
+            and len(lines[index]) - len(lines[index].lstrip(" ")) <= indent
+        ),
+        len(lines),
+    )
+    return lines[start + 1 : end]
+
+
+def extract_shard_variants(workflow: str) -> tuple[str, ...]:
+    lines = workflow.splitlines()
+    job_starts = [
+        index
+        for index, line in enumerate(lines)
+        if (match := JOB_KEY.match(line)) and match.group(1) == UNIT_JOB
+    ]
+    if len(job_starts) != 1:
+        raise GuardFailure(
+            f"expected exactly one {UNIT_JOB!r} job, found {len(job_starts)}"
+        )
+    start = job_starts[0]
+    end = next(
+        (
+            index
+            for index in range(start + 1, len(lines))
+            if JOB_KEY.match(lines[index])
+        ),
+        len(lines),
+    )
+    job = lines[start + 1 : end]
+
+    matrix = indented_block(
+        indented_block(job, "strategy:", 4), "matrix:", 6
+    )
+    declarations = [
+        line for line in matrix if line.startswith(" " * 8 + "variant:")
+    ]
+    if len(declarations) != 1:
+        raise GuardFailure(
+            f"the {UNIT_JOB!r} job must declare exactly one "
+            f"strategy.matrix.variant, found {len(declarations)}"
+        )
+    value = declarations[0].split(":", 1)[1].strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        raise GuardFailure(
+            "strategy.matrix.variant must be an inline list, e.g. "
+            f"[{', '.join(SHARD_VARIANTS)}]; got {value!r}"
+        )
+    return tuple(
+        item.strip().strip("'\"")
+        for item in value[1:-1].split(",")
+        if item.strip()
+    )
+
+
 def validate(workflow: str) -> None:
+    variants = extract_shard_variants(workflow)
+    if variants != SHARD_VARIANTS:
+        raise GuardFailure(
+            f"the {UNIT_JOB!r} job's shards must be exactly "
+            f"{list(SHARD_VARIANTS)} — the two halves whose union is the "
+            f"complete test graph (issue #2069); got {list(variants)}. "
+            "Dropping, duplicating or renaming a shard silently stops running "
+            "one variant's ~4.5k tests while `Unit tests` stays green."
+        )
     arguments = extract_gradle_arguments(extract_step(workflow))
     for flag in REQUIRED_FLAGS:
         count = arguments.count(flag)
@@ -89,15 +206,25 @@ def validate(workflow: str) -> None:
 def self_test() -> None:
     canonical = """jobs:
   unit:
+    name: JVM unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [Debug, Release]
     steps:
       - name: Run JVM unit tests
         id: unit_tests
         run: |
           set -o pipefail
-          ./gradlew test --no-daemon --rerun-tasks \\
+          ./gradlew "test${{ matrix.variant }}UnitTest" --no-daemon \\
+            --rerun-tasks \\
             --no-build-cache --console=plain 2>&1 | tee "$RUNNER_TEMP/log"
       - name: Assert tests actually executed
         run: scripts/check-executed-test-counts.sh
+  python:
+    steps:
+      - name: Run pytest
+        run: pytest
 """
     validate(canonical)
     checks = 1
@@ -109,8 +236,35 @@ def self_test() -> None:
         canonical.replace(STEP_NAME, "Run some tests"),
         canonical.replace(
             '2>&1 | tee "$RUNNER_TEMP/log"',
-            '2>&1 | tee "$RUNNER_TEMP/log"\n          ./gradlew test '
+            '2>&1 | tee "$RUNNER_TEMP/log"\n          ./gradlew '
+            '"test${{ matrix.variant }}UnitTest" '
             "--rerun-tasks --no-build-cache",
+        ),
+        # -- issue #2069: the ways a shard silently stops running ------------
+        # A hardcoded variant: both matrix legs run the SAME half, and the
+        # other ~4.5k tests never run under a green required check.
+        canonical.replace('"test${{ matrix.variant }}UnitTest"', "testDebugUnitTest"),
+        # One shard deleted.
+        canonical.replace("[Debug, Release]", "[Debug]"),
+        # Two shards, one variant — reads plausible, runs half the graph twice.
+        canonical.replace("[Debug, Release]", "[Debug, Debug]"),
+        # Wrong case: `testdebugUnitTest` is not a Gradle task, but a guard
+        # matching on "two entries" alone would wave it through.
+        canonical.replace("[Debug, Release]", "[debug, release]"),
+        # An extra shard nobody wired anywhere.
+        canonical.replace("[Debug, Release]", "[Debug, Release, Staging]"),
+        # The matrix removed entirely: one job, one interpolation of nothing.
+        canonical.replace(
+            "    strategy:\n      fail-fast: false\n"
+            "      matrix:\n        variant: [Debug, Release]\n",
+            "",
+        ),
+        # The matrix moved onto a DIFFERENT job — the extractor must read the
+        # `unit` job's own matrix, not the first one in the file.
+        canonical.replace("  unit:\n", "  guards:\n").replace(
+            "    steps:\n      - name: Run JVM unit tests",
+            "  unit:\n    steps:\n      - name: Run JVM unit tests",
+            1,
         ),
     )
     for fixture in rejected:
@@ -120,8 +274,8 @@ def self_test() -> None:
             checks += 1
         else:
             raise GuardFailure("self-test accepted an unsafe workflow mutation")
-    if checks != 7:
-        raise GuardFailure(f"self-test ran {checks} checks, expected 7")
+    if checks != 14:
+        raise GuardFailure(f"self-test ran {checks} checks, expected 14")
     print(f"PASS: CI Unit forced-execution guard self-test ({checks} checks)")
 
 

--- a/scripts/check-executed-test-counts.sh
+++ b/scripts/check-executed-test-counts.sh
@@ -64,6 +64,30 @@
 # a module's tests for real therefore requires deleting its floors line in the
 # same change — an intentional act, which is the point.
 #
+# SHARDED LANE: --variant, AND THE PARTITION PROOF (issue #2069)
+# --------------------------------------------------------------
+# The CI Unit lane no longer runs `./gradlew test` in one job. Since #2069 it is
+# a two-way matrix — one job runs `testDebugUnitTest`, the other
+# `testReleaseUnitTest` — because the single Gradle step was the whole 18-minute
+# critical path and more workers bought ~57 s. `--variant Debug|Release` scopes
+# this guard to the half of the graph its own shard was asked to run: without it
+# each shard would fail on the twelve tasks the OTHER shard owns.
+#
+# That scoping introduces exactly one new way to lose coverage, and it is the
+# quiet one: a module whose test task is NEITHER `testDebugUnitTest` NOR
+# `testReleaseUnitTest`. `./gradlew test` would have run it; neither shard task
+# names it, so it would vanish from CI with every shard still green — a whole
+# module's tests silently unrun, which is the #1646 disease in a new costume.
+# Today every module applies an Android plugin so every task is one of the two,
+# but adding one plain `kotlin("jvm")` module with tests is a two-line change
+# nobody would connect to CI coverage.
+#
+# So the SHARD PARTITION CHECK below is unconditional (it runs with or without
+# --variant, so the local full gate catches it too): every task a required
+# module expects must be one of the two shard tasks. It is the mechanical form
+# of the coverage invariant "union of the shards == the whole graph" — asserted
+# from the module set rather than eyeballed from a task list.
+#
 # WHAT THIS SCRIPT DOES NOT COVER
 # -------------------------------
 # Modules with no declared floor and no test sources are exempt, and their tests
@@ -80,10 +104,15 @@
 #
 # Usage:
 #   scripts/check-executed-test-counts.sh [--newer-than FILE] [--gradle-log FILE]
-#                                         [--root DIR]
+#                                         [--root DIR] [--variant Debug|Release]
 #   scripts/check-executed-test-counts.sh --self-test
 #
 # Options:
+#   --variant V        scope the expected-task set to one CI shard's half of the
+#                      graph: Debug -> testDebugUnitTest, Release ->
+#                      testReleaseUnitTest (issue #2069). Omit for the whole
+#                      graph (the local full gate). The shard partition check is
+#                      unconditional either way.
 #   --newer-than FILE  require each task's XML to be strictly newer than FILE
 #                      (the --rerun-tasks / UP-TO-DATE-skip enforcement).
 #                      Omit to only check coverage + counts.
@@ -204,10 +233,21 @@ explicit_floor_for_task() {
 # The check.
 # ---------------------------------------------------------------------------
 check_root() {
-  local root="$1" marker="${2:-}" gradle_log="${3:-}"
+  local root="$1" marker="${2:-}" gradle_log="${3:-}" variant="${4:-}"
   local violations=() rows=() module task task_path results_dir count floor
   local total_executed=0 checked_tasks=0 nosource_modules=()
   local expected_task_paths=() testfree_task_paths=() sourceless_task_paths=()
+  local unshardable_task_paths=() shard_task=""
+
+  if [ -n "$variant" ]; then
+    case "$variant" in
+      Debug|Release) shard_task="test${variant}UnitTest" ;;
+      *)
+        echo "FAIL: --variant must be Debug or Release, got: $variant" >&2
+        return 1
+        ;;
+    esac
+  fi
 
   local module_list
   module_list="$(modules_from_settings "$root")"
@@ -229,6 +269,27 @@ check_root() {
     while IFS= read -r task; do
       [ -n "$task" ] || continue
       task_path="$task_prefix:$task"
+
+      # ---- SHARD PARTITION CHECK (issue #2069) ----------------------------
+      # Unconditional, and deliberately BEFORE the --variant filter: the point
+      # is to catch a task that belongs to NO shard, and a variant filter would
+      # skip exactly that task first. Only required modules matter — a task-free
+      # module's unrun task loses nothing.
+      case "$task" in
+        testDebugUnitTest|testReleaseUnitTest) ;;
+        *)
+          if [ "$has_sources" -eq 1 ] ||
+             [ -n "$(explicit_floor_for_task "$root" "$task_path")" ]; then
+            unshardable_task_paths+=("$task_path")
+          fi
+          ;;
+      esac
+
+      # ---- scope to this shard's half of the graph ------------------------
+      if [ -n "$shard_task" ] && [ "$task" != "$shard_task" ]; then
+        continue
+      fi
+
       results_dir="$dir/build/test-results/$task"
       module_tasks=$(( module_tasks + 1 ))
 
@@ -302,6 +363,18 @@ check_root() {
       nosource_modules+=("$task_prefix")
     fi
   done <<< "$module_list"
+
+  # ---- the coverage invariant behind the sharded lane (issue #2069) -------
+  # The CI Unit lane runs `testDebugUnitTest` in one job and `testReleaseUnitTest`
+  # in another; their union is the whole graph ONLY while every required task is
+  # one of those two. A task outside that pair is run by neither shard, so its
+  # module's tests would stop running with the required check still green.
+  if [ ${#unshardable_task_paths[@]} -gt 0 ]; then
+    local u
+    for u in "${unshardable_task_paths[@]}"; do
+      violations+=("$u is not one of the two CI Unit shard tasks (testDebugUnitTest / testReleaseUnitTest), so NEITHER shard job runs it and its tests would silently stop running with the required \`Unit tests\` check still green (issue #2069). This module is not an Android application/library, so Gradle gives it a plain \`test\` task. Either apply the Android plugin so it produces both variant tasks, or re-shard the Unit lane in .github/workflows/tests.yml so this task is owned by a shard.")
+    done
+  fi
 
   # ---- Gradle console scan: a no-op task must FAIL, not pass silently -----
   # Needed on top of the XML check because org.gradle.caching=true means a
@@ -401,6 +474,12 @@ check_root() {
     if [ ${#nosource_modules[@]} -gt 0 ]; then
       echo "  NO-SOURCE (no src/test sources — legitimately exempt): ${nosource_modules[*]}"
     fi
+    if [ -n "$variant" ]; then
+      # Say the scope out loud: a reader comparing this number against the
+      # familiar whole-graph total must not read a healthy shard as a shortfall.
+      echo "  SHARD: $variant (this job runs $shard_task only; the other variant"
+      echo "         is the sibling matrix job — issue #2069)"
+    fi
     echo "  TOTAL EXECUTED: $total_executed across $checked_tasks task(s)"
   }
 
@@ -417,6 +496,10 @@ check_root() {
       echo
       if [ ${#nosource_modules[@]} -gt 0 ]; then
         echo "NO-SOURCE (no \`src/test\` sources — legitimately exempt): ${nosource_modules[*]}"
+        echo
+      fi
+      if [ -n "$variant" ]; then
+        echo "Shard: \`$variant\` — this job runs \`$shard_task\` only (issue #2069)."
         echo
       fi
       echo "**Total executed: $total_executed** across $checked_tasks task(s)."
@@ -792,8 +875,159 @@ EOF
     SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
   fi
 
+  # =========================================================================
+  # Issue #2069: the sharded Unit lane. --variant scoping, and the coverage
+  # invariant that makes the two shards safe to believe.
+  # =========================================================================
+
+  # Task paths this script REPORTED as in-scope, one per line.
+  selftest_reported_tasks() { grep -oE '^  :[A-Za-z0-9_:.-]+' <<< "$1" | tr -d ' '; }
+
+  # -- T17 a shard job sees only its own half and PASSES on it --------------
+  root="$tmp/t17"; mkdir -p "$root"; selftest_make_root "$root"
+  selftest_write_results "$root" "testDebugUnitTest" 4553
+  # testReleaseUnitTest deliberately absent: it belongs to the sibling shard.
+  out="$(check_root "$root" "" "" "Debug" 2>&1)"; rc=$?
+  selftest_assert "T17 --variant Debug PASSES with only the debug half present" 0 "$rc"
+  SELFTEST_RUN=$(( SELFTEST_RUN + 1 ))
+  if grep -q 'SHARD: Debug' <<< "$out" &&
+     [ "$(selftest_reported_tasks "$out")" = ":app:testDebugUnitTest" ]; then
+    echo "  ok   T17 scope is stated and exactly one task is in scope"
+  else
+    echo "  FAIL T17: shard scope not stated, or the wrong task set was checked" >&2
+    echo "$out" | sed 's/^/       /' >&2
+    SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+  fi
+
+  # -- T18 ...and --variant is NOT a blanket excuse -------------------------
+  # The load-bearing negative for T17: the SAME tree under the sibling shard
+  # must still fail, or "--variant" would just mean "check less".
+  out="$(check_root "$root" "" "" "Release" 2>&1)"; rc=$?
+  selftest_assert "T18 --variant Release on the same tree FAILS (its half never ran)" 1 "$rc"
+  SELFTEST_RUN=$(( SELFTEST_RUN + 1 ))
+  if grep -q ':app:testReleaseUnitTest' <<< "$out"; then
+    echo "  ok   T18 message names the task the release shard failed to run"
+  else
+    echo "  FAIL T18: message did not name the missing release task" >&2
+    SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+  fi
+
+  # -- T19 THE COVERAGE INVARIANT: union(shards) == the unsharded graph -----
+  # Asserted mechanically from the reported task sets, not eyeballed. This is
+  # the property the whole two-job split rests on.
+  root="$tmp/t19"; mkdir -p "$root"; selftest_make_root "$root"
+  mkdir -p "$root/shared/core-ssh/src/test/java"
+  echo "class SshTest" > "$root/shared/core-ssh/src/test/java/SshTest.kt"
+  cat > "$root/shared/core-ssh/build.gradle.kts" <<'EOF'
+plugins { alias(libs.plugins.android.library) }
+EOF
+  echo 'include(":shared:core-ssh")' >> "$root/settings.gradle.kts"
+  local ssh_results="$root/shared/core-ssh/build/test-results"
+  local vtask
+  for vtask in testDebugUnitTest testReleaseUnitTest; do
+    selftest_write_results "$root" "$vtask" 4553
+    mkdir -p "$ssh_results/$vtask"
+    cp "$root/app/build/test-results/$vtask/TEST-SomeTest.xml" "$ssh_results/$vtask/"
+  done
+  local whole debug_half release_half
+  whole="$(selftest_reported_tasks "$(check_root "$root" 2>&1)" | sort -u)"
+  debug_half="$(selftest_reported_tasks "$(check_root "$root" "" "" Debug 2>&1)" | sort -u)"
+  release_half="$(selftest_reported_tasks "$(check_root "$root" "" "" Release 2>&1)" | sort -u)"
+  SELFTEST_RUN=$(( SELFTEST_RUN + 1 ))
+  if [ -n "$whole" ] && [ -n "$debug_half" ] && [ -n "$release_half" ] &&
+     [ "$(printf '%s\n%s\n' "$debug_half" "$release_half" | sort -u)" = "$whole" ]; then
+    echo "  ok   T19 union(Debug shard, Release shard) == the unsharded task set"
+  else
+    echo "  FAIL T19: the two shards do NOT cover the unsharded task set" >&2
+    echo "       whole:   $(tr '\n' ' ' <<< "$whole")" >&2
+    echo "       debug:   $(tr '\n' ' ' <<< "$debug_half")" >&2
+    echo "       release: $(tr '\n' ' ' <<< "$release_half")" >&2
+    SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+  fi
+  # ...and no task is charged to both shards (a double-run would be waste, and
+  # would also let one shard's green hide the other's missing task).
+  SELFTEST_RUN=$(( SELFTEST_RUN + 1 ))
+  if [ -z "$(comm -12 <(echo "$debug_half") <(echo "$release_half"))" ]; then
+    echo "  ok   T19b the two shards are disjoint (no task runs twice)"
+  else
+    echo "  FAIL T19b: a task is owned by BOTH shards" >&2
+    SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+  fi
+
+  # -- T20 THE HOLE THE SPLIT OPENS: a task no shard owns -------------------
+  # A plain kotlin("jvm") module WITH tests gets a `test` task. `./gradlew test`
+  # ran it; neither shard task names it. Every shard would stay green while a
+  # whole module's tests stopped running. That must be RED — and red in the
+  # unsharded local gate too, which is why the partition check is unconditional.
+  root="$tmp/t20"; mkdir -p "$root"; selftest_make_root "$root"
+  mkdir -p "$root/tools/analyzer/src/test/java"
+  echo "class AnalyzerTest" > "$root/tools/analyzer/src/test/java/AnalyzerTest.kt"
+  cat > "$root/tools/analyzer/build.gradle.kts" <<'EOF'
+plugins { kotlin("jvm") }
+EOF
+  echo 'include(":tools:analyzer")' >> "$root/settings.gradle.kts"
+  selftest_write_results "$root" "testDebugUnitTest" 4553
+  selftest_write_results "$root" "testReleaseUnitTest" 4541
+  mkdir -p "$root/tools/analyzer/build/test-results/test"
+  cp "$root/app/build/test-results/testDebugUnitTest/TEST-SomeTest.xml" \
+     "$root/tools/analyzer/build/test-results/test/"
+  out="$(check_root "$root" "" "" Debug 2>&1)"; rc=$?
+  selftest_assert "T20 a module whose task belongs to NO shard FAILS the shard job" 1 "$rc"
+  SELFTEST_RUN=$(( SELFTEST_RUN + 1 ))
+  if grep -q ':tools:analyzer:test is not one of the two CI Unit shard tasks' <<< "$out"; then
+    echo "  ok   T20 message names the unowned task and why no shard runs it"
+  else
+    echo "  FAIL T20: message did not name the unowned task" >&2
+    echo "$out" | sed 's/^/       /' >&2
+    SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+  fi
+  # The same hole is red WITHOUT --variant: the local full gate catches it too.
+  check_root "$root" >/dev/null 2>&1
+  selftest_assert "T20b the unsharded local gate FAILS on the same unowned task" 1 "$?"
+
+  # -- T21 the load-bearing negative (G6): a test-FREE jvm module is fine ---
+  # Otherwise the partition check would ban a perfectly ordinary build-logic or
+  # support module and get switched off.
+  rm -rf "$root/tools/analyzer/src/test" "$root/tools/analyzer/build"
+  check_root "$root" "" "" Debug >/dev/null 2>&1
+  selftest_assert "T21 a jvm module with NO tests does not trip the partition check" 0 "$?"
+
+  # -- T22 an unknown --variant is a hard failure, not a silent whole-graph --
+  # A typo ("debug", "release", "Both") must not quietly widen or narrow scope.
+  out="$(check_root "$root" "" "" "debug" 2>&1)"; rc=$?
+  selftest_assert "T22 a mis-spelled --variant FAILS instead of guessing" 1 "$rc"
+  SELFTEST_RUN=$(( SELFTEST_RUN + 1 ))
+  if grep -q 'must be Debug or Release' <<< "$out"; then
+    echo "  ok   T22 message states the accepted shard names"
+  else
+    echo "  FAIL T22: message did not state the accepted shard names" >&2
+    SELFTEST_FAIL=$(( SELFTEST_FAIL + 1 ))
+  fi
+
+  # -- T23 the console scan is scoped to the shard too ----------------------
+  # A shard's Gradle log only ever contains its own tasks. Without scoping, the
+  # #1646 "expected task never observed" rule would redden every shard.
+  root="$tmp/t23"; mkdir -p "$root"; selftest_make_root "$root"
+  selftest_write_results "$root" "testDebugUnitTest" 4553
+  log="$tmp/t23.log"
+  cat > "$log" <<'EOF'
+> Task :app:testDebugUnitTest
+> Task :shared:test-support:testDebugUnitTest NO-SOURCE
+BUILD SUCCESSFUL in 9m 33s
+EOF
+  check_root "$root" "" "$log" Debug >/dev/null 2>&1
+  selftest_assert "T23 a debug shard's own console log PASSES the scan" 0 "$?"
+  # ...and the scan still bites inside the shard: FROM-CACHE on its own task.
+  cat > "$log" <<'EOF'
+> Task :app:testDebugUnitTest FROM-CACHE
+> Task :shared:test-support:testDebugUnitTest NO-SOURCE
+BUILD SUCCESSFUL in 12s
+EOF
+  out="$(check_root "$root" "" "$log" Debug 2>&1)"; rc=$?
+  selftest_assert "T23b FROM-CACHE on the shard's OWN task still FAILS" 1 "$rc"
+
   # -- meta: assert the self-test itself is not vacuous ---------------------
-  local expected_checks=33
+  local expected_checks=47
   echo
   # G3 on the self-test itself: a self-test that ran ZERO cases and reported
   # PASS would be this script's own disease. Assert count > 0 explicitly before
@@ -818,7 +1052,7 @@ EOF
 
 # ---------------------------------------------------------------------------
 main() {
-  local root="$DEFAULT_ROOT" marker="" gradle_log="" self_test=0
+  local root="$DEFAULT_ROOT" marker="" gradle_log="" self_test=0 variant=""
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -826,6 +1060,7 @@ main() {
       --newer-than) marker="${2:-}"; shift 2 || true ;;
       --gradle-log) gradle_log="${2:-}"; shift 2 || true ;;
       --root) root="${2:-}"; shift 2 || true ;;
+      --variant) variant="${2:-}"; shift 2 || true ;;
       -h|--help) usage; return 0 ;;
       *) echo "FAIL: unknown argument: $1" >&2; usage >&2; return 2 ;;
     esac
@@ -841,7 +1076,7 @@ main() {
     return 1
   fi
 
-  check_root "$root" "$marker" "$gradle_log"
+  check_root "$root" "$marker" "$gradle_log" "$variant"
 }
 
 main "$@"


### PR DESCRIPTION
After #2060 the per-PR critical path was a single ~19min Gradle step, and `--max-workers` had already been measured at 57s of benefit. The remaining time was in the step itself.

`unit` becomes a `strategy.matrix.variant: [Debug, Release]` job — **a matrix rather than two hand-written jobs**, because `needs.unit.result` aggregates over legs, so `unit-gate`'s three-list contract stays byte-identical and the wiring hazard becomes *structurally unreachable* instead of guarded after the fact.

The reviewer verified that from a real observation rather than docs: run `31229288850`'s 6-leg matrix had one green and two red legs, and the dependent job logged `UPSTREAM_MATRIX_RESULT: failure`. One red leg reddens the required check.

## The most useful finding is a negative one

**Two shards is the knee, and not because of per-job overhead.** `guards-ci-harness` runs 644–666s across the last three `main` runs; the shards land at ~616s/~657s — *on that floor*. A third shard drops `unit` to ~450s and **moves the lane by zero**. The next win here is `guards-ci-harness`, not more sharding.

The reviewer pulled the durations from the API itself and every figure matched to the second.

## Sharding introduces a hole worth more than the speed

A plain `kotlin("jvm")` module whose bare `test` task neither shard names would **silently stop running under a green required check**. `check-executed-test-counts.sh` gains an unconditional partition check. Its union and disjointness assertions are **not** redundant — neutering the variant filter leaves union green and is caught only by disjointness, reproduced by the reviewer.

The reviewer planted a real `:tools:reportgen` module with passing results: rc=1 unsharded and on both legs, exactly one violation; strip the tests and it goes green, so ordinary support modules are not banned.

## Coverage invariant

Debug **6187** + Release **6175** = **12362** across 24 disjoint tasks, matching `main` run `31339684629`'s own count guard task-for-task. `test --dry-run` differs from the two shard tasks by exactly the 13 no-op `:module:test` aggregators.

`tests.yml` headroom **656 → 1297 bytes**, by moving inline rationale into docs rather than re-baselining.

## Honest limits

The measured Actions figure is **not** in this PR — implementers cannot push, so it closes on this PR's own run. The projection was declared as a projection with its falsification criterion named. One caveat on the record: the local run had Debug > Release (493 vs 466), the opposite *direction* to the CI-derived attribution though the magnitudes agree — likely warm-up, and this run settles it.

**Merge order:** this must land **before** #2066 (PR #2076), which renames `check-ci-unit-forced-execution.sh` to `.py` while this diff adds 168 lines to the `.sh`.

Closes #2069