### PR TITLE
tests: make four self-skipping tests actually protect something (#2111)

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -215,12 +215,22 @@ jobs:
       # on ANY shard (round-robin), so every shard starts them. This mirrors how
       # the per-push emulator-journey job (.github/workflows/tests.yml) and the
       # release gate (scripts/pre-release-confidence-gate.sh) wire them.
+      # Issue #2111: the bootstrap phase now runs ALL TEN scenarios (six used to
+      # run on no lane at all), so the four remaining bootstrap fixtures must be
+      # up too: bootstrap-unsupported (2232, `unsupported`),
+      # bootstrap-daemon-disabled (2233, `daemonDisabled`),
+      # bootstrap-user-local-path (2234, `userLocalPath`) and
+      # bootstrap-fish-user-local-path (2235, `fishUserLocalPath`). The suite
+      # connects to these by host port (10.0.2.2:223x) and fails hard when the
+      # port is unforwarded, so they are started and health-waited like the rest.
       - name: Start Docker fixtures (agents, flaky-agent, tmux + toxiproxy + bootstrap + old-cli + daemon)
         run: |
           docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps \
             agents flaky-agent tmux network-fault-proxy packet-loss-proxy \
             bootstrap-ready bootstrap-uv-install bootstrap-uv-upgrade \
             bootstrap-notifications \
+            bootstrap-unsupported bootstrap-daemon-disabled \
+            bootstrap-user-local-path bootstrap-fish-user-local-path \
             agents-old-cli agents-daemon
 
       - name: Wait for fixture containers to report healthy
@@ -242,6 +252,17 @@ jobs:
           # Issue #1236 (D26): the silent-host notifications fixture (2241).
           wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-notifications /tmp/bootstrap-notifications-health.log 60
           cat /tmp/bootstrap-notifications-health.log
+          # Issue #2111: the four bootstrap fixtures the six previously-unrun
+          # scenarios need (2232 unsupported, 2233 daemon-disabled,
+          # 2234 user-local-path, 2235 fish-user-local-path).
+          wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-unsupported /tmp/bootstrap-unsupported-health.log 60
+          cat /tmp/bootstrap-unsupported-health.log
+          wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-daemon-disabled /tmp/bootstrap-daemon-disabled-health.log 60
+          cat /tmp/bootstrap-daemon-disabled-health.log
+          wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-user-local-path /tmp/bootstrap-user-local-path-health.log 60
+          cat /tmp/bootstrap-user-local-path-health.log
+          wait_for_container_healthy tests/docker/docker-compose.yml bootstrap-fish-user-local-path /tmp/bootstrap-fish-user-local-path-health.log 60
+          cat /tmp/bootstrap-fish-user-local-path-health.log
           # Old-CLI (2238, #849) + daemon (2239, #839) fixtures: the phase-1
           # FolderList*DockerTest journeys target these by host port and fail
           # hard when the port is unforwarded, so wait on them before handing off
@@ -276,6 +297,20 @@ jobs:
               sleep 1
             done
           done
+
+      # Issue #2111 (audit item 4 — the cadence gap): the real-agent fixture for
+      # nightly phase 4. It lives in its own compose file and ships the REAL
+      # claude/codex/opencode CLIs, deliberately WITHOUT API keys — the gate
+      # asserts the credential-free deterministic output ("Not logged in", the
+      # Codex banner) and the JSONL each CLI writes, so no secret is needed.
+      # Only shard 0 runs the aux phases, so only shard 0 pays the image build.
+      - name: Start real-agent fixture (2240, shard 0 only)
+        if: matrix.shard == 0
+        run: |
+          docker compose -f tests/docker/real-agent/compose.yml up -d --build real-agents
+          source tests/docker/lib/wait-for-healthy.sh
+          wait_for_container_healthy tests/docker/real-agent/compose.yml real-agents /tmp/real-agents-health.log 120
+          cat /tmp/real-agents-health.log
 
       - name: Verify agent SSH target tool surface
         run: |
@@ -358,11 +393,17 @@ jobs:
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-uv-install > artifacts/docker/bootstrap-uv-install.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-uv-upgrade > artifacts/docker/bootstrap-uv-upgrade.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-notifications > artifacts/docker/bootstrap-notifications.log 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-unsupported > artifacts/docker/bootstrap-unsupported.log 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-daemon-disabled > artifacts/docker/bootstrap-daemon-disabled.log 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-user-local-path > artifacts/docker/bootstrap-user-local-path.log 2>/dev/null || true
+          docker compose -f tests/docker/docker-compose.yml logs --no-color bootstrap-fish-user-local-path > artifacts/docker/bootstrap-fish-user-local-path.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color agents-old-cli > artifacts/docker/agents-old-cli.log 2>/dev/null || true
           docker compose -f tests/docker/docker-compose.yml logs --no-color agents-daemon > artifacts/docker/agents-daemon.log 2>/dev/null || true
           docker inspect pocketshell-test-agents > artifacts/docker/agents-inspect.json 2>/dev/null || true
           docker inspect pocketshell-test-agents-old-cli > artifacts/docker/agents-old-cli-inspect.json 2>/dev/null || true
           docker inspect pocketshell-test-agents-daemon > artifacts/docker/agents-daemon-inspect.json 2>/dev/null || true
+          # Issue #2111: real-agent fixture (phase 4, shard 0 only).
+          docker compose -f tests/docker/real-agent/compose.yml logs --no-color --timestamps real-agents > artifacts/docker/real-agents.log 2>/dev/null || true
 
       - name: Publish extensive suite summary
         if: always()
@@ -414,7 +455,10 @@ jobs:
 
       - name: Stop Docker fixtures
         if: always()
-        run: docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
+        run: |
+          docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
+          # Issue #2111: the real-agent fixture is a separate compose project.
+          docker compose -f tests/docker/real-agent/compose.yml down --volumes --remove-orphans || true
 
   # ---------------------------------------------------------------------------
   # Fault-injection safety verdict (issue #1201) — the RELEASE-GATING signal.

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
@@ -9,7 +9,6 @@ import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
-import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.session.ConversationLoadState
 import com.pocketshell.app.session.SessionTab
@@ -28,7 +27,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
-import org.junit.Assume
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -83,15 +81,34 @@ import java.io.File
  * drop that is never observed surfaces as a clear bounded-wait failure
  * message, never an instrumentation-process hang.
  *
- * ### CI gate
+ * ### It runs on EVERY lane (issue #2111)
  *
- * Even with a dead-transport drop, the reconnect round-trip on the shared CI
- * emulator can be flaky under residual process / memory pressure (cf. #502).
- * The authoritative CI coverage of the remember/restore/reconcile/tab logic is
- * the unit layer (`AgentSessionMemoryTest` + the `TmuxSessionViewModelTest`
- * reconnect cases); this connected test is *local* reconnect evidence. It is
- * therefore CI-gated with `Assume.assumeFalse(isRunningOnCi())` so a flaky
- * emulator reconnect cannot spam red CI after merge.
+ * This test used to open with `Assume.assumeFalse(isRunningOnCi())`, which made
+ * it skip in **both** CI lanes: the per-push journey suite targets only this
+ * class's three other methods, and nightly phase 1 runs the whole class WITH
+ * `pocketshellCi=true` (`scripts/nightly-extensive-suite.sh:300`). So it read as
+ * coverage while protecting nothing — the whole reattach tab-restore logic could
+ * be deleted and every lane stayed green. The self-skip is gone; the test now
+ * executes wherever the class is selected (nightly phase 1 today).
+ *
+ * ### Why the open-time default is pinned to Terminal
+ *
+ * The load-bearing property is "the user who was on Conversation is put BACK on
+ * Conversation by the reattach memory restore, before live re-detection". With
+ * the production open-time default (Conversation, #818) that property is
+ * unobservable: even with [seedAgentConversationFromMemory] deleted, the #878
+ * auto-seeded placeholder — and later `markAgentTailLive`'s fresh-row branch —
+ * would land the pane on Conversation anyway, so the assertion would pass with
+ * the bug present (the G6 wrong-cost trap).
+ *
+ * So this test pins the open-time default to **Terminal** (the real #818
+ * opt-out a user can select). In that configuration nothing else can put the
+ * pane on Conversation after the reattach: the #878 seed self-gates on the
+ * Conversation default, and `markAgentTailLive`'s `current == null` branch
+ * applies the open-time default (Terminal). The ONLY thing that can restore
+ * Conversation is the reattach memory seed. Deleting it therefore turns this
+ * test RED, deterministically, with the exact reported symptom — the user is
+ * bounced out of Conversation onto the raw Terminal.
  *
  *  1. Seed a tmux session whose single pane runs a `claude`-named process
  *     in `/workspace/pocketshell`, and refresh the seeded Claude JSONL so
@@ -131,15 +148,8 @@ class AgentConversationReconnectDockerTest {
 
     @Test
     fun reconnectRestoresConversationTabImmediatelyForAgentSession() { runBlocking {
-        // Local-only reconnect evidence. The remember/restore/reconcile/tab
-        // logic is owned on CI by AgentSessionMemoryTest + the
-        // TmuxSessionViewModelTest reconnect cases; this connected reconnect
-        // round-trip is too sensitive to shared-CI-emulator process/memory
-        // pressure (cf. #502) to run unguarded.
-        Assume.assumeFalse(
-            "issue-495 connected reconnect is local-only evidence; CI coverage is the unit layer",
-            TerminalTestTimeouts.isRunningOnCi(),
-        )
+        // Issue #2111: NO `assumeFalse(isRunningOnCi())` here. This test ran on
+        // no lane at all — see the class KDoc. It runs unguarded now.
         val key = readFixtureKey()
         // agents:2222 readiness — so a not-yet-up fixture is the loud failure,
         // not the cause of a later hang.
@@ -225,6 +235,16 @@ class AgentConversationReconnectDockerTest {
             activeTmuxClients = registry,
             runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
         )
+        // Issue #2111: pin the open-time default to Terminal (the real #818
+        // opt-out). This is what makes the reattach memory restore the ONLY
+        // thing that can put the pane back on Conversation after the reconnect —
+        // see the class KDoc. With the production Conversation default the #878
+        // auto-seed / markAgentTailLive fresh-row branch would land on
+        // Conversation regardless, so the core assertion below would pass with
+        // the restore logic deleted (G6).
+        vm.setDefaultAgentSessionViewForTest(
+            com.pocketshell.app.settings.DefaultAgentSessionView.Terminal,
+        )
 
         try {
             vm.connect(
@@ -251,6 +271,24 @@ class AgentConversationReconnectDockerTest {
                 vm.agentForWindow(windowId),
             )
             val firstPaneId = vm.panes.value.first { it.windowId == windowId }.paneId
+
+            // Issue #2111 precondition (HARD, not assumed): with the open-time
+            // default pinned to Terminal the freshly-detected agent row lands on
+            // Terminal. If this ever fails the pin did not take effect and the
+            // restore assertion below would be vacuous, so fail loudly here.
+            waitForCondition(
+                "issue2111 initial agent row exists",
+                timeoutMs = 15_000,
+                describe = { "conversations=${vm.agentConversations.value.keys}" },
+            ) { vm.agentConversations.value[firstPaneId] != null }
+            assertEquals(
+                "#2111: the open-time default is pinned to Terminal, so the freshly-detected " +
+                    "agent row must OPEN on Terminal — otherwise the restore assertion after " +
+                    "the reconnect could be satisfied by the open-time default instead of by " +
+                    "the reattach memory restore (G6)",
+                SessionTab.Terminal,
+                vm.agentConversations.value[firstPaneId]!!.selectedTab,
+            )
 
             // The user opens Conversation — this is remembered for the window.
             vm.selectSessionTab(firstPaneId, SessionTab.Conversation)
@@ -352,6 +390,14 @@ class AgentConversationReconnectDockerTest {
             // status is restored — the Conversation tab is available and the
             // user is back on Conversation — WITHOUT bouncing to Terminal. The
             // restore is seeded synchronously in applyParsedPanes.
+            //
+            // Issue #2111 — the mutation this assertion must catch: delete the
+            // reattach tab-restore (make `seedAgentConversationFromMemory` a
+            // no-op). With the open-time default pinned to Terminal nothing else
+            // seeds a row on reattach, so the pane comes back on Terminal and
+            // `selectedTab == Conversation` never becomes true — RED inside
+            // IMMEDIATE_RESTORE_TIMEOUT_MS. That is the maintainer's exact
+            // report: the reconnect bounced the user out of Conversation.
             //
             // Issue #819 (Slice A2): the reattach seed is a detection-LESS
             // RESOLVING placeholder (rememberedAgentPlaceholder = true,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationOpenLatencyRttDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationOpenLatencyRttDockerTest.kt
@@ -7,7 +7,6 @@ import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.PreGrantPermissionsRule
-import com.pocketshell.app.proof.TerminalTestTimeouts
 import com.pocketshell.app.proof.ToxiproxyControl
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.session.SessionTab
@@ -29,9 +28,9 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestName
 import org.junit.runner.RunWith
 import java.io.File
 
@@ -73,21 +72,117 @@ import java.io.File
  * scan) → `readEventsWindow` (1 exec). No fixture-image change is needed — real
  * tmux honours the user option and the seeding sets it directly.
  *
- * ### Gating
+ * ### Where it runs (issue #2111)
  *
- * The `network-fault-proxy` service is opt-in (the default CI workflow does not
- * start it), so this test is gated off CI (`isRunningOnCi()`) AND behind the
- * `pocketshellNetworkFaultProofs=true` instrumentation arg, exactly like the
- * other [com.pocketshell.app.proof.NetworkFaultProofBase] proofs. It is local
- * measurement evidence; CI coverage of the open-path correctness stays in the
- * unit + the deterministic `agentOpensOnDefaultViewAndIsNotYankedMidSessionShellGetsNoConversationRow`
- * connected test.
+ * It used to run on **no lane at all**. Its `assumeFalse(isRunningOnCi())`
+ * skipped it per-push, and nightly's `NETWORK_FAULT_CLASSES` list was
+ * `com.pocketshell.app.proof.*` only — so nightly phase 1 selected it WITHOUT
+ * the `pocketshellNetworkFaultProofs` opt-in and the `assumeTrue` skipped it
+ * there too. The #828 gates below were therefore unprotected: reintroducing the
+ * serial open-path detection execs left every lane green.
+ *
+ * It is now enrolled in nightly's fault run — specifically the NON-GATING
+ * **phase 2b** (`scripts/nightly-extensive-suite.sh` `EXPECTED_FAIL_CLASSES`),
+ * which runs WITH `pocketshellNetworkFaultProofs=true` against the
+ * `network-fault-proxy:2228` + toxiproxy API:8474 fixtures the nightly workflow
+ * already starts. Being in that list also excludes it from phase 1, so it is
+ * never selected without the opt-in on CI.
+ *
+ * The opt-in is therefore a HARD assertion, not an `assumeTrue` — mirroring the
+ * sibling toxiproxy fixture user `OutboundAttachmentOffsetResumeJourneyE2eTest`
+ * (#1733/#1866). A lost opt-in must be a loud red, never a silent skip that
+ * reads as coverage; that silent skip is exactly the defect #2111 removes.
+ *
+ * ### Why TWO `@Test` methods, and not one (issue #2111 round 2)
+ *
+ * This class asserts two DIFFERENT properties with two DIFFERENT current fates,
+ * and round 1 shipped them as two sequential `assertTrue` calls inside one
+ * `@Test`. That was a real defect, not a style nit:
+ *
+ *  - [recordedClaudeFirstWindowIsPrefetchedUnderRealisticRtt] is the STRUCTURAL
+ *    #828 guard — the window-read leg must collapse to ~0 because the first
+ *    window is folded into the resolve exec. It **passes today**.
+ *  - [recordedClaudeColdOpenMeetsPhoneBudgetAtGoodRtt] is the <0.3 s PHONE-class
+ *    budget. It **fails on an emulator at any RTT** (numbers below), tracked as
+ *    a follow-up.
+ *
+ * With both in one method the budget assertion threw first and the structural
+ * one was **never evaluated**, so the #828 mutation ("drop the prefetch fold")
+ * produced red-before and red-after — indistinguishable, i.e. zero protection.
+ * Splitting them means a #828 regression changes the run's FAILURE SET (one
+ * failing test becomes two) on a lane whose overall exit code is informational.
+ * Neither assertion was weakened to achieve this (a #2111 non-goal); both stay
+ * hard, they just no longer mask each other.
+ *
+ * ### Running it locally — pass `--no-pool` (issue #2111 round 2)
+ *
+ * This class seeds its tmux session over the DIRECT fixture port ([DEFAULT_PORT])
+ * but drives the app through the proxy on [NETWORK_FAULT_SSH_PORT], whose
+ * upstream is the SHARED `agents` container. `scripts/connected-test.sh`
+ * auto-enables `--pool` for a `*DockerTest*` class when more than one emulator is
+ * online, and pool mode relocates `DEFAULT_PORT` to a per-lane agents container —
+ * so the session would be seeded in one container while the app reads a different
+ * one, and the test fails for a reason that has nothing to do with the code. The
+ * fault proxy itself is a singleton and is not pool-isolated either. So always:
+ *
+ * ```
+ * scripts/connected-test.sh --no-pool --suffix i<issue> :app:connectedDebugAndroidTest \
+ *   -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true \
+ *   -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.app.tmux.ConversationOpenLatencyRttDockerTest
+ * ```
+ *
+ * Nightly is unaffected: `scripts/nightly-extensive-suite.sh` invokes Gradle
+ * directly and never takes the pool path.
+ *
+ * If every SSH attempt fails with `Server closed connection during identification
+ * exchange` while `docker ps` still reports the fixture healthy, it is not this
+ * test: OpenSSH 9.8+ `PerSourcePenalties` has penalised the docker gateway
+ * (`srclimit_penalise ... penalty: failed authentication` in `docker logs`). All
+ * emulator/host traffic NATs through that one source address, while the
+ * container's own healthcheck comes over `::1` and keeps passing — so the fixture
+ * looks fine and every lane fails. See the issue #2111 thread.
+ *
+ * ### What its first-ever execution measured (2026-08-13)
+ *
+ *  - [PREFETCHED_WINDOW_READ_GATE_MS] — **satisfied**: the window-read leg is
+ *    0 ms at both 150 ms and 80 ms RTT, i.e. #828's fold of the first window
+ *    into the resolve exec is intact. Removing that fold pushes it to 184 ms
+ *    (80 ms RTT) / 784 ms (150 ms RTT) and reddens this assertion. It is
+ *    asserted at BOTH measured RTTs: a dropped fold costs one extra serial
+ *    round-trip, so the higher RTT is the louder detector.
+ *
+ *    Re-confirmed by mutation on the SHIPPED tree (2026-08-14, round 2), with
+ *    [COLD_OPEN_GATE_MS] left untouched at 300 ms. Dropping the fold — deleting
+ *    the `prefetchedWindow ?:` in `TmuxSessionViewModel.startAgentConversation`
+ *    so the separate window read always runs — moves this method PASS -> FAIL
+ *    (window-read leg 0 ms -> 818 ms at 150 ms RTT) while the budget method
+ *    fails either way. The run's FAILURE SET therefore changes, 1 -> 2, which is
+ *    the signal this split exists to produce: before the split the budget
+ *    assertion threw first and this one never ran, so the same mutation gave red
+ *    before and red after — indistinguishable.
+ *  - [COLD_OPEN_GATE_MS] — **not met on an emulator at any RTT**: measured
+ *    `conversation_open_full` was 840 / 429 / 753 / 842 ms at 80 ms RTT across
+ *    four runs, and a control pass at 10 ms RTT still measured 406 ms; a fifth
+ *    run (round 2) measured 357 ms. The device-side fixed cost on this AVD is
+ *    ~400 ms, so a <0.3 s PHONE-class budget cannot be met there no matter how
+ *    fast the link. Tracked as a follow-up; #2111 only makes the test run.
+ *
+ * That is why the enrolment is the NON-GATING phase 2b and not the
+ * release-GATING phase 2: gating on a budget the runner's hardware cannot meet
+ * would turn the nightly fault verdict permanently red for an environmental
+ * reason. Promote this class into `NETWORK_FAULT_CLASSES` once the <0.3 s
+ * question is resolved (a device-class-aware budget, or cutting the ~400 ms of
+ * device-side open cost).
  */
 @RunWith(AndroidJUnit4::class)
 class ConversationOpenLatencyRttDockerTest {
 
     @get:Rule
     val preGrantPermissions = PreGrantPermissionsRule()
+
+    /** Issue #2111: keeps the two methods' timing artifacts from overwriting each other. */
+    @get:Rule
+    val testName = TestName()
 
     private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val cleanupCommands = mutableListOf<String>()
@@ -106,20 +201,70 @@ class ConversationOpenLatencyRttDockerTest {
         writeSummary()
     }
 
+    /**
+     * Issue #828 STRUCTURAL guard, and the load-bearing test of this class.
+     *
+     * The recorded-Claude cold open must be ONE SSH round-trip: kind + source +
+     * the first transcript window all folded into the resolve exec. So the
+     * window-read leg (`conversation_open`) must collapse to ~0 at every RTT.
+     * Reintroducing the separate window-read round-trip (the #817 baseline
+     * shape) reddens this and ONLY this.
+     *
+     * Issue #2111 round 2: this is deliberately its own `@Test`, separate from
+     * the <0.3 s budget below, so a budget failure cannot abort the method
+     * before this assertion runs. See the class KDoc.
+     */
     @Test
-    fun coldOpenAndWarmSwitchUnderRealisticRtt(): Unit { runBlocking {
-        // Opt-in, local-only: the network-fault-proxy is not started by CI.
-        Assume.assumeFalse(
-            "network-fault-proxy is an opt-in Docker fixture; tests.yml does not start it",
-            TerminalTestTimeouts.isRunningOnCi(),
-        )
-        val enabled = InstrumentationRegistry.getArguments()
-            .getString("pocketshellNetworkFaultProofs")
-            ?.toBooleanStrictOrNull() == true
-        Assume.assumeTrue(
-            "Enable with -Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true " +
+    fun recordedClaudeFirstWindowIsPrefetchedUnderRealisticRtt(): Unit { runBlocking {
+        val (key, keyPath) = prepareFixtures()
+        // Two RTTs: ~150 ms (typical mobile/wifi) and ~80 ms (a good link).
+        // One-way latencies of 75 / 40 ms; toxiproxy delays each direction.
+        // The fold is asserted at BOTH: a dropped fold costs one extra serial
+        // round-trip, so the higher RTT is the louder detector (784 ms vs 184 ms).
+        measureAtRtt(key, keyPath, oneWayMs = 75, gate = LatencyGate.PrefetchedWindowRead)
+        measureAtRtt(key, keyPath, oneWayMs = 40, gate = LatencyGate.PrefetchedWindowRead)
+    } }
+
+    /**
+     * Issue #828 BUDGET gate: the recorded-Claude cold Conversation open must fit
+     * the <0.3 s target at the realistic-good 80 ms RTT.
+     *
+     * Issue #2111 round 2: known-red on an emulator (~400 ms of device-side fixed
+     * cost — see the class KDoc for the measurements), which is why this class
+     * sits in nightly's NON-GATING phase 2b. The assertion is NOT weakened and
+     * NOT skipped; it is isolated in its own `@Test` so its environmental failure
+     * cannot mask the structural guard above.
+     */
+    @Test
+    fun recordedClaudeColdOpenMeetsPhoneBudgetAtGoodRtt(): Unit { runBlocking {
+        val (key, keyPath) = prepareFixtures()
+        measureAtRtt(key, keyPath, oneWayMs = GATE_RTT_MS / 2, gate = LatencyGate.ColdOpenBudget)
+    } }
+
+    /** Which hard gate [measureAtRtt] applies (issue #2111 round 2). */
+    private enum class LatencyGate {
+        /** #828 structural: the first window is prefetched, so no second round-trip. */
+        PrefetchedWindowRead,
+
+        /** #828 budget: cold `conversation_open_full` < [COLD_OPEN_GATE_MS]. */
+        ColdOpenBudget,
+    }
+
+    /** Hard-asserts the toxiproxy opt-in and readies both the direct and proxied fixtures. */
+    private suspend fun prepareFixtures(): Pair<String, String> {
+        // Issue #2111: HARD-assert the toxiproxy opt-in — never `assumeTrue`.
+        // This class is enrolled in nightly fault phase 2b, which passes the flag
+        // and is therefore excluded from phase 1; anything else selecting it
+        // without the fixture must be a loud red, not a silent skip that reads
+        // as coverage. Mirrors OutboundAttachmentOffsetResumeJourneyE2eTest.
+        assertTrue(
+            "issue #2111: this proof requires the explicitly opted-in Toxiproxy fixture. " +
+                "Run it via nightly fault phase 2b, or locally with " +
+                "-Pandroid.testInstrumentationRunnerArguments.pocketshellNetworkFaultProofs=true " +
                 "after `docker compose -f tests/docker/docker-compose.yml up -d --build agents network-fault-proxy`",
-            enabled,
+            InstrumentationRegistry.getArguments()
+                .getString("pocketshellNetworkFaultProofs")
+                ?.toBooleanStrictOrNull() == true,
         )
 
         val key = readFixtureKey()
@@ -129,15 +274,15 @@ class ConversationOpenLatencyRttDockerTest {
         proxyTouched = true
         waitForSshFixtureReady(SshKey.Pem(key), port = NETWORK_FAULT_SSH_PORT)
 
-        val keyPath = writeKeyFile(key)
+        return key to writeKeyFile(key)
+    }
 
-        // Two RTTs: ~150 ms (typical mobile/wifi) and ~80 ms (a good link).
-        // One-way latencies of 75 / 40 ms; toxiproxy delays each direction.
-        measureAtRtt(key, keyPath, oneWayMs = 75)
-        measureAtRtt(key, keyPath, oneWayMs = 40)
-    } }
-
-    private suspend fun measureAtRtt(key: String, keyPath: String, oneWayMs: Int) {
+    private suspend fun measureAtRtt(
+        key: String,
+        keyPath: String,
+        oneWayMs: Int,
+        gate: LatencyGate,
+    ) {
         val rttMs = oneWayMs * 2
         val suffix = "${System.currentTimeMillis().toString().takeLast(8)}-rtt$rttMs"
         val sessionName = "issue817-rtt-$suffix"
@@ -277,46 +422,6 @@ class ConversationOpenLatencyRttDockerTest {
             measurements += "  full=${fullOpen.toArtifactLine()}"
             measurements += "  window=${windowOpen.toArtifactLine()}"
 
-            // Issue #828: the recorded-Claude cold open must fit the <0.3s gate at
-            // the realistic-good 80 ms RTT. This is the HARD regression assertion —
-            // NOT behind any assumeTrue (the opt-in proxy gate at the top of the
-            // @Test is the infra precondition; once the test runs, this bound is
-            // load-bearing, per #657/F3). At 80 ms the recorded-Claude open path
-            // after #828 is candidate-enum + window-read (the standalone
-            // readRecordedAgentKind exec is cached away and the host-wide ps scan
-            // is skipped for Claude/OpenCode), so the full open must clear 300 ms.
-            // 150 ms RTT is reported for the record but not gated: with the two
-            // mandatory serial round-trips it physically cannot fit 300 ms, and
-            // 80 ms is the phone-to-remote target the issue asks us to certify.
-            if (rttMs == GATE_RTT_MS) {
-                assertTrue(
-                    "recorded Claude cold conversation_open_full at ${rttMs}ms RTT must be " +
-                        "< ${COLD_OPEN_GATE_MS}ms (the <0.3s gate); was ${fullOpen.durationMs}ms " +
-                        "(window_read=${windowOpen.durationMs}ms detection_chain=${detectionChainMs}ms). " +
-                        "A regression here means the open path grew an extra serial SSH round-trip — " +
-                        "check the recorded-kind cache (no readRecordedAgentKind re-exec), that the " +
-                        "Claude/OpenCode recorded path skips the host-wide ps scan, and that the " +
-                        "recorded-Claude first window is prefetched in the resolve exec (not a " +
-                        "separate window-read round-trip).",
-                    fullOpen.durationMs < COLD_OPEN_GATE_MS,
-                )
-                // After #828 the recorded-Claude cold open is ONE SSH round-trip:
-                // kind + source + first window folded into the resolve exec. So the
-                // window-read leg (conversation_open) collapses to ~0 (the window
-                // was prefetched, no separate read) — the proof that the fold took
-                // effect. A non-trivial window-read here means the prefetch was
-                // dropped and the path fell back to a second round-trip (the #817
-                // baseline shape). Allow a small margin for the StateFlow push /
-                // parse the span still spans.
-                assertTrue(
-                    "recorded Claude window-read leg at ${rttMs}ms RTT must collapse to ~0 — the " +
-                        "first window is prefetched in the resolve exec, so no separate window-read " +
-                        "round-trip should run; was ${windowOpen.durationMs}ms. A larger value means " +
-                        "the prefetch was dropped and a second SSH round-trip came back.",
-                    windowOpen.durationMs < PREFETCHED_WINDOW_READ_GATE_MS,
-                )
-            }
-
             // ---- Warm switch: Terminal -> Conversation on an already-loaded row.
             // The open-time default is pinned to Terminal for this latency test
             // (see setDefaultAgentSessionViewForTest above), so the transcript is
@@ -339,6 +444,58 @@ class ConversationOpenLatencyRttDockerTest {
             val switchSpan = waitForSpan(CONVERSATION_SWITCH_LATENCY_OPERATION, "rtt$rttMs switch")
             record("rtt${rttMs}_conversation_switch_ms", switchSpan.durationMs)
             measurements += "  switch=${switchSpan.toArtifactLine()}"
+
+            // Issue #2111 round 2: exactly ONE hard gate per measurement pass, and
+            // which one is decided by the calling @Test. Both are HARD assertions —
+            // NOT behind any assumeTrue (the opt-in proxy gate in prepareFixtures is
+            // the infra precondition; once the test runs, these bounds are
+            // load-bearing, per #657/F3). They live in separate @Test methods so
+            // the known-red budget cannot abort the method before the structural
+            // guard is evaluated; see the class KDoc. The gates run LAST so every
+            // measurement above reaches the timing artifact even when one fails.
+            when (gate) {
+                // After #828 the recorded-Claude cold open is ONE SSH round-trip:
+                // kind + source + first window folded into the resolve exec. So the
+                // window-read leg (conversation_open) collapses to ~0 (the window
+                // was prefetched, no separate read) — the proof that the fold took
+                // effect. A non-trivial window-read here means the prefetch was
+                // dropped and the path fell back to a second round-trip (the #817
+                // baseline shape). Allow a small margin for the StateFlow push /
+                // parse the span still spans.
+                LatencyGate.PrefetchedWindowRead -> assertTrue(
+                    "recorded Claude window-read leg at ${rttMs}ms RTT must collapse to ~0 — the " +
+                        "first window is prefetched in the resolve exec, so no separate window-read " +
+                        "round-trip should run; was ${windowOpen.durationMs}ms " +
+                        "(full_open=${fullOpen.durationMs}ms detection_chain=${detectionChainMs}ms). " +
+                        "A larger value means the prefetch was dropped and a second SSH round-trip " +
+                        "came back.",
+                    windowOpen.durationMs < PREFETCHED_WINDOW_READ_GATE_MS,
+                )
+                // The <0.3s gate is asserted at the realistic-good 80 ms RTT only:
+                // 150 ms is measured for the record but cannot fit 300 ms with the
+                // mandatory serial round-trips, and 80 ms is the phone-to-remote
+                // target the issue asks us to certify. `check` rather than an `if`
+                // so a future caller at the wrong RTT is a loud error, not a
+                // silently-skipped gate.
+                LatencyGate.ColdOpenBudget -> {
+                    check(rttMs == GATE_RTT_MS) {
+                        "the <0.3s budget is only asserted at the ${GATE_RTT_MS}ms gate RTT; " +
+                            "this pass ran at ${rttMs}ms"
+                    }
+                    assertTrue(
+                        "recorded Claude cold conversation_open_full at ${rttMs}ms RTT must be " +
+                            "< ${COLD_OPEN_GATE_MS}ms (the <0.3s gate); was ${fullOpen.durationMs}ms " +
+                            "(window_read=${windowOpen.durationMs}ms " +
+                            "detection_chain=${detectionChainMs}ms). " +
+                            "A regression here means the open path grew an extra serial SSH " +
+                            "round-trip — check the recorded-kind cache (no readRecordedAgentKind " +
+                            "re-exec), that the Claude/OpenCode recorded path skips the host-wide " +
+                            "ps scan, and that the recorded-Claude first window is prefetched in " +
+                            "the resolve exec (not a separate window-read round-trip).",
+                        fullOpen.durationMs < COLD_OPEN_GATE_MS,
+                    )
+                }
+            }
         } finally {
             vm.clearForTest()
         }
@@ -471,8 +628,10 @@ class ConversationOpenLatencyRttDockerTest {
 
     private fun writeSummary() {
         if (measurements.isEmpty()) return
+        val method = testName.methodName ?: "unknown"
         val text = buildString {
             appendLine("scenario=conversation-open+switch-under-realistic-rtt (#817 Rank-1 measurement)")
+            appendLine("test_method=$method")
             appendLine("recorded_session=@ps_agent_kind=claude (the #825 path #818 will default to)")
             appendLine("proxy=network-fault-proxy toxiproxy symmetric latency, upstream agents:22")
             appendLine("measurements:")
@@ -486,7 +645,10 @@ class ConversationOpenLatencyRttDockerTest {
         val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
         val dir = File(mediaRoot, "additional_test_output/conversation-open-rtt")
         check(dir.exists() || dir.mkdirs()) { "could not create artifact dir ${dir.absolutePath}" }
-        val file = File(dir, "issue817-conversation-open-rtt-timing.txt")
+        // Issue #2111 round 2: one file per @Test method — the two methods run in
+        // the same instrumentation process, so a fixed name would let whichever
+        // ran last silently overwrite the other's timings.
+        val file = File(dir, "issue817-conversation-open-rtt-timing-$method.txt")
         file.writeText(text)
         println("ISSUE817_TEXT ${file.absolutePath}")
     }

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -33,18 +33,28 @@
 #      `pocketshellNetworkFaultProofs=true` (so the `assumeTrue(...)` opt-in
 #      guard passes). This is the un-gating the per-push/smoke jobs never do.
 #
-#   3) BOOTSTRAP setup-scenario matrix (issue #667) — a TRIMMED but meaningful
-#      slice of HostBootstrapScenarioSuiteTest, run WITH
-#      `pocketshellBootstrapScenarios=true` so the `assumeTrue(...)` opt-in
-#      guard passes. The suite otherwise self-skips, leaving the first-run
-#      install / uv-install / app-update-required setup journeys guarded only
-#      by the release gate (so they can regress silently between releases).
-#      We select exactly three methods (ready + uvInstall + appUpdateRequired)
-#      via `class=...#method` so the cost stays bounded. These drive the real
-#      host-list tap path against the bootstrap Docker fixtures
-#      (bootstrap-ready:2230, bootstrap-uv-install:2231, bootstrap-uv-upgrade:2236;
-#      appUpdateRequired reuses the uv-upgrade container on 2236), which the
-#      workflow brings up alongside the journey fixtures.
+#   3) BOOTSTRAP setup-scenario matrix (issue #667) — HostBootstrapScenarioSuiteTest,
+#      run WITH `pocketshellBootstrapScenarios=true` so the `assumeTrue(...)`
+#      opt-in guard passes. The suite otherwise self-skips, leaving the setup
+#      journeys guarded only by the release gate (so they can regress silently
+#      between releases). Methods are selected by name via `class=...#method`.
+#      Issue #2111: this used to select FOUR of the class's TEN scenarios, so six
+#      executed on no lane at all; ALL TEN now run. They drive the real host-list
+#      tap path against the bootstrap Docker fixtures (bootstrap-ready:2230,
+#      -uv-install:2231, -unsupported:2232, -daemon-disabled:2233,
+#      -user-local-path:2234, -fish-user-local-path:2235, -uv-upgrade:2236 —
+#      reused by uvUpgradeFailure and appUpdateRequired — and
+#      -notifications:2241), which the workflow brings up alongside the journey
+#      fixtures.
+#
+#   4) REAL-AGENT CLI gate (issue #2111) — RealAgentReleaseGateTest against the
+#      separate `tests/docker/real-agent/compose.yml` fixture on port 2240, run
+#      WITH `pocketshellRealAgentReleaseGate=1`. It drives the REAL claude/codex
+#      binaries in a tmux pane through the app. It previously ran ONLY under
+#      `TERMINAL_RELEASE_GATE=1 scripts/release-emulator-validation.sh`, so a
+#      real-CLI rendering regression stayed invisible until someone cut a
+#      release. Its exit code feeds `overall_status` but NOT the #1201
+#      release-gating fault verdict.
 #
 # The script never aborts on the first phase failure: it runs all phases,
 # records each exit code, writes a pass/fail summary, and exits non-zero if
@@ -146,6 +156,13 @@ NETWORK_FAULT_CLASSES=(
 # ---------------------------------------------------------------------------
 # EXPECTED-FAIL lane (issue #1201, de-gated from the fault verdict).
 #
+# Issue #2111 widened this lane's remit slightly: it is the home for any
+# toxiproxy-fixture proof that must RUN nightly and have its artifacts collected
+# while its exit code is not yet trustworthy as a release signal — whether that
+# is a TDD spec for an unbuilt feature (#822 below) or a budget that the emulator
+# cannot meet (#2111's Conversation-open latency proof below). The promotion rule
+# is the same for both: move it into NETWORK_FAULT_CLASSES once it runs green.
+#
 # The #822 Slice C/D journeys (SilentMidSessionDropDetectionE2eTest) are TDD-style
 # executable specs for UNBUILT connection-manager features — the two tests assert
 # "Expected to FAIL until the LivenessProbe (Slice D) lands" / "until the
@@ -165,6 +182,62 @@ NETWORK_FAULT_CLASSES=(
 # pocketshellNetworkFaultProofs=true opt-in flag.
 EXPECTED_FAIL_CLASSES=(
   "$FQCN_PREFIX.SilentMidSessionDropDetectionE2eTest"
+  # Issue #2111 (audit §2.1 item 2): the #817/#828 network-realistic
+  # Conversation-open latency proof. It is not a NetworkFaultProofBase subclass
+  # (hence the fully-qualified name), but it is a toxiproxy fixture user with
+  # identical preconditions: it drives the production open path through
+  # network-fault-proxy:2228 with a symmetric-latency toxic and HARD-asserts the
+  # two #828 gates in TWO SEPARATE @Test methods — (a)
+  # `recordedClaudeColdOpenMeetsPhoneBudgetAtGoodRtt`: cold
+  # `conversation_open_full` < 300 ms at 80 ms RTT, and (b)
+  # `recordedClaudeFirstWindowIsPrefetchedUnderRealisticRtt`: the window-read leg
+  # collapsed to ~0 (at BOTH 150 ms and 80 ms RTT) because the first window is
+  # prefetched in the resolve exec. Two methods, not two asserts in one method,
+  # because (a) is known-red here (below) and would otherwise abort the method
+  # before (b) — the structural guard — ever ran, making a #828 regression
+  # indistinguishable from the standing environmental failure. Split, a #828
+  # regression changes this phase's FAILURE SET: 1 failing test becomes 2.
+  # It guards exactly what AGENTS.md warns about
+  # ("do not land #818 on localhost-only timings; localhost zero-RTT hides the
+  # whole cost"). It reuses network-fault-proxy:2228 + toxiproxy API:8474 — no
+  # new fixture.
+  #
+  # Before this enrolment it executed on NO lane at all: nightly phase 1 selected
+  # it WITHOUT the `pocketshellNetworkFaultProofs` opt-in so its `assumeTrue`
+  # skipped it, and its `assumeFalse(isRunningOnCi())` skipped it per-push. Both
+  # self-skips are now gone (the opt-in is a HARD assert in the class), so the
+  # only question was WHICH nightly phase it belongs in.
+  #
+  # It goes in the NON-GATING lane, and the reason is a measurement, not a
+  # preference. Running it for the first time (2026-08-13, this issue, emulator +
+  # the real toxiproxy fixture) shows assertion (b) is solidly satisfied —
+  # window-read leg = 0 ms at both 150 ms and 80 ms RTT, i.e. #828's fold is
+  # intact — while assertion (a) is NOT met on an emulator at ANY RTT: measured
+  # `conversation_open_full` was 840 / 429 / 753 / 842 ms at 80 ms RTT across four
+  # runs, and a control pass at 10 ms RTT still measured 406 ms. So the
+  # device-side fixed cost on this AVD is ~400 ms and the <0.3 s budget — a
+  # PHONE-class target — is unreachable there regardless of the network. Making
+  # this phase GATING would therefore turn the nightly fault verdict (and with it
+  # the release gate) permanently red for an environmental reason, while
+  # weakening the 300 ms budget to make it pass is explicitly forbidden
+  # (#2111 non-goal). Neither is acceptable, so it runs here: the proof EXECUTES
+  # every night against the real fixture, its per-method timing artifacts
+  # (`issue817-conversation-open-rtt-timing-<method>.txt`) are uploaded, and its
+  # status is shown in the summary — but its exit code stays informational.
+  #
+  # READ THIS PHASE'S RESULT PER-METHOD, NOT AS ONE EXIT CODE. The expected
+  # steady state is exactly ONE failing method here (the budget). If
+  # `recordedClaudeFirstWindowIsPrefetchedUnderRealisticRtt` ever joins it, #828's
+  # prefetch fold has regressed and the cold open grew a second serial SSH
+  # round-trip — that is a real product regression hiding in an informational
+  # lane, so the per-method report matters more than the phase's exit code.
+  #
+  # PROMOTE IT INTO `NETWORK_FAULT_CLASSES` the moment BOTH methods run green,
+  # exactly as this lane's #1201 protocol says. That needs a follow-up decision
+  # on the <0.3 s gate (make the budget device-class-aware, or cut the ~400 ms of
+  # device-side open cost); it is out of scope for #2111, which is about making
+  # the test run at all.
+  "com.pocketshell.app.tmux.ConversationOpenLatencyRttDockerTest"
 )
 
 # The bootstrap setup-scenario class (opt-in via pocketshellBootstrapScenarios).
@@ -173,11 +246,33 @@ EXPECTED_FAIL_CLASSES=(
 BOOTSTRAP_TEST_CLASS="com.pocketshell.app.bootstrap.HostBootstrapScenarioSuiteTest"
 NOTIFICATION_PERMISSION_TEST_CLASS="com.pocketshell.app.notifications.NoNotificationPromptOnAppOpenE2eTest"
 
-# Trimmed but meaningful set of bootstrap scenarios (issue #667): the first-run
-# `ready` profile, the `uvInstall` first-install journey, and the
-# `appUpdateRequired` (remote-newer) journey. Selected by JUnit method name via
+# Issue #2111 (audit §2.1 item 4 — the cadence gap): the real-agent release gate.
+# It drives the REAL `claude` and `codex` binaries in a tmux pane through the app
+# and asserts on visible terminal output + the on-disk JSONL each CLI writes, so
+# it is the only guard against a real-CLI rendering/parsing regression. Until now
+# it ran ONLY under `TERMINAL_RELEASE_GATE=1 scripts/release-emulator-validation.sh`
+# — i.e. a regression stayed invisible until someone cut a release, which can be
+# weeks. It is opt-in via `pocketshellRealAgentReleaseGate=1` and needs the
+# separate `tests/docker/real-agent/compose.yml` fixture on port 2240 (which the
+# nightly workflow now starts). That image ships deliberately WITHOUT API keys and
+# the assertions are the credential-free deterministic strings ("Not logged in",
+# the Codex banner), so no secret is required to run it here.
+REAL_AGENT_TEST_CLASS="$FQCN_PREFIX.RealAgentReleaseGateTest"
+REAL_AGENT_COMPOSE_FILE="$REPO_ROOT/tests/docker/real-agent/compose.yml"
+
+# The bootstrap scenarios run nightly. Selected by JUnit method name via
 # `class=<FQCN>#<method>,<FQCN>#<method>`.
+#
+# Issue #2111 (audit §2.1 item 3): this list used to hold FOUR of the class's TEN
+# scenarios, so six scenarios executed on NO lane — the class is excluded from
+# phase 1 (it would only self-skip there without the opt-in) and phase 3 selected
+# by name. Breaking the uv-upgrade-failure recovery sheet or the fish-PATH
+# bootstrap reddened nothing. All ten now run. Every fixture they need is already
+# defined in `tests/docker/docker-compose.yml` and is started by
+# `.github/workflows/nightly-extensive.yml`.
 BOOTSTRAP_METHODS=(
+  # Issue #667: the first-run `ready` profile, the `uvInstall` first-install
+  # journey, and the `appUpdateRequired` (remote-newer) journey.
   "ready"
   "uvInstall"
   "appUpdateRequired"
@@ -186,6 +281,49 @@ BOOTSTRAP_METHODS=(
   # NON-DESTRUCTIVE `pocketshell hooks install` (pre-existing foreign hook
   # survives). Needs the bootstrap-notifications:2241 fixture (brought up below).
   "notifications"
+  # --- Issue #2111: the six scenarios that previously ran nowhere. ------------
+  # FAILURE PATHS — the ones the audit called out by name. A successful install
+  # is the easy half; what a user actually hits is the install that FAILS, and
+  # the recovery sheet is the only thing standing between them and a dead host.
+  # `uvUpgradeFailure` asserts the failed-upgrade sheet names the path, the
+  # remote/expected versions, the exact failing `uv tool install` command and the
+  # fixture's stderr, and that the old CLI is left in place (bootstrap-uv-upgrade
+  # :2236, already up for uvUpgrade/appUpdateRequired — no new fixture).
+  "uvUpgradeFailure"
+  # `unsupported` is the no-installer host: the sheet must offer the MANUAL
+  # `uv tool install ... or pipx install pocketshell` instruction and the Install
+  # attempt must fail closed with a reachable Close action (bootstrap-unsupported
+  # :2232).
+  "unsupported"
+  # `daemonDisabled` proves the OPTIONAL jobs daemon is genuinely optional: the
+  # host navigates normally and bootstrap must NOT enable it behind the user's
+  # back (bootstrap-daemon-disabled:2233).
+  "daemonDisabled"
+  # SUCCESS PATH the failure path is meaningless without: `uvUpgrade` is the
+  # working CLI-update journey AND the only proof of the #779 one-clear-action
+  # rule (badge "Outdated" + a single "Update" button; the synonym verb "Upgrade"
+  # must not appear as a control). Reuses bootstrap-uv-upgrade:2236.
+  "uvUpgrade"
+  # PATH DISCOVERY — `pocketshell` installed in `~/.local/bin` rather than on the
+  # default non-login PATH, under bash (`userLocalPath`, bootstrap-user-local-path
+  # :2234) and under fish, whose login-PATH handling is different again
+  # (`fishUserLocalPath`, bootstrap-fish-user-local-path:2235). This is the exact
+  # shape of the v0.4.10 connect break (AGENTS.md: the host `pocketshell` lives in
+  # `~/.local/bin`, where `PocketshellCommand.wrap()` is multi-statement), so it
+  # is real coverage, not a completeness box-tick.
+  #
+  # HONEST SCOPE, established by mutation (#2111): mutating the fish login-PATH
+  # probe body ALONE kills 0 tests — `fishUserLocalPath` stays green — because
+  # `HostBootstrapper.detectCommonToolPath` probes `$HOME/.local/bin/pocketshell`
+  # by ABSOLUTE path, independent of PATH, so the tool is still found. So what
+  # these two scenarios guard is "a bash/fish host whose pocketshell lives in
+  # ~/.local/bin bootstraps end-to-end", carried by the `COMMON_TOOL_DIRS`
+  # fallback — NOT the per-shell probe body in isolation. Mutating the whole
+  # ~/.local/bin bootstrap (the three login-PATH probe bodies + the
+  # `pathAwareCommand` fallback + `COMMON_TOOL_DIRS`) reddens exactly
+  # userLocalPath + fishUserLocalPath + uvInstall and nothing else.
+  "userLocalPath"
+  "fishUserLocalPath"
 )
 BOOTSTRAP_CLASS_ARG="$(printf "%s\n" "${BOOTSTRAP_METHODS[@]}" \
   | sed "s|^|$BOOTSTRAP_TEST_CLASS#|" | paste -sd, -)"
@@ -200,7 +338,10 @@ JOURNEY_EXCLUDED_CLASSES=(
   "${EXPECTED_FAIL_CLASSES[@]}"
   "$FQCN_PREFIX.LongRunningSessionStabilityTest"
   "$FQCN_PREFIX.LongRunningInstrumentationHeartbeatTest"
-  "$FQCN_PREFIX.RealAgentReleaseGateTest"
+  # Issue #2111: still excluded from phase 1 (which passes no opt-in, so it would
+  # only self-skip there); it now runs in its OWN phase 4 with the opt-in + the
+  # real-agent:2240 fixture.
+  "$REAL_AGENT_TEST_CLASS"
   "$BOOTSTRAP_TEST_CLASS"
   "$NOTIFICATION_PERMISSION_TEST_CLASS"
 )
@@ -322,15 +463,18 @@ NOTIFICATION_PERMISSION_EXIT=0
 NETWORK_FAULT_EXIT=0
 BOOTSTRAP_EXIT=0
 EXPECTED_FAIL_EXIT=0
+REAL_AGENT_EXIT=0
 notification_permission_status="SKIP"
 notification_permission_executed=0
 nf_status="SKIP"
 bootstrap_status="SKIP"
 expectedfail_status="SKIP"
+real_agent_status="SKIP"
 notification_permission_classification="SKIP"
 nf_classification="SKIP"
 bootstrap_classification="SKIP"
 expectedfail_classification="SKIP"
+real_agent_classification="SKIP"
 
 if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   echo "=========================================================="
@@ -421,11 +565,13 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   )"
 
   echo "=========================================================="
-  echo "Nightly Extensive Tests — phase 2b: #822 expected-fail lane (NON-GATING)"
+  echo "Nightly Extensive Tests — phase 2b: expected-fail lane (NON-GATING)"
   echo "Included classes: $EXPECTED_FAIL_CLASS_ARG"
-  echo "  (pocketshellNetworkFaultProofs=true; result is INFORMATIONAL ONLY —"
-  echo "   these are TDD specs for unbuilt Slice C/D features, designed RED, and"
-  echo "   are DELIBERATELY excluded from the fault verdict — issue #1201)"
+  echo "  (pocketshellNetworkFaultProofs=true; result is INFORMATIONAL ONLY and"
+  echo "   is DELIBERATELY excluded from the fault verdict — issue #1201. Holds"
+  echo "   the #822 TDD specs for unbuilt Slice C/D features AND the #2111"
+  echo "   Conversation-open latency proof, whose <0.3s budget an emulator cannot"
+  echo "   meet; each is promoted to the GATING phase 2 once it runs green.)"
   echo "=========================================================="
 
   # Issue #1201: the #822 Slice C/D journeys still RUN nightly (their tracking
@@ -437,7 +583,7 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
     -Pandroid.testInstrumentationRunnerArguments.class="$EXPECTED_FAIL_CLASS_ARG" \
     --stacktrace
   EXPECTED_FAIL_EXIT=$?
-  echo "phase 2b (#822 expected-fail lane) exit code: $EXPECTED_FAIL_EXIT (NON-GATING)"
+  echo "phase 2b (expected-fail lane) exit code: $EXPECTED_FAIL_EXIT (NON-GATING)"
 
   # Snapshot phase 2b's report BEFORE the phase-3 gradle invocation overwrites it
   # (issue #1293). Observability only — never affects EXPECTED_FAIL_EXIT.
@@ -485,9 +631,57 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
     classify_nightly_phase "$BOOTSTRAP_EXIT" "$PHASE_REPORTS_DIR/phase3-bootstrap"
   )"
 
+  echo "=========================================================="
+  echo "Nightly Extensive Tests — phase 4: real-agent CLI gate (opt-in, issue #2111)"
+  echo "Included class: $REAL_AGENT_TEST_CLASS"
+  echo "  (pocketshellRealAgentReleaseGate=1, real-agents:2240 fixture)"
+  echo "=========================================================="
+
+  # Issue #2111 (audit item 4): close the cadence gap. This phase's exit code
+  # feeds `overall_status` (so a real-CLI rendering regression makes the nightly
+  # shard RED and is visible the next morning) but is DELIBERATELY NOT an input
+  # to the machine-readable fault verdict: #1201 fixed that verdict's inputs to
+  # the network-fault + bootstrap phases, and widening it here would change the
+  # release-gating signal, which is out of this issue's scope. The release gate
+  # (`TERMINAL_RELEASE_GATE=1 scripts/release-emulator-validation.sh`) remains
+  # the authoritative pre-tag run; this is the nightly early-warning copy.
+  #
+  # The fixture lives in its own compose file, so it is only exercised when the
+  # workflow actually started it. If port 2240 is not up the phase is recorded
+  # SKIP rather than a phantom red — the tests themselves fail loudly on an
+  # unreachable fixture, so this check only distinguishes "not provisioned on
+  # this runner" from "provisioned and broken".
+  if [[ -f "$REAL_AGENT_COMPOSE_FILE" ]] && \
+     timeout 2 bash -c 'exec 3<>/dev/tcp/127.0.0.1/2240' 2>/dev/null; then
+    "$GRADLEW" :app:connectedDebugAndroidTest \
+      -Pandroid.testInstrumentationRunnerArguments.pocketshellRealAgentReleaseGate=1 \
+      -Pandroid.testInstrumentationRunnerArguments.class="$REAL_AGENT_TEST_CLASS" \
+      --stacktrace
+    REAL_AGENT_EXIT=$?
+    echo "phase 4 (real-agent CLI gate) exit code: $REAL_AGENT_EXIT"
+
+    preserve_phase_reports "phase4-real-agent" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+    write_nightly_phase_classification \
+      "$PHASE_CLASSIFICATIONS_DIR/phase4-real-agent.txt" \
+      "phase4-real-agent" "$REAL_AGENT_EXIT" "$PHASE_REPORTS_DIR/phase4-real-agent"
+    capture_nightly_device_boundary \
+      "$PHASE_CLASSIFICATIONS_DIR/phase4-real-agent-device.txt" "phase4-real-agent"
+    real_agent_classification="$(
+      classify_nightly_phase "$REAL_AGENT_EXIT" "$PHASE_REPORTS_DIR/phase4-real-agent"
+    )"
+  else
+    echo "phase 4 (real-agent CLI gate) SKIPPED: real-agents:2240 fixture is not up on this runner"
+    real_agent_classification="SKIP"
+  fi
+
   nf_status="$(nightly_phase_status "$nf_classification")"
   bootstrap_status="$(nightly_phase_status "$bootstrap_classification")"
   expectedfail_status="$(nightly_phase_status "$expectedfail_classification")"
+  if [[ "$real_agent_classification" == "SKIP" ]]; then
+    real_agent_status="SKIP"
+  else
+    real_agent_status="$(nightly_phase_status "$real_agent_classification")"
+  fi
 
   # Issue #1201: emit the authoritative, machine-readable fault-injection safety
   # verdict from the network-fault + bootstrap phases ONLY. The journey suite
@@ -507,8 +701,9 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   echo "----------------------------------------------------------"
 else
   echo "=========================================================="
-  echo "Nightly Extensive Tests — phases 1b, 2, 2b & 3 SKIPPED on shard ${SHARD_INDEX:-0}"
-  echo "  (notification + network-fault + expected-fail + bootstrap run once, on shard 0)"
+  echo "Nightly Extensive Tests — phases 1b, 2, 2b, 3 & 4 SKIPPED on shard ${SHARD_INDEX:-0}"
+  echo "  (notification + network-fault + expected-fail + bootstrap + real-agent"
+  echo "   run once, on shard 0)"
   echo "=========================================================="
 fi
 
@@ -519,11 +714,17 @@ journey_status="$(nightly_phase_status "$JOURNEY_CLASSIFICATION")"
 # expected-fail lane (phase 2b) — including an intentionally-red TDD lane would
 # make the shard summary permanently red for a non-reason. Note: `overall_status`
 # is NOT the release-gating signal; the machine-readable fault verdict above is.
+#
+# Issue #2111: phase 4 (real-agent CLI gate) IS included here — that is the whole
+# point of closing the cadence gap: a real Claude/Codex rendering regression must
+# make the nightly shard red the next morning instead of waiting for a release
+# cut. It is still NOT an input to the release-gating fault verdict above.
 overall_status="PASS"
 if [[ "$JOURNEY_EXIT" -ne 0 \
       || "$NOTIFICATION_PERMISSION_EXIT" -ne 0 \
       || "$NETWORK_FAULT_EXIT" -ne 0 \
-      || "$BOOTSTRAP_EXIT" -ne 0 ]]; then
+      || "$BOOTSTRAP_EXIT" -ne 0 \
+      || "$REAL_AGENT_EXIT" -ne 0 ]]; then
   overall_status="FAIL"
 fi
 
@@ -543,8 +744,9 @@ fi
   echo "| Journey / E2E (non-gating) | full connected suite minus network-fault + expected-fail + opt-in classes ($shard_label) | \`pocketshellCi=true\` | $JOURNEY_EXIT | **$journey_status** ($JOURNEY_CLASSIFICATION) |"
   echo "| Notification permission (NON-GATING) | dedicated unsharded $NOTIFICATION_PERMISSION_TEST_CLASS; executed=$notification_permission_executed | external revoke/verify before instrumentation; external grant/verify after | $NOTIFICATION_PERMISSION_EXIT | **$notification_permission_status** ($notification_permission_classification) |"
   echo "| Network-fault proofs (GATING) | ${#NETWORK_FAULT_CLASSES[@]} Toxiproxy-backed classes | \`pocketshellNetworkFaultProofs=true\` (no pocketshellCi) | $NETWORK_FAULT_EXIT | **$nf_status** ($nf_classification) |"
-  echo "| #822 expected-fail lane (NON-GATING) | ${#EXPECTED_FAIL_CLASSES[@]} Slice C/D TDD spec class(es) | \`pocketshellNetworkFaultProofs=true\` | $EXPECTED_FAIL_EXIT | **$expectedfail_status** ($expectedfail_classification) |"
-  echo "| Bootstrap setup scenarios (GATING) | ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (trimmed) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** ($bootstrap_classification) |"
+  echo "| Expected-fail lane (NON-GATING) | ${#EXPECTED_FAIL_CLASSES[@]} class(es): #822 Slice C/D TDD specs + the #2111 Conversation-open latency proof | \`pocketshellNetworkFaultProofs=true\` | $EXPECTED_FAIL_EXIT | **$expectedfail_status** ($expectedfail_classification) |"
+  echo "| Bootstrap setup scenarios (GATING) | ALL ${#BOOTSTRAP_METHODS[@]} HostBootstrapScenarioSuiteTest methods (issue #2111) | \`pocketshellBootstrapScenarios=true\` | $BOOTSTRAP_EXIT | **$bootstrap_status** ($bootstrap_classification) |"
+  echo "| Real-agent CLI gate (issue #2111; in overall_status, NOT in the fault verdict) | $REAL_AGENT_TEST_CLASS against real-agents:2240 | \`pocketshellRealAgentReleaseGate=1\` | $REAL_AGENT_EXIT | **$real_agent_status** ($real_agent_classification) |"
   echo
   echo "**Extensive-shard overall (non-gating summary): $overall_status**"
   echo
@@ -574,7 +776,9 @@ fi
     echo "- \`$c\`"
   done
   echo
-  echo "#822 expected-fail lane (NON-GATING, tracked only — TDD specs for unbuilt Slice C/D):"
+  echo "Expected-fail lane (NON-GATING, tracked only — #822 TDD specs for unbuilt"
+  echo "Slice C/D, plus the #2111 Conversation-open latency proof whose <0.3s budget"
+  echo "an emulator cannot meet; each is promoted to the GATING phase once green):"
   for c in "${EXPECTED_FAIL_CLASSES[@]}"; do
     echo "- \`$c\`"
   done
@@ -583,6 +787,12 @@ fi
   for m in "${BOOTSTRAP_METHODS[@]}"; do
     echo "- \`$m\`"
   done
+  echo
+  echo "Real-agent CLI gate (issue #2111 — nightly cadence for the real"
+  echo "Claude/Codex rendering + JSONL parsing journeys; the release gate"
+  echo "\`TERMINAL_RELEASE_GATE=1 scripts/release-emulator-validation.sh\` remains"
+  echo "the authoritative pre-tag run):"
+  echo "- \`$REAL_AGENT_TEST_CLASS\`"
 } > "$SUMMARY"
 
 echo "----------------------------------------------------------"


### PR DESCRIPTION
Four tests/scenario sets self-skipped on every lane, so they were green
without ever asserting anything.

The headline defect: `ConversationOpenLatencyRttDockerTest` packed two gates
into a single `if (rttMs == GATE_RTT_MS)` block behind a `try/finally`. The
unreachable 300ms budget assertion at the top threw, and the structural #828
assertion below it never ran at all — so the test that exists to protect the
prefetched-window optimisation was protecting nothing. Split into two `@Test`
methods so each gate is independently reachable.

**Proof the split is load-bearing, not cosmetic:** dropping `prefetchedWindow ?: `
in `TmuxSessionViewModel` changes the failure *set*, not merely the count —
baseline `{budget}`, mutant `{budget, structural}`.

Reviewer verdict on #2111: **APPROVED** — it independently reproduced the
changed failure set (baseline `tests=2 failures=1`, mutant `tests=2 failures=2`,
`window_read` 0ms → 1077ms @80ms RTT / 823ms @150ms), and closed the two gaps
the implementer had honestly left unproven:

- ran item (1) in the exact lane that used to skip it — 4/4, `skipped=0` — and
  confirmed deleting `seedAgentConversationFromMemory` reddens precisely that test;
- ran all ten bootstrap scenarios with `skipped=0`, so the six newly-enrolled
  cases are proven *before* they become gating;
- confirmed `RealAgentReleaseGateTest` is green, so wiring it in does not create
  a standing nightly red.

Closes #2111