### PR TITLE
test: stall-then-clear uses a healable bandwidth-zero fixture (#2127)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -771,14 +771,20 @@ abstract class NetworkFaultProofBase {
     }
 
     /**
-     * Half-open/no-FIN link starvation for short ride-through checks. Toxiproxy
+     * Half-open/no-FIN link starvation for short ride-through checks. Uses
+     * [ToxiproxyControl.addHalfOpenStall] (`bandwidth` `rate=0`) so Toxiproxy
      * keeps the socket established while dropping bytes for [downMillis], then
-     * removes the toxic so the same SSH/tmux connection can make progress again.
+     * removing the toxic lets the SAME SSH/tmux connection make progress again.
+     *
+     * Do not use [ToxiproxyControl.addBlackhole] here: Toxiproxy FINs every
+     * connection carrying a `timeout` toxic when that toxic is removed (#2127 /
+     * #1678), so blackhole-then-clear is a stall followed by a genuine close —
+     * not a recoverable blip.
      */
     protected fun starveLinkFor(label: String, downMillis: Long) {
         val proxy = toxiproxy()
         val cutStart = SystemClock.elapsedRealtime()
-        proxy.addBlackhole()
+        proxy.addHalfOpenStall()
         try {
             recordTiming("${label}_link_starved_ms", downMillis)
             waitForNoDisconnectBandDuring("${label}_while_starved", downMillis)

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt
@@ -36,10 +36,14 @@ import java.io.FileOutputStream
  * tmux session, a quick step-away while the link is momentarily dead (metro
  * tunnel / dead spot), and a return *within* the background grace window.
  *
- * The toxiproxy `addBlackhole` toxic models that case: a half-open, no-FIN byte
- * drop that keeps the socket "established" (so the warm `-CC` lease is intact)
- * while bytes are dropped. The warm lease means the within-grace foreground takes
- * the #754 driver-owned RESEED-ONLY path.
+ * The toxiproxy `addHalfOpenStall` toxic models that case: a half-open, no-FIN
+ * byte drop (`bandwidth` `rate=0` on both streams) that keeps the socket
+ * "established" (so the warm `-CC` lease is intact) while bytes are dropped,
+ * and that HEALS on removal. `addBlackhole()` is the wrong fixture here —
+ * Toxiproxy FINs every connection carrying a `timeout` toxic when that toxic is
+ * removed (#2127 / #1678), so blackhole-then-clear is a stall followed by a
+ * genuine close, not a recoverable metro-tunnel blip. The warm lease means the
+ * within-grace foreground takes the #754 driver-owned RESEED-ONLY path.
  *
  * #754 hard-cut DELETED the inline `probeCurrentRuntimeOnForegroundIfNeeded →
  * connect(LifecycleReattach)` path that raised the reveal-machine hold (the
@@ -110,14 +114,15 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
 
         // Use a short grace override so the resume lands well within grace
         // without holding the cut longer than grace (which would be a genuine
-        // outage). The blackhole stays half-open the whole time so the socket
+        // outage). The stall stays half-open the whole time so the socket
         // remains `isConnected` (the `-CC` lease stays warm) — exactly the
-        // within-grace case the #754 reseed-only path handles.
+        // within-grace case the #754 reseed-only path handles. #2127: must be
+        // addHalfOpenStall, not addBlackhole — timeout-toxic removal FINs.
         BackgroundGraceTestOverride.setForTest(WITHIN_GRACE_MS)
 
         val proxy = toxiproxy()
         val cycleStart = SystemClock.elapsedRealtime()
-        proxy.addBlackhole()
+        proxy.addHalfOpenStall()
         try {
             // Background within grace WHILE the link is cut.
             launchedActivity?.moveToState(Lifecycle.State.CREATED)
@@ -139,9 +144,9 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
         }
 
         // Ride-through: the live session is held, no disconnect band appears,
-        // and the link recovers without a reconnect. The blackhole keeps the
+        // and the link recovers without a reconnect. The stall keeps the
         // socket established (warm lease), so the dropped bytes drain on restore
-        // and the same `-CC` lease makes progress again.
+        // and the same `-CC` lease makes progress again — no fixture FIN.
         waitForNoDisconnectBandDuring("wgrace_after_restore", durationMillis = POST_RESTORE_SETTLE_MS)
         waitForConnected("within-grace foreground after restore")
         assertNoExtraConnectAttempts(
@@ -180,7 +185,7 @@ class WithinGraceResumeRideThroughE2eTest : NetworkFaultProofBase() {
             lines = listOf(
                 "session=$sessionName",
                 "marker=$marker",
-                "scenario=blackhole link, background within grace, foreground while cut, restore",
+                "scenario=half-open stall, background within grace, foreground while cut, restore",
                 "grace_override_ms=$WITHIN_GRACE_MS",
                 "expectation=no Attaching overlay, reseed_only (no probe), no disconnect band, " +
                     "no reconnect, same client",

--- a/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
+++ b/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
@@ -39,6 +39,38 @@ class ToxiproxyControl(
         )
     }
 
+    /**
+     * Issue #2127 / #1678 — a half-open stall that the SAME socket actually SURVIVES.
+     *
+     * [addBlackhole] is the right fixture for a wedge that is never healed (NAT
+     * idle death, background socket death): the `timeout=0` toxic holds bytes with
+     * no FIN for as long as it is installed. It is the WRONG fixture for a
+     * blip-then-heal journey, because **Toxiproxy CLOSES every connection carrying
+     * a `timeout` toxic when that toxic is REMOVED**. So "blackhole then clear"
+     * is physically a stall followed by a genuine remote FIN — and an SSH client
+     * is CORRECT to report `reader_exception`/`eof` and recover.
+     *
+     * The `bandwidth` toxic at `rate = 0` produces the same symmetric no-byte
+     * starvation and is a plain streaming toxic, so removing it resumes the SAME
+     * connection instead of tearing it down. Use this for any "brief interruption
+     * the connection must ride through" journey; keep [addBlackhole] for
+     * permanent-wedge journeys.
+     */
+    fun addHalfOpenStall() {
+        addToxic(
+            name = "halfopen_stall_upstream",
+            type = "bandwidth",
+            stream = "upstream",
+            attributesJson = """{"rate":0}""",
+        )
+        addToxic(
+            name = "halfopen_stall_downstream",
+            type = "bandwidth",
+            stream = "downstream",
+            attributesJson = """{"rate":0}""",
+        )
+    }
+
     fun addLatencyModel() {
         addToxic(
             name = "latency_upstream",
@@ -265,6 +297,8 @@ class ToxiproxyControl(
         private val KNOWN_TOXICS: List<String> = listOf(
             "blackhole_upstream",
             "blackhole_downstream",
+            "halfopen_stall_upstream",
+            "halfopen_stall_downstream",
             "latency_upstream",
             "latency_downstream",
             "bandwidth_downstream",

--- a/app/src/test/java/com/pocketshell/app/proof/BlackholeSiteClassificationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/BlackholeSiteClassificationTest.kt
@@ -1,0 +1,242 @@
+package com.pocketshell.app.proof
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #2127 — durable classification of every `addBlackhole()` call site.
+ *
+ * Toxiproxy CLOSES every connection carrying a `timeout` toxic when that toxic
+ * is removed, so `addBlackhole()` + `clearToxics()` is a stall followed by a
+ * genuine FIN — not a recoverable half-open. Stall-intended journeys must use
+ * [ToxiproxyControl.addHalfOpenStall] (`bandwidth` `rate=0`); wedge-intended
+ * sites keep `addBlackhole()`.
+ *
+ * This inventory is the recorded classification (AC1/AC4) and the Unit-gate
+ * pin that a new stall-then-clear site cannot silently reuse the FIN-on-clear
+ * fixture.
+ */
+class BlackholeSiteClassificationTest {
+
+    @Test
+    fun remainingBlackholeCallsAreOnlyWedgeIntendedSites() {
+        val calls = blackholeCalls()
+        val unexpected = calls.filterNot { it.relativePath in WEDGE_INTENDED_FILES }
+        assertTrue(
+            "addBlackhole() is the permanent-wedge fixture; stall-then-clear " +
+                "sites must use addHalfOpenStall(). Unexpected call(s) at " +
+                unexpected.joinToString { "${it.relativePath}:${it.line}" },
+            unexpected.isEmpty(),
+        )
+        assertEquals(
+            "Update the #2127 wedge allowlist when adding/removing a permanent " +
+                "addBlackhole() site — do not convert a wedge to a stall here.",
+            WEDGE_INTENDED_FILES,
+            calls.map { it.relativePath }.toSet(),
+        )
+    }
+
+    @Test
+    fun stallIntendedSitesUseHealableHalfOpenStallNotBlackhole() {
+        val missingStall = mutableListOf<String>()
+        val stillBlackhole = mutableListOf<String>()
+        for (path in STALL_INTENDED_FILES) {
+            val source = maskNonCode(sourceFile(path).readText())
+            if (!ADD_HALF_OPEN_STALL.containsMatchIn(source)) {
+                missingStall += path
+            }
+            if (ADD_BLACKHOLE_CALL.containsMatchIn(source) &&
+                !FUN_ADD_BLACKHOLE.containsMatchIn(source)
+            ) {
+                stillBlackhole += path
+            }
+        }
+        assertTrue(
+            "stall-intended site(s) no longer call addHalfOpenStall(): $missingStall",
+            missingStall.isEmpty(),
+        )
+        assertTrue(
+            "stall-intended site(s) still call addBlackhole(): $stillBlackhole",
+            stillBlackhole.isEmpty(),
+        )
+    }
+
+    private fun blackholeCalls(): List<CallSite> {
+        val root = projectRoot()
+        return SOURCE_ROOTS
+            .map { File(root, it) }
+            .filter { it.isDirectory }
+            .flatMap { dir ->
+                dir.walkTopDown()
+                    .filter { it.isFile && it.extension == "kt" }
+                    .filter { !it.invariantSeparatorsPath.contains("/build/") }
+                    .flatMap { file -> callsIn(file, root) }
+            }
+            .sortedWith(compareBy(CallSite::relativePath, CallSite::line))
+    }
+
+    private fun callsIn(file: File, root: File): List<CallSite> {
+        val source = file.readText()
+        val masked = maskNonCode(source)
+        return ADD_BLACKHOLE_CALL.findAll(masked).mapNotNull { match ->
+            val prefix = masked.substring(0, match.range.first)
+            if (prefix.endsWith("fun ")) return@mapNotNull null
+            CallSite(
+                relativePath = file.relativeTo(root).invariantSeparatorsPath,
+                line = masked.take(match.range.first).count { it == '\n' } + 1,
+            )
+        }.toList()
+    }
+
+    /** Masks strings/comments while preserving offsets and newlines. */
+    private fun maskNonCode(source: String): String {
+        val result = source.toCharArray()
+        var index = 0
+        var state = LexState.CODE
+
+        fun mask(at: Int) {
+            if (result[at] != '\n' && result[at] != '\r') result[at] = ' '
+        }
+
+        while (index < source.length) {
+            when (state) {
+                LexState.CODE -> when {
+                    source.startsWith("//", index) -> {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                        state = LexState.LINE_COMMENT
+                    }
+                    source.startsWith("/*", index) -> {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                        state = LexState.BLOCK_COMMENT
+                    }
+                    source.startsWith("\"\"\"", index) -> {
+                        repeat(3) { mask(index + it) }
+                        index += 3
+                        state = LexState.TRIPLE_STRING
+                    }
+                    source[index] == '"' -> {
+                        mask(index++)
+                        state = LexState.STRING
+                    }
+                    source[index] == '\'' -> {
+                        mask(index++)
+                        state = LexState.CHAR
+                    }
+                    else -> index += 1
+                }
+                LexState.LINE_COMMENT -> {
+                    if (source[index] == '\n') {
+                        state = LexState.CODE
+                    } else {
+                        mask(index)
+                    }
+                    index += 1
+                }
+                LexState.BLOCK_COMMENT -> {
+                    if (source.startsWith("*/", index)) {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                        state = LexState.CODE
+                    } else {
+                        mask(index)
+                        index += 1
+                    }
+                }
+                LexState.STRING, LexState.CHAR -> {
+                    val terminator = if (state == LexState.STRING) '"' else '\''
+                    if (source[index] == '\\' && index + 1 < source.length) {
+                        mask(index)
+                        mask(index + 1)
+                        index += 2
+                    } else {
+                        val done = source[index] == terminator
+                        mask(index)
+                        index += 1
+                        if (done) state = LexState.CODE
+                    }
+                }
+                LexState.TRIPLE_STRING -> {
+                    if (source.startsWith("\"\"\"", index)) {
+                        repeat(3) { mask(index + it) }
+                        index += 3
+                        state = LexState.CODE
+                    } else {
+                        mask(index)
+                        index += 1
+                    }
+                }
+            }
+        }
+        return String(result)
+    }
+
+    private fun projectRoot(): File {
+        var cursor = File(System.getProperty("user.dir")).absoluteFile
+        while (true) {
+            if (File(cursor, "settings.gradle.kts").isFile) return cursor
+            cursor = cursor.parentFile ?: break
+        }
+        error("Cannot locate project root from ${System.getProperty("user.dir")}")
+    }
+
+    private fun sourceFile(relativePath: String): File = File(projectRoot(), relativePath)
+
+    private data class CallSite(
+        val relativePath: String,
+        val line: Int,
+    )
+
+    private enum class LexState {
+        CODE,
+        LINE_COMMENT,
+        BLOCK_COMMENT,
+        STRING,
+        TRIPLE_STRING,
+        CHAR,
+    }
+
+    companion object {
+        private val ADD_BLACKHOLE_CALL = Regex("""\baddBlackhole\s*\(""")
+        private val FUN_ADD_BLACKHOLE = Regex("""\bfun\s+addBlackhole\s*\(""")
+        private val ADD_HALF_OPEN_STALL = Regex("""\baddHalfOpenStall\s*\(""")
+
+        private val SOURCE_ROOTS = listOf(
+            "app/src/androidTest",
+            "app/src/debug",
+            "app/src/test",
+            "app/src/testDebug",
+            "shared",
+        )
+
+        /**
+         * Permanent-wedge sites: the socket should stay half-open for as long as
+         * the toxic is installed. A later `clearToxics()` (if any) is restore-
+         * for-a-new-path / cleanup, not "heal the same socket".
+         */
+        private val WEDGE_INTENDED_FILES = setOf(
+            "app/src/testDebug/java/com/pocketshell/app/proof/ToxiproxyControlTest.kt",
+            "app/src/androidTest/java/com/pocketshell/app/proof/ColdDialUnderBandwidthLimitE2eTest.kt",
+            "app/src/androidTest/java/com/pocketshell/app/proof/DisconnectBlackholeE2eTest.kt",
+            "app/src/androidTest/java/com/pocketshell/app/proof/DisconnectFlapSoakE2eTest.kt",
+            "app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt",
+            "app/src/androidTest/java/com/pocketshell/app/proof/PushResumeDeadSocketMainResponsiveE2eTest.kt",
+            "app/src/androidTest/java/com/pocketshell/app/proof/SilentMidSessionDropDetectionE2eTest.kt",
+        )
+
+        /**
+         * Recoverable-stall sites: the SAME socket must survive toxic removal.
+         * `addBlackhole()` FINs on clear; these must use `addHalfOpenStall()`.
+         */
+        private val STALL_INTENDED_FILES = setOf(
+            "app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt",
+            "app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceResumeRideThroughE2eTest.kt",
+        )
+    }
+}

--- a/app/src/testDebug/java/com/pocketshell/app/proof/ToxiproxyControlTest.kt
+++ b/app/src/testDebug/java/com/pocketshell/app/proof/ToxiproxyControlTest.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.proof
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ToxiproxyControlTest {
@@ -72,6 +73,39 @@ class ToxiproxyControlTest {
                 ),
             ),
             transport.requests.toSet(),
+        )
+    }
+
+    /**
+     * Issue #2127 / #1678. A blip-then-heal journey must NOT use the `timeout`
+     * toxic: DELETEing a `timeout` toxic closes every connection carrying it, so
+     * "blackhole then clear" is physically a stall followed by a real remote FIN.
+     * The heal-able stall is the streaming `bandwidth` toxic pinned to `rate = 0`
+     * on BOTH directions.
+     */
+    @Test
+    fun halfOpenStallUsesRateZeroBandwidthInBothDirectionsNotATimeoutToxic() {
+        val transport = RecordingTransport()
+        ToxiproxyControl(baseUrl = "http://unused", transport = transport).addHalfOpenStall()
+
+        assertEquals(
+            setOf(
+                RecordedRequest(
+                    "POST",
+                    "/proxies/agents_ssh/toxics",
+                    """{"name":"halfopen_stall_upstream","type":"bandwidth","stream":"upstream","toxicity":1.0,"attributes":{"rate":0}}""",
+                ),
+                RecordedRequest(
+                    "POST",
+                    "/proxies/agents_ssh/toxics",
+                    """{"name":"halfopen_stall_downstream","type":"bandwidth","stream":"downstream","toxicity":1.0,"attributes":{"rate":0}}""",
+                ),
+            ),
+            transport.requests.toSet(),
+        )
+        assertTrue(
+            "a heal-able half-open stall must never use the connection-closing `timeout` toxic",
+            transport.requests.none { it.body?.contains("\"type\":\"timeout\"") == true },
         )
     }
 
@@ -160,6 +194,8 @@ class ToxiproxyControlTest {
             setOf(
                 RecordedRequest("DELETE", "/proxies/agents_ssh/toxics/blackhole_upstream", null),
                 RecordedRequest("DELETE", "/proxies/agents_ssh/toxics/blackhole_downstream", null),
+                RecordedRequest("DELETE", "/proxies/agents_ssh/toxics/halfopen_stall_upstream", null),
+                RecordedRequest("DELETE", "/proxies/agents_ssh/toxics/halfopen_stall_downstream", null),
                 RecordedRequest("DELETE", "/proxies/agents_ssh/toxics/latency_upstream", null),
                 RecordedRequest("DELETE", "/proxies/agents_ssh/toxics/latency_downstream", null),
                 RecordedRequest("DELETE", "/proxies/agents_ssh/toxics/bandwidth_downstream", null),


### PR DESCRIPTION
Closes #2127

Stall-then-clear Toxiproxy sites now use a healable `bandwidth rate=0` fixture instead of `addBlackhole()`-then-clear (which FINs on timeout-toxic removal). Wedge sites, `addBlackhole()` itself, and the #1678 `briefLinkCut` Assume are untouched.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2127#issuecomment-5334562840

Rebased onto origin/main `271159c4` (#2219 / #2139).
- `scripts/check-file-size-hygiene.sh` rc=0
- `scripts/check-ci-journey-harness.sh` PASS
- `:app:testDebugUnitTest --rerun-tasks` XML: BlackholeSiteClassificationTest 2/2, ToxiproxyControlTest 9/9