### PR TITLE
Fix stale session generation handling (#2239)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
@@ -1,5 +1,17 @@
 package com.pocketshell.app.projects
 
+import android.graphics.Bitmap
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.core.graphics.createBitmap
 import androidx.lifecycle.ViewModelStore
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -8,20 +20,27 @@ import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.ProjectRootEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.uikit.theme.PocketShellTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
@@ -98,6 +117,9 @@ import java.io.FileOutputStream
 @RunWith(AndroidJUnit4::class)
 class FolderListDurableTreeDaemonDockerTest {
 
+    @get:Rule
+    val compose = createComposeRule()
+
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
     private lateinit var db: AppDatabase
@@ -139,6 +161,14 @@ class FolderListDurableTreeDaemonDockerTest {
 
     @After
     fun tearDown(): Unit { runBlocking {
+        // FolderListScreen owns the production polling lifecycle through its
+        // DisposableEffect. Unmount it before clearing the ViewModelStore so a
+        // failed journey cannot leave the screen's collector/polling job alive
+        // while the next test tears down the SSH fixture.
+        runCatching {
+            compose.setContent { }
+            compose.waitForIdle()
+        }
         viewModelStore.clear()
         runCatching {
             withTimeout(20_000) {
@@ -384,6 +414,489 @@ class FolderListDurableTreeDaemonDockerTest {
     } }
 
     /**
+     * Issue #2239: a lifecycle event emitted for a dead tmux generation must
+     * never remove a live same-name successor. This is deliberately in the
+     * already-gated daemon journey class so it exercises the production
+     * FolderListViewModel + SshFolderListGateway + SessionLifecycleSignals path
+     * on an emulator against a real tmux server.
+     *
+     * The predecessor event is held until AFTER a fresh authoritative probe has
+     * painted the successor's exact `$N` + `session_created` identity. Stopping
+     * polling before delivery is load-bearing: no follow-up probe can rescue a
+     * wrongly name-keyed removal, so that mutation makes the screen-facing Ready
+     * state lose its only row and fails the stability observation below.
+     */
+    @Test
+    fun delayedPredecessorKillDoesNotDeleteSameNameSuccessorGeneration(): Unit { runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        hostName = "issue2239-host-$suffix"
+        val rootDir = "/tmp/issue2239-$suffix"
+        val sessionName = "issue2239-work-$suffix"
+        val watchRoot = FolderListViewModel.canonicalisePath(rootDir)
+        val evidence = mutableListOf<String>()
+
+        val predecessor = withTimeout(20_000) {
+            connect().use { session ->
+                assertTrue(
+                    "predecessor folder creation must succeed",
+                    session.exec("mkdir -p ${shellQuote(rootDir)}").exitCode == 0,
+                )
+                val created = session.exec(
+                    "tmux new-session -d -s ${shellQuote(sessionName)} " +
+                        "-c ${shellQuote(rootDir)}",
+                )
+                assertTrue(
+                    "predecessor tmux session/window must be created; " +
+                        "exit=${created.exitCode} stderr=${created.stderr}",
+                    created.exitCode == 0,
+                )
+                createdSessions += sessionName
+                readRemoteIdentity(session, sessionName)
+            }
+        }
+        evidence += "predecessor_remote=${predecessor.describe()}"
+
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "issue2239-key", privateKeyPath = keyFile.absolutePath),
+        )
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = hostName,
+                hostname = DEFAULT_HOST,
+                port = DAEMON_PORT,
+                username = DEFAULT_USER,
+                keyId = keyId,
+            ),
+        )
+        db.projectRootDao().insert(
+            ProjectRootEntity(hostId = hostId, label = "issue2239", path = watchRoot),
+        )
+        val host = db.hostDao().getById(hostId)!!
+        val signals = SessionLifecycleSignals()
+        val vm = newViewModel(signals)
+        vm.setProcessStartedForTest(true)
+
+        // Mount the real production screen around this same production
+        // FolderListViewModel + SshFolderListGateway. FolderListScreen's own
+        // LaunchedEffect performs the bind, so this proof does not inject a
+        // test-only bind path that production never uses.
+        compose.setContent {
+            PocketShellTheme {
+                FolderListScreen(
+                    hostId = host.id,
+                    hostName = host.name,
+                    hostname = host.hostname,
+                    port = host.port,
+                    username = host.username,
+                    keyPath = keyFile.absolutePath,
+                    passphrase = null,
+                    onBack = {},
+                    onOpenSession = { _, _, _, _ -> },
+                    onSessionCreated = { _, _ -> },
+                    onBrowseRepos = { _ -> },
+                    onEditEnv = { _, _, _ -> },
+                    modifier = Modifier.fillMaxSize(),
+                    viewModel = vm,
+                )
+            }
+        }
+
+        val predecessorReady = awaitExactSession(vm, sessionName, predecessor.generation)
+        evidence += "predecessor_ui=${predecessorReady.describeIdentityRows(sessionName)}"
+        val predecessorFolderPath = predecessorReady.folderPathForGeneration(
+            sessionName = sessionName,
+            expected = predecessor.generation,
+        )
+        ensureTreeSessionChildVisible(predecessorFolderPath, sessionName)
+
+        // Kill the predecessor out-of-band, then wait for the host's epoch clock
+        // to advance before recreating the exact SAME name. tmux may reuse the
+        // freed `$N` and `%N` identifiers when this was the server's only
+        // session/window, so the creation timestamp is the load-bearing fence.
+        val successor = withTimeout(25_000) {
+            connect().use { session ->
+                val recreated = session.exec(
+                    "set -eu; " +
+                        "tmux kill-session -t ${shellQuote(sessionName)}; " +
+                        "while [ \"\$(date +%s)\" -le " +
+                        "${predecessor.generation.createdEpochSeconds} ]; do sleep 0.1; done; " +
+                        "tmux new-session -d -s ${shellQuote(sessionName)} " +
+                        "-c ${shellQuote(rootDir)}",
+                )
+                assertTrue(
+                    "same-name successor must be recreated; exit=${recreated.exitCode} " +
+                        "stderr=${recreated.stderr}",
+                    recreated.exitCode == 0,
+                )
+                readRemoteIdentity(session, sessionName)
+            }
+        }
+        assertNotEquals(
+            "the successor creation timestamp must differ from the predecessor",
+            predecessor.generation.createdEpochSeconds,
+            successor.generation.createdEpochSeconds,
+        )
+        assertNotEquals(
+            "the successor generation must differ from the predecessor",
+            predecessor.generation,
+            successor.generation,
+        )
+        evidence += "successor_remote=${successor.describe()}"
+
+        // Real pull-to-refresh -> real SSH enumeration -> production tree
+        // replacement. Do not deliver the delayed event until the screen-facing
+        // state proves the successor generation is the sole visible row.
+        vm.refreshSessions()
+        val successorBeforeDelayedKill =
+            awaitExactSession(vm, sessionName, successor.generation)
+        assertSingleExactRow(
+            state = successorBeforeDelayedKill,
+            sessionName = sessionName,
+            expected = successor.generation,
+            phase = "before delayed predecessor kill",
+        )
+        val successorFolderPath = successorBeforeDelayedKill.folderPathForGeneration(
+            sessionName = sessionName,
+            expected = successor.generation,
+        )
+        assertEquals(
+            "same-name successor must stay under the predecessor's watched folder",
+            predecessorFolderPath,
+            successorFolderPath,
+        )
+        val successorTreeRowTag = folderDetailRowTestTag(successorFolderPath, sessionName)
+        assertComposeTreeSessionChildExactlyOnce(
+            rowTag = successorTreeRowTag,
+            phase = "before delayed predecessor kill",
+        )
+        val beforeScreenshot = captureIssue2239Viewport(
+            name = "successor-before-delayed-predecessor.png",
+            rowTag = successorTreeRowTag,
+        )
+        evidence += "successor_ui_before_event=" +
+            successorBeforeDelayedKill.describeIdentityRows(sessionName)
+        evidence += "successor_compose_before=${beforeScreenshot.file.absolutePath}" +
+            " row_tag=$successorTreeRowTag" +
+            " row_nonblank_pixels=${beforeScreenshot.rowNonBlankPixels}"
+
+        // Freeze the displayed tree. A buggy name-keyed reducer now has no
+        // authoritative refresh available to re-add the successor and hide the
+        // regression. emitKilled is the same process-scoped production entry
+        // point used by session Stop; the ViewModel's real collector/reducer
+        // receives the predecessor's exact identity.
+        vm.stopPolling()
+        signals.emitKilled(
+            hostId = hostId,
+            generation = predecessor.generation,
+            lastKnownName = sessionName,
+        )
+        // Drain the Main queue after SharedFlow delivery, then observe multiple
+        // frames. This is intentionally not a refresh/reconcile rescue step.
+        onMain { }
+        val successorAfterDelayedKill = assertExactRowStable(
+            vm = vm,
+            sessionName = sessionName,
+            expected = successor.generation,
+            observationMs = 2_000L,
+        )
+        evidence += "delayed_event=KilledSession(hostId=$hostId," +
+            "generation=${predecessor.generation},lastKnownName=$sessionName)"
+        evidence += "successor_ui_after_event=" +
+            successorAfterDelayedKill.describeIdentityRows(sessionName)
+        assertComposeTreeSessionChildExactlyOnce(
+            rowTag = successorTreeRowTag,
+            phase = "after delayed predecessor kill",
+        )
+        val afterScreenshot = captureIssue2239Viewport(
+            name = "successor-after-delayed-predecessor.png",
+            rowTag = successorTreeRowTag,
+        )
+        evidence += "successor_compose_after=${afterScreenshot.file.absolutePath}" +
+            " row_tag=$successorTreeRowTag" +
+            " row_nonblank_pixels=${afterScreenshot.rowNonBlankPixels}"
+
+        // Final out-of-band SSH/tmux oracle: exactly one live row has this name,
+        // and its id + creation timestamp + window are still the successor's.
+        val finalRemote = withTimeout(15_000) {
+            connect().use { session ->
+                val matching = session.exec(
+                    "tmux list-sessions -F " +
+                        "'#{session_id}::#{session_created}::#{session_name}'",
+                )
+                assertTrue(
+                    "direct tmux list-sessions must succeed; exit=${matching.exitCode} " +
+                        "stderr=${matching.stderr}",
+                    matching.exitCode == 0,
+                )
+                val exactNameRows = matching.stdout.lineSequence()
+                    .filter { it.substringAfterLast("::", missingDelimiterValue = "") == sessionName }
+                    .toList()
+                assertEquals(
+                    "the host must contain exactly one same-name live session; " +
+                        "all=${matching.stdout}",
+                    1,
+                    exactNameRows.size,
+                )
+                readRemoteIdentity(session, sessionName)
+            }
+        }
+        assertEquals(
+            "the delayed predecessor event must not kill or replace the successor remotely",
+            successor,
+            finalRemote,
+        )
+        evidence += "final_ssh_tmux=${finalRemote.describe()} live=true same_name_rows=1"
+        writeIssue2239Evidence(evidence)
+    } }
+
+    /**
+     * Issue #2239's connected A→B→A navigation contract. The rows and the
+     * navigation callback both have to carry the exact tmux generation; a
+     * session name is only display text and is not an identity oracle.
+     *
+     * The screen is the real production [FolderListScreen]. Its bind and
+     * refresh paths use the production [FolderListViewModel],
+     * [SshFolderListGateway], and [TreeRemoteSource] against the live Docker
+     * tmux server. Tapping a row observes the real production navigation
+     * payload; the test then uses the screen's production refresh entry point
+     * before selecting the next row.
+     */
+    @Test
+    fun exactGenerationSurvivesAtoBtoASwitchAndRefresh(): Unit { runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        hostName = "issue2239-aba-host-$suffix"
+        val rootDir = "/tmp/issue2239-aba-$suffix"
+        val aDir = "$rootDir/a"
+        val bDir = "$rootDir/b"
+        val aName = "issue2239-a-$suffix"
+        val bName = "issue2239-b-$suffix"
+        val watchRoot = FolderListViewModel.canonicalisePath(rootDir)
+        val evidence = mutableListOf<String>()
+
+        val seeded = withTimeout(30_000) {
+            connect().use { session ->
+                val folders = session.exec(
+                    "mkdir -p ${shellQuote(aDir)} ${shellQuote(bDir)}",
+                )
+                assertTrue(
+                    "A/B folder creation must succeed; exit=${folders.exitCode} " +
+                        "stderr=${folders.stderr}",
+                    folders.exitCode == 0,
+                )
+                val createdA = session.exec(
+                    "tmux new-session -d -s ${shellQuote(aName)} -c ${shellQuote(aDir)}",
+                )
+                assertTrue(
+                    "live tmux session A must be created; exit=${createdA.exitCode} " +
+                        "stderr=${createdA.stderr}",
+                    createdA.exitCode == 0,
+                )
+                val createdB = session.exec(
+                    "tmux new-session -d -s ${shellQuote(bName)} -c ${shellQuote(bDir)}",
+                )
+                assertTrue(
+                    "live tmux session B must be created; exit=${createdB.exitCode} " +
+                        "stderr=${createdB.stderr}",
+                    createdB.exitCode == 0,
+                )
+                createdSessions += aName
+                createdSessions += bName
+                val a = readRemoteIdentity(session, aName)
+                val b = readRemoteIdentity(session, bName)
+                assertNotEquals(
+                    "A and B must be distinct live tmux generations",
+                    a.generation,
+                    b.generation,
+                )
+                a to b
+            }
+        }
+        val remoteA = seeded.first
+        val remoteB = seeded.second
+        val expected = linkedMapOf(
+            remoteA.sessionName to remoteA.generation,
+            remoteB.sessionName to remoteB.generation,
+        )
+        evidence += "seed_A=${remoteA.describe()}"
+        evidence += "seed_B=${remoteB.describe()}"
+
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "issue2239-aba-key", privateKeyPath = keyFile.absolutePath),
+        )
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = hostName,
+                hostname = DEFAULT_HOST,
+                port = DAEMON_PORT,
+                username = DEFAULT_USER,
+                keyId = keyId,
+            ),
+        )
+        db.projectRootDao().insert(
+            ProjectRootEntity(hostId = hostId, label = "issue2239-aba", path = watchRoot),
+        )
+        val host = db.hostDao().getById(hostId)!!
+        val navigation = mutableListOf<ProductionNavigationSelection>()
+        val vm = newViewModel()
+        vm.setProcessStartedForTest(true)
+
+        // FolderListScreen's LaunchedEffect performs the production bind. The
+        // callback below only records the real route payload; it does not seed
+        // or replace any view-model state.
+        compose.setContent {
+            PocketShellTheme {
+                FolderListScreen(
+                    hostId = host.id,
+                    hostName = host.name,
+                    hostname = host.hostname,
+                    port = host.port,
+                    username = host.username,
+                    keyPath = keyFile.absolutePath,
+                    passphrase = null,
+                    onBack = {},
+                    onOpenSession = { _, _, _, _ -> },
+                    onOpenSessionWindow = { sessionName, _, _, tmuxSessionId, sessionCreated ->
+                        navigation += ProductionNavigationSelection(
+                            sessionName = sessionName,
+                            generation = if (tmuxSessionId != null && sessionCreated != null) {
+                                TmuxSessionGeneration(
+                                    sessionId = tmuxSessionId,
+                                    createdEpochSeconds = sessionCreated,
+                                )
+                            } else {
+                                null
+                            },
+                        )
+                    },
+                    onSessionCreated = { _, _ -> },
+                    onBrowseRepos = { _ -> },
+                    onEditEnv = { _, _, _ -> },
+                    modifier = Modifier.fillMaxSize(),
+                    viewModel = vm,
+                )
+            }
+        }
+
+        // Render A, then observe the exact production navigation payload for A.
+        val aBefore = awaitExactGenerations(vm, expected, "A initial")
+        assertExactGenerationsInProductionTree(aBefore, expected, "A initial")
+        val aFolder = aBefore.folderPathForGeneration(remoteA.sessionName, remoteA.generation)
+        ensureTreeSessionChildVisible(aFolder, remoteA.sessionName)
+        val aInitialScreenshot = captureIssue2239Viewport(
+            name = "a-initial.png",
+            rowTag = folderDetailRowTestTag(aFolder, remoteA.sessionName),
+        )
+        val aNavigationIndex = navigation.size
+        compose.onNodeWithTag(
+            folderDetailRowTestTag(aFolder, remoteA.sessionName),
+            useUnmergedTree = true,
+        ).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) { navigation.size > aNavigationIndex }
+        val selectedA = navigation[aNavigationIndex]
+        assertEquals(remoteA.sessionName, selectedA.sessionName)
+        assertEquals(remoteA.generation, selectedA.generation)
+        evidence += "phase=A_INITIAL rendered=true " +
+            "tree=${aBefore.describeExactGenerationRows(expected)} " +
+            "navigation=${selectedA.describe()} " +
+            "screenshot=${aInitialScreenshot.file.absolutePath} " +
+            "row_nonblank_pixels=${aInitialScreenshot.rowNonBlankPixels}"
+
+        // Refresh through the production screen's real ViewModel path, then
+        // switch to B through the rendered production row.
+        vm.refreshSessions()
+        val bReady = awaitExactGenerations(vm, expected, "B after refresh")
+        assertExactGenerationsInProductionTree(bReady, expected, "B after refresh")
+        val bFolder = bReady.folderPathForGeneration(remoteB.sessionName, remoteB.generation)
+        ensureTreeSessionChildVisible(bFolder, remoteB.sessionName)
+        val bScreenshot = captureIssue2239Viewport(
+            name = "b-after-refresh.png",
+            rowTag = folderDetailRowTestTag(bFolder, remoteB.sessionName),
+        )
+        val bNavigationIndex = navigation.size
+        compose.onNodeWithTag(
+            folderDetailRowTestTag(bFolder, remoteB.sessionName),
+            useUnmergedTree = true,
+        ).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) { navigation.size > bNavigationIndex }
+        val selectedB = navigation[bNavigationIndex]
+        assertEquals(remoteB.sessionName, selectedB.sessionName)
+        assertEquals(remoteB.generation, selectedB.generation)
+        evidence += "phase=B_AFTER_REFRESH rendered=true " +
+            "tree=${bReady.describeExactGenerationRows(expected)} " +
+            "navigation=${selectedB.describe()} " +
+            "screenshot=${bScreenshot.file.absolutePath} " +
+            "row_nonblank_pixels=${bScreenshot.rowNonBlankPixels}"
+
+        // Refresh again through the production path and return to A. This is
+        // the load-bearing A→B→A assertion: A's exact pair must be byte-for-
+        // byte the pair observed before B was selected.
+        vm.refreshSessions()
+        val aAfter = awaitExactGenerations(vm, expected, "A after refresh")
+        assertExactGenerationsInProductionTree(aAfter, expected, "A after refresh")
+        val aAfterFolder = aAfter.folderPathForGeneration(remoteA.sessionName, remoteA.generation)
+        assertEquals(
+            "A's folder must remain stable across the B round trip",
+            aFolder,
+            aAfterFolder,
+        )
+        ensureTreeSessionChildVisible(aAfterFolder, remoteA.sessionName)
+        val aAfterScreenshot = captureIssue2239Viewport(
+            name = "a-after-refresh.png",
+            rowTag = folderDetailRowTestTag(aAfterFolder, remoteA.sessionName),
+        )
+        val aAfterNavigationIndex = navigation.size
+        compose.onNodeWithTag(
+            folderDetailRowTestTag(aAfterFolder, remoteA.sessionName),
+            useUnmergedTree = true,
+        ).performClick()
+        compose.waitUntil(timeoutMillis = 5_000) { navigation.size > aAfterNavigationIndex }
+        val selectedAAfter = navigation[aAfterNavigationIndex]
+        assertEquals(remoteA.sessionName, selectedAAfter.sessionName)
+        assertEquals(remoteA.generation, selectedAAfter.generation)
+
+        val aBeforeGeneration = aBefore.exactGenerationFor(remoteA.sessionName)
+        val aAfterGeneration = aAfter.exactGenerationFor(remoteA.sessionName)
+        assertEquals(
+            "A's exact tmuxSessionId + sessionCreated pair must survive A→B→A",
+            aBeforeGeneration,
+            aAfterGeneration,
+        )
+        assertEquals(remoteA.generation, aBeforeGeneration)
+        assertEquals(remoteB.generation, bReady.exactGenerationFor(remoteB.sessionName))
+        assertEquals(
+            "the three production navigation events must be A, B, A",
+            listOf(remoteA.sessionName, remoteB.sessionName, remoteA.sessionName),
+            navigation.map { it.sessionName })
+        assertEquals(
+            "the production navigation payloads must preserve exact generations",
+            listOf(remoteA.generation, remoteB.generation, remoteA.generation),
+            navigation.map { it.generation },
+        )
+        evidence += "phase=A_AFTER_REFRESH rendered=true " +
+            "tree=${aAfter.describeExactGenerationRows(expected)} " +
+            "navigation=${selectedAAfter.describe()} " +
+            "screenshot=${aAfterScreenshot.file.absolutePath} " +
+            "row_nonblank_pixels=${aAfterScreenshot.rowNonBlankPixels}"
+
+        // Final direct SSH/tmux oracle: the app did not merely echo cached
+        // fields; both distinct live sessions still resolve to the seeded pairs.
+        val finalRemote = withTimeout(20_000) {
+            connect().use { session ->
+                readRemoteIdentity(session, remoteA.sessionName) to
+                    readRemoteIdentity(session, remoteB.sessionName)
+            }
+        }
+        assertEquals(remoteA, finalRemote.first)
+        assertEquals(remoteB, finalRemote.second)
+        evidence += "final_ssh_tmux_A=${finalRemote.first.describe()}"
+        evidence += "final_ssh_tmux_B=${finalRemote.second.describe()}"
+        evidence += "a_exact_pair_unchanged=true b_exact_pair_own=true " +
+            "tree_one_row_per_expected_generation=true name_only_aliases=0 " +
+            "navigation_sequence=A,B,A"
+        writeIssue2239AbaEvidence(evidence)
+    } }
+
+    /**
      * Issue #1829: run a Main-confined view-model entry point on Main, the way
      * every production caller does. Used for `bind` AND for the non-suspend
      * members that reach `emitReady()` synchronously (`toggleProjectExpanded`).
@@ -432,6 +945,296 @@ class FolderListDurableTreeDaemonDockerTest {
         return vm.state.value as FolderListUiState.Ready
     }
 
+    private suspend fun awaitExactSession(
+        vm: FolderListViewModel,
+        sessionName: String,
+        expected: TmuxSessionGeneration,
+    ): FolderListUiState.Ready {
+        withTimeout(40_000) {
+            while (true) {
+                val ready = vm.state.value as? FolderListUiState.Ready
+                val rows = ready?.flatSessions?.filter { it.sessionName == sessionName }.orEmpty()
+                if (rows.size == 1 &&
+                    rows.single().tmuxSessionId == expected.sessionId &&
+                    rows.single().sessionCreated == expected.createdEpochSeconds &&
+                    ready?.isRefreshing == false
+                ) {
+                    return@withTimeout
+                }
+                delay(100L)
+            }
+        }
+        return vm.state.value as FolderListUiState.Ready
+    }
+
+    private suspend fun awaitExactGenerations(
+        vm: FolderListViewModel,
+        expected: Map<String, TmuxSessionGeneration>,
+        phase: String,
+    ): FolderListUiState.Ready {
+        withTimeout(40_000) {
+            while (true) {
+                val ready = vm.state.value as? FolderListUiState.Ready
+                if (ready != null &&
+                    !ready.isRefreshing &&
+                    ready.hasExactGenerationRows(expected)
+                ) {
+                    return@withTimeout
+                }
+                delay(100L)
+            }
+        }
+        return (vm.state.value as? FolderListUiState.Ready)
+            ?: error("$phase did not reach FolderListUiState.Ready")
+    }
+
+    private suspend fun assertExactRowStable(
+        vm: FolderListViewModel,
+        sessionName: String,
+        expected: TmuxSessionGeneration,
+        observationMs: Long,
+    ): FolderListUiState.Ready {
+        val deadline = System.currentTimeMillis() + observationMs
+        var latest = vm.state.value as FolderListUiState.Ready
+        while (System.currentTimeMillis() < deadline) {
+            latest = vm.state.value as FolderListUiState.Ready
+            assertSingleExactRow(latest, sessionName, expected, "after delayed predecessor kill")
+            delay(50L)
+        }
+        return latest
+    }
+
+    private fun ensureTreeSessionChildVisible(folderPath: String, sessionName: String) {
+        val headerTag = folderHeaderClickTestTag(folderPath)
+        val rowTag = folderDetailRowTestTag(folderPath, sessionName)
+        compose.waitUntil(timeoutMillis = 40_000) {
+            compose.onAllNodesWithTag(headerTag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        compose.onNodeWithTag(FOLDER_LIST_CONTENT_TAG, useUnmergedTree = true)
+            .performScrollToNode(hasTestTag(headerTag))
+        if (compose.onAllNodesWithTag(rowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isEmpty()
+        ) {
+            // This is the real user's expand gesture on the production tree;
+            // it happens before the delayed event, never as a post-event rescue.
+            compose.onNodeWithTag(headerTag, useUnmergedTree = true).performClick()
+        }
+        compose.waitUntil(timeoutMillis = 10_000) {
+            compose.onAllNodesWithTag(rowTag, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .size == 1
+        }
+        assertComposeTreeSessionChildExactlyOnce(rowTag, "tree expansion")
+    }
+
+    private fun assertComposeTreeSessionChildExactlyOnce(rowTag: String, phase: String) {
+        val nodes = compose.onAllNodesWithTag(rowTag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+        assertEquals(
+            "$phase: the production tree must expose exactly one same-name successor " +
+                "child node; tag=$rowTag",
+            1,
+            nodes.size,
+        )
+        compose.onNodeWithTag(rowTag, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    private fun captureIssue2239Viewport(
+        name: String,
+        rowTag: String,
+    ): Issue2239ScreenshotEvidence {
+        compose.waitForIdle()
+        assertComposeTreeSessionChildExactlyOnce("$rowTag", "screenshot $name")
+
+        // The tree row is the load-bearing screenshot oracle: count pixels from
+        // the actual displayed child before saving the full production viewport.
+        // A successful file write alone would be a vacuous artifact if the row
+        // were blank or off-screen.
+        val rowImage = compose.onNodeWithTag(rowTag, useUnmergedTree = true).captureToImage()
+        assertTrue(
+            "$name: the displayed tree child must have non-zero screenshot bounds",
+            rowImage.width > 0 && rowImage.height > 0,
+        )
+        val rowPixels = IntArray(rowImage.width * rowImage.height)
+        rowImage.readPixels(rowPixels)
+        val rowBackground = rowPixels.firstOrNull()
+        val rowNonBlankPixels = rowPixels.count { pixel ->
+            pixel != rowBackground && ((pixel ushr 24) and 0xFF) != 0
+        }
+        assertTrue(
+            "$name: the displayed tree child screenshot must be nonblank; " +
+                "rowNonBlankPixels=$rowNonBlankPixels size=${rowImage.width}x${rowImage.height}",
+            rowNonBlankPixels >= MIN_ISSUE2239_NONBLANK_PIXELS,
+        )
+
+        val image = compose.onNodeWithTag(FOLDER_LIST_SCREEN_TAG, useUnmergedTree = true)
+            .captureToImage()
+        assertTrue(
+            "$name: the production folder-list viewport must have non-zero bounds",
+            image.width > 0 && image.height > 0,
+        )
+        val bitmap: Bitmap = createBitmap(image.width, image.height)
+        val pixels = IntArray(image.width * image.height)
+        image.readPixels(pixels)
+        bitmap.setPixels(pixels, 0, image.width, 0, 0, image.width, image.height)
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val root = com.pocketshell.app.test.testArtifactsRoot(context)
+        val dir = File(root, "additional_test_output/issue2239-generation-fence")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create issue #2239 screenshot directory ${dir.absolutePath}"
+        }
+        val file = File(dir, name)
+        FileOutputStream(file).use { output ->
+            assertTrue(
+                "$name: could not encode Compose screenshot ${file.absolutePath}",
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, output),
+            )
+        }
+        bitmap.recycle()
+        assertTrue(
+            "$name: Compose screenshot must be a non-empty artifact ${file.absolutePath}",
+            file.isFile && file.length() > 0L,
+        )
+        println(
+            "ISSUE2239_COMPOSE_SCREENSHOT ${file.absolutePath} " +
+                "row_nonblank_pixels=$rowNonBlankPixels",
+        )
+        return Issue2239ScreenshotEvidence(file, rowNonBlankPixels)
+    }
+
+    private fun FolderListUiState.Ready.folderPathForGeneration(
+        sessionName: String,
+        expected: TmuxSessionGeneration,
+    ): String = treeRoots
+        .flatMap { it.folders }
+        .first { folder ->
+            folder.sessions.any { session ->
+                session.sessionName == sessionName &&
+                    session.tmuxSessionId == expected.sessionId &&
+                    session.sessionCreated == expected.createdEpochSeconds
+            }
+        }
+        .path
+
+    private fun assertSingleExactRow(
+        state: FolderListUiState.Ready,
+        sessionName: String,
+        expected: TmuxSessionGeneration,
+        phase: String,
+    ) {
+        val sameNameRows = state.flatSessions.filter { it.sessionName == sessionName }
+        assertEquals(
+            "$phase: exactly one visible same-name row is required; " +
+                "rows=${state.describeIdentityRows(sessionName)}",
+            1,
+            sameNameRows.size,
+        )
+        val row = sameNameRows.single()
+        assertEquals(
+            "$phase: stale predecessor id must not be shown",
+            expected.sessionId,
+            row.tmuxSessionId,
+        )
+        assertEquals(
+            "$phase: stale predecessor creation timestamp must not be shown",
+            expected.createdEpochSeconds,
+            row.sessionCreated,
+        )
+    }
+
+    private fun FolderListUiState.Ready.describeIdentityRows(sessionName: String): String =
+        flatSessions
+            .filter { it.sessionName == sessionName }
+            .joinToString(prefix = "[", postfix = "]") { row ->
+                "${row.sessionName}/${row.tmuxSessionId}/${row.sessionCreated}"
+            }
+
+    private fun FolderListUiState.Ready.hasExactGenerationRows(
+        expected: Map<String, TmuxSessionGeneration>,
+    ): Boolean {
+        val flatTargets = flatSessions.filter { it.sessionName in expected.keys }
+        val treeTargets = treeRoots
+            .flatMap { it.folders }
+            .flatMap { it.sessions }
+            .filter { it.sessionName in expected.keys }
+        fun rowsMatch(rows: List<FolderSessionEntry>): Boolean {
+            if (rows.size != expected.size) return false
+            if (rows.map { it.sessionName }.toSet() != expected.keys) return false
+            if (rows.any { it.tmuxSessionId.isNullOrBlank() || it.sessionCreated == null }) {
+                return false
+            }
+            val actual = rows.associate { row ->
+                row.sessionName to TmuxSessionGeneration(
+                    sessionId = checkNotNull(row.tmuxSessionId),
+                    createdEpochSeconds = checkNotNull(row.sessionCreated),
+                )
+            }
+            return actual == expected
+        }
+        return rowsMatch(flatTargets) && rowsMatch(treeTargets)
+    }
+
+    private fun assertExactGenerationsInProductionTree(
+        state: FolderListUiState.Ready,
+        expected: Map<String, TmuxSessionGeneration>,
+        phase: String,
+    ) {
+        val flatTargets = state.flatSessions.filter { it.sessionName in expected.keys }
+        val treeTargets = state.treeRoots
+            .flatMap { it.folders }
+            .flatMap { it.sessions }
+            .filter { it.sessionName in expected.keys }
+        assertEquals(
+            "$phase: one flat production row per expected session name",
+            expected.size,
+            flatTargets.size,
+        )
+        assertEquals(
+            "$phase: one tree production row per expected session name",
+            expected.size,
+            treeTargets.size,
+        )
+        assertEquals(
+            "$phase: flat production rows must carry exact generations",
+            expected,
+            flatTargets.associate { row ->
+                row.sessionName to TmuxSessionGeneration(
+                    sessionId = checkNotNull(row.tmuxSessionId),
+                    createdEpochSeconds = checkNotNull(row.sessionCreated),
+                )
+            },
+        )
+        assertEquals(
+            "$phase: tree production rows must carry exact generations; no name-only alias",
+            expected,
+            treeTargets.associate { row ->
+                row.sessionName to TmuxSessionGeneration(
+                    sessionId = checkNotNull(row.tmuxSessionId),
+                    createdEpochSeconds = checkNotNull(row.sessionCreated),
+                )
+            },
+        )
+    }
+
+    private fun FolderListUiState.Ready.exactGenerationFor(sessionName: String): TmuxSessionGeneration {
+        val row = flatSessions.single { it.sessionName == sessionName }
+        return TmuxSessionGeneration(
+            sessionId = checkNotNull(row.tmuxSessionId),
+            createdEpochSeconds = checkNotNull(row.sessionCreated),
+        )
+    }
+
+    private fun FolderListUiState.Ready.describeExactGenerationRows(
+        expected: Map<String, TmuxSessionGeneration>,
+    ): String = expected.keys.sorted().joinToString(prefix = "[", postfix = "]") { name ->
+        val row = flatSessions.singleOrNull { it.sessionName == name }
+        "$name/${row?.tmuxSessionId ?: "<missing>"}/${row?.sessionCreated ?: "<missing>"}"
+    }
+
     private suspend fun connect() = SshConnection.connect(
         host = DEFAULT_HOST,
         port = DAEMON_PORT,
@@ -440,6 +1243,77 @@ class FolderListDurableTreeDaemonDockerTest {
         knownHosts = KnownHostsPolicy.AcceptAll,
         timeoutMs = 10_000,
     ).getOrThrow()
+
+    private suspend fun readRemoteIdentity(
+        session: SshSession,
+        sessionName: String,
+    ): RemoteTmuxIdentity {
+        val result = session.exec(
+            "tmux display-message -p -t ${shellQuote(sessionName)} " +
+                "'#{session_id}::#{session_created}::#{window_id}::#{session_name}'",
+        )
+        check(result.exitCode == 0) {
+            "could not read exact tmux identity for $sessionName: " +
+                "exit=${result.exitCode} stderr=${result.stderr}"
+        }
+        val fields = result.stdout.trim().split("::", limit = 4)
+        check(fields.size == 4 && fields[0].startsWith("$") && fields[2].startsWith("@")) {
+            "malformed exact tmux identity for $sessionName: '${result.stdout}'"
+        }
+        check(fields[3] == sessionName) {
+            "tmux target resolved to '${fields[3]}', expected '$sessionName'"
+        }
+        return RemoteTmuxIdentity(
+            generation = TmuxSessionGeneration(
+                sessionId = fields[0],
+                createdEpochSeconds = checkNotNull(fields[1].toLongOrNull()) {
+                    "malformed session_created in '${result.stdout}'"
+                },
+            ),
+            windowId = fields[2],
+            sessionName = fields[3],
+        )
+    }
+
+    private fun writeIssue2239Evidence(lines: List<String>) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val root = com.pocketshell.app.test.testArtifactsRoot(context)
+        val dir = File(root, "additional_test_output/issue2239-generation-fence")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create issue #2239 evidence directory ${dir.absolutePath}"
+        }
+        val file = File(dir, "same-name-generation-fence.txt")
+        file.writeText(lines.joinToString(separator = "\n", postfix = "\n"))
+        println("ISSUE2239_GENERATION_FENCE ${file.absolutePath}")
+        lines.forEach { println("ISSUE2239_EVIDENCE $it") }
+    }
+
+    private fun writeIssue2239AbaEvidence(lines: List<String>) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val root = com.pocketshell.app.test.testArtifactsRoot(context)
+        val dir = File(root, "additional_test_output/issue2239-generation-fence")
+        check(dir.exists() || dir.mkdirs()) {
+            "could not create issue #2239 A→B→A evidence directory ${dir.absolutePath}"
+        }
+        val file = File(dir, "a-b-a-exact-generation.txt")
+        file.writeText(
+            buildString {
+                appendLine("format=issue2239-exact-generation-v1")
+                appendLine("journey=A->B->A")
+                appendLine("test=exactGenerationSurvivesAtoBtoASwitchAndRefresh")
+                lines.forEach(::appendLine)
+            },
+        )
+        assertTrue(
+            "A→B→A exact-generation artifact must be non-empty: ${file.absolutePath}",
+            file.isFile && file.length() > 0L,
+        )
+        println("ISSUE2239_ABA_EXACT_GENERATION ${file.absolutePath}")
+        lines.forEach { println("ISSUE2239_ABA_EVIDENCE $it") }
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
 
     /**
      * Parse the `pocketshell tree get` JSON envelope and report whether [session]'s
@@ -458,7 +1332,9 @@ class FolderListDurableTreeDaemonDockerTest {
         return false
     }
 
-    private fun newViewModel(): FolderListViewModel {
+    private fun newViewModel(
+        sessionLifecycleSignals: SessionLifecycleSignals? = null,
+    ): FolderListViewModel {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         return FolderListViewModel(
             gateway = SshFolderListGateway(),
@@ -471,13 +1347,39 @@ class FolderListDurableTreeDaemonDockerTest {
             // path (#837/#839) from the client-side instant-render cache (#867),
             // so the relaunch's instant collapse can only come from the host.
             treeRemoteSource = TreeRemoteSource(),
+            sessionLifecycleSignals = sessionLifecycleSignals,
             attachLifecycle = false,
         ).also { vm ->
             viewModelStore.put("FolderListViewModel-${nextViewModelKey++}", vm)
         }
     }
 
+    private data class RemoteTmuxIdentity(
+        val generation: TmuxSessionGeneration,
+        val windowId: String,
+        val sessionName: String,
+    ) {
+        fun describe(): String =
+            "name=$sessionName session_id=${generation.sessionId} " +
+                "session_created=${generation.createdEpochSeconds} window_id=$windowId"
+    }
+
+    private data class Issue2239ScreenshotEvidence(
+        val file: File,
+        val rowNonBlankPixels: Int,
+    )
+
+    private data class ProductionNavigationSelection(
+        val sessionName: String,
+        val generation: TmuxSessionGeneration?,
+    ) {
+        fun describe(): String =
+            "$sessionName/${generation?.sessionId ?: "<missing>"}/" +
+                "${generation?.createdEpochSeconds ?: "<missing>"}"
+    }
+
     private companion object {
         const val DAEMON_PORT: Int = 2239
+        const val MIN_ISSUE2239_NONBLANK_PIXELS: Int = 16
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListStopSessionTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListStopSessionTest.kt
@@ -23,6 +23,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.settings.HostDetailViewMode
 import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.ProjectRootEntity
@@ -627,6 +628,7 @@ class FolderListStopSessionTest {
             passphrase: CharArray?,
             oldName: String,
             newName: String,
+            expectedGeneration: TmuxSessionGeneration,
         ): Result<Unit> {
             renamedSessions.add(oldName to newName)
             rows = rows.map { row ->

--- a/app/src/androidTest/java/com/pocketshell/app/projects/SiblingSuffixExactTargetDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SiblingSuffixExactTargetDockerTest.kt
@@ -7,6 +7,7 @@ import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.session.AgentConversationRepository
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.app.tmux.buildTmuxPaneListingCommand
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
@@ -203,6 +204,7 @@ class SiblingSuffixExactTargetDockerTest {
         // both ways on real tmux 3.4 before pinning it.
         val renamed = base.replace("issue1820-rename-", "issue1820-newname-")
         createdSessions += renamed
+        val baseGeneration = sessionGeneration(base)
         assertTrue(
             "the new name must not share the base's prefix, or the bug cannot bite",
             !renamed.startsWith(base),
@@ -214,6 +216,7 @@ class SiblingSuffixExactTargetDockerTest {
             passphrase = null,
             oldName = base,
             newName = renamed,
+            expectedGeneration = baseGeneration,
         )
 
         assertTrue(
@@ -547,6 +550,23 @@ class SiblingSuffixExactTargetDockerTest {
     private fun literalExactSession(sessionName: String): String = "=$sessionName"
 
     private fun literalExactPane(sessionName: String): String = "=$sessionName:"
+
+    private suspend fun sessionGeneration(sessionName: String): TmuxSessionGeneration =
+        withHostSession { session ->
+            val output = session.exec(
+                "tmux display-message -p -t '${literalExactPane(sessionName)}' " +
+                    "'#{session_id} #{session_created}'",
+            ).stdout.trim()
+            val fields = output.split(Regex("\\s+"))
+            check(fields.size == 2) {
+                "could not read exact generation for '$sessionName': '$output'"
+            }
+            TmuxSessionGeneration(
+                sessionId = fields[0],
+                createdEpochSeconds = fields[1].toLongOrNull()
+                    ?: error("invalid session_created for '$sessionName': '$output'"),
+            )
+        }
 
     /**
      * Seed `<base>` + `<base>-2`, then remove `<base>` so a bare `-t <base>`

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
@@ -46,6 +46,7 @@ import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
 import com.pocketshell.app.tmux.TMUX_SURFACE_PANE_PRESENT_SEMANTICS_KEY
 import com.pocketshell.app.tmux.TMUX_TERMINAL_HELD_SEMANTICS_KEY
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
@@ -351,18 +352,33 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
         // as both Stop entry points do. MainActivity's #834 observer must
         // invalidate the restore record. Resolve the host id we just seeded so
         // the (hostId, sessionName) identity matches what was persisted.
-        killRemoteSession(key)
-        assertTrue("session must be gone server-side after delete", !sessionAlive(key))
         val ctx = InstrumentationRegistry.getInstrumentation().targetContext
         val entryPoint = EntryPointAccessors
             .fromApplication(ctx, TestAccessEntryPoint::class.java)
         val killedHostId = hostRowTag.removePrefix(HOST_ROW_TAG_PREFIX).toLong()
+        val storedBeforeKill = checkNotNull(
+            entryPoint.lastSessionStore().read(maxAgeMillis = Long.MAX_VALUE),
+        ) { "backgrounding the attached session must persist its exact restore identity" }
+        val killedGeneration = TmuxSessionGeneration(
+            sessionId = checkNotNull(storedBeforeKill.tmuxSessionId) {
+                "persisted killed session must carry tmux session id"
+            },
+            createdEpochSeconds = checkNotNull(storedBeforeKill.sessionCreated) {
+                "persisted killed session must carry tmux creation timestamp"
+            },
+        )
+        killRemoteSession(key)
+        assertTrue("session must be gone server-side after delete", !sessionAlive(key))
         // The activity is in CREATED (still STARTED-collected? no — CREATED is
         // below STARTED). Bring it to STARTED so the repeatOnLifecycle observer
         // is collecting, emit the kill, then let it drain.
         compose.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
         delay(LIFECYCLE_DRAIN_MS)
-        entryPoint.sessionLifecycleSignals().emitKilled(killedHostId, SEEDED_SESSION)
+        entryPoint.sessionLifecycleSignals().emitKilled(
+            hostId = killedHostId,
+            generation = killedGeneration,
+            lastKnownName = SEEDED_SESSION,
+        )
         delay(LIFECYCLE_DRAIN_MS)
 
         // The store must no longer hold the deleted session as a restore target.
@@ -455,6 +471,17 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
         // ---- Background -> persist last session, then kill it on the server.
         compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
         delay(LIFECYCLE_DRAIN_MS)
+        val storedBeforeKill = checkNotNull(
+            entryPoint.lastSessionStore().read(maxAgeMillis = Long.MAX_VALUE),
+        ) { "backgrounding the attached session must persist its exact restore identity" }
+        val expectedGeneration = TmuxSessionGeneration(
+            sessionId = checkNotNull(storedBeforeKill.tmuxSessionId) {
+                "cold-restore stale proof needs the persisted tmux session id"
+            },
+            createdEpochSeconds = checkNotNull(storedBeforeKill.sessionCreated) {
+                "cold-restore stale proof needs the persisted tmux creation timestamp"
+            },
+        )
         killRemoteSession(key)
         assertTrue("session must be gone on the server after kill", !sessionAlive(key))
 
@@ -465,22 +492,28 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
         // The genuinely-gone attach must broadcast a StaleSession naming the gone
         // session, so the folder tree can offer the recreate prompt.
         compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
-            staleEvents.any { it.sessionName == SEEDED_SESSION }
+            staleEvents.any {
+                it.sessionName == SEEDED_SESSION && it.generation == expectedGeneration
+            }
         }
         val fired = synchronized(staleEvents) { staleEvents.toList() }
         writeText(
             "stale-session-signal.txt",
             buildString {
                 appendLine("expected_stale_session=$SEEDED_SESSION")
+                appendLine("expected_generation=$expectedGeneration")
                 appendLine("stale_events=${fired.map { it.sessionName }}")
+                appendLine("stale_generations=${fired.map { it.generation }}")
                 appendLine("stale_folders=${fired.map { it.folderPath }}")
+                appendLine("exact_generation_match=${fired.any { it.generation == expectedGeneration }}")
             },
         )
         collectorScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
         assertTrue(
             "a genuinely-gone cold-restore must broadcast a StaleSession for the " +
-                "folder tree's recreate prompt; saw ${fired.map { it.sessionName }}",
-            fired.any { it.sessionName == SEEDED_SESSION },
+                "folder tree's recreate prompt with the persisted generation; saw " +
+                "${fired.map { it.sessionName to it.generation }}",
+            fired.any { it.sessionName == SEEDED_SESSION && it.generation == expectedGeneration },
         )
         Unit
     } }

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -90,6 +90,7 @@ import com.pocketshell.app.tmux.TmuxConnectTrigger
 import com.pocketshell.app.tmux.TmuxRestoreIntentSnapshot
 import com.pocketshell.app.tmux.TmuxSessionScreen
 import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.tmuxSessionGenerationOrNull
 import com.pocketshell.app.usage.UsageScheduler
 import com.pocketshell.app.usage.UsageScreen
 import com.pocketshell.app.usage.UsageViewModel
@@ -495,7 +496,15 @@ class MainActivity : FragmentActivity() {
                             // same name. A no-op when nothing was tombstoned or
                             // the identity differs.
                             if (dest is AppDestination.TmuxSession) {
-                                lastSessionStore.onSessionOpened(dest.hostId, dest.sessionName)
+                                tmuxSessionGenerationOrNull(
+                                    dest.tmuxSessionId,
+                                    dest.sessionCreated,
+                                )?.let { generation ->
+                                    lastSessionStore.onSessionOpened(
+                                        hostId = dest.hostId,
+                                        generation = generation,
+                                    )
+                                }
                             }
                         },
                         onComposerDraftChanged = { draft -> currentComposerDraft = draft },
@@ -694,7 +703,11 @@ class MainActivity : FragmentActivity() {
                     "issue834-killed-session-clear hostId=${killed.hostId} " +
                         "session=${killed.sessionName}",
                 )
-                lastSessionStore.onSessionKilled(killed.hostId, killed.sessionName)
+                lastSessionStore.onSessionKilled(
+                    hostId = killed.hostId,
+                    generation = killed.generation,
+                    lastKnownName = killed.lastKnownName,
+                )
             }
         }
     }

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -8,6 +8,7 @@ import com.pocketshell.app.sessions.HostTmuxSessionListParser
 import com.pocketshell.app.sessions.launchTargetCollisionMessage
 import com.pocketshell.app.sessions.remoteStartDirectoryExistsCommand
 import com.pocketshell.app.sessions.startDirectoryMissingMessage
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.app.ssh.BoundedSessionExec
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.portfwd.PortScanner
@@ -430,6 +431,7 @@ interface FolderListGateway {
         passphrase: CharArray?,
         oldName: String,
         newName: String,
+        expectedGeneration: TmuxSessionGeneration,
     ): Result<Unit> = Result.failure(UnsupportedOperationException("Session rename is not available."))
 
     /**
@@ -1574,34 +1576,25 @@ class SshFolderListGateway internal constructor(
         passphrase: CharArray?,
         oldName: String,
         newName: String,
-    ): Result<Unit> {
-        val oldTarget = oldName.trim()
-        val newTarget = newName.trim()
-        if (oldTarget.isEmpty() || newTarget.isEmpty()) {
-            return Result.failure(IllegalArgumentException("Enter a session name."))
-        }
-        if (oldTarget == newTarget) return Result.success(Unit)
-        return withLeaseSession(host, keyPath, passphrase) { session ->
-            // Issue #1820: EXACT session targets. The NEW name is a name to
-            // CREATE, not a target to resolve, so it stays verbatim — only the
-            // `-t` lookups take the `=` prefix. Without it, renaming `<name>`
-            // while `<name>-2` lives renames the neighbour, and the
-            // old-name verify below prefix-matches the survivor and reports
-            // "was not renamed" even when the rename landed.
-            val quotedOld = shellQuote(TmuxTarget.session(oldTarget))
-            val quotedNewTarget = shellQuote(TmuxTarget.session(newTarget))
-            val quotedNew = shellQuote(newTarget)
-            val rename = session.exec(pathAware("tmux rename-session -t $quotedOld $quotedNew"))
-            if (rename.exitCode != 0) {
-                throw RuntimeException(rename.stderr.ifBlank { rename.stdout }.trim())
-            }
-            val oldExists = session.exec(pathAware("tmux has-session -t $quotedOld"))
-            val newExists = session.exec(pathAware("tmux has-session -t $quotedNewTarget"))
-            if (oldExists.exitCode == 0 || newExists.exitCode != 0) {
-                throw RuntimeException("tmux session '$oldTarget' was not renamed to '$newTarget'.")
-            }
-        }
-    }
+        expectedGeneration: TmuxSessionGeneration,
+    ): Result<Unit> = renameSessionWithGeneration(
+        host = host,
+        keyPath = keyPath,
+        passphrase = passphrase,
+        oldName = oldName,
+        newName = newName,
+        expectedGeneration = expectedGeneration,
+        withLeaseSession = { targetHost, targetKeyPath, targetPassphrase, block ->
+            withLeaseSession(
+                targetHost,
+                targetKeyPath,
+                targetPassphrase,
+                block = block,
+            )
+        },
+        pathAware = ::pathAware,
+        shellQuote = ::shellQuote,
+    )
 
     override suspend fun setRecordedKind(
         host: HostEntity,

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGatewayRename.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGatewayRename.kt
@@ -1,0 +1,92 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.tmux.TmuxSessionGeneration
+import com.pocketshell.app.tmux.tmuxSessionGenerationOrNull
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.tmux.TmuxRead
+import com.pocketshell.core.tmux.TmuxTarget
+
+/**
+ * Generation-fenced remote rename. The name is checked first, but the actual
+ * tmux mutation targets the stable session id so a predecessor disappearing
+ * during the check cannot redirect the operation to a same-name successor.
+ */
+internal suspend fun renameSessionWithGeneration(
+    host: HostEntity,
+    keyPath: String,
+    passphrase: CharArray?,
+    oldName: String,
+    newName: String,
+    expectedGeneration: TmuxSessionGeneration,
+    withLeaseSession: suspend (
+        HostEntity,
+        String,
+        CharArray?,
+        suspend (SshSession) -> Unit,
+    ) -> Result<Unit>,
+    pathAware: (String) -> String,
+    shellQuote: (String) -> String,
+): Result<Unit> {
+    val oldTarget = oldName.trim()
+    val newTarget = newName.trim()
+    if (oldTarget.isEmpty() || newTarget.isEmpty()) {
+        return Result.failure(IllegalArgumentException("Enter a session name."))
+    }
+    if (oldTarget == newTarget) return Result.success(Unit)
+    val exactGeneration = tmuxSessionGenerationOrNull(
+        expectedGeneration.sessionId,
+        expectedGeneration.createdEpochSeconds,
+    ) ?: return Result.failure(IllegalArgumentException("Invalid session generation."))
+
+    return withLeaseSession(host, keyPath, passphrase) { session ->
+        val quotedOld = shellQuote(TmuxTarget.session(oldTarget))
+        // display-message resolves a pane/window target, not a target-session;
+        // the bare `=name` form silently returns an empty format on tmux. Keep
+        // the session target for has-session, but read the generation through
+        // the exact current-pane form so the check is both exact and real.
+        val quotedOldPane = shellQuote(TmuxTarget.pane(oldTarget))
+        val observedBeforeRename = session.exec(
+            pathAware(
+                "${TmuxRead.CLIENT} display-message -p -t $quotedOldPane " +
+                    "'#{session_id} #{session_created}'",
+            ),
+        )
+        if (parseExactGeneration(observedBeforeRename) != exactGeneration) {
+            throw RuntimeException(
+                "tmux session '$oldTarget' changed before rename; refusing successor.",
+            )
+        }
+
+        // A raw `$N` target addresses the captured tmux session id. If the
+        // predecessor disappears now, tmux cannot resolve it to its successor.
+        val rename = session.exec(
+            pathAware(
+                "tmux rename-session -t ${shellQuote(exactGeneration.sessionId)} " +
+                    shellQuote(newTarget),
+            ),
+        )
+        if (rename.exitCode != 0) {
+            throw RuntimeException(rename.stderr.ifBlank { rename.stdout }.trim())
+        }
+        val oldExists = session.exec(pathAware("tmux has-session -t $quotedOld"))
+        val observedAfterRename = session.exec(
+            pathAware(
+                "${TmuxRead.CLIENT} display-message -p -t " +
+                    shellQuote(TmuxTarget.pane(newTarget)) +
+                    " '#{session_id} #{session_created}'",
+            ),
+        )
+        if (oldExists.exitCode == 0 || parseExactGeneration(observedAfterRename) != exactGeneration) {
+            throw RuntimeException("tmux session '$oldTarget' was not renamed to '$newTarget'.")
+        }
+    }
+}
+
+private fun parseExactGeneration(result: ExecResult): TmuxSessionGeneration? {
+    if (result.exitCode != 0) return null
+    val fields = result.stdout.trim().split(Regex("\\s+"))
+    if (fields.size != 2) return null
+    return tmuxSessionGenerationOrNull(fields[0], fields[1].toLongOrNull())
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListRenameActions.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListRenameActions.kt
@@ -1,0 +1,60 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.storage.dao.HostDao
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Runs the folder-tree rename against the exact row generation captured before
+ * the gateway suspension. Keeping this async action outside the large tree VM
+ * also makes the generation fence visible at the action boundary.
+ */
+internal fun launchFolderListRename(
+    scope: CoroutineScope,
+    gateway: FolderListGateway,
+    hostDao: HostDao,
+    ioDispatcher: CoroutineDispatcher,
+    tree: HostTreeModel,
+    params: BoundParams,
+    oldTarget: String,
+    newTarget: String,
+    refresh: () -> Unit,
+    emitReady: () -> Unit,
+    onMissingGeneration: () -> Unit,
+    onFailure: (String) -> Unit,
+) {
+    // Capture before the first suspend point. Resolving the name after the
+    // gateway returns could authorize a same-name successor.
+    val requestedGeneration = tree.generationForSession(oldTarget) ?: run {
+        onMissingGeneration()
+        return
+    }
+    scope.launch {
+        val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) } ?: run {
+            onFailure("Host not found.")
+            return@launch
+        }
+        val result = gateway.renameSession(
+            host = host,
+            keyPath = params.keyPath,
+            passphrase = params.passphrase,
+            oldName = oldTarget,
+            newName = newTarget,
+            expectedGeneration = requestedGeneration,
+        )
+        result.fold(
+            onSuccess = {
+                if (tree.renameSession(requestedGeneration, newTarget)) emitReady()
+                refresh()
+            },
+            onFailure = { error ->
+                onFailure(
+                    "Couldn't rename $oldTarget: " +
+                        (error.message ?: error.javaClass.simpleName),
+                )
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListSessionLifecycleBindings.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListSessionLifecycleBindings.kt
@@ -1,0 +1,71 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.tmux.ClosedWindow
+import com.pocketshell.app.tmux.KilledSession
+import com.pocketshell.app.tmux.SessionIdentityUncertain
+import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.StaleSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+/**
+ * Binds the process-scoped session lifecycle signals to the folder tree.
+ *
+ * The collectors intentionally start in the same order as the tree's previous
+ * inline bindings. The callbacks keep the destructive decisions in
+ * [FolderListViewModel], where exact tmux generations remain authoritative.
+ * A name-only signal is forwarded separately so it can request a reconcile
+ * without authorizing removal of a same-name successor.
+ */
+internal fun bindFolderListSessionLifecycleSignals(
+    scope: CoroutineScope,
+    signals: SessionLifecycleSignals,
+    onKilled: (KilledSession) -> Unit,
+    onWindowClosed: (ClosedWindow) -> Unit,
+    onStale: (StaleSession) -> Unit,
+    onIdentityUncertain: (SessionIdentityUncertain) -> Unit,
+) {
+    scope.launch {
+        signals.killedSessions.collect { killed -> onKilled(killed) }
+    }
+    scope.launch {
+        signals.closedWindows.collect { closed -> onWindowClosed(closed) }
+    }
+    scope.launch {
+        signals.staleSessions.collect { stale -> onStale(stale) }
+    }
+    scope.launch {
+        signals.identityUncertain.collect { uncertain -> onIdentityUncertain(uncertain) }
+    }
+}
+
+/** Applies lifecycle events to the generation-keyed held tree. */
+internal class FolderListSessionLifecycleActions(
+    private val boundHostId: () -> Long?,
+    private val tree: HostTreeModel,
+    private val emitReady: () -> Unit,
+    private val isPolling: () -> Boolean,
+    private val refresh: () -> Unit,
+    private val requestIdentityReconcile: () -> Unit,
+) {
+    fun onIdentityUncertain(uncertain: SessionIdentityUncertain) {
+        val hostId = boundHostId() ?: return
+        if (hostId != uncertain.hostId) return
+        requestIdentityReconcile()
+        if (isPolling()) refresh()
+    }
+
+    fun onWindowClosed(closed: ClosedWindow) {
+        val hostId = boundHostId() ?: return
+        if (hostId != closed.hostId) return
+        if (tree.removeWindow(closed.windowId)) emitReady()
+        if (isPolling()) refresh()
+    }
+
+    fun onStale(stale: StaleSession) {
+        val hostId = boundHostId() ?: return
+        if (hostId != stale.hostId) return
+        if (tree.removeSession(stale.generation)) emitReady()
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListTreeMappings.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListTreeMappings.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.tmux.tmuxSessionGenerationOrNull
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.model.isLiveAgent
 import com.pocketshell.uikit.model.resolveSessionAgentState
@@ -11,6 +12,7 @@ internal fun TreeRemoteSource.TreeNode.toHydratedNode(): HostTreeModel.HydratedN
         folderPath = folderPath,
         collapsed = collapsed,
         foreignGuess = foreignKind.toSessionAgentKindOrNull(),
+        generation = tmuxSessionGenerationOrNull(tmuxSessionId, sessionCreated),
     )
 
 internal fun HostTreeModel.HydratedNode.toTreeNode(): TreeRemoteSource.TreeNode =
@@ -20,6 +22,8 @@ internal fun HostTreeModel.HydratedNode.toTreeNode(): TreeRemoteSource.TreeNode 
         folderPath = folderPath,
         collapsed = collapsed,
         foreignKind = foreignGuess?.toRegistryKindString(),
+        tmuxSessionId = generation?.sessionId,
+        sessionCreated = generation?.createdEpochSeconds,
     )
 
 private fun String?.toSessionAgentKindOrNull(): SessionAgentKind? = when (this) {

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -620,6 +620,21 @@ class FolderListViewModel internal constructor(
     private var sessionRefreshInFlight: Boolean = false
     private var createSessionInFlight: Boolean = false
     private var refreshSessionsRequested: Boolean = false
+    /**
+     * A lifecycle signal without a complete generation is only a hint.  Keep
+     * it until an authoritative session probe succeeds; never let the hint
+     * authorize a name-based removal.
+     */
+    private var sessionIdentityReconcileRequested: Boolean = false
+
+    private val sessionLifecycleActions = FolderListSessionLifecycleActions(
+        boundHostId = { bound?.hostId },
+        tree = tree,
+        emitReady = ::emitReady,
+        isPolling = { probeJob != null },
+        refresh = ::refresh,
+        requestIdentityReconcile = { sessionIdentityReconcileRequested = true },
+    )
 
     /**
      * Issue #711: count of consecutive QUIET retries the current refresh has
@@ -660,36 +675,15 @@ class FolderListViewModel internal constructor(
                 emitReady()
             }
         }
-        // Issue #464: when the per-session screen confirms a Kill session,
-        // drop the matching row from this tree immediately (optimistic),
-        // then re-probe so a failed kill that somehow still broadcast — or
-        // a same-name session recreated since — is reconciled against the
-        // authoritative `tmux list-sessions` result.
         sessionLifecycleSignals?.let { signals ->
-            viewModelScope.launch {
-                signals.killedSessions.collect { killed ->
-                    onSessionKilled(killed)
-                }
-            }
-            // Issue #883: a confirmed single-window close (the session survived).
-            // Drop ONLY that window row from this tree — siblings + the session
-            // stay — then reconcile if the tree screen is still composed.
-            viewModelScope.launch {
-                signals.closedWindows.collect { closed ->
-                    onWindowClosed(closed)
-                }
-            }
-            // Issue #1155 (Part B): a persisted session the user tried to open was
-            // confirmed GENUINELY GONE on attach (absent tmux session, not a
-            // transient reconnect). Raise the "create a new session in this folder?"
-            // recreate prompt so the user recovers in one tap instead of landing on
-            // a blank list. Filtered by bound host so a gone session on host A never
-            // prompts on host B's tree.
-            viewModelScope.launch {
-                signals.staleSessions.collect { stale ->
-                    onStaleSession(stale)
-                }
-            }
+            bindFolderListSessionLifecycleSignals(
+                scope = viewModelScope,
+                signals = signals,
+                onKilled = ::onSessionKilled,
+                onWindowClosed = sessionLifecycleActions::onWindowClosed,
+                onStale = sessionLifecycleActions::onStale,
+                onIdentityUncertain = sessionLifecycleActions::onIdentityUncertain,
+            )
         }
         // EPIC #679 requirement #2: reconcile INFREQUENTLY, not on a constant
         // poll. The tree is held across opens, so a foreground/resume only
@@ -738,20 +732,17 @@ class FolderListViewModel internal constructor(
     internal fun onSessionKilled(killed: com.pocketshell.app.tmux.KilledSession) {
         val params = bound ?: return
         if (params.hostId != killed.hostId) return
-        // EPIC #679: drop the dead row from the maintained tree directly by id.
-        // The reconcile is a confirmation, not the trigger.
-        if (tree.removeSession(killed.sessionName)) {
+        if (tree.removeSession(killed.generation)) {
             emitReady()
         }
-        // Only kick an authoritative reconcile when the tree screen is still
-        // composed (a reconcile is already in flight / the screen is live). If
-        // the user navigated onward (stopPolling cleared probeJob), the
-        // optimistic drop stands and the reconcile rides the next bind/resume —
-        // re-probing now would re-acquire the warm lease and race the session
-        // screen's own attach, and a gateway that still reports the just-killed
-        // session would resurrect the dropped row.
         if (probeJob != null) refresh()
     }
+
+    /** Name-only signals request a probe. */
+    @androidx.annotation.VisibleForTesting
+    internal fun onSessionIdentityUncertain(
+        uncertain: com.pocketshell.app.tmux.SessionIdentityUncertain,
+    ) = sessionLifecycleActions.onIdentityUncertain(uncertain)
 
     /**
      * Issue #883: handle a confirmed single-window close broadcast from the
@@ -763,14 +754,8 @@ class FolderListViewModel internal constructor(
      * and the next bind/resume re-probe confirms it). Ignores other hosts.
      */
     @androidx.annotation.VisibleForTesting
-    internal fun onWindowClosed(closed: com.pocketshell.app.tmux.ClosedWindow) {
-        val params = bound ?: return
-        if (params.hostId != closed.hostId) return
-        if (tree.removeWindow(closed.windowId)) {
-            emitReady()
-        }
-        if (probeJob != null) refresh()
-    }
+    internal fun onWindowClosed(closed: com.pocketshell.app.tmux.ClosedWindow) =
+        sessionLifecycleActions.onWindowClosed(closed)
 
     /**
      * Issue #1155: handle a persisted-but-GENUINELY-GONE session broadcast from
@@ -788,14 +773,8 @@ class FolderListViewModel internal constructor(
      * tree it IS bound to accurate.
      */
     @androidx.annotation.VisibleForTesting
-    internal fun onStaleSession(stale: com.pocketshell.app.tmux.StaleSession) {
-        val params = bound ?: return
-        if (params.hostId != stale.hostId) return
-        // The session is confirmed gone — drop its row from the maintained tree.
-        if (tree.removeSession(stale.sessionName)) {
-            emitReady()
-        }
-    }
+    internal fun onStaleSession(stale: com.pocketshell.app.tmux.StaleSession) =
+        sessionLifecycleActions.onStale(stale)
 
     /**
      * Attach a [ProcessLifecycleOwner] observer so [processStarted]
@@ -935,6 +914,7 @@ class FolderListViewModel internal constructor(
         lastWatchedFolders = emptyList()
         sessionRefreshInFlight = false
         transientRefreshRetries = 0
+        sessionIdentityReconcileRequested = false
         // Issue #867 (stale-while-revalidate): paint the last-known tree
         // INSTANTLY from the per-host CLIENT cache before any SSH, so a fresh
         // connect / cold app start no longer flashes the empty rebuild ("No
@@ -1192,6 +1172,11 @@ class FolderListViewModel internal constructor(
         val params = bound ?: return
         val target = sessionName.trim()
         if (target.isEmpty()) return
+        // Authorize the destructive action against the exact row the user
+        // tapped, before the gateway suspension can observe a same-name
+        // recreation. Never resolve this generation again from [target] after
+        // the async kill: that lookup could authorize the successor instead.
+        val requestedGeneration = tree.generationForSession(target)
         viewModelScope.launch {
             val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) } ?: run {
                 _actionStatus.value = FolderActionStatus.Failed("Host not found.")
@@ -1212,13 +1197,30 @@ class FolderListViewModel internal constructor(
                     // so every view model converges on the dead session being
                     // gone. onSessionKilled also kicks an authoritative
                     // re-probe when the tree poll is still live.
-                    onSessionKilled(
-                        com.pocketshell.app.tmux.KilledSession(
-                            hostId = params.hostId,
-                            sessionName = target,
-                        ),
+                    val generation = requestedGeneration
+                    if (generation != null) {
+                        onSessionKilled(
+                            com.pocketshell.app.tmux.KilledSession(
+                                hostId = params.hostId,
+                                generation = generation,
+                                lastKnownName = target,
+                            ),
+                        )
+                    } else {
+                        onSessionIdentityUncertain(
+                            com.pocketshell.app.tmux.SessionIdentityUncertain(
+                                hostId = params.hostId,
+                                lastKnownName = target,
+                                folderPath = null,
+                                action = com.pocketshell.app.tmux.SessionLifecycleAction.Kill,
+                            ),
+                        )
+                    }
+                    sessionLifecycleSignals?.emitKilled(
+                        hostId = params.hostId,
+                        generation = generation,
+                        lastKnownName = target,
                     )
-                    sessionLifecycleSignals?.emitKilled(params.hostId, target)
                 },
                 onFailure = { error ->
                     _actionStatus.value = FolderActionStatus.Failed(
@@ -1234,37 +1236,25 @@ class FolderListViewModel internal constructor(
         val oldTarget = oldName.trim()
         val newTarget = newName.trim()
         if (oldTarget.isEmpty() || newTarget.isEmpty() || oldTarget == newTarget) return
-        viewModelScope.launch {
-            val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) } ?: run {
-                _actionStatus.value = FolderActionStatus.Failed("Host not found.")
-                return@launch
-            }
-            val result = gateway.renameSession(
-                host = host,
-                keyPath = params.keyPath,
-                passphrase = params.passphrase,
-                oldName = oldTarget,
-                newName = newTarget,
-            )
-            result.fold(
-                onSuccess = {
-                    // Issue #656: a successful rename emits no banner — the
-                    // renamed row in the list is the feedback.
-                    renameSessionSnapshot(oldTarget = oldTarget, newTarget = newTarget)
-                    refresh()
-                },
-                onFailure = { error ->
-                    _actionStatus.value = FolderActionStatus.Failed(
-                        "Couldn't rename $oldTarget: ${error.message ?: error.javaClass.simpleName}",
-                    )
-                },
-            )
-        }
-    }
-
-    private fun renameSessionSnapshot(oldTarget: String, newTarget: String) {
-        // EPIC #679: rename by id on the maintained tree, preserving the slot.
-        if (tree.renameSession(oldTarget, newTarget)) emitReady()
+        launchFolderListRename(
+            scope = viewModelScope,
+            gateway = gateway,
+            hostDao = hostDao,
+            ioDispatcher = ioDispatcher,
+            tree = tree,
+            params = params,
+            oldTarget = oldTarget,
+            newTarget = newTarget,
+            refresh = ::refresh,
+            emitReady = ::emitReady,
+            onMissingGeneration = {
+                sessionIdentityReconcileRequested = true
+                if (probeJob != null) refresh()
+            },
+            onFailure = { message ->
+                _actionStatus.value = FolderActionStatus.Failed(message)
+            },
+        )
     }
 
     fun createEmptyProject(
@@ -1475,6 +1465,10 @@ class FolderListViewModel internal constructor(
             return
         }
         lastResumeGenerationHandled = foregroundGeneration
+        if (sessionIdentityReconcileRequested) {
+            launchReconcile(params)
+            return
+        }
         if (tree.reconcileDue(now = System.currentTimeMillis(), staleAfterMs = HostTreeModel.RECONCILE_STALENESS_MS)) {
             launchReconcile(params)
         } else {
@@ -1499,16 +1493,20 @@ class FolderListViewModel internal constructor(
         // Only react to a genuine new foreground generation.
         if (foregroundGeneration == lastResumeGenerationHandled) return
         lastResumeGenerationHandled = foregroundGeneration
+        if (sessionIdentityReconcileRequested) {
+            launchReconcile(params)
+            return
+        }
         if (!tree.reconcileDue(now = System.currentTimeMillis(), staleAfterMs = RESUME_FRESHEN_MS)) {
             return
         }
         // Epic #821 slice C (issue #837): on a resume-when-stale, prefer the
-        // CHEAP daemon delta reconcile (gone/added by name) over a full gateway
-        // re-probe when the durable seam is available — "refresh to see which
-        // sessions are gone, without reloading everything". A clean delta (no
-        // additions) prunes gone sessions in place and avoids the heavier probe;
-        // any addition (or an unavailable delta) falls back to the full
-        // reconcile so the new session's content is fetched.
+        // CHEAP daemon delta reconcile over a full gateway re-probe when the
+        // durable seam is available — "refresh to see which sessions are gone,
+        // without reloading everything". Added/unavailable deltas fall back to
+        // the full reconcile so new content is fetched. Gone names also use the
+        // full path because a name-only delta cannot safely delete a successor
+        // generation.
         if (treeRemoteSource != null && tree.hasSnapshot) {
             reconcileTreeDeltasOnResume(params)
         } else {
@@ -1518,11 +1516,11 @@ class FolderListViewModel internal constructor(
 
     /**
      * Epic #821 slice C (issue #837): the delta-refresh path. Execs the daemon
-     * `tree.reconcile` over the warm session, prunes the held tree's GONE
-     * sessions in place (deltas only — no full reload), and only escalates to a
-     * full [launchReconcile] when the delta reports ADDED sessions (whose content
-     * a probe must fetch) or when the delta is unavailable. Persists the pruned
-     * tree so the registry stays clean.
+     * `tree.reconcile` over the warm session. Added or unavailable deltas use a
+     * full [launchReconcile] because their content must be fetched. Gone hints
+     * are also escalated to the authoritative probe: the daemon delta currently
+     * carries names only, and a name cannot authorize deletion of a same-name
+     * successor generation.
      */
     private fun reconcileTreeDeltasOnResume(params: BoundParams) {
         val source = treeRemoteSource ?: run { launchReconcile(params); return }
@@ -1549,12 +1547,13 @@ class FolderListViewModel internal constructor(
                 launchReconcile(params)
                 return@launch
             }
-            // Gone-only delta: prune in place, re-emit, persist. No full reload.
-            if (tree.applyReconcileGoneDelta(delta.gone)) {
-                emitReady()
-                persistTree(params)
-                // Issue #867: keep the client cache in step with the pruned tree.
-                persistClientCache(params)
+            // A daemon delta currently identifies gone rows by display name.
+            // That is insufficient to authorize destructive mutation because a
+            // same-name successor may already be live.  Use the authoritative
+            // probe path for every gone hint; HostTreeModel then applies exact
+            // generation replacement/removal semantics.
+            if (delta.gone.isNotEmpty()) {
+                launchReconcile(params)
             }
         }
     }
@@ -2319,6 +2318,7 @@ class FolderListViewModel internal constructor(
                 // budget so a later, unrelated transient drop gets its own full
                 // retry allowance.
                 transientRefreshRetries = 0
+                sessionIdentityReconcileRequested = false
                 setSessionRefreshInFlight(false)
                 emitReady()
                 // Epic #821 slice C (issue #837): persist the freshened tree so

--- a/app/src/main/java/com/pocketshell/app/projects/HostTreeModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostTreeModel.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.tmux.TmuxSessionGeneration
+import com.pocketshell.app.tmux.tmuxSessionGenerationOrNull
 import com.pocketshell.core.storage.entity.ProjectRootEntity
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.model.SessionAgentState
@@ -21,7 +23,7 @@ import com.pocketshell.uikit.model.SessionAgentState
  * [HostTreeModel] makes the **held tree the source of truth**:
  *
  *  - Node existence, order, and expansion are **intrinsic state** — a session
- *    keeps its slot because it is the same keyed entry in the same
+ *    keeps its slot because it is the same generation-keyed entry in the same
  *    [LinkedHashMap] position, not because a stabilizer re-froze the order.
  *  - The tree is **held across opens** — only a host *change* resets it
  *    ([reset]). Re-opening the same host renders the held tree INSTANTLY with
@@ -29,7 +31,7 @@ import com.pocketshell.uikit.model.SessionAgentState
  *  - A probe becomes a **reconcile** ([reconcile]): diff incoming keys against
  *    held keys → add new, remove gone, update-in-place existing — never
  *    blank-and-rebuild.
- *  - App-initiated changes mutate the tree **directly by id**
+ *  - App-initiated changes mutate the tree **directly by generation**
  *    ([removeSession], [insertWindow]) the instant the app knows about them
  *    (#653 stop→remove, #678 create-window→insert), so the probe is a
  *    confirmation, not the source of truth for our own actions.
@@ -76,16 +78,28 @@ internal class HostTreeModel {
         private set
 
     /**
-     * Keyed session nodes in **insertion order** — the intrinsic display order
-     * that replaces the #639 `stableSessionOrder` stabilizer. A session keeps
-     * its slot across reconciles because it stays the same map entry; only
-     * genuinely new sessions are appended (sorted among new peers), and removed
-     * sessions drop out.
+     * Exact live session nodes keyed by the tmux generation identity. A
+     * same-name recreation therefore cannot update this map entry in place.
      */
-    private val sessions = LinkedHashMap<String, SessionNode>()
+    private val sessions = LinkedHashMap<TmuxSessionGeneration, SessionNode>()
 
-    /** Folder path per session, canonicalised. Mirrors `lastSessionFolderPaths`. */
-    private val sessionFolderPaths = LinkedHashMap<String, String>()
+    /**
+     * Legacy/degraded probe rows that have no complete generation. These rows
+     * are display-only until an authoritative probe supplies an exact identity;
+     * no destructive lifecycle event can target them.
+     */
+    private val provisionalSessions = LinkedHashMap<String, SessionNode>()
+
+    /** Intrinsic display order for exact and provisional nodes. */
+    private val sessionOrder = LinkedHashMap<SessionNodeKey, Unit>()
+
+    /** Secondary name index used only for display lookup and rename routing. */
+    private val sessionNameIndex = LinkedHashMap<String, SessionNodeKey>()
+
+    private sealed interface SessionNodeKey {
+        data class Exact(val generation: TmuxSessionGeneration) : SessionNodeKey
+        data class Provisional(val sessionName: String) : SessionNodeKey
+    }
 
     /** The host's watched-root overlay (Room `project_roots`). */
     private var watchedFolders: List<ProjectRootEntity> = emptyList()
@@ -95,18 +109,16 @@ internal class HostTreeModel {
     private var resolvedWatchedRootPaths: Map<String, String> = emptyMap()
 
     /**
-     * #729 (#679 Slice 2): sticky bucket placement memory. Maps a session name
-     * to the resolved root *match* path it was last AUTHORITATIVELY placed under
+     * #729 (#679 Slice 2): sticky bucket placement memory. Each held node stores
+     * the resolved root *match* path it was last AUTHORITATIVELY placed under
      * by a healthy probe. A reconcile refreshes the entry whenever the live
      * probe resolves the session under a watched root, and drops it when the
      * session authoritatively moves out of every root. [project] threads this
      * into [FolderListViewModel.buildFolderTree] so a momentarily-degraded
      * `resolvedWatchedRootPaths` cannot flash an already-placed session into
-     * "Other folders" — the placement is held by node id, not recomputed solely
+     * "Other folders" — the placement is held by generation, not recomputed solely
      * from the degraded roots on every projection.
      */
-    private val stickyBuckets = LinkedHashMap<String, String>()
-
     /**
      * Optimistic folder overlay (#653 create/import). Holds canonical path →
      * label for a folder the app created locally before a probe confirms it.
@@ -145,6 +157,8 @@ internal class HostTreeModel {
      * to be re-derived each probe, plus the optimistic-insert grace marker.
      */
     private data class SessionNode(
+        var sessionName: String,
+        var folderPath: String,
         var lastActivity: Long?,
         var attached: Boolean,
         var agentKind: SessionAgentKind,
@@ -175,6 +189,8 @@ internal class HostTreeModel {
          * [tmuxSessionId] for durable identity construction.
          */
         var sessionCreated: Long?,
+        /** Held bucket placement, scoped to this exact node/generation. */
+        var stickyBucket: String? = null,
         /**
          * Wall-clock millis this node was inserted optimistically by an
          * app-initiated action (#653/#678), or `null` if it came from a probe.
@@ -207,12 +223,13 @@ internal class HostTreeModel {
         hasSnapshot = false
         lastReconciledAt = null
         sessions.clear()
-        sessionFolderPaths.clear()
+        provisionalSessions.clear()
+        sessionOrder.clear()
+        sessionNameIndex.clear()
         watchedFolders = emptyList()
         scannedProjectFoldersByRoot = emptyMap()
         historyProjectFoldersByRoot = emptyMap()
         resolvedWatchedRootPaths = emptyMap()
-        stickyBuckets.clear()
         optimisticFolders.clear()
         userCollapsedProjectPaths = emptySet()
         expandedProjectPaths = emptySet()
@@ -256,7 +273,17 @@ internal class HostTreeModel {
 
         val collapsedPaths = LinkedHashSet<String>()
         nodes.forEach { node ->
+            val canonicalFolder = FolderListViewModel.canonicalisePath(node.folderPath)
+                .ifBlank { FolderListViewModel.UNTRACKED_PATH }
+            val key = node.generation?.let(SessionNodeKey::Exact)
+                ?: SessionNodeKey.Provisional(node.sessionName)
+            // A malformed/colliding registry entry must not create two visible
+            // rows for one display name. The first persisted row wins, and the
+            // following authoritative reconcile supplies the live identity.
+            if (sessionNameIndex.containsKey(node.sessionName)) return@forEach
             val placeholder = SessionNode(
+                sessionName = node.sessionName,
+                folderPath = canonicalFolder,
                 lastActivity = null,
                 attached = false,
                 agentKind = node.foreignGuess ?: SessionAgentKind.Probing,
@@ -268,16 +295,13 @@ internal class HostTreeModel {
                 // the recorded profile — the first reconcile re-reads it from the
                 // host @ps_agent_profile option (#858).
                 recordedProfile = null,
-                tmuxSessionId = null,
-                sessionCreated = null,
+                tmuxSessionId = node.generation?.sessionId,
+                sessionCreated = node.generation?.createdEpochSeconds,
                 // A registry seed is NOT app-inserted: leave it prunable by the
                 // first reconcile if the session is gone.
                 optimisticSince = null,
             )
-            sessions[node.sessionName] = placeholder
-            val canonicalFolder = FolderListViewModel.canonicalisePath(node.folderPath)
-                .ifBlank { FolderListViewModel.UNTRACKED_PATH }
-            sessionFolderPaths[node.sessionName] = canonicalFolder
+            addNode(key, placeholder)
             if (node.collapsed && canonicalFolder.isNotBlank()) {
                 collapsedPaths.add(canonicalFolder)
             }
@@ -380,14 +404,14 @@ internal class HostTreeModel {
      */
     fun exportNodes(): List<HydratedNode> {
         var order = 0
-        return sessions.entries.map { (name, node) ->
-            val folderPath = sessionFolderPaths[name] ?: FolderListViewModel.UNTRACKED_PATH
+        return orderedNodes().map { (key, node) ->
             HydratedNode(
-                sessionName = name,
+                sessionName = node.sessionName,
                 order = order++,
-                folderPath = folderPath,
-                collapsed = folderPath in userCollapsedProjectPaths,
+                folderPath = node.folderPath,
+                collapsed = node.folderPath in userCollapsedProjectPaths,
                 foreignGuess = node.agentKind.takeIf { it.isForeignGuessExportable() },
+                generation = (key as? SessionNodeKey.Exact)?.generation,
             )
         }
     }
@@ -404,6 +428,7 @@ internal class HostTreeModel {
         val folderPath: String,
         val collapsed: Boolean,
         val foreignGuess: SessionAgentKind? = null,
+        val generation: TmuxSessionGeneration? = null,
     )
 
     /**
@@ -439,67 +464,89 @@ internal class HostTreeModel {
      *   stamp [lastReconciledAt]. Injectable for deterministic tests.
      */
     fun reconcile(snapshot: ProbeSnapshot, now: Long = System.currentTimeMillis()) {
-        val incomingByName = snapshot.sessions.associateBy { it.sessionName }
-        val incomingNames = incomingByName.keys
-
-        // Remove held sessions the probe no longer reports, sparing nodes still
-        // inside their optimistic grace window.
-        val toRemove = sessions.keys.filter { name ->
-            if (name in incomingNames) return@filter false
-            val node = sessions[name]
-            val since = node?.optimisticSince
-            // Prune unless the node was optimistically inserted recently.
-            since == null || (now - since) >= OPTIMISTIC_GRACE_MS
-        }
-        toRemove.forEach { name ->
-            sessions.remove(name)
-            sessionFolderPaths.remove(name)
-        }
-
-        // Add new + update existing, preserving the insertion order of held
-        // sessions and appending genuinely-new ones in probe order.
+        val incomingByGeneration = LinkedHashMap<TmuxSessionGeneration, FolderSessionEntry>()
+        val incomingProvisionalByName = LinkedHashMap<String, FolderSessionEntry>()
         snapshot.sessions.forEach { entry ->
-            val existing = sessions[entry.sessionName]
-            if (existing == null) {
-                sessions[entry.sessionName] = entry.toNode(optimisticSince = null)
+            val generation = entry.generationOrNull()
+            if (generation == null) {
+                incomingProvisionalByName[entry.sessionName] = entry
             } else {
-                existing.lastActivity = entry.lastActivity
-                existing.attached = entry.attached
-                // Issue #1237: the agent state is NOT sticky — take the latest
-                // read. The `@ps_agent_state` option is authoritative and a
-                // resting state that has gone stale is already dropped to
-                // Unknown upstream (resolveSessionAgentState), so a fresh read
-                // never wrongly persists an old idle/waiting chip.
-                existing.agentState = entry.agentState
-                // Issue #716: agent-ness is STICKY. A known agent kind is only
-                // overwritten by another agent kind or a CONFIRMED Shell — an
-                // incoming Probing must NOT clobber a known agent.
-                existing.agentKind = mergeAgentKind(existing.agentKind, entry.agentKind)
-                // Issue #858 / #889: reconcile the recorded profile against the
-                // host. A fresh NON-NULL read is always authoritative (a z.ai
-                // launch or a profile change). A BLANK read is authoritative
-                // ONLY when the incoming read is itself authoritative — i.e. it
-                // carries a real recorded agent kind or a confirmed shell (the
-                // host returned a live `@ps_agent_kind`, not a slow/incomplete
-                // probe). That blank means the host CLEARED `@ps_agent_profile`
-                // (a default relaunch in the same tmux session, #889): the stale
-                // z.ai chip MUST drop, not stay sticky. A blank read from a
-                // DEGRADED probe (incoming kind still Probing/Exited —
-                // `@ps_agent_kind` not read) keeps the held label so a transient
-                // blank doesn't flicker the chip off (the #858 stickiness intent).
-                existing.recordedProfile = when {
-                    entry.recordedProfile != null -> entry.recordedProfile
-                    entry.agentKind.isAuthoritativeRead -> null
-                    else -> existing.recordedProfile
-                }
-                existing.tmuxSessionId = entry.tmuxSessionId
-                existing.sessionCreated = entry.sessionCreated
-                existing.windows = mergeWindows(existing.windows, entry.windows.map { it.toState() })
-                // The probe confirmed this node — it is no longer optimistic.
-                existing.optimisticSince = null
+                incomingByGeneration[generation] = entry
             }
-            sessionFolderPaths[entry.sessionName] = snapshot.folderPaths[entry.sessionName]
+        }
+        val incomingExactNames = incomingByGeneration.values.mapTo(linkedSetOf()) { it.sessionName }
+
+        // A generation match is the ONLY in-place update. A same-name row with
+        // another generation is an explicit replacement: remove the predecessor
+        // first so agent/profile/window state cannot leak into the successor.
+        orderedNodes().forEach { (key, node) ->
+            val generation = (key as? SessionNodeKey.Exact)?.generation
+            val generationStillLive = generation != null && generation in incomingByGeneration
+            if (generationStillLive) return@forEach
+            val provisionalStillLive =
+                key is SessionNodeKey.Provisional && key.sessionName in incomingProvisionalByName
+            if (provisionalStillLive) return@forEach
+            // A degraded name-only row cannot prove that an exact held row was
+            // replaced or killed. Keep the exact node until a probe supplies
+            // either its matching generation, a different exact generation, or
+            // no row at all.
+            if (key is SessionNodeKey.Exact && node.sessionName in incomingProvisionalByName) {
+                return@forEach
+            }
+
+            val sameNameIsPresent = node.sessionName in incomingExactNames
+            val replacement = sameNameIsPresent
+            val since = node.optimisticSince
+            val outsideGrace = since == null || (now - since) >= OPTIMISTIC_GRACE_MS
+            if (replacement || outsideGrace) {
+                removeNode(key)
+            }
+        }
+
+        // Add new + update existing, preserving the insertion order of exact
+        // generations. A rename with the same generation keeps its slot; a
+        // same-name recreation gets a new node and therefore fresh state.
+        snapshot.sessions.forEach { entry ->
+            val generation = entry.generationOrNull()
+            val folderPath = snapshot.folderPaths[entry.sessionName]
                 ?: FolderListViewModel.UNTRACKED_PATH
+            if (generation == null) {
+                // An exact held row wins over a degraded same-name observation;
+                // do not create a provisional alias or overwrite its state.
+                if (sessionNameIndex[entry.sessionName] is SessionNodeKey.Exact) {
+                    return@forEach
+                }
+                val existing = provisionalSessions[entry.sessionName]
+                if (existing == null) {
+                    addNode(
+                        SessionNodeKey.Provisional(entry.sessionName),
+                        entry.toNode(folderPath = folderPath, optimisticSince = null),
+                    )
+                } else {
+                    updateNode(existing, entry, folderPath)
+                    existing.optimisticSince = null
+                }
+            } else {
+                val existing = sessions[generation]
+                if (existing == null) {
+                    // A provisional row for this display name has no state that
+                    // may be transferred into an exact generation.
+                    sessionNameIndex[entry.sessionName]?.let(::removeNode)
+                    addNode(
+                        SessionNodeKey.Exact(generation),
+                        entry.toNode(folderPath = folderPath, optimisticSince = null),
+                    )
+                } else {
+                    // A rename cannot alias another live node under the target
+                    // name. The exact generation remains the authority.
+                    sessionNameIndex[entry.sessionName]
+                        ?.takeUnless { it == SessionNodeKey.Exact(generation) }
+                        ?.let(::removeNode)
+                    renameNodeIfNeeded(existing, entry.sessionName, SessionNodeKey.Exact(generation))
+                    updateNode(existing, entry, folderPath)
+                    existing.optimisticSince = null
+                }
+            }
         }
 
         scannedProjectFoldersByRoot = snapshot.scannedProjectFoldersByRoot
@@ -511,7 +558,7 @@ internal class HostTreeModel {
         // A reconcile that observes a created folder (under a real session or
         // scan) retires its optimistic overlay entry.
         if (optimisticFolders.isNotEmpty()) {
-            val observed = sessionFolderPaths.values.toSet() +
+            val observed = orderedNodes().mapTo(mutableSetOf()) { it.second.folderPath } +
                 snapshot.scannedProjectFoldersByRoot.values.flatten()
                     .map(FolderListViewModel::canonicalisePath)
             optimisticFolders.keys.removeAll { it in observed }
@@ -537,26 +584,29 @@ internal class HostTreeModel {
      * node, never letting a degraded probe flash it into "Other folders".
      */
     private fun refreshStickyBuckets() {
-        stickyBuckets.keys.retainAll(sessionFolderPaths.keys)
         val livePlacements = FolderListViewModel.resolveStickyPlacements(
-            sessionFolderPaths = sessionFolderPaths,
+            sessionFolderPaths = orderedNodes().associate { (_, node) ->
+                node.sessionName to node.folderPath
+            },
             watchedFolders = watchedFolders,
             resolvedWatchedRootPaths = resolvedWatchedRootPaths,
         )
-        for ((name, cwd) in sessionFolderPaths) {
+        for ((_, node) in orderedNodes()) {
+            val name = node.sessionName
+            val cwd = node.folderPath
             val live = livePlacements[name]
             if (live != null) {
                 // Healthy placement — refresh the held root.
-                stickyBuckets[name] = live
+                node.stickyBucket = live
                 continue
             }
             // No live placement. Keep a held sticky root only while the cwd
             // still sits under it (degraded probe); otherwise the session
             // authoritatively left the root, so drop the entry.
-            val held = stickyBuckets[name]
+            val held = node.stickyBucket
             val canonicalCwd = FolderListViewModel.canonicalisePath(cwd)
             if (held != null && !FolderListViewModel.pathWithinRoot(canonicalCwd, held)) {
-                stickyBuckets.remove(name)
+                node.stickyBucket = null
             }
         }
     }
@@ -566,10 +616,18 @@ internal class HostTreeModel {
      * from the next [project] immediately; the following reconcile is a
      * confirmation, not the trigger. Returns `true` when a node was removed.
      */
-    fun removeSession(sessionName: String): Boolean {
-        if (sessions.remove(sessionName) == null) return false
-        sessionFolderPaths.remove(sessionName)
-        return true
+    fun removeSession(generation: TmuxSessionGeneration): Boolean {
+        return removeNode(SessionNodeKey.Exact(generation)) != null
+    }
+
+    /**
+     * Resolve a name to an exact generation for callers that only have a row's
+     * display name. A provisional row deliberately returns `null`, forcing the
+     * caller to request an authoritative reconcile instead of deleting by name.
+     */
+    fun generationForSession(sessionName: String): TmuxSessionGeneration? {
+        val key = sessionNameIndex[sessionName.trim()] as? SessionNodeKey.Exact ?: return null
+        return key.generation
     }
 
     /**
@@ -594,7 +652,7 @@ internal class HostTreeModel {
      */
     fun removeWindow(windowId: String): Boolean {
         if (windowId.isBlank()) return false
-        sessions.values.forEach { node ->
+        orderedNodes().forEach { (_, node) ->
             if (node.windows.any { it.windowId == windowId }) {
                 node.windows = node.windows.filterNot { it.windowId == windowId }
                 return true
@@ -604,24 +662,20 @@ internal class HostTreeModel {
     }
 
     /**
-     * Optimistically rename a session by id, preserving its slot, windows, and
-     * expansion (#653). The new name inherits the old node's insertion position
-     * so the row does not jump. Returns `true` when the rename applied.
+     * Optimistically rename one exact session generation, preserving its slot,
+     * windows, and expansion (#653). The new name inherits the old node's
+     * insertion position so the row does not jump. A display name is only a
+     * lookup hint at the UI boundary; it is never sufficient to authorize this
+     * mutation because a same-name successor may already occupy the row.
+     * Returns `true` when the rename applied.
      */
-    fun renameSession(oldName: String, newName: String): Boolean {
+    fun renameSession(generation: TmuxSessionGeneration, newName: String): Boolean {
+        val oldKey = SessionNodeKey.Exact(generation)
+        val node = nodeFor(oldKey) ?: return false
+        val oldName = node.sessionName
         if (oldName == newName) return false
-        val node = sessions[oldName] ?: return false
-        // Rebuild the map preserving order, swapping the key in place.
-        val rebuilt = LinkedHashMap<String, SessionNode>(sessions.size)
-        sessions.forEach { (name, value) ->
-            if (name == oldName) rebuilt[newName] = value else rebuilt[name] = value
-        }
-        sessions.clear()
-        sessions.putAll(rebuilt)
-        sessionFolderPaths[oldName]?.let { path ->
-            sessionFolderPaths.remove(oldName)
-            sessionFolderPaths[newName] = path
-        }
+        if (sessionNameIndex.containsKey(newName)) return false
+        renameNodeIfNeeded(node, newName, oldKey)
         return true
     }
 
@@ -642,47 +696,61 @@ internal class HostTreeModel {
      * slot); a new node is appended.
      */
     fun insertSession(entry: FolderSessionEntry, folderPath: String, now: Long = System.currentTimeMillis()) {
-        val existing = sessions[entry.sessionName]
-        if (existing == null) {
-            sessions[entry.sessionName] = entry.toNode(optimisticSince = now)
+        val generation = entry.generationOrNull()
+        if (generation == null) {
+            // A name-only insert is provisional. It may be displayed, but it
+            // cannot replace or authorize destructive mutation of an exact row.
+            if (sessionNameIndex[entry.sessionName] is SessionNodeKey.Exact) return
+            val existing = provisionalSessions[entry.sessionName]
+            if (existing == null) {
+                addNode(
+                    SessionNodeKey.Provisional(entry.sessionName),
+                    entry.toNode(folderPath = folderPath, optimisticSince = now),
+                )
+            } else {
+                updateNode(existing, entry, folderPath)
+                existing.optimisticSince = now
+            }
         } else {
-            existing.lastActivity = entry.lastActivity
-            existing.attached = entry.attached
-            existing.agentKind = entry.agentKind
-            existing.agentState = entry.agentState
-            existing.windows = entry.windows.map { it.toState() }
-            existing.recordedProfile = entry.recordedProfile
-            existing.tmuxSessionId = entry.tmuxSessionId
-            existing.sessionCreated = entry.sessionCreated
-            existing.optimisticSince = now
+            sessionNameIndex[entry.sessionName]
+                ?.takeUnless { it == SessionNodeKey.Exact(generation) }
+                ?.let(::removeNode)
+            val existing = sessions[generation]
+            if (existing == null) {
+                addNode(
+                    SessionNodeKey.Exact(generation),
+                    entry.toNode(folderPath = folderPath, optimisticSince = now),
+                )
+            } else {
+                renameNodeIfNeeded(existing, entry.sessionName, SessionNodeKey.Exact(generation))
+                updateNode(existing, entry, folderPath)
+                existing.optimisticSince = now
+            }
         }
-        sessionFolderPaths[entry.sessionName] =
-            FolderListViewModel.canonicalisePath(folderPath).ifBlank { FolderListViewModel.UNTRACKED_PATH }
         hasSnapshot = true
     }
 
     /**
      * Epic #821 slice C (issue #837): apply a `tree.reconcile` DELTA to the held
      * tree without a full reload — the "refresh to see which sessions are gone,
-     * without reloading everything" path. Prunes each session in [goneNames]
-     * from the held tree by id (sparing nodes still within their optimistic
+     * without reloading everything" path. Prunes each session in
+     * [goneGenerations] from the held tree by exact generation (sparing nodes
+     * still within their optimistic
      * grace, exactly like [reconcile]). Returns `true` when at least one node was
      * pruned, so the caller can persist + re-emit. ADDED sessions are NOT folded
      * here — they need a full probe to fetch their content, so the caller kicks a
      * reconcile when the delta reports additions.
      */
     fun applyReconcileGoneDelta(
-        goneNames: Collection<String>,
+        goneGenerations: Collection<TmuxSessionGeneration>,
         now: Long = System.currentTimeMillis(),
     ): Boolean {
         var pruned = false
-        goneNames.forEach { name ->
-            val node = sessions[name] ?: return@forEach
+        goneGenerations.forEach { generation ->
+            val node = sessions[generation] ?: return@forEach
             val since = node.optimisticSince
             if (since != null && (now - since) < OPTIMISTIC_GRACE_MS) return@forEach
-            sessions.remove(name)
-            sessionFolderPaths.remove(name)
-            stickyBuckets.remove(name)
+            removeNode(SessionNodeKey.Exact(generation))
             pruned = true
         }
         return pruned
@@ -702,7 +770,7 @@ internal class HostTreeModel {
 
     /** The maintained session list in intrinsic insertion order. */
     fun sessionEntries(): List<FolderSessionEntry> =
-        sessions.entries.map { (name, node) -> node.toEntry(name) }
+        orderedNodes().map { (_, node) -> node.toEntry() }
 
     /** Current expanded-folder set (intrinsic, for the rendered Ready state). */
     fun expandedPaths(): Set<String> = expandedProjectPaths
@@ -756,13 +824,17 @@ internal class HostTreeModel {
     fun snapshotForProjection(): ProjectionSnapshot =
         ProjectionSnapshot(
             orderedSessions = sessionEntries(),
-            sessionFolderPaths = LinkedHashMap(sessionFolderPaths),
+            sessionFolderPaths = orderedNodes().associateTo(LinkedHashMap()) { (_, node) ->
+                node.sessionName to node.folderPath
+            },
             watchedFolders = watchedFolders,
             scannedProjectFoldersByRoot = scannedProjectFoldersByRoot,
             historyProjectFoldersByRoot = historyProjectFoldersByRoot,
             resolvedWatchedRootPaths = resolvedWatchedRootPaths,
             optimisticFolders = LinkedHashMap(optimisticFolders),
-            stickyBuckets = LinkedHashMap(stickyBuckets),
+            stickyBuckets = orderedNodes().mapNotNull { (_, node) ->
+                node.stickyBucket?.let { node.sessionName to it }
+            }.toMap(LinkedHashMap()),
             previousExpanded = expandedProjectPaths,
             userCollapsedProjectPaths = userCollapsedProjectPaths,
         )
@@ -771,6 +843,91 @@ internal class HostTreeModel {
     fun applyProjection(result: ProjectionResult) {
         expandedProjectPaths = result.projection.expandedProjectPaths
         userCollapsedProjectPaths = result.userCollapsedProjectPaths
+    }
+
+    private fun FolderSessionEntry.generationOrNull(): TmuxSessionGeneration? =
+        tmuxSessionGenerationOrNull(tmuxSessionId, sessionCreated)
+
+    private fun nodeFor(key: SessionNodeKey): SessionNode? = when (key) {
+        is SessionNodeKey.Exact -> sessions[key.generation]
+        is SessionNodeKey.Provisional -> provisionalSessions[key.sessionName]
+    }
+
+    private fun orderedNodes(): List<Pair<SessionNodeKey, SessionNode>> =
+        sessionOrder.keys.mapNotNull { key -> nodeFor(key)?.let { key to it } }
+
+    private fun addNode(key: SessionNodeKey, node: SessionNode) {
+        when (key) {
+            is SessionNodeKey.Exact -> sessions[key.generation] = node
+            is SessionNodeKey.Provisional -> provisionalSessions[key.sessionName] = node
+        }
+        sessionOrder[key] = Unit
+        sessionNameIndex[node.sessionName] = key
+    }
+
+    private fun removeNode(key: SessionNodeKey): SessionNode? {
+        val node = nodeFor(key) ?: return null
+        when (key) {
+            is SessionNodeKey.Exact -> sessions.remove(key.generation)
+            is SessionNodeKey.Provisional -> provisionalSessions.remove(key.sessionName)
+        }
+        sessionOrder.remove(key)
+        if (sessionNameIndex[node.sessionName] == key) {
+            sessionNameIndex.remove(node.sessionName)
+        }
+        return node
+    }
+
+    /** Rename the display field while keeping an exact generation key stable. */
+    private fun renameNodeIfNeeded(
+        node: SessionNode,
+        newName: String,
+        key: SessionNodeKey,
+    ) {
+        if (node.sessionName == newName) return
+        sessionNameIndex.remove(node.sessionName)
+        if (key is SessionNodeKey.Provisional) {
+            val newKey = SessionNodeKey.Provisional(newName)
+            provisionalSessions.remove(key.sessionName)
+            provisionalSessions[newName] = node
+            val rebuiltOrder = LinkedHashMap<SessionNodeKey, Unit>(sessionOrder.size)
+            sessionOrder.forEach { (candidate, value) ->
+                rebuiltOrder[if (candidate == key) newKey else candidate] = value
+            }
+            sessionOrder.clear()
+            sessionOrder.putAll(rebuiltOrder)
+            sessionNameIndex[newName] = newKey
+        } else {
+            sessionNameIndex[newName] = key
+        }
+        node.sessionName = newName
+    }
+
+    /** Update fields only after the caller proved the generation is unchanged. */
+    private fun updateNode(
+        existing: SessionNode,
+        entry: FolderSessionEntry,
+        folderPath: String,
+    ) {
+        existing.lastActivity = entry.lastActivity
+        existing.attached = entry.attached
+        // Issue #1237: the agent state is NOT sticky — take the latest read.
+        existing.agentState = entry.agentState
+        // Issue #716: a degraded Probing read must not clobber a known agent.
+        existing.agentKind = mergeAgentKind(existing.agentKind, entry.agentKind)
+        // Issue #858 / #889: retain a profile only across a degraded read. A
+        // generation replacement never reaches this function, so it starts
+        // with the successor's own profile state.
+        existing.recordedProfile = when {
+            entry.recordedProfile != null -> entry.recordedProfile
+            entry.agentKind.isAuthoritativeRead -> null
+            else -> existing.recordedProfile
+        }
+        existing.tmuxSessionId = entry.tmuxSessionId
+        existing.sessionCreated = entry.sessionCreated
+        existing.windows = mergeWindows(existing.windows, entry.windows.map { it.toState() })
+        existing.folderPath = FolderListViewModel.canonicalisePath(folderPath)
+            .ifBlank { FolderListViewModel.UNTRACKED_PATH }
     }
 
     /**
@@ -871,8 +1028,14 @@ internal class HostTreeModel {
         }
     }
 
-    private fun FolderSessionEntry.toNode(optimisticSince: Long?): SessionNode =
+    private fun FolderSessionEntry.toNode(
+        folderPath: String,
+        optimisticSince: Long?,
+    ): SessionNode =
         SessionNode(
+            sessionName = sessionName,
+            folderPath = FolderListViewModel.canonicalisePath(folderPath)
+                .ifBlank { FolderListViewModel.UNTRACKED_PATH },
             lastActivity = lastActivity,
             attached = attached,
             agentKind = agentKind,
@@ -884,9 +1047,9 @@ internal class HostTreeModel {
             optimisticSince = optimisticSince,
         )
 
-    private fun SessionNode.toEntry(name: String): FolderSessionEntry =
+    private fun SessionNode.toEntry(): FolderSessionEntry =
         FolderSessionEntry(
-            sessionName = name,
+            sessionName = sessionName,
             lastActivity = lastActivity,
             attached = attached,
             agentKind = agentKind,

--- a/app/src/main/java/com/pocketshell/app/projects/TreeClientCache.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TreeClientCache.kt
@@ -218,6 +218,12 @@ public class TreeClientCache @Inject constructor(
                 .put(KEY_FOLDER_PATH, node.folderPath)
                 .put(KEY_COLLAPSED, node.collapsed)
             node.foreignKind?.takeIf { it.isNotBlank() }?.let { obj.put(KEY_FOREIGN_KIND, it) }
+            node.tmuxSessionId?.trim()?.takeIf { it.isNotEmpty() }?.let { id ->
+                node.sessionCreated?.takeIf { it > 0L }?.let { created ->
+                    obj.put(KEY_TMUX_SESSION_ID, id)
+                    obj.put(KEY_SESSION_CREATED, created)
+                }
+            }
             nodesArray.put(obj)
         }
         val watchedArray = JSONArray()
@@ -244,6 +250,10 @@ public class TreeClientCache @Inject constructor(
         for (i in 0 until nodesJson.length()) {
             val obj = nodesJson.optJSONObject(i) ?: continue
             val session = obj.optString(KEY_SESSION).takeIf { it.isNotBlank() } ?: continue
+            val tmuxSessionId = obj.optString(KEY_TMUX_SESSION_ID, "")
+                .trim()
+                .takeIf { it.isNotEmpty() }
+            val sessionCreated = obj.optLong(KEY_SESSION_CREATED, 0L).takeIf { it > 0L }
             nodes.add(
                 TreeRemoteSource.TreeNode(
                     session = session,
@@ -251,6 +261,8 @@ public class TreeClientCache @Inject constructor(
                     folderPath = obj.optString(KEY_FOLDER_PATH, ""),
                     collapsed = obj.optBoolean(KEY_COLLAPSED, false),
                     foreignKind = obj.optString(KEY_FOREIGN_KIND, "").takeIf { it.isNotBlank() },
+                    tmuxSessionId = tmuxSessionId?.takeIf { sessionCreated != null },
+                    sessionCreated = sessionCreated?.takeIf { tmuxSessionId != null },
                 ),
             )
         }
@@ -319,6 +331,8 @@ public class TreeClientCache @Inject constructor(
         const val KEY_FOLDER_PATH: String = "folder_path"
         const val KEY_COLLAPSED: String = "collapsed"
         const val KEY_FOREIGN_KIND: String = "foreign_kind"
+        const val KEY_TMUX_SESSION_ID: String = "tmux_session_id"
+        const val KEY_SESSION_CREATED: String = "session_created"
         const val KEY_WATCHED_FOLDERS: String = "watched_folders"
         const val KEY_WATCHED_PATH: String = "path"
         const val KEY_WATCHED_LABEL: String = "label"

--- a/app/src/main/java/com/pocketshell/app/projects/TreeRemoteSource.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TreeRemoteSource.kt
@@ -53,11 +53,12 @@ public class TreeRemoteSource @Inject constructor() {
     internal var remoteExecDispatcher: CoroutineDispatcher = Dispatchers.IO
 
     /**
-     * One persisted tree node. [session] is the tmux session name (the key);
-     * [order] is its intrinsic display position; [folderPath] is its
-     * canonicalised bucket; [collapsed] is the user's expand/collapse choice for
-     * its folder; [foreignKind] is the optional one-shot foreign-guess cache
-     * (`claude` / `codex` / `opencode`), NOT the confirmed kind.
+     * One persisted tree node. [session] is the display name; [tmuxSessionId]
+     * + [sessionCreated] are the exact tmux generation when known. [order] is
+     * its intrinsic display position; [folderPath] is its canonicalised bucket;
+     * [collapsed] is the user's expand/collapse choice for its folder;
+     * [foreignKind] is the optional one-shot foreign-guess cache (`claude` /
+     * `codex` / `opencode`), NOT the confirmed kind.
      */
     public data class TreeNode(
         val session: String,
@@ -65,6 +66,8 @@ public class TreeRemoteSource @Inject constructor() {
         val folderPath: String,
         val collapsed: Boolean,
         val foreignKind: String? = null,
+        val tmuxSessionId: String? = null,
+        val sessionCreated: Long? = null,
     )
 
     /** The `tree.reconcile` delta result. Deltas only — never a full reload. */
@@ -171,6 +174,12 @@ public class TreeRemoteSource @Inject constructor() {
             if (node.foreignKind != null && node.foreignKind.isNotBlank()) {
                 obj.put("foreign_kind", node.foreignKind)
             }
+            node.tmuxSessionId?.trim()?.takeIf { it.isNotEmpty() }?.let { id ->
+                node.sessionCreated?.takeIf { it > 0L }?.let { created ->
+                    obj.put("tmux_session_id", id)
+                    obj.put("session_created", created)
+                }
+            }
             nodesArray.put(obj)
         }
         return JSONObject().put("host", host).put("nodes", nodesArray).toString()
@@ -186,6 +195,10 @@ public class TreeRemoteSource @Inject constructor() {
         for (i in 0 until nodes.length()) {
             val row = nodes.optJSONObject(i) ?: continue
             val sessionName = row.optString("session").takeIf { it.isNotBlank() } ?: continue
+            val tmuxSessionId = row.optString("tmux_session_id", "")
+                .trim()
+                .takeIf { it.isNotEmpty() }
+            val sessionCreated = row.optLong("session_created", 0L).takeIf { it > 0L }
             out.add(
                 TreeNode(
                     session = sessionName,
@@ -193,6 +206,8 @@ public class TreeRemoteSource @Inject constructor() {
                     folderPath = row.optString("folder_path", ""),
                     collapsed = row.optBoolean("collapsed", false),
                     foreignKind = row.optString("foreign_kind", "").takeIf { it.isNotBlank() },
+                    tmuxSessionId = tmuxSessionId?.takeIf { sessionCreated != null },
+                    sessionCreated = sessionCreated?.takeIf { tmuxSessionId != null },
                 ),
             )
         }

--- a/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
+++ b/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.prefs.DeferredPrefs
+import com.pocketshell.app.tmux.TmuxSessionGeneration
+import com.pocketshell.app.tmux.tmuxSessionGenerationOrNull
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -134,8 +136,11 @@ class LastSessionStore @VisibleForTesting internal constructor(
     @Volatile
     private var killedTombstone: SessionIdentity? = null
 
-    /** Minimal (hostId, sessionName) identity used for kill matching (#834). */
-    private data class SessionIdentity(val hostId: Long, val sessionName: String)
+    /** Exact host-scoped tmux generation used for kill matching (#834). */
+    private data class SessionIdentity(
+        val hostId: Long,
+        val generation: TmuxSessionGeneration,
+    )
 
     /**
      * Persisted snapshot of the last active `tmux -CC` session view.
@@ -160,7 +165,11 @@ class LastSessionStore @VisibleForTesting internal constructor(
         val sessionCreated: Long? = null,
         val composerDraft: String,
         val savedAtMillis: Long,
-    )
+    ) {
+        /** The complete tmux identity, when this snapshot carried one. */
+        val generation: TmuxSessionGeneration?
+            get() = tmuxSessionGenerationOrNull(tmuxSessionId, sessionCreated)
+    }
 
     /**
      * Persist [session] as the last active view. Called from
@@ -180,7 +189,7 @@ class LastSessionStore @VisibleForTesting internal constructor(
         // longer exists, and the next foreground/process-death restore would
         // reopen it (→ #818 Conversation tab of a deleted session, the #686
         // hazard). Clear the on-disk record instead of writing the dead one.
-        if (killedTombstone == session.identity()) {
+        if (session.identity()?.let { it == killedTombstone } == true) {
             Log.i(
                 LAST_SESSION_LOG_TAG,
                 "last-session-save-suppressed trigger=onStop reason=killed " +
@@ -337,23 +346,31 @@ class LastSessionStore @VisibleForTesting internal constructor(
      *     [save] for the SAME dead session (user still parked on the now-dead
      *     screen) is refused rather than re-arming the restore.
      *
-     * Matching is on (hostId, sessionName) — the same identity
-     * [com.pocketshell.app.tmux.SessionLifecycleSignals] broadcasts. A kill on
-     * one session never invalidates a different stored session.
+     * Matching is on (hostId, exact tmux generation). The display name is only
+     * diagnostic copy; it is never used to invalidate a snapshot or suppress a
+     * save. A delayed predecessor event therefore cannot clear or suppress a
+     * same-name successor.
      *
      * @return `true` when there was no matching persisted record or its clear
      *   was durably acknowledged; `false` when the matching clear failed.
      */
-    fun onSessionKilled(hostId: Long, sessionName: String): Boolean {
-        val trimmed = sessionName.trim()
-        if (trimmed.isEmpty()) return true
-        val killed = SessionIdentity(hostId = hostId, sessionName = trimmed)
+    fun onSessionKilled(
+        hostId: Long,
+        generation: TmuxSessionGeneration,
+        lastKnownName: String,
+    ): Boolean {
+        val exact = tmuxSessionGenerationOrNull(
+            generation.sessionId,
+            generation.createdEpochSeconds,
+        ) ?: return true
+        val killed = SessionIdentity(hostId = hostId, generation = exact)
         killedTombstone = killed
         val stored = peek(maxAgeMillis = Long.MAX_VALUE)
         if (stored != null && stored.identity() == killed) {
             Log.i(
                 LAST_SESSION_LOG_TAG,
-                "last-session-clear trigger=killed hostId=$hostId session=$trimmed",
+                "last-session-clear trigger=killed hostId=$hostId " +
+                    "generation=$exact session=${lastKnownName.trim()}",
             )
             return clearDurably("clear-killed")
         }
@@ -443,32 +460,36 @@ class LastSessionStore @VisibleForTesting internal constructor(
     }
 
     /**
-     * Issue #834: a session of [sessionName] on [hostId] was legitimately
+     * Issue #834: a session generation on [hostId] was legitimately
      * (re)opened. Clears the kill tombstone for that exact identity so a
-     * recreated same-name session is restorable again.
+     * recreated same-name generation is restorable again.
      *
      * tmux session names are user-chosen and habitually reused (`main`,
      * `work`, `claude-main`), so a kill tombstone must NOT outlive the
      * recreation of that identity — otherwise the next `onStop` [save] of the
      * recreated live session is wrongly suppressed and the #177 fast-resume
      * breaks for that name forever (the over-suppression the reviewer flagged).
-     * Matching is on (hostId, sessionName), identical to [onSessionKilled], so
-     * opening a DIFFERENT session never clears another session's tombstone.
+     * Matching is on (hostId, exact tmux generation), identical to
+     * [onSessionKilled], so opening a DIFFERENT generation never clears another
+     * session's tombstone.
      */
-    fun onSessionOpened(hostId: Long, sessionName: String) {
-        val trimmed = sessionName.trim()
-        if (trimmed.isEmpty()) return
-        if (killedTombstone == SessionIdentity(hostId = hostId, sessionName = trimmed)) {
+    fun onSessionOpened(hostId: Long, generation: TmuxSessionGeneration) {
+        val exact = tmuxSessionGenerationOrNull(
+            generation.sessionId,
+            generation.createdEpochSeconds,
+        ) ?: return
+        if (killedTombstone == SessionIdentity(hostId = hostId, generation = exact)) {
             Log.i(
                 LAST_SESSION_LOG_TAG,
-                "last-session-tombstone-clear trigger=opened hostId=$hostId session=$trimmed",
+                "last-session-tombstone-clear trigger=opened hostId=$hostId " +
+                    "generation=$exact",
             )
             killedTombstone = null
         }
     }
 
-    private fun LastSession.identity(): SessionIdentity =
-        SessionIdentity(hostId = hostId, sessionName = sessionName)
+    private fun LastSession.identity(): SessionIdentity? =
+        generation?.let { SessionIdentity(hostId = hostId, generation = it) }
 
     /**
      * Rebuild the navigation destination from a persisted [LastSession].

--- a/app/src/main/java/com/pocketshell/app/tmux/AgentSessionMemory.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/AgentSessionMemory.kt
@@ -108,11 +108,14 @@ public class AgentSessionMemory @Inject constructor() {
      * A newly-created session can reuse the same name and even the same tmux
      * window ids, so per-window forget is not enough at session teardown.
      */
-    internal fun forgetSession(hostId: Long, sessionName: String) {
-        val trimmed = sessionName.trim()
-        if (trimmed.isEmpty()) return
+    internal fun forgetSession(hostId: Long, generation: TmuxSessionGeneration) {
+        val durableKey = durableTmuxSessionKey(
+            hostId,
+            generation.sessionId,
+            generation.createdEpochSeconds,
+        ) ?: return
         statuses.keys.removeIf { key ->
-            key.hostId == hostId && key.sessionName == trimmed
+            key.hostId == hostId && key.durableSessionKey == durableKey
         }
     }
 

--- a/app/src/main/java/com/pocketshell/app/tmux/KilledSessionRestorePlan.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/KilledSessionRestorePlan.kt
@@ -31,17 +31,17 @@ internal data class KilledSessionRestorePlan(
 )
 
 /**
- * Match the confirmed kill against every in-memory restore lane. Matching is
- * deliberately host-plus-name only: that is the identity carried by the
- * lifecycle signal, and same-name recreation is allowed to clear the old
- * invalidation when its open signal arrives.
+ * Match the confirmed kill against every in-memory restore lane by the exact
+ * host-plus-generation identity. A same-name successor must never have its
+ * restore lane invalidated by a delayed predecessor event.
  */
 internal fun planKilledSessionRestore(
     killed: KilledSession,
     state: KilledSessionRestoreSnapshot,
 ): KilledSessionRestorePlan? {
     fun isKilled(target: ConnectionTarget?): Boolean =
-        target?.hostId == killed.hostId && target.sessionName == killed.sessionName
+        target?.hostId == killed.hostId &&
+            tmuxSessionGenerationOrNull(target.tmuxSessionId, target.sessionCreated) == killed.generation
 
     val activeWasKilled = isKilled(state.activeTarget)
     val connectingWasKilled = isKilled(state.connectingTarget)

--- a/app/src/main/java/com/pocketshell/app/tmux/SessionLifecycleSignals.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/SessionLifecycleSignals.kt
@@ -23,12 +23,17 @@ import javax.inject.Singleton
  *
  * @property hostId the host the killed session belonged to. The tree filters
  *   on this so a kill on host A never disturbs host B's rows.
- * @property sessionName the tmux session name that was killed.
+ * @property generation the exact tmux generation that was killed.
+ * @property lastKnownName the display name at the time the event was emitted.
  */
 data class KilledSession(
     val hostId: Long,
-    val sessionName: String,
-)
+    val generation: TmuxSessionGeneration,
+    val lastKnownName: String,
+) {
+    /** Compatibility read-only projection for existing non-destructive logs. */
+    val sessionName: String get() = lastKnownName
+}
 
 /**
  * Issue #883: one tmux WINDOW was closed by an in-session "Stop session" on a
@@ -62,7 +67,8 @@ data class ClosedWindow(
  * folder?" so the user recovers in one tap.
  *
  * @property hostId the host the gone session belonged to (the tree filters on it).
- * @property sessionName the tmux session name that was confirmed absent.
+ * @property generation the exact tmux generation that was confirmed absent.
+ * @property lastKnownName the display name at the time the event was emitted.
  * @property folderPath the session's working directory (its folder) so the
  *   recreate reuses the SAME folder's create-session path. `null` when the gone
  *   session carried no known start directory (the prompt then falls back to the
@@ -70,8 +76,27 @@ data class ClosedWindow(
  */
 data class StaleSession(
     val hostId: Long,
-    val sessionName: String,
+    val generation: TmuxSessionGeneration,
+    val lastKnownName: String,
     val folderPath: String?,
+) {
+    /** Compatibility read-only projection for the recovery prompt copy. */
+    val sessionName: String get() = lastKnownName
+}
+
+/**
+ * A lifecycle caller knew a session was gone but could not prove its tmux
+ * generation. This is deliberately a reconcile request, never a delete: a
+ * name-only event is allowed to refresh authoritative state but cannot remove
+ * a same-name successor.
+ */
+enum class SessionLifecycleAction { Kill, Stale }
+
+data class SessionIdentityUncertain(
+    val hostId: Long,
+    val lastKnownName: String,
+    val folderPath: String?,
+    val action: SessionLifecycleAction,
 )
 
 /**
@@ -140,15 +165,43 @@ class SessionLifecycleSignals @Inject constructor(
      */
     val staleSessions: SharedFlow<StaleSession> = _staleSessions.asSharedFlow()
 
-    /** Broadcast a confirmed kill of [sessionName] on [hostId]. */
-    fun emitKilled(hostId: Long, sessionName: String) {
-        val trimmed = sessionName.trim()
+    private val _identityUncertain = MutableSharedFlow<SessionIdentityUncertain>(
+        replay = 0,
+        extraBufferCapacity = 8,
+    )
+
+    /** Name-only lifecycle observations that require an authoritative reconcile. */
+    val identityUncertain: SharedFlow<SessionIdentityUncertain> = _identityUncertain.asSharedFlow()
+
+    /**
+     * Broadcast a confirmed kill of one exact [generation] on [hostId]. A null
+     * or malformed generation emits [identityUncertain] and performs no
+     * destructive cache/tree mutation.
+     */
+    fun emitKilled(
+        hostId: Long,
+        generation: TmuxSessionGeneration?,
+        lastKnownName: String,
+    ) {
+        val trimmed = lastKnownName.trim()
         if (trimmed.isEmpty()) return
-        agentSessionMemory?.forgetSession(hostId = hostId, sessionName = trimmed)
-        runtimeCache?.removeSession(hostId = hostId, sessionName = trimmed)?.forEach { runtime ->
+        val exact = generation.normalizedOrNull()
+        if (exact == null) {
+            emitIdentityUncertain(
+                hostId = hostId,
+                lastKnownName = trimmed,
+                folderPath = null,
+                action = SessionLifecycleAction.Kill,
+            )
+            return
+        }
+        agentSessionMemory?.forgetSession(hostId = hostId, generation = exact)
+        runtimeCache?.removeSession(hostId = hostId, generation = exact)?.forEach { runtime ->
             cleanupScope.launch { runtime.closeCachedRuntime() }
         }
-        _killedSessions.tryEmit(KilledSession(hostId = hostId, sessionName = trimmed))
+        _killedSessions.tryEmit(
+            KilledSession(hostId = hostId, generation = exact, lastKnownName = trimmed),
+        )
     }
 
     /**
@@ -170,19 +223,55 @@ class SessionLifecycleSignals @Inject constructor(
      * in this folder?". Also forgets the dead session's per-host memory/runtime like
      * [emitKilled], since it is confirmed gone.
      */
-    fun emitStaleSession(hostId: Long, sessionName: String, folderPath: String?) {
-        val trimmed = sessionName.trim()
+    fun emitStaleSession(
+        hostId: Long,
+        generation: TmuxSessionGeneration?,
+        lastKnownName: String,
+        folderPath: String?,
+    ) {
+        val trimmed = lastKnownName.trim()
         if (trimmed.isEmpty()) return
-        agentSessionMemory?.forgetSession(hostId = hostId, sessionName = trimmed)
-        runtimeCache?.removeSession(hostId = hostId, sessionName = trimmed)?.forEach { runtime ->
+        val exact = generation.normalizedOrNull()
+        val cleanFolder = folderPath?.trim()?.takeIf { it.isNotEmpty() }
+        if (exact == null) {
+            emitIdentityUncertain(
+                hostId = hostId,
+                lastKnownName = trimmed,
+                folderPath = cleanFolder,
+                action = SessionLifecycleAction.Stale,
+            )
+            return
+        }
+        agentSessionMemory?.forgetSession(hostId = hostId, generation = exact)
+        runtimeCache?.removeSession(hostId = hostId, generation = exact)?.forEach { runtime ->
             cleanupScope.launch { runtime.closeCachedRuntime() }
         }
         _staleSessions.tryEmit(
             StaleSession(
                 hostId = hostId,
-                sessionName = trimmed,
-                folderPath = folderPath?.trim()?.takeIf { it.isNotEmpty() },
+                generation = exact,
+                lastKnownName = trimmed,
+                folderPath = cleanFolder,
             ),
         )
     }
+
+    private fun emitIdentityUncertain(
+        hostId: Long,
+        lastKnownName: String,
+        folderPath: String?,
+        action: SessionLifecycleAction,
+    ) {
+        _identityUncertain.tryEmit(
+            SessionIdentityUncertain(
+                hostId = hostId,
+                lastKnownName = lastKnownName,
+                folderPath = folderPath,
+                action = action,
+            ),
+        )
+    }
+
+    private fun TmuxSessionGeneration?.normalizedOrNull(): TmuxSessionGeneration? =
+        this?.let { tmuxSessionGenerationOrNull(it.sessionId, it.createdEpochSeconds) }
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxOutboundQueueBinding.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxOutboundQueueBinding.kt
@@ -69,8 +69,8 @@ internal fun knownSessionNavigationTarget(
     val identity = hostId?.let { parseDurableTmuxSessionIdentity(it, durableKey) }
     return TmuxSessionNavigationTarget(
         sessionName,
-        identity?.tmuxSessionId,
-        identity?.sessionCreated,
+        identity?.sessionId,
+        identity?.createdEpochSeconds,
     )
 }
 
@@ -84,5 +84,9 @@ internal fun knownPaneSessionNavigationTarget(
         .firstOrNull { it.key.sessionName == sessionName && it.panes.any { pane -> pane.paneId == paneId } }
         ?.key?.durableSessionKey
         ?.let { parseDurableTmuxSessionIdentity(hostId, it) }
-    return TmuxSessionNavigationTarget(sessionName, identity?.tmuxSessionId, identity?.sessionCreated)
+    return TmuxSessionNavigationTarget(
+        sessionName,
+        identity?.sessionId,
+        identity?.createdEpochSeconds,
+    )
 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionIdentity.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionIdentity.kt
@@ -3,9 +3,17 @@ package com.pocketshell.app.tmux
 import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.core.connection.SessionId
 
-internal data class DurableTmuxSessionIdentity(
-    val tmuxSessionId: String,
-    val sessionCreated: Long,
+/**
+ * Exact identity of one tmux session generation.
+ *
+ * A tmux session name is mutable and can be reused. The server-assigned
+ * `#{session_id}` plus `#{session_created}` pair remains stable for the
+ * lifetime of that session object, so destructive lifecycle mutations must
+ * carry this value instead of falling back to the display name.
+ */
+public data class TmuxSessionGeneration(
+    val sessionId: String,
+    val createdEpochSeconds: Long,
 )
 
 /** Correlated navigation payload; identity travels with the user action. */
@@ -19,6 +27,15 @@ internal fun HostTmuxSessionRow.navigationTargetOrNull(): TmuxSessionNavigationT
     val id = tmuxSessionId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
     val created = createdAt?.takeIf { it > 0L } ?: return null
     return TmuxSessionNavigationTarget(name, id, created)
+}
+
+internal fun tmuxSessionGenerationOrNull(
+    tmuxSessionId: String?,
+    sessionCreated: Long?,
+): TmuxSessionGeneration? {
+    val id = tmuxSessionId?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val created = sessionCreated?.takeIf { it > 0L } ?: return null
+    return TmuxSessionGeneration(sessionId = id, createdEpochSeconds = created)
 }
 
 internal fun durableTmuxSessionKey(
@@ -42,7 +59,7 @@ internal fun tmuxTargetSessionId(
 internal fun parseDurableTmuxSessionIdentity(
     hostId: Long,
     durableSessionKey: String?,
-): DurableTmuxSessionIdentity? {
+): TmuxSessionGeneration? {
     val body = durableSessionKey?.removePrefix("tmux:$hostId:")
         ?.takeIf { it != durableSessionKey }
         ?: return null
@@ -50,7 +67,7 @@ internal fun parseDurableTmuxSessionIdentity(
     if (separator <= 0 || separator == body.lastIndex) return null
     val id = body.substring(0, separator).trim().takeIf { it.isNotEmpty() } ?: return null
     val created = body.substring(separator + 1).toLongOrNull()?.takeIf { it > 0L } ?: return null
-    return DurableTmuxSessionIdentity(id, created)
+    return TmuxSessionGeneration(id, created)
 }
 
 internal fun sessionCardsTargetKey(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCache.kt
@@ -18,8 +18,9 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Process-scoped cache of warm tmux/UI runtimes keyed by host identity and
- * tmux session name.
+ * Process-scoped cache of warm tmux/UI runtimes keyed by host identity and the
+ * exact tmux session generation when one is known. Picker prewarms may still
+ * carry a name-only key until the live row supplies the generation.
  *
  * A cached runtime keeps the already-attached tmux control client and
  * TerminalSurfaceState graph alive while another same-host session is in the
@@ -203,15 +204,23 @@ public class TmuxSessionRuntimeCache @Inject constructor() {
             null
         }
 
-    internal fun removeSession(hostId: Long, sessionName: String): List<CachedTmuxRuntime> =
+    /** Remove only cached runtimes belonging to this exact tmux generation. */
+    internal fun removeSession(
+        hostId: Long,
+        generation: TmuxSessionGeneration,
+    ): List<CachedTmuxRuntime> =
         synchronized(this) {
-            val trimmed = sessionName.trim()
-            if (trimmed.isEmpty()) return@synchronized emptyList()
             val removed = mutableListOf<CachedTmuxRuntime>()
             val iterator = runtimes.entries.iterator()
             while (iterator.hasNext()) {
                 val entry = iterator.next()
-                if (entry.key.hostId == hostId && entry.key.sessionName == trimmed) {
+                if (entry.key.hostId == hostId &&
+                    entry.key.durableSessionKey == durableTmuxSessionKey(
+                        hostId,
+                        generation.sessionId,
+                        generation.createdEpochSeconds,
+                    )
+                ) {
                     iterator.remove()
                     removed += entry.value.runtime
                 }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -6720,7 +6720,11 @@ public class TmuxSessionViewModel @Inject constructor(
         // folder?" instead of a blank drop-to-list.
         sessionLifecycleSignals?.emitStaleSession(
             hostId = target.hostId,
-            sessionName = target.sessionName,
+            generation = tmuxSessionGenerationOrNull(
+                target.tmuxSessionId,
+                target.sessionCreated,
+            ),
+            lastKnownName = target.sessionName,
             folderPath = target.startDirectory,
         )
         _sessionEnded.tryEmit(target.sessionName)
@@ -16224,11 +16228,25 @@ public class TmuxSessionViewModel @Inject constructor(
                 if (windowId != null) {
                     sessionLifecycleSignals?.emitWindowClosed(current.hostId, windowId)
                 } else {
-                    sessionLifecycleSignals?.emitKilled(current.hostId, target)
+                    sessionLifecycleSignals?.emitKilled(
+                        hostId = current.hostId,
+                        generation = tmuxSessionGenerationOrNull(
+                            current.tmuxSessionId,
+                            current.sessionCreated,
+                        ),
+                        lastKnownName = target,
+                    )
                 }
             } else {
                 sendLifecycleCommand("kill-session -t '${escapeSingleQuoted(TmuxTarget.session(target))}'")
-                sessionLifecycleSignals?.emitKilled(current.hostId, target)
+                sessionLifecycleSignals?.emitKilled(
+                    hostId = current.hostId,
+                    generation = tmuxSessionGenerationOrNull(
+                        current.tmuxSessionId,
+                        current.sessionCreated,
+                    ),
+                    lastKnownName = target,
+                )
             }
             return
         }
@@ -16274,7 +16292,14 @@ public class TmuxSessionViewModel @Inject constructor(
                                 "stop-window-signal host=${current.hostId} name=$target " +
                                     "window=$windowIndex session-destroyed",
                             )
-                            sessionLifecycleSignals?.emitKilled(current.hostId, target)
+                            sessionLifecycleSignals?.emitKilled(
+                                hostId = current.hostId,
+                                generation = tmuxSessionGenerationOrNull(
+                                    current.tmuxSessionId,
+                                    current.sessionCreated,
+                                ),
+                                lastKnownName = target,
+                            )
                         }
                     },
                     onFailure = { error ->
@@ -16301,7 +16326,14 @@ public class TmuxSessionViewModel @Inject constructor(
                         ISSUE_464_KILL_TAG,
                         "stop-session-signal host=${current.hostId} name=$target",
                     )
-                    sessionLifecycleSignals?.emitKilled(current.hostId, target)
+                    sessionLifecycleSignals?.emitKilled(
+                        hostId = current.hostId,
+                        generation = tmuxSessionGenerationOrNull(
+                            current.tmuxSessionId,
+                            current.sessionCreated,
+                        ),
+                        lastKnownName = target,
+                    )
                 },
                 onFailure = { error ->
                     Log.w(

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
@@ -11,6 +11,8 @@ import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.tmux.TmuxRead
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
@@ -109,8 +111,17 @@ class FolderListGatewaySshLeaseTest {
         // command strings the gateway sends rather than a fragile substring.
         val hasOldQuoted = ReposRemoteSource.pathAwareCommand("tmux has-session -t '=old'\\''s'")
         val hasNewQuoted = ReposRemoteSource.pathAwareCommand("tmux has-session -t '=new name'")
+        val inspectOldQuoted = ReposRemoteSource.pathAwareCommand(
+            "${TmuxRead.CLIENT} display-message -p -t '=old'\\''s:' '#{session_id} #{session_created}'",
+        )
+        val inspectNewQuoted = ReposRemoteSource.pathAwareCommand(
+            "${TmuxRead.CLIENT} display-message -p -t '=new name:' '#{session_id} #{session_created}'",
+        )
         val session = FakeSshSession { command ->
             when (command) {
+                inspectOldQuoted,
+                inspectNewQuoted,
+                -> ExecResult(stdout = "\$7 1700000007\n", stderr = "", exitCode = 0)
                 hasOldQuoted ->
                     ExecResult(stdout = "", stderr = "", exitCode = 1)
                 hasNewQuoted ->
@@ -135,17 +146,61 @@ class FolderListGatewaySshLeaseTest {
             passphrase = null,
             oldName = "old's",
             newName = "new name",
+            expectedGeneration = TmuxSessionGeneration("\$7", 1700000007L),
         )
 
         assertTrue(result.isSuccess)
         assertEquals(
             listOf(
-                // Issue #1820: the `-t` LOOKUPS are exact (`=`); the NEW name is
-                // created, not resolved, so it stays bare.
-                "tmux rename-session -t '=old'\\''s' 'new name'",
+                // The old name is checked against the captured generation, then
+                // the rename targets the stable tmux session id. The NEW name
+                // is created, not resolved, so it stays bare.
+                "${TmuxRead.CLIENT} display-message -p -t '=old'\\''s:' '#{session_id} #{session_created}'",
+                "tmux rename-session -t '\$7' 'new name'",
                 "tmux has-session -t '=old'\\''s'",
-                "tmux has-session -t '=new name'",
+                "${TmuxRead.CLIENT} display-message -p -t '=new name:' '#{session_id} #{session_created}'",
             ).map { ReposRemoteSource.pathAwareCommand(it) },
+            session.execCommands,
+        )
+    }
+
+    @Test
+    fun renameSessionRefusesSameNameSuccessorBeforeIssuingRename() = runTest {
+        val inspectOld = ReposRemoteSource.pathAwareCommand(
+            "${TmuxRead.CLIENT} display-message -p -t '=work:' '#{session_id} #{session_created}'",
+        )
+        val session = FakeSshSession { command ->
+            if (command == inspectOld) {
+                // The live row is a successor. The delayed rename still carries
+                // the predecessor generation captured by the ViewModel.
+                ExecResult(stdout = "\$8 1700000008\n", stderr = "", exitCode = 0)
+            } else {
+                ExecResult(stdout = "", stderr = "", exitCode = 0)
+            }
+        }
+        val gateway = SshFolderListGateway(
+            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+            activeTmuxClients = ActiveTmuxClients(),
+            sshLeaseManager = SshLeaseManager(
+                connector = CountingConnector(session),
+                scope = this,
+                idleTtlMillis = 30_000L,
+            ),
+        )
+
+        val result = gateway.renameSession(
+            host = HOST,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            oldName = "work",
+            newName = "renamed",
+            expectedGeneration = TmuxSessionGeneration("\$7", 1700000007L),
+        )
+
+        assertTrue("a same-name successor must reject the delayed rename", result.isFailure)
+        assertEquals(
+            "generation mismatch must stop before tmux rename-session can touch the successor",
+            listOf(inspectOld),
             session.execCommands,
         )
     }

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelCreateSessionTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
@@ -669,6 +670,7 @@ class FolderListViewModelCreateSessionTest {
             passphrase: CharArray?,
             oldName: String,
             newName: String,
+            expectedGeneration: TmuxSessionGeneration,
         ): Result<Unit> = error("not used")
     }
 

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelKillSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelKillSessionTest.kt
@@ -6,6 +6,7 @@ import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.tmux.KilledSession
 import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
@@ -16,8 +17,10 @@ import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.uikit.model.SessionAgentKind
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -79,7 +82,7 @@ class FolderListViewModelKillSessionTest {
             runCurrent()
 
             // Kill confirmed on the per-session screen for the bound host.
-            signals.emitKilled(HOST.id, "beta")
+            signals.emitKilled(HOST.id, generation("beta"), "beta")
             runCurrent()
 
             assertTrue(
@@ -114,7 +117,7 @@ class FolderListViewModelKillSessionTest {
 
             // A kill of a same-named session on a DIFFERENT host must not
             // touch this host's tree.
-            signals.emitKilled(HOST.id + 1, "beta")
+            signals.emitKilled(HOST.id + 1, generation("beta"), "beta")
             runCurrent()
 
             assertEquals(
@@ -145,7 +148,7 @@ class FolderListViewModelKillSessionTest {
 
             // Remote no longer reports beta -> kill agreed -> row gone.
             gateway.rows = listOf(sessionRow("alpha"))
-            signals.emitKilled(HOST.id, "beta")
+            signals.emitKilled(HOST.id, generation("beta"), "beta")
             runCurrent()
             assertEquals(setOf("alpha"), readySessionNames(vm))
 
@@ -153,10 +156,152 @@ class FolderListViewModelKillSessionTest {
             // -> re-probe reconciles it back so a live row is never lost.
             gateway.rows = listOf(sessionRow("alpha"), sessionRow("gamma"))
             runCurrent()
-            signals.emitKilled(HOST.id, "gamma")
+            signals.emitKilled(HOST.id, generation("gamma"), "gamma")
             runCurrent()
             assertEquals(setOf("alpha", "gamma"), readySessionNames(vm))
         } finally {
+            vm.stopPolling()
+        }
+    }
+
+    @Test
+    fun delayedPredecessorKillDoesNotDeleteSameNameSuccessorThroughViewModel() = runTest {
+        val signals = SessionLifecycleSignals()
+        val predecessor = TmuxSessionGeneration("predecessor-id", 1_710_000_000L)
+        val successor = TmuxSessionGeneration("successor-id", 1_720_000_000L)
+        val gateway = StubGateway(
+            listOf(
+                sessionRow(
+                    name = "work",
+                    generation = predecessor,
+                    agentKind = SessionAgentKind.Claude,
+                    recordedProfile = "Claude (old)",
+                ),
+            ),
+        )
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            vm.stopPolling()
+            runCurrent()
+
+            // The authoritative production reconcile observes a same-name
+            // recreation with a different exact generation. The successor is
+            // intentionally left with its own state so a name-keyed kill can
+            // only pass by deleting the actual successor row below.
+            gateway.rows = listOf(
+                sessionRow(
+                    name = "work",
+                    generation = successor,
+                    agentKind = SessionAgentKind.Codex,
+                    recordedProfile = "Codex (new)",
+                ),
+            )
+            vm.refreshSessions()
+            runCurrent()
+            vm.stopPolling()
+            runCurrent()
+
+            signals.emitKilled(HOST.id, predecessor, "work")
+            runCurrent()
+
+            val rows = (vm.state.value as FolderListUiState.Ready).flatSessions
+                .filter { it.sessionName == "work" }
+            assertEquals(
+                "same-name successor must survive delayed predecessor kill through the production ViewModel",
+                1,
+                rows.size,
+            )
+            val held = rows.single()
+            assertEquals(successor.sessionId, held.tmuxSessionId)
+            assertEquals(successor.createdEpochSeconds, held.sessionCreated)
+            assertEquals(SessionAgentKind.Codex, held.agentKind)
+            assertEquals("Codex (new)", held.recordedProfile)
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    @Test
+    fun treeKillCarriesGenerationCapturedBeforeSameNameRecreationCanReconcile() = runTest {
+        val signals = SessionLifecycleSignals()
+        val killed = mutableListOf<KilledSession>()
+        val collector = launchKilledCollector(signals, killed)
+        val predecessor = TmuxSessionGeneration("predecessor-id", 1_710_000_000L)
+        val successor = TmuxSessionGeneration("successor-id", 1_720_000_000L)
+        val gateway = StubGateway(
+            listOf(
+                sessionRow(
+                    name = "work",
+                    generation = predecessor,
+                    agentKind = SessionAgentKind.Claude,
+                    recordedProfile = "Claude (old)",
+                ),
+            ),
+        )
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            vm.stopPolling()
+            runCurrent()
+
+            val successorReconciled = CompletableDeferred<Unit>()
+            val allowKillReturn = CompletableDeferred<Unit>()
+            gateway.onSessionsListed = {
+                if (gateway.rows.singleOrNull()?.tmuxSessionId == successor.sessionId) {
+                    successorReconciled.complete(Unit)
+                }
+            }
+            gateway.afterSuccessfulKill = {
+                gateway.rows = listOf(
+                    sessionRow(
+                        name = "work",
+                        generation = successor,
+                        agentKind = SessionAgentKind.Codex,
+                        recordedProfile = "Codex (new)",
+                    ),
+                )
+                vm.refreshSessions()
+                // Hold the gateway result open until the authoritative probe
+                // has installed the same-name successor in the production
+                // tree. This makes a post-async name lookup observably stale.
+                successorReconciled.await()
+                allowKillReturn.await()
+            }
+            vm.killSession("work")
+            runCurrent()
+
+            assertTrue(
+                "successor must be reconciled before the gateway kill returns",
+                successorReconciled.isCompleted,
+            )
+            assertTrue(
+                "kill event must remain pending while the gateway result is held",
+                killed.isEmpty(),
+            )
+            val reconciledRows = (vm.state.value as FolderListUiState.Ready).flatSessions
+                .filter { it.sessionName == "work" }
+            assertEquals(1, reconciledRows.size)
+            assertEquals(successor.sessionId, reconciledRows.single().tmuxSessionId)
+            assertEquals(successor.createdEpochSeconds, reconciledRows.single().sessionCreated)
+
+            allowKillReturn.complete(Unit)
+            runCurrent()
+            val event = killed.single { it.hostId == HOST.id && it.sessionName == "work" }
+            assertEquals(
+                "tree Stop must retain the generation selected before the async gateway result",
+                predecessor,
+                event.generation,
+            )
+            val rows = (vm.state.value as FolderListUiState.Ready).flatSessions
+                .filter { it.sessionName == "work" }
+            assertEquals(1, rows.size)
+            assertEquals(successor.sessionId, rows.single().tmuxSessionId)
+            assertEquals(successor.createdEpochSeconds, rows.single().sessionCreated)
+        } finally {
+            collector.cancel()
             vm.stopPolling()
         }
     }
@@ -317,6 +462,51 @@ class FolderListViewModelKillSessionTest {
         }
     }
 
+    @Test
+    fun delayedPredecessorRenameCarriesGenerationAndCannotRenameSuccessor() = runTest {
+        val signals = SessionLifecycleSignals()
+        val predecessor = TmuxSessionGeneration("predecessor-id", 1_710_000_000L)
+        val successor = TmuxSessionGeneration("successor-id", 1_720_000_000L)
+        val renameGate = CompletableDeferred<Unit>()
+        val gateway = StubGateway(
+            rows = listOf(sessionRow(name = "work", generation = predecessor)),
+        ).also { it.renameGate = renameGate }
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+            vm.stopPolling()
+            runCurrent()
+
+            vm.renameSession("work", "renamed")
+            runCurrent()
+            assertEquals(listOf(predecessor), gateway.renamedGenerations)
+
+            // The gateway is still suspended. A fresh reconcile replaces the
+            // row with a same-name successor before the old rename returns.
+            gateway.rows = listOf(sessionRow(name = "work", generation = successor))
+            vm.refreshSessions()
+            runCurrent()
+            val reconciled = (vm.state.value as FolderListUiState.Ready).flatSessions.single()
+            assertEquals(successor.sessionId, reconciled.tmuxSessionId)
+            assertEquals(successor.createdEpochSeconds, reconciled.sessionCreated)
+
+            renameGate.complete(Unit)
+            runCurrent()
+
+            assertEquals(
+                "a generation-aware gateway must reject the predecessor after recreation",
+                setOf("work"),
+                readySessionNames(vm),
+            )
+            val held = (vm.state.value as FolderListUiState.Ready).flatSessions.single()
+            assertEquals(successor.sessionId, held.tmuxSessionId)
+            assertEquals(successor.createdEpochSeconds, held.sessionCreated)
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
     private fun TestScope.launchKilledCollector(
         signals: SessionLifecycleSignals,
         sink: MutableList<KilledSession>,
@@ -341,13 +531,25 @@ class FolderListViewModelKillSessionTest {
         return state.flatSessions.map { it.sessionName }.toSet()
     }
 
-    private fun sessionRow(name: String): FolderSessionRow =
+    private fun sessionRow(
+        name: String,
+        generation: TmuxSessionGeneration = generation(name),
+        agentKind: SessionAgentKind = SessionAgentKind.Shell,
+        recordedProfile: String? = null,
+    ): FolderSessionRow =
         FolderSessionRow(
             sessionName = name,
             lastActivity = 1_000L,
             attached = false,
             cwd = "/home/alexey/git/$name",
+            agentKind = agentKind,
+            recordedProfile = recordedProfile,
+            tmuxSessionId = generation.sessionId,
+            sessionCreated = generation.createdEpochSeconds,
         )
+
+    private fun generation(name: String): TmuxSessionGeneration =
+        TmuxSessionGeneration(sessionId = "id-$name", createdEpochSeconds = name.length.toLong() + 1L)
 
     private fun TestScope.newViewModel(
         gateway: FolderListGateway,
@@ -395,13 +597,24 @@ class FolderListViewModelKillSessionTest {
         var killedSessionNames: MutableList<String> = mutableListOf()
         @Volatile
         var renamedSessionNames: MutableList<Pair<String, String>> = mutableListOf()
+        @Volatile
+        var renamedGenerations: MutableList<TmuxSessionGeneration> = mutableListOf()
+        @Volatile
+        var renameGate: CompletableDeferred<Unit>? = null
+        @Volatile
+        var afterSuccessfulKill: (suspend () -> Unit)? = null
+        @Volatile
+        var onSessionsListed: (() -> Unit)? = null
 
         override suspend fun listSessionsWithFolder(
             host: HostEntity,
             keyPath: String,
             passphrase: CharArray?,
             watchedRoots: List<ProjectRootEntity>,
-        ): FolderListResult = FolderListResult.Sessions(rows = rows)
+        ): FolderListResult {
+            onSessionsListed?.invoke()
+            return FolderListResult.Sessions(rows = rows)
+        }
 
         override suspend fun createSession(
             host: HostEntity,
@@ -440,6 +653,7 @@ class FolderListViewModelKillSessionTest {
             }
             killedSessionNames.add(sessionName)
             rows = rows.filterNot { it.sessionName == sessionName }
+            afterSuccessfulKill?.invoke()
             return Result.success(Unit)
         }
 
@@ -449,9 +663,22 @@ class FolderListViewModelKillSessionTest {
             passphrase: CharArray?,
             oldName: String,
             newName: String,
+            expectedGeneration: TmuxSessionGeneration,
         ): Result<Unit> {
+            renamedGenerations.add(expectedGeneration)
+            renameGate?.await()
             if (!renameSucceeds) {
                 return Result.failure(RuntimeException("rename failed"))
+            }
+            val current = rows.singleOrNull { it.sessionName == oldName }
+                ?.let { row ->
+                    TmuxSessionGeneration(
+                        sessionId = requireNotNull(row.tmuxSessionId),
+                        createdEpochSeconds = requireNotNull(row.sessionCreated),
+                    )
+                }
+            if (current != expectedGeneration) {
+                return Result.failure(RuntimeException("session generation changed"))
             }
             renamedSessionNames.add(oldName to newName)
             rows = rows.map { row ->

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelStaleSessionTest.kt
@@ -5,12 +5,14 @@ import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.uikit.model.SessionAgentKind
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +24,8 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -82,7 +86,7 @@ class FolderListViewModelStaleSessionTest {
             // The session was confirmed genuinely gone on attach. The USER-FACING
             // recovery prompt is owned app-level (StaleSessionPromptController);
             // the tree just keeps its list accurate by dropping the dead row.
-            signals.emitStaleSession(HOST.id, "git-pocketshell", goneFolder)
+            signals.emitStaleSession(HOST.id, generation("git-pocketshell"), "git-pocketshell", goneFolder)
             runCurrent()
 
             assertTrue(
@@ -109,7 +113,12 @@ class FolderListViewModelStaleSessionTest {
             bind(vm)
             runCurrent()
 
-            signals.emitStaleSession(HOST.id + 1, "git-pocketshell", goneFolder)
+            signals.emitStaleSession(
+                HOST.id + 1,
+                generation("git-pocketshell"),
+                "git-pocketshell",
+                goneFolder,
+            )
             runCurrent()
 
             assertTrue(
@@ -137,11 +146,80 @@ class FolderListViewModelStaleSessionTest {
             // The COMMON case: the user removed the session THROUGH the app — the
             // tree drops the row immediately (external removal is the gone-on-open
             // case the app-level recovery prompt covers).
-            signals.emitKilled(HOST.id, "git-pocketshell")
+            signals.emitKilled(HOST.id, generation("git-pocketshell"), "git-pocketshell")
             runCurrent()
 
             assertTrue("app-created removal drops the row", "git-pocketshell" !in readySessionNames(vm))
             assertTrue("the sibling row survives", "beta" in readySessionNames(vm))
+        } finally {
+            vm.stopPolling()
+        }
+    }
+
+    @Test
+    fun uncertainPredecessorReconcilesWithoutHidingProbingSuccessor() = runTest {
+        val signals = SessionLifecycleSignals()
+        val predecessor = TmuxSessionGeneration("predecessor-id", 1_710_000_000L)
+        val successor = TmuxSessionGeneration("successor-id", 1_720_000_000L)
+        val gateway = StubGateway(
+            listOf(
+                sessionRow(
+                    name = "work",
+                    generation = predecessor,
+                    agentKind = SessionAgentKind.Claude,
+                    recordedProfile = "Claude (old)",
+                ),
+            ),
+        )
+        val vm = newViewModel(gateway = gateway, signals = signals)
+        try {
+            bind(vm)
+            runCurrent()
+
+            // Reconcile through the production ViewModel first. A different
+            // generation starts with no predecessor state, even when its
+            // detector is still Probing and its profile is blank.
+            gateway.rows = listOf(
+                sessionRow(
+                    name = "work",
+                    generation = successor,
+                    agentKind = SessionAgentKind.Probing,
+                    recordedProfile = null,
+                ),
+            )
+            vm.refreshSessions()
+            runCurrent()
+            val beforeUncertain = readySession(vm)
+            assertEquals(successor.sessionId, beforeUncertain.tmuxSessionId)
+            assertEquals(successor.createdEpochSeconds, beforeUncertain.sessionCreated)
+            assertEquals(SessionAgentKind.Probing, beforeUncertain.agentKind)
+            assertNull(beforeUncertain.recordedProfile)
+
+            val probesBefore = gateway.probeCount
+            // A name-only lifecycle identity is uncertain. The production
+            // consumer must request an authoritative reconcile; it must not
+            // remove or hide the exact successor directly.
+            signals.emitKilled(
+                hostId = HOST.id,
+                generation = null,
+                lastKnownName = "work",
+            )
+            runCurrent()
+
+            assertEquals(
+                "identity-uncertain predecessor must trigger one authoritative production reconcile",
+                probesBefore + 1,
+                gateway.probeCount,
+            )
+            val afterUncertain = readySession(vm)
+            assertEquals(
+                "the Probing successor must remain visible after an uncertain predecessor event",
+                successor.sessionId,
+                afterUncertain.tmuxSessionId,
+            )
+            assertEquals(successor.createdEpochSeconds, afterUncertain.sessionCreated)
+            assertEquals(SessionAgentKind.Probing, afterUncertain.agentKind)
+            assertNull(afterUncertain.recordedProfile)
         } finally {
             vm.stopPolling()
         }
@@ -166,13 +244,28 @@ class FolderListViewModelStaleSessionTest {
         return state.flatSessions.map { it.sessionName }.toSet()
     }
 
-    private fun sessionRow(name: String): FolderSessionRow =
+    private fun readySession(vm: FolderListViewModel): FolderSessionEntry =
+        (vm.state.value as FolderListUiState.Ready).flatSessions.single { it.sessionName == "work" }
+
+    private fun sessionRow(
+        name: String,
+        generation: TmuxSessionGeneration = generation(name),
+        agentKind: SessionAgentKind = SessionAgentKind.Shell,
+        recordedProfile: String? = null,
+    ): FolderSessionRow =
         FolderSessionRow(
             sessionName = name,
             lastActivity = 1_000L,
             attached = false,
             cwd = "/home/alexey/git/$name",
+            agentKind = agentKind,
+            recordedProfile = recordedProfile,
+            tmuxSessionId = generation.sessionId,
+            sessionCreated = generation.createdEpochSeconds,
         )
+
+    private fun generation(name: String): TmuxSessionGeneration =
+        TmuxSessionGeneration(sessionId = "id-$name", createdEpochSeconds = name.length.toLong() + 1L)
 
     private fun TestScope.newViewModel(
         gateway: FolderListGateway,
@@ -208,13 +301,17 @@ class FolderListViewModelStaleSessionTest {
         @Volatile var rows: List<FolderSessionRow>,
     ) : FolderListGateway {
         val createdSessions: MutableList<Pair<String, String>> = mutableListOf()
+        var probeCount: Int = 0
 
         override suspend fun listSessionsWithFolder(
             host: HostEntity,
             keyPath: String,
             passphrase: CharArray?,
             watchedRoots: List<ProjectRootEntity>,
-        ): FolderListResult = FolderListResult.Sessions(rows = rows)
+        ): FolderListResult {
+            probeCount += 1
+            return FolderListResult.Sessions(rows = rows)
+        }
 
         override suspend fun createSession(
             host: HostEntity,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelTreeDurabilityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelTreeDurabilityTest.kt
@@ -138,7 +138,7 @@ class FolderListViewModelTreeDurabilityTest {
     // ---- refresh reconciles gone/added as DELTAS only ----------------------
 
     @Test
-    fun resumeReconcilePrunesGoneSessionAsDelta() = runTest {
+    fun resumeReconcilePrunesGoneSessionAfterAuthoritativeProbe() = runTest {
         val daemon = FakeTreeDaemon()
         // Seed the daemon registry as if a prior session persisted two sessions.
         daemon.seed(
@@ -157,11 +157,11 @@ class FolderListViewModelTreeDurabilityTest {
         assertEquals(listOf("beta", "alpha"), readySessions(vm))
 
         // `alpha` is killed out-of-band: the daemon's live enumeration now omits
-        // it. A resume-when-stale should reconcile this as a DELTA (prune alpha)
-        // WITHOUT a full gateway reload — the gateway is told to fail loudly if
-        // it is probed, proving the delta path was used.
+        // it. A name-only gone hint is escalated to the authoritative gateway
+        // probe so a same-name successor cannot be pruned by the hint.
         daemon.setLive(HOST.name, setOf("beta"))
-        gateway.rows = null // a full re-probe would now blow up
+        val gatewayProbesBeforeResume = gateway.probeCount
+        gateway.rows = listOf(sessionRow("beta"))
 
         // Drive a resume past the freshen window.
         vm.forceTreeStaleForTest()
@@ -171,9 +171,14 @@ class FolderListViewModelTreeDurabilityTest {
         awaitReady(vm)
 
         assertEquals(
-            "the gone session is pruned via the delta path, no full reload",
+            "the authoritative probe result prunes the gone alpha session",
             listOf("beta"),
             readySessions(vm),
+        )
+        assertEquals(
+            "a name-only gone hint must trigger an authoritative gateway probe",
+            gatewayProbesBeforeResume + 1,
+            gateway.probeCount,
         )
     }
 
@@ -463,13 +468,16 @@ class FolderListViewModelTreeDurabilityTest {
     private class StubGateway(
         @Volatile var rows: List<FolderSessionRow>?,
     ) : FolderListGateway {
+        @Volatile var probeCount: Int = 0
+
         override suspend fun listSessionsWithFolder(
             host: HostEntity,
             keyPath: String,
             passphrase: CharArray?,
             watchedRoots: List<ProjectRootEntity>,
         ): FolderListResult {
-            val r = rows ?: error("gateway probe must not be called on the delta path")
+            probeCount += 1
+            val r = rows ?: error("gateway probe result was not configured")
             return FolderListResult.Sessions(rows = r)
         }
 

--- a/app/src/test/java/com/pocketshell/app/projects/HostTreeModelHydrateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostTreeModelHydrateTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.uikit.model.SessionAgentKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -27,12 +28,14 @@ class HostTreeModelHydrateTest {
         folder: String = "/home/alexey/git/$name",
         collapsed: Boolean = false,
         foreign: SessionAgentKind? = null,
+        generation: TmuxSessionGeneration? = null,
     ) = HostTreeModel.HydratedNode(
         sessionName = name,
         order = order,
         folderPath = FolderListViewModel.canonicalisePath(folder),
         collapsed = collapsed,
         foreignGuess = foreign,
+        generation = generation,
     )
 
     private fun probe(names: List<String>) = HostTreeModel.ProbeSnapshot(
@@ -131,9 +134,10 @@ class HostTreeModelHydrateTest {
     fun exportRoundTripsOrderFolderAndCollapseButNotConfirmedKind() {
         val tree = HostTreeModel()
         tree.bindHost(1L)
+        val betaGeneration = TmuxSessionGeneration("\$7", 1_700_000_007L)
         tree.hydrate(
             listOf(
-                node("beta", order = 0),
+                node("beta", order = 0, generation = betaGeneration),
                 node("alpha", order = 1, collapsed = true),
             ),
         )
@@ -143,6 +147,7 @@ class HostTreeModelHydrateTest {
         assertEquals(listOf(0, 1), exported.map { it.order })
         val alpha = exported.first { it.sessionName == "alpha" }
         assertTrue("the user's collapse choice round-trips", alpha.collapsed)
+        assertEquals(betaGeneration, exported.first { it.sessionName == "beta" }.generation)
     }
 
     @Test
@@ -183,8 +188,15 @@ class HostTreeModelHydrateTest {
     fun applyReconcileGoneDeltaPrunesInPlace() {
         val tree = HostTreeModel()
         tree.bindHost(1L)
-        tree.hydrate(listOf(node("keep", order = 0), node("drop", order = 1)))
-        val pruned = tree.applyReconcileGoneDelta(listOf("drop"))
+        val keepGeneration = TmuxSessionGeneration("\$keep", 1L)
+        val dropGeneration = TmuxSessionGeneration("\$drop", 2L)
+        tree.hydrate(
+            listOf(
+                node("keep", order = 0, generation = keepGeneration),
+                node("drop", order = 1, generation = dropGeneration),
+            ),
+        )
+        val pruned = tree.applyReconcileGoneDelta(listOf(dropGeneration))
         assertTrue(pruned)
         assertEquals(listOf("keep"), tree.sessionEntries().map { it.sessionName })
     }
@@ -195,17 +207,20 @@ class HostTreeModelHydrateTest {
         tree.bindHost(1L)
         // A freshly app-inserted session (optimistic marker set now) must be
         // spared from a gone-delta that has not yet observed it.
+        val freshGeneration = TmuxSessionGeneration("\$fresh", 3L)
         tree.insertSession(
             FolderSessionEntry(
                 sessionName = "fresh",
                 lastActivity = 1L,
                 attached = false,
                 agentKind = SessionAgentKind.Shell,
+                tmuxSessionId = freshGeneration.sessionId,
+                sessionCreated = freshGeneration.createdEpochSeconds,
             ),
             folderPath = "/home/alexey/git/fresh",
             now = 1_000L,
         )
-        val pruned = tree.applyReconcileGoneDelta(listOf("fresh"), now = 1_005L)
+        val pruned = tree.applyReconcileGoneDelta(listOf(freshGeneration), now = 1_005L)
         assertFalse("a node within optimistic grace is spared", pruned)
         assertEquals(listOf("fresh"), tree.sessionEntries().map { it.sessionName })
     }

--- a/app/src/test/java/com/pocketshell/app/projects/HostTreeModelProjectionOffMainTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostTreeModelProjectionOffMainTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.storage.entity.ProjectRootEntity
 import com.pocketshell.uikit.model.SessionAgentKind
 import org.junit.Assert.assertEquals
@@ -58,6 +59,8 @@ class HostTreeModelProjectionOffMainTest {
                 attached = i == 0,
                 agentKind = agentKinds[i % agentKinds.size],
                 windows = emptyList(),
+                tmuxSessionId = "id-$i",
+                sessionCreated = i.toLong() + 1L,
             )
         }
         val folderPaths = sessionEntries.associate { it.sessionName to projectPath(it.sessionName.substringAfter('-').toInt()) }
@@ -166,7 +169,7 @@ class HostTreeModelProjectionOffMainTest {
         val snapshot = tree.snapshotForProjection()
         val sizeBefore = snapshot.orderedSessions.size
         // Mutate the model AFTER taking the snapshot.
-        tree.removeSession("session-0")
+        tree.removeSession(TmuxSessionGeneration("id-0", 1L))
         // The snapshot is a copy — the heavy build over it still sees the
         // pre-mutation set, so an off-Main build can never observe a half-mutated
         // model.

--- a/app/src/test/java/com/pocketshell/app/projects/HostTreeModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/HostTreeModelTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import com.pocketshell.core.storage.entity.ProjectRootEntity
 import com.pocketshell.uikit.model.SessionAgentKind
 import org.junit.Assert.assertEquals
@@ -140,7 +141,7 @@ class HostTreeModelTest {
     }
 
     @Test
-    fun reconcileUpdatesDurableTmuxIdentityForSameNameSession() {
+    fun reconcileReplacesSameNameSessionWhenGenerationChanges() {
         val tree = HostTreeModel()
         tree.bindHost(1L)
         tree.reconcile(
@@ -150,6 +151,9 @@ class HostTreeModelTest {
                         "alpha",
                         tmuxSessionId = "\$0",
                         sessionCreated = 100L,
+                        agentKind = SessionAgentKind.Claude,
+                        recordedProfile = "Claude (old)",
+                        windows = listOf(window(0, "@old")),
                     ),
                 ),
             ),
@@ -163,6 +167,9 @@ class HostTreeModelTest {
                         "alpha",
                         tmuxSessionId = "\$1",
                         sessionCreated = 200L,
+                        agentKind = SessionAgentKind.Codex,
+                        recordedProfile = "Codex (new)",
+                        windows = listOf(window(1, "@new")),
                     ),
                 ),
             ),
@@ -173,6 +180,91 @@ class HostTreeModelTest {
         assertEquals("alpha", alpha.sessionName)
         assertEquals("\$1", alpha.tmuxSessionId)
         assertEquals(200L, alpha.sessionCreated)
+        assertEquals(SessionAgentKind.Codex, alpha.agentKind)
+        assertEquals("Codex (new)", alpha.recordedProfile)
+        assertEquals(listOf("@new"), alpha.windows.map { it.windowId })
+    }
+
+    @Test
+    fun degradedSameNameProbeCannotReplaceExactGeneration() {
+        val tree = HostTreeModel()
+        tree.bindHost(1L)
+        val generation = TmuxSessionGeneration("\$4", 1_710_000_000L)
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session(
+                        "work",
+                        tmuxSessionId = generation.sessionId,
+                        sessionCreated = generation.createdEpochSeconds,
+                        agentKind = SessionAgentKind.Claude,
+                        recordedProfile = "Claude (old)",
+                    ),
+                ),
+            ),
+            now = 100L,
+        )
+
+        // A degraded probe carries the name but no generation. It may not
+        // authorize deletion or state transfer from the exact held node.
+        tree.reconcile(
+            snapshot(listOf(session("work", agentKind = SessionAgentKind.Probing))),
+            now = 200L,
+        )
+
+        val held = tree.sessionEntries().single()
+        assertEquals(generation.sessionId, held.tmuxSessionId)
+        assertEquals(generation.createdEpochSeconds, held.sessionCreated)
+        assertEquals(SessionAgentKind.Claude, held.agentKind)
+        assertEquals("Claude (old)", held.recordedProfile)
+    }
+
+    @Test
+    fun delayedNameOnlyKillCannotRemoveSameNameSuccessorGeneration() {
+        val tree = HostTreeModel()
+        tree.bindHost(1L)
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session(
+                        "work",
+                        tmuxSessionId = "\$4",
+                        sessionCreated = 1_710_000_000L,
+                        agentKind = SessionAgentKind.Claude,
+                        recordedProfile = "Claude (old)",
+                    ),
+                ),
+            ),
+            now = 100L,
+        )
+
+        val oldGeneration = TmuxSessionGeneration("\$4", 1_710_000_000L)
+        val successorGeneration = TmuxSessionGeneration("\$9", 1_720_000_000L)
+
+        // The old lifecycle event is delayed until after the authoritative probe
+        // has already observed the same-name successor. The exact-generation
+        // mutation must now be an idempotent no-op for the old generation.
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session(
+                        "work",
+                        tmuxSessionId = "\$9",
+                        sessionCreated = 1_720_000_000L,
+                        agentKind = SessionAgentKind.Codex,
+                        recordedProfile = "Codex (new)",
+                    ),
+                ),
+            ),
+            now = 200L,
+        )
+
+        assertFalse(tree.removeSession(oldGeneration))
+        val successor = tree.sessionEntries().singleOrNull()
+        assertEquals(successorGeneration.sessionId, successor?.tmuxSessionId)
+        assertEquals(successorGeneration.createdEpochSeconds, successor?.sessionCreated)
+        assertEquals(SessionAgentKind.Codex, successor?.agentKind)
+        assertEquals("Codex (new)", successor?.recordedProfile)
     }
 
     // --- Sticky agent-ness (#716) ----------------------------------------
@@ -606,10 +698,23 @@ class HostTreeModelTest {
     fun removeSessionDropsRowImmediatelyById() {
         val tree = HostTreeModel()
         tree.bindHost(1L)
-        tree.reconcile(snapshot(listOf(session("alpha"), session("beta"))), now = 100L)
-        assertTrue(tree.removeSession("beta"))
+        val alphaGeneration = TmuxSessionGeneration("\$alpha", 1L)
+        val betaGeneration = TmuxSessionGeneration("\$beta", 2L)
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session("alpha", tmuxSessionId = alphaGeneration.sessionId, sessionCreated = alphaGeneration.createdEpochSeconds),
+                    session("beta", tmuxSessionId = betaGeneration.sessionId, sessionCreated = betaGeneration.createdEpochSeconds),
+                ),
+            ),
+            now = 100L,
+        )
+        assertTrue(tree.removeSession(betaGeneration))
         assertEquals(listOf("alpha"), tree.sessionEntries().map { it.sessionName })
-        assertFalse("removing an unknown session is a no-op", tree.removeSession("ghost"))
+        assertFalse(
+            "removing an unknown generation is a no-op",
+            tree.removeSession(TmuxSessionGeneration("\$ghost", 3L)),
+        )
     }
 
     @Test
@@ -749,9 +854,107 @@ class HostTreeModelTest {
     fun renameSessionPreservesSlot() {
         val tree = HostTreeModel()
         tree.bindHost(1L)
-        tree.reconcile(snapshot(listOf(session("a"), session("b"), session("c"))), now = 100L)
-        assertTrue(tree.renameSession("b", "b2"))
+        val generation = TmuxSessionGeneration("\$2", 1_710_000_002L)
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session("a"),
+                    session(
+                        name = "b",
+                        tmuxSessionId = generation.sessionId,
+                        sessionCreated = generation.createdEpochSeconds,
+                    ),
+                    session("c"),
+                ),
+            ),
+            now = 100L,
+        )
+        assertTrue(tree.renameSession(generation, "b2"))
         assertEquals(listOf("a", "b2", "c"), tree.sessionEntries().map { it.sessionName })
+    }
+
+    @Test
+    fun renameExactGenerationRekeysNameIndexesAndExportWithoutChangingState() {
+        val tree = HostTreeModel()
+        tree.bindHost(1L)
+        val generation = TmuxSessionGeneration("$" + "4", 1_710_000_000L)
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session(
+                        name = "old-name",
+                        tmuxSessionId = generation.sessionId,
+                        sessionCreated = generation.createdEpochSeconds,
+                        agentKind = SessionAgentKind.Claude,
+                        recordedProfile = "Claude (old)",
+                        windows = listOf(window(0, "@old")),
+                    ),
+                ),
+            ),
+            now = 100L,
+        )
+
+        assertTrue(tree.renameSession(generation, "new-name"))
+
+        val row = tree.sessionEntries().single()
+        assertEquals("new-name", row.sessionName)
+        assertEquals(generation.sessionId, row.tmuxSessionId)
+        assertEquals(generation.createdEpochSeconds, row.sessionCreated)
+        assertEquals(SessionAgentKind.Claude, row.agentKind)
+        assertEquals("Claude (old)", row.recordedProfile)
+        assertEquals(listOf("@old"), row.windows.map { it.windowId })
+        assertEquals(generation, tree.generationForSession("new-name"))
+        assertNull(tree.generationForSession("old-name"))
+
+        val projection = tree.snapshotForProjection()
+        assertTrue("new-name" in projection.sessionFolderPaths)
+        assertFalse("old-name" in projection.sessionFolderPaths)
+        assertEquals("/home/alexey/git/old-name", projection.sessionFolderPaths["new-name"])
+
+        val exported = tree.exportNodes().single()
+        assertEquals("new-name", exported.sessionName)
+        assertEquals(generation, exported.generation)
+    }
+
+    @Test
+    fun delayedPredecessorRenameCannotRenameSameNameSuccessor() {
+        val tree = HostTreeModel()
+        tree.bindHost(1L)
+        val predecessor = TmuxSessionGeneration("\$5", 1_710_000_005L)
+        val successor = TmuxSessionGeneration("\$6", 1_720_000_006L)
+
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session(
+                        name = "work",
+                        tmuxSessionId = predecessor.sessionId,
+                        sessionCreated = predecessor.createdEpochSeconds,
+                    ),
+                ),
+            ),
+            now = 100L,
+        )
+
+        // The async rename captured predecessor before the remote operation.
+        // Reconcile installs a same-name successor while that operation is in
+        // flight; the old generation must no longer authorize a local rename.
+        tree.reconcile(
+            snapshot(
+                listOf(
+                    session(
+                        name = "work",
+                        tmuxSessionId = successor.sessionId,
+                        sessionCreated = successor.createdEpochSeconds,
+                    ),
+                ),
+            ),
+            now = 200L,
+        )
+
+        assertFalse(tree.renameSession(predecessor, "renamed"))
+        assertEquals("work", tree.sessionEntries().single().sessionName)
+        assertEquals(successor, tree.generationForSession("work"))
     }
 
     // --- Intrinsic expansion (#471) --------------------------------------

--- a/app/src/test/java/com/pocketshell/app/projects/TreeRemoteSourceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/TreeRemoteSourceTest.kt
@@ -72,6 +72,30 @@ class TreeRemoteSourceTest {
     }
 
     @Test
+    fun getTreeCarriesExactTmuxGeneration() = runTest {
+        val json = JSONObject()
+            .put(
+                "nodes",
+                org.json.JSONArray().put(
+                    node(
+                        "work",
+                        order = 0,
+                        folder = "/p/work",
+                        collapsed = false,
+                        tmuxSessionId = "\$9",
+                        sessionCreated = 1_720_000_000L,
+                    ),
+                ),
+            )
+            .toString()
+
+        val result = source.getTree(treeSession(getStdout = json), host = "h")
+
+        assertEquals("\$9", result.nodes.single().tmuxSessionId)
+        assertEquals(1_720_000_000L, result.nodes.single().sessionCreated)
+    }
+
+    @Test
     fun getTree_emptyRegistryYieldsEmptyList() = runTest {
         val session = treeSession(getStdout = """{"nodes":[],"version":0,"cli_version":"0.4.12"}""")
         val result = source.getTree(session, host = "h")
@@ -114,7 +138,15 @@ class TreeRemoteSourceTest {
             host = "hetzner",
             nodes = listOf(
                 TreeRemoteSource.TreeNode("a", order = 0, folderPath = "/p/a", collapsed = true),
-                TreeRemoteSource.TreeNode("b", order = 1, folderPath = "/p/b", collapsed = false, foreignKind = "claude"),
+                TreeRemoteSource.TreeNode(
+                    "b",
+                    order = 1,
+                    folderPath = "/p/b",
+                    collapsed = false,
+                    foreignKind = "claude",
+                    tmuxSessionId = "\$4",
+                    sessionCreated = 1_710_000_000L,
+                ),
             ),
         )
 
@@ -126,6 +158,8 @@ class TreeRemoteSourceTest {
         assertTrue(sent, sent.contains("\"session\":\"a\""))
         assertTrue(sent, sent.contains("\"collapsed\":true"))
         assertTrue(sent, sent.contains("\"foreign_kind\":\"claude\""))
+        assertTrue(sent, sent.contains("\"tmux_session_id\":\"\$4\""))
+        assertTrue(sent, sent.contains("\"session_created\":1710000000"))
         assertFalse("must not write a confirmed kind copy", sent.contains("\"kind\""))
     }
 
@@ -234,12 +268,18 @@ class TreeRemoteSourceTest {
         folder: String,
         collapsed: Boolean,
         foreign: String? = null,
+        tmuxSessionId: String? = null,
+        sessionCreated: Long? = null,
     ): JSONObject = JSONObject()
         .put("session", name)
         .put("order", order)
         .put("folder_path", folder)
         .put("collapsed", collapsed)
-        .apply { if (foreign != null) put("foreign_kind", foreign) }
+        .apply {
+            if (foreign != null) put("foreign_kind", foreign)
+            if (tmuxSessionId != null) put("tmux_session_id", tmuxSessionId)
+            if (sessionCreated != null) put("session_created", sessionCreated)
+        }
 
     private fun treeSession(
         getStdout: String = "",

--- a/app/src/test/java/com/pocketshell/app/session/LastSessionStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/session/LastSessionStoreTest.kt
@@ -6,6 +6,7 @@ import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.resolveLastSessionForStop
 import com.pocketshell.app.tmux.TmuxConnectTrigger
 import com.pocketshell.app.tmux.TmuxRestoreIntentSnapshot
+import com.pocketshell.app.tmux.TmuxSessionGeneration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -53,6 +54,9 @@ class LastSessionStoreTest {
         composerDraft = draft,
         savedAtMillis = savedAtMillis,
     )
+
+    private val predecessor = TmuxSessionGeneration("\$3", 1_700_000_003L)
+    private val successor = TmuxSessionGeneration("\$4", 1_700_000_004L)
 
     @Test
     fun `read on cold store returns null`() {
@@ -346,9 +350,19 @@ class LastSessionStoreTest {
         // Repro of #834: the killed agent session is the persisted "last
         // active". On d63b6a63 nothing cleared it, so a restore re-opened it.
         val store = LastSessionStore(context)
-        store.save(sample(savedAtMillis = 1_000L)) // sessionName = "claude-main", hostId = 7
+        store.save(
+            sample(
+                savedAtMillis = 1_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        )
 
-        store.onSessionKilled(hostId = 7L, sessionName = "claude-main")
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
 
         // Read from a fresh instance to prove the clear reached disk.
         assertNull(
@@ -361,9 +375,19 @@ class LastSessionStoreTest {
     fun `onSessionKilled does NOT clear a record for a different session`() {
         // Guard: killing session A never invalidates a stored session B.
         val store = LastSessionStore(context)
-        store.save(sample(savedAtMillis = 1_000L)) // "claude-main"
+        store.save(
+            sample(
+                savedAtMillis = 1_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        )
 
-        store.onSessionKilled(hostId = 7L, sessionName = "codex-side")
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = successor,
+            lastKnownName = "claude-main",
+        )
 
         val read = LastSessionStore(context).read(nowMillis = 2_000L)
         assertNotNull("an unrelated stored session must remain restorable", read)
@@ -372,12 +396,22 @@ class LastSessionStoreTest {
 
     @Test
     fun `onSessionKilled does NOT clear a same-name session on a different host`() {
-        // Identity is (hostId, sessionName): a same-named session on host 99
-        // must not be invalidated by a kill on host 7.
+        // The exact generation is host-scoped: the same generation payload on
+        // another host must not invalidate host 7's record.
         val store = LastSessionStore(context)
-        store.save(sample(savedAtMillis = 1_000L)) // host 7, "claude-main"
+        store.save(
+            sample(
+                savedAtMillis = 1_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        )
 
-        store.onSessionKilled(hostId = 99L, sessionName = "claude-main")
+        store.onSessionKilled(
+            hostId = 99L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
 
         val read = LastSessionStore(context).read(nowMillis = 2_000L)
         assertNotNull("a same-name session on another host must remain", read)
@@ -391,9 +425,19 @@ class LastSessionStoreTest {
         // re-`save()` the dead session and re-arm the restore. The tombstone
         // makes that save a no-op (clears instead).
         val store = LastSessionStore(context)
-        store.onSessionKilled(hostId = 7L, sessionName = "claude-main")
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
 
-        store.save(sample(savedAtMillis = 5_000L)) // same identity as the kill
+        store.save(
+            sample(
+                savedAtMillis = 5_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        )
 
         assertNull(
             "a save for the just-killed session must not persist a restore target",
@@ -406,9 +450,19 @@ class LastSessionStoreTest {
         // Guard: the tombstone only suppresses the exact killed identity;
         // opening + saving a DIFFERENT session still arms a normal restore.
         val store = LastSessionStore(context)
-        store.onSessionKilled(hostId = 7L, sessionName = "claude-main")
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
 
-        store.save(sample(savedAtMillis = 5_000L).copyWith(sessionName = "codex"))
+        store.save(
+            sample(
+                savedAtMillis = 5_000L,
+                tmuxSessionId = successor.sessionId,
+                sessionCreated = successor.createdEpochSeconds,
+            ).copyWith(sessionName = "codex"),
+        )
 
         val read = LastSessionStore(context).read(nowMillis = 6_000L)
         assertNotNull("a different session must still be restorable after a kill", read)
@@ -416,14 +470,24 @@ class LastSessionStoreTest {
     }
 
     @Test
-    fun `onSessionKilled with a blank session name is a no-op`() {
+    fun `onSessionKilled uses the exact generation even when the display name is blank`() {
         val store = LastSessionStore(context)
-        store.save(sample(savedAtMillis = 1_000L))
+        store.save(
+            sample(
+                savedAtMillis = 1_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        )
 
-        store.onSessionKilled(hostId = 7L, sessionName = "   ")
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "   ",
+        )
 
-        assertNotNull(
-            "a blank kill name must not clear an unrelated stored session",
+        assertNull(
+            "the display name must never replace the exact generation as identity",
             LastSessionStore(context).read(nowMillis = 2_000L),
         )
     }
@@ -437,14 +501,24 @@ class LastSessionStoreTest {
         val store = LastSessionStore(context)
 
         // 1. Delete the original same-identity session.
-        store.onSessionKilled(hostId = 7L, sessionName = "claude-main")
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
 
         // 2. The user recreates + OPENS a new session of that identity
         //    (navigator routes to the TmuxSession destination → onSessionOpened).
-        store.onSessionOpened(hostId = 7L, sessionName = "claude-main")
+        store.onSessionOpened(hostId = 7L, generation = successor)
 
         // 3. Background → onStop saves the now-live recreated session.
-        store.save(sample(savedAtMillis = 5_000L)) // host 7, "claude-main"
+        store.save(
+            sample(
+                savedAtMillis = 5_000L,
+                tmuxSessionId = successor.sessionId,
+                sessionCreated = successor.createdEpochSeconds,
+            ),
+        ) // host 7, "claude-main"
 
         // 4. Next foreground must restore it — the tombstone is gone.
         val read = LastSessionStore(context).read(nowMillis = 6_000L)
@@ -463,12 +537,22 @@ class LastSessionStoreTest {
         // identity. Opening session B must not un-suppress a just-killed
         // session A, so A still cannot re-arm a restore.
         val store = LastSessionStore(context)
-        store.onSessionKilled(hostId = 7L, sessionName = "claude-main")
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
 
-        store.onSessionOpened(hostId = 7L, sessionName = "codex-side")
+        store.onSessionOpened(hostId = 7L, generation = successor)
 
         // A's tombstone survives, so a save of A is still suppressed.
-        store.save(sample(savedAtMillis = 5_000L)) // host 7, "claude-main"
+        store.save(
+            sample(
+                savedAtMillis = 5_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        ) // host 7, "claude-main"
         assertNull(
             "killing A then opening B must not let A re-arm a restore",
             LastSessionStore(context).read(nowMillis = 6_000L),
@@ -478,10 +562,16 @@ class LastSessionStoreTest {
     @Test
     fun `opening a session with no tombstone is a harmless no-op`() {
         val store = LastSessionStore(context)
-        store.save(sample(savedAtMillis = 1_000L))
+        store.save(
+            sample(
+                savedAtMillis = 1_000L,
+                tmuxSessionId = successor.sessionId,
+                sessionCreated = successor.createdEpochSeconds,
+            ),
+        )
 
         // No kill happened; opening must not disturb the stored record.
-        store.onSessionOpened(hostId = 7L, sessionName = "claude-main")
+        store.onSessionOpened(hostId = 7L, generation = successor)
 
         val read = LastSessionStore(context).read(nowMillis = 2_000L)
         assertNotNull(read)
@@ -544,10 +634,58 @@ class LastSessionStoreTest {
     @Test
     fun `peek returns null after the stored session is killed`() {
         val store = LastSessionStore(context)
-        store.save(sample(savedAtMillis = 1_000L))
-        store.onSessionKilled(hostId = 7L, sessionName = "claude-main")
+        store.save(
+            sample(
+                savedAtMillis = 1_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        )
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
 
         assertNull(LastSessionStore(context).peek(nowMillis = 2_000L))
+    }
+
+    @Test
+    fun `delayed predecessor kill cannot clear same-name successor restore`() {
+        val store = LastSessionStore(context)
+        store.save(
+            sample(
+                savedAtMillis = 1_000L,
+                tmuxSessionId = predecessor.sessionId,
+                sessionCreated = predecessor.createdEpochSeconds,
+            ),
+        )
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
+
+        // The name is reused by a distinct tmux generation before a delayed
+        // predecessor event is delivered. The successor is the restore target.
+        store.save(
+            sample(
+                savedAtMillis = 2_000L,
+                tmuxSessionId = successor.sessionId,
+                sessionCreated = successor.createdEpochSeconds,
+            ),
+        )
+        store.onSessionKilled(
+            hostId = 7L,
+            generation = predecessor,
+            lastKnownName = "claude-main",
+        )
+        store.onSessionOpened(hostId = 7L, generation = predecessor)
+
+        val restored = LastSessionStore(context).read(nowMillis = 3_000L)
+        assertNotNull("a delayed predecessor event must not clear the successor", restored)
+        assertEquals(successor.sessionId, restored!!.tmuxSessionId)
+        assertEquals(successor.createdEpochSeconds, restored.sessionCreated)
     }
 
     private fun LastSessionStore.LastSession.copyWith(

--- a/app/src/test/java/com/pocketshell/app/tmux/AgentSessionMemoryTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/AgentSessionMemoryTest.kt
@@ -97,20 +97,51 @@ class AgentSessionMemoryTest {
     }
 
     @Test
-    fun forgetSessionClearsEveryRememberedWindowForKilledSessionName() {
+    fun forgetSessionClearsOnlyTheKilledGeneration() {
         val memory = AgentSessionMemory()
-        memory.remember(7L, "work", "@2", claude(), wasOnConversation = true)
-        memory.remember(7L, "work", "@3", claude(), wasOnConversation = false)
+        val oldKey = "tmux:7:\$0:100"
+        val successorKey = "tmux:7:\$1:200"
+        memory.remember(
+            7L,
+            "work",
+            "@2",
+            claude(),
+            wasOnConversation = true,
+            durableSessionKey = oldKey,
+        )
+        memory.remember(
+            7L,
+            "work",
+            "@3",
+            claude(),
+            wasOnConversation = false,
+            durableSessionKey = oldKey,
+        )
+        memory.remember(
+            7L,
+            "work",
+            "@2",
+            claude(),
+            wasOnConversation = false,
+            durableSessionKey = successorKey,
+        )
         memory.remember(7L, "deploy", "@2", claude(), wasOnConversation = true)
         memory.remember(8L, "work", "@2", claude(), wasOnConversation = true)
 
-        memory.forgetSession(hostId = 7L, sessionName = "work")
+        memory.forgetSession(
+            hostId = 7L,
+            generation = TmuxSessionGeneration("\$0", 100L),
+        )
 
         assertNull(
-            "a same-name successor must not recall window memory from the killed session",
-            memory.recall(7L, "work", "@2"),
+            "the killed generation's first window must be forgotten",
+            memory.recall(7L, "work", "@2", durableSessionKey = oldKey),
         )
-        assertNull(memory.recall(7L, "work", "@3"))
+        assertNull(memory.recall(7L, "work", "@3", durableSessionKey = oldKey))
+        assertEquals(
+            claude(),
+            memory.recall(7L, "work", "@2", durableSessionKey = successorKey)?.detection,
+        )
         assertEquals(claude(), memory.recall(7L, "deploy", "@2")?.detection)
         assertEquals(claude(), memory.recall(8L, "work", "@2")?.detection)
     }

--- a/app/src/test/java/com/pocketshell/app/tmux/SessionLifecycleSignalsGenerationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/SessionLifecycleSignalsGenerationTest.kt
@@ -1,0 +1,50 @@
+package com.pocketshell.app.tmux
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionLifecycleSignalsGenerationTest {
+
+    @Test
+    fun incompleteKillIdentityEmitsReconcileHintInsteadOfDestructiveEvent() = runTest {
+        val signals = SessionLifecycleSignals()
+        val hint = async { signals.identityUncertain.first() }
+        runCurrent()
+
+        signals.emitKilled(
+            hostId = 7L,
+            generation = null,
+            lastKnownName = "work",
+        )
+
+        assertEquals(
+            SessionIdentityUncertain(
+                hostId = 7L,
+                lastKnownName = "work",
+                folderPath = null,
+                action = SessionLifecycleAction.Kill,
+            ),
+            hint.await(),
+        )
+    }
+
+    @Test
+    fun exactKillEventCarriesTheGeneration() = runTest {
+        val signals = SessionLifecycleSignals()
+        val generation = TmuxSessionGeneration("\$4", 1_710_000_000L)
+        val killed = async { signals.killedSessions.first() }
+        runCurrent()
+
+        signals.emitKilled(
+            hostId = 7L,
+            generation = generation,
+            lastKnownName = "work",
+        )
+
+        assertEquals(generation, killed.await().generation)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/StaleSessionPromptControllerTest.kt
@@ -79,7 +79,12 @@ class StaleSessionPromptControllerTest {
         assertNull("no prompt before the gone-session broadcast", controller.prompt.value)
 
         // The cold-restore attach confirmed the session is genuinely gone.
-        signals.emitStaleSession(hostId = 7L, sessionName = "work", folderPath = goneFolder)
+        signals.emitStaleSession(
+            hostId = 7L,
+            generation = generation("work"),
+            lastKnownName = "work",
+            folderPath = goneFolder,
+        )
         runCurrent()
 
         val prompt = controller.prompt.value
@@ -103,7 +108,12 @@ class StaleSessionPromptControllerTest {
         val controller = StaleSessionPromptController(signals)
         runCurrent()
 
-        signals.emitStaleSession(hostId = 3L, sessionName = "beta", folderPath = "/srv/beta")
+        signals.emitStaleSession(
+            hostId = 3L,
+            generation = generation("beta"),
+            lastKnownName = "beta",
+            folderPath = "/srv/beta",
+        )
         runCurrent()
 
         assertEquals("beta", controller.prompt.value?.sessionName)
@@ -121,7 +131,12 @@ class StaleSessionPromptControllerTest {
         val controller = StaleSessionPromptController(signals)
         runCurrent()
 
-        signals.emitStaleSession(hostId = 9L, sessionName = "orphan", folderPath = null)
+        signals.emitStaleSession(
+            hostId = 9L,
+            generation = generation("orphan"),
+            lastKnownName = "orphan",
+            folderPath = null,
+        )
         runCurrent()
 
         val prompt = controller.prompt.value
@@ -145,7 +160,11 @@ class StaleSessionPromptControllerTest {
 
         // A transient reconnect emits a KILL or nothing on this bus, never a
         // stale-session; assert the controller does not fabricate a prompt.
-        signals.emitKilled(hostId = 7L, sessionName = "work")
+        signals.emitKilled(
+            hostId = 7L,
+            generation = generation("work"),
+            lastKnownName = "work",
+        )
         runCurrent()
 
         assertNull("only a genuinely-gone broadcast may surface the prompt", controller.prompt.value)
@@ -158,7 +177,12 @@ class StaleSessionPromptControllerTest {
         val controller = StaleSessionPromptController(signals)
         runCurrent()
 
-        signals.emitStaleSession(hostId = 7L, sessionName = "work", folderPath = goneFolder)
+        signals.emitStaleSession(
+            hostId = 7L,
+            generation = generation("work"),
+            lastKnownName = "work",
+            folderPath = goneFolder,
+        )
         runCurrent()
         assertNotNull(controller.prompt.value)
 
@@ -277,6 +301,9 @@ class StaleSessionPromptControllerTest {
 
     private fun host(id: Long): HostEntity =
         HostEntity(id = id, name = "h", hostname = "example", username = "u", keyId = 1L)
+
+    private fun generation(name: String): TmuxSessionGeneration =
+        TmuxSessionGeneration(sessionId = "id-$name", createdEpochSeconds = name.length.toLong() + 1L)
 
     private class FakeHostDao(private val host: HostEntity) : HostDao {
         override fun getAll(): Flow<List<HostEntity>> = flowOf(listOf(host))

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionGatewayActionsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionGatewayActionsTest.kt
@@ -134,6 +134,8 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
             user = "alex",
             keyPath = "/keys/a",
             sessionName = "doomed",
+            tmuxSessionId = "\$4",
+            sessionCreated = 1_710_000_000L,
             client = client,
         )
         runCurrent()
@@ -158,16 +160,26 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
     }
 
     @Test
-    fun confirmedKillEvictsKilledSessionFromNameKeyedCaches() = runTest(scheduler) {
+    fun confirmedKillEvictsKilledGenerationFromCaches() = runTest(scheduler) {
         val runtimeCache = TmuxSessionRuntimeCache(maxEntries = 4, nowMs = { 0L })
         val agentSessionMemory = AgentSessionMemory()
         val signals = SessionLifecycleSignals(
             runtimeCache = runtimeCache,
             agentSessionMemory = agentSessionMemory,
         )
-        val doomedRuntime = cachedRuntimeForGatewayActionTest(sessionName = "doomed", hostId = 7L)
+        val doomedRuntime = cachedRuntimeForGatewayActionTest(
+            sessionName = "doomed",
+            hostId = 7L,
+            durableSessionKey = "tmux:7:\$4:1710000000",
+        )
+        val successorRuntime = cachedRuntimeForGatewayActionTest(
+            sessionName = "doomed",
+            hostId = 7L,
+            durableSessionKey = "tmux:7:\$9:1720000000",
+        )
         val otherRuntime = cachedRuntimeForGatewayActionTest(sessionName = "other", hostId = 7L)
         runtimeCache.put(doomedRuntime)
+        runtimeCache.put(successorRuntime)
         runtimeCache.put(otherRuntime)
         agentSessionMemory.remember(
             hostId = 7L,
@@ -180,6 +192,20 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
                 confidence = AgentDetection.Confidence.ProcessConfirmed,
             ),
             wasOnConversation = true,
+            durableSessionKey = "tmux:7:\$4:1710000000",
+        )
+        agentSessionMemory.remember(
+            hostId = 7L,
+            sessionName = "doomed",
+            windowId = "@2",
+            detection = AgentDetection(
+                agent = AgentKind.Codex,
+                sourcePath = "/home/alex/.codex/projects/doomed.jsonl",
+                sessionId = "successor-agent",
+                confidence = AgentDetection.Confidence.ProcessConfirmed,
+            ),
+            wasOnConversation = false,
+            durableSessionKey = "tmux:7:\$9:1720000000",
         )
         val gateway = RecordingStopGateway(killSucceeds = true)
         val vm = newVm(
@@ -197,6 +223,8 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
             user = "alex",
             keyPath = "/keys/a",
             sessionName = "doomed",
+            tmuxSessionId = "\$4",
+            sessionCreated = 1_710_000_000L,
             client = FakeTmuxClient(),
         )
         runCurrent()
@@ -215,9 +243,24 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
             runtimeCache.contains(doomedRuntime.key),
         )
         assertTrue(runtimeCache.contains(otherRuntime.key))
+        assertTrue(runtimeCache.contains(successorRuntime.key))
         assertNull(
-            "same-name successor must not recall agent memory from the killed session",
-            agentSessionMemory.recall(7L, "doomed", "@2"),
+            "the killed generation's agent memory must be forgotten",
+            agentSessionMemory.recall(
+                7L,
+                "doomed",
+                "@2",
+                durableSessionKey = "tmux:7:\$4:1710000000",
+            ),
+        )
+        assertEquals(
+            AgentKind.Codex,
+            agentSessionMemory.recall(
+                7L,
+                "doomed",
+                "@2",
+                durableSessionKey = "tmux:7:\$9:1720000000",
+            )?.detection?.agent,
         )
     }
 
@@ -510,6 +553,8 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
             user = "alex",
             keyPath = "/keys/a",
             sessionName = "solo",
+            tmuxSessionId = "\$20",
+            sessionCreated = 1_720_000_020L,
             client = client,
         )
         runCurrent()
@@ -562,6 +607,8 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
             user = "alex",
             keyPath = "/keys/a",
             sessionName = "whole",
+            tmuxSessionId = "\$21",
+            sessionCreated = 1_720_000_021L,
             client = client,
         )
         runCurrent()
@@ -588,6 +635,7 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
     private fun cachedRuntimeForGatewayActionTest(
         sessionName: String,
         hostId: Long = 1L,
+        durableSessionKey: String? = null,
         client: FakeTmuxClient = FakeTmuxClient(),
         session: SshSession = GatewayActionSshSession(),
     ): CachedTmuxRuntime {
@@ -598,6 +646,7 @@ class TmuxSessionGatewayActionsTest : TmuxSessionViewModelTestBase() {
             username = "alex",
             keyPath = "/keys/a",
             sessionName = sessionName,
+            durableSessionKey = durableSessionKey,
         )
         return CachedTmuxRuntime(
             key = key,

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionIdentityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionIdentityTest.kt
@@ -10,7 +10,7 @@ class TmuxSessionIdentityTest {
     fun durableIdentityRoundTripsForNavigationWithoutNameFallback() {
         val key = durableTmuxSessionKey(7, "\$12", 1_700_000_000)
         assertEquals(
-            DurableTmuxSessionIdentity("\$12", 1_700_000_000),
+            TmuxSessionGeneration("\$12", 1_700_000_000),
             parseDurableTmuxSessionIdentity(7, key),
         )
         assertNull(parseDurableTmuxSessionIdentity(8, key))

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCacheTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionRuntimeCacheTest.kt
@@ -44,24 +44,36 @@ class TmuxSessionRuntimeCacheTest {
     }
 
     @Test
-    fun removeSessionEvictsOnlyKilledHostAndSessionName() {
+    fun removeSessionEvictsOnlyKilledGeneration() {
         val cache = TmuxSessionRuntimeCache(maxEntries = 4, nowMs = { 0L })
-        val killed = cachedRuntime("work")
+        val killed = cachedRuntime("work", durableSessionKey = "tmux:1:\$0:100")
+        val sameNameSuccessor = cachedRuntime("work", durableSessionKey = "tmux:1:\$1:200")
         val sameNameOtherHost = cachedRuntime("work", hostId = 2L)
         val otherSession = cachedRuntime("deploy")
 
         cache.put(killed)
+        cache.put(sameNameSuccessor)
         cache.put(sameNameOtherHost)
         cache.put(otherSession)
 
-        assertEquals(listOf(killed), cache.removeSession(hostId = 1L, sessionName = "work"))
+        assertEquals(
+            listOf(killed),
+            cache.removeSession(
+                hostId = 1L,
+                generation = TmuxSessionGeneration("\$0", 100L),
+            ),
+        )
 
-        assertEquals(listOf(sameNameOtherHost.key, otherSession.key), cache.snapshotKeys())
+        assertEquals(
+            listOf(sameNameSuccessor.key, sameNameOtherHost.key, otherSession.key),
+            cache.snapshotKeys(),
+        )
         assertFalse(
             "a killed session's warm runtime must not be reusable by a same-name successor",
             cache.contains(killed.key),
         )
         assertTrue(cache.contains(sameNameOtherHost.key))
+        assertTrue(cache.contains(sameNameSuccessor.key))
         assertTrue(cache.contains(otherSession.key))
     }
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelReconnectTest.kt
@@ -141,6 +141,8 @@ class TmuxSessionViewModelReconnectTest : TmuxSessionViewModelTestBase() {
             user = "alex",
             keyPath = "/keys/a",
             sessionName = "work",
+            tmuxSessionId = "\$4",
+            sessionCreated = 1_710_000_000L,
             client = FakeTmuxClient(),
         )
 

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -519,6 +519,8 @@ class TmuxSessionWarmOpenTest {
             passphrase = null,
             sessionName = "work",
             startDirectory = "/home/alex/git/pocketshell",
+            tmuxSessionId = "\$9",
+            sessionCreated = 1_720_000_000L,
             trigger = TmuxConnectTrigger.ColdRestore,
         )
         pumpUntil(reason = "gone-session stale broadcast") { staleEvents.isNotEmpty() }
@@ -526,7 +528,14 @@ class TmuxSessionWarmOpenTest {
 
         assertEquals(
             "genuinely-gone must broadcast exactly one StaleSession for the folder tree",
-            listOf(StaleSession(hostId = 7L, sessionName = "work", folderPath = "/home/alex/git/pocketshell")),
+            listOf(
+                StaleSession(
+                    hostId = 7L,
+                    generation = TmuxSessionGeneration("\$9", 1_720_000_000L),
+                    lastKnownName = "work",
+                    folderPath = "/home/alex/git/pocketshell",
+                ),
+            ),
             staleEvents,
         )
     }
@@ -635,6 +644,8 @@ class TmuxSessionWarmOpenTest {
             passphrase = null,
             sessionName = "work",
             startDirectory = "/home/alex/git/pocketshell",
+            tmuxSessionId = "\$9",
+            sessionCreated = 1_720_000_000L,
             trigger = TmuxConnectTrigger.OpenExisting,
         )
         pumpUntil(reason = "open-existing gone-session stale broadcast") { staleEvents.isNotEmpty() }
@@ -646,7 +657,14 @@ class TmuxSessionWarmOpenTest {
         )
         assertEquals(
             "a confirmed-gone tap must broadcast exactly one StaleSession for the recreate prompt",
-            listOf(StaleSession(hostId = 7L, sessionName = "work", folderPath = "/home/alex/git/pocketshell")),
+            listOf(
+                StaleSession(
+                    hostId = 7L,
+                    generation = TmuxSessionGeneration("\$9", 1_720_000_000L),
+                    lastKnownName = "work",
+                    folderPath = "/home/alex/git/pocketshell",
+                ),
+            ),
             staleEvents,
         )
     }

--- a/scripts/issue-2239-generation-mutation.py
+++ b/scripts/issue-2239-generation-mutation.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Preserve selective red/green proofs for issue #2239.
+
+The mutations replace both load-bearing exact-generation kill decisions with
+name lookups. Each focused production-path test must then fail at its own
+selective assertion. The source is restored and both tests must pass again
+before this runner reports success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import signal
+import shutil
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt"
+TEST_SOURCE = ROOT / (
+    "app/src/test/java/com/pocketshell/app/projects/"
+    "FolderListViewModelKillSessionTest.kt"
+)
+TEST_FILTER = (
+    "com.pocketshell.app.projects.FolderListViewModelKillSessionTest."
+    "delayedPredecessorKillDoesNotDeleteSameNameSuccessorThroughViewModel"
+)
+ACTION_TEST_FILTER = (
+    "com.pocketshell.app.projects.FolderListViewModelKillSessionTest."
+    "treeKillCarriesGenerationCapturedBeforeSameNameRecreationCanReconcile"
+)
+SOURCE_ANCHOR = "        if (tree.removeSession(killed.generation)) {"
+NAME_KEYED_MUTANT = (
+    "        if (tree.generationForSession(killed.lastKnownName)?."
+    "let(tree::removeSession) == true) {"
+)
+SELECTIVE_ASSERTION = (
+    "same-name successor must survive delayed predecessor kill through the "
+    "production ViewModel"
+)
+ACTION_SOURCE_ANCHOR = "                    val generation = requestedGeneration"
+ACTION_NAME_KEYED_MUTANT = "                    val generation = tree.generationForSession(target)"
+ACTION_SELECTIVE_ASSERTION = (
+    "tree Stop must retain the generation selected before the async gateway result"
+)
+DEFAULT_ARTIFACT_DIR = ROOT / "artifacts/issue-2239-generation-mutation"
+TEST_RESULT_XML = ROOT / (
+    "app/build/test-results/testDebugUnitTest/"
+    "TEST-com.pocketshell.app.projects.FolderListViewModelKillSessionTest.xml"
+)
+RUN_TIMEOUT_SECONDS = 900
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def run_focused_test(
+    artifact_dir: Path,
+    label: str,
+    test_filter: str = TEST_FILTER,
+    *,
+    final_source_sha: str,
+    executed_source_sha: str,
+) -> int:
+    log_path = artifact_dir / f"{label}.log"
+    xml_artifact_path = artifact_dir / f"{label}.xml"
+    provenance_path = artifact_dir / f"{label}.provenance"
+    command = [
+        "./gradlew",
+        ":app:testDebugUnitTest",
+        "--tests",
+        test_filter,
+        "--no-daemon",
+        "--no-parallel",
+        "--max-workers=1",
+        "--rerun-tasks",
+        "--no-build-cache",
+        "--console=plain",
+        "--stacktrace",
+        "-Dorg.gradle.jvmargs=-Xmx2048m",
+        "-Pkotlin.daemon.jvmargs=-Xmx4096m",
+    ]
+    # Gradle leaves the previous XML in place when a run fails before the test
+    # task writes results. Remove only this known generated report so a red
+    # mutation can never inherit XML from an earlier, unrelated source.
+    TEST_RESULT_XML.unlink(missing_ok=True)
+    xml_artifact_path.unlink(missing_ok=True)
+    with log_path.open("w", encoding="utf-8") as log:
+        log.write(
+            "# final source SHA-256 (all baseline/restored reports)\n"
+            f"{final_source_sha}\n"
+            "# executed source SHA-256 for this lane\n"
+            f"{executed_source_sha}\n"
+            f"# test filter\n{test_filter}\n\n"
+            "$ " + " ".join(command) + "\n\n"
+        )
+        log.flush()
+        process = subprocess.Popen(
+            command,
+            cwd=ROOT,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            return_code = process.wait(timeout=RUN_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait()
+            log.write(f"\nTIMEOUT after {RUN_TIMEOUT_SECONDS}s\n")
+            return_code = 124
+    xml_copied = TEST_RESULT_XML.exists()
+    if xml_copied:
+        shutil.copy2(TEST_RESULT_XML, xml_artifact_path)
+    (artifact_dir / f"{label}.exit").write_text(
+        f"{return_code}\n",
+        encoding="utf-8",
+    )
+    provenance_path.write_text(
+        "final_source_sha256=" + final_source_sha + "\n"
+        "executed_source_sha256=" + executed_source_sha + "\n"
+        "test_filter=" + test_filter + "\n"
+        f"exit_code={return_code}\n"
+        f"xml_artifact={xml_artifact_path.name if xml_copied else 'absent'}\n",
+        encoding="utf-8",
+    )
+    return return_code
+
+
+def validate_sites(source_text: str, test_text: str) -> None:
+    if source_text.count(SOURCE_ANCHOR) != 1:
+        raise RuntimeError("expected exactly one live production source anchor")
+    if NAME_KEYED_MUTANT in source_text:
+        raise RuntimeError("name-keyed mutant is already present in production")
+    if test_text.count(TEST_FILTER.rsplit(".", 1)[1]) != 1:
+        raise RuntimeError("expected exactly one focused regression test")
+    if test_text.count(SELECTIVE_ASSERTION) != 1:
+        raise RuntimeError("focused test lacks its selective successor assertion")
+    if source_text.count(ACTION_SOURCE_ANCHOR) != 1:
+        raise RuntimeError("expected exactly one captured-generation source anchor")
+    if test_text.count(ACTION_TEST_FILTER.rsplit(".", 1)[1]) != 1:
+        raise RuntimeError("expected exactly one async kill regression test")
+    if test_text.count(ACTION_SELECTIVE_ASSERTION) != 1:
+        raise RuntimeError("async kill test lacks its selective generation assertion")
+
+
+def write_summary(
+    artifact_dir: Path,
+    *,
+    before_sha: str,
+    mutant_sha: str | None,
+    restored_sha: str | None,
+    baseline_exit: int | None,
+    mutant_exit: int | None,
+    restored_exit: int | None,
+    action_baseline_exit: int | None,
+    action_mutant_exit: int | None,
+    action_restored_exit: int | None,
+    action_mutant_sha: str | None,
+    run_source_hashes: dict[str, str],
+    final_source_sha: str,
+    error: str | None,
+) -> None:
+    lines = [
+        "# Issue #2239 generation-fence mutation proof",
+        "",
+        "This artifact is produced by the preserved source mutation runner.",
+        "The mutations are applied to both load-bearing FolderListViewModel kill paths.",
+        "",
+        f"- production source: `{SOURCE.relative_to(ROOT)}`",
+        f"- focused test: `{TEST_FILTER}`",
+        f"- final current source SHA-256 (baseline/restored lanes): `{final_source_sha}`",
+        f"- source SHA-256 before mutation: `{before_sha}`",
+        f"- name-keyed mutant SHA-256: `{mutant_sha}`",
+        f"- source SHA-256 after restore: `{restored_sha}`",
+        "- source SHA-256 per Gradle lane (the `.provenance` sidecar is paired with each log/XML report):",
+        *[
+            f"  - `{label}`: `{source_sha}`"
+            for label, source_sha in run_source_hashes.items()
+        ],
+        f"- baseline generation-fenced exit: `{baseline_exit}`",
+        f"- name-keyed mutant exit: `{mutant_exit}`",
+        f"- restored generation-fenced exit: `{restored_exit}`",
+        f"- selective assertion: `{SELECTIVE_ASSERTION}`",
+        "- selective red evidence: `name-keyed-mutant-red.xml` and `name-keyed-mutant-red.log`",
+        f"- async-kill focused test: `{ACTION_TEST_FILTER}`",
+        f"- async-kill baseline exit: `{action_baseline_exit}`",
+        f"- async-kill name-keyed mutant SHA-256: `{action_mutant_sha}`",
+        f"- async-kill name-keyed mutant exit: `{action_mutant_exit}`",
+        f"- async-kill restored exit: `{action_restored_exit}`",
+        f"- async-kill selective assertion: `{ACTION_SELECTIVE_ASSERTION}`",
+        "- async-kill selective red evidence: `async-name-keyed-mutant-red.xml` and `async-name-keyed-mutant-red.log`",
+        "- every lane also has a `.provenance` sidecar containing the final current source SHA-256 and the executed source SHA-256",
+        "",
+        "## Ordered verdict",
+        "",
+        "1. `BASELINE GREEN`: the exact-generation implementation passes.",
+        "2. `NAME_KEYED_MUTANT RED`: the tree removal mutant must fail the successor-preservation assertion.",
+        "3. `ASYNC_NAME_KEYED_MUTANT RED`: the post-async lookup mutant must fail the captured-generation assertion.",
+        "4. `RESTORED GENERATION-FENCED GREEN`: the original source is restored byte-for-byte and both tests pass again.",
+        "",
+        "## Mutation",
+        "",
+        f"```text\n{SOURCE_ANCHOR}\n=>\n{NAME_KEYED_MUTANT}\n```",
+        "",
+        "## Async kill mutation",
+        "",
+        f"```text\n{ACTION_SOURCE_ANCHOR}\n=>\n{ACTION_NAME_KEYED_MUTANT}\n```",
+    ]
+    if error is not None:
+        lines.extend(["", "## Runner error", "", f"`{error}`"])
+    (artifact_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=DEFAULT_ARTIFACT_DIR,
+        help="new directory for logs and the mutation verdict",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    artifact_dir: Path = args.artifact_dir.expanduser().resolve()
+    if artifact_dir.exists():
+        print(f"artifact directory already exists: {artifact_dir}", file=sys.stderr)
+        return 2
+    artifact_dir.mkdir(parents=True)
+
+    original_source = SOURCE.read_bytes()
+    before_sha = sha256_bytes(original_source)
+    mutant_sha: str | None = None
+    restored_sha: str | None = None
+    baseline_exit: int | None = None
+    mutant_exit: int | None = None
+    restored_exit: int | None = None
+    action_baseline_exit: int | None = None
+    action_mutant_exit: int | None = None
+    action_restored_exit: int | None = None
+    action_mutant_sha: str | None = None
+    run_source_hashes: dict[str, str] = {}
+    error: str | None = None
+
+    try:
+        validate_sites(
+            original_source.decode("utf-8"),
+            TEST_SOURCE.read_text(encoding="utf-8"),
+        )
+
+        if sha256_bytes(SOURCE.read_bytes()) != before_sha:
+            raise RuntimeError("production source changed before baseline run")
+        run_source_hashes["baseline-green"] = before_sha
+        baseline_exit = run_focused_test(
+            artifact_dir,
+            "baseline-green",
+            final_source_sha=before_sha,
+            executed_source_sha=before_sha,
+        )
+        if baseline_exit != 0:
+            raise RuntimeError(f"baseline focused test exited {baseline_exit}")
+
+        mutant_source = original_source.decode("utf-8").replace(
+            SOURCE_ANCHOR,
+            NAME_KEYED_MUTANT,
+            1,
+        ).encode("utf-8")
+        SOURCE.write_bytes(mutant_source)
+        mutant_sha = sha256_bytes(mutant_source)
+        run_source_hashes["name-keyed-mutant-red"] = mutant_sha
+        (artifact_dir / "mutant-source.kt").write_bytes(mutant_source)
+        mutant_exit = run_focused_test(
+            artifact_dir,
+            "name-keyed-mutant-red",
+            final_source_sha=before_sha,
+            executed_source_sha=mutant_sha,
+        )
+        mutant_log = (artifact_dir / "name-keyed-mutant-red.log").read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+        mutant_xml = ""
+        mutant_xml_path = artifact_dir / "name-keyed-mutant-red.xml"
+        if mutant_xml_path.exists():
+            mutant_xml = mutant_xml_path.read_text(encoding="utf-8", errors="replace")
+        if mutant_exit == 0:
+            raise RuntimeError("name-keyed mutant unexpectedly passed")
+        if SELECTIVE_ASSERTION not in mutant_log and SELECTIVE_ASSERTION not in mutant_xml:
+            raise RuntimeError(
+                "mutant failed without reaching the selective successor assertion"
+            )
+
+        # Restore before exercising the second independent mutation. This
+        # keeps each mutant attributable to one production decision.
+        SOURCE.write_bytes(original_source)
+        if sha256_bytes(SOURCE.read_bytes()) != before_sha:
+            raise RuntimeError("production source was not restored before async baseline")
+        run_source_hashes["async-baseline-green"] = before_sha
+        action_baseline_exit = run_focused_test(
+            artifact_dir,
+            "async-baseline-green",
+            ACTION_TEST_FILTER,
+            final_source_sha=before_sha,
+            executed_source_sha=before_sha,
+        )
+        if action_baseline_exit != 0:
+            raise RuntimeError(
+                f"async kill baseline focused test exited {action_baseline_exit}"
+            )
+
+        async_mutant_source = original_source.decode("utf-8").replace(
+            ACTION_SOURCE_ANCHOR,
+            ACTION_NAME_KEYED_MUTANT,
+            1,
+        ).encode("utf-8")
+        SOURCE.write_bytes(async_mutant_source)
+        action_mutant_sha = sha256_bytes(async_mutant_source)
+        run_source_hashes["async-name-keyed-mutant-red"] = action_mutant_sha
+        (artifact_dir / "async-name-keyed-mutant-source.kt").write_bytes(
+            async_mutant_source
+        )
+        action_mutant_exit = run_focused_test(
+            artifact_dir,
+            "async-name-keyed-mutant-red",
+            ACTION_TEST_FILTER,
+            final_source_sha=before_sha,
+            executed_source_sha=action_mutant_sha,
+        )
+        action_mutant_log = (
+            artifact_dir / "async-name-keyed-mutant-red.log"
+        ).read_text(encoding="utf-8", errors="replace")
+        action_mutant_xml = ""
+        action_mutant_xml_path = artifact_dir / "async-name-keyed-mutant-red.xml"
+        if action_mutant_xml_path.exists():
+            action_mutant_xml = action_mutant_xml_path.read_text(
+                encoding="utf-8", errors="replace"
+            )
+        if action_mutant_exit == 0:
+            raise RuntimeError("async name-keyed mutant unexpectedly passed")
+        if (
+            ACTION_SELECTIVE_ASSERTION not in action_mutant_log
+            and ACTION_SELECTIVE_ASSERTION not in action_mutant_xml
+        ):
+            raise RuntimeError(
+                "async mutant failed without reaching the selective captured-generation assertion"
+            )
+    except Exception as exc:  # noqa: BLE001 - summary must survive a red run
+        error = str(exc)
+    finally:
+        SOURCE.write_bytes(original_source)
+        restored_sha = sha256_bytes(SOURCE.read_bytes())
+
+    # Even when the mutant oracle check itself fails, run the restored source
+    # once. A mutation artifact without the final green pass is incomplete.
+    if baseline_exit == 0 and mutant_exit is not None:
+        current_restored_sha = sha256_bytes(SOURCE.read_bytes())
+        run_source_hashes["restored-green"] = current_restored_sha
+        restored_exit = run_focused_test(
+            artifact_dir,
+            "restored-green",
+            final_source_sha=before_sha,
+            executed_source_sha=current_restored_sha,
+        )
+        if restored_exit != 0:
+            error = error or f"restored focused test exited {restored_exit}"
+        elif restored_sha != before_sha:
+            error = error or "restored production source does not match the original SHA-256"
+    if action_baseline_exit == 0 and action_mutant_exit is not None:
+        current_restored_sha = sha256_bytes(SOURCE.read_bytes())
+        run_source_hashes["async-restored-green"] = current_restored_sha
+        action_restored_exit = run_focused_test(
+            artifact_dir,
+            "async-restored-green",
+            ACTION_TEST_FILTER,
+            final_source_sha=before_sha,
+            executed_source_sha=current_restored_sha,
+        )
+        if action_restored_exit != 0:
+            error = error or (
+                f"async restored focused test exited {action_restored_exit}"
+            )
+        elif restored_sha != before_sha:
+            error = error or "restored production source does not match the original SHA-256"
+
+    write_summary(
+        artifact_dir,
+        before_sha=before_sha,
+        mutant_sha=mutant_sha,
+        restored_sha=restored_sha,
+        baseline_exit=baseline_exit,
+        mutant_exit=mutant_exit,
+        restored_exit=restored_exit,
+        action_baseline_exit=action_baseline_exit,
+        action_mutant_exit=action_mutant_exit,
+        action_restored_exit=action_restored_exit,
+        action_mutant_sha=action_mutant_sha,
+        run_source_hashes=run_source_hashes,
+        final_source_sha=before_sha,
+        error=error,
+    )
+
+    if error is not None:
+        print(f"mutation proof failed: {error}", file=sys.stderr)
+        print(f"artifacts: {artifact_dir}", file=sys.stderr)
+        return 1
+    print(f"mutation proof passed: {artifact_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/issue-2239-process-restart.sh
+++ b/scripts/issue-2239-process-restart.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Issue #2239 AC9: source-matched real process-restart evidence.
+#
+# This wrapper deliberately delegates the device boundary to the repository's
+# two-phase harness. Its job is to bind that run to one exact worktree HEAD,
+# capture a complete relevant-source manifest before and after the run, and
+# reject empty or drifting provenance rather than publishing a vacuous green.
+# shellcheck disable=SC2317
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS="$ROOT_DIR/scripts/two-phase-android-instrumentation.sh"
+
+ANDROID_SDK="${ANDROID_SDK:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/home/alexey/Android/Sdk}}}"
+ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
+CACHE_BASE="${XDG_CACHE_HOME:-${HOME:?HOME is required}/.cache}"
+EVIDENCE_ROOT="${EVIDENCE_ROOT:-$CACHE_BASE/pocketshell/evidence/issue-2239-process-restart}"
+RUN_NAMESPACE="${RUN_NAMESPACE:-issue2239-process-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RUN_DIR="${RUN_DIR:-$CACHE_BASE/pocketshell/evidence/android-process-restart/$RUN_NAMESPACE}"
+META_DIR="${META_DIR:-$EVIDENCE_ROOT/$RUN_NAMESPACE}"
+SUFFIX="${SUFFIX:-i2239process}"
+BUILD_APKS="${BUILD_APKS:-1}"
+ANDROID_SERIAL="${ANDROID_SERIAL:-}"
+SOURCE_BASE_COMMIT="${SOURCE_BASE_COMMIT:-HEAD^}"
+
+HEAD_SHA=""
+BASE_SHA=""
+PARENT_SHA=""
+MERGE_BASE_SHA=""
+RUN_RC=125
+RUN_STARTED=0
+FINAL_RC=125
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/issue-2239-process-restart.sh
+
+Runs the real two-process LastSessionStore/tmux-generation proof through
+scripts/two-phase-android-instrumentation.sh and writes a source-bound bundle.
+
+Environment:
+  ANDROID_SERIAL=<serial>       required; one isolated emulator serial
+  SUFFIX=i2239process            suffixed target/test package identity
+  RUN_NAMESPACE=<token>          unique device/artifact namespace
+  RUN_DIR=<path>                 two-phase device artifact directory
+  META_DIR=<path>                source/provenance artifact directory
+  SOURCE_BASE_COMMIT=<rev>      comparison base, default HEAD^
+  BUILD_APKS=1                  build exact worktree source before install
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+[[ $# -eq 0 ]] || { usage >&2; exit 2; }
+
+[[ -x "$ADB" ]] || fail "adb is not executable: $ADB"
+[[ -x "$HARNESS" ]] || fail "two-phase harness is not executable: $HARNESS"
+[[ -n "$ANDROID_SERIAL" ]] || fail "ANDROID_SERIAL is required"
+[[ "$ANDROID_SERIAL" != "emulator-5554" ]] \
+  || fail "emulator-5554 is reserved by another issue lane"
+[[ "$BUILD_APKS" == "0" || "$BUILD_APKS" == "1" ]] \
+  || fail "BUILD_APKS must be 0 or 1"
+[[ "$RUN_NAMESPACE" =~ ^[A-Za-z0-9._-]+$ ]] \
+  || fail "RUN_NAMESPACE must match [A-Za-z0-9._-]+"
+[[ "$SUFFIX" =~ ^[A-Za-z0-9._]+$ && -n "$SUFFIX" ]] \
+  || fail "SUFFIX must match [A-Za-z0-9._]+"
+[[ "$ROOT_DIR" == "$PWD" || "$ROOT_DIR" == "$(pwd -P)" ]] \
+  || fail "run from the target worktree: expected $ROOT_DIR, got $PWD"
+[[ ! -e "$RUN_DIR" ]] || fail "RUN_DIR already exists: $RUN_DIR"
+[[ ! -e "$META_DIR" ]] || fail "META_DIR already exists: $META_DIR"
+mkdir -p "$(dirname "$RUN_DIR")" "$META_DIR"
+chmod 700 "$META_DIR"
+
+HEAD_SHA="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+BASE_SHA="$(git -C "$ROOT_DIR" rev-parse "$SOURCE_BASE_COMMIT^{commit}")"
+PARENT_SHA="$(git -C "$ROOT_DIR" rev-parse "$HEAD_SHA^")"
+MERGE_BASE_SHA="$(git -C "$ROOT_DIR" merge-base "$BASE_SHA" "$HEAD_SHA")"
+
+if [[ -n "${EXPECTED_HEAD:-}" && "$HEAD_SHA" != "$EXPECTED_HEAD" ]]; then
+  fail "HEAD changed before launch: expected $EXPECTED_HEAD, observed $HEAD_SHA"
+fi
+if [[ -n "${EXPECTED_BASE:-}" && "$BASE_SHA" != "$EXPECTED_BASE" ]]; then
+  fail "base changed before launch: expected $EXPECTED_BASE, observed $BASE_SHA"
+fi
+
+# The runner itself may be the one intentional untracked file in this
+# worktree. Every tracked product/source path must be clean; any other change
+# makes a source-matched APK claim unsafe.
+validate_worktree_status() {
+  local status_line
+  while IFS= read -r status_line; do
+    [[ -z "$status_line" ]] && continue
+    case "$status_line" in
+      "?? scripts/issue-2239-process-restart.sh") ;;
+      *)
+        printf 'unexpected worktree change: %s\n' "$status_line" >&2
+        return 1
+        ;;
+    esac
+  done < <(git -C "$ROOT_DIR" status --porcelain=v1 --untracked-files=all)
+  git -C "$ROOT_DIR" diff --quiet HEAD -- \
+    app/src shared tools/pocketshell scripts
+  git -C "$ROOT_DIR" diff --cached --quiet HEAD -- \
+    app/src shared tools/pocketshell scripts
+}
+
+validate_worktree_status \
+  || fail "tracked source is dirty or an unrelated worktree change is present"
+
+source_files() {
+  git -C "$ROOT_DIR" ls-files -- app/src shared tools/pocketshell scripts
+}
+
+hash_file_list() {
+  local list_file="$1" hashes_file="$2" rel
+  : > "$hashes_file"
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    [[ -f "$ROOT_DIR/$rel" ]] \
+      || { printf 'missing_source=%s\n' "$rel" >&2; return 1; }
+    (cd "$ROOT_DIR" && sha256sum "$rel") >> "$hashes_file"
+  done < "$list_file"
+  [[ -s "$hashes_file" ]] || { echo "source hash manifest is empty" >&2; return 1; }
+}
+
+snapshot_sources() {
+  local label="$1"
+  local list_file="$META_DIR/source-files-$label.txt"
+  local hashes_file="$META_DIR/source-hashes-$label.txt"
+  source_files > "$list_file"
+  [[ -s "$list_file" ]] || { echo "source file manifest is empty" >&2; return 1; }
+  hash_file_list "$list_file" "$hashes_file" || return 1
+  sha256sum "$hashes_file" | awk '{print $1}' > \
+    "$META_DIR/source-aggregate-$label.sha256"
+  [[ "$(wc -l < "$list_file" | tr -d ' ')" == \
+      "$(wc -l < "$hashes_file" | tr -d ' ')" ]] \
+    || { echo "source file/hash manifest count mismatch ($label)" >&2; return 1; }
+  git -C "$ROOT_DIR" rev-parse HEAD > "$META_DIR/head-$label.txt"
+  git -C "$ROOT_DIR" status --porcelain=v1 --untracked-files=all > \
+    "$META_DIR/status-$label.txt"
+  sha256sum "$ROOT_DIR/scripts/issue-2239-process-restart.sh" | \
+    awk '{print $1}' > "$META_DIR/runner-sha256-$label.txt"
+}
+
+hash_changed_sources() {
+  local rel
+  git -C "$ROOT_DIR" diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \
+    app/src shared tools/pocketshell scripts > "$META_DIR/changed-source-files.txt"
+  : > "$META_DIR/changed-source-hashes.txt"
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    [[ -f "$ROOT_DIR/$rel" ]] || {
+      printf 'missing_changed_source=%s\n' "$rel" >&2
+      return 1
+    }
+    (cd "$ROOT_DIR" && sha256sum "$rel") >> \
+      "$META_DIR/changed-source-hashes.txt"
+  done < "$META_DIR/changed-source-files.txt"
+  [[ -s "$META_DIR/changed-source-hashes.txt" ]] \
+    || { echo "changed-source hash manifest is empty" >&2; return 1; }
+}
+
+write_provenance_start() {
+  {
+    printf 'worktree=%s\n' "$ROOT_DIR"
+    printf 'head=%s\n' "$HEAD_SHA"
+    printf 'parent=%s\n' "$PARENT_SHA"
+    printf 'source_base=%s\n' "$BASE_SHA"
+    printf 'merge_base=%s\n' "$MERGE_BASE_SHA"
+    printf 'branch=%s\n' "$(git -C "$ROOT_DIR" symbolic-ref --short -q HEAD || echo DETACHED)"
+    printf 'run_namespace=%s\n' "$RUN_NAMESPACE"
+    printf 'run_dir=%s\n' "$RUN_DIR"
+    printf 'meta_dir=%s\n' "$META_DIR"
+    printf 'android_serial=%s\n' "$ANDROID_SERIAL"
+    printf 'suffix=%s\n' "$SUFFIX"
+    printf 'build_apks=%s\n' "$BUILD_APKS"
+    printf 'harness=%s\n' "$HARNESS"
+    printf 'source_scope=app/src,shared,tools/pocketshell,scripts\n'
+    printf 'source_files_before=%s\n' \
+      "$(wc -l < "$META_DIR/source-files-before.txt" | tr -d ' ')"
+    printf 'source_hashes_before=%s\n' \
+      "$META_DIR/source-hashes-before.txt"
+    printf 'source_aggregate_before=%s\n' \
+      "$(tr -d '[:space:]' < "$META_DIR/source-aggregate-before.sha256")"
+    printf 'changed_source_files=%s\n' "$META_DIR/changed-source-files.txt"
+    printf 'changed_source_hashes=%s\n' "$META_DIR/changed-source-hashes.txt"
+  } > "$META_DIR/source-provenance.txt"
+  {
+    printf 'env ANDROID_SERIAL=%q BUILD_APKS=%q SUFFIX=%q RUN_NAMESPACE=%q RUN_DIR=%q EVIDENCE_ROOT=%q %q\n' \
+      "$ANDROID_SERIAL" "$BUILD_APKS" "$SUFFIX" "$RUN_NAMESPACE" \
+      "$RUN_DIR" "$CACHE_BASE/pocketshell/evidence/android-process-restart" \
+      "$HARNESS"
+  } > "$META_DIR/runner-command.txt"
+  {
+    printf 'runner_pid=%s\n' "$$"
+    printf 'started_at=%s\n' "$(date --iso-8601=seconds)"
+    printf 'unit=%s\n' "${RUNNER_UNIT:-direct-shell}"
+    printf 'run_namespace=%s\n' "$RUN_NAMESPACE"
+    printf 'run_dir=%s\n' "$RUN_DIR"
+    printf 'serial=%s\n' "$ANDROID_SERIAL"
+    printf 'avd_name=%s\n' "$("$ADB" -s "$ANDROID_SERIAL" shell getprop ro.boot.qemu.avd_name | tr -d '\r')"
+    printf 'head=%s\n' "$HEAD_SHA"
+    printf 'parent=%s\n' "$PARENT_SHA"
+    printf 'source_base=%s\n' "$BASE_SHA"
+    printf 'source_aggregate_before=%s\n' \
+      "$(tr -d '[:space:]' < "$META_DIR/source-aggregate-before.sha256")"
+  } > "$META_DIR/runner-start.txt"
+}
+
+validate_after_snapshot() {
+  local before_aggregate after_aggregate before_head after_head
+  before_aggregate="$(tr -d '[:space:]' < "$META_DIR/source-aggregate-before.sha256")"
+  after_aggregate="$(tr -d '[:space:]' < "$META_DIR/source-aggregate-after.sha256")"
+  before_head="$(tr -d '[:space:]' < "$META_DIR/head-before.txt")"
+  after_head="$(tr -d '[:space:]' < "$META_DIR/head-after.txt")"
+  [[ "$before_aggregate" =~ ^[[:xdigit:]]{64}$ ]] || return 1
+  [[ "$after_aggregate" =~ ^[[:xdigit:]]{64}$ ]] || return 1
+  [[ "$before_head" == "$HEAD_SHA" && "$after_head" == "$HEAD_SHA" ]] || return 1
+  cmp -s "$META_DIR/source-files-before.txt" "$META_DIR/source-files-after.txt" || return 1
+  cmp -s "$META_DIR/source-hashes-before.txt" "$META_DIR/source-hashes-after.txt" || return 1
+  [[ "$before_aggregate" == "$after_aggregate" ]] || return 1
+  cmp -s "$META_DIR/runner-sha256-before.txt" "$META_DIR/runner-sha256-after.txt" || return 1
+  validate_worktree_status
+}
+
+write_runner_finish() {
+  local process_dir_exists=false summary_result=ABSENT source_stable=false head_stable=false
+  local status_stable=false before_aggregate=UNAVAILABLE after_aggregate=UNAVAILABLE
+  [[ -d "$RUN_DIR" ]] && process_dir_exists=true
+  [[ -f "$RUN_DIR/summary.txt" ]] && \
+    summary_result="$(sed -n 's/^result=//p' "$RUN_DIR/summary.txt" | head -1)"
+  if [[ -s "$META_DIR/source-aggregate-before.sha256" ]]; then
+    before_aggregate="$(tr -d '[:space:]' < "$META_DIR/source-aggregate-before.sha256")"
+  fi
+  if [[ -s "$META_DIR/source-aggregate-after.sha256" ]]; then
+    after_aggregate="$(tr -d '[:space:]' < "$META_DIR/source-aggregate-after.sha256")"
+  fi
+  if [[ "$before_aggregate" =~ ^[[:xdigit:]]{64}$ && \
+        "$before_aggregate" == "$after_aggregate" ]]; then
+    source_stable=true
+  fi
+  if [[ -s "$META_DIR/head-before.txt" && -s "$META_DIR/head-after.txt" && \
+        "$(tr -d '[:space:]' < "$META_DIR/head-before.txt")" == "$HEAD_SHA" && \
+        "$(tr -d '[:space:]' < "$META_DIR/head-after.txt")" == "$HEAD_SHA" ]]; then
+    head_stable=true
+  fi
+  if [[ -f "$META_DIR/status-before.txt" && -f "$META_DIR/status-after.txt" ]] && \
+      cmp -s "$META_DIR/status-before.txt" "$META_DIR/status-after.txt"; then
+    status_stable=true
+  fi
+  {
+    printf 'exit_code=%s\n' "$RUN_RC"
+    printf 'finished_at=%s\n' "$(date --iso-8601=seconds)"
+    printf 'runner_pid=%s\n' "$$"
+    printf 'run_namespace=%s\n' "$RUN_NAMESPACE"
+    printf 'run_dir=%s\n' "$RUN_DIR"
+    printf 'meta_dir=%s\n' "$META_DIR"
+    printf 'head=%s\nparent=%s\nsource_base=%s\nmerge_base=%s\n' \
+      "$HEAD_SHA" "$PARENT_SHA" "$BASE_SHA" "$MERGE_BASE_SHA"
+    printf 'source_aggregate_before=%s\n' "$before_aggregate"
+    printf 'source_aggregate_after=%s\n' "$after_aggregate"
+    printf 'source_hashes_stable=%s\n' "$source_stable"
+    printf 'head_stable=%s\n' "$head_stable"
+    printf 'status_stable=%s\n' "$status_stable"
+    printf 'process_run_dir_exists=%s\n' "$process_dir_exists"
+    printf 'harness_summary_result=%s\n' "$summary_result"
+  } > "$META_DIR/runner-finish.txt"
+}
+
+write_final_manifest() {
+  local verdict="$1"
+  {
+    printf 'verdict=%s\n' "$verdict"
+    printf 'classification=%s\n' \
+      "$([[ "$verdict" == PASS ]] && echo valid_source_matched_real_two_process_proof || echo invalid_or_blocked)"
+    printf 'worktree=%s\nhead=%s\nparent=%s\nsource_base=%s\nmerge_base=%s\n' \
+      "$ROOT_DIR" "$HEAD_SHA" "$PARENT_SHA" "$BASE_SHA" "$MERGE_BASE_SHA"
+    printf 'meta_dir=%s\nrun_dir=%s\n' "$META_DIR" "$RUN_DIR"
+    printf 'runner_command=%s\n' "$META_DIR/runner-command.txt"
+    printf 'runner_start=%s\nrunner_finish=%s\n' \
+      "$META_DIR/runner-start.txt" "$META_DIR/runner-finish.txt"
+    printf 'source_provenance=%s\n' "$META_DIR/source-provenance.txt"
+    printf 'source_files_before=%s\nsource_files_after=%s\n' \
+      "$META_DIR/source-files-before.txt" "$META_DIR/source-files-after.txt"
+    printf 'source_hashes_before=%s\nsource_hashes_after=%s\n' \
+      "$META_DIR/source-hashes-before.txt" "$META_DIR/source-hashes-after.txt"
+    printf 'source_aggregate_before_file=%s\nsource_aggregate_after_file=%s\n' \
+      "$META_DIR/source-aggregate-before.sha256" "$META_DIR/source-aggregate-after.sha256"
+    printf 'two_phase_summary=%s\n' "$RUN_DIR/summary.txt"
+    printf 'phase_1_artifact=%s\nphase_2_artifact=%s\nforce_stop_evidence=%s\n' \
+      "$RUN_DIR/phase-1.txt" "$RUN_DIR/phase-2.txt" "$RUN_DIR/force-stop-evidence.txt"
+    printf 'mutation_control_unchanged=true\n'
+  } > "$META_DIR/real-proof-final-manifest.txt"
+}
+
+finish() {
+  local trap_rc=$?
+  local provenance_ok=0
+  set +e
+  if [[ "$RUN_STARTED" == "1" ]]; then
+    snapshot_sources after
+  else
+    : > "$META_DIR/source-files-after.txt"
+    : > "$META_DIR/source-hashes-after.txt"
+    : > "$META_DIR/source-aggregate-after.sha256"
+    git -C "$ROOT_DIR" rev-parse HEAD > "$META_DIR/head-after.txt"
+    git -C "$ROOT_DIR" status --porcelain=v1 --untracked-files=all > \
+      "$META_DIR/status-after.txt"
+    sha256sum "$ROOT_DIR/scripts/issue-2239-process-restart.sh" | \
+      awk '{print $1}' > "$META_DIR/runner-sha256-after.txt"
+  fi
+  if [[ "$RUN_RC" == "125" && "$trap_rc" != "0" ]]; then
+    RUN_RC="$trap_rc"
+  fi
+  if [[ -s "$META_DIR/source-aggregate-before.sha256" && \
+        -s "$META_DIR/source-aggregate-after.sha256" ]]; then
+    validate_after_snapshot && provenance_ok=1
+  fi
+  write_runner_finish
+  if [[ "$RUN_RC" == "0" && "$provenance_ok" == "1" && \
+        -f "$RUN_DIR/summary.txt" && \
+        "$(sed -n 's/^result=//p' "$RUN_DIR/summary.txt" | head -1)" == "PASS" ]]; then
+    FINAL_RC=0
+    write_final_manifest PASS
+  else
+    FINAL_RC="${RUN_RC:-1}"
+    [[ "$FINAL_RC" == "0" ]] && FINAL_RC=1
+    write_final_manifest BLOCKED_OR_FAILED
+  fi
+  find "$META_DIR" -maxdepth 1 -type f ! -name SHA256SUMS -print0 \
+    | sort -z | xargs -0 sha256sum > "$META_DIR/SHA256SUMS"
+  exit "$FINAL_RC"
+}
+
+trap finish EXIT
+
+source_files > "$META_DIR/source-files-before.txt"
+hash_file_list "$META_DIR/source-files-before.txt" \
+  "$META_DIR/source-hashes-before.txt"
+sha256sum "$META_DIR/source-hashes-before.txt" | awk '{print $1}' > \
+  "$META_DIR/source-aggregate-before.sha256"
+git -C "$ROOT_DIR" rev-parse HEAD > "$META_DIR/head-before.txt"
+git -C "$ROOT_DIR" status --porcelain=v1 --untracked-files=all > \
+  "$META_DIR/status-before.txt"
+sha256sum "$ROOT_DIR/scripts/issue-2239-process-restart.sh" | \
+  awk '{print $1}' > "$META_DIR/runner-sha256-before.txt"
+hash_changed_sources
+write_provenance_start
+
+RUN_STARTED=1
+set +e
+env \
+  ANDROID_SERIAL="$ANDROID_SERIAL" \
+  BUILD_APKS="$BUILD_APKS" \
+  SUFFIX="$SUFFIX" \
+  RUN_NAMESPACE="$RUN_NAMESPACE" \
+  RUN_DIR="$RUN_DIR" \
+  EVIDENCE_ROOT="$CACHE_BASE/pocketshell/evidence/android-process-restart" \
+  "$HARNESS" > "$META_DIR/two-phase.log" 2>&1
+RUN_RC=$?
+set -e
+exit "$RUN_RC"

--- a/tools/pocketshell/src/pocketshell/tree.py
+++ b/tools/pocketshell/src/pocketshell/tree.py
@@ -11,9 +11,10 @@ state. It is a host-keyed JSON registry the `pocketshell` daemon owns, exposed
 via three JSON-RPC methods:
 
 - ``tree.get {host}`` -> ``{nodes: [...], version}`` — the persisted node list
-  (order, folder_path, collapsed, optional cached foreign-guess kind). An empty
-  result is valid (no registry yet → the client seeds fresh). Cached with a
-  short TTL (~5 s) like ``sessions.list``.
+  (order, folder_path, collapsed, optional cached foreign-guess kind, and the
+  exact tmux generation when known). An empty result is valid (no registry yet
+  → the client seeds fresh). Cached with a short TTL (~5 s) like
+  ``sessions.list``.
 - ``tree.upsert {host, nodes}`` -> ``{status, version}`` — atomically persists
   the node list. A mutation: it carries NO TTL and invalidates the ``tree.get``
   cache for that host (see :data:`pocketshell.daemon.METHOD_CACHE_INVALIDATIONS`).
@@ -191,8 +192,10 @@ def _normalise_node(raw: Any, fallback_order: int) -> Optional[dict[str, Any]]:
     A node MUST have a non-empty ``session`` string; everything else is
     optional and defaulted. ``foreign_kind`` is the cheap one-shot foreign-guess
     cache (NOT the confirmed kind — that lives in ``@ps_agent_kind``); it is
-    persisted verbatim when present and omitted otherwise. One malformed node
-    never sinks the batch — the caller filters ``None`` out.
+    persisted verbatim when present and omitted otherwise. ``tmux_session_id``
+    and positive ``session_created`` are persisted together as the exact
+    generation; an incomplete pair is treated as provisional. One malformed
+    node never sinks the batch — the caller filters ``None`` out.
     """
     if not isinstance(raw, Mapping):
         return None
@@ -217,6 +220,16 @@ def _normalise_node(raw: Any, fallback_order: int) -> Optional[dict[str, Any]]:
     foreign_kind = raw.get("foreign_kind")
     if isinstance(foreign_kind, str) and foreign_kind:
         node["foreign_kind"] = foreign_kind
+    tmux_session_id = raw.get("tmux_session_id")
+    session_created = raw.get("session_created")
+    if isinstance(tmux_session_id, str) and tmux_session_id.strip():
+        try:
+            created = int(session_created)
+        except (TypeError, ValueError):
+            created = 0
+        if created > 0:
+            node["tmux_session_id"] = tmux_session_id.strip()
+            node["session_created"] = created
     # Preserve / stamp the optimistic-grace marker so the next reconcile spares
     # a just-upserted node the live probe has not yet observed.
     optimistic_since = raw.get("optimistic_since")

--- a/tools/pocketshell/tests/test_tree.py
+++ b/tools/pocketshell/tests/test_tree.py
@@ -113,6 +113,27 @@ def test_get_returns_persisted_nodes_after_upsert(tmp_path: Path) -> None:
     assert got["nodes"][1]["collapsed"] is False
 
 
+def test_get_preserves_exact_tmux_generation(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    tree_mod.upsert_tree(
+        {
+            "host": "h1",
+            "nodes": [
+                {
+                    "session": "work",
+                    "tmux_session_id": "$9",
+                    "session_created": 1720000000,
+                },
+            ],
+        },
+        paths=paths,
+    )
+
+    node = tree_mod.get_tree({"host": "h1"}, paths=paths)["nodes"][0]
+    assert node["tmux_session_id"] == "$9"
+    assert node["session_created"] == 1720000000
+
+
 def test_get_is_host_scoped(tmp_path: Path) -> None:
     paths = _paths(tmp_path)
     tree_mod.upsert_tree(


### PR DESCRIPTION
Closes #2239

Implemented the generation-fenced stale-session/tree lifecycle fix, including durable tree/session identity handling and regression coverage.

Verification:
- Full current-base JVM gate: /home/alexey/.cache/pocketshell/evidence/issue-2239-implementer/full-jvm-current-main-20260822T131659Z-r2 — 604 tasks, 13236 testcase tags, 0 failures/errors.
- Connected generation/tree journey: /home/alexey/.cache/pocketshell/evidence/issue-2239-implementer/connected-current-main-20260822T133951Z-r1 — 5/5 tests, 0 failures/errors/skips, complete fixture/text/viewport/lifecycle evidence.
- Final integration focused JVM gate: 199 actionable tasks, all selected tests passed.
- Final integration Android-test compile: 188 actionable tasks, BUILD SUCCESSFUL.
- Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2239#issuecomment-5380827177