### PR TITLE
usage: show Grok Build quota via quse 0.0.13 (#2195)

### DIFF
--- a/docs/usage-panel.md
+++ b/docs/usage-panel.md
@@ -1,6 +1,6 @@
 # Usage Panel
 
-Provider quota tracking for Claude Code, Codex, GitHub Copilot, Z.AI, and other coding-agent CLIs — surfaced as a dedicated screen and a dashboard widget. Lets the user check "how much budget have I burned through this week" without leaving PocketShell.
+Provider quota tracking for Claude Code, Codex, GitHub Copilot, Grok Build, Z.AI, and other coding-agent CLIs — surfaced as a dedicated screen and a dashboard widget. Lets the user check "how much budget have I burned through this week" without leaving PocketShell.
 
 ## Key principle: zero credentials on the phone
 
@@ -207,7 +207,8 @@ straight from `short_term.window` / `long_term.window`. The app ignores
 `details` except for Codex's strict reset-credit inventory fields documented
 above; it never reads `details.windows` or re-derives quota state from details.
 
-The supported providers are `codex`, `claude`, `copilot`, and `zai`.
+The supported providers are `codex`, `claude`, `copilot`, `grok` (Grok Build;
+alias `grok-build`), and `zai`.
 `gemini` is accepted but reports `status: "unsupported"` because Gemini
 does not currently expose a usage endpoint.
 

--- a/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
+++ b/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
@@ -235,6 +235,10 @@ private const val CLAUDE_USAGE_AUTH_SETUP_MESSAGE =
     "Claude login needed on this host. " +
         "Open Claude Code on the host and sign in, then refresh usage."
 
+private const val GROK_USAGE_AUTH_SETUP_MESSAGE =
+    "Grok login needed on this host. " +
+        "Sign in with `grok` on the host, then refresh usage."
+
 /**
  * Rewrite a provider `error` string into an actionable, human message. This is
  * genuine error-message UX (a legit runtime state, kept per issue #1318), NOT
@@ -270,6 +274,18 @@ private fun actionableProviderError(provider: String, error: String?): String? {
                     lower == "no credentials"
             ) ->
             "Codex login needed on this host. Run `codex login` in the host shell, then refresh usage."
+        (
+            provider.equals("grok", ignoreCase = true) ||
+                provider.equals("grok-build", ignoreCase = true)
+            ) &&
+            (
+                lower == "no-credentials" ||
+                    lower == "no credentials" ||
+                    lower == "no-auth-token" ||
+                    lower == "no auth token" ||
+                    lower.contains("auth.json")
+            ) ->
+            GROK_USAGE_AUTH_SETUP_MESSAGE
         else -> text
     }
 }

--- a/shared/core-usage/src/main/java/com/pocketshell/core/usage/UsageModels.kt
+++ b/shared/core-usage/src/main/java/com/pocketshell/core/usage/UsageModels.kt
@@ -82,6 +82,7 @@ public data class UsageProviderRecord(
             "codex" -> "Codex"
             "opencode", "open_code", "open-code" -> "OpenCode"
             "copilot", "github_copilot", "github-copilot" -> "GitHub Copilot"
+            "grok", "grok-build" -> "Grok Build"
             else -> provider
                 .split('-', '_', ' ')
                 .filter { it.isNotBlank() }

--- a/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
+++ b/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
@@ -169,6 +169,99 @@ class PocketshellUsageJsonParserTest {
         assertEquals("GitHub Copilot", records[2].displayName)
     }
 
+    @Test
+    fun parse_weeklyOnlyGrok_rendersWeeklyWindow_displayNameIsGrokBuild() {
+        // #2195 live quse 0.0.13 shape: null short_term, weekly long_term.
+        // Null short_term must not throw. used = 100 - percent_remaining.
+        // displayName MUST be "Grok Build" — generic title-case "Grok" is a
+        // G6 miss (reverting the explicit mapping reddens this).
+        val record = parser.parse(
+            """{"provider":"grok","status":"ok","short_term":{"percent_remaining":null,"reset_at":null,"window":null},"long_term":{"percent_remaining":95.0,"reset_at":"2026-08-25T00:08:17Z","window":"weekly"},"error":null,"details":{"subscription":"SuperGrokPlus"}}""",
+        ).single()
+
+        assertEquals("grok", record.provider)
+        assertEquals("Grok Build", record.displayName)
+        assertTrue(
+            "generic title-case 'Grok' is not the product name",
+            record.displayName != "Grok",
+        )
+        assertEquals(1, record.windows.size)
+        val weekly = record.windows.single()
+        assertEquals("weekly", weekly.name)
+        assertEquals(5.0, weekly.percent, 0.001) // 100 - 95
+        assertEquals(Instant.parse("2026-08-25T00:08:17Z"), weekly.resetAt)
+    }
+
+    @Test
+    fun parse_grokBuildAlias_displayNameIsGrokBuild() {
+        val record = parser.parse(
+            """{"provider":"grok-build","status":"ok","short_term":null,"long_term":{"percent_remaining":95.0,"reset_at":null,"window":"weekly"},"error":null,"details":{}}""",
+        ).single()
+        assertEquals("Grok Build", record.displayName)
+    }
+
+    @Test
+    fun parse_grokBothWindows_weeklyShortAndMonthlyLong() {
+        val record = parser.parse(
+            """{"provider":"grok","status":"ok","short_term":{"percent_remaining":62.5,"reset_at":"2026-08-25T00:08:17Z","window":"weekly"},"long_term":{"percent_remaining":75.0,"reset_at":"2026-09-01T00:00:00Z","window":"monthly"},"error":null,"details":{}}""",
+        ).single()
+
+        assertEquals("Grok Build", record.displayName)
+        assertEquals(2, record.windows.size)
+        assertEquals("weekly", record.windows[0].name)
+        assertEquals(37.5, record.windows[0].percent, 0.001) // 100 - 62.5
+        assertEquals(Instant.parse("2026-08-25T00:08:17Z"), record.windows[0].resetAt)
+        assertEquals("monthly", record.windows[1].name)
+        assertEquals(25.0, record.windows[1].percent, 0.001) // 100 - 75
+        assertEquals(Instant.parse("2026-09-01T00:00:00Z"), record.windows[1].resetAt)
+    }
+
+    @Test
+    fun parse_grokNullPercentsOnBothWindows_recordExistsNoThrow() {
+        // A grok record with null percents on both windows must still parse
+        // (zero renderable windows) and must not fail the whole panel.
+        val record = parser.parse(
+            """{"provider":"grok","status":"ok","short_term":{"percent_remaining":null,"reset_at":null,"window":null},"long_term":{"percent_remaining":null,"reset_at":null,"window":null},"error":null,"details":{}}""",
+        ).single()
+
+        assertEquals("grok", record.provider)
+        assertEquals("Grok Build", record.displayName)
+        assertEquals(UsageStatus.Ok, record.status)
+        assertTrue(record.windows.isEmpty())
+    }
+
+    @Test
+    fun parse_grokNoCredentials_mapsToActionableSignInError() {
+        val record = parser.parse(
+            """{"provider":"grok","status":"error","short_term":null,"long_term":null,"error":"no-credentials","details":{}}""",
+        ).single()
+
+        assertEquals(UsageStatus.Error, record.status)
+        assertEquals(
+            "Grok login needed on this host. " +
+                "Sign in with `grok` on the host, then refresh usage.",
+            record.lastError,
+        )
+        assertTrue(record.lastError?.contains("no-credentials", ignoreCase = true) == false)
+        assertTrue(record.lastError?.contains("Sign in with `grok` on the host") == true)
+        assertTrue(record.windows.isEmpty())
+    }
+
+    @Test
+    fun parse_grokAuthJsonMissing_mapsToActionableSignInError() {
+        val record = parser.parse(
+            """{"provider":"grok","status":"error","short_term":null,"long_term":null,"error":"grok auth.json not found","details":{}}""",
+        ).single()
+
+        assertEquals(UsageStatus.Error, record.status)
+        assertEquals(
+            "Grok login needed on this host. " +
+                "Sign in with `grok` on the host, then refresh usage.",
+            record.lastError,
+        )
+        assertTrue(record.lastError?.contains("auth.json") == false)
+    }
+
     // -- genuine runtime states (kept) ---------------------------------------
 
     @Test

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -39,14 +39,13 @@ dependencies = [
     # provider-keyed `--json` document (per provider: status +
     # short_term/long_term {percent_remaining, reset_at, window} + error) and
     # fails loudly on any schema drift, so the version is frozen, not a range.
-    # 0.0.11 (#1564): quse labels each Codex window from its actual
+    # 0.0.13 (#2195): adds the `grok` provider (alias `grok-build`) so
+    # `pocketshell usage --json` can emit Grok Build quota. 0.0.11 (#1564)
+    # still matters historically: it labels each Codex window from its actual
     # `limit_window_seconds` instead of assuming primary==5h / secondary==7d,
     # and omits a window Codex drops (`present: false`) as a null placeholder
-    # rather than a phantom "0% / unavailable" ghost row. Codex temporarily
-    # removed the 5h window, so its `primary_window` now carries the WEEKLY
-    # (604800s) span — the old positional labels mislabeled weekly data as a
-    # "5h window" with a 5-day reset and left a "7d" ghost.
-    "quse==0.0.11",
+    # rather than a phantom "0% / unavailable" ghost row.
+    "quse==0.0.13",
     # FCM HTTP v1 push delivery (#690): service-account OAuth2 bearer minting
     # for `pocketshell push` / the `usage --capture` reset-push send. Imported
     # lazily and fail-soft — a host without it (or without a Firebase

--- a/tools/pocketshell/src/pocketshell/usage.py
+++ b/tools/pocketshell/src/pocketshell/usage.py
@@ -56,6 +56,10 @@ _CLAUDE_USAGE_AUTH_SETUP_MESSAGE = (
     "Claude usage authentication needs setup on this host. "
     "Open Claude Code on the host and complete sign-in, then refresh usage."
 )
+_GROK_USAGE_AUTH_SETUP_MESSAGE = (
+    "Grok authentication is missing on this host. "
+    "Sign in with `grok` on the host, then refresh usage."
+)
 
 # quse is bundled WITH pocketshell as a pinned dependency (issue #1318). A
 # missing pinned quse is therefore a packaging-integrity error, NOT a user
@@ -161,6 +165,11 @@ def _actionable_error(provider: str, error: Any) -> Optional[str]:
             "Codex authentication is missing on this host. "
             "Run `codex login` in the host shell, then refresh usage."
         )
+    if provider in {"grok", "grok-build"} and (
+        lower in {"no-credentials", "no credentials", "no-auth-token", "no auth token"}
+        or "auth.json" in lower
+    ):
+        return _GROK_USAGE_AUTH_SETUP_MESSAGE
     return text
 
 

--- a/tools/pocketshell/tests/data/quse-0.0.13-usage.json
+++ b/tools/pocketshell/tests/data/quse-0.0.13-usage.json
@@ -1,0 +1,170 @@
+{
+  "claude": {
+    "details": {
+      "limit_reached": true,
+      "subscription": null,
+      "windows": {
+        "five_hour": {
+          "reset_at": null,
+          "used_percent": 0.0
+        },
+        "seven_day": {
+          "reset_at": "2026-08-20T15:00:00Z",
+          "used_percent": 96.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 4.0,
+      "reset_at": "2026-08-20T15:00:00Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": "5h"
+    },
+    "status": "ok"
+  },
+  "codex": {
+    "details": {
+      "limit_reached": true,
+      "reset_credits": [],
+      "reset_credits_available": 0,
+      "reset_credits_error": null,
+      "windows": {
+        "primary_window": {
+          "limit_window_seconds": 604800,
+          "present": true,
+          "reset_at": "2026-08-20T03:30:22Z",
+          "used_percent": 98.0
+        },
+        "secondary_window": {
+          "limit_window_seconds": null,
+          "present": false,
+          "reset_at": null,
+          "used_percent": 0.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 2.0,
+      "reset_at": "2026-08-20T03:30:22Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": null,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "copilot": {
+    "details": {
+      "limit_reached": false,
+      "premium_entitlement": 1500,
+      "premium_percent_remaining": 100.0,
+      "premium_remaining": 1500
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 100.0,
+      "reset_at": "2026-09-01T00:00:00Z",
+      "window": "monthly"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "grok": {
+    "details": {
+      "has_grok_code_access": true,
+      "is_unified_billing_user": true,
+      "limit_reached": false,
+      "on_demand_cap": 0.0,
+      "on_demand_used": 0.0,
+      "prepaid_balance": 0.0,
+      "product_usage": [
+        {
+          "product": "GrokBuild",
+          "usage_percent": 5.0
+        }
+      ],
+      "subscription": "SuperGrokPlus",
+      "windows": {
+        "monthly": {
+          "limit": null,
+          "present": false,
+          "reset_at": null,
+          "used": null,
+          "used_percent": null
+        },
+        "weekly": {
+          "limit": 0.0,
+          "present": true,
+          "reset_at": "2026-08-25T00:08:17Z",
+          "used": 0.0,
+          "used_percent": 5.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 95.0,
+      "reset_at": "2026-08-25T00:08:17Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": null,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "zai": {
+    "details": {
+      "limit_reached": false,
+      "max_used_percent": 22.0,
+      "windows": {
+        "five_hour": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": null,
+          "used_percent": 1.0,
+          "window_hours": 5
+        },
+        "monthly_web_search": {
+          "limit": 4000,
+          "remaining": 3971,
+          "reset_at": "2026-08-27T14:04:58Z",
+          "used_percent": 1.0,
+          "window_hours": 5
+        },
+        "weekly": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": "2026-08-24T14:04:58Z",
+          "used_percent": 22.0,
+          "window_hours": null
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 78.0,
+      "reset_at": "2026-08-24T14:04:58Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": 99.0,
+      "reset_at": null,
+      "window": "5h"
+    },
+    "status": "ok"
+  }
+}

--- a/tools/pocketshell/tests/test_usage.py
+++ b/tools/pocketshell/tests/test_usage.py
@@ -34,6 +34,14 @@ from pocketshell.usage import (
     usage_command,
 )
 
+# Load-bearing Grok auth UX (#2195): must mention signing in with `grok` on
+# the host. Kept as a test-side literal so a generic/raw "no-credentials"
+# rewrite cannot silently satisfy the assertion.
+_EXPECTED_GROK_AUTH = (
+    "Grok authentication is missing on this host. "
+    "Sign in with `grok` on the host, then refresh usage."
+)
+
 _PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 _FIXTURE = Path(__file__).resolve().parent / "data" / "quse-0.0.9-usage.json"
 # Captured LIVE from the pinned quse 0.0.11 (`quse --json`) on 2026-07-15 —
@@ -46,6 +54,12 @@ _FIXTURE = Path(__file__).resolve().parent / "data" / "quse-0.0.9-usage.json"
 # "0% / unavailable" ghost row. Claude / Copilot / zai in the same document
 # keep their correct 5h / 7d / monthly / weekly labels (class coverage).
 _FIXTURE_0011 = Path(__file__).resolve().parent / "data" / "quse-0.0.11-usage.json"
+# Captured LIVE from host quse 0.0.13 (`quse --json`) on 2026-08-18 — the
+# first release that emits a `grok` provider (alias `grok-build`). Live
+# shape is weekly-only: null short_term, weekly long_term. Claude / Codex /
+# Copilot / zai stay in the same document (class coverage).
+_FIXTURE_0013 = Path(__file__).resolve().parent / "data" / "quse-0.0.13-usage.json"
+_LOCK = Path(__file__).resolve().parent.parent / "uv.lock"
 
 
 def _fake_completed(
@@ -72,11 +86,17 @@ def _quse_keyed_json() -> str:
 
 
 def test_pyproject_pins_quse_exactly() -> None:
-    # AC: pocketshell pins quse==0.0.11 as a hard dependency (frozen contract).
-    # 0.0.11 (#1564) labels Codex windows from the actual `limit_window_seconds`
-    # and omits a dropped window rather than emitting a phantom "5h"/ghost row.
+    # AC (#2195): pocketshell pins quse==0.0.13 as a hard dependency so the
+    # usage panel can see Grok. Reverting the pin to 0.0.11 must redden this
+    # assertion (G6). 0.0.13 is the first quse that emits a `grok` provider.
     text = _PYPROJECT.read_text()
-    assert '"quse==0.0.11"' in text, "pyproject must pin quse==0.0.11 in dependencies"
+    assert '"quse==0.0.13"' in text, "pyproject must pin quse==0.0.13 in dependencies"
+    assert '"quse==0.0.11"' not in text, "the 0.0.11 pin must not remain"
+    lock = _LOCK.read_text()
+    assert 'name = "quse"' in lock
+    assert 'version = "0.0.13"' in lock
+    assert 'specifier = "==0.0.13"' in lock
+    assert 'specifier = "==0.0.11"' not in lock
 
 
 def test_resolve_quse_binary_uses_pinned_env_next_to_interpreter(tmp_path: Path) -> None:
@@ -258,6 +278,111 @@ def test_flatten_codex_0011_leaves_other_providers_unchanged() -> None:
     assert zai["long_term"]["window"] == "weekly"
 
 
+def test_flatten_quse_0013_emits_grok_and_passes_windows_through() -> None:
+    """#2195: quse 0.0.13 adds grok; flatten must emit it unchanged.
+
+    Feeds the REAL captured quse 0.0.13 document (weekly-only grok: null
+    short_term, weekly long_term) and asserts the wire shape the app consumes.
+    Reverting the pin without a grok line in the 0.0.13 fixture reddens the
+    provider set. The four historical providers stay present.
+    """
+    out = normalize_usage_stdout(_FIXTURE_0013.read_text())
+    by_provider = {r["provider"]: r for r in (json.loads(ln) for ln in out.splitlines())}
+
+    assert set(by_provider) == {"claude", "codex", "copilot", "grok", "zai"}
+    grok = by_provider["grok"]
+    assert grok["provider"] == "grok"
+    assert grok["status"] == "ok"
+    # Live 0.0.13 weekly-only shape: unused term is a null placeholder.
+    assert grok["short_term"] == {
+        "percent_remaining": None,
+        "reset_at": None,
+        "window": None,
+    }
+    assert grok["long_term"] == {
+        "percent_remaining": 95.0,
+        "reset_at": "2026-08-25T00:08:17Z",
+        "window": "weekly",
+    }
+    # Historical four-provider cards stay in the same document.
+    assert by_provider["claude"]["short_term"]["window"] == "5h"
+    assert by_provider["claude"]["long_term"]["window"] == "7d"
+    assert by_provider["copilot"]["long_term"]["window"] == "monthly"
+    assert by_provider["zai"]["long_term"]["window"] == "weekly"
+
+
+def test_flatten_handles_grok_only_object() -> None:
+    # AC: flattening a grok-only object `{"grok": {...}}` emits one NDJSON
+    # line with provider "grok" and passes weekly/monthly fields through.
+    keyed = json.dumps(
+        {
+            "grok": {
+                "status": "ok",
+                "short_term": {
+                    "percent_remaining": None,
+                    "reset_at": None,
+                    "window": None,
+                },
+                "long_term": {
+                    "percent_remaining": 95.0,
+                    "reset_at": "2026-08-25T00:08:17Z",
+                    "window": "weekly",
+                },
+                "error": None,
+                "details": {"subscription": "SuperGrokPlus"},
+            }
+        }
+    )
+    out = normalize_usage_stdout(keyed)
+    lines = out.splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["provider"] == "grok"
+    assert record["long_term"] == {
+        "percent_remaining": 95.0,
+        "reset_at": "2026-08-25T00:08:17Z",
+        "window": "weekly",
+    }
+    assert record["short_term"]["percent_remaining"] is None
+    assert record["short_term"]["window"] is None
+
+
+def test_flatten_passes_grok_both_windows_through_unchanged() -> None:
+    # quse maps weekly SuperGrok + monthly credit to short_term / long_term
+    # when both windows are present. Flatten must not relabel or drop them.
+    keyed = json.dumps(
+        {
+            "grok": {
+                "status": "ok",
+                "short_term": {
+                    "percent_remaining": 62.5,
+                    "reset_at": "2026-08-25T00:08:17Z",
+                    "window": "weekly",
+                },
+                "long_term": {
+                    "percent_remaining": 75.0,
+                    "reset_at": "2026-09-01T00:00:00Z",
+                    "window": "monthly",
+                },
+                "error": None,
+                "details": {},
+            }
+        }
+    )
+    record = json.loads(normalize_usage_stdout(keyed).splitlines()[0])
+    assert record["provider"] == "grok"
+    assert record["short_term"] == {
+        "percent_remaining": 62.5,
+        "reset_at": "2026-08-25T00:08:17Z",
+        "window": "weekly",
+    }
+    assert record["long_term"] == {
+        "percent_remaining": 75.0,
+        "reset_at": "2026-09-01T00:00:00Z",
+        "window": "monthly",
+    }
+
+
 def test_flatten_raises_on_non_json() -> None:
     try:
         normalize_usage_stdout("this is not json")
@@ -329,6 +454,33 @@ def test_claude_stale_auth_telemetry_error_is_usage_unavailable() -> None:
     assert _actionable_error("claude", stale_error) == _CLAUDE_USAGE_AUTH_SETUP_MESSAGE
 
 
+def test_flatten_maps_grok_no_credentials_to_actionable_error() -> None:
+    keyed = json.dumps(
+        {
+            "grok": {
+                "status": "error",
+                "short_term": None,
+                "long_term": None,
+                "error": "no-credentials",
+                "details": {},
+            }
+        }
+    )
+    record = json.loads(normalize_usage_stdout(keyed).splitlines()[0])
+    assert record["error"] == _EXPECTED_GROK_AUTH
+    assert "no-credentials" not in record["error"].lower()
+    assert "Sign in with `grok` on the host" in record["error"]
+
+
+def test_actionable_error_rewrites_grok_auth_json_miss() -> None:
+    rewritten = _actionable_error("grok", "grok auth.json not found")
+    assert rewritten == _EXPECTED_GROK_AUTH
+    assert _actionable_error("grok", "no credentials") == _EXPECTED_GROK_AUTH
+    assert _actionable_error("grok-build", "no-credentials") == _EXPECTED_GROK_AUTH
+    # Idempotent — the rewritten message must not re-match.
+    assert _actionable_error("grok", rewritten) == _EXPECTED_GROK_AUTH
+
+
 # ---------------------------------------------------------------------------
 # CLI wiring: forwards to the pinned quse and flattens JSON output
 # ---------------------------------------------------------------------------
@@ -392,6 +544,43 @@ def test_usage_forwards_provider_and_json_flag_together() -> None:
     invoked: Sequence[str] = run.call_args.args[0]
     assert invoked == ["/fake/quse", "claude", "--json"]
     assert json.loads(result.output.splitlines()[0])["provider"] == "claude"
+
+
+def test_usage_forwards_grok_provider_and_json() -> None:
+    # AC: `pocketshell usage grok` is an accepted provider filter (quse 0.0.13
+    # already accepts it once pinned). Flatten of the grok-only object is the
+    # load-bearing JSON contract; the CLI must forward `grok` + `--json`.
+    runner = CliRunner()
+    single = json.dumps(
+        {
+            "grok": {
+                "status": "ok",
+                "short_term": {
+                    "percent_remaining": None,
+                    "reset_at": None,
+                    "window": None,
+                },
+                "long_term": {
+                    "percent_remaining": 95.0,
+                    "reset_at": "2026-08-25T00:08:17Z",
+                    "window": "weekly",
+                },
+                "error": None,
+                "details": {},
+            }
+        }
+    )
+    with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
+        "pocketshell.usage.subprocess.run",
+        return_value=_fake_completed(stdout=single),
+    ) as run, patch("pocketshell.usage._try_daemon_usage_fetch", return_value=None):
+        result = runner.invoke(usage_command, ["grok", "--json", "--no-daemon"])
+    assert result.exit_code == 0, result.output
+    invoked: Sequence[str] = run.call_args.args[0]
+    assert invoked == ["/fake/quse", "grok", "--json"]
+    record = json.loads(result.output.splitlines()[0])
+    assert record["provider"] == "grok"
+    assert record["long_term"]["window"] == "weekly"
 
 
 def test_usage_fails_loud_when_pinned_quse_missing() -> None:

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-08-07T21:38:29.279222994Z"
-exclude-newer-span = "P7D"
+exclude-newer = "2027-01-01T23:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -347,7 +346,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qrcode", extras = ["pil"], marker = "extra == 'qr'", specifier = ">=7.4" },
-    { name = "quse", specifier = "==0.0.11" },
+    { name = "quse", specifier = "==0.0.13" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
     { name = "tmuxctl", specifier = ">=0.3.3" },
 ]
@@ -488,14 +487,14 @@ pil = [
 
 [[package]]
 name = "quse"
-version = "0.0.11"
+version = "0.0.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/5d/c659757cf4532e8f347476881caf998e4339f1e9dc7c71ee7887270f2069/quse-0.0.11.tar.gz", hash = "sha256:3728b89b5011638a48c68465870ec9be824844ce3b1e2a8f0a9a4d3dc888124b", size = 52456, upload-time = "2026-07-15T08:26:18.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/b5/d2e510f2fde5ef3edc8d01a94bb0e4423789279b5d84d299ad50378b742c/quse-0.0.13.tar.gz", hash = "sha256:3f744d730f0583d78456f32847a8ed64eb16f0acc16d474bb7696c3bdef91060", size = 58806, upload-time = "2026-08-18T17:20:35.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c1/53e5a3ab471833b0fec1dcaaa81affd07e2bbbefa059e793ca7b333934f2/quse-0.0.11-py3-none-any.whl", hash = "sha256:2fae4365f7c9c78c544e7afff5ce9aa2e5543892c3736402ff06bb1e3d16230a", size = 19051, upload-time = "2026-07-15T08:26:18Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/5e/309a8a2ba7c441d1d94a8f7a963d6ec4f7458424eb05ebc8debceb694e6a/quse-0.0.13-py3-none-any.whl", hash = "sha256:ea4da9826d7cf5abeeab2cf690cc49134cd4e58af92575291ff3633983c081d9", size = 24666, upload-time = "2026-08-18T17:20:34.084Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #2195

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2195#issuecomment-5331964433
Orchestrator verify: `uv run --exclude-newer 2027-01-01 pytest tests/test_usage.py` → 30 passed; `:shared:core-usage:test --rerun-tasks` BUILD SUCCESSFUL (30 tasks executed).

After merge, upgrade the host CLI (`uv tool install --exclude-newer 2027-01-01 --force ~/git/pocketshell/tools/pocketshell`) so the phone sees grok usage.