### PR TITLE
feat: drive session picker from engine registry (#2275)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchCommandDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchCommandDockerTest.kt
@@ -10,6 +10,7 @@ import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.uikit.model.SessionAgentKind
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
@@ -23,7 +24,7 @@ import java.io.FileOutputStream
 
 /**
  * Connected proof for issue #703: the SHORT server-side wrapper command
- * PocketShell builds (`pocketshell agent <kind> --dir '<dir>' …`) is the
+ * PocketShell builds (`pocketshell agent <registry-id> --dir '<dir>' …`) is the
  * exact text that lands in the new tmux pane via `createSession` ->
  * `tmux send-keys`, AND the wrapper actually exec's the agent (the agent
  * STARTS / becomes usable), not merely that the command text is in
@@ -118,25 +119,25 @@ class AgentLaunchCommandDockerTest {
         val cases = listOf(
             Case(
                 name = "issue703-claude-on-$suffix",
-                choice = agentChoice(AgentCli.Claude, skip = true, cwd),
+                choice = agentChoice(pickerTestEngine("claude", SessionAgentKind.Claude), skip = true, cwd),
                 readyToken = "Claude Code fixture",
                 expectedCommand = "pocketshell agent claude --dir '$cwd'",
             ),
             Case(
                 name = "issue703-claude-off-$suffix",
-                choice = agentChoice(AgentCli.Claude, skip = false, cwd),
+                choice = agentChoice(pickerTestEngine("claude", SessionAgentKind.Claude), skip = false, cwd),
                 readyToken = "Claude Code fixture",
                 expectedCommand = "pocketshell agent claude --dir '$cwd' --no-skip-permissions",
             ),
             Case(
                 name = "issue703-codex-on-$suffix",
-                choice = agentChoice(AgentCli.Codex, skip = true, cwd),
+                choice = agentChoice(pickerTestEngine("codex", SessionAgentKind.Codex), skip = true, cwd),
                 readyToken = "Codex fixture",
                 expectedCommand = "pocketshell agent codex --dir '$cwd'",
             ),
             Case(
                 name = "issue703-opencode-$suffix",
-                choice = agentChoice(AgentCli.OpenCode, skip = true, cwd),
+                choice = agentChoice(pickerTestEngine("opencode", SessionAgentKind.OpenCode), skip = true, cwd),
                 readyToken = "OpenCode fixture",
                 expectedCommand = "pocketshell agent opencode --dir '$cwd'",
             ),
@@ -199,10 +200,10 @@ class AgentLaunchCommandDockerTest {
         File(artifactDir, "agent-launch-command-summary.txt").writeText(summary.toString())
     } }
 
-    private fun agentChoice(agent: AgentCli, skip: Boolean, cwd: String) =
+    private fun agentChoice(engine: RemoteEngine, skip: Boolean, cwd: String) =
         SessionTypeChoice(
             type = SessionType.Agent,
-            agent = agent,
+            engine = engine,
             startDirectory = cwd,
             skipPermissions = skip,
         )

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentRecordedKindReadBackDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentRecordedKindReadBackDockerTest.kt
@@ -30,7 +30,7 @@ import java.io.FileOutputStream
  * focused Docker-gated path:
  *
  *  1. launch Claude, Codex, and OpenCode through [SshFolderListGateway.createSession]
- *     using the same short [AgentCli.buildAgentCommand] line the app types;
+ *     using the same short registry-wrapper line the app types;
  *  2. wait for the fixture `pocketshell agent` wrapper to write host-side
  *     `@ps_agent_kind`;
  *  3. re-read via [SshFolderListGateway.listSessionsWithFolder], the same
@@ -86,26 +86,29 @@ class AgentRecordedKindReadBackDockerTest {
         ensureRemoteDir(cwd)
 
         data class Case(
-            val agent: AgentCli,
+            val engine: RemoteEngine,
             val rawKind: String,
             val expected: SessionAgentKind,
         )
 
         val cases = listOf(
-            Case(AgentCli.Claude, rawKind = "claude", expected = SessionAgentKind.Claude),
-            Case(AgentCli.Codex, rawKind = "codex", expected = SessionAgentKind.Codex),
-            Case(AgentCli.OpenCode, rawKind = "opencode", expected = SessionAgentKind.OpenCode),
+            Case(pickerTestEngine("claude", SessionAgentKind.Claude), rawKind = "claude", expected = SessionAgentKind.Claude),
+            Case(pickerTestEngine("codex", SessionAgentKind.Codex), rawKind = "codex", expected = SessionAgentKind.Codex),
+            Case(pickerTestEngine("opencode", SessionAgentKind.OpenCode), rawKind = "opencode", expected = SessionAgentKind.OpenCode),
         )
 
         for (case in cases) {
             val sessionName = "issue852-${case.rawKind}-$suffix"
             cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
-            val startCommand = AgentCli.buildAgentCommand(
-                kind = case.agent.command,
-                directory = cwd,
-                noSkipPermissions = false,
-                profileName = null,
+            val choice = SessionTypeChoice(
+                type = SessionType.Agent,
+                engine = case.engine,
+                startDirectory = cwd,
+                skipPermissions = true,
             )
+            assertEquals(case.rawKind, choice.engineId)
+            assertEquals(case.expected, choice.sessionAgentKind)
+            val startCommand = choice.startCommand()!!
 
             withTimeout(30_000) {
                 gateway.createSession(
@@ -120,19 +123,19 @@ class AgentRecordedKindReadBackDockerTest {
             }
 
             assertEquals(
-                "fixture wrapper must record @ps_agent_kind for ${case.agent}",
+                "fixture wrapper must record @ps_agent_kind for ${case.engine.id}",
                 case.rawKind,
                 awaitRecordedKindOption(sessionName, case.rawKind),
             )
 
             val row = readSessionRow(gateway, host, sessionName)
             assertEquals(
-                "gateway must read back recordedKind for ${case.agent}",
+                "gateway must read back recordedKind for ${case.engine.id}",
                 case.expected,
                 row.recordedKind,
             )
             assertEquals(
-                "recorded kind must drive the authoritative rendered kind for ${case.agent}",
+                "recorded kind must drive the authoritative rendered kind for ${case.engine.id}",
                 case.expected,
                 row.agentKind,
             )

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListScreenE2eTest.kt
@@ -1089,10 +1089,10 @@ class FolderListScreenE2eTest {
         }
         compose.onNodeWithTag(SESSION_TYPE_PICKER_SHELL_TAG).assertExists()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_TAG).assertExists()
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CLAUDE_TAG).assertExists()
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CODEX_TAG).assertExists()
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG).assertExists()
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_GROK_TAG).assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("claude")).assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex")).assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("opencode")).assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("grok")).assertExists()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).assertExists()
 
         // Capture the picker sheet via the full-device screenshot path

--- a/app/src/androidTest/java/com/pocketshell/app/projects/Issue1973AgentLaunchStateFolderIsolationDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/Issue1973AgentLaunchStateFolderIsolationDockerTest.kt
@@ -105,10 +105,10 @@ class Issue1973AgentLaunchStateFolderIsolationDockerTest {
         val launchCommandDir = "/tmp/issue1973-launch-command-$suffix".also(remoteDirs::add)
         ensureRemoteDir(launchCommandDir)
         val commandLaunches = listOf(
-            Triple("claude-on", AgentCli.Claude, false),
-            Triple("claude-off", AgentCli.Claude, true),
-            Triple("codex", AgentCli.Codex, false),
-            Triple("opencode", AgentCli.OpenCode, false),
+            Triple("claude-on", pickerTestEngine("claude", SessionAgentKind.Claude), false),
+            Triple("claude-off", pickerTestEngine("claude", SessionAgentKind.Claude), true),
+            Triple("codex", pickerTestEngine("codex", SessionAgentKind.Codex), false),
+            Triple("opencode", pickerTestEngine("opencode", SessionAgentKind.OpenCode), false),
         )
         val commandSessions = commandLaunches.map { (label, agent, noSkip) ->
             val name = "issue1973-command-$label-$suffix"
@@ -122,9 +122,13 @@ class Issue1973AgentLaunchStateFolderIsolationDockerTest {
         // exact test-owned cleanup. Recorded kinds remain the sole authority.
         val recordedDir = "/tmp/issue1973-recorded-$suffix".also(remoteDirs::add)
         ensureRemoteDir(recordedDir)
-        val recordedSessions = listOf(AgentCli.Claude, AgentCli.Codex, AgentCli.OpenCode).map { agent ->
-            val name = "issue1973-recorded-${agent.command}-$suffix"
-            launchAgent(gateway, host, name, recordedDir, agent, noSkip = false)
+        val recordedSessions = listOf(
+            pickerTestEngine("claude", SessionAgentKind.Claude),
+            pickerTestEngine("codex", SessionAgentKind.Codex),
+            pickerTestEngine("opencode", SessionAgentKind.OpenCode),
+        ).map { engine ->
+            val name = "issue1973-recorded-${engine.id}-$suffix"
+            launchAgent(gateway, host, name, recordedDir, engine, noSkip = false)
             name
         }
         val recordedRows = gatewayRows(gateway, host).filter { it.sessionName in recordedSessions }
@@ -223,16 +227,16 @@ class Issue1973AgentLaunchStateFolderIsolationDockerTest {
         host: HostEntity,
         sessionName: String,
         cwd: String,
-        agent: AgentCli,
+        engine: RemoteEngine,
         noSkip: Boolean,
     ) {
         liveSessions += sessionName
-        val command = AgentCli.buildAgentCommand(
-            kind = agent.command,
-            directory = cwd,
-            noSkipPermissions = noSkip,
-            profileName = null,
-        )
+        val command = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = engine,
+            startDirectory = cwd,
+            skipPermissions = !noSkip,
+        ).startCommand()!!
         withTimeout(30_000) {
             gateway.createSession(
                 host = host,
@@ -244,7 +248,7 @@ class Issue1973AgentLaunchStateFolderIsolationDockerTest {
                 namePolicy = SessionNamePolicy.UniqueOnHost,
             ).getOrThrow()
         }
-        awaitRecordedKind(sessionName, agent.command)
+        awaitRecordedKind(sessionName, engine.id)
     }
 
     private suspend fun awaitRecordedKind(sessionName: String, expected: String) {

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ProfileChipRelaunchDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ProfileChipRelaunchDockerTest.kt
@@ -96,12 +96,15 @@ class ProfileChipRelaunchDockerTest {
         tree.bindHost(host.id)
 
         // --- Launch 1: a z.ai-profile Claude (the reproduce fixture state) ----
-        val zaiCommand = AgentCli.buildAgentCommand(
-            kind = "claude",
-            directory = cwd,
-            noSkipPermissions = false,
+        val claudeEngine = pickerTestEngine("claude", SessionAgentKind.Claude)
+        val zaiCommand = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = claudeEngine,
+            startDirectory = cwd,
             profileName = zaiProfileLabel,
-        )
+        ).startCommand(
+            claudeProfiles = listOf(ClaudeProfile(zaiProfileLabel)),
+        )!!
         withTimeout(30_000) {
             gateway.createSession(
                 host, keyFile.absolutePath, null, session, cwd, zaiCommand,
@@ -129,12 +132,11 @@ class ProfileChipRelaunchDockerTest {
         // --- Launch 2: relaunch the SAME session as a DEFAULT Claude ----------
         // No --profile, so the wrapper UNSETS @ps_agent_profile. send-keys it
         // into the same pane (the fake claude already exited back to the shell).
-        val defaultCommand = AgentCli.buildAgentCommand(
-            kind = "claude",
-            directory = cwd,
-            noSkipPermissions = false,
-            profileName = null,
-        )
+        val defaultCommand = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = claudeEngine,
+            startDirectory = cwd,
+        ).startCommand()!!
         withSshSession { s ->
             s.exec("tmux send-keys -t '$session' '${defaultCommand.replace("'", "'\\''")}' Enter")
         }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ProfileDiscoveryPickerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ProfileDiscoveryPickerDockerTest.kt
@@ -43,7 +43,7 @@ import java.io.FileOutputStream
  *     ToolUnavailable / Failed) and to contain both seeded Claude profiles.
  *  3. The discovered rows are projected onto the picker's [ClaudeProfile]
  *     flow exactly as [FolderListViewModel] does, then the non-default
- *     "Claude (Z.AI)" profile is SELECTED and [AgentCli.launchCommand]
+ *     "Claude (Z.AI)" profile is SELECTED and the registry-row launch command
  *     threads its name into `--profile '<name>'`.
  *  4. That launch command is finally EXEC'd over SSH against the fixture's
  *     `pocketshell agent` wrapper, proving the discovered + selected profile
@@ -142,12 +142,13 @@ class ProfileDiscoveryPickerDockerTest {
         // Select the NON-default discovered profile.
         val selected = "Claude (Z.AI)"
         val workdir = "/tmp/issue732-discovery-${System.currentTimeMillis().toString().takeLast(6)}"
-        val launchCommand = AgentCli.Claude.launchCommand(
-            directory = workdir,
+        val launchCommand = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = pickerTestEngine("claude", com.pocketshell.uikit.model.SessionAgentKind.Claude),
+            startDirectory = workdir,
             skipPermissions = true,
-            claudeProfileName = selected,
-            claudeProfiles = claudeProfiles,
-        )
+            profileName = selected,
+        ).startCommand(claudeProfiles = claudeProfiles)!!
         // The selected non-default profile name is threaded into --profile.
         assertTrue(
             "launch command must thread --profile for the selected non-default profile, got: $launchCommand",

--- a/app/src/androidTest/java/com/pocketshell/app/projects/RegistryPickerTestFixtures.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RegistryPickerTestFixtures.kt
@@ -1,0 +1,27 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.uikit.model.SessionAgentKind
+
+/** Registry rows used by picker UI/connected launch tests. */
+internal fun pickerTestEngine(
+    id: String,
+    family: SessionAgentKind,
+    label: String = id,
+    supportsSkipPermissions: Boolean = family != SessionAgentKind.OpenCode,
+): RemoteEngine = RemoteEngine(
+    id = id,
+    familyId = family.name.lowercase(),
+    family = family,
+    label = label,
+    launch = RemoteEngineLaunch(
+        supportsSkipPermissions = supportsSkipPermissions,
+    ),
+)
+
+internal val pickerTestEngines: List<RemoteEngine>
+    get() = listOf(
+        pickerTestEngine("claude", SessionAgentKind.Claude, "Claude"),
+        pickerTestEngine("codex", SessionAgentKind.Codex, "Codex"),
+        pickerTestEngine("opencode", SessionAgentKind.OpenCode, "OpenCode"),
+        pickerTestEngine("grok", SessionAgentKind.Grok, "Grok"),
+    )

--- a/app/src/androidTest/java/com/pocketshell/app/projects/RepoBrowserSessionPickerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/RepoBrowserSessionPickerTest.kt
@@ -58,6 +58,7 @@ class RepoBrowserSessionPickerTest {
                     folderLabel = repoFolderLabel(repoPath),
                     onCancel = {},
                     onCreate = { choice = it },
+                    engines = pickerTestEngines,
                     // Mirror RepoBrowserScreen's production picker wiring.
                     // The standalone content fallback is only the trailing
                     // basename and stopped representing this path when the
@@ -85,7 +86,7 @@ class RepoBrowserSessionPickerTest {
 
         val shellChoice = requireNotNull(choice) { "Shell create did not fire" }
         assertEquals(SessionType.Shell, shellChoice.type)
-        assertNull("Shell session has no agent", shellChoice.agent)
+        assertNull("Shell session has no engine", shellChoice.engine)
         assertNull("Shell session is a plain terminal — no start command", shellChoice.startCommand())
         assertEquals(repoPath, shellChoice.startDirectory)
 
@@ -108,6 +109,7 @@ class RepoBrowserSessionPickerTest {
                     folderLabel = repoFolderLabel(repoPath),
                     onCancel = {},
                     onCreate = { choice = it },
+                    engines = pickerTestEngines,
                     // Keep this content-only fixture on the exact production
                     // RepoBrowserScreen name-prefill path (#1184/#1868).
                     deriveDefaultName = { path ->
@@ -120,7 +122,7 @@ class RepoBrowserSessionPickerTest {
         // Agent is the default session type; switch the CLI to codex and confirm.
         compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_TAG).performClick()
         compose.waitForIdle()
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CODEX_TAG).performClick()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex")).performClick()
         compose.waitForIdle()
         captureScreenshot("issue516-repo-picker-agent-codex-selected")
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
@@ -128,7 +130,7 @@ class RepoBrowserSessionPickerTest {
 
         val agentChoice = requireNotNull(choice) { "Agent create did not fire" }
         assertEquals(SessionType.Agent, agentChoice.type)
-        assertEquals(AgentCli.Codex, agentChoice.agent)
+        assertEquals("codex", agentChoice.engineId)
         assertEquals(repoPath, agentChoice.startDirectory)
         // The agent CLI is launched in the new pane through the SAME
         // `pocketshell agent <kind> --dir '<dir>'` wrapper the folder Agent

--- a/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypePickerSkipPermissionsUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypePickerSkipPermissionsUiTest.kt
@@ -67,6 +67,7 @@ class SessionTypePickerSkipPermissionsUiTest {
                     folderLabel = "pocketshell",
                     onCancel = {},
                     onCreate = { lastChoice = it },
+                    engines = pickerTestEngines,
                 )
             }
         }
@@ -81,7 +82,7 @@ class SessionTypePickerSkipPermissionsUiTest {
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
         compose.waitForIdle()
         assertTrue(lastChoice?.skipPermissions == true)
-        assertTrue(lastChoice?.agent == AgentCli.Claude)
+        assertTrue(lastChoice?.engineId == "claude")
         // Post-#627/#703 hard-cut (D22): the app emits the short server-side
         // wrapper line, NOT the old inline `env -u … claude --dangerously…`.
         // Skip-permissions defaults ON in the wrapper, so no extra flag.
@@ -92,7 +93,7 @@ class SessionTypePickerSkipPermissionsUiTest {
         )
 
         // Switch to OpenCode -> the checkbox is hidden (no-op for OpenCode).
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG).performClick()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("opencode")).performClick()
         compose.waitForIdle()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG).assertDoesNotExist()
         captureScreenshot("issue428-picker-opencode-no-checkbox")
@@ -108,6 +109,7 @@ class SessionTypePickerSkipPermissionsUiTest {
                     folderLabel = "app",
                     onCancel = {},
                     onCreate = { lastChoice = it },
+                    engines = pickerTestEngines,
                 )
             }
         }
@@ -129,7 +131,7 @@ class SessionTypePickerSkipPermissionsUiTest {
     }
 
     @Test
-    fun agentCliChoicesUseSingleAlignedSegmentedRow() {
+    fun registryEngineChoicesUseSingleAlignedSegmentedRow() {
         compose.setContent {
             PocketShellTheme {
                 SessionTypePickerContent(
@@ -137,17 +139,18 @@ class SessionTypePickerSkipPermissionsUiTest {
                     folderLabel = "app",
                     onCancel = {},
                     onCreate = {},
+                    engines = pickerTestEngines,
                 )
             }
         }
 
-        val claude = compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CLAUDE_TAG)
+        val claude = compose.onNodeWithTag(sessionTypePickerAgentEngineTag("claude"))
             .fetchSemanticsNode().boundsInRoot
-        val codex = compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CODEX_TAG)
+        val codex = compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex"))
             .fetchSemanticsNode().boundsInRoot
-        val opencode = compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG)
+        val opencode = compose.onNodeWithTag(sessionTypePickerAgentEngineTag("opencode"))
             .fetchSemanticsNode().boundsInRoot
-        val grok = compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_GROK_TAG)
+        val grok = compose.onNodeWithTag(sessionTypePickerAgentEngineTag("grok"))
             .fetchSemanticsNode().boundsInRoot
 
         assertTrue("codex should sit to the right of claude", codex.left > claude.left)
@@ -170,11 +173,12 @@ class SessionTypePickerSkipPermissionsUiTest {
                     folderLabel = "app",
                     onCancel = {},
                     onCreate = {},
+                    engines = pickerTestEngines,
                 )
             }
         }
 
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_GROK_TAG).performClick()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("grok")).performClick()
         compose.waitForIdle()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG).assertIsDisplayed()
         compose.onNodeWithText("Skip permissions").assertIsDisplayed()
@@ -194,6 +198,7 @@ class SessionTypePickerSkipPermissionsUiTest {
                         folderLabel = "ai-shipping-labs-workshops-raw",
                         onCancel = {},
                         onCreate = {},
+                        engines = pickerTestEngines,
                     )
                 }
             }
@@ -242,6 +247,7 @@ class SessionTypePickerSkipPermissionsUiTest {
                         folderLabel = "srv",
                         onCancel = {},
                         onCreate = {},
+                        engines = pickerTestEngines,
                         autocompleteController = autocomplete,
                     )
                 }
@@ -303,6 +309,7 @@ class SessionTypePickerSkipPermissionsUiTest {
                         folderLabel = "srv",
                         onCancel = {},
                         onCreate = { lastChoice = it },
+                        engines = pickerTestEngines,
                         autocompleteController = autocomplete,
                     )
                 }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypeProfilePickerUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SessionTypeProfilePickerUiTest.kt
@@ -88,6 +88,7 @@ class SessionTypeProfilePickerUiTest {
                         folderLabel = "app",
                         onCancel = {},
                         onCreate = onCreate,
+                        engines = pickerTestEngines,
                         claudeProfiles = claudeProfiles,
                         codexProfiles = codexProfiles,
                     )
@@ -103,21 +104,20 @@ class SessionTypeProfilePickerUiTest {
 
         // Agent + Claude are the defaults, so with >1 Claude profile the
         // "Profile" toggle is shown and lists all discovered profiles by name.
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_PROFILE_TAG).assertIsDisplayed()
         compose.onNodeWithText("default").assertIsDisplayed()
         compose.onNodeWithText("work").assertIsDisplayed()
         compose.onNodeWithText("oss").assertIsDisplayed()
 
         // Select the non-default "work" profile, then Create.
-        compose.onNodeWithTag("$SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG:work").performClick()
+        compose.onNodeWithTag("$SESSION_TYPE_PICKER_PROFILE_TAG:work").performClick()
         compose.waitForIdle()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
         compose.waitForIdle()
 
         assertTrue("create should route a choice", choice != null)
-        assertEquals(AgentCli.Claude, choice?.agent)
-        assertEquals("work", choice?.claudeProfileName)
-        assertNull("codex profile is irrelevant for a Claude session", choice?.codexProfileName)
+        assertEquals("claude", choice?.engineId)
+        assertEquals("work", choice?.profileName)
 
         // The chosen profile threads into the launched command as --profile.
         val command = choice?.startCommand(
@@ -136,7 +136,7 @@ class SessionTypeProfilePickerUiTest {
         picker(claudeProfiles = claudeProfiles, codexProfiles = codexProfiles) { choice = it }
 
         // Pick the default profile explicitly, Create.
-        compose.onNodeWithTag("$SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG:default").performClick()
+        compose.onNodeWithTag("$SESSION_TYPE_PICKER_PROFILE_TAG:default").performClick()
         compose.waitForIdle()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
         compose.waitForIdle()
@@ -145,7 +145,7 @@ class SessionTypeProfilePickerUiTest {
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
         )
-        assertEquals("default", choice?.claudeProfileName)
+        assertEquals("default", choice?.profileName)
         // The default profile means "use the engine's built-in config dir" — no flag.
         assertTrue(
             "the default profile must emit no --profile flag: $command",
@@ -159,18 +159,18 @@ class SessionTypeProfilePickerUiTest {
         picker(claudeProfiles = claudeProfiles, codexProfiles = codexProfiles) { choice = it }
 
         // Switch to Codex; its >1-profile toggle then appears.
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_CODEX_TAG).performClick()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex")).performClick()
         compose.waitForIdle()
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_CODEX_PROFILE_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_PROFILE_TAG).assertIsDisplayed()
         compose.onNodeWithText("team").assertIsDisplayed()
 
-        compose.onNodeWithTag("$SESSION_TYPE_PICKER_CODEX_PROFILE_TAG:team").performClick()
+        compose.onNodeWithTag("$SESSION_TYPE_PICKER_PROFILE_TAG:team").performClick()
         compose.waitForIdle()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
         compose.waitForIdle()
 
-        assertEquals(AgentCli.Codex, choice?.agent)
-        assertEquals("team", choice?.codexProfileName)
+        assertEquals("codex", choice?.engineId)
+        assertEquals("team", choice?.profileName)
         val command = choice?.startCommand(
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
@@ -193,7 +193,7 @@ class SessionTypeProfilePickerUiTest {
             codexProfiles = codexProfiles,
         )
 
-        compose.onNodeWithTag(SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG).assertDoesNotExist()
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_PROFILE_TAG).assertDoesNotExist()
     }
 
     /**
@@ -236,6 +236,13 @@ class SessionTypeProfilePickerUiTest {
         }
 
         val profilesGateway = TransientThenZaiProfilesGateway()
+        val enginesGateway = object : EnginesGateway {
+            override suspend fun listEngines(
+                host: HostEntity,
+                keyPath: String,
+                passphrase: CharArray?,
+            ): EnginesResult = EnginesResult.Engines(pickerTestEngines)
+        }
         val sessionGateway = RecordingSessionGateway()
         lateinit var viewModel: FolderListViewModel
         instrumentation.runOnMainSync {
@@ -251,6 +258,7 @@ class SessionTypeProfilePickerUiTest {
                 ),
                 forwardingController = ForwardingController(context),
                 profilesGateway = profilesGateway,
+                enginesGateway = enginesGateway,
                 attachLifecycle = false,
             ).also {
                 it.setProcessStartedForTest(true)
@@ -298,12 +306,12 @@ class SessionTypeProfilePickerUiTest {
             // production host-screen open path retries the transient failure.
             compose.waitUntil(timeoutMillis = 10_000) {
                 compose.onAllNodesWithTag(
-                    "$SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG:Claude (Z.AI)",
+                    "$SESSION_TYPE_PICKER_PROFILE_TAG:Claude (Z.AI)",
                     useUnmergedTree = true,
                 ).fetchSemanticsNodes().isNotEmpty()
             }
             compose.onNodeWithTag(
-                "$SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG:Claude (Z.AI)",
+                "$SESSION_TYPE_PICKER_PROFILE_TAG:Claude (Z.AI)",
                 useUnmergedTree = true,
             ).performScrollTo().assertIsDisplayed().performClick()
             compose.waitForIdle()

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxNewSessionRichSheetTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxNewSessionRichSheetTest.kt
@@ -20,6 +20,7 @@ import com.pocketshell.app.projects.SESSION_TYPE_PICKER_CONTENT_TAG
 import com.pocketshell.app.projects.SESSION_TYPE_PICKER_SHELL_TAG
 import com.pocketshell.app.projects.SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG
 import com.pocketshell.app.projects.SessionTypePickerSheet
+import com.pocketshell.app.projects.sessionTypePickerAgentEngineTag
 import com.pocketshell.uikit.theme.PocketShellTheme
 import java.io.File
 import java.io.FileOutputStream
@@ -87,6 +88,7 @@ class TmuxNewSessionRichSheetTest {
                         // A multi-profile host so the Profile selector renders —
                         // proving the rich sheet's Profile criterion is reachable
                         // from this in-session entry point.
+                        engines = com.pocketshell.app.projects.pickerTestEngines,
                         claudeProfiles = listOf(
                             ClaudeProfile(name = "Claude", default = true),
                             ClaudeProfile(name = "Claude (Z.AI)"),
@@ -110,11 +112,15 @@ class TmuxNewSessionRichSheetTest {
             .assertExists()
         compose.onNodeWithTag(SESSION_TYPE_PICKER_AGENT_TAG, useUnmergedTree = true)
             .assertExists()
-        // Agent CLI sub-picker (Agent is the default selection) — claude/codex/
-        // opencode segments.
-        compose.onNodeWithText("claude", useUnmergedTree = true).assertExists()
-        compose.onNodeWithText("codex", useUnmergedTree = true).assertExists()
-        compose.onNodeWithText("opencode", useUnmergedTree = true).assertExists()
+        // Registry engine sub-picker (Agent is the default selection). The
+        // semantics tags are keyed by the raw registry ids; display labels
+        // remain host-owned and may be capitalized or customized.
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("claude"), useUnmergedTree = true)
+            .assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex"), useUnmergedTree = true)
+            .assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("opencode"), useUnmergedTree = true)
+            .assertExists()
         // Skip permissions row.
         compose.onNodeWithTag(SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG, useUnmergedTree = true)
             .assertExists()

--- a/app/src/main/java/com/pocketshell/app/projects/AgentLaunchVersionCheck.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/AgentLaunchVersionCheck.kt
@@ -6,7 +6,8 @@ import com.pocketshell.app.bootstrap.UV_EXCLUDE_NEWER_FLAG
  * Graceful version-mismatch detection for the agent-launch flow (issue #759).
  *
  * Launching a coding agent in a new pane runs the short server-side wrapper
- * `pocketshell agent <kind> --dir '<dir>' …` (see [AgentCli.launchCommand]).
+ * `pocketshell agent <registry-id> --dir '<dir>' …` (see
+ * [buildRegistryAgentCommand]).
  * That `agent` subcommand only exists in `pocketshell` ≥ [MIN_AGENT_POCKETSHELL_VERSION].
  * When the host has an OLDER `pocketshell` installed, Click answers with a raw
  *
@@ -66,7 +67,7 @@ object AgentLaunchVersionCheck {
     /**
      * The server-side wrapper line the agent-launch flow types into a fresh
      * pane is `pocketshell agent <kind> --dir '<dir>' …` (see
-     * [AgentCli.buildAgentCommand]). This prefix is how the gateway recognises
+     * [buildRegistryAgentCommand]). This prefix is how the gateway recognises
      * that a start command is an agent launch (and therefore wants the
      * pre-flight version guard) versus a plain shell session.
      */

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListScreen.kt
@@ -240,6 +240,7 @@ fun FolderListScreen(
     // over the warm session). Drives the Update button's spinner + failure line.
     val cliVersionUpdateState by viewModel.cliVersionUpdateState.collectAsState()
     val assistantState by viewModel.assistantState.collectAsState()
+    val engines by viewModel.engines.collectAsState()
     val claudeProfiles by viewModel.claudeProfiles.collectAsState()
     val codexProfiles by viewModel.codexProfiles.collectAsState()
     val assistantDictationUiState = remember(assistantDictationViewModel) {
@@ -503,6 +504,7 @@ fun FolderListScreen(
             folderLabel = target.label,
             onDismiss = { pickerFolder = null },
             suggestStartDirectories = suggestStartDirectories,
+            engines = engines,
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
             creating = (state as? FolderListUiState.Ready)?.isCreatingSession == true,

--- a/app/src/main/java/com/pocketshell/app/projects/RepoBrowserScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RepoBrowserScreen.kt
@@ -135,6 +135,7 @@ fun RepoBrowserScreen(
         )
     }
     val state by viewModel.state.collectAsState()
+    val engines by sessionViewModel.engines.collectAsState()
     val claudeProfiles by sessionViewModel.claudeProfiles.collectAsState()
     val codexProfiles by sessionViewModel.codexProfiles.collectAsState()
 
@@ -148,6 +149,7 @@ fun RepoBrowserScreen(
     LaunchedEffect(pickerRepoPath) {
         if (pickerRepoPath != null) {
             sessionViewModel.refreshProfilesForPicker()
+            sessionViewModel.refreshEnginesForPicker()
         }
     }
 
@@ -174,6 +176,7 @@ fun RepoBrowserScreen(
             folderLabel = repoFolderLabel(repoPath),
             onDismiss = { pickerRepoPath = null },
             suggestStartDirectories = suggestStartDirectories,
+            engines = engines,
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
             // Issue #1184: prefill the editable "Session name" field with the

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerModels.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerModels.kt
@@ -1,0 +1,32 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.uikit.model.SessionAgentKind
+
+/** The only rows that may be offered by a create-session picker. */
+internal fun availableEnginesForCreate(engines: List<RemoteEngine>): List<RemoteEngine> =
+    engines.filter { it.availableForCreate && it.enabled && it.available }
+
+/** One profile row after projecting the existing family-specific discoveries. */
+internal data class PickerProfile(
+    val name: String,
+    val default: Boolean,
+)
+
+/**
+ * Profiles remain discovered through the existing Claude/Codex APIs. The
+ * registry supplies the selected engine id; its closed family only chooses
+ * which already-published profile StateFlow can be used.
+ */
+internal fun pickerProfilesForEngine(
+    engine: RemoteEngine?,
+    claudeProfiles: List<ClaudeProfile>,
+    codexProfiles: List<CodexProfile>,
+): List<PickerProfile> = when (engine?.family) {
+    SessionAgentKind.Claude -> claudeProfiles.map { PickerProfile(it.name, it.default) }
+    SessionAgentKind.Codex -> codexProfiles.map { PickerProfile(it.name, it.default) }
+    else -> emptyList()
+}
+
+/** Stable semantics tag for a registry row; the id is deliberately open-ended. */
+fun sessionTypePickerAgentEngineTag(engineId: String): String =
+    "$SESSION_TYPE_PICKER_AGENT_ENGINE_TAG_PREFIX$engineId"

--- a/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/SessionTypePickerSheet.kt
@@ -58,13 +58,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
  *
  * The maintainer's refinement comment requires that "+ New session"
  * prompts the user for the SESSION TYPE (agent vs shell) and, when
- * "Agent" is chosen, a sub-picker for the agent CLI
- * (`claude` / `codex` / `opencode`). The folder is the explicit `cwd`
- * for the new session.
+ * "Agent" is chosen, a sub-picker for the host registry's available engines.
+ * The folder is the explicit `cwd` for the new session.
  *
  * The sheet is presented from [FolderListScreen] when the user taps the
  * FAB or an empty-folder row. Confirming the sheet fires
- * [onCreate] with the chosen kind + cwd + (optional) agent CLI; the
+ * [onCreate] with the chosen kind + cwd + (optional) registry engine; the
  * caller routes to `AppDestination.TmuxSession` with the right
  * `startDirectory` and (for agent sessions) a `startCommand` that the
  * tmux create path invokes via `send-keys` so the agent CLI runs as
@@ -78,6 +77,7 @@ fun SessionTypePickerSheet(
     onDismiss: () -> Unit,
     onCreate: (choice: SessionTypeChoice) -> Unit,
     suggestStartDirectories: (suspend (String) -> List<String>)? = null,
+    engines: List<RemoteEngine> = emptyList(),
     claudeProfiles: List<ClaudeProfile> = emptyList(),
     codexProfiles: List<CodexProfile> = emptyList(),
     creating: Boolean = false,
@@ -109,6 +109,7 @@ fun SessionTypePickerSheet(
             onCancel = onDismiss,
             onCreate = onCreate,
             autocompleteController = autocompleteController,
+            engines = engines,
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
             creating = creating,
@@ -131,6 +132,7 @@ internal fun SessionTypePickerContent(
     onCancel: () -> Unit,
     onCreate: (choice: SessionTypeChoice) -> Unit,
     autocompleteController: StartDirectoryAutocompleteController? = null,
+    engines: List<RemoteEngine> = emptyList(),
     claudeProfiles: List<ClaudeProfile> = emptyList(),
     codexProfiles: List<CodexProfile> = emptyList(),
     creating: Boolean = false,
@@ -138,8 +140,18 @@ internal fun SessionTypePickerContent(
     title: String = "New session",
     deriveDefaultName: (startDirectory: String) -> String = { it.trimEnd('/').substringAfterLast('/') },
 ) {
-    var sessionType by remember { mutableStateOf(SessionType.Agent) }
-    var agentKind by remember { mutableStateOf(AgentCli.Claude) }
+    val availableEngines = availableEnginesForCreate(engines)
+    val availableEngineIds = availableEngines.map { it.id }
+    var sessionType by remember(availableEngineIds) {
+        mutableStateOf(
+            if (availableEngines.isEmpty()) SessionType.Shell else SessionType.Agent,
+        )
+    }
+    var selectedEngineId by remember(availableEngineIds) {
+        mutableStateOf(availableEngines.firstOrNull()?.id)
+    }
+    val selectedEngine = availableEngines.firstOrNull { it.id == selectedEngineId }
+        ?: availableEngines.firstOrNull()
     // Issue #428: default ON — the maintainer almost always wants the
     // agent launched without per-action approval prompts.
     var skipPermissions by remember { mutableStateOf(true) }
@@ -155,10 +167,10 @@ internal fun SessionTypePickerContent(
             sessionName = deriveDefaultName(startDirectory)
         }
     }
-    // Issue #627: selected Claude profile. null = default (no config dir override).
-    var claudeProfile by remember { mutableStateOf<String?>(null) }
-    // Issue #631: selected Codex profile. null = default (no config dir override).
-    var codexProfile by remember { mutableStateOf<String?>(null) }
+    // The existing profile discoveries remain family-specific, but the
+    // selected picker row is an open registry engine id.
+    var profileName by remember { mutableStateOf<String?>(null) }
+    val profiles = pickerProfilesForEngine(selectedEngine, claudeProfiles, codexProfiles)
     val scrollState = rememberScrollState()
     val fallbackAutocompleteState = remember { MutableStateFlow(StartDirectoryAutocompleteUiState()) }
     val autocompleteState by (autocompleteController?.state ?: fallbackAutocompleteState).collectAsState()
@@ -179,19 +191,10 @@ internal fun SessionTypePickerContent(
         onCreate(
             SessionTypeChoice(
                 type = sessionType,
-                agent = if (sessionType == SessionType.Agent) agentKind else null,
+                engine = if (sessionType == SessionType.Agent) selectedEngine else null,
                 startDirectory = resolvedStartDirectory,
                 skipPermissions = skipPermissions,
-                claudeProfileName = if (sessionType == SessionType.Agent && agentKind == AgentCli.Claude) {
-                    claudeProfile
-                } else {
-                    null
-                },
-                codexProfileName = if (sessionType == SessionType.Agent && agentKind == AgentCli.Codex) {
-                    codexProfile
-                } else {
-                    null
-                },
+                profileName = if (sessionType == SessionType.Agent) profileName else null,
                 // Issue #1184: carry the user's custom label. Blank falls
                 // back to the derived default at create time.
                 customName = sessionName.trim().ifBlank { null },
@@ -307,82 +310,67 @@ internal fun SessionTypePickerContent(
                 )
             }
 
-            // Conditional agent CLI sub-picker.
+            // Conditional registry-engine sub-picker. The host owns the
+            // labels, ordering, enabled/available state, and raw launch ids.
             if (sessionType == SessionType.Agent) {
                 Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
-                    SectionHeader(label = "Agent CLI")
-                    SegmentedToggle(
-                        labels = AGENT_CLI_LABELS,
-                        selectedIndex = agentKind.ordinal,
-                        onSelected = { agentKind = AgentCli.entries[it] },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = PICKER_SEGMENT_HEIGHT),
-                        fillSegments = true,
-                        segmentTag = { index -> AGENT_CLI_SEGMENT_TAGS[index] },
-                    )
-                    Text(
-                        text = "The CLI will auto-start in the new pane.",
-                        color = PocketShellColors.TextMuted,
-                        style = PocketShellType.labelMono,
-                    )
+                    if (availableEngines.isEmpty()) {
+                        Text(
+                            text = "No agent engines are available on this host.",
+                            color = PocketShellColors.TextMuted,
+                            style = PocketShellType.labelMono,
+                        )
+                    } else {
+                        SectionHeader(label = "Agent engine")
+                        SegmentedToggle(
+                            labels = availableEngines.map { it.label },
+                            selectedIndex = availableEngines
+                                .indexOfFirst { it.id == selectedEngine?.id }
+                                .coerceAtLeast(0),
+                            onSelected = {
+                                selectedEngineId = availableEngines[it].id
+                                profileName = null
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = PICKER_SEGMENT_HEIGHT),
+                            fillSegments = true,
+                            segmentTag = { index ->
+                                sessionTypePickerAgentEngineTag(availableEngines[index].id)
+                            },
+                        )
+                        Text(
+                            text = "The engine will auto-start in the new pane.",
+                            color = PocketShellColors.TextMuted,
+                            style = PocketShellType.labelMono,
+                        )
+                    }
 
-                    // Skip-permissions toggle (issue #428). Hidden for
-                    // OpenCode: its per-action permissions are config-driven
-                    // in opencode.json, not a CLI flag, so the checkbox would
-                    // be a no-op there. OpenCode is always launched
-                    // env-stripped (subscription auth) by the wrapper
-                    // regardless (issue #703).
-                    if (agentKind != AgentCli.OpenCode) {
+                    // The wrapper's generic flag is useful only when the
+                    // selected registry row declares skip-permissions support.
+                    if (selectedEngine?.launch?.supportsSkipPermissions == true) {
                         SkipPermissionsRow(
                             checked = skipPermissions,
                             onToggle = { skipPermissions = !skipPermissions },
                         )
                     }
 
-                    // Issue #627: Claude Code profile selector. Shown only
-                    // when Claude is selected AND the host has more than one
-                    // profile configured (default + at least one custom).
-                    if (agentKind == AgentCli.Claude && claudeProfiles.size > 1) {
+                    if (profiles.size > 1) {
                         Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
                             SectionHeader(label = "Profile")
                             SegmentedToggle(
-                                labels = claudeProfiles.map { it.name },
-                                selectedIndex = claudeProfiles
-                                    .indexOfFirst { it.name == claudeProfile }
+                                labels = profiles.map { it.name },
+                                selectedIndex = profiles
+                                    .indexOfFirst { it.name == profileName }
                                     .coerceAtLeast(0),
-                                onSelected = { claudeProfile = claudeProfiles[it].name },
+                                onSelected = { profileName = profiles[it].name },
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .heightIn(min = PICKER_SEGMENT_HEIGHT)
-                                    .testTag(SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG),
+                                    .testTag(SESSION_TYPE_PICKER_PROFILE_TAG),
                                 fillSegments = true,
                                 segmentTag = { index ->
-                                    "$SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG:${claudeProfiles[index].name}"
-                                },
-                            )
-                        }
-                    }
-
-                    // Issue #631: Codex profile selector. Shown only when
-                    // Codex is selected AND the host has more than one
-                    // profile configured.
-                    if (agentKind == AgentCli.Codex && codexProfiles.size > 1) {
-                        Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
-                            SectionHeader(label = "Profile")
-                            SegmentedToggle(
-                                labels = codexProfiles.map { it.name },
-                                selectedIndex = codexProfiles
-                                    .indexOfFirst { it.name == codexProfile }
-                                    .coerceAtLeast(0),
-                                onSelected = { codexProfile = codexProfiles[it].name },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .heightIn(min = PICKER_SEGMENT_HEIGHT)
-                                    .testTag(SESSION_TYPE_PICKER_CODEX_PROFILE_TAG),
-                                fillSegments = true,
-                                segmentTag = { index ->
-                                    "$SESSION_TYPE_PICKER_CODEX_PROFILE_TAG:${codexProfiles[index].name}"
+                                    "$SESSION_TYPE_PICKER_PROFILE_TAG:${profiles[index].name}"
                                 },
                             )
                         }
@@ -412,7 +400,9 @@ internal fun SessionTypePickerContent(
                     if (!creating) emitCreateChoice(missingFolderOffer)
                 },
                 variant = ButtonVariant.Primary,
-                enabled = startDirectory.isNotBlank() && !creating,
+                enabled = startDirectory.isNotBlank() &&
+                    !creating &&
+                    (sessionType == SessionType.Shell || selectedEngine != null),
                 modifier = Modifier.testTag(SESSION_TYPE_PICKER_CREATE_TAG),
             ) {
                 if (creating) {
@@ -455,7 +445,8 @@ private fun SkipPermissionsRow(
 /** What the picker emits when the user confirms. */
 data class SessionTypeChoice(
     val type: SessionType,
-    val agent: AgentCli?,
+    /** The host-registry row selected for an agent session. */
+    val engine: RemoteEngine?,
     val startDirectory: String,
     /**
      * Whether the agent CLI should launch with its per-action approval
@@ -466,20 +457,8 @@ data class SessionTypeChoice(
      * config-driven in `opencode.json`, not a CLI flag).
      */
     val skipPermissions: Boolean = true,
-    /**
-     * The selected Claude Code profile name (issue #627). `null` means
-     * the default profile (no `CLAUDE_CONFIG_DIR` override). Only
-     * relevant when [agent] is [AgentCli.Claude]; ignored for other
-     * agents and for shell sessions.
-     */
-    val claudeProfileName: String? = null,
-    /**
-     * The selected Codex profile name (issue #631). `null` means the
-     * default profile (no `CODEX_HOME` override). Only relevant when
-     * [agent] is [AgentCli.Codex]; ignored for other agents and shell
-     * sessions.
-     */
-    val codexProfileName: String? = null,
+    /** The selected profile name, or null for the engine default. */
+    val profileName: String? = null,
     /**
      * The user-entered custom session label (issue #1184). `null`/blank means
      * "use the directory-derived default" (#429/#642). When present it is
@@ -507,7 +486,7 @@ data class SessionTypeChoice(
      * (issue #703):
      *
      * ```
-     * pocketshell agent <kind> --dir '<dir>' [--no-skip-permissions] [--config-dir '<path>']
+     * pocketshell agent <registry-id> --dir '<dir>' [--no-skip-permissions]
      * ```
      *
      * The wrapper (`tools/pocketshell` `agent` subcommand) does everything
@@ -526,20 +505,31 @@ data class SessionTypeChoice(
      * - Skip-permissions defaults ON in the wrapper, so `--no-skip-permissions`
      *   is emitted only when the user turned it OFF (and never for OpenCode,
      *   where it is a no-op).
-     * - The selected Claude / Codex profile (issue #718) is passed by NAME as
-     *   `--profile '<name>'`; the host-side wrapper resolves the name to its
-     *   `CLAUDE_CONFIG_DIR` / `CODEX_HOME` via the same discovery the picker
-     *   was populated from. The default profile is omitted (the wrapper uses
-     *   the engine's built-in config dir).
+     * - The selected profile (issue #718) is passed by NAME as `--profile
+     *   '<name>'`; the host-side wrapper resolves it through the same
+     *   discovery the picker was populated from. The default profile is
+     *   omitted.
      */
     fun startCommand(
         claudeProfiles: List<ClaudeProfile> = emptyList(),
         codexProfiles: List<CodexProfile> = emptyList(),
-    ): String? = when (type) {
-        SessionType.Shell -> null
-        SessionType.Agent -> agent?.launchCommand(
-            startDirectory, skipPermissions, claudeProfileName, claudeProfiles,
-            codexProfileName, codexProfiles,
+    ): String? {
+        if (type == SessionType.Shell) return null
+        val selectedEngine = engine ?: return null
+        val selectedProfile = pickerProfilesForEngine(
+            engine = selectedEngine,
+            claudeProfiles = claudeProfiles,
+            codexProfiles = codexProfiles,
+        ).firstOrNull { it.name == profileName }
+            ?.takeUnless { it.default }
+            ?.name
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+        return buildRegistryAgentCommand(
+            engineId = selectedEngine.rawId,
+            directory = startDirectory,
+            noSkipPermissions = !skipPermissions && selectedEngine.launch.supportsSkipPermissions,
+            profileName = selectedProfile,
         )
     }
 
@@ -554,8 +544,12 @@ data class SessionTypeChoice(
     val sessionAgentKind: SessionAgentKind?
         get() = when (type) {
             SessionType.Shell -> null
-            SessionType.Agent -> agent?.toSessionAgentKind()
+            SessionType.Agent -> engine?.family
         }
+
+    /** Open-ended host identity used for the wrapper and durable tmux option. */
+    val engineId: String?
+        get() = engine?.rawId
 }
 
 data class MissingStartDirectoryCreation(
@@ -613,102 +607,27 @@ private fun isRootedRemoteParent(parent: String): Boolean =
 
 enum class SessionType { Shell, Agent }
 
-enum class AgentCli(val command: String) {
-    Claude("claude"),
-    Codex("codex"),
-    OpenCode("opencode"),
-    Grok("grok"),
-    ;
-
-    /**
-     * Epic #821 Workstream A: map the picked CLI to the [SessionAgentKind] the
-     * tree renders, so the chosen kind can be recorded on the new session node
-     * at create time. This is the SAME kind the `pocketshell agent <command>`
-     * wrapper records host-side as `@ps_agent_kind` ([command]), so the
-     * optimistic node and the host read-back agree.
-     */
-    fun toSessionAgentKind(): SessionAgentKind = when (this) {
-        Claude -> SessionAgentKind.Claude
-        Codex -> SessionAgentKind.Codex
-        OpenCode -> SessionAgentKind.OpenCode
-        Grok -> SessionAgentKind.Grok
+/**
+ * Assemble the short wrapper invocation for one open-ended registry id.
+ * Registry ids are validated by the host registry; directory/profile values
+ * still need shell quoting because they are user/host data.
+ */
+internal fun buildRegistryAgentCommand(
+    engineId: String,
+    directory: String,
+    noSkipPermissions: Boolean,
+    profileName: String?,
+): String {
+    val parts = StringBuilder("pocketshell agent ")
+    parts.append(engineId)
+    parts.append(" --dir ").append(shellSingleQuote(directory))
+    if (noSkipPermissions) {
+        parts.append(" --no-skip-permissions")
     }
-
-    /**
-     * Build the SHORT `pocketshell agent <kind> --dir <dir> …` line typed
-     * into the new pane (issue #703). The server-side wrapper owns the env
-     * merge, the OpenCode-only env strip, the per-agent first-run-prompt
-     * suppression, and the `execvpe`. The app's only job is to assemble the
-     * short, shell-safe argv.
-     *
-     * - [directory] → `--dir '<dir>'` (shell-quoted; the wrapper validates
-     *   and `cd`s into it).
-     * - [skipPermissions] defaults ON in the wrapper, so the app emits
-     *   `--no-skip-permissions` only when it is OFF. OpenCode never gets a
-     *   skip flag (it is a no-op there — permissions are config-driven).
-     * - A non-default Claude / Codex profile (issue #718) → `--profile
-     *   '<name>'`; the wrapper resolves the name to `CLAUDE_CONFIG_DIR` /
-     *   `CODEX_HOME` host-side. The default profile (and OpenCode, which has
-     *   no profiles) emits no `--profile`.
-     */
-    fun launchCommand(
-        directory: String,
-        skipPermissions: Boolean,
-        claudeProfileName: String? = null,
-        claudeProfiles: List<ClaudeProfile> = emptyList(),
-        codexProfileName: String? = null,
-        codexProfiles: List<CodexProfile> = emptyList(),
-    ): String {
-        // Resolve the selected profile and only pass it by NAME when it is a
-        // real, non-default profile. The default profile means "use the
-        // engine's built-in config dir", so no `--profile` is emitted.
-        val profileName: String? = when (this) {
-            Claude -> claudeProfiles.firstOrNull { it.name == claudeProfileName }
-                ?.takeUnless { it.default }?.name
-            Codex -> codexProfiles.firstOrNull { it.name == codexProfileName }
-                ?.takeUnless { it.default }?.name
-            OpenCode, Grok -> null
-        }?.trim()?.takeIf { it.isNotBlank() }
-
-        // OpenCode's skip-permissions checkbox is a no-op, so never emit the
-        // flag for it; for claude/codex the wrapper defaults ON, so we only
-        // speak up to turn it OFF.
-        val emitNoSkip = this != OpenCode && !skipPermissions
-
-        return buildAgentCommand(
-            kind = command,
-            directory = directory,
-            noSkipPermissions = emitNoSkip,
-            profileName = profileName,
-        )
+    if (profileName != null) {
+        parts.append(" --profile ").append(shellSingleQuote(profileName))
     }
-
-    companion object {
-        /**
-         * Assemble `pocketshell agent <kind> --dir '<dir>' [--no-skip-permissions]
-         * [--profile '<name>']` (issue #703 / #718). Paths and names are
-         * single-quoted so spaces or shell metacharacters cannot break out of
-         * the argument or inject a command. The whole line is single-quoted
-         * again by the gateway when it is passed to `tmux send-keys`.
-         */
-        internal fun buildAgentCommand(
-            kind: String,
-            directory: String,
-            noSkipPermissions: Boolean,
-            profileName: String?,
-        ): String {
-            val parts = StringBuilder("pocketshell agent ")
-            parts.append(kind)
-            parts.append(" --dir ").append(shellSingleQuote(directory))
-            if (noSkipPermissions) {
-                parts.append(" --no-skip-permissions")
-            }
-            if (profileName != null) {
-                parts.append(" --profile ").append(shellSingleQuote(profileName))
-            }
-            return parts.toString()
-        }
-    }
+    return parts.toString()
 }
 
 private val PICKER_SEGMENT_HEIGHT = 48.dp
@@ -721,10 +640,7 @@ const val SESSION_TYPE_PICKER_SHEET_TAG: String = "session-type-picker:sheet"
 const val SESSION_TYPE_PICKER_CONTENT_TAG: String = "session-type-picker:content"
 const val SESSION_TYPE_PICKER_SHELL_TAG: String = "session-type-picker:shell"
 const val SESSION_TYPE_PICKER_AGENT_TAG: String = "session-type-picker:agent"
-const val SESSION_TYPE_PICKER_AGENT_CLAUDE_TAG: String = "session-type-picker:agent:claude"
-const val SESSION_TYPE_PICKER_AGENT_CODEX_TAG: String = "session-type-picker:agent:codex"
-const val SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG: String = "session-type-picker:agent:opencode"
-const val SESSION_TYPE_PICKER_AGENT_GROK_TAG: String = "session-type-picker:agent:grok"
+const val SESSION_TYPE_PICKER_AGENT_ENGINE_TAG_PREFIX: String = "session-type-picker:agent:engine:"
 const val SESSION_TYPE_PICKER_SKIP_PERMISSIONS_TAG: String = "session-type-picker:skip-permissions"
 const val SESSION_TYPE_PICKER_CWD_TAG: String = "session-type-picker:cwd"
 const val SESSION_TYPE_PICKER_NAME_TAG: String = "session-type-picker:name"
@@ -732,20 +648,9 @@ const val SESSION_TYPE_PICKER_CREATE_MISSING_FOLDER_TAG: String =
     "session-type-picker:create-missing-folder"
 const val SESSION_TYPE_PICKER_CANCEL_TAG: String = "session-type-picker:cancel"
 const val SESSION_TYPE_PICKER_CREATE_TAG: String = "session-type-picker:create"
-const val SESSION_TYPE_PICKER_CLAUDE_PROFILE_TAG: String = "session-type-picker:claude-profile"
-const val SESSION_TYPE_PICKER_CODEX_PROFILE_TAG: String = "session-type-picker:codex-profile"
+const val SESSION_TYPE_PICKER_PROFILE_TAG: String = "session-type-picker:profile"
 
-// Segment labels and per-segment tags for the shared SegmentedToggle controls.
-// AGENT_CLI_* lists are ordered to match AgentCli.entries (Claude, Codex,
-// OpenCode, Grok), so the segment index maps straight onto the enum ordinal.
 private val SESSION_TYPE_LABELS = listOf("Shell", "Agent")
-private val AGENT_CLI_LABELS = listOf("claude", "codex", "opencode", "grok")
-private val AGENT_CLI_SEGMENT_TAGS = listOf(
-    SESSION_TYPE_PICKER_AGENT_CLAUDE_TAG,
-    SESSION_TYPE_PICKER_AGENT_CODEX_TAG,
-    SESSION_TYPE_PICKER_AGENT_OPENCODE_TAG,
-    SESSION_TYPE_PICKER_AGENT_GROK_TAG,
-)
 
 /**
  * A named Claude Code configuration profile shown in the picker — issue #718.

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionAuxiliaryModals.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionAuxiliaryModals.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.pocketshell.app.projects.ClaudeProfile
 import com.pocketshell.app.projects.CodexProfile
+import com.pocketshell.app.projects.RemoteEngine
 import com.pocketshell.app.projects.FolderListViewModel
 import com.pocketshell.app.projects.SessionKindPickerSheet
 import com.pocketshell.app.projects.SessionTypeChoice
@@ -28,6 +29,7 @@ internal fun TmuxSessionAuxiliaryModals(
     showNewSessionSheet: Boolean,
     currentPaneCwd: String?,
     suggestStartDirectories: (suspend (String) -> List<String>)?,
+    engines: List<RemoteEngine>,
     claudeProfiles: List<ClaudeProfile>,
     codexProfiles: List<CodexProfile>,
     deriveDefaultName: (startDirectory: String) -> String,
@@ -61,6 +63,7 @@ internal fun TmuxSessionAuxiliaryModals(
             folderLabel = FolderListViewModel.defaultLabelForPath(newSessionFolderPath),
             onDismiss = onDismissNewSessionSheet,
             suggestStartDirectories = suggestStartDirectories,
+            engines = engines,
             claudeProfiles = claudeProfiles,
             codexProfiles = codexProfiles,
             deriveDefaultName = deriveDefaultName,

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionEnginePickerState.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionEnginePickerState.kt
@@ -1,0 +1,55 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.app.projects.EnginesGateway
+import com.pocketshell.app.projects.EnginesResult
+import com.pocketshell.app.projects.RemoteEngine
+import com.pocketshell.core.storage.dao.HostDao
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** Host-registry state and explicit refresh for the in-session picker. */
+internal class TmuxSessionEnginePickerState(
+    private val enginesGateway: EnginesGateway?,
+    private val hostDao: HostDao?,
+    private val scope: CoroutineScope,
+    private val ioDispatcher: () -> CoroutineDispatcher,
+    private val activeTarget: () -> TmuxSessionViewModel.ConnectionTarget?,
+) {
+    private val _engines = MutableStateFlow<List<RemoteEngine>>(emptyList())
+    val engines: StateFlow<List<RemoteEngine>> = _engines.asStateFlow()
+    private var refreshGeneration: Long = 0L
+
+    fun refresh() {
+        val gateway = enginesGateway
+        val dao = hostDao
+        val current = activeTarget()
+        if (gateway == null || dao == null || current == null) {
+            _engines.value = emptyList()
+            return
+        }
+        val hostId = current.hostId
+        val generation = ++refreshGeneration
+        _engines.value = gateway.cachedEngines(hostId)
+        scope.launch {
+            val host = withContext(ioDispatcher()) { dao.getById(hostId) } ?: return@launch
+            val result = withContext(ioDispatcher()) {
+                gateway.listEngines(
+                    host = host,
+                    keyPath = current.keyPath,
+                    passphrase = current.passphrase,
+                )
+            }
+            if (activeTarget()?.hostId != hostId || generation != refreshGeneration) {
+                return@launch
+            }
+            if (result is EnginesResult.Engines) {
+                _engines.value = result.engines
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreen.kt
@@ -333,6 +333,7 @@ public fun TmuxSessionScreen(
     // Issue #898: the single entry point for the rich "+ New session" sheet.
     val openNewSessionSheet: () -> Unit = {
         viewModel.fetchProfilesForActiveSession()
+        viewModel.fetchEnginesForActiveSession()
         sessionPickerViewModel.load(sessionPickerRequest)
         overlay.showNewSessionSheet = true
     }
@@ -1763,6 +1764,7 @@ private fun BoxScope.TmuxSessionOverlaysRegion(
 ) {
     val currentPane = panesSel.currentPane
     val sessionPickerState by sessionPickerViewModel.state.collectAsState()
+    val newSessionEngines by viewModel.engines.collectAsState()
     val newSessionClaudeProfiles by viewModel.claudeProfiles.collectAsState()
     val newSessionCodexProfiles by viewModel.codexProfiles.collectAsState()
     val currentSessionRecordedProfile by viewModel.currentSessionRecordedProfile.collectAsState()
@@ -1801,6 +1803,7 @@ private fun BoxScope.TmuxSessionOverlaysRegion(
         showNewSessionSheet = overlay.showNewSessionSheet,
         currentPaneCwd = currentPane?.cwd,
         suggestStartDirectories = suggestStartDirectories,
+        engines = newSessionEngines,
         claudeProfiles = newSessionClaudeProfiles,
         codexProfiles = newSessionCodexProfiles,
         deriveDefaultName = { dir ->

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -38,9 +38,12 @@ import com.pocketshell.app.diagnostics.consume
 import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.projects.ClaudeProfile
 import com.pocketshell.app.projects.CodexProfile
+import com.pocketshell.app.projects.EnginesGateway
+import com.pocketshell.app.projects.EnginesResult
 import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.ManualKindWriter
 import com.pocketshell.app.projects.ProfilesResult
+import com.pocketshell.app.projects.RemoteEngine
 import com.pocketshell.app.projects.RemoteProfile
 import com.pocketshell.app.projects.SessionNamePolicy
 import com.pocketshell.uikit.model.SessionAgentKind
@@ -269,6 +272,10 @@ public class TmuxSessionViewModel @Inject constructor(
     // the singleton; when absent the picker shows no profile selector (the safe
     // default-only behaviour, identical to the host screen with no gateway).
     private val profilesGateway: com.pocketshell.app.projects.ProfilesGateway? = null,
+    // Issue #2275: the in-session picker consumes the same host engine
+    // registry as the folder/repo surfaces. Nullable keeps direct unit-test
+    // constructors working; no background refresh is introduced.
+    private val enginesGateway: EnginesGateway? = null,
     private val reposRemoteSource: ReposRemoteSource? = null,
     @ApplicationContext private val applicationContext: Context? = null,
     private val projectRootDao: ProjectRootDao? = null,
@@ -2085,6 +2092,16 @@ public class TmuxSessionViewModel @Inject constructor(
     private val _codexProfiles: MutableStateFlow<List<CodexProfile>> =
         MutableStateFlow(emptyList())
     public val codexProfiles: StateFlow<List<CodexProfile>> = _codexProfiles.asStateFlow()
+
+    /**
+     * Issue #2275: host-registry rows for the in-session new-session picker.
+     * The flow is filled by an explicit picker-open refresh and is host-scoped;
+     * there is intentionally no ticker or tree-sync coupling here.
+     */
+    private val _engines: MutableStateFlow<List<RemoteEngine>> =
+        MutableStateFlow(emptyList())
+    public val engines: StateFlow<List<RemoteEngine>> = _engines.asStateFlow()
+    private var pickerEngineRefreshGeneration: Long = 0L
 
     /**
      * Issue #894 (epic #821 "Slice C"): the durable per-session CONFIRMED-SHELL
@@ -16156,6 +16173,40 @@ public class TmuxSessionViewModel @Inject constructor(
                     _claudeProfiles.value = emptyList()
                     _codexProfiles.value = emptyList()
                 }
+            }
+        }
+    }
+
+    /**
+     * Issue #2275: refresh the host engine registry when the in-session
+     * new-session sheet is opened. Cached rows are projected immediately, then
+     * one bounded read updates them; a stale session result is discarded.
+     */
+    public fun fetchEnginesForActiveSession() {
+        val gateway = enginesGateway
+        val dao = hostDao
+        val current = activeTarget
+        if (gateway == null || dao == null || current == null) {
+            _engines.value = emptyList()
+            return
+        }
+        val hostId = current.hostId
+        val refreshGeneration = ++pickerEngineRefreshGeneration
+        _engines.value = gateway.cachedEngines(hostId)
+        bridgeScope.launch {
+            val host = withContext(Dispatchers.IO) { dao.getById(hostId) } ?: return@launch
+            val result = withContext(Dispatchers.IO) {
+                gateway.listEngines(
+                    host = host,
+                    keyPath = current.keyPath,
+                    passphrase = current.passphrase,
+                )
+            }
+            if (activeTarget?.hostId != hostId || refreshGeneration != pickerEngineRefreshGeneration) {
+                return@launch
+            }
+            if (result is EnginesResult.Engines) {
+                _engines.value = result.engines
             }
         }
     }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -39,7 +39,6 @@ import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.projects.ClaudeProfile
 import com.pocketshell.app.projects.CodexProfile
 import com.pocketshell.app.projects.EnginesGateway
-import com.pocketshell.app.projects.EnginesResult
 import com.pocketshell.app.projects.FolderListGateway
 import com.pocketshell.app.projects.ManualKindWriter
 import com.pocketshell.app.projects.ProfilesResult
@@ -2095,13 +2094,20 @@ public class TmuxSessionViewModel @Inject constructor(
 
     /**
      * Issue #2275: host-registry rows for the in-session new-session picker.
-     * The flow is filled by an explicit picker-open refresh and is host-scoped;
-     * there is intentionally no ticker or tree-sync coupling here.
+     * State and refresh sequencing live in the picker-owned helper so this
+     * connection VM does not grow with registry-specific IO details.
      */
-    private val _engines: MutableStateFlow<List<RemoteEngine>> =
-        MutableStateFlow(emptyList())
-    public val engines: StateFlow<List<RemoteEngine>> = _engines.asStateFlow()
-    private var pickerEngineRefreshGeneration: Long = 0L
+    private val enginePickerState: TmuxSessionEnginePickerState by lazy {
+        TmuxSessionEnginePickerState(
+            enginesGateway = enginesGateway,
+            hostDao = hostDao,
+            scope = bridgeScope,
+            ioDispatcher = { sessionCardsDispatcher },
+            activeTarget = { this@TmuxSessionViewModel.activeTarget },
+        )
+    }
+    public val engines: StateFlow<List<RemoteEngine>>
+        get() = enginePickerState.engines
 
     /**
      * Issue #894 (epic #821 "Slice C"): the durable per-session CONFIRMED-SHELL
@@ -16182,34 +16188,7 @@ public class TmuxSessionViewModel @Inject constructor(
      * new-session sheet is opened. Cached rows are projected immediately, then
      * one bounded read updates them; a stale session result is discarded.
      */
-    public fun fetchEnginesForActiveSession() {
-        val gateway = enginesGateway
-        val dao = hostDao
-        val current = activeTarget
-        if (gateway == null || dao == null || current == null) {
-            _engines.value = emptyList()
-            return
-        }
-        val hostId = current.hostId
-        val refreshGeneration = ++pickerEngineRefreshGeneration
-        _engines.value = gateway.cachedEngines(hostId)
-        bridgeScope.launch {
-            val host = withContext(Dispatchers.IO) { dao.getById(hostId) } ?: return@launch
-            val result = withContext(Dispatchers.IO) {
-                gateway.listEngines(
-                    host = host,
-                    keyPath = current.keyPath,
-                    passphrase = current.passphrase,
-                )
-            }
-            if (activeTarget?.hostId != hostId || refreshGeneration != pickerEngineRefreshGeneration) {
-                return@launch
-            }
-            if (result is EnginesResult.Engines) {
-                _engines.value = result.engines
-            }
-        }
-    }
+    public fun fetchEnginesForActiveSession() = enginePickerState.refresh()
 
     private fun applyProfiles(profiles: List<RemoteProfile>) {
         _claudeProfiles.value = profiles

--- a/app/src/test/java/com/pocketshell/app/projects/RegistryDrivenSessionTypePickerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/RegistryDrivenSessionTypePickerTest.kt
@@ -1,0 +1,69 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.uikit.model.SessionAgentKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for the app-side half of issue #2275.
+ *
+ * The custom row is deliberate: replacing the registry projection with a
+ * closed enum or a built-in-only branch must make this test fail. The test
+ * also exercises the actual picker choice/launch model, not a source-text
+ * assertion that merely mentions the desired names.
+ */
+class RegistryDrivenSessionTypePickerTest {
+
+    private val customCodex = RemoteEngine(
+        id = "godex-custom",
+        familyId = "codex",
+        family = SessionAgentKind.Codex,
+        label = "GoDex Custom",
+        launch = RemoteEngineLaunch(
+            skipPermissionsArgv = listOf("--custom-yolo"),
+            supportsSkipPermissions = true,
+        ),
+    )
+
+    @Test
+    fun pickerRowsUseOpenRegistryIdsAndHideDisabledOrUnavailableEngines() {
+        val rows = availableEnginesForCreate(
+            listOf(
+                RemoteEngine(
+                    id = "claude",
+                    familyId = "claude",
+                    family = SessionAgentKind.Claude,
+                    label = "Claude",
+                ),
+                customCodex,
+                customCodex.copy(id = "disabled", enabled = false),
+                customCodex.copy(id = "missing", available = false),
+                customCodex.copy(id = "not-creatable", availableForCreate = false),
+            ),
+        )
+
+        assertEquals(listOf("claude", "godex-custom"), rows.map { it.id })
+        assertFalse(rows.any { it.id == "disabled" })
+        assertFalse(rows.any { it.id == "missing" })
+        assertFalse(rows.any { it.id == "not-creatable" })
+    }
+
+    @Test
+    fun customRawIdLaunchesThroughWrapperAndKeepsClosedFamilyForTree() {
+        val choice = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = customCodex,
+            startDirectory = "/srv/project",
+        )
+
+        assertEquals("godex-custom", choice.engineId)
+        assertEquals(SessionAgentKind.Codex, choice.sessionAgentKind)
+        assertEquals(
+            "pocketshell agent godex-custom --dir '/srv/project'",
+            choice.startCommand(),
+        )
+        assertTrue("the raw registry id must reach the wrapper", choice.startCommand()!!.contains("godex-custom"))
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.app.projects
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import com.pocketshell.uikit.model.SessionAgentKind
 
 /**
  * Unit tests for the tmuxctl-style directory-derived session naming
@@ -253,7 +254,7 @@ class SessionNameDerivationTest {
     fun derivedSessionNameWrapperReturnsTheBaseAndNeverDisambiguates() {
         val choice = SessionTypeChoice(
             type = SessionType.Shell,
-            agent = null,
+            engine = null,
             startDirectory = "/tmp/issue898",
             skipPermissions = false,
         )
@@ -275,7 +276,7 @@ class SessionNameDerivationTest {
         // reintroducing a client-side "remember what I just created" set.
         val choice = SessionTypeChoice(
             type = SessionType.Shell,
-            agent = null,
+            engine = null,
             startDirectory = "/tmp/issue898",
             skipPermissions = false,
         )
@@ -388,7 +389,12 @@ class SessionNameDerivationTest {
         // must sanitise + use it instead of the directory-derived default.
         val choice = SessionTypeChoice(
             type = SessionType.Agent,
-            agent = AgentCli.Claude,
+            engine = RemoteEngine(
+                id = "claude",
+                familyId = "claude",
+                family = SessionAgentKind.Claude,
+                label = "Claude",
+            ),
             startDirectory = "~/git/pocketshell",
             customName = "git pocketshell review",
         )
@@ -403,7 +409,7 @@ class SessionNameDerivationTest {
     fun derivedSessionNameWrapperKeepsCustomLabelVerbatim() {
         val choice = SessionTypeChoice(
             type = SessionType.Shell,
-            agent = null,
+            engine = null,
             startDirectory = "~/git/pocketshell",
             customName = "review",
         )
@@ -423,7 +429,7 @@ class SessionNameDerivationTest {
     fun derivedSessionNameWrapperBlankCustomFallsBackToDerived() {
         val choice = SessionTypeChoice(
             type = SessionType.Shell,
-            agent = null,
+            engine = null,
             startDirectory = "~/git/pocketshell",
             customName = "   ",
         )

--- a/app/src/test/java/com/pocketshell/app/projects/SessionTypeChoiceCommandTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionTypeChoiceCommandTest.kt
@@ -1,34 +1,27 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.uikit.model.SessionAgentKind
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-/**
- * Unit tests for the per-agent launch-command assembly (issues #428 / #703 /
- * #718).
- *
- * Since #703 the app emits the SHORT server-side wrapper line
- * (`pocketshell agent <kind> --dir '<dir>' …`) instead of the old
- * ~1500-char inline `env -u …(71)… <agent>`. The wrapper owns the env
- * merge, the OpenCode-only env strip, the first-run-prompt suppression,
- * and the exec. Since #718 a selected, non-default profile is passed BY
- * NAME as `--profile '<name>'` (the host resolves it to
- * `CLAUDE_CONFIG_DIR` / `CODEX_HOME`) instead of the old client-resolved
- * `--config-dir '<path>'`. These tests pin the exact short command the app
- * types.
- */
+/** Command and data tests for the registry-driven new-session picker. */
 class SessionTypeChoiceCommandTest {
 
-    private fun agentChoice(agent: AgentCli, skip: Boolean, dir: String = "/srv/app") =
-        SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = agent,
-            startDirectory = dir,
-            skipPermissions = skip,
-        )
+    private fun engine(
+        id: String,
+        family: SessionAgentKind,
+        supportsSkipPermissions: Boolean = true,
+    ) = RemoteEngine(
+        id = id,
+        familyId = family.name.lowercase(),
+        family = family,
+        label = id,
+        launch = RemoteEngineLaunch(
+            supportsSkipPermissions = supportsSkipPermissions,
+        ),
+    )
 
     @Test
     fun missingStartDirectoryCreationBuildsChildUnderCurrentFolder() {
@@ -84,326 +77,95 @@ class SessionTypeChoiceCommandTest {
                 loading = true,
             ),
         )
-        assertNull(
-            missingStartDirectoryCreation(
-                baseFolderPath = "~/git",
-                typedStartDirectory = "~",
-                suggestions = emptyList(),
-                loading = false,
+    }
+
+    @Test
+    fun customRawEngineIdIsPassedUnchangedToHostWrapper() {
+        val choice = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = engine("godex-custom", SessionAgentKind.Codex),
+            startDirectory = "/home/alexey/git/my project",
+        )
+
+        assertEquals("godex-custom", choice.engineId)
+        assertEquals(SessionAgentKind.Codex, choice.sessionAgentKind)
+        assertEquals(
+            "pocketshell agent godex-custom --dir '/home/alexey/git/my project'",
+            choice.startCommand(),
+        )
+    }
+
+    @Test
+    fun skipPermissionsFlagUsesRegistryLaunchCapability() {
+        val noFlag = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = engine("claude", SessionAgentKind.Claude),
+            startDirectory = "/srv/app",
+            skipPermissions = false,
+        )
+        val unsupported = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = engine(
+                "custom-opencode",
+                SessionAgentKind.OpenCode,
+                supportsSkipPermissions = false,
             ),
+            startDirectory = "/srv/app",
+            skipPermissions = false,
         )
-        assertNull(
-            missingStartDirectoryCreation(
-                baseFolderPath = "~/git/pocketshell",
-                typedStartDirectory = "~/git/pocketshell",
-                suggestions = emptyList(),
-                loading = false,
-            ),
-        )
-    }
 
-    // --- The short wrapper form, per agent ---
-
-    @Test
-    fun claudeWithSkipPermissionsIsShortWrapperNoExtraFlag() {
-        val command = agentChoice(AgentCli.Claude, skip = true).startCommand()!!
-        // skip-permissions defaults ON in the wrapper, so nothing extra.
-        assertEquals("pocketshell agent claude --dir '/srv/app'", command)
-    }
-
-    @Test
-    fun claudeWithoutSkipPermissionsEmitsNoSkipFlag() {
-        val command = agentChoice(AgentCli.Claude, skip = false).startCommand()!!
+        assertTrue(noFlag.startCommand()!!.endsWith("--no-skip-permissions"))
         assertEquals(
-            "pocketshell agent claude --dir '/srv/app' --no-skip-permissions",
+            "pocketshell agent custom-opencode --dir '/srv/app'",
+            unsupported.startCommand(),
+        )
+    }
+
+    @Test
+    fun selectedNonDefaultProfileIsMappedByFamilyAndQuoted() {
+        val choice = SessionTypeChoice(
+            type = SessionType.Agent,
+            engine = engine("godex-custom", SessionAgentKind.Codex),
+            startDirectory = "/srv/app",
+            profileName = "team's profile",
+        )
+
+        val command = choice.startCommand(
+            claudeProfiles = listOf(ClaudeProfile("wrong-family")),
+            codexProfiles = listOf(CodexProfile("team's profile")),
+        )
+
+        assertEquals(
+            "pocketshell agent godex-custom --dir '/srv/app' --profile 'team'\\''s profile'",
             command,
         )
     }
 
     @Test
-    fun codexWithSkipPermissionsIsShortWrapperNoExtraFlag() {
-        val command = agentChoice(AgentCli.Codex, skip = true).startCommand()!!
-        assertEquals("pocketshell agent codex --dir '/srv/app'", command)
-    }
-
-    @Test
-    fun codexWithoutSkipPermissionsEmitsNoSkipFlag() {
-        val command = agentChoice(AgentCli.Codex, skip = false).startCommand()!!
-        assertEquals(
-            "pocketshell agent codex --dir '/srv/app' --no-skip-permissions",
-            command,
-        )
-    }
-
-    @Test
-    fun grokWithSkipPermissionsIsShortWrapperNoExtraFlag() {
-        val command = agentChoice(AgentCli.Grok, skip = true).startCommand()!!
-        assertEquals("pocketshell agent grok --dir '/srv/app'", command)
-    }
-
-    @Test
-    fun grokWithoutSkipPermissionsEmitsNoSkipFlag() {
-        val command = agentChoice(AgentCli.Grok, skip = false).startCommand()!!
-        assertEquals(
-            "pocketshell agent grok --dir '/srv/app' --no-skip-permissions",
-            command,
-        )
-    }
-
-    @Test
-    fun openCodeIsShortWrapperAndNeverGetsSkipFlag() {
-        // The checkbox is a no-op for OpenCode: same command either way and
-        // never `--no-skip-permissions` (the wrapper does the billing strip).
-        val withSkip = agentChoice(AgentCli.OpenCode, skip = true).startCommand()
-        val withoutSkip = agentChoice(AgentCli.OpenCode, skip = false).startCommand()
-        assertEquals(withSkip, withoutSkip)
-        assertEquals("pocketshell agent opencode --dir '/srv/app'", withSkip)
-        assertFalse(withSkip!!.contains("--no-skip-permissions"))
-    }
-
-    @Test
-    fun commandNeverContainsTheOldInlineEnvStrip() {
-        // Hard-cut (D22): the giant `env -u …` strip and the
-        // `eval "$(pocketshell env export …)"` prelude are gone.
-        for (agent in AgentCli.entries) {
-            val command = agentChoice(agent, skip = true).startCommand()!!
-            assertFalse("must not inline env -u: $command", command.contains("env -u "))
-            assertFalse("must not inline export prelude: $command", command.contains("env export"))
-            assertFalse("must not inline --dangerously: $command", command.contains("--dangerously"))
-            assertTrue("must be the wrapper: $command", command.startsWith("pocketshell agent "))
-        }
-    }
-
-    @Test
-    fun commandNeverContainsLegacyConfigDirFlag() {
-        // Hard-cut (#718): the client no longer resolves a profile to a path
-        // and never emits `--config-dir`; profiles are passed by name.
-        val profiles = listOf(ClaudeProfile(name = "work"))
-        val choice = SessionTypeChoice(
+    fun defaultOrUnknownProfileDoesNotBecomeAWrapperArgument() {
+        val default = SessionTypeChoice(
             type = SessionType.Agent,
-            agent = AgentCli.Claude,
+            engine = engine("claude", SessionAgentKind.Claude),
             startDirectory = "/srv/app",
-            claudeProfileName = "work",
+            profileName = "default",
         )
-        assertFalse(choice.startCommand(claudeProfiles = profiles)!!.contains("--config-dir"))
-    }
+        val unknown = default.copy(profileName = "not-discovered")
+        val profiles = listOf(ClaudeProfile("default", default = true))
 
-    // --- --dir handling / shell quoting ---
-
-    @Test
-    fun dirIsShellQuoted() {
-        val command = agentChoice(AgentCli.Claude, skip = true, dir = "/home/alexey/git/my project")
-            .startCommand()!!
-        assertTrue(command.contains("--dir '/home/alexey/git/my project'"))
+        assertEquals("pocketshell agent claude --dir '/srv/app'", default.startCommand(profiles))
+        assertEquals("pocketshell agent claude --dir '/srv/app'", unknown.startCommand(profiles))
     }
 
     @Test
-    fun hostileDirCannotInjectShell() {
-        val hostile = "/tmp/it's a folder; rm -rf \$HOME"
-        val command = agentChoice(AgentCli.Codex, skip = true, dir = hostile).startCommand()!!
-        // Single-quoted with the embedded single quote escaped as '\''.
-        assertTrue(
-            command.contains("--dir '/tmp/it'\\''s a folder; rm -rf \$HOME'"),
-        )
-        // With skip ON the quoted dir is the last token.
-        assertTrue(command.endsWith("'"))
-    }
-
-    // --- Claude profile → --profile <name> (issue #718) ---
-
-    @Test
-    fun claudeWithProfilePassesProfileName() {
-        val profiles = listOf(
-            ClaudeProfile(name = "Claude (Z.AI)"),
-        )
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Claude,
-            startDirectory = "/srv/app",
-            skipPermissions = true,
-            claudeProfileName = "Claude (Z.AI)",
-        )
-        val command = choice.startCommand(claudeProfiles = profiles)!!
-        assertEquals(
-            "pocketshell agent claude --dir '/srv/app' --profile 'Claude (Z.AI)'",
-            command,
-        )
-    }
-
-    @Test
-    fun claudeWithoutProfileHasNoProfileFlag() {
-        val command = agentChoice(AgentCli.Claude, skip = true).startCommand()!!
-        assertFalse(command.contains("--profile"))
-    }
-
-    @Test
-    fun claudeDefaultProfileEmitsNoProfileFlag() {
-        // The engine's default profile means "built-in config dir": no flag.
-        val profiles = listOf(ClaudeProfile(name = "Claude", default = true))
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Claude,
-            startDirectory = "/srv/app",
-            claudeProfileName = "Claude",
-        )
-        assertFalse(choice.startCommand(claudeProfiles = profiles)!!.contains("--profile"))
-    }
-
-    @Test
-    fun claudeMissingProfileFallsBackToDefault() {
-        val profiles = listOf(ClaudeProfile(name = "work"))
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Claude,
-            startDirectory = "/srv/app",
-            claudeProfileName = "personal",  // not in profiles
-        )
-        assertFalse(choice.startCommand(claudeProfiles = profiles)!!.contains("--profile"))
-    }
-
-    @Test
-    fun claudeProfileNameIsShellQuoted() {
-        val profiles = listOf(ClaudeProfile(name = "weird's name"))
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Claude,
-            startDirectory = "/srv/app",
-            claudeProfileName = "weird's name",
-        )
-        val command = choice.startCommand(claudeProfiles = profiles)!!
-        assertTrue(command.contains("--profile 'weird'\\''s name'"))
-    }
-
-    @Test
-    fun claudeProfileIgnoredForOtherAgents() {
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Codex,
-            startDirectory = "/srv/app",
-            claudeProfileName = "work",
-        )
-        assertFalse(choice.startCommand()!!.contains("--profile"))
-    }
-
-    @Test
-    fun claudeProfileIgnoredForShellSessions() {
+    fun shellChoiceHasNoEngineOrLaunchCommand() {
         val choice = SessionTypeChoice(
             type = SessionType.Shell,
-            agent = null,
+            engine = null,
             startDirectory = "/srv/app",
-            claudeProfileName = "work",
         )
+
+        assertNull(choice.engineId)
+        assertNull(choice.sessionAgentKind)
         assertNull(choice.startCommand())
-    }
-
-    // --- Codex profile → --profile <name> (issue #718) ---
-
-    @Test
-    fun codexWithProfilePassesProfileName() {
-        val profiles = listOf(
-            CodexProfile(name = "work"),
-        )
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Codex,
-            startDirectory = "/srv/app",
-            skipPermissions = true,
-            codexProfileName = "work",
-        )
-        val command = choice.startCommand(codexProfiles = profiles)!!
-        assertEquals(
-            "pocketshell agent codex --dir '/srv/app' --profile 'work'",
-            command,
-        )
-    }
-
-    @Test
-    fun codexWithoutProfileHasNoProfileFlag() {
-        assertFalse(agentChoice(AgentCli.Codex, skip = true).startCommand()!!.contains("--profile"))
-    }
-
-    @Test
-    fun codexDefaultProfileEmitsNoProfileFlag() {
-        val profiles = listOf(CodexProfile(name = "Codex", default = true))
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Codex,
-            startDirectory = "/srv/app",
-            codexProfileName = "Codex",
-        )
-        assertFalse(choice.startCommand(codexProfiles = profiles)!!.contains("--profile"))
-    }
-
-    @Test
-    fun codexMissingProfileFallsBackToDefault() {
-        val profiles = listOf(CodexProfile(name = "work"))
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Codex,
-            startDirectory = "/srv/app",
-            codexProfileName = "personal",  // not in profiles
-        )
-        assertFalse(choice.startCommand(codexProfiles = profiles)!!.contains("--profile"))
-    }
-
-    @Test
-    fun codexProfileNameIsShellQuoted() {
-        val profiles = listOf(CodexProfile(name = "weird's name"))
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Codex,
-            startDirectory = "/srv/app",
-            codexProfileName = "weird's name",
-        )
-        val command = choice.startCommand(codexProfiles = profiles)!!
-        assertTrue(command.contains("--profile 'weird'\\''s name'"))
-    }
-
-    @Test
-    fun codexProfileIgnoredForOtherAgents() {
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Claude,
-            startDirectory = "/srv/app",
-            codexProfileName = "work",
-        )
-        assertFalse(choice.startCommand()!!.contains("--profile"))
-    }
-
-    @Test
-    fun codexProfileIgnoredForShellSessions() {
-        val choice = SessionTypeChoice(
-            type = SessionType.Shell,
-            agent = null,
-            startDirectory = "/srv/app",
-            codexProfileName = "work",
-        )
-        assertNull(choice.startCommand())
-    }
-
-    // --- Shell sessions + defaults ---
-
-    @Test
-    fun shellSessionHasNoStartCommand() {
-        val shell = SessionTypeChoice(
-            type = SessionType.Shell,
-            agent = null,
-            startDirectory = "/srv/app",
-            skipPermissions = true,
-        )
-        assertNull(shell.startCommand())
-    }
-
-    @Test
-    fun skipPermissionsDefaultsToTrue() {
-        // Default-ON: the maintainer's preference sticks without ticking the
-        // box, so the wrapper line carries no `--no-skip-permissions`.
-        val choice = SessionTypeChoice(
-            type = SessionType.Agent,
-            agent = AgentCli.Claude,
-            startDirectory = "/srv/app",
-        )
-        assertTrue(choice.skipPermissions)
-        assertEquals("pocketshell agent claude --dir '/srv/app'", choice.startCommand())
     }
 }


### PR DESCRIPTION
Closes #2275

## Summary
- Drive the new-session picker from host engine-registry rows and preserve raw engine IDs for launch.
- Wire the registry through FolderList, Repo Browser, and in-session new-session surfaces.
- Add registry-driven unit and connected coverage while preserving profile and permission behavior.

## Verification
- Full JVM gate: Debug 4,988/4,988 and Release 4,970/4,970; zero failures/errors.
- Android test compilation passed.
- Connected: profile 5/5, skip-permissions 7/7, repo picker 2/2, rich sheet 1/1.
- Independent reviewer: APPROVED.