### PR TITLE
test(journey): stop the surface-failure proof typing into a lossy window (#2126)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticImeStage.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/insets/SyntheticImeStage.kt
@@ -55,12 +55,21 @@ import org.junit.Assert.assertTrue
  *
  * There is no `assumeTrue` / `assumeFalse` anywhere: an environment that cannot
  * reach the required state fails hard (F3).
+ *
+ * ## Issue #2126 — generic over the activity type
+ *
+ * This was pinned to `ComponentActivity` because every #1821 caller mounted its
+ * own content in a bare `createAndroidComposeRule<ComponentActivity>()`. The
+ * gating journey `TmuxTerminalSurfaceFailureE2eTest` needs exactly the same
+ * synthetic-IME contract on the REAL launch-owned
+ * `createAndroidComposeRule<MainActivity>()` harness, so the receiver is now
+ * generic over `A : ComponentActivity`. Nothing here reads anything beyond
+ * `ComponentActivity` (window, decor view, system services), so this is a pure
+ * widening: every existing call site infers `SyntheticImeStage<ComponentActivity>`
+ * and behaves byte-identically.
  */
-internal class SyntheticImeStage(
-    private val compose: AndroidComposeTestRule<
-        ActivityScenarioRule<ComponentActivity>,
-        ComponentActivity,
-        >,
+internal class SyntheticImeStage<A : ComponentActivity>(
+    private val compose: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
 ) {
 
     /** The synthetic keyboard height, in px on the device under test. */
@@ -79,7 +88,7 @@ internal class SyntheticImeStage(
     val density: Float
         get() = compose.density.density
 
-    private val scenario: ActivityScenario<ComponentActivity>
+    private val scenario: ActivityScenario<A>
         get() = compose.activityRule.scenario
 
     /**

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxTerminalSurfaceFailureE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxTerminalSurfaceFailureE2eTest.kt
@@ -17,8 +17,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.printToString
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -26,10 +24,14 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.insets.SyntheticImeStage
+import com.pocketshell.app.proof.signals.assertNodeFullyAboveImeOrKeyboard
 import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
-import com.pocketshell.app.proof.signals.waitForInputMethodVisible
+import com.pocketshell.app.tmux.TERMINAL_HOTKEYS_LAUNCHER_TAG
+import com.pocketshell.app.tmux.TMUX_COMPACT_BREADCRUMB_TAG
 import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_CONVERSATION_PANE_TAG
+import com.pocketshell.app.tmux.TMUX_FULL_BREADCRUMB_TAG
 import com.pocketshell.app.tmux.TMUX_FULL_CHROME_BACK_BUTTON_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
@@ -106,6 +108,101 @@ import java.io.FileOutputStream
  * nightly-extensive workflow for sibling connected tests
  * (`TmuxBracketedPasteDictationE2eTest`, `TmuxSessionWindowNavigationE2eTest`).
  * No extra fixture or port is required.
+ *
+ * # Issue #2126 — the two environment races this class used to lose
+ *
+ * This class sat in the **gating** shard-0 journey suite and failed at roughly a
+ * 17% per-run rate, with two signatures. Both are fixed here; neither was a
+ * product regression in the code under test, and neither was fixed by widening a
+ * timeout or a retry budget (#2139 rules both out explicitly).
+ *
+ * ## Signature 1 — `expected visible terminal text for large prompt echo within
+ * 180000ms`. NOT a slow device: BYTES WERE LOST.
+ *
+ * The captured failure (run 31725258187, shard 0, cold boot 2, attempt 1) is not
+ * an empty transcript. It is the whole typed prompt, shifted left by exactly two
+ * columns:
+ *
+ * ```
+ * ISSUE423-READY
+ * ~ $ SUE423-PROMPT-HEAD detail line 0 about the cable world s   <- 60 cols
+ * ession and the long dictated codex prompt that precedes the ke <- 62 cols
+ * ```
+ *
+ * The pane is 62 columns (`tmux-client-size-known cols=62 rows=58`); every
+ * continuation row is 61–62 and only the first is 60. So `ISSUE423-PROMPT-HEAD`
+ * arrived as `SUE423-PROMPT-HEAD` — the leading `IS` never reached the screen —
+ * and `contains(PROMPT_HEAD)` was therefore **unsatisfiable from ~200 ms in**.
+ * The 180 s was spent waiting for text that could never appear.
+ *
+ * The device log names the race. In EVERY run of this class, passing or failing,
+ * the ordering is the same and the test loses a coin flip inside a ~250–460 ms
+ * window:
+ *
+ * ```
+ * 19:46:03.074  Issue423SurfaceFail: timing session-row-tap->terminal-visible   <- test resumes
+ * 19:46:03.355  PsTmuxReconnect: tmux-refresh-client-size-ok  cols=62 rows=58
+ * 19:46:03.356  PsTmuxReconnect: tmux-reattach-full-viewport-reseed pane=%1 partialBlank=true
+ * ```
+ *
+ * The reveal gate paints a healed capture (which already contains the seed
+ * marker) BEFORE the attach finishes, so `waitForVisibleTerminal("initial
+ * marker")` returns while the production attach is still mid-flight. The attach
+ * then completes and issues `reseedActivePaneForReattach`, whose `capture-pane`
+ * round-trip snapshots the server grid and REPLACES the local screen with it.
+ * Any byte echoed locally after that snapshot was taken, but before it is
+ * applied, is discarded. Typing into that window is a coin flip on the SSH
+ * round-trip; two characters lost is what a lost flip looks like.
+ *
+ * The corrective is a real precondition, not a sleep:
+ * [awaitTerminalDurablyRendersTypedInput] types a uniquely-numbered probe through
+ * the SAME production `InputConnection` and requires the transcript to contain it
+ * AND to be byte-identical for a settle window before the journey types anything
+ * load-bearing. That condition is exactly the absence of the defect: a reseed can
+ * only drop characters when its snapshot DIFFERS from the local screen, and a
+ * differing snapshot necessarily mutates `transcriptText`. A clobbered probe is
+ * retyped, and the surviving-probe count is written to the artifact so a CI run
+ * says how many reseeds it absorbed. It hard-fails if the pane never becomes
+ * durably writable — there is no skip.
+ *
+ * `waitForVisibleTerminal` additionally aborts the instant the wait becomes
+ * *unsatisfiable* (the prompt's tail is on screen but its head is not), so a
+ * residual occurrence costs ~seconds and reports "the echo lost its leading
+ * characters" instead of burning 180 s and reporting a timeout that misdescribes
+ * its own cause.
+ *
+ * **The underlying reseed-vs-echo race is a real, separate product defect** (a
+ * user typing inside the first second of an attach can lose the leading
+ * characters). It lives in `TmuxSessionViewModel.reseedActivePaneForReattach`,
+ * which is owned by another lane, and is reported separately rather than patched
+ * from here. Nothing about #423's regression requires typing before the attach
+ * has settled.
+ *
+ * ## Signature 2 — `one production Show keyboard tap must make the real IME
+ * visible`. Converted to the #780 synthetic-inset model.
+ *
+ * The keyboard is CONTEXT for this journey, not its subject: the surface failure
+ * is injected through [TmuxSessionViewModel.reportTerminalSurfaceFailure], so
+ * what this class needs is the keyboard-UP *chrome and geometry*, not proof that
+ * the CI swiftshader AVD can raise a real system IME. Depending on the real IME
+ * made this class a second copy of a contract that is already owned, per-push, by
+ * `ShowKeyboardChipE2eTest` (registered in `scripts/ci-journey-suite.sh`), which
+ * establishes keyboard-down, taps exactly once, and hard-names the observed state
+ * on failure.
+ *
+ * So per F3 and #2139, the real-IME dependence is DELETED (D22 hard cut — no
+ * flag, no fallback) and replaced by [enterKeyboardUpChromeWithSyntheticIme],
+ * which dispatches a synthetic `Type.ime()` inset through the audited
+ * [SyntheticImeStage] and then HARD-asserts the PRODUCTION screen actually
+ * entered keyboard-up chrome. The read-back is not "an inset is non-zero": it is
+ * the observable behaviour change — the #184 chrome compaction
+ * (`chromeCompressed = isImeVisible` swaps the full breadcrumb for the compact
+ * one), plus the IME-only `TERMINAL_HOTKEYS_LAUNCHER_TAG` overlay being present,
+ * contained, and fully above the synthetic keyboard top.
+ *
+ * This is strictly MORE than the deleted code checked — the old version measured
+ * the chip's containment with the keyboard DOWN and never measured any control in
+ * the keyboard-up layout at all.
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxTerminalSurfaceFailureE2eTest {
@@ -124,6 +221,15 @@ class TmuxTerminalSurfaceFailureE2eTest {
     private lateinit var fixtureKey: String
     private lateinit var hostRowTag: String
     private lateinit var artifactScenario: String
+
+    /** Issue #2126: the audited #780/#1821 synthetic-IME harness. */
+    private val imeStage by lazy { SyntheticImeStage(compose) }
+
+    /** Issue #2126 evidence: probes typed before the pane held one durably. */
+    private var inputReadinessProbes: Int = 0
+
+    /** Issue #2126 evidence: probes an in-flight reattach reseed clobbered. */
+    private var inputReadinessProbesDiscarded: Int = 0
 
     private suspend fun seedBeforeLaunch() {
         fixtureKey = readFixtureKey()
@@ -163,7 +269,7 @@ class TmuxTerminalSurfaceFailureE2eTest {
         // has scrolled out of the visible viewport behind that prompt), so the
         // proof that we reattached to the SAME live pane is that the prompt
         // head reappears in the recreated surface.
-        waitForVisibleTerminal("recovered live pane") { it.contains(PROMPT_HEAD) }
+        waitForVisibleTerminal("recovered live pane") { transcriptContains(it, PROMPT_HEAD) }
         recordTiming("recreate-tap->terminal-reattached", recreateStart)
         captureViewport("issue423-05-recovered")
 
@@ -208,24 +314,56 @@ class TmuxTerminalSurfaceFailureE2eTest {
         waitForTerminalViewAttached()
         waitForVisibleTerminal("initial marker") { it.contains(INITIAL_MARKER) }
         recordTiming("session-row-tap->terminal-visible", sessionRowTapStart)
+
+        // ===== Step 2 — Prove the pane DURABLY renders typed input =====
+        // Issue #2126: the reveal gate paints a healed capture before the
+        // production attach finishes, so the marker being visible does NOT mean
+        // the terminal is ready to be typed into — the attach's
+        // `tmux-reattach-full-viewport-reseed` is still in flight and, when it
+        // lands, replaces the local screen with a server snapshot taken before
+        // the freshly-echoed bytes. This gate is what stops the load-bearing
+        // prompt below from being typed into that window. See the class KDoc.
+        awaitTerminalDurablyRendersTypedInput()
         captureViewport("issue423-01-attached")
 
-        // ===== Step 2 — Type a large multi-line prompt =====
+        // ===== Step 3 — Type a large multi-line prompt =====
         // The field report precedes the failure with a long dictated
         // prompt; reproduce the size so the resize/redraw path is under
         // load when the surface fails.
         sendLargePromptThroughTerminalInput()
-        waitForVisibleTerminal("large prompt echo") { transcript ->
-            transcript.contains(PROMPT_HEAD)
+        waitForVisibleTerminal(
+            label = "large prompt echo",
+            // Issue #2126: the echo completing WITHOUT its head is a lost-byte
+            // failure, not a slow one, and no further waiting can satisfy the
+            // predicate. Abort at once and say so, instead of spending the whole
+            // 180 s budget and reporting a timeout that misdescribes its cause.
+            //
+            // BOTH sides use the audited wrap-tolerant matcher against the pane's
+            // REAL column count. The prompt is far longer than the ~62-column
+            // grid, so `TerminalEmulator` inserts soft-wrap newlines through the
+            // middle of the tail phrase; a raw `contains` would never see it and
+            // the abort would be dead code. (The head is matched the same way for
+            // the same reason — at a different prompt column it can straddle the
+            // margin too, and a raw `contains` would then spend the whole budget
+            // on text that IS on screen.)
+            unsatisfiableWhen = { transcript ->
+                transcriptContains(transcript, PROMPT_TAIL) &&
+                    !transcriptContains(transcript, PROMPT_HEAD)
+            },
+            unsatisfiableReason = "the pane echoed the prompt's tail but its " +
+                "leading characters never reached the screen (issue #2126 " +
+                "reseed-vs-echo byte loss); waiting longer cannot satisfy this",
+        ) { transcript ->
+            transcriptContains(transcript, PROMPT_HEAD)
         }
         captureViewport("issue423-02-large-prompt")
 
-        // ===== Step 3 — Raise the real soft keyboard =====
-        // Hard-prove the causal field state before touching the failure seam:
-        // the IME is down, the production Show keyboard control is contained,
-        // exactly one real tap raises the system IME, and its non-zero inset
-        // stays stable long enough to rule out a transient frame.
-        showProductionKeyboardAndProveStableIme()
+        // ===== Step 4 — Put the screen in the keyboard-UP state =====
+        // Hard-prove the causal field state before touching the failure seam.
+        // Issue #2126: via the #780 synthetic-inset model rather than the real
+        // system IME — see the class KDoc for why, and for the read-back that
+        // makes it non-vacuous.
+        enterKeyboardUpChromeWithSyntheticIme()
 
         // Sanity: transport is Connected before we fail the surface.
         assertTrue(
@@ -233,7 +371,7 @@ class TmuxTerminalSurfaceFailureE2eTest {
             currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
         )
 
-        // ===== Step 4 — Drive a terminal-surface recovery storm =====
+        // ===== Step 5 — Drive a terminal-surface recovery storm =====
         // Same seam the screen's `onLocalTerminalError` callback uses when
         // the embedded Termux view throws during IME/resize/render. A
         // burst past the recovery-storm threshold must trip the actionable
@@ -256,6 +394,14 @@ class TmuxTerminalSurfaceFailureE2eTest {
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+        // Issue #2126: measure the actionable error in the state the field
+        // report describes — keyboard UP. The surface-failure burst tears the
+        // TerminalView out and rebuilds the column, which can trigger a window
+        // traversal that re-applies the REAL (keyboard-down) insets, so
+        // re-establish and re-assert the keyboard-up chrome rather than assuming
+        // it survived. Before #2126 these two containment checks were measured
+        // in whatever keyboard state the real IME happened to be in.
+        reassertKeyboardUpChrome("after the surface-failure burst")
         compose.assertNodeFullyWithinRoot(
             TMUX_TERMINAL_SURFACE_ERROR_TAG,
             useUnmergedTree = true,
@@ -480,22 +626,130 @@ class TmuxTerminalSurfaceFailureE2eTest {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     }
 
+    /**
+     * Waits until [predicate] holds over the visible terminal transcript.
+     *
+     * Issue #2126 adds [unsatisfiableWhen]: a predicate over the same transcript
+     * that identifies a state from which [predicate] can NEVER become true. When
+     * it holds, the wait fails immediately and reports [unsatisfiableReason]
+     * instead of running out the (deliberately generous, 180 s on CI) budget and
+     * reporting a timeout. That distinction is the whole point — the observed
+     * shard-0 failure was byte LOSS being reported as slowness, which sent triage
+     * to the emulator's frame rate rather than to the attach race that caused it.
+     */
     private fun waitForVisibleTerminal(
         label: String,
         timeoutMillis: Long = TerminalTestTimeouts.terminalVisibilityTimeoutMs(),
+        unsatisfiableWhen: (String) -> Boolean = { false },
+        unsatisfiableReason: String = "",
         predicate: (String) -> Boolean,
     ) {
         var last = ""
+        var unsatisfiable = false
+        val startedAt = SystemClock.elapsedRealtime()
         val satisfied = runCatching {
             compose.waitUntil(timeoutMillis = timeoutMillis) {
                 last = visibleTerminalText()
-                predicate(last)
+                if (predicate(last)) return@waitUntil true
+                unsatisfiable = unsatisfiableWhen(last)
+                unsatisfiable
             }
             true
         }.getOrDefault(false)
+        if (unsatisfiable && !predicate(last)) {
+            throw AssertionError(
+                "visible terminal text for $label can no longer become correct: " +
+                    "$unsatisfiableReason. Aborted after " +
+                    "${SystemClock.elapsedRealtime() - startedAt}ms of a " +
+                    "${timeoutMillis}ms budget; got:\n$last",
+            )
+        }
         assertTrue(
             "expected visible terminal text for $label within ${timeoutMillis}ms; got:\n$last",
             satisfied && predicate(last),
+        )
+    }
+
+    /**
+     * Issue #2126 — the precondition the large-prompt step needs and never had.
+     *
+     * The reveal gate paints a healed `capture-pane` (which already carries the
+     * seed marker) BEFORE the production attach finishes, so
+     * `waitForVisibleTerminal("initial marker")` returns while
+     * `reseedActivePaneForReattach` is still in flight. When that reseed's own
+     * `capture-pane` result lands it REPLACES the local screen with a server
+     * snapshot taken earlier, silently discarding any byte echoed in between.
+     *
+     * This gate proves the pane is past that, using only the production surface —
+     * text typed through the real `InputConnection`, read back off the real
+     * `TerminalEmulator` transcript:
+     *
+     *  1. type a uniquely-numbered probe;
+     *  2. require the transcript to CONTAIN it and to be BYTE-IDENTICAL for
+     *     [INPUT_SETTLE_MS].
+     *
+     * Step 2 is exactly the absence of the defect, not a proxy for it: a reseed
+     * can only drop characters when its snapshot DIFFERS from the local screen,
+     * and a differing snapshot necessarily mutates `transcriptText`. A probe that
+     * is clobbered (its leading characters eaten, so `contains` goes false) is
+     * simply retyped with a fresh number, and the discard count is recorded for
+     * the artifact so a run reports how many reseeds it absorbed.
+     *
+     * Hard-fails when the pane never becomes durably writable. There is no
+     * `assumeTrue` and no silent degradation (F3).
+     */
+    private fun awaitTerminalDurablyRendersTypedInput() {
+        val deadline = SystemClock.elapsedRealtime() + INPUT_READINESS_TIMEOUT_MS
+        var attempts = 0
+        var lastTranscript = visibleTerminalText()
+        while (SystemClock.elapsedRealtime() < deadline) {
+            attempts += 1
+            val probe = "$INPUT_PROBE_PREFIX$attempts]"
+            typeThroughTerminalInput(probe)
+
+            var stableSince = SystemClock.elapsedRealtime()
+            var previous: String? = null
+            val cycleDeadline = minOf(
+                SystemClock.elapsedRealtime() + INPUT_PROBE_CYCLE_MS,
+                deadline,
+            )
+            while (SystemClock.elapsedRealtime() < cycleDeadline) {
+                val now = SystemClock.elapsedRealtime()
+                val transcript = visibleTerminalText()
+                lastTranscript = transcript
+                if (transcript != previous) {
+                    previous = transcript
+                    stableSince = now
+                } else if (now - stableSince >= INPUT_SETTLE_MS) {
+                    // Wrap-tolerant: a retyped probe lands further along the
+                    // shell line, so probe N can straddle the right margin. A raw
+                    // `contains` would read that as "clobbered" and retype
+                    // forever, inflating the discard count with a fixture
+                    // artefact. The cheap raw check short-circuits the common
+                    // case so the extra main-thread hop is not paid per sample.
+                    if (transcript.contains(probe) || transcriptContains(transcript, probe)) {
+                        inputReadinessProbes = attempts
+                        inputReadinessProbesDiscarded = attempts - 1
+                        Log.i(
+                            LOG_TAG,
+                            "issue2126 terminal-input-readiness probes=$attempts " +
+                                "discarded=${attempts - 1}",
+                        )
+                        return
+                    }
+                    // Settled WITHOUT the probe: a reseed replaced the screen and
+                    // took the probe with it. Retype under a fresh number.
+                    break
+                }
+                SystemClock.sleep(INPUT_SAMPLE_INTERVAL_MS)
+            }
+        }
+        throw AssertionError(
+            "the tmux pane never durably rendered typed input within " +
+                "${INPUT_READINESS_TIMEOUT_MS}ms (issue #2126): $attempts probe(s) " +
+                "typed through the production InputConnection, none of which both " +
+                "appeared in the transcript and survived a ${INPUT_SETTLE_MS}ms " +
+                "byte-stable window. Last transcript:\n$lastTranscript",
         )
     }
 
@@ -506,13 +760,21 @@ class TmuxTerminalSurfaceFailureE2eTest {
         val prompt = buildString {
             append(PROMPT_HEAD)
             repeat(12) { line ->
-                append(" detail line $line about the cable world session and ")
+                append(" $PROMPT_DETAIL_PREFIX $line about the cable world session and ")
                 append("the long dictated codex prompt that precedes the keyboard tap")
             }
         }
-        prompt.chunked(8).forEach { chunk ->
+        typeThroughTerminalInput(prompt)
+    }
+
+    /**
+     * Types [text] into the attached pane through the SAME production
+     * [InputConnection] the soft keyboard commits into — no test-only input seam.
+     */
+    private fun typeThroughTerminalInput(text: String) {
+        text.chunked(TYPING_CHUNK_CHARS).forEach { chunk ->
             terminalInputConnection().commitText(chunk, 1)
-            SystemClock.sleep(20)
+            SystemClock.sleep(TYPING_CHUNK_PAUSE_MS)
         }
     }
 
@@ -529,108 +791,173 @@ class TmuxTerminalSurfaceFailureE2eTest {
         return requireNotNull(connection) { "TerminalView did not create an InputConnection" }
     }
 
-    private fun showProductionKeyboardAndProveStableIme() {
-        compose.waitUntil(timeoutMillis = 15_000) {
+    /**
+     * Issue #2126 — puts the production session screen into the keyboard-UP
+     * state the field report describes, WITHOUT depending on the CI swiftshader
+     * AVD's ability to raise a real system input-method window.
+     *
+     * The old body tapped the production Show-keyboard chip once and required the
+     * real IME to appear and hold a non-zero inset. That is a genuine contract,
+     * but it is `ShowKeyboardChipE2eTest`'s contract (also gate-wired per push),
+     * not this journey's: here the surface failure is injected through
+     * [TmuxSessionViewModel.reportTerminalSurfaceFailure], so all this journey
+     * needs from the keyboard is the keyboard-up chrome and geometry. Depending
+     * on the real IME made this class fail with
+     * `Ignoring showSoftInput() as view=…TerminalView… is not served` whenever the
+     * input connection had not been established by the time the single tap fired.
+     * D22 hard cut: the real-IME path is deleted, not flagged off.
+     *
+     * The read-back is deliberately a PRODUCTION BEHAVIOUR change, not "the inset
+     * we dispatched reads back non-zero":
+     *
+     *  - keyboard DOWN, `SHOW_KEYBOARD_CHIP_TAG` is present and contained;
+     *  - after the dispatch, the #184 chrome compaction must have happened —
+     *    `TmuxSessionScreen` derives `chromeCompressed = isImeVisible` and swaps
+     *    the full breadcrumb for the compact one — and the IME-only
+     *    `TERMINAL_HOTKEYS_LAUNCHER_TAG` overlay must be present, contained, and
+     *    fully above the synthetic keyboard top.
+     *
+     * The production screen reads the inset through `rememberHostImeBottomPx`, an
+     * `OnApplyWindowInsetsListener` on the host root, which is exactly what
+     * [SyntheticImeStage.dispatch] drives; the breadcrumb swap is the same signal
+     * `Issue796ImeRecompositionProofTest` uses to prove a synthetic inset reached
+     * THIS screen.
+     *
+     * Named mutation, RUN not argued: deleting the `imeStage.dispatch(...)` line
+     * turns both `@Test`s red here (2/2), with the breadcrumb assertion naming
+     * `compact=0 full=1`.
+     *
+     * A first draft of this used "the Show-keyboard chip must VANISH" as the
+     * read-back, reasoning that `ReservedTmuxTerminalBottomBand` wraps it in
+     * `clearAndSetSemantics {}` and declines to place it when `isImeVisible`. The
+     * emulator falsified that: with the compaction demonstrably applied
+     * (`compact_breadcrumb_nodes=1 full_breadcrumb_nodes=0`) the chip's semantics
+     * node is still present (`show_keyboard_chip_nodes=1`). Both counts are kept
+     * in the artifact as diagnostics, and neither the chip count nor the launcher
+     * count is used as the keyboard-state oracle.
+     */
+    private fun enterKeyboardUpChromeWithSyntheticIme() {
+        compose.waitUntil(timeoutMillis = KEYBOARD_CHROME_TIMEOUT_MS) {
             compose.onAllNodesWithTag(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
         compose.assertNodeFullyWithinRoot(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true)
 
-        val visibleBeforeTap = waitForInputMethodVisible(
-            scenario = compose.activityRule.scenario,
-            expected = false,
-            timeoutMs = IME_HIDE_TIMEOUT_MS,
-        )
-        assertFalse(
-            "expected the real IME to be hidden before the one production Show keyboard " +
-                "tap; observed ime_visible=$visibleBeforeTap",
-            visibleBeforeTap,
+        imeStage.startEdgeToEdge()
+        // A synthetic boundary must never be mixed with a real keyboard, and this
+        // is a hard assertion, not a skip.
+        imeStage.hideRealImeAndAssertHidden(
+            "Issue #2126: the keyboard-up state for the #423 surface-failure " +
+                "journey is synthetic (#780 model).",
         )
 
-        // Exactly one production action. Retrying would hide a broken first tap.
-        val tapStart = SystemClock.elapsedRealtime()
-        compose.onNodeWithTag(SHOW_KEYBOARD_CHIP_TAG, useUnmergedTree = true).performClick()
-        val visibleAfterTap = waitForInputMethodVisible(
-            scenario = compose.activityRule.scenario,
-            expected = true,
-            timeoutMs = IME_SHOW_TIMEOUT_MS,
-        )
-        assertTrue(
-            "one production Show keyboard tap must make the real IME visible",
-            visibleAfterTap,
-        )
+        val keyboardUpStart = SystemClock.elapsedRealtime()
+        applySyntheticKeyboardUp()
+        recordTiming("synthetic-ime-dispatch->keyboard-up-chrome", keyboardUpStart)
 
-        val stableIme = waitForStableVisibleIme()
-        assertTrue(
-            "real IME must remain visible with a non-zero bottom inset for " +
-                "${IME_STABLE_DURATION_MS}ms before the surface-failure seam; " +
-                "last visible=${stableIme.visible} bottom=${stableIme.bottomPx}px " +
-                "stable=${stableIme.stableDurationMs}ms samples=${stableIme.samples}",
-            stableIme.visible &&
-                stableIme.bottomPx > 0 &&
-                stableIme.stableDurationMs >= IME_STABLE_DURATION_MS,
-        )
-        recordTiming("show-keyboard-tap->stable-real-ime", tapStart)
         writeText(
             "issue423-03-keyboard-up-ime.txt",
             buildString {
-                appendLine("production_show_keyboard_taps=1")
-                appendLine("ime_visible_before_tap=$visibleBeforeTap")
-                appendLine("ime_visible_after_tap=$visibleAfterTap")
-                appendLine("ime_visible_stable=${stableIme.visible}")
-                appendLine("ime_bottom_px=${stableIme.bottomPx}")
-                appendLine("stable_duration_ms=${stableIme.stableDurationMs}")
-                appendLine("stable_samples=${stableIme.samples}")
+                appendLine("keyboard_up_model=synthetic-inset (issue #780 / #2126)")
+                appendLine("real_system_ime_used=false")
+                appendLine("synthetic_ime_bottom_px=${imeStage.imeBottomPx}")
+                appendLine("synthetic_nav_bar_bottom_px=${imeStage.navBarBottomPx}")
+                appendLine("synthetic_keyboard_top_px=${syntheticKeyboardTopPx()}")
+                appendLine("compact_breadcrumb_nodes=${nodeCount(TMUX_COMPACT_BREADCRUMB_TAG)}")
+                appendLine("full_breadcrumb_nodes=${nodeCount(TMUX_FULL_BREADCRUMB_TAG)}")
+                appendLine("show_keyboard_chip_nodes=${nodeCount(SHOW_KEYBOARD_CHIP_TAG)}")
+                appendLine("ime_hotkeys_launcher_nodes=${nodeCount(TERMINAL_HOTKEYS_LAUNCHER_TAG)}")
+                appendLine("input_readiness_probes=$inputReadinessProbes")
+                appendLine("input_readiness_probes_discarded=$inputReadinessProbesDiscarded")
             },
         )
         captureFullDevice("issue423-03-keyboard-up")
     }
 
-    private fun waitForStableVisibleIme(): ImeEvidence {
-        val deadline = SystemClock.elapsedRealtime() + IME_STABILITY_TIMEOUT_MS
-        var stableSince = 0L
-        var stableSamples = 0
-        var last = ImeEvidence(false, 0, 0, 0)
-
-        while (SystemClock.elapsedRealtime() < deadline) {
-            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-            val sample = readImeEvidence()
-            val now = SystemClock.elapsedRealtime()
-            if (sample.visible && sample.bottomPx > 0) {
-                if (stableSince == 0L) {
-                    stableSince = now
-                    stableSamples = 0
-                }
-                stableSamples += 1
-                val stableDuration = now - stableSince
-                last = sample.copy(
-                    stableDurationMs = stableDuration,
-                    samples = stableSamples,
-                )
-                if (stableDuration >= IME_STABLE_DURATION_MS) return last
-            } else {
-                stableSince = 0L
-                stableSamples = 0
-                last = sample
-            }
-            SystemClock.sleep(IME_SAMPLE_INTERVAL_MS)
-        }
-        return last
+    /**
+     * Re-dispatches the synthetic keyboard-up inset and re-asserts the production
+     * chrome, so a later measurement is taken in the reported state rather than
+     * in whatever state a window traversal left behind.
+     */
+    private fun reassertKeyboardUpChrome(stage: String) {
+        imeStage.hideRealImeAndAssertHidden(
+            "Issue #2126: the synthetic keyboard-up state $stage must not be " +
+                "mixed with a real IME window.",
+        )
+        applySyntheticKeyboardUp(stage)
     }
 
-    private fun readImeEvidence(): ImeEvidence {
-        var evidence = ImeEvidence(false, 0, 0, 0)
-        compose.activityRule.scenario.onActivity { activity ->
-            val insets = ViewCompat.getRootWindowInsets(activity.window.decorView)
-            evidence = ImeEvidence(
-                visible = insets?.isVisible(WindowInsetsCompat.Type.ime()) == true,
-                bottomPx = insets?.getInsets(WindowInsetsCompat.Type.ime())?.bottom ?: 0,
-                stableDurationMs = 0,
-                samples = 1,
-            )
+    private fun applySyntheticKeyboardUp(stage: String = "before the surface-failure burst") {
+        imeStage.dispatch(imeBottomPx = imeStage.imeBottomPx, requireExtraWindowRoot = false)
+
+        // Read-back 1 — the #184 chrome compaction. This is the assertion that
+        // fails if the dispatch never reached the production composition, and it
+        // is what makes everything measured afterwards non-vacuous.
+        //
+        // `TmuxSessionScreen` derives `chromeCompressed = isImeVisible` (which
+        // comes from the real `rememberHostImeBottomPx` decor listener that
+        // `dispatch` drives) and swaps the FULL breadcrumb for the COMPACT one.
+        // A test cannot fake that swap: it is production state, not a value we
+        // wrote. Same signal `Issue796ImeRecompositionProofTest` uses to prove a
+        // synthetic inset reached this exact screen.
+        val compacted = waitForCondition(KEYBOARD_CHROME_TIMEOUT_MS) {
+            nodeCount(TMUX_COMPACT_BREADCRUMB_TAG) > 0 && nodeCount(TMUX_FULL_BREADCRUMB_TAG) == 0
         }
-        return evidence
+        assertTrue(
+            "the synthetic ime() inset must drive the PRODUCTION keyboard-up " +
+                "state $stage: TmuxSessionScreen sets chromeCompressed = " +
+                "isImeVisible and swaps the full breadcrumb for the #184 compact " +
+                "one, so '$TMUX_COMPACT_BREADCRUMB_TAG' must be present and " +
+                "'$TMUX_FULL_BREADCRUMB_TAG' gone; observed compact=" +
+                "${nodeCount(TMUX_COMPACT_BREADCRUMB_TAG)} full=" +
+                "${nodeCount(TMUX_FULL_BREADCRUMB_TAG)}. " +
+                "syntheticImeBottomPx=${imeStage.imeBottomPx}",
+            compacted,
+        )
+
+        // Read-back 2 — the IME-only launcher overlay is present, contained, and
+        // reachable ABOVE the synthetic keyboard (F2/F3 containment, never a bare
+        // assertIsDisplayed()).
+        val launcherPresent = waitForCondition(KEYBOARD_CHROME_TIMEOUT_MS) {
+            nodeCount(TERMINAL_HOTKEYS_LAUNCHER_TAG) > 0
+        }
+        assertTrue(
+            "the IME-only terminal hotkeys launcher must be composed in the " +
+                "keyboard-up state $stage; observed " +
+                "${nodeCount(TERMINAL_HOTKEYS_LAUNCHER_TAG)} node(s)",
+            launcherPresent,
+        )
+        compose.assertNodeFullyWithinRoot(TERMINAL_HOTKEYS_LAUNCHER_TAG, useUnmergedTree = true)
+        compose.assertNodeFullyAboveImeOrKeyboard(
+            tag = TERMINAL_HOTKEYS_LAUNCHER_TAG,
+            keyboardTopPx = syntheticKeyboardTopPx(),
+            useUnmergedTree = true,
+        )
+    }
+
+    /**
+     * Top edge of the synthetic keyboard in `boundsInRoot` coordinates. The
+     * window is not resized by the keyboard (#887 `SOFT_INPUT_ADJUST_NOTHING`),
+     * so the keyboard intrudes into the root by `ime - navBars`.
+     */
+    private fun syntheticKeyboardTopPx(): Float {
+        val root = compose.onRoot().fetchSemanticsNode().boundsInRoot
+        val intrusion = (imeStage.imeBottomPx - imeStage.navBarBottomPx).coerceAtLeast(0)
+        return root.bottom - intrusion
+    }
+
+    private fun nodeCount(tag: String): Int =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().size
+
+    /** Bounded poll; returns `false` on timeout so every caller can hard-assert. */
+    private fun waitForCondition(timeoutMs: Long, condition: () -> Boolean): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (runCatching(condition).getOrDefault(false)) return true
+            SystemClock.sleep(INPUT_SAMPLE_INTERVAL_MS)
+        }
+        return runCatching(condition).getOrDefault(false)
     }
 
     private fun navigateFromActiveSurfaceErrorToHostDetail() {
@@ -691,6 +1018,36 @@ class TmuxTerminalSurfaceFailureE2eTest {
                 rowBounds.right <= rootBounds.right &&
                 rowBounds.bottom <= rootBounds.bottom,
         )
+    }
+
+    /**
+     * Wrap-tolerant `contains` over the visible transcript.
+     *
+     * Issue #2126: the pane is ~62 columns and the journey's prompt is far
+     * longer, so `TerminalEmulator` inserts soft-wrap newlines mid-phrase. A raw
+     * `String.contains` therefore mis-reports text that IS on screen, which is
+     * why this goes through the audited [TerminalTextMatcher] with the pane's
+     * REAL column count rather than a hardcoded width.
+     */
+    private fun transcriptContains(transcript: String, substring: String): Boolean =
+        TerminalTextMatcher.containsWrapTolerant(
+            transcript = transcript,
+            substring = substring,
+            terminalCols = terminalColumns(),
+        )
+
+    /** The attached pane's live grid width; 0 disables wrap collapsing. */
+    private fun terminalColumns(): Int {
+        var columns = 0
+        compose.activityRule.scenario.onActivity { activity ->
+            columns = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.mColumns
+                ?: 0
+        }
+        return columns
     }
 
     private fun visibleTerminalText(): String {
@@ -818,22 +1175,40 @@ class TmuxTerminalSurfaceFailureE2eTest {
         const val SESSION_NAME: String = "issue423-surface"
         const val INITIAL_MARKER: String = "ISSUE423-READY"
         const val PROMPT_HEAD: String = "ISSUE423-PROMPT-HEAD"
-        const val IME_HIDE_TIMEOUT_MS: Long = 5_000
-        const val IME_SHOW_TIMEOUT_MS: Long = 15_000
-        const val IME_STABILITY_TIMEOUT_MS: Long = 5_000
-        const val IME_STABLE_DURATION_MS: Long = 750
-        const val IME_SAMPLE_INTERVAL_MS: Long = 50
+
+        /**
+         * Issue #2126: a distinctive fragment of the prompt's TAIL. Its presence
+         * without [PROMPT_HEAD] means the echo completed having lost its leading
+         * characters, so the head wait is unsatisfiable and must abort at once
+         * rather than run out a 180 s budget.
+         */
+        const val PROMPT_DETAIL_PREFIX: String = "detail line"
+        const val PROMPT_TAIL: String = "$PROMPT_DETAIL_PREFIX 11 about the cable world"
+
+        /** Issue #2126: chunk size / pacing of every production commitText. */
+        const val TYPING_CHUNK_CHARS: Int = 8
+        const val TYPING_CHUNK_PAUSE_MS: Long = 20
+
+        /**
+         * Issue #2126 input-readiness gate. The observed attach tail between
+         * "seed marker visible" and the reattach reseed landing was 245–460 ms
+         * locally and ~280 ms on the CI shard, so a 1.5 s byte-stable window is
+         * several times the race it has to outlast, while the outer budget is a
+         * "this is hung, not slow" ceiling that stays far under the 300 s
+         * per-test `ci-journey-suite.sh` watchdog.
+         */
+        const val INPUT_READINESS_TIMEOUT_MS: Long = 90_000
+        const val INPUT_PROBE_CYCLE_MS: Long = 20_000
+        const val INPUT_SETTLE_MS: Long = 1_500
+        const val INPUT_SAMPLE_INTERVAL_MS: Long = 50
+        const val INPUT_PROBE_PREFIX: String = "[PS2126-PROBE-"
+
+        /** Issue #2126: presence/settle ceiling for the keyboard-up chrome. */
+        const val KEYBOARD_CHROME_TIMEOUT_MS: Long = 15_000
 
         // One past the in-app storm threshold so the error state trips
         // deterministically even if a stray transparent recovery is
         // absorbed first.
         const val SURFACE_FAILURE_BURST: Int = 6
     }
-
-    private data class ImeEvidence(
-        val visible: Boolean,
-        val bottomPx: Int,
-        val stableDurationMs: Long,
-        val samples: Int,
-    )
 }


### PR DESCRIPTION
Closes #2126

Reviewer **APPROVED**: https://github.com/alexeygrigorev/pocketshell/issues/2126#issuecomment-5307246312

## The re-diagnosis

`TmuxTerminalSurfaceFailureE2eTest` failed ~17% of runs in the **gating** shard. It was twice read as emulator frame starvation — including by me in the implementer brief. It is **byte loss**.

The reviewer did not take that on trust: it pulled the raw CI artifact and rebuilt the expected 62-column screen. The observed transcript is the expected transcript with exactly the two characters `IS` deleted and **nothing else different** (1116 vs 1114 non-space chars, first divergence at index 2). So `contains(PROMPT_HEAD)` was unsatisfiable ~200 ms in, and the remaining 179.8 s was spent waiting for text that could never appear — which presents exactly like a starved emulator.

Two corollaries, both verified independently: the `1 frame / 30 s` signal spans the dead wait (a static screen with nothing to draw — consequence, not cause), and `Failed to start Emulator console` is **not a discriminator** — the reviewer counted **28** in the GREEN shard-0 job.

**The underlying product defect is filed as #2178**: the reveal gate returns 282 ms before the attach reseed is issued, and the reseed applies a stale `capture-pane` snapshot over bytes echoed in between. Users can still lose leading characters typed within ~250 ms of an attach. This change only stops the *test* typing into that window; it touches no production file.

## Evidence (reviewer-run, this session — 42 connected runs)

| arm | result |
|---|---|
| fix intact | **14/14 green**, 28 executed, class named in all 14, no cache marker, no rc 90 |
| readiness gate deleted (M2) | **6/14 red**, all six the byte-loss shape (rows 50/54/59 vs 62; 3–12 chars lost), aborting in 2–407 ms |
| synthetic dispatch deleted (M1) | deterministic **4/4 red**, on the load-bearing read-back only |

Fisher two-tailed p ≈ **0.016** for the M2 arm. Mutant liveness by unique anchor + md5 delta + the red outcome; restored by `cp` and verified byte-exact (`4f66a259…`).

Also: `scripts/full-jvm-gate.py` rc=0 (603/603 executed, 12532 tests, 0 failures, both `:app:test*UnitTest` uncached), fresh `:app:compileDebugAndroidTestKotlin --rerun-tasks` rc=0, all four static guards rc=0.

## Judgement calls recorded rather than glossed

- **The "byte-identical for 1.5 s" argument is slightly overstated as written** — it proves absence of the defect *within* the window and extrapolates forward. The reviewer measured the margin instead of arguing it: the reseed lands at +207 ms and the gate exits at +1.81 s, on every attach in the log. Accepted with reasoning stated. Follow-up filed to anchor the gate to the `freshlySeededAndPainted` reseed event and retire the last tuned constant.
- **The real-IME contract is now single-sourced** in `ShowKeyboardChipE2eTest`. Dropping or `assume`-gating that class would silently remove the contract this change relied on when deleting the duplicate.
- The reviewer hit two off-class failures while two sibling lanes ran full JVM gates on the same box, both before any changed code. Signatures captured, 20 subsequent clean runs. One is a real shared-helper defect, filed as **#2180**.
