### PR TITLE
host-cli: add `pocketshell send` — an acknowledged delivery primitive (#2122)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -869,13 +869,7 @@ jobs:
       - name: Install uv
         run: pip install --upgrade uv
 
-      # Issue #2122: `tests/test_send.py` drives a REAL tmux server (on an
-      # isolated socket) because `pocketshell send` is an injection primitive
-      # and a mocked tmux would prove nothing about bytes reaching a pane. The
-      # tests HARD-FAIL rather than skip when tmux is missing (a skip would
-      # make this job green while asserting nothing — G3), so the binary must
-      # be present. `command -v` first keeps this free when the runner image
-      # already ships it.
+      # test_send.py drives a real tmux and hard-fails (never skips) without it (#2122).
       - name: Ensure tmux is available (issue #2122)
         run: |
           command -v tmux || { sudo apt-get update && sudo apt-get install -y tmux; }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -869,6 +869,18 @@ jobs:
       - name: Install uv
         run: pip install --upgrade uv
 
+      # Issue #2122: `tests/test_send.py` drives a REAL tmux server (on an
+      # isolated socket) because `pocketshell send` is an injection primitive
+      # and a mocked tmux would prove nothing about bytes reaching a pane. The
+      # tests HARD-FAIL rather than skip when tmux is missing (a skip would
+      # make this job green while asserting nothing — G3), so the binary must
+      # be present. `command -v` first keeps this free when the runner image
+      # already ships it.
+      - name: Ensure tmux is available (issue #2122)
+        run: |
+          command -v tmux || { sudo apt-get update && sudo apt-get install -y tmux; }
+          tmux -V
+
       - name: Install pocketshell + dev deps
         working-directory: tools/pocketshell
         run: |

--- a/scripts/select-test-areas-selftest.sh
+++ b/scripts/select-test-areas-selftest.sh
@@ -597,7 +597,7 @@ SET = (
 FIRST = 'cli.add_command(usage_command, name="usage")'
 
 # (e) ALIAS — the reviewer's exact reproduction. This one must be READ, not
-#     merely refused: the vocabulary stays 17 and the seam does not move.
+#     merely refused: the vocabulary stays 18 and the seam does not move.
 e = src.replace(FIRST, "_g = cli\n" + FIRST, 1)
 for sub, obj in SET:
     old = 'cli.add_command(%s, name="%s")' % (obj, sub)
@@ -720,7 +720,7 @@ then
   out="$(POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/alias.py" bash "$SELECT" --verify-manifest 2>&1)"
   if [[ "$alias_probe" == "$real_probe" ]] && [[ "$alias_probe" == ON-SEAM\ * ]] &&
      grep -q '^PASS: manifest verified' <<<"$out" &&
-     grep -q 'over 17 subcommands read from the 17 top-level registration sites this reader could see' <<<"$out"; then
+     grep -q 'over 18 subcommands read from the 18 top-level registration sites this reader could see' <<<"$out"; then
     ok "16g-h a registration through an ALIAS of the root group is READ correctly, and is a NO-OP for the seam ($alias_probe, unchanged) — receiver-keyed detection dropped 4 subcommands here and stayed green"
   else
     bad "16g-h the aliased registration moves the seam or is not read: real=[$real_probe] alias=[$alias_probe]\n$out"
@@ -900,8 +900,8 @@ PY
   # 16g-k (ROUND 5) — the paired proof that 16g-h is load-bearing. Revert the
   # receiver resolution to round 4's receiver-keyed form (only the literal name
   # `cli` is the root; anything else is treated as some other object) and run it
-  # against the SAME aliased cli.py. It must under-read: 17 subcommands become
-  # 13 while the guard still says PASS. That is precisely the silent failure the
+  # against the SAME aliased cli.py. It must under-read: 18 subcommands become
+  # 14 while the guard still says PASS. That is precisely the silent failure the
   # equality check cannot see, and 16g-h is the assertion that catches it — so
   # if someone reverts the resolver, 16g-h goes red and this case explains why.
   R5DIR="$(mut_copy mut-r5-receiver-keyed)"
@@ -935,8 +935,8 @@ PY
          POCKETSHELL_TA_HOSTCLI_CLI_SOURCE="$CLIDIR/alias.py" \
          bash "$R5DIR/select-test-areas.sh" --verify-manifest 2>&1)"
   if grep -q '^PASS: manifest verified' <<<"$out" &&
-     grep -q 'over 13 subcommands read from the 13 top-level registration sites this reader could see' <<<"$out"; then
-    ok "16g-k receiver-keyed detection silently under-reads the SAME aliased cli.py (17 -> 13 subcommands, still PASS) — so 16g-h's no-op assertion is the thing standing between us and the sixth spelling"
+     grep -q 'over 14 subcommands read from the 14 top-level registration sites this reader could see' <<<"$out"; then
+    ok "16g-k receiver-keyed detection silently under-reads the SAME aliased cli.py (18 -> 14 subcommands, still PASS) — so 16g-h's no-op assertion is the thing standing between us and the sixth spelling"
   else
     bad "16g-k could not reproduce the receiver-keyed under-read, so 16g-h's no-op assertion is unproven:\n$out"
   fi

--- a/tools/pocketshell/README.md
+++ b/tools/pocketshell/README.md
@@ -49,6 +49,7 @@ Top-level commands in the current helper:
 
 ```text
 pocketshell usage [provider] [--json]       # provider quota / usage
+pocketshell send --pane %3 --token <id>     # acknowledged pane delivery
 pocketshell sessions list [--by activity]   # tmux session summaries
 pocketshell jobs ...                        # tmux recurring jobs
 pocketshell agent-log ...                   # agent conversation logs
@@ -65,6 +66,80 @@ Run `pocketshell --help` or `pocketshell <command> --help` for the live
 flag set. Some parity subcommands still proxy through the existing host
 tools internally so their output remains byte-identical to what the app
 already parses.
+
+### `pocketshell send`
+
+Deliver a payload into an exact tmux pane, **exactly once per token**. The
+exit status IS the acknowledgement — the client no longer has to read the
+terminal screen and guess whether its prompt landed (issue #2122, epic
+#2121).
+
+```bash
+printf 'summarise the diff' | pocketshell send --pane %3 --token <row-id> --enter
+pocketshell send --prune-older-than 30d
+```
+
+The payload is read from **stdin as raw bytes** and delivered byte-exact
+(`load-buffer -` → `paste-buffer -d -r`, never argv). This command does not
+add bracketed-paste markers: the client already frames its payload, and
+framing twice put the inner markers into the receiving program as literal
+text (issue #1854). Callers that want bracketed paste write the framed bytes
+to stdin.
+
+Exit codes are stable, and `--help` documents them (rendered from the same
+table the code exits with, so they cannot drift):
+
+| Exit | stdout reason | Meaning |
+| ---- | ------------- | ------- |
+| 0 | `delivered` | Injected by this call and journaled. |
+| 0 | `already-delivered` | The token was already journaled; nothing injected. |
+| 0 | `pruned <n>` | `--prune-older-than` removed `n` records. |
+| 2 | `bad-usage` | Invalid/missing arguments. Nothing injected or journaled. |
+| 3 | `pane-not-found` | Pane missing or dead. Not journaled; stays retryable. |
+| 4 | `tmux-failed` | tmux missing / no server / definitive failure before the pane was touched. Not journaled; stays retryable. |
+| 5 | `send-interrupted` or `journal-corrupt` | A previous attempt for this token died without an answer (its process is gone). Delivery is genuinely UNKNOWN and nothing was injected now. |
+| 6 | `timeout` | A tmux call exceeded `--timeout`. |
+| 7 | `journal-failed` | The journal could not be read/written. Nothing injected. |
+| 8 | `send-in-progress` | Another send for this token is STILL RUNNING. Nothing injected, nothing unknown — retry shortly to read that call's answer. |
+
+stdout is machine-readable: the first whitespace-delimited token is one of
+the reasons above; human detail goes to stderr. Every retry path drains stdin
+before exiting, so a caller piping a payload never takes SIGPIPE on a
+successful acknowledgement. (Argument validation runs *before* stdin is read,
+deliberately: a caller with an open-but-idle stdin gets `bad-usage`
+immediately instead of blocking on a payload that will never arrive.)
+
+**Durability invariant: at-most-once, except on an explicit opt-in.** A token
+is never injected a second time unless the caller passes
+`--resend-interrupted` on the injecting call itself; no sequence of failures,
+kills, races or automatic housekeeping can turn an injected token back into a
+state a plain call will inject. The journal under
+`${XDG_STATE_HOME:-~/.local/state}/pocketshell/sends/` is two-phase — a
+`pending` record is written (atomically, fsync'd) immediately before the one
+command that can put bytes into the pane, then promoted to `delivered` once
+tmux answers. A definitive tmux failure rolls that claim back, so ordinary
+errors stay cleanly retryable; rolling back means undoing *this* call, so a
+record this call created is removed and a pre-existing unresolved record it
+overwrote is restored byte-for-byte rather than erased.
+
+An unresolved record is then read against its owner process: gone ⇒ a previous
+attempt died and delivery is genuinely unknown (exit 5, resolvable with
+`--resend-interrupted`, so the state is never absorbing); still running ⇒
+nothing is unknown and the outcome belongs to that call (exit 8, retryable).
+`--resend-interrupted` does not override a live owner — there is no unknown to
+resolve, and forcing one would simply duplicate the payload.
+
+The invariant's honest edges: a definitive non-zero from `paste-buffer` is
+taken as proof nothing reached the pane; the journal directory must survive
+(delete it and the memory is gone); and `--prune-older-than` is an operator
+action that *can* clear unresolved records.
+
+Records carry a timestamp and are pruned two ways: explicitly with
+`--prune-older-than <30d|12h|90m|3600s>`, and automatically on delivery at a
+**30-day default retention** (throttled to at most once every 6 h), so the
+directory cannot grow without bound even if pruning is never invoked. The
+automatic sweep only removes **resolved** records — ageing an unknown out of
+the journal would silently make the token injectable again.
 
 ### `pocketshell usage`
 

--- a/tools/pocketshell/README.md
+++ b/tools/pocketshell/README.md
@@ -96,11 +96,32 @@ table the code exits with, so they cannot drift):
 | 0 | `pruned <n>` | `--prune-older-than` removed `n` records. |
 | 2 | `bad-usage` | Invalid/missing arguments. Nothing injected or journaled. |
 | 3 | `pane-not-found` | Pane missing or dead. Not journaled; stays retryable. |
-| 4 | `tmux-failed` | tmux missing / no server / definitive failure before the pane was touched. Not journaled; stays retryable. |
+| 4 | `tmux-failed` | tmux missing / no server / a definitive tmux failure. This call never recorded a delivery. Usually the pane was never touched and the token is left unclaimed, but not always — see the note below before auto-retrying. |
 | 5 | `send-interrupted` or `journal-corrupt` | A previous attempt for this token died without an answer (its process is gone). Delivery is genuinely UNKNOWN and nothing was injected now. |
 | 6 | `timeout` | A tmux call exceeded `--timeout`. |
 | 7 | `journal-failed` | The journal could not be read/written. Nothing injected. |
 | 8 | `send-in-progress` | Another send for this token is STILL RUNNING. Nothing injected, nothing unknown — retry shortly to read that call's answer. |
+
+**Exit 4 in detail** — a client that branches on this table to decide whether
+to auto-retry (#2124) must not read `tmux-failed` as "clean slate". It
+guarantees only that this call never recorded a *delivery*. It does **not**
+guarantee the token is unjournaled, and in one narrow case it does not
+guarantee the pane is untouched:
+
+- Failure at the pane lookup, or while filling the paste buffer — both happen
+  before the journal is written at all: nothing injected, token unclaimed,
+  cleanly retryable. This is the ordinary case.
+- A definitive `paste-buffer` failure rolls this call's claim back. For a plain
+  call that returns the token to absent (cleanly retryable). Under
+  `--resend-interrupted` the *pre-existing* unresolved record is restored
+  byte-for-byte rather than erased, so the token stays journaled-unresolved and
+  the next plain call answers exit 5, not a fresh injection.
+- tmux disappearing between a successful paste and the `Enter`: the payload
+  **is** in the pane, the pending record is deliberately kept, and the next
+  plain call answers exit 5.
+
+A plain retry after exit 4 is therefore always *safe* — it re-reads the journal
+and answers exit 5 rather than duplicating — but it is not guaranteed to inject.
 
 stdout is machine-readable: the first whitespace-delimited token is one of
 the reasons above; human detail goes to stderr. Every retry path drains stdin
@@ -131,8 +152,17 @@ resolve, and forcing one would simply duplicate the payload.
 
 The invariant's honest edges: a definitive non-zero from `paste-buffer` is
 taken as proof nothing reached the pane; the journal directory must survive
-(delete it and the memory is gone); and `--prune-older-than` is an operator
-action that *can* clear unresolved records.
+(delete it and the memory is gone); `--prune-older-than` is an operator
+action that *can* clear unresolved records; and exit 8 is bounded by the owner
+process's **liveness**, not by the owner's `--timeout`. A suspended owner
+(reproduced with `SIGSTOP`) holds its token in `send-in-progress` for as long
+as it stays stopped, because the liveness probe asks whether the process still
+exists, not whether it is making progress, and `--timeout` bounds the tmux
+calls of the process that passed it rather than some other process's lifetime.
+This fails safe — the payload is never duplicated and the token never becomes
+absorbing once the owner dies — and a client cannot reach it through its own
+use, since it would have to suspend its own in-flight send. Nothing reaps a
+suspended owner.
 
 Records carry a timestamp and are pruned two ways: explicitly with
 `--prune-older-than <30d|12h|90m|3600s>`, and automatically on delivery at a

--- a/tools/pocketshell/src/pocketshell/cli.py
+++ b/tools/pocketshell/src/pocketshell/cli.py
@@ -36,6 +36,7 @@ from pocketshell.prune_attachments import prune_attachments_command
 from pocketshell.push import push_group
 from pocketshell.qr_share import qr_share_command
 from pocketshell.repos import repos_group
+from pocketshell.send import send_command
 from pocketshell.sessions import sessions_group
 from pocketshell.tree import tree_group
 from pocketshell.usage import usage_command
@@ -62,6 +63,10 @@ cli.add_command(agents_group, name="agents")
 cli.add_command(profiles_group, name="profiles")
 cli.add_command(jobs_group, name="jobs")
 cli.add_command(sessions_group, name="sessions")
+# Issue #2122 (epic #2121): the acknowledged outbound delivery primitive. The
+# exec's exit status IS the delivery acknowledgement, replacing the client's
+# bounded terminal-observation guess.
+cli.add_command(send_command, name="send")
 cli.add_command(tree_group, name="tree")
 cli.add_command(agent_log_command, name="agent-log")
 cli.add_command(repos_group, name="repos")

--- a/tools/pocketshell/src/pocketshell/send.py
+++ b/tools/pocketshell/src/pocketshell/send.py
@@ -1,0 +1,1351 @@
+"""`pocketshell send` — an ACKNOWLEDGED outbound delivery primitive (issue #2122).
+
+Step 1a of epic #2121. Pure host-side. No client changes live here.
+
+Why this exists
+---------------
+
+Today the Android composer cannot learn whether a prompt actually landed. It
+injects the payload and then *reads the terminal screen*, guessing within an
+800 ms / 2 s stopwatch. A missed window becomes a row stuck permanently at
+"unconfirmed" whose Retry is a provable no-op, while the exactly-once ledger —
+correctly — refuses to re-send. #2121 has the full mechanism.
+
+This command replaces the guess with an answer: **the exec's exit status IS the
+acknowledgement.** One round trip, no windows, no needles, no screen scraping.
+The truth is decided by the only party that can observe it (the tmux server on
+the host), and it is recorded in a durable journal that survives client death,
+app restart and reinstall.
+
+Durability invariant (deliberate, see issue #2122 status comment)
+-----------------------------------------------------------------
+
+**At-most-once, except on an explicit opt-in: a token is never injected a second
+time unless the caller passes ``--resend-interrupted`` on the injecting call
+itself.** No sequence of failures, kills, races or automatic housekeeping can
+turn an already-injected token back into a state that a plain call will inject.
+
+The journal is two-phase:
+
+1. A ``pending`` record is written (atomically, fsync'd) immediately before the
+   one exec that can put bytes into the pane. It carries the writing process's
+   identity (pid + start time + boot id).
+2. The record is promoted to ``delivered`` once tmux has answered.
+
+Everything before step 1 touches no pane, so a death there is a clean no-op and
+the next call retries from scratch. A *definitive* tmux failure (we got a
+return code, so we know nothing reached the pane) rolls the claim back, which
+leaves the token cleanly retryable — this is what makes ``pane-not-found`` /
+``tmux-failed`` non-poisoning. Rolling back means "undo what THIS call did": a
+record this call created is removed, and a pre-existing unresolved record this
+call overwrote is RESTORED byte-for-byte, never erased (#2122 F1).
+
+An unresolved record therefore has exactly two readings, and they are reported
+as different outcomes because they are different facts:
+
+* its owner process is **gone** — a previous attempt died without an answer, so
+  delivery is genuinely unknown: exit 5 ``send-interrupted``. Not laundered into
+  "delivered" (which would lose a prompt) or "not delivered" (which would
+  duplicate one). ``--resend-interrupted`` is the caller's explicit, opt-in
+  escape into at-least-once for that single token, so the state is never
+  absorbing — the property #2121 says the current client lacks.
+* its owner process is **still running** — nothing is unknown; the outcome is
+  simply owned by that call: exit 8 ``send-in-progress``, retryable (#2122 F2).
+  Reporting the dead-attempt code for a healthy sibling would recreate the
+  spurious-unknown class this epic exists to delete, and it is the common shape
+  in practice (an automatic flush racing a manual retry, #1602).
+
+The invariant's honest edges, stated rather than glossed:
+
+* A definitive non-zero from ``tmux paste-buffer`` is taken as proof that
+  nothing reached the pane. There is no known tmux path that errors after
+  writing bytes; if one existed the rollback would be wrong.
+* The journal must survive. Delete the state directory (or point
+  ``XDG_STATE_HOME`` somewhere else) and the memory is gone, so a re-send
+  injects again.
+* Automatic pruning only removes RESOLVED records, so an unknown is never aged
+  into an injectable ``absent``. The explicit ``--prune-older-than`` sweep is a
+  deliberate operator action and does clear them.
+* Liveness is proven from ``/proc``; anything unprovable reads as "not alive",
+  i.e. the conservative unknown, never as "inject".
+
+Payload fidelity
+----------------
+
+The payload is read from stdin as raw bytes and delivered byte-exact. It is
+loaded into a tmux paste buffer via ``load-buffer -`` (never argv — argv would
+mangle a trailing ``;`` per issue #1845, cap the size, and force quoting), then
+committed with ``paste-buffer -d -r``. The ``-r`` is load-bearing: without it
+tmux rewrites every ``\\n`` into ``\\r``, which an agent input box reads as
+SUBMIT and tears a multi-line prompt into one prompt per line (issue #1636).
+
+This command does NOT frame the payload in bracketed-paste markers. The client
+already owns framing (``BracketedPaste.frame``) and framing a second time here
+would reproduce issue #1854, where the inner markers reached the receiving
+program as literal content. Callers that want bracketed paste write the framed
+bytes to stdin; the bytes on stdin are the bytes the pane receives.
+
+Storage
+-------
+
+``${XDG_STATE_HOME:-~/.local/state}/pocketshell/sends/`` — ONE file per token,
+named ``<sha256(token)>.json`` (the token is opaque and may contain anything, so
+it is hashed rather than used as a filename; the raw token is stored inside the
+document and verified on read). One file per token, not one shared document,
+because a shared document has a read-modify-write lost-update race between
+concurrent sends and because a single corrupt document would break every token
+rather than one. Written with the temp-file + ``os.replace`` + fsync pattern
+used by :mod:`pocketshell.tree`, so a reader never sees a half-written record.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+import click
+
+# --------------------------------------------------------------------------
+# Exit codes — STABLE and documented. The client (#2124) branches on these.
+# --------------------------------------------------------------------------
+
+EXIT_OK = 0
+EXIT_BAD_USAGE = 2
+EXIT_PANE_NOT_FOUND = 3
+EXIT_TMUX_FAILED = 4
+EXIT_SEND_INTERRUPTED = 5
+EXIT_TIMEOUT = 6
+EXIT_JOURNAL_FAILED = 7
+EXIT_SEND_IN_PROGRESS = 8
+
+# Machine-readable first token printed on stdout for each outcome.
+REASON_DELIVERED = "delivered"
+REASON_ALREADY_DELIVERED = "already-delivered"
+REASON_PRUNED = "pruned"
+REASON_BAD_USAGE = "bad-usage"
+REASON_PANE_NOT_FOUND = "pane-not-found"
+REASON_TMUX_FAILED = "tmux-failed"
+REASON_SEND_INTERRUPTED = "send-interrupted"
+REASON_SEND_IN_PROGRESS = "send-in-progress"
+REASON_JOURNAL_CORRUPT = "journal-corrupt"
+REASON_TIMEOUT = "timeout"
+REASON_JOURNAL_FAILED = "journal-failed"
+
+#: The documented exit-code table. ``--help`` is rendered FROM this tuple, so
+#: the documentation cannot drift from the constants (a test asserts every row
+#: appears in ``--help``).
+EXIT_CODE_TABLE: tuple[tuple[int, str, str], ...] = (
+    (
+        EXIT_OK,
+        f"{REASON_DELIVERED} | {REASON_ALREADY_DELIVERED} | {REASON_PRUNED}",
+        "Success. 'delivered' = injected by THIS call and journaled. "
+        "'already-delivered' = the token was already journaled, nothing was "
+        "injected. 'pruned' = --prune-older-than removed N records.",
+    ),
+    (
+        EXIT_BAD_USAGE,
+        REASON_BAD_USAGE,
+        "Invalid or missing arguments. Nothing was injected or journaled.",
+    ),
+    (
+        EXIT_PANE_NOT_FOUND,
+        REASON_PANE_NOT_FOUND,
+        "The pane id does not exist on the tmux server, or it is dead. "
+        "Nothing was injected; the token is NOT journaled and stays retryable.",
+    ),
+    (
+        EXIT_TMUX_FAILED,
+        REASON_TMUX_FAILED,
+        "tmux is missing, no server is running, or a tmux command returned a "
+        "definitive failure before anything could reach the pane. Nothing was "
+        "injected; the token is NOT journaled and stays retryable.",
+    ),
+    (
+        EXIT_SEND_INTERRUPTED,
+        f"{REASON_SEND_INTERRUPTED} | {REASON_JOURNAL_CORRUPT}",
+        "A PREVIOUS attempt with this token died without an answer (or left an "
+        "unreadable record) and its owning process is gone, so its delivery is "
+        "genuinely UNKNOWN. Nothing was injected by this call: the token is "
+        "never injected twice implicitly. Re-run with --resend-interrupted to "
+        "accept a possible duplicate and deliver again.",
+    ),
+    (
+        EXIT_TIMEOUT,
+        REASON_TIMEOUT,
+        "A tmux invocation exceeded --timeout. If the timeout hit during the "
+        "commit the token is left in the unknown state above; a retry then "
+        "reports 'send-interrupted' rather than injecting again.",
+    ),
+    (
+        EXIT_JOURNAL_FAILED,
+        REASON_JOURNAL_FAILED,
+        "The durable token journal could not be read or written (permissions, "
+        "disk). Nothing was injected — the journal is written BEFORE the pane "
+        "is touched precisely so this failure is safe.",
+    ),
+    (
+        EXIT_SEND_IN_PROGRESS,
+        REASON_SEND_IN_PROGRESS,
+        "Another send for this token is STILL RUNNING (its process is alive on "
+        "this host). Nothing was injected by this call and nothing is unknown: "
+        "the outcome is owned by that call. Retry shortly to read the answer — "
+        "it will be 'delivered'/'already-delivered' or, if that process dies, "
+        "'send-interrupted'. --resend-interrupted does not override this: "
+        "there is no unknown to resolve while the owner is alive, and forcing "
+        "one would duplicate the payload.",
+    ),
+)
+
+# --------------------------------------------------------------------------
+# Journal
+# --------------------------------------------------------------------------
+
+JOURNAL_SCHEMA = 1
+STATE_PENDING = "pending"
+STATE_DELIVERED = "delivered"
+
+NEW_FILE_MODE = 0o600
+
+#: Retention default for the automatic background prune. Journal records exist
+#: only to make a client retry safe; a token whose row the client resolved a
+#: month ago can never be retried, so 30 days is generous. Explicit pruning
+#: (``--prune-older-than``) may use any duration.
+DEFAULT_RETENTION_SECS = 30 * 24 * 60 * 60
+
+#: The auto-prune runs at most this often (tracked by the mtime of the
+#: ``.last-prune`` marker), so the common send path never pays for a directory
+#: walk. Best-effort: an auto-prune failure never fails a send.
+AUTO_PRUNE_INTERVAL_SECS = 6 * 60 * 60
+
+LAST_PRUNE_MARKER = ".last-prune"
+
+#: Tokens are opaque, but a control character in one would be a client bug and
+#: would make logs unreadable, and an unbounded token would make an unbounded
+#: record. Rejected as bad-usage rather than silently mangled.
+MAX_TOKEN_LENGTH = 512
+
+_DURATION_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhdw]?)\s*$", re.IGNORECASE)
+_DURATION_UNITS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+
+
+class JournalError(RuntimeError):
+    """The token journal could not be read or written."""
+
+
+@dataclass(frozen=True)
+class SendPaths:
+    """Resolved filesystem location for the token journal."""
+
+    sends_dir: Path
+
+    def record_file(self, token: str) -> Path:
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        return self.sends_dir / f"{digest}.json"
+
+    @property
+    def prune_marker(self) -> Path:
+        return self.sends_dir / LAST_PRUNE_MARKER
+
+
+def resolve_paths(
+    *,
+    home: Optional[Path] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> SendPaths:
+    """Return the :class:`SendPaths` for the current (or given) environment.
+
+    1. ``$XDG_STATE_HOME/pocketshell/sends`` when ``$XDG_STATE_HOME`` is set.
+    2. ``<home>/.local/state/pocketshell/sends``.
+
+    Mirrors :func:`pocketshell.tree.resolve_paths` so all PocketShell durable
+    state lives under one XDG-state root.
+    """
+    env_map = env if env is not None else os.environ
+    base_home = home if home is not None else Path(os.path.expanduser("~"))
+
+    xdg_state = env_map.get("XDG_STATE_HOME")
+    if xdg_state:
+        state_root = Path(os.path.expanduser(xdg_state))
+    else:
+        state_root = base_home / ".local" / "state"
+    return SendPaths(sends_dir=state_root / "pocketshell" / "sends")
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+
+
+def _fsync_dir(path: Path) -> None:
+    """fsync a directory so a completed ``os.replace`` survives power loss."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _write_temp(path: Path, payload: bytes) -> Path:
+    """Write ``payload`` to a private, fsync'd temp file beside ``path``."""
+    _ensure_dir(path.parent)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex[:8]}.tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, NEW_FILE_MODE)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return tmp
+
+
+def write_bytes_atomic(path: Path, payload: bytes) -> None:
+    """Publish ``payload`` at ``path`` atomically with mode 0600.
+
+    Temp file in the SAME directory (so ``os.replace`` is a rename inside one
+    filesystem and therefore atomic), fsync'd before the rename and the parent
+    directory fsync'd after it. A reader — including the next invocation after a
+    ``kill -9`` — sees either the old record or the new one, never a truncated
+    one. The temp file is removed if anything fails, so a crashed write leaves
+    no ``*.tmp`` litter that a later read could mistake for a record.
+    """
+    tmp = _write_temp(path, payload)
+    try:
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    _fsync_dir(path.parent)
+
+
+def write_record_atomic(path: Path, document: Mapping[str, Any]) -> None:
+    """Atomically publish ``document`` as the record at ``path``."""
+    write_bytes_atomic(path, _serialise(document))
+
+
+def _serialise(document: Mapping[str, Any]) -> bytes:
+    return json.dumps(document, ensure_ascii=False, sort_keys=True).encode("utf-8")
+
+
+def claim_record_exclusive(path: Path, document: Mapping[str, Any]) -> bool:
+    """Create the record, returning False if another process got there first.
+
+    This is the mutual exclusion that stops two concurrent ``send`` calls
+    carrying the SAME token from both reading "absent" and both injecting.
+    Exactly-once has to survive a racing caller, not just a sequential retry.
+
+    The document is written to a private temp file FIRST and published with
+    ``os.link``, which fails with ``FileExistsError`` when the target already
+    exists and is otherwise atomic. That gives both properties at once:
+    exclusion (exactly one racer can link onto the name) and completeness (the
+    record is fully written and fsync'd before it becomes visible). Creating
+    the final path directly with ``O_CREAT|O_EXCL`` would leave a window in
+    which a sibling reads a zero-length file and has to classify it as corrupt,
+    i.e. an unresolved state manufactured by a healthy race.
+    """
+    payload = _serialise(document)
+    tmp = _write_temp(path, payload)
+    try:
+        try:
+            os.link(tmp, path)
+        except FileExistsError:
+            return False
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+    _fsync_dir(path.parent)
+    return True
+
+
+def roll_back_claim(path: Path, prior_bytes: Optional[bytes]) -> None:
+    """Undo THIS call's pending claim, and only this call's.
+
+    ``prior_bytes`` is ``None`` when the token had no record at entry: this
+    call created it, so removing it returns the token to genuinely-absent and
+    keeps an ordinary transient tmux error cleanly retryable.
+
+    When a record DID exist — the ``--resend-interrupted`` path, where this
+    call overwrote somebody else's "delivery unknown" memory — deleting it
+    would erase evidence this call did not create, and the very next PLAIN
+    (non-opt-in) call would read ``absent`` and inject a second copy. That
+    falsifies the whole at-most-once claim, so the prior document is restored
+    byte-for-byte instead (issue #2122, review finding F1).
+
+    Never raises: it runs on an already-failing path, and if the restore itself
+    fails this call's own pending record stays behind — which is still an
+    unresolved state, i.e. still safe, never "absent".
+    """
+    if prior_bytes is None:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return
+    try:
+        write_bytes_atomic(path, prior_bytes)
+    except OSError:
+        pass
+
+
+# --------------------------------------------------------------------------
+# Owner liveness — telling a DEAD previous attempt (genuinely unknown) apart
+# from a LIVE sibling that is merely still running (provably not unknown).
+# --------------------------------------------------------------------------
+
+
+def _boot_id() -> str:
+    """The kernel's per-boot id, or "" when it cannot be read.
+
+    A pending record that survived a reboot names a pid from a previous boot,
+    which is a different process universe: without this, an unrelated process
+    that happens to hold that pid could make a dead attempt look alive.
+    """
+    try:
+        return Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _process_start_ticks(pid: int) -> Optional[int]:
+    """Field 22 of ``/proc/<pid>/stat`` — the process start time in ticks.
+
+    Together with the pid this is a stable process identity: a REUSED pid
+    necessarily has a later start time, so a stale record can never be mistaken
+    for a running one. ``comm`` (field 2) may itself contain spaces and
+    parentheses, so parsing starts after the LAST ``)``.
+    """
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_bytes()
+    except OSError:
+        return None
+    close = raw.rfind(b")")
+    if close < 0:
+        return None
+    fields = raw[close + 2 :].split()
+    # The remainder starts at field 3 (state), so field 22 is index 19.
+    if len(fields) <= 19:
+        return None
+    try:
+        return int(fields[19])
+    except ValueError:
+        return None
+
+
+def owner_identity(pid: Optional[int] = None) -> dict[str, Any]:
+    """The identity stamp written into a ``pending`` record."""
+    resolved = os.getpid() if pid is None else pid
+    return {
+        "pid": resolved,
+        "start_ticks": _process_start_ticks(resolved),
+        "boot_id": _boot_id(),
+    }
+
+
+def owner_is_alive(owner: Any) -> bool:
+    """True only when ``owner`` PROVABLY names a process running right now.
+
+    Fails closed. Anything that cannot be proven — a missing or malformed
+    stamp, an unreadable ``/proc``, a different boot, a pid whose start time no
+    longer matches — reports False, which routes to the conservative "delivery
+    is unknown" answer. The dangerous direction is the other one: a false
+    "somebody else owns this" would suppress a legitimate resend, so this
+    function must never guess in that direction.
+    """
+    if not isinstance(owner, Mapping):
+        return False
+    pid = owner.get("pid")
+    start_ticks = owner.get("start_ticks")
+    boot_id = owner.get("boot_id")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    if not isinstance(start_ticks, int) or isinstance(start_ticks, bool):
+        return False
+    if not isinstance(boot_id, str) or not boot_id:
+        return False
+    current_boot = _boot_id()
+    if not current_boot or current_boot != boot_id:
+        return False
+    return _process_start_ticks(pid) == start_ticks
+
+
+@dataclass(frozen=True)
+class JournalRecord:
+    """A parsed journal record.
+
+    ``state`` is one of :data:`STATE_PENDING`, :data:`STATE_DELIVERED`, the
+    sentinel ``"absent"`` (no record) or ``"corrupt"`` (a record exists but
+    cannot be trusted).
+    """
+
+    state: str
+    token: str = ""
+    pane: str = ""
+    created_at: float = 0.0
+    delivered_at: Optional[float] = None
+    #: Identity of the process that wrote a ``pending`` record, used to tell a
+    #: dead attempt (unknown) from a live sibling (not unknown). ``None`` when
+    #: absent or unusable, which :func:`owner_is_alive` treats as "not alive".
+    owner: Optional[Mapping[str, Any]] = None
+
+    @property
+    def timestamp(self) -> float:
+        return self.delivered_at if self.delivered_at is not None else self.created_at
+
+
+STATE_ABSENT = "absent"
+STATE_CORRUPT = "corrupt"
+
+
+def read_record(path: Path, token: str) -> JournalRecord:
+    """Read the journal record at ``path``, never raising on bad content.
+
+    A truncated / non-JSON / wrong-shaped / wrong-token document is reported as
+    :data:`STATE_CORRUPT`, not as "absent" — something happened for this token
+    and we cannot prove what, so it must be treated as ambiguous rather than as
+    permission to inject again. An unreadable file (permissions/IO) raises
+    :class:`JournalError`, which is a different failure: we could not consult
+    the journal at all.
+    """
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return JournalRecord(state=STATE_ABSENT)
+    except OSError as exc:
+        raise JournalError(f"cannot read {path}: {exc}") from exc
+
+    try:
+        document = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return JournalRecord(state=STATE_CORRUPT)
+    if not isinstance(document, dict):
+        return JournalRecord(state=STATE_CORRUPT)
+
+    state = document.get("state")
+    recorded_token = document.get("token")
+    if state not in (STATE_PENDING, STATE_DELIVERED):
+        return JournalRecord(state=STATE_CORRUPT)
+    if not isinstance(recorded_token, str) or recorded_token != token:
+        return JournalRecord(state=STATE_CORRUPT)
+
+    def _float(key: str) -> Optional[float]:
+        value = document.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        return None
+
+    created = _float("created_at")
+    if created is None:
+        return JournalRecord(state=STATE_CORRUPT)
+    delivered = _float("delivered_at")
+    if state == STATE_DELIVERED and delivered is None:
+        return JournalRecord(state=STATE_CORRUPT)
+
+    pane = document.get("pane")
+    owner = document.get("owner")
+    return JournalRecord(
+        state=state,
+        token=recorded_token,
+        pane=pane if isinstance(pane, str) else "",
+        created_at=created,
+        delivered_at=delivered,
+        owner=owner if isinstance(owner, Mapping) else None,
+    )
+
+
+def classify_unresolved(path: Path, token: str) -> tuple[JournalRecord, bool]:
+    """Read the record and decide whether a LIVE process still owns the token.
+
+    Returns ``(record, owner_alive)``. When the owner looks dead the record is
+    read a SECOND time before that verdict is returned, because the owner may
+    have finished and promoted the record in the microseconds between the first
+    read and the liveness check — without the re-read that race would report a
+    completed delivery as an unresolved unknown, which is exactly the spurious
+    unknown this command exists to eliminate.
+    """
+    record = read_record(path, token)
+    if record.state != STATE_PENDING:
+        return record, False
+    if owner_is_alive(record.owner):
+        return record, True
+    settled = read_record(path, token)
+    if settled.state != STATE_PENDING:
+        return settled, False
+    return settled, owner_is_alive(settled.owner)
+
+
+def _iso(epoch: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+
+
+def _record_document(
+    *,
+    token: str,
+    pane: str,
+    state: str,
+    created_at: float,
+    delivered_at: Optional[float],
+    payload_bytes: int,
+    enter: bool,
+    owner: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        "schema": JOURNAL_SCHEMA,
+        "token": token,
+        "pane": pane,
+        "state": state,
+        "created_at": created_at,
+        "payload_bytes": payload_bytes,
+        "enter": enter,
+    }
+    if delivered_at is not None:
+        document["delivered_at"] = delivered_at
+    if owner is not None:
+        document["owner"] = dict(owner)
+    return document
+
+
+# --------------------------------------------------------------------------
+# Pruning
+# --------------------------------------------------------------------------
+
+
+def parse_duration(text: str) -> float:
+    """Parse ``30d`` / ``12h`` / ``90m`` / ``3600s`` / ``3600`` into seconds."""
+    match = _DURATION_RE.match(text)
+    if match is None:
+        raise ValueError(f"cannot parse duration: {text!r}")
+    value = float(match.group(1))
+    unit = match.group(2).lower()
+    return value * _DURATION_UNITS[unit]
+
+
+def prune(
+    paths: SendPaths,
+    *,
+    older_than_secs: float,
+    now: Optional[float] = None,
+    resolved_only: bool = False,
+) -> int:
+    """Delete journal records older than ``older_than_secs``. Returns the count.
+
+    A record's age is its ``delivered_at`` (falling back to ``created_at``); a
+    record we cannot parse is aged by its file mtime, so corrupt records are
+    prunable too rather than immortal.
+
+    ``resolved_only`` restricts the sweep to records whose outcome is settled
+    (``delivered``). The AUTOMATIC prune uses it: an aged ``pending`` or
+    unreadable record is still "we do not know whether this token was
+    injected", and deleting it would silently return the token to ``absent``
+    so the next plain call injects a second copy — the at-most-once
+    falsification of finding F1, on a timer instead of on a tmux error. The
+    explicit ``--prune-older-than`` sweep is a deliberate operator action and
+    keeps removing everything past the cutoff.
+    """
+    moment = time.time() if now is None else now
+    cutoff = moment - older_than_secs
+    removed = 0
+    try:
+        entries = sorted(paths.sends_dir.glob("*.json"))
+    except OSError:
+        return 0
+    for entry in entries:
+        try:
+            document = json.loads(entry.read_bytes().decode("utf-8"))
+            resolved = isinstance(document, dict) and document.get("state") == STATE_DELIVERED
+            stamp = document.get("delivered_at")
+            if not isinstance(stamp, (int, float)) or isinstance(stamp, bool):
+                stamp = document.get("created_at")
+            if not isinstance(stamp, (int, float)) or isinstance(stamp, bool):
+                raise ValueError("no usable timestamp")
+            age_stamp = float(stamp)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError, AttributeError):
+            # Unreadable: still a token something happened for, so it counts as
+            # UNRESOLVED for the automatic sweep. Aged by mtime for the
+            # explicit one, which must be able to clear it.
+            resolved = False
+            try:
+                age_stamp = entry.stat().st_mtime
+            except OSError:
+                continue
+        if resolved_only and not resolved:
+            continue
+        if age_stamp < cutoff:
+            try:
+                entry.unlink()
+            except OSError:
+                continue
+            removed += 1
+    return removed
+
+
+def maybe_auto_prune(paths: SendPaths, *, now: Optional[float] = None) -> bool:
+    """Run the default-retention prune at most once per interval. Best-effort.
+
+    Returns True when a prune ran. NEVER raises: the caller has already
+    delivered a payload, and a housekeeping failure must not turn a successful
+    delivery into an error the client would retry.
+
+    Only RESOLVED (``delivered``) records are swept. Automatic housekeeping may
+    not delete an unknown — see :func:`prune`.
+    """
+    moment = time.time() if now is None else now
+    marker = paths.prune_marker
+    try:
+        last = marker.stat().st_mtime
+        if moment - last < AUTO_PRUNE_INTERVAL_SECS:
+            return False
+    except OSError:
+        pass
+    try:
+        prune(
+            paths,
+            older_than_secs=DEFAULT_RETENTION_SECS,
+            now=moment,
+            resolved_only=True,
+        )
+        _ensure_dir(marker.parent)
+        with open(marker, "a", encoding="utf-8"):
+            pass
+        os.utime(marker, (moment, moment))
+    except OSError:
+        return False
+    return True
+
+
+# --------------------------------------------------------------------------
+# tmux
+# --------------------------------------------------------------------------
+
+
+class TmuxUnavailable(RuntimeError):
+    """The tmux binary could not be executed."""
+
+
+class TmuxTimeout(RuntimeError):
+    """A tmux invocation exceeded the caller's deadline."""
+
+
+@dataclass
+class TmuxRunner:
+    """Runs tmux commands against one server, under a single total deadline.
+
+    ``socket_name`` maps to tmux ``-L``. It exists so tests can drive a real
+    tmux server on an ISOLATED socket; production callers omit it and get the
+    host's default server (the one tmuxctl and the app use).
+    """
+
+    socket_name: Optional[str] = None
+    deadline: Optional[float] = None
+    tmux_binary: str = "tmux"
+
+    def _remaining(self) -> Optional[float]:
+        if self.deadline is None:
+            return None
+        left = self.deadline - time.monotonic()
+        if left <= 0:
+            raise TmuxTimeout("deadline exceeded before the tmux call started")
+        return left
+
+    def run(
+        self,
+        args: Sequence[str],
+        *,
+        input_bytes: Optional[bytes] = None,
+    ) -> subprocess.CompletedProcess:
+        argv = [self.tmux_binary]
+        if self.socket_name:
+            argv += ["-L", self.socket_name]
+        argv += list(args)
+        try:
+            # Fixed argv, never a shell string: the payload and the token
+            # never become shell words.
+            return subprocess.run(
+                argv,
+                input=input_bytes if input_bytes is not None else b"",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=self._remaining(),
+            )
+        except FileNotFoundError as exc:
+            raise TmuxUnavailable(f"cannot execute {self.tmux_binary}: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TmuxTimeout(f"tmux {' '.join(args)} timed out") from exc
+
+
+def _decode(stream: Optional[bytes]) -> str:
+    if not stream:
+        return ""
+    return stream.decode("utf-8", "replace").strip()
+
+
+@dataclass(frozen=True)
+class PaneLookup:
+    found: bool
+    dead: bool
+    detail: str = ""
+
+
+def lookup_pane(runner: TmuxRunner, pane: str) -> PaneLookup:
+    """Report whether ``pane`` exists and is alive on the server.
+
+    Uses ``list-panes -a`` and compares ids ourselves rather than probing with
+    ``-t`` and parsing tmux's stderr prose, so the classification does not
+    depend on an error message's wording.
+    """
+    proc = runner.run(["list-panes", "-a", "-F", "#{pane_id} #{pane_dead}"])
+    if proc.returncode != 0:
+        raise TmuxCommandFailed(_decode(proc.stderr) or "tmux list-panes failed")
+    for line in _decode(proc.stdout).splitlines():
+        parts = line.split()
+        if not parts or parts[0] != pane:
+            continue
+        dead = len(parts) > 1 and parts[1] == "1"
+        return PaneLookup(found=True, dead=dead)
+    return PaneLookup(found=False, dead=False, detail=f"no such pane: {pane}")
+
+
+class TmuxCommandFailed(RuntimeError):
+    """A tmux command returned a definitive non-zero status."""
+
+
+def buffer_name_for(token: str) -> str:
+    """A per-token tmux buffer name, alphanumeric only.
+
+    Per-token (not per-pane) so two concurrent sends never truncate each other's
+    buffer between fill and commit. Alphanumeric because tmux treats a trailing
+    ``;`` in an argv element as a command separator (issue #1845).
+    """
+    return "pssend" + hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+# --------------------------------------------------------------------------
+# The command
+# --------------------------------------------------------------------------
+
+
+def _epilog() -> str:
+    """Render the ``--help`` epilog FROM :data:`EXIT_CODE_TABLE`.
+
+    Built from the table rather than written out by hand so the documented
+    codes cannot drift from the constants the code actually exits with (a test
+    asserts every row of the table appears in ``--help``). Each block is
+    preceded by a ``\\b`` marker, which is click's "do not rewrap the following
+    paragraph" escape.
+    """
+    lines = [
+        "\b",
+        "EXIT CODES (stable — clients branch on these):",
+        "",
+    ]
+    for code, reason, description in EXIT_CODE_TABLE:
+        lines.append("\b")
+        lines.append(f"  {code}  {reason}")
+        for chunk in _wrap(description, 66):
+            lines.append(f"      {chunk}")
+        lines.append("")
+    lines.extend(
+        [
+            "\b",
+            "STDOUT is machine-readable: the first whitespace-delimited token is",
+            "one of the reasons above. Human detail goes to stderr.",
+            "",
+            "\b",
+            "DURABILITY: at-most-once, except on an explicit opt-in. A token is",
+            "never injected a second time unless --resend-interrupted is passed",
+            "on the injecting call itself. If a previous attempt DIED without an",
+            "answer the next call reports 'send-interrupted' (exit 5) instead of",
+            "guessing; pass --resend-interrupted to accept a possible duplicate.",
+            "If a previous attempt is still RUNNING nothing is unknown and the",
+            "call reports 'send-in-progress' (exit 8) — retry to read the answer.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _wrap(text: str, width: int) -> list[str]:
+    words = text.split()
+    out: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if len(candidate) > width and current:
+            out.append(current)
+            current = word
+        else:
+            current = candidate
+    if current:
+        out.append(current)
+    return out
+
+
+def _fail(ctx: click.Context, code: int, reason: str, detail: str) -> None:
+    click.echo(reason)
+    if detail:
+        click.echo(detail, err=True)
+    ctx.exit(code)
+
+
+def _report_in_progress(ctx: click.Context, record: JournalRecord) -> None:
+    """Report that a LIVE process owns this token. Deliberately not exit 5.
+
+    Nothing was injected by this call and nothing is unknown — the outcome is
+    simply not decided yet, by a process that is demonstrably running. Saying
+    "a previous attempt died, delivery is UNKNOWN" here would be false, and a
+    client that surfaces it as "we don't know — resend?" would offer the user a
+    duplicate for a send that is about to succeed.
+    """
+    owner = record.owner or {}
+    click.echo(REASON_SEND_IN_PROGRESS)
+    click.echo(
+        f"another send for this token is still running (pid {owner.get('pid')}); "
+        "this call injected nothing and that call owns the outcome. Retry "
+        "shortly to read it.",
+        err=True,
+    )
+    ctx.exit(EXIT_SEND_IN_PROGRESS)
+
+
+def _report_lost_claim(ctx: click.Context, record_path: Path, token: str) -> None:
+    """Report the outcome of losing the exclusive claim to a racing sibling.
+
+    Losing the claim is a PROVABLE state: this call had not touched tmux, so it
+    injected nothing. The only question is what the winner did, so the winner's
+    record is consulted rather than assumed — it may already have delivered, it
+    may still be running, or (only if it died) the outcome is genuinely
+    unknown.
+    """
+    try:
+        record, owner_alive = classify_unresolved(record_path, token)
+    except JournalError as exc:
+        _fail(ctx, EXIT_JOURNAL_FAILED, REASON_JOURNAL_FAILED, str(exc))
+        return
+    if record.state == STATE_DELIVERED:
+        click.echo(f"{REASON_ALREADY_DELIVERED} {_iso(record.timestamp)}")
+        ctx.exit(EXIT_OK)
+    if owner_alive:
+        _report_in_progress(ctx, record)
+        return
+    click.echo(REASON_SEND_INTERRUPTED)
+    click.echo(
+        f"another send claimed token {token!r} and is no longer running; this "
+        "call injected nothing and that call's outcome is unknown. Re-run with "
+        "--resend-interrupted to accept a possible duplicate.",
+        err=True,
+    )
+    ctx.exit(EXIT_SEND_INTERRUPTED)
+
+
+@click.command(
+    "send",
+    context_settings={"help_option_names": ["-h", "--help"]},
+    epilog=_epilog(),
+)
+@click.option("--pane", "pane", default=None, help="Target tmux pane id, e.g. %3.")
+@click.option(
+    "--token",
+    "token",
+    default=None,
+    help=(
+        "Opaque, caller-supplied delivery id (the client's durable row id). "
+        "Re-running with the same token never injects twice."
+    ),
+)
+@click.option("--enter", is_flag=True, help="Press Enter in the pane after the payload lands.")
+@click.option(
+    "--timeout",
+    "timeout",
+    type=float,
+    default=10.0,
+    show_default=True,
+    help="Total seconds budgeted for all tmux calls in this invocation.",
+)
+@click.option(
+    "--resend-interrupted",
+    is_flag=True,
+    help=(
+        "Opt in to at-least-once for THIS token: deliver again even though a "
+        "previous attempt's outcome is unknown, accepting a possible duplicate."
+    ),
+)
+@click.option(
+    "--prune-older-than",
+    "prune_older_than",
+    default=None,
+    metavar="DURATION",
+    help=(
+        "Housekeeping mode: delete journal records older than DURATION "
+        "(30d / 12h / 90m / 3600s) and exit. Mutually exclusive with --pane / "
+        "--token. Records are also auto-pruned at the "
+        f"{DEFAULT_RETENTION_SECS // 86400}d default retention on delivery."
+    ),
+)
+@click.option(
+    "--socket-name",
+    "socket_name",
+    default=None,
+    help="tmux -L socket name. Omit to use the host's default tmux server.",
+)
+@click.pass_context
+def send_command(
+    ctx: click.Context,
+    pane: Optional[str],
+    token: Optional[str],
+    enter: bool,
+    timeout: float,
+    resend_interrupted: bool,
+    prune_older_than: Optional[str],
+    socket_name: Optional[str],
+) -> None:
+    """Deliver a payload from stdin into a tmux pane, exactly once per token.
+
+    The exit status IS the acknowledgement: 0 means the tmux server accepted
+    the payload for that exact pane (or had already accepted it for this
+    token), and every other code says precisely what went wrong. There is no
+    screen scraping, no timing window, and no unprovable outcome.
+
+    \b
+    Deliver:  pocketshell send --pane %3 --token <row-id> --enter < payload
+    Prune:    pocketshell send --prune-older-than 30d
+    """
+    paths = resolve_paths()
+
+    # ---- housekeeping mode ------------------------------------------------
+    if prune_older_than is not None:
+        if pane is not None or token is not None:
+            _fail(
+                ctx,
+                EXIT_BAD_USAGE,
+                REASON_BAD_USAGE,
+                "--prune-older-than cannot be combined with --pane/--token",
+            )
+        try:
+            retention = parse_duration(prune_older_than)
+        except ValueError as exc:
+            _fail(ctx, EXIT_BAD_USAGE, REASON_BAD_USAGE, str(exc))
+            return
+        try:
+            removed = prune(paths, older_than_secs=retention)
+        except OSError as exc:
+            _fail(ctx, EXIT_JOURNAL_FAILED, REASON_JOURNAL_FAILED, str(exc))
+            return
+        click.echo(f"{REASON_PRUNED} {removed}")
+        ctx.exit(EXIT_OK)
+
+    # ---- argument validation ---------------------------------------------
+    if not pane:
+        _fail(ctx, EXIT_BAD_USAGE, REASON_BAD_USAGE, "--pane is required")
+        return
+    if token is None or not token.strip():
+        _fail(ctx, EXIT_BAD_USAGE, REASON_BAD_USAGE, "--token is required and must not be blank")
+        return
+    if len(token) > MAX_TOKEN_LENGTH:
+        _fail(
+            ctx,
+            EXIT_BAD_USAGE,
+            REASON_BAD_USAGE,
+            f"--token exceeds {MAX_TOKEN_LENGTH} characters",
+        )
+        return
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in token):
+        _fail(ctx, EXIT_BAD_USAGE, REASON_BAD_USAGE, "--token must not contain control characters")
+        return
+    if timeout <= 0:
+        _fail(ctx, EXIT_BAD_USAGE, REASON_BAD_USAGE, "--timeout must be positive")
+        return
+
+    record_path = paths.record_file(token)
+
+    # ---- read the payload BEFORE any branch that can exit ------------------
+    # The caller is piping the payload into us. Exiting without reading it —
+    # which the `already-delivered` / `send-interrupted` short-circuits used to
+    # do — leaves the writer's next write on a closed pipe, i.e. SIGPIPE (shell
+    # status 141): a successful acknowledgement surfacing to the caller as a
+    # failed write (issue #2122, review finding F3). Those are the RETRY paths,
+    # the ones a client exercises most.
+    #
+    # Argument validation deliberately stays ABOVE this read: a caller with an
+    # open-but-idle stdin (an ssh exec channel it has not closed) must get its
+    # `bad-usage` immediately rather than blocking forever on a payload that is
+    # never coming. Hanging is strictly worse than a writer signal, and this
+    # command must never hang.
+    payload = _read_stdin_bytes()
+
+    # ---- consult the durable journal --------------------------------------
+    try:
+        record, owner_alive = classify_unresolved(record_path, token)
+    except JournalError as exc:
+        _fail(ctx, EXIT_JOURNAL_FAILED, REASON_JOURNAL_FAILED, str(exc))
+        return
+
+    if record.state == STATE_DELIVERED:
+        stamp = record.delivered_at if record.delivered_at is not None else record.created_at
+        click.echo(f"{REASON_ALREADY_DELIVERED} {_iso(stamp)}")
+        ctx.exit(EXIT_OK)
+
+    if owner_alive:
+        # PROVABLE, not unknown: another send for this token is still running.
+        # This call injected nothing and the outcome belongs to that process,
+        # so reporting the dead-attempt code here would manufacture an unknown
+        # out of a healthy race — the #2121 defect reproduced one layer down.
+        # --resend-interrupted does not override it either: the opt-in exists to
+        # resolve an unknown, and forcing a resend alongside a live sibling is
+        # simply a duplicate.
+        _report_in_progress(ctx, record)
+        return
+
+    if record.state in (STATE_PENDING, STATE_CORRUPT) and not resend_interrupted:
+        reason = (
+            REASON_SEND_INTERRUPTED if record.state == STATE_PENDING else REASON_JOURNAL_CORRUPT
+        )
+        click.echo(reason)
+        click.echo(
+            "a previous attempt for this token left an unresolved record "
+            f"({record_path}) and its process is gone; delivery is unknown. "
+            "Nothing was injected. Re-run with --resend-interrupted to accept "
+            "a possible duplicate.",
+            err=True,
+        )
+        ctx.exit(EXIT_SEND_INTERRUPTED)
+
+    # ---- payload shape -----------------------------------------------------
+    if not payload and not enter:
+        _fail(
+            ctx,
+            EXIT_BAD_USAGE,
+            REASON_BAD_USAGE,
+            "empty payload with no --enter would inject nothing",
+        )
+        return
+
+    runner = TmuxRunner(socket_name=socket_name, deadline=time.monotonic() + timeout)
+
+    # ---- pane check: nothing is journaled or injected if this fails -------
+    try:
+        lookup = lookup_pane(runner, pane)
+    except TmuxTimeout as exc:
+        _fail(ctx, EXIT_TIMEOUT, REASON_TIMEOUT, str(exc))
+        return
+    except TmuxUnavailable as exc:
+        _fail(ctx, EXIT_TMUX_FAILED, REASON_TMUX_FAILED, str(exc))
+        return
+    except TmuxCommandFailed as exc:
+        _fail(ctx, EXIT_TMUX_FAILED, REASON_TMUX_FAILED, str(exc))
+        return
+    if not lookup.found:
+        _fail(ctx, EXIT_PANE_NOT_FOUND, REASON_PANE_NOT_FOUND, lookup.detail)
+        return
+    if lookup.dead:
+        _fail(ctx, EXIT_PANE_NOT_FOUND, REASON_PANE_NOT_FOUND, f"pane is dead: {pane}")
+        return
+
+    buffer_name = buffer_name_for(token)
+
+    # ---- fill the paste buffer: still touches no pane ---------------------
+    if payload:
+        try:
+            filled = runner.run(["load-buffer", "-b", buffer_name, "-"], input_bytes=payload)
+        except TmuxTimeout as exc:
+            _fail(ctx, EXIT_TIMEOUT, REASON_TIMEOUT, str(exc))
+            return
+        except TmuxUnavailable as exc:
+            _fail(ctx, EXIT_TMUX_FAILED, REASON_TMUX_FAILED, str(exc))
+            return
+        if filled.returncode != 0:
+            _fail(
+                ctx,
+                EXIT_TMUX_FAILED,
+                REASON_TMUX_FAILED,
+                _decode(filled.stderr) or "tmux load-buffer failed",
+            )
+            return
+
+    # ---- the ambiguity boundary ------------------------------------------
+    # Everything above is a clean no-op if this process dies. From here on a
+    # death is genuinely ambiguous, so the pending record goes down FIRST,
+    # fsync'd, immediately before the one command that can put bytes in the
+    # pane. It is rolled back only on a DEFINITIVE tmux failure (we have a
+    # return code, so we know nothing reached the pane) — never on a guess.
+    created_at = time.time()
+    pending_document = _record_document(
+        token=token,
+        pane=pane,
+        state=STATE_PENDING,
+        created_at=created_at,
+        delivered_at=None,
+        payload_bytes=len(payload),
+        enter=enter,
+        # Stamped so a later call can tell "this attempt DIED" (unknown) from
+        # "this attempt is still running" (owned, not unknown).
+        owner=owner_identity(),
+    )
+    # The document this call is about to overwrite, or None when the token had
+    # no record and this call is creating one. It is what a rollback restores;
+    # see roll_back_claim.
+    prior_bytes: Optional[bytes] = None
+    try:
+        if record.state == STATE_ABSENT:
+            # Nobody has claimed this token yet, so the claim must be exclusive:
+            # a CONCURRENT send with the same token would otherwise also have
+            # read "absent" and injected a second copy.
+            if not claim_record_exclusive(record_path, pending_document):
+                _report_lost_claim(ctx, record_path, token)
+                return
+        else:
+            # --resend-interrupted over an existing pending/corrupt record.
+            # Capture the prior document FIRST: this call is overwriting an
+            # unresolved state it did not create, and a rollback has to put it
+            # back rather than erase it (#2122 F1). If it cannot be read, fail
+            # closed without touching anything — an unrestorable overwrite is
+            # exactly how the unknown gets lost.
+            try:
+                prior_bytes = record_path.read_bytes()
+            except OSError as exc:
+                _fail(
+                    ctx,
+                    EXIT_JOURNAL_FAILED,
+                    REASON_JOURNAL_FAILED,
+                    f"cannot read {record_path} before overwriting it: {exc}",
+                )
+                return
+            write_record_atomic(record_path, pending_document)
+    except OSError as exc:
+        _fail(ctx, EXIT_JOURNAL_FAILED, REASON_JOURNAL_FAILED, f"cannot write {record_path}: {exc}")
+        return
+
+    def _rollback() -> None:
+        roll_back_claim(record_path, prior_bytes)
+
+    if payload:
+        try:
+            pasted = runner.run(
+                ["paste-buffer", "-d", "-r", "-b", buffer_name, "-t", pane],
+            )
+        except TmuxTimeout as exc:
+            # No answer => genuinely ambiguous. Keep the pending record so the
+            # next call reports 'send-interrupted' instead of re-pasting.
+            _fail(ctx, EXIT_TIMEOUT, REASON_TIMEOUT, str(exc))
+            return
+        except TmuxUnavailable as exc:
+            _rollback()
+            _fail(ctx, EXIT_TMUX_FAILED, REASON_TMUX_FAILED, str(exc))
+            return
+        if pasted.returncode != 0:
+            # Definitive failure: tmux rejected the paste, so the pane is
+            # untouched and the token must stay cleanly retryable.
+            _rollback()
+            runner_delete_buffer(runner, buffer_name)
+            _fail(
+                ctx,
+                EXIT_TMUX_FAILED,
+                REASON_TMUX_FAILED,
+                _decode(pasted.stderr) or "tmux paste-buffer failed",
+            )
+            return
+
+    if enter:
+        try:
+            submitted = runner.run(["send-keys", "-t", pane, "Enter"])
+        except TmuxTimeout as exc:
+            _fail(ctx, EXIT_TIMEOUT, REASON_TIMEOUT, str(exc))
+            return
+        except TmuxUnavailable as exc:
+            _fail(ctx, EXIT_TMUX_FAILED, REASON_TMUX_FAILED, str(exc))
+            return
+        if submitted.returncode != 0:
+            # The payload IS in the pane but was not submitted. Rolling back
+            # here would let a retry paste it a second time, so this stays the
+            # unknown state and the caller must decide.
+            click.echo(REASON_SEND_INTERRUPTED)
+            click.echo(
+                _decode(submitted.stderr)
+                or f"payload landed in {pane} but Enter was rejected; delivery is partial",
+                err=True,
+            )
+            ctx.exit(EXIT_SEND_INTERRUPTED)
+
+    delivered_at = time.time()
+    try:
+        write_record_atomic(
+            record_path,
+            _record_document(
+                token=token,
+                pane=pane,
+                state=STATE_DELIVERED,
+                created_at=created_at,
+                delivered_at=delivered_at,
+                payload_bytes=len(payload),
+                enter=enter,
+            ),
+        )
+    except OSError as exc:
+        # The payload landed. We could not record it, so a retry cannot be
+        # proven safe — report the unknown state rather than a clean failure
+        # the client would retry into a duplicate.
+        click.echo(REASON_SEND_INTERRUPTED)
+        click.echo(f"delivered but could not journal {record_path}: {exc}", err=True)
+        ctx.exit(EXIT_SEND_INTERRUPTED)
+
+    maybe_auto_prune(paths, now=delivered_at)
+    click.echo(f"{REASON_DELIVERED} {_iso(delivered_at)}")
+    ctx.exit(EXIT_OK)
+
+
+def runner_delete_buffer(runner: TmuxRunner, buffer_name: str) -> None:
+    """Best-effort cleanup of a paste buffer a failed commit left behind."""
+    try:
+        runner.run(["delete-buffer", "-b", buffer_name])
+    except (TmuxTimeout, TmuxUnavailable):
+        pass
+
+
+def _read_stdin_bytes() -> bytes:
+    """Read the whole payload from stdin as raw bytes.
+
+    ``sys.stdin.buffer`` — never ``sys.stdin`` — so newlines, trailing
+    whitespace and non-ASCII survive untouched. Absent under some test
+    harnesses, hence the guard.
+
+    A TERMINAL is never a payload: there is nothing piped and no EOF until a
+    human types one, so reading would hang. Returning empty routes an
+    interactive invocation to the documented ``bad-usage`` exit instead.
+    """
+    stream = getattr(sys, "stdin", None)
+    if stream is None:
+        return b""
+    try:
+        if stream.isatty():
+            return b""
+    except (AttributeError, ValueError, OSError):
+        pass
+    buffer = getattr(sys.stdin, "buffer", None)
+    if buffer is None:
+        data = sys.stdin.read()
+        return data.encode("utf-8") if isinstance(data, str) else bytes(data)
+    return buffer.read()

--- a/tools/pocketshell/tests/test_send.py
+++ b/tools/pocketshell/tests/test_send.py
@@ -1,0 +1,2092 @@
+"""Tests for `pocketshell send` — the acknowledged delivery primitive (#2122).
+
+These run against a REAL tmux server, never the maintainer's. Every tmux call
+here is scoped by BOTH an isolated ``TMUX_TMPDIR`` (so the socket file lives
+under the test's own ``tmp_path``) and an explicit ``-L`` socket name. ``TMUX``
+is scrubbed from the child environment so an enclosing session can never be
+targeted. Teardown kills only the sessions this file created, BY NAME:
+``tmux kill-server`` appears nowhere, in no fixture and no trap — it has wiped
+the maintainer's live sessions twice (AGENTS.md, locked).
+
+Payload fidelity is asserted against the BYTES that reach the pane's process,
+not against a ``capture-pane`` screen render (which loses trailing whitespace
+and wraps long lines). The fixture pane runs ``stty raw -echo; cat > out.bin``,
+so what lands in ``out.bin`` is exactly what tmux wrote to the pty.
+
+The load-bearing assertion throughout is on the PANE CONTENT, not on the exit
+code. An exit-code-only check would stay green with a double-injection bug
+present, which is the wrong-cost shape (G6) this repo's process doc catalogues.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+import pytest
+from click.testing import CliRunner
+
+from pocketshell import send as send_mod
+from pocketshell.cli import cli
+
+# A generous wall-clock budget for "the bytes reached the pane". Local tmux
+# answers in milliseconds; the budget only has to survive a contended box, and
+# it HARD-FAILS rather than skipping.
+CAPTURE_DEADLINE_SECS = 60.0
+
+# How long a hypothetical SECOND injection would have to stay invisible for the
+# idempotency assertion to be fooled. tmux delivers locally in milliseconds, so
+# a quiet window of this length is decisive.
+QUIET_WINDOW_SECS = 1.5
+
+
+def _require_tmux() -> str:
+    """Absolute path to tmux, HARD-failing when it is absent.
+
+    Deliberately not `pytest.skip`: a skip here would make the CI job green
+    while asserting nothing at all about the primitive's core behaviour (G3).
+    The workflow installs tmux for exactly this reason.
+    """
+    binary = shutil.which("tmux")
+    if binary is None:
+        raise AssertionError(
+            "tmux is required by the pocketshell send tests and was not found on PATH. "
+            "Install it (apt-get install -y tmux); do NOT skip these tests."
+        )
+    return binary
+
+
+# --------------------------------------------------------------------------
+# Real-tmux fixture
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class TmuxFixture:
+    """One isolated tmux server plus a pane that records raw stdin bytes."""
+
+    socket_name: str
+    session: str
+    pane_id: str
+    capture_file: Path
+    env: dict
+    state_dir: Path
+    real_tmux: str
+
+    def tmux(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [self.real_tmux, "-L", self.socket_name, *args],
+            env=self.env,
+            capture_output=True,
+            check=False,
+        )
+
+    def captured(self) -> bytes:
+        try:
+            return self.capture_file.read_bytes()
+        except FileNotFoundError:
+            return b""
+
+    def wait_for_capture(self, expected: int, *, deadline: float = CAPTURE_DEADLINE_SECS) -> bytes:
+        stop = time.monotonic() + deadline
+        while time.monotonic() < stop:
+            data = self.captured()
+            if len(data) >= expected:
+                return data
+            time.sleep(0.05)
+        raise AssertionError(
+            f"pane capture never reached {expected} bytes within {deadline}s "
+            f"(got {len(self.captured())})"
+        )
+
+    def settle(self, *, quiet: float = QUIET_WINDOW_SECS) -> bytes:
+        """Return the capture once it has stopped growing for ``quiet`` seconds.
+
+        This is what makes "exactly one occurrence" decisive: a second
+        injection would have to land inside this window to be missed, and a
+        local tmux paste lands in milliseconds.
+        """
+        last = self.captured()
+        stable_since = time.monotonic()
+        while time.monotonic() - stable_since < quiet:
+            time.sleep(0.05)
+            current = self.captured()
+            if current != last:
+                last = current
+                stable_since = time.monotonic()
+        return last
+
+    def send(
+        self,
+        *args: str,
+        payload: bytes = b"",
+        path_prefix: Optional[Path] = None,
+        timeout: float = 120.0,
+    ) -> subprocess.CompletedProcess:
+        """Run the REAL `pocketshell send` CLI as its own process."""
+        env = dict(self.env)
+        if path_prefix is not None:
+            env["PATH"] = f"{path_prefix}{os.pathsep}{env['PATH']}"
+        return subprocess.run(
+            [sys.executable, "-m", "pocketshell", "send", "--socket-name", self.socket_name, *args],
+            input=payload,
+            env=env,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+
+    def records(self) -> list[Path]:
+        sends = self.state_dir / "pocketshell" / "sends"
+        if not sends.is_dir():
+            return []
+        return sorted(sends.glob("*.json"))
+
+    def record_for(self, token: str) -> Path:
+        paths = send_mod.resolve_paths(env={"XDG_STATE_HOME": str(self.state_dir)})
+        return paths.record_file(token)
+
+
+@pytest.fixture
+def tmux_fixture(tmp_path: Path):
+    real_tmux = _require_tmux()
+
+    # A unix socket path is capped near 108 bytes, and pytest's `tmp_path` is
+    # already long, so TMUX_TMPDIR gets its own SHORT directory. It is still a
+    # private directory, so the isolation guarantee is unchanged: the socket
+    # can never be /tmp/tmux-$UID/default.
+    tmux_tmpdir = Path(tempfile.mkdtemp(prefix="pssnd-"))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    unique = uuid.uuid4().hex[:8]
+    socket_name = f"pssnd-{unique}"
+    session = f"ps-send-{unique}"
+    capture_file = tmp_path / "pane-stdin.bin"
+    ready_file = tmp_path / "pane-ready"
+
+    env = dict(os.environ)
+    env.pop("TMUX", None)  # never inherit an enclosing session
+    env["TMUX_TMPDIR"] = str(tmux_tmpdir)
+    env["XDG_STATE_HOME"] = str(state_dir)
+
+    # `stty raw -echo` first, so the tty line discipline performs no LF/CR
+    # translation and imposes no canonical-mode line-length cap; then a marker
+    # file so the test never pastes into a still-cooked terminal; then a plain
+    # byte pump into a file.
+    pane_command = f"stty raw -echo; : > {ready_file}; cat > {capture_file}"
+    created = subprocess.run(
+        [
+            real_tmux, "-L", socket_name,
+            "new-session", "-d", "-s", session, "-x", "200", "-y", "50",
+            "-P", "-F", "#{pane_id}",
+            "sh", "-c", pane_command,
+        ],
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    assert created.returncode == 0, created.stderr.decode("utf-8", "replace")
+    pane_id = created.stdout.decode().strip()
+    assert pane_id.startswith("%"), f"unexpected pane id {pane_id!r}"
+
+    # The socket must live under the test's own tmp dir, never /tmp/tmux-$UID.
+    socket_path = tmux_tmpdir / f"tmux-{os.getuid()}" / socket_name
+    deadline = time.monotonic() + 20.0
+    while time.monotonic() < deadline and not ready_file.exists():
+        time.sleep(0.05)
+    assert ready_file.exists(), "capture pane never reached raw mode"
+    assert socket_path.exists(), f"tmux socket not isolated under {tmux_tmpdir}"
+
+    fixture = TmuxFixture(
+        socket_name=socket_name,
+        session=session,
+        pane_id=pane_id,
+        capture_file=capture_file,
+        env=env,
+        state_dir=state_dir,
+        real_tmux=real_tmux,
+    )
+    try:
+        yield fixture
+    finally:
+        # Kill ONLY the sessions this fixture created, by name. The server exits
+        # by itself once its last session is gone. Never `kill-server`.
+        listed = subprocess.run(
+            [real_tmux, "-L", socket_name, "list-sessions", "-F", "#{session_name}"],
+            env=env,
+            capture_output=True,
+            check=False,
+        )
+        for name in listed.stdout.decode("utf-8", "replace").split():
+            if name.startswith("ps-send-"):
+                subprocess.run(
+                    [real_tmux, "-L", socket_name, "kill-session", "-t", name],
+                    env=env,
+                    capture_output=True,
+                    check=False,
+                )
+        shutil.rmtree(tmux_tmpdir, ignore_errors=True)
+
+
+def _shim_dir(tmp_path: Path, real_tmux: str, body: str, name: str) -> Path:
+    """A PATH-shadowing `tmux` wrapper that forwards to the real binary.
+
+    Used to inject a *real* failure (or a real SIGKILL of the real
+    `pocketshell send` process) at a precise point in the injection sequence.
+    The real tmux path is baked in, so the shim can never recurse into itself.
+    """
+    directory = tmp_path / f"shim-{name}"
+    directory.mkdir(parents=True, exist_ok=True)
+    script = directory / "tmux"
+    script.write_text(
+        "#!/bin/sh\n"
+        f"REAL={real_tmux}\n"
+        f"{body}\n"
+        'exec "$REAL" "$@"\n',
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return directory
+
+
+def _match_first_arg(command: str, action: str) -> str:
+    """Shim body: run ``action`` when ``command`` appears in the argv."""
+    return (
+        'for a in "$@"; do\n'
+        f'  if [ "$a" = "{command}" ]; then\n'
+        f"{action}\n"
+        "  fi\n"
+        "done"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC: delivers a payload to a real tmux pane and exits 0 with `delivered`
+# --------------------------------------------------------------------------
+
+
+def test_send_delivers_payload_to_a_real_pane(tmux_fixture: TmuxFixture) -> None:
+    payload = b"echo hello from pocketshell send\n"
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", "row-deliver-1", payload=payload
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    assert result.stdout.decode().split()[0] == "delivered"
+
+    landed = tmux_fixture.wait_for_capture(len(payload))
+    assert landed == payload, "the pane must receive the payload byte-exact"
+
+    record = json.loads(tmux_fixture.record_for("row-deliver-1").read_text(encoding="utf-8"))
+    assert record["state"] == "delivered"
+    assert record["pane"] == tmux_fixture.pane_id
+    assert record["token"] == "row-deliver-1"
+    assert record["delivered_at"] > 0
+
+
+def test_send_with_enter_presses_enter_after_the_payload(tmux_fixture: TmuxFixture) -> None:
+    payload = b"pwd"
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", "row-enter-1", "--enter", payload=payload
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+
+    landed = tmux_fixture.wait_for_capture(len(payload) + 1)
+    assert landed[: len(payload)] == payload
+    assert landed[len(payload) :] in (b"\r", b"\n"), (
+        "--enter must put a submit byte in the pane after the payload; "
+        f"got {landed[len(payload):]!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC: same token twice => EXACTLY ONE occurrence in the pane, exit 0
+#     `already-delivered`. Asserted on pane CONTENT, not the exit code.
+# --------------------------------------------------------------------------
+
+
+def test_same_token_twice_injects_exactly_once(tmux_fixture: TmuxFixture) -> None:
+    marker = b"MARKER-2122-IDEMPOTENT"
+    payload = b"first line\n" + marker + b"\n"
+    token = "row-idempotent-1"
+
+    first = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert first.returncode == 0, first.stderr.decode("utf-8", "replace")
+    assert first.stdout.decode().split()[0] == "delivered"
+    tmux_fixture.wait_for_capture(len(payload))
+
+    second = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert second.returncode == 0, second.stderr.decode("utf-8", "replace")
+    assert second.stdout.decode().split()[0] == "already-delivered"
+
+    landed = tmux_fixture.settle()
+    assert landed.count(marker) == 1, (
+        "re-running with the same token must produce EXACTLY ONE occurrence in "
+        f"the pane; found {landed.count(marker)}"
+    )
+    assert landed == payload, "the pane must hold the payload once and nothing else"
+
+
+def test_third_and_fourth_replay_still_leave_exactly_one_occurrence(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """A client retry loop is unbounded; idempotency must not be once-only."""
+    marker = b"MARKER-2122-REPLAY"
+    payload = marker + b"\n"
+    token = "row-replay-1"
+
+    for attempt in range(4):
+        result = tmux_fixture.send(
+            "--pane", tmux_fixture.pane_id, "--token", token, payload=payload
+        )
+        assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+        expected = "delivered" if attempt == 0 else "already-delivered"
+        assert result.stdout.decode().split()[0] == expected
+
+    landed = tmux_fixture.settle()
+    assert landed.count(marker) == 1
+    assert landed == payload
+
+
+def test_a_different_token_with_the_same_payload_delivers_again(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """Idempotency is keyed on the TOKEN, not on the payload bytes."""
+    marker = b"MARKER-2122-DISTINCT"
+    payload = marker + b"\n"
+
+    for token in ("row-distinct-a", "row-distinct-b"):
+        result = tmux_fixture.send(
+            "--pane", tmux_fixture.pane_id, "--token", token, payload=payload
+        )
+        assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+        assert result.stdout.decode().split()[0] == "delivered"
+
+    landed = tmux_fixture.wait_for_capture(len(payload) * 2)
+    assert landed.count(marker) == 2
+    assert landed == payload * 2
+
+
+# --------------------------------------------------------------------------
+# AC: a killed process between injection and journal write does not
+#     double-inject on the next call. Real SIGKILL of the real CLI process at
+#     the real boundary, via a PATH shim that kills its parent.
+# --------------------------------------------------------------------------
+
+
+def test_kill_after_injection_before_journal_never_double_injects(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The chosen invariant: AT-MOST-ONCE, with the ambiguity reported.
+
+    The shim lets the real `paste-buffer` run (so the payload genuinely lands)
+    and then SIGKILLs the `pocketshell send` process before it can promote the
+    journal record to `delivered`. The next call with that token must NOT
+    inject again — the pane keeps exactly one occurrence — and must say so with
+    the documented `send-interrupted` exit code rather than inventing either
+    "delivered" or "not delivered".
+    """
+    marker = b"MARKER-2122-KILLED-AFTER"
+    payload = marker + b"\n"
+    token = "row-killed-after"
+
+    shim = _shim_dir(
+        tmp_path,
+        tmux_fixture.real_tmux,
+        _match_first_arg(
+            "paste-buffer",
+            '    "$REAL" "$@"; rc=$?\n'
+            '    kill -9 "$PPID"\n'
+            "    exit $rc",
+        ),
+        "kill-after-paste",
+    )
+
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=payload, path_prefix=shim
+    )
+    assert killed.returncode == -9, (
+        "the fixture must actually SIGKILL the send process at the ambiguity "
+        f"boundary; got rc={killed.returncode}"
+    )
+
+    landed = tmux_fixture.wait_for_capture(len(payload))
+    assert landed.count(marker) == 1, "the killed run must genuinely have injected once"
+
+    record = json.loads(tmux_fixture.record_for(token).read_text(encoding="utf-8"))
+    assert record["state"] == "pending", "the kill must leave the unresolved pending record"
+
+    retry = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert retry.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert retry.stdout.decode().split()[0] == "send-interrupted"
+
+    settled = tmux_fixture.settle()
+    assert settled.count(marker) == 1, (
+        "a retry after an interrupted send must NOT double-inject; found "
+        f"{settled.count(marker)} occurrences"
+    )
+    assert settled == payload
+
+
+def test_kill_before_injection_leaves_the_pane_untouched_and_is_recoverable(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The other half of the kill window: pending written, nothing injected.
+
+    The default answer is still "unknown, not retried" — that is what
+    at-most-once costs — and `--resend-interrupted` is the escape hatch that
+    keeps the state from being absorbing (the #2121 defect).
+    """
+    marker = b"MARKER-2122-KILLED-BEFORE"
+    payload = marker + b"\n"
+    token = "row-killed-before"
+
+    shim = _shim_dir(
+        tmp_path,
+        tmux_fixture.real_tmux,
+        _match_first_arg("paste-buffer", '    kill -9 "$PPID"\n    exit 1'),
+        "kill-before-paste",
+    )
+
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=payload, path_prefix=shim
+    )
+    assert killed.returncode == -9
+
+    record = json.loads(tmux_fixture.record_for(token).read_text(encoding="utf-8"))
+    assert record["state"] == "pending"
+    assert tmux_fixture.settle(quiet=0.5) == b"", "nothing may have reached the pane"
+
+    blocked = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert blocked.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert blocked.stdout.decode().split()[0] == "send-interrupted"
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+    recovered = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted", payload=payload
+    )
+    assert recovered.returncode == 0, recovered.stderr.decode("utf-8", "replace")
+    assert recovered.stdout.decode().split()[0] == "delivered"
+
+    landed = tmux_fixture.wait_for_capture(len(payload))
+    assert landed.count(marker) == 1
+    assert landed == payload
+
+    replay = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert replay.returncode == 0
+    assert replay.stdout.decode().split()[0] == "already-delivered"
+    assert tmux_fixture.settle().count(marker) == 1
+
+
+def test_resend_interrupted_is_the_documented_opt_in_duplicate(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """`--resend-interrupted` after a real injection CAN duplicate — on purpose.
+
+    This is the documented cost of the escape hatch, pinned so the tradeoff is
+    a decision rather than a surprise: the caller asked for at-least-once.
+    """
+    marker = b"MARKER-2122-OPTIN-DUP"
+    payload = marker + b"\n"
+    token = "row-optin-dup"
+
+    shim = _shim_dir(
+        tmp_path,
+        tmux_fixture.real_tmux,
+        _match_first_arg(
+            "paste-buffer",
+            '    "$REAL" "$@"; rc=$?\n    kill -9 "$PPID"\n    exit $rc',
+        ),
+        "kill-after-paste-dup",
+    )
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=payload, path_prefix=shim
+    )
+    assert killed.returncode == -9
+    tmux_fixture.wait_for_capture(len(payload))
+
+    forced = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted", payload=payload
+    )
+    assert forced.returncode == 0, forced.stderr.decode("utf-8", "replace")
+    assert forced.stdout.decode().split()[0] == "delivered"
+
+    landed = tmux_fixture.wait_for_capture(len(payload) * 2)
+    assert landed.count(marker) == 2, "the opt-in resend delivers a second time by design"
+
+    # And the token is resolved again, so the loop terminates.
+    after = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert after.returncode == 0
+    assert after.stdout.decode().split()[0] == "already-delivered"
+    assert tmux_fixture.settle().count(marker) == 2
+
+
+def test_claim_record_exclusive_admits_exactly_one_writer(tmp_path: Path) -> None:
+    """The mutual exclusion the concurrency guarantee rests on."""
+    target = tmp_path / "sends" / "claim.json"
+    document = {"schema": 1, "token": "t", "state": "pending", "created_at": 1.0}
+
+    assert send_mod.claim_record_exclusive(target, document) is True
+    assert send_mod.claim_record_exclusive(target, document) is False, (
+        "a second claim on the same token must lose"
+    )
+    assert json.loads(target.read_text(encoding="utf-8"))["token"] == "t"
+    assert oct(target.stat().st_mode & 0o777) == "0o600"
+
+
+def test_concurrent_sends_with_the_same_token_inject_exactly_once(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """Exactly-once must survive a RACING caller, not just a sequential retry.
+
+    Five `pocketshell send` processes are launched simultaneously with one
+    token. Exactly one may report `delivered`, and — the load-bearing check —
+    the pane must hold exactly one copy of the payload.
+    """
+    marker = b"MARKER-2122-CONCURRENT"
+    payload = marker + b"\n"
+    token = "row-concurrent"
+
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable, "-m", "pocketshell", "send",
+                "--socket-name", tmux_fixture.socket_name,
+                "--pane", tmux_fixture.pane_id, "--token", token,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=tmux_fixture.env,
+        )
+        for _ in range(5)
+    ]
+    outcomes = []
+    for process in processes:
+        stdout, _stderr = process.communicate(input=payload, timeout=120)
+        outcomes.append((process.returncode, stdout.decode().split()[0] if stdout else ""))
+
+    # The PANE is checked first and is the load-bearing assertion: an
+    # exit-code-only check would still pass with a double-injection bug.
+    landed = tmux_fixture.settle()
+    assert landed.count(marker) == 1, (
+        f"concurrent sends with one token must inject exactly once; found "
+        f"{landed.count(marker)} occurrences (outcomes: {outcomes})"
+    )
+    assert landed == payload
+
+    delivered = [outcome for outcome in outcomes if outcome[1] == "delivered"]
+    assert len(delivered) == 1, f"exactly one racer may deliver; got {outcomes}"
+
+    # Safety is not enough: the losers must also be told the TRUTH (#2122 F2).
+    # A racer that lost the exclusive claim provably injected nothing, and the
+    # winner is a healthy live sibling, so "a previous attempt died without an
+    # answer, delivery is UNKNOWN" (exit 5) is a manufactured unknown — exactly
+    # the absorbing state epic #2121 exists to delete. The honest answers are
+    # "a live sibling owns this" or "it is already delivered".
+    reasons = [reason for _code, reason in outcomes]
+    assert "send-interrupted" not in reasons, (
+        "a racer that lost to a LIVE sibling injected nothing and must not be "
+        f"told its delivery is unknown; got {outcomes}"
+    )
+    for code, reason in outcomes:
+        assert reason in {"delivered", "already-delivered", "send-in-progress"}, outcomes
+        assert code in {0, send_mod.EXIT_SEND_IN_PROGRESS}, outcomes
+
+
+# --------------------------------------------------------------------------
+# AC: pane-not-found and tmux-failure exit non-zero with the documented reason
+#     and do NOT journal the token.
+# --------------------------------------------------------------------------
+
+
+def test_pane_not_found_exits_three_and_journals_nothing(tmux_fixture: TmuxFixture) -> None:
+    token = "row-nopane"
+    result = tmux_fixture.send("--pane", "%9999", "--token", token, payload=b"never lands\n")
+    assert result.returncode == send_mod.EXIT_PANE_NOT_FOUND
+    assert result.stdout.decode().split()[0] == "pane-not-found"
+    assert not tmux_fixture.record_for(token).exists(), "a pane that does not exist must not journal"
+    assert tmux_fixture.records() == []
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+    # ...and the token is still cleanly retryable afterwards.
+    retry = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=b"lands now\n"
+    )
+    assert retry.returncode == 0
+    assert retry.stdout.decode().split()[0] == "delivered"
+
+
+def test_dead_pane_exits_three_and_journals_nothing(tmux_fixture: TmuxFixture) -> None:
+    assert tmux_fixture.tmux("set-option", "-w", "-g", "remain-on-exit", "on").returncode == 0
+    created = tmux_fixture.tmux(
+        "new-window", "-d", "-P", "-F", "#{pane_id}", "-t", tmux_fixture.session,
+        "sh", "-c", "exit 0",
+    )
+    assert created.returncode == 0, created.stderr.decode("utf-8", "replace")
+    dead_pane = created.stdout.decode().strip()
+
+    deadline = time.monotonic() + 20.0
+    while time.monotonic() < deadline:
+        listing = tmux_fixture.tmux("list-panes", "-a", "-F", "#{pane_id} #{pane_dead}")
+        if f"{dead_pane} 1" in listing.stdout.decode():
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError(f"pane {dead_pane} never became dead")
+
+    token = "row-deadpane"
+    result = tmux_fixture.send("--pane", dead_pane, "--token", token, payload=b"nope\n")
+    assert result.returncode == send_mod.EXIT_PANE_NOT_FOUND
+    assert result.stdout.decode().split()[0] == "pane-not-found"
+    assert not tmux_fixture.record_for(token).exists()
+
+
+def test_no_tmux_server_exits_four_and_journals_nothing(tmp_path: Path) -> None:
+    _require_tmux()
+    tmux_tmpdir = Path(tempfile.mkdtemp(prefix="pssnd-"))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    env = dict(os.environ)
+    env.pop("TMUX", None)
+    env["TMUX_TMPDIR"] = str(tmux_tmpdir)
+    env["XDG_STATE_HOME"] = str(state_dir)
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "pocketshell", "send",
+                "--socket-name", f"pssnd-absent-{uuid.uuid4().hex[:8]}",
+                "--pane", "%0", "--token", "row-noserver",
+            ],
+            input=b"nothing\n",
+            env=env,
+            capture_output=True,
+            check=False,
+            timeout=120.0,
+        )
+    finally:
+        shutil.rmtree(tmux_tmpdir, ignore_errors=True)
+    assert result.returncode == send_mod.EXIT_TMUX_FAILED
+    assert result.stdout.decode().split()[0] == "tmux-failed"
+    assert list((state_dir / "pocketshell" / "sends").glob("*.json")) == []
+
+
+def test_load_buffer_failure_exits_four_and_journals_nothing(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    shim = _shim_dir(
+        tmux_fixture.capture_file.parent,
+        tmux_fixture.real_tmux,
+        _match_first_arg(
+            "load-buffer", '    echo "simulated load-buffer failure" >&2\n    exit 1'
+        ),
+        "fail-load-buffer",
+    )
+    token = "row-loadfail"
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=b"x\n", path_prefix=shim
+    )
+    assert result.returncode == send_mod.EXIT_TMUX_FAILED
+    assert result.stdout.decode().split()[0] == "tmux-failed"
+    assert not tmux_fixture.record_for(token).exists()
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+
+def test_paste_buffer_definitive_failure_rolls_the_pending_record_back(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """A tmux answer of "no" means nothing reached the pane => stay retryable.
+
+    This is what separates a definitive failure from the ambiguous kill: the
+    pending record is written before the paste and MUST be rolled back here, or
+    a transient tmux error would poison the token forever.
+    """
+    shim = _shim_dir(
+        tmux_fixture.capture_file.parent,
+        tmux_fixture.real_tmux,
+        _match_first_arg(
+            "paste-buffer", '    echo "simulated paste-buffer failure" >&2\n    exit 1'
+        ),
+        "fail-paste-buffer",
+    )
+    token = "row-pastefail"
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=b"x\n", path_prefix=shim
+    )
+    assert result.returncode == send_mod.EXIT_TMUX_FAILED
+    assert result.stdout.decode().split()[0] == "tmux-failed"
+    assert not tmux_fixture.record_for(token).exists(), (
+        "a definitive paste failure must roll the pending record back so the "
+        "token stays cleanly retryable"
+    )
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+    retry = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=b"x\n")
+    assert retry.returncode == 0
+    assert retry.stdout.decode().split()[0] == "delivered"
+    assert tmux_fixture.wait_for_capture(2) == b"x\n"
+
+
+def test_enter_failure_after_a_landed_payload_reports_the_unknown_state(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """The payload landed but was not submitted: partial, therefore unknown.
+
+    Rolling back here would let a retry paste the payload a SECOND time, so the
+    record deliberately stays pending and the caller is told.
+    """
+    shim = _shim_dir(
+        tmux_fixture.capture_file.parent,
+        tmux_fixture.real_tmux,
+        _match_first_arg("send-keys", '    echo "simulated send-keys failure" >&2\n    exit 1'),
+        "fail-send-keys",
+    )
+    token = "row-enterfail"
+    payload = b"MARKER-2122-ENTERFAIL\n"
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--enter",
+        payload=payload, path_prefix=shim,
+    )
+    assert result.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert result.stdout.decode().split()[0] == "send-interrupted"
+
+    landed = tmux_fixture.wait_for_capture(len(payload))
+    assert landed == payload
+    record = json.loads(tmux_fixture.record_for(token).read_text(encoding="utf-8"))
+    assert record["state"] == "pending"
+
+    retry = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert retry.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert tmux_fixture.settle().count(b"MARKER-2122-ENTERFAIL") == 1
+
+
+def test_timeout_exits_six_without_journaling(tmux_fixture: TmuxFixture) -> None:
+    shim = _shim_dir(
+        tmux_fixture.capture_file.parent,
+        tmux_fixture.real_tmux,
+        _match_first_arg("list-panes", "    sleep 30\n    exit 0"),
+        "slow-list-panes",
+    )
+    token = "row-timeout"
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--timeout", "1",
+        payload=b"x\n", path_prefix=shim,
+    )
+    assert result.returncode == send_mod.EXIT_TIMEOUT
+    assert result.stdout.decode().split()[0] == "timeout"
+    assert not tmux_fixture.record_for(token).exists()
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+
+# --------------------------------------------------------------------------
+# AC: payload fidelity — multi-line, trailing whitespace, unicode, >64 KB
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("multiline", b"first line\nsecond line\n\nfourth after a blank\n"),
+        ("trailing-whitespace", b"body with trailing spaces   \nand a trailing tab\t"),
+        ("crlf-and-lone-cr", b"windows\r\nline\rand more\n"),
+        ("unicode", "ünïcødé — «кавычки» — 🚀🙂\nвторая строка\n".encode("utf-8")),
+        ("control-bytes", b"esc\x1b[31mred\x1b[0m and bell\x07 and tab\t\n"),
+        ("large-64k-plus", b"A" * 70000 + b"\nTAIL-MARKER\n"),
+        ("no-trailing-newline", b"exactly this and nothing more"),
+        ("single-byte", b"x"),
+    ],
+)
+def test_payload_arrives_byte_exact(
+    tmux_fixture: TmuxFixture, label: str, payload: bytes
+) -> None:
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", f"row-fidelity-{label}", payload=payload
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+
+    landed = tmux_fixture.wait_for_capture(len(payload))
+    assert landed == payload, (
+        f"payload class {label!r} was mangled in transit: "
+        f"expected {len(payload)} bytes, got {len(landed)}"
+    )
+
+
+def test_large_payload_is_not_truncated_or_reordered(tmux_fixture: TmuxFixture) -> None:
+    """A >64 KB payload with position-encoded content, so a reorder is visible."""
+    chunks = [f"[{index:05d}]".encode() for index in range(12000)]
+    payload = b"".join(chunks) + b"\n"
+    assert len(payload) > 64 * 1024
+
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", "row-large-ordered", payload=payload
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+
+    landed = tmux_fixture.wait_for_capture(len(payload))
+    assert landed == payload
+
+
+# --------------------------------------------------------------------------
+# AC: journal writes are atomic; a truncated/corrupt entry does not crash
+# --------------------------------------------------------------------------
+
+
+def test_write_record_atomic_is_private_and_leaves_no_temp(tmp_path: Path) -> None:
+    target = tmp_path / "sends" / "record.json"
+    send_mod.write_record_atomic(target, {"schema": 1, "token": "t", "state": "delivered"})
+    assert json.loads(target.read_text(encoding="utf-8"))["token"] == "t"
+    assert oct(target.stat().st_mode & 0o777) == "0o600"
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+def test_write_record_atomic_never_publishes_a_partial_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the rename fails, readers must see nothing rather than a partial."""
+    target = tmp_path / "sends" / "record.json"
+    target.parent.mkdir(parents=True)
+
+    def _boom(src, dst):
+        raise OSError("simulated rename failure")
+
+    monkeypatch.setattr(send_mod.os, "replace", _boom)
+    with pytest.raises(OSError):
+        send_mod.write_record_atomic(target, {"schema": 1, "token": "t", "state": "pending"})
+
+    assert not target.exists(), "a failed write must not publish the record"
+    assert list(target.parent.glob("*.tmp")) == [], "a failed write must not leave temp litter"
+
+
+def test_write_record_atomic_replaces_an_existing_record_in_place(tmp_path: Path) -> None:
+    target = tmp_path / "sends" / "record.json"
+    send_mod.write_record_atomic(target, {"schema": 1, "token": "t", "state": "pending"})
+    send_mod.write_record_atomic(
+        target, {"schema": 1, "token": "t", "state": "delivered", "delivered_at": 5.0}
+    )
+    document = json.loads(target.read_text(encoding="utf-8"))
+    assert document["state"] == "delivered"
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+@pytest.mark.parametrize(
+    ("label", "content"),
+    [
+        ("truncated-json", b'{"schema": 1, "token": "tok", "sta'),
+        ("empty", b""),
+        ("not-json", b"\x00\x01\x02 not json at all"),
+        ("json-but-a-list", b"[1, 2, 3]"),
+        ("missing-state", b'{"schema": 1, "token": "tok", "created_at": 1.0}'),
+        ("unknown-state", b'{"schema":1,"token":"tok","state":"weird","created_at":1.0}'),
+        ("wrong-token", b'{"schema":1,"token":"other","state":"delivered",'
+                        b'"created_at":1.0,"delivered_at":2.0}'),
+        ("delivered-without-timestamp", b'{"schema":1,"token":"tok","state":"delivered",'
+                                        b'"created_at":1.0}'),
+        ("invalid-utf8", b"\xff\xfe\xfd"),
+    ],
+)
+def test_read_record_reports_corrupt_instead_of_raising(
+    tmp_path: Path, label: str, content: bytes
+) -> None:
+    target = tmp_path / "record.json"
+    target.write_bytes(content)
+    record = send_mod.read_record(target, "tok")
+    assert record.state == send_mod.STATE_CORRUPT, label
+
+
+def test_read_record_reports_absent_for_a_missing_file(tmp_path: Path) -> None:
+    assert send_mod.read_record(tmp_path / "nope.json", "tok").state == send_mod.STATE_ABSENT
+
+
+def test_a_corrupt_record_does_not_crash_the_next_call(tmux_fixture: TmuxFixture) -> None:
+    """A truncated record must yield a clean documented exit, never a traceback."""
+    token = "row-corrupt"
+    record_path = tmux_fixture.record_for(token)
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_bytes(b'{"schema": 1, "token": "row-corr')
+
+    payload = b"MARKER-2122-CORRUPT\n"
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=payload
+    )
+    assert result.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert result.stdout.decode().split()[0] == "journal-corrupt"
+    assert "Traceback" not in result.stderr.decode("utf-8", "replace")
+    assert tmux_fixture.settle(quiet=0.5) == b"", "a corrupt record must not trigger an injection"
+
+    recovered = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted", payload=payload
+    )
+    assert recovered.returncode == 0
+    assert recovered.stdout.decode().split()[0] == "delivered"
+    landed = tmux_fixture.wait_for_capture(len(payload))
+    assert landed.count(b"MARKER-2122-CORRUPT") == 1
+
+
+# --------------------------------------------------------------------------
+# AC: retention / pruning works and is documented
+# --------------------------------------------------------------------------
+
+
+def _seed_record(paths: send_mod.SendPaths, token: str, *, age_secs: float, now: float) -> Path:
+    path = paths.record_file(token)
+    send_mod.write_record_atomic(
+        path,
+        {
+            "schema": 1,
+            "token": token,
+            "pane": "%0",
+            "state": "delivered",
+            "created_at": now - age_secs,
+            "delivered_at": now - age_secs,
+            "payload_bytes": 3,
+            "enter": True,
+        },
+    )
+    return path
+
+
+def test_prune_removes_only_records_older_than_the_cutoff(tmp_path: Path) -> None:
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    now = time.time()
+    old = _seed_record(paths, "old", age_secs=10 * 86400, now=now)
+    edge = _seed_record(paths, "edge", age_secs=2 * 86400, now=now)
+    fresh = _seed_record(paths, "fresh", age_secs=60, now=now)
+
+    removed = send_mod.prune(paths, older_than_secs=send_mod.parse_duration("1d"), now=now)
+    assert removed == 2
+    assert not old.exists()
+    assert not edge.exists()
+    assert fresh.exists()
+
+
+def test_prune_ages_a_corrupt_record_by_its_mtime(tmp_path: Path) -> None:
+    """A corrupt record must be prunable, not immortal."""
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    paths.sends_dir.mkdir(parents=True)
+    corrupt = paths.sends_dir / "deadbeef.json"
+    corrupt.write_bytes(b"not json")
+    now = time.time()
+    os.utime(corrupt, (now - 10 * 86400, now - 10 * 86400))
+
+    assert send_mod.prune(paths, older_than_secs=86400, now=now) == 1
+    assert not corrupt.exists()
+
+
+def test_prune_cli_reports_the_count_and_exits_zero(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    paths = send_mod.resolve_paths(env={"XDG_STATE_HOME": str(state_dir)})
+    now = time.time()
+    _seed_record(paths, "old-a", age_secs=40 * 86400, now=now)
+    _seed_record(paths, "old-b", age_secs=40 * 86400, now=now)
+    _seed_record(paths, "keep", age_secs=60, now=now)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["send", "--prune-older-than", "30d"], env={"XDG_STATE_HOME": str(state_dir)}
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "pruned 2"
+    assert len(list(paths.sends_dir.glob("*.json"))) == 1
+
+
+def test_default_retention_is_thirty_days() -> None:
+    assert send_mod.DEFAULT_RETENTION_SECS == 30 * 24 * 60 * 60
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("30d", 30 * 86400),
+        ("12h", 12 * 3600),
+        ("90m", 5400),
+        ("45s", 45),
+        ("3600", 3600),
+        ("1w", 604800),
+        (" 2d ", 2 * 86400),
+        ("1.5h", 5400),
+    ],
+)
+def test_parse_duration_accepts_the_documented_forms(text: str, expected: float) -> None:
+    assert send_mod.parse_duration(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "abc", "10x", "-5d", "d", "1 2d"])
+def test_parse_duration_rejects_garbage(text: str) -> None:
+    with pytest.raises(ValueError):
+        send_mod.parse_duration(text)
+
+
+def test_auto_prune_keeps_the_journal_bounded_without_an_explicit_call(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """Delivery itself prunes at the default retention, so the dir cannot grow
+    without bound even if `--prune-older-than` is never invoked."""
+    paths = send_mod.resolve_paths(env={"XDG_STATE_HOME": str(tmux_fixture.state_dir)})
+    now = time.time()
+    ancient = _seed_record(paths, "ancient-token", age_secs=100 * 86400, now=now)
+    recent = _seed_record(paths, "recent-token", age_secs=3600, now=now)
+    assert ancient.exists()
+
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", "row-autoprune", payload=b"y\n"
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+
+    assert not ancient.exists(), "delivery must auto-prune records past the default retention"
+    assert recent.exists(), "delivery must not prune records inside the retention window"
+    assert paths.prune_marker.exists()
+
+
+def test_auto_prune_is_throttled_by_its_marker(tmp_path: Path) -> None:
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    now = time.time()
+    ancient = _seed_record(paths, "ancient", age_secs=100 * 86400, now=now)
+    paths.prune_marker.write_text("", encoding="utf-8")
+    os.utime(paths.prune_marker, (now - 60, now - 60))
+
+    assert send_mod.maybe_auto_prune(paths, now=now) is False
+    assert ancient.exists(), "a fresh marker must suppress the walk"
+
+    os.utime(
+        paths.prune_marker,
+        (now - send_mod.AUTO_PRUNE_INTERVAL_SECS - 1, now - send_mod.AUTO_PRUNE_INTERVAL_SECS - 1),
+    )
+    assert send_mod.maybe_auto_prune(paths, now=now) is True
+    assert not ancient.exists()
+
+
+def test_auto_prune_never_raises_on_a_broken_journal_dir(tmp_path: Path) -> None:
+    """Housekeeping must never turn a successful delivery into a failure."""
+    blocked = tmp_path / "not-a-dir"
+    blocked.write_text("i am a file", encoding="utf-8")
+    paths = send_mod.SendPaths(sends_dir=blocked / "sends")
+    assert send_mod.maybe_auto_prune(paths) is False
+
+
+# --------------------------------------------------------------------------
+# AC: `--help` documents every exit code
+# --------------------------------------------------------------------------
+
+
+def test_help_documents_every_exit_code_and_reason() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["send", "--help"])
+    assert result.exit_code == 0
+    help_text = result.output
+
+    for code, reasons, _description in send_mod.EXIT_CODE_TABLE:
+        assert f"  {code}  " in help_text, f"exit code {code} is not documented in --help"
+        for reason in (part.strip() for part in reasons.split("|")):
+            assert reason in help_text, f"reason {reason!r} is not documented in --help"
+
+
+def test_help_documents_the_durability_invariant_and_the_escape_hatch() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["send", "--help"])
+    assert "at-most-once" in result.output
+    assert "--resend-interrupted" in result.output
+    assert "--prune-older-than" in result.output
+
+
+def test_every_reason_constant_appears_in_the_documented_table() -> None:
+    """No exit path may print a reason the table does not document."""
+    documented = {
+        part.strip()
+        for _code, reasons, _description in send_mod.EXIT_CODE_TABLE
+        for part in reasons.split("|")
+    }
+    for name, value in vars(send_mod).items():
+        if name.startswith("REASON_"):
+            assert value in documented, f"{name} = {value!r} is missing from EXIT_CODE_TABLE"
+
+
+def test_send_is_registered_on_the_top_level_cli() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "send" in result.output
+
+
+# --------------------------------------------------------------------------
+# Usage errors
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "args"),
+    [
+        ("no-pane", ["--token", "t"]),
+        ("no-token", ["--pane", "%0"]),
+        ("blank-token", ["--pane", "%0", "--token", "   "]),
+        ("control-char-token", ["--pane", "%0", "--token", "a\nb"]),
+        ("oversized-token", ["--pane", "%0", "--token", "z" * 513]),
+        ("prune-with-pane", ["--pane", "%0", "--prune-older-than", "1d"]),
+        ("prune-with-token", ["--token", "t", "--prune-older-than", "1d"]),
+        ("bad-duration", ["--prune-older-than", "banana"]),
+        ("non-positive-timeout", ["--pane", "%0", "--token", "t", "--timeout", "0"]),
+    ],
+)
+def test_bad_usage_exits_two_with_the_documented_reason(
+    tmux_fixture: TmuxFixture, label: str, args: Sequence[str]
+) -> None:
+    result = tmux_fixture.send(*args, payload=b"x\n")
+    assert result.returncode == send_mod.EXIT_BAD_USAGE, label
+    assert result.stdout.decode().split()[0] == "bad-usage", label
+    assert tmux_fixture.records() == [], label
+
+
+def test_empty_payload_without_enter_is_rejected(tmux_fixture: TmuxFixture) -> None:
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", "row-empty", payload=b""
+    )
+    assert result.returncode == send_mod.EXIT_BAD_USAGE
+    assert result.stdout.decode().split()[0] == "bad-usage"
+    assert tmux_fixture.records() == []
+
+
+def test_empty_payload_with_enter_submits_a_bare_enter(tmux_fixture: TmuxFixture) -> None:
+    result = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", "row-bare-enter", "--enter", payload=b""
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    landed = tmux_fixture.wait_for_capture(1)
+    assert landed in (b"\r", b"\n")
+
+
+# --------------------------------------------------------------------------
+# Path resolution + token hashing
+# --------------------------------------------------------------------------
+
+
+def test_resolve_paths_prefers_xdg_state(tmp_path: Path) -> None:
+    paths = send_mod.resolve_paths(env={"XDG_STATE_HOME": str(tmp_path / "xdg")})
+    assert paths.sends_dir == tmp_path / "xdg" / "pocketshell" / "sends"
+
+
+def test_resolve_paths_falls_back_to_local_state(tmp_path: Path) -> None:
+    paths = send_mod.resolve_paths(home=tmp_path, env={})
+    assert paths.sends_dir == tmp_path / ".local" / "state" / "pocketshell" / "sends"
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["../../etc/passwd", "a/b/c", "token with spaces", "🚀-emoji", "tok:with:colons", "."],
+)
+def test_a_hostile_token_never_escapes_the_journal_directory(tmp_path: Path, token: str) -> None:
+    """The token is opaque, so it is HASHED into a filename, never used as one."""
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    record = paths.record_file(token)
+    assert record.parent == paths.sends_dir
+    assert record.name.endswith(".json")
+    assert "/" not in record.name and ".." not in record.name
+
+
+def test_distinct_tokens_get_distinct_records(tmp_path: Path) -> None:
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    assert paths.record_file("a") != paths.record_file("b")
+    assert paths.record_file("a") == paths.record_file("a")
+
+
+def test_buffer_name_is_alphanumeric_and_per_token() -> None:
+    name = send_mod.buffer_name_for("row-1;drop")
+    assert name.isalnum(), "tmux treats a trailing ';' as a command separator (#1845)"
+    assert send_mod.buffer_name_for("row-1;drop") == name
+    assert send_mod.buffer_name_for("other") != name
+
+
+# ==========================================================================
+# Round-2 review findings (#2122). Each test below reproduces a defect the
+# reviewer drove end to end against a real tmux server, and each was RED on
+# the round-1 implementation before the fix.
+# ==========================================================================
+
+# --------------------------------------------------------------------------
+# F1 — a definitive tmux failure must not ERASE a pre-existing "delivery
+#      unknown" memory. Rolling back a claim this call created is correct;
+#      deleting somebody else's unresolved record lets the very next PLAIN
+#      call inject a second copy with no opt-in, which falsifies the headline
+#      at-most-once claim.
+# --------------------------------------------------------------------------
+
+
+def _kill_after_paste_shim(tmux_fixture: TmuxFixture, tmp_path: Path, name: str) -> Path:
+    """A shim that lets the real paste run and then SIGKILLs `pocketshell send`."""
+    return _shim_dir(
+        tmp_path,
+        tmux_fixture.real_tmux,
+        _match_first_arg(
+            "paste-buffer",
+            '    "$REAL" "$@"; rc=$?\n    kill -9 "$PPID"\n    exit $rc',
+        ),
+        name,
+    )
+
+
+def _failing_paste_shim(tmux_fixture: TmuxFixture, tmp_path: Path, name: str) -> Path:
+    return _shim_dir(
+        tmp_path,
+        tmux_fixture.real_tmux,
+        _match_first_arg("paste-buffer", '    echo "simulated paste failure" >&2\n    exit 1'),
+        name,
+    )
+
+
+def test_a_definitive_failure_after_resend_interrupted_restores_the_prior_unknown(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """#2122 F1: the reviewer's exact four-step journey, end to end.
+
+    kill-after-paste (payload landed, record `pending`) -> plain retry says
+    `send-interrupted` -> the user opts in with `--resend-interrupted` and tmux
+    fails definitively -> a LATER PLAIN call must still refuse. On the round-1
+    code the rollback unlinked the record it had overwritten, the token read
+    `absent` again, and step four delivered a SECOND copy with no opt-in.
+    """
+    marker = b"MARKER-2122-F1-PENDING"
+    payload = marker + b"\n"
+    token = "row-f1-pending"
+    record_path = tmux_fixture.record_for(token)
+
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token,
+        payload=payload,
+        path_prefix=_kill_after_paste_shim(tmux_fixture, tmp_path, "f1-kill-after"),
+    )
+    assert killed.returncode == -9
+    tmux_fixture.wait_for_capture(len(payload))
+    assert json.loads(record_path.read_text(encoding="utf-8"))["state"] == "pending"
+
+    forced = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted",
+        payload=payload,
+        path_prefix=_failing_paste_shim(tmux_fixture, tmp_path, "f1-fail-paste"),
+    )
+    assert forced.returncode == send_mod.EXIT_TMUX_FAILED
+    assert forced.stdout.decode().split()[0] == "tmux-failed"
+    assert record_path.exists(), (
+        "a definitive failure on an opt-in resend must RESTORE the unresolved "
+        "record it overwrote, not erase the fact that delivery is unknown"
+    )
+    assert json.loads(record_path.read_text(encoding="utf-8"))["state"] == "pending"
+
+    plain = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert plain.stdout.decode().split()[0] == "send-interrupted", (
+        "the next PLAIN call must still refuse; if it delivers, the token has "
+        "been injected twice with no --resend-interrupted opt-in"
+    )
+    assert plain.returncode == send_mod.EXIT_SEND_INTERRUPTED
+
+    settled = tmux_fixture.settle()
+    assert settled.count(marker) == 1, (
+        f"at-most-once violated: the pane holds {settled.count(marker)} copies"
+    )
+
+
+def test_a_definitive_failure_after_resend_interrupted_restores_a_prior_corrupt_record(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The same class, other state: a CORRUPT record is unresolved too.
+
+    "We cannot read what happened for this token" is an unknown exactly like a
+    pending record, so erasing it is the same falsification.
+    """
+    marker = b"MARKER-2122-F1-CORRUPT"
+    payload = marker + b"\n"
+    token = "row-f1-corrupt"
+    record_path = tmux_fixture.record_for(token)
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    planted = b'{"schema": 1, "token": "row-f1-cor'
+    record_path.write_bytes(planted)
+
+    forced = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted",
+        payload=payload,
+        path_prefix=_failing_paste_shim(tmux_fixture, tmp_path, "f1-fail-paste-corrupt"),
+    )
+    assert forced.returncode == send_mod.EXIT_TMUX_FAILED
+    assert record_path.exists(), "the corrupt (= unresolved) record must survive the rollback"
+    assert record_path.read_bytes() == planted, (
+        "the prior document must be restored byte-for-byte, so the next call "
+        "sees exactly the state it would have seen without this attempt"
+    )
+
+    plain = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert plain.stdout.decode().split()[0] == "journal-corrupt"
+    assert plain.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert tmux_fixture.settle(quiet=0.5).count(marker) == 0
+
+
+def test_a_load_buffer_failure_after_resend_interrupted_leaves_the_prior_unknown(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The other definitive-failure site: it happens BEFORE the claim is taken.
+
+    Nothing has been overwritten yet, so the prior unresolved record must be
+    untouched — same user-visible outcome, different mechanism.
+    """
+    marker = b"MARKER-2122-F1-LOADFAIL"
+    payload = marker + b"\n"
+    token = "row-f1-loadfail"
+    record_path = tmux_fixture.record_for(token)
+
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token,
+        payload=payload,
+        path_prefix=_kill_after_paste_shim(tmux_fixture, tmp_path, "f1-kill-after-load"),
+    )
+    assert killed.returncode == -9
+    tmux_fixture.wait_for_capture(len(payload))
+    before = record_path.read_bytes()
+
+    shim = _shim_dir(
+        tmp_path,
+        tmux_fixture.real_tmux,
+        _match_first_arg("load-buffer", '    echo "simulated load failure" >&2\n    exit 1'),
+        "f1-fail-load",
+    )
+    forced = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted",
+        payload=payload, path_prefix=shim,
+    )
+    assert forced.returncode == send_mod.EXIT_TMUX_FAILED
+    assert record_path.read_bytes() == before, "the prior unknown must be untouched"
+
+    plain = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert plain.stdout.decode().split()[0] == "send-interrupted"
+    assert tmux_fixture.settle().count(marker) == 1
+
+
+def test_roll_back_claim_removes_a_record_this_call_created(tmp_path: Path) -> None:
+    """The mechanism, directly: no prior document => the claim is ours to drop."""
+    target = tmp_path / "sends" / "record.json"
+    send_mod.write_record_atomic(target, {"schema": 1, "token": "t", "state": "pending"})
+    send_mod.roll_back_claim(target, None)
+    assert not target.exists()
+
+
+def test_roll_back_claim_restores_the_prior_document_byte_for_byte(tmp_path: Path) -> None:
+    """The mechanism, directly: a prior document is restored, never deleted.
+
+    Both rollback call sites (a definitive `paste-buffer` failure and a tmux
+    binary that vanished mid-run) go through this one function, so this pins
+    the branch the end-to-end tests cannot reach.
+    """
+    target = tmp_path / "sends" / "record.json"
+    prior = b'{"schema": 1, "state": "pending", "token": "t", "created_at": 1.0}'
+    target.parent.mkdir(parents=True)
+    target.write_bytes(prior)
+    send_mod.write_record_atomic(target, {"schema": 1, "token": "t", "state": "pending"})
+    assert target.read_bytes() != prior
+
+    send_mod.roll_back_claim(target, prior)
+    assert target.read_bytes() == prior
+    assert list(target.parent.glob("*.tmp")) == []
+
+
+def test_at_most_once_survives_interleaved_kills_failures_and_retries(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The whole invariant, in one messy journey rather than one happy step.
+
+    Every kill window and both retry kinds, interleaved: kill-before-paste,
+    plain retry, opt-in resend that fails definitively, plain retry, opt-in
+    resend that succeeds, plain replay. The load-bearing assertion is the copy
+    count after each stage, and the rule under test is that a copy only ever
+    appears on a call that passed --resend-interrupted (or the first delivery).
+    """
+    marker = b"MARKER-2122-INTERLEAVED"
+    payload = marker + b"\n"
+    token = "row-interleaved"
+
+    kill_before = _shim_dir(
+        tmp_path,
+        tmux_fixture.real_tmux,
+        _match_first_arg("paste-buffer", '    kill -9 "$PPID"\n    exit 1'),
+        "mix-kill-before",
+    )
+    stage1 = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=payload, path_prefix=kill_before
+    )
+    assert stage1.returncode == -9
+    assert tmux_fixture.settle(quiet=0.5).count(marker) == 0
+
+    stage2 = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert stage2.stdout.decode().split()[0] == "send-interrupted"
+    assert tmux_fixture.settle(quiet=0.5).count(marker) == 0
+
+    stage3 = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted",
+        payload=payload,
+        path_prefix=_failing_paste_shim(tmux_fixture, tmp_path, "mix-fail-paste"),
+    )
+    assert stage3.returncode == send_mod.EXIT_TMUX_FAILED
+    assert tmux_fixture.settle(quiet=0.5).count(marker) == 0
+
+    stage4 = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert stage4.stdout.decode().split()[0] == "send-interrupted", (
+        "the failed opt-in resend must not have erased the unknown"
+    )
+    assert tmux_fixture.settle(quiet=0.5).count(marker) == 0
+
+    stage5 = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted", payload=payload
+    )
+    assert stage5.returncode == 0
+    assert stage5.stdout.decode().split()[0] == "delivered"
+    assert tmux_fixture.wait_for_capture(len(payload)).count(marker) == 1
+
+    stage6 = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert stage6.stdout.decode().split()[0] == "already-delivered"
+    assert tmux_fixture.settle().count(marker) == 1
+
+    # And the OTHER kill window on a fresh token, in the same pane: the payload
+    # really landed, so the plain retry must refuse and the count must hold.
+    second_token = "row-interleaved-after"
+    # Deliberately NOT a superstring of `marker`: bytes.count would then
+    # match the first marker inside the second and mask a real duplicate.
+    second_marker = b"MARKER-2122-SECOND-WINDOW"
+    second_payload = second_marker + b"\n"
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", second_token,
+        payload=second_payload,
+        path_prefix=_kill_after_paste_shim(tmux_fixture, tmp_path, "mix-kill-after"),
+    )
+    assert killed.returncode == -9
+    tmux_fixture.wait_for_capture(len(payload) + len(second_payload))
+    retry = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", second_token, payload=second_payload
+    )
+    assert retry.stdout.decode().split()[0] == "send-interrupted"
+
+    final = tmux_fixture.settle()
+    assert final.count(marker) == 1
+    assert final.count(second_marker) == 1
+
+
+# --------------------------------------------------------------------------
+# F2 — a LIVE sibling is not an unknown. Exit 5 documents "a previous attempt
+#      DIED without an answer"; reporting it while a healthy sibling is
+#      mid-flight recreates the spurious-unknown class #2121 exists to delete.
+# --------------------------------------------------------------------------
+
+
+def _start_slow_owner(
+    tmux_fixture: TmuxFixture, token: str, payload: bytes, env: dict
+) -> subprocess.Popen:
+    """Launch a `pocketshell send` that will sit inside `paste-buffer`.
+
+    The payload is written and stdin closed immediately so the child can make
+    progress while the test probes it — but `Popen.stdin` is then dropped,
+    because `communicate()` on Python 3.11 (the version CI runs) flushes
+    `self.stdin` unconditionally and raises `ValueError: flush of closed file`
+    on an already-closed pipe. Python 3.12+ tolerates it, so this only shows up
+    on the runner.
+    """
+    owner = subprocess.Popen(
+        [
+            sys.executable, "-m", "pocketshell", "send",
+            "--socket-name", tmux_fixture.socket_name,
+            "--pane", tmux_fixture.pane_id, "--token", token, "--timeout", "60",
+        ],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+    )
+    owner.stdin.write(payload)
+    owner.stdin.close()
+    owner.stdin = None
+    return owner
+
+
+def _reap(owner: subprocess.Popen) -> None:
+    """Never let cleanup raise over the real failure it is cleaning up after."""
+    if owner.poll() is None:
+        owner.kill()
+    try:
+        owner.wait(timeout=30)
+    except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+        pass
+    for stream in (owner.stdout, owner.stderr):
+        if stream is not None:
+            stream.close()
+
+
+def _await_owner_claim(tmux_fixture: TmuxFixture, token: str, owner: subprocess.Popen) -> None:
+    """Block until the owner has claimed the token and is inside the paste.
+
+    The record file only becomes visible once it is COMPLETE (the claim links a
+    fully written temp file into place), so its presence is a sound signal.
+    """
+    record_path = tmux_fixture.record_for(token)
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline and not record_path.exists():
+        time.sleep(0.02)
+    assert record_path.exists(), "the owner never claimed the token"
+    assert owner.poll() is None, "the owner must still be running for this test to mean anything"
+
+
+def test_a_send_that_loses_to_a_live_sibling_is_not_reported_as_unknown(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """#2122 F2: the reviewer's in-flight probe, end to end.
+
+    The first send is held inside `paste-buffer` for several seconds (a slow or
+    loaded host). A second call fired during that window provably injected
+    nothing and its outcome is owned by a process that is demonstrably ALIVE —
+    so the honest answer is `send-in-progress`, not "delivery is UNKNOWN".
+    """
+    marker = b"MARKER-2122-F2-INFLIGHT"
+    payload = marker + b"\n"
+    token = "row-f2-inflight"
+
+    slow = _shim_dir(
+        tmp_path, tmux_fixture.real_tmux,
+        _match_first_arg("paste-buffer", "    sleep 5"), "f2-slow-paste",
+    )
+    owner_env = dict(tmux_fixture.env)
+    owner_env["PATH"] = f"{slow}{os.pathsep}{tmux_fixture.env['PATH']}"
+    owner = _start_slow_owner(tmux_fixture, token, payload, owner_env)
+    try:
+
+        _await_owner_claim(tmux_fixture, token, owner)
+
+        loser = tmux_fixture.send(
+            "--pane", tmux_fixture.pane_id, "--token", token, payload=payload
+        )
+        assert loser.stdout.decode().split()[0] == "send-in-progress", (
+            "a call that lost to a LIVE owner injected nothing and knows it; "
+            "reporting 'send-interrupted' invents an unknown (#2122 F2)"
+        )
+        assert loser.returncode == send_mod.EXIT_SEND_IN_PROGRESS
+        stderr = loser.stderr.decode("utf-8", "replace").lower()
+        assert "unknown" not in stderr, f"the message must not claim an unknown: {stderr!r}"
+
+        stdout, _stderr = owner.communicate(timeout=120)
+    finally:
+        _reap(owner)
+    assert owner.returncode == 0, "the sibling was healthy and must have delivered"
+    assert stdout.decode().split()[0] == "delivered"
+
+    after = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert after.returncode == 0
+    assert after.stdout.decode().split()[0] == "already-delivered"
+    assert tmux_fixture.settle().count(marker) == 1
+
+
+def test_resend_interrupted_refuses_while_a_live_sibling_owns_the_token(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The opt-in resolves an UNKNOWN; a live owner is not one.
+
+    Without this, one "Resend" tap racing an automatic flush duplicates the
+    prompt into the agent — the #1602 shape, and the outcome #2121 calls worse
+    than an unacked send.
+    """
+    marker = b"MARKER-2122-F2-OPTIN"
+    payload = marker + b"\n"
+    token = "row-f2-optin"
+
+    slow = _shim_dir(
+        tmp_path, tmux_fixture.real_tmux,
+        _match_first_arg("paste-buffer", "    sleep 5"), "f2-slow-paste-optin",
+    )
+    owner_env = dict(tmux_fixture.env)
+    owner_env["PATH"] = f"{slow}{os.pathsep}{tmux_fixture.env['PATH']}"
+    owner = _start_slow_owner(tmux_fixture, token, payload, owner_env)
+    try:
+        _await_owner_claim(tmux_fixture, token, owner)
+
+        forced = tmux_fixture.send(
+            "--pane", tmux_fixture.pane_id, "--token", token, "--resend-interrupted",
+            payload=payload,
+        )
+        assert forced.stdout.decode().split()[0] == "send-in-progress"
+        assert forced.returncode == send_mod.EXIT_SEND_IN_PROGRESS
+        owner.communicate(timeout=120)
+    finally:
+        _reap(owner)
+
+    assert tmux_fixture.settle().count(marker) == 1, (
+        "an opt-in resend during a live sibling's flight must not duplicate"
+    )
+
+
+def test_a_dead_owner_is_still_reported_as_the_genuine_unknown(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The guard against over-correcting F2.
+
+    Liveness must not launder a REAL unknown into "somebody else has it": when
+    the owner is gone, exit 5 is the correct and required answer.
+    """
+    marker = b"MARKER-2122-F2-DEAD"
+    payload = marker + b"\n"
+    token = "row-f2-dead"
+
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=payload,
+        path_prefix=_kill_after_paste_shim(tmux_fixture, tmp_path, "f2-kill-after"),
+    )
+    assert killed.returncode == -9
+    tmux_fixture.wait_for_capture(len(payload))
+
+    retry = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=payload)
+    assert retry.stdout.decode().split()[0] == "send-interrupted"
+    assert retry.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert tmux_fixture.settle().count(marker) == 1
+
+
+def test_owner_is_alive_reports_true_only_for_this_running_process() -> None:
+    assert send_mod.owner_is_alive(send_mod.owner_identity()) is True
+
+
+def test_owner_is_alive_reports_false_for_a_process_that_exited() -> None:
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        owner = send_mod.owner_identity(child.pid)
+        assert send_mod.owner_is_alive(owner) is True
+    finally:
+        child.kill()
+        child.wait(timeout=30)
+    assert send_mod.owner_is_alive(owner) is False, (
+        "a reaped process must never look alive, or a real unknown would be "
+        "laundered into 'a sibling owns it'"
+    )
+
+
+def test_owner_is_alive_rejects_a_reused_pid_and_a_different_boot() -> None:
+    """pid alone is not identity: a reused pid has a different start time, and
+    a record that survived a reboot names a pid from another boot entirely."""
+    live = dict(send_mod.owner_identity())
+    assert send_mod.owner_is_alive(live) is True
+
+    reused = dict(live)
+    reused["start_ticks"] = int(live["start_ticks"]) + 1
+    assert send_mod.owner_is_alive(reused) is False
+
+    rebooted = dict(live)
+    rebooted["boot_id"] = "00000000-0000-0000-0000-000000000000"
+    assert send_mod.owner_is_alive(rebooted) is False
+
+
+@pytest.mark.parametrize(
+    ("label", "owner"),
+    [
+        ("none", None),
+        ("not-a-mapping", "pid-1234"),
+        ("empty", {}),
+        ("missing-start-ticks", {"pid": 1, "boot_id": "x"}),
+        ("missing-boot-id", {"pid": 1, "start_ticks": 1}),
+        ("pid-zero", {"pid": 0, "start_ticks": 1, "boot_id": "x"}),
+        ("pid-not-int", {"pid": "1", "start_ticks": 1, "boot_id": "x"}),
+        ("blank-boot-id", {"pid": 1, "start_ticks": 1, "boot_id": ""}),
+    ],
+)
+def test_owner_is_alive_fails_closed_on_anything_it_cannot_prove(label: str, owner) -> None:
+    """Unprovable must read as 'not alive' (=> the honest unknown), never as
+    'a sibling owns it' (which would suppress a legitimate resend forever)."""
+    assert send_mod.owner_is_alive(owner) is False, label
+
+
+def test_a_pending_record_without_owner_evidence_reports_the_unknown(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """Fail-closed end to end: no owner evidence => the conservative answer."""
+    token = "row-f2-noowner"
+    record_path = tmux_fixture.record_for(token)
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    send_mod.write_record_atomic(
+        record_path,
+        {
+            "schema": 1, "token": token, "pane": tmux_fixture.pane_id,
+            "state": "pending", "created_at": time.time(),
+            "payload_bytes": 2, "enter": False,
+        },
+    )
+    result = tmux_fixture.send("--pane", tmux_fixture.pane_id, "--token", token, payload=b"x\n")
+    assert result.stdout.decode().split()[0] == "send-interrupted"
+    assert result.returncode == send_mod.EXIT_SEND_INTERRUPTED
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+
+def test_send_in_progress_is_documented_as_a_distinct_retryable_outcome() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["send", "--help"])
+    assert result.exit_code == 0
+    assert f"  {send_mod.EXIT_SEND_IN_PROGRESS}  " in result.output
+    assert "send-in-progress" in result.output
+    assert send_mod.EXIT_SEND_IN_PROGRESS != send_mod.EXIT_SEND_INTERRUPTED
+
+
+# --------------------------------------------------------------------------
+# F3 — the retry paths must drain stdin. A caller piping a payload into a
+#      process that exits without reading takes SIGPIPE, so a successful
+#      acknowledgement reads as a failed write on the SSH channel.
+# --------------------------------------------------------------------------
+
+
+def _pipeline_statuses(
+    tmux_fixture: TmuxFixture, args: Sequence[str], *, nbytes: int
+) -> tuple[int, int, str]:
+    """Run `head -c N /dev/zero | pocketshell send ...` in a real shell.
+
+    Returns (writer_status, cli_status, cli_stdout). PIPESTATUS is read
+    explicitly rather than relying on `pipefail`, which reports only the
+    RIGHTMOST non-zero status and would therefore hide a SIGPIPE on every
+    non-zero CLI exit — the exact paths under test.
+    """
+    import shlex
+
+    command = " ".join(
+        shlex.quote(part)
+        for part in [
+            sys.executable, "-m", "pocketshell", "send",
+            "--socket-name", tmux_fixture.socket_name, *args,
+        ]
+    )
+    script = (
+        f"head -c {nbytes} /dev/zero | {command} > /tmp/psf3.$$.out 2>/dev/null\n"
+        'echo "STATUS ${PIPESTATUS[0]} ${PIPESTATUS[1]}"\n'
+        "cat /tmp/psf3.$$.out; rm -f /tmp/psf3.$$.out\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], env=tmux_fixture.env, capture_output=True, timeout=120.0
+    )
+    lines = result.stdout.decode("utf-8", "replace").splitlines()
+    status_line = next(line for line in lines if line.startswith("STATUS "))
+    _, writer, cli_status = status_line.split()
+    body = "\n".join(line for line in lines if not line.startswith("STATUS "))
+    return int(writer), int(cli_status), body.strip()
+
+
+def test_the_already_delivered_retry_does_not_sigpipe_the_writer(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """#2122 F3: the retry path is the one #2124 exercises most.
+
+    The round-1 code short-circuited on `already-delivered` BEFORE reading
+    stdin, so a writer still piping a payload got SIGPIPE (status 141) — a
+    successful acknowledgement surfacing to the caller as a write failure.
+    """
+    token = "row-f3-already"
+    first = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=b"Z" * 200000 + b"\n"
+    )
+    assert first.returncode == 0
+
+    writer, cli_status, body = _pipeline_statuses(
+        tmux_fixture, ["--pane", tmux_fixture.pane_id, "--token", token], nbytes=200001
+    )
+    assert body.split()[0] == "already-delivered"
+    assert cli_status == 0
+    assert writer == 0, (
+        f"the writer took signal {writer - 128} (SIGPIPE=13 => 141): the "
+        "already-delivered path must drain stdin before exiting"
+    )
+
+
+def test_the_send_interrupted_retry_does_not_sigpipe_the_writer(
+    tmux_fixture: TmuxFixture, tmp_path: Path
+) -> None:
+    """The same hazard on the other retry path — this one is a whole class."""
+    token = "row-f3-interrupted"
+    killed = tmux_fixture.send(
+        "--pane", tmux_fixture.pane_id, "--token", token, payload=b"Q" * 1000 + b"\n",
+        path_prefix=_kill_after_paste_shim(tmux_fixture, tmp_path, "f3-kill-after"),
+    )
+    assert killed.returncode == -9
+
+    writer, cli_status, body = _pipeline_statuses(
+        tmux_fixture, ["--pane", tmux_fixture.pane_id, "--token", token], nbytes=200001
+    )
+    assert body.split()[0] == "send-interrupted"
+    assert cli_status == send_mod.EXIT_SEND_INTERRUPTED
+    assert writer == 0, f"the writer took signal {writer - 128} on the send-interrupted path"
+
+
+def test_the_journal_corrupt_retry_does_not_sigpipe_the_writer(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    token = "row-f3-corrupt"
+    record_path = tmux_fixture.record_for(token)
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_bytes(b"{not json")
+
+    writer, cli_status, body = _pipeline_statuses(
+        tmux_fixture, ["--pane", tmux_fixture.pane_id, "--token", token], nbytes=200001
+    )
+    assert body.split()[0] == "journal-corrupt"
+    assert cli_status == send_mod.EXIT_SEND_INTERRUPTED
+    assert writer == 0, f"the writer took signal {writer - 128} on the journal-corrupt path"
+
+
+def test_bad_usage_exits_promptly_instead_of_waiting_for_a_payload(
+    tmux_fixture: TmuxFixture,
+) -> None:
+    """The deliberate limit of the F3 fix, pinned so it cannot drift.
+
+    Argument validation happens BEFORE stdin is read on purpose: a caller with
+    an open-but-idle stdin (an ssh exec channel the client has not closed)
+    must get its documented `bad-usage` immediately rather than blocking
+    forever waiting for a payload that will never arrive. Hanging is strictly
+    worse than a writer signal, and the issue is explicit that this command
+    must never hang.
+    """
+    process = subprocess.Popen(
+        [
+            sys.executable, "-m", "pocketshell", "send",
+            "--socket-name", tmux_fixture.socket_name, "--token", "row-f3-badusage",
+        ],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=tmux_fixture.env,
+    )
+    try:
+        stdout, _stderr = process.communicate(timeout=30.0)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.communicate()
+        raise AssertionError("bad usage must not block waiting for stdin")
+    assert process.returncode == send_mod.EXIT_BAD_USAGE
+    assert stdout.decode().split()[0] == "bad-usage"
+
+
+def test_an_interactive_terminal_stdin_is_not_read_as_a_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Draining stdin must never block a human at a terminal.
+
+    A tty has no piped payload and no EOF until the user types one, so the read
+    is skipped entirely; the empty payload then takes the documented
+    `bad-usage` path rather than hanging.
+    """
+
+    class _Tty:
+        def isatty(self) -> bool:
+            return True
+
+        def read(self) -> str:  # pragma: no cover - must never be called
+            raise AssertionError("stdin must not be read when it is a terminal")
+
+    monkeypatch.setattr(send_mod.sys, "stdin", _Tty())
+    assert send_mod._read_stdin_bytes() == b""
+
+
+# --------------------------------------------------------------------------
+# The at-most-once invariant depends on the journal REMEMBERING: automatic
+# housekeeping must never delete an unresolved record.
+# --------------------------------------------------------------------------
+
+
+def test_auto_prune_never_removes_an_unresolved_record(tmp_path: Path) -> None:
+    """An aged `pending`/corrupt record is still an unknown, not garbage.
+
+    Pruning one silently returns the token to `absent`, so the next plain call
+    injects again with no opt-in — the same falsification as F1, on a timer.
+    """
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    now = time.time()
+    delivered = _seed_record(paths, "old-delivered", age_secs=100 * 86400, now=now)
+    pending = paths.record_file("old-pending")
+    send_mod.write_record_atomic(
+        pending,
+        {
+            "schema": 1, "token": "old-pending", "pane": "%0", "state": "pending",
+            "created_at": now - 100 * 86400, "payload_bytes": 1, "enter": False,
+        },
+    )
+    corrupt = paths.sends_dir / "cafebabe.json"
+    corrupt.write_bytes(b"not json")
+    os.utime(corrupt, (now - 100 * 86400, now - 100 * 86400))
+
+    assert send_mod.maybe_auto_prune(paths, now=now) is True
+    assert not delivered.exists(), "resolved records past retention are still pruned"
+    assert pending.exists(), "an unresolved pending record must survive auto-pruning"
+    assert corrupt.exists(), "an unreadable (= unresolved) record must survive auto-pruning"
+
+
+def test_explicit_prune_remains_a_deliberate_operator_sweep(tmp_path: Path) -> None:
+    """`--prune-older-than` is an explicit human action and still removes
+    everything past the cutoff, including unresolved records."""
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    now = time.time()
+    pending = paths.record_file("old-pending")
+    send_mod.write_record_atomic(
+        pending,
+        {
+            "schema": 1, "token": "old-pending", "pane": "%0", "state": "pending",
+            "created_at": now - 100 * 86400, "payload_bytes": 1, "enter": False,
+        },
+    )
+    assert send_mod.prune(paths, older_than_secs=86400, now=now) == 1
+    assert not pending.exists()
+
+
+# --------------------------------------------------------------------------
+# The two narrow races the F2 fix rests on. Both are microsecond-wide against
+# a real tmux server, so the losing state is injected deterministically (the
+# environment cannot be made to produce it on demand) and the assertion is on
+# what the USER sees, never on a seam having fired.
+# --------------------------------------------------------------------------
+
+
+def _dead_owner() -> dict:
+    """An owner stamp naming a process that has certainly exited."""
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait(timeout=30)
+    owner = send_mod.owner_identity(child.pid)
+    assert send_mod.owner_is_alive(owner) is False
+    return owner
+
+
+def _lost_claim_outcome(
+    tmux_fixture: TmuxFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    token: str,
+    winner_document: dict,
+):
+    """Drive the CLI into "a sibling won the exclusive claim" deterministically.
+
+    The claim is lost only when a sibling publishes the record in the window
+    between this call's journal read and its own claim — real (five racing
+    processes hit it) but not reproducible on demand, so the winner's record is
+    published from inside the claim itself. Everything downstream of the claim,
+    including the whole outcome decision, is untouched production code.
+    """
+    paths = send_mod.resolve_paths(env={"XDG_STATE_HOME": str(tmux_fixture.state_dir)})
+
+    def _sibling_won(path: Path, document) -> bool:
+        send_mod.write_record_atomic(path, winner_document)
+        return False
+
+    monkeypatch.setattr(send_mod, "claim_record_exclusive", _sibling_won)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "send", "--socket-name", tmux_fixture.socket_name,
+            "--pane", tmux_fixture.pane_id, "--token", token,
+        ],
+        input=b"MARKER-2122-LOSTCLAIM\n",
+        env=tmux_fixture.env,
+    )
+    assert paths.record_file(token).exists()
+    return result
+
+
+def _winner_document(token: str, pane: str, *, state: str, owner=None) -> dict:
+    now = time.time()
+    return send_mod._record_document(
+        token=token, pane=pane, state=state, created_at=now,
+        delivered_at=now if state == send_mod.STATE_DELIVERED else None,
+        payload_bytes=22, enter=False, owner=owner,
+    )
+
+
+def test_losing_the_claim_to_a_sibling_that_already_delivered_reports_success(
+    tmux_fixture: TmuxFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token = "row-lostclaim-delivered"
+    result = _lost_claim_outcome(
+        tmux_fixture, monkeypatch, token,
+        _winner_document(token, tmux_fixture.pane_id, state=send_mod.STATE_DELIVERED),
+    )
+    assert result.output.split()[0] == "already-delivered", result.output
+    assert result.exit_code == 0
+    assert tmux_fixture.settle(quiet=0.5) == b"", "the loser must not have injected"
+
+
+def test_losing_the_claim_to_a_live_sibling_reports_send_in_progress(
+    tmux_fixture: TmuxFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token = "row-lostclaim-live"
+    result = _lost_claim_outcome(
+        tmux_fixture, monkeypatch, token,
+        _winner_document(
+            token, tmux_fixture.pane_id,
+            state=send_mod.STATE_PENDING, owner=send_mod.owner_identity(),
+        ),
+    )
+    assert result.output.split()[0] == "send-in-progress", result.output
+    assert result.exit_code == send_mod.EXIT_SEND_IN_PROGRESS
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+
+def test_losing_the_claim_to_a_sibling_that_then_died_reports_the_unknown(
+    tmux_fixture: TmuxFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one case where exit 5 IS the honest answer on this path."""
+    token = "row-lostclaim-dead"
+    result = _lost_claim_outcome(
+        tmux_fixture, monkeypatch, token,
+        _winner_document(
+            token, tmux_fixture.pane_id,
+            state=send_mod.STATE_PENDING, owner=_dead_owner(),
+        ),
+    )
+    assert result.output.split()[0] == "send-interrupted", result.output
+    assert result.exit_code == send_mod.EXIT_SEND_INTERRUPTED
+    assert tmux_fixture.settle(quiet=0.5) == b""
+
+
+def test_a_sibling_that_finished_between_the_read_and_the_liveness_check_is_not_an_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other race: the owner promoted the record and exited microseconds
+    after we read it, so a single read would show `pending` + a dead owner and
+    report a COMPLETED delivery as unknown — a spurious unknown manufactured
+    out of nothing, which is the whole defect class #2121 exists to delete.
+    """
+    state_dir = tmp_path / "state"
+    paths = send_mod.resolve_paths(env={"XDG_STATE_HOME": str(state_dir)})
+    token = "row-read-race"
+    send_mod.write_record_atomic(
+        paths.record_file(token),
+        _winner_document(token, "%0", state=send_mod.STATE_DELIVERED),
+    )
+
+    stale = send_mod.JournalRecord(
+        state=send_mod.STATE_PENDING, token=token, pane="%0",
+        created_at=time.time(), owner=_dead_owner(),
+    )
+    real_read = send_mod.read_record
+    reads: list[int] = []
+
+    def _stale_first(path: Path, wanted: str):
+        reads.append(1)
+        return stale if len(reads) == 1 else real_read(path, wanted)
+
+    monkeypatch.setattr(send_mod, "read_record", _stale_first)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["send", "--pane", "%0", "--token", token],
+        input=b"x\n", env={"XDG_STATE_HOME": str(state_dir)},
+    )
+    assert result.output.split()[0] == "already-delivered", result.output
+    assert result.exit_code == 0
+
+
+def test_classify_unresolved_reports_a_live_owner_without_a_second_read(
+    tmp_path: Path,
+) -> None:
+    """The fast path stays fast: a live owner is decided on the first read."""
+    paths = send_mod.SendPaths(sends_dir=tmp_path / "sends")
+    token = "row-classify-live"
+    path = paths.record_file(token)
+    send_mod.write_record_atomic(
+        path,
+        _winner_document(
+            token, "%0", state=send_mod.STATE_PENDING, owner=send_mod.owner_identity()
+        ),
+    )
+    record, alive = send_mod.classify_unresolved(path, token)
+    assert record.state == send_mod.STATE_PENDING
+    assert alive is True


### PR DESCRIPTION
**Step 1a of #2121** (maintainer-approved two-step plan). Host-side Python only — no Kotlin, no client changes, and the existing inference stack is untouched.

## Why

PocketShell cannot currently learn whether a prompt landed. It injects the payload, then *reads the terminal* and guesses within an 800 ms / 2 s window. A missed window leaves a row permanently "unconfirmed" whose Retry is a provable no-op — and the exactly-once ledger then correctly refuses to act, so the row is proven-sent and unconfirmable at the same time. The maintainer photographed this on 2026-08-13 (`2 queued · 2 unconfirmed` while the terminal showed the prompt as **Working**). Full analysis in #2121.

This adds the primitive that can *answer* the question:

```
pocketshell send --pane <id> --token <id> [--enter] < payload
```

**The exit status is the acknowledgement.** A durable token journal under `$XDG_STATE_HOME/pocketshell/sends/` makes a repeat token inject nothing and report `already-delivered`, so exactly-once moves to the only place that can observe the truth. Journal writes are atomic; an `O_CREAT|O_EXCL` claim closes the same-token race.

## The durability claim, stated narrowly because the broad one was false

**A token is never injected a second time unless `--resend-interrupted` is passed on the injecting call itself**, with four stated edges.

Round 1 claimed "never injected twice by this command". The reviewer disproved it on a real pane: kill-after-paste → exit 5 → opt-in resend with a paste failure (exit 4) → plain retry → **two copies**, because rollback unconditionally erased the pre-existing "unknown" memory. Exit 4 is documented as retryable, so #2124's *automatic* retry is what would have landed there.

Exit 5 now means only "the previous attempt is dead". A lost race against a **live** sibling gets the new retryable **exit 8** — round 1 reported a false unknown there, which would have recreated inside its own replacement the spurious-unknown class #2121 exists to delete.

## Verification

- 882 passed ×10 with per-run failure capture; also green under **Python 3.11** (CI's version), which caught a `communicate()`/closed-stdin defect the dev box hides and that would have been a red required check.
- Reviewer's **13/13 mutants killed** in a private `cp -a` root with its own venv, asserting per mutant that the md5 changed, `ast.parse` succeeds, and **the live imported module is inside the mutant root** — added after an earlier run reported 0/11 killed because an editable-install `.pth` still pointed at the reviewed tree (an unmutated green).
- A 10-scenario adversarial probe against the durability claim (vanished tmux binary, corrupt record, load-buffer failure, mid-paste timeout, concurrent opt-in resends, 90-day-old unknown vs auto-prune, SIGSTOPped owner) — **no falsification**.
- Tests **hard-fail rather than skip** without tmux (proved by running with tmux off `PATH`); the workflow adds tmux to the Python job so the criterion is meetable.
- Orchestrator gate on this branch: `check-version-coupling.sh` rc=0 with `pyproject.toml` correctly un-bumped, `check-script-interpreter-hygiene.sh` rc=0, `git diff --check` clean, 882 passed. Merged file bytes md5-verified identical to the reviewed worktree.

Reviewer verdict: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2122#issuecomment-5287452675

## Note for #2124

The reviewer found one **unstated fifth edge**: exit 8 is bounded by owner *liveness*, not by the owner's `--timeout` (reproduced with SIGSTOP). It fails safe and a client cannot reach it by its own use. They also flag that the **exit-4 table row** ("the token is NOT journaled and stays retryable") is now imprecise on the opt-in-resend rollback path — safe, but #2124 branches on that table, so it must be tightened before the client contract is written.

Closes #2122