### PR TITLE
fix(ui): keep composer launcher tappable through reconnect wedges (#2192)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2192ComposerLauncherAfterReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2192ComposerLauncherAfterReconnectE2eTest.kt
@@ -1,0 +1,766 @@
+package com.pocketshell.app.proof
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.SystemClock
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.composer.COMPOSER_CLOSE_TAG
+import com.pocketshell.app.composer.COMPOSER_CONNECTION_LOST_TAG
+import com.pocketshell.app.composer.COMPOSER_DRAFT_TAG
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_COMPACT_CHROME_BACK_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_CONNECTING_PROGRESS_TAG
+import com.pocketshell.app.tmux.TMUX_FULL_CHROME_BACK_BUTTON_TAG
+import com.pocketshell.app.tmux.TMUX_SESSION_LIVE_SEMANTICS_KEY
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TMUX_SURFACE_PANE_PRESENT_SEMANTICS_KEY
+import com.pocketshell.app.tmux.TMUX_TERMINAL_HELD_SEMANTICS_KEY
+import com.pocketshell.app.tmux.TMUX_TERMINAL_TAB_TAG
+import com.pocketshell.app.tmux.DEFAULT_AUTO_RECONNECT_DELAYS_MS
+import com.pocketshell.app.tmux.PASSIVE_DISCONNECT_GRACE_MS
+import com.pocketshell.app.tmux.PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.voice.SESSION_COMPOSER_LAUNCHER_TAG
+import com.pocketshell.app.voice.SESSION_ENTER_CHIP_TAG
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #2192 — after a real reconnect the composer launcher must open the
+ * sheet, never silently no-op. The class-covering wedges (raw not-Connected
+ * while the Terminal band still looks live; surfacePane null after re-seed)
+ * live on the production helpers + [TmuxSessionVoiceSurfaceUiTest]; this
+ * journey is the emulator+Docker backstop the maintainer actually hits.
+ *
+ *  1. Attach to session A on the Docker `agents` fixture.
+ *  2. `kill -9` the app's sshd worker (same #553 reconnect path).
+ *  3. As soon as the screen LOOKS live again (launcher present, terminal
+ *     not held) — without waiting for raw `sessionLive` — tap the launcher.
+ *  4. Assert the production composer sheet is open. Record which wedge
+ *     (if any) the semantics still showed at the tap.
+ *  5. While the sheet is open after a not-live tap, the offline-queue
+ *     banner must be visible (#1613).
+ *  6. Back → session B → back to A (the maintainer workaround) and tap
+ *     again so a round-trip cannot be the only way the launcher works.
+ *  7. Repeat the retained-frame/raw-drop observation through the accepted
+ *     clean-passive-drop seam with a wide grace window, so the proof does not
+ *     depend on catching a physical reconnect at one particular millisecond.
+ */
+@RunWith(AndroidJUnit4::class)
+class Issue2192ComposerLauncherAfterReconnectE2eTest {
+
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+    private var baselineSshdPids: Set<Int> = emptySet()
+    private val timings = mutableListOf<String>()
+    private var observedWedge: String = "none"
+    private var physicalDropWedge: String = "none"
+    private var postReconnectWedge: String = "not-reached"
+    private var acceptedSeamWedge: String = "not-run"
+
+    private suspend fun seedBeforeLaunch() {
+        fixtureKey = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        baselineSshdPids = listSshdPidsForTestuser(fixtureKey)
+        seedTmuxSessions(fixtureKey)
+        hostRowTag = seedDockerHost(fixtureKey, "Issue2192 Launcher")
+        forceFlatHostDetailViewMode()
+    }
+
+    @After
+    fun teardown() {
+        runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+        if (::fixtureKey.isInitialized) {
+            runCatching { runBlocking { cleanupSeededSessions(fixtureKey) } }
+        }
+    }
+
+    @Test
+    fun launcherOpensAfterReconnectAndWhileDisconnected() { runBlocking<Unit> {
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForSessionRowVisible(SESSION_A)
+        compose.onNodeWithText(SESSION_A).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        selectTerminalTabIfPresent()
+        waitForTerminalViewAttached()
+        waitForVisibleTerminal("initial attach") { it.contains(MARKER_A) }
+        waitForLauncherPresent("initial attach")
+        captureViewport("issue2192-01-attached")
+
+        val attachedPids = listSshdPidsForTestuser(fixtureKey)
+        val appSshdPids = attachedPids - baselineSshdPids
+        assertTrue(
+            "expected at least one new sshd worker for the app connection; " +
+                "baseline=$baselineSshdPids attached=$attachedPids",
+            appSshdPids.isNotEmpty(),
+        )
+        val killAt = SystemClock.elapsedRealtime()
+        killRemoteSshdPids(fixtureKey, appSshdPids)
+        Log.i(LOG_TAG, "killed app sshd PIDs: $appSshdPids")
+
+        var sawDrop = false
+        val dropDeadline = SystemClock.elapsedRealtime() + DROP_OBSERVED_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < dropDeadline) {
+            val reconnecting = nodeCount(TMUX_CONNECTING_PROGRESS_TAG) > 0
+            val lifecycle = runCatching { sessionLifecycle() }.getOrNull()
+            val held = lifecycle?.terminalHeld == true
+            val wedge = lifecycle?.let(::classifyWedge) ?: "none"
+            if (physicalDropWedge == "none" && wedge != "none") {
+                physicalDropWedge = wedge
+                observedWedge = wedge
+                Log.i(
+                    LOG_TAG,
+                    "physical drop window observed wedge=$wedge " +
+                        "lifecycle=$lifecycle",
+                )
+                captureViewport("issue2192-physical-$wedge")
+            }
+            if (reconnecting || held || MARKER_A !in visibleTerminalText()) {
+                sawDrop = true
+                break
+            }
+            SystemClock.sleep(100)
+        }
+        recordTiming("drop_observed_ms", SystemClock.elapsedRealtime() - killAt)
+        Log.i(LOG_TAG, "sawDrop=$sawDrop")
+
+        // AC3: if we catch the reconnecting window, the launcher must still open.
+        if (nodeCount(TMUX_CONNECTING_PROGRESS_TAG) > 0 || sessionLifecycle().terminalHeld) {
+            waitForLauncherPresent("during reconnect")
+            tapLauncherAndAssertSheetOpen("during-reconnect")
+            dismissComposerSheet()
+        }
+
+        // Wait until the screen LOOKS live — do NOT wait for raw sessionLive.
+        // That is the reported wedge: display/retained frame live, tap dead.
+        val looksLiveAt = SystemClock.elapsedRealtime()
+        waitUntilLooksLive()
+        recordTiming("looks_live_ms", SystemClock.elapsedRealtime() - looksLiveAt)
+        val lifecycle = sessionLifecycle()
+        postReconnectWedge = classifyWedge(lifecycle)
+        if (observedWedge == "none") observedWedge = postReconnectWedge
+        Log.i(
+            LOG_TAG,
+            "looks-live lifecycle sessionLive=${lifecycle.sessionLive} " +
+                "held=${lifecycle.terminalHeld} pane=${lifecycle.surfacePanePresent} " +
+                "postReconnectWedge=$postReconnectWedge observedWedge=$observedWedge",
+        )
+        captureViewport("issue2192-02-after-reconnect")
+
+        if (!lifecycle.sessionLive && lifecycle.paneBoundEnterPresent) {
+            val beforeEnter = visibleTerminalText()
+            compose.onNodeWithTag(SESSION_ENTER_CHIP_TAG, useUnmergedTree = true)
+                .performClick()
+            SystemClock.sleep(400)
+            assertEquals(
+                "pane-bound Enter must stay gated while raw status is not Connected",
+                beforeEnter,
+                visibleTerminalText(),
+            )
+        }
+
+        tapLauncherAndAssertSheetOpen("after-reconnect")
+        if (!lifecycle.sessionLive) {
+            assertTrue(
+                "offline/reconnecting tap must open the queue-mode sheet (#1613); " +
+                    "missing $COMPOSER_CONNECTION_LOST_TAG",
+                nodeCount(COMPOSER_CONNECTION_LOST_TAG) > 0,
+            )
+        }
+        dismissComposerSheet()
+
+        // The physical kill above remains the real Docker behavior assertion.
+        // This accepted seam drives the same transport-death reader path but
+        // widens the retained-frame grace window so Wedge A is deterministic.
+        proveRetainedFrameDropWithAcceptedSeam()
+
+        // Maintainer workaround: back → other session → back. Launcher must
+        // still open afterwards (it must not be the ONLY way it works).
+        clickTmuxBack()
+        waitForSessionRowVisible(SESSION_B)
+        compose.onNodeWithText(SESSION_B).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        selectTerminalTabIfPresent()
+        waitForTerminalViewAttached()
+        waitForVisibleTerminal("session B") { it.contains(MARKER_B) }
+        clickTmuxBack()
+        waitForSessionRowVisible(SESSION_A)
+        compose.onNodeWithText(SESSION_A).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        selectTerminalTabIfPresent()
+        waitForTerminalViewAttached()
+        waitForVisibleTerminal("session A after round-trip") { it.contains(MARKER_A) }
+        waitForLauncherPresent("after round-trip")
+        tapLauncherAndAssertSheetOpen("after-round-trip")
+        dismissComposerSheet()
+        captureViewport("issue2192-03-after-round-trip")
+
+        writeSummary()
+        writeTimings()
+    } }
+
+    private data class SessionLifecycle(
+        val sessionLive: Boolean,
+        val terminalHeld: Boolean,
+        val surfacePanePresent: Boolean,
+        val paneBoundEnterPresent: Boolean,
+    )
+
+    private fun sessionLifecycle(): SessionLifecycle {
+        val config = compose
+            .onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .config
+        return SessionLifecycle(
+            sessionLive = config.getOrNull(TMUX_SESSION_LIVE_SEMANTICS_KEY) == true,
+            terminalHeld = config.getOrNull(TMUX_TERMINAL_HELD_SEMANTICS_KEY) == true,
+            surfacePanePresent = config.getOrNull(TMUX_SURFACE_PANE_PRESENT_SEMANTICS_KEY) == true,
+            paneBoundEnterPresent = nodeCount(SESSION_ENTER_CHIP_TAG) > 0,
+        )
+    }
+
+    private fun classifyWedge(lifecycle: SessionLifecycle): String = when {
+        !lifecycle.sessionLive && !lifecycle.terminalHeld -> "wedge-A-raw-not-connected"
+        lifecycle.sessionLive && !lifecycle.surfacePanePresent -> "wedge-B-surface-pane-null"
+        else -> "none"
+    }
+
+    private fun proveRetainedFrameDropWithAcceptedSeam() {
+        val vm = currentViewModel()
+        val alreadyLive = runCatching { sessionLifecycle().sessionLive }.getOrDefault(false)
+        if (!alreadyLive) {
+            assertTrue(
+                "the accepted Wedge A seam requires a live transport after the physical " +
+                    "journey; manual reconnect must be accepted",
+                vm.reconnect(),
+            )
+            assertTrue(
+                "the accepted Wedge A seam precondition must recover to a live session",
+                waitForCondition(RECONNECT_LOOKS_LIVE_TIMEOUT_MS) {
+                    runCatching { sessionLifecycle().sessionLive }.getOrDefault(false)
+                },
+            )
+        }
+        // Keep the controller's normal eight-rung budget. A one-item override
+        // would make the first failed passive cycle reach Unreachable, which
+        // correctly hides the terminal and cannot represent Wedge A; only the
+        // per-rung delay is widened for this deterministic observation.
+        vm.setAutoReconnectDelaysForTest(DEFAULT_AUTO_RECONNECT_DELAYS_MS.map { 60_000L })
+        vm.setPassiveDisconnectRecoveryForTest(
+            // Keep the id-keyed retained Live frame while the raw control
+            // channel reports the clean EOF. This is the accepted deterministic
+            // seam used by the reconnect journeys; production remains 60s.
+            graceMs = 60_000L,
+            silentReattachTimeoutMs = PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS,
+        )
+        // The retained-frame projection is a production within-grace lifecycle
+        // decision, not a property of the unrecoverable-host seam. Without this
+        // arm, the real RevealStateMachine correctly maps Reconnecting to
+        // Seeding, which is why the previous run observed terminalHeld=true and
+        // could not produce Wedge A. Exercise the same public foreground edge
+        // that arms the live-frame hold before injecting the clean drop.
+        vm.onAppForegrounded(resumedWithinGrace = true)
+        assertTrue(
+            "accepted #2192 seam must arm the production within-grace reveal hold",
+            waitForCondition(2_000L) { vm.withinGraceRecoveryActiveForTest() },
+        )
+        val previousCleanOutageOverride = vm.forceCleanOutageForTest
+        try {
+            // The Docker listener stays up after the real transport is killed, so the
+            // ordinary clean-drop path can heal before the retained-frame wedge is
+            // observable. Arm the existing test seam only for this observation: it
+            // keeps the passive recovery ladder in Reconnecting while its
+            // replacement primitives fail, modelling the same accepted raw
+            // not-Connected interval without changing production behavior. The
+            // unrecoverable-host seam is intentionally stronger: it exhausts
+            // fresh connects and correctly projects an Error/held surface.
+            vm.forceCleanOutageForTest = true
+            val dropAt = SystemClock.elapsedRealtime()
+            assertTrue(
+                "accepted #2192 drop seam must fire on the live Docker transport",
+                vm.triggerCleanPassiveDropForTest(),
+            )
+            val observed = waitForCondition(8_000L) {
+                runCatching { classifyWedge(sessionLifecycle()) == "wedge-A-raw-not-connected" }
+                    .getOrDefault(false)
+            }
+            val lifecycle = runCatching { sessionLifecycle() }.getOrNull()
+            acceptedSeamWedge = lifecycle?.let(::classifyWedge) ?: "none"
+            recordTiming(
+                "accepted_seam_wedge_ms",
+                if (observed) SystemClock.elapsedRealtime() - dropAt else -1L,
+            )
+            writeText(
+                "issue2192-accepted-seam-lifecycle.txt",
+                "observed=$observed\n" +
+                    "wedge=$acceptedSeamWedge\n" +
+                    "lifecycle=$lifecycle\n",
+            )
+            assertTrue(
+                "accepted clean-drop seam must expose retained Live + raw-not-Connected " +
+                    "Wedge A; observed=$acceptedSeamWedge lifecycle=$lifecycle",
+                observed && acceptedSeamWedge == "wedge-A-raw-not-connected",
+            )
+            observedWedge = acceptedSeamWedge
+            captureViewport("issue2192-accepted-wedge-A")
+            tapLauncherAndAssertSheetOpen("accepted-clean-drop-wedge-A")
+            assertTrue(
+                "accepted Wedge A tap must open queue mode",
+                nodeCount(COMPOSER_CONNECTION_LOST_TAG) > 0,
+            )
+            dismissComposerSheet()
+
+            // The host is reachable again for the real manual-recovery assertion.
+            vm.forceCleanOutageForTest = false
+            val reconnectAt = SystemClock.elapsedRealtime()
+            assertTrue(
+                "manual recovery after the accepted Wedge A proof must be accepted",
+                vm.reconnect(),
+            )
+            val recovered = waitForCondition(RECONNECT_LOOKS_LIVE_TIMEOUT_MS) {
+                runCatching {
+                    val current = sessionLifecycle()
+                    current.sessionLive && !current.terminalHeld &&
+                        MARKER_A in visibleTerminalText()
+                }.getOrDefault(false)
+            }
+            recordTiming(
+                "accepted_seam_reconnect_ms",
+                if (recovered) SystemClock.elapsedRealtime() - reconnectAt else -1L,
+            )
+            assertTrue(
+                "accepted Wedge A proof must recover to a live session before the " +
+                    "A→B→A journey; lifecycle=${runCatching { sessionLifecycle() }.getOrNull()}",
+                recovered,
+            )
+        } finally {
+            vm.forceCleanOutageForTest = previousCleanOutageOverride
+            // Restore the production budgets before the session-switch backstop,
+            // including when an assertion aborts the accepted-seam proof.
+            vm.setPassiveDisconnectRecoveryForTest(
+                graceMs = PASSIVE_DISCONNECT_GRACE_MS,
+                silentReattachTimeoutMs = PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS,
+            )
+            vm.setAutoReconnectDelaysForTest(DEFAULT_AUTO_RECONNECT_DELAYS_MS)
+        }
+    }
+
+    private fun currentViewModel(): TmuxSessionViewModel {
+        var vm: TmuxSessionViewModel? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+        }
+        return requireNotNull(vm) { "TmuxSessionViewModel not available" }
+    }
+
+    private fun waitUntilLooksLive() {
+        val ready = waitForCondition(RECONNECT_LOOKS_LIVE_TIMEOUT_MS) {
+            val lifecycle = runCatching { sessionLifecycle() }.getOrNull() ?: return@waitForCondition false
+            nodeCount(SESSION_COMPOSER_LAUNCHER_TAG) > 0 && !lifecycle.terminalHeld
+        }
+        assertTrue(
+            "expected the session screen to look live (launcher present, " +
+                "terminal not held) after reconnect; lifecycle=${
+                    runCatching { sessionLifecycle() }.getOrNull()
+                } terminal=\n${visibleTerminalText()}",
+            ready,
+        )
+    }
+
+    private fun tapLauncherAndAssertSheetOpen(label: String) {
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG, useUnmergedTree = true)
+            .performClick()
+        val opened = waitForCondition(SHEET_OPEN_TIMEOUT_MS) {
+            nodeCount(COMPOSER_DRAFT_TAG) > 0 || nodeCount(COMPOSER_CLOSE_TAG) > 0
+        }
+        assertTrue(
+            "issue #2192: launcher tap ($label) must open the composer sheet, " +
+                "never a silent no-op. wedge=$observedWedge " +
+                "lifecycle=${runCatching { sessionLifecycle() }.getOrNull()}",
+            opened,
+        )
+        captureViewport("issue2192-sheet-$label")
+    }
+
+    private fun dismissComposerSheet() {
+        if (nodeCount(COMPOSER_CLOSE_TAG) == 0) return
+        compose.onNodeWithTag(COMPOSER_CLOSE_TAG, useUnmergedTree = true).performClick()
+        val closed = waitForCondition(SHEET_OPEN_TIMEOUT_MS) {
+            nodeCount(COMPOSER_DRAFT_TAG) == 0 && nodeCount(COMPOSER_CLOSE_TAG) == 0
+        }
+        assertTrue("composer sheet must dismiss after Close", closed)
+    }
+
+    private fun waitForLauncherPresent(label: String) {
+        val present = waitForCondition(LAUNCHER_TIMEOUT_MS) {
+            nodeCount(SESSION_COMPOSER_LAUNCHER_TAG) > 0
+        }
+        assertTrue("expected composer launcher present ($label)", present)
+    }
+
+    private fun selectTerminalTabIfPresent() {
+        val hasTab = waitForCondition(8_000) {
+            nodeCount(TMUX_TERMINAL_TAB_TAG) > 0
+        }
+        if (!hasTab) return
+        compose.onNodeWithTag(TMUX_TERMINAL_TAB_TAG, useUnmergedTree = true).performClick()
+        compose.waitForIdle()
+    }
+
+    private fun clickTmuxBack() {
+        val tags = listOf(TMUX_COMPACT_CHROME_BACK_BUTTON_TAG, TMUX_FULL_CHROME_BACK_BUTTON_TAG)
+        val tag = tags.firstOrNull { candidate -> nodeCount(candidate) > 0 }
+            ?: error("expected a production tmux Back control")
+        compose.onNodeWithTag(tag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = 15_000) {
+            nodeCount(TMUX_SESSION_SCREEN_TAG) == 0
+        }
+    }
+
+    private fun waitForHostRowPresent(hostRowTag: String) {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching { nodeCount(hostRowTag) > 0 }.getOrDefault(false)
+        }
+    }
+
+    private fun waitForSessionRowVisible(sessionName: String) {
+        val ready = runCatching {
+            compose.waitUntil(timeoutMillis = 40_000) {
+                compose.onAllNodesWithText(sessionName, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            true
+        }.getOrDefault(false)
+        assertTrue("expected host detail to show session '$sessionName'", ready)
+    }
+
+    private fun waitForTerminalViewAttached() {
+        compose.waitUntil(timeoutMillis = 30_000) {
+            var attached = false
+            compose.activityRule.scenario.onActivity { activity ->
+                val view = activity.window.decorView.findTerminalView()
+                attached = view?.currentSession != null && view.mEmulator != null
+            }
+            attached
+        }
+    }
+
+    private fun waitForVisibleTerminal(label: String, predicate: (String) -> Boolean) {
+        var last = ""
+        val satisfied = runCatching {
+            compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+                last = visibleTerminalText()
+                predicate(last)
+            }
+            true
+        }.getOrDefault(false)
+        assertTrue("expected visible terminal text for $label; got:\n$last", satisfied)
+    }
+
+    private fun waitForCondition(timeoutMs: Long, condition: () -> Boolean): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (runCatching(condition).getOrDefault(false)) return true
+            SystemClock.sleep(SAMPLE_INTERVAL_MS)
+        }
+        return runCatching(condition).getOrDefault(false)
+    }
+
+    private fun nodeCount(tag: String): Int =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .size
+
+    private fun visibleTerminalText(): String {
+        var text = ""
+        compose.activityRule.scenario.onActivity { activity ->
+            text = activity.window.decorView
+                .findTerminalView()
+                ?.currentSession
+                ?.emulator
+                ?.screen
+                ?.transcriptText
+                .orEmpty()
+        }
+        return text
+    }
+
+    private fun forceFlatHostDetailViewMode() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        appContext
+            .getSharedPreferences("app_settings", android.content.Context.MODE_PRIVATE)
+            .edit()
+            .putString("host_detail_view_mode", "Flat")
+            .commit()
+    }
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context
+            .assets
+            .open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String, hostName: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue2192-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = hostName,
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    private suspend fun seedTmuxSessions(key: String) {
+        val script = buildString {
+            appendLine("set -eu")
+            listOf(SESSION_A to MARKER_A, SESSION_B to MARKER_B).forEach { (name, marker) ->
+                appendLine("tmux kill-session -t ${shellQuote(name)} 2>/dev/null || true")
+                appendLine(
+                    "tmux new-session -d -s ${shellQuote(name)} " +
+                        shellQuote("printf '$marker\\n'; exec sh"),
+                )
+            }
+            appendLine("tmux list-sessions")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected tmux session seeding to succeed for #2192, got " +
+                "exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded sessions: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun cleanupSeededSessions(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec(
+                        listOf(SESSION_A, SESSION_B).joinToString("\n") { name ->
+                            "tmux kill-session -t ${shellQuote(name)} 2>/dev/null || true"
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun listSshdPidsForTestuser(key: String): Set<Int> {
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session ->
+            session.use { it.exec("pgrep -u testuser sshd 2>/dev/null || true") }
+        }
+        val out = result.getOrNull()?.stdout.orEmpty()
+        return out.lines().mapNotNull { it.trim().toIntOrNull() }.toSet()
+    }
+
+    private suspend fun killRemoteSshdPids(key: String, pids: Set<Int>) {
+        if (pids.isEmpty()) return
+        val script = buildString {
+            for (pid in pids) appendLine("kill -9 $pid 2>/dev/null || true")
+        }
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session -> session.use { it.exec(script) } }
+        }
+    }
+
+    private fun captureViewport(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            val view = activity.window.decorView.findTerminalView()
+                ?: activity.findViewById<View>(android.R.id.content)
+                ?: activity.window.decorView
+            if (view.width <= 0 || view.height <= 0) return@onActivity
+            val b = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            view.draw(Canvas(b))
+            bitmap = b
+        }
+        bitmap?.let { writeBitmap("$name-viewport", it) }
+        writeText("$name-visible-terminal.txt", visibleTerminalText())
+        bitmap?.recycle()
+    }
+
+    private fun writeBitmap(name: String, bitmap: Bitmap): File {
+        val file = artifactFile("$name.png")
+        FileOutputStream(file).use { out ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                "failed to write bitmap to ${file.absolutePath}"
+            }
+        }
+        println("ISSUE2192_VIEWPORT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeText(name: String, text: String): File {
+        val file = artifactFile(name)
+        file.writeText(text)
+        println("ISSUE2192_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeTimings(): File {
+        val file = artifactFile("timings.txt")
+        file.writeText(timings.joinToString(separator = "\n", postfix = "\n"))
+        println("ISSUE2192_TIMINGS ${file.absolutePath}")
+        return file
+    }
+
+    private fun writeSummary(): File {
+        val file = artifactFile("summary.txt")
+        file.writeText(
+            buildString {
+                appendLine("scenario=composer-launcher-opens-after-reconnect")
+                appendLine("issue=2192")
+                appendLine("fixture=tests/docker (agents host port $DEFAULT_PORT)")
+                appendLine("physical_drop_window_wedge=$physicalDropWedge")
+                appendLine("post_reconnect_wedge=$postReconnectWedge")
+                appendLine("accepted_seam_wedge=$acceptedSeamWedge")
+                appendLine("observed_wedge=$observedWedge")
+                appendLine()
+                appendLine("timings:")
+                timings.forEach(::appendLine)
+            },
+        )
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create artifact directory ${dir.absolutePath}"
+        }
+        return File(dir, name)
+    }
+
+    private fun recordTiming(name: String, startOrValueMs: Long) {
+        val line = if (name.endsWith("_ms")) "$name=$startOrValueMs" else "$name=$startOrValueMs"
+        timings += line
+        println("ISSUE2192_TIMING $line")
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue2192Launcher"
+        const val DEVICE_DIR_NAME: String = "issue2192-composer-launcher-reconnect"
+
+        const val SESSION_A: String = "issue2192-a"
+        const val SESSION_B: String = "issue2192-b"
+        const val MARKER_A: String = "ISSUE2192-READY-A"
+        const val MARKER_B: String = "ISSUE2192-READY-B"
+
+        const val SAMPLE_INTERVAL_MS: Long = 80
+        const val SHEET_OPEN_TIMEOUT_MS: Long = 8_000
+        const val LAUNCHER_TIMEOUT_MS: Long = 15_000
+        val DROP_OBSERVED_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 30_000L else 15_000L
+        val RECONNECT_LOOKS_LIVE_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 60_000L else 40_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionVoiceSurfaceUiTest.kt
@@ -30,6 +30,7 @@ import com.pocketshell.app.assistant.AssistantAgentLoop
 import com.pocketshell.app.assistant.AssistantUiState
 import com.pocketshell.app.composer.COMPOSER_ATTACHMENT_CHIPS_TAG
 import com.pocketshell.app.session.InlineDictationViewModel
+import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.voice.ADD_COMMAND_CHIP_LABEL
 import com.pocketshell.app.voice.ADD_PROMPT_CHIP_LABEL
 import com.pocketshell.app.voice.ASSISTANT_CORRECTION_MIC_TAG
@@ -1068,6 +1069,102 @@ class TmuxSessionVoiceSurfaceUiTest {
 
         compose.runOnIdle { retryableState.value = false }
         compose.onNodeWithTag(ASSISTANT_RETRY_TAG).assertDoesNotExist()
+    }
+
+    /**
+     * Issue #2192 Wedge A — live-looking Terminal (not held), raw status not
+     * `Connected`. Production folds that into `sessionLive = false` on the
+     * Controls branch, which used to disable the launcher itself. Opening the
+     * sheet is a local action (#1944) and must still fire; Enter stays gated.
+     */
+    @Test
+    fun issue2192_wedgeA_rawNotConnectedLiveLookingTerminal_launcherOpensEnterStaysGated() {
+        assertLauncherOpensAndEnterStaysGated(
+            sessionLive = false,
+            paneBoundCallbackPresent = true,
+        )
+    }
+
+    /**
+     * Issue #2192 Wedge B — live-looking Terminal after a re-seed left
+     * `surfacePane == null`. The production page-rebind identity proof lives in
+     * the JVM Issue #2192 test; this component check keeps the resulting
+     * bottom-controls contract explicit: the launcher must still open, while
+     * there is no pane-bound Enter to fire.
+     */
+    @Test
+    fun issue2192_wedgeB_surfacePaneNullAfterReseed_launcherOpensEnterAbsent() {
+        assertLauncherOpensAndEnterStaysGated(
+            sessionLive = false,
+            paneBoundCallbackPresent = false,
+        )
+    }
+
+    /**
+     * Issue #2192 AC3 — genuinely reconnecting / disconnected, Terminal tab
+     * still showing the live Controls band (display debounce has not flipped
+     * `terminalHeld`). A launcher tap must open, never silently no-op.
+     */
+    @Test
+    fun issue2192_offlineOrReconnectingLiveLookingTerminal_launcherOpens() {
+        assertLauncherOpensAndEnterStaysGated(
+            sessionLive = false,
+            paneBoundCallbackPresent = true,
+        )
+    }
+
+    private fun assertLauncherOpensAndEnterStaysGated(
+        sessionLive: Boolean,
+        paneBoundCallbackPresent: Boolean,
+    ) {
+        var opened = 0
+        var enter = 0
+        compose.setContent {
+            PocketShellTheme {
+                // Same wiring [TmuxSessionScreen] uses for the keyboard-down
+                // Terminal band: `controlsInputEnabled = sessionLive && pane != null`
+                // is passed as `sessionLive` here. Both wedges collapse to
+                // `sessionLive = false` at this call site.
+                TmuxSessionBottomControlsCallSite(
+                    selectedTab = SessionTab.Terminal,
+                    sessionLive = sessionLive,
+                    terminalHeld = false,
+                    onDictateTap = { opened += 1 },
+                    onEnterTap = if (paneBoundCallbackPresent) {
+                        { enter += 1 }
+                    } else {
+                        null
+                    },
+                    onShowKeyboardTap = if (paneBoundCallbackPresent) {{ }} else null,
+                    onAddSnippetTap = if (paneBoundCallbackPresent) {{ }} else null,
+                )
+            }
+        }
+
+        compose.assertNodeFullyWithinRoot(SESSION_COMPOSER_LAUNCHER_TAG)
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG)
+            .assertHasClickAction()
+            .performClick()
+        assertEquals(
+            "issue #2192: launcher tap must open the composer sheet " +
+                "(sessionLive=$sessionLive paneBound=$paneBoundCallbackPresent)",
+            1,
+            opened,
+        )
+
+        if (paneBoundCallbackPresent) {
+            compose.onNodeWithTag(SESSION_ENTER_CHIP_TAG)
+                .assertHasClickAction()
+                .performClick()
+            assertEquals(
+                "issue #2192: pane-bound Enter must stay gated while not live",
+                0,
+                enter,
+            )
+        } else {
+            compose.onNodeWithTag(SESSION_ENTER_CHIP_TAG).assertDoesNotExist()
+            assertEquals(0, enter)
+        }
     }
 
     @Test

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
@@ -208,6 +208,9 @@ internal fun TmuxTerminalBottomControls(
                         // follow-up — see #123 notes on per-pane cwd /
                         // project-root wiring.
                         onProjectNavigationTap = null,
+                        // Issue #2192: sessionLive gates pane-bound writes (Enter)
+                        // only. The launcher is a local sheet-open (#1944) and
+                        // must stay enabled through reconnect / empty-pane wedges.
                         inputEnabled = sessionLive,
                         unsentCount = unsentCount,
                         unsentHasFailure = unsentHasFailure,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -215,7 +215,12 @@ public fun TmuxSessionScreen(
     )
     val pagerState = rememberPagerState(pageCount = { unifiedPager.pages.size })
     // Issue #1685: the pager-relative pane selection in its own frame.
-    val panesSel = rememberTmuxSessionPaneSelection(conn, viewModel, pagerState)
+    val panesSel = rememberTmuxSessionPaneSelection(
+        conn = conn,
+        viewModel = viewModel,
+        pagerState = pagerState,
+        unifiedPagerPages = unifiedPager.pages,
+    )
     // Epic #821 Slice 1: the active session's RECORDED `@ps_agent_kind`.
     val currentSessionRecordedKind by viewModel.currentSessionRecordedKind.collectAsState()
     val recordedAgentRouteEvidence by viewModel.currentRecordedAgentRouteEvidence.collectAsState()
@@ -1606,7 +1611,12 @@ private fun ColumnScope.TmuxSessionSurfaceRegion(
     // Issue #810 (hard-cut, D22): the composer launcher is ALWAYS present.
     run {
         val pane = surfacePane
-        val controlsInputEnabled = sessionLive && pane != null
+        // Issue #2192: launcher open is local; only pane-bound writes stay gated.
+        val controlsEnablement = tmuxSessionBottomControlEnablement(
+            sessionLive = sessionLive,
+            panePresent = pane != null,
+        )
+        val controlsInputEnabled = controlsEnablement.paneBoundEnabled
         TmuxSessionBottomBandPlacement(
             isImeVisible = isImeVisible,
             onConversationTab = tmuxSessionBottomControlsShowsConversation(currentSelectedTab),

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRouting.kt
@@ -251,6 +251,43 @@ internal fun tmuxSessionSurfacePane(
 ): TmuxPaneState? = if (switchHidesTerminal) null else visibleUnifiedPane
 
 /**
+ * Issue #2192 Wedge B: after a reconnect re-seed, [pages] can shrink while the
+ * pager's [currentPage] is still the old (now out-of-bounds) index.
+ *
+ * A numeric page is only meaningful inside the pager snapshot that produced
+ * it. If that snapshot has been replaced, falling back to [List.firstOrNull]
+ * can bind the surface to a cached *other* session because [unifiedPanes]
+ * spans all sessions. Rebind only to a page owned by the current target
+ * session; returning null is safer than painting or routing a foreign pane.
+ * An empty list, or a list without the target, still returns null.
+ */
+internal fun tmuxSessionVisibleUnifiedPane(
+    pages: List<UnifiedPagerPage>,
+    currentPage: Int,
+    targetSessionId: com.pocketshell.core.connection.SessionId,
+): TmuxPaneState? = pages.getOrNull(currentPage)?.pane
+    ?: pages.firstOrNull { it.owner.sessionId == targetSessionId }?.pane
+
+/**
+ * Issue #2192: launcher open is a LOCAL action (#1944). [sessionLive] and pane
+ * presence may gate only pane-bound writes (Enter, keyboard, control bytes),
+ * never the composer sheet. Both post-reconnect wedges used to fold into
+ * `sessionLive && panePresent` and silently disable the launcher.
+ */
+internal data class TmuxSessionBottomControlEnablement(
+    val launcherOpenEnabled: Boolean,
+    val paneBoundEnabled: Boolean,
+)
+
+internal fun tmuxSessionBottomControlEnablement(
+    sessionLive: Boolean,
+    panePresent: Boolean,
+): TmuxSessionBottomControlEnablement = TmuxSessionBottomControlEnablement(
+    launcherOpenEnabled = true,
+    paneBoundEnabled = sessionLive && panePresent,
+)
+
+/**
  * Issue #797 (promotion-on-settle): decide whether a unified-pager settle that
  * came to rest on a CACHED (non-active) pane should trigger a warm switch
  * (pane-promotion) so input routing + agent detection are RESTORED for the

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
@@ -157,9 +157,16 @@ internal fun rememberTmuxSessionPaneSelection(
     conn: TmuxSessionConnectionRuntime,
     viewModel: TmuxSessionViewModel,
     pagerState: PagerState,
+    unifiedPagerPages: List<UnifiedPagerPage>,
 ): TmuxSessionPaneSelection {
     // Issue #626: the unified pager shows panes from all sessions.
-    val currentUnifiedPane = conn.unifiedPanes.getOrNull(pagerState.currentPage)
+    // Issue #2192: when a reconnect re-seed invalidates the numeric page, use
+    // the page owner's target identity rather than a cross-session first pane.
+    val currentUnifiedPane = tmuxSessionVisibleUnifiedPane(
+        pages = unifiedPagerPages,
+        currentPage = pagerState.currentPage,
+        targetSessionId = conn.targetSessionId,
+    )
     val isActiveSessionPane = currentUnifiedPane?.let { viewModel.isActiveSessionPane(it) } ?: true
     val currentPane = if (isActiveSessionPane) currentUnifiedPane else null
     val activeSessionPane = conn.panes.firstOrNull()

--- a/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
+++ b/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
@@ -626,12 +626,10 @@ internal fun BottomChipControls(
     addSnippetIcon: ImageVector? = SnippetsChipIcon,
     onProjectNavigationTap: (() -> Unit)? = null,
     leadingContent: (@Composable () -> Unit)? = null,
-    // Issue #249: gate terminal input controls and optional composer launcher on whether
-    // the SSH/tmux session is live. While disconnected or reconnecting an
-    // input-control tap would write into a dead bridge and be silently dropped.
-    // We disable the controls, and when the launcher is
-    // present render it in its disabled state so the user
-    // sees that input is unavailable rather than losing a tap.
+    // Issue #249 / #2192: gate pane-bound input (Enter) on whether the
+    // SSH/tmux session is live — a tap would write into a dead bridge and be
+    // silently dropped. The composer launcher is a LOCAL sheet-open (#1944)
+    // and stays enabled so a reconnect / empty-pane wedge cannot swallow it.
     inputEnabled: Boolean = true,
     // Issue #1531 (audit RC1): the unsent-queue badge count + failure flag for the
     // docked launcher (see [ComposerLauncherButton]).
@@ -744,7 +742,7 @@ internal fun BottomChipControls(
                         contentAlignment = Alignment.CenterEnd,
                     ) {
                         ComposerLauncherButton(
-                            enabled = inputEnabled,
+                            enabled = true,
                             onClick = onDictateTap,
                             onHoldSwipeUp = onDictateHoldSwipeUp,
                             unsentCount = unsentCount,

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2192ComposerLauncherEnablementTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2192ComposerLauncherEnablementTest.kt
@@ -1,0 +1,189 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.terminal.ui.TerminalSurfaceState
+import com.pocketshell.core.connection.SessionId
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2192 — the composer launcher must stay a local open even when the
+ * post-reconnect surface is wedged. These proofs drive the SAME production
+ * helpers [TmuxSessionScreen] now uses, so a future fold of launcher-open back
+ * into `sessionLive && panePresent` is RED here, not only on the device.
+ */
+class Issue2192ComposerLauncherEnablementTest {
+
+    @Test
+    fun pre2192BaselineDisablesLauncherOnBothWedges() {
+        // RED baseline: the pre-#2192 call-site formula
+        // `controlsInputEnabled = sessionLive && pane != null` disabled the
+        // launcher itself. Both candidate reconnect wedges collapse to that.
+        assertFalse(
+            "Wedge A: raw not-Connected, pane present → launcher was dead",
+            pre2192LauncherEnabled(sessionLive = false, panePresent = true),
+        )
+        assertFalse(
+            "Wedge B: Connected, surfacePane null → launcher was dead",
+            pre2192LauncherEnabled(sessionLive = true, panePresent = false),
+        )
+        assertTrue(
+            "happy path stayed enabled (the formula was not always-false)",
+            pre2192LauncherEnabled(sessionLive = true, panePresent = true),
+        )
+    }
+
+    @Test
+    fun wedgeA_rawNotConnectedKeepsLauncherOpenAndGatesPaneBound() {
+        val enablement = tmuxSessionBottomControlEnablement(
+            sessionLive = false,
+            panePresent = true,
+        )
+        assertTrue(
+            "Wedge A: launcher open is local and must not wait for Connected",
+            enablement.launcherOpenEnabled,
+        )
+        assertFalse(
+            "Wedge A: Enter / keyboard / control-bytes stay gated (#249)",
+            enablement.paneBoundEnabled,
+        )
+    }
+
+    @Test
+    fun wedgeB_missingSurfacePaneKeepsLauncherOpenAndGatesPaneBound() {
+        val enablement = tmuxSessionBottomControlEnablement(
+            sessionLive = true,
+            panePresent = false,
+        )
+        assertTrue(
+            "Wedge B: launcher open must survive a null surface pane",
+            enablement.launcherOpenEnabled,
+        )
+        assertFalse(
+            "Wedge B: no pane means no pane-bound write",
+            enablement.paneBoundEnabled,
+        )
+    }
+
+    @Test
+    fun genuinelyDisconnectedKeepsLauncherOpen() {
+        val enablement = tmuxSessionBottomControlEnablement(
+            sessionLive = false,
+            panePresent = false,
+        )
+        assertTrue(
+            "offline / reconnecting still opens the sheet (#1613 queue)",
+            enablement.launcherOpenEnabled,
+        )
+        assertFalse(enablement.paneBoundEnabled)
+    }
+
+    @Test
+    fun livePaneKeepsBothEnabled() {
+        val enablement = tmuxSessionBottomControlEnablement(
+            sessionLive = true,
+            panePresent = true,
+        )
+        assertTrue(enablement.launcherOpenEnabled)
+        assertTrue(enablement.paneBoundEnabled)
+    }
+
+    @Test
+    fun visibleUnifiedPaneFallbackStaysOnTargetAfterReseed() {
+        val targetSessionId = SessionId("tmux:7:\$0:100")
+        val targetEpoch = UnifiedPagerTargetEpoch(
+            targetSessionId = targetSessionId,
+            instance = 1L,
+        )
+        val foreign = fakePane("%foreign", sessionId = "\$1", sessionCreated = 200L)
+        val target = fakePane("%target", sessionId = "\$0", sessionCreated = 100L)
+        val pages = unifiedPagerPages(
+            panes = listOf(foreign, target),
+            targetEpoch = targetEpoch,
+            targetSessionName = "target",
+            sessionNameForPane = { pane ->
+                if (pane === target) "target" else "foreign"
+            },
+        )
+        assertSame(
+            "a valid page keeps following the pane the pager is showing",
+            foreign,
+            tmuxSessionVisibleUnifiedPane(
+                pages = pages,
+                currentPage = 0,
+                targetSessionId = targetSessionId,
+            ),
+        )
+        assertSame(
+            "Wedge B rebind: an out-of-bounds page must land on the current target, " +
+                "never the first foreign cached session",
+            target,
+            tmuxSessionVisibleUnifiedPane(
+                pages = pages,
+                currentPage = 4,
+                targetSessionId = targetSessionId,
+            ),
+        )
+        assertSame(
+            target,
+            tmuxSessionVisibleUnifiedPane(
+                pages = pages,
+                currentPage = -1,
+                targetSessionId = targetSessionId,
+            ),
+        )
+        assertNull(
+            "no target-owned page is safer than selecting a foreign session",
+            tmuxSessionVisibleUnifiedPane(
+                pages = unifiedPagerPages(
+                    panes = listOf(foreign),
+                    targetEpoch = targetEpoch,
+                    targetSessionName = "target",
+                    sessionNameForPane = { "foreign" },
+                ),
+                currentPage = 4,
+                targetSessionId = targetSessionId,
+            ),
+        )
+    }
+
+    @Test
+    fun visibleUnifiedPaneStaysNullWhenTheListIsEmpty() {
+        val targetSessionId = SessionId("tmux:7:\$0:100")
+        assertNull(
+            tmuxSessionVisibleUnifiedPane(
+                pages = emptyList(),
+                currentPage = 0,
+                targetSessionId = targetSessionId,
+            ),
+        )
+        assertNull(
+            tmuxSessionVisibleUnifiedPane(
+                pages = emptyList(),
+                currentPage = 3,
+                targetSessionId = targetSessionId,
+            ),
+        )
+    }
+
+    private fun pre2192LauncherEnabled(sessionLive: Boolean, panePresent: Boolean): Boolean =
+        sessionLive && panePresent
+
+    private fun fakePane(
+        paneId: String,
+        sessionId: String,
+        sessionCreated: Long,
+    ): TmuxPaneState = TmuxPaneState(
+        paneId = paneId,
+        windowId = "@0",
+        sessionId = sessionId,
+        sessionCreated = sessionCreated,
+        title = "work",
+        cwd = "/repo",
+        currentCommand = "bash",
+        paneTty = "/dev/pts/1",
+        terminalState = TerminalSurfaceState(),
+    )
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -228,6 +228,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.tmux.Issue796ComposerOpenTerminalScopeProofTest"  # #796 #638 #657 H3): the composer-open - terminal-relayout collision regress…
   "com.pocketshell.app.tmux.Issue1085RecompositionScopeProofTest"  # #1085 #638 #657 F3): the voice-first recomposition-jank scope proof. The mai…
   "$FQCN_PREFIX.ComposerAlwaysPresentSwitchJourneyE2eTest"  # #810 #657 #638 the composer-launcher ALWAYS-PRESENT switch journey. The mai…
+  "$FQCN_PREFIX.Issue2192ComposerLauncherAfterReconnectE2eTest"  # #2192 D33/G10: after a real sshd-kill reconnect the composer launcher must open the sheet (never a silent no-op); records Wedge A/B from production semantics and keeps pane-bound Enter gated
   "com.pocketshell.app.tmux.AgentConversationReconnectDockerTest#conversationTapIsHonouredBeforeDetectionLands"  # #778 #848 /): tapping Conversation while live detection is still null
   "com.pocketshell.app.tmux.AgentConversationReconnectDockerTest#agentOpensOnDefaultViewAndIsNotYankedMidSessionShellGetsNoConversationRow"  # #818 #815 #878 #807 //): an agent pane must OPEN on the user's
   "com.pocketshell.app.tmux.AgentConversationReconnectDockerTest#reconciledPresumedAgentWithDroppedRowReseedsConversationPlaceholderOnDevice"  # #874 #878 #894 #975 residual black-screen, conversation-source area — sibling of…
@@ -247,6 +248,9 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.tmux.ComposerUnsentBadgeContainmentProofTest"  # #1531 RC1: the docked-launcher UNSENT badge is present + fully within the window (containment, not assertIsDisplayed) on both the chip-cluster and conversation launchers, pending + failed states — a stuck send is SEEN, not silently dropped
   "com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#heldTerminalHidesQuickCommandBand_keepsComposerLauncher"  # #1672 the maintainer's Reconnecting/Attaching report: while the terminal is HELD the quick-command band (git status/tmux ls/…) + primary cluster are ABSENT (hidden, not disabled); the composer launcher stays present (#810)
   "com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#liveTerminalShowsRetainedPrimaryControlsWithoutGenericLiterals"  # #1672/#1754 Live returns only retained primary controls; generic command literals stay hard-deleted
+  "com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#issue2192_wedgeA_rawNotConnectedLiveLookingTerminal_launcherOpensEnterStaysGated"  # #2192 Wedge A: live-looking Terminal + raw not-Connected — launcher opens, Enter stays gated
+  "com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#issue2192_wedgeB_surfacePaneNullAfterReseed_launcherOpensEnterAbsent"  # #2192 Wedge B: live-looking Terminal + surfacePane null (folded to sessionLive=false) — launcher opens
+  "com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#issue2192_offlineOrReconnectingLiveLookingTerminal_launcherOpens"  # #2192 AC3: disconnected/reconnecting live-looking Terminal band — launcher opens, never a dead tap
   "com.pocketshell.app.conversation.ConversationShowAllJourneyTest"  # #1889 capped messages retain a lazy in-app full-text route
 
   "com.pocketshell.app.tmux.TmuxChromeConversationTogglePresentTest"  # #1320 #962 #975 #1057 the Terminal/Conversation TOGGLE-CLIP regression guard — the…


### PR DESCRIPTION
Closes #2192

Reviewer-approved and orchestrator-verified per the issue thread; this PR carries the already-committed, already-pushed fix through the required PR checks for merge.