### PR TITLE
test infra: record connected-test signal provenance

### DIFF
--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -101,6 +101,17 @@ set -euo pipefail
 # The task defaults to :app:connectedDebugAndroidTest and is overridable per
 # --module (issue #798). The base package (no suffix) and release build are
 # never touched.
+#
+# Lifecycle diagnostics (issue #2004): each mutation run writes a mode-0600 log
+# under build/connected-test-lifecycle/ (override the directory with
+# POCKETSHELL_CONNECTED_TEST_LIFECYCLE_DIR). It records timestamps, PID/PPID/
+# process-group/session/cgroup metadata, lock ownership, scoped-child lifecycle,
+# and received/forwarded signals without command lines or environments. A Bash
+# trap does not receive Linux siginfo_t, so an external signal's sender PID is
+# fundamentally unavailable here; the log says so explicitly and must be
+# correlated with the parent orchestrator/system journal when attribution is
+# needed. SIGINT/SIGTERM remain hard failures and are never retried or translated
+# into a successful result.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
@@ -566,6 +577,141 @@ export POCKETSHELL_AVD_LOCK_FILE
 
 MUTATION_PID=""
 POCKETSHELL_AVD_OWNERSHIP_LOST=""
+POCKETSHELL_CONNECTED_TEST_SIGNAL_RC=0
+POCKETSHELL_CONNECTED_TEST_SIGNAL_SNAPSHOT_PENDING=0
+
+# Issue #2004: preserve enough wrapper-side lifecycle evidence to distinguish
+# "Gradle failed" from "the already-locked wrapper received an external
+# signal". Bash signal traps expose the signal name but NOT siginfo_t (and thus
+# not si_pid), so this deliberately records sender_pid=unavailable instead of
+# inventing attribution from PPID/session membership. The process snapshots use
+# PID metadata and comm only; command lines and environments are excluded
+# because Gradle runner arguments may contain credentials or other secrets.
+CONNECTED_TEST_LIFECYCLE_DIR="${POCKETSHELL_CONNECTED_TEST_LIFECYCLE_DIR:-$ROOT_DIR/build/connected-test-lifecycle}"
+CONNECTED_TEST_LIFECYCLE_LOG=""
+
+pocketshell_lifecycle_value() {
+  local value="${1:-unknown}"
+  value="${value//$'\n'/;}"
+  value="${value//$'\r'/;}"
+  value="${value//$'\t'/_}"
+  value="${value// /_}"
+  printf '%s' "$value"
+}
+
+pocketshell_lifecycle_log() {
+  local event="$1"
+  shift
+  [[ -n "$CONNECTED_TEST_LIFECYCLE_LOG" ]] || return 0
+  local timestamp line field
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ 2>/dev/null || printf 'unknown')"
+  line="timestamp=$timestamp event=$event"
+  for field in "$@"; do
+    line+=" $field"
+  done
+  printf '%s\n' "$line" >> "$CONNECTED_TEST_LIFECYCLE_LOG" 2>/dev/null || true
+}
+
+# Signal handlers can interrupt this script while Bash is suspended inside a
+# command substitution. Re-entering the general logger (which itself uses a
+# command substitution for `date`) can corrupt the interrupted parser state.
+# Keep trap-time persistence to Bash builtins only; richer /proc + systemd
+# snapshots run immediately after the child has observed the forwarded signal.
+pocketshell_lifecycle_signal_log() {
+  local event="$1"
+  shift
+  [[ -n "$CONNECTED_TEST_LIFECYCLE_LOG" ]] || return 0
+  local timestamp field
+  # Bash's %(...)T formatter otherwise obeys the caller's local timezone. The
+  # temporary TZ assignment and printf -v both stay inside the shell: no fork,
+  # command substitution, argument leakage, or pre-forwarding external work.
+  TZ=UTC0 printf -v timestamp '%(%Y-%m-%dT%H:%M:%SZ)T' -1
+  {
+    printf 'timestamp=%s event=%s' "$timestamp" "$event"
+    for field in "$@"; do
+      printf ' %s' "$field"
+    done
+    printf '\n'
+  } >> "$CONNECTED_TEST_LIFECYCLE_LOG" 2>/dev/null || true
+}
+
+pocketshell_lifecycle_process_snapshot() {
+  local pid="${1:-}" role="${2:-unknown}"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+  local process_line ppid="unavailable" pgid="unavailable" sid="unavailable"
+  local state="unavailable" comm="unavailable" cgroup="unavailable"
+  process_line="$(ps -o ppid=,pgid=,sid=,stat=,comm= -p "$pid" 2>/dev/null || true)"
+  if [[ -n "$process_line" ]]; then
+    read -r ppid pgid sid state comm <<< "$process_line" || true
+  fi
+  if [[ -r "/proc/$pid/cgroup" ]]; then
+    cgroup="$(tr '\n' ';' < "/proc/$pid/cgroup" 2>/dev/null || true)"
+    [[ -n "$cgroup" ]] || cgroup="unavailable"
+  fi
+  pocketshell_lifecycle_log process_snapshot \
+    "pid=$pid" \
+    "ppid=$(pocketshell_lifecycle_value "$ppid")" \
+    "pgid=$(pocketshell_lifecycle_value "$pgid")" \
+    "sid=$(pocketshell_lifecycle_value "$sid")" \
+    "comm=$(pocketshell_lifecycle_value "$comm")" \
+    "state=$(pocketshell_lifecycle_value "$state")" \
+    "role=$(pocketshell_lifecycle_value "$role")"
+  pocketshell_lifecycle_log cgroup_snapshot \
+    "pid=$pid" \
+    "cgroup=$(pocketshell_lifecycle_value "$cgroup")" \
+    "role=$(pocketshell_lifecycle_value "$role")"
+}
+
+pocketshell_lifecycle_scope_snapshot() {
+  local state="unavailable"
+  if [[ -n "${SCOPE_UNIT:-}" ]] && command -v systemctl >/dev/null 2>&1; then
+    state="$(timeout 2s systemctl --user show "$SCOPE_UNIT.scope" \
+      --property=ActiveState,SubState,Result,MainPID,ControlGroup \
+      --value 2>/dev/null | tr '\n' ',' || true)"
+    [[ -n "$state" ]] || state="unavailable"
+  fi
+  pocketshell_lifecycle_log scope_snapshot \
+    "scope=$(pocketshell_lifecycle_value "${SCOPE_UNIT:-unassigned}")" \
+    "state=$(pocketshell_lifecycle_value "$state")"
+}
+
+pocketshell_lifecycle_snapshot_tree() {
+  pocketshell_lifecycle_process_snapshot "$$" wrapper
+  pocketshell_lifecycle_process_snapshot "$PPID" parent
+  if [[ -n "$MUTATION_PID" ]]; then
+    pocketshell_lifecycle_process_snapshot "$MUTATION_PID" mutation_child
+    local descendant
+    while IFS= read -r descendant; do
+      [[ -n "$descendant" ]] || continue
+      pocketshell_lifecycle_process_snapshot "$descendant" mutation_descendant
+    done < <(ps -o pid= --ppid "$MUTATION_PID" 2>/dev/null | awk '{ print $1 }')
+  fi
+  pocketshell_lifecycle_scope_snapshot
+}
+
+pocketshell_lifecycle_init() {
+  mkdir -p "$CONNECTED_TEST_LIFECYCLE_DIR" 2>/dev/null || return 0
+  chmod 700 "$CONNECTED_TEST_LIFECYCLE_DIR" 2>/dev/null || true
+  local started_at token
+  started_at="$(date -u +%Y%m%dT%H%M%S 2>/dev/null || printf 'unknown')"
+  token="${SUFFIX:-base}-${ANDROID_SERIAL:-unknown}-$$"
+  token="${token//[^A-Za-z0-9._-]/_}"
+  CONNECTED_TEST_LIFECYCLE_LOG="$(mktemp \
+    --tmpdir="$CONNECTED_TEST_LIFECYCLE_DIR" \
+    --suffix=.log \
+    "$started_at-$token.XXXXXX" 2>/dev/null || true)"
+  if [[ -z "$CONNECTED_TEST_LIFECYCLE_LOG" ]]; then
+    CONNECTED_TEST_LIFECYCLE_LOG=""
+    return 0
+  fi
+  chmod 600 "$CONNECTED_TEST_LIFECYCLE_LOG" 2>/dev/null || true
+  pocketshell_lifecycle_log wrapper_started \
+    "wrapper_pid=$$" "parent_pid=$PPID" \
+    "sender_pid=unavailable" \
+    "sender_limit=bash_traps_do_not_expose_kernel_siginfo"
+  pocketshell_lifecycle_snapshot_tree
+  printf 'Connected-test lifecycle log: %s\n' "$CONNECTED_TEST_LIFECYCLE_LOG" >&2
+}
 
 pocketshell_collect_descendant_pids_postorder() {
   local pid="$1"
@@ -636,7 +782,17 @@ pocketshell_run_guarded_mutation() {
 
   pocketshell_start_without_avd_lock_fd "$@"
   local child_pid="$POCKETSHELL_AVD_CHILD_PID"
+  local mutation_lock="${POCKETSHELL_AVD_LOCK_FILE:-unavailable}"
+  mutation_lock="${mutation_lock// /_}"
   MUTATION_PID="$child_pid"
+  pocketshell_lifecycle_signal_log mutation_started \
+    "child_pid=$child_pid" \
+    "child_state=spawned" \
+    "lock_file=$mutation_lock"
+  # Do not run the multi-command /proc snapshot here: the child may publish its
+  # test-ready boundary immediately, and an external TERM can then interrupt
+  # Bash while it is expanding that snapshot. Trap-time logging stays builtin-
+  # only; the rich child/scope snapshot is taken after signal forwarding below.
   local ownership_lost=0
   while kill -0 "$child_pid" 2>/dev/null; do
     if ! pocketshell_assert_avd_lock_owned "$POCKETSHELL_AVD_LOCK_FILE"; then
@@ -655,6 +811,13 @@ pocketshell_run_guarded_mutation() {
 
   local child_rc=0
   wait "$child_pid" || child_rc=$?
+  pocketshell_lifecycle_log mutation_finished \
+    "child_pid=$child_pid" "child_rc=$child_rc" \
+    "ownership_lost=${ownership_lost:-0}"
+  if (( POCKETSHELL_CONNECTED_TEST_SIGNAL_SNAPSHOT_PENDING != 0 )); then
+    pocketshell_lifecycle_snapshot_tree
+    POCKETSHELL_CONNECTED_TEST_SIGNAL_SNAPSHOT_PENDING=0
+  fi
   MUTATION_PID=""
   if (( ownership_lost == 1 )); then
     return 70
@@ -929,8 +1092,17 @@ cleanup_suffixed_packages() {
 
 # Acquire the AVD lock for BOTH cleanup and test runs so the sweep cannot race
 # a sibling's install/test on the same device.
+pocketshell_lifecycle_init
 pocketshell_acquire_avd_lock "$ROOT_DIR"
 pocketshell_assert_avd_lock_owned "$POCKETSHELL_AVD_LOCK_FILE"
+pocketshell_lifecycle_log avd_lock_acquired \
+  "wrapper_pid=$$" \
+  "lock_file=$(pocketshell_lifecycle_value "${POCKETSHELL_AVD_LOCK_FILE:-unavailable}")" \
+  "lock_fd=$(pocketshell_lifecycle_value "${POCKETSHELL_AVD_LOCK_FD:-unavailable}")" \
+  "lock_owner_pid=$(pocketshell_lifecycle_value "${POCKETSHELL_AVD_LOCK_OWNER_PID:-unavailable}")" \
+  "lock_holder_pid=$(pocketshell_lifecycle_value "${POCKETSHELL_AVD_LOCK_HOLDER_PID:-unavailable}")" \
+  "android_serial=$(pocketshell_lifecycle_value "${ANDROID_SERIAL:-unavailable}")"
+pocketshell_lifecycle_snapshot_tree
 
 if [[ "$CLEANUP_ONLY" == "1" ]]; then
   cleanup_suffixed_packages
@@ -1038,6 +1210,20 @@ NOTIFICATION_PERMISSION_TARGET_APK="$NOTIFICATION_PERMISSION_BUILD_DIR/outputs/a
 # shellcheck disable=SC2317
 pocketshell_connected_test_exit_cleanup() {
   local original_rc=$?
+  pocketshell_lifecycle_log wrapper_exit \
+    "rc=$original_rc" \
+    "received_wrapper_signal_rc=$POCKETSHELL_CONNECTED_TEST_SIGNAL_RC" \
+    "active_child_pid=$(pocketshell_lifecycle_value "${MUTATION_PID:-none}")" \
+    "lock_file=$(pocketshell_lifecycle_value "${POCKETSHELL_AVD_LOCK_FILE:-unavailable}")" \
+    "lock_fd=$(pocketshell_lifecycle_value "${POCKETSHELL_AVD_LOCK_FD:-unavailable}")"
+  if (( POCKETSHELL_CONNECTED_TEST_SIGNAL_RC != 0 )); then
+    printf 'CONNECTED_TEST_SIGNAL_EXIT rc=%s lifecycle_log=%s\n' \
+      "$original_rc" "${CONNECTED_TEST_LIFECYCLE_LOG:-unavailable}" >&2
+  elif (( original_rc > 128 )); then
+    printf 'CONNECTED_TEST_CHILD_SIGNAL_EXIT rc=%s received_wrapper_signal=none lifecycle_log=%s\n' \
+      "$original_rc" "${CONNECTED_TEST_LIFECYCLE_LOG:-unavailable}" >&2
+  fi
+  pocketshell_lifecycle_snapshot_tree
   if [[ -n "${CONNECTED_EVIDENCE_DIR:-}" && -n "${CONNECTED_EVIDENCE_STARTED_AT:-}" ]]; then
     local evidence_port evidence_container evidence_final_identity evidence_output_root
     evidence_port="${POCKETSHELL_AGENTS_PORT:-2222}"
@@ -1114,9 +1300,42 @@ SCOPE_UNIT="pocketshell-test-${SCOPE_TOKEN//[^A-Za-z0-9._-]/_}-${SCOPE_SERIAL//[
 # shellcheck disable=SC2317
 forward_signal() {
   local sig="$1"
-  if [[ -n "$MUTATION_PID" ]]; then
-    kill -s "$sig" "$MUTATION_PID" 2>/dev/null || true
+  local child_pid="${MUTATION_PID:-}" child_state="none" forward_result="no_active_child"
+  case "$sig" in
+    INT) POCKETSHELL_CONNECTED_TEST_SIGNAL_RC=130 ;;
+    TERM) POCKETSHELL_CONNECTED_TEST_SIGNAL_RC=143 ;;
+  esac
+  if [[ -n "$child_pid" ]]; then
+    if pocketshell_process_is_running "$child_pid"; then
+      child_state="running"
+    else
+      child_state="exited"
+    fi
   fi
+  POCKETSHELL_CONNECTED_TEST_SIGNAL_SNAPSHOT_PENDING=1
+  pocketshell_lifecycle_signal_log signal_received \
+    "signal=$sig" \
+    "child_pid=${child_pid:-none}" \
+    "child_state=$child_state" \
+    "sender_pid=unavailable" \
+    "sender_limit=bash_traps_do_not_expose_kernel_siginfo"
+  printf 'CONNECTED_TEST_SIGNAL_RECEIVED signal=%s wrapper_pid=%s child_pid=%s child_state=%s sender_pid=unavailable lifecycle_log=%s\n' \
+    "$sig" "$$" "${child_pid:-none}" "$child_state" \
+    "${CONNECTED_TEST_LIFECYCLE_LOG:-unavailable}" >&2
+  if [[ -n "$MUTATION_PID" ]]; then
+    if kill -s "$sig" "$MUTATION_PID" 2>/dev/null; then
+      forward_result="sent"
+    else
+      forward_result="already_exited"
+    fi
+  fi
+  pocketshell_lifecycle_signal_log signal_forwarded \
+    "signal=$sig" \
+    "child_pid=${child_pid:-none}" \
+    "forward_result=$forward_result" \
+    "child_state_before=$child_state"
+  printf 'CONNECTED_TEST_SIGNAL_FORWARDED signal=%s child_pid=%s result=%s\n' \
+    "$sig" "${child_pid:-none}" "$forward_result" >&2
 }
 trap 'forward_signal INT' INT
 trap 'forward_signal TERM' TERM
@@ -1208,5 +1427,15 @@ fi
 # Only a claimed pool lane has a fingerprint, so single-lane / CI runs are
 # untouched (the helper returns 0 when there is nothing to compare).
 rc="$(pocketshell_agents_final_rc "$rc")"
+
+# A trapped external INT/TERM is always a hard failure even if a wrapper child
+# races to report zero while the trap is forwarding the signal. Enforce this
+# after every result classifier so nothing can translate an interrupted attempt
+# into green (or into a different wrapper verdict). No work is retried.
+if (( POCKETSHELL_CONNECTED_TEST_SIGNAL_RC != 0 )); then
+  pocketshell_lifecycle_log signal_rc_enforced \
+    "child_rc=$rc" "wrapper_rc=$POCKETSHELL_CONNECTED_TEST_SIGNAL_RC"
+  rc="$POCKETSHELL_CONNECTED_TEST_SIGNAL_RC"
+fi
 
 exit "$rc"

--- a/tests/scripts/connected-test-serial-ownership-test.sh
+++ b/tests/scripts/connected-test-serial-ownership-test.sh
@@ -45,6 +45,15 @@ fail() {
   exit 1
 }
 
+lifecycle_event_epoch() {
+  local lifecycle_log="$1" event="$2" timestamp
+  timestamp="$(sed -n "s/^timestamp=\([^ ]*\) event=$event\([[:space:]].*\)\{0,1\}$/\1/p" \
+    "$lifecycle_log" | tail -1)"
+  [[ -n "$timestamp" ]] || fail "lifecycle log has no timestamp for event=$event"
+  date -u --date="$timestamp" +%s 2>/dev/null \
+    || fail "lifecycle event=$event has an unparsable UTC timestamp: $timestamp"
+}
+
 wait_for_file() {
   local target="$1" timeout="${2:-10}"
   local waited=0 limit=$((timeout * 20))
@@ -376,6 +385,7 @@ start_wrapper() {
   [[ -n "$test_class" ]] && extra_args=("--tests" "$test_class")
 
   setsid env \
+    TZ="${FAKE_WRAPPER_TZ:-${TZ:-UTC0}}" \
     PATH="$sandbox/bin:$PATH" \
     ADB="$sandbox/bin/adb" \
     ANDROID_SDK="$sandbox" \
@@ -387,6 +397,8 @@ start_wrapper() {
     POCKETSHELL_AGENTS_POOL_PORTS=2243 \
     POCKETSHELL_AGENTS_WAIT_SECONDS=0 \
     POCKETSHELL_TEST_MEM=1G \
+    POCKETSHELL_CONNECTED_TEST_LIFECYCLE_DIR="$sandbox/lifecycle" \
+    FAKE_LIFECYCLE_SECRET=SuperSecretEnvironmentValue2004 \
     FAKE_DEFAULT_SERIAL="${online_serials%% *}" \
     FAKE_ONLINE_SERIALS="$online_serials" \
     FAKE_DEVICE_STATE="$sandbox/device-state" \
@@ -1010,6 +1022,133 @@ hard_killed_toxiproxy_holder_leaves_no_descendant_flock() {
   kill_group "$wrapper_pid"
 }
 
+term_after_lock_records_lifecycle_and_preserves_rc143() {
+  local sandbox="$1"
+  make_sandbox "$sandbox"
+
+  local wrapper_pid wrapper_rc=0 lifecycle_log child_pid
+  local controller_started_utc controller_before_signal_utc controller_after_exit_utc
+  local wrapper_timezone="${ISSUE2004_WRAPPER_TZ:-Europe/Berlin}"
+  controller_started_utc="$(date -u +%s)"
+  FAKE_WRAPPER_TZ="$wrapper_timezone" start_wrapper "$sandbox" legacy termdiag i2004 \
+    emulator-5554 "" emulator-5554 8 0 2222 SuperSecretRunnerArgument2004
+  wrapper_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/termdiag.started" 10 \
+    || { kill_group "$wrapper_pid"; fail "TERM provenance run never reached its locked mutation window"; }
+
+  controller_before_signal_utc="$(date -u +%s)"
+  kill -TERM "$wrapper_pid"
+  wait "$wrapper_pid" || wrapper_rc=$?
+  controller_after_exit_utc="$(date -u +%s)"
+
+  lifecycle_log="$(find "$sandbox/lifecycle" -maxdepth 1 -type f -name '*.log' -print -quit 2>/dev/null || true)"
+  if [[ "$wrapper_rc" != "143" ]]; then
+    printf '%s\n' '--- wrapper stderr ---' >&2
+    sed -n '1,240p' "$sandbox/termdiag.err" >&2 || true
+    printf '%s\n' '--- lifecycle log ---' >&2
+    [[ -n "$lifecycle_log" ]] && sed -n '1,240p' "$lifecycle_log" >&2
+    fail "externally TERM-terminated wrapper changed hard-failure semantics (rc=$wrapper_rc, want 143)"
+  fi
+  [[ -n "$lifecycle_log" ]] \
+    || fail "TERM after AVD lock acquisition left no persistent wrapper lifecycle/provenance log"
+  grep -Eq 'event=avd_lock_acquired .*wrapper_pid=[0-9]+ .*lock_file=.*avd-lock-emulator-5554 .*lock_fd=[0-9]+' "$lifecycle_log" \
+    || fail "lifecycle log does not identify the wrapper and acquired AVD lock/FD"
+  grep -Eq 'event=avd_lock_acquired .*lock_owner_pid=[0-9]+ .*lock_holder_pid=[0-9]+ .*android_serial=emulator-5554' "$lifecycle_log" \
+    || fail "lifecycle log does not identify lock owner/helper and selected serial"
+  grep -Eq 'event=mutation_started .*child_pid=[0-9]+' "$lifecycle_log" \
+    || fail "lifecycle log does not identify the active scoped child"
+  child_pid="$(sed -n 's/.*event=mutation_started .*child_pid=\([0-9][0-9]*\).*/\1/p' "$lifecycle_log" | tail -1)"
+  [[ -n "$child_pid" ]] || fail "could not recover child PID from lifecycle log"
+  grep -Eq "event=signal_received .*signal=TERM .*child_pid=$child_pid .*child_state=(running|exited)" "$lifecycle_log" \
+    || fail "lifecycle log does not capture the TERM boundary and active child PID"
+  grep -Eq "event=signal_forwarded .*signal=TERM .*child_pid=$child_pid .*forward_result=(sent|already_exited) .*child_state_before=(running|exited)" "$lifecycle_log" \
+    || fail "lifecycle log does not capture TERM forwarding outcome"
+  grep -Eq "event=mutation_finished .*child_pid=$child_pid .*child_rc=143" "$lifecycle_log" \
+    || fail "lifecycle log does not capture the TERM-terminated child's final status"
+  grep -Eq 'event=wrapper_exit .*rc=143 .*received_wrapper_signal_rc=143' "$lifecycle_log" \
+    || fail "lifecycle log does not preserve the wrapper's final rc143"
+  grep -Eq 'sender_pid=unavailable' "$lifecycle_log" \
+    || fail "diagnostics must state that bash traps cannot recover the external signal sender PID"
+  if grep -Eq 'sender_pid=[0-9]+' "$lifecycle_log"; then
+    fail "diagnostics invented a sender PID unavailable to a bash signal trap"
+  fi
+  if grep -Fq 'SuperSecretRunnerArgument2004' "$lifecycle_log"; then
+    fail "lifecycle diagnostics exposed a Gradle/runner argument instead of PID-only metadata"
+  fi
+  if grep -Fq 'SuperSecretEnvironmentValue2004' "$lifecycle_log"; then
+    fail "lifecycle diagnostics exposed an environment value instead of PID-only metadata"
+  fi
+  grep -Eq 'event=process_snapshot .*pid=[0-9]+ .*ppid=[0-9]+ .*pgid=[0-9]+ .*sid=[0-9]+ .*comm=' "$lifecycle_log" \
+    || fail "lifecycle log lacks the non-secret PID/PPID/session process snapshot"
+  grep -Eq 'event=cgroup_snapshot .*pid=[0-9]+ .*cgroup=' "$lifecycle_log" \
+    || fail "lifecycle log lacks best-effort cgroup state"
+  grep -Eq 'event=scope_snapshot .*scope=pocketshell-test-.* .*state=' "$lifecycle_log" \
+    || fail "lifecycle log lacks best-effort transient-scope state"
+  awk 'NF && $1 !~ /^timestamp=[0-9]{4}-[0-9]{2}-[0-9]{2}T/ { exit 1 }' "$lifecycle_log" \
+    || fail "a lifecycle record has no UTC timestamp"
+
+  # Load-bearing UTC proof: the wrapper is deliberately in Europe/Berlin while
+  # this harness records ordinary UTC boundaries. Every trap-time and ordinary
+  # record must still correlate with that controller window, and the mixed
+  # record stream must remain monotonic. A local-time value with a literal Z is
+  # two hours in the future here and fails this assertion.
+  local mutation_started_utc signal_received_utc signal_forwarded_utc
+  local mutation_finished_utc wrapper_exit_utc
+  mutation_started_utc="$(lifecycle_event_epoch "$lifecycle_log" mutation_started)"
+  signal_received_utc="$(lifecycle_event_epoch "$lifecycle_log" signal_received)"
+  signal_forwarded_utc="$(lifecycle_event_epoch "$lifecycle_log" signal_forwarded)"
+  mutation_finished_utc="$(lifecycle_event_epoch "$lifecycle_log" mutation_finished)"
+  wrapper_exit_utc="$(lifecycle_event_epoch "$lifecycle_log" wrapper_exit)"
+  if (( mutation_started_utc < controller_started_utc \
+        || wrapper_exit_utc > controller_after_exit_utc \
+        || signal_received_utc < controller_before_signal_utc \
+        || signal_received_utc > controller_after_exit_utc \
+        || signal_forwarded_utc < controller_before_signal_utc \
+        || signal_forwarded_utc > controller_after_exit_utc )); then
+    fail "mixed lifecycle records do not correlate with the controller's real UTC window (controller=$controller_started_utc..$controller_after_exit_utc signal_boundary=$controller_before_signal_utc events=$mutation_started_utc,$signal_received_utc,$signal_forwarded_utc,$mutation_finished_utc,$wrapper_exit_utc TZ=$wrapper_timezone)"
+  fi
+  if (( mutation_started_utc > signal_received_utc \
+        || signal_received_utc > signal_forwarded_utc \
+        || signal_forwarded_utc > mutation_finished_utc \
+        || mutation_finished_utc > wrapper_exit_utc )); then
+    fail "mixed ordinary/trap lifecycle timestamps are not monotonic UTC (events=$mutation_started_utc,$signal_received_utc,$signal_forwarded_utc,$mutation_finished_utc,$wrapper_exit_utc TZ=$wrapper_timezone)"
+  fi
+  grep -Eq "CONNECTED_TEST_SIGNAL_RECEIVED signal=TERM wrapper_pid=[0-9]+ child_pid=$child_pid child_state=(running|exited) sender_pid=unavailable lifecycle_log=" "$sandbox/termdiag.err" \
+    || fail "caller stderr does not retain the received-signal boundary when the wrapper dies"
+  grep -Eq "CONNECTED_TEST_SIGNAL_FORWARDED signal=TERM child_pid=$child_pid result=(sent|already_exited)" "$sandbox/termdiag.err" \
+    || fail "caller stderr does not retain the forwarded-signal outcome"
+  grep -Eq 'CONNECTED_TEST_SIGNAL_EXIT rc=143 lifecycle_log=' "$sandbox/termdiag.err" \
+    || fail "caller stderr does not retain final rc143 and the persistent-log location"
+  if grep -q 'CONNECTED_TEST_CHILD_SIGNAL_EXIT' "$sandbox/termdiag.err"; then
+    fail "wrapper-owned TERM was mislabeled as an unattributed child-only signal exit"
+  fi
+
+  # Adjacent attribution control: the same rc143 originating in the child (no
+  # TERM delivered to the wrapper) must not claim a wrapper signal boundary.
+  local child_only_pid child_only_rc=0 child_only_log
+  start_wrapper "$sandbox" legacy childterm i2004child \
+    emulator-5554 "" emulator-5554 8 143
+  child_only_pid="$WRAPPER_PID"
+  wait_for_file "$sandbox/device-state/childterm.started" 10 \
+    || { kill_group "$child_only_pid"; fail "child-only rc143 attribution control never started"; }
+  touch "$sandbox/device-state/childterm.release"
+  wait "$child_only_pid" || child_only_rc=$?
+  [[ "$child_only_rc" == "143" ]] \
+    || fail "child-only rc143 attribution control changed result (rc=$child_only_rc)"
+  child_only_log="$(find "$sandbox/lifecycle" -maxdepth 1 -type f -name '*i2004child*.log' -print -quit 2>/dev/null || true)"
+  [[ -n "$child_only_log" ]] || fail "child-only rc143 control left no lifecycle log"
+  grep -Eq 'event=wrapper_exit .*rc=143 .*received_wrapper_signal_rc=0' "$child_only_log" \
+    || fail "child-only rc143 was not distinguished from a wrapper-received signal"
+  if grep -q 'event=signal_received' "$child_only_log"; then
+    fail "child-only rc143 invented a wrapper signal-receipt event"
+  fi
+  grep -Eq 'CONNECTED_TEST_CHILD_SIGNAL_EXIT rc=143 received_wrapper_signal=none lifecycle_log=' "$sandbox/childterm.err" \
+    || fail "caller stderr does not distinguish child rc143 from wrapper TERM"
+  if grep -q 'CONNECTED_TEST_SIGNAL_RECEIVED' "$sandbox/childterm.err"; then
+    fail "child-only rc143 stderr invented an external wrapper TERM"
+  fi
+}
+
 run_case() {
   local name="$1" sandbox
   sandbox="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-serial-owner.XXXXXX")"
@@ -1038,6 +1177,7 @@ CASES=(
   hard_killed_agents_docker_up_leaves_no_descendant_flock
   hard_killed_agents_docker_health_leaves_no_descendant_flock
   hard_killed_toxiproxy_holder_leaves_no_descendant_flock
+  term_after_lock_records_lifecycle_and_preserves_rc143
 )
 if [[ $# -gt 0 ]]; then
   CASES=("$@")


### PR DESCRIPTION
Closes #2004.

Records durable, mode-0600 wrapper lifecycle evidence after the AVD lock is acquired, distinguishes wrapper-received TERM/INT from child-only signal exits, forwards signals without retry or success translation, and keeps diagnostics free of command-line/environment secrets.

Verification:
- Independent reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2004#issuecomment-5256472791
- Exact-current isolated ownership harness: 16/16 PASS
- Europe/Berlin and Pacific/Kiritimati UTC correlation proofs
- Selective local-time-with-literal-Z mutation fails the UTC window
- Canonical reviewer-audited full JVM gate: 12,364 tests, 0 failures/errors/skips
- bash syntax, ShellCheck, diff check, validity/reference/file-size/interpreter and adjacent AVD/notification/output-lock guards pass