### PR TITLE
Pin hosted emulator runner action

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -373,7 +373,7 @@ jobs:
              echo "agents-daemon real-tree persist confirmed: $got"'
 
       - name: Run extensive connected journey/E2E + network-fault + bootstrap scenarios
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           # API 35 (Android 15): the full connected suite includes two API-35
           # evidence tests (BoundedGraceSessionHoldJourneyE2eTest +

--- a/.github/workflows/release-emulator-validation.yml
+++ b/.github/workflows/release-emulator-validation.yml
@@ -170,7 +170,7 @@ jobs:
             test-execution-ledger-${{ runner.os }}-
 
       - name: Run emulator-only release validation
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         env:
           RUN_ID: ${{ steps.validation.outputs.run_id }}
           ANDROID_SDK: ${{ env.ANDROID_SDK }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -442,9 +442,11 @@ jobs:
       # release-gating fault-verdict wiring under the per-push static guard.
       - name: "Nightly workflow integrity guard (issue #2252)"
         run: |
-          chmod +x scripts/check-nightly-workflow.sh
+          chmod +x scripts/check-nightly-workflow.sh scripts/check-emulator-action-pin.sh
           scripts/check-nightly-workflow.sh --self-test
           scripts/check-nightly-workflow.sh
+          scripts/check-emulator-action-pin.sh --self-test
+          scripts/check-emulator-action-pin.sh
 
       # #2067 keeps unit-gate's needs/result lists aligned; the final grep keeps
       # #1956's executable lifecycle harness wired into guards-harness.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2107,14 +2107,79 @@ Two guards hold the invariant, and neither is sufficient alone:
 
 ## CI matrix
 
-GitHub Actions runs:
+The `Tests` workflow separates the canonical full-suite gates from the slower
+emulator and nightly lanes. For code changes, it runs the cheap gates on pull
+requests and on `main`. The Docker and emulator jobs run on `main` pushes or
+manual dispatches, not on every pull request.
 
-1. `./gradlew test --stacktrace` — unit tests
-2. `./gradlew :shared:core-ssh:integrationTest :shared:core-portfwd:integrationTest` — Docker-backed JVM integration tests via Testcontainers
-3. Local emulator + Docker agent smoke after the fast gates pass:
-   - starts `tests/docker`'s `agents` target on host port 2222
-   - runs the connected Android suite on an emulator
-   - uploads Android test reports and Docker logs as workflow artifacts
+### Canonical full-suite gates
+
+- **JVM unit tests** — the `unit` job is a two-leg matrix, `variant: [Debug,
+  Release]`. Each leg runs the complete variant task
+  (`./gradlew testDebugUnitTest` or `./gradlew testReleaseUnitTest`) with
+  forced execution (`--rerun-tasks --no-build-cache`), rather than a filtered
+  class list. Execution-count and rolling-ledger checks prove that the
+  expected test tasks actually ran. The required `Unit tests` aggregator also
+  requires the static guards, CI-harness guards, test-selection guards, and
+  DEX ratchet job.
+- **Python utility tests** — `tools/pocketshell` runs its full `pytest` suite
+  in the separate `Python utility tests (pocketshell)` check.
+- **Docker-backed JVM integration** — the `Integration tests (Docker)` job
+  runs all four integration tasks:
+
+  ```text
+  :app:integrationTest
+  :shared:core-ssh:integrationTest
+  :shared:core-portfwd:integrationTest
+  :shared:core-tmux:integrationTest
+  ```
+
+  The execution guard verifies fresh JUnit results for the complete task set.
+- **Per-push emulator journey subset** — on `main`/manual runs,
+  `Emulator journey subset (load-bearing, Docker agents)` fans the journey
+  registry across six independent shards (`0` through `5`). Each shard gets a
+  cold API-35 Pixel 7 emulator and its Docker fixtures. The downstream
+  `Emulator journey aggregate verdict` combines shard tokens into `CLEAN`,
+  `RE-RUN`, or `RED`, with a real journey failure remaining release-blocking.
+
+For the local canonical full-JVM gate, run `scripts/full-jvm-gate.py`. A
+focused `--tests` invocation is useful for iteration but is not a substitute
+for the complete Debug + Release or unsharded local gate.
+
+### Conditional nightly and release lanes
+
+- **Nightly Extensive Tests** runs at 02:17 UTC and can be force-run manually.
+  Its cheap guard skips the expensive suite when `main` has no new commit in
+  the preceding 24 hours. When enabled, the extensive job runs three shards.
+  Phase 1 is partitioned across all three. The network-fault and bootstrap
+  phases run once on shard 0. The mixed extensive job uses
+  `continue-on-error`. The separate **Fault-injection safety verdict (release
+  gate)** reads the machine verdict for the network-fault and bootstrap phases.
+  It fails closed when a gating artifact is missing, incomplete,
+  infrastructurally unavailable, or red. The **Test-execution ledger (selected
+  vs executed)** also fails closed when a shard or selected class has no result.
+  **Nightly failure recurrence** reports the bounded historical failure trend.
+  The #822 expected-fail lane is recorded but is not part of the release-gating
+  fault verdict.
+- **Release Emulator Validation** is a manual, evidence-producing lane. Its
+  emulator step runs `scripts/release-emulator-validation.sh`. It covers the
+  pre-release confidence gate, terminal-lab, tmux-existing-session,
+  setup-detection, and visual-audit stages. The workflow then records the
+  execution ledger and uploads the evidence bundle. It does not create or push
+  a tag. For taggable evidence, validate the stable `main` commit that will be
+  tagged.
+
+Every hosted `reactivecircus/android-emulator-runner` invocation in these lanes
+uses the audited immutable v2.37.0 commit. The static guard in the `Tests`
+workflow rejects a floating tag, a different SHA, or a missing `# v2.37.0`
+comment.
+
+The optional long-running lanes stay separate from these canonical gates. A
+terminal-heavy release may opt into the real-agent terminal release check with
+`TERMINAL_RELEASE_GATE=1`. It may also enable the ten-minute stability hold
+with `LONG_RUNNING_TEST=1`. The hold isn't required for unrelated small
+releases and never replaces the canonical unit, integration, journey, nightly,
+or release evidence gates described above.
 
 ---
 

--- a/scripts/check-emulator-action-pin.sh
+++ b/scripts/check-emulator-action-pin.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Issue #2310: keep every hosted emulator-runner invocation reproducible.
+#
+# The release-validation, nightly-extensive, and per-push journey lanes all
+# depend on reactivecircus/android-emulator-runner. A floating major tag lets
+# the action implementation change underneath an otherwise identical commit,
+# so every active workflow reference must use the one audited v2.37.0 commit.
+# The version comment is checked on the same line so a reader can identify the
+# pinned action without resolving the SHA manually.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+WORKFLOW_DIR="${POCKETSHELL_EMULATOR_ACTION_WORKFLOW_DIR:-$ROOT_DIR/.github/workflows}"
+
+readonly EXPECTED_SHA="e89f39f1abbbd05b1113a29cf4db69e7540cae5a"
+readonly EXPECTED_VERSION="v2.37.0"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  return 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-emulator-action-pin.sh [--self-test | WORKFLOW_DIR]
+
+Checks every reactivecircus/android-emulator-runner reference under the GitHub
+Actions workflow directory. Each reference must use the audited v2.37.0 commit
+SHA and retain a same-line '# v2.37.0' comment.
+
+--self-test runs a synthetic red->green proof for a valid pin, a floating tag,
+a different commit SHA, and a missing human-readable version comment.
+USAGE
+}
+
+check_workflows() {
+  local workflow_dir="$1"
+  [[ -d "$workflow_dir" ]] || {
+    fail "workflow directory not found: $workflow_dir"
+    return 1
+  }
+
+  local -a matches=()
+  mapfile -t matches < <(
+    grep -RIn \
+      --include='*.yml' \
+      --include='*.yaml' \
+      -E '^[[:space:]]*uses:[[:space:]]*reactivecircus/android-emulator-runner@' \
+      "$workflow_dir" || true
+  )
+
+  (( ${#matches[@]} > 0 )) || {
+    fail "no reactivecircus/android-emulator-runner workflow references found under $workflow_dir"
+    return 1
+  }
+
+  local match file remainder line_number source ref
+  local reference_count=0
+  for match in "${matches[@]}"; do
+    file="${match%%:*}"
+    remainder="${match#*:}"
+    line_number="${remainder%%:*}"
+    source="${remainder#*:}"
+    ref="$(sed -E 's/.*reactivecircus\/android-emulator-runner@([^[:space:]#]+).*/\1/' <<<"$source")"
+
+    if [[ "$ref" != "$EXPECTED_SHA" ]]; then
+      if [[ "$ref" == v* || "$ref" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
+        fail "$file:$line_number uses floating emulator-runner tag @$ref; pin @$EXPECTED_SHA"
+      else
+        fail "$file:$line_number uses emulator-runner @$ref; expected audited @$EXPECTED_SHA"
+      fi
+      return 1
+    fi
+
+    if ! grep -Eq "#[[:space:]]*${EXPECTED_VERSION//./\\.}([[:space:]]|$)" <<<"$source"; then
+      fail "$file:$line_number pins @$EXPECTED_SHA but is missing the '# $EXPECTED_VERSION' comment"
+      return 1
+    fi
+
+    reference_count=$((reference_count + 1))
+  done
+
+  printf 'PASS: %d emulator-runner reference(s) use @%s # %s\n' \
+    "$reference_count" "$EXPECTED_SHA" "$EXPECTED_VERSION"
+}
+
+self_test() {
+  local temp_dir valid_root floating_root wrong_sha_root missing_comment_root
+  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/emulator-action-pin-check.XXXXXX")"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  valid_root="$temp_dir/valid/.github/workflows"
+  mkdir -p "$valid_root"
+
+  write_fixture() {
+    local workflow="$1"
+    local sha="$2"
+    local comment="$3"
+    {
+      printf 'name: fixture\n'
+      printf 'jobs:\n'
+      printf '  emulator:\n'
+      printf '    runs-on: ubuntu-latest\n'
+      printf '    steps:\n'
+      printf '      - name: Run emulator\n'
+      printf '        uses: reactivecircus/android-emulator-runner@%s%s\n' "$sha" "$comment"
+    } > "$workflow"
+  }
+
+  write_fixture "$valid_root/release-emulator-validation.yml" "$EXPECTED_SHA" " # $EXPECTED_VERSION"
+  write_fixture "$valid_root/nightly-extensive.yml" "$EXPECTED_SHA" " # $EXPECTED_VERSION"
+
+  local failures=0
+  printf '== self-test: valid pinned workflows (expect PASS) ==\n'
+  if check_workflows "$valid_root"; then
+    printf '   -> PASS as expected\n\n'
+  else
+    printf '   -> UNEXPECTED FAIL on valid pinned workflows\n\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  floating_root="$temp_dir/floating/.github/workflows"
+  mkdir -p "$floating_root"
+  cp "$valid_root"/*.yml "$floating_root/"
+  sed -i "s/@$EXPECTED_SHA/@v2/" "$floating_root/release-emulator-validation.yml"
+  printf '== self-test: floating major tag (expect FAIL) ==\n'
+  if check_workflows "$floating_root" >"$temp_dir/floating.out" 2>&1; then
+    printf '   -> UNEXPECTED PASS on floating tag\n\n' >&2
+    failures=$((failures + 1))
+  elif grep -Fq 'floating emulator-runner tag' "$temp_dir/floating.out"; then
+    printf '   -> FAIL as expected\n\n'
+  else
+    cat "$temp_dir/floating.out" >&2
+    printf '   -> FAIL used the wrong diagnostic\n\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  wrong_sha_root="$temp_dir/wrong-sha/.github/workflows"
+  mkdir -p "$wrong_sha_root"
+  cp "$valid_root"/*.yml "$wrong_sha_root/"
+  sed -i "s/@$EXPECTED_SHA/@0000000000000000000000000000000000000000/" \
+    "$wrong_sha_root/nightly-extensive.yml"
+  printf '== self-test: different commit SHA (expect FAIL) ==\n'
+  if check_workflows "$wrong_sha_root" >"$temp_dir/wrong-sha.out" 2>&1; then
+    printf '   -> UNEXPECTED PASS on different SHA\n\n' >&2
+    failures=$((failures + 1))
+  elif grep -Fq 'expected audited' "$temp_dir/wrong-sha.out"; then
+    printf '   -> FAIL as expected\n\n'
+  else
+    cat "$temp_dir/wrong-sha.out" >&2
+    printf '   -> FAIL used the wrong diagnostic\n\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  missing_comment_root="$temp_dir/missing-comment/.github/workflows"
+  mkdir -p "$missing_comment_root"
+  cp "$valid_root"/*.yml "$missing_comment_root/"
+  sed -i "s/ # $EXPECTED_VERSION$//" "$missing_comment_root/release-emulator-validation.yml"
+  printf '== self-test: missing human-readable version comment (expect FAIL) ==\n'
+  if check_workflows "$missing_comment_root" >"$temp_dir/missing-comment.out" 2>&1; then
+    printf '   -> UNEXPECTED PASS without version comment\n\n' >&2
+    failures=$((failures + 1))
+  elif grep -Fq 'missing the' "$temp_dir/missing-comment.out"; then
+    printf '   -> FAIL as expected\n\n'
+  else
+    cat "$temp_dir/missing-comment.out" >&2
+    printf '   -> FAIL used the wrong diagnostic\n\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  if (( failures != 0 )); then
+    fail "emulator action pin self-test: $failures case(s) behaved incorrectly"
+    return 1
+  fi
+  printf 'PASS: emulator action pin self-test (4 cases)\n'
+}
+
+case "${1:-}" in
+  --help|-h)
+    usage
+    ;;
+  --self-test)
+    self_test
+    ;;
+  "")
+    check_workflows "$WORKFLOW_DIR"
+    ;;
+  *)
+    check_workflows "$1"
+    ;;
+esac


### PR DESCRIPTION
Fixes #2310.\n\nRebased approved implementation onto origin/main after PR #2326. Pins all hosted emulator-runner references to the audited v2.37.0 SHA, adds the mutation-tested static guard, and documents the canonical CI matrix.\n\nFinal local verification: YAML 4/4, pin guard red/green plus 4-case self-test, shellcheck, bash syntax 5/5, nightly guard, unit-gate guard, interpreter hygiene guard, and git diff --check all passed. Reviewer approval is recorded on #2310.