### PR TITLE
host-cli: generate the README exit-code table from EXIT_CODE_TABLE (#2153)

### DIFF
--- a/tools/pocketshell/README.md
+++ b/tools/pocketshell/README.md
@@ -86,21 +86,28 @@ framing twice put the inner markers into the receiving program as literal
 text (issue #1854). Callers that want bracketed paste write the framed bytes
 to stdin.
 
-Exit codes are stable, and `--help` documents them (rendered from the same
-table the code exits with, so they cannot drift):
+Exit codes are stable. Both renderings below — this table and `--help` — are
+generated from the one `EXIT_CODE_TABLE` the code exits with, so neither can
+drift from the other (issue #2153; regenerate with
+`tools/pocketshell/scripts/sync-readme-exit-codes.py`, pinned by a test in the
+`Python utility tests (pocketshell)` check):
+
+<!-- BEGIN GENERATED: send exit codes (source: EXIT_CODE_TABLE in pocketshell/send.py) -->
 
 | Exit | stdout reason | Meaning |
 | ---- | ------------- | ------- |
-| 0 | `delivered` | Injected by this call and journaled. |
-| 0 | `already-delivered` | The token was already journaled; nothing injected. |
-| 0 | `pruned <n>` | `--prune-older-than` removed `n` records. |
-| 2 | `bad-usage` | Invalid/missing arguments. Nothing injected or journaled. |
-| 3 | `pane-not-found` | Pane missing or dead. Not journaled; stays retryable. |
-| 4 | `tmux-failed` | tmux missing / no server / a definitive tmux failure. This call put **nothing** into the pane and left the journal exactly as it found it — see the note below for what that does and does not promise. |
-| 5 | `send-interrupted` or `journal-corrupt` | Delivery is genuinely UNKNOWN and the token is left journaled-unresolved. Either a previous attempt died without an answer, or this call got past the paste and the payload may already be in the pane. Never auto-retry — see below. |
-| 6 | `timeout` | A tmux call exceeded `--timeout`. If it hit at or after the commit, the payload may already be in the pane and the token is left in the exit-5 unknown. |
-| 7 | `journal-failed` | The journal could not be read/written. Nothing injected. |
-| 8 | `send-in-progress` | Another send for this token is STILL RUNNING. Nothing injected, nothing unknown — retry shortly to read that call's answer. |
+| 0 | `delivered` \| `already-delivered` \| `pruned` | Success. 'delivered' = injected by THIS call and journaled. 'already-delivered' = the token was already journaled, nothing was injected. 'pruned' = --prune-older-than removed N records. |
+| 2 | `bad-usage` | Invalid or missing arguments. Nothing was injected or journaled. |
+| 3 | `pane-not-found` | The pane id does not exist on the tmux server, or it is dead. Nothing was injected; the token is NOT journaled and stays retryable. |
+| 4 | `tmux-failed` | tmux is missing, no server is running, or a tmux command returned a definitive failure. This call put NOTHING into the pane and recorded no delivery, and it left the journal exactly as it found it: a claim this call took is released, and a pre-existing unresolved record it overwrote under --resend-interrupted is restored byte-for-byte. A retry therefore cannot duplicate — but 'unchanged' is not 'absent': if the token was already journaled-unresolved it still is, and the next plain call answers 'send-interrupted' rather than injecting. |
+| 5 | `send-interrupted` \| `journal-corrupt` | Delivery is genuinely UNKNOWN and the token is left journaled-unresolved, so no plain call will ever inject it again. Two ways in. Either a PREVIOUS attempt died without an answer (or left an unreadable record) and its owning process is gone, in which case this call injected nothing; or THIS call got past the point of no return — tmux accepted the paste and then the Enter failed, or the delivery could not be journaled — in which case the payload may ALREADY be in the pane. Never auto-retry either reading. Re-run with --resend-interrupted only to accept a possible duplicate. |
+| 6 | `timeout` | A tmux invocation exceeded --timeout. If the timeout hit at or after the commit the token is left in the unknown state above and the payload may ALREADY be in the pane; a retry then reports 'send-interrupted' rather than injecting again. |
+| 7 | `journal-failed` | The durable token journal could not be read or written (permissions, disk). Nothing was injected — the journal is written BEFORE the pane is touched precisely so this failure is safe. |
+| 8 | `send-in-progress` | Another send for this token is STILL RUNNING (its process is alive on this host). Nothing was injected by this call and nothing is unknown: the outcome is owned by that call. Retry shortly to read the answer — it will be 'delivered'/'already-delivered' or, if that process dies, 'send-interrupted'. --resend-interrupted does not override this: there is no unknown to resolve while the owner is alive, and forcing one would duplicate the payload. |
+
+<!-- END GENERATED: send exit codes -->
+
+(`pruned` prints the record count after the reason word: `pruned <n>`.)
 
 **The paste is the point of no return, and that is the boundary between exit 4
 and exit 5** (issue #2136). A client that branches on this table to decide

--- a/tools/pocketshell/scripts/sync-readme-exit-codes.py
+++ b/tools/pocketshell/scripts/sync-readme-exit-codes.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Regenerate (or check) the README's `pocketshell send` exit-code table (#2153).
+
+WHY THIS EXISTS
+
+`pocketshell send`'s exit-code table existed in two places with no mechanical
+link: `EXIT_CODE_TABLE` in `pocketshell/send.py` — which `--help` is rendered
+from, so THAT half cannot drift — and a hand-written prose table in
+`tools/pocketshell/README.md`. #2122 corrected the exit-4 wording on the README
+half and left `--help` stale; #2136 fixed `--help` and added description pins,
+but only on the `EXIT_CODE_TABLE` side. Either way the two disagreed, and the
+README is what a client author reads while implementing #2124's auto-retry
+branching — the exact decision a wrong exit-4 description makes unsafe.
+
+So the README block is GENERATED from the tuple, fenced by markers, and pinned
+by `test_send.py` in the required `Python utility tests (pocketshell)` check.
+Both directions redden: edit the tuple alone and the committed README no longer
+matches the render; edit the README alone and it no longer matches the tuple.
+
+USAGE (from `tools/pocketshell/`, so `click` is importable — `uv run` supplies
+the project environment; a plain `./scripts/sync-readme-exit-codes.py` works
+wherever the package is already installed):
+
+    uv run scripts/sync-readme-exit-codes.py              # rewrite the block
+    uv run scripts/sync-readme-exit-codes.py --check      # verify only
+    uv run scripts/sync-readme-exit-codes.py --self-test  # prove it detects
+
+`--self-test` plants a drift of each direction on a throwaway copy and requires
+`--check` to go RED for each, plus GREEN on the clean tree and GREEN on an edit
+OUTSIDE the block — so a guard that has silently stopped detecting anything
+cannot pass as protection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT / "src"))
+
+from pocketshell import send as send_mod  # noqa: E402  (after the sys.path fix)
+
+README = PACKAGE_ROOT / "README.md"
+
+
+def check(readme_path: Path) -> int:
+    """0 when the committed block matches the render, 1 otherwise."""
+    text = readme_path.read_text(encoding="utf-8")
+    try:
+        committed = send_mod.extract_readme_exit_code_table(text)
+    except ValueError as exc:
+        print(f"FAIL {readme_path}: {exc}", file=sys.stderr)
+        return 1
+    expected = send_mod.render_readme_exit_code_table()
+    if committed == expected:
+        print(f"OK   {readme_path}: exit-code table matches EXIT_CODE_TABLE")
+        return 0
+    diff = difflib.unified_diff(
+        committed.splitlines(),
+        expected.splitlines(),
+        fromfile="README.md (committed)",
+        tofile="EXIT_CODE_TABLE (send.py)",
+        lineterm="",
+    )
+    print(
+        f"FAIL {readme_path}: the exit-code table disagrees with EXIT_CODE_TABLE.\n"
+        "Regenerate with tools/pocketshell/scripts/sync-readme-exit-codes.py",
+        file=sys.stderr,
+    )
+    for line in diff:
+        print(line, file=sys.stderr)
+    return 1
+
+
+def write(readme_path: Path) -> int:
+    text = readme_path.read_text(encoding="utf-8")
+    updated = send_mod.readme_with_exit_code_table(text)
+    if updated == text:
+        print(f"OK   {readme_path}: already up to date")
+        return 0
+    readme_path.write_text(updated, encoding="utf-8")
+    print(f"WROTE {readme_path}: exit-code table regenerated from EXIT_CODE_TABLE")
+    return 0
+
+
+def _self_test() -> int:
+    """Plant a violation of each direction and require a RED."""
+    failures: list[str] = []
+
+    def expect(label: str, rc: int, want: int) -> None:
+        verdict = "OK" if rc == want else "SELF-TEST FAILURE"
+        print(f"  [{verdict}] {label}: rc={rc} (want {want})")
+        if rc != want:
+            failures.append(label)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp) / "README.md"
+        shutil.copy2(README, work)
+        clean = work.read_text(encoding="utf-8")
+
+        expect("clean tree is GREEN", check(work), 0)
+
+        # Direction 1 — the README half is edited alone. This is the #2122
+        # shape: someone corrects (or breaks) the prose and the code half is
+        # untouched.
+        committed = send_mod.extract_readme_exit_code_table(clean)
+        mutated_readme = clean.replace(
+            committed,
+            committed.replace("Nothing was injected or journaled.", "Nothing happened."),
+            1,
+        )
+        assert mutated_readme != clean, "README-side mutation did not apply"
+        work.write_text(mutated_readme, encoding="utf-8")
+        expect("README edited alone is RED", check(work), 1)
+
+        # Direction 2 — the table half is edited alone. This is the #2136 shape
+        # in reverse: the tuple moves (and `--help` with it) and the README is
+        # left behind. Simulated by regenerating the block from a mutated tuple
+        # and checking it against the real one.
+        mutated_table = tuple(
+            (code, reason, description.replace("Invalid or missing", "Bogus or missing"))
+            for code, reason, description in send_mod.EXIT_CODE_TABLE
+        )
+        assert mutated_table != send_mod.EXIT_CODE_TABLE, "table-side mutation did not apply"
+        work.write_text(
+            send_mod.readme_with_exit_code_table(clean, mutated_table), encoding="utf-8"
+        )
+        expect("EXIT_CODE_TABLE edited alone is RED", check(work), 1)
+
+        # Selectivity — an edit OUTSIDE the generated block must stay GREEN, or
+        # the guard is a tripwire on the whole README rather than on the table.
+        work.write_text(clean + "\n\nAn unrelated new paragraph.\n", encoding="utf-8")
+        expect("edit outside the block stays GREEN", check(work), 0)
+
+        # A README that lost its fences must fail loudly rather than silently
+        # stop checking anything.
+        work.write_text(clean.replace(send_mod.README_TABLE_BEGIN, ""), encoding="utf-8")
+        expect("missing fence is RED", check(work), 1)
+
+    if failures:
+        print(f"SELF-TEST FAILED: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    print("SELF-TEST PASSED")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="verify without writing")
+    group.add_argument(
+        "--self-test", action="store_true", help="prove the check still detects drift"
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+    if args.check:
+        return check(README)
+    return write(README)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pocketshell/src/pocketshell/send.py
+++ b/tools/pocketshell/src/pocketshell/send.py
@@ -234,6 +234,95 @@ EXIT_CODE_TABLE: tuple[tuple[int, str, str], ...] = (
 )
 
 # --------------------------------------------------------------------------
+# The SECOND rendering of the table above: the README (issue #2153)
+# --------------------------------------------------------------------------
+#
+# ``--help`` is rendered from ``EXIT_CODE_TABLE`` by ``_epilog()`` below, so it
+# cannot drift. The prose table in ``tools/pocketshell/README.md`` had no such
+# link, and that is precisely what produced #2136: #2122 corrected the exit-4
+# wording in the README and left ``--help`` stale, and a client author reads the
+# README (not ``--help``) while implementing #2124's auto-retry branching.
+#
+# So the README block is GENERATED from the same tuple and pinned by a test in
+# the required `Python utility tests (pocketshell)` check. Neither side can be
+# edited alone: change the tuple and the committed README no longer matches the
+# render; change the README and it no longer matches the tuple. Regenerate with
+#
+#     tools/pocketshell/scripts/sync-readme-exit-codes.py
+
+#: Fences of the generated block in ``tools/pocketshell/README.md``. Both must
+#: appear exactly once, in this order.
+README_TABLE_BEGIN = (
+    "<!-- BEGIN GENERATED: send exit codes (source: EXIT_CODE_TABLE in pocketshell/send.py) -->"
+)
+README_TABLE_END = "<!-- END GENERATED: send exit codes -->"
+
+
+def _escape_markdown_cell(text: str) -> str:
+    """Escape what would otherwise end a markdown table cell early."""
+    return text.replace("|", "\\|")
+
+
+def render_readme_exit_code_table(
+    table: Sequence[tuple[int, str, str]] = EXIT_CODE_TABLE,
+) -> str:
+    """Render ``EXIT_CODE_TABLE`` as the README's markdown table.
+
+    The ``Meaning`` column carries the table's description VERBATIM — the same
+    sentences ``--help`` prints. A shorter hand-written paraphrase is exactly
+    the seam #2136 came through: two wordings, one of them wrong, and nothing
+    to say which.
+    """
+    lines = [
+        "| Exit | stdout reason | Meaning |",
+        "| ---- | ------------- | ------- |",
+    ]
+    for code, reason, description in table:
+        reasons = " \\| ".join(f"`{part.strip()}`" for part in reason.split("|"))
+        lines.append(f"| {code} | {reasons} | {_escape_markdown_cell(description)} |")
+    return "\n".join(lines)
+
+
+def extract_readme_exit_code_table(readme_text: str) -> str:
+    """Return the generated block of ``readme_text``, between its two fences.
+
+    Raises ``ValueError`` when the fences are missing, duplicated or inverted —
+    a README that lost its fences must fail loudly, not silently stop being
+    checked (that would be the drift hole reopened, wearing a green tick).
+    """
+    begins = readme_text.count(README_TABLE_BEGIN)
+    ends = readme_text.count(README_TABLE_END)
+    if begins != 1 or ends != 1:
+        raise ValueError(
+            "README must contain exactly one generated send exit-code block; "
+            f"found {begins} begin marker(s) and {ends} end marker(s)"
+        )
+    start = readme_text.index(README_TABLE_BEGIN) + len(README_TABLE_BEGIN)
+    end = readme_text.index(README_TABLE_END)
+    if end < start:
+        raise ValueError("README send exit-code markers are inverted")
+    return readme_text[start:end].strip("\n")
+
+
+def readme_with_exit_code_table(
+    readme_text: str,
+    table: Sequence[tuple[int, str, str]] = EXIT_CODE_TABLE,
+) -> str:
+    """``readme_text`` with its generated block replaced by a fresh render."""
+    # Validates the fences before rewriting anything.
+    extract_readme_exit_code_table(readme_text)
+    start = readme_text.index(README_TABLE_BEGIN) + len(README_TABLE_BEGIN)
+    end = readme_text.index(README_TABLE_END)
+    return (
+        readme_text[:start]
+        + "\n\n"
+        + render_readme_exit_code_table(table)
+        + "\n\n"
+        + readme_text[end:]
+    )
+
+
+# --------------------------------------------------------------------------
 # Journal
 # --------------------------------------------------------------------------
 

--- a/tools/pocketshell/tests/test_send.py
+++ b/tools/pocketshell/tests/test_send.py
@@ -2480,3 +2480,142 @@ def test_classify_unresolved_reports_a_live_owner_without_a_second_read(
     record, alive = send_mod.classify_unresolved(path, token)
     assert record.state == send_mod.STATE_PENDING
     assert alive is True
+
+
+# --------------------------------------------------------------------------
+# AC (#2153): the README table and EXIT_CODE_TABLE cannot disagree
+# --------------------------------------------------------------------------
+#
+# `--help` is rendered from EXIT_CODE_TABLE, so that half cannot drift. The
+# README half had no such link — which is how #2136 happened: #2122 fixed the
+# exit-4 wording in the README and left `--help` stale, and #2136 then pinned
+# the descriptions on the EXIT_CODE_TABLE side only, leaving the same hole open
+# in the other direction. These tests close both directions.
+
+REPO_README = Path(__file__).resolve().parents[1] / "README.md"
+SYNC_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "sync-readme-exit-codes.py"
+
+
+def _mutated_table(old: str, new: str) -> tuple[tuple[int, str, str], ...]:
+    """EXIT_CODE_TABLE with one description word changed — a live mutant.
+
+    Asserts the substitution actually applied. A mutation that silently missed
+    reads exactly like "my check is adequate" (AGENTS.md, the #1641 lesson).
+    """
+    mutated = tuple(
+        (code, reason, description.replace(old, new))
+        for code, reason, description in send_mod.EXIT_CODE_TABLE
+    )
+    assert mutated != send_mod.EXIT_CODE_TABLE, f"mutation {old!r} -> {new!r} did not apply"
+    return mutated
+
+
+def test_readme_exit_code_table_is_generated_from_the_source_table() -> None:
+    """The committed README block must equal the render of EXIT_CODE_TABLE.
+
+    Row for row, including the DESCRIPTION column — the column #2122/#2136
+    drifted on, and the one a #2124 client reads to decide whether an auto-retry
+    is safe.
+    """
+    committed = send_mod.extract_readme_exit_code_table(
+        REPO_README.read_text(encoding="utf-8")
+    )
+    assert committed == send_mod.render_readme_exit_code_table(), (
+        "tools/pocketshell/README.md disagrees with EXIT_CODE_TABLE; regenerate "
+        "with tools/pocketshell/scripts/sync-readme-exit-codes.py"
+    )
+
+
+def test_the_pin_reddens_when_only_EXIT_CODE_TABLE_moves() -> None:
+    """Direction 1: the code half is edited and the README is left behind.
+
+    This is the hole #2136's description pins left open — they pinned `--help`
+    against the tuple, and both move together, so nothing noticed the README.
+    """
+    committed = send_mod.extract_readme_exit_code_table(
+        REPO_README.read_text(encoding="utf-8")
+    )
+    mutated = _mutated_table("Nothing was injected or journaled.", "Nothing happened.")
+    assert committed != send_mod.render_readme_exit_code_table(mutated)
+
+
+def test_the_pin_reddens_when_only_the_README_moves() -> None:
+    """Direction 2: the README half is edited alone — the #2122 shape."""
+    readme = REPO_README.read_text(encoding="utf-8")
+    committed = send_mod.extract_readme_exit_code_table(readme)
+    edited = send_mod.extract_readme_exit_code_table(
+        readme.replace(
+            committed,
+            committed.replace("stays retryable", "is gone forever"),
+            1,
+        )
+    )
+    assert edited != committed, "README-side mutation did not apply"
+    assert edited != send_mod.render_readme_exit_code_table()
+
+
+def test_the_pin_ignores_edits_outside_the_generated_block() -> None:
+    """Selectivity: the pin guards the table, not the whole README."""
+    readme = REPO_README.read_text(encoding="utf-8")
+    unrelated = readme + "\n\nAn unrelated new paragraph.\n"
+    assert send_mod.extract_readme_exit_code_table(unrelated) == (
+        send_mod.render_readme_exit_code_table()
+    )
+
+
+def test_a_readme_without_its_fences_fails_loudly() -> None:
+    """A lost fence must raise, not silently stop checking anything."""
+    readme = REPO_README.read_text(encoding="utf-8")
+    with pytest.raises(ValueError):
+        send_mod.extract_readme_exit_code_table(
+            readme.replace(send_mod.README_TABLE_BEGIN, "")
+        )
+    with pytest.raises(ValueError):
+        send_mod.extract_readme_exit_code_table(readme + readme)
+
+
+def test_every_exit_code_and_reason_reaches_the_generated_readme_table() -> None:
+    """The render must carry every code and reason, not a subset."""
+    rendered = send_mod.render_readme_exit_code_table()
+    for code, reasons, description in send_mod.EXIT_CODE_TABLE:
+        assert f"| {code} |" in rendered, f"exit code {code} missing from the README table"
+        for reason in (part.strip() for part in reasons.split("|")):
+            assert f"`{reason}`" in rendered, f"reason {reason!r} missing"
+        # The description is carried VERBATIM (bar markdown pipe escaping), so
+        # the README reader and the `--help` reader get the same sentences.
+        assert description.replace("|", "\\|") in rendered
+
+
+def test_the_regenerator_rewrites_only_the_block_and_is_idempotent() -> None:
+    """`sync-readme-exit-codes.py`'s rewrite is a fixpoint on a clean tree."""
+    readme = REPO_README.read_text(encoding="utf-8")
+    assert send_mod.readme_with_exit_code_table(readme) == readme
+    stale = send_mod.readme_with_exit_code_table(
+        readme, _mutated_table("Invalid or missing", "Bogus or missing")
+    )
+    assert stale != readme
+    # Only the block moved: everything outside the fences is byte-identical.
+    assert stale.split(send_mod.README_TABLE_BEGIN)[0] == (
+        readme.split(send_mod.README_TABLE_BEGIN)[0]
+    )
+    assert stale.split(send_mod.README_TABLE_END)[1] == (
+        readme.split(send_mod.README_TABLE_END)[1]
+    )
+    assert send_mod.readme_with_exit_code_table(stale) == readme
+
+
+def test_the_sync_script_self_test_still_detects_drift() -> None:
+    """Run the guard's own `--self-test` in the required Python check.
+
+    It plants a drift of each direction on a throwaway copy and requires a RED
+    for each, plus a GREEN on the clean tree and on an edit outside the block.
+    A guard that has silently stopped detecting anything fails here.
+    """
+    assert SYNC_SCRIPT.exists(), SYNC_SCRIPT
+    result = subprocess.run(
+        [sys.executable, str(SYNC_SCRIPT), "--self-test"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SELF-TEST PASSED" in result.stdout


### PR DESCRIPTION
The `pocketshell send` exit-code table lived twice — once as `EXIT_CODE_TABLE`
in `send.py`, once as hand-written prose in the README — with nothing coupling
them. #2136's semantic corrections could land in one and not the other.

The README block is now **rendered from `EXIT_CODE_TABLE`** into a fenced region
and asserted byte-equal by tests collected in the required `Python utility tests
(pocketshell)` check, so neither half can be edited alone. A regenerator with
`--check` / `--self-test` ships alongside.

**The hole was real, not theoretical.** Changing the exit-4 description in the
tuple alone leaves 136 tests green — including all 32 `--help` pins and the three
#2136 semantic pins — while the README silently disagrees.

Reviewer verdict: **APPROVED**, earned per-criterion from artifacts produced that
run. It re-ran both of the implementer's mutations and added eight more in a
`cp -a` mutant root (no symlinks, md5-snapshotted before/after, 0 files differing):
added row, removed row, reordered rows, changed numeric code on each side,
neutralised guard — and the strongest case, **degrading the render *and*
regenerating the README so both halves genuinely agree**, which byte-equality
alone would pass but the independent verbatim-description assertion catches. All
red. Three unrelated edits (prose outside the fences, reworded text below the
table, an unrelated `send.py` comment) stayed green, confirming selectivity.

Verification:

- `uv run pytest -q` → **902 passed, 0 skipped**; counts read from the JUnit XML
  rather than the console, with all 8 new tests confirmed named as executed and
  no duplicate `def test_*` that could shadow one out of the run.
- Gate wiring confirmed at `.github/workflows/tests.yml:889-891` — `uv run pytest -v`,
  no filters, so the new tests are genuinely collected by the required check.
- Semantics match the code: exit 4 says the journal is **unchanged**, not empty,
  consistent with `roll_back_claim` and its single call site.
- `check-script-interpreter-hygiene.sh` run directly: 177 tracked shebang files on
  `main` → **178** in this branch, so the new `.py` is actually covered by the
  no-allowlist guard.

Non-blocking follow-ups the reviewer flagged: a stale *second* table appended
outside the fences would still pass (same residual class as the hand-written prose
below the block), and one test's name is broader than its body.

Closes #2153