### PR TITLE
test: hard-fail core-terminal viewport captures on a 0x0 view (#2206)

### DIFF
--- a/shared/core-terminal/build.gradle.kts
+++ b/shared/core-terminal/build.gradle.kts
@@ -153,7 +153,11 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     // Issue #1048: the ONE audited shared de-flake settle-pump
     // (`drainMainLooperUntil`) the SshTerminalBridge flood pump converges on.
+    // Issue #2206: the same module also hosts `captureViewToBitmap`, the
+    // hard-fail 0x0 viewport capture the leftover core-terminal androidTests
+    // now share (they cannot import the app-module #2135 helper).
     testImplementation(project(":shared:test-support"))
+    androidTestImplementation(project(":shared:test-support"))
 
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.core)

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/AgentPaneLinkAffordanceOffMainProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/AgentPaneLinkAffordanceOffMainProofTest.kt
@@ -1,7 +1,6 @@
 package com.pocketshell.core.terminal.ui
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.os.Looper
 import android.os.SystemClock
 import android.view.MotionEvent
@@ -19,6 +18,7 @@ import com.pocketshell.core.terminal.selection.findVisibleFilePaths
 import com.pocketshell.core.terminal.selection.findVisibleUrls
 import com.pocketshell.core.terminal.selection.hitTestFilePath
 import com.pocketshell.core.terminal.selection.hitTestUrl
+import com.pocketshell.testsupport.captureViewToBitmap
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -654,23 +654,20 @@ class AgentPaneLinkAffordanceOffMainProofTest {
         SystemClock.sleep(150)
         var bitmap: Bitmap? = null
         instrumentation.runOnMainSync {
-            if (view.width > 0 && view.height > 0) {
-                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-                view.draw(Canvas(b))
-                bitmap = b
-            }
+            bitmap = captureViewToBitmap(view, name)
+        }
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap '$name' (#2206)"
         }
         val ctx = instrumentation.targetContext
-        bitmap?.let { b ->
-            val file = artifactFile(ctx, "$name-viewport.png")
-            FileOutputStream(file).use { out ->
-                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                    "failed to write bitmap to ${file.absolutePath}"
-                }
+        val file = artifactFile(ctx, "$name-viewport.png")
+        FileOutputStream(file).use { out ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
             }
-            println("ISSUE871_VIEWPORT ${file.absolutePath}")
-            b.recycle()
         }
+        println("ISSUE871_VIEWPORT ${file.absolutePath}")
+        captured.recycle()
         artifactFile(ctx, "$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 
@@ -683,20 +680,17 @@ class AgentPaneLinkAffordanceOffMainProofTest {
         val root = view.rootView
         var bitmap: Bitmap? = null
         instrumentation.runOnMainSync {
-            if (root.width > 0 && root.height > 0) {
-                bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888).also {
-                    root.draw(Canvas(it))
-                }
-            }
+            bitmap = captureViewToBitmap(root, "issue558-pixel7-wrapped-url-root")
         }
-        bitmap?.let { captured ->
-            val screenshot = artifactFile(instrumentation.targetContext, "issue558-pixel7-wrapped-url-root.png")
-            FileOutputStream(screenshot).use { out ->
-                check(captured.compress(Bitmap.CompressFormat.PNG, 100, out))
-            }
-            println("ISSUE558_PIXEL7_VIEWPORT ${screenshot.absolutePath}")
-            captured.recycle()
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap 'issue558-pixel7-wrapped-url-root' (#2206)"
         }
+        val screenshot = artifactFile(instrumentation.targetContext, "issue558-pixel7-wrapped-url-root.png")
+        FileOutputStream(screenshot).use { out ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, out))
+        }
+        println("ISSUE558_PIXEL7_VIEWPORT ${screenshot.absolutePath}")
+        captured.recycle()
         val routed = artifactFile(instrumentation.targetContext, "issue558-routed-url.txt")
         routed.writeText(
             buildString {

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexAppendBurstMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexAppendBurstMainThreadProofTest.kt
@@ -1,7 +1,6 @@
 package com.pocketshell.core.terminal.ui
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
@@ -13,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.testsupport.captureViewToBitmap
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -356,23 +356,20 @@ class CodexAppendBurstMainThreadProofTest {
         SystemClock.sleep(150)
         var bitmap: Bitmap? = null
         instrumentation.runOnMainSync {
-            if (view.width > 0 && view.height > 0) {
-                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-                view.draw(Canvas(b))
-                bitmap = b
-            }
+            bitmap = captureViewToBitmap(view, name)
+        }
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap '$name' (#2206)"
         }
         val ctx = instrumentation.targetContext
-        bitmap?.let { b ->
-            val file = artifactFile(ctx, "$name-viewport.png")
-            FileOutputStream(file).use { out ->
-                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                    "failed to write bitmap to ${file.absolutePath}"
-                }
+        val file = artifactFile(ctx, "$name-viewport.png")
+        FileOutputStream(file).use { out ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
             }
-            println("ISSUE803_BURST_VIEWPORT ${file.absolutePath}")
-            b.recycle()
         }
+        println("ISSUE803_BURST_VIEWPORT ${file.absolutePath}")
+        captured.recycle()
         artifactFile(ctx, "$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexMultiChunkSeedAttachMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexMultiChunkSeedAttachMainThreadProofTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.testsupport.captureViewToBitmap
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -390,25 +391,20 @@ class CodexMultiChunkSeedAttachMainThreadProofTest {
         SystemClock.sleep(150)
         var bitmap: android.graphics.Bitmap? = null
         instrumentation.runOnMainSync {
-            if (view.width > 0 && view.height > 0) {
-                val b = android.graphics.Bitmap.createBitmap(
-                    view.width, view.height, android.graphics.Bitmap.Config.ARGB_8888,
-                )
-                view.draw(android.graphics.Canvas(b))
-                bitmap = b
-            }
+            bitmap = captureViewToBitmap(view, name)
+        }
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap '$name' (#2206)"
         }
         val ctx = instrumentation.targetContext
-        bitmap?.let { b ->
-            val file = artifactFile(ctx, "$name-viewport.png")
-            java.io.FileOutputStream(file).use { out ->
-                check(b.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)) {
-                    "failed to write bitmap to ${file.absolutePath}"
-                }
+        val file = artifactFile(ctx, "$name-viewport.png")
+        java.io.FileOutputStream(file).use { out ->
+            check(captured.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
             }
-            println("ISSUE866_SEED_VIEWPORT ${file.absolutePath}")
-            b.recycle()
         }
+        println("ISSUE866_SEED_VIEWPORT ${file.absolutePath}")
+        captured.recycle()
         artifactFile(ctx, "$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexOutputBurstImeMainThreadProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/CodexOutputBurstImeMainThreadProofTest.kt
@@ -19,6 +19,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.core.terminal.selection.TerminalMatch
 import com.pocketshell.core.terminal.selection.TerminalMatcher
+import com.pocketshell.testsupport.captureViewToBitmap
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -836,23 +837,20 @@ class CodexOutputBurstImeMainThreadProofTest {
         SystemClock.sleep(150)
         var bitmap: Bitmap? = null
         instrumentation.runOnMainSync {
-            if (view.width > 0 && view.height > 0) {
-                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-                view.draw(Canvas(b))
-                bitmap = b
-            }
+            bitmap = captureViewToBitmap(view, name)
+        }
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap '$name' (#2206)"
         }
         val ctx = instrumentation.targetContext
-        bitmap?.let { b ->
-            val file = artifactFile(ctx, "$name-viewport.png")
-            FileOutputStream(file).use { out ->
-                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                    "failed to write bitmap to ${file.absolutePath}"
-                }
+        val file = artifactFile(ctx, "$name-viewport.png")
+        FileOutputStream(file).use { out ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
             }
-            println("ISSUE796_BURST_VIEWPORT ${file.absolutePath}")
-            b.recycle()
         }
+        println("ISSUE796_BURST_VIEWPORT ${file.absolutePath}")
+        captured.recycle()
         artifactFile(ctx, "$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 

--- a/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/ShellPaneAffordanceSingleSnapshotProofTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/pocketshell/core/terminal/ui/ShellPaneAffordanceSingleSnapshotProofTest.kt
@@ -1,7 +1,6 @@
 package com.pocketshell.core.terminal.ui
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.os.Looper
 import android.os.SystemClock
 import android.view.MotionEvent
@@ -20,6 +19,7 @@ import com.pocketshell.core.terminal.selection.UrlRegion
 import com.pocketshell.core.terminal.selection.findVisibleEngineCommands
 import com.pocketshell.core.terminal.selection.findVisibleFilePaths
 import com.pocketshell.core.terminal.selection.findVisibleUrls
+import com.pocketshell.testsupport.captureViewToBitmap
 import com.termux.view.TerminalView
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -430,23 +430,20 @@ class ShellPaneAffordanceSingleSnapshotProofTest {
         SystemClock.sleep(150)
         var bitmap: Bitmap? = null
         instrumentation.runOnMainSync {
-            if (view.width > 0 && view.height > 0) {
-                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-                view.draw(Canvas(b))
-                bitmap = b
-            }
+            bitmap = captureViewToBitmap(view, name)
+        }
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap '$name' (#2206)"
         }
         val ctx = instrumentation.targetContext
-        bitmap?.let { b ->
-            val file = artifactFile(ctx, "$name-viewport.png")
-            FileOutputStream(file).use { out ->
-                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                    "failed to write bitmap to ${file.absolutePath}"
-                }
+        val file = artifactFile(ctx, "$name-viewport.png")
+        FileOutputStream(file).use { out ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
             }
-            println("ISSUE1233_VIEWPORT ${file.absolutePath}")
-            b.recycle()
         }
+        println("ISSUE1233_VIEWPORT ${file.absolutePath}")
+        captured.recycle()
         artifactFile(ctx, "$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 

--- a/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalSelectionViewportStabilityInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalSelectionViewportStabilityInstrumentedTest.kt
@@ -1,7 +1,6 @@
 package com.termux.view
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.os.SystemClock
 import android.view.MotionEvent
 import android.view.View
@@ -15,6 +14,7 @@ import com.pocketshell.core.terminal.ui.TerminalSurface
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.terminal.ui.pinTerminalToBottom
 import com.pocketshell.core.terminal.ui.testArtifactsRoot
+import com.pocketshell.testsupport.captureViewToBitmap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -828,22 +828,19 @@ class TerminalSelectionViewportStabilityInstrumentedTest {
         instrumentation.waitForIdleSync()
         var bitmap: Bitmap? = null
         onMain {
-            if (view.width > 0 && view.height > 0) {
-                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-                view.draw(Canvas(b))
-                bitmap = b
+            bitmap = captureViewToBitmap(view, name)
+        }
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap '$name' (#2206)"
+        }
+        val file = artifactFile("$name-viewport.png")
+        FileOutputStream(file).use { out ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
             }
         }
-        bitmap?.let { b ->
-            val file = artifactFile("$name-viewport.png")
-            FileOutputStream(file).use { out ->
-                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                    "failed to write bitmap to ${file.absolutePath}"
-                }
-            }
-            println("ISSUE2154_VIEWPORT ${file.absolutePath}")
-            b.recycle()
-        }
+        println("ISSUE2154_VIEWPORT ${file.absolutePath}")
+        captured.recycle()
         artifactFile("$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 

--- a/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewPixelProbeAbandonedCopyInstrumentedTest.kt
+++ b/shared/core-terminal/src/androidTest/java/com/termux/view/TerminalViewPixelProbeAbandonedCopyInstrumentedTest.kt
@@ -1,7 +1,6 @@
 package com.termux.view
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.core.terminal.ui.TerminalSurface
 import com.pocketshell.core.terminal.ui.TerminalSurfaceState
 import com.pocketshell.core.terminal.ui.testArtifactsRoot
+import com.pocketshell.testsupport.captureViewToBitmap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -329,22 +329,19 @@ class TerminalViewPixelProbeAbandonedCopyInstrumentedTest {
         SystemClock.sleep(150)
         var bitmap: Bitmap? = null
         instrumentation.runOnMainSync {
-            if (view.width > 0 && view.height > 0) {
-                val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-                view.draw(Canvas(b))
-                bitmap = b
+            bitmap = captureViewToBitmap(view, name)
+        }
+        val captured = checkNotNull(bitmap) {
+            "main thread did not produce viewport bitmap '$name' (#2206)"
+        }
+        val file = artifactFile("$name-viewport.png")
+        FileOutputStream(file).use { out ->
+            check(captured.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
             }
         }
-        bitmap?.let { b ->
-            val file = artifactFile("$name-viewport.png")
-            FileOutputStream(file).use { out ->
-                check(b.compress(Bitmap.CompressFormat.PNG, 100, out)) {
-                    "failed to write bitmap to ${file.absolutePath}"
-                }
-            }
-            println("ISSUE2003_VIEWPORT ${file.absolutePath}")
-            b.recycle()
-        }
+        println("ISSUE2003_VIEWPORT ${file.absolutePath}")
+        captured.recycle()
         artifactFile("$name-visible-terminal.txt").writeText(visibleTerminalText(view))
     }
 

--- a/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/CaptureViewToBitmapTest.kt
+++ b/shared/core-terminal/src/test/java/com/pocketshell/core/terminal/ui/CaptureViewToBitmapTest.kt
@@ -1,0 +1,165 @@
+package com.pocketshell.core.terminal.ui
+
+import android.content.Context
+import android.graphics.Color
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.testsupport.captureViewToBitmap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Issue #2206 — the leftover `:shared:core-terminal` capture helper must
+ * hard-fail on a 0x0 view instead of returning quietly.
+ *
+ * Seven instrumented tests used to do:
+ *
+ * ```
+ * if (view.width > 0 && view.height > 0) { view.draw(...) }
+ * bitmap?.let { write png }
+ * ```
+ *
+ * When TerminalView has collapsed to 0x0 — the failure state worth
+ * capturing — that branch writes no `*-viewport.png` and the test can
+ * still pass. This class is the D32 proof that the shared-module sibling
+ * of the #2135 helper does not reproduce that hole.
+ *
+ * ## The mutation that must redden this test (D32/G6)
+ *
+ * Restore the silent-skip: make [captureViewToBitmap] return null (or
+ * return a dummy bitmap without throwing) when `width <= 0 || height <= 0`.
+ * [captureViewToBitmap_failsOnZeroByZeroViewRatherThanReturningQuietly]
+ * then fails because no [AssertionError] is thrown.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CaptureViewToBitmapTest {
+
+    private fun newView(): View = View(ApplicationProvider.getApplicationContext<Context>())
+
+    @Test
+    fun captureViewToBitmap_failsOnZeroByZeroViewRatherThanReturningQuietly() {
+        val view = newView()
+        assertEquals("unlaid-out View must start 0x0 so this is the reported hole", 0, view.width)
+        assertEquals(0, view.height)
+
+        val error = runCatching { captureViewToBitmap(view, "issue2206-zero") }.exceptionOrNull()
+
+        assertNotNull(
+            "a 0x0 view must hard-fail the capture; a silent return is the #2206 hole",
+            error,
+        )
+        assertTrue(
+            "expected AssertionError, got ${error!!::class.java.name}: ${error.message}",
+            error is AssertionError,
+        )
+        val message = error.message.orEmpty()
+        assertTrue(
+            "diagnostic must name measured size: $message",
+            message.contains("measured=0x0"),
+        )
+        assertTrue(
+            "diagnostic must name on-screen rect: $message",
+            message.contains("onScreenRect="),
+        )
+        assertTrue(
+            "diagnostic must name blank-frame detection: $message",
+            message.contains("drawnFrameIsUniformBlank="),
+        )
+        assertTrue(
+            "failure must name the requested artifact: $message",
+            message.contains("issue2206-zero"),
+        )
+    }
+
+    @Test
+    fun captureViewToBitmap_failsOnMissingView() {
+        val error = runCatching {
+            captureViewToBitmap(null, "issue2206-missing")
+        }.exceptionOrNull()
+
+        assertNotNull("a missing view must hard-fail, not return quietly", error)
+        assertTrue(
+            "expected AssertionError, got ${error!!::class.java.name}: ${error.message}",
+            error is AssertionError,
+        )
+        val message = error.message.orEmpty()
+        assertTrue("diagnostic must name a missing view: $message", message.contains("viewFound=false"))
+        assertTrue("failure must name the requested artifact: $message", message.contains("issue2206-missing"))
+    }
+
+    @Test
+    fun captureViewToBitmap_drawsALaidOutView() {
+        val view = newView().apply {
+            setBackgroundColor(Color.RED)
+            measure(
+                View.MeasureSpec.makeMeasureSpec(48, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(32, View.MeasureSpec.EXACTLY),
+            )
+            layout(0, 0, measuredWidth, measuredHeight)
+        }
+        val bitmap = captureViewToBitmap(view, "issue2206-sized")
+        try {
+            assertEquals(48, bitmap.width)
+            assertEquals(32, bitmap.height)
+            assertEquals(Color.RED, bitmap.getPixel(0, 0))
+        } finally {
+            bitmap.recycle()
+        }
+    }
+
+    /**
+     * Criterion: none of the seven leftover FQCNs may keep a private
+     * silent-skip capture. Restoring
+     * `if (view.width > 0 && view.height > 0) { view.draw(...) }` in any
+     * of them must redden this test.
+     */
+    @Test
+    fun leftoverCoreTerminalCapturesNoLongerSilentSkipAZeroByZeroView() {
+        val androidTestRoot = leftoverAndroidTestRoot()
+        val leftovers = listOf(
+            "com/termux/view/TerminalSelectionViewportStabilityInstrumentedTest.kt",
+            "com/termux/view/TerminalViewPixelProbeAbandonedCopyInstrumentedTest.kt",
+            "com/pocketshell/core/terminal/ui/CodexMultiChunkSeedAttachMainThreadProofTest.kt",
+            "com/pocketshell/core/terminal/ui/ShellPaneAffordanceSingleSnapshotProofTest.kt",
+            "com/pocketshell/core/terminal/ui/CodexOutputBurstImeMainThreadProofTest.kt",
+            "com/pocketshell/core/terminal/ui/AgentPaneLinkAffordanceOffMainProofTest.kt",
+            "com/pocketshell/core/terminal/ui/CodexAppendBurstMainThreadProofTest.kt",
+        )
+        val silentSkip = Regex(
+            """if\s*\(\s*\w+\.width\s*>\s*0\s*&&\s*\w+\.height\s*>\s*0\s*\)""",
+        )
+        leftovers.forEach { relative ->
+            val file = File(androidTestRoot, relative)
+            assertTrue("leftover source missing: ${file.path}", file.isFile)
+            val source = file.readText()
+            assertFalse(
+                "${file.name} still has a silent-skip 0x0 capture; migrate it to captureViewToBitmap (#2206)",
+                silentSkip.containsMatchIn(source),
+            )
+            assertTrue(
+                "${file.name} must call the shared hard-fail helper",
+                source.contains("captureViewToBitmap("),
+            )
+        }
+    }
+
+    private fun leftoverAndroidTestRoot(): File {
+        val marker = "com/termux/view/TerminalSelectionViewportStabilityInstrumentedTest.kt"
+        val userDir = requireNotNull(System.getProperty("user.dir")) { "user.dir is unset" }
+        var dir = File(userDir).absoluteFile
+        repeat(6) {
+            val candidate = File(dir, "src/androidTest/java")
+            if (File(candidate, marker).isFile) return candidate
+            dir = dir.parentFile ?: return@repeat
+        }
+        throw AssertionError(
+            "could not locate core-terminal androidTest sources from user.dir=$userDir",
+        )
+    }
+}

--- a/shared/test-support/build.gradle.kts
+++ b/shared/test-support/build.gradle.kts
@@ -15,6 +15,11 @@ plugins {
 // `dumpsys input_method` text, so the emulator-only IO stays in `androidTest`
 // while the discrimination it drives is pinned in the required per-PR Unit job.
 //
+// Issue #2206 added a third: `ViewCapture.kt` (`captureViewToBitmap`) is the
+// shared-module sibling of the app-module #2135 helper. `:shared:core-terminal`
+// instrumented tests cannot import `app/.../proof/signals/`, so the hard-fail
+// 0x0 capture lives here instead of silently skipping a collapsed TerminalView.
+//
 // The pump itself is pure JVM (Long deadlines + lambdas) — it deliberately does
 // NOT depend on Robolectric or kotlinx-coroutines-test. The per-tick drain
 // (looper idle / `runCurrent()`) is injected by each caller, which already has

--- a/shared/test-support/src/main/java/com/pocketshell/testsupport/ViewCapture.kt
+++ b/shared/test-support/src/main/java/com/pocketshell/testsupport/ViewCapture.kt
@@ -1,0 +1,87 @@
+package com.pocketshell.testsupport
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.view.View
+
+/**
+ * Draws [view] into a software bitmap. Hard-fails if [view] is missing or
+ * has collapsed to 0x0 — a missing artifact is a test failure, never a
+ * silent skip (#2206 / #2135 / #822).
+ *
+ * Seven `:shared:core-terminal` instrumented tests used to do:
+ *
+ * ```
+ * if (view.width > 0 && view.height > 0) { view.draw(...) }
+ * bitmap?.let { write png }
+ * ```
+ *
+ * That is the same hole #2135 closed in the app module. This sibling
+ * lives in `:shared:test-support` so `:shared:core-terminal` can import
+ * it without depending on the app helper (queued on `origin/issue-2135`).
+ *
+ * The diagnostic names the measured size, on-screen rect, and whether a
+ * drawn frame could be inspected for uniform-blank pixels, so a reviewer
+ * can tell a destroyed [android.view.View] from a merely-empty pane.
+ *
+ * Callers still own idle-wait, file I/O, and sidecar text. This function's
+ * only job is: produce the bitmap or throw.
+ */
+fun captureViewToBitmap(view: View?, label: String): Bitmap {
+    if (view == null || view.width <= 0 || view.height <= 0) {
+        throw AssertionError(
+            "the authoritative viewport artifact '$label' could not be captured: " +
+                "${describeViewCaptureState(view)}. A missing terminal viewport " +
+                "capture is a hard failure, never a silent skip (#2206).",
+        )
+    }
+    val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+    view.draw(Canvas(bitmap))
+    return bitmap
+}
+
+/**
+ * One-line view-state diagnostic used by [captureViewToBitmap] and by
+ * tests that assert the failure names the right fields.
+ *
+ * A 0x0 view cannot be drawn, so [drawnFrameIsUniformBlank] is reported
+ * as `unmeasurable` rather than guessed.
+ */
+fun describeViewCaptureState(view: View?): String {
+    if (view == null) {
+        return "viewFound=false measured=n/a onScreenRect=n/a drawnFrameIsUniformBlank=n/a"
+    }
+    val onScreen = Rect()
+    val hasVisibleRect = view.getGlobalVisibleRect(onScreen)
+    val visibleWidth = if (hasVisibleRect) onScreen.width() else 0
+    val visibleHeight = if (hasVisibleRect) onScreen.height() else 0
+    val uniform = if (view.width > 0 && view.height > 0) {
+        val probe = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+        try {
+            view.draw(Canvas(probe))
+            bitmapIsUniform(probe).toString()
+        } finally {
+            probe.recycle()
+        }
+    } else {
+        "unmeasurable"
+    }
+    return "viewFound=true attachedAndShown=${view.isShown} " +
+        "measured=${view.width}x${view.height} " +
+        "onScreenRect=${visibleWidth}x$visibleHeight " +
+        "drawnFrameIsUniformBlank=$uniform"
+}
+
+private fun bitmapIsUniform(bitmap: Bitmap): Boolean {
+    val width = bitmap.width
+    val height = bitmap.height
+    if (width <= 0 || height <= 0) return true
+    val pixels = IntArray(width * height)
+    bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+    val first = pixels[0]
+    for (pixel in pixels) {
+        if (pixel != first) return false
+    }
+    return true
+}


### PR DESCRIPTION
Closes #2206

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2206#issuecomment-5333977208

Move a sibling of the #2135 helper into :shared:test-support so the seven leftover instrumented proofs cannot skip a missing artifact.

Orchestrator verify after rebase: `:shared:core-terminal:testDebugUnitTest --tests CaptureViewToBitmapTest --rerun-tasks` BUILD SUCCESSFUL.