### PR TITLE
terminal: keep the viewport still while text is being selected (#2154)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -86,6 +86,7 @@ import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionStatus
 import com.pocketshell.app.voice.AssistantStrip
 import com.pocketshell.core.terminal.selection.LocalhostUrl
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.terminal.ui.ImeViewportPinPolicy
 import com.pocketshell.core.terminal.ui.showTerminalSoftKeyboard
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -778,8 +779,18 @@ private fun TmuxSessionScreenEffects(
     )
 
     // Issue #184 Layer 1: snap the active pane to the bottom when the IME shows.
+    //
+    // Issue #2154: the pin is a SHOW-EDGE event gated on "no live selection", not
+    // "the IME happens to be up". The old `if (isImeVisible)` body re-fired on every
+    // change of the key tuple — most importantly a pane/page settle — so a scrolled-
+    // back transcript was yanked to the bottom long after the user raised the
+    // keyboard, and a selection drag (which raises the IME via the vendored view's
+    // requestFocus()) was destroyed mid-gesture. [ImeViewportPinPolicy] owns both
+    // rules and is remembered across recompositions so the edge is real.
+    val imeViewportPinPolicy = remember { ImeViewportPinPolicy() }
     LaunchedEffect(isImeVisible, surfacePane?.paneId) {
-        if (isImeVisible) {
+        val textSelectionActive = surfacePane?.terminalState?.isTextSelectionActive() == true
+        if (imeViewportPinPolicy.shouldPinOnImeVisibility(isImeVisible, textSelectionActive)) {
             com.pocketshell.core.terminal.ui.pinTerminalToBottom(
                 composeRootView,
                 onLocalTerminalError = { cause ->

--- a/scripts/ci-journey-core-terminal-functions.sh
+++ b/scripts/ci-journey-core-terminal-functions.sh
@@ -85,6 +85,13 @@ run_core_terminal_pixel_probe_abandon() {
   run_ct_class "$CORE_TERMINAL_PIXEL_PROBE_ABANDON_CLASS"
 }
 
+CORE_TERMINAL_SELECTION_VIEWPORT_CLASS="com.termux.view.TerminalSelectionViewportStabilityInstrumentedTest"
+SELECTION_VIEWPORT_STATUS="PASS"
+
+run_core_terminal_selection_viewport() {
+  run_ct_class "$CORE_TERMINAL_SELECTION_VIEWPORT_CLASS"
+}
+
 # ---------------------------------------------------------------------------
 # Issue #1827: THE registry of core-terminal proofs.
 #
@@ -124,6 +131,7 @@ CORE_TERMINAL_PROOFS=(
   "SHELL_SNAPSHOT_STATUS|CORE_TERMINAL_SHELL_SNAPSHOT_CLASS|Core-terminal #1233 shell-pane single-snapshot affordance-scan proof"
   "HARD_WRAPPED_URL_STATUS|CORE_TERMINAL_HARD_WRAPPED_URL_CLASS|Core-terminal #1955 hard-wrapped URL target proof"
   "PIXEL_PROBE_ABANDON_STATUS|CORE_TERMINAL_PIXEL_PROBE_ABANDON_CLASS|Core-terminal #2003 abandoned-PixelCopy RenderThread abort proof"
+  "SELECTION_VIEWPORT_STATUS|CORE_TERMINAL_SELECTION_VIEWPORT_CLASS|Core-terminal #2154 selection-viewport-stability proof"
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -994,4 +994,47 @@ else
   fi
 fi
 
+# --------------------------------------------------------------------------
+# Issue #2154 selection-viewport-stability proof (core-terminal androidTest).
+# The maintainer reported that selecting text on-device makes the terminal
+# "start jumping", so a multi-line copy-paste is impossible. The vendored
+# `TerminalView.onScreenUpdated` selection guard was already correct — the
+# jumping came from PocketShell's OWN viewport resets, which never consulted the
+# selection: the #184 IME pin (`setTopRow(0)` BEFORE `onScreenUpdated()`, fired
+# by the very `requestFocus()` the selection gesture performs) and
+# `TerminalView.updateSize` (`mTopRow = 0` on any row/column change, i.e. on
+# every layout shift around a selection drag). This proof drives a REAL
+# long-press selection on the production TerminalSurface with the transcript
+# scrolled BACK, then fires each reset path and asserts the viewport row and the
+# selection's on-screen row are unchanged: RED on base for the IME-pin and
+# resize members, plus characterization coverage for the capture-pane reseed and
+# a live `%output` burst. It ALSO pins the #184 pin's POSITIVE path (no selection
+# -> the pin still snaps to the bottom; and the guard does not latch once the
+# selection ends), so the selection guard cannot be hardened into a #184 kill.
+# Uses NO Docker fixture (in-process real TerminalView).
+if core_terminal_proof_deferred SELECTION_VIEWPORT_STATUS; then
+  # Issue #2110: a sibling leg of THIS push owns this proof.
+  announce_core_terminal_deferred SELECTION_VIEWPORT_STATUS
+elif budget_exhausted; then
+  STEP_TIMEOUT_HIT=1
+  SELECTION_VIEWPORT_STATUS="SKIPPED"
+  echo "JOURNEY_STEP_TIMEOUT: skipping #2154 selection-viewport proof — suite budget exhausted (issue #835 / #470 stall)"
+else
+  echo "=========================================================="
+  echo ">>> CORE-TERMINAL #2154 SELECTION-VIEWPORT PROOF: $CORE_TERMINAL_SELECTION_VIEWPORT_CLASS (attempt 1)"
+  echo "=========================================================="
+  selection_viewport_start=$SECONDS
+  if run_core_terminal_selection_viewport; then
+    echo "SELECTION_VIEWPORT_PASS: passed on attempt 1 (elapsed $((SECONDS - selection_viewport_start))s)"
+  else
+    echo ">>> SELECTION-VIEWPORT PROOF FAILED attempt 1 — retrying once (CI-AVD infra flake / sibling-install)"
+    if run_core_terminal_selection_viewport; then
+      echo "SELECTION_VIEWPORT_FLAKE_RECOVERED: passed on retry (attempt 2)"
+    else
+      echo "SELECTION_VIEWPORT_FAILED: #2154 proof failed twice"
+      SELECTION_VIEWPORT_STATUS="FAIL"
+    fi
+  fi
+fi
+
 finish_ci_journey_suite

--- a/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalSelectionViewportStabilityInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalSelectionViewportStabilityInstrumentedTest.kt
@@ -1,0 +1,877 @@
+package com.termux.view
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.core.terminal.ui.TerminalSurface
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.terminal.ui.pinTerminalToBottom
+import com.pocketshell.core.terminal.ui.testArtifactsRoot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #2154 — the terminal viewport must not JUMP while the user is selecting
+ * text.
+ *
+ * ## The maintainer's report (on-device, 2026-08-15)
+ *
+ * > "when I'm in the terminal I try to select text — I hold my finger and I
+ * > select a part, I start selecting the rest of the thing I want to copy-paste,
+ * > and then my terminal starts jumping. It's even difficult to sometimes just
+ * > scroll it up."
+ *
+ * ## Why the vendored guard did NOT cover it
+ *
+ * [TerminalView.onScreenUpdated] already refuses to scroll for OUTPUT while a
+ * selection is live (`isSelectingText()` → `skipScrolling = true`), and that
+ * guard is correct. The jumping came from PocketShell's OWN viewport resets,
+ * none of which consulted the selection:
+ *
+ *  - `pinTerminalToBottom` (#184's IME pin) called `setTopRow(0)` FIRST and only
+ *    then `onScreenUpdated()`, so the vendored guard ran after the damage. And
+ *    the gesture that starts a selection calls `TerminalView.requestFocus()`,
+ *    which can raise the soft IME — the very event that fires the pin.
+ *  - [TerminalView.updateSize] reset `mTopRow = 0` on ANY row/column change, and
+ *    a selection drag is surrounded by layout shifts (floating action mode,
+ *    bottom chrome, IME inset).
+ *
+ * ## What each test pins (D32-G2 class coverage — every app-layer mover)
+ *
+ * | test | reset path | RED on base |
+ * |---|---|---|
+ * | [imeShowPinDoesNotMoveViewportOrDropSelectionWhileSelecting] | the #184 IME pin | `topRow` snapped from -6 to 0 |
+ * | [layoutSizeChangeDoesNotSnapViewportToBottomWhileSelecting] | `onSizeChanged` → `updateSize` | `topRow` snapped from -6 to 0 |
+ * | [modelReseedWithFullRepaintHoldsViewportAndSelection] | capture-pane model reseed + `forceFullRepaint` | (green on base — characterization guard) |
+ * | [outputBurstWhileScrolledBackDoesNotYankViewportToBottom] | live `%output` burst | (green on base — pins the vendored guard) |
+ * | [selectionLifecycleIsPublishedOntoTerminalSurfaceState] | the `copyModeChanged` seam | the flag never left `false` |
+ * | [imePinStillSnapsToBottomWhenNoSelectionIsActive] | the #184 pin's POSITIVE path | (green on base — the counterweight) |
+ * | [imePinWorksAgainAfterTheSelectionEnds] | refuse-then-honour, no latch | (green on base — the counterweight) |
+ *
+ * The last two rows are the counterweight to the guard this issue adds. Every other
+ * test that touches `pinTerminalToBottom` asserts only its REFUSAL, so hardening the
+ * new early return into `if (true) return false` — buying selection stability by
+ * silently killing #184 — would pass all of them. These two redden it, and nothing
+ * else does.
+ *
+ * The reseed and burst tests are green on base by design: the issue asks to CONFIRM the reseed
+ * / repaint / output paths do not move the viewport or drop the selection, and a
+ * confirmation is only durable if a test holds it. Their load-bearing character
+ * is proven by mutation (deleting the `isSelectingText()` branch in
+ * `onScreenUpdated`, or resetting `mTopRow` in `forceFullRepaint`, reddens them).
+ *
+ * ## Fidelity (F2 — the REAL reported state, no proxy)
+ *
+ * Everything runs on the production path: the real [TerminalSurface] composable
+ * hosted on a real Activity, the real vendored [TerminalView] it mounts, a REAL
+ * long-press gesture through `dispatchTouchEvent` (the same
+ * `GestureAndScaleRecognizer` → `startTextSelectionMode` route a finger takes),
+ * the real transcript scrolled BACK into history, and the production
+ * `pinTerminalToBottom(rootView)` entry point called on the Activity's real
+ * decor view. Assertions are on the geometry the user sees — `TerminalView.topRow`
+ * and the selection's on-screen row — never on a seam having fired.
+ */
+@RunWith(AndroidJUnit4::class)
+class TerminalSelectionViewportStabilityInstrumentedTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val producerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private lateinit var state: TerminalSurfaceState
+
+    @Before
+    fun setUp() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val activity = composeTestRule.activity
+            activity.setShowWhenLocked(true)
+            activity.setTurnScreenOn(true)
+            @Suppress("DEPRECATION")
+            activity.window.addFlags(
+                android.view.WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    android.view.WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
+                    android.view.WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+                    android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON,
+            )
+            activity.window.decorView.requestFocus()
+        }
+        try {
+            val ua = instrumentation.uiAutomation
+            ua.executeShellCommand("input keyevent KEYCODE_WAKEUP").close()
+            ua.executeShellCommand("wm dismiss-keyguard").close()
+        } catch (_: Throwable) {
+            // UiAutomation is not available on every SDK level; the window flags above
+            // are enough for the assertions in this file (none need clipboard focus).
+        }
+    }
+
+    @After
+    fun tearDown() {
+        producerScope.cancel()
+    }
+
+    // -----------------------------------------------------------------------
+    // The four class members.
+    // -----------------------------------------------------------------------
+
+    /**
+     * THE reproduction (G10/D33). The user is scrolled back in the transcript with
+     * a live selection; the #184 IME pin fires (as it does when the selection
+     * gesture's own `requestFocus()` raises the soft keyboard).
+     *
+     * RED on base: `pinTerminalToBottom` set `topRow = 0` — the transcript snapped
+     * to the bottom and the selection scrolled off screen mid-drag.
+     * GREEN: the pin is refused; `topRow`, the selection anchors, the selected
+     * text and the selection's on-screen row are all unchanged.
+     */
+    @Test
+    fun imeShowPinDoesNotMoveViewportOrDropSelectionWhileSelecting() {
+        val scenario = startSelectionScrolledBack("issue2154-ime-pin")
+
+        val pinned = booleanArrayOf(false)
+        onMain {
+            // The production entry point, on the Activity's real decor view — exactly
+            // what TmuxSessionScreen passes as `composeRootView`.
+            pinned[0] = pinTerminalToBottom(composeTestRule.activity.window.decorView)
+        }
+        composeTestRule.waitForIdle()
+
+        val after = readSelectionSnapshot(scenario.view)
+        captureViewport(scenario.view, "issue2154-ime-pin-after")
+        writeArtifact(
+            "issue2154-ime-pin-summary.txt",
+            "before=${scenario.before}\nafter=$after\npinReturned=${pinned[0]}\n",
+        )
+
+        assertTrue(
+            "the selection must still be live after the IME pin — the user is still dragging",
+            after.selecting,
+        )
+        assertEquals(
+            "ISSUE #2154: the #184 IME pin must NOT move the viewport while a text selection " +
+                "is live. topRow ${scenario.before.topRow} -> ${after.topRow} means the transcript " +
+                "jumped out from under the user's finger (0 = snapped to the bottom).",
+            scenario.before.topRow,
+            after.topRow,
+        )
+        assertEquals(
+            "the selection anchors must be untouched by the pin",
+            scenario.before.selectors.toList(),
+            after.selectors.toList(),
+        )
+        assertEquals(
+            "the selected text must be untouched by the pin",
+            scenario.before.selectedText,
+            after.selectedText,
+        )
+        assertEquals(
+            "the selection must stay on the same ON-SCREEN row (selY1 - topRow) — that is what " +
+                "'the terminal jumped' means to the user",
+            scenario.before.selectionScreenRow,
+            after.selectionScreenRow,
+        )
+        assertEquals(
+            "pinTerminalToBottom must report the refusal to its caller",
+            false,
+            pinned[0],
+        )
+    }
+
+    /**
+     * The layout/size-change member of the class. A selection drag is surrounded by
+     * layout shifts (the floating action mode, the bottom chrome, the IME inset);
+     * each re-runs `onSizeChanged` → [TerminalView.updateSize].
+     *
+     * RED on base: `updateSize` reset `mTopRow = 0` on any row change, snapping the
+     * transcript to the bottom.
+     * GREEN: the scroll position is preserved (clamped into the reflowed history)
+     * and the selection is still live and still on screen.
+     */
+    @Test
+    fun layoutSizeChangeDoesNotSnapViewportToBottomWhileSelecting() {
+        val scenario = startSelectionScrolledBack("issue2154-resize")
+        val view = scenario.view
+
+        val rowsBefore = intArrayOf(0)
+        val rowsAfter = intArrayOf(0)
+        onMain {
+            rowsBefore[0] = view.currentSession.emulator.mRows
+            // The REAL resize entry point: View.layout -> setFrame -> onSizeChanged ->
+            // updateSize(). Shrink by three text rows, the scale of a chip row / action
+            // mode appearing under a selection.
+            val shrinkPx = (3 * view.mRenderer.fontLineSpacing)
+            view.layout(view.left, view.top, view.right, view.bottom - shrinkPx)
+            rowsAfter[0] = view.currentSession.emulator.mRows
+        }
+
+        val after = readSelectionSnapshot(view)
+        captureViewport(view, "issue2154-resize-after")
+        writeArtifact(
+            "issue2154-resize-summary.txt",
+            "before=${scenario.before}\nafter=$after\n" +
+                "emulatorRows ${rowsBefore[0]} -> ${rowsAfter[0]}\n",
+        )
+
+        assertNotEquals(
+            "precondition: the layout change must actually change the emulator row count, " +
+                "otherwise updateSize short-circuits and this test proves nothing (G3)",
+            rowsBefore[0],
+            rowsAfter[0],
+        )
+        assertTrue(
+            "the selection must survive a resize — the user is still dragging",
+            after.selecting,
+        )
+        assertEquals(
+            "ISSUE #2154: TerminalView.updateSize must NOT reset the viewport to the bottom " +
+                "while a text selection is live. topRow ${scenario.before.topRow} -> " +
+                "${after.topRow} (0 = snapped to the bottom).",
+            scenario.before.topRow,
+            after.topRow,
+        )
+        assertEquals(
+            "the selection must stay on the same ON-SCREEN row across the resize",
+            scenario.before.selectionScreenRow,
+            after.selectionScreenRow,
+        )
+    }
+
+    /**
+     * The model-reseed / full-repaint member. Production's tmux reattach + render
+     * heal apply a `capture-pane` snapshot through
+     * [TerminalSurfaceState.appendRemoteOutput], which also fires the
+     * `fullRepaintRequests` signal the surface turns into
+     * [TerminalView.forceFullRepaint].
+     *
+     * The issue asks to CONFIRM that path neither moves the viewport nor drops the
+     * selection. It does not today — and this pins it so it cannot start to.
+     */
+    @Test
+    fun modelReseedWithFullRepaintHoldsViewportAndSelection() {
+        val scenario = startSelectionScrolledBack("issue2154-reseed")
+        val view = scenario.view
+
+        val rows = intArrayOf(0)
+        onMain { rows[0] = view.currentSession.emulator.mRows }
+        // A screenful-sized reseed shaped exactly like tmux `capture-pane` replay:
+        // cursor home + erase display, then one screen of content. Sized to the
+        // screen so it repaints without scrolling, as a real reseed does.
+        val reseed = buildString {
+            append("\u001B[H\u001B[2J")
+            for (i in 0 until (rows[0] - 1).coerceAtLeast(1)) {
+                append("RESEED %03d capture-pane snapshot line\r\n".format(i))
+            }
+        }
+        state.appendRemoteOutput(reseed.toByteArray(Charsets.US_ASCII))
+        // Bounded + HARD-failing: the snapshot must actually be in the emulator before
+        // we judge the viewport, or the assertions below would pass against a screen the
+        // reseed never touched (G3).
+        awaitOrFail("the capture-pane reseed must reach the emulator") {
+            visibleTerminalText(view).contains("RESEED 000")
+        }
+        composeTestRule.waitForIdle()
+
+        val after = readSelectionSnapshot(view)
+        captureViewport(view, "issue2154-reseed-after")
+        writeArtifact(
+            "issue2154-reseed-summary.txt",
+            "before=${scenario.before}\nafter=$after\nreseedBytes=${reseed.length}\n",
+        )
+
+        assertTrue(
+            "ISSUE #2154: a capture-pane model reseed + full repaint must NOT drop the user's " +
+                "live selection",
+            after.selecting,
+        )
+        assertEquals(
+            "ISSUE #2154: a capture-pane model reseed + full repaint must NOT move the viewport " +
+                "while a text selection is live. topRow ${scenario.before.topRow} -> ${after.topRow}",
+            scenario.before.topRow,
+            after.topRow,
+        )
+        assertEquals(
+            "the reseed must not move the selection anchors",
+            scenario.before.selectors.toList(),
+            after.selectors.toList(),
+        )
+    }
+
+    /**
+     * The live-output member — the maintainer's "it's even difficult to sometimes
+     * just scroll it up". While a selection is live and the user is scrolled back,
+     * an output burst must keep the SAME content under the selection instead of
+     * yanking the viewport to the bottom.
+     *
+     * The vendored `onScreenUpdated` guard is what provides this; the test pins it
+     * (deleting the `isSelectingText()` branch reddens it) so no future app-layer
+     * change can quietly reintroduce the yank.
+     */
+    @Test
+    fun outputBurstWhileScrolledBackDoesNotYankViewportToBottom() {
+        val scenario = startSelectionScrolledBack("issue2154-burst")
+        val view = scenario.view
+
+        for (i in 0 until BURST_LINES) {
+            state.appendRemoteOutput("BURST %03d streaming output line\r\n".format(i).toByteArray(Charsets.US_ASCII))
+        }
+        // Bounded + HARD-failing: every burst line must have reached the emulator (and
+        // therefore driven the repaint path) before we judge the viewport.
+        awaitOrFail("the whole output burst must reach the emulator") {
+            transcriptText(view).contains("BURST %03d".format(BURST_LINES - 1))
+        }
+        composeTestRule.waitForIdle()
+
+        val after = readSelectionSnapshot(view)
+        captureViewport(view, "issue2154-burst-after")
+        writeArtifact(
+            "issue2154-burst-summary.txt",
+            "before=${scenario.before}\nafter=$after\nburstLines=$BURST_LINES\n",
+        )
+
+        assertTrue(
+            "ISSUE #2154: an output burst must not end the user's selection",
+            after.selecting,
+        )
+        assertTrue(
+            "ISSUE #2154: an output burst must not yank the viewport back to the bottom while a " +
+                "selection is live. topRow ${scenario.before.topRow} -> ${after.topRow} " +
+                "(0 = bottom); the viewport must ride the scroll so the SAME content stays visible.",
+            after.topRow < 0 && after.topRow <= scenario.before.topRow,
+        )
+        assertEquals(
+            "the selected TEXT must be unchanged after the burst — the anchors ride the scroll " +
+                "with the content the user picked",
+            scenario.before.selectedText,
+            after.selectedText,
+        )
+        assertEquals(
+            "the selection must stay on the same ON-SCREEN row through the burst",
+            scenario.before.selectionScreenRow,
+            after.selectionScreenRow,
+        )
+    }
+
+    /**
+     * The seam itself, end-to-end on the production composable: a real long-press
+     * must publish through [com.pocketshell.core.terminal.ui.PocketShellTerminalViewClient.copyModeChanged]
+     * onto [TerminalSurfaceState.textSelectionActive], and ending the selection must
+     * release it again.
+     *
+     * RED on base: the override was `= Unit`, so the flag never left `false` and no
+     * app-layer code could defer to a live selection.
+     */
+    @Test
+    fun selectionLifecycleIsPublishedOntoTerminalSurfaceState() {
+        val scenario = startSelectionScrolledBack("issue2154-seam")
+        val view = scenario.view
+
+        assertTrue(
+            "ISSUE #2154: starting a real selection must publish through the production " +
+                "copyModeChanged wiring onto TerminalSurfaceState.textSelectionActive — that " +
+                "override was `= Unit`, so nothing outside the vendored view could know a " +
+                "selection was live",
+            scenario.before.textSelectionActiveOnState,
+        )
+
+        onMain { view.stopTextSelectionMode() }
+        composeTestRule.waitForIdle()
+        val after = readSelectionSnapshot(view)
+        writeArtifact(
+            "issue2154-seam-summary.txt",
+            "before=${scenario.before}\nafter=$after\n",
+        )
+
+        assertEquals(
+            "precondition: stopTextSelectionMode must actually end the selection",
+            false,
+            after.selecting,
+        )
+        assertEquals(
+            "ISSUE #2154: ending the selection must publish the falling edge too — otherwise the " +
+                "#184 IME pin would stay dead for the rest of the session",
+            false,
+            after.textSelectionActiveOnState,
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // The #184 POSITIVE path — the guard must not buy selection stability by
+    // killing the behaviour it guards.
+    // -----------------------------------------------------------------------
+
+    /**
+     * #184's original job, unchanged: the user raised the soft keyboard because they
+     * committed to typing at the prompt, so the transcript snaps to the bottom and
+     * the cursor row is on screen again.
+     *
+     * This is the counterweight to
+     * [imeShowPinDoesNotMoveViewportOrDropSelectionWhileSelecting]. That test asserts
+     * only the REFUSAL, so hardening the new early return to `if (true) return false`
+     * — protecting the selection by silently killing #184 — would survive it. This
+     * test is what reddens that mutant: no selection is live, so the pin MUST fire,
+     * report `true`, and put `topRow` back at 0.
+     */
+    @Test
+    fun imePinStillSnapsToBottomWhenNoSelectionIsActive() {
+        val view = composeScrolledBack()
+
+        val before = readSelectionSnapshot(view)
+        captureViewport(view, "issue2154-pin-no-selection-before")
+        // HARD preconditions — a pin from an already-bottomed viewport, or one taken
+        // while a stray selection is live, would make the assertion below vacuous.
+        check(!before.selecting) { "precondition: no selection may be live for the #184 positive path" }
+        check(before.topRow == SCROLLED_BACK_ROWS) {
+            "precondition: the viewport must be scrolled BACK before the pin, topRow=${before.topRow}"
+        }
+
+        val pinned = booleanArrayOf(false)
+        onMain {
+            pinned[0] = pinTerminalToBottom(composeTestRule.activity.window.decorView)
+        }
+        composeTestRule.waitForIdle()
+
+        val after = readSelectionSnapshot(view)
+        captureViewport(view, "issue2154-pin-no-selection-after")
+        writeArtifact(
+            "issue2154-pin-no-selection-summary.txt",
+            "before=$before\nafter=$after\npinReturned=${pinned[0]}\n",
+        )
+
+        assertEquals(
+            "ISSUE #2154 must NOT break #184: with no selection live the IME pin must still " +
+                "snap the transcript to the bottom so the cursor row is visible. " +
+                "topRow ${before.topRow} -> ${after.topRow}, expected 0.",
+            0,
+            after.topRow,
+        )
+        assertEquals(
+            "pinTerminalToBottom must report that it pinned",
+            true,
+            pinned[0],
+        )
+    }
+
+    /**
+     * The guard must be a live read of the selection, not a latch. A user selects,
+     * copies, dismisses the selection, scrolls back, then raises the keyboard again —
+     * #184 must work exactly as before. The falling edge of `copyModeChanged` exists
+     * for precisely this.
+     *
+     * Both directions are asserted in ONE journey so a mutation cannot satisfy one by
+     * breaking the other: refused while selecting, honoured once the selection ends.
+     */
+    @Test
+    fun imePinWorksAgainAfterTheSelectionEnds() {
+        val scenario = startSelectionScrolledBack("issue2154-pin-after-selection")
+        val view = scenario.view
+
+        val refused = booleanArrayOf(true)
+        onMain {
+            refused[0] = pinTerminalToBottom(composeTestRule.activity.window.decorView)
+        }
+        composeTestRule.waitForIdle()
+        val whileSelecting = readSelectionSnapshot(view)
+
+        assertEquals(
+            "precondition (the refusal half): the pin must be refused while the selection is live",
+            false,
+            refused[0],
+        )
+        assertEquals(
+            "precondition (the refusal half): the refused pin must not have moved the viewport",
+            scenario.before.topRow,
+            whileSelecting.topRow,
+        )
+
+        // The user is done: the selection ends and they scroll back again.
+        onMain { view.stopTextSelectionMode() }
+        composeTestRule.waitForIdle()
+        val released = readSelectionSnapshot(view)
+        check(!released.selecting) { "precondition: stopTextSelectionMode must end the selection" }
+        check(!released.textSelectionActiveOnState) {
+            "precondition: the falling edge must reach TerminalSurfaceState"
+        }
+        settleScrolledBack(view)
+
+        val pinned = booleanArrayOf(false)
+        onMain {
+            pinned[0] = pinTerminalToBottom(composeTestRule.activity.window.decorView)
+        }
+        composeTestRule.waitForIdle()
+
+        val after = readSelectionSnapshot(view)
+        captureViewport(view, "issue2154-pin-after-selection-after")
+        writeArtifact(
+            "issue2154-pin-after-selection-summary.txt",
+            "before=${scenario.before}\nwhileSelecting=$whileSelecting refused=${refused[0]}\n" +
+                "released=$released\nafter=$after\npinReturned=${pinned[0]}\n",
+        )
+
+        assertEquals(
+            "ISSUE #2154: the selection guard must not LATCH — once the selection ends, the #184 " +
+                "IME pin must work again. topRow ${released.topRow} -> ${after.topRow}, expected 0.",
+            0,
+            after.topRow,
+        )
+        assertEquals(
+            "pinTerminalToBottom must report that it pinned once the selection ended",
+            true,
+            pinned[0],
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Harness
+    // -----------------------------------------------------------------------
+
+    private class SelectionSnapshot(
+        val topRow: Int,
+        val selecting: Boolean,
+        val selectors: IntArray,
+        val selectedText: String,
+        /** `selY1 - topRow`: which VISIBLE row the selection starts on. */
+        val selectionScreenRow: Int,
+        val textSelectionActiveOnState: Boolean,
+    ) {
+        override fun toString(): String =
+            "topRow=$topRow selecting=$selecting selectors=${selectors.toList()} " +
+                "screenRow=$selectionScreenRow stateFlag=$textSelectionActiveOnState " +
+                "selectedText=${selectedText.trim().take(60)}"
+    }
+
+    private class Scenario(val view: TerminalView, val before: SelectionSnapshot)
+
+    /**
+     * Compose the production [TerminalSurface], fill the transcript and scroll the
+     * user BACK into history — the state the report starts from, with NO selection
+     * yet. The #184-positive tests stop here; the selection tests go on to
+     * [longPressToSelect].
+     */
+    private fun composeScrolledBack(): TerminalView {
+        state = TerminalSurfaceState()
+        state.attachExternalProducer(
+            scope = producerScope,
+            stdout = MutableSharedFlow(extraBufferCapacity = 8),
+            remoteStdin = null,
+        )
+
+        composeTestRule.setContent {
+            TerminalSurface(state = state, modifier = Modifier)
+        }
+        composeTestRule.waitForIdle()
+        val view = waitForTerminalView()
+
+        // Fill the transcript so there IS scrollback to be scrolled back into.
+        for (i in 0 until TRANSCRIPT_LINES) {
+            state.appendRemoteOutput("LINE %03d selectable-token-$i tail\r\n".format(i).toByteArray(Charsets.US_ASCII))
+        }
+        awaitOrFail("the transcript fill must reach the emulator") {
+            transcriptText(view).contains("LINE %03d".format(TRANSCRIPT_LINES - 1))
+        }
+        composeTestRule.waitForIdle()
+
+        // The user scrolls up. This is the state the report is about: "it's even
+        // difficult to sometimes just scroll it up".
+        settleScrolledBack(view)
+        return view
+    }
+
+    /**
+     * Compose the production [TerminalSurface], fill the transcript, scroll the user
+     * BACK into history, and start a real long-press text selection there.
+     */
+    private fun startSelectionScrolledBack(artifactPrefix: String): Scenario {
+        val view = composeScrolledBack()
+
+        longPressToSelect(view)
+
+        val before = readSelectionSnapshot(view)
+        captureViewport(view, "$artifactPrefix-before")
+        // HARD preconditions — without them every assertion below is vacuous (G3).
+        check(before.selecting) { "precondition: the long-press must start a real selection" }
+        check(before.topRow == SCROLLED_BACK_ROWS) {
+            "precondition: the selection must start while scrolled BACK, topRow=${before.topRow}"
+        }
+        check(before.selectors[0] >= 0) {
+            "precondition: the selection must have real anchors, got ${before.selectors.toList()}"
+        }
+        return Scenario(view, before)
+    }
+
+    /**
+     * Put the user where the report starts: scrolled BACK in the transcript, and
+     * STAYING there.
+     *
+     * Driven through the vendored view's REAL scroll path (`doScroll` — what the
+     * gesture recogniser's `onScroll` calls), so the viewport lands where a finger
+     * would put it and clamps to the history that actually exists.
+     *
+     * The retry loop is not decoration. Until a selection exists, `onScreenUpdated`
+     * legitimately snaps the viewport back to the bottom, and the coalesced repaint
+     * that the transcript fill queued can land AFTER the scroll. So the exit
+     * condition is the real one — the viewport is at the target AND still there
+     * after a quiet window wider than the render-coalescer frame. Bounded, and it
+     * HARD-FAILS rather than proceeding from an unscrolled viewport (which would
+     * make every assertion downstream vacuous).
+     */
+    private fun settleScrolledBack(view: TerminalView) {
+        val deadline = SystemClock.uptimeMillis() + SETTLE_TIMEOUT_MS
+        var lastTopRow = 0
+        var transcriptRows = 0
+        while (SystemClock.uptimeMillis() < deadline) {
+            val now = SystemClock.uptimeMillis()
+            val scrollEvent = MotionEvent.obtain(now, now, MotionEvent.ACTION_MOVE, 1f, 1f, 0)
+            onMain {
+                try {
+                    val delta = SCROLLED_BACK_ROWS - view.topRow
+                    if (delta != 0) view.doScroll(scrollEvent, delta)
+                } finally {
+                    scrollEvent.recycle()
+                }
+            }
+            composeTestRule.waitForIdle()
+            SystemClock.sleep(QUIET_WINDOW_MS)
+            composeTestRule.waitForIdle()
+            onMain {
+                lastTopRow = view.topRow
+                transcriptRows = view.currentSession.emulator.screen.activeTranscriptRows
+            }
+            if (lastTopRow == SCROLLED_BACK_ROWS) return
+        }
+        throw AssertionError(
+            "precondition: the transcript must settle scrolled back to $SCROLLED_BACK_ROWS " +
+                "within ${SETTLE_TIMEOUT_MS}ms, last topRow=$lastTopRow " +
+                "(activeTranscriptRows=$transcriptRows)",
+        )
+    }
+
+    /** Drive a REAL long-press on a middle visible row, exactly as a finger does. */
+    private fun longPressToSelect(view: TerminalView) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val press = floatArrayOf(0f, 0f)
+        onMain {
+            val renderer = view.mRenderer
+            // A column inside the "selectable-token" word and a row in the middle of
+            // the visible viewport.
+            press[0] = 12.5f * renderer.fontWidth
+            press[1] = renderer.fontLineSpacingAndAscent +
+                (view.currentSession.emulator.mRows / 2f) * renderer.fontLineSpacing
+        }
+
+        val downTime = SystemClock.uptimeMillis()
+        val down = MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, press[0], press[1], 0)
+        onMain {
+            try {
+                view.dispatchTouchEvent(down)
+            } finally {
+                down.recycle()
+            }
+        }
+        // Hold past ViewConfiguration.getLongPressTimeout() (500 ms) on the TEST
+        // thread so the detector's pending Runnable can fire on Main.
+        SystemClock.sleep(750)
+        val upTime = SystemClock.uptimeMillis()
+        val up = MotionEvent.obtain(downTime, upTime, MotionEvent.ACTION_UP, press[0], press[1], 0)
+        onMain {
+            try {
+                view.dispatchTouchEvent(up)
+            } finally {
+                up.recycle()
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val deadline = SystemClock.uptimeMillis() + SELECTION_TIMEOUT_MS
+        var selecting = false
+        while (SystemClock.uptimeMillis() < deadline && !selecting) {
+            onMain { selecting = view.isSelectingText }
+            if (!selecting) SystemClock.sleep(25)
+        }
+        assertTrue(
+            "the long-press gesture must put the real TerminalView into selection mode — the " +
+                "whole reported scenario is a selection drag",
+            selecting,
+        )
+        // Past the controller's 300 ms show/hide guard, so nothing we do next is
+        // silently swallowed as a too-fast hide.
+        SystemClock.sleep(350)
+    }
+
+    private fun readSelectionSnapshot(view: TerminalView): SelectionSnapshot {
+        var snapshot: SelectionSnapshot? = null
+        onMain {
+            val selectors = IntArray(4)
+            view.getTextSelectionCursorController().getSelectors(selectors)
+            snapshot = SelectionSnapshot(
+                topRow = view.topRow,
+                selecting = view.isSelectingText,
+                selectors = selectors,
+                selectedText = view.selectedText.orEmpty(),
+                selectionScreenRow = selectors[0] - view.topRow,
+                textSelectionActiveOnState = state.isTextSelectionActive(),
+            )
+        }
+        return requireNotNull(snapshot)
+    }
+
+    private fun onMain(block: () -> Unit) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+    }
+
+    /**
+     * Poll [predicate] to a generous wall-clock deadline and HARD-FAIL if it never
+     * holds. The exit condition is the load-bearing assertion — never a bare sleep
+     * before a judgement (the repo's TIMING1 rule).
+     */
+    private fun awaitOrFail(what: String, predicate: () -> Boolean) {
+        val deadline = SystemClock.uptimeMillis() + SETTLE_TIMEOUT_MS
+        while (SystemClock.uptimeMillis() < deadline) {
+            composeTestRule.waitForIdle()
+            if (predicate()) return
+            SystemClock.sleep(25)
+        }
+        throw AssertionError("timed out after ${SETTLE_TIMEOUT_MS}ms waiting: $what")
+    }
+
+    private fun transcriptText(view: TerminalView): String {
+        var text = ""
+        onMain { text = view.currentSession?.emulator?.screen?.transcriptText.orEmpty() }
+        return text
+    }
+
+    private fun waitForTerminalView(): TerminalView {
+        val deadline = SystemClock.uptimeMillis() + TERMINAL_VIEW_TIMEOUT_MS
+        var found: TerminalView? = null
+        while (SystemClock.uptimeMillis() < deadline && found == null) {
+            onMain {
+                found = composeTestRule.activity.window.decorView.findTerminalView()
+            }
+            if (found == null) {
+                composeTestRule.waitForIdle()
+                SystemClock.sleep(50)
+            }
+        }
+        return requireNotNull(found) { "the production TerminalSurface never mounted a TerminalView" }
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (i in 0 until childCount) {
+            val hit = getChildAt(i).findTerminalView()
+            if (hit != null) return hit
+        }
+        return null
+    }
+
+    // -----------------------------------------------------------------------
+    // Artifacts (authoritative terminal-viewport evidence for the reviewer)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Artifacts go under `additional_test_output/terminal-lab` on the external
+     * media root: AGP/UTP pulls `additional_test_output` into
+     * `build/outputs/connected_android_test_additional_output/` BEFORE it
+     * uninstalls the test APK, which is what makes the authoritative
+     * `*-viewport.png` / `*-visible-terminal.txt` survive the run (the media dir
+     * itself is deleted with the package). Same mechanism the app module's
+     * durable-state exports use.
+     */
+    private fun artifactFile(name: String): File {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val dir = File(testArtifactsRoot(context), "additional_test_output/terminal-lab")
+            .apply { mkdirs() }
+        return File(dir, name)
+    }
+
+    private fun visibleTerminalText(view: TerminalView): String {
+        var text = ""
+        onMain {
+            val emulator = view.currentSession?.emulator
+            text = if (emulator == null) {
+                ""
+            } else {
+                val top = view.topRow
+                val rows = emulator.mRows
+                (top until top + rows).joinToString("\n") { row ->
+                    emulator.screen.getSelectedText(0, row, emulator.mColumns - 1, row)
+                }
+            }
+        }
+        return text
+    }
+
+    private fun captureViewport(view: TerminalView, name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        var bitmap: Bitmap? = null
+        onMain {
+            if (view.width > 0 && view.height > 0) {
+                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+                view.draw(Canvas(b))
+                bitmap = b
+            }
+        }
+        bitmap?.let { b ->
+            val file = artifactFile("$name-viewport.png")
+            FileOutputStream(file).use { out ->
+                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                    "failed to write bitmap to ${file.absolutePath}"
+                }
+            }
+            println("ISSUE2154_VIEWPORT ${file.absolutePath}")
+            b.recycle()
+        }
+        artifactFile("$name-visible-terminal.txt").writeText(visibleTerminalText(view))
+    }
+
+    private fun writeArtifact(name: String, text: String) {
+        artifactFile(name).writeText(text)
+        println("ISSUE2154_ARTIFACT $name")
+        for (line in text.trim().lines()) android.util.Log.i(LOG_TAG, line)
+    }
+
+    private companion object {
+        const val LOG_TAG = "Issue2154Selection"
+
+        /** Lines pushed into the transcript so there is real scrollback. */
+        const val TRANSCRIPT_LINES = 120
+
+        /** How far back the user has scrolled when the selection starts. */
+        const val SCROLLED_BACK_ROWS = -6
+
+        /** Live output lines streamed while the selection is held. */
+        const val BURST_LINES = 30
+
+        const val TERMINAL_VIEW_TIMEOUT_MS = 20_000L
+        const val SELECTION_TIMEOUT_MS = 5_000L
+
+        /** Generous wall-clock ceiling for a bounded settle poll on a contended CI AVD. */
+        const val SETTLE_TIMEOUT_MS = 30_000L
+
+        /** Quiet window wider than the render coalescer's frame budget. */
+        const val QUIET_WINDOW_MS = 250L
+    }
+}

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalKeyboardController.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalKeyboardController.kt
@@ -69,7 +69,8 @@ fun showTerminalSoftKeyboard(
  *
  * Returns `true` when a [TerminalView] descendant was found and its
  * scroll position was reset, `false` when no terminal view is mounted
- * yet (e.g. the screen has not finished its first composition). The
+ * yet (e.g. the screen has not finished its first composition) or when
+ * the pin was REFUSED because the user is mid-selection (see below). The
  * caller treats `false` as a no-op rather than an error — the same
  * defensive contract as [showTerminalSoftKeyboard].
  *
@@ -79,6 +80,25 @@ fun showTerminalSoftKeyboard(
  * `TerminalView.updateSize` → `mTopRow = 0`); this helper handles the
  * orthogonal "user scrolled then tapped IME" case where the size has
  * not changed but the visible viewport no longer covers the cursor row.
+ *
+ * ## Issue #2154 — a live text selection OWNS the viewport
+ *
+ * The vendored view already refuses to move the transcript for OUTPUT
+ * while a selection is live (`TerminalView.onScreenUpdated` takes the
+ * `isSelectingText()` branch and sets `skipScrolling`). This helper used
+ * to blow straight past that guard: it called `setTopRow(0)` FIRST, so by
+ * the time `onScreenUpdated()` decided to skip scrolling the viewport had
+ * already jumped to the bottom — the transcript snapping out from under a
+ * user's in-progress selection drag, which is exactly the reported symptom
+ * ("I select a part … and then my terminal starts jumping"). Starting a
+ * selection calls `TerminalView.requestFocus()`, which can raise the soft
+ * IME, which is what fires the #184 pin in the first place — so this path
+ * is reached by the very gesture it destroys.
+ *
+ * The pin is therefore REFUSED (returns `false`, viewport untouched) while
+ * [TerminalView.isSelectingText] is true. The invariant lives here, next to
+ * the mutation, so it holds for EVERY caller of this module function rather
+ * than only for the one screen that remembers to ask.
  */
 fun pinTerminalToBottom(
     rootView: View,
@@ -86,12 +106,61 @@ fun pinTerminalToBottom(
 ): Boolean {
     return runCatching {
         val terminalView = rootView.findTerminalViewDescendant() ?: return@runCatching false
+        if (terminalView.isSelectingText) return@runCatching false
         terminalView.setTopRow(0)
         terminalView.onScreenUpdated()
         true
     }.getOrElse { cause ->
         onLocalTerminalError?.invoke(cause)
         false
+    }
+}
+
+/**
+ * Issue #2154 / #184 — the app-layer decision "should the soft keyboard
+ * becoming visible pin this pane's transcript to the bottom right now?".
+ *
+ * Two rules, both of which the previous inline
+ * `LaunchedEffect(isImeVisible, paneId) { if (isImeVisible) pin() }` broke:
+ *
+ * 1. **Show EDGE only.** #184's contract is "when the user asks for the
+ *    keyboard they have committed to typing at the prompt, so put the cursor
+ *    row back on screen". That is a transition, not a level. Keying the effect
+ *    on `(isImeVisible, paneId)` re-fired the pin on EVERY key-tuple change
+ *    while the IME merely happened to be up — notably on a pane/page settle
+ *    (the unified pager hands the screen a different `surfacePane`), which
+ *    yanked a scrolled-back transcript to the bottom for a keyboard the user
+ *    raised minutes ago. Only a `false → true` transition pins.
+ * 2. **Never over a live selection.** While the user is dragging a selection
+ *    the viewport belongs to them. Starting a selection calls
+ *    `TerminalView.requestFocus()`, which can raise the IME — so the rising
+ *    edge and the selection routinely arrive together, and honouring the pin
+ *    would destroy the selection the user is still making.
+ *
+ * Deliberately a tiny stateful policy object rather than inline Compose state:
+ * the edge is a property of the *sequence* of IME observations, and keeping it
+ * here makes it directly unit-testable on the JVM (no Compose, no device).
+ * Remember one instance per screen; it is not thread-safe and is only ever
+ * touched from the composition/main thread.
+ */
+class ImeViewportPinPolicy {
+
+    private var imeVisible: Boolean = false
+
+    /**
+     * Record an IME-visibility observation and return `true` iff this
+     * observation is the rising `false → true` edge AND no text selection is
+     * live. Always updates the remembered visibility, so a refused rising edge
+     * is CONSUMED (the pin does not fire later when some unrelated key changes
+     * while the IME stays up).
+     */
+    fun shouldPinOnImeVisibility(
+        imeVisible: Boolean,
+        textSelectionActive: Boolean,
+    ): Boolean {
+        val rising = imeVisible && !this.imeVisible
+        this.imeVisible = imeVisible
+        return rising && !textSelectionActive
     }
 }
 

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurface.kt
@@ -339,6 +339,9 @@ fun TerminalSurface(
     viewClient.terminalKeyboardMode = terminalKeyboardMode
     viewClient.onTerminalSizeChanged = onTerminalSizeChanged
     viewClient.onTerminalSurfaceError = onLocalTerminalError
+    // Issue #2154: publish the vendored view's selection lifecycle onto the state
+    // so app-layer viewport work can defer to a live selection.
+    viewClient.onCopyModeChanged = { selecting -> state.setTextSelectionActive(selecting) }
     var terminalView by remember { mutableStateOf<TerminalView?>(null) }
     var viewportTick by remember { mutableStateOf(0L) }
     val publishedTapAffordances = remember { PublishedTapAffordances() }
@@ -1012,6 +1015,16 @@ internal class PocketShellTerminalViewClient : TerminalViewClient, TerminalSessi
     var onViewportChanged: (() -> Unit)? = null
 
     /**
+     * Issue #2154 — sink for the vendored view's text-selection lifecycle.
+     * [TerminalSurface] points this at [TerminalSurfaceState.setTextSelectionActive]
+     * so app-layer code can read [TerminalSurfaceState.textSelectionActive] and
+     * stop moving the viewport under a user's in-progress selection drag.
+     * `null` only for the bare-client unit/instrumented harnesses that construct
+     * this client without a surface.
+     */
+    var onCopyModeChanged: ((Boolean) -> Unit)? = null
+
+    /**
      * Hook installed by [TerminalSurface] when URL detection is enabled.
      * Called from [onSingleTapUp] for every confirmed single tap; given the
      * tap coordinates in view-local pixels, the host returns `true` if the
@@ -1071,7 +1084,14 @@ internal class PocketShellTerminalViewClient : TerminalViewClient, TerminalSessi
     override fun shouldUseSmartTextInput(): Boolean = terminalKeyboardMode == TerminalKeyboardMode.SmartText
     override fun shouldUseCtrlSpaceWorkaround(): Boolean = false
     override fun isTerminalViewSelected(): Boolean = true
-    override fun copyModeChanged(copyMode: Boolean) = Unit
+    // Issue #2154: NO LONGER INERT. The vendored TerminalView fires this on both
+    // selection edges (startTextSelectionMode / stopTextSelectionMode). Publishing
+    // it is what lets app-layer code know a selection is live and stop moving the
+    // viewport under the user's finger.
+    override fun copyModeChanged(copyMode: Boolean) {
+        runCatching { onCopyModeChanged?.invoke(copyMode) }
+            .onFailure { onTerminalSurfaceError?.invoke(it) }
+    }
     override fun onKeyDown(keyCode: Int, e: KeyEvent?, session: TerminalSession?): Boolean = false
     override fun onKeyUp(keyCode: Int, e: KeyEvent?): Boolean = false
     override fun onLongPress(event: MotionEvent?): Boolean = false

--- a/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
+++ b/shared/core-terminal/src/main/java/com/pocketshell/core/terminal/ui/TerminalSurfaceState.kt
@@ -294,6 +294,49 @@ class TerminalSurfaceState(
     private var surfaceRepaintRequestCount: Int = 0
 
     /**
+     * Issue #2154 — backing state for [textSelectionActive].
+     *
+     * Fed from the vendored [TerminalView]'s selection lifecycle
+     * (`startTextSelectionMode` / `stopTextSelectionMode` →
+     * [com.termux.view.TerminalViewClient.copyModeChanged]) by
+     * [PocketShellTerminalViewClient]. Before #2154 that client override was
+     * `= Unit`, so NOTHING outside the vendored view could know a selection was
+     * live — and every PocketShell-owned viewport reset (the #184 IME pin) ran
+     * straight through a user's in-progress drag, snapping the transcript to the
+     * bottom and destroying the selection.
+     */
+    private val _textSelectionActive = MutableStateFlow(false)
+
+    /**
+     * Issue #2154 — `true` while the user has a LIVE text selection in this
+     * pane's terminal (long-press → drag handles → Copy).
+     *
+     * A live selection makes the USER the viewport owner: PocketShell must not
+     * move the transcript under their finger. App-layer code reads this to skip
+     * viewport work it would otherwise schedule (see
+     * [ImeViewportPinPolicy]); the module-level enforcement that travels with
+     * the mutation itself lives in [pinTerminalToBottom] and
+     * [com.termux.view.TerminalView.updateSize], which consult the View directly.
+     *
+     * Emits `false` until the first selection starts. Distinct-until-changed by
+     * construction ([MutableStateFlow]).
+     */
+    val textSelectionActive: StateFlow<Boolean> get() = _textSelectionActive.asStateFlow()
+
+    /** Issue #2154 — current value of [textSelectionActive], for non-Flow callers. */
+    fun isTextSelectionActive(): Boolean = _textSelectionActive.value
+
+    /**
+     * Issue #2154 — publish the vendored view's selection lifecycle onto
+     * [textSelectionActive]. Called by [PocketShellTerminalViewClient.copyModeChanged],
+     * which the vendored [TerminalView] fires on BOTH edges
+     * (`startTextSelectionMode` and `stopTextSelectionMode`).
+     */
+    internal fun setTextSelectionActive(active: Boolean) {
+        _textSelectionActive.value = active
+    }
+
+    /**
      * Issue #1203 — request a SURFACE force-repaint of the bound [TerminalView]
      * (re-bind emulator + full-clip invalidate) to recover a surface-only-black
      * pane (model intact, surface black). Called by the tmux ViewModel from the

--- a/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
+++ b/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
@@ -1627,6 +1627,18 @@ public final class TerminalView extends View {
             int newRows = Math.max(4, (viewHeight - mRenderer.mFontLineSpacingAndAscent) / mRenderer.mFontLineSpacing);
 
             if (mEmulator == null || (newColumns != mEmulator.mColumns || newRows != mEmulator.mRows)) {
+                // PocketShell issue #2154: a LIVE text selection makes the user the
+                // viewport owner, and a resize must not snap the transcript out from
+                // under their finger. Any layout shift re-runs this through
+                // onSizeChanged — the bottom chrome, the chip row, the IME inset, the
+                // floating selection action mode itself — so on a phone the reported
+                // "terminal starts jumping" while selecting is routinely THIS reset,
+                // not the output path (which the isSelectingText() branch in
+                // onScreenUpdated already guards). Remember where the user was looking
+                // and restore it after the resize instead of resetting to bottom.
+                boolean preserveViewportForSelection = isSelectingText();
+                int viewportTopRowBeforeResize = mTopRow;
+
                 mTermSession.updateSize(newColumns, newRows, (int) mRenderer.getFontWidth(), mRenderer.getFontLineSpacing());
                 mEmulator = mTermSession.getEmulator();
                 mClient.onEmulatorSet();
@@ -1635,8 +1647,16 @@ public final class TerminalView extends View {
                 if (mTerminalCursorBlinkerRunnable != null)
                     mTerminalCursorBlinkerRunnable.setEmulator(mEmulator);
 
-                mTopRow = 0;
-                scrollTo(0, 0);
+                if (preserveViewportForSelection) {
+                    // The resize reflows the transcript, so clamp into the new
+                    // history bounds — but keep the user in scrollback rather than
+                    // pinning to bottom.
+                    int rowsInHistory = mEmulator.getScreen().getActiveTranscriptRows();
+                    mTopRow = Math.max(-rowsInHistory, Math.min(0, viewportTopRowBeforeResize));
+                } else {
+                    mTopRow = 0;
+                    scrollTo(0, 0);
+                }
                 scheduleRenderInvalidation();
             }
         } catch (Throwable t) {

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/ImeViewportPinPolicyTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/ImeViewportPinPolicyTest.kt
@@ -1,0 +1,129 @@
+package com.pocketshell.core.terminal.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2154 — the app-layer half of "an active selection owns the viewport",
+ * plus the #184 pin becoming a SHOW EDGE instead of a level.
+ *
+ * ## What was wrong
+ *
+ * `TmuxSessionScreen` ran
+ * `LaunchedEffect(isImeVisible, surfacePane?.paneId) { if (isImeVisible) pin() }`.
+ * That body re-fires on EVERY change of the key tuple, so:
+ *
+ *  - a pane / page settle (the unified pager hands the screen a different
+ *    `surfacePane`) while the keyboard merely happened to be up yanked a
+ *    scrolled-back transcript to the bottom — the "pager realignment" member of
+ *    the reported class; and
+ *  - a selection drag, which raises the IME through the vendored view's own
+ *    `requestFocus()`, pinned the viewport out from under the user's finger.
+ *
+ * [ImeViewportPinPolicy] is the whole decision, so it can be driven exhaustively
+ * here on the JVM. The device-truth sibling — the real long-press on the real
+ * [TerminalSurface] — is
+ * `com.termux.view.TerminalSelectionViewportStabilityInstrumentedTest`.
+ *
+ * ## The mutation that reddens this file (G6)
+ *
+ * Restoring the old behaviour — `shouldPinOnImeVisibility` returning plain
+ * `imeVisible` — reddens [imeStayingVisibleAcrossAPagerPaneSettleDoesNotPinAgain],
+ * [selectionActiveOnTheRisingEdgeRefusesThePin] and
+ * [aRefusedRisingEdgeIsConsumedNotDeferred], and nothing else.
+ */
+class ImeViewportPinPolicyTest {
+
+    /** #184's contract still holds: the IME coming up pins the cursor row back on screen. */
+    @Test
+    fun risingImeEdgeWithNoSelectionPins() {
+        val policy = ImeViewportPinPolicy()
+        assertTrue(
+            "the false -> true IME transition is exactly what #184 pins for",
+            policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false),
+        )
+    }
+
+    /** The pager/pane-settle member: the key tuple changed, the IME level did not. */
+    @Test
+    fun imeStayingVisibleAcrossAPagerPaneSettleDoesNotPinAgain() {
+        val policy = ImeViewportPinPolicy()
+        assertTrue(policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false))
+
+        // Every one of these is a re-run of the LaunchedEffect caused by the OTHER key
+        // (surfacePane?.paneId) changing while the keyboard stayed up: a pager settle
+        // onto pane B, back onto A, and a recomposition with no change at all.
+        repeat(3) { attempt ->
+            assertFalse(
+                "attempt $attempt: the IME never went away, so there is no show EDGE — pinning " +
+                    "here yanks a scrolled-back transcript to the bottom for a keyboard the user " +
+                    "raised long ago",
+                policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false),
+            )
+        }
+    }
+
+    /** The reported scenario: the selection gesture's requestFocus() raises the IME. */
+    @Test
+    fun selectionActiveOnTheRisingEdgeRefusesThePin() {
+        val policy = ImeViewportPinPolicy()
+        assertFalse(
+            "while the user is dragging a selection the viewport belongs to them — pinning to " +
+                "the bottom is the reported 'terminal starts jumping'",
+            policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = true),
+        )
+    }
+
+    /**
+     * A refused rising edge must be CONSUMED, not deferred: once the selection ends,
+     * an unrelated recomposition must not cash in the pin the user never asked for.
+     */
+    @Test
+    fun aRefusedRisingEdgeIsConsumedNotDeferred() {
+        val policy = ImeViewportPinPolicy()
+        assertFalse(policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = true))
+        assertFalse(
+            "the selection ended, but the IME never re-rose — there is no edge left to honour",
+            policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false),
+        )
+    }
+
+    /** After the keyboard goes away, the next show is a real edge again. */
+    @Test
+    fun hidingThenShowingTheImeIsANewEdge() {
+        val policy = ImeViewportPinPolicy()
+        assertTrue(policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false))
+        assertFalse(
+            "hiding the keyboard never pins",
+            policy.shouldPinOnImeVisibility(imeVisible = false, textSelectionActive = false),
+        )
+        assertTrue(
+            "the user asked for the keyboard again — that is a fresh #184 edge",
+            policy.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false),
+        )
+    }
+
+    /** A keyboard that is never raised never moves the viewport. */
+    @Test
+    fun anImeThatIsNeverVisibleNeverPins() {
+        val policy = ImeViewportPinPolicy()
+        repeat(4) {
+            assertFalse(policy.shouldPinOnImeVisibility(imeVisible = false, textSelectionActive = false))
+            assertFalse(policy.shouldPinOnImeVisibility(imeVisible = false, textSelectionActive = true))
+        }
+    }
+
+    /** Two screens must not share an edge; the policy is per-instance state. */
+    @Test
+    fun eachPolicyInstanceOwnsItsOwnEdge() {
+        val first = ImeViewportPinPolicy()
+        val second = ImeViewportPinPolicy()
+        assertTrue(first.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false))
+        assertTrue(
+            "a freshly remembered policy has not seen the IME yet, so its first visible " +
+                "observation is still a rising edge",
+            second.shouldPinOnImeVisibility(imeVisible = true, textSelectionActive = false),
+        )
+    }
+}

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceSelectionStateTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/TerminalSurfaceSelectionStateTest.kt
@@ -1,0 +1,98 @@
+package com.pocketshell.core.terminal.ui
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Issue #2154 — `copyModeChanged` must no longer be inert, and the selection it
+ * carries must be observable on [TerminalSurfaceState].
+ *
+ * Before #2154 the production client override was literally
+ * `override fun copyModeChanged(copyMode: Boolean) = Unit`, so the vendored
+ * view's selection lifecycle died at the seam and NO app-layer code could know a
+ * selection was live — which is why every PocketShell viewport reset ran straight
+ * through the user's drag.
+ *
+ * The MUTATION that reddens this file (G6): restoring that `= Unit` body reddens
+ * [copyModeChangedForwardsBothSelectionEdges] and
+ * [aClientWiredToASurfaceStatePublishesSelectionOntoIt], and nothing else. The
+ * end-to-end proof that [TerminalSurface] actually performs this wiring on a real
+ * device — a real long-press on the real composable — is
+ * `com.termux.view.TerminalSelectionViewportStabilityInstrumentedTest`, which hard-
+ * fails its precondition if the state flag does not flip.
+ */
+@RunWith(RobolectricTestRunner::class)
+class TerminalSurfaceSelectionStateTest {
+
+    @Test
+    fun copyModeChangedForwardsBothSelectionEdges() {
+        val client = PocketShellTerminalViewClient()
+        val observed = mutableListOf<Boolean>()
+        client.onCopyModeChanged = { observed.add(it) }
+
+        // The vendored TerminalView fires this from startTextSelectionMode and
+        // stopTextSelectionMode respectively.
+        client.copyModeChanged(true)
+        client.copyModeChanged(false)
+
+        assertEquals(
+            "copyModeChanged must forward BOTH selection edges — a start-only signal would " +
+                "leave the viewport frozen forever after one selection",
+            listOf(true, false),
+            observed,
+        )
+    }
+
+    @Test
+    fun aClientWiredToASurfaceStatePublishesSelectionOntoIt() = runBlocking {
+        val state = TerminalSurfaceState()
+        val client = PocketShellTerminalViewClient()
+        // Exactly the wiring TerminalSurface installs.
+        client.onCopyModeChanged = { selecting -> state.setTextSelectionActive(selecting) }
+
+        assertFalse(
+            "a fresh surface has no selection",
+            state.isTextSelectionActive(),
+        )
+        assertFalse(state.textSelectionActive.first())
+
+        client.copyModeChanged(true)
+        assertTrue(
+            "a live selection must be observable from app-layer code",
+            state.isTextSelectionActive(),
+        )
+        assertTrue(state.textSelectionActive.first())
+
+        client.copyModeChanged(false)
+        assertFalse(
+            "ending the selection must release the viewport again — otherwise the #184 IME pin " +
+                "would be dead for the rest of the session",
+            state.isTextSelectionActive(),
+        )
+        assertFalse(state.textSelectionActive.first())
+    }
+
+    /** A throwing observer must never escape into the vendored view's selection path. */
+    @Test
+    fun aFailingObserverIsReportedNotPropagated() {
+        val client = PocketShellTerminalViewClient()
+        val failures = mutableListOf<Throwable>()
+        client.onTerminalSurfaceError = { failures.add(it) }
+        client.onCopyModeChanged = { error("boom") }
+
+        client.copyModeChanged(true)
+
+        assertEquals(
+            "the failure must reach the surface's error sink instead of crashing the vendored " +
+                "startTextSelectionMode call",
+            1,
+            failures.size,
+        )
+    }
+}


### PR DESCRIPTION
Maintainer report: holding a finger to select text made the terminal jump, so extending
a selection to copy a multi-line region was impossible, and scrolling up was fought.

**The vendored Termux guard was already correct** — `onScreenUpdated` skips scrolling
while `isSelectingText` — so the output path was never the cause. Three
PocketShell-owned paths moved the viewport without ever consulting the selection:

- `pinTerminalToBottom` called `setTopRow(0)`, and was reached by **the very gesture that
  creates the selection**: `startTextSelectionMode` calls `requestFocus()`, which raises
  the IME, which fires the #184 pin. That self-inflicted loop is why it felt relentless.
- `TerminalView.updateSize` reset `mTopRow` on any row-count change.
- `copyModeChanged` was inert, so no app-layer code could know a selection existed.

Selection state now flows through `copyModeChanged` into `TerminalSurfaceState`; the pin
refuses while selecting and fires on the IME **show edge only**; `updateSize` preserves
the viewport (clamped) while selecting. #184's own job is preserved and now covered.

Reviewer verdict after two rounds: **APPROVED**.

**Round 1** proved the fix on a real emulator — base RED (`tests=5 failures=3`,
`topRow -6 -> 0` on both viewport paths, the maintainer's exact symptom), GREEN 5/5 with
the fix, five mutations with clean selectivity. It returned CHANGES REQUESTED on two
things the fix's own evidence could not show:

1. **Shard collision.** The branch predated #2110's carve, so the new block lacked the
   `core_terminal_proof_deferred` branch its 11 siblings gained. The reviewer rebased and
   ran the guard rather than reasoning about it: `proof ... ran on BOTH shard 0 and
   shard 1`, exit 1. That guard runs per push, so it would have reddened `main`.
2. **`pinTerminalToBottom`'s positive path had zero coverage.** The change adds an early
   return in front of it, but the only test asserted the *refusal* path — an
   `if (true) return false` mutant survived the whole suite. Not a regression (#184 was
   verified working on-device), but the protection everyone would assume existed did not.

**Round 2** fixed both. The budget guard now reports `(shard-proof) all 12 core-terminal
proofs ran exactly once across the SHIPPED 6 shards`, distribution 1/1/3/3/2/2, with
#2110's carve confirmed intact structurally (12 deferred branches, 12 announce calls, 12
registry entries, exactly one of each per status var). Two new tests cover the #184
positive path, and the reviewer's own mutant takes the run to `tests=7 failures=2` —
exactly those two, other five green.

**On the never-run-on-CI risk** — this class is added and registered in one commit, so its
first CI execution is post-merge — the reviewer answered structurally rather than by run
count: the `LONG_PRESS` message is scheduled at `downTime+500` and `ACTION_UP` posts at
`downTime+750`, and `MessageQueue` is time-ordered, so swiftshader CPU starvation cannot
lose it. It uses the #788-approved `createAndroidComposeRule` shape and every wait
hard-fails. Five green emulator runs besides.

`origin/main` is merged into this branch deliberately, so the PR picks up #2117's new
androidTest compile lane — which means this PR's own new instrumented test is
compile-checked by a required check rather than only after merge.
`check-androidtest-compile-wiring.sh` rc=0 on the merged tree.

Local guards on the committed tree, all rc=0: `test-ci-journey-budget.sh`
(`ALL TESTS PASSED`), `check-ci-journey-harness.sh`, `check-journey-shard-literals.sh`,
`check-test-validity.sh` (no ungated androidTest journeys), `check-file-size-hygiene.sh`,
`check-script-interpreter-hygiene.sh`. Gate: 12506 executed / 0 failed, validated four
ways, both new JVM classes named in both variants.

Two traps this review surfaced are recorded in `process.md` (`aee4cb8e`): Gradle
re-executing `compile*Kotlin` is **not** proof a mutant landed (the reviewer got
`FROM-CACHE` for a fully live mutant), and per-run test artifacts are overwritten, so an
artifact pull taken after a mutation run shows the mutant's output.

Closes #2154