### PR TITLE
fix(test): arm the ack-wedge needle on tmux 3.7c caret-ESC paste (#2205)

### DIFF
--- a/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1739AgentAckBoundRealTransportIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/tmux/Issue1739AgentAckBoundRealTransportIntegrationTest.kt
@@ -83,6 +83,7 @@ class Issue1739AgentAckBoundRealTransportIntegrationTest {
         private const val DIAGNOSTIC_POLL_INTERVAL_MS = 20L
         private const val DETERMINISTIC_SHORT_TIMEOUT_MS = 100L
         private const val DETERMINISTIC_LONG_TIMEOUT_MS = 5_000L
+        private const val NEEDLE_ONLY_HIDES_BEFORE_WEDGE = 3
         private val TERMINAL_ACK_TIMEOUT_RESULTS = setOf("ack_timeout", "capture_timeout")
 
         private val projectRoot: Path by lazy { findProjectRoot() }
@@ -327,6 +328,8 @@ class Issue1739AgentAckBoundRealTransportIntegrationTest {
                 ),
             )
 
+            HostAckSendProbe.reset()
+            OutboundLegacyStackProbe.reset()
             client.wedgeNextVisibleCapture = true
             val startedAt = System.currentTimeMillis()
             val first = withTimeout(CALLER_BOUND_MS) {
@@ -340,7 +343,31 @@ class Issue1739AgentAckBoundRealTransportIntegrationTest {
             }
             val firstElapsedMs = System.currentTimeMillis() - startedAt
 
-            assertTrue("unconfirmed first attempt must remain retryable", first.isFailure)
+            assertTrue(
+                "this proof is the LEGACY inference lane, not HostAck " +
+                    "(authority=${vm.hostAck.authority} active=${vm.hostAck.active})",
+                !vm.hostAck.active,
+            )
+            assertEquals(
+                "HostAck must not own a TerminalInference send: " +
+                    OutboundLegacyStackProbe.snapshot(),
+                0L,
+                HostAckSendProbe.count(),
+            )
+            assertTrue(
+                "the send must have entered the legacy paste-ack gate: " +
+                    OutboundLegacyStackProbe.snapshot(),
+                OutboundLegacyStackProbe.pasteAck.get() > 0L,
+            )
+            assertTrue(
+                "unconfirmed first attempt must remain retryable " +
+                    "(success=${first.isSuccess} elapsed=${firstElapsedMs}ms " +
+                    "hostAckActive=${vm.hostAck.active} hostAckSends=${HostAckSendProbe.count()} " +
+                    "legacy=${OutboundLegacyStackProbe.snapshot()} " +
+                    "realCaptureCompleted=${client.realCaptureCompleted} " +
+                    "landed=${client.landedCapture} seen=${client.seenFrames})",
+                first.isFailure,
+            )
             assertTrue(
                 "ack caller must resolve well below the old 50s composer timeout; " +
                     "elapsed=${firstElapsedMs}ms",
@@ -348,7 +375,13 @@ class Issue1739AgentAckBoundRealTransportIntegrationTest {
             )
             assertTrue("the real capture completed before teardown wedged", client.realCaptureCompleted)
             assertTrue(
-                "the real pane must reproduce Claude's collapsed multiline-paste chip: " +
+                "the real capture must be ack-positive (collapsed chip or payload needle): " +
+                    client.landedCapture,
+                agentSubmitVisibleFrameAcksPaste(client.landedCapture, PAYLOAD),
+            )
+            assertTrue(
+                "after settle the real pane must show Claude's collapsed chip " +
+                    "(needle-only means the fixture treated the paste as typed): " +
                     client.landedCapture,
                 client.landedCapture.any { it.contains("[Pasted text #") },
             )
@@ -609,6 +642,11 @@ class Issue1739AgentAckBoundRealTransportIntegrationTest {
         var landedCapture: List<String> = emptyList()
             private set
 
+        val seenFrames: MutableList<List<String>> = CopyOnWriteArrayList()
+
+        @Volatile
+        private var needleOnlyHides: Int = 0
+
         override suspend fun sendKeysViaExec(
             sendKeysCommand: String,
             timeoutMs: Long?,
@@ -623,16 +661,37 @@ class Issue1739AgentAckBoundRealTransportIntegrationTest {
             scrollbackLines: Int,
         ): CommandResponse {
             val response = delegate.capturePaneTextViaExec(paneId, timeoutMs, scrollbackLines)
-            if (
-                !wedgeNextVisibleCapture ||
-                scrollbackLines != 0 ||
-                response.output.none { it.contains("[Pasted text #") }
-            ) {
+            // Issue #2205: never hand an ack-positive frame back to the paste-ack
+            // gate while the wedge is armed. Matching only `[Pasted text #` left a
+            // needle-visible body unwedged, so the first send returned success.
+            //
+            // A needle-only frame can appear MID-paste (bytes echoed before the
+            // fake-agent finishes `\e[200~`…`\e[201~`). Returning it acks the
+            // send; wedging it immediately can let a later `\n` submit a second
+            // turn. Hide transient needle frames (the gate keeps polling) until
+            // the collapsed chip arrives, or until a few polls show the needle
+            // is stable — then park cleanup.
+            if (!wedgeNextVisibleCapture || scrollbackLines != 0) {
                 return response
+            }
+            val hasChip = response.output.any { it.contains("[Pasted text #") }
+            val acksPaste = agentSubmitVisibleFrameAcksPaste(response.output, PAYLOAD)
+            if (!acksPaste) {
+                return response
+            }
+            if (!hasChip && needleOnlyHides < NEEDLE_ONLY_HIDES_BEFORE_WEDGE) {
+                needleOnlyHides += 1
+                seenFrames += response.output
+                return CommandResponse(
+                    number = response.number,
+                    output = listOf("> "),
+                    isError = false,
+                )
             }
             wedgeNextVisibleCapture = false
             realCaptureCompleted = true
             landedCapture = response.output
+            seenFrames += response.output
             try {
                 CompletableDeferred<Unit>().await()
             } catch (cancelled: CancellationException) {

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentSubmitAck.kt
@@ -614,6 +614,28 @@ private fun agentPaneShowsPayload(
             )
 }
 
+/**
+ * Issue #2205: would the paste-ack gate accept [visibleLines] as proof this
+ * [payload] landed? The #1739 capture-wedge must use THIS predicate — not the
+ * collapsed-chip substring alone — so a needle-visible body (no
+ * `[Pasted text #`) cannot silently succeed the first send.
+ */
+internal fun agentSubmitVisibleFrameAcksPaste(
+    visibleLines: List<String>,
+    payload: String,
+    baselineNeedleCount: Int = 0,
+    collapsedMarkerBaseline: Int = 0,
+): Boolean {
+    val needle = agentSubmitAckNeedle(payload) ?: return false
+    return agentPaneShowsPayload(
+        response = CommandResponse(number = -1L, output = visibleLines, isError = false),
+        needle = needle,
+        baselineNeedleCount = baselineNeedleCount,
+        payloadIsMultiLine = agentSubmitPayloadIsMultiLine(payload),
+        collapsedMarkerBaseline = collapsedMarkerBaseline,
+    )
+}
+
 internal fun agentSubmitAckNeedle(payload: String): String? {
     val lastLine = payload
         .split('\n')

--- a/app/src/test/java/com/pocketshell/app/proof/FakeAgentTranscriptJsonTest.kt
+++ b/app/src/test/java/com/pocketshell/app/proof/FakeAgentTranscriptJsonTest.kt
@@ -54,6 +54,30 @@ class FakeAgentTranscriptJsonTest {
         assertEquals(payload, parsed.text)
     }
 
+    @Test
+    fun tmux37cCaretEncodedBracketedPasteCollapsesToChip() {
+        val script = projectRoot().resolve(FAKE_AGENT_SCRIPT)
+        // tmux 3.7c paste-buffer vis-encodes ESC as `^[` (issue #2205).
+        val caretFramed = "^[[200~echo line1\necho line2^[[201~"
+        val process = ProcessBuilder(script.toString())
+            .directory(projectRoot().toFile())
+            .redirectErrorStream(true)
+            .start()
+        process.outputStream.use { it.write(caretFramed.toByteArray(Charsets.UTF_8)) }
+        val completed = process.waitFor(5, TimeUnit.SECONDS)
+        if (!completed) process.destroyForcibly()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        assertTrue("fake-agent timed out on caret-encoded paste: $output", completed)
+        assertTrue(
+            "tmux 3.7c caret-ESC framed paste must collapse to the Claude chip, got: $output",
+            output.contains("[Pasted text #1 +1 lines]"),
+        )
+        assertTrue(
+            "caret-encoded paste must not submit on the embedded newline, got: $output",
+            !output.contains("FAKE-AGENT SUBMITTED:"),
+        )
+    }
+
     private fun projectRoot(): Path {
         var candidate: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
         while (candidate != null) {

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2205AckWedgeNeedleGapTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2205AckWedgeNeedleGapTest.kt
@@ -1,0 +1,205 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.agents.AgentDetection
+import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.tmux.CommandResponse
+import com.pocketshell.core.tmux.TmuxClient
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2205: the #1739 real-transport wedge keyed only on the collapsed
+ * `[Pasted text #` chip, but the paste-ack gate also accepts the payload
+ * needle. A visible frame that echoes the body (no chip) therefore acked,
+ * the first send returned success, and Integration went red on
+ * `unconfirmed first attempt must remain retryable`.
+ *
+ * This is the deterministic JVM reproduction of that harness hole. It is
+ * not the HostAck-default vacuous case: [TmuxSessionViewModelTestBase]
+ * pins [com.pocketshell.app.settings.OutboundDeliveryAuthority.TerminalInference],
+ * and the send is asserted to stay on the legacy stack.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue2205AckWedgeNeedleGapTest : TmuxSessionViewModelTestBase() {
+
+    @Test
+    fun needleVisibleFrameWithoutChipMustKeepFirstSendRetryable() = runTest(scheduler) {
+        HostAckSendProbe.reset()
+        OutboundLegacyStackProbe.reset()
+        val vm = newVm()
+        val inner = FakeTmuxClient()
+        inner.defaultCaptureResponse = EMPTY_PROMPT
+        val client = Issue1739AckWedgeClient(inner, PAYLOAD)
+        vm.attachClientForTest(client)
+        vm.startAgentConversationForTest("%0", newClaudeDetection())
+        vm.setAgentSubmitEnterDelayForTest(0)
+        vm.setAgentSubmitAckTimeoutForTest(80L)
+        assertFalse(
+            "this proof is the LEGACY inference lane, not HostAck",
+            vm.hostAck.active,
+        )
+
+        inner.onCommandSent = { cmd ->
+            if (cmd.startsWith("paste-buffer ")) {
+                inner.defaultCaptureResponse = NEEDLE_ONLY_FRAME
+            }
+        }
+        client.wedgeNextVisibleCapture = true
+
+        val first = async {
+            vm.sendAgentPayloadToPaneResult(
+                "%0",
+                PAYLOAD,
+                AgentKind.ClaudeCode,
+                "issue-2205-needle-gap",
+            )
+        }
+        try {
+            advanceTimeBy(80L)
+            runCurrent()
+            assertTrue(
+                "unconfirmed first attempt must remain retryable " +
+                    "(completed=${first.isCompleted} hostAckActive=${vm.hostAck.active} " +
+                    "hostAckSends=${HostAckSendProbe.count()} " +
+                    "legacy=${OutboundLegacyStackProbe.snapshot()} " +
+                    "wedged=${client.didWedge} landed=${client.landedCapture})",
+                first.isCompleted && first.await().isFailure,
+            )
+            assertTrue("the ack-positive needle frame must have armed the wedge", client.didWedge)
+            assertEqualsZeroEnters(inner)
+            assertTrue(
+                "the send must have entered the legacy paste-ack gate",
+                OutboundLegacyStackProbe.pasteAck.get() > 0L,
+            )
+            assertEquals(
+                "HostAck must not own a TerminalInference send",
+                0L,
+                HostAckSendProbe.count(),
+            )
+        } finally {
+            client.releaseCaptureCleanup()
+            advanceUntilIdle()
+        }
+    }
+
+    @Test
+    fun pasteAckAcceptsNeedleVisibleFrameThatChipSubstringMisses() {
+        assertFalse(
+            "the Integration wedge used to key only on this substring",
+            NEEDLE_ONLY_FRAME.output.any { it.contains("[Pasted text #") },
+        )
+        assertTrue(
+            "the paste-ack gate accepts the same frame via the payload needle",
+            agentSubmitVisibleFrameAcksPaste(NEEDLE_ONLY_FRAME.output, PAYLOAD),
+        )
+        assertTrue(
+            "the collapsed chip remains an ack-positive frame",
+            agentSubmitVisibleFrameAcksPaste(listOf("> [Pasted text #1 +1 lines]"), PAYLOAD),
+        )
+        assertFalse(
+            "an empty prompt must not ack or wedge",
+            agentSubmitVisibleFrameAcksPaste(EMPTY_PROMPT.output, PAYLOAD),
+        )
+    }
+
+    private fun assertEqualsZeroEnters(client: FakeTmuxClient) {
+        assertFalse(
+            "an unconfirmed capture must never authorize Enter",
+            client.sentCommands.any { it == "send-keys -t %0 Enter" || it.endsWith(" Enter") },
+        )
+    }
+
+    private fun newClaudeDetection(): AgentDetection = AgentDetection(
+        agent = AgentKind.ClaudeCode,
+        sourcePath = "/tmp/issue2205.jsonl",
+        sessionId = "issue2205",
+        confidence = AgentDetection.Confidence.ProcessConfirmed,
+    )
+
+    /**
+     * Mirrors the #1739 Integration [AckCleanupWedgeClient]: real capture first,
+     * then park in NonCancellable teardown when the visible frame would let
+     * the paste-ack gate succeed.
+     */
+    private class Issue1739AckWedgeClient(
+        private val delegate: FakeTmuxClient,
+        private val payload: String,
+    ) : TmuxClient by delegate {
+        private val cleanupGate = CompletableDeferred<Unit>()
+
+        @Volatile
+        var wedgeNextVisibleCapture: Boolean = false
+
+        @Volatile
+        var didWedge: Boolean = false
+            private set
+
+        @Volatile
+        var landedCapture: List<String> = emptyList()
+            private set
+
+        override suspend fun capturePaneTextViaExec(
+            paneId: String,
+            timeoutMs: Long?,
+            scrollbackLines: Int,
+        ): CommandResponse {
+            val response = delegate.capturePaneTextViaExec(paneId, timeoutMs, scrollbackLines)
+            // Issue #2205: wedge on every frame the paste-ack gate would accept
+            // (needle OR collapsed chip). The pre-fix chip-only substring left a
+            // needle-visible body unwedged, so the first send returned success.
+            if (
+                !wedgeNextVisibleCapture ||
+                scrollbackLines != 0 ||
+                !agentSubmitVisibleFrameAcksPaste(response.output, payload)
+            ) {
+                return response
+            }
+            wedgeNextVisibleCapture = false
+            didWedge = true
+            landedCapture = response.output
+            try {
+                CompletableDeferred<Unit>().await()
+            } catch (cancelled: CancellationException) {
+                withContext(NonCancellable) {
+                    cleanupGate.await()
+                }
+                throw cancelled
+            }
+            error("unreachable")
+        }
+
+        fun releaseCaptureCleanup() {
+            cleanupGate.complete(Unit)
+        }
+    }
+
+    companion object {
+        private const val PAYLOAD =
+            "echo issue1739_agent_ack_line1\necho issue1739_agent_ack_exactly_once"
+        private val EMPTY_PROMPT = CommandResponse(
+            number = 0L,
+            output = listOf("> "),
+            isError = false,
+        )
+        private val NEEDLE_ONLY_FRAME = CommandResponse(
+            number = 0L,
+            output = listOf(
+                "> echo issue1739_agent_ack_line1",
+                "echo issue1739_agent_ack_exactly_once",
+            ),
+            isError = false,
+        )
+    }
+}

--- a/tests/docker/agent-bin/pocketshell-fake-agent
+++ b/tests/docker/agent-bin/pocketshell-fake-agent
@@ -240,7 +240,15 @@ read_paste_body() {
   while true; do
     read_byte || cleanup
     b="$REPLY"
-    if [ "$b" = "$ESC" ]; then
+    # Real ESC, or tmux 3.7c paste-buffer caret-ESC (`^[`, issue #2205).
+    if [ "$(printf '%d' "'$b")" = "27" ] || [ "$b" = "^" ]; then
+      if [ "$b" = "^" ]; then
+        read_byte || cleanup
+        if [ "$REPLY" != "[" ]; then
+          PASTE_BODY="$PASTE_BODY^$REPLY"
+          continue
+        fi
+      fi
       read_byte || cleanup
       if [ "$REPLY" = "[" ]; then
         csi=""
@@ -302,9 +310,31 @@ handle_esc() {
 
 # Handle one input byte. Shared by the initial read and the debounce drain so a
 # paste is parsed identically no matter which loop sees its leading ESC.
+# The caller leaves the byte in REPLY (do not pass it as $1 — an ESC argument
+# is lossy on some bash/PTY combinations).
 process_byte() {
-  ch="$1"
+  ch="$REPLY"
   [ -z "$ch" ] && return 0
+  # Real ESC (0x1b). Also accept tmux 3.7c paste-buffer's vis-encoding of ESC
+  # as the two-byte caret sequence `^[` (0x5e 0x5b) — issue #2205. Without
+  # that, a framed `\e[200~`…`\e[201~` is typed, the embedded newline submits
+  # the first line, and the paste-ack needle fires without a collapsed chip.
+  if [ "$(printf '%d' "'$ch")" = "27" ]; then
+    handle_esc
+    return 0
+  fi
+  if [ "$ch" = "^" ]; then
+    read_byte || cleanup
+    if [ "$REPLY" = "[" ]; then
+      handle_esc
+      return 0
+    fi
+    buffer="$buffer^"
+    submit_buffer="$submit_buffer^"
+    dirty=1
+    process_byte
+    return 0
+  fi
   case "$ch" in
     "$CR"|"$LF")
       # Submit: record the submitted line (shown by the next render) and clear
@@ -341,9 +371,6 @@ process_byte() {
       buffer=""
       submit_buffer=""
       dirty=1
-      ;;
-    "$ESC")
-      handle_esc
       ;;
     *)
       buffer="$buffer$ch"
@@ -396,10 +423,10 @@ while true; do
     # EOF on the channel — exit; the outer `exec sh` keeps the pane alive.
     cleanup
   fi
-  process_byte "$REPLY"
+  process_byte
   # Drain any back-to-back burst bytes before redrawing (debounce).
   while IFS= read -r -s -N 1 -t 0.02 REPLY; do
-    process_byte "$REPLY"
+    process_byte
   done
   flush
 done


### PR DESCRIPTION
Closes #2205

Arm the ack-wedge needle so Issue1739AgentAckBound does not treat the first send as success when tmux 3.7c caret-ESC paste hides the chip substring.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2205#issuecomment-5334522073

Rebased onto origin/main `3db5bca5` (#2220 / #2127).
- `scripts/check-file-size-hygiene.sh` rc=0
- `:app:testDebugUnitTest --rerun-tasks` XML: Issue2205AckWedgeNeedleGapTest 2/2, FakeAgentTranscriptJsonTest 2/2