### PR TITLE
ci: cancelled unit-gate is cancelled, not failure (#2187)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -822,9 +822,24 @@ jobs:
   # non-blocking until someone edited the ruleset by hand — a real loss of
   # enforcement dressed up as a speed-up. This ~10-second aggregator keeps the
   # name and fails unless every unit-lane job succeeded, so the blocking
-  # contract is bit-for-bit the same with zero admin action. `if: always()` so it
-  # still reports (as a failure) when a dependency fails, is cancelled or is
-  # skipped — a `needs:` job that never reports would leave it pending forever.
+  # contract is bit-for-bit the same with zero admin action.
+  #
+  # `if: ${{ !cancelled() }}` (issue #2187) is load-bearing and is NOT
+  # `always()`. `always()` kept this job running after the `main` push
+  # concurrency group cancelled the run, and the result loop then folded
+  # every `cancelled` input into a red required check — an absent result
+  # rendering as a failure (runs 31950499521 / 31952697403 / 31952932366).
+  # Without `always()`, GitHub does not dispatch the job on a cancelled
+  # workflow and the required check concludes `cancelled`, which is what
+  # `scripts/watch-ci.py` already treats as exit 4/5 rather than exit 1.
+  # `always() && !cancelled()` is also wrong: GitHub evaluates it and a
+  # false result is `skipped`, which a required-check ruleset can treat as
+  # passing. The job still runs when a needed job failed or was skipped
+  # (`!cancelled()` is not the default `success()`), so #2060 stays
+  # fail-closed. A single-job cancel while the workflow continues
+  # (timeout / runner death) still reaches the loop and fails closed —
+  # that is not a concurrency-supersession and must not be laundered.
+  # `scripts/check-unit-gate-wiring.sh` C11/C13 assert both halves.
   #
   # Issue #2067 — THIS JOB HAS THREE LISTS AND THEY MUST AGREE: `needs:`, the
   # `env:` mapping, and the loop. A job in `needs:` but not in the loop runs, can
@@ -836,7 +851,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     needs: [unit, guards-static, guards-ci-harness, guards-test-selection, dex]
-    if: always()
+    if: ${{ !cancelled() }}
     timeout-minutes: 5
     steps:
       - name: Require every unit-lane job to have succeeded

--- a/scripts/check-unit-gate-wiring.sh
+++ b/scripts/check-unit-gate-wiring.sh
@@ -29,6 +29,11 @@
 #   C7  every workflow job is either wired into the gate or explicitly exempt
 #   C8  every exempt name still exists                          (the list cannot rot)
 #   C9  the #2063 selection guards are NOT reachable from a Gradle test task
+#   C11 the aggregator uses `if: ${{ !cancelled() }}` and not `always()`
+#       (issue #2187: a concurrency-cancel must conclude the required check
+#       as cancelled, not dispatch the job so `!= success` paints it failure)
+#   C13 the extracted result loop still fail-closes on skipped / empty /
+#       failure / cancelled-while-running (the original #2060 property)
 #
 # C5 is the subtle one: without it `GUARDS_STATIC: ${{ needs.guards-ci-harness.result }}`
 # passes C4 and C6 while the loop prints one job's label next to another job's
@@ -134,6 +139,34 @@ sorted_unique() {
 
 upper_snake() {
   printf '%s' "$1" | tr '[:lower:]-' '[:upper:]_'
+}
+
+# Issue #2187: the exact job-level `if:` that lets GitHub mark the required
+# check `cancelled` when the workflow is cancelled, while still dispatching
+# the job when a needed job failed or was skipped. `always()` is the bug —
+# it keeps the job running after a concurrency-cancel, and the result loop
+# then paints the required check red. `always() && !cancelled()` is also
+# wrong: GitHub evaluates it (because of `always()`) and the false result
+# is `skipped`, which required-check rulesets can treat as passing.
+EXPECTED_GATE_IF='${{ !cancelled() }}'
+
+extract_job_if() {
+  # First job-level `if:` (4-space indent) in the supplied job block.
+  printf '%s\n' "$1" | sed -n 's/^    if:[[:space:]]*//p' | head -1
+}
+
+extract_gate_script() {
+  # The `run: |` body of the unit-gate result loop. Fails loudly on empty:
+  # C13 executes this script, so "I could not extract it" must not look like
+  # "the rollup is fine".
+  printf '%s\n' "$1" | awk '
+    /^        run: \|[[:space:]]*$/ { inrun = 1; next }
+    inrun {
+      if ($0 != "" && $0 !~ /^          /) exit
+      sub(/^          /, "")
+      print
+    }
+  '
 }
 
 check_workflow() {
@@ -279,13 +312,60 @@ a step to that job instead."
     fail "C9: \`$scan_root\` is not a git checkout, so the Gradle-test-graph scan could not run. 'I could not check' is not 'I checked and it is fine'."
   fi
 
+  # --- C11: cancelled must not be dispatched into a manufactured failure ----
+  # G6 mutation: restore `if: always()` (or wrap `!cancelled()` in `always()`).
+  # That is exactly how run 31952697403 painted `Unit tests` failure over
+  # five cancelled inputs: the job kept running after the concurrency-cancel
+  # and `!= success` folded `cancelled` into failure.
+  local gate_if
+  gate_if="$(extract_job_if "$block")"
+  [ -n "$gate_if" ] || fail "C11: \`$GATE_JOB\` has no job-level \`if:\`. The default \`success()\` skips the gate when a needed job fails (#2060) and leaves a cancelled run's required check pending. The required form is \`if: $EXPECTED_GATE_IF\` (#2187)."
+  if [ "$gate_if" != "$EXPECTED_GATE_IF" ]; then
+    fail "C11: \`$GATE_JOB\` if: is '$gate_if', but must be '$EXPECTED_GATE_IF' (#2187). \`always()\` keeps the job running after a concurrency-cancel so the result loop paints the required \`$GATE_CHECK_NAME\` check as failure; \`always() && !cancelled()\` evaluates to skipped, which a required-check ruleset can treat as passing. No \`always()\` is load-bearing: GitHub then marks the undispatched check cancelled."
+  fi
+
+  # --- C13: the result loop still fail-closes on every non-success ----------
+  # The job-level if is what makes a SUPERSEDED run conclude cancelled. Once
+  # the job actually runs (a needed job failed, skipped, or a single job was
+  # cancelled while the workflow continued), the loop must still reject
+  # anything that is not success. Narrowing it to `== "failure"` would let a
+  # skipped or missing input pass — the original #2060 hole.
+  local gate_script
+  gate_script="$(extract_gate_script "$block")"
+  [ -n "$gate_script" ] || fail "C13: could not extract \`$GATE_JOB\`'s \`run: |\` body — the fail-closed loop is unreadable, so this is not a pass"
+  assert_rollup_exit() {
+    local want="$1" label="$2"
+    local unit="$3" gs="$4" gch="$5" gts="$6" dex="$7"
+    local out rc
+    set +e
+    out="$(UNIT="$unit" GUARDS_STATIC="$gs" GUARDS_CI_HARNESS="$gch" \
+           GUARDS_TEST_SELECTION="$gts" DEX="$dex" \
+           bash <<<"$gate_script" 2>&1)"
+    rc=$?
+    set -e
+    if [ "$rc" -ne "$want" ]; then
+      fail "C13: $label: extracted rollup exited $rc, expected $want
+$out"
+    fi
+  }
+  assert_rollup_exit 0 "all-success" success success success success success
+  assert_rollup_exit 1 "a failing input" failure success success success success
+  assert_rollup_exit 1 "a skipped input" success skipped success success success
+  assert_rollup_exit 1 "an empty/missing input" success success "" success success
+  # Conservative: a cancelled input WHILE THIS JOB RAN is a single-job cancel
+  # (timeout / runner death), not a concurrency-supersession. Those must still
+  # fail closed. The concurrency case never reaches this script (C11).
+  assert_rollup_exit 1 "cancelled-while-running" cancelled cancelled cancelled cancelled cancelled
+
   echo "OK: \`$GATE_JOB\` is named '$GATE_CHECK_NAME' and its three lists agree."
   echo "OK: \`$PYTHON_JOB\` is named '$PYTHON_CHECK_NAME' (the second required check)."
+  echo "OK: \`$GATE_JOB\` if: is '$EXPECTED_GATE_IF' (concurrency-cancel concludes cancelled, #2187)."
   echo "    needs      : $(printf '%s' "$needs" | tr '\n' ' ')"
   echo "    env reads  : $(printf '%s' "$env_vars" | tr '\n' ' ')"
   echo "    loop checks: $(printf '%s' "$loop_vars" | tr '\n' ' ')"
   echo "    exempt     : $(printf '%s' "$exempt_list" | tr '\n' ' ')"
   echo "OK: the #2063 selection guards are not reachable from any Gradle test source or build script."
+  echo "OK: the extracted rollup fail-closes on failure / skipped / empty / cancelled-while-running."
 }
 
 # --- self-test ---------------------------------------------------------------
@@ -293,7 +373,7 @@ a step to that job instead."
 # for the intended reason. The pass count is asserted at the end, so the
 # anti-vacuous guard cannot itself pass vacuously.
 
-SELFTEST_EXPECTED_CASES=12 # 11 + case 4b (the second required check name, #2134)
+SELFTEST_EXPECTED_CASES=16 # 12 + C11/C13 cases for #2187 (11, 12, 13, 14)
 selftest_passed=0
 selftest_failed=0
 # Overridden per case so C9's scan can be pointed at a sandbox checkout instead
@@ -478,6 +558,52 @@ self_test() {
   git -C "$scan_sandbox" add -A
   expect_red "10 a Gradle test task reaching the guards again" "C9" "$src"
   EXPECT_SCAN_ROOT=""
+
+  # Case 11 (issue #2187) — THE HEADLINE MUTATION: restore `if: always()`.
+  # That is how a concurrency-superseded run manufactured a red required
+  # check: the job kept running and `!= success` folded `cancelled` into
+  # failure. This case is the reproduce-first proof.
+  local m11="$sandbox/m11.yml"
+  awk '
+    /^  unit-gate:$/ { ingate = 1 }
+    ingate && /^    if:/ { print "    if: always()"; ingate = 0; next }
+    { print }
+  ' "$src" > "$m11"
+  cmp -s "$src" "$m11" && st_bad "11 mutation did not apply" || \
+    expect_red "11 if: always() restored (cancelled becomes failure)" "C11" "$m11"
+
+  # Case 12 — no job-level if: defaults to success(), so a failed needed job
+  # skips the gate and a cancelled run leaves the required check pending.
+  local m12="$sandbox/m12.yml"
+  awk '
+    /^  unit-gate:$/ { ingate = 1 }
+    ingate && /^    if:/ { next }
+    /^  [A-Za-z0-9_-]+:/ && !/^  unit-gate:$/ { ingate = 0 }
+    { print }
+  ' "$src" > "$m12"
+  cmp -s "$src" "$m12" && st_bad "12 mutation did not apply" || \
+    expect_red "12 job-level if: removed" "C11" "$m12"
+
+  # Case 13 — `always() && !cancelled()` looks like the fix but GitHub
+  # evaluates it (because of always()) and a false result is `skipped`,
+  # which a required-check ruleset can treat as passing.
+  local m13="$sandbox/m13.yml"
+  awk '
+    /^  unit-gate:$/ { ingate = 1 }
+    ingate && /^    if:/ { print "    if: ${{ always() && !cancelled() }}"; ingate = 0; next }
+    { print }
+  ' "$src" > "$m13"
+  cmp -s "$src" "$m13" && st_bad "13 mutation did not apply" || \
+    expect_red "13 if: always() && !cancelled() (skipped, not cancelled)" "C11" "$m13"
+
+  # Case 14 — the loop only reddens on `failure`, so skipped/empty/cancelled
+  # while running pass. That is the original #2060 hole reopened while
+  # "fixing" #2187.
+  local m14="$sandbox/m14.yml"
+  sed 's/if \[\[ "\$result" != "success" \]\]; then/if [[ "$result" == "failure" ]]; then/' \
+    "$src" > "$m14"
+  cmp -s "$src" "$m14" && st_bad "14 mutation did not apply" || \
+    expect_red "14 loop only treats failure as bad" "C13" "$m14"
 
   echo
   echo "$selftest_passed passed, $selftest_failed failed"

--- a/scripts/watch-ci.py
+++ b/scripts/watch-ci.py
@@ -429,6 +429,11 @@ def classify_run(
     failure is always checked FIRST and always wins, so a run that genuinely
     broke and was cancelled afterwards still reports RESULT_FAILED — the fix for
     the false-alarm bug must never launder real red CI into "superseded".
+    Issue #2187: that precedence includes a non-required unit-lane job
+    (Static guards, JVM unit tests, …). The `unit-gate` rollup now uses
+    `if: ${{ !cancelled() }}`, so a superseded run concludes the required
+    `Unit tests` check as `cancelled` instead of manufacturing `failure`;
+    a real input failure still lives on that input job and must still win.
     Absent a genuine failure, a cancelled run yields NO verdict.
     """
     required = resolve_required_checks(jobs, required_names)
@@ -477,14 +482,34 @@ def classify_run(
             reason=f"run concluded {run_conclusion}",
         )
 
-    # No genuine failure anywhere. Was anything cancelled? Then this run reached
-    # no trustworthy verdict — the caller decides superseded vs no_verdict.
+    # No genuine failure on the required-check / run-conclusion surface. Was
+    # anything cancelled? Then this run reached no trustworthy verdict — the
+    # caller decides superseded vs no_verdict.
     cancelled_required = [
         rc.name
         for rc in required.values()
         if rc.status == "completed" and (rc.conclusion or "") == CANCELLED
     ]
-    if (run_conclusion or "") == CANCELLED or cancelled_required:
+    run_was_cancelled = (run_conclusion or "") == CANCELLED or bool(
+        cancelled_required
+    )
+    # Issue #2187: the unit-gate rollup uses `if: ${{ !cancelled() }}`, so a
+    # superseded run never dispatches the required `Unit tests` check (it
+    # concludes `cancelled` instead of manufacturing `failure`). A unit-lane
+    # job that had already failed still lives on that input job. Genuine
+    # failure anywhere still wins — otherwise a Static-guards red plus a
+    # later concurrency-cancel would be laundered into exit 4.
+    if run_was_cancelled and failed_jobs:
+        return Classification(
+            result=RESULT_FAILED,
+            required=required,
+            failing_jobs=failed_jobs,
+            reason=(
+                "job(s) concluded failing on a cancelled run: "
+                + ", ".join(failed_jobs)
+            ),
+        )
+    if run_was_cancelled:
         detail = (
             "required check(s) cancelled: " + ", ".join(cancelled_required)
             if cancelled_required

--- a/tools/pocketshell/tests/test_watch_ci_cancelled.py
+++ b/tools/pocketshell/tests/test_watch_ci_cancelled.py
@@ -529,6 +529,184 @@ def test_healthy_long_running_emulator_shard_is_not_a_hang():
 # ── The exit-code contract stays complete and distinct ───────────────────────
 
 
+# ── Issue #2187: rollup concludes cancelled, watcher must agree ───────────────
+# After the #2060 unit-gate rollup, a concurrency-superseded `main` run kept
+# dispatching the required `Unit tests` check (`if: always()`) and the result
+# loop painted every cancelled input as failure. The rollup now uses
+# `if: ${{ !cancelled() }}`, so the check itself concludes `cancelled`. These
+# fixtures are the post-fix shape of the reported runs; the watcher must
+# classify them exit 4 (superseded) / exit 1 (real failure), never confuse
+# the two.
+
+
+def _issue2187_unit_lane_jobs(*, unit_tests_conclusion: str, extra_jobs=None):
+    """Unit-lane + required-check jobs for the #2187 superseded-run shape.
+
+    Mirrors the input set the rollup reads (run 31952697403 / 31952932366):
+    JVM unit (matrix), the three guard jobs, dex, plus the required checks.
+    """
+    jobs = [
+        _job("JVM unit tests (Debug)", "completed", "cancelled", 1),
+        _job("JVM unit tests (Release)", "completed", "cancelled", 2),
+        _job("Static guards", "completed", "cancelled", 3),
+        _job("CI harness guards", "completed", "cancelled", 4),
+        _job("Test-selection coverage guards", "completed", "success", 5),
+        _job("Dex register-pressure ratchet", "completed", "cancelled", 6),
+        _job("Unit tests", "completed", unit_tests_conclusion, 7),
+        _job("Python utility tests (pocketshell)", "completed", "cancelled", 8),
+        _job("Integration tests (Docker)", "completed", "cancelled", 9),
+        _job(
+            "Emulator journey subset (load-bearing, Docker agents) (0)",
+            "completed",
+            "cancelled",
+            10,
+        ),
+    ]
+    if extra_jobs:
+        jobs.extend(extra_jobs)
+    return jobs
+
+
+def _issue2187_run_state(jobs):
+    return {
+        "status": "completed",
+        "conclusion": "cancelled",
+        "databaseId": 31952697403,
+        "headBranch": "main",
+        "workflowName": "Tests",
+        "createdAt": "2026-08-16T12:00:00Z",
+        "jobs": jobs,
+    }
+
+
+def _issue2187_newer_run():
+    return [
+        {
+            "databaseId": 31952932366,
+            "workflowName": "Tests",
+            "headBranch": "main",
+            "status": "in_progress",
+            "createdAt": "2026-08-16T12:05:00Z",
+        },
+        {
+            "databaseId": 31952697403,
+            "workflowName": "Tests",
+            "headBranch": "main",
+            "status": "completed",
+            "createdAt": "2026-08-16T12:00:00Z",
+        },
+    ]
+
+
+def test_issue2187_superseded_rollup_cancelled_is_exit_4_not_failed():
+    """THE reported instance, post-fix. Unit tests concludes cancelled.
+
+    Run 31952697403: every unit-lane input cancelled (or one leftover
+    success), required check cancelled, newer run on `main`. Must be
+    superseded (exit 4), not the exit-1 path that sent the on-call hunting
+    a test failure that did not exist.
+    """
+    gh = FakeGh()
+    gh.queue_run_state(
+        **_issue2187_run_state(
+            _issue2187_unit_lane_jobs(unit_tests_conclusion="cancelled")
+        )
+    )
+    gh.run_list_json = _issue2187_newer_run()
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="31952697403")
+
+    assert outcome.result == wci.RESULT_SUPERSEDED
+    assert outcome.exit_code == 4
+    assert outcome.signature is None
+    assert "31952932366" in outcome.reason
+
+
+def test_issue2187_mixed_success_and_cancelled_inputs_still_exit_4():
+    """Run 31952932366 shape: one input cancelled, the rest success.
+
+    The rollup no longer runs, so Unit tests is cancelled even though
+    four of five inputs succeeded. Nothing failed; this is still a
+    supersession, not a unit-lane break.
+    """
+    jobs = _issue2187_unit_lane_jobs(unit_tests_conclusion="cancelled")
+    for j in jobs:
+        if j["name"] in {
+            "JVM unit tests (Debug)",
+            "JVM unit tests (Release)",
+            "CI harness guards",
+            "Dex register-pressure ratchet",
+        }:
+            j["conclusion"] = "success"
+        if j["name"] == "Static guards":
+            j["conclusion"] = "cancelled"
+    gh = FakeGh()
+    gh.queue_run_state(**_issue2187_run_state(jobs))
+    gh.run_list_json = _issue2187_newer_run()
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="31952697403")
+
+    assert outcome.result == wci.RESULT_SUPERSEDED
+    assert outcome.exit_code == 4
+
+
+def test_issue2187_genuine_unit_lane_failure_then_cancel_is_still_exit_1():
+    """AC2/AC4: a real failing input still wins after the rollup stops running.
+
+    `if: ${{ !cancelled() }}` means Unit tests itself is cancelled when the
+    workflow is cancelled, even if Static guards already failed. The watcher
+    must not launder that into superseded.
+    """
+    jobs = _issue2187_unit_lane_jobs(unit_tests_conclusion="cancelled")
+    for j in jobs:
+        if j["name"] == "Static guards":
+            j["conclusion"] = "failure"
+    gh = FakeGh()
+    gh.queue_run_state(**_issue2187_run_state(jobs))
+    gh.run_list_json = _issue2187_newer_run()
+    gh.log_text = (
+        "Static guards\tUnit-gate wiring guard\t2026-08-16T12:03:00Z "
+        "error: C11: unit-gate if: is always()\n"
+    )
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="31952697403")
+
+    assert outcome.result == wci.RESULT_FAILED, (
+        "a genuinely failed unit-lane job must stay FAILED even though the "
+        f"required check was cancelled — got {outcome.result}: {outcome.reason}"
+    )
+    assert outcome.exit_code == 1
+    assert "Static guards" in outcome.failing_jobs
+
+
+def test_issue2187_manufactured_rollup_failure_still_reads_as_failed():
+    """If the rollup regresses and paints cancelled inputs as failure again,
+    the watcher agrees with that conclusion (exit 1). Agreement is the AC;
+    the wiring guard is what stops the regression from landing.
+    """
+    gh = FakeGh()
+    gh.queue_run_state(
+        **_issue2187_run_state(
+            _issue2187_unit_lane_jobs(unit_tests_conclusion="failure")
+        )
+    )
+    gh.run_list_json = _issue2187_newer_run()
+    gh.log_text = (
+        "Unit tests\tRequire every unit-lane job to have succeeded\t"
+        "2026-08-16T12:04:00Z ##[error]A unit-lane job did not succeed (#2060).\n"
+    )
+    watcher, _ = _make_watcher(gh)
+
+    outcome = watcher.watch(run_id="31952697403")
+
+    assert outcome.result == wci.RESULT_FAILED
+    assert outcome.exit_code == 1
+    assert "Unit tests" in outcome.failing_jobs
+
+
 def test_exit_code_contract_is_complete_and_distinct():
     codes = wci.EXIT_CODE
     assert codes[wci.RESULT_GREEN] == 0


### PR DESCRIPTION
Closes #2187

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2187#issuecomment-5331826375
Orchestrator verify: wiring guard + 16-case self-test green; `uv run pytest tests/test_watch_ci.py tests/test_watch_ci_cancelled.py` → 57 passed.