### PR TITLE
Keep voice coachmark claims across control replacement

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/VoiceGestureCoachmarkMainActivityDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/VoiceGestureCoachmarkMainActivityDockerTest.kt
@@ -655,6 +655,7 @@ class VoiceGestureCoachmarkMainActivityDockerTest {
 
     private fun AccessibilityNodeInfo.isValidPlatformLauncher(): Boolean =
         isDiscoverableForAccessibility() &&
+            className == android.widget.Button::class.java.name &&
             isEnabled &&
             isClickable &&
             actionList.any { it.id == AccessibilityNodeInfo.ACTION_CLICK } &&

--- a/app/src/androidTest/java/com/pocketshell/app/proof/VoiceGestureCoachmarkMainActivityDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/VoiceGestureCoachmarkMainActivityDockerTest.kt
@@ -141,6 +141,7 @@ class VoiceGestureCoachmarkMainActivityDockerTest {
             assertLauncherIconIdentity()
             assertCoachmarkEndAnchor()
             assertPlatformAccessibilityContract()
+            WalkthroughScreenshotArtifacts.capture("issue-1753-mainactivity-docker-coachmark-pre-action")
             invokeNativeDictationAction()
             WalkthroughScreenshotArtifacts.capture("issue-1753-mainactivity-docker-coachmark")
             waitForTerminalMarker(SESSION_A_MARKER)

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionBottomControls.kt
@@ -28,6 +28,7 @@ import com.pocketshell.app.voice.HOTKEYS_CHIP_LABEL
 import com.pocketshell.app.voice.LocalVoiceGestureBandPlaced
 import com.pocketshell.app.voice.HotkeysChipIcon
 import com.pocketshell.app.voice.SnippetsChipIcon
+import com.pocketshell.app.voice.VoiceGestureCoachmarkHost
 import com.pocketshell.uikit.components.CommandChip
 import com.pocketshell.uikit.components.HotkeySection
 import com.pocketshell.uikit.model.KeyBinding
@@ -146,12 +147,22 @@ internal fun TmuxTerminalBottomControls(
     unsentHasFailure: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
-    when (
-        tmuxTerminalHiddenImeSurface(
-            showConversation = showConversation,
-            terminalHeld = terminalHeld,
-        )
+    // Keep the education host outside the mutually exclusive bottom-band
+    // branches. During attach -> live (and equivalent resize/replacement)
+    // Compose disposes one branch before placing the other; a host inside the
+    // branch would release a presented claim in that gap. This stable tmux owner
+    // lets the launcher and coachmark retain one lifecycle across the swap.
+    VoiceGestureCoachmarkHost(
+        eligible = onDictateTap != null && onDictateHoldSwipeUp != null,
+        launcherEnabled = true,
+        modifier = modifier,
     ) {
+        when (
+            tmuxTerminalHiddenImeSurface(
+                showConversation = showConversation,
+                terminalHeld = terminalHeld,
+            )
+        ) {
                 TmuxTerminalHiddenImeSurface.LauncherOnly -> {
                     // Issue #786 (Conversation tab, hard-cut D22) AND Issue #1672
                     // (Terminal tab while the terminal is HELD during connect): the
@@ -181,7 +192,8 @@ internal fun TmuxTerminalBottomControls(
                             inputEnabled = true,
                             unsentCount = unsentCount,
                             unsentHasFailure = unsentHasFailure,
-                            modifier = modifier,
+                            modifier = Modifier,
+                            manageVoiceGestureCoachmark = false,
                         )
                     }
                 }
@@ -216,9 +228,11 @@ internal fun TmuxTerminalBottomControls(
                         inputEnabled = sessionLive,
                         unsentCount = unsentCount,
                         unsentHasFailure = unsentHasFailure,
-                        modifier = modifier,
+                        modifier = Modifier,
+                        manageVoiceGestureCoachmark = false,
                     )
                 }
+        }
     }
 }
 

--- a/app/src/main/java/com/pocketshell/app/voice/VoiceGestureAccessibilityProxy.kt
+++ b/app/src/main/java/com/pocketshell/app/voice/VoiceGestureAccessibilityProxy.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import android.widget.Button
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
@@ -50,7 +51,7 @@ internal fun VoiceGestureAccessibilityProxy(
 
 private class VoiceGestureAccessibilityProxyView(
     context: Context,
-) : View(context) {
+) : Button(context) {
 
     private var actionsEnabled = false
     private var onCompose: (() -> Unit)? = null
@@ -61,7 +62,13 @@ private class VoiceGestureAccessibilityProxyView(
         // The proxy has no visual content. Its bounds deliberately match the
         // real launcher, so accessibility focus lands on the visible control.
         setWillNotDraw(true)
+        background = null
+        text = null
+        setPadding(0, 0, 0, 0)
+        minWidth = 0
+        minHeight = 0
         contentDescription = SESSION_COMPOSER_LAUNCHER_CONTENT_DESCRIPTION
+        setOnClickListener { onCompose?.invoke() }
     }
 
     fun setActions(
@@ -72,6 +79,8 @@ private class VoiceGestureAccessibilityProxyView(
         val changed = actionsEnabled != enabled
         actionsEnabled = enabled
         isEnabled = enabled
+        isClickable = enabled
+        isFocusable = enabled
         onCompose = onClick
         this.onDictation = onDictation
         if (changed) {
@@ -83,7 +92,7 @@ private class VoiceGestureAccessibilityProxyView(
 
     override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
         super.onInitializeAccessibilityNodeInfo(info)
-        info.className = android.widget.Button::class.java.name
+        info.className = Button::class.java.name
         info.contentDescription = SESSION_COMPOSER_LAUNCHER_CONTENT_DESCRIPTION
         info.isEnabled = actionsEnabled
         info.isClickable = actionsEnabled

--- a/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
+++ b/app/src/main/java/com/pocketshell/app/voice/VoiceSessionSurface.kt
@@ -642,15 +642,12 @@ internal fun BottomChipControls(
     unsentCount: Int = 0,
     unsentHasFailure: Boolean = false,
     modifier: Modifier = Modifier,
+    // The tmux bottom band owns one stable host around its LauncherOnly/Controls
+    // branch. Direct callers keep the historical self-hosted behavior.
+    manageVoiceGestureCoachmark: Boolean = true,
 ) {
-    VoiceGestureCoachmarkHost(
-        eligible = onDictateTap != null && onDictateHoldSwipeUp != null,
-        // The terminal launcher is a local composer entry point and remains
-        // enabled through reconnect/empty-pane states (#2192). Pane-bound
-        // controls still use [inputEnabled] below.
-        launcherEnabled = true,
-        modifier = modifier,
-    ) {
+    val contentModifier = if (manageVoiceGestureCoachmark) Modifier else modifier
+    val body: @Composable () -> Unit = {
         // Issue #813 (clean rework — D22): the composer launcher RESERVES its
         // width FIRST and is NEVER the element that overflows. We compute the
         // available row width with [BoxWithConstraints] and hand the chip area
@@ -675,7 +672,7 @@ internal fun BottomChipControls(
             0.dp
         }
         BoxWithConstraints(
-            modifier = Modifier
+            modifier = contentModifier
                 .fillMaxWidth()
                 .heightIn(min = SessionBottomControlsMinHeight)
                 .background(color = PocketShellColors.Surface)
@@ -766,6 +763,21 @@ internal fun BottomChipControls(
             }
         }
     }
+
+    if (manageVoiceGestureCoachmark) {
+        VoiceGestureCoachmarkHost(
+            eligible = onDictateTap != null && onDictateHoldSwipeUp != null,
+            // The terminal launcher is a local composer entry point and remains
+            // enabled through reconnect/empty-pane states (#2192). Pane-bound
+            // controls still use [inputEnabled] below.
+            launcherEnabled = true,
+            modifier = modifier,
+        ) {
+            body()
+        }
+    } else {
+        body()
+    }
 }
 
 internal val SessionBottomControlsMinHeight = PocketShellDensity.tapTargetMin + 8.dp
@@ -799,14 +811,14 @@ internal fun ConversationComposerLauncherRow(
     // docked launcher (see [ComposerLauncherButton]).
     unsentCount: Int = 0,
     unsentHasFailure: Boolean = false,
+    // The tmux bottom band owns one stable host around its LauncherOnly/Controls
+    // branch. Direct callers keep the historical self-hosted behavior.
+    manageVoiceGestureCoachmark: Boolean = true,
 ) {
-    VoiceGestureCoachmarkHost(
-        eligible = onDictateHoldSwipeUp != null,
-        launcherEnabled = inputEnabled,
-        modifier = modifier,
-    ) {
+    val contentModifier = if (manageVoiceGestureCoachmark) Modifier else modifier
+    val body: @Composable () -> Unit = {
         Box(
-            modifier = Modifier
+            modifier = contentModifier
                 .fillMaxWidth()
                 .heightIn(min = SessionBottomControlsMinHeight)
                 .padding(
@@ -824,6 +836,18 @@ internal fun ConversationComposerLauncherRow(
                 unsentHasFailure = unsentHasFailure,
             )
         }
+    }
+
+    if (manageVoiceGestureCoachmark) {
+        VoiceGestureCoachmarkHost(
+            eligible = onDictateHoldSwipeUp != null,
+            launcherEnabled = inputEnabled,
+            modifier = modifier,
+        ) {
+            body()
+        }
+    } else {
+        body()
     }
 }
 


### PR DESCRIPTION
Fixes #1753.

The coachmark host now lives above the mutually-exclusive LauncherOnly/Controls branches, so attach/resize replacement does not release a presented claim. Child surfaces opt out of self-hosting to avoid double claims. The accessibility proxy is a native Button with a real click path.

Review: APPROVED on issue #1753 (issuecomment-5381601701).

Verification:
- VoiceGestureCoachmarkControllerTest: 10/10, rc 0.
- Android-test compilation: rc 0.
- VoiceGestureCoachmarkMainActivityDockerTest on emulator-5556: 1 test, 0 failures/errors/skips; wrapper and child rc 0.
- Native accessibility evidence: one enabled/clickable android.widget.Button, ACTION_CLICK and Start dictation retained after refresh.
- Lifecycle: Ready -> Claimed -> Persisting -> Presented.