### PR TITLE
test(ci): isolate network-fault --pool lanes onto per-lane toxiproxy (#2128)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -489,6 +489,18 @@ jobs:
           chmod +x scripts/test-agents-pool-isolation.sh
           scripts/test-agents-pool-isolation.sh
 
+      # Issue #2128: --pool promised a distinct (emulator, agents-port) claim
+      # but NetworkFaultProofBase hard-coded 2222/2228 and Toxiproxy upstream
+      # agents:22, so fault-class lanes stayed pinned to the shared fixture
+      # and siblings wiped it mid-run (empty session list). Fast, JVM-free,
+      # no docker daemon: proves the pin is gone, two pool lanes get disjoint
+      # fault ports, compose is parameterized, and a wiped proxy is rc 90
+      # with a banner that cannot be read as a product failure.
+      - name: "Network-fault pool isolation guard (issue #2128)"
+        run: |
+          chmod +x scripts/test-network-fault-pool-isolation.sh
+          scripts/test-network-fault-pool-isolation.sh
+
       # Issue #2143 (rationale + case list in the script header). Fast, stubbed:
       # no JVM, no Docker, no emulator.
       - name: "Shared SSH/tmux fixture health guard (issue #2143)"

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -65,10 +65,13 @@ import java.util.concurrent.CopyOnWriteArrayList
  * Shared harness for opt-in network-fault proof tests.
  *
  * The tests route PocketShell through the Docker `network-fault-proxy`
- * service on host port 2228. Control traffic uses Toxiproxy's HTTP API
- * on host port 8474. Toxiproxy documents `timeout=0` as a non-closing
- * data drop, which gives us a half-open/no-FIN failure instead of the
- * existing EOF/process-kill fixtures.
+ * service. Single-lane / nightly keep host port 2228 and Toxiproxy's HTTP
+ * API on 8474. A `connected-test.sh --pool` lane derives a disjoint pair
+ * from its claimed agents port ([NetworkFaultPorts]) and talks to its own
+ * compose-project proxy (issue #2128) so a sibling cannot wipe the shared
+ * 2222/2228 fixture out from under it. Toxiproxy documents `timeout=0` as
+ * a non-closing data drop, which gives us a half-open/no-FIN failure
+ * instead of the existing EOF/process-kill fixtures.
  */
 abstract class NetworkFaultProofBase {
 
@@ -119,6 +122,7 @@ abstract class NetworkFaultProofBase {
                 "agents network-fault-proxy packet-loss-proxy`.",
             enabled,
         )
+        NetworkFaultPorts.checkNotPinnedToSharedFixture(AgentsFixtureTarget.port)
         networkFaultProofEnabled = true
     }
 
@@ -131,7 +135,11 @@ abstract class NetworkFaultProofBase {
             .use { it.readText() }
 
     protected fun toxiproxy(): ToxiproxyControl =
-        ToxiproxyControl(baseUrl = "http://$DEFAULT_HOST:$TOXIPROXY_API_PORT")
+        ToxiproxyControl(
+            baseUrl = "http://$DEFAULT_HOST:$TOXIPROXY_API_PORT",
+            listen = NetworkFaultPorts.CONTAINER_LISTEN,
+            upstream = NetworkFaultPorts.CONTAINER_UPSTREAM,
+        )
 
     /**
      * Issue #1681 — open the UN-PROXIED sentinel: a direct SSH connection to the
@@ -1075,9 +1083,12 @@ abstract class NetworkFaultProofBase {
 
     protected companion object {
         const val NETWORK_FAULT_ARG: String = "pocketshellNetworkFaultProofs"
-        const val NETWORK_FAULT_SSH_PORT: Int = 2228
-        const val PACKET_LOSS_SSH_PORT: Int = 2229
-        const val TOXIPROXY_API_PORT: Int = 8474
+        val NETWORK_FAULT_SSH_PORT: Int
+            get() = NetworkFaultPorts.faultSshPort(AgentsFixtureTarget.port)
+        val PACKET_LOSS_SSH_PORT: Int
+            get() = NetworkFaultPorts.packetLossSshPort(AgentsFixtureTarget.port)
+        val TOXIPROXY_API_PORT: Int
+            get() = NetworkFaultPorts.toxiproxyApiPort(AgentsFixtureTarget.port)
         const val DATABASE_NAME: String = "pocketshell.db"
         const val DEVICE_DIR_NAME: String = "issue342-network-faults"
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
@@ -1331,9 +1331,11 @@ class OutboundAttachmentOffsetResumeJourneyE2eTest {
         const val SSHD_SNAPSHOT = "ps -o pid,ppid,stat,cmd -u testuser | grep '[s]shd' || true"
         const val PRESERVED_DEVICE_ROOT = "/sdcard/Download/pocketshell-issue1733"
         const val NETWORK_FAULT_ARG = "pocketshellNetworkFaultProofs"
-        const val DIRECT_AGENTS_SSH_PORT = 2222
-        const val NETWORK_FAULT_SSH_PORT = 2228
-        const val TOXIPROXY_API_PORT = 8474
+        val DIRECT_AGENTS_SSH_PORT: Int get() = DEFAULT_PORT
+        val NETWORK_FAULT_SSH_PORT: Int
+            get() = NetworkFaultPorts.faultSshPort(AgentsFixtureTarget.port)
+        val TOXIPROXY_API_PORT: Int
+            get() = NetworkFaultPorts.toxiproxyApiPort(AgentsFixtureTarget.port)
         val CLAIMED_OUTBOUND_STATES = setOf(OutboundState.Uploading, OutboundState.InFlight)
         const val ATTACHING_LABEL = "Attaching…"
 

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationOpenLatencyRttDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationOpenLatencyRttDockerTest.kt
@@ -3,9 +3,11 @@ package com.pocketshell.app.tmux
 import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.AgentsFixtureTarget
 import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.NetworkFaultPorts
 import com.pocketshell.app.proof.PreGrantPermissionsRule
 import com.pocketshell.app.proof.ToxiproxyControl
 import com.pocketshell.app.proof.waitForSshFixtureReady
@@ -657,8 +659,10 @@ class ConversationOpenLatencyRttDockerTest {
         "'" + value.replace("'", "'\"'\"'") + "'"
 
     private companion object {
-        const val NETWORK_FAULT_SSH_PORT: Int = 2228
-        const val TOXIPROXY_API_PORT: Int = 8474
+        val NETWORK_FAULT_SSH_PORT: Int
+            get() = NetworkFaultPorts.faultSshPort(AgentsFixtureTarget.port)
+        val TOXIPROXY_API_PORT: Int
+            get() = NetworkFaultPorts.toxiproxyApiPort(AgentsFixtureTarget.port)
 
         // Issue #828: the RTT the <0.3s gate is asserted at — the realistic-good
         // 80 ms phone-to-remote link. 150 ms is measured + reported but not gated

--- a/app/src/debug/java/com/pocketshell/app/proof/NetworkFaultPorts.kt
+++ b/app/src/debug/java/com/pocketshell/app/proof/NetworkFaultPorts.kt
@@ -1,0 +1,84 @@
+package com.pocketshell.app.proof
+
+/**
+ * Host-port map for the network-fault / packet-loss / Toxiproxy fixtures.
+ *
+ * Issue #2128: `NetworkFaultProofBase` used to hardcode 2228 / 2229 / 8474, so
+ * a `connected-test.sh --pool` lane that had claimed agents port 2243 still
+ * attached through the shared `pocketshell-test-network-fault-proxy` (upstream
+ * `agents:22` = the shared 2222 fixture). Sibling lanes wiping that fixture
+ * presented as an empty session list — the #1842 class, in a place #1842's
+ * agents-port lock does not reach.
+ *
+ * Single-lane / CI / nightly keep the historical identity (2222 → 2228/2229/
+ * 8474). A pool agents port derives a disjoint triple so two fault-class lanes
+ * cannot share a proxy. There is no unset-fallback to the shared ports: a
+ * pool lane that only has `agentsPort` still isolates, because the formula
+ * is a function of that port (D22).
+ *
+ * Keep the offsets in lockstep with `scripts/lib/agents-pool.sh`
+ * (`FAULT_SSH_OFFSET` / `PACKET_LOSS_OFFSET`).
+ */
+object NetworkFaultPorts {
+    const val SINGLE_LANE_AGENTS_PORT: Int = 2222
+    const val SINGLE_LANE_FAULT_SSH_PORT: Int = 2228
+    const val SINGLE_LANE_PACKET_LOSS_PORT: Int = 2229
+    const val SINGLE_LANE_TOXIPROXY_API_PORT: Int = 8474
+
+    /** Container-internal Toxiproxy listen. Host publish is [faultSshPort]. */
+    const val CONTAINER_LISTEN: String = "0.0.0.0:2228"
+
+    /**
+     * Toxiproxy upstream. Per-lane compose projects still name their agents
+     * service `agents`, so this hostname is correct on an isolated network;
+     * it is only a pin when every lane shares one proxy on the default
+     * compose network.
+     */
+    const val CONTAINER_UPSTREAM: String = "agents:22"
+
+    const val POOL_FAULT_SSH_OFFSET: Int = 10
+    const val POOL_PACKET_LOSS_OFFSET: Int = 20
+
+    fun faultSshPort(agentsPort: Int): Int =
+        if (agentsPort == SINGLE_LANE_AGENTS_PORT) {
+            SINGLE_LANE_FAULT_SSH_PORT
+        } else {
+            agentsPort + POOL_FAULT_SSH_OFFSET
+        }
+
+    fun packetLossSshPort(agentsPort: Int): Int =
+        if (agentsPort == SINGLE_LANE_AGENTS_PORT) {
+            SINGLE_LANE_PACKET_LOSS_PORT
+        } else {
+            agentsPort + POOL_PACKET_LOSS_OFFSET
+        }
+
+    fun toxiproxyApiPort(agentsPort: Int): Int =
+        if (agentsPort == SINGLE_LANE_AGENTS_PORT) {
+            SINGLE_LANE_TOXIPROXY_API_PORT
+        } else {
+            SINGLE_LANE_TOXIPROXY_API_PORT + (agentsPort - SINGLE_LANE_AGENTS_PORT)
+        }
+
+    fun isPinnedToSharedFixture(
+        agentsPort: Int,
+        faultSshPort: Int = faultSshPort(agentsPort),
+        apiPort: Int = toxiproxyApiPort(agentsPort),
+    ): Boolean =
+        agentsPort != SINGLE_LANE_AGENTS_PORT &&
+            (
+                faultSshPort == SINGLE_LANE_FAULT_SSH_PORT ||
+                    apiPort == SINGLE_LANE_TOXIPROXY_API_PORT
+                )
+
+    fun checkNotPinnedToSharedFixture(agentsPort: Int) {
+        val fault = faultSshPort(agentsPort)
+        val api = toxiproxyApiPort(agentsPort)
+        check(!isPinnedToSharedFixture(agentsPort, fault, api)) {
+            "FAIL: network-fault class is pinned to the shared 2228/8474 " +
+                "fixture while agentsPort=$agentsPort (faultSsh=$fault " +
+                "api=$api). A --pool lane must use its own toxiproxy, never " +
+                "pocketshell-test-network-fault-proxy. Issue #2128."
+        }
+    }
+}

--- a/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
+++ b/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
@@ -9,6 +9,8 @@ import java.nio.charset.StandardCharsets
 class ToxiproxyControl(
     baseUrl: String,
     private val transport: ToxiproxyTransport = HttpToxiproxyTransport(baseUrl),
+    private val listen: String = NetworkFaultPorts.CONTAINER_LISTEN,
+    private val upstream: String = NetworkFaultPorts.CONTAINER_UPSTREAM,
 ) {
 
     data class ProxyState(
@@ -215,17 +217,16 @@ class ToxiproxyControl(
     }
 
     private fun createProxy() {
-        // Tolerate HTTP 409 "proxy already exists": toxiproxy is a single shared
-        // instance, so when more than one connected lane resets concurrently the
-        // DELETE+POST pair can interleave (one lane's POST lands after another
-        // re-created the proxy). The post-condition of [reset] — an enabled
-        // `agents_ssh` proxy on :2228 — still holds, so a 409 is benign and must
-        // not fail the reset.
+        // Tolerate HTTP 409 "proxy already exists": a shared toxiproxy (the
+        // single-lane 8474 instance) can see two resets interleave. The
+        // post-condition of [reset] — an enabled `agents_ssh` proxy on
+        // [listen] — still holds, so a 409 is benign and must not fail the
+        // reset. Per-lane --pool proxies (#2128) do not share that instance.
         runCatching {
             transport.request(
                 "POST",
                 "/proxies",
-                """{"name":"$PROXY_NAME","listen":"0.0.0.0:2228","upstream":"agents:22","enabled":true}""",
+                """{"name":"$PROXY_NAME","listen":"$listen","upstream":"$upstream","enabled":true}""",
             )
         }.onFailure { error ->
             if (error.message?.contains("HTTP 409") != true) throw error

--- a/app/src/testDebug/java/com/pocketshell/app/proof/NetworkFaultPortsTest.kt
+++ b/app/src/testDebug/java/com/pocketshell/app/proof/NetworkFaultPortsTest.kt
@@ -1,0 +1,69 @@
+package com.pocketshell.app.proof
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkFaultPortsTest {
+
+    @Test
+    fun singleLaneKeepsHistoricalFaultIdentity() {
+        assertEquals(2228, NetworkFaultPorts.faultSshPort(2222))
+        assertEquals(2229, NetworkFaultPorts.packetLossSshPort(2222))
+        assertEquals(8474, NetworkFaultPorts.toxiproxyApiPort(2222))
+        assertFalse(NetworkFaultPorts.isPinnedToSharedFixture(2222))
+    }
+
+    @Test
+    fun poolLaneMustNotResolveToSharedFaultPorts() {
+        val agentsPort = 2243
+        val fault = NetworkFaultPorts.faultSshPort(agentsPort)
+        val loss = NetworkFaultPorts.packetLossSshPort(agentsPort)
+        val api = NetworkFaultPorts.toxiproxyApiPort(agentsPort)
+        assertNotEquals(
+            "a --pool lane on agentsPort=2243 must not attach through the shared 2228 fixture (issue #2128)",
+            2228,
+            fault,
+        )
+        assertNotEquals(2222, fault)
+        assertNotEquals(2229, loss)
+        assertNotEquals(2222, loss)
+        assertNotEquals(8474, api)
+        assertFalse(NetworkFaultPorts.isPinnedToSharedFixture(agentsPort, fault, api))
+    }
+
+    @Test
+    fun twoPoolLanesGetDisjointFaultPorts() {
+        val a = Triple(
+            NetworkFaultPorts.faultSshPort(2243),
+            NetworkFaultPorts.packetLossSshPort(2243),
+            NetworkFaultPorts.toxiproxyApiPort(2243),
+        )
+        val b = Triple(
+            NetworkFaultPorts.faultSshPort(2244),
+            NetworkFaultPorts.packetLossSshPort(2244),
+            NetworkFaultPorts.toxiproxyApiPort(2244),
+        )
+        assertNotEquals(a.first, b.first)
+        assertNotEquals(a.second, b.second)
+        assertNotEquals(a.third, b.third)
+        setOf(a.first, a.second, a.third, b.first, b.second, b.third).forEach { port ->
+            assertFalse(
+                "pool-derived port $port landed on a shared-fixture port",
+                port == 2222 || port == 2228 || port == 2229 || port == 8474,
+            )
+        }
+    }
+
+    @Test
+    fun pinDetectorCatchesAPoolLaneForcedOnto2228() {
+        // The mutation this detector exists to catch: a leftover `?: 2228`
+        // (or `?: 8474`) result on a pool agents port.
+        assertTrue(NetworkFaultPorts.isPinnedToSharedFixture(2243, 2228, 8495))
+        assertTrue(NetworkFaultPorts.isPinnedToSharedFixture(2243, 2253, 8474))
+        assertFalse(NetworkFaultPorts.isPinnedToSharedFixture(2243, 2253, 8495))
+        NetworkFaultPorts.checkNotPinnedToSharedFixture(2243)
+    }
+}

--- a/app/src/testDebug/java/com/pocketshell/app/proof/ToxiproxyControlTest.kt
+++ b/app/src/testDebug/java/com/pocketshell/app/proof/ToxiproxyControlTest.kt
@@ -8,6 +8,29 @@ import org.junit.Test
 class ToxiproxyControlTest {
 
     @Test
+    fun resetHonoursConstructorListenAndUpstream() {
+        val transport = RecordingTransport()
+        ToxiproxyControl(
+            baseUrl = "http://unused",
+            transport = transport,
+            listen = "0.0.0.0:2253",
+            upstream = "agents:22",
+        ).reset()
+
+        assertEquals(
+            listOf(
+                RecordedRequest("DELETE", "/proxies/agents_ssh", null),
+                RecordedRequest(
+                    "POST",
+                    "/proxies",
+                    """{"name":"agents_ssh","listen":"0.0.0.0:2253","upstream":"agents:22","enabled":true}""",
+                ),
+            ),
+            transport.requests,
+        )
+    }
+
+    @Test
     fun resetRecreatesTheAgentsProxy() {
         val transport = RecordingTransport()
         ToxiproxyControl(baseUrl = "http://unused", transport = transport).reset()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -224,6 +224,27 @@ androidTest suite via
 `-Pandroid.testInstrumentationRunnerArguments.agentsPort=<port>`. Two concurrent
 invocations land on different `(emulator, port)` lanes with no cross-talk.
 
+**Network-fault classes under `--pool` are isolated too (issue #2128).** Until
+this fix, `NetworkFaultProofBase` hard-coded host ports 2228 / 2229 / 8474 and
+Toxiproxy's upstream `agents:22`, so a fault-class lane stayed pinned to the
+shared `pocketshell-test-agents` / `pocketshell-test-network-fault-proxy`
+fixture no matter which agents port the pool allocated. A sibling wiping that
+fixture mid-run presented as an empty session list — the #1842 class, in a
+place #1842's agents-port lock does not reach. A `--pool` fault-class lane
+now brings up its own `network-fault-proxy` + `packet-loss-proxy` under the
+same compose project as its claimed agents fixture. Host ports are derived
+from the agents port (2243 → fault 2253 / packet-loss 2263 / API 8495;
+single-lane 2222 still maps to 2228 / 2229 / 8474). Inside each container
+the listen stays `:2228` and the upstream stays `agents:22` — that hostname
+is the compose service on *this* project. A wipe of the per-lane proxy
+exits **90** with a `NETWORK-FAULT FIXTURE DISTURBED` banner that names the
+empty-session-list signature so it cannot be read as a product failure.
+
+Remaining limitation, stated honestly: `--no-pool` / nightly / a `--pool`
+fallback onto port 2222 still use the historical shared 2228/8474 singleton
+and still serialize on the machine-wide toxiproxy lock (#776 P3). Isolation
+is a property of a claimed non-2222 pool port, not of the class name.
+
 Both halves of that claim are anchored to the MACHINE
 (`$HOME/.cache/pocketshell/avd-locks/`), not to the checkout. Until #1842 the
 agents-port half was `"$root_dir/build/.agents-port-lock-$port"` — the worktree
@@ -1770,6 +1791,12 @@ They require a booted emulator plus the Docker `agents` target behind
 Toxiproxy. Default CI does not start these services, and the tests also skip
 when the instrumentation process detects CI, so run them manually for reviewer
 evidence or after explicitly changing the workflow.
+
+A `--pool` run of a fault-class journey (issue #2128) does **not** use the
+shared 2228/8474 singleton: `scripts/connected-test.sh --pool` brings up a
+per-lane proxy on ports derived from the claimed agents port
+([NetworkFaultPorts] / `scripts/lib/agents-pool.sh`). `--no-pool` and the
+commands below still start the historical shared fixture.
 
 Start the ride-through fixture:
 

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -76,12 +76,16 @@ set -euo pipefail
 #                        emulator serial is claimable as a SECOND lane (single
 #                        AVD, e.g. CI), --pool falls back cleanly to that one
 #                        emulator + port 2222.
-#                        WARNING: the toxiproxy network-fault proxies
-#                        (NetworkFaultProofBase: hardcoded 10.0.2.2:2228 / API
-#                        8474, single shared proxy) are NOT pool-isolated, so two
-#                        network-fault lanes corrupt each other's toxics. The
-#                        wrapper warns + serializes network-fault classes onto a
-#                        single shared lock even under --pool (issue #776 P3).
+#                        Network-fault classes under --pool (issue #2128) get a
+#                        per-lane toxiproxy + packet-loss proxy on the same
+#                        compose project as the claimed agents fixture, derived
+#                        from that agents port (2243 -> 2253/2263/8495). They
+#                        no longer attach through the shared 2228/8474
+#                        singleton. The wrapper still serializes fault-class
+#                        runs on the machine-wide toxiproxy lock (issue #776
+#                        P3) so a --no-pool sibling cannot race the shared
+#                        singleton; isolation is what stops a sibling wipe
+#                        presenting as an empty session list.
 #   --no-pool            Force the legacy single-lane path even for a journey/E2e
 #                        class that would otherwise auto-default to --pool (P2).
 #                        Still honours the P0/P1 base-sweep + serial-pin hygiene.
@@ -393,17 +397,14 @@ if [[ "$POOL_FLAG" == "0" && "$CLEANUP_ONLY" != "1" ]]; then
   fi
 fi
 
-# P3 (issue #776) — network-fault classes share ONE global toxiproxy.
-# NetworkFaultProofBase connects to a HARDCODED 10.0.2.2:2228 / API 8474 single
-# shared proxy and its @After does toxiproxy().reset(); --pool does NOT isolate
-# that (it only relocates the agents SSH port, not the fault proxy). So two
-# network-fault lanes running concurrently reset/blackhole/latency EACH OTHER's
-# connection mid-test -> a spurious `Broken transport: EOF` on the innocent lane.
-# Until the per-lane toxiproxy plumbing lands (research P3, an M-sized Kotlin +
-# compose change), detect a network-fault class here and SERIALIZE it: force
-# every such run onto ONE shared lock file regardless of emulator, so at most one
-# network-fault lane touches the singleton proxy at a time. Detection matches the
-# known NetworkFaultProofBase-derived class names.
+# P3 (issue #776) + #2128 — network-fault classes used to share ONE global
+# toxiproxy (hardcoded 10.0.2.2:2228 / API 8474). --pool now isolates that:
+# a pool lane brings up its own network-fault-proxy under the claimed
+# agents compose project and NetworkFaultPorts derives the host ports from
+# the agents port. The machine-wide toxiproxy lock still serializes
+# fault-class runs so a --no-pool sibling on the shared 2228 singleton
+# cannot race another --no-pool (or a pool fallback to 2222). Detection
+# matches the known NetworkFaultProofBase-derived class names.
 NETWORK_FAULT_RUN=0
 gradle_args_str="${GRADLE_ARGS[*]:-}"
 if [[ "$CLEANUP_ONLY" != "1" ]]; then
@@ -411,7 +412,10 @@ if [[ "$CLEANUP_ONLY" != "1" ]]; then
     *NetworkFault*|*NetworkLatencyModel*|*PacketLoss*|*DisconnectBlackhole*\
       |*DisconnectFlap*|*KeepAliveDeadPeer*|*RideThrough*|*WithinGrace*\
       |*StaleLeaseSwitchRecovery*|*CodexRedrawOverflowReconnect*\
-      |*OutboundAttachmentOffsetResumeJourneyE2eTest*)
+      |*OutboundAttachmentOffsetResumeJourneyE2eTest*\
+      |*SilentMidSessionDrop*|*ColdDialUnderBandwidth*|*RealisticWifiStability*\
+      |*NatIdleMapping*|*MobileLatencyStorm*|*PushResumeDeadSocket*\
+      |*ConversationOpenLatency*)
       NETWORK_FAULT_RUN=1
       ;;
   esac
@@ -423,7 +427,7 @@ if [[ "$NETWORK_FAULT_RUN" == "1" ]]; then
   # pool emulators each hold their own serial lock but must still not share the
   # singleton proxy, so they queue on this one shared lock.
   POCKETSHELL_TOXIPROXY_SERIALIZED=1
-  printf 'Network-fault class detected (issue #776 P3): the toxiproxy proxy is a global singleton, so this run is SERIALIZED on a shared lock (no concurrent network-fault lanes).\n' >&2
+  printf 'Network-fault class detected (issue #776 P3 / #2128): serialized on the shared toxiproxy lock; a --pool lane still gets its own derived proxy so a sibling wipe of 2222/2228 cannot look like a product failure.\n' >&2
 fi
 
 # Issue #2007: own this checkout's Gradle OUTPUT TREE before ANY other shared
@@ -514,6 +518,29 @@ if [[ "$USE_POOL" == "1" && -z "${POCKETSHELL_AGENTS_PORT:-}" ]]; then
     exit 1
   fi
   printf 'Pool mode: agents fixture on host port %s\n' "${POCKETSHELL_AGENTS_PORT:-?}" >&2
+fi
+
+# Issue #2128: a pool fault-class lane must actually HAVE a per-lane
+# toxiproxy. Claiming agents:2243 and then attaching through the shared
+# 2228 proxy is the pin this issue exists to kill. Bring the proxies up
+# on the derived host ports under this lane's compose project, then
+# fingerprint the proxy so a mid-run wipe is rc 90, not an empty session
+# list. Single-lane / 2222 fallback keeps the historical shared proxy
+# (started by nightly / the caller) and does not recreate it here.
+if [[ "$CLEANUP_ONLY" != "1" && "$NETWORK_FAULT_RUN" == "1" \
+      && "$USE_POOL" == "1" \
+      && -n "${POCKETSHELL_AGENTS_PORT:-}" \
+      && "${POCKETSHELL_AGENTS_PORT}" != "2222" ]]; then
+  if ! pocketshell_network_fault_fixture_up "$ROOT_DIR" "$POCKETSHELL_AGENTS_PORT"; then
+    printf 'FAIL: could not bring up the per-lane network-fault proxy for agents port %s (issue #2128).\n' \
+      "$POCKETSHELL_AGENTS_PORT" >&2
+    exit 1
+  fi
+  pocketshell_network_fault_record_fixture_identity "$POCKETSHELL_AGENTS_PORT"
+  printf 'Pool mode: network-fault proxy on host port %s (API %s) for agents %s\n' \
+    "$(pocketshell_network_fault_ssh_port "$POCKETSHELL_AGENTS_PORT")" \
+    "$(pocketshell_toxiproxy_api_port "$POCKETSHELL_AGENTS_PORT")" \
+    "$POCKETSHELL_AGENTS_PORT" >&2
 fi
 
 # Optional same-run fixture evidence. The capture happens while this wrapper still

--- a/scripts/lib/agents-pool.sh
+++ b/scripts/lib/agents-pool.sh
@@ -132,6 +132,100 @@ pocketshell_agents_compose_env_for_port() {
 }
 
 # ---------------------------------------------------------------------------
+# Network-fault / packet-loss / Toxiproxy host ports (issue #2128)
+#
+# NetworkFaultProofBase used to hardcode 2228/2229/8474, so a --pool lane
+# that had claimed agents:2243 still attached through the shared
+# pocketshell-test-network-fault-proxy (upstream agents:22 = the 2222
+# fixture). Keep these offsets in lockstep with NetworkFaultPorts.kt
+# (POOL_FAULT_SSH_OFFSET / POOL_PACKET_LOSS_OFFSET). Single-lane 2222 keeps
+# the historical identity; every other agents port derives a disjoint triple.
+# ---------------------------------------------------------------------------
+FAULT_SSH_OFFSET=10
+PACKET_LOSS_OFFSET=20
+
+pocketshell_network_fault_ssh_port() {
+  local agents_port="$1"
+  if [[ "$agents_port" == "2222" ]]; then
+    printf '2228\n'
+  else
+    printf '%s\n' "$((agents_port + FAULT_SSH_OFFSET))"
+  fi
+}
+
+pocketshell_packet_loss_ssh_port() {
+  local agents_port="$1"
+  if [[ "$agents_port" == "2222" ]]; then
+    printf '2229\n'
+  else
+    printf '%s\n' "$((agents_port + PACKET_LOSS_OFFSET))"
+  fi
+}
+
+pocketshell_toxiproxy_api_port() {
+  local agents_port="$1"
+  if [[ "$agents_port" == "2222" ]]; then
+    printf '8474\n'
+  else
+    printf '%s\n' "$((8474 + agents_port - 2222))"
+  fi
+}
+
+pocketshell_network_fault_container_for_port() {
+  local port="$1"
+  if [[ "$port" == "2222" ]]; then
+    printf 'pocketshell-test-network-fault-proxy\n'
+  else
+    printf 'pocketshell-test-network-fault-proxy-%s\n' "$port"
+  fi
+}
+
+pocketshell_packet_loss_container_for_port() {
+  local port="$1"
+  if [[ "$port" == "2222" ]]; then
+    printf 'pocketshell-test-packet-loss-proxy\n'
+  else
+    printf 'pocketshell-test-packet-loss-proxy-%s\n' "$port"
+  fi
+}
+
+# Agents env + the per-lane fault-proxy publish/name overrides.
+pocketshell_network_fault_compose_env_for_port() {
+  local port="$1"
+  pocketshell_agents_compose_env_for_port "$port"
+  printf 'NETWORK_FAULT_HOST_PORT=%s\n' "$(pocketshell_network_fault_ssh_port "$port")"
+  printf 'TOXIPROXY_API_HOST_PORT=%s\n' "$(pocketshell_toxiproxy_api_port "$port")"
+  printf 'NETWORK_FAULT_CONTAINER_NAME=%s\n' "$(pocketshell_network_fault_container_for_port "$port")"
+  printf 'PACKET_LOSS_HOST_PORT=%s\n' "$(pocketshell_packet_loss_ssh_port "$port")"
+  printf 'PACKET_LOSS_CONTAINER_NAME=%s\n' "$(pocketshell_packet_loss_container_for_port "$port")"
+}
+
+# Bring up the per-lane network-fault + packet-loss proxies on $port's
+# compose project (idempotent). The agents fixture must already be up —
+# `depends_on: agents` will start it if not, but a pool claim already did.
+pocketshell_network_fault_fixture_up() {
+  local root_dir="$1"
+  local port="$2"
+  local compose_file container
+  compose_file="$(pocketshell_agents_compose_file "$root_dir")"
+  container="$(pocketshell_network_fault_container_for_port "$port")"
+
+  local env_prefix=(env)
+  local assignment
+  while IFS= read -r assignment; do
+    env_prefix+=("$assignment")
+  done < <(pocketshell_network_fault_compose_env_for_port "$port")
+
+  printf 'Bringing up network-fault fixtures for agents port %s (proxy %s on host %s / API %s)...\n' \
+    "$port" "$container" \
+    "$(pocketshell_network_fault_ssh_port "$port")" \
+    "$(pocketshell_toxiproxy_api_port "$port")" >&2
+  _pocketshell_agents_run_without_avd_lock_fd \
+    "${env_prefix[@]}" docker compose -f "$compose_file" up -d --build \
+    network-fault-proxy packet-loss-proxy >&2
+}
+
+# ---------------------------------------------------------------------------
 # Per-port lock file — MACHINE-anchored, not checkout-anchored (issue #1842)
 #
 # This carried the exact defect #1657 found and fixed in the AVD half, and it
@@ -350,6 +444,68 @@ BANNER
 # test failure without parsing text.
 POCKETSHELL_AGENTS_DISTURBED_RC=90
 
+# Issue #2128: fingerprint the per-lane network-fault-proxy the same way.
+# A wiped toxiproxy presents as ATTACH death / empty session list just like
+# a wiped agents fixture — the app attaches through 2228-equivalent onto a
+# proxy that no longer forwards to the seeded tmux. Same inoculation.
+pocketshell_network_fault_fixture_identity() {
+  local port="$1"
+  local container
+  container="$(pocketshell_network_fault_container_for_port "$port")"
+  local out=""
+  out="$(_pocketshell_agents_run_without_avd_lock_fd \
+    docker inspect --format='{{.Id}} {{.State.StartedAt}}' "$container" 2>/dev/null)" || out=""
+  out="${out%%$'\n'*}"
+  if [[ -z "$out" ]]; then
+    out="unknown"
+  fi
+  printf '%s\n' "$out"
+}
+
+pocketshell_network_fault_record_fixture_identity() {
+  local port="$1"
+  POCKETSHELL_NETWORK_FAULT_FIXTURE_IDENTITY="$(pocketshell_network_fault_fixture_identity "$port")"
+  export POCKETSHELL_NETWORK_FAULT_FIXTURE_IDENTITY
+}
+
+pocketshell_network_fault_assert_fixture_undisturbed() {
+  local port="${1:-${POCKETSHELL_AGENTS_PORT:-}}"
+  local expected="${POCKETSHELL_NETWORK_FAULT_FIXTURE_IDENTITY:-}"
+  if [[ -z "$port" || -z "$expected" || "$expected" == "unknown" ]]; then
+    return 0
+  fi
+  local actual
+  actual="$(pocketshell_network_fault_fixture_identity "$port")"
+  if [[ "$actual" == "$expected" ]]; then
+    return 0
+  fi
+  local container
+  container="$(pocketshell_network_fault_container_for_port "$port")"
+  cat >&2 <<BANNER
+=====================================================================
+FAIL: NETWORK-FAULT FIXTURE DISTURBED MID-RUN (pool isolation violated)
+
+  agents port : $port
+  container   : $container
+  at claim    : $expected
+  now         : $actual
+
+Another process recreated or restarted THIS LANE's network-fault-proxy
+while the run was in progress. The Toxiproxy this run was asserting
+against no longer exists (or no longer forwards to the seeded tmux).
+
+DO NOT read this run's result as a product signal. In particular, an
+empty session list / "got []" / ATTACH death / a missing session in
+the picker is EXPECTED after the fixture is wiped and is NOT evidence of a product
+defect (it mimics #1810 and #1820 exactly). Any PASS is equally void.
+
+Find the other writer before re-running: 'docker ps' will show this
+container with a short uptime. Issue #2128.
+=====================================================================
+BANNER
+  return 1
+}
+
 # Fold the fixture check into a run's final exit code.
 #
 # Takes the gradle/test exit code, returns the code the wrapper should exit with.
@@ -357,7 +513,10 @@ POCKETSHELL_AGENTS_DISTURBED_RC=90
 # disturbed PASS is as worthless as a disturbed FAIL.
 pocketshell_agents_final_rc() {
   local gradle_rc="$1"
-  if pocketshell_agents_assert_fixture_undisturbed; then
+  local disturbed=0
+  pocketshell_agents_assert_fixture_undisturbed || disturbed=1
+  pocketshell_network_fault_assert_fixture_undisturbed || disturbed=1
+  if (( disturbed == 0 )); then
     printf '%s\n' "$gradle_rc"
     return 0
   fi
@@ -598,4 +757,5 @@ pocketshell_release_agents_port() {
   unset POCKETSHELL_AGENTS_OWNER_PID
   unset POCKETSHELL_AGENTS_PORT
   unset POCKETSHELL_AGENTS_FIXTURE_IDENTITY
+  unset POCKETSHELL_NETWORK_FAULT_FIXTURE_IDENTITY
 }

--- a/scripts/lib/avd-lock.sh
+++ b/scripts/lib/avd-lock.sh
@@ -326,15 +326,11 @@ pocketshell_release_all() {
 # ---------------------------------------------------------------------------
 # Toxiproxy serialization lock (issue #776 P3)
 #
-# The network-fault tests (NetworkFaultProofBase) all drive ONE global toxiproxy
-# (hardcoded 10.0.2.2:2228 / API 8474, single shared proxy, @After reset()).
-# --pool does NOT isolate that singleton, so two network-fault lanes corrupt
-# each other's toxics. Until per-lane toxiproxy plumbing lands, serialize every
-# network-fault lane on ONE shared, machine-wide flock so at most one touches the
-# proxy at a time — even across distinct pool emulators. This is SEPARATE from
-# the per-serial AVD lock (two lanes on different emulators each hold their own
-# serial lock but must still NOT share the proxy). Released by
-# pocketshell_release_all on exit.
+# The --no-pool / 2222-fallback network-fault tests still drive ONE global
+# toxiproxy (10.0.2.2:2228 / API 8474). A --pool lane now gets its own
+# proxy (issue #2128) but this lock still serializes every fault-class run
+# so a --no-pool sibling cannot race the shared singleton. This is SEPARATE
+# from the per-serial AVD lock. Released by pocketshell_release_all on exit.
 #
 # Issue #1657: this lock carried the SAME defect as the AVD lock — it promised
 # "ONE shared, machine-wide flock" while living under `$root_dir/build/`, so two

--- a/scripts/test-network-fault-pool-isolation.sh
+++ b/scripts/test-network-fault-pool-isolation.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Network-fault --pool isolation harness (issue #2128).
+#
+# THE DEFECT this harness exists to stop coming back: `connected-test.sh --pool`
+# promises each lane a distinct `(emulator, agents-port)` claim, but
+# `NetworkFaultProofBase` hardcodes host ports 2222/2228 and Toxiproxy's
+# upstream `agents:22`. A fault-class lane therefore stays pinned to the shared
+# `pocketshell-test-agents` / `pocketshell-test-network-fault-proxy` fixture
+# regardless of what the pool allocated. Concurrent siblings wipe that fixture
+# mid-run (empty session list — the #1842 class, in a place #1842's fix does
+# not reach).
+#
+# No docker daemon, no emulator, no Gradle: this is a static + formula guard
+# so a future pin cannot land as "isolation that does not isolate".
+#
+# Wired into the per-push Unit job next to scripts/test-agents-pool-isolation.sh
+# (G9). An unwired regression test is not a regression test.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+[[ -f "$ROOT_DIR/scripts/lib/agents-pool.sh" ]] \
+  || { printf 'FAIL: ROOT_DIR=%s does not look like the repo root\n' "$ROOT_DIR" >&2; exit 2; }
+
+FAILURES=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  FAILURES=$((FAILURES + 1))
+  return 1
+}
+
+pass() {
+  printf '  ok: %s\n' "$1"
+}
+
+PROOF_BASE="$ROOT_DIR/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt"
+TOXICONTROL="$ROOT_DIR/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt"
+PORTS_KT="$ROOT_DIR/app/src/debug/java/com/pocketshell/app/proof/NetworkFaultPorts.kt"
+PORTS_TEST="$ROOT_DIR/app/src/testDebug/java/com/pocketshell/app/proof/NetworkFaultPortsTest.kt"
+COMPOSE="$ROOT_DIR/tests/docker/docker-compose.yml"
+AGENTS_LIB="$ROOT_DIR/scripts/lib/agents-pool.sh"
+CONNECTED="$ROOT_DIR/scripts/connected-test.sh"
+TESTING_MD="$ROOT_DIR/docs/testing.md"
+OUTBOUND="$ROOT_DIR/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt"
+CONV_RTT="$ROOT_DIR/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationOpenLatencyRttDockerTest.kt"
+
+# --------------------------------------------------------------------------
+# 1. THE BUG (red on base): NetworkFaultProofBase must not pin 2228/2229/8474
+#    as compile-time constants. A const 2228 is what made --pool a lie for
+#    every fault-class lane: agentsPort=2243 was honoured for the unproxied
+#    seed and then thrown away when the app attached through hardcoded 2228.
+# --------------------------------------------------------------------------
+network_fault_base_must_not_hardcode_shared_ports() {
+  local pin
+  pin="$(grep -n 'const val NETWORK_FAULT_SSH_PORT: Int = 2228' "$PROOF_BASE" || true)"
+  if [[ -n "$pin" ]]; then
+    fail "NetworkFaultProofBase hardcodes NETWORK_FAULT_SSH_PORT=2228, so a --pool lane stays pinned to the shared toxiproxy fixture regardless of the allocated agents port (issue #2128): $pin"
+    return 1
+  fi
+  pin="$(grep -n 'const val PACKET_LOSS_SSH_PORT: Int = 2229' "$PROOF_BASE" || true)"
+  if [[ -n "$pin" ]]; then
+    fail "NetworkFaultProofBase hardcodes PACKET_LOSS_SSH_PORT=2229 (same class of pin as 2228): $pin"
+    return 1
+  fi
+  pin="$(grep -n 'const val TOXIPROXY_API_PORT: Int = 8474' "$PROOF_BASE" || true)"
+  if [[ -n "$pin" ]]; then
+    fail "NetworkFaultProofBase hardcodes TOXIPROXY_API_PORT=8474 (same class of pin as 2228): $pin"
+    return 1
+  fi
+  # The runtime ports must come from the shared resolver, not a leftover local
+  # literal. A getter that still returns 2228 for every agentsPort is the same
+  # bug wearing a different hat — pinned by the formula checks below.
+  if ! grep -q 'NetworkFaultPorts' "$PROOF_BASE"; then
+    fail "NetworkFaultProofBase does not consult NetworkFaultPorts, so even without a const 2228 it cannot honour a pool-allocated agents port (issue #2128)"
+    return 1
+  fi
+  pass "NetworkFaultProofBase does not hardcode 2228/2229/8474; runtime ports go through NetworkFaultPorts"
+}
+
+# --------------------------------------------------------------------------
+# 2. Independent copies of the same pin. OutboundAttachmentOffsetResume and
+#    ConversationOpenLatencyRtt keep their own `= 2228` constants; fixing only
+#    the base leaves those fault-class lanes on the shared fixture.
+# --------------------------------------------------------------------------
+independent_fault_classes_must_not_keep_their_own_pin() {
+  local file pin
+  for file in "$OUTBOUND" "$CONV_RTT"; do
+    pin="$(grep -n 'NETWORK_FAULT_SSH_PORT.*= 2228' "$file" || true)"
+    if [[ -n "$pin" ]]; then
+      fail "$(basename "$file") keeps its own NETWORK_FAULT_SSH_PORT=2228 pin, so a --pool run of that class still hits the shared fixture (issue #2128): $pin"
+      return 1
+    fi
+    pin="$(grep -n 'TOXIPROXY_API_PORT.*= 8474' "$file" || true)"
+    if [[ -n "$pin" ]]; then
+      fail "$(basename "$file") keeps its own TOXIPROXY_API_PORT=8474 pin (issue #2128): $pin"
+      return 1
+    fi
+  done
+  pass "independent fault-class copies no longer hardcode 2228/8474"
+}
+
+# --------------------------------------------------------------------------
+# 3. ToxiproxyControl.createProxy must take listen/upstream from parameters,
+#    not a single hardcoded POST body. Per-lane toxiproxy still uses
+#    agents:22 *inside its own compose project*, but the control object must
+#    not be the thing that re-pins a pool lane onto the shared proxy.
+# --------------------------------------------------------------------------
+toxiproxy_control_must_parameterise_listen_and_upstream() {
+  if [[ ! -f "$PORTS_KT" ]]; then
+    fail "NetworkFaultPorts.kt is missing; ToxiproxyControl has no place to take listen/upstream from besides the hardcoded 0.0.0.0:2228 / agents:22 POST (issue #2128)"
+    return 1
+  fi
+  if ! grep -q 'listen' "$TOXICONTROL" || ! grep -q 'upstream' "$TOXICONTROL"; then
+    fail "ToxiproxyControl does not expose listen/upstream parameters (issue #2128)"
+    return 1
+  fi
+  # The POST body must interpolate, not embed the shared-fixture literals as
+  # the only path. A leftover """...0.0.0.0:2228...agents:22...""" in
+  # createProxy is the pin.
+  if grep -n 'createProxy' -A 20 "$TOXICONTROL" | grep -q '0.0.0.0:2228'; then
+    fail "ToxiproxyControl.createProxy still embeds listen 0.0.0.0:2228 in the POST body, so a pool lane cannot claim its own proxy (issue #2128)"
+    return 1
+  fi
+  if grep -n 'createProxy' -A 20 "$TOXICONTROL" | grep -q 'agents:22'; then
+    fail "ToxiproxyControl.createProxy still embeds upstream agents:22 in the POST body (issue #2128)"
+    return 1
+  fi
+  pass "ToxiproxyControl.createProxy parameterises listen and upstream"
+}
+
+# --------------------------------------------------------------------------
+# 4. THE FORMULA (red on base: the functions do not exist). A pool agents
+#    port must resolve to fault/API ports that are NOT the shared 2228/8474
+#    singleton. Single-lane 2222 must keep the historical 2228/2229/8474
+#    identity so --no-pool / nightly stay byte-identical.
+# --------------------------------------------------------------------------
+source_pool_lib() {
+  # shellcheck source=scripts/lib/agents-pool.sh
+  source "$AGENTS_LIB"
+}
+
+pool_lane_must_not_resolve_to_the_shared_fault_ports() {
+  if ! grep -q 'pocketshell_network_fault_ssh_port' "$AGENTS_LIB"; then
+    fail "scripts/lib/agents-pool.sh has no pocketshell_network_fault_ssh_port; there is no way for a --pool lane to honour its allocated port on the fault path (issue #2128)"
+    return 1
+  fi
+  source_pool_lib
+  local agents=2243
+  local fault api loss
+  fault="$(pocketshell_network_fault_ssh_port "$agents")"
+  api="$(pocketshell_toxiproxy_api_port "$agents")"
+  loss="$(pocketshell_packet_loss_ssh_port "$agents")"
+  if [[ "$fault" == "2228" || "$fault" == "2222" ]]; then
+    fail "agents port $agents resolved to fault SSH $fault — that is the shared-fixture pin (issue #2128)"
+    return 1
+  fi
+  if [[ "$api" == "8474" ]]; then
+    fail "agents port $agents resolved to toxiproxy API 8474 — that is the shared-fixture pin (issue #2128)"
+    return 1
+  fi
+  if [[ "$loss" == "2229" || "$loss" == "2222" ]]; then
+    fail "agents port $agents resolved to packet-loss $loss — that is the shared-fixture pin (issue #2128)"
+    return 1
+  fi
+  pass "pool agents port $agents resolves to isolated fault=$fault packet-loss=$loss api=$api"
+}
+
+single_lane_keeps_the_historical_fault_identity() {
+  if ! grep -q 'pocketshell_network_fault_ssh_port' "$AGENTS_LIB"; then
+    fail "no derivation function; cannot prove the single-lane 2222 -> 2228 identity is preserved"
+    return 1
+  fi
+  source_pool_lib
+  local fault api loss
+  fault="$(pocketshell_network_fault_ssh_port 2222)"
+  api="$(pocketshell_toxiproxy_api_port 2222)"
+  loss="$(pocketshell_packet_loss_ssh_port 2222)"
+  if [[ "$fault" != "2228" || "$api" != "8474" || "$loss" != "2229" ]]; then
+    fail "single-lane 2222 must stay on the historical 2228/2229/8474 identity (got fault=$fault loss=$loss api=$api); --no-pool / nightly must not move"
+    return 1
+  fi
+  pass "single-lane 2222 still maps to 2228/2229/8474"
+}
+
+two_pool_lanes_get_disjoint_fault_ports() {
+  if ! grep -q 'pocketshell_network_fault_ssh_port' "$AGENTS_LIB"; then
+    fail "no derivation function; cannot prove two pool lanes get disjoint fault ports"
+    return 1
+  fi
+  source_pool_lib
+  local a_fault a_api a_loss b_fault b_api b_loss
+  a_fault="$(pocketshell_network_fault_ssh_port 2243)"
+  a_api="$(pocketshell_toxiproxy_api_port 2243)"
+  a_loss="$(pocketshell_packet_loss_ssh_port 2243)"
+  b_fault="$(pocketshell_network_fault_ssh_port 2244)"
+  b_api="$(pocketshell_toxiproxy_api_port 2244)"
+  b_loss="$(pocketshell_packet_loss_ssh_port 2244)"
+  if [[ "$a_fault" == "$b_fault" || "$a_api" == "$b_api" || "$a_loss" == "$b_loss" ]]; then
+    fail "pool lanes 2243 and 2244 collapsed onto the same fault ports (2243 -> $a_fault/$a_loss/$a_api, 2244 -> $b_fault/$b_loss/$b_api); concurrent fault-class lanes would share one proxy (issue #2128)"
+    return 1
+  fi
+  local port
+  for port in "$a_fault" "$a_api" "$a_loss" "$b_fault" "$b_api" "$b_loss"; do
+    case "$port" in
+      2222|2228|2229|8474)
+        fail "a pool-derived port landed on a shared-fixture port ($port)"
+        return 1
+        ;;
+    esac
+  done
+  pass "pool lanes 2243 and 2244 get disjoint fault ports ($a_fault/$a_loss/$a_api vs $b_fault/$b_loss/$b_api)"
+}
+
+# --------------------------------------------------------------------------
+# 5. Hard-cut (D22): no "use 2228 if unset" leftover that reintroduces the
+#    pin as the default for a pool lane. The Kotlin resolver must derive from
+#    agentsPort; a `?: 2228` / `?: 8474` on the fault path is the bug.
+# --------------------------------------------------------------------------
+no_unset_fallback_reintroduces_the_shared_pin() {
+  if [[ ! -f "$PORTS_KT" ]]; then
+    fail "NetworkFaultPorts.kt is missing, so the only runtime ports are the hardcoded 2228/8474 defaults (issue #2128)"
+    return 1
+  fi
+  local hits
+  hits="$(grep -n -E '\?:[[:space:]]*2228|\?:[[:space:]]*2229|\?:[[:space:]]*8474|else[[:space:]]+2228|else[[:space:]]+8474' "$PORTS_KT" "$PROOF_BASE" \
+    | grep -v ':[[:space:]]*//' \
+    | grep -v ':[[:space:]]*\*' \
+    || true)"
+  if [[ -n "$hits" ]]; then
+    fail "a 'use 2228/8474 if unset' fallback is still on the fault path; a --pool lane that only sets agentsPort would silently re-pin (issue #2128 / D22): $hits"
+    return 1
+  fi
+  pass "no unset-fallback reintroduces 2228/8474 as the pool-lane default"
+}
+
+# --------------------------------------------------------------------------
+# 6. docker-compose must publish parameterized host ports and container
+#    names. A hardcoded "2228:2228" / pocketshell-test-network-fault-proxy
+#    with no ${...} is why a pool lane cannot claim its own proxy.
+# --------------------------------------------------------------------------
+compose_fault_proxy_is_parameterised() {
+  if ! grep -q 'NETWORK_FAULT_HOST_PORT' "$COMPOSE"; then
+    fail "docker-compose.yml network-fault-proxy host port is not parameterized (no NETWORK_FAULT_HOST_PORT); two lanes cannot publish distinct 2228-equivalents (issue #2128)"
+    return 1
+  fi
+  if ! grep -q 'TOXIPROXY_API_HOST_PORT' "$COMPOSE"; then
+    fail "docker-compose.yml toxiproxy API host port is not parameterized (no TOXIPROXY_API_HOST_PORT) (issue #2128)"
+    return 1
+  fi
+  if ! grep -q 'NETWORK_FAULT_CONTAINER_NAME' "$COMPOSE"; then
+    fail "docker-compose.yml network-fault-proxy container_name is not parameterized; two compose projects would collide on pocketshell-test-network-fault-proxy (issue #2128)"
+    return 1
+  fi
+  if ! grep -q 'PACKET_LOSS_HOST_PORT' "$COMPOSE"; then
+    fail "docker-compose.yml packet-loss-proxy host port is not parameterized (issue #2128)"
+    return 1
+  fi
+  if ! grep -q 'PACKET_LOSS_CONTAINER_NAME' "$COMPOSE"; then
+    fail "docker-compose.yml packet-loss-proxy container_name is not parameterized (issue #2128)"
+    return 1
+  fi
+  # Defaults must keep the single-lane identity.
+  grep -q 'NETWORK_FAULT_HOST_PORT:-2228' "$COMPOSE" \
+    || { fail "NETWORK_FAULT_HOST_PORT default is not 2228; --no-pool / nightly would move"; return 1; }
+  grep -q 'TOXIPROXY_API_HOST_PORT:-8474' "$COMPOSE" \
+    || { fail "TOXIPROXY_API_HOST_PORT default is not 8474; --no-pool / nightly would move"; return 1; }
+  pass "compose network-fault and packet-loss proxies are parameterized (defaults keep 2228/2229/8474)"
+}
+
+# --------------------------------------------------------------------------
+# 7. connected-test.sh must bring up the per-lane fault proxies on a pool
+#    fault-class run, and must not claim that they are "NOT pool-isolated".
+# --------------------------------------------------------------------------
+connected_test_isolates_pool_fault_classes() {
+  if ! grep -q 'pocketshell_network_fault_fixture_up' "$CONNECTED"; then
+    fail "connected-test.sh never calls pocketshell_network_fault_fixture_up, so a --pool fault-class lane has no per-lane toxiproxy to honour (issue #2128)"
+    return 1
+  fi
+  if grep -q 'are NOT pool-isolated' "$CONNECTED"; then
+    fail "connected-test.sh still documents network-fault proxies as NOT pool-isolated — that warning is now a lie if isolation landed, and a confession if it did not (issue #2128)"
+    return 1
+  fi
+  pass "connected-test.sh brings up per-lane fault proxies for a pool fault-class run"
+}
+
+# --------------------------------------------------------------------------
+# 8. A wipe of the fault fixture must be distinguishable from a product
+#    failure. The banner must name the collision and inoculate the reader
+#    against the empty-session-list signature (#1810/#1820/#1842).
+# --------------------------------------------------------------------------
+a_disturbed_fault_fixture_is_not_an_empty_session_list() {
+  if ! grep -q 'pocketshell_network_fault_assert_fixture_undisturbed' "$AGENTS_LIB"; then
+    fail "no fault-fixture disturbance check; a wiped network-fault-proxy would present as an empty session list / ATTACH death (issue #2128)"
+    return 1
+  fi
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-nf-wipe.XXXXXX")"
+  export POCKETSHELL_AVD_LOCK_DIR="$tmp/locks"
+  export AGENTS_POOL_TEST_STATE="$tmp/docker-state"
+  mkdir -p "$AGENTS_POOL_TEST_STATE"
+  printf 'sha256:BEFORE 2026-08-18T00:00:00Z\n' > "$AGENTS_POOL_TEST_STATE/identity"
+  # Minimal docker stub so identity inspect works.
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/docker" <<'DOCKER_STUB'
+#!/usr/bin/env bash
+set -u
+state="${AGENTS_POOL_TEST_STATE:?}"
+if [[ "${1:-}" == "inspect" ]]; then
+  case "${2:-}" in
+    *.Id*) cat "$state/identity"; exit 0 ;;
+  esac
+fi
+exit 0
+DOCKER_STUB
+  chmod +x "$tmp/bin/docker"
+  local oldpath="$PATH"
+  export PATH="$tmp/bin:$PATH"
+  source_pool_lib
+  pocketshell_network_fault_record_fixture_identity 2243
+  printf 'sha256:AFTER 2026-08-18T01:00:00Z\n' > "$AGENTS_POOL_TEST_STATE/identity"
+  local out rc=0
+  out="$(pocketshell_network_fault_assert_fixture_undisturbed 2243 2>&1)" || rc=$?
+  export PATH="$oldpath"
+  rm -rf "$tmp"
+  if (( rc == 0 )); then
+    fail "a recreated network-fault-proxy was NOT detected — the lane would report an empty session list as a product defect (issue #2128)"
+    return 1
+  fi
+  local phrase
+  for phrase in "NETWORK-FAULT FIXTURE DISTURBED" "2243" "empty session list" "NOT evidence of a product" "2128"; do
+    if [[ "$out" != *"$phrase"* ]]; then
+      fail "the disturbed-fault-fixture banner is missing '$phrase'; it must be impossible to mistake for an empty-session-list product bug. Got: $out"
+      return 1
+    fi
+  done
+  pass "a wiped network-fault fixture fails with a banner that cannot be read as an empty session list"
+}
+
+# --------------------------------------------------------------------------
+# 9. Kotlin and bash formulas must agree. Two copies of "2243 + 10" that
+#    drift are how the next pin lands.
+# --------------------------------------------------------------------------
+kotlin_and_bash_formulas_agree() {
+  if [[ ! -f "$PORTS_KT" ]]; then
+    fail "NetworkFaultPorts.kt is missing; there is no Kotlin formula to agree with bash (issue #2128)"
+    return 1
+  fi
+  if ! grep -q 'pocketshell_network_fault_ssh_port' "$AGENTS_LIB"; then
+    fail "bash derivation is missing; cannot prove it matches Kotlin"
+    return 1
+  fi
+  local k_fault k_loss k_api
+  k_fault="$(sed -n 's/.*POOL_FAULT_SSH_OFFSET[^0-9]*\([0-9]\+\).*/\1/p' "$PORTS_KT" | head -n1)"
+  k_loss="$(sed -n 's/.*POOL_PACKET_LOSS_OFFSET[^0-9]*\([0-9]\+\).*/\1/p' "$PORTS_KT" | head -n1)"
+  k_api="$(sed -n 's/.*SINGLE_LANE_TOXIPROXY_API_PORT[^0-9]*\([0-9]\+\).*/\1/p' "$PORTS_KT" | head -n1)"
+  local b_fault b_loss
+  b_fault="$(sed -n 's/.*FAULT_SSH_OFFSET=\([0-9]\+\).*/\1/p' "$AGENTS_LIB" | head -n1)"
+  b_loss="$(sed -n 's/.*PACKET_LOSS_OFFSET=\([0-9]\+\).*/\1/p' "$AGENTS_LIB" | head -n1)"
+  if [[ -z "$k_fault" || -z "$b_fault" || "$k_fault" != "$b_fault" ]]; then
+    fail "fault-SSH offset disagrees (Kotlin='$k_fault' bash='$b_fault'); the two formulas would send the APK and the compose publish to different ports"
+    return 1
+  fi
+  if [[ -z "$k_loss" || -z "$b_loss" || "$k_loss" != "$b_loss" ]]; then
+    fail "packet-loss offset disagrees (Kotlin='$k_loss' bash='$b_loss')"
+    return 1
+  fi
+  if [[ "$k_api" != "8474" ]]; then
+    fail "Kotlin SINGLE_LANE_TOXIPROXY_API_PORT is '$k_api', expected 8474"
+    return 1
+  fi
+  pass "Kotlin and bash fault-port offsets agree (fault +$k_fault, packet-loss +$k_loss)"
+}
+
+# --------------------------------------------------------------------------
+# 10. The JVM unit test that pins the formula must exist and be wired into
+#     the debug unit suite (it lives next to ToxiproxyControlTest).
+# --------------------------------------------------------------------------
+jvm_formula_test_exists() {
+  if [[ ! -f "$PORTS_TEST" ]]; then
+    fail "NetworkFaultPortsTest.kt is missing; the 2243-must-not-be-2228 property has no JVM gate (issue #2128)"
+    return 1
+  fi
+  if ! grep -q '2243' "$PORTS_TEST" || ! grep -q '2228' "$PORTS_TEST"; then
+    fail "NetworkFaultPortsTest.kt does not assert that agentsPort=2243 must not resolve to 2228 (issue #2128)"
+    return 1
+  fi
+  pass "NetworkFaultPortsTest.kt pins the pool-lane-is-not-2228 property"
+}
+
+# --------------------------------------------------------------------------
+# 11. Every NetworkFaultProofBase subclass (and the two independent
+#     Toxiproxy journeys that now use NetworkFaultPorts) must be matched
+#     by connected-test.sh's NETWORK_FAULT_RUN detector. A missed class
+#     under --pool would derive 2253/8495 and find no proxy — a new hole
+#     introduced by removing the 2228 pin.
+# --------------------------------------------------------------------------
+every_fault_class_is_detected_by_connected_test() {
+  local classes missing="" name pat matched
+  mapfile -t classes < <(
+    grep -Rlh ': NetworkFaultProofBase(' \
+      "$ROOT_DIR/app/src/androidTest" --include='*Test.kt' \
+      | while IFS= read -r f; do basename "$f" .kt; done
+    printf '%s\n' \
+      OutboundAttachmentOffsetResumeJourneyE2eTest \
+      ConversationOpenLatencyRttDockerTest
+  )
+  if (( ${#classes[@]} < 10 )); then
+    fail "expected to discover NetworkFaultProofBase subclasses; found ${#classes[@]} — detector scan would pass vacuously"
+    return 1
+  fi
+
+  local patterns=()
+  mapfile -t patterns < <(
+    awk '/case "\$gradle_args_str" in/,/esac/' "$CONNECTED" \
+      | grep -v 'case ' | grep -v 'esac' | grep -v 'NETWORK_FAULT' \
+      | tr -d ' \t\\' | tr '|' '\n' | sed 's/)//g' | grep -E '^\*.+\*$' || true
+  )
+  if (( ${#patterns[@]} == 0 )); then
+    fail "could not extract NETWORK_FAULT_RUN globs from connected-test.sh"
+    return 1
+  fi
+
+  for name in "${classes[@]}"; do
+    [[ -n "$name" ]] || continue
+    matched=0
+    for pat in "${patterns[@]}"; do
+      case "$name" in
+        $pat) matched=1; break ;;
+      esac
+    done
+    if (( matched == 0 )); then
+      missing+="  $name"$'\n'
+    fi
+  done
+  if [[ -n "$missing" ]]; then
+    fail "connected-test.sh NETWORK_FAULT_RUN does not match these fault-class names, so a --pool run would derive isolated ports and never bring up the per-lane proxy (issue #2128):
+$missing"
+    return 1
+  fi
+  pass "every fault-class name is matched by connected-test.sh NETWORK_FAULT_RUN (${#classes[@]} classes, ${#patterns[@]} globs)"
+}
+
+# --------------------------------------------------------------------------
+# 12. docs/testing.md must state the --pool fault-class behaviour honestly.
+# --------------------------------------------------------------------------
+docs_state_the_fault_pool_behaviour() {
+  if ! grep -q '2128' "$TESTING_MD"; then
+    fail "docs/testing.md does not mention issue #2128, so the --pool / network-fault limitation (or its fix) is not documented (AC)"
+    return 1
+  fi
+  pass "docs/testing.md documents the #2128 network-fault --pool behaviour"
+}
+
+# --------------------------------------------------------------------------
+
+main() {
+  printf 'network-fault pool isolation harness (issue #2128)\n'
+  network_fault_base_must_not_hardcode_shared_ports || true
+  independent_fault_classes_must_not_keep_their_own_pin || true
+  toxiproxy_control_must_parameterise_listen_and_upstream || true
+  pool_lane_must_not_resolve_to_the_shared_fault_ports || true
+  single_lane_keeps_the_historical_fault_identity || true
+  two_pool_lanes_get_disjoint_fault_ports || true
+  no_unset_fallback_reintroduces_the_shared_pin || true
+  compose_fault_proxy_is_parameterised || true
+  connected_test_isolates_pool_fault_classes || true
+  a_disturbed_fault_fixture_is_not_an_empty_session_list || true
+  kotlin_and_bash_formulas_agree || true
+  jvm_formula_test_exists || true
+  every_fault_class_is_detected_by_connected_test || true
+  docs_state_the_fault_pool_behaviour || true
+
+  if (( FAILURES > 0 )); then
+    printf '\nnetwork-fault pool isolation: %s FAILING check(s)\n' "$FAILURES" >&2
+    exit 1
+  fi
+  printf '\nnetwork-fault pool isolation: all checks passed\n'
+}
+
+main "$@"

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -362,18 +362,25 @@ services:
   # to the normal `agents` SSH fixture on the compose network. Tests control
   # toxics through the HTTP API exposed on 10.0.2.2:8474.
   #
+  # Issue #2128: a `--pool` lane cannot share this singleton. The host ports
+  # and container name are parameterized (defaults keep the single-lane
+  # identity) so `scripts/lib/agents-pool.sh` can bring up a per-lane proxy
+  # under the same COMPOSE_PROJECT_NAME as that lane's `agents` fixture.
+  # Inside the container the listen stays 2228 and the upstream stays
+  # `agents:22` — that hostname is the compose service on THIS project.
+  #
   # The default GitHub workflow does not start this service, so the Android
   # tests that use it are gated with `pocketshellNetworkFaultProofs=true` and
   # skipped on CI unless the workflow is explicitly expanded later.
   network-fault-proxy:
     image: ghcr.io/shopify/toxiproxy:2.9.0
-    container_name: pocketshell-test-network-fault-proxy
+    container_name: ${NETWORK_FAULT_CONTAINER_NAME:-pocketshell-test-network-fault-proxy}
     command: ["-host", "0.0.0.0"]
     depends_on:
       - agents
     ports:
-      - "2228:2228"
-      - "8474:8474"
+      - "${NETWORK_FAULT_HOST_PORT:-2228}:2228"
+      - "${TOXIPROXY_API_HOST_PORT:-8474}:8474"
 
   # Issue #346: true packet-loss proxy for opt-in connected Android proofs.
   # The emulator reaches this proxy at 10.0.2.2:2229. Linux `tc netem loss`
@@ -389,7 +396,7 @@ services:
       context: .
       dockerfile: packet-loss-proxy/Dockerfile
     image: pocketshell-test:packet-loss-proxy
-    container_name: pocketshell-test-packet-loss-proxy
+    container_name: ${PACKET_LOSS_CONTAINER_NAME:-pocketshell-test-packet-loss-proxy}
     cap_add:
       - NET_ADMIN
     environment:
@@ -402,4 +409,4 @@ services:
     depends_on:
       - agents
     ports:
-      - "2229:2229"
+      - "${PACKET_LOSS_HOST_PORT:-2229}:2229"


### PR DESCRIPTION
Closes #2128

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2128#issuecomment-5333451764

Derive fault ports from the claimed agents port so two --pool lanes no longer share 2222/2228. A wiped fixture is rc 90, not an empty session list.

Orchestrator verify after rebase: test-network-fault-pool-isolation.sh PASS; test-agents-pool-isolation.sh PASS.