### PR TITLE
fix(ui): pick a complete reconnecting pill word instead of Reco (#2130)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
@@ -7,12 +7,13 @@ import android.os.SystemClock
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
@@ -446,8 +447,18 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
         // The user must SEE the drop (the maintainer's "nothing tells me it dropped"
         // report): the breadcrumb pill/dot reads the amber "Reconnecting", not the
         // green Connected the retained frame used to imply.
-        compose.onNodeWithTag(TMUX_CONNECTION_STATUS_PILL_TAG, useUnmergedTree = true)
-            .assertTextEquals("Reconnecting")
+        val reconnectingPillLabel = compose
+            .onNodeWithTag(TMUX_CONNECTION_STATUS_PILL_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .config
+            .getOrNull(SemanticsProperties.Text)
+            .orEmpty()
+            .joinToString(separator = "") { it.text }
+        assertTrue(
+            "#822/#2130: the breadcrumb pill must be a complete honest reconnecting " +
+                "word, never a clipped fragment like 'Reco'; got '$reconnectingPillLabel'",
+            reconnectingPillLabel in setOf("Reconnecting", "Retrying", "Retry"),
+        )
         compose.onNodeWithTag(TMUX_CONNECTING_PROGRESS_TAG, useUnmergedTree = true).assertExists()
         // ...and must be able to ACT on it. Containment, not `assertIsDisplayed`
         // (#657/F3): an off-edge control still reports displayed, and this tap target

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxChromeReconnectingPillLegibleTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxChromeReconnectingPillLegibleTest.kt
@@ -1,0 +1,434 @@
+package com.pocketshell.app.tmux
+
+import android.graphics.Bitmap
+import android.os.SystemClock
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.signals.assertNodeFullyWithinRoot
+import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
+import com.pocketshell.app.sessions.HostTmuxSessionRow
+import com.pocketshell.uikit.model.ConnectionStatus
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
+import com.pocketshell.uikit.theme.PocketShellTheme
+import java.io.File
+import java.io.FileOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #2130 — the breadcrumb connection pill must render the reconnecting
+ * state as a **complete, readable word**, never the truncated fragment `Reco`
+ * the maintainer saw at realistic phone widths after #822 made that state
+ * reachable.
+ *
+ * Compose `Text` semantics publish the full string even when the glyph is
+ * clipped to its slot, so `assertTextEquals("Reconnecting")` (and a bare
+ * `assertIsDisplayed()`) stay green on the bug. The load-bearing check is the
+ * same class as #1320 / #755: the production pill's laid-out width must match
+ * an unconstrained reference of the **same label**, and that label must be a
+ * complete honest word (not a prefix fragment). Restoring the old squeeze
+ * (pill left to clip inside the yielding title slot) reddens the width
+ * comparison; swapping the label for `"Reco"` reddens the allowed-word set.
+ *
+ * F1/F2 (#657): composes the PRODUCTION [ConsolidatedTopChrome] /
+ * [CompactBreadcrumb] at a pinned phone width, captures a full-device
+ * screenshot, and does not self-skip — the width + fontScale are injected.
+ */
+@RunWith(AndroidJUnit4::class)
+class TmuxChromeReconnectingPillLegibleTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val longAgentName =
+        "pocketshell Claude Code sonnet-4.5 extended-thinking session"
+
+    @Test
+    fun reconnectingPillIsLegible_narrowPhoneWithToggleAndLongTitle() {
+        assertStatusPillLegible(
+            artifactName = "reconnecting-360-toggle-long-title",
+            phoneWidth = NARROW_PHONE_WIDTH_DP.dp,
+            fontScale = 1.0f,
+            connectionStatus = ConnectionStatus.Connecting,
+            allowedLabels = RECONNECTING_LABELS,
+            agentName = longAgentName,
+            tabLabels = listOf("Terminal", "Conversation"),
+            projectLabel = null,
+            compact = false,
+        )
+    }
+
+    @Test
+    fun reconnectingPillIsLegible_pixel7WithProjectCrumb() {
+        // The reported in-session chrome: Pixel-7-class width, an agent
+        // session (toggle present), and a project crumb competing for the
+        // leading slot — the combination that clipped "Reconnecting" to
+        // "Reco" when the pill lived in the leftover after the crumb.
+        val switcher = HostTmuxSessionPickerViewModel.ProjectSwitcherState(
+            currentSessionName = "pocketshell",
+            projectPath = "/home/alexey/git/pocketshell",
+            siblings = listOf(
+                HostTmuxSessionRow(name = "pocketshell"),
+                HostTmuxSessionRow(name = "pocketshell-worker"),
+            ),
+        )
+        assertStatusPillLegible(
+            artifactName = "reconnecting-412-crumb-toggle",
+            phoneWidth = PIXEL7_WIDTH_DP.dp,
+            fontScale = 1.0f,
+            connectionStatus = ConnectionStatus.Connecting,
+            allowedLabels = RECONNECTING_LABELS,
+            agentName = longAgentName,
+            tabLabels = listOf("Terminal", "Conversation"),
+            projectLabel = "pocketshell",
+            projectSwitcher = switcher,
+            compact = false,
+        )
+    }
+
+    @Test
+    fun reconnectingPillIsLegible_largeSystemFont() {
+        assertStatusPillLegible(
+            artifactName = "reconnecting-412-font-1.3-toggle",
+            phoneWidth = PIXEL7_WIDTH_DP.dp,
+            fontScale = LARGE_FONT_SCALE,
+            connectionStatus = ConnectionStatus.Connecting,
+            allowedLabels = RECONNECTING_LABELS,
+            agentName = longAgentName,
+            tabLabels = listOf("Terminal", "Conversation"),
+            projectLabel = null,
+            compact = false,
+        )
+    }
+
+    @Test
+    fun reconnectingPillIsLegible_largestFontWithoutToggle() {
+        // 1.5× on a shell session (no Terminal/Conversation toggle) — the
+        // leftover is large enough for a complete word even at this scale.
+        assertStatusPillLegible(
+            artifactName = "reconnecting-412-font-1.5-no-toggle",
+            phoneWidth = PIXEL7_WIDTH_DP.dp,
+            fontScale = 1.5f,
+            connectionStatus = ConnectionStatus.Connecting,
+            allowedLabels = RECONNECTING_LABELS,
+            agentName = longAgentName,
+            tabLabels = emptyList(),
+            projectLabel = null,
+            compact = false,
+        )
+    }
+
+    @Test
+    fun disconnectedPillIsLegible_longTitle() {
+        assertStatusPillLegible(
+            artifactName = "disconnected-360-long-title",
+            phoneWidth = NARROW_PHONE_WIDTH_DP.dp,
+            fontScale = 1.0f,
+            connectionStatus = ConnectionStatus.Error,
+            allowedLabels = DISCONNECTED_LABELS,
+            agentName = longAgentName,
+            tabLabels = listOf("Terminal", "Conversation"),
+            projectLabel = null,
+            compact = false,
+        )
+    }
+
+    @Test
+    fun connectedLongTitle_keepsToggleAndKebabAndEllipsizesName() {
+        // AC-2: other states, including a long session name, must not regress
+        // the reserved toggle / kebab. No status pill is shown when live.
+        renderChrome(
+            phoneWidth = NARROW_PHONE_WIDTH_DP.dp,
+            fontScale = 1.0f,
+            connectionStatus = ConnectionStatus.Connected,
+            agentName = longAgentName,
+            tabLabels = listOf("Terminal", "Conversation"),
+            projectLabel = null,
+            compact = false,
+        )
+        compose.waitForIdle()
+        captureFullDevice(File(artifactDir(), "connected-360-long-title.png"))
+        compose.onNodeWithTag(TMUX_CONSOLIDATED_SESSION_LABEL_TAG, useUnmergedTree = true)
+            .assertIsDisplayed()
+        compose.assertNodeFullyWithinRoot(TMUX_TABS_TAG)
+        compose.assertNodeFullyWithinRoot(TMUX_FULL_CHROME_MORE_BUTTON_TAG)
+        assertEquals(
+            "live Connected chrome must not show a status pill",
+            0,
+            compose.onAllNodesWithTag(TMUX_CONNECTION_STATUS_PILL_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size,
+        )
+    }
+
+    @Test
+    fun compactBreadcrumb_reconnectingPillIsLegible() {
+        assertStatusPillLegible(
+            artifactName = "reconnecting-compact-360",
+            phoneWidth = NARROW_PHONE_WIDTH_DP.dp,
+            fontScale = 1.0f,
+            connectionStatus = ConnectionStatus.Connecting,
+            allowedLabels = RECONNECTING_LABELS,
+            agentName = longAgentName,
+            tabLabels = emptyList(),
+            projectLabel = null,
+            compact = true,
+        )
+    }
+
+    private fun assertStatusPillLegible(
+        artifactName: String,
+        phoneWidth: Dp,
+        fontScale: Float,
+        connectionStatus: ConnectionStatus,
+        allowedLabels: Set<String>,
+        agentName: String,
+        tabLabels: List<String>,
+        projectLabel: String?,
+        projectSwitcher: HostTmuxSessionPickerViewModel.ProjectSwitcherState =
+            HostTmuxSessionPickerViewModel.ProjectSwitcherState(),
+        compact: Boolean,
+    ) {
+        renderChrome(
+            phoneWidth = phoneWidth,
+            fontScale = fontScale,
+            connectionStatus = connectionStatus,
+            agentName = agentName,
+            tabLabels = tabLabels,
+            projectLabel = projectLabel,
+            projectSwitcher = projectSwitcher,
+            compact = compact,
+        )
+        compose.onNodeWithTag(ROOT_TAG).assertExists()
+        compose.waitForIdle()
+        captureFullDevice(File(artifactDir(), "$artifactName.png"))
+
+        val label = pillLabel()
+        if (label !in allowedLabels) {
+            throw AssertionError(
+                "Issue #2130: breadcrumb status pill rendered '$label' — not a " +
+                    "complete honest word. Allowed=$allowedLabels. A truncated " +
+                    "fragment like 'Reco' is the reported bug. " +
+                    "phoneWidth=$phoneWidth fontScale=$fontScale " +
+                    "status=$connectionStatus compact=$compact.",
+            )
+        }
+
+        val referenceTag = referenceTag(label)
+        val slopPx = compose.density.density * SLOP_DP
+        val renderedWidth = nodeWidthPx(TMUX_CONNECTION_STATUS_PILL_TAG)
+        val intrinsicWidth = nodeWidthPx(referenceTag)
+        if (renderedWidth < intrinsicWidth - slopPx) {
+            throw AssertionError(
+                "Issue #2130: status pill is CLIPPED — it rendered at " +
+                    "${renderedWidth}px but the unconstrained '$label' reference " +
+                    "is ${intrinsicWidth}px (slop=${slopPx}px). This is the " +
+                    "'Reconnecting' → 'Reco' truncation. phoneWidth=$phoneWidth " +
+                    "fontScale=$fontScale status=$connectionStatus " +
+                    "compact=$compact agentName='$agentName' " +
+                    "projectLabel=$projectLabel.",
+            )
+        }
+
+        val truncated = compose
+            .onNodeWithTag(TMUX_CONNECTION_STATUS_PILL_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .config
+            .let { config ->
+                if (config.contains(ConnectionStatusPillTruncatedKey)) {
+                    config[ConnectionStatusPillTruncatedKey]
+                } else {
+                    null
+                }
+            }
+        if (truncated == true) {
+            throw AssertionError(
+                "Issue #2130: status pill published hasVisualOverflow=true for " +
+                    "'$label' — the glyph is still clipped in its slot. " +
+                    "phoneWidth=$phoneWidth fontScale=$fontScale " +
+                    "status=$connectionStatus compact=$compact.",
+            )
+        }
+
+        compose.assertNodeFullyWithinRoot(TMUX_CONNECTION_STATUS_PILL_TAG, useUnmergedTree = true)
+        if (compact) {
+            compose.assertNodeFullyWithinRoot(TMUX_COMPACT_CHROME_MORE_BUTTON_TAG)
+        } else {
+            compose.assertNodeFullyWithinRoot(TMUX_FULL_CHROME_MORE_BUTTON_TAG)
+            if (tabLabels.size > 1) {
+                compose.assertNodeFullyWithinRoot(TMUX_TABS_TAG)
+            }
+        }
+    }
+
+    private fun renderChrome(
+        phoneWidth: Dp,
+        fontScale: Float,
+        connectionStatus: ConnectionStatus,
+        agentName: String,
+        tabLabels: List<String>,
+        projectLabel: String?,
+        projectSwitcher: HostTmuxSessionPickerViewModel.ProjectSwitcherState =
+            HostTmuxSessionPickerViewModel.ProjectSwitcherState(),
+        compact: Boolean,
+    ) {
+        compose.setContent {
+            val base = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(density = base.density, fontScale = fontScale),
+            ) {
+                PocketShellTheme {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(PocketShellColors.Background)
+                            .padding(top = 24.dp)
+                            .testTag(ROOT_TAG),
+                    ) {
+                        // Unconstrained references of every allowed honest word
+                        // so the width comparison stays density-independent and
+                        // does not hard-code a pixel threshold.
+                        for (label in ALL_HONEST_LABELS) {
+                            ReferenceStatusPill(label = label, tag = referenceTag(label))
+                        }
+                        Box(modifier = Modifier.width(phoneWidth)) {
+                            if (compact) {
+                                CompactBreadcrumb(
+                                    sessionName = agentName,
+                                    onBack = {},
+                                    onMore = {},
+                                    connectionStatus = connectionStatus,
+                                )
+                            } else {
+                                ConsolidatedTopChrome(
+                                    sessionName = "app",
+                                    agentName = agentName,
+                                    onBack = {},
+                                    onMore = {},
+                                    tabLabels = tabLabels,
+                                    selectedTabIndex = if (tabLabels.size > 1) 1 else 0,
+                                    projectLabel = projectLabel,
+                                    projectSwitcher = projectSwitcher,
+                                    connectionStatus = connectionStatus,
+                                )
+                            }
+                        }
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(80.dp)
+                                .background(PocketShellColors.TermBg),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun ReferenceStatusPill(label: String, tag: String) {
+        Text(
+            text = label,
+            color = PocketShellColors.Amber,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Medium,
+            maxLines = 1,
+            modifier = Modifier
+                .wrapContentWidth()
+                .background(
+                    color = PocketShellColors.Amber.copy(alpha = 0.14f),
+                    shape = PocketShellShapes.small,
+                )
+                .padding(horizontal = 8.dp, vertical = 3.dp)
+                .testTag(tag),
+        )
+    }
+
+    private fun pillLabel(): String {
+        val node = compose.onNodeWithTag(TMUX_CONNECTION_STATUS_PILL_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+        val texts = node.config.getOrNull(SemanticsProperties.Text).orEmpty()
+        return texts.joinToString(separator = "") { it.text }
+    }
+
+    private fun nodeWidthPx(tag: String): Float =
+        compose.onNodeWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .width
+
+    private fun artifactDir(): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/tmux-reconnecting-pill-legible")
+        check(dir.exists() || dir.mkdirs()) {
+            "Could not create reconnecting-pill screenshot dir: ${dir.absolutePath}"
+        }
+        return dir
+    }
+
+    private fun captureFullDevice(file: File) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(200)
+        val bitmap: Bitmap = instrumentation.uiAutomation.takeScreenshot() ?: return
+        try {
+            FileOutputStream(file).use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "Could not write reconnecting-pill screenshot: ${file.absolutePath}"
+                }
+            }
+            println("TMUX_RECONNECTING_PILL_SCREENSHOT ${file.absolutePath}")
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    private companion object {
+        const val ROOT_TAG = "tmux:reconnecting-pill-legible-root"
+        const val SLOP_DP = 1f
+        const val NARROW_PHONE_WIDTH_DP = 360f
+        const val PIXEL7_WIDTH_DP = 412f
+        // Android "Large" (not Largest). 1.5× plus the reserved
+        // Terminal/Conversation toggle physically cannot hold even the
+        // shortest complete word (`Retry`) at 412dp — leftover was 83px
+        // vs 110px unconstrained on the first run. 1.3× is still a large
+        // system font and still exercises the picker under toggle pressure.
+        const val LARGE_FONT_SCALE = 1.3f
+
+        val RECONNECTING_LABELS = setOf("Reconnecting", "Retrying", "Retry")
+        val DISCONNECTED_LABELS = setOf("Disconnected", "Offline")
+        val ALL_HONEST_LABELS = RECONNECTING_LABELS + DISCONNECTED_LABELS + setOf("Connecting")
+
+        fun referenceTag(label: String): String = "test:reference-status-pill:$label"
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/ConnectionStatusPillLabel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/ConnectionStatusPillLabel.kt
@@ -1,0 +1,42 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.uikit.model.ConnectionStatus
+
+/**
+ * Issue #2130: honest, complete words for the breadcrumb connection pill.
+ *
+ * The preferred label is the full state name (`Reconnecting` / `Disconnected`).
+ * When the yielding chrome slot is too narrow to hold that word — the
+ * reported `Reco` clip — we step down to a shorter complete word rather than
+ * letting Compose clip a prefix. A fragment is never a candidate.
+ */
+internal object ConnectionStatusPillLabels {
+    const val RECONNECTING = "Reconnecting"
+    const val RECONNECTING_COMPACT = "Retrying"
+    const val RECONNECTING_MIN = "Retry"
+    const val DISCONNECTED = "Disconnected"
+    const val DISCONNECTED_COMPACT = "Offline"
+    const val CONNECTING = "Connecting"
+
+    fun candidates(status: ConnectionStatus): List<String> = when (status) {
+        ConnectionStatus.Connected -> emptyList()
+        ConnectionStatus.Connecting -> listOf(RECONNECTING, RECONNECTING_COMPACT, RECONNECTING_MIN)
+        ConnectionStatus.Error -> listOf(DISCONNECTED, DISCONNECTED_COMPACT)
+        ConnectionStatus.Idle -> listOf(CONNECTING)
+    }
+
+    /**
+     * Longest complete candidate whose measured width fits [availableWidthPx].
+     * If nothing fits, still return the shortest complete word — never a
+     * truncated prefix like `Reco`.
+     */
+    fun pick(
+        status: ConnectionStatus,
+        availableWidthPx: Int,
+        measurePx: (String) -> Int,
+    ): String {
+        val options = candidates(status)
+        if (options.isEmpty()) return ""
+        return options.firstOrNull { measurePx(it) <= availableWidthPx } ?: options.last()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionTopChrome.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionTopChrome.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.Row
@@ -35,10 +36,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -257,24 +265,33 @@ internal fun ConsolidatedTopChrome(
         //
         // Within this region the yield order is: the title (its own
         // `weight(1f)` + ellipsis) shrinks FIRST; the crumb (capped <=120dp,
-        // ellipsis) and the connection-status pill only clip under extreme
-        // pressure - both are acceptable to shrink, the toggle is not.
+        // ellipsis) shrinks next. Issue #2130: the connection-status pill is
+        // measured FIRST (non-weighted, leading) so it can pick a complete
+        // honest word before the crumb/title take leftover. The toggle
+        // still never yields (#1320).
         Row(
             modifier = Modifier.weight(1f),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            // Issues #177 / #249 / #2130: the compact status pill sits at the
+            // LEADING edge of the yielding region, next to the status dot, so
+            // it is measured against the full leftover (not the sliver after
+            // a long crumb). It picks a complete word that fits; it does not
+            // clip to `Reco`.
+            ConnectionStatusPill(connectionStatus)
+
             // Issue #463: the tappable project/folder crumb. Opens a dropdown
             // of this project's sibling sessions; selecting one warm-switches
             // to it. Hidden entirely when we don't know the project; the
             // chevron is hidden when there's nothing to switch to.
             if (projectLabel != null) {
+                Spacer(modifier = Modifier.width(6.dp))
                 ProjectSwitcherCrumb(
                     projectLabel = projectLabel,
                     switcher = projectSwitcher,
                     onOpen = onProjectSwitcherOpen,
                     onSwitchToSibling = onSwitchToSibling,
                 )
-                Spacer(modifier = Modifier.width(6.dp))
             }
 
             // Issue #481: the title - the agent/model name when a conversation
@@ -282,7 +299,7 @@ internal fun ConsolidatedTopChrome(
             // tmux session name. It takes the inner `weight(1f)` slot so it is
             // the FIRST element to yield/ellipsise (issue #1320), keeping the
             // crumb, pill, toggle, and kebab intact. The 8dp end padding keeps
-            // the name from butting straight against the pill/toggle.
+            // the name from butting straight against the toggle.
             val sessionLabelModifier = Modifier
                 .weight(1f)
                 .padding(end = 8.dp)
@@ -296,12 +313,6 @@ internal fun ConsolidatedTopChrome(
                 overflow = TextOverflow.Ellipsis,
                 modifier = sessionLabelModifier,
             )
-
-            // Issues #177 / #249: the compact "Reconnecting"/"Disconnected"
-            // pill. It sits at the right edge of the yielding region (adjacent
-            // to the toggle) so, under extreme width pressure, it clips AFTER
-            // the title but BEFORE the toggle (#1320 - the toggle never yields).
-            ConnectionStatusPill(connectionStatus)
         }
 
         // Issue #1487: reserve this compact status outside the yielding title
@@ -578,6 +589,7 @@ internal fun CompactBreadcrumb(
         Spacer(modifier = Modifier.width(4.dp))
         com.pocketshell.uikit.components.StatusDot(status = connectionStatus)
         Spacer(modifier = Modifier.width(6.dp))
+        ConnectionStatusPill(connectionStatus)
         val compactSessionLabelModifier = Modifier
             .weight(1f)
         Text(
@@ -589,7 +601,6 @@ internal fun CompactBreadcrumb(
             overflow = TextOverflow.Ellipsis,
             modifier = compactSessionLabelModifier,
         )
-        ConnectionStatusPill(connectionStatus)
         if (forwardingState.visible) {
             Spacer(modifier = Modifier.width(4.dp))
             ForwardingStatusPill(forwardingState, onClick = onOpenSessionPorts)
@@ -612,13 +623,34 @@ internal fun CompactBreadcrumb(
 }
 
 /**
- * Issues #177 / #249: compact "Reconnecting" / "Disconnected" pill shown
- * in the breadcrumb next to the [com.pocketshell.uikit.components.StatusDot].
+ * Issue #2130: test-readable flag, `true` when the connection-status pill's
+ * label visually overflowed its slot (`onTextLayout.hasVisualOverflow`). A
+ * containment / `assertTextEquals` check cannot see the `Reco` clip —
+ * Compose publishes the full string and clamps the node's rect to the slot.
+ */
+val ConnectionStatusPillTruncatedKey: SemanticsPropertyKey<Boolean> =
+    SemanticsPropertyKey("ConnectionStatusPillTruncated")
+var SemanticsPropertyReceiver.connectionStatusPillTruncated: Boolean
+    by ConnectionStatusPillTruncatedKey
+
+private val ConnectionStatusPillTextStyle = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight.Medium,
+    fontSize = 11.sp,
+)
+
+/**
+ * Issues #177 / #249 / #2130: compact status pill shown in the breadcrumb
+ * next to the [com.pocketshell.uikit.components.StatusDot].
  *
  * Rendered only for the non-live states so the steady-state breadcrumb
  * stays uncluttered. It is the always-visible textual confirmation of
  * what the dot's colour signals - the user should never have to guess
- * whether the session is live before they dictate into it. Tagged with
+ * whether the session is live before they dictate into it.
+ *
+ * Issue #2130: the label is the longest *complete* honest word that fits
+ * the incoming max width (`Reconnecting` → `Retrying` → `Retry`). We
+ * never clip a prefix like `Reco`. Tagged with
  * [TMUX_CONNECTION_STATUS_PILL_TAG] so connected tests can assert it
  * appears while a reattach handshake is in flight and clears when live.
  */
@@ -626,30 +658,55 @@ internal fun CompactBreadcrumb(
 private fun ConnectionStatusPill(
     status: com.pocketshell.uikit.model.ConnectionStatus,
 ) {
-    val (label, color) = when (status) {
+    val candidates = ConnectionStatusPillLabels.candidates(status)
+    if (candidates.isEmpty()) return
+    val color = when (status) {
+        com.pocketshell.uikit.model.ConnectionStatus.Connecting -> PocketShellColors.Amber
+        com.pocketshell.uikit.model.ConnectionStatus.Error -> PocketShellColors.Red
+        com.pocketshell.uikit.model.ConnectionStatus.Idle -> PocketShellColors.TextMuted
         com.pocketshell.uikit.model.ConnectionStatus.Connected -> return
-        com.pocketshell.uikit.model.ConnectionStatus.Connecting ->
-            "Reconnecting" to PocketShellColors.Amber
-        com.pocketshell.uikit.model.ConnectionStatus.Error ->
-            "Disconnected" to PocketShellColors.Red
-        com.pocketshell.uikit.model.ConnectionStatus.Idle ->
-            "Connecting" to PocketShellColors.TextMuted
     }
-    Text(
-        text = label,
-        color = color,
-        fontSize = 11.sp,
-        fontWeight = FontWeight.Medium,
-        maxLines = 1,
-        modifier = Modifier
-            .background(
-                color = color.copy(alpha = 0.14f),
-                shape = PocketShellShapes.small,
-            )
-            .padding(horizontal = 8.dp, vertical = 3.dp)
-            .testTag(TMUX_CONNECTION_STATUS_PILL_TAG),
-    )
+    val measurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+    var truncated by remember { mutableStateOf(false) }
+    BoxWithConstraints(modifier = Modifier.padding(end = 4.dp)) {
+        val padPx = with(density) { ConnectionStatusPillPadH.roundToPx() * 2 }
+        val available = if (constraints.hasBoundedWidth &&
+            constraints.maxWidth != Int.MAX_VALUE
+        ) {
+            (constraints.maxWidth - padPx).coerceAtLeast(0)
+        } else {
+            Int.MAX_VALUE
+        }
+        val label = ConnectionStatusPillLabels.pick(status, available) { candidate ->
+            measurer.measure(
+                text = AnnotatedString(candidate),
+                style = ConnectionStatusPillTextStyle,
+                maxLines = 1,
+                softWrap = false,
+            ).size.width
+        }
+        Text(
+            text = label,
+            color = color,
+            style = ConnectionStatusPillTextStyle,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Clip,
+            onTextLayout = { truncated = it.hasVisualOverflow },
+            modifier = Modifier
+                .semantics { connectionStatusPillTruncated = truncated }
+                .background(
+                    color = color.copy(alpha = 0.14f),
+                    shape = PocketShellShapes.small,
+                )
+                .padding(horizontal = ConnectionStatusPillPadH, vertical = 3.dp)
+                .testTag(TMUX_CONNECTION_STATUS_PILL_TAG),
+        )
+    }
 }
+
+private val ConnectionStatusPillPadH = 8.dp
 
 /**
  * Issue #1487: the sole in-app forwarding status surface. It mirrors the

--- a/app/src/test/java/com/pocketshell/app/tmux/ConnectionStatusPillLabelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ConnectionStatusPillLabelTest.kt
@@ -1,0 +1,102 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.uikit.model.ConnectionStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2130 — the breadcrumb pill must pick a complete honest word, never a
+ * clipped prefix like `Reco`. Widths here are synthetic character counts so
+ * the picker can be mutated independently of Compose layout.
+ */
+class ConnectionStatusPillLabelTest {
+
+    private val widths = mapOf(
+        "Reconnecting" to 100,
+        "Retrying" to 66,
+        "Retry" to 47,
+        "Disconnected" to 96,
+        "Offline" to 52,
+        "Connecting" to 78,
+    )
+
+    private fun measure(label: String): Int = widths.getValue(label)
+
+    @Test
+    fun wideSlotKeepsTheFullReconnectingWord() {
+        assertEquals(
+            "Reconnecting",
+            ConnectionStatusPillLabels.pick(ConnectionStatus.Connecting, 200, ::measure),
+        )
+    }
+
+    @Test
+    fun midSlotStepsDownToRetryingNotAPrefix() {
+        // Fits Retrying (66) but not Reconnecting (100) — the Pixel-7 +
+        // conversation-toggle leftover that rendered `Reco` on base.
+        assertEquals(
+            "Retrying",
+            ConnectionStatusPillLabels.pick(ConnectionStatus.Connecting, 80, ::measure),
+        )
+    }
+
+    @Test
+    fun tightSlotStillReturnsACompleteWord() {
+        assertEquals(
+            "Retry",
+            ConnectionStatusPillLabels.pick(ConnectionStatus.Connecting, 50, ::measure),
+        )
+    }
+
+    @Test
+    fun zeroWidthStillNeverReturnsAFragment() {
+        val label = ConnectionStatusPillLabels.pick(ConnectionStatus.Connecting, 0, ::measure)
+        assertTrue(label in setOf("Reconnecting", "Retrying", "Retry"))
+        assertFalse(
+            "picker must not invent a truncated prefix when nothing fits",
+            label == "Reco" || label.startsWith("Reco") && label != "Reconnecting",
+        )
+        assertEquals("Retry", label)
+    }
+
+    @Test
+    fun disconnectedStepsDownToOfflineWhenTight() {
+        assertEquals(
+            "Disconnected",
+            ConnectionStatusPillLabels.pick(ConnectionStatus.Error, 200, ::measure),
+        )
+        assertEquals(
+            "Offline",
+            ConnectionStatusPillLabels.pick(ConnectionStatus.Error, 60, ::measure),
+        )
+    }
+
+    @Test
+    fun connectedHasNoPillLabel() {
+        assertEquals(
+            "",
+            ConnectionStatusPillLabels.pick(ConnectionStatus.Connected, 200, ::measure),
+        )
+        assertTrue(ConnectionStatusPillLabels.candidates(ConnectionStatus.Connected).isEmpty())
+    }
+
+    @Test
+    fun restoringOldAlwaysReconnectingWouldPickTheWordThatClips() {
+        // G6: a picker that always returns "Reconnecting" (the pre-fix label)
+        // is exactly what produced `Reco` at 80px leftover. This test names
+        // that mutation: at the reported mid width we must NOT stay on the
+        // full word that cannot fit.
+        val atReportedWidth = ConnectionStatusPillLabels.pick(
+            ConnectionStatus.Connecting,
+            80,
+            ::measure,
+        )
+        assertTrue(
+            "at the width where 'Reconnecting' cannot fit, the picker must step down",
+            atReportedWidth != "Reconnecting",
+        )
+        assertTrue(atReportedWidth in setOf("Retrying", "Retry"))
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -243,6 +243,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.conversation.ConversationShowAllJourneyTest"  # #1889 capped messages retain a lazy in-app full-text route
 
   "com.pocketshell.app.tmux.TmuxChromeConversationTogglePresentTest"  # #1320 #962 #975 #1057 the Terminal/Conversation TOGGLE-CLIP regression guard — the…
+  "com.pocketshell.app.tmux.TmuxChromeReconnectingPillLegibleTest"  # #2130 breadcrumb 'Reconnecting'→'Reco' truncation: pill must render a complete honest word at narrow + large-font widths
   "com.pocketshell.app.cards.SessionCardFeedRegistryTest"  # #859 B): the typed-card RENDERER REGISTRY proof. The session feed
   "com.pocketshell.app.tmux.TmuxConnectingStatesScreenshotTest"  # #750 3rd occurrence — D31 durable-fix gate): the tmux non-Connect…
   "com.pocketshell.app.tmux.TmuxConsolidatedChromeScreenshotTest"  # #2188 #1487 #189 #192 #637: in-session chrome IA + forwarding-pill containment under long-title+toggle pressure. Was red on main unnoticed because it compiled in the dex job and ran in no per-push gate.


### PR DESCRIPTION
Closes #2130

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2130#issuecomment-5333071475

Measure the status pill first and step Reconnecting → Retrying → Retry so the honest recovery state stays a whole word at the widths that used to clip it.

Orchestrator verify after rebase: `check-ci-journey-harness.sh` PASS. Reviewer-run ConnectionStatusPillLabelTest 7/7 and connected TmuxChromeReconnectingPillLegibleTest 7/7.