### PR TITLE
release: v0.4.44 (versionCode 91)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 90
-        versionName = "0.4.43"
+        versionCode = 91
+        versionName = "0.4.44"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.43"
+version = "0.4.44"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump only. Bumps `app/build.gradle.kts` `versionName`/`versionCode` **and** `tools/pocketshell/pyproject.toml` in lockstep, as the #948 coupling guard requires.

## Validated base

`50f39a9d`, green on the batched `main` run [31759714621](https://github.com/alexeygrigorev/pocketshell/actions/runs/31759714621) — **16/16 jobs**, all six emulator shards `CLEAN` on first attempt, `Integration tests (Docker)` 87 testcases 0 failed 0 skipped. Two infra flakes recovered with captured signatures (G5), neither in connection core.

A **release freeze** is in effect: nothing else merges to `main` until the tag lands, so the validated commit stays put.

## Headline changes since v0.4.43

- **#822** — honest in-place recovery after a within-grace socket drop. The Reconnecting band was *structurally unreachable* (its gate could never be true), and Retry cancelled the auto ladder but not the bounded grace owner — so an in-place Retry could not recover, and switching sessions away and back was the maintainer's only way out. Its journey now runs with a hard-failing `captureViewport` and a rendered-geometry assertion; the previous proof passed while the terminal frame was destroyed on screen.
- **#1602 / #2123** — the composer queue proofs are device-independent and now actually execute on CI (they had never run anywhere: added and registered in one commit, and emulator jobs are skipped on PRs). **The underlying delivery-confirmation mechanism is NOT fixed by this release** — that is #2121, and the maintainer's `2 queued · 2 unconfirmed` symptom can still occur.
- **#2122** — host CLI `pocketshell send --token`, the acknowledged delivery primitive that #2124 will make authoritative.
- **#1202** — durable port-forward notification Stop.

## Verification on this branch

- `scripts/check-version-coupling.sh` → OK, aligned at 0.4.44
- `scripts/check-pypi-version.sh` → OK, versions aligned
- `git diff --check` → clean
- Diff is exactly two lines in two files

## Known limitation shipping with this cut

**#1671's fault gate is not satisfied** — #1678 is parked at 7 of the required 20 executed-and-engaged iterations, blocked by the fixture contention in #2128 rather than by any defect in the fix. #1678 did establish the root cause of the chronic five-second flake: Toxiproxy closes every connection carrying a `timeout` toxic when that toxic is removed, so `addBlackhole()` + `clearToxics()` was a stall followed by a genuine FIN and the app's silent-reattach was correct. That is a fixture defect, not a product defect, and no `core-connection` change was warranted.

## Runtime lockstep — required after installing

Host-CLI/client version lockstep is a **runtime** dependency, not just a build one. Upgrade the host CLI alongside the APK:

```
uv tool install --exclude-newer 2027-01-01 --force ~/git/pocketshell/tools/pocketshell
```

Release validation runs after this merges, against the exact commit to be tagged.