### PR TITLE
conversation: stop painting Live over a transcript we could not read (#2159)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue2159LiveOverEmptyPaneProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue2159LiveOverEmptyPaneProofTest.kt
@@ -1,0 +1,101 @@
+package com.pocketshell.app.tmux
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.session.AgentConversationSyncStatus
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #2159 — the pixel-level half of "Live and an empty pane cannot coexist".
+ *
+ * The maintainer photographed a green `Conversation: Live` sitting directly above
+ * "No conversation events yet." while the SAME session's Terminal showed a live
+ * Codex agent mid-turn. `Live` claims the feed is healthy and current; over an
+ * empty pane that claim is simply false, and it is the whole difference between
+ * "nothing is wrong, this agent just hasn't said anything" and "we are bound to
+ * nothing you can see".
+ *
+ * The ViewModel now stamps an honest status
+ * (`Issue2159LiveOverEmptyConversationTest` covers those state transitions), but
+ * a status is written by many call sites and this pane renders whatever it is
+ * handed. So the status row derives its display from `(status, hasEvents)` — and
+ * THIS test renders the production [TmuxConversationPane] with the exact
+ * contradiction (`syncStatus = Live`, zero events) and asserts the user is never
+ * shown the green claim.
+ *
+ * Mutation that must redden it: drop the `hasEvents = events.isNotEmpty()`
+ * argument at [TmuxConversationPane]'s `ConversationSyncStatusRow` call (or make
+ * `resolvedConversationSyncStatus` return its input unchanged) — the row goes
+ * back to "Conversation: Live" over an empty feed and the first case fails.
+ */
+@RunWith(AndroidJUnit4::class)
+class Issue2159LiveOverEmptyPaneProofTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun emptyConversationNeverRendersTheGreenLiveClaim() {
+        compose.setContent {
+            PocketShellTheme {
+                TmuxConversationPane(
+                    events = emptyList(),
+                    modifier = Modifier.fillMaxSize(),
+                    // The exact state the ViewModel used to hand this pane.
+                    syncStatus = AgentConversationSyncStatus.Live,
+                )
+            }
+        }
+        compose.waitForIdle()
+
+        // The reported screen: the empty-feed message IS shown...
+        compose.onNodeWithText("No conversation events yet.").assertIsDisplayed()
+        // ...so the status above it must NOT claim the feed is Live.
+        assertEquals(
+            "#2159: `Conversation: Live` must never render above " +
+                "\"No conversation events yet.\" — that is the maintainer's " +
+                "reported screen.",
+            0,
+            compose.onAllNodesWithText("Conversation: Live").fetchSemanticsNodes().size,
+        )
+        compose.onNodeWithText("Conversation: No messages yet").assertIsDisplayed()
+    }
+
+    @Test
+    fun aPopulatedConversationStillRendersLive() {
+        compose.setContent {
+            PocketShellTheme {
+                TmuxConversationPane(
+                    events = listOf(
+                        ConversationEvent.Message(
+                            id = "m1",
+                            agent = AgentKind.Codex,
+                            role = ConversationRole.Assistant,
+                            text = "working on it",
+                        ),
+                    ),
+                    modifier = Modifier.fillMaxSize(),
+                    syncStatus = AgentConversationSyncStatus.Live,
+                )
+            }
+        }
+        compose.waitForIdle()
+
+        // Selectivity: the fix must not swallow the genuine Live state — a feed
+        // with content still reports Live, so the mutation above reddens ONLY
+        // the empty case.
+        compose.onNodeWithText("Conversation: Live").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -525,6 +525,24 @@ public data class ConversationEventsWindow(
      * is `0` there (and is never used as a line cursor).
      */
     val tailStartLine: Long = 0L,
+    /**
+     * Issue #2159: TRUE when the host answered but produced nothing usable for a
+     * transcript that is supposed to exist — as opposed to a transcript that
+     * genuinely has no messages yet.
+     *
+     * Every transcript read runs behind `2>/dev/null || true`, so a host CLI that
+     * could not resolve the session id, errored, or is version-skewed returns an
+     * EMPTY stdout that is byte-identical to "this transcript has no events". The
+     * maintainer's Conversation tab reported a green `Live` over
+     * "No conversation events yet." while a healthy 1.7 MB / 103-event rollout was
+     * bound, because that distinction was thrown away at the read boundary.
+     *
+     * The signal is deliberately conservative: it is raised only when the source
+     * is demonstrably NON-EMPTY (its `wc -l` is > 0) yet the read yielded no
+     * parseable window at all. A genuinely empty transcript reports `false` and
+     * resolves to the honest empty state, not to a failure.
+     */
+    val sourceUnavailable: Boolean = false,
 )
 
 private const val PROCESS_TREE_SCAN_COMMAND: String =
@@ -1662,6 +1680,7 @@ public class AgentConversationRepository internal constructor(
                 // that count into its own exec via a sentinel, so the cold-open
                 // path no longer needs the separate `lineCount` round-trip.
                 tailStartLine = codex.sourceLineCount,
+                sourceUnavailable = codex.sourceUnavailable,
             )
         }
         val parser = parserFor(detection.agent)
@@ -1693,9 +1712,17 @@ public class AgentConversationRepository internal constructor(
             lines
         }
         val events = parseTranscriptTailLines(parser, detection.agent, tailRawLines.asSequence())
+        // Issue #2159: same distinction as the Codex branch. `tail` runs behind
+        // `2>/dev/null || true`, so a vanished/unreadable transcript yields an
+        // empty window that reads exactly like an empty transcript. When the
+        // source's own `wc -l` says it HAS lines and the tail came back with no
+        // content at all, the read failed — surface it instead of painting a
+        // healthy empty conversation.
+        val tailReturnedNothing = tailRawLines.none { it.isNotBlank() }
         return ConversationEventsWindow(
             events = events,
             hasMoreOlder = totalLines > rawLineBudget,
+            sourceUnavailable = totalLines > 0L && tailReturnedNothing,
             // Issue #817: the file's line count at read time is exactly the
             // `fromLineExclusive` cursor the follow-tail needs — it is the same
             // value the separate `lineCount` exec used to fetch. Thread it
@@ -1715,6 +1742,8 @@ public class AgentConversationRepository internal constructor(
         val events: List<ConversationEvent>,
         val rawLineCount: Int,
         val sourceLineCount: Long,
+        /** Issue #2159: see [ConversationEventsWindow.sourceUnavailable]. */
+        val sourceUnavailable: Boolean = false,
     )
 
     private suspend fun readCodexWindow(
@@ -1769,13 +1798,24 @@ public class AgentConversationRepository internal constructor(
             envelope = agentLogEnvelopeOrNull(plainEnvelopeOutput)
         }
         if (envelope == null) {
-            if (envelopeOutput.isNotBlank()) {
-                diagnostic(
-                    "agent-log output had non-blank lines but no JSON envelope carrying " +
-                        "`lines` (preamble/format drift) — returning no messages",
-                )
-            }
-            return CodexWindow(emptyList(), 0, sourceLineCount)
+            // Issue #2159: the host answered with no envelope at all. For a
+            // source whose `wc -l` says it HAS lines that is a failed read
+            // (unresolvable session id / CLI error / version skew — all swallowed
+            // by `2>/dev/null || true`), NOT an empty transcript. Reporting it as
+            // an empty-but-healthy conversation is what put a green `Live` over
+            // "No conversation events yet." on the maintainer's screen.
+            diagnostic(
+                "agent-log produced no JSON envelope carrying `lines` for " +
+                    "${detection.sourcePath} (sourceLineCount=$sourceLineCount, " +
+                    "nonBlankOutput=${envelopeOutput.isNotBlank()}) — " +
+                    "treating as an unavailable read, not an empty transcript",
+            )
+            return CodexWindow(
+                events = emptyList(),
+                rawLineCount = 0,
+                sourceLineCount = sourceLineCount,
+                sourceUnavailable = sourceLineCount > 0L,
+            )
         }
         val lines = agentLogEnvelopeLines(envelope)
         // Issue #1267: route the envelope lines through the truncation-aware

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationUiState.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationUiState.kt
@@ -26,6 +26,25 @@ public enum class AgentConversationSyncStatus {
     Stale,
     LogUnavailable,
     Retrying,
+
+    /**
+     * Issue #2159: the transcript read SUCCEEDED but the transcript carries no
+     * messages yet — a bound source with an empty feed.
+     *
+     * The maintainer's report was a green `Live` dot sitting next to
+     * "No conversation events yet." while the Terminal of the SAME session
+     * showed a live Codex mid-turn. `Live` means "the feed is healthy and
+     * current"; rendering it over an empty pane tells the user the transcript is
+     * fine when it is bound to nothing they can see. The two must not be able to
+     * disagree, so an empty feed gets its own honest, RETRYABLE status instead of
+     * borrowing `Live`'s green.
+     *
+     * This is NOT [LogUnavailable]: nothing failed. It is the "we are bound and
+     * waiting for the first message" state — a genuinely fresh agent that has not
+     * completed a turn. A read that could not be completed at all resolves to
+     * [LogUnavailable] + [ConversationLoadState.Failed] instead.
+     */
+    NoMessages,
 }
 
 /**

--- a/app/src/main/java/com/pocketshell/app/session/ConversationLoadOutcome.kt
+++ b/app/src/main/java/com/pocketshell/app/session/ConversationLoadOutcome.kt
@@ -1,0 +1,64 @@
+package com.pocketshell.app.session
+
+/**
+ * Issue #2159: the honest outcome of a Conversation transcript read.
+ *
+ * ### Why this exists
+ *
+ * The maintainer photographed the Conversation tab reporting a green
+ * `Conversation: Live` directly above "No conversation events yet.", while the
+ * SAME tmux session's Terminal showed a live Codex agent mid-turn with a full
+ * transcript. On the host the session carried `@ps_agent_kind = codex` and
+ * `@ps_agent_source_generation`, but `@ps_agent_source` was never written, so the
+ * client fell back to its same-kind selector — which DID bind the healthy rollout.
+ * The transcript READ is what came back with nothing.
+ *
+ * `Live` is a CLAIM: "the feed is healthy and current". It used to be stamped
+ * unconditionally by `markAgentTailLive`, so a read that failed — or that
+ * silently produced nothing, because every transcript read runs behind
+ * `2>/dev/null || true` and an unresolvable/errored/version-skewed host answer is
+ * an empty string — was presented as a clean, healthy, empty conversation with no
+ * retry offered. That is strictly worse than an error: it tells the user nothing
+ * is wrong.
+ *
+ * These two functions are the single decision point for "what did that read
+ * actually mean", shared by the first-open path and the reconnect-restore path so
+ * they cannot drift apart.
+ */
+
+/**
+ * The transcript freshness to report after a load completed.
+ *
+ * - [readFailed] — the read threw, or the host produced no usable window for a
+ *   source that demonstrably has content ([ConversationEventsWindow.sourceUnavailable]).
+ *   Retryable and red; the row's load state goes [ConversationLoadState.Failed]
+ *   so the screen shows the retry affordance directly.
+ * - no events — bound, nothing to show yet. Honest and retryable, never `Live`.
+ * - events present — genuinely [AgentConversationSyncStatus.Live].
+ */
+internal fun conversationSyncStatusForLoad(
+    readFailed: Boolean,
+    hasEvents: Boolean,
+): AgentConversationSyncStatus = when {
+    readFailed -> AgentConversationSyncStatus.LogUnavailable
+    !hasEvents -> AgentConversationSyncStatus.NoMessages
+    else -> AgentConversationSyncStatus.Live
+}
+
+/**
+ * The load state to report after a load completed, given the same two facts.
+ *
+ * A failed read with nothing to show is a clear, retryable [ConversationLoadState.Failed]
+ * — NOT a `Ready` feed, which is what the reconnect-restore path used to force
+ * unconditionally, erasing the failure. A failed read that still has previously
+ * restored events keeps those events readable ([ConversationLoadState.Ready]);
+ * the status carries the failure instead of blanking the pane (#1057).
+ */
+internal fun conversationLoadStateForOutcome(
+    readFailed: Boolean,
+    hasEvents: Boolean,
+): ConversationLoadState = when {
+    readFailed && !hasEvents -> ConversationLoadState.Failed
+    !hasEvents -> ConversationLoadState.Empty
+    else -> ConversationLoadState.Ready
+}

--- a/app/src/main/java/com/pocketshell/app/session/ConversationSyncStatusUi.kt
+++ b/app/src/main/java/com/pocketshell/app/session/ConversationSyncStatusUi.kt
@@ -22,13 +22,20 @@ import com.pocketshell.uikit.theme.PocketShellColors
 @Composable
 internal fun ConversationSyncStatusRow(
     syncStatus: AgentConversationSyncStatus,
+    hasEvents: Boolean = true,
     onRetry: (() -> Unit)? = null,
 ) {
-    val (label, color) = when (syncStatus) {
-        AgentConversationSyncStatus.Live -> conversationSyncStatusLabel(syncStatus) to PocketShellColors.Green
-        AgentConversationSyncStatus.Stale -> conversationSyncStatusLabel(syncStatus) to PocketShellColors.Amber
-        AgentConversationSyncStatus.LogUnavailable -> conversationSyncStatusLabel(syncStatus) to PocketShellColors.Red
-        AgentConversationSyncStatus.Retrying -> conversationSyncStatusLabel(syncStatus) to PocketShellColors.Amber
+    // Issue #2159: the row NEVER renders the raw status. `Live` over an empty
+    // feed is the reported contradiction, so the displayed status is a total
+    // function of (status, hasEvents) — no ViewModel path can put the green dot
+    // next to "No conversation events yet." again.
+    val resolved = resolvedConversationSyncStatus(syncStatus, hasEvents)
+    val (label, color) = when (resolved) {
+        AgentConversationSyncStatus.Live -> conversationSyncStatusLabel(resolved) to PocketShellColors.Green
+        AgentConversationSyncStatus.Stale -> conversationSyncStatusLabel(resolved) to PocketShellColors.Amber
+        AgentConversationSyncStatus.LogUnavailable -> conversationSyncStatusLabel(resolved) to PocketShellColors.Red
+        AgentConversationSyncStatus.Retrying -> conversationSyncStatusLabel(resolved) to PocketShellColors.Amber
+        AgentConversationSyncStatus.NoMessages -> conversationSyncStatusLabel(resolved) to PocketShellColors.Amber
     }
     Row(
         modifier = Modifier
@@ -47,7 +54,7 @@ internal fun ConversationSyncStatusRow(
             color = PocketShellColors.TextSecondary,
             fontSize = 12.sp,
         )
-        if (onRetry != null && syncStatus.canRetryAgentStream) {
+        if (onRetry != null && resolved.canRetryAgentStream) {
             PocketShellButton(
                 text = "Retry",
                 onClick = onRetry,
@@ -64,10 +71,42 @@ internal fun conversationSyncStatusLabel(syncStatus: AgentConversationSyncStatus
         AgentConversationSyncStatus.Stale -> "Stale"
         AgentConversationSyncStatus.LogUnavailable -> "Log unavailable"
         AgentConversationSyncStatus.Retrying -> "Retrying"
+        AgentConversationSyncStatus.NoMessages -> "No messages yet"
+    }
+
+/**
+ * Issue #2159: the status the user is actually shown, given the feed it sits
+ * above.
+ *
+ * The maintainer photographed a green `Conversation: Live` directly above
+ * "No conversation events yet." while the same session's Terminal showed a live
+ * Codex mid-turn. `Live` asserts the feed is healthy and current; over an empty
+ * pane that assertion is simply false, and it is the difference between "we are
+ * still resolving / there is nothing yet" and "everything is fine". The two must
+ * not be able to disagree, so the render path collapses that combination to the
+ * honest, retryable [AgentConversationSyncStatus.NoMessages].
+ *
+ * The ViewModel also stamps [AgentConversationSyncStatus.NoMessages] directly
+ * when a load completes with no events — this is the second fence, so a status
+ * written by ANY path (a seeded placeholder, a restore, a future call site)
+ * cannot reintroduce the contradiction at the pixel level.
+ */
+internal fun resolvedConversationSyncStatus(
+    syncStatus: AgentConversationSyncStatus,
+    hasEvents: Boolean,
+): AgentConversationSyncStatus =
+    if (!hasEvents && syncStatus == AgentConversationSyncStatus.Live) {
+        AgentConversationSyncStatus.NoMessages
+    } else {
+        syncStatus
     }
 
 internal val AgentConversationSyncStatus.canRetryAgentStream: Boolean
     get() = this == AgentConversationSyncStatus.Stale ||
-        this == AgentConversationSyncStatus.LogUnavailable
+        this == AgentConversationSyncStatus.LogUnavailable ||
+        // Issue #2159: an empty feed is retryable — re-resolving the source and
+        // re-reading the window is exactly the actionable next step for a pane
+        // that is bound but showing nothing.
+        this == AgentConversationSyncStatus.NoMessages
 
 internal const val CONVERSATION_SYNC_RETRY_TAG: String = "conversation_sync_retry"

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxConversationPane.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxConversationPane.kt
@@ -214,6 +214,10 @@ internal fun TmuxConversationPane(
         // maintainer asked for.
         ConversationSyncStatusRow(
             syncStatus = syncStatus,
+            // Issue #2159: the status row is told whether there is anything
+            // under it, so a green `Live` can never sit above
+            // "No conversation events yet." (the reported screen).
+            hasEvents = events.isNotEmpty(),
             onRetry = onRetryAgentStream,
         )
         // Wrap the LazyColumn in a Box so the jump-to-latest FAB can

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConversationHelpers.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionConversationHelpers.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.app.session.AgentConversationUiState
+import com.pocketshell.app.session.SessionTab
+import com.pocketshell.app.session.conversationSyncStatusForLoad
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.agents.ConversationRole
@@ -38,3 +41,79 @@ internal fun sameAgentSource(left: AgentDetection?, right: AgentDetection?): Boo
         right != null &&
         left.agent == right.agent &&
         left.sourcePath == right.sourcePath
+
+/**
+ * Issue #2159 (extracted from the [TmuxSessionViewModel] god-object per the
+ * #1047 downward ratchet): the pure reducer behind `markAgentTailLive`.
+ *
+ * [readFailed] is what makes the status honest. `Live` is a CLAIM — "the feed is
+ * healthy and current" — and it used to be stamped unconditionally, so a
+ * transcript read that failed, or that silently produced nothing (every read runs
+ * behind `2>/dev/null || true`, so an unresolvable / errored / version-skewed
+ * host answer is an empty string), painted a green dot over
+ * "No conversation events yet." while the same session's Terminal showed a live
+ * agent mid-turn. That is the maintainer's reported screen in issue #2159. The
+ * status now comes from [conversationSyncStatusForLoad].
+ */
+internal fun nextAgentTailLiveState(
+    current: AgentConversationUiState?,
+    detection: AgentDetection,
+    initialEvents: List<ConversationEvent>,
+    preserveDifferentDetection: Boolean,
+    readFailed: Boolean,
+    openTimeDefaultTab: SessionTab,
+): AgentConversationUiState {
+    fun statusFor(events: List<ConversationEvent>) =
+        conversationSyncStatusForLoad(readFailed, events.isNotEmpty())
+    // A fresh POSITIVE agent detection landed on a pane with no existing
+    // conversation row. This is the OPEN/initial-tab moment for the agent
+    // session, so the new row lands on the user's configured open-time default
+    // (#818) — Conversation by default (the black-screen cure), Terminal if the
+    // user opted out. This is NOT a mid-session yank: there is no existing row,
+    // so no tab the user is currently viewing is being changed (the #815 line is
+    // about detection/refresh on an ALREADY-open session, handled by the
+    // `current != null` branches below, which preserve the user's tab). A
+    // remembered/explicit per-session choice still wins —
+    // `seedAgentConversationFromMemory` runs first and would have created the row
+    // already if a remembered choice existed.
+    if (current == null) {
+        val events = boundedDistinctEvents(initialEvents)
+        return AgentConversationUiState(
+            detection = detection,
+            events = events,
+            selectedTab = openTimeDefaultTab,
+            syncStatus = statusFor(events),
+        )
+    }
+    if (current.detection != detection && preserveDifferentDetection) return current
+    // Issue #495: when live detection refines the SAME agent on the SAME log for
+    // this window (only confidence/sessionId drifted — e.g. a seeded reconnect
+    // verdict promoted from RecentFile to ProcessConfirmed), keep the user's
+    // selected tab. The previous unconditional reset-to-Terminal here bounced a
+    // user who was in Conversation back to Terminal on every reconnect.
+    if (current.detection != detection && sameAgentSource(current.detection, detection)) {
+        val events = boundedDistinctEvents(current.events + initialEvents)
+        return current.copy(
+            detection = detection,
+            events = events,
+            syncStatus = statusFor(events),
+        )
+    }
+    // A DIFFERENT agent (no same-source continuity) took over this pane's window.
+    // This is a detection/refresh on an ALREADY-open session, NOT an open-time
+    // event, so it must NOT yank the user onto another view in EITHER direction
+    // (#815): PRESERVE the tab the user is currently viewing rather than apply the
+    // open-time default. (Applying it here would yank a user on Terminal onto
+    // Conversation on a mid-session takeover — exactly the #815 regression.)
+    if (current.detection != detection) {
+        val events = boundedDistinctEvents(initialEvents)
+        return AgentConversationUiState(
+            detection = detection,
+            events = events,
+            selectedTab = current.selectedTab,
+            syncStatus = statusFor(events),
+        )
+    }
+    val events = boundedDistinctEvents(current.events + initialEvents)
+    return current.copy(events = events, syncStatus = statusFor(events))
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -60,6 +60,8 @@ import com.pocketshell.app.session.OLDER_PAGE_GROWTH_FACTOR
 import com.pocketshell.app.session.OPTIMISTIC_USER_MESSAGE_ID_PREFIX
 import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.session.canRetryAgentStream
+import com.pocketshell.app.session.conversationLoadStateForOutcome
+import com.pocketshell.app.session.conversationSyncStatusForLoad
 import com.pocketshell.app.session.markOptimisticFailed
 import com.pocketshell.app.startup.StartupTiming
 import com.pocketshell.app.tmux.connection.BackgroundArm
@@ -13277,7 +13279,7 @@ public class TmuxSessionViewModel @Inject constructor(
         // the `fromLineExclusive` cursor the follow-tail needs. The cold-open
         // path therefore no longer pays a separate `lineCount` SSH round-trip
         // before the read — one fewer serial exec on every fresh open.
-        var loadFailed = false
+        var readThrew = false
         val window = try {
             // Issue #828: a recorded-Claude open already fetched the first window
             // in the resolve exec — use it and skip the read round-trip.
@@ -13296,14 +13298,27 @@ public class TmuxSessionViewModel @Inject constructor(
                 cause = t,
                 reason = "initial_window_read",
             )
-            loadFailed = true
+            readThrew = true
             ConversationEventsWindow(emptyList(), hasMoreOlder = false)
         }
         if (refreshGuard != null && !isCurrentRuntime(refreshGuard)) return
+        // Issue #2159: a read that THREW and a read that returned nothing usable
+        // for a non-empty source are the SAME user-facing failure (see
+        // [ConversationLoadOutcome]). Only the second was previously invisible.
+        val loadFailed = readThrew || window.sourceUnavailable
+        if (window.sourceUnavailable) {
+            recordAgentConversationTailStatus(
+                paneId = paneId,
+                detection = detection,
+                status = AgentConversationSyncStatus.LogUnavailable,
+                cause = null,
+                reason = "initial_window_read_no_content",
+            )
+        }
         val initialEvents = window.events
         val tailStartLine = window.tailStartLine
         val markLiveAtMs = SystemClock.elapsedRealtime()
-        markAgentTailLive(paneId, detection, initialEvents)
+        markAgentTailLive(paneId, detection, initialEvents, readFailed = loadFailed)
         TmuxSessionLatencyTelemetry.record(
             name = CONVERSATION_OPEN_LATENCY_OPERATION,
             durationMs = markLiveAtMs - openStartedAtMs,
@@ -13411,6 +13426,13 @@ public class TmuxSessionViewModel @Inject constructor(
         // read failure we keep the previously-restored events (the reconnect
         // fallback) rather than blanking the pane.
         var restoreHasMoreOlder = restored.hasMoreOlderEvents
+        // Issue #2159: the restore read's OUTCOME was discarded — `loadState` was
+        // forced to Ready and `Live` was stamped unconditionally, so a failed
+        // restore rendered as a healthy empty conversation with no retry. Starts
+        // true and is cleared only by a read that actually completed:
+        // `recoverAgentConversationStartupRead` swallows the throw and returns the
+        // fallback, so "never reached the `also`" IS the failure signal.
+        var restoreFailed = true
         val initialEvents = recoverAgentConversationStartupRead(
             paneId = paneId,
             detection = detection,
@@ -13421,13 +13443,19 @@ public class TmuxSessionViewModel @Inject constructor(
                 session = session,
                 detection = detection,
                 maxMessages = FIRST_PAINT_MESSAGE_BUDGET,
-            ).also { restoreHasMoreOlder = it.hasMoreOlder }.events
+            ).also {
+                restoreHasMoreOlder = it.hasMoreOlder
+                restoreFailed = it.sourceUnavailable
+            }.events
         }
         if (!isCurrentRuntime(refreshGuard)) return
-        markRestoredAgentTailLive(paneId, detection, initialEvents)
+        markRestoredAgentTailLive(paneId, detection, initialEvents, readFailed = restoreFailed)
         updateAgentConversation(paneId) { current ->
             current.copy(
-                loadState = ConversationLoadState.Ready,
+                loadState = conversationLoadStateForOutcome(
+                    readFailed = restoreFailed,
+                    hasEvents = current.events.isNotEmpty(),
+                ),
                 hasMoreOlderEvents = restoreHasMoreOlder,
             )
         }
@@ -14645,7 +14673,20 @@ public class TmuxSessionViewModel @Inject constructor(
     private fun appendAgentEvents(paneId: String, events: List<ConversationEvent>) {
         if (events.isEmpty()) return
         updateAgentConversation(paneId) { current ->
-            current.copy(events = boundedDistinctEvents(current.events + events))
+            val merged = boundedDistinctEvents(current.events + events)
+            // Issue #2159: an honestly-empty row becomes genuinely Live the
+            // moment the tail delivers its first message.
+            val wasEmptyFeed = current.syncStatus == AgentConversationSyncStatus.NoMessages ||
+                current.loadState == ConversationLoadState.Empty
+            if (merged.isEmpty() || !wasEmptyFeed) {
+                current.copy(events = merged)
+            } else {
+                current.copy(
+                    events = merged,
+                    syncStatus = conversationSyncStatusForLoad(false, hasEvents = true),
+                    loadState = conversationLoadStateForOutcome(false, hasEvents = true),
+                )
+            }
         }
         scanAgentConversationEventsForPortOffers(paneId, events)
     }
@@ -14756,8 +14797,10 @@ public class TmuxSessionViewModel @Inject constructor(
         paneId: String,
         detection: AgentDetection,
         fallbackEvents: List<ConversationEvent>,
+        // Issue #2159: a failed restore is never stamped `Live`.
+        readFailed: Boolean = false,
     ) {
-        markAgentTailLive(paneId, detection, fallbackEvents, preserveDifferentDetection = true)
+        markAgentTailLive(paneId, detection, fallbackEvents, true, readFailed)
     }
 
     private fun markAgentTailLive(
@@ -14765,62 +14808,22 @@ public class TmuxSessionViewModel @Inject constructor(
         detection: AgentDetection,
         initialEvents: List<ConversationEvent>,
         preserveDifferentDetection: Boolean = false,
+        // Issue #2159: the read that produced [initialEvents] could not be
+        // completed. `Live` is a CLAIM and must never be stamped over it.
+        readFailed: Boolean = false,
     ) {
         _agentConversations.update { conversations ->
             val current = conversations[paneId]
-            val updated = when {
-                // A fresh POSITIVE agent detection landed on a pane with no
-                // existing conversation row. This is the OPEN/initial-tab moment
-                // for the agent session, so the new row lands on the user's
-                // configured open-time default (#818) — Conversation by default
-                // (the black-screen cure), Terminal if the user opted out. This
-                // is NOT a mid-session yank: there is no existing row, so no tab
-                // the user is currently viewing is being changed (the #815 line
-                // is about detection/refresh on an ALREADY-open session, handled
-                // by the `current != null` branches below, which preserve the
-                // user's tab). A remembered/explicit per-session choice still
-                // wins — `seedAgentConversationFromMemory` runs first and would
-                // have created the row already if a remembered choice existed.
-                current == null -> AgentConversationUiState(
-                    detection = detection,
-                    events = boundedDistinctEvents(initialEvents),
-                    selectedTab = openTimeDefaultSessionTab(),
-                    syncStatus = AgentConversationSyncStatus.Live,
-                )
-                current.detection != detection && preserveDifferentDetection -> current
-                // Issue #495: when live detection refines the SAME agent on
-                // the SAME log for this window (only confidence/sessionId
-                // drifted — e.g. a seeded reconnect verdict promoted from
-                // RecentFile to ProcessConfirmed), keep the user's selected
-                // tab. The previous unconditional reset-to-Terminal here
-                // bounced a user who was in Conversation back to Terminal on
-                // every reconnect, which is the bug this issue fixes.
-                current.detection != detection && sameAgentSource(current.detection, detection) ->
-                    current.copy(
-                        detection = detection,
-                        events = boundedDistinctEvents(current.events + initialEvents),
-                        syncStatus = AgentConversationSyncStatus.Live,
-                    )
-                // A DIFFERENT agent (no same-source continuity) took over this
-                // pane's window. This is a detection/refresh on an ALREADY-open
-                // session, NOT an open-time event, so it must NOT yank the user
-                // onto another view in EITHER direction (#815): we PRESERVE the
-                // tab the user is currently viewing rather than apply the
-                // open-time default. (The open-time default only governs the
-                // fresh-row branch above. Applying it here would yank a user on
-                // Terminal onto Conversation on a mid-session takeover — exactly
-                // the #815 regression.)
-                current.detection != detection -> AgentConversationUiState(
-                    detection = detection,
-                    events = boundedDistinctEvents(initialEvents),
-                    selectedTab = current.selectedTab,
-                    syncStatus = AgentConversationSyncStatus.Live,
-                )
-                else -> current.copy(
-                    events = boundedDistinctEvents(current.events + initialEvents),
-                    syncStatus = AgentConversationSyncStatus.Live,
-                )
-            }
+            // Issue #1555/#2159: the reducer itself is a pure, VM-state-free
+            // function in [TmuxSessionConversationHelpers].
+            val updated = nextAgentTailLiveState(
+                current = current,
+                detection = detection,
+                initialEvents = initialEvents,
+                preserveDifferentDetection = preserveDifferentDetection,
+                readFailed = readFailed,
+                openTimeDefaultTab = openTimeDefaultSessionTab(),
+            )
             if (updated == current) conversations else conversations + (paneId to updated)
         }
         // Issue #962: a live agent detection just bound to [paneId]. If that
@@ -14909,11 +14912,11 @@ public class TmuxSessionViewModel @Inject constructor(
             if (current.detection != null && !sameAgentSource(current.detection, detection)) {
                 return@updateAgentConversation current
             }
-            val nextLoadState = when {
-                failed -> ConversationLoadState.Failed
-                current.events.isEmpty() && loadedEvents.isEmpty() -> ConversationLoadState.Empty
-                else -> ConversationLoadState.Ready
-            }
+            // Issue #2159: shared with the restore path ([ConversationLoadOutcome]).
+            val nextLoadState = conversationLoadStateForOutcome(
+                readFailed = failed,
+                hasEvents = current.events.isNotEmpty() || loadedEvents.isNotEmpty(),
+            )
             current.copy(
                 loadState = nextLoadState,
                 hasMoreOlderEvents = hasMoreOlder && !failed,

--- a/app/src/test/java/com/pocketshell/app/session/Issue2159ConversationStatusInvariantTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/Issue2159ConversationStatusInvariantTest.kt
@@ -1,0 +1,89 @@
+package com.pocketshell.app.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2159 — the status the Conversation pane displays must be a TOTAL
+ * function of `(syncStatus, hasEvents)`.
+ *
+ * The maintainer's screenshot showed a green `Conversation: Live` directly above
+ * "No conversation events yet." while the same session's Terminal was rendering a
+ * live Codex agent mid-turn. `Live` asserts the feed is healthy and current, so
+ * over an empty pane it is a false claim — and it is the difference between "the
+ * agent simply hasn't spoken yet" and "we're bound to nothing".
+ *
+ * `Issue2159LiveOverEmptyConversationTest` pins the ViewModel's own state
+ * transitions; this pins the render-boundary collapse so no call site — present
+ * or future — can put the green dot back over an empty feed.
+ *
+ * Mutation that must redden this: make [resolvedConversationSyncStatus] return
+ * its `syncStatus` argument unchanged.
+ */
+class Issue2159ConversationStatusInvariantTest {
+
+    @Test
+    fun noStatusEverResolvesToLiveOverAnEmptyFeed() {
+        // Exhaustive over the enum, so a future status cannot slip through with
+        // an unchecked green dot.
+        for (status in AgentConversationSyncStatus.entries) {
+            assertNotEquals(
+                "#2159: `$status` over an EMPTY feed must not display as `Live` — " +
+                    "a green dot above \"No conversation events yet.\" is the " +
+                    "maintainer's reported screen.",
+                AgentConversationSyncStatus.Live,
+                resolvedConversationSyncStatus(status, hasEvents = false),
+            )
+        }
+    }
+
+    @Test
+    fun anEmptyLiveFeedReportsNoMessagesAndOffersARetry() {
+        val resolved = resolvedConversationSyncStatus(
+            AgentConversationSyncStatus.Live,
+            hasEvents = false,
+        )
+        assertEquals(AgentConversationSyncStatus.NoMessages, resolved)
+        assertEquals("No messages yet", conversationSyncStatusLabel(resolved))
+        assertTrue(
+            "#2159: an empty feed must offer an actionable next step (Retry).",
+            resolved.canRetryAgentStream,
+        )
+    }
+
+    @Test
+    fun aPopulatedFeedKeepsItsStatusVerbatim() {
+        // Selectivity (G6): the collapse must fire ONLY on the empty feed. If it
+        // rewrote populated rows too, the mutation above would redden this as
+        // well and the proof would be over-broad rather than targeted.
+        for (status in AgentConversationSyncStatus.entries) {
+            assertEquals(
+                "#2159: a populated feed's status must pass through untouched.",
+                status,
+                resolvedConversationSyncStatus(status, hasEvents = true),
+            )
+        }
+    }
+
+    @Test
+    fun aFailedOrStaleEmptyFeedKeepsItsOwnHonestStatus() {
+        // The empty-feed collapse must not flatten a genuine failure into the
+        // softer "no messages yet" — an unreadable log stays red + retryable.
+        assertEquals(
+            AgentConversationSyncStatus.LogUnavailable,
+            resolvedConversationSyncStatus(
+                AgentConversationSyncStatus.LogUnavailable,
+                hasEvents = false,
+            ),
+        )
+        assertEquals(
+            AgentConversationSyncStatus.Stale,
+            resolvedConversationSyncStatus(
+                AgentConversationSyncStatus.Stale,
+                hasEvents = false,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2159LiveOverEmptyConversationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2159LiveOverEmptyConversationTest.kt
@@ -1,0 +1,487 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.session.AgentConversationSyncStatus
+import com.pocketshell.app.session.ConversationLoadState
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #2159 — REPRODUCE-FIRST (G10/D33) for the maintainer's on-device report:
+ *
+ * > The Conversation tab reports `Conversation: Live` with a green dot and
+ * > renders "No conversation events yet.", while the Terminal tab of the *same*
+ * > session shows a live Codex agent mid-turn with a full transcript.
+ *
+ * This is NOT #2155 (a *stale* binding showing the previous agent's transcript).
+ * Here the pane shows **nothing at all** while a transcript demonstrably exists.
+ *
+ * ### The host state that produced it
+ *
+ * On the maintainer's box the tmux session carried `@ps_agent_kind = codex` and
+ * `@ps_agent_source_generation`, but **`@ps_agent_source` was unset** — the
+ * launch recorded the kind and minted a generation, and the detached watcher
+ * never wrote the transcript path (root-caused on the host side in
+ * `tools/pocketshell/tests/test_agents_source_target.py`). The transcript itself
+ * was healthy: 1.7 MB, 103 events, actively growing.
+ *
+ * Every fixture here therefore has `@ps_agent_source` **ABSENT** while a valid
+ * same-kind transcript **does** exist for the cwd. A happy fixture that always
+ * writes the option cannot enter this state and would prove nothing (the
+ * #847/v0.4.10 lesson).
+ *
+ * ### What the screenshot actually proves
+ *
+ * `Conversation: Live` + "No conversation events yet." is only reachable with a
+ * row whose `events` are empty and whose `loadState` is `Ready`/`Empty` —
+ * `TmuxSessionScreen` renders the "Loading conversation…" / "Failed" placeholder
+ * (never the status row) while `loadState` is `Loading`/`Failed` with no events.
+ * So a source WAS bound and the transcript READ came back with nothing, and the
+ * client laundered that into a healthy green `Live`. The reads that can come
+ * back with nothing are all silent: `pocketshell agent-log` is invoked behind
+ * `2>/dev/null || true`, so an unresolvable session id, a CLI error, or version
+ * skew all arrive as an empty envelope that is indistinguishable from "this
+ * transcript genuinely has no events yet".
+ *
+ * Class coverage (G2): source absent + transcript present; source absent +
+ * genuinely no transcript; source present but pointing at a DELETED file; and a
+ * second launch in the same session whose watcher never wrote (the #2155
+ * overlap).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue2159LiveOverEmptyConversationTest : TmuxSessionViewModelTestBase() {
+
+    private companion object {
+        const val CWD = "/home/alexey/tmp/openclaw"
+        const val TTY = "/dev/pts/12"
+        const val SESSION_ID = "\$0"
+        const val PANE = "%282"
+
+        /** The maintainer's real rollout (1.7 MB, 103 events, actively growing). */
+        const val ROLLOUT =
+            "/home/alexey/.codex/sessions/2026/08/15/rollout-2026-08-15T09-42-10-live.jsonl"
+
+        /** A same-cwd sibling rollout the pane's own process does NOT hold open. */
+        const val SIBLING =
+            "/home/alexey/.codex/sessions/2026/08/15/rollout-2026-08-15T08-00-00-sibling.jsonl"
+
+        const val KIND_SENTINEL = "@@PS_RECORDED_KIND@@"
+        const val GENERATION_SENTINEL = "@@PS_RECORDED_SOURCE_GENERATION@@"
+        const val SOURCE_SENTINEL = "@@PS_RECORDED_SOURCE@@"
+        const val CLAUDE_WINDOW_SENTINEL = "@@PS_CLAUDE_WINDOW@@"
+        const val CODEX_WINDOW_SENTINEL = "@@PS_CODEX_WINDOW@@"
+
+        /** One parseable Codex transcript event, in the shape `agent-log` emits. */
+        val TRANSCRIPT_LINE: String = """
+            {"type":"response_item","payload":{"type":"message","role":"assistant",
+            "content":[{"type":"output_text","text":"working on it"}]}}
+        """.trimIndent().replace("\n", "")
+    }
+
+    /**
+     * A fake host modelling the maintainer's box: a recorded Codex session whose
+     * `@ps_agent_source` was NEVER written, a live rollout the pane's own process
+     * holds open, and the `pocketshell agent-log` read that serves the window.
+     */
+    private class CodexHost(
+        var recordedKind: String = "codex",
+        var generation: String = "gen-1",
+        /** Raw `@ps_agent_source`; EMPTY models the option being unset. */
+        var sourceOption: String = "",
+        /** `agent|mtimeSeconds|cwd|path` rows. */
+        var candidates: String = "",
+        /** Rollouts the pane's own PIDs hold open via `/proc/<pid>/fd`. */
+        var ownedFds: List<String> = emptyList(),
+        /** The `agent-log --json` envelope; EMPTY models a read that yields nothing. */
+        var agentLogEnvelope: String = "",
+        var sourceLineCount: String = "103",
+        /** When true every transcript read throws (a transport drop mid-read). */
+        var readsThrow: Boolean = false,
+    ) : SshSession {
+        val execCommands: MutableList<String> = java.util.concurrent.CopyOnWriteArrayList()
+
+        override val isConnected: Boolean = true
+
+        private fun optionBlock(): String = buildString {
+            append(generation.trim())
+            append("\n$GENERATION_SENTINEL\n")
+            append(sourceOption.trim())
+            append("\n$SOURCE_SENTINEL\n")
+        }
+
+        override suspend fun exec(command: String): ExecResult {
+            execCommands += command
+            if (readsThrow && (
+                    command.contains(CODEX_WINDOW_SENTINEL) ||
+                        command.startsWith("wc -l < ") ||
+                        command.startsWith("tail -n ")
+                    )
+            ) {
+                throw java.io.IOException("transport dropped mid-read")
+            }
+            val stdout = when {
+                command.contains("agents kind") ->
+                    """{"results":[{"pane_id":"$PANE","agent_kind":"unknown"}]}"""
+                // The #828 single-round-trip cache-MISS open.
+                command.contains(KIND_SENTINEL) -> buildString {
+                    append(recordedKind.trim())
+                    append("\n$KIND_SENTINEL\n")
+                    append(optionBlock())
+                    append(candidates)
+                    append("\n$CLAUDE_WINDOW_SENTINEL\n")
+                }
+                // The recorded-Codex second pass: option read folded into the
+                // candidate enumeration.
+                command.contains(SOURCE_SENTINEL) -> optionBlock() + candidates
+                // `/proc/<pid>/fd` owned-rollout resolution (#819).
+                command.contains("/proc/") -> ownedFds.joinToString("\n")
+                // Host-wide `ps` snapshot, folded to the pane's tty by the caller.
+                command.startsWith("ps -eo") ->
+                    "4242 4200 ${TTY.removePrefix("/dev/")} node " +
+                        "node /home/alexey/.nvm/versions/node/v24.13.1/bin/codex " +
+                        "--dangerously-bypass-approvals-and-sandbox"
+                // The Codex window read: `wc -l` + sentinel + agent-log envelope.
+                command.contains(CODEX_WINDOW_SENTINEL) ->
+                    "${sourceLineCount.trim()}\n$CODEX_WINDOW_SENTINEL\n$agentLogEnvelope"
+                command.contains("show-options -v") && command.contains("@ps_agent_kind") ->
+                    recordedKind
+                command.startsWith("wc -l < ") -> sourceLineCount
+                command.contains(".claude") ||
+                    command.contains(".codex") ||
+                    command.contains("opencode") -> candidates
+                else -> ""
+            }
+            return ExecResult(stdout = stdout, stderr = "", exitCode = 0)
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job =
+            Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError()
+
+        override fun startShell(): SshShell = throw NotImplementedError()
+
+        override suspend fun uploadFile(file: File, remotePath: String): String =
+            error("uploadFile not used in this test")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("uploadStream not used in this test")
+
+        override fun close() = Unit
+    }
+
+    private fun nowSeconds(): Long = System.currentTimeMillis() / 1000
+
+    private fun candidateRow(path: String, ageSeconds: Long): String =
+        "codex|${nowSeconds() - ageSeconds}|$CWD|$path"
+
+    private fun envelope(vararg lines: String): String {
+        val payload = lines.joinToString(",") { org.json.JSONObject.quote(it) }
+        return """{"count": ${lines.size}, "engine": "codex", "lines": [$payload]}"""
+    }
+
+    private fun pane(
+        paneId: String = PANE,
+        windowId: String = "@0",
+        currentCommand: String = "node",
+    ): TmuxSessionViewModel.ParsedPane = TmuxSessionViewModel.ParsedPane(
+        paneId = paneId,
+        windowId = windowId,
+        sessionId = SESSION_ID,
+        title = "tmp-openclaw",
+        paneIndex = 0,
+        cwd = CWD,
+        currentCommand = currentCommand,
+        paneTty = TTY,
+        panePid = 4242L,
+        sessionName = "tmp-openclaw",
+    )
+
+    private fun TmuxSessionViewModel.connectWith(host: CodexHost) {
+        replaceClientForTest(
+            hostId = 1L,
+            hostName = "hetzner",
+            host = "135.181.114.209",
+            port = 22,
+            user = "alexey",
+            keyPath = "/keys/a",
+            sessionName = "tmp-openclaw",
+            client = FakeTmuxClient(),
+            session = host,
+        )
+        setSessionRefForTest(host)
+    }
+
+    private fun row(vm: TmuxSessionViewModel) = vm.agentConversations.value[PANE]
+
+    /**
+     * The invariant the maintainer's screenshot violates: a green `Live` next to
+     * an empty pane tells the user the feed is healthy while it is bound to
+     * nothing. Either events are present, or the status must report honestly.
+     */
+    private fun assertNoLiveOverEmptyPane(vm: TmuxSessionViewModel, context: String) {
+        val state = row(vm) ?: return
+        val rendersTheStatusRow = state.loadState != ConversationLoadState.Loading &&
+            !(state.loadState == ConversationLoadState.Failed && state.events.isEmpty())
+        val claimsLive = state.syncStatus == AgentConversationSyncStatus.Live
+        assertTrue(
+            "#2159 ($context): the Conversation must never render `Live` over an " +
+                "empty transcript — that is the reported screen. " +
+                "events=${state.events.size} loadState=${state.loadState} " +
+                "syncStatus=${state.syncStatus} source=${state.detection?.sourcePath}",
+            !(rendersTheStatusRow && claimsLive && state.events.isEmpty()),
+        )
+    }
+
+    /**
+     * THE REPORTED SYMPTOM. `@ps_agent_source` was never written, the healthy
+     * rollout is on disk and held open by the pane's own Codex process, and the
+     * host's `agent-log` read comes back with NOTHING (the silent
+     * `2>/dev/null || true` failure: unresolvable session id / CLI error /
+     * version skew).
+     *
+     * RED on base: the empty read is treated as a successful load of an empty
+     * transcript — `loadState = Empty`, `syncStatus = Live`, zero events — i.e.
+     * a green "Conversation: Live" over "No conversation events yet.".
+     */
+    @Test
+    fun aTranscriptReadThatYieldsNothingIsNotReportedAsALiveConversation() =
+        runTest(scheduler) {
+            val host = CodexHost(
+                sourceOption = "",
+                candidates = candidateRow(ROLLOUT, ageSeconds = 30),
+                ownedFds = listOf(ROLLOUT),
+                // The host answered, but with no `agent-log` envelope at all.
+                agentLogEnvelope = "",
+                sourceLineCount = "103",
+            )
+            val vm = newVm()
+            vm.connectWith(host)
+            vm.applyParsedPanesForTest(listOf(pane()))
+            advanceUntilIdle()
+
+            assertEquals(
+                "precondition: the source-absent fallback still binds the live rollout",
+                ROLLOUT,
+                row(vm)?.detection?.sourcePath,
+            )
+            assertNoLiveOverEmptyPane(vm, "agent-log read yielded no envelope")
+            // LOAD-BEARING (G6): an unreadable transcript must be actionable, not
+            // silently presented as an empty-but-healthy conversation.
+            assertEquals(
+                "#2159: a transcript read that produced nothing must resolve to a " +
+                    "FAILED load with a retry, not a clean empty state. " +
+                    "row=${row(vm)}",
+                ConversationLoadState.Failed,
+                row(vm)?.loadState,
+            )
+            assertEquals(
+                "#2159: the sync status must say the log could not be read.",
+                AgentConversationSyncStatus.LogUnavailable,
+                row(vm)?.syncStatus,
+            )
+        }
+
+    /**
+     * Criterion 2 (class coverage): with `@ps_agent_source` ABSENT and a valid
+     * same-kind transcript present, the client must fall back to its same-kind
+     * selector and bind that transcript — the contract
+     * `record_agent_source`'s docstring states.
+     *
+     * The SIBLING rollout is what makes this discriminating (G6): it shares the
+     * cwd, so "bind anything you can find" would also pass. Only honouring the
+     * pane's OWN `/proc/<pid>/fd`-held rollout binds [ROLLOUT].
+     */
+    @Test
+    fun sourceAbsentWithATranscriptPresentBindsThatTranscript() = runTest(scheduler) {
+        val host = CodexHost(
+            sourceOption = "",
+            candidates = listOf(
+                // The sibling flushed MORE recently — an mtime race would pick it.
+                candidateRow(SIBLING, ageSeconds = 1),
+                candidateRow(ROLLOUT, ageSeconds = 30),
+            ).joinToString("\n"),
+            ownedFds = listOf(ROLLOUT),
+            agentLogEnvelope = envelope(TRANSCRIPT_LINE),
+        )
+        val vm = newVm()
+        vm.connectWith(host)
+        vm.applyParsedPanesForTest(listOf(pane()))
+        advanceUntilIdle()
+
+        assertEquals(
+            "#2159: with @ps_agent_source unset the client must fall back to the " +
+                "same-kind selector and bind the pane's own live transcript.",
+            ROLLOUT,
+            row(vm)?.detection?.sourcePath,
+        )
+        assertTrue(
+            "#2159: the bound transcript's events must actually render. row=${row(vm)}",
+            (row(vm)?.events?.size ?: 0) > 0,
+        )
+        assertEquals(AgentConversationSyncStatus.Live, row(vm)?.syncStatus)
+        assertNoLiveOverEmptyPane(vm, "source absent + transcript present")
+    }
+
+    /**
+     * Class coverage (G2): `@ps_agent_source` absent AND genuinely no transcript
+     * for the cwd. Nothing may bind, and the pane must not sit on a green `Live`
+     * over an empty feed — the #894 no-flap invariant is preserved (no phantom
+     * conversation for a pane with no agent log).
+     */
+    @Test
+    fun sourceAbsentWithNoTranscriptBindsNothingAndNeverClaimsLive() = runTest(scheduler) {
+        val host = CodexHost(
+            sourceOption = "",
+            candidates = "",
+            ownedFds = emptyList(),
+            agentLogEnvelope = "",
+        )
+        val vm = newVm()
+        vm.connectWith(host)
+        vm.applyParsedPanesForTest(listOf(pane()))
+        advanceUntilIdle()
+
+        assertNull(
+            "#2159: no transcript exists, so nothing may bind.",
+            row(vm)?.detection,
+        )
+        assertNoLiveOverEmptyPane(vm, "source absent + no transcript")
+    }
+
+    /**
+     * Class coverage (G2): `@ps_agent_source` IS set for the live generation but
+     * points at a file that no longer exists (the agent's rollout was rotated /
+     * deleted), so it is not among the enumerated candidates. The exact-source
+     * match must fail SOFT into the same-kind selector and bind the transcript
+     * that IS live — never leave the pane bound to nothing.
+     */
+    @Test
+    fun recordedSourcePointingAtADeletedFileFallsBackToTheLiveTranscript() =
+        runTest(scheduler) {
+            val host = CodexHost(
+                sourceOption = "gen-1\t/home/alexey/.codex/sessions/2026/08/14/rollout-deleted.jsonl",
+                candidates = candidateRow(ROLLOUT, ageSeconds = 30),
+                ownedFds = listOf(ROLLOUT),
+                agentLogEnvelope = envelope(TRANSCRIPT_LINE),
+            )
+            val vm = newVm()
+            vm.connectWith(host)
+            vm.applyParsedPanesForTest(listOf(pane()))
+            advanceUntilIdle()
+
+            assertEquals(
+                "#2159: a recorded source naming a deleted file must degrade to the " +
+                    "same-kind selector, not strand the Conversation on nothing.",
+                ROLLOUT,
+                row(vm)?.detection?.sourcePath,
+            )
+            assertNoLiveOverEmptyPane(vm, "recorded source names a deleted file")
+        }
+
+    /**
+     * Class coverage (G2) — the #2155 overlap. A SECOND agent launch in the SAME
+     * tmux session bumps the generation and clears the option; this issue's
+     * failure is that the watcher then never writes the new one. The Conversation
+     * must re-anchor to the NEW transcript via the selector, NOT stay on the
+     * previous agent's rollout.
+     */
+    @Test
+    fun secondLaunchWhoseWatcherNeverWroteReAnchorsToTheNewTranscript() =
+        runTest(scheduler) {
+            val host = CodexHost(
+                generation = "gen-1",
+                sourceOption = "gen-1\t$SIBLING",
+                candidates = candidateRow(SIBLING, ageSeconds = 300),
+                ownedFds = listOf(SIBLING),
+                agentLogEnvelope = envelope(TRANSCRIPT_LINE),
+            )
+            val vm = newVm()
+            vm.connectWith(host)
+            vm.applyParsedPanesForTest(listOf(pane()))
+            advanceUntilIdle()
+            assertEquals(
+                "precondition: the first agent's recorded transcript binds",
+                SIBLING,
+                row(vm)?.detection?.sourcePath,
+            )
+
+            // A second agent starts in the same session: the host mints gen-2 and
+            // UNSETS @ps_agent_source. Its watcher never writes the new path —
+            // the defect this issue reports.
+            host.generation = "gen-2"
+            host.sourceOption = ""
+            host.candidates = listOf(
+                candidateRow(SIBLING, ageSeconds = 300),
+                candidateRow(ROLLOUT, ageSeconds = 5),
+            ).joinToString("\n")
+            host.ownedFds = listOf(ROLLOUT)
+            vm.applyParsedPanesForTest(listOf(pane(currentCommand = "bash")))
+            advanceUntilIdle()
+            vm.applyParsedPanesForTest(listOf(pane(currentCommand = "node")))
+            advanceUntilIdle()
+
+            assertEquals(
+                "#2159/#2155: with the new generation's source never written, the " +
+                    "Conversation must re-anchor to the NEW agent's transcript via " +
+                    "the selector — serving $SIBLING is the stale-binding symptom.",
+                ROLLOUT,
+                row(vm)?.detection?.sourcePath,
+            )
+            assertNoLiveOverEmptyPane(vm, "second launch, watcher never wrote")
+        }
+
+    /**
+     * Class coverage (G2): the transcript read THROWS (a transport drop mid-read).
+     * The row must resolve to a clear, retryable failure — never a green `Live`
+     * over an empty pane.
+     */
+    @Test
+    fun aTranscriptReadThatThrowsIsNotReportedAsALiveConversation() = runTest(scheduler) {
+        val host = CodexHost(
+            sourceOption = "",
+            candidates = candidateRow(ROLLOUT, ageSeconds = 30),
+            ownedFds = listOf(ROLLOUT),
+            readsThrow = true,
+        )
+        val vm = newVm()
+        vm.connectWith(host)
+        vm.applyParsedPanesForTest(listOf(pane()))
+        advanceUntilIdle()
+
+        assertNotNull("precondition: the source still binds", row(vm)?.detection)
+        assertNoLiveOverEmptyPane(vm, "transcript read threw")
+        assertEquals(
+            "#2159: a read that threw must resolve to a retryable failure.",
+            AgentConversationSyncStatus.LogUnavailable,
+            row(vm)?.syncStatus,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelAgentTailTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelAgentTailTest.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -400,7 +401,16 @@ class TmuxSessionViewModelAgentTailTest : TmuxSessionViewModelTestBase() {
         advanceUntilIdle()
 
         assertEquals(1, retrySession.tailCalls)
-        assertEquals(AgentConversationSyncStatus.Live, vm.agentConversations.value["%0"]!!.syncStatus)
+        // Issue #2159: this row's transcript read returns NOTHING, so the honest
+        // post-retry status is `NoMessages` — not `Live`. Asserting `Live` here
+        // was asserting the reported defect: a green "the feed is healthy and
+        // current" dot above "No conversation events yet.". What the retry must
+        // prove is unchanged and still asserted: it left the Retrying state and
+        // did not land on a failure.
+        val retriedStatus = vm.agentConversations.value["%0"]!!.syncStatus
+        assertEquals(AgentConversationSyncStatus.NoMessages, retriedStatus)
+        assertNotEquals(AgentConversationSyncStatus.Retrying, retriedStatus)
+        assertNotEquals(AgentConversationSyncStatus.LogUnavailable, retriedStatus)
         assertTrue(vm.connectionStatus.value is TmuxSessionViewModel.ConnectionStatus.Connected)
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelTest.kt
@@ -73,7 +73,6 @@ import kotlin.time.Duration.Companion.seconds
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -1049,7 +1048,8 @@ class TmuxSessionViewModelTest : TmuxSessionViewModelTestBase() {
             2,
             session.tailCalls,
         )
-        assertEquals(AgentConversationSyncStatus.Live, vm.agentConversations.value["%0"]?.syncStatus)
+        // #2159
+        assertEquals(AgentConversationSyncStatus.NoMessages, vm.agentConversations.value["%0"]?.syncStatus)
     }
 
     @Test

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -156,6 +156,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.projects.RootProjectAddSheetKeyboardLayoutTest"  # #1742 deterministic modal-root IME layout proof
   "com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest"  # #898 reviewer Blocker B): the in-session + New session rich-sheet
   "com.pocketshell.app.tmux.TmuxCreateAfterAttachFailureDockerTest"  # #1832 failed attach then Create must fail visibly, never silently create nothing
+  "com.pocketshell.app.tmux.Issue2159LiveOverEmptyPaneProofTest"  # #2159 D33/G10: the production conversation pane must never render a green "Conversation: Live" above "No conversation events yet." (the maintainer's reported screen), while a populated feed still reports Live
   "com.pocketshell.app.composer.Issue1622ComposerSheetGeometryProofTest"  # #1622 #567 #615 #682 #765 #790 #801 D33/G10: the REAL ModalBottomSheet's standing chrome (top-inset dead pad + 48dp default handle) and the double-subtracted keyboard budget, measured through a synthetic status-bar/ime inset dispatched into the modal's own window — the AVD cannot reproduce the device inset unaided
   "com.pocketshell.app.composer.PromptComposerImeSquishProofTest"  # #736 #567 #638 #657 follow-up to the review): the composer keyboard-up SQUISH re…
   "com.pocketshell.app.composer.PromptComposerLongDraftCaretVisibleTest"  # #1619/#765 D33/G10: synthetic + real-IME long-draft caret containment above sticky controls

--- a/tools/pocketshell/src/pocketshell/agents.py
+++ b/tools/pocketshell/src/pocketshell/agents.py
@@ -552,6 +552,7 @@ def _watch_and_record_agent_source(
     cwd: str,
     started_at: str,
     generation: str,
+    target: str,
     timeout_seconds: str = "20",
 ) -> int:
     """Watch for this launch's transcript and record it on the tmux session.
@@ -559,7 +560,28 @@ def _watch_and_record_agent_source(
     The wrapper starts this helper immediately before ``execvpe``. The agent
     process has not minted its transcript id yet, so this runs in a detached
     host-side child and records ``@ps_agent_source`` once the source appears.
+
+    ``target`` is the tmux ``-t`` target of the session this launch belongs to,
+    resolved by the PARENT (issue #2159). It is not optional and there is no
+    ambient-inference fallback (D22 — hard cut).
+
+    Both tmux calls used to omit ``-t`` and let tmux infer "the current session"
+    from the child's environment. That inference is only correct while
+    ``$TMUX_PANE`` survives into the detached child; without it tmux silently
+    resolves the **most-recently-used session on the server**, which produced
+    the maintainer's exact host state: the guard read another session's
+    generation, saw a mismatch, and gave up without writing — leaving
+    ``@ps_agent_source_generation`` set (written by the parent, whose inference
+    IS authoritative) and ``@ps_agent_source`` absent. The other direction is
+    worse: the write itself could land on an unrelated session, handing it a
+    bogus recorded transcript (the #819/#2155 wrong-source class).
+
+    ``-u`` forces a UTF-8 tmux client on the read (#2160): a client without a
+    UTF-8 locale sanitises every byte it prints, so a bare read is only correct
+    on hosts whose environment happens to carry one.
     """
+    if not target:
+        return 2
     try:
         started = float(started_at)
         timeout = float(timeout_seconds)
@@ -571,7 +593,15 @@ def _watch_and_record_agent_source(
         if source:
             try:
                 current_generation = subprocess.run(
-                    ["tmux", "show-options", "-v", "@ps_agent_source_generation"],
+                    [
+                        "tmux",
+                        "-u",
+                        "show-options",
+                        "-v",
+                        "-t",
+                        target,
+                        "@ps_agent_source_generation",
+                    ],
                     check=False,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.DEVNULL,
@@ -580,7 +610,14 @@ def _watch_and_record_agent_source(
                 if current_generation != generation:
                     return 1
                 subprocess.run(
-                    ["tmux", "set-option", "@ps_agent_source", f"{generation}\t{source}"],
+                    [
+                        "tmux",
+                        "set-option",
+                        "-t",
+                        target,
+                        "@ps_agent_source",
+                        f"{generation}\t{source}",
+                    ],
                     check=False,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -592,12 +629,51 @@ def _watch_and_record_agent_source(
     return 1
 
 
+def _resolve_tmux_session_target(env: dict[str, str]) -> Optional[str]:
+    """Resolve the tmux session id this launch belongs to (issue #2159).
+
+    Runs in the PARENT, where ``$TMUX_PANE`` is authoritative, and returns a
+    stable ``$N`` session id the detached watcher can pass to ``-t``. The
+    session id outlives pane churn inside the session, so it stays valid for the
+    whole watch window.
+
+    ``$TMUX_PANE`` is REQUIRED: it is the only honest evidence of which session
+    this launch belongs to. Without it, ``tmux display-message`` would answer
+    from the server's most-recently-used session — a confident, unrelated
+    answer, which is the very defect #2159 exists to kill one layer down. So an
+    absent pane resolves to ``None`` rather than to somebody else's session (no
+    ambient-inference fallback survives — D22).
+
+    Returns ``None`` when ``$TMUX_PANE`` is absent or tmux cannot name that
+    pane's session — the caller then refuses to start an untargeted watcher
+    rather than risk writing onto another session.
+    """
+    pane = env.get("TMUX_PANE", "").strip()
+    if not pane:
+        return None
+    argv = ["tmux", "display-message", "-p", "-t", pane, "#{session_id}"]
+    try:
+        result = subprocess.run(
+            argv,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            env=env,
+        )
+    except Exception:
+        return None
+    session_id = result.stdout.strip()
+    return session_id or None
+
+
 def record_agent_source(
     kind: str,
     cwd: str,
     env: Optional[dict[str, str]] = None,
     runner=None,
     popen=None,
+    resolve_target=None,
 ) -> bool:
     """Start a best-effort recorder for this launch's transcript source.
 
@@ -617,14 +693,26 @@ def record_agent_source(
         runner = subprocess.run
     if popen is None:
         popen = subprocess.Popen
+    if resolve_target is None:
+        resolve_target = _resolve_tmux_session_target
     try:
+        # Issue #2159: resolve the tmux target HERE, in the launching process,
+        # where `$TMUX_PANE` is authoritative — then name it explicitly on every
+        # option write and hand it to the detached watcher. Nothing on this path
+        # relies on tmux's ambient "current session" inference any more; when the
+        # target cannot be resolved there is no safe write, so we do not start a
+        # watcher at all rather than risk recording onto another session (D22 —
+        # no ambient fallback branch survives).
+        target = resolve_target(dict(source_env))
+        if not target:
+            return False
         generation = uuid.uuid4().hex
         runner(
-            ["tmux", "set-option", "@ps_agent_source_generation", generation],
+            ["tmux", "set-option", "-t", target, "@ps_agent_source_generation", generation],
             check=False,
         )
         runner(
-            ["tmux", "set-option", "-uq", "@ps_agent_source"],
+            ["tmux", "set-option", "-t", target, "-uq", "@ps_agent_source"],
             check=False,
         )
         started_at = str(time.time() - 1.0)
@@ -636,12 +724,14 @@ def record_agent_source(
                     "from pocketshell.agents import "
                     "_watch_and_record_agent_source; import sys; "
                     "raise SystemExit(_watch_and_record_agent_source("
-                    "sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]))"
+                    "sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], "
+                    "sys.argv[5]))"
                 ),
                 kind,
                 cwd,
                 started_at,
                 generation,
+                target,
             ],
             env=dict(source_env),
             stdin=subprocess.DEVNULL,

--- a/tools/pocketshell/tests/test_agents.py
+++ b/tools/pocketshell/tests/test_agents.py
@@ -550,15 +550,25 @@ def test_record_agent_source_clears_stale_source_and_starts_watcher(tmp_path):
         env={"TMUX": "/tmp/tmux-1000/default,1234,0", "PATH": "/usr/bin"},
         runner=lambda argv, **kw: run_calls.append((argv, kw)),
         popen=lambda *args, **kwargs: popen_calls.append((args, kwargs)) or _FakePopen(),
+        # Issue #2159: the target is resolved in the parent and named explicitly
+        # on every tmux write; nothing relies on ambient `$TMUX_PANE` inference.
+        resolve_target=lambda env: "$3",
     )
 
     assert ok is True
     generation = run_calls[0][0][-1]
-    assert run_calls[0][0] == ["tmux", "set-option", "@ps_agent_source_generation", generation]
+    assert run_calls[0][0] == [
+        "tmux",
+        "set-option",
+        "-t",
+        "$3",
+        "@ps_agent_source_generation",
+        generation,
+    ]
     assert len(generation) == 32
     assert run_calls[0][1] == {"check": False}
     assert run_calls[1] == (
-        ["tmux", "set-option", "-uq", "@ps_agent_source"],
+        ["tmux", "set-option", "-t", "$3", "-uq", "@ps_agent_source"],
         {"check": False},
     )
     assert len(popen_calls) == 1
@@ -566,6 +576,7 @@ def test_record_agent_source_clears_stale_source_and_starts_watcher(tmp_path):
     assert argv[:2] == [sys.executable, "-c"]
     assert argv[3:5] == ["codex", str(tmp_path)]
     assert argv[6] == generation
+    assert argv[7] == "$3"
     assert popen_calls[0][1]["env"]["TMUX"] == "/tmp/tmux-1000/default,1234,0"
 
 
@@ -579,7 +590,7 @@ def test_watch_agent_source_refuses_stale_generation(monkeypatch):
 
     def fake_run(argv, **kwargs):
         calls.append((argv, kwargs))
-        if argv[:3] == ["tmux", "show-options", "-v"]:
+        if argv[:4] == ["tmux", "-u", "show-options", "-v"]:
             return agents.subprocess.CompletedProcess(argv, 0, stdout="newer-generation\n")
         return agents.subprocess.CompletedProcess(argv, 0, stdout="")
 
@@ -590,11 +601,22 @@ def test_watch_agent_source_refuses_stale_generation(monkeypatch):
         "/workspace/proj",
         "100",
         "older-generation",
+        "$3",
         timeout_seconds="0.01",
     ) == 1
+    # Issue #2159: the guard read names its session with `-t` (and `-u` for the
+    # #2160 UTF-8 client) instead of letting tmux infer the current session.
     assert calls == [
         (
-            ["tmux", "show-options", "-v", "@ps_agent_source_generation"],
+            [
+                "tmux",
+                "-u",
+                "show-options",
+                "-v",
+                "-t",
+                "$3",
+                "@ps_agent_source_generation",
+            ],
             {
                 "check": False,
                 "stdout": agents.subprocess.PIPE,
@@ -615,7 +637,7 @@ def test_watch_agent_source_records_generation_scoped_source(monkeypatch):
 
     def fake_run(argv, **kwargs):
         calls.append((argv, kwargs))
-        if argv[:3] == ["tmux", "show-options", "-v"]:
+        if argv[:4] == ["tmux", "-u", "show-options", "-v"]:
             return agents.subprocess.CompletedProcess(argv, 0, stdout="same-generation\n")
         return agents.subprocess.CompletedProcess(argv, 0, stdout="")
 
@@ -626,11 +648,15 @@ def test_watch_agent_source_records_generation_scoped_source(monkeypatch):
         "/workspace/proj",
         "100",
         "same-generation",
+        "$3",
         timeout_seconds="0.01",
     ) == 0
+    # Issue #2159: the write names the session it was launched for.
     assert calls[-1][0] == [
         "tmux",
         "set-option",
+        "-t",
+        "$3",
         "@ps_agent_source",
         "same-generation\t/tmp/current.jsonl",
     ]

--- a/tools/pocketshell/tests/test_agents_source_target.py
+++ b/tools/pocketshell/tests/test_agents_source_target.py
@@ -1,0 +1,426 @@
+"""Issue #2159 — the transcript-source watcher must name its tmux target.
+
+REPRODUCE-FIRST (G10/D33) for the maintainer's on-device report: the
+Conversation tab said ``Live`` and rendered "No conversation events yet."
+while the Terminal of the SAME session showed a live Codex mid-turn. On the
+host the tmux session carried ``@ps_agent_kind = codex`` and
+``@ps_agent_source_generation`` but ``@ps_agent_source`` was **unset** — the
+launch recorded the kind and minted a generation, and the transcript path was
+never written.
+
+### Why the write can silently go missing
+
+``record_agent_source`` spawns a DETACHED child
+(``_watch_and_record_agent_source``) that, once the transcript appears,
+re-reads ``@ps_agent_source_generation`` as a guard and then writes
+``@ps_agent_source``. Both operations used to run with **no ``-t`` target**,
+so tmux resolved "the current session" from the child's ambient environment.
+That inference is unsound:
+
+* with ``TMUX_PANE`` present it names the launching pane's session, and
+* with ``TMUX_PANE`` absent tmux silently falls back to the **most-recently-used
+  session on the server** — a DIFFERENT session.
+
+Both failure directions are bad, and the observable result of the first is
+byte-identical to the maintainer's state:
+
+* the guard reads a FOREIGN session's generation, sees a mismatch, and returns
+  1 — a silent give-up that leaves ``@ps_agent_source_generation`` set (written
+  earlier by the parent, whose inference IS authoritative) and
+  ``@ps_agent_source`` unset;
+* or, worse, the write lands on the WRONG session, handing an unrelated session
+  a bogus recorded source — the #819/#2155 wrong-transcript class.
+
+### These tests drive the REAL path
+
+They stand up a REAL tmux server on an isolated socket (never the maintainer's
+default socket) with TWO sessions carrying DIFFERENT generations, and run the
+production watcher against it. The FIXTURE is what makes it a reproduction: a
+single-session server can never enter the failing state, so a happy fixture
+would prove nothing (the #847/v0.4.10 lesson). The failing ambient state is
+INJECTED (``TMUX_PANE`` withheld) rather than raced for, so the reproduction is
+deterministic.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import uuid
+
+import pytest
+
+from pocketshell import agents
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("tmux") is None,
+    reason="tmux is required to reproduce the real target-resolution behaviour",
+)
+
+
+class _TmuxServer:
+    """A throwaway tmux server on its own socket (process.md: never `default`)."""
+
+    def __init__(self) -> None:
+        self.socket = f"pocketshell-i2159-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+
+    def run(self, *args: str, env: dict[str, str] | None = None):
+        return subprocess.run(
+            ["tmux", "-L", self.socket, *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+
+    def new_session(self, name: str) -> str:
+        self.run("new-session", "-d", "-s", name, "sh", "-c", "sleep 300")
+        return self.run(
+            "display-message", "-p", "-t", f"={name}:", "#{session_id}"
+        ).stdout.strip()
+
+    def option(self, name: str, option: str) -> str:
+        result = self.run("show-options", "-v", "-t", f"={name}:", option)
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    def kill(self) -> None:
+        # Target sessions by name; never `kill-server` (locked, AGENTS.md).
+        for name in ("target", "decoy"):
+            self.run("kill-session", "-t", f"={name}:")
+
+
+@pytest.fixture()
+def tmux_server():
+    server = _TmuxServer()
+    try:
+        yield server
+    finally:
+        server.kill()
+
+
+def _child_env(server: _TmuxServer, *, pane: str | None) -> dict[str, str]:
+    """The environment a DETACHED watcher child actually runs with.
+
+    ``TMUX`` names the server (so the child can talk to it at all). ``TMUX_PANE``
+    is the ambient signal tmux uses to infer "the current session" — withholding
+    it injects the exact state in which the untargeted read/write silently
+    retargets another session.
+    """
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "TMUX": f"/tmp/tmux-{os.getuid()}/{server.socket},0,0",
+    }
+    if pane is not None:
+        env["TMUX_PANE"] = pane
+    return env
+
+
+def _run_watcher(
+    server: _TmuxServer,
+    *,
+    target: str,
+    generation: str,
+    source: str,
+    pane: str | None,
+) -> int:
+    """Run the production watcher in a child process against the real server.
+
+    The watcher is executed out-of-process with the injected environment so the
+    `tmux` invocations it makes resolve exactly the way they do on-device.
+    """
+    program = (
+        "import sys;"
+        "from pocketshell import agents;"
+        "agents._latest_agent_source = lambda kind, cwd, started_at: sys.argv[5];"
+        "raise SystemExit(agents._watch_and_record_agent_source("
+        "sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[6],"
+        " timeout_seconds='2'))"
+    )
+    env = _child_env(server, pane=pane)
+    env["PYTHONPATH"] = os.pathsep.join(
+        p for p in (os.environ.get("PYTHONPATH", ""), _src_root()) if p
+    )
+    # `tmux -L <socket>` is how the test server is addressed; the watcher builds
+    # bare `tmux` argv, so route it through a shim on PATH.
+    env["PATH"] = f"{_tmux_shim_dir(server)}{os.pathsep}{env['PATH']}"
+    completed = subprocess.run(
+        [
+            os.sys.executable,
+            "-c",
+            program,
+            "codex",
+            "/workspace/proj",
+            "0",
+            generation,
+            source,
+            target,
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    return completed.returncode
+
+
+_SHIM_DIRS: dict[str, str] = {}
+
+
+def _src_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.abspath(agents.__file__)))
+
+
+def _tmux_shim_dir(server: _TmuxServer) -> str:
+    """A PATH shim so the watcher's bare `tmux` hits the isolated test server."""
+    cached = _SHIM_DIRS.get(server.socket)
+    if cached is not None:
+        return cached
+    import tempfile
+
+    directory = tempfile.mkdtemp(prefix="i2159-tmux-shim-")
+    shim = os.path.join(directory, "tmux")
+    real = shutil.which("tmux")
+    with open(shim, "w", encoding="utf-8") as handle:
+        handle.write(f'#!/bin/sh\nexec {real} -L {server.socket} "$@"\n')
+    os.chmod(shim, 0o755)
+    _SHIM_DIRS[server.socket] = directory
+    return directory
+
+
+def test_watcher_records_on_its_own_session_without_ambient_pane(tmux_server):
+    """THE REPORTED STATE: the write must land even with no ambient `TMUX_PANE`.
+
+    RED on base: with no ``-t`` the guard read resolves the DECOY session's
+    generation, the mismatch trips the give-up branch, and ``@ps_agent_source``
+    is never written on the target — exactly the maintainer's
+    generation-present / source-absent host state.
+    """
+    target_id = tmux_server.new_session("target")
+    tmux_server.new_session("decoy")
+    generation = "gen-target"
+    tmux_server.run("set-option", "-t", "=target:", "@ps_agent_source_generation", generation)
+    tmux_server.run("set-option", "-t", "=decoy:", "@ps_agent_source_generation", "gen-decoy")
+
+    rc = _run_watcher(
+        tmux_server,
+        target=target_id,
+        generation=generation,
+        source="/home/u/.codex/sessions/2026/08/15/rollout-live.jsonl",
+        pane=None,
+    )
+
+    # LOAD-BEARING (G6): the symptom-defining signal is the OPTION ON THE
+    # TARGET SESSION, not the watcher's exit code.
+    assert tmux_server.option("target", "@ps_agent_source") == (
+        f"{generation}\t/home/u/.codex/sessions/2026/08/15/rollout-live.jsonl"
+    ), (
+        "#2159: the watcher must write @ps_agent_source on the session it was "
+        "launched for. An empty value is the maintainer's exact host state "
+        f"(generation present, source absent). watcher rc={rc}"
+    )
+
+
+def test_watcher_never_writes_onto_another_session(tmux_server):
+    """Class coverage (G2): the untargeted write could hit the WRONG session.
+
+    The mirror of the test above and the more damaging direction: a source
+    written onto an unrelated session is the #819/#2155 wrong-transcript class.
+    """
+    target_id = tmux_server.new_session("target")
+    tmux_server.new_session("decoy")
+    generation = "gen-target"
+    tmux_server.run("set-option", "-t", "=target:", "@ps_agent_source_generation", generation)
+    tmux_server.run("set-option", "-t", "=decoy:", "@ps_agent_source_generation", generation)
+
+    _run_watcher(
+        tmux_server,
+        target=target_id,
+        generation=generation,
+        source="/home/u/.codex/sessions/2026/08/15/rollout-live.jsonl",
+        pane=None,
+    )
+
+    assert tmux_server.option("decoy", "@ps_agent_source") == "", (
+        "#2159: the watcher must never record a transcript source onto a "
+        "session it was not launched for."
+    )
+
+
+def test_watcher_still_honours_a_real_generation_bump(tmux_server):
+    """The generation guard must keep working once the target is explicit.
+
+    A SECOND launch in the same tmux session bumps the generation; the first
+    watcher must give up rather than overwrite the newer agent's binding
+    (#2155's contract).
+    """
+    target_id = tmux_server.new_session("target")
+    tmux_server.run("set-option", "-t", "=target:", "@ps_agent_source_generation", "gen-2")
+
+    rc = _run_watcher(
+        tmux_server,
+        target=target_id,
+        generation="gen-1",
+        source="/home/u/.codex/sessions/2026/08/15/rollout-stale.jsonl",
+        pane=None,
+    )
+
+    assert rc == 1
+    assert tmux_server.option("target", "@ps_agent_source") == "", (
+        "#2159/#2155: a watcher whose generation was superseded must not write."
+    )
+
+
+def test_record_agent_source_passes_an_explicit_target_to_the_watcher(tmp_path):
+    """The parent resolves the target where `$TMUX_PANE` IS authoritative."""
+    popen_calls: list[tuple] = []
+    run_calls: list[list[str]] = []
+
+    def fake_runner(argv, **kwargs):
+        run_calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="")
+
+    def fake_resolver(env):
+        return "$7"
+
+    ok = agents.record_agent_source(
+        "codex",
+        str(tmp_path),
+        env={"TMUX": "/tmp/tmux-1000/default,1234,0", "TMUX_PANE": "%282"},
+        runner=fake_runner,
+        popen=lambda *args, **kwargs: popen_calls.append((args, kwargs)) or object(),
+        resolve_target=fake_resolver,
+    )
+
+    assert ok is True
+    argv = popen_calls[0][0][0]
+    assert argv[-1] == "$7", (
+        "#2159: the detached watcher must be handed an explicit tmux target so "
+        "it never depends on ambient `$TMUX_PANE` inference."
+    )
+    # Every parent-side option write is targeted too.
+    for call in run_calls:
+        assert "-t" in call, f"untargeted tmux write: {call}"
+
+
+def _resolver_env(server: _TmuxServer, *, pane: str | None) -> dict[str, str]:
+    """The environment `_resolve_tmux_session_target` is called with.
+
+    Same shape as the watcher's, plus the PATH shim so the resolver's bare
+    `tmux` argv reaches the isolated test server. (`subprocess` resolves the
+    executable through ``os.get_exec_path(env)``, so the shim must live on
+    *this* PATH, not the ambient one.)
+    """
+    env = _child_env(server, pane=pane)
+    env["PATH"] = f"{_tmux_shim_dir(server)}{os.pathsep}{env['PATH']}"
+    return env
+
+
+def _ambient_session_id(server: _TmuxServer) -> str:
+    """What tmux answers when nothing names a target — the confident guess."""
+    return server.run("display-message", "-p", "#{session_id}").stdout.strip()
+
+
+def test_resolver_refuses_to_guess_a_session_without_an_ambient_pane(tmux_server):
+    """One layer up (#2159 round 2): the RESOLVER must not infer either.
+
+    ``record_agent_source`` correctly refuses to start an untargeted watcher
+    when the target is unresolvable — but that guard is only as honest as the
+    resolver feeding it. With ``$TMUX_PANE`` absent the resolver used to fall
+    back to ``tmux display-message`` with no ``-t``, which answers with the
+    server's most-recently-used session: a confidently WRONG target that the
+    caller then treats as authoritative and writes onto. That is the exact
+    defect class this issue exists to kill, so "cannot determine" must resolve
+    to ``None``, never to somebody else's session (D22 — no ambient fallback).
+    """
+    target_id = tmux_server.new_session("target")
+    decoy_id = tmux_server.new_session("decoy")
+
+    # NON-VACUITY: the fixture really can produce a confident wrong answer.
+    # A single-session (or empty) server would return `None` for reasons that
+    # have nothing to do with the guard under test.
+    ambient = _ambient_session_id(tmux_server)
+    assert ambient in (target_id, decoy_id), (
+        "fixture cannot enter the failing state: tmux named no ambient session "
+        f"({ambient!r}), so a None result would prove nothing"
+    )
+
+    resolved = agents._resolve_tmux_session_target(_resolver_env(tmux_server, pane=None))
+
+    # LOAD-BEARING: `None` is the only honest answer. Any session id here is the
+    # ambient guess, and the caller cannot tell it apart from a real target.
+    assert resolved is None, (
+        "#2159: with no $TMUX_PANE the resolver must return None. It returned "
+        f"{resolved!r}, which is tmux's most-recently-used session "
+        f"(ambient={ambient!r}) — the caller would then record this launch's "
+        "transcript source onto an unrelated session."
+    )
+
+
+def test_resolver_names_the_panes_session_not_the_ambient_one(tmux_server):
+    """The other half: refusing must not degrade into always refusing.
+
+    Deliberately resolves the session tmux would NOT have guessed, so a correct
+    answer can only have come from ``$TMUX_PANE``.
+    """
+    target_id = tmux_server.new_session("target")
+    decoy_id = tmux_server.new_session("decoy")
+    ambient = _ambient_session_id(tmux_server)
+    assert ambient in (target_id, decoy_id)
+
+    # Whichever session tmux would NOT pick on its own.
+    name, expected_id = (
+        ("target", target_id) if ambient == decoy_id else ("decoy", decoy_id)
+    )
+    pane = tmux_server.run(
+        "display-message", "-p", "-t", f"={name}:", "#{pane_id}"
+    ).stdout.strip()
+    assert pane.startswith("%")
+
+    resolved = agents._resolve_tmux_session_target(_resolver_env(tmux_server, pane=pane))
+
+    assert resolved == expected_id, (
+        "#2159: the resolver must name the session owning $TMUX_PANE "
+        f"({expected_id!r}), not the ambient guess ({ambient!r})."
+    )
+
+
+def test_resolver_returns_none_when_the_pane_is_unknown(tmux_server):
+    """Missing-data class (G2): a stale/foreign pane id is not a licence to guess."""
+    target_id = tmux_server.new_session("target")
+    tmux_server.new_session("decoy")
+    assert _ambient_session_id(tmux_server) != ""
+
+    resolved = agents._resolve_tmux_session_target(
+        _resolver_env(tmux_server, pane="%99999")
+    )
+
+    assert resolved is None, (
+        "#2159: an unresolvable pane must not fall through to the ambient "
+        f"session; got {resolved!r} (target was {target_id!r})."
+    )
+
+
+def test_record_agent_source_refuses_to_spawn_an_untargeted_watcher(tmp_path):
+    """Hard-cut (D22): no ambient-inference fallback path survives.
+
+    When the target cannot be resolved there is no safe write — an untargeted
+    watcher would either give up silently or corrupt another session — so the
+    watcher is not started at all.
+    """
+    popen_calls: list[tuple] = []
+
+    ok = agents.record_agent_source(
+        "codex",
+        str(tmp_path),
+        env={"TMUX": "/tmp/tmux-1000/default,1234,0"},
+        runner=lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=""),
+        popen=lambda *args, **kwargs: popen_calls.append((args, kwargs)) or object(),
+        resolve_target=lambda env: None,
+    )
+
+    assert ok is False
+    assert popen_calls == []


### PR DESCRIPTION
Closes #2159

Reviewer **APPROVED** (round 1): https://github.com/alexeygrigorev/pocketshell/issues/2159#issuecomment-5307757954 — and **APPROVED** again for round 2: https://github.com/alexeygrigorev/pocketshell/issues/2159#issuecomment-5307817701

## The symptom

The Conversation tab reported `Conversation: Live` with a green dot and "No conversation events yet." while the Terminal tab of the **same session** showed a live Codex agent mid-turn with a full 1.7 MB transcript.

## Two separate defects

**Host side — the option was never written.** The detached watcher's guard read *and* its write both ran with **no `-t` target**, relying on tmux's ambient `$TMUX_PANE` inference. On a server with more than one session, tmux silently resolves the **most-recently-used** session — so the guard read a *foreign* generation, mismatched, and gave up. That leaves precisely the reported host state: generation minted, `@ps_agent_source` absent. A single-session probe **cannot** enter that state, which is why it survived earlier testing.

**Client side — the issue's premise was wrong.** I filed this saying "the client fallback finds nothing." It doesn't. `Live` + zero events is only reachable with a source **already bound** — a session with no detection renders the loading placeholder instead. What happened is the transcript *read* returned nothing and the client **laundered that into a healthy green feed**: `readCodexWindow` could not distinguish a missing `agent-log` envelope (unresolvable id, CLI error, version skew — all swallowed by `2>/dev/null || true`) from a genuinely empty transcript, and `restartAgentConversationTailForPane` forced `Ready` + `Live` **even when the restore read threw**.

## Evidence (reviewer-produced, both rounds)

- **Mechanism reproduced independently** on an isolated socket: without `TMUX_PANE`, tmux resolves the MRU session (`GEN_BETA` when targeting alpha). The host test was then driven red **two ways** — dropping `-t` from the guard read reproduces the maintainer's exact host state; dropping it from the write reddens the wrong-session test.
- **The premise-is-false claim was re-derived, not accepted:** every base `Live`-stamping site other than `markAgentTailLive` sets `loadState = Loading`, so only a *completed* read can paint the reported screen. Reconstructing base semantics in place returned the screenshot as a test failure — `events=0 loadState=Empty syncStatus=Live source=<the rollout>`.
- **The green-on-base fallback test is not vacuous** — mutating the fd-owner binding to degrade to mtime selection reddens it.
- **The two changed sibling assertions were pinning the defect:** under the base-equivalent mutant, one reverted to `expected:<NoMessages> but was:<Live>` on a zero-event row. Neither test's real property was weakened; one was strengthened.
- **Gate:** `GATE_RC=0`, **12576 executed / 0 failed / 0 skipped**, counts from XML, no cache markers, load-bearing classes named. Connected 2/2, adjacency 10/10.

## Round 2 — one item I sent back despite the approval

`_resolve_tmux_session_target` still fell back to ambient inference when `TMUX_PANE` was absent, returning a confidently wrong MRU session id instead of `None` — the same defect class one layer up, contradicting both its own KDoc and the "no ambient fallback survives (D22)" claim. The reviewer judged it non-blocking (not a regression; unreachable in production since a tmux pane process always carries `TMUX_PANE`); I asked for it anyway as cheap now versus expensive later.

Now returns `None` and the caller declines to start the watcher. The reviewer widened its own selectivity check to the **entire unfiltered suite**: the mutant reddens `1 failed, 968 passed` — exactly the new guard, across all 969 tests. It also verified round 1's proof was not quietly weakened by mutating the round-1 fix and confirming those tests still redden.

New tests run against a **real two-session** tmux server on an isolated `-L` socket, each hard-asserting the ambient guess is a real session id first, so a `None` result cannot pass for unrelated reasons.

## Merge verification

Rebased onto `7bd6ad95`. All four static guards rc=0 (VM ratchet: no growth), `:app:compileDebugKotlin` + `:app:compileDebugAndroidTestKotlin` BUILD SUCCESSFUL, and the full unfiltered `tools/pocketshell` suite **969 passed**. All four existing `ci-journey-suite.sh` entries intact.

## Follow-ups filed

**#2185** — `record_agent_kind`'s writes remain untargeted (same construction, and `@ps_agent_kind` is the sole kind authority); no Docker journey for the client half; a safety fence defaulting off; and the honest note that the host *trigger* remains unproven.

## Operational note

**The host CLI must be reinstalled on the dev box** for the watcher fix to take effect — a runtime lockstep dependency, not a build one (the v0.4.10 / #847 class).
