### PR TITLE
fix(ui): distinguish idle agents from paused sessions (#2255)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentStateChipHostCardScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentStateChipHostCardScreenshotTest.kt
@@ -97,12 +97,12 @@ class AgentStateChipHostCardScreenshotTest {
 
         // On-device icon presence for the three known states. The full words
         // remain accessible descriptions, never width-consuming visible text.
-        compose.onNodeWithContentDescription("Waiting").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Waiting for input").assertIsDisplayed()
         compose.onNodeWithContentDescription("Working").assertIsDisplayed()
-        compose.onNodeWithContentDescription("Idle").assertIsDisplayed()
-        compose.onNodeWithText("Waiting").assertDoesNotExist()
+        compose.onNodeWithContentDescription("Idle (finished)").assertIsDisplayed()
+        compose.onNodeWithText("Waiting for input").assertDoesNotExist()
         compose.onNodeWithText("Working").assertDoesNotExist()
-        compose.onNodeWithText("Idle").assertDoesNotExist()
+        compose.onNodeWithText("Idle (finished)").assertDoesNotExist()
         // "absent, not wrong": the quiet host is rendered but shows NO chip —
         // there is no state description or visible fallback on that card.
         compose.onNodeWithText("quiet-host").assertIsDisplayed()

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
@@ -1398,7 +1398,7 @@ class FolderListScreenE2eTest {
 
         // #1701: the REAL production list exposes every compact state glyph via
         // its full accessibility label, with no width-consuming status words.
-        listOf("Working", "Waiting", "Idle").forEach { label ->
+        listOf("Working", "Waiting for input", "Idle (finished)").forEach { label ->
             assertTrue(
                 "$label state icon must expose its full content description",
                 compose.onAllNodes(hasContentDescription(label), useUnmergedTree = true)

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/AgentStateChip.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/AgentStateChip.kt
@@ -2,12 +2,13 @@ package com.pocketshell.uikit.components
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.outlined.HourglassEmpty
-import androidx.compose.material.icons.outlined.PauseCircle
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.model.SessionAgentState
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -25,22 +26,25 @@ import com.pocketshell.uikit.theme.PocketShellColors
  * Design-language semantic colours:
  *  - Waiting → amber: the agent is blocked on the user — the "come look" signal.
  *  - Working → accent cyan: actively working.
- *  - Idle    → neutral grey: finished / resting.
+ *  - Idle    → neutral grey: finished / resting (a checkmark, never a pause
+ *    affordance).
  *
  * The visible words were deliberately hard-cut in #1701 to return their width
- * to the session name. The full words remain as icon content descriptions so
- * TalkBack receives the same state information.
+ * to the session name. The explicit state descriptions remain on the icons so
+ * TalkBack receives the same state information without making an idle agent
+ * sound like a paused control.
  */
 @Composable
 fun AgentStateChip(
     state: SessionAgentState,
     modifier: Modifier = Modifier,
 ) {
-    val label = state.chipLabel ?: return
-    val (imageVector, tint) = when (state) {
-        SessionAgentState.WaitingForInput -> Icons.Outlined.HourglassEmpty to PocketShellColors.Amber
-        SessionAgentState.Working -> Icons.Filled.Autorenew to PocketShellColors.Accent
-        SessionAgentState.Idle -> Icons.Outlined.PauseCircle to PocketShellColors.TextSecondary
+    val label = state.accessibilityDescription ?: return
+    val imageVector = agentStateIconFor(state) ?: return
+    val tint = when (state) {
+        SessionAgentState.WaitingForInput -> PocketShellColors.Amber
+        SessionAgentState.Working -> PocketShellColors.Accent
+        SessionAgentState.Idle -> PocketShellColors.TextSecondary
         SessionAgentState.Unknown -> return
     }
     Icon(
@@ -50,5 +54,26 @@ fun AgentStateChip(
         modifier = modifier.size(AgentStateIconSize),
     )
 }
+
+/**
+ * The visual state vocabulary is deliberately separate from provider identity
+ * badges and from the green attached/agent-kind dot used by the tree rows.
+ * In particular, [SessionAgentState.Idle] means the agent finished/rested; it
+ * is not a user-controlled paused session, so it must not use a pause glyph.
+ */
+internal fun agentStateIconFor(state: SessionAgentState): ImageVector? = when (state) {
+    SessionAgentState.WaitingForInput -> Icons.Outlined.HourglassEmpty
+    SessionAgentState.Working -> Icons.Filled.Autorenew
+    SessionAgentState.Idle -> Icons.Outlined.CheckCircle
+    SessionAgentState.Unknown -> null
+}
+
+private val SessionAgentState.accessibilityDescription: String?
+    get() = when (this) {
+        SessionAgentState.WaitingForInput -> "Waiting for input"
+        SessionAgentState.Working -> "Working"
+        SessionAgentState.Idle -> "Idle (finished)"
+        SessionAgentState.Unknown -> null
+    }
 
 internal val AgentStateIconSize = 18.dp

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/AgentStateChipTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/AgentStateChipTest.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.model.SessionAgentState
 import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,12 +37,29 @@ class AgentStateChipTest {
 
     @Test
     fun waitingRendersAccessibleCompactIcon() {
-        assertAccessibleCompactIcon(SessionAgentState.WaitingForInput, "Waiting")
+        assertAccessibleCompactIcon(SessionAgentState.WaitingForInput, "Waiting for input")
     }
 
     @Test
     fun idleRendersAccessibleCompactIcon() {
-        assertAccessibleCompactIcon(SessionAgentState.Idle, "Idle")
+        assertAccessibleCompactIcon(SessionAgentState.Idle, "Idle (finished)")
+    }
+
+    @Test
+    fun stateDescriptionsDistinguishFinishedFromWorkingAndWaiting() {
+        composeRule.setContent {
+            PocketShellTheme {
+                AgentStateChip(state = SessionAgentState.Idle)
+                AgentStateChip(state = SessionAgentState.Working)
+                AgentStateChip(state = SessionAgentState.WaitingForInput)
+            }
+        }
+
+        // The idle glyph must communicate a finished/resting agent, not a
+        // paused control. Working and waiting remain separate states.
+        composeRule.onNodeWithContentDescription("Idle (finished)").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Working").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Waiting for input").assertIsDisplayed()
     }
 
     @Test
@@ -77,5 +96,19 @@ class AgentStateChipTest {
             .assertWidthIsEqualTo(18.dp)
             .assertHeightIsEqualTo(18.dp)
         composeRule.onNodeWithText(label).assertDoesNotExist()
+    }
+
+    @Test
+    fun stateIconsKeepWorkingAndFinishedDistinctFromWaiting() {
+        assertTrue(agentStateIconFor(SessionAgentState.Idle)?.name.orEmpty().endsWith("CheckCircle"))
+        assertTrue(agentStateIconFor(SessionAgentState.Working)?.name.orEmpty().endsWith("Autorenew"))
+        assertTrue(
+            agentStateIconFor(SessionAgentState.WaitingForInput)?.name.orEmpty().endsWith("HourglassEmpty"),
+        )
+        assertNotEquals(
+            "working must not be represented by the finished/idle icon",
+            agentStateIconFor(SessionAgentState.Working),
+            agentStateIconFor(SessionAgentState.Idle),
+        )
     }
 }


### PR DESCRIPTION
Implements #2255.

- replace the misleading idle PauseCircle glyph with a finished-state check icon
- keep Working/Waiting and provider identity semantics separate
- add state/icon regression coverage and refresh affected screenshot journey calls
- reviewer approval: https://github.com/alexeygrigorev/pocketshell/issues/2255#issuecomment-5359491852

Validation is recorded in the issue implementer/reviewer reports, including red old-mapping mutation, UI-kit tests, design render, and one authoritative connected emulator test.