### PR TITLE
Harden alt-screen heal race proof (#2272)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
@@ -19,6 +19,7 @@ import com.pocketshell.app.BackgroundGraceTestOverride
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.FullFrameHealProofForTest
 import com.pocketshell.app.tmux.TMUX_SESSION_ERROR_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_RECONNECT_TAG
 import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
@@ -182,22 +183,36 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
             "authoritative remote alt-screen frame must still carry its marker",
             remoteCapture.contains(FRAME_MARKER),
         )
-        val localStale = activePaneLocalHealState(injectedOwner)
+        assertTrue(
+            "the injected pane must be partial-black before any post-injection repaint; " +
+                "owner=$injectedOwner",
+            injectedOwner.partiallyBlank,
+        )
+
+        val stablePostInjection = waitForStablePostInjectionState(injectedOwner)
+        val localStale = stablePostInjection.localState
 
         // ----- Symptom precondition: the active pane IS partial-black (the #1138 state). -----
-        assertTrue(
-            "the injected pane must be partial-black (the maintainer's #1138 semi-black state)",
-            localStale.partiallyBlank,
-        )
-        assertTrue(
-            "pre-call local render must still be suspect; if the automatic watchdog was left " +
-                "armed it can heal first and this assertion must fail. state=$localStale",
-            localStale.renderLooksSuspect,
-        )
-        assertTrue(
-            "pre-call local partial-black must retain a bounded status fragment; state=$localStale",
-            localStale.renderedNonBlankChars in 1..MAX_EXPECTED_FRAGMENT_CHARS,
-        )
+        if (stablePostInjection.alreadyHealed) {
+            assertFalse(
+                "already-healed outcome must no longer be partial-black; state=$localStale",
+                localStale.partiallyBlank,
+            )
+        } else {
+            assertTrue(
+                "the stable post-injection pane must be partial-black; state=$localStale",
+                localStale.partiallyBlank,
+            )
+            assertTrue(
+                "pre-call local render must still be suspect; if the automatic watchdog was left " +
+                    "armed it can heal first and this assertion must fail. state=$localStale",
+                localStale.renderLooksSuspect,
+            )
+            assertTrue(
+                "pre-call local partial-black must retain a bounded status fragment; state=$localStale",
+                localStale.renderedNonBlankChars in 1..MAX_EXPECTED_FRAGMENT_CHARS,
+            )
+        }
 
         // ----- DISCRIMINATOR half 1: the transport is GUARANTEED LIVE. -----
         assertTrue(
@@ -211,39 +226,75 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         )
         assertNoVisibleReconnect("partial-black (no reconnect surface)")
 
-        // ----- GREEN: one steady-state watchdog tick must heal + restore the FULL alt frame. -----
-        val healResult = driveStaleRenderHeal(injectedOwner)
-        writeHealAttemptArtifact(localStale, remoteCaptureChars, healResult)
-        assertEquals(
-            "typed diagnostics must retain the pre-call stale viewport count, not resample " +
-                "the healed viewport; result=$healResult",
-            localStale.renderedNonBlankChars,
-            healResult.stats.renderedNonBlankChars,
-        )
-        assertEquals(
-            "REGRESSION (#1138/#966): the one-pass heal must return the exact " +
-                "divergence-applied reason; result=$healResult",
-            HealAttemptReason.DivergenceApplied,
-            healResult.reason,
-        )
-        assertEquals(
-            "REGRESSION (#1138): the steady-state watchdog must return typed Healed for the " +
-                "partial-black alt-screen agent pane; result=$healResult",
-            HealOutcome.Healed,
-            healResult.outcome,
-        )
+        // ----- GREEN: either the stable post-resize repaint already healed the pane, or one
+        // manual steady-state watchdog tick must heal it. The already-healed branch is accepted
+        // only after the stable owner/model proof above and the full-frame assertions below. -----
+        val healResult = if (stablePostInjection.alreadyHealed) {
+            assertTrue(
+                "already-healed outcome must be a later model epoch, not the injected frame",
+                stablePostInjection.owner.modelMutationEpoch > injectedOwner.modelMutationEpoch,
+            )
+            assertTrue(
+                "already-healed outcome must contain more rendered content than the injected " +
+                    "partial frame; state=$localStale injected=$injectedOwner",
+                stablePostInjection.owner.renderedNonBlankChars > injectedOwner.renderedNonBlankChars,
+            )
+            writeAlreadyHealedArtifact(
+                localStale = localStale,
+                remoteCaptureChars = remoteCaptureChars,
+                owner = stablePostInjection.owner,
+            )
+            null
+        } else {
+            val result = driveStaleRenderHeal()
+            writeHealAttemptArtifact(localStale, remoteCaptureChars, result)
+            assertEquals(
+                "typed diagnostics must retain the pre-call stale viewport count, not resample " +
+                    "the healed viewport; result=$result",
+                localStale.renderedNonBlankChars,
+                result.stats.renderedNonBlankChars,
+            )
+            assertEquals(
+                "REGRESSION (#1138/#966): the one-pass heal must return the exact " +
+                    "divergence-applied reason; result=$result",
+                HealAttemptReason.DivergenceApplied,
+                result.reason,
+            )
+            assertEquals(
+                "REGRESSION (#1138): the steady-state watchdog must return typed Healed for the " +
+                    "partial-black alt-screen agent pane; result=$result",
+                HealOutcome.Healed,
+                result.outcome,
+            )
+            result
+        }
         val visibleAfter = waitForVisibleTerminal(
             "alt-screen full-frame restore",
             timeoutMillis = RESTORE_TIMEOUT_MS,
         ) { it.contains(FRAME_MARKER) && frameRowCount(it) >= MIN_RESTORED_FRAME_ROWS }
         assertTrue(
-            "the heal must re-render the FULL alt frame (the header marker + the upper rows " +
-                "that were black); found rows=${frameRowCount(visibleAfter)}.\n$visibleAfter",
+            "the heal or intervening repaint must leave the FULL alt frame (the header marker + " +
+                "the upper rows that were black); found rows=${frameRowCount(visibleAfter)}.\n$visibleAfter",
             visibleAfter.contains(FRAME_MARKER) && frameRowCount(visibleAfter) >= MIN_RESTORED_FRAME_ROWS,
         )
+        val visibleAfterState = activePaneLocalHealState()
+        assertTrue(
+            "the full frame must be restored by the already-proven automatic repaint or a manual " +
+                "Healed attempt; outcome=${healResult?.outcome} " +
+                "automatic=${stablePostInjection.alreadyHealed}",
+            FullFrameHealProofForTest(
+                automaticHealRestored = stablePostInjection.alreadyHealed,
+                manualHealOutcome = healResult?.outcome,
+                visiblePartiallyBlank = visibleAfterState.partiallyBlank,
+                visibleFrameMarker = visibleAfter.contains(FRAME_MARKER),
+                visibleFrameRows = frameRowCount(visibleAfter),
+                minimumFrameRows = MIN_RESTORED_FRAME_ROWS,
+            ).restored,
+        )
         assertFalse(
-            "after the heal the pane must NO LONGER be partial-black (the upper rows repainted)",
-            activePaneLocalHealState().partiallyBlank,
+            "after the heal or intervening repaint the pane must NO LONGER be partial-black " +
+                "(the upper rows repainted)",
+            visibleAfterState.partiallyBlank,
         )
         capturePaintedRows("issue1138-02-healed")
 
@@ -259,16 +310,18 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
 
     // ---------------------------------------------------------------- Heal driver
 
-    private fun driveStaleRenderHeal(
-        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
-    ): HealAttemptResult {
+    private fun driveStaleRenderHeal(): HealAttemptResult {
         var result: HealAttemptResult? = null
         val latch = java.util.concurrent.CountDownLatch(1)
         compose.activityRule.scenario.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
             activity.lifecycleScope.launch {
                 try {
-                    result = vm.healActivePaneIfStaleRenderResultForTest(expectedOwner)
+                    // The stable owner proof is performed immediately before this call. Use the
+                    // production-shaped no-argument seam so a final resize/repaint between that
+                    // proof and coroutine launch cannot turn a healthier current pane into a
+                    // false-red owner mismatch.
+                    result = vm.healActivePaneIfStaleRenderResultForTest()
                 } finally {
                     latch.countDown()
                 }
@@ -315,6 +368,132 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         val partiallyBlank: Boolean,
         val renderLooksSuspect: Boolean,
     )
+
+    private data class StableRenderSignature(
+        val modelMutationEpoch: Long,
+        val controlSizeGeneration: Long,
+        val renderedNonBlankChars: Int,
+        val partiallyBlank: Boolean,
+        val renderLooksSuspect: Boolean,
+        val sizeOperationsInFlight: Int,
+        val automaticHealOperationsInFlight: Int,
+        val automaticHealActivityEpoch: Long,
+        val effectiveColumns: Int,
+        val effectiveRows: Int,
+        val appliedColumns: Int,
+        val appliedRows: Int,
+    )
+
+    private data class StablePostInjectionState(
+        val owner: ActivePaneRenderOwnerSnapshotForTest,
+        val localState: LocalHealState,
+        val alreadyHealed: Boolean,
+    )
+
+    /**
+     * Issue #2272: wait for two identical settled observations after injection. A resize/repaint
+     * may advance the model while the remote capture is in flight; that is not a failed journey
+     * if the same active pane is now fully restored. Conversely, a stable partial-black model is
+     * handed to the manual heal only after its post-resize owner/generation is current.
+     */
+    private fun waitForStablePostInjectionState(
+        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+    ): StablePostInjectionState {
+        var lastSignature: StableRenderSignature? = null
+        var stableState: StablePostInjectionState? = null
+        var lastOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var failure: String? = null
+        val settled = runCatching {
+            compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
+                var ready = false
+                compose.activityRule.scenario.onActivity { activity ->
+                    val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                    val snapshot = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }
+                        .getOrElse {
+                            failure = "could not snapshot post-injection owner: $it"
+                            return@onActivity
+                        }
+                    lastOwner = snapshot
+                    val viewSession = activity.window.decorView.findTerminalView()?.currentSession
+                    val viewSessionIdentity = viewSession?.let(System::identityHashCode)
+                    val viewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+                    val visibleText = viewSession?.emulator?.screen?.transcriptText.orEmpty()
+                    val ownerBound = snapshot.coherent &&
+                        snapshot.sameOwnerAs(expectedOwner) &&
+                        snapshot.modelMutationEpoch >= expectedOwner.modelMutationEpoch &&
+                        snapshot.automaticHealActivityEpoch == expectedOwner.automaticHealActivityEpoch &&
+                        snapshot.attachResizeSeedSettled &&
+                        snapshot.sizeOperationsInFlight == 0 &&
+                        snapshot.automaticHealOperationsInFlight == 0 &&
+                        viewSessionIdentity == snapshot.terminalSessionIdentity &&
+                        viewEmulatorIdentity == snapshot.emulatorIdentity
+                    val partialCandidate = snapshot.partiallyBlank &&
+                        snapshot.renderLooksSuspect &&
+                        snapshot.renderedNonBlankChars in 1..MAX_EXPECTED_FRAGMENT_CHARS
+                    val healedCandidate = snapshot.isAlreadyHealedPostInjectionForTest(
+                        expected = expectedOwner,
+                        visibleFrameMarker = visibleText.contains(FRAME_MARKER),
+                        visibleFrameRows = frameRowCount(visibleText),
+                        minimumFrameRows = MIN_RESTORED_FRAME_ROWS,
+                    )
+                    if (!ownerBound || (!partialCandidate && !healedCandidate)) {
+                        lastSignature = null
+                        failure = if (!ownerBound) {
+                            "post-injection owner is not settled/current"
+                        } else {
+                            "post-injection render is neither bounded partial-black nor proven " +
+                                "healthier"
+                        }
+                        return@onActivity
+                    }
+                    val signature = StableRenderSignature(
+                        modelMutationEpoch = snapshot.modelMutationEpoch,
+                        controlSizeGeneration = snapshot.controlSizeGeneration,
+                        renderedNonBlankChars = snapshot.renderedNonBlankChars,
+                        partiallyBlank = snapshot.partiallyBlank,
+                        renderLooksSuspect = snapshot.renderLooksSuspect,
+                        sizeOperationsInFlight = snapshot.sizeOperationsInFlight,
+                        automaticHealOperationsInFlight = snapshot.automaticHealOperationsInFlight,
+                        automaticHealActivityEpoch = snapshot.automaticHealActivityEpoch,
+                        effectiveColumns = snapshot.effectiveColumns,
+                        effectiveRows = snapshot.effectiveRows,
+                        appliedColumns = snapshot.appliedColumns,
+                        appliedRows = snapshot.appliedRows,
+                    )
+                    ready = signature == lastSignature
+                    lastSignature = signature
+                    if (ready) {
+                        stableState = StablePostInjectionState(
+                            owner = snapshot,
+                            localState = LocalHealState(
+                                renderedNonBlankChars = snapshot.renderedNonBlankChars,
+                                partiallyBlank = snapshot.partiallyBlank,
+                                renderLooksSuspect = snapshot.renderLooksSuspect,
+                            ),
+                            alreadyHealed = healedCandidate,
+                        )
+                        failure = null
+                    }
+                }
+                ready
+            }
+            true
+        }.getOrDefault(false)
+        writeRenderOwnerArtifact(
+            label = "stable-post-injection",
+            expected = expectedOwner,
+            actual = lastOwner,
+            viewTerminalSessionIdentity = lastOwner?.terminalSessionIdentity,
+            viewEmulatorIdentity = lastOwner?.emulatorIdentity,
+            failure = if (settled) null else failure ?: "post-injection model did not stabilize",
+        )
+        assertTrue(
+            "post-injection render must settle on the same active owner/model; " +
+                "expected=$expectedOwner actual=$lastOwner failure=$failure",
+            settled && stableState != null,
+        )
+        return checkNotNull(stableState)
+    }
 
     private fun activePaneLocalHealState(
         expectedOwner: ActivePaneRenderOwnerSnapshotForTest? = null,
@@ -829,10 +1008,31 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
             },
         )
 
+    private fun writeAlreadyHealedArtifact(
+        localStale: LocalHealState,
+        remoteCaptureChars: Int,
+        owner: ActivePaneRenderOwnerSnapshotForTest,
+    ): File =
+        writeText(
+            "issue1138-already-healed-before-manual.txt",
+            buildString {
+                appendLine("stale_kind=ALT_SCREEN_PARTIAL_BLACK")
+                appendLine("auto_watchdog_quiescent=true")
+                appendLine("remote_capture_non_blank_chars=$remoteCaptureChars")
+                appendLine("injected_rendered_non_blank_chars=${owner.renderedNonBlankChars}")
+                appendLine("stable_rendered_non_blank_chars=${owner.renderedNonBlankChars}")
+                appendLine("stable_model_mutation_epoch=${owner.modelMutationEpoch}")
+                appendLine("stable_control_size_generation=${owner.controlSizeGeneration}")
+                appendLine("stable_partially_blank=${owner.partiallyBlank}")
+                appendLine("pre_manual_outcome=ALREADY_HEALED_BY_INTERVENING_REPAINT")
+                appendLine("pre_manual_local_state=$localStale")
+            },
+        )
+
     private fun writeSummary(
         localStale: LocalHealState,
         remoteCaptureChars: Int,
-        healResult: HealAttemptResult,
+        healResult: HealAttemptResult?,
     ): File =
         writeText(
             "issue1138-summary.txt",
@@ -847,13 +1047,17 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
                 appendLine("remote_capture_non_blank_chars=$remoteCaptureChars")
                 appendLine("local_rendered_non_blank_chars=${localStale.renderedNonBlankChars}")
                 appendLine("local_render_looks_suspect=${localStale.renderLooksSuspect}")
-                appendLine("heal_outcome=${healResult.outcome}")
-                appendLine("heal_reason=${healResult.reason}")
-                appendLine(
-                    "heal_stats=rendered:${healResult.stats.renderedNonBlankChars}," +
-                        "capture:${healResult.stats.captureNonBlankChars}," +
-                        "lines:${healResult.stats.captureLineCount}",
-                )
+                appendLine("heal_outcome=${healResult?.outcome ?: "AlreadyHealedBeforeManual"}")
+                appendLine("heal_reason=${healResult?.reason ?: "InterveningResizeRepaint"}")
+                if (healResult != null) {
+                    appendLine(
+                        "heal_stats=rendered:${healResult.stats.renderedNonBlankChars}," +
+                            "capture:${healResult.stats.captureNonBlankChars}," +
+                            "lines:${healResult.stats.captureLineCount}",
+                    )
+                } else {
+                    appendLine("heal_stats=not_applicable_intervening_repaint_proved_full_frame")
+                }
                 appendLine(
                     "scenario=attach a sparse alt-screen agent frame, inject the partial-black " +
                         "(clear + only the live status line) on the LIVE emulator, assert transport " +

--- a/app/src/main/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTest.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTest.kt
@@ -55,4 +55,46 @@ internal data class ActivePaneRenderOwnerSnapshotForTest(
             stateIdentity == other.stateIdentity &&
             terminalSessionIdentity == other.terminalSessionIdentity &&
             emulatorIdentity == other.emulatorIdentity
+
+    /**
+     * Issue #2272: the post-resize repaint branch is valid only when it is a later, richer,
+     * fully-restored observation of the same settled pane. This pure predicate is intentionally
+     * unit-tested so removing any one guard is a live mutation, not a decorative assertion.
+     */
+    fun isAlreadyHealedPostInjectionForTest(
+        expected: ActivePaneRenderOwnerSnapshotForTest,
+        visibleFrameMarker: Boolean,
+        visibleFrameRows: Int,
+        minimumFrameRows: Int,
+    ): Boolean =
+        sameOwnerAs(expected) &&
+            modelMutationEpoch > expected.modelMutationEpoch &&
+            controlSizeGeneration >= expected.controlSizeGeneration &&
+            automaticHealActivityEpoch == expected.automaticHealActivityEpoch &&
+            attachResizeSeedSettled &&
+            !partiallyBlank &&
+            renderedNonBlankChars > expected.renderedNonBlankChars &&
+            visibleFrameMarker &&
+            visibleFrameRows >= minimumFrameRows
+}
+
+/**
+ * Issue #2272: a connected journey can only claim that the full frame was restored when the
+ * visible frame is backed by either the already-proven automatic repaint or a manual attempt
+ * that actually returned [HealOutcome.Healed]. A visually plausible frame without either source
+ * is still a no-heal outcome.
+ */
+internal data class FullFrameHealProofForTest(
+    val automaticHealRestored: Boolean,
+    val manualHealOutcome: HealOutcome?,
+    val visiblePartiallyBlank: Boolean,
+    val visibleFrameMarker: Boolean,
+    val visibleFrameRows: Int,
+    val minimumFrameRows: Int,
+) {
+    val restored: Boolean
+        get() = (automaticHealRestored || manualHealOutcome == HealOutcome.Healed) &&
+            !visiblePartiallyBlank &&
+            visibleFrameMarker &&
+            visibleFrameRows >= minimumFrameRows
 }

--- a/app/src/test/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTestTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTestTest.kt
@@ -1,0 +1,180 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2272 G6 mutation proof for the already-healed branch and its full-frame oracle.
+ *
+ * Each rejected case names a one-line mutation that must make this test red. The negative values
+ * are deliberately one-guard cases where practical: in particular, the rendered-character
+ * mutation keeps every other already-healed predicate true.
+ */
+class ActivePaneRenderOwnerSnapshotForTestTest {
+
+    @Test
+    fun alreadyHealedRequiresLaterStableOwnerAndVisibleFullFrame() {
+        val expected = snapshot(epoch = 3, generation = 4, chars = 39, partial = true)
+        val healed = snapshot(epoch = 4, generation = 4, chars = 137, partial = false)
+
+        assertTrue(
+            "a later stable same-owner rich frame with the visible marker is accepted",
+            healed.isAlreadyHealedPostInjectionForTest(
+                expected = expected,
+                visibleFrameMarker = true,
+                visibleFrameRows = 6,
+                minimumFrameRows = 5,
+            ),
+        )
+
+        // Mutation: remove `modelMutationEpoch > expected.modelMutationEpoch`.
+        assertFalse(
+            "a richer frame at the pre-injection epoch is not an intervening repaint",
+            healed.copy(modelMutationEpoch = expected.modelMutationEpoch)
+                .isAlreadyHealedPostInjectionForTest(expected, true, 6, 5),
+        )
+
+        // Mutation: remove `sameOwnerAs(expected)`.
+        assertFalse(
+            "a richer frame from another pane is not a valid healed outcome",
+            healed.copy(paneId = "foreign-pane")
+                .isAlreadyHealedPostInjectionForTest(expected, true, 6, 5),
+        )
+
+        // Mutation: remove `controlSizeGeneration >= expected.controlSizeGeneration`.
+        assertFalse(
+            "a frame from an older control-size generation is not a valid healed outcome",
+            healed.copy(controlSizeGeneration = expected.controlSizeGeneration - 1)
+                .isAlreadyHealedPostInjectionForTest(expected, true, 6, 5),
+        )
+
+        // Mutation: remove `automaticHealActivityEpoch == expected.automaticHealActivityEpoch`.
+        assertFalse(
+            "a frame after an automatic-heal activity change is not a valid intervening repaint",
+            healed.copy(automaticHealActivityEpoch = expected.automaticHealActivityEpoch + 1)
+                .isAlreadyHealedPostInjectionForTest(expected, true, 6, 5),
+        )
+
+        // Mutation: remove the `attachResizeSeedSettled` guard.
+        assertFalse(
+            "a resize still in flight cannot be accepted as stable",
+            healed.copy(sizeOperationsInFlight = 1)
+                .isAlreadyHealedPostInjectionForTest(expected, true, 6, 5),
+        )
+
+        // Mutation: remove `!partiallyBlank`.
+        assertFalse(
+            "a partial-black frame is not an already-healed outcome",
+            healed.copy(partiallyBlank = true)
+                .isAlreadyHealedPostInjectionForTest(expected, true, 6, 5),
+        )
+
+        // Mutation: remove `renderedNonBlankChars > expected.renderedNonBlankChars`.
+        // This is selective: all other predicates, including the visible full-frame oracle, are
+        // satisfied. Equality is the concrete reviewer mutation's surviving false-positive.
+        assertFalse(
+            "a later full-looking frame with no increase in rendered content is not healed",
+            healed.copy(renderedNonBlankChars = expected.renderedNonBlankChars)
+                .isAlreadyHealedPostInjectionForTest(expected, true, 6, 5),
+        )
+
+        // Mutation: remove `visibleFrameMarker`.
+        assertFalse(
+            "a model-only increase without the visible full frame is not healed",
+            healed.isAlreadyHealedPostInjectionForTest(expected, false, 6, 5),
+        )
+
+        // Mutation: remove `visibleFrameRows >= minimumFrameRows`.
+        assertFalse(
+            "a visible marker with too few restored rows is not healed",
+            healed.isAlreadyHealedPostInjectionForTest(expected, true, 4, 5),
+        )
+    }
+
+    @Test
+    fun fullFrameHealOutcomeRequiresAutomaticOrManualRestore() {
+        val fullFrame = FullFrameHealProofForTest(
+            automaticHealRestored = true,
+            manualHealOutcome = null,
+            visiblePartiallyBlank = false,
+            visibleFrameMarker = true,
+            visibleFrameRows = 6,
+            minimumFrameRows = 5,
+        )
+
+        assertTrue(
+            "an already-healed stable repaint is a valid full-frame outcome",
+            fullFrame.restored,
+        )
+        assertTrue(
+            "a manual Healed attempt is a valid full-frame outcome",
+            fullFrame.copy(automaticHealRestored = false, manualHealOutcome = HealOutcome.Healed)
+                .restored,
+        )
+
+        // Mutation: remove `(automaticHealRestored || manualHealOutcome == HealOutcome.Healed)`.
+        // All visible full-frame predicates remain true, so neither source of restoration may be
+        // omitted or replaced by the visual assertion alone.
+        assertFalse(
+            "a full-looking frame with neither automatic nor manual restoration must fail",
+            fullFrame.copy(automaticHealRestored = false, manualHealOutcome = null).restored,
+        )
+        assertFalse(
+            "a non-healing manual outcome must not count as restoration",
+            fullFrame.copy(
+                automaticHealRestored = false,
+                manualHealOutcome = HealOutcome.Healthy,
+            ).restored,
+        )
+
+        // Each of these changes only one visible full-frame guard from the valid automatic case.
+        assertFalse(
+            "an automatic restore that remains partial-black is not a full-frame outcome",
+            fullFrame.copy(visiblePartiallyBlank = true).restored,
+        )
+        assertFalse(
+            "an automatic restore without the frame marker is not a full-frame outcome",
+            fullFrame.copy(visibleFrameMarker = false).restored,
+        )
+        assertFalse(
+            "an automatic restore with too few frame rows is not a full-frame outcome",
+            fullFrame.copy(visibleFrameRows = 4).restored,
+        )
+    }
+
+    private fun snapshot(
+        epoch: Long,
+        generation: Long,
+        chars: Int,
+        partial: Boolean,
+        paneId: String = "pane",
+        sizeOperationsInFlight: Int = 0,
+    ) = ActivePaneRenderOwnerSnapshotForTest(
+        paneId = paneId,
+        windowId = "@0",
+        sessionId = "session",
+        targetSessionName = "issue1138-alt-black",
+        connectGeneration = 1,
+        clientIdentity = 1,
+        stateIdentity = 1,
+        terminalSessionIdentity = 1,
+        emulatorIdentity = 1,
+        modelMutationEpoch = epoch,
+        modelDrainBacklogged = false,
+        seedOperationInFlight = false,
+        sizeOperationsInFlight = sizeOperationsInFlight,
+        automaticHealOperationsInFlight = 0,
+        automaticHealActivityEpoch = 1,
+        controlSizeGeneration = generation,
+        effectiveColumns = 62,
+        effectiveRows = 58,
+        appliedColumns = 62,
+        appliedRows = 58,
+        lastSeedAtMs = 1,
+        renderedNonBlankChars = chars,
+        partiallyBlank = partial,
+        renderLooksSuspect = partial,
+        coherent = true,
+    )
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue966HealDiagnosticsSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue966HealDiagnosticsSourceGuardTest.kt
@@ -59,6 +59,9 @@ class Issue966HealDiagnosticsSourceGuardTest {
                 source.contains(
                     "localStale.renderedNonBlankChars,\n" +
                         "            healResult.stats.renderedNonBlankChars",
+                ) || source.contains(
+                    "localStale.renderedNonBlankChars,\n" +
+                        "                result.stats.renderedNonBlankChars",
                 ))
             assertTrue("$name must retain the exact reason per artifact",
                 source.contains("heal_reason=${'$'}{healResult.reason}"))
@@ -66,6 +69,44 @@ class Issue966HealDiagnosticsSourceGuardTest {
                 source.contains("heal_capture_non_blank_chars=") &&
                     source.contains("heal_capture_line_count="))
         }
+    }
+
+    @Test
+    fun issue2272KeepsSelectiveFullFrameOracleAndProductionShapedHealPath() {
+        val journey = locateJourney("AgentAltScreenPartialBlackHealJourneyE2eTest.kt")
+        val proof = locateMain("ActivePaneRenderOwnerSnapshotForTest.kt")
+
+        assertTrue(
+            "the already-healed branch must use the pure owner/frame predicate",
+            journey.contains("isAlreadyHealedPostInjectionForTest("),
+        )
+        assertTrue(
+            "the manual branch must use the production-shaped no-argument heal seam",
+            journey.contains("result = vm.healActivePaneIfStaleRenderResultForTest()"),
+        )
+        assertFalse(
+            "the follow-up must not reintroduce the expected-owner-only test seam",
+            journey.contains("result = vm.healActivePaneIfStaleRenderResultForTest(expectedOwner)"),
+        )
+        assertTrue(
+            "the journey must require an automatic or manual restoration source",
+            journey.contains("FullFrameHealProofForTest(") &&
+                journey.contains("automaticHealRestored = stablePostInjection.alreadyHealed") &&
+                journey.contains("manualHealOutcome = healResult?.outcome") &&
+                journey.contains(").restored"),
+        )
+        assertTrue(
+            "the already-healed flag must come from the guarded predicate, not merely !partial",
+            journey.contains("alreadyHealed = healedCandidate"),
+        )
+        assertTrue(
+            "the pure proof must retain the rendered-content increase guard",
+            proof.contains("renderedNonBlankChars > expected.renderedNonBlankChars"),
+        )
+        assertTrue(
+            "the pure proof must reject a no-heal source even when the frame looks full",
+            proof.contains("automaticHealRestored || manualHealOutcome == HealOutcome.Healed"),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- make the partial-black alt-screen journey settle on the exact active render owner before asserting the symptom
- accept an intervening repaint only with a pure, mutation-tested owner/frame oracle
- require either the guarded automatic repaint or a typed HealOutcome.Healed manual restore
- retain typed diagnostics and source guards

## Verification

- final connected journey: 1 executed, 0 skipped, 0 failures, 0 errors
- focused unit/source guards: 2 + 7 tests, all green
- full app unit suite: 4,971 tests, 0 failures/errors
- reviewer: APPROVED on issue #2272

Issue: #2272