### PR TITLE
fix(navigation): consume Usage notification deep links once (#2256)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/nav/Issue1831SessionEntryPathBackE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/nav/Issue1831SessionEntryPathBackE2eTest.kt
@@ -5,6 +5,7 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.lifecycle.Lifecycle
 import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -30,6 +31,7 @@ import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -74,9 +76,11 @@ import java.io.File
  * Each must land Back on the host's SESSION list ([FOLDER_LIST_SCREEN_TAG]),
  * not the host list ([HOST_LIST_CONTENT_TAG]).
  *
- * A fifth test pins the paths whose host-list fallback is CORRECT and must not
- * change: the usage-notification launch (`EXTRA_OPEN_USAGE`) still goes Back to
- * the host list.
+ * The Usage tests pin the path whose host-list fallback is CORRECT and must not
+ * change: a usage-notification launch (`EXTRA_OPEN_USAGE`) goes Back to the host
+ * list, consumes that transient route before Activity recreation, and has the
+ * same one-shot contract when delivered to a warm Activity through
+ * `onNewIntent` (#2256).
  *
  * ## Harness note
  *
@@ -193,7 +197,7 @@ class Issue1831SessionEntryPathBackE2eTest {
      * there, not to some host's session list.
      */
     @Test
-    fun usageNotificationLaunchBackStillLandsOnHostList() {
+    fun usageNotificationLaunchBackRecreateDoesNotReplayUsage() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         launchedActivity = ActivityScenario.launch(
             Intent(context, MainActivity::class.java)
@@ -214,6 +218,68 @@ class Issue1831SessionEntryPathBackE2eTest {
         assertFalse(
             "Back from Usage must NOT land on a host's session list",
             onFolderList(),
+        )
+
+        recreateStoppedActivity()
+        val routeAfterRecreate = waitForHostListOrUsage()
+        record("02-after-recreate")
+        writeTrail("usage-back-recreate-trail.txt")
+        assertEquals(
+            "ISSUE 2256: the consumed Usage notification route must not replay after Back + " +
+                "Activity recreation. Route=$routeAfterRecreate. Observed: " +
+                trail.joinToString(" | "),
+            PostRecreateRoute.HOST_LIST,
+            routeAfterRecreate,
+        )
+        assertFalse(
+            "ISSUE 2256: EXTRA_OPEN_USAGE must be absent from the Activity's retained intent",
+            retainedActivityIntentHasUsageExtra(),
+        )
+    }
+
+    /** The same one-shot contract when a live Activity receives `onNewIntent`. */
+    @Test
+    fun warmUsageIntentBackRecreateDoesNotReplayUsage() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        launchedActivity = ActivityScenario.launch(Intent(context, MainActivity::class.java))
+        assertTrue("warm-delivery precondition must start on the host list", waitFor("host list") {
+            onHostList()
+        })
+
+        launchedActivity?.onActivity { activity ->
+            activity.startActivity(
+                Intent(activity, MainActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .putExtra(MainActivity.EXTRA_OPEN_USAGE, true),
+            )
+        }
+        assertTrue(
+            "warm onNewIntent delivery must route to Usage once",
+            waitFor("usage screen after warm intent") { nodesWithTag(USAGE_OVERFLOW_TAG) },
+        )
+        record("00-warm-usage")
+
+        pressSystemBack()
+        assertTrue(
+            "Back from warm-delivered Usage must land on the host list",
+            waitFor("host list after warm Usage Back") { onHostList() },
+        )
+        record("01-warm-after-back")
+
+        recreateStoppedActivity()
+        val routeAfterRecreate = waitForHostListOrUsage()
+        record("02-warm-after-recreate")
+        writeTrail("usage-warm-back-recreate-trail.txt")
+        assertEquals(
+            "ISSUE 2256: a warm-delivered consumed Usage route must not replay after Back + " +
+                "Activity recreation. Route=$routeAfterRecreate. Observed: " +
+                trail.joinToString(" | "),
+            PostRecreateRoute.HOST_LIST,
+            routeAfterRecreate,
+        )
+        assertFalse(
+            "ISSUE 2256: warm delivery must retain an intent without EXTRA_OPEN_USAGE",
+            retainedActivityIntentHasUsageExtra(),
         )
     }
 
@@ -272,6 +338,32 @@ class Issue1831SessionEntryPathBackE2eTest {
         return false
     }
 
+    /** Distinguishes a #2256 Usage replay from a generic screen-settle timeout. */
+    private fun waitForHostListOrUsage(): PostRecreateRoute {
+        val deadline = SystemClock.elapsedRealtime() + SCREEN_SETTLE_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (nodesWithTag(USAGE_OVERFLOW_TAG)) return PostRecreateRoute.USAGE
+            if (onHostList()) return PostRecreateRoute.HOST_LIST
+            SystemClock.sleep(100)
+        }
+        return PostRecreateRoute.TIMEOUT
+    }
+
+    private fun recreateStoppedActivity() {
+        launchedActivity?.moveToState(Lifecycle.State.CREATED)
+        launchedActivity?.recreate()
+        launchedActivity?.moveToState(Lifecycle.State.RESUMED)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun retainedActivityIntentHasUsageExtra(): Boolean {
+        var retained = false
+        launchedActivity?.onActivity { activity ->
+            retained = activity.intent.hasExtra(MainActivity.EXTRA_OPEN_USAGE)
+        }
+        return retained
+    }
+
     private fun waitFor(label: String, condition: () -> Boolean): Boolean {
         val deadline = SystemClock.elapsedRealtime() + SCREEN_SETTLE_MS
         while (SystemClock.elapsedRealtime() < deadline) {
@@ -297,7 +389,7 @@ class Issue1831SessionEntryPathBackE2eTest {
 
     private fun record(label: String) {
         val line = "$label => session=${onSessionScreen()} folderList=${onFolderList()} " +
-            "hostList=${onHostList()}"
+            "hostList=${onHostList()} usage=${nodesWithTag(USAGE_OVERFLOW_TAG)}"
         trail += line
         Log.i(LOG_TAG, "ISSUE1831_ENTRY_TRAIL $line")
         println("ISSUE1831_ENTRY_TRAIL $line")
@@ -420,6 +512,12 @@ class Issue1831SessionEntryPathBackE2eTest {
             "could not create artifact directory ${dir.absolutePath}"
         }
         File(dir, name).writeText(trail.joinToString(separator = "\n", postfix = "\n"))
+    }
+
+    private enum class PostRecreateRoute {
+        HOST_LIST,
+        USAGE,
+        TIMEOUT,
     }
 
     private companion object {

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -320,9 +320,11 @@ class MainActivity : FragmentActivity() {
         // The recency cap inside [LastSessionStore.read] is the second guard:
         // even on a genuine process-death resume, a snapshot older than 24h
         // is not restored.
-        val intentDestination = initialDestinationFromIntent(intent)
+        val incomingIntent = intent
+        val incomingRoute = decodeActivityRoute(incomingIntent)
+        val intentDestination = incomingRoute.destination
         val resumingFromProcessDeath = savedInstanceState != null
-        val importPayload = importPayloadFromIntent(intent)
+        val importPayload = importPayloadFromIntent(incomingIntent)
         // Issue #859 (Slice D): an agent-card push deep-links to the card's
         // session feed. We capture the request synchronously here, but resolve
         // the right host + route to it OFF the Main thread (see
@@ -330,11 +332,12 @@ class MainActivity : FragmentActivity() {
         // a key-file stat that must never block launch (the #951 off-Main
         // mandate). A no/ambiguous host match leaves the user on the host list,
         // never the wrong host.
-        val agentCardFeedRequest = agentCardFeedRequestFromIntent(intent)
+        val agentCardFeedRequest = agentCardFeedRequestFromIntent(incomingIntent)
         // Issue #560: a share-into-session launch carries the staged remote
         // attachment path(s); seed them into the session composer as #544
         // chips once the navigator reaches the tmux destination.
-        pendingComposerAttachments = composerAttachmentsFromIntent(intent)
+        pendingComposerAttachments = composerAttachmentsFromIntent(incomingIntent)
+        incomingRoute.retainedIntent?.let(::setIntent)
         StartupTiming.mark(
             "main-initial-route-input",
             "savedInstanceState" to resumingFromProcessDeath,
@@ -736,8 +739,9 @@ class MainActivity : FragmentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        setIntent(intent)
-        requestedDestination = initialDestinationFromIntent(intent)
+        val incomingRoute = decodeActivityRoute(intent)
+        setIntent(incomingRoute.retainedIntent ?: intent)
+        requestedDestination = incomingRoute.destination
         StartupTiming.mark(
             "main-new-intent",
             "requestedDestination" to requestedDestination.timingName(),
@@ -952,6 +956,14 @@ private fun AppNavigator(
             "current" to current.timingName(),
         )
         if (requestedDestination == AppDestination.PortForwardChooser && current != requestedDestination) {
+            backStack += current
+            setCurrentDestination(requestedDestination)
+        }
+        // Issue #2256: a Usage notification can be delivered to this existing
+        // Activity through onNewIntent. Treat that late request like the other
+        // explicit panel deep link above so it routes once through the normal
+        // navigator and Back returns to the screen that was already showing.
+        if (requestedDestination == AppDestination.Usage && current != requestedDestination) {
             backStack += current
             setCurrentDestination(requestedDestination)
         }
@@ -2067,6 +2079,29 @@ internal fun initialDestinationFromIntent(intent: Intent?): AppDestination {
     shareSessionDestinationFromIntent(intent)?.let { return it }
     return AppDestination.HostList
 }
+
+/**
+ * Decodes an Activity route once and returns the intent that Android may retain
+ * for a later Activity recreation. Usage notifications are transient commands,
+ * so their route extra is removed only after it has selected [AppDestination.Usage].
+ * Every adjacent route keeps its existing raw intent and restoration behavior.
+ */
+internal fun decodeActivityRoute(intent: Intent?): DecodedActivityRoute {
+    val destination = initialDestinationFromIntent(intent)
+    val retainedIntent = if (
+        intent?.getBooleanExtra(MainActivity.EXTRA_OPEN_USAGE, false) == true
+    ) {
+        Intent(intent).apply { removeExtra(MainActivity.EXTRA_OPEN_USAGE) }
+    } else {
+        intent
+    }
+    return DecodedActivityRoute(destination, retainedIntent)
+}
+
+internal data class DecodedActivityRoute(
+    val destination: AppDestination,
+    val retainedIntent: Intent?,
+)
 
 /**
  * Issue #560: build a [AppDestination.TmuxSession] from a share-into-session

--- a/app/src/test/java/com/pocketshell/app/MainActivityDeepLinkTest.kt
+++ b/app/src/test/java/com/pocketshell/app/MainActivityDeepLinkTest.kt
@@ -3,9 +3,13 @@ package com.pocketshell.app
 import android.content.Intent
 import android.net.Uri
 import com.pocketshell.app.nav.AppDestination
+import com.pocketshell.app.systemsurfaces.ForwardingTileService
 import com.pocketshell.core.storage.entity.HostEntity
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -215,6 +219,55 @@ class MainActivityDeepLinkTest {
         val intent = Intent().putExtra(MainActivity.EXTRA_OPEN_USAGE, true)
 
         assertEquals(AppDestination.Usage, initialDestinationFromIntent(intent))
+    }
+
+    @Test
+    fun decodeActivityRoute_routesUsageOnceAndRemovesOnlyItsRetainedExtra() {
+        val importUri = Uri.parse("pocketshell://import?payload=still-present")
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = importUri
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(MainActivity.EXTRA_OPEN_USAGE, true)
+            putExtra(MainActivity.EXTRA_OPEN_SESSION_FEED, true)
+            putExtra(MainActivity.EXTRA_OPEN_SESSION_FEED_SESSION, "claude-main")
+        }
+
+        val decoded = decodeActivityRoute(intent)
+
+        assertEquals(AppDestination.Usage, decoded.destination)
+        val retained = requireNotNull(decoded.retainedIntent)
+        assertFalse(retained.hasExtra(MainActivity.EXTRA_OPEN_USAGE))
+        assertEquals(Intent.ACTION_VIEW, retained.action)
+        assertEquals(importUri, retained.data)
+        assertEquals(intent.flags, retained.flags)
+        assertTrue(retained.getBooleanExtra(MainActivity.EXTRA_OPEN_SESSION_FEED, false))
+        assertEquals(
+            "claude-main",
+            retained.getStringExtra(MainActivity.EXTRA_OPEN_SESSION_FEED_SESSION),
+        )
+        assertTrue("sanitization must not mutate the delivered intent", intent.hasExtra(
+            MainActivity.EXTRA_OPEN_USAGE,
+        ))
+    }
+
+    @Test
+    fun decodeActivityRoute_leavesAdjacentTransientRoutesUntouched() {
+        val adjacentRoutes = listOf(
+            Intent().putExtra(ForwardingTileService.EXTRA_OPEN_PORT_FORWARDING, true),
+            shareSessionIntent(),
+            Intent(Intent.ACTION_VIEW).apply {
+                data = Uri.parse("pocketshell://import?payload=host")
+            },
+            Intent().apply {
+                putExtra(MainActivity.EXTRA_OPEN_SESSION_FEED, true)
+                putExtra(MainActivity.EXTRA_OPEN_SESSION_FEED_SESSION, "claude-main")
+                putExtra(MainActivity.EXTRA_OPEN_SESSION_FEED_HOST, "hetzner")
+            },
+        )
+
+        adjacentRoutes.forEach { incoming ->
+            assertSame(incoming, decodeActivityRoute(incoming).retainedIntent)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- consume `EXTRA_OPEN_USAGE` as a one-shot route and retain a sanitized Activity intent
- apply the same behavior to cold `onCreate` and warm `onNewIntent` delivery
- add cold/warm recreation journeys and adjacent-route unit coverage

Issue: #2256

## Evidence and review

- Implementer: https://github.com/alexeygrigorev/pocketshell/issues/2256#issuecomment-5359764949
- Independent reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2256#issuecomment-5359846597
- Full-gate verification: https://github.com/alexeygrigorev/pocketshell/issues/2256#issuecomment-5360095933
- Focused connected journey: 5 tests, 0 failures/errors, including cold and warm Usage delivery
- Live raw-intent mutation: 1 test, 1 expected load-bearing failure with `Route=USAGE`; source restoration was byte-exact
- Full unfiltered JVM gate: BUILD SUCCESSFUL in 19m54s, 604 actionable tasks executed
- Static/test-validity/CI-harness checks passed

The PR contains exactly the three reviewed tracked product/test files. Current-main CI is monitored separately and is not being claimed green by this PR description.
