### PR TITLE
test infra: carve journey sharding to sharding-only (#2110)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1052,8 +1052,15 @@ jobs:
     # (the suite reads POCKETSHELL_JOURNEY_CI_SHARD_INDEX/_TOTAL; see
     # scripts/ci-journey-suite.sh), so each leg's wall clock drops and each
     # emulator stays healthier (~1/N install/teardown cycles). `fail-fast: false`
-    # so one shard's failure does not cancel the others. The 6 core-terminal
-    # proofs run on every leg (cheap Compose UI tests), not sharded.
+    # so one shard's failure does not cancel the others.
+    #
+    # Issue #2110: the core-terminal proofs are sharded by the same #1862 hash
+    # now. They used to run on EVERY leg "so a regression in any of them is caught
+    # on every leg", but all six legs run the SAME COMMIT and those proofs are
+    # device-independent in-process tests — five of every six verdicts were
+    # copies. Each proof now runs on exactly one leg per push; the union over the
+    # matrix is still the whole registry, asserted mechanically by
+    # scripts/test-ci-journey-budget.sh rather than by inspection.
     #
     # Issue #2060 (CI Phase A): 3 -> 6 shards, as much a RELIABILITY fix as a
     # speed one. The registry has grown to 173 entries and on BOTH recent green

--- a/scripts/ci-journey-class-selection-functions.sh
+++ b/scripts/ci-journey-class-selection-functions.sh
@@ -85,10 +85,16 @@
 # Default (unset / TOTAL<=1) = the unsharded serial path, UNCHANGED — so local
 # runs and the budget self-test still run the FULL set. This is ORTHOGONAL to the
 # #724 POCKETSHELL_JOURNEY_SHARD dev-box pool sharding (multiple emulators on ONE
-# host); the two never combine on CI (one AVD per matrix leg). The six
-# core-terminal proofs are NOT sharded — they are cheap in-process Compose UI
-# tests (no Docker churn) and run on EVERY shard so a regression in any of them is
-# caught on every leg.
+# host); the two never combine on CI (one AVD per matrix leg).
+#
+# Issue #2110: the core-terminal proofs are sharded by this SAME hash now. They
+# used to run on EVERY leg "so a regression in any of them is caught on every
+# leg" — but every leg runs the same commit and these proofs are device-
+# independent in-process tests, so five of the six verdicts were copies costing
+# ~20-35 runner-minutes a push. The partition lives in
+# scripts/ci-journey-core-terminal-functions.sh
+# (select_effective_core_terminal_proofs), reusing journey_class_shard_index
+# below so there is exactly one partition mechanism to reason about.
 
 # FNV-1a/32 over the bytes of "$1", printed as an unsigned decimal.
 #
@@ -135,7 +141,7 @@ select_effective_journey_classes() {
         EFFECTIVE_JOURNEY_CLASSES+=("$_shard_class")
       fi
     done
-    echo ">>> CI journey shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL} (issues #835, #1862): running ${#EFFECTIVE_JOURNEY_CLASSES[@]} of ${#JOURNEY_CLASSES[@]} journey classes (partitioned by class-name hash, so registering a journey does not re-roll the others), plus all 6 core-terminal proofs"
+    echo ">>> CI journey shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL} (issues #835, #1862): running ${#EFFECTIVE_JOURNEY_CLASSES[@]} of ${#JOURNEY_CLASSES[@]} journey classes (partitioned by class-name hash, so registering a journey does not re-roll the others); the core-terminal proofs are partitioned by the same hash (issue #2110)"
   fi
 }
 

--- a/scripts/ci-journey-core-terminal-functions.sh
+++ b/scripts/ci-journey-core-terminal-functions.sh
@@ -125,3 +125,106 @@ CORE_TERMINAL_PROOFS=(
   "HARD_WRAPPED_URL_STATUS|CORE_TERMINAL_HARD_WRAPPED_URL_CLASS|Core-terminal #1955 hard-wrapped URL target proof"
   "PIXEL_PROBE_ABANDON_STATUS|CORE_TERMINAL_PIXEL_PROBE_ABANDON_CLASS|Core-terminal #2003 abandoned-PixelCopy RenderThread abort proof"
 )
+
+# ---------------------------------------------------------------------------
+# Issue #2110: the proofs are SHARDED across the CI matrix, exactly like the
+# journey classes.
+#
+# THE WASTE THIS REMOVES
+# ----------------------
+# Every one of these proofs used to run on EVERY matrix leg. The stated reason
+# was "a regression in any of them is caught on every leg" — but all six legs
+# run the SAME COMMIT, and these are device-independent in-process Compose /
+# TerminalView tests with no Docker fixture and no cross-shard state. Six
+# identical verdicts on one commit is one verdict plus five copies: ~20-35
+# runner-minutes and 4-7 minutes of wall clock on five legs, buying zero
+# additional signal. (The measured suite is 206 of ~269 runner-min per push and
+# roughly half of that is work repeated six times — see _docs/2026-08-13-test-suite-audit.md §4.)
+#
+# THE MECHANISM AND WHY THIS SHAPE
+# --------------------------------
+# The partition reuses the #1862 class-name hash verbatim (journey_class_shard_hash
+# over the proof's SELECTOR, i.e. the FQCN or `FQCN#method` the runner is given).
+# So a proof's leg depends only on its own name: registering, removing or
+# reordering a proof cannot re-roll where the others land, and a red leg right
+# after a registration is signal about the new proof rather than noise from
+# relocated siblings. The same reasons the index-based partition was rejected for
+# journey classes apply here unchanged.
+#
+# Deliberately NOT chosen:
+#   * pinning the proofs to one nominated shard — that leg becomes strictly the
+#     slowest by construction and the imbalance grows with every new proof;
+#   * a second, proof-specific hash/salt — a second partition to reason about for
+#     no benefit; the #1862 mechanism already has the property we need.
+#
+# WHAT A DEFERRED PROOF IS
+# ------------------------
+# A proof this leg does not own gets status OTHER_SHARD. That is NOT a pass and
+# NOT a skip: it means another leg of the SAME push owns it, so this shard has no
+# opinion. `ci_journey_core_terminal_all_passed` therefore treats it as
+# "nothing to say" and the red-evidence fail-safe never names it as a cause.
+# The property that actually matters — every registered proof runs on exactly one
+# leg, and the union over the shipped matrix is the whole registry — is not left
+# to inspection: scripts/test-ci-journey-budget.sh drives the REAL suite once per
+# shipped shard and asserts disjointness + completeness mechanically, the same way
+# it already does for JOURNEY_CLASSES.
+#
+# Unsharded (total <= 1, i.e. every local run and every self-test that does not
+# set the matrix vars) selects ALL proofs, unchanged.
+CORE_TERMINAL_OTHER_SHARD_STATUS="OTHER_SHARD"
+
+# select_effective_core_terminal_proofs — partition CORE_TERMINAL_PROOFS by the
+# #1862 name hash and mark the proofs this leg does not own as OTHER_SHARD.
+# Populates EFFECTIVE_CORE_TERMINAL_PROOFS (registry entries this leg runs).
+select_effective_core_terminal_proofs() {
+  # Prefer the ALREADY-NORMALISED values select_effective_journey_classes wrote
+  # (it clamps a malformed/out-of-range matrix var), so the proofs and the
+  # classes can never be partitioned over two different totals.
+  local total="${JOURNEY_CI_SHARD_TOTAL:-${POCKETSHELL_JOURNEY_CI_SHARD_TOTAL:-1}}"
+  local index="${JOURNEY_CI_SHARD_INDEX:-${POCKETSHELL_JOURNEY_CI_SHARD_INDEX:-0}}"
+  [[ "$total" =~ ^[0-9]+$ ]] || total=1
+  [[ "$index" =~ ^[0-9]+$ ]] || index=0
+  (( total < 1 )) && total=1
+  (( index < 0 || index >= total )) && index=0
+
+  EFFECTIVE_CORE_TERMINAL_PROOFS=()
+  local entry status_var class_var label owner deferred=0
+  for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
+    IFS='|' read -r status_var class_var label <<<"$entry"
+    if (( total <= 1 )); then
+      owner="$index"
+    else
+      owner="$(journey_class_shard_index "${!class_var}" "$total")"
+    fi
+    if [[ "$owner" == "$index" ]]; then
+      EFFECTIVE_CORE_TERMINAL_PROOFS+=("$entry")
+      echo "CORE_TERMINAL_SHARD_SELECTED: ${!class_var} (shard ${owner}/${total}) — ${label}"
+    else
+      printf -v "$status_var" '%s' "$CORE_TERMINAL_OTHER_SHARD_STATUS"
+      deferred=$((deferred + 1))
+      echo "CORE_TERMINAL_SHARD_DEFERRED: ${!class_var} (runs on shard ${owner}/${total} this push) — ${label}"
+    fi
+  done
+  echo ">>> CI core-terminal proof shard ${index}/${total} (issue #2110): running ${#EFFECTIVE_CORE_TERMINAL_PROOFS[@]} of ${#CORE_TERMINAL_PROOFS[@]} proofs on this leg, ${deferred} owned by sibling legs of the SAME push (partitioned by the #1862 proof-name hash)"
+}
+
+# core_terminal_proof_deferred <STATUS_VAR> — true when this leg does not own the
+# proof. The suite gates each proof block on it; the summary treats it as
+# "no opinion", never as a pass and never as a failure cause.
+core_terminal_proof_deferred() {
+  [[ "${!1:-}" == "$CORE_TERMINAL_OTHER_SHARD_STATUS" ]]
+}
+
+# announce_core_terminal_deferred <STATUS_VAR> — one greppable line at the point
+# in the run where the proof WOULD have executed, so a leg's log reads honestly
+# top-to-bottom instead of silently omitting it.
+announce_core_terminal_deferred() {
+  local wanted="$1" entry status_var class_var label
+  for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
+    IFS='|' read -r status_var class_var label <<<"$entry"
+    [[ "$status_var" == "$wanted" ]] || continue
+    echo "CORE_TERMINAL_OTHER_SHARD: skipping ${label} (\`${!class_var}\`) — a sibling leg of this push owns it (issue #2110)"
+    return 0
+  done
+  echo "CORE_TERMINAL_OTHER_SHARD: skipping $wanted — a sibling leg of this push owns it (issue #2110)"
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -543,6 +543,15 @@ if [[ ! -f "$CI_JOURNEY_CORE_TERMINAL_HELPER" && -f "$INVOCATION_DIR/scripts/ci-
 fi
 source "$CI_JOURNEY_CORE_TERMINAL_HELPER"
 
+# Issue #2110: partition the core-terminal proofs across the CI matrix by the
+# same #1862 name hash the journey classes use, so each proof runs on exactly ONE
+# leg per push instead of all six. Six legs of the same commit re-running the
+# same device-independent in-process proof produced one verdict and five copies.
+# A proof this leg does not own is marked OTHER_SHARD before its block below and
+# skipped there; see the helper for why OTHER_SHARD is neither a pass nor a skip.
+# Unsharded runs (no matrix vars) select every proof, unchanged.
+select_effective_core_terminal_proofs
+
 # Result classification and markdown summary generation live in a sourced helper.
 # shellcheck source=scripts/ci-journey-summary-functions.sh
 CI_JOURNEY_SUMMARY_HELPER="$REPO_ROOT/scripts/ci-journey-summary-functions.sh"
@@ -572,7 +581,10 @@ source "$CI_JOURNEY_SUMMARY_HELPER"
 # cap and lose the artifact. A skipped proof is recorded as SKIPPED (not PASS,
 # not FAIL) so the summary is honest; the budget-timeout label below makes the
 # job red regardless.
-if budget_exhausted; then
+if core_terminal_proof_deferred APPEND_BURST_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred APPEND_BURST_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   APPEND_BURST_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #803 append-burst proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -607,7 +619,10 @@ fi
 # not at PR time. Adding it here closes the loop so the Codex ANR cannot reach a
 # green `main` again. Uses NO Docker fixture (in-process Compose UI test).
 # Issue #835: same budget guard as the #803 proof above.
-if budget_exhausted; then
+if core_terminal_proof_deferred OUTPUT_BURST_IME_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred OUTPUT_BURST_IME_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   OUTPUT_BURST_IME_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #796 output-burst-IME proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -641,7 +656,10 @@ fi
 # Uses NO Docker fixture (in-process Compose UI test). The JVM sibling
 # SshTerminalBridgeTest#onMainMultiChunkSeedRespectsTimeBudgetAcrossWholeFeed...
 # proves the same property deterministically in the per-push Unit job.
-if budget_exhausted; then
+if core_terminal_proof_deferred MULTICHUNK_SEED_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred MULTICHUNK_SEED_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   MULTICHUNK_SEED_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #866 multi-chunk seed attach proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -676,7 +694,10 @@ fi
 # a regression of #803's over-correction, an un-gated test invites the exact
 # recurrence — so it runs in this per-push gate alongside the #803/#796/#866
 # proofs. Uses NO Docker fixture (in-process Compose UI test).
-if budget_exhausted; then
+if core_terminal_proof_deferred AGENT_LINK_AFFORDANCE_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred AGENT_LINK_AFFORDANCE_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   AGENT_LINK_AFFORDANCE_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #871 agent-pane link-affordance proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -717,7 +738,10 @@ fi
 # a REAL TerminalView (its onDraw under the platform dirty clip + the real
 # forceFullRepaint() + the real TerminalSurfaceState.fullRepaintRequests
 # collector), not a renderer-model stand-in.
-if budget_exhausted; then
+if core_terminal_proof_deferred REATTACH_REPAINT_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred REATTACH_REPAINT_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   REATTACH_REPAINT_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #879 reattach-repaint proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -747,7 +771,10 @@ fi
 # proxy gap that bypassed TerminalView.currentSession and stayed green while
 # the connected journey lost the first post-grace key into stale session A.
 # Uses no Docker fixture.
-if budget_exhausted; then
+if core_terminal_proof_deferred SESSION_BINDING_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred SESSION_BINDING_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   SESSION_BINDING_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #959 mounted session-binding proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -785,7 +812,10 @@ fi
 # the un-fixed overlays (the activity dies with the out-of-range crash); GREEN
 # after the `layoutOverlayBounded` clamp. Uses NO Docker fixture (in-process
 # Compose UI test). It lives under com.pocketshell.core.terminal.selection.
-if budget_exhausted; then
+if core_terminal_proof_deferred OVERLAY_UNBOUNDED_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred OVERLAY_UNBOUNDED_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   OVERLAY_UNBOUNDED_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping overlay-unbounded-measure proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -822,7 +852,10 @@ fi
 # onDraw paints CONTENT (observer reports true). Proves the surface re-bind is
 # the load-bearing recovery, not another invalidate(). Uses NO Docker fixture
 # (in-process render test). Lives under com.termux.view.
-if budget_exhausted; then
+if core_terminal_proof_deferred SURFACE_REPAINT_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred SURFACE_REPAINT_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   SURFACE_REPAINT_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #1203 surface-repaint proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -860,7 +893,10 @@ fi
 # on-main scans per tick. Because #1233 is adjacent to the #796/#803/#866/#871
 # terminal-ANR class it runs alongside those proofs in this per-push gate. Uses
 # NO Docker fixture (in-process Compose UI test).
-if budget_exhausted; then
+if core_terminal_proof_deferred SHELL_SNAPSHOT_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred SHELL_SNAPSHOT_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   SHELL_SNAPSHOT_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #1233 shell-pane single-snapshot proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -891,7 +927,10 @@ fi
 # TerminalViewClient route, and requires two ACTION_VIEW intents carrying the
 # exact complete GitHub URI. It also pins the continuation not being exposed as
 # a local file path. Uses NO Docker fixture (in-process real TerminalView).
-if budget_exhausted; then
+if core_terminal_proof_deferred HARD_WRAPPED_URL_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred HARD_WRAPPED_URL_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   HARD_WRAPPED_URL_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #1955 hard-wrapped URL proof — suite budget exhausted (issue #835 / #470 stall)"
@@ -930,7 +969,10 @@ fi
 # with the base recycle it dies as "Process crashed", with the ownership fix the
 # process survives and the probe still works. A diagnostic must never be able to
 # abort the app, so it stays guarded per-push. Uses NO Docker fixture.
-if budget_exhausted; then
+if core_terminal_proof_deferred PIXEL_PROBE_ABANDON_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred PIXEL_PROBE_ABANDON_STATUS
+elif budget_exhausted; then
   STEP_TIMEOUT_HIT=1
   PIXEL_PROBE_ABANDON_STATUS="SKIPPED"
   echo "JOURNEY_STEP_TIMEOUT: skipping #2003 abandoned-PixelCopy proof — suite budget exhausted (issue #835 / #470 stall)"

--- a/scripts/ci-journey-summary-functions.sh
+++ b/scripts/ci-journey-summary-functions.sh
@@ -19,12 +19,17 @@ declare -p FIXTURE_WEDGED_CLASSES >/dev/null 2>&1 || FIXTURE_WEDGED_CLASSES=()
 # construction. `ci_journey_assert_red_has_evidence` below is the belt-and-braces
 # backstop for any FUTURE red cause that is not a registered proof.
 
-# ci_journey_core_terminal_all_passed — true iff every registered proof is PASS.
+# ci_journey_core_terminal_all_passed — true iff every proof THIS LEG OWNS is
+# PASS. Issue #2110: a proof owned by a sibling leg of the same push carries
+# status OTHER_SHARD; this leg has no opinion about it, so it neither reddens
+# nor greens this shard. The union property (every proof owned by exactly one
+# leg) is asserted mechanically by scripts/test-ci-journey-budget.sh, not by
+# hoping each shard checks all eleven.
 ci_journey_core_terminal_all_passed() {
   local entry status_var
   for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
     status_var="${entry%%|*}"
-    [[ "${!status_var}" == "PASS" ]] || return 1
+    [[ "${!status_var}" == "PASS" || "${!status_var}" == "OTHER_SHARD" ]] || return 1
   done
   return 0
 }
@@ -51,6 +56,11 @@ ci_journey_core_terminal_status_lines() {
     echo
     echo "$label (\`shared:core-terminal\`): **${!status_var}**"
     echo "- \`${!class_var}\`"
+    # Issue #2110: say plainly that OTHER_SHARD is "another leg of this push ran
+    # it", so nobody reads the absent verdict as a silently dropped proof.
+    if [[ "${!status_var}" == "OTHER_SHARD" ]]; then
+      echo "- owned by a sibling matrix leg of this push (issue #2110 proof sharding); this shard did not run it"
+    fi
   done
 }
 
@@ -101,7 +111,10 @@ ci_journey_assert_red_has_evidence() {
   } >> "$summary"
   for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
     IFS='|' read -r status_var class_var label <<<"$entry"
-    [[ "${!status_var}" == "PASS" ]] && continue
+    # Issue #2110: PASS is not a cause, and neither is OTHER_SHARD — a proof a
+    # sibling leg of this push owns cannot be the reason THIS leg went red, and
+    # naming it would point the investigation at a class this shard never ran.
+    [[ "${!status_var}" == "PASS" || "${!status_var}" == "OTHER_SHARD" ]] && continue
     echo "- \`${!class_var}\` (${label#Core-terminal } — status ${!status_var})" >> "$summary"
     wrote=1
   done

--- a/scripts/test-ci-journey-budget.sh
+++ b/scripts/test-ci-journey-budget.sh
@@ -2077,7 +2077,20 @@ pass "(shard-balance) the partition is uniform to 3 sigma on the real list (tota
 # emulator). Drive the REAL suite once per shard (instant gradle stub, generous
 # budget) and assert: (a) each shard launches ~class_count/N classes, (b) the
 # slices are pairwise DISJOINT (no class on two shards), (c) the UNION is every
-# class (none dropped), (d) the core-terminal proofs run on EVERY shard.
+# class (none dropped), (d) the SAME three properties for the core-terminal
+# proofs (issue #2110).
+#
+# Issue #2110 replaced (d). It used to be `grep 'CORE-TERMINAL #796 ...'` on every
+# shard — the right check for the old "proofs run on EVERY leg" design, and the
+# wrong one now that a proof runs on exactly ONE leg. The property that matters
+# did not get weaker, it moved: coverage is no longer "each shard runs all of
+# them" but "the UNION over the shipped matrix is the whole registry", which is
+# the criterion the issue demands be proven mechanically rather than asserted by
+# inspection. So it is now the same disjoint+complete arithmetic the classes get,
+# computed from the proofs the suite actually EXECUTED (the run headers), not
+# from the selector's own claim about what it picked — and (shard-proof-live)
+# below proves that arithmetic is sensitive by deferring one proof everywhere and
+# requiring the completeness check to redden.
 #
 # Issue #1862 widened (a)'s tolerance from +/-2 to +/-25%: the partition is now
 # by class-name hash, which is statistically rather than exactly balanced. The
@@ -2100,8 +2113,35 @@ chmod +x "$SANDBOX/gradlew"
 shard_total="$shipped_shard_total"
 [[ "$shard_total" =~ ^[0-9]+$ && "$shard_total" -ge 2 ]] \
   || fail "(shard) implausible shipped shard total '$shard_total' — refusing to drive the suite over an unknown partition"
+
+# Issue #2110: the proof registry, read from the REAL helper, so "the union is
+# complete" is measured against the shipping list rather than a copy that rots.
+# shellcheck source=scripts/ci-journey-core-terminal-functions.sh
+source "$SCRIPT_DIR/ci-journey-core-terminal-functions.sh"
+registry_proof_selectors=()
+registry_proof_status_vars=()
+for ct_entry in "${CORE_TERMINAL_PROOFS[@]}"; do
+  IFS='|' read -r ct_status_var ct_class_var _ct_label <<<"$ct_entry"
+  registry_proof_selectors+=("${!ct_class_var}")
+  registry_proof_status_vars+=("$ct_status_var")
+done
+proof_count="${#registry_proof_selectors[@]}"
+[[ "$proof_count" -ge 9 ]] \
+  || fail "(shard-proof) only $proof_count core-terminal proofs parsed from the registry — the reader is broken, not the registry"
+
+# executed_proofs_in <log> — the proofs a shard actually RAN, from the run header
+# the suite prints inside the execute branch. A deferred proof prints
+# CORE_TERMINAL_OTHER_SHARD instead and is deliberately not matched here: this
+# must measure execution, not the selector's claim about its own output.
+executed_proofs_in() {
+  grep -oE '>>> CORE-TERMINAL .*PROOF: [^ ]+ \(attempt 1\)' "$1" \
+    | sed -E 's/^.*PROOF: ([^ ]+) \(attempt 1\)$/\1/'
+}
+
 declare -A seen_class_shard=()
+declare -A seen_proof_shard=()
 shard_union_count=0
+proof_union_count=0
 for (( shard_idx = 0; shard_idx < shard_total; shard_idx++ )); do
   shard_log="$SANDBOX/run-shard-$shard_idx.log"
   set +e
@@ -2127,12 +2167,116 @@ for (( shard_idx = 0; shard_idx < shard_total; shard_idx++ )); do
     seen_class_shard["$sc"]="$shard_idx"
     shard_union_count=$((shard_union_count + 1))
   done
-  grep -q 'CORE-TERMINAL #796 OUTPUT-BURST-IME PROOF' "$shard_log" \
-    || fail "(shard) shard $shard_idx did not run the core-terminal proofs (they must run on EVERY leg, not be sharded)"
+  # Issue #2110: the same disjointness bookkeeping for the core-terminal proofs.
+  mapfile -t shard_proofs < <(executed_proofs_in "$shard_log")
+  for sp in "${shard_proofs[@]}"; do
+    [[ -z "${seen_proof_shard[$sp]:-}" ]] \
+      || fail "(shard-proof) proof $sp ran on BOTH shard ${seen_proof_shard[$sp]} and shard $shard_idx — the proof partition is not disjoint, so the push pays for it twice"
+    seen_proof_shard["$sp"]="$shard_idx"
+    proof_union_count=$((proof_union_count + 1))
+  done
+  echo "    shard $shard_idx: ${shard_n} classes, ${#shard_proofs[@]} core-terminal proofs"
 done
 [[ "$shard_union_count" -eq "$class_count" ]] \
   || fail "(shard) union of all shards = $shard_union_count classes, expected the full $class_count (a class ran on no shard or twice)"
-pass "(shard) hash partition: the SHIPPED $shard_total shards each ~1/$shard_total, disjoint, union = all $class_count classes; proofs on every shard"
+
+# THE COVERAGE-PRESERVATION CRITERION, computed rather than asserted: every
+# registered proof must have executed on exactly one leg of the shipped matrix.
+[[ "$proof_union_count" -eq "$proof_count" ]] \
+  || fail "(shard-proof) union of all shards = $proof_union_count proof runs, expected exactly $proof_count (a proof ran on no shard, or on more than one)"
+for sel in "${registry_proof_selectors[@]}"; do
+  [[ -n "${seen_proof_shard[$sel]:-}" ]] \
+    || fail "(shard-proof) registered core-terminal proof $sel ran on NO shard of the shipped $shard_total — sharding the proofs must redistribute them, never drop one (issue #2110)"
+done
+pass "(shard) hash partition: the SHIPPED $shard_total shards each ~1/$shard_total, disjoint, union = all $class_count classes"
+pass "(shard-proof) all $proof_count core-terminal proofs ran exactly once across the SHIPPED $shard_total shards (disjoint + complete), so proof coverage per push is unchanged while five of every six runs are gone"
+
+# ---------------------------------------------------------------------------
+# (shard-proof-live) The completeness check above must be SENSITIVE, or it is
+# decorative. Name the mutation: make ONE registered proof deferred on EVERY leg
+# — the exact way proof sharding could silently delete coverage — and require
+# (shard-proof) to redden. Only the affected shard is re-run; the other legs'
+# already-collected sets are reused, so this liveness control costs one extra
+# suite invocation, not another full matrix.
+echo "== (shard-proof-live) a proof that runs NOWHERE must redden the completeness check =="
+live_target_var=""
+live_target_sel=""
+live_target_shard=""
+for (( li = 0; li < proof_count; li++ )); do
+  live_target_var="${registry_proof_status_vars[$li]}"
+  live_target_sel="${registry_proof_selectors[$li]}"
+  live_target_shard="${seen_proof_shard[$live_target_sel]}"
+  break
+done
+[[ -n "$live_target_var" && -n "$live_target_shard" ]] \
+  || fail "(shard-proof-live) could not pick a proof to drop — the control cannot run"
+
+# The mutant is written INTO THE SANDBOX, never into the repository. The suite
+# resolves each helper from its own $REPO_ROOT first (here: $SANDBOX, where only
+# the suite has been copied) and falls back to the invocation dir (the real
+# scripts/), so DROPPING a mutated copy into $SANDBOX/scripts shadows the real
+# helper for this one run and deleting it restores the fallback. Editing the
+# repository copy in place would be the #2054 write-through: a harness that
+# mutates the tree it is measuring produces results about a tree that no longer
+# exists. The real file's checksum is taken before and re-checked after, so a
+# future refactor that reintroduces an in-place edit is caught rather than
+# shipped.
+ct_real="$SCRIPT_DIR/ci-journey-core-terminal-functions.sh"
+ct_real_md5_before="$(md5sum "$ct_real" | awk '{print $1}')"
+ct_mutant="$SANDBOX/scripts/ci-journey-core-terminal-functions.sh"
+[[ ! -e "$ct_mutant" ]] \
+  || fail "(shard-proof-live) $ct_mutant already exists — the baseline shards above did NOT run the real helper, so the control compares two mutants"
+# Force this ONE proof's owner to a bucket no real shard index can equal.
+python3 - "$ct_real" "$ct_mutant" "$live_target_var" <<'PYEOF'
+import sys
+src_path, out_path, target = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(src_path).read()
+anchor = '    if [[ "$owner" == "$index" ]]; then\n'
+assert anchor in src, "(shard-proof-live) selector anchor moved; the mutant cannot be built"
+inject = ('    [[ "$status_var" == "%s" ]] && owner=999999  # mutant: owned by nobody\n' % target)
+open(out_path, "w").write(src.replace(anchor, inject + anchor, 1))
+PYEOF
+[[ $? -eq 0 ]] || fail "(shard-proof-live) could not build the mutant selector"
+grep -q 'owner=999999' "$ct_mutant" \
+  || fail "(shard-proof-live) the mutant does not contain the injected line — a mutation that never happened is not a passing mutation test"
+
+live_log="$SANDBOX/run-shard-$live_target_shard-mutant.log"
+set +e
+PATH="$STUBBIN:$PATH" \
+  JOURNEY_STEP_BUDGET_SECS=3600 \
+  JOURNEY_CLASS_TIMEOUT_SECS=420 \
+  POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$shard_total" \
+  POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$live_target_shard" \
+  bash "$SANDBOX/scripts/ci-journey-suite.sh" > "$live_log" 2>&1
+rc_live=$?
+set -e
+rm -f "$ct_mutant"   # restore the real helper for every later block
+[[ ! -e "$ct_mutant" ]] \
+  || fail "(shard-proof-live) the mutant helper survived — later blocks would measure a mutated tree"
+[[ "$(md5sum "$ct_real" | awk '{print $1}')" == "$ct_real_md5_before" ]] \
+  || fail "(shard-proof-live) the REPOSITORY copy of ci-journey-core-terminal-functions.sh changed during the mutation — the harness wrote through into the tree it is measuring (#2054)"
+[[ "$rc_live" -eq 0 ]] \
+  || { sed -n '1,40p' "$live_log"; fail "(shard-proof-live) the mutant shard exited $rc_live; the control must differ from the baseline ONLY in the dropped proof"; }
+
+mapfile -t live_proofs < <(executed_proofs_in "$live_log")
+for lp in "${live_proofs[@]}"; do
+  [[ "$lp" != "$live_target_sel" ]] \
+    || { sed -n '1,40p' "$live_log"; fail "(shard-proof-live) the mutant still ran $live_target_sel — the control is not live"; }
+done
+# Recompute completeness with the mutant leg substituted for its baseline leg.
+declare -A live_seen=()
+for sel in "${!seen_proof_shard[@]}"; do
+  [[ "${seen_proof_shard[$sel]}" == "$live_target_shard" ]] && continue
+  live_seen["$sel"]=1
+done
+for lp in "${live_proofs[@]}"; do live_seen["$lp"]=1; done
+live_missing=()
+for sel in "${registry_proof_selectors[@]}"; do
+  [[ -n "${live_seen[$sel]:-}" ]] || live_missing+=("$sel")
+done
+[[ "${#live_missing[@]}" -eq 1 && "${live_missing[0]}" == "$live_target_sel" ]] \
+  || fail "(shard-proof-live) dropping $live_target_sel everywhere left missing=[${live_missing[*]:-none}]; the completeness check must report exactly that one proof — anything else means it is over- or under-sensitive"
+pass "(shard-proof-live) deferring $live_target_var on every leg leaves exactly $live_target_sel uncovered, and (shard-proof) reddens on it — the completeness check is live, not decorative"
 
 # ---------------------------------------------------------------------------
 # (m) ACCEPTANCE — Issue #835 (REOPENED): the six core-terminal proofs are now

--- a/scripts/test-ci-journey-summary-evidence.sh
+++ b/scripts/test-ci-journey-summary-evidence.sh
@@ -500,9 +500,18 @@ STUB
 }
 
 # run_real_suite <workspace> [env assignments...] — the REAL suite. A large shard
-# total keeps the journey-class loop to a single class so the run is cheap; the
-# core-terminal proofs are NOT sharded and all run on every shard, which is the
-# part under test.
+# total keeps the journey-class loop to a single class so the run is cheap.
+#
+# Issue #2110: the core-terminal proofs are sharded by the SAME #1862 name hash,
+# so "run the suite and every proof executes" is no longer true — each proof runs
+# only on the leg its own name hashes to. Callers that need a SPECIFIC proof to
+# execute set RUN_REAL_SUITE_SHARD_INDEX to that proof's owning index (derived
+# from the production `journey_class_shard_index`, never hardcoded), which is
+# what the (b) matrix below does. Everything else keeps the resolved single-class
+# shard. Deliberately NOT done: an env knob that disables proof sharding for the
+# harness — that would stop this file traversing the production selector, which
+# is the exact "the guard presets the variable it exists to exercise" shape the
+# repo keeps getting bitten by.
 SUITE_RC=0
 run_real_suite() {
   local ws="$1"; shift
@@ -513,7 +522,7 @@ run_real_suite() {
     JOURNEY_CLASS_KILL_AFTER_SECS=1 \
     JOURNEY_GRADLE_STOP_TIMEOUT_SECS=5 \
     POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$SOLO_SHARD_TOTAL" \
-    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$SOLO_SHARD_INDEX" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="${RUN_REAL_SUITE_SHARD_INDEX:-$SOLO_SHARD_INDEX}" \
     "$@" \
     bash "$ws/scripts/ci-journey-suite.sh" > "$ws/suite.log" 2>&1
   SUITE_RC=$?
@@ -537,6 +546,15 @@ for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
   IFS='|' read -r status_var class_var label <<<"$entry"
   selector="${!class_var}"
   bare_class="${selector%%#*}"
+
+  # Issue #2110: run this arm on the leg that OWNS this proof, computed by the
+  # production selector rather than assumed. Before proof sharding every leg ran
+  # every proof, so any index worked; now the wrong index would silently defer the
+  # proof under test and turn both arms of this matrix vacuous (the suite would
+  # stay green with nothing failing, and the "no failed-both section" assertion
+  # in the red control would pass for entirely the wrong reason).
+  RUN_REAL_SUITE_SHARD_INDEX="$(journey_class_shard_index "$selector" "$SOLO_SHARD_TOTAL")"
+  export RUN_REAL_SUITE_SHARD_INDEX
 
   # --- RED CONTROL: the pre-#1827 writer for this one entry.
   mut="$SANDBOX/mutant-$status_var"
@@ -562,6 +580,12 @@ for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
   ws="$SANDBOX/fixed-$status_var"
   make_workspace "$ws"
   run_real_suite "$ws" JOURNEY_STUB_FAIL_CLASS="$selector"
+  # Issue #2110 anti-vacuity: prove the proof actually EXECUTED on this leg. If
+  # the ownership arithmetic above were wrong the proof would be deferred, the
+  # suite would pass, and every assertion in this arm would be about a proof that
+  # never ran.
+  grep -qF "PROOF: $selector (attempt 1)" "$ws/suite.log" \
+    || { sed -n '1,40p' "$ws/suite.log"; fail "(b/$status_var) $selector did not execute on shard $RUN_REAL_SUITE_SHARD_INDEX of $SOLO_SHARD_TOTAL — this arm would be vacuous (issue #2110 proof sharding)"; }
   [[ "$SUITE_RC" -ne 0 ]] \
     || { sed -n '1,40p' "$ws/suite.log"; fail "(b/$status_var) the suite exited 0 with a proof failed twice"; }
   summary="$ws/artifacts/ci-journey/summary.md"
@@ -592,7 +616,8 @@ for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
   [[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
     || { printf '%s\n' "$AGG_OUT"; fail "(b/$status_var) expected aggregate RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
 
-  pass "(b/$status_var) pre-#1827 writer -> INFRA / RE-RUN / exit 0   |   real writer -> RED / RED / exit 1   [$bare_class]"
+  pass "(b/$status_var) pre-#1827 writer -> INFRA / RE-RUN / exit 0   |   real writer -> RED / RED / exit 1   [$bare_class, shard $RUN_REAL_SUITE_SHARD_INDEX]"
+  unset RUN_REAL_SUITE_SHARD_INDEX
 done
 
 # ---------------------------------------------------------------------------
@@ -780,11 +805,25 @@ run_real_suite "$ws"
 summary="$ws/artifacts/ci-journey/summary.md"
 grep -qE 'Failed BOTH attempts|JOURNEY_STEP_TIMEOUT' "$summary" \
   && { cat "$summary"; fail "(e1) a healthy suite must write no failure evidence (no false red)"; }
+# Issue #2110: every registered proof still gets a status LINE on every leg — the
+# #1827 anti-drift property is unchanged — but its value is PASS only on the leg
+# that OWNS it and OTHER_SHARD elsewhere. Assert the exact expected value per
+# entry, derived from the production selector, so this stays a real constraint
+# rather than "PASS or anything else".
+e1_owned=0
 for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
   IFS='|' read -r status_var class_var label <<<"$entry"
-  grep -qF "$label (\`shared:core-terminal\`): **PASS**" "$summary" \
-    || { cat "$summary"; fail "(e1) the summary lost the status line for $label"; }
+  owner="$(journey_class_shard_index "${!class_var}" "$SOLO_SHARD_TOTAL")"
+  if [[ "$owner" == "$SOLO_SHARD_INDEX" ]]; then
+    expected="PASS"
+    e1_owned=$((e1_owned + 1))
+  else
+    expected="OTHER_SHARD"
+  fi
+  grep -qF "$label (\`shared:core-terminal\`): **$expected**" "$summary" \
+    || { cat "$summary"; fail "(e1) the summary line for $label is not **$expected** on shard $SOLO_SHARD_INDEX of $SOLO_SHARD_TOTAL (issue #2110)"; }
 done
+echo "   (e1) shard $SOLO_SHARD_INDEX of $SOLO_SHARD_TOTAL owns $e1_owned of ${#CORE_TERMINAL_PROOFS[@]} proofs; the other ${#CORE_TERMINAL_PROOFS[@]} - $e1_owned carry OTHER_SHARD and still have a status line"
 grep -q 'Warm build (issue #1814): \*\*ok\*\*' "$summary" \
   || { cat "$summary"; fail "(e1) the #1814 warm-build line is missing from the summary"; }
 run_journey_summary_step "$ws"
@@ -807,6 +846,45 @@ run_agg "$clean_dir"
 [[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
   || { printf '%s\n' "$AGG_OUT"; fail "(e1) a missing shard token must downgrade CLEAN to RE-RUN, got $AGG_VERDICT/exit$AGG_RC"; }
 pass "(e1) #1458/#1800/#1814 preserved: all-CLEAN -> CLEAN -> aggregate CLEAN; missing token -> RE-RUN; every proof status line + the warm-build line intact"
+
+# (e1b) Issue #2110: (e1) runs on the resolved single-CLASS shard, which at
+# SOLO_SHARD_TOTAL owns few or no proofs — so on its own it can only ever check
+# the OTHER_SHARD half, and "every proof reports **PASS** on a healthy leg" would
+# quietly stop being asserted anywhere. Run ONE more healthy suite on a leg that
+# does own a proof and pin the exact split: that proof **PASS**, every other
+# **OTHER_SHARD**, and the shard still CLEAN.
+echo
+echo "== (e1b) a healthy leg reports PASS for the proof it owns, OTHER_SHARD for the rest =="
+e1b_entry="${CORE_TERMINAL_PROOFS[0]}"
+IFS='|' read -r e1b_status_var e1b_class_var e1b_label <<<"$e1b_entry"
+e1b_selector="${!e1b_class_var}"
+ws="$SANDBOX/all-clean-owning-leg"
+make_workspace "$ws"
+RUN_REAL_SUITE_SHARD_INDEX="$(journey_class_shard_index "$e1b_selector" "$SOLO_SHARD_TOTAL")"
+export RUN_REAL_SUITE_SHARD_INDEX
+run_real_suite "$ws"
+[[ "$SUITE_RC" -eq 0 ]] \
+  || { sed -n '1,40p' "$ws/suite.log"; fail "(e1b) a healthy suite on the owning leg exited $SUITE_RC"; }
+grep -qF "PROOF: $e1b_selector (attempt 1)" "$ws/suite.log" \
+  || { sed -n '1,40p' "$ws/suite.log"; fail "(e1b) $e1b_selector did not execute on its own shard $RUN_REAL_SUITE_SHARD_INDEX — the PASS assertion below would be vacuous"; }
+summary="$ws/artifacts/ci-journey/summary.md"
+for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
+  IFS='|' read -r status_var class_var label <<<"$entry"
+  if [[ "$status_var" == "$e1b_status_var" ]]; then expected="PASS"; else
+    owner="$(journey_class_shard_index "${!class_var}" "$SOLO_SHARD_TOTAL")"
+    [[ "$owner" == "$RUN_REAL_SUITE_SHARD_INDEX" ]] && expected="PASS" || expected="OTHER_SHARD"
+  fi
+  grep -qF "$label (\`shared:core-terminal\`): **$expected**" "$summary" \
+    || { cat "$summary"; fail "(e1b) the summary line for $label is not **$expected** on the owning shard $RUN_REAL_SUITE_SHARD_INDEX"; }
+done
+run_journey_summary_step "$ws"
+[[ "$FIRST_FAILURE" == "false" && "$FIRST_TIMEOUT" == "false" ]] \
+  || fail "(e1b) owning-leg healthy summary reported first_failure=$FIRST_FAILURE first_timeout=$FIRST_TIMEOUT"
+run_classify_step "$ws" "$(classify_expressions success "$FIRST_TIMEOUT" "$FIRST_FAILURE")"
+[[ "$CLASSIFY_TOKEN" == "CLEAN" && "$CLASSIFY_RC" -eq 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(e1b) expected CLEAN/exit0 on the owning leg, got '$CLASSIFY_TOKEN'/exit$CLASSIFY_RC"; }
+unset RUN_REAL_SUITE_SHARD_INDEX
+pass "(e1b) on shard $(journey_class_shard_index "$e1b_selector" "$SOLO_SHARD_TOTAL") of $SOLO_SHARD_TOTAL the owned proof reports **PASS** and every deferred proof **OTHER_SHARD**; the leg still classifies CLEAN"
 
 # The remaining sibling properties (#1800 real-IME INFRA, #1822 mixed-summary
 # RED, #1822 unreadable-entry RED, #1809 no-RED-with-INFRA neutral green) are


### PR DESCRIPTION
Carves the CI journey suite to sharding-only: removes the build-cache scope
wiring that had been conflated with shard selection.

Reviewer verdict on #2110: **APPROVED** — "The carve is clean and everything
load-bearing was re-proven this run against the carved tree."

- Ownership across the harness is partitioned 1/1/3/3/2/1 = 11 proofs.
- The 179 journey classes distribute 27/28/26/35/31/32 across the six shards.

The reviewer also corrected its own round-2 arithmetic in the process: the
budget delta is 20.9 − 3.9 = **−17.0**, not the −17.4 quoted earlier.

Local guards, all run against the carved tree as a detached transient unit
(verdict recorded by the run itself, not read back from `systemctl show`):

- `check-ci-journey-harness-selftest.sh` rc=0
- `test-ci-journey-budget.sh` rc=0
- `test-ci-journey-summary-evidence.sh` rc=0
- `check-journey-shard-literals.sh` rc=0
- `check-script-interpreter-hygiene.sh` rc=0

Closes #2110