### PR TITLE
fix(ui): classify unpublished host-CLI upgrades without blaming the cap (#2033)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/CliVersionMismatchBannerUpdateButtonTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/CliVersionMismatchBannerUpdateButtonTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -65,13 +66,13 @@ class CliVersionMismatchBannerUpdateButtonTest {
     // Derived from the PRODUCTION prompt builder so the banner copy (and its
     // embedded upgrade command) can never drift from the real one — issue #1492
     // widened that command to the global `--exclude-newer` cap override.
-    private val message =
-        PayloadVersionCheck.outdatedHostPrompt(
-            PayloadVersionCheck.Verdict.HostOutdated(
-                hostVersion = "0.4.14",
-                expectedVersion = "0.4.16",
-            ),
+    private val mismatchVerdict =
+        PayloadVersionCheck.Verdict.HostOutdated(
+            hostVersion = "0.4.14",
+            expectedVersion = "0.4.16",
         )
+
+    private val message = PayloadVersionCheck.outdatedHostPrompt(mismatchVerdict)
 
     @Test
     fun idleState_updateAndDismissPresentReachableNotClipped() {
@@ -109,6 +110,43 @@ class CliVersionMismatchBannerUpdateButtonTest {
     }
 
     @Test
+    fun unpublishedState_saysNotOnPypi_noFailingCommand_retryPresent() {
+        val unpublished = FolderListViewModel.CliVersionUpdateState.Failure(
+            message = "pocketshell 0.4.16 is not on PyPI yet (host still reports 0.4.14).",
+            kind = FolderListViewModel.CliVersionUpdateState.Failure.Kind.Unpublished,
+            offerRetry = true,
+        )
+        setBanner(unpublished, CliVersionBannerCopy.bannerMessage(mismatchVerdict, unpublished))
+
+        compose.onNodeWithText("not on PyPI", substring = true).assertIsDisplayed()
+        compose.onNodeWithText("uv tool install", substring = true).assertDoesNotExist()
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_ERROR_TAG).assertDoesNotExist()
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG)
+            .assertIsDisplayed().assertIsEnabled().assertHasClickAction()
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+            .assertIsDisplayed().assertIsEnabled().assertHasClickAction()
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_UPDATE_TAG)
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+        capture("issue-2033-banner-unpublished-retry-dismiss.png")
+    }
+
+    @Test
+    fun cappedState_hidesRetry_dismissPresent() {
+        val capped = FolderListViewModel.CliVersionUpdateState.Failure(
+            message = "The host installer is date-capped and could not resolve pocketshell 0.4.16.",
+            kind = FolderListViewModel.CliVersionUpdateState.Failure.Kind.Capped,
+            offerRetry = false,
+        )
+        setBanner(capped, CliVersionBannerCopy.bannerMessage(mismatchVerdict, capped))
+
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG).assertDoesNotExist()
+        compose.onNodeWithTag(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+            .assertIsDisplayed().assertIsEnabled().assertHasClickAction()
+        compose.assertNodeFullyWithinRoot(FOLDER_LIST_CLI_VERSION_DISMISS_TAG)
+        capture("issue-2033-banner-capped-dismiss-only.png")
+    }
+
+    @Test
     fun failureState_errorAndRetryDismissPresentReachableNotClipped() {
         setBanner(
             FolderListViewModel.CliVersionUpdateState.Failure(
@@ -134,7 +172,10 @@ class CliVersionMismatchBannerUpdateButtonTest {
 
     // --- helpers ------------------------------------------------------------
 
-    private fun setBanner(state: FolderListViewModel.CliVersionUpdateState) {
+    private fun setBanner(
+        state: FolderListViewModel.CliVersionUpdateState,
+        bannerMessage: String = message,
+    ) {
         compose.setContent {
             PocketShellTheme {
                 Box(
@@ -146,7 +187,7 @@ class CliVersionMismatchBannerUpdateButtonTest {
                     // non-displacing overlay pinned to the bottom edge with the
                     // same 12dp padding the production call site uses.
                     CliVersionMismatchBanner(
-                        message = message,
+                        message = bannerMessage,
                         updateState = state,
                         onUpdate = {},
                         onDismiss = {},

--- a/app/src/main/java/com/pocketshell/app/projects/CliVersionBannerCoordinator.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/CliVersionBannerCoordinator.kt
@@ -1,0 +1,101 @@
+package com.pocketshell.app.projects
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Issue #2033: persist-on-dismiss, payload-version observe gate, and
+ * classify-and-apply for the host-CLI mismatch banner.
+ *
+ * Lives outside [FolderListViewModel] so that file can stay at its
+ * file-size baseline. Prefs open lazily on first use (#1087 / #1292).
+ */
+internal class CliVersionBannerCoordinator(
+    private val expectedVersion: () -> String,
+    private val hostId: () -> Long?,
+    dismissStore: CliVersionBannerDismissStore,
+) {
+    private var dismissStore: CliVersionBannerDismissStore = dismissStore
+
+    private val _mismatch =
+        MutableStateFlow<PayloadVersionCheck.Verdict.HostOutdated?>(null)
+    val mismatch: StateFlow<PayloadVersionCheck.Verdict.HostOutdated?> =
+        _mismatch.asStateFlow()
+
+    private val _updateState =
+        MutableStateFlow<FolderListViewModel.CliVersionUpdateState>(
+            FolderListViewModel.CliVersionUpdateState.Idle,
+        )
+    val updateState: StateFlow<FolderListViewModel.CliVersionUpdateState> =
+        _updateState.asStateFlow()
+
+    fun setDismissStoreForTest(store: CliVersionBannerDismissStore) {
+        dismissStore = store
+    }
+
+    fun dismiss() {
+        dismissStore.persist(hostId(), _mismatch.value)
+        _mismatch.value = null
+        _updateState.value = FolderListViewModel.CliVersionUpdateState.Idle
+    }
+
+    fun setUpdateState(state: FolderListViewModel.CliVersionUpdateState) {
+        _updateState.value = state
+    }
+
+    fun clearAfterTrustedSuccess() {
+        _mismatch.value = null
+        _updateState.value = FolderListViewModel.CliVersionUpdateState.Idle
+    }
+
+    fun applyUpgradeOutcome(outcome: HostCliUpgradeOutcome.Verdict) {
+        _updateState.value = outcome.toUpdateFailure()
+    }
+
+    fun classifyAndApply(
+        requestedVersion: String,
+        resolvedVersion: String?,
+        exitCode: Int,
+        output: String,
+    ) {
+        applyUpgradeOutcome(
+            HostCliUpgradeOutcome.classify(
+                requestedVersion = requestedVersion,
+                resolvedVersion = resolvedVersion,
+                exitCode = exitCode,
+                output = output,
+            ),
+        )
+    }
+
+    fun observePayloadCliVersion(hostCliVersion: String?) {
+        if (hostCliVersion.isNullOrBlank()) return
+        when (val verdict = PayloadVersionCheck.evaluate(hostCliVersion, expectedVersion())) {
+            is PayloadVersionCheck.Verdict.HostOutdated -> {
+                _mismatch.value = dismissStore.takeIfNotDismissed(hostId(), verdict)
+            }
+            else -> _mismatch.value = null
+        }
+    }
+
+    /**
+     * After a fresh `tree get`, re-evaluate. A match (or dismissed triple)
+     * returns to Idle; a still-outdated host is classified from requested
+     * vs resolved + installer output — never guessed as a cap (#2033).
+     */
+    fun applyRecheck(hostCliVersion: String?, installerOutput: String) {
+        observePayloadCliVersion(hostCliVersion)
+        val mismatch = _mismatch.value
+        if (mismatch == null) {
+            _updateState.value = FolderListViewModel.CliVersionUpdateState.Idle
+        } else {
+            classifyAndApply(
+                requestedVersion = mismatch.expectedVersion.ifBlank { expectedVersion() },
+                resolvedVersion = mismatch.hostVersion,
+                exitCode = 0,
+                output = installerOutput,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/CliVersionBannerCopy.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/CliVersionBannerCopy.kt
@@ -1,0 +1,38 @@
+package com.pocketshell.app.projects
+
+/**
+ * User-facing copy for the host-CLI version-mismatch banner (issues #885 / #947
+ * / #2033).
+ *
+ * The Idle prompt still names the update command (the package may well be
+ * published). After an upgrade attempt, [bannerMessage] must describe the
+ * actual outcome — unpublished vs capped vs failed — and must not tell the
+ * user to run a command that cannot succeed.
+ */
+object CliVersionBannerCopy {
+
+    fun bannerMessage(
+        mismatch: PayloadVersionCheck.Verdict.HostOutdated,
+        updateState: FolderListViewModel.CliVersionUpdateState,
+    ): String {
+        val failure = updateState as? FolderListViewModel.CliVersionUpdateState.Failure
+        return when (failure?.kind) {
+            FolderListViewModel.CliVersionUpdateState.Failure.Kind.Unpublished ->
+                unpublishedMessage(mismatch)
+            FolderListViewModel.CliVersionUpdateState.Failure.Kind.Capped ->
+                cappedMessage(mismatch)
+            else -> PayloadVersionCheck.outdatedHostPrompt(mismatch)
+        }
+    }
+
+    fun unpublishedMessage(mismatch: PayloadVersionCheck.Verdict.HostOutdated): String =
+        "This host's pocketshell is ${mismatch.hostVersion}; the app expects " +
+            "${mismatch.expectedVersion}. pocketshell ${mismatch.expectedVersion} " +
+            "is not on PyPI yet, so this host cannot be updated to it. " +
+            "Wait for the package to publish, then tap Retry."
+
+    fun cappedMessage(mismatch: PayloadVersionCheck.Verdict.HostOutdated): String =
+        "This host's pocketshell is ${mismatch.hostVersion}; the app expects " +
+            "${mismatch.expectedVersion}. The host installer is date-capped and " +
+            "could not resolve pocketshell ${mismatch.expectedVersion}."
+}

--- a/app/src/main/java/com/pocketshell/app/projects/CliVersionBannerDismissStore.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/CliVersionBannerDismissStore.kt
@@ -1,0 +1,71 @@
+package com.pocketshell.app.projects
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Issue #2033: persist a dismiss of the host-CLI version-mismatch banner so
+ * the same unpublished (or otherwise unchanged) nag does not reappear on
+ * every launch.
+ *
+ * The key is `(hostId, hostVersion, expectedVersion)`. A later app bump or
+ * a host that actually upgraded produces a different key and the banner
+ * is allowed to return.
+ *
+ * Prefs are opened lazily on first use — never in the constructor — so a
+ * FolderListViewModel constructed on Main does not pay a disk read at
+ * inject time (#1087 / #1292).
+ */
+class CliVersionBannerDismissStore(
+    private val openPrefs: (() -> SharedPreferences)? = null,
+) {
+    private val memory = linkedSetOf<String>()
+
+    fun isDismissed(hostId: Long?, hostVersion: String, expectedVersion: String): Boolean {
+        val key = key(hostId, hostVersion, expectedVersion)
+        if (key in memory) return true
+        val persisted = runCatching { openPrefs?.invoke()?.getBoolean(key, false) == true }
+            .getOrDefault(false)
+        if (persisted) memory.add(key)
+        return persisted
+    }
+
+    fun dismiss(hostId: Long?, hostVersion: String, expectedVersion: String) {
+        val key = key(hostId, hostVersion, expectedVersion)
+        memory.add(key)
+        runCatching {
+            openPrefs?.invoke()?.edit()?.putBoolean(key, true)?.apply()
+        }
+    }
+
+    fun persist(
+        hostId: Long?,
+        mismatch: PayloadVersionCheck.Verdict.HostOutdated?,
+    ) {
+        if (mismatch != null) {
+            dismiss(hostId, mismatch.hostVersion, mismatch.expectedVersion)
+        }
+    }
+
+    fun takeIfNotDismissed(
+        hostId: Long?,
+        verdict: PayloadVersionCheck.Verdict.HostOutdated,
+    ): PayloadVersionCheck.Verdict.HostOutdated? =
+        if (isDismissed(hostId, verdict.hostVersion, verdict.expectedVersion)) null else verdict
+
+    companion object {
+        internal const val PREFS_NAME: String = "cli_version_banner_dismiss"
+
+        fun from(context: Context?): CliVersionBannerDismissStore {
+            val app = context?.applicationContext ?: return CliVersionBannerDismissStore()
+            return CliVersionBannerDismissStore(
+                openPrefs = {
+                    app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                },
+            )
+        }
+
+        internal fun key(hostId: Long?, hostVersion: String, expectedVersion: String): String =
+            "${hostId ?: "none"}|$hostVersion|$expectedVersion"
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -485,7 +485,7 @@ fun FolderListScreen(
         // `tree` payload reports a host CLI older than this app build expects.
         cliVersionMismatch?.let { mismatch ->
             CliVersionMismatchBanner(
-                message = PayloadVersionCheck.outdatedHostPrompt(mismatch),
+                message = CliVersionBannerCopy.bannerMessage(mismatch, cliVersionUpdateState),
                 updateState = cliVersionUpdateState,
                 onUpdate = viewModel::runHostPocketshellUpgrade,
                 onDismiss = viewModel::dismissCliVersionMismatch,
@@ -1523,10 +1523,12 @@ internal fun CliVersionMismatchBanner(
         // Issue #947: the upgrade failure line (installer stderr / timeout /
         // no-installer), shown above the action row so the user can read it and
         // then Retry or Dismiss — the spinner never sticks.
-        failure?.let { fail ->
+        // Issue #2033: Unpublished / Capped already rewrite the banner body, so
+        // repeating that copy in red is noise (and a second "not on PyPI" node).
+        if (failure?.kind == FolderListViewModel.CliVersionUpdateState.Failure.Kind.Failed) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = fail.message,
+                text = failure.message,
                 color = PocketShellColors.Red,
                 style = PocketShellType.bodyDense,
                 modifier = Modifier
@@ -1554,16 +1556,22 @@ internal fun CliVersionMismatchBanner(
                     style = PocketShellType.bodyDense,
                 )
             } else {
-                PocketShellButton(
-                    // Issue #947: a no-op upgrade re-raises a failure, so offer
-                    // "Retry" once the first attempt failed.
-                    text = if (failure != null) "Retry" else "Update",
-                    onClick = onUpdate,
-                    modifier = Modifier.testTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG),
-                    variant = ButtonVariant.Primary,
-                    compact = true,
-                )
-                Spacer(modifier = Modifier.width(8.dp))
+                // Issue #2033: Retry only where retrying can help (unpublished
+                // — wait for PyPI; failed — transient). A true date-cap will
+                // not change on Retry of the same already-uncapped command.
+                val showUpdate = failure == null || failure.offerRetry
+                if (showUpdate) {
+                    PocketShellButton(
+                        // Issue #947: a no-op upgrade re-raises a failure, so offer
+                        // "Retry" once the first attempt failed.
+                        text = if (failure != null) "Retry" else "Update",
+                        onClick = onUpdate,
+                        modifier = Modifier.testTag(FOLDER_LIST_CLI_VERSION_UPDATE_TAG),
+                        variant = ButtonVariant.Primary,
+                        compact = true,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
                 PocketShellButton(
                     text = "Dismiss",
                     onClick = onDismiss,

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -259,16 +259,20 @@ class FolderListViewModel internal constructor(
      * `null` on match, on a versionless payload (old CLI), or when the host is
      * NEWER (the app-behind case — see [PayloadVersionCheck.Verdict.AppOutdated]).
      */
-    private val _cliVersionMismatch: MutableStateFlow<PayloadVersionCheck.Verdict.HostOutdated?> =
-        MutableStateFlow(null)
+    private val cliVersionBanner = CliVersionBannerCoordinator(
+        expectedVersion = { expectedPocketshellVersion() },
+        hostId = { bound?.hostId },
+        dismissStore = CliVersionBannerDismissStore.from(applicationContext),
+    )
     val cliVersionMismatch: StateFlow<PayloadVersionCheck.Verdict.HostOutdated?> =
-        _cliVersionMismatch.asStateFlow()
+        cliVersionBanner.mismatch
 
-    /** Dismiss the passive CLI-version update prompt (issue #885). */
-    fun dismissCliVersionMismatch() {
-        _cliVersionMismatch.value = null
-        _cliVersionUpdateState.value = CliVersionUpdateState.Idle
-    }
+    @androidx.annotation.VisibleForTesting
+    internal fun setCliVersionBannerDismissStoreForTest(store: CliVersionBannerDismissStore) =
+        cliVersionBanner.setDismissStoreForTest(store)
+
+    /** Dismiss the passive CLI-version update prompt (issue #885 / #2033). */
+    fun dismissCliVersionMismatch() = cliVersionBanner.dismiss()
 
     /** Issue #1509: THE single session-tree setup coordinator (relocation + dedup, D22). */
     private val sessionTreeSetup = SessionTreeSetupCoordinator(notificationPermissionNeeded)
@@ -290,13 +294,17 @@ class FolderListViewModel internal constructor(
     public sealed interface CliVersionUpdateState {
         public data object Idle : CliVersionUpdateState
         public data object Running : CliVersionUpdateState
-        public data class Failure(val message: String) : CliVersionUpdateState
+        public data class Failure(
+            val message: String,
+            val kind: Kind = Kind.Failed,
+            val offerRetry: Boolean = true,
+        ) : CliVersionUpdateState {
+            public enum class Kind { Unpublished, Capped, Failed }
+        }
     }
 
-    private val _cliVersionUpdateState: MutableStateFlow<CliVersionUpdateState> =
-        MutableStateFlow(CliVersionUpdateState.Idle)
     val cliVersionUpdateState: StateFlow<CliVersionUpdateState> =
-        _cliVersionUpdateState.asStateFlow()
+        cliVersionBanner.updateState
 
     /**
      * Issue #947: the host-upgrade seam. Runs `pocketshell`'s installer upgrade
@@ -323,7 +331,7 @@ class FolderListViewModel internal constructor(
      * a double tap (a second call while one is in flight is ignored).
      */
     fun runHostPocketshellUpgrade() {
-        if (_cliVersionUpdateState.value is CliVersionUpdateState.Running) return
+        if (cliVersionBanner.updateState.value is CliVersionUpdateState.Running) return
         val params = bound
         if (params == null) {
             // Issue #1157: with NO bound host there is genuinely no "the host" to
@@ -331,12 +339,13 @@ class FolderListViewModel internal constructor(
             // host (see [observePayloadCliVersion]), so this is a defensive edge.
             // Do NOT claim a false connection failure ("Not connected — reconnect"),
             // which contradicts a connected tray/tree; say what is actually true.
-            _cliVersionUpdateState.value =
-                CliVersionUpdateState.Failure("No host is selected — reopen the host and try again.")
+            cliVersionBanner.setUpdateState(
+                CliVersionUpdateState.Failure("No host is selected — reopen the host and try again."),
+            )
             return
         }
         hostUpgradeJob?.cancel()
-        _cliVersionUpdateState.value = CliVersionUpdateState.Running
+        cliVersionBanner.setUpdateState(CliVersionUpdateState.Running)
         hostUpgradeJob = viewModelScope.launch {
             // Issue #1157: robustly (re)acquire a live session on demand rather than
             // dead-ending on a possibly-absent/expired warm lease. [acquireUpgradeSession]
@@ -347,22 +356,29 @@ class FolderListViewModel internal constructor(
             // that contradicted a connected tree + tray. Null ONLY when unreachable.
             val session = acquireUpgradeSession(params)
             if (session == null || bound != params) {
-                _cliVersionUpdateState.value =
+                cliVersionBanner.setUpdateState(
                     CliVersionUpdateState.Failure(
                         "Couldn't reach the host to run the update — reconnect and try again.",
-                    )
+                    ),
+                )
                 return@launch
             }
-            when (val result = hostPocketshellUpgrade.run(session)) {
+            when (val result = hostPocketshellUpgrade.run(session, expectedPocketshellVersion())) {
                 is HostPocketshellUpgrade.Result.Success -> {
                     // Re-check the host version from a fresh payload. A SUCCESSFUL
                     // upgrade should now report the matching version, clearing the
-                    // banner; a no-op upgrade (already-newest / capped) re-raises
-                    // a failure so the user isn't left thinking it worked.
-                    recheckHostVersionAfterUpgrade(params, session)
+                    // banner; a no-op upgrade (already-newest / unpublished) is
+                    // classified from requested vs resolved (#2033), not guessed
+                    // as a cap.
+                    recheckHostVersionAfterUpgrade(params, session, result.output)
                 }
                 is HostPocketshellUpgrade.Result.Failure -> {
-                    _cliVersionUpdateState.value = CliVersionUpdateState.Failure(result.message)
+                    cliVersionBanner.classifyAndApply(
+                        requestedVersion = expectedPocketshellVersion(),
+                        resolvedVersion = cliVersionBanner.mismatch.value?.hostVersion,
+                        exitCode = result.exitCode ?: 1,
+                        output = result.rawOutput.ifBlank { result.message },
+                    )
                 }
             }
         }
@@ -375,13 +391,16 @@ class FolderListViewModel internal constructor(
      * a still-outdated read (a silent no-op upgrade) surfaces a failure so the
      * spinner never sticks and the user can retry/dismiss.
      */
-    private suspend fun recheckHostVersionAfterUpgrade(params: BoundParams, session: SshSession) {
+    private suspend fun recheckHostVersionAfterUpgrade(
+        params: BoundParams,
+        session: SshSession,
+        installerOutput: String,
+    ) {
         val source = treeRemoteSource
         if (source == null) {
             // No durable source (some unit paths): trust the exit-0 success and
             // clear the banner so the spinner doesn't stick.
-            _cliVersionMismatch.value = null
-            _cliVersionUpdateState.value = CliVersionUpdateState.Idle
+            cliVersionBanner.clearAfterTrustedSuccess()
             return
         }
         // `getTree` is itself bounded (TreeRemoteSource.execTreeRpcBounded), but
@@ -396,41 +415,15 @@ class FolderListViewModel internal constructor(
             // empty payload). The upgrade exec itself exited 0, so trust that
             // success and clear the banner rather than raising a false
             // "still outdated" — and never leave the spinner stuck.
-            _cliVersionMismatch.value = null
-            _cliVersionUpdateState.value = CliVersionUpdateState.Idle
+            cliVersionBanner.clearAfterTrustedSuccess()
             return
         }
-        observePayloadCliVersion(treeResult.cliVersion)
-        if (_cliVersionMismatch.value == null) {
-            _cliVersionUpdateState.value = CliVersionUpdateState.Idle
-        } else {
-            // The re-read reported a CONCRETE version that is STILL older — the
-            // upgrade was a silent no-op (e.g. capped). Don't pretend it worked.
-            _cliVersionUpdateState.value = CliVersionUpdateState.Failure(
-                "Update ran but the host still reports " +
-                    "${_cliVersionMismatch.value?.hostVersion ?: "an older version"}. " +
-                    "It may be capped — try the command on the host.",
-            )
-        }
+        cliVersionBanner.applyRecheck(treeResult.cliVersion, installerOutput)
     }
 
-    /**
-     * Issue #885: feed a payload-carried [hostCliVersion] through
-     * [PayloadVersionCheck] and raise the passive update prompt when the host CLI
-     * is older than this app build. A null/blank/unparseable version or a NEWER
-     * host CLI is "no signal" and never raises a false prompt. Visible for test.
-     */
-    internal fun observePayloadCliVersion(hostCliVersion: String?) {
-        if (hostCliVersion.isNullOrBlank()) return
-        when (val verdict = PayloadVersionCheck.evaluate(hostCliVersion, expectedPocketshellVersion())) {
-            is PayloadVersionCheck.Verdict.HostOutdated -> _cliVersionMismatch.value = verdict
-            else -> {
-                // Match / AppOutdated: clear any stale prompt (e.g. the host was
-                // updated since the last open).
-                _cliVersionMismatch.value = null
-            }
-        }
-    }
+    /** Issue #885: raise the passive update prompt from a payload-carried version. */
+    internal fun observePayloadCliVersion(hostCliVersion: String?) =
+        cliVersionBanner.observePayloadCliVersion(hostCliVersion)
 
     /**
      * The `pocketshell` version this app build expects on the host, via

--- a/app/src/main/java/com/pocketshell/app/projects/HostCliUpgradeOutcome.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostCliUpgradeOutcome.kt
@@ -1,0 +1,172 @@
+package com.pocketshell.app.projects
+
+/**
+ * Issue #2033: classify a host-CLI upgrade attempt from the **actual**
+ * installer signal — requested version vs resolved version, plus the
+ * installer output — instead of guessing "it may be capped".
+ *
+ * The three outcomes the banner must distinguish:
+ *
+ *  - [Kind.Unpublished] — the installer resolved something older than
+ *    requested (or said the requested version does not exist). The
+ *    package is not on the index the host can see.
+ *  - [Kind.Capped] — the installer output names a date / `exclude-newer`
+ *    cap. This is independent of the `--exclude-newer 2099-12-31`
+ *    override we already pass; if that override worked, this kind is
+ *    not selected.
+ *  - [Kind.Failed] — any other non-success (network, no installer, …).
+ *
+ * [Kind.Success] is the matching-version case so callers can share one
+ * function; the banner never shows it.
+ */
+object HostCliUpgradeOutcome {
+
+    enum class Kind { Success, Unpublished, Capped, Failed }
+
+    data class Verdict(
+        val kind: Kind,
+        val message: String,
+        val offerRetry: Boolean,
+        val requestedVersion: String,
+        val resolvedVersion: String?,
+    ) {
+        val failureKind: FolderListViewModel.CliVersionUpdateState.Failure.Kind
+            get() = when (kind) {
+                Kind.Unpublished ->
+                    FolderListViewModel.CliVersionUpdateState.Failure.Kind.Unpublished
+                Kind.Capped ->
+                    FolderListViewModel.CliVersionUpdateState.Failure.Kind.Capped
+                Kind.Failed, Kind.Success ->
+                    FolderListViewModel.CliVersionUpdateState.Failure.Kind.Failed
+            }
+
+        fun toUpdateFailure(): FolderListViewModel.CliVersionUpdateState.Failure =
+            FolderListViewModel.CliVersionUpdateState.Failure(
+                message = message,
+                kind = failureKind,
+                offerRetry = offerRetry,
+            )
+    }
+
+    fun classify(
+        requestedVersion: String,
+        resolvedVersion: String?,
+        exitCode: Int,
+        output: String,
+    ): Verdict {
+        val requested = requestedVersion.trim()
+        val resolved = resolvedVersion?.trim()?.takeIf { it.isNotEmpty() }
+        val combined = output
+
+        // Cap signal first: only when the installer itself named a date cap.
+        // "Nothing to upgrade" is NOT a cap — that is what uv/pipx/pip print
+        // when the newest published version is already installed (the
+        // unpublished-N case this issue exists to stop misdiagnosing).
+        if (looksLikeCapped(combined)) {
+            return Verdict(
+                kind = Kind.Capped,
+                message = cappedMessage(requested, resolved),
+                offerRetry = false,
+                requestedVersion = requested,
+                resolvedVersion = resolved,
+            )
+        }
+        if (looksLikeUnpublished(combined, requested)) {
+            return unpublished(requested, resolved)
+        }
+        if (exitCode == 0) {
+            if (resolved != null && requested.isNotEmpty()) {
+                when (PayloadVersionCheck.evaluate(resolved, requested)) {
+                    is PayloadVersionCheck.Verdict.HostOutdated ->
+                        return unpublished(requested, resolved)
+                    else -> { /* resolved matches or is newer — success */ }
+                }
+            }
+            return Verdict(
+                kind = Kind.Success,
+                message = "",
+                offerRetry = false,
+                requestedVersion = requested,
+                resolvedVersion = resolved,
+            )
+        }
+        return Verdict(
+            kind = Kind.Failed,
+            message = failedMessage(exitCode, combined),
+            offerRetry = true,
+            requestedVersion = requested,
+            resolvedVersion = resolved,
+        )
+    }
+
+    internal fun looksLikeCapped(output: String): Boolean {
+        if (output.isBlank()) return false
+        val lower = output.lowercase()
+        return CAP_MARKERS.any { lower.contains(it) }
+    }
+
+    internal fun looksLikeUnpublished(output: String, requestedVersion: String): Boolean {
+        if (output.isBlank()) return false
+        val lower = output.lowercase()
+        if (UNPUBLISHED_MARKERS.any { lower.contains(it) }) return true
+        val requested = requestedVersion.trim()
+        if (requested.isEmpty()) return false
+        // uv: "because there is no version of pocketshell==0.4.40"
+        // pip: "no matching distribution found for pocketshell==0.4.40"
+        return lower.contains("no version") && lower.contains(requested.lowercase())
+    }
+
+    private fun unpublished(requested: String, resolved: String?): Verdict =
+        Verdict(
+            kind = Kind.Unpublished,
+            message = unpublishedMessage(requested, resolved),
+            offerRetry = true,
+            requestedVersion = requested,
+            resolvedVersion = resolved,
+        )
+
+    internal fun unpublishedMessage(requested: String, resolved: String?): String {
+        val resolvedBit = resolved?.takeIf { it.isNotBlank() }?.let { " (host still reports $it)" }.orEmpty()
+        return "pocketshell $requested is not on PyPI yet$resolvedBit. " +
+            "The in-app update cannot install it until the package is published."
+    }
+
+    internal fun cappedMessage(requested: String, resolved: String?): String {
+        val resolvedBit = resolved?.takeIf { it.isNotBlank() }?.let { " The host still reports $it." }.orEmpty()
+        return "The host installer is date-capped and could not resolve " +
+            "pocketshell $requested.$resolvedBit"
+    }
+
+    private fun failedMessage(exitCode: Int, output: String): String {
+        val detail = output.lines().filter { it.isNotBlank() }.takeLast(MAX_ERROR_LINES)
+            .joinToString("\n")
+            .take(MAX_ERROR_CHARS)
+        return if (detail.isBlank()) {
+            "Update failed (exit $exitCode)."
+        } else {
+            "Update failed (exit $exitCode):\n$detail"
+        }
+    }
+
+    private val CAP_MARKERS: List<String> = listOf(
+        "exclude-newer",
+        "excluded because of",
+        "because of the exclude",
+        "date-capped",
+        "date cap",
+    )
+
+    private val UNPUBLISHED_MARKERS: List<String> = listOf(
+        "not found in the registry",
+        "could not find a version that satisfies",
+        "no matching distribution found",
+        "no packages found matching",
+        "could not find a version",
+        "because there is no version",
+        "is not available on",
+        "404 client error",
+    )
+
+    private const val MAX_ERROR_LINES: Int = 6
+    private const val MAX_ERROR_CHARS: Int = 600
+}

--- a/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
@@ -59,15 +59,20 @@ public class HostPocketshellUpgrade {
 
     /** The outcome of a [run] call. */
     public sealed interface Result {
-        /** The upgrade command exited 0. */
-        public data object Success : Result
+        /** The upgrade command exited 0. [output] is installer stdout+stderr. */
+        public data class Success(val output: String = "") : Result
 
         /**
          * The upgrade did not succeed. [message] is a short, user-facing reason
          * built from the installer stderr/stdout (or a timeout / no-installer
-         * note), suitable for the banner's failure line.
+         * note), suitable for the banner's failure line. [rawOutput] / [exitCode]
+         * are the installer signal [HostCliUpgradeOutcome] classifies (#2033).
          */
-        public data class Failure(val message: String) : Result
+        public data class Failure(
+            val message: String,
+            val exitCode: Int? = null,
+            val rawOutput: String = "",
+        ) : Result
     }
 
     /**
@@ -75,10 +80,14 @@ public class HostPocketshellUpgrade {
      * throws except [CancellationException]; any transport/parse failure
      * degrades to a [Result.Failure] so the banner always leaves the running
      * state (no stuck spinner — #939).
+     *
+     * When [requestedVersion] is a dotted version the command pins
+     * `pocketshell==<requested>` so an unpublished release fails loudly
+     * instead of silently installing N−1 (#2033).
      */
-    public suspend fun run(session: SshSession): Result {
+    public suspend fun run(session: SshSession, requestedVersion: String = ""): Result {
         val result = try {
-            session.execBounded(UPGRADE_COMMAND)
+            session.execBounded(upgradeCommand(requestedVersion))
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
@@ -87,14 +96,21 @@ public class HostPocketshellUpgrade {
             ?: return Result.Failure(
                 "Update timed out after ${upgradeTimeoutMs / 1000}s. Try again, or run the command on the host.",
             )
-        if (result.exitCode == 0) return Result.Success
+        val output = "${result.stdout}\n${result.stderr}"
+        if (result.exitCode == 0) return Result.Success(output = output)
         if (result.exitCode == NO_INSTALLER_EXIT) {
             return Result.Failure(
-                "No uv / pipx / pip found on the host to upgrade pocketshell. " +
+                message = "No uv / pipx / pip found on the host to upgrade pocketshell. " +
                     "Install one, or run the command on the host.",
+                exitCode = result.exitCode,
+                rawOutput = output,
             )
         }
-        return Result.Failure(formatFailure(result))
+        return Result.Failure(
+            message = formatFailure(result),
+            exitCode = result.exitCode,
+            rawOutput = output,
+        )
     }
 
     private fun formatFailure(result: ExecResult): String {
@@ -146,30 +162,61 @@ public class HostPocketshellUpgrade {
          * (the global [UV_EXCLUDE_NEWER_FLAG], issue #779 widened by #1492) so the
          * upgrade is never silently capped by the host's global uv cutoff — for
          * pocketshell OR any of its pinned siblings.
+         *
+         * When [requestedVersion] is a dotted version, every installer arm pins
+         * `pocketshell==<requested>` so an unpublished release fails with a
+         * not-found signal instead of silently installing N−1 (#2033). The
+         * no-version form is the unpinned `--upgrade` used by existing flag
+         * tests and as the fallback when the app version cannot be read.
          */
-        internal val UPGRADE_COMMAND: String = buildString {
-            // PATH augmentation: same per-user bin dirs PocketshellCommand prepends
-            // so uv/pipx/pip shims under ~/.local/bin etc. are discoverable on a
-            // non-interactive exec.
-            append("export PATH=\"\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/.pixi/bin:")
-            append("\$HOME/bin:/usr/local/bin:\$PATH\"; ")
-            // uv: only if uv exists AND its tool list actually owns pocketshell —
-            // otherwise a host with uv-for-something-else but pipx-owned
-            // pocketshell would wrongly try uv.
-            append("if command -v uv >/dev/null 2>&1 && ")
-            append("uv tool list 2>/dev/null | grep -qi '^pocketshell\\b'; then ")
-            append("exec uv tool install --refresh --upgrade ")
-            append("$UV_EXCLUDE_NEWER_FLAG pocketshell; ")
-            // pipx next.
-            append("elif command -v pipx >/dev/null 2>&1; then ")
-            append("exec pipx upgrade pocketshell; ")
-            // pip / pip3 last.
-            append("elif command -v pip >/dev/null 2>&1; then ")
-            append("exec pip install -U pocketshell; ")
-            append("elif command -v pip3 >/dev/null 2>&1; then ")
-            append("exec pip3 install -U pocketshell; ")
-            // No installer at all.
-            append("else exit 127; fi")
+        internal fun upgradeCommand(requestedVersion: String = ""): String {
+            val spec = pinnedSpec(requestedVersion)
+            val pipxArm = if (requestedVersion.isBlank()) {
+                "exec pipx upgrade pocketshell; "
+            } else {
+                "exec pipx install --force $spec; "
+            }
+            return buildString {
+                // PATH augmentation: same per-user bin dirs PocketshellCommand prepends
+                // so uv/pipx/pip shims under ~/.local/bin etc. are discoverable on a
+                // non-interactive exec.
+                append("export PATH=\"\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/.pixi/bin:")
+                append("\$HOME/bin:/usr/local/bin:\$PATH\"; ")
+                // uv: only if uv exists AND its tool list actually owns pocketshell —
+                // otherwise a host with uv-for-something-else but pipx-owned
+                // pocketshell would wrongly try uv.
+                append("if command -v uv >/dev/null 2>&1 && ")
+                append("uv tool list 2>/dev/null | grep -qi '^pocketshell\\b'; then ")
+                append("exec uv tool install --refresh --upgrade ")
+                append("$UV_EXCLUDE_NEWER_FLAG $spec; ")
+                // pipx next.
+                append("elif command -v pipx >/dev/null 2>&1; then ")
+                append(pipxArm)
+                // pip / pip3 last.
+                append("elif command -v pip >/dev/null 2>&1; then ")
+                append("exec pip install -U $spec; ")
+                append("elif command -v pip3 >/dev/null 2>&1; then ")
+                append("exec pip3 install -U $spec; ")
+                // No installer at all.
+                append("else exit 127; fi")
+            }
+        }
+
+        /**
+         * Unpinned form (no `==version`). Kept so existing flag-coverage tests
+         * and [UPGRADE_COMMAND] readers keep working; production passes the
+         * app version through [upgradeCommand].
+         */
+        internal val UPGRADE_COMMAND: String = upgradeCommand("")
+
+        private fun pinnedSpec(requestedVersion: String): String {
+            val version = requestedVersion.trim()
+            if (version.isEmpty()) return "pocketshell"
+            // versionName is dotted-numeric from our own APK; still quote so a
+            // surprising character cannot break the /bin/sh -c wrapping.
+            val safe = version.filter { it.isLetterOrDigit() || it == '.' || it == '-' || it == '_' }
+            if (safe.isEmpty()) return "pocketshell"
+            return "pocketshell==$safe"
         }
     }
 }

--- a/app/src/test/java/com/pocketshell/app/projects/CliVersionBannerCopyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/CliVersionBannerCopyTest.kt
@@ -1,0 +1,80 @@
+package com.pocketshell.app.projects
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2033 — the composed banner text must name the real outcome and
+ * must not quote a command that will fail while the package is unpublished.
+ *
+ * G6 mutation: if [CliVersionBannerCopy.unpublishedMessage] appended
+ * [PayloadVersionCheck.UPDATE_COMMAND], `unpublished_doesNotQuoteFailingCommand`
+ * reddens. If Idle copy dropped the command, `idle_stillNamesUpdateCommand`
+ * reddens (we still want the command before an attempt).
+ */
+class CliVersionBannerCopyTest {
+
+    private val mismatch = PayloadVersionCheck.Verdict.HostOutdated(
+        hostVersion = "0.4.39",
+        expectedVersion = "0.4.40",
+    )
+
+    @Test
+    fun idle_stillNamesUpdateCommand() {
+        val text = CliVersionBannerCopy.bannerMessage(
+            mismatch,
+            FolderListViewModel.CliVersionUpdateState.Idle,
+        )
+        assertTrue(text.contains("0.4.39"))
+        assertTrue(text.contains("0.4.40"))
+        assertTrue(text.contains(PayloadVersionCheck.UPDATE_COMMAND))
+    }
+
+    @Test
+    fun unpublished_doesNotQuoteFailingCommand() {
+        val text = CliVersionBannerCopy.bannerMessage(
+            mismatch,
+            FolderListViewModel.CliVersionUpdateState.Failure(
+                message = "pocketshell 0.4.40 is not on PyPI yet",
+                kind = FolderListViewModel.CliVersionUpdateState.Failure.Kind.Unpublished,
+                offerRetry = true,
+            ),
+        )
+        assertTrue(text.contains("not on PyPI"))
+        assertTrue(text.contains("0.4.40"))
+        assertFalse(text.contains("uv tool install"))
+        assertFalse(text.contains("pipx upgrade"))
+        assertFalse(text.contains("pip install"))
+        assertFalse(text.contains("capped", ignoreCase = true))
+    }
+
+    @Test
+    fun capped_doesNotQuoteFailingCommand() {
+        val text = CliVersionBannerCopy.bannerMessage(
+            mismatch,
+            FolderListViewModel.CliVersionUpdateState.Failure(
+                message = "date-capped",
+                kind = FolderListViewModel.CliVersionUpdateState.Failure.Kind.Capped,
+                offerRetry = false,
+            ),
+        )
+        assertTrue(text.contains("date-capped") || text.contains("capped"))
+        assertFalse(text.contains("uv tool install"))
+        assertFalse(text.contains("pipx upgrade"))
+        assertFalse(text.contains("pip install"))
+    }
+
+    @Test
+    fun failed_keepsTheManualCommand() {
+        val text = CliVersionBannerCopy.bannerMessage(
+            mismatch,
+            FolderListViewModel.CliVersionUpdateState.Failure(
+                message = "Update failed (exit 1):\nerror: network unreachable",
+                kind = FolderListViewModel.CliVersionUpdateState.Failure.Kind.Failed,
+                offerRetry = true,
+            ),
+        )
+        assertTrue(text.contains(PayloadVersionCheck.UPDATE_COMMAND))
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/CliVersionBannerDismissStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/CliVersionBannerDismissStoreTest.kt
@@ -1,0 +1,68 @@
+package com.pocketshell.app.projects
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #2033 — dismiss of the host-CLI banner must survive process death
+ * until the (host, hostVersion, expectedVersion) triple changes.
+ *
+ * G6 mutation: if [CliVersionBannerDismissStore.dismiss] wrote only the
+ * in-memory set and skipped prefs, `survivesNewStoreInstance` reddens.
+ * If the key ignored expectedVersion, `differentExpectedVersion_isNotDismissed`
+ * reddens.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class CliVersionBannerDismissStoreTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences(CliVersionBannerDismissStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+    }
+
+    @Test
+    fun survivesNewStoreInstance() {
+        val first = CliVersionBannerDismissStore.from(context)
+        assertFalse(first.isDismissed(hostId = 42L, hostVersion = "0.4.39", expectedVersion = "0.4.40"))
+        first.dismiss(hostId = 42L, hostVersion = "0.4.39", expectedVersion = "0.4.40")
+
+        val second = CliVersionBannerDismissStore.from(context)
+        assertTrue(
+            "the same unpublished triple must stay dismissed across a new store " +
+                "(process death / next launch)",
+            second.isDismissed(hostId = 42L, hostVersion = "0.4.39", expectedVersion = "0.4.40"),
+        )
+    }
+
+    @Test
+    fun differentExpectedVersion_isNotDismissed() {
+        val store = CliVersionBannerDismissStore.from(context)
+        store.dismiss(hostId = 42L, hostVersion = "0.4.39", expectedVersion = "0.4.40")
+        assertFalse(
+            "an app bump (new expected version) must re-raise the banner",
+            store.isDismissed(hostId = 42L, hostVersion = "0.4.39", expectedVersion = "0.4.41"),
+        )
+    }
+
+    @Test
+    fun differentHostVersion_isNotDismissed() {
+        val store = CliVersionBannerDismissStore.from(context)
+        store.dismiss(hostId = 42L, hostVersion = "0.4.39", expectedVersion = "0.4.40")
+        assertFalse(
+            "a host that actually upgraded must re-raise if it is still behind",
+            store.isDismissed(hostId = 42L, hostVersion = "0.4.40", expectedVersion = "0.4.41"),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelHostUpgradeTest.kt
@@ -125,14 +125,161 @@ class FolderListViewModelHostUpgradeTest {
             "a failing upgrade must end in Failure, not a stuck spinner — was $state",
             state is FolderListViewModel.CliVersionUpdateState.Failure,
         )
+        val failure = state as FolderListViewModel.CliVersionUpdateState.Failure
         assertTrue(
             "the failure message must surface the installer stderr — was $state",
-            (state as FolderListViewModel.CliVersionUpdateState.Failure).message.contains("network unreachable"),
+            failure.message.contains("network unreachable"),
         )
+        assertEquals(
+            FolderListViewModel.CliVersionUpdateState.Failure.Kind.Failed,
+            failure.kind,
+        )
+        assertTrue("a transient installer error must keep Retry", failure.offerRetry)
         assertTrue(
             "the mismatch banner must stay up so the user can retry/dismiss",
             vm.cliVersionMismatch.value != null,
         )
+    }
+
+    @Test
+    fun update_appAtN_pypiAtNMinus1_doesNotClaimCapOrOfferFailingCommand() = runTest {
+        // Issue #2033 reproduce-first (G10): the exact on-device state.
+        // App is 0.4.40; the host (and PyPI) still have 0.4.39. The in-app
+        // unpinned `--upgrade` exits 0 ("Nothing to upgrade") because 0.4.40
+        // is unpublished — Retry of the same command cannot install it, and
+        // `--exclude-newer 2099-12-31` already defeated the cap. Current
+        // main blames the cap and tells the user to run that failing command.
+        val session = UpgradableSession(
+            initialVersion = "0.4.39",
+            upgradedVersion = "0.4.39",
+            upgradeResult = ExecResult("Nothing to upgrade", "", 0),
+        )
+        val vm = newViewModel(session, expectedVersion = "0.4.40")
+        bind(vm)
+        advanceUntilIdle()
+        assertEquals("0.4.39", vm.cliVersionMismatch.value?.hostVersion)
+        assertEquals("0.4.40", vm.cliVersionMismatch.value?.expectedVersion)
+
+        vm.runHostPocketshellUpgrade()
+        advanceUntilIdle()
+
+        val state = vm.cliVersionUpdateState.value
+        assertTrue(
+            "the unpublished N vs N−1 upgrade must end in Failure — was $state",
+            state is FolderListViewModel.CliVersionUpdateState.Failure,
+        )
+        val failure = state as FolderListViewModel.CliVersionUpdateState.Failure
+        val banner = CliVersionBannerCopy.bannerMessage(
+            mismatch = vm.cliVersionMismatch.value!!,
+            updateState = failure,
+        )
+        assertFalse(
+            "app=0.4.40 / PyPI=0.4.39 must NOT blame the exclude-newer cap " +
+                "(the command already passes --exclude-newer 2099-12-31) — " +
+                "failure=${failure.message} banner=$banner",
+            failure.message.contains("capped", ignoreCase = true) ||
+                banner.contains("capped", ignoreCase = true),
+        )
+        assertTrue(
+            "must say the newer package is not published yet — " +
+                "failure=${failure.message} banner=$banner",
+            banner.contains("not on PyPI") || failure.message.contains("not on PyPI"),
+        )
+        assertFalse(
+            "must not tell the user to run uv/pipx/pip — that command will fail " +
+                "while 0.4.40 is unpublished — banner=$banner",
+            banner.contains("uv tool install") ||
+                banner.contains("pipx upgrade") ||
+                banner.contains("pip install"),
+        )
+        assertEquals(
+            "resolved 0.4.39 vs requested 0.4.40 is Unpublished, not a guess",
+            FolderListViewModel.CliVersionUpdateState.Failure.Kind.Unpublished,
+            failure.kind,
+        )
+        assertTrue(
+            "Retry can help once PyPI publishes — offer it",
+            failure.offerRetry,
+        )
+    }
+
+    @Test
+    fun dismiss_unpublishedTriple_survivesNewViewModel() = runTest {
+        // Issue #2033: dismissing the unpublished nag must not re-raise on
+        // the next launch while host+app versions are unchanged.
+        val store = CliVersionBannerDismissStore()
+        val session = UpgradableSession(
+            initialVersion = "0.4.39",
+            upgradedVersion = "0.4.39",
+            upgradeResult = ExecResult("Nothing to upgrade", "", 0),
+        )
+        val first = newViewModel(session, expectedVersion = "0.4.40", dismissStore = store)
+        bind(first)
+        advanceUntilIdle()
+        assertTrue(first.cliVersionMismatch.value != null)
+        first.dismissCliVersionMismatch()
+        assertNull(first.cliVersionMismatch.value)
+
+        val second = newViewModel(session, expectedVersion = "0.4.40", dismissStore = store)
+        bind(second)
+        advanceUntilIdle()
+        assertNull(
+            "the same unpublished triple must stay dismissed on a new VM / launch",
+            second.cliVersionMismatch.value,
+        )
+    }
+
+    @Test
+    fun dismiss_newExpectedVersion_reRaises() = runTest {
+        val store = CliVersionBannerDismissStore()
+        val session = UpgradableSession(
+            initialVersion = "0.4.39",
+            upgradedVersion = "0.4.39",
+            upgradeResult = ExecResult("Nothing to upgrade", "", 0),
+        )
+        val first = newViewModel(session, expectedVersion = "0.4.40", dismissStore = store)
+        bind(first)
+        advanceUntilIdle()
+        first.dismissCliVersionMismatch()
+
+        val second = newViewModel(session, expectedVersion = "0.4.41", dismissStore = store)
+        bind(second)
+        advanceUntilIdle()
+        assertTrue(
+            "an app bump must re-raise the banner even if the previous triple was dismissed",
+            second.cliVersionMismatch.value != null,
+        )
+        assertEquals("0.4.41", second.cliVersionMismatch.value?.expectedVersion)
+    }
+
+    @Test
+    fun update_excludeNewerOutput_isCapped_hidesRetry() = runTest {
+        val session = UpgradableSession(
+            initialVersion = "0.4.39",
+            upgradedVersion = "0.4.39",
+            upgradeResult = ExecResult(
+                "",
+                "No solution found because exclude-newer is set to 2026-07-05",
+                1,
+            ),
+        )
+        val vm = newViewModel(session, expectedVersion = "0.4.40")
+        bind(vm)
+        advanceUntilIdle()
+
+        vm.runHostPocketshellUpgrade()
+        advanceUntilIdle()
+
+        val state = vm.cliVersionUpdateState.value
+        assertTrue(state is FolderListViewModel.CliVersionUpdateState.Failure)
+        val failure = state as FolderListViewModel.CliVersionUpdateState.Failure
+        assertEquals(
+            FolderListViewModel.CliVersionUpdateState.Failure.Kind.Capped,
+            failure.kind,
+        )
+        assertFalse("Retry cannot help a remaining date cap", failure.offerRetry)
+        val banner = CliVersionBannerCopy.bannerMessage(vm.cliVersionMismatch.value!!, failure)
+        assertFalse(banner.contains("uv tool install"))
     }
 
     @Test
@@ -213,6 +360,19 @@ class FolderListViewModelHostUpgradeTest {
         assertTrue("must fall back to pipx", cmd.contains("pipx upgrade pocketshell"))
         assertTrue("must fall back to pip", cmd.contains("pip install -U pocketshell"))
         assertTrue("must exit 127 when no installer is found", cmd.contains("exit 127"))
+
+        val pinned = HostPocketshellUpgrade.upgradeCommand("0.4.40")
+        assertTrue(
+            "pinned uv arm must request pocketshell==0.4.40 so unpublished fails loudly",
+            pinned.contains("pocketshell==0.4.40"),
+        )
+        assertTrue(pinned.contains("--exclude-newer 2099-12-31"))
+        assertTrue(pinned.contains("--refresh"))
+        assertTrue(
+            "pinned pipx arm must force-install the requested spec (upgrade cannot pin)",
+            pinned.contains("pipx install --force pocketshell==0.4.40"),
+        )
+        assertTrue(pinned.contains("pip install -U pocketshell==0.4.40"))
     }
 
     // --- Issue #1157: no false "Not connected" while the host is connected ---
@@ -455,6 +615,7 @@ class FolderListViewModelHostUpgradeTest {
     private fun TestScope.newViewModel(
         session: SshSession,
         expectedVersion: String,
+        dismissStore: CliVersionBannerDismissStore? = null,
     ): FolderListViewModel {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         Dispatchers.setMain(dispatcher)
@@ -482,6 +643,9 @@ class FolderListViewModelHostUpgradeTest {
             it.setHostPocketshellUpgradeForTest(
                 HostPocketshellUpgrade().apply { execDispatcher = dispatcher },
             )
+            if (dismissStore != null) {
+                it.setCliVersionBannerDismissStoreForTest(dismissStore)
+            }
             it.setProcessStartedForTest(true)
             viewModelStore.put("FolderListViewModel-${nextViewModelKey++}", it)
         }
@@ -517,7 +681,9 @@ class FolderListViewModelHostUpgradeTest {
         override suspend fun exec(command: String): ExecResult {
             return when {
                 // The upgrade probe-and-run command (issue #947).
-                command.contains("pipx upgrade pocketshell") -> {
+                command.contains("pipx upgrade pocketshell") ||
+                    command.contains("pipx install --force") ||
+                    command.contains("uv tool list") -> {
                     upgradeRan = true
                     if (wedgeUpgrade) {
                         kotlinx.coroutines.awaitCancellation()

--- a/app/src/test/java/com/pocketshell/app/projects/HostCliUpgradeOutcomeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostCliUpgradeOutcomeTest.kt
@@ -1,0 +1,170 @@
+package com.pocketshell.app.projects
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2033 — classify a host-CLI upgrade from requested vs resolved +
+ * the installer output. Class coverage for the three installer paths the
+ * banner quotes (`uv`, `pipx`, `pip`).
+ *
+ * G6 mutations (each must redden exactly the named assertion):
+ *  - Treat "Nothing to upgrade" as Capped → unpublished-from-resolved reddens.
+ *  - Drop the pip "No matching distribution" marker → pip unpublished reddens.
+ *  - Drop the uv "no version of" marker → uv unpublished reddens.
+ *  - Drop the pipx "no packages found matching" marker → pipx unpublished reddens.
+ *  - Ignore `exclude-newer` in output → capped reddens.
+ *  - Offer Retry on Capped → offerRetry assertion reddens.
+ */
+class HostCliUpgradeOutcomeTest {
+
+    @Test
+    fun exitZeroResolvedOlder_isUnpublished_notCapped() {
+        // The exact reported state: `--upgrade` exits 0, host still on N−1,
+        // output is uv's "Nothing to upgrade". The command already passed
+        // `--exclude-newer 2099-12-31`, so this is unpublished, not a cap.
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.39",
+            exitCode = 0,
+            output = "Nothing to upgrade",
+        )
+        assertEquals(HostCliUpgradeOutcome.Kind.Unpublished, verdict.kind)
+        assertTrue(verdict.offerRetry)
+        assertTrue(verdict.message.contains("not on PyPI"))
+        assertFalse(verdict.message.contains("capped", ignoreCase = true))
+        assertFalse(verdict.message.contains("uv tool install"))
+        assertFalse(verdict.message.contains("pipx"))
+        assertFalse(verdict.message.contains("pip install"))
+    }
+
+    @Test
+    fun uv_noVersionOfRequested_isUnpublished() {
+        val output = """
+            error: Because there is no version of pocketshell==0.4.40 and you
+            require pocketshell==0.4.40, we can conclude that your requirements
+            are unsatisfiable.
+        """.trimIndent()
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.39",
+            exitCode = 1,
+            output = output,
+        )
+        assertEquals(
+            "uv not-found for pocketshell==0.4.40 must be Unpublished — $verdict",
+            HostCliUpgradeOutcome.Kind.Unpublished,
+            verdict.kind,
+        )
+        assertTrue(verdict.offerRetry)
+    }
+
+    @Test
+    fun uv_notFoundInRegistry_isUnpublished() {
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.39",
+            exitCode = 1,
+            output = "error: Package `pocketshell` was not found in the registry",
+        )
+        assertEquals(HostCliUpgradeOutcome.Kind.Unpublished, verdict.kind)
+    }
+
+    @Test
+    fun pip_noMatchingDistribution_isUnpublished() {
+        val output = """
+            ERROR: Could not find a version that satisfies the requirement pocketshell==0.4.40 (from versions: 0.4.39)
+            ERROR: No matching distribution found for pocketshell==0.4.40
+        """.trimIndent()
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.39",
+            exitCode = 1,
+            output = output,
+        )
+        assertEquals(
+            "pip not-found for pocketshell==0.4.40 must be Unpublished — $verdict",
+            HostCliUpgradeOutcome.Kind.Unpublished,
+            verdict.kind,
+        )
+        assertTrue(verdict.offerRetry)
+        assertFalse(verdict.message.contains("capped", ignoreCase = true))
+    }
+
+    @Test
+    fun pipx_noPackagesFoundMatching_isUnpublished() {
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.39",
+            exitCode = 1,
+            output = "No packages found matching specified spec pocketshell==0.4.40",
+        )
+        assertEquals(
+            "pipx not-found for pocketshell==0.4.40 must be Unpublished — $verdict",
+            HostCliUpgradeOutcome.Kind.Unpublished,
+            verdict.kind,
+        )
+        assertTrue(verdict.offerRetry)
+    }
+
+    @Test
+    fun excludeNewerInOutput_isCapped_noRetry() {
+        val output = """
+            No solution found when resolving dependencies:
+            Because exclude-newer is set to 2026-07-05, pocketshell==0.4.40
+            is not a candidate.
+        """.trimIndent()
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.39",
+            exitCode = 1,
+            output = output,
+        )
+        assertEquals(HostCliUpgradeOutcome.Kind.Capped, verdict.kind)
+        assertFalse(
+            "Retry of the same already-uncapped command cannot lift a remaining cap",
+            verdict.offerRetry,
+        )
+        assertTrue(verdict.message.contains("date-capped") || verdict.message.contains("capped"))
+        assertFalse(verdict.message.contains("uv tool install"))
+    }
+
+    @Test
+    fun networkError_isFailed_offersRetry() {
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.39",
+            exitCode = 1,
+            output = "error: network unreachable",
+        )
+        assertEquals(HostCliUpgradeOutcome.Kind.Failed, verdict.kind)
+        assertTrue(verdict.offerRetry)
+        assertTrue(verdict.message.contains("network unreachable"))
+    }
+
+    @Test
+    fun exitZeroResolvedMatches_isSuccess() {
+        val verdict = HostCliUpgradeOutcome.classify(
+            requestedVersion = "0.4.40",
+            resolvedVersion = "0.4.40",
+            exitCode = 0,
+            output = "Updated pocketshell 0.4.39 -> 0.4.40",
+        )
+        assertEquals(HostCliUpgradeOutcome.Kind.Success, verdict.kind)
+        assertFalse(verdict.offerRetry)
+    }
+
+    @Test
+    fun nothingToUpgrade_isNotACapSignal() {
+        // G6: if looksLikeCapped treated "Nothing to upgrade" as a cap, the
+        // reported N vs N−1 state would be misdiagnosed again.
+        assertFalse(
+            HostCliUpgradeOutcome.looksLikeCapped("Nothing to upgrade"),
+        )
+        assertFalse(
+            HostCliUpgradeOutcome.looksLikeCapped("nothing newer to install"),
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/HostPocketshellUpgradeTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostPocketshellUpgradeTest.kt
@@ -28,8 +28,23 @@ class HostPocketshellUpgradeTest {
             execDispatcher = UnconfinedTestDispatcher(testScheduler)
         }
         val result = upgrade.run(session)
-        assertEquals(HostPocketshellUpgrade.Result.Success, result)
+        assertTrue(result is HostPocketshellUpgrade.Result.Success)
         assertTrue("the bounded upgrade command must have run", session.ran)
+    }
+
+    @Test
+    fun run_withRequestedVersion_pinsEveryInstallerArm() = runTest {
+        val session = FakeSession { ExecResult("upgraded", "", 0) }
+        val upgrade = HostPocketshellUpgrade().apply {
+            execDispatcher = UnconfinedTestDispatcher(testScheduler)
+        }
+        val result = upgrade.run(session, requestedVersion = "0.4.40")
+        assertTrue(result is HostPocketshellUpgrade.Result.Success)
+        val command = session.lastCommand
+        assertTrue("must pin uv to 0.4.40 — was $command", command.contains("pocketshell==0.4.40"))
+        assertTrue(command.contains("pipx install --force pocketshell==0.4.40"))
+        assertTrue(command.contains("pip install -U pocketshell==0.4.40"))
+        assertTrue(command.contains("--exclude-newer 2099-12-31"))
     }
 
     @Test
@@ -99,10 +114,12 @@ class HostPocketshellUpgradeTest {
     ) : SshSession {
         @Volatile var ran: Boolean = false
         @Volatile var closed: Boolean = false
+        @Volatile var lastCommand: String = ""
         override val isConnected: Boolean = true
 
         override suspend fun exec(command: String): ExecResult {
             ran = true
+            lastCommand = command
             return onExec()
         }
 

--- a/app/src/test/java/com/pocketshell/app/projects/HostUpdateCommandExcludeNewerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostUpdateCommandExcludeNewerTest.kt
@@ -77,6 +77,8 @@ class HostUpdateCommandExcludeNewerTest {
         "HostBootstrapper.uvToolInstallCommand(install)" to
             uvToolInstallCommand(BootstrapTool.Pocketshell, upgrade = false),
         "HostPocketshellUpgrade.UPGRADE_COMMAND (uv arm)" to HostPocketshellUpgrade.UPGRADE_COMMAND,
+        "HostPocketshellUpgrade.upgradeCommand(pinned)" to
+            HostPocketshellUpgrade.upgradeCommand(targetVersion),
     )
 
     // --- Load-bearing assertion (GREEN only with the whole-resolution fix) ----


### PR DESCRIPTION
Closes #2033

Reviewer-approved and orchestrator-verified per the issue thread; this PR carries the already-committed, already-pushed fix through the required PR checks for merge.