### PR TITLE
test: classify leftover splash-owner focus as inherited stall (#2021)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/EnvironmentFocusOwnerCleanupE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/EnvironmentFocusOwnerCleanupE2eTest.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import androidx.activity.ComponentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.app.proof.WalkthroughScreenshotArtifacts
+import com.pocketshell.app.proof.signals.awaitHomePackageOwnsDisplay
 import com.pocketshell.app.proof.signals.executeFocusShellCommand
 import com.pocketshell.app.proof.signals.dismissFocusedLauncherFrameworkDialog
 import com.pocketshell.app.proof.signals.focusedFrameworkErrorPackage
@@ -66,7 +67,11 @@ class EnvironmentFocusOwnerCleanupE2eTest {
         try {
             executeFocusShellCommand("settings put global show_first_crash_dialog 1")
             executeFocusShellCommand("input keyevent HOME")
-            SystemClock.sleep(1_500)
+            assertTrue(
+                "the fixture must wait until HOME owns the display before crashing it; " +
+                    "home_package=$homePackage",
+                awaitHomePackageOwnsDisplay(homePackage, timeoutMs = 15_000),
+            )
             executeFocusShellCommand("am crash $homePackage")
         } finally {
             if (oldShowFirst == "null" || oldShowFirst.isBlank()) {
@@ -78,11 +83,17 @@ class EnvironmentFocusOwnerCleanupE2eTest {
             }
         }
 
-        val deadline = SystemClock.elapsedRealtime() + 5_000
+        val deadline = SystemClock.elapsedRealtime() + 15_000
+        val retryAt = SystemClock.elapsedRealtime() + 5_000
         var focusedPackage: String? = null
+        var retriedCrash = false
         while (SystemClock.elapsedRealtime() < deadline) {
             focusedPackage = focusedFrameworkErrorPackage()
             if (focusedPackage != null) break
+            if (!retriedCrash && SystemClock.elapsedRealtime() >= retryAt) {
+                executeFocusShellCommand("am crash $homePackage")
+                retriedCrash = true
+            }
             SystemClock.sleep(50)
         }
         assertEquals(

--- a/app/src/androidTest/java/com/pocketshell/app/proof/InheritedFocusOwnerVerdictE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/InheritedFocusOwnerVerdictE2eTest.kt
@@ -12,11 +12,15 @@ import com.pocketshell.app.proof.signals.FOREIGN_WINDOW_FOCUS_SIGNATURE
 import com.pocketshell.app.proof.signals.InheritedJourneyFocus
 import com.pocketshell.app.proof.signals.SyntheticFocusOwnerHarness
 import com.pocketshell.app.proof.signals.activityWindowFocused
+import com.pocketshell.app.proof.signals.describeActiveWindow
+import com.pocketshell.app.proof.signals.executeFocusShellCommand
+import com.pocketshell.app.proof.signals.parseHomePackage
 import com.pocketshell.app.proof.signals.recordJourneyEntryFocus
 import com.pocketshell.app.proof.signals.requireNoJourneyOwnedFocusRegression
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocusLost
 import com.pocketshell.app.proof.signals.waitForActivityWindowFocused
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -65,6 +69,13 @@ import org.junit.runner.RunWith
  * [aJourneyThatLeaksItsOwnSyntheticOwnerStillFails] is the anti-amnesty control:
  * relaxing the INHERITED case must not relax the OWNED one. Without it, "the
  * journey reached its body" could be bought by deleting the checks entirely.
+ *
+ * Leftover (Nightly 31147697950 / 31456819680, and the later
+ * EnvironmentFocusOwnerCleanup self-check flake): an APP-OWNED splash/sheet
+ * FrameLayout after a *focused* entry used to fail the exit boundary with the
+ * same `active_window_pkg=<app>` reading. That is now classified as splash-
+ * owner, not a journey regression. A genuine foreign package still fails
+ * ([theJourneyBoundaryStillFailsOnAForeignFocusOwner]).
  */
 @RunWith(AndroidJUnit4::class)
 class InheritedFocusOwnerVerdictE2eTest {
@@ -181,9 +192,10 @@ class InheritedFocusOwnerVerdictE2eTest {
     }
 
     /**
-     * The class-boundary sibling of the reproduction: an inherited unfocused
-     * reading is recorded and reported, never converted into this journey's
-     * verdict, while a focus regression THIS journey caused still fails.
+     * The class-boundary sibling of the leftover recurrence: an inherited
+     * unfocused reading stays quiet, AND an APP-OWNED splash/sheet owner that
+     * appears after a focused entry also stays quiet. A genuine foreign owner
+     * is covered by [theJourneyBoundaryStillFailsOnAForeignFocusOwner].
      */
     @Test
     fun theJourneyBoundaryFailsOnAnOwnedRegressionAndNotOnAnInheritedOne() {
@@ -212,30 +224,104 @@ class InheritedFocusOwnerVerdictE2eTest {
             timeoutMs = 2_000,
         )
 
-        // (b) owned: entry focused, then this journey loses focus -> exit fails.
+        // (b) leftover recurrence: entry WAS focused, then an APP-OWNED splash /
+        // sheet / FrameLayout owns the display (FileViewer teardown + both
+        // #1994 arms on Nightly 31456819680). That reading is the hosted
+        // splash-owner stall, not a foreign thief this journey leaked, so the
+        // exit boundary must stay quiet. RED on current main: the boundary
+        // still calls requirePocketShellFocusAtJourneyBoundary and throws
+        // FOREIGN_WINDOW_FOCUS_SIGNATURE with active_window_pkg=<our package>.
         dismissInheritedOwner()
-        val ownedEntry = recordJourneyEntryFocus(
+        val focusedEntry = recordJourneyEntryFocus(
             scenario = scenario,
-            context = "issue #2021 owned entry",
+            context = "issue #2021 splash-owner entry",
             timeoutMs = 10_000,
         )
-        assertTrue("the owned case needs a focused entry reading", ownedEntry.focused)
+        assertTrue("the splash-owner leftover needs a focused entry reading", focusedEntry.focused)
         inheritAppOwnedFocusWindow()
+        requireNoJourneyOwnedFocusRegression(
+            scenario = scenario,
+            entry = focusedEntry,
+            context = "issue #2021 splash-owner exit",
+            timeoutMs = 2_000,
+        )
+    }
+
+    /**
+     * Selectivity for the leftover: relaxing the APP-OWNED splash-owner case
+     * must not become blanket amnesty for a genuine foreign owner. A Settings
+     * window in front is the named-other-package reading the class boundary
+     * still exists to catch (#1985 / #1879).
+     */
+    @Test
+    fun theJourneyBoundaryStillFailsOnAForeignFocusOwner() {
+        val scenario = compose.activityRule.scenario
+        val focusedEntry = recordJourneyEntryFocus(
+            scenario = scenario,
+            context = "issue #2021 foreign-owner entry",
+            timeoutMs = 10_000,
+        )
+        assertTrue("the foreign-owner control needs a focused entry reading", focusedEntry.focused)
+
+        val targetPackage = InstrumentationRegistry.getInstrumentation()
+            .targetContext.packageName
+        executeFocusShellCommand("am start -a android.settings.SETTINGS")
+        assertTrue(
+            "the fixture must actually put a foreign package in front, otherwise this " +
+                "control proves nothing about the leftover classification",
+            waitForForeignPackageInFront(targetPackage),
+        )
         val regression = runCatching {
             requireNoJourneyOwnedFocusRegression(
                 scenario = scenario,
-                entry = ownedEntry,
-                context = "issue #2021 owned exit",
+                entry = focusedEntry,
+                context = "issue #2021 foreign-owner exit",
                 timeoutMs = 2_000,
             )
         }.exceptionOrNull()
+        bringScenarioBackToFront()
         assertNotNull(
-            "a focus regression this journey caused must still hard-fail at the boundary",
+            "a genuine foreign focus owner must still hard-fail at the boundary — " +
+                "excusing splash-owner must not become blanket amnesty",
             regression,
         )
         assertTrue(
             "the boundary failure must keep the #1879 signature, got: ${regression?.message}",
             regression?.message.orEmpty().contains(FOREIGN_WINDOW_FOCUS_SIGNATURE),
+        )
+        assertTrue(
+            "the foreign-owner failure must name a package that is not this app, got: " +
+                "${regression?.message}",
+            regression?.message.orEmpty().contains("active_window_pkg=") &&
+                !regression?.message.orEmpty().contains("active_window_pkg=$targetPackage"),
+        )
+    }
+
+    /**
+     * Issue #2021 leftover self-check flake: an empty HOME resolver output
+     * must not be treated as a package. Mutation: returning a hardcoded
+     * launcher package on blank input reddens the empty cases.
+     */
+    @Test
+    fun homePackageParserDoesNotInventALauncherWhenTheResolverIsEmpty() {
+        assertEquals(
+            "empty dumpsys/resolver output is not a HOME package",
+            "",
+            parseHomePackage(""),
+        )
+        assertEquals(
+            "a resolver miss is not a HOME package",
+            "",
+            parseHomePackage("No activity found"),
+        )
+        assertEquals(
+            "the last component/line is the HOME package",
+            "com.google.android.apps.nexuslauncher",
+            parseHomePackage(
+                "priority=0 preferredOrder=0 match=0x108000\n" +
+                    "com.google.android.apps.nexuslauncher/" +
+                    "com.google.android.apps.nexuslauncher.NexusLauncherActivity\n",
+            ),
         )
     }
 
@@ -283,5 +369,30 @@ class InheritedFocusOwnerVerdictE2eTest {
             SystemClock.sleep(50)
         }
         return dialog.window?.decorView?.hasWindowFocus() == true
+    }
+
+    private fun waitForForeignPackageInFront(appPackage: String): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + 10_000
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val diagnosis = describeActiveWindow()
+            val pkg = diagnosis.substringAfter("active_window_pkg=", "")
+                .substringBefore(' ')
+            if (pkg.isNotBlank() && pkg != appPackage && pkg != "<unavailable>") {
+                return true
+            }
+            SystemClock.sleep(50)
+        }
+        return false
+    }
+
+    private fun bringScenarioBackToFront() {
+        compose.activityRule.scenario.onActivity { activity ->
+            activity.getSystemService(android.app.ActivityManager::class.java)
+                .appTasks
+                .firstOrNull { it.taskInfo.taskId == activity.taskId }
+                ?.moveToFront()
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        waitForActivityWindowFocused(compose.activityRule.scenario, timeoutMs = 10_000)
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/LauncherFrameworkDialogFocusBoundary.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/LauncherFrameworkDialogFocusBoundary.kt
@@ -26,16 +26,61 @@ private val FRAMEWORK_ERROR_FOCUS_PATTERN = Regex(
  * (SyntheticFocusOwnerHarness.kt), which call the primitives below.
  */
 
-internal fun resolveHomePackage(): String {
-    val component = executeShellCommand(
-        "cmd package resolve-activity --brief " +
-            "-a android.intent.action.MAIN -c android.intent.category.HOME",
-    ).lineSequence().lastOrNull { '/' in it }.orEmpty().trim()
-    val pkg = component.substringBefore('/')
-    if (pkg.isBlank()) {
-        throw AssertionError("issue #1985 could not resolve the device HOME package: '$component'")
+internal fun parseHomePackage(resolveActivityOutput: String): String {
+    val component = resolveActivityOutput.lineSequence()
+        .lastOrNull { '/' in it }
+        .orEmpty()
+        .trim()
+    return component.substringBefore('/')
+}
+
+internal fun tryResolveHomePackage(): String? {
+    val pkg = parseHomePackage(
+        executeShellCommand(
+            "cmd package resolve-activity --brief " +
+                "-a android.intent.action.MAIN -c android.intent.category.HOME",
+        ),
+    )
+    return pkg.takeIf { it.isNotBlank() }
+}
+
+/**
+ * Issue #2021 leftover self-check: on a cold AVD the HOME resolver can return
+ * empty for a beat. Wait, then throw — never proceed with a null launcher
+ * package (that voided EnvironmentFocusOwnerCleanup's arrange step).
+ */
+internal fun resolveHomePackage(
+    timeoutMs: Long = 15_000L,
+): String {
+    val deadline = android.os.SystemClock.elapsedRealtime() + timeoutMs
+    var last = ""
+    while (android.os.SystemClock.elapsedRealtime() < deadline) {
+        last = tryResolveHomePackage().orEmpty()
+        if (last.isNotBlank()) return last
+        android.os.SystemClock.sleep(50)
     }
-    return pkg
+    throw AssertionError("issue #1985 could not resolve the device HOME package: '$last'")
+}
+
+/** Wait until [homePackage] owns the focused window (HOME keyevent settled). */
+internal fun awaitHomePackageOwnsDisplay(
+    homePackage: String,
+    timeoutMs: Long = 15_000L,
+): Boolean {
+    val deadline = android.os.SystemClock.elapsedRealtime() + timeoutMs
+    while (android.os.SystemClock.elapsedRealtime() < deadline) {
+        val dump = executeShellCommand("dumpsys window")
+        val currentFocus = dump.lineSequence()
+            .firstOrNull { it.contains("mCurrentFocus") }
+            .orEmpty()
+        if (currentFocus.contains(homePackage)) return true
+        android.os.SystemClock.sleep(50)
+    }
+    return executeShellCommand("dumpsys window")
+        .lineSequence()
+        .firstOrNull { it.contains("mCurrentFocus") }
+        .orEmpty()
+        .contains(homePackage)
 }
 
 internal fun focusedFrameworkErrorPackage(): String? = FRAMEWORK_ERROR_FOCUS_PATTERN

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/SyntheticFocusOwnerHarness.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/SyntheticFocusOwnerHarness.kt
@@ -175,13 +175,15 @@ class SyntheticFocusOwnerHarness(
             )
         }
 
-        // #1985 invariant, unchanged for the state this harness disturbed: if the
-        // activity held focus before the owner was raised, it must hold it again.
-        // When focus was NOT ours to begin with, the inherited owner is reported
-        // in the message of whatever the journey asserts next, not converted into
-        // this harness's verdict (issue #2021).
+        // #1985 invariant, unchanged for a FOREIGN owner this harness did not
+        // create: if the activity held focus before the owner was raised, a
+        // leftover thief that is not our package still hard-fails. The leftover
+        // #2021 recurrence is an APP-OWNED splash/sheet FrameLayout after a
+        // focused entry — that is the same inherited stall, not a leak of the
+        // dialog this harness just dismissed (the leak check above already
+        // proved that window is gone).
         if (focusedAtEntry) {
-            requirePocketShellFocusAtJourneyBoundary(
+            requireNoForeignFocusOwnerAtJourneyBoundary(
                 scenario = scenario,
                 context = "after dismissing synthetic focus owner '$label'",
                 timeoutMs = timeoutMs,
@@ -285,10 +287,35 @@ fun requireNoJourneyOwnedFocusRegression(
         )
         return
     }
-    requirePocketShellFocusAtJourneyBoundary(
+    requireNoForeignFocusOwnerAtJourneyBoundary(
         scenario = scenario,
         context = context,
         timeoutMs = timeoutMs,
+    )
+}
+
+/**
+ * Exit-boundary teeth: wait for activity focus, then HARD-fail only on a
+ * remaining FOREIGN owner. An app-owned splash/sheet FrameLayout after a
+ * focused entry is the leftover Nightly recurrence (FileViewer teardown +
+ * SessionSwipeSwitch #1994 arms) and must not become this journey's verdict.
+ */
+private fun requireNoForeignFocusOwnerAtJourneyBoundary(
+    scenario: ActivityScenario<out Activity>,
+    context: String,
+    timeoutMs: Long,
+) {
+    val outcome = awaitActivityWindowFocus(scenario, timeoutMs)
+    if (outcome.focused) return
+    if (isAppOwnedUnfocusedDiagnosis(outcome.diagnosis)) {
+        Log.w(
+            FOCUS_BOUNDARY_LOG_TAG,
+            "journey-exit-app-owned-splash-owner $context; ${outcome.diagnosis}",
+        )
+        return
+    }
+    throw AssertionError(
+        "$FOREIGN_WINDOW_FOCUS_SIGNATURE $context; ${focusBoundaryDiagnosis(outcome.diagnosis)}",
     )
 }
 
@@ -304,7 +331,14 @@ fun requirePocketShellFocusAtJourneyBoundary(
     val outcome = awaitActivityWindowFocus(scenario, timeoutMs)
     if (!outcome.focused) {
         throw AssertionError(
-            "$FOREIGN_WINDOW_FOCUS_SIGNATURE $context; ${outcome.diagnosis}",
+            "$FOREIGN_WINDOW_FOCUS_SIGNATURE $context; ${focusBoundaryDiagnosis(outcome.diagnosis)}",
         )
     }
+}
+
+private fun focusBoundaryDiagnosis(base: String): String {
+    val framework = focusedFrameworkErrorPackage()
+    val home = tryResolveHomePackage()
+    return "$base focused_framework_package=${framework ?: "<none>"} " +
+        "home_package=${home ?: "<unavailable>"}"
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/signals/WindowFocusSignals.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/signals/WindowFocusSignals.kt
@@ -241,6 +241,25 @@ fun awaitActivityWindowFocus(
 }
 
 /**
+ * Issue #2021 leftover: an unfocused activity while OUR package still owns
+ * the accessibility window is the hosted splash-owner / in-app sheet stall
+ * (`active_window_pkg=<app> active_window_class=android.widget.FrameLayout`),
+ * not a foreign thief. Fail closed on `<unavailable>` or any other package.
+ *
+ * A framework Error/ANR is never app-owned: its window belongs to `android`
+ * (#1879) and [focusedFrameworkErrorPackage] names the subject.
+ */
+fun isAppOwnedUnfocusedDiagnosis(diagnosis: String): Boolean {
+    val appPackage = InstrumentationRegistry.getInstrumentation().targetContext.packageName
+    val pkg = diagnosis.substringAfter("active_window_pkg=", missingDelimiterValue = "")
+        .substringBefore(' ')
+    if (pkg.isBlank() || pkg == ACTIVE_WINDOW_UNAVAILABLE || pkg != appPackage) {
+        return false
+    }
+    return focusedFrameworkErrorPackage() == null
+}
+
+/**
  * Describe the window that currently owns the active (focused) accessibility
  * window: its owning package and root class. Used to name the real cause in a
  * failure message, and parsed by the CI classifier's foreignness gate.


### PR DESCRIPTION
Closes #2021

Reviewer-approved and orchestrator-verified per the issue thread; this PR carries the already-committed, already-pushed fix through the required PR checks for merge.