### PR TITLE
CI: retry Docker registry setup failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1378,7 +1378,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Build SSH base image
-        run: docker compose -f tests/docker/docker-compose.yml build sshd
+        run: scripts/ci-journey-fixture-retry.sh sshd -- docker compose -f tests/docker/docker-compose.yml build sshd
 
       # The selected journeys (DeepLinkSessionSwitch, MultiSessionSwitch,
       # ColdRestoreGoneSessionNoResurrect, ReconnectRepaint,
@@ -1391,7 +1391,7 @@ jobs:
       # cannot self-skip or silently fall back to the direct route.
       - name: Start Docker fixture (agents)
         run: |
-          docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents
+          scripts/ci-journey-fixture-retry.sh agents -- docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents
 
       - name: Wait for the agents fixture to report healthy
         run: |
@@ -1411,7 +1411,7 @@ jobs:
           # before the first OpenSSH readiness attempt; OpenSSH rejects it
           # otherwise and no load-bearing journey reaches the proxy.
           chmod 600 tests/docker/test_key
-          docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps packet-loss-proxy
+          scripts/ci-journey-fixture-retry.sh packet-loss-proxy -- docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps packet-loss-proxy
           for attempt in $(seq 1 30); do
             if ssh -i tests/docker/test_key -p 2229 \
               -o BatchMode=yes -o ConnectTimeout=3 \
@@ -1426,7 +1426,7 @@ jobs:
 
       - name: Start Docker fixture (network-fault-proxy, issue #1733)
         run: |
-          docker compose -f tests/docker/docker-compose.yml up -d --no-deps network-fault-proxy
+          scripts/ci-journey-fixture-retry.sh network-fault-proxy -- docker compose -f tests/docker/docker-compose.yml up -d --no-deps network-fault-proxy
           for attempt in $(seq 1 30); do
             if curl --fail --silent --show-error http://127.0.0.1:8474/version; then
               exit 0
@@ -1458,7 +1458,7 @@ jobs:
       # connect-break class was structurally invisible to CI (the #848 gate gap).
       - name: Start Docker fixture (agents-old-cli, issue #849)
         run: |
-          docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents-old-cli
+          scripts/ci-journey-fixture-retry.sh agents-old-cli -- docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents-old-cli
 
       - name: Wait for the agents-old-cli fixture to report healthy
         run: |
@@ -1491,7 +1491,7 @@ jobs:
       # the agents-old-cli (#849) precedent directly above.
       - name: Start Docker fixture (agents-daemon, issue #839)
         run: |
-          docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents-daemon
+          scripts/ci-journey-fixture-retry.sh agents-daemon -- docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents-daemon
 
       - name: Wait for the agents-daemon fixture to report healthy
         run: |
@@ -1884,12 +1884,18 @@ jobs:
           SHARD_RETRY_DENIED_REASON="${retry_reason:-missing_decision}"
           SHARD_RETRY_SHORTFALL_MS="$retry_shortfall_ms"
           export SHARD_RETRY_AFFORDABLE SHARD_RETRY_DENIED_REASON SHARD_RETRY_SHORTFALL_MS
-          # Issue #1913: `skipped` means the first journey action was NEVER
-          # attempted. An earlier workflow/setup step failed, so absence of a
-          # suite summary cannot prove #771 emulator-never-booted infra. Fail
-          # closed with the stable failed phase; the native failed setup step
-          # retains the exact step-level diagnosis in the shard job log.
+          # #2095: only captured provider failures with zero journeys are INFRA.
           if [[ "$first" == "skipped" ]]; then
+            setup_out="$(scripts/ci-journey-fixture-retry.sh --classify artifacts/ci-journey-setup artifacts/ci-journey 2>&1 || true)"
+            printf '%s\n' "$setup_out" | sed 's/^/pre-journey setup signature: /'
+            setup_reason="$(sed -n 's/^pre_journey_infra_reason=//p' <<<"$setup_out" | tail -n 1)"
+            case "$setup_reason" in
+              docker_registry_http_5xx_exhausted|docker_registry_network_exhausted)
+                echo "::warning title=Emulator journey INFRA — external Docker registry unavailable::Fixture setup exhausted its one bounded retry before any journey ran (${setup_reason}). Attempt logs are preserved; this is provider/bootstrap INFRA, not a product regression (issue #2095)."
+                write_verdict INFRA "$setup_reason"
+                exit 1
+                ;;
+            esac
             echo "::error title=Emulator journey PRE-JOURNEY SETUP FAILURE::The first emulator journey action was skipped, so an earlier workflow/setup step failed before emulator launch. This is a commit-bound workflow failure, NOT emulator_never_booted infra; refusing to downgrade it to environmental RE-RUN (issue #1913)."
             write_verdict RED pre_journey_setup_failure
             exit 1
@@ -2060,7 +2066,9 @@ jobs:
         with:
           # Issue #835: per-shard name so matrix legs don't collide on upload.
           name: emulator-journey-docker-logs-shard-${{ matrix.shard }}
-          path: artifacts/docker/
+          path: |
+            artifacts/docker/
+            artifacts/ci-journey-setup/
           # Issue #1809: same attempt-scoped re-run hygiene as the reports above.
           overwrite: true
           if-no-files-found: ignore
@@ -2087,29 +2095,7 @@ jobs:
         if: always()
         run: docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
 
-      # Issue #1809 (G5 clean re-run): make THIS shard's job conclusion reflect a
-      # genuine RED verdict.
-      #
-      # The defect this closes: #1458 made the classify step `continue-on-error`
-      # so an environmental shard could not fire a false red-CI email. A side
-      # effect nobody noticed is that a shard whose token is RED ALSO finishes
-      # `success` — so on a red emulator-journey run the ONLY failed job is the
-      # aggregation job, and GitHub's "Re-run failed jobs" re-runs ONLY that
-      # aggregation job. It then re-downloads the very same shard tokens and
-      # emits the very same RED: a second, identical red that proves nothing.
-      # That is the on-call's "could not produce a clean re-run" in mechanical
-      # terms (runs 30305256109 / 30314178005 / 30318408377 all show three
-      # `success` shard jobs under a `failure` aggregate).
-      #
-      # Failing the shard on RED — and ONLY on RED — makes "Re-run failed jobs"
-      # re-run the offending shard AND the aggregation job that `needs` it, so
-      # the standard button is the G5 clean-re-run path. It cannot reintroduce
-      # the #1458 false red: a RED token already turns the whole run red through
-      # the aggregation job, so the run's conclusion is unchanged. INFRA and
-      # CLEAN shards still finish green, which is the property #1458 added.
-      #
-      # Placed last so every `if: always()` artifact/teardown step above has
-      # already run; the verdict artifact is uploaded before this can fail.
+      # #1809: fail genuine RED only after artifacts for failed-job re-runs.
       - name: "Fail this shard on a genuine RED verdict (issue #1809)"
         if: always() && steps.classify.outputs.shard_verdict == 'RED'
         run: |
@@ -2117,6 +2103,11 @@ jobs:
           echo "Failing the shard job so 'Re-run failed jobs' re-runs THIS shard plus the aggregation job (issue #1809, G5)."
           echo "The per-shard annotations above carry the failing class(es); the aggregate verdict job owns the overall run verdict."
           exit 1
+
+      # #2095: make only exhausted provider-INFRA shards eligible for re-run.
+      - name: "Request failed-job retry for external setup INFRA (issue #2095)"
+        if: always() && (steps.classify.outputs.shard_verdict_reason == 'docker_registry_http_5xx_exhausted' || steps.classify.outputs.shard_verdict_reason == 'docker_registry_network_exhausted')
+        run: exit 1
 
   # ---------------------------------------------------------------------------
   # Issue #1458 (AGGREGATION): roll the per-shard emulator-journey verdict tokens

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -86,6 +86,11 @@ cold_build_shards=()
 # Issue #1833: shards that reached their verdict unable to start a cold-boot
 # retry, i.e. shards whose result came from ONE attempt.
 one_shot_shards=()
+# #2095 external setup INFRA deliberately fails its shard job so GitHub's
+# failed-job retry re-runs only that shard. Its precise token reason explains
+# the otherwise-fail-closed upstream matrix failure.
+external_setup_infra_shards=()
+unclassified_infra=0
 fresh_tokens=0
 
 current_attempt="${GITHUB_RUN_ATTEMPT:-}"
@@ -108,6 +113,18 @@ if [[ -d "$verdict_dir" ]]; then
     # before the reason existed, which stays a plain `unspecified`.
     tok_reason="$(sed -n 's/^verdict_reason=//p' "$f" 2>/dev/null | head -n 1)"
     [[ -n "$tok_reason" ]] || tok_reason="unspecified"
+    if [[ "$token" == "INFRA" ]]; then
+      case "$tok_reason" in
+        docker_registry_http_5xx_exhausted|docker_registry_network_exhausted)
+          external_setup_infra_shards+=("shard ${tok_shard} (${tok_reason})")
+          ;;
+        foreign_framework_anr_focus|real_ime_precondition|retry_wall_exhausted|attempt_cancelled|emulator_never_booted)
+          ;;
+        *)
+          unclassified_infra=$((unclassified_infra + 1))
+          ;;
+      esac
+    fi
     if [[ -z "$tok_shard" ]]; then
       # No stamp (a token from a job that died before the pre-seed, or a foreign
       # artifact): fall back to the download-artifact per-shard subdir name.
@@ -259,10 +276,14 @@ emit_summary() {
 # tokens are missing or all CLEAN; a deterministic workflow failure cannot be
 # presented as neutral RE-RUN.
 if [[ "$upstream_matrix_result" == "failure" ]] && (( have_red == 0 && have_unknown == 0 )); then
-  echo "::error title=Emulator journey verdict — RED (upstream/classifier mismatch)::The upstream emulator-journey matrix result was failure, but no shard verdict token reported RED. A commit-bound shard/setup failure escaped the classifier; refusing to downgrade the run to environmental RE-RUN (issue #1913)."
-  emit_summary "RED" "upstream matrix failed without a RED shard token — classifier mismatch"
-  echo "AGGREGATE_VERDICT=RED"
-  exit 1
+  if (( ${#external_setup_infra_shards[@]} > 0 && unclassified_infra == 0 && missing == 0 )); then
+    echo "::warning title=Emulator journey external setup INFRA — failed shard is retryable (#2095)::${external_setup_infra_shards[*]} exhausted a bounded provider retry before zero journeys. Its shard job intentionally failed so 'Re-run failed jobs' re-runs only that shard; the typed aggregate remains RE-RUN, never product RED."
+  else
+    echo "::error title=Emulator journey verdict — RED (upstream/classifier mismatch)::The upstream emulator-journey matrix result was failure, but no shard verdict token reported RED. A commit-bound shard/setup failure escaped the classifier; refusing to downgrade the run to environmental RE-RUN (issue #1913)."
+    emit_summary "RED" "upstream matrix failed without a RED shard token — classifier mismatch"
+    echo "AGGREGATE_VERDICT=RED"
+    exit 1
+  fi
 fi
 
 # No tokens at all AND none were expected: nothing ran (e.g. the emulator job was

--- a/scripts/ci-journey-fixture-retry.sh
+++ b/scripts/ci-journey-fixture-retry.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Issue #2095: retry only captured external Docker-registry failures during
+# pre-journey fixture setup, and leave attempt-local evidence for the shard
+# classifier. Unknown failures are never retried or softened.
+set -euo pipefail
+
+MAX_ATTEMPTS=2
+DEFAULT_ARTIFACT_ROOT="artifacts/ci-journey-setup"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  ci-journey-fixture-retry.sh <fixture-name> -- <command> [args...]
+  ci-journey-fixture-retry.sh --classify [setup-artifact-root] [journey-artifact-root]
+EOF
+  exit 2
+}
+
+registry_failure_reason() {
+  local log="$1"
+  local reason
+
+  # Bind the provider URL and failure signature to ONE Docker error record.
+  # BuildKit wraps the observed blob error over three contiguous lines:
+  # operation failure -> provider URL -> HTTP status. A provider URL elsewhere
+  # in the log (normal auth/pull chatter) cannot bless a later product error.
+  reason="$(awk '
+    function lower(s) { return tolower(s) }
+    function provider(s, v) {
+      v=lower(s)
+      return v ~ /(registry-1\.docker\.io|auth\.docker\.io|production\.cloudflare\.docker\.com|docker\.io\/v2\/)/
+    }
+    function operation_failure(s, v) {
+      v=lower(s)
+      return v ~ /(failed to copy|failed open|failed to do request|failed to resolve|failed to fetch|error pulling|pull failed|unexpected status code|unexpected http status|request failed)/
+    }
+    function http_5xx(s) {
+      return s ~ /(^|[^0-9])5[0-9][0-9]([^0-9]|$)/
+    }
+    function network(s, v) {
+      v=lower(s)
+      return v ~ /(tls handshake timeout|i\/o timeout|connection reset by peer|unexpected eof|temporary failure in name resolution|no such host|net\/http: request canceled|client\.timeout exceeded)/
+    }
+    { line[NR]=$0 }
+    END {
+      for (i=1; i<=NR; i++) {
+        if (!operation_failure(line[i])) continue
+        if (provider(line[i])) {
+          if (http_5xx(line[i]) || http_5xx(line[i+1])) http_found=1
+          if (network(line[i]) || network(line[i+1])) network_found=1
+        }
+        if (provider(line[i+1])) {
+          if (http_5xx(line[i+1]) || http_5xx(line[i+2])) http_found=1
+          if (network(line[i+1]) || network(line[i+2])) network_found=1
+        }
+      }
+      if (http_found) print "docker_registry_http_5xx"
+      else if (network_found) print "docker_registry_network"
+    }
+  ' "$log")"
+  [[ -n "$reason" ]] || return 1
+  printf '%s\n' "$reason"
+}
+
+write_failure_manifest() {
+  local root="$1" fixture="$2" status="$3" reason="$4" attempts="$5"
+  {
+    printf 'status=%s\n' "$status"
+    printf 'reason=%s\n' "$reason"
+    printf 'fixture=%s\n' "$fixture"
+    printf 'attempts=%s\n' "$attempts"
+  } > "$root/failure.env"
+}
+
+read_field() {
+  local key="$1" file="$2"
+  sed -n "s/^${key}=//p" "$file" | tail -n 1
+}
+
+classify_exhausted_setup() {
+  local root="${1:-$DEFAULT_ARTIFACT_ROOT}"
+  local journey_root="${2:-artifacts/ci-journey}"
+  local manifest="$root/failure.env"
+  local status reason fixture attempts attempt log actual_reason rc
+
+  # The downgrade is valid only before any journey evidence exists. This is
+  # deliberately stronger than checking a missing summary: a partial class
+  # attempt is a journey and must remain product-red/fail-closed.
+  if [[ -d "$journey_root" ]] && find "$journey_root" -mindepth 1 -print -quit | grep -q .; then
+    echo "pre-journey infra rejected: journey evidence exists under $journey_root" >&2
+    return 1
+  fi
+  [[ -f "$manifest" ]] || {
+    echo "pre-journey infra rejected: missing $manifest" >&2
+    return 1
+  }
+
+  status="$(read_field status "$manifest")"
+  reason="$(read_field reason "$manifest")"
+  fixture="$(read_field fixture "$manifest")"
+  attempts="$(read_field attempts "$manifest")"
+  [[ "$status" == "infra_exhausted" && "$attempts" == "$MAX_ATTEMPTS" ]] || {
+    echo "pre-journey infra rejected: status=$status attempts=$attempts" >&2
+    return 1
+  }
+  [[ "$fixture" =~ ^[a-z0-9][a-z0-9_-]{0,63}$ ]] || {
+    echo "pre-journey infra rejected: invalid fixture identity" >&2
+    return 1
+  }
+  [[ "$reason" == "docker_registry_http_5xx" || "$reason" == "docker_registry_network" ]] || {
+    echo "pre-journey infra rejected: unknown reason=$reason" >&2
+    return 1
+  }
+
+  for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    log="$root/$fixture/attempt-$attempt.log"
+    [[ -s "$log" ]] || {
+      echo "pre-journey infra rejected: missing attempt log $log" >&2
+      return 1
+    }
+    rc="$(read_field rc "$root/$fixture/attempt-$attempt.env")"
+    [[ "$rc" =~ ^[1-9][0-9]*$ ]] || {
+      echo "pre-journey infra rejected: attempt $attempt was not a captured failure" >&2
+      return 1
+    }
+    actual_reason="$(registry_failure_reason "$log" || true)"
+    [[ "$actual_reason" == "$reason" ]] || {
+      echo "pre-journey infra rejected: attempt $attempt signature=${actual_reason:-unknown}, expected $reason" >&2
+      return 1
+    }
+  done
+
+  printf 'pre_journey_infra_verdict=INFRA\n'
+  printf 'pre_journey_infra_reason=%s_exhausted\n' "$reason"
+  printf 'pre_journey_infra_fixture=%s\n' "$fixture"
+  printf 'pre_journey_infra_attempts=%s\n' "$attempts"
+}
+
+if [[ "${1:-}" == "--classify" ]]; then
+  shift
+  classify_exhausted_setup "${1:-$DEFAULT_ARTIFACT_ROOT}" "${2:-artifacts/ci-journey}"
+  exit $?
+fi
+
+fixture="${1:-}"
+[[ "$fixture" =~ ^[a-z0-9][a-z0-9_-]{0,63}$ ]] || usage
+shift
+[[ "${1:-}" == "--" ]] || usage
+shift
+(( $# > 0 )) || usage
+
+artifact_root="${CI_JOURNEY_SETUP_ARTIFACT_ROOT:-$DEFAULT_ARTIFACT_ROOT}"
+fixture_dir="$artifact_root/$fixture"
+retry_delay_seconds="${CI_JOURNEY_FIXTURE_RETRY_DELAY_SECONDS:-5}"
+[[ "$retry_delay_seconds" =~ ^[0-9]+$ ]] || retry_delay_seconds=5
+mkdir -p "$fixture_dir" || exit 1
+rm -f "$artifact_root/failure.env"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  log="$fixture_dir/attempt-$attempt.log"
+  echo "fixture $fixture: attempt $attempt/$MAX_ATTEMPTS"
+  set +e
+  "$@" 2>&1 | tee "$log"
+  rc="${PIPESTATUS[0]}"
+  set -e
+  printf 'rc=%s\n' "$rc" > "$fixture_dir/attempt-$attempt.env"
+
+  if [[ "$rc" -eq 0 ]]; then
+    if [[ "$attempt" -eq 1 ]]; then
+      printf 'status=success\nattempts=1\n' > "$fixture_dir/result.env"
+    else
+      printf 'status=recovered\nattempts=%s\n' "$attempt" > "$fixture_dir/result.env"
+      echo "fixture $fixture: captured registry failure recovered on bounded retry"
+    fi
+    exit 0
+  fi
+
+  reason="$(registry_failure_reason "$log" || true)"
+  if [[ -z "$reason" ]]; then
+    printf 'status=unknown_failure\nattempts=%s\n' "$attempt" > "$fixture_dir/result.env"
+    write_failure_manifest "$artifact_root" "$fixture" unknown_failure unknown "$attempt"
+    echo "fixture $fixture: unknown setup failure; refusing retry/INFRA classification" >&2
+    exit "$rc"
+  fi
+
+  if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+    echo "fixture $fixture: captured $reason; retrying once after ${retry_delay_seconds}s"
+    sleep "$retry_delay_seconds"
+    continue
+  fi
+
+  printf 'status=infra_exhausted\nreason=%s\nattempts=%s\n' "$reason" "$attempt" \
+    > "$fixture_dir/result.env"
+  write_failure_manifest "$artifact_root" "$fixture" infra_exhausted "$reason" "$attempt"
+  echo "fixture $fixture: $reason exhausted after $attempt attempts" >&2
+  exit "$rc"
+done
+
+exit 1

--- a/scripts/test-ci-journey-artifact-packaging.sh
+++ b/scripts/test-ci-journey-artifact-packaging.sh
@@ -564,6 +564,25 @@ grep -q 'path: artifacts/ci-journey-shard-verdict/shard-verdict.txt' "$WORKFLOW"
 grep -q 'artifacts/ci-journey/shard-verdict.txt' "$WORKFLOW" \
   && fail "the shard token must not be written or uploaded from inside artifacts/ci-journey/ — it would land in the first-attempt snapshot"
 
+docker_upload_step="$(awk '
+  /^      - name: Upload Docker logs$/ { capture=1 }
+  capture && seen && /^      - name:/ { exit }
+  capture { print; seen=1 }
+' "$WORKFLOW")"
+[[ -n "$docker_upload_step" ]] || fail "could not find named Upload Docker logs step"
+grep -Fxq '        if: always()' <<<"$docker_upload_step" \
+  || fail "setup-log upload must be if: always() so failed setup evidence survives"
+grep -Fxq '        uses: actions/upload-artifact@v7' <<<"$docker_upload_step" \
+  || fail "setup-log upload lost actions/upload-artifact@v7"
+grep -Fxq '            artifacts/ci-journey-setup/' <<<"$docker_upload_step" \
+  || fail "setup-log upload lost artifacts/ci-journey-setup/"
+docker_upload_line="$(grep -n '^      - name: Upload Docker logs$' "$WORKFLOW" | cut -d: -f1)"
+setup_retry_line="$(grep -n 'Request failed-job retry for external setup INFRA' "$WORKFLOW" | cut -d: -f1)"
+[[ "$docker_upload_line" =~ ^[0-9]+$ && "$setup_retry_line" =~ ^[0-9]+$ \
+    && "$docker_upload_line" -lt "$setup_retry_line" ]] \
+  || fail "setup logs must upload before the intentional failed-job trigger"
+pass "#2095 failed-setup logs have a named always-run upload before shard failure"
+
 upload_step="$(sed -n \
   '/- name: Upload Android test reports/,/- name: Upload Docker logs/p' \
   "$WORKFLOW")"

--- a/scripts/test-ci-journey-pre-journey-classification.sh
+++ b/scripts/test-ci-journey-pre-journey-classification.sh
@@ -7,8 +7,9 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
+WORKFLOW="${CI_JOURNEY_WORKFLOW:-$REPO_ROOT/.github/workflows/tests.yml}"
 AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+FIXTURE_RETRY="$SCRIPT_DIR/ci-journey-fixture-retry.sh"
 
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
@@ -102,8 +103,17 @@ JSONEOF
 CLASSIFY_OUT="" CLASSIFY_RC=0 CLASSIFY_TOKEN="" CLASSIFY_REASON=""
 run_classify() {
   local name="$1" first="$2" retry="$3"
+  local setup_source="${4:-}" journey_source="${5:-}"
   local ws="$SANDBOX/$name" body="$SANDBOX/$name-classifier.sh"
   mkdir -p "$ws/artifacts/ci-journey-shard-verdict"
+  if [[ -n "$setup_source" ]]; then
+    mkdir -p "$ws/artifacts/ci-journey-setup"
+    cp -a "$setup_source/." "$ws/artifacts/ci-journey-setup/"
+  fi
+  if [[ -n "$journey_source" ]]; then
+    mkdir -p "$ws/artifacts/ci-journey"
+    cp -a "$journey_source/." "$ws/artifacts/ci-journey/"
+  fi
   ln -s "$SCRIPT_DIR" "$ws/scripts"
   extract_step_body "Classify emulator-journey result (infra-abort vs test-failure)" \
     "$body" "$(classify_expressions "$first" "$retry")" \
@@ -127,6 +137,67 @@ run_classify() {
   CLASSIFY_FILE="$ws/artifacts/ci-journey-shard-verdict/shard-verdict.txt"
 }
 
+make_registry_stub() {
+  local path="$1"
+  cat > "$path" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+count=0
+[[ ! -f "$STUB_COUNT" ]] || count="$(cat "$STUB_COUNT")"
+count=$((count + 1))
+printf '%s\n' "$count" > "$STUB_COUNT"
+if [[ ( "$STUB_MODE" == "recover" || "$STUB_MODE" == "network-recover" ) && "$count" -ge 2 ]]; then
+  echo "fixture build succeeded"
+  exit 0
+fi
+if [[ "$STUB_MODE" == "unknown" ]]; then
+  echo "failed open: unexpected status code"
+  echo "https://product.example.test/api/build:"
+  echo "502 Bad Gateway"
+  exit 42
+fi
+if [[ "$STUB_MODE" == "mixed" ]]; then
+  cat <<'LOG'
+auth request https://auth.docker.io/token returned 200 OK
+registry-1.docker.io/v2/ authentication and manifest lookup succeeded
+pull setup completed normally
+failed open: unexpected status code
+https://product.example.test/api/build:
+502 Bad Gateway
+LOG
+  exit 43
+fi
+if [[ "$STUB_MODE" == network-* ]]; then
+  echo 'failed to do request: Head "https://registry-1.docker.io/v2/library/alpine/manifests/3.20": net/http: TLS handshake timeout'
+  exit 38
+fi
+cat <<'LOG'
+failed to copy: httpReadSeeker: failed open: unexpected status code
+https://registry-1.docker.io/v2/library/alpine/blobs/sha256:bf8527eb54c3680e728d5b4b383a8ba730d72dae7236fbc8dff97ed6b224a731:
+502 Bad Gateway
+LOG
+exit 37
+STUB
+  chmod +x "$path"
+}
+
+run_fixture_retry() {
+  local name="$1" mode="$2"
+  local root="$SANDBOX/$name-setup" count="$SANDBOX/$name-count"
+  rm -rf "$root" "$count"
+  set +e
+  CI_JOURNEY_SETUP_ARTIFACT_ROOT="$root" \
+    CI_JOURNEY_FIXTURE_RETRY_DELAY_SECONDS=0 \
+    STUB_MODE="$mode" STUB_COUNT="$count" \
+    "$FIXTURE_RETRY" packet-loss-proxy -- "$REGISTRY_STUB" \
+    > "$SANDBOX/$name-retry.log" 2>&1
+  FIXTURE_RC=$?
+  set -e
+  FIXTURE_CALLS=0
+  [[ ! -f "$count" ]] || FIXTURE_CALLS="$(cat "$count")"
+  FIXTURE_ROOT="$root"
+}
+
 write_token() {
   local dir="$1" shard="$2" token="$3"
   mkdir -p "$dir/emulator-journey-verdict-shard-$shard"
@@ -142,6 +213,26 @@ run_aggregate() {
   AGG_RC=$?
   set -e
   AGG_VERDICT="$(sed -n 's/^AGGREGATE_VERDICT=//p' <<<"$AGG_OUT" | tail -n 1)"
+}
+
+assert_setup_upload_contract() {
+  local step upload_line retry_line
+  step="$(awk '
+    /^      - name: Upload Docker logs$/ { capture=1 }
+    capture && seen && /^      - name:/ { exit }
+    capture { print; seen=1 }
+  ' "$WORKFLOW")"
+  [[ -n "$step" ]] || fail "could not find the named Upload Docker logs step"
+  grep -Fxq '        if: always()' <<<"$step" \
+    || fail "Upload Docker logs must run under if: always() after failed setup"
+  grep -Fxq '        uses: actions/upload-artifact@v7' <<<"$step" \
+    || fail "Upload Docker logs must use actions/upload-artifact@v7"
+  grep -Fxq '            artifacts/ci-journey-setup/' <<<"$step" \
+    || fail "Upload Docker logs must package artifacts/ci-journey-setup/"
+  upload_line="$(grep -n '^      - name: Upload Docker logs$' "$WORKFLOW" | cut -d: -f1)"
+  retry_line="$(grep -n 'Request failed-job retry for external setup INFRA' "$WORKFLOW" | cut -d: -f1)"
+  [[ "$upload_line" =~ ^[0-9]+$ && "$retry_line" =~ ^[0-9]+$ && "$upload_line" -lt "$retry_line" ]] \
+    || fail "setup logs must upload before the intentional failed-job trigger"
 }
 
 echo "== #1913 pre-journey phase classification =="
@@ -164,6 +255,119 @@ grep -qx 'run_attempt=4' "$CLASSIFY_FILE" || fail "classifier token lost rerun-a
 grep -qx 'verdict_reason=preseed_before_classify' "$CLASSIFY_FILE" \
   && fail "classifier left the #1809 pre-seed in place"
 pass "skipped first/retry -> RED pre_journey_setup_failure -> aggregate RED, with current provenance"
+
+echo
+echo "== #2095 Docker Hub setup retry + exact signature classification =="
+REGISTRY_STUB="$SANDBOX/registry-stub.sh"
+make_registry_stub "$REGISTRY_STUB"
+
+run_fixture_retry recovered recover
+[[ "$FIXTURE_RC" -eq 0 && "$FIXTURE_CALLS" -eq 2 ]] \
+  || { cat "$SANDBOX/recovered-retry.log"; fail "observed 502 then success must recover on exactly one retry (rc=$FIXTURE_RC calls=$FIXTURE_CALLS)"; }
+grep -qx 'status=recovered' "$FIXTURE_ROOT/packet-loss-proxy/result.env" \
+  || fail "recovered setup did not record status=recovered"
+[[ ! -e "$FIXTURE_ROOT/failure.env" ]] \
+  || fail "recovered setup left a failure manifest that could poison classification"
+pass "observed Docker Hub 502 -> one in-shard retry -> success"
+
+run_fixture_retry exhausted exhaust
+EXHAUSTED_ROOT="$FIXTURE_ROOT"
+[[ "$FIXTURE_RC" -eq 37 && "$FIXTURE_CALLS" -eq 2 ]] \
+  || { cat "$SANDBOX/exhausted-retry.log"; fail "exhausted 502 must stop after two attempts (rc=$FIXTURE_RC calls=$FIXTURE_CALLS)"; }
+run_classify exhausted-502 skipped skipped "$EXHAUSTED_ROOT"
+[[ "$CLASSIFY_TOKEN" == "INFRA" \
+    && "$CLASSIFY_REASON" == "docker_registry_http_5xx_exhausted" \
+    && "$CLASSIFY_RC" -ne 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "two captured 502 attempts with zero journeys must classify INFRA precisely; got $CLASSIFY_TOKEN/$CLASSIFY_REASON/exit$CLASSIFY_RC"; }
+d="$SANDBOX/exhausted-token-plus-clean"; mkdir -p "$d"
+cp "$CLASSIFY_FILE" "$d/shard-verdict-2.txt"
+write_token "$d" 0 CLEAN; write_token "$d" 1 CLEAN
+run_aggregate "$d" failure
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "typed external setup INFRA must not be laundered back to aggregate RED; got $AGG_VERDICT/exit$AGG_RC"; }
+pass "exhausted captured 502 + zero journeys -> precise INFRA -> aggregate RE-RUN"
+
+if [[ -z "${ISSUE2095_FOCUS:-}" || "${ISSUE2095_FOCUS:-}" == "mixed" ]]; then
+  run_fixture_retry mixed-provider-product mixed
+  MIXED_ROOT="$FIXTURE_ROOT"
+  [[ "$FIXTURE_RC" -eq 43 && "$FIXTURE_CALLS" -eq 1 ]] \
+    || { cat "$SANDBOX/mixed-provider-product-retry.log"; fail "earlier successful Docker Hub chatter must not bind a later product 502 (rc=$FIXTURE_RC calls=$FIXTURE_CALLS)"; }
+  run_classify mixed-provider-product skipped skipped "$MIXED_ROOT"
+  [[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_REASON" == "pre_journey_setup_failure" ]] \
+    || { printf '%s\n' "$CLASSIFY_OUT"; fail "mixed provider/product log must stay RED/pre_journey_setup_failure"; }
+  pass "record-local binding: successful Docker Hub chatter cannot launder a later product 502"
+fi
+
+if [[ -z "${ISSUE2095_FOCUS:-}" || "${ISSUE2095_FOCUS:-}" == "network" ]]; then
+  run_fixture_retry recovered-network network-recover
+  [[ "$FIXTURE_RC" -eq 0 && "$FIXTURE_CALLS" -eq 2 ]] \
+    || fail "captured Docker registry network failure must recover on exactly one retry"
+  grep -qx 'status=recovered' "$FIXTURE_ROOT/packet-loss-proxy/result.env" \
+    || fail "network recovery did not record status=recovered"
+
+  run_fixture_retry exhausted-network network-exhaust
+  NETWORK_ROOT="$FIXTURE_ROOT"
+  [[ "$FIXTURE_RC" -eq 38 && "$FIXTURE_CALLS" -eq 2 ]] \
+    || fail "exhausted network signature must stop after two attempts"
+  run_classify exhausted-network skipped skipped "$NETWORK_ROOT"
+  [[ "$CLASSIFY_TOKEN" == "INFRA" \
+      && "$CLASSIFY_REASON" == "docker_registry_network_exhausted" \
+      && "$CLASSIFY_RC" -ne 0 ]] \
+    || { printf '%s\n' "$CLASSIFY_OUT"; fail "two captured network failures with zero journeys must classify INFRA precisely"; }
+  d="$SANDBOX/exhausted-network-token-plus-clean"; mkdir -p "$d"
+  cp "$CLASSIFY_FILE" "$d/shard-verdict-2.txt"
+  write_token "$d" 0 CLEAN; write_token "$d" 1 CLEAN
+  run_aggregate "$d" failure
+  [[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+    || fail "typed network setup INFRA must aggregate RE-RUN"
+  grep -Fq "shard_verdict_reason == 'docker_registry_network_exhausted'" "$WORKFLOW" \
+    || fail "failed-job retry gate must be bound to the precise network reason"
+  pass "registry-network signature -> bounded recover/exhaust -> precise INFRA/aggregate/failed-job reason"
+fi
+
+if [[ -z "${ISSUE2095_FOCUS:-}" || "${ISSUE2095_FOCUS:-}" == "upload" ]]; then
+  assert_setup_upload_contract
+  pass "named setup-log artifact upload is always-run and precedes the failed-job trigger"
+fi
+
+if [[ -n "${ISSUE2095_FOCUS:-}" ]]; then
+  echo "PASS: focused #2095 case ${ISSUE2095_FOCUS}"
+  exit 0
+fi
+
+# Signature mutation: the same bounded failures without the provider/status
+# signature are unknown. They get one attempt and stay fail-closed RED.
+run_fixture_retry unknown-signature unknown
+UNKNOWN_ROOT="$FIXTURE_ROOT"
+[[ "$FIXTURE_RC" -eq 42 && "$FIXTURE_CALLS" -eq 1 ]] \
+  || fail "unknown setup failure must not consume the external-infra retry"
+run_classify unknown-signature skipped skipped "$UNKNOWN_ROOT"
+[[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_REASON" == "pre_journey_setup_failure" ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "signature mutation must stay RED/pre_journey_setup_failure"; }
+pass "signature mutation is selective: unknown setup failure is not retried or typed INFRA"
+
+# Zero-journey mutation: even valid setup logs cannot soften a shard once any
+# journey-owned artifact exists.
+JOURNEY_EVIDENCE="$SANDBOX/journey-evidence"
+mkdir -p "$JOURNEY_EVIDENCE/class-attempts/real-red/attempt-1"
+printf 'journey started\n' > "$JOURNEY_EVIDENCE/class-attempts/real-red/attempt-1/manifest.env"
+run_classify has-journey-evidence skipped skipped "$EXHAUSTED_ROOT" "$JOURNEY_EVIDENCE"
+[[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_REASON" == "pre_journey_setup_failure" ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "zero-journey mutation must reject INFRA and remain RED"; }
+pass "zero-journey condition is load-bearing: any journey evidence keeps the shard RED"
+
+# Real-red control: a substantive suite failure dominates adjacent setup logs.
+REAL_RED="$SANDBOX/real-red"
+mkdir -p "$REAL_RED"
+cat > "$REAL_RED/summary.md" <<'EOF'
+JOURNEY_FAILED
+Failed BOTH attempts
+- `com.pocketshell.RealJourneyAssertionTest`
+EOF
+run_classify real-journey-red failure failure "$EXHAUSTED_ROOT" "$REAL_RED"
+[[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_REASON" == "journey_failure_both_attempts" ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "real journey assertion failure must remain RED beside setup signatures"; }
+pass "real Failed-BOTH assertion remains RED; setup INFRA cannot launder product red"
 
 echo
 echo "== #1913 upstream-matrix aggregate backstop =="
@@ -200,6 +404,20 @@ grep -Fq 'UPSTREAM_MATRIX_RESULT: ${{ needs.emulator-journey.result }}' "$WORKFL
 grep -Fq 'scripts/test-ci-journey-pre-journey-classification.sh' "$WORKFLOW" \
   || fail "the #1913 regression must be wired into the Unit job"
 pass "upstream matrix result and this cheap guard are wired in tests.yml"
+
+echo
+echo "== #2095 workflow retry/artifact wiring =="
+for fixture in sshd agents packet-loss-proxy network-fault-proxy agents-old-cli agents-daemon; do
+  count="$(grep -c "ci-journey-fixture-retry.sh $fixture -- docker compose" "$WORKFLOW" || true)"
+  [[ "$count" -eq 1 ]] \
+    || fail "fixture $fixture must have exactly one bounded pre-journey wrapper, found $count"
+done
+assert_setup_upload_contract
+grep -Fq 'Request failed-job retry for external setup INFRA (issue #2095)' "$WORKFLOW" \
+  || fail "exhausted external setup INFRA must fail only its shard for failed-job retry"
+grep -Fq "shard_verdict_reason == 'docker_registry_http_5xx_exhausted'" "$WORKFLOW" \
+  || fail "failed-job retry gate must be bound to the precise HTTP-5xx reason"
+pass "all pull/build fixtures are wrapped once; setup logs + precise failed-shard retry are wired"
 
 echo
 echo "PASS: #1913 real classifier + aggregate phase-aware verdict guard"

--- a/scripts/test-ci-mobile-rtt-readiness.sh
+++ b/scripts/test-ci-mobile-rtt-readiness.sh
@@ -55,9 +55,24 @@ PY
 
 sandbox="$(mktemp -d)"
 trap 'rm -rf "$sandbox"' EXIT
-mkdir -p "$sandbox/repo/tests/docker" "$sandbox/bin"
+mkdir -p "$sandbox/repo/tests/docker" "$sandbox/repo/scripts" "$sandbox/bin"
 cp "$REPO_ROOT/tests/docker/test_key" "$sandbox/repo/tests/docker/test_key"
 chmod 0644 "$sandbox/repo/tests/docker/test_key"
+
+# Issue #2095: the extracted production block now calls the bounded fixture
+# retry helper. Copy the real helper, not a no-op stub, so this sandbox exercises
+# its command dispatch and success artifact as production does. The helper is
+# self-contained; its external utilities continue to come from the normal PATH.
+fixture_retry_source="$REPO_ROOT/scripts/ci-journey-fixture-retry.sh"
+fixture_retry_sandbox="$sandbox/repo/scripts/ci-journey-fixture-retry.sh"
+[[ -f "$fixture_retry_source" ]] \
+  || fail "repository fixture-retry wrapper not found: $fixture_retry_source"
+cp "$fixture_retry_source" "$fixture_retry_sandbox"
+chmod +x "$fixture_retry_sandbox"
+[[ -x "$fixture_retry_sandbox" ]] \
+  || fail "mobile-RTT sandbox is missing the executable fixture-retry wrapper"
+cmp -s "$fixture_retry_source" "$fixture_retry_sandbox" \
+  || fail "mobile-RTT sandbox must exercise the real fixture-retry wrapper"
 
 run_block="$sandbox/mobile-rtt-readiness.sh"
 awk '
@@ -119,12 +134,20 @@ export CI_MOBILE_RTT_SSH_LOG="$sandbox/ssh.log"
 (
   cd "$sandbox/repo" || exit 1
   PATH="$sandbox/bin:$PATH" bash -eu "$run_block"
-) || fail "mobile-RTT readiness invoked OpenSSH before securing the 0644 checkout key"
+) || fail "mobile-RTT readiness block failed (check the real fixture-retry wrapper, key ordering, and SSH proof)"
 
 [[ "$(stat -c '%a' "$sandbox/repo/tests/docker/test_key")" == "600" ]] \
   || fail "readiness block did not leave the checkout key owner-only"
 grep -Fq 'compose -f tests/docker/docker-compose.yml up -d --build --no-deps packet-loss-proxy' \
   "$sandbox/docker.log" || fail "readiness no longer starts the packet-loss proxy"
+[[ "$(wc -l < "$sandbox/docker.log")" -eq 1 ]] \
+  || fail "successful packet-loss proxy setup must invoke Docker exactly once"
+grep -Fxq 'status=success' \
+  "$sandbox/repo/artifacts/ci-journey-setup/packet-loss-proxy/result.env" \
+  || fail "real fixture-retry wrapper did not record successful setup"
+grep -Fxq 'attempts=1' \
+  "$sandbox/repo/artifacts/ci-journey-setup/packet-loss-proxy/result.env" \
+  || fail "real fixture-retry wrapper did not preserve the one-attempt success bound"
 grep -Fq -- '-i tests/docker/test_key -p 2229' "$sandbox/ssh.log" \
   || fail "readiness no longer probes the proxy with the repository test key on port 2229"
 grep -Fq -- '-o BatchMode=yes -o ConnectTimeout=3' "$sandbox/ssh.log" \
@@ -132,4 +155,4 @@ grep -Fq -- '-o BatchMode=yes -o ConnectTimeout=3' "$sandbox/ssh.log" \
 grep -Fq -- '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null testuser@127.0.0.1 true' \
   "$sandbox/ssh.log" || fail "readiness no longer proves SSH auth through the proxy"
 
-pass "mobile-RTT readiness secures a 0644 checkout key before the preserved proxy/SSH proof"
+pass "mobile-RTT readiness uses the real fixture-retry wrapper, secures the key, and preserves the proxy/SSH proof"


### PR DESCRIPTION
Closes #2095.

- retries only record-local Docker registry HTTP-5xx/network setup failures, once
- preserves unknown/product failures as RED and requires zero journey evidence for INFRA
- uploads setup logs on failed paths and keeps failed-job rerun classification load-bearing
- regression-first production-body guard plus seven selective mutations

Implementer: https://github.com/alexeygrigorev/pocketshell/issues/2095#issuecomment-5259445552
Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2095#issuecomment-5259597544