### PR TITLE
Prove process-restart session durability (#2265)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/LastSessionProcessRestartProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LastSessionProcessRestartProofTest.kt
@@ -2,6 +2,8 @@ package com.pocketshell.app.proof
 
 import android.app.Application
 import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
 import android.os.Process
 import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -49,7 +51,12 @@ class LastSessionProcessRestartProofTest {
         val context = targetContext()
         assertRunnerIsInTargetProcess(context.packageName)
         val namespace = runNamespace()
-        val store = LastSessionStore(context)
+        // The host force-stop is the real process boundary. This wrapper makes
+        // the old apply() behavior deterministic: it accepts the in-process
+        // editor mutation but drops the asynchronous disk handoff. The control
+        // commit() path still writes the real Android preferences file, which
+        // phase 2 reads from a genuinely new process.
+        val store = LastSessionStore(ExternalKillBoundaryContext(context))
         assertTrue("phase 1 must durably clear stale run state", store.clear())
 
         // The generation source is the real host-side tmux server used by the
@@ -100,26 +107,25 @@ class LastSessionProcessRestartProofTest {
         )
         assertTrue("successor snapshot must be durably saved", store.save(successorSnapshot))
 
-        val persistedCandidate = store.read(maxAgeMillis = Long.MAX_VALUE)
-        assertNotNull(persistedCandidate)
-        val persisted = requireNotNull(persistedCandidate)
-        assertEquals(successor.tmuxSessionId, persisted.tmuxSessionId)
-        assertEquals(successor.sessionCreated, persisted.sessionCreated)
+        // Do not read LastSessionStore here. A same-process read is allowed to
+        // observe apply()'s in-memory state and lets an async mutant flush
+        // before the host reaches the external force-stop. The phase artifact
+        // records the exact payload handed to save(); only phase 2's new
+        // process may serve as the persistence oracle.
+        val persistedGeneration = ExactGeneration(
+            tmuxSessionId = requireNotNull(successorSnapshot.tmuxSessionId),
+            sessionCreated = requireNotNull(successorSnapshot.sessionCreated),
+        )
+        assertEquals(successor, persistedGeneration)
         assertNotEquals(
-            "persisted successor generation must differ from the predecessor as a pair",
+            "successor generation must differ from the predecessor as a pair",
             predecessor,
-            ExactGeneration(
-                tmuxSessionId = requireNotNull(persisted.tmuxSessionId),
-                sessionCreated = requireNotNull(persisted.sessionCreated),
-            ),
+            persistedGeneration,
         )
 
         val phaseArtifact = writePhaseArtifact(
             phase = 1,
-            generation = ExactGeneration(
-                tmuxSessionId = requireNotNull(persisted.tmuxSessionId),
-                sessionCreated = requireNotNull(persisted.sessionCreated),
-            ),
+            generation = persistedGeneration,
             predecessor = predecessor,
             predecessorReappeared = false,
             fixture = production.fixture,
@@ -133,6 +139,7 @@ class LastSessionProcessRestartProofTest {
         val context = targetContext()
         assertRunnerIsInTargetProcess(context.packageName)
         val namespace = runNamespace()
+        writePhaseProcessMarker(phase = 2)
         val phaseOne = readPhaseOneArtifact(namespace)
         assertNotEquals(
             "phase 2 must run in a new target process after external force-stop",
@@ -547,6 +554,34 @@ class LastSessionProcessRestartProofTest {
     }
 
     /**
+     * Publish the phase-2 PID before touching the persistence oracle. The
+     * marker lets a deliberately red mutant still prove that the second direct
+     * instrumentation call entered a genuinely new target process.
+     */
+    private fun writePhaseProcessMarker(phase: Int) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val namespace = runNamespace()
+        val targetPackage = instrumentation.targetContext.packageName
+        val outputDir = File(testArtifactsRoot(instrumentation.targetContext), "process-restart/$namespace")
+        check(outputDir.mkdirs() || outputDir.isDirectory) { "cannot create $outputDir" }
+        val marker = File(outputDir, "phase-$phase.started.txt")
+        val temporary = File(outputDir, ".phase-$phase.started-${Process.myPid()}.tmp")
+        temporary.writeText(
+            buildString {
+                appendLine("schema=1")
+                appendLine("run_namespace=$namespace")
+                appendLine("phase=$phase")
+                appendLine("pid=${Process.myPid()}")
+                appendLine("process_name=${Application.getProcessName()}")
+                appendLine("target_package=$targetPackage")
+                appendLine("test_package=${instrumentation.context.packageName}")
+            },
+        )
+        check(temporary.renameTo(marker)) { "cannot atomically publish $marker" }
+        assertTrue("phase $phase process marker must be non-empty", marker.length() > 0L)
+    }
+
+    /**
      * Keep this target/instrumentation process alive after the complete phase-1
      * proof. The host force-stops both packages during this interval; the
      * bounded ceiling prevents a broken host from leaving a stray test alive
@@ -614,5 +649,70 @@ class LastSessionProcessRestartProofTest {
             "agents-daemon-2239-tmux-list-sessions-through-SshHostTmuxSessionsGateway-to-navigation-to-on-stop-to-last-session-store"
         private const val PHASE_ONE_PERSISTENCE_ORIGIN = "LastSessionStore.save"
         private const val PHASE_TWO_PERSISTENCE_ORIGIN = "LastSessionStore.read"
+    }
+}
+
+/**
+ * Deterministic external-kill boundary for the live APK mutation proof.
+ *
+ * Android documents [SharedPreferences.Editor.apply] as updating the current
+ * process immediately while scheduling its disk write asynchronously. There
+ * is no supported API that freezes that worker until an external `am
+ * force-stop`; relying on the worker losing a host-side race is therefore a
+ * flaky proof. This wrapper models the documented kill window by withholding
+ * only [SharedPreferences.Editor.apply], while delegating [commit] to the
+ * real Android preferences implementation. Phase 1 never reads the wrapped
+ * store after save; phase 2 reads the real file in a new process.
+ */
+private class ExternalKillBoundaryContext(base: Context) : ContextWrapper(base) {
+    private val crashWindowPrefs: SharedPreferences by lazy {
+        DropAsyncApplySharedPreferences(
+            base.getSharedPreferences("last_session", Context.MODE_PRIVATE),
+        )
+    }
+
+    override fun getApplicationContext(): Context = this
+
+    override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences =
+        if (name == "last_session") crashWindowPrefs else super.getSharedPreferences(name, mode)
+}
+
+private class DropAsyncApplySharedPreferences(
+    private val delegate: SharedPreferences,
+) : SharedPreferences by delegate {
+    override fun edit(): SharedPreferences.Editor = Editor(delegate.edit())
+
+    private inner class Editor(
+        private val delegateEditor: SharedPreferences.Editor,
+    ) : SharedPreferences.Editor {
+        override fun putString(key: String?, value: String?) =
+            apply { delegateEditor.putString(key, value) }
+
+        override fun putStringSet(key: String?, values: MutableSet<String>?) =
+            apply { delegateEditor.putStringSet(key, values) }
+
+        override fun putInt(key: String?, value: Int) =
+            apply { delegateEditor.putInt(key, value) }
+
+        override fun putLong(key: String?, value: Long) =
+            apply { delegateEditor.putLong(key, value) }
+
+        override fun putFloat(key: String?, value: Float) =
+            apply { delegateEditor.putFloat(key, value) }
+
+        override fun putBoolean(key: String?, value: Boolean) =
+            apply { delegateEditor.putBoolean(key, value) }
+
+        override fun remove(key: String?) = apply { delegateEditor.remove(key) }
+
+        override fun clear() = apply { delegateEditor.clear() }
+
+        override fun commit(): Boolean = delegateEditor.commit()
+
+        override fun apply() {
+            // Intentional no-op: the simulated external kill wins before the
+            // asynchronous disk handoff. A same-process read is forbidden by
+            // the phase-one proof, so no in-memory oracle can mask this.
+        }
     }
 }

--- a/scripts/test-two-phase-android-instrumentation.sh
+++ b/scripts/test-two-phase-android-instrumentation.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS="$ROOT_DIR/scripts/two-phase-android-instrumentation.sh"
 MUTATION_SCRIPT="$ROOT_DIR/scripts/two-phase-android-mutation.sh"
+DURABILITY_MUTATION_SCRIPT="$ROOT_DIR/scripts/two-phase-android-durability-mutation.sh"
 PROOF_SOURCE="$ROOT_DIR/app/src/androidTest/java/com/pocketshell/app/proof/LastSessionProcessRestartProofTest.kt"
 READ_SOURCE="$ROOT_DIR/app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt"
 SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-two-phase-self-test.XXXXXX")"
@@ -43,7 +44,40 @@ verify_real_mutation_contract() {
     "$READ_SOURCE" "$MUTATION_SCRIPT" > "$SCRATCH/mutation-contract.txt"
 }
 
+verify_durability_boundary_contract() {
+  local phase_one_source
+  [[ -x "$DURABILITY_MUTATION_SCRIPT" ]] \
+    || { echo "missing durability mutation runner: $DURABILITY_MUTATION_SCRIPT" >&2; exit 1; }
+  phase_one_source="$(sed -n \
+    '/fun phaseOnePersistsExactSuccessorGeneration()/,/^    @Test$/p' \
+    "$PROOF_SOURCE")"
+  if grep -Eq '\.read\(' <<<"$phase_one_source"; then
+    echo 'phase 1 must not read LastSessionStore before the external boundary' >&2
+    exit 1
+  fi
+  for proof_token in \
+    'ExternalKillBoundaryContext' \
+    'DropAsyncApplySharedPreferences' \
+    'only phase 2'
+  do
+    grep -Fq "$proof_token" "$PROOF_SOURCE" \
+      || { echo "durability proof lost required token: $proof_token" >&2; exit 1; }
+  done
+  for mutation_token in \
+    'WRITE_ANCHOR=' \
+    'apply().let { true }' \
+    'phase_one_external_boundary=true' \
+    'phase2_started_pid=' \
+    'mutant_result=RED'; do
+    grep -Fq "$mutation_token" "$DURABILITY_MUTATION_SCRIPT" \
+      || { echo "durability mutation runner lost required token: $mutation_token" >&2; exit 1; }
+  done
+  printf 'async-apply-boundary=deterministic\nrunner=%s\n' \
+    "$DURABILITY_MUTATION_SCRIPT" > "$SCRATCH/durability-contract.txt"
+}
+
 verify_real_mutation_contract
+verify_durability_boundary_contract
 for production_token in \
   'SshHostTmuxSessionsGateway' \
   'gateway.listSessions' \
@@ -205,6 +239,12 @@ case "$command_name" in
         predecessor_id="$(<"$state_root/predecessor-tmux-session-id")"
         predecessor_created="$(<"$state_root/predecessor-session-created")"
       fi
+      started_path="$output_dir/phase-$phase.started.txt"
+      {
+        printf 'schema=1\nrun_namespace=%s\nphase=%s\npid=%s\n' "$namespace" "$phase" "$pid"
+        printf 'process_name=%s\ntarget_package=%s\ntest_package=%s.test\n' \
+          "$package_name" "$package_name" "$package_name"
+      } > "$started_path"
       artifact_path="$output_dir/phase-$phase.txt"
       producer_fixture_host='10.0.2.2'
       if [[ "${FAKE_PRODUCER_METADATA_MUTANT:-0}" == "1" ]]; then

--- a/scripts/two-phase-android-durability-mutation.sh
+++ b/scripts/two-phase-android-durability-mutation.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Live Android durability mutation proof for issue #2265.
+#
+# The control and mutant both use the host-owned two-phase process-restart
+# harness. The mutant changes only LastSessionStore's acknowledged commit into
+# apply(); true. The device proof drops apply() deterministically at its
+# external-kill boundary, so phase 2 must fail when a new process reads the
+# real preferences file.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS="$ROOT_DIR/scripts/two-phase-android-instrumentation.sh"
+PROOF_SOURCE="$ROOT_DIR/app/src/androidTest/java/com/pocketshell/app/proof/LastSessionProcessRestartProofTest.kt"
+WRITE_SOURCE_REL="app/src/main/java/com/pocketshell/app/session/LastSessionStore.kt"
+WRITE_SOURCE="$ROOT_DIR/$WRITE_SOURCE_REL"
+ANDROID_SDK="${ANDROID_SDK:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/home/alexey/Android/Sdk}}}"
+ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
+CACHE_BASE="${XDG_CACHE_HOME:-${HOME:?HOME is required}/.cache}"
+RUN_ROOT="${RUN_ROOT:-$CACHE_BASE/pocketshell/evidence/android-process-restart/issue2265-durability-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+CONTROL_NAMESPACE="${CONTROL_NAMESPACE:-issue2265-control-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+MUTANT_NAMESPACE="${MUTANT_NAMESPACE:-issue2265-async-apply-mutant-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+CONTROL_SUFFIX="${CONTROL_SUFFIX:-i2265control}"
+MUTANT_SUFFIX="${MUTANT_SUFFIX:-i2265asyncmutant}"
+POOL_WAIT_SECONDS="${POCKETSHELL_POOL_WAIT_SECONDS:-600}"
+MUTANT_ROOT=""
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  printf 'Evidence: %s\n' "$RUN_ROOT" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$MUTANT_ROOT" && -d "$MUTANT_ROOT" ]]; then
+    rm -rf "$MUTANT_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/two-phase-android-durability-mutation.sh
+
+Runs a fresh current-source control journey, then a fresh APK built from a live
+commit-to-apply mutation. The control must survive the external force-stop and
+new-process read; the async-apply mutant must fail only at phase 2.
+
+Environment:
+  RUN_ROOT=<dir>                 new durable evidence directory
+  CONTROL_NAMESPACE=<name>       control run namespace
+  MUTANT_NAMESPACE=<name>        mutant run namespace
+  CONTROL_SUFFIX=i2265control    control application-id suffix
+  MUTANT_SUFFIX=i2265asyncmutant mutant application-id suffix
+  POCKETSHELL_POOL_WAIT_SECONDS   emulator-lock wait (default 600)
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+[[ -x "$ADB" ]] || fail "adb is not executable: $ADB"
+[[ -x "$HARNESS" ]] || fail "two-phase harness is not executable: $HARNESS"
+[[ -f "$PROOF_SOURCE" ]] || fail "proof source is absent: $PROOF_SOURCE"
+[[ -f "$WRITE_SOURCE" ]] || fail "durability source is absent: $WRITE_SOURCE"
+[[ "$POOL_WAIT_SECONDS" =~ ^[0-9]+$ ]] || fail "POCKETSHELL_POOL_WAIT_SECONDS must be numeric"
+[[ ! -e "$RUN_ROOT" ]] || fail "RUN_ROOT already exists; refusing stale/mixed evidence: $RUN_ROOT"
+mkdir -p "$RUN_ROOT"
+chmod 700 "$RUN_ROOT"
+
+WRITE_ANCHOR='            prefs.edit().also(edit).commit()'
+MUTANT_WRITE='            prefs.edit().also(edit).apply().let { true }'
+[[ "$(grep -Fc "$WRITE_ANCHOR" "$WRITE_SOURCE")" == "1" ]] \
+  || fail "durability commit mutation anchor is not unique"
+
+PHASE_ONE_SOURCE="$(sed -n \
+  '/fun phaseOnePersistsExactSuccessorGeneration()/,/^    @Test$/p' \
+  "$PROOF_SOURCE")"
+if grep -Eq '\.read\(' <<<"$PHASE_ONE_SOURCE"; then
+  fail "phase 1 contains a same-process LastSessionStore read oracle"
+fi
+
+{
+  printf 'mutation_target=%s\n' "$WRITE_SOURCE_REL"
+  printf 'mutation_anchor=%s\n' "$WRITE_ANCHOR"
+  printf 'mutant_replacement=%s\n' "$MUTANT_WRITE"
+  printf 'control_source_sha256=%s\n' "$(sha256sum "$WRITE_SOURCE" | awk '{print $1}')"
+  printf 'control_suffix=%s\ncontrol_namespace=%s\n' "$CONTROL_SUFFIX" "$CONTROL_NAMESPACE"
+  printf 'phase_one_external_boundary=true\nphase_two_oracle=new_process_LastSessionStore.read\n'
+} > "$RUN_ROOT/mutation-manifest.txt"
+
+run_harness() {
+  local root="$1" suffix="$2" namespace="$3" run_dir="$4" log_file="$5"
+  shift 5
+  env \
+    ADB="$ADB" \
+    POCKETSHELL_POOL_WAIT_SECONDS="$POOL_WAIT_SECONDS" \
+    BUILD_APKS=1 \
+    SUFFIX="$suffix" \
+    RUN_NAMESPACE="$namespace" \
+    RUN_DIR="$run_dir" \
+    "$@" \
+    bash "$root/scripts/two-phase-android-instrumentation.sh" \
+    > "$log_file" 2>&1
+}
+
+# Control: the real commit path must survive the host force-stop and the
+# phase-2 read must run in the second target process.
+run_harness "$ROOT_DIR" "$CONTROL_SUFFIX" "$CONTROL_NAMESPACE" \
+  "$RUN_ROOT/control" "$RUN_ROOT/control-run.log"
+grep -Fqx 'result=PASS' "$RUN_ROOT/control/summary.txt" \
+  || fail "current-source control journey did not pass"
+grep -Fqx 'persistence_origin=LastSessionStore.read' "$RUN_ROOT/control/phase-2.txt" \
+  || fail "control phase 2 did not publish a production read artifact"
+CONTROL_PHASE1_PID="$(sed -n 's/^phase1_pid=//p' "$RUN_ROOT/control/summary.txt")"
+CONTROL_PHASE2_STARTED_PID="$(sed -n 's/^phase2_started_pid=//p' "$RUN_ROOT/control/summary.txt")"
+CONTROL_PHASE2_PID="$(sed -n 's/^phase2_pid=//p' "$RUN_ROOT/control/summary.txt")"
+[[ -n "$CONTROL_PHASE1_PID" && -n "$CONTROL_PHASE2_STARTED_PID" && -n "$CONTROL_PHASE2_PID" ]] \
+  || fail "control summary lacks phase PID evidence"
+[[ "$CONTROL_PHASE1_PID" != "$CONTROL_PHASE2_STARTED_PID" ]] \
+  || fail "control phase 2 did not enter a new target process"
+[[ "$CONTROL_PHASE2_STARTED_PID" == "$CONTROL_PHASE2_PID" ]] \
+  || fail "control phase-2 start marker disagrees with its production artifact"
+[[ "$(grep -c 'event=external_force_stop_complete' "$RUN_ROOT/control/package-mutations.log")" == "1" ]] \
+  || fail "control lacks exactly one completed external force-stop boundary"
+
+# Make a private, non-symlinked source copy for the live APK mutation.
+MUTANT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/pocketshell-issue2265-mutant.XXXXXX")"
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a \
+    --exclude='.git/' \
+    --exclude='.gradle/' \
+    --exclude='build/' \
+    --exclude='*/build/' \
+    "$ROOT_DIR/" "$MUTANT_ROOT/"
+else
+  cp -a "$ROOT_DIR/." "$MUTANT_ROOT/"
+  rm -rf "$MUTANT_ROOT/build" "$MUTANT_ROOT/.gradle" "$MUTANT_ROOT/.git"
+fi
+
+MUTANT_SOURCE="$MUTANT_ROOT/$WRITE_SOURCE_REL"
+[[ -f "$MUTANT_SOURCE" ]] || fail "mutant source copy is absent: $MUTANT_SOURCE"
+[[ "$(grep -Fc "$WRITE_ANCHOR" "$MUTANT_SOURCE")" == "1" ]] \
+  || fail "mutant source lost the durability mutation anchor"
+
+WRITE_ANCHOR="$WRITE_ANCHOR" MUTANT_WRITE="$MUTANT_WRITE" \
+  perl -0pi -e 's/\Q$ENV{WRITE_ANCHOR}\E/$ENV{MUTANT_WRITE}/' "$MUTANT_SOURCE"
+[[ "$(grep -Fc "$WRITE_ANCHOR" "$MUTANT_SOURCE")" == "0" ]] \
+  || fail "mutant source still contains the synchronous commit"
+[[ "$(grep -Fc "$MUTANT_WRITE" "$MUTANT_SOURCE")" == "1" ]] \
+  || fail "mutant source did not contain exactly one async-apply replacement"
+[[ "$(sha256sum "$WRITE_SOURCE" | awk '{print $1}')" != \
+   "$(sha256sum "$MUTANT_SOURCE" | awk '{print $1}')" ]] \
+  || fail "durability mutation did not change the production source"
+
+cp "$MUTANT_SOURCE" "$RUN_ROOT/mutant-LastSessionStore.kt"
+{
+  printf 'mutant_source_sha256=%s\n' "$(sha256sum "$MUTANT_SOURCE" | awk '{print $1}')"
+  printf 'mutant_suffix=%s\nmutant_namespace=%s\n' "$MUTANT_SUFFIX" "$MUTANT_NAMESPACE"
+  printf 'mutant_write=apply_then_true\nexpected_control=PASS\nexpected_mutant=RED\n'
+} >> "$RUN_ROOT/mutation-manifest.txt"
+
+# Mutant: phase 1 must still complete and the host must still prove the real
+# external boundary. Only the new-process persistence assertion may turn red.
+set +e
+run_harness "$MUTANT_ROOT" "$MUTANT_SUFFIX" "$MUTANT_NAMESPACE" \
+  "$RUN_ROOT/mutant" "$RUN_ROOT/mutant-run.log"
+MUTANT_RC=$?
+set -e
+printf '%s\n' "$MUTANT_RC" > "$RUN_ROOT/mutant-exit-code.txt"
+[[ "$MUTANT_RC" -ne 0 ]] || fail "live async-apply mutant stayed green"
+[[ -s "$RUN_ROOT/mutant/phase-1.txt" ]] \
+  || fail "async-apply mutant failed before phase 1 artifact publication"
+[[ -s "$RUN_ROOT/mutant/force-stop-evidence.txt" ]] \
+  || fail "async-apply mutant failed before external force-stop evidence"
+[[ -s "$RUN_ROOT/mutant/phase-2-started.txt" ]] \
+  || fail "async-apply mutant did not enter phase 2"
+MUTANT_PHASE1_PID="$(sed -n 's/^pid=//p' "$RUN_ROOT/mutant/phase-1.txt")"
+MUTANT_PHASE2_STARTED_PID="$(sed -n 's/^pid=//p' "$RUN_ROOT/mutant/phase-2-started.txt")"
+[[ "$MUTANT_PHASE1_PID" != "$MUTANT_PHASE2_STARTED_PID" ]] \
+  || fail "async-apply mutant phase 2 reused phase-1 PID"
+grep -Fq 'production LastSessionStore must survive external process death' \
+  "$RUN_ROOT/mutant/phase-2-instrumentation.log" \
+  || fail "async-apply mutant did not fail at the phase-2 persistence assertion"
+grep -Eq 'FAILURES!!!|INSTRUMENTATION_FAILED|Tests run: 1,  Failures: 1' \
+  "$RUN_ROOT/mutant/phase-2-instrumentation.log" \
+  || fail "async-apply mutant phase 2 lacks a one-test failure result"
+[[ ! -e "$RUN_ROOT/mutant/summary.txt" ]] \
+  || fail "red async-apply mutant incorrectly published a passing summary"
+
+{
+  printf 'result=PASS\ncontrol_result=PASS\nmutant_result=RED\n'
+  printf 'mutant_exit_code=%s\n' "$MUTANT_RC"
+  printf 'mutation_target=%s\n' "$WRITE_SOURCE_REL"
+  printf 'mutant_apk_built=true\nmutant_apk_executed=true\n'
+  printf 'phase_one_external_boundary=true\nphase_two_oracle=new_process_LastSessionStore.read\n'
+  printf 'control_phase1_pid=%s\ncontrol_phase2_started_pid=%s\ncontrol_phase2_pid=%s\n' \
+    "$CONTROL_PHASE1_PID" "$CONTROL_PHASE2_STARTED_PID" "$CONTROL_PHASE2_PID"
+  printf 'mutant_phase1_pid=%s\nmutant_phase2_started_pid=%s\n' \
+    "$MUTANT_PHASE1_PID" "$MUTANT_PHASE2_STARTED_PID"
+} > "$RUN_ROOT/summary.txt"
+find "$RUN_ROOT" -type f ! -name SHA256SUMS -print0 \
+  | sort -z | xargs -0 sha256sum > "$RUN_ROOT/SHA256SUMS"
+
+printf 'Two-phase Android async-apply durability mutation proof passed.\n'
+printf 'Evidence: %s\n' "$RUN_ROOT"

--- a/scripts/two-phase-android-instrumentation.sh
+++ b/scripts/two-phase-android-instrumentation.sh
@@ -352,6 +352,31 @@ validate_phase_one_ready_marker() {
     || fail "phase 1 ready marker PID does not match phase 1 artifact"
 }
 
+validate_phase_process_marker() {
+  local phase="$1" marker="$2"
+  [[ -s "$marker" ]] || fail "phase $phase process marker is absent or empty"
+  [[ "$(artifact_value "$marker" schema)" == "1" ]] \
+    || fail "phase $phase process marker schema mismatch"
+  [[ "$(artifact_value "$marker" run_namespace)" == "$RUN_NAMESPACE" ]] \
+    || fail "phase $phase process marker namespace mismatch"
+  [[ "$(artifact_value "$marker" phase)" == "$phase" ]] \
+    || fail "phase $phase process marker phase mismatch"
+
+  local pid process_name target_package test_package
+  pid="$(artifact_value "$marker" pid)"
+  process_name="$(artifact_value "$marker" process_name)"
+  target_package="$(artifact_value "$marker" target_package)"
+  test_package="$(artifact_value "$marker" test_package)"
+  [[ "$pid" =~ ^[0-9]+$ && "$pid" -gt 1 ]] \
+    || fail "phase $phase process marker PID is not real: $pid"
+  [[ "$process_name" == "$TARGET_PACKAGE" ]] \
+    || fail "phase $phase process marker ran in $process_name, not $TARGET_PACKAGE"
+  [[ "$target_package" == "$TARGET_PACKAGE" ]] \
+    || fail "phase $phase process marker target mismatch"
+  [[ "$test_package" == "$TEST_PACKAGE" ]] \
+    || fail "phase $phase process marker test mismatch"
+}
+
 validate_instrumentation_success() {
   local phase="$1" method="$2" log_file="$3" rc="$4"
   [[ "$rc" == "0" ]] || fail "phase $phase am instrument exited $rc"
@@ -509,6 +534,10 @@ run_phase() {
   rc=${PIPESTATUS[0]}
   set -e
   printf '%s\n' "$rc" > "$RUN_DIR/phase-$phase-instrumentation.rc"
+  adb_cmd pull "$DEVICE_DIR/phase-$phase.started.txt" "$RUN_DIR/phase-$phase-started.txt" \
+    > "$RUN_DIR/phase-$phase-started-pull.log" 2>&1 \
+    || fail "phase $phase process marker pull failed"
+  validate_phase_process_marker "$phase" "$RUN_DIR/phase-$phase-started.txt"
   validate_instrumentation_success "$phase" "$method" "$log_file" "$rc"
   adb_cmd pull "$DEVICE_DIR/phase-$phase.txt" "$RUN_DIR/phase-$phase.txt" \
     > "$RUN_DIR/phase-$phase-artifact-pull.log" 2>&1 \
@@ -641,6 +670,10 @@ record_event "phase_1_complete"
 
 run_phase 2 "$PHASE2_METHOD"
 PHASE2_PID="$(artifact_value "$RUN_DIR/phase-2.txt" pid)"
+PHASE2_STARTED_PID="$(artifact_value "$RUN_DIR/phase-2-started.txt" pid)"
+
+[[ "$PHASE1_PID" != "$PHASE2_STARTED_PID" ]] \
+  || fail "phase 2 process marker reused phase-1 PID $PHASE1_PID"
 
 [[ "$PHASE1_PID" != "$PHASE2_PID" ]] \
   || fail "phase 2 reused phase-1 PID $PHASE1_PID; no process restart occurred"
@@ -715,6 +748,7 @@ grep -Eq ' command=shell am force-stop com\.pocketshell\.app\.[A-Za-z0-9._-]+([[
   printf 'install_test_count=1\n'
   printf 'phase1_pid=%s\n' "$PHASE1_PID"
   printf 'phase2_pid=%s\n' "$PHASE2_PID"
+  printf 'phase2_started_pid=%s\n' "$PHASE2_STARTED_PID"
   printf 'pid_changed=true\n'
   printf 'producer_fixture_name=%s\n' "$(artifact_value "$RUN_DIR/phase-2.txt" producer_fixture_name)"
   printf 'producer_fixture_host=%s\n' "$(artifact_value "$RUN_DIR/phase-2.txt" producer_fixture_host)"


### PR DESCRIPTION
Closes #2265

## Reviewed evidence

- Independent reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2265#issuecomment-5384172963
- Two-process AVD proof: control PASS; async-apply mutant RED at the new-process LastSessionStore read.
- Canonical unfiltered full gate: BUILD SUCCESSFUL, 604 tasks, exit 0.
- Fresh evidence is preserved in build/issue-2265/full-jvm-gate-retry-20260823.verdict and the adjacent log pointer.

This PR contains only the proof test/harness and live async-apply mutation helper; no production implementation changes.