### PR TITLE
Fix FileViewer raw component guard drift (#2280)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -327,6 +327,7 @@ jobs:
       - name: Raw-component drift guard (issue #865)
         run: |
           chmod +x scripts/check-component-drift.sh
+          scripts/check-component-drift.sh --self-test
           scripts/check-component-drift.sh
 
       # Issue #901: design-token (radius/font-size) ladder guardrail. Sibling of

--- a/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerScreen.kt
@@ -89,6 +89,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.FileIconClass
 import com.pocketshell.uikit.components.FileTypeIcon
+import com.pocketshell.uikit.components.FormDialog
 import com.pocketshell.uikit.components.LoadingIndicator
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
@@ -630,6 +631,9 @@ internal fun FileViewerScaffold(
                 is PendingTabAction.Close -> "closing"
                 is PendingTabAction.Switch -> "switching"
             }
+            // Deliberately raw: this footer has conditional Submit and
+            // Discard actions that the shared ConfirmDialog/FormDialog
+            // contracts do not model.
             AlertDialog(
                 onDismissRequest = onStayOnTab,
                 modifier = Modifier.testTag(FILE_VIEWER_DIRTY_WORK_DIALOG_TAG),
@@ -1321,36 +1325,24 @@ private fun EmptyWorkspacePanel(
         }
     }
     if (showOpenPath) {
-        AlertDialog(
-            onDismissRequest = { showOpenPath = false },
-            title = { Text("Open path") },
-            text = {
-                OutlinedTextField(
-                    value = typedPath,
-                    onValueChange = { typedPath = it },
-                    singleLine = true,
-                    label = { Text("Remote path") },
-                    modifier = Modifier.testTag(FILE_VIEWER_EMPTY_OPEN_PATH_FIELD_TAG),
-                )
+        FormDialog(
+            title = "Open path",
+            confirmLabel = "Open",
+            onConfirm = {
+                showOpenPath = false
+                onOpenPath(typedPath)
             },
-            confirmButton = {
-                PocketShellButton(
-                    text = "Open",
-                    onClick = {
-                        showOpenPath = false
-                        onOpenPath(typedPath)
-                    },
-                    modifier = Modifier.testTag(FILE_VIEWER_EMPTY_OPEN_PATH_CONFIRM_TAG),
-                )
-            },
-            dismissButton = {
-                PocketShellButton(
-                    text = "Cancel",
-                    onClick = { showOpenPath = false },
-                    variant = ButtonVariant.Secondary,
-                )
-            },
-        )
+            onDismiss = { showOpenPath = false },
+            confirmTestTag = FILE_VIEWER_EMPTY_OPEN_PATH_CONFIRM_TAG,
+        ) {
+            OutlinedTextField(
+                value = typedPath,
+                onValueChange = { typedPath = it },
+                singleLine = true,
+                label = { Text("Remote path") },
+                modifier = Modifier.testTag(FILE_VIEWER_EMPTY_OPEN_PATH_FIELD_TAG),
+            )
+        }
     }
 }
 
@@ -1573,50 +1565,29 @@ private fun AnnotationTextDialog(
     onDismiss: () -> Unit,
 ) {
     var text by remember { mutableStateOf("") }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        containerColor = PocketShellColors.Surface,
-        title = {
-            Text(
-                text = "Add text",
-                style = PocketShellType.bodyDense,
-                fontWeight = FontWeight.SemiBold,
-                color = PocketShellColors.Text,
-            )
-        },
-        text = {
-            OutlinedTextField(
-                value = text,
-                onValueChange = { text = it },
-                singleLine = false,
-                placeholder = {
-                    Text(
-                        text = "Label…",
-                        style = PocketShellType.bodyDense,
-                        color = PocketShellColors.TextMuted,
-                    )
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag(FILE_VIEWER_ANNOTATE_TEXT_FIELD_TAG),
-            )
-        },
-        confirmButton = {
-            PocketShellButton(
-                text = "Add",
-                onClick = { onConfirm(text) },
-                variant = ButtonVariant.Primary,
-                modifier = Modifier.testTag(FILE_VIEWER_ANNOTATE_TEXT_CONFIRM_TAG),
-            )
-        },
-        dismissButton = {
-            PocketShellButton(
-                text = "Cancel",
-                onClick = onDismiss,
-                variant = ButtonVariant.Secondary,
-            )
-        },
-    )
+    FormDialog(
+        title = "Add text",
+        confirmLabel = "Add",
+        onConfirm = { onConfirm(text) },
+        onDismiss = onDismiss,
+        confirmTestTag = FILE_VIEWER_ANNOTATE_TEXT_CONFIRM_TAG,
+    ) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it },
+            singleLine = false,
+            placeholder = {
+                Text(
+                    text = "Label…",
+                    style = PocketShellType.bodyDense,
+                    color = PocketShellColors.TextMuted,
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(FILE_VIEWER_ANNOTATE_TEXT_FIELD_TAG),
+        )
+    }
 }
 
 /**

--- a/scripts/check-component-drift.sh
+++ b/scripts/check-component-drift.sh
@@ -30,6 +30,7 @@
 # Usage:
 #   scripts/check-component-drift.sh            # check against the committed baseline
 #   scripts/check-component-drift.sh --update   # rewrite the baseline to current counts
+#   scripts/check-component-drift.sh --self-test # prove raw-call mutations go red
 #
 # Exit codes:
 #   0  no NEW drift (counts <= baseline)            [also: --update succeeded]
@@ -64,6 +65,72 @@ current_counts() {
     | awk '{ printf "%s %s\n", $2, $1 }' \
     | sort
 }
+
+# Mutation-sensitive proof for the guard itself. The production FileViewer
+# source is copied into a temporary miniature tree, then each migrated form
+# dialog is changed back to a raw AlertDialog in isolation. The real guard must
+# reject both mutations; otherwise a green count check could be disconnected
+# from the source boundary it is meant to protect.
+self_test() (
+  set -euo pipefail
+
+  local sandbox clean_source scan_source mutant_file output
+  sandbox="$(mktemp -d "${TMPDIR:-/tmp}/component-drift-selftest.XXXXXX")"
+  trap 'rm -rf -- "$sandbox"' EXIT
+
+  scan_source="$sandbox/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerScreen.kt"
+  clean_source="$sandbox/clean/FileViewerScreen.kt"
+  mkdir -p "$(dirname "$scan_source")" "$(dirname "$clean_source")" "$sandbox/shared/ui-kit/src/main" "$sandbox/scripts"
+  cp "$REPO_ROOT/app/src/main/java/com/pocketshell/app/fileviewer/FileViewerScreen.kt" "$clean_source"
+  cp "$clean_source" "$scan_source"
+  cp "$BASELINE_FILE" "$sandbox/scripts/component-drift-baseline.txt"
+  cp "$SCRIPT_DIR/check-component-drift.sh" "$sandbox/scripts/check-component-drift.sh"
+  chmod +x "$sandbox/scripts/check-component-drift.sh"
+
+  if ! output="$(cd "$sandbox" && scripts/check-component-drift.sh 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    echo "FAIL: clean FileViewerScreen source is not accepted by the component-drift guard" >&2
+    exit 1
+  fi
+
+  mutate_and_require_red() {
+    local label="$1"
+    local range_start="$2"
+    local range_end="$3"
+    local mutated_call="$4"
+    mutant_file="$sandbox/$label/FileViewerScreen.kt"
+    mkdir -p "$(dirname "$mutant_file")"
+    cp "$clean_source" "$mutant_file"
+    sed -i "/$range_start/,/$range_end/ s/FormDialog(/AlertDialog(/" "$mutant_file"
+    [[ "$(grep -Fxc "$mutated_call" "$mutant_file")" == 1 ]] \
+      || { echo "FAIL: $label mutation did not apply" >&2; exit 1; }
+
+    cp "$mutant_file" "$scan_source"
+    if output="$(cd "$sandbox" && scripts/check-component-drift.sh 2>&1)"; then
+      printf '%s\n' "$output" >&2
+      echo "FAIL: $label raw-component mutation was accepted" >&2
+      exit 1
+    fi
+    grep -Fq \
+      'DRIFT  app/src/main/java/com/pocketshell/app/fileviewer/FileViewerScreen.kt: 2 raw component call-sites (baseline 1, +1 new)' \
+      <<<"$output" \
+      || { printf '%s\n' "$output" >&2; echo "FAIL: $label mutation failed for an unexpected reason" >&2; exit 1; }
+    echo "PASS: $label raw-component mutation is rejected"
+    cp "$clean_source" "$scan_source"
+  }
+
+  mutate_and_require_red \
+    open-path 'if (showOpenPath) {' 'title = "Open path",' '        AlertDialog('
+  mutate_and_require_red \
+    annotation-text 'private fun AnnotationTextDialog(' 'title = "Add text",' '    AlertDialog('
+
+  echo "PASS: clean source is accepted and both FileViewer form migrations are guarded"
+)
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test
+  exit 0
+fi
 
 if [[ "${1:-}" == "--update" ]]; then
   {

--- a/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
+++ b/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
@@ -1,5 +1,14 @@
 # Per-class (and per-core-terminal-proof) instrumentation seconds for issue #1850.
-# Provenance: GitHub Actions Tests run 31961310072 on main @ 3c7a01ef (2026-08-16).
+# Provenance: baseline rows from GitHub Actions Tests run 31961310072 on main @ 3c7a01ef (2026-08-16).
+# Issue #2281 additions: the 30 selectors that were absent from that baseline
+# were measured from GitHub Actions Tests run 32566299419 on main @
+# c4bb92f3c5f29bbafd26746751220018e669821f (2026-08-22). Values are the
+# suite's integer-second per-selector costs: JOURNEY_PASS elapsed for a
+# first-pass selector; attempt-1 manifest duration plus retry elapsed for a
+# selector recovered by the per-class retry; and both completed attempt
+# manifest durations for a selector that failed twice. No median/default cost
+# was used for these additions. The additions are grouped at the end so their
+# run provenance remains auditable.
 # Jobs: shard 0=95200324865  shard 1=95200324870  shard 2=95200324829
 #       shard 3=95200324874  shard 4=95200324832  shard 5=95200324883
 # Journey classes: JOURNEY_PASS attempt-1 elapsed, except the three
@@ -210,3 +219,35 @@ com.termux.view.TerminalSelectionViewportStabilityInstrumentedTest	46
 com.termux.view.TerminalViewForceSurfaceRepaintInstrumentedTest	7
 com.termux.view.TerminalViewPixelProbeAbandonedCopyInstrumentedTest	21
 com.termux.view.TerminalViewReattachLateSubscribeRepaintInstrumentedTest	11
+
+# Issue #2281: measured additions from run 32566299419 (see provenance above).
+com.pocketshell.app.cards.SessionNotePushJourneyDockerTest	39
+com.pocketshell.app.fileviewer.FileViewerLoadingSpinnerScreenshotTest	28
+com.pocketshell.app.fileviewer.FileViewerTabStripTest#dirtyWorkDialogStayAndDiscard	20
+com.pocketshell.app.fileviewer.FileViewerTabStripTest#emptyWorkspaceShowsBrowseAndOpenPath	16
+com.pocketshell.app.fileviewer.FileViewerTabStripTest#stripShowsUniqueSuffixLabelsAndSeparateSwitchClose	23
+com.pocketshell.app.fileviewer.FileViewerTabStripTest#twelveTabOverflowKeepsActiveFullyOnScreen	17
+com.pocketshell.app.fileviewer.FileViewerTabsJourneyDockerTest#lastCloseShowsEmptyWorkspace	23
+com.pocketshell.app.fileviewer.FileViewerTabsJourneyDockerTest#openABCLeaveAndOpenFilesRestoresThreeTabsAndActive	28
+com.pocketshell.app.fileviewer.FileViewerTabsMainActivityJourneyDockerTest#mainActivityRestartRestoresTabsGuardsDirtyBackAndConsumesSubmitAction	42
+com.pocketshell.app.git.GitHistoryScaffoldTest	63
+com.pocketshell.app.proof.Issue2178TypedEchoSurvivesReseedE2eTest	41
+com.pocketshell.app.proof.Issue2189HostAckExactlyOnceAcrossFlapE2eTest	24
+com.pocketshell.app.proof.Issue2189HostAckSendHealJourneyE2eTest	66
+com.pocketshell.app.proof.Issue2189HostAckSubmitJourneyE2eTest	114
+com.pocketshell.app.proof.Issue2192ComposerLauncherAfterReconnectE2eTest	48
+com.pocketshell.app.proof.TmuxKeyBarCtrlComboE2eTest#hotkeysTwoPageFlowSendsExactShellAndAgentControlBytes	69
+com.pocketshell.app.proof.VoiceGestureCoachmarkMainActivityDockerTest	88
+com.pocketshell.app.proof.signals.TerminalViewportCaptureTest	21
+com.pocketshell.app.tmux.Issue2155ConversationRebindsAfterInSessionRelaunchDockerTest	44
+com.pocketshell.app.tmux.Issue2174LocaleProofPaneCaptureDockerTest	28
+com.pocketshell.app.tmux.Issue2185UnreadableTranscriptDockerTest	27
+com.pocketshell.app.tmux.TmuxChromeReconnectingPillLegibleTest	34
+com.pocketshell.app.tmux.TmuxConsolidatedChromeScreenshotTest	29
+com.pocketshell.app.tmux.TmuxConversationDetectingComposerVisibleTest	18
+com.pocketshell.app.tmux.TmuxConversationDetectingComposerVisibleTest#showKeyboardChipIsGoneOnEveryFrameAfterConversationTabIsSelected	22
+com.pocketshell.app.tmux.TmuxMoreMenuOpenFilesTest#openFilesItemIsPresentAndInvokesCallback	20
+com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#issue2192_offlineOrReconnectingLiveLookingTerminal_launcherOpens	14
+com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#issue2192_wedgeA_rawNotConnectedLiveLookingTerminal_launcherOpensEnterStaysGated	15
+com.pocketshell.app.tmux.TmuxSessionVoiceSurfaceUiTest#issue2192_wedgeB_surfacePaneNullAfterReseed_launcherOpensEnterAbsent	13
+com.pocketshell.app.voice.VoiceGestureCoachmarkLauncherProofTest	43

--- a/scripts/test-ci-journey-retry-budget.sh
+++ b/scripts/test-ci-journey-retry-budget.sh
@@ -1089,7 +1089,7 @@ echo "== #1850 per-shard load: the shipped matrix must leave >420s retry headroo
 # Conservative fixed-cost inputs (worst observed in the #1850/#2060
 # derivation). They are fixture inputs to the production formula, NOT new
 # budget constants — case (w) above still pins those.
-LOAD_FIXTURE="$SCRIPT_DIR/fixtures/ci-journey-run-31961310072-class-seconds.tsv"
+LOAD_FIXTURE="${CI_JOURNEY_LOAD_FIXTURE:-$SCRIPT_DIR/fixtures/ci-journey-run-31961310072-class-seconds.tsv}"
 LOAD_SELECTION_HELPER="$SCRIPT_DIR/ci-journey-class-selection-functions.sh"
 LOAD_CORE_HELPER="$SCRIPT_DIR/ci-journey-core-terminal-functions.sh"
 LOAD_SHARD_COUNT="$SCRIPT_DIR/ci-journey-shard-count.sh"
@@ -1117,11 +1117,6 @@ while IFS=$'\t' read -r load_fqcn load_secs; do
 done < "$LOAD_FIXTURE"
 (( load_fixture_rows >= 150 )) \
   || fail "(aa) fixture has only $load_fixture_rows rows — a truncated TSV cannot constrain per-shard load"
-
-mapfile -t LOAD_SORTED_COSTS < <(printf '%s\n' "${LOAD_COST_SECS[@]}" | sort -n)
-LOAD_MEDIAN="${LOAD_SORTED_COSTS[$(( ${#LOAD_SORTED_COSTS[@]} / 2 ))]}"
-[[ "$LOAD_MEDIAN" =~ ^[1-9][0-9]*$ ]] \
-  || fail "(aa) could not derive a median from the fixture"
 
 # shellcheck source=scripts/ci-journey-class-selection-functions.sh
 source "$LOAD_SELECTION_HELPER"
@@ -1162,15 +1157,68 @@ for load_fqcn in "${LOAD_JOURNEY_CLASSES[@]}" "${LOAD_CORE_SELECTORS[@]}"; do
   load_unknowns+=("$load_fqcn")
 done
 if (( ${#load_unknowns[@]} > 0 )); then
-  echo "  (aa) ${#load_unknowns[@]} class(es) not in the fixture — costing each at the fixture median ${LOAD_MEDIAN}s:"
-  printf '    %s\n' "${load_unknowns[@]}"
+  echo "  (aa) missing required cost for ${#load_unknowns[@]} registered selector(s):"
+  printf '    missing required cost: %s\n' "${load_unknowns[@]}"
 fi
-(( ${#load_unknowns[@]} <= 20 )) \
-  || fail "(aa) ${#load_unknowns[@]} classes have no fixture cost — the TSV is too stale to ratchet load; re-derive it from a real run"
+(( ${#load_unknowns[@]} == 0 )) \
+  || fail "(aa) ${#load_unknowns[@]} registered selector(s) have no fixture cost — re-derive the TSV from a real run"
+
+# (aa0) G6 / issue #2281 mutation proof. Removing one real registered selector
+# from a copied fixture must execute the exact missing-cost guard and redden it;
+# a structural row-count check or a median fallback would let this mutant pass.
+# The child invocation skips only this parent self-test to avoid recursion. It
+# still runs the production-shaped parser, registry walk, and guarded failure.
+if [[ "${CI_JOURNEY_SKIP_FIXTURE_MUTATION_GUARD:-0}" != "1" ]]; then
+  load_fixture_mutant="$warm_ws/missing-required-cost.tsv"
+  load_fixture_mutant_log="$warm_ws/missing-required-cost.log"
+  load_mutant_victim=""
+  for load_fqcn in "${LOAD_JOURNEY_CLASSES[@]}" "${LOAD_CORE_SELECTORS[@]}"; do
+    if [[ -n "${LOAD_COST_SECS[$load_fqcn]+x}" ]]; then
+      load_mutant_victim="$load_fqcn"
+      break
+    fi
+  done
+  [[ -n "$load_mutant_victim" ]] \
+    || fail "(aa0) could not choose a registered fixture row for the mutation proof"
+  cp "$LOAD_FIXTURE" "$load_fixture_mutant" \
+    || fail "(aa0) could not copy the fixture for mutation"
+  python3 - "$load_fixture_mutant" "$load_mutant_victim" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+victim = sys.argv[2]
+lines = path.read_text().splitlines(keepends=True)
+matches = [i for i, line in enumerate(lines) if line.startswith(victim + "\t")]
+if len(matches) != 1:
+    raise SystemExit(f"mutation expected one row for {victim!r}, found {len(matches)}")
+del lines[matches[0]]
+path.write_text("".join(lines))
+PY
+  mutated_rows="$(awk 'NF && $1 !~ /^#/ {n++} END{print n}' "$load_fixture_mutant")"
+  [[ "$mutated_rows" == "$((load_fixture_rows - 1))" ]] \
+    || fail "(aa0) mutation changed $load_fixture_rows rows to $mutated_rows instead of removing exactly one"
+  if CI_JOURNEY_LOAD_FIXTURE="$load_fixture_mutant" \
+    CI_JOURNEY_SKIP_FIXTURE_MUTATION_GUARD=1 \
+    bash "$SCRIPT_DIR/test-ci-journey-retry-budget.sh" >"$load_fixture_mutant_log" 2>&1; then
+    load_mutant_rc=0
+  else
+    load_mutant_rc=$?
+  fi
+  (( load_mutant_rc != 0 )) \
+    || fail "(aa0) removing required cost for $load_mutant_victim stayed green"
+  grep -Fq "missing required cost: $load_mutant_victim" "$load_fixture_mutant_log" \
+    || { sed -n '/missing required cost/,+4p' "$load_fixture_mutant_log" >&2 || true; fail "(aa0) mutant did not execute the named missing-cost guard for $load_mutant_victim"; }
+  [[ "$(grep -Fc 'TEST FAIL: (aa)' "$load_fixture_mutant_log")" == "1" ]] \
+    || fail "(aa0) mutant produced an unexpected number of load-guard failures"
+  pass "(aa0) removing one required cost for $load_mutant_victim selectively reddens the live missing-cost guard (rc=$load_mutant_rc)"
+fi
 
 load_cost_of() {
   local fqcn="$1"
-  printf '%s' "${LOAD_COST_SECS[$fqcn]:-$LOAD_MEDIAN}"
+  [[ -n "${LOAD_COST_SECS[$fqcn]+x}" ]] \
+    || fail "(aa) load model requested an unpriced registered selector: $fqcn"
+  printf '%s' "${LOAD_COST_SECS[$fqcn]}"
 }
 
 # instrumentation_secs <total> <idx> — journey + core-terminal seconds the
@@ -1277,10 +1325,7 @@ for load_fqcn in "${!LOAD_COST_SECS[@]}"; do
   load_saved_costs+=("$load_fqcn" "${LOAD_COST_SECS[$load_fqcn]}")
   LOAD_COST_SECS["$load_fqcn"]=1
 done
-LOAD_MEDIAN_SAVED="$LOAD_MEDIAN"
-LOAD_MEDIAN=1
 LOAD_FLAT_THREE="$(load_model_min_margin_ms 3)"
-LOAD_MEDIAN="$LOAD_MEDIAN_SAVED"
 for (( load_i = 0; load_i < ${#load_saved_costs[@]}; load_i += 2 )); do
   LOAD_COST_SECS["${load_saved_costs[$load_i]}"]="${load_saved_costs[$((load_i + 1))]}"
 done


### PR DESCRIPTION
## Summary
- migrate the two FileViewer form dialogs to shared FormDialog
- retain the intentionally raw dirty-tab footer as the single baseline-backed AlertDialog
- add a source-connected mutation self-test and run it in CI

## Verification
- reviewer APPROVED on issue #2280
- component-drift self-test: both raw-call mutations rejected
- normal component-drift guard: passed
- full relevant JVM/UI suite: BUILD SUCCESSFUL, 215 actionable tasks
- connected FileViewerTabStripTest: 4/4 passed on emulator-5556

Closes #2280
