### PR TITLE
feat: first-class Grok Build agent — launch, detect, conversation (#2193)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -784,10 +784,12 @@ those sections, not repeated here.)
   `~/git/.claude` dotfiles): Claude (`csp`) = `claude
   --dangerously-skip-permissions`; Codex (`cy`) = `codex
   --dangerously-bypass-approvals-and-sandbox`; OpenCode (`oc`) = `env -u <VAR> …
-  opencode` env-stripped of ~71 provider API-key vars. **OpenCode MUST be
+  opencode` env-stripped of ~71 provider API-key vars; Grok Build (`grok`) =
+  `grok --always-approve`. **OpenCode MUST be
   env-stripped** so it uses the maintainer's subscription auth, not an env API key
-  (otherwise it bills per-token = real money). Build explicit self-contained
-  commands, don't rely on remote shell aliases being sourced.
+  (otherwise it bills per-token = real money). `XAI_API_KEY` is already in that
+  strip list, so Grok also falls back to subscription auth. Build explicit
+  self-contained commands, don't rely on remote shell aliases being sourced.
 - **Disk cleanup hot spots** (dev box recurrently ~96%): biggest + safe =
   `~/git/pocketshell/.claude/worktrees/agent-*` (bulk-remove UNLOCKED ones only —
   git marks in-flight agent worktrees `locked`), `docker builder prune -f`,

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
@@ -1092,6 +1092,7 @@ class FolderListScreenE2eTest {
         compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CLAUDE_TAG).assertExists()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CODEX_TAG).assertExists()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG).assertExists()
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_GROK_TAG).assertExists()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).assertExists()
 
         // Capture the picker sheet via the full-device screenshot path

--- a/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypePickerSkipPermissionsUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypePickerSkipPermissionsUiTest.kt
@@ -147,13 +147,37 @@ class SessionTypePickerSkipPermissionsUiTest {
             .fetchSemanticsNode().boundsInRoot
         val opencode = compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG)
             .fetchSemanticsNode().boundsInRoot
+        val grok = compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_GROK_TAG)
+            .fetchSemanticsNode().boundsInRoot
 
         assertTrue("codex should sit to the right of claude", codex.left > claude.left)
         assertTrue("opencode should sit to the right of codex", opencode.left > codex.left)
+        assertTrue("grok should sit to the right of opencode", grok.left > opencode.left)
         assertTrue("CLI segments should share one row", abs(claude.top - codex.top) < 1f)
         assertTrue("CLI segments should share one row", abs(codex.top - opencode.top) < 1f)
+        assertTrue("CLI segments should share one row", abs(opencode.top - grok.top) < 1f)
         assertTrue("CLI segments should have matching heights", abs(claude.height - codex.height) < 1f)
         assertTrue("CLI segments should have matching heights", abs(codex.height - opencode.height) < 1f)
+        assertTrue("CLI segments should have matching heights", abs(opencode.height - grok.height) < 1f)
+    }
+
+    @Test
+    fun skipPermissionsCheckboxStaysVisibleForGrok() {
+        compose.setContent {
+            PocketShellTheme {
+                SessionTypePickerContent(
+                    folderPath = "/srv/app",
+                    folderLabel = "app",
+                    onCancel = {},
+                    onCreate = {},
+                )
+            }
+        }
+
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_GROK_TAG).performClick()
+        compose.waitForIdle()
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG).assertIsDisplayed()
+        compose.onNodeWithText("Skip permissions").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/com/pocketshell/app/agentcommands/AgentCommandCatalog.kt
+++ b/app/src/main/java/com/pocketshell/app/agentcommands/AgentCommandCatalog.kt
@@ -250,6 +250,31 @@ public object AgentCommandCatalog {
         ),
     )
 
+    private val grokBuild: List<AgentCommand> = listOf(
+        AgentCommand(
+            command = "/new",
+            label = "New conversation",
+            description = "Start a fresh conversation in this CLI session.",
+            destructive = true,
+        ),
+        AgentCommand(
+            command = "/compact",
+            label = "Compact context",
+            description = "Summarise the conversation to free up context.",
+            argument = compactArgument,
+        ),
+        AgentCommand(
+            command = "/export",
+            label = "Export",
+            description = "Export the current session.",
+        ),
+        AgentCommand(
+            command = "/context",
+            label = "Context",
+            description = "Show the current context usage.",
+        ),
+    )
+
     /**
      * The full ordered command list for [agent], curated-first then long
      * tail. Never null — every supported [AgentKind] has a catalog.
@@ -258,6 +283,7 @@ public object AgentCommandCatalog {
         AgentKind.ClaudeCode -> claudeCode
         AgentKind.Codex -> codex
         AgentKind.OpenCode -> openCode
+        AgentKind.GrokBuild -> grokBuild
     }
 
     /**
@@ -291,10 +317,15 @@ public object AgentCommandCatalog {
         "/models", "/sessions", "/themes", "/editor",
     )
 
+    private val grokTuiOnly: Set<String> = setOf(
+        "/resume", "/dashboard", "/rewind", "/model", "/login",
+    )
+
     private fun tuiOnlyRoots(agent: AgentKind): Set<String> = when (agent) {
         AgentKind.ClaudeCode -> claudeTuiOnly
         AgentKind.Codex -> codexTuiOnly
         AgentKind.OpenCode -> openCodeTuiOnly
+        AgentKind.GrokBuild -> grokTuiOnly
     }
 
     /**

--- a/app/src/main/java/com/pocketshell/app/agents/AgentKindRemoteSource.kt
+++ b/app/src/main/java/com/pocketshell/app/agents/AgentKindRemoteSource.kt
@@ -149,7 +149,7 @@ public class AgentKindRemoteSource @Inject constructor() {
      * Parse the CLI envelope
      * `{"results": [{"pane_id", "agent_kind", "scope", "evidence_pid"?}]}`.
      * One malformed row never sinks the batch. `agent_kind` is one of
-     * `claude` / `codex` / `opencode` / `none` / `unknown`.
+     * `claude` / `codex` / `opencode` / `grok` / `none` / `unknown`.
      */
     private fun parseEnvelope(stdout: String): Map<String, PaneKind> {
         val trimmed = stdout.trim().ifBlank { return emptyMap() }
@@ -164,6 +164,7 @@ public class AgentKindRemoteSource @Inject constructor() {
                 "claude" -> AgentKind.ClaudeCode
                 "codex" -> AgentKind.Codex
                 "opencode" -> AgentKind.OpenCode
+                "grok" -> AgentKind.GrokBuild
                 else -> null
             }
             out[paneId] = PaneKind(

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -1787,6 +1787,7 @@ class SshFolderListGateway internal constructor(
             AgentKind.ClaudeCode -> SessionAgentKind.Claude
             AgentKind.Codex -> SessionAgentKind.Codex
             AgentKind.OpenCode -> SessionAgentKind.OpenCode
+            AgentKind.GrokBuild -> SessionAgentKind.Grok
         }
 
 

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListModels.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListModels.kt
@@ -267,6 +267,7 @@ data class FlatSessionGroups(
             SessionAgentKind.Claude,
             SessionAgentKind.Codex,
             SessionAgentKind.OpenCode,
+            SessionAgentKind.Grok,
             SessionAgentKind.Probing,
             SessionAgentKind.Exited,
             -> true

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListTreeChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListTreeChrome.kt
@@ -230,6 +230,7 @@ internal fun sessionBadgeLabel(session: FolderSessionEntry): String = when (sess
     SessionAgentKind.Claude -> "Claude"
     SessionAgentKind.Codex -> "Codex"
     SessionAgentKind.OpenCode -> "OpenCode"
+    SessionAgentKind.Grok -> "Grok"
     SessionAgentKind.Probing -> "Detecting"
     SessionAgentKind.Exited -> "Shell"
     SessionAgentKind.Shell -> "Shell"
@@ -240,6 +241,7 @@ internal fun sessionBadgeMonogram(session: FolderSessionEntry): String = when (s
     SessionAgentKind.Claude -> "CL"
     SessionAgentKind.Codex -> "CX"
     SessionAgentKind.OpenCode -> "OC"
+    SessionAgentKind.Grok -> "GK"
     SessionAgentKind.Probing -> "…"
     SessionAgentKind.Exited,
     SessionAgentKind.Shell,
@@ -251,6 +253,7 @@ internal fun sessionKindLabel(session: FolderSessionEntry): String = when (sessi
     SessionAgentKind.Claude -> "Claude · ${agentStateLabel(session)}"
     SessionAgentKind.Codex -> "Codex · ${agentStateLabel(session)}"
     SessionAgentKind.OpenCode -> "OpenCode · ${agentStateLabel(session)}"
+    SessionAgentKind.Grok -> "Grok · ${agentStateLabel(session)}"
     SessionAgentKind.Probing -> "Detecting"
     SessionAgentKind.Exited -> "Shell"
     SessionAgentKind.Shell -> "Shell"
@@ -291,6 +294,7 @@ internal fun SessionAgentKind.isAgent(): Boolean = when (this) {
     SessionAgentKind.Claude,
     SessionAgentKind.Codex,
     SessionAgentKind.OpenCode,
+    SessionAgentKind.Grok,
     SessionAgentKind.Probing,
     SessionAgentKind.Exited,
     -> true

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListTreeMappings.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListTreeMappings.kt
@@ -26,6 +26,7 @@ private fun String?.toSessionAgentKindOrNull(): SessionAgentKind? = when (this) 
     "claude" -> SessionAgentKind.Claude
     "codex" -> SessionAgentKind.Codex
     "opencode" -> SessionAgentKind.OpenCode
+    "grok" -> SessionAgentKind.Grok
     else -> null
 }
 
@@ -33,6 +34,7 @@ private fun SessionAgentKind.toRegistryKindString(): String? = when (this) {
     SessionAgentKind.Claude -> "claude"
     SessionAgentKind.Codex -> "codex"
     SessionAgentKind.OpenCode -> "opencode"
+    SessionAgentKind.Grok -> "grok"
     else -> null
 }
 

--- a/app/src/main/java/com/pocketshell/app/projects/FolderTreeProjection.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderTreeProjection.kt
@@ -589,6 +589,7 @@ internal object FolderTreeProjection {
         SessionAgentKind.Claude,
         SessionAgentKind.Codex,
         SessionAgentKind.OpenCode,
+        SessionAgentKind.Grok,
         SessionAgentKind.Probing,
         SessionAgentKind.Exited,
         -> true

--- a/app/src/main/java/com/pocketshell/app/projects/HostTreeModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostTreeModel.kt
@@ -415,7 +415,8 @@ internal class HostTreeModel {
     private fun SessionAgentKind.isForeignGuessExportable(): Boolean =
         this == SessionAgentKind.Claude ||
             this == SessionAgentKind.Codex ||
-            this == SessionAgentKind.OpenCode
+            this == SessionAgentKind.OpenCode ||
+            this == SessionAgentKind.Grok
 
     /**
      * Reconcile the held tree against a fresh authoritative probe snapshot
@@ -926,7 +927,8 @@ internal class HostTreeModel {
     private val SessionAgentKind.isAgent: Boolean
         get() = this == SessionAgentKind.Claude ||
             this == SessionAgentKind.Codex ||
-            this == SessionAgentKind.OpenCode
+            this == SessionAgentKind.OpenCode ||
+            this == SessionAgentKind.Grok
 
     /**
      * Issue #889: an AUTHORITATIVE host read of this session's classification —

--- a/app/src/main/java/com/pocketshell/app/projects/SessionKindPickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionKindPickerSheet.kt
@@ -238,6 +238,7 @@ internal fun sessionKindPickerLabel(kind: SessionAgentKind): String = when (kind
     SessionAgentKind.Claude -> "Claude"
     SessionAgentKind.Codex -> "Codex"
     SessionAgentKind.OpenCode -> "OpenCode"
+    SessionAgentKind.Grok -> "Grok"
     SessionAgentKind.Shell -> "Shell"
     // Not user-pickable, but keep the `when` exhaustive.
     SessionAgentKind.Probing,

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -617,6 +617,7 @@ enum class AgentCli(val command: String) {
     Claude("claude"),
     Codex("codex"),
     OpenCode("opencode"),
+    Grok("grok"),
     ;
 
     /**
@@ -630,6 +631,7 @@ enum class AgentCli(val command: String) {
         Claude -> SessionAgentKind.Claude
         Codex -> SessionAgentKind.Codex
         OpenCode -> SessionAgentKind.OpenCode
+        Grok -> SessionAgentKind.Grok
     }
 
     /**
@@ -665,7 +667,7 @@ enum class AgentCli(val command: String) {
                 ?.takeUnless { it.default }?.name
             Codex -> codexProfiles.firstOrNull { it.name == codexProfileName }
                 ?.takeUnless { it.default }?.name
-            OpenCode -> null
+            OpenCode, Grok -> null
         }?.trim()?.takeIf { it.isNotBlank() }
 
         // OpenCode's skip-permissions checkbox is a no-op, so never emit the
@@ -722,6 +724,7 @@ const val SESSION_TYPE_PICKER_AGENT_TAG: String = "session-type-picker:agent"
 const val SESSION_TYPE_PICKER_AGENT_CLAUDE_TAG: String = "session-type-picker:agent:claude"
 const val SESSION_TYPE_PICKER_AGENT_CODEX_TAG: String = "session-type-picker:agent:codex"
 const val SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG: String = "session-type-picker:agent:opencode"
+const val SESSION_TYPE_PICKER_AGENT_GROK_TAG: String = "session-type-picker:agent:grok"
 const val SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG: String = "session-type-picker:skip-permissions"
 const val SESSION_TYPE_PICKER_CWD_TAG: String = "session-type-picker:cwd"
 const val SESSION_TYPE_PICKER_NAME_TAG: String = "session-type-picker:name"
@@ -734,13 +737,14 @@ const val SESSION_TYPE_PICKER_CODEX_PROFILE_TAG: String = "session-type-picker:c
 
 // Segment labels and per-segment tags for the shared SegmentedToggle controls.
 // AGENT_CLI_* lists are ordered to match AgentCli.entries (Claude, Codex,
-// OpenCode), so the segment index maps straight onto the enum ordinal.
+// OpenCode, Grok), so the segment index maps straight onto the enum ordinal.
 private val SESSION_TYPE_LABELS = listOf("Shell", "Agent")
-private val AGENT_CLI_LABELS = listOf("claude", "codex", "opencode")
+private val AGENT_CLI_LABELS = listOf("claude", "codex", "opencode", "grok")
 private val AGENT_CLI_SEGMENT_TAGS = listOf(
     SESSION_TYPE_PICKER_AGENT_CLAUDE_TAG,
     SESSION_TYPE_PICKER_AGENT_CODEX_TAG,
     SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG,
+    SESSION_TYPE_PICKER_AGENT_GROK_TAG,
 )
 
 /**

--- a/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
+++ b/app/src/main/java/com/pocketshell/app/session/AgentConversationRepository.kt
@@ -11,6 +11,8 @@ import com.pocketshell.core.agents.CodexParser
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.agents.ConversationParser
 import com.pocketshell.core.agents.ConversationRole
+import com.pocketshell.core.agents.GrokBuildParser
+import com.pocketshell.core.agents.GrokBuildReader
 import com.pocketshell.core.agents.OpenCodeReader
 import com.pocketshell.core.ssh.SshException
 import com.pocketshell.core.ssh.SshSession
@@ -456,7 +458,7 @@ internal fun parseTranscriptTailLines(
             out += parser.parseLine(line)
         }
     }
-    return out
+    return if (agent == AgentKind.GrokBuild) GrokBuildReader.coalesce(out) else out
 }
 
 private fun truncatedLineByteCountOrNull(line: String): Long? {
@@ -547,7 +549,7 @@ public data class ConversationEventsWindow(
 
 private const val PROCESS_TREE_SCAN_COMMAND: String =
     "ps -eo pid,ppid,tty,comm,args 2>/dev/null | " +
-        "grep -E 'claude|codex|opencode|node' | grep -v grep || true"
+        "grep -E 'claude|codex|opencode|grok|node' | grep -v grep || true"
 
 // Issue #576: public type (the TmuxSessionViewModel constructor now takes it
 // as an injectable parameter so a burst-ingest test can wire a repository
@@ -645,7 +647,7 @@ public class AgentConversationRepository internal constructor(
     /**
      * Epic #821 slice #3 (#825): map a raw `@ps_agent_kind` option value to an
      * [AgentKind]. The launch wrapper writes the lowercase engine token
-     * (`claude` / `codex` / `opencode`); anything else (blank, a foreign
+     * (`claude` / `codex` / `opencode` / `grok`); anything else (blank, a foreign
      * session with no option, an unknown value) maps to `null`. Kept in lockstep
      * with `FolderListGateway.recordedKindFromOption`.
      */
@@ -654,6 +656,7 @@ public class AgentConversationRepository internal constructor(
             "claude" -> AgentKind.ClaudeCode
             "codex" -> AgentKind.Codex
             "opencode" -> AgentKind.OpenCode
+            "grok" -> AgentKind.GrokBuild
             else -> null
         }
 
@@ -1541,10 +1544,11 @@ public class AgentConversationRepository internal constructor(
      * `null` for a path outside a known transcript convention. Kept in lockstep
      * with the enumeration directories in [detectionCommand].
      */
-    private fun kindOfOwnedTranscriptPath(path: String): AgentKind? = when {
+    internal fun kindOfOwnedTranscriptPath(path: String): AgentKind? = when {
         path.contains("/.codex/sessions/") && path.endsWith(".jsonl") -> AgentKind.Codex
         path.contains("/.claude/projects/") && path.endsWith(".jsonl") -> AgentKind.ClaudeCode
         path.substringBefore('#').endsWith("/opencode.db") -> AgentKind.OpenCode
+        path.contains("/.grok/sessions/") && path.endsWith("/updates.jsonl") -> AgentKind.GrokBuild
         else -> null
     }
 
@@ -2281,10 +2285,12 @@ public class AgentConversationRepository internal constructor(
         // OpenCode is read exclusively from its SQLite database via the
         // [isOpenCodeSqlite] branches; it has no JSONL-tailing parser.
         AgentKind.OpenCode -> null
+        AgentKind.GrokBuild -> GrokBuildParser()
     }
 
     internal fun detectionCommand(cwd: String): String {
         val encodedClaudeCwd = detector.encodeClaudeCwd(cwd)
+        val encodedGrokCwd = detector.encodeGrokCwd(cwd)
         val quotedCwd = shellQuote(cwd)
         val sqlCwd = sqlQuote(cwd.trim().trimEnd('/').ifBlank { "/" })
         val openCodeCwdWhere = """
@@ -2339,6 +2345,8 @@ public class AgentConversationRepository internal constructor(
             codex_dir="${'$'}HOME/.codex/sessions"
             opencode_dir="${'$'}HOME/.local/share/opencode"
             opencode_db="${'$'}opencode_dir/opencode.db"
+            grok_home="${'$'}{GROK_HOME:-${'$'}HOME/.grok}"
+            grok_dir="${'$'}grok_home/sessions/$encodedGrokCwd"
             find "${'$'}claude_dir" -maxdepth 1 -type f -name '*.jsonl' -mmin -120 -print 2>/dev/null | while IFS= read -r f; do
               mtime=${'$'}(stat -c '%Y' "${'$'}f" 2>/dev/null) || continue
               printf 'claude|%s|%s|%s\n' "${'$'}mtime" "${'$'}cwd" "${'$'}f"
@@ -2364,6 +2372,10 @@ public class AgentConversationRepository internal constructor(
               mtime=${'$'}(stat -c '%Y' "${'$'}f" 2>/dev/null) || continue
               printf 'codex|%s|%s|%s\n' "${'$'}mtime" "${'$'}cwd" "${'$'}f"
             done
+            find "${'$'}grok_dir" -type f -name 'updates.jsonl' -mmin -120 -print 2>/dev/null | while IFS= read -r f; do
+              mtime=${'$'}(stat -c '%Y' "${'$'}f" 2>/dev/null) || continue
+              printf 'grok|%s|%s|%s\n' "${'$'}mtime" "${'$'}cwd" "${'$'}f"
+            done
             if [ -f "${'$'}opencode_db" ] && command -v sqlite3 >/dev/null 2>&1; then
               sqlite3 -readonly -separator '|' "${'$'}opencode_db" ${shellQuote(openCodeSessionQuery)} 2>/dev/null | while IFS='|' read -r sid updated _worktree _directory; do
                 [ -n "${'$'}sid" ] || continue
@@ -2386,6 +2398,7 @@ public class AgentConversationRepository internal constructor(
             "claude" -> AgentKind.ClaudeCode
             "codex" -> AgentKind.Codex
             "opencode" -> AgentKind.OpenCode
+            "grok" -> AgentKind.GrokBuild
             else -> return null
         }
         val seconds = parts[1].toDoubleOrNull() ?: return null
@@ -2397,6 +2410,8 @@ public class AgentConversationRepository internal constructor(
             modifiedAtMillis = (seconds * 1000).toLong(),
             sessionId = when {
                 agent == AgentKind.OpenCode && "#" in path -> path.substringAfter('#')
+                agent == AgentKind.GrokBuild && path.endsWith("/updates.jsonl") ->
+                    path.removeSuffix("/updates.jsonl").substringAfterLast('/')
                 else -> path.substringAfterLast('/').substringBeforeLast('.')
             },
             cwd = cwd,

--- a/app/src/main/java/com/pocketshell/app/tmux/RecordedAgentRouteEvidence.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/RecordedAgentRouteEvidence.kt
@@ -37,6 +37,7 @@ internal fun SessionAgentKind?.toRecordedAgentKindOrNull(): AgentKind? = when (t
     SessionAgentKind.Claude -> AgentKind.ClaudeCode
     SessionAgentKind.Codex -> AgentKind.Codex
     SessionAgentKind.OpenCode -> AgentKind.OpenCode
+    SessionAgentKind.Grok -> AgentKind.GrokBuild
     SessionAgentKind.Shell,
     SessionAgentKind.Probing,
     SessionAgentKind.Exited,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
@@ -334,7 +334,8 @@ internal fun tmuxSessionRecordedAgentKind(recordedKind: SessionAgentKind?): Bool
     when (recordedKind) {
         SessionAgentKind.Claude,
         SessionAgentKind.Codex,
-        SessionAgentKind.OpenCode -> true
+        SessionAgentKind.OpenCode,
+        SessionAgentKind.Grok -> true
         SessionAgentKind.Shell,
         SessionAgentKind.Probing,
         SessionAgentKind.Exited,
@@ -741,6 +742,7 @@ internal fun tmuxComposerAgentToken(agent: AgentKind?): String? = when (agent) {
     AgentKind.ClaudeCode -> "claude"
     AgentKind.Codex -> "codex"
     AgentKind.OpenCode -> "opencode"
+    AgentKind.GrokBuild -> "grok"
     null -> null
 }
 
@@ -748,6 +750,7 @@ internal fun tmuxComposerAgentKindFromToken(token: String?): AgentKind? = when (
     "claude", "claudecode", "claude_code" -> AgentKind.ClaudeCode
     "codex" -> AgentKind.Codex
     "opencode", "open_code" -> AgentKind.OpenCode
+    "grok", "grokbuild", "grok_build" -> AgentKind.GrokBuild
     else -> null
 }
 

--- a/app/src/test/java/com/pocketshell/app/agentcommands/AgentCommandCatalogTest.kt
+++ b/app/src/test/java/com/pocketshell/app/agentcommands/AgentCommandCatalogTest.kt
@@ -82,6 +82,15 @@ class AgentCommandCatalogTest {
     }
 
     @Test
+    fun `grok curated set includes new compact export context`() {
+        val commands = AgentCommandCatalog.commandsFor(AgentKind.GrokBuild).map { it.command }
+        assertTrue(commands.contains("/new"))
+        assertTrue(commands.contains("/compact"))
+        assertTrue(commands.contains("/export"))
+        assertTrue(commands.contains("/context"))
+    }
+
+    @Test
     fun `openCode curated set leads with new compact sessions undo`() {
         val curated = AgentCommandCatalog.commandsFor(AgentKind.OpenCode)
             .take(4)

--- a/app/src/test/java/com/pocketshell/app/projects/ManualKindWriterTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/ManualKindWriterTest.kt
@@ -37,6 +37,10 @@ class ManualKindWriterTest {
             manualKindCommand("work", "opencode"),
             ManualKindWriter.buildSetOptionCommand("work", SessionAgentKind.OpenCode),
         )
+        assertEquals(
+            manualKindCommand("work", "grok"),
+            ManualKindWriter.buildSetOptionCommand("work", SessionAgentKind.Grok),
+        )
         // A manually-classified plain shell IS recordable (so it never
         // re-prompts as Unknown) — the one extra value over the wrapper.
         assertEquals(

--- a/app/src/test/java/com/pocketshell/app/projects/SessionKindLabelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionKindLabelTest.kt
@@ -61,6 +61,11 @@ class SessionKindLabelTest {
     }
 
     @Test
+    fun grokAgentRendersNameAndState() {
+        assertEquals("Grok · Idle", sessionKindLabel(entry(SessionAgentKind.Grok)))
+    }
+
+    @Test
     fun noAgentLabelIsEverBareIdle() {
         // The conflated-label bug surfaced as a row reading just "Idle". Assert
         // that any agent state word always travels with its agent identity.
@@ -68,6 +73,7 @@ class SessionKindLabelTest {
             SessionAgentKind.Claude,
             SessionAgentKind.Codex,
             SessionAgentKind.OpenCode,
+            SessionAgentKind.Grok,
         )
         agents.forEach { kind ->
             val label = sessionKindLabel(entry(kind))
@@ -98,6 +104,7 @@ class SessionKindLabelTest {
         assertEquals("Claude", sessionBadgeLabel(entry(SessionAgentKind.Claude)))
         assertEquals("Codex", sessionBadgeLabel(entry(SessionAgentKind.Codex)))
         assertEquals("OpenCode", sessionBadgeLabel(entry(SessionAgentKind.OpenCode)))
+        assertEquals("Grok", sessionBadgeLabel(entry(SessionAgentKind.Grok)))
     }
 
     @Test
@@ -126,6 +133,7 @@ class SessionKindLabelTest {
         assertEquals("CL", sessionBadgeMonogram(entry(SessionAgentKind.Claude)))
         assertEquals("CX", sessionBadgeMonogram(entry(SessionAgentKind.Codex)))
         assertEquals("OC", sessionBadgeMonogram(entry(SessionAgentKind.OpenCode)))
+        assertEquals("GK", sessionBadgeMonogram(entry(SessionAgentKind.Grok)))
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/projects/SessionTypeChoiceCommandTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionTypeChoiceCommandTest.kt
@@ -136,6 +136,21 @@ class SessionTypeChoiceCommandTest {
     }
 
     @Test
+    fun grokWithSkipPermissionsIsShortWrapperNoExtraFlag() {
+        val command = agentChoice(AgentCli.Grok, skip = true).startCommand()!!
+        assertEquals("pocketshell agent grok --dir '/srv/app'", command)
+    }
+
+    @Test
+    fun grokWithoutSkipPermissionsEmitsNoSkipFlag() {
+        val command = agentChoice(AgentCli.Grok, skip = false).startCommand()!!
+        assertEquals(
+            "pocketshell agent grok --dir '/srv/app' --no-skip-permissions",
+            command,
+        )
+    }
+
+    @Test
     fun openCodeIsShortWrapperAndNeverGetsSkipFlag() {
         // The checkbox is a no-op for OpenCode: same command either way and
         // never `--no-skip-permissions` (the wrapper does the billing strip).

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryDetectionCommandTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryDetectionCommandTest.kt
@@ -54,6 +54,86 @@ class AgentConversationRepositoryDetectionCommandTest {
     }
 
     @Test
+    fun detectionCommandEmitsGrokRowsForUpdatesJsonlUnderEncodedCwd() {
+        val home = File.createTempFile("ps-grok-home", "").let { tmp ->
+            tmp.delete()
+            tmp.mkdirs()
+            tmp
+        }
+        try {
+            val cwd = "/home/me/proj"
+            val encoded = "%2Fhome%2Fme%2Fproj"
+            val sessionDir = File(home, ".grok/sessions/$encoded/sess-1")
+            sessionDir.mkdirs()
+            File(sessionDir, "updates.jsonl").writeText("{}\n")
+
+            val otherDir = File(home, ".grok/sessions/%2Fother/sess-2")
+            otherDir.mkdirs()
+            File(otherDir, "updates.jsonl").writeText("{}\n")
+
+            val script = AgentConversationRepository().detectionCommand(cwd)
+            val process = ProcessBuilder("sh", "-c", script)
+                .apply { environment()["HOME"] = home.absolutePath }
+                .start()
+            val stdout = process.inputStream.bufferedReader().readText()
+            process.waitFor()
+
+            val grokRows = stdout.lineSequence().filter { it.startsWith("grok|") }.toList()
+            assertTrue(
+                "detectionCommand must emit a grok| row for updates.jsonl under the encoded cwd; got: $stdout",
+                grokRows.any { it.contains("sess-1/updates.jsonl") && it.contains(cwd) },
+            )
+            assertTrue(
+                "detectionCommand must not emit a grok| row for a different encoded cwd; got: $stdout",
+                grokRows.none { it.contains("sess-2/updates.jsonl") },
+            )
+        } finally {
+            home.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun detectionCommandHonorsGrokHomeWhenResolvingUpdatesJsonl() {
+        val home = File.createTempFile("ps-grok-default-home", "").let { tmp ->
+            tmp.delete()
+            tmp.mkdirs()
+            tmp
+        }
+        val grokHome = File.createTempFile("ps-grok-custom", "").let { tmp ->
+            tmp.delete()
+            tmp.mkdirs()
+            tmp
+        }
+        try {
+            val cwd = "/workspace/proj"
+            val encoded = "%2Fworkspace%2Fproj"
+            val sessionDir = File(grokHome, "sessions/$encoded/sess-9")
+            sessionDir.mkdirs()
+            File(sessionDir, "updates.jsonl").writeText("{}\n")
+
+            val script = AgentConversationRepository().detectionCommand(cwd)
+            val process = ProcessBuilder("sh", "-c", script)
+                .apply {
+                    environment()["HOME"] = home.absolutePath
+                    environment()["GROK_HOME"] = grokHome.absolutePath
+                }
+                .start()
+            val stdout = process.inputStream.bufferedReader().readText()
+            process.waitFor()
+
+            assertTrue(
+                "detectionCommand must honor GROK_HOME; got: $stdout",
+                stdout.lineSequence().any {
+                    it.startsWith("grok|") && it.contains("sess-9/updates.jsonl")
+                },
+            )
+        } finally {
+            home.deleteRecursively()
+            grokHome.deleteRecursively()
+        }
+    }
+
+    @Test
     fun detectionCommandUsesA120MinuteFreshnessWindowForClaude() {
         val command = AgentConversationRepository().detectionCommand("/workspace/pocketshell")
 

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryGrokTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryGrokTest.kt
@@ -1,0 +1,171 @@
+package com.pocketshell.app.session
+
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.ConversationRole
+import com.pocketshell.core.agents.GrokBuildParser
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #2155: the tmux `-t` target every recorded-source-resolving exec reads
+ * `@ps_agent_source_generation` / `@ps_agent_source` against. It is now a
+ * required parameter of `detectRecordedSessionForPane` — the source is resolved
+ * LIVE inside that exec instead of being handed in by a caller that may be
+ * holding a path from a PREVIOUS agent launch in the same session.
+ */
+private const val RECORDED_SESSION_TARGET: String = "$3"
+
+/**
+ * Issue #2193: Grok Build conversation-source + tail-coalesce cases extracted
+ * from [AgentConversationRepositoryTest] so that file stays under the 128 KiB
+ * hygiene threshold. Same package so they share the internal
+ * [parseTranscriptTailLines] helper.
+ */
+class AgentConversationRepositoryGrokTest {
+    @Test
+    fun recordedGrokSessionBindsToGrokOverANewerClaudeSibling() = runTest {
+        val now = System.currentTimeMillis() / 1000
+        val grokPath =
+            "/home/testuser/.grok/sessions/%2Fworkspace%2Fproj/grok-sess/updates.jsonl"
+        val session = FakeSshSession(
+            detectionOutput = """
+                claude|$now|/workspace/proj|/home/testuser/.claude/projects/-workspace-proj/newer.jsonl
+                grok|${now - 300}|/workspace/proj|$grokPath
+            """.trimIndent(),
+        )
+
+        val detection = AgentConversationRepository().detectRecordedSessionForPane(
+            session = session,
+            sessionTarget = RECORDED_SESSION_TARGET,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/3",
+            paneCommand = "grok",
+            recordedKind = AgentKind.GrokBuild,
+        )
+
+        assertEquals(AgentKind.GrokBuild, detection?.agent)
+        assertEquals("grok-sess", detection?.sessionId)
+        assertEquals(grokPath, detection?.sourcePath)
+        assertFalse(
+            "recorded Grok (session id in path) must not require a process scan; " +
+                "got ${session.execCommands}",
+            session.execCommands.any { it.contains("ps -eo pid,ppid,tty,comm,args") },
+        )
+    }
+
+    @Test
+    fun recordedAgentKindFromOptionMapsGrok() {
+        val repo = AgentConversationRepository()
+        assertEquals(AgentKind.GrokBuild, repo.recordedAgentKindFromOption("grok"))
+        assertEquals(AgentKind.GrokBuild, repo.recordedAgentKindFromOption("GROK"))
+    }
+
+    @Test
+    fun kindOfOwnedTranscriptPathRecognisesGrokUpdatesJsonl() {
+        val repo = AgentConversationRepository()
+        assertEquals(
+            AgentKind.GrokBuild,
+            repo.kindOfOwnedTranscriptPath(
+                "/home/me/.grok/sessions/%2Fhome%2Fme%2Fproj/sess/updates.jsonl",
+            ),
+        )
+        assertEquals(
+            null,
+            repo.kindOfOwnedTranscriptPath("/tmp/backup/updates.jsonl"),
+        )
+    }
+
+    @Test
+    fun parseTranscriptTailLinesCoalescesGrokChunks() {
+        // Multi-turn, real user-chunk shape: eventId only, no promptId /
+        // promptIndex. G6 mutation: User messageId `?: "0"` collapses both
+        // user turns onto grok:user:s:0 and the 2-User count fails.
+        val user1 = """{"timestamp":1787072184,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Hi"}},"_meta":{"eventId":"u1"}}}"""
+        val asst1a = """{"timestamp":1787072185,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello "}},"_meta":{"eventId":"a1","promptId":"p1"}}}"""
+        val asst1b = """{"timestamp":1787072186,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"there"}},"_meta":{"eventId":"a2","promptId":"p1"}}}"""
+        val thought = """{"timestamp":1787072186,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}}}"""
+        val tool = """{"timestamp":1787072187,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"c1","title":"bash","rawInput":{"command":"pwd"}}}}"""
+        val result = """{"timestamp":1787072188,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"tool_call_update","toolCallId":"c1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"/tmp"}}]}}}"""
+        val user2 = """{"timestamp":1787072189,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Again"}},"_meta":{"eventId":"u2"}}}"""
+        val asst2a = """{"timestamp":1787072190,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Still "}},"_meta":{"eventId":"a3","promptId":"p2"}}}"""
+        val asst2b = """{"timestamp":1787072191,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"here"}},"_meta":{"eventId":"a4","promptId":"p2"}}}"""
+
+        val events = parseTranscriptTailLines(
+            GrokBuildParser(),
+            AgentKind.GrokBuild,
+            sequenceOf(user1, asst1a, asst1b, thought, tool, result, user2, asst2a, asst2b),
+        )
+
+        val users = events.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.User }
+        val assistants = events.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.Assistant }
+        assertEquals("two user turns, not one collapsed Message", 2, users.size)
+        assertEquals(2, assistants.size)
+        assertEquals(1, events.filterIsInstance<ConversationEvent.ToolCall>().size)
+        assertEquals(1, events.filterIsInstance<ConversationEvent.ToolResult>().size)
+        assertEquals("Hi", users[0].text)
+        assertEquals("Again", users[1].text)
+        assertEquals("Hello there", assistants[0].text)
+        assertEquals("Still here", assistants[1].text)
+        assertTrue(users[0].id != users[1].id)
+        assertEquals("bash", (events.filterIsInstance<ConversationEvent.ToolCall>().single()).name)
+        assertEquals("/tmp", (events.filterIsInstance<ConversationEvent.ToolResult>().single()).output)
+    }
+
+    private class FakeSshSession(
+        private val detectionOutput: String = "",
+    ) : SshSession {
+        val execCommands = mutableListOf<String>()
+
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            execCommands += command
+            val stdout = when {
+                command.contains("claude_dir=") -> detectionOutput
+                else -> ""
+            }
+            return ExecResult(stdout = stdout, stderr = "", exitCode = 0)
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun tail(path: String, fromLineExclusive: Long, onLine: (String) -> Unit): Job = Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward {
+            throw NotImplementedError()
+        }
+
+        override fun startShell(): SshShell {
+            throw NotImplementedError()
+        }
+
+        override suspend fun uploadFile(file: File, remotePath: String): String =
+            error("uploadFile not used in this test")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("uploadStream not used in this test")
+
+        override fun close() = Unit
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -4,7 +4,6 @@ import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.agents.ClaudeCodeParser
 import com.pocketshell.core.agents.ConversationEvent
-import com.pocketshell.core.agents.GrokBuildParser
 import com.pocketshell.core.agents.ConversationImage
 import com.pocketshell.core.agents.ConversationRole
 import com.pocketshell.core.ssh.ExecResult
@@ -1204,97 +1203,6 @@ class AgentConversationRepositoryTest {
                 "got ${session.execCommands}",
             session.execCommands.any { it.contains("ps -eo pid,ppid,tty,comm,args") },
         )
-    }
-
-    @Test
-    fun recordedGrokSessionBindsToGrokOverANewerClaudeSibling() = runTest {
-        val now = System.currentTimeMillis() / 1000
-        val grokPath =
-            "/home/testuser/.grok/sessions/%2Fworkspace%2Fproj/grok-sess/updates.jsonl"
-        val session = FakeSshSession(
-            detectionOutput = """
-                claude|$now|/workspace/proj|/home/testuser/.claude/projects/-workspace-proj/newer.jsonl
-                grok|${now - 300}|/workspace/proj|$grokPath
-            """.trimIndent(),
-        )
-
-        val detection = AgentConversationRepository().detectRecordedSessionForPane(
-            session = session,
-            sessionTarget = RECORDED_SESSION_TARGET,
-            cwd = "/workspace/proj",
-            paneTty = "/dev/pts/3",
-            paneCommand = "grok",
-            recordedKind = AgentKind.GrokBuild,
-        )
-
-        assertEquals(AgentKind.GrokBuild, detection?.agent)
-        assertEquals("grok-sess", detection?.sessionId)
-        assertEquals(grokPath, detection?.sourcePath)
-        assertFalse(
-            "recorded Grok (session id in path) must not require a process scan; " +
-                "got ${session.execCommands}",
-            session.execCommands.any { it.contains("ps -eo pid,ppid,tty,comm,args") },
-        )
-    }
-
-    @Test
-    fun recordedAgentKindFromOptionMapsGrok() {
-        val repo = AgentConversationRepository()
-        assertEquals(AgentKind.GrokBuild, repo.recordedAgentKindFromOption("grok"))
-        assertEquals(AgentKind.GrokBuild, repo.recordedAgentKindFromOption("GROK"))
-    }
-
-    @Test
-    fun kindOfOwnedTranscriptPathRecognisesGrokUpdatesJsonl() {
-        val repo = AgentConversationRepository()
-        assertEquals(
-            AgentKind.GrokBuild,
-            repo.kindOfOwnedTranscriptPath(
-                "/home/me/.grok/sessions/%2Fhome%2Fme%2Fproj/sess/updates.jsonl",
-            ),
-        )
-        assertEquals(
-            null,
-            repo.kindOfOwnedTranscriptPath("/tmp/backup/updates.jsonl"),
-        )
-    }
-
-    @Test
-    fun parseTranscriptTailLinesCoalescesGrokChunks() {
-        // Multi-turn, real user-chunk shape: eventId only, no promptId /
-        // promptIndex. G6 mutation: User messageId `?: "0"` collapses both
-        // user turns onto grok:user:s:0 and the 2-User count fails.
-        val user1 = """{"timestamp":1787072184,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Hi"}},"_meta":{"eventId":"u1"}}}"""
-        val asst1a = """{"timestamp":1787072185,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello "}},"_meta":{"eventId":"a1","promptId":"p1"}}}"""
-        val asst1b = """{"timestamp":1787072186,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"there"}},"_meta":{"eventId":"a2","promptId":"p1"}}}"""
-        val thought = """{"timestamp":1787072186,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}}}"""
-        val tool = """{"timestamp":1787072187,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"c1","title":"bash","rawInput":{"command":"pwd"}}}}"""
-        val result = """{"timestamp":1787072188,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"tool_call_update","toolCallId":"c1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"/tmp"}}]}}}"""
-        val user2 = """{"timestamp":1787072189,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Again"}},"_meta":{"eventId":"u2"}}}"""
-        val asst2a = """{"timestamp":1787072190,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Still "}},"_meta":{"eventId":"a3","promptId":"p2"}}}"""
-        val asst2b = """{"timestamp":1787072191,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"here"}},"_meta":{"eventId":"a4","promptId":"p2"}}}"""
-
-        val events = parseTranscriptTailLines(
-            GrokBuildParser(),
-            AgentKind.GrokBuild,
-            sequenceOf(user1, asst1a, asst1b, thought, tool, result, user2, asst2a, asst2b),
-        )
-
-        val users = events.filterIsInstance<ConversationEvent.Message>()
-            .filter { it.role == ConversationRole.User }
-        val assistants = events.filterIsInstance<ConversationEvent.Message>()
-            .filter { it.role == ConversationRole.Assistant }
-        assertEquals("two user turns, not one collapsed Message", 2, users.size)
-        assertEquals(2, assistants.size)
-        assertEquals(1, events.filterIsInstance<ConversationEvent.ToolCall>().size)
-        assertEquals(1, events.filterIsInstance<ConversationEvent.ToolResult>().size)
-        assertEquals("Hi", users[0].text)
-        assertEquals("Again", users[1].text)
-        assertEquals("Hello there", assistants[0].text)
-        assertEquals("Still here", assistants[1].text)
-        assertTrue(users[0].id != users[1].id)
-        assertEquals("bash", (events.filterIsInstance<ConversationEvent.ToolCall>().single()).name)
-        assertEquals("/tmp", (events.filterIsInstance<ConversationEvent.ToolResult>().single()).output)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/AgentConversationRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.agents.ClaudeCodeParser
 import com.pocketshell.core.agents.ConversationEvent
+import com.pocketshell.core.agents.GrokBuildParser
 import com.pocketshell.core.agents.ConversationImage
 import com.pocketshell.core.agents.ConversationRole
 import com.pocketshell.core.ssh.ExecResult
@@ -21,6 +22,7 @@ import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -1202,6 +1204,97 @@ class AgentConversationRepositoryTest {
                 "got ${session.execCommands}",
             session.execCommands.any { it.contains("ps -eo pid,ppid,tty,comm,args") },
         )
+    }
+
+    @Test
+    fun recordedGrokSessionBindsToGrokOverANewerClaudeSibling() = runTest {
+        val now = System.currentTimeMillis() / 1000
+        val grokPath =
+            "/home/testuser/.grok/sessions/%2Fworkspace%2Fproj/grok-sess/updates.jsonl"
+        val session = FakeSshSession(
+            detectionOutput = """
+                claude|$now|/workspace/proj|/home/testuser/.claude/projects/-workspace-proj/newer.jsonl
+                grok|${now - 300}|/workspace/proj|$grokPath
+            """.trimIndent(),
+        )
+
+        val detection = AgentConversationRepository().detectRecordedSessionForPane(
+            session = session,
+            sessionTarget = RECORDED_SESSION_TARGET,
+            cwd = "/workspace/proj",
+            paneTty = "/dev/pts/3",
+            paneCommand = "grok",
+            recordedKind = AgentKind.GrokBuild,
+        )
+
+        assertEquals(AgentKind.GrokBuild, detection?.agent)
+        assertEquals("grok-sess", detection?.sessionId)
+        assertEquals(grokPath, detection?.sourcePath)
+        assertFalse(
+            "recorded Grok (session id in path) must not require a process scan; " +
+                "got ${session.execCommands}",
+            session.execCommands.any { it.contains("ps -eo pid,ppid,tty,comm,args") },
+        )
+    }
+
+    @Test
+    fun recordedAgentKindFromOptionMapsGrok() {
+        val repo = AgentConversationRepository()
+        assertEquals(AgentKind.GrokBuild, repo.recordedAgentKindFromOption("grok"))
+        assertEquals(AgentKind.GrokBuild, repo.recordedAgentKindFromOption("GROK"))
+    }
+
+    @Test
+    fun kindOfOwnedTranscriptPathRecognisesGrokUpdatesJsonl() {
+        val repo = AgentConversationRepository()
+        assertEquals(
+            AgentKind.GrokBuild,
+            repo.kindOfOwnedTranscriptPath(
+                "/home/me/.grok/sessions/%2Fhome%2Fme%2Fproj/sess/updates.jsonl",
+            ),
+        )
+        assertEquals(
+            null,
+            repo.kindOfOwnedTranscriptPath("/tmp/backup/updates.jsonl"),
+        )
+    }
+
+    @Test
+    fun parseTranscriptTailLinesCoalescesGrokChunks() {
+        // Multi-turn, real user-chunk shape: eventId only, no promptId /
+        // promptIndex. G6 mutation: User messageId `?: "0"` collapses both
+        // user turns onto grok:user:s:0 and the 2-User count fails.
+        val user1 = """{"timestamp":1787072184,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Hi"}},"_meta":{"eventId":"u1"}}}"""
+        val asst1a = """{"timestamp":1787072185,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello "}},"_meta":{"eventId":"a1","promptId":"p1"}}}"""
+        val asst1b = """{"timestamp":1787072186,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"there"}},"_meta":{"eventId":"a2","promptId":"p1"}}}"""
+        val thought = """{"timestamp":1787072186,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}}}"""
+        val tool = """{"timestamp":1787072187,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"tool_call","toolCallId":"c1","title":"bash","rawInput":{"command":"pwd"}}}}"""
+        val result = """{"timestamp":1787072188,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"tool_call_update","toolCallId":"c1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"/tmp"}}]}}}"""
+        val user2 = """{"timestamp":1787072189,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"Again"}},"_meta":{"eventId":"u2"}}}"""
+        val asst2a = """{"timestamp":1787072190,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Still "}},"_meta":{"eventId":"a3","promptId":"p2"}}}"""
+        val asst2b = """{"timestamp":1787072191,"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"here"}},"_meta":{"eventId":"a4","promptId":"p2"}}}"""
+
+        val events = parseTranscriptTailLines(
+            GrokBuildParser(),
+            AgentKind.GrokBuild,
+            sequenceOf(user1, asst1a, asst1b, thought, tool, result, user2, asst2a, asst2b),
+        )
+
+        val users = events.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.User }
+        val assistants = events.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.Assistant }
+        assertEquals("two user turns, not one collapsed Message", 2, users.size)
+        assertEquals(2, assistants.size)
+        assertEquals(1, events.filterIsInstance<ConversationEvent.ToolCall>().size)
+        assertEquals(1, events.filterIsInstance<ConversationEvent.ToolResult>().size)
+        assertEquals("Hi", users[0].text)
+        assertEquals("Again", users[1].text)
+        assertEquals("Hello there", assistants[0].text)
+        assertEquals("Still here", assistants[1].text)
+        assertTrue(users[0].id != users[1].id)
+        assertEquals("bash", (events.filterIsInstance<ConversationEvent.ToolCall>().single()).name)
+        assertEquals("/tmp", (events.filterIsInstance<ConversationEvent.ToolResult>().single()).output)
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionScreenTest.kt
@@ -902,6 +902,7 @@ class TmuxSessionScreenTest {
         assertTrue(tmuxSessionRecordedAgentKind(SessionAgentKind.Claude))
         assertTrue(tmuxSessionRecordedAgentKind(SessionAgentKind.Codex))
         assertTrue(tmuxSessionRecordedAgentKind(SessionAgentKind.OpenCode))
+        assertTrue(tmuxSessionRecordedAgentKind(SessionAgentKind.Grok))
         assertTrue(!tmuxSessionRecordedAgentKind(SessionAgentKind.Shell))
         assertTrue(!tmuxSessionRecordedAgentKind(SessionAgentKind.Probing))
         assertTrue(!tmuxSessionRecordedAgentKind(SessionAgentKind.Exited))
@@ -1424,6 +1425,7 @@ class TmuxSessionScreenTest {
         assertEquals(AgentKind.ClaudeCode, tmuxComposerAgentKindFromToken("claude"))
         assertEquals(AgentKind.Codex, tmuxComposerAgentKindFromToken("codex"))
         assertEquals(AgentKind.OpenCode, tmuxComposerAgentKindFromToken("opencode"))
+        assertEquals(AgentKind.GrokBuild, tmuxComposerAgentKindFromToken("grok"))
     }
 
     @Test

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ context; the README and current feature docs track released behavior.
 | [architecture.md](architecture.md) | Composition layout, tech stack, three load-bearing decisions |
 | [input-methods.md](input-methods.md) | Voice, key bar, snippets, and composer behaviour — the alternative-to-typing strategy |
 | [ssh-qr-import.md](ssh-qr-import.md) | Versioned SSH host import payload and helper commands for QR generation |
-| [agent-awareness.md](agent-awareness.md) | Detecting Claude Code, Codex, and OpenCode in a tmux pane and showing a clean conversation view |
+| [agent-awareness.md](agent-awareness.md) | Detecting Claude Code, Codex, OpenCode, and Grok Build in a tmux pane and showing a clean conversation view |
 | [usage-panel.md](usage-panel.md) | Provider quota / usage tracking via server-side `pocketshell usage` over SSH — zero credentials on the phone |
 | [diagnostics.md](diagnostics.md) | Shareable JSONL flight recorder for app, connection, network, and action events |
 | [design-language.md](design-language.md) | Termius-inspired visual tokens |

--- a/docs/agent-awareness.md
+++ b/docs/agent-awareness.md
@@ -1,6 +1,6 @@
 # Agent Awareness
 
-PocketShell detects when Claude Code, Codex, or OpenCode is running in
+PocketShell detects when Claude Code, Codex, OpenCode, or Grok Build is running in
 the active tmux pane and surfaces a clean conversation view of *that
 session* — solving the "I can't see what the agent just asked me"
 scrollback problem.
@@ -27,7 +27,8 @@ Detection combines log candidates with pane/process evidence:
    candidate logs for the supported agents. Claude Code is cwd-encoded
    under `~/.claude/projects/`; Codex candidates are filtered by
    rollout `session_meta.cwd`; OpenCode candidates are filtered by
-   SQLite session directory / project worktree.
+   SQLite session directory / project worktree; Grok Build candidates
+   live under `$GROK_HOME/sessions/<urlencoded-cwd>/` (default `~/.grok`).
 2. Pane-scoped process scan. For tmux panes, PocketShell scopes `ps`
    output to the pane TTY and requires the matching agent command to be
    present before showing the Conversation tab.
@@ -41,6 +42,7 @@ If both miss → no Conversation tab. Silent.
 | Claude Code | `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` | Yes (append-only) |
 | Codex (OpenAI) | `~/.codex/sessions/**/*.jsonl` | Yes after the rollout JSONL flushes |
 | OpenCode | `~/.local/share/opencode/opencode.db` | Yes, polled from SQLite |
+| Grok Build | `$GROK_HOME/sessions/<urlencoded-cwd>/<session-id>/updates.jsonl` | Yes (ACP JSONL) |
 
 Codex and OpenCode use wider freshness windows than Claude Code. Codex
 flushes its rollout JSONL on turn completion, and OpenCode persists to a
@@ -49,6 +51,8 @@ but still requires cwd/session filtering and pane process evidence before
 attributing them to the visible pane.
 
 Encoded-cwd format for Claude Code: `/home/alexey/git/pocketshell` → `-home-alexey-git-pocketshell`.
+
+Encoded-cwd format for Grok Build: `/home/alexey/git/pocketshell` → `%2Fhome%2Falexey%2Fgit%2Fpocketshell` (percent-encoding, honouring `GROK_HOME`).
 
 ## UI
 
@@ -135,6 +139,7 @@ core-agents/
 ├── ClaudeCodeParser.kt     # JSONL -> ConversationEvent
 ├── CodexParser.kt          # JSONL -> ConversationEvent
 ├── OpenCodeReader.kt       # SQLite/JSON rows -> ConversationEvent
+├── GrokBuildParser.kt      # ACP updates.jsonl -> ConversationEvent
 ├── AgentDetector.kt        # path hints + freshness + process confirmation
 └── ConversationEvent.kt    # normalized model
 ```

--- a/shared/core-agents/src/main/java/com/pocketshell/core/agents/AgentDetector.kt
+++ b/shared/core-agents/src/main/java/com/pocketshell/core/agents/AgentDetector.kt
@@ -186,6 +186,7 @@ public class AgentDetector(
         AgentKind.ClaudeCode to listOf(".claude/projects/${encodeClaudeCwd(cwd)}"),
         AgentKind.Codex to listOf(".codex/sessions/"),
         AgentKind.OpenCode to listOf(".local/share/opencode/opencode.db"),
+        AgentKind.GrokBuild to listOf(".grok/sessions/${encodeGrokCwd(cwd)}"),
     )
 
     /**
@@ -207,6 +208,28 @@ public class AgentDetector(
     public fun encodeClaudeCwd(cwd: String): String =
         cwd.trim().replace('/', '-').replace('.', '-').ifBlank { "-" }
 
+    /**
+     * Percent-encodes a working directory the way Grok Build names the
+     * group under `~/.grok/sessions/<encoded-cwd>/`. `/home/me/proj` →
+     * `%2Fhome%2Fme%2Fproj` (RFC 3986 unreserved characters stay literal).
+     */
+    public fun encodeGrokCwd(cwd: String): String {
+        val trimmed = cwd.trim().ifBlank { "/" }
+        val bytes = trimmed.toByteArray(Charsets.UTF_8)
+        val out = StringBuilder(bytes.size * 3)
+        for (byte in bytes) {
+            val unsigned = byte.toInt() and 0xFF
+            val ch = unsigned.toChar()
+            if (ch.isLetterOrDigit() || ch == '-' || ch == '_' || ch == '.' || ch == '~') {
+                out.append(ch)
+            } else {
+                out.append('%')
+                out.append("%02X".format(unsigned))
+            }
+        }
+        return out.toString()
+    }
+
     private fun normalizeCwd(cwd: String): String =
         cwd.trim().trimEnd('/').ifBlank { "/" }
 
@@ -216,6 +239,7 @@ public class AgentDetector(
             AgentKind.ClaudeCode -> lower.containsCommandToken("claude(?:-?code)?")
             AgentKind.Codex -> lower.containsCommandToken("codex")
             AgentKind.OpenCode -> lower.containsCommandToken("open[-_]?code(?:[-_][a-z0-9]+)?")
+            AgentKind.GrokBuild -> lower.containsCommandToken("grok")
         }
     }
 

--- a/shared/core-agents/src/main/java/com/pocketshell/core/agents/ConversationEvent.kt
+++ b/shared/core-agents/src/main/java/com/pocketshell/core/agents/ConversationEvent.kt
@@ -4,6 +4,7 @@ public enum class AgentKind(public val displayName: String) {
     ClaudeCode("Claude Code"),
     Codex("Codex"),
     OpenCode("OpenCode"),
+    GrokBuild("Grok Build"),
 }
 
 public enum class ConversationRole {

--- a/shared/core-agents/src/main/java/com/pocketshell/core/agents/GrokBuildParser.kt
+++ b/shared/core-agents/src/main/java/com/pocketshell/core/agents/GrokBuildParser.kt
@@ -1,0 +1,174 @@
+package com.pocketshell.core.agents
+
+import org.json.JSONObject
+
+/**
+ * Parser for Grok Build ACP `updates.jsonl` lines (`session/update`).
+ *
+ * [parseLine] is per-line. Assistant chunks share a stable [promptId] and
+ * accumulate text so same-id replacement keeps the concatenated reply, not
+ * the last chunk alone. User turns are one chunk each with a unique
+ * [eventId] (no promptId on live rows). [GrokBuildReader.parseLines]
+ * collapses those replacements into one event per turn.
+ */
+public class GrokBuildParser : ConversationParser {
+    private val accumulatedText = LinkedHashMap<String, String>()
+
+    override fun parseLine(line: String): List<ConversationEvent> {
+        val json = line.asJsonObjectOrNull() ?: return emptyList()
+        val params = json.objectOrNull("params") ?: return emptyList()
+        val update = params.objectOrNull("update") ?: return emptyList()
+        val kind = update.stringOrNull("sessionUpdate") ?: return emptyList()
+        val atMillis = timestampOf(json, params)
+        val sessionId = params.stringOrNull("sessionId").orEmpty()
+        val meta = params.objectOrNull("_meta") ?: update.objectOrNull("_meta")
+
+        return when (kind) {
+            "user_message_chunk" -> messageChunk(
+                update = update,
+                meta = meta,
+                sessionId = sessionId,
+                atMillis = atMillis,
+                role = ConversationRole.User,
+            )
+            "agent_message_chunk" -> messageChunk(
+                update = update,
+                meta = meta,
+                sessionId = sessionId,
+                atMillis = atMillis,
+                role = ConversationRole.Assistant,
+            )
+            "tool_call" -> toolCall(update, atMillis)
+            "tool_call_update" -> toolResult(update, atMillis)
+            "agent_thought_chunk", "hook_execution" -> emptyList()
+            else -> emptyList()
+        }
+    }
+
+    private fun messageChunk(
+        update: JSONObject,
+        meta: JSONObject?,
+        sessionId: String,
+        atMillis: Long?,
+        role: ConversationRole,
+    ): List<ConversationEvent> {
+        val text = chunkText(update) ?: return emptyList()
+        val id = messageId(role, sessionId, meta)
+        val combined = (accumulatedText[id] ?: "") + text
+        accumulatedText[id] = combined
+        return listOf(
+            ConversationEvent.Message(
+                id = id,
+                agent = AgentKind.GrokBuild,
+                atMillis = atMillis,
+                role = role,
+                text = combined,
+            ),
+        )
+    }
+
+    private fun toolCall(update: JSONObject, atMillis: Long?): List<ConversationEvent> {
+        val id = update.stringOrNull("toolCallId") ?: return emptyList()
+        return listOf(
+            ConversationEvent.ToolCall(
+                id = id,
+                agent = AgentKind.GrokBuild,
+                atMillis = atMillis,
+                name = update.stringOrNull("title") ?: "tool",
+                input = update.opt("rawInput").stringValue(),
+            ),
+        )
+    }
+
+    private fun toolResult(update: JSONObject, atMillis: Long?): List<ConversationEvent> {
+        val status = update.stringOrNull("status")?.lowercase()
+        if (status != null && status != "completed") return emptyList()
+        val toolCallId = update.stringOrNull("toolCallId") ?: return emptyList()
+        val output = toolResultText(update)
+        if (output.isEmpty() && status != "completed") return emptyList()
+        return listOf(
+            ConversationEvent.ToolResult(
+                id = "$toolCallId:result",
+                agent = AgentKind.GrokBuild,
+                atMillis = atMillis,
+                toolCallId = toolCallId,
+                output = output,
+            ),
+        )
+    }
+
+    private var userTurnSeq = 0
+
+    private fun messageId(
+        role: ConversationRole,
+        sessionId: String,
+        meta: JSONObject?,
+    ): String {
+        val promptId = meta?.stringOrNull("promptId")
+        val promptIndex = meta?.longOrNull("promptIndex")
+        val eventId = meta?.stringOrNull("eventId")
+        return when (role) {
+            // Live user_message_chunk rows have neither promptId nor
+            // promptIndex — only eventId. One chunk per turn; do not
+            // collapse every user turn onto literal "0".
+            ConversationRole.User ->
+                "grok:user:$sessionId:${promptIndex ?: promptId ?: eventId ?: nextUserTurnId()}"
+            ConversationRole.Assistant ->
+                "grok:assistant:$sessionId:${promptId ?: promptIndex ?: "0"}"
+        }
+    }
+
+    private fun nextUserTurnId(): String = "u${userTurnSeq++}"
+
+    private fun chunkText(update: JSONObject): String? {
+        val content = update.opt("content")
+        val text = when (content) {
+            is String -> content
+            is JSONObject -> content.stringOrNull("text")
+            else -> null
+        }?.takeIf { it.isNotEmpty() }
+        return text
+    }
+
+    private fun toolResultText(update: JSONObject): String {
+        val parts = ArrayList<String>()
+        update.arrayOrNull("content")?.objects()?.forEach { item ->
+            val inner = item.objectOrNull("content") ?: item
+            inner.stringOrNull("text")?.takeIf { it.isNotEmpty() }?.let { parts += it }
+        }
+        if (parts.isNotEmpty()) return parts.joinToString("\n")
+        return update.opt("rawOutput").stringValue()
+    }
+
+    private fun timestampOf(json: JSONObject, params: JSONObject): Long? {
+        val seconds = json.longOrNull("timestamp")
+        if (seconds != null) {
+            return if (seconds < 10_000_000_000L) seconds * 1000 else seconds
+        }
+        return params.objectOrNull("_meta")?.longOrNull("agentTimestampMs")
+    }
+}
+
+/** File-level reader that collapses same-id Grok chunk replacements. */
+public class GrokBuildReader {
+    public fun parseLines(lines: Iterable<String>): List<ConversationEvent> {
+        val parser = GrokBuildParser()
+        val byId = LinkedHashMap<String, ConversationEvent>()
+        for (line in lines) {
+            for (event in parser.parseLine(line)) {
+                byId[event.id] = event
+            }
+        }
+        return byId.values.toList()
+    }
+
+    public companion object {
+        public fun coalesce(events: List<ConversationEvent>): List<ConversationEvent> {
+            val byId = LinkedHashMap<String, ConversationEvent>()
+            for (event in events) {
+                byId[event.id] = event
+            }
+            return byId.values.toList()
+        }
+    }
+}

--- a/shared/core-agents/src/test/java/com/pocketshell/core/agents/AgentDetectorTest.kt
+++ b/shared/core-agents/src/test/java/com/pocketshell/core/agents/AgentDetectorTest.kt
@@ -3,6 +3,7 @@ package com.pocketshell.core.agents
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -127,6 +128,89 @@ class AgentDetectorTest {
             listOf(".local/share/opencode/opencode.db"),
             hints[AgentKind.OpenCode],
         )
+        val grokHints = hints[AgentKind.GrokBuild]
+        assertTrue(
+            "Grok hint must include .grok/sessions/; got $grokHints",
+            grokHints.orEmpty().any { it.contains(".grok/sessions/") },
+        )
+        assertTrue(
+            "Grok hint must include the URL-encoded cwd; got $grokHints",
+            grokHints.orEmpty().any { it.contains("%2Fhome%2Falexey%2Fgit%2Fpocketshell") },
+        )
+    }
+
+    @Test
+    fun encodesGrokCwdAsPercentEncodedPath() {
+        assertEquals(
+            "%2Fhome%2Falexey%2Fgit%2Fpocketshell",
+            detector.encodeGrokCwd("/home/alexey/git/pocketshell"),
+        )
+        assertEquals(
+            "%2Fhome%2Fme%2Fproj",
+            detector.encodeGrokCwd("/home/me/proj"),
+        )
+    }
+
+    @Test
+    fun detectsGrokCandidateWhenPathMatchesEncodedCwd() {
+        val detection = detector.detect(
+            cwd = "/home/me/proj",
+            nowMillis = 10_000,
+            candidates = listOf(
+                AgentLogCandidate(
+                    agent = AgentKind.GrokBuild,
+                    path = "/home/me/.grok/sessions/%2Fhome%2Fme%2Fproj/sess-1/updates.jsonl",
+                    modifiedAtMillis = 9_500,
+                    sessionId = "sess-1",
+                    cwd = "/home/me/proj",
+                ),
+            ),
+            processLines = listOf("1234 pts/0 00:00:01 grok --always-approve"),
+        )
+
+        assertNotNull(detection)
+        assertEquals(AgentKind.GrokBuild, detection?.agent)
+        assertEquals("sess-1", detection?.sessionId)
+        assertEquals(AgentDetection.Confidence.ProcessConfirmed, detection?.confidence)
+    }
+
+    @Test
+    fun rejectsGrokCandidateOutsideExpectedDirectoryTree() {
+        val detection = detector.detect(
+            cwd = "/home/me/proj",
+            nowMillis = 10_000,
+            candidates = listOf(
+                AgentLogCandidate(
+                    agent = AgentKind.GrokBuild,
+                    path = "/tmp/backup/updates.jsonl",
+                    modifiedAtMillis = 9_500,
+                    cwd = "/home/me/proj",
+                ),
+            ),
+            processLines = listOf("1234 grok"),
+        )
+
+        assertNull(detection)
+    }
+
+    @Test
+    fun groqEnvLineDoesNotConfirmGrokProcess() {
+        val detection = detector.detect(
+            cwd = "/home/me/proj",
+            nowMillis = 10_000,
+            candidates = listOf(
+                AgentLogCandidate(
+                    agent = AgentKind.GrokBuild,
+                    path = "/home/me/.grok/sessions/%2Fhome%2Fme%2Fproj/sess-1/updates.jsonl",
+                    modifiedAtMillis = 9_500,
+                    sessionId = "sess-1",
+                ),
+            ),
+            processLines = listOf("4242 pts/3 00:00:00 env GROQ_API_KEY=secret node app.js"),
+            requireProcessMatch = true,
+        )
+
+        assertNull(detection)
     }
 
     @Test

--- a/shared/core-agents/src/test/java/com/pocketshell/core/agents/GrokBuildParserTest.kt
+++ b/shared/core-agents/src/test/java/com/pocketshell/core/agents/GrokBuildParserTest.kt
@@ -1,0 +1,240 @@
+package com.pocketshell.core.agents
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2193: Grok Build ACP `updates.jsonl` must coalesce streaming chunks
+ * into one user Message, one assistant Message, plus tool call/result. A
+ * one-event-per-chunk implementation must fail the exact counts below (G6).
+ */
+class GrokBuildParserTest {
+
+    @Test
+    fun parseLinesCoalescesChunksAndDropsThoughtsAndHooks() {
+        val lines = listOf(
+            acpLine(
+                sessionUpdate = "user_message_chunk",
+                contentText = "Look at this wrapper.",
+                eventId = "evt-user-1",
+            ),
+            acpLine(
+                sessionUpdate = "agent_thought_chunk",
+                contentText = "I should inspect the repo first.",
+                eventId = "evt-thought-1",
+            ),
+            acpLine(
+                sessionUpdate = "agent_message_chunk",
+                contentText = "I'll start by checking ",
+                eventId = "evt-asst-1",
+                promptId = "prompt-1",
+            ),
+            acpLine(
+                sessionUpdate = "agent_message_chunk",
+                contentText = "how other agents are wrapped.",
+                eventId = "evt-asst-2",
+                promptId = "prompt-1",
+            ),
+            hookLine(),
+            toolCallLine(
+                toolCallId = "call-1",
+                title = "run_terminal_command",
+                command = "ls -la",
+            ),
+            toolResultLine(
+                toolCallId = "call-1",
+                output = "total 12\ndrwxr-xr-x 3 me me 4096 Jan 1 .",
+            ),
+        )
+
+        val events = GrokBuildReader().parseLines(lines)
+
+        assertEquals(
+            "one user, one assistant, one tool call, one tool result — " +
+                "not one event per ACP chunk",
+            4,
+            events.size,
+        )
+        val user = events[0] as ConversationEvent.Message
+        val assistant = events[1] as ConversationEvent.Message
+        val toolCall = events[2] as ConversationEvent.ToolCall
+        val toolResult = events[3] as ConversationEvent.ToolResult
+
+        assertEquals(ConversationRole.User, user.role)
+        assertEquals("Look at this wrapper.", user.text)
+        assertEquals(AgentKind.GrokBuild, user.agent)
+
+        assertEquals(ConversationRole.Assistant, assistant.role)
+        assertEquals(
+            "I'll start by checking how other agents are wrapped.",
+            assistant.text,
+        )
+        assertEquals(AgentKind.GrokBuild, assistant.agent)
+
+        assertEquals("run_terminal_command", toolCall.name)
+        assertTrue(toolCall.input.contains("ls -la"))
+        assertEquals("call-1", toolCall.id)
+
+        assertEquals("call-1", toolResult.toolCallId)
+        assertEquals("total 12\ndrwxr-xr-x 3 me me 4096 Jan 1 .", toolResult.output)
+        assertTrue(events.none { it is ConversationEvent.SystemNote })
+    }
+
+    @Test
+    fun parseLinesKeepsMultiTurnUsersDistinctWithoutPromptId() {
+        // Live user_message_chunk rows carry eventId only — no promptId /
+        // promptIndex. G6 mutation: User messageId falling back to literal
+        // "0" (`promptIndex ?: promptId ?: "0"`) collapses both turns onto
+        // grok:user:<session>:0 and the 2-User count / distinct-text
+        // asserts fail.
+        val lines = listOf(
+            acpLine(
+                sessionUpdate = "user_message_chunk",
+                contentText = "First question.",
+                eventId = "evt-user-1",
+            ),
+            acpLine(
+                sessionUpdate = "agent_message_chunk",
+                contentText = "Answer one ",
+                eventId = "evt-asst-1a",
+                promptId = "prompt-1",
+            ),
+            acpLine(
+                sessionUpdate = "agent_message_chunk",
+                contentText = "part A.",
+                eventId = "evt-asst-1b",
+                promptId = "prompt-1",
+            ),
+            toolCallLine(
+                toolCallId = "call-1",
+                title = "run_terminal_command",
+                command = "pwd",
+            ),
+            toolResultLine(
+                toolCallId = "call-1",
+                output = "/workspace",
+            ),
+            acpLine(
+                sessionUpdate = "user_message_chunk",
+                contentText = "Second question.",
+                eventId = "evt-user-2",
+            ),
+            acpLine(
+                sessionUpdate = "agent_message_chunk",
+                contentText = "Answer two ",
+                eventId = "evt-asst-2a",
+                promptId = "prompt-2",
+            ),
+            acpLine(
+                sessionUpdate = "agent_message_chunk",
+                contentText = "part B.",
+                eventId = "evt-asst-2b",
+                promptId = "prompt-2",
+            ),
+        )
+
+        val events = GrokBuildReader().parseLines(lines)
+        val users = events.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.User }
+        val assistants = events.filterIsInstance<ConversationEvent.Message>()
+            .filter { it.role == ConversationRole.Assistant }
+        val toolCalls = events.filterIsInstance<ConversationEvent.ToolCall>()
+        val toolResults = events.filterIsInstance<ConversationEvent.ToolResult>()
+
+        assertEquals("two user turns, not one collapsed Message", 2, users.size)
+        assertEquals("two assistant replies (promptId-coalesced)", 2, assistants.size)
+        assertEquals(1, toolCalls.size)
+        assertEquals(1, toolResults.size)
+
+        assertEquals("First question.", users[0].text)
+        assertEquals("Second question.", users[1].text)
+        assertEquals("Answer one part A.", assistants[0].text)
+        assertEquals("Answer two part B.", assistants[1].text)
+        assertTrue(
+            "user ids must differ; literal 0 fallback makes them identical",
+            users[0].id != users[1].id,
+        )
+        assertTrue(users.none { it.id.endsWith(":0") })
+        assertEquals("run_terminal_command", toolCalls[0].name)
+        assertEquals("/workspace", toolResults[0].output)
+    }
+
+    @Test
+    fun parseLineDropsThoughtsAndHooksOnTheirOwn() {
+        val parser = GrokBuildParser()
+        assertEquals(emptyList<ConversationEvent>(), parser.parseLine(hookLine()))
+        assertEquals(
+            emptyList<ConversationEvent>(),
+            parser.parseLine(
+                acpLine(
+                    sessionUpdate = "agent_thought_chunk",
+                    contentText = "thinking",
+                    eventId = "t1",
+                ),
+            ),
+        )
+    }
+
+    private fun acpLine(
+        sessionUpdate: String,
+        contentText: String,
+        eventId: String,
+        promptId: String? = null,
+    ): String {
+        val prompt = if (promptId != null) {
+            """, "promptId": "$promptId""""
+        } else {
+            ""
+        }
+        return """
+            {"timestamp": 1787072184, "method": "session/update", "params": {
+              "sessionId": "sess-1",
+              "update": {
+                "sessionUpdate": "$sessionUpdate",
+                "content": {"type": "text", "text": "$contentText"}
+              },
+              "_meta": {"eventId": "$eventId"$prompt}
+            }}
+        """.trimIndent().replace("\n", "")
+    }
+
+    private fun hookLine(): String = """
+        {"timestamp": 1787072195, "method": "_x.ai/session/update", "params": {
+          "sessionId": "sess-1",
+          "update": {
+            "sessionUpdate": "hook_execution",
+            "event_name": "pre_tool_use",
+            "tool_name": "run_terminal_command",
+            "runs": [{"name": "hook", "status": {"status": "success"}}]
+          }
+        }}
+    """.trimIndent().replace("\n", "")
+
+    private fun toolCallLine(toolCallId: String, title: String, command: String): String = """
+        {"timestamp": 1787072195, "method": "session/update", "params": {
+          "sessionId": "sess-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "$toolCallId",
+            "title": "$title",
+            "rawInput": {"command": "$command", "description": "list files"}
+          }
+        }}
+    """.trimIndent().replace("\n", "")
+
+    private fun toolResultLine(toolCallId: String, output: String): String {
+        val escaped = output.replace("\n", "\\n")
+        return """
+            {"timestamp": 1787072196, "method": "session/update", "params": {
+              "sessionId": "sess-1",
+              "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "$toolCallId",
+                "status": "completed",
+                "content": [{"type": "content", "content": {"type": "text", "text": "$escaped"}}]
+              }
+            }}
+        """.trimIndent().replace("\n", "")
+    }
+}

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/model/SessionAgentKind.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/model/SessionAgentKind.kt
@@ -10,6 +10,7 @@ enum class SessionAgentKind {
     Claude,
     Codex,
     OpenCode,
+    Grok,
     Shell,
     Probing,
     Exited,
@@ -33,11 +34,11 @@ enum class SessionAgentKind {
          * [Probing], [Exited], and [Unknown] are transient/derived states,
          * not user-assignable classifications, so they are excluded.
          *
-         * Ordered Claude / Codex / OpenCode / Shell — agents first (the
+         * Ordered Claude / Codex / OpenCode / Grok / Shell — agents first (the
          * common case), shell last.
          */
         val pickable: List<SessionAgentKind> =
-            listOf(Claude, Codex, OpenCode, Shell)
+            listOf(Claude, Codex, OpenCode, Grok, Shell)
     }
 }
 
@@ -54,6 +55,7 @@ fun SessionAgentKind.isLiveAgent(): Boolean = when (this) {
     SessionAgentKind.Claude,
     SessionAgentKind.Codex,
     SessionAgentKind.OpenCode,
+    SessionAgentKind.Grok,
     -> true
     SessionAgentKind.Shell,
     SessionAgentKind.Probing,
@@ -75,6 +77,7 @@ fun SessionAgentKind.tmuxOptionValue(): String? = when (this) {
     SessionAgentKind.Claude -> "claude"
     SessionAgentKind.Codex -> "codex"
     SessionAgentKind.OpenCode -> "opencode"
+    SessionAgentKind.Grok -> "grok"
     SessionAgentKind.Shell -> "shell"
     SessionAgentKind.Probing,
     SessionAgentKind.Exited,
@@ -96,6 +99,7 @@ fun sessionAgentKindFromOption(raw: String?): SessionAgentKind? =
         "claude" -> SessionAgentKind.Claude
         "codex" -> SessionAgentKind.Codex
         "opencode" -> SessionAgentKind.OpenCode
+        "grok" -> SessionAgentKind.Grok
         "shell" -> SessionAgentKind.Shell
         else -> null
     }

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/model/SessionAgentKindOptionTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/model/SessionAgentKindOptionTest.kt
@@ -18,6 +18,7 @@ class SessionAgentKindOptionTest {
         assertEquals("claude", SessionAgentKind.Claude.tmuxOptionValue())
         assertEquals("codex", SessionAgentKind.Codex.tmuxOptionValue())
         assertEquals("opencode", SessionAgentKind.OpenCode.tmuxOptionValue())
+        assertEquals("grok", SessionAgentKind.Grok.tmuxOptionValue())
         assertEquals("shell", SessionAgentKind.Shell.tmuxOptionValue())
     }
 
@@ -41,6 +42,7 @@ class SessionAgentKindOptionTest {
         assertEquals(SessionAgentKind.Claude, sessionAgentKindFromOption("CLAUDE"))
         assertEquals(SessionAgentKind.Codex, sessionAgentKindFromOption(" codex "))
         assertEquals(SessionAgentKind.OpenCode, sessionAgentKindFromOption("opencode"))
+        assertEquals(SessionAgentKind.Grok, sessionAgentKindFromOption("GROK"))
         assertEquals(SessionAgentKind.Shell, sessionAgentKindFromOption("shell"))
     }
 
@@ -61,6 +63,7 @@ class SessionAgentKindOptionTest {
                 SessionAgentKind.Claude,
                 SessionAgentKind.Codex,
                 SessionAgentKind.OpenCode,
+                SessionAgentKind.Grok,
                 SessionAgentKind.Shell,
             ),
             SessionAgentKind.pickable,

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/model/SessionAgentStateTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/model/SessionAgentStateTest.kt
@@ -259,6 +259,7 @@ class SessionAgentStateTest {
         assertEquals(true, SessionAgentKind.Claude.isLiveAgent())
         assertEquals(true, SessionAgentKind.Codex.isLiveAgent())
         assertEquals(true, SessionAgentKind.OpenCode.isLiveAgent())
+        assertEquals(true, SessionAgentKind.Grok.isLiveAgent())
         assertEquals(false, SessionAgentKind.Shell.isLiveAgent())
         assertEquals(false, SessionAgentKind.Probing.isLiveAgent())
         assertEquals(false, SessionAgentKind.Exited.isLiveAgent())

--- a/tools/pocketshell/src/pocketshell/agent_log.py
+++ b/tools/pocketshell/src/pocketshell/agent_log.py
@@ -125,6 +125,26 @@ def _opencode_root() -> Path:
     return Path.home() / ".local" / "share" / "opencode"
 
 
+def _grok_sessions_root() -> Path:
+    """Root directory for Grok Build session trees.
+
+    Honours ``GROK_HOME`` (default ``~/.grok``). Session files live at
+    ``<root>/sessions/<urlencoded-cwd>/<session-id>/updates.jsonl``.
+    """
+    override = os.environ.get("GROK_HOME")
+    if override:
+        return Path(override).expanduser() / "sessions"
+    return Path.home() / ".grok" / "sessions"
+
+
+def _encode_grok_cwd(cwd: str) -> str:
+    """Percent-encode a cwd the way Grok names session group directories."""
+    from urllib.parse import quote
+
+    trimmed = cwd.strip() or "/"
+    return quote(trimmed, safe="")
+
+
 def _encode_claude_cwd(cwd: str) -> str:
     """Mirror of ``AgentDetector.encodeClaudeCwd`` from core-agents.
 
@@ -232,6 +252,34 @@ def _resolve_codex_path(session: str) -> Optional[Path]:
     return None
 
 
+def _resolve_grok_path(session: str, cwd: Optional[str]) -> Optional[Path]:
+    """Resolve a Grok Build session to its ``updates.jsonl``.
+
+    ``session`` is the session-id directory name. When ``cwd`` is given the
+    lookup is ``$GROK_HOME/sessions/<urlencoded-cwd>/<session>/updates.jsonl``.
+    When omitted we scan every encoded-cwd directory for that session id.
+    """
+    session_id = session
+    if session.endswith("/updates.jsonl"):
+        session_id = Path(session).parent.name
+    elif session == "updates.jsonl":
+        session_id = session
+    root = _grok_sessions_root()
+    if cwd is not None:
+        candidate = root / _encode_grok_cwd(cwd) / session_id / "updates.jsonl"
+        return _contained_candidate(candidate, root)
+    if not root.is_dir():
+        return None
+    for project_dir in sorted(root.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        candidate = project_dir / session_id / "updates.jsonl"
+        contained = _contained_candidate(candidate, root)
+        if contained is not None:
+            return contained
+    return None
+
+
 def _resolve_opencode_path(session: str) -> Optional[Path]:
     """Resolve an OpenCode session to its JSONL file.
 
@@ -261,6 +309,8 @@ def _resolve_log_path(
         return _resolve_codex_path(session)
     if engine == "opencode":
         return _resolve_opencode_path(session)
+    if engine == "grok":
+        return _resolve_grok_path(session, cwd)
     # Click's ``type=Choice`` rejects unknown engines before we ever get
     # here; guard anyway so the function is total.
     return None
@@ -469,6 +519,26 @@ def _opencode_messages_from_row(row: dict[str, Any]) -> List[HandoffMessage]:
     return [HandoffMessage(role=role, text=fallback)] if fallback else []
 
 
+def _grok_content_text(update: dict[str, Any]) -> Optional[str]:
+    content = update.get("content")
+    if isinstance(content, dict):
+        return _text_from_scalar(content.get("text"))
+    return _text_from_scalar(content)
+
+
+def _grok_messages_from_row(row: dict[str, Any]) -> List[HandoffMessage]:
+    params = row.get("params") if isinstance(row.get("params"), dict) else {}
+    update = params.get("update") if isinstance(params.get("update"), dict) else {}
+    kind = update.get("sessionUpdate")
+    if kind == "user_message_chunk":
+        text = _grok_content_text(update)
+        return [HandoffMessage(role="user", text=text)] if text else []
+    if kind == "agent_message_chunk":
+        text = _grok_content_text(update)
+        return [HandoffMessage(role="assistant", text=text)] if text else []
+    return []
+
+
 def _handoff_messages_from_lines(engine: str, lines: Iterable[str]) -> List[HandoffMessage]:
     """Extract user/assistant prose from raw agent JSONL rows."""
     messages: List[HandoffMessage] = []
@@ -482,6 +552,8 @@ def _handoff_messages_from_lines(engine: str, lines: Iterable[str]) -> List[Hand
             messages.extend(_codex_messages_from_row(row))
         elif engine == "opencode":
             messages.extend(_opencode_messages_from_row(row))
+        elif engine == "grok":
+            messages.extend(_grok_messages_from_row(row))
     return messages
 
 
@@ -635,7 +707,7 @@ def _emit_json(
     "-e",
     "engine",
     required=False,
-    type=click.Choice(["claude", "codex", "opencode"], case_sensitive=False),
+    type=click.Choice(["claude", "codex", "opencode", "grok"], case_sensitive=False),
     help="Which agent CLI's log to read.",
 )
 @click.option(
@@ -644,8 +716,8 @@ def _emit_json(
     type=str,
     default=None,
     help=(
-        "Working directory the agent was launched from. Only used for "
-        "Claude Code (to pick the right `~/.claude/projects/<encoded>/` "
+        "Working directory the agent was launched from. Used for "
+        "Claude Code and Grok Build (to pick the right encoded-cwd "
         "subdirectory). Ignored for codex and opencode."
     ),
 )
@@ -753,7 +825,7 @@ def agent_log_command(
     "-e",
     "engine",
     required=True,
-    type=click.Choice(["claude", "codex", "opencode"], case_sensitive=False),
+    type=click.Choice(["claude", "codex", "opencode", "grok"], case_sensitive=False),
     help="Which agent CLI's log to export.",
 )
 @click.option(
@@ -762,8 +834,8 @@ def agent_log_command(
     type=str,
     default=None,
     help=(
-        "Working directory the agent was launched from. Only used for "
-        "Claude Code; ignored for codex and opencode."
+        "Working directory the agent was launched from. Used for "
+        "Claude Code and Grok Build; ignored for codex and opencode."
     ),
 )
 @click.option(
@@ -849,4 +921,6 @@ def _search_root_for(engine: str) -> str:
         return str(_codex_sessions_root()) + os.sep + "<YYYY>/<MM>/<DD>" + os.sep
     if engine == "opencode":
         return str(_opencode_root()) + os.sep
+    if engine == "grok":
+        return str(_grok_sessions_root()) + os.sep + "<urlencoded-cwd>" + os.sep
     return "(unknown engine)"

--- a/tools/pocketshell/src/pocketshell/agents.py
+++ b/tools/pocketshell/src/pocketshell/agents.py
@@ -1,6 +1,6 @@
 """`pocketshell agent <kind> --dir <dir>` subcommand.
 
-Launch a coding-agent CLI (``codex`` / ``claude`` / ``opencode``) in a
+Launch a coding-agent CLI (``codex`` / ``claude`` / ``opencode`` / ``grok``) in a
 folder, server-side, replacing the giant inline ``env -u VAR1 -u VAR2 …``
 line the Android app used to type into the new tmux pane (issue #703).
 
@@ -67,6 +67,9 @@ Prompt suppression (the part that fixes "the agent doesn't start")
   wrapper pre-seeds ``projects.<dir>.hasTrustDialogAccepted = true`` before
   exec, so claude starts straight into the usable agent prompt.
 - **opencode** — config-driven; no first-run modal to suppress.
+- **grok** — no first-run trust modal. ``--always-approve`` is the
+  skip-permissions flag. Session logs live under ``$GROK_HOME/sessions``
+  (default ``~/.grok``).
 """
 
 from __future__ import annotations
@@ -81,6 +84,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote
 
 import click
 
@@ -182,7 +186,7 @@ PROVIDER_ENV_UNSET_VARS: tuple[str, ...] = (
 
 # Recognised agent kinds. Order is the picker's order (claude, codex,
 # opencode) but the wrapper is keyed by name, not ordinal.
-AGENT_KINDS: tuple[str, ...] = ("codex", "claude", "opencode")
+AGENT_KINDS: tuple[str, ...] = ("codex", "claude", "opencode", "grok")
 
 
 # ---------------------------------------------------------------------------
@@ -238,6 +242,8 @@ def build_env(
             env["CODEX_HOME"] = config_dir
         elif kind == "claude":
             env["CLAUDE_CONFIG_DIR"] = config_dir
+        elif kind == "grok":
+            env["GROK_HOME"] = config_dir
 
     return env
 
@@ -271,6 +277,11 @@ def build_argv(kind: str, *, skip_permissions: bool) -> list[str]:
         return argv
     if kind == "opencode":
         return ["opencode"]
+    if kind == "grok":
+        argv = ["grok"]
+        if skip_permissions:
+            argv.append("--always-approve")
+        return argv
     raise ValueError(f"unknown agent kind: {kind!r}")
 
 
@@ -451,6 +462,19 @@ def _encode_agent_cwd(cwd: str) -> str:
     return trimmed.replace("/", "-").replace(".", "-") if trimmed else "-"
 
 
+def _encode_grok_cwd(cwd: str) -> str:
+    """Percent-encode a cwd the way Grok names ``~/.grok/sessions/<cwd>/``."""
+    trimmed = cwd.strip() or "/"
+    return quote(trimmed, safe="")
+
+
+def _grok_home() -> Path:
+    override = os.environ.get("GROK_HOME")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".grok"
+
+
 def _codex_file_cwd(path: Path) -> Optional[str]:
     try:
         with path.open("r", encoding="utf-8", errors="replace") as handle:
@@ -504,6 +528,20 @@ def _latest_codex_source(cwd: str, started_at: float) -> Optional[str]:
     return str(max(candidates, key=_path_mtime))
 
 
+def _latest_grok_source(cwd: str, started_at: float) -> Optional[str]:
+    root = _grok_home() / "sessions" / _encode_grok_cwd(cwd)
+    if not root.is_dir():
+        return None
+    candidates = [
+        path
+        for path in root.glob("*/updates.jsonl")
+        if path.is_file() and _path_mtime(path) >= started_at
+    ]
+    if not candidates:
+        return None
+    return str(max(candidates, key=_path_mtime))
+
+
 def _latest_opencode_source(cwd: str, started_at: float) -> Optional[str]:
     db = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
     if not db.is_file():
@@ -544,6 +582,8 @@ def _latest_agent_source(
         return _latest_codex_source(cwd, started_at)
     if kind == "opencode":
         return _latest_opencode_source(cwd, started_at)
+    if kind == "grok":
+        return _latest_grok_source(cwd, started_at)
     return None
 
 
@@ -901,7 +941,8 @@ def _make_agent_command(kind: str):
         show_default=True,
         help=(
             "Launch with per-action approval prompts disabled "
-            "(codex YOLO / claude bypass). No-op for opencode."
+            "(codex YOLO / claude bypass / grok --always-approve). "
+            "No-op for opencode."
         ),
     )
     @click.option(

--- a/tools/pocketshell/src/pocketshell/cgroup_agents.py
+++ b/tools/pocketshell/src/pocketshell/cgroup_agents.py
@@ -49,6 +49,7 @@ DEFAULT_PROC_ROOT = "/proc"
 AGENT_CLAUDE = "claude"
 AGENT_CODEX = "codex"
 AGENT_OPENCODE = "opencode"
+AGENT_GROK = "grok"
 AGENT_NONE = "none"
 AGENT_UNKNOWN = "unknown"
 
@@ -63,6 +64,7 @@ _AGENT_TOKEN_PATTERNS: Sequence[tuple[str, str]] = (
     (AGENT_CLAUDE, r"claude(?:-?code)?"),
     (AGENT_CODEX, r"codex"),
     (AGENT_OPENCODE, r"open[-_]?code(?:[-_][a-z0-9]+)?"),
+    (AGENT_GROK, r"grok"),
 )
 
 # Pre-compile the boundary-wrapped matchers once. The guard is identical to

--- a/tools/pocketshell/tests/test_agent_log.py
+++ b/tools/pocketshell/tests/test_agent_log.py
@@ -111,6 +111,7 @@ def test_agent_log_help_lists_engine_session_tail_json_flags() -> None:
     assert "claude" in lowered
     assert "codex" in lowered
     assert "opencode" in lowered
+    assert "grok" in lowered
 
 
 def test_agent_log_handoff_help_lists_export_bounds() -> None:
@@ -250,6 +251,75 @@ def test_opencode_session_reads_local_share_directory(fake_home: Path) -> None:
 
     runner = CliRunner()
     result = runner.invoke(agent_log_command, ["--engine", "opencode", "--session", session])
+
+    assert result.exit_code == 0, result.output
+    expected = "".join(json.dumps(e, sort_keys=True) + "\n" for e in events)
+    assert result.output == expected
+
+
+# ----- Grok resolution -----------------------------------------------
+
+
+def test_grok_session_with_cwd_reads_percent_encoded_directory(fake_home: Path) -> None:
+    cwd = "/home/alexey/git/pocketshell"
+    encoded = "%2Fhome%2Falexey%2Fgit%2Fpocketshell"
+    session = "01a015cd-780c-7ae0-befb-164bfe88c007"
+    events = _sample_events("grok")
+    log_path = (
+        fake_home / ".grok" / "sessions" / encoded / session / "updates.jsonl"
+    )
+    _write_jsonl(log_path, events)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        agent_log_command,
+        ["--engine", "grok", "--session", session, "--cwd", cwd],
+    )
+
+    assert result.exit_code == 0, result.output
+    expected = "".join(json.dumps(e, sort_keys=True) + "\n" for e in events)
+    assert result.output == expected
+
+
+def test_grok_session_without_cwd_scans_sessions_tree(fake_home: Path) -> None:
+    session = "sess-scan"
+    events = _sample_events("grok-scan")
+    log_path = (
+        fake_home
+        / ".grok"
+        / "sessions"
+        / "%2Ftmp"
+        / session
+        / "updates.jsonl"
+    )
+    _write_jsonl(log_path, events)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        agent_log_command,
+        ["--engine", "grok", "--session", session],
+    )
+
+    assert result.exit_code == 0, result.output
+    expected = "".join(json.dumps(e, sort_keys=True) + "\n" for e in events)
+    assert result.output == expected
+
+
+def test_grok_honors_grok_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    grok_home = tmp_path / "custom-grok"
+    monkeypatch.setenv("GROK_HOME", str(grok_home))
+    cwd = "/workspace/proj"
+    encoded = "%2Fworkspace%2Fproj"
+    session = "sess-home"
+    events = _sample_events("grok-home")
+    log_path = grok_home / "sessions" / encoded / session / "updates.jsonl"
+    _write_jsonl(log_path, events)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        agent_log_command,
+        ["--engine", "grok", "--session", session, "--cwd", cwd],
+    )
 
     assert result.exit_code == 0, result.output
     expected = "".join(json.dumps(e, sort_keys=True) + "\n" for e in events)

--- a/tools/pocketshell/tests/test_agents.py
+++ b/tools/pocketshell/tests/test_agents.py
@@ -156,6 +156,12 @@ def test_opencode_ignores_config_dir():
     env = agents.build_env("opencode", {}, {}, config_dir="/whatever")
     assert "CODEX_HOME" not in env
     assert "CLAUDE_CONFIG_DIR" not in env
+    assert "GROK_HOME" not in env
+
+
+def test_grok_config_dir_sets_grok_home():
+    env = agents.build_env("grok", {}, {}, config_dir="/home/u/.grok-work")
+    assert env["GROK_HOME"] == "/home/u/.grok-work"
 
 
 def test_no_config_dir_leaves_profile_vars_unset():
@@ -262,9 +268,20 @@ def test_opencode_argv_is_bare_no_flags():
     assert off == ["opencode"]
 
 
+def test_grok_argv_skip_permissions_is_always_approve():
+    on = agents.build_argv("grok", skip_permissions=True)
+    off = agents.build_argv("grok", skip_permissions=False)
+    assert on == ["grok", "--always-approve"]
+    assert off == ["grok"]
+
+
 def test_unknown_kind_argv_raises():
     with pytest.raises(ValueError):
         agents.build_argv("nope", skip_permissions=True)
+
+
+def test_grok_is_a_recognised_agent_kind():
+    assert "grok" in agents.AGENT_KINDS
 
 
 # ---------------------------------------------------------------------------
@@ -689,6 +706,33 @@ def test_latest_claude_source_ignores_prelaunch_sibling(tmp_path, monkeypatch):
     assert agents._latest_agent_source("claude", cwd, started_at=200) == str(newer)
 
 
+def test_latest_grok_source_uses_percent_encoded_cwd(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cwd = "/home/alexey/git/pocketshell"
+    encoded = "%2Fhome%2Falexey%2Fgit%2Fpocketshell"
+    session_dir = tmp_path / ".grok" / "sessions" / encoded / "sess-1"
+    session_dir.mkdir(parents=True)
+    transcript = session_dir / "updates.jsonl"
+    transcript.write_text("{}\n", encoding="utf-8")
+    os.utime(transcript, (300, 300))
+
+    assert agents._latest_agent_source("grok", cwd, started_at=200) == str(transcript)
+
+
+def test_latest_grok_source_honors_grok_home(tmp_path, monkeypatch):
+    grok_home = tmp_path / "custom-grok"
+    monkeypatch.setenv("GROK_HOME", str(grok_home))
+    cwd = "/workspace/proj"
+    encoded = "%2Fworkspace%2Fproj"
+    session_dir = grok_home / "sessions" / encoded / "sess-9"
+    session_dir.mkdir(parents=True)
+    transcript = session_dir / "updates.jsonl"
+    transcript.write_text("{}\n", encoding="utf-8")
+    os.utime(transcript, (300, 300))
+
+    assert agents._latest_agent_source("grok", cwd, started_at=200) == str(transcript)
+
+
 def test_latest_codex_source_matches_cwd_and_launch_time(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     root = tmp_path / ".codex" / "sessions" / "2026" / "06" / "27"
@@ -836,6 +880,17 @@ def test_record_agent_kind_empty_profile_clears_profile_option():
         ["tmux", "set-option", "@ps_agent_kind", "codex"],
         ["tmux", "set-option", "-uq", "@ps_agent_profile"],
     ]
+
+
+def test_record_agent_kind_writes_grok():
+    calls = []
+    ok = agents.record_agent_kind(
+        "grok",
+        env={"TMUX": "x"},
+        runner=lambda argv, **kw: calls.append(argv),
+    )
+    assert ok is True
+    assert ["tmux", "set-option", "@ps_agent_kind", "grok"] in calls
 
 
 def test_record_agent_kind_default_relaunch_clears_stale_profile():

--- a/tools/pocketshell/tests/test_agents_kind.py
+++ b/tools/pocketshell/tests/test_agents_kind.py
@@ -119,6 +119,19 @@ def _seed_opencode(host: _FakeHost) -> None:
     host.add_scope("tmuxctl-opencode-lab.scope", [3001, 3002])
 
 
+def _seed_grok(host: _FakeHost) -> None:
+    host.add_proc(
+        3501, scope="tmuxctl-grok.scope", comm="bash", cmdline="-bash"
+    )
+    host.add_proc(
+        3502,
+        scope="tmuxctl-grok.scope",
+        comm="grok",
+        cmdline="grok --always-approve",
+    )
+    host.add_scope("tmuxctl-grok.scope", [3501, 3502])
+
+
 def _seed_plain_shell(host: _FakeHost) -> None:
     """A pane that resolves to a scope but runs no agent -> ``none``."""
     host.add_proc(
@@ -177,6 +190,14 @@ def test_classifies_opencode(tmp_path: Path) -> None:
     _seed_opencode(host)
     out = _invoke([{"pane_id": "%3", "pane_pid": 3001}], host)
     assert out["results"][0]["agent_kind"] == "opencode"
+
+
+def test_classifies_grok(tmp_path: Path) -> None:
+    host = _FakeHost(tmp_path)
+    _seed_grok(host)
+    out = _invoke([{"pane_id": "%5", "pane_pid": 3501}], host)
+    assert out["results"][0]["agent_kind"] == "grok"
+    assert out["results"][0]["evidence_pid"] == 3502
 
 
 def test_plain_shell_resolves_to_none(tmp_path: Path) -> None:

--- a/tools/pocketshell/tests/test_cgroup_agents.py
+++ b/tools/pocketshell/tests/test_cgroup_agents.py
@@ -21,6 +21,7 @@ from pocketshell import cgroup_agents
 from pocketshell.cgroup_agents import (
     AGENT_CLAUDE,
     AGENT_CODEX,
+    AGENT_GROK,
     AGENT_NONE,
     AGENT_OPENCODE,
     AGENT_UNKNOWN,
@@ -129,6 +130,9 @@ def _classify(host: _FakeHost, pane_pid: int, pane_id: str = "%1"):
         ("opencode", AGENT_OPENCODE),
         ("open-code", AGENT_OPENCODE),
         ("opencode-tui", AGENT_OPENCODE),
+        ("grok", AGENT_GROK),
+        ("grok --always-approve", AGENT_GROK),
+        ("/home/alexey/.local/bin/grok --always-approve", AGENT_GROK),
         # Plain shells / unrelated processes name no agent.
         ("bash", None),
         ("/bin/bash -l", None),
@@ -137,6 +141,10 @@ def _classify(host: _FakeHost, pane_pid: int, pane_id: str = "%1"):
         # `codexicon` substring case is covered separately below.
         ("git commit && codex", AGENT_CODEX),
         ("", None),
+        # G6: a raw substring `grok` matcher must go red on these.
+        ("GROQ_API_KEY=secret", None),
+        ("/home/user/.grok/sessions/%2Ftmp/sess/updates.jsonl", None),
+        ("mygrokhelper", None),
     ],
 )
 def test_classify_token(text: str, expected: Optional[str]) -> None:
@@ -148,6 +156,9 @@ def test_classify_token_substring_does_not_false_positive() -> None:
     # guard (mirroring containsCommandToken) must NOT match it.
     assert classify_token("codexedit") is None
     assert classify_token("myclaudeproxy") is None
+    assert classify_token("GROQ_API_KEY=secret") is None
+    assert classify_token("/home/user/.grok/sessions/foo") is None
+    assert classify_token("mygrokhelper") is None
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +229,23 @@ def test_opencode_scope(host: _FakeHost) -> None:
     assert result.agent_kind == AGENT_OPENCODE
     assert result.scope == scope
     assert result.evidence_pid == 900002
+
+
+def test_grok_scope(host: _FakeHost) -> None:
+    scope = "tmuxctl-git-pocketshell.scope"
+    host.add_proc(910001, scope=scope, comm="bash", cmdline="/bin/bash -l")
+    host.add_proc(
+        910002,
+        scope=scope,
+        comm="grok",
+        cmdline="grok --always-approve",
+    )
+    host.set_scope_procs(scope, [910001, 910002])
+
+    result = _classify(host, 910001)
+    assert result.agent_kind == AGENT_GROK
+    assert result.scope == scope
+    assert result.evidence_pid == 910002
 
 
 def test_plain_shell_scope_is_none(host: _FakeHost) -> None:


### PR DESCRIPTION
Closes #2193

Reviewer APPROVED (round 2): https://github.com/alexeygrigorev/pocketshell/issues/2193#issuecomment-5332923526

Adds Grok Build as a first-class agent: picker + skip-permissions default (`grok --always-approve`), kind detect/record, and ACP conversation parse that keeps live user turns distinct when chunks carry only `eventId`.

Usage-panel quota for Grok already landed in #2195.

Orchestrator verify on rebased `origin/main`:
- `uv run --exclude-newer 2027-01-01 pytest` (agent_log / agents / agents_kind / cgroup_agents): 176 passed
- focused JVM grok suites: BUILD SUCCESSFUL