### PR TITLE
ci: reclaim tests.yml headroom by extracting inline emulator shell (#2134)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1185,205 +1185,21 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Issue #760: the AVD create intermittently FATAL-ed with
-      # "Not enough space to create userdata partition. Available: 6957 MB,
-      # need 7372 MB" — pure runner disk pressure, not a test failure. The
-      # ubuntu-latest image ships ~30 GB of preinstalled SDKs/toolchains we do
-      # not use for this job (.NET, Haskell/GHC, the bundled Android NDK, the
-      # large CodeQL/boost caches). Reclaim them BEFORE the emulator-runner
-      # creates the AVD so the userdata partition always fits, then print the
-      # free space so a future disk regression is visible in the log. The `|| true`
-      # guards keep the step green if a path is already gone on a newer image.
-      #
-      # Issue #771 (round-3, PROVEN ROOT CAUSE): the original #760 version also
-      # ran
-      #     sudo rm -rf "$AGENT_TOOLSDIRECTORY"   # == /opt/hostedtoolcache
-      # which DELETED the JDK that `actions/setup-java@v5` installs under
-      # `/opt/hostedtoolcache/Java_*` and that `JAVA_HOME` points into
-      # (e.g. /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/x64).
-      # After that delete, EVERY Java tool died with
-      #     ERROR: JAVA_HOME is set to an invalid directory: …
-      # so the runner's sdkmanager (and the #771 freshly-reinstalled copy)
-      # crashed instantly and the emulator never booted. The cmdline-tools were
-      # never the real problem — the missing JDK was. Fix: prune the OTHER
-      # tool-caches under $AGENT_TOOLSDIRECTORY but PRESERVE the directory the
-      # live JAVA_HOME resolves into, so the active JDK survives.
+      # Issue #760/#771 — runner disk pressure FATAL-ed the AVD create, and the
+      # first fix deleted the JDK while reclaiming space. Rationale, the
+      # JAVA_HOME preservation and the 9000 MB infra-classified floor live in
+      # the script header (extracted verbatim in #2134).
       - name: Free disk space for the AVD
-        run: |
-          set -uo pipefail
-          echo "::group::Disk before cleanup"
-          df -h /
-          echo "::endgroup::"
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android/sdk/ndk || true
-          sudo rm -rf /opt/ghc /usr/local/.ghcup || true
-          sudo rm -rf /usr/local/share/boost || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-          # Prune unused tool-caches under $AGENT_TOOLSDIRECTORY but KEEP the
-          # active JDK that JAVA_HOME depends on (issue #771). Resolve the
-          # top-level tool-cache subdir the live JAVA_HOME lives in (e.g.
-          # `Java_Temurin-Hotspot_jdk`) and exclude exactly that one, so the
-          # exact JDK setup-java installed survives even across version bumps.
-          if [[ -n "${AGENT_TOOLSDIRECTORY:-}" && -d "${AGENT_TOOLSDIRECTORY:-}" ]]; then
-            keep_dir=""
-            if [[ -n "${JAVA_HOME:-}" && "$JAVA_HOME" == "$AGENT_TOOLSDIRECTORY"/* ]]; then
-              # First path segment of JAVA_HOME relative to the tool-cache root.
-              rel="${JAVA_HOME#"$AGENT_TOOLSDIRECTORY"/}"
-              keep_dir="${rel%%/*}"
-            fi
-            echo "Pruning $AGENT_TOOLSDIRECTORY, keeping active JDK dir: '${keep_dir:-<none>}'"
-            if [[ -n "$keep_dir" ]]; then
-              sudo find "$AGENT_TOOLSDIRECTORY" -mindepth 1 -maxdepth 1 \
-                ! -name "$keep_dir" -exec rm -rf {} + || true
-            else
-              # No JAVA_HOME under the tool-cache (unexpected): leave the dir
-              # intact rather than risk deleting the JDK. The deletions above
-              # plus docker prune already free far more than the 9000 MB guard.
-              echo "JAVA_HOME not under \$AGENT_TOOLSDIRECTORY; leaving it intact to protect the JDK."
-            fi
-          fi
-          sudo docker image prune -af || true
-          echo "::group::Disk after cleanup"
-          df -h /
-          echo "::endgroup::"
-          # Confirm the active JDK survived the prune (issue #771): a deleted
-          # JAVA_HOME makes every Java tool fail with
-          # "JAVA_HOME is set to an invalid directory" and the emulator never
-          # boots. Fail NOW with an explicit infra classification if it's gone.
-          if [[ -n "${JAVA_HOME:-}" && ! -x "$JAVA_HOME/bin/java" ]]; then
-            echo "::error title=EMULATOR INFRA UNAVAILABLE::JAVA_HOME=$JAVA_HOME has no bin/java after disk cleanup; the JDK was deleted (issue #771 regression guard). This is an infra setup error, not a test failure."
-            exit 1
-          fi
-          avail_mb="$(df -m --output=avail / | tail -1 | tr -d ' ')"
-          echo "Available on / after cleanup: ${avail_mb} MB"
-          # The AVD userdata partition needs ~7372 MB; require a safe margin so
-          # the create cannot FATAL on disk. If it still can't be freed, fail
-          # NOW with an explicit infra classification rather than letting the
-          # emulator-runner FATAL deeper in with a confusing message.
-          if [[ "$avail_mb" -lt 9000 ]]; then
-            echo "::error title=EMULATOR INFRA UNAVAILABLE::Only ${avail_mb} MB free on / after cleanup; the AVD userdata partition needs ~7372 MB. This is a runner-disk infra shortage (issue #760), not a test failure."
-            exit 1
-          fi
+        run: scripts/ci-emulator-free-disk.sh
 
-      # Issue #771 — REAL root cause + fix (supersedes the earlier "warm up a
-      # separate SDK copy" pre-step, which was INEFFECTIVE).
-      #
-      # The job dies inside the emulator-runner action's OWN "Install Android SDK"
-      # step. The action runs, by name on PATH:
-      #     sh -c "yes | sdkmanager --licenses > /dev/null"
-      # and that exits 1 in ~10 ms — far too fast for a JVM tool that actually
-      # started. The matching symptom in the previous pre-step's log was
-      # `yes: standard output: Broken pipe` on EVERY attempt: `sdkmanager` exits
-      # before reading a single line of stdin, so `yes` gets SIGPIPE. In other
-      # words the runner image's PRE-INSTALLED `sdkmanager`
-      # ($ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager) is broken on the
-      # current ubuntu-24.04 image and crashes instantly. The later
-      # "could not connect to TCP port 5554" is only the action's cleanup handler
-      # firing after that crash — no emulator was ever started.
-      #
-      # Why the previous attempt did NOT work: it accepted licenses / warmed
-      # packages against the SAME broken sdkmanager and threw the output away
-      # (`> /dev/null 2>&1`), so it could not even tell the binary was crashing.
-      # And the action does not reuse a "warmed" SDK — it re-invokes its own
-      # `sdkmanager --licenses` regardless, against the same broken binary.
-      #
-      # Why bumping the action version does NOT help: android-emulator-runner only
-      # downloads its own cmdline-tools when `$ANDROID_HOME/cmdline-tools` does NOT
-      # already exist (`if (!fs.existsSync(cmdlineToolsPath))`). On the hosted
-      # runner that directory exists, so EVERY action version (incl. main) skips
-      # the download and uses the runner's broken pre-installed sdkmanager.
-      #
-      # THE FIX (targets the action's actual failing call): replace the runner's
-      # broken `$ANDROID_HOME/cmdline-tools/latest` with the exact known-good
-      # cmdline-tools build the action itself pins (commandlinetools build
-      # 14742923). When the action then runs `sdkmanager --licenses` by name on
-      # PATH, PATH resolves to THIS freshly-installed, working sdkmanager — the
-      # same path the action uses — so its own license step succeeds and the AVD
-      # actually boots. We also accept licenses + warm the api-34 packages with
-      # the fresh tools so the action's subsequent install is a no-op.
-      #
-      # This step runs BEFORE any emulator/test, so a failure here can only ever
-      # block the run on infra provisioning — it can NEVER turn a genuine J1/J3
-      # test failure green (no #636/#638 false-green). We keep the journey suite
-      # + #760 retry-once + classifier below as the sole authoritative test gate.
+      # Issue #771 — the hosted runner's pre-installed `sdkmanager` crashes in
+      # ~10 ms, so the emulator-runner action's own `sdkmanager --licenses`
+      # dies and no emulator ever boots. Full root-cause analysis, why the
+      # earlier warm-up and an action bump could not work, and the repair +
+      # verification steps live in the script header (extracted verbatim in
+      # #2134).
       - name: Repair Android cmdline-tools + accept licenses (issue #771)
-        run: |
-          set -uo pipefail
-          SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/usr/local/lib/android/sdk}}"
-          echo "Using SDK_ROOT=$SDK_ROOT"
-          PREINSTALLED="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
-
-          # 1) DIAGNOSE the pre-installed sdkmanager so the next CI run proves the
-          #    root cause (do NOT discard stderr this time). A working sdkmanager
-          #    prints its version in well under a second; the broken one exits
-          #    instantly. `|| true` keeps this purely diagnostic.
-          echo "::group::Diagnose pre-installed sdkmanager (expected to be broken)"
-          if [[ -x "$PREINSTALLED" ]]; then
-            echo "java -version:"; java -version 2>&1 | sed 's/^/  /' || true
-            echo "sdkmanager --version (stderr included):"
-            "$PREINSTALLED" --version 2>&1 | sed 's/^/  /' || echo "  (non-zero exit from pre-installed sdkmanager --version)"
-          else
-            echo "No pre-installed sdkmanager at $PREINSTALLED"
-          fi
-          echo "::endgroup::"
-
-          # 2) REPAIR: install the action's exact known-good cmdline-tools build
-          #    over the (broken) pre-installed `latest`, so the action's own
-          #    PATH-resolved `sdkmanager --licenses` runs against a working copy.
-          CMDLINE_TOOLS_ZIP="commandlinetools-linux-14742923_latest.zip"
-          CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/${CMDLINE_TOOLS_ZIP}"
-          echo "::group::Reinstall known-good cmdline-tools (build 14742923)"
-          TMP_DL="$(mktemp -d)"
-          ok=""
-          for attempt in 1 2 3; do
-            if curl -fsSL --retry 3 -o "$TMP_DL/$CMDLINE_TOOLS_ZIP" "$CMDLINE_TOOLS_URL"; then
-              ok="yes"; echo "Downloaded $CMDLINE_TOOLS_ZIP on attempt $attempt"; break
-            fi
-            echo "cmdline-tools download attempt $attempt failed; retrying in 5s..."
-            sleep 5
-          done
-          if [[ -z "$ok" ]]; then
-            echo "::error title=cmdline-tools download failed::Could not fetch ${CMDLINE_TOOLS_URL} after retries. This is a runner-network infra failure, not a test failure (issue #771)."
-            exit 1
-          fi
-          rm -rf "$TMP_DL/extract"
-          unzip -q "$TMP_DL/$CMDLINE_TOOLS_ZIP" -d "$TMP_DL/extract"
-          # The zip extracts to `cmdline-tools/`; the action expects the tools at
-          # `$SDK_ROOT/cmdline-tools/latest`.
-          rm -rf "$SDK_ROOT/cmdline-tools/latest"
-          mkdir -p "$SDK_ROOT/cmdline-tools"
-          mv "$TMP_DL/extract/cmdline-tools" "$SDK_ROOT/cmdline-tools/latest"
-          SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
-          chmod +x "$SDKMANAGER" || true
-          echo "Installed fresh sdkmanager at $SDKMANAGER"
-          echo "::endgroup::"
-
-          # 3) VERIFY the fresh sdkmanager actually runs. This is the load-bearing
-          #    proof that the repair worked (a JVM tool that starts prints a
-          #    version line in well under a second). If it still can't run, fail
-          #    NOW with an explicit infra classification rather than letting the
-          #    action crash deeper with the confusing "TCP port 5554" message.
-          echo "::group::Verify fresh sdkmanager"
-          if ! "$SDKMANAGER" --version; then
-            echo "::error title=sdkmanager still broken after repair::The freshly-installed cmdline-tools sdkmanager still failed to run (issue #771). Treat as EMULATOR INFRA UNAVAILABLE, not a test failure."
-            exit 1
-          fi
-          echo "::endgroup::"
-
-          # 4) Accept licenses + warm the exact api-34 packages with the WORKING
-          #    tools so the action's own license/install step is a no-op. Output is
-          #    visible this time so a future regression is diagnosable. The `|| true`
-          #    keeps these non-fatal: the action re-runs them, and the journey
-          #    suite + classifier remain the authoritative test gate.
-          echo "::group::Accept SDK licenses"
-          yes | "$SDKMANAGER" --sdk_root="$SDK_ROOT" --licenses || true
-          echo "::endgroup::"
-          echo "::group::Warm up api-35 packages"
-          "$SDKMANAGER" --sdk_root="$SDK_ROOT" \
-            "platform-tools" \
-            "platforms;android-35" \
-            "system-images;android-35;google_apis;x86_64" || true
-          echo "::endgroup::"
+        run: scripts/ci-emulator-repair-sdk-tools.sh
 
       - name: Build SSH base image
         run: scripts/ci-journey-fixture-retry.sh sshd -- docker compose -f tests/docker/docker-compose.yml build sshd
@@ -1715,22 +1531,14 @@ jobs:
         # Issue #771: same v2.37.0 pin as the first attempt (see note above).
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
-          # API 35 (Android 15): matches the maintainer's dogfood device and the
-          # three connection-core journeys (BoundedGraceSessionHoldJourneyE2eTest,
-          # NotificationTapLivePinnedForegroundReseedJourneyE2eTest,
-          # SessionConnectionServiceE2eTest) that hard-assert SDK_INT == 35.
-          # nightly-extensive.yml already runs these classes green on this exact
-          # image/action. (#1197)
+          # Byte-identical to the first attempt's `with:` block above; the #1197
+          # api-level and #1458 `-memory 6144` rationale is on that copy.
           api-level: 35
           target: google_apis
           arch: x86_64
           profile: pixel_7
           force-avd-creation: true
           disable-animations: true
-          # Issue #1458: `-memory 6144` raises the guest RAM from the pixel_7 AVD
-          # hwconfig default (2048 MB) to 6 GB, leaving the render pipeline and
-          # connected journeys enough guest headroom while Docker fixtures run.
-          # ubuntu-latest gives ~16 GB host RAM, so 6 GB leaves host headroom.
           emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -memory 6144 -noaudio -no-boot-anim -camera-back none -camera-front none
           emulator-boot-timeout: 900
           script: scripts/ci-journey-suite.sh

--- a/scripts/check-file-size-hygiene.sh
+++ b/scripts/check-file-size-hygiene.sh
@@ -16,6 +16,25 @@ BASELINE_REL="scripts/file-size-hygiene-baseline.txt"
 DEFAULT_THRESHOLD_BYTES=131072 # 128 KiB
 THRESHOLD_BYTES="${FILE_SIZE_HYGIENE_THRESHOLD_BYTES:-$DEFAULT_THRESHOLD_BYTES}"
 
+# Issue #2134: a hand-authored workflow file crossing the threshold is a
+# different failure from a god-object source file, and it used to arrive with no
+# warning. `.github/workflows/tests.yml` sat 271 bytes under the cap, so the
+# NEXT workflow addition of any realistic size failed this guard regardless of
+# what it was — and the cheapest way out under time pressure was deleting the
+# explanatory comments that make the workflow readable, i.e. the guard's
+# practical effect became "remove the documentation".
+#
+# Two changes close that. (1) A workflow file that is still UNDER the cap but
+# within WORKFLOW_HEADROOM_BYTES of it fails HERE, early, while the fix is still
+# cheap — 1024 bytes is roughly the ~15-line job or step this margin exists to
+# leave room for. (2) Every workflow failure, early or hard, prints the intended
+# remedy, so the next person extracts inline shell into scripts/ instead of
+# reaching for a comment, the threshold, or the baseline.
+#
+# This is strictly stricter than the plain cap: it introduces no new allowance
+# and admits no growth the ratchet forbids, so there is nothing to ratchet down.
+WORKFLOW_HEADROOM_BYTES="${FILE_SIZE_HYGIENE_WORKFLOW_HEADROOM_BYTES:-1024}"
+
 usage() {
   cat <<'USAGE'
 Usage: scripts/check-file-size-hygiene.sh [--update | --self-test]
@@ -27,8 +46,14 @@ Ratchet-style oversized-file guard over tracked, first-party files:
   - a baselined oversized file may shrink or disappear, but may not grow.
   - a new non-exempt tracked file above the threshold fails.
 
+  - a workflow under .github/workflows/ must also keep WORKFLOW_HEADROOM_BYTES
+    of room under the threshold, and its failures name the intended remedy.
+
 Environment:
   FILE_SIZE_HYGIENE_THRESHOLD_BYTES  override the default 131072-byte threshold.
+  FILE_SIZE_HYGIENE_WORKFLOW_HEADROOM_BYTES
+                                     override the default 1024-byte workflow
+                                     headroom margin.
 
 (no args)    check the real tree against the committed baseline
 --update     rewrite the baseline downward only; refuses growth or new oversized files
@@ -46,6 +71,25 @@ validate_threshold() {
   if ! [[ "$THRESHOLD_BYTES" =~ ^[1-9][0-9]*$ ]]; then
     fail_usage "FILE_SIZE_HYGIENE_THRESHOLD_BYTES must be a positive integer (got: $THRESHOLD_BYTES)"
   fi
+  if ! [[ "$WORKFLOW_HEADROOM_BYTES" =~ ^[0-9]+$ ]]; then
+    fail_usage "FILE_SIZE_HYGIENE_WORKFLOW_HEADROOM_BYTES must be a non-negative integer (got: $WORKFLOW_HEADROOM_BYTES)"
+  fi
+}
+
+path_is_workflow() {
+  case "$1" in
+    .github/workflows/*.yml|.github/workflows/*.yaml) return 0 ;;
+  esac
+  return 1
+}
+
+# Issue #2134: the remedy, printed on EVERY workflow-file failure so the next
+# person does not reflexively delete comments to buy bytes.
+print_workflow_remedy() {
+  printf '  Remedy for a workflow file: extract its inline `run: |` shell into a scripts/*.sh\n' >&2
+  printf '  file and call that from the step (comments move with the code they explain), or\n' >&2
+  printf '  collapse duplicated job/step boilerplate. Keep the required check NAMES unchanged.\n' >&2
+  printf '  Do NOT delete explanatory comments, raise the threshold, or baseline the workflow.\n' >&2
 }
 
 human_bytes() {
@@ -160,6 +204,7 @@ check_tree() {
 
   local regressions=0
   local improvements=0
+  local workflow_regressions=0
   printf '== file-size-hygiene (threshold %s bytes / %s) ==\n' \
     "$THRESHOLD_BYTES" "$(human_bytes "$THRESHOLD_BYTES")"
 
@@ -187,6 +232,25 @@ check_tree() {
       printf 'NEW oversized %s: %s bytes (%s) exceeds threshold %s bytes (%s)\n' \
         "$path" "$size" "$(human_bytes "$size")" "$THRESHOLD_BYTES" "$(human_bytes "$THRESHOLD_BYTES")" >&2
       regressions=$((regressions + 1))
+      if path_is_workflow "$path"; then
+        workflow_regressions=$((workflow_regressions + 1))
+      fi
+    fi
+  done
+
+  # Issue #2134: workflow headroom. A workflow still under the cap but within
+  # WORKFLOW_HEADROOM_BYTES of it fails here, while the fix is cheap, instead of
+  # ambushing the next unrelated CI change with a size failure.
+  for path in "${!current[@]}"; do
+    size="${current[$path]}"
+    path_is_workflow "$path" || continue
+    (( size <= THRESHOLD_BYTES )) || continue
+    local headroom=$((THRESHOLD_BYTES - size))
+    if (( headroom < WORKFLOW_HEADROOM_BYTES )); then
+      printf 'WORKFLOW HEADROOM %s: %s bytes (%s) leaves only %s bytes under the %s-byte threshold (need %s)\n' \
+        "$path" "$size" "$(human_bytes "$size")" "$headroom" "$THRESHOLD_BYTES" "$WORKFLOW_HEADROOM_BYTES" >&2
+      regressions=$((regressions + 1))
+      workflow_regressions=$((workflow_regressions + 1))
     fi
   done
 
@@ -195,6 +259,9 @@ check_tree() {
     printf 'check-file-size-hygiene: FAIL — %d oversized-file regression(s).\n' "$regressions" >&2
     printf '  Split/shrink the file, move generated/vendor artifacts out of git, or keep generated/vendor/worktree output under an exempt directory.\n' >&2
     printf '  Do not raise the baseline to accept growth; --update only ratchets downward.\n' >&2
+    if (( workflow_regressions > 0 )); then
+      print_workflow_remedy
+    fi
     return 1
   fi
 
@@ -272,7 +339,11 @@ run_self_test() {
   git -C "$repo" init -q
 
   local old_threshold="$THRESHOLD_BYTES"
+  local old_headroom="$WORKFLOW_HEADROOM_BYTES"
   THRESHOLD_BYTES=16
+  # Scaled to the synthetic 16-byte threshold: 4 bytes here plays the role the
+  # production 1024 bytes plays against 131072 (issue #2134).
+  WORKFLOW_HEADROOM_BYTES=4
 
   write_bytes 24 "$repo/large.txt"
   write_bytes 8 "$repo/small.txt"
@@ -351,7 +422,76 @@ run_self_test() {
     printf '   -> FAIL as expected\n\n'
   fi
 
+  # --- issue #2134: workflow headroom + remedy message -----------------------
+  # Restore the tree the earlier cases left over-baseline, so every verdict
+  # below is caused by the workflow file under test and nothing else.
+  write_bytes 20 "$repo/large.txt"
+  mkdir -p "$repo/.github/workflows"
+
+  printf '== self-test: a workflow with headroom passes ==\n'
+  write_bytes 11 "$repo/.github/workflows/roomy.yml" # headroom 5 >= 4
+  git -C "$repo" add .github/workflows/roomy.yml
+  if check_tree "$repo" "$baseline"; then
+    printf '   -> PASS as expected\n\n'
+  else
+    printf '   -> UNEXPECTED FAIL: a workflow with headroom was rejected\n\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  printf '== self-test: a workflow inside the headroom margin fails with the remedy ==\n'
+  # 13 bytes under a 16-byte threshold: still UNDER the cap (the plain ratchet
+  # is happy) but only 3 bytes of room, below the 4-byte margin. This is the
+  # #2134 state tests.yml was in at 271 bytes.
+  write_bytes 13 "$repo/.github/workflows/roomy.yml"
+  local headroom_out
+  headroom_out="$(check_tree "$repo" "$baseline" 2>&1)" && headroom_out=""
+  if [[ -z "$headroom_out" ]]; then
+    printf '   -> UNEXPECTED PASS: a workflow 3 bytes under the cap was accepted\n\n' >&2
+    failures=$((failures + 1))
+  elif ! grep -q 'WORKFLOW HEADROOM .*roomy.yml' <<<"$headroom_out"; then
+    printf '   -> UNEXPECTED: failed, but not with the headroom diagnosis\n%s\n\n' "$headroom_out" >&2
+    failures=$((failures + 1))
+  elif ! grep -q 'extract its inline `run: |` shell into a scripts/\*\.sh' <<<"$headroom_out"; then
+    printf '   -> UNEXPECTED: headroom failure did not print the remedy\n%s\n\n' "$headroom_out" >&2
+    failures=$((failures + 1))
+  elif ! grep -q 'Do NOT delete explanatory comments' <<<"$headroom_out"; then
+    printf '   -> UNEXPECTED: remedy did not warn against deleting comments\n%s\n\n' "$headroom_out" >&2
+    failures=$((failures + 1))
+  else
+    printf '   -> FAIL as expected, with the headroom diagnosis + remedy\n\n'
+  fi
+
+  printf '== self-test: an oversized workflow also gets the remedy ==\n'
+  write_bytes 24 "$repo/.github/workflows/roomy.yml"
+  local oversized_out
+  oversized_out="$(check_tree "$repo" "$baseline" 2>&1)" && oversized_out=""
+  if [[ -z "$oversized_out" ]]; then
+    printf '   -> UNEXPECTED PASS on an oversized workflow\n\n' >&2
+    failures=$((failures + 1))
+  elif ! grep -q 'NEW oversized .*roomy.yml' <<<"$oversized_out"; then
+    printf '   -> UNEXPECTED: failed, but not as a NEW oversized workflow\n%s\n\n' "$oversized_out" >&2
+    failures=$((failures + 1))
+  elif ! grep -q 'extract its inline `run: |` shell into a scripts/\*\.sh' <<<"$oversized_out"; then
+    printf '   -> UNEXPECTED: oversized workflow failure did not print the remedy\n%s\n\n' "$oversized_out" >&2
+    failures=$((failures + 1))
+  else
+    printf '   -> FAIL as expected, with the remedy\n\n'
+  fi
+
+  printf '== self-test: a non-workflow file inside the margin is unaffected ==\n'
+  git -C "$repo" rm -q -f --cached .github/workflows/roomy.yml
+  rm -f "$repo/.github/workflows/roomy.yml"
+  write_bytes 13 "$repo/near-cap.txt" # 3 bytes of room, but not a workflow
+  git -C "$repo" add near-cap.txt
+  if check_tree "$repo" "$baseline"; then
+    printf '   -> PASS as expected (the margin is workflow-only)\n\n'
+  else
+    printf '   -> UNEXPECTED FAIL: the headroom margin leaked to a source file\n\n' >&2
+    failures=$((failures + 1))
+  fi
+
   THRESHOLD_BYTES="$old_threshold"
+  WORKFLOW_HEADROOM_BYTES="$old_headroom"
 
   if (( failures > 0 )); then
     printf 'SELF-TEST FAILED: %d case(s) behaved incorrectly.\n' "$failures" >&2

--- a/scripts/check-unit-gate-wiring.sh
+++ b/scripts/check-unit-gate-wiring.sh
@@ -63,6 +63,14 @@ DEFAULT_WORKFLOW="$ROOT_DIR/.github/workflows/tests.yml"
 GATE_JOB="unit-gate"
 GATE_CHECK_NAME="Unit tests"
 
+# Issue #2134: `main`'s ruleset requires TWO literal check names, and C1 only
+# ever pinned one. The second belonged to a job listed in EXEMPT_JOBS below with
+# its check name written in a COMMENT — so renaming it (or, as #2134 refactors
+# the workflow for size, moving/retitling it) would have silently unblocked
+# `Python utility tests (pocketshell)` with every guard here still green.
+PYTHON_JOB="python"
+PYTHON_CHECK_NAME="Python utility tests (pocketshell)"
+
 # Jobs that are deliberately NOT part of the `Unit tests` required check.
 # Each one is either its own required context or a batched heavy lane.
 EXEMPT_JOBS=(
@@ -149,6 +157,18 @@ check_workflow() {
   [ -n "$gate_name" ] || fail "C1: \`$GATE_JOB\` has no \`name:\`"
   if [ "$gate_name" != "$GATE_CHECK_NAME" ]; then
     fail "C1: \`$GATE_JOB\` is named '$gate_name', but branch protection requires the literal check name '$GATE_CHECK_NAME'. Renaming it silently demotes every unit-lane guard to non-blocking."
+  fi
+
+  # --- C10: the OTHER ruleset-visible check name (issue #2134) ------------
+  printf '%s\n' "$all_jobs" | grep -qx "$PYTHON_JOB" ||
+    fail "C10: the \`$PYTHON_JOB\` job is gone from $workflow; the required \`$PYTHON_CHECK_NAME\` check has no owner"
+  local python_block python_name
+  python_block="$(job_block "$workflow" "$PYTHON_JOB")"
+  [ -n "$python_block" ] || fail "C10: could not read the \`$PYTHON_JOB\` block out of $workflow"
+  python_name="$(printf '%s\n' "$python_block" | sed -n 's/^    name:[[:space:]]*\(.*[^[:space:]]\)[[:space:]]*$/\1/p' | head -1)"
+  [ -n "$python_name" ] || fail "C10: \`$PYTHON_JOB\` has no \`name:\`"
+  if [ "$python_name" != "$PYTHON_CHECK_NAME" ]; then
+    fail "C10: \`$PYTHON_JOB\` is named '$python_name', but branch protection requires the literal check name '$PYTHON_CHECK_NAME'. Renaming it makes the required check unsatisfiable and blocks every merge."
   fi
 
   # --- C2/C3: the needs list ---------------------------------------------
@@ -260,6 +280,7 @@ a step to that job instead."
   fi
 
   echo "OK: \`$GATE_JOB\` is named '$GATE_CHECK_NAME' and its three lists agree."
+  echo "OK: \`$PYTHON_JOB\` is named '$PYTHON_CHECK_NAME' (the second required check)."
   echo "    needs      : $(printf '%s' "$needs" | tr '\n' ' ')"
   echo "    env reads  : $(printf '%s' "$env_vars" | tr '\n' ' ')"
   echo "    loop checks: $(printf '%s' "$loop_vars" | tr '\n' ' ')"
@@ -272,7 +293,7 @@ a step to that job instead."
 # for the intended reason. The pass count is asserted at the end, so the
 # anti-vacuous guard cannot itself pass vacuously.
 
-SELFTEST_EXPECTED_CASES=11
+SELFTEST_EXPECTED_CASES=12 # 11 + case 4b (the second required check name, #2134)
 selftest_passed=0
 selftest_failed=0
 # Overridden per case so C9's scan can be pointed at a sandbox checkout instead
@@ -374,6 +395,19 @@ self_test() {
   ' "$src" > "$m4"
   cmp -s "$src" "$m4" && st_bad "4 mutation did not apply" || \
     expect_red "4 gate renamed" "C1" "$m4"
+
+  # Case 4b (issue #2134) — the OTHER required check renamed. Same silent-gate
+  #          class as case 4, on the check C1 never covered.
+  local m4b="$sandbox/m4b.yml"
+  awk '
+    /^  python:$/ { inpy = 1 }
+    inpy && /^    name: Python utility tests \(pocketshell\)$/ {
+      print "    name: Python tests"; inpy = 0; next
+    }
+    { print }
+  ' "$src" > "$m4b"
+  cmp -s "$src" "$m4b" && st_bad "4b mutation did not apply" || \
+    expect_red "4b python required check renamed" "C10" "$m4b"
 
   # Case 5 — crossed wires: the var names swapped between two real jobs. Every
   #          list still "agrees" as a set; only the pairing is wrong.

--- a/scripts/ci-emulator-free-disk.sh
+++ b/scripts/ci-emulator-free-disk.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ci-emulator-free-disk.sh — reclaim runner disk before the AVD is created.
+#
+# Extracted VERBATIM out of the `Free disk space for the AVD` step of
+# .github/workflows/tests.yml's `emulator-journey` job (issue #2134). The step
+# body and the rationale below are byte-identical to what ran inline; only their
+# home moved, so `tests.yml` stops being ~270 bytes from the 128 KiB
+# oversized-file guard. The workflow now calls this file directly.
+#
+# The inline step ran under Actions' DEFAULT shell, `bash -e {0}` — errexit was
+# already on before the body's own `set -uo pipefail`. `set -e` here reproduces
+# that exactly, and the body keeps its own `set -uo pipefail` line unchanged, so
+# every `|| true` in it still guards the same thing it always did.
+set -e
+
+# Issue #760: the AVD create intermittently FATAL-ed with
+# "Not enough space to create userdata partition. Available: 6957 MB,
+# need 7372 MB" — pure runner disk pressure, not a test failure. The
+# ubuntu-latest image ships ~30 GB of preinstalled SDKs/toolchains we do
+# not use for this job (.NET, Haskell/GHC, the bundled Android NDK, the
+# large CodeQL/boost caches). Reclaim them BEFORE the emulator-runner
+# creates the AVD so the userdata partition always fits, then print the
+# free space so a future disk regression is visible in the log. The `|| true`
+# guards keep the step green if a path is already gone on a newer image.
+#
+# Issue #771 (round-3, PROVEN ROOT CAUSE): the original #760 version also
+# ran
+#     sudo rm -rf "$AGENT_TOOLSDIRECTORY"   # == /opt/hostedtoolcache
+# which DELETED the JDK that `actions/setup-java@v5` installs under
+# `/opt/hostedtoolcache/Java_*` and that `JAVA_HOME` points into
+# (e.g. /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/x64).
+# After that delete, EVERY Java tool died with
+#     ERROR: JAVA_HOME is set to an invalid directory: …
+# so the runner's sdkmanager (and the #771 freshly-reinstalled copy)
+# crashed instantly and the emulator never booted. The cmdline-tools were
+# never the real problem — the missing JDK was. Fix: prune the OTHER
+# tool-caches under $AGENT_TOOLSDIRECTORY but PRESERVE the directory the
+# live JAVA_HOME resolves into, so the active JDK survives.
+set -uo pipefail
+echo "::group::Disk before cleanup"
+df -h /
+echo "::endgroup::"
+sudo rm -rf /usr/share/dotnet || true
+sudo rm -rf /usr/local/lib/android/sdk/ndk || true
+sudo rm -rf /opt/ghc /usr/local/.ghcup || true
+sudo rm -rf /usr/local/share/boost || true
+sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+# Prune unused tool-caches under $AGENT_TOOLSDIRECTORY but KEEP the
+# active JDK that JAVA_HOME depends on (issue #771). Resolve the
+# top-level tool-cache subdir the live JAVA_HOME lives in (e.g.
+# `Java_Temurin-Hotspot_jdk`) and exclude exactly that one, so the
+# exact JDK setup-java installed survives even across version bumps.
+if [[ -n "${AGENT_TOOLSDIRECTORY:-}" && -d "${AGENT_TOOLSDIRECTORY:-}" ]]; then
+  keep_dir=""
+  if [[ -n "${JAVA_HOME:-}" && "$JAVA_HOME" == "$AGENT_TOOLSDIRECTORY"/* ]]; then
+    # First path segment of JAVA_HOME relative to the tool-cache root.
+    rel="${JAVA_HOME#"$AGENT_TOOLSDIRECTORY"/}"
+    keep_dir="${rel%%/*}"
+  fi
+  echo "Pruning $AGENT_TOOLSDIRECTORY, keeping active JDK dir: '${keep_dir:-<none>}'"
+  if [[ -n "$keep_dir" ]]; then
+    sudo find "$AGENT_TOOLSDIRECTORY" -mindepth 1 -maxdepth 1 \
+      ! -name "$keep_dir" -exec rm -rf {} + || true
+  else
+    # No JAVA_HOME under the tool-cache (unexpected): leave the dir
+    # intact rather than risk deleting the JDK. The deletions above
+    # plus docker prune already free far more than the 9000 MB guard.
+    echo "JAVA_HOME not under \$AGENT_TOOLSDIRECTORY; leaving it intact to protect the JDK."
+  fi
+fi
+sudo docker image prune -af || true
+echo "::group::Disk after cleanup"
+df -h /
+echo "::endgroup::"
+# Confirm the active JDK survived the prune (issue #771): a deleted
+# JAVA_HOME makes every Java tool fail with
+# "JAVA_HOME is set to an invalid directory" and the emulator never
+# boots. Fail NOW with an explicit infra classification if it's gone.
+if [[ -n "${JAVA_HOME:-}" && ! -x "$JAVA_HOME/bin/java" ]]; then
+  echo "::error title=EMULATOR INFRA UNAVAILABLE::JAVA_HOME=$JAVA_HOME has no bin/java after disk cleanup; the JDK was deleted (issue #771 regression guard). This is an infra setup error, not a test failure."
+  exit 1
+fi
+avail_mb="$(df -m --output=avail / | tail -1 | tr -d ' ')"
+echo "Available on / after cleanup: ${avail_mb} MB"
+# The AVD userdata partition needs ~7372 MB; require a safe margin so
+# the create cannot FATAL on disk. If it still can't be freed, fail
+# NOW with an explicit infra classification rather than letting the
+# emulator-runner FATAL deeper in with a confusing message.
+if [[ "$avail_mb" -lt 9000 ]]; then
+  echo "::error title=EMULATOR INFRA UNAVAILABLE::Only ${avail_mb} MB free on / after cleanup; the AVD userdata partition needs ~7372 MB. This is a runner-disk infra shortage (issue #760), not a test failure."
+  exit 1
+fi

--- a/scripts/ci-emulator-repair-sdk-tools.sh
+++ b/scripts/ci-emulator-repair-sdk-tools.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# ci-emulator-repair-sdk-tools.sh — repair the hosted runner's Android cmdline-tools.
+#
+# Extracted VERBATIM out of the `Repair Android cmdline-tools + accept licenses (issue #771)` step of
+# .github/workflows/tests.yml's `emulator-journey` job (issue #2134). The step
+# body and the rationale below are byte-identical to what ran inline; only their
+# home moved, so `tests.yml` stops being ~270 bytes from the 128 KiB
+# oversized-file guard. The workflow now calls this file directly.
+#
+# The inline step ran under Actions' DEFAULT shell, `bash -e {0}` — errexit was
+# already on before the body's own `set -uo pipefail`. `set -e` here reproduces
+# that exactly, and the body keeps its own `set -uo pipefail` line unchanged, so
+# every `|| true` in it still guards the same thing it always did.
+set -e
+
+# Issue #771 — REAL root cause + fix (supersedes the earlier "warm up a
+# separate SDK copy" pre-step, which was INEFFECTIVE).
+#
+# The job dies inside the emulator-runner action's OWN "Install Android SDK"
+# step. The action runs, by name on PATH:
+#     sh -c "yes | sdkmanager --licenses > /dev/null"
+# and that exits 1 in ~10 ms — far too fast for a JVM tool that actually
+# started. The matching symptom in the previous pre-step's log was
+# `yes: standard output: Broken pipe` on EVERY attempt: `sdkmanager` exits
+# before reading a single line of stdin, so `yes` gets SIGPIPE. In other
+# words the runner image's PRE-INSTALLED `sdkmanager`
+# ($ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager) is broken on the
+# current ubuntu-24.04 image and crashes instantly. The later
+# "could not connect to TCP port 5554" is only the action's cleanup handler
+# firing after that crash — no emulator was ever started.
+#
+# Why the previous attempt did NOT work: it accepted licenses / warmed
+# packages against the SAME broken sdkmanager and threw the output away
+# (`> /dev/null 2>&1`), so it could not even tell the binary was crashing.
+# And the action does not reuse a "warmed" SDK — it re-invokes its own
+# `sdkmanager --licenses` regardless, against the same broken binary.
+#
+# Why bumping the action version does NOT help: android-emulator-runner only
+# downloads its own cmdline-tools when `$ANDROID_HOME/cmdline-tools` does NOT
+# already exist (`if (!fs.existsSync(cmdlineToolsPath))`). On the hosted
+# runner that directory exists, so EVERY action version (incl. main) skips
+# the download and uses the runner's broken pre-installed sdkmanager.
+#
+# THE FIX (targets the action's actual failing call): replace the runner's
+# broken `$ANDROID_HOME/cmdline-tools/latest` with the exact known-good
+# cmdline-tools build the action itself pins (commandlinetools build
+# 14742923). When the action then runs `sdkmanager --licenses` by name on
+# PATH, PATH resolves to THIS freshly-installed, working sdkmanager — the
+# same path the action uses — so its own license step succeeds and the AVD
+# actually boots. We also accept licenses + warm the api-34 packages with
+# the fresh tools so the action's subsequent install is a no-op.
+#
+# This step runs BEFORE any emulator/test, so a failure here can only ever
+# block the run on infra provisioning — it can NEVER turn a genuine J1/J3
+# test failure green (no #636/#638 false-green). We keep the journey suite
+# + #760 retry-once + classifier below as the sole authoritative test gate.
+set -uo pipefail
+SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/usr/local/lib/android/sdk}}"
+echo "Using SDK_ROOT=$SDK_ROOT"
+PREINSTALLED="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+
+# 1) DIAGNOSE the pre-installed sdkmanager so the next CI run proves the
+#    root cause (do NOT discard stderr this time). A working sdkmanager
+#    prints its version in well under a second; the broken one exits
+#    instantly. `|| true` keeps this purely diagnostic.
+echo "::group::Diagnose pre-installed sdkmanager (expected to be broken)"
+if [[ -x "$PREINSTALLED" ]]; then
+  echo "java -version:"; java -version 2>&1 | sed 's/^/  /' || true
+  echo "sdkmanager --version (stderr included):"
+  "$PREINSTALLED" --version 2>&1 | sed 's/^/  /' || echo "  (non-zero exit from pre-installed sdkmanager --version)"
+else
+  echo "No pre-installed sdkmanager at $PREINSTALLED"
+fi
+echo "::endgroup::"
+
+# 2) REPAIR: install the action's exact known-good cmdline-tools build
+#    over the (broken) pre-installed `latest`, so the action's own
+#    PATH-resolved `sdkmanager --licenses` runs against a working copy.
+CMDLINE_TOOLS_ZIP="commandlinetools-linux-14742923_latest.zip"
+CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/${CMDLINE_TOOLS_ZIP}"
+echo "::group::Reinstall known-good cmdline-tools (build 14742923)"
+TMP_DL="$(mktemp -d)"
+ok=""
+for attempt in 1 2 3; do
+  if curl -fsSL --retry 3 -o "$TMP_DL/$CMDLINE_TOOLS_ZIP" "$CMDLINE_TOOLS_URL"; then
+    ok="yes"; echo "Downloaded $CMDLINE_TOOLS_ZIP on attempt $attempt"; break
+  fi
+  echo "cmdline-tools download attempt $attempt failed; retrying in 5s..."
+  sleep 5
+done
+if [[ -z "$ok" ]]; then
+  echo "::error title=cmdline-tools download failed::Could not fetch ${CMDLINE_TOOLS_URL} after retries. This is a runner-network infra failure, not a test failure (issue #771)."
+  exit 1
+fi
+rm -rf "$TMP_DL/extract"
+unzip -q "$TMP_DL/$CMDLINE_TOOLS_ZIP" -d "$TMP_DL/extract"
+# The zip extracts to `cmdline-tools/`; the action expects the tools at
+# `$SDK_ROOT/cmdline-tools/latest`.
+rm -rf "$SDK_ROOT/cmdline-tools/latest"
+mkdir -p "$SDK_ROOT/cmdline-tools"
+mv "$TMP_DL/extract/cmdline-tools" "$SDK_ROOT/cmdline-tools/latest"
+SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+chmod +x "$SDKMANAGER" || true
+echo "Installed fresh sdkmanager at $SDKMANAGER"
+echo "::endgroup::"
+
+# 3) VERIFY the fresh sdkmanager actually runs. This is the load-bearing
+#    proof that the repair worked (a JVM tool that starts prints a
+#    version line in well under a second). If it still can't run, fail
+#    NOW with an explicit infra classification rather than letting the
+#    action crash deeper with the confusing "TCP port 5554" message.
+echo "::group::Verify fresh sdkmanager"
+if ! "$SDKMANAGER" --version; then
+  echo "::error title=sdkmanager still broken after repair::The freshly-installed cmdline-tools sdkmanager still failed to run (issue #771). Treat as EMULATOR INFRA UNAVAILABLE, not a test failure."
+  exit 1
+fi
+echo "::endgroup::"
+
+# 4) Accept licenses + warm the exact api-34 packages with the WORKING
+#    tools so the action's own license/install step is a no-op. Output is
+#    visible this time so a future regression is diagnosable. The `|| true`
+#    keeps these non-fatal: the action re-runs them, and the journey
+#    suite + classifier remain the authoritative test gate.
+echo "::group::Accept SDK licenses"
+yes | "$SDKMANAGER" --sdk_root="$SDK_ROOT" --licenses || true
+echo "::endgroup::"
+echo "::group::Warm up api-35 packages"
+"$SDKMANAGER" --sdk_root="$SDK_ROOT" \
+  "platform-tools" \
+  "platforms;android-35" \
+  "system-images;android-35;google_apis;x86_64" || true
+echo "::endgroup::"


### PR DESCRIPTION
`.github/workflows/tests.yml` was **271 bytes** under the 128 KiB file-size guard, so the
next workflow addition would fail regardless of content. #2117's first draft already came
in *over* the line and was caught only because it measured.

The mechanic is not the ordinary ratchet: the guard pins only files that are *already*
oversized, so `tests.yml` was unratcheted and free to grow right up until it crossed
131072 — at which point it becomes a **new** oversized file and reddens `Static guards`
inside the required `Unit tests` check, for reasons unrelated to the offending change and
invisible to Gradle-based verification.

Two inline emulator shell bodies move to `scripts/`, **verbatim** under a restored
`set -e`. **130801 → 118896 bytes; headroom 271 → 12176** (45x). No threshold change, no
baselining, no deleted checks, no deleted prose.

**It also closes a real gap found on the way:** the required check name
`Python utility tests (pocketshell)` was pinned only in a *comment*. Branch protection
matches it as a literal string, so the job could have been renamed with every guard still
green while merge gating silently stopped working. `check-unit-gate-wiring.sh` now pins it
(C10) — and on `origin/main` the old guard returns **rc=0** against a rename mutant while
the new one returns rc=1.

Reviewer verdict: **APPROVED**, with everything established independently.

- **Guard attack (conflict of interest — the implementer modified
  `check-file-size-hygiene.sh` itself):** a `cp -a` mutant root with both guard versions
  over identical trees, 8 scenarios through each. **Zero cases where the new guard is more
  permissive**; it adds exactly one fail case (a workflow inside the 1024-byte margin),
  keeps the hard cap, does not leak the margin to source files, adds no exemption, and the
  boundary is exact at 1024.
- **Independent equivalence:** the reviewer's own PyYAML model — 340 structural entries,
  124/124 steps, **0** non-`run` differences, exactly 2 sanctioned `run:` payload changes,
  both required-check job blocks byte-identical, and both extracted scripts ending with the
  inline body verbatim.
- **`set -e` semantics, observed rather than reasoned** — the subtlest risk in any
  extraction, since an inline `run:` body and a script do not fail identically: 25 injected
  single-command failures × inline-vs-extracted, comparing exit code **and executed-command
  multiset**, **125/125 identical over 5 repeats**. It then proved its own harness was not
  vacuous by deleting `set -e` from md5-verified sandbox copies → **7 DIFFs** where the
  mutant returns rc=0 past a failure.
- All five implementer mutations re-run plus a `unit-gate` control, each reddening the
  intended check. M2 (a script body line deleted) is selective: workflow equivalence stays
  green and only the verbatim-body check catches it.
- 28 guards + `git diff --check` + the Python test quoting the step name: all rc=0.

Local on the merged tree: `check-file-size-hygiene.sh` rc=0 (118896 bytes, 12176
headroom), `check-script-interpreter-hygiene.sh` rc=0, `check-unit-gate-wiring.sh` rc=0,
`check-androidtest-compile-wiring.sh` rc=0.

**Two conditions the reviewer made blocking, both satisfied/noted:**

1. The two new scripts must land `100755` — `chmod +x` in the workflow does not cover
   them. Verified in the index: both are `100755`.
2. `emulator-journey` never runs on a PR, so those two extracted steps get their **first
   real execution on the batched `main` push** after merge. Flagged deliberately rather
   than assumed.

The 22 KB `Classify emulator-journey result` step is left alone on purpose: eight guard
harnesses extract its YAML `run:` body and *execute* it as their proof, so moving it would
break all eight. Worth ~25 KiB more, and it needs its own issue.

Closes #2134