### PR TITLE
test(lifecycle): isolate stale session prompt between journeys (#2249)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
@@ -36,7 +36,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
 import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
 import java.io.File
 
 /**
@@ -90,10 +93,29 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
 
     val compose = createAndroidComposeRule<MainActivity>()
 
+    /**
+     * Compose closes its ActivityScenario in its own rule teardown. Keep the
+     * process-scoped prompt reset after that close, so this class cannot carry
+     * a stale gone-session dialog from one journey into the next Activity.
+     */
+    private val cleanupAfterActivity = object : TestRule {
+        override fun apply(base: Statement, description: Description): Statement =
+            object : Statement() {
+                override fun evaluate() {
+                    try {
+                        base.evaluate()
+                    } finally {
+                        cleanupAfterActivityClosed()
+                    }
+                }
+            }
+    }
+
     @get:Rule
     val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
         .outerRule(PreGrantPermissionsRule())
         .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(cleanupAfterActivity)
         .around(compose)
 
     private lateinit var fixtureKey: String
@@ -103,6 +125,14 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
     @After
     fun tearDown() {
         runCatching { compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED) }
+    }
+
+    private fun cleanupAfterActivityClosed() {
+        // This runs outside the inner Compose rule, after ActivityScenario has
+        // closed the Activity. The prompt itself is intentionally process-scoped
+        // in production, but each connected-test method is an independent
+        // journey and must begin with no prompt left by its predecessor.
+        runCatching { clearProcessScopedStalePrompt() }
         BackgroundGraceTestOverride.setForTest(null)
         clearBackgroundGraceSetting()
         clearLastSessionPrefs()
@@ -115,6 +145,9 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
     }
 
     private suspend fun seedBeforeLaunch() {
+        // Also clear before the Activity launches. This protects the class when
+        // another connected test left the app singleton holding a stale prompt.
+        clearProcessScopedStalePrompt()
         clearLastSessionPrefs()
         clearBackgroundGraceSetting()
         BackgroundGraceTestOverride.setForTest(null)
@@ -126,6 +159,14 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
         assertTrue("seeded target session must be alive", sessionAlive(key, TARGET_SESSION))
         assertTrue("seeded keepalive session must be alive", sessionAlive(key, KEEPALIVE_SESSION))
         hostRowTag = seedDockerHost(key)
+    }
+
+    private fun clearProcessScopedStalePrompt() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        EntryPointAccessors
+            .fromApplication(context, TestAccessEntryPoint::class.java)
+            .staleSessionPromptController()
+            .clear()
     }
 
     @Test

--- a/app/src/main/java/com/pocketshell/app/testaccess/TestAccessEntryPoint.kt
+++ b/app/src/main/java/com/pocketshell/app/testaccess/TestAccessEntryPoint.kt
@@ -6,6 +6,7 @@ import com.pocketshell.app.session.LastSessionStore
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.app.settings.SettingsRepository
 import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.StaleSessionPromptController
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.dao.SshKeyDao
 import dagger.hilt.EntryPoint
@@ -71,6 +72,14 @@ internal interface TestAccessEntryPoint {
      * last-session restore target — instead of constructing a throwaway one.
      */
     fun sessionLifecycleSignals(): SessionLifecycleSignals
+
+    /**
+     * Issue #2249: the process-scoped stale-session prompt must be reset by
+     * connected-test lifecycle cleanup. The prompt is intentionally retained
+     * across Activity recreation in production, so an instrumentation class
+     * that recreates MainActivity must clear it between independent journeys.
+     */
+    fun staleSessionPromptController(): StaleSessionPromptController
 
     /**
      * Issue #834: the singleton [LastSessionStore] so the connected test can


### PR DESCRIPTION
## Summary

- isolate the process-scoped stale-session prompt between the two #2249 lifecycle journeys
- reset the test-only lifecycle/last-session seams before and after the class
- expose the existing prompt controller through the test-only access entry point

Issue: #2249

## Review and verification

- Verification handoff: https://github.com/alexeygrigorev/pocketshell/issues/2249#issuecomment-5360004629
- Independent reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2249#issuecomment-5360062607
- Full unfiltered JVM gate: BUILD SUCCESSFUL in 20m59s, 604 actionable tasks executed
- Exact lifecycle class: 2/2 green twice; selective cleanup mutation: 1 expected failure while the unrelated journey stayed green
- Static/validity/selection guards: green in reviewer evidence

The PR contains exactly the two reviewed source/test files and is based on the reviewed candidate patch.
