### PR TITLE
tmux: surface honest in-place recovery after a within-grace drop (#822)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.proof
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.os.SystemClock
 import android.util.Log
 import android.view.View
@@ -11,6 +12,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
@@ -23,11 +25,16 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
 import com.pocketshell.app.tmux.TMUX_CONNECTING_PROGRESS_TAG
+import com.pocketshell.app.tmux.TMUX_CONNECTION_STATUS_PILL_TAG
+import com.pocketshell.app.tmux.TMUX_RECONNECTING_RETRY_NOW_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
+import com.pocketshell.app.tmux.TMUX_CONVERSATION_PANE_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
+import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
 import com.pocketshell.app.tmux.TmuxSessionViewModel
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -38,6 +45,8 @@ import com.termux.view.TerminalView
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -47,10 +56,10 @@ import java.io.File
 import java.io.FileOutputStream
 
 /**
- * Issue #635 (epic #687 Phase 0, J1) — DEVICE-TRUTH journey: a background→
- * foreground WITHIN grace must NOT reconnect, EVEN WHEN THE SOCKET DROPPED while
- * backgrounded. The pane must be re-seeded (the prior content restored), and
- * NO "Reconnecting"/"Disconnected"/"Attaching…" surface may appear.
+ * Issue #635/#822 (epic #687 Phase 0, J1) — DEVICE-TRUTH journey: after a socket
+ * drops while backgrounded, a foreground return WITHIN grace keeps the last pane
+ * viewport visible but must truthfully show `Reconnecting` with an in-place action.
+ * Tapping that action recovers the SAME session; no A→B→A switch workaround.
  *
  * ## Why the existing within-grace CI tests miss the maintainer's bug
  *
@@ -90,23 +99,23 @@ import java.io.FileOutputStream
  *
  * ## Contract (DEVICE TRUTH — asserts the user's pixels)
  *
- *  1. After foregrounding within grace following the socket drop, the pane
- *     VIEWPORT is RE-SEEDED: the visible terminal is non-blank AND shows the
- *     prior [READY_MARKER] content (the user does not return to a blank pane).
- *  2. NO "Reconnecting"/"Disconnected"/"Tap Reconnect"/"Connecting"/
- *     "Attaching…" surface appears at any point across the within-grace
- *     foreground window — neither the band ([TMUX_SESSION_ERROR_TAG]) nor the
- *     overlays.
+ *  1. During the confirmed-dead interval the prior [READY_MARKER] viewport remains
+ *     visible — proven on the RENDERED `TerminalView` (measured, shown, on-screen and
+ *     actually painted; see [assertRetainedFrameIsRendered]) as well as in the terminal
+ *     buffer, because the buffer survives a view collapsed to 0x0 — while raw status is
+ *     Reconnecting, send is unwritable, and the top `Retry now` action is visible. No
+ *     destructive centered "Attaching…" overlay, collapsed pull-to-refresh wrapper, or
+ *     terminal `Disconnected` failure surface may replace it.
+ *  2. Tapping `Retry now` recovers through a different control client, remains on
+ *     [SESSION_NAME], and round-trips [AFTER_MARKER] without a session switch.
  *
  * ## Fail-first
  *
- * On base `origin/main` the dropped socket makes
- * `canReseedWithinGraceForeground()` false, so the within-grace foreground
- * falls into the reconnect ladder: a Reconnecting/Disconnected surface appears
- * (assertion 2 RED) and/or the pane is left blank until the reconnect re-seeds
- * (assertion 1 RED). That RED is the proof this reproduces #635. The Phase-2
- * single-grace-owner fix (the controller heals the dropped channel within grace
- * with no scary band, then re-seeds) flips it GREEN.
+ * On the reopened-#822 base, the dropped socket makes the reseed gate decline, but
+ * `launchForegroundHealWithinGrace` sends a synthetic preserved-channel seed and the
+ * status projector rewrites Reconnecting to Connected. The first wait therefore REDs:
+ * raw status stays false Connected and no Retry-now action exists over the dead wire.
+ * A genuine typed drop plus reveal-only hold flips it GREEN.
  */
 @RunWith(AndroidJUnit4::class)
 class WithinGraceSocketDropForegroundJourneyE2eTest {
@@ -130,6 +139,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
 
     @After
     fun tearDown() {
+        runCatching { currentViewModel().forceCleanOutageForTest = false }
         runCatching { launchedActivity?.close() }
         launchedActivity = null
         BackgroundGraceTestOverride.setForTest(null)
@@ -139,7 +149,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
     }
 
     @Test
-    fun withinGraceForegroundAfterSocketDropReseedsWithoutReconnect() { runBlocking {
+    fun withinGraceForegroundAfterSocketDropRetainsViewportAndRetryRecoversSameSession() { runBlocking {
         val key = readFixtureKey()
         seededKey = key
         waitForSshFixtureReady(SshKey.Pem(key))
@@ -153,10 +163,17 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
         attachSeededTmuxSession(hostRowTag)
 
+        // #818 defaults an agent-kinded session to Conversation; this journey is about the
+        // TERMINAL viewport the user was looking at, so put the real Terminal tab on screen
+        // before the drop. Otherwise the retained frame under test is not the visible
+        // surface and the chrome screenshot cannot evidence the reported state.
+        selectTerminalTabForJourney()
         // Baseline: the seeded content is on screen. This is the content that
         // must survive the within-grace socket drop and be re-seeded on return.
         waitForVisibleTerminal("initial attach") { it.contains(READY_MARKER) }
         waitForConnected("initial attach")
+        val vm = currentViewModel()
+        val clientBeforeDrop = vm.currentClientIdentityForTest()
         captureViewport("issue635-01-attached")
         diagnostics!!.clear()
 
@@ -172,6 +189,10 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
 
         // Use a short grace override so the resume lands well within grace.
         BackgroundGraceTestOverride.setForTest(WITHIN_GRACE_MS)
+        // Hold the passive replacement primitives down after the real socket death so the
+        // UI has a deterministic confirmed-dead interval to render. The real `Retry now`
+        // action uses the production manual reconnect entrypoint and remains available.
+        vm.forceCleanOutageForTest = true
 
         val cycleStart = SystemClock.elapsedRealtime()
         // (1) Background within grace.
@@ -197,57 +218,51 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
         }
         recordTiming("within_grace_cycle_ms", SystemClock.elapsedRealtime() - cycleStart)
 
-        // DEVICE-TRUTH assertion (2): NO reconnect surface across the foreground
-        // window. On base `main` the dropped socket sends the within-grace
-        // foreground into the reconnect ladder, which paints a
-        // Reconnecting/Disconnected surface — this watch goes RED there.
-        watchNoVisibleReconnect("within-grace after socket drop", OVERLAY_WATCH_MS)
-        // Issue #1954: authoritative in-app proof at the actual no-overlay watch point,
-        // before waiting for recovery completion. This is a direct TerminalView draw plus
-        // same-view visible text; the generic harness failure screenshot is not evidence.
-        captureViewport("issue1954-02-post-resume-no-overlay")
-
-        // DEVICE-TRUTH assertion (1): the pane VIEWPORT is RE-SEEDED — non-blank
-        // AND shows the prior content. The user must not be left on a blank
-        // pane. On base `main` the dropped socket either shows a reconnect band
-        // (assertion 2) or the pane stays blank until a reconnect re-seeds it.
-        waitForVisibleTerminal("within-grace re-seeded pane") { it.contains(READY_MARKER) }
-        val visibleAfter = visibleTerminalText()
+        // #822 DEVICE TRUTH: the dead wire is honestly Reconnecting and actionable, while
+        // the reveal hold preserves the exact prior viewport instead of painting Attaching.
+        waitForHonestReconnectWithRetainedViewport(vm)
+        captureViewport("issue822-02-post-resume-reconnecting-retained")
+        // The whole window too: the reviewer must SEE the honest chrome the user gets —
+        // the amber "Reconnecting" breadcrumb pill and the in-place `Retry now` band over
+        // the retained pane frame. The TerminalView-only capture cannot show either.
+        captureScreen("issue822-02b-post-resume-reconnecting-chrome")
+        val visibleDuringOutage = visibleTerminalText()
         assertTrue(
-            "within-grace foreground after a socket drop must RE-SEED the pane " +
-                "(non-blank), but the visible terminal was blank",
-            visibleAfter.isNotBlank(),
+            "within-grace foreground after a socket drop must retain a non-blank viewport",
+            visibleDuringOutage.isNotBlank(),
         )
         assertTrue(
-            "within-grace foreground after a socket drop must restore the prior " +
-                "pane content ('$READY_MARKER'); visible terminal was:\n$visibleAfter",
-            visibleAfter.contains(READY_MARKER),
+            "the held viewport must retain '$READY_MARKER' during the real outage; visible:\n" +
+                visibleDuringOutage,
+            visibleDuringOutage.contains(READY_MARKER),
         )
-        val deadLeaseRecovery = diagnostics!!.eventsNamed("dead_lease_recovery")
-        assertEquals(
-            "the within-grace owner must invalidate/acquire the dead lease exactly once",
-            1,
-            deadLeaseRecovery.size,
-        )
-        assertEquals(true, deadLeaseRecovery.single().fields["invalidatedLease"])
-        assertEquals(true, deadLeaseRecovery.single().fields["freshTransport"])
         assertEquals(
             "liveness must stay deferred while the within-grace owner heals the dead client",
             0,
             diagnostics!!.eventsNamed("liveness_probe_silent_drop").size,
         )
 
-        // The recovered channel must accept real input, not merely repaint an old marker.
-        val recoveredClient = requireNotNull(currentViewModel().liveTmuxClientForSendOrNullForTest())
-        val send = recoveredClient.sendKeysViaExec(
-            "send-keys -t ${shellQuote(SESSION_NAME)} ${shellQuote("printf '$AFTER_MARKER\\n'")} Enter",
+        // The in-place action must work. This is the exact user journey that previously
+        // required switching to another session and back: tap Retry now on this session.
+        compose.onNodeWithTag(TMUX_RECONNECTING_RETRY_NOW_TAG, useUnmergedTree = true).performClick()
+        waitForDiagnostic("reconnect_tapped", "in-place Retry now action")
+        vm.forceCleanOutageForTest = false
+        waitForConnected("same-session Retry now recovery")
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            vm.currentClientIdentityForTest()?.let { it != clientBeforeDrop } == true &&
+                vm.isSendTransportWritable()
+        }
+        val clientAfterRecovery = vm.currentClientIdentityForTest()
+        assertNotEquals(
+            "Retry now must install a replacement control client without a session switch",
+            clientBeforeDrop,
+            clientAfterRecovery,
         )
-        assertTrue("post-recovery input failed: ${send.output}", !send.isError)
-        waitForVisibleTerminal("within-grace post-recovery input") { it.contains(AFTER_MARKER) }
-        // And the band stays absent through the settle (a late reconnect band
-        // would still be the #635 regression).
-        watchNoVisibleReconnect("within-grace settle after re-seed", POST_RESTORE_SETTLE_MS)
-        captureViewport("issue1954-03-within-grace-reseeded")
+
+        // The recovered channel must accept real input, not merely repaint the old marker.
+        assertPostRecoveryInputReachesTheVisibleViewport()
+        assertNoReconnectSurface("same-session settle after Retry now")
+        captureViewport("issue822-03-same-session-recovered")
 
         // The session screen is still up (a cleared pane that also lost the
         // screen would be a teardown/reconnect, not a within-grace ride-through).
@@ -348,13 +363,239 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
     }
 
     /**
-     * The within-grace foreground after a socket drop must paint NONE of the
-     * reconnect surfaces (the maintainer's exact "scary band" complaint). This
-     * asserts on the USER-VISIBLE bands/overlays/text, not an internal flag.
+     * The load-bearing writability proof: real input over the RECOVERED same-session wire
+     * must reach the user's visible viewport.
+     *
+     * It is a bounded re-send loop rather than a single send because a `-CC` client streams
+     * only the output produced AFTER it subscribes — tmux does not replay what landed during
+     * the attach window. A marker sent into that window is therefore never painted, which
+     * made a single-send assertion fail ~1 run in 3 on the dev box for a reason that has
+     * nothing to do with writability. The loop's EXIT CONDITION is the load-bearing
+     * assertion (the marker is visible), each send is still hard-checked for a transport
+     * error, and the whole thing hard-fails at the deadline — so a genuinely unwritable wire
+     * can never pass by retrying.
      */
-    private fun assertNoVisibleReconnect(label: String) {
+    private suspend fun assertPostRecoveryInputReachesTheVisibleViewport() {
+        val deadline = SystemClock.elapsedRealtime() + TerminalTestTimeouts.terminalVisibilityTimeoutMs()
+        var sends = 0
+        var visible = false
+        while (!visible && SystemClock.elapsedRealtime() < deadline) {
+            val client = requireNotNull(currentViewModel().liveTmuxClientForSendOrNullForTest()) {
+                "the recovered same-session wire must expose a live client for send"
+            }
+            val send = client.sendKeysViaExec(
+                "send-keys -t ${shellQuote(SESSION_NAME)} ${shellQuote("printf '$AFTER_MARKER\\n'")} Enter",
+            )
+            sends += 1
+            assertTrue("post-recovery input failed: ${send.output}", !send.isError)
+            visible = runCatching {
+                compose.waitUntil(timeoutMillis = POST_RECOVERY_INPUT_PAINT_MS) {
+                    visibleTerminalText().contains(AFTER_MARKER)
+                }
+                true
+            }.getOrDefault(false)
+        }
+        recordTiming("post_recovery_input_sends", sends.toLong())
+        if (!visible) writeText("failure-post-recovery-visible-terminal.txt", visibleTerminalText())
+        assertTrue(
+            "the recovered same-session wire must carry input through to the visible " +
+                "viewport after $sends send(s); visible terminal was:\n${visibleTerminalText()}",
+            visible,
+        )
+    }
+
+    private fun selectTerminalTabForJourney() {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_CONVERSATION_PANE_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+        compose.waitForIdle()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun waitForHonestReconnectWithRetainedViewport(vm: TmuxSessionViewModel) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting &&
+                compose.onAllNodesWithTag(
+                    TMUX_RECONNECTING_RETRY_NOW_TAG,
+                    useUnmergedTree = true,
+                ).fetchSemanticsNodes().isNotEmpty() &&
+                visibleTerminalText().contains(READY_MARKER)
+        }
+        assertTrue(
+            "#822: confirmed-dead foreground must report Reconnecting; " +
+                "status=${vm.connectionStatus.value}",
+            vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+        )
+        assertFalse(
+            "#822: confirmed-dead foreground must be transport-unwritable before Retry now",
+            vm.isSendTransportWritable(),
+        )
+        // ...and the retained viewport must actually be ON SCREEN. See
+        // [assertRetainedFrameIsRendered]: the transcript checks below read the terminal
+        // EMULATOR BUFFER, which survives a collapsed view, so they cannot see the
+        // reported destruction on their own.
+        assertRetainedFrameIsRendered("post-resume confirmed-dead interval")
+        // The user must SEE the drop (the maintainer's "nothing tells me it dropped"
+        // report): the breadcrumb pill/dot reads the amber "Reconnecting", not the
+        // green Connected the retained frame used to imply.
+        compose.onNodeWithTag(TMUX_CONNECTION_STATUS_PILL_TAG, useUnmergedTree = true)
+            .assertTextEquals("Reconnecting")
+        compose.onNodeWithTag(TMUX_CONNECTING_PROGRESS_TAG, useUnmergedTree = true).assertExists()
+        // ...and must be able to ACT on it. Containment, not `assertIsDisplayed`
+        // (#657/F3): an off-edge control still reports displayed, and this tap target
+        // is the whole point of the issue.
+        compose.assertNodeFullyWithinRoot(TMUX_RECONNECTING_RETRY_NOW_TAG, useUnmergedTree = true)
         assertEquals(
-            "expected no Connecting overlay for $label",
+            "the retained viewport must not be replaced by the centered Attaching overlay",
+            0,
+            compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertEquals(
+            "a recoverable within-grace outage must not show the terminal failure band",
+            0,
+            compose.onAllNodesWithTag(TMUX_SESSION_ERROR_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+        assertEquals(
+            "a recoverable within-grace outage must not show the terminal Tap Reconnect action",
+            0,
+            compose.onAllNodesWithTag(TMUX_SESSION_RECONNECT_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().size,
+        )
+    }
+
+    /**
+     * Issue #822 (round 2): the load-bearing "the user still SEES their pane" assertion.
+     *
+     * ## Why the buffer is not enough
+     *
+     * Every other "retained viewport" check in this journey goes through
+     * [visibleTerminalText], which reads `TerminalView.currentSession.emulator.screen
+     * .transcriptText` — the terminal emulator's BUFFER. That buffer is completely
+     * independent of whether the view is measured, laid out, or drawn, so it stays intact
+     * while the user is looking at nothing. On the emulator, removing the one-line
+     * `surfaceOwnsPrimary` guard on `pullToReconnectActive` mounts the #823
+     * `PullToRefreshBox` over the live `TerminalView`; its `verticalScroll` gives the
+     * terminal an unbounded height constraint, the terminal measures to 0x0, and the
+     * user's frame is replaced by an empty pull area with a spinner — while every
+     * buffer-based assertion in this file stayed green.
+     *
+     * ## What this asserts instead
+     *
+     * The RENDERED view: a `TerminalView` exists, is attached and shown, has non-zero
+     * measured size, occupies a non-empty rectangle on screen, and — drawn through the
+     * same `view.draw(Canvas)` path the authoritative viewport artifact uses — is not a
+     * single uniform colour (i.e. the retained pane content is actually painted, not a
+     * blank surface of the right size).
+     *
+     * The bounded wait exists only so a transient layout pass cannot flake it; the HARD
+     * assertion is the loop's exit condition, never the loop body.
+     */
+    private fun assertRetainedFrameIsRendered(label: String) {
+        var last = "never sampled"
+        val satisfied = runCatching {
+            compose.waitUntil(timeoutMillis = RENDERED_FRAME_TIMEOUT_MS) {
+                val probe = probeRenderedTerminalFrame()
+                last = probe.describe()
+                probe.isRendered
+            }
+            true
+        }.getOrDefault(false)
+        if (!satisfied) {
+            writeText("failure-rendered-frame.txt", "$label\n$last\n")
+            runCatching { captureScreen("issue822-failure-rendered-frame") }
+        }
+        assertTrue(
+            "#822: during $label the retained terminal frame must still be RENDERED for " +
+                "the user, not merely present in the terminal buffer. A collapsed " +
+                "(0x0 / unshown / blank) TerminalView is the reported destruction of the " +
+                "retained viewport. Observed: $last",
+            satisfied,
+        )
+    }
+
+    private fun probeRenderedTerminalFrame(): RenderedTerminalProbe {
+        var probe = RenderedTerminalProbe(found = false)
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val onScreen = Rect()
+            val hasVisibleRect = view.getGlobalVisibleRect(onScreen)
+            val width = view.width
+            val height = view.height
+            var uniform = true
+            if (width > 0 && height > 0) {
+                val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                view.draw(Canvas(bitmap))
+                uniform = bitmapIsUniform(bitmap)
+                bitmap.recycle()
+            }
+            probe = RenderedTerminalProbe(
+                found = true,
+                shown = view.isShown,
+                width = width,
+                height = height,
+                visibleWidth = if (hasVisibleRect) onScreen.width() else 0,
+                visibleHeight = if (hasVisibleRect) onScreen.height() else 0,
+                uniformPixels = uniform,
+            )
+        }
+        return probe
+    }
+
+    /**
+     * True when every pixel of the drawn frame is the same colour — a surface that is the
+     * right SIZE but paints nothing (the other way a retained frame can be lost). The
+     * seeded pane always carries at least the [READY_MARKER] line and a prompt, so a
+     * genuinely retained frame is never uniform.
+     */
+    private fun bitmapIsUniform(bitmap: Bitmap): Boolean {
+        val width = bitmap.width
+        val height = bitmap.height
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+        val first = pixels[0]
+        for (pixel in pixels) {
+            if (pixel != first) return false
+        }
+        return true
+    }
+
+    private class RenderedTerminalProbe(
+        val found: Boolean,
+        val shown: Boolean = false,
+        val width: Int = 0,
+        val height: Int = 0,
+        val visibleWidth: Int = 0,
+        val visibleHeight: Int = 0,
+        val uniformPixels: Boolean = true,
+    ) {
+        val isRendered: Boolean
+            get() = found && shown && width > 0 && height > 0 &&
+                visibleWidth > 0 && visibleHeight > 0 && !uniformPixels
+
+        fun describe(): String =
+            "terminalViewFound=$found attachedAndShown=$shown measured=${width}x$height " +
+                "onScreenRect=${visibleWidth}x$visibleHeight drawnFrameIsUniformBlank=$uniformPixels"
+    }
+
+    private fun assertNoReconnectSurface(label: String) {
+        compose.waitUntil(timeoutMillis = CONNECTED_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(TMUX_CONNECTING_PROGRESS_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes().isEmpty() &&
+                compose.onAllNodesWithTag(TMUX_SWITCHING_LOADING_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isEmpty()
+        }
+        assertEquals(
+            "expected no connecting/reconnecting band for $label",
             0,
             compose.onAllNodesWithTag(TMUX_CONNECTING_PROGRESS_TAG, useUnmergedTree = true)
                 .fetchSemanticsNodes().size,
@@ -385,15 +626,6 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
                     .fetchSemanticsNodes().size,
             )
         }
-    }
-
-    private fun watchNoVisibleReconnect(label: String, durationMs: Long) {
-        val deadline = SystemClock.elapsedRealtime() + durationMs
-        while (SystemClock.elapsedRealtime() < deadline) {
-            assertNoVisibleReconnect(label)
-            SystemClock.sleep(100)
-        }
-        recordTiming("${label.replace(' ', '_')}_no_reconnect_ms", durationMs)
     }
 
     private fun waitForDiagnostic(
@@ -525,22 +757,78 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
         }
     }
 
+    /**
+     * Issue #822 (round 2): captures the AUTHORITATIVE `*-viewport.png` terminal artifact
+     * and HARD-FAILS when it cannot.
+     *
+     * It used to `return@onActivity` silently when the `TerminalView` was missing or
+     * measured 0x0 — so a run whose terminal had been collapsed produced no authoritative
+     * viewport artifact at all and nothing noticed. That is the worst artifact shape in
+     * this repo: "I could not check" reading exactly like "I checked and it is fine". The
+     * missing PNG was in fact the strongest available evidence that the retained frame had
+     * been destroyed, and it was thrown away. Every state this journey captures in
+     * (attached, confirmed-dead-with-retained-frame, recovered) must have a measurable
+     * terminal, so an unmeasurable one is a failure of the journey, never a skipped
+     * screenshot.
+     */
     private fun captureViewport(name: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         instrumentation.waitForIdleSync()
         SystemClock.sleep(150)
 
         var bitmap: Bitmap? = null
+        var problem: String? = "MainActivity was not available"
         launchedActivity?.onActivity { activity ->
-            val view = activity.window.decorView.findTerminalView() ?: return@onActivity
+            val view = activity.window.decorView.findTerminalView()
+            if (view == null) {
+                problem = "no TerminalView in the decor view"
+                return@onActivity
+            }
+            if (view.width <= 0 || view.height <= 0) {
+                problem = "TerminalView measured ${view.width}x${view.height} " +
+                    "(shown=${view.isShown}) — the retained frame is not rendered"
+                return@onActivity
+            }
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+            problem = null
+        }
+        // Always write the buffer text first, so the failure below carries context.
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        val captured = bitmap
+        if (captured == null) {
+            runCatching { captureScreen("$name-failure-no-viewport") }
+            error(
+                "#822: the authoritative viewport artifact '$name-viewport.png' could not " +
+                    "be captured: $problem. A missing terminal viewport capture is a hard " +
+                    "failure, never a silent skip.",
+            )
+        }
+        writeBitmap("$name-viewport", captured)
+        captured.recycle()
+    }
+
+    /**
+     * Whole-window capture (advisory per the terminal-artifact rules, but the ONLY way to
+     * evidence the chrome): draws the activity decor view, so the breadcrumb pill and the
+     * under-header reconnect band appear alongside the retained terminal frame.
+     */
+    private fun captureScreen(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        launchedActivity?.onActivity { activity ->
+            val view = activity.window.decorView
             if (view.width <= 0 || view.height <= 0) return@onActivity
             val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
             view.draw(Canvas(b))
             bitmap = b
         }
-        bitmap?.let { writeBitmap("$name-viewport", it) }
-        writeText("$name-visible-terminal.txt", visibleTerminalText())
-        bitmap?.recycle()
+        val captured = requireNotNull(bitmap) { "decor view was not measurable for $name" }
+        writeBitmap("$name-screen", captured)
+        captured.recycle()
     }
 
     private fun writeBitmap(name: String, bitmap: Bitmap): File {
@@ -569,7 +857,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
             "summary.txt",
             buildString {
                 appendLine("test=WithinGraceSocketDropForegroundJourneyE2eTest")
-                appendLine("issue=1954")
+                appendLine("issue=822")
                 appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
                 appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
                 appendLine("session=$SESSION_NAME")
@@ -579,8 +867,8 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
                         "(socket drop), foreground within grace",
                 )
                 appendLine(
-                    "expectation=pane re-seeded (non-blank, prior content), " +
-                        "no Reconnecting/Disconnected/Attaching surface",
+                    "expectation=retained prior viewport + honest Reconnecting + working Retry now, " +
+                        "then same-session fresh-client recovery without A→B→A",
                 )
                 appendLine(
                     "liveness_recovery_starts=" +
@@ -633,9 +921,16 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
 
         const val WITHIN_GRACE_MS: Long = 8_000L
         const val BACKGROUND_HOLD_MS: Long = 1_500L
-        const val OVERLAY_WATCH_MS: Long = 2_500L
-        const val POST_RESTORE_SETTLE_MS: Long = 2_000L
         const val DIAGNOSTIC_TIMEOUT_MS: Long = 8_000L
+        const val POST_RECOVERY_INPUT_PAINT_MS: Long = 6_000L
+
+        /**
+         * Generous bound for the rendered-frame probe. The retained frame is a settled
+         * state, not a transient one, so this only absorbs a layout pass on a contended
+         * emulator; the destroyed-frame case never becomes rendered and burns the whole
+         * budget before hard-failing.
+         */
+        const val RENDERED_FRAME_TIMEOUT_MS: Long = 10_000L
 
         val CONNECTED_TIMEOUT_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConnectingStatesScreenshotTest.kt
@@ -382,6 +382,7 @@ class TmuxConnectingStatesScreenshotTest {
                     TmuxTopConnectingBanner(
                         surfaceState = surfaceOf(RevealState.Seeding(sid, "git-pocketshell"), connecting),
                         surfaceOwnsPrimary = true,
+                        status = connecting,
                         sessionName = "git-pocketshell",
                         onCancelConnect = {},
                         onRetryNow = {},
@@ -746,6 +747,7 @@ class TmuxConnectingStatesScreenshotTest {
                     TmuxTopConnectingBanner(
                         surfaceState = waitingState,
                         surfaceOwnsPrimary = ownsPrimary,
+                        status = reconnecting,
                         sessionName = "claude-main",
                         onCancelConnect = {},
                         onRetryNow = {},

--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1952TypedPassiveDropRealTransportIntegrationTest.kt
@@ -23,7 +23,9 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
@@ -302,11 +304,12 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
     }
 
     /**
-     * Issue #1954 D34 proof: kill the real authenticated sshd worker while the app is in its
-     * bounded background grace, then foreground through the production grace-heal entrypoint.
-     * The symptom-defining assertions are on the real reader death, the absence of a competing
-     * liveness owner, the lease-authority invalidation record, object identities, connect count,
-     * and the real same-session transcript.
+     * Issue #1954/#822 D34 proof: kill the real authenticated sshd worker while the app is in
+     * bounded background grace, keep the authoritative replacement connector unavailable for
+     * one foreground attempt, then restore it. The dead interval must be typed Reattaching /
+     * displayed Reconnecting and unwritable while the retained viewport remains available;
+     * recovery must happen in place over a distinct SSH/client and real seed, with no manual
+     * reconnect or session-switch workaround.
      */
     @Test
     fun realReaderDropWithinGraceHasOneOwnerAndOneFreshHandshake() = runBlocking {
@@ -319,7 +322,8 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
         startDockerOrFail()
         val fixture = requireNotNull(container)
         val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-        val connector = CountingLeaseConnector(DefaultSshLeaseConnector())
+        val outageConnector = OneHeldOutageLeaseConnector(DefaultSshLeaseConnector())
+        val connector = CountingLeaseConnector(outageConnector)
         val leaseManager = SshLeaseManager(
             connector = connector,
             scope = ioScope,
@@ -374,6 +378,10 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
                 "precondition: process background must close the liveness probe gate",
                 vm.shouldRunLivenessProbeForTest(),
             )
+            // #822: the replacement transport stays unavailable for exactly the first
+            // foreground attempt. This exposes the interval that used to remain falsely
+            // Live/Connected until an eventual recovery outcome happened.
+            outageConnector.armOneAttemptOutage()
             val killedPeerPids = killAuthenticatedSshdProcessesFromServer()
             val readerExit = awaitReaderExit(tmuxDiagnostics, firstClientHash)
             assertTrue(
@@ -412,6 +420,38 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
             vm.setProcessForegroundForClearedForTest(true)
             vm.onAppForegrounded(resumedWithinGrace = true)
 
+            awaitCondition(RECOVERY_TIMEOUT_MS, "first within-grace replacement attempt blocked") {
+                outageConnector.blockedAttemptInFlight
+            }
+            assertEquals(
+                "the peer must remain unavailable for exactly one replacement attempt",
+                1,
+                outageConnector.blockedConnectCount,
+            )
+            assertTrue(
+                "#822: confirmed-dead foreground must be typed Reattaching before a replacement " +
+                    "transport or seed exists; state=${vm.connectionControllerStateForTest()}",
+                vm.connectionControllerStateForTest() is ConnectionState.Reattaching,
+            )
+            assertTrue(
+                "#822: raw/display status must truthfully be Reconnecting during the real outage; " +
+                    "status=${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+            )
+            assertFalse(
+                "#822: the dead transport must not be writable before replacement seed",
+                vm.isSendTransportWritable(),
+            )
+            assertTrue(
+                "the original within-grace owner must remain active during the blocked attempt",
+                vm.withinGraceRecoveryActiveForTest(),
+            )
+            assertTrue(
+                "the in-place grace owner must not require the normal reconnect entrypoint",
+                diagnostics.eventsNamed("reconnect_start").isEmpty(),
+            )
+
+            outageConnector.releaseBlockedAttemptWithFailure()
             awaitCondition(RECOVERY_TIMEOUT_MS, "within-grace fresh-client recovery completion") {
                 val currentClient = vm.liveTmuxClientForSendOrNullForTest()
                 val currentHash = currentClient?.let(System::identityHashCode)
@@ -431,9 +471,19 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
             assertEquals(true, leaseRecovery.single().fields["invalidatedLease"])
             assertEquals(true, leaseRecovery.single().fields["freshTransport"])
             assertEquals(
-                "one initial + exactly one recovery handshake",
-                2,
+                "one initial acquire + one blocked replacement + one recovered acquire",
+                3,
                 connector.connectCount,
+            )
+            assertEquals(
+                "only the initial and recovered transports may handshake successfully",
+                2,
+                outageConnector.successfulConnectCount,
+            )
+            assertEquals(
+                "the recovery must survive one unavailable replacement attempt in place",
+                1,
+                outageConnector.blockedConnectCount,
             )
             assertTrue(
                 "the competing liveness owner must stay deferred for the owned dead client: " +
@@ -454,7 +504,8 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
 
             println(
                 "ISSUE1954_REAL_TRANSPORT owner=within_grace livenessStarts=0 " +
-                    "connectCount=${connector.connectCount} leaseRecovery=${leaseRecovery.single().fields} " +
+                    "connectCount=${connector.connectCount} blocked=${outageConnector.blockedConnectCount} " +
+                    "leaseRecovery=${leaseRecovery.single().fields} " +
                     "firstClient=$firstClientHash recoveredClient=${System.identityHashCode(recoveredClient)} " +
                     "firstSsh=$firstSshIdentity recoveredSsh=$recoveredSshIdentity " +
                     "peerKilledPids=$killedPeerPids reader=$readerExit",
@@ -471,6 +522,7 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
                         "${event.category}/${event.name} ${event.fields}"
                     },
             )
+            outageConnector.releaseBlockedAttemptWithFailure()
             LivenessProbeTestOverride.clear()
             vm?.setProcessForegroundForClearedForTest(null)
             vm?.cancelOwnScopesForTest()
@@ -846,6 +898,50 @@ class Issue1952TypedPassiveDropRealTransportIntegrationTest {
             if (outageActive) {
                 blockedAttempts.incrementAndGet()
                 return Result.failure(IOException("synthetic sustained outage at connector attempt $attempt"))
+            }
+            return delegate.connect(target).also { result ->
+                if (result.isSuccess) successfulAttempts.incrementAndGet()
+            }
+        }
+    }
+
+    /**
+     * Holds exactly one manager-new acquisition before returning a failure. The test can
+     * inspect controller/status/send truth while no replacement IO outcome exists, then
+     * release that one failed attempt and let the same grace owner recover on its next tick.
+     */
+    private class OneHeldOutageLeaseConnector(
+        private val delegate: SshLeaseConnector,
+    ) : SshLeaseConnector {
+        private val armed = AtomicBoolean(false)
+        private val blockedAttempts = AtomicInteger(0)
+        private val successfulAttempts = AtomicInteger(0)
+        private val blockedAttemptStarted = CompletableDeferred<Unit>()
+        private val releaseBlockedAttempt = CompletableDeferred<Unit>()
+
+        val blockedConnectCount: Int
+            get() = blockedAttempts.get()
+
+        val blockedAttemptInFlight: Boolean
+            get() = blockedAttemptStarted.isCompleted && !releaseBlockedAttempt.isCompleted
+
+        val successfulConnectCount: Int
+            get() = successfulAttempts.get()
+
+        fun armOneAttemptOutage() {
+            check(armed.compareAndSet(false, true)) { "one-attempt outage already armed" }
+        }
+
+        fun releaseBlockedAttemptWithFailure() {
+            releaseBlockedAttempt.complete(Unit)
+        }
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            if (armed.compareAndSet(true, false)) {
+                blockedAttempts.incrementAndGet()
+                blockedAttemptStarted.complete(Unit)
+                releaseBlockedAttempt.await()
+                return Result.failure(IOException("held one-attempt replacement outage"))
             }
             return delegate.connect(target).also { result ->
                 if (result.isSuccess) successfulAttempts.incrementAndGet()

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConnectionChrome.kt
@@ -207,17 +207,85 @@ internal fun shouldShowConnectingProgressOverlay(
     !surfaceOwnsPrimary && surfaceState is SessionSurfaceState.Connecting
 
 /**
- * Issue #750/#1326: the single-indicator gate for the top under-header
- * [ReconnectingProgressRow] progress line. Same rule as
- * [shouldShowConnectingProgressOverlay] — derived from the ONE state; the centered
- * "Attaching…" hold is the sole reattach affordance for every real reconnect (the
- * terminal is held), so this top bar is the unreachable live-frame fallback.
+ * Issue #750/#1326/#822: the single-indicator gate for the top under-header
+ * [ReconnectingProgressRow] band.
+ *
+ * The #750 half is unchanged: while the surface owns the primary indicator (the
+ * centered "Attaching…" hold or the calm-failure placeholder) this band stays
+ * suppressed, so a reconnect can never paint two loaders at once.
+ *
+ * The #822 half fixes the OTHER half of the gate. It used to read
+ * `surfaceState is SessionSurfaceState.Reconnecting`, which is a contradiction
+ * with `!surfaceOwnsPrimary`: a [SessionSurfaceState.Reconnecting] is by
+ * construction a HELD surface, so the band was structurally unreachable and the
+ * live-frame reconnect the KDoc promised to cover had ZERO indicator and ZERO
+ * action. That is exactly the reported #822 state — the reveal hold keeps the
+ * last pane frame while the `-CC` wire is confirmed dead — and the user was left
+ * with a frozen screen, a green pill and nothing to tap. The band is therefore
+ * driven by the CONNECTION being [ConnectionStatus.Reconnecting] (the debounced
+ * display status, #876), which is the only signal that knows the wire is down
+ * while the surface is still painting a retained frame.
  */
 internal fun shouldShowReconnectingProgressRow(
-    surfaceState: SessionSurfaceState,
+    surfaceOwnsPrimary: Boolean,
+    status: ConnectionStatus,
+): Boolean =
+    !surfaceOwnsPrimary && status is ConnectionStatus.Reconnecting
+
+/**
+ * Issue #823/#822: the gate that decides whether the session surface is WRAPPED in
+ * the pull-to-reconnect [SessionSurfaceReconnectWrapper].
+ *
+ * #823 introduced the wrapper for every non-Connected state. #822 found the missing
+ * third term the hard way, on the emulator: the wrapper's own contract is "the
+ * surface shows only a STATIC placeholder — never a live terminal", because
+ * [androidx.compose.material3.pulltorefresh.PullToRefreshBox] puts its content under
+ * an unbounded-height scroll constraint. #822 makes `sessionLive` FALSE while the
+ * reveal hold still paints the user's last pane frame, so without this gate the box
+ * mounts OVER a live `TerminalView`, that view measures to ZERO, and the retained
+ * frame the entire fix exists to preserve is destroyed — a blank pull area with a
+ * spinner where the user's session used to be.
+ *
+ * [surfaceOwnsPrimary] is exactly "the surface is showing a placeholder it owns"
+ * (the centered "Attaching…" hold, the waiting-for-panes ring, the calm-failure
+ * placeholder), so it is the precise complement of "a live frame is painted". When
+ * it is false the pull gesture is withheld, and the honest
+ * [shouldShowReconnectingProgressRow] band owns the in-place `Retry now` action
+ * instead — the two gates are complementary, so no state is ever left with neither.
+ *
+ * Extracted as a pure function (rather than inlined in the screen body) so this
+ * one-line guard is pinned by a per-PR JVM test: on-device it is reachable only
+ * through the batched within-grace socket-drop journey, and a green journey that
+ * reads the terminal EMULATOR BUFFER cannot see the collapsed view at all.
+ */
+internal fun shouldMountPullToReconnect(
+    sessionLive: Boolean,
+    canReconnect: Boolean,
     surfaceOwnsPrimary: Boolean,
 ): Boolean =
-    !surfaceOwnsPrimary && surfaceState is SessionSurfaceState.Reconnecting
+    !sessionLive && canReconnect && surfaceOwnsPrimary
+
+/**
+ * Issue #822: the breadcrumb connection pill/dot must report the CONNECTION, not
+ * the retained frame. [SessionSurfaceState.Live] maps to a green `Connected` pill
+ * ([toUiStatus]) — correct while the wire is up, a lie during the within-grace
+ * reveal hold over a confirmed-dead `-CC` channel, which is the maintainer's
+ * "nothing foretells trouble, it suddenly drops and nothing tells me" report.
+ *
+ * The override is monotone: it only ever downgrades a pill to the amber
+ * "Reconnecting" while the connection genuinely IS reconnecting, so no healthy
+ * state can be made to look dead by it. Everything else keeps the fused
+ * surface-derived pill verbatim.
+ */
+internal fun connectionPillStatus(
+    surfaceState: SessionSurfaceState,
+    status: ConnectionStatus,
+): com.pocketshell.uikit.model.ConnectionStatus =
+    if (status is ConnectionStatus.Reconnecting) {
+        com.pocketshell.uikit.model.ConnectionStatus.Connecting
+    } else {
+        surfaceState.toUiStatus()
+    }
 
 /**
  * Issue #145: stable test tags for the mid-session SSH disconnect band
@@ -453,6 +521,10 @@ internal fun TmuxTopConnectingBanner(
     // panes…" ring, AND the calm failure placeholder — so the top banner is
     // suppressed in ALL of them (never stacked over a surface loader/failure).
     surfaceOwnsPrimary: Boolean,
+    // Issue #822: the debounced display status. The reconnect band is a CONNECTION
+    // affordance, so it is gated on this rather than on the retained frame's
+    // surface state (see [shouldShowReconnectingProgressRow]).
+    status: ConnectionStatus,
     sessionName: String,
     onCancelConnect: () -> Unit,
     onRetryNow: () -> Unit,
@@ -473,14 +545,18 @@ internal fun TmuxTopConnectingBanner(
             )
         }
     }
-    // Issue #750/#1326: the recovery band. Every reconnect/reattach holds the
-    // terminal and paints the centered "Attaching…" [SwitchingLoadingPlaceholder]
-    // (the SOLE attach affordance), so the band is suppressed while held. It renders
-    // ONLY for a [SessionSurfaceState.Reconnecting] that keeps a live frame painted
-    // (surface owns nothing) — the fallback so a reconnect is never left with zero
-    // indicators. (Reconnect behaviour is untouched — this is presentation-only.)
-    if (shouldShowReconnectingProgressRow(surfaceState, surfaceOwnsPrimary)) {
-        (surfaceState as SessionSurfaceState.Reconnecting).let {
+    // Issue #750/#1326: the recovery band. Every reconnect/reattach that HOLDS the
+    // terminal paints the centered "Attaching…" [SwitchingLoadingPlaceholder] (the
+    // SOLE attach affordance), so the band stays suppressed while held.
+    //
+    // Issue #822: it renders for the live-frame reconnect — the reveal hold keeps the
+    // last pane frame painted (the surface owns nothing) while the `-CC` wire is
+    // confirmed dead. That state previously showed NOTHING at all; now it carries the
+    // honest "Reconnecting to …" line plus the in-place `Retry now` / `Cancel`
+    // actions. Both actions route to the pre-existing entrypoints — no new connection
+    // logic and no second writer on the reconnect path (D28).
+    if (shouldShowReconnectingProgressRow(surfaceOwnsPrimary, status)) {
+        (status as ConnectionStatus.Reconnecting).let {
             ReconnectingProgressRow(
                 user = it.user,
                 host = it.host,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -1091,7 +1091,7 @@ private fun TmuxSessionHeaderRegion(
                             )
                         }
                     },
-                    connectionStatus = surfaceState.toUiStatus(),
+                    connectionStatus = conn.pillStatus,
                     forwardingState = sessionForwardingState,
                     modifier = Modifier.testTag(TMUX_FULL_BREADCRUMB_TAG),
                 )
@@ -1114,7 +1114,7 @@ private fun TmuxSessionHeaderRegion(
                     onBack = onBack,
                     onMore = { overlay.moreExpanded = true },
                     moreMenu = { AnchoredTmuxMoreMenu() },
-                    connectionStatus = surfaceState.toUiStatus(),
+                    connectionStatus = conn.pillStatus,
                     forwardingState = sessionForwardingState,
                     modifier = Modifier.testTag(TMUX_COMPACT_BREADCRUMB_TAG),
                 )
@@ -1222,6 +1222,7 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
     TmuxTopConnectingBanner(
         surfaceState = surfaceState,
         surfaceOwnsPrimary = surfaceOwnsPrimary,
+        status = status,
         sessionName = sessionName,
         onCancelConnect = { viewModel.cancelConnect() },
         onRetryNow = { viewModel.reconnect() },
@@ -1333,8 +1334,16 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
             }
         }
     }
-    // Issue #823: pull-to-reconnect, scoped to non-Connected states only.
-    val pullToReconnectActive = !sessionLive && canReconnect
+    // Issue #823/#822: pull-to-reconnect, scoped to non-Connected states AND only
+    // while the surface shows a placeholder it owns. See [shouldMountPullToReconnect]
+    // for the full rationale (mounting the box over a live retained frame collapses
+    // the `TerminalView` to 0x0) — it is a pure function there so the guard is pinned
+    // by a per-PR JVM test rather than only by the batched emulator journey.
+    val pullToReconnectActive = shouldMountPullToReconnect(
+        sessionLive = sessionLive,
+        canReconnect = canReconnect,
+        surfaceOwnsPrimary = surfaceOwnsPrimary,
+    )
     val surfaceContent: @Composable () -> Unit = {
         val keepTerminalMounted = !terminalHeld &&
             !deferTerminalAttachForSwap &&

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
@@ -59,6 +59,11 @@ internal class TmuxSessionConnectionRuntime(
     val surfaceCalmFailure: Boolean,
     val surfaceCenteredLoader: Boolean,
     val surfaceOwnsPrimary: Boolean,
+    // Issue #822: the breadcrumb pill/dot payload. Derived from the connection, not
+    // only from the retained frame, so a confirmed-dead `-CC` wire under the
+    // within-grace reveal hold reads amber "Reconnecting" instead of a green
+    // "Connected" lie.
+    val pillStatus: com.pocketshell.uikit.model.ConnectionStatus,
     val sessionLive: Boolean,
 )
 
@@ -125,6 +130,7 @@ internal fun rememberTmuxSessionConnectionRuntime(
         surfaceCalmFailure = surfaceState.showsCalmFailure,
         surfaceCenteredLoader = surfaceState.showsCenteredLoader(panesEmpty),
         surfaceOwnsPrimary = surfaceState.surfaceOwnsPrimary(panesEmpty),
+        pillStatus = connectionPillStatus(surfaceState, status),
         sessionLive = sessionLive,
     )
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1610,30 +1610,28 @@ public class TmuxSessionViewModel @Inject constructor(
      * transition (the controller's core state carries opaque HostKey/SessionId, not
      * the host/port/user the view renders).
      *
-     * The two approved #685 behavior changes fall out of the controller's state for
-     * free: a recoverable drop leaves the controller in `Reattaching`/`Reconnecting`
-     * (calm) rather than the inline `Unreachable`, so the user sees a calm
-     * `Reconnecting` band, NOT the scary `Failed`/"Tap Reconnect" control-channel
-     * band; and a within-grace foreground keeps the controller `Live`, so the user
-     * sees `Connected` with no probe band. #720: a true `Unreachable` projects to a
-     * [ConnectionStatus.Failed] whose curated message + calm tappable "Tap to
-     * reconnect" band ([FailedConnectionRow]) replace the scary error text.
+     * The approved #685 behavior falls out of the controller's state for free: a
+     * recoverable drop leaves the controller in `Reattaching`/`Reconnecting` (calm)
+     * rather than the inline `Unreachable`, so the user sees a calm `Reconnecting`
+     * band, NOT the scary `Failed`/"Tap Reconnect" control-channel band. A healthy
+     * within-grace foreground whose control channel survived remains `Live`; #822
+     * requires a confirmed-dead one to stay truthfully `Reattaching` until a real
+     * replacement seed lands. #720: a true `Unreachable` projects to a
+     * [ConnectionStatus.Failed] whose curated message + calm tappable "Tap to reconnect"
+     * band ([FailedConnectionRow]) replace the scary error text.
      */
     private fun projectStatusFromController(inlineState: ConnectionState) {
-        val projected = connectionStatusForController(connectionManager.state, inlineState)
-        _connectionStatus.value =
-            if (graceEffects.isWithinGraceRecoveryActive() && projected is ConnectionStatus.Reconnecting) {
-                // Issue #1098 (item 4 / #635): the within-grace SILENT heal re-opens the
-                // dropped `-CC` (controller `Reattaching`/`Reconnecting`), but a brief
-                // background→foreground ride-through must read the CALM `Connected` — never
-                // a Reconnecting bar / Connecting overlay. Hold `Connected` (the same
-                // host/port/user payload) for the bounded heal; the heal job's completion
-                // handler clears the flag, after which the live `Live` re-projects naturally
-                // (success) or the normal calm-Reconnecting ladder shows (genuine failure).
-                ConnectionStatus.Connected(projected.host, projected.port, projected.user)
+        // #822: the reveal hold preserves the viewport, not false transport truth. A fresh
+        // carrier advances the core to Attaching; this recovery still displays Reconnecting
+        // until a real replacement seed makes the core Live. Healthy foregrounds stay Live.
+        val controllerState = connectionManager.state
+        val displayState =
+            if (graceEffects.isWithinGraceRecoveryActive() && controllerState is CoreConnectionState.Attaching) {
+                CoreConnectionState.Reattaching(controllerState.host, controllerState.targetId)
             } else {
-                projected
+                controllerState
             }
+        _connectionStatus.value = connectionStatusForController(displayState, inlineState)
     }
 
     /**
@@ -3211,6 +3209,9 @@ public class TmuxSessionViewModel @Inject constructor(
      * re-enters `connect(Reconnect)`, returns the connect [Job] (or null, no target).
      */
     private fun startReconnectForSendBody(): Job? {
+        // Issue #822: a user reconnect supersedes the bounded within-grace owner (two
+        // writers on one transport is why an in-place Retry failed and a switch did not).
+        graceEffects.retireForSupersedingOwner()
         pausedAutoReconnect = null
         autoReconnectJob?.cancel()
         autoReconnectJob = null
@@ -3680,14 +3681,13 @@ public class TmuxSessionViewModel @Inject constructor(
             return
         }
         // EPIC #687 P2 (J1/#635): SINGLE GRACE OWNER. The App-level background-grace window (#450)
-        // is the SOLE grace authority — a within-grace foreground must stay CALM even when the
-        // `-CC` socket dropped while backgrounded (WiFi→cellular / Doze). The reseed-only fast path
-        // above declines then (the dropped socket killed the warm lease), so without this branch
-        // the foreground would fall into the reconnect ladder and paint the #635 scary band.
-        // Instead we SILENTLY heal the dropped channel within grace: re-open a fresh
-        // `-CC` control client over a freshly-acquired lease and reseed, with NO band
-        // and NO overlay. The inline passive-disconnect grace clock that fired while
-        // backgrounded is disabled (see [handlePassiveClientDisconnect]), so
+        // is the SOLE grace authority. When the `-CC` socket dropped while backgrounded
+        // (WiFi→cellular / Doze), the reseed-only fast path above declines. #822 requires
+        // this single owner to report that confirmed death truthfully as Reconnecting while
+        // the reveal hold keeps the last viewport (no destructive Attaching overlay), then
+        // re-open a fresh `-CC` client over a freshly-acquired lease and reseed. The inline
+        // passive-disconnect grace clock that fired while backgrounded is disabled (see
+        // [handlePassiveClientDisconnect]), so
         // there is no competing second clock — this within-grace foreground heal is the
         // single owner of the within-grace recovery decision.
         if (resumedWithinGrace) {
@@ -3905,6 +3905,7 @@ public class TmuxSessionViewModel @Inject constructor(
             delay(passiveDisconnectGraceMs.coerceAtLeast(1L))
         }
         withinGraceSilentHealReleaseJob = job
+        graceEffects.trackRecoveryJob(job)
         job.invokeOnCompletion {
             if (withinGraceSilentHealReleaseJob === job) {
                 withinGraceSilentHealReleaseJob = null
@@ -4169,14 +4170,11 @@ public class TmuxSessionViewModel @Inject constructor(
      * EPIC #687 P2 (J1/#635): the within-grace foreground SILENT heal of a `-CC` socket
      * that DROPPED while backgrounded (WiFi→cellular handoff / Doze). This is the
      * NEW-path single-grace-owner recovery: the App-level grace window (#450) reported
-     * `resumedWithinGrace=true`, so the user must NOT see a reconnect band — but the
-     * reseed-only fast path declined because the dropped socket killed the warm lease
-     * (and the inline passive disconnect that fired while backgrounded paused the
-     * auto-reconnect + set [ConnectionStatus.Unreachable]). So there is nothing live to
-     * reseed: we re-open a fresh `-CC` control client over a freshly-acquired lease and
-     * reseed the panes, SILENTLY — NO band, NO "Attaching…"/"Connecting" overlay. The
-     * controller is moved Reattaching → Live, so the displayed status stays the calm
-     * `Connected` throughout.
+     * `resumedWithinGrace=true`, but the reseed-only fast path declined because the dropped
+     * socket killed the warm lease. There is nothing live to reseed: we report the genuine
+     * typed drop, retain the last viewport through the reveal hold, expose the actionable
+     * `Reconnecting` status, then re-open a fresh `-CC` client over a freshly-acquired lease.
+     * Only the real replacement pane seed moves the controller Reattaching → Live.
      *
      * This NEVER calls [connect] (which would raise the Connecting overlay / scary
      * band); it reuses the existing [silentlyReconnectTransportAfterPassiveDisconnect]
@@ -4244,13 +4242,13 @@ public class TmuxSessionViewModel @Inject constructor(
             "session" to target.sessionName,
             *originationDiagnosticFields,
         )
-        // Keep the displayed status CALM while we heal: the within-grace foreground is a
-        // ride-through, not a reconnect. Promote the controller back toward Live so the
-        // header indicator never shows Reconnecting/Disconnected during the heal.
-        connectionManager.observeForegroundReattachLive()
-        // Issue #1098 (item 4 / #635): the within-grace silent heal re-opens the dropped `-CC`
-        // transport (controller `Live -> Reattaching -> Live`); a hold keeps [RevealStateMachine]
-        // from projecting that Reattaching as [RevealState.Seeding] (the "Attaching…" overlay).
+        // Issue #822: entered only after the runtime is CONFIRMED DEAD. Submit that typed
+        // fact BEFORE replacement IO so the controller walks Live -> Reattaching at once;
+        // never synthesize a preserved-channel seed for a channel that did not survive. The
+        // reveal hold keeps the last viewport; status/session-live/send stay honest.
+        connectionManager.reportRemoteDrop(originationCause)
+        // Issue #1098 (item 4 / #635): a hold keeps [RevealStateMachine] from projecting the
+        // honest Reattaching state as [RevealState.Seeding] (the "Attaching…" overlay).
         // Issue #754 (re-fix): the hold is armed at the foreground DECISION POINT
         // ([armWithinGraceSilentHealHold], SINGLE OWNER) and released after the whole grace window
         // — NOT on this heal job — so the confirmed-dead ride-through survives the single-shot
@@ -4309,7 +4307,8 @@ public class TmuxSessionViewModel @Inject constructor(
         // Issue #754 (re-fix): the hold is NOT released here — that premature release (on a failed
         // single-shot heal that hands off to the loud ladder) was the reopened bug. The SINGLE
         // OWNER [armWithinGraceSilentHealHold] releases it after the whole grace window; we only
-        // re-project the status on completion so a success settles on the live `Connected`.
+        // re-project the status on completion so a real seeded success settles on `Connected`.
+        graceEffects.trackRecoveryJob(healJob)
         healJob.invokeOnCompletion {
             projectStatusFromController()
         }
@@ -8361,7 +8360,8 @@ public class TmuxSessionViewModel @Inject constructor(
             activeTarget = target
             connectingTarget = null
             refreshReconnectAvailability()
-            revealControllerLive()
+            // #822: reseedVisiblePanesForPassiveReattach feeds the real target-tagged
+            // SeedLanded edge. Never synthesize Live here if no authoritative seed landed.
             setConnectionState(
                 ConnectionState.Live(
                     target.host,
@@ -8611,7 +8611,8 @@ public class TmuxSessionViewModel @Inject constructor(
             activeTarget = target
             connectingTarget = null
             refreshReconnectAvailability()
-            revealControllerLive()
+            // #822: only the real target-tagged capture seed above may promote the
+            // confirmed-dead recovery from Reattaching back to Live.
             setConnectionState(
                 ConnectionState.Live(
                     target.host,

--- a/app/src/main/java/com/pocketshell/app/tmux/connection/GraceEffects.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/connection/GraceEffects.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.tmux.connection
 
 import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.tmux.TmuxClient
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -61,9 +62,42 @@ class GraceEffects(private val io: GraceIo) {
     var recoveryOwnership: GraceRecoveryOwnership = GraceRecoveryOwnership.Idle
         private set
 
+    /**
+     * The coroutines the CURRENT bounded owner runs (its hold-release timer and its heal
+     * retry loop), so a superseding owner can retire them instead of racing them. Reset by
+     * [beginWithinGraceRecovery] so a fresh claim never inherits the previous claim's jobs.
+     */
+    private var recoveryJobs: List<Job> = emptyList()
+
     /** Claim the bounded recovery window before either the reseed or dead-socket arm starts. */
     fun beginWithinGraceRecovery(claim: WithinGraceRecoveryClaim) {
         recoveryOwnership = GraceRecoveryOwnership.WithinGrace(claim)
+        recoveryJobs = emptyList()
+    }
+
+    /** Register a coroutine owned by the current bounded claim. */
+    fun trackRecoveryJob(job: Job) {
+        recoveryJobs = recoveryJobs + job
+    }
+
+    /**
+     * Issue #822: hand the channel over to a USER-initiated in-place reconnect.
+     *
+     * The bounded within-grace owner and the manual reconnect were two writers on the same
+     * transport, and that is why tapping the in-place action did NOT recover while a
+     * switch-away-and-back did — a switch retires this owner, a Retry did not. On device the
+     * manual reconnect acquired a healthy fresh lease and the still-running grace loop then
+     * failed its own re-dial with `proven-dead SSH lease was no longer current` every 250 ms,
+     * tearing the successor down until the session settled on `Unreachable`. Retiring the
+     * claim AND cancelling its coroutines makes the manual reconnect the single owner (D28);
+     * the hold-release job's own guarded completion handler restores the reveal projection,
+     * so the honest "Attaching…" for the user's explicit retry is not suppressed.
+     */
+    fun retireForSupersedingOwner() {
+        recoveryOwnership = GraceRecoveryOwnership.Idle
+        val jobs = recoveryJobs
+        recoveryJobs = emptyList()
+        jobs.forEach { it.cancel() }
     }
 
     /** Release only the claim whose bounded owner timer completed; stale timers are inert. */

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue1538ForegroundHealWithinGraceRideThroughTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue1538ForegroundHealWithinGraceRideThroughTest.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.tmux
 
 import com.pocketshell.app.diagnostics.installRecordingDiagnosticSink
 import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.tmux.connection.ReconnectRungFailureSource
+import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseTarget
@@ -12,6 +14,7 @@ import com.pocketshell.core.tmux.CommandResponse
 import com.pocketshell.core.tmux.TmuxClientException
 import com.pocketshell.core.tmux.TmuxDisconnectEvent
 import com.pocketshell.core.tmux.TmuxDisconnectReason
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.advanceTimeBy
@@ -307,12 +310,9 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
             val registry = ActiveTmuxClients()
             val deadSession = FakeSshSession()
             val freshSession = FakeSshSession()
-            val connector = ScriptedLeaseConnector(
-                listOf(
-                    Result.success(deadSession),
-                    Result.failure(IOException("first recovery dial is still inside the outage")),
-                    Result.success(freshSession),
-                ),
+            val connector = HeldFirstRecoveryLeaseConnector(
+                initialSession = deadSession,
+                freshSession = freshSession,
             )
             val vm = newVm(
                 registry = registry,
@@ -330,7 +330,13 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
             vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
             vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
 
-            val replacementClient = FakeTmuxClient().withSinglePane("work", "%1")
+            val replacementSeedGate = CompletableDeferred<Unit>()
+            val replacementClient = FakeTmuxClient().withSinglePane("work", "%1").apply {
+                captureWithCursorGate = replacementSeedGate
+                gatedCaptureResponse =
+                    CommandResponse(number = 4L, output = listOf("work ready"), isError = false)
+                gatedCursorReply = "0,0"
+            }
             vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
                 assertSame(freshSession, session)
                 assertEquals("work", sessionName)
@@ -370,11 +376,40 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
                 vm.onAppForegrounded(resumedWithinGrace = true)
                 runCurrent()
 
-                assertEquals("setup + failed first recovery dial", 2, connector.connectCount)
                 assertTrue(
-                    "the bounded grace owner must keep the projected status calm after the " +
-                        "first dial fails",
-                    vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+                    "the first replacement dial must be held in flight before any IO outcome",
+                    connector.firstRecoveryStarted.isCompleted,
+                )
+                assertEquals("setup + in-flight first recovery dial", 2, connector.connectCount)
+                assertTrue(
+                    "#822: confirmed-dead foreground must synchronously transition the controller " +
+                        "Live -> Reattaching before replacement IO can finish; " +
+                        "got ${vm.connectionControllerStateForTest()}",
+                    vm.connectionControllerStateForTest() is CoreConnectionState.Reattaching,
+                )
+                assertTrue(
+                    "#822: the raw/display-driving status must be Reconnecting after the first " +
+                        "failed in-place recovery, never false Connected over the dead wire; " +
+                        "got ${vm.connectionStatus.value}",
+                    vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+                )
+                assertFalse(
+                    "#822: the dropped control client must remain transport-unwritable while the " +
+                        "replacement is unavailable",
+                    vm.isSendTransportWritable(),
+                )
+
+                connector.releaseFirstRecoveryWithFailure()
+                runCurrent()
+                assertTrue(
+                    "the same typed within-grace owner must retain authority after the failed dial",
+                    vm.withinGraceRecoveryActiveForTest(),
+                )
+                assertEquals(
+                    "the within-grace owner retries in place and must not enter the numbered " +
+                        "passive/auto reconnect ladder",
+                    0,
+                    vm.reconnectRungFailedCountForTest(ReconnectRungFailureSource.PassiveGraceLoop),
                 )
                 assertTrue(
                     "the first failed dial must not hand off to the visible auto-reconnect ladder",
@@ -384,14 +419,51 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
                 advanceTimeBy(1_000L)
                 runCurrent()
                 assertEquals("the same owner must perform the paced fresh retry", 3, connector.connectCount)
-                awaitCondition {
-                    registry.clients.value[7L]?.client === replacementClient &&
-                        vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected
-                }
+                assertTrue(
+                    "the replacement must reach its authoritative capture before the seed gate is released",
+                    replacementClient.lastCaptureTimeoutMs != null,
+                )
+                assertTrue(
+                    "a fresh replacement transport without its real target-tagged seed must remain " +
+                        "non-Live (Attaching); got ${vm.connectionControllerStateForTest()}",
+                    vm.connectionControllerStateForTest() is CoreConnectionState.Attaching,
+                )
+                assertTrue(
+                    "the display must remain Reconnecting until the replacement seed lands; " +
+                        "got ${vm.connectionStatus.value}",
+                    vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+                )
+
+                replacementSeedGate.complete(Unit)
+                runCurrent()
+                assertTrue(
+                    "the released reserved capture must submit real SeedLanded and make the " +
+                        "controller Live; got ${vm.connectionControllerStateForTest()}",
+                    vm.connectionControllerStateForTest() is CoreConnectionState.Live,
+                )
+                assertTrue(
+                    "the real seed must project Connected; got ${vm.connectionStatus.value}",
+                    vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+                )
+                assertSame(
+                    "the seeded replacement must become the registered host client",
+                    replacementClient,
+                    registry.clients.value[7L]?.client,
+                )
+                assertTrue("the seeded replacement must reopen the wire", vm.isSendTransportWritable())
 
                 assertEquals("one setup + two paced recovery dials", 3, connector.connectCount)
                 assertTrue("the exact dead manager-owned lease must be closed", deadSession.closed)
                 assertFalse("the fresh replacement transport must stay live", freshSession.closed)
+                assertTrue(
+                    "only the replacement client plus its real target-tagged capture seed may " +
+                        "return the controller to Live",
+                    vm.connectionControllerStateForTest() is CoreConnectionState.Live,
+                )
+                assertTrue(
+                    "the same-session replacement must reopen the real send wire",
+                    vm.isSendTransportWritable(),
+                )
                 assertEquals(
                     "the hidden foreground owner must never enter connect()/the user-visible ladder",
                     1,
@@ -406,6 +478,91 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
                 diagnostics.close()
             }
         }
+
+    /**
+     * Issue #822 VM wiring: the user's in-place reconnect must RETIRE the bounded
+     * within-grace owner before it re-dials.
+     *
+     * This is the reported "only a switch-away-and-back recovers" mechanism: a switch
+     * supersedes the claim, a Retry did not, so the grace loop kept re-dialling the corpse
+     * and tore down the successor the manual reconnect had just acquired. Red without
+     * `graceEffects.retireForSupersedingOwner()` in `startReconnectForSendBody`.
+     */
+    @Test
+    fun manualReconnectRetiresTheWithinGraceOwner() =
+        runTest(scheduler) {
+            TMUX_CONNECT_ATTEMPTS.set(1)
+            val registry = ActiveTmuxClients()
+            val initialSession = FakeSshSession()
+            val replacementSession = FakeSshSession()
+            val connector = QueueLeaseConnector(initialSession, replacementSession)
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(
+                    connector = connector,
+                    scope = this,
+                    idleTtlMillis = 60_000L,
+                ),
+            )
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = 60_000L,
+                silentReattachTimeoutMs = 100L,
+            )
+            vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+            vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+            vm.setTmuxClientFactoryForTest { _, _, _ -> FakeTmuxClient().withSinglePane("work", "%1") }
+
+            val droppedCcClient = FakeTmuxClient()
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = droppedCcClient,
+                session = initialSession,
+            )
+            vm.setActiveLeaseRefWarmForTest()
+            runCurrent()
+
+            vm.setProcessForegroundForClearedForTest(false)
+            initialSession.markDisconnected()
+            droppedCcClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "device_background",
+                    intent = "unknown",
+                ),
+            )
+            runCurrent()
+            vm.setProcessForegroundForClearedForTest(true)
+            vm.onAppForegrounded(resumedWithinGrace = true)
+            runCurrent()
+
+            assertTrue(
+                "precondition: the confirmed-dead within-grace foreground owns the bounded recovery",
+                vm.withinGraceRecoveryActiveForTest(),
+            )
+
+            assertTrue("the in-place action must reach the manual reconnect entrypoint", vm.reconnect())
+            runCurrent()
+
+            assertFalse(
+                "#822: the user's in-place reconnect must retire the bounded within-grace owner " +
+                    "— leaving it running is why only a switch-away-and-back recovered",
+                vm.withinGraceRecoveryActiveForTest(),
+            )
+        }
+
+    @Test
+    fun warmRecoveryWithoutAuthoritativeSeedMustNotPromoteLive() =
+        assertUnseededRecoveryStaysReattaching(freshTransport = false)
+
+    @Test
+    fun freshRecoveryWithoutAuthoritativeSeedMustNotPromoteLive() =
+        assertUnseededRecoveryStaysReattaching(freshTransport = true)
 
     /**
      * Issue #1954 / #1653 interop: once the exact corpse has been invalidated and a fresh,
@@ -602,17 +759,35 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
         }
     }
 
-    private class ScriptedLeaseConnector(
-        private val results: List<Result<SshSession>>,
+    /**
+     * Holds the first replacement dial before it can report success/failure. This makes the
+     * foreground edge itself observable independently of all later recovery outcomes: without
+     * #822's typed drop, the controller is still falsely Live while this dial is suspended.
+     */
+    private class HeldFirstRecoveryLeaseConnector(
+        private val initialSession: SshSession,
+        private val freshSession: SshSession,
     ) : SshLeaseConnector {
+        val firstRecoveryStarted = CompletableDeferred<Unit>()
+        private val releaseFirstRecovery = CompletableDeferred<Unit>()
+
         var connectCount: Int = 0
             private set
 
-        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
-            val next = results.getOrNull(connectCount)
-                ?: error("unexpected lease connect $connectCount for ${target.leaseKey}")
-            connectCount += 1
-            return next
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> =
+            when (val attempt = connectCount++) {
+                0 -> Result.success(initialSession)
+                1 -> {
+                    firstRecoveryStarted.complete(Unit)
+                    releaseFirstRecovery.await()
+                    Result.failure(IOException("first recovery dial is still inside the outage"))
+                }
+                2 -> Result.success(freshSession)
+                else -> error("unexpected lease connect $attempt for ${target.leaseKey}")
+            }
+
+        fun releaseFirstRecoveryWithFailure() {
+            releaseFirstRecovery.complete(Unit)
         }
     }
 
@@ -665,5 +840,126 @@ class Issue1538ForegroundHealWithinGraceRideThroughTest : TmuxSessionViewModelTe
         override fun close() {
             closed = true
         }
+    }
+
+    /**
+     * #822 selective behavior proof for the two passive-success arms. A replacement may be
+     * attached and healthy while every bounded capture is still empty; that is not a seed.
+     * The last viewport remains held, but the controller/status cannot become live until a
+     * later watchdog capture actually feeds target-tagged SeedLanded. The replacement wire
+     * itself is already healthy and therefore writable under #1686's transport-truth rule.
+     */
+    private fun assertUnseededRecoveryStaysReattaching(freshTransport: Boolean) =
+        runTest(scheduler) {
+            TMUX_CONNECT_ATTEMPTS.set(1)
+            val registry = ActiveTmuxClients()
+            val initialSession = FakeSshSession()
+            val replacementSession = FakeSshSession()
+            val connector =
+                if (freshTransport) {
+                    QueueLeaseConnector(initialSession, replacementSession)
+                } else {
+                    QueueLeaseConnector(initialSession)
+                }
+            val vm = newVm(
+                registry = registry,
+                sshLeaseManager = testLeaseManager(
+                    connector = connector,
+                    scope = this,
+                    idleTtlMillis = 60_000L,
+                ),
+            )
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = 10_000L,
+                silentReattachTimeoutMs = 100L,
+            )
+            vm.setStaleRenderWatchdogAutoArmEnabledForTest(false)
+            vm.setConnectedBlankWatchdogAutoArmEnabledForTest(false)
+
+            val replacementClient = FakeTmuxClient().withSinglePaneButNoSeed("work", "%1")
+            var factorySession: SshSession? = null
+            vm.setTmuxClientFactoryForTest { session, sessionName, _ ->
+                assertEquals("work", sessionName)
+                factorySession = session
+                replacementClient
+            }
+            val droppedCcClient = FakeTmuxClient()
+            vm.replaceClientForTest(
+                hostId = 7L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = droppedCcClient,
+                session = initialSession,
+            )
+            vm.setActiveLeaseRefWarmForTest()
+            runCurrent()
+            assertEquals("one setup lease", 1, connector.connectCount)
+            if (freshTransport) initialSession.markDisconnected()
+
+            vm.setProcessForegroundForClearedForTest(false)
+            droppedCcClient.markDisconnectedForTest(
+                TmuxDisconnectEvent(
+                    reason = TmuxDisconnectReason.ReaderEof,
+                    source = "device_background",
+                    intent = "unknown",
+                ),
+            )
+            runCurrent()
+            vm.setProcessForegroundForClearedForTest(true)
+            vm.onAppForegrounded(resumedWithinGrace = true)
+            runCurrent()
+            advanceTimeBy(6_000L)
+            runCurrent()
+            awaitCondition { registry.clients.value[7L]?.client === replacementClient }
+
+            assertSame(
+                if (freshTransport) replacementSession else initialSession,
+                factorySession,
+            )
+            assertEquals(
+                if (freshTransport) 2 else 1,
+                connector.connectCount,
+            )
+            assertTrue(
+                "${if (freshTransport) "fresh" else "warm"} recovery without a real seed " +
+                    "must remain in its exact typed non-Live stage; " +
+                    "got ${vm.connectionControllerStateForTest()}",
+                if (freshTransport) {
+                    // A fresh lease emits TransportLive: carrier up, pane still unseeded.
+                    vm.connectionControllerStateForTest() is CoreConnectionState.Attaching
+                } else {
+                    // Reusing the already-up transport emits no new TransportLive edge.
+                    vm.connectionControllerStateForTest() is CoreConnectionState.Reattaching
+                },
+            )
+            assertTrue(
+                "an unseeded replacement must remain visibly Reconnecting; " +
+                    "got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
+            )
+            assertTrue(
+                "the healthy replacement wire remains physically writable even while its " +
+                    "controller reveal awaits the first real seed",
+                vm.isSendTransportWritable(),
+            )
+        }
+
+    private fun FakeTmuxClient.withSinglePaneButNoSeed(
+        sessionName: String,
+        paneId: String,
+    ): FakeTmuxClient = apply {
+        responses.addLast(
+            CommandResponse(
+                number = 1L,
+                output = listOf("$paneId\t@0\t\$0\t$sessionName\t$sessionName\t0"),
+                isError = false,
+            ),
+        )
+        defaultCaptureResponse =
+            CommandResponse(number = 2L, output = emptyList(), isError = false)
     }
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue754ReseedSilentHealHoldTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue754ReseedSilentHealHoldTest.kt
@@ -46,10 +46,11 @@ import java.io.InputStream
  *
  * ## The fix these tests pin
  *
- * The reseed path now arms the silent-heal reveal/status hold for the bounded grace window
+ * The reseed path now arms the silent-heal reveal hold for the bounded grace window
  * (mirroring the heal path). While armed, a Reattaching projection HOLDS the current live
- * frame (no overlay) and the status stays the calm `Connected`. The hold is released after
- * the grace window so a genuine BEYOND-grace drop still surfaces its reconnect band.
+ * frame (no overlay), while the status truthfully reports `Reconnecting` over a confirmed-dead
+ * transport. The hold is released after the grace window so a genuine BEYOND-grace drop also
+ * surfaces the reconnect/loading reveal.
  *
  * ## Deterministic red→green (the #780 synthetic-injection model, per-PR gated JVM proof)
  *
@@ -175,8 +176,8 @@ class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
 
     // -----------------------------------------------------------------------
     // (1) LOAD-BEARING red→green: a drop DURING the within-grace reseed window must be
-    //     ridden through silently — NO RevealState.Seeding (the "Attaching…" overlay), and
-    //     the status stays the calm Connected. RED on base (Seeding + Reconnecting).
+    //     ridden through without replacing the last viewport — NO RevealState.Seeding (the
+    //     "Attaching…" overlay), while status honestly reports Reconnecting.
     // -----------------------------------------------------------------------
 
     @Test
@@ -231,11 +232,12 @@ class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
                     "${vm.revealState.value}",
                 vm.revealState.value is RevealState.Live,
             )
-            // The status hold keeps the calm Connected (no Reconnecting bar) during the ride-through.
+            // #822: reveal continuity must not falsify transport state. The held frame remains
+            // visible above, while the confirmed-dead wire reports Reconnecting.
             assertTrue(
-                "the within-grace ride-through keeps the calm Connected status (no Reconnecting " +
-                    "band); got ${vm.connectionStatus.value}",
-                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+                "the within-grace ride-through must report Reconnecting over the confirmed-dead " +
+                    "wire while retaining the last live reveal; got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
             )
         } finally {
             diagnostics.close()
@@ -397,11 +399,12 @@ class Issue754ReseedSilentHealHoldTest : TmuxSessionViewModelTestBase() {
                     "${vm.revealState.value}",
                 vm.revealState.value is RevealState.Live,
             )
-            // The status hold keeps the calm Connected (no Reconnecting bar) across the window.
+            // #822: the reveal hold is visual continuity only; a confirmed-dead foreground wire
+            // must report Reconnecting throughout the bounded in-place recovery.
             assertTrue(
-                "the confirmed-dead within-grace ride-through keeps the calm Connected status (no " +
-                    "Reconnecting band); got ${vm.connectionStatus.value}",
-                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected,
+                "the confirmed-dead within-grace ride-through must truthfully report Reconnecting " +
+                    "while retaining the last live reveal; got ${vm.connectionStatus.value}",
+                vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Reconnecting,
             )
         } finally {
             diagnostics.close()

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue822HonestReconnectChromeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue822HonestReconnectChromeTest.kt
@@ -1,0 +1,281 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.connection.ConnectionPhase
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.SessionSurfaceState
+import com.pocketshell.core.connection.sessionSurfaceState
+import com.pocketshell.core.connection.surfaceOwnsPrimary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #822 — the chrome half of "honest in-place recovery after a within-grace socket
+ * drop".
+ *
+ * ## The reported bug this pins
+ *
+ * The maintainer's `-CC` socket died mid-session; the within-grace reveal hold kept the
+ * last pane frame painted, and the SCREEN read that retained frame as connection truth:
+ * a green "Connected" dot, no band, no in-place action. Nothing told him the wire was
+ * gone until a send wedged, and the only recovery was switching to another session and
+ * back.
+ *
+ * Two chrome defects made that state unrecoverable in place, and both are gate-wired here:
+ *
+ *  1. **The pill lied.** [SessionSurfaceState.Live] maps to a green `Connected` pill
+ *     ([toUiStatus]); with the reveal hold retaining the frame over a dead wire that is a
+ *     false green. [connectionPillStatus] now follows the CONNECTION.
+ *  2. **The reconnect band was structurally unreachable, so there was nothing to tap.**
+ *     The old gate was `!surfaceOwnsPrimary && surfaceState is SessionSurfaceState.Reconnecting`
+ *     — a contradiction, because a `SessionSurfaceState.Reconnecting` is by construction a
+ *     HELD surface and a held surface always owns the primary indicator. The band's own
+ *     KDoc promised to cover "a Reconnecting that keeps a live frame painted"; that case
+ *     could never evaluate true. [shouldShowReconnectingProgressRow] is now gated on the
+ *     connection.
+ *  3. **Making the wire honestly not-live then DESTROYED the retained frame.** Once
+ *     `sessionLive` goes false under the reveal hold, the #823 `PullToRefreshBox` mounts
+ *     over the live `TerminalView` and its `verticalScroll` collapses the terminal to
+ *     0x0 — the user loses the very frame this issue exists to preserve.
+ *     [shouldMountPullToReconnect] withholds the box while a live frame is painted.
+ *
+ * The #750 half of the gate is unchanged and re-pinned below: while the surface owns the
+ * centered "Attaching…" hold, the band stays suppressed for EVERY status, so a reconnect
+ * can still never paint two loaders.
+ */
+class Issue822HonestReconnectChromeTest {
+
+    private val sid = SessionId("1/work")
+
+    private val reconnecting = TmuxSessionViewModel.ConnectionStatus.Reconnecting(
+        host = "h",
+        port = 22,
+        user = "u",
+        attempt = 1,
+        maxAttempts = 3,
+        retryDelayMs = 0L,
+        reason = "Reconnecting…",
+    )
+    private val connected = TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u")
+    private val connecting = TmuxSessionViewModel.ConnectionStatus.Connecting("h", 22, "u")
+
+    private fun liveFrame(): SessionSurfaceState =
+        sessionSurfaceState(
+            RevealState.Live(sid, "work", panes = emptyList()),
+            ConnectionPhase.Reconnecting("h", 22, "u", 1, 3, 0L),
+            sid,
+        )
+
+    private fun heldFrame(): SessionSurfaceState =
+        sessionSurfaceState(
+            RevealState.Seeding(sid, "work"),
+            ConnectionPhase.Reconnecting("h", 22, "u", 1, 3, 0L),
+            sid,
+        )
+
+    private fun calmFailureFrame(): SessionSurfaceState =
+        sessionSurfaceState(
+            RevealState.Error(sid, "work", retrying = false),
+            ConnectionPhase.Failed,
+            sid,
+        )
+
+    private fun goneFrame(): SessionSurfaceState =
+        sessionSurfaceState(RevealState.Gone(sid, "work"), ConnectionPhase.Failed, sid)
+
+    @Test
+    fun retainedLiveFrameOverADeadWireReadsTheHonestReconnectingPill() {
+        val state = liveFrame()
+        assertTrue("precondition: the reveal hold retains the live frame", state is SessionSurfaceState.Live)
+        assertEquals(
+            "the retained frame alone still maps to the green Connected pill — that is the lie",
+            com.pocketshell.uikit.model.ConnectionStatus.Connected,
+            state.toUiStatus(),
+        )
+        assertEquals(
+            "#822: the pill/dot must follow the CONNECTION, so a confirmed-dead wire under " +
+                "the reveal hold reads the amber Reconnecting",
+            com.pocketshell.uikit.model.ConnectionStatus.Connecting,
+            connectionPillStatus(state, reconnecting),
+        )
+    }
+
+    @Test
+    fun healthyStatesKeepTheirSurfaceDerivedPill() {
+        // The override is MONOTONE: it only downgrades while the connection genuinely is
+        // reconnecting, so no healthy state can be made to look dead by it.
+        val live = liveFrame()
+        assertEquals(
+            com.pocketshell.uikit.model.ConnectionStatus.Connected,
+            connectionPillStatus(live, connected),
+        )
+        assertEquals(
+            com.pocketshell.uikit.model.ConnectionStatus.Connected,
+            connectionPillStatus(live, connecting),
+        )
+        val held = heldFrame()
+        assertEquals(
+            "a held reconnect keeps its own amber pill",
+            held.toUiStatus(),
+            connectionPillStatus(held, reconnecting),
+        )
+    }
+
+    @Test
+    fun retainedLiveFrameOverADeadWireOffersTheInPlaceRetryBand() {
+        val state = liveFrame()
+        val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
+        assertFalse("precondition: a retained live frame owns no loader", ownsPrimary)
+        assertTrue(
+            "#822: the retained frame must carry the honest Reconnecting band, whose " +
+                "`Retry now` is the in-place action the switch-away dance replaced",
+            shouldShowReconnectingProgressRow(ownsPrimary, reconnecting),
+        )
+        assertTrue(
+            "#822: the surface `Reconnect` affordance also stays available over the frame",
+            surfaceReconnectButtonVisible(state),
+        )
+    }
+
+    @Test
+    fun healthyLiveFrameShowsNoReconnectBand() {
+        val state = liveFrame()
+        val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
+        listOf(connected, connecting, TmuxSessionViewModel.ConnectionStatus.Idle).forEach { status ->
+            assertFalse(
+                "no reconnect band for status=$status",
+                shouldShowReconnectingProgressRow(ownsPrimary, status),
+            )
+        }
+    }
+
+    @Test
+    fun heldSurfaceStillSuppressesTheBandForEveryStatus() {
+        // The #750 single-indicator half, unchanged: the centered "Attaching…" hold is the
+        // SOLE loader, so no status may raise the top band on top of it.
+        val held = heldFrame()
+        val ownsPrimary = held.surfaceOwnsPrimary(panesEmpty = false)
+        assertTrue("precondition: a held surface owns the primary indicator", ownsPrimary)
+        listOf(reconnecting, connected, connecting, TmuxSessionViewModel.ConnectionStatus.Idle)
+            .forEach { status ->
+                assertFalse(
+                    "held surface must suppress the band for status=$status",
+                    shouldShowReconnectingProgressRow(ownsPrimary, status),
+                )
+            }
+    }
+
+    // ------------------------------------------------------------------
+    // #822 round 2 — the pull-to-reconnect mount gate.
+    //
+    // The on-device defect this pins (found by running the journey on the emulator):
+    // with `sessionLive` false while the reveal hold still paints the user's last pane
+    // frame, mounting the #823 `PullToRefreshBox` wraps the LIVE `TerminalView` in a
+    // `verticalScroll`. Under that unbounded height constraint the terminal measures to
+    // ZERO and the retained frame is destroyed — an empty pull area with a spinner where
+    // the user's session was. The terminal EMULATOR BUFFER is untouched by that collapse,
+    // which is precisely why a journey assertion reading `transcriptText` stayed green
+    // while the screen was blank. These tests constrain the guard directly.
+    // ------------------------------------------------------------------
+
+    @Test
+    fun retainedLiveFrameOverADeadWireMustNotMountThePullToReconnectBox() {
+        val state = liveFrame()
+        val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
+        assertFalse("precondition: a retained live frame owns no placeholder", ownsPrimary)
+        assertFalse(
+            "#822: the pull box must NOT wrap a live retained TerminalView — its " +
+                "verticalScroll collapses the terminal to 0x0 and destroys the very frame " +
+                "the within-grace hold exists to preserve",
+            shouldMountPullToReconnect(
+                sessionLive = false,
+                canReconnect = true,
+                surfaceOwnsPrimary = ownsPrimary,
+            ),
+        )
+    }
+
+    @Test
+    fun withholdingThePullBoxStillLeavesTheRetainedFrameAnInPlaceAction() {
+        // The two gates are complementary: exactly one of them owns the recovery
+        // affordance in every non-Connected state, so withholding the pull gesture over a
+        // retained frame can never leave the user with nothing to tap (the #822 report).
+        val state = liveFrame()
+        val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
+        val pullBox = shouldMountPullToReconnect(
+            sessionLive = false,
+            canReconnect = true,
+            surfaceOwnsPrimary = ownsPrimary,
+        )
+        val band = shouldShowReconnectingProgressRow(ownsPrimary, reconnecting)
+        assertFalse("the pull box stays off over a live retained frame", pullBox)
+        assertTrue("...and the honest Retry-now band takes over the action", band)
+        assertTrue(
+            "#822 invariant: a dropped wire always has exactly one recovery affordance",
+            pullBox != band,
+        )
+    }
+
+    @Test
+    fun placeholderSurfacesStillMountThePullToReconnectBox() {
+        // Class coverage: every state the #823 wrapper was actually written for — a
+        // STATIC placeholder, never a live terminal — keeps the pull gesture.
+        val placeholders = mapOf(
+            "held Attaching hold" to heldFrame().surfaceOwnsPrimary(panesEmpty = false),
+            "live reveal with no panes yet (waiting ring)" to
+                liveFrame().surfaceOwnsPrimary(panesEmpty = true),
+            "settled calm failure" to calmFailureFrame().surfaceOwnsPrimary(panesEmpty = false),
+            "session gone elsewhere" to goneFrame().surfaceOwnsPrimary(panesEmpty = false),
+        )
+        placeholders.forEach { (label, ownsPrimary) ->
+            assertTrue("precondition: $label owns the primary indicator", ownsPrimary)
+            assertTrue(
+                "#823: $label shows only a placeholder, so pull-to-reconnect stays mounted",
+                shouldMountPullToReconnect(
+                    sessionLive = false,
+                    canReconnect = true,
+                    surfaceOwnsPrimary = ownsPrimary,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun aHealthyOrUnreconnectableSessionNeverMountsThePullToReconnectBox() {
+        // The other two terms of the gate, unchanged by #822 but pinned so a future
+        // rewrite cannot silently drop them either.
+        listOf(true, false).forEach { ownsPrimary ->
+            assertFalse(
+                "a live session is not reconnectable by pull (ownsPrimary=$ownsPrimary)",
+                shouldMountPullToReconnect(
+                    sessionLive = true,
+                    canReconnect = true,
+                    surfaceOwnsPrimary = ownsPrimary,
+                ),
+            )
+            assertFalse(
+                "no reconnect capability means no pull affordance (ownsPrimary=$ownsPrimary)",
+                shouldMountPullToReconnect(
+                    sessionLive = false,
+                    canReconnect = false,
+                    surfaceOwnsPrimary = ownsPrimary,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun emptyPaneSurfaceKeepsItsOwnLoaderAndSuppressesTheBand() {
+        // Class coverage (#1322): a live reveal with NO panes yet owns the "waiting for
+        // tmux panes…" ring, so even a Reconnecting connection must not stack the band.
+        val state = liveFrame()
+        val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = true)
+        assertTrue("precondition: an empty-pane surface owns its ring", ownsPrimary)
+        assertFalse(
+            "the waiting ring stays the sole indicator",
+            shouldShowReconnectingProgressRow(ownsPrimary, reconnecting),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue822ManualReconnectRetiresGraceOwnerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue822ManualReconnectRetiresGraceOwnerTest.kt
@@ -1,0 +1,109 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.tmux.connection.GraceClientId
+import com.pocketshell.app.tmux.connection.GraceEffects
+import com.pocketshell.app.tmux.connection.GraceRecoveryOwnership
+import com.pocketshell.app.tmux.connection.WithinGraceRecoveryClaim
+import com.pocketshell.core.connection.SessionId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #822 — the in-place Retry must be the SINGLE owner of the transport.
+ *
+ * ## The reported bug this pins
+ *
+ * "The current session does not reconnect in place; switching to a different session and
+ * back finally restores it." The reason a SWITCH worked and a RETRY did not is ownership:
+ * a switch supersedes the bounded within-grace recovery claim, a manual reconnect did not.
+ * So the user's Retry acquired a healthy fresh lease while the still-running grace loop kept
+ * re-dialling the corpse — observed on the emulator as
+ * `proven-dead SSH lease was no longer current` every 250 ms, tearing the successor down
+ * until the session settled on `Unreachable`. Two writers on one transport (D28).
+ *
+ * [GraceEffects.retireForSupersedingOwner] is the hand-over, and
+ * `TmuxSessionViewModel.startReconnectForSendBody` calls it before re-entering `connect()`.
+ * The VM-level wiring of that call on the exact reported path is pinned by
+ * [Issue1538ForegroundHealWithinGraceRideThroughTest.manualReconnectRetiresTheWithinGraceOwner].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue822ManualReconnectRetiresGraceOwnerTest : TmuxSessionViewModelTestBase() {
+
+    private val claim = WithinGraceRecoveryClaim(SessionId("7/work"), GraceClientId(1))
+
+    private fun graceEffects(): GraceEffects =
+        GraceEffects(
+            object : GraceEffects.GraceIo {
+                override fun launchBackgroundDetachTeardown() = Unit
+                override fun launchForegroundReattachReseed() = Unit
+                override fun launchForegroundHealWithinGrace() = Unit
+            },
+        )
+
+    @Test
+    fun retirementEndsTheClaimAndCancelsItsCoroutines() = runTest(scheduler) {
+        val effects = graceEffects()
+        effects.beginWithinGraceRecovery(claim)
+        val tracked = Job()
+        effects.trackRecoveryJob(tracked)
+
+        assertTrue("precondition: the bounded owner holds the claim", effects.isWithinGraceRecoveryActive())
+        assertFalse("precondition: the owner's coroutine is live", tracked.isCancelled)
+
+        effects.retireForSupersedingOwner()
+
+        assertEquals(
+            "#822: the superseding manual reconnect must end the bounded claim",
+            GraceRecoveryOwnership.Idle,
+            effects.recoveryOwnership,
+        )
+        assertTrue(
+            "#822: the retired owner's coroutines must be cancelled, not left racing the " +
+                "manual reconnect's fresh transport",
+            tracked.isCancelled,
+        )
+    }
+
+    @Test
+    fun retirementStopsTheInFlightRecoveryRetryLoop() = runTest(scheduler) {
+        val effects = graceEffects()
+        effects.beginWithinGraceRecovery(claim)
+        var attempts = 0
+        val loop = launch {
+            effects.retryWithinGraceRecovery(
+                claim = claim,
+                timeoutMs = 60_000L,
+                retryDelayMs = 250L,
+            ) {
+                attempts += 1
+                false
+            }
+        }
+        runCurrent()
+        advanceTimeBy(600L)
+        runCurrent()
+        val attemptsBeforeRetirement = attempts
+        assertTrue("precondition: the grace loop is re-dialling", attemptsBeforeRetirement >= 2)
+
+        effects.retireForSupersedingOwner()
+        advanceTimeBy(5_000L)
+        runCurrent()
+
+        assertEquals(
+            "#822: no further grace-loop re-dial may run after the manual reconnect takes " +
+                "over — every extra attempt is what evicted the successor's fresh lease",
+            attemptsBeforeRetirement,
+            attempts,
+        )
+        assertTrue("the retired loop must complete", loop.isCompleted)
+    }
+
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -2104,7 +2104,7 @@ class TmuxSessionScreenTest {
         assertEquals(com.pocketshell.uikit.model.ConnectionStatus.Connecting, state.toUiStatus())
         // Both top banners suppressed while the surface owns the primary indicator.
         val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
-        assertFalse(shouldShowReconnectingProgressRow(state, ownsPrimary))
+        assertFalse(shouldShowReconnectingProgressRow(ownsPrimary, reconnectingStatus))
         assertFalse(shouldShowConnectingProgressOverlay(state, ownsPrimary))
     }
 
@@ -2130,7 +2130,9 @@ class TmuxSessionScreenTest {
             )
             val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty = false)
             assertFalse("$label: top Connecting overlay suppressed", shouldShowConnectingProgressOverlay(state, ownsPrimary))
-            assertFalse("$label: top Reconnecting band suppressed", shouldShowReconnectingProgressRow(state, ownsPrimary))
+            // #822: even a Reconnecting CONNECTION cannot raise the band while the
+            // surface owns the centered hold — the #750 single-indicator half.
+            assertFalse("$label: top Reconnecting band suppressed", shouldShowReconnectingProgressRow(ownsPrimary, reconnectingStatus))
             // No settled failure surface for an in-progress hold.
             assertFalse("$label: not a calm failure", state.showsCalmFailure)
         }
@@ -2138,11 +2140,15 @@ class TmuxSessionScreenTest {
 
     @Test
     fun fusion_liveReveal_dominates_regardlessOfPhase_withinGraceSuppression() {
-        // AC-4 (#685/#1098): a LIVE reveal is the surface authority — even if the
-        // connection phase is still Reconnecting (a within-grace silent heal), the
-        // fused state stays Live: terminal shown, GREEN pill, NO overlay/band. The
-        // load-bearing green is the SUPPRESSION (G6). Red if a phase read leaked
-        // through and flipped the surface/pill during the heal.
+        // AC-4 (#685/#1098): a LIVE reveal is the SURFACE authority — even if the
+        // connection phase is still Reconnecting (a within-grace heal), the fused
+        // state stays Live: the retained terminal frame is shown, no centered
+        // "Attaching…" hold. Red if a phase read leaked through and replaced the
+        // user's last frame with a loader during the heal.
+        //
+        // The pill/band half of this contract moved to Issue822HonestReconnectChromeTest:
+        // #822 made a live reveal authority over the PIXELS only, never over transport
+        // truth, so a retained frame no longer implies a green Connected pill.
         listOf(
             reconnectingStatus,
             connectingStatus,
@@ -2151,8 +2157,8 @@ class TmuxSessionScreenTest {
             val state = fuse(RevealState.Live(sid, "work", panes = emptyList()), phaseStatus)
             assertTrue("live reveal dominates phase=$phaseStatus", state is SessionSurfaceState.Live)
             assertFalse("terminal shown (no hold)", state.terminalHeld)
-            assertEquals("green Connected pill", com.pocketshell.uikit.model.ConnectionStatus.Connected, state.toUiStatus())
             assertEquals("no loading surface over a live frame", PrimaryLoadingSurface.None, primaryLoadingSurface(state, panesEmpty = false))
+            assertFalse("live frame never owns the primary indicator", state.surfaceOwnsPrimary(panesEmpty = false))
         }
     }
 
@@ -2201,11 +2207,29 @@ class TmuxSessionScreenTest {
                     val ownsPrimary = state.surfaceOwnsPrimary(panesEmpty)
                     // The two top banners are mutually exclusive AND suppressed while
                     // the surface owns the primary indicator.
-                    assertFalse(
-                        "reveal=$reveal phase=$phase: both top banners at once",
-                        shouldShowConnectingProgressOverlay(state, ownsPrimary) &&
-                            shouldShowReconnectingProgressRow(state, ownsPrimary),
-                    )
+                    listOf(
+                        connectingStatus,
+                        reconnectingStatus,
+                        TmuxSessionViewModel.ConnectionStatus.Connected("h", 22, "u"),
+                        TmuxSessionViewModel.ConnectionStatus.Idle,
+                    ).forEach { bannerStatus ->
+                        assertFalse(
+                            "reveal=$reveal phase=$phase status=$bannerStatus: " +
+                                "both top banners at once",
+                            shouldShowConnectingProgressOverlay(state, ownsPrimary) &&
+                                shouldShowReconnectingProgressRow(ownsPrimary, bannerStatus),
+                        )
+                        // #822: the band is a CONNECTION affordance, but the #750
+                        // single-indicator half still binds — a surface that owns the
+                        // primary indicator suppresses it for every status.
+                        if (ownsPrimary) {
+                            assertFalse(
+                                "reveal=$reveal phase=$phase status=$bannerStatus: " +
+                                    "band raised over a surface-owned indicator",
+                                shouldShowReconnectingProgressRow(ownsPrimary, bannerStatus),
+                            )
+                        }
+                    }
                     // Pill agrees with the surface: a calm-failure surface ALWAYS reads
                     // Error; a live surface NEVER reads Error.
                     if (state.showsCalmFailure) {


### PR DESCRIPTION
Reopened connection-core recurrence (D28/D31). Reviewer **APPROVED** after two rounds — https://github.com/alexeygrigorev/pocketshell/issues/822#issuecomment-5287904805

## What the maintainer was hitting

After a within-grace socket drop, an in-place Retry could not recover; the only working recovery was to switch to another session, let it connect, and switch back. Two structural defects, both found only by **running** the connected journey rather than trusting the ViewModel fix:

1. **The Reconnecting band was structurally unreachable.** Its gate read `!surfaceOwnsPrimary && surfaceState is Reconnecting` — but a `Reconnecting` surface is by construction held, and a held surface always owns the primary indicator. The honest state therefore had no indicator and no action at all.
2. **`startReconnectForSendBody` cancelled the auto ladder but not the bounded within-grace owner.** Retry took a fresh lease while the grace loop kept failing its own re-dial (`proven-dead SSH lease was no longer current`, every 250 ms) until the session settled on `Unreachable`. A session **switch** retires that claim; a **Retry** did not. That asymmetry is exactly why the workaround worked and Retry didn't.

A third defect was caught on-device: mounting the `PullToRefreshBox` over a live terminal collapsed the `TerminalView` to 0×0, destroying the retained frame the fix exists to preserve.

## The proof for that third defect was vacuous — fixing it is most of round 2

"Retained viewport" was asserted via `visibleTerminalText()`, which reads the transcript **buffer**, not the rendered view; and `captureViewport` **silently early-returned** on a 0×0 view, so no authoritative viewport artifact was produced and nothing noticed its absence. The reviewer removed the guard, watched the frame be destroyed on screen, and **the test still passed rc=0**.

Now: `shouldMountPullToReconnect` is extracted as a JVM-testable helper; `assertRetainedFrameIsRendered` checks measured / shown / on-screen / non-uniform-pixels; `captureViewport` **hard-fails**. The same mutation now yields **rc=1** with `measured=1070x0 onScreenRect=0x0 drawnFrameIsUniformBlank=true`, and neutralizing only `view.draw()` reddens at full size (`1070x1613`) — so each leg bites independently and none is satisfiable by buffer state.

A prepared test asserting **source text, including its own file's text**, was **cut** rather than kept — it would redden on a rename and green on a behaviour break. Its coverage moved to behavioural assertions the reviewer killed with their own mutations.

## Verification

**Reviewer (this run):** acceptance mutation now caught on both surfaces — JVM selective (2 new pull-box tests red, 133 siblings green) and emulator journey rc=1 with the destroyed-screen artifact; blank-but-sized probe RED; `captureViewport` observed throwing; full gate 603/603, 12,464 tests, 0 failed/skipped; adjacency `BackgroundGraceReconnectE2eTest` 3/3; tree md5-verified 3× after mutation work.

**Orchestrator gate on this branch:** `scripts/full-jvm-gate.py` rc=0, **603/603 tasks executed, 12,464 tests, 0 failures**, no cached test-execution task (the only `UP-TO-DATE` hits are `:shared:test-support` lifecycle tasks and its no-`src/test` aggregate). New classes named in fresh XML: `Issue822HonestReconnectChromeTest` tests=10, `Issue822ManualReconnectRetiresGraceOwnerTest` tests=2, both 0 failures / 0 skipped. Guards all exit 0 including `check-connection-vm-ratchet` (**no growth** — the VM is 64 bytes under baseline) and `select-test-areas-selftest` (57 passed). `:app:compileDebugAndroidTestKotlin` clean. File set is exactly the 13 entries both agents verified, with the two new test files copied explicitly (a plain `git diff` omits untracked files — merging the fix without its tests is the D33 failure this guards against). Changed paths confirmed disjoint from everything merged tonight.

## Follow-ups filed, not fixed here

- **#2135** — 48 other `androidTest` classes carry the same silent-skip capture, so the artifact goes missing exactly when a run is broken.
- **#2130** — the breadcrumb pill truncates `Reconnecting` to `Reco`, undercutting the honest state this PR surfaces.
- **#2131** — output produced during a `-CC` re-attach window is never replayed into the viewport (silent gap on the recovery path).

Unblocks **#766**, which is held pending this merge because it owns the same `TmuxSessionViewModel.kt`.

Closes #822