### PR TITLE
fix(ci): separate UX smoke startup and result deadlines (#2260)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,7 +231,11 @@ jobs:
       # include stateful interactions that a static link check cannot cover.
       - name: Work-first UX mockup smoke test (issue #2238)
         run: |
-          chmod +x scripts/test-ux-redesign-2238.sh
+          chmod +x \
+            scripts/test-ux-redesign-2238.sh \
+            scripts/test-ux-redesign-2238-fake-browser.py \
+            scripts/test-ux-redesign-2238-timeouts-selftest.sh
+          scripts/test-ux-redesign-2238-timeouts-selftest.sh
           scripts/test-ux-redesign-2238.sh
 
       # Issue #657/#1857 (F4): test-validity guard. Flags the highest-signal

--- a/scripts/test-ux-redesign-2238-fake-browser.py
+++ b/scripts/test-ux-redesign-2238-fake-browser.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Tiny deterministic browser stand-in for the #2260 smoke-harness self-test."""
+
+import json
+import os
+import re
+import sys
+import time
+from urllib.parse import urlencode, urlparse
+from urllib.request import urlopen
+
+
+def main() -> int:
+    startup_delay = float(os.environ.get("POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS", "0"))
+    result_delay = float(os.environ.get("POCKETSHELL_FAKE_BROWSER_RESULT_DELAY_SECONDS", "0"))
+    mode = os.environ.get("POCKETSHELL_FAKE_BROWSER_MODE", "report")
+    time.sleep(startup_delay)
+
+    page_url = sys.argv[-1]
+    with urlopen(page_url, timeout=10) as response:
+        page = response.read().decode("utf-8")
+
+    match = re.search(r"const token = (\".*?\");", page)
+    if match is None:
+        raise RuntimeError("smoke observer token was not injected")
+    token = json.loads(match.group(1))
+
+    if mode == "missing":
+        while True:
+            time.sleep(1)
+
+    time.sleep(result_delay)
+    result_url = f"{urlparse(page_url)._replace(query='', fragment='').geturl()}"
+    result_url = result_url.rsplit("/ux-redesign-2238.html", 1)[0]
+    result_url += "/__pocketshell_smoke_result?" + urlencode(
+        {"token": token, "value": "pass", "text": "fake browser"}
+    )
+    with urlopen(result_url, timeout=10):
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-ux-redesign-2238-timeouts-selftest.sh
+++ b/scripts/test-ux-redesign-2238-timeouts-selftest.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Issue #2260: the browser-load phase must not consume the result-reporting
+# phase's budget, while a page that never reports must still fail closed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE_SCRIPT="$SCRIPT_DIR/test-ux-redesign-2238.sh"
+FAKE_BROWSER="$SCRIPT_DIR/test-ux-redesign-2238-fake-browser.py"
+SANDBOX="$(mktemp -d)"
+MUTANT_SCRIPT="$SCRIPT_DIR/.test-ux-redesign-2238-mutant.$$"
+trap 'rm -rf "$SANDBOX" "$MUTANT_SCRIPT"' EXIT
+
+fail() {
+  echo "TEST FAIL: $*" >&2
+  exit 1
+}
+
+run_case() {
+  local log_path="$1"
+  shift
+  set +e
+  timeout 10s "$@" >"$log_path" 2>&1
+  CASE_RC=$?
+  set -e
+}
+
+assert_reported_result() {
+  local label="$1" log_path="$2"
+  (( CASE_RC == 0 )) || {
+    tail -n 80 "$log_path" >&2
+    fail "$label did not pass (rc=$CASE_RC)"
+  }
+  grep -Fqx 'PASS: #2238 HTML prototype browser smoke test' "$log_path" \
+    || { tail -n 80 "$log_path" >&2; fail "$label had no PASS result"; }
+}
+
+assert_missing_result_failure() {
+  local label="$1" log_path="$2"
+  (( CASE_RC != 0 )) || fail "$label unexpectedly passed"
+  grep -Fq 'browser interaction smoke test did not report a result' "$log_path" \
+    || { tail -n 80 "$log_path" >&2; fail "$label did not fail at the result phase"; }
+}
+
+common_env=(
+  env
+  "POCKETSHELL_BROWSER=$FAKE_BROWSER"
+  "POCKETSHELL_BROWSER_SMOKE_SERVER_START_TIMEOUT_SECONDS=5"
+  "POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS=5"
+  "POCKETSHELL_BROWSER_SMOKE_RESULT_TIMEOUT_SECONDS=1"
+  "POCKETSHELL_FAKE_BROWSER_RESULT_DELAY_SECONDS=0.25"
+)
+
+# A two-second fake browser startup is longer than the one-second result
+# budget. It must still pass because the result clock starts only after the
+# server has served the smoke page.
+run_case "$SANDBOX/delayed-start.log" \
+  "${common_env[@]}" \
+  POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=2 \
+  POCKETSHELL_FAKE_BROWSER_MODE=report \
+  "$SMOKE_SCRIPT"
+assert_reported_result "delayed browser startup" "$SANDBOX/delayed-start.log"
+
+# Mutation proof: reintroduce the old shared-deadline shape into a temporary
+# copy. The same delayed browser must then miss the already-expired result
+# budget. This makes the timing assertion load-bearing rather than decorative.
+cp "$SMOKE_SCRIPT" "$MUTANT_SCRIPT"
+MUTANT_DEADLINE_LINE="smoke_deadline=\$((SECONDS + SMOKE_RESULT_TIMEOUT_SECONDS))"
+MUTANT_RESULT_LINE="result_deadline=\"\$smoke_deadline\""
+sed -i \
+  -e "/^setsid env -u DBUS_SESSION_BUS_ADDRESS -u DBUS_SYSTEM_BUS_ADDRESS/i $MUTANT_DEADLINE_LINE" \
+  -e "s/^result_deadline=.*\$/$MUTANT_RESULT_LINE/" \
+  "$MUTANT_SCRIPT"
+grep -Fq "$MUTANT_DEADLINE_LINE" "$MUTANT_SCRIPT" \
+  || fail "shared-deadline mutation was not installed"
+grep -Fq "$MUTANT_RESULT_LINE" "$MUTANT_SCRIPT" \
+  || fail "shared-deadline mutation did not replace the result deadline"
+
+run_case "$SANDBOX/shared-deadline-mutant.log" \
+  "${common_env[@]}" \
+  POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=2 \
+  POCKETSHELL_FAKE_BROWSER_MODE=report \
+  "$MUTANT_SCRIPT"
+assert_missing_result_failure "shared-deadline mutation" "$SANDBOX/shared-deadline-mutant.log"
+
+# A real missing result must remain a bounded hard failure after the page has
+# loaded. The one-second result budget keeps this self-test fast and selective.
+run_case "$SANDBOX/missing-result.log" \
+  "${common_env[@]}" \
+  POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=0 \
+  POCKETSHELL_FAKE_BROWSER_MODE=missing \
+  "$SMOKE_SCRIPT"
+assert_missing_result_failure "missing result" "$SANDBOX/missing-result.log"
+
+echo "PASS: #2260 UX smoke timeout self-test"

--- a/scripts/test-ux-redesign-2238-timeouts-selftest.sh
+++ b/scripts/test-ux-redesign-2238-timeouts-selftest.sh
@@ -16,10 +16,11 @@ fail() {
 }
 
 run_case() {
-  local log_path="$1"
-  shift
+  local timeout_seconds="$1"
+  local log_path="$2"
+  shift 2
   set +e
-  timeout 10s "$@" >"$log_path" 2>&1
+  timeout "${timeout_seconds}s" "$@" >"$log_path" 2>&1
   CASE_RC=$?
   set -e
 }
@@ -45,16 +46,26 @@ common_env=(
   env
   "POCKETSHELL_BROWSER=$FAKE_BROWSER"
   "POCKETSHELL_BROWSER_SMOKE_SERVER_START_TIMEOUT_SECONDS=5"
-  "POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS=5"
   "POCKETSHELL_BROWSER_SMOKE_RESULT_TIMEOUT_SECONDS=1"
   "POCKETSHELL_FAKE_BROWSER_RESULT_DELAY_SECONDS=0.25"
 )
 
+# Hosted-shaped regression: the observed runner needed more than the old 30s
+# browser-load window before it requested the page. The default 60s budget must
+# absorb that startup while retaining the one-second result budget.
+run_case 75 "$SANDBOX/hosted-start.log" \
+  "${common_env[@]}" \
+  POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=31 \
+  POCKETSHELL_FAKE_BROWSER_MODE=report \
+  "$SMOKE_SCRIPT"
+assert_reported_result "hosted-shaped browser startup" "$SANDBOX/hosted-start.log"
+
 # A two-second fake browser startup is longer than the one-second result
 # budget. It must still pass because the result clock starts only after the
 # server has served the smoke page.
-run_case "$SANDBOX/delayed-start.log" \
+run_case 10 "$SANDBOX/delayed-start.log" \
   "${common_env[@]}" \
+  POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS=5 \
   POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=2 \
   POCKETSHELL_FAKE_BROWSER_MODE=report \
   "$SMOKE_SCRIPT"
@@ -75,8 +86,9 @@ grep -Fq "$MUTANT_DEADLINE_LINE" "$MUTANT_SCRIPT" \
 grep -Fq "$MUTANT_RESULT_LINE" "$MUTANT_SCRIPT" \
   || fail "shared-deadline mutation did not replace the result deadline"
 
-run_case "$SANDBOX/shared-deadline-mutant.log" \
+run_case 10 "$SANDBOX/shared-deadline-mutant.log" \
   "${common_env[@]}" \
+  POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS=5 \
   POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=2 \
   POCKETSHELL_FAKE_BROWSER_MODE=report \
   "$MUTANT_SCRIPT"
@@ -84,8 +96,9 @@ assert_missing_result_failure "shared-deadline mutation" "$SANDBOX/shared-deadli
 
 # A real missing result must remain a bounded hard failure after the page has
 # loaded. The one-second result budget keeps this self-test fast and selective.
-run_case "$SANDBOX/missing-result.log" \
+run_case 10 "$SANDBOX/missing-result.log" \
   "${common_env[@]}" \
+  POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS=5 \
   POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=0 \
   POCKETSHELL_FAKE_BROWSER_MODE=missing \
   "$SMOKE_SCRIPT"

--- a/scripts/test-ux-redesign-2238.sh
+++ b/scripts/test-ux-redesign-2238.sh
@@ -20,7 +20,9 @@ fi
 # These are deliberately separate so a slow hosted runner reports which phase
 # exhausted its bounded wait instead of looking like a missing DOM result.
 SERVER_START_TIMEOUT_SECONDS="${POCKETSHELL_BROWSER_SMOKE_SERVER_START_TIMEOUT_SECONDS:-30}"
-BROWSER_LOAD_TIMEOUT_SECONDS="${POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS:-30}"
+# Hosted Chromium startup has exceeded 30s (issue #2260). Keep this bounded,
+# but give process startup/page load its own 60s window before the result clock.
+BROWSER_LOAD_TIMEOUT_SECONDS="${POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS:-60}"
 SMOKE_RESULT_TIMEOUT_SECONDS="${POCKETSHELL_BROWSER_SMOKE_RESULT_TIMEOUT_SECONDS:-30}"
 for timeout_value in \
   "$SERVER_START_TIMEOUT_SECONDS" \
@@ -83,6 +85,19 @@ cleanup() {
 trap cleanup EXIT
 
 print_diagnostics() {
+  local phase="${1:-unknown}"
+  local page_request_seen="no"
+  local smoke_result_seen="no"
+  [[ -s "$PAGE_REQUEST_FILE" ]] && page_request_seen="yes"
+  [[ -s "$SMOKE_RESULT_FILE" ]] && smoke_result_seen="yes"
+  echo "--- browser smoke diagnostics ---" >&2
+  echo "phase=$phase" >&2
+  echo "server_port=${SERVER_PORT:-unassigned}" >&2
+  echo "page_request_seen=$page_request_seen" >&2
+  echo "smoke_result_seen=$smoke_result_seen" >&2
+  echo "server_start_timeout_seconds=$SERVER_START_TIMEOUT_SECONDS" >&2
+  echo "browser_load_timeout_seconds=$BROWSER_LOAD_TIMEOUT_SECONDS" >&2
+  echo "smoke_result_timeout_seconds=$SMOKE_RESULT_TIMEOUT_SECONDS" >&2
   echo "--- browser diagnostics ---" >&2
   if [[ -s "$BROWSER_LOG" ]]; then
     tail -n 80 "$BROWSER_LOG" >&2
@@ -186,7 +201,7 @@ done
 [[ -s "$SERVER_PORT_FILE" ]] \
   || {
     echo "FAIL: browser smoke server did not start within ${SERVER_START_TIMEOUT_SECONDS}s" >&2
-    print_diagnostics
+    print_diagnostics "server-start"
     exit 1
   }
 
@@ -194,7 +209,7 @@ SERVER_PORT="$(<"$SERVER_PORT_FILE")"
 [[ "$SERVER_PORT" =~ ^[1-9][0-9]*$ ]] \
   || {
     echo "FAIL: browser smoke server returned an invalid port" >&2
-    print_diagnostics
+    print_diagnostics "server-port"
     exit 1
   }
 SMOKE_QUERY="smoke=1"
@@ -240,7 +255,7 @@ if [[ ! -s "$PAGE_REQUEST_FILE" ]]; then
   stop_browser
   stop_server
   echo "FAIL: browser did not load the smoke page within ${BROWSER_LOAD_TIMEOUT_SECONDS}s" >&2
-  print_diagnostics
+  print_diagnostics "browser-load"
   exit 1
 fi
 
@@ -258,7 +273,7 @@ stop_server
 [[ -s "$SMOKE_RESULT_FILE" ]] \
   || {
     echo "FAIL: browser interaction smoke test did not report a result within ${SMOKE_RESULT_TIMEOUT_SECONDS}s after page load" >&2
-    print_diagnostics
+    print_diagnostics "smoke-result"
     exit 1
   }
 IFS= read -r SMOKE_RESULT <"$SMOKE_RESULT_FILE"
@@ -266,7 +281,7 @@ IFS= read -r SMOKE_RESULT <"$SMOKE_RESULT_FILE"
   || {
     echo "FAIL: browser interaction smoke test reported data-smoke=\"$SMOKE_RESULT\"" >&2
     tail -n +2 "$SMOKE_RESULT_FILE" >&2
-    print_diagnostics
+    print_diagnostics "smoke-result-value"
     exit 1
   }
 

--- a/scripts/test-ux-redesign-2238.sh
+++ b/scripts/test-ux-redesign-2238.sh
@@ -16,6 +16,20 @@ if [[ -z "$BROWSER" ]]; then
 fi
 [[ -n "$BROWSER" ]] || { echo "FAIL: Chromium/Chrome is required for the #2238 smoke check" >&2; exit 1; }
 
+# Keep browser startup/load cost from consuming the result-reporting budget.
+# These are deliberately separate so a slow hosted runner reports which phase
+# exhausted its bounded wait instead of looking like a missing DOM result.
+SERVER_START_TIMEOUT_SECONDS="${POCKETSHELL_BROWSER_SMOKE_SERVER_START_TIMEOUT_SECONDS:-30}"
+BROWSER_LOAD_TIMEOUT_SECONDS="${POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS:-30}"
+SMOKE_RESULT_TIMEOUT_SECONDS="${POCKETSHELL_BROWSER_SMOKE_RESULT_TIMEOUT_SECONDS:-30}"
+for timeout_value in \
+  "$SERVER_START_TIMEOUT_SECONDS" \
+  "$BROWSER_LOAD_TIMEOUT_SECONDS" \
+  "$SMOKE_RESULT_TIMEOUT_SECONDS"; do
+  [[ "$timeout_value" =~ ^[1-9][0-9]*$ ]] \
+    || { echo "FAIL: browser smoke timeouts must be positive integers" >&2; exit 1; }
+done
+
 BROWSER_MODE_FLAGS=()
 if [[ "${POCKETSHELL_FORCE_COLORS:-0}" == "1" ]]; then
   BROWSER_MODE_FLAGS+=(--force-high-contrast)
@@ -24,7 +38,9 @@ fi
 BROWSER_DATA_DIR="$(mktemp -d)"
 SERVER_PORT_FILE="$(mktemp)"
 SMOKE_RESULT_FILE="$(mktemp)"
+PAGE_REQUEST_FILE="$(mktemp)"
 SERVER_LOG="$(mktemp)"
+BROWSER_LOG="$(mktemp)"
 SMOKE_TOKEN="$(basename "$SMOKE_RESULT_FILE")"
 BROWSER_PID=""
 BROWSER_PGID=""
@@ -56,11 +72,38 @@ cleanup() {
   stop_browser
   stop_server
   rm -rf "$BROWSER_DATA_DIR"
-  rm -f "$SERVER_PORT_FILE" "$SMOKE_RESULT_FILE" "$SMOKE_RESULT_FILE.pending" "$SERVER_LOG"
+  rm -f \
+    "$SERVER_PORT_FILE" \
+    "$SMOKE_RESULT_FILE" \
+    "$SMOKE_RESULT_FILE.pending" \
+    "$PAGE_REQUEST_FILE" \
+    "$SERVER_LOG" \
+    "$BROWSER_LOG"
 }
 trap cleanup EXIT
 
-setsid python3 -u - "$MOCKUP" "$SERVER_PORT_FILE" "$SMOKE_RESULT_FILE" "$SMOKE_TOKEN" >"$SERVER_LOG" 2>&1 <<'PY' &
+print_diagnostics() {
+  echo "--- browser diagnostics ---" >&2
+  if [[ -s "$BROWSER_LOG" ]]; then
+    tail -n 80 "$BROWSER_LOG" >&2
+  else
+    echo "(browser produced no diagnostics)" >&2
+  fi
+  echo "--- server diagnostics ---" >&2
+  if [[ -s "$SERVER_LOG" ]]; then
+    tail -n 80 "$SERVER_LOG" >&2
+  else
+    echo "(server produced no diagnostics)" >&2
+  fi
+}
+
+setsid python3 -u - \
+  "$MOCKUP" \
+  "$SERVER_PORT_FILE" \
+  "$SMOKE_RESULT_FILE" \
+  "$SMOKE_TOKEN" \
+  "$PAGE_REQUEST_FILE" \
+  >"$SERVER_LOG" 2>&1 <<'PY' &
 import json
 import os
 import sys
@@ -72,6 +115,7 @@ mockup = Path(sys.argv[1])
 port_file = Path(sys.argv[2])
 result_file = Path(sys.argv[3])
 token = sys.argv[4]
+page_request_file = Path(sys.argv[5])
 
 observer = f"""<script>
 (() => {{
@@ -119,6 +163,8 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+        self.wfile.flush()
+        page_request_file.write_text("loaded\n", encoding="ascii")
 
     def log_message(self, message, *args):
         print(message % args, flush=True)
@@ -131,18 +177,26 @@ PY
 SERVER_PID=$!
 SERVER_PGID=$SERVER_PID
 
-deadline=$((SECONDS + 30))
+server_deadline=$((SECONDS + SERVER_START_TIMEOUT_SECONDS))
 while [[ ! -s "$SERVER_PORT_FILE" ]]; do
   kill -0 "$SERVER_PID" 2>/dev/null || break
-  (( SECONDS < deadline )) || break
+  (( SECONDS < server_deadline )) || break
   sleep 0.1
 done
 [[ -s "$SERVER_PORT_FILE" ]] \
-  || { echo "FAIL: browser smoke server did not start" >&2; cat "$SERVER_LOG" >&2; exit 1; }
+  || {
+    echo "FAIL: browser smoke server did not start within ${SERVER_START_TIMEOUT_SECONDS}s" >&2
+    print_diagnostics
+    exit 1
+  }
 
 SERVER_PORT="$(<"$SERVER_PORT_FILE")"
 [[ "$SERVER_PORT" =~ ^[1-9][0-9]*$ ]] \
-  || { echo "FAIL: browser smoke server returned an invalid port" >&2; cat "$SERVER_LOG" >&2; exit 1; }
+  || {
+    echo "FAIL: browser smoke server returned an invalid port" >&2
+    print_diagnostics
+    exit 1
+  }
 SMOKE_QUERY="smoke=1"
 if [[ "${POCKETSHELL_FORCE_COLORS:-0}" == "1" ]]; then
   SMOKE_QUERY+="&forced-colors=1"
@@ -169,14 +223,32 @@ setsid env -u DBUS_SESSION_BUS_ADDRESS -u DBUS_SYSTEM_BUS_ADDRESS \
   --user-data-dir="$BROWSER_DATA_DIR" \
   --window-size=390,844 \
   --virtual-time-budget=5000 \
-  "$MOCKUP_URI" &
+  "$MOCKUP_URI" \
+  >"$BROWSER_LOG" 2>&1 &
 BROWSER_PID=$!
 BROWSER_PGID=$BROWSER_PID
 
+browser_load_deadline=$((SECONDS + BROWSER_LOAD_TIMEOUT_SECONDS))
+while [[ ! -s "$PAGE_REQUEST_FILE" ]]; do
+  kill -0 "$BROWSER_PID" 2>/dev/null || break
+  kill -0 "$SERVER_PID" 2>/dev/null || break
+  (( SECONDS < browser_load_deadline )) || break
+  sleep 0.1
+done
+
+if [[ ! -s "$PAGE_REQUEST_FILE" ]]; then
+  stop_browser
+  stop_server
+  echo "FAIL: browser did not load the smoke page within ${BROWSER_LOAD_TIMEOUT_SECONDS}s" >&2
+  print_diagnostics
+  exit 1
+fi
+
+result_deadline=$((SECONDS + SMOKE_RESULT_TIMEOUT_SECONDS))
 while [[ ! -s "$SMOKE_RESULT_FILE" ]]; do
   kill -0 "$BROWSER_PID" 2>/dev/null || break
   kill -0 "$SERVER_PID" 2>/dev/null || break
-  (( SECONDS < deadline )) || break
+  (( SECONDS < result_deadline )) || break
   sleep 0.1
 done
 
@@ -184,9 +256,18 @@ stop_browser
 stop_server
 
 [[ -s "$SMOKE_RESULT_FILE" ]] \
-  || { echo "FAIL: browser interaction smoke test did not report a result" >&2; cat "$SERVER_LOG" >&2; exit 1; }
+  || {
+    echo "FAIL: browser interaction smoke test did not report a result within ${SMOKE_RESULT_TIMEOUT_SECONDS}s after page load" >&2
+    print_diagnostics
+    exit 1
+  }
 IFS= read -r SMOKE_RESULT <"$SMOKE_RESULT_FILE"
 [[ "$SMOKE_RESULT" == "pass" ]] \
-  || { echo "FAIL: browser interaction smoke test reported data-smoke=\"$SMOKE_RESULT\"" >&2; tail -n +2 "$SMOKE_RESULT_FILE" >&2; exit 1; }
+  || {
+    echo "FAIL: browser interaction smoke test reported data-smoke=\"$SMOKE_RESULT\"" >&2
+    tail -n +2 "$SMOKE_RESULT_FILE" >&2
+    print_diagnostics
+    exit 1
+  }
 
 echo "PASS: #2238 HTML prototype browser smoke test"


### PR DESCRIPTION
Fixes #2260.

The #2238 browser smoke used one 30-second wall-clock deadline beginning before Chromium startup. Hosted runners could serve the page at the deadline and be killed before the DOM result callback, producing a misleading no-result failure.

Changes:
- separate server-start, browser-page-load, and smoke-result deadlines;
- begin result timing after the page is served;
- preserve bounded failures with browser/server diagnostics;
- add a fake-browser selective self-test for delayed startup, the shared-deadline mutant, and a genuinely missing result;
- run that self-test in Static guards before real Chromium.

Evidence:
- implementer: https://github.com/alexeygrigorev/pocketshell/issues/2260#issuecomment-5360602896
- reviewer: https://github.com/alexeygrigorev/pocketshell/issues/2260#issuecomment-5360811677
- commit: `11d2ecb2`
- full local `guards-static` sequence, mutation proof, real Chromium (3/3), forced-colors, syntax, ShellCheck, and diff checks passed.

The existing Usage PR #2259 was blocked by this shared Static guard failure; after this PR merges, update/recheck #2259 on the new main.