### PR TITLE
Fix safe outbound queue disposal and orphan repair (#1589)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueProductionDeleteDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/composer/PromptComposerOutboundQueueProductionDeleteDockerTest.kt
@@ -1,0 +1,202 @@
+package com.pocketshell.app.composer
+
+import android.content.Context
+import android.net.Uri
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #1589 AC8/AC9: the production composer Delete action reaches the real,
+ * Hilt-provided durable queue lifecycle coordinator. This deliberately mounts
+ * [PromptComposerSheet] through [ComposerHiltHostActivity]; unlike
+ * [PromptComposerOutboundQueueTest], it does not construct a ViewModel or
+ * forward Delete into a test-owned list.
+ */
+@RunWith(AndroidJUnit4::class)
+class PromptComposerOutboundQueueProductionDeleteDockerTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComposerHiltHostActivity>()
+
+    private var vmUnderTest: PromptComposerViewModel? = null
+    private var sourceFile: File? = null
+
+    @After
+    fun clearDurableProofState() {
+        vmUnderTest?.outboundQueueStore?.clearSession(TARGET)
+        targetContext().getSharedPreferences(
+            OutboundAttachmentSidecarStore.PREFS_NAME,
+            Context.MODE_PRIVATE,
+        ).edit().clear().commit()
+        File(
+            targetContext().filesDir,
+            OutboundAttachmentSidecarStore.DIRECTORY_NAME,
+        ).deleteRecursively()
+        sourceFile?.delete()
+    }
+
+    @Test
+    fun productionDeleteRemovesDurableRowAndLeavesRemoteCleanupTombstone() {
+        val vm = activityScopedComposerVm().also { vmUnderTest = it }
+        val queue = vm.outboundQueueStore
+        assertNotNull(
+            "production Hilt graph must provide the real attachment sidecar store",
+            vm.outboundAttachmentSidecarStore,
+        )
+        val sidecars = requireNotNull(vm.outboundAttachmentSidecarStore)
+        assertTrue(
+            "production Hilt graph must provide SharedPrefsOutboundQueueStore, was ${queue::class.java.name}",
+            queue is SharedPrefsOutboundQueueStore,
+        )
+        assertNotNull(
+            "production Hilt graph must provide OutboundQueueLifecycleCoordinator",
+            vm.outboundQueueLifecycleCoordinator,
+        )
+
+        // Start clean even after an aborted prior instrumentation process.
+        queue.clearSession(TARGET)
+        targetContext().getSharedPreferences(
+            OutboundAttachmentSidecarStore.PREFS_NAME,
+            Context.MODE_PRIVATE,
+        ).edit().clear().commit()
+        File(
+            targetContext().filesDir,
+            OutboundAttachmentSidecarStore.DIRECTORY_NAME,
+        ).deleteRecursively()
+
+        val id = "issue1589-production-delete-${System.currentTimeMillis()}"
+        val source = File(targetContext().cacheDir, "$id.txt").also {
+            sourceFile = it
+            it.writeText("durable attachment bytes for production Delete proof\n")
+        }
+        val sidecar = runBlocking {
+            sidecars.stage(
+                outboundItemId = id,
+                uris = listOf(Uri.fromFile(source)),
+                attachmentIndices = listOf(0),
+            ).single()
+        }
+        runBlocking { sidecars.markUploaded(mapOf(sidecar.id to REMOTE_PATH)) }
+        val persistedSidecarPath = File(sidecar.localPath)
+        assertTrue("real staged sidecar bytes must exist before Delete", persistedSidecarPath.isFile)
+
+        val failed = OutboundItem(
+            id = id,
+            sessionKey = TARGET,
+            cleanText = "delete this failed production queue row",
+            attachments = listOf(
+                DurableAttachmentRef(
+                    remotePath = REMOTE_PATH,
+                    displayName = sidecar.displayName,
+                    mimeType = sidecar.mimeType,
+                ),
+            ),
+            state = OutboundState.Failed,
+            lastError = "connection lost",
+            createdAtMs = System.currentTimeMillis(),
+        )
+        assertEquals(id, queue.enqueueExisting(failed).id)
+        assertEquals(id, queue.item(id)?.id)
+
+        compose.runOnUiThread {
+            // ComposerHiltHostActivity's null target effect has already settled;
+            // drive the same activity-scoped VM used by the production sheet.
+            vm.onComposerTargetChanged(TARGET)
+            vm.refreshOutboundQueueItemsFor(TARGET)
+        }
+
+        compose.waitUntil(TIMEOUT_MS) {
+            compose.onAllNodesWithTag(
+                COMPOSER_OUTBOUND_QUEUE_BANNER_TAG,
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithTag(
+            COMPOSER_OUTBOUND_QUEUE_BANNER_TAG,
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+        compose.onNodeWithTag(
+            COMPOSER_OUTBOUND_QUEUE_TOGGLE_TAG,
+            useUnmergedTree = true,
+        ).performClick()
+        compose.waitUntil(TIMEOUT_MS) {
+            compose.onAllNodesWithTag(
+                composerOutboundQueueItemRowTestTag(id),
+                useUnmergedTree = true,
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val deleteTag = composerOutboundQueueDeleteTestTag(id)
+        compose.onNodeWithTag(deleteTag, useUnmergedTree = true)
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+
+        // MUTATION ANCHOR: replace PromptComposerSheet's production
+        // `onDeleteOutboundItem = viewModel::discardOutboundItem` callback with
+        // `{}`. This wait then hard-times-out because only the real callback can
+        // acquire OutboundDisposalPermit and remove the SharedPreferences row.
+        compose.waitUntil(TIMEOUT_MS) { queue.item(id) == null }
+        assertEquals("production Delete must durably remove the exact row", null, queue.item(id))
+
+        compose.waitUntil(TIMEOUT_MS) {
+            vm.outboundQueueItems.value.none { it.id == id } &&
+                runBlocking { sidecars.refsFor(id).isEmpty() } &&
+                !persistedSidecarPath.exists()
+        }
+        compose.onNodeWithTag(
+            composerOutboundQueueItemRowTestTag(id),
+            useUnmergedTree = true,
+        ).assertDoesNotExist()
+        compose.onNodeWithTag(
+            COMPOSER_OUTBOUND_QUEUE_BANNER_TAG,
+            useUnmergedTree = true,
+        ).assertDoesNotExist()
+        assertFalse("production Delete must remove local sidecar bytes", persistedSidecarPath.exists())
+        assertTrue(
+            "production Delete must remove persisted local sidecar refs",
+            runBlocking { sidecars.refsFor(id) }.isEmpty(),
+        )
+
+        val tombstones = sidecars.pendingTombstonesBlocking().filter { it.outboundItemId == id }
+        assertEquals("remote cleanup must retain exactly one durable tombstone", 1, tombstones.size)
+        assertEquals(sidecar.id, tombstones.single().sidecarId)
+        assertEquals(REMOTE_PATH, tombstones.single().remotePath)
+        assertEquals(sidecar.id, tombstones.single().stableToken)
+    }
+
+    private fun activityScopedComposerVm(): PromptComposerViewModel {
+        lateinit var vm: PromptComposerViewModel
+        compose.runOnUiThread {
+            vm = ViewModelProvider(compose.activity)[PromptComposerViewModel::class.java]
+        }
+        compose.waitForIdle()
+        return vm
+    }
+
+    private fun targetContext(): Context =
+        InstrumentationRegistry.getInstrumentation().targetContext
+
+    private companion object {
+        const val TARGET = "tmux:1589:\$42:1700000000"
+        const val REMOTE_PATH = ".pocketshell/attachments/issue1589-sidecar.txt"
+        const val TIMEOUT_MS = 10_000L
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
@@ -1,9 +1,12 @@
 package com.pocketshell.app.projects
 
+import android.net.Uri
 import androidx.lifecycle.ViewModelStore
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.composer.OutboundAttachmentSidecarStore
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
@@ -67,6 +70,10 @@ class FolderListKillSessionDockerTest {
     private val viewModelStore = ViewModelStore()
     private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val createdSessions = mutableListOf<String>()
+    private var parkedQueue: SharedPrefsOutboundQueueStore? = null
+    private var parkedSidecars: OutboundAttachmentSidecarStore? = null
+    private var parkedRowId: String? = null
+    private var parkedSource: File? = null
 
     @Before
     fun setUp(): Unit { runBlocking {
@@ -93,6 +100,7 @@ class FolderListKillSessionDockerTest {
 
     @After
     fun tearDown(): Unit { runBlocking {
+        cleanupParkedQueue()
         viewModelStore.clear()
         factoryScope.cancel()
         if (createdSessions.isNotEmpty()) {
@@ -160,6 +168,29 @@ class FolderListKillSessionDockerTest {
         val host = db.hostDao().getById(hostId)!!
 
         val signals = SessionLifecycleSignals()
+        // Issue #1589/B1: the real Stop journey must not silently discard a
+        // queued prompt or its local attachment bytes. This slice deliberately
+        // has no lifecycle-to-disposal authority, so the row must survive the
+        // confirmed remote kill and its lifecycle broadcast.
+        parkedQueue = SharedPrefsOutboundQueueStore(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        )
+        parkedSidecars = OutboundAttachmentSidecarStore(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        )
+        val parkedRow = parkedQueue!!.enqueue(
+            sessionKey = "issue1589/kill/$suffix",
+            cleanText = "keep this queued prompt",
+        )
+        parkedRowId = parkedRow.id
+        parkedSource = File(
+            InstrumentationRegistry.getInstrumentation().targetContext.cacheDir,
+            "issue1589-kill-$suffix.txt",
+        ).apply { writeText("keep these attachment bytes") }
+        val parkedRef = parkedSidecars!!.stage(
+            parkedRow.id,
+            listOf(Uri.fromFile(parkedSource!!)),
+        ).single()
 
         // 2. Folder tree lists both sessions.
         val folderVm = FolderListViewModel(
@@ -269,13 +300,33 @@ class FolderListKillSessionDockerTest {
                 "kept tmux session must still be alive on the remote",
                 keepAlive,
             )
+            assertTrue(
+                "confirmed Stop must not silently discard the queued prompt",
+                (parkedQueue ?: error("queue store was not seeded")).item(parkedRow.id) != null,
+            )
+            assertTrue(
+                "confirmed Stop must not silently discard queued attachment bytes",
+                File(parkedRef.localPath).exists(),
+            )
             // The kill really landed on the remote — drop it from cleanup.
             createdSessions.remove(doomed)
         } finally {
             tmuxVm.clearForTest()
             folderVm.stopPolling()
+            cleanupParkedQueue()
         }
     } }
+
+    private suspend fun cleanupParkedQueue() {
+        val rowId = parkedRowId ?: return
+        runCatching { parkedSidecars?.removeOutboundItem(rowId) }
+        parkedQueue?.remove(rowId)
+        parkedSource?.delete()
+        parkedRowId = null
+        parkedQueue = null
+        parkedSidecars = null
+        parkedSource = null
+    }
 
     private fun hasSession(vm: FolderListViewModel, sessionName: String): Boolean {
         val state = vm.state.value as? FolderListUiState.Ready ?: return false

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStore.kt
@@ -54,15 +54,43 @@ class OutboundAttachmentSidecarStore @Inject constructor(
     // `Dispatchers.IO`, so production behaviour is unchanged.
     internal var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 
+    @VisibleForTesting
+    @Volatile
+    internal var lastBlockingAccessThreadNameForTest: String? = null
+
+    @VisibleForTesting
+    internal var lockAttemptObserverForTest: (() -> Unit)? = null
+
+    // Shared with enqueue/stage so repair cannot delete a dir mid-createTempFile
+    // or drop a sidecar whose row became live after a stale snapshot.
+    private val sidecarLock = Any()
+
     suspend fun stage(
         outboundItemId: String,
         uris: List<Uri>,
         attachmentIndices: List<Int> = emptyList(),
     ): List<LocalAttachmentSidecarRef> = withContext(ioDispatcher) {
-        if (outboundItemId.isBlank() || uris.isEmpty()) return@withContext emptyList()
-        uris.mapIndexedNotNull { index, uri ->
-            stageOne(outboundItemId, uri, attachmentIndices.getOrNull(index))
-        }
+        synchronized(sidecarLock) { stageLocked(outboundItemId, uris, attachmentIndices) }
+    }
+
+    /**
+     * Serialize sidecar staging/metadata plus the queue-row enqueue against
+     * orphan repair and authorized disposal. The block is deliberately
+     * non-suspending: all blocking prefs/file work and the queue-store commit
+     * happen on [ioDispatcher] while the lock is held.
+     */
+    internal suspend fun <T> withSidecarLock(block: () -> T): T = withContext(ioDispatcher) {
+        withSidecarLockBlocking(block)
+    }
+
+    /**
+     * The coordinator calls this only from its injected IO dispatcher. Keeping
+     * the blocking form explicit prevents a nested hop back to this store's
+     * independently configured dispatcher during row-before-cleanup commits.
+     */
+    internal fun <T> withSidecarLockBlocking(block: () -> T): T {
+        lockAttemptObserverForTest?.invoke()
+        return synchronized(sidecarLock) { block() }
     }
 
     suspend fun refsFor(outboundItemId: String): List<LocalAttachmentSidecarRef> = withContext(ioDispatcher) {
@@ -80,56 +108,192 @@ class OutboundAttachmentSidecarStore @Inject constructor(
      * input or ids with no matching persisted ref.
      */
     suspend fun markUploaded(uploadedRemotePathById: Map<String, String>) = withContext(ioDispatcher) {
-        if (uploadedRemotePathById.isEmpty()) return@withContext
-        val refs = allRefsBlocking()
-        if (refs.none { uploadedRemotePathById.containsKey(it.id) }) return@withContext
-        val updated = refs.map { ref ->
-            uploadedRemotePathById[ref.id]
-                ?.takeIf { it.isNotBlank() }
-                ?.let { path -> ref.copy(uploadedRemotePath = path) }
-                ?: ref
+        synchronized(sidecarLock) {
+            if (uploadedRemotePathById.isEmpty()) return@synchronized
+            val refs = allRefsBlocking()
+            if (refs.none { uploadedRemotePathById.containsKey(it.id) }) return@synchronized
+            val updated = refs.map { ref ->
+                uploadedRemotePathById[ref.id]
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { path -> ref.copy(uploadedRemotePath = path) }
+                    ?: ref
+            }
+            persistAll(updated)
         }
-        persistAll(updated)
     }
 
     internal suspend fun updateMetadata(
         metadataById: Map<String, Pair<String, String?>>,
     ): List<LocalAttachmentSidecarRef> = withContext(ioDispatcher) {
-        if (metadataById.isEmpty()) return@withContext emptyList()
+        synchronized(sidecarLock) { updateMetadataLocked(metadataById) }
+    }
+
+    suspend fun removeOutboundItem(outboundItemId: String) = withContext(ioDispatcher) {
+        synchronized(sidecarLock) { removeOutboundItemLocked(outboundItemId) }
+    }
+
+    suspend fun remove(refId: String) = withContext(ioDispatcher) {
+        synchronized(sidecarLock) {
+            val refs = allRefsBlocking()
+            refs.firstOrNull { it.id == refId }?.let { ref ->
+                runCatching { File(ref.localPath).delete() }
+            }
+            persistAll(refs.filterNot { it.id == refId })
+        }
+    }
+
+    suspend fun reconcile() = withContext(ioDispatcher) {
+        withSidecarLockBlocking { reconcileLocked() }
+    }
+
+    /**
+     * Issue #1589: compare every sidecar ref against the complete live queue-row
+     * id set. Refs whose [LocalAttachmentSidecarRef.outboundItemId] is still a
+     * live row, or a `draft/...` composer scope, are kept. Proven queue orphans
+     * lose their ref + local bytes. Existing file-vs-ref reconcile still runs
+     * first so a missing file cannot keep a dead ref alive.
+     *
+     * [liveRowIds] is a provider, not a snapshot: each candidate is re-checked
+     * immediately before delete so a concurrent enqueue+stage cannot lose a
+     * sidecar whose row is still queued. Callers that only have a frozen set
+     * should pass `{ snapshot }` and accept that they own snapshot freshness.
+     */
+    suspend fun reconcileAgainstLiveRowIds(liveRowIds: () -> Set<String>) = withContext(ioDispatcher) {
+        withSidecarLockBlocking {
+            // Keep completed remote-upload evidence through this first local
+            // file pass. A process can crash after the local sidecar is gone
+            // but before orphan repair persists the remote cleanup tombstone.
+            // Dropping that ref here would make the remote path unrecoverable.
+            reconcileLocked(preserveUploadedRemoteRefs = true)
+            val remaining = mutableListOf<LocalAttachmentSidecarRef>()
+            val orphaned = mutableListOf<LocalAttachmentSidecarRef>()
+            val snapshot = liveRowIds()
+            for (ref in allRefsBlocking()) {
+                if (OutboundQueueRetentionPolicy.isDraftSidecarScope(ref.outboundItemId)) {
+                    remaining += ref
+                    continue
+                }
+                if (ref.outboundItemId in snapshot) {
+                    remaining += ref
+                    continue
+                }
+                // Re-read immediately before delete. A snapshot taken earlier
+                // is not proof of death: a concurrent enqueue+stage on B can
+                // land between the snapshot and this point.
+                val live = liveRowIds()
+                if (ref.outboundItemId in live) {
+                    remaining += ref
+                } else {
+                    orphaned += ref
+                }
+            }
+            // A remote upload may already have completed before the process
+            // died. Persist its exact remote path before dropping the ref/file;
+            // otherwise repair would erase the only evidence needed to delete
+            // the remote checkpoint/final sidecar on the next foreground pass.
+            val remoteTombstones = orphaned.mapNotNull { ref ->
+                ref.uploadedRemotePath
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { path ->
+                        SidecarCleanupTombstone(
+                            outboundItemId = ref.outboundItemId,
+                            sidecarId = ref.id,
+                            localPath = ref.localPath,
+                            remotePath = path,
+                            stableToken = ref.id,
+                        )
+                    }
+            }
+            if (remoteTombstones.isNotEmpty()) {
+                persistTombstonesBlocking(remoteTombstones)
+            }
+            orphaned.forEach { ref -> runCatching { File(ref.localPath).delete() } }
+            persistAll(remaining)
+            orphaned.map { it.outboundItemId }.distinct().forEach { outboundItemId ->
+                runCatching { File(rootDir(), outboundItemId).deleteRecursively() }
+            }
+            rootDir().walkBottomUp()
+                .filter { it.isDirectory && it != rootDir() && it.listFiles().isNullOrEmpty() }
+                .forEach { dir -> runCatching { dir.delete() } }
+        }
+    }
+
+    suspend fun reconcileAgainstLiveRowIds(liveRowIds: Set<String>) =
+        reconcileAgainstLiveRowIds(liveRowIds = { liveRowIds })
+
+    internal fun allRefsIncludingMissingBlocking(): List<LocalAttachmentSidecarRef> =
+        synchronized(sidecarLock) { allRefsBlocking() }
+
+    internal fun tombstonesForOutboundItem(
+        outboundItemId: String,
+        remotePathBySidecarId: Map<String, String> = emptyMap(),
+    ): List<SidecarCleanupTombstone> = synchronized(sidecarLock) {
+        allRefsBlocking()
+            .filter { it.outboundItemId == outboundItemId }
+            .map { ref ->
+                SidecarCleanupTombstone(
+                    outboundItemId = outboundItemId,
+                    sidecarId = ref.id,
+                    localPath = ref.localPath,
+                    remotePath = ref.uploadedRemotePath
+                        ?: remotePathBySidecarId[ref.id]?.takeIf { it.isNotBlank() },
+                    stableToken = ref.id,
+                )
+            }
+    }
+
+    internal fun persistTombstonesBlocking(tombstones: List<SidecarCleanupTombstone>) {
+        synchronized(sidecarLock) {
+            if (tombstones.isEmpty()) return
+            val merged = (pendingTombstonesBlocking() + tombstones)
+                .associateBy { it.sidecarId }
+                .values
+                .toList()
+            prefs.edit().putString(KEY_TOMBSTONES, encodeTombstones(merged)).commit()
+        }
+    }
+
+    internal fun pendingTombstonesBlocking(): List<SidecarCleanupTombstone> =
+        synchronized(sidecarLock) {
+            decodeTombstones(prefs.getString(KEY_TOMBSTONES, "").orEmpty())
+        }
+
+    internal fun removeTombstonesBlocking(sidecarIds: Set<String>) {
+        synchronized(sidecarLock) {
+            if (sidecarIds.isEmpty()) return
+            val remaining = pendingTombstonesBlocking().filterNot { it.sidecarId in sidecarIds }
+            val editor = prefs.edit()
+            if (remaining.isEmpty()) {
+                editor.remove(KEY_TOMBSTONES)
+            } else {
+                editor.putString(KEY_TOMBSTONES, encodeTombstones(remaining))
+            }
+            editor.commit()
+        }
+    }
+
+    internal fun stageLocked(
+        outboundItemId: String,
+        uris: List<Uri>,
+        attachmentIndices: List<Int>,
+    ): List<LocalAttachmentSidecarRef> {
+        if (outboundItemId.isBlank() || uris.isEmpty()) return emptyList()
+        return uris.mapIndexedNotNull { index, uri ->
+            stageOne(outboundItemId, uri, attachmentIndices.getOrNull(index))
+        }
+    }
+
+    internal fun updateMetadataLocked(
+        metadataById: Map<String, Pair<String, String?>>,
+    ): List<LocalAttachmentSidecarRef> {
+        if (metadataById.isEmpty()) return emptyList()
         val updated = allRefsBlocking().map { ref ->
             metadataById[ref.id]?.let { (displayName, mimeType) ->
                 ref.copy(displayName = displayName, mimeType = mimeType ?: ref.mimeType)
             } ?: ref
         }
         persistAll(updated)
-        updated.filter { metadataById.containsKey(it.id) }
-    }
-
-    suspend fun removeOutboundItem(outboundItemId: String) = withContext(ioDispatcher) {
-        refsForBlocking(outboundItemId).forEach { ref -> runCatching { File(ref.localPath).delete() } }
-        val remaining = allRefsBlocking().filterNot { it.outboundItemId == outboundItemId }
-        persistAll(remaining)
-        runCatching { File(rootDir(), outboundItemId).deleteRecursively() }
-    }
-
-    suspend fun remove(refId: String) = withContext(ioDispatcher) {
-        val refs = allRefsBlocking()
-        refs.firstOrNull { it.id == refId }?.let { ref ->
-            runCatching { File(ref.localPath).delete() }
-        }
-        persistAll(refs.filterNot { it.id == refId })
-    }
-
-    suspend fun reconcile() = withContext(ioDispatcher) {
-        val liveRefs = allRefsBlocking().filter { File(it.localPath).exists() }
-        persistAll(liveRefs)
-        val livePaths = liveRefs.mapTo(mutableSetOf()) { File(it.localPath).absolutePath }
-        rootDir().walkTopDown()
-            .filter { it.isFile && it.absolutePath !in livePaths }
-            .forEach { file -> runCatching { file.delete() } }
-        rootDir().walkBottomUp()
-            .filter { it.isDirectory && it != rootDir() && it.listFiles().isNullOrEmpty() }
-            .forEach { dir -> runCatching { dir.delete() } }
+        return updated.filter { metadataById.containsKey(it.id) }
     }
 
     private fun stageOne(
@@ -198,6 +362,28 @@ class OutboundAttachmentSidecarStore @Inject constructor(
         )
     }
 
+    internal fun removeOutboundItemLocked(outboundItemId: String) {
+        refsForBlocking(outboundItemId).forEach { ref -> runCatching { File(ref.localPath).delete() } }
+        val remaining = allRefsBlocking().filterNot { it.outboundItemId == outboundItemId }
+        persistAll(remaining)
+        runCatching { File(rootDir(), outboundItemId).deleteRecursively() }
+    }
+
+    private fun reconcileLocked(preserveUploadedRemoteRefs: Boolean = false) {
+        val liveRefs = allRefsBlocking().filter { ref ->
+            File(ref.localPath).exists() ||
+                (preserveUploadedRemoteRefs && !ref.uploadedRemotePath.isNullOrBlank())
+        }
+        persistAll(liveRefs)
+        val livePaths = liveRefs.mapTo(mutableSetOf()) { File(it.localPath).absolutePath }
+        rootDir().walkTopDown()
+            .filter { it.isFile && it.absolutePath !in livePaths }
+            .forEach { file -> runCatching { file.delete() } }
+        rootDir().walkBottomUp()
+            .filter { it.isDirectory && it != rootDir() && it.listFiles().isNullOrEmpty() }
+            .forEach { dir -> runCatching { dir.delete() } }
+    }
+
     private fun refsForBlocking(outboundItemId: String): List<LocalAttachmentSidecarRef> =
         allRefsBlocking()
             .filter { it.outboundItemId == outboundItemId && File(it.localPath).exists() }
@@ -206,7 +392,9 @@ class OutboundAttachmentSidecarStore @Inject constructor(
                 .thenBy { it.id })
 
     private fun allRefsBlocking(): List<LocalAttachmentSidecarRef> =
-        decodeRefs(prefs.getString(KEY_REFS, "").orEmpty())
+        decodeRefs(prefs.getString(KEY_REFS, "").orEmpty()).also {
+            lastBlockingAccessThreadNameForTest = Thread.currentThread().name
+        }
 
     private fun persistAll(refs: List<LocalAttachmentSidecarRef>) {
         prefs.edit().putString(KEY_REFS, encodeRefs(refs)).commit()
@@ -228,8 +416,22 @@ class OutboundAttachmentSidecarStore @Inject constructor(
         internal const val DIRECTORY_NAME = "outbound-attachments"
         internal const val PREFS_NAME = "outbound_attachment_sidecars"
         private const val KEY_REFS = "refs"
+        internal const val KEY_TOMBSTONES = "tombstones"
     }
 }
+
+/**
+ * Issue #1589: crash-safe cleanup record for one discarded queue sidecar.
+ * Persisted before the durable queue row is removed so a crash between row
+ * removal and local/remote hygiene can resume without resurrecting the send.
+ */
+internal data class SidecarCleanupTombstone(
+    val outboundItemId: String,
+    val sidecarId: String,
+    val localPath: String,
+    val remotePath: String?,
+    val stableToken: String,
+)
 
 data class LocalAttachmentSidecarRef(
     val id: String,
@@ -288,6 +490,37 @@ private fun decodeRefs(raw: String): List<LocalAttachmentSidecarRef> {
             createdAtMs = createdAtMs,
             attachmentIndex = attachmentIndex,
             uploadedRemotePath = uploadedRemotePath,
+        )
+    }
+}
+
+private fun encodeTombstones(tombstones: List<SidecarCleanupTombstone>): String =
+    tombstones.joinToString("\n") { tombstone ->
+        listOf(
+            tombstone.outboundItemId,
+            tombstone.sidecarId,
+            tombstone.localPath,
+            tombstone.remotePath.orEmpty(),
+            tombstone.stableToken,
+        ).joinToString("\t") { field -> escapeSidecarField(field) }
+    }
+
+private fun decodeTombstones(raw: String): List<SidecarCleanupTombstone> {
+    if (raw.isBlank()) return emptyList()
+    return raw.split('\n').mapNotNull { row ->
+        if (row.isBlank()) return@mapNotNull null
+        val fields = row.split('\t').map { unescapeSidecarField(it) }
+        val outboundItemId = fields.getOrNull(0).orEmpty()
+        val sidecarId = fields.getOrNull(1).orEmpty()
+        val localPath = fields.getOrNull(2).orEmpty()
+        val stableToken = fields.getOrNull(4).orEmpty().ifBlank { sidecarId }
+        if (outboundItemId.isBlank() || sidecarId.isBlank()) return@mapNotNull null
+        SidecarCleanupTombstone(
+            outboundItemId = outboundItemId,
+            sidecarId = sidecarId,
+            localPath = localPath,
+            remotePath = fields.getOrNull(3)?.ifBlank { null },
+            stableToken = stableToken,
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundDrainOwnership.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundDrainOwnership.kt
@@ -7,7 +7,25 @@ internal data class OutboundDrainLease(
     val rowId: String,
     val token: Long,
     val acceptedByConsumer: Boolean = false,
+    val purpose: OutboundDrainLeasePurpose = OutboundDrainLeasePurpose.Delivery,
 )
+
+internal enum class OutboundDrainLeasePurpose { Delivery, Disposal }
+
+/**
+ * Typed proof that the production drain owner atomically reserved [rowId] for
+ * user-authorized disposal while no delivery owns the physical pipe. Keeping
+ * this reservation alive prevents a reconnect/collector wake from acquiring a
+ * delivery lease between the UI's Delete tap and the queue-store commit.
+ */
+internal class OutboundDisposalPermit internal constructor(
+    internal val lease: OutboundDrainLease,
+    private val owner: OutboundDrainOwnership,
+) {
+    val rowId: String get() = lease.rowId
+
+    internal fun isCurrent(): Boolean = owner.ownsDisposal(this)
+}
 
 /**
  * Owns one durable outbound row during dispatch setup. Queue effects and
@@ -28,11 +46,35 @@ internal class OutboundDrainOwnership {
         return lease.takeIf { activeLease.compareAndSet(null, lease) }
     }
 
+    /**
+     * Refuse safely when any delivery lease is live; otherwise reserve the same
+     * single-owner slot for disposal. There is deliberately no "empty owner
+     * set" fallback: callers either hold this proof or they cannot delete.
+     */
+    fun tryAcquireDisposal(rowId: String): OutboundDisposalPermit? {
+        if (rowId.isBlank()) return null
+        val lease = OutboundDrainLease(
+            rowId = rowId,
+            token = nextToken.incrementAndGet(),
+            purpose = OutboundDrainLeasePurpose.Disposal,
+        )
+        return if (activeLease.compareAndSet(null, lease)) {
+            OutboundDisposalPermit(lease, this)
+        } else {
+            null
+        }
+    }
+
     fun acceptByConsumer(rowId: String?, token: Long?): Boolean {
         if (rowId == null || token == null) return false
         while (true) {
             val current = activeLease.get() ?: return false
-            if (current.rowId != rowId || current.token != token || current.acceptedByConsumer) return false
+            if (
+                current.purpose != OutboundDrainLeasePurpose.Delivery ||
+                current.rowId != rowId ||
+                current.token != token ||
+                current.acceptedByConsumer
+            ) return false
             if (activeLease.compareAndSet(current, current.copy(acceptedByConsumer = true))) return true
         }
     }
@@ -41,13 +83,24 @@ internal class OutboundDrainOwnership {
         if (rowId == null || token == null) return false
         while (true) {
             val current = activeLease.get() ?: return false
-            if (current.rowId != rowId || current.token != token) return false
+            if (
+                current.purpose != OutboundDrainLeasePurpose.Delivery ||
+                current.rowId != rowId ||
+                current.token != token
+            ) return false
             if (activeLease.compareAndSet(current, null)) return true
         }
     }
 
     fun release(lease: OutboundDrainLease?): Boolean =
         release(lease?.rowId, lease?.token)
+
+    fun releaseDisposal(permit: OutboundDisposalPermit): Boolean =
+        activeLease.compareAndSet(permit.lease, null)
+
+    internal fun ownsDisposal(permit: OutboundDisposalPermit): Boolean =
+        permit.lease.purpose == OutboundDrainLeasePurpose.Disposal &&
+            activeLease.get() === permit.lease
 
     fun forceRelease(): String? = activeLease.getAndSet(null)?.rowId
 

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueLifecycleCoordinator.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueLifecycleCoordinator.kt
@@ -1,0 +1,252 @@
+package com.pocketshell.app.composer
+
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Exact remote checkpoint/file hygiene for a discarded queue sidecar.
+ *
+ * The coordinator never dials SSH (D28). A live foreground transport may be
+ * handed in later to retry tombstones; failure leaves the tombstone for
+ * another pass and never resurrects the send.
+ */
+public fun interface QueueSidecarRemoteCleaner {
+    public suspend fun discardCheckpoint(remotePath: String, stableToken: String)
+}
+
+/**
+ * Issue #1589: binds the current foreground SSH transport to the typed, atomic
+ * lifecycle owner for the real user Delete path. Direct JVM tests may omit the
+ * coordinator; production Hilt supplies the singleton coordinator.
+ */
+public fun PromptComposerViewModel.setOutboundQueueRemoteCleaner(
+    cleaner: QueueSidecarRemoteCleaner?,
+) {
+    outboundQueueLifecycleCoordinator?.bindRemoteCleaner(cleaner)
+}
+
+public data class OutboundDisposalResult(
+    val removedRowIds: Set<String>,
+    val tombstoneCount: Int,
+) {
+    public companion object {
+        public val Empty: OutboundDisposalResult = OutboundDisposalResult(emptySet(), 0)
+    }
+}
+
+/**
+ * Issue #1589: the one app-scoped foreground owner for authorized queue
+ * disposal and crash-safe sidecar repair. It does not claim, flush, or send
+ * rows — host-CLI ack remains the delivery authority.
+ *
+ * [ioDispatcher] is a constructor argument (Shape A) so tests can pin every
+ * owned hop to the `runTest` scheduler before `init` runs. Setting a var
+ * after construction cannot cancel the real-IO startup repair that raced
+ * `stage()` / `deleteRecursively()`.
+ */
+@Singleton
+public class OutboundQueueLifecycleCoordinator(
+    private val queueStore: OutboundQueueStore,
+    private val sidecarStore: OutboundAttachmentSidecarStore,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    autoRepairOnInit: Boolean = true,
+) {
+    @Inject
+    public constructor(
+        queueStore: OutboundQueueStore,
+        sidecarStore: OutboundAttachmentSidecarStore,
+    ) : this(
+        queueStore = queueStore,
+        sidecarStore = sidecarStore,
+        ioDispatcher = Dispatchers.IO,
+        autoRepairOnInit = true,
+    )
+
+    @Volatile
+    @VisibleForTesting
+    internal var remoteCleaner: QueueSidecarRemoteCleaner? = null
+
+    private val job: Job = SupervisorJob()
+    private val scope = CoroutineScope(job + ioDispatcher)
+    private val lock = Any()
+    private val repairMutex = Mutex()
+
+    init {
+        if (autoRepairOnInit) {
+            scope.launch { runCatching { repairOrphans() } }
+        }
+    }
+
+    /**
+     * Bind the currently connected foreground transport for exact remote
+     * checkpoint cleanup. The coordinator never creates a second SSH session.
+     * A failed cleanup leaves its tombstone persisted for the next retry.
+     */
+    public fun bindRemoteCleaner(cleaner: QueueSidecarRemoteCleaner?) {
+        remoteCleaner = cleaner
+        if (cleaner != null) {
+            scope.launch { runCatching { retryRemoteHygiene(cleaner) } }
+        }
+    }
+
+    /**
+     * Durable commit: persist sidecar tombstones, then remove authorized rows.
+     * Local/remote bytes are cleaned after that commit so a crash can leak
+     * files but cannot destroy bytes while a deliverable row remains.
+     *
+     * Post-commit hygiene only touches the just-removed row ids (via
+     * tombstones). A full live-id repair is [repairOrphans] and must re-read
+     * live ids immediately before each sidecar delete.
+     */
+    internal suspend fun discardAuthorized(
+        authorization: OutboundDisposalAuthorization,
+        ownership: OutboundDisposalPermit,
+    ): OutboundDisposalResult = withContext(ioDispatcher) {
+        val authorizedRowId = when (authorization) {
+            is OutboundDisposalAuthorization.ExplicitDiscard -> authorization.rowId
+        }
+        if (ownership.rowId != authorizedRowId || !ownership.isCurrent()) {
+            return@withContext OutboundDisposalResult.Empty
+        }
+        val candidate = synchronized(lock) {
+            when (authorization) {
+                is OutboundDisposalAuthorization.ExplicitDiscard ->
+                    queueStore.item(authorization.rowId)
+            }
+        } ?: return@withContext OutboundDisposalResult.Empty
+        if (!OutboundQueueRetentionPolicy.mayDiscard(candidate, authorization)) {
+            return@withContext OutboundDisposalResult.Empty
+        }
+
+        // Keep the sidecar transaction lock held through the atomic queue
+        // removal. Repair and enqueue use the same ordering, so neither can
+        // delete a sidecar between this snapshot and its row commit.
+        val committed = sidecarStore.withSidecarLockBlocking {
+                val byDisplayName = candidate.attachments
+                    .mapNotNull { ref ->
+                        val path = ref.remotePath.trim().takeIf { it.isNotEmpty() }
+                            ?: return@mapNotNull null
+                        ref.displayName.takeIf { it.isNotBlank() }?.let { it to path }
+                    }
+                    .toMap()
+                val bySidecarId = sidecarStore.allRefsIncludingMissingBlocking()
+                    .filter { it.outboundItemId == candidate.id }
+                    .mapNotNull { ref ->
+                        val path = ref.uploadedRemotePath
+                            ?: byDisplayName[ref.displayName]
+                            ?: return@mapNotNull null
+                        ref.id to path
+                    }
+                    .toMap()
+                val tombstones = sidecarStore.tombstonesForOutboundItem(candidate.id, bySidecarId)
+                if (tombstones.isNotEmpty()) {
+                    sidecarStore.persistTombstonesBlocking(tombstones)
+                }
+                // The typed drain-owner permit stays reserved until this method
+                // returns, while removeIfIdle atomically arbitrates a direct
+                // store claim that may have started before the reservation.
+                val removed = queueStore.removeIfIdle(candidate.id)
+                removed to tombstones
+        }
+        val removed = committed.first ?: return@withContext OutboundDisposalResult.Empty
+        val committedTombstones = committed.second
+        if (committedTombstones.isNotEmpty()) {
+            scope.launch {
+                runCatching { applyLocalTombstones(committedTombstones) }
+            }
+        }
+        OutboundDisposalResult(
+            removedRowIds = setOf(removed.id),
+            tombstoneCount = committedTombstones.size,
+        )
+    }
+
+    public suspend fun repairOrphans() = withContext(ioDispatcher) {
+        repairMutex.withLock {
+            // Re-read live ids inside the sidecar lock, immediately before each
+            // delete. A snapshot taken here would let a concurrent enqueue+stage
+            // on B lose B's sidecar while B's row stayed queued.
+            sidecarStore.reconcileAgainstLiveRowIds(queueStore::allLiveRowIds)
+            val liveRowIds = queueStore.allLiveRowIds()
+            val pending = sidecarStore.pendingTombstonesBlocking().filter { tombstone ->
+                tombstone.outboundItemId !in liveRowIds &&
+                    !OutboundQueueRetentionPolicy.isDraftSidecarScope(tombstone.outboundItemId)
+            }
+            applyLocalTombstones(pending)
+            remoteCleaner?.let { retryRemoteHygieneLocked(it) }
+        }
+    }
+
+    public suspend fun retryRemoteHygiene(cleaner: QueueSidecarRemoteCleaner) =
+        withContext(ioDispatcher) {
+            repairMutex.withLock { retryRemoteHygieneLocked(cleaner) }
+        }
+
+    @VisibleForTesting
+    internal fun close() {
+        job.cancel()
+    }
+
+    @VisibleForTesting
+    internal suspend fun closeAndJoin() {
+        job.cancelAndJoin()
+    }
+
+    private suspend fun retryRemoteHygieneLocked(cleaner: QueueSidecarRemoteCleaner) {
+        val liveRowIds = queueStore.allLiveRowIds()
+        val pending = sidecarStore.pendingTombstonesBlocking().filter { tombstone ->
+            tombstone.outboundItemId !in liveRowIds &&
+                !OutboundQueueRetentionPolicy.isDraftSidecarScope(tombstone.outboundItemId)
+        }
+        val completed = mutableSetOf<String>()
+        for (tombstone in pending) {
+            val remotePath = tombstone.remotePath ?: continue
+            val discarded = runCatching {
+                cleaner.discardCheckpoint(remotePath, tombstone.stableToken)
+            }.isSuccess
+            if (discarded) completed += tombstone.sidecarId
+        }
+        if (completed.isNotEmpty()) {
+            sidecarStore.removeTombstonesBlocking(completed)
+        }
+    }
+
+    private suspend fun applyLocalTombstones(tombstones: List<SidecarCleanupTombstone>) {
+        val fullyLocal = mutableSetOf<String>()
+        for (tombstone in tombstones) {
+            // Re-read ownership while holding the same lock as enqueue/stage.
+            // A row re-created with the same durable id between the earlier
+            // snapshot and cleanup must keep its sidecar bytes.
+            val removed = sidecarStore.withSidecarLockBlocking {
+                val live = queueStore.allLiveRowIds()
+                if (
+                    tombstone.outboundItemId in live ||
+                    OutboundQueueRetentionPolicy.isDraftSidecarScope(tombstone.outboundItemId)
+                ) {
+                    false
+                } else {
+                    runCatching {
+                        sidecarStore.removeOutboundItemLocked(tombstone.outboundItemId)
+                    }.isSuccess
+                }
+            }
+            if (removed && tombstone.remotePath.isNullOrBlank()) {
+                fullyLocal += tombstone.sidecarId
+            }
+        }
+        if (fullyLocal.isNotEmpty()) {
+            sidecarStore.removeTombstonesBlocking(fullyLocal)
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueRetentionPolicy.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueRetentionPolicy.kt
@@ -1,0 +1,40 @@
+package com.pocketshell.app.composer
+
+/**
+ * Issue #1589: the pure storage/lifecycle policy for parked outbound rows.
+ *
+ * This is not a delivery authority and never claims or sends a row. Age alone
+ * never authorizes deletion. A name-only fallback key, a failed/partial
+ * reconcile, current-screen absence, or a same-name recreate is never proof
+ * that a target is dead.
+ */
+public sealed class OutboundDisposalAuthorization {
+    /** User tapped Delete on one visible retryable row. */
+    public data class ExplicitDiscard(val rowId: String) : OutboundDisposalAuthorization()
+}
+
+public object OutboundQueueRetentionPolicy {
+
+    public fun isDraftSidecarScope(outboundItemId: String): Boolean =
+        outboundItemId.startsWith("draft/")
+
+    public fun isOrphanSidecar(outboundItemId: String, liveRowIds: Set<String>): Boolean =
+        outboundItemId.isNotBlank() &&
+            !isDraftSidecarScope(outboundItemId) &&
+            outboundItemId !in liveRowIds
+
+    public fun mayDiscard(
+        row: OutboundItem,
+        authorization: OutboundDisposalAuthorization,
+        nowMs: Long = 0L,
+        createdAtMs: Long = row.createdAtMs,
+    ): Boolean {
+        // [nowMs]/[createdAtMs] exist so a clock mutation can prove age is ignored.
+        if (row.state == OutboundState.Delivered) return false
+        return when (authorization) {
+            is OutboundDisposalAuthorization.ExplicitDiscard ->
+                row.id == authorization.rowId && row.state.isExplicitlyDiscardable
+        }
+    }
+
+}

--- a/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/OutboundQueueStore.kt
@@ -146,6 +146,16 @@ public interface OutboundQueueStore {
     public fun itemsFor(sessionKey: String): List<OutboundItem>
 
     /**
+     * Issue #1589: every un-delivered row across all sessions, oldest-first.
+     * Sidecar repair compares refs against [allLiveRowIds].
+     */
+    public fun allLiveItems(): List<OutboundItem>
+
+    /** Stable ids of [allLiveItems]. */
+    public fun allLiveRowIds(): Set<String> =
+        allLiveItems().mapTo(mutableSetOf()) { it.id }
+
+    /**
      * Atomically move undelivered rows from a temporary [fromSessionKey] to the
      * canonical [toSessionKey], but only when each row's tap-time pane belongs
      * to [livePaneIds]. This is the bounded identity-promotion path for a live
@@ -369,6 +379,21 @@ public interface OutboundQueueStore {
      * an item was removed.
      */
     public fun remove(id: String): Boolean
+
+    /**
+     * Atomically remove an idle row owned by [id], or return `null` without
+     * changing the store when the row is active or missing. The production
+     * caller separately holds an [OutboundDisposalPermit], so a delivery worker
+     * cannot begin ownership during this store transaction. The state check and removal happen
+     * under the queue-store lock; a claim racing this operation therefore wins
+     * exactly one side of the interleaving, never both.
+     *
+     * This is the only row-removal primitive used by authorized user disposal.
+     * It intentionally permits `HeldForReview` because an explicit Delete is
+     * an exact user action; `Uploading`/`InFlight` remain protected until their
+     * owner has cancelled and joined.
+     */
+    public fun removeIfIdle(id: String): OutboundItem?
 
     /** Drop every item for [sessionKey]. */
     public fun clearSession(sessionKey: String)
@@ -693,6 +718,10 @@ public enum class OutboundState {
      */
     public val isPending: Boolean
         get() = this == Queued || this == Uploading || this == InFlight
+
+    /** Explicit Delete may remove idle/held intent, never an active attempt. */
+    public val isExplicitlyDiscardable: Boolean
+        get() = this == Queued || this == Failed || this == HeldForReview
 }
 
 /**
@@ -793,6 +822,12 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
     override fun itemsFor(sessionKey: String): List<OutboundItem> = synchronized(lock) {
         items.values
             .filter { it.sessionKey == sessionKey }
+            .sortedBy { it.createdAtMs }
+    }
+
+    override fun allLiveItems(): List<OutboundItem> = synchronized(lock) {
+        items.values
+            .filter { it.state != OutboundState.Delivered }
             .sortedBy { it.createdAtMs }
     }
 
@@ -999,6 +1034,14 @@ public open class InMemoryOutboundQueueStore : OutboundQueueStore {
 
     override fun remove(id: String): Boolean = synchronized(lock) { items.remove(id) != null }
 
+    override fun removeIfIdle(id: String): OutboundItem? = synchronized(lock) {
+        val existing = items[id] ?: return@synchronized null
+        if (!existing.state.isExplicitlyDiscardable) {
+            return@synchronized null
+        }
+        items.remove(id)
+    }
+
     override fun clearSession(sessionKey: String): Unit = synchronized(lock) {
         items.values.removeAll { it.sessionKey == sessionKey }
     }
@@ -1112,6 +1155,7 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
 
     override fun enqueueExisting(item: OutboundItem): OutboundItem = item
     override fun itemsFor(sessionKey: String): List<OutboundItem> = emptyList()
+    override fun allLiveItems(): List<OutboundItem> = emptyList()
     override fun promoteSessionIdentity(
         fromSessionKey: String,
         toSessionKey: String,
@@ -1133,6 +1177,7 @@ public object DisabledOutboundQueueStore : OutboundQueueStore {
     override fun approveStaleForSend(id: String, nowMillis: Long): OutboundItem? = null
     override fun requeueStaleInFlight(sessionKey: String, cutoffMs: Long): List<OutboundItem> = emptyList()
     override fun remove(id: String): Boolean = false
+    override fun removeIfIdle(id: String): OutboundItem? = null
     override fun clearSession(sessionKey: String) = Unit
     override fun markWireAttempted(
         sessionKey: String,
@@ -1313,6 +1358,13 @@ public class SharedPrefsOutboundQueueStore internal constructor(
 
     override fun itemsFor(sessionKey: String): List<OutboundItem> = synchronized(lock) {
         loadSession(sessionKey).sortedBy { it.createdAtMs }
+    }
+
+    override fun allLiveItems(): List<OutboundItem> = synchronized(lock) {
+        sessionKeys()
+            .flatMap { key -> loadSession(key) }
+            .filter { it.state != OutboundState.Delivered }
+            .sortedBy { it.createdAtMs }
     }
 
     override fun promoteSessionIdentity(
@@ -1573,6 +1625,17 @@ public class SharedPrefsOutboundQueueStore internal constructor(
         val removed = list.removeAll { it.id == id }
         if (removed) storeSession(sessionKey, list)
         removed
+    }
+
+    override fun removeIfIdle(id: String): OutboundItem? = synchronized(lock) {
+        val sessionKey = sessionOf(id) ?: return@synchronized null
+        val list = loadSession(sessionKey)
+        val target = list.firstOrNull { it.id == id }
+            ?: return@synchronized null
+        if (!target.state.isExplicitlyDiscardable) return@synchronized null
+        val remaining = list.filterNot { it.id == id }
+        storeSession(sessionKey, remaining)
+        target
     }
 
     override fun clearSession(sessionKey: String): Unit = synchronized(lock) {

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundDrain.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundDrain.kt
@@ -1,7 +1,35 @@
 package com.pocketshell.app.composer
 
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Runs explicit Delete under the same physical-owner lease as delivery.
+ * Reserving the lease before launching IO prevents reconnect/collector wakes
+ * from claiming the row between the user's tap and the durable queue commit.
+ */
+internal fun PromptComposerViewModel.discardOutboundItemThroughLifecycleCoordinator(id: String) {
+    val item = outboundQueueStore.item(id) ?: return
+    if (!item.isComposerQueueRetryable() && !item.isComposerQueueHeldForReview()) return
+    val coordinator = outboundQueueLifecycleCoordinator ?: return
+    val ownership = outboundDrainOwnership.tryAcquireDisposal(id) ?: return
+    viewModelScope.launch {
+        try {
+            val result = coordinator.discardAuthorized(
+                OutboundDisposalAuthorization.ExplicitDiscard(id),
+                ownership,
+            )
+            if (id !in result.removedRowIds) return@launch
+            clearOutboundRetrying(id)
+            clearApprovedOutboundItemForDrain(id)
+            refreshOutboundQueueItems()
+        } finally {
+            outboundDrainOwnership.releaseDisposal(ownership)
+        }
+    }
+}
 
 internal fun PromptComposerViewModel.approveStaleOutboundItem(id: String): OutboundItem? {
     val previousState = outboundQueueStore.item(id)?.state?.name

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerOutboundSend.kt
@@ -755,38 +755,50 @@ internal suspend fun PromptComposerViewModel.enqueueSidecarBackedSend(
         index to localUri
     }
     val itemId = UUID.randomUUID().toString()
-    val stagedSidecars = sidecarStore.stage(
-        outboundItemId = itemId,
-        uris = localAttachments.map { it.second },
-        attachmentIndices = localAttachments.map { it.first },
-    )
-    if (stagedSidecars.size != localAttachments.size) {
-        error("Attachment upload failed: could not preserve selected file bytes")
+    val queuedItem = sidecarStore.withSidecarLock {
+        try {
+            // Commit the queue row while the sidecar lock is still held. Repair
+            // therefore cannot observe a staged ref before its row exists and
+            // delete it in the enqueue-vs-repair window.
+            val stagedSidecars = sidecarStore.stageLocked(
+                outboundItemId = itemId,
+                uris = localAttachments.map { it.second },
+                attachmentIndices = localAttachments.map { it.first },
+            )
+            if (stagedSidecars.size != localAttachments.size) {
+                error("Attachment upload failed: could not preserve selected file bytes")
+            }
+            val sidecars = sidecarStore.updateMetadataLocked(
+                stagedSidecars.associate { ref ->
+                    val attachment = attachments[requireNotNull(ref.attachmentIndex)]
+                    ref.id to (attachment.displayName to attachment.mimeType)
+                },
+            )
+            val item = OutboundItem(
+                id = itemId,
+                sessionKey = sessionKey,
+                cleanText = cleanDraft,
+                attachments = attachments.toSidecarAwareDurableRefs(sidecars),
+                withEnter = withEnter,
+                state = OutboundState.Queued,
+                createdAtMs = clock(),
+                paneId = sendTarget.paneId,
+                route = sendTarget.route,
+                agentKind = sendTarget.agentKind,
+                tmuxSessionId = sendTarget.tmuxSessionId,
+                tmuxSessionCreated = sendTarget.tmuxSessionCreated,
+                // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
+                // existing un-delivered row instead of minting a duplicate.
+                sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
+            )
+            outboundQueueStore.enqueueExisting(item)
+        } catch (t: Throwable) {
+            // A partial stage or queue persistence failure must not leave a
+            // sidecar ref outside the transaction's row ownership.
+            sidecarStore.removeOutboundItemLocked(itemId)
+            throw t
+        }
     }
-    val sidecars = sidecarStore.updateMetadata(
-        stagedSidecars.associate { ref ->
-            val attachment = attachments[requireNotNull(ref.attachmentIndex)]
-            ref.id to (attachment.displayName to attachment.mimeType)
-        },
-    )
-    val item = OutboundItem(
-        id = itemId,
-        sessionKey = sessionKey,
-        cleanText = cleanDraft,
-        attachments = attachments.toSidecarAwareDurableRefs(sidecars),
-        withEnter = withEnter,
-        state = OutboundState.Queued,
-        createdAtMs = clock(),
-        paneId = sendTarget.paneId,
-        route = sendTarget.route,
-        agentKind = sendTarget.agentKind,
-        tmuxSessionId = sendTarget.tmuxSessionId,
-        tmuxSessionCreated = sendTarget.tmuxSessionCreated,
-        // Issue #961: coalesce a re-Send of the SAME logical prompt onto the
-        // existing un-delivered row instead of minting a duplicate.
-        sendKey = computeSendKey(cleanDraft, attachments, withEnter, sendTarget),
-    )
-    val queuedItem = outboundQueueStore.enqueueExisting(item)
     // Issue #961: if this coalesced onto an existing un-delivered row, the
     // freshly-staged sidecars under our throwaway `itemId` are orphaned —
     // the existing row keeps its own staged bytes. Drop them and dispatch

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerViewModel.kt
@@ -115,6 +115,7 @@ public class PromptComposerViewModel @Inject constructor(
     // Hilt wiring provides the SharedPreferences-backed store.
     internal val outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
     internal val outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
+    internal val outboundQueueLifecycleCoordinator: OutboundQueueLifecycleCoordinator? = null,
     internal val savedStateHandle: SavedStateHandle = SavedStateHandle(),
 ) : ViewModel() {
 
@@ -1470,15 +1471,8 @@ public class PromptComposerViewModel @Inject constructor(
      * explicitly held-for-review rows can be deleted from the composer surface;
      * upload/in-flight rows stay visible and owned by the delivery worker.
      */
-    public fun discardOutboundItem(id: String) {
-        val item = outboundQueueStore.item(id) ?: return
-        if (!item.isComposerQueueRetryable() && !item.isComposerQueueHeldForReview()) return
-        outboundQueueStore.remove(id)
-        clearOutboundRetrying(id)
-        clearApprovedOutboundItemForDrain(id)
-        launchSidecarRemoval(id)
-        refreshOutboundQueueItems()
-    }
+    public fun discardOutboundItem(id: String): Unit =
+        discardOutboundItemThroughLifecycleCoordinator(id)
 
     /**
      * Issue #900: manually retry a durable outbound row without minting a new

--- a/app/src/main/java/com/pocketshell/app/tmux/SessionLifecycleSignals.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/SessionLifecycleSignals.kt
@@ -246,6 +246,10 @@ class SessionLifecycleSignals @Inject constructor(
         runtimeCache?.removeSession(hostId = hostId, generation = exact)?.forEach { runtime ->
             cleanupScope.launch { runtime.closeCachedRuntime() }
         }
+        // Name-only stale-absent is never a queue-deletion authority: a failed
+        // attach, hot-flow miss, or same-name recreate must not dispose parked
+        // rows. Lifecycle signals never dispose queue rows; explicit Delete is
+        // the only disposal authorization in this slice.
         _staleSessions.tryEmit(
             StaleSession(
                 hostId = hostId,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -57,6 +57,7 @@ import com.pocketshell.app.conversation.rememberConversationToTerminalSwapLatch
 import com.pocketshell.app.composer.PromptComposerViewModel
 import com.pocketshell.app.composer.outboundLauncherBadge
 import com.pocketshell.app.composer.promoteFallbackOutboundIdentity
+import com.pocketshell.app.composer.setOutboundQueueRemoteCleaner
 import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.layout.rememberTmuxImeLayoutState
 import com.pocketshell.app.projects.conventionalRemoteHome
@@ -705,11 +706,18 @@ private fun TmuxSessionScreenEffects(
                 viewModel.uploadQueuedAttachmentSidecars(pending)
             }
         }
+        // Issue #1589: remote tombstones use this screen's already-live
+        // foreground transport; the coordinator never creates a cleanup-only
+        // SSH connection.
+        promptComposerViewModel.setOutboundQueueRemoteCleaner { remotePath, stableToken ->
+            viewModel.discardQueueSidecarCheckpoint(remotePath, stableToken)
+        }
         // Issue #1686: wire the WIRE-oracle probe so the failure taxonomy + drain gate
         // read the transport's own truth instead of the ConnectionStatus enum.
         promptComposerViewModel.setTransportWritableProbe { viewModel.isSendTransportWritable() }
         onDispose {
             promptComposerViewModel.setOutboundAttachmentSidecarUploader(null)
+            promptComposerViewModel.setOutboundQueueRemoteCleaner(null)
             promptComposerViewModel.setTransportWritableProbe { false }
         }
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -13789,6 +13789,22 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /**
+     * Issue #1589: use the already-connected foreground transport to remove
+     * the exact final sidecar and its owned resumable-upload siblings. This is
+     * intentionally fail-fast when the screen has no live session so the
+     * coordinator keeps the tombstone for a later connected retry; it never
+     * creates a cleanup-only SSH connection.
+     */
+    public suspend fun discardQueueSidecarCheckpoint(
+        remotePath: String,
+        stableToken: String,
+    ) = withContext(seedIoDispatcher) {
+        val session = sessionRef?.takeIf { it.isConnected }
+            ?: throw SshException("No live foreground SSH session for queue sidecar cleanup")
+        session.discardQueueSidecarCheckpoint(remotePath, stableToken)
+    }
+
+    /**
      * Issue #451: return the live terminal [SshSession] for an attachment
      * upload, lazily connecting-then-awaiting the connection the way the
      * Send path does when the session is not currently live.

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundAttachmentSidecarStoreTest.kt
@@ -93,6 +93,81 @@ class OutboundAttachmentSidecarStoreTest {
     }
 
     @Test
+    fun reconcileAgainstLiveRowIdsRemovesOnlyProvenQueueOrphans() = runTest {
+        val store = newStore()
+        val orphan = store.stage(
+            outboundItemId = "dead-row",
+            uris = listOf(Uri.fromFile(sourceFile("gone.txt", "gone"))),
+        ).single()
+        val live = store.stage(
+            outboundItemId = "live-row",
+            uris = listOf(Uri.fromFile(sourceFile("keep.txt", "keep"))),
+        ).single()
+        val draft = store.stage(
+            outboundItemId = "draft/tmux:1:\$2:3",
+            uris = listOf(Uri.fromFile(sourceFile("draft.txt", "draft"))),
+        ).single()
+
+        // G6: if live-row-id membership were ignored, passing only live-row
+        // would still keep dead-row (current reconcile() behavior).
+        store.reconcile()
+        assertEquals(listOf(orphan.id), newStore().refsFor("dead-row").map { it.id })
+
+        newStore().reconcileAgainstLiveRowIds(setOf("live-row"))
+
+        val repaired = newStore()
+        assertTrue(repaired.refsFor("dead-row").isEmpty())
+        assertFalse(File(orphan.localPath).exists())
+        assertEquals(listOf(live.id), repaired.refsFor("live-row").map { it.id })
+        assertEquals(listOf(draft.id), repaired.refsFor("draft/tmux:1:\$2:3").map { it.id })
+        assertTrue(File(live.localPath).exists())
+        assertTrue(File(draft.localPath).exists())
+    }
+
+    @Test
+    fun reconcileReReadsLiveRowIdsBeforeDeletingEachSidecar() = runTest {
+        val store = newStore()
+        val live = store.stage(
+            outboundItemId = "live-row",
+            uris = listOf(Uri.fromFile(sourceFile("keep.txt", "keep"))),
+        ).single()
+        var reads = 0
+        store.reconcileAgainstLiveRowIds {
+            reads += 1
+            // G6: if only the first snapshot were used, this live sidecar
+            // would be deleted while its row is still queued.
+            if (reads == 1) emptySet() else setOf("live-row")
+        }
+        assertTrue(File(live.localPath).exists())
+        assertEquals(listOf(live.id), newStore().refsFor("live-row").map { it.id })
+        assertTrue("must consult live ids more than once", reads >= 2)
+    }
+
+    @Test
+    fun reconcileAgainstLiveRowIdsTombstonesRemotePathAfterMissingLocalCrashCut() = runTest {
+        val store = newStore()
+        val ref = store.stage(
+            outboundItemId = "dead-row",
+            uris = listOf(Uri.fromFile(sourceFile("uploaded.txt", "uploaded"))),
+        ).single()
+        store.markUploaded(mapOf(ref.id to "~/inbox/uploaded.txt"))
+
+        // Deterministic crash cut: the local sidecar has already disappeared,
+        // while the persisted ref still carries the completed remote upload.
+        // A fresh store models the next process and must repair that evidence.
+        File(ref.localPath).delete()
+        val restarted = newStore()
+        restarted.reconcileAgainstLiveRowIds(emptySet())
+
+        assertTrue(restarted.allRefsIncludingMissingBlocking().isEmpty())
+        assertFalse(File(ref.localPath).exists())
+        assertEquals(
+            "~/inbox/uploaded.txt",
+            restarted.pendingTombstonesBlocking().single { it.sidecarId == ref.id }.remotePath,
+        )
+    }
+
+    @Test
     fun reconcileRemovesRowsMissingLocalBytesAndOrphanFiles() = runTest {
         val saved = newStore().stage(
             outboundItemId = "queue-1",

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundParkedRowGcTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundParkedRowGcTest.kt
@@ -1,0 +1,306 @@
+package com.pocketshell.app.composer
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.tmux.SessionLifecycleSignals
+import com.pocketshell.app.tmux.TmuxSessionGeneration
+import java.io.File
+import java.util.concurrent.Executors
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #1589 regression coverage: exact explicit disposal and crash-safe
+ * sidecar repair. Stop/Kill is deliberately outside this disposal authority;
+ * lifecycle signals must never silently destroy user queue data.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class OutboundParkedRowGcTest {
+
+    private lateinit var context: Context
+    private val coordinators = mutableListOf<OutboundQueueLifecycleCoordinator>()
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("outbound_queue", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        context.getSharedPreferences(OutboundAttachmentSidecarStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        File(context.filesDir, OutboundAttachmentSidecarStore.DIRECTORY_NAME).deleteRecursively()
+    }
+
+    @After
+    fun tearDown() {
+        coordinators.forEach { it.close() }
+        coordinators.clear()
+    }
+
+    @Test
+    fun stopKillSignalDoesNotDisposeQueuedSidecars() = runTest {
+        val queue = SharedPrefsOutboundQueueStore(context)
+        val sidecar = pinnedSidecar()
+        val row = queue.enqueue("tmux:7:\$12:1700000000", "keep this prompt")
+        val ref = sidecar.stage(row.id, listOf(Uri.fromFile(sourceFile("keep.txt", "bytes")))).single()
+
+        // B1 safe fallback: lifecycle fan-out carries tree/cache identity only;
+        // there is no discard-on-kill path.
+        SessionLifecycleSignals(null, null).emitKilled(
+            hostId = 7L,
+            generation = TmuxSessionGeneration("\$12", 1700000000L),
+            lastKnownName = "old-name",
+        )
+
+        assertNotNull(queue.item(row.id))
+        assertEquals(listOf(ref.id), sidecar.refsFor(row.id).map { it.id })
+        assertTrue(File(ref.localPath).exists())
+    }
+
+    @Test
+    fun nameOnlyKillOrStaleObservationLeavesParkedRowUntouched() = runTest {
+        val queue = SharedPrefsOutboundQueueStore(context)
+        val row = queue.enqueue("tmux:7:\$12:1700000000", "must survive uncertainty")
+        val signals = SessionLifecycleSignals(null, null)
+
+        signals.emitKilled(hostId = 7L, generation = null, lastKnownName = "old-name")
+        signals.emitStaleSession(
+            hostId = 7L,
+            generation = null,
+            lastKnownName = "old-name",
+            folderPath = "/tmp/old-name",
+        )
+
+        assertEquals(row, queue.item(row.id))
+    }
+
+    @Test
+    fun repairReReadsLiveIdsRatherThanUsingAStaleSnapshot() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecar = pinnedSidecar()
+        val live = queue.enqueue("tmux:7:\$13:1700000001", "live B")
+        val staged = sidecar.stage(
+            live.id,
+            listOf(Uri.fromFile(sourceFile("live.txt", "live bytes"))),
+        ).single()
+
+        var liveReads = 0
+        val delayed = object : OutboundQueueStore by queue {
+            override fun allLiveRowIds(): Set<String> {
+                liveReads += 1
+                return if (liveReads == 1) emptySet() else queue.allLiveRowIds()
+            }
+        }
+        val coordinator = newCoordinator(delayed, sidecar)
+        coordinator.repairOrphans()
+
+        assertTrue(File(staged.localPath).exists())
+        assertEquals(listOf(staged.id), sidecar.refsFor(live.id).map { it.id })
+        assertTrue("must consult live ids more than once", liveReads >= 2)
+    }
+
+    @Test
+    fun uploadedRemoteOrphanIsTombstonedBeforeRefAndFileDrop() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecar = pinnedSidecar()
+        val row = queue.enqueue("tmux:7:\$12:1700000000", "orphan")
+        val ref = sidecar.stage(row.id, listOf(Uri.fromFile(sourceFile("remote.txt", "remote")))).single()
+        sidecar.markUploaded(mapOf(ref.id to "~/inbox/remote.txt"))
+        queue.remove(row.id)
+
+        val coordinator = newCoordinator(queue, sidecar)
+        coordinator.repairOrphans()
+
+        assertTrue(sidecar.refsFor(row.id).isEmpty())
+        assertFalse(File(ref.localPath).exists())
+        assertEquals(
+            "remote evidence must survive ref removal for a later connected retry",
+            "~/inbox/remote.txt",
+            sidecar.pendingTombstonesBlocking().single { it.sidecarId == ref.id }.remotePath,
+        )
+    }
+
+    @Test
+    fun explicitDeleteTombstoneSurvivesRowRemovalAndRemoteRetry() = runTest {
+        val queue = SharedPrefsOutboundQueueStore(context)
+        val sidecar = pinnedSidecar()
+        val coordinator = newCoordinator(queue, sidecar)
+        val row = queue.enqueue(
+            sessionKey = "tmux:7:\$12:1700000000",
+            cleanText = "attach",
+            attachments = listOf(DurableAttachmentRef("~/inbox/notes.txt", "notes.txt", "text/plain")),
+        )
+        val ref = sidecar.stage(row.id, listOf(Uri.fromFile(sourceFile("notes.txt", "notes")))).single()
+        sidecar.markUploaded(mapOf(ref.id to "~/inbox/notes.txt"))
+
+        val result = coordinator.discardWithOwnership(row.id)
+        assertEquals(setOf(row.id), result.removedRowIds)
+        assertTrue(result.tombstoneCount >= 1)
+        assertNull(queue.item(row.id))
+        advanceUntilIdle()
+        assertTrue(sidecar.refsFor(row.id).isEmpty())
+        assertFalse(File(ref.localPath).exists())
+        assertTrue(sidecar.pendingTombstonesBlocking().any { it.sidecarId == ref.id })
+
+        val cleaned = mutableListOf<Pair<String, String>>()
+        coordinator.bindRemoteCleaner { remotePath, token -> cleaned += remotePath to token }
+        coordinator.repairOrphans()
+
+        assertEquals(listOf("~/inbox/notes.txt" to ref.id), cleaned)
+        assertTrue(sidecar.pendingTombstonesBlocking().none { it.sidecarId == ref.id })
+    }
+
+    @Test
+    fun remoteCleanupCannotTouchLiveRowToken() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecar = pinnedSidecar()
+        val dead = queue.enqueue("tmux:7:\$12:1700000000", "dead")
+        val live = queue.enqueue("tmux:7:\$13:1700000001", "live")
+        val deadRef = sidecar.stage(dead.id, listOf(Uri.fromFile(sourceFile("dead.txt", "d")))).single()
+        val liveRef = sidecar.stage(live.id, listOf(Uri.fromFile(sourceFile("live.txt", "l")))).single()
+        sidecar.markUploaded(
+            mapOf(deadRef.id to "~/inbox/dead.txt", liveRef.id to "~/inbox/live.txt"),
+        )
+        queue.remove(dead.id)
+
+        val seen = mutableListOf<String>()
+        val coordinator = newCoordinator(queue, sidecar)
+        coordinator.bindRemoteCleaner { _, token -> seen += token }
+        coordinator.repairOrphans()
+
+        assertEquals(setOf(deadRef.id), seen.toSet())
+        assertFalse(liveRef.id in seen)
+        assertEquals(listOf(liveRef.id), sidecar.refsFor(live.id).map { it.id })
+    }
+
+    @Test
+    fun removeIfIdleRefusesClaimThatWinsTheInterleaving() = runTest {
+        val delegate = InMemoryOutboundQueueStore()
+        val row = delegate.enqueue("tmux:7:\$12:1700000000", "claim race")
+        val queue = object : OutboundQueueStore by delegate {
+            override fun removeIfIdle(id: String): OutboundItem? {
+                // Simulate the drain winning immediately before the store's
+                // atomic removal check. The active row must remain recoverable.
+                delegate.claim(id)
+                return delegate.removeIfIdle(id)
+            }
+        }
+        val coordinator = newCoordinator(queue, pinnedSidecar())
+
+        val result = coordinator.discardWithOwnership(row.id)
+
+        assertEquals(OutboundDisposalResult.Empty, result)
+        assertEquals(OutboundState.InFlight, delegate.item(row.id)?.state)
+    }
+
+    @Test
+    fun explicitDiscardBlockingPrefsRunOnCoordinatorIoDispatcher() = runTest {
+        val executor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "issue-1589-queue-io")
+        }
+        val dispatcher = executor.asCoroutineDispatcher()
+        try {
+            val queue = InMemoryOutboundQueueStore()
+            val sidecar = OutboundAttachmentSidecarStore(context).also { it.ioDispatcher = dispatcher }
+            val coordinator = OutboundQueueLifecycleCoordinator(
+                queueStore = queue,
+                sidecarStore = sidecar,
+                ioDispatcher = dispatcher,
+                autoRepairOnInit = false,
+            ).also { coordinators += it }
+            val row = queue.enqueue("tmux:7:\$12:1700000000", "thread check")
+            sidecar.stage(row.id, listOf(Uri.fromFile(sourceFile("thread.txt", "bytes"))))
+
+            coordinator.discardWithOwnership(row.id)
+
+            assertEquals("issue-1589-queue-io", sidecar.lastBlockingAccessThreadNameForTest)
+        } finally {
+            dispatcher.close()
+        }
+    }
+
+    @Test
+    fun coordinatorNeverClaimsOrDeliversRows() = runTest {
+        val queue = CountingClaimStore()
+        val coordinator = newCoordinator(queue, pinnedSidecar())
+        val row = queue.enqueue("tmux:7:\$12:1700000000", "must not send")
+
+        coordinator.discardWithOwnership(row.id)
+
+        assertEquals(0, queue.claimCalls)
+        assertEquals(0, queue.deliverCalls)
+    }
+
+    private fun TestScope.pinnedSidecar(): OutboundAttachmentSidecarStore =
+        OutboundAttachmentSidecarStore(context).also {
+            it.ioDispatcher = StandardTestDispatcher(testScheduler)
+        }
+
+    private fun TestScope.newCoordinator(
+        queue: OutboundQueueStore,
+        sidecar: OutboundAttachmentSidecarStore,
+    ): OutboundQueueLifecycleCoordinator =
+        OutboundQueueLifecycleCoordinator(
+            queueStore = queue,
+            sidecarStore = sidecar,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            autoRepairOnInit = false,
+        ).also { coordinators += it }
+
+    private suspend fun OutboundQueueLifecycleCoordinator.discardWithOwnership(
+        rowId: String,
+    ): OutboundDisposalResult {
+        val owner = OutboundDrainOwnership()
+        val permit = requireNotNull(owner.tryAcquireDisposal(rowId))
+        return try {
+            discardAuthorized(OutboundDisposalAuthorization.ExplicitDiscard(rowId), permit)
+        } finally {
+            assertTrue(owner.releaseDisposal(permit))
+        }
+    }
+
+    private fun sourceFile(name: String, content: String): File =
+        File(context.cacheDir, name).apply {
+            parentFile?.mkdirs()
+            writeText(content)
+        }
+
+    private class CountingClaimStore(
+        private val delegate: InMemoryOutboundQueueStore = InMemoryOutboundQueueStore(),
+    ) : OutboundQueueStore by delegate {
+        var claimCalls: Int = 0
+        var deliverCalls: Int = 0
+
+        override fun claimNext(sessionKey: String, nowMillis: Long): OutboundItem? {
+            claimCalls += 1
+            return delegate.claimNext(sessionKey, nowMillis)
+        }
+
+        override fun claim(id: String, nowMillis: Long): OutboundItem? {
+            claimCalls += 1
+            return delegate.claim(id, nowMillis)
+        }
+
+        override fun markDelivered(id: String): Boolean {
+            deliverCalls += 1
+            return delegate.markDelivered(id)
+        }
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueRetentionPolicyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueRetentionPolicyTest.kt
@@ -1,0 +1,115 @@
+package com.pocketshell.app.composer
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OutboundQueueRetentionPolicyTest {
+
+    @Test
+    fun ageAloneNeverAuthorizesDeletion() {
+        val row = queued(createdAtMs = 1L)
+        assertFalse(
+            "G6 mutation: age must never replace explicit row authorization",
+            OutboundQueueRetentionPolicy.mayDiscard(
+                row = row,
+                authorization = OutboundDisposalAuthorization.ExplicitDiscard("other-id"),
+                nowMs = 1_000_000_000L,
+                createdAtMs = 1L,
+            ),
+        )
+    }
+
+    @Test
+    fun explicitDiscardRequiresTheExactRowId() {
+        val row = queued()
+        assertTrue(
+            OutboundQueueRetentionPolicy.mayDiscard(
+                row,
+                OutboundDisposalAuthorization.ExplicitDiscard(row.id),
+            ),
+        )
+        assertFalse(
+            "G6: a different row id must not authorize this row",
+            OutboundQueueRetentionPolicy.mayDiscard(
+                row,
+                OutboundDisposalAuthorization.ExplicitDiscard("different-row"),
+            ),
+        )
+    }
+
+    @Test
+    fun explicitDiscardAllowsHeldRowsButNeverActiveRows() {
+        val queued = queued()
+        val failed = queued.copy(id = "failed", state = OutboundState.Failed)
+        val held = queued.copy(id = "held", state = OutboundState.HeldForReview)
+        val inFlight = queued.copy(id = "inflight", state = OutboundState.InFlight)
+        val uploading = queued.copy(id = "uploading", state = OutboundState.Uploading)
+
+        assertTrue(
+            OutboundQueueRetentionPolicy.mayDiscard(
+                queued,
+                OutboundDisposalAuthorization.ExplicitDiscard(queued.id),
+            ),
+        )
+        assertTrue(
+            OutboundQueueRetentionPolicy.mayDiscard(
+                failed,
+                OutboundDisposalAuthorization.ExplicitDiscard(failed.id),
+            ),
+        )
+        assertTrue(
+            OutboundQueueRetentionPolicy.mayDiscard(
+                held,
+                OutboundDisposalAuthorization.ExplicitDiscard(held.id),
+            ),
+        )
+        assertFalse(
+            OutboundQueueRetentionPolicy.mayDiscard(
+                inFlight,
+                OutboundDisposalAuthorization.ExplicitDiscard(inFlight.id),
+            ),
+        )
+        assertFalse(
+            OutboundQueueRetentionPolicy.mayDiscard(
+                uploading,
+                OutboundDisposalAuthorization.ExplicitDiscard(uploading.id),
+            ),
+        )
+    }
+
+    @Test
+    fun disposalPermitRefusesWhileDeliveryOwnsThePhysicalDrain() {
+        val owner = OutboundDrainOwnership()
+        val delivery = requireNotNull(owner.tryAcquire("row-a"))
+
+        assertTrue("precondition: delivery owns row-a", owner.activeRowId() == "row-a")
+        assertTrue(
+            "G6: Delete must have no typed permit while delivery is live",
+            owner.tryAcquireDisposal("row-a") == null,
+        )
+
+        assertTrue(owner.release(delivery))
+        val permit = requireNotNull(owner.tryAcquireDisposal("row-a"))
+        assertTrue(permit.isCurrent())
+        assertTrue(owner.releaseDisposal(permit))
+    }
+
+    @Test
+    fun draftScopesAreNeverQueueOrphans() {
+        assertTrue(OutboundQueueRetentionPolicy.isDraftSidecarScope("draft/tmux:7:\$12:1"))
+        assertFalse(
+            OutboundQueueRetentionPolicy.isOrphanSidecar("draft/tmux:7:\$12:1", liveRowIds = emptySet()),
+        )
+        assertTrue(OutboundQueueRetentionPolicy.isOrphanSidecar("dead-row", liveRowIds = setOf("live-row")))
+        assertFalse(OutboundQueueRetentionPolicy.isOrphanSidecar("live-row", liveRowIds = setOf("live-row")))
+    }
+
+    private fun queued(createdAtMs: Long = 10L): OutboundItem =
+        OutboundItem(
+            id = "row-a",
+            sessionKey = "tmux:7:\$12:1700000000",
+            cleanText = "parked",
+            createdAtMs = createdAtMs,
+        )
+}

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundQueueStoreTest.kt
@@ -678,6 +678,29 @@ class OutboundQueueStoreTest {
     }
 
     @Test
+    fun allLiveRowIdsEnumerateEveryUndeliveredRow() {
+        val store = store()
+        val a = store.enqueue("tmux:1:\$1:1", "a")
+        val b = store.enqueue("tmux:1:\$2:2", "b")
+        store.enqueue("tmux:1:\$1:1", "a2")
+        store.markDelivered(b.id)
+        assertEquals(setOf(a.id, store.itemsFor("tmux:1:\$1:1").last().id), store.allLiveRowIds())
+        assertFalse(b.id in store.allLiveRowIds())
+    }
+
+    @Test
+    fun removeIfIdleIsAtomicAndPreservesActiveOrOwnedRows() {
+        val store = store()
+        val queued = store.enqueue("sessA", "queued")
+        val active = store.enqueue("sessA", "active")
+        store.claim(active.id)
+
+        assertEquals(queued, store.removeIfIdle(queued.id))
+        assertNull(store.removeIfIdle(active.id))
+        assertEquals(OutboundState.InFlight, store.item(active.id)?.state)
+    }
+
+    @Test
     fun clearSessionAndRemoveAreScopedAndDoNotBleed() {
         val store = store()
         val a = store.enqueue("sessA", "a1")

--- a/app/src/test/java/com/pocketshell/app/composer/OutboundStaleHoldPolicyTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/OutboundStaleHoldPolicyTest.kt
@@ -438,6 +438,12 @@ class OutboundStaleHoldPolicyTest {
     fun discardHeldForReviewRemovesTheRowAndItsSidecar() = runTest {
         val store = InMemoryOutboundQueueStore()
         val sidecars = newSidecarStore(StandardTestDispatcher(testScheduler))
+        val coordinator = OutboundQueueLifecycleCoordinator(
+            queueStore = store,
+            sidecarStore = sidecars,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            autoRepairOnInit = false,
+        )
         val now = System.currentTimeMillis()
         val queued = store.enqueue(
             sessionKey = SESSION,
@@ -460,7 +466,7 @@ class OutboundStaleHoldPolicyTest {
         assertTrue(sidecarFile.exists())
         assertEquals(listOf(staged), sidecars.refsFor(held.id))
 
-        val vm = newVm(store, sidecars)
+        val vm = newVm(store, sidecars, coordinator)
         vm.onComposerTargetChanged(SESSION)
         vm.discardOutboundItem(held.id)
         advanceUntilIdle()
@@ -477,6 +483,7 @@ class OutboundStaleHoldPolicyTest {
             "Delete must remove the held row's sidecar metadata",
             sidecars.refsFor(held.id).isEmpty(),
         )
+        coordinator.close()
     }
 
     @Test
@@ -495,6 +502,7 @@ class OutboundStaleHoldPolicyTest {
     private fun newVm(
         store: OutboundQueueStore,
         sidecars: OutboundAttachmentSidecarStore? = null,
+        coordinator: OutboundQueueLifecycleCoordinator? = null,
     ): PromptComposerViewModel {
         val dispatcher = StandardTestDispatcher(mainDispatcherRule.dispatcher.scheduler)
         val vm = PromptComposerViewModel(
@@ -523,6 +531,7 @@ class OutboundStaleHoldPolicyTest {
             },
             outboundQueueStore = store,
             outboundAttachmentSidecarStore = sidecars,
+            outboundQueueLifecycleCoordinator = coordinator,
             savedStateHandle = SavedStateHandle(),
         )
         vm.samplerDispatcher = dispatcher

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentDurableFromPickTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerAttachmentDurableFromPickTest.kt
@@ -10,8 +10,16 @@ import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.settings.VoiceTranscriptionProvider
 import com.pocketshell.core.ssh.SshException
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -84,7 +92,7 @@ class PromptComposerAttachmentDurableFromPickTest {
     }
 
     private fun newVm(
-        dispatcher: TestDispatcher,
+        dispatcher: CoroutineDispatcher,
         outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
         outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
         composerDraftStore: ComposerDraftStore = InMemoryComposerDraftStore(),
@@ -121,7 +129,7 @@ class PromptComposerAttachmentDurableFromPickTest {
     }
 
     private fun newSidecarStore(
-        ioDispatcher: TestDispatcher,
+        ioDispatcher: CoroutineDispatcher,
         context: Context = ApplicationProvider.getApplicationContext(),
     ): OutboundAttachmentSidecarStore {
         context.getSharedPreferences(OutboundAttachmentSidecarStore.PREFS_NAME, Context.MODE_PRIVATE)
@@ -490,6 +498,86 @@ class PromptComposerAttachmentDurableFromPickTest {
         val queuedRef = sidecars.refsFor(row.id).single()
         assertEquals("b.txt", queuedRef.displayName)
         assertEquals("B-BYTES", File(queuedRef.localPath).readText())
+    }
+
+    @Test
+    fun sidecarEnqueueAndOrphanRepairShareOneCommitLock() = runTest {
+        // G6: the queue commit is deliberately paused after staging. Repair is
+        // forced to attempt its lock during that pause; the pre-fix window let
+        // it delete the staged bytes before the row existed.
+        val executor = Executors.newFixedThreadPool(2)
+        val dispatcher = executor.asCoroutineDispatcher()
+        val releaseQueueCommit = CountDownLatch(1)
+        val enqueueEntered = CountDownLatch(1)
+        val repairAttempted = CountDownLatch(1)
+        val captured = AtomicReference<OutboundItem>()
+        var coordinator: OutboundQueueLifecycleCoordinator? = null
+        try {
+            val delegate = InMemoryOutboundQueueStore()
+            val queue = object : OutboundQueueStore by delegate {
+                override fun enqueueExisting(item: OutboundItem): OutboundItem {
+                    captured.set(item)
+                    enqueueEntered.countDown()
+                    check(releaseQueueCommit.await(5, TimeUnit.SECONDS)) {
+                        "test queue commit was not released"
+                    }
+                    return delegate.enqueueExisting(item)
+                }
+            }
+            val sidecars = newSidecarStore(dispatcher)
+            val lockAttempts = AtomicInteger()
+            sidecars.lockAttemptObserverForTest = {
+                if (lockAttempts.incrementAndGet() == 2) repairAttempted.countDown()
+            }
+            coordinator = OutboundQueueLifecycleCoordinator(
+                queueStore = queue,
+                sidecarStore = sidecars,
+                ioDispatcher = dispatcher,
+                autoRepairOnInit = false,
+            )
+            val vm = newVm(dispatcher, queue, sidecars)
+            val enqueueJob = async(dispatcher) {
+                vm.enqueueSidecarBackedSend(
+                    cleanDraft = "keep sidecar bytes",
+                    attachments = listOf(
+                        PromptComposerViewModel.StagedAttachment(
+                            remotePath = "pending/file.txt",
+                            displayName = "file.txt",
+                            previewUri = pickedFile("lock.txt", "LOCK-BYTES"),
+                            mimeType = "text/plain",
+                            transferState = AttachmentTransferState.PendingLocal,
+                        ),
+                    ),
+                    withEnter = true,
+                    sendTarget = PromptComposerViewModel.SendTargetSnapshot(
+                        sessionKey = "1/session-lock",
+                    ),
+                )
+            }
+            assertTrue(enqueueEntered.await(5, TimeUnit.SECONDS))
+            val stagedItem = requireNotNull(captured.get())
+            assertNull(delegate.item(stagedItem.id))
+
+            val repairJob = async(dispatcher) { coordinator!!.repairOrphans() }
+            assertTrue(
+                "repair must attempt the shared lock while enqueue is paused",
+                repairAttempted.await(5, TimeUnit.SECONDS),
+            )
+            assertFalse(
+                "repair must remain blocked until the queue row commits",
+                repairJob.isCompleted,
+            )
+
+            releaseQueueCommit.countDown()
+            val queued = requireNotNull(enqueueJob.await())
+            repairJob.await()
+            assertNotNull(delegate.item(queued.id))
+            assertEquals(1, sidecars.refsFor(queued.id).size)
+        } finally {
+            releaseQueueCommit.countDown()
+            coordinator?.close()
+            executor.shutdownNow()
+        }
     }
 
     // ---- R-A durability across a session switch A→B→A (no bytes lost) ---------

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerOutboundSendQueueViewModelTest.kt
@@ -209,6 +209,7 @@ class PromptComposerOutboundSendQueueViewModelTest {
         connectivity: PromptComposerViewModel.ConnectivityProbe = AlwaysOnlineConnectivityProbe,
         outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
         outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
+        outboundQueueLifecycleCoordinator: OutboundQueueLifecycleCoordinator? = null,
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
     ): PromptComposerViewModel {
         val factory = WhisperClientFactory { whisper }
@@ -223,6 +224,7 @@ class PromptComposerOutboundSendQueueViewModelTest {
             composerDraftStore = composerDraftStore,
             outboundQueueStore = outboundQueueStore,
             outboundAttachmentSidecarStore = outboundAttachmentSidecarStore,
+            outboundQueueLifecycleCoordinator = outboundQueueLifecycleCoordinator,
             savedStateHandle = savedStateHandle,
         )
         if (samplerDispatcher != null) {
@@ -1681,6 +1683,12 @@ class PromptComposerOutboundSendQueueViewModelTest {
     fun deliveredAndDeletedOutboundItemsCleanUpSidecars() = runTest {
         val queue = InMemoryOutboundQueueStore()
         val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))
+        val coordinator = OutboundQueueLifecycleCoordinator(
+            queueStore = queue,
+            sidecarStore = sidecars,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            autoRepairOnInit = false,
+        )
         val delivered = OutboundItem(
             id = "delivered-local",
             sessionKey = "1/session-a",
@@ -1703,6 +1711,7 @@ class PromptComposerOutboundSendQueueViewModelTest {
             samplerDispatcher = StandardTestDispatcher(testScheduler),
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
+            outboundQueueLifecycleCoordinator = coordinator,
         )
         vm.onComposerTargetChanged("1/session-a")
 
@@ -1722,12 +1731,19 @@ class PromptComposerOutboundSendQueueViewModelTest {
         advanceUntilIdle()
 
         waitForSidecarsCleared(sidecars, deleted.id)
+        coordinator.close()
     }
 
     @Test
     fun heldForReviewOutboundItemCanBeDeletedAndCleansSidecar() = runTest {
         val queue = InMemoryOutboundQueueStore()
         val sidecars = newSidecarStore(ioDispatcher = StandardTestDispatcher(testScheduler))
+        val coordinator = OutboundQueueLifecycleCoordinator(
+            queueStore = queue,
+            sidecarStore = sidecars,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            autoRepairOnInit = false,
+        )
         val now = System.currentTimeMillis()
         val queued = queue.enqueue(
             sessionKey = "1/session-a",
@@ -1742,6 +1758,7 @@ class PromptComposerOutboundSendQueueViewModelTest {
             samplerDispatcher = StandardTestDispatcher(testScheduler),
             outboundQueueStore = queue,
             outboundAttachmentSidecarStore = sidecars,
+            outboundQueueLifecycleCoordinator = coordinator,
         )
         vm.onComposerTargetChanged("1/session-a")
 
@@ -1753,6 +1770,7 @@ class PromptComposerOutboundSendQueueViewModelTest {
             queue.item(held.id),
         )
         waitForSidecarsCleared(sidecars, held.id)
+        coordinator.close()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/composer/PromptComposerViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.pocketshell.app.composer
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.app.composer.PromptComposerViewModel.ApiKeyVault
 import com.pocketshell.app.composer.PromptComposerViewModel.RecordingState
 import com.pocketshell.app.di.WhisperClientFactory
@@ -168,6 +170,7 @@ class PromptComposerViewModelTest {
         connectivity: PromptComposerViewModel.ConnectivityProbe = AlwaysOnlineConnectivityProbe,
         outboundQueueStore: OutboundQueueStore = DisabledOutboundQueueStore,
         outboundAttachmentSidecarStore: OutboundAttachmentSidecarStore? = null,
+        outboundQueueLifecycleCoordinator: OutboundQueueLifecycleCoordinator? = null,
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
     ): PromptComposerViewModel {
         val factory = WhisperClientFactory { whisper }
@@ -182,6 +185,7 @@ class PromptComposerViewModelTest {
             composerDraftStore = composerDraftStore,
             outboundQueueStore = outboundQueueStore,
             outboundAttachmentSidecarStore = outboundAttachmentSidecarStore,
+            outboundQueueLifecycleCoordinator = outboundQueueLifecycleCoordinator,
             savedStateHandle = savedStateHandle,
         )
         if (samplerDispatcher != null) {
@@ -204,6 +208,41 @@ class PromptComposerViewModelTest {
         // load-bearing behaviour is still proven (never vacuously skipped).
         vm.setSendWatchdogTimeoutForTest(null)
         return vm
+    }
+
+    @Test
+    fun queueDeleteUsesTheRealDrainOwnerAndRefusesUntilDeliveryReleases() = runTest {
+        val queue = InMemoryOutboundQueueStore()
+        val sidecars = OutboundAttachmentSidecarStore(
+            ApplicationProvider.getApplicationContext<Context>(),
+        ).also { it.ioDispatcher = StandardTestDispatcher(testScheduler) }
+        val coordinator = OutboundQueueLifecycleCoordinator(
+            queueStore = queue,
+            sidecarStore = sidecars,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            autoRepairOnInit = false,
+        )
+        val row = queue.enqueue("tmux:7:\$12:1700000000", "do not race delivery")
+        val vm = newVm(
+            samplerDispatcher = StandardTestDispatcher(testScheduler),
+            outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+            outboundQueueLifecycleCoordinator = coordinator,
+        )
+        try {
+            val delivery = requireNotNull(vm.outboundDrainOwnership.tryAcquire(row.id))
+
+            vm.discardOutboundItem(row.id)
+            runCurrent()
+            assertNotNull("Delete must refuse while the real drain owns any row", queue.item(row.id))
+
+            assertTrue(vm.outboundDrainOwnership.release(delivery))
+            vm.discardOutboundItem(row.id)
+            advanceUntilIdle()
+            assertNull("Delete may commit only under its typed disposal permit", queue.item(row.id))
+        } finally {
+            coordinator.close()
+        }
     }
 
     // -- Issue #1350: Send clears the draft for EVERY prompt shape --------
@@ -366,6 +405,15 @@ class PromptComposerViewModelTest {
     @Test
     fun discardOutboundItemRemovesQueuedAndFailedButKeepsActiveRows() = runTest {
         val queue = InMemoryOutboundQueueStore()
+        val sidecars = OutboundAttachmentSidecarStore(
+            ApplicationProvider.getApplicationContext<Context>(),
+        ).also { it.ioDispatcher = StandardTestDispatcher(testScheduler) }
+        val coordinator = OutboundQueueLifecycleCoordinator(
+            queueStore = queue,
+            sidecarStore = sidecars,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+            autoRepairOnInit = false,
+        )
         val inFlight = queue.enqueue(
             sessionKey = "1/a",
             cleanText = "in flight",
@@ -389,6 +437,8 @@ class PromptComposerViewModelTest {
         val vm = newVm(
             samplerDispatcher = StandardTestDispatcher(testScheduler),
             outboundQueueStore = queue,
+            outboundAttachmentSidecarStore = sidecars,
+            outboundQueueLifecycleCoordinator = coordinator,
         )
         vm.onComposerTargetChanged("1/a")
         assertEquals(
@@ -398,10 +448,12 @@ class PromptComposerViewModelTest {
 
         vm.discardOutboundItem(uploading.id)
         vm.discardOutboundItem(inFlight.id)
+        advanceUntilIdle()
         assertNotNull(queue.item(uploading.id))
         assertNotNull(queue.item(inFlight.id))
 
         vm.discardOutboundItem(queued.id)
+        advanceUntilIdle()
         assertNull(queue.item(queued.id))
         assertEquals(
             listOf(inFlight.id, failed.id, uploading.id),
@@ -409,11 +461,13 @@ class PromptComposerViewModelTest {
         )
 
         vm.discardOutboundItem(failed.id)
+        advanceUntilIdle()
         assertNull(queue.item(failed.id))
         assertEquals(
             listOf(inFlight.id, uploading.id),
             vm.outboundQueueItems.value.map { it.id },
         )
+        coordinator.close()
     }
 
     @Test

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelKillSessionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListViewModelKillSessionTest.kt
@@ -1,7 +1,11 @@
 package com.pocketshell.app.projects
 
+import android.content.Context
 import androidx.lifecycle.ViewModelStore
 import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.app.composer.OutboundAttachmentSidecarStore
+import com.pocketshell.app.composer.OutboundQueueLifecycleCoordinator
+import com.pocketshell.app.composer.SharedPrefsOutboundQueueStore
 import com.pocketshell.app.hosts.MainDispatcherRule
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.tmux.KilledSession
@@ -32,6 +36,8 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -173,6 +173,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.composer.PromptComposerSendPipeliningE2eTest"  # #1621 real-sheet A-active/B-queued FIFO, once-only completion, queue-empty and quiescent-close proof
   "com.pocketshell.app.composer.PromptComposerSendDismissE2eTest"  # #1108 #694 #872 #971 the composer send/dismiss + ATTACHMENT-on-failed-send journe…
   "com.pocketshell.app.composer.PromptComposerOutboundQueueTest"  # #848 #900 audit / ): the foreground outbound queue surface was
+  "com.pocketshell.app.composer.PromptComposerOutboundQueueProductionDeleteDockerTest"  # #1589 AC8/AC9: real Hilt sheet Delete -> permit -> durable coordinator row/sidecar cleanup
   "com.pocketshell.app.tmux.Issue1686QueueDrainWireOracleDockerTest"  # #1686 D33/G4 the composer-queue clog fix on the REAL wire: a false not-Connected label (inline enum Reconnecting + drain-gate sessionLive=false) while the -CC transport is writable — the queued prompt must DRAIN to the real tmux pane (capture-pane), and the transport-alive edge un-parks the storm-stranded backlog
   "$FQCN_PREFIX.Issue1700StaleFlushJourneyE2eTest"  # #1700 D32/G9: a 5-minute-old queued prompt must NOT silently flush into a moved-on pane when the wire returns; the fresh tail still drains (#1686), the held row is visible, and Send now delivers the same id exactly once
   "$FQCN_PREFIX.OutboundExactlyOnceAcrossFlapE2eTest"  # #1963/#1526 D31/D32: full-class fixture isolation plus delivery-level exactly-once across a mid-send flap (server capture-pane occurrence == 1, composer + keystroke lanes)

--- a/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
+++ b/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
@@ -261,3 +261,4 @@ com.pocketshell.app.voice.VoiceGestureCoachmarkLauncherProofTest	43
 # substituted for the isolated Gradle invocation cost. Evidence XML digest:
 # ca1510f2d226f63b24bd2d07e29faaa877572b7c26219afbc2ec79464aa8d332.
 com.pocketshell.app.proof.Issue1700StaleFlushJourneyE2eTest	79
+com.pocketshell.app.composer.PromptComposerOutboundQueueProductionDeleteDockerTest	260

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/ResumableUpload.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/ResumableUpload.kt
@@ -64,6 +64,20 @@ public fun queueSidecarCheckpointPaths(
     return QueueSidecarCheckpointPaths(dataPath = data, identityPath = "$data.identity")
 }
 
+/**
+ * Issue #1589: exact `rm -f` of the uploaded final file plus its hashed
+ * checkpoint + identity siblings. The command names only those three paths;
+ * callers must not append globs.
+ */
+public fun queueSidecarCheckpointDiscardCommand(
+    remotePath: String,
+    stableToken: String,
+    shellQuote: (String) -> String = ::quoteRemotePathForShell,
+): String {
+    val paths = queueSidecarCheckpointPaths(remotePath, stableToken)
+    return "rm -f -- ${shellQuote(remotePath)} ${shellQuote(paths.dataPath)} ${shellQuote(paths.identityPath)}"
+}
+
 internal fun queueSidecarCheckpointIdentity(
     request: QueueSidecarResumableUploadRequest,
 ): String = sha256Hex(

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshSession.kt
@@ -168,6 +168,25 @@ public interface SshSession : AutoCloseable {
         throw NotImplementedError("resumable queue-sidecar upload is only implemented by RealSshSession")
 
     /**
+     * Issue #1589: delete only the exact hashed checkpoint sibling owned by
+     * [stableToken] for [remotePath]. Never globs. Default calls [exec] so
+     * [RealSshSession] inherits the exact-path cleanup without a second owner.
+     */
+    public suspend fun discardQueueSidecarCheckpoint(
+        remotePath: String,
+        stableToken: String,
+    ) {
+        val result = exec(queueSidecarCheckpointDiscardCommand(remotePath, stableToken))
+        if (result.exitCode != 0) {
+            val detail = result.stderr.ifBlank { result.stdout }.trim()
+            throw SshException(
+                "Could not discard queue sidecar checkpoint: " +
+                    detail.ifBlank { "remote rm failed (${result.exitCode})" },
+            )
+        }
+    }
+
+    /**
      * Read the contents of a remote file at [remotePath] into memory.
      *
      * The path is resolved by the remote login shell, so `~`-relative and

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/QueueSidecarCheckpointDiscardTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/QueueSidecarCheckpointDiscardTest.kt
@@ -1,0 +1,27 @@
+package com.pocketshell.core.ssh
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QueueSidecarCheckpointDiscardTest {
+
+    @Test
+    fun discardCommandNamesFinalFileAndOnlyItsExactHashedSiblings() {
+        val remote = "~/inbox/notes.txt"
+        val token = "sidecar-token-a"
+        val paths = queueSidecarCheckpointPaths(remote, token)
+        val foreign = queueSidecarCheckpointPaths(remote, "sidecar-token-b")
+        val command = queueSidecarCheckpointDiscardCommand(remote, token)
+
+        assertTrue(command.startsWith("rm -f -- "))
+        assertFalse("must never glob", command.contains("*") || command.contains("?"))
+        assertTrue(command.contains(quoteRemotePathForShell(remote)))
+        assertTrue(command.contains(quoteRemotePathForShell(paths.dataPath)))
+        assertTrue(command.contains(quoteRemotePathForShell(paths.identityPath)))
+        assertFalse(command.contains(quoteRemotePathForShell(foreign.dataPath)))
+        assertFalse(command.contains(quoteRemotePathForShell(foreign.identityPath)))
+        assertEquals(paths.identityPath, paths.dataPath + ".identity")
+    }
+}


### PR DESCRIPTION
Fixes #1589

## Summary

- add typed, owner-aware disposal for explicit outbound Delete
- commit exact local/remote cleanup tombstones before row removal
- preserve uploaded remote paths through missing-local orphan repair
- add retention/GC unit coverage and a real Hilt/emulator production Delete journey
- wire the journey into the CI matrix

## Verification

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/1589#issuecomment-5384343104

- full unfiltered JVM suite: 4,968 tests, 0 failures/errors/skips
- Android-test compile: 188 tasks, success
- connected production Delete journey: 1 executed, 0 skipped/failures/errors
- selective AC3 ownership and AC5 missing-local mutations redden
- file-size, connection-ratchet, validity, referenced-tests, and journey-harness guards pass
