### PR TITLE
test infra: repoke every session-picker consumer

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackThenOpenSecondSessionReusesWarmLeaseE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackThenOpenSecondSessionReusesWarmLeaseE2eTest.kt
@@ -21,9 +21,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
-import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
 import com.pocketshell.app.projects.FOLDER_LIST_PULL_TO_REFRESH_TAG
 import com.pocketshell.app.projects.SshFolderListGateway
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.SSH_HANDSHAKE_ATTEMPTS
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
@@ -182,7 +182,12 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
             rule = compose,
             sessionName = SESSION_A,
             timeoutMs = pickerWaitMs,
-            onRepoke = { repokeFolderListFromHostRow(hostRowTag) },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
         )
         compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
@@ -198,7 +203,17 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
         // ---- (2) BACK to the picker. A's transport + lease stay LIVE (the VM is
         // activity-scoped; Back runs no teardown).
         clickTmuxBack()
-        waitForSessionInPicker(rule = compose, sessionName = SESSION_B, timeoutMs = pickerWaitMs)
+        waitForSessionInPicker(
+            rule = compose,
+            sessionName = SESSION_B,
+            timeoutMs = pickerWaitMs,
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
+        )
 
         // ---- (3) ARM exactly one forced poll-time stale-channel symptom, then
         // trigger a picker discovery reconcile over the shared lease via the
@@ -272,7 +287,17 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
             ) {
                 clickTmuxBack()
             }
-            waitForSessionInPicker(rule = compose, sessionName = SESSION_B, timeoutMs = pickerWaitMs)
+            waitForSessionInPicker(
+                rule = compose,
+                sessionName = SESSION_B,
+                timeoutMs = pickerWaitMs,
+                onRepoke = {
+                    repokeSessionPickerFromHostRow(
+                        rule = compose,
+                        hostRowTag = hostRowTag,
+                    )
+                },
+            )
             compose.onNodeWithText(SESSION_B, useUnmergedTree = true).performClick()
             compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
             // Sample the Connecting overlay while B's content lands.
@@ -481,31 +506,6 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
                     .fetchSemanticsNodes()
                     .isNotEmpty()
             }.getOrDefault(false)
-        }
-    }
-
-    /**
-     * Issue #740 first-open enumeration-stall recovery: pop Back to the host
-     * list (via the folder-list back affordance), wait for the host row, then
-     * re-tap it to re-trigger the warm-lease acquire + `tmux list-sessions`
-     * enumeration. Re-opens the SAME host's picker so the picker readiness polls
-     * stay valid. Best-effort — guarded so a transient missing affordance never
-     * throws out of the watchdog.
-     */
-    private fun repokeFolderListFromHostRow(hostRowTag: String) {
-        runCatching {
-            if (compose.onAllNodesWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            ) {
-                compose.onNodeWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true).performClick()
-            }
-            compose.waitUntil(timeoutMillis = 10_000) {
-                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ComposerAlwaysPresentSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ComposerAlwaysPresentSwitchJourneyE2eTest.kt
@@ -19,8 +19,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
-import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_FULL_CHROME_BACK_BUTTON_TAG
@@ -172,6 +172,7 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
                 step = index + 1,
                 fromSession = previousSession,
                 toSession = target,
+                hostRowTag = hostRowTag,
             )
             previousSession = target
         }
@@ -195,14 +196,19 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
      * -> named-row tap, wait for the target to land, then assert the composer
      * launcher is present + contained.
      */
-    private fun switchAndAssertComposer(step: Int, fromSession: String, toSession: String) {
+    private fun switchAndAssertComposer(
+        step: Int,
+        fromSession: String,
+        toSession: String,
+        hostRowTag: String,
+    ) {
         val toMarker = requireNotNull(expectedMarker[toSession]) {
             "no tracked marker for $toSession"
         }
         Log.i(LOG_TAG, "composer-switch step=$step $fromSession -> $toSession")
         val switchAt = SystemClock.elapsedRealtime()
 
-        switchToSessionViaBackTap(toSession, toMarker, "step$step")
+        switchToSessionViaBackTap(toSession, toMarker, "step$step", hostRowTag)
 
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
@@ -429,25 +435,13 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
             rule = compose,
             sessionName = SESSION_AGENT,
             timeoutMs = pickerWaitMs,
-            onRepoke = { repokeFolderListFromHostRow(hostRowTag) },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
         )
-    }
-
-    private fun repokeFolderListFromHostRow(hostRowTag: String) {
-        runCatching {
-            if (compose.onAllNodesWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            ) {
-                compose.onNodeWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true).performClick()
-            }
-            compose.waitUntil(timeoutMillis = 10_000) {
-                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        }
     }
 
     private fun forceFlatHostDetailViewMode() {
@@ -459,13 +453,28 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
             .commit()
     }
 
-    private fun switchToSessionViaBackTap(toSession: String, toMarker: String, label: String) {
+    private fun switchToSessionViaBackTap(
+        toSession: String,
+        toMarker: String,
+        label: String,
+        hostRowTag: String,
+    ) {
         val deadline = SystemClock.elapsedRealtime() + SWITCH_DEADLINE_MS
         var attempts = 0
         while (SystemClock.elapsedRealtime() < deadline) {
             attempts += 1
             clickTmuxBack()
-            waitForSessionInPicker(rule = compose, sessionName = toSession, timeoutMs = pickerWaitMs)
+            waitForSessionInPicker(
+                rule = compose,
+                sessionName = toSession,
+                timeoutMs = pickerWaitMs,
+                onRepoke = {
+                    repokeSessionPickerFromHostRow(
+                        rule = compose,
+                        hostRowTag = hostRowTag,
+                    )
+                },
+            )
             compose.onNodeWithText(toSession, useUnmergedTree = true).performClick()
             compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
             val landed = runCatching {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
@@ -28,8 +28,8 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
-import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
 import com.pocketshell.app.proof.signals.MainThreadResponsivenessProbe
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.SSH_HANDSHAKE_ATTEMPTS
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
@@ -1093,7 +1093,17 @@ class MultiSessionSwitchJourneyE2eTest {
         var landed = false
         while (!landed && SystemClock.elapsedRealtime() < landDeadline) {
             clickTmuxBack()
-            waitForSessionInPicker(rule = compose, sessionName = toSession, timeoutMs = pickerWaitMs)
+            waitForSessionInPicker(
+                rule = compose,
+                sessionName = toSession,
+                timeoutMs = pickerWaitMs,
+                onRepoke = {
+                    repokeSessionPickerFromHostRow(
+                        rule = compose,
+                        hostRowTag = hostRowTag,
+                    )
+                },
+            )
             compose.onNodeWithText(toSession, useUnmergedTree = true).performClick()
             compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
             val settleDeadline = SystemClock.elapsedRealtime() + SWITCH_LAND_RETRY_MS
@@ -1760,36 +1770,13 @@ class MultiSessionSwitchJourneyE2eTest {
             rule = compose,
             sessionName = SESSION_A,
             timeoutMs = pickerWaitMs,
-            onRepoke = { repokeFolderListFromHostRow(hostRowTag) },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
         )
-    }
-
-    /**
-     * Issue #740 test-only recovery for a first-open enumeration stall (the
-     * awaited row absent, no error panel) on the FIRST host-detail folder-list
-     * open: pop Back to the host list (via the folder-list back affordance),
-     * wait for the host row, then re-tap it to re-trigger the warm-lease
-     * acquire + `tmux list-sessions` enumeration.
-     * Re-opens the SAME host's picker so [waitForSessionInPicker]'s polls stay
-     * valid. Best-effort — guarded so a transient missing affordance never
-     * throws out of the watchdog (the helper's own deadline remains the
-     * load-bearing bound).
-     */
-    private fun repokeFolderListFromHostRow(hostRowTag: String) {
-        runCatching {
-            if (compose.onAllNodesWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            ) {
-                compose.onNodeWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true).performClick()
-            }
-            compose.waitUntil(timeoutMillis = 10_000) {
-                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        }
     }
 
     private fun forceFlatHostDetailViewMode() {
@@ -1818,6 +1805,12 @@ class MultiSessionSwitchJourneyE2eTest {
                 rule = compose,
                 sessionName = toSession,
                 timeoutMs = pickerWaitMs,
+                onRepoke = {
+                    repokeSessionPickerFromHostRow(
+                        rule = compose,
+                        hostRowTag = hostRowTag,
+                    )
+                },
             )
             compose.onNodeWithText(toSession, useUnmergedTree = true).performClick()
             compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ProjectSwitcherDropdownE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ProjectSwitcherDropdownE2eTest.kt
@@ -19,6 +19,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.sessions.SSH_SOURCE_FOLDER_LIST_PROBE
 import com.pocketshell.app.sessions.SSH_SOURCE_SESSION_PICKER_LIST
@@ -109,7 +110,17 @@ class ProjectSwitcherDropdownE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        waitForSessionInPicker(rule = compose, sessionName = SESSION_B, timeoutMs = readyWaitMs)
+        waitForSessionInPicker(
+            rule = compose,
+            sessionName = SESSION_B,
+            timeoutMs = readyWaitMs,
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
+        )
         compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
@@ -173,10 +173,21 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
      * BODY + visible text tree that B (and only B) is shown.
      */
     private fun switchToBAndAssertCorrectSessionBody(step: Int) {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
         Log.i(LOG_TAG, "switch step=$step $SESSION_A -> $SESSION_B")
         val switchAt = SystemClock.elapsedRealtime()
         clickTmuxBack()
-        waitForSessionInPicker(rule = compose, sessionName = SESSION_B, timeoutMs = pickerWaitMs)
+        waitForSessionInPicker(
+            rule = compose,
+            sessionName = SESSION_B,
+            timeoutMs = pickerWaitMs,
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
+        )
         compose.onNodeWithText(SESSION_B, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
@@ -250,8 +261,19 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
     }
 
     private fun switchBackToA(step: Int) {
+        val hostRowTag = requireNotNull(seededHostRowTag) { "seed-before-launch host row missing" }
         clickTmuxBack()
-        waitForSessionInPicker(rule = compose, sessionName = SESSION_A, timeoutMs = pickerWaitMs)
+        waitForSessionInPicker(
+            rule = compose,
+            sessionName = SESSION_A,
+            timeoutMs = pickerWaitMs,
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
+        )
         compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SystemBackForegroundE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SystemBackForegroundE2eTest.kt
@@ -18,6 +18,7 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -123,7 +124,19 @@ class SystemBackForegroundE2eTest {
         // probed session row (with the production one-retry inside
         // waitForSessionInPicker).
         tapHostUntilHostDetail(hostRowTag)
-        waitForSessionInPicker(rule = compose, sessionName = SESSION_NAME, timeoutMs = 30_000)
+        waitForSessionInPicker(
+            rule = compose,
+            sessionName = SESSION_NAME,
+            timeoutMs = 30_000,
+            onStateNote = { note -> Log.i(LOG_TAG, "ISSUE520_PICKER $note") },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                    onStateNote = { note -> Log.i(LOG_TAG, "ISSUE520_PICKER $note") },
+                )
+            },
+        )
         compose.onNodeWithText(SESSION_NAME).performClick()
         // Wait for the terminal screen to mount (the session row is gone from
         // the picker; the terminal viewport is up).

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchE2eTest.kt
@@ -27,6 +27,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_MORE_BUTTON_TAG
@@ -133,7 +134,7 @@ class TmuxSessionSwitchE2eTest {
         }
         val tapHostAt = SystemClock.elapsedRealtime()
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        waitForFolderListReady()
+        waitForFolderListReady(hostRowTag)
         waitForText(SESSION_CLAUDE, timeoutMs = 20_000)
         compose.onNodeWithText(SESSION_CLAUDE).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
@@ -255,7 +256,7 @@ class TmuxSessionSwitchE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        waitForFolderListReady()
+        waitForFolderListReady(hostRowTag)
         waitForText(SESSION_CLAUDE, timeoutMs = 20_000)
         compose.onNodeWithText(SESSION_CLAUDE).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
@@ -296,7 +297,7 @@ class TmuxSessionSwitchE2eTest {
         // claude-main ROW. Pre-fix, the stale unified-pager index dragged the
         // user back into codex.
         pressInSessionBack()
-        waitForFolderListReady()
+        waitForFolderListReady(hostRowTag)
         waitForText(SESSION_CLAUDE, timeoutMs = 20_000)
         val tapClaudeRowAt = SystemClock.elapsedRealtime()
         compose.onNodeWithText(SESSION_CLAUDE).performClick()
@@ -460,17 +461,28 @@ class TmuxSessionSwitchE2eTest {
         }
     }
 
-    private fun waitForFolderListReady() {
+    private fun waitForFolderListReady(hostRowTag: String) {
         // Issue #470 blocker #2: shared session-picker readiness gate with a
         // generous bound and one production Retry, replacing the bare
         // `waitUntil` that burned its full timeout when a cold-AVD
         // `tmux list-sessions` SSH-exec probe landed on the connect-error
         // panel instead of the session row. The folder-list screen is
         // implicitly up once the SESSION_CLAUDE row is present.
+        val recordPickerState: (String) -> Unit = { note ->
+            Log.i(LOG_TAG, "ISSUE470_PICKER $note")
+        }
         waitForSessionInPicker(
             rule = compose,
             sessionName = SESSION_CLAUDE,
             timeoutMs = if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 20_000L,
+            onStateNote = recordPickerState,
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                    onStateNote = recordPickerState,
+                )
+            },
         )
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchSameHostReusesSshE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchSameHostReusesSshE2eTest.kt
@@ -21,6 +21,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.sessions.SSH_SOURCE_FOLDER_LIST_PROBE
 import com.pocketshell.app.sessions.SSH_SOURCE_SESSION_PICKER_LIST
@@ -146,7 +147,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        waitForFolderListReady()
+        waitForFolderListReady(hostRowTag)
         compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
@@ -302,7 +303,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
                 .isNotEmpty()
         }
         compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        waitForFolderListReady()
+        waitForFolderListReady(hostRowTag)
         compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
@@ -315,7 +316,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
         val switchWindowStart = SystemClock.elapsedRealtime()
 
         clickTmuxBack()
-        waitForFolderListReady()
+        waitForFolderListReady(hostRowTag)
         recordTiming("folder_back_to_rows_ready_ms", SystemClock.elapsedRealtime() - switchWindowStart)
         val rowTapAt = SystemClock.elapsedRealtime()
         compose.onNodeWithText(SESSION_B, useUnmergedTree = true).performClick()
@@ -385,7 +386,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
                     .isNotEmpty()
             }
             compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-            waitForFolderListReady()
+            waitForFolderListReady(hostRowTag)
             compose.onNodeWithText(SESSION_A, useUnmergedTree = true).performClick()
             compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
             waitForTerminalViewAttached()
@@ -632,7 +633,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
         }
     }
 
-    private fun waitForFolderListReady() {
+    private fun waitForFolderListReady(hostRowTag: String) {
         // Issue #470 blocker #2: wait on the shared session-picker readiness
         // gate, which surfaces the folder-list session row (here SESSION_B,
         // the last seeded session, so the whole enumeration has landed) with
@@ -645,6 +646,12 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
             rule = compose,
             sessionName = SESSION_B,
             timeoutMs = pickerWaitMs,
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
         )
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/SessionPickerSignals.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/SessionPickerSignals.kt
@@ -134,9 +134,10 @@ const val SESSION_PICKER_REPOKE_NAVIGATION_TIMEOUT_MS: Long = 10_000L
  * runs carried `expanded_folders=true, error_panel_visible=false`). In either
  * case the helper used to burn its FULL [timeoutMs] before asserting false,
  * and the coarse class-level retry then double-hit. To self-heal
- * deterministically, callers may pass an [onRepoke] recovery action (e.g.
+ * deterministically, every caller passes an [onRepoke] recovery action (e.g.
  * Back to the host list + re-tap the host row) that re-triggers a fresh
- * enumeration. The watchdog calls it when the awaited row has been absent —
+ * enumeration. The watchdog calls it when
+ * the awaited row has been absent —
  * with no error panel — continuously past a bounded sub-deadline
  * `min(timeoutMs / 3, `[SESSION_PICKER_STALL_REPOKE_CEILING_MS]`)`,
  * re-triggering enumeration on the SAME signals the helper already reads
@@ -144,8 +145,8 @@ const val SESSION_PICKER_REPOKE_NAVIGATION_TIMEOUT_MS: Long = 10_000L
  * [maxRepokes] re-pokes so a genuinely absent/wedged session still fails the
  * run within [timeoutMs] — the watchdog never masks a real first-open
  * failure, it only converts a recoverable enumeration stall into a recovery
- * instead of a full-bound burn. When [onRepoke] is null (or [maxRepokes] is
- * 0) the behaviour is identical to round 3.
+ * instead of a full-bound burn. When [maxRepokes] is 0 the behaviour is
+ * identical to round 3.
  *
  * @param rule the Compose test rule hosting the picker.
  * @param sessionName the tmux session name expected to list.
@@ -156,22 +157,21 @@ const val SESSION_PICKER_REPOKE_NAVIGATION_TIMEOUT_MS: Long = 10_000L
  *   `session_list_expanding_folders`, `session_list_stall_repoke`) so
  *   callers that record per-stage timing stamps can keep their artifact
  *   breadcrumbs.
- * @param onRepoke optional test-only recovery that re-triggers the host's
+ * @param onRepoke required test-only recovery that re-triggers the host's
  *   enumeration (e.g. Back to the host list + re-tap the host row). Invoked
  *   by the bounded enumeration-stall watchdog (#740) up to [maxRepokes] times.
- *   Null disables the watchdog (round-3 behaviour). The lambda must leave the
- *   picker in a state where this helper's success/error/expand polls remain
- *   valid (i.e. it re-opens the SAME host's picker).
- * @param maxRepokes upper bound on watchdog re-pokes; ignored when [onRepoke]
- *   is null. Default 2 keeps a 60 s CI bound recoverable without the
- *   sub-deadline swallowing the whole budget.
+ *   The lambda must leave the picker in a state where this helper's
+ *   success/error/expand polls remain valid (i.e. it re-opens the SAME host's
+ *   picker).
+ * @param maxRepokes upper bound on watchdog re-pokes. Default 2 keeps a 60 s
+ *   CI bound recoverable without the sub-deadline swallowing the whole budget.
  */
 fun waitForSessionInPicker(
     rule: ComposeTestRule,
     sessionName: String,
     timeoutMs: Long = SESSION_PICKER_DEFAULT_TIMEOUT_MS,
     onStateNote: (String) -> Unit = {},
-    onRepoke: (() -> Unit)? = null,
+    onRepoke: () -> Unit,
     maxRepokes: Int = 2,
 ) {
     var retried = false
@@ -252,7 +252,6 @@ fun waitForSessionInPicker(
             // genuinely absent session still exhausts the budget and fails
             // within `timeoutMs`, so a real first-open failure is never masked.
             if (
-                onRepoke != null &&
                 repokesPerformed < maxRepokes &&
                 SystemClock.elapsedRealtime() - rowAbsentSince >= stallRepokeThresholdMs
             ) {

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
@@ -24,12 +24,12 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
-import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
 import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.TerminalTestTimeouts
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.proof.signals.InheritedJourneyFocus
 import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
@@ -143,7 +143,12 @@ class Issue887TerminalFixedUnderImeE2eTest {
             rule = compose,
             sessionName = SESSION_LAB,
             timeoutMs = pickerWaitMs,
-            onRepoke = { repokeFolderListFromHostRow(hostRowTag) },
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                )
+            },
         )
         compose.onNodeWithText(SESSION_LAB, useUnmergedTree = true).performClick()
 
@@ -561,23 +566,6 @@ class Issue887TerminalFixedUnderImeE2eTest {
             .edit()
             .putString("host_detail_view_mode", "Flat")
             .commit()
-    }
-
-    private fun repokeFolderListFromHostRow(hostRowTag: String) {
-        runCatching {
-            if (compose.onAllNodesWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            ) {
-                compose.onNodeWithTag(FOLDER_LIST_BACK_TAG, useUnmergedTree = true).performClick()
-            }
-            compose.waitUntil(timeoutMillis = 10_000) {
-                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-            compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
-        }
     }
 
     private fun View.findTerminalView(): TerminalView? {

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxAttachPrefillDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxAttachPrefillDockerTest.kt
@@ -25,6 +25,7 @@ import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.signals.repokeSessionPickerFromHostRow
 import com.pocketshell.app.proof.signals.waitForSessionInPicker
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.core.ssh.KnownHostsPolicy
@@ -164,7 +165,7 @@ class TmuxAttachPrefillDockerTest {
             // Issue #468 blocker #2: deterministic session-list readiness wait
             // with retry-once, replacing the bare 20s waitUntil that flaked on
             // a cold AVD's slow tmux -CC enumeration.
-            waitForSessionInPicker(sessionName)
+            waitForAttachedSessionInPicker(sessionName = sessionName, hostRowTag = hostRowTag)
 
             // ---- Authoritative "before" capture: terminal not attached yet. ----
             recordStamp("picker_visible")
@@ -404,7 +405,7 @@ class TmuxAttachPrefillDockerTest {
             // Issue #468 blocker #2: deterministic session-list readiness wait
             // with retry-once, replacing the bare 20s waitUntil that flaked on
             // a cold AVD's slow tmux -CC enumeration.
-            waitForSessionInPicker(sessionName)
+            waitForAttachedSessionInPicker(sessionName = sessionName, hostRowTag = hostRowTag)
             compose.onNodeWithText(sessionName).performClick()
             compose.waitUntil(timeoutMillis = 20_000) {
                 compose.onAllNodesWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
@@ -797,12 +798,19 @@ class TmuxAttachPrefillDockerTest {
      * production Retry instead of a bare `waitUntil` that flaked on a cold
      * AVD's slow first enumeration.
      */
-    private fun waitForSessionInPicker(sessionName: String) {
+    private fun waitForAttachedSessionInPicker(sessionName: String, hostRowTag: String) {
         waitForSessionInPicker(
             rule = compose,
             sessionName = sessionName,
             timeoutMs = SESSION_LIST_TIMEOUT_MS,
             onStateNote = ::recordStamp,
+            onRepoke = {
+                repokeSessionPickerFromHostRow(
+                    rule = compose,
+                    hostRowTag = hostRowTag,
+                    onStateNote = ::recordStamp,
+                )
+            },
         )
     }
 

--- a/app/src/test/java/com/pocketshell/app/proof/SessionPickerRepokeContractTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/SessionPickerRepokeContractTest.kt
@@ -1,0 +1,293 @@
+package com.pocketshell.app.proof
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #470 recurrence guard.
+ *
+ * Every connected caller of [waitForSessionInPicker] is exposed to the same
+ * expanded/no-error/no-row stall. A nullable callback let individual journeys
+ * silently disable the bounded watchdog, so this test inventories the whole
+ * androidTest tree and pins both halves of the recovery route:
+ *
+ *  1. every direct shared-helper call supplies the bounded standard re-poke;
+ *  2. that re-poke receives the caller's current `hostRowTag`, not a stale tag
+ *     or a terminal-screen Back route.
+ *
+ * The test is in the ordinary JVM source set, so both Debug and Release unit
+ * gates execute it without needing an emulator.
+ */
+class SessionPickerRepokeContractTest {
+
+    @Test
+    fun everyPickerWaitEnablesTheBoundedStandardRepoke() {
+        val calls = pickerCalls()
+        assertEquals(
+            "Update the reviewed caller inventory when adding/removing a picker wait",
+            EXPECTED_CALL_COUNTS,
+            calls.groupingBy { it.relativePath }.eachCount().toSortedMap(),
+        )
+
+        val missing = calls.filterNot { call ->
+            ON_REPOKE_BLOCK.containsMatchIn(call.maskedCall) &&
+                STANDARD_REPOKE_CALL.containsMatchIn(call.maskedCall)
+        }
+        assertTrue(
+            "Every waitForSessionInPicker caller must enable the bounded " +
+                "repokeSessionPickerFromHostRow recovery; missing at " +
+                missing.joinToString { "${it.relativePath}:${it.line}" },
+            missing.isEmpty(),
+        )
+    }
+
+    @Test
+    fun everyRepokeRoutesThroughTheCallersExactHostRow() {
+        // Deliberately inspect only callbacks that invoke the standard helper.
+        // This keeps the wrong-row mutation selective: a missing callback is
+        // owned by the first test, while a stale/wrong row fails this one.
+        val wrongRows = pickerCalls()
+            .filter { STANDARD_REPOKE_CALL.containsMatchIn(it.maskedCall) }
+            .filterNot { EXACT_HOST_ROW_ARGUMENT.containsMatchIn(it.maskedCall) }
+
+        assertTrue(
+            "Every picker re-poke must pass the current hostRowTag exactly; " +
+                "wrong/stale route at " +
+                wrongRows.joinToString { "${it.relativePath}:${it.line}" },
+            wrongRows.isEmpty(),
+        )
+    }
+
+    @Test
+    fun sharedRepokeContractStaysRequiredAndBounded() {
+        val source = sourceFile(SIGNALS_PATH).readText()
+        val masked = maskNonCode(source)
+
+        assertTrue(
+            "waitForSessionInPicker must require a non-null onRepoke callback",
+            Regex("""onRepoke\s*:\s*\(\s*\)\s*->\s*Unit\s*,""")
+                .containsMatchIn(masked),
+        )
+        assertTrue(
+            "repokeSessionPickerFromHostRow must retain the bounded navigation default",
+            Regex(
+                """fun\s+repokeSessionPickerFromHostRow\s*\([\s\S]*?""" +
+                    """timeoutMs\s*:\s*Long\s*=\s*""" +
+                    """SESSION_PICKER_REPOKE_NAVIGATION_TIMEOUT_MS""",
+            ).containsMatchIn(masked),
+        )
+        assertTrue(
+            "the re-poke must hard-bound and verify Back, host row, and reopen",
+            listOf(
+                "folder_detail_back_reachable",
+                "host_row_reachable",
+                "folder_detail_reopened",
+            ).all(source::contains),
+        )
+    }
+
+    private fun pickerCalls(): List<PickerCall> {
+        val root = projectRoot()
+        val androidTestRoot = File(root, "app/src/androidTest/java")
+        require(androidTestRoot.isDirectory) { "Missing $androidTestRoot" }
+
+        return androidTestRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file -> callsIn(file, root).asSequence() }
+            .toList()
+            .sortedWith(compareBy(PickerCall::relativePath, PickerCall::line))
+    }
+
+    private fun callsIn(file: File, root: File): List<PickerCall> {
+        val source = file.readText()
+        val masked = maskNonCode(source)
+        val calls = mutableListOf<PickerCall>()
+        CALL_START.findAll(masked).forEach { match ->
+            val prefix = masked.substring(maxOf(0, match.range.first - 32), match.range.first)
+            if (FUNCTION_DECLARATION_SUFFIX.containsMatchIn(prefix)) return@forEach
+
+            val openParen = masked.indexOf('(', startIndex = match.range.first)
+            val closeParen = matchingParen(masked, openParen)
+            val call = masked.substring(match.range.first, closeParen + 1)
+
+            calls += PickerCall(
+                relativePath = file.relativeTo(root).invariantSeparatorsPath,
+                line = masked.take(match.range.first).count { it == '\n' } + 1,
+                maskedCall = call,
+            )
+        }
+        return calls
+    }
+
+    private fun matchingParen(source: String, openParen: Int): Int {
+        require(openParen >= 0) { "call has no opening parenthesis" }
+        var depth = 0
+        for (index in openParen until source.length) {
+            when (source[index]) {
+                '(' -> depth += 1
+                ')' -> {
+                    depth -= 1
+                    if (depth == 0) return index
+                }
+            }
+        }
+        error("Unclosed waitForSessionInPicker call at offset $openParen")
+    }
+
+    /** Masks strings/comments while preserving offsets and newlines. */
+    private fun maskNonCode(source: String): String {
+        val result = source.toCharArray()
+        var index = 0
+        var blockDepth = 0
+        var state = LexState.CODE
+
+        fun mask(at: Int) {
+            if (result[at] != '\n' && result[at] != '\r') result[at] = ' '
+        }
+
+        while (index < source.length) {
+            when (state) {
+                LexState.CODE -> when {
+                    source.startsWith("//", index) -> {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                        state = LexState.LINE_COMMENT
+                    }
+                    source.startsWith("/*", index) -> {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                        blockDepth = 1
+                        state = LexState.BLOCK_COMMENT
+                    }
+                    source.startsWith("\"\"\"", index) -> {
+                        repeat(3) { mask(index + it) }
+                        index += 3
+                        state = LexState.TRIPLE_STRING
+                    }
+                    source[index] == '"' -> {
+                        mask(index++)
+                        state = LexState.STRING
+                    }
+                    source[index] == '\'' -> {
+                        mask(index++)
+                        state = LexState.CHAR
+                    }
+                    else -> index += 1
+                }
+                LexState.LINE_COMMENT -> {
+                    if (source[index] == '\n') {
+                        state = LexState.CODE
+                    } else {
+                        mask(index)
+                    }
+                    index += 1
+                }
+                LexState.BLOCK_COMMENT -> when {
+                    source.startsWith("/*", index) -> {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                        blockDepth += 1
+                    }
+                    source.startsWith("*/", index) -> {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                        blockDepth -= 1
+                        if (blockDepth == 0) state = LexState.CODE
+                    }
+                    else -> {
+                        mask(index)
+                        index += 1
+                    }
+                }
+                LexState.STRING, LexState.CHAR -> {
+                    val terminator = if (state == LexState.STRING) '"' else '\''
+                    if (source[index] == '\\' && index + 1 < source.length) {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                    } else {
+                        val done = source[index] == terminator
+                        mask(index)
+                        index += 1
+                        if (done) state = LexState.CODE
+                    }
+                }
+                LexState.TRIPLE_STRING -> {
+                    if (source.startsWith("\"\"\"", index)) {
+                        repeat(3) { mask(index + it) }
+                        index += 3
+                        state = LexState.CODE
+                    } else {
+                        mask(index)
+                        index += 1
+                    }
+                }
+            }
+        }
+        return result.concatToString()
+    }
+
+    private fun projectRoot(): File {
+        System.getenv(ROOT_OVERRIDE_ENV)?.takeIf(String::isNotBlank)?.let { override ->
+            return File(override).canonicalFile
+        }
+        var cursor = File(System.getProperty("user.dir")).absoluteFile
+        while (true) {
+            if (File(cursor, "settings.gradle.kts").isFile) return cursor
+            cursor = cursor.parentFile ?: break
+        }
+        error("Cannot locate project root from ${System.getProperty("user.dir")}")
+    }
+
+    private fun sourceFile(relativePath: String): File = File(projectRoot(), relativePath)
+
+    private data class PickerCall(
+        val relativePath: String,
+        val line: Int,
+        val maskedCall: String,
+    )
+
+    private enum class LexState {
+        CODE,
+        LINE_COMMENT,
+        BLOCK_COMMENT,
+        STRING,
+        TRIPLE_STRING,
+        CHAR,
+    }
+
+    companion object {
+        private const val ROOT_OVERRIDE_ENV = "POCKETSHELL_SESSION_PICKER_CONTRACT_ROOT"
+        private const val SIGNALS_PATH =
+            "app/src/androidTest/java/com/pocketshell/app/proof/signals/SessionPickerSignals.kt"
+
+        private val EXPECTED_CALL_COUNTS = sortedMapOf(
+            "app/src/androidTest/java/com/pocketshell/app/proof/BackThenOpenSecondSessionReusesWarmLeaseE2eTest.kt" to 3,
+            "app/src/androidTest/java/com/pocketshell/app/proof/ComposerAlwaysPresentSwitchJourneyE2eTest.kt" to 2,
+            "app/src/androidTest/java/com/pocketshell/app/proof/Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/proof/Issue1831BackFromRestoredSessionJourneyE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt" to 3,
+            "app/src/androidTest/java/com/pocketshell/app/proof/ProjectSwitcherDropdownE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt" to 3,
+            "app/src/androidTest/java/com/pocketshell/app/proof/SystemBackForegroundE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchSameHostReusesSshE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt" to 1,
+            "app/src/androidTest/java/com/pocketshell/app/tmux/TmuxAttachPrefillDockerTest.kt" to 1,
+        )
+        private val CALL_START = Regex("""\bwaitForSessionInPicker\s*\(""")
+        private val FUNCTION_DECLARATION_SUFFIX = Regex("""\bfun\s+$""")
+        private val ON_REPOKE_BLOCK = Regex("""\bonRepoke\s*=\s*\{""")
+        private val STANDARD_REPOKE_CALL =
+            Regex("""\brepokeSessionPickerFromHostRow\s*\(""")
+        private val EXACT_HOST_ROW_ARGUMENT =
+            Regex("""\bhostRowTag\s*=\s*hostRowTag\b""")
+    }
+}


### PR DESCRIPTION
Closes #470.

Makes the shared session-picker recovery callback mandatory and routes every direct connected-test consumer through the same bounded Back → exact host-row → reopen repoke contract. Removes bespoke caller helpers and adds a gate-wired inventory/exact-row contract test.

Verification:
- Independent reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/470#issuecomment-5257331606
- 20/20 direct waits across 13 connected classes use the standard callback with the exact host row tag
- Missing-callback, wrong-row, and coordinated nullable-helper mutants fail selectively
- Canonical full JVM: 603/603 tasks, 12,370 tests, zero failures/errors/skips
- Four isolated emulator→Docker adjacency runs pass 2/2, including a natural bounded repoke recovery
- Evidence-enabled run has identical start/end fixture fingerprints, healthy SSH/tmux readiness, verified manifest hashes, and no fatal/ANR/corruption markers
- Exact-current static validity, journey wiring, file-size, connection-VM, interpreter, and diff guards pass