### PR TITLE
build: pin sshj BouncyCastle transitives to exact versions (#2172)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,3 +17,152 @@ plugins {
     // configured Firebase project).
     alias(libs.plugins.google.services) apply false
 }
+
+// Issue #2172: sshj 0.40.0 → bcpkix-jdk18on:1.80 declares
+// bcutil-jdk18on:[1.80,1.81). A dynamic range cannot be satisfied from a
+// local cache alone — Gradle HEADs maven-metadata.xml on every resolve,
+// which is the traffic pattern that 429s Maven Central before any test
+// runs.
+//
+// Constraints pin every BC sibling to the exact version resolution
+// selects today, applied on every Android module so the range cannot
+// sneak in through a second classpath (app / portfwd / tmux / tests).
+// failOnDynamicVersions() is the reproduce-first / stay-red gate: if
+// that range (or any sibling range) still participates, resolution
+// fails closed instead of rolling the network dice.
+fun Project.pinBouncyCastleTransitives() {
+    val pins = listOf(
+        libs.bouncycastle.bcutil,
+        libs.bouncycastle.bcpkix,
+        libs.bouncycastle.bcprov,
+    )
+    val configNames = listOf(
+        "implementation",
+        "api",
+        "testImplementation",
+        "androidTestImplementation",
+    ).filter { configurations.findByName(it) != null }
+    dependencies {
+        constraints {
+            configNames.forEach { configName ->
+                pins.forEach { pin ->
+                    add(configName, pin)
+                }
+            }
+        }
+    }
+}
+
+subprojects {
+    configurations.configureEach {
+        val isClasspath = name.endsWith("RuntimeClasspath") || name.endsWith("CompileClasspath")
+        if (isClasspath) {
+            resolutionStrategy.failOnDynamicVersions()
+        }
+    }
+    pluginManager.withPlugin("com.android.library") {
+        pinBouncyCastleTransitives()
+    }
+    pluginManager.withPlugin("com.android.application") {
+        pinBouncyCastleTransitives()
+    }
+}
+
+// Exact versions resolution selected on #2172. A catalog bump that is
+// not also reflected here is an upgrade smuggled in as a pin.
+val expectedBouncyCastlePins = mapOf(
+    "org.bouncycastle:bcutil-jdk18on" to "1.80.2",
+    "org.bouncycastle:bcpkix-jdk18on" to "1.80",
+    "org.bouncycastle:bcprov-jdk18on" to "1.80.2",
+)
+
+val sshjClasspathGraphs = listOf(
+    ":shared:core-ssh" to "releaseRuntimeClasspath",
+    ":shared:core-ssh" to "releaseUnitTestRuntimeClasspath",
+    ":app" to "releaseRuntimeClasspath",
+    ":shared:core-portfwd" to "releaseRuntimeClasspath",
+    ":shared:core-tmux" to "releaseRuntimeClasspath",
+)
+
+tasks.register("assertNoDynamicDependencyVersions") {
+    group = "verification"
+    description =
+        "Fails if a dynamic version still participates in sshj/BouncyCastle resolution (#2172)."
+    doLast {
+        val errors = mutableListOf<String>()
+
+        val catalogBcutil = libs.versions.bouncycastle.bcutil.get()
+        val catalogBcpkix = libs.versions.bouncycastle.bcpkix.get()
+        val catalogBcprov = libs.versions.bouncycastle.bcprov.get()
+        if (catalogBcutil != expectedBouncyCastlePins.getValue("org.bouncycastle:bcutil-jdk18on")) {
+            errors += "catalog bouncycastle-bcutil=$catalogBcutil, expected ${expectedBouncyCastlePins["org.bouncycastle:bcutil-jdk18on"]}"
+        }
+        if (catalogBcpkix != expectedBouncyCastlePins.getValue("org.bouncycastle:bcpkix-jdk18on")) {
+            errors += "catalog bouncycastle-bcpkix=$catalogBcpkix, expected ${expectedBouncyCastlePins["org.bouncycastle:bcpkix-jdk18on"]}"
+        }
+        if (catalogBcprov != expectedBouncyCastlePins.getValue("org.bouncycastle:bcprov-jdk18on")) {
+            errors += "catalog bouncycastle-bcprov=$catalogBcprov, expected ${expectedBouncyCastlePins["org.bouncycastle:bcprov-jdk18on"]}"
+        }
+
+        val testsYml = rootProject.file(".github/workflows/tests.yml").readText()
+        if (!testsYml.contains("Assert tests actually executed (issue #1646)")) {
+            errors += ".github/workflows/tests.yml no longer has the #1646 executed-test guard"
+        }
+
+        // Without these, a resolve from a warm cache still selects 1.80.2
+        // and this task would stay green over a range that 429s on a cold
+        // runner. Deleting the gate or the pin must redden the assertion.
+        val rootScript = rootProject.buildFile.readText()
+        if (!rootScript.contains("failOnDynamicVersions()")) {
+            errors += "root build.gradle.kts no longer calls failOnDynamicVersions()"
+        }
+        if (!rootScript.contains("pinBouncyCastleTransitives")) {
+            errors += "root build.gradle.kts no longer applies pinBouncyCastleTransitives"
+        }
+        val coreSshScript = rootProject.file("shared/core-ssh/build.gradle.kts").readText()
+        if (!coreSshScript.contains("libs.bouncycastle.bcutil")) {
+            errors += "shared/core-ssh/build.gradle.kts no longer constrains bcutil"
+        }
+
+        sshjClasspathGraphs.forEach { (path, configName) ->
+            val cfg = project(path).configurations.findByName(configName)
+            if (cfg == null) {
+                errors += "$path:$configName does not exist"
+                return@forEach
+            }
+            val result = cfg.incoming.resolutionResult
+            result.allDependencies.forEach { dep ->
+                if (dep is org.gradle.api.artifacts.result.UnresolvedDependencyResult) {
+                    errors += "$path:$configName unresolved ${dep.requested}: ${dep.failure.message}"
+                }
+            }
+            val selected = result.allComponents
+                .map { it.id }
+                .filterIsInstance<org.gradle.api.artifacts.component.ModuleComponentIdentifier>()
+                .associate { "${it.group}:${it.module}" to it.version }
+            expectedBouncyCastlePins.forEach { (coord, expected) ->
+                val actual = selected[coord]
+                if (actual == null) {
+                    errors += "$path:$configName missing $coord"
+                } else if (actual != expected) {
+                    errors += "$path:$configName $coord selected $actual, expected $expected (no-upgrade pin)"
+                }
+            }
+        }
+
+        check(errors.isEmpty()) {
+            "Issue #2172: dynamic version still participates in resolution, or the pin drifted:\n" +
+                errors.joinToString("\n")
+        }
+        logger.lifecycle(
+            "assertNoDynamicDependencyVersions: OK — BC pins $expectedBouncyCastlePins " +
+                "and no dynamic versions on inspected classpaths",
+        )
+    }
+}
+
+subprojects {
+    tasks.withType<Test>().configureEach {
+        dependsOn(rootProject.tasks.named("assertNoDynamicDependencyVersions"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,15 @@ androidx-hilt-navigation-compose = "1.2.0"
 
 # core-ssh (issue #4). sshj replaces JSch per D3.
 sshj = "0.40.0"
+# Issue #2172: pin sshj 0.40.0's transitive BouncyCastle graph to the
+# exact versions resolution selects today. bcpkix-jdk18on:1.80 declares
+# bcutil-jdk18on:[1.80,1.81); a dynamic range forces a maven-metadata.xml
+# fetch on every resolve and 429s Maven Central. Do not bump these as
+# part of a range-pin — an upgrade is a separate, separately-reviewed
+# change.
+bouncycastle-bcutil = "1.80.2"
+bouncycastle-bcpkix = "1.80"
+bouncycastle-bcprov = "1.80.2"
 slf4j = "2.0.17"
 kotlinx-coroutines = "1.10.2"
 testcontainers = "1.21.3"
@@ -151,6 +160,10 @@ androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navig
 
 # core-ssh (issue #4).
 sshj = { group = "com.hierynomus", name = "sshj", version.ref = "sshj" }
+# Issue #2172: exact pins for sshj's BC graph (see [versions] above).
+bouncycastle-bcutil = { group = "org.bouncycastle", name = "bcutil-jdk18on", version.ref = "bouncycastle-bcutil" }
+bouncycastle-bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncycastle-bcpkix" }
+bouncycastle-bcprov = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle-bcprov" }
 slf4j-nop = { group = "org.slf4j", name = "slf4j-nop", version.ref = "slf4j" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }

--- a/shared/core-ssh/build.gradle.kts
+++ b/shared/core-ssh/build.gradle.kts
@@ -98,7 +98,21 @@ dependencies {
     // backend at runtime; slf4j-nop is the no-op binding so we don't pull in
     // logback or log4j on Android.
     api(libs.sshj)
-    implementation("org.bouncycastle:bcprov-jdk18on:1.80.2")
+    implementation(libs.bouncycastle.bcprov)
+    // Issue #2172: sshj 0.40.0 → bcpkix-jdk18on:1.80 declares
+    // bcutil-jdk18on:[1.80,1.81). Pin every BC sibling to the exact
+    // version resolution selects today so a normal resolve needs no
+    // maven-metadata.xml fetch. Root `subprojects` repeats the same
+    // constraints on every Android module so a second path cannot
+    // revive the range.
+    constraints {
+        api(libs.bouncycastle.bcutil)
+        api(libs.bouncycastle.bcpkix)
+        api(libs.bouncycastle.bcprov)
+        testImplementation(libs.bouncycastle.bcutil)
+        testImplementation(libs.bouncycastle.bcpkix)
+        testImplementation(libs.bouncycastle.bcprov)
+    }
     runtimeOnly(libs.slf4j.nop)
 
     // Coroutines are part of the public surface (SshSession.tail returns


### PR DESCRIPTION
Closes #2172

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2172#issuecomment-5332009920
Orchestrator verify: `./gradlew assertNoDynamicDependencyVersions --rerun-tasks` → exit 0, pins bcutil=1.80.2 / bcpkix=1.80 / bcprov=1.80.2.