### PR TITLE
fix(lifecycle): clear killed sessions before restore (#2249)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -18,12 +19,16 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
+import com.pocketshell.app.projects.STALE_SESSION_DIALOG_TAG
+import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.app.tmux.TMUX_LIFECYCLE_DIALOG_CONFIRM_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -223,6 +228,117 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
         Unit
     } }
 
+    /**
+     * Issue #2249: the real phone journey is a LOCAL Stop, immediate
+     * navigation to the tree, minimize, and reopen.  The target + keepalive
+     * fixture deliberately keeps the tmux server alive so a stale foreground
+     * replay would reach the session-gone dialog path instead of merely
+     * observing a dead server.
+     *
+     * Mutation that must redden this test: restore MainActivity's
+     * repeatOnLifecycle(STARTED) kill collector and remove the VM's lifetime
+     * killed-session collector.  The kill completes while the activity is
+     * below STARTED, onStop has already run, and the stale target then gets
+     * rearmed by the post-grace foreground detach/restore.
+     */
+    @Test
+    fun localStopThenBackgroundForegroundDoesNotRestoreKilledTarget() { runBlocking {
+        val key = fixtureKey
+
+        // ---- (1) Attach through the actual session screen.
+        waitForHostRowPresent(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        waitForText(TARGET_SESSION, timeoutMs = 20_000)
+        compose.onNodeWithText(TARGET_SESSION).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        delay(LIFECYCLE_DRAIN_MS)
+
+        // ---- (2) The production Stop route: kebab -> Stop session -> Stop.
+        compose.onNodeWithContentDescription(
+            "More session actions",
+            useUnmergedTree = true,
+        ).performClick()
+        compose.onNodeWithText("Stop session", useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(
+            TMUX_LIFECYCLE_DIALOG_CONFIRM_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+
+        // The UI navigates back immediately, before the verified gateway kill
+        // completes.  Minimize at this exact boundary: this is the missed
+        // lifecycle-emission window from the phone report.
+        BackgroundGraceTestOverride.setForTest(POST_GRACE_MS)
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+
+        // The real gateway kill continues in the activity-scoped VM while the
+        // activity is stopped.  Wait for the authoritative remote result, not
+        // for a UI row that could be stale.
+        waitUntilRemoteGone(key, TARGET_SESSION)
+        assertTrue(
+            "the keepalive session must remain alive so the server-gone branch is not exercised",
+            sessionAlive(key, KEEPALIVE_SESSION),
+        )
+        delay(POST_GRACE_MS + LIFECYCLE_DRAIN_MS)
+
+        // ---- (3) Reopen the app.  The exact killed target must not be probed
+        // again and must not raise the stale-session recovery dialog.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        compose.waitUntil(timeoutMillis = RECONNECT_TIMEOUT_MS) {
+            droppedToSessionList() &&
+                compose.onAllNodesWithTag(STALE_SESSION_DIALOG_TAG, useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+        }
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val entryPoint = EntryPointAccessors
+            .fromApplication(context, TestAccessEntryPoint::class.java)
+        val hostId = hostRowTag.removePrefix(HOST_ROW_TAG_PREFIX).toLong()
+        val stored = entryPoint.lastSessionStore().read(maxAgeMillis = Long.MAX_VALUE)
+        val killedRecordRearmed = stored?.let {
+            it.hostId == hostId && it.sessionName == TARGET_SESSION
+        } == true
+        val targetAliveAfterResume = sessionAlive(key, TARGET_SESSION)
+        val keepaliveAliveAfterResume = sessionAlive(key, KEEPALIVE_SESSION)
+        writeText(
+            "issue2249-local-stop-restore.txt",
+            buildString {
+                appendLine("target_session=$TARGET_SESSION")
+                appendLine("keepalive_session=$KEEPALIVE_SESSION")
+                appendLine("target_alive_after_resume=$targetAliveAfterResume")
+                appendLine("keepalive_alive_after_resume=$keepaliveAliveAfterResume")
+                appendLine("stored_session=${stored?.sessionName}")
+                appendLine("killed_record_rearmed=$killedRecordRearmed")
+                appendLine("stale_dialog_visible=${!compose.onAllNodesWithTag(
+                    STALE_SESSION_DIALOG_TAG,
+                    useUnmergedTree = true,
+                ).fetchSemanticsNodes().isEmpty()}")
+            },
+        )
+
+        assertFalse(
+            "REGRESSION (#2249): the locally stopped target must not be resurrected on reopen",
+            targetAliveAfterResume,
+        )
+        assertTrue(
+            "the unrelated live keepalive session must survive the local stop journey",
+            keepaliveAliveAfterResume,
+        )
+        assertFalse(
+            "REGRESSION (#2249): onStop must not re-arm the exact killed target",
+            killedRecordRearmed,
+        )
+        assertTrue(
+            "reopen must land on the session list without the stale-session dialog",
+            droppedToSessionList() && compose.onAllNodesWithTag(
+                STALE_SESSION_DIALOG_TAG,
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().isEmpty(),
+        )
+        writeTimings()
+        Unit
+    } }
+
     // ---------------------------------------------------------------- Helpers
 
     /**
@@ -327,6 +443,15 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
             "tmux has-session -t ${shellQuote(session)} 2>/dev/null && echo ALIVE || echo GONE",
         )
         return exec?.stdout?.contains("ALIVE") == true
+    }
+
+    private suspend fun waitUntilRemoteGone(key: String, session: String) {
+        val deadline = SystemClock.elapsedRealtime() + RECONNECT_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (!sessionAlive(key, session)) return
+            delay(250L)
+        }
+        throw AssertionError("timed out waiting for remote session `$session` to be gone")
     }
 
     private suspend fun runScript(key: String, script: String) =

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -672,19 +672,23 @@ class MainActivity : FragmentActivity() {
      */
     private fun observeKilledSessionsForLastSession() {
         lifecycleScope.launch {
-            // Collect across STARTED so a kill broadcast while the activity is
-            // foregrounded (the dominant case — Stop is tapped from a visible
-            // tree/session screen) reaches the store before the user can
-            // background and trigger a restore.
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                sessionLifecycleSignals.killedSessions.collect { killed ->
-                    Log.i(
-                        "MainActivity",
-                        "issue834-killed-session-clear hostId=${killed.hostId} " +
-                            "session=${killed.sessionName}",
-                    )
-                    lastSessionStore.onSessionKilled(killed.hostId, killed.sessionName)
-                }
+            // This is an event sink, not a foreground UI collector.  The
+            // in-session Stop action navigates to the tree immediately while
+            // its verified gateway kill finishes asynchronously; collecting
+            // only inside repeatOnLifecycle(STARTED) loses that event when the
+            // user minimizes during the gap, allowing onStop to re-arm the
+            // dead destination.  lifecycleScope remains alive while this
+            // activity is stopped, so the event is still handled during the
+            // app's background grace window.  A process death also destroys
+            // the VM and its in-memory target, so there is no stale event to
+            // replay into a new process.
+            sessionLifecycleSignals.killedSessions.collect { killed ->
+                Log.i(
+                    "MainActivity",
+                    "issue834-killed-session-clear hostId=${killed.hostId} " +
+                        "session=${killed.sessionName}",
+                )
+                lastSessionStore.onSessionKilled(killed.hostId, killed.sessionName)
             }
         }
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/KilledSessionRestorePlan.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/KilledSessionRestorePlan.kt
@@ -1,0 +1,134 @@
+package com.pocketshell.app.tmux
+
+import android.util.Log
+import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import androidx.lifecycle.viewModelScope
+
+/**
+ * The restore-related targets which can outlive the visible session screen.
+ * Keeping the identity calculation outside the VM makes the kill invalidation
+ * path reviewable without adding more weight to the connection god object.
+ */
+internal data class KilledSessionRestoreSnapshot(
+    val activeTarget: ConnectionTarget?,
+    val connectingTarget: ConnectionTarget?,
+    val pendingTarget: ConnectionTarget?,
+    val pausedTarget: ConnectionTarget?,
+    val intentTarget: ConnectionTarget?,
+)
+
+internal data class KilledSessionRestorePlan(
+    val activeWasKilled: Boolean,
+    val connectingWasKilled: Boolean,
+    val pendingWasKilled: Boolean,
+    val pausedWasKilled: Boolean,
+    val intentWasKilled: Boolean,
+    val connectingToPreserve: ConnectionTarget?,
+    val killedTarget: ConnectionTarget?,
+)
+
+/**
+ * Match the confirmed kill against every in-memory restore lane. Matching is
+ * deliberately host-plus-name only: that is the identity carried by the
+ * lifecycle signal, and same-name recreation is allowed to clear the old
+ * invalidation when its open signal arrives.
+ */
+internal fun planKilledSessionRestore(
+    killed: KilledSession,
+    state: KilledSessionRestoreSnapshot,
+): KilledSessionRestorePlan? {
+    fun isKilled(target: ConnectionTarget?): Boolean =
+        target?.hostId == killed.hostId && target.sessionName == killed.sessionName
+
+    val activeWasKilled = isKilled(state.activeTarget)
+    val connectingWasKilled = isKilled(state.connectingTarget)
+    val pendingWasKilled = isKilled(state.pendingTarget)
+    val pausedWasKilled = isKilled(state.pausedTarget)
+    val intentWasKilled = isKilled(state.intentTarget)
+    if (!activeWasKilled && !connectingWasKilled && !pendingWasKilled &&
+        !pausedWasKilled && !intentWasKilled
+    ) {
+        return null
+    }
+
+    return KilledSessionRestorePlan(
+        activeWasKilled = activeWasKilled,
+        connectingWasKilled = connectingWasKilled,
+        pendingWasKilled = pendingWasKilled,
+        pausedWasKilled = pausedWasKilled,
+        intentWasKilled = intentWasKilled,
+        connectingToPreserve = state.connectingTarget?.takeUnless(::isKilled),
+        killedTarget = state.activeTarget,
+    )
+}
+
+/** Observe kills for the VM lifetime; the visible screen can leave first. */
+internal fun TmuxSessionViewModel.observeKilledSessionsForRestore() {
+    val signals = sessionLifecycleSignals ?: return
+    viewModelScope.launch {
+        signals.killedSessions.collect { killed -> invalidateKilledRestoreState(killed) }
+    }
+}
+
+/**
+ * Apply a confirmed kill to the VM's restore state. This is deliberately a
+ * lifetime-scoped observer path: Stop navigates away before the verified
+ * gateway result arrives, so the background detach must not stash the
+ * just-killed target for a later foreground replay. The VM members touched
+ * here are package-internal solely for this narrow invalidation helper; they
+ * remain outside the public app API.
+ */
+internal fun TmuxSessionViewModel.invalidateKilledRestoreState(killed: KilledSession) {
+    val plan = planKilledSessionRestore(
+        killed,
+        KilledSessionRestoreSnapshot(
+            activeTarget = activeTarget,
+            connectingTarget = connectingTarget,
+            pendingTarget = pendingReattach?.target,
+            pausedTarget = pausedAutoReconnect?.target,
+            intentTarget = latestConnectIntent?.target,
+        ),
+    ) ?: return
+    if (plan.pendingWasKilled) pendingReattach = null
+    if (plan.pausedWasKilled) pausedAutoReconnect = null
+    if (plan.intentWasKilled) latestConnectIntent = null
+    if (plan.connectingWasKilled) connectingTarget = null
+
+    if (plan.activeWasKilled) {
+        // Clear restore-producing fields before asynchronous teardown. A
+        // racing lifecycle edge therefore cannot re-arm the killed target.
+        activeTarget = null
+        pendingBackgroundDetachPreserveTarget = plan.connectingToPreserve
+        if (backgroundDetachJob?.isActive != true) {
+            launchContainedTeardown {
+                withContext(NonCancellable) {
+                    closeCurrentConnectionAndJoin(
+                        preserveConnectingTarget = plan.connectingToPreserve,
+                        cacheEviction = RuntimeCacheEviction.TargetRuntime(
+                            checkNotNull(plan.killedTarget).toRuntimeKey(),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    if (plan.connectingWasKilled || (plan.activeWasKilled && plan.intentWasKilled)) {
+        connectJob?.cancel()
+        connectJob = null
+    }
+    if (plan.activeWasKilled || plan.pausedWasKilled) {
+        autoReconnectJob?.cancel()
+        autoReconnectJob = null
+    }
+    refreshReconnectAvailability()
+    Log.i(
+        ISSUE_464_KILL_TAG,
+        "stop-session-restore-invalidated host=${killed.hostId} " +
+            "session=${killed.sessionName} active=${plan.activeWasKilled} " +
+            "pending=${plan.pendingWasKilled} paused=${plan.pausedWasKilled}",
+    )
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -284,7 +284,7 @@ public class TmuxSessionViewModel @Inject constructor(
     // this screen tells the folder/session tree to drop the dead row.
     // Nullable default keeps the existing unit-test constructors working
     // without supplying the singleton.
-    private val sessionLifecycleSignals: SessionLifecycleSignals? = null,
+    internal val sessionLifecycleSignals: SessionLifecycleSignals? = null,
     // Issue #526: source of the user-configurable agent-submit Enter delay.
     // The composer/agent send path types the message text, waits this delay,
     // then sends the submit Enter as a separate `send-keys` so a fast Enter
@@ -1549,6 +1549,7 @@ public class TmuxSessionViewModel @Inject constructor(
 
     init {
         driveRevealStateMachine()
+        observeKilledSessionsForRestore()
     }
 
     private fun navigateRevealTo(target: ConnectionTarget) {
@@ -1973,10 +1974,10 @@ public class TmuxSessionViewModel @Inject constructor(
     // VM truly goes away and the hook must be removed too.
     private var lifecycleHookRegistration: ActiveTmuxClients.LifecycleRegistration? = null
     private var lifecycleHookHostId: Long? = null
-    private var activeTarget: ConnectionTarget? = null
-    private var connectingTarget: ConnectionTarget? = null
-    private var connectJob: Job? = null
-    private var autoReconnectJob: Job? = null
+    internal var activeTarget: ConnectionTarget? = null
+    internal var connectingTarget: ConnectionTarget? = null
+    internal var connectJob: Job? = null
+    internal var autoReconnectJob: Job? = null
 
     /**
      * Issue #1072 — the in-flight attachment-upload coroutine, OWNED by the VM so
@@ -2478,7 +2479,7 @@ public class TmuxSessionViewModel @Inject constructor(
     // preserved by construction. The handler's sole job is to stop a
     // teardown-time throw from killing the process — not to suppress lifecycle
     // signals.
-    private fun launchContainedTeardown(
+    internal fun launchContainedTeardown(
         block: suspend kotlinx.coroutines.CoroutineScope.() -> Unit,
     ): Job =
         viewModelScope.launch(bridgeExceptionHandler) {
@@ -3308,7 +3309,7 @@ public class TmuxSessionViewModel @Inject constructor(
         this.keepaliveDeathQuietResetMs = keepaliveDeathQuietResetMs
     }
 
-    private fun refreshReconnectAvailability() {
+    internal fun refreshReconnectAvailability() {
         // Issue #1574: a once-opened session ([latestConnectIntent]) stays reconnectable.
         _canReconnect.value =
             activeTarget != null || connectingTarget != null || latestConnectIntent != null
@@ -3359,9 +3360,9 @@ public class TmuxSessionViewModel @Inject constructor(
     // we stash the [activeTarget] so [onAppForegrounded] knows what to
     // re-attach to. Going through [activeTarget] for the reconnect path
     // would not work because [closeCurrentConnectionAndJoin] clears it.
-    private var pendingReattach: PendingReattach? = null
-    private var pausedAutoReconnect: PausedAutoReconnect? = null
-    private var backgroundDetachJob: Job? = null
+    internal var pendingReattach: PendingReattach? = null
+    internal var pausedAutoReconnect: PausedAutoReconnect? = null
+    internal var backgroundDetachJob: Job? = null
     private var lastSuppressedDropDiagnostic: SuppressedDropDiagnostic? = null
 
     // #754/#1954: bounded release of the one typed claim shared by status, reveal, and liveness.
@@ -3373,7 +3374,7 @@ public class TmuxSessionViewModel @Inject constructor(
     // value must be read at the same instant the old inline launch read it (before
     // any rapid foreground mutates `connectingTarget`), so the field captures it on
     // the background-decision turn rather than re-deriving it in the driver effect.
-    private var pendingBackgroundDetachPreserveTarget: ConnectionTarget? = null
+    internal var pendingBackgroundDetachPreserveTarget: ConnectionTarget? = null
     private var sessionPrewarmJob: Job? = null
     private var foregroundReattachForTest: (() -> Unit)? = null
     // EPIC #792 Slice B: the `foregroundReattachReseedForTest` /
@@ -3381,7 +3382,7 @@ public class TmuxSessionViewModel @Inject constructor(
     // were never set (always null → always fell through to the real body), and the grace
     // IO is now dispatched through the single [graceEffects] owner (no dual-write, D22).
     private var processForegroundForClearedOverrideForTest: Boolean? = null
-    private var latestConnectIntent: ConnectIntent? = null
+    internal var latestConnectIntent: ConnectIntent? = null
     private var connectGeneration: Long = 0L
 
     // Issue #257: the in-flight fire-and-forget `detach-client` of the
@@ -16948,7 +16949,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * exception-propagation policy the caller needs (the production caller
      * wraps this in `NonCancellable`; tests may not need to).
      */
-    private suspend fun closeCurrentConnectionAndJoin(
+    internal suspend fun closeCurrentConnectionAndJoin(
         preserveConnectingTarget: ConnectionTarget? = null,
         cacheEviction: RuntimeCacheEviction = RuntimeCacheEviction.HostWide,
     ) {

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
@@ -118,6 +118,51 @@ class TmuxSessionViewModelReconnectTest : TmuxSessionViewModelTestBase() {
         assertEquals(0, connector.connectCount)
     }
 
+    /**
+     * Issue #2249: the in-session Stop action navigates away immediately, while
+     * its confirmed kill signal can arrive later.  Even when the app is then
+     * backgrounded before that signal is collected by a lifecycle-gated
+     * subscriber, the killed session must not be stashed as the foreground
+     * reattach target.
+     *
+     * Mutation that must redden this assertion: restore the old
+     * [onSessionScreenLeft] behavior (or remove the kill-signal cleanup) so the
+     * live client remains eligible for [onAppBackgrounded]'s pending reattach.
+     */
+    @Test
+    fun locallyKilledSessionCannotBeRearmedByBackgroundAfterScreenLeaves() = runTest(scheduler) {
+        val signals = SessionLifecycleSignals()
+        val vm = newVm(sessionLifecycleSignals = signals)
+        vm.replaceClientForTest(
+            hostId = 7L,
+            hostName = "alpha",
+            host = "alpha.example",
+            port = 22,
+            user = "alex",
+            keyPath = "/keys/a",
+            sessionName = "work",
+            client = FakeTmuxClient(),
+        )
+
+        // This is the production Stop-confirmation call.  MainActivity then
+        // immediately invokes onSessionScreenLeft() while the verified kill
+        // signal is still asynchronous in production.
+        vm.killCurrentSession()
+        vm.onSessionScreenLeft()
+        vm.onAppBackgrounded()
+        advanceUntilIdle()
+
+        assertFalse(
+            "a locally stopped session must not remain a pending foreground restore target",
+            vm.hasPendingReattachForTest(),
+        )
+        assertEquals(
+            "a locally stopped session must be removed from the VM's active restore state",
+            null,
+            vm.activeSessionNameForTest(),
+        )
+    }
+
     @Test
     fun networkReconnectEvictsConnectedIdleLeaseBeforeReattaching() = runTest(scheduler) {
         val registry = ActiveTmuxClients()


### PR DESCRIPTION
Closes #2249

Reviewer McClintock approved the implementation and regression proof in the issue comments.

Final local verification: canonical full JVM gate passed (BUILD SUCCESSFUL; 604 actionable tasks), then the branch was rebased onto origin/main 5872a117.

Changed behavior: a killed session is removed from the restore candidate set before lifecycle restore, so stopping a session cannot resurrect it after app restart.