### PR TITLE
ci: keep last-completed-class evidence when a journey shard runner dies (#2090)

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -132,6 +132,10 @@ jobs:
     needs: guard
     if: needs.guard.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      checks: write
     # SHARD (issue #835 follow-up): the full connected suite is ~680 tests and
     # could NOT finish serially on ONE swiftshader AVD inside this ceiling
     # (a triage run reached only 544/683 at the 150-min timeout, so phases 2 & 3
@@ -431,6 +435,10 @@ jobs:
             **/build/outputs/connected_android_test_additional_output/
             artifacts/nightly-extensive/
           if-no-files-found: ignore
+
+      - name: "Mark journey progress artifacts-uploaded (issue #2090)"
+        if: always()
+        run: scripts/ci-journey-progress-telemetry.sh artifacts-uploaded || true
 
       - name: Upload Docker logs
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -679,6 +679,16 @@ jobs:
       - name: CI journey cold-boot canonical artifact guard (issue #2093)
         run: scripts/test-ci-journey-canonical-artifacts.sh
 
+      # Issue #2090: extra-runner last-completed-class telemetry. Proves a
+      # simulated hosted-runner death still leaves last-completed-class + job
+      # metadata, a missing shard never aggregates CLEAN, and a successful
+      # shard keeps its existing verdict/artifact contract. Cheap, no emulator.
+      - name: "Journey shard progress-telemetry guard (issue #2090)"
+        run: |
+          chmod +x scripts/ci-journey-progress-telemetry.sh \
+            scripts/test-ci-journey-progress-telemetry.sh
+          scripts/test-ci-journey-progress-telemetry.sh
+
       # Issue #1827: every condition that turns the journey suite RED must leave
       # evidence the classify step can read. The suite's red condition and the
       # summary's failed-BOTH-attempts section used to be two hand-maintained
@@ -1067,6 +1077,13 @@ jobs:
   emulator-journey:
     name: Emulator journey subset (load-bearing, Docker agents)
     if: github.event_name != 'pull_request'
+    # Issue #2090: Checks-API publisher for last-completed-class telemetry.
+    # actions: write keeps the existing artifact uploads working once this job
+    # names its token scopes.
+    permissions:
+      contents: read
+      actions: write
+      checks: write
     # Issue #2060 (CI Phase A) — THE ACTIONS-BUDGET DECISION, recorded here
     # because this one line owned ~37 of `main`'s ~99-minute wall clock. It was
     # `needs: [unit, python, integration]`, so the shards could not start until
@@ -1946,6 +1963,10 @@ jobs:
           overwrite: true
           if-no-files-found: warn
 
+      - name: "Mark journey progress artifacts-uploaded (issue #2090)"
+        if: always()
+        run: scripts/ci-journey-progress-telemetry.sh artifacts-uploaded || true
+
       - name: Stop Docker fixture
         if: always()
         run: docker compose -f tests/docker/docker-compose.yml down --volumes --remove-orphans
@@ -1986,6 +2007,10 @@ jobs:
     needs: emulator-journey
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      checks: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1996,6 +2021,14 @@ jobs:
           pattern: emulator-journey-verdict-shard-*
           path: artifacts/ci-journey-verdicts
         continue-on-error: true
+
+      - name: "Collect surviving journey-progress telemetry (issue #2090)"
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p artifacts/ci-journey-progress
+          scripts/ci-journey-progress-telemetry.sh collect-from-github artifacts/ci-journey-progress || true
 
       - name: Aggregate the per-shard verdicts into ONE verdict
         env:
@@ -2008,6 +2041,7 @@ jobs:
           # lost a commit-bound failure. Genuine typed INFRA shards finish green,
           # so their matrix result is success and remains neutral RE-RUN.
           UPSTREAM_MATRIX_RESULT: ${{ needs.emulator-journey.result }}
+          CI_JOURNEY_PROGRESS_DIR: artifacts/ci-journey-progress
         run: |
           chmod +x scripts/ci-journey-aggregate-verdict.sh
           scripts/ci-journey-aggregate-verdict.sh artifacts/ci-journey-verdicts

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -51,6 +51,11 @@
 #                  mismatch and fails closed to RED (#1913). Genuine typed
 #                  INFRA shards finish successfully, so their upstream result
 #                  is `success` and their aggregate remains green RE-RUN.
+#   CI_JOURNEY_PROGRESS_DIR (env, optional) extra-runner last-completed-class
+#                  records collected by ci-journey-progress-telemetry.sh
+#                  (issue #2090). When a shard is missing, the last class and
+#                  job metadata are printed as an INFRA diagnostic. This never
+#                  flips CLEAN/RED — attendance fail-closed stays with #2082.
 #
 # Verdict / exit code:
 #   CLEAN   every shard reported CLEAN (and none are missing). exit 0.
@@ -92,6 +97,7 @@ one_shot_shards=()
 external_setup_infra_shards=()
 unclassified_infra=0
 fresh_tokens=0
+reported_shards=()
 
 current_attempt="${GITHUB_RUN_ATTEMPT:-}"
 [[ "$current_attempt" =~ ^[0-9]+$ ]] || current_attempt=""
@@ -172,6 +178,9 @@ if [[ -d "$verdict_dir" ]]; then
 
     count=$((count + 1))
     tokens+=("$token")
+    if [[ "$tok_shard" =~ ^[0-9]+$ ]]; then
+      reported_shards+=("$tok_shard")
+    fi
     case "$token" in
       CLEAN) have_clean=$((have_clean + 1)) ;;
       INFRA) have_infra=$((have_infra + 1)) ;;
@@ -188,6 +197,44 @@ fi
 
 echo "per-shard verdict tokens found: ${count} ${tokens[*]:-<none>}"
 echo "  CLEAN=$have_clean  INFRA=$have_infra  RED=$have_red  UNKNOWN=$have_unknown  MISSING=$missing (expected ${expected_shards})"
+
+# Issue #2090: a vanished shard may still have extra-runner last-completed-class
+# telemetry. That is INFRA diagnostic, never a product CLEAN/RED flip — #2082
+# still owns fail-closed attendance, and missing stays at least RE-RUN.
+progress_dir="${CI_JOURNEY_PROGRESS_DIR:-}"
+if (( missing > 0 )) && [[ -n "$progress_dir" && -d "$progress_dir" ]]; then
+  progress_idx=0
+  while (( progress_idx < expected_shards )); do
+    shard_seen=0
+    for seen in "${reported_shards[@]:-}"; do
+      if [[ "$seen" == "$progress_idx" ]]; then
+        shard_seen=1
+        break
+      fi
+    done
+    if (( shard_seen == 0 )); then
+      progress_file=""
+      for candidate in "$progress_dir"/journey-progress-shard-${progress_idx}-*.txt \
+                       "$progress_dir"/*shard-${progress_idx}*.txt; do
+        [[ -f "$candidate" ]] || continue
+        progress_file="$candidate"
+        break
+      done
+      if [[ -n "$progress_file" ]]; then
+        last_class="$(sed -n 's/^last_completed_class=//p' "$progress_file" | head -n 1)"
+        last_status="$(sed -n 's/^last_completed_status=//p' "$progress_file" | head -n 1)"
+        in_progress="$(sed -n 's/^in_progress_class=//p' "$progress_file" | head -n 1)"
+        job_name="$(sed -n 's/^job_name=//p' "$progress_file" | head -n 1)"
+        run_id="$(sed -n 's/^run_id=//p' "$progress_file" | head -n 1)"
+        run_attempt="$(sed -n 's/^run_attempt=//p' "$progress_file" | head -n 1)"
+        [[ -n "$last_class" ]] || last_class="(none recorded)"
+        echo "missing shard ${progress_idx} last-completed-class (infra diagnostic, issue #2090): ${last_class} status=${last_status:-unknown} in_progress=${in_progress:-} job=${job_name:-unknown} run=${run_id:-unknown} attempt=${run_attempt:-unknown}"
+        echo "::notice title=Emulator journey shard ${progress_idx} last-completed-class (infra)::owner=infra signature=hosted_runner_progress last_completed_class=${last_class} — diagnostic only, not a product verdict (issue #2090)"
+      fi
+    fi
+    progress_idx=$((progress_idx + 1))
+  done
+fi
 
 # Issue #1809: per-shard provenance, so a G5 "clean re-run" claim is backed by
 # the artifact rather than by which button someone remembers pressing.

--- a/scripts/ci-journey-class-loop-functions.sh
+++ b/scripts/ci-journey-class-loop-functions.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 # Journey class retry loop and result buckets for scripts/ci-journey-suite.sh.
 
+# Issue #2090: fail-soft last-completed-class heartbeat. A missing helper, a
+# publish fault, or a non-CI invocation must never change a class verdict.
+ci_journey_progress_event() {
+  local helper="${CI_JOURNEY_PROGRESS_HELPER:-}"
+  if [[ -z "$helper" && -n "${REPO_ROOT:-}" ]]; then
+    helper="$REPO_ROOT/scripts/ci-journey-progress-telemetry.sh"
+  fi
+  [[ -n "$helper" && -f "$helper" ]] || return 0
+  bash "$helper" "$@" || true
+}
+
 # run_journey_classes_with_retry - issue #712.
 #
 # The per-push job runs on the GitHub `android-emulator-runner` AVD - a 2-core
@@ -77,6 +88,7 @@ run_journey_classes_with_retry() {
       STEP_TIMEOUT_HIT=1
       echo "JOURNEY_STEP_TIMEOUT: suite budget (${JOURNEY_STEP_BUDGET_SECS}s) exhausted before $fqcn — not run (issue #835 / #470 stall)"
       BUDGET_TIMEOUT_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" budget_skipped
       continue
     fi
 
@@ -85,6 +97,7 @@ run_journey_classes_with_retry() {
     echo "=========================================================="
     class_start=$SECONDS
     class_wedged=0
+    ci_journey_progress_event class-started "$fqcn"
 
     run_class "$fqcn"
     rc=$?
@@ -98,11 +111,13 @@ run_journey_classes_with_retry() {
     if [[ "${JOURNEY_ABORT_ISOLATION_FAILED:-0}" -eq 1 ]]; then
       echo "JOURNEY_ISOLATION_FAILURE: $fqcn primary_rc=${LAST_RUN_CLASS_PRIMARY_RC:-unknown} cleanup_failed=${LAST_RUN_CLASS_ABORT_CLEANUP_FAILED:-0} artifact_failed=${LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED:-0} — refusing every retry/next class because isolation is unproven"
       FAILED_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" isolation_failure
       break
     fi
     if [[ $rc -eq 0 ]]; then
       echo "JOURNEY_PASS: $fqcn passed on attempt 1 (elapsed $((SECONDS - class_start))s)"
       PASSED_FIRST_TRY+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" pass
       continue
     fi
 
@@ -114,11 +129,13 @@ run_journey_classes_with_retry() {
       STEP_TIMEOUT_HIT=1
       echo "JOURNEY_STEP_TIMEOUT: $fqcn attempt 1 exhausted the suite budget (rc=$rc) — not retried (issue #835 / #470 stall)"
       BUDGET_TIMEOUT_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" budget_timeout
       continue
     fi
     if budget_exhausted; then
       echo "JOURNEY_FAILED: $fqcn failed before retry and cleanup exhausted the suite budget (rc=$rc)"
       FAILED_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" fail
       continue
     fi
 
@@ -142,6 +159,7 @@ run_journey_classes_with_retry() {
     if [[ "${JOURNEY_ABORT_ISOLATION_FAILED:-0}" -eq 1 ]]; then
       echo "JOURNEY_ISOLATION_FAILURE: $fqcn retry primary_rc=${LAST_RUN_CLASS_PRIMARY_RC:-unknown} cleanup_failed=${LAST_RUN_CLASS_ABORT_CLEANUP_FAILED:-0} artifact_failed=${LAST_RUN_CLASS_ARTIFACT_SNAPSHOT_FAILED:-0} — refusing every next class because isolation is unproven"
       FAILED_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" isolation_failure
       break
     fi
     if [[ $rc -eq 0 ]]; then
@@ -149,6 +167,7 @@ run_journey_classes_with_retry() {
       # degrading trend is detectable in the CI logs.
       echo "JOURNEY_FLAKE_RECOVERED: $fqcn passed on retry (attempt 2) (retry elapsed $((SECONDS - retry_start))s)"
       RECOVERED_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" flake_recovered
     elif class_attempt_hit_time_budget "$rc"; then
       # rc=124 == `timeout` sent TERM at the class cap; rc=137 == the command
       # survived TERM and hit the SIGKILL backstop. Either way this is a time-
@@ -158,12 +177,15 @@ run_journey_classes_with_retry() {
       STEP_TIMEOUT_HIT=1
       echo "JOURNEY_STEP_TIMEOUT: $fqcn retry was cut by the suite budget (rc=$rc) (issue #835 / #470 stall)"
       BUDGET_TIMEOUT_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" budget_timeout
     elif budget_exhausted; then
       echo "JOURNEY_FAILED: $fqcn retry failed and cleanup exhausted the suite budget (rc=$rc)"
       FAILED_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" fail
     else
       echo "JOURNEY_FAILED: $fqcn failed twice"
       FAILED_CLASSES+=("$fqcn")
+      ci_journey_progress_event class-completed "$fqcn" fail
     fi
 
     # Issue #2143: a class that failed while the SHARED fixture was not answering

--- a/scripts/ci-journey-progress-telemetry.sh
+++ b/scripts/ci-journey-progress-telemetry.sh
@@ -1,0 +1,554 @@
+#!/usr/bin/env bash
+# Issue #2090: bounded last-completed-class + job-metadata telemetry for a
+# hosted journey shard. The local snapshot is a convenience; the load-bearing
+# copy is published OUTSIDE the runner filesystem so it survives abrupt runner
+# disappearance (the #2038 hosted-shard-2 loss: job log BlobNotFound, every
+# if:always() step still pending, no report/XML/summary).
+#
+# This path is INFRASTRUCTURE DIAGNOSTIC only. It never writes a product
+# CLEAN/RED verdict and never lets a missing shard look green — artifact
+# attendance / fail-closed accounting stays with #2082.
+#
+# Usage:
+#   ci-journey-progress-telemetry.sh start
+#   ci-journey-progress-telemetry.sh class-started FQCN
+#   ci-journey-progress-telemetry.sh class-completed FQCN STATUS
+#   ci-journey-progress-telemetry.sh suite-completed [STATUS]
+#   ci-journey-progress-telemetry.sh artifacts-uploaded
+#   ci-journey-progress-telemetry.sh observe-stream
+#   ci-journey-progress-telemetry.sh classify
+#   ci-journey-progress-telemetry.sh collect-from-github DEST_DIR
+#   ci-journey-progress-telemetry.sh read [FILE]
+#
+# Env (production + tests):
+#   CI_JOURNEY_PROGRESS_FILE           local snapshot (default under
+#                                      artifacts/ci-journey-progress/)
+#   CI_JOURNEY_PROGRESS_EXTERNAL_DIR   extra-runner store. Tests point this
+#                                      outside the wiped workspace; CI can
+#                                      also set it. THIS is the durable copy.
+#   CI_JOURNEY_PROGRESS_MAX_BYTES      hard cap (default 4096)
+#   CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1  skip the Checks-API publisher
+#   CI_JOURNEY_PROGRESS_VERDICT_PRESENT / _LATER_STEPS_RAN /
+#   CI_JOURNEY_PROGRESS_LOST_COMMUNICATION
+#                                      classify() inputs (true|false)
+#
+# Publish is ALWAYS fail-soft: a telemetry fault must never redden a shard.
+set -uo pipefail
+
+SCHEMA="pocketshell.journey.progress.v1"
+OWNER="infra"
+PROGRESS_SIGNATURE="hosted_runner_progress"
+VERDICT_ROLE="diagnostic"
+MAX_BYTES="${CI_JOURNEY_PROGRESS_MAX_BYTES:-4096}"
+[[ "$MAX_BYTES" =~ ^[1-9][0-9]{2,6}$ ]] || MAX_BYTES=4096
+
+cmd="${1:-}"
+shift || true
+
+progress_fail_soft() {
+  echo "ci-journey-progress-telemetry: $*" >&2
+  return 0
+}
+
+iso_now() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+sanitize_token() {
+  local raw="${1-}"
+  raw="${raw//$'\n'/}"
+  raw="${raw//$'\r'/}"
+  printf '%s' "$raw"
+}
+
+sanitize_class() {
+  local raw
+  raw="$(sanitize_token "${1-}")"
+  if [[ "$raw" =~ ^[A-Za-z_][A-Za-z0-9_.]*([#][A-Za-z_][A-Za-z0-9_]*)?$ ]]; then
+    printf '%s' "$raw"
+    return 0
+  fi
+  printf ''
+}
+
+sanitize_status() {
+  local raw
+  raw="$(sanitize_token "${1-}")"
+  raw="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$raw" in
+    pass|fail|flake_recovered|budget_timeout|budget_skipped|isolation_failure|error|started|completed|running|'')
+      printf '%s' "$raw"
+      ;;
+    *)
+      printf 'unknown'
+      ;;
+  esac
+}
+
+resolve_shard() {
+  local shard total
+  shard="${POCKETSHELL_JOURNEY_CI_SHARD_INDEX:-${POCKETSHELL_NIGHTLY_SHARD_INDEX:-${JOURNEY_CI_SHARD_INDEX:-0}}}"
+  total="${POCKETSHELL_JOURNEY_CI_SHARD_TOTAL:-${POCKETSHELL_NIGHTLY_SHARD_TOTAL:-${JOURNEY_CI_SHARD_TOTAL:-1}}}"
+  [[ "$shard" =~ ^[0-9]+$ ]] || shard=0
+  [[ "$total" =~ ^[1-9][0-9]*$ ]] || total=1
+  printf '%s %s' "$shard" "$total"
+}
+
+progress_basename() {
+  local shard attempt run_id
+  shard="${1:-0}"
+  attempt="${GITHUB_RUN_ATTEMPT:-1}"
+  run_id="${GITHUB_RUN_ID:-local}"
+  [[ "$attempt" =~ ^[0-9]+$ ]] || attempt=1
+  printf 'journey-progress-shard-%s-attempt-%s-run-%s.txt' "$shard" "$attempt" "$run_id"
+}
+
+default_local_file() {
+  local shard total
+  read -r shard total <<<"$(resolve_shard)"
+  printf 'artifacts/ci-journey-progress/%s' "$(progress_basename "$shard")"
+}
+
+LOCAL_FILE="${CI_JOURNEY_PROGRESS_FILE:-$(default_local_file)}"
+EXTERNAL_DIR="${CI_JOURNEY_PROGRESS_EXTERNAL_DIR:-}"
+
+read_field() {
+  local file="$1" key="$2"
+  [[ -f "$file" ]] || { printf ''; return 0; }
+  sed -n "s/^${key}=//p" "$file" 2>/dev/null | head -n 1
+}
+
+write_record() {
+  local phase="$1"
+  local now
+  now="$(iso_now)"
+  local shard total
+  read -r shard total <<<"$(resolve_shard)"
+
+  local started_at="" seq="0" classes_completed="0" last_class="" last_status="" \
+    last_at="" in_progress="" check_run_id="" suite_state="running" \
+    classes_selected="${CI_JOURNEY_PROGRESS_CLASSES_SELECTED:-0}"
+  if [[ -f "$LOCAL_FILE" ]]; then
+    started_at="$(read_field "$LOCAL_FILE" started_at)"
+    seq="$(read_field "$LOCAL_FILE" seq)"
+    classes_completed="$(read_field "$LOCAL_FILE" classes_completed)"
+    last_class="$(read_field "$LOCAL_FILE" last_completed_class)"
+    last_status="$(read_field "$LOCAL_FILE" last_completed_status)"
+    last_at="$(read_field "$LOCAL_FILE" last_completed_at)"
+    in_progress="$(read_field "$LOCAL_FILE" in_progress_class)"
+    check_run_id="$(read_field "$LOCAL_FILE" check_run_id)"
+    suite_state="$(read_field "$LOCAL_FILE" suite_state)"
+    classes_selected="$(read_field "$LOCAL_FILE" classes_selected)"
+  fi
+  [[ "${seq}" =~ ^[0-9]+$ ]] || seq=0
+  [[ "${classes_completed}" =~ ^[0-9]+$ ]] || classes_completed=0
+  [[ "${classes_selected}" =~ ^[0-9]+$ ]] || classes_selected="${CI_JOURNEY_PROGRESS_CLASSES_SELECTED:-0}"
+  [[ -n "${started_at}" ]] || started_at="$now"
+  [[ -n "${suite_state}" ]] || suite_state="running"
+
+  case "$phase" in
+    started)
+      seq=0
+      classes_completed=0
+      last_class=""
+      last_status=""
+      last_at=""
+      in_progress=""
+      suite_state="running"
+      started_at="$now"
+      ;;
+    class_started)
+      in_progress="${2-}"
+      seq=$((seq + 1))
+      ;;
+    class_completed)
+      last_class="${2-}"
+      last_status="${3-}"
+      last_at="$now"
+      in_progress=""
+      classes_completed=$((classes_completed + 1))
+      seq=$((seq + 1))
+      ;;
+    suite_completed)
+      suite_state="${2:-completed}"
+      in_progress=""
+      seq=$((seq + 1))
+      ;;
+    artifacts_uploaded)
+      suite_state="artifacts_uploaded"
+      seq=$((seq + 1))
+      ;;
+  esac
+
+  local parent
+  parent="$(dirname "$LOCAL_FILE")"
+  mkdir -p "$parent" || { progress_fail_soft "cannot create $parent"; return 0; }
+
+  local tmp
+  tmp="${LOCAL_FILE}.tmp.$$"
+  {
+    printf 'schema=%s\n' "$SCHEMA"
+    printf 'owner=%s\n' "$OWNER"
+    printf 'signature=%s\n' "$PROGRESS_SIGNATURE"
+    printf 'verdict_role=%s\n' "$VERDICT_ROLE"
+    printf 'workflow=%s\n' "$(sanitize_token "${CI_JOURNEY_PROGRESS_WORKFLOW:-${GITHUB_WORKFLOW:-unknown}}")"
+    printf 'job_name=%s\n' "$(sanitize_token "${CI_JOURNEY_PROGRESS_JOB_NAME:-${GITHUB_JOB:-unknown}}")"
+    printf 'job_id=%s\n' "$(sanitize_token "${CI_JOURNEY_PROGRESS_JOB_ID:-${GITHUB_JOB_ID:-unknown}}")"
+    printf 'run_id=%s\n' "$(sanitize_token "${GITHUB_RUN_ID:-unknown}")"
+    printf 'run_attempt=%s\n' "$(sanitize_token "${GITHUB_RUN_ATTEMPT:-unknown}")"
+    printf 'shard=%s\n' "$shard"
+    printf 'shard_total=%s\n' "$total"
+    printf 'runner_name=%s\n' "$(sanitize_token "${RUNNER_NAME:-unknown}")"
+    printf 'runner_os=%s\n' "$(sanitize_token "${RUNNER_OS:-unknown}")"
+    printf 'head_sha=%s\n' "$(sanitize_token "${GITHUB_SHA:-unknown}")"
+    printf 'started_at=%s\n' "$started_at"
+    printf 'updated_at=%s\n' "$now"
+    printf 'seq=%s\n' "$seq"
+    printf 'phase=%s\n' "$phase"
+    printf 'last_completed_class=%s\n' "$last_class"
+    printf 'last_completed_status=%s\n' "$last_status"
+    printf 'last_completed_at=%s\n' "$last_at"
+    printf 'in_progress_class=%s\n' "$in_progress"
+    printf 'classes_completed=%s\n' "$classes_completed"
+    printf 'classes_selected=%s\n' "$classes_selected"
+    printf 'suite_state=%s\n' "$suite_state"
+    printf 'check_run_id=%s\n' "$check_run_id"
+  } > "$tmp" || { rm -f "$tmp"; progress_fail_soft "cannot write $tmp"; return 0; }
+
+  local size
+  size="$(wc -c < "$tmp" | tr -d ' ')"
+  if [[ "$size" =~ ^[0-9]+$ ]] && (( size > MAX_BYTES )); then
+    progress_fail_soft "record ${size}B exceeds cap ${MAX_BYTES}B — dropping"
+    rm -f "$tmp"
+    return 0
+  fi
+
+  mv -f "$tmp" "$LOCAL_FILE" || { rm -f "$tmp"; progress_fail_soft "cannot publish $LOCAL_FILE"; return 0; }
+  publish_external "$LOCAL_FILE" "$shard"
+  publish_github_check "$LOCAL_FILE" || true
+}
+
+publish_external() {
+  local file="$1" shard="$2"
+  [[ -n "$EXTERNAL_DIR" ]] || return 0
+  mkdir -p "$EXTERNAL_DIR" || { progress_fail_soft "cannot create external dir $EXTERNAL_DIR"; return 0; }
+  local dest="$EXTERNAL_DIR/$(progress_basename "$shard")"
+  cp -f "$file" "$dest" || progress_fail_soft "cannot copy to $dest"
+}
+
+publish_github_check() {
+  local file="$1"
+  [[ "${CI_JOURNEY_PROGRESS_DISABLE_GITHUB:-0}" == "1" ]] && return 0
+  [[ -n "${GITHUB_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_SHA:-}" ]] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+
+  local api="${GITHUB_API_URL:-https://api.github.com}"
+  local check_id
+  check_id="$(read_field "$file" check_run_id)"
+  local new_id
+  new_id="$(
+    CI_JOURNEY_PROGRESS_FILE="$file" \
+    CI_JOURNEY_PROGRESS_CHECK_ID="$check_id" \
+    CI_JOURNEY_PROGRESS_API="$api" \
+    python3 - <<'PY'
+import json, os, urllib.error, urllib.request
+
+path = os.environ["CI_JOURNEY_PROGRESS_FILE"]
+token = os.environ.get("GITHUB_TOKEN", "")
+repo = os.environ.get("GITHUB_REPOSITORY", "")
+sha = os.environ.get("GITHUB_SHA", "")
+api = os.environ.get("CI_JOURNEY_PROGRESS_API", "https://api.github.com").rstrip("/")
+check_id = os.environ.get("CI_JOURNEY_PROGRESS_CHECK_ID", "").strip()
+fields = {}
+with open(path, encoding="utf-8") as handle:
+    for raw in handle:
+        raw = raw.rstrip("\n")
+        if "=" not in raw:
+            continue
+        key, value = raw.split("=", 1)
+        fields[key] = value
+
+shard = fields.get("shard", "unknown")
+attempt = fields.get("run_attempt", "unknown")
+name = "journey-progress-shard-%s-attempt-%s" % (shard, attempt)
+last_class = fields.get("last_completed_class") or "(none yet)"
+title = "last completed: %s" % last_class
+summary_lines = [
+    "owner=infra (issue #2090) — diagnostic only, not a product verdict",
+    "signature=%s" % fields.get("signature", "hosted_runner_progress"),
+    "phase=%s" % fields.get("phase", ""),
+    "last_completed_class=%s" % fields.get("last_completed_class", ""),
+    "last_completed_status=%s" % fields.get("last_completed_status", ""),
+    "in_progress_class=%s" % fields.get("in_progress_class", ""),
+    "classes_completed=%s" % fields.get("classes_completed", ""),
+    "classes_selected=%s" % fields.get("classes_selected", ""),
+    "suite_state=%s" % fields.get("suite_state", ""),
+    "run_id=%s" % fields.get("run_id", ""),
+    "run_attempt=%s" % fields.get("run_attempt", ""),
+    "job_name=%s" % fields.get("job_name", ""),
+    "job_id=%s" % fields.get("job_id", ""),
+    "runner_name=%s" % fields.get("runner_name", ""),
+    "updated_at=%s" % fields.get("updated_at", ""),
+]
+payload = {
+    "name": name,
+    "head_sha": sha,
+    "status": "in_progress" if fields.get("suite_state") not in (
+        "completed", "artifacts_uploaded"
+    ) else "completed",
+    "output": {
+        "title": title[:255],
+        "summary": "\n".join(summary_lines)[:60000],
+    },
+}
+if payload["status"] == "completed":
+    payload["conclusion"] = "neutral"
+data = json.dumps(payload).encode("utf-8")
+if check_id.isdigit():
+    url = "%s/repos/%s/check-runs/%s" % (api, repo, check_id)
+    method = "PATCH"
+else:
+    url = "%s/repos/%s/check-runs" % (api, repo)
+    method = "POST"
+request = urllib.request.Request(
+    url,
+    data=data,
+    method=method,
+    headers={
+        "Authorization": "Bearer " + token,
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+        "User-Agent": "pocketshell-ci-journey-progress",
+    },
+)
+try:
+    with urllib.request.urlopen(request, timeout=10) as response:
+        body = json.loads(response.read().decode("utf-8"))
+except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+    raise SystemExit(0)
+ident = body.get("id")
+if ident is not None:
+    print(ident)
+PY
+  )" || true
+  if [[ "$new_id" =~ ^[0-9]+$ && "$new_id" != "$check_id" ]]; then
+    local tmp="${LOCAL_FILE}.tmp.$$"
+    if [[ -f "$LOCAL_FILE" ]]; then
+      sed "s/^check_run_id=.*/check_run_id=${new_id}/" "$LOCAL_FILE" > "$tmp" \
+        && mv -f "$tmp" "$LOCAL_FILE" \
+        || rm -f "$tmp"
+      publish_external "$LOCAL_FILE" "$(read_field "$LOCAL_FILE" shard)"
+    fi
+  fi
+}
+
+cmd_start() {
+  CI_JOURNEY_PROGRESS_CLASSES_SELECTED="${CI_JOURNEY_PROGRESS_CLASSES_SELECTED:-0}"
+  write_record started
+}
+
+cmd_class_started() {
+  local fqcn
+  fqcn="$(sanitize_class "${1-}")"
+  [[ -n "$fqcn" ]] || return 0
+  write_record class_started "$fqcn"
+}
+
+cmd_class_completed() {
+  local fqcn status
+  fqcn="$(sanitize_class "${1-}")"
+  status="$(sanitize_status "${2-}")"
+  [[ -n "$fqcn" ]] || return 0
+  write_record class_completed "$fqcn" "$status"
+}
+
+cmd_suite_completed() {
+  local status
+  status="$(sanitize_status "${1:-completed}")"
+  [[ -n "$status" ]] || status="completed"
+  write_record suite_completed "$status"
+}
+
+cmd_artifacts_uploaded() {
+  write_record artifacts_uploaded
+}
+
+# Parse Gradle / instrumentation lines for a completed class. Always exit 0
+# and pass every line through so a caller can sit in a pipeline.
+cmd_observe_stream() {
+  local line class_hint=""
+  local gradle_re='^[[:space:]]*([A-Za-z_][A-Za-z0-9_.]*)[[:space:]]+>[[:space:]]+[^[:space:]]+[[:space:]]+(PASSED|FAILED|SKIPPED)\b'
+  local instr_class_re='INSTRUMENTATION_STATUS:[[:space:]]*class=([A-Za-z_][A-Za-z0-9_.]*)'
+  local instr_code_re='INSTRUMENTATION_STATUS_CODE:[[:space:]]*(-?[0-9]+)'
+  local journey_pass_re='^JOURNEY_PASS:[[:space:]]+([A-Za-z_][A-Za-z0-9_.#]*)'
+  local journey_fail_re='^JOURNEY_FAILED:[[:space:]]+([A-Za-z_][A-Za-z0-9_.#]*)'
+  local journey_recovered_re='^JOURNEY_FLAKE_RECOVERED:[[:space:]]+([A-Za-z_][A-Za-z0-9_.#]*)'
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    printf '%s\n' "$line"
+    if [[ "$line" =~ $gradle_re ]]; then
+      local gclass gstatus
+      gclass="$(sanitize_class "${BASH_REMATCH[1]}")"
+      gstatus="$(sanitize_status "${BASH_REMATCH[2]}")"
+      [[ -n "$gclass" ]] && cmd_class_completed "$gclass" "$gstatus"
+      continue
+    fi
+    if [[ "$line" =~ $instr_class_re ]]; then
+      class_hint="$(sanitize_class "${BASH_REMATCH[1]}")"
+      continue
+    fi
+    if [[ "$line" =~ $instr_code_re && -n "$class_hint" ]]; then
+      local code="${BASH_REMATCH[1]}" status="pass"
+      case "$code" in
+        0) status="pass" ;;
+        -1|1) status="fail" ;;
+        -2) status="error" ;;
+        -3) status="budget_skipped" ;;
+        *) status="unknown" ;;
+      esac
+      cmd_class_completed "$class_hint" "$status"
+      class_hint=""
+      continue
+    fi
+    if [[ "$line" =~ $journey_pass_re ]]; then
+      cmd_class_completed "${BASH_REMATCH[1]}" pass
+      continue
+    fi
+    if [[ "$line" =~ $journey_recovered_re ]]; then
+      cmd_class_completed "${BASH_REMATCH[1]}" flake_recovered
+      continue
+    fi
+    if [[ "$line" =~ $journey_fail_re ]]; then
+      cmd_class_completed "${BASH_REMATCH[1]}" fail
+      continue
+    fi
+  done
+  return 0
+}
+
+# Distinguish provider VM loss / process death / artifact-upload failure from
+# a normal completion. Never a product verdict: owner stays infra.
+cmd_classify() {
+  local file="${1:-$LOCAL_FILE}"
+  if [[ -z "$file" || ! -f "$file" ]]; then
+    if [[ -n "$EXTERNAL_DIR" ]]; then
+      local shard total
+      read -r shard total <<<"$(resolve_shard)"
+      file="$EXTERNAL_DIR/$(progress_basename "$shard")"
+    fi
+  fi
+  local last_class="" phase="" suite_state=""
+  if [[ -f "$file" ]]; then
+    last_class="$(read_field "$file" last_completed_class)"
+    phase="$(read_field "$file" phase)"
+    suite_state="$(read_field "$file" suite_state)"
+  fi
+  local verdict_present="${CI_JOURNEY_PROGRESS_VERDICT_PRESENT:-false}"
+  local later_steps="${CI_JOURNEY_PROGRESS_LATER_STEPS_RAN:-false}"
+  local lost_comm="${CI_JOURNEY_PROGRESS_LOST_COMMUNICATION:-false}"
+  local signature="none"
+  if [[ "$lost_comm" == "true" ]]; then
+    signature="hosted_runner_vm_loss"
+  elif [[ "$suite_state" == "artifacts_uploaded" && "$verdict_present" == "true" ]]; then
+    signature="none"
+  elif [[ "$suite_state" == "completed" || "$phase" == "suite_completed" ]] \
+       && [[ "$verdict_present" != "true" ]]; then
+    signature="hosted_runner_artifact_upload_failure"
+  elif [[ "$later_steps" == "true" && "$verdict_present" != "true" ]]; then
+    signature="hosted_runner_process_death"
+  elif [[ -f "$file" && "$verdict_present" != "true" && "$later_steps" != "true" ]]; then
+    signature="hosted_runner_vm_loss"
+  fi
+  printf 'owner=%s\n' "$OWNER"
+  printf 'signature=%s\n' "$signature"
+  printf 'verdict_role=%s\n' "$VERDICT_ROLE"
+  printf 'last_completed_class=%s\n' "$last_class"
+  printf 'phase=%s\n' "$phase"
+  printf 'suite_state=%s\n' "$suite_state"
+}
+
+cmd_collect_from_github() {
+  local dest="${1:-}"
+  [[ -n "$dest" ]] || { progress_fail_soft "collect-from-github needs DEST_DIR"; return 0; }
+  mkdir -p "$dest" || return 0
+  if [[ -n "$EXTERNAL_DIR" && -d "$EXTERNAL_DIR" ]]; then
+    local src
+    for src in "$EXTERNAL_DIR"/journey-progress-shard-*.txt; do
+      [[ -f "$src" ]] || continue
+      cp -f "$src" "$dest/" || true
+    done
+  fi
+  [[ "${CI_JOURNEY_PROGRESS_DISABLE_GITHUB:-0}" == "1" ]] && return 0
+  [[ -n "${GITHUB_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_SHA:-}" ]] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  CI_JOURNEY_PROGRESS_COLLECT_DIR="$dest" \
+  CI_JOURNEY_PROGRESS_API="${GITHUB_API_URL:-https://api.github.com}" \
+  python3 - <<'PY' || true
+import json, os, urllib.error, urllib.request
+
+dest = os.environ["CI_JOURNEY_PROGRESS_COLLECT_DIR"]
+token = os.environ.get("GITHUB_TOKEN", "")
+repo = os.environ.get("GITHUB_REPOSITORY", "")
+sha = os.environ.get("GITHUB_SHA", "")
+api = os.environ.get("CI_JOURNEY_PROGRESS_API", "https://api.github.com").rstrip("/")
+url = "%s/repos/%s/commits/%s/check-runs?per_page=100" % (api, repo, sha)
+request = urllib.request.Request(
+    url,
+    headers={
+        "Authorization": "Bearer " + token,
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "pocketshell-ci-journey-progress",
+    },
+)
+try:
+    with urllib.request.urlopen(request, timeout=15) as response:
+        body = json.loads(response.read().decode("utf-8"))
+except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+    raise SystemExit(0)
+for run in body.get("check_runs") or []:
+    name = run.get("name") or ""
+    if not name.startswith("journey-progress-shard-"):
+        continue
+    summary = ((run.get("output") or {}).get("summary") or "").strip()
+    if not summary:
+        continue
+    safe = "".join(ch if ch.isalnum() or ch in "-._" else "_" for ch in name)
+    path = os.path.join(dest, safe + ".txt")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(summary)
+        if not summary.endswith("\n"):
+            handle.write("\n")
+PY
+}
+
+cmd_read() {
+  local file="${1:-$LOCAL_FILE}"
+  if [[ ! -f "$file" && -n "$EXTERNAL_DIR" ]]; then
+    local shard total
+    read -r shard total <<<"$(resolve_shard)"
+    file="$EXTERNAL_DIR/$(progress_basename "$shard")"
+  fi
+  [[ -f "$file" ]] || return 0
+  cat "$file"
+}
+
+case "$cmd" in
+  start) cmd_start ;;
+  class-started) cmd_class_started "${1-}" ;;
+  class-completed) cmd_class_completed "${1-}" "${2-}" ;;
+  suite-completed) cmd_suite_completed "${1-}" ;;
+  artifacts-uploaded) cmd_artifacts_uploaded ;;
+  observe-stream) cmd_observe_stream ;;
+  classify) cmd_classify "${1-}" ;;
+  collect-from-github) cmd_collect_from_github "${1-}" ;;
+  read) cmd_read "${1-}" ;;
+  ''|-h|--help|help)
+    echo "usage: ci-journey-progress-telemetry.sh start|class-started|class-completed|suite-completed|artifacts-uploaded|observe-stream|classify|collect-from-github|read" >&2
+    exit 2
+    ;;
+  *)
+    progress_fail_soft "unknown command: $cmd"
+    ;;
+esac
+exit 0

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -358,6 +358,14 @@ source "$CI_JOURNEY_CLASS_SELECTION_HELPER"
 select_effective_journey_classes
 print_journey_class_selection
 
+# Issue #2090: start extra-runner last-completed-class telemetry before the
+# first class so a runner loss mid-shard still names how far this leg got.
+CI_JOURNEY_PROGRESS_HELPER="${CI_JOURNEY_PROGRESS_HELPER:-$REPO_ROOT/scripts/ci-journey-progress-telemetry.sh}"
+if [[ -f "$CI_JOURNEY_PROGRESS_HELPER" ]]; then
+  CI_JOURNEY_PROGRESS_CLASSES_SELECTED="${#EFFECTIVE_JOURNEY_CLASSES[@]}" \
+    bash "$CI_JOURNEY_PROGRESS_HELPER" start || true
+fi
+
 # Issue #691 (S2 defense-in-depth): pass AndroidJUnitRunner's per-test
 # `timeout_msec` so a wedged test is interrupted and FAILS FAST (~5 min) instead
 # of hanging the whole job to the runner cap. A hang is worse than a clean fail

--- a/scripts/ci-journey-summary-functions.sh
+++ b/scripts/ci-journey-summary-functions.sh
@@ -313,5 +313,13 @@ finish_ci_journey_suite() {
   cat "$SUMMARY"
   echo "----------------------------------------------------------"
 
+  # Issue #2090: suite-completed is how classify() tells "process died mid-
+  # class" from "suite finished but the artifact upload never landed".
+  if [[ -n "${CI_JOURNEY_PROGRESS_HELPER:-}" && -f "$CI_JOURNEY_PROGRESS_HELPER" ]]; then
+    bash "$CI_JOURNEY_PROGRESS_HELPER" suite-completed "$journey_status" || true
+  elif [[ -n "${REPO_ROOT:-}" && -f "$REPO_ROOT/scripts/ci-journey-progress-telemetry.sh" ]]; then
+    bash "$REPO_ROOT/scripts/ci-journey-progress-telemetry.sh" suite-completed "$journey_status" || true
+  fi
+
   exit "$JOURNEY_EXIT"
 }

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -439,6 +439,16 @@ if [[ "$SHARDING" == "yes" && "${SHARD_INDEX:-0}" -ne 0 ]]; then
   RUN_AUX_PHASES="no"
 fi
 
+# Choose the observer outside the phase-1 block. select-test-areas.sh slices
+# `/phase 1: journey\/E2E/,/^JOURNEY_EXIT=/` and requires wholesale-minus-notClass
+# with JOURNEY_EXIT= at column 0; indenting the assignment widens the slice into
+# later class= phases and falsely flags phase 1 as an allowlist.
+if [[ -f "$CI_JOURNEY_PROGRESS_HELPER" ]]; then
+  PHASE1_OBSERVER=(bash "$CI_JOURNEY_PROGRESS_HELPER" observe-stream)
+else
+  PHASE1_OBSERVER=(cat)
+fi
+
 echo "=========================================================="
 echo "Nightly Extensive Tests — phase 1: journey/E2E (pocketshellCi=true)"
 echo "Excluded classes: $JOURNEY_NOTCLASS_ARG"
@@ -449,21 +459,12 @@ else
 fi
 echo "=========================================================="
 
-if [[ -f "$CI_JOURNEY_PROGRESS_HELPER" ]]; then
-  "$GRADLEW" :app:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
-    -Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG" \
-    "${JOURNEY_SHARD_ARGS[@]}" \
-    --stacktrace 2>&1 | bash "$CI_JOURNEY_PROGRESS_HELPER" observe-stream
-  JOURNEY_EXIT=${PIPESTATUS[0]}
-else
-  "$GRADLEW" :app:connectedDebugAndroidTest \
-    -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
-    -Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG" \
-    "${JOURNEY_SHARD_ARGS[@]}" \
-    --stacktrace
-  JOURNEY_EXIT=$?
-fi
+"$GRADLEW" :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+  -Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG" \
+  "${JOURNEY_SHARD_ARGS[@]}" \
+  --stacktrace 2>&1 | "${PHASE1_OBSERVER[@]}"
+JOURNEY_EXIT=${PIPESTATUS[0]}
 echo "phase 1 (journey/E2E) exit code: $JOURNEY_EXIT"
 
 # Snapshot phase 1's report BEFORE the phase-2 gradle invocation overwrites it

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -69,6 +69,13 @@ ARTIFACT_DIR="$REPO_ROOT/artifacts/nightly-extensive"
 mkdir -p "$ARTIFACT_DIR"
 SUMMARY="$ARTIFACT_DIR/summary.md"
 
+# Issue #2090: extra-runner last-completed-class heartbeat. Nightly has no
+# per-class bash loop, so phase-1 Gradle output is parsed via observe-stream.
+CI_JOURNEY_PROGRESS_HELPER="${CI_JOURNEY_PROGRESS_HELPER:-$REPO_ROOT/scripts/ci-journey-progress-telemetry.sh}"
+if [[ -f "$CI_JOURNEY_PROGRESS_HELPER" ]]; then
+  bash "$CI_JOURNEY_PROGRESS_HELPER" start || true
+fi
+
 GRADLEW="$REPO_ROOT/gradlew"
 
 # The Toxiproxy-backed proofs. This is primarily the NetworkFaultProofBase
@@ -442,12 +449,21 @@ else
 fi
 echo "=========================================================="
 
-"$GRADLEW" :app:connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
-  -Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG" \
-  "${JOURNEY_SHARD_ARGS[@]}" \
-  --stacktrace
-JOURNEY_EXIT=$?
+if [[ -f "$CI_JOURNEY_PROGRESS_HELPER" ]]; then
+  "$GRADLEW" :app:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+    -Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG" \
+    "${JOURNEY_SHARD_ARGS[@]}" \
+    --stacktrace 2>&1 | bash "$CI_JOURNEY_PROGRESS_HELPER" observe-stream
+  JOURNEY_EXIT=${PIPESTATUS[0]}
+else
+  "$GRADLEW" :app:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.pocketshellCi=true \
+    -Pandroid.testInstrumentationRunnerArguments.notClass="$JOURNEY_NOTCLASS_ARG" \
+    "${JOURNEY_SHARD_ARGS[@]}" \
+    --stacktrace
+  JOURNEY_EXIT=$?
+fi
 echo "phase 1 (journey/E2E) exit code: $JOURNEY_EXIT"
 
 # Snapshot phase 1's report BEFORE the phase-2 gradle invocation overwrites it
@@ -815,6 +831,10 @@ fi
 echo "----------------------------------------------------------"
 cat "$SUMMARY"
 echo "----------------------------------------------------------"
+
+if [[ -f "${CI_JOURNEY_PROGRESS_HELPER:-}" ]]; then
+  bash "$CI_JOURNEY_PROGRESS_HELPER" suite-completed "$overall_status" || true
+fi
 
 if [[ "$overall_status" == "FAIL" ]]; then
   exit 1

--- a/scripts/test-ci-journey-progress-telemetry.sh
+++ b/scripts/test-ci-journey-progress-telemetry.sh
@@ -20,12 +20,13 @@ SUITE="$SCRIPT_DIR/ci-journey-suite.sh"
 CLASS_LOOP="$SCRIPT_DIR/ci-journey-class-loop-functions.sh"
 NIGHTLY_SUITE="$SCRIPT_DIR/nightly-extensive-suite.sh"
 SUMMARY_FN="$SCRIPT_DIR/ci-journey-summary-functions.sh"
+SHARD_COUNT="$SCRIPT_DIR/ci-journey-shard-count.sh"
 
 fail() { echo "TEST FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
 for required in "$PROGRESS" "$AGG" "$WRITER" "$WORKFLOW" "$SUITE" "$CLASS_LOOP" \
-                "$NIGHTLY_SUITE" "$SUMMARY_FN"; do
+                "$NIGHTLY_SUITE" "$SUMMARY_FN" "$SHARD_COUNT"; do
   [[ -f "$required" ]] || fail "missing required file: $required"
 done
 chmod +x "$PROGRESS" "$AGG" "$WRITER"
@@ -36,6 +37,15 @@ trap 'rm -rf "$SANDBOX"' EXIT
 CLASS_A="com.pocketshell.app.proof.DeepLinkSessionSwitchE2eTest"
 CLASS_B="com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest"
 CLASS_C="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
+
+# Issue #2060: derive the shipped matrix length. Hardcoded EXPECTED_SHARDS=3 /
+# POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=6 / `for idx in 0 1 2` are the exact
+# shapes the downward-only ratchet refuses to absorb as a new file.
+SHARD_TOTAL="$(bash "$SHARD_COUNT" "$WORKFLOW")" \
+  || fail "could not derive the emulator-journey shard count from the matrix"
+(( SHARD_TOTAL >= 2 )) \
+  || fail "matrix must have at least 2 shards so a missing-shard case exists"
+LAST_SHARD="$((SHARD_TOTAL - 1))"
 
 # ---------------------------------------------------------------------------
 # AC1 RED: local-only publisher (the pre-#2090 shape) loses last-completed-class
@@ -73,13 +83,13 @@ chmod +x "$local_only"
   export CI_JOURNEY_PROGRESS_EXTERNAL_DIR=""
   export CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1
   export GITHUB_RUN_ID=2038 GITHUB_RUN_ATTEMPT=1 GITHUB_JOB=extensive
-  export POCKETSHELL_NIGHTLY_SHARD_INDEX=2 POCKETSHELL_NIGHTLY_SHARD_TOTAL=3
+  export POCKETSHELL_NIGHTLY_SHARD_INDEX="$LAST_SHARD" POCKETSHELL_NIGHTLY_SHARD_TOTAL="$SHARD_TOTAL"
   bash "$local_only" start
   bash "$local_only" class-completed "$CLASS_A" pass
   bash "$local_only" class-completed "$CLASS_B" pass
 )
 rm -rf "$runner_dead"
-if [[ -e "$external_dead/journey-progress-shard-2-attempt-1-run-2038.txt" ]] \
+if [[ -e "$external_dead/journey-progress-shard-${LAST_SHARD}-attempt-1-run-2038.txt" ]] \
    || grep -Rqs "$CLASS_B" "$external_dead" 2>/dev/null; then
   fail "AC1 RED control was vacuous: the local-only mutant still left extra-runner evidence"
 fi
@@ -108,8 +118,8 @@ progress_env=(
   GITHUB_SHA=e08c336bdeadbeef
   RUNNER_NAME=GitHubActions-hosted
   RUNNER_OS=Linux
-  POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2
-  POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=6
+  POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$LAST_SHARD"
+  POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$SHARD_TOTAL"
   CI_JOURNEY_PROGRESS_CLASSES_SELECTED=3
 )
 
@@ -151,7 +161,7 @@ grep -qx "job_id=92770537075" "$surviving" \
   || fail "AC1 GREEN: surviving record missing job_id"
 grep -qx "runner_name=GitHubActions-hosted" "$surviving" \
   || fail "AC1 GREEN: surviving record missing runner_name"
-grep -qx "shard=2" "$surviving" \
+grep -qx "shard=$LAST_SHARD" "$surviving" \
   || fail "AC1 GREEN: surviving record missing shard"
 [[ ! -e "$runner_live" ]] \
   || fail "AC1 GREEN: runner workspace was not wiped"
@@ -218,19 +228,19 @@ pass "artifact-upload failure -> hosted_runner_artifact_upload_failure (infra di
 echo "== #2090 AC2: missing shard stays fail-closed / not green =="
 
 verdict_dir="$SANDBOX/verdicts-missing"
-mkdir -p "$verdict_dir/emulator-journey-verdict-shard-0" \
-         "$verdict_dir/emulator-journey-verdict-shard-1"
-GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1 POCKETSHELL_JOURNEY_CI_SHARD_INDEX=0 \
-  SHARD_VERDICT_FILE="$verdict_dir/emulator-journey-verdict-shard-0/shard-verdict.txt" \
-  bash "$WRITER" CLEAN journey_ok >/dev/null
-GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1 POCKETSHELL_JOURNEY_CI_SHARD_INDEX=1 \
-  SHARD_VERDICT_FILE="$verdict_dir/emulator-journey-verdict-shard-1/shard-verdict.txt" \
-  bash "$WRITER" CLEAN journey_ok >/dev/null
-# shard 2 missing — only extra-runner progress survived.
+mkdir -p "$verdict_dir"
+for (( idx = 0; idx < SHARD_TOTAL; idx++ )); do
+  (( idx == LAST_SHARD )) && continue
+  mkdir -p "$verdict_dir/emulator-journey-verdict-shard-$idx"
+  GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1 POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+    SHARD_VERDICT_FILE="$verdict_dir/emulator-journey-verdict-shard-$idx/shard-verdict.txt" \
+    bash "$WRITER" CLEAN journey_ok >/dev/null
+done
+# last shard missing — only extra-runner progress survived.
 
 set +e
 AGG_OUT="$(
-  EXPECTED_SHARDS=3 \
+  EXPECTED_SHARDS="$SHARD_TOTAL" \
   GITHUB_STEP_SUMMARY="" \
   GITHUB_RUN_ATTEMPT=1 \
   CI_JOURNEY_PROGRESS_DIR="$external_live" \
@@ -274,7 +284,7 @@ PY
 chmod +x "$agg_mutant"
 set +e
 MUT_OUT="$(
-  EXPECTED_SHARDS=3 \
+  EXPECTED_SHARDS="$SHARD_TOTAL" \
   GITHUB_STEP_SUMMARY="" \
   GITHUB_RUN_ATTEMPT=1 \
   CI_JOURNEY_PROGRESS_DIR="$external_live" \
@@ -299,19 +309,17 @@ echo "== #2090 AC3: successful shard keeps the existing contract =="
 success_runner="$SANDBOX/success-runner"
 success_external="$SANDBOX/success-external"
 success_verdicts="$SANDBOX/success-verdicts"
-mkdir -p "$success_runner" "$success_external" \
-  "$success_verdicts/emulator-journey-verdict-shard-0" \
-  "$success_verdicts/emulator-journey-verdict-shard-1" \
-  "$success_verdicts/emulator-journey-verdict-shard-2"
+mkdir -p "$success_runner" "$success_external" "$success_verdicts"
 
-for idx in 0 1 2; do
+for (( idx = 0; idx < SHARD_TOTAL; idx++ )); do
+  mkdir -p "$success_verdicts/emulator-journey-verdict-shard-$idx"
   GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1 POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
     SHARD_VERDICT_FILE="$success_verdicts/emulator-journey-verdict-shard-$idx/shard-verdict.txt" \
     bash "$WRITER" CLEAN journey_ok >/dev/null
 done
 
 # Pin the pre-#2090 verdict contract: line 1 is the bare token, then key=value.
-success_token="$success_verdicts/emulator-journey-verdict-shard-2/shard-verdict.txt"
+success_token="$success_verdicts/emulator-journey-verdict-shard-$LAST_SHARD/shard-verdict.txt"
 first_line="$(awk 'NR==1 { print; exit }' "$success_token")"
 [[ "$first_line" == "CLEAN" ]] \
   || fail "AC3: successful shard verdict line 1 must stay the bare CLEAN token"
@@ -327,8 +335,8 @@ grep -q '^run_id=' "$success_token" \
   export CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1
   export GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1
   export GITHUB_JOB=emulator-journey
-  export POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2
-  export POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=6
+  export POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$LAST_SHARD"
+  export POCKETSHELL_JOURNEY_CI_SHARD_TOTAL="$SHARD_TOTAL"
   export CI_JOURNEY_PROGRESS_CLASSES_SELECTED=3
   bash "$PROGRESS" start
   bash "$PROGRESS" class-completed "$CLASS_A" pass
@@ -338,7 +346,7 @@ grep -q '^run_id=' "$success_token" \
   bash "$PROGRESS" artifacts-uploaded
 )
 
-success_progress="$(find "$success_external" -type f -name 'journey-progress-shard-2-*.txt' | head -n 1)"
+success_progress="$(find "$success_external" -type f -name "journey-progress-shard-${LAST_SHARD}-*.txt" | head -n 1)"
 [[ -f "$success_progress" ]] || fail "AC3: successful shard wrote no bounded telemetry"
 progress_bytes="$(wc -c < "$success_progress" | tr -d ' ')"
 (( progress_bytes <= 4096 )) \
@@ -359,7 +367,7 @@ grep -qx "suite_state=artifacts_uploaded" "$success_progress" \
 
 set +e
 SUCCESS_OUT="$(
-  EXPECTED_SHARDS=3 \
+  EXPECTED_SHARDS="$SHARD_TOTAL" \
   GITHUB_STEP_SUMMARY="" \
   GITHUB_RUN_ATTEMPT=1 \
   CI_JOURNEY_PROGRESS_DIR="$success_external" \
@@ -397,9 +405,9 @@ obs_file="$SANDBOX/observe-local.txt"
     CI_JOURNEY_PROGRESS_EXTERNAL_DIR="$obs_external" \
     CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1 \
     GITHUB_RUN_ID=obs GITHUB_RUN_ATTEMPT=1 \
-    POCKETSHELL_NIGHTLY_SHARD_INDEX=2 POCKETSHELL_NIGHTLY_SHARD_TOTAL=3 \
+    POCKETSHELL_NIGHTLY_SHARD_INDEX="$LAST_SHARD" POCKETSHELL_NIGHTLY_SHARD_TOTAL="$SHARD_TOTAL" \
     bash "$PROGRESS" observe-stream >/dev/null
-obs_surviving="$(find "$obs_external" -type f -name 'journey-progress-shard-2-*.txt' | head -n 1)"
+obs_surviving="$(find "$obs_external" -type f -name "journey-progress-shard-${LAST_SHARD}-*.txt" | head -n 1)"
 [[ -f "$obs_surviving" ]] || fail "observe-stream wrote no extra-runner record"
 grep -qx "last_completed_class=com.pocketshell.app.proof.BarTest" "$obs_surviving" \
   || { cat "$obs_surviving"; fail "observe-stream must keep the last completed class"; }

--- a/scripts/test-ci-journey-progress-telemetry.sh
+++ b/scripts/test-ci-journey-progress-telemetry.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+# Issue #2090: JVM-free, emulator-free proof that last-completed-class + job
+# metadata survive a hosted journey-shard runner disappearing, that a missing
+# shard never aggregates CLEAN, and that a successful shard keeps its existing
+# verdict/artifact contract while adding only bounded telemetry.
+#
+# Reproduce-first (D32): a publisher that writes ONLY on the runner filesystem
+# leaves no last-completed-class after a simulated runner death. That is the
+# #2038 hole. The real publisher must keep the record in an extra-runner store.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+PROGRESS="$SCRIPT_DIR/ci-journey-progress-telemetry.sh"
+AGG="$SCRIPT_DIR/ci-journey-aggregate-verdict.sh"
+WRITER="$SCRIPT_DIR/ci-journey-write-shard-verdict.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/tests.yml"
+NIGHTLY="$REPO_ROOT/.github/workflows/nightly-extensive.yml"
+SUITE="$SCRIPT_DIR/ci-journey-suite.sh"
+CLASS_LOOP="$SCRIPT_DIR/ci-journey-class-loop-functions.sh"
+NIGHTLY_SUITE="$SCRIPT_DIR/nightly-extensive-suite.sh"
+SUMMARY_FN="$SCRIPT_DIR/ci-journey-summary-functions.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+for required in "$PROGRESS" "$AGG" "$WRITER" "$WORKFLOW" "$SUITE" "$CLASS_LOOP" \
+                "$NIGHTLY_SUITE" "$SUMMARY_FN"; do
+  [[ -f "$required" ]] || fail "missing required file: $required"
+done
+chmod +x "$PROGRESS" "$AGG" "$WRITER"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+CLASS_A="com.pocketshell.app.proof.DeepLinkSessionSwitchE2eTest"
+CLASS_B="com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest"
+CLASS_C="com.pocketshell.app.composer.PromptComposerSaturatedImeAnchorE2eTest"
+
+# ---------------------------------------------------------------------------
+# AC1 RED: local-only publisher (the pre-#2090 shape) loses last-completed-class
+# after a simulated runner death. This is the reproduction; it must stay RED.
+# ---------------------------------------------------------------------------
+echo "== #2090 AC1 reproduction: local-only publisher loses evidence =="
+
+runner_dead="$SANDBOX/runner-local-only"
+external_dead="$SANDBOX/external-local-only"
+mkdir -p "$runner_dead" "$external_dead"
+local_only="$runner_dead/local-only-publisher.sh"
+cat > "$local_only" <<'LOCAL'
+#!/usr/bin/env bash
+# Mutant: writes the progress record only on the runner filesystem.
+set -uo pipefail
+cmd="${1:-}"; shift || true
+file="${CI_JOURNEY_PROGRESS_FILE:-$PWD/progress.txt}"
+mkdir -p "$(dirname "$file")"
+case "$cmd" in
+  start)
+    printf 'schema=pocketshell.journey.progress.v1\nowner=infra\nphase=started\nlast_completed_class=\nseq=0\n' > "$file"
+    ;;
+  class-completed)
+    printf 'schema=pocketshell.journey.progress.v1\nowner=infra\nphase=class_completed\nlast_completed_class=%s\nlast_completed_status=%s\nseq=2\nrun_id=%s\njob_name=%s\n' \
+      "${1-}" "${2-}" "${GITHUB_RUN_ID:-unknown}" "${GITHUB_JOB:-unknown}" > "$file"
+    ;;
+esac
+exit 0
+LOCAL
+chmod +x "$local_only"
+
+(
+  cd "$runner_dead" || exit 1
+  export CI_JOURNEY_PROGRESS_FILE="$runner_dead/artifacts/ci-journey-progress/progress.txt"
+  export CI_JOURNEY_PROGRESS_EXTERNAL_DIR=""
+  export CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1
+  export GITHUB_RUN_ID=2038 GITHUB_RUN_ATTEMPT=1 GITHUB_JOB=extensive
+  export POCKETSHELL_NIGHTLY_SHARD_INDEX=2 POCKETSHELL_NIGHTLY_SHARD_TOTAL=3
+  bash "$local_only" start
+  bash "$local_only" class-completed "$CLASS_A" pass
+  bash "$local_only" class-completed "$CLASS_B" pass
+)
+rm -rf "$runner_dead"
+if [[ -e "$external_dead/journey-progress-shard-2-attempt-1-run-2038.txt" ]] \
+   || grep -Rqs "$CLASS_B" "$external_dead" 2>/dev/null; then
+  fail "AC1 RED control was vacuous: the local-only mutant still left extra-runner evidence"
+fi
+if [[ -e "$runner_dead" ]]; then
+  fail "AC1 RED control: simulated runner death did not wipe the runner workspace"
+fi
+pass "RED: local-only publisher leaves no last-completed-class after runner death"
+
+# ---------------------------------------------------------------------------
+# AC1 GREEN: the real publisher keeps last-completed-class + job metadata in
+# the extra-runner store after the same wipe.
+# ---------------------------------------------------------------------------
+echo "== #2090 AC1 green: extra-runner store survives runner death =="
+
+runner_live="$SANDBOX/runner-real"
+external_live="$SANDBOX/external-real"
+mkdir -p "$runner_live" "$external_live"
+
+progress_env=(
+  CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1
+  GITHUB_RUN_ID=2090
+  GITHUB_RUN_ATTEMPT=1
+  GITHUB_JOB=emulator-journey
+  GITHUB_JOB_ID=92770537075
+  GITHUB_WORKFLOW=Tests
+  GITHUB_SHA=e08c336bdeadbeef
+  RUNNER_NAME=GitHubActions-hosted
+  RUNNER_OS=Linux
+  POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2
+  POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=6
+  CI_JOURNEY_PROGRESS_CLASSES_SELECTED=3
+)
+
+(
+  cd "$runner_live" || exit 1
+  export CI_JOURNEY_PROGRESS_FILE="$runner_live/artifacts/ci-journey-progress/progress.txt"
+  export CI_JOURNEY_PROGRESS_EXTERNAL_DIR="$external_live"
+  export "${progress_env[@]}"
+  bash "$PROGRESS" start
+  bash "$PROGRESS" class-started "$CLASS_A"
+  bash "$PROGRESS" class-completed "$CLASS_A" pass
+  bash "$PROGRESS" class-started "$CLASS_B"
+  bash "$PROGRESS" class-completed "$CLASS_B" pass
+  bash "$PROGRESS" class-started "$CLASS_C"
+  # Abrupt loss mid-class C: no suite-completed, no artifacts-uploaded.
+)
+# Simulated hosted-runner disappearance: workspace gone, later if:always()
+# steps never ran, no verdict artifact uploaded.
+rm -rf "$runner_live"
+
+surviving="$(find "$external_live" -type f -name 'journey-progress-shard-*.txt' | head -n 1)"
+[[ -n "$surviving" && -f "$surviving" ]] \
+  || fail "AC1 GREEN: extra-runner store has no progress record after runner death"
+grep -qx "last_completed_class=$CLASS_B" "$surviving" \
+  || { cat "$surviving"; fail "AC1 GREEN: surviving record is missing last_completed_class=$CLASS_B"; }
+grep -qx "in_progress_class=$CLASS_C" "$surviving" \
+  || { cat "$surviving"; fail "AC1 GREEN: surviving record is missing in_progress_class=$CLASS_C"; }
+grep -qx "owner=infra" "$surviving" \
+  || fail "AC1 GREEN: surviving record must be owned by infra, not a product verdict"
+grep -qx "verdict_role=diagnostic" "$surviving" \
+  || fail "AC1 GREEN: surviving record must be diagnostic, not a product verdict"
+grep -qx "run_id=2090" "$surviving" \
+  || fail "AC1 GREEN: surviving record missing run_id job metadata"
+grep -qx "run_attempt=1" "$surviving" \
+  || fail "AC1 GREEN: surviving record missing run_attempt"
+grep -qx "job_name=emulator-journey" "$surviving" \
+  || fail "AC1 GREEN: surviving record missing job_name"
+grep -qx "job_id=92770537075" "$surviving" \
+  || fail "AC1 GREEN: surviving record missing job_id"
+grep -qx "runner_name=GitHubActions-hosted" "$surviving" \
+  || fail "AC1 GREEN: surviving record missing runner_name"
+grep -qx "shard=2" "$surviving" \
+  || fail "AC1 GREEN: surviving record missing shard"
+[[ ! -e "$runner_live" ]] \
+  || fail "AC1 GREEN: runner workspace was not wiped"
+pass "GREEN: last-completed-class + job metadata survive runner death"
+
+# Classify the three loss modes from the surviving record + job hints.
+echo "== #2090 loss-mode signatures stay infra =="
+
+classify_out="$(
+  CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1 \
+  CI_JOURNEY_PROGRESS_VERDICT_PRESENT=false \
+  CI_JOURNEY_PROGRESS_LATER_STEPS_RAN=false \
+  CI_JOURNEY_PROGRESS_LOST_COMMUNICATION=true \
+  bash "$PROGRESS" classify "$surviving"
+)"
+grep -qx "signature=hosted_runner_vm_loss" <<<"$classify_out" \
+  || { printf '%s\n' "$classify_out"; fail "lost-communication must classify as hosted_runner_vm_loss"; }
+grep -qx "owner=infra" <<<"$classify_out" \
+  || fail "vm-loss signature must stay owner=infra"
+grep -qx "verdict_role=diagnostic" <<<"$classify_out" \
+  || fail "vm-loss signature must stay diagnostic"
+grep -qx "last_completed_class=$CLASS_B" <<<"$classify_out" \
+  || fail "vm-loss classification must carry last_completed_class"
+pass "provider VM loss -> hosted_runner_vm_loss (infra diagnostic)"
+
+classify_out="$(
+  CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1 \
+  CI_JOURNEY_PROGRESS_VERDICT_PRESENT=false \
+  CI_JOURNEY_PROGRESS_LATER_STEPS_RAN=true \
+  CI_JOURNEY_PROGRESS_LOST_COMMUNICATION=false \
+  bash "$PROGRESS" classify "$surviving"
+)"
+grep -qx "signature=hosted_runner_process_death" <<<"$classify_out" \
+  || { printf '%s\n' "$classify_out"; fail "later-steps-without-verdict must classify as hosted_runner_process_death"; }
+grep -qx "owner=infra" <<<"$classify_out" \
+  || fail "process-death signature must stay owner=infra"
+pass "process death -> hosted_runner_process_death (infra diagnostic)"
+
+upload_fail_record="$SANDBOX/upload-fail.progress.txt"
+cp "$surviving" "$upload_fail_record"
+# Suite finished and wrote a local verdict, but the upload step failed.
+{
+  grep -vE '^(phase|suite_state)=' "$surviving"
+  echo "phase=suite_completed"
+  echo "suite_state=completed"
+} > "$upload_fail_record"
+classify_out="$(
+  CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1 \
+  CI_JOURNEY_PROGRESS_VERDICT_PRESENT=false \
+  CI_JOURNEY_PROGRESS_LATER_STEPS_RAN=true \
+  CI_JOURNEY_PROGRESS_LOST_COMMUNICATION=false \
+  bash "$PROGRESS" classify "$upload_fail_record"
+)"
+grep -qx "signature=hosted_runner_artifact_upload_failure" <<<"$classify_out" \
+  || { printf '%s\n' "$classify_out"; fail "completed-suite without uploaded verdict must classify as artifact-upload failure"; }
+grep -qx "owner=infra" <<<"$classify_out" \
+  || fail "upload-failure signature must stay owner=infra"
+pass "artifact-upload failure -> hosted_runner_artifact_upload_failure (infra diagnostic)"
+
+# ---------------------------------------------------------------------------
+# AC2: missing shard is never CLEAN. Drive the REAL aggregator. Progress is
+# diagnostic INFRA, not a product RED/CLEAN flip.
+# ---------------------------------------------------------------------------
+echo "== #2090 AC2: missing shard stays fail-closed / not green =="
+
+verdict_dir="$SANDBOX/verdicts-missing"
+mkdir -p "$verdict_dir/emulator-journey-verdict-shard-0" \
+         "$verdict_dir/emulator-journey-verdict-shard-1"
+GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1 POCKETSHELL_JOURNEY_CI_SHARD_INDEX=0 \
+  SHARD_VERDICT_FILE="$verdict_dir/emulator-journey-verdict-shard-0/shard-verdict.txt" \
+  bash "$WRITER" CLEAN journey_ok >/dev/null
+GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1 POCKETSHELL_JOURNEY_CI_SHARD_INDEX=1 \
+  SHARD_VERDICT_FILE="$verdict_dir/emulator-journey-verdict-shard-1/shard-verdict.txt" \
+  bash "$WRITER" CLEAN journey_ok >/dev/null
+# shard 2 missing — only extra-runner progress survived.
+
+set +e
+AGG_OUT="$(
+  EXPECTED_SHARDS=3 \
+  GITHUB_STEP_SUMMARY="" \
+  GITHUB_RUN_ATTEMPT=1 \
+  CI_JOURNEY_PROGRESS_DIR="$external_live" \
+  bash "$AGG" "$verdict_dir" 2>&1
+)"
+AGG_RC=$?
+set -e
+AGG_VERDICT="$(sed -n 's/^AGGREGATE_VERDICT=//p' <<<"$AGG_OUT" | tail -n 1)"
+[[ "$AGG_VERDICT" != "CLEAN" ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "AC2: a missing shard must not aggregate CLEAN"; }
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "AC2: missing shard expected existing RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+grep -q "$CLASS_B" <<<"$AGG_OUT" \
+  || { printf '%s\n' "$AGG_OUT"; fail "AC2: aggregate must name the surviving last-completed-class"; }
+grep -qi 'infra' <<<"$AGG_OUT" \
+  || { printf '%s\n' "$AGG_OUT"; fail "AC2: last-completed-class note must be linked to infra, not a product verdict"; }
+grep -q '::error' <<<"$AGG_OUT" \
+  && fail "AC2: missing-shard + progress must not become product RED"
+pass "missing shard stays not-CLEAN; last-completed-class is infra diagnostic"
+
+# Mutation: an aggregator that reports CLEAN when a shard is missing must go
+# RED here. That is the G6 check for AC2.
+agg_mutant="$SANDBOX/agg-clean-on-missing.sh"
+python3 - "$AGG" "$agg_mutant" <<'PY'
+import pathlib, sys
+src = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+old = '''if (( have_infra > 0 || missing > 0 )); then
+  echo "::warning title=Emulator journey verdict — RE-RUN (environmental)::No genuine journey failure, but ${have_infra} shard(s) hit an environmental infra abort (#470 cancel / #771 never-booted / retry budget denied) and ${missing} shard(s) did not report. This is a re-run signal, NOT a product regression — the run stays green so main-health is readable and no false red-CI email fires. Re-run the emulator-journey job."
+  emit_summary "RE-RUN" "${have_infra} infra shard(s) + ${missing} missing shard(s), no genuine failure — re-run"
+  echo "AGGREGATE_VERDICT=RE-RUN"
+  exit 0
+fi'''
+new = '''if (( have_infra > 0 || missing > 0 )); then
+  echo "AGGREGATE_VERDICT=CLEAN"
+  exit 0
+fi'''
+if old not in src:
+    raise SystemExit("could not locate the missing-shard RE-RUN branch to mutate")
+pathlib.Path(sys.argv[2]).write_text(src.replace(old, new, 1), encoding="utf-8")
+PY
+chmod +x "$agg_mutant"
+set +e
+MUT_OUT="$(
+  EXPECTED_SHARDS=3 \
+  GITHUB_STEP_SUMMARY="" \
+  GITHUB_RUN_ATTEMPT=1 \
+  CI_JOURNEY_PROGRESS_DIR="$external_live" \
+  bash "$agg_mutant" "$verdict_dir" 2>&1
+)"
+set -e
+MUT_VERDICT="$(sed -n 's/^AGGREGATE_VERDICT=//p' <<<"$MUT_OUT" | tail -n 1)"
+[[ "$MUT_VERDICT" == "CLEAN" ]] \
+  || { printf '%s\n' "$MUT_OUT"; fail "AC2 mutant did not report CLEAN — the mutation is not exercising the missing-shard branch"; }
+# The production assertion above already rejected CLEAN. Confirm selectivity:
+# the mutant is the only thing that went green.
+[[ "$AGG_VERDICT" != "CLEAN" && "$MUT_VERDICT" == "CLEAN" ]] \
+  || fail "AC2 mutant was not selective"
+pass "mutation: CLEAN-on-missing reddens AC2 (G6)"
+
+# ---------------------------------------------------------------------------
+# AC3: a normal successful shard adds only bounded telemetry and keeps the
+# existing verdict/artifact contract.
+# ---------------------------------------------------------------------------
+echo "== #2090 AC3: successful shard keeps the existing contract =="
+
+success_runner="$SANDBOX/success-runner"
+success_external="$SANDBOX/success-external"
+success_verdicts="$SANDBOX/success-verdicts"
+mkdir -p "$success_runner" "$success_external" \
+  "$success_verdicts/emulator-journey-verdict-shard-0" \
+  "$success_verdicts/emulator-journey-verdict-shard-1" \
+  "$success_verdicts/emulator-journey-verdict-shard-2"
+
+for idx in 0 1 2; do
+  GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1 POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+    SHARD_VERDICT_FILE="$success_verdicts/emulator-journey-verdict-shard-$idx/shard-verdict.txt" \
+    bash "$WRITER" CLEAN journey_ok >/dev/null
+done
+
+# Pin the pre-#2090 verdict contract: line 1 is the bare token, then key=value.
+success_token="$success_verdicts/emulator-journey-verdict-shard-2/shard-verdict.txt"
+first_line="$(awk 'NR==1 { print; exit }' "$success_token")"
+[[ "$first_line" == "CLEAN" ]] \
+  || fail "AC3: successful shard verdict line 1 must stay the bare CLEAN token"
+grep -q '^shard=' "$success_token" \
+  || fail "AC3: successful shard verdict must keep #1809 provenance"
+grep -q '^run_id=' "$success_token" \
+  || fail "AC3: successful shard verdict must keep run_id"
+
+(
+  cd "$success_runner" || exit 1
+  export CI_JOURNEY_PROGRESS_FILE="$success_runner/artifacts/ci-journey-progress/progress.txt"
+  export CI_JOURNEY_PROGRESS_EXTERNAL_DIR="$success_external"
+  export CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1
+  export GITHUB_RUN_ID=2090 GITHUB_RUN_ATTEMPT=1
+  export GITHUB_JOB=emulator-journey
+  export POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2
+  export POCKETSHELL_JOURNEY_CI_SHARD_TOTAL=6
+  export CI_JOURNEY_PROGRESS_CLASSES_SELECTED=3
+  bash "$PROGRESS" start
+  bash "$PROGRESS" class-completed "$CLASS_A" pass
+  bash "$PROGRESS" class-completed "$CLASS_B" pass
+  bash "$PROGRESS" class-completed "$CLASS_C" pass
+  bash "$PROGRESS" suite-completed completed
+  bash "$PROGRESS" artifacts-uploaded
+)
+
+success_progress="$(find "$success_external" -type f -name 'journey-progress-shard-2-*.txt' | head -n 1)"
+[[ -f "$success_progress" ]] || fail "AC3: successful shard wrote no bounded telemetry"
+progress_bytes="$(wc -c < "$success_progress" | tr -d ' ')"
+(( progress_bytes <= 4096 )) \
+  || fail "AC3: telemetry is not bounded (${progress_bytes}B > 4096)"
+# Last class only — a full class dump would be the unbounded shape.
+grep -qx "last_completed_class=$CLASS_C" "$success_progress" \
+  || fail "AC3: successful telemetry must keep the LAST completed class"
+class_lines="$(grep -c 'com.pocketshell.app' "$success_progress" || true)"
+(( class_lines <= 2 )) \
+  || fail "AC3: telemetry must not retain a full class list (found $class_lines class lines)"
+grep -qx "suite_state=artifacts_uploaded" "$success_progress" \
+  || fail "AC3: successful shard should mark artifacts-uploaded"
+# Local snapshot is a sibling of ci-journey/, never inside it (#1781).
+[[ -f "$success_runner/artifacts/ci-journey-progress/progress.txt" ]] \
+  || fail "AC3: local snapshot should live under artifacts/ci-journey-progress/"
+[[ ! -e "$success_runner/artifacts/ci-journey/progress.txt" ]] \
+  || fail "AC3: telemetry must not land inside artifacts/ci-journey/"
+
+set +e
+SUCCESS_OUT="$(
+  EXPECTED_SHARDS=3 \
+  GITHUB_STEP_SUMMARY="" \
+  GITHUB_RUN_ATTEMPT=1 \
+  CI_JOURNEY_PROGRESS_DIR="$success_external" \
+  bash "$AGG" "$success_verdicts" 2>&1
+)"
+SUCCESS_RC=$?
+set -e
+SUCCESS_VERDICT="$(sed -n 's/^AGGREGATE_VERDICT=//p' <<<"$SUCCESS_OUT" | tail -n 1)"
+[[ "$SUCCESS_VERDICT" == "CLEAN" && "$SUCCESS_RC" -eq 0 ]] \
+  || { printf '%s\n' "$SUCCESS_OUT"; fail "AC3: all-CLEAN shards plus telemetry must stay CLEAN, got $SUCCESS_VERDICT/exit$SUCCESS_RC"; }
+pass "successful shards stay CLEAN with bounded sibling telemetry"
+
+classify_out="$(
+  CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1 \
+  CI_JOURNEY_PROGRESS_VERDICT_PRESENT=true \
+  CI_JOURNEY_PROGRESS_LATER_STEPS_RAN=true \
+  CI_JOURNEY_PROGRESS_LOST_COMMUNICATION=false \
+  bash "$PROGRESS" classify "$success_progress"
+)"
+grep -qx "signature=none" <<<"$classify_out" \
+  || { printf '%s\n' "$classify_out"; fail "AC3: a completed uploaded shard must not carry a runner-loss signature"; }
+pass "successful shard classify() is signature=none"
+
+# observe-stream must record last-completed-class from Gradle/instrumentation
+# lines (the nightly path has no per-class bash loop).
+echo "== #2090 nightly observe-stream =="
+obs_external="$SANDBOX/observe-external"
+mkdir -p "$obs_external"
+obs_file="$SANDBOX/observe-local.txt"
+{
+  echo "com.pocketshell.app.proof.FooTest > foo PASSED"
+  echo "INSTRUMENTATION_STATUS: class=com.pocketshell.app.proof.BarTest"
+  echo "INSTRUMENTATION_STATUS_CODE: 0"
+} | CI_JOURNEY_PROGRESS_FILE="$obs_file" \
+    CI_JOURNEY_PROGRESS_EXTERNAL_DIR="$obs_external" \
+    CI_JOURNEY_PROGRESS_DISABLE_GITHUB=1 \
+    GITHUB_RUN_ID=obs GITHUB_RUN_ATTEMPT=1 \
+    POCKETSHELL_NIGHTLY_SHARD_INDEX=2 POCKETSHELL_NIGHTLY_SHARD_TOTAL=3 \
+    bash "$PROGRESS" observe-stream >/dev/null
+obs_surviving="$(find "$obs_external" -type f -name 'journey-progress-shard-2-*.txt' | head -n 1)"
+[[ -f "$obs_surviving" ]] || fail "observe-stream wrote no extra-runner record"
+grep -qx "last_completed_class=com.pocketshell.app.proof.BarTest" "$obs_surviving" \
+  || { cat "$obs_surviving"; fail "observe-stream must keep the last completed class"; }
+pass "observe-stream records last completed class for the nightly path"
+
+# ---------------------------------------------------------------------------
+# Wiring: the class loop, suite, nightly, summary, and per-push Unit job must
+# actually invoke this helper. A helper nobody calls is not coverage.
+# ---------------------------------------------------------------------------
+echo "== #2090 production + Unit-job wiring =="
+
+grep -q 'ci-journey-progress-telemetry.sh' "$CLASS_LOOP" \
+  || fail "class loop must invoke ci-journey-progress-telemetry.sh"
+grep -q 'class-completed' "$CLASS_LOOP" \
+  || fail "class loop must record class-completed"
+grep -q 'class-started' "$CLASS_LOOP" \
+  || fail "class loop must record class-started"
+grep -q 'ci-journey-progress-telemetry.sh' "$SUITE" \
+  || fail "ci-journey-suite.sh must start progress telemetry"
+grep -q 'ci-journey-progress-telemetry.sh' "$SUMMARY_FN" \
+  || fail "finish_ci_journey_suite must mark suite-completed"
+grep -q 'ci-journey-progress-telemetry.sh' "$NIGHTLY_SUITE" \
+  || fail "nightly-extensive-suite.sh must start / observe progress telemetry"
+grep -q 'observe-stream' "$NIGHTLY_SUITE" \
+  || fail "nightly-extensive-suite.sh must pipe phase-1 output through observe-stream"
+grep -q 'test-ci-journey-progress-telemetry.sh' "$WORKFLOW" \
+  || fail "tests.yml Unit/guards job must run this self-test"
+grep -q 'ci-journey-progress-telemetry.sh artifacts-uploaded' "$WORKFLOW" \
+  || fail "emulator-journey must mark artifacts-uploaded after the verdict upload"
+grep -q 'CI_JOURNEY_PROGRESS_DIR' "$WORKFLOW" \
+  || fail "aggregate job must collect surviving progress into CI_JOURNEY_PROGRESS_DIR"
+if [[ -f "$NIGHTLY" ]]; then
+  grep -q 'ci-journey-progress-telemetry.sh artifacts-uploaded' "$NIGHTLY" \
+    || fail "nightly-extensive.yml must mark artifacts-uploaded after report upload"
+fi
+grep -q 'CI_JOURNEY_PROGRESS_DIR' "$AGG" \
+  || fail "aggregate script must read CI_JOURNEY_PROGRESS_DIR for missing shards"
+pass "production hooks and the per-push Unit guard are wired"
+
+echo
+echo "PASS: test-ci-journey-progress-telemetry ($SECONDS s)"


### PR DESCRIPTION
Closes #2090

Publish extra-runner last-completed-class telemetry so a vanished hosted
journey shard still leaves a diagnostic, and keep missing-shard aggregation
fail-closed (never a false CLEAN).

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2090#issuecomment-5334429643
Orchestrator verify: telemetry self-test + aggregate verdict + interpreter hygiene on rebased origin/main.