### PR TITLE
fix(ci): give hosted UX self-test enough result time

### DIFF
--- a/scripts/test-ux-redesign-2238-timeouts-selftest.sh
+++ b/scripts/test-ux-redesign-2238-timeouts-selftest.sh
@@ -52,17 +52,20 @@ common_env=(
 
 # Hosted-shaped regression: the observed runner needed more than the old 30s
 # browser-load window before it requested the page. The default 60s budget must
-# absorb that startup while retaining the one-second result budget.
+# absorb that startup. Once the page is loaded, use a realistic five-second
+# result budget for this hosted-shaped callback; the focused timing cases below
+# deliberately retain the strict one-second result budget.
 run_case 75 "$SANDBOX/hosted-start.log" \
   "${common_env[@]}" \
+  POCKETSHELL_BROWSER_SMOKE_RESULT_TIMEOUT_SECONDS=5 \
   POCKETSHELL_FAKE_BROWSER_STARTUP_SECONDS=31 \
   POCKETSHELL_FAKE_BROWSER_MODE=report \
   "$SMOKE_SCRIPT"
 assert_reported_result "hosted-shaped browser startup" "$SANDBOX/hosted-start.log"
 
-# A two-second fake browser startup is longer than the one-second result
-# budget. It must still pass because the result clock starts only after the
-# server has served the smoke page.
+# Keep the one-second result budget here. A two-second fake browser startup is
+# longer than that budget, but it must still pass because the result clock
+# starts only after the server has served the smoke page.
 run_case 10 "$SANDBOX/delayed-start.log" \
   "${common_env[@]}" \
   POCKETSHELL_BROWSER_SMOKE_BROWSER_LOAD_TIMEOUT_SECONDS=5 \


### PR DESCRIPTION
Closes #2262.

Follow-up to #2260 / merged PR #2261. The hosted-shaped 31-second fake-browser case was still inheriting the self-test's strict 1-second post-load result deadline, so Static guards failed even though the production smoke deadlines were separated correctly.

This one-file change gives only that hosted-shaped case a 5-second result budget. The delayed-start, shared-deadline mutant, and missing-result cases retain the strict 1-second budget and the mutation/failure-phase assertions remain intact.

Reviewed candidate evidence: reviewer APPROVED on #2260 comment 5361256337. Fresh branch validation: self-test PASS; Bash syntax, ShellCheck, and diff check PASS. No Android behavior is involved.