### PR TITLE
ci: stop a killed storm test from leaving the shared tmux server frozen (#2143)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -486,6 +486,11 @@ jobs:
           chmod +x scripts/test-agents-pool-isolation.sh
           scripts/test-agents-pool-isolation.sh
 
+      # Issue #2143 (rationale + case list in the script header). Fast, stubbed:
+      # no JVM, no Docker, no emulator.
+      - name: "Shared SSH/tmux fixture health guard (issue #2143)"
+        run: chmod +x scripts/test-ci-journey-fixture-health.sh && scripts/test-ci-journey-fixture-health.sh
+
       # Issue #2007: connected-test.sh and full-jvm-gate.py are both canonical
       # wrappers around ./gradlew and both rewrite the SAME app/build graph of
       # the checkout they run from. Nothing stopped them overlapping, so during
@@ -963,6 +968,12 @@ jobs:
       - name: Smoke shared tmux-wrapper fixtures
         run: scripts/test-shared-tmux-wrapper-fixtures.sh --docker
 
+      # Issue #2143: same guard with its REAL-Docker case on, so the fix rests on
+      # the fixture and not a model of it. The script brings the fixture up.
+      # Quoted: an unquoted ` #2143)` is a YAML comment and truncates the name.
+      - name: "Shared SSH/tmux fixture health on a REAL fixture (issue #2143)"
+        run: POCKETSHELL_FIXTURE_HEALTH_REAL_DOCKER=1 scripts/test-ci-journey-fixture-health.sh
+
       - name: Integration run marker (#2094)
         run: touch "${RUNNER_TEMP}/integration-test-run-start"
 
@@ -996,48 +1007,15 @@ jobs:
   # never-black / wrong-session / EOF-on-switch regressions are caught at PR
   # time, not the next morning by nightly or at release by the gate.
   #
-  # Issue #710 (RE-ADDED): MultiSessionSwitchJourneyE2eTest is back in this
-  # per-push subset. It was quarantined under #691 because it WEDGED on the
-  # GitHub android-emulator-runner AVD (rapid A->B->C->A backgrounded a
-  # just-switched runtime whose VM-clear park stalled the main thread on an
-  # UNBOUNDED `cancelAndJoin()`). #710 bounds that teardown at
-  # SYNC_DETACH_TIMEOUT_MS so the main thread is guaranteed to return. The
-  # per-push subset is therefore the full A->B->C->A switch journey plus
-  # DeepLinkSessionSwitchE2eTest, ColdRestoreGoneSessionNoResurrectE2eTest,
-  # ReconnectRepaintE2eTest, and BackgroundGraceReconnectE2eTest (see
-  # scripts/ci-journey-suite.sh for the inline note). The suite also passes
-  # AndroidJUnitRunner's per-test `timeout_msec` so any future wedge fails fast
-  # instead of hanging, and the job `timeout-minutes` below is a 45-min backstop.
-  #
-  # Issue #795 (ADDED): the #794 ~90s STEADY-HOLD no-flap proof
-  # (LongRunningSessionStabilityTest#steadyForegroundHoldDoesNotFlapTransportEveryTenSeconds)
-  # joins this subset. #794 fixed the ~11s app-initiated SSH transport flap on a
-  # quiet foreground hold (the maintainer's black-screen / "conversations don't
-  # work" report), but its regression proof ran ONLY in the opt-in release gate,
-  # so the flap could silently come back at PR time. Per the #638/#691 "load-
-  # bearing connection-lifecycle journeys run in regular per-PR CI" mandate it is
-  # now in scripts/ci-journey-suite.sh, targeted by FQCN#method so the sibling
-  # opt-in 10-minute hold (which self-skips without `pocketshellLongRunningTest=1`)
-  # stays release-gate-only. It uses the SAME deterministic agents:2222 fixture as
-  # the classes above — no new Docker service/port.
-  #
-  # This is intentionally the FAST subset (scripts/ci-journey-suite.sh), not the
-  # full connected suite — the heavy/long-running network-fault matrix and
-  # bootstrap matrix stay in nightly-extensive.yml. Issue #1733 is the one
-  # selected proof that also needs the existing deterministic Toxiproxy route
-  # (2228/API 8474) to hold a genuine app-transport outage; all other selected
-  # proofs remain on plain `agents` (2222), `agents-old-cli` (2238), or their
-  # documented fixture. This explicit fixture is not a self-skipping nightly
-  # lane.
-  #
-  # Issue #849 (epic #848, ADDED): the v0.4.10 connect-break regression tests
-  # (FolderListOldCliHydrateDockerTest + FolderListBootstrapSkipTreeLoadsDockerTest)
-  # + the #759 agent-launch version-mismatch guard
-  # (AgentLaunchVersionMismatchHintE2eTest) are now in scripts/ci-journey-suite.sh.
-  # The two old-CLI Docker tests need a host whose `pocketshell` CLI is OLDER than
-  # the client, so this job now ALSO starts the `agents-old-cli` fixture on host
-  # port 2238 (below). Before this, those tests self-skipped on CI and the whole
-  # connect-break class was structurally invisible to CI — the exact #848 gate gap.
+  # WHICH classes are selected, and WHY each was added or re-added (#710
+  # MultiSessionSwitchJourney, #795 the ~90s steady-hold no-flap proof, #849 the
+  # old-CLI connect-break pair, #1733's Toxiproxy route), is recorded per entry
+  # in scripts/ci-journey-suite.sh — the single list CI actually runs. This is
+  # intentionally the FAST subset; the heavy network-fault and bootstrap
+  # matrices stay in nightly-extensive.yml, and the fixtures those entries need
+  # (agents 2222, agents-old-cli 2238, agents-daemon 2239, Toxiproxy 2228/8474)
+  # are started explicitly below rather than self-skipped.
+
   emulator-journey:
     name: Emulator journey subset (load-bearing, Docker agents)
     if: github.event_name != 'pull_request'
@@ -1852,11 +1830,15 @@ jobs:
           # failure is checked FIRST because it explains why the shard has no
           # journey verdict at all, which subsumes a cold-build timeout earlier
           # in the same class.
+          # Issue #2143: a failure seen while the shared fixture was wedged is a
+          # SETUP failure. Verdict stays RED; only the attribution changes.
           verdict_reason_for() {
             if (( build_fail_attempts > 0 )); then
               printf 'build_level_failure\n'
             elif (( build_phase_attempts > 0 )); then
               printf 'cold_build_timeout\n'
+            elif [[ -f "$summary" ]] && grep -q 'JOURNEY_FIXTURE_SETUP_FAILURE' "$summary"; then
+              printf 'shared_fixture_setup_failure\n'
             else
               printf '%s\n' "$1"
             fi
@@ -2078,6 +2060,7 @@ jobs:
           path: |
             artifacts/docker/
             artifacts/ci-journey-setup/
+            artifacts/ci-journey/fixture-health.tsv
           # Issue #1809: same attempt-scoped re-run hygiene as the reports above.
           overwrite: true
           if-no-files-found: ignore

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AndroidSshTestFixtures.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AndroidSshTestFixtures.kt
@@ -207,12 +207,14 @@ suspend fun execRemoteSetupUntilReady(
     isReady: (ExecResult) -> Boolean = { it.exitCode == 0 },
 ): ExecResult {
     var attempt = 0
-    var lastFailure = "remote setup never ran"
+    val failures = mutableListOf<String>()
     var lastResult: ExecResult? = null
+    val startedAt = SystemClock.elapsedRealtime()
     val satisfied = runCatching {
         withTimeout(timeoutMs) {
             while (true) {
                 attempt += 1
+                val attemptStart = SystemClock.elapsedRealtime()
                 val outcome = SshConnection.connect(
                     host = host,
                     port = port,
@@ -228,9 +230,28 @@ suspend fun execRemoteSetupUntilReady(
                     lastResult = result
                     return@withTimeout result
                 }
-                lastFailure = "attempt $attempt: " +
-                    (outcome.exceptionOrNull()?.toString()
-                        ?: "exit=${result?.exitCode} stdout='${result?.stdout}' stderr='${result?.stderr}'")
+                val cause = outcome.exceptionOrNull()
+                // Issue #2143 — DO NOT let the deadline erase the real reason.
+                //
+                // `SshConnection.connect` captures throwables into its Result, and the
+                // final in-flight attempt is cancelled by the `withTimeout` above, so its
+                // captured cause is the deadline's own `TimeoutCancellationException`.
+                // The previous code kept only the LAST failure, so every wedged-fixture
+                // report read `last failure after 3 attempts: attempt 3:
+                // TimeoutCancellationException: Timed out waiting for 90000 ms` — the
+                // deadline restating itself, with the actual cause (each attempt's exec
+                // making no read progress against a frozen tmux server) discarded. That
+                // is what made shard 0's cascade on `main` @ 23ed1b10 unreadable and
+                // sent triage looking for an app regression. Keep EVERY attempt, with its
+                // elapsed time, and label the cancellation artifact as what it is.
+                val label = if (cause is kotlinx.coroutines.CancellationException) {
+                    "cut by the ${timeoutMs}ms deadline while in flight (not itself the " +
+                        "cause — see the earlier attempts): $cause"
+                } else {
+                    cause?.toString()
+                        ?: "exit=${result?.exitCode} stdout='${result?.stdout}' stderr='${result?.stderr}'"
+                }
+                failures += "attempt $attempt (+${SystemClock.elapsedRealtime() - attemptStart}ms): $label"
                 result?.let { lastResult = it }
                 delay(pollIntervalMs)
             }
@@ -239,8 +260,14 @@ suspend fun execRemoteSetupUntilReady(
         }
     }.getOrNull()
     return satisfied ?: error(
-        "expected $description to become ready within ${timeoutMs}ms; " +
-            "last failure after $attempt attempts: $lastFailure",
+        "expected $description to become ready within ${timeoutMs}ms " +
+            "(gave up after ${SystemClock.elapsedRealtime() - startedAt}ms, $attempt attempts) " +
+            "against $host:$port. Every attempt: \n" +
+            (failures.takeIf { it.isNotEmpty() } ?: listOf("remote setup never ran"))
+                .joinToString("\n") +
+            "\nIf these are exec/no-progress timeouts while a plain SSH probe still " +
+            "succeeds, the SHARED tmux server on this fixture is wedged (issue #2143) — " +
+            "a setup failure of the fixture, not a failure of the code under test.",
     )
 }
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectStormLivelockE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectStormLivelockE2eTest.kt
@@ -161,6 +161,9 @@ class ReconnectStormLivelockE2eTest {
     private var seededHostRowTag: String? = null
     private var tmuxServerPid: String? = null
     private var serverStalled: Boolean = false
+
+    /** Issue #2143: pid of the detached remote sleeper that un-stalls the server. */
+    private var stallDeadManPid: String? = null
     private var decoySshSession: SshSession? = null
     private var decoyShell: SshShell? = null
     private var decoyControlClientPid: String? = null
@@ -582,6 +585,7 @@ class ReconnectStormLivelockE2eTest {
         key: String,
         targetControlClientLookup: String =
             "tmux list-clients -t ${shellQuote(SESSION_NAME)} -F '#{client_pid}' 2>/dev/null",
+        deadManSecs: Long = STALL_DEAD_MAN_SECS,
     ) {
         val script = buildString {
             appendLine("set -u")
@@ -599,6 +603,33 @@ class ReconnectStormLivelockE2eTest {
             // that SHELL exits — not merely when tmux does. Kill both.
             appendLine("SH=\$(ps -o ppid= -p \"\$CC\" 2>/dev/null | tr -d ' ')")
             appendLine("echo \"cc_shell_pid=\$SH\"")
+            // Issue #2143 — ARM THE DEAD-MAN BEFORE THE STALL.
+            //
+            // Every restore path this test owns runs IN THIS PROCESS: the catch below and
+            // @After's resumeTmuxServer(). Neither exists when the process is not unwound
+            // but KILLED — and the journey harness kills a class attempt at its 420s cap
+            // (`JOURNEY_CLASS_TIMEOUT_SECS`). On `main` at 23ed1b10 that cap fired inside
+            // this very method, and the shared `agents` tmux server stayed SIGSTOPped for
+            // the rest of the shard: this class's own retry then failed all three methods
+            // in setup at the full 90s deadline, and ProfileChipRelaunchDockerTest failed
+            // twice at its 30s `createSession`, while every class targeting a DIFFERENT
+            // container passed. That is #1940 recurring, because #1940's fix hardened the
+            // in-process assertion-throw path only, which a SIGKILL cannot reach.
+            //
+            // So the resume is owned by the HOST that holds the frozen process, not by the
+            // client that can die: a detached sleeper SIGCONTs the server unconditionally
+            // after `deadManSecs`. It is set to strictly outlast the longest stall this
+            // method can legitimately need (see STALL_DEAD_MAN_SECS), so it can never end a
+            // real observation early and turn the proof green for the wrong reason; it only
+            // bounds a stall whose owner is already gone. Detached from the exec channel's
+            // fds so the SSH session can close without taking the sleeper with it.
+            appendLine(
+                "nohup sh -c \"sleep $deadManSecs; kill -CONT \$PID 2>/dev/null || true\" " +
+                    "</dev/null >/dev/null 2>&1 &",
+            )
+            appendLine("DEADMAN=\$!")
+            appendLine("echo \"dead_man_pid=\$DEADMAN\"")
+            appendLine("echo \"dead_man_secs=$deadManSecs\"")
             // Stall FIRST, drop SECOND: reversed, the grace loop can heal in the gap and
             // the tail would never be slow.
             appendLine("kill -STOP \"\$PID\"")
@@ -607,6 +638,7 @@ class ReconnectStormLivelockE2eTest {
         }
         val result = execRemote(key, script)
         tmuxServerPid = Regex("tmux_server_pid=(\\d+)").find(result.stdout)?.groupValues?.get(1)
+        stallDeadManPid = Regex("dead_man_pid=(\\d+)").find(result.stdout)?.groupValues?.get(1)
         val controlClientCount =
             Regex("cc_client_count=(\\d+)").find(result.stdout)?.groupValues?.get(1)?.toIntOrNull()
         val controlClientPid =
@@ -650,12 +682,22 @@ class ReconnectStormLivelockE2eTest {
         recordTiming("fixture_tmux_server_pid", tmuxServerPid!!.toLong())
     }
 
-    /** `kill -CONT` the stalled tmux server. Idempotent; safe from `tearDown`. */
+    /**
+     * `kill -CONT` the stalled tmux server. Idempotent; safe from `tearDown`.
+     *
+     * Also cancels the #2143 dead-man in the same round-trip. Leaving it running would
+     * be harmless today (SIGCONT on a running process is a no-op) but the container's
+     * pids are small and recycled, so an orphaned sleeper is a signal aimed at whatever
+     * holds that pid minutes later.
+     */
     private suspend fun resumeTmuxServer() {
         val pid = tmuxServerPid ?: return
         if (!serverStalled) return
         val key = seededKey ?: return
-        execRemote(key, "kill -CONT $pid 2>/dev/null || true; echo resumed")
+        val deadMan = stallDeadManPid
+        val cancelDeadMan = if (deadMan != null) "kill -9 $deadMan 2>/dev/null || true; " else ""
+        execRemote(key, "${cancelDeadMan}kill -CONT $pid 2>/dev/null || true; echo resumed")
+        stallDeadManPid = null
         serverStalled = false
     }
 
@@ -1080,7 +1122,44 @@ class ReconnectStormLivelockE2eTest {
                     "test's knob expired rather than because the counter walked to give-up.",
                 WIDE_GRACE_MS > OBSERVE_WINDOW_MS + TERMINATION_WINDOW_MS,
             )
+            // Issue #2143: the same self-consistency discipline for the dead-man. If it
+            // could expire inside the observation, this test's stall would clear on its
+            // own and the storm assertions would be measuring a fixture that healed
+            // itself rather than the machine under test.
+            assertTrue(
+                "STALL_DEAD_MAN_SECS ($STALL_DEAD_MAN_SECS) must strictly outlast the " +
+                    "longest stall this class holds — OBSERVE_WINDOW_MS ($OBSERVE_WINDOW_MS) " +
+                    "+ TERMINATION_WINDOW_MS ($TERMINATION_WINDOW_MS) — or the fixture would " +
+                    "un-stall itself mid-observation and the proof would go green for the " +
+                    "wrong reason.",
+                STALL_DEAD_MAN_SECS * 1000L > OBSERVE_WINDOW_MS + TERMINATION_WINDOW_MS,
+            )
         }
+        /**
+         * Issue #2143 — the wall-clock bound on a stall whose owner has died.
+         *
+         * The stall is destructive SHARED state: while the `agents` tmux server is
+         * SIGSTOPped, every other journey class on the shard that touches it hangs. This
+         * class's in-process restores cannot run when the harness SIGKILLs the attempt at
+         * its 420s cap, so the remote arms a detached sleeper that SIGCONTs the server
+         * unconditionally after this many seconds.
+         *
+         * DERIVED, not picked: it must strictly outlast the longest stall any method here
+         * can legitimately hold, or it would end a real observation early and the proof
+         * could go green for the wrong reason (G6). The longest is the storm test's
+         * [OBSERVE_WINDOW_MS] + [TERMINATION_WINDOW_MS], so it is derived from those and
+         * retunes with them — the same discipline [assertWindowsAreSelfConsistent]
+         * enforces for the other derived windows. It is deliberately LONGER than the
+         * harness's per-class cap: shortening the stall to fit the cap would change what
+         * the test observes, and the harness's own post-attempt fixture health gate
+         * (`scripts/ci-journey-fixture-health.sh`) already restores the fixture within
+         * seconds of a killed attempt. This bound is the belt-and-braces that turns
+         * "stranded until the runner is torn down" into "stranded for a known interval"
+         * even where that gate does not run.
+         */
+        val STALL_DEAD_MAN_SECS: Long =
+            ((OBSERVE_WINDOW_MS + TERMINATION_WINDOW_MS) / 1000L) + 120L
+
         val HEAL_RECOVER_WINDOW_MS: Long =
             if (TerminalTestTimeouts.isRunningOnCi()) 90_000L else 60_000L
         val ROUND_TRIP_WINDOW_MS: Long =

--- a/scripts/ci-journey-budget-functions.sh
+++ b/scripts/ci-journey-budget-functions.sh
@@ -1133,6 +1133,11 @@ finalize_class_attempt_manifest() {
     printf 'cleanup_status=%s\n' "$cleanup_status"
     printf 'gradle_cleanup_exit_code=%s\n' "$LAST_RUN_CLASS_GRADLE_CLEANUP_RC"
     printf 'device_cleanup_exit_code=%s\n' "$LAST_RUN_CLASS_DEVICE_CLEANUP_RC"
+    # Issue #2143: the shared-fixture state OBSERVED for this attempt, so a
+    # future triage can tell a setup failure from an assertion failure straight
+    # from the attempt artifact instead of re-deriving it from the job log.
+    printf 'shared_fixture_health=%s\n' "${LAST_RUN_CLASS_FIXTURE_HEALTH:-not_run}"
+    printf 'shared_fixture_probe_ms=%s\n' "${LAST_RUN_CLASS_FIXTURE_PROBE_MS:-unknown}"
     printf 'status=%s\n' "$final_status"
     printf 'finished_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   } >> "$manifest" || return 1
@@ -1226,6 +1231,8 @@ run_class() {
   LAST_RUN_CLASS_DEVICE_CLEANUP_RC="not_run"
   LAST_RUN_CLASS_OUTER_TIMEOUT_PHASE=""
   LAST_RUN_CLASS_ATTEMPT_FAILURE_PHASE=""
+  LAST_RUN_CLASS_FIXTURE_HEALTH="not_run"
+  LAST_RUN_CLASS_FIXTURE_PROBE_MS="unknown"
   if [[ -n "$app_id_suffix" ]]; then
     [[ "$app_id_suffix" =~ ^[A-Za-z0-9._]+$ ]] || {
       echo "JOURNEY_INVOCATION_IDENTITY_FAILED: invalid application id suffix '$app_id_suffix'" >&2
@@ -1296,6 +1303,18 @@ run_class() {
   record_build_phase_timeout_attempt "$fqcn"
   # Issue #1840: and name a build-level failure for what it is.
   record_build_phase_failure_attempt "$fqcn"
+  # Issue #2143: probe (and repair) the SHARED SSH/tmux fixture after EVERY
+  # attempt, pass or fail. After a FAIL it decides whether this was an assertion
+  # failure or the fixture being frozen underneath it, and it hands the retry a
+  # working fixture instead of the frozen one that made the retry meaningless on
+  # 23ed1b10. After a PASS it is a ~150ms probe that keeps the bring-up timing
+  # series continuous, so a degrading fixture is visible BEFORE it wedges — and
+  # so a class that wedges the fixture and still passes cannot hide.
+  if declare -F journey_fixture_health_gate >/dev/null 2>&1; then
+    journey_fixture_health_gate post_attempt "$fqcn"
+    LAST_RUN_CLASS_FIXTURE_HEALTH="$JOURNEY_FIXTURE_HEALTH_STATUS"
+    LAST_RUN_CLASS_FIXTURE_PROBE_MS="$JOURNEY_FIXTURE_HEALTH_PROBE_MS"
+  fi
   cleanup_status="not_required"
   if needs_gradle_cleanup_after_class_abort "$rc"; then
     cleanup_status="failed"

--- a/scripts/ci-journey-class-loop-functions.sh
+++ b/scripts/ci-journey-class-loop-functions.sh
@@ -29,6 +29,15 @@ run_journey_classes_with_retry() {
   RECOVERED_CLASSES=()  # classes that failed first then PASSED on retry
   FAILED_CLASSES=()     # classes that failed BOTH attempts (real failures)
   PASSED_FIRST_TRY=()   # classes that passed on the first attempt
+  FIXTURE_WEDGED_CLASSES=()  # issue #2143: classes whose failure was observed while
+                             # the SHARED SSH/tmux fixture was not answering. That is
+                             # a SETUP failure of the fixture, not an assertion failure
+                             # of the code under test, and the two must not read alike
+                             # in the verdict — on 23ed1b10 three storm-test setup
+                             # timeouts and one ProfileChipRelaunch timeout were
+                             # reported as a "genuine test failure (app-code
+                             # regression)" on a commit whose whole diff was three
+                             # version strings.
   BUDGET_TIMEOUT_CLASSES=()  # issue #835: classes not run / cut short because the
                              # suite-level budget was exhausted (the #470 stall
                              # ate the time). A DISTINCT bucket from a real failure
@@ -49,7 +58,14 @@ run_journey_classes_with_retry() {
   # note): a failed warm build leaves the class loop exactly as it was.
   warm_journey_build
 
-  local fqcn class_start rc retry_start
+  # Issue #2143: one baseline probe of the shared SSH/tmux fixture BEFORE any
+  # class runs. It is the reference point for the per-attempt series that
+  # follows — without a known-good first row there is nothing to compare a later
+  # slow/absent probe against, which is why the previous occurrences had to be
+  # re-derived from scratch each time.
+  journey_fixture_health_gate preflight suite_start
+
+  local fqcn class_start rc retry_start class_wedged
   for fqcn in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
     # Issue #835: stop launching new classes once the suite-level budget is spent.
     # A #470 enumeration stall earlier in the run can eat the budget; rather than
@@ -68,9 +84,11 @@ run_journey_classes_with_retry() {
     echo ">>> JOURNEY CLASS: $fqcn (attempt 1) [budget remaining: $(budget_remaining)s]"
     echo "=========================================================="
     class_start=$SECONDS
+    class_wedged=0
 
     run_class "$fqcn"
     rc=$?
+    [[ "${LAST_RUN_CLASS_FIXTURE_HEALTH:-ok}" == "ok" || "${LAST_RUN_CLASS_FIXTURE_HEALTH:-ok}" == "skipped" ]] || class_wedged=1
     if [[ "${JOURNEY_ABORT_ISOLATION_FAILED:-0}" -eq 1 ]]; then
       echo "JOURNEY_ISOLATION_FAILURE: $fqcn primary_rc=${LAST_RUN_CLASS_PRIMARY_RC:-unknown} cleanup_failed=${LAST_RUN_CLASS_ABORT_CLEANUP_FAILED:-0} artifact_failed=${LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED:-0} — refusing every retry/next class because isolation is unproven"
       FAILED_CLASSES+=("$fqcn")
@@ -108,6 +126,7 @@ run_journey_classes_with_retry() {
 
     run_class "$fqcn"
     rc=$?
+    [[ "${LAST_RUN_CLASS_FIXTURE_HEALTH:-ok}" == "ok" || "${LAST_RUN_CLASS_FIXTURE_HEALTH:-ok}" == "skipped" ]] || class_wedged=1
     if [[ "${JOURNEY_ABORT_ISOLATION_FAILED:-0}" -eq 1 ]]; then
       echo "JOURNEY_ISOLATION_FAILURE: $fqcn retry primary_rc=${LAST_RUN_CLASS_PRIMARY_RC:-unknown} cleanup_failed=${LAST_RUN_CLASS_ABORT_CLEANUP_FAILED:-0} artifact_failed=${LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED:-0} — refusing every next class because isolation is unproven"
       FAILED_CLASSES+=("$fqcn")
@@ -133,6 +152,15 @@ run_journey_classes_with_retry() {
     else
       echo "JOURNEY_FAILED: $fqcn failed twice"
       FAILED_CLASSES+=("$fqcn")
+    fi
+
+    # Issue #2143: a class that failed while the SHARED fixture was not answering
+    # is recorded in a SECOND, additive bucket. It stays in FAILED_CLASSES — the
+    # job is still red, nothing is masked — but the verdict now says WHICH kind
+    # of failure it was, so the next occurrence is not read as an app regression.
+    if [[ $class_wedged -eq 1 ]]; then
+      echo "JOURNEY_FIXTURE_SETUP_FAILURE: $fqcn failed while the shared SSH/tmux fixture was ${LAST_RUN_CLASS_FIXTURE_HEALTH:-unknown} — classified as a fixture SETUP failure, not an assertion failure (issue #2143)"
+      FIXTURE_WEDGED_CLASSES+=("$fqcn")
     fi
   done
 }

--- a/scripts/ci-journey-fixture-health.sh
+++ b/scripts/ci-journey-fixture-health.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# ci-journey-fixture-health.sh — shared SSH/tmux fixture health gate for the
+# emulator-journey suite (issue #2143).
+#
+# WHY THIS EXISTS — the measured mechanism, not a hypothesis.
+#
+# `ReconnectStormLivelockE2eTest` reproduces the #1610 storm by `kill -STOP`-ing
+# the tmux SERVER inside the shared `agents` container while leaving sshd alone.
+# Every restore path it owns runs IN THE TEST PROCESS: the fixture helper's own
+# `catch { resumeTmuxServer() }` and `@After`'s SIGCONT. Both are unreachable
+# when the process is not unwound but KILLED — and the journey harness kills a
+# class attempt at `JOURNEY_CLASS_TIMEOUT_SECS` (420s).
+#
+# That is what happened on `main` at 23ed1b10 (run 31764246653, shard 0):
+#
+#   03:06:39  storm class attempt 1 starts
+#   03:10:19  method 1 passes (210s — identical to the green rerun)
+#   03:13:27  the 420s per-class cap fires MID-method-2, while that method holds
+#             the shared tmux server SIGSTOPped. The process dies; no SIGCONT.
+#   03:14:11  attempt 2: all 3 methods fail in SETUP, each after the full 90s
+#             `execRemoteSetupUntilReady` deadline
+#   03:19:28  ProfileChipRelaunchDockerTest fails twice at `withTimeout(30_000)`
+#   03:22:09  FolderListDurableTreeDaemonDockerTest PASSES — it targets the
+#             SEPARATE `agents-daemon` container on 2239
+#
+# Every class after the abort that touched `agents:2222`'s tmux server failed;
+# every class that did not, passed. Reproduced headlessly on the real fixture:
+# with the server SIGSTOPped the storm test's verbatim seed script hangs past
+# 90s (the reported `IllegalStateException ... within 90000ms`), while
+# `waitForSshFixtureReady`'s `printf ...; tmux -V` still returns 0 in
+# milliseconds — `tmux -V` never contacts the server. THAT is why a wedged
+# fixture presents as a per-test SETUP failure rather than "fixture not ready",
+# and why it reads like a product regression on a version-only commit.
+#
+# WHAT THIS DOES. Around every class attempt, probe the shared fixture over the
+# SAME SSH path the journey classes use, bounded. A probe that cannot complete
+# means the fixture — not the code under test — is broken, so:
+#
+#   1. record the probe latency (this is the per-shard bring-up timing series
+#      the artifacts were missing);
+#   2. repair: SIGCONT every stopped process in the container, re-probe, and if
+#      it is still wedged kill the tmux server so the next `new-session` starts
+#      a fresh one. Journey classes seed their own sessions, and a wedged server
+#      has no usable sessions to preserve;
+#   3. classify: a failure observed while the shared fixture was wedged is a
+#      SETUP failure, reported distinctly from an assertion failure.
+#
+# This is deliberately a CLASS-level guard, not a patch on one test. #1940 was
+# this same cascade and its fix hardened only the in-process assertion-throw
+# path, which a SIGKILL cannot reach. Any journey class that wedges the shared
+# fixture — this one, a future one, or a killed one — is now contained.
+#
+# NOT A RETRY. The per-class retry already exists (#712). This gate does not add
+# one and never turns a red green: a repaired fixture only means the retry runs
+# against a working fixture instead of a frozen one, and a class that still
+# fails is still red — with an honest reason.
+#
+# Sourced by scripts/ci-journey-suite.sh; also runnable standalone:
+#   scripts/ci-journey-fixture-health.sh probe   [container]
+#   scripts/ci-journey-fixture-health.sh repair  [container]
+#   scripts/ci-journey-fixture-health.sh gate    <phase> <label>
+#
+# When SOURCED it must not mutate the caller's shell options (the suite runs its
+# own discipline), so `set` is applied only on direct execution.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -uo pipefail
+fi
+
+# --- configuration seams -----------------------------------------------------
+# Every external command is injectable so the guard self-test can drive the real
+# control flow with stubs, and so a local run can point at a private fixture
+# instead of the shared one.
+JOURNEY_FIXTURE_HEALTH_DOCKER="${JOURNEY_FIXTURE_HEALTH_DOCKER:-docker}"
+JOURNEY_FIXTURE_HEALTH_SSH="${JOURNEY_FIXTURE_HEALTH_SSH:-ssh}"
+JOURNEY_FIXTURE_HEALTH_CONTAINER="${JOURNEY_FIXTURE_HEALTH_CONTAINER:-pocketshell-test-agents}"
+JOURNEY_FIXTURE_HEALTH_PORT="${JOURNEY_FIXTURE_HEALTH_PORT:-2222}"
+JOURNEY_FIXTURE_HEALTH_USER="${JOURNEY_FIXTURE_HEALTH_USER:-testuser}"
+JOURNEY_FIXTURE_HEALTH_HOST="${JOURNEY_FIXTURE_HEALTH_HOST:-127.0.0.1}"
+JOURNEY_FIXTURE_HEALTH_KEY="${JOURNEY_FIXTURE_HEALTH_KEY:-tests/docker/test_key}"
+# The probe bound must be well UNDER the 90s in-test setup deadline it exists to
+# pre-empt, and well OVER a healthy round-trip (measured 56ms on a warm fixture).
+JOURNEY_FIXTURE_HEALTH_PROBE_SECS="${JOURNEY_FIXTURE_HEALTH_PROBE_SECS:-20}"
+JOURNEY_FIXTURE_HEALTH_REPAIR_SECS="${JOURNEY_FIXTURE_HEALTH_REPAIR_SECS:-30}"
+# Set to 1 where there is no shared Docker fixture at all (unit self-tests of
+# unrelated harness logic). A MISSING fixture is reported as `unavailable`, never
+# silently as `ok` — "I could not check" must not read like "I checked".
+JOURNEY_FIXTURE_HEALTH_DISABLED="${JOURNEY_FIXTURE_HEALTH_DISABLED:-0}"
+
+# Set by journey_fixture_health_gate for the caller to read.
+JOURNEY_FIXTURE_HEALTH_STATUS="not_run"
+JOURNEY_FIXTURE_HEALTH_PROBE_MS="unknown"
+JOURNEY_FIXTURE_HEALTH_DETAIL=""
+
+journey_fixture_health_tsv_path() {
+  local root="${JOURNEY_FIXTURE_HEALTH_TSV:-}"
+  if [[ -n "$root" ]]; then
+    printf '%s\n' "$root"
+    return 0
+  fi
+  printf '%s\n' "${ARTIFACT_DIR:-artifacts/ci-journey}/fixture-health.tsv"
+}
+
+# The committed key is checked out 0644 on GitHub runners and OpenSSH refuses
+# it (#1876). Copy it once to a private 0600 file rather than depending on some
+# earlier workflow step having chmod'ed the tracked file — a probe that fails on
+# permissions would be misread as a wedged fixture.
+journey_fixture_health_private_key() {
+  # Keyed by the SOURCE path, not just the pid: two fixtures in one process must
+  # not share one cached copy (a stale copy authenticates as the wrong identity
+  # and the failure reads as "Permission denied", i.e. an unavailable fixture).
+  local tag dest
+  tag="$(printf '%s' "$JOURNEY_FIXTURE_HEALTH_KEY" | cksum | tr -d ' ')"
+  dest="${TMPDIR:-/tmp}/ci-journey-fixture-health-key.$$.$tag"
+  if [[ ! -s "$dest" ]]; then
+    cp "$JOURNEY_FIXTURE_HEALTH_KEY" "$dest" 2>/dev/null || {
+      printf '%s\n' "$JOURNEY_FIXTURE_HEALTH_KEY"
+      return 0
+    }
+    chmod 600 "$dest" 2>/dev/null || true
+  fi
+  printf '%s\n' "$dest"
+}
+
+journey_fixture_health_now_ms() {
+  # `date +%s%3N` is GNU-only; fall back to whole seconds elsewhere.
+  local raw
+  raw="$(date +%s%3N 2>/dev/null || true)"
+  if [[ "$raw" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$raw"
+  else
+    printf '%s000\n' "$(date +%s)"
+  fi
+}
+
+# journey_fixture_probe — one bounded round-trip THROUGH the tmux server over
+# the same SSH path the journey classes use.
+#
+# Exit codes carry the classification, and the three outcomes are genuinely
+# distinct (this is the part a naive probe gets wrong):
+#   0  healthy — either sessions listed (rc 0) or a FAST, explicit
+#      "no server running" (rc 1). An idle fixture with no server is healthy:
+#      the next `new-session` starts one.
+#   1  wedged  — the bound expired. A stopped/blocked server accepts the socket
+#      connection and never answers, so the client hangs forever; that is the
+#      exact shape of the reported failure.
+#   2  unavailable — ssh itself could not reach the fixture (no container, no
+#      key, no port). Reported as its own state, never as healthy.
+#
+# Writes JOURNEY_FIXTURE_HEALTH_PROBE_MS and JOURNEY_FIXTURE_HEALTH_DETAIL as
+# globals rather than echoing them: a `$(journey_fixture_probe)` call would run
+# the body in a SUBSHELL and silently drop every variable it set, which is
+# exactly the kind of "reads correctly, records nothing" defect this file exists
+# to make visible.
+journey_fixture_probe() {
+  local started ended rc out key
+  key="$(journey_fixture_health_private_key)"
+  started="$(journey_fixture_health_now_ms)"
+  out="$(
+    timeout "$JOURNEY_FIXTURE_HEALTH_PROBE_SECS" \
+      "$JOURNEY_FIXTURE_HEALTH_SSH" \
+      -i "$key" \
+      -p "$JOURNEY_FIXTURE_HEALTH_PORT" \
+      -o BatchMode=yes \
+      -o ConnectTimeout=5 \
+      -o StrictHostKeyChecking=no \
+      -o UserKnownHostsFile=/dev/null \
+      -o LogLevel=ERROR \
+      "$JOURNEY_FIXTURE_HEALTH_USER@$JOURNEY_FIXTURE_HEALTH_HOST" \
+      'tmux list-sessions' 2>&1
+  )"
+  rc=$?
+  ended="$(journey_fixture_health_now_ms)"
+  JOURNEY_FIXTURE_HEALTH_PROBE_MS=$((ended - started))
+  JOURNEY_FIXTURE_HEALTH_DETAIL="$(printf '%s' "$out" | tr '\n\t' ';  ' | cut -c1-200)"
+  case "$rc" in
+    0) return 0 ;;
+    124 | 137)
+      JOURNEY_FIXTURE_HEALTH_DETAIL="probe_timeout_after_${JOURNEY_FIXTURE_HEALTH_PROBE_SECS}s: $JOURNEY_FIXTURE_HEALTH_DETAIL"
+      return 1
+      ;;
+  esac
+  # A non-timeout, non-zero exit is healthy ONLY when tmux itself answered that
+  # there is no server. Anything else (auth failure, refused connection, unknown
+  # host) is an unavailable fixture, not a healthy one.
+  if printf '%s' "$out" | grep -qE 'no server running|no current (client|session)'; then
+    return 0
+  fi
+  return 2
+}
+
+# journey_fixture_repair — restore a wedged shared fixture, escalating.
+#
+# Step 1 SIGCONTs every stopped process in the container. That is the exact
+# inverse of the fixture's `kill -STOP`, and it is what the killed test process
+# never got to run.
+# Step 2, only if the fixture is STILL wedged, kills the tmux server outright so
+# the next `new-session` starts a fresh one. Safe here by construction: we only
+# reach step 2 with a server that provably cannot answer, so there is no live
+# session state to preserve; journey classes seed their own sessions in setup.
+#
+# Prints what it did. Returns 0 if the fixture probes healthy afterwards.
+journey_fixture_repair() {
+  local resumed rc
+  resumed="$(
+    timeout "$JOURNEY_FIXTURE_HEALTH_REPAIR_SECS" \
+      "$JOURNEY_FIXTURE_HEALTH_DOCKER" exec "$JOURNEY_FIXTURE_HEALTH_CONTAINER" \
+      sh -c 'ps -eo pid,state 2>/dev/null | awk '"'"'$2 ~ /^T/ {print $1}'"'"'' 2>/dev/null | tr '\n' ' '
+  )" || true
+  echo "JOURNEY_FIXTURE_REPAIR: stopped pids in $JOURNEY_FIXTURE_HEALTH_CONTAINER: [${resumed:-none}] — sending SIGCONT"
+  timeout "$JOURNEY_FIXTURE_HEALTH_REPAIR_SECS" \
+    "$JOURNEY_FIXTURE_HEALTH_DOCKER" exec "$JOURNEY_FIXTURE_HEALTH_CONTAINER" \
+    sh -c 'ps -eo pid,state 2>/dev/null | awk '"'"'$2 ~ /^T/ {print $1}'"'"' | xargs -r kill -CONT; exit 0' \
+    >/dev/null 2>&1 || true
+
+  journey_fixture_probe
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "JOURNEY_FIXTURE_REPAIR_OK: SIGCONT restored $JOURNEY_FIXTURE_HEALTH_CONTAINER (probe ${JOURNEY_FIXTURE_HEALTH_PROBE_MS}ms)"
+    return 0
+  fi
+
+  echo "JOURNEY_FIXTURE_REPAIR_ESCALATE: still unhealthy (rc=$rc) after SIGCONT — killing the tmux server so a fresh one can start"
+  timeout "$JOURNEY_FIXTURE_HEALTH_REPAIR_SECS" \
+    "$JOURNEY_FIXTURE_HEALTH_DOCKER" exec "$JOURNEY_FIXTURE_HEALTH_CONTAINER" \
+    sh -c 'pkill -9 -f tmux >/dev/null 2>&1; exit 0' \
+    >/dev/null 2>&1 || true
+
+  journey_fixture_probe
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "JOURNEY_FIXTURE_REPAIR_OK: tmux-server kill restored $JOURNEY_FIXTURE_HEALTH_CONTAINER (probe ${JOURNEY_FIXTURE_HEALTH_PROBE_MS}ms)"
+    return 0
+  fi
+  echo "JOURNEY_FIXTURE_REPAIR_FAILED: $JOURNEY_FIXTURE_HEALTH_CONTAINER is still not answering (probe ${JOURNEY_FIXTURE_HEALTH_PROBE_MS}ms, ${JOURNEY_FIXTURE_HEALTH_DETAIL})" >&2
+  return 1
+}
+
+# journey_fixture_health_gate <phase> <label> — probe, repair if needed, record.
+#
+# Sets JOURNEY_FIXTURE_HEALTH_STATUS to one of:
+#   ok               the fixture answered on the first probe
+#   wedged_repaired  it did not, and the repair restored it
+#   wedged           it did not, and the repair could not restore it
+#   unavailable      the fixture could not be reached at all
+#   skipped          this run has no shared fixture (explicitly disabled)
+# Always returns 0: the gate reports, it does not decide the verdict.
+journey_fixture_health_gate() {
+  local phase="$1" label="${2:-}" rc
+  JOURNEY_FIXTURE_HEALTH_DETAIL=""
+  if [[ "$JOURNEY_FIXTURE_HEALTH_DISABLED" == "1" ]]; then
+    JOURNEY_FIXTURE_HEALTH_STATUS="skipped"
+    JOURNEY_FIXTURE_HEALTH_PROBE_MS="unknown"
+    journey_fixture_health_record "$phase" "$label"
+    return 0
+  fi
+
+  journey_fixture_probe
+  rc=$?
+  case "$rc" in
+    0)
+      JOURNEY_FIXTURE_HEALTH_STATUS="ok"
+      echo "JOURNEY_FIXTURE_HEALTH: phase=$phase label=${label:-none} fixture=$JOURNEY_FIXTURE_HEALTH_CONTAINER status=ok probe_ms=$JOURNEY_FIXTURE_HEALTH_PROBE_MS"
+      ;;
+    1)
+      echo "JOURNEY_FIXTURE_WEDGED: phase=$phase label=${label:-none} fixture=$JOURNEY_FIXTURE_HEALTH_CONTAINER did not answer within ${JOURNEY_FIXTURE_HEALTH_PROBE_SECS}s — this is a SETUP failure of the shared fixture, not an assertion failure of the code under test (issue #2143)" >&2
+      if journey_fixture_repair; then
+        JOURNEY_FIXTURE_HEALTH_STATUS="wedged_repaired"
+      else
+        JOURNEY_FIXTURE_HEALTH_STATUS="wedged"
+      fi
+      ;;
+    *)
+      JOURNEY_FIXTURE_HEALTH_STATUS="unavailable"
+      echo "JOURNEY_FIXTURE_UNAVAILABLE: phase=$phase label=${label:-none} fixture=$JOURNEY_FIXTURE_HEALTH_CONTAINER unreachable (${JOURNEY_FIXTURE_HEALTH_DETAIL})" >&2
+      ;;
+  esac
+  journey_fixture_health_record "$phase" "$label"
+  return 0
+}
+
+journey_fixture_health_record() {
+  local phase="$1" label="${2:-}"
+  local tsv
+  tsv="$(journey_fixture_health_tsv_path)"
+  mkdir -p "$(dirname "$tsv")" 2>/dev/null || return 0
+  if [[ ! -s "$tsv" ]]; then
+    printf 'timestamp_utc\tphase\tlabel\tfixture\tstatus\tprobe_ms\tdetail\n' > "$tsv" || return 0
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$phase" \
+    "${label:-none}" \
+    "$JOURNEY_FIXTURE_HEALTH_CONTAINER" \
+    "$JOURNEY_FIXTURE_HEALTH_STATUS" \
+    "$JOURNEY_FIXTURE_HEALTH_PROBE_MS" \
+    "${JOURNEY_FIXTURE_HEALTH_DETAIL:-}" >> "$tsv" || true
+  return 0
+}
+
+# journey_fixture_health_was_wedged — did the LAST gate observe a broken fixture?
+# Used by the class loop to classify a failure as SETUP rather than assertion.
+journey_fixture_health_was_wedged() {
+  [[ "$JOURNEY_FIXTURE_HEALTH_STATUS" == "wedged_repaired" \
+     || "$JOURNEY_FIXTURE_HEALTH_STATUS" == "wedged" \
+     || "$JOURNEY_FIXTURE_HEALTH_STATUS" == "unavailable" ]]
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  cmd="${1:-gate}"
+  shift || true
+  case "$cmd" in
+    probe)
+      journey_fixture_probe; rc=$?
+      echo "probe_ms=$JOURNEY_FIXTURE_HEALTH_PROBE_MS rc=$rc detail=$JOURNEY_FIXTURE_HEALTH_DETAIL"
+      exit "$rc"
+      ;;
+    repair) journey_fixture_repair; exit $? ;;
+    gate)
+      journey_fixture_health_gate "${1:-manual}" "${2:-}"
+      echo "status=$JOURNEY_FIXTURE_HEALTH_STATUS probe_ms=$JOURNEY_FIXTURE_HEALTH_PROBE_MS"
+      [[ "$JOURNEY_FIXTURE_HEALTH_STATUS" == "ok" || "$JOURNEY_FIXTURE_HEALTH_STATUS" == "wedged_repaired" || "$JOURNEY_FIXTURE_HEALTH_STATUS" == "skipped" ]]
+      exit $?
+      ;;
+    *) echo "usage: $0 {probe|repair|gate <phase> [label]}" >&2; exit 2 ;;
+  esac
+fi

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -257,7 +257,22 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.portfwd.ForwardingNotificationObserverGenerationE2eTest"  # #2006 D33/G10: a real Docker-backed forward started inside EITHER side of the notification-generation close (before the close / before the torn-down observer is cleared, no injected follow-up start) must leave the ongoing notification describing host + forwarded port — never removed, never stranded on 'Connecting…' — with the tunnel still carrying bytes and Stop still tearing socket+notification down
   "$FQCN_PREFIX.SilentDropSyntheticSeamJourneyE2eTest"  # #792 #822 #823 #964 epic Slice D, /V7a + — D31 durable-fix gate
   "$FQCN_PREFIX.CleanOutageReattachResilienceE2eTest"  # #833 a CLEAN sustained outage (clean FIN/connection-refused for t…
-  "$FQCN_PREFIX.ReconnectStormLivelockE2eTest"  # #1652 #1610 #1539 #1632 #1633 the LIVELOCK proof: N>=5 consecutive passive-grace cycles on the real path with a stalled tail + healthy dial; no handshaken transport killed, the counter walks, the machine terminates. Also in the pre-release confidence gate (red blocks a tag).
+  # Issue #2143 — the three LIVELOCK-proof methods run as SEPARATE entries, and
+  # this is a fit-the-cap change, not cosmetics. As ONE class they cost 326s of
+  # the 420s per-class cap (measured on the green rerun of 31764246653 shard 0:
+  # 210s + 90s + 3s), i.e. 78% consumed with three multi-minute OBSERVATION
+  # windows still free to vary. On the red first attempt of that same run the
+  # 90s method ran past 188s and the cap fired MID-method — killing the process
+  # while it held the shared tmux server SIGSTOPped, which stranded the fixture
+  # and took down this class's own retry plus ProfileChipRelaunchDockerTest.
+  # Per entry the worst method is 210s = 50% of its own cap, so the variance
+  # that was fatal is now a non-event. Cost: two extra Gradle invocations
+  # (~25s each) against 2452s of remaining shard budget at that point.
+  # NOTE the coupling: these are the same per-method selectors the pre-release
+  # confidence gate already uses (scripts/pre-release-confidence-gate.sh:120).
+  "$FQCN_PREFIX.ReconnectStormLivelockE2eTest#slowTailOnAProvenLinkNeitherKillsHandshakenTransportsNorSpinsForever"  # #1652 #1610 #1539 #1632 #1633 the LIVELOCK proof: N>=5 consecutive passive-grace cycles on the real path with a stalled tail + healthy dial; no handshaken transport killed, the counter walks, the machine terminates. Also in the pre-release confidence gate (red blocks a tag).
+  "$FQCN_PREFIX.ReconnectStormLivelockE2eTest#slowTailThatClearsHealsTheSameSessionWithoutKillingTheHandshakenTransport"  # #1652 the heal side: a tail that clears must bring the SAME session back without ever having killed the handshaken transport. Also in the pre-release confidence gate.
+  "$FQCN_PREFIX.ReconnectStormLivelockE2eTest#missingControlClientAfterServerStopIsResumedBeforeSiblingSetup"  # #1940 #2143 the fixture-hygiene guard: a REJECTED post-STOP fixture must not strand the shared tmux server for the classes that follow.
   "$FQCN_PREFIX.SlowClassifyKeepsSharedLeaseJourneyDockerTest"  # #1641 #1670 #1610 the storm-ENTRY-edge: a foreign-pane agents-kind classify slower than its 3.5s bound (real >3.5s host delay, #847/G10 non-happy fixture) must NOT close the shared `-CC` lease — status stays Connected, marker round-trips, cause-trail breadcrumb transportClosed=false
   "$FQCN_PREFIX.BackgroundResumeSocketDeathE2eTest"  # #1098 #173 item 3): the genuinely-UNRECOVERABLE-host counterpart of the…
   "$FQCN_PREFIX.Issue895SwitchWhileBlackBandJourneyE2eTest"  # #895 switch-while-black freeze): the R1 trigger — a transport dro…
@@ -470,6 +485,21 @@ if [[ ! -f "$CI_JOURNEY_BUDGET_HELPER" && -f "$INVOCATION_DIR/scripts/ci-journey
   CI_JOURNEY_BUDGET_HELPER="$INVOCATION_DIR/scripts/ci-journey-budget-functions.sh"
 fi
 source "$CI_JOURNEY_BUDGET_HELPER"
+
+# Issue #2143: shared SSH/tmux fixture health gate. A journey class killed at the
+# per-class cap while holding the shared `agents` tmux server SIGSTOPped leaves
+# it frozen for every later class, and that presents as those classes' own SETUP
+# timeouts — indistinguishable from a product regression. This helper probes,
+# repairs, and records so a wedged fixture is contained and named.
+# shellcheck source=scripts/ci-journey-fixture-health.sh
+CI_JOURNEY_FIXTURE_HEALTH_HELPER="$REPO_ROOT/scripts/ci-journey-fixture-health.sh"
+if [[ ! -f "$CI_JOURNEY_FIXTURE_HEALTH_HELPER" && -f "$INVOCATION_DIR/scripts/ci-journey-fixture-health.sh" ]]; then
+  CI_JOURNEY_FIXTURE_HEALTH_HELPER="$INVOCATION_DIR/scripts/ci-journey-fixture-health.sh"
+fi
+source "$CI_JOURNEY_FIXTURE_HEALTH_HELPER"
+# Declared here as well as in the class loop so the summary can read it under
+# `set -u` on every path that reaches summary generation.
+FIXTURE_WEDGED_CLASSES=()
 
 if [[ "${POCKETSHELL_JOURNEY_SHARD:-0}" == "1" ]]; then
   if shard_run; then

--- a/scripts/ci-journey-summary-functions.sh
+++ b/scripts/ci-journey-summary-functions.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # Result classification and markdown summary helpers for scripts/ci-journey-suite.sh.
 
+# Issue #2143: this file is sourced standalone by guards that set only the
+# buckets they exercise, so the fixture-wedge bucket declares its own empty
+# default here. Under `set -u` an undeclared array would abort summary
+# generation — i.e. a change meant to make a red MORE readable would instead
+# destroy the summary the classifier depends on.
+declare -p FIXTURE_WEDGED_CLASSES >/dev/null 2>&1 || FIXTURE_WEDGED_CLASSES=()
+
 # ---------------------------------------------------------------------------
 # Issue #1827: every reader of the core-terminal proof set derives from the ONE
 # registry declared in scripts/ci-journey-core-terminal-functions.sh
@@ -143,6 +150,7 @@ finish_ci_journey_suite() {
   echo "  recovered on retry: ${#RECOVERED_CLASSES[@]}"
   echo "  failed twice: ${#FAILED_CLASSES[@]}"
   echo "  budget-timeout (issue #835 / #470 stall): ${#BUDGET_TIMEOUT_CLASSES[@]}"
+  echo "  of which the shared SSH/tmux fixture was wedged (issue #2143 SETUP failure): ${#FIXTURE_WEDGED_CLASSES[@]}"
   echo "=========================================================="
 
   # Build the markdown summary. Quote arrays defensively — an empty array under
@@ -264,6 +272,23 @@ finish_ci_journey_suite() {
         echo "- \`$c\`"
       done
       ci_journey_core_terminal_failed_bullets
+    fi
+    # Issue #2143: name a SETUP failure for what it is. This section is ADDITIVE
+    # — every class above stays in the red list and the job stays red — but it
+    # tells the reader that the shared `agents` SSH/tmux fixture was not
+    # answering when these classes ran, so the failure is not evidence about the
+    # code under test. On 23ed1b10 the absence of exactly this line sent a
+    # release chasing an app regression on a three-line version-bump commit.
+    if [[ "${#FIXTURE_WEDGED_CLASSES[@]}" -gt 0 ]]; then
+      echo
+      echo "Shared SSH/tmux fixture was WEDGED during these classes (\`JOURNEY_FIXTURE_SETUP_FAILURE\` — setup failure, NOT an assertion failure — issue #2143):"
+      for c in "${FIXTURE_WEDGED_CLASSES[@]}"; do
+        echo "- \`$c\`"
+      done
+      echo
+      echo "A wedged shared fixture makes every later tmux-touching class time out in its own"
+      echo "setup, which reads exactly like a product regression. See \`fixture-health.tsv\` in"
+      echo "this shard's artifacts for the per-attempt probe latencies and the repair actions."
     fi
   } > "$SUMMARY"
 

--- a/scripts/test-ci-journey-fixture-health.sh
+++ b/scripts/test-ci-journey-fixture-health.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+# test-ci-journey-fixture-health.sh — guard for the issue #2143 shared SSH/tmux
+# fixture health gate.
+#
+# WHAT IT PROVES, and why each case exists.
+#
+# The defect: `ReconnectStormLivelockE2eTest` SIGSTOPs the shared `agents` tmux
+# server as its fixture and restores it only from paths that run IN THE TEST
+# PROCESS. The journey harness kills a class attempt at its 420s cap, so on
+# `main` @ 23ed1b10 the server stayed frozen and every later class that touched
+# it timed out in its own SETUP — three storm-test setup timeouts at the full
+# 90s deadline plus two ProfileChipRelaunchDockerTest 30s timeouts — while the
+# class targeting the SEPARATE `agents-daemon` container passed. The shard was
+# typed "a genuine test failure (app-code regression)" on a commit whose entire
+# diff was three version strings, and the release could only proceed by re-running.
+#
+# Cases:
+#   (1) probe CLASSIFICATION — healthy, idle-no-server, wedged, unreachable are
+#       four different states and must not collapse. An idle fixture with no tmux
+#       server is HEALTHY (the next new-session starts one); a probe that cannot
+#       reach the fixture at all is NOT healthy (the "I could not check must not
+#       read like I checked" rule).
+#   (2) REPAIR, both rungs — SIGCONT restores; if it does not, the escalation to
+#       killing the tmux server does; if neither does, the status stays `wedged`
+#       and is never laundered into ok.
+#   (3) the TSV timing series exists with a numeric probe_ms per gate call.
+#   (4) END-TO-END through the REAL suite: a class that fails while the fixture is
+#       wedged is classified `JOURNEY_FIXTURE_SETUP_FAILURE`, appears in the
+#       summary's own section, and — the part that actually fixes the cascade —
+#       its RETRY runs against a REPAIRED fixture instead of the frozen one.
+#   (5) SELECTIVITY: an ordinary assertion failure on a HEALTHY fixture must NOT
+#       be classified as a setup failure. Without this, (4) would pass for a gate
+#       that simply labels every failure a fixture problem.
+#   (6) the workflow's verdict attribution maps that summary to a DISTINCT reason
+#       while STILL writing RED — the fix must not mask anything.
+#   (7) MUTATION: neuter the gate in a private sandbox copy and require (4) to go
+#       RED. A green assertion that would stay green with the bug present is the
+#       G6 wrong-cost trap; this is the mutation that must redden it.
+#   (8) REAL DOCKER (opt-in, POCKETSHELL_FIXTURE_HEALTH_REAL_DOCKER=1): the
+#       mechanism and the repair on a live `agents` container over real SSH.
+#
+# JVM-free, Docker-free and emulator-free by default (ssh/docker/gradle stubbed).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HEALTH="$SCRIPT_DIR/ci-journey-fixture-health.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+[[ -f "$HEALTH" ]] || fail "cannot find ci-journey-fixture-health.sh at $HEALTH"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# ---------------------------------------------------------------------------
+# Stub transports. State lives in files so a stub can change behaviour between
+# calls — that is what lets a repair be OBSERVED rather than assumed.
+# ---------------------------------------------------------------------------
+STATE="$SANDBOX/state"
+mkdir -p "$STATE"
+printf 'healthy\n' > "$STATE/fixture-mode"
+
+cat > "$SANDBOX/ssh-stub" <<'STUB'
+#!/usr/bin/env bash
+# Models the fixture's response to `tmux list-sessions` over SSH.
+mode="$(cat "$FIXTURE_STATE/fixture-mode" 2>/dev/null || echo healthy)"
+printf '%s\n' "$mode" >> "$FIXTURE_STATE/probe.log"
+case "$mode" in
+  healthy)     printf 'seed: 1 windows (created now)\n'; exit 0 ;;
+  no_server)   printf 'no server running on /tmp/tmux-1000/default\n' >&2; exit 1 ;;
+  wedged)      sleep 3600; exit 0 ;;
+  unreachable) printf 'ssh: connect to host 127.0.0.1 port 2222: Connection refused\n' >&2; exit 255 ;;
+esac
+exit 0
+STUB
+chmod +x "$SANDBOX/ssh-stub"
+
+cat > "$SANDBOX/docker-stub" <<'STUB'
+#!/usr/bin/env bash
+# Records what the repair actually did and applies the configured recovery.
+printf '%s\n' "$*" >> "$FIXTURE_STATE/docker.log"
+if [[ "$*" == *"kill -CONT"* ]]; then
+  printf 'sigcont\n' >> "$FIXTURE_STATE/repair.log"
+  [[ "$(cat "$FIXTURE_STATE/sigcont-restores" 2>/dev/null || echo 1)" == "1" ]] \
+    && printf 'healthy\n' > "$FIXTURE_STATE/fixture-mode"
+  exit 0
+fi
+if [[ "$*" == *"pkill -9 -f tmux"* ]]; then
+  printf 'tmux-kill\n' >> "$FIXTURE_STATE/repair.log"
+  [[ "$(cat "$FIXTURE_STATE/kill-restores" 2>/dev/null || echo 1)" == "1" ]] \
+    && printf 'no_server\n' > "$FIXTURE_STATE/fixture-mode"
+  exit 0
+fi
+# `ps -eo pid,state` enumeration used to REPORT what was stopped.
+if [[ "$*" == *"ps -eo pid,state"* ]]; then
+  printf '4242\n'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$SANDBOX/docker-stub"
+
+export FIXTURE_STATE="$STATE"
+export JOURNEY_FIXTURE_HEALTH_SSH="$SANDBOX/ssh-stub"
+export JOURNEY_FIXTURE_HEALTH_DOCKER="$SANDBOX/docker-stub"
+export JOURNEY_FIXTURE_HEALTH_CONTAINER="stub-agents"
+export JOURNEY_FIXTURE_HEALTH_KEY="$SANDBOX/stub-key"
+export JOURNEY_FIXTURE_HEALTH_PROBE_SECS=3
+export JOURNEY_FIXTURE_HEALTH_REPAIR_SECS=3
+printf 'stub-key\n' > "$SANDBOX/stub-key"
+
+set_mode() { printf '%s\n' "$1" > "$STATE/fixture-mode"; }
+reset_logs() { : > "$STATE/probe.log"; : > "$STATE/docker.log"; : > "$STATE/repair.log"; }
+
+# ---------------------------------------------------------------------------
+# (1) probe classification
+# ---------------------------------------------------------------------------
+echo "== (1) probe classification =="
+# shellcheck source=scripts/ci-journey-fixture-health.sh
+source "$HEALTH"
+
+set_mode healthy
+journey_fixture_probe; rc=$?
+[[ $rc -eq 0 ]] || fail "(1) a fixture that lists sessions must probe healthy, got rc=$rc"
+[[ "$JOURNEY_FIXTURE_HEALTH_PROBE_MS" =~ ^[0-9]+$ ]] \
+  || fail "(1) probe must record a numeric elapsed time, got '$JOURNEY_FIXTURE_HEALTH_PROBE_MS'"
+pass "(1a) sessions listed -> healthy, with a measured probe_ms"
+
+set_mode no_server
+journey_fixture_probe; rc=$?
+[[ $rc -eq 0 ]] || fail "(1) an IDLE fixture ('no server running') must probe healthy, got rc=$rc — the next new-session starts a server"
+pass "(1b) idle 'no server running' -> healthy (not mistaken for a wedge)"
+
+set_mode wedged
+journey_fixture_probe; rc=$?
+[[ $rc -eq 1 ]] || fail "(1) a non-answering fixture must probe WEDGED (rc=1), got rc=$rc"
+[[ "$JOURNEY_FIXTURE_HEALTH_DETAIL" == *"probe_timeout_after_${JOURNEY_FIXTURE_HEALTH_PROBE_SECS}s"* ]] \
+  || fail "(1) a wedged probe must name the timeout in its detail, got '$JOURNEY_FIXTURE_HEALTH_DETAIL'"
+pass "(1c) non-answering fixture -> wedged, with the timeout named"
+
+set_mode unreachable
+journey_fixture_probe; rc=$?
+[[ $rc -eq 2 ]] || fail "(1) an UNREACHABLE fixture must be its own state (rc=2), got rc=$rc — 'I could not check' must never read like 'I checked and it is fine'"
+pass "(1d) unreachable fixture -> unavailable (never laundered into healthy)"
+
+# ---------------------------------------------------------------------------
+# (2) repair, both rungs
+# ---------------------------------------------------------------------------
+echo "== (2) repair =="
+reset_logs
+set_mode wedged
+printf '1\n' > "$STATE/sigcont-restores"
+journey_fixture_health_gate post_attempt RungOne >/dev/null 2>&1
+[[ "$JOURNEY_FIXTURE_HEALTH_STATUS" == "wedged_repaired" ]] \
+  || fail "(2) SIGCONT must restore a SIGSTOPped fixture, got status=$JOURNEY_FIXTURE_HEALTH_STATUS"
+grep -q '^sigcont$' "$STATE/repair.log" \
+  || fail "(2) the repair must actually have SENT SIGCONT — repair.log: $(cat "$STATE/repair.log")"
+grep -q 'kill -CONT' "$STATE/docker.log" \
+  || fail "(2) the repair's docker invocation must carry kill -CONT"
+pass "(2a) SIGCONT rung restores a stopped server, and the signal was really sent"
+
+reset_logs
+set_mode wedged
+printf '0\n' > "$STATE/sigcont-restores"
+printf '1\n' > "$STATE/kill-restores"
+journey_fixture_health_gate post_attempt RungTwo >/dev/null 2>&1
+[[ "$JOURNEY_FIXTURE_HEALTH_STATUS" == "wedged_repaired" ]] \
+  || fail "(2) escalation to killing the tmux server must restore the fixture, got status=$JOURNEY_FIXTURE_HEALTH_STATUS"
+grep -q '^tmux-kill$' "$STATE/repair.log" \
+  || fail "(2) the escalation rung must have run — repair.log: $(cat "$STATE/repair.log")"
+pass "(2b) escalation rung restores a server SIGCONT could not"
+
+reset_logs
+set_mode wedged
+printf '0\n' > "$STATE/sigcont-restores"
+printf '0\n' > "$STATE/kill-restores"
+journey_fixture_health_gate post_attempt Unfixable >/dev/null 2>&1
+[[ "$JOURNEY_FIXTURE_HEALTH_STATUS" == "wedged" ]] \
+  || fail "(2) an unrepairable fixture must stay 'wedged', got status=$JOURNEY_FIXTURE_HEALTH_STATUS"
+pass "(2c) an unrepairable fixture is reported wedged, never ok"
+printf '1\n' > "$STATE/sigcont-restores"
+printf '1\n' > "$STATE/kill-restores"
+
+# ---------------------------------------------------------------------------
+# (3) the timing series
+# ---------------------------------------------------------------------------
+echo "== (3) bring-up timing artifact =="
+tsv="$SANDBOX/fixture-health.tsv"
+JOURNEY_FIXTURE_HEALTH_TSV="$tsv"
+set_mode healthy
+journey_fixture_health_gate preflight suite_start >/dev/null 2>&1
+journey_fixture_health_gate post_attempt SomeClass >/dev/null 2>&1
+[[ -s "$tsv" ]] || fail "(3) no fixture-health.tsv was written"
+head -1 "$tsv" | grep -q $'^timestamp_utc\tphase\tlabel\tfixture\tstatus\tprobe_ms\tdetail$' \
+  || fail "(3) fixture-health.tsv header is wrong: $(head -1 "$tsv")"
+rows="$(($(wc -l < "$tsv") - 1))"
+[[ "$rows" -eq 2 ]] || fail "(3) expected one row per gate call, got $rows"
+awk -F'\t' 'NR>1 && $6 !~ /^[0-9]+$/ { print; exit 1 }' "$tsv" \
+  || fail "(3) every recorded row must carry a numeric probe_ms"
+grep -qP '\tpreflight\tsuite_start\t' "$tsv" \
+  || fail "(3) the baseline preflight row is missing — without a known-good first row a later slow probe has nothing to be compared against"
+pass "(3) per-attempt bring-up timings are recorded with a preflight baseline"
+
+# ---------------------------------------------------------------------------
+# Sandbox repo for the end-to-end suite cases. `cp -a` (never symlinks — a
+# symlinked mutation root writes through into the tree under review, #2054).
+# ---------------------------------------------------------------------------
+# build_suite_sandbox <root> <failing-class> <wedges-the-fixture: 1|0>
+#
+# The wedging stub models REALITY: the class does not merely fail, it leaves the
+# SHARED fixture frozen behind it, exactly as the killed storm test left the tmux
+# server SIGSTOPped. Flipping the fixture to `wedged` before the suite starts
+# would instead be repaired by the preflight probe and never reach a class.
+build_suite_sandbox() {
+  local root="$1" failing_class="$2" wedges="${3:-0}"
+  rm -rf "$root"
+  mkdir -p "$root"
+  cp -a "$REPO_ROOT/scripts" "$root/scripts"
+  cat > "$root/gradlew" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--stop" ]]; then exit 0; fi
+for arg in "\$@"; do
+  case "\$arg" in
+    *class=*$failing_class*)
+      if [[ "$wedges" == "1" && ! -f "\$FIXTURE_STATE/already-wedged" ]]; then
+        : > "\$FIXTURE_STATE/already-wedged"
+        printf 'wedged\n' > "\$FIXTURE_STATE/fixture-mode"
+      fi
+      exit 1
+      ;;
+  esac
+done
+exit 0
+STUB
+  chmod +x "$root/gradlew"
+  cat > "$root/scripts/connected-test.sh" <<'STUB'
+#!/usr/bin/env bash
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$root_dir/gradlew" :app:connectedDebugAndroidTest "$@"
+STUB
+  chmod +x "$root/scripts/connected-test.sh"
+  # Narrow the class list to two entries so the run is fast and deterministic.
+  python3 - "$root/scripts/ci-journey-suite.sh" <<'PY'
+import sys
+p = sys.argv[1]
+lines = open(p).read().split('\n')
+start = next(i for i, l in enumerate(lines) if l.startswith('JOURNEY_CLASSES=('))
+end = next(i for i in range(start + 1, len(lines)) if lines[i].rstrip() == ')')
+lines[start:end + 1] = [
+    'JOURNEY_CLASSES=(',
+    '  "com.pocketshell.app.proof.SandboxWedgingClass"',
+    '  "com.pocketshell.app.proof.SandboxHealthyClass"',
+    ')',
+]
+# The core-terminal proofs are a separate cluster and irrelevant here.
+lines = [':' if l.strip() == 'run_core_terminal_proofs' else l for l in lines]
+open(p, 'w').write('\n'.join(lines))
+PY
+  # The harness refuses to continue when attempt-artifact capture comes back
+  # empty (#1840 isolation guard), so the adb stub must produce non-empty
+  # logcat / ps / dumpsys / screenshot exactly like the #835 guard's stub.
+  mkdir -p "$root/stubbin"
+  cat > "$root/stubbin/adb" <<'STUB'
+#!/usr/bin/env bash
+set -u
+emit_valid_png() {
+  printf '\211\120\116\107\015\012\032\012\000\000\000\015\111\110\104\122\000\000\000\001\000\000\000\001\010\006\000\000\000\037\025\304\211\000\000\000\015\111\104\101\124\170\234\143\140\140\140\370\017\000\001\004\001\000\137\345\303\113\000\000\000\000\111\105\116\104\256\102\140\202'
+}
+if [[ "${1:-}" == "devices" ]]; then
+  printf 'List of devices attached\nemulator-5554\tdevice\n'
+  exit 0
+fi
+if [[ "${1:-}" == "-s" ]]; then shift 2; fi
+case "${1:-}" in
+  logcat)   [[ "${2:-}" == "-c" ]] || printf 'stub-device-logcat\n' ;;
+  exec-out) emit_valid_png ;;
+  shell)
+    case "${2:-}" in
+      ps)      printf 'PID NAME\n' ;;
+      dumpsys) printf 'stub dumpsys %s\n' "$*" ;;
+    esac
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "$root/stubbin/adb"
+}
+
+run_suite_sandbox() {
+  local root="$1" out="$2"
+  ( cd "$root" && PATH="$root/stubbin:$PATH" \
+      JOURNEY_STEP_BUDGET_SECS=600 \
+      JOURNEY_CLASS_TIMEOUT_SECS=30 \
+      JOURNEY_NO_OUTPUT_TIMEOUT_SECS=25 \
+      JOURNEY_FIXTURE_HEALTH_TSV="$root/artifacts/ci-journey/fixture-health.tsv" \
+      bash "$root/scripts/ci-journey-suite.sh" ) > "$out" 2>&1
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# (4) end-to-end: a failure on a WEDGED fixture is classified as SETUP, and the
+#     retry runs against a REPAIRED fixture.
+# ---------------------------------------------------------------------------
+echo "== (4) end-to-end classification + retry on a repaired fixture =="
+WEDGE_ROOT="$SANDBOX/wedge"
+build_suite_sandbox "$WEDGE_ROOT" SandboxWedgingClass 1
+reset_logs
+set_mode healthy
+rm -f "$STATE/already-wedged"
+printf '1\n' > "$STATE/sigcont-restores"
+out4="$SANDBOX/wedge.log"
+run_suite_sandbox "$WEDGE_ROOT" "$out4"; rc4=$?
+
+[[ $rc4 -ne 0 ]] || { sed -n '1,40p' "$out4"; fail "(4) the suite must stay RED — the gate must never turn a failure green"; }
+grep -q 'JOURNEY_FIXTURE_WEDGED' "$out4" \
+  || { sed -n '1,60p' "$out4"; fail "(4) the wedged fixture was not detected"; }
+grep -q 'JOURNEY_FIXTURE_SETUP_FAILURE: com.pocketshell.app.proof.SandboxWedgingClass' "$out4" \
+  || { sed -n '1,60p' "$out4"; fail "(4) the failing class was not classified as a fixture SETUP failure"; }
+summary4="$WEDGE_ROOT/artifacts/ci-journey/summary.md"
+[[ -f "$summary4" ]] || fail "(4) no summary.md"
+grep -q 'Shared SSH/tmux fixture was WEDGED during these classes' "$summary4" \
+  || { cat "$summary4"; fail "(4) summary.md has no fixture-setup-failure section"; }
+grep -q 'Failed BOTH attempts' "$summary4" \
+  || { cat "$summary4"; fail "(4) the class must STILL be listed as failed — the classification is additive, not a downgrade"; }
+# The load-bearing half: the RETRY must have run against a repaired fixture.
+tsv4="$WEDGE_ROOT/artifacts/ci-journey/fixture-health.tsv"
+[[ -s "$tsv4" ]] || fail "(4) no fixture-health.tsv from the suite run"
+statuses4="$(awk -F'\t' 'NR>1 {print $5}' "$tsv4" | tr '\n' ',')"
+[[ "$statuses4" == *"wedged_repaired,"* ]] \
+  || fail "(4) expected a wedged_repaired row; got: $statuses4"
+[[ "$statuses4" == *"wedged_repaired,ok"* ]] \
+  || fail "(4) the attempt AFTER the repair must probe ok — that is what makes the existing retry meaningful instead of a second run against a frozen fixture. Statuses: $statuses4"
+pass "(4) wedged fixture detected, repaired, classified as SETUP, still red, retry ran healthy"
+
+# ---------------------------------------------------------------------------
+# (5) SELECTIVITY — an ordinary failure on a HEALTHY fixture is NOT a setup failure
+# ---------------------------------------------------------------------------
+echo "== (5) selectivity on a healthy fixture =="
+HEALTHY_ROOT="$SANDBOX/healthy"
+build_suite_sandbox "$HEALTHY_ROOT" SandboxWedgingClass 0
+reset_logs
+set_mode healthy
+rm -f "$STATE/already-wedged"
+out5="$SANDBOX/healthy.log"
+run_suite_sandbox "$HEALTHY_ROOT" "$out5"; rc5=$?
+[[ $rc5 -ne 0 ]] || fail "(5) the failing class must still redden the suite"
+if grep -q 'JOURNEY_FIXTURE_SETUP_FAILURE' "$out5"; then
+  sed -n '1,60p' "$out5"
+  fail "(5) an ordinary assertion failure on a HEALTHY fixture was mislabelled a fixture setup failure — the classification would be decorative"
+fi
+summary5="$HEALTHY_ROOT/artifacts/ci-journey/summary.md"
+if grep -q 'Shared SSH/tmux fixture was WEDGED' "$summary5"; then
+  cat "$summary5"
+  fail "(5) the summary claimed a wedged fixture on a healthy run"
+fi
+grep -q 'Failed BOTH attempts' "$summary5" \
+  || { cat "$summary5"; fail "(5) the genuine failure must still be reported"; }
+pass "(5) a genuine failure on a healthy fixture is NOT reclassified"
+
+# ---------------------------------------------------------------------------
+# (6) the workflow's verdict attribution
+# ---------------------------------------------------------------------------
+echo "== (6) workflow verdict attribution =="
+verdict_fn="$(awk '/^ *verdict_reason_for\(\) \{/{f=1} f{print} f && /^ *\}$/{exit}' "$WORKFLOW")"
+[[ -n "$verdict_fn" ]] || fail "(6) could not extract verdict_reason_for from tests.yml"
+probe_reason() {
+  local summary_file="$1"
+  bash -c "
+    summary='$summary_file'
+    build_fail_attempts=0
+    build_phase_attempts=0
+    $verdict_fn
+    verdict_reason_for first_attempt_journey_failure
+  "
+}
+[[ "$(probe_reason "$summary4")" == "shared_fixture_setup_failure" ]] \
+  || fail "(6) a summary carrying JOURNEY_FIXTURE_SETUP_FAILURE must be attributed distinctly, got '$(probe_reason "$summary4")'"
+[[ "$(probe_reason "$summary5")" == "first_attempt_journey_failure" ]] \
+  || fail "(6) an ordinary failure must keep its ordinary reason, got '$(probe_reason "$summary5")'"
+grep -q 'write_verdict RED "\$(verdict_reason_for first_attempt_journey_failure)"' "$WORKFLOW" \
+  || fail "(6) the fixture-setup attribution must still write a RED verdict — it renames the reason, it does not downgrade the verdict"
+pass "(6) verdict reason is distinct for a fixture setup failure, and the verdict stays RED"
+
+# ---------------------------------------------------------------------------
+# (7) MUTATION — the gate must be load-bearing
+# ---------------------------------------------------------------------------
+echo "== (7) mutation: neuter the gate and require (4) to redden =="
+MUTANT_ROOT="$SANDBOX/mutant"
+build_suite_sandbox "$MUTANT_ROOT" SandboxWedgingClass 1
+# The mutation: the gate reports `ok` unconditionally and never repairs — i.e.
+# exactly the pre-#2143 world, where a wedged fixture was invisible.
+python3 - "$MUTANT_ROOT/scripts/ci-journey-fixture-health.sh" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+needle = 'journey_fixture_health_gate() {'
+assert needle in s, "mutation anchor missing — the mutant would be a no-op"
+s = s.replace(needle, needle + '\n  JOURNEY_FIXTURE_HEALTH_STATUS=ok; JOURNEY_FIXTURE_HEALTH_PROBE_MS=0; return 0', 1)
+open(p, 'w').write(s)
+PY
+grep -q 'JOURNEY_FIXTURE_HEALTH_STATUS=ok; JOURNEY_FIXTURE_HEALTH_PROBE_MS=0; return 0' \
+  "$MUTANT_ROOT/scripts/ci-journey-fixture-health.sh" \
+  || fail "(7) the mutant was not applied — a mutation that never happened is not a passing mutation test"
+reset_logs
+set_mode healthy
+rm -f "$STATE/already-wedged"
+out7="$SANDBOX/mutant.log"
+run_suite_sandbox "$MUTANT_ROOT" "$out7" || true
+if grep -q 'JOURNEY_FIXTURE_SETUP_FAILURE' "$out7"; then
+  fail "(7) the neutered gate STILL reported a fixture setup failure — case (4) does not depend on the gate and is decorative"
+fi
+grep -q 'Failed BOTH attempts' "$MUTANT_ROOT/artifacts/ci-journey/summary.md" \
+  || fail "(7) the mutant run should still have failed the class (the mutation must redden only the new check)"
+pass "(7) mutation confirmed: without the gate the setup failure is invisible, and only that check reddens"
+
+# ---------------------------------------------------------------------------
+# (8) REAL DOCKER (opt-in)
+# ---------------------------------------------------------------------------
+if [[ "${POCKETSHELL_FIXTURE_HEALTH_REAL_DOCKER:-0}" == "1" ]]; then
+  echo "== (8) real Docker fixture: wedge -> detect -> repair =="
+  real_container="${POCKETSHELL_FIXTURE_HEALTH_REAL_CONTAINER:-pocketshell-test-agents}"
+  real_port="${POCKETSHELL_FIXTURE_HEALTH_REAL_PORT:-2222}"
+  # Own the bring-up here rather than in the workflow, so the case is runnable
+  # verbatim on any box with Docker and the workflow step stays one line.
+  chmod 600 "$REPO_ROOT/tests/docker/test_key" 2>/dev/null || true
+  if ! docker inspect -f '{{.State.Running}}' "$real_container" 2>/dev/null | grep -q true; then
+    ( cd "$REPO_ROOT" \
+      && docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents \
+      && source tests/docker/lib/wait-for-healthy.sh \
+      && wait_for_container_healthy tests/docker/docker-compose.yml agents \
+           /tmp/agents-fixture-health.log 60 ) \
+      || fail "(8) could not bring up the real agents fixture"
+  fi
+  (
+    unset JOURNEY_FIXTURE_HEALTH_SSH JOURNEY_FIXTURE_HEALTH_DOCKER
+    export JOURNEY_FIXTURE_HEALTH_CONTAINER="$real_container"
+    export JOURNEY_FIXTURE_HEALTH_PORT="$real_port"
+    export JOURNEY_FIXTURE_HEALTH_KEY="$REPO_ROOT/tests/docker/test_key"
+    export JOURNEY_FIXTURE_HEALTH_PROBE_SECS=20
+    export JOURNEY_FIXTURE_HEALTH_TSV="$SANDBOX/real.tsv"
+    unset JOURNEY_FIXTURE_HEALTH_STATUS
+    # shellcheck source=scripts/ci-journey-fixture-health.sh
+    source "$HEALTH"
+    key="$(journey_fixture_health_private_key)"
+    ssh_fixture() {
+      ssh -i "$key" -p "$real_port" -o BatchMode=yes -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR testuser@127.0.0.1 "$@"
+    }
+    ssh_fixture "tmux kill-session -t fh-probe 2>/dev/null; tmux new-session -d -s fh-probe 'sleep 600'" \
+      || { echo "TEST FAIL: (8) could not seed the real fixture" >&2; exit 1; }
+    journey_fixture_health_gate preflight real >/dev/null
+    [[ "$JOURNEY_FIXTURE_HEALTH_STATUS" == "ok" ]] \
+      || { echo "TEST FAIL: (8) the real fixture did not start healthy ($JOURNEY_FIXTURE_HEALTH_STATUS)" >&2; exit 1; }
+    pid="$(ssh_fixture "tmux display-message -p -t fh-probe '#{pid}'")"
+    ssh_fixture "kill -STOP $pid"
+    journey_fixture_health_gate post_attempt real >/dev/null
+    [[ "$JOURNEY_FIXTURE_HEALTH_STATUS" == "wedged_repaired" ]] \
+      || { echo "TEST FAIL: (8) a really SIGSTOPped tmux server was not detected+repaired ($JOURNEY_FIXTURE_HEALTH_STATUS)" >&2; exit 1; }
+    ssh_fixture "tmux kill-session -t fh-probe 2>/dev/null" || true
+    echo "  ok: (8) real fixture wedged by SIGSTOP was detected and repaired"
+  ) || fail "(8) real-Docker case failed"
+else
+  echo "  skip: (8) real-Docker case (set POCKETSHELL_FIXTURE_HEALTH_REAL_DOCKER=1 to run it)"
+fi
+
+echo "ALL FIXTURE-HEALTH GUARD CASES PASSED"


### PR DESCRIPTION
Shard 0 kept going red on commits that could not have caused it — most recently the **v0.4.44 version bump**, whose entire diff is three lines of version strings — and each release paid for it with a rerun. Reviewer **APPROVED**: https://github.com/alexeygrigorev/pocketshell/issues/2143#issuecomment-5291311301

## Cause — measured, not inferred

`ReconnectStormLivelockE2eTest` freezes the shared `agents:2222` tmux server with `kill -STOP` and restores it **only from paths that run in the test process**. The journey harness kills a class attempt at its 420 s cap; on `23ed1b10` that fired **mid-method-2 while the SIGSTOP was held** (class start 03:06:26, `GRADLE_TIMEOUT_CLEANUP` at start + 421 s), so the server stayed frozen. Every later class touching that container then timed out in its own setup — the one class targeting `agents-daemon:2239` passed.

**Why it read as an app regression:** `waitForSshFixtureReady` stays green throughout, because `tmux -V` never contacts the server. The harness reports a healthy fixture while the server is frozen solid.

Reproduced directly by the reviewer on a private fixture: against a SIGSTOPped server the readiness command returns **rc 0 in 152 ms**, while the storm seed script returns **rc 124 at 90 005 ms** — the exact reported exception — and `ProfileChipRelaunchDockerTest`'s `tmux new-session` returns **rc 124 at 31 004 ms** under its 30 s bound. Both CI failures, one root. That second one matters: `ProfileChipRelaunch` previously had no local counter-evidence and had failed twice, so its pass is now **explained rather than incidental**.

**This refutes #1850's per-shard load as the *cause*.** Per-class durations are near-identical red vs green (storm method 1: 210 s both). Load is the **trigger** — the class sits at 326 s of a 420 s cap, so a kill is likely. Which is exactly why raising timeouts and adding retries never fixed it.

## Fix

- A **remote dead-man armed before the SIGSTOP**, so the host owns the resume instead of a killable client (budget 1114 s on CI vs a 994 s max stall, so it cannot end an observation early).
- A class-covering **fixture health probe/repair** around every class attempt.
- A distinct **`shared_fixture_setup_failure`** verdict — still RED, nothing masked, **no retry added and no bound raised anywhere in the diff**.
- Per-shard bring-up timings in the artifacts.
- A seed error that keeps every attempt instead of restating the deadline.
- The 3 storm methods split into separate suite entries (shard placement 4/0/1 — shard 0 **sheds** the heavy method, so #1850's criteria still hold).

## Evidence

- **Distribution, not a sample:** implementer n=12 and reviewer n=5 consecutive real-fixture runs — **100% fail without the gate** at the full 90 s deadline, **0% with it** (detect+repair 150–206 ms; median 1174 ms against a 1177 ms healthy baseline).
- Emulator via `connected-test.sh --pool`: storm **3/3** green (212/87/8 s), `ProfileChipRelaunchDockerTest` green. rc 0, no rc 90.
- Reviewer watched the dead-man **reparent to pid 1**, survive channel close, and SIGCONT the server at its deadline; `assertWindowsAreSelfConsistent()` verified running from `@Before`.
- Two independent reviewer mutations each reddened the load-bearing guard (classification and repair), tree md5-verified untouched.
- **Orchestrator gate on this branch:** `check-file-size-hygiene` (3 files improved), `check-script-interpreter-hygiene`, `check-test-validity`, `check-version-coupling`, `check-ci-journey-harness`, `select-test-areas-selftest` (57 passed), the new `test-ci-journey-fixture-health.sh` (all cases passed), and `:app:compileDebugAndroidTestKotlin` — all exit 0. Both new scripts copied explicitly and md5-verified against the reviewed worktree.

## Disclosed, not buried

`tests.yml` had **280 bytes** of headroom (#2134), so any addition failed the size guard. A historical narrative block **already recorded per-entry in `ci-journey-suite.sh`** was compressed; the file is now **1270 bytes smaller**. The reviewer checked every removed fact against its recorded home rather than accepting the redundancy claim.

## Left for the maintainer, deliberately unchanged

The **420 s per-class cap is below this class's own declared observation ceilings** (~1250 s on CI). The split makes each method fit today, but a genuinely stuck loop is still **cut rather than reported** — which is precisely how this bug hid for months. Neither constant was changed; that is a maintainer call.

Seven non-blocking follow-ups are listed on the issue, the most important being that the dead-man's liveness currently has no automated guard.

Closes #2143