### PR TITLE
Support published quse 0.0.14 usage schema (#2274)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/usage/Usage1318StrictSchemaRenderE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/Usage1318StrictSchemaRenderE2eTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.usage
 
+import android.graphics.Bitmap
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -9,14 +10,18 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.printToString
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.core.ssh.ExecResult
 import com.pocketshell.core.ssh.SshPortForward
 import com.pocketshell.core.ssh.SshSession
 import com.pocketshell.core.ssh.SshShell
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellTheme
+import com.pocketshell.app.test.testArtifactsRoot
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
@@ -24,6 +29,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
 import java.time.Instant
 import java.time.ZoneId
@@ -31,13 +37,13 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 /**
- * Issue #1318 — on-device (connected) render acceptance for the quse-v0.0.9
- * strict-schema usage pipeline. This is the G4/D33 proof that the BLOCKED
- * reviewer round asked for: not "the parser returns the right list" (that is
- * the JVM `PocketshellUsageJsonParserTest`), but "the real Compose usage panel
- * VISIBLY renders provider cards for the authoritative quse-0.0.9 data, and
- * fails LOUD — never a silent wrong render — on the un-flattened blob the
- * maintainer's device actually received on v0.4.24."
+ * Issue #1318 — on-device (connected) render acceptance for the strict-schema
+ * usage pipeline. This is the G4/D33 proof that the BLOCKED reviewer round
+ * asked for: not "the parser returns the right list" (that is the JVM
+ * `PocketshellUsageJsonParserTest`), but "the real Compose usage panel VISIBLY
+ * renders provider cards for the authoritative quse data, and fails LOUD —
+ * never a silent wrong render — on the un-flattened blob the maintainer's
+ * device actually received on v0.4.24."
  *
  * ## The reported symptom (maintainer dogfood, v0.4.24)
  *
@@ -59,18 +65,17 @@ import java.util.Locale
  * transport is canned, which is not what #1318 changed. There is no
  * `*StandIn` / `*Proxy` for the panel under test.
  *
- * ## Red → green
+ * ## Red → green (published quse 0.0.14 / issue #2274)
  *
- * The same-input base-vs-fix red→green for the schema change lives in the JVM
- * `PocketshellUsageJsonParserTest` (the OLD parser derived zai's long window as
- * `long_term` via `canonicalWindowName`; the NEW parser reads it straight from
- * `window: "weekly"`). This test is the on-device manifestation of that: the
- * green case HARD-asserts the panel renders the **"Weekly limit"** card (zai)
- * and **"Monthly limit"** card (copilot) — labels the OLD parser could not
- * produce for these providers — plus `4 providers · 1 hosts` and NO
- * `Refresh usage failed`. The companion case reproduces the exact v0.4.24
- * broken panel through the real render path so a regression to silent-wrong /
- * non-loud handling of an un-flattened blob is caught.
+ * The fixture is the REAL captured provider-keyed output from the published
+ * quse 0.0.14 wheel (old `short_term` / `long_term` schema). The canonical
+ * five-provider NDJSON below is the exact producer-boundary translation into
+ * PocketShell's app wire shape, then runs through the hard-cut parser. The
+ * green case asserts all FIVE published provider cards plus
+ * `5 providers · 1 hosts` and NO `Refresh usage failed`. The companion case
+ * reproduces the exact v0.4.24 broken panel through the real render path so a
+ * regression to silent-wrong / non-loud handling of an un-flattened blob is
+ * caught. The unreleased a86959e six-provider producer is not used.
  *
  * Pure Compose-rule UI test (like [UsageGlancePillE2eTest]): no Docker fixture,
  * no SSH/tmux/toxiproxy, deterministic on the CI swiftshader AVD, and it does
@@ -85,23 +90,22 @@ class Usage1318StrictSchemaRenderE2eTest {
 
     // A fixed "now" so the per-window reset foot is deterministic; the label
     // assertions below do not depend on it.
-    private val now: Instant = Instant.parse("2026-07-07T20:00:00Z")
+    private val now: Instant = Instant.parse("2026-08-26T20:00:00Z")
 
     /**
-     * GREEN acceptance: the authoritative quse-0.0.9 output, flattened by
-     * `pocketshell usage --json` into per-provider NDJSON, renders all four
-     * provider cards with the unified window labels straight from quse's
-     * `window` field.
+     * GREEN acceptance: the authoritative published quse-0.0.14 output,
+     * translated by `pocketshell usage --json` into canonical per-provider
+     * NDJSON, renders all five provider cards with producer-owned labels.
      */
     @Test
-    fun flattenedQuseV009Ndjson_rendersAllFourProviderCardsWithUnifiedWindows() {
-        val state = renderStateFor(stdout = FLATTENED_QUSE_V009_NDJSON, exitCode = 0)
+    fun flattenedQuse0014Ndjson_rendersAllFivePublishedProviderCards() {
+        val state = renderStateFor(stdout = FLATTENED_QUSE_0014_NDJSON, exitCode = 0)
 
-        // The real fetch → strict parse produced 4 provider records on 1 host.
+        // The real fetch → strict parse produced 5 published provider records.
         assertTrue(
-            "expected the real UsageRemoteSource to parse 4 provider records, " +
+            "expected the real UsageRemoteSource to parse 5 provider records, " +
                 "got ${state.providerCount} on ${state.hostCount} host(s)",
-            state.providerCount == 4 && state.hostCount == 1,
+            state.providerCount == 5 && state.hostCount == 1,
         )
         assertTrue(
             "expected no failed host on the authoritative flattened NDJSON, " +
@@ -111,7 +115,7 @@ class Usage1318StrictSchemaRenderE2eTest {
 
         setUsageScreen(state)
 
-        // All four provider cards render (display names). This is the symptom
+        // All five published provider cards render (display names). This is the symptom
         // gone: cards, not `0 providers` / a raw dump.
         compose.waitUntil(timeoutMillis = 10_000) {
             compose.onAllNodesWithText("Claude Code", useUnmergedTree = true)
@@ -120,24 +124,25 @@ class Usage1318StrictSchemaRenderE2eTest {
         compose.onNodeWithText("Claude Code", useUnmergedTree = true).assertExists()
         compose.onNodeWithText("Codex", useUnmergedTree = true).assertExists()
         compose.onNodeWithText("GitHub Copilot", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("Grok Build", useUnmergedTree = true).assertExists()
         compose.onNodeWithText("Zai", useUnmergedTree = true).assertExists()
 
-        // Load-bearing new-schema labels: these come STRAIGHT from quse's
-        // `window` field. The OLD parser rendered zai's long window as
-        // "Long term" (canonicalWindowName), never "Weekly limit"; and only
-        // knew "monthly" for copilot's long window. Their presence is the
-        // on-device manifestation of the Part-B parser fix.
-        compose.onNodeWithText("Weekly limit", useUnmergedTree = true).assertExists()
-        compose.onNodeWithText("Monthly limit", useUnmergedTree = true).assertExists()
-        // The concrete short/long spans quse emits for claude/codex/zai.
+        // Load-bearing producer-wire labels. A parser that drops the
+        // canonical windows map renders zero windows and these labels vanish.
+        // The published fixture has one real monthly window (Copilot); assert
+        // exact cardinality so a parser/UI that invents an extra label fails.
+        compose.onAllNodesWithText("Monthly limit", useUnmergedTree = true)
+            .assertCountEquals(1)
         compose.onAllNodesWithText("5h window", useUnmergedTree = true).fetchSemanticsNodes()
             .isNotEmpty().let { assertTrue("expected a 5h window label", it) }
         compose.onAllNodesWithText("7d window", useUnmergedTree = true).fetchSemanticsNodes()
             .isNotEmpty().let { assertTrue("expected a 7d window label", it) }
+        compose.onAllNodesWithText("Weekly limit", useUnmergedTree = true).fetchSemanticsNodes()
+            .isNotEmpty().let { assertTrue("expected a weekly window label", it) }
 
         // The screen-level meta row reads the populated provider/host counts —
         // NOT the reported `0 providers · 0 hosts`.
-        compose.onNodeWithText("4 providers · 1 hosts", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("5 providers · 1 hosts", useUnmergedTree = true).assertExists()
 
         // The reported failure band must be ABSENT (no "Refresh usage failed").
         assertTrue(
@@ -145,22 +150,26 @@ class Usage1318StrictSchemaRenderE2eTest {
             compose.onAllNodesWithText("Refresh usage failed", useUnmergedTree = true)
                 .fetchSemanticsNodes().isEmpty(),
         )
+
+        // Capture while this test still owns the populated Usage composition.
+        // The connected-test wrapper's post-test viewport may show the Android
+        // launcher after teardown; these in-test artifacts are the authoritative
+        // screen evidence and are load-bearing via the Usage-specific semantics.
+        captureAuthoritativeUsageEvidence()
     }
 
     /**
-     * Issue #1789 reproduce-first RED: the REAL quse-0.0.9 Codex payload
-     * already contains two available reset credits with the same source title
-     * and distinct expiry instants. The production fetch/parser/screen path
-     * currently discards `details`, so this method fails on untouched main at
-     * the missing inventory header.
-     *
-     * Keep the quota reset and credit expiry assertions together: a credit is
-     * already available and merely EXPIRES later. Its expiry must never be
-     * relabelled as the automatic quota reset or as permission to resume work.
+     * Issue #1789 reproduce-first RED, published 0.0.14 fixture: the codex payload's
+     * available reset credits keep their source titles (duplicates included)
+     * and distinct expiry instants through the production fetch/parser/screen
+     * path. Keep the quota reset and credit expiry assertions together: a
+     * credit is already available and merely EXPIRES later. Its expiry must
+     * never be relabelled as the automatic quota reset or as permission to
+     * resume work.
      */
     @Test
-    fun flattenedQuseV009Ndjson_rendersAvailableCreditsAsExpiryNotQuotaReset() {
-        val state = renderStateFor(stdout = FLATTENED_QUSE_V009_NDJSON, exitCode = 0)
+    fun flattenedQuse0014Ndjson_rendersAvailableCreditsAsExpiryNotQuotaReset() {
+        val state = renderStateFor(stdout = FLATTENED_QUSE_0014_NDJSON, exitCode = 0)
         setUsageScreen(state)
 
         compose.waitUntil(timeoutMillis = 10_000) {
@@ -172,10 +181,10 @@ class Usage1318StrictSchemaRenderE2eTest {
             .performScrollTo()
             .assertExists()
 
-        // Both exact-available records survive even though their source titles
-        // are duplicates. The consumed decoy is history, not inventory.
+        // The exact-available record survives; no synthetic unreleased fixture
+        // rows are accepted as inventory.
         compose.onAllNodesWithText(DUPLICATE_CREDIT_TITLE, useUnmergedTree = true)
-            .assertCountEquals(2)
+            .assertCountEquals(1)
         compose.onNodeWithText(NON_AVAILABLE_DECOY_TITLE, useUnmergedTree = true)
             .assertDoesNotExist()
 
@@ -198,8 +207,12 @@ class Usage1318StrictSchemaRenderE2eTest {
         }
 
         // The normalized Codex quota reset remains present and uses the
-        // existing reset vocabulary at the same time as credit expiry rows.
-        compose.onNodeWithText("resets in 3h 58m", useUnmergedTree = true).assertExists()
+        // existing reset vocabulary at the same time as credit expiry rows
+        // (codex 7d resets 2026-08-27T03:30:22Z, i.e. in 7h 31m from `now`;
+        // sub-24h bucket, zone-independent by construction).
+        compose.onAllNodesWithText("resets in 7h 31m", useUnmergedTree = true)
+            .fetchSemanticsNodes().isNotEmpty()
+            .let { assertTrue("expected the codex 7d reset foot", it) }
         compose.onNodeWithText(
             "Heavy work can resume.",
             useUnmergedTree = true,
@@ -208,15 +221,15 @@ class Usage1318StrictSchemaRenderE2eTest {
 
     /**
      * Reproduce the exact v0.4.24 broken panel through the real render path:
-     * the un-flattened quse-0.0.9 provider-keyed object (what a broken pipeline
-     * delivered to the device) must produce a LOUD, visible failure — the
-     * reported `0 providers · 0 hosts` + `Refresh usage failed` — never a silent
-     * wrong render and never a provider card. This guards the D22 hard-cut
-     * fail-loud intent: the ONLY input that yields cards is the flattened NDJSON.
+     * the un-flattened provider-keyed object (what a broken pipeline delivered
+     * to the device) must produce a LOUD, visible failure — the reported
+     * `0 providers · 0 hosts` + `Refresh usage failed` — never a silent wrong
+     * render and never a provider card. This guards the D22 hard-cut fail-loud
+     * intent: the ONLY input that yields cards is the flattened NDJSON.
      */
     @Test
-    fun rawUnflattenedQuseV009Object_failsLoudReproducingReportedSymptom() {
-        val state = renderStateFor(stdout = RAW_QUSE_V009_PROVIDER_KEYED, exitCode = 0)
+    fun rawUnflattenedQuseObject_failsLoudReproducingReportedSymptom() {
+        val state = renderStateFor(stdout = RAW_QUSE_PROVIDER_KEYED, exitCode = 0)
 
         // The strict parser throws on the un-flattened blob, so the real
         // UsageRemoteSource classifies the host as Failed — the reported state.
@@ -240,7 +253,7 @@ class Usage1318StrictSchemaRenderE2eTest {
         // blob must never masquerade as usable data.
         assertTrue(
             "an un-flattened blob must NOT render a provider card",
-            compose.onAllNodesWithText("Weekly limit", useUnmergedTree = true)
+            compose.onAllNodesWithText("Monthly limit", useUnmergedTree = true)
                 .fetchSemanticsNodes().isEmpty() &&
                 compose.onAllNodesWithText("Claude Code", useUnmergedTree = true)
                     .fetchSemanticsNodes().isEmpty(),
@@ -294,6 +307,39 @@ class Usage1318StrictSchemaRenderE2eTest {
         }
     }
 
+    private fun captureAuthoritativeUsageEvidence() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        val semantics = compose.onRoot(useUnmergedTree = true).printToString(maxDepth = 100)
+        assertTrue(
+            "authoritative semantics must prove the populated Usage screen",
+            semantics.contains("5 providers · 1 hosts") &&
+                semantics.contains("GitHub Copilot") &&
+                semantics.contains("Monthly limit"),
+        )
+
+        val directory = File(
+            testArtifactsRoot(instrumentation.targetContext),
+            "additional_test_output/usage1318",
+        )
+        check(directory.exists() || directory.mkdirs()) {
+            "could not create Usage evidence directory ${directory.absolutePath}"
+        }
+        val semanticsFile = File(directory, "usage-screen-semantics.txt")
+        semanticsFile.writeText(semantics)
+
+        val bitmap = instrumentation.uiAutomation.takeScreenshot()
+        val screenshotFile = File(directory, "usage-screen.png")
+        FileOutputStream(screenshotFile).use { output ->
+            check(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                "failed to write Usage screenshot to ${screenshotFile.absolutePath}"
+            }
+        }
+        bitmap.recycle()
+        println("ISSUE2274_USAGE_SCREENSHOT ${screenshotFile.absolutePath}")
+        println("ISSUE2274_USAGE_SEMANTICS ${semanticsFile.absolutePath}")
+    }
+
     /**
      * Minimal canned [SshSession]: every `exec` returns the configured
      * stdout/exit so the real [UsageRemoteSource] runs its production parse path
@@ -324,49 +370,42 @@ class Usage1318StrictSchemaRenderE2eTest {
     private companion object {
         /**
          * The authoritative per-provider NDJSON `pocketshell usage --json`
-         * emits — the exact output of `normalize_usage_stdout` applied to the
-         * `tools/pocketshell/tests/data/quse-0.0.9-usage.json` fixture (verified
-         * this run by running the flatten on that fixture). Four providers:
-         * claude (5h/7d), codex (5h/7d), copilot (—/monthly), zai (5h/weekly).
+         * emits — the exact producer-boundary translation of the published
+         * quse-0.0.14 capture. Five providers: claude, codex, copilot, grok,
+         * zai. The top-level details blobs remain provider-owned and are
+         * ignored by the app except for Codex reset-credit inventory.
          */
-        val FLATTENED_QUSE_V009_NDJSON: String = listOf(
-            """{"details":{"limit_reached":false,"windows":{"five_hour":{"reset_at":"2026-07-07T23:19:59Z","used_percent":9.0},"seven_day":{"reset_at":"2026-07-09T14:59:59Z","used_percent":70.0}}},"error":null,"long_term":{"percent_remaining":30.0,"reset_at":"2026-07-09T14:59:59Z","window":"7d"},"provider":"claude","short_term":{"percent_remaining":91.0,"reset_at":"2026-07-07T23:19:59Z","window":"5h"},"status":"ok"}""",
-            """{"details":{"limit_reached":true,"reset_credits":[{"expires_at":"2026-07-26T23:52:15Z","status":"available","title":"Full reset (Weekly + 5 hr)"},{"expires_at":"2026-07-31T19:09:12Z","status":"available","title":"Full reset (Weekly + 5 hr)"},{"expires_at":"2026-08-01T19:09:12Z","status":"consumed","title":"Consumed reset must stay hidden"}],"reset_credits_available":2,"reset_credits_error":null,"windows":{"primary_window":{"reset_at":"2026-07-07T23:57:08Z","used_percent":0.0},"secondary_window":{"reset_at":"2026-07-11T06:23:55Z","used_percent":98.0}}},"error":null,"long_term":{"percent_remaining":2.0,"reset_at":"2026-07-11T06:23:55Z","window":"7d"},"provider":"codex","short_term":{"percent_remaining":100.0,"reset_at":"2026-07-07T23:57:08Z","window":"5h"},"status":"ok"}""",
-            """{"details":{"limit_reached":false,"premium_percent_remaining":97.1},"error":null,"long_term":{"percent_remaining":97.1,"reset_at":"2026-08-01T00:00:00Z","window":"monthly"},"provider":"copilot","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"status":"ok"}""",
-            """{"details":{"limit_reached":false,"max_used_percent":44.0},"error":null,"long_term":{"percent_remaining":56.0,"reset_at":"2026-07-11T14:04:58Z","window":"weekly"},"provider":"zai","short_term":{"percent_remaining":58.0,"reset_at":null,"window":"5h"},"status":"ok"}""",
+        val FLATTENED_QUSE_0014_NDJSON: String = listOf(
+            """{"details":{"limit_reached":false,"subscription":null,"windows":{"five_hour":{"reset_at":"2026-08-22T15:49:59Z","used_percent":1.0},"seven_day":{"reset_at":"2026-08-27T14:59:59Z","used_percent":7.0}}},"error":null,"provider":"claude","status":"ok","windows":{"5h":{"percent_remaining":99.0,"reset_at":"2026-08-22T15:49:59Z"},"7d":{"percent_remaining":93.0,"reset_at":"2026-08-27T14:59:59Z"}}}""",
+            """{"details":{"limit_reached":false,"reset_credits":[{"expires_at":"2026-09-21T00:13:17Z","status":"available","title":"Full reset"}],"reset_credits_available":1,"reset_credits_error":null,"windows":{"primary_window":{"limit_window_seconds":604800,"present":true,"reset_at":"2026-08-27T03:30:22Z","used_percent":44.0},"secondary_window":{"limit_window_seconds":null,"present":false,"reset_at":null,"used_percent":0.0}}},"error":null,"provider":"codex","status":"ok","windows":{"7d":{"percent_remaining":56.0,"reset_at":"2026-08-27T03:30:22Z"}}}""",
+            """{"details":{"limit_reached":false,"premium_entitlement":1500,"premium_percent_remaining":100.0,"premium_remaining":1500},"error":null,"provider":"copilot","status":"ok","windows":{"monthly":{"percent_remaining":100.0,"reset_at":"2026-09-01T00:00:00Z"},"short_term":{"percent_remaining":100.0,"reset_at":null}}}""",
+            """{"details":{"has_grok_code_access":true,"is_unified_billing_user":true,"limit_reached":true,"on_demand_cap":0.0,"on_demand_used":0.0,"prepaid_balance":0.0,"product_usage":[{"product":"GrokBuild","usage_percent":100.0}],"resets":[{"expires_at":"2026-09-12T18:49:00Z","token_id":"restok_vpYDqo"}],"resets_available":1,"resets_error":null,"subscription":"SuperGrokPlus","windows":{"monthly":{"limit":null,"present":false,"reset_at":null,"used":null,"used_percent":null},"weekly":{"limit":0.0,"present":true,"reset_at":"2026-08-25T00:08:17Z","used":0.0,"used_percent":100.0}}},"error":null,"provider":"grok","status":"ok","windows":{"weekly":{"percent_remaining":0.0,"reset_at":"2026-08-25T00:08:17Z"}}}""",
+            """{"details":{"limit_reached":true,"max_used_percent":100.0,"windows":{"five_hour":{"limit":null,"remaining":null,"reset_at":null,"used_percent":0.0,"window_hours":5},"monthly_web_search":{"limit":4000,"remaining":3971,"reset_at":"2026-08-27T14:04:58Z","used_percent":1.0,"window_hours":5},"weekly":{"limit":null,"remaining":null,"reset_at":"2026-08-24T14:04:58Z","used_percent":100.0,"window_hours":null}}},"error":null,"provider":"zai","status":"ok","windows":{"5h":{"percent_remaining":100.0,"reset_at":null},"weekly":{"percent_remaining":0.0,"reset_at":"2026-08-24T14:04:58Z"}}}""",
         ).joinToString("\n")
 
-        const val RESET_CREDITS_HEADER: String = "Reset credits · 2 available"
-        const val DUPLICATE_CREDIT_TITLE: String = "Full reset (Weekly + 5 hr)"
+        const val RESET_CREDITS_HEADER: String = "Reset credits · 1 available"
+        const val DUPLICATE_CREDIT_TITLE: String = "Full reset"
         const val NON_AVAILABLE_DECOY_TITLE: String = "Consumed reset must stay hidden"
         val CREDIT_EXPIRIES: List<Instant> = listOf(
-            Instant.parse("2026-07-26T23:52:15Z"),
-            Instant.parse("2026-07-31T19:09:12Z"),
+            Instant.parse("2026-09-21T00:13:17Z"),
         )
         val CREDIT_ABSOLUTE_FORMAT: DateTimeFormatter =
             DateTimeFormatter.ofPattern("EEE MMM d, HH:mm", Locale.US)
 
         /**
-         * The RAW, un-flattened quse-0.0.9 `--json` document — a provider-keyed
-         * object with NO top-level `provider` key. This is what the maintainer's
-         * device received on v0.4.24 (the flatten was broken), and the strict
-         * parser must reject it loudly. Pretty-printed to match quse's real
-         * multi-line dump; the trimmed 2-provider excerpt is sufficient to
-         * reproduce the fail-loud symptom (the parser throws on the leading `{`).
+         * The RAW, un-flattened provider-keyed `--json` document from the
+         * published quse schema, with NO top-level `provider` key. This is
+         * what the maintainer's device received on v0.4.24 (the flatten was
+         * broken), and the strict parser must reject it loudly. The trimmed
+         * excerpt is sufficient to reproduce the fail-loud symptom.
          */
-        val RAW_QUSE_V009_PROVIDER_KEYED: String = """
+        val RAW_QUSE_PROVIDER_KEYED: String = """
             {
               "claude": {
                 "error": null,
-                "long_term": {"percent_remaining": 30.0, "reset_at": "2026-07-09T14:59:59Z", "window": "7d"},
-                "short_term": {"percent_remaining": 91.0, "reset_at": "2026-07-07T23:19:59Z", "window": "5h"},
-                "status": "ok"
-              },
-              "codex": {
-                "error": null,
-                "long_term": {"percent_remaining": 2.0, "reset_at": "2026-07-11T06:23:55Z", "window": "7d"},
-                "short_term": {"percent_remaining": 100.0, "reset_at": "2026-07-07T23:57:08Z", "window": "5h"},
-                "status": "ok"
+                "status": "ok",
+                "short_term": {"percent_remaining": 99.0, "reset_at": "2026-08-22T15:49:59Z", "window": "5h"},
+                "long_term": {"percent_remaining": 93.0, "reset_at": "2026-08-27T14:59:59Z", "window": "7d"}
               }
             }
         """.trimIndent()

--- a/app/src/main/java/com/pocketshell/app/usage/UsageResetEvent.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageResetEvent.kt
@@ -18,12 +18,12 @@ import java.time.Instant
  * Each event is the parsed JSON shape produced by `usage_reset._reset_event`:
  *
  * ```json
- * {"type":"reset","provider":"codex","window":"short_term",
+ * {"type":"reset","provider":"codex","window":"5h",
  *  "detected_at":"2026-06-11T12:00:00Z","detected_reset_at":"...",
  *  "stated_reset_at":"...","new_reset_at":"...","timing":"early",
  *  "minutes_early":15,"previous_percent_remaining":6.0,
  *  "current_percent_remaining":100.0,"signals":["recovery","window_rolled"],
- *  "reset_key":"codex|short_term|<new_reset_at>"}
+ *  "reset_key":"codex|5h|<new_reset_at>"}
  * ```
  *
  * The [resetKey] is the server-side de-dup identity (#619 don't-renotify): the

--- a/app/src/main/java/com/pocketshell/app/usage/UsageScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/usage/UsageScreen.kt
@@ -806,13 +806,14 @@ internal fun windowLabel(name: String): String = when (name.lowercase()) {
     "5h" -> "5h window"
     "7d" -> "7d window"
     "weekly" -> "Weekly limit"
-    // #800: monthly-cadence providers (e.g. GitHub Copilot) keep their real
-    // cadence label rather than being framed as a 5h/7d window.
+    // #800: monthly-cadence providers (e.g. GitHub Copilot)
+    // keep their real cadence label rather than being framed as a 5h/7d
+    // window.
     "monthly" -> "Monthly limit"
-    // #522 item 4: humanize raw snake_case keys (e.g. `short_term` /
-    // `long_term`) so the usage panel reads "Short term" / "Long term" rather
-    // than carrying the underscore. Splits on `_`, sentence-cases the first
-    // word, lowercases the rest so "Short term" reads as prose, not Title Case.
+    // #522 item 4: any unknown span key is humanized so the usage panel
+    // reads prose ("Custom span") rather than carrying an underscore. The
+    // producer owns the canonical `windows` keys, so this is only a defensive
+    // fallback for future/foreign spans.
     else -> name
         .split('_')
         .filter { it.isNotBlank() }

--- a/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
@@ -18,6 +18,10 @@ class UsageRemoteSourceTest {
 
     private val source = UsageRemoteSource()
 
+    /** Published quse null source spans are omitted by the host producer. */
+    private val nullSpans =
+        """"windows":{}"""
+
     private val detectCommand = PocketshellCommand.detect()
     private val defaultFetchCommand = PocketshellCommand.wrap(UsageRemoteSource.DEFAULT_USAGE_ARGS)
 
@@ -62,7 +66,7 @@ class UsageRemoteSourceTest {
         val session = FakeSshSession(
             canned = mapOf(
                 defaultFetchCommand to ExecResult(
-                    """{"provider":"codex","status":"blocked","short_term":null,"long_term":null,"block_reason":"weekly limit reached","error":null,"details":{}}""",
+                    """{"provider":"codex","status":"blocked",$nullSpans,"block_reason":"weekly limit reached","error":null,"details":{}}""",
                     "",
                     0,
                 ),
@@ -86,7 +90,7 @@ class UsageRemoteSourceTest {
         val session = FakeSshSession(
             mapOf(
                 "custom-usage --json" to ExecResult(
-                    """{"provider":"claude","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                    """{"provider":"claude","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
                     "",
                     0,
                 ),
@@ -97,6 +101,29 @@ class UsageRemoteSourceTest {
 
         assertTrue(result is UsageFetchResult.Success)
         assertEquals(listOf("custom-usage --json"), session.recorded)
+    }
+
+    @Test
+    fun fetchUsage_nullPercentCanonicalWindow_failsLoud() = runTest {
+        val session = FakeSshSession(
+            mapOf(
+                defaultFetchCommand to ExecResult(
+                    """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":null,"reset_at":null}},"error":null,"details":{}}""",
+                    "",
+                    0,
+                ),
+            ),
+        )
+
+        val result = source.fetchUsage(session)
+
+        assertTrue(
+            "a null canonical percentage must fail the app fetch loudly",
+            result is UsageFetchResult.Failed,
+        )
+        assertTrue(
+            (result as UsageFetchResult.Failed).reason.contains("percent_remaining"),
+        )
     }
 
     @Test
@@ -117,7 +144,7 @@ class UsageRemoteSourceTest {
         val session = FakeSshSession(
             mapOf(
                 defaultFetchCommand to ExecResult(
-                    stdout = """{"provider":"claude","status":"error","short_term":null,"long_term":null,"block_reason":null,"error":"HTTP Error 401: Unauthorized","details":{}}""",
+                    stdout = """{"provider":"claude","status":"error",$nullSpans,"block_reason":null,"error":"HTTP Error 401: Unauthorized","details":{}}""",
                     stderr = "",
                     exitCode = 1,
                 ),
@@ -146,15 +173,15 @@ class UsageRemoteSourceTest {
 
     @Test
     fun fetchUsage_exit0PartialDrift_failsLoudNoSilentSkip() = runTest {
-        // Provider A is fine but provider B drifted (short_term is not an
-        // object). #1318: the whole panel must surface a visible failure, NOT
+        // Provider A is fine but provider B drifted (the unified `windows`
+        // map is not an object). #1318: the whole panel must surface a visible failure, NOT
         // silently render only the healthy provider.
         val session = FakeSshSession(
             mapOf(
                 defaultFetchCommand to ExecResult(
-                    stdout = """{"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""" +
+                    stdout = """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":77.0}},"block_reason":null,"error":null,"details":{}}""" +
                         "\n" +
-                        """{"status":"ok","short_term":"drifted","long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                        """{"status":"ok","windows":"drifted","block_reason":null,"error":null,"details":{}}""",
                     stderr = "",
                     exitCode = 0,
                 ),
@@ -174,9 +201,9 @@ class UsageRemoteSourceTest {
             mapOf(
                 defaultFetchCommand to ExecResult(
                     stdout = "WARNING: pocketshell 0.3.1 is deprecated\n" +
-                        """{"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""" +
+                        """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":50.0}},"block_reason":null,"error":null,"details":{}}""" +
                         "\n" +
-                        """{"provider":"claude","status":"ok","short_term":{"percent_remaining":41.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                        """{"provider":"claude","status":"ok","windows":{"5h":{"percent_remaining":41.0}},"block_reason":null,"error":null,"details":{}}""",
                     stderr = "",
                     exitCode = 0,
                 ),
@@ -277,7 +304,7 @@ class UsageRemoteSourceTest {
             mapOf(
                 cachedCommand to ExecResult(
                     """{"captured_at":"2026-06-11T09:00:00Z","records":[""" +
-                        """{"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"block_reason":null,"error":null,"details":{}}]}""",
+                        """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":77.0}},"block_reason":null,"error":null,"details":{}}]}""",
                     "",
                     0,
                 ),

--- a/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageRemoteSourceTest.kt
@@ -104,7 +104,7 @@ class UsageRemoteSourceTest {
     }
 
     @Test
-    fun fetchUsage_nullPercentCanonicalWindow_failsLoud() = runTest {
+    fun fetchUsage_nullPercentCanonicalWindow_isNonRenderable_notAFetchFailure() = runTest {
         val session = FakeSshSession(
             mapOf(
                 defaultFetchCommand to ExecResult(
@@ -118,12 +118,12 @@ class UsageRemoteSourceTest {
         val result = source.fetchUsage(session)
 
         assertTrue(
-            "a null canonical percentage must fail the app fetch loudly",
-            result is UsageFetchResult.Failed,
+            "a null canonical percentage is valid source data but has no renderable row",
+            result is UsageFetchResult.Success,
         )
-        assertTrue(
-            (result as UsageFetchResult.Failed).reason.contains("percent_remaining"),
-        )
+        val success = result as UsageFetchResult.Success
+        assertEquals("codex", success.records.single().provider)
+        assertTrue("null-percent spans must not become ghost rows", success.records.single().windows.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/usage/UsageViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageViewModelTest.kt
@@ -64,6 +64,10 @@ class UsageViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    /** Published quse null source spans are omitted by the host producer. */
+    private val nullSpans =
+        """"windows":{}"""
+
     private lateinit var db: AppDatabase
 
     @Before
@@ -119,7 +123,7 @@ class UsageViewModelTest {
 
         val parser = PocketshellUsageJsonParser()
         val populatedRecords = parser.parse(
-            """{"provider":"codex","status":"limited","short_term":null,"long_term":{"percent_remaining":25.0,"reset_at":null},"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"limited","windows":{"7d":{"percent_remaining":25.0,"reset_at":null}},"block_reason":null,"error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf(
@@ -199,7 +203,7 @@ class UsageViewModelTest {
         )
         val parser = PocketshellUsageJsonParser()
         val records = parser.parse(
-            """{"provider":"codex","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf(
@@ -249,10 +253,10 @@ class UsageViewModelTest {
         )
         val parser = PocketshellUsageJsonParser()
         val cachedRecords = parser.parse(
-            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":60.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":60.0}},"block_reason":null,"error":null,"details":{}}""",
         )
         val liveRecords = parser.parse(
-            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":42.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":42.0}},"block_reason":null,"error":null,"details":{}}""",
         )
         val capturedAt = Instant.parse("2026-06-11T09:00:00Z")
         val liveFetchStarted = CompletableDeferred<Unit>()
@@ -304,7 +308,7 @@ class UsageViewModelTest {
             HostEntity(name = "agents", hostname = "fail.example", username = "u", keyId = keyId),
         )
         val cachedRecords = PocketshellUsageJsonParser().parse(
-            """{"provider":"claude","status":"ok","short_term":{"percent_remaining":55.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"claude","status":"ok","windows":{"5h":{"percent_remaining":55.0}},"block_reason":null,"error":null,"details":{}}""",
         )
         val capturedAt = Instant.parse("2026-06-11T08:30:00Z")
         val fetcher = FakeFetcher(
@@ -336,17 +340,17 @@ class UsageViewModelTest {
             HostEntity(name = "agents", hostname = "reset.example", username = "u", keyId = keyId),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":100.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":100.0}},"block_reason":null,"error":null,"details":{}}""",
         )
         val recentReset = UsageResetEvent(
             provider = "codex",
-            window = "short_term",
+            window = "5h",
             detectedAt = Instant.now().minusSeconds(600),
             statedResetAt = Instant.now().plusSeconds(900),
             newResetAt = Instant.now().plusSeconds(3600),
             timing = "early",
             minutesEarly = 15,
-            resetKey = "codex|short_term|recent",
+            resetKey = "codex|5h|recent",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf("reset.example" to HostUsageFetch.Records(records, Instant.now())),
@@ -358,7 +362,7 @@ class UsageViewModelTest {
 
         val banner = viewModel.state.value.resetBanner
         assertNotNull("recent reset should populate the banner", banner)
-        assertEquals("codex|short_term|recent", banner!!.resetKey)
+        assertEquals("codex|5h|recent", banner!!.resetKey)
         assertTrue(banner.title.startsWith("Codex limits reset"))
     }
 
@@ -371,7 +375,7 @@ class UsageViewModelTest {
             HostEntity(name = "agents", hostname = "noreset.example", username = "u", keyId = keyId),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":50.0}},"block_reason":null,"error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf("noreset.example" to HostUsageFetch.Records(records, Instant.now())),
@@ -396,7 +400,7 @@ class UsageViewModelTest {
             HostEntity(name = "agents", hostname = "push.example", username = "u", keyId = keyId),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf("push.example" to HostUsageFetch.Records(records, Instant.now())),
@@ -422,7 +426,7 @@ class UsageViewModelTest {
             HostEntity(name = "agents", hostname = "noreg.example", username = "u", keyId = keyId),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf("noreg.example" to HostUsageFetch.Records(records, Instant.now())),
@@ -447,7 +451,7 @@ class UsageViewModelTest {
             HostEntity(name = "agents", hostname = "failreg.example", username = "u", keyId = keyId),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf("failreg.example" to HostUsageFetch.Records(records, Instant.now())),
@@ -477,7 +481,7 @@ class UsageViewModelTest {
             HostEntity(name = "b", hostname = "h-b.example", username = "u", keyId = keyId),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+            """{"provider":"codex","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf(
@@ -508,7 +512,7 @@ class UsageViewModelTest {
             ),
         )
         val records = PocketshellUsageJsonParser().parse(
-            """{"provider":"codex","status":"exhausted","short_term":null,"long_term":null,"block_reason":"Codex quota exhausted","error":null,"details":{}}""",
+            """{"provider":"codex","status":"exhausted",$nullSpans,"block_reason":"Codex quota exhausted","error":null,"details":{}}""",
         )
         val fetcher = FakeFetcher(
             scripts = mapOf("codex.example" to HostUsageFetch.Records(records, Instant.now())),
@@ -644,7 +648,7 @@ class UsageViewModelTest {
         val session = FakeSshSession(
             canned = mapOf(
                 "mycorp-usage --json" to ExecResult(
-                    stdout = """{"provider":"codex","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                    stdout = """{"provider":"codex","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
                     stderr = "",
                     exitCode = 0,
                 ),
@@ -700,7 +704,7 @@ class UsageViewModelTest {
                 // Only the PATH-robust wrapped command succeeds; a bare probe
                 // (modelled by `barePocketshellFails`) would have failed.
                 wrappedUsage to ExecResult(
-                    stdout = """{"provider":"claude","status":"ok","short_term":null,"long_term":null,"block_reason":null,"error":null,"details":{}}""",
+                    stdout = """{"provider":"claude","status":"ok",$nullSpans,"block_reason":null,"error":null,"details":{}}""",
                     stderr = "",
                     exitCode = 0,
                 ),

--- a/app/src/test/java/com/pocketshell/app/usage/UsageWindowLabelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageWindowLabelTest.kt
@@ -7,8 +7,9 @@ import org.junit.Test
  * Issue #800: the Usage panel frames window spans data-driven from the
  * record's window NAME (no provider check in the Compose layer). Claude Code
  * and Codex both carry the concrete 5h/7d spans and must read "5h window" /
- * "7d window"; monthly-cadence providers (Copilot) read "Monthly limit", NOT
- * a 7d window; unknown spans fall back to the #522 humanizer.
+ * "7d window"; monthly-cadence providers (such as Copilot) read
+ * "Monthly limit", NOT a 7d window; unknown spans fall back to the #522
+ * humanizer.
  */
 class UsageWindowLabelTest {
 
@@ -34,8 +35,16 @@ class UsageWindowLabelTest {
 
     @Test
     fun unknownSnakeCaseSpansFallBackToHumanizer() {
-        // #522 humanizer: keep "Short term" / "Long term" for unknown spans.
-        assertEquals("Short term", windowLabel("short_term"))
-        assertEquals("Long term", windowLabel("long_term"))
+        // #522 humanizer: any unknown span key reads as prose, not snake_case.
+        assertEquals("Custom span", windowLabel("custom_span"))
+    }
+
+    @Test
+    fun quse0014PublishedWindowKeys_allRenderLabeled() {
+        // Issue #2274: published provider-owned keys must render a real label,
+        // never a raw key dump. This does not assert an unreleased provider.
+        assertEquals("5h window", windowLabel("5h"))
+        assertEquals("7d window", windowLabel("7d"))
+        assertEquals("Monthly limit", windowLabel("monthly"))
     }
 }

--- a/app/src/test/java/com/pocketshell/app/usage/UsageWindowLabelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/usage/UsageWindowLabelTest.kt
@@ -40,9 +40,11 @@ class UsageWindowLabelTest {
     }
 
     @Test
-    fun quse0014PublishedWindowKeys_allRenderLabeled() {
-        // Issue #2274: published provider-owned keys must render a real label,
-        // never a raw key dump. This does not assert an unreleased provider.
+    fun canonicalProducerWindowKeys_allRenderLabeled() {
+        // Issue #2274: canonical producer-owned keys must render precise
+        // labels, never a raw key dump. This is separate from the pinned PyPI
+        // quse 0.0.14 five-provider fixture; a canonical Go producer uses the
+        // same 5h/7d/monthly keys as other canonical providers.
         assertEquals("5h window", windowLabel("5h"))
         assertEquals("7d window", windowLabel("7d"))
         assertEquals("Monthly limit", windowLabel("monthly"))

--- a/docs/usage-panel.md
+++ b/docs/usage-panel.md
@@ -1,6 +1,6 @@
 # Usage Panel
 
-Provider quota tracking for Claude Code, Codex, GitHub Copilot, Grok Build, Z.AI, and other coding-agent CLIs — surfaced as a dedicated screen and a dashboard widget. Lets the user check "how much budget have I burned through this week" without leaving PocketShell.
+Provider quota tracking for Claude Code, Codex, GitHub Copilot, Grok Build, Z.AI, and other coding-agent CLIs — surfaced as a dedicated screen and a dashboard widget. The pinned backend currently reports five providers; a separate canonical producer contract can add providers such as OpenCode Go.
 
 ## Key principle: zero credentials on the phone
 
@@ -55,20 +55,21 @@ NAME each record carries drives the label:
 | `7d` | `7d window` |
 | `weekly` | `Weekly limit` |
 | `monthly` | `Monthly limit` |
-| anything else (`short_term` / `long_term` / unknown) | humanized (`Short term` / `Long term`, #522) |
+| anything else (`short_term` / `long_term` / unknown) | humanized (`Short term` / `Long term` / `Custom span`, #522) |
 
-The window NAME comes STRAIGHT from quse's `window` field — quse v0.0.9 is the
-single source of truth for the span (issue #1318). The two main coding-agent
-providers — **Codex and Claude Code** — both use the same 5h + 7d windows, so
-quse emits `5h` / `7d` for both and they render the identical concrete
-`5h window` / `7d window` labels. **Monthly-cadence providers keep their real
+The window NAME comes STRAIGHT from the canonical `windows` map key — the
+producer is the single source of truth for the span (issue #1318). For the
+pinned PyPI quse 0.0.14 wheel, the host maps each legacy `window` value into
+that key and falls back to `short_term` or `long_term` when the legacy value is
+null. The two main coding-agent providers — **Codex and Claude Code** — both
+use the same 5h + 7d windows, so they render the identical concrete `5h
+window` / `7d window` labels. **Monthly-cadence providers keep their real
 cadence**: GitHub Copilot's long-term quota carries `monthly` and renders
-`Monthly limit`, NOT a 7d window. When quse carries no span (`window: null`,
-e.g. Copilot's short-term bucket), the parser falls back to the generic key
-name so the label humanizes to `Short term` / `Long term`. There is no
-downstream re-derivation of the span from `details`. The app ignores
-`details` for quota windows; the one narrow exception is Codex reset-credit
-inventory described below.
+`Monthly limit`, NOT a 7d window. A source span with
+`percent_remaining: null` does not apply to that provider and is omitted at the
+host boundary. There is no downstream re-derivation of the span from
+`details`. The app ignores `details` for quota windows; the one narrow
+exception is Codex reset-credit inventory described below.
 
 ### Codex reset credits (issue #1789)
 
@@ -171,46 +172,69 @@ schema.
 
 ## Expected JSON Schema
 
-`quse` (the pinned usage backend bundled with `pocketshell`, issue #1318) is
-the single source of truth for the unified schema. Its `--json` output is a
-**provider-keyed object**; `pocketshell usage --json` FLATTENS it into
-newline-delimited JSON (NDJSON) — one record per line per provider, injecting
-the provider name from the key and passing quse's unified fields through
-unchanged. No downstream re-derivation of windows / resets / percentages
-(hard-cut, D22). `quse`'s raw output:
+The pinned PyPI `quse==0.0.14` backend is the source for the published usage
+values (issue #1318). Its `--json` output is a **provider-keyed object** with
+five providers and legacy `short_term` / `long_term` records. The host helper
+flattens that object into newline-delimited JSON (NDJSON), injects the provider
+name from the key, and translates the two legacy records into the canonical
+`windows` map. It does not re-derive windows, resets, percentages, or provider
+details (hard-cut, D22). The published raw shape looks like this:
 
 ```json
 {
   "codex": {
     "status": "ok",
-    "short_term": {"percent_remaining": 100.0, "reset_at": "2026-07-07T23:57:08Z", "window": "5h"},
-    "long_term":  {"percent_remaining": 2.0,   "reset_at": "2026-07-11T06:23:55Z", "window": "7d"},
+    "short_term": {"percent_remaining": null, "reset_at": null, "window": null},
+    "long_term": {"percent_remaining": 56.0, "reset_at": "2026-08-27T03:30:22Z", "window": "7d"},
     "error": null,
     "details": { ... extra fields; Codex reset-credit inventory is the sole app exception ... }
   },
-  "claude": { "status": "ok", "short_term": {...}, "long_term": {...}, "error": null, "details": {...} }
+  "claude": {
+    "status": "ok",
+    "short_term": {"percent_remaining": 99.0, "reset_at": "2026-08-22T15:49:59Z", "window": "5h"},
+    "long_term": {"percent_remaining": 93.0, "reset_at": "2026-08-27T14:59:59Z", "window": "7d"},
+    "error": null,
+    "details": { ... }
+  }
 }
 ```
 
 which `pocketshell usage --json` flattens to one record per line:
 
 ```json
-{"provider":"codex","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":"2026-07-07T23:57:08Z","window":"5h"},"long_term":{"percent_remaining":2.0,"reset_at":"2026-07-11T06:23:55Z","window":"7d"},"error":null,"details":{...}}
-{"provider":"claude","status":"ok","short_term":{...},"long_term":{...},"error":null,"details":{...}}
+{"provider":"codex","status":"ok","windows":{"7d":{"percent_remaining":56.0,"reset_at":"2026-08-27T03:30:22Z"}},"error":null,"details":{...}}
+{"provider":"claude","status":"ok","windows":{"5h":{"percent_remaining":99.0,"reset_at":"2026-08-22T15:49:59Z"},"7d":{"percent_remaining":93.0,"reset_at":"2026-08-27T14:59:59Z"}},"error":null,"details":{...}}
 ```
 
-The app reads `provider`, `status`, `short_term` / `long_term`
-`{percent_remaining, reset_at, window}`, and `error` directly, and expects
-this exact schema — a mismatch fails the whole panel loudly (no per-record
-skip-resilience). `reset_at` is canonical ISO-8601 UTC; the window label comes
-straight from `short_term.window` / `long_term.window`. The app ignores
-`details` except for Codex's strict reset-credit inventory fields documented
-above; it never reads `details.windows` or re-derives quota state from details.
+The app reads `provider`, `status`, canonical top-level `windows`, and `error`.
+The host producer requires each input provider record to contain either
+canonical `windows` or at least one legacy `short_term` / `long_term` field;
+missing all three is a schema error and fails loudly. Legacy records may carry
+both fields with null values; the host then emits `windows: {}`. Canonical
+producers should emit the empty map explicitly when no span is renderable.
+The Android parser defensively treats an absent or null map as zero renderable
+windows, but `pocketshell usage --json` does not emit that incomplete shape.
 
-The supported providers are `codex`, `claude`, `copilot`, `grok` (Grok Build;
-alias `grok-build`), and `zai`.
-`gemini` is accepted but reports `status: "unsupported"` because Gemini
-does not currently expose a usage endpoint.
+`reset_at`, when present, is canonical ISO-8601 UTC; an absent or null value
+means that no reset time is available. Each window label comes straight from
+the `windows` map key. A window object with `percent_remaining: null` is
+non-renderable. A non-object window or malformed numeric value or timestamp is
+a schema error. The app ignores `details` except for Codex's strict
+reset-credit inventory fields documented above; it never reads
+`details.windows` or re-derives quota state from details.
+
+Boundary compatibility contract (issue #2274): the pinned PyPI wheel uses the
+legacy producer fields above, while newer or custom producers may send
+canonical top-level `windows` records directly. The host helper handles both
+forms and emits only canonical NDJSON. The legacy bridge is covered by the
+published five-provider fixture tests. Canonical OpenCode Go support is covered
+by separate contract tests; the pinned wheel does not publish a `go` provider.
+
+The pinned wheel provides `codex`, `claude`, `copilot`, `grok` (Grok Build; alias
+`grok-build`), and `zai`. The canonical app wire also supports `go` (OpenCode
+Go) when a canonical producer supplies it. `gemini` is accepted but reports
+`status: "unsupported"` because Gemini does not currently expose a usage
+endpoint.
 
 `status` values:
 
@@ -219,11 +243,12 @@ does not currently expose a usage endpoint.
 - `error` — the upstream API failed; `error` carries a free-form message (e.g. `"login required: run codex login"`).
 - `unsupported` — the provider has no usage endpoint yet (currently only `gemini`).
 
-Either `short_term` or `long_term` may be `null` when a provider only
-exposes one of them. Both can also be `null` for `unsupported` / `error`
-statuses. PocketShell maps `percent_remaining = R` to `used = 100 - R,
-limit = 100, unit = "percent"` so the existing progress-bar UI keeps the
-same data contract.
+Any `windows` entry may be null-percent when a provider does not expose that
+span. A canonical producer uses an empty map for `unsupported` / `error`
+statuses with no renderable span; a legacy producer can keep both source fields
+null and the host will produce that empty map. PocketShell maps
+`percent_remaining = R` to `used = 100 - R, limit = 100, unit = "percent"` so
+the existing progress-bar UI keeps the same data contract.
 
 ## Out of scope (v1)
 

--- a/scripts/test-usage-missing-window-mutation.sh
+++ b/scripts/test-usage-missing-window-mutation.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Deterministic mutation/selectivity proof for issue #2274.
+#
+# This intentionally works on a temporary copy.  The four-file implementation
+# in the worktree is never edited; the temporary source is restored before the
+# script exits, including on an unexpected failure.
+
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+PROJECT_REL="tools/pocketshell"
+SOURCE_REL="$PROJECT_REL/src/pocketshell/usage.py"
+SOURCE="$ROOT_DIR/$SOURCE_REL"
+
+SANDBOX="$(mktemp -d "/tmp/pocketshell-issue-2274-mutation.XXXXXX")"
+EVIDENCE="$SANDBOX/evidence"
+CANDIDATE="$SANDBOX/pocketshell"
+CANDIDATE_SOURCE="$CANDIDATE/src/pocketshell/usage.py"
+PRISTINE_SOURCE="$SANDBOX/usage.py.pristine"
+mkdir -p "$EVIDENCE" "$CANDIDATE"
+
+PYTHON="${POCKETSHELL_PYTHON:-$ROOT_DIR/$PROJECT_REL/.venv/bin/python}"
+if [[ ! -x "$PYTHON" ]]; then
+  PYTHON="$(command -v python3 || true)"
+fi
+
+HEAD_SHA="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+WORKTREE_SOURCE_SHA_BEFORE="$(sha256sum "$SOURCE" | awk '{print $1}')"
+WORKTREE_SOURCE_DIFF_SHA="$(git -C "$ROOT_DIR" diff --no-ext-diff -- "$SOURCE_REL" | sha256sum | awk '{print $1}')"
+
+copy_candidate() {
+  cp -a "$ROOT_DIR/$PROJECT_REL/pyproject.toml" "$CANDIDATE/"
+  cp -a "$ROOT_DIR/$PROJECT_REL/uv.lock" "$CANDIDATE/"
+  cp -a "$ROOT_DIR/$PROJECT_REL/src" "$CANDIDATE/"
+  cp -a "$ROOT_DIR/$PROJECT_REL/tests" "$CANDIDATE/"
+  cp "$SOURCE" "$PRISTINE_SOURCE"
+  cp "$PRISTINE_SOURCE" "$CANDIDATE_SOURCE"
+}
+
+RUN_NAME=""
+RUN_RC="not-run"
+run_test() {
+  RUN_NAME="$1"
+  shift
+  local log="$EVIDENCE/$RUN_NAME.log"
+  printf '%s\n' "$PYTHON -m pytest -q $*" > "$EVIDENCE/$RUN_NAME.command"
+  set +e
+  (
+    cd "$CANDIDATE"
+    PYTHONPATH="$CANDIDATE/src${PYTHONPATH:+:$PYTHONPATH}" \
+      "$PYTHON" -m pytest -q "$@"
+  ) >"$log" 2>&1
+  RUN_RC=$?
+  set -e
+  printf '%s\t%s\n' "$RUN_NAME" "$RUN_RC" >> "$EVIDENCE/rcs.tsv"
+  printf '%-32s rc=%s\n' "$RUN_NAME" "$RUN_RC"
+}
+
+require_rc() {
+  local expected="$1"
+  local label="$2"
+  if [[ "$RUN_RC" != "$expected" ]]; then
+    printf 'FAIL: %s expected rc=%s, got rc=%s\n' "$label" "$expected" "$RUN_RC" >&2
+    return 1
+  fi
+}
+
+apply_old_silent_empty_mutant() {
+  "$PYTHON" - "$CANDIDATE_SOURCE" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+anchor = '''    if "short_term" not in record and "long_term" not in record:
+        raise ValueError(
+            f"quse provider '{provider}' is missing both published window fields "
+            "'short_term' and 'long_term'"
+        )
+'''
+if text.count(anchor) != 1:
+    raise SystemExit(
+        f"expected exactly one #2274 guard block in {path}, found {text.count(anchor)}"
+    )
+
+# Exact old behavior: no missing-both-fields check, so the later loop silently
+# emits windows={} and returns a flattened record.
+mutated = text.replace(anchor, "", 1)
+if mutated == text or anchor in mutated:
+    raise SystemExit("old silent-empty mutant was not applied exactly once")
+path.write_text(mutated)
+PY
+}
+
+write_manifest() {
+  local final_rc="$1"
+  local candidate_after_restore="missing"
+  local worktree_after="missing"
+  [[ -f "$CANDIDATE_SOURCE" ]] && candidate_after_restore="$(sha256sum "$CANDIDATE_SOURCE" | awk '{print $1}')"
+  [[ -f "$SOURCE" ]] && worktree_after="$(sha256sum "$SOURCE" | awk '{print $1}')"
+  {
+    printf 'issue=2274\n'
+    printf 'proof_script=%s\n' "$ROOT_DIR/scripts/test-usage-missing-window-mutation.sh"
+    printf 'worktree=%s\n' "$ROOT_DIR"
+    printf 'head_sha=%s\n' "$HEAD_SHA"
+    printf 'source_rel=%s\n' "$SOURCE_REL"
+    printf 'worktree_source_sha_before=%s\n' "$WORKTREE_SOURCE_SHA_BEFORE"
+    printf 'worktree_source_diff_sha=%s\n' "$WORKTREE_SOURCE_DIFF_SHA"
+    printf 'candidate=%s\n' "$CANDIDATE"
+    printf 'candidate_source_sha_before=%s\n' "$(sha256sum "$PRISTINE_SOURCE" | awk '{print $1}')"
+    printf 'candidate_source_sha_mutant=%s\n' "${MUTANT_SOURCE_SHA:-not-recorded}"
+    printf 'candidate_source_sha_after_restore=%s\n' "$candidate_after_restore"
+    printf 'worktree_source_sha_after=%s\n' "$worktree_after"
+    printf 'baseline_affected_rc=%s\n' "${BASELINE_AFFECTED_RC:-not-run}"
+    printf 'baseline_control_translation_rc=%s\n' "${BASELINE_CONTROL_TRANSLATION_RC:-not-run}"
+    printf 'baseline_control_top_level_windows_rc=%s\n' "${BASELINE_CONTROL_TOP_LEVEL_RC:-not-run}"
+    printf 'mutant_affected_rc=%s\n' "${MUTANT_AFFECTED_RC:-not-run}"
+    printf 'mutant_control_translation_rc=%s\n' "${MUTANT_CONTROL_TRANSLATION_RC:-not-run}"
+    printf 'mutant_control_top_level_windows_rc=%s\n' "${MUTANT_CONTROL_TOP_LEVEL_RC:-not-run}"
+    printf 'restored_affected_rc=%s\n' "${RESTORED_AFFECTED_RC:-not-run}"
+    printf 'final_rc=%s\n' "$final_rc"
+    printf 'source_restored=%s\n' "$([[ "$candidate_after_restore" == "$WORKTREE_SOURCE_SHA_BEFORE" ]] && echo yes || echo no)"
+    printf 'worktree_unchanged=%s\n' "$([[ "$worktree_after" == "$WORKTREE_SOURCE_SHA_BEFORE" ]] && echo yes || echo no)"
+  } > "$EVIDENCE/manifest.txt"
+}
+
+BASELINE_AFFECTED_RC="not-run"
+BASELINE_CONTROL_TRANSLATION_RC="not-run"
+BASELINE_CONTROL_TOP_LEVEL_RC="not-run"
+MUTANT_SOURCE_SHA="not-recorded"
+MUTANT_AFFECTED_RC="not-run"
+MUTANT_CONTROL_TRANSLATION_RC="not-run"
+MUTANT_CONTROL_TOP_LEVEL_RC="not-run"
+RESTORED_AFFECTED_RC="not-run"
+
+on_exit() {
+  local rc=$?
+  set +e
+  if [[ -f "$PRISTINE_SOURCE" && -f "$CANDIDATE_SOURCE" ]]; then
+    cp "$PRISTINE_SOURCE" "$CANDIDATE_SOURCE"
+  fi
+  write_manifest "$rc"
+  printf 'evidence=%s\n' "$EVIDENCE"
+  exit "$rc"
+}
+trap on_exit EXIT
+
+if [[ -z "$PYTHON" || ! -x "$PYTHON" ]]; then
+  printf 'FAIL: no executable Python selected (set POCKETSHELL_PYTHON if needed)\n' >&2
+  exit 1
+fi
+"$PYTHON" -m pytest --version > "$EVIDENCE/pytest-version.txt" 2>&1
+
+copy_candidate
+candidate_clean_sha="$(sha256sum "$CANDIDATE_SOURCE" | awk '{print $1}')"
+if [[ "$candidate_clean_sha" != "$WORKTREE_SOURCE_SHA_BEFORE" ]]; then
+  printf 'FAIL: candidate source does not match the worktree source before mutation\n' >&2
+  exit 1
+fi
+
+run_test baseline_affected \
+  tests/test_usage.py::test_flatten_rejects_record_without_published_windows
+BASELINE_AFFECTED_RC="$RUN_RC"
+require_rc 0 "fixed affected test"
+
+run_test baseline_control_translation \
+  tests/test_usage.py::test_flatten_translates_published_window_labels_without_rederiving_values
+BASELINE_CONTROL_TRANSLATION_RC="$RUN_RC"
+require_rc 0 "fixed translation control"
+
+run_test baseline_control_top_level_windows \
+  tests/test_usage.py::test_flatten_rejects_unreleased_top_level_windows_schema
+BASELINE_CONTROL_TOP_LEVEL_RC="$RUN_RC"
+require_rc 0 "fixed top-level-windows control"
+
+apply_old_silent_empty_mutant
+MUTANT_SOURCE_SHA="$(sha256sum "$CANDIDATE_SOURCE" | awk '{print $1}')"
+if [[ "$MUTANT_SOURCE_SHA" == "$candidate_clean_sha" ]]; then
+  printf 'FAIL: old silent-empty mutant did not change candidate source\n' >&2
+  exit 1
+fi
+
+run_test mutant_affected \
+  tests/test_usage.py::test_flatten_rejects_record_without_published_windows
+MUTANT_AFFECTED_RC="$RUN_RC"
+require_rc 1 "old silent-empty mutant affected test"
+
+run_test mutant_control_translation \
+  tests/test_usage.py::test_flatten_translates_published_window_labels_without_rederiving_values
+MUTANT_CONTROL_TRANSLATION_RC="$RUN_RC"
+require_rc 0 "old silent-empty mutant translation control"
+
+run_test mutant_control_top_level_windows \
+  tests/test_usage.py::test_flatten_rejects_unreleased_top_level_windows_schema
+MUTANT_CONTROL_TOP_LEVEL_RC="$RUN_RC"
+require_rc 0 "old silent-empty mutant top-level-windows control"
+
+cp "$PRISTINE_SOURCE" "$CANDIDATE_SOURCE"
+restored_sha="$(sha256sum "$CANDIDATE_SOURCE" | awk '{print $1}')"
+if [[ "$restored_sha" != "$candidate_clean_sha" ]]; then
+  printf 'FAIL: candidate source did not restore to its clean hash\n' >&2
+  exit 1
+fi
+
+run_test restored_affected \
+  tests/test_usage.py::test_flatten_rejects_record_without_published_windows
+RESTORED_AFFECTED_RC="$RUN_RC"
+require_rc 0 "restored affected test"
+
+worktree_after_run="$(sha256sum "$SOURCE" | awk '{print $1}')"
+if [[ "$worktree_after_run" != "$WORKTREE_SOURCE_SHA_BEFORE" ]]; then
+  printf 'FAIL: worktree source changed during proof\n' >&2
+  exit 1
+fi
+
+printf 'PASS: mutant red (affected rc=1), controls green (translation/top-level rc=0), source restored\n'

--- a/scripts/test-usage-missing-window-mutation.sh
+++ b/scripts/test-usage-missing-window-mutation.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Deterministic mutation/selectivity proof for issue #2274.
 #
-# This intentionally works on a temporary copy.  The four-file implementation
-# in the worktree is never edited; the temporary source is restored before the
-# script exits, including on an unexpected failure.
+# This intentionally works on a temporary copy. The worktree source is never
+# edited; the temporary source is restored before the script exits, including
+# on an unexpected failure.
 
 set -Eeuo pipefail
 
@@ -65,7 +65,7 @@ require_rc() {
   fi
 }
 
-apply_old_silent_empty_mutant() {
+apply_missing_both_fields_mutant() {
   "$PYTHON" - "$CANDIDATE_SOURCE" <<'PY'
 from pathlib import Path
 import sys
@@ -74,20 +74,21 @@ path = Path(sys.argv[1])
 text = path.read_text()
 anchor = '''    if "short_term" not in record and "long_term" not in record:
         raise ValueError(
-            f"quse provider '{provider}' is missing both published window fields "
-            "'short_term' and 'long_term'"
+            f"quse provider '{provider}' is missing canonical 'windows' or both "
+            "legacy window fields 'short_term' and 'long_term'"
         )
 '''
 if text.count(anchor) != 1:
     raise SystemExit(
-        f"expected exactly one #2274 guard block in {path}, found {text.count(anchor)}"
+        f"expected exactly one #2274 missing-both guard in {path}, found {text.count(anchor)}"
     )
 
-# Exact old behavior: no missing-both-fields check, so the later loop silently
-# emits windows={} and returns a flattened record.
+# Exact regression mutant: remove the missing-both guard. The old loop then
+# silently emits an empty canonical map, while both valid producer controls
+# remain unaffected.
 mutated = text.replace(anchor, "", 1)
 if mutated == text or anchor in mutated:
-    raise SystemExit("old silent-empty mutant was not applied exactly once")
+    raise SystemExit("missing-both guard mutant was not applied exactly once")
 path.write_text(mutated)
 PY
 }
@@ -113,10 +114,10 @@ write_manifest() {
     printf 'worktree_source_sha_after=%s\n' "$worktree_after"
     printf 'baseline_affected_rc=%s\n' "${BASELINE_AFFECTED_RC:-not-run}"
     printf 'baseline_control_translation_rc=%s\n' "${BASELINE_CONTROL_TRANSLATION_RC:-not-run}"
-    printf 'baseline_control_top_level_windows_rc=%s\n' "${BASELINE_CONTROL_TOP_LEVEL_RC:-not-run}"
+    printf 'baseline_control_canonical_rc=%s\n' "${BASELINE_CONTROL_CANONICAL_RC:-not-run}"
     printf 'mutant_affected_rc=%s\n' "${MUTANT_AFFECTED_RC:-not-run}"
     printf 'mutant_control_translation_rc=%s\n' "${MUTANT_CONTROL_TRANSLATION_RC:-not-run}"
-    printf 'mutant_control_top_level_windows_rc=%s\n' "${MUTANT_CONTROL_TOP_LEVEL_RC:-not-run}"
+    printf 'mutant_control_canonical_rc=%s\n' "${MUTANT_CONTROL_CANONICAL_RC:-not-run}"
     printf 'restored_affected_rc=%s\n' "${RESTORED_AFFECTED_RC:-not-run}"
     printf 'final_rc=%s\n' "$final_rc"
     printf 'source_restored=%s\n' "$([[ "$candidate_after_restore" == "$WORKTREE_SOURCE_SHA_BEFORE" ]] && echo yes || echo no)"
@@ -126,11 +127,11 @@ write_manifest() {
 
 BASELINE_AFFECTED_RC="not-run"
 BASELINE_CONTROL_TRANSLATION_RC="not-run"
-BASELINE_CONTROL_TOP_LEVEL_RC="not-run"
+BASELINE_CONTROL_CANONICAL_RC="not-run"
 MUTANT_SOURCE_SHA="not-recorded"
 MUTANT_AFFECTED_RC="not-run"
 MUTANT_CONTROL_TRANSLATION_RC="not-run"
-MUTANT_CONTROL_TOP_LEVEL_RC="not-run"
+MUTANT_CONTROL_CANONICAL_RC="not-run"
 RESTORED_AFFECTED_RC="not-run"
 
 on_exit() {
@@ -159,7 +160,7 @@ if [[ "$candidate_clean_sha" != "$WORKTREE_SOURCE_SHA_BEFORE" ]]; then
 fi
 
 run_test baseline_affected \
-  tests/test_usage.py::test_flatten_rejects_record_without_published_windows
+  tests/test_usage.py::test_flatten_rejects_record_without_any_window_fields
 BASELINE_AFFECTED_RC="$RUN_RC"
 require_rc 0 "fixed affected test"
 
@@ -168,32 +169,32 @@ run_test baseline_control_translation \
 BASELINE_CONTROL_TRANSLATION_RC="$RUN_RC"
 require_rc 0 "fixed translation control"
 
-run_test baseline_control_top_level_windows \
-  tests/test_usage.py::test_flatten_rejects_unreleased_top_level_windows_schema
-BASELINE_CONTROL_TOP_LEVEL_RC="$RUN_RC"
-require_rc 0 "fixed top-level-windows control"
+run_test baseline_control_canonical \
+  tests/test_usage.py::test_flatten_accepts_separate_canonical_go_contract
+BASELINE_CONTROL_CANONICAL_RC="$RUN_RC"
+require_rc 0 "fixed canonical control"
 
-apply_old_silent_empty_mutant
+apply_missing_both_fields_mutant
 MUTANT_SOURCE_SHA="$(sha256sum "$CANDIDATE_SOURCE" | awk '{print $1}')"
 if [[ "$MUTANT_SOURCE_SHA" == "$candidate_clean_sha" ]]; then
-  printf 'FAIL: old silent-empty mutant did not change candidate source\n' >&2
+  printf 'FAIL: missing-both guard mutant did not change candidate source\n' >&2
   exit 1
 fi
 
 run_test mutant_affected \
-  tests/test_usage.py::test_flatten_rejects_record_without_published_windows
+  tests/test_usage.py::test_flatten_rejects_record_without_any_window_fields
 MUTANT_AFFECTED_RC="$RUN_RC"
-require_rc 1 "old silent-empty mutant affected test"
+require_rc 1 "missing-both guard mutant affected test"
 
 run_test mutant_control_translation \
   tests/test_usage.py::test_flatten_translates_published_window_labels_without_rederiving_values
 MUTANT_CONTROL_TRANSLATION_RC="$RUN_RC"
-require_rc 0 "old silent-empty mutant translation control"
+require_rc 0 "missing-both guard mutant translation control"
 
-run_test mutant_control_top_level_windows \
-  tests/test_usage.py::test_flatten_rejects_unreleased_top_level_windows_schema
-MUTANT_CONTROL_TOP_LEVEL_RC="$RUN_RC"
-require_rc 0 "old silent-empty mutant top-level-windows control"
+run_test mutant_control_canonical \
+  tests/test_usage.py::test_flatten_accepts_separate_canonical_go_contract
+MUTANT_CONTROL_CANONICAL_RC="$RUN_RC"
+require_rc 0 "missing-both guard mutant canonical control"
 
 cp "$PRISTINE_SOURCE" "$CANDIDATE_SOURCE"
 restored_sha="$(sha256sum "$CANDIDATE_SOURCE" | awk '{print $1}')"
@@ -203,7 +204,7 @@ if [[ "$restored_sha" != "$candidate_clean_sha" ]]; then
 fi
 
 run_test restored_affected \
-  tests/test_usage.py::test_flatten_rejects_record_without_published_windows
+  tests/test_usage.py::test_flatten_rejects_record_without_any_window_fields
 RESTORED_AFFECTED_RC="$RUN_RC"
 require_rc 0 "restored affected test"
 
@@ -213,4 +214,4 @@ if [[ "$worktree_after_run" != "$WORKTREE_SOURCE_SHA_BEFORE" ]]; then
   exit 1
 fi
 
-printf 'PASS: mutant red (affected rc=1), controls green (translation/top-level rc=0), source restored\n'
+printf 'PASS: missing-both mutant red (affected rc=1), legacy/canonical controls green, source restored\n'

--- a/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
+++ b/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
@@ -7,12 +7,14 @@ import java.time.Instant
 /**
  * Parser for the per-provider NDJSON produced by `pocketshell usage --json`.
  *
- * `pocketshell usage` normalizes quse's provider-keyed `--json` document into
- * newline-delimited JSON — ONE object per line per provider. Published quse
- * 0.0.14 still emits `short_term` / `long_term`; the host producer performs
- * that explicit compatibility translation, and this parser consumes the
- * resulting PocketShell wire shape. It does NOT re-derive windows / resets /
- * percentages. Each record has this fixed shape:
+ * `pocketshell usage` flattens quse's provider-keyed `--json` document into
+ * newline-delimited JSON — ONE object per line per provider. The pinned PyPI
+ * quse 0.0.14 wheel is the five-provider legacy `short_term` /
+ * `long_term` producer; the host boundary translates it and this parser
+ * consumes only the resulting canonical PocketShell wire shape. A separate
+ * canonical producer contract may add providers such as OpenCode Go. The
+ * parser does NOT re-derive windows / resets / percentages. Each record has
+ * this shape:
  *
  * ```json
  * {
@@ -29,9 +31,9 @@ import java.time.Instant
  * ```
  *
  * The top-level `windows` map carries one entry per span; the KEY IS the
- * producer's window label (`5h`, `7d`, `weekly`, `monthly`, or the explicit
- * `short_term` fallback) and is passed through verbatim. A span that does not
- * apply to the provider is omitted by the host translation. Only the `5h` entry may carry a
+ * producer's window label (`5h`, `7d`, `weekly`, `monthly`, or another
+ * provider-owned key) and is passed through verbatim. A span that does not
+ * apply to the provider is omitted from rendering. Only the `5h` entry may carry a
  * `rolling: bool`, which has no counterpart in the PocketShell window model
  * and is deliberately ignored. `status` values include `ok`, `unsupported`,
  * `error`, and `limited` / `blocked`. When `status == "error"` the `error`
@@ -43,7 +45,7 @@ import java.time.Instant
  * canonical schema.
  * Any malformed record — non-JSON line, missing `provider`, a `windows` that
  * is not an object, a null/non-object window entry, or a window with a
- * missing/null/non-numeric percentage — throws
+ * missing/non-numeric percentage — throws
  * [UsageParseException], which the caller surfaces as a whole-panel error.
  * There is no per-record skip-resilience, no old-schema alias fallback, and no
  * re-derivation: a schema mismatch fails visibly instead of silently rendering
@@ -180,13 +182,17 @@ public class PocketshellUsageJsonParser {
      * The per-window `rolling: bool` (only the `5h` entry carries it) has no
      * counterpart in the [UsageWindow] model and is deliberately ignored.
      *
-     * Returns an empty list only when the map is absent / null. THROWS
+     * The host producer requires either canonical `windows` or at least one
+     * legacy `short_term` / `long_term` field, so a producer record missing
+     * both never reaches this parser. For defensive compatibility, this parser
+     * returns an empty list when the canonical map is absent / null. THROWS
      * fail-loud (issue #1318) when `windows` is present but not an object,
      * when an entry is present but not an object, or when `percent_remaining`
-     * / `reset_at` are missing or malformed. The host producer omits
-     * published quse's non-applicable null-percentage source spans before
-     * producing this canonical map; silently skipping a null canonical value
-     * here would hide a producer/schema regression.
+     * A non-null `reset_at` must be canonical ISO-8601; an absent or null
+     * `reset_at` means that no reset time is available. A present window
+     * object with a null `percent_remaining` is a valid non-applicable span
+     * in a canonical producer record and is omitted from rendering; a present
+     * non-object entry remains a schema error.
      * There is NO `short_term` / `long_term` alias fallback here: the host
      * producer owns that compatibility translation, so reading those fields
      * in the app would silently mask a producer/schema drift.
@@ -206,11 +212,12 @@ public class PocketshellUsageJsonParser {
             }
             val obj = windowsObj.opt(key) as? JSONObject
                 ?: throw UsageParseException("'windows.$key' for $provider is not an object")
-            if (!obj.has("percent_remaining") || obj.isNull("percent_remaining")) {
+            if (!obj.has("percent_remaining")) {
                 throw UsageParseException(
-                    "'windows.$key.percent_remaining' for $provider is missing or null",
+                    "'windows.$key.percent_remaining' for $provider is missing",
                 )
             }
+            if (obj.isNull("percent_remaining")) continue
             val percentRemaining = obj.requiredNumber("percent_remaining", provider, key)
             val used = (100.0 - percentRemaining).coerceIn(0.0, 100.0)
             windows += UsageWindow(

--- a/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
+++ b/shared/core-usage/src/main/java/com/pocketshell/core/usage/PocketshellUsageJsonParser.kt
@@ -7,41 +7,49 @@ import java.time.Instant
 /**
  * Parser for the per-provider NDJSON produced by `pocketshell usage --json`.
  *
- * `pocketshell usage` flattens quse's provider-keyed `--json` document into
- * newline-delimited JSON — ONE object per line per provider. quse v0.0.9 is
- * the single source of truth for the unified schema (issue #1318, D22
- * hard-cut): the app reads quse's exact fields and does NOT re-derive windows
- * / resets / percentages. Each record has this fixed shape:
+ * `pocketshell usage` normalizes quse's provider-keyed `--json` document into
+ * newline-delimited JSON — ONE object per line per provider. Published quse
+ * 0.0.14 still emits `short_term` / `long_term`; the host producer performs
+ * that explicit compatibility translation, and this parser consumes the
+ * resulting PocketShell wire shape. It does NOT re-derive windows / resets /
+ * percentages. Each record has this fixed shape:
  *
  * ```json
  * {
  *   "provider": "claude",
  *   "status": "ok",
- *   "short_term": {"percent_remaining": 91.0, "reset_at": "2026-07-07T23:19:59Z", "window": "5h"},
- *   "long_term":  {"percent_remaining": 30.0, "reset_at": "2026-07-09T14:59:59Z", "window": "7d"},
+ *   "windows": {
+ *     "5h":      {"percent_remaining": 99.0, "reset_at": "2026-08-22T09:49:59Z", "rolling": false},
+ *     "7d":      {"percent_remaining": 96.0, "reset_at": "2026-08-27T14:59:59Z"},
+ *   },
  *   "block_reason": null,
  *   "error": null,
  *   "details": { ... ignored except documented Codex reset-credit fields ... }
  * }
  * ```
  *
- * Either `short_term` or `long_term` (or both) may be present / null. The
- * window label comes straight from `short_term.window` / `long_term.window`
- * (e.g. `5h`, `7d`, `weekly`, `monthly`, or `null` → the generic key name).
- * `status` values include `ok`, `unsupported`, `error`, and `limited` /
- * `blocked`. When `status == "error"` the `error` field carries a free-form
- * string. The app ignores `details` except for Codex
- * `reset_credits_available`, `reset_credits`, and `reset_credits_error`.
- * Windows still come only from the unified top-level fields.
+ * The top-level `windows` map carries one entry per span; the KEY IS the
+ * producer's window label (`5h`, `7d`, `weekly`, `monthly`, or the explicit
+ * `short_term` fallback) and is passed through verbatim. A span that does not
+ * apply to the provider is omitted by the host translation. Only the `5h` entry may carry a
+ * `rolling: bool`, which has no counterpart in the PocketShell window model
+ * and is deliberately ignored. `status` values include `ok`, `unsupported`,
+ * `error`, and `limited` / `blocked`. When `status == "error"` the `error`
+ * field carries a free-form string. The app ignores `details` except for
+ * Codex `reset_credits_available`, `reset_credits`, and
+ * `reset_credits_error`. Windows still come only from quse's own fields.
  *
- * STRICT / fail-loud (issue #1318): the parser expects quse's exact schema.
- * Any malformed record — non-JSON line, missing `provider`, a `short_term` /
- * `long_term` that is not an object — throws [UsageParseException], which the
- * caller surfaces as a whole-panel error. There is no per-record
- * skip-resilience, no `details.windows` alias fallback, and no re-derivation:
- * a schema mismatch fails visibly instead of silently rendering a broken
- * panel. Genuine RUNTIME states (SSH failure, quse-missing / exit != 0
- * provider-error, empty `--cached`) are handled by the caller, not here.
+ * STRICT / fail-loud (issue #1318): the parser expects the producer's exact
+ * canonical schema.
+ * Any malformed record — non-JSON line, missing `provider`, a `windows` that
+ * is not an object, a null/non-object window entry, or a window with a
+ * missing/null/non-numeric percentage — throws
+ * [UsageParseException], which the caller surfaces as a whole-panel error.
+ * There is no per-record skip-resilience, no old-schema alias fallback, and no
+ * re-derivation: a schema mismatch fails visibly instead of silently rendering
+ * a broken panel. Genuine RUNTIME states (SSH
+ * failure, quse-missing / exit != 0 provider-error, empty `--cached`) are
+ * handled by the caller, not here.
  *
  * Parsing stays app-credential-free: the app only consumes JSON already
  * fetched by a server-side command.
@@ -79,17 +87,13 @@ public class PocketshellUsageJsonParser {
         val provider = obj.requiredString("provider")
         val rawStatus = obj.optString("status", "unknown").ifBlank { "unknown" }
 
-        val windows = mutableListOf<UsageWindow>()
-        parseWindow(record = obj, jsonKey = "short_term", provider = provider)?.let { windows += it }
-        parseWindow(record = obj, jsonKey = "long_term", provider = provider)?.let { windows += it }
-
         return UsageProviderRecord(
             provider = provider,
             status = parseStatus(rawStatus),
             rawStatus = rawStatus,
             blockReason = obj.optionalString("block_reason"),
             lastError = actionableProviderError(provider, obj.optionalString("error")),
-            windows = windows,
+            windows = parseWindows(record = obj, provider = provider),
             resetCredits = parseResetCredits(record = obj, provider = provider),
         )
     }
@@ -164,47 +168,60 @@ public class PocketshellUsageJsonParser {
     }
 
     /**
-     * Convert a usage window object into a [UsageWindow]. quse reports
-     * `percent_remaining`; the PocketShell model uses `used` / `limit` in
-     * `percent` units, so `percent_remaining = R` maps to
-     * `used = 100 - R, limit = 100, unit = "percent"`.
+     * Parse the producer's canonical top-level `windows` map (issue #2274,
+     * D22 hard-cut). Each KEY is the published window label (`5h`, `7d`,
+     * `weekly`, `monthly`, …) and is passed through verbatim. Each value is
+     * `{percent_remaining, reset_at[, rolling]}`; quse reports
+     * `percent_remaining`, and the PocketShell model uses `used` / `limit` in
+     * percent units, so `percent_remaining = R` maps to
+     * `used = 100 - R, limit = 100, unit = "percent"`. The reset time comes
+     * straight from the per-window `reset_at` (canonical ISO-8601 UTC).
      *
-     * The window NAME comes straight from quse's `window` field (`5h`, `7d`,
-     * `weekly`, `monthly`, …); when quse carries no span (`window: null`) the
-     * generic key name (`short_term` / `long_term`) is used so the UI's
-     * `windowLabel` humanizes it. The reset time comes straight from the
-     * `reset_at` field (canonical ISO-8601 UTC).
+     * The per-window `rolling: bool` (only the `5h` entry carries it) has no
+     * counterpart in the [UsageWindow] model and is deliberately ignored.
      *
-     * Returns `null` when the field is absent / null on the record, or when
-     * the window carries no `percent_remaining` (some providers expose only
-     * one of short/long term). THROWS when the field is present but is not an
-     * object, or when `percent_remaining` / `reset_at` are malformed
-     * (fail-loud, issue #1318).
+     * Returns an empty list only when the map is absent / null. THROWS
+     * fail-loud (issue #1318) when `windows` is present but not an object,
+     * when an entry is present but not an object, or when `percent_remaining`
+     * / `reset_at` are missing or malformed. The host producer omits
+     * published quse's non-applicable null-percentage source spans before
+     * producing this canonical map; silently skipping a null canonical value
+     * here would hide a producer/schema regression.
+     * There is NO `short_term` / `long_term` alias fallback here: the host
+     * producer owns that compatibility translation, so reading those fields
+     * in the app would silently mask a producer/schema drift.
      */
-    private fun parseWindow(
+    private fun parseWindows(
         record: JSONObject,
-        jsonKey: String,
         provider: String,
-    ): UsageWindow? {
-        if (!record.has(jsonKey) || record.isNull(jsonKey)) return null
-        val obj = record.opt(jsonKey) as? JSONObject
-            ?: throw UsageParseException("'$jsonKey' for $provider is not an object")
+    ): List<UsageWindow> {
+        if (!record.has("windows") || record.isNull("windows")) return emptyList()
+        val windowsObj = record.opt("windows") as? JSONObject
+            ?: throw UsageParseException("'windows' for $provider is not an object")
 
-        if (!obj.has("percent_remaining") || obj.isNull("percent_remaining")) {
-            // The window object exists but carries no value (e.g. a provider
-            // that only populates one range, or an error record with null
-            // percent). Treat as absent — no renderable window.
-            return null
+        val windows = mutableListOf<UsageWindow>()
+        for (key in windowsObj.keys()) {
+            if (windowsObj.isNull(key)) {
+                throw UsageParseException("'windows.$key' for $provider is not an object")
+            }
+            val obj = windowsObj.opt(key) as? JSONObject
+                ?: throw UsageParseException("'windows.$key' for $provider is not an object")
+            if (!obj.has("percent_remaining") || obj.isNull("percent_remaining")) {
+                throw UsageParseException(
+                    "'windows.$key.percent_remaining' for $provider is missing or null",
+                )
+            }
+            val percentRemaining = obj.requiredNumber("percent_remaining", provider, key)
+            val used = (100.0 - percentRemaining).coerceIn(0.0, 100.0)
+            windows += UsageWindow(
+                name = key,
+                used = used,
+                limit = 100.0,
+                unit = "percent",
+                resetAt = obj.optionalResetInstant(),
+            )
         }
-        val percentRemaining = obj.requiredNumber("percent_remaining", provider, jsonKey)
-        val used = (100.0 - percentRemaining).coerceIn(0.0, 100.0)
-        return UsageWindow(
-            name = obj.optionalString("window") ?: jsonKey,
-            used = used,
-            limit = 100.0,
-            unit = "percent",
-            resetAt = obj.optionalResetInstant(),
-        )
+        return windows
     }
 
     private fun parseStatus(raw: String): UsageStatus = when (

--- a/shared/core-usage/src/main/java/com/pocketshell/core/usage/UsageModels.kt
+++ b/shared/core-usage/src/main/java/com/pocketshell/core/usage/UsageModels.kt
@@ -80,6 +80,7 @@ public data class UsageProviderRecord(
         get() = when (provider.lowercase()) {
             "claude" -> "Claude Code"
             "codex" -> "Codex"
+            "go" -> "OpenCode Go"
             "opencode", "open_code", "open-code" -> "OpenCode"
             "copilot", "github_copilot", "github-copilot" -> "GitHub Copilot"
             "grok", "grok-build" -> "Grok Build"

--- a/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
+++ b/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.core.usage
 
 import java.time.Instant
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
@@ -10,24 +11,34 @@ import org.junit.Test
 
 /**
  * Strict-schema parser tests (issue #1318). `pocketshell usage --json` emits
- * per-provider NDJSON flattened from quse v0.0.9's provider-keyed document;
- * quse owns the unified schema, so each record carries `status`,
- * `short_term`/`long_term` `{percent_remaining, reset_at, window}`, and
- * `error` directly. The window label comes STRAIGHT from `*.window`. The
- * parser is fail-loud: any schema drift throws (no details-window aliasing, no
- * per-record skip-resilience). The app ignores `details`.
+ * per-provider NDJSON flattened from quse's provider-keyed document; quse owns
+ * the unified schema, so each record carries `status`, a top-level `windows`
+ * map keyed by span label (`5h` / `7d` / `monthly`; issue #2274, quse 0.0.14),
+ * and `error` directly. Non-applicable null-percent spans are omitted by the
+ * host producer before this canonical wire reaches the parser; a null-percent
+ * canonical span is malformed and fails loudly. The key IS the window label.
+ * The parser is fail-loud: any schema drift throws (no details-window aliasing,
+ * no per-record skip-resilience). The app ignores
+ * `details`.
  */
 class PocketshellUsageJsonParserTest {
 
     private val parser = PocketshellUsageJsonParser()
 
-    /** The four provider records as `pocketshell usage --json` emits them,
-     * flattened from the real quse-0.0.9 output (window + ISO reset_at). */
+    /**
+     * Published quse's null-placeholder spans are handled at the host
+     * producer boundary and are not emitted on the canonical app wire.
+     */
+    private val nullSpans =
+        """"windows":{}"""
+
+    /** Four provider records in the real 0.0.14 wire shape, as `pocketshell
+     * usage --json` emits them (key-is-label + ISO reset_at + rolling on 5h). */
     private val fourProviderNdjson = listOf(
-        """{"provider":"claude","status":"ok","short_term":{"percent_remaining":91.0,"reset_at":"2026-07-07T23:19:59Z","window":"5h"},"long_term":{"percent_remaining":30.0,"reset_at":"2026-07-09T14:59:59Z","window":"7d"},"error":null,"details":{"anything":true}}""",
-        """{"provider":"codex","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":"2026-07-07T23:57:08Z","window":"5h"},"long_term":{"percent_remaining":2.0,"reset_at":"2026-07-11T06:23:55Z","window":"7d"},"error":null,"details":{}}""",
-        """{"provider":"copilot","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"long_term":{"percent_remaining":97.1,"reset_at":"2026-08-01T00:00:00Z","window":"monthly"},"error":null,"details":{}}""",
-        """{"provider":"zai","status":"ok","short_term":{"percent_remaining":58.0,"reset_at":null,"window":"5h"},"long_term":{"percent_remaining":56.0,"reset_at":"2026-07-11T14:04:58Z","window":"weekly"},"error":null,"details":{}}""",
+        """{"provider":"claude","status":"ok","windows":{"5h":{"percent_remaining":91.0,"reset_at":"2026-07-07T23:19:59Z","rolling":false},"7d":{"percent_remaining":30.0,"reset_at":"2026-07-09T14:59:59Z"}},"error":null,"details":{"anything":true}}""",
+        """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":100.0,"reset_at":"2026-07-07T23:57:08Z","rolling":false},"7d":{"percent_remaining":2.0,"reset_at":"2026-07-11T06:23:55Z"}},"error":null,"details":{}}""",
+        """{"provider":"copilot","status":"ok","windows":{"monthly":{"percent_remaining":97.1,"reset_at":"2026-08-01T00:00:00Z"}},"error":null,"details":{}}""",
+        """{"provider":"zai","status":"ok","windows":{"5h":{"percent_remaining":58.0,"reset_at":null,"rolling":true},"7d":{"percent_remaining":56.0,"reset_at":"2026-07-11T14:04:58Z"}},"error":null,"details":{}}""",
     ).joinToString("\n")
 
     @Test
@@ -37,75 +48,49 @@ class PocketshellUsageJsonParserTest {
         records.forEach { assertEquals(UsageStatus.Ok, it.status) }
 
         val claude = records[0]
-        assertEquals(2, claude.windows.size)
-        assertEquals("5h", claude.windows[0].name)
-        assertEquals(9.0, claude.windows[0].percent, 0.001) // 100 - 91
-        assertEquals(Instant.parse("2026-07-07T23:19:59Z"), claude.windows[0].resetAt)
-        assertEquals("7d", claude.windows[1].name)
-        assertEquals(70.0, claude.windows[1].percent, 0.001) // 100 - 30
-        assertEquals(Instant.parse("2026-07-09T14:59:59Z"), claude.windows[1].resetAt)
+        // The published fixture reaches this parser with only renderable
+        // windows; 5h + 7d are labeled from the canonical keys.
+        assertEquals(listOf("5h", "7d"), claude.windows.map { it.name }.sorted())
+        assertEquals(9.0, claude.windows.first { it.name == "5h" }.percent, 0.001) // 100 - 91
+        assertEquals(Instant.parse("2026-07-07T23:19:59Z"), claude.windows.first { it.name == "5h" }.resetAt)
+        assertEquals(70.0, claude.windows.first { it.name == "7d" }.percent, 0.001) // 100 - 30
+        assertEquals(Instant.parse("2026-07-09T14:59:59Z"), claude.windows.first { it.name == "7d" }.resetAt)
 
         val codex = records[1]
-        assertEquals("5h", codex.windows[0].name)
-        assertEquals("7d", codex.windows[1].name)
-        assertEquals(98.0, codex.windows[1].percent, 0.001) // 100 - 2
+        assertEquals(setOf("5h", "7d"), codex.windows.map { it.name }.toSet())
+        assertEquals(98.0, codex.windows.first { it.name == "7d" }.percent, 0.001) // 100 - 2
 
         val copilot = records[2]
-        // short_term window is null -> generic key name; long_term is monthly.
-        assertEquals("short_term", copilot.windows[0].name)
-        assertNull(copilot.windows[0].resetAt)
-        assertEquals("monthly", copilot.windows[1].name)
-        assertTrue("copilot long-term must not be framed 7d", copilot.windows[1].name != "7d")
-        assertEquals(Instant.parse("2026-08-01T00:00:00Z"), copilot.windows[1].resetAt)
+        // Null 5h/7d spans are omitted; only the real monthly span renders.
+        assertEquals("monthly", copilot.windows.single().name)
+        assertTrue(
+            "null-percent spans must not render as ghost rows",
+            copilot.windows.none { it.name == "5h" || it.name == "7d" },
+        )
+        assertEquals(2.9, copilot.windows.single().percent, 0.001) // 100 - 97.1
+        assertEquals(Instant.parse("2026-08-01T00:00:00Z"), copilot.windows.single().resetAt)
 
         val zai = records[3]
-        assertEquals("5h", zai.windows[0].name)
-        assertEquals("weekly", zai.windows[1].name)
-        assertEquals(Instant.parse("2026-07-11T14:04:58Z"), zai.windows[1].resetAt)
-    }
-
-    @Test
-    fun parse_windowLabelComesStraightFromWindowField() {
-        val record = parser.parse(
-            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0,"reset_at":"2026-05-24T15:53:01Z","window":"5h"},"long_term":{"percent_remaining":88.0,"reset_at":"2026-05-30T20:33:54Z","window":"7d"},"error":null,"details":{}}""",
-        ).single()
-
-        val shortTerm = record.windows[0]
-        assertEquals("5h", shortTerm.name)
-        assertEquals(23.0, shortTerm.used, 0.001)
-        assertEquals(100.0, shortTerm.limit, 0.001)
-        assertEquals("percent", shortTerm.unit)
-        assertEquals(Instant.parse("2026-05-24T15:53:01Z"), shortTerm.resetAt)
-        assertEquals("7d", record.windows[1].name)
-    }
-
-    @Test
-    fun parse_nullWindow_fallsBackToGenericKeyName() {
-        val record = parser.parse(
-            """{"provider":"zai","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"long_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"error":null,"details":{}}""",
-        ).single()
-
-        assertEquals("short_term", record.windows[0].name)
-        assertEquals("long_term", record.windows[1].name)
+        // zai's weekly cadence renders under quse's unified "7d" key.
+        assertEquals(setOf("5h", "7d"), zai.windows.map { it.name }.toSet())
+        assertEquals(44.0, zai.windows.first { it.name == "7d" }.percent, 0.001) // 100 - 56
+        assertEquals(Instant.parse("2026-07-11T14:04:58Z"), zai.windows.first { it.name == "7d" }.resetAt)
     }
 
     @Test
     fun parse_codexNo5hWindow_rendersWeeklyOnly_noPhantom5h_noGhostRow() {
-        // #1564 regression: Codex temporarily removed its 5h window, so quse
-        // 0.0.11 now emits Codex's `primary_window` (the WEEKLY 604800s span)
-        // in `short_term` labeled from its real `limit_window_seconds` → "7d"
-        // (NOT the old positional "5h"), and the DROPPED window as a null
-        // placeholder (`long_term.percent_remaining == null`). The maintainer's
-        // v0.4.33 symptom was a "5h window · 53% · resets in 5 days" (weekly
-        // data under a 5h label) plus a "7d window · 0% · unavailable" GHOST.
+        // #1564 regression, 0.0.14 shape (issue #2274): Codex temporarily
+        // removed its 5h window, so its weekly span renders under the unified
+        // "7d" key. The host producer omits the null-percent source span.
+        // The maintainer's v0.4.33 symptom was a "5h window · 53% · resets in
+        // 5 days" (weekly data under a 5h label) plus a "7d window · 0% ·
+        // unavailable" GHOST.
         //
-        // This is the app-side load-bearing assertion for the acceptance
-        // criteria: the parser must render the WEEKLY window labeled "7d" (no
-        // phantom 5h) and OMIT the null-percent dropped window (no ghost row).
-        // If the parser stopped omitting null-percent windows this test goes
-        // red (a 2nd ghost window would appear).
+        // This is the app-side load-bearing assertion: the parser must render
+        // the WEEKLY window labeled "7d" (no phantom 5h), with no malformed
+        // null-percent canonical entry present.
         val codexNo5hNdjson =
-            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":69.0,"reset_at":"2026-07-21T20:37:32Z","window":"7d"},"long_term":{"percent_remaining":null,"reset_at":null,"window":null},"error":null,"details":{}}"""
+            """{"provider":"codex","status":"ok","windows":{"7d":{"percent_remaining":69.0,"reset_at":"2026-07-21T20:37:32Z"}},"error":null,"details":{}}"""
         val record = parser.parse(codexNo5hNdjson).single()
 
         // Exactly ONE renderable window — the dropped 5h is omitted (no ghost).
@@ -116,49 +101,12 @@ class PocketshellUsageJsonParserTest {
         assertTrue("Codex weekly window must not be mislabeled 5h", weekly.name != "5h")
         assertEquals(31.0, weekly.percent, 0.001) // 100 - 69
         assertEquals(Instant.parse("2026-07-21T20:37:32Z"), weekly.resetAt)
-        // No ghost "0% / unavailable" (null-reset) row survived: the only
-        // window has a real reset time.
+        // No ghost "0% / unavailable" row survived: the only window has a
+        // real reset time.
         assertTrue(
             "the dropped Codex window must not render as a ghost row",
             record.windows.all { it.resetAt != null },
         )
-    }
-
-    @Test
-    fun parse_quse0011FullDocument_codexFixedButOtherCardsUnchanged() {
-        // #1564 class coverage: the quse 0.0.11 Codex window fix must NOT
-        // regress the other provider cards. Feeds all four providers exactly as
-        // `pocketshell usage --json` flattens quse 0.0.11 and asserts Claude
-        // (5h + 7d), Copilot (monthly), and zai (5h + weekly) are unchanged
-        // while Codex renders weekly-only.
-        val quse0011Ndjson = listOf(
-            """{"provider":"claude","status":"ok","short_term":{"percent_remaining":82.0,"reset_at":"2026-07-15T11:39:59Z","window":"5h"},"long_term":{"percent_remaining":5.0,"reset_at":"2026-07-16T14:59:59Z","window":"7d"},"error":null,"details":{}}""",
-            """{"provider":"codex","status":"ok","short_term":{"percent_remaining":69.0,"reset_at":"2026-07-21T20:37:32Z","window":"7d"},"long_term":{"percent_remaining":null,"reset_at":null,"window":null},"error":null,"details":{}}""",
-            """{"provider":"copilot","status":"ok","short_term":{"percent_remaining":100.0,"reset_at":null,"window":null},"long_term":{"percent_remaining":97.1,"reset_at":"2026-08-01T00:00:00Z","window":"monthly"},"error":null,"details":{}}""",
-            """{"provider":"zai","status":"ok","short_term":{"percent_remaining":99.0,"reset_at":null,"window":"5h"},"long_term":{"percent_remaining":75.0,"reset_at":"2026-07-18T14:04:58Z","window":"weekly"},"error":null,"details":{}}""",
-        ).joinToString("\n")
-        val records = parser.parse(quse0011Ndjson)
-        val byProvider = records.associateBy { it.provider }
-
-        // Claude: 5h + 7d, both real resets — unchanged.
-        val claude = byProvider.getValue("claude")
-        assertEquals(2, claude.windows.size)
-        assertEquals("5h", claude.windows[0].name)
-        assertEquals("7d", claude.windows[1].name)
-
-        // Codex: weekly-only, labeled "7d", no ghost.
-        val codex = byProvider.getValue("codex")
-        assertEquals(1, codex.windows.size)
-        assertEquals("7d", codex.windows.single().name)
-
-        // Copilot: monthly window unchanged (short_term null window omitted-or-generic).
-        val copilot = byProvider.getValue("copilot")
-        assertEquals("monthly", copilot.windows.last().name)
-
-        // zai: 5h + weekly unchanged.
-        val zai = byProvider.getValue("zai")
-        assertEquals("5h", zai.windows[0].name)
-        assertEquals("weekly", zai.windows[1].name)
     }
 
     @Test
@@ -170,13 +118,15 @@ class PocketshellUsageJsonParserTest {
     }
 
     @Test
-    fun parse_weeklyOnlyGrok_rendersWeeklyWindow_displayNameIsGrokBuild() {
-        // #2195 live quse 0.0.13 shape: null short_term, weekly long_term.
-        // Null short_term must not throw. used = 100 - percent_remaining.
+    fun parse_weeklyOnlyGrok_rendersUnified7dWindow_displayNameIsGrokBuild() {
+        // #2195 live quse shape (0.0.14 form, issue #2274): only the weekly
+        // span carries a value, under the unified "7d" key; the host producer
+        // omits the null-percent 5h/monthly placeholders. used =
+        // 100 - percent_remaining.
         // displayName MUST be "Grok Build" — generic title-case "Grok" is a
         // G6 miss (reverting the explicit mapping reddens this).
         val record = parser.parse(
-            """{"provider":"grok","status":"ok","short_term":{"percent_remaining":null,"reset_at":null,"window":null},"long_term":{"percent_remaining":95.0,"reset_at":"2026-08-25T00:08:17Z","window":"weekly"},"error":null,"details":{"subscription":"SuperGrokPlus"}}""",
+            """{"provider":"grok","status":"ok","windows":{"7d":{"percent_remaining":95.0,"reset_at":"2026-08-25T00:08:17Z"}},"error":null,"details":{"subscription":"SuperGrokPlus"}}""",
         ).single()
 
         assertEquals("grok", record.provider)
@@ -187,7 +137,7 @@ class PocketshellUsageJsonParserTest {
         )
         assertEquals(1, record.windows.size)
         val weekly = record.windows.single()
-        assertEquals("weekly", weekly.name)
+        assertEquals("7d", weekly.name)
         assertEquals(5.0, weekly.percent, 0.001) // 100 - 95
         assertEquals(Instant.parse("2026-08-25T00:08:17Z"), weekly.resetAt)
     }
@@ -195,33 +145,32 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_grokBuildAlias_displayNameIsGrokBuild() {
         val record = parser.parse(
-            """{"provider":"grok-build","status":"ok","short_term":null,"long_term":{"percent_remaining":95.0,"reset_at":null,"window":"weekly"},"error":null,"details":{}}""",
+            """{"provider":"grok-build","status":"ok","windows":{"7d":{"percent_remaining":95.0,"reset_at":null}},"error":null,"details":{}}""",
         ).single()
         assertEquals("Grok Build", record.displayName)
     }
 
     @Test
-    fun parse_grokBothWindows_weeklyShortAndMonthlyLong() {
+    fun parse_grokBothWindows_unified7dAndMonthlyLabels() {
         val record = parser.parse(
-            """{"provider":"grok","status":"ok","short_term":{"percent_remaining":62.5,"reset_at":"2026-08-25T00:08:17Z","window":"weekly"},"long_term":{"percent_remaining":75.0,"reset_at":"2026-09-01T00:00:00Z","window":"monthly"},"error":null,"details":{}}""",
+            """{"provider":"grok","status":"ok","windows":{"7d":{"percent_remaining":62.5,"reset_at":"2026-08-25T00:08:17Z"},"monthly":{"percent_remaining":75.0,"reset_at":"2026-09-01T00:00:00Z"}},"error":null,"details":{}}""",
         ).single()
 
         assertEquals("Grok Build", record.displayName)
-        assertEquals(2, record.windows.size)
-        assertEquals("weekly", record.windows[0].name)
-        assertEquals(37.5, record.windows[0].percent, 0.001) // 100 - 62.5
-        assertEquals(Instant.parse("2026-08-25T00:08:17Z"), record.windows[0].resetAt)
-        assertEquals("monthly", record.windows[1].name)
-        assertEquals(25.0, record.windows[1].percent, 0.001) // 100 - 75
-        assertEquals(Instant.parse("2026-09-01T00:00:00Z"), record.windows[1].resetAt)
+        assertEquals(setOf("7d", "monthly"), record.windows.map { it.name }.toSet())
+        assertEquals(37.5, record.windows.first { it.name == "7d" }.percent, 0.001) // 100 - 62.5
+        assertEquals(Instant.parse("2026-08-25T00:08:17Z"), record.windows.first { it.name == "7d" }.resetAt)
+        assertEquals("monthly", record.windows.first { it.name == "monthly" }.name)
+        assertEquals(25.0, record.windows.first { it.name == "monthly" }.percent, 0.001) // 100 - 75
+        assertEquals(Instant.parse("2026-09-01T00:00:00Z"), record.windows.first { it.name == "monthly" }.resetAt)
     }
 
     @Test
-    fun parse_grokNullPercentsOnBothWindows_recordExistsNoThrow() {
-        // A grok record with null percents on both windows must still parse
-        // (zero renderable windows) and must not fail the whole panel.
+    fun parse_grokWithNoRenderableWindows_recordExistsNoThrow() {
+        // The producer may explicitly emit an empty canonical map when a
+        // provider has no renderable source span; that is not schema drift.
         val record = parser.parse(
-            """{"provider":"grok","status":"ok","short_term":{"percent_remaining":null,"reset_at":null,"window":null},"long_term":{"percent_remaining":null,"reset_at":null,"window":null},"error":null,"details":{}}""",
+            """{"provider":"grok","status":"ok",$nullSpans,"error":null,"details":{}}""",
         ).single()
 
         assertEquals("grok", record.provider)
@@ -233,7 +182,7 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_grokNoCredentials_mapsToActionableSignInError() {
         val record = parser.parse(
-            """{"provider":"grok","status":"error","short_term":null,"long_term":null,"error":"no-credentials","details":{}}""",
+            """{"provider":"grok","status":"error",$nullSpans,"error":"no-credentials","details":{}}""",
         ).single()
 
         assertEquals(UsageStatus.Error, record.status)
@@ -250,7 +199,7 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_grokAuthJsonMissing_mapsToActionableSignInError() {
         val record = parser.parse(
-            """{"provider":"grok","status":"error","short_term":null,"long_term":null,"error":"grok auth.json not found","details":{}}""",
+            """{"provider":"grok","status":"error",$nullSpans,"error":"grok auth.json not found","details":{}}""",
         ).single()
 
         assertEquals(UsageStatus.Error, record.status)
@@ -267,7 +216,7 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_unsupportedStatus_forGemini() {
         val record = parser.parse(
-            """{"provider":"gemini","status":"unsupported","short_term":null,"long_term":null,"error":"gemini does not expose a usage endpoint","details":{}}""",
+            """{"provider":"gemini","status":"unsupported",$nullSpans,"error":"gemini does not expose a usage endpoint","details":{}}""",
         ).single()
 
         assertEquals(UsageStatus.Unsupported, record.status)
@@ -278,7 +227,7 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_errorStatus_surfacesErrorField() {
         val record = parser.parse(
-            """{"provider":"codex","status":"error","short_term":null,"long_term":null,"error":"login required: run codex login","details":{}}""",
+            """{"provider":"codex","status":"error",$nullSpans,"error":"login required: run codex login","details":{}}""",
         ).single()
 
         assertEquals(UsageStatus.Error, record.status)
@@ -289,7 +238,7 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_claudeUnauthorizedMapsToActionableError() {
         val record = parser.parse(
-            """{"provider":"claude","status":"error","short_term":{"percent_remaining":null,"reset_at":null},"long_term":{"percent_remaining":null,"reset_at":null},"error":"HTTP Error 401: Unauthorized","details":{}}""",
+            """{"provider":"claude","status":"error",$nullSpans,"error":"HTTP Error 401: Unauthorized","details":{}}""",
         ).single()
 
         assertEquals(UsageStatus.Error, record.status)
@@ -299,14 +248,14 @@ class PocketshellUsageJsonParserTest {
             record.lastError,
         )
         assertTrue(record.lastError?.contains("HTTP Error 401", ignoreCase = true) == false)
-        // percent_remaining null on both windows -> no renderable windows.
+        // An empty canonical map yields no renderable windows.
         assertTrue(record.windows.isEmpty())
     }
 
     @Test
     fun parse_blockedStatus_mapsToBlockedExceededRecord() {
         val record = parser.parse(
-            """{"provider":"codex","status":"quota-exhausted","short_term":null,"long_term":null,"block_reason":"Codex quota exhausted","error":null,"details":{"message":"quota exhausted"}}""",
+            """{"provider":"codex","status":"quota-exhausted",$nullSpans,"block_reason":"Codex quota exhausted","error":null,"details":{"message":"quota exhausted"}}""",
         ).single()
 
         assertEquals(UsageStatus.Blocked, record.status)
@@ -320,8 +269,8 @@ class PocketshellUsageJsonParserTest {
     fun parse_multipleNdjsonLines() {
         val records = parser.parse(
             """
-            {"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"error":null,"details":{}}
-            {"provider":"claude","status":"limited","short_term":{"percent_remaining":0.0},"long_term":null,"block_reason":"weekly limit reached","error":null,"details":{}}
+            {"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":50.0}},"error":null,"details":{}}
+            {"provider":"claude","status":"limited","windows":{"5h":{"percent_remaining":0.0}},"block_reason":"weekly limit reached","error":null,"details":{}}
             """.trimIndent(),
         )
         assertEquals(2, records.size)
@@ -334,7 +283,7 @@ class PocketshellUsageJsonParserTest {
     fun parse_skipsBlankLines() {
         val records = parser.parse(
             "\n\n" +
-                """{"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"error":null,"details":{}}""" +
+                """{"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":77.0}},"error":null,"details":{}}""" +
                 "\n\n",
         )
         assertEquals(1, records.size)
@@ -349,10 +298,208 @@ class PocketshellUsageJsonParserTest {
     @Test
     fun parse_preservesUnknownStatus() {
         val record = parser.parse(
-            """{"provider":"x","status":"maintenance","short_term":null,"long_term":null,"error":null,"details":{}}""",
+            """{"provider":"x","status":"maintenance",$nullSpans,"error":null,"details":{}}""",
         ).single()
         assertEquals(UsageStatus.Unknown, record.status)
         assertEquals("maintenance", record.rawStatus)
+    }
+
+    // -- issue #2274: published quse 0.0.14 -> app wire normalization --------
+
+    /**
+     * The REAL captured quse-0.0.14 `--json` document from the published
+     * wheel (same file as tools/pocketshell/tests/data/quse-0.0.14-usage.json).
+     */
+    private fun quse0014Document(): org.json.JSONObject {
+        val bytes = javaClass.getResourceAsStream("/quse-0.0.14-usage.json")?.readBytes()
+            ?: throw AssertionError("missing quse-0.0.14-usage.json test resource")
+        return org.json.JSONObject(bytes.decodeToString())
+    }
+
+    /** Apply the host producer's published short/long -> canonical windows
+     * translation, then inject each key as a top-level `provider`. */
+    private fun flattenProviderKeyed(doc: org.json.JSONObject): String = buildString {
+        for (key in doc.keys()) {
+            val line = org.json.JSONObject(doc.getJSONObject(key).toString())
+            val windows = org.json.JSONObject()
+            for (sourceKey in listOf("short_term", "long_term")) {
+                if (!line.has(sourceKey) || line.isNull(sourceKey)) continue
+                val sourceWindow = line.getJSONObject(sourceKey)
+                // Match the host producer: a published null percentage means
+                // that source span is unavailable, so it is omitted before
+                // canonical parser input is formed.
+                if (sourceWindow.isNull("percent_remaining")) continue
+                val label = if (sourceWindow.isNull("window")) {
+                    sourceKey
+                } else {
+                    sourceWindow.getString("window")
+                }
+                windows.put(
+                    label,
+                    org.json.JSONObject()
+                        .put("percent_remaining", sourceWindow.get("percent_remaining"))
+                        .put("reset_at", sourceWindow.get("reset_at")),
+                )
+            }
+            line.remove("short_term")
+            line.remove("long_term")
+            line.put("windows", windows)
+            line.put("provider", key)
+            append(line.toString())
+            append('\n')
+        }
+    }
+
+    private fun windowOf(record: UsageProviderRecord, name: String): UsageWindow =
+        record.windows.firstOrNull { it.name == name }
+            ?: throw AssertionError(
+                "record for ${record.provider} has no '$name' window " +
+                    "(windows=${record.windows.map { it.name }}) — silent-empty?",
+            )
+
+    @Test
+    fun parse_quse0014PublishedCapture_rendersCanonicalWindowsForAllFiveProviders() {
+        val records = parser.parse(flattenProviderKeyed(quse0014Document()))
+        val byProvider = records.associateBy { it.provider }
+
+        // The published 0.0.14 release has five providers; the unreleased
+        // a86959e `go` provider is deliberately absent.
+        assertEquals(
+            setOf("claude", "codex", "copilot", "grok", "zai"),
+            byProvider.keys,
+        )
+        records.forEach { assertEquals(UsageStatus.Ok, it.status) }
+
+        // claude: 5h + 7d renderable; monthly is a null-percent span → omitted.
+        val claude = byProvider.getValue("claude")
+        assertEquals(listOf("5h", "7d"), claude.windows.map { it.name }.sorted())
+        assertEquals(1.0, windowOf(claude, "5h").percent, 0.001) // 100 - 99
+        assertEquals(Instant.parse("2026-08-22T15:49:59Z"), windowOf(claude, "5h").resetAt)
+        assertEquals(7.0, windowOf(claude, "7d").percent, 0.001) // 100 - 93
+        assertEquals(Instant.parse("2026-08-27T14:59:59Z"), windowOf(claude, "7d").resetAt)
+
+        // codex: weekly-only renderable — its 5h span carries null percent and
+        // must be omitted (no ghost row), same semantics as the 0.0.11 era.
+        val codex = byProvider.getValue("codex")
+        assertEquals(listOf("7d"), codex.windows.map { it.name })
+        assertEquals(44.0, windowOf(codex, "7d").percent, 0.001) // 100 - 56
+        assertEquals(Instant.parse("2026-08-27T03:30:22Z"), windowOf(codex, "7d").resetAt)
+
+        // copilot: the published short-term span has a 100% value and no
+        // label, so the producer uses the generic short_term key alongside
+        // the real monthly window.
+        val copilot = byProvider.getValue("copilot")
+        assertEquals(listOf("monthly", "short_term"), copilot.windows.map { it.name }.sorted())
+        assertEquals(0.0, windowOf(copilot, "monthly").percent, 0.001) // 100 - 100
+        assertEquals(Instant.parse("2026-09-01T00:00:00Z"), windowOf(copilot, "monthly").resetAt)
+
+        // grok: the published provider-owned weekly label remains weekly.
+        val grok = byProvider.getValue("grok")
+        assertEquals(listOf("weekly"), grok.windows.map { it.name })
+        assertEquals(100.0, windowOf(grok, "weekly").percent, 0.001) // 100 - 0
+        assertTrue("grok at 100% used must read blocked", grok.isBlocked)
+
+        // zai: 5h + weekly.
+        val zai = byProvider.getValue("zai")
+        assertEquals(setOf("5h", "weekly"), zai.windows.map { it.name }.toSet())
+        assertEquals(100.0, windowOf(zai, "weekly").percent, 0.001) // 100 - 0
+    }
+
+    @Test
+    fun parse_quse0014CanonicalWindows_keyIsLabel_producerOmittedNullSpan() {
+        val record = parser.parse(
+            """{"provider":"claude","status":"ok","windows":{"5h":{"percent_remaining":99.0,"reset_at":"2026-08-22T09:49:59Z","rolling":true},"7d":{"percent_remaining":96.0,"reset_at":"2026-08-27T14:59:59Z"}},"error":null,"details":{}}""",
+        ).single()
+
+        assertEquals(2, record.windows.size)
+        val fiveHour = record.windows.first { it.name == "5h" }
+        // The producer's canonical map key is the window label.
+        assertEquals("5h", fiveHour.name)
+        assertEquals(1.0, fiveHour.used, 0.001) // 100 - 99
+        assertEquals(100.0, fiveHour.limit, 0.001)
+        assertEquals("percent", fiveHour.unit)
+        assertEquals(Instant.parse("2026-08-22T09:49:59Z"), fiveHour.resetAt)
+        assertEquals(4.0, record.windows.first { it.name == "7d" }.percent, 0.001)
+        // Extra producer metadata such as rolling is ignored by the app model.
+    }
+
+    @Test
+    fun parse_quse0014AbsentWindowsField_yieldsZeroRenderableWindows_noThrow() {
+        // An absent / null top-level `windows` means "no renderable window"
+        // (unchanged absent-data semantics) — NOT a panel-failing throw.
+        val absent = parser.parse(
+            """{"provider":"x","status":"ok","error":null,"details":{}}""",
+        ).single()
+        val explicitNull = parser.parse(
+            """{"provider":"x","status":"ok","windows":null,"error":null,"details":{}}""",
+        ).single()
+        assertTrue(absent.windows.isEmpty())
+        assertTrue(explicitNull.windows.isEmpty())
+    }
+
+    @Test
+    fun parse_quse0014NonObjectWindows_failsLoud() {
+        val error = assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """{"provider":"x","status":"ok","windows":"drifted","error":null,"details":{}}""",
+            )
+        }
+        assertTrue(error.message!!.contains("windows"))
+        assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """{"provider":"x","status":"ok","windows":{"5h":"not-an-object"},"error":null,"details":{}}""",
+            )
+        }
+    }
+
+    @Test
+    fun parse_quse0014NullWindowEntry_failsLoud_insteadOfSkippingIt() {
+        val error = assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """{"provider":"x","status":"ok","windows":{"5h":null},"error":null,"details":{}}""",
+            )
+        }
+        assertTrue(error.message!!.contains("windows.5h"))
+    }
+
+    @Test
+    fun parse_quse0014NullPercentWindowEntry_failsLoud_insteadOfSkippingIt() {
+        val error = assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """{"provider":"x","status":"ok","windows":{"5h":{"percent_remaining":null,"reset_at":null}},"error":null,"details":{}}""",
+            )
+        }
+        assertTrue(error.message!!.contains("windows.5h.percent_remaining"))
+    }
+
+    @Test
+    fun parse_quse0014MalformedPercentOrResetInWindow_failsLoud() {
+        assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """{"provider":"x","status":"ok","windows":{"5h":{"percent_remaining":"not-a-number"}},"error":null,"details":{}}""",
+            )
+        }
+        val error = assertThrows(UsageParseException::class.java) {
+            parser.parse(
+                """{"provider":"x","status":"ok","windows":{"5h":{"percent_remaining":50.0,"reset_at":"not-a-date"}},"error":null,"details":{}}""",
+            )
+        }
+        assertTrue(error.message!!.contains("reset_at"))
+    }
+
+    @Test
+    fun parse_quse0014CodexResetCredits_realDetailsShapeParsesWithExactMatchInvariant() {
+        // Fix-shape item: verify the real 0.0.14 `{expires_at, status, title}`
+        // entry shape against the live capture, including the
+        // availableCount == exact-available rows invariant (mismatch throws).
+        val codex = parser.parse(flattenProviderKeyed(quse0014Document()))
+            .single { it.provider == "codex" }
+        val credits = requireNotNull(codex.resetCredits)
+        assertFalse(credits.unavailable)
+        assertEquals(1, credits.availableCount)
+        assertEquals(1, credits.credits.size)
+        assertEquals("Full reset", credits.credits.single().title)
+        assertEquals(Instant.parse("2026-09-21T00:13:17Z"), credits.credits.single().expiresAt)
     }
 
     // -- fail-loud on schema mismatch (issue #1318: no skip-resilience) ------
@@ -367,20 +514,10 @@ class PocketshellUsageJsonParserTest {
     }
 
     @Test
-    fun parse_rejectsNonObjectWindowField() {
-        val error = assertThrows(UsageParseException::class.java) {
-            parser.parse(
-                """{"provider":"x","status":"ok","short_term":"not an object","long_term":null,"error":null,"details":{}}""",
-            )
-        }
-        assertTrue(error.message!!.contains("short_term"))
-    }
-
-    @Test
     fun parse_rejectsMissingProvider() {
         assertThrows(UsageParseException::class.java) {
             parser.parse(
-                """{"status":"ok","short_term":null,"long_term":null,"error":null,"details":{}}""",
+                """{"status":"ok",$nullSpans,"error":null,"details":{}}""",
             )
         }
     }
@@ -394,8 +531,8 @@ class PocketshellUsageJsonParserTest {
         val error = assertThrows(UsageParseException::class.java) {
             parser.parse(
                 """
-                {"provider":"codex","status":"ok","short_term":{"percent_remaining":77.0},"long_term":null,"error":null,"details":{}}
-                {"status":"ok","short_term":"not-an-object","long_term":null,"error":null,"details":{}}
+                {"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":77.0}},"error":null,"details":{}}
+                {"status":"ok","windows":"not-an-object","error":null,"details":{}}
                 """.trimIndent(),
             )
         }
@@ -410,19 +547,9 @@ class PocketshellUsageJsonParserTest {
             parser.parse(
                 """
                 WARNING: pocketshell 0.3.1 is deprecated
-                {"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0},"long_term":null,"error":null,"details":{}}
+                {"provider":"codex","status":"ok","windows":{"5h":{"percent_remaining":50.0}},"error":null,"details":{}}
                 """.trimIndent(),
             )
         }
-    }
-
-    @Test
-    fun parse_rejectsMalformedResetAt() {
-        val error = assertThrows(UsageParseException::class.java) {
-            parser.parse(
-                """{"provider":"codex","status":"ok","short_term":{"percent_remaining":50.0,"reset_at":"not-a-date"},"long_term":null,"error":null,"details":{}}""",
-            )
-        }
-        assertTrue(error.message!!.contains("reset_at"))
     }
 }

--- a/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
+++ b/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageJsonParserTest.kt
@@ -11,15 +11,14 @@ import org.junit.Test
 
 /**
  * Strict-schema parser tests (issue #1318). `pocketshell usage --json` emits
- * per-provider NDJSON flattened from quse's provider-keyed document; quse owns
- * the unified schema, so each record carries `status`, a top-level `windows`
- * map keyed by span label (`5h` / `7d` / `monthly`; issue #2274, quse 0.0.14),
- * and `error` directly. Non-applicable null-percent spans are omitted by the
- * host producer before this canonical wire reaches the parser; a null-percent
- * canonical span is malformed and fails loudly. The key IS the window label.
- * The parser is fail-loud: any schema drift throws (no details-window aliasing,
- * no per-record skip-resilience). The app ignores
- * `details`.
+ * per-provider NDJSON flattened from quse's provider-keyed document. The
+ * published quse 0.0.14 wheel is legacy `short_term` / `long_term`; the host
+ * producer translates it before this parser sees canonical top-level
+ * `windows`. A separate canonical producer contract may include providers such
+ * as OpenCode Go. The key IS the window label. Non-applicable null-percent
+ * spans are non-renderable and omitted; malformed entries still fail loudly.
+ * The parser is fail-loud for schema drift (no details-window aliasing, no
+ * per-record skip-resilience). The app ignores `details`.
  */
 class PocketshellUsageJsonParserTest {
 
@@ -71,7 +70,8 @@ class PocketshellUsageJsonParserTest {
         assertEquals(Instant.parse("2026-08-01T00:00:00Z"), copilot.windows.single().resetAt)
 
         val zai = records[3]
-        // zai's weekly cadence renders under quse's unified "7d" key.
+        // zai's weekly cadence reaches the app under the producer's canonical
+        // "7d" key.
         assertEquals(setOf("5h", "7d"), zai.windows.map { it.name }.toSet())
         assertEquals(44.0, zai.windows.first { it.name == "7d" }.percent, 0.001) // 100 - 56
         assertEquals(Instant.parse("2026-07-11T14:04:58Z"), zai.windows.first { it.name == "7d" }.resetAt)
@@ -406,27 +406,30 @@ class PocketshellUsageJsonParserTest {
     }
 
     @Test
-    fun parse_quse0014CanonicalWindows_keyIsLabel_producerOmittedNullSpan() {
+    fun parse_separateCanonicalGoContract_preservesWindowLabels() {
         val record = parser.parse(
-            """{"provider":"claude","status":"ok","windows":{"5h":{"percent_remaining":99.0,"reset_at":"2026-08-22T09:49:59Z","rolling":true},"7d":{"percent_remaining":96.0,"reset_at":"2026-08-27T14:59:59Z"}},"error":null,"details":{}}""",
+            """{"provider":"go","status":"ok","windows":{"5h":{"percent_remaining":97.0,"reset_at":"2026-08-22T11:21:36Z","rolling":true},"monthly":{"percent_remaining":94.0,"reset_at":"2026-09-22T06:20:28Z"}},"error":null,"details":{"max_used_percent":3.0}}""",
         ).single()
 
+        assertEquals("go", record.provider)
+        assertEquals("OpenCode Go", record.displayName)
         assertEquals(2, record.windows.size)
         val fiveHour = record.windows.first { it.name == "5h" }
-        // The producer's canonical map key is the window label.
+        // The separate canonical producer's map key is the window label.
         assertEquals("5h", fiveHour.name)
-        assertEquals(1.0, fiveHour.used, 0.001) // 100 - 99
+        assertEquals(3.0, fiveHour.used, 0.001) // 100 - 97
         assertEquals(100.0, fiveHour.limit, 0.001)
         assertEquals("percent", fiveHour.unit)
-        assertEquals(Instant.parse("2026-08-22T09:49:59Z"), fiveHour.resetAt)
-        assertEquals(4.0, record.windows.first { it.name == "7d" }.percent, 0.001)
+        assertEquals(Instant.parse("2026-08-22T11:21:36Z"), fiveHour.resetAt)
+        assertEquals(6.0, record.windows.first { it.name == "monthly" }.percent, 0.001)
         // Extra producer metadata such as rolling is ignored by the app model.
     }
 
     @Test
-    fun parse_quse0014AbsentWindowsField_yieldsZeroRenderableWindows_noThrow() {
-        // An absent / null top-level `windows` means "no renderable window"
-        // (unchanged absent-data semantics) — NOT a panel-failing throw.
+    fun parse_defensivelyTreatsAbsentWindowsAsZeroRenderableRows() {
+        // The producer boundary rejects a record missing both canonical and
+        // legacy window fields. The parser remains defensive for custom or
+        // already-normalized input and treats an absent/null map as no rows.
         val absent = parser.parse(
             """{"provider":"x","status":"ok","error":null,"details":{}}""",
         ).single()
@@ -463,13 +466,12 @@ class PocketshellUsageJsonParserTest {
     }
 
     @Test
-    fun parse_quse0014NullPercentWindowEntry_failsLoud_insteadOfSkippingIt() {
-        val error = assertThrows(UsageParseException::class.java) {
-            parser.parse(
-                """{"provider":"x","status":"ok","windows":{"5h":{"percent_remaining":null,"reset_at":null}},"error":null,"details":{}}""",
-            )
-        }
-        assertTrue(error.message!!.contains("windows.5h.percent_remaining"))
+    fun parse_nullPercentWindowEntry_isNonRenderable_insteadOfGhostRow() {
+        val record = parser.parse(
+            """{"provider":"x","status":"ok","windows":{"5h":{"percent_remaining":null,"reset_at":null},"7d":{"percent_remaining":75.0,"reset_at":null}},"error":null,"details":{}}""",
+        ).single()
+        assertEquals(listOf("7d"), record.windows.map { it.name })
+        assertEquals(25.0, record.windows.single().percent, 0.001)
     }
 
     @Test

--- a/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageResetCreditsTest.kt
+++ b/shared/core-usage/src/test/java/com/pocketshell/core/usage/PocketshellUsageResetCreditsTest.kt
@@ -338,8 +338,9 @@ class PocketshellUsageResetCreditsTest {
             {
               "provider":"$provider",
               "status":"ok",
-              "short_term":{"percent_remaining":69.0,"reset_at":"$resetAt","window":"7d"},
-              "long_term":null,
+              "windows":{
+                "7d":{"percent_remaining":69.0,"reset_at":"$resetAt"}
+              },
               "block_reason":null,
               "error":null
               $detailsField

--- a/shared/core-usage/src/test/resources/quse-0.0.14-usage.json
+++ b/shared/core-usage/src/test/resources/quse-0.0.14-usage.json
@@ -1,0 +1,184 @@
+{
+  "claude": {
+    "details": {
+      "limit_reached": false,
+      "subscription": null,
+      "windows": {
+        "five_hour": {
+          "reset_at": "2026-08-22T15:49:59Z",
+          "used_percent": 1.0
+        },
+        "seven_day": {
+          "reset_at": "2026-08-27T14:59:59Z",
+          "used_percent": 7.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 93.0,
+      "reset_at": "2026-08-27T14:59:59Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": 99.0,
+      "reset_at": "2026-08-22T15:49:59Z",
+      "window": "5h"
+    },
+    "status": "ok"
+  },
+  "codex": {
+    "details": {
+      "limit_reached": false,
+      "reset_credits": [
+        {
+          "expires_at": "2026-09-21T00:13:17Z",
+          "status": "available",
+          "title": "Full reset"
+        }
+      ],
+      "reset_credits_available": 1,
+      "reset_credits_error": null,
+      "windows": {
+        "primary_window": {
+          "limit_window_seconds": 604800,
+          "present": true,
+          "reset_at": "2026-08-27T03:30:22Z",
+          "used_percent": 44.0
+        },
+        "secondary_window": {
+          "limit_window_seconds": null,
+          "present": false,
+          "reset_at": null,
+          "used_percent": 0.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 56.0,
+      "reset_at": "2026-08-27T03:30:22Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": null,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "copilot": {
+    "details": {
+      "limit_reached": false,
+      "premium_entitlement": 1500,
+      "premium_percent_remaining": 100.0,
+      "premium_remaining": 1500
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 100.0,
+      "reset_at": "2026-09-01T00:00:00Z",
+      "window": "monthly"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "grok": {
+    "details": {
+      "has_grok_code_access": true,
+      "is_unified_billing_user": true,
+      "limit_reached": true,
+      "on_demand_cap": 0.0,
+      "on_demand_used": 0.0,
+      "prepaid_balance": 0.0,
+      "product_usage": [
+        {
+          "product": "GrokBuild",
+          "usage_percent": 100.0
+        }
+      ],
+      "resets": [
+        {
+          "expires_at": "2026-09-12T18:49:00Z",
+          "token_id": "restok_vpYDqo"
+        }
+      ],
+      "resets_available": 1,
+      "resets_error": null,
+      "subscription": "SuperGrokPlus",
+      "windows": {
+        "monthly": {
+          "limit": null,
+          "present": false,
+          "reset_at": null,
+          "used": null,
+          "used_percent": null
+        },
+        "weekly": {
+          "limit": 0.0,
+          "present": true,
+          "reset_at": "2026-08-25T00:08:17Z",
+          "used": 0.0,
+          "used_percent": 100.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 0.0,
+      "reset_at": "2026-08-25T00:08:17Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": null,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "zai": {
+    "details": {
+      "limit_reached": true,
+      "max_used_percent": 100.0,
+      "windows": {
+        "five_hour": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": null,
+          "used_percent": 0.0,
+          "window_hours": 5
+        },
+        "monthly_web_search": {
+          "limit": 4000,
+          "remaining": 3971,
+          "reset_at": "2026-08-27T14:04:58Z",
+          "used_percent": 1.0,
+          "window_hours": 5
+        },
+        "weekly": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": "2026-08-24T14:04:58Z",
+          "used_percent": 100.0,
+          "window_hours": null
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 0.0,
+      "reset_at": "2026-08-24T14:04:58Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": "5h"
+    },
+    "status": "ok"
+  }
+}

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -36,16 +36,16 @@ dependencies = [
     "click>=8.2.0",
     # Usage backend + single source of truth for the unified provider schema
     # (issue #1318). Pinned exactly: `pocketshell usage --json` expects quse's
-    # provider-keyed `--json` document (per provider: status +
-    # short_term/long_term {percent_remaining, reset_at, window} + error) and
-    # fails loudly on any schema drift, so the version is frozen, not a range.
-    # 0.0.13 (#2195): adds the `grok` provider (alias `grok-build`) so
-    # `pocketshell usage --json` can emit Grok Build quota. 0.0.11 (#1564)
-    # still matters historically: it labels each Codex window from its actual
-    # `limit_window_seconds` instead of assuming primary==5h / secondary==7d,
-    # and omits a window Codex drops (`present: false`) as a null placeholder
-    # rather than a phantom "0% / unavailable" ghost row.
-    "quse==0.0.13",
+    # provider-keyed `--json` document and fails loudly on any schema drift,
+    # so the version is frozen, not a range. 0.0.14 (#2274): the per-provider
+    # `short_term` / `long_term` fields are REPLACED by one unified top-level
+    # `windows` map whose keys ARE the window labels (`5h` / `7d` /
+    # `monthly`, null percent_remaining for spans that don't apply), plus a
+    # new `go` (OpenCode Go) provider. The Android parser reads exactly that
+    # shape — no alias fallback. 0.0.13 (#2195) historically added the `grok`
+    # provider; 0.0.11 (#1564) labeled each Codex window from its actual
+    # `limit_window_seconds`.
+    "quse==0.0.14",
     # FCM HTTP v1 push delivery (#690): service-account OAuth2 bearer minting
     # for `pocketshell push` / the `usage --capture` reset-push send. Imported
     # lazily and fail-soft — a host without it (or without a Firebase
@@ -109,6 +109,13 @@ exclude = [
     "/.venv",
     "/dist",
 ]
+
+[tool.uv]
+# Keep the lockfile's reproducibility cutoff project-local. The host may have
+# a rolling global `exclude-newer` policy that predates a deliberately pinned
+# release (quse 0.0.14 was uploaded 2026-08-20); this exact value is also the
+# `uv.lock` options cutoff and must be used when checking this lock.
+exclude-newer = "2026-08-20T22:00:00Z"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -36,14 +36,16 @@ dependencies = [
     "click>=8.2.0",
     # Usage backend + single source of truth for the unified provider schema
     # (issue #1318). Pinned exactly: `pocketshell usage --json` expects quse's
-    # provider-keyed `--json` document and fails loudly on any schema drift,
-    # so the version is frozen, not a range. The published 0.0.14 (#2274)
-    # wheel retains the per-provider `short_term` / `long_term` fields. The
-    # PocketShell boundary translates those records into the app's canonical
-    # `windows` map; 0.0.14 does not publish a top-level `windows` schema or a
-    # `go` provider. 0.0.13 (#2195) historically added the `grok` provider;
-    # 0.0.11 (#1564) labeled each Codex window from its actual
-    # `limit_window_seconds`.
+    # provider-keyed `--json` document and fails loudly on schema drift, so the
+    # version is frozen, not a range. The published 0.0.14 wheel is the
+    # five-provider legacy shape with `short_term` / `long_term` records. The
+    # host boundary translates those records into canonical `windows`; it also
+    # accepts a separate top-level `windows` producer contract for newer or
+    # custom producers, without treating that shape as PyPI 0.0.14 provenance.
+    # Canonical-only providers such as OpenCode Go belong to that separate
+    # contract, not to the published-wheel provider list. 0.0.13 (#2195)
+    # historically added the `grok` provider; 0.0.11 (#1564) labeled each
+    # Codex window from its actual `limit_window_seconds`.
     "quse==0.0.14",
     # FCM HTTP v1 push delivery (#690): service-account OAuth2 bearer minting
     # for `pocketshell push` / the `usage --capture` reset-push send. Imported

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -37,13 +37,12 @@ dependencies = [
     # Usage backend + single source of truth for the unified provider schema
     # (issue #1318). Pinned exactly: `pocketshell usage --json` expects quse's
     # provider-keyed `--json` document and fails loudly on any schema drift,
-    # so the version is frozen, not a range. 0.0.14 (#2274): the per-provider
-    # `short_term` / `long_term` fields are REPLACED by one unified top-level
-    # `windows` map whose keys ARE the window labels (`5h` / `7d` /
-    # `monthly`, null percent_remaining for spans that don't apply), plus a
-    # new `go` (OpenCode Go) provider. The Android parser reads exactly that
-    # shape — no alias fallback. 0.0.13 (#2195) historically added the `grok`
-    # provider; 0.0.11 (#1564) labeled each Codex window from its actual
+    # so the version is frozen, not a range. The published 0.0.14 (#2274)
+    # wheel retains the per-provider `short_term` / `long_term` fields. The
+    # PocketShell boundary translates those records into the app's canonical
+    # `windows` map; 0.0.14 does not publish a top-level `windows` schema or a
+    # `go` provider. 0.0.13 (#2195) historically added the `grok` provider;
+    # 0.0.11 (#1564) labeled each Codex window from its actual
     # `limit_window_seconds`.
     "quse==0.0.14",
     # FCM HTTP v1 push delivery (#690): service-account OAuth2 bearer minting

--- a/tools/pocketshell/src/pocketshell/usage.py
+++ b/tools/pocketshell/src/pocketshell/usage.py
@@ -4,13 +4,16 @@ Implementation delegates to the **pinned** `quse` CLI via `subprocess.run`
 and normalizes its provider-keyed `--json` document into the per-provider
 NDJSON the Android app consumes. Human output is proxied verbatim.
 
-The published `quse==0.0.14` contract is the old provider-keyed object with
-`short_term` / `long_term` records. PocketShell owns the narrow wire-format
-translation at this boundary: it injects the provider name and maps those
-two published records into the app's canonical `windows` map. It does not
-re-derive quota values, resets, or provider-specific details. A schema
-mismatch (non-JSON / non-object payload, malformed published window, or an
-unreleased top-level `windows` producer) raises loudly rather than silently
+The pinned PyPI `quse==0.0.14` contract is a five-provider, provider-keyed
+object whose records carry legacy `short_term` / `long_term` windows. PocketShell
+owns the narrow producer-boundary translation: it injects the provider name and
+maps those records to the canonical `windows` map consumed by Android. A
+separate canonical producer contract is also accepted for newer or custom host
+producers that already emit a top-level `windows` map; that support does not
+change the published-wheel provenance or claim OpenCode Go for the pinned
+wheel. The Android parser never reads the legacy fields. A schema mismatch
+(non-JSON / non-object payload, malformed window container, or missing both
+canonical and legacy window fields) raises loudly rather than silently
 emptying the panel.
 
 quse is a hard dependency of pocketshell (see `pyproject.toml`), so its
@@ -175,27 +178,34 @@ def _actionable_error(provider: str, error: Any) -> Optional[str]:
     return text
 
 
-def _canonicalize_published_quse_record(
+def _canonicalize_quse_record(
     provider: str,
     record: dict[str, Any],
 ) -> dict[str, Any]:
-    """Translate one published quse 0.0.14 record to the app wire shape.
+    """Normalize one provider record at the PocketShell producer boundary.
 
-    The PyPI release still emits ``short_term`` / ``long_term``. Keep that
-    compatibility mapping explicit and local to the producer boundary; the
-    Android parser consumes only the canonical ``windows`` map. A top-level
-    ``windows`` field is deliberately rejected because it identifies the
-    unreleased quse commit that must not be treated as published output.
+    The pinned PyPI wheel uses the legacy ``short_term`` / ``long_term`` shape;
+    that translation is deliberately confined to this host boundary. Newer or
+    custom producers may already provide canonical ``windows`` records, which
+    are passed through verbatim. Neither branch re-derives provider values,
+    reset times, or labels. A provider must provide one of those two shapes.
     """
     if "windows" in record:
-        raise ValueError(
-            f"quse provider '{provider}' emitted unsupported top-level 'windows' "
-            "schema; published quse 0.0.14 uses short_term/long_term"
-        )
+        windows = record["windows"]
+        if not isinstance(windows, dict):
+            raise ValueError(
+                f"quse provider '{provider}' top-level 'windows' is not a JSON object"
+            )
+        if "short_term" in record or "long_term" in record:
+            raise ValueError(
+                f"quse provider '{provider}' mixes canonical 'windows' with "
+                "legacy short_term/long_term fields"
+            )
+        return {"provider": provider, **record}
     if "short_term" not in record and "long_term" not in record:
         raise ValueError(
-            f"quse provider '{provider}' is missing both published window fields "
-            "'short_term' and 'long_term'"
+            f"quse provider '{provider}' is missing canonical 'windows' or both "
+            "legacy window fields 'short_term' and 'long_term'"
         )
 
     windows: dict[str, dict[str, Any]] = {}
@@ -216,11 +226,10 @@ def _canonicalize_published_quse_record(
             raise ValueError(
                 f"quse provider '{provider}' field '{source_key}' is missing reset_at"
             )
-        # Published quse represents a span that does not apply to a provider
-        # with a null percentage. It is not a valid app-wire window, so omit
-        # it explicitly at this compatibility boundary. The Android parser
-        # remains strict for canonical input and rejects the same null value
-        # if a producer emits it instead of doing this translation.
+        # Legacy quse represents a span that does not apply to a provider with
+        # a null percentage. Omit it at this compatibility boundary; canonical
+        # producers may retain that source span and the Android parser omits
+        # its non-renderable row.
         if source_window["percent_remaining"] is None:
             continue
         label = source_window.get("window") or source_key
@@ -245,16 +254,17 @@ def _canonicalize_published_quse_record(
 
 
 def normalize_usage_stdout(stdout: str) -> str:
-    """Normalize published quse's provider-keyed object into per-provider NDJSON.
+    """Flatten quse's provider-keyed object into per-provider NDJSON.
 
-    Published ``quse==0.0.14`` emits one JSON object keyed by provider; each
-    value carries ``short_term`` / ``long_term`` records. This function injects
-    the provider key and performs the one explicit compatibility translation to
-    the app-facing ``windows`` map. It never invents percentages or reset times
-    and never accepts the unreleased six-provider/top-level-``windows`` shape.
+    Published `quse==0.0.14` records use legacy ``short_term`` /
+    ``long_term`` fields and receive the one explicit producer-boundary
+    translation to the app-facing ``windows`` map. A separate canonical
+    top-level ``windows`` producer record passes through unchanged. This
+    function never invents percentages or reset times, and Android receives
+    only the canonical map.
 
     Strict / fail-loud: non-JSON stdout, a non-object top-level payload, a
-    non-object provider value, or malformed published window fields all raise
+    non-object provider value, or malformed producer window fields all raise
     ``ValueError`` so a schema mismatch fails visibly instead of silently
     emptying the usage panel. Empty/blank stdout passes through untouched (the
     caller decides what an empty read means).
@@ -277,7 +287,7 @@ def normalize_usage_stdout(stdout: str) -> str:
                 f"quse --json provider '{provider}' is not a JSON object "
                 f"(got {type(record).__name__})"
             )
-        flattened = _canonicalize_published_quse_record(provider, record)
+        flattened = _canonicalize_quse_record(provider, record)
         if flattened.get("error") is not None:
             flattened["error"] = _actionable_error(provider, flattened["error"])
         lines.append(json.dumps(flattened, sort_keys=True))

--- a/tools/pocketshell/src/pocketshell/usage.py
+++ b/tools/pocketshell/src/pocketshell/usage.py
@@ -1,15 +1,17 @@
 """`pocketshell usage` subcommand.
 
 Implementation delegates to the **pinned** `quse` CLI via `subprocess.run`
-and FLATTENS its provider-keyed `--json` document into the per-provider
+and normalizes its provider-keyed `--json` document into the per-provider
 NDJSON the Android app consumes. Human output is proxied verbatim.
 
-quse is the single source of truth for the unified schema (issue #1318,
-D22 hard-cut): pocketshell does NOT re-derive windows / resets / percentages
-downstream. It parses quse's provider-keyed object, injects the `provider`
-name from each key, and passes quse's unified fields through unchanged. A
-schema mismatch (non-JSON / non-object payload) raises loudly rather than
-silently emptying the panel.
+The published `quse==0.0.14` contract is the old provider-keyed object with
+`short_term` / `long_term` records. PocketShell owns the narrow wire-format
+translation at this boundary: it injects the provider name and maps those
+two published records into the app's canonical `windows` map. It does not
+re-derive quota values, resets, or provider-specific details. A schema
+mismatch (non-JSON / non-object payload, malformed published window, or an
+unreleased top-level `windows` producer) raises loudly rather than silently
+emptying the panel.
 
 quse is a hard dependency of pocketshell (see `pyproject.toml`), so its
 console-script ships in the SAME bin directory as the running interpreter.
@@ -173,24 +175,84 @@ def _actionable_error(provider: str, error: Any) -> Optional[str]:
     return text
 
 
+def _canonicalize_published_quse_record(
+    provider: str,
+    record: dict[str, Any],
+) -> dict[str, Any]:
+    """Translate one published quse 0.0.14 record to the app wire shape.
+
+    The PyPI release still emits ``short_term`` / ``long_term``. Keep that
+    compatibility mapping explicit and local to the producer boundary; the
+    Android parser consumes only the canonical ``windows`` map. A top-level
+    ``windows`` field is deliberately rejected because it identifies the
+    unreleased quse commit that must not be treated as published output.
+    """
+    if "windows" in record:
+        raise ValueError(
+            f"quse provider '{provider}' emitted unsupported top-level 'windows' "
+            "schema; published quse 0.0.14 uses short_term/long_term"
+        )
+
+    windows: dict[str, dict[str, Any]] = {}
+    for source_key in ("short_term", "long_term"):
+        if source_key not in record or record[source_key] is None:
+            continue
+        source_window = record[source_key]
+        if not isinstance(source_window, dict):
+            raise ValueError(
+                f"quse provider '{provider}' field '{source_key}' is not a JSON object"
+            )
+        if "percent_remaining" not in source_window:
+            raise ValueError(
+                f"quse provider '{provider}' field '{source_key}' is missing "
+                "percent_remaining"
+            )
+        if "reset_at" not in source_window:
+            raise ValueError(
+                f"quse provider '{provider}' field '{source_key}' is missing reset_at"
+            )
+        # Published quse represents a span that does not apply to a provider
+        # with a null percentage. It is not a valid app-wire window, so omit
+        # it explicitly at this compatibility boundary. The Android parser
+        # remains strict for canonical input and rejects the same null value
+        # if a producer emits it instead of doing this translation.
+        if source_window["percent_remaining"] is None:
+            continue
+        label = source_window.get("window") or source_key
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError(
+                f"quse provider '{provider}' field '{source_key}' has an invalid window label"
+            )
+        if label in windows:
+            raise ValueError(
+                f"quse provider '{provider}' has duplicate window label '{label}'"
+            )
+        windows[label] = {
+            "percent_remaining": source_window["percent_remaining"],
+            "reset_at": source_window["reset_at"],
+        }
+
+    flattened: dict[str, Any] = {"provider": provider, **record}
+    flattened.pop("short_term", None)
+    flattened.pop("long_term", None)
+    flattened["windows"] = windows
+    return flattened
+
+
 def normalize_usage_stdout(stdout: str) -> str:
-    """Flatten quse's provider-keyed `--json` object into per-provider NDJSON.
+    """Normalize published quse's provider-keyed object into per-provider NDJSON.
 
-    quse v0.0.9 emits ONE JSON object keyed by provider name; each value is
-    the unified per-provider record (``status`` / ``short_term`` /
-    ``long_term`` / ``error`` / ``details``). This is a THIN flatten — one
-    NDJSON line per provider — that injects the provider name (from the
-    object key) as a top-level ``provider`` field and passes quse's unified
-    fields through unchanged. quse is the single source of truth for the
-    schema (D22): pocketshell does NOT re-derive windows / resets /
-    percentages here.
+    Published ``quse==0.0.14`` emits one JSON object keyed by provider; each
+    value carries ``short_term`` / ``long_term`` records. This function injects
+    the provider key and performs the one explicit compatibility translation to
+    the app-facing ``windows`` map. It never invents percentages or reset times
+    and never accepts the unreleased six-provider/top-level-``windows`` shape.
 
-    Strict / fail-loud: non-JSON stdout, a non-object top-level payload, or a
-    non-object provider value all raise ``ValueError`` so a schema mismatch
-    fails visibly instead of silently emptying the usage panel. Handles both
-    the multi-provider and single-provider (``{"<p>": {...}}``) shapes — both
-    are provider-keyed objects. Empty/blank stdout passes through untouched
-    (the caller decides what an empty read means).
+    Strict / fail-loud: non-JSON stdout, a non-object top-level payload, a
+    non-object provider value, or malformed published window fields all raise
+    ``ValueError`` so a schema mismatch fails visibly instead of silently
+    emptying the usage panel. Empty/blank stdout passes through untouched (the
+    caller decides what an empty read means).
     """
     if not stdout.strip():
         return stdout
@@ -210,7 +272,7 @@ def normalize_usage_stdout(stdout: str) -> str:
                 f"quse --json provider '{provider}' is not a JSON object "
                 f"(got {type(record).__name__})"
             )
-        flattened: dict[str, Any] = {"provider": provider, **record}
+        flattened = _canonicalize_published_quse_record(provider, record)
         if flattened.get("error") is not None:
             flattened["error"] = _actionable_error(provider, flattened["error"])
         lines.append(json.dumps(flattened, sort_keys=True))

--- a/tools/pocketshell/src/pocketshell/usage.py
+++ b/tools/pocketshell/src/pocketshell/usage.py
@@ -192,6 +192,11 @@ def _canonicalize_published_quse_record(
             f"quse provider '{provider}' emitted unsupported top-level 'windows' "
             "schema; published quse 0.0.14 uses short_term/long_term"
         )
+    if "short_term" not in record and "long_term" not in record:
+        raise ValueError(
+            f"quse provider '{provider}' is missing both published window fields "
+            "'short_term' and 'long_term'"
+        )
 
     windows: dict[str, dict[str, Any]] = {}
     for source_key in ("short_term", "long_term"):

--- a/tools/pocketshell/src/pocketshell/usage_reset.py
+++ b/tools/pocketshell/src/pocketshell/usage_reset.py
@@ -18,8 +18,9 @@ foundation only.
 What counts as a reset
 ----------------------
 
-For each provider, and each window (``short_term`` / ``long_term``), we
-compare the previous reading to the current one:
+For each provider, and each entry of PocketShell's canonical ``windows`` map
+(the keys are the producer-normalized window labels), we compare the previous
+reading to the current one:
 
 1. **Usage dropped back toward baseline.** ``percent_remaining`` jumped UP
    by at least :data:`RESET_RECOVERY_THRESHOLD` percentage points (e.g.
@@ -68,10 +69,8 @@ from pathlib import Path
 from typing import Any, Optional
 
 from pocketshell.usage_capture import (
-    NEW_FILE_MODE,
     UsagePaths,
     _append_history,
-    _write_private,
     resolve_paths,
 )
 
@@ -88,10 +87,6 @@ RESET_RECOVERY_THRESHOLD = 30.0
 DEFAULT_RESET_EVENTS_MAX_LINES = 500
 
 RESET_EVENTS_FILENAME = "usage-reset-events.jsonl"
-
-# The windows we inspect on each provider record, in the app-facing schema
-# written by ``normalize_usage_record``.
-_WINDOWS = ("short_term", "long_term")
 
 
 def reset_events_file(paths: UsagePaths) -> Path:
@@ -114,10 +109,25 @@ def _parse_iso(value: Any) -> Optional[datetime]:
 
 
 def _window_obj(record: Any, window: str) -> Optional[dict[str, Any]]:
+    """Return the record's window object for ``window`` (a ``windows``-map
+    key), or ``None`` when absent / not an object."""
     if not isinstance(record, dict):
         return None
-    obj = record.get(window)
+    windows = record.get("windows")
+    if not isinstance(windows, dict):
+        return None
+    obj = windows.get(window)
     return obj if isinstance(obj, dict) else None
+
+
+def _window_names(record: Any) -> list[str]:
+    """The window labels present on a record's unified ``windows`` map."""
+    if not isinstance(record, dict):
+        return []
+    windows = record.get("windows")
+    if not isinstance(windows, dict):
+        return []
+    return [name for name, obj in windows.items() if isinstance(obj, dict)]
 
 
 def _records_by_provider(cache: Optional[dict[str, Any]]) -> dict[str, dict[str, Any]]:
@@ -147,9 +157,10 @@ def _detect_window_reset(
 ) -> Optional[dict[str, Any]]:
     """Return a reset event dict for one provider+window, or ``None``.
 
-    ``previous``/``current`` are the window objects (``short_term`` etc.)
-    from the previous and current readings. A reset is flagged when usage
-    recovered toward baseline OR a new window boundary started.
+    ``previous``/``current`` are the window objects (entries of the record's
+    unified ``windows`` map) from the previous and current readings. A reset
+    is flagged when usage recovered toward baseline OR a new window boundary
+    started.
     """
     prev_pct = previous.get("percent_remaining")
     cur_pct = current.get("percent_remaining")
@@ -254,7 +265,9 @@ def detect_resets(
         prev_record = prev_by_provider.get(provider)
         if prev_record is None:
             continue
-        for window in _WINDOWS:
+        # The producer-normalized map keys are the window labels; compare
+        # like-for-like by label.
+        for window in _window_names(cur_record):
             prev_window = _window_obj(prev_record, window)
             cur_window = _window_obj(cur_record, window)
             if prev_window is None or cur_window is None:

--- a/tools/pocketshell/tests/data/quse-0.0.14-usage.json
+++ b/tools/pocketshell/tests/data/quse-0.0.14-usage.json
@@ -1,0 +1,184 @@
+{
+  "claude": {
+    "details": {
+      "limit_reached": false,
+      "subscription": null,
+      "windows": {
+        "five_hour": {
+          "reset_at": "2026-08-22T15:49:59Z",
+          "used_percent": 1.0
+        },
+        "seven_day": {
+          "reset_at": "2026-08-27T14:59:59Z",
+          "used_percent": 7.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 93.0,
+      "reset_at": "2026-08-27T14:59:59Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": 99.0,
+      "reset_at": "2026-08-22T15:49:59Z",
+      "window": "5h"
+    },
+    "status": "ok"
+  },
+  "codex": {
+    "details": {
+      "limit_reached": false,
+      "reset_credits": [
+        {
+          "expires_at": "2026-09-21T00:13:17Z",
+          "status": "available",
+          "title": "Full reset"
+        }
+      ],
+      "reset_credits_available": 1,
+      "reset_credits_error": null,
+      "windows": {
+        "primary_window": {
+          "limit_window_seconds": 604800,
+          "present": true,
+          "reset_at": "2026-08-27T03:30:22Z",
+          "used_percent": 44.0
+        },
+        "secondary_window": {
+          "limit_window_seconds": null,
+          "present": false,
+          "reset_at": null,
+          "used_percent": 0.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 56.0,
+      "reset_at": "2026-08-27T03:30:22Z",
+      "window": "7d"
+    },
+    "short_term": {
+      "percent_remaining": null,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "copilot": {
+    "details": {
+      "limit_reached": false,
+      "premium_entitlement": 1500,
+      "premium_percent_remaining": 100.0,
+      "premium_remaining": 1500
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 100.0,
+      "reset_at": "2026-09-01T00:00:00Z",
+      "window": "monthly"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "grok": {
+    "details": {
+      "has_grok_code_access": true,
+      "is_unified_billing_user": true,
+      "limit_reached": true,
+      "on_demand_cap": 0.0,
+      "on_demand_used": 0.0,
+      "prepaid_balance": 0.0,
+      "product_usage": [
+        {
+          "product": "GrokBuild",
+          "usage_percent": 100.0
+        }
+      ],
+      "resets": [
+        {
+          "expires_at": "2026-09-12T18:49:00Z",
+          "token_id": "restok_vpYDqo"
+        }
+      ],
+      "resets_available": 1,
+      "resets_error": null,
+      "subscription": "SuperGrokPlus",
+      "windows": {
+        "monthly": {
+          "limit": null,
+          "present": false,
+          "reset_at": null,
+          "used": null,
+          "used_percent": null
+        },
+        "weekly": {
+          "limit": 0.0,
+          "present": true,
+          "reset_at": "2026-08-25T00:08:17Z",
+          "used": 0.0,
+          "used_percent": 100.0
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 0.0,
+      "reset_at": "2026-08-25T00:08:17Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": null,
+      "reset_at": null,
+      "window": null
+    },
+    "status": "ok"
+  },
+  "zai": {
+    "details": {
+      "limit_reached": true,
+      "max_used_percent": 100.0,
+      "windows": {
+        "five_hour": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": null,
+          "used_percent": 0.0,
+          "window_hours": 5
+        },
+        "monthly_web_search": {
+          "limit": 4000,
+          "remaining": 3971,
+          "reset_at": "2026-08-27T14:04:58Z",
+          "used_percent": 1.0,
+          "window_hours": 5
+        },
+        "weekly": {
+          "limit": null,
+          "remaining": null,
+          "reset_at": "2026-08-24T14:04:58Z",
+          "used_percent": 100.0,
+          "window_hours": null
+        }
+      }
+    },
+    "error": null,
+    "long_term": {
+      "percent_remaining": 0.0,
+      "reset_at": "2026-08-24T14:04:58Z",
+      "window": "weekly"
+    },
+    "short_term": {
+      "percent_remaining": 100.0,
+      "reset_at": null,
+      "window": "5h"
+    },
+    "status": "ok"
+  }
+}

--- a/tools/pocketshell/tests/data/quse-0.0.14-usage.provenance.txt
+++ b/tools/pocketshell/tests/data/quse-0.0.14-usage.provenance.txt
@@ -1,0 +1,18 @@
+Fixture provenance for quse==0.0.14 (issue #2274)
+
+Source package: the PyPI wheel quse-0.0.14-py3-none-any.whl
+PyPI upload: 2026-08-20T06:28:18Z
+Wheel SHA-256: 7b99a3db422f2a370a0786445c7ab89215b9a93174e63802913d83f8f1dd1b76
+
+Capture command (using the published wheel, not a checkout):
+  PYTHONPATH=<unpacked quse-0.0.14 wheel> <python> -c \
+    'from quse.cli import main; raise SystemExit(main(["--json"]))'
+
+Observed published contract:
+  providers: claude, codex, copilot, grok, zai
+  record fields: details, error, long_term, short_term, status
+  no top-level windows map and no go provider
+
+The host producer explicitly translates the published short_term/long_term
+records into PocketShell's app-facing windows map. Commit a86959e (the
+unreleased unified Go/top-level-windows producer) is not used by this fixture.

--- a/tools/pocketshell/tests/test_daemon.py
+++ b/tools/pocketshell/tests/test_daemon.py
@@ -321,7 +321,11 @@ def test_two_concurrent_clients_cache_hit_is_faster(
     """
     fake_bin = tmp_path / "bin"
     python_exe = _fake_python_bin(fake_bin)
-    payload = '{"codex": {"status": "ok"}}\n'
+    payload = (
+        '{"codex": {"status": "ok", '
+        '"short_term": {"percent_remaining": null, "reset_at": null, "window": null}, '
+        '"long_term": {"percent_remaining": null, "reset_at": null, "window": null}}}\n'
+    )
     # The daemon flattens the provider-keyed payload into NDJSON before
     # caching; the cold and warm responses both carry this flattened form.
     flattened = '{"provider": "codex", "status": "ok", "windows": {}}\n'
@@ -395,7 +399,9 @@ def test_no_cache_param_bypasses_cache(
         f"n=$(cat {counter_file})\n"
         "n=$((n+1))\n"
         f'echo "$n" > {counter_file}\n'
-        'printf \'{"x": {"status": "ok", "call": %s}}\\n\' "$n"\n'
+        'printf \'{"x": {"status": "ok", "call": %s, '
+        '"short_term": {"percent_remaining": null, "reset_at": null, "window": null}, '
+        '"long_term": {"percent_remaining": null, "reset_at": null, "window": null}}}\\n\' "$n"\n'
     )
     script.chmod(0o755)
 
@@ -511,8 +517,16 @@ def test_no_daemon_flag_skips_daemon_probe(
     fake_bin.mkdir()
     # Provider names encode the source so the flattened NDJSON reveals which
     # path answered (issue #1318: provider-keyed payloads).
-    daemon_payload = '{"fromdaemon": {"status": "ok"}}\n'
-    subprocess_payload = '{"fromsubprocess": {"status": "ok"}}\n'
+    daemon_payload = (
+        '{"fromdaemon": {"status": "ok", '
+        '"short_term": {"percent_remaining": null, "reset_at": null, "window": null}, '
+        '"long_term": {"percent_remaining": null, "reset_at": null, "window": null}}}\n'
+    )
+    subprocess_payload = (
+        '{"fromsubprocess": {"status": "ok", '
+        '"short_term": {"percent_remaining": null, "reset_at": null, "window": null}, '
+        '"long_term": {"percent_remaining": null, "reset_at": null, "window": null}}}\n'
+    )
     _write_fake_quse(fake_bin, payload=subprocess_payload)
 
     # Spin up a daemon that returns a different payload so we can
@@ -553,8 +567,16 @@ def test_usage_uses_daemon_by_default(
     """Without ``--no-daemon`` the CLI must dispatch via the daemon."""
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
-    daemon_payload = '{"fromdaemon": {"status": "ok"}}\n'
-    subprocess_payload = '{"fromsubprocess": {"status": "ok"}}\n'
+    daemon_payload = (
+        '{"fromdaemon": {"status": "ok", '
+        '"short_term": {"percent_remaining": null, "reset_at": null, "window": null}, '
+        '"long_term": {"percent_remaining": null, "reset_at": null, "window": null}}}\n'
+    )
+    subprocess_payload = (
+        '{"fromsubprocess": {"status": "ok", '
+        '"short_term": {"percent_remaining": null, "reset_at": null, "window": null}, '
+        '"long_term": {"percent_remaining": null, "reset_at": null, "window": null}}}\n'
+    )
     _write_fake_quse(fake_bin, payload=subprocess_payload)
 
     daemon_bin = tmp_path / "daemon_bin"
@@ -588,7 +610,11 @@ def test_usage_falls_through_when_daemon_absent(
     """No daemon socket on disk => CLI must use the subprocess path."""
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
-    payload = '{"fromsubprocess": {"status": "ok"}}\n'
+    payload = (
+        '{"fromsubprocess": {"status": "ok", '
+        '"short_term": {"percent_remaining": null, "reset_at": null, "window": null}, '
+        '"long_term": {"percent_remaining": null, "reset_at": null, "window": null}}}\n'
+    )
     _write_fake_quse(fake_bin, payload=payload)
     monkeypatch.setattr(
         "pocketshell.usage._resolve_quse_binary",

--- a/tools/pocketshell/tests/test_daemon.py
+++ b/tools/pocketshell/tests/test_daemon.py
@@ -285,7 +285,8 @@ def test_usage_fetch_round_trip(
     provider-keyed output into per-provider NDJSON (issue #1318)."""
     fake_bin = tmp_path / "bin"
     python_exe = _fake_python_bin(fake_bin)
-    # quse-0.0.9 emits a provider-keyed object; the daemon flattens it.
+    # Published quse 0.0.14 emits a provider-keyed short/long object; the
+    # daemon applies the producer-boundary canonical windows translation.
     payload = '{"codex": {"status": "ok", "short_term": {"percent_remaining": 77.0, "reset_at": null, "window": "5h"}}}\n'
     _write_fake_quse(fake_bin, payload=payload)
 
@@ -302,7 +303,8 @@ def test_usage_fetch_round_trip(
         # stdout is FLATTENED NDJSON: one record, provider injected from key.
         record = json.loads(result["stdout"].strip())
         assert record["provider"] == "codex"
-        assert record["short_term"]["window"] == "5h"
+        # The canonical map key is the published window label.
+        assert record["windows"]["5h"]["percent_remaining"] == 77.0
     finally:
         _terminate(proc)
 
@@ -322,7 +324,7 @@ def test_two_concurrent_clients_cache_hit_is_faster(
     payload = '{"codex": {"status": "ok"}}\n'
     # The daemon flattens the provider-keyed payload into NDJSON before
     # caching; the cold and warm responses both carry this flattened form.
-    flattened = '{"provider": "codex", "status": "ok"}\n'
+    flattened = '{"provider": "codex", "status": "ok", "windows": {}}\n'
     _write_fake_quse(fake_bin, payload=payload, sleep_secs=0.3)
 
     proc = _spawn_daemon(sandbox_socket, python_exe=python_exe)

--- a/tools/pocketshell/tests/test_push.py
+++ b/tools/pocketshell/tests/test_push.py
@@ -51,11 +51,11 @@ class _RecordingSender(push.FcmSender):
         return self.outcomes.get(data.get("reset_key", ""), True)
 
 
-def _reset_event(reset_key: str = "codex|short_term|2026-06-11T15:00:00Z") -> dict:
+def _reset_event(reset_key: str = "codex|5h|2026-06-11T15:00:00Z") -> dict:
     return {
         "type": "reset",
         "provider": "codex",
-        "window": "short_term",
+        "window": "5h",
         "detected_at": "2026-06-11T14:30:00Z",
         "reset_key": reset_key,
     }
@@ -203,11 +203,11 @@ def test_multiple_events_each_sent_once(tmp_path: Path) -> None:
     push.register_token("tok", paths=paths)
     sender = _RecordingSender()
     events = [
-        _reset_event("codex|short_term|A"),
-        _reset_event("claude|long_term|B"),
+        _reset_event("codex|5h|A"),
+        _reset_event("claude|7d|B"),
     ]
     pushed = push.push_reset_events(events, paths=paths, sender=sender)
-    assert set(pushed) == {"codex|short_term|A", "claude|long_term|B"}
+    assert set(pushed) == {"codex|5h|A", "claude|7d|B"}
     assert len(sender.calls) == 2
 
 
@@ -258,8 +258,7 @@ def _usage_ndjson(percent: float, reset_at: str | None) -> str:
     record = {
         "provider": "codex",
         "status": "ok",
-        "short_term": {"percent_remaining": percent, "reset_at": reset_at},
-        "long_term": None,
+        "windows": {"5h": {"percent_remaining": percent, "reset_at": reset_at}},
         "block_reason": None,
         "error": None,
         "details": {},
@@ -318,5 +317,5 @@ def test_capture_never_breaks_when_push_raises(tmp_path: Path, monkeypatch) -> N
         paths=paths,
         captured_at="2026-06-11T14:30:00Z",
     )
-    assert result["records"][0]["short_term"]["percent_remaining"] == 100.0
+    assert result["records"][0]["windows"]["5h"]["percent_remaining"] == 100.0
     assert paths.cache_file.exists()

--- a/tools/pocketshell/tests/test_usage.py
+++ b/tools/pocketshell/tests/test_usage.py
@@ -98,6 +98,14 @@ def test_pyproject_pins_quse_exactly() -> None:
     assert 'specifier = "==0.0.13"' not in lock
 
 
+def test_pyproject_documents_published_quse_0014_schema() -> None:
+    """The dependency comment must describe the wheel we actually pin."""
+    text = _PYPROJECT.read_text()
+    assert "short_term" in text and "long_term" in text
+    assert "REPLACED by one unified top-level" not in text
+    assert "new `go`" not in text
+
+
 def test_resolve_quse_binary_uses_pinned_env_next_to_interpreter(tmp_path: Path) -> None:
     # AC: `pocketshell usage` invokes the PINNED quse (next to sys.executable),
     # not PATH. A quse living next to the interpreter is resolved.
@@ -202,6 +210,25 @@ def test_flatten_handles_single_provider_shape() -> None:
     assert record["provider"] == "codex"
     assert record["windows"]["7d"]["percent_remaining"] == 88.0
     assert set(record["windows"]) == {"7d"}
+
+
+def test_flatten_rejects_record_without_published_windows() -> None:
+    keyed = json.dumps(
+        {
+            "codex": {
+                "status": "error",
+                "error": "usage unavailable",
+                "details": {},
+            }
+        }
+    )
+    try:
+        normalize_usage_stdout(keyed)
+    except ValueError as exc:
+        assert "short_term" in str(exc)
+        assert "long_term" in str(exc)
+    else:  # pragma: no cover - fail-loud contract
+        raise AssertionError("a record without published windows must be rejected")
 
 
 def test_flatten_translates_published_window_labels_without_rederiving_values() -> None:

--- a/tools/pocketshell/tests/test_usage.py
+++ b/tools/pocketshell/tests/test_usage.py
@@ -1,11 +1,14 @@
 """Unit tests for `pocketshell usage` (issue #1318).
 
-quse v0.0.9 is the single source of truth for the unified usage schema. Its
-``--json`` output is a provider-keyed object; ``pocketshell usage --json``
-FLATTENS it into per-provider NDJSON (one record per line, ``provider``
-injected from the key, quse's unified fields passed through unchanged). There
-is no downstream re-derivation of windows / resets / percentages — pocketshell
-expects quse's exact schema and fails loudly on a mismatch (D22 hard-cut).
+Published ``quse==0.0.14`` emits a provider-keyed object whose records carry
+``short_term`` / ``long_term`` windows. ``pocketshell usage --json`` performs
+the one explicit producer-boundary translation into per-provider NDJSON with a
+canonical ``windows`` map; it does not re-derive quota values, reset times, or
+provider details. The app parser consumes only that canonical wire shape.
+
+The tests use a live output captured from the published 0.0.14 wheel. The
+unreleased ``a86959e`` six-provider/top-level-``windows`` producer is not part
+of the fixture or contract.
 
 The tests stub ``pocketshell.usage._resolve_quse_binary`` and
 ``subprocess.run`` so they never invoke a real ``quse`` binary; the contract
@@ -43,23 +46,19 @@ _EXPECTED_GROK_AUTH = (
 )
 
 _PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
-_FIXTURE = Path(__file__).resolve().parent / "data" / "quse-0.0.9-usage.json"
-# Captured LIVE from the pinned quse 0.0.11 (`quse --json`) on 2026-07-15 —
-# the exact Codex "no 5h window" shape (#1564): Codex temporarily removed the
-# 5h window, so its `primary_window` now carries the WEEKLY (604800s) span and
-# `secondary_window` is `present: false`. quse 0.0.11 labels the primary from
-# its actual `limit_window_seconds` (→ `short_term.window == "7d"`, NOT the old
-# positional "5h") and emits the dropped window as a null placeholder
-# (`long_term: {percent_remaining: null, ...}`) instead of a phantom
-# "0% / unavailable" ghost row. Claude / Copilot / zai in the same document
-# keep their correct 5h / 7d / monthly / weekly labels (class coverage).
-_FIXTURE_0011 = Path(__file__).resolve().parent / "data" / "quse-0.0.11-usage.json"
-# Captured LIVE from host quse 0.0.13 (`quse --json`) on 2026-08-18 — the
-# first release that emits a `grok` provider (alias `grok-build`). Live
-# shape is weekly-only: null short_term, weekly long_term. Claude / Codex /
-# Copilot / zai stay in the same document (class coverage).
-_FIXTURE_0013 = Path(__file__).resolve().parent / "data" / "quse-0.0.13-usage.json"
+# Captured LIVE from the published quse 0.0.14 wheel (`quse --json`) on
+# 2026-08-22. The release still emits short_term/long_term and has five
+# providers; see the adjacent .provenance.txt sidecar for the wheel digest.
+_FIXTURE_0014 = Path(__file__).resolve().parent / "data" / "quse-0.0.14-usage.json"
+_FIXTURE_0014_PROVENANCE = (
+    Path(__file__).resolve().parent / "data" / "quse-0.0.14-usage.provenance.txt"
+)
 _LOCK = Path(__file__).resolve().parent.parent / "uv.lock"
+
+_NULL_PUBLISHED_WINDOWS = {
+    "short_term": {"percent_remaining": None, "reset_at": None, "window": None},
+    "long_term": {"percent_remaining": None, "reset_at": None, "window": None},
+}
 
 
 def _fake_completed(
@@ -76,8 +75,8 @@ def _fake_completed(
 
 
 def _quse_keyed_json() -> str:
-    """The real quse-0.0.9 provider-keyed --json document (4 providers)."""
-    return _FIXTURE.read_text()
+    """The live published quse-0.0.14 provider-keyed document (5 providers)."""
+    return _FIXTURE_0014.read_text()
 
 
 # ---------------------------------------------------------------------------
@@ -86,17 +85,17 @@ def _quse_keyed_json() -> str:
 
 
 def test_pyproject_pins_quse_exactly() -> None:
-    # AC (#2195): pocketshell pins quse==0.0.13 as a hard dependency so the
-    # usage panel can see Grok. Reverting the pin to 0.0.11 must redden this
-    # assertion (G6). 0.0.13 is the first quse that emits a `grok` provider.
+    # AC (#2274): pocketshell pins the published quse==0.0.14 release. The
+    # producer must remain aligned with that release's old short/long schema;
+    # it must not claim the unreleased a86959e output.
     text = _PYPROJECT.read_text()
-    assert '"quse==0.0.13"' in text, "pyproject must pin quse==0.0.13 in dependencies"
-    assert '"quse==0.0.11"' not in text, "the 0.0.11 pin must not remain"
+    assert '"quse==0.0.14"' in text, "pyproject must pin quse==0.0.14 in dependencies"
+    assert '"quse==0.0.13"' not in text, "the 0.0.13 pin must not remain"
     lock = _LOCK.read_text()
     assert 'name = "quse"' in lock
-    assert 'version = "0.0.13"' in lock
-    assert 'specifier = "==0.0.13"' in lock
-    assert 'specifier = "==0.0.11"' not in lock
+    assert 'version = "0.0.14"' in lock
+    assert 'specifier = "==0.0.14"' in lock
+    assert 'specifier = "==0.0.13"' not in lock
 
 
 def test_resolve_quse_binary_uses_pinned_env_next_to_interpreter(tmp_path: Path) -> None:
@@ -137,42 +136,51 @@ def test_resolve_quse_binary_does_not_fall_back_to_path(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# normalize_usage_stdout: thin flatten of quse's provider-keyed object
+# normalize_usage_stdout: published quse compatibility translation
 # ---------------------------------------------------------------------------
 
 
-def test_flatten_emits_per_provider_ndjson_with_window_and_iso_reset() -> None:
-    # AC: `pocketshell usage --json` fed quse-0.0.9 keyed JSON emits strict
-    # per-provider NDJSON (provider + unified fields + window + ISO reset_at).
+def test_quse_0014_fixture_matches_published_contract() -> None:
+    raw = json.loads(_quse_keyed_json())
+    assert set(raw) == {"claude", "codex", "copilot", "grok", "zai"}
+    assert "go" not in raw
+    assert "Wheel SHA-256:" in _FIXTURE_0014_PROVENANCE.read_text()
+    for record in raw.values():
+        assert set(record) == {"details", "error", "long_term", "short_term", "status"}
+        assert "windows" not in record
+
+
+def test_flatten_emits_per_provider_ndjson_with_canonical_windows_and_iso_reset() -> None:
+    # AC (#2274): the producer translates the REAL published quse-0.0.14
+    # short_term/long_term records into the app-facing windows map. Provider
+    # identity is injected from the object key and reset_at stays unchanged.
     out = normalize_usage_stdout(_quse_keyed_json())
     lines = [json.loads(ln) for ln in out.splitlines()]
     by_provider = {r["provider"]: r for r in lines}
 
-    assert set(by_provider) == {"claude", "codex", "copilot", "zai"}
+    assert set(by_provider) == {"claude", "codex", "copilot", "grok", "zai"}
 
     claude = by_provider["claude"]
-    assert claude["short_term"]["window"] == "5h"
-    assert claude["short_term"]["reset_at"] == "2026-07-07T23:19:59Z"
-    assert claude["short_term"]["percent_remaining"] == 91.0
-    assert claude["long_term"]["window"] == "7d"
-    assert claude["long_term"]["reset_at"] == "2026-07-09T14:59:59Z"
+    assert set(claude["windows"]) == {"5h", "7d"}
+    assert claude["windows"]["5h"]["percent_remaining"] == 99.0
+    assert claude["windows"]["5h"]["reset_at"] == "2026-08-22T15:49:59Z"
+    assert claude["windows"]["7d"]["percent_remaining"] == 93.0
 
     codex = by_provider["codex"]
-    assert codex["short_term"]["window"] == "5h"
-    assert codex["long_term"]["window"] == "7d"
+    # Published quse's dropped short-term span has a null percentage. The
+    # producer omits that non-renderable source span rather than emitting a
+    # malformed canonical window that the Android parser would have to skip.
+    assert set(codex["windows"]) == {"7d"}
+    assert codex["windows"]["7d"]["percent_remaining"] == 56.0
 
-    copilot = by_provider["copilot"]
-    assert copilot["long_term"]["window"] == "monthly"
-    # quse passes null short-term window/reset through unchanged.
-    assert copilot["short_term"]["window"] is None
-    assert copilot["short_term"]["reset_at"] is None
+    assert by_provider["copilot"]["windows"]["monthly"]["percent_remaining"] == 100.0
+    assert by_provider["grok"]["windows"]["weekly"]["percent_remaining"] == 0.0
+    assert by_provider["zai"]["windows"]["5h"]["percent_remaining"] == 100.0
 
-    zai = by_provider["zai"]
-    assert zai["short_term"]["window"] == "5h"
-    assert zai["long_term"]["window"] == "weekly"
-
-    # Every line carries an injected `provider` field.
-    assert all("provider" in json.loads(ln) for ln in out.splitlines())
+    for record in lines:
+        assert "provider" in record
+        assert "short_term" not in record
+        assert "long_term" not in record
 
 
 def test_flatten_handles_single_provider_shape() -> None:
@@ -180,7 +188,7 @@ def test_flatten_handles_single_provider_shape() -> None:
         {
             "codex": {
                 "status": "ok",
-                "short_term": {"percent_remaining": 77.0, "reset_at": None, "window": "5h"},
+                "short_term": {"percent_remaining": None, "reset_at": None, "window": None},
                 "long_term": {"percent_remaining": 88.0, "reset_at": None, "window": "7d"},
                 "error": None,
                 "details": {},
@@ -192,137 +200,80 @@ def test_flatten_handles_single_provider_shape() -> None:
     assert len(lines) == 1
     record = json.loads(lines[0])
     assert record["provider"] == "codex"
-    assert record["short_term"]["window"] == "5h"
+    assert record["windows"]["7d"]["percent_remaining"] == 88.0
+    assert set(record["windows"]) == {"7d"}
 
 
-def test_flatten_passes_unified_fields_through_unchanged() -> None:
+def test_flatten_translates_published_window_labels_without_rederiving_values() -> None:
     keyed = json.dumps(
         {
             "claude": {
                 "status": "ok",
-                "short_term": {"percent_remaining": 59.0, "reset_at": "2026-05-24T14:30:00Z", "window": "5h"},
-                "long_term": {"percent_remaining": 15.0, "reset_at": "2026-05-28T14:59:59Z", "window": "7d"},
+                "short_term": {
+                    "percent_remaining": 59.0,
+                    "reset_at": "2026-05-24T14:30:00Z",
+                    "window": "5h",
+                },
+                "long_term": {
+                    "percent_remaining": 15.0,
+                    "reset_at": "2026-05-28T14:59:59Z",
+                    "window": "7d",
+                },
                 "error": None,
                 "details": {"anything": "the app ignores this"},
             }
         }
     )
     record = json.loads(normalize_usage_stdout(keyed).splitlines()[0])
-    # Quota math + spans are passed through verbatim (no re-derivation).
-    assert record["short_term"] == {
-        "percent_remaining": 59.0,
-        "reset_at": "2026-05-24T14:30:00Z",
-        "window": "5h",
+    assert record["windows"] == {
+        "5h": {"percent_remaining": 59.0, "reset_at": "2026-05-24T14:30:00Z"},
+        "7d": {"percent_remaining": 15.0, "reset_at": "2026-05-28T14:59:59Z"},
     }
-    assert record["long_term"] == {
-        "percent_remaining": 15.0,
-        "reset_at": "2026-05-28T14:59:59Z",
-        "window": "7d",
-    }
+    assert record["details"] == {"anything": "the app ignores this"}
 
 
-def test_flatten_codex_0011_no_5h_window_weekly_only_no_ghost() -> None:
-    """#1564: quse 0.0.11 fixes Codex's mislabeled/ghost windows at the source.
-
-    Feeds the REAL captured quse 0.0.11 Codex "no 5h window" shape through the
-    flatten and asserts the corrected wire shape the app consumes:
-
-    - `short_term` is the WEEKLY window labeled **"7d"** (from Codex's real
-      `limit_window_seconds=604800`) with its real reset — NOT the old phantom
-      "5h" window that showed weekly data under a 5h label with a 5-day reset.
-    - `long_term` is a null placeholder (`percent_remaining: null`) for the
-      window Codex DROPPED — the app parser treats a null-percent window as
-      absent, so there is NO "0% / unavailable" ghost row.
-
-    The flatten passes quse's unified fields through verbatim (D22 / #1318):
-    pocketshell does NOT relabel — the correct labels come from quse 0.0.11.
-    """
-    out = normalize_usage_stdout(_FIXTURE_0011.read_text())
-    by_provider = {r["provider"]: r for r in (json.loads(ln) for ln in out.splitlines())}
-
-    codex = by_provider["codex"]
-    # The single real Codex window is the WEEKLY one, labeled "7d" — no phantom 5h.
-    assert codex["short_term"]["window"] == "7d"
-    assert codex["short_term"]["window"] != "5h"
-    assert codex["short_term"]["reset_at"] == "2026-07-21T20:37:32Z"
-    assert codex["short_term"]["percent_remaining"] == 69.0
-    # The dropped window is a null placeholder → the app parser omits it (no
-    # "0% / unavailable" ghost row). percent_remaining MUST be null here.
-    assert codex["long_term"]["percent_remaining"] is None
-    assert codex["long_term"]["window"] is None
-    assert codex["long_term"]["reset_at"] is None
+def test_flatten_rejects_unreleased_top_level_windows_schema() -> None:
+    keyed = json.dumps(
+        {
+            "go": {
+                "status": "ok",
+                "windows": {"5h": {"percent_remaining": 100.0, "reset_at": None}},
+            }
+        }
+    )
+    try:
+        normalize_usage_stdout(keyed)
+    except ValueError as exc:
+        assert "unsupported top-level 'windows'" in str(exc)
+    else:  # pragma: no cover - fail-loud contract
+        raise AssertionError("unreleased quse schema must not be accepted as published")
 
 
-def test_flatten_codex_0011_leaves_other_providers_unchanged() -> None:
-    """#1564 class coverage: the quse Codex fix does NOT regress other cards.
-
-    Claude keeps its 5h + 7d windows, Copilot keeps its monthly window, and zai
-    keeps its 5h + weekly windows — all labeled correctly in the same quse
-    0.0.11 document. Only Codex's window shape changed.
-    """
-    out = normalize_usage_stdout(_FIXTURE_0011.read_text())
-    by_provider = {r["provider"]: r for r in (json.loads(ln) for ln in out.splitlines())}
-
-    claude = by_provider["claude"]
-    assert claude["short_term"]["window"] == "5h"
-    assert claude["short_term"]["reset_at"] == "2026-07-15T11:39:59Z"
-    assert claude["long_term"]["window"] == "7d"
-    assert claude["long_term"]["reset_at"] == "2026-07-16T14:59:59Z"
-
-    copilot = by_provider["copilot"]
-    assert copilot["long_term"]["window"] == "monthly"
-    assert copilot["long_term"]["percent_remaining"] == 97.1
-
-    zai = by_provider["zai"]
-    assert zai["short_term"]["window"] == "5h"
-    assert zai["long_term"]["window"] == "weekly"
-
-
-def test_flatten_quse_0013_emits_grok_and_passes_windows_through() -> None:
-    """#2195: quse 0.0.13 adds grok; flatten must emit it unchanged.
-
-    Feeds the REAL captured quse 0.0.13 document (weekly-only grok: null
-    short_term, weekly long_term) and asserts the wire shape the app consumes.
-    Reverting the pin without a grok line in the 0.0.13 fixture reddens the
-    provider set. The four historical providers stay present.
-    """
-    out = normalize_usage_stdout(_FIXTURE_0013.read_text())
-    by_provider = {r["provider"]: r for r in (json.loads(ln) for ln in out.splitlines())}
-
-    assert set(by_provider) == {"claude", "codex", "copilot", "grok", "zai"}
-    grok = by_provider["grok"]
-    assert grok["provider"] == "grok"
-    assert grok["status"] == "ok"
-    # Live 0.0.13 weekly-only shape: unused term is a null placeholder.
-    assert grok["short_term"] == {
-        "percent_remaining": None,
-        "reset_at": None,
-        "window": None,
-    }
-    assert grok["long_term"] == {
-        "percent_remaining": 95.0,
-        "reset_at": "2026-08-25T00:08:17Z",
-        "window": "weekly",
-    }
-    # Historical four-provider cards stay in the same document.
-    assert by_provider["claude"]["short_term"]["window"] == "5h"
-    assert by_provider["claude"]["long_term"]["window"] == "7d"
-    assert by_provider["copilot"]["long_term"]["window"] == "monthly"
-    assert by_provider["zai"]["long_term"]["window"] == "weekly"
+def test_flatten_quse_0014_codex_reset_credits_pass_through() -> None:
+    # Fix-shape verification: the published 0.0.14 codex details entries carry
+    # `{expires_at, status, title}` and the exact-match inventory fields the
+    # app's strict parser validates — passed through untouched here.
+    out = normalize_usage_stdout(_FIXTURE_0014.read_text())
+    codex = next(
+        json.loads(ln) for ln in out.splitlines()
+        if json.loads(ln)["provider"] == "codex"
+    )
+    credits = codex["details"]["reset_credits"]
+    assert len(credits) == 1
+    assert credits[0]["status"] == "available"
+    assert credits[0]["title"] == "Full reset"
+    assert credits[0]["expires_at"] == "2026-09-21T00:13:17Z"
+    assert codex["details"]["reset_credits_available"] == 1
 
 
 def test_flatten_handles_grok_only_object() -> None:
     # AC: flattening a grok-only object `{"grok": {...}}` emits one NDJSON
-    # line with provider "grok" and passes weekly/monthly fields through.
+    # line with provider "grok" and maps the published long-term window.
     keyed = json.dumps(
         {
             "grok": {
                 "status": "ok",
-                "short_term": {
-                    "percent_remaining": None,
-                    "reset_at": None,
-                    "window": None,
-                },
+                "short_term": {"percent_remaining": None, "reset_at": None, "window": None},
                 "long_term": {
                     "percent_remaining": 95.0,
                     "reset_at": "2026-08-25T00:08:17Z",
@@ -338,18 +289,15 @@ def test_flatten_handles_grok_only_object() -> None:
     assert len(lines) == 1
     record = json.loads(lines[0])
     assert record["provider"] == "grok"
-    assert record["long_term"] == {
+    assert record["windows"]["weekly"] == {
         "percent_remaining": 95.0,
         "reset_at": "2026-08-25T00:08:17Z",
-        "window": "weekly",
     }
-    assert record["short_term"]["percent_remaining"] is None
-    assert record["short_term"]["window"] is None
 
 
 def test_flatten_passes_grok_both_windows_through_unchanged() -> None:
-    # quse maps weekly SuperGrok + monthly credit to short_term / long_term
-    # when both windows are present. Flatten must not relabel or drop them.
+    # quse reports grok's weekly + monthly spans as short/long. Flatten must
+    # retain the provider-owned labels.
     keyed = json.dumps(
         {
             "grok": {
@@ -371,16 +319,8 @@ def test_flatten_passes_grok_both_windows_through_unchanged() -> None:
     )
     record = json.loads(normalize_usage_stdout(keyed).splitlines()[0])
     assert record["provider"] == "grok"
-    assert record["short_term"] == {
-        "percent_remaining": 62.5,
-        "reset_at": "2026-08-25T00:08:17Z",
-        "window": "weekly",
-    }
-    assert record["long_term"] == {
-        "percent_remaining": 75.0,
-        "reset_at": "2026-09-01T00:00:00Z",
-        "window": "monthly",
-    }
+    assert record["windows"]["weekly"]["percent_remaining"] == 62.5
+    assert record["windows"]["monthly"]["percent_remaining"] == 75.0
 
 
 def test_flatten_raises_on_non_json() -> None:
@@ -425,8 +365,7 @@ def test_flatten_maps_claude_401_to_actionable_error() -> None:
         {
             "claude": {
                 "status": "error",
-                "short_term": None,
-                "long_term": None,
+                **_NULL_PUBLISHED_WINDOWS,
                 "error": "HTTP Error 401: Unauthorized",
                 "details": {},
             }
@@ -459,8 +398,7 @@ def test_flatten_maps_grok_no_credentials_to_actionable_error() -> None:
         {
             "grok": {
                 "status": "error",
-                "short_term": None,
-                "long_term": None,
+                **_NULL_PUBLISHED_WINDOWS,
                 "error": "no-credentials",
                 "details": {},
             }
@@ -513,7 +451,7 @@ def test_usage_json_flattens_quse_keyed_object() -> None:
         result = runner.invoke(usage_command, ["--json", "--no-daemon"])
     assert result.exit_code == 0, result.output
     providers = [json.loads(ln)["provider"] for ln in result.output.splitlines()]
-    assert providers == ["claude", "codex", "copilot", "zai"]
+    assert providers == ["claude", "codex", "copilot", "grok", "zai"]
     # Args forwarded to the pinned quse subprocess must include `--json`.
     invoked: Sequence[str] = run.call_args.args[0]
     assert invoked == ["/fake/quse", "--json"]
@@ -534,7 +472,15 @@ def test_usage_forwards_provider_argument() -> None:
 
 def test_usage_forwards_provider_and_json_flag_together() -> None:
     runner = CliRunner()
-    single = json.dumps({"claude": {"status": "ok", "short_term": None, "long_term": None, "error": None}})
+    single = json.dumps(
+        {
+            "claude": {
+                "status": "ok",
+                **_NULL_PUBLISHED_WINDOWS,
+                "error": None,
+            }
+        }
+    )
     with patch("pocketshell.usage._resolve_quse_binary", return_value="/fake/quse"), patch(
         "pocketshell.usage.subprocess.run",
         return_value=_fake_completed(stdout=single),
@@ -547,19 +493,15 @@ def test_usage_forwards_provider_and_json_flag_together() -> None:
 
 
 def test_usage_forwards_grok_provider_and_json() -> None:
-    # AC: `pocketshell usage grok` is an accepted provider filter (quse 0.0.13
-    # already accepts it once pinned). Flatten of the grok-only object is the
-    # load-bearing JSON contract; the CLI must forward `grok` + `--json`.
+    # AC: `pocketshell usage grok` is an accepted provider filter. Flatten of
+    # the published short/long grok object is the load-bearing JSON contract;
+    # the CLI must forward `grok` + `--json`.
     runner = CliRunner()
     single = json.dumps(
         {
             "grok": {
                 "status": "ok",
-                "short_term": {
-                    "percent_remaining": None,
-                    "reset_at": None,
-                    "window": None,
-                },
+                "short_term": {"percent_remaining": None, "reset_at": None, "window": None},
                 "long_term": {
                     "percent_remaining": 95.0,
                     "reset_at": "2026-08-25T00:08:17Z",
@@ -580,7 +522,7 @@ def test_usage_forwards_grok_provider_and_json() -> None:
     assert invoked == ["/fake/quse", "grok", "--json"]
     record = json.loads(result.output.splitlines()[0])
     assert record["provider"] == "grok"
-    assert record["long_term"]["window"] == "weekly"
+    assert record["windows"]["weekly"]["percent_remaining"] == 95.0
 
 
 def test_usage_fails_loud_when_pinned_quse_missing() -> None:

--- a/tools/pocketshell/tests/test_usage.py
+++ b/tools/pocketshell/tests/test_usage.py
@@ -8,7 +8,8 @@ provider details. The app parser consumes only that canonical wire shape.
 
 The tests use a live output captured from the published 0.0.14 wheel. The
 unreleased ``a86959e`` six-provider/top-level-``windows`` producer is not part
-of the fixture or contract.
+of the fixture or published-wheel contract. A small inline test covers the
+separate canonical producer contract for OpenCode Go.
 
 The tests stub ``pocketshell.usage._resolve_quse_binary`` and
 ``subprocess.run`` so they never invoke a real ``quse`` binary; the contract
@@ -98,12 +99,14 @@ def test_pyproject_pins_quse_exactly() -> None:
     assert 'specifier = "==0.0.13"' not in lock
 
 
-def test_pyproject_documents_published_quse_0014_schema() -> None:
-    """The dependency comment must describe the wheel we actually pin."""
+def test_pyproject_documents_published_and_canonical_boundaries() -> None:
+    """The dependency comment must not turn local canonical data into PyPI provenance."""
     text = _PYPROJECT.read_text()
+    assert "published 0.0.14 wheel" in text
+    assert "five-provider" in text
     assert "short_term" in text and "long_term" in text
-    assert "REPLACED by one unified top-level" not in text
-    assert "new `go`" not in text
+    assert "separate top-level `windows` producer contract" in text
+    assert "OpenCode Go" in text
 
 
 def test_resolve_quse_binary_uses_pinned_env_next_to_interpreter(tmp_path: Path) -> None:
@@ -152,7 +155,11 @@ def test_quse_0014_fixture_matches_published_contract() -> None:
     raw = json.loads(_quse_keyed_json())
     assert set(raw) == {"claude", "codex", "copilot", "grok", "zai"}
     assert "go" not in raw
-    assert "Wheel SHA-256:" in _FIXTURE_0014_PROVENANCE.read_text()
+    assert (
+        "Wheel SHA-256: "
+        "7b99a3db422f2a370a0786445c7ab89215b9a93174e63802913d83f8f1dd1b76"
+        in _FIXTURE_0014_PROVENANCE.read_text()
+    )
     for record in raw.values():
         assert set(record) == {"details", "error", "long_term", "short_term", "status"}
         assert "windows" not in record
@@ -212,7 +219,7 @@ def test_flatten_handles_single_provider_shape() -> None:
     assert set(record["windows"]) == {"7d"}
 
 
-def test_flatten_rejects_record_without_published_windows() -> None:
+def test_flatten_rejects_record_without_any_window_fields() -> None:
     keyed = json.dumps(
         {
             "codex": {
@@ -225,10 +232,11 @@ def test_flatten_rejects_record_without_published_windows() -> None:
     try:
         normalize_usage_stdout(keyed)
     except ValueError as exc:
+        assert "canonical 'windows'" in str(exc)
         assert "short_term" in str(exc)
         assert "long_term" in str(exc)
     else:  # pragma: no cover - fail-loud contract
-        raise AssertionError("a record without published windows must be rejected")
+        raise AssertionError("a record without any window fields must be rejected")
 
 
 def test_flatten_translates_published_window_labels_without_rederiving_values() -> None:
@@ -259,21 +267,39 @@ def test_flatten_translates_published_window_labels_without_rederiving_values() 
     assert record["details"] == {"anything": "the app ignores this"}
 
 
-def test_flatten_rejects_unreleased_top_level_windows_schema() -> None:
+def test_flatten_accepts_separate_canonical_go_contract() -> None:
     keyed = json.dumps(
         {
             "go": {
                 "status": "ok",
-                "windows": {"5h": {"percent_remaining": 100.0, "reset_at": None}},
+                "windows": {
+                    "5h": {
+                        "percent_remaining": 100.0,
+                        "reset_at": "2026-08-22T11:21:36Z",
+                        "rolling": True,
+                    },
+                    "monthly": {"percent_remaining": 97.0, "reset_at": None},
+                },
+                "details": {"max_used_percent": 3.0},
             }
         }
     )
+    record = json.loads(normalize_usage_stdout(keyed).splitlines()[0])
+    assert record["provider"] == "go"
+    assert record["windows"] == json.loads(keyed)["go"]["windows"]
+    assert record["details"] == {"max_used_percent": 3.0}
+    assert "short_term" not in record
+    assert "long_term" not in record
+
+
+def test_flatten_rejects_canonical_windows_non_object() -> None:
+    keyed = json.dumps({"go": {"status": "ok", "windows": "not-an-object"}})
     try:
         normalize_usage_stdout(keyed)
     except ValueError as exc:
-        assert "unsupported top-level 'windows'" in str(exc)
+        assert "top-level 'windows'" in str(exc)
     else:  # pragma: no cover - fail-loud contract
-        raise AssertionError("unreleased quse schema must not be accepted as published")
+        raise AssertionError("a non-object canonical windows map must be rejected")
 
 
 def test_flatten_quse_0014_codex_reset_credits_pass_through() -> None:

--- a/tools/pocketshell/tests/test_usage_capture.py
+++ b/tools/pocketshell/tests/test_usage_capture.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import Sequence
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -35,27 +34,44 @@ from pocketshell.usage_capture import (
 # own output format — one provider record per line).
 _NDJSON = (
     '{"provider": "codex", "status": "ok", '
-    '"short_term": {"percent_remaining": 77.0, "reset_at": "2026-06-11T15:00:00Z"}}\n'
+    '"windows": {"5h": {"percent_remaining": 77.0, "reset_at": "2026-06-11T15:00:00Z"}}}\n'
     '{"provider": "claude", "status": "ok", '
-    '"short_term": {"percent_remaining": 41.0, "reset_at": "2026-06-11T14:00:00Z"}}\n'
+    '"windows": {"5h": {"percent_remaining": 41.0, "reset_at": "2026-06-11T14:00:00Z"}}}\n'
 )
 
-# quse v0.0.9's provider-keyed `--json` document — what `subprocess.run`
-# returns when the CLI capture path shells out to the pinned quse. The
-# `usage --capture` flow FLATTENS this into the NDJSON above before caching.
+# The published quse==0.0.14 provider-keyed `--json` document (old
+# `short_term` / `long_term` schema) — what `subprocess.run` returns when the
+# CLI capture path shells out to the pinned quse. The `usage --capture` flow
+# translates this at the producer boundary, then caches canonical NDJSON.
 _QUSE_KEYED = json.dumps(
     {
         "codex": {
             "status": "ok",
-            "short_term": {"percent_remaining": 77.0, "reset_at": "2026-06-11T15:00:00Z", "window": "5h"},
-            "long_term": {"percent_remaining": 88.0, "reset_at": "2026-06-18T15:00:00Z", "window": "7d"},
+            "short_term": {
+                "percent_remaining": 77.0,
+                "reset_at": "2026-06-11T15:00:00Z",
+                "window": "5h",
+            },
+            "long_term": {
+                "percent_remaining": 88.0,
+                "reset_at": "2026-06-18T15:00:00Z",
+                "window": "7d",
+            },
             "error": None,
             "details": {},
         },
         "claude": {
             "status": "ok",
-            "short_term": {"percent_remaining": 41.0, "reset_at": "2026-06-11T14:00:00Z", "window": "5h"},
-            "long_term": {"percent_remaining": 85.0, "reset_at": "2026-06-18T14:00:00Z", "window": "7d"},
+            "short_term": {
+                "percent_remaining": 41.0,
+                "reset_at": "2026-06-11T14:00:00Z",
+                "window": "5h",
+            },
+            "long_term": {
+                "percent_remaining": 85.0,
+                "reset_at": "2026-06-18T14:00:00Z",
+                "window": "7d",
+            },
             "error": None,
             "details": {},
         },

--- a/tools/pocketshell/tests/test_usage_reset.py
+++ b/tools/pocketshell/tests/test_usage_reset.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from pocketshell import usage_reset
 from pocketshell.cli import cli
 from pocketshell.usage_capture import UsagePaths, resolve_paths, write_capture
 from pocketshell.usage_reset import (
@@ -39,18 +38,17 @@ def _cache(
     provider: str = "codex",
     percent: float | None = 40.0,
     reset_at: str | None = "2026-06-11T15:00:00Z",
-    window: str = "short_term",
+    window: str = "5h",
 ) -> dict:
+    # quse 0.0.14 unified windows (issue #2274): the map key IS the label.
     return {
         "captured_at": captured_at,
         "records": [
             {
                 "provider": provider,
                 "status": "ok",
-                window: {
-                    "percent_remaining": percent,
-                    "reset_at": reset_at,
-                    "window": "5h",
+                "windows": {
+                    window: {"percent_remaining": percent, "reset_at": reset_at},
                 },
             }
         ],
@@ -89,7 +87,7 @@ def test_reset_detected_on_recovery_to_baseline() -> None:
     event = events[0]
     assert event["type"] == "reset"
     assert event["provider"] == "codex"
-    assert event["window"] == "short_term"
+    assert event["window"] == "5h"
     assert "recovery" in event["signals"]
     assert event["current_percent_remaining"] == 100.0
     assert event["previous_percent_remaining"] == 8.0
@@ -132,7 +130,7 @@ def test_dedup_within_run_one_event_per_window() -> None:
     previous = _cache("2026-06-11T14:00:00Z", percent=5.0, reset_at="2026-06-11T15:00:00Z")
     current = _cache("2026-06-11T14:30:00Z", percent=100.0, reset_at="2026-06-11T19:30:00Z")
     # Pre-seed the known keys with this reset's key -> suppressed.
-    key = f"codex|short_term|2026-06-11T19:30:00Z"
+    key = "codex|5h|2026-06-11T19:30:00Z"
     assert detect_resets(previous, current, known_reset_keys={key}) == []
 
 
@@ -190,11 +188,11 @@ def test_record_resets_returns_empty_when_no_reset(tmp_path: Path) -> None:
 
 _NDJSON_LOW = (
     '{"provider": "codex", "status": "ok", '
-    '"short_term": {"percent_remaining": 6.0, "reset_at": "2026-06-11T15:00:00Z"}}\n'
+    '"windows": {"5h": {"percent_remaining": 6.0, "reset_at": "2026-06-11T15:00:00Z"}}}\n'
 )
 _NDJSON_RESET = (
     '{"provider": "codex", "status": "ok", '
-    '"short_term": {"percent_remaining": 100.0, "reset_at": "2026-06-11T19:30:00Z"}}\n'
+    '"windows": {"5h": {"percent_remaining": 100.0, "reset_at": "2026-06-11T19:30:00Z"}}}\n'
 )
 
 

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2027-01-01T23:00:00Z"
+exclude-newer = "2026-08-20T22:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -346,7 +346,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qrcode", extras = ["pil"], marker = "extra == 'qr'", specifier = ">=7.4" },
-    { name = "quse", specifier = "==0.0.13" },
+    { name = "quse", specifier = "==0.0.14" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.0" },
     { name = "tmuxctl", specifier = ">=0.3.3" },
 ]
@@ -487,14 +487,14 @@ pil = [
 
 [[package]]
 name = "quse"
-version = "0.0.13"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/b5/d2e510f2fde5ef3edc8d01a94bb0e4423789279b5d84d299ad50378b742c/quse-0.0.13.tar.gz", hash = "sha256:3f744d730f0583d78456f32847a8ed64eb16f0acc16d474bb7696c3bdef91060", size = 58806, upload-time = "2026-08-18T17:20:35.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/27/473a4f591cfb8923724830b3cc1d0b31b2fb2ac12375f35df3e1353f2f3a/quse-0.0.14.tar.gz", hash = "sha256:2103fdfe7d49a343e6903fc2611e8866ca71bd37fe3e9d8e114ec482f6c8e881", size = 69250, upload-time = "2026-08-20T06:28:19.317Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/5e/309a8a2ba7c441d1d94a8f7a963d6ec4f7458424eb05ebc8debceb694e6a/quse-0.0.13-py3-none-any.whl", hash = "sha256:ea4da9826d7cf5abeeab2cf690cc49134cd4e58af92575291ff3633983c081d9", size = 24666, upload-time = "2026-08-18T17:20:34.084Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/04/ff51aaaad8fd9a4100e359cd700a4a75dd232d5f999a1d561c17bf0790e0/quse-0.0.14-py3-none-any.whl", hash = "sha256:7b99a3db422f2a370a0786445c7ab89215b9a93174e63802913d83f8f1dd1b76", size = 31777, upload-time = "2026-08-20T06:28:18.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- normalize the published quse 0.0.14 short_term/long_term producer output into canonical windows
- keep the Android parser strict for malformed/null present windows
- update real published-output fixtures, reset handling, and Usage UI coverage

## Verification
- issue #2274 reviewer APPROVED
- full JVM gate: 604 actionable tasks, BUILD SUCCESSFUL
- frozen Python suite: 1032 passed
- connected Usage1318StrictSchemaRenderE2eTest: 3/3, 0 skipped/failures/errors
- Android-test compilation: 188 actionable tasks, BUILD SUCCESSFUL

Closes #2274
