### PR TITLE
release: v0.4.43 (versionCode 90)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 89
-        versionName = "0.4.42"
+        versionCode = 90
+        versionName = "0.4.43"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.42"
+version = "0.4.43"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version-only commit. `versionName` 0.4.42 → **0.4.43**, `versionCode` 89 → **90**, `tools/pocketshell` in lockstep (`check-version-coupling.sh` OK).

## What ships

**#1622 — the composer dead band**, closing a chain the maintainer reported **seven times** (#567 → #615 → #682 → #765 → #790 → #801 → #1622). Sheet chrome **100.19dp → 22.48dp** in all five states; keyboard-up saturated editor **117.3dp → 220.2dp**, reaching its designed cap for the first time.

The root cause was a stale comment from the #567 era claiming the modal sheet does not reposition above the keyboard. material3 1.3.2 already IME-resizes the container — confirmed in bytecode by implementer and reviewer independently, and visible in the maintainer's own screenshot where the sheet bottom sits exactly at the keyboard top. So the layout subtracted the keyboard **twice** and capped the body to ~173dp when ~485dp was available. Six rounds of dp nudges were tuning inside a budget wrong by a factor of three.

Also closes **#682**, **#790**, **#801** — reopened when the symptom was reported live on v0.4.42.

**CI and release-gate hardening:** #2054 (the OOM that blocked v0.4.42 twice, now failing in 8ms instead of 19 minutes), #2060 (per-PR CI 53% faster, measured), #2063/#2067 (host-CLI coverage guard suite), #2065, #2069 (unit lane sharded by variant).

## Validated

`main` was green at `ad6acf28` — which already contains the composer fix — with , 453 emulator tests across 173 classes on attempt 1, and the new `Issue1622ComposerSheetGeometryProofTest` passing at its first CI execution.

A pooled pre-merge gate had already run that class 76/76 across four runs on a real emulator, with zero infra signatures.

## Not certifiable by emulator
Two things remain the maintainer's, and the release does not claim them: the dp reading on his physical Pixel (the AVD does not reproduce his 118px top inset — that environment gap is how this chain got closed as fixed before), and whether the keyboard-up composer now feels right to type into.