### PR TITLE
test(composer): make the #1602 queue proofs device-independent (#2123)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueTest.kt
@@ -9,9 +9,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click
@@ -37,6 +37,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+
+/**
+ * Reopened #1602 copy, verbatim from [outboundRetryActionState]: the LABEL the
+ * blocked control carries, and the longer per-row explanation. The label is the
+ * device-independent half of the anti-"tappable silent" contract — it travels
+ * with the control, so it is readable wherever the control itself is reachable.
+ */
+private const val WAITING_BEHIND_OWNER_LABEL = "Waiting…"
+private const val WAITING_BEHIND_OWNER_STATUS = "Waiting — another prompt is still sending"
 
 /**
  * Issue #900: connected proof for the foreground outbound queue surface.
@@ -149,6 +158,13 @@ class PromptComposerOutboundQueueTest {
             // row A and then row B, leaving the bounded status viewport at B.
             // Reproduce that production history through the same row semantics;
             // no synthetic offset or test-only layout seam is involved.
+            //
+            // Issue #2123: this seed is history, NOT a precondition. It exists so
+            // the per-row assertions below run from an ARBITRARY prior scroll
+            // offset (each row must still be reachable afterwards). Nothing below
+            // may assert that a particular node is on/off screen AT this offset —
+            // that is a viewport-size accident, not a product property, and it is
+            // what made this proof red on CI.
             val seededViewportRowIds = buildList {
                 rows.forEach { seedRow ->
                     compose.onNodeWithTag(
@@ -223,13 +239,16 @@ class PromptComposerOutboundQueueTest {
                             rowRawBoundsBeforeExactScroll,
                         ),
                     )
-                    if (row.id == rows.first().id) {
-                        // Count==1 plus raw containment above proves this is a real,
-                        // laid-out control, not assertIsNotDisplayed laundering an
-                        // absent node. This is the same Compose visibility predicate
-                        // that caught the full MainActivity Retry boundary.
-                        offlineRetryNode.assertIsNotDisplayed()
-                    }
+                    // Issue #2123: an `assertIsNotDisplayed()` on the first row's
+                    // Retry used to stand here. It asserted a VIEWPORT-SIZE
+                    // ACCIDENT — "this control happens to be off-screen at this
+                    // scroll offset" — which is true only while a row is taller
+                    // than the bounded status region. It is not a product property,
+                    // it was already false on CI, and reproducing it locally showed
+                    // it is false on the dev-box AVD too. Deleted, not relaxed: the
+                    // control's reality is proven by assertCountEquals(1) plus the
+                    // raw-bounds containment above, and its REACHABILITY by the
+                    // scroll + bounded-viewport containment below.
                     offlineRetryNode
                         // The 96dp status viewport is intentionally bounded. Scroll
                         // the exact trailing action, not only its potentially taller
@@ -246,6 +265,17 @@ class PromptComposerOutboundQueueTest {
                         )
                     }
                     offlineRetryNode.assertIsNotEnabled()
+                    // Issue #2123: the anti-"tappable silent" property that does
+                    // NOT depend on any geometry — the blocked reason travels ON
+                    // the control. Whatever the viewport height or scroll offset,
+                    // a user who reaches this action reads "Offline", never a bare
+                    // "Retry" that silently does nothing.
+                    compose.onAllNodes(
+                        hasText("Offline") and
+                            hasAnyAncestor(hasTestTag(retryTag)) and
+                            withinExactRow,
+                        useUnmergedTree = true,
+                    ).assertCountEquals(1)
                     val retryBoundsAfterExactScroll = offlineRetryNode.fetchSemanticsNode().boundsInRoot
                     val statusViewportBoundsAfterExactScroll = compose.onNodeWithTag(
                         COMPOSER_STATUS_VIEWPORT_TAG,
@@ -568,6 +598,12 @@ class PromptComposerOutboundQueueTest {
             createdAtMs = 2L,
         )
         val retried = mutableListOf<String>()
+        // Issue #2123: both queue states are exercised from ONE composition — the
+        // collapsed banner the user actually lands on, and the expanded row list.
+        // The test owns the flag directly (rather than tapping the toggle) so the
+        // state transition is deterministic and independent of whether a tap on a
+        // disabled child bubbles to the header's clickable.
+        var expanded by mutableStateOf(false)
         compose.setContent {
             PocketShellTheme {
                 SheetContent(
@@ -575,22 +611,108 @@ class PromptComposerOutboundQueueTest {
                     onClose = {}, onDraftChange = {}, onMicTap = {}, onSend = {},
                     outboundQueueItems = listOf(active, waiting),
                     outboundRetryBlockedByHealthyOwner = true,
-                    outboundQueueExpanded = true,
+                    outboundQueueExpanded = expanded,
                     onRetryOutboundItem = { retried += it },
                 )
             }
         }
 
-        compose.onNodeWithText("Waiting — another prompt is still sending").assertIsDisplayed()
-        compose.onNodeWithTag(composerOutboundQueueRetryTestTag(waiting.id))
-            .performScrollTo()
-            .assertIsDisplayed()
-            .assertIsNotEnabled()
-            // A real pointer tap (not a semantics action, which disabled nodes do not
-            // expose) proves the apparently present control cannot silently dispatch.
-            .performTouchInput { click() }
+        val retryTag = composerOutboundQueueRetryTestTag(waiting.id)
+        val rowTag = composerOutboundQueueItemRowTestTag(waiting.id)
+        val statusTag = composerOutboundQueueStatusTestTag(waiting.id)
+
+        // (1) COLLAPSED — the state the user lands in, and the only one that needs
+        // no scrolling at all. The blocked reason travels ON the control: the
+        // header action reads "Waiting…" instead of a bare "Retry", it is
+        // disabled, and it is contained inside the bounded status viewport as-is.
+        compose.onAllNodes(
+            hasText(WAITING_BEHIND_OWNER_LABEL) and hasAnyAncestor(hasTestTag(retryTag)),
+            useUnmergedTree = true,
+        ).assertCountEquals(1)
+        compose.onNodeWithTag(retryTag).assertIsNotEnabled()
+        assertFullyWithinBoundedStatusViewport(
+            compose.onNodeWithTag(retryTag),
+            "collapsed blocked Retry",
+        )
+        // A real pointer tap (not a semantics action, which disabled nodes do not
+        // expose) proves the apparently present control cannot silently dispatch.
+        compose.onNodeWithTag(retryTag).performTouchInput { click() }
         compose.waitForIdle()
-        assertTrue("disabled Waiting must not invoke a silent retry callback", retried.isEmpty())
+        assertTrue(
+            "collapsed blocked Retry pointer taps must not invoke a silent retry callback",
+            retried.isEmpty(),
+        )
+
+        // (2) EXPANDED — the per-row control plus its longer explanation.
+        //
+        // Issue #2123: this used to assert the explanation was `assertIsDisplayed()`
+        // with no scroll. The composer's status region is a deliberately BOUNDED
+        // 96dp strip above the editor (#1613/#1619/#1622), so a second queue row is
+        // fully clipped at rest — measured on a Pixel 7 AVD, the row's clipped
+        // bounds are Rect.Zero until it is scrolled to. That assertion was false on
+        // every device, not only CI's. The user reaches this row by scrolling, so
+        // the proof does too, and then asserts CONTAINMENT inside that bounded
+        // viewport (F3) rather than absolute device-viewport visibility.
+        compose.runOnUiThread { expanded = true }
+        compose.waitForIdle()
+
+        val explanation = hasText(WAITING_BEHIND_OWNER_STATUS) and
+            hasAnyAncestor(hasTestTag(statusTag)) and
+            hasAnyAncestor(hasTestTag(rowTag))
+        compose.onAllNodes(explanation, useUnmergedTree = true).assertCountEquals(1)
+        compose.onNode(explanation, useUnmergedTree = true).performScrollTo()
+        compose.waitForIdle()
+        assertFullyWithinBoundedStatusViewport(
+            compose.onNode(explanation, useUnmergedTree = true),
+            "blocked-row explanation",
+        )
+
+        val rowRetry = hasTestTag(retryTag) and hasAnyAncestor(hasTestTag(rowTag))
+        compose.onAllNodes(rowRetry, useUnmergedTree = true).assertCountEquals(1)
+        compose.onNode(rowRetry, useUnmergedTree = true).performScrollTo()
+        compose.waitForIdle()
+        assertFullyWithinBoundedStatusViewport(
+            compose.onNode(rowRetry, useUnmergedTree = true),
+            "expanded blocked Retry",
+        )
+        compose.onNode(rowRetry, useUnmergedTree = true).assertIsNotEnabled()
+        compose.onAllNodes(
+            hasText(WAITING_BEHIND_OWNER_LABEL) and
+                hasAnyAncestor(hasTestTag(retryTag)) and
+                hasAnyAncestor(hasTestTag(rowTag)),
+            useUnmergedTree = true,
+        ).assertCountEquals(1)
+        compose.onNode(rowRetry, useUnmergedTree = true).performTouchInput { click() }
+        compose.waitForIdle()
+        assertTrue(
+            "expanded blocked Retry pointer taps must not invoke a silent retry callback",
+            retried.isEmpty(),
+        )
+    }
+
+    /**
+     * Containment inside the composer's BOUNDED status viewport at the CURRENT
+     * scroll offset (issue #657 F3, issue #2123).
+     *
+     * `boundsInRoot` is clipped by ancestors, so a node scrolled out of the bounded
+     * status region collapses to `Rect.Zero` and fails the non-empty half of this
+     * check. That makes it a real "the user can see and reach this" assertion,
+     * unlike `assertIsDisplayed()` (satisfied by mere layout participation) — and,
+     * unlike an absolute device-viewport check, it does not encode how tall the
+     * viewport happens to be or how many rows happen to fit in it.
+     */
+    private fun assertFullyWithinBoundedStatusViewport(
+        node: SemanticsNodeInteraction,
+        label: String,
+    ) {
+        val bounds = node.fetchSemanticsNode().boundsInRoot
+        val viewport = compose.onNodeWithTag(COMPOSER_STATUS_VIEWPORT_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode().boundsInRoot
+        assertTrue(
+            "$label must be non-empty and fully inside the bounded composer status " +
+                "viewport at the current scroll offset: node=$bounds viewport=$viewport",
+            bounds.isNonEmptyAndFullyContainedBy(viewport),
+        )
     }
 
     // ---------------------------------------------------------------------

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerSheetSourceGuardTest.kt
@@ -270,7 +270,9 @@ class PromptComposerSheetSourceGuardTest {
             "retryRawBoundsBeforeExactScroll",
             "rowRawBoundsBeforeExactScroll",
             "retryRawBoundsBeforeExactScroll.isNonEmptyAndFullyContainedBy(",
-            "offlineRetryNode.assertIsNotDisplayed()",
+            // #2123: replaces the deleted scroll-offset-dependent invisibility
+            // precondition with the device-independent blocked-reason copy.
+            "hasText(\"Offline\") and",
             "postcondition: exact offline Retry must be displayed after its own scroll",
             "retryBoundsAfterExactScroll",
             "statusViewportBoundsAfterExactScroll",
@@ -504,13 +506,20 @@ class PromptComposerSheetSourceGuardTest {
             "retryRawBoundsBeforeExactScroll.isNonEmptyAndFullyContainedBy(",
             startIndex = rawRetryBoundsIndex.coerceAtLeast(0),
         )
-        val notDisplayedPreconditionIndex = method.indexOf(
-            "offlineRetryNode.assertIsNotDisplayed()",
+        // Issue #2123 deleted the `offlineRetryNode.assertIsNotDisplayed()`
+        // precondition that used to separate the row-level scroll from the exact
+        // action scroll: it pinned a viewport-size accident ("this control happens
+        // to be off-screen at this offset"), which was false on every device. The
+        // separator is now the exact trailing-action RECEIVER — the scroll proving
+        // reachability must be performed on the Retry control itself, not merely on
+        // its potentially taller row.
+        val exactActionNodeIndex = method.indexOf(
+            "offlineRetryNode",
             startIndex = rawRetryWithinRowIndex.coerceAtLeast(0),
         )
         val exactActionScrollIndex = method.indexOf(
             ".performScrollTo()",
-            startIndex = notDisplayedPreconditionIndex.coerceAtLeast(0),
+            startIndex = exactActionNodeIndex.coerceAtLeast(0),
         )
         val namedDisplayedPostconditionIndex = method.indexOf(
             "postcondition: exact offline Retry must be displayed after its own scroll",
@@ -520,9 +529,16 @@ class PromptComposerSheetSourceGuardTest {
             "offlineRetryNode.assertIsNotEnabled()",
             startIndex = namedDisplayedPostconditionIndex.coerceAtLeast(0),
         )
+        // The device-independent property #2123 put in the accident's place: the
+        // blocked reason travels ON the control, so a reachable action never reads
+        // as a bare, silently-inert "Retry" regardless of viewport height.
+        val blockedReasonCopyIndex = method.indexOf(
+            "hasText(\"Offline\") and",
+            startIndex = disabledPostconditionIndex.coerceAtLeast(0),
+        )
         val postBoundsIndex = method.indexOf(
             "val retryBoundsAfterExactScroll",
-            startIndex = disabledPostconditionIndex.coerceAtLeast(0),
+            startIndex = blockedReasonCopyIndex.coerceAtLeast(0),
         )
         val containedPostconditionIndex = method.indexOf(
             "retryBoundsAfterExactScroll.isNonEmptyAndFullyContainedBy(",
@@ -533,8 +549,9 @@ class PromptComposerSheetSourceGuardTest {
             startIndex = containedPostconditionIndex.coerceAtLeast(0),
         )
         assertTrue(
-            "#1602 component must seed the real FIFO capture position, prove a laid-out Retry not displayed " +
-                "after row scroll, then exact-scroll it into the viewport before disabled/tap proof",
+            "#1602 component must seed the real FIFO capture position, prove the laid-out Retry contained by " +
+                "its own row after the row scroll, then exact-scroll the trailing action itself into the " +
+                "bounded viewport before the disabled/blocked-reason/containment/tap proof",
             seedIndex >= 0 &&
                 seedRowIndex > seedIndex &&
                 seedScrollIndex > seedRowIndex &&
@@ -543,13 +560,23 @@ class PromptComposerSheetSourceGuardTest {
                 rowLevelScrollIndex > rowMarkerIndex &&
                 rawRetryBoundsIndex > rowLevelScrollIndex &&
                 rawRetryWithinRowIndex > rawRetryBoundsIndex &&
-                notDisplayedPreconditionIndex > rawRetryWithinRowIndex &&
-                exactActionScrollIndex > notDisplayedPreconditionIndex &&
+                exactActionNodeIndex > rawRetryWithinRowIndex &&
+                exactActionScrollIndex > exactActionNodeIndex &&
                 namedDisplayedPostconditionIndex > exactActionScrollIndex &&
                 disabledPostconditionIndex > namedDisplayedPostconditionIndex &&
-                postBoundsIndex > disabledPostconditionIndex &&
+                blockedReasonCopyIndex > disabledPostconditionIndex &&
+                postBoundsIndex > blockedReasonCopyIndex &&
                 containedPostconditionIndex > postBoundsIndex &&
                 physicalTapIndex > containedPostconditionIndex,
+        )
+        // Issue #2123: keep the deleted accident deleted. A scroll-offset-dependent
+        // invisibility assertion inside THIS proof is the exact defect that made the
+        // reopened #1602 evidence red on every device; the comment that records the
+        // deletion carries no leading dot, so it is not matched here.
+        assertFalse(
+            "#1602 component must not reinstate a scroll-offset-dependent invisibility assertion " +
+                "on a control it also proves reachable",
+            method.contains(".assertIsNotDisplayed()"),
         )
     }
 


### PR DESCRIPTION
Fixes the red `Emulator journey subset (0)` on `main` — the release blocker for v0.4.44.

Two proofs added with the reopened #1602 fix (`c7a73646`) failed deterministically on shard 0, 4/4 attempts, byte-identical. They are #1602's own acceptance proofs, so #1602 was not verified-done under D33 while they were red.

**Root cause, corrected during the round.** This was originally filed as a CI-vs-dev-box AVD geometry divergence. It is not. The implementer and the reviewer each independently reproduced **both** failures on the local AVD against unmodified `origin/main`, same lines and messages — local AVDs are `1080x2400 @420dpi, API 35`, the same geometry CI's `pixel_7` job uses. The assertions were false on every device and had simply never executed anywhere, because emulator journey jobs are skipped on PRs (the documented "compiling it is not running it" trap).

**Product question answered by measurement.** The composer status strip is genuinely bounded at 96dp (locked by #1613/#1619/#1622), so the per-row explanation is unreachable at rest. But the blocked reason travels on the *control* (`label = "Waiting…"`, `enabled = false`) and is visible with zero scrolling in the collapsed banner the user actually lands in — reviewer screenshot at `build/i2123-review/review2123-collapsed-blocked-banner.png` shows `2 queued · 1 failed` with a `Waiting…` button. The reviewer additionally proved the only branch yielding a bare disabled `"Retry"` is unreachable from a rendered button. So the anti-"tappable silent" contract of #1602 holds and the fix is test-side; **no production file is touched**.

**Not hollowed out.** The reviewer ran four of their own compiled mutants over the full 14-test class: restoring the exact reopened symptom (blocked → tappable bare Retry) reddens only the Waiting proof; dropping the blocked status reddens only it; a `.offset(y=300.dp)` mutant fires the new containment assertion by name; an offline-label mutant reddens only the offline proof. Production `PromptComposerQueueBanners.kt` byte-restored after each.

**Verification**
- Reviewer green run: `--rerun-tasks`, 313/313 executed, 14/14, `skipped=0`, both method names in fresh XML, no `UP-TO-DATE`/`FROM-CACHE`/`NO-SOURCE`, no fixture disturbance.
- Orchestrator gate on this branch: `:app:compileDebugAndroidTestKotlin` BUILD SUCCESSFUL, `scripts/check-test-validity.sh` PASS, `git diff --check` clean.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2123#issuecomment-5286566185

Non-blocking follow-ups noted by the reviewer (not addressed here): `assertFullyWithinBoundedStatusViewport` proves "some visible extent" rather than "fully within" because `boundsInRoot` is already ancestor-clipped (the repo-wide `ComposeSignals.kt:196` helper shares this); the disabled blocked control still uses the full accent fill so it *looks* actionable; and newly-registered journey classes should get one real-emulator run before merge.

Closes #2123