### PR TITLE
test: stabilize stale render heal proof (#2321)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
@@ -29,6 +29,11 @@ import com.pocketshell.app.tmux.TMUX_SWITCHING_LOADING_TAG
 import com.pocketshell.app.tmux.HealAttemptReason
 import com.pocketshell.app.tmux.HealAttemptResult
 import com.pocketshell.app.tmux.HealOutcome
+import com.pocketshell.app.tmux.StaleRenderHealOwnerRecoveryForTest
+import com.pocketshell.app.tmux.StaleRenderHealProofForTest
+import com.pocketshell.app.tmux.StaleRenderHealProofOrderForTest
+import com.pocketshell.app.tmux.StaleRenderHealProofStepForTest
+import com.pocketshell.app.tmux.StaleRenderOwnerChangedForTest
 import com.pocketshell.app.tmux.TmuxSessionViewModel
 import com.pocketshell.app.tmux.ActivePaneRenderOwnerSnapshotForTest
 import com.pocketshell.core.ssh.KnownHostsPolicy
@@ -37,6 +42,7 @@ import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.termux.view.TerminalView
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -180,23 +186,44 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         }
         val settledOwner = waitForSettledActiveRenderOwner(namePrefix)
         capturePaintedRows("$namePrefix-01-baseline")
+        val proofOrder = StaleRenderHealProofOrderForTest()
+        proofOrder.record(StaleRenderHealProofStepForTest.INITIAL_SETTLED_OWNER)
 
         // ===== Inject the stale render on the LIVE, retained emulator. =====
+        val staleFrame = when (kind) {
+            StaleKind.FULLY_BLANK -> "[2J[H"
+            StaleKind.SCATTERED_FRAGMENT,
+            StaleKind.STALE_AFTER_BURST -> scatteredFragmentFrame()
+        }
         val injectedOwner = when (kind) {
-            StaleKind.SCATTERED_FRAGMENT -> feedScatteredFragmentFrameToActiveModel(settledOwner, namePrefix)
-            StaleKind.FULLY_BLANK -> feedFrameToActivePaneModel("[2J[H", settledOwner, namePrefix)
+            StaleKind.SCATTERED_FRAGMENT ->
+                feedFrameToActivePaneModel(staleFrame, settledOwner, namePrefix)
+            StaleKind.FULLY_BLANK -> feedFrameToActivePaneModel(staleFrame, settledOwner, namePrefix)
             StaleKind.STALE_AFTER_BURST -> {
                 // A heavy alt-screen repaint burst that outruns the drain, then the
                 // scattered residue — the burst variant of the #966 stale grid.
                 val burstOwner = feedHeavyBurstToActiveModel(settledOwner, namePrefix)
-                feedScatteredFragmentFrameToActiveModel(burstOwner, namePrefix)
+                feedFrameToActivePaneModel(staleFrame, burstOwner, namePrefix)
             }
         }
+        proofOrder.record(StaleRenderHealProofStepForTest.STALE_FRAME_INJECTED)
+        // The feed intentionally advances the render-model epoch; settle the real production
+        // owner before any stale-frame oracle, rather than treating the injection return value as
+        // a settled owner.
+        val postInjectionSettledOwner = waitForSettledActiveRenderOwner("$namePrefix-post-injection")
+        assertTrue(
+            "$namePrefix post-injection owner must be newer than the injected model; " +
+                "injected=$injectedOwner settled=$postInjectionSettledOwner",
+            postInjectionSettledOwner.modelMutationEpoch >= injectedOwner.modelMutationEpoch,
+        )
+        proofOrder.record(StaleRenderHealProofStepForTest.POST_INJECTION_SETTLED_OWNER)
+
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         capturePaintedRows("$namePrefix-02-stale")
         // The RED state on the real device: the injected stale render shows almost
         // none of tmux's banner (the user-perceived black/fragment pane).
 
+        // ----- DISCRIMINATOR half 1: the authoritative frame and transport are LIVE. -----
         val remoteCapture = captureAuthoritativeRemotePane(key)
         val remoteCaptureChars = remoteCapture.count { !it.isWhitespace() }
         assertTrue(
@@ -209,41 +236,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             "$namePrefix authoritative remote tmux frame must still carry the banner marker",
             remoteCapture.contains(BANNER_MARKER),
         )
-        val localStale = activePaneLocalHealState(injectedOwner, namePrefix)
-        assertTrue(
-            "$namePrefix pre-call local render must still be suspect; if the automatic watchdog " +
-                "was left armed it can heal first and this assertion must fail. state=$localStale",
-            localStale.renderLooksSuspect,
-        )
-        when (kind) {
-            StaleKind.FULLY_BLANK -> assertEquals(
-                "$namePrefix intended local state must be fully blank before the manual call",
-                0,
-                localStale.renderedNonBlankChars,
-            )
-            StaleKind.SCATTERED_FRAGMENT,
-            StaleKind.STALE_AFTER_BURST -> assertTrue(
-                "$namePrefix intended local state must retain bounded fragments before the " +
-                    "manual call; state=$localStale",
-                localStale.renderedNonBlankChars in 1..MAX_EXPECTED_FRAGMENT_CHARS,
-            )
-        }
 
-        // ----- RED precondition: the v0.4.17 heal oracle SKIPS this pane. -----
-        // For the scattered-fragment / burst case the combined blank||partial-blank
-        // oracle reads FALSE, so the v0.4.17 heal would never fire — proving the gap.
-        // (The fully-blank case is the boundary the v0.4.17 heal already owned, so it
-        // reads TRUE there; the divergence path subsumes it.)
-        val v0417OracleHit = localStale.blankOrPartiallyBlank
-        if (kind != StaleKind.FULLY_BLANK) {
-            assertFalse(
-                "$namePrefix RED: the v0.4.17 heal oracle (blank||partial-blank) must SKIP " +
-                    "the scattered-fragment pane — this is the #966 gap the divergence heal closes",
-                v0417OracleHit,
-            )
-        }
-
-        // ----- DISCRIMINATOR half 1: the transport is GUARANTEED LIVE. -----
         assertTrue(
             "$namePrefix the transport must stay Connected with a stale render (the #967 " +
                 "render-death-on-live-transport class), observed=${currentConnectionStatus()}",
@@ -254,18 +247,106 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             clientDisconnected(),
         )
         assertNoVisibleReconnect("$namePrefix stale-render (no reconnect surface)")
+        proofOrder.record(StaleRenderHealProofStepForTest.REMOTE_LIVE_ASSERTIONS)
 
-        // ----- GREEN: drive ONE stale-render heal pass (the watchdog tick) and -----
-        // require the FULL banner to re-render from tmux's authoritative grid.
-        // The divergence oracle fires for ALL three stale kinds (fully-black,
-        // scattered fragments, post-burst clear) because tmux's grid holds the full
-        // banner while the VISIBLE viewport shows almost none of it.
-        val healResult = driveStaleRenderHeal(injectedOwner)
+        // The remote capture is a real SSH round-trip and can overlap a production resize/seed.
+        // The barrier rechecks the owner immediately before the local oracle and retries by
+        // re-injecting this same stale frame if either that check or the production-shaped heal
+        // preflight observes a mutation. This is the exact settlement-to-manual-heal race from
+        // #2321: the proof never silently changes owners and never abandons its stale frame.
+        var reinjectionCount = 0
+        val healPass = try {
+            StaleRenderHealOwnerRecoveryForTest().run(
+                initialOwner = postInjectionSettledOwner,
+                settleOwner = {
+                    waitForSettledActiveRenderOwner("$namePrefix-pre-heal").also {
+                        proofOrder.record(StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER)
+                    }
+                },
+                liveOwner = ::snapshotActivePaneRenderOwner,
+                retainStaleFrame = { owner ->
+                    reinjectionCount++
+                    proofOrder.record(
+                        StaleRenderHealProofStepForTest.STALE_FRAME_RETAINED_AFTER_OWNER_MUTATION,
+                    )
+                    feedFrameToActivePaneModel(
+                        staleFrame,
+                        owner,
+                        "$namePrefix-reinjected-$reinjectionCount",
+                    )
+                },
+                attemptHeal = { expectedOwner ->
+                    val localStale = activePaneLocalHealState(expectedOwner, namePrefix)
+                    assertTrue(
+                        "$namePrefix pre-call local render must still be suspect; if the automatic " +
+                            "watchdog was left armed it can heal first and this assertion must fail. " +
+                            "state=$localStale",
+                        localStale.renderLooksSuspect,
+                    )
+                    when (kind) {
+                        StaleKind.FULLY_BLANK -> assertEquals(
+                            "$namePrefix intended local state must be fully blank before the manual call",
+                            0,
+                            localStale.renderedNonBlankChars,
+                        )
+                        StaleKind.SCATTERED_FRAGMENT,
+                        StaleKind.STALE_AFTER_BURST -> assertTrue(
+                            "$namePrefix intended local state must retain bounded fragments before the " +
+                                "manual call; state=$localStale",
+                            localStale.renderedNonBlankChars in 1..MAX_EXPECTED_FRAGMENT_CHARS,
+                        )
+                    }
+
+                    // ----- RED precondition: the v0.4.17 heal oracle SKIPS this pane. -----
+                    // For the scattered-fragment / burst case the combined blank||partial-blank
+                    // oracle reads FALSE, so the v0.4.17 heal would never fire — proving the gap.
+                    val v0417OracleHit = localStale.blankOrPartiallyBlank
+                    if (kind != StaleKind.FULLY_BLANK) {
+                        assertFalse(
+                            "$namePrefix RED: the v0.4.17 heal oracle (blank||partial-blank) must " +
+                                "SKIP the scattered-fragment pane — this is the #966 gap the " +
+                                "divergence heal closes",
+                            v0417OracleHit,
+                        )
+                    }
+                    proofOrder.record(StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE)
+
+                    // ----- GREEN: drive ONE stale-render heal pass (the watchdog tick) and -----
+                    // require the FULL banner to re-render from tmux's authoritative grid.
+                    val healResult = driveStaleRenderHeal(
+                        expectedOwner = expectedOwner,
+                        namePrefix = namePrefix,
+                    )
+                    proofOrder.record(StaleRenderHealProofStepForTest.MANUAL_HEAL)
+                    ManualHealPass(
+                        owner = expectedOwner,
+                        localStale = localStale,
+                        healResult = healResult,
+                    )
+                },
+            )
+        } catch (ownerChanged: StaleRenderOwnerChangedForTest) {
+            writeText(
+                "$namePrefix-owner-recovery-failure.txt",
+                "owner recovery exhausted: ${ownerChanged.message}\n" +
+                    "reinjection_count=$reinjectionCount\n",
+            )
+            assertTrue(
+                "$namePrefix stale-render owner must remain stable through manual heal; " +
+                    "recovery exhausted after $reinjectionCount reinjections: ${ownerChanged.message}",
+                false,
+            )
+            throw ownerChanged
+        }
+        val settledOwnerBeforeHeal = healPass.owner
+        val localStale = healPass.localStale
+        val healResult = healPass.healResult
         writeHealAttemptArtifact(
             namePrefix = namePrefix,
             kind = kind,
             localStale = localStale,
             remoteCaptureChars = remoteCaptureChars,
+            settledOwner = settledOwnerBeforeHeal,
             healResult = healResult,
         )
         assertEquals(
@@ -300,6 +381,27 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
                 "painted rows); found $restoredPaintedRows",
             restoredPaintedRows >= MIN_PAINTED_ROWS,
         )
+        assertTrue(
+            "$namePrefix load-bearing stale-render oracle must require an actual healed attempt " +
+                "and the restored viewport",
+            StaleRenderHealProofForTest(
+                localRenderLooksSuspect = localStale.renderLooksSuspect,
+                remoteCaptureNonBlankChars = remoteCaptureChars,
+                minimumRemoteCaptureChars = MIN_AUTHORITATIVE_CAPTURE_CHARS,
+                remoteCaptureHasBanner = remoteCapture.contains(BANNER_MARKER),
+                transportConnected = currentConnectionStatus() is
+                    TmuxSessionViewModel.ConnectionStatus.Connected,
+                clientDisconnected = clientDisconnected(),
+                reconnectSurfaceVisible = visibleReconnectSurface(),
+                healOutcome = healResult.outcome,
+                healReason = healResult.reason,
+                restoredFrameHasBanner = visibleAfter.contains(BANNER_MARKER),
+                restoredFrameRows = bannerRowCount(visibleAfter),
+                minimumRestoredFrameRows = MIN_RESTORED_BANNER_ROWS,
+                restoredPaintedRows = restoredPaintedRows,
+                minimumRestoredPaintedRows = MIN_PAINTED_ROWS,
+            ).restored,
+        )
 
         // ----- DISCRIMINATOR half 2: still Connected, no reconnect across the heal. -----
         watchNoVisibleReconnect("$namePrefix heal settle", POST_RESTORE_SETTLE_MS)
@@ -312,6 +414,10 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             "$namePrefix session must stay Connected after the heal (render fix, no reconnect), " +
                 "observed=${currentConnectionStatus()}",
             currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertTrue(
+            "$namePrefix stale-render proof stages must execute in the settled-owner order",
+            proofOrder.isComplete(),
         )
 
         writeSummary(
@@ -332,16 +438,66 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
      */
     private fun driveStaleRenderHeal(
         expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
+        namePrefix: String,
     ): HealAttemptResult {
         var result: HealAttemptResult? = null
+        var actualOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var viewTerminalSessionIdentity: Int? = null
+        var viewEmulatorIdentity: Int? = null
+        var failure: String? = null
+        var ownerChangedFailure: String? = null
         val latch = java.util.concurrent.CountDownLatch(1)
-        launchedActivity?.onActivity { activity ->
-            val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-            activity.lifecycleScope.launch {
-                try {
-                    result = vm.healActivePaneIfStaleRenderResultForTest(expectedOwner)
-                } finally {
+        val activityScenario = launchedActivity
+        if (activityScenario == null) {
+            failure = "activity was unavailable for the manual-heal owner preflight"
+            latch.countDown()
+        } else {
+            activityScenario.onActivity { activity ->
+                val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                actualOwner = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }
+                    .getOrElse {
+                        failure = "could not snapshot manual-heal owner: $it"
+                        latch.countDown()
+                        return@onActivity
+                    }
+                val viewSession = activity.window.decorView.findTerminalView()?.currentSession
+                viewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
+                viewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
+                val ownerStillSettled = actualOwner?.attachResizeSeedSettled == true &&
+                    actualOwner?.isIdenticalSettledObservationAsForTest(expectedOwner) == true
+                val viewStillBound = viewTerminalSessionIdentity == actualOwner?.terminalSessionIdentity &&
+                    viewEmulatorIdentity == actualOwner?.emulatorIdentity
+                if (!ownerStillSettled || !viewStillBound) {
+                    failure = "manual-heal owner changed after the settled observation; " +
+                        "a resize/model mutation or owner swap occurred before heal " +
+                        "expected=$expectedOwner actual=$actualOwner " +
+                        "viewSession=$viewTerminalSessionIdentity viewEmulator=$viewEmulatorIdentity"
+                    ownerChangedFailure = failure
                     latch.countDown()
+                    return@onActivity
+                }
+                // onActivity is the main-thread barrier. UNDISPATCHED enters the VM seam before
+                // another main-thread resize callback can run between the final owner sample and
+                // the seam's own precondition. If a background mutation still wins that race, the
+                // catch reacquires the actual owner for the artifact before failing.
+                activity.lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                    try {
+                        result = vm.healActivePaneIfStaleRenderResultForTest(expectedOwner)
+                    } catch (t: Throwable) {
+                        failure = "manual heal rejected the freshly verified owner: $t"
+                        if (t is IllegalStateException &&
+                            t.message.orEmpty().contains("before manual heal")
+                        ) {
+                            ownerChangedFailure = failure
+                        }
+                        actualOwner = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }
+                            .getOrNull() ?: actualOwner
+                        val currentViewSession = activity.window.decorView.findTerminalView()?.currentSession
+                        viewTerminalSessionIdentity = currentViewSession?.let(System::identityHashCode)
+                        viewEmulatorIdentity = currentViewSession?.emulator?.let(System::identityHashCode)
+                    } finally {
+                        latch.countDown()
+                    }
                 }
             }
         }
@@ -349,7 +505,33 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             RESTORE_TIMEOUT_MS,
             java.util.concurrent.TimeUnit.MILLISECONDS,
         )
-        assertTrue("manual stale-render heal latch must complete within the bound", completed)
+        if (!completed) {
+            failure = failure ?: "manual stale-render heal latch timed out before a typed result"
+        }
+        if (!completed || failure != null || result == null) {
+            writeRenderOwnerArtifact(
+                namePrefix = namePrefix,
+                label = "manual-heal-owner-failure",
+                expected = expectedOwner,
+                actual = actualOwner,
+                viewTerminalSessionIdentity = viewTerminalSessionIdentity,
+                viewEmulatorIdentity = viewEmulatorIdentity,
+                settledObservationCount = SETTLED_OWNER_OBSERVATION_WINDOW,
+                requiredSettledObservationCount = SETTLED_OWNER_OBSERVATION_WINDOW,
+                failure = failure ?: "manual stale-render heal completed without a typed result",
+            )
+            ownerChangedFailure?.let { throw StaleRenderOwnerChangedForTest(it) }
+            assertTrue(
+                "manual stale-render heal latch must complete within the bound; failure=$failure",
+                completed,
+            )
+            assertTrue(
+                "manual stale-render heal must use a freshly verified settled owner; " +
+                    "failure=$failure expected=$expectedOwner actual=$actualOwner " +
+                    "viewSession=$viewTerminalSessionIdentity viewEmulator=$viewEmulatorIdentity",
+                failure == null && result != null,
+            )
+        }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         return checkNotNull(result) { "manual stale-render heal completed without a typed result" }
     }
@@ -387,6 +569,12 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         val renderLooksSuspect: Boolean,
     )
 
+    private data class ManualHealPass(
+        val owner: ActivePaneRenderOwnerSnapshotForTest,
+        val localStale: LocalHealState,
+        val healResult: HealAttemptResult,
+    )
+
     private fun activePaneLocalHealState(
         expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
         namePrefix: String,
@@ -396,6 +584,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         var viewTerminalSessionIdentity: Int? = null
         var viewEmulatorIdentity: Int? = null
         var failure: String? = null
+        var ownerChangedFailure: String? = null
         launchedActivity?.onActivity { activity ->
             val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
             val snapshot = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }
@@ -407,17 +596,13 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             val viewSession = activity.window.decorView.findTerminalView()?.currentSession
             viewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
             viewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
-            if (!snapshot.coherent ||
-                !snapshot.sameOwnerAs(expectedOwner) ||
-                snapshot.modelMutationEpoch != expectedOwner.modelMutationEpoch ||
-                snapshot.controlSizeGeneration != expectedOwner.controlSizeGeneration ||
-                snapshot.sizeOperationsInFlight != 0 ||
-                snapshot.automaticHealOperationsInFlight != 0 ||
-                snapshot.automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch ||
+            if (!snapshot.attachResizeSeedSettled ||
+                !snapshot.isIdenticalSettledObservationAsForTest(expectedOwner) ||
                 viewTerminalSessionIdentity != snapshot.terminalSessionIdentity ||
                 viewEmulatorIdentity != snapshot.emulatorIdentity
             ) {
-                failure = "render owner/model changed before pre-call oracle"
+                ownerChangedFailure = "render owner/model changed before pre-call oracle"
+                failure = ownerChangedFailure
                 return@onActivity
             }
             state = LocalHealState(
@@ -436,6 +621,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             viewEmulatorIdentity = viewEmulatorIdentity,
             failure = failure,
         )
+        ownerChangedFailure?.let { throw StaleRenderOwnerChangedForTest(it) }
         assertTrue(
             "$failure expected=$expectedOwner actual=$actualOwner " +
                 "viewSession=$viewTerminalSessionIdentity viewEmulator=$viewEmulatorIdentity",
@@ -453,6 +639,15 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         return disconnected
     }
 
+    private fun snapshotActivePaneRenderOwner(): ActivePaneRenderOwnerSnapshotForTest {
+        var owner: ActivePaneRenderOwnerSnapshotForTest? = null
+        launchedActivity?.onActivity { activity ->
+            owner = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .activePaneRenderOwnerSnapshotForTest()
+        }
+        return checkNotNull(owner) { "active pane render owner was unavailable" }
+    }
+
     // ---------------------------------------------------------------- Emulator feed
 
     /**
@@ -461,12 +656,9 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
      * a status line) — NOT fully blank, NOT cleanly partial-blank, so the v0.4.17
      * oracle skips it. Local to the emulator; the remote tmux grid keeps the banner.
      */
-    private fun feedScatteredFragmentFrameToActiveModel(
-        expectedOwner: ActivePaneRenderOwnerSnapshotForTest,
-        namePrefix: String,
-    ): ActivePaneRenderOwnerSnapshotForTest {
+    private fun scatteredFragmentFrame(): String {
         val esc = ""
-        val frame = buildString {
+        return buildString {
             append("$esc[2J$esc[H")          // erase + home
             append("3\r\n")                  // a lone glyph (the screenshot's "3")
             append("\r\n\r\n\r\n")
@@ -477,7 +669,6 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             append("$esc[20;5H")
             append("y z\r\n")
         }
-        return feedFrameToActivePaneModel(frame, expectedOwner, namePrefix)
     }
 
     /** A heavy alt-screen repaint burst — many colored rows faster than the drain. */
@@ -505,18 +696,61 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         var lastOwner: ActivePaneRenderOwnerSnapshotForTest? = null
         var lastViewTerminalSessionIdentity: Int? = null
         var lastViewEmulatorIdentity: Int? = null
+        var previousSettledOwner: ActivePaneRenderOwnerSnapshotForTest? = null
+        var settledObservationCount = 0
+        var lastFailure: String? = null
         val settled = runCatching {
             compose.waitUntil(timeoutMillis = RESTORE_TIMEOUT_MS) {
                 var ready = false
                 launchedActivity?.onActivity { activity ->
                     val vm = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-                    lastOwner = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }.getOrNull()
+                    val owner = runCatching { vm.activePaneRenderOwnerSnapshotForTest() }.getOrNull()
+                    lastOwner = owner
                     val viewSession = activity.window.decorView.findTerminalView()?.currentSession
                     lastViewTerminalSessionIdentity = viewSession?.let(System::identityHashCode)
                     lastViewEmulatorIdentity = viewSession?.emulator?.let(System::identityHashCode)
-                    ready = lastOwner?.attachResizeSeedSettled == true &&
-                        lastViewTerminalSessionIdentity == lastOwner?.terminalSessionIdentity &&
-                        lastViewEmulatorIdentity == lastOwner?.emulatorIdentity
+                    val viewBound = owner != null &&
+                        lastViewTerminalSessionIdentity == owner.terminalSessionIdentity &&
+                        lastViewEmulatorIdentity == owner.emulatorIdentity
+                    val sampleSettled = owner != null &&
+                        owner.attachResizeSeedSettled &&
+                        !owner.modelDrainBacklogged &&
+                        !owner.seedOperationInFlight &&
+                        owner.sizeOperationsInFlight == 0 &&
+                        owner.automaticHealOperationsInFlight == 0 &&
+                        owner.effectiveColumns > 0 &&
+                        owner.effectiveRows > 0 &&
+                        owner.appliedColumns == owner.effectiveColumns &&
+                        owner.appliedRows == owner.effectiveRows
+                    if (!sampleSettled || !viewBound) {
+                        previousSettledOwner = null
+                        settledObservationCount = 0
+                        lastFailure = if (owner == null) {
+                            "could not snapshot a settled active render owner"
+                        } else if (!sampleSettled) {
+                            "active render owner still has attach/resize/seed/heal work or " +
+                                "unapplied dimensions"
+                        } else {
+                            "TerminalView session/emulator is not bound to the settled owner"
+                        }
+                        return@onActivity
+                    }
+                    val settledOwner = owner ?: return@onActivity
+                    settledObservationCount = if (
+                        previousSettledOwner?.isIdenticalSettledObservationAsForTest(settledOwner) == true
+                    ) {
+                        settledObservationCount + 1
+                    } else {
+                        1
+                    }
+                    previousSettledOwner = settledOwner
+                    ready = settledObservationCount >= SETTLED_OWNER_OBSERVATION_WINDOW
+                    lastFailure = if (ready) {
+                        null
+                    } else {
+                        "only $settledObservationCount/$SETTLED_OWNER_OBSERVATION_WINDOW " +
+                            "identical settled observations observed"
+                    }
                 }
                 ready
             }
@@ -529,10 +763,14 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             actual = lastOwner,
             viewTerminalSessionIdentity = lastViewTerminalSessionIdentity,
             viewEmulatorIdentity = lastViewEmulatorIdentity,
-            failure = if (settled) null else "attach/resize/reseed settlement timed out",
+            settledObservationCount = settledObservationCount,
+            requiredSettledObservationCount = SETTLED_OWNER_OBSERVATION_WINDOW,
+            failure = if (settled) null else lastFailure ?: "attach/resize/reseed settlement timed out",
         )
         assertTrue(
-            "$namePrefix attach/resize/reseed must settle on the exact visible VM model; " +
+            "$namePrefix attach/resize/reseed must provide " +
+                "$SETTLED_OWNER_OBSERVATION_WINDOW identical settled observations on the exact " +
+                "visible VM model; observed=$settledObservationCount " +
                 "owner=$lastOwner viewSession=$lastViewTerminalSessionIdentity " +
                 "viewEmulator=$lastViewEmulatorIdentity",
             settled,
@@ -616,6 +854,8 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         viewTerminalSessionIdentity: Int?,
         viewTerminalSessionIdentityAfter: Int? = null,
         viewEmulatorIdentity: Int?,
+        settledObservationCount: Int? = null,
+        requiredSettledObservationCount: Int? = null,
         failure: String?,
     ) {
         writeText(
@@ -626,6 +866,8 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
                 appendLine("view_terminal_session_identity=$viewTerminalSessionIdentity")
                 appendLine("view_terminal_session_identity_after=$viewTerminalSessionIdentityAfter")
                 appendLine("view_emulator_identity=$viewEmulatorIdentity")
+                appendLine("settled_observation_count=" + settledObservationCount)
+                appendLine("required_settled_observation_count=" + requiredSettledObservationCount)
                 appendLine("expected_automatic_heal_activity_epoch=${expected?.automaticHealActivityEpoch}")
                 appendLine("actual_automatic_heal_activity_epoch=${actual?.automaticHealActivityEpoch}")
                 appendLine("expected=$expected")
@@ -773,6 +1015,10 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
     }
 
     private fun assertNoVisibleReconnect(label: String) {
+        assertFalse(
+            "expected no visible reconnect surface for $label",
+            visibleReconnectSurface(),
+        )
         assertEquals(
             "expected no Connecting overlay for $label", 0,
             compose.onAllNodesWithTag(TMUX_CONNECTING_PROGRESS_TAG, useUnmergedTree = true)
@@ -801,6 +1047,21 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
             )
         }
     }
+
+    private fun visibleReconnectSurface(): Boolean =
+        listOf(
+            TMUX_CONNECTING_PROGRESS_TAG,
+            TMUX_SESSION_ERROR_TAG,
+            TMUX_SESSION_RECONNECT_TAG,
+            TMUX_SWITCHING_LOADING_TAG,
+        ).any { tag ->
+            compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        } || listOf("Connecting", "Reconnecting", "Disconnected", "Tap Reconnect", "Attaching")
+            .any { text ->
+                compose.onAllNodesWithText(text, substring = true, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }
 
     private fun watchNoVisibleReconnect(label: String, durationMs: Long) {
         val deadline = SystemClock.elapsedRealtime() + durationMs
@@ -939,6 +1200,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         kind: StaleKind,
         localStale: LocalHealState,
         remoteCaptureChars: Int,
+        settledOwner: ActivePaneRenderOwnerSnapshotForTest,
         healResult: HealAttemptResult,
     ): File =
         writeText(
@@ -949,6 +1211,9 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
                 appendLine("remote_capture_non_blank_chars=$remoteCaptureChars")
                 appendLine("local_rendered_non_blank_chars=${localStale.renderedNonBlankChars}")
                 appendLine("local_render_looks_suspect=${localStale.renderLooksSuspect}")
+                appendLine("manual_heal_owner=$settledOwner")
+                appendLine("manual_heal_owner_model_mutation_epoch=${settledOwner.modelMutationEpoch}")
+                appendLine("manual_heal_owner_control_size_generation=${settledOwner.controlSizeGeneration}")
                 appendLine("heal_outcome=${healResult.outcome}")
                 appendLine("heal_reason=${healResult.reason}")
                 appendLine("heal_rendered_non_blank_chars=${healResult.stats.renderedNonBlankChars}")
@@ -1026,6 +1291,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         const val BANNER_MARKER: String = "ISSUE966-BANNER"
 
         const val POST_RESTORE_SETTLE_MS: Long = 2_000L
+        const val SETTLED_OWNER_OBSERVATION_WINDOW: Int = 2
         const val MIN_RESTORED_BANNER_ROWS: Int = 20
         const val MIN_PAINTED_ROWS: Int = 30
         const val MIN_AUTHORITATIVE_CAPTURE_CHARS: Int = 40

--- a/app/src/main/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTest.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTest.kt
@@ -1,5 +1,39 @@
 package com.pocketshell.app.tmux
 
+/** Named settlement/owner predicates used by the #2321 mutation matrix. */
+internal enum class SettledObservationGuardForTest {
+    COHERENT,
+    EMULATOR_IDENTITY_PRESENT,
+    MODEL_DRAIN_QUIET,
+    SEED_IDLE,
+    SIZE_IDLE,
+    AUTOMATIC_HEAL_IDLE,
+    EFFECTIVE_COLUMNS_POSITIVE,
+    EFFECTIVE_ROWS_POSITIVE,
+    APPLIED_COLUMNS_POSITIVE,
+    APPLIED_ROWS_POSITIVE,
+    APPLIED_COLUMNS_MATCH_EFFECTIVE,
+    APPLIED_ROWS_MATCH_EFFECTIVE,
+    LAST_SEED_PRESENT,
+    PANE_ID,
+    WINDOW_ID,
+    SESSION_ID,
+    TARGET_SESSION_NAME,
+    CONNECT_GENERATION,
+    CLIENT_IDENTITY,
+    STATE_IDENTITY,
+    TERMINAL_SESSION_IDENTITY,
+    EMULATOR_IDENTITY,
+    MODEL_MUTATION_EPOCH,
+    CONTROL_SIZE_GENERATION,
+    EFFECTIVE_COLUMNS,
+    EFFECTIVE_ROWS,
+    APPLIED_COLUMNS,
+    APPLIED_ROWS,
+    AUTOMATIC_HEAL_ACTIVITY_EPOCH,
+    LAST_SEED_AT,
+}
+
 /**
  * Issue #966 connected-proof owner snapshot. Identity binds the visible TerminalView session to
  * the exact active VM pane/model; settlement fields expose positive completion invariants for
@@ -33,17 +67,7 @@ internal data class ActivePaneRenderOwnerSnapshotForTest(
     val coherent: Boolean,
 ) {
     val attachResizeSeedSettled: Boolean
-        get() = coherent &&
-            emulatorIdentity != null &&
-            !modelDrainBacklogged &&
-            !seedOperationInFlight &&
-            sizeOperationsInFlight == 0 &&
-            automaticHealOperationsInFlight == 0 &&
-            effectiveColumns > 0 &&
-            effectiveRows > 0 &&
-            appliedColumns == effectiveColumns &&
-            appliedRows == effectiveRows &&
-            lastSeedAtMs != null
+        get() = settlementGuardFailuresForTest().isEmpty()
 
     fun sameOwnerAs(other: ActivePaneRenderOwnerSnapshotForTest): Boolean =
         paneId == other.paneId &&
@@ -55,6 +79,138 @@ internal data class ActivePaneRenderOwnerSnapshotForTest(
             stateIdentity == other.stateIdentity &&
             terminalSessionIdentity == other.terminalSessionIdentity &&
             emulatorIdentity == other.emulatorIdentity
+
+    /**
+     * Issue #2321: a journey settlement is an observation window, not one positive
+     * [attachResizeSeedSettled] sample. Both observations must describe the same owner,
+     * control/effective/applied dimensions, model/control generations, and mutation epoch, with
+     * no resize, seed, or automatic-heal work in flight. This remains a pure test-only
+     * predicate so a resize/model mutation between settlement and heal is a selective red case.
+     */
+    fun isIdenticalSettledObservationAsForTest(
+        other: ActivePaneRenderOwnerSnapshotForTest,
+    ): Boolean = identicalSettledObservationFailuresForTest(other).isEmpty()
+
+    /**
+     * Individual settlement predicates are exposed to the JVM proof so a one-field mutation can
+     * name exactly which guard rejected it. This prevents a dimension mutation from being
+     * laundered by a broad conjunction or by a second, accidental failure in the matrix.
+     */
+    internal fun settlementGuardFailuresForTest(): Set<SettledObservationGuardForTest> =
+        buildSet {
+            if (!coherent) add(SettledObservationGuardForTest.COHERENT)
+            if (emulatorIdentity == null) {
+                add(SettledObservationGuardForTest.EMULATOR_IDENTITY_PRESENT)
+            }
+            if (modelDrainBacklogged) add(SettledObservationGuardForTest.MODEL_DRAIN_QUIET)
+            if (seedOperationInFlight) add(SettledObservationGuardForTest.SEED_IDLE)
+            if (sizeOperationsInFlight != 0) add(SettledObservationGuardForTest.SIZE_IDLE)
+            if (automaticHealOperationsInFlight != 0) {
+                add(SettledObservationGuardForTest.AUTOMATIC_HEAL_IDLE)
+            }
+            if (effectiveColumns <= 0) {
+                add(SettledObservationGuardForTest.EFFECTIVE_COLUMNS_POSITIVE)
+            }
+            if (effectiveRows <= 0) {
+                add(SettledObservationGuardForTest.EFFECTIVE_ROWS_POSITIVE)
+            }
+            if (appliedColumns <= 0) {
+                add(SettledObservationGuardForTest.APPLIED_COLUMNS_POSITIVE)
+            }
+            if (appliedRows <= 0) {
+                add(SettledObservationGuardForTest.APPLIED_ROWS_POSITIVE)
+            }
+            if (appliedColumns != effectiveColumns) {
+                add(SettledObservationGuardForTest.APPLIED_COLUMNS_MATCH_EFFECTIVE)
+            }
+            if (appliedRows != effectiveRows) {
+                add(SettledObservationGuardForTest.APPLIED_ROWS_MATCH_EFFECTIVE)
+            }
+            if (lastSeedAtMs == null) add(SettledObservationGuardForTest.LAST_SEED_PRESENT)
+        }
+
+    internal fun identicalSettledObservationFailuresForTest(
+        other: ActivePaneRenderOwnerSnapshotForTest,
+    ): Set<SettledObservationGuardForTest> = buildSet {
+        // The observation comparator intentionally checks positive settlement shape without the
+        // applied==effective relation. The journey establishes the full relation on every sample
+        // via attachResizeSeedSettled; this keeps each effective/applied equality dimension
+        // independently load-bearing in the observation-window matrix.
+        addAll(observationShapeFailuresForTest())
+        addAll(other.observationShapeFailuresForTest())
+        if (paneId != other.paneId) add(SettledObservationGuardForTest.PANE_ID)
+        if (windowId != other.windowId) add(SettledObservationGuardForTest.WINDOW_ID)
+        if (sessionId != other.sessionId) add(SettledObservationGuardForTest.SESSION_ID)
+        if (targetSessionName != other.targetSessionName) {
+            add(SettledObservationGuardForTest.TARGET_SESSION_NAME)
+        }
+        if (connectGeneration != other.connectGeneration) {
+            add(SettledObservationGuardForTest.CONNECT_GENERATION)
+        }
+        if (clientIdentity != other.clientIdentity) {
+            add(SettledObservationGuardForTest.CLIENT_IDENTITY)
+        }
+        if (stateIdentity != other.stateIdentity) {
+            add(SettledObservationGuardForTest.STATE_IDENTITY)
+        }
+        if (terminalSessionIdentity != other.terminalSessionIdentity) {
+            add(SettledObservationGuardForTest.TERMINAL_SESSION_IDENTITY)
+        }
+        if (emulatorIdentity != other.emulatorIdentity) {
+            add(SettledObservationGuardForTest.EMULATOR_IDENTITY)
+        }
+        if (modelMutationEpoch != other.modelMutationEpoch) {
+            add(SettledObservationGuardForTest.MODEL_MUTATION_EPOCH)
+        }
+        if (controlSizeGeneration != other.controlSizeGeneration) {
+            add(SettledObservationGuardForTest.CONTROL_SIZE_GENERATION)
+        }
+        if (effectiveColumns != other.effectiveColumns) {
+            add(SettledObservationGuardForTest.EFFECTIVE_COLUMNS)
+        }
+        if (effectiveRows != other.effectiveRows) {
+            add(SettledObservationGuardForTest.EFFECTIVE_ROWS)
+        }
+        if (appliedColumns != other.appliedColumns) {
+            add(SettledObservationGuardForTest.APPLIED_COLUMNS)
+        }
+        if (appliedRows != other.appliedRows) {
+            add(SettledObservationGuardForTest.APPLIED_ROWS)
+        }
+        if (automaticHealActivityEpoch != other.automaticHealActivityEpoch) {
+            add(SettledObservationGuardForTest.AUTOMATIC_HEAL_ACTIVITY_EPOCH)
+        }
+        if (lastSeedAtMs != other.lastSeedAtMs) {
+            add(SettledObservationGuardForTest.LAST_SEED_AT)
+        }
+    }
+
+    private fun observationShapeFailuresForTest(): Set<SettledObservationGuardForTest> =
+        buildSet {
+            if (!coherent) add(SettledObservationGuardForTest.COHERENT)
+            if (emulatorIdentity == null) {
+                add(SettledObservationGuardForTest.EMULATOR_IDENTITY_PRESENT)
+            }
+            if (modelDrainBacklogged) add(SettledObservationGuardForTest.MODEL_DRAIN_QUIET)
+            if (seedOperationInFlight) add(SettledObservationGuardForTest.SEED_IDLE)
+            if (sizeOperationsInFlight != 0) add(SettledObservationGuardForTest.SIZE_IDLE)
+            if (automaticHealOperationsInFlight != 0) {
+                add(SettledObservationGuardForTest.AUTOMATIC_HEAL_IDLE)
+            }
+            if (effectiveColumns <= 0) {
+                add(SettledObservationGuardForTest.EFFECTIVE_COLUMNS_POSITIVE)
+            }
+            if (effectiveRows <= 0) {
+                add(SettledObservationGuardForTest.EFFECTIVE_ROWS_POSITIVE)
+            }
+            if (appliedColumns <= 0) {
+                add(SettledObservationGuardForTest.APPLIED_COLUMNS_POSITIVE)
+            }
+            if (appliedRows <= 0) {
+                add(SettledObservationGuardForTest.APPLIED_ROWS_POSITIVE)
+            }
+            if (lastSeedAtMs == null) add(SettledObservationGuardForTest.LAST_SEED_PRESENT)
+        }
 
     /**
      * Issue #2272: the post-resize repaint branch is valid only when it is a later, richer,
@@ -76,6 +232,166 @@ internal data class ActivePaneRenderOwnerSnapshotForTest(
             renderedNonBlankChars > expected.renderedNonBlankChars &&
             visibleFrameMarker &&
             visibleFrameRows >= minimumFrameRows
+}
+
+/**
+ * Issue #2321: executable order gate for the connected stale-render proof. It is deliberately a
+ * test-only seam: the production heal has no dependency on this state machine, while the journey
+ * cannot silently run its pre-call oracle against the injected owner or heal before live evidence.
+ */
+internal enum class StaleRenderHealProofStepForTest {
+    INITIAL_SETTLED_OWNER,
+    STALE_FRAME_INJECTED,
+    POST_INJECTION_SETTLED_OWNER,
+    REMOTE_LIVE_ASSERTIONS,
+    PRE_HEAL_REACQUIRED_OWNER,
+    STALE_FRAME_RETAINED_AFTER_OWNER_MUTATION,
+    PRE_CALL_LOCAL_ORACLE,
+    MANUAL_HEAL,
+}
+
+internal class StaleRenderHealProofOrderForTest {
+    private val steps = mutableListOf<StaleRenderHealProofStepForTest>()
+
+    fun record(step: StaleRenderHealProofStepForTest) {
+        check(isAllowedNext(step)) {
+            "stale-render proof step out of order: previous=${steps.lastOrNull()} actual=$step"
+        }
+        steps += step
+    }
+
+    fun isComplete(): Boolean =
+        steps.firstOrNull() == StaleRenderHealProofStepForTest.INITIAL_SETTLED_OWNER &&
+            steps.contains(StaleRenderHealProofStepForTest.STALE_FRAME_INJECTED) &&
+            steps.contains(StaleRenderHealProofStepForTest.POST_INJECTION_SETTLED_OWNER) &&
+            steps.contains(StaleRenderHealProofStepForTest.REMOTE_LIVE_ASSERTIONS) &&
+            steps.contains(StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER) &&
+            steps.contains(StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE) &&
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.MANUAL_HEAL
+
+    private fun isAllowedNext(step: StaleRenderHealProofStepForTest): Boolean = when (step) {
+        StaleRenderHealProofStepForTest.INITIAL_SETTLED_OWNER -> steps.isEmpty()
+        StaleRenderHealProofStepForTest.STALE_FRAME_INJECTED ->
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.INITIAL_SETTLED_OWNER
+        StaleRenderHealProofStepForTest.POST_INJECTION_SETTLED_OWNER ->
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.STALE_FRAME_INJECTED
+        StaleRenderHealProofStepForTest.REMOTE_LIVE_ASSERTIONS ->
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.POST_INJECTION_SETTLED_OWNER
+        StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER ->
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.REMOTE_LIVE_ASSERTIONS ||
+                steps.lastOrNull() == StaleRenderHealProofStepForTest.STALE_FRAME_RETAINED_AFTER_OWNER_MUTATION ||
+                steps.lastOrNull() == StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER ||
+                steps.lastOrNull() == StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE
+        StaleRenderHealProofStepForTest.STALE_FRAME_RETAINED_AFTER_OWNER_MUTATION ->
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER ||
+                steps.lastOrNull() == StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE
+        StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE ->
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER
+        StaleRenderHealProofStepForTest.MANUAL_HEAL ->
+            steps.lastOrNull() == StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE
+    }
+}
+
+/** Only owner/precondition failures are recoverable by the connected proof barrier. */
+internal class StaleRenderOwnerChangedForTest(message: String) : IllegalStateException(message)
+
+/**
+ * Issue #2321: close the settlement-to-heal race without weakening the stale-frame oracle.
+ *
+ * A settled observation is not a lease. The active pane can resize, reseed, or complete an
+ * automatic heal after the observation and before the manual call. The barrier therefore does
+ * two checks: it compares the settled sample with an immediate live sample, then lets the
+ * production-shaped attempt perform its own owner check. Either check can request recovery. The
+ * recovery waits for a fresh settled owner and re-injects the same stale frame before retrying.
+ *
+ * This is test-only coordination; production heal behavior is unchanged. The callbacks are
+ * intentionally explicit so the JVM test can place a resize/model mutation in each race window
+ * and prove that the stale frame is retained rather than silently turning the assertion green.
+ */
+internal class StaleRenderHealOwnerRecoveryForTest(
+    private val maxAttempts: Int = 3,
+    private val sameSettledOwner: (
+        ActivePaneRenderOwnerSnapshotForTest,
+        ActivePaneRenderOwnerSnapshotForTest,
+    ) -> Boolean = { expected, actual ->
+        expected.isIdenticalSettledObservationAsForTest(actual)
+    },
+) {
+    init {
+        require(maxAttempts > 0) { "maxAttempts must be positive" }
+    }
+
+    fun <T> run(
+        initialOwner: ActivePaneRenderOwnerSnapshotForTest,
+        settleOwner: () -> ActivePaneRenderOwnerSnapshotForTest,
+        liveOwner: () -> ActivePaneRenderOwnerSnapshotForTest,
+        retainStaleFrame: (ActivePaneRenderOwnerSnapshotForTest) -> ActivePaneRenderOwnerSnapshotForTest,
+        attemptHeal: (ActivePaneRenderOwnerSnapshotForTest) -> T,
+    ): T {
+        var expectedOwner = initialOwner
+        repeat(maxAttempts) { attemptNumber ->
+            val settledOwner = settleOwner()
+            if (!sameSettledOwner(expectedOwner, settledOwner)) {
+                expectedOwner = retainStaleFrame(settledOwner)
+                return@repeat
+            }
+
+            // This read is deliberately separate from settleOwner(). It is the deterministic
+            // barrier for a resize/model mutation in the exact interval the bug reported.
+            val ownerImmediatelyBeforeAttempt = liveOwner()
+            if (!sameSettledOwner(settledOwner, ownerImmediatelyBeforeAttempt)) {
+                expectedOwner = retainStaleFrame(settleOwner())
+                return@repeat
+            }
+
+            try {
+                return attemptHeal(settledOwner)
+            } catch (changed: StaleRenderOwnerChangedForTest) {
+                if (attemptNumber == maxAttempts - 1) throw changed
+                // The production-shaped attempt caught a mutation after the live sample. Re-read
+                // a settled owner and restore the same stale frame before trying again.
+                expectedOwner = retainStaleFrame(settleOwner())
+            }
+        }
+        throw StaleRenderOwnerChangedForTest(
+            "stale-render owner did not remain stable for $maxAttempts attempts",
+        )
+    }
+}
+
+/**
+ * Issue #2321: the connected journey's load-bearing oracle. A full-looking viewport is not a
+ * healed result unless the same run first observed the stale local render, proved the remote
+ * frame/transport discriminator, and the production-shaped manual attempt actually healed it.
+ */
+internal data class StaleRenderHealProofForTest(
+    val localRenderLooksSuspect: Boolean,
+    val remoteCaptureNonBlankChars: Int,
+    val minimumRemoteCaptureChars: Int,
+    val remoteCaptureHasBanner: Boolean,
+    val transportConnected: Boolean,
+    val clientDisconnected: Boolean,
+    val reconnectSurfaceVisible: Boolean,
+    val healOutcome: HealOutcome?,
+    val healReason: HealAttemptReason?,
+    val restoredFrameHasBanner: Boolean,
+    val restoredFrameRows: Int,
+    val minimumRestoredFrameRows: Int,
+    val restoredPaintedRows: Int,
+    val minimumRestoredPaintedRows: Int,
+) {
+    val restored: Boolean
+        get() = localRenderLooksSuspect &&
+            remoteCaptureNonBlankChars >= minimumRemoteCaptureChars &&
+            remoteCaptureHasBanner &&
+            transportConnected &&
+            !clientDisconnected &&
+            !reconnectSurfaceVisible &&
+            healOutcome == HealOutcome.Healed &&
+            healReason == HealAttemptReason.DivergenceApplied &&
+            restoredFrameHasBanner &&
+            restoredFrameRows >= minimumRestoredFrameRows &&
+            restoredPaintedRows >= minimumRestoredPaintedRows
 }
 
 /**

--- a/app/src/test/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTestTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/ActivePaneRenderOwnerSnapshotForTestTest.kt
@@ -1,17 +1,388 @@
 package com.pocketshell.app.tmux
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Issue #2272 G6 mutation proof for the already-healed branch and its full-frame oracle.
+ * Issue #2272/#2321 G6 mutation proof for the settled-owner and already-healed branches.
  *
  * Each rejected case names a one-line mutation that must make this test red. The negative values
- * are deliberately one-guard cases where practical: in particular, the rendered-character
- * mutation keeps every other already-healed predicate true.
+ * are deliberately one-guard cases: resize/seed shape mutations are applied symmetrically to
+ * both observations so equality/identity guards cannot launder the targeted failure.
  */
 class ActivePaneRenderOwnerSnapshotForTestTest {
+
+    @Test
+    fun identicalSettledObservationHasOneFieldAtATimeMutationMatrix() {
+        val settled = snapshot(epoch = 3, generation = 4, chars = 39, partial = true)
+
+        // The observation window may ignore a visual-only change; settlement is about the
+        // owner/size/model invariants, so the intentional stale frame is not normalized away.
+        assertTrue(
+            "the same settled owner remains valid when only rendered frame diagnostics change",
+            settled.isIdenticalSettledObservationAsForTest(
+                settled.copy(renderedNonBlankChars = 40, partiallyBlank = false),
+            ),
+        )
+
+        val mutations = listOf(
+            SettledObservationGuardForTest.MODEL_MUTATION_EPOCH to
+                settled.copy(modelMutationEpoch = settled.modelMutationEpoch + 1),
+            SettledObservationGuardForTest.CONTROL_SIZE_GENERATION to settled.copy(
+                controlSizeGeneration = settled.controlSizeGeneration + 1,
+            ),
+            // Change each dimension independently. The comparator is intentionally fed already
+            // settled observations by the journey; its field-by-field checks must still reject
+            // either half of a resize mutation without hiding the failure behind paired fields.
+            SettledObservationGuardForTest.EFFECTIVE_COLUMNS to
+                settled.copy(effectiveColumns = settled.effectiveColumns + 1),
+            SettledObservationGuardForTest.EFFECTIVE_ROWS to
+                settled.copy(effectiveRows = settled.effectiveRows + 1),
+            SettledObservationGuardForTest.APPLIED_COLUMNS to
+                settled.copy(appliedColumns = settled.appliedColumns + 1),
+            SettledObservationGuardForTest.APPLIED_ROWS to
+                settled.copy(appliedRows = settled.appliedRows + 1),
+            SettledObservationGuardForTest.AUTOMATIC_HEAL_ACTIVITY_EPOCH to settled.copy(
+                automaticHealActivityEpoch = settled.automaticHealActivityEpoch + 1,
+            ),
+            SettledObservationGuardForTest.LAST_SEED_AT to
+                settled.copy(lastSeedAtMs = settled.lastSeedAtMs!! + 1),
+            SettledObservationGuardForTest.COHERENT to settled.copy(coherent = false),
+            SettledObservationGuardForTest.MODEL_DRAIN_QUIET to
+                settled.copy(modelDrainBacklogged = true),
+            SettledObservationGuardForTest.SEED_IDLE to settled.copy(seedOperationInFlight = true),
+            SettledObservationGuardForTest.SIZE_IDLE to settled.copy(sizeOperationsInFlight = 1),
+            SettledObservationGuardForTest.AUTOMATIC_HEAL_IDLE to
+                settled.copy(automaticHealOperationsInFlight = 1),
+            SettledObservationGuardForTest.PANE_ID to settled.copy(paneId = "foreign-pane"),
+            SettledObservationGuardForTest.WINDOW_ID to settled.copy(windowId = "@9"),
+            SettledObservationGuardForTest.SESSION_ID to settled.copy(sessionId = "foreign-session"),
+            SettledObservationGuardForTest.TARGET_SESSION_NAME to
+                settled.copy(targetSessionName = "foreign-target"),
+            SettledObservationGuardForTest.CONNECT_GENERATION to
+                settled.copy(connectGeneration = settled.connectGeneration + 1),
+            SettledObservationGuardForTest.CLIENT_IDENTITY to
+                settled.copy(clientIdentity = settled.clientIdentity!! + 1),
+            SettledObservationGuardForTest.STATE_IDENTITY to
+                settled.copy(stateIdentity = settled.stateIdentity + 1),
+            SettledObservationGuardForTest.TERMINAL_SESSION_IDENTITY to settled.copy(
+                terminalSessionIdentity = settled.terminalSessionIdentity!! + 1,
+            ),
+            SettledObservationGuardForTest.EMULATOR_IDENTITY to
+                settled.copy(emulatorIdentity = settled.emulatorIdentity!! + 1),
+        )
+
+        // Every entry changes exactly one data-class field. A surviving assertion after removing
+        // that field's predicate would be a G6 false positive; the baseline above proves that
+        // all other predicates are simultaneously satisfied.
+        mutations.forEach { (field, mutated) ->
+            assertEquals(
+                "one-field mutation of $field must redden only its named observation guard",
+                setOf(field),
+                settled.identicalSettledObservationFailuresForTest(mutated),
+            )
+        }
+
+        // These are the positive-shape guards. Mutate the same single field in both observations
+        // so the pair remains identical and only the settlement-shape predicate can reject it.
+        val shapeMutations = listOf(
+            SettledObservationGuardForTest.EMULATOR_IDENTITY_PRESENT to
+                settled.copy(emulatorIdentity = null),
+            SettledObservationGuardForTest.EFFECTIVE_COLUMNS_POSITIVE to
+                settled.copy(effectiveColumns = 0),
+            SettledObservationGuardForTest.EFFECTIVE_ROWS_POSITIVE to
+                settled.copy(effectiveRows = 0),
+            SettledObservationGuardForTest.APPLIED_COLUMNS_POSITIVE to
+                settled.copy(appliedColumns = 0),
+            SettledObservationGuardForTest.APPLIED_ROWS_POSITIVE to
+                settled.copy(appliedRows = 0),
+            SettledObservationGuardForTest.LAST_SEED_PRESENT to
+                settled.copy(lastSeedAtMs = null),
+        )
+        shapeMutations.forEach { (field, mutated) ->
+            assertEquals(
+                "one-field shape mutation of $field must redden only its named observation guard",
+                setOf(field),
+                mutated.identicalSettledObservationFailuresForTest(mutated),
+            )
+        }
+    }
+
+    @Test
+    fun fullSettlementGateNamesDimensionAndActivityFailures() {
+        val settled = snapshot(epoch = 3, generation = 4, chars = 39, partial = true)
+        assertTrue(
+            "the positive settlement gate must have no failures",
+            settled.settlementGuardFailuresForTest().isEmpty(),
+        )
+
+        val directMutations = listOf(
+            SettledObservationGuardForTest.COHERENT to settled.copy(coherent = false),
+            SettledObservationGuardForTest.EMULATOR_IDENTITY_PRESENT to
+                settled.copy(emulatorIdentity = null),
+            SettledObservationGuardForTest.MODEL_DRAIN_QUIET to
+                settled.copy(modelDrainBacklogged = true),
+            SettledObservationGuardForTest.SEED_IDLE to settled.copy(seedOperationInFlight = true),
+            SettledObservationGuardForTest.SIZE_IDLE to settled.copy(sizeOperationsInFlight = 1),
+            SettledObservationGuardForTest.AUTOMATIC_HEAL_IDLE to
+                settled.copy(automaticHealOperationsInFlight = 1),
+            SettledObservationGuardForTest.LAST_SEED_PRESENT to settled.copy(lastSeedAtMs = null),
+        )
+        directMutations.forEach { (guard, mutated) ->
+            assertTrue(
+                "one-field settlement mutation of $guard must name its load-bearing guard",
+                mutated.settlementGuardFailuresForTest().contains(guard),
+            )
+        }
+
+        // The positive-dimension and applied==effective checks are intentionally both load
+        // bearing. A zero effective/applied dimension necessarily violates its positivity and
+        // its paired-size relation; test both names rather than allowing a broad false to hide
+        // either predicate. The nonzero mismatch isolates the paired relation by itself.
+        val dimensionMutations = listOf(
+            settled.copy(effectiveColumns = 0) to setOf(
+                SettledObservationGuardForTest.EFFECTIVE_COLUMNS_POSITIVE,
+                SettledObservationGuardForTest.APPLIED_COLUMNS_MATCH_EFFECTIVE,
+            ),
+            settled.copy(effectiveRows = 0) to setOf(
+                SettledObservationGuardForTest.EFFECTIVE_ROWS_POSITIVE,
+                SettledObservationGuardForTest.APPLIED_ROWS_MATCH_EFFECTIVE,
+            ),
+            settled.copy(appliedColumns = 0) to setOf(
+                SettledObservationGuardForTest.APPLIED_COLUMNS_POSITIVE,
+                SettledObservationGuardForTest.APPLIED_COLUMNS_MATCH_EFFECTIVE,
+            ),
+            settled.copy(appliedRows = 0) to setOf(
+                SettledObservationGuardForTest.APPLIED_ROWS_POSITIVE,
+                SettledObservationGuardForTest.APPLIED_ROWS_MATCH_EFFECTIVE,
+            ),
+            settled.copy(appliedColumns = settled.effectiveColumns + 1) to setOf(
+                SettledObservationGuardForTest.APPLIED_COLUMNS_MATCH_EFFECTIVE,
+            ),
+            settled.copy(appliedRows = settled.effectiveRows + 1) to setOf(
+                SettledObservationGuardForTest.APPLIED_ROWS_MATCH_EFFECTIVE,
+            ),
+        )
+        dimensionMutations.forEach { (mutated, expectedFailures) ->
+            assertEquals(
+                "dimension settlement mutation must report its exact guard set",
+                expectedFailures,
+                mutated.settlementGuardFailuresForTest(),
+            )
+        }
+    }
+
+    @Test
+    fun twoObservationWindowRejectsMutationBetweenSamplesDeterministically() {
+        val first = snapshot(epoch = 3, generation = 4, chars = 39, partial = true)
+        val stableSecond = first.copy(renderedNonBlankChars = 40, partiallyBlank = false)
+        val mutatedSecond = first.copy(modelMutationEpoch = first.modelMutationEpoch + 1)
+
+        fun acceptsTwoObservationWindow(second: ActivePaneRenderOwnerSnapshotForTest): Boolean =
+            first.isIdenticalSettledObservationAsForTest(second)
+
+        assertTrue(
+            "two identical settled observations must form a valid window",
+            acceptsTwoObservationWindow(stableSecond),
+        )
+        assertFalse(
+            "a model mutation between the first and second sample must reject the window",
+            acceptsTwoObservationWindow(mutatedSecond),
+        )
+
+        // The rejection is directional too: the mutated sample cannot be used as the prior
+        // observation to hide the change when the window is evaluated in the other direction.
+        assertFalse(
+            "the mutated observation must not become a valid prior sample",
+            mutatedSecond.isIdenticalSettledObservationAsForTest(first),
+        )
+    }
+
+    @Test
+    fun ownerRecoveryReacquiresAndRetainsFrameAfterResizeMutationBeforeAttempt() {
+        val initial = snapshot(epoch = 3, generation = 4, chars = 39, partial = true)
+        var current = initial
+        var mutateAtLiveRead = true
+        var settleOwnerReadCount = 0
+        var liveOwnerReadCount = 0
+        var retainCount = 0
+        var preCallOraclePassed = false
+        var manualHealPassed = false
+
+        val result = StaleRenderHealOwnerRecoveryForTest().run(
+            initialOwner = initial,
+            settleOwner = {
+                settleOwnerReadCount++
+                current
+            },
+            liveOwner = {
+                liveOwnerReadCount++
+                if (mutateAtLiveRead) {
+                    mutateAtLiveRead = false
+                    current = current.copy(
+                        modelMutationEpoch = current.modelMutationEpoch + 1,
+                        controlSizeGeneration = current.controlSizeGeneration + 1,
+                        effectiveColumns = current.effectiveColumns + 1,
+                        effectiveRows = current.effectiveRows + 1,
+                        appliedColumns = current.appliedColumns + 1,
+                        appliedRows = current.appliedRows + 1,
+                        automaticHealActivityEpoch = current.automaticHealActivityEpoch + 1,
+                        lastSeedAtMs = current.lastSeedAtMs!! + 1,
+                    )
+                }
+                current
+            },
+            retainStaleFrame = { settledAfterResize ->
+                retainCount++
+                current = settledAfterResize.copy(
+                    modelMutationEpoch = settledAfterResize.modelMutationEpoch + 1,
+                    renderedNonBlankChars = 4,
+                    partiallyBlank = true,
+                    renderLooksSuspect = true,
+                )
+                current
+            },
+            attemptHeal = { expected ->
+                // This is the exact pre-call local oracle: the manual attempt must receive the
+                // same owner as the live render model after recovery, with the retained stale
+                // viewport still present. A settlement-only proxy would let a resize mutation
+                // turn the proof green while the intended stale frame was gone.
+                assertTrue(
+                    "the pre-call owner must be identical to the recovered live owner",
+                    expected.isIdenticalSettledObservationAsForTest(current),
+                )
+                assertTrue(current.renderLooksSuspect)
+                assertEquals(4, current.renderedNonBlankChars)
+                preCallOraclePassed = true
+                manualHealPassed = true
+                "healed"
+            },
+        )
+
+        assertEquals("healed", result)
+        assertEquals(
+            "the resize/model mutation must cause one fresh stale-frame retention",
+            1,
+            retainCount,
+        )
+        assertEquals(
+            "the real live-owner barrier must be read once for each attempted owner",
+            2,
+            liveOwnerReadCount,
+        )
+        assertEquals(
+            "a barrier mismatch must reacquire a settled owner before retrying",
+            3,
+            settleOwnerReadCount,
+        )
+        assertEquals(4, current.renderedNonBlankChars)
+        assertTrue(current.renderLooksSuspect)
+        assertTrue("the pre-call local owner oracle must execute", preCallOraclePassed)
+        assertTrue("the manual heal callback must execute after that oracle", manualHealPassed)
+    }
+
+    @Test
+    fun ownerRecoveryRetriesWhenProductionHealPreflightSeesMutationAfterLiveRead() {
+        val initial = snapshot(epoch = 3, generation = 4, chars = 39, partial = true)
+        var current = initial
+        var firstAttempt = true
+        var attemptCount = 0
+        var retainCount = 0
+        var preCallOracleCount = 0
+        var manualHealPassed = false
+
+        val result = StaleRenderHealOwnerRecoveryForTest().run(
+            initialOwner = initial,
+            settleOwner = { current },
+            liveOwner = { current },
+            retainStaleFrame = { settledAfterMutation ->
+                retainCount++
+                current = settledAfterMutation.copy(
+                    modelMutationEpoch = settledAfterMutation.modelMutationEpoch + 1,
+                    renderedNonBlankChars = 3,
+                    partiallyBlank = true,
+                    renderLooksSuspect = true,
+                )
+                current
+            },
+            attemptHeal = { expected ->
+                attemptCount++
+                if (firstAttempt) {
+                    firstAttempt = false
+                    current = current.copy(modelMutationEpoch = current.modelMutationEpoch + 1)
+                    throw StaleRenderOwnerChangedForTest(
+                        "synthetic resize/model mutation between live owner and manual heal",
+                    )
+                }
+                preCallOracleCount++
+                assertTrue(expected.isIdenticalSettledObservationAsForTest(current))
+                assertTrue(current.renderLooksSuspect)
+                assertEquals(3, current.renderedNonBlankChars)
+                manualHealPassed = true
+                "healed-after-retry"
+            },
+        )
+
+        assertEquals("healed-after-retry", result)
+        assertEquals(
+            "a production preflight mutation must be recovered, not turned into a green skip",
+            2,
+            attemptCount,
+        )
+        assertEquals(1, retainCount)
+        assertTrue(current.renderLooksSuspect)
+        assertEquals(1, preCallOracleCount)
+        assertTrue("the retry must reach the manual heal only after its pre-call oracle", manualHealPassed)
+    }
+
+    @Test
+    fun executableMutantsRedWhenOwnerStabilizationOrProofOrderIsRemoved() {
+        val initial = snapshot(epoch = 3, generation = 4, chars = 39, partial = true)
+        var current = initial
+        var manualHealCalled = false
+
+        // Executable mutant: remove the live-owner stabilization predicate. The synthetic resize
+        // is in the exact settlement-to-manual interval; the pre-call oracle must then redden.
+        val ownerBarrierRemoved = StaleRenderHealOwnerRecoveryForTest(
+            maxAttempts = 1,
+            sameSettledOwner = { _, _ -> true },
+        )
+        val barrierFailure = assertThrows(AssertionError::class.java) {
+            ownerBarrierRemoved.run(
+                initialOwner = initial,
+                settleOwner = { current },
+                liveOwner = {
+                    current = current.copy(
+                        controlSizeGeneration = current.controlSizeGeneration + 1,
+                        effectiveColumns = current.effectiveColumns + 1,
+                        appliedColumns = current.appliedColumns + 1,
+                    )
+                    current
+                },
+                retainStaleFrame = { current },
+                attemptHeal = { expected ->
+                    manualHealCalled = true
+                    assertTrue(
+                        "pre-call owner stabilization must reject the resized live owner",
+                        expected.isIdenticalSettledObservationAsForTest(current),
+                    )
+                },
+            )
+        }
+        assertTrue(barrierFailure.message.orEmpty().contains("pre-call owner"))
+        assertTrue("the mutated barrier must reach the pre-call oracle before reddening", manualHealCalled)
+
+        // Executable mutant: remove the proof-order check. Healing before stale/live evidence must
+        // be rejected by the same state machine that the connected journey records.
+        val proofOrder = StaleRenderHealProofOrderForTest()
+        val orderFailure = assertThrows(IllegalStateException::class.java) {
+            proofOrder.record(StaleRenderHealProofStepForTest.MANUAL_HEAL)
+        }
+        assertTrue(orderFailure.message.orEmpty().contains("out of order"))
+    }
 
     @Test
     fun alreadyHealedRequiresLaterStableOwnerAndVisibleFullFrame() {
@@ -141,6 +512,47 @@ class ActivePaneRenderOwnerSnapshotForTestTest {
             "an automatic restore with too few frame rows is not a full-frame outcome",
             fullFrame.copy(visibleFrameRows = 4).restored,
         )
+    }
+
+    @Test
+    fun staleRenderProofOracleHasSelectiveHealAndViewportMatrix() {
+        val valid = StaleRenderHealProofForTest(
+            localRenderLooksSuspect = true,
+            remoteCaptureNonBlankChars = 40,
+            minimumRemoteCaptureChars = 40,
+            remoteCaptureHasBanner = true,
+            transportConnected = true,
+            clientDisconnected = false,
+            reconnectSurfaceVisible = false,
+            healOutcome = HealOutcome.Healed,
+            healReason = HealAttemptReason.DivergenceApplied,
+            restoredFrameHasBanner = true,
+            restoredFrameRows = 20,
+            minimumRestoredFrameRows = 20,
+            restoredPaintedRows = 30,
+            minimumRestoredPaintedRows = 30,
+        )
+        assertTrue("the complete stale-render evidence must pass", valid.restored)
+
+        val mutations = listOf(
+            "localRenderLooksSuspect" to valid.copy(localRenderLooksSuspect = false),
+            "remoteCaptureNonBlankChars" to valid.copy(remoteCaptureNonBlankChars = 39),
+            "remoteCaptureHasBanner" to valid.copy(remoteCaptureHasBanner = false),
+            "transportConnected" to valid.copy(transportConnected = false),
+            "clientDisconnected" to valid.copy(clientDisconnected = true),
+            "reconnectSurfaceVisible" to valid.copy(reconnectSurfaceVisible = true),
+            "healOutcome" to valid.copy(healOutcome = HealOutcome.Healthy),
+            "healReason" to valid.copy(healReason = HealAttemptReason.CaptureEmpty),
+            "restoredFrameHasBanner" to valid.copy(restoredFrameHasBanner = false),
+            "restoredFrameRows" to valid.copy(restoredFrameRows = 19),
+            "restoredPaintedRows" to valid.copy(restoredPaintedRows = 29),
+        )
+        mutations.forEach { (field, mutated) ->
+            assertFalse(
+                "one-field stale-render proof mutation of $field must redden the load-bearing oracle",
+                mutated.restored,
+            )
+        }
     }
 
     private fun snapshot(

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue966HealDiagnosticsSourceGuardTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue966HealDiagnosticsSourceGuardTest.kt
@@ -15,6 +15,97 @@ import org.junit.Test
 class Issue966HealDiagnosticsSourceGuardTest {
 
     @Test
+    fun staleRenderOwnerPredicateAndProofOrderAreExecutable() {
+        val first = settledOwner(modelMutationEpoch = 3)
+        val sameOwner = first.copy(renderedNonBlankChars = 40, partiallyBlank = false)
+        val mutatedOwner = first.copy(modelMutationEpoch = first.modelMutationEpoch + 1)
+
+        assertTrue(
+            "the executable owner predicate must accept two stable observations",
+            first.isIdenticalSettledObservationAsForTest(sameOwner),
+        )
+        assertFalse(
+            "the executable owner predicate must reject a mutation between observations",
+            first.isIdenticalSettledObservationAsForTest(mutatedOwner),
+        )
+
+        val order = StaleRenderHealProofOrderForTest()
+        listOf(
+            StaleRenderHealProofStepForTest.INITIAL_SETTLED_OWNER,
+            StaleRenderHealProofStepForTest.STALE_FRAME_INJECTED,
+            StaleRenderHealProofStepForTest.POST_INJECTION_SETTLED_OWNER,
+            StaleRenderHealProofStepForTest.REMOTE_LIVE_ASSERTIONS,
+            StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER,
+            StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE,
+            StaleRenderHealProofStepForTest.MANUAL_HEAL,
+        ).forEach(order::record)
+        assertTrue(
+            "the executable proof-order seam must accept the production journey order",
+            order.isComplete(),
+        )
+
+        val wrongOrder = StaleRenderHealProofOrderForTest()
+        val rejected = runCatching {
+            wrongOrder.record(StaleRenderHealProofStepForTest.MANUAL_HEAL)
+        }.isFailure
+        assertTrue(
+            "the executable proof-order seam must reject healing before stale/live evidence",
+            rejected,
+        )
+
+        val recoveredOrder = StaleRenderHealProofOrderForTest()
+        listOf(
+            StaleRenderHealProofStepForTest.INITIAL_SETTLED_OWNER,
+            StaleRenderHealProofStepForTest.STALE_FRAME_INJECTED,
+            StaleRenderHealProofStepForTest.POST_INJECTION_SETTLED_OWNER,
+            StaleRenderHealProofStepForTest.REMOTE_LIVE_ASSERTIONS,
+            StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER,
+            StaleRenderHealProofStepForTest.STALE_FRAME_RETAINED_AFTER_OWNER_MUTATION,
+            StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER,
+            StaleRenderHealProofStepForTest.PRE_CALL_LOCAL_ORACLE,
+            StaleRenderHealProofStepForTest.MANUAL_HEAL,
+        ).forEach(recoveredOrder::record)
+        assertTrue(
+            "the proof-order seam must allow a retained stale frame after owner mutation",
+            recoveredOrder.isComplete(),
+        )
+    }
+
+    @Test
+    fun staleRenderJourneyExecutesTheDeclaredProofOrder() {
+        val source = locateJourney("StaleRenderHealOnLiveTransportJourneyE2eTest.kt")
+        val steps = Regex(
+            """proofOrder\.record\s*\(\s*StaleRenderHealProofStepForTest\.([A-Z_]+)""",
+        ).findAll(source).map { match ->
+            StaleRenderHealProofStepForTest.valueOf(match.groupValues[1])
+        }.toList()
+
+        assertTrue(
+            "the connected journey must execute its proof-order state machine",
+            steps.isNotEmpty(),
+        )
+        val order = StaleRenderHealProofOrderForTest()
+        steps.forEach { step ->
+            order.record(step)
+            // The source has one settleOwner lambda, but recovery invokes it again after the
+            // stale frame is retained. Model that second execution so the guard checks the real
+            // runtime order rather than treating a callback's single source occurrence as one call.
+            if (step == StaleRenderHealProofStepForTest.STALE_FRAME_RETAINED_AFTER_OWNER_MUTATION) {
+                order.record(StaleRenderHealProofStepForTest.PRE_HEAL_REACQUIRED_OWNER)
+            }
+        }
+        assertTrue(
+            "the connected journey's actual proof-order calls must form a complete proof",
+            order.isComplete(),
+        )
+        assertTrue(
+            "owner recovery must retain the same stale frame for re-injection",
+            source.contains("feedFrameToActivePaneModel(\n                        staleFrame,") &&
+                source.contains("StaleRenderHealOwnerRecoveryForTest().run("),
+        )
+    }
+
+    @Test
     fun bothJourneysQuiesceBeforeInjectionAndRetainTypedEvidence() {
         listOf(
             "StaleRenderHealOnLiveTransportJourneyE2eTest.kt",
@@ -35,8 +126,13 @@ class Issue966HealDiagnosticsSourceGuardTest {
                 source.contains("appendToActivePaneRenderModelForTest(bytes, expectedOwner)"))
             assertTrue("$name must prove TerminalView and VM emulator identity equality",
                 source.contains("viewEmulatorIdentity != expectedOwner.emulatorIdentity"))
-            assertTrue("$name must retain the injected owner through the pre-call oracle",
-                source.contains("snapshot.modelMutationEpoch != expectedOwner.modelMutationEpoch"))
+            val preCallOwnerGuard = if (name == "StaleRenderHealOnLiveTransportJourneyE2eTest.kt") {
+                source.contains("isIdenticalSettledObservationAsForTest(expectedOwner)")
+            } else {
+                source.contains("snapshot.modelMutationEpoch != expectedOwner.modelMutationEpoch")
+            }
+            assertTrue("$name must retain its settled owner through the pre-call oracle",
+                preCallOwnerGuard)
             assertTrue("$name must cancel+join through the atomic VM seam",
                 source.contains("pauseActivePaneStaleRenderWatchdogForTest()"))
             assertTrue("$name must assert the watchdog is quiescent",
@@ -69,6 +165,47 @@ class Issue966HealDiagnosticsSourceGuardTest {
                 source.contains("heal_capture_non_blank_chars=") &&
                     source.contains("heal_capture_line_count="))
         }
+    }
+
+    @Test
+    fun staleRenderProofOracleRequiresHealSourceAndRestoredViewport() {
+        val valid = StaleRenderHealProofForTest(
+            localRenderLooksSuspect = true,
+            remoteCaptureNonBlankChars = 40,
+            minimumRemoteCaptureChars = 40,
+            remoteCaptureHasBanner = true,
+            transportConnected = true,
+            clientDisconnected = false,
+            reconnectSurfaceVisible = false,
+            healOutcome = HealOutcome.Healed,
+            healReason = HealAttemptReason.DivergenceApplied,
+            restoredFrameHasBanner = true,
+            restoredFrameRows = 20,
+            minimumRestoredFrameRows = 20,
+            restoredPaintedRows = 30,
+            minimumRestoredPaintedRows = 30,
+        )
+        assertTrue("the complete connected heal evidence must be accepted", valid.restored)
+        assertFalse(
+            "a full-looking frame without a healed manual attempt must fail",
+            valid.copy(healOutcome = HealOutcome.Healthy).restored,
+        )
+        assertFalse(
+            "a healed attempt without the exact divergence reason must fail",
+            valid.copy(healReason = HealAttemptReason.CaptureEmpty).restored,
+        )
+        assertFalse(
+            "a healed attempt without restored banner rows must fail",
+            valid.copy(restoredFrameRows = 19).restored,
+        )
+        assertFalse(
+            "a healed attempt without painted viewport rows must fail",
+            valid.copy(restoredPaintedRows = 29).restored,
+        )
+        assertFalse(
+            "a healed-looking viewport from a non-suspect precondition must fail",
+            valid.copy(localRenderLooksSuspect = false).restored,
+        )
     }
 
     @Test
@@ -167,12 +304,30 @@ class Issue966HealDiagnosticsSourceGuardTest {
         assertTrue(seam.contains("sizeOperationsInFlight == 0"))
         assertTrue(seam.contains("automaticHealOperationsInFlight == 0"))
         assertTrue(seam.contains("automaticHealActivityEpoch == expectedOwner.automaticHealActivityEpoch"))
-        assertTrue(seam.contains("appliedColumns == effectiveColumns"))
-        assertTrue(seam.contains("appliedRows == effectiveRows"))
-        assertTrue(seam.contains("lastSeedAtMs != null"))
         assertTrue(seam.contains("before.sameOwnerAs(expectedOwner)"))
         assertTrue(seam.contains("before.modelMutationEpoch == expectedOwner.modelMutationEpoch"))
         assertTrue(seam.contains("appendDirectlyToRenderModelForTesting(bytes)"))
+
+        // Exercise the settlement gate itself. A source substring cannot prove that either
+        // applied dimension remains tied to its effective dimension after a refactor.
+        val settled = settledOwner(modelMutationEpoch = 3)
+        assertTrue("the executable settlement baseline must be positive", settled.attachResizeSeedSettled)
+        assertFalse(
+            "a zero effective column count must fail settlement",
+            settled.copy(effectiveColumns = 0).attachResizeSeedSettled,
+        )
+        assertFalse(
+            "a zero effective row count must fail settlement",
+            settled.copy(effectiveRows = 0).attachResizeSeedSettled,
+        )
+        assertFalse(
+            "an unapplied column count must fail settlement",
+            settled.copy(appliedColumns = settled.appliedColumns + 1).attachResizeSeedSettled,
+        )
+        assertFalse(
+            "an unapplied row count must fail settlement",
+            settled.copy(appliedRows = settled.appliedRows + 1).attachResizeSeedSettled,
+        )
 
         val regression = locateTest("PartialBlackPaneHealTest.kt")
         assertTrue(regression.contains("issue966ManualInjectionRejectsAnUnequalVisibleEmulatorOwner"))
@@ -206,9 +361,11 @@ class Issue966HealDiagnosticsSourceGuardTest {
             assertTrue("$name artifacts must retain it",
                 source.contains("view_terminal_session_identity="))
             assertTrue("$name must reject pending automatic heals",
-                source.contains("automaticHealOperationsInFlight != 0"))
+                source.contains("automaticHealOperationsInFlight != 0") ||
+                    source.contains("attachResizeSeedSettled"))
             assertTrue("$name must reject automatic-heal ABA at every owner checkpoint",
-                source.split("automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch").size >= 4)
+                source.contains("isIdenticalSettledObservationAsForTest(expectedOwner)") ||
+                    source.split("automaticHealActivityEpoch != expectedOwner.automaticHealActivityEpoch").size >= 4)
             assertTrue("$name artifacts must retain the automatic-heal epoch",
                 source.contains("expected_automatic_heal_activity_epoch="))
         }
@@ -272,6 +429,34 @@ class Issue966HealDiagnosticsSourceGuardTest {
             ?: error("Could not locate ${candidates.joinToString()} from ${File(".").absolutePath}")
         return file.readText()
     }
+
+    private fun settledOwner(modelMutationEpoch: Long) = ActivePaneRenderOwnerSnapshotForTest(
+        paneId = "pane",
+        windowId = "@0",
+        sessionId = "session",
+        targetSessionName = "issue966",
+        connectGeneration = 1,
+        clientIdentity = 1,
+        stateIdentity = 1,
+        terminalSessionIdentity = 1,
+        emulatorIdentity = 1,
+        modelMutationEpoch = modelMutationEpoch,
+        modelDrainBacklogged = false,
+        seedOperationInFlight = false,
+        sizeOperationsInFlight = 0,
+        automaticHealOperationsInFlight = 0,
+        automaticHealActivityEpoch = 1,
+        controlSizeGeneration = 4,
+        effectiveColumns = 62,
+        effectiveRows = 58,
+        appliedColumns = 62,
+        appliedRows = 58,
+        lastSeedAtMs = 1,
+        renderedNonBlankChars = 39,
+        partiallyBlank = true,
+        renderLooksSuspect = true,
+        coherent = true,
+    )
 
     private fun String.substringBetween(
         start: String,


### PR DESCRIPTION
Closes #2321

## Summary
- Require two coherent settled owner observations before stale-render heal.
- Retain and re-inject stale frames across owner/resize races, with typed recovery outcomes.
- Add load-bearing source guards and mutation coverage for the connected proof.

## Verification
- Focused JVM: 19/19 passed.
- Owner-barrier mutation: selected test correctly red.
- Connected emulator + Docker: 1/1 passed across all three stale-render kinds, no reconnect.
- Canonical full JVM: Debug clean; one unchanged Release `FileViewerWorkspaceTest.closeActiveSelectsRightThenEmpty` baseline failure outside this diff.
- Independent reviewer: APPROVED.