### PR TITLE
release: reuse exact-SHA CI unit evidence

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -361,6 +361,15 @@ jobs:
           scripts/check-release-gate-execution-profile.sh --self-test
           scripts/check-release-gate-execution-profile.sh
 
+      # Issue #2064: fail-closed proofs for one gate-built APK pair, exact-SHA
+      # sharded CI evidence reuse, and measured/provenance-rich summaries.
+      - name: Release identity and evidence guards (issue #2064)
+        run: |
+          chmod +x scripts/test-release-apk-identity.sh scripts/test-reuse-ci-unit-evidence.sh scripts/test-release-gate-summary.sh
+          scripts/test-release-apk-identity.sh
+          scripts/test-reuse-ci-unit-evidence.sh
+          scripts/test-release-gate-summary.sh
+
       # Issue #1761: the local forced full-JVM gate hit Kotlin compiler OOM when
       # Worker API sessions overlapped inside the 8 GiB scope. Keep its complete
       # `test --rerun-tasks` graph on the proven single-worker / split-heap

--- a/scripts/capture-walkthrough-screenshots.sh
+++ b/scripts/capture-walkthrough-screenshots.sh
@@ -7,6 +7,15 @@ cd "$ROOT_DIR"
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+
+# Issue #2064: see scripts/phone-walkthrough.sh — same contract, same
+# device-free verification mode, same reason it must not queue on the AVD lock.
+POCKETSHELL_VERIFY_APK_IDENTITY_ONLY=0
+if [[ "${1:-}" == "--verify-apk-identity" ]]; then
+  POCKETSHELL_VERIFY_APK_IDENTITY_ONLY=1
+  export POCKETSHELL_AVD_LOCK_ACQUIRED=1
+fi
 
 # Issue #2054: the visual-audit stage of the release gate builds the same APKs
 # that OOMed the terminal-lab walkthrough. Same shared resource profile, same
@@ -53,8 +62,23 @@ SSH_KEY="${SSH_KEY:-$ROOT_DIR/tests/docker/test_key}"
 SSH_HOST="${SSH_HOST:-127.0.0.1}"
 SSH_PORT="${SSH_PORT:-2222}"
 SSH_USER="${SSH_USER:-testuser}"
-APP_APK="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
-TEST_APK="$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+# Issue #2064: the release chain hands this stage the pair the pre-release
+# confidence gate built, validated and publishes, so the visual-audit
+# screenshots are of the SHIPPED binary rather than of a byte-different rebuild.
+APP_APK="${APP_APK:-$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk}"
+TEST_APK="${TEST_APK:-$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk}"
+# 1 keeps the historical standalone behaviour (build the pair here). The release
+# chain exports 0 together with the expected digests.
+VISUAL_AUDIT_BUILD_APKS="${VISUAL_AUDIT_BUILD_APKS:-1}"
+
+if [[ "$POCKETSHELL_VERIFY_APK_IDENTITY_ONLY" == "1" ]]; then
+  pocketshell_require_walkthrough_apk_identity "visual audit" || exit 1
+  printf 'PASS: visual-audit APK identity verified (issue #2064)\n'
+  printf '  app  %s\n' "$APP_APK"
+  printf '  test %s\n' "$TEST_APK"
+  exit 0
+fi
+pocketshell_verify_walkthrough_apks "visual audit" || exit 1
 
 usage() {
   cat <<'USAGE'
@@ -350,11 +374,44 @@ run_logged "06-cold-reset-emulator-app-state" bash -lc \
   _ "$ADB"
 run_logged "07-clear-logcat" "$ADB" logcat -c
 run_logged "08-clear-device-screenshots" "$ADB" shell rm -rf "$DEVICE_OUTPUT_DIR"
-run_logged "09-stop-gradle-daemons" \
-  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-visual-audit-$(pocketshell_unit_token "$RUN_ID")-stop-gradle" -- \
-  ./gradlew --stop
+# Issue #2064: when the release chain supplies the pair the pre-release gate
+# already built, validated and will publish, this stage must NOT rebuild — its
+# screenshots would otherwise be of a different binary than the one shipped.
+#
+# The skip is a command PREFIX rather than an `if` wrapped around the build.
+# That is deliberate: scripts/check-release-gate-execution-profile.sh (issue
+# #2054) anchors roughly twenty reachability mutations on the exact text and
+# column of the apply line and the `10-build-walkthrough-visual-apks` step
+# below, and re-indenting them silently turns those mutations into no-ops — a
+# stale anchor is the "mutation that never happened" failure this repo has
+# already paid for. Keeping the build statement byte-stable keeps every one of
+# those mutations live. The prefix swallows the build command and verifies the
+# supplied pair instead.
+visual_audit_reuse_validated_apks() {
+  printf 'Skipped because VISUAL_AUDIT_BUILD_APKS=0 (issue #2064).\n'
+  printf 'App APK: %s\n' "$APP_APK"
+  printf 'Test APK: %s\n' "$TEST_APK"
+  pocketshell_verify_walkthrough_apks "visual audit (install)"
+}
+
+VISUAL_AUDIT_BUILD_PREFIX=()
+if [[ "$VISUAL_AUDIT_BUILD_APKS" != "1" ]]; then
+  [[ -f "$APP_APK" ]] || fail "VISUAL_AUDIT_BUILD_APKS=0 but the app APK is missing at $APP_APK"
+  [[ -f "$TEST_APK" ]] || fail "VISUAL_AUDIT_BUILD_APKS=0 but the androidTest APK is missing at $TEST_APK"
+  VISUAL_AUDIT_BUILD_PREFIX=(visual_audit_reuse_validated_apks)
+fi
+
+# Nothing is built when reusing, so there is no daemon to stop either — and
+# `gradlew --stop` is machine-wide, i.e. it kills SIBLING lanes' daemons (a
+# documented cross-agent hazard). Skipping the build removes that too.
+if [[ "$VISUAL_AUDIT_BUILD_APKS" = "1" ]]; then
+  run_logged "09-stop-gradle-daemons" \
+    "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-visual-audit-$(pocketshell_unit_token "$RUN_ID")-stop-gradle" -- \
+    ./gradlew --stop
+fi
 pocketshell_apply_release_gate_scope_memory "visual-audit APK build"
 run_logged "10-build-walkthrough-visual-apks" \
+  "${VISUAL_AUDIT_BUILD_PREFIX[@]}" \
   "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-visual-audit-$(pocketshell_unit_token "$RUN_ID")-build-apks" -- \
   ./gradlew --no-daemon --no-build-cache "${POCKETSHELL_GRADLE_RESOURCE_ARGS[@]}" :app:assembleDebug :app:assembleDebugAndroidTest --stacktrace
 install_apks "11-install-walkthrough-visual-apks"

--- a/scripts/lib/apk-identity.sh
+++ b/scripts/lib/apk-identity.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+
+# ---------------------------------------------------------------------------
+# Release-chain APK identity (issue #2064)
+#
+# THE DEFECT THIS CLOSES — a correctness hole, not just a slow gate
+# -----------------------------------------------------------------
+# `scripts/pre-release-confidence-gate.sh` builds the debug + androidTest APK
+# pair inside its isolated worktree copy and validates THAT binary on the
+# emulator. `scripts/release-emulator-validation.sh` then publishes exactly that
+# file as `release-emulator-validation/<run>/app-debug.apk` — the artifact the
+# release notes tell a human to download.
+#
+# But every downstream stage (`phone-walkthrough.sh` terminal-lab /
+# tmux-existing-session / setup-detection, and `capture-walkthrough-
+# screenshots.sh`) used to `rm -rf app/build` and rebuild its own pair from the
+# same source. Same source is NOT the same binary: those are byte-different
+# builds. So the terminal, tmux, setup-detection and visual-audit evidence — the
+# journey evidence a tag actually rests on — was produced against a binary that
+# nothing else in the chain ever validated, and that is not the one shipped.
+#
+# A release gate that signs off on a binary it did not test is a hole regardless
+# of how fast it runs. (It also cost real time: 472s in run 20260809-v0442-r3,
+# 603s in 20260808-165533 — and the FIRST v0.4.42 attempt died 58 minutes in,
+# with a zipflinger OOM inside terminal-lab's redundant rebuild.)
+#
+# THE CONTRACT
+# ------------
+#   1. The confidence gate builds the pair ONCE and records
+#      `apk-identity.txt` (absolute paths + sha256 + byte size) in its run dir.
+#   2. `release-emulator-validation.sh` reads that file and exports the pair,
+#      their expected sha256s, and BUILD_APKS=0 into every downstream stage.
+#   3. Every downstream stage HARD-FAILS before installing anything if the file
+#      it is about to install does not hash to the recorded value.
+#   4. `publish_validated_apk` re-verifies the published copy against the same
+#      recorded sha, so the shipped artifact is provably the validated one.
+#
+# FAIL CLOSED, BOTH WAYS
+# ----------------------
+# "I could not check" must never read the same as "I checked and it is fine"
+# (the standing rule in this repo's catalogue). So:
+#   * a missing APK, a missing identity file, a malformed field, an empty
+#     expected sha, or only ONE of the two expected shas being set is a hard
+#     failure, not a skip;
+#   * with NO expected sha exported at all the verifier is a deliberate no-op,
+#     because that is the standalone developer invocation
+#     (`scripts/phone-walkthrough.sh terminal-lab` on a dev box) which builds
+#     its own APKs and has nothing to compare against. The release chain always
+#     exports them, and `--verify-apk-identity` mode REQUIRES them.
+# ---------------------------------------------------------------------------
+
+POCKETSHELL_APK_IDENTITY_FILE_NAME="apk-identity.txt"
+
+pocketshell_apk_identity_fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  return 1
+}
+
+# sha256 of a file. Hard-fails (empty output, non-zero) when the file is absent
+# so a caller can never compare against a silently empty digest.
+pocketshell_apk_sha256() {
+  local file="$1"
+  [[ -f "$file" ]] || {
+    pocketshell_apk_identity_fail "cannot hash a file that does not exist: $file"
+    return 1
+  }
+  local digest
+  digest="$(sha256sum "$file" | awk '{print $1}')"
+  [[ -n "$digest" ]] || {
+    pocketshell_apk_identity_fail "sha256sum produced no digest for $file"
+    return 1
+  }
+  printf '%s' "$digest"
+}
+
+# pocketshell_record_apk_identity <identity-file> <app-apk> <test-apk>
+#
+# Called by the confidence gate immediately after the ONE build of the pair.
+pocketshell_record_apk_identity() {
+  local identity_file="$1"
+  local app_apk="$2"
+  local test_apk="$3"
+
+  local app_sha test_sha app_bytes test_bytes
+  app_sha="$(pocketshell_apk_sha256 "$app_apk")" || return 1
+  test_sha="$(pocketshell_apk_sha256 "$test_apk")" || return 1
+  app_bytes="$(stat -c '%s' "$app_apk")"
+  test_bytes="$(stat -c '%s' "$test_apk")"
+
+  mkdir -p "$(dirname "$identity_file")"
+  {
+    printf '# PocketShell release APK identity (issue #2064)\n'
+    printf '# Every downstream release stage installs THESE files and verifies\n'
+    printf '# THESE digests; publish_validated_apk ships the same bytes.\n'
+    printf 'recorded_at=%s\n' "$(date -Is)"
+    printf 'app_apk=%s\n' "$app_apk"
+    printf 'app_apk_sha256=%s\n' "$app_sha"
+    printf 'app_apk_bytes=%s\n' "$app_bytes"
+    printf 'test_apk=%s\n' "$test_apk"
+    printf 'test_apk_sha256=%s\n' "$test_sha"
+    printf 'test_apk_bytes=%s\n' "$test_bytes"
+  } > "$identity_file"
+
+  printf 'Recorded release APK identity: %s\n' "$identity_file"
+  printf '  app  %s  %s\n' "$app_sha" "$app_apk"
+  printf '  test %s  %s\n' "$test_sha" "$test_apk"
+}
+
+# pocketshell_read_apk_identity_field <identity-file> <key>
+#
+# Exact key match on a `key=value` line; comments ignored. Prints nothing and
+# returns non-zero when the key is absent, so an unset field can never be read
+# as an empty-but-valid value.
+pocketshell_read_apk_identity_field() {
+  local identity_file="$1"
+  local key="$2"
+  [[ -f "$identity_file" ]] || {
+    pocketshell_apk_identity_fail "APK identity file not found: $identity_file"
+    return 1
+  }
+  local value
+  value="$(awk -v want="$key" -F= '
+    /^[[:space:]]*#/ { next }
+    { name = $1; sub(/^[[:space:]]+/, "", name); sub(/[[:space:]]+$/, "", name) }
+    name == want { sub(/^[^=]*=/, "", $0); print; exit }
+  ' "$identity_file")"
+  [[ -n "$value" ]] || {
+    pocketshell_apk_identity_fail "APK identity file $identity_file has no '$key' value"
+    return 1
+  }
+  printf '%s' "$value"
+}
+
+# pocketshell_assert_apk_identity <label> <apk> <expected-sha256>
+#
+# The load-bearing assertion. A mismatch means the caller is about to install /
+# ship a DIFFERENT binary than the one the gate validated.
+pocketshell_assert_apk_identity() {
+  local label="$1"
+  local apk="$2"
+  local expected="$3"
+
+  [[ -n "$expected" ]] || {
+    pocketshell_apk_identity_fail "$label: no expected sha256 was supplied for $apk. An unverifiable APK is not a verified APK (issue #2064)."
+    return 1
+  }
+  [[ -f "$apk" ]] || {
+    pocketshell_apk_identity_fail "$label: APK is missing at $apk (expected sha256 $expected)"
+    return 1
+  }
+  local actual
+  actual="$(pocketshell_apk_sha256 "$apk")" || return 1
+  if [[ "$actual" != "$expected" ]]; then
+    pocketshell_apk_identity_fail "$label: APK identity mismatch for $apk
+  expected sha256: $expected  (built and validated by the pre-release confidence gate)
+  actual   sha256: $actual
+This stage would have installed a DIFFERENT binary than the one the release gate
+validated and than publish_validated_apk ships. Rebuild-in-stage is exactly the
+defect issue #2064 removed; do not paper over it by re-recording the digest."
+    return 1
+  fi
+  printf '%s: APK identity verified (%s) %s\n' "$label" "$actual" "$apk"
+}
+
+# pocketshell_export_walkthrough_apk_env <gate-run-dir>
+#
+# The ONE place the release chain turns the gate's recorded identity into the
+# environment every downstream stage consumes. Production and the #2064 test
+# both call this, so the test drives the real wiring rather than a re-spelling
+# of it.
+pocketshell_export_walkthrough_apk_env() {
+  local gate_run_dir="$1"
+  local identity_file="$gate_run_dir/$POCKETSHELL_APK_IDENTITY_FILE_NAME"
+
+  local app_apk test_apk app_sha test_sha
+  app_apk="$(pocketshell_read_apk_identity_field "$identity_file" app_apk)" || return 1
+  test_apk="$(pocketshell_read_apk_identity_field "$identity_file" test_apk)" || return 1
+  app_sha="$(pocketshell_read_apk_identity_field "$identity_file" app_apk_sha256)" || return 1
+  test_sha="$(pocketshell_read_apk_identity_field "$identity_file" test_apk_sha256)" || return 1
+
+  # Verify at the source, before any stage is launched: a gate APK that has
+  # been overwritten/truncated since it was recorded must stop the release here
+  # rather than at the third stage that tries to install it.
+  pocketshell_assert_apk_identity "release chain (gate-built app APK)" "$app_apk" "$app_sha" || return 1
+  pocketshell_assert_apk_identity "release chain (gate-built androidTest APK)" "$test_apk" "$test_sha" || return 1
+
+  export APP_APK="$app_apk"
+  export TEST_APK="$test_apk"
+  export POCKETSHELL_EXPECTED_APP_APK_SHA256="$app_sha"
+  export POCKETSHELL_EXPECTED_TEST_APK_SHA256="$test_sha"
+  # Build knobs for the four install-stage consumers. Each already had its own;
+  # none gains a new bypass channel — these turn the existing "do not rebuild" path
+  # ON for the release chain, which is what makes the binary identical.
+  export BUILD_APKS=0
+  export PHONE_WALKTHROUGH_CLEAN_GENERATED=0
+  export PARALLEL_BUILD_APKS=0
+  export VISUAL_AUDIT_BUILD_APKS=0
+  export POCKETSHELL_APK_IDENTITY_FILE="$identity_file"
+}
+
+# pocketshell_verify_walkthrough_apks <label>
+#
+# Called by every downstream stage before it installs anything.
+#   * both expected shas exported -> verify both, hard-fail on any mismatch;
+#   * neither exported            -> deliberate no-op (standalone dev run);
+#   * exactly one exported        -> hard failure (a half-configured chain must
+#                                    not silently verify half the pair).
+pocketshell_verify_walkthrough_apks() {
+  local label="$1"
+  local app_expected="${POCKETSHELL_EXPECTED_APP_APK_SHA256:-}"
+  local test_expected="${POCKETSHELL_EXPECTED_TEST_APK_SHA256:-}"
+
+  if [[ -z "$app_expected" && -z "$test_expected" ]]; then
+    return 0
+  fi
+  if [[ -z "$app_expected" || -z "$test_expected" ]]; then
+    pocketshell_apk_identity_fail "$label: exactly one of POCKETSHELL_EXPECTED_APP_APK_SHA256 / POCKETSHELL_EXPECTED_TEST_APK_SHA256 is set. Half a verified pair is not a verified pair (issue #2064)."
+    return 1
+  fi
+
+  pocketshell_assert_apk_identity "$label (app APK)" "${APP_APK:-}" "$app_expected" || return 1
+  pocketshell_assert_apk_identity "$label (androidTest APK)" "${TEST_APK:-}" "$test_expected" || return 1
+}
+
+# pocketshell_require_walkthrough_apk_identity <label>
+#
+# The `--verify-apk-identity` mode's entry point. Same as the verifier above but
+# an unset expectation is a HARD failure: a verification mode that verifies
+# nothing is the vacuous green this repo keeps re-learning about.
+pocketshell_require_walkthrough_apk_identity() {
+  local label="$1"
+  if [[ -z "${POCKETSHELL_EXPECTED_APP_APK_SHA256:-}" || -z "${POCKETSHELL_EXPECTED_TEST_APK_SHA256:-}" ]]; then
+    pocketshell_apk_identity_fail "$label: --verify-apk-identity requires POCKETSHELL_EXPECTED_APP_APK_SHA256 and POCKETSHELL_EXPECTED_TEST_APK_SHA256. Refusing to report a pass over an unchecked pair."
+    return 1
+  fi
+  pocketshell_verify_walkthrough_apks "$label"
+}

--- a/scripts/parallel-setup-detection.sh
+++ b/scripts/parallel-setup-detection.sh
@@ -34,6 +34,26 @@ cd "$ROOT_DIR"
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+
+# Issue #2064: the release chain hands the shards the pair the pre-release
+# confidence gate built, validated and publishes. Resolved here, above the
+# option parser, because `--verify-apk-identity` must short-circuit before it.
+APP_APK="${APP_APK:-$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk}"
+TEST_APK="${TEST_APK:-$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk}"
+PARALLEL_BUILD_APKS="${PARALLEL_BUILD_APKS:-1}"
+
+# Same contract and same device-free verification mode as
+# scripts/phone-walkthrough.sh; it touches no emulator, so no AVD lock.
+if [[ "${1:-}" == "--verify-apk-identity" ]]; then
+  export POCKETSHELL_AVD_LOCK_ACQUIRED=1
+  pocketshell_require_walkthrough_apk_identity "parallel setup-detection" || exit 1
+  printf 'PASS: parallel-setup-detection APK identity verified (issue #2064)\n'
+  printf '  app  %s\n' "$APP_APK"
+  printf '  test %s\n' "$TEST_APK"
+  exit 0
+fi
+pocketshell_verify_walkthrough_apks "parallel setup-detection" || exit 1
 
 # Issue #2054: the sharded setup-detection matrix builds the APKs ONCE up front
 # for every shard, so an unbounded-heap build here fails the whole fan-out. The
@@ -288,9 +308,8 @@ fi
 # shard with BUILD_APKS=0 + PHONE_WALKTHROUGH_CLEAN_GENERATED=0 so no shard
 # touches app/build — the per-emulator `pm install` step remains safe to run
 # concurrently (it targets each shard's own ANDROID_SERIAL).
-APP_APK="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
-TEST_APK="$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
-PARALLEL_BUILD_APKS="${PARALLEL_BUILD_APKS:-1}"
+# APP_APK / TEST_APK / PARALLEL_BUILD_APKS are resolved above the option parser
+# (issue #2064) so `--verify-apk-identity` can short-circuit on them.
 export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$LOG_ROOT/gradle-home}"
 if [[ "$PARALLEL_BUILD_APKS" = "1" ]]; then
   build_log="$RUN_DIR/00-build-apks.log"
@@ -306,6 +325,10 @@ if [[ "$PARALLEL_BUILD_APKS" = "1" ]]; then
 fi
 [[ -f "$APP_APK" ]] || fail "app APK missing at $APP_APK (set PARALLEL_BUILD_APKS=1 to build)"
 [[ -f "$TEST_APK" ]] || fail "androidTest APK missing at $TEST_APK (set PARALLEL_BUILD_APKS=1 to build)"
+# Issue #2064: re-verify AFTER the optional pre-shard build, so a local rebuild
+# that diverged from the gate-validated pair is caught before any shard
+# installs it.
+pocketshell_verify_walkthrough_apks "parallel setup-detection (pre-shard)" || fail "pre-shard APK identity check failed"
 
 # --- fan out ----------------------------------------------------------------
 declare -a SHARD_PIDS=()
@@ -340,6 +363,10 @@ for ((i = 0; i < num_shards; i++)); do
     # which is shared across shards (see the pre-shard build above).
     export BUILD_APKS=0
     export PHONE_WALKTHROUGH_CLEAN_GENERATED=0
+    # Issue #2064: hand the shard the resolved pair explicitly (it may be the
+    # gate's isolated-worktree APK, outside this checkout's app/build) plus the
+    # expected digests, so each shard verifies the binary it installs.
+    export APP_APK TEST_APK
     exec "$ROOT_DIR/scripts/phone-walkthrough.sh" "${scenario_args[@]}"
   ) >"$shard_log" 2>&1 &
   SHARD_PIDS[i]="$!"

--- a/scripts/phone-walkthrough.sh
+++ b/scripts/phone-walkthrough.sh
@@ -7,6 +7,18 @@ cd "$ROOT_DIR"
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+
+# Issue #2064: `--verify-apk-identity` proves the release chain's APK contract
+# end to end — the exported environment, this script's own resolution of it, and
+# the hard-fail on a mismatched binary — with no emulator, no Docker and no
+# Gradle. It touches no device, so it must not queue behind the machine-wide AVD
+# lock either.
+POCKETSHELL_VERIFY_APK_IDENTITY_ONLY=0
+if [[ "${1:-}" == "--verify-apk-identity" ]]; then
+  POCKETSHELL_VERIFY_APK_IDENTITY_ONLY=1
+  export POCKETSHELL_AVD_LOCK_ACQUIRED=1
+fi
 
 # Issue #2054: this script's `08-build-apks` step is where release run
 # 20260809-v0442 died with `OutOfMemoryError: Java heap space` in
@@ -72,8 +84,26 @@ else
 fi
 TEST_PACKAGE="$PACKAGE.test"
 DEVICE_OUTPUT_DIR="/sdcard/Android/media/$PACKAGE/additional_test_output"
-APP_APK="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
-TEST_APK="$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+# Issue #2064: the release chain points these at the pair the pre-release
+# confidence gate built and validated (and that publish_validated_apk ships), so
+# this walkthrough installs the SAME binary instead of rebuilding a
+# byte-different one. A standalone developer run leaves them unset and gets the
+# historical local paths.
+APP_APK="${APP_APK:-$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk}"
+TEST_APK="${TEST_APK:-$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk}"
+
+# Verify BEFORE the emulator, Docker fixtures and instrumentation are touched:
+# an APK that is not the validated one must stop the stage in the first second,
+# not after a Docker bring-up. A no-op when no expectation was exported (the
+# standalone dev run); a hard failure on any mismatch or half-set pair.
+if [[ "$POCKETSHELL_VERIFY_APK_IDENTITY_ONLY" == "1" ]]; then
+  pocketshell_require_walkthrough_apk_identity "phone walkthrough" || exit 1
+  printf 'PASS: phone-walkthrough APK identity verified (issue #2064)\n'
+  printf '  app  %s\n' "$APP_APK"
+  printf '  test %s\n' "$TEST_APK"
+  exit 0
+fi
+pocketshell_verify_walkthrough_apks "phone walkthrough" || exit 1
 
 TERMINAL_LAB_TEST_CLASS="com.pocketshell.app.terminal.TerminalLabDockerTest"
 TERMINAL_LAB_DEVICE_DIR="$DEVICE_OUTPUT_DIR/terminal-lab"
@@ -715,6 +745,13 @@ build_and_install_apks() {
       printf 'Test APK: %s\n' "$TEST_APK"
     } | tee "$LOG_DIR/08-build-apks.log"
   fi
+
+  # Issue #2064: the AUTHORITATIVE check, immediately before install. The
+  # early config-time check fails fast; this one is adjacent to the `adb
+  # install` it protects, so a rebuild between the two (BUILD_APKS=1 with an
+  # expectation exported) is caught rather than installed.
+  run_logged "08b-verify-apk-identity" \
+    pocketshell_verify_walkthrough_apks "phone walkthrough (install)"
 
   run_logged "09-cold-reset-app-state-before-install" bash -lc \
     "printf 'COLD-RESET: clearing app/test package data for deterministic phone walkthrough\n'; \

--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -7,6 +7,10 @@ cd "$ROOT_DIR"
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
+# Issue #2064: the debug + androidTest APK pair is built HERE, once, and every
+# downstream release stage installs and ships THESE bytes. See
+# scripts/lib/apk-identity.sh for why "same source" was not good enough.
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
 # Issue #2054: the AVD lock is acquired further down, AFTER the execution-profile
 # assertion. Queuing behind another emulator-touching run can take an hour; an
 # under-resourced profile should be rejected in the first second, not after that
@@ -203,7 +207,12 @@ if [[ "$GATE_ISOLATED_WORKTREE" != "0" && -z "${POCKETSHELL_GATE_ISOLATED_COPY:-
     --exclude='build/' \
     "$ROOT_DIR/" "$isolated_root/"
   export POCKETSHELL_GATE_ISOLATED_COPY=1
-  export POCKETSHELL_GATE_SOURCE_ROOT="$ROOT_DIR"
+  # Normally the outer release checkout is the exact clean/pushed source of
+  # truth. Preserve an explicit source root for pre-merge reviewer validation,
+  # where the candidate contains only gate-script changes but its JVM evidence
+  # must still be tied to the clean pushed base; the acceptor independently
+  # enforces clean HEAD == origin/main on whichever root is supplied.
+  export POCKETSHELL_GATE_SOURCE_ROOT="${POCKETSHELL_GATE_SOURCE_ROOT:-$ROOT_DIR}"
   # Issue #2054: POCKETSHELL_TEST_MEM must cross into the isolated copy too — the
   # child is what actually invokes scripts/cgroup-run.sh for every heavy step, so
   # without this the build scope silently falls back to scope-run.sh's 8G default.
@@ -242,6 +251,21 @@ STEP_NAMES=()
 STEP_STATUSES=()
 STEP_LOGS=()
 STEP_COMMANDS=()
+# Issue #2064: run_step has always MEASURED every step ("PASS: <name> (Ns)") but
+# never kept the numbers, so the gate's own cost stayed unaggregated and the
+# release chain was described as "unmeasured" for a year. Keep them and print a
+# ranked table in the summary; no new instrumentation, just not throwing the
+# existing measurement away.
+STEP_SECONDS=()
+# Issue #2064: how the unit-test evidence for this release was obtained —
+# "reused-ci" (the required `Unit tests` check on this exact SHA, independently
+# re-verified against the downloaded result XML) or "local" (the gate ran the
+# suite itself). Recorded in the summary either way; a missing/unusable CI
+# result always falls back to "local", never to "assumed green".
+UNIT_EVIDENCE_MODE="local"
+UNIT_EVIDENCE_DETAIL="local Gradle check graph (assembleDebug check -x lint -x lintDebug)"
+CI_UNIT_EVIDENCE_DIR="$RUN_DIR/ci-unit-evidence"
+APK_IDENTITY_FILE="$RUN_DIR/$POCKETSHELL_APK_IDENTITY_FILE_NAME"
 FOCUSED_SELECTORS=("${APP_WALKTHROUGH_TESTS[@]}")
 FOCUSED_STATUSES=()
 FOCUSED_LOGS=()
@@ -326,6 +350,19 @@ write_summary() {
     # runs died in the build with no artifact naming the heap/scope they used.
     printf 'Gradle flags: %s\n' "$GRADLE_FLAGS"
     printf 'Build scope MemoryMax (POCKETSHELL_TEST_MEM): %s\n' "${POCKETSHELL_TEST_MEM:-unset}"
+    # Issue #2064: WHERE the 12,362-test unit evidence for this release came
+    # from is release evidence in its own right. "reused-ci" names the run;
+    # "local" says the gate executed the suite itself.
+    printf 'Unit evidence: %s\n' "$UNIT_EVIDENCE_MODE"
+    printf 'Unit evidence detail: %s\n' "$UNIT_EVIDENCE_DETAIL"
+    # Issue #2064: the one binary this whole chain validates and ships.
+    printf 'APK identity file: %s\n' "$APK_IDENTITY_FILE"
+    if [[ -f "$APK_IDENTITY_FILE" ]]; then
+      printf 'Validated app APK sha256: %s\n' \
+        "$(pocketshell_read_apk_identity_field "$APK_IDENTITY_FILE" app_apk_sha256 2>/dev/null || printf 'unknown')"
+      printf 'Validated androidTest APK sha256: %s\n' \
+        "$(pocketshell_read_apk_identity_field "$APK_IDENTITY_FILE" test_apk_sha256 2>/dev/null || printf 'unknown')"
+    fi
     printf 'Connected core-terminal burst proof (step 12, non-fatal — issue #1314): %s\n' "$CONNECTED_TERMINAL_INPUT_STATUS"
     printf 'Focused app cold-reset APK install status: %s\n' "$APP_WALKTHROUGH_INSTALL_STATUS"
     printf 'Final data-preserving update install status: %s\n' "$FINAL_INSTALL_STATUS"
@@ -341,11 +378,31 @@ write_summary() {
 
     printf '\nSteps:\n'
     local i
+    local total_step_seconds=0
     for i in "${!STEP_NAMES[@]}"; do
       printf -- '- name: %s\n' "${STEP_NAMES[$i]}"
       printf '  status: %s\n' "${STEP_STATUSES[$i]}"
+      printf '  seconds: %s\n' "${STEP_SECONDS[$i]:-0}"
       printf '  log: %s\n' "${STEP_LOGS[$i]}"
       printf '  command: %s\n' "${STEP_COMMANDS[$i]}"
+      total_step_seconds=$((total_step_seconds + ${STEP_SECONDS[$i]:-0}))
+    done
+
+    # Issue #2064: the ranked cost table. The gate emitted every one of these
+    # numbers already; nobody had ever aggregated them, which is why the local
+    # release chain was "unmeasured". Cheapest possible measurement — sort what
+    # run_step already timed.
+    printf '\nStep timings (slowest first, seconds):\n'
+    printf 'Total step seconds: %s\n' "$total_step_seconds"
+    for i in "${!STEP_NAMES[@]}"; do
+      printf '%s\t%s\t%s\n' "${STEP_SECONDS[$i]:-0}" "${STEP_NAMES[$i]}" "${STEP_STATUSES[$i]}"
+    done | sort -rn | while IFS=$'\t' read -r secs name status; do
+      if [[ "$total_step_seconds" -gt 0 ]]; then
+        printf -- '- %6ss  %5s%%  %-52s %s\n' \
+          "$secs" "$((secs * 100 / total_step_seconds))" "$name" "$status"
+      else
+        printf -- '- %6ss  %5s   %-52s %s\n' "$secs" "n/a" "$name" "$status"
+      fi
     done
 
     printf '\nFocused selectors:\n'
@@ -405,6 +462,7 @@ run_step() {
   STEP_STATUSES+=("running")
   STEP_LOGS+=("$log_file")
   STEP_COMMANDS+=("$command_string")
+  STEP_SECONDS+=("0")
   local step_array_index=$((${#STEP_NAMES[@]} - 1))
 
   printf '\n[%02d] %s\n' "$STEP_INDEX" "$name"
@@ -422,6 +480,7 @@ run_step() {
   set -e
   end_seconds="$(date +%s)"
   elapsed_seconds=$((end_seconds - start_seconds))
+  STEP_SECONDS[step_array_index]="$elapsed_seconds"
 
   if [[ "$status" -eq 0 ]]; then
     STEP_STATUSES[step_array_index]="passed"
@@ -463,6 +522,28 @@ run_step() {
   fi
 
   return "$status"
+}
+
+# A CI-evidence refusal is an expected fail-closed branch, not a release-gate
+# failure: the next step runs the complete local graph. Preserve its timing/log
+# while preventing stale failure state from leaking into an otherwise-green
+# summary.
+mark_step_declined() {
+  local name="$1"
+  local index
+  for (( index=${#STEP_NAMES[@]} - 1; index >= 0; index-- )); do
+    if [[ "${STEP_NAMES[index]}" == "$name" ]]; then
+      STEP_STATUSES[index]="declined"
+      break
+    fi
+  done
+  if [[ "$FAILING_STEP" == "$name" ]]; then
+    FAILING_STEP=""
+    FAILING_LOG_PATH=""
+    FAILURE_MESSAGE=""
+    FAILURE_DIAGNOSTICS_PATH=""
+    FAILURE_LOGCAT_PATH=""
+  fi
 }
 
 run_bash_step() {
@@ -1740,8 +1821,45 @@ if ! "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then
   fail "AVD '$AVD_NAME' was not listed by $EMULATOR -list-avds"
 fi
 
+# Issue #2064: SHA-matched reuse of the required `Unit tests` evidence.
+#
+# MEASURED DUPLICATION. In release run 20260809-v0442-r3 (`Commit SHA
+# 0248d0ee`) this gate's `gradle-compile-unit` step cost 1083s of a 2516s
+# chain, and 890s of that (82%) was unit-test compile + execution: 12,362 tests
+# re-run against source the required `Unit tests` check had already tested green
+# on the very same commit. Task extraction from that run's console confirmed
+# `check` wires no custom guard tasks here, so `assembleDebug check` is exactly
+# `assembleDebug` + `./gradlew test`.
+#
+# AND CI IS STRICTER. The `unit` job runs `--rerun-tasks --no-build-cache` and
+# then the #1646 executed-count floors + freshness + FROM-CACHE console scan;
+# the local `check` applies none of those. Reusing that result RAISES the bar.
+#
+# NON-FATAL BY CONSTRUCTION. This step declines — loudly — on a dirty tree, an
+# unpushed HEAD, a missing/red/foreign-SHA check run, a weakened workflow, or
+# result XML that does not independently satisfy the floors. A decline means
+# the gate runs the whole suite locally below. A missing CI result can never
+# read as a pass.
+if run_step "reuse-ci-unit-evidence" \
+  "$ROOT_DIR/scripts/reuse-ci-unit-evidence.sh" \
+    --source-root "${POCKETSHELL_GATE_SOURCE_ROOT:-$ROOT_DIR}" \
+    --tree-root "$ROOT_DIR" \
+    --out-dir "$CI_UNIT_EVIDENCE_DIR"; then
+  UNIT_EVIDENCE_MODE="reused-ci"
+  UNIT_EVIDENCE_DETAIL="$(grep -m1 '^Workflow run URL: ' "$CI_UNIT_EVIDENCE_DIR/evidence.txt" 2>/dev/null | sed 's/^Workflow run URL: //')"
+  UNIT_EVIDENCE_DETAIL="reused the required 'Unit tests' check on this exact commit (${UNIT_EVIDENCE_DETAIL:-unknown run}); downloaded result XML re-verified locally against scripts/executed-test-count-floors.txt — see $CI_UNIT_EVIDENCE_DIR/evidence.txt"
+  GATE_COMPILE_UNIT_TASKS="assembleDebug"
+  printf 'Unit evidence: REUSING the CI `Unit tests` result for this commit; this gate builds only, and does not re-run the suite.\n'
+else
+  mark_step_declined "reuse-ci-unit-evidence"
+  UNIT_EVIDENCE_MODE="local"
+  UNIT_EVIDENCE_DETAIL="local Gradle check graph (assembleDebug check -x lint -x lintDebug); CI evidence was declined — see $RUN_DIR/03-reuse-ci-unit-evidence.log"
+  GATE_COMPILE_UNIT_TASKS="assembleDebug check -x lint -x lintDebug"
+  printf 'WARN: CI unit evidence was NOT accepted for this commit; running the full unit suite locally (issue #2064 fail-closed path). See the reuse-ci-unit-evidence step log for the reason.\n' >&2
+fi
+
 run_bash_step "gradle-compile-unit" \
-  "'$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-ksp-hilt' -- ./gradlew $GRADLE_FLAGS :app:kspDebugKotlin :app:kspReleaseKotlin :app:kspDebugAndroidTestKotlin :app:kspDebugUnitTestKotlin :app:kspReleaseUnitTestKotlin :app:hiltJavaCompileDebug :app:hiltJavaCompileRelease :app:hiltJavaCompileDebugAndroidTest --stacktrace && '$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-assemble-check' -- ./gradlew $GRADLE_FLAGS assembleDebug check -x lint -x lintDebug --stacktrace"
+  "'$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-ksp-hilt' -- ./gradlew $GRADLE_FLAGS :app:kspDebugKotlin :app:kspReleaseKotlin :app:kspDebugAndroidTestKotlin :app:kspDebugUnitTestKotlin :app:kspReleaseUnitTestKotlin :app:hiltJavaCompileDebug :app:hiltJavaCompileRelease :app:hiltJavaCompileDebugAndroidTest --stacktrace && '$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-assemble-check' -- ./gradlew $GRADLE_FLAGS $GATE_COMPILE_UNIT_TASKS --stacktrace"
 
 run_step "docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
 # Issue #150: wait on the compose `healthcheck:` block via
@@ -1809,6 +1927,17 @@ run_step "build-app-test-apks" \
 [[ -f "$APK_PATH" ]] || fail "APK artifact was not created at $APK_PATH"
 [[ -f "$TEST_APK_PATH" ]] || fail "Android test APK artifact was not created at $TEST_APK_PATH"
 
+# Issue #2064: this is the ONE build of the release pair. Record its identity so
+# every downstream stage installs THESE bytes and publish_validated_apk ships
+# THESE bytes. Before this, terminal-lab / tmux-existing-session /
+# setup-detection / visual-audit each `rm -rf app/build` and rebuilt their own
+# byte-different pair, so the journey evidence a tag rests on came from a binary
+# nothing else in the chain had validated.
+run_step "record-validated-apk-identity" \
+  pocketshell_record_apk_identity "$APK_IDENTITY_FILE" \
+  "$(cd "$(dirname "$APK_PATH")" && pwd)/$(basename "$APK_PATH")" \
+  "$(cd "$(dirname "$TEST_APK_PATH")" && pwd)/$(basename "$TEST_APK_PATH")"
+
 LEGACY_V1_DB_MIGRATION_STATUS="running"
 run_bash_step "migrate-legacy-v1-databases" "$(legacy_v1_database_migration_script)"
 
@@ -1838,10 +1967,17 @@ for app_walkthrough_index in "${!APP_WALKTHROUGH_TESTS[@]}"; do
   fi
 done
 
-run_step "build-debug-apk" \
-  "$ROOT_DIR/scripts/cgroup-run.sh" --unit "pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-build-debug-apk" -- \
-  ./gradlew "${GRADLE_ARGS[@]}" :app:assembleDebug --stacktrace
-[[ -f "$APK_PATH" ]] || fail "APK artifact was not created at $APK_PATH"
+# Issue #2064: this step used to re-run `:app:assembleDebug` after
+# `build-app-test-apks` had already produced the APK — a fourth build of the
+# same binary inside a chain that was already building it four times. It is
+# replaced by the assertion that makes the redundancy unnecessary AND provable:
+# the APK about to be update-installed and published must still hash to the
+# value recorded at the single build. A rebuild here would have masked exactly
+# the divergence this gate now refuses to ship.
+run_step "verify-debug-apk-identity" \
+  pocketshell_assert_apk_identity "pre-release gate (update-install candidate)" \
+  "$APK_PATH" \
+  "$(pocketshell_read_apk_identity_field "$APK_IDENTITY_FILE" app_apk_sha256)"
 
 run_step "update-install-debug-apk" "$ROOT_DIR/scripts/install-update-apk.sh" "$APK_PATH"
 

--- a/scripts/release-emulator-validation.sh
+++ b/scripts/release-emulator-validation.sh
@@ -6,6 +6,10 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
+# Issue #2064: one binary for the whole chain — the pre-release gate builds it,
+# every downstream stage installs it, publish_validated_apk ships it, and each
+# hop re-checks the sha256.
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
 
 # Issue #2054: apply and assert the release build resource profile ONCE, at the
 # top of the whole validation, before the ~30-60 minute run takes the shared AVD
@@ -25,6 +29,14 @@ pocketshell_assert_gradle_execution_profile \
 # because it exports POCKETSHELL_TEST_MEM, every child stage inherits 24G and
 # their own point-of-use assertions pass without repeating the export.
 
+# Issue #2064: `--verify-apk-identity` drives the REAL chain wiring — this
+# script's export of the gate-recorded pair, its publish-time digest assertion,
+# and each downstream stage's own verification — with no emulator, no Docker and
+# no Gradle. It touches no device, so it must not queue on the AVD lock.
+if [[ "${1:-}" == "--verify-apk-identity" ]]; then
+  export POCKETSHELL_AVD_LOCK_ACQUIRED=1
+fi
+
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/release-emulator-validation}"
@@ -35,7 +47,9 @@ RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
 SUMMARY_PATH="$RUN_DIR/summary.md"
 PRE_RELEASE_RUN_ID="$RUN_ID-pre-release"
-PRE_RELEASE_GATE_LOG_ROOT="$ROOT_DIR/build/pre-release-confidence-gate"
+# Overridable so the #2064 identity test can point the whole chain at a fixture
+# gate run without an emulator; the release default is unchanged.
+PRE_RELEASE_GATE_LOG_ROOT="${PRE_RELEASE_GATE_LOG_ROOT:-$ROOT_DIR/build/pre-release-confidence-gate}"
 PRE_RELEASE_GATE_RUN_DIR="$PRE_RELEASE_GATE_LOG_ROOT/$PRE_RELEASE_RUN_ID"
 PRE_RELEASE_GATE_APK="$PRE_RELEASE_GATE_RUN_DIR/worktree/app/build/outputs/apk/debug/app-debug.apk"
 VALIDATED_APK="$RUN_DIR/app-debug.apk"
@@ -197,6 +211,38 @@ print_failure_log_tail() {
   fi
 }
 
+# Issue #2064: run_required already measured every stage and threw the number
+# away. Keep them so the release summary carries its own wall-clock breakdown
+# and a "before/after" is a `grep`, not an archaeology exercise across artefact
+# mtimes (which is how the 41m56s baseline for run 20260809-v0442-r3 had to be
+# reconstructed).
+STAGE_LABELS=()
+STAGE_SECONDS=()
+STAGE_STATUSES=()
+
+write_stage_timings() {
+  local i total=0
+  for i in "${!STAGE_LABELS[@]}"; do
+    total=$((total + STAGE_SECONDS[i]))
+  done
+  {
+    printf '\n## Stage wall clock (issue #2064)\n\n'
+    printf -- '- Total stage seconds: **%s** (%sm%ss)\n\n' "$total" "$((total / 60))" "$((total % 60))"
+    printf '| Stage | Seconds | %% | Status |\n'
+    printf '| --- | ---: | ---: | --- |\n'
+    for i in "${!STAGE_LABELS[@]}"; do
+      if [[ "$total" -gt 0 ]]; then
+        printf '| %s | %s | %s%% | %s |\n' \
+          "${STAGE_LABELS[$i]}" "${STAGE_SECONDS[$i]}" \
+          "$((STAGE_SECONDS[i] * 100 / total))" "${STAGE_STATUSES[$i]}"
+      else
+        printf '| %s | %s | n/a | %s |\n' \
+          "${STAGE_LABELS[$i]}" "${STAGE_SECONDS[$i]}" "${STAGE_STATUSES[$i]}"
+      fi
+    done
+  } >> "$SUMMARY_PATH"
+}
+
 run_required() {
   local label="$1"
   local artifact="$2"
@@ -223,24 +269,60 @@ run_required() {
   set -e
   end_seconds="$(date +%s)"
   elapsed_seconds=$((end_seconds - start_seconds))
+  STAGE_LABELS+=("$label")
+  STAGE_SECONDS+=("$elapsed_seconds")
   if [[ "$status" -eq 0 ]]; then
+    STAGE_STATUSES+=("passed")
     printf 'PASS: %s (%ss)\n' "$label" "$elapsed_seconds"
     return 0
   fi
 
+  STAGE_STATUSES+=("failed")
   printf 'FAIL: %s exited %s after %ss\n' "$label" "$status" "$elapsed_seconds" >&2
   print_failure_log_tail "$log_file"
   {
     sed -i 's/^Automated status: RUNNING$/Automated status: FAIL/' "$SUMMARY_PATH"
+    write_stage_timings
     fail "$label failed"
   }
 }
 
+# Issue #2064: turn the gate's recorded identity into the environment every
+# downstream stage consumes, and verify the gate APKs are still the recorded
+# bytes before a single stage is launched. Hard-fails: the gate we just ran
+# always writes apk-identity.txt, so a missing/mismatched one means the release
+# chain is not describing one binary and must not continue.
+export_validated_apk_identity() {
+  pocketshell_export_walkthrough_apk_env "$PRE_RELEASE_GATE_RUN_DIR" ||
+    fail "the pre-release confidence gate did not leave a usable APK identity record at $PRE_RELEASE_GATE_RUN_DIR/$POCKETSHELL_APK_IDENTITY_FILE_NAME (issue #2064). Every downstream stage installs and ships that exact pair; without the record the chain cannot prove it validated the binary it publishes."
+  {
+    printf '\n## Validated APK identity (issue #2064)\n\n'
+    printf -- '- app APK: `%s`\n' "$APP_APK"
+    printf -- '- app APK sha256: `%s`\n' "$POCKETSHELL_EXPECTED_APP_APK_SHA256"
+    printf -- '- androidTest APK: `%s`\n' "$TEST_APK"
+    printf -- '- androidTest APK sha256: `%s`\n' "$POCKETSHELL_EXPECTED_TEST_APK_SHA256"
+    printf -- '- Every walkthrough/visual-audit stage below installs THESE bytes (BUILD_APKS=0) and re-verifies the digest before installing.\n'
+  } >> "$SUMMARY_PATH"
+}
+
 publish_validated_apk() {
-  [[ -f "$PRE_RELEASE_GATE_APK" ]] ||
-    fail "validated debug APK was not created by the pre-release gate at $PRE_RELEASE_GATE_APK"
-  cp "$PRE_RELEASE_GATE_APK" "$VALIDATED_APK"
+  # Issue #2064: ship the RECORDED file, not a second hardcoded guess at where
+  # the gate put it. `$PRE_RELEASE_GATE_APK` and the gate's `app_apk` record
+  # were two independent derivations of the same path — if they ever diverged
+  # (a variant/output-dir change, a suffixed applicationId, a relocated
+  # worktree) the chain would validate one binary and publish another, with
+  # nothing to notice. `$APP_APK` comes from the identity record and has already
+  # been digest-verified by export_validated_apk_identity.
+  local source_apk="${APP_APK:-$PRE_RELEASE_GATE_APK}"
+  [[ -f "$source_apk" ]] ||
+    fail "validated debug APK was not created by the pre-release gate at $source_apk"
+  cp "$source_apk" "$VALIDATED_APK"
+  # Issue #2064: the published artifact must be provably the validated one.
+  pocketshell_assert_apk_identity "release publish" "$VALIDATED_APK" \
+    "${POCKETSHELL_EXPECTED_APP_APK_SHA256:-}" ||
+    fail "the published debug APK does not match the sha256 the pre-release gate validated (issue #2064)"
   record_artifact "tested debug APK" "build/release-emulator-validation/$RUN_ID/app-debug.apk"
+  printf -- '- published APK sha256: `%s`\n' "$POCKETSHELL_EXPECTED_APP_APK_SHA256" >> "$SUMMARY_PATH"
 }
 
 real_agent_release_gate_instrumentation_log_has_success() {
@@ -624,6 +706,38 @@ run_long_running_session_instrumentation() {
   return 0
 }
 
+# Issue #2064: the device-free end-to-end proof of the APK identity chain.
+# Runs the REAL export, the REAL publish assertion, and then the REAL
+# `--verify-apk-identity` mode of every downstream stage as child processes,
+# exactly as the release flow launches them — so the test exercises production
+# wiring rather than a re-spelling of it. No emulator, no Docker, no Gradle.
+if [[ "${1:-}" == "--verify-apk-identity" ]]; then
+  write_summary_header
+  export_validated_apk_identity
+  for stage_script in \
+    scripts/terminal-workbench.sh \
+    scripts/phone-walkthrough.sh \
+    scripts/capture-walkthrough-screenshots.sh \
+    scripts/parallel-setup-detection.sh; do
+    printf '\n[%s --verify-apk-identity]\n' "$stage_script"
+    "$ROOT_DIR/$stage_script" --verify-apk-identity ||
+      fail "$stage_script rejected the validated APK pair"
+  done
+  # Test-only boundary seam: prove the publish-time assertion catches a file
+  # replaced after every install stage has passed. It is intentionally limited
+  # to this device-free verification mode.
+  if [[ -n "${POCKETSHELL_APK_IDENTITY_POST_STAGE_HOOK:-}" ]]; then
+    [[ -x "$POCKETSHELL_APK_IDENTITY_POST_STAGE_HOOK" ]] ||
+      fail "APK identity post-stage proof hook is not executable: $POCKETSHELL_APK_IDENTITY_POST_STAGE_HOOK"
+    "$POCKETSHELL_APK_IDENTITY_POST_STAGE_HOOK" "$APP_APK" "$TEST_APK" ||
+      fail "APK identity post-stage proof hook failed"
+  fi
+  publish_validated_apk
+  printf '\nPASS: release APK identity chain verified (issue #2064)\n'
+  printf 'Summary: %s\n' "$SUMMARY_PATH"
+  exit 0
+fi
+
 require_clean_pushed_main
 write_summary_header
 
@@ -665,6 +779,16 @@ run_required \
   "pre-release confidence gate" \
   "build/pre-release-confidence-gate/$PRE_RELEASE_RUN_ID/" \
   env LOG_ROOT="$PRE_RELEASE_GATE_LOG_ROOT" RUN_ID="$PRE_RELEASE_RUN_ID" PRE_RELEASE_MANAGE_EMULATOR=1 scripts/pre-release-confidence-gate.sh
+
+# Issue #2064: from here on, every stage installs the pair the gate just built
+# and validated. Before this, terminal-lab / tmux-existing-session /
+# setup-detection / visual-audit each wiped app/build and rebuilt their own
+# byte-different pair (472s in run 20260809-v0442-r3, 603s in 20260808-165533),
+# so the journey evidence the tag rests on was produced against a binary nothing
+# else in the chain validated and that publish_validated_apk does not ship. The
+# rebuild inside terminal-lab is also what OOM-killed release attempt r1, 58
+# minutes in.
+export_validated_apk_identity
 
 if [[ "$TERMINAL_RELEASE_GATE" == "1" ]]; then
   run_required \
@@ -734,6 +858,7 @@ run_required \
   env RUN_ID="$RUN_ID-visual-audit" scripts/capture-walkthrough-screenshots.sh
 
 publish_validated_apk
+write_stage_timings
 
 {
   printf '\n## Release Notes Checklist\n\n'

--- a/scripts/reuse-ci-unit-evidence.sh
+++ b/scripts/reuse-ci-unit-evidence.sh
@@ -1,0 +1,631 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# SHA-matched reuse of the required CI `Unit tests` evidence (issue #2064)
+#
+# WHY THIS IS A RIGOUR INCREASE, NOT A REDUCTION
+# ----------------------------------------------
+# The pre-release confidence gate's `[gradle-compile-unit]` step ran
+# `assembleDebug check -x lint -x lintDebug`. Task extraction from the v0.4.42
+# r3 console shows `check` contains no custom guard tasks in this repo: it is
+# exactly `assembleDebug` plus the complete Gradle `test` graph. Measured, that
+# step was 1083s of a 2516s release chain, and 890s of it (82%) was unit-test
+# compile + execution —
+# 12,362 tests re-run against source that the required `Unit tests` check had
+# ALREADY tested green on the very same commit.
+#
+# And CI's run is STRICTER than the local one. `.github/workflows/tests.yml`'s
+# `unit` job runs the whole test graph with `--rerun-tasks --no-build-cache`,
+# then the #1646 executed-count guard with a freshness marker and the console
+# scan — the per-task floors, the UP-TO-DATE rule and the FROM-CACHE defence.
+# The local `check` applies none of those. So consuming the CI result GAINS the
+# release those guards.
+#
+# The saving is real only because the duplication was real. Nothing that gates
+# the tag stops running: the emulator/Docker journeys, the migration, the
+# old-CLI fixture, the walkthroughs and the visual audit are untouched.
+#
+# FAIL CLOSED — A MISSING CI RESULT IS NEVER A PASS
+# -------------------------------------------------
+# Exit 0 means "accepted, the gate may skip its local `check`". ANY other exit
+# means "declined" and the caller MUST run the tests locally. Every one of the
+# following declines:
+#
+#   * RELEASE_GATE_REUSE_CI_UNIT=0 (the explicit opt-out);
+#   * the source checkout is dirty, INCLUDING untracked files — the gate rsyncs
+#     the working TREE, so a dirty tree is not the commit;
+#   * HEAD != origin/main after a fetch, or != the requested --sha;
+#   * no check run named exactly `Unit tests` for that exact commit SHA;
+#   * that check run is not `completed` + `success`, or its head_sha differs;
+#   * the workflow run's head_sha differs, or the `JVM unit tests` job is not
+#     success (that job is where the tests, the forced-execution wiring guard,
+#     the freshness marker and the FROM-CACHE console scan all run — so a
+#     weakened or vacuous Unit run cannot conclude success);
+#   * the `unit-test-reports` artifact will not download, or is empty;
+#   * the DOWNLOADED result XML does not independently satisfy the
+#     executed-test-count coverage + per-task floors, re-checked here.
+#
+# A branch match, a "latest run" match, or a green-looking label with no
+# downloadable counts behind it is never accepted. The last bullet is the
+# load-bearing one: the reused artefact must satisfy the floors ITSELF, not
+# merely be tagged green.
+#
+# Usage:
+#   scripts/reuse-ci-unit-evidence.sh --source-root DIR --tree-root DIR \
+#                                     --out-dir DIR [--sha SHA]
+#
+#   --source-root  the real git checkout (has .git); cleanliness + SHA come
+#                  from here.
+#   --tree-root    the tree whose settings.gradle.kts / modules / floors /
+#                  workflow define the expectations (the gate's isolated
+#                  worktree copy). Defaults to --source-root.
+#   --out-dir      where the downloaded artifact and evidence.txt are written.
+#   --sha          require this exact commit (defaults to the source HEAD).
+#
+# Injection points (test-only): POCKETSHELL_CI_EVIDENCE_GH overrides the `gh`
+# command; POCKETSHELL_CI_EVIDENCE_REPO overrides the owner/name slug.
+# ---------------------------------------------------------------------------
+
+GH_CMD="${POCKETSHELL_CI_EVIDENCE_GH:-gh}"
+REQUIRED_CHECK_NAME="Unit tests"
+readonly -a REQUIRED_JOB_NAMES=(
+  "JVM unit tests (Debug)"
+  "JVM unit tests (Release)"
+)
+readonly -a ARTIFACT_NAMES=(
+  "unit-test-reports-Debug"
+  "unit-test-reports-Release"
+)
+
+decline() {
+  printf 'DECLINE: %s\n' "$1" >&2
+  printf 'DECLINE: the pre-release gate must run the unit suite locally.\n' >&2
+  return 1
+}
+
+note() {
+  printf '%s\n' "$1"
+}
+
+# Owner/name slug. Explicit override wins; otherwise parse the `origin` remote.
+# A remote this parser cannot recognise as GitHub yields nothing, and the caller
+# declines — it does not guess.
+pocketshell_ci_evidence_repo_slug_from_url() {
+  local url="$1"
+  local slug=""
+  case "$url" in
+    git@github.com:*) slug="${url#git@github.com:}" ;;
+    ssh://git@github.com/*) slug="${url#ssh://git@github.com/}" ;;
+    https://github.com/*) slug="${url#https://github.com/}" ;;
+    http://github.com/*) slug="${url#http://github.com/}" ;;
+    *) return 1 ;;
+  esac
+  slug="${slug%.git}"
+  slug="${slug%/}"
+  # Exactly owner/name, nothing deeper.
+  case "$slug" in
+    */*/*) return 1 ;;
+    */*) printf '%s' "$slug" ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# JSON projection. `gh api` emits raw JSON here on purpose: the projection runs
+# in THIS script, so the test's stub `gh` (which only replays a captured API
+# body) still exercises the real parsing rather than a re-spelling of it.
+# ---------------------------------------------------------------------------
+pocketshell_ci_evidence_project() {
+  local mode="$1"
+  local json_file="$2"
+  local wanted="${3:-}"
+  python3 - "$mode" "$json_file" "$wanted" <<'PYTHON'
+import json
+import sys
+
+mode, path, wanted = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+except (OSError, ValueError) as error:
+    sys.stderr.write(f"unreadable JSON from the GitHub API ({path}): {error}\n")
+    raise SystemExit(2)
+
+if mode == "check-runs":
+    runs = payload.get("check_runs")
+    if not isinstance(runs, list):
+        sys.stderr.write("check-runs payload has no check_runs array\n")
+        raise SystemExit(2)
+    matches = [run for run in runs if run.get("name") == wanted]
+    if len(matches) != 1:
+        sys.stderr.write(
+            f"expected exactly one check run named {wanted!r}, found {len(matches)}\n"
+        )
+        raise SystemExit(2)
+    run = matches[0]
+    print(run.get("status", ""))
+    print(run.get("conclusion", ""))
+    print(run.get("head_sha", ""))
+    print(run.get("details_url", ""))
+elif mode == "workflow-run":
+    print(payload.get("head_sha", ""))
+    print(payload.get("status", ""))
+    print(payload.get("conclusion", ""))
+    print(payload.get("html_url", ""))
+elif mode == "jobs":
+    jobs = payload.get("jobs")
+    if not isinstance(jobs, list):
+        sys.stderr.write("jobs payload has no jobs array\n")
+        raise SystemExit(2)
+    matches = [job for job in jobs if job.get("name") == wanted]
+    if len(matches) != 1:
+        sys.stderr.write(
+            f"expected exactly one job named {wanted!r}, found {len(matches)}\n"
+        )
+        raise SystemExit(2)
+    job = matches[0]
+    print(job.get("status", ""))
+    print(job.get("conclusion", ""))
+    print(job.get("completed_at", ""))
+else:
+    sys.stderr.write(f"unknown projection mode {mode!r}\n")
+    raise SystemExit(2)
+PYTHON
+}
+
+# `.../actions/runs/<id>/job/<job-id>` -> `<id>`; anything else fails.
+pocketshell_ci_evidence_run_id_from_details_url() {
+  local url="$1"
+  local tail="${url#*/actions/runs/}"
+  [[ "$tail" != "$url" ]] || return 1
+  local run_id="${tail%%/*}"
+  [[ "$run_id" =~ ^[0-9]+$ ]] || return 1
+  printf '%s' "$run_id"
+}
+
+# Pin the rendered #2069 two-shard contract at the release commit. Runtime API
+# checks below independently require both rendered job names and both artifact
+# names; this local check makes a workflow rename fail with a direct diagnostic
+# instead of looking like missing historical evidence.
+pocketshell_ci_evidence_assert_workflow_contract() {
+  local workflow="$1"
+  [[ -f "$workflow" ]] || {
+    printf 'workflow is missing: %s\n' "$workflow" >&2
+    return 1
+  }
+  grep -qF '    name: JVM unit tests' "$workflow" || {
+    printf 'workflow no longer declares the JVM unit job base name\n' >&2
+    return 1
+  }
+  grep -qF '        variant: [Debug, Release]' "$workflow" || {
+    printf 'workflow no longer declares the exact Debug/Release unit matrix\n' >&2
+    return 1
+  }
+  # shellcheck disable=SC2016 # literal GitHub expression, not a shell expansion
+  grep -qF '          name: unit-test-reports-${{ matrix.variant }}' "$workflow" || {
+    printf 'workflow no longer publishes the expected per-variant unit artifacts\n' >&2
+    return 1
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Verification root: deciding whether the DOWNLOADED result XML is a real run
+# needs a tree that carries BOTH the module structure (settings, build files,
+# src/test) and the results. The CI artifact carries only the results, so
+# assemble a private root from the release tree's structural files plus the
+# downloaded results. Nothing is written into the release tree itself.
+#
+# WHY THE COUNT CHECK IS RE-IMPLEMENTED HERE and not delegated to the sibling
+# guard: `scripts/check-release-gate-execution-profile.sh` (issue #2054) walks
+# the closure of every script the release chain invokes and REJECTS any of them
+# that is not itself in RELEASE_CHAIN_SCRIPTS or that its bash block scanner
+# cannot model. Shelling out to the sibling guards from this chain-reachable
+# script therefore fails that guard, and the "remedy" it names — adding a static
+# guard to RELEASE_CHAIN_SCRIPTS — would force a pure text checker to apply a
+# 24 GiB build-scope ceiling it has no business applying. Neither weakening that
+# guard nor splitting the path string to slip past it is acceptable, so the rule
+# is applied here directly, over the SAME floors manifest and the SAME derivation
+# (a module with test sources under src/test must produce results for every
+# expected variant task, at or above its declared floor; a module with no test
+# sources is legitimately exempt).
+#
+# The duplication is pinned rather than trusted:
+# `scripts/test-reuse-ci-unit-evidence.sh` runs BOTH this implementation and
+# `scripts/check-executed-test-counts.sh --root` over the same synthetic roots
+# and requires identical verdicts, so the two cannot drift apart silently. That
+# test script is deliberately NOT reachable from the release chain, which is why
+# it may reference the sibling guard.
+# ---------------------------------------------------------------------------
+pocketshell_ci_evidence_modules() {
+  local tree_root="$1"
+  local settings="$tree_root/settings.gradle.kts"
+  [[ -f "$settings" ]] || return 1
+  grep -oE '^[[:space:]]*include\("[^"]+"\)' "$settings" |
+    sed -E 's/.*include\("//; s/"\)//' |
+    sed -E 's/^://; s/:/\//g'
+}
+
+pocketshell_ci_evidence_build_verify_root() {
+  local tree_root="$1"
+  local artifact_dir="$2"
+  local verify_root="$3"
+
+  mkdir -p "$verify_root/scripts"
+  cp "$tree_root/settings.gradle.kts" "$verify_root/settings.gradle.kts" || return 1
+  if [[ -f "$tree_root/scripts/executed-test-count-floors.txt" ]]; then
+    cp "$tree_root/scripts/executed-test-count-floors.txt" "$verify_root/scripts/" || return 1
+  fi
+
+  local module
+  while IFS= read -r module; do
+    [[ -n "$module" ]] || continue
+    [[ -d "$tree_root/$module" ]] || continue
+    mkdir -p "$verify_root/$module"
+    if [[ -f "$tree_root/$module/build.gradle.kts" ]]; then
+      cp "$tree_root/$module/build.gradle.kts" "$verify_root/$module/build.gradle.kts" || return 1
+    fi
+    if [[ -d "$tree_root/$module/src/test" ]]; then
+      mkdir -p "$verify_root/$module/src"
+      cp -a "$tree_root/$module/src/test" "$verify_root/$module/src/test" || return 1
+    fi
+    # Locate this module's downloaded results wherever upload-artifact rooted
+    # them. A module with no results simply gets none, and the count guard then
+    # reports MISSING -> decline. Fail closed by omission, never by assumption.
+    local found
+    while IFS= read -r found; do
+      [[ -n "$found" ]] || continue
+      mkdir -p "$verify_root/$module/build/test-results"
+      # Debug and Release are separate #2069 artifacts. Merge their disjoint
+      # task directories into one private verification root before applying the
+      # unchanged complete-graph floors.
+      cp -a "$found/." "$verify_root/$module/build/test-results/" || return 1
+    done < <(find "$artifact_dir" -type d -path "*$module/build/test-results" -print 2>/dev/null | sort)
+  done < <(pocketshell_ci_evidence_modules "$tree_root")
+}
+
+# pocketshell_ci_evidence_check_counts <verify-root>
+#
+# executed = tests - skipped, summed per task result directory. Every module
+# with test sources must produce results for every expected variant task, at or
+# above its floor (default 1). Prints a per-task table; non-zero on any
+# violation. The freshness (`--newer-than`) and console (`--gradle-log`) halves
+# of the #1646 guard are deliberately absent here because they are meaningless
+# for a downloaded artifact — and they were already applied, in the CI job whose
+# success is a precondition for even reaching this point.
+pocketshell_ci_evidence_check_counts() {
+  local verify_root="$1"
+  python3 - "$verify_root" <<'PYTHON'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+settings = root / "settings.gradle.kts"
+if not settings.is_file():
+    sys.stderr.write(f"no settings.gradle.kts under {root}\n")
+    raise SystemExit(1)
+
+modules = [
+    match.replace(":", "/").lstrip("/")
+    for match in re.findall(r'^\s*include\("([^"]+)"\)', settings.read_text(), re.M)
+]
+if not modules:
+    sys.stderr.write("no Gradle modules discovered\n")
+    raise SystemExit(1)
+
+floors = {}
+floors_file = root / "scripts" / "executed-test-count-floors.txt"
+if floors_file.is_file():
+    for line in floors_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[1].isdigit():
+            floors[parts[0]] = int(parts[1])
+
+ANDROID = re.compile(r"plugins\.android\.(application|library)|com\.android\.(application|library)")
+
+violations = []
+rows = []
+total = 0
+checked = 0
+
+for module in modules:
+    module_dir = root / module
+    if not module_dir.is_dir():
+        continue
+    prefix = ":" + module.replace("/", ":")
+    test_src = module_dir / "src" / "test"
+    has_sources = test_src.is_dir() and any(
+        path.suffix in (".kt", ".java") for path in test_src.rglob("*") if path.is_file()
+    )
+    build_file = module_dir / "build.gradle.kts"
+    android = build_file.is_file() and bool(ANDROID.search(build_file.read_text()))
+    tasks = ["testDebugUnitTest", "testReleaseUnitTest"] if android else ["test"]
+
+    for task in tasks:
+        task_path = f"{prefix}:{task}"
+        declared = floors.get(task_path)
+        if not has_sources and declared is None:
+            # Legitimately test-free (e.g. a testImplementation-only support
+            # module). Derived from the absence of sources, not allowlisted.
+            continue
+        floor = declared if declared is not None else 1
+        checked += 1
+        if not has_sources:
+            violations.append(
+                f"{task_path} is declared in the floors manifest but the module has no "
+                f"test sources; a declared task is never granted the test-free exemption"
+            )
+            rows.append((task_path, "-", "SOURCES GONE"))
+            continue
+        results = module_dir / "build" / "test-results" / task
+        if not results.is_dir():
+            violations.append(
+                f"{task_path} produced NO result XML in the reused CI artifact — the task "
+                f"did not run in that job, so the artifact does not cover this release"
+            )
+            rows.append((task_path, "-", "MISSING"))
+            continue
+        executed = 0
+        for xml in results.glob("TEST-*.xml"):
+            match = re.search(r"<testsuite [^>]*>", xml.read_text(errors="replace"))
+            if not match:
+                continue
+            head = match.group(0)
+            tests = re.search(r'tests="(\d+)"', head)
+            skipped = re.search(r'skipped="(\d+)"', head)
+            executed += int(tests.group(1) if tests else 0) - int(
+                skipped.group(1) if skipped else 0
+            )
+        total += executed
+        if executed < floor:
+            violations.append(
+                f"{task_path} executed {executed} tests in the reused CI artifact, below its "
+                f"floor of {floor}. A green label over zero executed tests is not evidence (G3)."
+            )
+            rows.append((task_path, executed, f"BELOW FLOOR (min {floor})"))
+            continue
+        rows.append((task_path, executed, "ok"))
+
+print("Executed test counts in the reused CI artifact (executed = tests - skipped)")
+print()
+print(f"  {'TASK':<46}{'EXECUTED':>10}  STATUS")
+for task_path, executed, status in rows:
+    print(f"  {task_path:<46}{str(executed):>10}  {status}")
+print()
+print(f"  tasks checked: {checked}   total executed: {total}")
+
+if checked == 0:
+    sys.stderr.write(
+        "no test task was checked at all; an artifact that constrains nothing is not evidence\n"
+    )
+    raise SystemExit(1)
+if violations:
+    sys.stderr.write("\n")
+    for violation in violations:
+        sys.stderr.write(f"FAIL: {violation}\n")
+    raise SystemExit(1)
+PYTHON
+}
+
+# ---------------------------------------------------------------------------
+# The acceptor.
+# ---------------------------------------------------------------------------
+pocketshell_reuse_ci_unit_evidence() {
+  local source_root="$1"
+  local tree_root="$2"
+  local out_dir="$3"
+  local requested_sha="$4"
+
+  if [[ "${RELEASE_GATE_REUSE_CI_UNIT:-1}" == "0" ]]; then
+    decline "RELEASE_GATE_REUSE_CI_UNIT=0 — SHA-matched CI unit reuse is switched off"
+    return 1
+  fi
+
+  command -v python3 >/dev/null 2>&1 ||
+    { decline "python3 is required to parse the GitHub API responses"; return 1; }
+  command -v "$GH_CMD" >/dev/null 2>&1 || [[ -x "$GH_CMD" ]] ||
+    { decline "the GitHub CLI ($GH_CMD) is not available"; return 1; }
+
+  mkdir -p "$out_dir"
+
+  # ---- 1. the tree must BE the commit -------------------------------------
+  local status_output
+  status_output="$(git -C "$source_root" status --porcelain 2>/dev/null)" ||
+    { decline "$source_root is not a git checkout"; return 1; }
+  if [[ -n "$status_output" ]]; then
+    decline "the release checkout is dirty (the gate rsyncs the working TREE, so a dirty tree is NOT the commit CI tested):
+$status_output"
+    return 1
+  fi
+
+  local head_sha
+  head_sha="$(git -C "$source_root" rev-parse HEAD 2>/dev/null)" ||
+    { decline "could not read HEAD from $source_root"; return 1; }
+  if [[ -n "$requested_sha" && "$requested_sha" != "$head_sha" ]]; then
+    decline "requested SHA $requested_sha does not match HEAD $head_sha"
+    return 1
+  fi
+
+  git -C "$source_root" fetch --quiet origin main 2>/dev/null ||
+    { decline "could not fetch origin/main to confirm the release commit is pushed"; return 1; }
+  local origin_sha
+  origin_sha="$(git -C "$source_root" rev-parse origin/main 2>/dev/null)" ||
+    { decline "could not resolve origin/main"; return 1; }
+  if [[ "$head_sha" != "$origin_sha" ]]; then
+    decline "HEAD ($head_sha) is not origin/main ($origin_sha); CI evidence is only reusable for a pushed release commit"
+    return 1
+  fi
+
+  pocketshell_ci_evidence_assert_workflow_contract "$source_root/.github/workflows/tests.yml" ||
+    { decline "the release commit's unit workflow no longer matches the pinned #2069 Debug/Release jobs and artifacts"; return 1; }
+
+  # ---- 2. the slug ---------------------------------------------------------
+  #
+  # (There is deliberately no local re-run of the CI Unit forced-execution
+  # wiring guard here. That guard runs as a STEP of the `unit` job — together
+  # with its own self-test — and this acceptor requires that job to have
+  # concluded `success`. A weakened Unit command therefore cannot produce a
+  # green `Unit tests` check in the first place, so re-deriving the same
+  # conclusion locally would add no constraint. It would, however, drag a
+  # Python-implemented guard into the release chain's script closure, which
+  # scripts/check-release-gate-execution-profile.sh correctly rejects.)
+  local slug="${POCKETSHELL_CI_EVIDENCE_REPO:-}"
+  if [[ -z "$slug" ]]; then
+    local origin_url
+    origin_url="$(git -C "$source_root" remote get-url origin 2>/dev/null)" || origin_url=""
+    slug="$(pocketshell_ci_evidence_repo_slug_from_url "$origin_url")" || slug=""
+  fi
+  if [[ -z "$slug" ]]; then
+    decline "could not determine the GitHub owner/name for $source_root"
+    return 1
+  fi
+
+  # ---- 4. an exact-SHA, green, required `Unit tests` check run -------------
+  local check_json="$out_dir/check-runs.json"
+  "$GH_CMD" api "repos/$slug/commits/$head_sha/check-runs?per_page=100" \
+    > "$check_json" 2> "$out_dir/check-runs.err" ||
+    { decline "could not read check runs for $head_sha; see $out_dir/check-runs.err"; return 1; }
+
+  local projected
+  projected="$(pocketshell_ci_evidence_project check-runs "$check_json" "$REQUIRED_CHECK_NAME" 2> "$out_dir/check-runs-parse.err")" ||
+    { decline "no single '$REQUIRED_CHECK_NAME' check run for $head_sha: $(cat "$out_dir/check-runs-parse.err")"; return 1; }
+
+  local check_status check_conclusion check_head_sha details_url
+  { read -r check_status; read -r check_conclusion; read -r check_head_sha; read -r details_url; } <<< "$projected"
+
+  [[ "$check_status" == "completed" ]] ||
+    { decline "'$REQUIRED_CHECK_NAME' for $head_sha is '$check_status', not completed"; return 1; }
+  [[ "$check_conclusion" == "success" ]] ||
+    { decline "'$REQUIRED_CHECK_NAME' for $head_sha concluded '$check_conclusion', not success"; return 1; }
+  [[ "$check_head_sha" == "$head_sha" ]] ||
+    { decline "'$REQUIRED_CHECK_NAME' reports head_sha $check_head_sha, not the release commit $head_sha"; return 1; }
+
+  local run_id
+  run_id="$(pocketshell_ci_evidence_run_id_from_details_url "$details_url")" ||
+    { decline "could not derive a workflow run id from details_url '$details_url'"; return 1; }
+
+  # ---- 5. the workflow run + the job that actually ran the tests -----------
+  local run_json="$out_dir/workflow-run.json"
+  "$GH_CMD" api "repos/$slug/actions/runs/$run_id" \
+    > "$run_json" 2> "$out_dir/workflow-run.err" ||
+    { decline "could not read workflow run $run_id; see $out_dir/workflow-run.err"; return 1; }
+
+  projected="$(pocketshell_ci_evidence_project workflow-run "$run_json" 2> "$out_dir/workflow-run-parse.err")" ||
+    { decline "unreadable workflow run $run_id: $(cat "$out_dir/workflow-run-parse.err")"; return 1; }
+  local run_head_sha run_status run_conclusion run_url
+  { read -r run_head_sha; read -r run_status; read -r run_conclusion; read -r run_url; } <<< "$projected"
+
+  [[ "$run_head_sha" == "$head_sha" ]] ||
+    { decline "workflow run $run_id tested $run_head_sha, not the release commit $head_sha"; return 1; }
+  [[ "$run_status" == "completed" ]] ||
+    { decline "workflow run $run_id is '$run_status', not completed"; return 1; }
+  [[ "$run_conclusion" == "success" ]] ||
+    { decline "workflow run $run_id concluded '$run_conclusion', not success"; return 1; }
+
+  local jobs_json="$out_dir/workflow-jobs.json"
+  "$GH_CMD" api "repos/$slug/actions/runs/$run_id/jobs?per_page=100" \
+    > "$jobs_json" 2> "$out_dir/workflow-jobs.err" ||
+    { decline "could not read the jobs of workflow run $run_id; see $out_dir/workflow-jobs.err"; return 1; }
+
+  local -a job_evidence=()
+  local required_job job_status job_conclusion job_completed_at
+  for required_job in "${REQUIRED_JOB_NAMES[@]}"; do
+    projected="$(pocketshell_ci_evidence_project jobs "$jobs_json" "$required_job" 2> "$out_dir/workflow-jobs-parse.err")" ||
+      { decline "no single '$required_job' job in run $run_id: $(cat "$out_dir/workflow-jobs-parse.err")"; return 1; }
+    { read -r job_status; read -r job_conclusion; read -r job_completed_at; } <<< "$projected"
+
+    [[ "$job_status" == "completed" ]] ||
+      { decline "'$required_job' in run $run_id is '$job_status', not completed"; return 1; }
+    [[ "$job_conclusion" == "success" ]] ||
+      { decline "'$required_job' in run $run_id concluded '$job_conclusion', not success"; return 1; }
+    job_evidence+=("$required_job|$job_status|$job_conclusion|$job_completed_at")
+  done
+
+  # ---- 6. download and INDEPENDENTLY re-check the counts -------------------
+  local artifact_dir="$out_dir/artifacts"
+  rm -rf "$artifact_dir"
+  mkdir -p "$artifact_dir"
+  local artifact_name artifact_variant_dir
+  for artifact_name in "${ARTIFACT_NAMES[@]}"; do
+    artifact_variant_dir="$artifact_dir/$artifact_name"
+    mkdir -p "$artifact_variant_dir"
+    "$GH_CMD" run download "$run_id" --repo "$slug" --name "$artifact_name" --dir "$artifact_variant_dir" \
+      >> "$out_dir/artifact-download.log" 2>&1 ||
+      { decline "could not download the '$artifact_name' artifact from run $run_id; see $out_dir/artifact-download.log"; return 1; }
+    if [[ -z "$(find "$artifact_variant_dir" -name 'TEST-*.xml' -type f -print -quit 2>/dev/null)" ]]; then
+      decline "the '$artifact_name' artifact from run $run_id contains no TEST-*.xml result files"
+      return 1
+    fi
+  done
+
+  local verify_root="$out_dir/verify-root"
+  rm -rf "$verify_root"
+  pocketshell_ci_evidence_build_verify_root "$tree_root" "$artifact_dir" "$verify_root" ||
+    { decline "could not assemble the verification root from $tree_root + the downloaded artifact"; return 1; }
+
+  pocketshell_ci_evidence_check_counts "$verify_root" > "$out_dir/executed-test-counts.log" 2>&1 ||
+    { decline "the DOWNLOADED CI result XML does not satisfy the executed-test-count floors; see $out_dir/executed-test-counts.log"; return 1; }
+
+  # ---- 7. record the provenance -------------------------------------------
+  {
+    printf 'PocketShell reused CI unit evidence (issue #2064)\n'
+    printf 'Accepted at: %s\n' "$(date -Is)"
+    printf 'Commit SHA: %s\n' "$head_sha"
+    printf 'Repository: %s\n' "$slug"
+    printf 'Required check: %s (%s/%s)\n' "$REQUIRED_CHECK_NAME" "$check_status" "$check_conclusion"
+    printf 'Workflow run: %s\n' "$run_id"
+    printf 'Workflow run URL: %s\n' "$run_url"
+    local job_row
+    for job_row in "${job_evidence[@]}"; do
+      IFS='|' read -r required_job job_status job_conclusion job_completed_at <<< "$job_row"
+      printf 'Unit job: %s (%s/%s) completed_at=%s\n' \
+        "$required_job" "$job_status" "$job_conclusion" "$job_completed_at"
+    done
+    printf 'Artifacts: %s, %s under %s\n' \
+      "${ARTIFACT_NAMES[0]}" "${ARTIFACT_NAMES[1]}" "$artifact_dir"
+    printf '\nIndependently re-checked executed test counts:\n'
+    cat "$out_dir/executed-test-counts.log"
+  } > "$out_dir/evidence.txt"
+
+  cat "$out_dir/evidence.txt"
+  note "ACCEPT: reusing the '$REQUIRED_CHECK_NAME' evidence from run $run_id for $head_sha"
+}
+
+usage() {
+  sed -n '/^# Usage:/,/^# ----/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' | sed '$d'
+}
+
+main() {
+  local source_root=""
+  local tree_root=""
+  local out_dir=""
+  local sha=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --help|-h) usage; return 0 ;;
+      --source-root) source_root="$2"; shift 2 ;;
+      --tree-root) tree_root="$2"; shift 2 ;;
+      --out-dir) out_dir="$2"; shift 2 ;;
+      --sha) sha="$2"; shift 2 ;;
+      *) printf 'FAIL: unknown argument %s\n' "$1" >&2; usage >&2; return 2 ;;
+    esac
+  done
+
+  [[ -n "$source_root" ]] || { printf 'FAIL: --source-root is required\n' >&2; return 2; }
+  [[ -n "$out_dir" ]] || { printf 'FAIL: --out-dir is required\n' >&2; return 2; }
+  [[ -n "$tree_root" ]] || tree_root="$source_root"
+
+  pocketshell_reuse_ci_unit_evidence "$source_root" "$tree_root" "$out_dir" "$sha"
+}
+
+# POCKETSHELL_CI_EVIDENCE_LIB_ONLY lets scripts/test-reuse-ci-unit-evidence.sh
+# source this file to exercise its pure helpers directly. Every acceptance /
+# decline case in that test still runs this script as a real child process.
+if [[ -z "${POCKETSHELL_CI_EVIDENCE_LIB_ONLY:-}" ]]; then
+  main "$@"
+fi

--- a/scripts/terminal-workbench.sh
+++ b/scripts/terminal-workbench.sh
@@ -20,6 +20,9 @@ fi
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
+# Issue #2064: when this workbench is a child of release validation it must
+# install the gate-recorded pair, not stale APKs from the root checkout.
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
 
 # Issue #2054: the optional terminal release gate (TERMINAL_RELEASE_GATE=1) runs
 # this workbench inside the release validation, and its `04-build-apks` step is
@@ -51,14 +54,16 @@ fi
 DEFAULT_LOG_ROOT="$(realpath -m "$DEFAULT_LOG_ROOT")"
 RELEASE_GATE_LOG_ROOT="$(realpath -m "$ROOT_DIR/build/release-terminal-gate")"
 LOG_ROOT="$(realpath -m "$LOG_ROOT")"
-case "$LOG_ROOT" in
-  "$DEFAULT_LOG_ROOT"|"$DEFAULT_LOG_ROOT"/*) ;;
-  "$RELEASE_GATE_LOG_ROOT"/*/workbench|"$RELEASE_GATE_LOG_ROOT"/*/workbench/*) ;;
-  *)
-    printf 'FAIL: LOG_ROOT must stay under %s or a release terminal gate workbench dir: %s\n' "$DEFAULT_LOG_ROOT" "$LOG_ROOT" >&2
-    exit 1
-    ;;
-esac
+if [[ "${1:-}" != "--verify-apk-identity" ]]; then
+  case "$LOG_ROOT" in
+    "$DEFAULT_LOG_ROOT"|"$DEFAULT_LOG_ROOT"/*) ;;
+    "$RELEASE_GATE_LOG_ROOT"/*/workbench|"$RELEASE_GATE_LOG_ROOT"/*/workbench/*) ;;
+    *)
+      printf 'FAIL: LOG_ROOT must stay under %s or a release terminal gate workbench dir: %s\n' "$DEFAULT_LOG_ROOT" "$LOG_ROOT" >&2
+      exit 1
+      ;;
+  esac
+fi
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 [[ "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]] || {
   printf 'FAIL: RUN_ID contains unsafe characters: %s\n' "$RUN_ID" >&2
@@ -119,8 +124,8 @@ if [[ "$REAL_AGENTS" == "1" && "$TEST_SELECTOR_WAS_SET" != "1" ]]; then
   TEST_SELECTOR="com.pocketshell.app.terminal.TerminalLabDockerTest#terminalWorkbenchCapturesRealAgentCliScreens"
 fi
 REAL_AGENT_TEST_SELECTOR="com.pocketshell.app.terminal.TerminalLabDockerTest#terminalWorkbenchCapturesRealAgentCliScreens"
-APP_APK="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
-TEST_APK="$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+APP_APK="${APP_APK:-$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk}"
+TEST_APK="${TEST_APK:-$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk}"
 SSH_KEY="${SSH_KEY:-$ROOT_DIR/tests/docker/test_key}"
 SSH_HOST="${SSH_HOST:-127.0.0.1}"
 SSH_USER="${SSH_USER:-testuser}"
@@ -130,6 +135,22 @@ fail() {
   printf 'Artifacts: %s\n' "$RUN_DIR" >&2
   exit 1
 }
+
+# Device-free release-chain coverage. This deliberately exercises this script's
+# real path resolution + identity verifier and exits before adb/Docker use.
+if [[ "${1:-}" == "--verify-apk-identity" ]]; then
+  pocketshell_require_walkthrough_apk_identity "terminal workbench" ||
+    fail "terminal workbench rejected the release APK identity"
+  printf 'PASS: terminal-workbench APK identity verified (issue #2064)\n'
+  printf '  app  %s\n' "$APP_APK"
+  printf '  test %s\n' "$TEST_APK"
+  exit 0
+fi
+
+# Cheap early failure for a release child. Standalone workbench runs export no
+# expected hashes, so this remains a deliberate no-op for their normal build.
+pocketshell_verify_walkthrough_apks "terminal workbench (startup)" ||
+  fail "terminal workbench rejected the release APK identity before setup"
 
 extract_field() {
   local line="$1"
@@ -401,6 +422,10 @@ else
   [[ -f "$TEST_APK" ]] || fail "test APK missing at $TEST_APK"
 fi
 
+# Load-bearing install-site check: catches any rebuild/replacement after the
+# startup check and immediately before adb consumes the files.
+run_logged "04b-verify-apk-identity" \
+  pocketshell_verify_walkthrough_apks "terminal workbench (install)"
 run_logged "05-install-apks" bash -lc "'$ADB' install -r -d -t '$APP_APK' && '$ADB' install -r -d -t '$TEST_APK'"
 INSTRUMENTATION_ARGS=(
   -e additionalTestOutputDir "$DEVICE_OUTPUT_DIR"

--- a/scripts/test-release-apk-identity.sh
+++ b/scripts/test-release-apk-identity.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1003,SC2016,SC2030,SC2031
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Release APK identity contract (issue #2064)
+#
+# THE REPORTED DEFECT, REPRODUCED
+# -------------------------------
+# `scripts/pre-release-confidence-gate.sh` builds the debug + androidTest pair
+# inside its isolated worktree, validates THAT binary on the emulator, and
+# `publish_validated_apk` ships it. Every downstream stage then used to
+# `rm -rf app/build` and rebuild its own pair, so terminal-lab,
+# tmux-existing-session, setup-detection and the visual audit produced their
+# journey evidence against a DIFFERENT binary — one nothing else in the chain
+# validated and that is not the one shipped.
+#
+# Case `rebuilt_stage_binary_is_rejected` below is that exact scenario: the
+# gate records its pair, then the app APK on disk is replaced by a different
+# (still perfectly valid) build, and the chain is driven. Before the fix the
+# stage would install it without a murmur. Now the chain hard-fails, naming
+# both digests.
+#
+# WHAT IS ACTUALLY EXERCISED
+# --------------------------
+# Not a re-spelling of production. Case 5 onward invoke the REAL
+# `scripts/release-emulator-validation.sh --verify-apk-identity`, which runs the
+# REAL `export_validated_apk_identity`, the REAL `publish_validated_apk`
+# assertion, and then launches the REAL
+# `scripts/terminal-workbench.sh` / `scripts/phone-walkthrough.sh` /
+# `scripts/capture-walkthrough-screenshots.sh` /
+# `scripts/parallel-setup-detection.sh` as child processes with exactly the
+# environment the release flow gives them. No emulator, no Docker, no Gradle,
+# no network: a couple of seconds.
+#
+# THE MUTATION THAT MUST REDDEN EACH CHECK is named in every case label. A case
+# whose mutation cannot be stated is decorative, and this repo has paid for that
+# lesson repeatedly (the G6 "wrong-cost" catalogue in AGENTS.md).
+#
+# Usage: scripts/test-release-apk-identity.sh
+# ---------------------------------------------------------------------------
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+
+CHECKS=0
+SANDBOX=""
+
+cleanup() {
+  [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+trap cleanup EXIT
+
+pass_case() {
+  CHECKS=$((CHECKS + 1))
+  printf '  ok  %s\n' "$1"
+}
+
+fail_case() {
+  printf 'FAIL: %s\n' "$1" >&2
+  [[ -s "${CASE_LOG:-}" ]] && tail -n 30 "$CASE_LOG" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: a pre-release confidence-gate run directory holding a built pair and
+# the identity record the real gate writes with the real recorder.
+# ---------------------------------------------------------------------------
+make_fixture() {
+  local gate_run_dir="$1"
+  mkdir -p "$gate_run_dir/worktree/app/build/outputs/apk/debug"
+  mkdir -p "$gate_run_dir/worktree/app/build/outputs/apk/androidTest/debug"
+  APP_FIXTURE="$gate_run_dir/worktree/app/build/outputs/apk/debug/app-debug.apk"
+  TEST_FIXTURE="$gate_run_dir/worktree/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+  printf 'PK\x03\x04 pocketshell debug apk build A\n' > "$APP_FIXTURE"
+  printf 'PK\x03\x04 pocketshell androidTest apk build A\n' > "$TEST_FIXTURE"
+  pocketshell_record_apk_identity \
+    "$gate_run_dir/$POCKETSHELL_APK_IDENTITY_FILE_NAME" \
+    "$APP_FIXTURE" "$TEST_FIXTURE" >/dev/null
+}
+
+# Drive the REAL release chain in its device-free identity-verification mode.
+run_chain() {
+  local gate_log_root="$1"
+  local run_id="$2"
+  env -u POCKETSHELL_TEST_MEM \
+      -u APP_APK -u TEST_APK \
+      -u POCKETSHELL_EXPECTED_APP_APK_SHA256 -u POCKETSHELL_EXPECTED_TEST_APK_SHA256 \
+      -u BUILD_APKS -u PARALLEL_BUILD_APKS -u VISUAL_AUDIT_BUILD_APKS \
+      LOG_ROOT="$SANDBOX/release" \
+      PRE_RELEASE_GATE_LOG_ROOT="$gate_log_root" \
+      RUN_ID="$run_id" \
+      POCKETSHELL_AVD_LOCK_DIR="$SANDBOX/locks" \
+      bash "$ROOT_DIR/scripts/release-emulator-validation.sh" --verify-apk-identity
+}
+
+main() {
+  SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-apk-identity-test.XXXXXX")"
+  CASE_LOG="$SANDBOX/case.log"
+  printf 'release APK identity contract test (issue #2064)\n'
+
+  # -- 1. the recorder + asserter agree on an untouched file ----------------
+  # Mutation that reddens this: any change to the digest algorithm or to the
+  # identity-file field names.
+  local unit_dir="$SANDBOX/unit"
+  mkdir -p "$unit_dir"
+  printf 'binary A\n' > "$unit_dir/a.apk"
+  printf 'binary B\n' > "$unit_dir/b.apk"
+  pocketshell_record_apk_identity "$unit_dir/apk-identity.txt" \
+    "$unit_dir/a.apk" "$unit_dir/b.apk" > "$CASE_LOG" 2>&1 ||
+    fail_case "the recorder could not record two real files"
+  local recorded_app
+  recorded_app="$(pocketshell_read_apk_identity_field "$unit_dir/apk-identity.txt" app_apk_sha256)" ||
+    fail_case "app_apk_sha256 was not readable back out of the identity file"
+  pocketshell_assert_apk_identity "unit" "$unit_dir/a.apk" "$recorded_app" >/dev/null 2>&1 ||
+    fail_case "an untouched file failed its own recorded digest"
+  pass_case "recorded digest verifies against the untouched file"
+
+  # -- 2. a one-byte change reddens it --------------------------------------
+  printf 'binary A tampered\n' > "$unit_dir/a.apk"
+  if pocketshell_assert_apk_identity "unit" "$unit_dir/a.apk" "$recorded_app" >"$CASE_LOG" 2>&1; then
+    fail_case "a changed file passed its recorded digest"
+  fi
+  grep -q 'APK identity mismatch' "$CASE_LOG" ||
+    fail_case "the mismatch failure did not name the mismatch"
+  pass_case "a changed file is rejected, naming both digests"
+
+  # -- 3. missing file and empty expectation both redden --------------------
+  if pocketshell_assert_apk_identity "unit" "$unit_dir/gone.apk" "$recorded_app" >/dev/null 2>&1; then
+    fail_case "a missing APK passed the identity assertion"
+  fi
+  pass_case "a missing APK is rejected"
+
+  if pocketshell_assert_apk_identity "unit" "$unit_dir/b.apk" "" >/dev/null 2>&1; then
+    fail_case "an EMPTY expected digest passed — 'I could not check' read as 'fine'"
+  fi
+  pass_case "an empty expected digest is rejected (fail closed)"
+
+  # -- 4. the standalone developer run is untouched -------------------------
+  # Mutation that reddens this: making the verifier mandatory unconditionally,
+  # which would break every `scripts/phone-walkthrough.sh terminal-lab` run on a
+  # dev box that builds its own APKs.
+  (
+    unset POCKETSHELL_EXPECTED_APP_APK_SHA256 POCKETSHELL_EXPECTED_TEST_APK_SHA256
+    pocketshell_verify_walkthrough_apks "standalone"
+  ) >/dev/null 2>&1 ||
+    fail_case "the verifier is not a no-op when no expectation was exported"
+  pass_case "no exported expectation -> deliberate no-op (standalone dev run)"
+
+  # A HALF-configured chain must not silently verify half the pair.
+  (
+    export POCKETSHELL_EXPECTED_APP_APK_SHA256="$recorded_app"
+    unset POCKETSHELL_EXPECTED_TEST_APK_SHA256
+    export APP_APK="$unit_dir/b.apk"
+    pocketshell_verify_walkthrough_apks "half"
+  ) >/dev/null 2>&1 &&
+    fail_case "only one of the two expected digests set was accepted"
+  pass_case "a half-set expectation pair is rejected"
+
+  # A verification MODE that verifies nothing must fail, not report a pass.
+  (
+    unset POCKETSHELL_EXPECTED_APP_APK_SHA256 POCKETSHELL_EXPECTED_TEST_APK_SHA256
+    pocketshell_require_walkthrough_apk_identity "mode"
+  ) >/dev/null 2>&1 &&
+    fail_case "--verify-apk-identity reported a pass over an unchecked pair"
+  pass_case "verification mode with nothing to verify fails closed"
+
+  # -- 5. the REAL chain, green ---------------------------------------------
+  # Mutation that reddens this: removing export_validated_apk_identity from
+  # scripts/release-emulator-validation.sh, or removing any stage's
+  # pocketshell_verify_walkthrough_apks call.
+  local gate_log_root="$SANDBOX/gate"
+  make_fixture "$gate_log_root/chain-green-pre-release"
+  if ! run_chain "$gate_log_root" "chain-green" > "$CASE_LOG" 2>&1; then
+    fail_case "the release chain rejected an intact validated pair"
+  fi
+  grep -q 'PASS: release APK identity chain verified' "$CASE_LOG" ||
+    fail_case "the chain did not report its end-to-end pass"
+  local stage
+  for stage in terminal-workbench phone-walkthrough capture-walkthrough-screenshots parallel-setup-detection; do
+    grep -q "scripts/$stage.sh --verify-apk-identity" "$CASE_LOG" ||
+      fail_case "the chain never drove scripts/$stage.sh"
+  done
+  grep -q 'PASS: phone-walkthrough APK identity verified' "$CASE_LOG" ||
+    fail_case "phone-walkthrough did not verify the pair"
+  grep -q 'PASS: visual-audit APK identity verified' "$CASE_LOG" ||
+    fail_case "the visual audit did not verify the pair"
+  grep -q 'PASS: parallel-setup-detection APK identity verified' "$CASE_LOG" ||
+    fail_case "parallel setup-detection did not verify the pair"
+  grep -q 'PASS: terminal-workbench APK identity verified' "$CASE_LOG" ||
+    fail_case "terminal workbench did not verify the pair"
+  pass_case "real chain: export -> all four install stages verify -> publish"
+
+  # The published artifact must exist and be byte-identical to the gate's APK.
+  local published="$SANDBOX/release/chain-green/app-debug.apk"
+  [[ -f "$published" ]] || fail_case "the chain published no APK"
+  local gate_apk="$gate_log_root/chain-green-pre-release/worktree/app/build/outputs/apk/debug/app-debug.apk"
+  local published_sha gate_sha recorded_sha
+  published_sha="$(sha256sum "$published" | awk '{print $1}')"
+  gate_sha="$(sha256sum "$gate_apk" | awk '{print $1}')"
+  recorded_sha="$(pocketshell_read_apk_identity_field \
+    "$gate_log_root/chain-green-pre-release/$POCKETSHELL_APK_IDENTITY_FILE_NAME" app_apk_sha256)"
+  [[ "$published_sha" == "$gate_sha" && "$gate_sha" == "$recorded_sha" ]] ||
+    fail_case "gate-validated ($gate_sha) / stage-installed ($recorded_sha) / published ($published_sha) are not one binary"
+  grep -q "published APK sha256: \`$published_sha\`" "$SANDBOX/release/chain-green/summary.md" ||
+    fail_case "the release summary does not record the published digest"
+  pass_case "gate-validated == stage-installed == published ($published_sha)"
+
+  # -- 6. THE REPORTED DEFECT: a stage rebuilds its own binary --------------
+  # This is what the three phone-walkthrough stages did on every release before
+  # this change: `rm -rf app/build` then rebuild. The rebuilt APK is valid — it
+  # is simply NOT the one the gate validated and ships.
+  local rebuilt_root="$SANDBOX/gate-rebuilt"
+  make_fixture "$rebuilt_root/chain-rebuilt-pre-release"
+  printf 'PK\x03\x04 pocketshell debug apk build B (stage rebuild)\n' \
+    > "$rebuilt_root/chain-rebuilt-pre-release/worktree/app/build/outputs/apk/debug/app-debug.apk"
+  if run_chain "$rebuilt_root" "chain-rebuilt" > "$CASE_LOG" 2>&1; then
+    fail_case "a stage-rebuilt, byte-different app APK was accepted — the #2064 defect is not closed"
+  fi
+  grep -q 'APK identity mismatch' "$CASE_LOG" ||
+    fail_case "the rebuilt-binary rejection did not name the identity mismatch"
+  pass_case "rebuilt_stage_binary_is_rejected (the reported defect, reproduced)"
+
+  # Same for the androidTest half — the instrumentation APK is half the journey
+  # evidence and was rebuilt by exactly the same code path.
+  local rebuilt_test_root="$SANDBOX/gate-rebuilt-test"
+  make_fixture "$rebuilt_test_root/chain-rebuilt-test-pre-release"
+  printf 'PK\x03\x04 pocketshell androidTest apk build B (stage rebuild)\n' \
+    > "$rebuilt_test_root/chain-rebuilt-test-pre-release/worktree/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+  if run_chain "$rebuilt_test_root" "chain-rebuilt-test" > "$CASE_LOG" 2>&1; then
+    fail_case "a stage-rebuilt androidTest APK was accepted"
+  fi
+  pass_case "a rebuilt androidTest APK is rejected too"
+
+  # -- 6b2. publish ships the RECORDED binary, not a second guess -----------
+  # The chain used to derive the publishable APK twice: once as the gate's
+  # recorded `app_apk`, once as a hardcoded `<gate-run>/worktree/app/build/...`
+  # path. Two derivations of "the validated binary" is one too many. Here the
+  # gate recorded a RELOCATED APK while a different, decoy binary sits at the
+  # conventional path — the artefact the release ships must be the recorded,
+  # validated one. Mutation that reddens this: publishing $PRE_RELEASE_GATE_APK
+  # instead of the recorded $APP_APK.
+  local reloc_root="$SANDBOX/gate-relocated"
+  local reloc_run="$reloc_root/chain-relocated-pre-release"
+  make_fixture "$reloc_run"
+  local reloc_apk="$reloc_run/worktree/app/build/outputs/apk/debug/app-debug-relocated.apk"
+  printf 'PK\x03\x04 pocketshell debug apk RELOCATED (the validated one)\n' > "$reloc_apk"
+  pocketshell_record_apk_identity "$reloc_run/$POCKETSHELL_APK_IDENTITY_FILE_NAME" \
+    "$reloc_apk" "$reloc_run/worktree/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk" \
+    >/dev/null
+  printf 'PK\x03\x04 DECOY at the conventional path — never validated\n' \
+    > "$reloc_run/worktree/app/build/outputs/apk/debug/app-debug.apk"
+  run_chain "$reloc_root" "chain-relocated" > "$CASE_LOG" 2>&1 ||
+    fail_case "the chain rejected a validated pair that simply lives at a different path"
+  local reloc_published_sha reloc_recorded_sha decoy_sha
+  reloc_published_sha="$(sha256sum "$SANDBOX/release/chain-relocated/app-debug.apk" | awk '{print $1}')"
+  reloc_recorded_sha="$(sha256sum "$reloc_apk" | awk '{print $1}')"
+  decoy_sha="$(sha256sum "$reloc_run/worktree/app/build/outputs/apk/debug/app-debug.apk" | awk '{print $1}')"
+  [[ "$reloc_published_sha" == "$reloc_recorded_sha" ]] ||
+    fail_case "the release published $reloc_published_sha, not the validated $reloc_recorded_sha"
+  [[ "$reloc_published_sha" != "$decoy_sha" ]] ||
+    fail_case "the release published the never-validated binary sitting at the conventional path"
+  pass_case "publish ships the RECORDED validated binary, not a second path guess"
+
+  # -- 6c. EACH stage independently rejects a tampered binary ---------------
+  # Cases 6/6b fail at the chain-level export, which would mask a single stage
+  # silently losing its own verification. So drive each stage DIRECTLY with a
+  # correct exported expectation and a binary that changed after the export —
+  # i.e. the stage rebuilt behind the chain's back. Every stage must redden on
+  # its own; the mutation is deleting that one stage's verification call.
+  local solo_root="$SANDBOX/gate-solo"
+  make_fixture "$solo_root/solo-pre-release"
+  (
+    pocketshell_export_walkthrough_apk_env "$solo_root/solo-pre-release" >/dev/null 2>&1 ||
+      exit 1
+    printf 'PK\x03\x04 rebuilt behind the chain\n' > "$APP_APK"
+    for solo_stage in \
+      scripts/terminal-workbench.sh \
+      scripts/phone-walkthrough.sh \
+      scripts/capture-walkthrough-screenshots.sh \
+      scripts/parallel-setup-detection.sh; do
+      if env POCKETSHELL_AVD_LOCK_DIR="$SANDBOX/locks" \
+          bash "$ROOT_DIR/$solo_stage" --verify-apk-identity >/dev/null 2>&1; then
+        printf 'stage %s accepted a binary that changed after the export\n' "$solo_stage" >&2
+        exit 1
+      fi
+    done
+  ) > "$CASE_LOG" 2>&1 ||
+    fail_case "a stage accepted a post-export rebuild: $(cat "$CASE_LOG")"
+  pass_case "each stage independently rejects a post-export rebuild"
+
+  # -- 6d. a mutation AFTER the last stage but BEFORE publish reddens -------
+  # Mutation that reddens this: moving publish_validated_apk before the final
+  # stage, or deleting its publish-time digest assertion. The hook is accepted
+  # only by the device-free proof mode and changes the app APK at the exact
+  # boundary that used to be untested.
+  local late_root="$SANDBOX/gate-late-tamper"
+  make_fixture "$late_root/chain-late-tamper-pre-release"
+  local late_hook="$SANDBOX/tamper-after-stages.sh"
+  cat > "$late_hook" <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'PK\x03\x04 tampered after the last stage\n' > "$1"
+HOOK
+  chmod +x "$late_hook"
+  if POCKETSHELL_APK_IDENTITY_POST_STAGE_HOOK="$late_hook" \
+      run_chain "$late_root" "chain-late-tamper" > "$CASE_LOG" 2>&1; then
+    fail_case "an APK changed after the last stage was still published"
+  fi
+  grep -q 'APK identity mismatch' "$CASE_LOG" ||
+    fail_case "the publish-time late-tamper rejection did not name the mismatch"
+  pass_case "publish rejects an APK changed after the last validation stage"
+
+  # -- 7. a missing identity record stops the release -----------------------
+  # Mutation that reddens this: making export_validated_apk_identity tolerant of
+  # an absent record, which would silently restore the old rebuild-per-stage
+  # behaviour on any gate run that failed to write one.
+  local no_record_root="$SANDBOX/gate-no-record"
+  make_fixture "$no_record_root/chain-no-record-pre-release"
+  rm -f "$no_record_root/chain-no-record-pre-release/$POCKETSHELL_APK_IDENTITY_FILE_NAME"
+  if run_chain "$no_record_root" "chain-no-record" > "$CASE_LOG" 2>&1; then
+    fail_case "the release chain continued with NO APK identity record"
+  fi
+  pass_case "a missing identity record stops the release chain"
+
+  # -- 8. a gate APK deleted after recording ---------------------------------
+  local gone_root="$SANDBOX/gate-gone"
+  make_fixture "$gone_root/chain-gone-pre-release"
+  rm -f "$gone_root/chain-gone-pre-release/worktree/app/build/outputs/apk/debug/app-debug.apk"
+  if run_chain "$gone_root" "chain-gone" > "$CASE_LOG" 2>&1; then
+    fail_case "the release chain continued with the validated APK missing"
+  fi
+  pass_case "a validated APK missing at export time stops the chain"
+
+  # -- 9. the two wiring facts the device-free mode cannot reach -------------
+  # Everything above drives production code. Two links can only be checked
+  # statically, because reaching them behaviourally needs an emulator:
+  #   (a) the REAL release flow calls export_validated_apk_identity between the
+  #       confidence gate and the first walkthrough stage — the verification
+  #       mode calls it directly, so deleting it from the real flow would not
+  #       redden case 5;
+  #   (b) each stage re-verifies at its INSTALL site, after any optional
+  #       rebuild, not only at config time.
+  # Both are asserted on line ORDER (not mere substring presence) and reject a
+  # commented-out call, which is the shape that keeps a wiring guard green while
+  # the wiring is gone.
+  local rev="$ROOT_DIR/scripts/release-emulator-validation.sh"
+  local export_line gate_line
+  export_line="$(grep -n '^export_validated_apk_identity$' "$rev" | head -1 | cut -d: -f1)"
+  gate_line="$(grep -n '"pre-release confidence gate" \\$' "$rev" | head -1 | cut -d: -f1)"
+  [[ -n "$export_line" && -n "$gate_line" ]] ||
+    fail_case "the real release flow has no top-level export_validated_apk_identity after the confidence gate"
+  [[ "$export_line" -gt "$gate_line" ]] ||
+    fail_case "export_validated_apk_identity runs before the gate that produces the identity record"
+  local stage_label
+  for stage_label in \
+    '"optional terminal release gate" \' \
+    '"terminal-lab phone walkthrough" \' \
+    '"tmux existing-session phone walkthrough" \' \
+    '"visual-audit screenshot capture" \'; do
+    local stage_line
+    stage_line="$(grep -nF "$stage_label" "$rev" | head -1 | cut -d: -f1)"
+    [[ -n "$stage_line" ]] ||
+      fail_case "could not locate the release stage: $stage_label"
+    [[ "$stage_line" -gt "$export_line" ]] ||
+      fail_case "release stage $stage_label runs BEFORE the validated-APK export, so it would install an unverified binary"
+  done
+  pass_case "the real release flow exports the identity between the gate and every stage"
+
+  local publish_line visual_stage_line
+  publish_line="$(grep -n '^publish_validated_apk$' "$rev" | tail -1 | cut -d: -f1)"
+  visual_stage_line="$(grep -nF '"visual-audit screenshot capture" \' "$rev" | tail -1 | cut -d: -f1)"
+  [[ -n "$publish_line" && -n "$visual_stage_line" && "$publish_line" -gt "$visual_stage_line" ]] ||
+    fail_case "publish_validated_apk is not pinned after the final install stage"
+  pass_case "the release publishes only after the final validation stage"
+
+  local pw="$ROOT_DIR/scripts/phone-walkthrough.sh"
+  grep -qE '^[[:space:]]+pocketshell_verify_walkthrough_apks "phone walkthrough \(install\)"' "$pw" ||
+    fail_case "phone-walkthrough no longer re-verifies at its install site"
+  local install_verify_line install_line
+  install_verify_line="$(grep -n 'phone walkthrough (install)' "$pw" | head -1 | cut -d: -f1)"
+  install_line="$(grep -n '10-cold-reset-install-apks' "$pw" | head -1 | cut -d: -f1)"
+  [[ -n "$install_verify_line" && -n "$install_line" && "$install_verify_line" -lt "$install_line" ]] ||
+    fail_case "phone-walkthrough verifies the APK after installing it, which proves nothing"
+  local ca="$ROOT_DIR/scripts/capture-walkthrough-screenshots.sh"
+  grep -qE '^[[:space:]]+pocketshell_verify_walkthrough_apks "visual audit \(install\)"' "$ca" ||
+    fail_case "the visual audit no longer re-verifies before installing"
+  local ps="$ROOT_DIR/scripts/parallel-setup-detection.sh"
+  grep -qE '^pocketshell_verify_walkthrough_apks "parallel setup-detection \(pre-shard\)"' "$ps" ||
+    fail_case "parallel setup-detection no longer re-verifies after its pre-shard build"
+  local tw="$ROOT_DIR/scripts/terminal-workbench.sh"
+  grep -qF 'source "$ROOT_DIR/scripts/lib/apk-identity.sh"' "$tw" ||
+    fail_case "terminal-workbench does not participate in the APK identity contract"
+  grep -qF 'APP_APK="${APP_APK:-$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk}"' "$tw" ||
+    fail_case "terminal-workbench still replaces the exported APP_APK with its root-checkout path"
+  grep -qF 'TEST_APK="${TEST_APK:-$ROOT_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk}"' "$tw" ||
+    fail_case "terminal-workbench still replaces the exported TEST_APK with its root-checkout path"
+  local terminal_verify_line terminal_install_line
+  terminal_verify_line="$(grep -n 'terminal workbench (install)' "$tw" | head -1 | cut -d: -f1)"
+  terminal_install_line="$(grep -n '05-install-apks' "$tw" | head -1 | cut -d: -f1)"
+  [[ -n "$terminal_verify_line" && -n "$terminal_install_line" && "$terminal_verify_line" -lt "$terminal_install_line" ]] ||
+    fail_case "terminal-workbench does not verify the exported APK pair immediately before install"
+  pass_case "every stage re-verifies at its install site, before installing"
+
+  # -- 10. green again, so none of the reds above are permanent --------------
+  local again_root="$SANDBOX/gate-again"
+  make_fixture "$again_root/chain-again-pre-release"
+  run_chain "$again_root" "chain-again" > "$CASE_LOG" 2>&1 ||
+    fail_case "the chain no longer passes on an intact pair after the red cases"
+  pass_case "green again after every red case"
+
+  # The test asserts its OWN check count so it cannot pass vacuously.
+  if [[ "$CHECKS" -ne 20 ]]; then
+    printf 'FAIL: ran %s checks, expected 20\n' "$CHECKS" >&2
+    exit 1
+  fi
+  printf 'PASS: release APK identity contract (%s checks)\n' "$CHECKS"
+}
+
+main "$@"

--- a/scripts/test-release-gate-summary.sh
+++ b/scripts/test-release-gate-summary.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Functions are extracted/eval'd from production, so ShellCheck cannot see the
+# indirect reads/calls that make the seeded state load-bearing.
+# shellcheck disable=SC2030,SC2031,SC2034,SC2269,SC2317
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# The pre-release confidence gate's summary contract (issue #2064)
+#
+# WHAT THIS PINS
+# --------------
+#   1. The per-step WALL CLOCK is published. `run_step` has always measured
+#      every step ("PASS: <name> (Ns)") and then thrown the number away, which
+#      is the entire reason the local release chain was described as unmeasured
+#      for a year: reconstructing the 41m56s / 1083s baseline for run
+#      20260809-v0442-r3 needed archaeology across build-artefact mtimes. The
+#      summary now carries a ranked table and a total, so before/after is a
+#      `grep`.
+#   2. WHERE the unit evidence came from — a reused CI run or a local run — is
+#      recorded, because that is release evidence in its own right.
+#   3. The validated APK's sha256 is recorded, so the summary names the one
+#      binary the chain validated and ships.
+#   4. `scripts/push-release-tag.sh`'s existing contract is untouched: the
+#      summary still carries `Commit SHA:` and the result line.
+#
+# HOW (no copy, no emulator, no Gradle)
+# -------------------------------------
+# The functions under test are EXTRACTED FROM THE PRODUCTION FILE at run time
+# and evaluated here with seeded state. Nothing is transcribed, so this cannot
+# drift away from what the gate actually runs — deleting the table from
+# scripts/pre-release-confidence-gate.sh reddens this immediately.
+#
+# Usage: scripts/test-release-gate-summary.sh
+# ---------------------------------------------------------------------------
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$ROOT_DIR/scripts/pre-release-confidence-gate.sh"
+
+CHECKS=0
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-gate-summary-test.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+ok() {
+  CHECKS=$((CHECKS + 1))
+  printf '  ok  %s\n' "$1"
+}
+
+die() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# Extract one shell function verbatim from the production gate.
+extract_function() {
+  local name="$1"
+  local text
+  text="$(awk -v fn="$name" '
+    $0 ~ "^" fn "\\(\\) \\{" { inside = 1 }
+    inside { print }
+    inside && /^\}$/ { exit }
+  ' "$GATE")"
+  [[ -n "$text" ]] || die "could not extract $name() from $GATE — the gate's summary writer moved or was renamed"
+  printf '%s\n' "$text"
+}
+
+printf 'pre-release gate summary contract (issue #2064)\n'
+
+# ---------------------------------------------------------------------------
+# Seed exactly the state the real gate holds at exit, then run the real
+# write_summary over it.
+# ---------------------------------------------------------------------------
+render_summary() {
+  local out_dir="$1"
+  local unit_mode="$2"
+  local identity_file="$3"
+  mkdir -p "$out_dir"
+
+  (
+    # shellcheck disable=SC1090
+    source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+    eval "$(extract_function commit_sha)"
+    eval "$(extract_function log_path_for)"
+    eval "$(extract_function print_failure_log_tail)"
+    eval "$(extract_function run_step)"
+    eval "$(extract_function mark_step_declined)"
+    eval "$(extract_function write_summary)"
+    update_emulator_serial() { EMULATOR_SERIAL="emulator-5554"; }
+
+    RUN_ID="summary-contract"
+    RUN_DIR="$out_dir"
+    SUMMARY_PATH="$out_dir/summary.txt"
+    SUMMARY_WRITTEN=0
+    GATE_RESULT="PASS"
+    GATE_RESULT_MESSAGE="PASS: pre-release confidence gate completed"
+    EMULATOR_SERIAL="unknown"
+    ROOT_DIR="$ROOT_DIR"
+    APK_PATH="app/build/outputs/apk/debug/app-debug.apk"
+    TEST_APK_PATH="app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
+    COMPOSE_FILE="tests/docker/docker-compose.yml"
+    GRADLE_FLAGS="--no-daemon --no-build-cache --no-parallel --max-workers=1"
+    POCKETSHELL_TEST_MEM="24G"
+    UNIT_EVIDENCE_MODE="$unit_mode"
+    UNIT_EVIDENCE_DETAIL="detail for $unit_mode"
+    APK_IDENTITY_FILE="$identity_file"
+    CONNECTED_TERMINAL_INPUT_STATUS="passed"
+    APP_WALKTHROUGH_INSTALL_STATUS="passed"
+    FINAL_INSTALL_STATUS="passed"
+    LEGACY_V1_DB_MIGRATION_STATUS="passed"
+    LEGACY_V1_DB_MIGRATION_LOGCAT="$out_dir/legacy.log"
+    FAILING_STEP=""
+    FAILURE_MESSAGE=""
+    FAILING_LOG_PATH=""
+    FAILURE_DIAGNOSTICS_PATH=""
+    FAILURE_LOGCAT_PATH=""
+    STEP_INDEX=0
+    STEP_NAMES=()
+    STEP_STATUSES=()
+    STEP_LOGS=()
+    STEP_COMMANDS=()
+    STEP_SECONDS=()
+    FOCUSED_SELECTORS=("com.example.Foo#bar")
+    FOCUSED_STATUSES=("passed")
+    FOCUSED_LOGS=("$out_dir/f.log")
+    FOCUSED_DIAGNOSTICS=("")
+    FOCUSED_LOGCATS=("")
+
+    # Drive the REAL run_step, so the PRODUCER of the timings is under test too.
+    # Seeding STEP_SECONDS by hand would leave "run_step stopped recording the
+    # elapsed time" a surviving mutant — the table would still render, from
+    # numbers nothing measured.
+    run_step "fast-step" true > /dev/null 2>&1
+    run_step "slow-step" sleep 2 > /dev/null 2>&1
+    run_step "reuse-ci-unit-evidence" false > /dev/null 2>&1 || true
+    mark_step_declined "reuse-ci-unit-evidence"
+
+    # The real write_summary's last statement is a `[[ -n … ]] && printf`, so it
+    # returns 1 whenever the final focused selector has no logcat path. In the
+    # gate that is invisible (it runs from the EXIT trap, whose return value is
+    # discarded), so this test asserts the summary's CONTENT and deliberately
+    # does not treat the return code as the verdict.
+    write_summary 0 || true
+  )
+}
+
+# A real identity record, written by the real recorder.
+APK_DIR="$SANDBOX/apks"
+mkdir -p "$APK_DIR"
+printf 'PK\x03\x04 app\n' > "$APK_DIR/app-debug.apk"
+printf 'PK\x03\x04 test\n' > "$APK_DIR/app-debug-androidTest.apk"
+# shellcheck disable=SC1090
+source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+pocketshell_record_apk_identity "$APK_DIR/apk-identity.txt" \
+  "$APK_DIR/app-debug.apk" "$APK_DIR/app-debug-androidTest.apk" >/dev/null
+APP_SHA="$(pocketshell_apk_sha256 "$APK_DIR/app-debug.apk")"
+TEST_SHA="$(pocketshell_apk_sha256 "$APK_DIR/app-debug-androidTest.apk")"
+
+OUT="$SANDBOX/reused"
+render_summary "$OUT" "reused-ci" "$APK_DIR/apk-identity.txt"
+SUMMARY="$OUT/summary.txt"
+[[ -s "$SUMMARY" ]] || die "write_summary produced no summary"
+
+# 1. per-step timings, ranked, with a total.
+grep -q '^Total step seconds: 2$' "$SUMMARY" ||
+  die "the summary does not total the MEASURED step wall clock (expected 2s from a real run_step of \`sleep 2\`; issue #2064 criterion 1). Got: $(grep '^Total step seconds:' "$SUMMARY")"
+ok "run_step's measured wall clock reaches the summary and is totalled"
+
+grep -q '^Step timings (slowest first, seconds):$' "$SUMMARY" ||
+  die "the summary has no ranked step-timing table"
+RANKED="$(grep -E '^- +[0-9]+s +' "$SUMMARY" | awk '{print $2}')"
+[[ "$(printf '%s\n' "$RANKED" | head -1)" == "2s" ]] ||
+  die "the timing table is not sorted slowest-first (top row: $(printf '%s\n' "$RANKED" | head -1))"
+[[ "$(printf '%s\n' "$RANKED" | tail -1)" == "0s" ]] ||
+  die "the timing table is not sorted slowest-first (last row: $(printf '%s\n' "$RANKED" | tail -1))"
+ok "the timing table is ranked slowest-first"
+
+grep -qE '^- +2s +100% +slow-step +passed' "$SUMMARY" ||
+  die "the timing table does not carry each step's share of the total"
+ok "each step carries its percentage of the total"
+
+grep -q '^  seconds: 2$' "$SUMMARY" ||
+  die "the per-step record does not carry its own duration"
+ok "each step record carries its duration"
+
+# 2. unit-evidence provenance.
+grep -q '^Unit evidence: reused-ci$' "$SUMMARY" ||
+  die "the summary does not record WHERE the unit evidence came from"
+ok "unit-evidence provenance is recorded (reused-ci)"
+
+# 3. the validated binary.
+grep -q "^Validated app APK sha256: $APP_SHA\$" "$SUMMARY" ||
+  die "the summary does not name the validated app APK digest"
+grep -q "^Validated androidTest APK sha256: $TEST_SHA\$" "$SUMMARY" ||
+  die "the summary does not name the validated androidTest APK digest"
+ok "the summary names the validated APK digests"
+
+# 4. the tag helper's existing contract survives.
+grep -q '^Commit SHA: ' "$SUMMARY" ||
+  die "the summary lost its 'Commit SHA:' line — scripts/push-release-tag.sh requires it"
+grep -q '^Result: PASS' "$SUMMARY" ||
+  die "the summary lost its result line"
+ok "the tag helper's Commit SHA + result contract is intact"
+
+# The local-run mode records itself distinctly, so a release that could NOT
+# reuse CI evidence is visible in its own summary rather than indistinguishable.
+OUT_LOCAL="$SANDBOX/local"
+render_summary "$OUT_LOCAL" "local" "$APK_DIR/apk-identity.txt"
+grep -q '^Unit evidence: local$' "$OUT_LOCAL/summary.txt" ||
+  die "a locally-run unit suite is not distinguishable in the summary"
+ok "a local unit run is distinguishable from a reused one"
+
+grep -A5 '^- name: reuse-ci-unit-evidence$' "$OUT_LOCAL/summary.txt" | grep -q '^  status: declined$' ||
+  die "a fail-closed CI-evidence refusal is still recorded as a failed release step"
+grep -q '^Failing step:' "$OUT_LOCAL/summary.txt" &&
+  die "a declined CI-evidence reuse left stale failure state in the summary"
+ok "declined CI reuse stays visible without poisoning the release verdict"
+
+# A missing identity record must not crash the summary writer, and must not
+# silently print a digest either.
+OUT_NO_ID="$SANDBOX/no-identity"
+render_summary "$OUT_NO_ID" "local" "$SANDBOX/absent/apk-identity.txt"
+[[ -s "$OUT_NO_ID/summary.txt" ]] ||
+  die "write_summary produced no summary when the identity record was absent"
+grep -q '^Validated app APK sha256:' "$OUT_NO_ID/summary.txt" &&
+  die "the summary printed an APK digest with no identity record behind it"
+ok "an absent identity record yields no digest line and no crash"
+
+if [[ "$CHECKS" -ne 10 ]]; then
+  printf 'FAIL: ran %s checks, expected 10\n' "$CHECKS" >&2
+  exit 1
+fi
+printf 'PASS: pre-release gate summary contract (%s checks)\n' "$CHECKS"

--- a/scripts/test-reuse-ci-unit-evidence.sh
+++ b/scripts/test-reuse-ci-unit-evidence.sh
@@ -1,0 +1,482 @@
+#!/usr/bin/env bash
+# The library-only source flag and nested fixture runner are consumed through
+# dynamic sourcing/calls that ShellCheck cannot resolve.
+# shellcheck disable=SC2034
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Fail-closed matrix for scripts/reuse-ci-unit-evidence.sh (issue #2064)
+#
+# The acceptor lets the pre-release confidence gate SKIP its local unit run when
+# the required `Unit tests` check is green on the exact release commit. That is
+# only safe if a missing/red/foreign/vacuous CI result can never read as a pass.
+# This drives the REAL acceptor over a real git checkout with a real pushed
+# origin; only `gh` is stubbed, and the stub replays raw API bodies so the real
+# JSON projection, the real verification-root assembly and the real count check
+# all execute. No network, no Gradle, no Android SDK — about three seconds.
+#
+# It ALSO pins the acceptor's in-script executed-count check against
+# scripts/check-executed-test-counts.sh, the #1646 guard whose rules it
+# re-implements. (The acceptor cannot shell out to that guard: it is reachable
+# from the release chain, and scripts/check-release-gate-execution-profile.sh
+# rejects chain-reachable scripts that are not themselves in
+# RELEASE_CHAIN_SCRIPTS. This test script is NOT chain-reachable, so it can hold
+# both implementations side by side and require identical verdicts — which is
+# what stops them drifting apart.)
+#
+# Usage: scripts/test-reuse-ci-unit-evidence.sh
+# ---------------------------------------------------------------------------
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# The acceptor's helper functions are sourced for the pure-parser and
+# cross-implementation cases below; every acceptance/decline case still runs it
+# as a real child process.
+POCKETSHELL_CI_EVIDENCE_LIB_ONLY=1
+# shellcheck source=/dev/null
+source "$ROOT_DIR/scripts/reuse-ci-unit-evidence.sh"
+
+CHECKS=0
+
+expect_case() {
+  local expectation="$1"
+  local label="$2"
+  shift 2
+  CHECKS=$((CHECKS + 1))
+  local rc=0
+  "$@" > "$CASE_LOG" 2>&1 || rc=$?
+  if [[ "$expectation" == "accept" && "$rc" -ne 0 ]]; then
+    printf 'FAIL: case %s should have ACCEPTED but exited %s\n' "$label" "$rc" >&2
+    tail -n 40 "$CASE_LOG" >&2
+    return 1
+  fi
+  if [[ "$expectation" == "decline" && "$rc" -eq 0 ]]; then
+    printf 'FAIL: case %s should have DECLINED but exited 0\n' "$label" >&2
+    tail -n 40 "$CASE_LOG" >&2
+    return 1
+  fi
+  printf '  ok  %-52s (%s, rc=%s)\n' "$label" "$expectation" "$rc"
+}
+
+write_fixture_api() {
+  local dir="$1"
+  local sha="$2"
+  local check_status="$3"
+  local check_conclusion="$4"
+  local check_head_sha="$5"
+  local run_head_sha="$6"
+  local debug_job_conclusion="$7"
+  local release_job_conclusion="${8:-$7}"
+
+  cat > "$dir/check-runs.json" <<JSON
+{"total_count": 2, "check_runs": [
+  {"name": "Python utility tests (pocketshell)", "status": "completed", "conclusion": "success",
+   "head_sha": "$sha", "details_url": "https://github.com/o/r/actions/runs/900/job/1"},
+  {"name": "Unit tests", "status": "$check_status", "conclusion": "$check_conclusion",
+   "head_sha": "$check_head_sha", "details_url": "https://github.com/o/r/actions/runs/4242/job/7"}
+]}
+JSON
+  cat > "$dir/workflow-run.json" <<JSON
+{"head_sha": "$run_head_sha", "status": "completed", "conclusion": "success",
+ "html_url": "https://github.com/o/r/actions/runs/4242"}
+JSON
+  cat > "$dir/workflow-jobs.json" <<JSON
+{"total_count": 3, "jobs": [
+  {"name": "Static guards", "status": "completed", "conclusion": "success", "completed_at": "2026-08-09T06:40:00Z"},
+  {"name": "JVM unit tests (Debug)", "status": "completed", "conclusion": "$debug_job_conclusion", "completed_at": "2026-08-11T06:51:13Z"},
+  {"name": "JVM unit tests (Release)", "status": "completed", "conclusion": "$release_job_conclusion", "completed_at": "2026-08-11T06:53:13Z"}
+]}
+JSON
+}
+
+write_stub_gh() {
+  local stub="$1"
+  local api_dir="$2"
+  local artifact_src="$3"
+  cat > "$stub" <<STUB
+#!/usr/bin/env bash
+set -uo pipefail
+case "\$1" in
+  api)
+    case "\$2" in
+      */check-runs*) cat "$api_dir/check-runs.json" ;;
+      */jobs*) cat "$api_dir/workflow-jobs.json" ;;
+      */actions/runs/*) cat "$api_dir/workflow-run.json" ;;
+      *) printf 'stub gh: unexpected api path %s\n' "\$2" >&2; exit 1 ;;
+    esac
+    ;;
+  run)
+    dest=""
+    name=""
+    prev=""
+    for arg in "\$@"; do
+      if [ "\$prev" = "--dir" ]; then dest="\$arg"; fi
+      if [ "\$prev" = "--name" ]; then name="\$arg"; fi
+      prev="\$arg"
+    done
+    [ -n "\$dest" ] || { printf 'stub gh: no --dir\n' >&2; exit 1; }
+    [ -n "\$name" ] || { printf 'stub gh: no --name\n' >&2; exit 1; }
+    if [ ! -d "$artifact_src/\$name" ]; then
+      printf 'stub gh: artifact %s not found\n' "\$name" >&2
+      exit 1
+    fi
+    mkdir -p "\$dest"
+    cp -a "$artifact_src/\$name/." "\$dest/"
+    ;;
+  *) printf 'stub gh: unexpected verb %s\n' "\$1" >&2; exit 1 ;;
+esac
+STUB
+  chmod +x "$stub"
+}
+
+run_matrix() {
+  local sandbox
+  sandbox="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-reuse-ci-selftest.XXXXXX")"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$sandbox'" RETURN
+  CASE_LOG="$sandbox/case.log"
+
+  printf 'reuse-ci-unit-evidence fail-closed matrix (issue #2064)\n'
+
+  # --- the URL parser, on its own ------------------------------------------
+  local parsed
+  CHECKS=$((CHECKS + 1))
+  parsed="$(pocketshell_ci_evidence_repo_slug_from_url 'git@github.com:alexeygrigorev/pocketshell.git')" || parsed=""
+  [[ "$parsed" == "alexeygrigorev/pocketshell" ]] ||
+    { printf 'FAIL: ssh remote parsed as %s\n' "$parsed" >&2; return 1; }
+  printf '  ok  %-52s (%s)\n' "slug from ssh remote" "$parsed"
+
+  CHECKS=$((CHECKS + 1))
+  parsed="$(pocketshell_ci_evidence_repo_slug_from_url 'https://github.com/alexeygrigorev/pocketshell')" || parsed=""
+  [[ "$parsed" == "alexeygrigorev/pocketshell" ]] ||
+    { printf 'FAIL: https remote parsed as %s\n' "$parsed" >&2; return 1; }
+  printf '  ok  %-52s (%s)\n' "slug from https remote" "$parsed"
+
+  CHECKS=$((CHECKS + 1))
+  if pocketshell_ci_evidence_repo_slug_from_url 'https://gitlab.com/o/r.git' >/dev/null 2>&1; then
+    printf 'FAIL: a non-GitHub remote must not yield a slug\n' >&2
+    return 1
+  fi
+  printf '  ok  %-52s\n' "non-GitHub remote yields no slug"
+
+  CHECKS=$((CHECKS + 1))
+  if pocketshell_ci_evidence_run_id_from_details_url 'https://github.com/o/r/checks' >/dev/null 2>&1; then
+    printf 'FAIL: a details_url without /actions/runs/<id> must not yield a run id\n' >&2
+    return 1
+  fi
+  printf '  ok  %-52s\n' "unparseable details_url yields no run id"
+
+  # The runtime acceptor requires these rendered names from GitHub too. This
+  # local pin makes workflow drift fail with a direct contract diagnostic.
+  CHECKS=$((CHECKS + 1))
+  pocketshell_ci_evidence_assert_workflow_contract "$ROOT_DIR/.github/workflows/tests.yml" ||
+    { printf 'FAIL: current tests.yml does not match the #2069 Debug/Release contract\n' >&2; return 1; }
+  sed 's/unit-test-reports-${{ matrix.variant }}/unit-test-results-${{ matrix.variant }}/' \
+    "$ROOT_DIR/.github/workflows/tests.yml" > "$sandbox/workflow-drift.yml"
+  if pocketshell_ci_evidence_assert_workflow_contract "$sandbox/workflow-drift.yml" >/dev/null 2>&1; then
+    printf 'FAIL: workflow contract accepted a renamed artifact family\n' >&2
+    return 1
+  fi
+  printf '  ok  %-52s\n' "workflow job/artifact contract is pinned and reddens"
+
+  # --- a real git checkout at a real pushed commit --------------------------
+  local origin="$sandbox/origin.git"
+  local tree="$sandbox/tree"
+  git init --quiet --bare "$origin"
+  git init --quiet -b main "$tree"
+  git -C "$tree" config user.email selftest@example.com
+  git -C "$tree" config user.name selftest
+  git -C "$tree" remote add origin "$origin"
+
+  # A miniature release tree: one Android module and one JVM module, the real
+  # floors file shape, the real guard scripts, and the real workflow.
+  mkdir -p "$tree/scripts" "$tree/.github/workflows"
+  mkdir -p "$tree/app/src/test/java" "$tree/shared/core-x/src/test/java"
+  cat > "$tree/settings.gradle.kts" <<'SETTINGS'
+include(":app")
+include(":shared:core-x")
+SETTINGS
+  printf 'plugins { id("com.android.application") }\n' > "$tree/app/build.gradle.kts"
+  # #2069's two shards cover Android Debug/Release tasks. A JVM-only `test`
+  # task is intentionally rejected by the current coverage-invariant guard.
+  printf 'plugins { id("com.android.library") }\n' > "$tree/shared/core-x/build.gradle.kts"
+  printf 'class AppTest\n' > "$tree/app/src/test/java/AppTest.kt"
+  printf 'class CoreXTest\n' > "$tree/shared/core-x/src/test/java/CoreXTest.kt"
+  printf '# task floor\n:app:testDebugUnitTest 2\n' > "$tree/scripts/executed-test-count-floors.txt"
+  cp "$ROOT_DIR/scripts/check-executed-test-counts.sh" "$tree/scripts/"
+  cp "$ROOT_DIR/scripts/check-ci-unit-forced-execution.py" "$tree/scripts/"
+  chmod +x "$tree/scripts/check-executed-test-counts.sh" "$tree/scripts/check-ci-unit-forced-execution.py"
+  cp "$ROOT_DIR/.github/workflows/tests.yml" "$tree/.github/workflows/tests.yml"
+  git -C "$tree" add -A
+  git -C "$tree" commit --quiet -m "self-test tree"
+  git -C "$tree" push --quiet origin main
+  git -C "$tree" fetch --quiet origin main
+  local sha
+  sha="$(git -C "$tree" rev-parse HEAD)"
+
+  # A green downloaded artifact: real result XML shapes, per module.
+  local artifact="$sandbox/artifacts-green"
+  local artifact_debug="$artifact/unit-test-reports-Debug"
+  local artifact_release="$artifact/unit-test-reports-Release"
+  mkdir -p "$artifact_debug/app/build/test-results/testDebugUnitTest"
+  cat > "$artifact_debug/app/build/test-results/testDebugUnitTest/TEST-AppTest.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="AppTest" tests="4" skipped="0" failures="0" errors="0" time="0.5">
+</testsuite>
+XML
+  mkdir -p "$artifact_release/app/build/test-results/testReleaseUnitTest"
+  cat > "$artifact_release/app/build/test-results/testReleaseUnitTest/TEST-AppTest.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="AppTest" tests="4" skipped="0" failures="0" errors="0" time="0.5">
+</testsuite>
+XML
+  mkdir -p "$artifact_debug/shared/core-x/build/test-results/testDebugUnitTest"
+  cat > "$artifact_debug/shared/core-x/build/test-results/testDebugUnitTest/TEST-CoreXTest.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="CoreXTest" tests="3" skipped="0" failures="0" errors="0" time="0.2">
+</testsuite>
+XML
+  mkdir -p "$artifact_release/shared/core-x/build/test-results/testReleaseUnitTest"
+  cat > "$artifact_release/shared/core-x/build/test-results/testReleaseUnitTest/TEST-CoreXTest.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="CoreXTest" tests="3" skipped="0" failures="0" errors="0" time="0.2">
+</testsuite>
+XML
+
+  # An artifact whose :app:testReleaseUnitTest results are absent — exactly the
+  # "wrong task / task never ran" disguise the count guard exists to catch.
+  local artifact_missing="$sandbox/artifact-missing-task"
+  cp -a "$artifact" "$artifact_missing"
+  rm -rf "$artifact_missing/unit-test-reports-Release/app/build/test-results/testReleaseUnitTest"
+
+  # An artifact where every test was SKIPPED: real XML, real files, zero
+  # executed. The G3 vacuous pass.
+  local artifact_skipped="$sandbox/artifact-all-skipped"
+  cp -a "$artifact" "$artifact_skipped"
+  cat > "$artifact_skipped/unit-test-reports-Debug/app/build/test-results/testDebugUnitTest/TEST-AppTest.xml" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="AppTest" tests="4" skipped="4" failures="0" errors="0" time="0.5">
+</testsuite>
+XML
+
+  local api="$sandbox/api"
+  mkdir -p "$api"
+  local stub="$sandbox/gh-stub"
+
+  local run_case
+  run_case() {
+    local out="$1"
+    rm -rf "$out"
+    env POCKETSHELL_CI_EVIDENCE_GH="$stub" \
+        POCKETSHELL_CI_EVIDENCE_REPO="o/r" \
+        RELEASE_GATE_REUSE_CI_UNIT="${RELEASE_GATE_REUSE_CI_UNIT:-1}" \
+        bash "$ROOT_DIR/scripts/reuse-ci-unit-evidence.sh" \
+          --source-root "$tree" --tree-root "$tree" --out-dir "$out" --sha "$sha"
+  }
+
+  # --- GREEN ----------------------------------------------------------------
+  write_fixture_api "$api" "$sha" completed success "$sha" "$sha" success
+  write_stub_gh "$stub" "$api" "$artifact"
+  expect_case accept "clean tree + green Unit tests + real counts" \
+    run_case "$sandbox/out-green" || return 1
+
+  # --- RED: the check run is not green --------------------------------------
+  write_fixture_api "$api" "$sha" completed failure "$sha" "$sha" success
+  expect_case decline "check run conclusion=failure" \
+    run_case "$sandbox/out-red-conclusion" || return 1
+
+  write_fixture_api "$api" "$sha" in_progress "" "$sha" "$sha" success
+  expect_case decline "check run still in_progress" \
+    run_case "$sandbox/out-red-status" || return 1
+
+  # --- RED: the green check belongs to a DIFFERENT commit -------------------
+  write_fixture_api "$api" "$sha" completed success \
+    "0000000000000000000000000000000000000000" "$sha" success
+  expect_case decline "check run head_sha is another commit" \
+    run_case "$sandbox/out-red-check-sha" || return 1
+
+  write_fixture_api "$api" "$sha" completed success "$sha" \
+    "1111111111111111111111111111111111111111" success
+  expect_case decline "workflow run head_sha is another commit" \
+    run_case "$sandbox/out-red-run-sha" || return 1
+
+  # --- RED: the job that runs the tests failed ------------------------------
+  write_fixture_api "$api" "$sha" completed success "$sha" "$sha" failure
+  expect_case decline "both JVM unit shards conclusion=failure" \
+    run_case "$sandbox/out-red-job" || return 1
+
+  write_fixture_api "$api" "$sha" completed success "$sha" "$sha" success failure
+  expect_case decline "Release JVM unit shard conclusion=failure" \
+    run_case "$sandbox/out-red-release-job" || return 1
+
+  write_fixture_api "$api" "$sha" completed success "$sha" "$sha" success
+  python3 - "$api/workflow-jobs.json" <<'PYTHON'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+payload["jobs"] = [
+    job for job in payload["jobs"] if job["name"] != "JVM unit tests (Release)"
+]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PYTHON
+  expect_case decline "Release JVM unit shard is missing" \
+    run_case "$sandbox/out-red-missing-release-job" || return 1
+
+  # --- RED: no `Unit tests` check run at all --------------------------------
+  write_fixture_api "$api" "$sha" completed success "$sha" "$sha" success
+  python3 - "$api/check-runs.json" <<'PYTHON'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+payload["check_runs"] = [
+    run for run in payload["check_runs"] if run["name"] != "Unit tests"
+]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PYTHON
+  expect_case decline "no 'Unit tests' check run for the commit" \
+    run_case "$sandbox/out-red-missing-check" || return 1
+
+  # --- RED: the downloaded artifact does not satisfy the floors -------------
+  write_fixture_api "$api" "$sha" completed success "$sha" "$sha" success
+  write_stub_gh "$stub" "$api" "$artifact_missing"
+  expect_case decline "downloaded artifact is missing a required task" \
+    run_case "$sandbox/out-red-missing-task" || return 1
+
+  write_stub_gh "$stub" "$api" "$artifact_skipped"
+  expect_case decline "downloaded artifact executed 0 tests (all skipped)" \
+    run_case "$sandbox/out-red-all-skipped" || return 1
+
+  write_stub_gh "$stub" "$api" "$sandbox/artifact-does-not-exist"
+  expect_case decline "artifact download fails" \
+    run_case "$sandbox/out-red-no-artifact" || return 1
+
+  local artifact_missing_release="$sandbox/artifact-missing-release"
+  cp -a "$artifact" "$artifact_missing_release"
+  rm -rf "$artifact_missing_release/unit-test-reports-Release"
+  write_stub_gh "$stub" "$api" "$artifact_missing_release"
+  expect_case decline "Release shard artifact is missing" \
+    run_case "$sandbox/out-red-no-release-artifact" || return 1
+
+  # --- RED: a dirty tree is not the commit ----------------------------------
+  write_stub_gh "$stub" "$api" "$artifact"
+  printf 'local edit\n' > "$tree/app/src/test/java/Scratch.kt"
+  expect_case decline "untracked file in the release checkout" \
+    run_case "$sandbox/out-red-untracked" || return 1
+  rm -f "$tree/app/src/test/java/Scratch.kt"
+
+  printf 'tracked edit\n' >> "$tree/app/src/test/java/AppTest.kt"
+  expect_case decline "modified tracked file in the release checkout" \
+    run_case "$sandbox/out-red-dirty" || return 1
+  git -C "$tree" checkout --quiet -- app/src/test/java/AppTest.kt
+
+  # --- RED: HEAD is ahead of origin/main ------------------------------------
+  printf 'class Extra\n' > "$tree/app/src/test/java/Extra.kt"
+  git -C "$tree" add -A
+  git -C "$tree" commit --quiet -m "unpushed"
+  expect_case decline "HEAD is not the pushed origin/main" \
+    run_case "$sandbox/out-red-unpushed" || return 1
+  git -C "$tree" reset --quiet --hard "$sha"
+
+  # --- RED: the requested SHA is not HEAD -----------------------------------
+  CHECKS=$((CHECKS + 1))
+  local rc=0
+  env POCKETSHELL_CI_EVIDENCE_GH="$stub" POCKETSHELL_CI_EVIDENCE_REPO="o/r" \
+    bash "$ROOT_DIR/scripts/reuse-ci-unit-evidence.sh" \
+      --source-root "$tree" --tree-root "$tree" --out-dir "$sandbox/out-red-sha" \
+      --sha "2222222222222222222222222222222222222222" \
+      > "$CASE_LOG" 2>&1 || rc=$?
+  [[ "$rc" -ne 0 ]] ||
+    { printf 'FAIL: a --sha that is not HEAD must decline\n' >&2; return 1; }
+  printf '  ok  %-52s (decline, rc=%s)\n' "--sha differs from HEAD" "$rc"
+
+  # --- the CI job's own forced-execution guard is the real defence ----------
+  # The acceptor deliberately does NOT re-derive "the workflow still forces
+  # execution" locally: that guard runs as a step of the `unit` job whose
+  # `success` is already a precondition here, so a weakened command cannot
+  # produce a green check to reuse. Pin that the guard exists, self-tests, and
+  # actually reddens on the weakened command — i.e. the constraint the acceptor
+  # leans on is real and not a story.
+  CHECKS=$((CHECKS + 1))
+  "$ROOT_DIR/scripts/check-ci-unit-forced-execution.py" --self-test >/dev/null 2>&1 ||
+    { printf 'FAIL: the CI Unit forced-execution guard fails its own self-test\n' >&2; return 1; }
+  "$ROOT_DIR/scripts/check-ci-unit-forced-execution.py" \
+    "$ROOT_DIR/.github/workflows/tests.yml" >/dev/null 2>&1 ||
+    { printf 'FAIL: the committed workflow does not force execution of the Unit test graph\n' >&2; return 1; }
+  sed 's/ --rerun-tasks//' "$ROOT_DIR/.github/workflows/tests.yml" > "$sandbox/weakened-tests.yml"
+  if "$ROOT_DIR/scripts/check-ci-unit-forced-execution.py" "$sandbox/weakened-tests.yml" >/dev/null 2>&1; then
+    printf 'FAIL: the forced-execution guard accepted a workflow with --rerun-tasks removed, so the acceptor cannot lean on it\n' >&2
+    return 1
+  fi
+  printf '  ok  %-52s\n' "the CI job's forced-execution guard is real and reddens"
+
+  # --- the acceptor's count check agrees with the #1646 guard ---------------
+  # The acceptor re-implements scripts/check-executed-test-counts.sh's coverage
+  # + floor rules (it cannot invoke it — see that script's header). Pin the two
+  # against each other on the same roots so they cannot drift: identical verdict
+  # on a healthy artifact, on a missing task, and on an all-skipped one.
+  local pin_case pin_artifact
+  for pin_case in "green:$artifact:0" "missing-task:$artifact_missing:1" "all-skipped:$artifact_skipped:1"; do
+    local pin_name="${pin_case%%:*}"
+    local pin_rest="${pin_case#*:}"
+    pin_artifact="${pin_rest%:*}"
+    local pin_expected="${pin_rest##*:}"
+    local pin_root="$sandbox/pin-$pin_name"
+    rm -rf "$pin_root"
+    pocketshell_ci_evidence_build_verify_root "$tree" "$pin_artifact" "$pin_root" ||
+      { printf 'FAIL: could not assemble the pin root for %s\n' "$pin_name" >&2; return 1; }
+    local mine=0 theirs=0
+    pocketshell_ci_evidence_check_counts "$pin_root" >/dev/null 2>&1 || mine=1
+    "$ROOT_DIR/scripts/check-executed-test-counts.sh" --root "$pin_root" >/dev/null 2>&1 || theirs=1
+    CHECKS=$((CHECKS + 1))
+    if [[ "$mine" != "$pin_expected" || "$theirs" != "$pin_expected" ]]; then
+      printf 'FAIL: count-check disagreement on %s (acceptor=%s, #1646 guard=%s, expected=%s)\n' \
+        "$pin_name" "$mine" "$theirs" "$pin_expected" >&2
+      return 1
+    fi
+    printf '  ok  %-52s (both=%s)\n' "count check agrees with #1646 guard: $pin_name" "$mine"
+  done
+
+  # --- RED: the explicit opt-out ---------------------------------------------
+  write_fixture_api "$api" "$sha" completed success "$sha" "$sha" success
+  CHECKS=$((CHECKS + 1))
+  rc=0
+  env POCKETSHELL_CI_EVIDENCE_GH="$stub" POCKETSHELL_CI_EVIDENCE_REPO="o/r" \
+    RELEASE_GATE_REUSE_CI_UNIT=0 \
+    bash "$ROOT_DIR/scripts/reuse-ci-unit-evidence.sh" \
+      --source-root "$tree" --tree-root "$tree" --out-dir "$sandbox/out-red-optout" \
+      > "$CASE_LOG" 2>&1 || rc=$?
+  [[ "$rc" -ne 0 ]] ||
+    { printf 'FAIL: RELEASE_GATE_REUSE_CI_UNIT=0 must decline\n' >&2; return 1; }
+  printf '  ok  %-52s (decline, rc=%s)\n' "RELEASE_GATE_REUSE_CI_UNIT=0 opt-out" "$rc"
+
+  # --- GREEN again, to prove none of the reds are permanent -----------------
+  expect_case accept "green again after every red case" \
+    run_case "$sandbox/out-green-2" || return 1
+  grep -q "ACCEPT: reusing the 'Unit tests' evidence" "$sandbox/out-green-2/../case.log" ||
+    { printf 'FAIL: the accepting run did not print its ACCEPT provenance line\n' >&2; return 1; }
+  [[ -s "$sandbox/out-green-2/evidence.txt" ]] ||
+    { printf 'FAIL: the accepting run wrote no evidence.txt\n' >&2; return 1; }
+
+  # This test asserts its OWN check count so it cannot itself pass vacuously
+  # (the #1646 convention).
+  if [[ "$CHECKS" -ne 28 ]]; then
+    printf 'FAIL: ran %s checks, expected 28\n' "$CHECKS" >&2
+    return 1
+  fi
+  printf 'PASS: reuse-ci-unit-evidence fail-closed matrix (%s checks)\n' "$CHECKS"
+}
+
+
+main() {
+  run_matrix
+}
+
+main "$@"


### PR DESCRIPTION
Closes #2064\n\nThis preserves one validated APK identity through every release install/publish stage and reuses only exact-SHA, completed Debug+Release CI unit evidence with nonzero task/test counts. It also records step timings and fail-closed reuse/identity provenance.\n\nReviewed evidence:\n- Authoritative default release run: 2,207 s versus 2,516 s baseline, saving 309 s / 12.28%.\n- APK identity suite 20/20, CI reuse suite 28/28, summary suite 10/10.\n- Exact reused unit evidence: Debug 6,188 + Release 6,176 = 12,364 tests.\n- All default emulator/Docker stages passed with exact APK identity.\n- Corrected same-APK visual pass contains 13 valid inspected screenshots; Conversation capture is populated and occurred after the completed first frame.\n- Independent APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2064#issuecomment-5255912462\n\nFinal current-main reconciliation:\n- Applied byte-exactly onto 46f74308; all 12 file hashes match the approved candidate.\n- Identity/reuse/summary suites, release execution-profile 90-check plus CI-invariance self-test, full-JVM profile 124-check self-test, memory 10-check guard, unit wiring 11-check self-test, forced execution 14-check self-test, validity/reference/file-size guards, Bash syntax, error-level ShellCheck, YAML parse, and diff checks all pass.