### PR TITLE
diagnostics: stop ConnectionLogPartStore convoying on a quadratic scan (#2147)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogPartStore.kt
+++ b/app/src/main/java/com/pocketshell/app/diagnostics/ConnectionLogPartStore.kt
@@ -41,6 +41,32 @@ import java.io.File
  * single-threaded, but the store is also driven concurrently by its stress test,
  * so N appends from any number of threads read back as exactly N lines — never a
  * torn line, never a dropped line, never a zero-length part.
+ *
+ * Because every operation holds that one lock, whatever the lock holder does is
+ * paid by every other writer. The set of live part files is therefore tracked
+ * **in memory** ([partFiles]) and the directory is scanned exactly ONCE, at
+ * construction, to recover what a previous process left behind. Re-deriving the
+ * part list from disk inside [append] made the hot path O(parts) — quadratic
+ * over a run — and convoyed 16 writers on the lock hard enough to wedge a
+ * full-JVM gate for over an hour (issue #2147).
+ *
+ * ## The tracked set may never claim health the disk does not have
+ *
+ * Tracking the parts in memory means [partCount] and [readAllLines] answer from
+ * the cache. That is only sound while the cache and the directory agree, so the
+ * ONE operation that can disagree — deleting a folded part — is checked: a part
+ * leaves [partFiles] only when it is genuinely gone from disk. A part whose
+ * `delete()` did not remove it moves to [undeletedFoldedParts], where it still
+ * counts against [partCount] (it is still occupying the on-disk part budget) and
+ * is retried on the next compaction. Popping it regardless would let the store
+ * report "bounded to [maxParts]" while the directory grew without limit —
+ * exactly the #1669 field failure (200+ stranded `.part-*` files) this class
+ * exists to prevent, only now invisible.
+ *
+ * The single construction-time scan is also the store's whole view of the
+ * directory: a FOREIGN writer that drops a `…part-*` file in afterwards is out
+ * of contract and stays unseen. Production has one store per directory (the
+ * `@Singleton` [DiagnosticRecorder] owns both), so there is no second writer.
  */
 internal class ConnectionLogPartStore(
     private val directory: File,
@@ -74,12 +100,36 @@ internal class ConnectionLogPartStore(
     // Line count of the newest part file; drives rotation.
     private var currentLineCount: Int = 0
 
+    /**
+     * Every live part file, oldest index first — the authoritative in-memory view
+     * of what [partFilesLocked] used to re-derive from disk on every call.
+     * Seeded once by the recovery scan below, then maintained by exactly two
+     * mutations: [append] adds a part the moment its first line creates it, and
+     * [compactLocked] / [clear] drop the parts they delete.
+     */
+    private val partFiles = ArrayDeque<File>()
+
+    /**
+     * Parts already folded into [baseFile] whose file survived its `delete()`.
+     * Their lines live in base, so they are NOT read back (that would duplicate
+     * them) and NOT folded again (that would grow base without bound) — but the
+     * file is still on disk, so it still counts towards [partCount] and its
+     * delete is retried at the start of every [compactLocked]. Empty in every
+     * healthy run; non-empty is the store reporting the truth about its
+     * directory instead of hiding a stranded part behind a healthy cache.
+     */
+    private val undeletedFoldedParts = ArrayDeque<File>()
+
     init {
         // Recover in-memory rotation state from any parts left by a prior process
-        // so appends continue the newest part instead of clobbering it.
+        // so appends continue the newest part instead of clobbering it. This is
+        // THE ONLY directory scan the store ever performs.
         synchronized(lock) {
-            val parts = partFilesLocked()
-            val newest = parts.maxByOrNull { indexOf(it) }
+            (directory.listFiles() ?: emptyArray())
+                .filter { it.isFile && partRegex.matches(it.name) }
+                .sortedBy { indexOf(it) }
+                .forEach { partFiles.addLast(it) }
+            val newest = partFiles.lastOrNull()
             if (newest != null) {
                 currentIndex = indexOf(newest)
                 currentLineCount = newest.readNonEmptyLineCount()
@@ -99,8 +149,15 @@ internal class ConnectionLogPartStore(
         // never observes a torn line. Creating the part here (append mode) with a
         // non-empty write is what guarantees no zero-length part ever exists.
         part.appendText(line + "\n")
+        if (partFiles.lastOrNull() != part) {
+            // The write above is what CREATED this part (append mode, non-empty),
+            // so this is the earliest moment it may join the tracked set — which
+            // is what keeps a zero-length part unrepresentable. The guard also
+            // covers the re-open case where recovery already tracked this part.
+            partFiles.addLast(part)
+        }
         currentLineCount += 1
-        if (partFilesLocked().size > maxParts) {
+        if (partFiles.size > maxParts) {
             compactLocked()
         }
     }
@@ -112,8 +169,14 @@ internal class ConnectionLogPartStore(
         baseLines + partFilesLocked().flatMap { it.readNonEmptyLines() }
     }
 
-    /** Current on-disk part-file count (excludes the folded [baseFile]). */
-    fun partCount(): Int = synchronized(lock) { partFilesLocked().size }
+    /**
+     * Current on-disk part-file count (excludes the folded [baseFile]).
+     *
+     * Counts the folded-but-undeleted parts too: they are still files in the
+     * directory, and a count that omitted them would understate the on-disk
+     * archive — the cache lying about the disk (issue #2147).
+     */
+    fun partCount(): Int = synchronized(lock) { partFilesLocked().size + undeletedFoldedParts.size }
 
     /**
      * Fold the oldest parts into [baseFile] until at most [maxParts] parts remain.
@@ -125,27 +188,61 @@ internal class ConnectionLogPartStore(
     /** Delete every part + base file (used by the recorder's `clear`). */
     fun clear() = synchronized(lock) {
         baseFile().delete()
-        partFilesLocked().forEach { it.delete() }
-        currentIndex = 0
-        currentLineCount = 0
+        // Anything that survives its delete is STILL on disk holding lines, and
+        // base is gone, so it stays tracked as a live part rather than vanishing
+        // into a cleared cache. Healthy runs leave `survivors` empty.
+        val survivors = (partFiles + undeletedFoldedParts)
+            .filter { part ->
+                part.delete()
+                part.exists()
+            }
+            .sortedBy { indexOf(it) }
+        partFiles.clear()
+        undeletedFoldedParts.clear()
+        survivors.forEach { partFiles.addLast(it) }
+        val newest = partFiles.lastOrNull()
+        currentIndex = if (newest == null) 0 else indexOf(newest)
+        currentLineCount = newest?.readNonEmptyLineCount() ?: 0
     }
 
     private fun compactLocked() {
-        val parts = partFilesLocked().sortedBy { indexOf(it) }
-        if (parts.size > maxParts) {
+        // Retry first: a part that survived an earlier delete is still spending
+        // the on-disk part budget, so clearing it takes priority over folding a
+        // new one. Retrying AFTER the fold would let a permanently undeletable
+        // part be masked by a successful delete in the same pass.
+        retryUndeletedFoldedPartsLocked()
+        if (partFiles.size > maxParts) {
             val base = baseFile()
             base.parentFile?.mkdirs()
             // Fold all but the newest [maxParts] parts into base, oldest first.
-            val toFold = parts.dropLast(maxParts)
-            for (part in toFold) {
+            repeat(partFiles.size - maxParts) {
+                val part = partFiles.removeFirst()
                 val lines = part.readNonEmptyLines()
                 if (lines.isNotEmpty()) {
                     base.appendText(lines.joinToString(separator = "\n", postfix = "\n"))
                 }
                 part.delete()
+                if (part.exists()) {
+                    // Folded but not removed. One stat per fold, O(1) — it is what
+                    // keeps [partCount] equal to the real on-disk part count when a
+                    // delete fails, instead of the cache silently reporting a bound
+                    // the directory does not honour (issue #2147).
+                    undeletedFoldedParts.addLast(part)
+                }
             }
         }
         trimBaseToByteCapLocked()
+    }
+
+    /** Re-attempt the deletes that previously failed; drop the ones now gone. */
+    private fun retryUndeletedFoldedPartsLocked() {
+        if (undeletedFoldedParts.isEmpty()) return
+        val iterator = undeletedFoldedParts.iterator()
+        while (iterator.hasNext()) {
+            val part = iterator.next()
+            part.delete()
+            if (!part.exists()) iterator.remove()
+        }
     }
 
     /** Keep the newest complete JSONL lines whose UTF-8 bytes fit the cap. */
@@ -172,10 +269,13 @@ internal class ConnectionLogPartStore(
     private fun partFile(index: Int): File =
         File(directory, "$baseName.part-" + index.toString().padStart(PART_INDEX_DIGITS, '0'))
 
-    private fun partFilesLocked(): List<File> =
-        (directory.listFiles() ?: emptyArray())
-            .filter { it.isFile && partRegex.matches(it.name) }
-            .sortedBy { indexOf(it) }
+    /**
+     * The live parts in index order. Reads the tracked set — it must NEVER go
+     * back to the filesystem: this is called from under [lock], and the O(parts)
+     * `listFiles` + `isFile` + regex + sort it used to run is the convoy that
+     * wedged a full-JVM gate for over an hour (issue #2147).
+     */
+    private fun partFilesLocked(): List<File> = partFiles.toList()
 
     private fun indexOf(file: File): Int =
         partRegex.matchEntire(file.name)?.groupValues?.get(1)?.toIntOrNull() ?: 0

--- a/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogPartStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/ConnectionLogPartStoreTest.kt
@@ -79,8 +79,9 @@ class ConnectionLogPartStoreTest {
 
     @Test
     fun `compaction bounds the on-disk part count without dropping lines`() = runBlocking {
+        val directory = dir()
         val store = ConnectionLogPartStore(
-            directory = dir(),
+            directory = directory,
             maxLinesPerPart = 10,
             maxParts = 4,
         )
@@ -92,6 +93,17 @@ class ConnectionLogPartStoreTest {
         assertTrue(
             "on-disk part count must be bounded to maxParts=4, was ${store.partCount()}",
             store.partCount() <= 4,
+        )
+        // ...and the bound must hold on the FILESYSTEM, not merely in whatever the
+        // store tracks in memory. #1669 was 200+ stranded `.part-*` files on a real
+        // device; a compaction that folds a part but fails to remove its file would
+        // satisfy an in-memory count while the directory grew without limit, and the
+        // stranded parts would be invisible to the exported archive too (#2147).
+        val onDisk = directory.listFiles().orEmpty().filter { it.name.contains(".part-") }
+        assertTrue(
+            "on-disk part FILE count must be bounded to maxParts=4, was ${onDisk.size}: " +
+                onDisk.map { it.name }.sorted(),
+            onDisk.size <= 4,
         )
         // Bounding the part count must NOT lose events: all 500 still read back in order.
         val seqs = store.readAllLines().map { it.substringAfter("\"seq\":").substringBefore("}").toInt() }

--- a/app/src/test/java/com/pocketshell/app/diagnostics/Issue2147AppendConvoyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/diagnostics/Issue2147AppendConvoyTest.kt
@@ -1,0 +1,324 @@
+package com.pocketshell.app.diagnostics
+
+import com.pocketshell.testsupport.drainMainLooperUntil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Issue #2147: [ConnectionLogPartStore.append] must not rescan its directory.
+ *
+ * ## The defect this reproduces
+ *
+ * A canonical `scripts/full-jvm-gate.py` run wedged **>60 minutes** in
+ * `:app:testReleaseUnitTest` on `ConnectionLogPartStoreTest`'s concurrent
+ * rotation case. `jstack` showed **16 coroutines convoyed on
+ * `synchronized(lock)`** while the lock holder ran an O(parts) `listFiles()` +
+ * `isFile` + regex + sort scan (`partFilesLocked`) — which `append` called on
+ * EVERY line, purely to compare the part count against `maxParts`. That is
+ * quadratic in the part count, executed under the one lock every writer needs,
+ * so the convoy grows with the archive. CI's `Unit tests` job has a 35-minute
+ * cap, and a job that times out while every test line reads PASSED is a hang,
+ * not an assertion failure (the #882 shape) — it takes `main` red and every
+ * filtered pre-merge gate misses it.
+ *
+ * ## Why the oracle is a scan COUNT and not only a stopwatch
+ *
+ * The wall-clock deadline below is the symptom-level bound and it HARD-fails
+ * (the audited [drainMainLooperUntil] convention, one generous
+ * `GENEROUS_SETTLE_DEADLINE_MS` budget — never a nudged local constant). But
+ * wall-clock alone is load-dependent: the convoy is catastrophic on a memory-
+ * pressured gate box and merely slow on an idle one, so a stopwatch-only proof
+ * would be green exactly where developers run it and red only on CI. The scan
+ * count is the same defect measured deterministically: it is load-independent,
+ * so it reds on ANY box, and it is measured on the REAL filesystem rather than
+ * through a production seam — [java.io.File] is open and `listFiles()` is
+ * virtual, so [ScanCountingDirectory] observes precisely the scans the store
+ * actually performs, with no test-only hook inside the store.
+ *
+ * Both assertions are load-bearing: the count pins the mechanism, the deadline
+ * pins the symptom.
+ */
+class Issue2147AppendConvoyTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    /**
+     * A real directory that counts every `listFiles()` scan performed against it.
+     * `java.io.File` is a non-final class with a virtual `listFiles()`, so this is
+     * a genuine observation of the store's filesystem behaviour — the store is
+     * handed an ordinary directory and is not aware it is being measured.
+     */
+    private class ScanCountingDirectory(path: String) : File(path) {
+        val scans = AtomicInteger()
+
+        override fun listFiles(): Array<File>? {
+            scans.incrementAndGet()
+            return super.listFiles()
+        }
+
+        companion object {
+            private const val serialVersionUID: Long = 1L
+        }
+    }
+
+    @Test
+    fun `concurrent append never rescans the part directory — the convoy that wedged the gate`() =
+        runBlocking {
+            val directory = ScanCountingDirectory(tmp.newFolder("connection-log").absolutePath)
+            // One line per part makes the on-disk part count grow with every append,
+            // so the removed per-append O(parts) scan is genuinely quadratic here —
+            // the same shape as the wedged gate run, sized so the convoy dominates.
+            // maxParts is above N so nothing is folded away and the part count keeps
+            // climbing for the whole run.
+            val store = ConnectionLogPartStore(
+                directory = directory,
+                maxLinesPerPart = 1,
+                maxParts = 100_000,
+            )
+            // Recovering rotation state at construction is allowed to scan the
+            // directory exactly once; everything after that must be in-memory.
+            val scansAfterOpen = directory.scans.get()
+            assertEquals("construction recovers rotation state with a single scan", 1, scansAfterOpen)
+
+            val writers = 16
+            val perWriter = 250
+            val n = writers * perWriter
+            val completed = AtomicInteger()
+            val abort = AtomicBoolean(false)
+            val jobs: List<Job> = (0 until writers).map { w ->
+                launch(Dispatchers.IO) {
+                    for (i in 0 until perWriter) {
+                        // The abort flag only bounds the RED case: on a healthy run
+                        // every writer finishes before the deadline and never reads
+                        // it as true, so it cannot weaken the assertions below.
+                        if (abort.get()) return@launch
+                        store.append("""{"seq":${w * perWriter + i},"w":$w}""")
+                    }
+                    completed.incrementAndGet()
+                }
+            }
+
+            val startedAtMs = System.currentTimeMillis()
+            val settled = drainMainLooperUntil { completed.get() == writers }
+            val elapsedMs = System.currentTimeMillis() - startedAtMs
+            if (!settled) abort.set(true)
+            jobs.forEach { it.join() }
+
+            assertTrue(
+                "$writers writers x $perWriter appends must finish inside the generous settle " +
+                    "deadline; they convoy on the per-append directory scan instead " +
+                    "(completed=${completed.get()}/$writers after ${elapsedMs}ms, " +
+                    "directory scans=${directory.scans.get()})",
+                settled,
+            )
+
+            // THE load-bearing mechanism assertion: appending must cost zero
+            // directory scans. On the unfixed store this is one scan per append.
+            assertEquals(
+                "append must not scan the part directory (issue #2147): $n appends performed " +
+                    "${directory.scans.get() - scansAfterOpen} extra scans",
+                scansAfterOpen,
+                directory.scans.get(),
+            )
+
+            // Losslessness is not traded away for the speed-up.
+            val lines = store.readAllLines()
+            assertEquals("every appended line must still read back", n, lines.size)
+        }
+
+    @Test
+    fun `compacting append never rescans the part directory either`() = runBlocking {
+        val directory = ScanCountingDirectory(tmp.newFolder("connection-log").absolutePath)
+        // The production shape: a tight part ceiling, so compaction folds parts into
+        // the base file on nearly every append. Rotation AND compaction must both
+        // maintain the tracked part set in memory rather than re-deriving it from
+        // disk, or the scan simply moves from one caller to another.
+        val store = ConnectionLogPartStore(
+            directory = directory,
+            maxLinesPerPart = 1,
+            maxParts = 8,
+        )
+        val scansAfterOpen = directory.scans.get()
+
+        val writers = 8
+        val perWriter = 250
+        val n = writers * perWriter
+        val completed = AtomicInteger()
+        val abort = AtomicBoolean(false)
+        val jobs: List<Job> = (0 until writers).map { w ->
+            launch(Dispatchers.IO) {
+                for (i in 0 until perWriter) {
+                    if (abort.get()) return@launch
+                    store.append("""{"seq":${w * perWriter + i},"w":$w}""")
+                }
+                completed.incrementAndGet()
+            }
+        }
+
+        val settled = drainMainLooperUntil { completed.get() == writers }
+        if (!settled) abort.set(true)
+        jobs.forEach { it.join() }
+
+        assertTrue(
+            "compacting writers must finish inside the generous settle deadline " +
+                "(completed=${completed.get()}/$writers, directory scans=${directory.scans.get()})",
+            settled,
+        )
+        assertEquals(
+            "compaction must not scan the part directory (issue #2147): " +
+                "${directory.scans.get() - scansAfterOpen} extra scans",
+            scansAfterOpen,
+            directory.scans.get(),
+        )
+        assertTrue(
+            "the on-disk part count must still be bounded, was ${store.partCount()}",
+            store.partCount() <= 8,
+        )
+        // The same bound, taken from the FILESYSTEM. `partCount()` is answered from
+        // the tracked set now, so on its own it cannot tell a bounded directory from
+        // a compaction that folds parts but never removes their files. Read through a
+        // SEPARATE plain handle, and only after the scan-count assertion above, so
+        // this check cannot perturb that oracle.
+        val onDisk = partEntriesOnDisk(directory)
+        assertTrue(
+            "the bound must hold on disk, not just in the tracked set: ${onDisk.size} " +
+                "part files remain (${onDisk.map { it.name }.sorted()})",
+            onDisk.size <= 8,
+        )
+        assertEquals("compaction must stay lossless", n, store.readAllLines().size)
+    }
+
+    @Test
+    fun `part count and read back are still answered without rescanning`() {
+        val directory = ScanCountingDirectory(tmp.newFolder("connection-log").absolutePath)
+        val store = ConnectionLogPartStore(
+            directory = directory,
+            maxLinesPerPart = 5,
+            maxParts = 100,
+        )
+        val scansAfterOpen = directory.scans.get()
+        repeat(60) { store.append("""{"seq":$it}""") }
+
+        assertEquals("12 parts of 5 lines each", 12, store.partCount())
+        assertEquals(60, store.readAllLines().size)
+        store.compact()
+        store.clear()
+        assertEquals(0, store.partCount())
+        assertEquals(
+            "no store operation may rescan the directory after construction (issue #2147)",
+            scansAfterOpen,
+            directory.scans.get(),
+        )
+        // `clear()` drops parts from the tracked set too, so its bound is disk-derived
+        // as well — asserted after the scan oracle, through a separate plain handle.
+        val leftOnDisk = partEntriesOnDisk(directory)
+        assertTrue(
+            "clear() must leave no part file behind, found ${leftOnDisk.map { it.name }.sorted()}",
+            leftOnDisk.isEmpty(),
+        )
+    }
+
+    /**
+     * The blocking half of the tracked-set design: what happens when a part is
+     * folded into base but its file survives `delete()`.
+     *
+     * With the part list re-derived from disk this could not go wrong — the next
+     * scan saw the survivor. With the list tracked in memory (the #2147 fix) a
+     * store that popped the part regardless would report "bounded to maxParts"
+     * while the directory grew without limit, and `readAllLines` would omit the
+     * stranded file, so the exported archive could not reveal it either. That is
+     * the #1669 field failure (200+ stranded `.part-*` files) made INVISIBLE.
+     *
+     * The undeletable part is created for real, not stubbed: a non-empty
+     * DIRECTORY at the part's path. `File.delete()` returns false for it on every
+     * platform, `isFile` is false so the store reads no lines from it, and it
+     * needs no permission games (which a root test runner would ignore anyway).
+     */
+    @Test
+    fun `a part whose delete fails stays counted instead of vanishing into the cache`() {
+        val directory = tmp.newFolder("connection-log")
+        val maxParts = 4
+        val store = ConnectionLogPartStore(
+            directory = directory,
+            maxLinesPerPart = 1,
+            maxParts = maxParts,
+        )
+        // Four parts, one line each: at the ceiling, nothing folded yet.
+        repeat(maxParts) { store.append("""{"seq":$it}""") }
+        val oldest = File(directory, "${ConnectionLogPartStore.DEFAULT_BASE_NAME}.part-000001")
+        assertTrue("the oldest part must exist before it is made undeletable", oldest.isFile)
+
+        // Make the oldest part undeletable. Its line goes with it — that loss is
+        // this test's own doing, not the store's, so the expected read-back below
+        // starts at seq 1.
+        assertTrue(oldest.delete())
+        assertTrue(oldest.mkdir())
+        assertTrue(File(oldest, "occupant").createNewFile())
+
+        // This append rotates to a fifth part, so compaction must fold the oldest —
+        // and its delete fails.
+        store.append("""{"seq":$maxParts}""")
+
+        val onDisk = partEntriesOnDisk(directory)
+        assertTrue(
+            "the undeletable part must still be on disk for this test to mean anything",
+            onDisk.any { it.name == oldest.name },
+        )
+        assertEquals(
+            "partCount() must equal the real on-disk part count — a part that could not " +
+                "be deleted may not disappear from the count (issue #2147): on disk " +
+                "${onDisk.map { it.name }.sorted()}",
+            onDisk.size,
+            store.partCount(),
+        )
+        assertTrue(
+            "the breached bound must be VISIBLE through the store's own API, not hidden " +
+                "behind a healthy-looking cache (partCount=${store.partCount()})",
+            store.partCount() > maxParts,
+        )
+
+        // Keep appending: the stranded part must neither be lost from the count nor
+        // re-folded into base (which would duplicate lines and grow base without
+        // bound), and every real line must still read back exactly once.
+        val total = 25
+        for (seq in (maxParts + 1) until total) {
+            store.append("""{"seq":$seq}""")
+        }
+        val stillOnDisk = partEntriesOnDisk(directory)
+        assertEquals(
+            "partCount() must keep matching the disk as compaction continues: on disk " +
+                "${stillOnDisk.map { it.name }.sorted()}",
+            stillOnDisk.size,
+            store.partCount(),
+        )
+        assertTrue(
+            "one undeletable part must not make the directory grow without bound, found " +
+                "${stillOnDisk.size} part entries",
+            stillOnDisk.size <= maxParts + 1,
+        )
+        val seqs = store.readAllLines().map { it.substringAfter("\"seq\":").substringBefore("}").toInt() }
+        assertEquals(
+            "the folded-but-undeleted part must not be read back twice, and no other " +
+                "line may be lost",
+            (1 until total).toList(),
+            seqs,
+        )
+    }
+
+    private fun partEntriesOnDisk(directory: File): List<File> =
+        // A plain handle: never the ScanCountingDirectory instance, so a disk-derived
+        // assertion can never perturb the scan-count oracle.
+        File(directory.absolutePath).listFiles().orEmpty()
+            .filter { it.name.contains(".part-") }
+            .sortedBy { it.name }
+}


### PR DESCRIPTION
`append()` called `partFilesLocked()` on **every line** just to compare the part count
against `maxParts`, and that helper ran `listFiles()` + a per-file `isFile` stat + regex +
sort — all inside `synchronized(lock)`, the one lock every writer needs. Quadratic in the
part count, paid by the whole convoy.

It was found the hard way: a canonical gate run wedged **>60 minutes** in
`:app:testReleaseUnitTest`, with `jstack` showing 16 coroutines queued on that lock. CI's
`Unit tests` job has a 35-minute cap, and a job that ends "timed out" with every test line
PASSED is a hang, not an assertion failure — the #882 shape, waiting to happen. It
reproduces under load, which is the condition CI runs in and an idle dev box does not.

The live part set is now tracked in memory; the directory is scanned exactly once, at
construction, for prior-process recovery.

**The review is why this took two rounds, and the second round is the interesting part.**
Round 1 fixed the performance defect, and the reviewer reproduced it independently
(`completed=1/16 after 30002ms, directory scans=2451` → 0.412 s). But it then found, with
its own mutation, that the fix had *removed* coverage: `partCount()` and `readAllLines()
`became cache-derived while `compactLocked` popped the part whether or not `delete()`
succeeded — so a fold-without-delete would read as "bounded" while the directory grew
unbounded. Its `delete()` → `canRead()` mutant **survived on the fixed tree and killed on
base**, which is what made it this diff's problem rather than a pre-existing gap.

Round 2 addressed it in production, not just in the test. A part leaves the tracked deque
only when it is genuinely gone from disk; one that survives its `delete()` moves to
`undeletedFoldedParts` — still counted, not re-folded (that would grow base without
bound), not read back (that would duplicate), delete retried at the **start** of each
compaction, since retrying last would mask the breach. Fold-then-delete ordering is
deliberately unchanged: delete-first would trade a benign duplicate-on-crash for a lost
line, and this class exists to not lose lines.

Reviewer verdict: **APPROVED**, verified at line-number precision rather than accepted:

- Restoring the round-1 production file and applying M3 gives `rc=1` with the failure
  reported at `ConnectionLogPartStoreTest.kt:103` — the **disk-derived** `onDisk.size <= 4`
  — while the **cache-derived** `partCount() <= 4` at `:93` executed and **passed** in that
  same run. Same shape in the convoy case: scan oracle at `:177-182` passed, new disk
  assertion at `:193` fired.
- M1 → `expected:<4000> but was:<160>`, byte-identical to round 1: the pre-existing
  losslessness assertion is intact and still bites (the test diff is purely additive).
- M2 reddens only `Issue2147AppendConvoyTest`; `ConnectionLogPartStoreTest` 5/5 and
  `Issue1709` 2/2 stay **green on base**, so the new disk assertion does not false-positive
  on the pre-fix store.
- The reviewer's own M5 (drop the `!part.exists()` guard) produced a clean `AssertionError`
  in exactly one test, proving that guard is load-bearing.
- Fixture design verified root-proof: `rmdir` on a non-empty directory fails `ENOTEMPTY`
  both as the user **and under `sudo`**, unlike a chmod fixture, and the test hard-asserts
  the fixture took effect — so a self-disable fails loudly rather than passing green.

Performance: the convoy case goes from never completing in 30 s (1 of 16 writers, 2725
directory scans) to ~0.35–0.4 s; the pre-existing lossless test 2.515 s → 0.163 s.

Two honest notes carried from the review. Its gate ended `rc=1` on three unrelated
`:shared:ui-kit` `ConfirmDialogTest` cases with a captured `AppNotIdleException … 60
SECONDS` signature under heavy sibling-lane contention (one case 1094 s; the whole gate
1h04m against a 22m baseline); per G5 it captured the XML first and produced a clean
re-run at 139/139 in both variants, and reported that rather than a clean green. And its
M4 (disable the self-heal retry) **survives 11/11** — the stuck→deletable transition is
untested. That is filed as a follow-up rather than a blocker because it fails *safe*
(over-reports a resolved breach, never hides a real one) and `partCount()` has no
production callers.

Closes #2147