### PR TITLE
test(ci): fail-close the fault verdict when a gating method is skipped (#2141)

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -522,6 +522,11 @@ jobs:
           nf="$(grep -E '^network_fault_status=' "$file" | head -1 | cut -d= -f2)"
           bootstrap="$(grep -E '^bootstrap_status=' "$file" | head -1 | cut -d= -f2)"
           expectedfail="$(grep -E '^expected_fail_status=' "$file" | head -1 | cut -d= -f2)"
+          expected_n="$(grep -E '^expected_gating_classes=' "$file" | head -1 | cut -d= -f2-)"
+          executed_n="$(grep -E '^executed_gating_classes=' "$file" | head -1 | cut -d= -f2-)"
+          missing="$(grep -E '^missing_gating_classes=' "$file" | head -1 | cut -d= -f2-)"
+          skipped="$(grep -E '^skipped_gating_methods=' "$file" | head -1 | cut -d= -f2-)"
+          coverage="$(grep -E '^gating_coverage=' "$file" | head -1 | cut -d= -f2-)"
 
           {
             echo "# Fault-injection safety verdict"
@@ -529,6 +534,10 @@ jobs:
             echo "- network-fault (GATING): \`$nf\`"
             echo "- bootstrap (GATING): \`$bootstrap\`"
             echo "- #822 expected-fail lane (NON-GATING, tracked only): \`$expectedfail\`"
+            echo "- gating classes executed/expected (#2141): \`${executed_n:-?}/${expected_n:-?}\`"
+            echo "- skipped gating methods (#2141): \`${skipped:-}\`"
+            echo "- missing gating classes (#2141): \`${missing:-}\`"
+            echo "- gating coverage (#2141): \`${coverage:-unknown}\`"
             echo "- **fault_verdict: \`$verdict\`**"
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
@@ -538,6 +547,10 @@ jobs:
           fi
           if [[ "$verdict" == "INFRA" ]]; then
             echo "BLOCK-INFRA: a gating phase lost the emulator/device; preserved UTP evidence did not contain a substantive product assertion. Re-run on a healthy AVD before release."
+            exit 1
+          fi
+          if [[ "$verdict" == "INCOMPLETE" ]]; then
+            echo "BLOCK-INCOMPLETE: a gating method was skipped or a gating class never executed (executed=${executed_n:-?}/${expected_n:-?}; skipped=${skipped:-none}). The brief-cut hole is #1678's to fill; this job only refuses a clean PASS while it is open."
             exit 1
           fi
           echo "BLOCK: fault_verdict=$verdict — a fault-injection safety phase failed on this HEAD."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -707,6 +707,13 @@ jobs:
           chmod +x scripts/test-nightly-phase-classification.sh
           scripts/test-nightly-phase-classification.sh
 
+      # Issue #2141: a skipped or unreached gating member cannot hide behind
+      # fault_verdict=PASS. Cheap XML-fixture proof (no emulator, no Gradle).
+      - name: Nightly fault-verdict coverage guard (issue #2141)
+        run: |
+          chmod +x scripts/lib/nightly-fault-verdict.sh
+          scripts/lib/nightly-fault-verdict.sh --self-test
+
       # Issue #1581: gate the Build workflow's corrupted-NDK-download retry
       # wrapper (scripts/ci-assemble-with-ndk-retry.sh) so its clear-and-retry
       # logic cannot silently regress. Fast, JVM-free shell test (fake build cmd,

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RideThroughInterruptionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RideThroughInterruptionE2eTest.kt
@@ -46,13 +46,13 @@ class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
      * blip, and the same tmux session resumes so input reaches the agent again
      * without teardown/reconnect.
      *
-     * Issue #1678: this case has an anti-correlated FAST-night flake on the nightly
-     * toxiproxy phase-2 cohort (it fails only on the FASTEST emulator nights, passes
-     * otherwise). Per the maintainer-approved #1676 plan (option 3) and #1678, it is
-     * GATED off the automated gate with this documented reference until the #1678
-     * root-cause (the FAST-night anti-correlation mechanism) yields a deterministic
-     * grace-vs-blip seam. See issue #1678 for the tracking + intended deterministic
-     * reframe.
+     * Issue #1678 owns deleting this Assume and making the five-second journey
+     * non-vacuous. Issue #2141 does NOT restore this method: it makes the skip
+     * fail-closed in `fault-verdict.txt` so a green verdict cannot hide the hole.
+     * Neither issue covers the other. The FAST-night anti-correlation tracking
+     * and the intended deterministic reframe stay on #1678; do not treat this
+     * skip as "covered by #2141" or the verdict hole as "covered by #1678".
+     * See issue #1678 for the tracking + intended deterministic reframe.
      */
     @Test
     fun briefLinkCutRidesThroughWithoutDisconnectOrTeardown() { runBlocking {

--- a/scripts/lib/nightly-fault-verdict.sh
+++ b/scripts/lib/nightly-fault-verdict.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # nightly-fault-verdict.sh — the authoritative fault-injection safety verdict
-# helper (issue #1201).
+# helper (issue #1201, coverage visibility #2141).
 #
 # WHY THIS EXISTS
 # ---------------
@@ -30,6 +30,14 @@
 # into a job conclusion; and `check-nightly-fault-run.sh` reads THAT job's
 # conclusion (not the mixed extensive-job conclusion).
 #
+# Issue #2141: a phase-status PASS is not a clean pass while a member of the
+# gating set was skipped or never executed. The brief-cut ride-through proof
+# (`RideThroughInterruptionE2eTest#briefLinkCutRidesThroughWithoutDisconnectOrTeardown`)
+# currently self-skips via `Assume.assumeTrue(..., false)` until #1678 lands.
+# #2141 owns making that hole visible in `fault-verdict.txt` (and refusing
+# `fault_verdict=PASS` while it is open). #1678 owns deleting the Assume and
+# making the five-second journey non-vacuous. Neither covers the other.
+#
 # Everything here is PURE (no gradle, no emulator, no network) so it is
 # unit-testable with `scripts/lib/nightly-fault-verdict.sh --self-test`.
 
@@ -44,6 +52,10 @@
 # FAIL dominates INFRA so a real assertion can never be downgraded by a later
 # device loss. Otherwise INFRA is preserved as a distinct blocking verdict.
 # Prints "PASS" / "FAIL" / "INFRA"; returns 0 / 1 / 2.
+#
+# Coverage (skipped / unreached gating members) is applied later by
+# apply_gating_coverage / write_fault_verdict_file — this function stays the
+# phase-status combiner so INFRA/FAIL classification tests stay independent.
 # ---------------------------------------------------------------------------
 compute_fault_verdict() {
   local network_fault_status="$1"
@@ -67,12 +79,202 @@ compute_fault_verdict() {
 }
 
 # ---------------------------------------------------------------------------
+# apply_gating_coverage <phase_verdict> <coverage_status>
+#
+# Issue #2141: a phase-status PASS is not a clean pass unless the gating set
+# was fully evaluated. `complete` is the only coverage status that may keep
+# PASS. `incomplete` / `unknown` / anything else downgrade PASS to INCOMPLETE.
+# FAIL and INFRA dominate — a skipped method must not hide a product failure
+# or a lost device.
+# Prints PASS / FAIL / INFRA / INCOMPLETE; returns 0 / 1 / 2 / 3.
+# ---------------------------------------------------------------------------
+apply_gating_coverage() {
+  local phase_verdict="$1"
+  local coverage_status="$2"
+
+  case "$phase_verdict" in
+    FAIL)
+      echo "FAIL"
+      return 1
+      ;;
+    INFRA)
+      echo "INFRA"
+      return 2
+      ;;
+    PASS)
+      if [[ "$coverage_status" == "complete" ]]; then
+        echo "PASS"
+        return 0
+      fi
+      echo "INCOMPLETE"
+      return 3
+      ;;
+    *)
+      echo "FAIL"
+      return 1
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# assess_fault_gating_coverage <results_root> <expected_class> [...]
+#
+# Reads preserved phase-2 JUnit XML and compares it to the expected gating
+# class list (NETWORK_FAULT_CLASSES). Prints machine-readable coverage fields:
+#
+#   expected_gating_classes=N
+#   executed_gating_classes=M
+#   missing_gating_classes=A,B
+#   skipped_gating_methods=Class#method,...
+#   gating_coverage=complete|incomplete
+#
+# A class is executed when at least one of its testcases appears in the XML.
+# A method is skipped when every observed result for that Class#method is a
+# JUnit <skipped> (an evaluated pass/fail wins over a skip on retry).
+# Coverage is complete only when every expected class executed, none is
+# missing, no expected-class method is skipped, and the expected set is
+# non-empty. Returns 0 if complete, 1 if incomplete.
+# ---------------------------------------------------------------------------
+assess_fault_gating_coverage() {
+  local results_root="$1"
+  shift
+  local expected_classes=("$@")
+  local listing expected_n executed_n
+  local -a missing_list=() skipped_list=() executed_list=()
+  local line classname method status cls found
+
+  expected_n="${#expected_classes[@]}"
+  listing="$(
+    python3 - "$results_root" <<'PY'
+from collections import defaultdict
+from pathlib import Path
+from xml.etree import ElementTree
+import sys
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+results_root = Path(sys.argv[1])
+# Single load-bearing skip tag. The #2141 G6 mutant rewrites this literal so a
+# skipped gating method is treated as evaluated; that must redden the skip
+# fixture and only the skip fixture.
+skip_tag = "skipped"
+seen: dict[tuple[str, str], set[str]] = defaultdict(set)
+if results_root.is_dir():
+    for path in results_root.rglob("TEST-*.xml"):
+        try:
+            root = ElementTree.parse(path).getroot()
+        except (OSError, ElementTree.ParseError):
+            continue
+        suite_name = root.get("name") or ""
+        for node in root.iter():
+            tag = local_name(node.tag)
+            if tag in {"testsuite", "testsuites"}:
+                suite_name = node.get("name") or suite_name
+                continue
+            if tag != "testcase":
+                continue
+            classname = node.get("classname") or suite_name
+            name = node.get("name") or ""
+            if not classname or not name:
+                continue
+            child_tags = {local_name(child.tag) for child in node}
+            if child_tags & {"failure", "error"}:
+                status = "fail"
+            elif skip_tag in child_tags:
+                status = "skip"
+            else:
+                status = "pass"
+            seen[(classname, name)].add(status)
+
+for (classname, name), statuses in sorted(seen.items()):
+    if statuses & {"pass", "fail"}:
+        status = "evaluated"
+    elif "skip" in statuses:
+        status = "skip"
+    else:
+        status = "evaluated"
+    print(f"{classname}\t{name}\t{status}")
+PY
+  )"
+
+  local -A executed_set=()
+  local -A skip_set=()
+  while IFS=$'\t' read -r classname method status; do
+    [[ -n "$classname" ]] || continue
+    executed_set["$classname"]=1
+    if [[ "$status" == "skip" ]]; then
+      skip_set["$classname#$method"]=1
+    fi
+  done <<<"$listing"
+
+  for cls in "${expected_classes[@]}"; do
+    found=0
+    if [[ -n "${executed_set[$cls]+x}" ]]; then
+      found=1
+    fi
+    if [[ "$found" -eq 1 ]]; then
+      executed_list+=("$cls")
+    else
+      missing_list+=("$cls")
+    fi
+  done
+
+  for cls in "${expected_classes[@]}"; do
+    for line in "${!skip_set[@]}"; do
+      if [[ "$line" == "$cls#"* ]]; then
+        skipped_list+=("$line")
+      fi
+    done
+  done
+
+  if ((${#skipped_list[@]} > 0)); then
+    local sorted_skips=""
+    sorted_skips="$(printf '%s\n' "${skipped_list[@]}" | sort -u)"
+    skipped_list=()
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && skipped_list+=("$line")
+    done <<<"$sorted_skips"
+  fi
+
+  executed_n="${#executed_list[@]}"
+  local coverage="incomplete"
+  if [[ "$expected_n" -gt 0 \
+        && "$executed_n" -eq "$expected_n" \
+        && "${#missing_list[@]}" -eq 0 \
+        && "${#skipped_list[@]}" -eq 0 ]]; then
+    coverage="complete"
+  fi
+
+  local missing_joined="" skipped_joined=""
+  if ((${#missing_list[@]} > 0)); then
+    missing_joined="$(IFS=,; echo "${missing_list[*]}")"
+  fi
+  if ((${#skipped_list[@]} > 0)); then
+    skipped_joined="$(IFS=,; echo "${skipped_list[*]}")"
+  fi
+
+  printf 'expected_gating_classes=%s\n' "$expected_n"
+  printf 'executed_gating_classes=%s\n' "$executed_n"
+  printf 'missing_gating_classes=%s\n' "$missing_joined"
+  printf 'skipped_gating_methods=%s\n' "$skipped_joined"
+  printf 'gating_coverage=%s\n' "$coverage"
+
+  [[ "$coverage" == "complete" ]]
+}
+
+# ---------------------------------------------------------------------------
 # write_fault_verdict_file <path> <nf_status> <nf_exit> <bootstrap_status> \
-#                          <bootstrap_exit> <expectedfail_status> <expectedfail_exit>
+#                          <bootstrap_exit> <expectedfail_status> <expectedfail_exit> \
+#                          [coverage_file]
 #
 # Writes the machine-readable verdict file the CI `Fault-injection safety
 # verdict` job reads. The expected-fail fields are recorded for TRACKING only
 # and are explicitly NON-GATING (they do not feed `fault_verdict`).
+#
+# coverage_file is the output of assess_fault_gating_coverage. It is GATING:
+# a missing file, or gating_coverage other than `complete`, refuses
+# fault_verdict=PASS (issue #2141). FAIL/INFRA still dominate.
 # ---------------------------------------------------------------------------
 write_fault_verdict_file() {
   local path="$1"
@@ -82,11 +284,25 @@ write_fault_verdict_file() {
   local bootstrap_exit="$5"
   local expectedfail_status="$6"
   local expectedfail_exit="$7"
+  local coverage_file="${8:-}"
 
-  local verdict
+  local phase_verdict verdict
+  local coverage_status="unknown"
+  local expected_n="" executed_n="" missing="" skipped=""
   # `compute_fault_verdict` returns non-zero on FAIL; capture the string without
   # letting a caller's `set -e` abort here (the assignment inherits its status).
-  verdict="$(compute_fault_verdict "$nf_status" "$bootstrap_status")" || true
+  phase_verdict="$(compute_fault_verdict "$nf_status" "$bootstrap_status")" || true
+
+  if [[ -n "$coverage_file" && -f "$coverage_file" ]]; then
+    coverage_status="$(grep -E '^gating_coverage=' "$coverage_file" | head -1 | cut -d= -f2-)"
+    expected_n="$(grep -E '^expected_gating_classes=' "$coverage_file" | head -1 | cut -d= -f2-)"
+    executed_n="$(grep -E '^executed_gating_classes=' "$coverage_file" | head -1 | cut -d= -f2-)"
+    missing="$(grep -E '^missing_gating_classes=' "$coverage_file" | head -1 | cut -d= -f2-)"
+    skipped="$(grep -E '^skipped_gating_methods=' "$coverage_file" | head -1 | cut -d= -f2-)"
+    coverage_status="${coverage_status:-unknown}"
+  fi
+
+  verdict="$(apply_gating_coverage "$phase_verdict" "$coverage_status")" || true
 
   {
     echo "# Fault-injection safety verdict (issue #1201) — machine-readable."
@@ -101,6 +317,13 @@ write_fault_verdict_file() {
     echo "# NON-GATING (tracked only): the #822 Slice C/D expected-fail lane."
     echo "expected_fail_status=$expectedfail_status"
     echo "expected_fail_exit=$expectedfail_exit"
+    echo "# Issue #2141: skipped / unreached gating members cannot hide behind PASS."
+    echo "# #2141 owns visibility of this hole; #1678 owns filling it (delete the Assume)."
+    echo "expected_gating_classes=$expected_n"
+    echo "executed_gating_classes=$executed_n"
+    echo "missing_gating_classes=$missing"
+    echo "skipped_gating_methods=$skipped"
+    echo "gating_coverage=$coverage_status"
     echo "fault_verdict=$verdict"
   } > "$path"
 }
@@ -110,10 +333,17 @@ write_fault_verdict_file() {
 # gradle/emulator. This is the dry-run proof (issue #1201 acceptance) that the
 # verdict GREENs when the fault phases passed even though the journey suite /
 # expected-fail lane are red, and REDs when a fault phase itself failed.
+#
+# Issue #2141 adds the coverage fixtures: a skipped gating method or a
+# truncated class set must refuse fault_verdict=PASS, and a mutant that
+# re-skips / ignores those holes must redden only the matching assertion.
 # ---------------------------------------------------------------------------
 _fault_verdict_self_test() {
   local failures=0
-  local out rc tmp
+  local out rc tmp coverage_tmp fixture_root
+  local BRIEF_CLASS="com.pocketshell.app.proof.RideThroughInterruptionE2eTest"
+  local BRIEF_METHOD="briefLinkCutRidesThroughWithoutDisconnectOrTeardown"
+  local SUSTAINED_METHOD="sustainedLinkCutReconnectsCleanlyWithoutHang"
 
   assert_verdict() {
     local label="$1" expect="$2" expect_rc="$3" nf="$4" bootstrap="$5"
@@ -125,6 +355,48 @@ _fault_verdict_self_test() {
     else
       printf 'ok   [%s] -> %s (rc=%s)\n' "$label" "$out" "$rc"
     fi
+  }
+
+  assert_file_field() {
+    local label="$1" file="$2" field="$3" expect="$4"
+    local actual
+    actual="$(grep -E "^${field}=" "$file" | head -1 | cut -d= -f2-)"
+    if [[ "$actual" != "$expect" ]]; then
+      printf 'FAIL [%s]: %s expected %s got %s\n' "$label" "$field" "$expect" "$actual"
+      failures=$((failures + 1))
+    else
+      printf 'ok   [%s] %s=%s\n' "$label" "$field" "$actual"
+    fi
+  }
+
+  write_complete_coverage() {
+    cat > "$1" <<'EOF'
+expected_gating_classes=13
+executed_gating_classes=13
+missing_gating_classes=
+skipped_gating_methods=
+gating_coverage=complete
+EOF
+  }
+
+  write_testcase() {
+    local file="$1" classname="$2" method="$3" kind="$4"
+    {
+      printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+      if [[ "$kind" == "skip" ]]; then
+        printf '<testsuite name="%s" tests="1" failures="0" errors="0" skipped="1">\n' "$classname"
+        printf '  <testcase name="%s" classname="%s"><skipped /></testcase>\n' \
+          "$method" "$classname"
+      elif [[ "$kind" == "fail" ]]; then
+        printf '<testsuite name="%s" tests="1" failures="1" errors="0" skipped="0">\n' "$classname"
+        printf '  <testcase name="%s" classname="%s"><failure>assertion</failure></testcase>\n' \
+          "$method" "$classname"
+      else
+        printf '<testsuite name="%s" tests="1" failures="0" errors="0" skipped="0">\n' "$classname"
+        printf '  <testcase name="%s" classname="%s" />\n' "$method" "$classname"
+      fi
+      printf '%s\n' '</testsuite>'
+    } > "$file"
   }
 
   # Both gating phases green -> PASS.
@@ -139,14 +411,52 @@ _fault_verdict_self_test() {
   assert_verdict "bootstrap device offline"           INFRA 2 PASS INFRA
   assert_verdict "product red dominates infra"        FAIL 1 FAIL INFRA
 
+  out="$(apply_gating_coverage PASS complete)" && rc=0 || rc=$?
+  if [[ "$out" != PASS || "$rc" != 0 ]]; then
+    printf 'FAIL [apply complete]: expected PASS(rc=0) got %s(rc=%s)\n' "$out" "$rc"
+    failures=$((failures + 1))
+  else
+    echo "ok   [apply complete] -> PASS"
+  fi
+  out="$(apply_gating_coverage PASS incomplete)" && rc=0 || rc=$?
+  if [[ "$out" != INCOMPLETE || "$rc" != 3 ]]; then
+    printf 'FAIL [apply skip]: expected INCOMPLETE(rc=3) got %s(rc=%s)\n' "$out" "$rc"
+    failures=$((failures + 1))
+  else
+    echo "ok   [apply skip] -> INCOMPLETE"
+  fi
+  out="$(apply_gating_coverage PASS unknown)" && rc=0 || rc=$?
+  if [[ "$out" != INCOMPLETE || "$rc" != 3 ]]; then
+    printf 'FAIL [apply unknown]: expected INCOMPLETE(rc=3) got %s(rc=%s)\n' "$out" "$rc"
+    failures=$((failures + 1))
+  else
+    echo "ok   [apply unknown] -> INCOMPLETE"
+  fi
+  out="$(apply_gating_coverage FAIL incomplete)" && rc=0 || rc=$?
+  if [[ "$out" != FAIL || "$rc" != 1 ]]; then
+    printf 'FAIL [apply fail dominates]: expected FAIL(rc=1) got %s(rc=%s)\n' "$out" "$rc"
+    failures=$((failures + 1))
+  else
+    echo "ok   [apply fail dominates skip]"
+  fi
+  out="$(apply_gating_coverage INFRA incomplete)" && rc=0 || rc=$?
+  if [[ "$out" != INFRA || "$rc" != 2 ]]; then
+    printf 'FAIL [apply infra dominates]: expected INFRA(rc=2) got %s(rc=%s)\n' "$out" "$rc"
+    failures=$((failures + 1))
+  else
+    echo "ok   [apply infra dominates skip]"
+  fi
+
   # THE load-bearing #1201 direction, at the FILE level: the journey suite and
-  # the #822 expected-fail lane are red, but the fault phases passed -> the
-  # written verdict is PASS and does NOT reflect the unrelated red.
+  # the #822 expected-fail lane are red, but the fault phases passed AND the
+  # gating set was fully evaluated -> the written verdict is PASS and does NOT
+  # reflect the unrelated red.
   echo
   echo "--- file-level dry run: fault phases green, journey + expected-fail RED ---"
   tmp="$(mktemp)"
-  # journey (not an arg here) FAIL + expected-fail FAIL, but nf/bootstrap PASS.
-  write_fault_verdict_file "$tmp" PASS 0 PASS 0 FAIL 1
+  coverage_tmp="$(mktemp)"
+  write_complete_coverage "$coverage_tmp"
+  write_fault_verdict_file "$tmp" PASS 0 PASS 0 FAIL 1 "$coverage_tmp"
   cat "$tmp"
   if grep -q '^fault_verdict=PASS$' "$tmp"; then
     echo "ok   [file] fault_verdict=PASS despite expected-fail lane red"
@@ -154,7 +464,7 @@ _fault_verdict_self_test() {
     echo "FAIL [file] fault_verdict should be PASS despite expected-fail lane red"
     failures=$((failures + 1))
   fi
-  rm -f "$tmp"
+  rm -f "$tmp" "$coverage_tmp"
 
   echo
   echo "--- file-level dry run: fault phase device-offline -> verdict INFRA ---"
@@ -181,6 +491,220 @@ _fault_verdict_self_test() {
     failures=$((failures + 1))
   fi
   rm -f "$tmp"
+
+  echo
+  echo "--- #2141: omitted coverage file refuses a clean PASS (fail closed) ---"
+  tmp="$(mktemp)"
+  write_fault_verdict_file "$tmp" PASS 0 PASS 0 FAIL 1
+  cat "$tmp"
+  assert_file_field "no coverage file" "$tmp" fault_verdict INCOMPLETE
+  assert_file_field "no coverage file marks unknown" "$tmp" gating_coverage unknown
+  rm -f "$tmp"
+
+  echo
+  echo "--- #2141: skipped brief-cut method is listed and refuses PASS ---"
+  fixture_root="$(mktemp -d)"
+  local gating_expected=(
+    "$BRIEF_CLASS"
+    "com.pocketshell.app.proof.WithinGraceResumeRideThroughE2eTest"
+    "com.pocketshell.app.proof.StaleLeaseSwitchRecoveryE2eTest"
+    "com.pocketshell.app.proof.DisconnectFlapSoakE2eTest"
+    "com.pocketshell.app.proof.DisconnectBlackholeE2eTest"
+    "com.pocketshell.app.proof.NetworkLatencyModelE2eTest"
+    "com.pocketshell.app.proof.PacketLossNetworkFaultE2eTest"
+    "com.pocketshell.app.proof.OutboundAttachmentOffsetResumeJourneyE2eTest"
+    "com.pocketshell.app.proof.ColdDialUnderBandwidthLimitE2eTest"
+    "com.pocketshell.app.proof.CodexRedrawOverflowReconnectE2eTest"
+    "com.pocketshell.app.proof.PushResumeDeadSocketMainResponsiveE2eTest"
+    "com.pocketshell.app.proof.NatIdleMappingSurvivalE2eTest"
+    "com.pocketshell.app.proof.MobileLatencyStormSelfInflictedCloseE2eTest"
+  )
+  local cls
+  for cls in "${gating_expected[@]}"; do
+    if [[ "$cls" == "$BRIEF_CLASS" ]]; then
+      {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '<testsuite name="%s" tests="2" failures="0" errors="0" skipped="1">\n' "$cls"
+        printf '  <testcase name="%s" classname="%s"><skipped /></testcase>\n' \
+          "$BRIEF_METHOD" "$cls"
+        printf '  <testcase name="%s" classname="%s" />\n' "$SUSTAINED_METHOD" "$cls"
+        printf '%s\n' '</testsuite>'
+      } >"$fixture_root/TEST-$cls.xml"
+    else
+      write_testcase "$fixture_root/TEST-$cls.xml" "$cls" "loadBearing" pass
+    fi
+  done
+  coverage_tmp="$(mktemp)"
+  assess_fault_gating_coverage "$fixture_root" "${gating_expected[@]}" >"$coverage_tmp" || true
+  cat "$coverage_tmp"
+  assert_file_field "brief skip coverage" "$coverage_tmp" gating_coverage incomplete
+  assert_file_field "brief skip expected" "$coverage_tmp" expected_gating_classes 13
+  assert_file_field "brief skip executed" "$coverage_tmp" executed_gating_classes 13
+  assert_file_field "brief skip missing" "$coverage_tmp" missing_gating_classes ""
+  assert_file_field "brief skip methods" "$coverage_tmp" skipped_gating_methods \
+    "${BRIEF_CLASS}#${BRIEF_METHOD}"
+  tmp="$(mktemp)"
+  write_fault_verdict_file "$tmp" PASS 0 PASS 0 FAIL 1 "$coverage_tmp"
+  cat "$tmp"
+  assert_file_field "brief skip verdict" "$tmp" fault_verdict INCOMPLETE
+  assert_file_field "brief skip listed in verdict" "$tmp" skipped_gating_methods \
+    "${BRIEF_CLASS}#${BRIEF_METHOD}"
+  rm -f "$tmp" "$coverage_tmp"
+
+  echo
+  echo "--- #2141: 1 of 13 classes executed refuses PASS ---"
+  local truncated_root
+  truncated_root="$(mktemp -d)"
+  write_testcase \
+    "$truncated_root/TEST-only.xml" \
+    "$BRIEF_CLASS" "$SUSTAINED_METHOD" pass
+  coverage_tmp="$(mktemp)"
+  assess_fault_gating_coverage "$truncated_root" "${gating_expected[@]}" >"$coverage_tmp" || true
+  cat "$coverage_tmp"
+  assert_file_field "truncated coverage" "$coverage_tmp" gating_coverage incomplete
+  assert_file_field "truncated expected" "$coverage_tmp" expected_gating_classes 13
+  assert_file_field "truncated executed" "$coverage_tmp" executed_gating_classes 1
+  if grep -q "^missing_gating_classes=.*WithinGraceResumeRideThroughE2eTest" "$coverage_tmp"; then
+    echo "ok   [truncated missing] lists unreached gating classes"
+  else
+    echo "FAIL [truncated missing] did not list unreached gating classes"
+    failures=$((failures + 1))
+  fi
+  tmp="$(mktemp)"
+  write_fault_verdict_file "$tmp" PASS 0 PASS 0 FAIL 1 "$coverage_tmp"
+  assert_file_field "truncated verdict" "$tmp" fault_verdict INCOMPLETE
+  assert_file_field "truncated executed in verdict" "$tmp" executed_gating_classes 1
+  assert_file_field "truncated expected in verdict" "$tmp" expected_gating_classes 13
+  rm -f "$tmp" "$coverage_tmp"
+  rm -rf "$truncated_root"
+
+  echo
+  echo "--- #2141: complete 13/13 with no skips may PASS ---"
+  local complete_root
+  complete_root="$(mktemp -d)"
+  for cls in "${gating_expected[@]}"; do
+    if [[ "$cls" == "$BRIEF_CLASS" ]]; then
+      {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '<testsuite name="%s" tests="2" failures="0" errors="0" skipped="0">\n' "$cls"
+        printf '  <testcase name="%s" classname="%s" />\n' "$BRIEF_METHOD" "$cls"
+        printf '  <testcase name="%s" classname="%s" />\n' "$SUSTAINED_METHOD" "$cls"
+        printf '%s\n' '</testsuite>'
+      } >"$complete_root/TEST-$cls.xml"
+    else
+      write_testcase "$complete_root/TEST-$cls.xml" "$cls" "loadBearing" pass
+    fi
+  done
+  coverage_tmp="$(mktemp)"
+  if assess_fault_gating_coverage "$complete_root" "${gating_expected[@]}" >"$coverage_tmp"; then
+    echo "ok   [complete assess] returns 0"
+  else
+    echo "FAIL [complete assess] should return 0"
+    failures=$((failures + 1))
+  fi
+  assert_file_field "complete coverage" "$coverage_tmp" gating_coverage complete
+  assert_file_field "complete skipped" "$coverage_tmp" skipped_gating_methods ""
+  tmp="$(mktemp)"
+  write_fault_verdict_file "$tmp" PASS 0 PASS 0 FAIL 1 "$coverage_tmp"
+  assert_file_field "complete verdict" "$tmp" fault_verdict PASS
+  rm -f "$tmp" "$coverage_tmp"
+  rm -rf "$complete_root" "$fixture_root"
+
+  echo
+  echo "--- #2141 G6: ignoring <skipped> greens the brief-cut fixture ---"
+  local lib_src mutant
+  lib_src="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/nightly-fault-verdict.sh"
+  if [[ ! -f "$lib_src" ]]; then
+    lib_src="${BASH_SOURCE[0]}"
+  fi
+  mutant="$(mktemp)"
+  if ! python3 - "$lib_src" "$mutant" <<'PY'
+from pathlib import Path
+import sys
+
+src, dest = sys.argv[1:]
+text = Path(src).read_text()
+old = 'skip_tag = "skipped"'
+idx = text.find(old)
+if idx < 0:
+    raise SystemExit("G6 needle missing from production parser")
+if "_fault_verdict_self_test" in text[:idx]:
+    raise SystemExit("G6 needle is in the self-test, not the production parser")
+Path(dest).write_text(text[:idx] + 'skip_tag = "skip-disabled"' + text[idx + len(old):])
+PY
+  then
+    echo "FAIL [G6 needle]: could not plant the skip-detector mutant"
+    failures=$((failures + 1))
+  else
+    fixture_root="$(mktemp -d)"
+    {
+      printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+      printf '<testsuite name="%s" tests="1" failures="0" errors="0" skipped="1">\n' "$BRIEF_CLASS"
+      printf '  <testcase name="%s" classname="%s"><skipped /></testcase>\n' \
+        "$BRIEF_METHOD" "$BRIEF_CLASS"
+      printf '%s\n' '</testsuite>'
+    } >"$fixture_root/TEST-brief.xml"
+    local baseline_cov mutant_cov
+    baseline_cov="$(mktemp)"
+    mutant_cov="$(mktemp)"
+    assess_fault_gating_coverage "$fixture_root" "$BRIEF_CLASS" >"$baseline_cov" || true
+    bash -c '
+      set -uo pipefail
+      # shellcheck disable=SC1090
+      source "$1"
+      assess_fault_gating_coverage "$2" "$3"
+    ' _ "$mutant" "$fixture_root" "$BRIEF_CLASS" >"$mutant_cov" || true
+    assert_file_field "G6 baseline skip" "$baseline_cov" gating_coverage incomplete
+    assert_file_field "G6 mutant hides skip" "$mutant_cov" gating_coverage complete
+    rm -f "$mutant" "$baseline_cov" "$mutant_cov"
+    rm -rf "$fixture_root"
+  fi
+
+  echo
+  echo "--- #2141 G6: dropping executed==expected greens a 1-of-13 run ---"
+  mutant="$(mktemp)"
+  if ! python3 - "$lib_src" "$mutant" <<'PY'
+from pathlib import Path
+import sys
+
+src, dest = sys.argv[1:]
+text = Path(src).read_text()
+old = '''        && "$executed_n" -eq "$expected_n" \\
+        && "${#missing_list[@]}" -eq 0 \\'''
+new = '''        && "$executed_n" -ge 1 \\
+        && true \\'''
+idx = text.find(old)
+if idx < 0:
+    raise SystemExit("G6 executed-vs-expected needle missing")
+if "_fault_verdict_self_test" in text[:idx]:
+    raise SystemExit("G6 executed-vs-expected needle is in the self-test")
+Path(dest).write_text(text[:idx] + new + text[idx + len(old):])
+PY
+  then
+    echo "FAIL [G6 executed-vs-expected]: could not plant the mutant"
+    failures=$((failures + 1))
+  else
+    truncated_root="$(mktemp -d)"
+    write_testcase \
+      "$truncated_root/TEST-only.xml" \
+      "$BRIEF_CLASS" "$SUSTAINED_METHOD" pass
+    local baseline_trunc mutant_trunc
+    baseline_trunc="$(mktemp)"
+    mutant_trunc="$(mktemp)"
+    assess_fault_gating_coverage "$truncated_root" "${gating_expected[@]}" \
+      >"$baseline_trunc" || true
+    bash -c '
+      set -uo pipefail
+      # shellcheck disable=SC1090
+      source "$1"
+      shift
+      assess_fault_gating_coverage "$@"
+    ' _ "$mutant" "$truncated_root" "${gating_expected[@]}" >"$mutant_trunc" || true
+    assert_file_field "G6 baseline truncated" "$baseline_trunc" gating_coverage incomplete
+    assert_file_field "G6 mutant hides truncated" "$mutant_trunc" gating_coverage complete
+    rm -f "$mutant" "$baseline_trunc" "$mutant_trunc"
+    rm -rf "$truncated_root"
+  fi
 
   echo
   if [[ "$failures" -eq 0 ]]; then

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -368,9 +368,13 @@ source "$REPO_ROOT/scripts/lib/nightly-exact-method-guard.sh"
 # The machine-readable fault-verdict helper (issue #1201): pure PASS/FAIL from the
 # network-fault + bootstrap phases ONLY (never the journey suite or the
 # expected-fail lane). Written to a file the CI fault-verdict job reads.
+# Issue #2141: skipped / unreached gating members are assessed from the
+# preserved phase-2 report and refuse fault_verdict=PASS. #2141 owns
+# visibility of that hole; #1678 owns deleting the brief-cut Assume.
 # shellcheck source=scripts/lib/nightly-fault-verdict.sh
 source "$REPO_ROOT/scripts/lib/nightly-fault-verdict.sh"
 FAULT_VERDICT_FILE="$ARTIFACT_DIR/fault-verdict.txt"
+FAULT_COVERAGE_FILE="$ARTIFACT_DIR/fault-gating-coverage.txt"
 
 # Per-phase test-report preservation (issue #1293): each phase below is a
 # SEPARATE `:app:connectedDebugAndroidTest` invocation that writes its JUnit
@@ -552,6 +556,16 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   # DisconnectBlackhole / NatIdle failing assertions unrecoverable. Observability
   # only — never affects NETWORK_FAULT_EXIT.
   preserve_phase_reports "phase2-network-fault" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+  # Issue #2141: compare the preserved phase-2 JUnit XML to NETWORK_FAULT_CLASSES
+  # AFTER the snapshot (later phases overwrite app/build). A skipped method or
+  # a truncated class set is recorded here and refuses fault_verdict=PASS.
+  # Read the snapshot, not the live report path — phase 2b/3/4 clobber it.
+  assess_fault_gating_coverage \
+    "$PHASE_REPORTS_DIR/phase2-network-fault" \
+    "${NETWORK_FAULT_CLASSES[@]}" \
+    > "$FAULT_COVERAGE_FILE" || true
+  echo "phase 2 (network-fault proofs) gating coverage:"
+  cat "$FAULT_COVERAGE_FILE"
   write_nightly_phase_classification \
     "$PHASE_CLASSIFICATIONS_DIR/phase2-network-fault.txt" \
     "phase2-network-fault" "$NETWORK_FAULT_EXIT" \
@@ -693,7 +707,8 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
     "$FAULT_VERDICT_FILE" \
     "$nf_status" "$NETWORK_FAULT_EXIT" \
     "$bootstrap_status" "$BOOTSTRAP_EXIT" \
-    "$expectedfail_status" "$EXPECTED_FAIL_EXIT"
+    "$expectedfail_status" "$EXPECTED_FAIL_EXIT" \
+    "$FAULT_COVERAGE_FILE"
   fault_verdict="$(grep -E '^fault_verdict=' "$FAULT_VERDICT_FILE" | head -1 | cut -d= -f2)"
   echo "----------------------------------------------------------"
   echo "Fault-injection safety verdict (issue #1201) -> $fault_verdict"
@@ -761,8 +776,10 @@ fi
   echo "## Fault-injection safety verdict (issue #1201 — the RELEASE-GATING signal)"
   echo
   if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
-    echo "\`fault_verdict\` = network-fault ($nf_status) + bootstrap ($bootstrap_status) ONLY."
+    echo "\`fault_verdict\` = network-fault ($nf_status) + bootstrap ($bootstrap_status) ONLY,"
+    echo "then refuse PASS when the phase-2 gating set is skipped or truncated (#2141)."
     echo "The journey suite and the #822 expected-fail lane are DELIBERATELY excluded."
+    echo "#1678 owns deleting the brief-cut Assume; #2141 only makes that hole visible."
     echo
     echo '```'
     cat "$FAULT_VERDICT_FILE"

--- a/scripts/test-nightly-phase-classification.sh
+++ b/scripts/test-nightly-phase-classification.sh
@@ -175,6 +175,50 @@ grep -Fq 'nf_status="$(nightly_phase_status "$nf_classification")"' "$suite" \
 grep -Fq 'if [[ "$verdict" == "INFRA" ]]' "$workflow" \
   || failures=$((failures + 1))
 grep -Fq 'BLOCK-INFRA:' "$workflow" || failures=$((failures + 1))
+# Issue #2141: skipped / unreached gating members must flow from the preserved
+# phase-2 snapshot through the verdict file and refuse a clean PASS. Pin the
+# joined assess statement so a leftover NETWORK_FAULT_CLASSES mention elsewhere
+# cannot vouch for a disconnected coverage call.
+suite_joined="$SANDBOX/suite-joined.sh"
+awk '{
+  line = $0
+  while (sub(/[[:space:]]*\\$/, "", line) > 0) {
+    if ((getline nextline) <= 0) break
+    sub(/^[[:space:]]+/, "", nextline)
+    line = line " " nextline
+  }
+  print line
+}' "$suite" > "$suite_joined"
+coverage_call="$(grep -F 'assess_fault_gating_coverage' "$suite_joined" | head -1)"
+if [[ -z "$coverage_call" ]]; then
+  echo 'FAIL [2141 wiring]: assess_fault_gating_coverage is not called'
+  failures=$((failures + 1))
+else
+  case "$coverage_call" in
+    *'"$PHASE_REPORTS_DIR/phase2-network-fault"'*'"${NETWORK_FAULT_CLASSES[@]}"'*)
+      echo 'ok   [2141 wiring] assess reads phase-2 snapshot vs NETWORK_FAULT_CLASSES'
+      ;;
+    *)
+      echo 'FAIL [2141 wiring]: assess is no longer phase-2 snapshot vs NETWORK_FAULT_CLASSES'
+      failures=$((failures + 1))
+      ;;
+  esac
+fi
+verdict_call="$(grep -F 'write_fault_verdict_file' "$suite_joined" | head -1)"
+case "$verdict_call" in
+  *'"$FAULT_COVERAGE_FILE"'*)
+    echo 'ok   [2141 wiring] verdict consumes the coverage file'
+    ;;
+  *)
+    echo 'FAIL [2141 wiring]: write_fault_verdict_file no longer takes FAULT_COVERAGE_FILE'
+    failures=$((failures + 1))
+    ;;
+esac
+grep -Fq 'if [[ "$verdict" == "INCOMPLETE" ]]' "$workflow" \
+  || failures=$((failures + 1))
+grep -Fq 'BLOCK-INCOMPLETE:' "$workflow" || failures=$((failures + 1))
+grep -Fq 'skipped_gating_methods=' "$workflow" \
+  || failures=$((failures + 1))
 
 # ---------------------------------------------------------------------------
 # G6: removing one new signature reddens only that signature's fixture.


### PR DESCRIPTION
Closes #2141

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2141#issuecomment-5333084353

A skipped or unreached gating member (including briefLinkCut) now makes fault_verdict=INCOMPLETE instead of a silent PASS. #1678 still owns deleting the Assume.

Orchestrator verify: nightly-fault-verdict --self-test PASS.