### PR TITLE
test infra: harden timing-oracle validity guard

### DIFF
--- a/app/src/test/java/com/pocketshell/app/portfwd/service/ForwardingServiceObserverGenerationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/portfwd/service/ForwardingServiceObserverGenerationTest.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.testsupport.drainMainLooperUntil
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -16,6 +17,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -327,6 +329,66 @@ class ForwardingServiceObserverGenerationTest {
         )
     }
 
+    /**
+     * Issue #2026 regression-first proof: the observer can be healthy but not
+     * scheduled until after the legacy local settle window. The condition is
+     * deliberately delayed on the REAL observe executor; an isolated happy
+     * pass is not evidence for the contention failure that filed this issue.
+     */
+    @Test
+    fun notificationPumpAbsorbsARealObserverSchedulingStall() {
+        startServiceWithSettledForward()
+
+        val stallStarted = CountDownLatch(1)
+        val stalledOnce = AtomicBoolean(false)
+        service.beforeNotificationPublishForTest = {
+            if (stalledOnce.compareAndSet(false, true)) {
+                stallStarted.countDown()
+                Thread.sleep(TimeUnit.SECONDS.toMillis(6L))
+            }
+        }
+
+        controller.updateActiveTunnels(HOST_A, MORE_TUNNELS)
+        assertTrue(
+            "the real observer must enter the injected scheduling stall",
+            stallStarted.await(BOUNDARY_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+        )
+
+        assertEquals(
+            "a healthy observer delayed by contention must still reach the expected body",
+            GREW_TEXT,
+            awaitForwardingNotificationText(GREW_TEXT),
+        )
+    }
+
+    /**
+     * Issue #2026 hard-timeout contract. The injected pump models the audited
+     * helper exhausting its deadline while the real condition never holds.
+     * This must throw here; returning the stale body would silently move the
+     * failure onto whichever outer assertion happens to consume it.
+     */
+    @Test
+    fun notificationPumpHardFailsWhenTheConditionNeverSettles() {
+        val failure = assertThrows(AssertionError::class.java) {
+            awaitForwardingNotificationText(
+                expected = "a notification body that can never exist",
+                settle = { onTick, condition ->
+                    onTick()
+                    assertTrue(
+                        "the timeout fixture must leave the exit condition unsatisfied",
+                        !condition(),
+                    )
+                    false
+                },
+            )
+        }
+
+        assertTrue(
+            "the wrapper must identify its own hard timeout",
+            failure.message.orEmpty().contains("timed out"),
+        )
+    }
+
     // ---------------------------------------------------------------- helpers
 
     private fun startServiceWithSettledForward() {
@@ -431,12 +493,33 @@ class ForwardingServiceObserverGenerationTest {
      * observer runs on a REAL executor, so the load-bearing assertion is this
      * pump's exit condition, never the loop body.
      */
-    private fun awaitForwardingNotificationText(expected: String): String? {
-        val deadline = System.currentTimeMillis() + SETTLE_TIMEOUT_MS
+    private fun awaitForwardingNotificationText(
+        expected: String,
+        settle: (onTick: () -> Unit, condition: () -> Boolean) -> Boolean =
+            { onTick, condition ->
+                drainMainLooperUntil(
+                    sleepMs = 0L,
+                    onTick = onTick,
+                    condition = condition,
+                )
+            },
+    ): String? {
         var text = forwardingNotificationText()
-        while (text != expected && System.currentTimeMillis() < deadline) {
-            Thread.sleep(POLL_INTERVAL_MS)
-            text = forwardingNotificationText()
+        val settled = settle(
+            {
+                // Issue #2026: preserve the predecessor's per-tick drain
+                // verbatim. Only the deadline/loop ownership moves to the
+                // audited shared helper.
+                Thread.sleep(POLL_INTERVAL_MS)
+                text = forwardingNotificationText()
+            },
+            { text == expected },
+        )
+        if (!settled) {
+            throw AssertionError(
+                "awaitForwardingNotificationText timed out waiting for: $expected; " +
+                    "last body=$text",
+            )
         }
         return text
     }
@@ -452,7 +535,6 @@ class ForwardingServiceObserverGenerationTest {
         const val GREW_TEXT = "Running in the background · Race Host · 3 ports forwarded"
         const val BOOTSTRAP_TEXT = "Running in the background · Connecting…"
         const val BOUNDARY_TIMEOUT_MS = 10_000L
-        const val SETTLE_TIMEOUT_MS = 5_000L
         const val POLL_INTERVAL_MS = 20L
     }
 }

--- a/app/src/test/java/com/pocketshell/app/prefs/DeferredPrefsCorruptPrefsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/prefs/DeferredPrefsCorruptPrefsTest.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.testsupport.drainMainLooperUntil
 import kotlinx.coroutines.asCoroutineDispatcher
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -172,6 +174,71 @@ class DeferredPrefsCorruptPrefsTest {
         }
     }
 
+    /**
+     * Issue #2026 regression-first proof: the cold get is healthy but remains
+     * unscheduled until after the legacy local settle window, then reaches the
+     * BLOCKED state that the race arbiter is waiting for. This is a real-thread
+     * scheduling stall, not an isolated immediate-success proxy.
+     */
+    @Test
+    fun raceArbitrationPumpAbsorbsARealThreadSchedulingStall() {
+        val corruptContext = RacingCorruptScreenPrefsContext(realContext)
+        val blockingMonitor = Any()
+        val coldGetThread = Thread(
+            {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(6L))
+                synchronized(blockingMonitor) {
+                    // The test thread deliberately holds this monitor until the
+                    // race arbiter observes this worker in BLOCKED state.
+                }
+            },
+            "deferred-prefs-delayed-cold-get-test",
+        )
+
+        try {
+            synchronized(blockingMonitor) {
+                coldGetThread.start()
+                assertEquals(
+                    "the delayed cold get must eventually be observed behind the in-flight warm open",
+                    false,
+                    corruptContext.awaitSecondThrowingOpenOrColdGetBlocked(coldGetThread),
+                )
+            }
+        } finally {
+            coldGetThread.joinOrFail()
+        }
+    }
+
+    /**
+     * Issue #2026 hard-timeout contract. The injected pump returns the audited
+     * helper's false-on-timeout result while neither race outcome is present.
+     * The arbiter must throw rather than returning a made-up branch decision.
+     */
+    @Test
+    fun raceArbitrationPumpHardFailsWhenNeitherConditionEverSettles() {
+        val corruptContext = RacingCorruptScreenPrefsContext(realContext)
+        val neverStartedColdGet = Thread({}, "deferred-prefs-never-started-cold-get-test")
+
+        val failure = assertThrows(AssertionError::class.java) {
+            corruptContext.awaitSecondThrowingOpenOrColdGetBlocked(
+                coldGetThread = neverStartedColdGet,
+                settle = { onTick, condition ->
+                    onTick()
+                    assertTrue(
+                        "the timeout fixture must leave both race outcomes unsatisfied",
+                        !condition(),
+                    )
+                    false
+                },
+            )
+        }
+
+        assertTrue(
+            "the race arbiter must identify its own hard timeout",
+            failure.message.orEmpty().contains("neither raced"),
+        )
+    }
+
     private fun clearPrefs() {
         realContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit().clear().commit()
@@ -255,16 +322,38 @@ class DeferredPrefsCorruptPrefsTest {
             )
         }
 
-        fun awaitSecondThrowingOpenOrColdGetBlocked(coldGetThread: Thread): Boolean {
-            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (System.nanoTime() < deadline) {
-                if (secondThrowingOpenStarted.await(10, TimeUnit.MILLISECONDS)) return true
-                if (coldGetThread.state == Thread.State.BLOCKED) return false
-            }
-            throw AssertionError(
-                "cold get neither raced into a second corrupt open nor blocked " +
-                    "behind the in-flight warm open",
+        fun awaitSecondThrowingOpenOrColdGetBlocked(
+            coldGetThread: Thread,
+            settle: (onTick: () -> Unit, condition: () -> Boolean) -> Boolean =
+                { onTick, condition ->
+                    drainMainLooperUntil(
+                        sleepMs = 0L,
+                        onTick = onTick,
+                        condition = condition,
+                    )
+                },
+        ): Boolean {
+            var result: Boolean? = null
+            val settled = settle(
+                {
+                    // Issue #2026: preserve both predecessor observation
+                    // points verbatim through onTick. Their ordering decides
+                    // which real race branch won.
+                    if (secondThrowingOpenStarted.await(10, TimeUnit.MILLISECONDS)) {
+                        result = true
+                    } else if (coldGetThread.state == Thread.State.BLOCKED) {
+                        result = false
+                    }
+                },
+                { result != null },
             )
+            if (!settled) {
+                throw AssertionError(
+                    "cold get neither raced into a second corrupt open nor blocked " +
+                        "behind the in-flight warm open",
+                )
+            }
+            return checkNotNull(result) { "settle pump reported success without a race outcome" }
         }
 
         fun allowFirstCorruptOpenToRecover() {

--- a/scripts/check-test-validity-selftest.sh
+++ b/scripts/check-test-validity-selftest.sh
@@ -2,7 +2,7 @@
 # Self-test for scripts/check-test-validity.sh (issue #850).
 #
 # For each detector added for #848/#850 (C1, FAKE1, AWAIT1, J1), the
-# pre-existing A5, and #1857 A5L, this driver plants a BAD fixture (the smell)
+# pre-existing A5, #1048/#2026 TIMING1, and #1857 A5L, this driver plants a BAD fixture (the smell)
 # and a GOOD fixture (the corrective shape), runs the guard, and asserts the bad
 # fixture is reported as a finding while the good fixture is NOT — the
 # red->green proof for the detector itself. It also asserts the guard HARD-FAILS
@@ -15,7 +15,9 @@
 # Usage: scripts/check-test-validity-selftest.sh
 # Runs alongside the guard in the Unit job; exits non-zero on any self-test miss.
 
-set -uo pipefail
+# This harness judges another fail-closed script. Its own unhandled runtime
+# errors must likewise stop the run instead of reaching a green summary.
+set -Eeuo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
@@ -31,24 +33,37 @@ FIX_TAG="selftest_$$"
 TEST_FIX_DIR="app/src/test/java/com/pocketshell/app/$FIX_TAG"
 ANDROID_FIX_DIR="app/src/androidTest/java/com/pocketshell/app/$FIX_TAG"
 SRC_FIX_DIR="app/src/main/java/com/pocketshell/app/$FIX_TAG"
-# TIMING1 is scoped to the connection/terminal roots, so its fixtures must live
-# under one of those dirs (here: the app tmux JVM test root).
+# TIMING1's original runTest fixture lives under app/tmux. Its #2026
+# plain-JUnit deadline-pump fixtures live under the two exact new roots so the
+# self-test proves real scan reachability rather than merely branch presence.
 TIMING_FIX_DIR="app/src/test/java/com/pocketshell/app/tmux/$FIX_TAG"
+TIMING_PORTFWD_FIX_DIR="app/src/test/java/com/pocketshell/app/portfwd/$FIX_TAG"
+TIMING_PREFS_FIX_DIR="app/src/test/java/com/pocketshell/app/prefs/$FIX_TAG"
 TMP_REG=""
 CLEANUP_SIBLING_TAG=""
+MUTATED_GUARD=""
 
 # Remove ONLY this invocation's own (PID-suffixed) fixture dirs, so a concurrent
 # sibling self-test (different PID) is never disturbed. Also remove this
 # invocation's unique temporary registry if an interrupt arrives mid-check.
 cleanup() {
-  rm -rf "$TEST_FIX_DIR" "$ANDROID_FIX_DIR" "$SRC_FIX_DIR" "$TIMING_FIX_DIR"
+  rm -rf \
+    "$TEST_FIX_DIR" \
+    "$ANDROID_FIX_DIR" \
+    "$SRC_FIX_DIR" \
+    "$TIMING_FIX_DIR" \
+    "$TIMING_PORTFWD_FIX_DIR" \
+    "$TIMING_PREFS_FIX_DIR"
   [[ -z "${TMP_REG:-}" ]] || rm -f -- "$TMP_REG"
+  [[ -z "${MUTATED_GUARD:-}" ]] || rm -f -- "$MUTATED_GUARD"
   if [[ -n "${CLEANUP_SIBLING_TAG:-}" ]]; then
     rm -rf \
       "app/src/test/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
       "app/src/androidTest/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
       "app/src/main/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
-      "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG"
+      "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG" \
+      "app/src/test/java/com/pocketshell/app/portfwd/$CLEANUP_SIBLING_TAG" \
+      "app/src/test/java/com/pocketshell/app/prefs/$CLEANUP_SIBLING_TAG"
   fi
 }
 exit_from_signal() {
@@ -61,7 +76,13 @@ trap cleanup EXIT
 trap 'exit_from_signal 130' INT
 trap 'exit_from_signal 143' TERM
 cleanup
-mkdir -p "$TEST_FIX_DIR" "$ANDROID_FIX_DIR" "$SRC_FIX_DIR" "$TIMING_FIX_DIR"
+mkdir -p \
+  "$TEST_FIX_DIR" \
+  "$ANDROID_FIX_DIR" \
+  "$SRC_FIX_DIR" \
+  "$TIMING_FIX_DIR" \
+  "$TIMING_PORTFWD_FIX_DIR" \
+  "$TIMING_PREFS_FIX_DIR"
 
 # Internal child mode for the deterministic SIGTERM cleanup regression below.
 # It creates only its normal PID-scoped fixtures, then waits to be terminated.
@@ -88,7 +109,9 @@ run_sigterm_cleanup_regression() {
     "app/src/test/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
     "app/src/androidTest/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
     "app/src/main/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
-    "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG"
+    "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG" \
+    "app/src/test/java/com/pocketshell/app/portfwd/$CLEANUP_SIBLING_TAG" \
+    "app/src/test/java/com/pocketshell/app/prefs/$CLEANUP_SIBLING_TAG"
 
   "$REPO_ROOT/scripts/check-test-validity-selftest.sh" --sigterm-cleanup-probe &
   probe_pid=$!
@@ -98,7 +121,9 @@ run_sigterm_cleanup_regression() {
     if [[ -d "app/src/test/java/com/pocketshell/app/$probe_tag" &&
           -d "app/src/androidTest/java/com/pocketshell/app/$probe_tag" &&
           -d "app/src/main/java/com/pocketshell/app/$probe_tag" &&
-          -d "app/src/test/java/com/pocketshell/app/tmux/$probe_tag" ]]; then
+          -d "app/src/test/java/com/pocketshell/app/tmux/$probe_tag" &&
+          -d "app/src/test/java/com/pocketshell/app/portfwd/$probe_tag" &&
+          -d "app/src/test/java/com/pocketshell/app/prefs/$probe_tag" ]]; then
       probe_ready=1
       break
     fi
@@ -114,13 +139,17 @@ run_sigterm_cleanup_regression() {
         ! -e "app/src/test/java/com/pocketshell/app/$probe_tag" &&
         ! -e "app/src/androidTest/java/com/pocketshell/app/$probe_tag" &&
         ! -e "app/src/main/java/com/pocketshell/app/$probe_tag" &&
-        ! -e "app/src/test/java/com/pocketshell/app/tmux/$probe_tag" ]]; then
+        ! -e "app/src/test/java/com/pocketshell/app/tmux/$probe_tag" &&
+        ! -e "app/src/test/java/com/pocketshell/app/portfwd/$probe_tag" &&
+        ! -e "app/src/test/java/com/pocketshell/app/prefs/$probe_tag" ]]; then
     own_removed=1
   fi
   if [[ -d "app/src/test/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" &&
-        -d "app/src/androidTest/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" &&
-        -d "app/src/main/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" &&
-        -d "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG" ]]; then
+      -d "app/src/androidTest/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" &&
+      -d "app/src/main/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" &&
+      -d "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG" &&
+      -d "app/src/test/java/com/pocketshell/app/portfwd/$CLEANUP_SIBLING_TAG" &&
+      -d "app/src/test/java/com/pocketshell/app/prefs/$CLEANUP_SIBLING_TAG" ]]; then
     sibling_preserved=1
   fi
 
@@ -140,10 +169,14 @@ run_sigterm_cleanup_regression() {
     "app/src/androidTest/java/com/pocketshell/app/$probe_tag" \
     "app/src/main/java/com/pocketshell/app/$probe_tag" \
     "app/src/test/java/com/pocketshell/app/tmux/$probe_tag" \
+    "app/src/test/java/com/pocketshell/app/portfwd/$probe_tag" \
+    "app/src/test/java/com/pocketshell/app/prefs/$probe_tag" \
     "app/src/test/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
     "app/src/androidTest/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
     "app/src/main/java/com/pocketshell/app/$CLEANUP_SIBLING_TAG" \
-    "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG"
+    "app/src/test/java/com/pocketshell/app/tmux/$CLEANUP_SIBLING_TAG" \
+    "app/src/test/java/com/pocketshell/app/portfwd/$CLEANUP_SIBLING_TAG" \
+    "app/src/test/java/com/pocketshell/app/prefs/$CLEANUP_SIBLING_TAG"
   CLEANUP_SIBLING_TAG=""
 }
 
@@ -175,20 +208,37 @@ _CACHE_OUT=""
 _CACHE_RC=""
 _fixture_signature() {
   {
-    find "$TEST_FIX_DIR" "$ANDROID_FIX_DIR" "$SRC_FIX_DIR" "$TIMING_FIX_DIR" \
+    find \
+      "$TEST_FIX_DIR" \
+      "$ANDROID_FIX_DIR" \
+      "$SRC_FIX_DIR" \
+      "$TIMING_FIX_DIR" \
+      "$TIMING_PORTFWD_FIX_DIR" \
+      "$TIMING_PREFS_FIX_DIR" \
       -type f -printf '%p|%s|%T@\n' 2>/dev/null | sort
     printf 'REG:%s\n' "${VETTED_SEAM_REGISTRY:-<default>}"
     [[ -n "${VETTED_SEAM_REGISTRY:-}" && -f "${VETTED_SEAM_REGISTRY}" ]] \
       && printf 'REGSIG:%s\n' "$(cksum "$VETTED_SEAM_REGISTRY")"
   } | cksum
+  return 0
 }
 ensure_guard_cache() {
   local sig
   sig="$(_fixture_signature)"
   if [[ "$sig" != "$_CACHE_SIG" ]]; then
     _CACHE_SIG="$sig"
-    _CACHE_OUT="$("$GUARD" 2>&1)"
-    _CACHE_RC=$?
+    if _CACHE_OUT="$("$GUARD" 2>&1)"; then
+      _CACHE_RC=0
+    else
+      _CACHE_RC=$?
+    fi
+    if printf '%s\n' "$_CACHE_OUT" \
+        | grep -Eq '(^|: )[[:alnum:]_./-]+: command not found($|[[:space:]])|unbound variable|syntax error near unexpected token'; then
+      note_fail "guard cache state emitted an internal shell/runtime diagnostic"
+      # Never let an expected detector rc=1 launder an unrelated runtime error
+      # into a successful red proof.
+      _CACHE_RC=125
+    fi
   fi
 }
 
@@ -211,6 +261,113 @@ assert_exit() {
   local got="$_CACHE_RC"
   if [[ "$got" -eq "$want" ]]; then note_pass "$desc (exit $got)"; else note_fail "$desc (want exit $want, got $got)"; fi
 }
+
+# A shell/runtime diagnostic in the guard output invalidates every cached
+# detector verdict. In particular, a later expected exit=1 must not launder an
+# unrelated `command not found` into a successful red proof.
+assert_guard_runtime_clean() {
+  local desc="$1"
+  ensure_guard_cache
+  if printf '%s\n' "$_CACHE_OUT" \
+      | grep -Eq '(^|: )[[:alnum:]_./-]+: command not found($|[[:space:]])|unbound variable|syntax error near unexpected token'; then
+    note_fail "$desc (guard emitted an internal shell/runtime diagnostic)"
+  else
+    note_pass "$desc"
+  fi
+}
+
+# Mutate the actual TIMING1 conditional-helper call in a private executable copy
+# beside the real guard (so its repo-root discovery is unchanged). Bash disables
+# errexit for commands used as an `if` condition, including all commands inside
+# a condition-invoked function. The mutant must therefore return non-zero by the
+# guard's explicit predicate-error contract, not by top-level `set -e` luck.
+run_guard_runtime_error_regression() {
+  local out rc inserted pass_footers
+  MUTATED_GUARD="$(mktemp "scripts/.check-test-validity-runtime-error.$$.XXXXXX.sh")"
+  awk '
+    {
+      if (index($0, "timing1_checked_predicate timing1_uses_shared_pump_only_scope \"$file\"") > 0) {
+        sub(/timing1_uses_shared_pump_only_scope/, "test_validity_selftest_missing_conditional_helper")
+        inserted++
+      }
+      print
+    }
+    END {
+      if (inserted != 1) exit 90
+    }
+  ' "$GUARD" > "$MUTATED_GUARD"
+  chmod +x "$MUTATED_GUARD"
+  inserted="$(grep -c 'timing1_checked_predicate test_validity_selftest_missing_conditional_helper "\$file"' "$MUTATED_GUARD")"
+  if [[ "$inserted" -eq 1 ]]; then
+    note_pass "conditional-helper mutant is live exactly once at the TIMING1 call site"
+  else
+    note_fail "conditional-helper mutant insertion count (want 1, got $inserted)"
+  fi
+  if out="$("$MUTATED_GUARD" 2>&1)"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if printf '%s\n' "$out" | grep -q 'test_validity_selftest_missing_conditional_helper: command not found'; then
+    note_pass "conditional-helper mutant executed the missing command"
+  else
+    note_fail "conditional-helper mutant did not emit its command-not-found diagnostic"
+  fi
+  pass_footers="$(printf '%s\n' "$out" | grep -c '^PASS: no new unjustified' || true)"
+  if [[ "$pass_footers" -eq 0 ]]; then
+    note_pass "conditional command-not-found cannot reach the normal PASS footer"
+  else
+    note_fail "conditional command-not-found reached $pass_footers normal PASS footer(s)"
+  fi
+  if [[ "$rc" -ne 0 ]]; then
+    note_pass "conditional command-not-found cannot be reported as a passing guard (exit $rc)"
+  else
+    note_fail "conditional command-not-found false-greened the guard (exit 0)"
+  fi
+  rm -f -- "$MUTATED_GUARD"
+  MUTATED_GUARD=""
+}
+
+# Keep this awk-shaped historical fragment out of the runtime mutant above:
+# the round-3 top-level mutation was insufficient because `set -e` made it red
+# without exercising the conditional-command exception.
+: <<'REMOVED_TOP_LEVEL_MUTANT'
+  awk '
+    { print }
+    /^scan_void1$/ {
+      print "test_validity_selftest_missing_command"
+      inserted++
+    }
+    END {
+      if (inserted != 1) exit 90
+    }
+  ' "$GUARD" > "$MUTATED_GUARD"
+  chmod +x "$MUTATED_GUARD"
+  inserted="$(grep -c '^test_validity_selftest_missing_command$' "$MUTATED_GUARD")"
+  if [[ "$inserted" -eq 1 ]]; then
+    note_pass "internal-error mutant is live exactly once"
+  else
+    note_fail "internal-error mutant insertion count (want 1, got $inserted)"
+  fi
+  if out="$("$MUTATED_GUARD" 2>&1)"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if printf '%s\n' "$out" | grep -q 'test_validity_selftest_missing_command: command not found'; then
+    note_pass "internal-error mutant executed the missing command"
+  else
+    note_fail "internal-error mutant did not emit its command-not-found diagnostic"
+  fi
+  if [[ "$rc" -ne 0 ]]; then
+    note_pass "internal command-not-found cannot be reported as a passing guard (exit $rc)"
+  else
+    note_fail "internal command-not-found false-greened the guard (exit 0)"
+  fi
+  rm -f -- "$MUTATED_GUARD"
+  MUTATED_GUARD=""
+}
+REMOVED_TOP_LEVEL_MUTANT
 
 echo "=============================================================="
 echo " Self-test: scripts/check-test-validity.sh (#850 detectors)"
@@ -596,6 +753,254 @@ class Timing1AdvisoryRealScopeTest {
 }
 KT
 
+# BAD-PLAIN-PORTFWD (#2026): the exact predecessor shape from
+# ForwardingServiceObserverGenerationTest. It is deliberately ordinary JUnit
+# (no runTest), computes a local 5 s currentTimeMillis deadline, then sleeps and
+# rereads the notification inside the while pump.
+cat > "$TIMING_PORTFWD_FIX_DIR/Timing1BadPortfwdLegacyPumpTest.kt" <<'KT'
+package com.pocketshell.app.portfwd.validityselftest
+class Timing1BadPortfwdLegacyPumpTest {
+    private fun awaitForwardingNotificationText(expected: String): String? {
+        val deadline = System.currentTimeMillis() + SETTLE_TIMEOUT_MS
+        var text = forwardingNotificationText()
+        while (text != expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(POLL_INTERVAL_MS)
+            text = forwardingNotificationText()
+        }
+        return text
+    }
+    private fun forwardingNotificationText(): String? = null
+    private companion object {
+        const val SETTLE_TIMEOUT_MS = 5_000L
+        const val POLL_INTERVAL_MS = 20L
+    }
+}
+KT
+
+# BAD-PLAIN-PREFS (#2026): the exact predecessor shape from
+# DeferredPrefsCorruptPrefsTest. It uses nanoTime plus the ordered latch/BLOCKED
+# observations and likewise has no runTest branch for the detector to lean on.
+cat > "$TIMING_PREFS_FIX_DIR/Timing1BadPrefsLegacyPumpTest.kt" <<'KT'
+package com.pocketshell.app.prefs.validityselftest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+class Timing1BadPrefsLegacyPumpTest {
+    private val secondThrowingOpenStarted = CountDownLatch(1)
+    fun awaitSecondThrowingOpenOrColdGetBlocked(coldGetThread: Thread): Boolean {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (System.nanoTime() < deadline) {
+            if (secondThrowingOpenStarted.await(10, TimeUnit.MILLISECONDS)) return true
+            if (coldGetThread.state == Thread.State.BLOCKED) return false
+        }
+        throw AssertionError("cold get neither raced nor blocked")
+    }
+}
+KT
+
+# BAD-PLAIN-PORTFWD-MULTILINE (#2026 round 3): the same predecessor semantics
+# with an ordinary wrapped deadline declaration and while condition. Formatting
+# cannot turn local wall-clock loop ownership into a clean result.
+cat > "$TIMING_PORTFWD_FIX_DIR/Timing1BadPortfwdMultilinePumpTest.kt" <<'KT'
+package com.pocketshell.app.portfwd.validityselftest
+class Timing1BadPortfwdMultilinePumpTest {
+    private fun awaitForwardingNotificationText(expected: String): String? {
+        val deadline =
+            System.currentTimeMillis() + 5_000L
+        var text = forwardingNotificationText()
+        while (
+            text != expected &&
+            System.currentTimeMillis() < deadline
+        ) {
+            Thread.sleep(20L)
+            text = forwardingNotificationText()
+        }
+        return text
+    }
+    private fun forwardingNotificationText(): String? = null
+}
+KT
+
+# BAD-PLAIN-PREFS-MULTILINE (#2026 round 3): the nanoTime predecessor keeps its
+# ordered latch/BLOCKED observations while both its typed deadline declaration
+# and loop comparison use normal multiline Kotlin formatting.
+cat > "$TIMING_PREFS_FIX_DIR/Timing1BadPrefsMultilinePumpTest.kt" <<'KT'
+package com.pocketshell.app.prefs.validityselftest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+class Timing1BadPrefsMultilinePumpTest {
+    private val secondThrowingOpenStarted = CountDownLatch(1)
+    fun awaitSecondThrowingOpenOrColdGetBlocked(coldGetThread: Thread): Boolean {
+        val deadline: Long =
+            System.nanoTime() +
+                TimeUnit.SECONDS.toNanos(5)
+        while (
+            System.nanoTime() <
+                deadline
+        ) {
+            if (secondThrowingOpenStarted.await(10, TimeUnit.MILLISECONDS)) return true
+            if (coldGetThread.state == Thread.State.BLOCKED) return false
+        }
+        throw AssertionError("cold get neither raced nor blocked")
+    }
+}
+KT
+
+# BAD lexical control: comments are allowed between executable tokens. The
+# sanitizer must erase them without erasing the real multiline deadline pump.
+cat > "$TIMING_PORTFWD_FIX_DIR/Timing1BadCommentInterleavedPumpTest.kt" <<'KT'
+package com.pocketshell.app.portfwd.validityselftest
+class Timing1BadCommentInterleavedPumpTest {
+    fun awaitCondition(): Boolean {
+        val deadline =
+            System.currentTimeMillis() /* still executable */ + 5_000L
+        while (System.currentTimeMillis() < /* compare */ deadline) {
+            Thread.sleep(20L)
+        }
+        return false
+    }
+}
+KT
+
+# BAD lexical control (#2026 round 4): executable block-comment trivia may
+# legally separate a clock method name from its call parentheses. Both the
+# declaration and while comparison use that spelling, so normal sanitizing
+# leaves whitespace exactly where a contiguous `currentTimeMillis()` matcher
+# used to false-green the forbidden portfwd pump.
+cat > "$TIMING_PORTFWD_FIX_DIR/Timing1BadPortfwdInsideCallTriviaPumpTest.kt" <<'KT'
+package com.pocketshell.app.portfwd.validityselftest
+class Timing1BadPortfwdInsideCallTriviaPumpTest {
+    fun awaitCondition(): Boolean {
+        val deadline =
+            System.currentTimeMillis /* declaration clock trivia */ () + 5_000L
+        while (
+            System.currentTimeMillis /* comparison clock trivia */ () < deadline
+        ) {
+            Thread.sleep(20L)
+            rereadNotification()
+        }
+        return false
+    }
+    private fun rereadNotification() = Unit
+}
+KT
+
+# BAD lexical control (#2026 round 4): nanoTime has the same legal inside-call
+# trivia in the prefs predecessor, including its ordered latch/BLOCKED drain.
+cat > "$TIMING_PREFS_FIX_DIR/Timing1BadPrefsInsideCallTriviaPumpTest.kt" <<'KT'
+package com.pocketshell.app.prefs.validityselftest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+class Timing1BadPrefsInsideCallTriviaPumpTest {
+    private val secondThrowingOpenStarted = CountDownLatch(1)
+    fun awaitSecondThrowingOpenOrColdGetBlocked(coldGetThread: Thread): Boolean {
+        val deadline =
+            System.nanoTime /* declaration clock trivia */ () +
+                TimeUnit.SECONDS.toNanos(5)
+        while (
+            System.nanoTime /* comparison clock trivia */ () < deadline
+        ) {
+            if (secondThrowingOpenStarted.await(10, TimeUnit.MILLISECONDS)) return true
+            if (coldGetThread.state == Thread.State.BLOCKED) return false
+        }
+        throw AssertionError("cold get neither raced nor blocked")
+    }
+}
+KT
+
+# GOOD lexical control: semantically complete pump text that exists only in
+# ordinary/raw strings and comments must not manufacture a TIMING1 finding.
+cat > "$TIMING_PREFS_FIX_DIR/Timing1GoodDeadlinePumpTextTest.kt" <<'KT'
+package com.pocketshell.app.prefs.validityselftest
+class Timing1GoodDeadlinePumpTextTest {
+    val ordinary = "val deadline = System.nanoTime() + 5_000L; while (System.nanoTime() < deadline)"
+    val raw = """
+        val deadline =
+            System.currentTimeMillis() + 5_000L
+        while (System.currentTimeMillis() < deadline) { Thread.sleep(20L) }
+    """.trimIndent()
+    /*
+     * val deadline =
+     *     System.nanoTime() + 5_000L
+     * while (System.nanoTime() < deadline) { Thread.sleep(20L) }
+     */
+}
+KT
+
+# GOOD-PLAIN-PORTFWD: candidate shape. The same sleep + notification reread is
+# injected verbatim through onTick, while only drainMainLooperUntil owns the
+# deadline and loop.
+cat > "$TIMING_PORTFWD_FIX_DIR/Timing1GoodPortfwdSharedPumpTest.kt" <<'KT'
+package com.pocketshell.app.portfwd.validityselftest
+class Timing1GoodPortfwdSharedPumpTest {
+    private fun awaitForwardingNotificationText(expected: String): String? {
+        var text = forwardingNotificationText()
+        val settled = drainMainLooperUntil(
+            sleepMs = 0L,
+            onTick = {
+                Thread.sleep(POLL_INTERVAL_MS)
+                text = forwardingNotificationText()
+            },
+            condition = { text == expected },
+        )
+        if (!settled) throw AssertionError("timed out")
+        return text
+    }
+    private fun forwardingNotificationText(): String? = null
+    private fun drainMainLooperUntil(
+        sleepMs: Long,
+        onTick: () -> Unit,
+        condition: () -> Boolean,
+    ): Boolean = condition()
+    private companion object { const val POLL_INTERVAL_MS = 20L }
+}
+KT
+
+# GOOD-PLAIN-PREFS: candidate shape. The ordered latch/BLOCKED observations are
+# preserved through onTick and the shared helper remains the sole loop owner.
+cat > "$TIMING_PREFS_FIX_DIR/Timing1GoodPrefsSharedPumpTest.kt" <<'KT'
+package com.pocketshell.app.prefs.validityselftest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+class Timing1GoodPrefsSharedPumpTest {
+    private val secondThrowingOpenStarted = CountDownLatch(1)
+    fun awaitSecondThrowingOpenOrColdGetBlocked(coldGetThread: Thread): Boolean {
+        var result: Boolean? = null
+        val settled = drainMainLooperUntil(
+            sleepMs = 0L,
+            onTick = {
+                if (secondThrowingOpenStarted.await(10, TimeUnit.MILLISECONDS)) {
+                    result = true
+                } else if (coldGetThread.state == Thread.State.BLOCKED) {
+                    result = false
+                }
+            },
+            condition = { result != null },
+        )
+        if (!settled) throw AssertionError("cold get neither raced nor blocked")
+        return checkNotNull(result)
+    }
+    private fun drainMainLooperUntil(
+        sleepMs: Long,
+        onTick: () -> Unit,
+        condition: () -> Boolean,
+    ): Boolean = condition()
+}
+KT
+
+# GOOD-PLAIN-BOUNDARY: a bounded one-shot coordination helper is sound and is
+# not a hand-rolled polling loop. This protects TIMING1 from broadening into a
+# ban on every legitimate timeout under the two roots.
+cat > "$TIMING_PORTFWD_FIX_DIR/Timing1GoodBoundedLatchTest.kt" <<'KT'
+package com.pocketshell.app.portfwd.validityselftest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+class Timing1GoodBoundedLatchTest {
+    fun waitForBoundary(latch: CountDownLatch) {
+        check(latch.await(5, TimeUnit.SECONDS))
+    }
+}
+KT
+
 assert_report present "Timing1BadSleepBeforeAssertTest.kt" "TIMING1 — NEW bare Thread.sleep" "TIMING1 hard-fails a bare sleep-before-assert with no bounded loop"
 assert_report absent  "Timing1GoodSeamTest.kt" "TIMING1 — NEW bare Thread.sleep" "TIMING1 spares a StandardTestDispatcher seam (Shape A) from hard-fail"
 assert_report absent  "Timing1GoodSeamTest.kt" "TIMING1 — NEW runTest over a real dispatcher" "TIMING1 spares a StandardTestDispatcher seam (Shape A) advisory"
@@ -603,11 +1008,63 @@ assert_report absent  "Timing1GoodBoundedPumpTest.kt" "TIMING1 — NEW runTest o
 assert_report present "Timing1GoodJustifiedTest.kt" "TIMING1 — JUSTIFIED" "TIMING1 lists a // JUSTIFIED: opt-out as justified"
 assert_report present "Timing1AdvisoryRealScopeTest.kt" "TIMING1 — NEW runTest over a real dispatcher" "TIMING1 advisory-flags a real-IO owned scope with no seam"
 assert_report absent  "Timing1AdvisoryRealScopeTest.kt" "TIMING1 — NEW bare Thread.sleep" "TIMING1 advisory real-IO scope is NOT a hard-fail"
+assert_report present "Timing1BadPortfwdLegacyPumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 catches the exact plain-JUnit portfwd predecessor without runTest"
+assert_report present "Timing1BadPrefsLegacyPumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 catches the exact plain-JUnit prefs predecessor without runTest"
+assert_report present "Timing1BadPortfwdMultilinePumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 catches a semantically equivalent multiline portfwd pump"
+assert_report present "Timing1BadPrefsMultilinePumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 catches a semantically equivalent multiline prefs pump"
+assert_report present "Timing1BadCommentInterleavedPumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 catches a real multiline pump with block comments between tokens"
+assert_report present "Timing1BadPortfwdInsideCallTriviaPumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 catches portfwd executable trivia inside both clock calls"
+assert_report present "Timing1BadPrefsInsideCallTriviaPumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 catches prefs executable trivia inside both clock calls"
+assert_report absent  "Timing1GoodDeadlinePumpTextTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 ignores multiline pump text in strings and comments"
+assert_report absent  "Timing1GoodPortfwdSharedPumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 spares the migrated portfwd shared-pump shape"
+assert_report absent  "Timing1GoodPrefsSharedPumpTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 spares the migrated prefs shared-pump shape"
+assert_report absent  "Timing1GoodBoundedLatchTest.kt" "TIMING1 — hand-rolled wall-clock deadline pump" "TIMING1 spares a sound one-shot bounded coordination helper"
 assert_exit 1 "TIMING1 bare sleep-before-assert hard-fails the guard"
 
-# Remove the BAD TIMING1 so the final clean-state assertion (exit 0 with only
-# advisory/justified findings) holds.
+# Prove every #2026 deadline-pump fixture bears the guard exit independently.
+# Park all offenders outside TIMING1's scoped roots, restore exactly one at a
+# time, and require both one named finding and no sibling finding. This makes a
+# broad/confounded red distinguishable from a selective detector kill.
 rm -f "$TIMING_FIX_DIR/Timing1BadSleepBeforeAssertTest.kt"
+TIMING1_BAD_PATHS=(
+  "$TIMING_PORTFWD_FIX_DIR/Timing1BadPortfwdLegacyPumpTest.kt"
+  "$TIMING_PREFS_FIX_DIR/Timing1BadPrefsLegacyPumpTest.kt"
+  "$TIMING_PORTFWD_FIX_DIR/Timing1BadPortfwdMultilinePumpTest.kt"
+  "$TIMING_PREFS_FIX_DIR/Timing1BadPrefsMultilinePumpTest.kt"
+  "$TIMING_PORTFWD_FIX_DIR/Timing1BadCommentInterleavedPumpTest.kt"
+  "$TIMING_PORTFWD_FIX_DIR/Timing1BadPortfwdInsideCallTriviaPumpTest.kt"
+  "$TIMING_PREFS_FIX_DIR/Timing1BadPrefsInsideCallTriviaPumpTest.kt"
+)
+for timing_bad_path in "${TIMING1_BAD_PATHS[@]}"; do
+  timing_bad_name="${timing_bad_path##*/}"
+  mv "$timing_bad_path" "$TEST_FIX_DIR/$timing_bad_name.held"
+done
+
+for timing_bad_path in "${TIMING1_BAD_PATHS[@]}"; do
+  timing_bad_name="${timing_bad_path##*/}"
+  mv "$TEST_FIX_DIR/$timing_bad_name.held" "$timing_bad_path"
+  assert_report \
+    present \
+    "$timing_bad_name" \
+    "TIMING1 — hand-rolled wall-clock deadline pump" \
+    "TIMING1 $timing_bad_name is the sole restored deadline-pump finding"
+  for timing_sibling_path in "${TIMING1_BAD_PATHS[@]}"; do
+    timing_sibling_name="${timing_sibling_path##*/}"
+    [[ "$timing_sibling_name" == "$timing_bad_name" ]] && continue
+    assert_report \
+      absent \
+      "$timing_sibling_name" \
+      "TIMING1 — hand-rolled wall-clock deadline pump" \
+      "TIMING1 $timing_bad_name does not launder a sibling $timing_sibling_name finding"
+  done
+  assert_exit 1 "TIMING1 $timing_bad_name independently hard-fails the guard"
+  mv "$timing_bad_path" "$TEST_FIX_DIR/$timing_bad_name.held"
+done
+
+# Remove every held BAD TIMING1. The end-of-script clean-state assertion now
+# proves the shared-pump and lexical text controls remain green without an
+# offender supplying their result.
+rm -f "$TEST_FIX_DIR"/Timing1Bad*.held
 
 # --------------------------------------------------------------------------
 # SEAM1 — connected test driving an assertion from an UNVETTED production
@@ -1020,6 +1477,8 @@ TMP_REG=""
 echo
 echo "[clean] only corrective shapes + advisory findings remain"
 assert_exit 0 "guard passes (exit 0) with no hard-fail smells, only advisory findings"
+assert_guard_runtime_clean "guard clean state emits no internal shell/runtime diagnostic"
+run_guard_runtime_error_regression
 
 echo
 echo "=============================================================="

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -115,9 +115,10 @@
 #
 #   --- #1048 addition (the runTest virtual-clock-vs-real-dispatcher flake class) ---
 #
-#   TIMING1 (ADVISORY warning, with ONE narrow HARD-FAIL) — scoped to the
+#   TIMING1 (ADVISORY warning, with TWO narrow HARD-FAILS) — scoped to the
 #       connection/terminal test roots (core-ssh, core-tmux, core-connection, and
-#       the app tmux/connectivity test dirs). The recurring "passes-locally /
+#       the app tmux/connectivity test dirs) plus app portfwd/prefs, where #2026
+#       found two more hand-rolled 5 s Shape-B pumps. The recurring "passes-locally /
 #       flakes-on-CI" JVM failure is ONE class: a `runTest` virtual clock drives
 #       code whose owned background work runs on a REAL dispatcher / Android
 #       Handler/Looper / raw Thread not pinned to the test scheduler, so
@@ -133,10 +134,17 @@
 #       Shape B (wall-clock-bounded pump — the audited drainMainLooperUntil in
 #       :shared:test-support / the codex pump; #2017 migrated the hand-rolled
 #       copies onto it). Current matches are baselined (advisory; the baseline only
-#       shrinks as tests adopt a seam). The lone HARD-FAIL is the narrow,
-#       high-signal NEW case: a `runTest` test with a bare small `Thread.sleep(<N>)`
-#       immediately preceding its load-bearing assert and NO bounded-deadline loop
-#       (the banned "fixed sleep as the only sync" shape).
+#       shrinks as tests adopt a seam). The two HARD-FAILS are narrow,
+#       high-signal cases: (1) a `runTest` test with a bare small
+#       `Thread.sleep(<N>)` immediately preceding its load-bearing assert and NO
+#       bounded-deadline loop (the banned "fixed sleep as the only sync" shape),
+#       and (2) under the portfwd/prefs roots, any plain-JUnit or Robolectric file
+#       that locally computes a wall-clock deadline and polls that same clock in
+#       a `while` condition. The second check deliberately runs before the
+#       `runTest` filter and before the old bounded-pump exemption: #2026's two
+#       exact 5 s predecessors had neither `runTest` nor an unbounded loop. Calls
+#       to `drainMainLooperUntil` and one-shot bounded helpers such as
+#       `CountDownLatch.await` remain clean because they do not own that loop.
 #
 # A BASELINE allowlist records the offenders the audits catalogued but that are
 # intentionally NOT rewritten here (the rewrites are per-issue follow-up work).
@@ -161,7 +169,10 @@
 # (it runs in the cheap Unit job in .github/workflows/tests.yml before the
 # Gradle test step, adding < 1 s).
 
-set -uo pipefail
+# Internal detector/runtime errors must never fall through to the normal PASS
+# footer. `-e` makes an unhandled command failure authoritative; `-E` carries
+# that fail-closed behavior through scan functions and cleanup helpers.
+set -Eeuo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
@@ -382,7 +393,8 @@ TIMING1_BASELINE=(
   "app/src/test/java/com/pocketshell/app/hosts/HostListViewModelTest.kt"                        # CountDownLatch off-main close await (#1110 Shape-B)
 )
 
-# Connection/terminal test roots TIMING1 is scoped to (path-prefix match).
+# Connection/terminal plus #2026 portfwd/prefs test roots TIMING1 is scoped to
+# (path-prefix match).
 timing1_in_scope() {
   case "$1" in
     shared/core-ssh/src/test/*) return 0 ;;
@@ -392,6 +404,10 @@ timing1_in_scope() {
     app/src/androidTest/java/com/pocketshell/app/tmux/*) return 0 ;;
     app/src/test/java/com/pocketshell/app/connectivity/*) return 0 ;;
     app/src/androidTest/java/com/pocketshell/app/connectivity/*) return 0 ;;
+    # Issue #2026: two hand-rolled 5 s Shape-B pumps survived in these JVM
+    # roots because the original connection/terminal sweep could not see them.
+    app/src/test/java/com/pocketshell/app/portfwd/*) return 0 ;;
+    app/src/test/java/com/pocketshell/app/prefs/*) return 0 ;;
     # Issue #1048: widened to the areas that actually flaked this class —
     # composer (#1102, sidecar-store real-IO drain) and hosts (#1110, real
     # off-main close) — plus projects, the sibling source-binding area, so a
@@ -404,6 +420,19 @@ timing1_in_scope() {
     app/src/androidTest/java/com/pocketshell/app/projects/*) return 0 ;;
   esac
   return 1
+}
+
+# Load-bearing scope contract (#2026). The guard runs this every time, so
+# deleting either newly-required branch cannot read as a clean scan merely
+# because today's two offending pumps have already been migrated.
+declare -a TIMING1_SCOPE_ERRORS=()
+validate_timing1_scope_contract() {
+  local probe
+  for probe in \
+    "app/src/test/java/com/pocketshell/app/portfwd/Timing1ScopeProbeTest.kt" \
+    "app/src/test/java/com/pocketshell/app/prefs/Timing1ScopeProbeTest.kt"; do
+    timing1_in_scope "$probe" || TIMING1_SCOPE_ERRORS+=("$probe -> required root is not scanned")
+  done
 }
 
 in_list() {
@@ -965,17 +994,20 @@ scan_j1() {
 }
 
 # --------------------------------------------------------------------------
-# TIMING1 scan (#1048) — connection/terminal `runTest` tests whose owned
+# TIMING1 scan (#1048/#2026) — connection/terminal `runTest` tests whose owned
 # background work runs on a real dispatcher/thread not pinned to the test
 # scheduler, with neither a TestDispatcher seam nor a bounded pump. Advisory,
-# with ONE narrow hard-fail: a bare small `Thread.sleep(<N>)` immediately before
+# with TWO narrow hard-fails: a bare small `Thread.sleep(<N>)` immediately before
 # a load-bearing assert and no bounded-deadline loop (the banned "fixed sleep as
-# the only sync" shape).
+# the only sync" shape), plus a locally hand-rolled wall-clock deadline loop in
+# the #2026 portfwd/prefs plain-JUnit roots.
 # --------------------------------------------------------------------------
 declare -a TIMING1_NEW_HARD=()
+declare -a TIMING1_HAND_ROLLED_PUMPS=()
 declare -a TIMING1_FINDINGS=()
 declare -a TIMING1_KNOWN=()
 declare -a TIMING1_JUSTIFIED=()
+TIMING1_LEX_DIR=""
 
 # The real-dispatcher/thread tokens that signal an owned background hop is not
 # pinned to the virtual scheduler.
@@ -1013,6 +1045,135 @@ timing1_has_code_smell() {
     is_code_line "$text" && return 0
   done < <(grep -nE "$timing1_dispatcher_smell" "$file" | cut -d: -f1)
   return 1
+}
+
+# #2026's offenders are ordinary JUnit/Robolectric tests, not runTest tests.
+# Keep this hard rule deliberately limited to the two newly-added roots whose
+# contract is "use the one audited settle helper; do not own another wall-clock
+# pump". Other TIMING1 roots retain their existing Shape-A/Shape-B semantics,
+# including the documented advanceSchedulerUntil exception.
+timing1_uses_shared_pump_only_scope() {
+  case "$1" in
+    app/src/test/java/com/pocketshell/app/portfwd/*) return 0 ;;
+    app/src/test/java/com/pocketshell/app/prefs/*) return 0 ;;
+  esac
+  return 1
+}
+
+# Run a boolean TIMING1 predicate without letting Bash conflate its deliberate
+# "no match" status (1) with a missing command or other runtime failure. Every
+# scan call consumes TIMING1_PREDICATE_MATCH only after this wrapper returns 0;
+# any other status is propagated out of scan_timing1 before the PASS footer.
+TIMING1_PREDICATE_MATCH=0
+timing1_checked_predicate() {
+  local predicate="$1"
+  shift
+  local rc
+  if "$predicate" "$@"; then
+    TIMING1_PREDICATE_MATCH=1
+    return 0
+  else
+    rc=$?
+  fi
+  if [[ "$rc" -eq 1 ]]; then
+    TIMING1_PREDICATE_MATCH=0
+    return 0
+  fi
+  echo "ERROR: TIMING1 predicate '$predicate' failed at runtime (exit $rc)" >&2
+  return "$rc"
+}
+
+# Detect the mechanical Shape-B loop itself: a local deadline computed from a
+# wall clock, followed by a while condition that compares the SAME clock with
+# that deadline variable. The source passed here has strings and comments
+# removed, so KDoc examples cannot trip the guard. We intentionally do not key
+# this to a literal "5 seconds": changing 5 to 10 must not launder the local
+# pump into a clean result; the shared helper owns the one generous deadline.
+timing1_has_hand_rolled_deadline_pump() {
+  local code_file="$1"
+  awk '
+    function declaration_name(line, rest, name) {
+      rest = line
+      sub(/^[[:space:]]*(private[[:space:]]+|internal[[:space:]]+|public[[:space:]]+)?(val|var)[[:space:]]+/, "", rest)
+      if (rest == line) return ""
+      name = rest
+      sub(/[[:space:]:=].*$/, "", name)
+      if (name ~ /^[A-Za-z_][A-Za-z0-9_]*$/) return name
+      return ""
+    }
+    function starts_new_statement(line) {
+      if (declaration_name(line) != "") return 1
+      return line ~ /^[[:space:]]*(while|do|for|if|when|return|throw|fun|class|object)([^A-Za-z0-9_]|$)/ ||
+             line ~ /^[[:space:]]*}/
+    }
+    function remember_deadline(start, name, statement, i) {
+      name = declaration_name(lines[start])
+      if (name == "") return
+      statement = lines[start]
+      # Kotlin routinely wraps the initializer after `=` / `+`. Join only this
+      # declaration (bounded for guard cost), stopping before another statement
+      # so a later clock expression cannot be attributed to the wrong variable.
+      for (i = start + 1; i <= total && i < start + 12; i++) {
+        if (starts_new_statement(lines[i])) break
+        statement = statement " " lines[i]
+      }
+      if (statement ~ /System\.currentTimeMillis[[:space:]]*\([[:space:]]*\)[[:space:]]*\+/) {
+        deadlines[name] = "currentTimeMillis"
+      } else if (statement ~ /System\.nanoTime[[:space:]]*\([[:space:]]*\)[[:space:]]*\+/) {
+        deadlines[name] = "nanoTime"
+      }
+    }
+    function while_condition(start, joined, i, ch, depth, opened, condition, while_pos) {
+      joined = lines[start]
+      for (i = start + 1; i <= total && i < start + 12; i++) joined = joined "\n" lines[i]
+      while_pos = match(joined, /while[[:space:]]*\(/)
+      if (!while_pos) return ""
+      joined = substr(joined, while_pos)
+      sub(/^while[[:space:]]*/, "", joined)
+      depth = 0
+      opened = 0
+      condition = ""
+      for (i = 1; i <= length(joined); i++) {
+        ch = substr(joined, i, 1)
+        if (ch == "(") {
+          depth++
+          opened = 1
+        }
+        if (opened) condition = condition ch
+        if (ch == ")") {
+          depth--
+          if (opened && depth == 0) return condition
+        }
+      }
+      return ""
+    }
+    function mentions_identifier(text, name, pattern) {
+      pattern = "(^|[^A-Za-z0-9_])" name "([^A-Za-z0-9_]|$)"
+      return text ~ pattern
+    }
+    {
+      lines[NR] = $0
+      total = NR
+    }
+    END {
+      for (line_no = 1; line_no <= total; line_no++) {
+        remember_deadline(line_no)
+      }
+      for (line_no = 1; line_no <= total; line_no++) {
+        if (lines[line_no] !~ /while[[:space:]]*\(/) continue
+        loop_condition = while_condition(line_no)
+        if (loop_condition == "") continue
+        for (deadline in deadlines) {
+          clock_pattern = "System\\." deadlines[deadline] "[[:space:]]*\\([[:space:]]*\\)"
+          if (loop_condition ~ clock_pattern &&
+              mentions_identifier(loop_condition, deadline)) {
+            found = 1
+          }
+        }
+      }
+      exit(found ? 0 : 1)
+    }
+  ' "$code_file"
 }
 
 # The narrow hard-fail: a bare numeric `Thread.sleep(<N>)` on a code line whose
@@ -1053,23 +1214,56 @@ timing1_has_bare_sleep_before_assert() {
 }
 
 scan_timing1() {
-  local file
+  local file code_file comment_file file_index=0
   for file in "${ALL_TEST_FILES[@]}"; do
     [[ -z "$file" ]] && continue
-    timing1_in_scope "$file" || continue
-    timing1_has_run_test "$file" || continue
-    timing1_has_code_smell "$file" || continue
+    timing1_checked_predicate timing1_in_scope "$file" || return $?
+    [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]] || continue
+
+    # This check must precede timing1_has_run_test and the bounded-pump
+    # exemption: both exact #2026 predecessors were plain JUnit/Robolectric,
+    # and the old exemption is precisely what incorrectly spared them.
+    timing1_checked_predicate timing1_uses_shared_pump_only_scope "$file" || return $?
+    if [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]]; then
+      if [[ -z "$TIMING1_LEX_DIR" ]]; then
+        TIMING1_LEX_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-timing1-lex.XXXXXX")" || {
+          TIMING1_SCOPE_ERRORS+=("could not create TIMING1 lexical scratch directory")
+          return
+        }
+      fi
+      file_index=$((file_index + 1))
+      code_file="$TIMING1_LEX_DIR/file-$file_index.code"
+      comment_file="$TIMING1_LEX_DIR/file-$file_index.comments"
+      sanitize_kotlin_source "$file" "$code_file" "$comment_file"
+      timing1_checked_predicate timing1_has_hand_rolled_deadline_pump "$code_file" || return $?
+      if [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]]; then
+        TIMING1_HAND_ROLLED_PUMPS+=("$file")
+        continue
+      fi
+    fi
+
+    timing1_checked_predicate timing1_has_run_test "$file" || return $?
+    [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]] || continue
+    timing1_checked_predicate timing1_has_code_smell "$file" || return $?
+    [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]] || continue
 
     # The narrow NEW hard-fail (never baselined): a bare sleep-before-assert with
     # no bounded loop.
-    if ! in_list "$file" "${TIMING1_BASELINE[@]}" \
-       && timing1_has_bare_sleep_before_assert "$file"; then
-      TIMING1_NEW_HARD+=("$file")
-      continue
+    if ! in_list "$file" "${TIMING1_BASELINE[@]}"; then
+      timing1_checked_predicate timing1_has_bare_sleep_before_assert "$file" || return $?
+      if [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]]; then
+        TIMING1_NEW_HARD+=("$file")
+        continue
+      fi
     fi
 
     # Spared (advisory clean): a TestDispatcher seam or a bounded pump.
-    if timing1_has_test_dispatcher "$file" || timing1_has_bounded_pump "$file"; then
+    timing1_checked_predicate timing1_has_test_dispatcher "$file" || return $?
+    if [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]]; then
+      continue
+    fi
+    timing1_checked_predicate timing1_has_bounded_pump "$file" || return $?
+    if [[ "$TIMING1_PREDICATE_MATCH" -eq 1 ]]; then
       continue
     fi
     # Opted out via an inline // JUSTIFIED: comment.
@@ -1119,10 +1313,11 @@ declare -A PROD_CALL_SEAM_DEFINED=()
 declare -A PROD_PROPERTY_SEAM_DEFINED=()
 SEAM1_LEX_DIR=""
 
-cleanup_seam1_lex_dir() {
+cleanup_test_validity_lex_dirs() {
+  [[ -z "${TIMING1_LEX_DIR:-}" ]] || rm -rf -- "$TIMING1_LEX_DIR"
   [[ -z "${SEAM1_LEX_DIR:-}" ]] || rm -rf -- "$SEAM1_LEX_DIR"
 }
-trap cleanup_seam1_lex_dir EXIT
+trap cleanup_test_validity_lex_dirs EXIT
 
 # The high-signal state-injection name shape (the alt-buffer cheat's shape).
 SEAM1_INJECTION_SHAPE='(force[A-Za-z]*ForTest|[a-z][A-Za-z]*Override[A-Za-z]*ForTest|set[A-Za-z]*ActiveForTest)'
@@ -1520,10 +1715,10 @@ scan_seam1() {
           SEAM1_NEW+=("$file:$lineno ($seam; $kind)")
         fi
       done < <(
-        grep -oE "$SEAM1_CALL_PATTERN" <<< "$text" \
+        { grep -oE "$SEAM1_CALL_PATTERN" <<< "$text" || true; } \
           | sed -E 's/[[:space:]]*\($//' \
           | sed 's/^/call:/'
-        grep -oE "$SEAM1_ASSIGNMENT_PATTERN" <<< "$text" \
+        { grep -oE "$SEAM1_ASSIGNMENT_PATTERN" <<< "$text" || true; } \
           | sed -E 's/[[:space:]]*=.*$//' \
           | sed 's/^/assignment:/'
       )
@@ -1539,7 +1734,8 @@ scan_seam1() {
     [[ -n "${PROD_SEAM_DEFINED[$v]:-}" ]] || SEAM1_STALE_REGISTRY+=("$v -> not defined in any src/main")
   done
 
-  cleanup_seam1_lex_dir
+  cleanup_test_validity_lex_dirs
+  TIMING1_LEX_DIR=""
   SEAM1_LEX_DIR=""
 }
 
@@ -1636,6 +1832,7 @@ scan_c1
 scan_fake1
 scan_await1
 scan_j1
+validate_timing1_scope_contract
 scan_timing1
 scan_seam1
 scan_void1
@@ -1690,6 +1887,8 @@ print_list "J1 — JUSTIFIED local CI_JOURNEY_SUITE_JUSTIFIED exemption [advisor
 print_list "J1 — STALE unwired baseline entry [HARD FAIL]" "${J1_STALE_BASELINE[@]:-}"
 print_list "J1 — PARSER failure reading ci-journey-suite.sh [HARD FAIL]" "${J1_PARSER_FAILURE[@]:-}"
 print_list "TIMING1 — NEW bare Thread.sleep(N) before a load-bearing assert, no bounded loop [HARD FAIL]" "${TIMING1_NEW_HARD[@]:-}"
+print_list "TIMING1 — hand-rolled wall-clock deadline pump in portfwd/prefs [HARD FAIL]" "${TIMING1_HAND_ROLLED_PUMPS[@]:-}"
+print_list "TIMING1 — REQUIRED scan root missing [HARD FAIL]" "${TIMING1_SCOPE_ERRORS[@]:-}"
 print_list "TIMING1 — NEW runTest over a real dispatcher/thread without a pinned seam or bounded pump [advisory]" "${TIMING1_FINDINGS[@]:-}"
 print_list "TIMING1 — KNOWN baseline (real-dispatcher/thread runTest catalogued; seam adoption is per-test follow-up) [advisory]" "${TIMING1_KNOWN[@]:-}"
 print_list "TIMING1 — JUSTIFIED (opted out via // JUSTIFIED:) [advisory]" "${TIMING1_JUSTIFIED[@]:-}"
@@ -1757,6 +1956,8 @@ for x in \
   "${J1_STALE_BASELINE[@]:-}" \
   "${J1_PARSER_FAILURE[@]:-}" \
   "${TIMING1_NEW_HARD[@]:-}" \
+  "${TIMING1_HAND_ROLLED_PUMPS[@]:-}" \
+  "${TIMING1_SCOPE_ERRORS[@]:-}" \
   "${SEAM1_NEW[@]:-}" \
   "${SEAM1_REGISTRY_ERRORS[@]:-}" \
   "${V1_NEW[@]:-}"; do
@@ -1771,12 +1972,12 @@ fi
 
 if [[ "${#real_hard_fail[@]}" -gt 0 ]]; then
   echo
-  echo "::error title=Test-validity guard (issue #657/#848/#1048/#1154/#1430/#1758/#1857)::A NEW load-bearing self-skip, ungated androidTest journey, fixed-sleep-before-assert, unvetted connected-test state-injection seam (a production-defined force*/Override*/set*Active*ForTest call or property assignment driving an assertion that is not vetted in scripts/vetted-test-state-setters.txt with a real-path-reachability reason — the #1158 alt-buffer cheat class), or non-void androidTest @Test method was found. An unconditional assumeTrue(..., false) / assumeFalse(..., true) makes the remainder of a test unreachable and must be removed; an exact survivor baseline requires a tracking issue (#1857). An androidTest @Test/@Before/@After must use a VOID BLOCK body (fun x() { … }), never an expression body (fun x() = …) — a non-Unit expression body makes the method non-void and JUnit rejects the ENTIRE class at load (InvalidTestClassError), so it never runs (#1154). An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture), a new androidTest *E2eTest/*DockerTest class must be wired into scripts/ci-journey-suite.sh or carry a local // CI_JOURNEY_SUITE_JUSTIFIED: reason, and a connection/terminal runTest test must not use a bare Thread.sleep(N) as the only sync before a load-bearing assert (use a StandardTestDispatcher seam or a bounded advanceUntilIdle()+idleFor() deadline pump per #1048). Remove stale J1/A5L baselines when a class or exact occurrence is promoted, moved, or deleted."
+  echo "::error title=Test-validity guard (issue #657/#848/#1048/#1154/#1430/#1758/#1857/#2026)::A NEW load-bearing self-skip, ungated androidTest journey, fixed-sleep-before-assert, hand-rolled portfwd/prefs wall-clock deadline pump, unvetted connected-test state-injection seam (a production-defined force*/Override*/set*Active*ForTest call or property assignment driving an assertion that is not vetted in scripts/vetted-test-state-setters.txt with a real-path-reachability reason — the #1158 alt-buffer cheat class), or non-void androidTest @Test method was found. An unconditional assumeTrue(..., false) / assumeFalse(..., true) makes the remainder of a test unreachable and must be removed; an exact survivor baseline requires a tracking issue (#1857). An androidTest @Test/@Before/@After must use a VOID BLOCK body (fun x() { … }), never an expression body (fun x() = …) — a non-Unit expression body makes the method non-void and JUnit rejects the ENTIRE class at load (InvalidTestClassError), so it never runs (#1154). An IME/keyboard/geometry test must not gate its assertion behind assumeTrue(...) (convert to the synthetic-inset model, #780), a connect/journey test must not gate behind assumeFalse(isRunningOnCi()) outside a genuine opt-in fault/Docker fixture (inject the state and HARD-assert, or add an inline // JUSTIFIED: comment naming the opt-in fixture), a new androidTest *E2eTest/*DockerTest class must be wired into scripts/ci-journey-suite.sh or carry a local // CI_JOURNEY_SUITE_JUSTIFIED: reason, and a connection/terminal runTest test must not use a bare Thread.sleep(N) as the only sync before a load-bearing assert (use a StandardTestDispatcher seam or the audited drainMainLooperUntil helper per #1048/#2026). Remove stale J1/A5L baselines when a class or exact occurrence is promoted, moved, or deleted."
   echo
   echo "FAIL: ${#real_hard_fail[@]} unjustified hard-fail occurrence(s) (A5 + A5L + C1 + J1 + TIMING1 + SEAM1 + V1)."
   exit 1
 fi
 
 echo
-echo "PASS: no new unjustified load-bearing self-skips, ungated androidTest journeys, fixed-sleep-before-assert flakes, unvetted state-injection seams, or non-void androidTest @Test methods (A5 + A5L + C1 + J1 + TIMING1 + SEAM1 + V1)."
+echo "PASS: no new unjustified load-bearing self-skips, ungated androidTest journeys, fixed-sleep or hand-rolled deadline-pump flakes, unvetted state-injection seams, or non-void androidTest @Test methods (A5 + A5L + C1 + J1 + TIMING1 + SEAM1 + V1)."
 exit 0


### PR DESCRIPTION
Closes #2026.

Hardens TIMING1 test-validity detection across multiline/comment-split clocks and fail-closes when helper commands are missing. Adds load-bearing production-adjacent oracle cases.

Reviewed and approved in #2026. Integration validation: guard green, self-test 129/129, file-size/syntax/diff checks green.