### PR TITLE
Keep stale-session dismissal on its host tree (#2237)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
@@ -1036,6 +1036,16 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
             readyMarker = SIBLING_READY_MARKER,
         )
         val siblingConnectionStatus = siblingUiEvidence.statusName
+        // The first stable window proves the rendered screen is live. Capture
+        // an authoritative screenshot, then require a SECOND stable window
+        // after that capture. A stale owner that starts its retry ladder after
+        // the first green VM sample must redden this post-capture oracle.
+        captureFullDevice("issue2237-dismiss-cold-restore-sibling-open-pre-settlement")
+        val siblingUiAfterScreenshotEvidence = waitForStableSessionUi(
+            label = "sibling session open after authoritative screenshot",
+            expectedSessionName = SIBLING_SESSION,
+            readyMarker = SIBLING_READY_MARKER,
+        )
         val siblingUiAfterCapture: SessionUiSnapshot
         captureFullDevice("issue2237-dismiss-cold-restore-sibling-open-connected")
         siblingUiAfterCapture = currentSessionUiSnapshot(SIBLING_SESSION)
@@ -1077,10 +1087,16 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
                 appendLine("sibling_ssh_handshakes_at_stable_start=${siblingUiEvidence.sshHandshakesAtStableStart}")
                 appendLine("sibling_connect_attempts_at_settlement=${siblingUiEvidence.connectAttemptsAtSettlement}")
                 appendLine("sibling_ssh_handshakes_at_settlement=${siblingUiEvidence.sshHandshakesAtSettlement}")
+                appendLine("expected_connect_sequence=one intentional sibling logical connect from tap to first ready; zero additional logical connects after first ready; zero SSH handshakes")
                 appendLine("sibling_connect_attempt_delta_after_tap=${siblingUiEvidence.connectAttemptsAtSettlement - siblingConnectAttemptsAtTap}")
                 appendLine("sibling_ssh_handshake_delta_after_tap=${siblingUiEvidence.sshHandshakesAtSettlement - siblingSshHandshakesAtTap}")
+                appendLine("sibling_unexpected_connect_attempt_delta_after_ready=${siblingUiAfterScreenshotEvidence.connectAttemptsAtSettlement - siblingUiEvidence.connectAttemptsAtStableStart}")
                 appendLine("sibling_ui_stable_samples=${siblingUiEvidence.stableSamples}")
                 appendLine("sibling_ui_stable_window_ms=${siblingUiEvidence.stableWindowMs}")
+                appendLine("sibling_post_screenshot_connect_attempts_at_settlement=${siblingUiAfterScreenshotEvidence.connectAttemptsAtSettlement}")
+                appendLine("sibling_post_screenshot_ssh_handshakes_at_settlement=${siblingUiAfterScreenshotEvidence.sshHandshakesAtSettlement}")
+                appendLine("sibling_post_screenshot_ui_stable_samples=${siblingUiAfterScreenshotEvidence.stableSamples}")
+                appendLine("sibling_post_screenshot_ui_stable_window_ms=${siblingUiAfterScreenshotEvidence.stableWindowMs}")
                 appendLine("sibling_terminal_session_name=${siblingUiEvidence.terminalSessionName}")
                 appendLine("sibling_terminal_output_seen=${siblingUiEvidence.terminalOutputSeen}")
                 appendLine("sibling_session_label_count_at_settlement=${siblingUiEvidence.sessionLabelCount}")
@@ -1112,6 +1128,9 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
                 appendLine("expected_ssh_handshake_delta_before_sibling_tap=0")
                 appendLine("expected_sibling_session_opened=true")
                 appendLine("expected_dialog_dismissed=true")
+                appendLine("expected_sibling_connect_attempt_delta_after_tap=1")
+                appendLine("expected_sibling_ssh_handshake_delta_after_tap=0")
+                appendLine("expected_sibling_unexpected_connect_attempt_delta_after_ready=0")
             },
         )
 
@@ -1191,6 +1210,27 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
             "the sibling UI must still be genuinely ready after the connected screenshot " +
                 "was captured; a VM Connected value alone is not sufficient",
             siblingUiAfterCapture.isReadyFor(SIBLING_SESSION, SIBLING_READY_MARKER),
+        )
+        // TMUX_CONNECT_ATTEMPTS counts logical connect() calls, so opening the
+        // selected sibling must advance it once even though the host SSH lease is
+        // reused. The stale-owner regression is an EXTRA attempt after the sibling
+        // is already ready; the next assertion is the selective oracle for it.
+        assertEquals(
+            "opening the sibling must issue exactly one intentional logical tmux connect; " +
+                "same-host switches increment TMUX_CONNECT_ATTEMPTS while reusing SSH",
+            siblingConnectAttemptsAtTap + 1,
+            siblingUiEvidence.connectAttemptsAtStableStart,
+        )
+        assertEquals(
+            "a stale old-session owner must not start another logical connect after the " +
+                "sibling first becomes genuinely ready",
+            siblingUiEvidence.connectAttemptsAtStableStart,
+            siblingUiAfterScreenshotEvidence.connectAttemptsAtSettlement,
+        )
+        assertEquals(
+            "a stale old-session owner must not start an SSH handshake after the sibling tap",
+            siblingSshHandshakesAtTap,
+            siblingUiAfterScreenshotEvidence.sshHandshakesAtSettlement,
         )
         assertTrue(
             "the sibling screenshot must correspond to the selected sibling terminal " +
@@ -1672,6 +1712,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
 
     private data class SessionUiSnapshot(
         val status: TmuxSessionViewModel.ConnectionStatus,
+        val sessionScreenCount: Int,
         val sessionLive: Boolean?,
         val terminalHeld: Boolean?,
         val surfacePanePresent: Boolean?,
@@ -1688,6 +1729,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
     ) {
         fun isReadyFor(expectedSessionName: String, readyMarker: String): Boolean =
             status is TmuxSessionViewModel.ConnectionStatus.Connected &&
+                sessionScreenCount == 1 &&
                 sessionLive == true &&
                 terminalHeld == false &&
                 surfacePanePresent == true &&
@@ -1780,6 +1822,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
         val terminal = currentTerminalViewSnapshot()
         return SessionUiSnapshot(
             status = currentConnectionStatus(),
+            sessionScreenCount = visibleNodeCount(TMUX_SESSION_SCREEN_TAG),
             sessionLive = sessionScreenBoolean(TMUX_SESSION_LIVE_SEMANTICS_KEY),
             terminalHeld = sessionScreenBoolean(TMUX_TERMINAL_HELD_SEMANTICS_KEY),
             surfacePanePresent = sessionScreenBoolean(TMUX_SURFACE_PANE_PRESENT_SEMANTICS_KEY),

--- a/app/src/main/java/com/pocketshell/app/MainActivity.kt
+++ b/app/src/main/java/com/pocketshell/app/MainActivity.kt
@@ -1982,6 +1982,16 @@ private fun AppNavigator(
             // effects, not just inspect a destination value.
             onDismiss = staleSessionDismissCallback(
                 action = dismissAction,
+                // Issue #2237: the stale prompt can outlive the failed attach's
+                // visible error state. Cancel the old VM owner and run its
+                // existing close cascade before the FolderList gets a chance
+                // to reuse the shared host transport. `onSessionScreenLeft`
+                // clears the remembered intent as well; the null route keeps
+                // its existing HostList fallback.
+                neutralizeOwner = {
+                    tmuxSessionViewModel.detachAndExit()
+                    tmuxSessionViewModel.onSessionScreenLeft()
+                },
                 clearPrompt = { staleSessionPromptController.clear() },
                 clearBackStack = { backStack.clear() },
                 setCurrentDestination = ::setCurrentDestination,
@@ -2116,10 +2126,12 @@ internal data class StaleSessionDismissAction(
  */
 internal fun staleSessionDismissCallback(
     action: StaleSessionDismissAction,
+    neutralizeOwner: () -> Unit,
     clearPrompt: () -> Unit,
     clearBackStack: () -> Unit,
     setCurrentDestination: (AppDestination) -> Unit,
 ): () -> Unit = {
+    neutralizeOwner()
     clearPrompt()
     clearBackStack()
     setCurrentDestination(action.destination)

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -4524,15 +4524,40 @@ public class TmuxSessionViewModel @Inject constructor(
         // animation) does not re-seed the reattach.
         pendingReattach = null
         pausedAutoReconnect = null
+        passiveDisconnectGraceJob?.cancel()
+        passiveDisconnectGraceJob = null
+        lifecycleReattachNetworkCoalesce = null
+        backgroundDetachJob?.cancel()
+        backgroundDetachJob = null
+        val connectOwner = connectJob
+        val reconnectOwner = autoReconnectJob
+        connectOwner?.cancel()
+        reconnectOwner?.cancel()
+        connectJob = null
+        autoReconnectJob = null
+        // A manual/stale-session exit is terminal for this VM's current
+        // attach intent. Leaving these fields live until the asynchronous
+        // close starts lets a late preflight/reconnect callback re-advertise
+        // the dead target while the next FolderList is binding the host.
+        latestConnectIntent = null
+        connectingTarget = null
+        val detachedHost = activeTarget?.host
+        val detachedSession = activeTarget?.sessionName
+        activeTarget = null
+        refreshReconnectAvailability()
         Log.i(
             ISSUE_235_LIFECYCLE_TAG,
-            "tmux-detach-manual host=${activeTarget?.host} session=${activeTarget?.sessionName}",
+            "tmux-detach-manual host=$detachedHost session=$detachedSession",
         )
         // Issue #935 R1: contained — the manual detach runs the full
         // close-cascade (`detach-client` + lease release + cache eviction) IO
         // against a transport racing to tear down; a throw must not crash.
         launchContainedTeardown {
             withContext(NonCancellable) {
+                connectOwner?.cancelAndJoin()
+                if (reconnectOwner !== connectOwner) {
+                    reconnectOwner?.cancelAndJoin()
+                }
                 closeCurrentConnectionAndJoin()
             }
         }

--- a/app/src/test/java/com/pocketshell/app/MainActivityStaleSessionRecreateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/MainActivityStaleSessionRecreateTest.kt
@@ -159,14 +159,30 @@ class MainActivityStaleSessionRecreateTest {
         var promptVisible = true
         val backStack = mutableListOf<AppDestination>(AppDestination.Settings)
         var destination: AppDestination? = AppDestination.HostList
+        val events = mutableListOf<String>()
         val onDismiss = staleSessionDismissCallback(
             action = staleSessionDismissAction(base),
-            clearPrompt = { promptVisible = false },
-            clearBackStack = backStack::clear,
-            setCurrentDestination = { destination = it },
+            neutralizeOwner = { events += "neutralize-owner" },
+            clearPrompt = {
+                events += "clear-prompt"
+                promptVisible = false
+            },
+            clearBackStack = {
+                events += "clear-back-stack"
+                backStack.clear()
+            },
+            setCurrentDestination = {
+                events += "route"
+                destination = it
+            },
         )
         onDismiss()
 
+        assertEquals(
+            "the dead stale-session owner must be neutralized before routing",
+            listOf("neutralize-owner", "clear-prompt", "clear-back-stack", "route"),
+            events,
+        )
         assertFalse("the stale prompt must be cleared", promptVisible)
         assertTrue("recovery history must be cleared", backStack.isEmpty())
         val tree = destination as? AppDestination.FolderList
@@ -198,8 +214,9 @@ class MainActivityStaleSessionRecreateTest {
         var destination: AppDestination? = null
         val onDismiss = staleSessionDismissCallback(
             action = staleSessionDismissAction(base = null),
+            neutralizeOwner = {},
             clearPrompt = { promptVisible = false },
-            clearBackStack = backStack::clear,
+            clearBackStack = { backStack.clear() },
             setCurrentDestination = { destination = it },
         )
         onDismiss()

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelStaleDismissOwnerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionViewModelStaleDismissOwnerTest.kt
@@ -1,0 +1,31 @@
+package com.pocketshell.app.tmux
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Regression proof for the stale-session dismiss owner cancellation seam. */
+class TmuxSessionViewModelStaleDismissOwnerTest : TmuxSessionViewModelTestBase() {
+    @Test
+    fun detachAndExitCancelsStaleConnectAndReconnectOwnersBeforeCloseCascade() =
+        runTest(scheduler) {
+            val vm = newVm()
+            val connect = Job()
+            vm.beginConnectingForTest("10.0.2.2", 2222, "testuser", "claude-main", connect)
+            val reconnect = Job()
+            vm.autoReconnectJob = reconnect
+
+            vm.detachAndExit()
+
+            assertTrue(connect.isCancelled)
+            assertTrue(reconnect.isCancelled)
+            assertNull(vm.connectJob)
+            assertNull(vm.autoReconnectJob)
+            assertNull(vm.latestRestoreIntentSnapshot())
+            assertNull(vm.connectingSessionNameForTest())
+            advanceUntilIdle()
+        }
+}

--- a/scripts/check-issue2237-stale-dismiss-mutation.sh
+++ b/scripts/check-issue2237-stale-dismiss-mutation.sh
@@ -17,8 +17,17 @@ TEST_PATH="$ROOT_DIR/$TEST_REL"
 TEST_CLASS="com.pocketshell.app.MainActivityStaleSessionRecreateTest"
 ROUTING_TEST="staleDialogDismissCallbackRoutesToHostsOwnSessionTree"
 FALLBACK_TEST="staleDialogDismissCallbackFallsBackToHostListWhenTreeIsUnavailable"
-ANCHOR='    setCurrentDestination(action.destination)'
-MUTATION='    setCurrentDestination(AppDestination.HostList)'
+TWO_HOST_TEST="staleDialogSelectsTheStaleHostWhenRememberedDestinationIsAnotherHost"
+# Keep the mutation location-specific: this is the complete effect sequence of
+# the actual stale-session dismiss callback, not any other destination setter.
+ANCHOR='    neutralizeOwner()
+    clearPrompt()
+    clearBackStack()
+    setCurrentDestination(action.destination)'
+MUTATION='    neutralizeOwner()
+    clearPrompt()
+    clearBackStack()
+    setCurrentDestination(AppDestination.HostList)'
 CALL_SITE='            onDismiss = staleSessionDismissCallback('
 MODE=""
 ARTIFACT_DIR=""
@@ -74,11 +83,11 @@ done
 
 check_static() {
     python3 - "$SOURCE_PATH" "$TEST_PATH" "$ANCHOR" "$MUTATION" \
-        "$CALL_SITE" "$ROUTING_TEST" "$FALLBACK_TEST" <<'PY'
+        "$CALL_SITE" "$ROUTING_TEST" "$FALLBACK_TEST" "$TWO_HOST_TEST" <<'PY'
 import sys
 from pathlib import Path
 
-source_path, test_path, anchor, mutation, call_site, routing_test, fallback_test = sys.argv[1:]
+source_path, test_path, anchor, mutation, call_site, routing_test, fallback_test, two_host_test = sys.argv[1:]
 source = Path(source_path).read_text(encoding="utf-8")
 tests = Path(test_path).read_text(encoding="utf-8")
 
@@ -97,6 +106,8 @@ if tests.count(f"fun {routing_test}(") != 1:
     raise SystemExit(f"load-bearing routing test is not unique: {routing_test}")
 if tests.count(f"fun {fallback_test}(") != 1:
     raise SystemExit(f"load-bearing fallback test is not unique: {fallback_test}")
+if tests.count(f"fun {two_host_test}(") != 1:
+    raise SystemExit(f"load-bearing two-host test is not unique: {two_host_test}")
 print("PASS: #2237 mutation anchor and selective JVM test names are present")
 print(f"source={source_path}")
 print(f"anchor={anchor}")
@@ -104,6 +115,7 @@ print(f"mutation={mutation}")
 print(f"call_site={call_site}")
 print(f"routing_test={routing_test}")
 print(f"fallback_test={fallback_test}")
+print(f"two_host_test={two_host_test}")
 PY
 }
 
@@ -122,7 +134,7 @@ CLEAN_SHA256="$(sha256sum "$SOURCE_PATH" | awk '{print $1}')"
 CLEAN_MD5="$(md5sum "$SOURCE_PATH" | awk '{print $1}')"
 CLEAN_BYTES="$(wc -c < "$SOURCE_PATH" | tr -d ' ')"
 GIT_HEAD="$(git -C "$ROOT_DIR" rev-parse HEAD)"
-COMMAND="./gradlew :app:testDebugUnitTest --tests $TEST_CLASS --console=plain --no-daemon --stacktrace --rerun-tasks --no-build-cache --no-parallel --max-workers=1 -Dorg.gradle.jvmargs=-Xmx1536m -Pkotlin.daemon.jvmargs=-Xmx3072m"
+COMMAND="./gradlew :app:testDebugUnitTest --tests $TEST_CLASS --console=plain --no-daemon --stacktrace --rerun-tasks --no-build-cache --no-parallel --max-workers=1 -Dorg.gradle.jvmargs=-Xmx3072m -Pkotlin.compiler.execution.strategy=in-process -Pkotlin.daemon.jvmargs=-Xmx3072m"
 
 cat > "$ARTIFACT_DIR/metadata.txt" <<EOF
 issue=2237
@@ -137,6 +149,7 @@ call_site=$CALL_SITE
 proof_class=$TEST_CLASS
 routing_test=$ROUTING_TEST
 fallback_test=$FALLBACK_TEST
+two_host_test=$TWO_HOST_TEST
 gradle_command=$COMMAND
 EOF
 
@@ -194,7 +207,8 @@ run_proof() {
             --no-build-cache \
             --no-parallel \
             --max-workers=1 \
-            -Dorg.gradle.jvmargs=-Xmx1536m \
+            -Dorg.gradle.jvmargs=-Xmx3072m \
+            -Pkotlin.compiler.execution.strategy=in-process \
             -Pkotlin.daemon.jvmargs=-Xmx3072m
     ) > "$log_path" 2>&1; then
         return 0
@@ -206,13 +220,13 @@ run_proof() {
 inspect_results() {
     local phase="$1"
     local worktree="$2"
-    python3 - "$phase" "$worktree" "$TEST_CLASS" "$ROUTING_TEST" "$FALLBACK_TEST" <<'PY' \
+    python3 - "$phase" "$worktree" "$TEST_CLASS" "$ROUTING_TEST" "$FALLBACK_TEST" "$TWO_HOST_TEST" <<'PY' \
         > "$ARTIFACT_DIR/${phase}-tests.txt"
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-phase, worktree, test_class, routing_test, fallback_test = sys.argv[1:]
+phase, worktree, test_class, routing_test, fallback_test, two_host_test = sys.argv[1:]
 result_dir = Path(worktree) / "app/build/test-results/testDebugUnitTest"
 records = []
 for path in sorted(result_dir.rglob("TEST-*.xml")) if result_dir.is_dir() else []:
@@ -230,8 +244,9 @@ if not records:
 by_name = {name: status for name, status, _ in records}
 for name, status, file_name in records:
     print(f"{name}={status} ({file_name})")
-if routing_test not in by_name or fallback_test not in by_name:
-    raise SystemExit("the two load-bearing callback tests were not executed")
+required = (routing_test, fallback_test, two_host_test)
+if any(name not in by_name for name in required):
+    raise SystemExit("the routing, fallback, and two-host tests were not all executed")
 
 if phase == "clean":
     if any(status != "passed" for status in by_name.values()):
@@ -241,6 +256,8 @@ elif phase == "mutant":
         raise SystemExit("the onDismiss routing mutant did not redden the routing test")
     if by_name[fallback_test] != "passed":
         raise SystemExit("the host-list fallback was not selective/green under the mutant")
+    if by_name[two_host_test] != "passed":
+        raise SystemExit("the two-host identity proof was not selective/green under the mutant")
     unexpected = [
         name for name, status in by_name.items()
         if status == "failed" and name != routing_test
@@ -250,6 +267,7 @@ elif phase == "mutant":
 else:
     raise SystemExit(f"unknown result phase: {phase}")
 print(f"tests_completed={len(records)}")
+print(f"two_host_selectivity={by_name[two_host_test]}")
 PY
 }
 


### PR DESCRIPTION
Closes #2237.

## Summary
- cancel the stale session's connect/reconnect/lifecycle owners before routing away;
- clear stale attach intent and target state before the next host tree can bind;
- route dismissal to the stale prompt's host session tree, with a host-list fallback only when no host tuple exists;
- add JVM, mutation/selectivity, and current-source cold-restore connected coverage.

## Verification
- focused JVM and stale-owner mutation proof passed; the exact two-host mutant selectively reddened the owner-routing assertion and source was restored;
- current connected selector: `ColdRestoreGoneSessionNoResurrectE2eTest#dismissTapOnColdRestoreStaleDialogLandsOnHostSessionTree` — 1 executed, 0 skipped/failures/errors, wrapper/child RC 0;
- fresh artifacts show the correct host tree, sibling row, green Connected sibling screenshot with `ISSUE2237-SIBLING-READY`, no Disconnected/Reconnect UI, exactly one intentional sibling-open connect, and no post-ready reconnect or SSH handshake;
- reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2237#issuecomment-5382339432
