### PR TITLE
fix: make port-forward teardown race-safe

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
@@ -46,6 +46,7 @@ internal class RealSshPortForward(
     override val remoteHost: String,
     override val remotePort: Int,
     override val localPort: Int,
+    private val activePairs: MutableSet<Pair<Socket, DirectConnection>> = CopyOnWriteArraySet(),
 ) : SshPortForward {
 
     private val serverSocket: ServerSocket =
@@ -57,23 +58,23 @@ internal class RealSshPortForward(
     private val activeConnectionSlots = AtomicInteger(0)
 
     /**
+     * Serialises pair ownership and copy-thread registration with close().
+     * Once [running] is false, no new copy thread may be registered. This
+     * makes the snapshots used by close() complete: a thread cannot appear
+     * after close has taken its join set.
+     */
+    private val lifecycleLock = Any()
+
+    /**
      * Live copy threads (one per direction, per accepted connection). We
      * track these so [close] can `join` them deterministically rather than
      * relying on daemon-thread auto-cleanup, which would leak file
      * descriptors briefly after teardown and produce flaky tests.
-     * `CopyOnWriteArraySet` is a fine fit — writes are rare (only on
-     * connection open/close), reads happen in [close].
+     * Mutations are serialised by [lifecycleLock]. A live thread is never
+     * removed by [close] merely because its join budget expired; its finally
+     * block owns removal when it actually exits.
      */
     private val copyThreads: CopyOnWriteArraySet<Thread> = CopyOnWriteArraySet()
-
-    /**
-     * Currently-open accepted-connection pairs. [close] iterates and
-     * closes each one, which unblocks the per-direction copy threads
-     * (they're stuck on `read()` on one of these streams, not on the
-     * `running` flag — that's only checked between iterations).
-     */
-    private val activePairs: CopyOnWriteArraySet<Pair<Socket, DirectConnection>> =
-        CopyOnWriteArraySet()
 
     /** Daemon thread that accepts incoming local connections. */
     private val acceptThread: Thread = Thread(::acceptLoop, "ssh-portfwd-accept-$localPort").apply {
@@ -142,12 +143,15 @@ internal class RealSshPortForward(
         }
 
         val pair = local to channel
-        activePairs.add(pair)
-        // Re-check `running` AFTER adding to the set: close() may have
-        // raced past us and already swept activePairs (without seeing
-        // ours). In that case we close eagerly and skip the copy threads.
-        if (!running.get()) {
-            activePairs.remove(pair)
+        val pairRegistered = synchronized(lifecycleLock) {
+            if (!running.get()) {
+                false
+            } else {
+                activePairs.add(pair)
+                true
+            }
+        }
+        if (!pairRegistered) {
             try {
                 closePair(local, channel)
             } finally {
@@ -177,7 +181,8 @@ internal class RealSshPortForward(
     }
 
     private fun closePairAndUntrack(pair: Pair<Socket, DirectConnection>) {
-        if (activePairs.remove(pair)) {
+        val owned = synchronized(lifecycleLock) { activePairs.remove(pair) }
+        if (owned) {
             try {
                 closePair(pair.first, pair.second)
             } finally {
@@ -209,11 +214,16 @@ internal class RealSshPortForward(
             try {
                 body()
             } finally {
-                copyThreads.remove(Thread.currentThread())
+                synchronized(lifecycleLock) {
+                    copyThreads.remove(Thread.currentThread())
+                }
             }
         }, name).apply { isDaemon = true }
-        copyThreads.add(thread)
-        thread.start()
+        synchronized(lifecycleLock) {
+            if (!running.get()) return
+            copyThreads.add(thread)
+            thread.start()
+        }
     }
 
     private fun copy(src: InputStream, dst: OutputStream, counter: AtomicLong) {
@@ -239,23 +249,35 @@ internal class RealSshPortForward(
         channels.closeChannel(channel)
     }
 
+    /**
+     * Stops accepting connections and tears down owned pairs.
+     *
+     * The lifecycle lock seals pair/thread registration before the snapshots
+     * are taken. A close that cannot prove every copy thread terminated within
+     * the aggregate join budget interrupts the remaining threads and throws a
+     * diagnostic; it never silently detaches a live thread from [copyThreads].
+     */
     override fun close() {
-        // `compareAndSet` gives us a single-shot guarantee: the first
-        // caller wins and runs the teardown, every subsequent (including
-        // concurrent) close() returns immediately. This is what makes
-        // double-close + concurrent close + stop-during-copy safe — there
-        // is exactly one writer to serverSocket.close(), and copy threads
-        // observe `running` going false on their next iteration.
-        if (!running.compareAndSet(true, false)) return
+        // Seal the lifecycle transition and pair snapshot together. A copy
+        // callback that reaches closePairAndUntrack concurrently must either
+        // claim the pair before this block or observe that close() owns it;
+        // it cannot mutate activePairs between the snapshot and clear.
+        val pairs = synchronized(lifecycleLock) {
+            // `running` is written under the same lock that serialises every
+            // activePairs mutation and snapshot. This also makes the
+            // post-close startCopyThread check a single lifecycle decision.
+            if (!running.compareAndSet(true, false)) return
+            val snapshot = ArrayList(activePairs)
+            activePairs.clear()
+            snapshot
+        }
         runCatching { serverSocket.close() }
         // Close every accepted-connection pair we still own. Copy
         // threads block on `src.read(buf)` inside [copy], which doesn't
         // check `running` until between iterations — so closing the
-        // underlying sockets is what actually unblocks them (`read`
-        // throws IOException, which the loop catches as normal
+        // underlying socket and channel is what actually unblocks them
+        // (`read` throws IOException, which the loop catches as normal
         // termination).
-        val pairs = activePairs.toList()
-        activePairs.clear()
         for ((local, channel) in pairs) {
             try {
                 closePair(local, channel)
@@ -269,19 +291,65 @@ internal class RealSshPortForward(
         // calling close() — unusual but cheap to guard).
         val self = Thread.currentThread()
         val deadlineNanos = System.nanoTime() + CLOSE_JOIN_TIMEOUT_MS * NANOS_PER_MILLI
-        for (t in copyThreads) {
+        val threadsToJoin = synchronized(lifecycleLock) { ArrayList(copyThreads) }
+        for (t in threadsToJoin) {
             if (t === self) continue
             val remainingMillis = (deadlineNanos - System.nanoTime()) / NANOS_PER_MILLI
             if (remainingMillis <= 0L) break
             try {
                 t.join(remainingMillis)
             } catch (_: InterruptedException) {
-                // Preserve interrupt status; stop joining the rest — they
-                // are daemon threads and will eventually exit on their
-                // own as the sockets/channels are closed.
+                // Preserve interrupt status and stop joining. The final
+                // live-thread check below turns an incomplete join into an
+                // explicit close failure instead of silently detaching it.
                 Thread.currentThread().interrupt()
                 break
             }
+        }
+        // The join budget is aggregate and deliberately bounded. A callback
+        // that ignores the closed streams remains registered and makes the
+        // close fail explicitly; it is never detached while still alive.
+        val lingeringThreads = threadsToJoin.filter { it !== self && it.isAlive }
+        if (lingeringThreads.isNotEmpty()) {
+            lingeringThreads.forEach(Thread::interrupt)
+            // Interruptible callbacks can need a small scheduling window to
+            // unwind their finally blocks. Give them that window before
+            // declaring close failed; the first join remains the aggregate
+            // cleanup budget, and this is only the short interrupt response
+            // grace period.
+            var interrupted = false
+            if (Thread.interrupted()) interrupted = true
+            val interruptDeadlineNanos =
+                System.nanoTime() + POST_INTERRUPT_JOIN_TIMEOUT_MS * NANOS_PER_MILLI
+            for (thread in lingeringThreads) {
+                val remainingMillis =
+                    (interruptDeadlineNanos - System.nanoTime()) / NANOS_PER_MILLI
+                if (remainingMillis <= 0L) break
+                try {
+                    thread.join(remainingMillis)
+                } catch (_: InterruptedException) {
+                    interrupted = true
+                    break
+                }
+            }
+            if (interrupted) Thread.currentThread().interrupt()
+
+            // Check the actual Thread handles captured before teardown. A
+            // callback removes itself from copyThreads in finally, slightly
+            // before Thread.run() returns; registry emptiness alone would
+            // therefore be an unsound close-success oracle.
+            val stillAlive = lingeringThreads.filter(Thread::isAlive)
+            synchronized(lifecycleLock) {
+                copyThreads.filter { !it.isAlive }.forEach(copyThreads::remove)
+            }
+            if (stillAlive.isEmpty()) return
+            val details = stillAlive.joinToString { thread ->
+                "${thread.name}(${thread.state})"
+            }
+            throw IllegalStateException(
+                "Port forward 127.0.0.1:$localPort close timed out after " +
+                    "$CLOSE_JOIN_TIMEOUT_MS ms; live copy threads: $details",
+            )
         }
         // Don't join the accept thread — it's a daemon and the SocketException
         // wakeup is immediate. Joining would deadlock if close() is called
@@ -304,6 +372,7 @@ internal class RealSshPortForward(
         // have already been closed, so this is only a deterministic cleanup
         // window, not a per-thread multiplier.
         const val CLOSE_JOIN_TIMEOUT_MS = 1_000L
+        const val POST_INTERRUPT_JOIN_TIMEOUT_MS = 100L
         const val NANOS_PER_MILLI = 1_000_000L
     }
 }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
@@ -15,6 +15,8 @@ import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.lang.reflect.Proxy
+import java.util.AbstractSet
+import java.util.LinkedHashSet
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -130,31 +132,245 @@ class RealSshPortForwardCountersTest {
             Function0::class.java,
         )
         startCopyThread.isAccessible = true
+        val finished = CountDownLatch(4)
         repeat(4) { index ->
             startCopyThread.invoke(
                 forward,
                 "test-copy-$index",
                 {
                     started.countDown()
-                    release.await(5, TimeUnit.SECONDS)
+                    try {
+                        release.await(5, TimeUnit.SECONDS)
+                    } catch (_: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    } finally {
+                        finished.countDown()
+                    }
                     Unit
                 } as Function0<Unit>,
             )
         }
-        assertTrue("test copy threads should be running", started.await(2, TimeUnit.SECONDS))
-
-        val startedAt = System.nanoTime()
         try {
+            assertTrue("test copy threads should be running", started.await(2, TimeUnit.SECONDS))
+
+            val startedAt = System.nanoTime()
             forward.close()
+            val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+            assertTrue(
+                "close should spend one aggregate join budget, not one timeout per copy thread; " +
+                    "elapsed=$elapsedMs ms",
+                elapsedMs < 1_800L,
+            )
+            assertTrue(
+                "an interruptible callback must finish before close returns",
+                finished.await(2, TimeUnit.SECONDS),
+            )
         } finally {
             release.countDown()
+            assertTrue(
+                "all aggregate-budget callbacks must be released and awaited during cleanup",
+                finished.await(2, TimeUnit.SECONDS),
+            )
+            forward.close()
         }
-        val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+    }
 
-        assertTrue(
-            "close should spend one aggregate join budget, not one timeout per copy thread; elapsed=$elapsedMs ms",
-            elapsedMs < 1_800L,
+    @Test
+    fun `close leaves no live copy-thread registrations after its bounded cleanup`() {
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+        val forward = RealSshPortForward(
+            channels = object : PortForwardChannelTransport {
+                override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection =
+                    error("test does not accept local connections")
+
+                override fun closeChannel(channel: DirectConnection) = Unit
+            },
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
         )
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val finished = CountDownLatch(1)
+        val startCopyThread = RealSshPortForward::class.java.getDeclaredMethod(
+            "startCopyThread",
+            String::class.java,
+            Function0::class.java,
+        ).apply { isAccessible = true }
+        val copyThreadsField = RealSshPortForward::class.java.getDeclaredField("copyThreads")
+            .apply { isAccessible = true }
+        var copyThread: Thread? = null
+
+        try {
+            startCopyThread.invoke(
+                forward,
+                "test-copy-lifecycle",
+                {
+                    started.countDown()
+                    try {
+                        release.await(5, TimeUnit.SECONDS)
+                    } catch (_: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    } finally {
+                        finished.countDown()
+                    }
+                    Unit
+                } as Function0<Unit>,
+            )
+            assertTrue("test copy thread should be running", started.await(2, TimeUnit.SECONDS))
+
+            @Suppress("UNCHECKED_CAST")
+            val registered = copyThreadsField.get(forward) as Set<Thread>
+            copyThread = registered.singleOrNull { it.name == "test-copy-lifecycle" }
+            assertTrue("the running callback must be present in copyThreads", copyThread != null)
+            assertTrue("the captured copy thread should be alive", copyThread!!.isAlive)
+
+            forward.close()
+
+            assertTrue(
+                "close must wait for the callback's finally block",
+                finished.await(2, TimeUnit.SECONDS),
+            )
+            assertTrue(
+                "the actual copy thread captured before close must no longer be alive",
+                !copyThread!!.isAlive,
+            )
+        } finally {
+            release.countDown()
+            assertTrue(
+                "the live-thread callback must always be released and awaited during cleanup",
+                finished.await(2, TimeUnit.SECONDS),
+            )
+            copyThread?.join(2_000L)
+            forward.close()
+        }
+    }
+
+    @Test
+    fun `close reports a copy callback that stays alive after interrupt`() {
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+        val forward = RealSshPortForward(
+            channels = object : PortForwardChannelTransport {
+                override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection =
+                    error("test does not accept local connections")
+
+                override fun closeChannel(channel: DirectConnection) = Unit
+            },
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
+        )
+        val started = CountDownLatch(1)
+        val stop = CountDownLatch(1)
+        val finished = CountDownLatch(1)
+        val startCopyThread = RealSshPortForward::class.java.getDeclaredMethod(
+            "startCopyThread",
+            String::class.java,
+            Function0::class.java,
+        ).apply { isAccessible = true }
+        val copyThreadsField = RealSshPortForward::class.java.getDeclaredField("copyThreads")
+            .apply { isAccessible = true }
+        var copyThread: Thread? = null
+
+        try {
+            startCopyThread.invoke(
+                forward,
+                "test-copy-non-terminating",
+                {
+                    started.countDown()
+                    try {
+                        while (stop.count > 0L) {
+                            try {
+                                stop.await(25, TimeUnit.MILLISECONDS)
+                            } catch (_: InterruptedException) {
+                                // Deliberately ignore close()'s interrupt: this
+                                // callback is the non-terminating close case.
+                            }
+                        }
+                    } finally {
+                        finished.countDown()
+                    }
+                    Unit
+                } as Function0<Unit>,
+            )
+            assertTrue("test callback should be running", started.await(2, TimeUnit.SECONDS))
+
+            @Suppress("UNCHECKED_CAST")
+            val registered = copyThreadsField.get(forward) as Set<Thread>
+            copyThread = registered.singleOrNull { it.name == "test-copy-non-terminating" }
+            assertTrue("the non-terminating callback must be registered", copyThread != null)
+
+            var failure: IllegalStateException? = null
+            try {
+                forward.close()
+            } catch (e: IllegalStateException) {
+                failure = e
+            }
+            assertTrue("a still-live callback must make close fail explicitly", failure != null)
+            assertTrue(
+                "the failure must identify the live copy thread",
+                failure!!.message.orEmpty().contains("live copy threads"),
+            )
+            assertTrue("the deliberately non-terminating callback should still be alive", copyThread!!.isAlive)
+        } finally {
+            stop.countDown()
+            copyThread?.interrupt()
+            assertTrue(
+                "the non-terminating callback must be released and awaited during cleanup",
+                finished.await(2, TimeUnit.SECONDS),
+            )
+            copyThread?.join(2_000L)
+            forward.close()
+        }
+    }
+
+    @Test
+    fun `close snapshots injected active pairs under its lifecycle lock`() {
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+        val raceSet = LockAwareSnapshotRaceSet<Pair<Socket, DirectConnection>>()
+        raceSet.add(Socket() to TestDirectConnection())
+        val forward = RealSshPortForward(
+            channels = object : PortForwardChannelTransport {
+                override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection =
+                    error("test does not accept local connections")
+
+                override fun closeChannel(channel: DirectConnection) = Unit
+            },
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
+            activePairs = raceSet,
+        )
+        val lifecycleLock = requireNotNull(
+            RealSshPortForward::class.java.getDeclaredField("lifecycleLock")
+                .apply { isAccessible = true }
+                .get(forward),
+        )
+        raceSet.attachLifecycleLock(lifecycleLock)
+
+        try {
+            raceSet.startMutator()
+            forward.close()
+            assertTrue(
+                "the snapshot must execute while lifecycleLock is held",
+                raceSet.snapshotObservedUnderLock,
+            )
+            assertTrue(
+                "the injected mutation must always be released and awaited",
+                raceSet.mutationFinished.await(2, TimeUnit.SECONDS),
+            )
+        } finally {
+            raceSet.releaseMutator()
+            assertTrue(
+                "the injected race fixture must not leave its mutator behind",
+                raceSet.mutationFinished.await(2, TimeUnit.SECONDS),
+            )
+            forward.close()
+        }
     }
 
     private class SingleReadInputStream(
@@ -216,6 +432,73 @@ class RealSshPortForwardCountersTest {
                 Thread.currentThread().interrupt()
                 throw IOException(e)
             }
+        }
+    }
+
+    /**
+     * A one-element set that makes an unlocked snapshot deterministic: it
+     * reports its pre-race size, lets a mutator clear the set, and then lets
+     * the old one-element `toList()` call `iterator().next()` on an empty set,
+     * which throws NoSuchElementException. The production ArrayList snapshot
+     * runs under lifecycleLock, so the mutator waits until the copy is made.
+     */
+    private class LockAwareSnapshotRaceSet<T> : AbstractSet<T>() {
+        private val values = LinkedHashSet<T>()
+        private val snapshotEntered = CountDownLatch(1)
+        val mutationFinished = CountDownLatch(1)
+        @Volatile
+        var snapshotObservedUnderLock: Boolean = false
+            private set
+
+        private var lifecycleLock: Any? = null
+        private var mutator: Thread? = null
+
+        override val size: Int
+            get() {
+                val observedSize = values.size
+                val lock = requireNotNull(lifecycleLock) { "lifecycle lock not attached" }
+                snapshotObservedUnderLock = Thread.holdsLock(lock)
+                snapshotEntered.countDown()
+                if (!snapshotObservedUnderLock) {
+                    check(mutationFinished.await(2, TimeUnit.SECONDS)) {
+                        "race mutator did not clear the unlocked snapshot"
+                    }
+                }
+                return observedSize
+            }
+
+        override fun iterator(): MutableIterator<T> = values.iterator()
+
+        override fun add(element: T): Boolean = values.add(element)
+
+        override fun clear() {
+            values.clear()
+        }
+
+        fun attachLifecycleLock(lock: Any) {
+            lifecycleLock = lock
+        }
+
+        fun startMutator() {
+            val lock = requireNotNull(lifecycleLock) { "lifecycle lock not attached" }
+            mutator = Thread({
+                try {
+                    snapshotEntered.await(2, TimeUnit.SECONDS)
+                    synchronized(lock) {
+                        values.clear()
+                    }
+                } finally {
+                    mutationFinished.countDown()
+                }
+            }, "test-active-pairs-mutator").apply {
+                isDaemon = true
+                start()
+            }
+        }
+
+        fun releaseMutator() {
+            snapshotEntered.countDown()
+            mutator?.join(2_000L)
         }
     }
 


### PR DESCRIPTION
Closes #2213.

Summary:
- serialize active-pair and copy-thread lifecycle with one lock;
- make close use one aggregate join budget and explicit live-thread diagnostics;
- add mutation-sensitive tests for the active-pair race and actual thread termination.

Validation:
- reviewer red/green mutations;
- reviewer core-ssh unit module: 256/256;
- reviewer Docker integration: core-ssh 52/52 and core-portfwd 6/6;
- final integration-worktree focused test: 6/6.