### PR TITLE
test(ci): require every androidTest class to be wired or baselined (#2188)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConsolidatedChromeScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxConsolidatedChromeScreenshotTest.kt
@@ -47,6 +47,13 @@ import org.junit.runner.RunWith
  * Combined with [TmuxSessionScreenImeChromeTest] (which asserts the
  * 56dp height limit and the IME-down/up tag visibility contract), this
  * is the visual gate for the chrome IA.
+ *
+ * Issue #2188: this class is in the per-push journey suite. It compiled
+ * for months and ran in no gate; `activeForwardingRendersContainedHeaderPillWithLongTitleAndToggle`
+ * was red on main after #2176 appended ". Opens session ports" to the
+ * pill description. 1b096d30 switched that wait to a substring match
+ * (the status wording is what this proof owns; actionability lives in
+ * [ForwardingPillOpensSessionPortsTest]).
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxConsolidatedChromeScreenshotTest {

--- a/scripts/androidtest-unwired-baseline.txt
+++ b/scripts/androidtest-unwired-baseline.txt
@@ -1,0 +1,128 @@
+# Concrete app/src/androidTest classes that are intentionally NOT in
+# scripts/ci-journey-suite.sh. Issue #2188: a test nobody runs looks like
+# coverage and provides none. New concrete @Test classes must be wired
+# into the per-push suite, added here with a reason, or marked with a
+# local // ANDROIDTEST_GATE_JUSTIFIED: comment.
+#
+# Format: FQCN<TAB>reason
+# E2e/Docker backlog stays in check-ci-journey-harness.sh
+# KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES — do not duplicate it here.
+# Stale entries (class now wired or deleted) fail the guard.
+
+com.pocketshell.app.bootstrap.CliUpdateRowSingleActionScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.bootstrap.HostBootstrapScenarioSuiteTest	nightly/release opt-in bootstrap matrix (pocketshellBootstrapScenarios); would ALL-SKIP in the per-push suite
+com.pocketshell.app.cards.SessionChecklistUiInteractionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.EngineCommandPrefillsComposerAcceptanceTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.Issue1622DeadBandScreenshotHarness	local visual screenshot harness; not a per-push property
+com.pocketshell.app.composer.PromptComposerCancelRecordingTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerDismissReleasesMicTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerImeDeadSpaceScreenshotHarness	local visual screenshot harness; not a per-push property
+com.pocketshell.app.composer.PromptComposerImeEmptyDraftDeadSpaceProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.composer.PromptComposerImeLayoutRegressionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerImeShortDraftDeadSpaceProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.composer.PromptComposerPendingTranscriptionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerRecreateAndKeepScreenOnTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerSendWhileRecordingTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerSheetImeReachabilityTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerSilenceThresholdTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerSlashButtonTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.composer.PromptComposerSlashDropdownImeContainmentProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.composer.PromptComposerVisualScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.conversation.ConversationCopyActionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.conversation.ConversationDetectingPlaceholderRenderTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.conversation.ConversationFontSizeScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.conversation.ConversationInteractionCleanupTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.conversation.ConversationTimestampScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.conversation.ConversationToTerminalSwapLatchTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.conversation.ConversationToolArgsSectionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.costs.CostsScreenScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.crash.Issue863ButtonSweepScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.fileexplorer.FileExplorerRedesignScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.fileexplorer.FileExplorerRowIconRegressionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.fileviewer.FileViewerActOnFileScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.fileviewer.FileViewerAnnotateScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.fileviewer.FileViewerSaveMediaStoreTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.fileviewer.FileViewerTypeIconTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.fileviewer.FileViewerWrapMarkdownScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.hosts.AddEditHostScreenTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.AppUpdateActionBannerTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.FirstHostTestConnectScreenTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.HostCardConnectingIndicatorTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.HostCardSetupBadgeTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.HostCardStatusChipTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.HostListEmptyStateActionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.HostOverflowMenuEditItemTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.HostUsagePerHostAccessScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.hosts.SshKeysDeleteDialogButtonScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.hosts.SshKeysManagementPaneActionsTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.hosts.UpdateBannerFeedbackTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.jobs.RecurringJobsScreenTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.nav.NavigatorSystemBackTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.portfwd.AutoForwardControlScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.portfwd.PortForwardScanningStateScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.portfwd.ShowAllPortsScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.projects.FolderContextActionSheetScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.projects.FolderListRefreshIndicatorScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.projects.FolderListSessionClickTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.projects.FolderListStopSessionTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.projects.HostDetailAssistantFlowTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.projects.HostDetailAssistantFolderDisambiguationTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.projects.RepoBrowserScreenTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.projects.RepoBrowserSessionPickerTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.projects.RootProjectAddSheetTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.projects.SessionTypePickerSkipPermissionsUiTest	isolated component UI; not load-bearing for the per-push subset
+com.pocketshell.app.proof.EmulatorDockerSshSmokeTest	local Docker/SSH smoke; not a per-push property
+com.pocketshell.app.proof.Issue1733ArtifactPreservationSmokeTest	test-infrastructure / helper coverage; not product chrome
+com.pocketshell.app.proof.LongRunningInstrumentationHeartbeatTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.proof.RealAgentReleaseGateTest	nightly/release opt-in real-agent CLI gate; would ALL-SKIP in the per-push suite
+com.pocketshell.app.proof.TerminalTextMatcherTest	test-infrastructure / helper coverage; not product chrome
+com.pocketshell.app.proof.WalkthroughConversationScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.proof.WalkthroughVisualScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.proof.signals.SignalsTest	test-infrastructure / helper coverage; not product chrome
+com.pocketshell.app.release.ReleaseCheckerInstrumentedTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.session.InlineDictationTranscribingSpinnerTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.session.RawSessionKeyboardPanLayoutTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.settings.SettingsUpdateCheckUiTest	isolated component UI; not load-bearing for the per-push subset
+com.pocketshell.app.snippets.CommandTemplateEditorDialogTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.snippets.FormDialogMigrationScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.snippets.SnippetPickerBodyPreviewTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.snippets.SnippetPickerSendButtonsTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.snippets.SnippetTemplateAndroidRegexTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.snippets.SnippetsScreenTabsTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.terminal.TerminalKeyboardStressTest	interactive lab / stress harness; not a per-push property
+com.pocketshell.app.terminal.TerminalLabInteractiveInputTest	interactive lab / stress harness; not a per-push property
+com.pocketshell.app.tmux.Issue796ComposerOpenDuringCodexBurstProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.tmux.Issue796ImeRecompositionProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.tmux.Issue796ImeRecompositionScopeProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.tmux.ReservedTmuxTerminalBottomBandTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.ShiftTabHotkeyContainmentTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TerminalHotkeysPanelNoTruncationTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TerminalHotkeysPanelScreenshotHarness	local visual screenshot harness; not a per-push property
+com.pocketshell.app.tmux.TmuxChromeKebabReachableTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxComposerLauncherLargeFontScreenshotHarness	local visual screenshot harness; not a per-push property
+com.pocketshell.app.tmux.TmuxComposerLauncherNeverClippedProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.tmux.TmuxConnectingProgressOverlayTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxConversationCodexAgentsInstructionsCollapseTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxConversationPaneNavigationUiTest	isolated component UI; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxConversationTurnDensityScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.tmux.TmuxHotkeysLauncherImeProofTest	local component proof; not promoted to the per-push subset
+com.pocketshell.app.tmux.TmuxKeyBarImeReachabilityTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxKeyboardPanLayoutTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxMoreMenuGroupingTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxMoreMenuOpenFileTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxMoreMenuPortForwardingTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxMoreMenuReconnectTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxMoreMenuRedrawTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxMoreMenuSettingsTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxNewSessionRichSheetTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxSessionBackHandlerTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxSessionDrawerUiTest	isolated component UI; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxSessionScreenImeChromeTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.tmux.TmuxTerminalImeHotkeysOverlayLifecycleTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.usage.UsageOverflowMenuTest	isolated component / instrumented unit; not load-bearing for the per-push subset
+com.pocketshell.app.usage.UsageResetBannerScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.usage.UsageResetTimeScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.usage.UsageSchedulerTestIsolationRuleTest	test-infrastructure / helper coverage; not product chrome
+com.pocketshell.app.usage.UsageStaleWhileRevalidateScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.usage.UsageThresholdTintScreenshotTest	local visual screenshot harness; not a per-push property
+com.pocketshell.app.usage.UsageWindowLabelScreenshotTest	local visual screenshot harness; not a per-push property

--- a/scripts/check-ci-journey-harness-selftest.sh
+++ b/scripts/check-ci-journey-harness-selftest.sh
@@ -511,6 +511,87 @@ else
   note_fail "a required update-notification method with a CI self-skip should fail specifically (got exit $rc)"
 fi
 
+# ---------------------------------------------------------------------------
+# Issue #2188: a concrete non-E2e/Docker androidTest class that is in neither
+# the per-push suite nor the sidecar baseline must hard-fail. That is the
+# TmuxConsolidatedChromeScreenshotTest hole: compiled, looks like coverage,
+# executed nowhere.
+# ---------------------------------------------------------------------------
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/notifications/UpdateAvailableNotificationE2eTest.kt" <<'KT'
+package com.pocketshell.app.notifications
+class UpdateAvailableNotificationE2eTest {
+    @Test
+    fun updateNotification_postsToStatusBar_andIsTappable() {
+        check(true)
+    }
+}
+KT
+mkdir -p "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/tmux"
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/tmux/UnlistedChromeScreenshotTest.kt" <<'KT'
+package com.pocketshell.app.tmux
+class UnlistedChromeScreenshotTest {
+    @Test
+    fun capture() = Unit
+}
+KT
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$out" | awk '/NEW FAIL - androidTest class not wired/{capture=1; next} /^$/{if (capture) exit} capture {print}' | grep -q 'UnlistedChromeScreenshotTest'; then
+  note_pass "unlisted ScreenshotTest is reported by the #2188 wiring guard"
+else
+  note_fail "unlisted ScreenshotTest should be reported as unwired (got exit $rc)"
+fi
+
+cat > "$SANDBOX/scripts/androidtest-unwired-baseline.txt" <<'TXT'
+com.pocketshell.app.tmux.UnlistedChromeScreenshotTest	local screenshot harness; not a per-push property
+TXT
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  note_pass "baseline-exempted ScreenshotTest is spared"
+else
+  note_fail "baseline-exempted ScreenshotTest should pass (got exit $rc)"
+  printf '%s\n' "$out" | tail -40
+fi
+
+cat >> "$SANDBOX/scripts/ci-journey-suite.sh" <<'SH'
+  "com.pocketshell.app.tmux.UnlistedChromeScreenshotTest"
+SH
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$out" | grep -q 'UnlistedChromeScreenshotTest'; then
+  note_pass "wired ScreenshotTest left in the unwired baseline is stale"
+else
+  note_fail "wired+baselined ScreenshotTest should be a stale-baseline failure (got exit $rc)"
+fi
+
+rm -f "$SANDBOX/scripts/androidtest-unwired-baseline.txt"
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  note_pass "wired ScreenshotTest with no baseline entry passes"
+else
+  note_fail "wired ScreenshotTest should pass once the stale baseline is gone (got exit $rc)"
+  printf '%s\n' "$out" | tail -40
+fi
+
+cat > "$SANDBOX/app/src/androidTest/java/com/pocketshell/app/tmux/JustifiedLocalScreenshotTest.kt" <<'KT'
+package com.pocketshell.app.tmux
+// ANDROIDTEST_GATE_JUSTIFIED: local visual harness only
+class JustifiedLocalScreenshotTest {
+    @Test
+    fun capture() = Unit
+}
+KT
+out="$(run_guard)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  note_pass "inline ANDROIDTEST_GATE_JUSTIFIED ScreenshotTest is spared"
+else
+  note_fail "inline ANDROIDTEST_GATE_JUSTIFIED ScreenshotTest should pass (got exit $rc)"
+  printf '%s\n' "$out" | tail -40
+fi
+
 echo
 echo "=============================================================="
 echo " Self-test result: $PASS passed, $FAIL failed"

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -85,6 +85,8 @@ REQUIRED_PER_PUSH_ANDROID_TEST_SELECTORS=(
 # per-push journey allowlist. New *E2eTest/*DockerTest classes must either be
 # wired into scripts/ci-journey-suite.sh or added here with an intentional
 # follow-up. Keep full FQCNs so moves are visible.
+# Non-E2e/Docker concrete classes (Screenshot/Scaffold/Ui/Proof/component) are
+# covered by scripts/androidtest-unwired-baseline.txt (issue #2188).
 KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.composer.ComposerPartialExpandE2eTest"
   "com.pocketshell.app.costs.CostsScreenE2eTest"
@@ -191,6 +193,14 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.usage.UsageScreenE2eTest"
 )
 
+# Issue #2188: every OTHER concrete androidTest class (Screenshot / Scaffold /
+# Ui / Proof / component) must be in scripts/ci-journey-suite.sh or explicitly
+# exempted with a reason. A class that only compiles (dex job) and never runs
+# is how TmuxConsolidatedChromeScreenshotTest sat red on main unnoticed.
+# E2e/Docker backlog stays in KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES above —
+# do not duplicate it in the sidecar. Override the path in the self-test.
+ANDROIDTEST_UNWIRED_BASELINE="${POCKETSHELL_ANDROIDTEST_UNWIRED_BASELINE:-scripts/androidtest-unwired-baseline.txt}"
+
 in_list() {
   local item="$1"; shift
   local candidate
@@ -246,6 +256,26 @@ android_test_fqcn_for_file() {
   local rel="${file#"$ANDROID_TEST_ROOT"/}"
   rel="${rel%.kt}"
   printf '%s\n' "${rel//\//.}"
+}
+
+file_has_line_annotation() {
+  local file="$1" name="$2"
+  grep -Eq "^[[:space:]]*@(${name}|org[.]junit[.]${name})([[:space:]]|\$|[[:space:]]*\\()" "$file"
+}
+
+is_abstract_class_file() {
+  grep -Eq '^[[:space:]]*abstract[[:space:]]+class[[:space:]]+' "$1"
+}
+
+is_e2e_or_docker_fqcn() {
+  case "$1" in
+    *E2eTest|*DockerTest) return 0 ;;
+  esac
+  return 1
+}
+
+file_has_androidtest_gate_justification() {
+  grep -Eq 'ANDROIDTEST_GATE_JUSTIFIED:[[:space:]]*[^[:space:]]' "$1"
 }
 
 declare -a JOURNEY_CLASSES=()
@@ -314,6 +344,35 @@ declare -a UNWIRED_ANDROID_E2E_DOCKER_NEW=()
 declare -a UNWIRED_ANDROID_E2E_DOCKER_KNOWN=()
 declare -a STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE=()
 declare -a NIGHTLY_FIXTURE_ROUTING_FAILURE=()
+declare -a BASELINE_UNWIRED_ANDROID_TEST_CLASSES=()
+declare -A BASELINE_UNWIRED_ANDROID_TEST_SEEN=()
+declare -a UNWIRED_ANDROID_TEST_NEW=()
+declare -a UNWIRED_ANDROID_TEST_KNOWN=()
+declare -a UNWIRED_ANDROID_TEST_JUSTIFIED=()
+declare -a STALE_UNWIRED_ANDROID_TEST_BASELINE=()
+declare -a ANDROIDTEST_BASELINE_PARSE_FAILURE=()
+
+if [[ -f "$ANDROIDTEST_UNWIRED_BASELINE" ]]; then
+  while IFS=$'\t' read -r fqcn reason || [[ -n "${fqcn:-}" ]]; do
+    [[ -z "${fqcn:-}" || "$fqcn" == \#* ]] && continue
+    if [[ "$fqcn" != com.pocketshell.app.* ]]; then
+      ANDROIDTEST_BASELINE_PARSE_FAILURE+=("not an app androidTest FQCN: $fqcn")
+      continue
+    fi
+    if is_e2e_or_docker_fqcn "$fqcn"; then
+      ANDROIDTEST_BASELINE_PARSE_FAILURE+=("E2e/Docker belongs in KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES: $fqcn")
+      continue
+    fi
+    if [[ -z "${reason:-}" ]]; then
+      ANDROIDTEST_BASELINE_PARSE_FAILURE+=("missing reason: $fqcn")
+      continue
+    fi
+    if [[ -z "${BASELINE_UNWIRED_ANDROID_TEST_SEEN[$fqcn]:-}" ]]; then
+      BASELINE_UNWIRED_ANDROID_TEST_CLASSES+=("$fqcn")
+      BASELINE_UNWIRED_ANDROID_TEST_SEEN[$fqcn]=1
+    fi
+  done < "$ANDROIDTEST_UNWIRED_BASELINE"
+fi
 
 if [[ "${#JOURNEY_CLASSES[@]}" -eq 0 ]]; then
   PARSER_FAILURE+=("NO_PROOF_CLASSES_PARSED")
@@ -545,6 +604,41 @@ done < <(
     | sort
 )
 
+# Issue #2188: every concrete non-E2e/Docker androidTest class must be wired
+# into the per-push suite, listed in the sidecar baseline with a reason, or
+# carry a local ANDROIDTEST_GATE_JUSTIFIED comment. Helpers (no @Test) and
+# abstract bases are skipped. E2e/Docker stay in the scan above.
+if [[ -d "$ANDROID_TEST_ROOT" ]]; then
+  while IFS= read -r file; do
+    [[ -z "${file:-}" ]] && continue
+    is_abstract_class_file "$file" && continue
+    file_has_line_annotation "$file" "Test" || continue
+    fqcn="$(android_test_fqcn_for_file "$file")"
+    is_e2e_or_docker_fqcn "$fqcn" && continue
+    if in_list "$fqcn" "${WIRED_ANDROID_TEST_CLASSES[@]}"; then
+      if in_list "$fqcn" "${BASELINE_UNWIRED_ANDROID_TEST_CLASSES[@]}"; then
+        STALE_UNWIRED_ANDROID_TEST_BASELINE+=("$fqcn")
+      fi
+      continue
+    fi
+    if file_has_androidtest_gate_justification "$file"; then
+      UNWIRED_ANDROID_TEST_JUSTIFIED+=("$fqcn")
+      continue
+    fi
+    if in_list "$fqcn" "${BASELINE_UNWIRED_ANDROID_TEST_CLASSES[@]}"; then
+      UNWIRED_ANDROID_TEST_KNOWN+=("$fqcn")
+    else
+      UNWIRED_ANDROID_TEST_NEW+=("$fqcn")
+    fi
+  done < <(find "$ANDROID_TEST_ROOT" -type f -name '*.kt' | sort)
+fi
+
+for fqcn in "${BASELINE_UNWIRED_ANDROID_TEST_CLASSES[@]}"; do
+  if [[ ! -f "$(android_class_file_for "$fqcn")" ]]; then
+    STALE_UNWIRED_ANDROID_TEST_BASELINE+=("$fqcn")
+  fi
+done
+
 for class_name in "${JOURNEY_CLASSES[@]}"; do
   file="$(class_file_for "$class_name")"
   if [[ ! -f "$file" ]]; then
@@ -658,11 +752,15 @@ print_list "PASS - launch-owned MainActivity harness with SeedBeforeLaunchRule" 
 print_list "KNOWN - manual old harness baseline" "${MANUAL_KNOWN[@]:-}"
 print_list "KNOWN - launch-owned but missing shared SeedBeforeLaunchRule baseline" "${MISSING_SHARED_SEED_KNOWN[@]:-}"
 print_list "KNOWN - unwired androidTest E2e/Docker baseline" "${UNWIRED_ANDROID_E2E_DOCKER_KNOWN[@]:-}"
+print_list "KNOWN - unwired androidTest class baseline (#2188)" "${UNWIRED_ANDROID_TEST_KNOWN[@]:-}"
 print_list "JUSTIFIED - local JOURNEY_HARNESS_JUSTIFIED exemption" "${MANUAL_JUSTIFIED[@]:-}" "${MISSING_SHARED_SEED_JUSTIFIED[@]:-}"
+print_list "JUSTIFIED - local ANDROIDTEST_GATE_JUSTIFIED exemption" "${UNWIRED_ANDROID_TEST_JUSTIFIED[@]:-}"
 print_list "IGNORED - listed proof class does not launch MainActivity" "${NOT_MAINACTIVITY_LAUNCHERS[@]:-}"
 print_list "STALE BASELINE - class no longer matches its baseline entry" "${STALE_BASELINE[@]:-}"
 print_list "STALE BASELINE - unwired androidTest E2e/Docker class is now wired" "${STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]:-}"
+print_list "STALE BASELINE - unwired androidTest class is now wired or deleted" "${STALE_UNWIRED_ANDROID_TEST_BASELINE[@]:-}"
 print_list "PARSER FAIL - proof allowlist parser" "${PARSER_FAILURE[@]:-}"
+print_list "PARSER FAIL - androidTest unwired baseline" "${ANDROIDTEST_BASELINE_PARSE_FAILURE[@]:-}"
 print_list "MISSING FILE - listed proof class has no source file" "${MISSING_FILES[@]:-}"
 print_list "MISSING REQUIRED - #848 per-push androidTest class not wired" "${MISSING_REQUIRED_PER_PUSH[@]:-}"
 print_list "MISSING REQUIRED SELECTOR - exact per-push androidTest method not wired" "${MISSING_REQUIRED_PER_PUSH_SELECTOR[@]:-}"
@@ -671,6 +769,7 @@ print_list "INVALID REQUIRED SELECTOR - exact method retains a CI self-skip" "${
 print_list "NEW FAIL - manual ActivityScenario/createEmptyComposeRule harness" "${MANUAL_NEW[@]:-}"
 print_list "NEW FAIL - createAndroidComposeRule without SeedBeforeLaunchRule" "${MISSING_SHARED_SEED_NEW[@]:-}"
 print_list "NEW FAIL - androidTest E2e/Docker class not wired into ci-journey-suite.sh" "${UNWIRED_ANDROID_E2E_DOCKER_NEW[@]:-}"
+print_list "NEW FAIL - androidTest class not wired into ci-journey-suite.sh" "${UNWIRED_ANDROID_TEST_NEW[@]:-}"
 print_list "FIXTURE ROUTING FAIL - #1733 nightly selection" "${NIGHTLY_FIXTURE_ROUTING_FAILURE[@]:-}"
 
 hard_fail=()
@@ -684,9 +783,12 @@ for item in \
   "${MANUAL_NEW[@]:-}" \
   "${MISSING_SHARED_SEED_NEW[@]:-}" \
   "${UNWIRED_ANDROID_E2E_DOCKER_NEW[@]:-}" \
+  "${UNWIRED_ANDROID_TEST_NEW[@]:-}" \
+  "${ANDROIDTEST_BASELINE_PARSE_FAILURE[@]:-}" \
   "${NIGHTLY_FIXTURE_ROUTING_FAILURE[@]:-}" \
   "${STALE_BASELINE[@]:-}" \
-  "${STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]:-}"; do
+  "${STALE_UNWIRED_ANDROID_E2E_DOCKER_BASELINE[@]:-}" \
+  "${STALE_UNWIRED_ANDROID_TEST_BASELINE[@]:-}"; do
   [[ -n "$item" ]] && hard_fail+=("$item")
 done
 
@@ -698,7 +800,7 @@ fi
 
 if [[ "${#hard_fail[@]}" -gt 0 ]]; then
   echo
-  echo "::error title=CI journey harness guard (#848/#788/#743)::A required #848 androidTest is missing from the per-push journey allowlist, a new androidTest E2e/Docker class is unwired, a listed com.pocketshell.app.proof journey that launches MainActivity is not using createAndroidComposeRule<MainActivity>() plus SeedBeforeLaunchRule, the allowlist parser failed, or a known-baseline entry is stale. Wire the test into scripts/ci-journey-suite.sh, add an intentional unwired baseline for backlog-only E2e/Docker classes, migrate to the launch-owned harness, remove stale baselines, or add a local // JOURNEY_HARNESS_JUSTIFIED: comment naming why the manual/old pattern is required."
+  echo "::error title=CI journey harness guard (#848/#788/#743/#2188)::A required #848 androidTest is missing from the per-push journey allowlist, a new androidTest class is unwired, a listed com.pocketshell.app.proof journey that launches MainActivity is not using createAndroidComposeRule<MainActivity>() plus SeedBeforeLaunchRule, the allowlist parser failed, or a known-baseline entry is stale. Wire the test into scripts/ci-journey-suite.sh, add it to scripts/androidtest-unwired-baseline.txt (or KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES for E2e/Docker) with a reason, migrate to the launch-owned harness, remove stale baselines, or add a local // JOURNEY_HARNESS_JUSTIFIED: / // ANDROIDTEST_GATE_JUSTIFIED: comment."
   echo
   echo "FAIL: ${#hard_fail[@]} CI journey harness issue(s)."
   exit 1

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -245,6 +245,10 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.tmux.TmuxChromeConversationTogglePresentTest"  # #1320 #962 #975 #1057 the Terminal/Conversation TOGGLE-CLIP regression guard — the…
   "com.pocketshell.app.cards.SessionCardFeedRegistryTest"  # #859 B): the typed-card RENDERER REGISTRY proof. The session feed
   "com.pocketshell.app.tmux.TmuxConnectingStatesScreenshotTest"  # #750 3rd occurrence — D31 durable-fix gate): the tmux non-Connect…
+  "com.pocketshell.app.tmux.TmuxConsolidatedChromeScreenshotTest"  # #2188 #1487 #189 #192 #637: in-session chrome IA + forwarding-pill containment under long-title+toggle pressure. Was red on main unnoticed because it compiled in the dex job and ran in no per-push gate.
+  "com.pocketshell.app.git.GitHistoryScaffoldTest"  # #2188 #646: 30 scaffold states / 29 containment assertions. Unregistered before this; #2180 migrated the helpers but CI only compiled them.
+  "com.pocketshell.app.tmux.TmuxConversationDetectingComposerVisibleTest"  # #2188 #805: composer launcher stays contained during detection-uncertainty (the v0.4.7 clip). Component proof, no Docker.
+  "com.pocketshell.app.fileviewer.FileViewerLoadingSpinnerScreenshotTest"  # #2188 #862: loading state uses the shared spinner and stays contained.
   "com.pocketshell.app.tmux.SessionSurfaceReconnectWrapperTest"  # #823 the manual-reconnect AFFORDANCE proof. The maintainer's ask…
   "$FQCN_PREFIX.Issue1831BackFromRestoredSessionJourneyE2eTest"  # #1831 D33/G10: Back from an agent session restored after process death / a config change must reach the SESSION list, not the host list; 3rd Back on the root host list still EXITS (#520)
   "com.pocketshell.app.nav.Issue1831SessionEntryPathBackE2eTest"  # #1831 G2: the other empty-back-stack producers — share-into-session, active-sessions widget, #859 agent-card push, onNewIntent re-delivery — plus the usage-notification path whose host-list fallback must NOT change


### PR DESCRIPTION
Closes #2188

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2188#issuecomment-5332619041

Register the chrome screenshot class and three siblings in the per-push journey suite, and fail guards-static when a concrete androidTest compiles but is listed nowhere. Includes `scripts/androidtest-unwired-baseline.txt`.

Orchestrator verify after rebase onto `34f7b647`: `check-ci-journey-harness.sh` PASS; self-test 27/27.