### PR TITLE
connection: pin the background grace / lease TTL relation (#2112)

### DIFF
--- a/app/src/test/java/com/pocketshell/app/tmux/connection/Issue2112GraceLeaseTtlRelationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/connection/Issue2112GraceLeaseTtlRelationTest.kt
@@ -1,0 +1,383 @@
+package com.pocketshell.app.tmux.connection
+
+import com.pocketshell.app.settings.AppSettings
+import com.pocketshell.core.connection.Clock
+import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.ConnectionEvent
+import com.pocketshell.core.connection.ConnectionState
+import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.TransportPort
+import com.pocketshell.core.connection.TransportUpDown
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseConnectionState
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Issue #2112 — the CROSS-MODULE relation guard between the background grace window
+ * (`ConnectionController.DEFAULT_GRACE_MS`, `:shared:core-connection`) and the lease pool's
+ * idle TTL (`SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS`, `:shared:core-ssh`).
+ *
+ * `:app` is the only module that sees both constants (neither `core-*` module depends on the
+ * other), so the guard lives here rather than beside `ControllerGraceDefaultTest`.
+ *
+ * **Step-1 finding (recorded on #2112): (a).** The 90 s is deliberate — it is the
+ * maintainer's #1159 directive, refining #1123's 300 s, itself raised from #687's original
+ * 60 s — AND the lease is held for the full window. It is not held by the TTL: it is held
+ * because nothing releases it. The App-level `BackgroundGraceController` starts a timer at
+ * `ON_STOP` and tears down NOTHING; the `-CC` client keeps its lease (refCount >= 1) for the
+ * whole window, so the idle-TTL clock never starts. When the window finally elapses, the
+ * teardown releases the lease alongside `onProcessStopped()`, and a release with the process
+ * stopped closes the transport immediately instead of parking it warm. So the reported
+ * "cold lease inside the grace window" state is never reached in the production sequence.
+ *
+ * Collapsing the two constants to one number (the #685 "one clock" reflex) would therefore
+ * be WRONG: they measure different things, and the user can already set the grace to 10
+ * minutes (`AppSettings.MAX_BACKGROUND_GRACE_MILLIS`) against an unchanged 60 s pool TTL.
+ * What must hold instead is the MECHANISM, and this class drives it end to end — a real
+ * [SshLeaseManager] with its real default TTL, wired to a real [ConnectionController] with
+ * its real default grace, on one virtual clock, with the controller's warm predicate reading
+ * the pool's own `stateEvents` exactly as `TmuxSessionViewModel.liveLeaseKeys` does.
+ *
+ * The counterfactual test below is the sensitivity proof: release the lease at background
+ * time (with the process still started, i.e. park it warm on the 60 s TTL) and the SAME
+ * wiring produces the dead zone — the 75 s return reconnects. That is the state this guard
+ * exists to keep out of the tree, and it is also why the guard cannot pass vacuously: the
+ * warm signal is derived from the real pool, not from a constant.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue2112GraceLeaseTtlRelationTest {
+
+    private val session = SessionId("A")
+
+    // --- The constant relation ---------------------------------------------
+
+    @Test
+    fun `the grace window and the lease idle TTL are pinned as deliberately different clocks`() {
+        // Fails if EITHER constant drifts, forcing a deliberate re-derivation of the
+        // relation (the mechanical sibling of the passive pair's equality pin). The
+        // relation is NOT equality — see the class doc and the mechanism tests below.
+        assertEquals(
+            "background grace default (#1159 maintainer directive)",
+            90_000L,
+            ConnectionController.DEFAULT_GRACE_MS,
+        )
+        assertEquals(
+            "lease pool idle TTL (#687 warm-lease window)",
+            60_000L,
+            SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS,
+        )
+        assertTrue(
+            "the grace deliberately outruns the pool TTL; if this ever flips, re-derive " +
+                "the whole relation rather than 'fixing' one constant",
+            ConnectionController.DEFAULT_GRACE_MS > SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS,
+        )
+    }
+
+    @Test
+    fun `the controller grace mirrors the App-level grace the user actually configures`() {
+        // The controller's window and the window the App-level BackgroundGraceController
+        // enforces must be ONE number, or that IS a #685-class second clock.
+        assertEquals(
+            "ConnectionController.DEFAULT_GRACE_MS must mirror AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS",
+            AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS,
+            ConnectionController.DEFAULT_GRACE_MS,
+        )
+        assertTrue(
+            "the user-configurable maximum grace (10 min) already exceeds the pool TTL by " +
+                "an order of magnitude, so equality of the two constants is not achievable " +
+                "and is not the invariant",
+            AppSettings.MAX_BACKGROUND_GRACE_MILLIS > SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS,
+        )
+    }
+
+    // --- The mechanism, driven end to end ----------------------------------
+
+    @Test
+    fun `the production background cycle keeps the lease live so a 75s return reattaches`() = runTest {
+        val fixture = fixture()
+
+        val held = fixture.acquireAndBringLive()
+        fixture.controller.submit(ConnectionEvent.Background)
+
+        // Production: ON_STOP starts the App grace timer and tears down NOTHING, so the
+        // lease stays held across the whole window. Cross the pool's 60s TTL...
+        advanceTimeBy(SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS + 1L)
+        runCurrent()
+        assertTrue(
+            "the held lease must still be live just past the pool idle TTL",
+            fixture.manager.hasLiveLease(TARGET.leaseKey),
+        )
+
+        // ...and return at 75s, inside the reported 60-90s divergence window.
+        advanceTimeBy(75_000L - (SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS + 1L))
+        runCurrent()
+        fixture.controller.submit(ConnectionEvent.Foreground)
+
+        assertEquals(
+            "a 75s return over a held lease must reattach with zero reconnect",
+            ConnectionState.Reattaching(HOST, session),
+            fixture.controller.state.value,
+        )
+        assertEquals("no re-dial may have happened", 1, fixture.connector.connectCount)
+
+        held.release()
+        runCurrent()
+    }
+
+    @Test
+    fun `the production background cycle still reattaches just inside the grace deadline`() = runTest {
+        val fixture = fixture()
+
+        val held = fixture.acquireAndBringLive()
+        fixture.controller.submit(ConnectionEvent.Background)
+        advanceTimeBy(ConnectionController.DEFAULT_GRACE_MS - 1L)
+        runCurrent()
+
+        assertTrue(
+            "the held lease must survive the entire grace window",
+            fixture.manager.hasLiveLease(TARGET.leaseKey),
+        )
+        fixture.controller.submit(ConnectionEvent.Foreground)
+        assertEquals(
+            ConnectionState.Reattaching(HOST, session),
+            fixture.controller.state.value,
+        )
+
+        held.release()
+        runCurrent()
+    }
+
+    @Test
+    fun `releasing the lease at background time would open the 60 to 90s dead zone`() = runTest {
+        // The COUNTERFACTUAL — the state the audit hypothesized, driven against the real
+        // pool. If some future change ever releases the warm lease at background time (a
+        // plausible battery-minded "D21" move), the pool's 60s TTL closes the transport
+        // mid-window and the SAME 75s return that reattaches above now reconnects. This is
+        // what the mechanism tests keep out of the tree, and it proves the wiring above is
+        // sensitive to the pool rather than reading a constant-true warm signal.
+        val fixture = fixture()
+
+        val held = fixture.acquireAndBringLive()
+        fixture.controller.submit(ConnectionEvent.Background)
+        held.release() // the hypothetical background release: parks the transport warm
+        runCurrent()
+
+        assertTrue(
+            "just inside the pool TTL the parked lease still reads warm",
+            fixture.manager.hasLiveLease(TARGET.leaseKey),
+        )
+        advanceTimeBy(SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS)
+        runCurrent()
+        assertFalse(
+            "the pool TTL closes the parked transport mid-grace-window",
+            fixture.manager.hasLiveLease(TARGET.leaseKey),
+        )
+
+        advanceTimeBy(75_000L - SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS)
+        runCurrent()
+        fixture.controller.submit(ConnectionEvent.Foreground)
+
+        assertEquals(
+            "with the lease released at background time the 75s return reconnects — the " +
+                "dead zone. The controller stays HONEST (it never promises a reattach it " +
+                "cannot keep), but the user pays a reconnect inside the grace window.",
+            ConnectionState.Reconnecting(HOST, session, attempt = 1),
+            fixture.controller.state.value,
+        )
+    }
+
+    @Test
+    fun `the grace-elapsed teardown drops the warm snapshot at once, not an idle TTL later`() = runTest {
+        // The other end of the window: at grace-elapsed the app tears down and stops the
+        // lease process. The warm snapshot the controller's predicate reads must go false
+        // immediately, so a later foreground can never be told "within grace" over a
+        // transport the app already tore down.
+        val fixture = fixture()
+
+        val held = fixture.acquireAndBringLive()
+        fixture.controller.submit(ConnectionEvent.Background)
+        advanceTimeBy(ConnectionController.DEFAULT_GRACE_MS)
+        runCurrent()
+
+        // grace elapsed -> dispatchTmuxBackground() teardown + lease process stop
+        fixture.manager.onProcessStopped()
+        held.release()
+        runCurrent()
+
+        val teardownAtMs = testScheduler.currentTime
+        assertFalse(
+            "the teardown release must drop the warm snapshot at once",
+            fixture.warmSnapshot(HOST),
+        )
+        assertEquals(
+            "no part of the drop may be deferred to the pool idle TTL",
+            teardownAtMs,
+            testScheduler.currentTime,
+        )
+
+        fixture.controller.submit(ConnectionEvent.Foreground)
+        assertEquals(
+            ConnectionState.Reconnecting(HOST, session, attempt = 1),
+            fixture.controller.state.value,
+        )
+    }
+
+    // ---- harness ----
+
+    /**
+     * The real pool + the real controller on ONE virtual clock, wired the way production
+     * wires them: the controller's warm predicate reads a `liveLeaseKeys` set fed from
+     * `SshLeaseManager.stateEvents` (Connecting/Connected/Idle -> warm, Closed -> cold),
+     * which is byte-for-byte the `TmuxSessionViewModel` bookkeeping, and the lease key is
+     * mapped through the production [hostKeyFor].
+     */
+    private inner class Fixture(
+        val manager: SshLeaseManager,
+        val connector: CountingConnector,
+        val controller: ConnectionController,
+        private val liveLeaseKeys: MutableSet<SshLeaseKey>,
+    ) {
+        fun warmSnapshot(host: HostKey): Boolean =
+            liveLeaseKeys.any { hostKeyFor(it) == host }
+
+        suspend fun acquireAndBringLive(): SshLease {
+            val lease = manager.acquire(TARGET).getOrThrow()
+            controller.submit(ConnectionEvent.Enter(HOST, session))
+            controller.submit(ConnectionEvent.TransportLive)
+            controller.submit(ConnectionEvent.SeedLanded(session, "%0"))
+            assertEquals(ConnectionState.Live(HOST, session), controller.state.value)
+            return lease
+        }
+    }
+
+    private fun TestScope.fixture(): Fixture {
+        val connector = CountingConnector()
+        val manager = SshLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS,
+            maxIdleLeases = SshLeaseManager.DEFAULT_MAX_IDLE_LEASES,
+            connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
+            nowMillis = { testScheduler.currentTime },
+        )
+        val liveLeaseKeys: MutableSet<SshLeaseKey> = ConcurrentHashMap.newKeySet()
+        backgroundScope.launch(StandardTestDispatcher(testScheduler)) {
+            manager.stateEvents.collect { event ->
+                when (event.state) {
+                    SshLeaseConnectionState.Connecting,
+                    SshLeaseConnectionState.Connected,
+                    SshLeaseConnectionState.Idle,
+                    -> liveLeaseKeys.add(event.key)
+
+                    SshLeaseConnectionState.Closed -> liveLeaseKeys.remove(event.key)
+                }
+            }
+        }
+        runCurrent()
+        val controller = ConnectionController(
+            clock = object : Clock {
+                override fun nowMs(): Long = testScheduler.currentTime
+            },
+            transport = object : TransportPort {
+                // The controller itself only ever consults `isWarm`; `transportEvents` is
+                // the ConnectionEffectDriver's input, which this relation guard does not
+                // exercise. `isWarm` — the property under test — is the REAL pool signal.
+                override val transportEvents: Flow<TransportUpDown> = emptyFlow()
+
+                override fun isWarm(host: HostKey): Boolean =
+                    liveLeaseKeys.any { hostKeyFor(it) == host }
+            },
+        )
+        return Fixture(manager, connector, controller, liveLeaseKeys)
+    }
+
+    private class CountingConnector : SshLeaseConnector {
+        var connectCount: Int = 0
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            connectCount += 1
+            return Result.success(FakeSshSession())
+        }
+    }
+
+    private class FakeSshSession : SshSession {
+        private var closed: Boolean = false
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = object : SshShell {
+            override val stdin = ByteArrayOutputStream()
+            override val stdout = ByteArrayInputStream(ByteArray(0))
+            override val stderr = ByteArrayInputStream(ByteArray(0))
+            override fun close() = Unit
+        }
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        val TARGET: SshLeaseTarget = SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = "10.0.2.2",
+                port = 2222,
+                user = "testuser",
+                credentialId = "/tmp/key-a",
+            ),
+            key = SshKey.Path(File("/tmp/key-a")),
+        )
+
+        val HOST: HostKey = hostKeyFor(TARGET.leaseKey)
+    }
+}

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue2112GraceLeaseTtlBoundaryTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/Issue2112GraceLeaseTtlBoundaryTest.kt
@@ -1,0 +1,250 @@
+package com.pocketshell.core.connection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2112 — the background-grace / lease-idle-TTL boundary CLASS.
+ *
+ * The #685 root cause was three disagreeing clocks, and the cure was to collapse the
+ * decision onto ONE. The passive pair still pins that literally
+ * (`TmuxSessionViewModelPassiveReconnectTest` asserts `PASSIVE_DISCONNECT_GRACE_MS ==
+ * DEFAULT_IDLE_TTL_MILLIS`), but the BACKGROUND grace is 90 s
+ * ([ConnectionController.DEFAULT_GRACE_MS], #1123 60 s -> 300 s, #1159 300 s -> 90 s)
+ * against a 60 s `SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS`, and nothing related them.
+ *
+ * The step-1 finding (recorded on #2112) is **(a)**: the divergence is deliberate and the
+ * lease IS held for the whole window — during the App-level background grace the `-CC`
+ * client still holds its lease (refCount >= 1), so the idle-TTL clock never starts; the
+ * teardown that finally releases it runs with the process stopped, which closes the
+ * transport IMMEDIATELY instead of parking it warm. The two constants therefore measure
+ * DIFFERENT things and must not be collapsed to one number. What has to be true instead
+ * is pinned here:
+ *
+ *  - the 60 s lease-TTL instant is NOT a grace boundary — a return at 59 999 / 60 000 /
+ *    60 001 / 75 000 / 89 999 ms is equally within grace (the whole reported 60-90 s
+ *    "divergence window" behaves as one region);
+ *  - the ONLY boundary is the grace deadline itself (90 000 ms, exclusive);
+ *  - the within-grace promise is CONJOINED with warmth, so if a lease ever did go cold
+ *    inside the window the controller degrades honestly to `Reconnecting` rather than
+ *    promising a zero-reconnect reattach it cannot keep.
+ *
+ * The mutations these are written to redden: collapsing `DEFAULT_GRACE_MS` back to
+ * 60 000 (the "one clock" reflex) reddens every point past 60 s; dropping the
+ * `consultWarm` conjunct from `onForeground` reddens the cold half; relaxing `now <
+ * deadline` to `<=` reddens the exact-deadline case.
+ *
+ * The cross-module relation (this window vs the real lease pool) is guarded in `:app` by
+ * `Issue2112GraceLeaseTtlRelationTest`, the only module that sees both constants.
+ */
+class Issue2112GraceLeaseTtlBoundaryTest {
+
+    private val host = HostKey("alice@host:22")
+    private val target = SessionId("A")
+
+    /**
+     * The instants that make up the class. The reported symptom (a return at 75 s) is ONE
+     * member of it; the lease-TTL boundary on either side and the grace boundary on either
+     * side are the rest.
+     */
+    private val leaseTtlMs = 60_000L
+    private val justInsideLeaseTtl = leaseTtlMs - 1L
+    private val exactlyLeaseTtl = leaseTtlMs
+    private val justPastLeaseTtl = leaseTtlMs + 1L
+    private val reportedDivergenceMidpoint = 75_000L
+    private val justInsideGrace = ConnectionController.DEFAULT_GRACE_MS - 1L
+    private val exactlyGrace = ConnectionController.DEFAULT_GRACE_MS
+    private val justPastGrace = ConnectionController.DEFAULT_GRACE_MS + 1L
+
+    @Test
+    fun `the divergence window is real - the grace outruns the lease idle TTL`() {
+        // The premise of the whole class. If these ever become equal the boundary cases
+        // below stop testing anything, so state the premise instead of assuming it.
+        assertTrue(
+            "issue #2112 only exists while the background grace outruns the lease idle TTL; " +
+                "grace=${ConnectionController.DEFAULT_GRACE_MS} ttl=$leaseTtlMs",
+            ConnectionController.DEFAULT_GRACE_MS > leaseTtlMs,
+        )
+        assertNotEquals(
+            "the 60s constant here mirrors SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS",
+            ConnectionController.DEFAULT_GRACE_MS,
+            leaseTtlMs,
+        )
+    }
+
+    // --- Within grace: the lease-TTL instant is NOT a boundary -------------
+
+    @Test
+    fun `a warm return just inside the lease idle TTL reattaches`() {
+        assertEquals(
+            ConnectionState.Reattaching(host, target),
+            foregroundAfter(justInsideLeaseTtl, leaseWarmOnReturn = true),
+        )
+    }
+
+    @Test
+    fun `a warm return exactly at the lease idle TTL reattaches`() {
+        assertEquals(
+            ConnectionState.Reattaching(host, target),
+            foregroundAfter(exactlyLeaseTtl, leaseWarmOnReturn = true),
+        )
+    }
+
+    @Test
+    fun `a warm return just past the lease idle TTL still reattaches`() {
+        // The load-bearing point of #2112: crossing the LEASE clock changes nothing,
+        // because that clock is not running during the background hold. Collapsing
+        // DEFAULT_GRACE_MS to 60s reddens exactly here.
+        assertEquals(
+            ConnectionState.Reattaching(host, target),
+            foregroundAfter(justPastLeaseTtl, leaseWarmOnReturn = true),
+        )
+    }
+
+    @Test
+    fun `a warm return at 75s - the reported divergence midpoint - reattaches`() {
+        assertEquals(
+            ConnectionState.Reattaching(host, target),
+            foregroundAfter(reportedDivergenceMidpoint, leaseWarmOnReturn = true),
+        )
+    }
+
+    @Test
+    fun `a warm return just inside the grace deadline reattaches`() {
+        assertEquals(
+            ConnectionState.Reattaching(host, target),
+            foregroundAfter(justInsideGrace, leaseWarmOnReturn = true),
+        )
+    }
+
+    // --- The one real boundary: the grace deadline itself ------------------
+
+    @Test
+    fun `a warm return exactly at the grace deadline reconnects`() {
+        // `now < deadline` is strict, so the deadline instant is already beyond grace.
+        assertEquals(
+            ConnectionState.Reconnecting(host, target, attempt = 1),
+            foregroundAfter(exactlyGrace, leaseWarmOnReturn = true),
+        )
+    }
+
+    @Test
+    fun `a warm return just past the grace deadline reconnects`() {
+        assertEquals(
+            ConnectionState.Reconnecting(host, target, attempt = 1),
+            foregroundAfter(justPastGrace, leaseWarmOnReturn = true),
+        )
+    }
+
+    // --- The 75s journey makes zero reconnect, not merely one good state ---
+
+    @Test
+    fun `the 75s return heals without ever entering a reconnect or a cold connect`() {
+        val clock = FakeClock()
+        val transport = FakeTransportPort()
+        val controller = controller(clock, transport).bringLive(transport)
+        val seen = mutableListOf(controller.state.value)
+
+        controller.submit(ConnectionEvent.Background)
+        seen += controller.state.value
+        clock.advanceBy(reportedDivergenceMidpoint)
+
+        controller.submit(ConnectionEvent.Foreground)
+        seen += controller.state.value
+        controller.submit(ConnectionEvent.TransportLive)
+        seen += controller.state.value
+        controller.submit(ConnectionEvent.SeedLanded(target, "%0"))
+        seen += controller.state.value
+
+        assertEquals(
+            "the 75s return must land back on the same live target",
+            ConnectionState.Live(host, target),
+            controller.state.value,
+        )
+        assertTrue(
+            "a within-grace return must never reconnect or re-dial; saw $seen",
+            seen.none { it is ConnectionState.Reconnecting || it is ConnectionState.Connecting },
+        )
+    }
+
+    // --- The negative half: a cold lease inside the window stays honest ----
+    //
+    // Class coverage (G2): the within-grace promise is `deadline && warm`, never the
+    // deadline alone. If some future change DOES release the lease at background time
+    // (the counterfactual `:app` `Issue2112GraceLeaseTtlRelationTest` drives against the
+    // real pool), the user must get an honest silent reconnect, not a promise of a
+    // zero-reconnect reattach over a transport that is gone.
+
+    @Test
+    fun `a cold return just inside the lease idle TTL reconnects honestly`() {
+        assertEquals(
+            ConnectionState.Reconnecting(host, target, attempt = 1),
+            foregroundAfter(justInsideLeaseTtl, leaseWarmOnReturn = false),
+        )
+    }
+
+    @Test
+    fun `a cold return just past the lease idle TTL reconnects honestly`() {
+        assertEquals(
+            ConnectionState.Reconnecting(host, target, attempt = 1),
+            foregroundAfter(justPastLeaseTtl, leaseWarmOnReturn = false),
+        )
+    }
+
+    @Test
+    fun `a cold return at 75s reconnects honestly instead of promising a reattach`() {
+        assertEquals(
+            ConnectionState.Reconnecting(host, target, attempt = 1),
+            foregroundAfter(reportedDivergenceMidpoint, leaseWarmOnReturn = false),
+        )
+    }
+
+    @Test
+    fun `a cold return just inside the grace deadline reconnects honestly`() {
+        assertEquals(
+            ConnectionState.Reconnecting(host, target, attempt = 1),
+            foregroundAfter(justInsideGrace, leaseWarmOnReturn = false),
+        )
+    }
+
+    // ---- harness ----
+
+    /**
+     * Live -> Background -> advance [elapsedMs] -> Foreground, with the lease warm or
+     * cold at the moment of return. Returns the state the controller resolved to.
+     */
+    private fun foregroundAfter(elapsedMs: Long, leaseWarmOnReturn: Boolean): ConnectionState {
+        val clock = FakeClock()
+        val transport = FakeTransportPort()
+        val controller = controller(clock, transport).bringLive(transport)
+
+        controller.submit(ConnectionEvent.Background)
+        assertTrue(
+            "the fixture must actually be backgrounded before the return",
+            controller.state.value is ConnectionState.Backgrounded,
+        )
+        transport.setWarm(host, leaseWarmOnReturn)
+        clock.advanceBy(elapsedMs)
+
+        controller.submit(ConnectionEvent.Foreground)
+        return controller.state.value
+    }
+
+    /** Production shape: the REAL default grace window and the REAL default ladder. */
+    private fun controller(clock: FakeClock, transport: FakeTransportPort) =
+        ConnectionController(clock = clock, transport = transport)
+
+    private fun ConnectionController.bringLive(
+        transport: FakeTransportPort,
+    ): ConnectionController {
+        transport.setWarm(host, false)
+        submit(ConnectionEvent.Enter(host, target))
+        transport.setWarm(host, true)
+        submit(ConnectionEvent.TransportLive)
+        submit(ConnectionEvent.SeedLanded(target, "%0"))
+        assertEquals(ConnectionState.Live(host, target), state.value)
+        return this
+    }
+}

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/Issue2112BackgroundGraceLeaseHoldTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/Issue2112BackgroundGraceLeaseHoldTest.kt
@@ -1,0 +1,329 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #2112 — the lease-pool half of the "90 s background grace vs 60 s lease idle TTL"
+ * question.
+ *
+ * The audit's hypothesis was that a background return at t = 60-90 s finds a lease that
+ * has passed its idle TTL and gone cold, so the controller's within-grace contract
+ * promises a zero-reconnect reattach the transport cannot honour. The step-1 finding
+ * (recorded on #2112) is that the hypothesis does not hold, and this class pins the two
+ * mechanisms that are the REASON it does not hold — the properties a future change would
+ * have to break in order to open that 30-second dead zone:
+ *
+ *  1. **The idle-TTL clock only runs on a ZERO-REF entry.** Throughout the App-level
+ *     background grace window the `-CC` control client still holds its lease (the VM
+ *     acquires at connect and releases only in the teardown), so the 60 s TTL is not
+ *     running at all — the transport is held, not parked.
+ *  2. **The release that finally happens, at grace-elapsed, closes IMMEDIATELY.** The
+ *     teardown runs alongside `onProcessStopped()`, and `release()` with the process
+ *     stopped removes and closes the entry rather than parking it warm for another TTL.
+ *     So the pool can never hold a warm-looking entry across a process-stop boundary.
+ *
+ * Together these are what make `DEFAULT_GRACE_MS` (90 s) > `DEFAULT_IDLE_TTL_MILLIS`
+ * (60 s) SAFE rather than a dead zone: the two constants never measure the same interval.
+ *
+ * Mutations these are written to redden: making the idle reaper ignore `refCount`
+ * (test 1); deleting the `!processStarted` disjunct from `release()` so a teardown-time
+ * release parks warm on the 60 s TTL instead of closing (tests 3/4) — that one mutation
+ * is precisely the change that would CREATE the reported dead zone. Test 2 is the
+ * complementary POSITIVE: the TTL must still work for an ordinary foreground release, so
+ * a fix for 3/4 cannot be "never park anything warm".
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue2112BackgroundGraceLeaseHoldTest {
+
+    /**
+     * The controller's background grace window (`ConnectionController.DEFAULT_GRACE_MS`).
+     * Duplicated as a literal because `:shared:core-ssh` does not depend on
+     * `:shared:core-connection`; the cross-module equality of the two numbers is asserted
+     * in `:app` by `Issue2112GraceLeaseTtlRelationTest`, which sees both.
+     */
+    private val controllerGraceMs = 90_000L
+
+    @Test
+    fun `a held lease never starts the idle TTL clock so it outlives the whole grace window`() {
+        // Mechanism 1. The session is attached for the whole background hold, so its lease
+        // refCount stays >= 1 and the idle reaper never gets an entry to reap. Advance well
+        // past BOTH the 60s TTL and the 90s grace window: the transport is still live and
+        // no second dial happened.
+        runTest {
+            val session = FakeSshSession()
+            val connector = QueueLeaseConnector(session)
+            val manager = leaseManager(connector)
+
+            val held = manager.acquire(TARGET).getOrThrow()
+
+            advanceTimeBy(SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS + 1L)
+            runCurrent()
+            assertFalse(
+                "a held lease must not be reaped when the idle TTL elapses",
+                session.closed,
+            )
+            assertTrue(
+                "the pool must still report the held lease as live at the TTL boundary",
+                manager.hasLiveLease(TARGET.leaseKey),
+            )
+
+            advanceTimeBy(controllerGraceMs - SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS)
+            runCurrent()
+            assertFalse(
+                "a held lease must survive the whole 90s background grace window",
+                session.closed,
+            )
+            assertTrue(
+                "the warm snapshot the controller's grace predicate reads must still be warm",
+                manager.hasLiveLease(TARGET.leaseKey),
+            )
+            assertEquals("the held lease must not have been re-dialled", 1, connector.connectCount)
+
+            held.release()
+            runCurrent()
+        }
+    }
+
+    @Test
+    fun `a partial release during the background hold does not start the idle clock`() {
+        // Mechanism 1's live mutant: only the LAST release may start the idle clock. If a
+        // partial release ever parked the entry (deleting the `refCount > 0` early return
+        // in `release()`), the still-attached `-CC` client's transport would be reaped 60 s
+        // into a 90 s hold — the dead zone, arriving from the refcount side instead of the
+        // background side.
+        runTest {
+            val session = FakeSshSession()
+            val connector = QueueLeaseConnector(session)
+            val manager = leaseManager(connector)
+
+            val first = manager.acquire(TARGET).getOrThrow()
+            val second = manager.acquire(TARGET).getOrThrow()
+            assertEquals("the two holders must share one dial", 1, connector.connectCount)
+
+            second.release()
+            runCurrent()
+
+            advanceTimeBy(controllerGraceMs)
+            runCurrent()
+            assertFalse(
+                "a remaining holder must keep the transport alive across the whole window",
+                session.closed,
+            )
+            assertTrue(manager.hasLiveLease(TARGET.leaseKey))
+
+            first.release()
+            runCurrent()
+        }
+    }
+
+    @Test
+    fun `a foreground release parks the transport warm for exactly the idle TTL`() {
+        // Mechanism 2, positive half. With the process STARTED (the app in the
+        // foreground), the last release parks the transport warm so a host switch-back
+        // reuses it. This is the behaviour the 60s TTL actually governs, and it must keep
+        // working — the tests below must not be satisfiable by "close everything at once".
+        runTest {
+            val session = FakeSshSession()
+            val connector = QueueLeaseConnector(session)
+            val manager = leaseManager(connector)
+            val events = collectStateEvents(manager)
+
+            manager.acquire(TARGET).getOrThrow().release()
+            runCurrent()
+            assertFalse("the release must park the transport warm, not close it", session.closed)
+            assertEquals(SshLeaseConnectionState.Idle, events.last().state)
+
+            advanceTimeBy(SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS - 1L)
+            runCurrent()
+            assertFalse("the warm transport must survive until the idle TTL", session.closed)
+
+            advanceTimeBy(1L)
+            runCurrent()
+            assertTrue("the warm transport must close at the idle TTL", session.closed)
+            assertEquals(SshLeaseConnectionState.Closed, events.last().state)
+            assertEquals(SshLeaseCloseReason.IdleExpired, events.last().closeReason)
+        }
+    }
+
+    @Test
+    fun `a release after the process stopped closes immediately instead of parking warm`() {
+        // Mechanism 2, load-bearing half. The grace-elapsed teardown releases the lease
+        // with the process stopped. If that release parked the transport warm on the 60s
+        // TTL, the pool would report a warm lease for another minute over a transport the
+        // app has already torn down — the exact shape of the dead zone #2112 asks about.
+        // It must close AT ONCE, at the same virtual instant.
+        runTest {
+            val session = FakeSshSession()
+            val connector = QueueLeaseConnector(session)
+            val manager = leaseManager(connector)
+            val events = collectStateEvents(manager)
+
+            val held = manager.acquire(TARGET).getOrThrow()
+            manager.onProcessStopped()
+            val releasedAtMs = testScheduler.currentTime
+
+            held.release()
+            runCurrent()
+
+            assertTrue(
+                "a release with the process stopped must close the transport immediately",
+                session.closed,
+            )
+            assertEquals(
+                "the close must land at the same instant as the release, not after the idle TTL",
+                releasedAtMs,
+                testScheduler.currentTime,
+            )
+            assertFalse(
+                "the pool must not report a warm lease after the teardown release",
+                manager.hasLiveLease(TARGET.leaseKey),
+            )
+            assertEquals(SshLeaseConnectionState.Closed, events.last().state)
+            assertEquals(
+                "the close must be attributed to the process stop, not an idle expiry",
+                SshLeaseCloseReason.ProcessStopped,
+                events.last().closeReason,
+            )
+        }
+    }
+
+    @Test
+    fun `onProcessStopped closes an already-parked warm lease immediately`() {
+        // The ordering sibling of the test above: the teardown's release can land BEFORE
+        // the process-stop dispatch, leaving a briefly-parked warm entry. The process stop
+        // must then collapse it at once rather than leaving it to serve out the rest of a
+        // 60s TTL while the app is backgrounded.
+        runTest {
+            val session = FakeSshSession()
+            val connector = QueueLeaseConnector(session)
+            val manager = leaseManager(connector)
+            val events = collectStateEvents(manager)
+
+            manager.acquire(TARGET).getOrThrow().release()
+            runCurrent()
+            assertFalse("precondition: the release parked the transport warm", session.closed)
+
+            val stoppedAtMs = testScheduler.currentTime
+            manager.onProcessStopped()
+            runCurrent()
+
+            assertTrue("the process stop must close the parked warm transport", session.closed)
+            assertEquals(
+                "the close must land at the process stop, not at the remaining idle TTL",
+                stoppedAtMs,
+                testScheduler.currentTime,
+            )
+            assertFalse(manager.hasLiveLease(TARGET.leaseKey))
+            assertEquals(SshLeaseCloseReason.ProcessStopped, events.last().closeReason)
+        }
+    }
+
+    // ---- harness ----
+
+    /**
+     * Every owned background hop is pinned to the test scheduler (the dial bound, its
+     * abort, the idle-reaper `scope`, and the manager's own clock), so the virtual clock
+     * fully drives the pool — no real dispatcher, no wall-clock race.
+     */
+    private fun TestScope.leaseManager(connector: SshLeaseConnector): SshLeaseManager =
+        SshLeaseManager(
+            connector = connector,
+            scope = this,
+            // The REAL production default: this test is about that exact number.
+            idleTtlMillis = SshLeaseManager.DEFAULT_IDLE_TTL_MILLIS,
+            maxIdleLeases = SshLeaseManager.DEFAULT_MAX_IDLE_LEASES,
+            connectTimeoutContext = StandardTestDispatcher(testScheduler),
+            abortTimeoutContext = StandardTestDispatcher(testScheduler),
+            nowMillis = { testScheduler.currentTime },
+        )
+
+    private fun TestScope.collectStateEvents(
+        manager: SshLeaseManager,
+    ): List<SshLeaseStateEvent> {
+        val events = mutableListOf<SshLeaseStateEvent>()
+        backgroundScope.launch(StandardTestDispatcher(testScheduler)) {
+            manager.stateEvents.collect { events += it }
+        }
+        runCurrent()
+        return events
+    }
+
+    private class QueueLeaseConnector(
+        private vararg val sessions: FakeSshSession,
+    ) : SshLeaseConnector {
+        var connectCount: Int = 0
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val next = sessions.getOrNull(connectCount)
+                ?: error("unexpected connect $connectCount for ${target.leaseKey}")
+            connectCount += 1
+            return Result.success(next)
+        }
+    }
+
+    private class FakeSshSession : SshSession {
+        var closed: Boolean = false
+        var connected: Boolean = true
+
+        override val isConnected: Boolean
+            get() = connected && !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = object : SshShell {
+            override val stdin = ByteArrayOutputStream()
+            override val stdout = ByteArrayInputStream(ByteArray(0))
+            override val stderr = ByteArrayInputStream(ByteArray(0))
+            override fun close() = Unit
+        }
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        val TARGET: SshLeaseTarget = SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = "10.0.2.2",
+                port = 2222,
+                user = "testuser",
+                credentialId = "/tmp/key-a",
+            ),
+            key = SshKey.Path(File("/tmp/key-a")),
+        )
+    }
+}


### PR DESCRIPTION
Closes #2112

## The issue's premise was wrong — and that is the main finding

I filed #2112 off the test-suite audit claiming a live user-visible dead zone: background the app, foreground at t=60-90s, and the lease has passed its 60s idle TTL so you get a reconnect despite being "within grace". **That does not happen.** Both the implementer and the reviewer established it independently:

- `App.kt` (`ON_STOP`) starts only the grace timer. The `-CC` client keeps its lease, and `SshLeaseManager.release()` returns early while `refCount > 0` — so the 60s TTL clock never starts.
- The controller's `Background` is reached only from inside `onGraceElapsed`.
- That teardown stops the lease process, and the `!processStarted` disjunct closes the transport immediately rather than parking it warm.

The reviewer added a reductio the code trace does not need but which settles it on its own: **`MAX_BACKGROUND_GRACE_MILLIS` is 10 minutes and already user-selectable** against the unchanged 60s TTL. If the premise held, choosing the maximum would expose a nine-minute dead zone that shipped long ago and nobody has reported.

Two further corrections to the issue body: the divergence came from **#1123** (60s→300s), not #1159 — `git log -L` gives `#687 60s → #1123 300s → #1159 90s`; and the citation of `ConnectionManagerEquivalenceTest` was a misreading, since that test injects `warm = { false }` at t=10s.

## What lands

Three new test files, **zero production changes** — pinning the real contract so the relation cannot drift silently:

- the 75s case plus the boundary class (59999 / 60000 / 60001 / 75000 / 89999 / 90000 / 90001, warm and cold arms)
- the two pool mechanisms exercised against a real `SshLeaseManager`
- a cross-module relation guard that fails if the two constants drift apart

## Evidence

Six-mutant matrix, re-derived independently by the reviewer from `cp -a` backups, each compiled (so provably live), run with `--continue` so a first-module failure could not hide the rest, then restored and md5-verified. Every claim reproduced exactly: M1 collapse-grace-to-60s = 8 kills, M2 drop-`consultWarm` = 5, M3 `<`→`<=` = 1, M4 delete `!processStarted` = 2, M5 ref-blind reaper = 1, M6 TTL drift = 1.

The two that carry the most weight: **M2 kills the relation counterfactual**, proving the warm signal comes from the real pool rather than a constant-true stub; and **M4 kills the cross-module teardown guard** — M4 being precisely the change that *would* create the reported dead zone. Boundary outcomes partition on two axes and are discriminated by M1/M2/M3, so they are not seven assertions that cannot disagree.

## Verification on this integration commit, rebased onto `66c3acf8`

Note `main` moved under this branch: **#822 (#2137)** and **#1602 (#2119)** both touched the connection core after its base, so the full canonical gate was run rather than a module subset.

- `scripts/full-jvm-gate.py` run directly as a transient unit recording its own exit status: **verdict 0**, `BUILD SUCCESSFUL in 18m 24s`, 603/603 tasks executed
- **12,514 tests executed, 0 failures** (Debug 6263 + Release 6251), counts asserted from this run's XML
- No `UP-TO-DATE` / `FROM-CACHE` on any real test task
- All three new classes named in **both** Debug and Release XML at 13 / 5 / 6 tests

## Follow-up

The reviewer confirmed the controller's 90s window never yields `Reattaching` on the background path — at the moment `Background` is submitted the lease has just closed, so `consultWarm` is false for the whole window it counts. That is tracked separately as **#2116** (a D28 call), along with a naming nit: the relation test's "the production background cycle …" names overclaim, since production does not submit `Background` at `ON_STOP`.

Audit: `_docs/2026-08-13-test-suite-audit.md` §3 — which needs the same correction as this PR body.