### PR TITLE
refactor: extract tree sync coordinator (#2307)

### DIFF
--- a/app/src/main/java/com/pocketshell/app/projects/FolderListTreeSyncRemote.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListTreeSyncRemote.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -47,11 +49,28 @@ internal class FolderListTreeSyncRemote(
     private var warmJob: Job? = null
     private var warmLease: SshLease? = null
     private val warmSessionReady = kotlinx.coroutines.flow.MutableStateFlow(false)
-    private var boundParams: BoundParams? = null
+    private var currentBinding: TreeSyncBinding? = null
+    private var warmBinding: TreeSyncBinding? = null
+    private val warmMutex = Mutex()
 
-    override fun events(params: BoundParams): Flow<TreeSyncEvent> {
+    override fun bind(binding: TreeSyncBinding) {
+        val previous = currentBinding
+        if (previous != null && previous.generation > binding.generation) return
+        if (previous == binding) return
+        currentBinding = binding
+        warmBinding = null
+        warmSessionReady.value = false
+        // The coordinator cancels only its wrapper job. Cancel the adapter's
+        // sibling warm job immediately; the next ensure joins it before
+        // releasing the old lease and dialing the new host.
+        warmJob?.cancel()
+    }
+
+    override fun events(binding: TreeSyncBinding): Flow<TreeSyncEvent> {
         val registry = activeTmuxClients ?: return emptyFlow()
         return channelFlow {
+            if (!isCurrent(binding)) return@channelFlow
+            val params = binding.params
             launch {
                 registry.clients
                     .map { snapshot -> snapshot[params.hostId]?.takeIf { it.matches(params) }?.client }
@@ -81,33 +100,19 @@ internal class FolderListTreeSyncRemote(
         }
     }
 
-    override suspend fun ensureWarmConnected(params: BoundParams) {
-        if (boundParams != params) {
-            invalidateWarmStateForHostSwitch()
-            boundParams = params
-        }
-        if (warmLease?.session?.isConnected == true) return
-        val liveClient = activeTmuxClients?.clients?.value?.get(params.hostId)
-            ?.takeIf { it.matches(params) }
-            ?.takeUnless { it.client.disconnected.value }
-        if (liveClient != null) return
-
-        val existing = warmJob
-        if (existing != null && existing.isActive) {
-            existing.join()
-        } else if (warmLease == null && (existing == null || existing.isCancelled)) {
-            val job = scope.launch { replaceWarmLease(params) }
-            warmJob = job
-            job.join()
-        }
+    override suspend fun ensureWarmConnected(binding: TreeSyncBinding) = warmMutex.withLock {
+        ensureWarmConnectedLocked(binding)
     }
 
     override suspend fun fullReconcile(
-        params: BoundParams,
+        binding: TreeSyncBinding,
         watchedFolders: List<com.pocketshell.core.storage.entity.ProjectRootEntity>,
     ): TreeSyncRemote.FullResult {
+        if (!isCurrent(binding)) return staleFullResult()
+        val params = binding.params
         val host = withContext(dispatcher()) { hostDao.getById(params.hostId) }
             ?: return TreeSyncRemote.FullResult.HostNotFound
+        if (!isCurrent(binding)) return staleFullResult()
         return when (
             val result = gateway.listSessionsWithFolder(
                 host = host,
@@ -123,52 +128,100 @@ internal class FolderListTreeSyncRemote(
         }
     }
 
-    override suspend fun getTree(params: BoundParams): TreeRemoteSource.TreeResult {
+    override suspend fun getTree(binding: TreeSyncBinding): TreeRemoteSource.TreeResult {
+        if (!isCurrent(binding)) return TreeRemoteSource.TreeResult.Empty
+        val params = binding.params
         val source = treeRemoteSource ?: return TreeRemoteSource.TreeResult.Empty
-        val session = awaitWarmSession(params) ?: return TreeRemoteSource.TreeResult.Empty
+        val session = awaitWarmSession(binding) ?: return TreeRemoteSource.TreeResult.Empty
+        if (!isCurrent(binding)) return TreeRemoteSource.TreeResult.Empty
         return source.getTree(session, params.hostName)
     }
 
-    override suspend fun reconcileTree(params: BoundParams): TreeRemoteSource.ReconcileDelta? {
+    override suspend fun reconcileTree(binding: TreeSyncBinding): TreeRemoteSource.ReconcileDelta? {
+        if (!isCurrent(binding)) return null
+        val params = binding.params
         val source = treeRemoteSource ?: return null
-        val session = awaitWarmSession(params) ?: return null
+        val session = awaitWarmSession(binding) ?: return null
+        if (!isCurrent(binding)) return null
         return source.reconcileTree(session, params.hostName)
     }
 
     override suspend fun upsertTree(
-        params: BoundParams,
+        binding: TreeSyncBinding,
         nodes: List<TreeRemoteSource.TreeNode>,
     ): Boolean {
+        if (!isCurrent(binding)) return false
+        val params = binding.params
         val source = treeRemoteSource ?: return false
-        val session = awaitWarmSession(params) ?: return false
+        val session = awaitWarmSession(binding) ?: return false
+        if (!isCurrent(binding)) return false
         return source.upsertTree(session, params.hostName, nodes)
     }
 
-    override suspend fun acquireSessionForUpgrade(params: BoundParams): SshSession? {
-        ensureWarmConnected(params)
-        warmLease?.session?.takeIf { it.isConnected }?.let { return it }
-        warmJob?.takeIf { it.isActive }?.join()
-        warmLease?.session?.takeIf { it.isConnected }?.let { return it }
-        replaceWarmLease(params)
-        return warmLease?.session?.takeIf { it.isConnected }
-    }
-
-    override suspend fun releaseWarm() {
-        val lease = warmLease ?: return
-        warmLease = null
-        warmSessionReady.value = false
-        withContext(NonCancellable + dispatcher()) {
-            withTimeoutOrNull(WARM_LEASE_RELEASE_TIMEOUT_MS) { lease.release() }
+    override suspend fun acquireSessionForUpgrade(binding: TreeSyncBinding): SshSession? =
+        warmMutex.withLock {
+            if (!isCurrent(binding)) return@withLock null
+            ensureWarmConnectedLocked(binding)
+            if (!isCurrent(binding)) return@withLock null
+            liveWarmSessionFor(binding)?.let { return@withLock it }
+            warmJob?.takeIf { it.isActive }?.join()
+            if (!isCurrent(binding)) return@withLock null
+            liveWarmSessionFor(binding)?.let { return@withLock it }
+            replaceWarmLease(binding)
+            if (!isCurrent(binding)) return@withLock null
+            liveWarmSessionFor(binding)
         }
+
+    override suspend fun releaseWarm() = warmMutex.withLock {
+        releaseWarmLocked()
     }
 
-    private suspend fun awaitWarmSession(params: BoundParams): SshSession? {
-        ensureWarmConnected(params)
-        warmLease?.session?.let { return it }
+    private suspend fun awaitWarmSession(binding: TreeSyncBinding): SshSession? {
+        ensureWarmConnected(binding)
+        if (!isCurrent(binding)) return null
+        warmSessionFor(binding)?.let { return it }
         val ready = withTimeoutOrNull(warmSessionAwaitMs()) {
             warmSessionReady.first { it }
         }
-        return if (ready == true && boundParams == params) warmLease?.session else null
+        return if (ready == true && isCurrent(binding)) warmSessionFor(binding) else null
+    }
+
+    private suspend fun ensureWarmConnectedLocked(binding: TreeSyncBinding) {
+        if (!isCurrent(binding)) return
+        if (warmBinding != binding) {
+            invalidateWarmStateForHostSwitch()
+            if (!isCurrent(binding)) return
+            warmBinding = binding
+            warmSessionReady.value = false
+        }
+        if (!isCurrent(binding)) return
+        if (warmSessionFor(binding)?.isConnected == true) return
+        val params = binding.params
+        val liveClient = activeTmuxClients?.clients?.value?.get(params.hostId)
+            ?.takeIf { it.matches(params) }
+            ?.takeUnless { it.client.disconnected.value }
+        if (!isCurrent(binding) || liveClient != null) return
+
+        val existing = warmJob
+        if (existing != null && existing.isActive) {
+            existing.join()
+        } else if (warmLease == null && (existing == null || existing.isCancelled)) {
+            val job = scope.launch { replaceWarmLease(binding) }
+            warmJob = job
+            job.join()
+        }
+    }
+
+    private suspend fun releaseWarmLocked() {
+        val lease = warmLease
+        warmLease = null
+        warmBinding = null
+        warmSessionReady.value = false
+        if (lease != null) {
+            withContext(NonCancellable + dispatcher()) {
+                withTimeoutOrNull(WARM_LEASE_RELEASE_TIMEOUT_MS) { lease.release() }
+            }
+        }
     }
 
     /**
@@ -180,21 +233,23 @@ internal class FolderListTreeSyncRemote(
         val previousWarmJob = warmJob
         warmJob = null
         previousWarmJob?.cancelAndJoin()
-        releaseWarm()
+        releaseWarmLocked()
     }
 
-    private suspend fun replaceWarmLease(params: BoundParams) {
-        releaseWarm()
+    private suspend fun replaceWarmLease(binding: TreeSyncBinding) {
+        if (!isCurrent(binding)) return
+        releaseWarmFor(binding)
+        if (!isCurrent(binding)) return
         var acquiredLease: SshLease? = null
         try {
-            val lease = sshLeaseManager.acquire(params.toSshLeaseTarget()).getOrNull() ?: return
+            val lease = sshLeaseManager.acquire(binding.params.toSshLeaseTarget()).getOrNull() ?: return
             acquiredLease = lease
             onWarmSessionAcquired()
             withContext(NonCancellable) {
-                if (boundParams != params) return@withContext
+                if (!isCurrent(binding)) return@withContext
                 warmLease = lease
                 acquiredLease = null
-                boundParams = params
+                warmBinding = binding
                 warmSessionReady.value = true
             }
         } catch (cancellation: CancellationException) {
@@ -203,6 +258,27 @@ internal class FolderListTreeSyncRemote(
             acquiredLease?.release()
         }
     }
+
+    private fun isCurrent(binding: TreeSyncBinding): Boolean = currentBinding == binding
+
+    private fun warmSessionFor(binding: TreeSyncBinding): SshSession? =
+        warmLease?.session?.takeIf { warmBinding == binding }
+
+    private fun liveWarmSessionFor(binding: TreeSyncBinding): SshSession? =
+        warmSessionFor(binding)?.takeIf { it.isConnected }
+
+    private suspend fun releaseWarmFor(binding: TreeSyncBinding) {
+        if (warmBinding != binding) return
+        releaseWarmLocked()
+        // Replacing a lease for the same binding must not look like a failed
+        // host switch.  Keep the completed warm attempt associated with this
+        // generation so the reconcile can surface its failure through the
+        // gateway instead of immediately dialing a third time.
+        if (isCurrent(binding)) warmBinding = binding
+    }
+
+    private fun staleFullResult(): TreeSyncRemote.FullResult =
+        TreeSyncRemote.FullResult.ConnectFailed(CancellationException("stale tree binding"))
 
     private fun ActiveTmuxClients.Entry.matches(params: BoundParams): Boolean =
         hostname == params.hostname &&

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListTreeSyncRemote.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListTreeSyncRemote.kt
@@ -1,0 +1,216 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.ssh.SshLease
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.storage.dao.HostDao
+import com.pocketshell.core.tmux.protocol.ControlEvent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Production transport adapter for [TreeSyncCoordinator]. It keeps SSH/daemon
+ * mechanics out of the coordinator while preserving the existing one-warm-lease
+ * and one-live-client contracts.
+ */
+internal class FolderListTreeSyncRemote(
+    private val gateway: FolderListGateway,
+    private val hostDao: HostDao,
+    private val treeRemoteSource: TreeRemoteSource?,
+    private val sshLeaseManager: SshLeaseManager,
+    private val activeTmuxClients: ActiveTmuxClients?,
+    private val scope: CoroutineScope,
+    private val dispatcher: () -> CoroutineDispatcher,
+    private val warmSessionAwaitMs: () -> Long,
+    private val onWarmSessionAcquired: () -> Unit = {},
+) : TreeSyncRemote {
+    override val hasDurableTree: Boolean get() = treeRemoteSource != null
+
+    private var warmJob: Job? = null
+    private var warmLease: SshLease? = null
+    private val warmSessionReady = kotlinx.coroutines.flow.MutableStateFlow(false)
+    private var boundParams: BoundParams? = null
+
+    override fun events(params: BoundParams): Flow<TreeSyncEvent> {
+        val registry = activeTmuxClients ?: return emptyFlow()
+        return channelFlow {
+            launch {
+                registry.clients
+                    .map { snapshot -> snapshot[params.hostId]?.takeIf { it.matches(params) }?.client }
+                    .distinctUntilChanged()
+                    .collectLatest { client ->
+                        if (client == null) return@collectLatest
+                        client.events
+                            .filter { it is ControlEvent.SessionsChanged }
+                            .collect { send(TreeSyncEvent.SessionsChanged) }
+                    }
+            }
+            launch {
+                registry.clients
+                    .map { snapshot -> snapshot[params.hostId]?.takeIf { it.matches(params) }?.client }
+                    .distinctUntilChanged()
+                    .collectLatest { client ->
+                        if (client == null) return@collectLatest
+                        client.events
+                            .filter { it is ControlEvent.WindowClose }
+                            .collect { event ->
+                                val window = event as ControlEvent.WindowClose
+                                send(TreeSyncEvent.WindowClosed(window.windowId))
+                            }
+                    }
+            }
+            awaitClose { }
+        }
+    }
+
+    override suspend fun ensureWarmConnected(params: BoundParams) {
+        if (boundParams != params) {
+            invalidateWarmStateForHostSwitch()
+            boundParams = params
+        }
+        if (warmLease?.session?.isConnected == true) return
+        val liveClient = activeTmuxClients?.clients?.value?.get(params.hostId)
+            ?.takeIf { it.matches(params) }
+            ?.takeUnless { it.client.disconnected.value }
+        if (liveClient != null) return
+
+        val existing = warmJob
+        if (existing != null && existing.isActive) {
+            existing.join()
+        } else if (warmLease == null && (existing == null || existing.isCancelled)) {
+            val job = scope.launch { replaceWarmLease(params) }
+            warmJob = job
+            job.join()
+        }
+    }
+
+    override suspend fun fullReconcile(
+        params: BoundParams,
+        watchedFolders: List<com.pocketshell.core.storage.entity.ProjectRootEntity>,
+    ): TreeSyncRemote.FullResult {
+        val host = withContext(dispatcher()) { hostDao.getById(params.hostId) }
+            ?: return TreeSyncRemote.FullResult.HostNotFound
+        return when (
+            val result = gateway.listSessionsWithFolder(
+                host = host,
+                keyPath = params.keyPath,
+                passphrase = params.passphrase,
+                watchedRoots = watchedFolders,
+            )
+        ) {
+            is FolderListResult.Sessions -> TreeSyncRemote.FullResult.Sessions(result)
+            FolderListResult.ToolUnavailable -> TreeSyncRemote.FullResult.ToolUnavailable
+            is FolderListResult.Failed -> TreeSyncRemote.FullResult.Failed(result.message)
+            is FolderListResult.ConnectFailed -> TreeSyncRemote.FullResult.ConnectFailed(result.cause)
+        }
+    }
+
+    override suspend fun getTree(params: BoundParams): TreeRemoteSource.TreeResult {
+        val source = treeRemoteSource ?: return TreeRemoteSource.TreeResult.Empty
+        val session = awaitWarmSession(params) ?: return TreeRemoteSource.TreeResult.Empty
+        return source.getTree(session, params.hostName)
+    }
+
+    override suspend fun reconcileTree(params: BoundParams): TreeRemoteSource.ReconcileDelta? {
+        val source = treeRemoteSource ?: return null
+        val session = awaitWarmSession(params) ?: return null
+        return source.reconcileTree(session, params.hostName)
+    }
+
+    override suspend fun upsertTree(
+        params: BoundParams,
+        nodes: List<TreeRemoteSource.TreeNode>,
+    ): Boolean {
+        val source = treeRemoteSource ?: return false
+        val session = awaitWarmSession(params) ?: return false
+        return source.upsertTree(session, params.hostName, nodes)
+    }
+
+    override suspend fun acquireSessionForUpgrade(params: BoundParams): SshSession? {
+        ensureWarmConnected(params)
+        warmLease?.session?.takeIf { it.isConnected }?.let { return it }
+        warmJob?.takeIf { it.isActive }?.join()
+        warmLease?.session?.takeIf { it.isConnected }?.let { return it }
+        replaceWarmLease(params)
+        return warmLease?.session?.takeIf { it.isConnected }
+    }
+
+    override suspend fun releaseWarm() {
+        val lease = warmLease ?: return
+        warmLease = null
+        warmSessionReady.value = false
+        withContext(NonCancellable + dispatcher()) {
+            withTimeoutOrNull(WARM_LEASE_RELEASE_TIMEOUT_MS) { lease.release() }
+        }
+    }
+
+    private suspend fun awaitWarmSession(params: BoundParams): SshSession? {
+        ensureWarmConnected(params)
+        warmLease?.session?.let { return it }
+        val ready = withTimeoutOrNull(warmSessionAwaitMs()) {
+            warmSessionReady.first { it }
+        }
+        return if (ready == true && boundParams == params) warmLease?.session else null
+    }
+
+    /**
+     * A coordinator host switch cancels only its wrapper job. The remote's
+     * bind-time warm job is a sibling in [scope], and its lease must therefore
+     * be invalidated here before the new host can reuse the adapter state.
+     */
+    private suspend fun invalidateWarmStateForHostSwitch() {
+        val previousWarmJob = warmJob
+        warmJob = null
+        previousWarmJob?.cancelAndJoin()
+        releaseWarm()
+    }
+
+    private suspend fun replaceWarmLease(params: BoundParams) {
+        releaseWarm()
+        var acquiredLease: SshLease? = null
+        try {
+            val lease = sshLeaseManager.acquire(params.toSshLeaseTarget()).getOrNull() ?: return
+            acquiredLease = lease
+            onWarmSessionAcquired()
+            withContext(NonCancellable) {
+                if (boundParams != params) return@withContext
+                warmLease = lease
+                acquiredLease = null
+                boundParams = params
+                warmSessionReady.value = true
+            }
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } finally {
+            acquiredLease?.release()
+        }
+    }
+
+    private fun ActiveTmuxClients.Entry.matches(params: BoundParams): Boolean =
+        hostname == params.hostname &&
+            port == params.port &&
+            username == params.username &&
+            keyPath == params.keyPath
+
+    private companion object {
+        const val WARM_LEASE_RELEASE_TIMEOUT_MS: Long = 3_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -188,6 +188,7 @@ class FolderListViewModel internal constructor(
     @androidx.annotation.VisibleForTesting
     internal fun setPeriodicReconcileEnabledForTest(enabled: Boolean) {
         periodicReconcileEnabled = enabled
+        treeSync.setPeriodicEnabledForTest(enabled)
     }
 
     /**
@@ -360,7 +361,7 @@ class FolderListViewModel internal constructor(
             // — D21) and dialing fresh only when there is genuinely no live transport,
             // so it avoids the old `awaitWarmSession() == null` FALSE "Not connected"
             // that contradicted a connected tree + tray. Null ONLY when unreachable.
-            val session = acquireUpgradeSession(params)
+            val session = treeSync.acquireSessionForUpgrade(params)
             if (session == null || bound != params) {
                 cliVersionBanner.setUpdateState(
                     CliVersionUpdateState.Failure(
@@ -376,7 +377,7 @@ class FolderListViewModel internal constructor(
                     // banner; a no-op upgrade (already-newest / unpublished) is
                     // classified from requested vs resolved (#2033), not guessed
                     // as a cap.
-                    recheckHostVersionAfterUpgrade(params, session, result.output)
+                    recheckHostVersionAfterUpgrade(params, result.output)
                 }
                 is HostPocketshellUpgrade.Result.Failure -> {
                     cliVersionBanner.classifyAndApply(
@@ -399,11 +400,9 @@ class FolderListViewModel internal constructor(
      */
     private suspend fun recheckHostVersionAfterUpgrade(
         params: BoundParams,
-        session: SshSession,
         installerOutput: String,
     ) {
-        val source = treeRemoteSource
-        if (source == null) {
+        if (treeRemoteSource == null) {
             // No durable source (some unit paths): trust the exit-0 success and
             // clear the banner so the spinner doesn't stick.
             cliVersionBanner.clearAfterTrustedSuccess()
@@ -413,7 +412,7 @@ class FolderListViewModel internal constructor(
         // wrap the re-check in an OUTER bound too so a future unbounded `getTree`
         // can never leave the banner's spinner stuck (#947 / #944 / #939).
         val treeResult = withTimeoutOrNull(HYDRATE_TIMEOUT_MS) {
-            runCatching { source.getTree(session, params.hostName) }
+            runCatching { treeSync.getTreeForUpgrade(params) }
                 .getOrDefault(TreeRemoteSource.TreeResult.Empty)
         } ?: TreeRemoteSource.TreeResult.Empty
         if (treeResult.cliVersion.isNullOrBlank()) {
@@ -466,7 +465,7 @@ class FolderListViewModel internal constructor(
     val claudeProfiles: StateFlow<List<ClaudeProfile>> = profileDiscovery.claudeProfiles
     val codexProfiles: StateFlow<List<CodexProfile>> = profileDiscovery.codexProfiles
 
-    private val engineDiscovery = FolderListEngineDiscovery(
+    private val engineDiscovery: FolderListEngineDiscovery = FolderListEngineDiscovery(
         enginesGateway = enginesGateway,
         hostDao = hostDao,
         scope = viewModelScope,
@@ -474,40 +473,12 @@ class FolderListViewModel internal constructor(
         isCurrentHost = { hostId -> bound?.hostId == hostId },
         onRefreshApplied = { hostId ->
             bound?.takeIf { it.hostId == hostId }?.let {
-                if (rootSnapshotLoaded) launchReconcile(it)
+                if (rootSnapshotLoaded) treeSync.requestReconcile()
             }
         },
     )
 
     val engines: StateFlow<List<RemoteEngine>> = engineDiscovery.engines
-
-    private var warmJob: Job? = null
-    private var warmReleaseJob: Job? = null
-    private var warmLease: SshLease? = null
-
-    /**
-     * Epic #821 slice C (issue #837): the warm SSH session becomes available
-     * (`true`) once [replaceWarmLease] sets [warmLease]. The cold-start
-     * tree-hydrate coroutine awaits this so it execs `tree.get` over the SAME
-     * warm session the gateway uses (D21 — no new connection). Reset to `false`
-     * on a host change / release.
-     */
-    private val warmSessionReady = MutableStateFlow(false)
-
-    /** Epic #821 slice C: the cold-start tree-hydrate coroutine for this open. */
-    private var hydrateTreeJob: Job? = null
-
-    /**
-     * Issue #1109: the OFF-Main client-cache read coroutine for the cold-MISS
-     * fallback only (the in-memory snapshot was not warmed in time, so [bind]'s
-     * synchronous [peek][TreeClientCache.peek] missed). It reads + parses the file
-     * OFF Main, then hydrates the held tree + emits the advisory paint — the #965
-     * off-Main behaviour, used only on a miss. The cold-start reconcile path awaits
-     * it so the advisory paint lands BEFORE the freshening reconcile (the #867
-     * stale-while-revalidate ordering). `null`/already-completed on the common
-     * warm-hit path (the seed already painted synchronously inside `bind`).
-     */
-    private var clientCacheSeedJob: Job? = null
 
     @androidx.annotation.VisibleForTesting
     internal var warmLeaseAcquiredForTest: (() -> Unit)? = null
@@ -527,22 +498,6 @@ class FolderListViewModel internal constructor(
     @androidx.annotation.VisibleForTesting
     internal var treeDispatcher: CoroutineDispatcher =
         Dispatchers.Default.limitedParallelism(1)
-
-    /**
-     * Issue #702: outer bound on a single [runReconcile] gateway call so NO
-     * gateway path (now or in future) can pin the picker in `Loading` forever.
-     * The gateway already bounds its live `-CC` enumeration (#702) and its
-     * SSH-lease exec reads (#470), but this is the last-line defence at the view
-     * model: if the whole reconcile somehow out-waits those inner bounds, the
-     * picker surfaces a retryable `ConnectError` panel instead of an indefinite
-     * spinner. Generous relative to the sum of the inner bounds (live-enum +
-     * lease enum + agent detection + watched-root expansion) so it only fires on
-     * a true wedge, never on a slow-but-progressing reconcile. Test-overridable.
-     */
-    @androidx.annotation.VisibleForTesting
-    internal var reconcileTimeoutMs: Long = RECONCILE_TIMEOUT_MS
-    private var watchedFoldersJob: Job? = null
-    private var probeJob: Job? = null
 
     /**
      * Issue #965: the most-recent [emitReady] projection coroutine + a monotone
@@ -570,7 +525,6 @@ class FolderListViewModel internal constructor(
      * [launchReconcile], so no second SSH/`-CC` connection is opened and nothing
      * runs while backgrounded.
      */
-    private var sessionsChangedJob: Job? = null
 
     /**
      * Issue #653 / #783: subscription to the bound host's live `tmux -CC` client's
@@ -592,7 +546,6 @@ class FolderListViewModel internal constructor(
      * instant the event arrives. It reuses the warm `-CC` client (D21 — no second
      * connection) and is foreground-gated by [processStarted].
      */
-    private var windowCloseJob: Job? = null
 
     /**
      * Issue #783: the host id the event subscriptions ([sessionsChangedJob] /
@@ -602,7 +555,6 @@ class FolderListViewModel internal constructor(
      * while a host CHANGE tears them down and re-subscribes for the new host.
      * `null` while unbound.
      */
-    private var subscriptionsHost: Long? = null
 
     /**
      * Issue #783: periodic (~5 min) reconcile while the tree screen is composed.
@@ -621,7 +573,6 @@ class FolderListViewModel internal constructor(
      * loop parks at the gate and never runs background SSH work — a foreground
      * heartbeat, not a `Timer`/`WorkManager`/`AlarmManager`.
      */
-    private var periodicReconcileJob: Job? = null
 
     /**
      * EPIC #679 — the maintained in-memory project tree. Held across opens of
@@ -633,9 +584,6 @@ class FolderListViewModel internal constructor(
      * `stableSessionOrder` + `expandedProjectPaths` recompute that this view
      * model used to carry.
      */
-    private val tree = HostTreeModel()
-    private var lastWatchedFolders: List<ProjectRootEntity> = emptyList()
-    private var rootSnapshotLoaded: Boolean = false
     private var lastDiscoveredPorts: List<HostDiscoveredPort> = emptyList()
     private var forwardingSnapshots: Map<Long, ForwardingHostSnapshot> = emptyMap()
     private var sessionRefreshInFlight: Boolean = false
@@ -646,16 +594,7 @@ class FolderListViewModel internal constructor(
      * it until an authoritative session probe succeeds; never let the hint
      * authorize a name-based removal.
      */
-    private var sessionIdentityReconcileRequested: Boolean = false
 
-    private val sessionLifecycleActions = FolderListSessionLifecycleActions(
-        boundHostId = { bound?.hostId },
-        tree = tree,
-        emitReady = ::emitReady,
-        isPolling = { probeJob != null },
-        refresh = ::refresh,
-        requestIdentityReconcile = { sessionIdentityReconcileRequested = true },
-    )
 
     /**
      * Issue #711: count of consecutive QUIET retries the current refresh has
@@ -664,9 +603,6 @@ class FolderListViewModel internal constructor(
      * unrecoverable host eventually surfaces the calm message instead of looping
      * forever. Reset to 0 on any successful reconcile and on a fresh [bind].
      */
-    private var transientRefreshRetries: Int = 0
-    /** Foreground generation observed by the last scheduled resume reconcile. */
-    private var lastResumeGenerationHandled: Long = -1L
 
     /**
      * Issue #430: whole-process foreground signal driven by
@@ -686,8 +622,120 @@ class FolderListViewModel internal constructor(
      * stale `false`.
      */
     private val processStarted = MutableStateFlow(false)
-    private var foregroundGeneration: Long = 0L
     private var lifecycleObserver: LifecycleEventObserver? = null
+
+    private val treeSyncRemote = FolderListTreeSyncRemote(
+        gateway = gateway,
+        hostDao = hostDao,
+        treeRemoteSource = treeRemoteSource,
+        sshLeaseManager = sshLeaseManager,
+        activeTmuxClients = activeTmuxClients,
+        scope = viewModelScope,
+        dispatcher = { ioDispatcher },
+        warmSessionAwaitMs = { TreeSyncCoordinator.DEFAULT_WARM_SESSION_AWAIT_MS },
+        onWarmSessionAcquired = { warmLeaseAcquiredForTest?.invoke() },
+    )
+
+    private val treeSyncListener = object : TreeSyncCoordinator.Listener {
+        override fun onLoadingRequested() {
+            if (_state.value !is FolderListUiState.Ready) {
+                _state.value = folderListLoadingState(bound?.hostId, forwardingSnapshots)
+            }
+        }
+
+        override fun onRefreshingChanged(refreshing: Boolean) {
+            setSessionRefreshInFlight(refreshing)
+        }
+
+        override fun onTreeChanged(synchronous: Boolean) {
+            emitReady(synchronous = synchronous)
+        }
+
+        override fun onReconcileSuccess(result: FolderListResult.Sessions) {
+            lastDiscoveredPorts = InterestingPortFilter.filter(result.discoveredPorts).map { port ->
+                HostDiscoveredPort(remotePort = port.port, process = port.processName)
+            }
+            setSessionRefreshInFlight(false)
+            if (refreshSessionsRequested) completeManualRefresh() else clearRefreshFailure()
+        }
+
+        override fun onReconcileFailure(failure: TreeSyncFailure) {
+            setSessionRefreshInFlight(false)
+            when (failure) {
+                TreeSyncFailure.HostNotFound -> {
+                    _state.value = FolderListUiState.Failed("Host not found.")
+                }
+                is TreeSyncFailure.Failed -> {
+                    if (preserveReadyOnRefresh(REFRESH_FAILED_MESSAGE)) return
+                    _state.value = FolderListUiState.Failed(REFRESH_FAILED_MESSAGE)
+                }
+                TreeSyncFailure.Timeout -> {
+                    val cause = FolderReconcileTimeoutException(reconcileTimeoutMs)
+                    if (preserveReadyOnRefresh(REFRESH_FAILED_MESSAGE)) return
+                    _state.value = FolderListUiState.ConnectError(
+                        message = folderListConnectErrorMessage(cause, REFRESH_FAILED_MESSAGE),
+                        cause = cause,
+                    )
+                }
+                is TreeSyncFailure.ConnectFailed -> {
+                    if (preserveReadyOnRefresh(REFRESH_FAILED_MESSAGE)) return
+                    _state.value = FolderListUiState.ConnectError(
+                        message = folderListConnectErrorMessage(failure.cause, REFRESH_FAILED_MESSAGE),
+                        cause = failure.cause,
+                    )
+                }
+                is TreeSyncFailure.ToolUnavailable -> {
+                    if (preserveReadyOnRefresh("Couldn't refresh sessions: tmux is not installed.")) return
+                    _state.value = FolderListUiState.ToolUnavailable
+                }
+                is TreeSyncFailure.Unexpected -> onUnexpectedFailure(failure.cause)
+            }
+        }
+
+        override fun onUnexpectedFailure(cause: Throwable) {
+            if (bound == null) return
+            if (preserveReadyOnRefresh(REFRESH_FAILED_MESSAGE)) return
+            _state.value = FolderListUiState.ConnectError(
+                message = folderListConnectErrorMessage(cause, REFRESH_FAILED_MESSAGE),
+                cause = cause,
+            )
+        }
+
+        override fun onPayloadCliVersion(version: String) {
+            sessionTreeSetup.maybeRunVersionCheck(version, ::observePayloadCliVersion)
+        }
+    }
+
+    private val treeSync: TreeSyncCoordinator = TreeSyncCoordinator(
+        scope = viewModelScope,
+        remote = treeSyncRemote,
+        cache = treeClientCache,
+        processStarted = processStarted,
+        dispatcher = { ioDispatcher },
+        policy = TreeSyncPolicy(periodicEnabled = periodicReconcileEnabled),
+        awaitBeforeFullReconcile = { params: BoundParams ->
+            engineDiscovery.awaitBindRefresh(params.hostId)
+        },
+        listener = treeSyncListener,
+    )
+
+    private val tree: HostTreeModel get() = treeSync.tree
+    private val rootSnapshotLoaded: Boolean get() = treeSync.rootSnapshotLoaded
+    private val lastWatchedFolders: List<ProjectRootEntity> get() = treeSync.watchedFolders
+
+    private val sessionLifecycleActions = FolderListSessionLifecycleActions(
+        boundHostId = { bound?.hostId },
+        tree = tree,
+        emitReady = ::emitReady,
+        isPolling = { treeSync.isPolling },
+        refresh = ::refresh,
+        requestIdentityReconcile = treeSync::requestIdentityReconcile,
+    )
+
+    @androidx.annotation.VisibleForTesting
+    internal var reconcileTimeoutMs: Long
+        get() = treeSync.policy.reconcileTimeoutMs
+        set(value) { treeSync.policy.reconcileTimeoutMs = value }
 
     init {
         viewModelScope.launch {
@@ -705,16 +753,6 @@ class FolderListViewModel internal constructor(
                 onStale = sessionLifecycleActions::onStale,
                 onIdentityUncertain = sessionLifecycleActions::onIdentityUncertain,
             )
-        }
-        // EPIC #679 requirement #2: reconcile INFREQUENTLY, not on a constant
-        // poll. The tree is held across opens, so a foreground/resume only
-        // triggers a reconcile when the held tree is stale (or never
-        // reconciled). D21-clean: this rides the existing [ProcessLifecycleOwner]
-        // foreground signal, never a Timer/WorkManager/AlarmManager.
-        viewModelScope.launch {
-            processStarted.collect { started ->
-                if (started) maybeReconcileOnResume()
-            }
         }
         // Issue #1155 (Part A): the client-cache PARSED snapshots are warmed into
         // memory ONCE at process startup by [com.pocketshell.app.App.onCreate]
@@ -756,7 +794,7 @@ class FolderListViewModel internal constructor(
         if (tree.removeSession(killed.generation)) {
             emitReady()
         }
-        if (probeJob != null) refresh()
+        if (treeSync.isPolling) refresh()
     }
 
     /** Name-only signals request a probe. */
@@ -846,15 +884,11 @@ class FolderListViewModel internal constructor(
      */
     @androidx.annotation.VisibleForTesting
     internal fun forceTreeStaleForTest() {
-        tree.markReconcileDueForTest()
+        treeSync.forceTreeStaleForTest()
     }
 
     private fun updateProcessStarted(started: Boolean) {
-        val wasStarted = processStarted.value
         processStarted.value = started
-        if (!wasStarted && started) {
-            foregroundGeneration += 1
-        }
     }
 
     /**
@@ -886,8 +920,6 @@ class FolderListViewModel internal constructor(
             keyPath = keyPath,
             passphrase = passphrase,
         )
-        warmReleaseJob?.cancel()
-        warmReleaseJob = null
         // Issue #1509: the single setup pass — folds in the notifications request
         // (the MainActivity.onCreate app-open trigger is deleted, D22).
         sessionTreeSetup.runSetup()
@@ -900,42 +932,20 @@ class FolderListViewModel internal constructor(
         // session screen still prunes the tree, because `stopPolling` no longer
         // cancels these jobs. They reuse the warm `-CC` client (D21, no second
         // connection) and are foreground-gated.
-        ensureBoundHostSubscriptions(params)
         // Issue #783: (re)start the periodic ~5-min reconcile heartbeat for the
         // SHOWN tree. Unlike the event subscriptions it follows the screen
         // lifecycle (cancelled in `stopPolling`), so it is restarted on every
         // tree open. It reuses the screen's own warm lease (no second
         // connection) and is foreground-gated.
-        startPeriodicReconcile(params)
         // EPIC #679 requirement #1: opening the host detail renders the HELD
         // tree INSTANTLY. Re-binding the SAME host reuses the maintained tree
         // (no probe-on-open, no loading flash) and only kicks a reconcile if one
         // is genuinely due (staleness gate). A host CHANGE resets the tree.
-        if (bound == params && !tree.bindHost(hostId)) {
-            // Same host: keep showing the held tree; re-project so a re-entry
-            // reflects any by-id mutation that landed while away, then reconcile
-            // only if stale.
-            if (rootSnapshotLoaded) emitReady()
-            maybeReconcileOnOpen(params)
-            return
-        }
-        probeJob?.cancel()
-        probeJob = null
-        hydrateTreeJob?.cancel()
-        hydrateTreeJob = null
-        clientCacheSeedJob?.cancel()
-        clientCacheSeedJob = null
-        warmSessionReady.value = false
+        val hostChanged = bound != params
         bound = params
         // Issue #1509: host CHANGE re-arms the one-shot version-mismatch check
         // (a same-host re-entry, handled above, keeps a dismissed banner gone).
-        sessionTreeSetup.onHostChanged()
-        tree.bindHost(hostId)
-        rootSnapshotLoaded = false
-        lastWatchedFolders = emptyList()
-        sessionRefreshInFlight = false
-        transientRefreshRetries = 0
-        sessionIdentityReconcileRequested = false
+        if (hostChanged) sessionTreeSetup.onHostChanged()
         // Issue #867 (stale-while-revalidate): paint the last-known tree
         // INSTANTLY from the per-host CLIENT cache before any SSH, so a fresh
         // connect / cold app start no longer flashes the empty rebuild ("No
@@ -964,10 +974,12 @@ class FolderListViewModel internal constructor(
         // the brief Loading + an OFF-Main read, never a Main-thread file read. The
         // cache stays ADVISORY: the silent reconcile overwrites the seeded
         // placeholders in place.
-        if (!hydrateFromClientCache(params)) {
-            _state.value = folderListLoadingState(bound?.hostId, forwardingSnapshots)
-            warmFromClientCacheOffMain(params)
-        }
+        // Start the registry read before binding the coordinator. Its initial
+        // reconcile may start synchronously on an unconfined/test dispatcher,
+        // so the bind-read job must already exist when the ordering barrier is
+        // reached.
+        engineDiscovery.bind(params)
+        treeSync.bind(params, projectRootDao.getByHostId(hostId))
         // The maintained in-memory tree is held across opens of the SAME host
         // (so a re-open renders instantly), the daemon registry (#837) makes the
         // presentation state durable host-side, and this client cache makes the
@@ -979,42 +991,7 @@ class FolderListViewModel internal constructor(
         // The default-only / CLI-missing / fetch-failure cases all collapse to
         // an empty list, so the picker simply shows no profile selector.
         profileDiscovery.refresh(params)
-        engineDiscovery.bind(params)
 
-        warmJob?.cancel()
-        warmJob = viewModelScope.launch {
-            replaceWarmLease(params)
-        }
-        watchedFoldersJob?.cancel()
-        watchedFoldersJob = viewModelScope.launch {
-            projectRootDao.getByHostId(hostId).collectLatest { rows ->
-                lastWatchedFolders = rows
-                tree.setWatchedFolders(rows)
-                val firstSnapshot = !rootSnapshotLoaded
-                rootSnapshotLoaded = true
-                // EPIC #679: a reconcile fires only when one is due. On the very
-                // first watched-folder snapshot the held tree has never been
-                // reconciled, so this kicks the initial probe; afterwards a
-                // watched-folder edit just re-projects (the bucket overlay
-                // changed, the session set did not).
-                if (firstSnapshot) {
-                    // Epic #821 slice C (issue #837): on a cold start of a
-                    // previously-opened host, HYDRATE the held tree from the
-                    // durable registry BEFORE the freshening reconcile so the
-                    // held order + expand/collapse render INSTANTLY (no Loading
-                    // flash, no order shuffle). [hydrateTreeOnColdStart] seeds the
-                    // tree, emits the held shape, and ONLY THEN runs the
-                    // freshening reconcile — so the reconcile never races ahead of
-                    // (and no-ops) the hydrate. Without a durable source it falls
-                    // straight through to the reconcile, exactly as before.
-                    hydrateTreeOnColdStart(params)
-                } else {
-                    // Re-emit so a watched-folder write surfaces immediately,
-                    // mapping sessions into the new root overlay without a probe.
-                    emitReady()
-                }
-            }
-        }
     }
 
     /**
@@ -1039,7 +1016,7 @@ class FolderListViewModel internal constructor(
      * foreground/resume.
      */
     fun refresh() {
-        runReconcileNow()
+        treeSync.requestReconcile()
     }
 
     /**
@@ -1274,8 +1251,7 @@ class FolderListViewModel internal constructor(
             refresh = ::refresh,
             emitReady = ::emitReady,
             onMissingGeneration = {
-                sessionIdentityReconcileRequested = true
-                if (probeJob != null) refresh()
+                treeSync.requestIdentityReconcile()
             },
             onFailure = { message ->
                 _actionStatus.value = FolderActionStatus.Failed(message)
@@ -1355,18 +1331,7 @@ class FolderListViewModel internal constructor(
     }
 
     fun toggleProjectExpanded(projectPath: String) {
-        // EPIC #679: expansion is intrinsic node state on the maintained tree
-        // (#471 collapse-stickiness lives there now). Collapsing a folder pins
-        // it collapsed across reconciles; expanding it restores auto-expand.
-        tree.toggleProjectExpanded(projectPath)
-        emitReady()
-        // Epic #821 slice C (issue #837): persist the new collapse state so a
-        // folder the user collapsed stays collapsed across an app kill +
-        // relaunch. Fire-and-forget over the warm session.
-        bound?.let { persistTree(it) }
-        // Issue #867: mirror the collapse into the CLIENT cache so the next cold
-        // start renders the collapsed folder collapsed without waiting on SSH.
-        bound?.let { persistClientCache(it) }
+        treeSync.toggleProjectExpanded(projectPath)
     }
 
     @androidx.annotation.VisibleForTesting
@@ -1477,951 +1442,11 @@ class FolderListViewModel internal constructor(
     }
 
     /**
-     * EPIC #679 reconcile entry point for an OPEN (bind / first watched-folder
-     * snapshot). Renders the held tree instantly and only kicks a reconcile when
-     * one is genuinely due (the tree was never reconciled, or it is stale past
-     * [HostTreeModel.RECONCILE_STALENESS_MS]). This is requirement #1: no
-     * probe-on-open unless due.
-     */
-    private fun maybeReconcileOnOpen(params: BoundParams) {
-        if (!rootSnapshotLoaded) {
-            if (_state.value !is FolderListUiState.Ready) {
-                _state.value = folderListLoadingState(bound?.hostId, forwardingSnapshots)
-            }
-            return
-        }
-        lastResumeGenerationHandled = foregroundGeneration
-        if (sessionIdentityReconcileRequested) {
-            launchReconcile(params)
-            return
-        }
-        if (tree.reconcileDue(now = System.currentTimeMillis(), staleAfterMs = HostTreeModel.RECONCILE_STALENESS_MS)) {
-            launchReconcile(params)
-        } else {
-            // Fresh held tree — render it immediately, no spinner.
-            emitReady()
-        }
-    }
-
-    /**
-     * EPIC #679 requirement #2 + issue #706: a foreground/resume reconciles the
-     * held tree when it is even mildly stale (older than [RESUME_FRESHEN_MS]),
-     * NOT only past the 15-min held-tree gate. This closes the "created in
-     * another terminal / by an agent while I was away, switch back" case: a real
-     * foreground return freshens the picker within seconds. A rapid in-place
-     * background→foreground bounce (held tree younger than [RESUME_FRESHEN_MS])
-     * still does NOT re-probe, preserving #679's "no constant poll" intent.
-     * D21-clean: rides the [ProcessLifecycleOwner] signal, no background timer.
-     */
-    private fun maybeReconcileOnResume() {
-        val params = bound ?: return
-        if (!rootSnapshotLoaded) return
-        // Only react to a genuine new foreground generation.
-        if (foregroundGeneration == lastResumeGenerationHandled) return
-        lastResumeGenerationHandled = foregroundGeneration
-        if (sessionIdentityReconcileRequested) {
-            launchReconcile(params)
-            return
-        }
-        if (!tree.reconcileDue(now = System.currentTimeMillis(), staleAfterMs = RESUME_FRESHEN_MS)) {
-            return
-        }
-        // Epic #821 slice C (issue #837): on a resume-when-stale, prefer the
-        // CHEAP daemon delta reconcile over a full gateway re-probe when the
-        // durable seam is available — "refresh to see which sessions are gone,
-        // without reloading everything". Added/unavailable deltas fall back to
-        // the full reconcile so new content is fetched. Gone names also use the
-        // full path because a name-only delta cannot safely delete a successor
-        // generation.
-        if (treeRemoteSource != null && tree.hasSnapshot) {
-            reconcileTreeDeltasOnResume(params)
-        } else {
-            launchReconcile(params)
-        }
-    }
-
-    /**
-     * Epic #821 slice C (issue #837): the delta-refresh path. Execs the daemon
-     * `tree.reconcile` over the warm session. Added or unavailable deltas use a
-     * full [launchReconcile] because their content must be fetched. Gone hints
-     * are also escalated to the authoritative probe: the daemon delta currently
-     * carries names only, and a name cannot authorize deletion of a same-name
-     * successor generation.
-     */
-    private fun reconcileTreeDeltasOnResume(params: BoundParams) {
-        val source = treeRemoteSource ?: run { launchReconcile(params); return }
-        viewModelScope.launch {
-            processStarted.first { it }
-            val session = warmLease?.session ?: awaitWarmSession()
-            if (session == null) {
-                if (bound == params) launchReconcile(params)
-                return@launch
-            }
-            if (bound != params) return@launch
-            val delta = withTimeoutOrNull(reconcileTimeoutMs + 1_000L) {
-                source.reconcileTree(session, params.hostName)
-            }
-            if (bound != params) return@launch
-            // Issue #885/#1509: the reconcile payload also carries the version, so
-            // the one-shot check still fires when `tree get` returned an empty
-            // seed — still gated to ONCE per open (no re-raise on later polls).
-            sessionTreeSetup.maybeRunVersionCheck(delta?.cliVersion) {
-                observePayloadCliVersion(it)
-            }
-            if (delta == null || delta.added.isNotEmpty()) {
-                // Unavailable or new sessions appeared → full probe.
-                launchReconcile(params)
-                return@launch
-            }
-            // A daemon delta currently identifies gone rows by display name.
-            // That is insufficient to authorize destructive mutation because a
-            // same-name successor may already be live.  Use the authoritative
-            // probe path for every gone hint; HostTreeModel then applies exact
-            // generation replacement/removal semantics.
-            if (delta.gone.isNotEmpty()) {
-                launchReconcile(params)
-            }
-        }
-    }
-
-    /**
-     * Epic #821 slice C (issue #837): seed the held tree from the durable
-     * host-side registry on a cold start, BEFORE the freshening reconcile, so
-     * the held order + expand/collapse render INSTANTLY (no Loading flash, no
-     * order shuffle). Awaits the warm session (bounded), execs `tree.get` over
-     * it (D21 — no new connection), hydrates the [HostTreeModel], and emits the
-     * seeded tree immediately. A no-op when there is no [treeRemoteSource]
-     * (unit tests) or no persisted nodes (a genuinely new host stays
-     * empty-until-probe, exactly as before). [HostTreeModel.hydrate] itself
-     * skips clobbering an already-populated tree, so a reconcile that beat the
-     * hydrate is never overwritten.
-     *
-     * ## Fail-safe: the hydrate NEVER gates connect (issue #847)
-     *
-     * The hydrate is a pure PRESENTATION optimisation (instant held order +
-     * collapse). The freshening reconcile is what actually POPULATES the tree
-     * and clears "loading tree". v0.4.10 shipped a release-breaking regression
-     * (#847): on a host whose `pocketshell` CLI is OLDER than the client (no
-     * `tree` subcommand), the hydrate's `tree get` errored, and because the
-     * freshening reconcile was CHAINED AFTER the hydrate with NO bound on the
-     * `tree get`, a slow/failed/wedged `tree get` left the reconcile un-run and
-     * the screen pinned on "loading tree" forever — the app would not connect.
-     *
-     * The fix keeps the hydrate-BEFORE-reconcile ordering (so a successful
-     * `tree get` still seeds the held order + collapse memory before the
-     * reconcile lands — the #837 durability contract, see
-     * [FolderListViewModelTreeDurabilityTest]) but makes it FAIL-SAFE:
-     *  - the hydrate body (warm-session await + `tree get` + parse) is BOUNDED
-     *    by [HYDRATE_TIMEOUT_MS], so a wedged/never-returning old-CLI `tree get`
-     *    can no longer suspend the coroutine forever; and
-     *  - the freshening reconcile runs in a `finally`, so it ALWAYS fires —
-     *    whether the hydrate seeded, returned nothing, errored, or timed out —
-     *    and connect can never hang behind `tree get`.
-     * `getTree` is itself exit-code-guarded + catch-all, so a missing/old/
-     * erroring CLI yields an empty seed promptly and the `finally` reconcile
-     * runs without delay; the timeout is the last-line defence for a true wedge.
-     *
-     * NO POLLING: this runs ONCE per cold-start open.
-     */
-    private fun hydrateTreeOnColdStart(params: BoundParams) {
-        val source = treeRemoteSource
-        if (source == null) {
-            // No durable source (unit tests / never-installed daemon): on the common
-            // warm-HIT path the synchronous client-cache seed (#1109) already painted
-            // the advisory instant tree within bind(), so [clientCacheSeedJob] is null
-            // and this falls straight through. On a cold MISS it awaits the OFF-Main
-            // seed (#965) so its advisory paint lands BEFORE the freshening reconcile
-            // (the #867 stale-while-revalidate ordering), then reconciles.
-            viewModelScope.launch {
-                clientCacheSeedJob?.join()
-                if (bound != params) return@launch
-                maybeReconcileOnOpen(params)
-            }
-            return
-        }
-        hydrateTreeJob?.cancel()
-        hydrateTreeJob = viewModelScope.launch {
-            // On a cold MISS await the OFF-Main client-cache seed so its advisory
-            // paint precedes the durable hydrate + freshening reconcile (#965/#867);
-            // null/already-complete on the synchronous warm-hit path (#1109).
-            clientCacheSeedJob?.join()
-            if (bound != params) return@launch
-            // Foreground-gated, mirroring the reconcile path (D21-clean).
-            processStarted.first { it }
-            var hostChanged = false
-            try {
-                // Bound the best-effort seed so a wedged/old host CLI can't keep
-                // this coroutine alive: a missing `tree` command, a parse failure,
-                // or a never-returning exec all collapse to "no seed", and the
-                // `finally` reconcile below is the authoritative tree.
-                withTimeoutOrNull(HYDRATE_TIMEOUT_MS) {
-                    val session = awaitWarmSession() ?: return@withTimeoutOrNull
-                    if (bound != params) {
-                        hostChanged = true
-                        return@withTimeoutOrNull
-                    }
-                    // `getTree` returns an empty list for a missing/old/erroring
-                    // CLI and never throws except on cancellation. Run it in a
-                    // CHILD coroutine on [ioDispatcher] so a TRUE wedge (the #470
-                    // blocking stdout read inside `exec`, which a plain
-                    // `withTimeout` can't interrupt because the read sits in a
-                    // non-cancellable `Dispatchers.IO` block) is still bounded:
-                    // when [HYDRATE_TIMEOUT_MS] expires the parent is cancelled at
-                    // `await()` — a real suspension point — and the orphaned read
-                    // is reaped with the warm lease. In unit tests [ioDispatcher]
-                    // is the virtual test dispatcher, so a fast `getTree` resolves
-                    // synchronously and the hydrate-before-reconcile ordering is
-                    // preserved (the #837 durability contract).
-                    val treeResult = withTimeoutOrNull(HYDRATE_TIMEOUT_MS) {
-                        async(ioDispatcher) { source.getTree(session, params.hostName) }.await()
-                    } ?: return@withTimeoutOrNull
-                    if (bound != params) {
-                        hostChanged = true
-                        return@withTimeoutOrNull
-                    }
-                    // Issue #885/#1509: passive host-CLI-version check, gated to
-                    // run EXACTLY ONCE per session-tree open (the single lazy
-                    // background check, never an app-open trigger).
-                    sessionTreeSetup.maybeRunVersionCheck(treeResult.cliVersion) {
-                        observePayloadCliVersion(it)
-                    }
-                    val nodes = treeResult.nodes
-                    if (nodes.isNotEmpty()) {
-                        tree.hydrate(nodes.map { it.toHydratedNode() })
-                        // Render the seeded order/collapse immediately — instant
-                        // held shape, no Loading flash, BEFORE the reconcile.
-                        if (rootSnapshotLoaded) emitReady()
-                    }
-                }
-            } finally {
-                // Issue #847: the freshening reconcile is the load-bearing step —
-                // it populates the tree and clears "loading tree", so it MUST fire
-                // whether the hydrate seeded, no-op'd, errored, or timed out. Skip
-                // only when the host actually changed (a new bind drives its own
-                // hydrate/reconcile) or this job was cancelled.
-                if (!hostChanged && bound == params) maybeReconcileOnOpen(params)
-            }
-        }
-    }
-
-    /**
-     * Issue #867 (stale-while-revalidate) + #1109 (instant-render restore) + #965
-     * (ANR off-Main): seed the held tree from the per-host CLIENT cache and emit
-     * Ready SYNCHRONOUSLY on the calling (Main) thread, so a cold connect's FIRST
-     * painted frame is already the last-known tree — NO Loading flash. Returns
-     * `true` when a WARMED snapshot seeded a non-empty tree (the caller then skips
-     * the Loading emit) and `false` on a cold MISS (the snapshot was not warmed in
-     * time / no cache yet) — the caller then shows the brief Loading and reads OFF
-     * Main via [warmFromClientCacheOffMain].
-     *
-     * ## How it is synchronous WITHOUT a Main-thread `disk_read` (the #965 fix held)
-     *
-     * The expensive part — the file read + full `JSONObject` parse — is DECOUPLED
-     * from the hydrate. It runs OFF Main (the init pre-warm [TreeClientCache.warmAll]
-     * + each reconcile's [persistClientCache] write) into [TreeClientCache]'s
-     * in-memory PARSED snapshot. This method reads that already-parsed snapshot via
-     * [TreeClientCache.peek] — a pure in-memory lookup, NO disk I/O — and hydrates +
-     * projects it inline. So Main does ZERO file reads here (the StrictMode tripwire
-     * in [FolderListScaleAnrStrictModeDockerTest] stays green at 71/12 scale), yet
-     * the seed is fully synchronous (the instant render in
-     * [FolderListClientCacheInstantRenderDockerTest] stays green). The one-time inline
-     * `buildFolderTree` projection is bounded and the row VIRTUALIZATION restored by
-     * #965 keeps the first composition cheap; the REPEATED reconcile-driven emits
-     * still run the projection off Main (see [emitReady]).
-     *
-     * The cache stays ADVISORY: [HostTreeModel.hydrate]/[hydrateStructure]
-     * self-guard against clobbering an already-populated (fresher, authoritative)
-     * tree, and the silent reconcile overwrites the seeded placeholders + the
-     * structural maps wholesale, so a stale cache entry can never survive the
-     * first refresh (#679 stale-type guard, D22).
-     */
-    private fun hydrateFromClientCache(params: BoundParams): Boolean {
-        val cache = treeClientCache ?: return false
-        // SYNCHRONOUS, NO disk I/O on Main: the in-memory parsed snapshot only.
-        val cached = cache.peek(params.hostName) ?: return false
-        if (cached.isEmpty) return false
-        if (!applyCachedTree(cached)) return false
-        // Render the seeded order / placement / collapse + grouping INLINE — the
-        // held shape on the FIRST frame, no empty-rebuild flash. The confirmed
-        // kinds + the authoritative session set arrive with the first reconcile
-        // and update in place.
-        emitReady(synchronous = true)
-        return true
-    }
-
-    /**
-     * Issue #1109 cold-MISS fallback (the #965 off-Main path): the in-memory snapshot
-     * was not warmed before [bind] ran, so read + parse the per-host cache file OFF
-     * Main on [ioDispatcher], then hydrate the held tree + emit the advisory paint.
-     * Used ONLY on a [hydrateFromClientCache] miss — never on Main. The cold-start
-     * reconcile path joins [clientCacheSeedJob] so this advisory paint precedes the
-     * freshening reconcile (the #867 stale-while-revalidate ordering). A stale read
-     * (host changed mid-flight) is dropped.
-     */
-    private fun warmFromClientCacheOffMain(params: BoundParams) {
-        val cache = treeClientCache ?: return
-        clientCacheSeedJob?.cancel()
-        clientCacheSeedJob = viewModelScope.launch {
-            val cached = withContext(ioDispatcher) {
-                runCatching { cache.read(params.hostName) }
-                    .getOrDefault(TreeClientCache.CachedTree(nodes = emptyList()))
-            }
-            if (bound != params) return@launch
-            if (cached.isEmpty) return@launch
-            if (!applyCachedTree(cached)) return@launch
-            // AWAIT the (off-Main) projection so the advisory paint is on screen
-            // BEFORE this seed job completes — the cold-start reconcile path joins
-            // this job, so this is what preserves the #867 ordering across the hop.
-            emitReady()
-            emitJob?.join()
-        }
-    }
-
-    /**
-     * Hydrate the held tree from a (warmed or freshly-read) [TreeClientCache.CachedTree]
-     * — the watched-root overlay + the structural maps + the per-session nodes.
-     * Shared by the synchronous seed ([hydrateFromClientCache]) and the off-Main
-     * cold-miss fallback ([warmFromClientCacheOffMain]). Pure in-memory tree
-     * mutation (no I/O), so it is safe on either thread. Returns whether the tree now
-     * has a renderable snapshot.
-     */
-    private fun applyCachedTree(cached: TreeClientCache.CachedTree): Boolean {
-        // Issue #867 (REOPEN): seed the watched-root overlay + the structural maps
-        // the grouping needs BEFORE the per-session hydrate's emit, so the
-        // cold-start frame shows the SETTLED tree — sessions bucketed under their
-        // watched root, the project subfolders + counts visible — not "0 projects"
-        // with everything dumped into "Other folders". The authoritative Room
-        // `project_roots` Flow overwrites the seeded watched folders the moment it
-        // emits (advisory), and the first reconcile overwrites the structural maps
-        // wholesale.
-        if (cached.watchedFolders.isNotEmpty()) {
-            tree.setWatchedFolders(cached.watchedFolders)
-        }
-        // Hydrate the per-session nodes FIRST (populates `sessionFolderPaths`),
-        // then the structure — so [HostTreeModel.hydrateStructure]'s sticky-bucket
-        // seed sees the sessions and can place them under their root by id.
-        tree.hydrate(cached.nodes.map { it.toHydratedNode() })
-        tree.hydrateStructure(
-            resolvedWatchedRootPaths = cached.resolvedWatchedRootPaths,
-            scannedProjectFoldersByRoot = cached.scannedProjectFoldersByRoot,
-            historyProjectFoldersByRoot = cached.historyProjectFoldersByRoot,
-        )
-        return tree.hasSnapshot
-    }
-
-    /**
-     * Issue #867: persist the current tree state to the per-host CLIENT cache so
-     * the NEXT cold start renders instantly. Fire-and-forget on a background
-     * dispatcher; mirrors [persistTree]'s host-side upsert but to the local
-     * advisory cache. A no-op without a [treeClientCache]; an empty tree deletes
-     * the cache file.
-     */
-    private fun persistClientCache(params: BoundParams) {
-        val cache = treeClientCache ?: return
-        // Issue #867 (REOPEN): snapshot the FULL presentation shape — the session
-        // nodes PLUS the watched-root overlay + the structural maps — so the next
-        // cold start can reproduce the SETTLED grouping instantly (sessions under
-        // their root, project counts), not just the flat session list.
-        val structure = tree.exportStructure()
-        val cached = TreeClientCache.CachedTree(
-            nodes = tree.exportNodes().map { it.toTreeNode() },
-            watchedFolders = lastWatchedFolders,
-            resolvedWatchedRootPaths = structure.resolvedWatchedRootPaths,
-            scannedProjectFoldersByRoot = structure.scannedProjectFoldersByRoot,
-            historyProjectFoldersByRoot = structure.historyProjectFoldersByRoot,
-        )
-        viewModelScope.launch(ioDispatcher) {
-            runCatching { cache.write(params.hostName, cached) }
-        }
-    }
-
-    /**
-     * Epic #821 slice C (issue #837): fire-and-forget persist of the current
-     * tree state (order + folder paths + collapse memory + foreign-guess) to the
-     * durable registry after a mutation (toggle-expanded, reconcile). Execs
-     * `tree.upsert` over the warm session. A no-op without a [treeRemoteSource];
-     * any failure is swallowed (the tree is still correct in memory; the next
-     * mutation re-persists).
-     */
-    private fun persistTree(params: BoundParams) {
-        val source = treeRemoteSource ?: return
-        val nodes = tree.exportNodes()
-        if (nodes.isEmpty()) return
-        viewModelScope.launch {
-            val session = warmLease?.session ?: awaitWarmSession() ?: return@launch
-            if (bound != params) return@launch
-            withTimeoutOrNull(HYDRATE_TIMEOUT_MS) {
-                source.upsertTree(
-                    session = session,
-                    host = params.hostName,
-                    nodes = nodes.map { it.toTreeNode() },
-                )
-            }
-        }
-    }
-
-    /**
-     * Await the warm SSH session for a bounded window. Returns the live session
-     * once [replaceWarmLease] has acquired it, or `null` if it does not appear
-     * in time (so a hydrate/persist that loses the connect race simply skips —
-     * the tree stays correct, the next probe/mutation re-seeds/re-persists).
-     */
-    private suspend fun awaitWarmSession(): SshSession? {
-        warmLease?.session?.let { return it }
-        val ready = withTimeoutOrNull(WARM_SESSION_AWAIT_MS) {
-            warmSessionReady.first { it }
-        }
-        return if (ready == true) warmLease?.session else null
-    }
-
-    /**
-     * Issue #1157: resolve a LIVE session for the host-CLI upgrade WITHOUT
-     * dead-ending on a possibly-absent/expired warm lease.
-     *
-     * The upgrade banner runs over the FolderList's warm-lease session, which is
-     * SEPARATE from the live terminal sessions. On device the warm lease is
-     * released when the user leaves this screen ([stopPolling] → [scheduleWarmRelease])
-     * and can also go stale on a network handoff — yet the host stays genuinely
-     * connected because the live terminal sessions keep the pooled transport open.
-     * The old path (`awaitWarmSession()`) returned null (no warm lease) or a
-     * DISCONNECTED stale session, so tapping Retry surfaced a FALSE
-     * "Not connected — reconnect and try again." that contradicted the tree
-     * ("13 active") and the tray.
-     *
-     * This resolves a session robustly and D21-cleanly:
-     *  1. A still-live warm session is reused AS-IS — no new connect.
-     *  2. A bind-time warm connect in flight ([warmJob]) is joined rather than
-     *     racing a second dial.
-     *  3. Otherwise [replaceWarmLease] re-acquires from the SHARED
-     *     [sshLeaseManager]. `acquire` REUSES the live pooled transport (the one
-     *     the live terminal sessions hold — refcount, NO new connect) when one
-     *     exists, and only dials fresh when there is genuinely no live transport.
-     *
-     * Returns a connected session, or null ONLY when the host is truly
-     * unreachable — the caller then surfaces a TRUTHFUL "couldn't reach" message,
-     * never a false "not connected" while sessions are live.
-     */
-    private suspend fun acquireUpgradeSession(params: BoundParams): SshSession? {
-        // 1. Reuse a still-live warm session as-is (D21 — no new connect).
-        warmLease?.session?.takeIf { it.isConnected }?.let { return it }
-        // 2. Join a bind-time warm connect already in flight rather than dial twice.
-        warmJob?.takeIf { it.isActive }?.join()
-        warmLease?.session?.takeIf { it.isConnected }?.let { return it }
-        if (bound != params) return null
-        // 3. Warm lease genuinely absent or expired while the host may still be
-        //    connected (live terminal sessions over the shared pool). Re-acquire —
-        //    a live pooled transport is REUSED (refcount, no new connect); only a
-        //    truly poolless host dials fresh, and a truly unreachable one fails.
-        replaceWarmLease(params)
-        return warmLease?.session?.takeIf { it.isConnected }
-    }
-
-    /**
-     * Issue #847: establish the warm SSH connection BEFORE the bounded
-     * enumeration in [runReconcile], so the cold sshj dial (≤ the lease
-     * manager's ~35s connect timeout) is NOT charged against the 12s
-     * enumeration budget. This is the structural fix for the v0.4.10/v0.4.11
-     * "Session list didn't load within 12000ms" connect break: when the
-     * bootstrap "Host setup needed" sheet is dismissed via Skip its warm
-     * `warm-host-connect` lease is released, so the first reconcile would need a
-     * FRESH cold dial — and that dial, wrapped by the 12s enumeration bound,
-     * blew the budget on a real/slow network and surfaced the spurious error
-     * even though the host was connectable.
-     *
-     * Fast paths (no behaviour change for the healthy / warm-reuse case):
-     * - a still-connected warm lease is reused immediately;
-     * - a live `-CC` control client makes the enumeration leaseless, so we do
-     *   not block on a lease the gateway won't open.
-     *
-     * Otherwise we drive [replaceWarmLease] (re-using the in-flight bind-time
-     * [warmJob] when present) and await its completion. The acquire's own
-     * connect timeout bounds it — a slow-but-valid connect succeeds and the
-     * gateway acquire inside the enumeration window is then a fast REUSE of the
-     * live transport. A genuine connect failure completes [warmJob] promptly
-     * (no warm lease), and the bounded enumeration below opens its own lease and
-     * surfaces an honest retryable connect error — never a spurious 12s timeout
-     * on a connectable host.
-     */
-    private suspend fun ensureWarmConnectForReconcile(params: BoundParams) {
-        if (warmLease?.session?.isConnected == true) return
-        // A live `-CC` client serves the enumeration without a lease (the
-        // gateway's [listSessionRowsFromLiveClient] fast path), so there is
-        // nothing to pre-connect — don't block the leaseless path.
-        val liveClient = activeTmuxClients?.clients?.value?.get(params.hostId)
-            ?.takeIf { it.matches(params) }
-            ?.takeUnless { it.client.disconnected.value }
-        if (liveClient != null) return
-        val existing = warmJob
-        if (existing != null && existing.isActive) {
-            // Re-use the bind-time connect already in flight (the dominant case
-            // on a fresh open / after a bootstrap-Skip re-bind, which launches a
-            // fresh [warmJob] before this reconcile runs). Its acquire is bounded
-            // by the lease manager's OWN connect timeout (~35s), NOT the 12s
-            // enumeration budget — so a slow-but-valid cold dial completes here,
-            // OUTSIDE the window, and the gateway acquire below is then a fast
-            // REUSE. A connect failure also completes the job promptly (no warm
-            // lease), and the bounded enumeration surfaces the honest error.
-            existing.join()
-        } else if (warmLease == null && (existing == null || existing.isCancelled)) {
-            // No warm lease, and the bind-time connect is absent or was CANCELLED
-            // (not merely failed): drive ONE fresh acquire OUTSIDE the
-            // enumeration window so a slow cold dial isn't charged to the 12s
-            // budget. A connect that already RAN and failed is NOT retried here —
-            // the bounded enumeration's own gateway acquire surfaces the honest
-            // retryable connect error, and re-dialing would just waste a handshake
-            // and (worse) consume virtual time before the window opens.
-            val job = viewModelScope.launch { replaceWarmLease(params) }
-            warmJob = job
-            job.join()
-        }
-    }
-
-    /**
-     * Issue #706: subscribe the held tree to the bound host's live `tmux -CC`
-     * client's `%sessions-changed` (ControlEvent.SessionsChanged) event and treat
-     * it as a DEBOUNCED, foreground-only reconcile trigger. This is the core fix
-     * for the out-of-band-session gap: a session created/killed outside the app
-     * (another terminal, an agent spawning one) emits `%sessions-changed` on the
-     * already-open control channel, which here schedules a debounced reconcile so
-     * the new/dead row appears within seconds — instead of staying invisible
-     * until the 15-min staleness gate or a manual pull-to-refresh.
-     *
-     * D21-clean: NO poll, NO Timer/AlarmManager/WorkManager. It rides the
-     * existing hot `-CC` event bus (the SAME `%sessions-changed`
-     * [TmuxSessionViewModel]/[SessionsDashboardViewModel] already consume) and
-     * the reconcile itself is foreground-gated inside [launchReconcile]
-     * (`processStarted.first { it }`), so nothing runs while backgrounded.
-     *
-     * Tracks [ActiveTmuxClients.clients] with [collectLatest] so the
-     * subscription always follows the live client for [params]'s host: if the
-     * client (re)registers (a reconnect), the event collector re-attaches to the
-     * fresh client; if it deregisters, the inner collector is cancelled and we
-     * idle until one reappears. [debounce] coalesces a `%sessions-changed` burst
-     * into one reconcile.
-     */
-    @OptIn(kotlinx.coroutines.FlowPreview::class)
-    private fun startSessionsChangedSubscription(params: BoundParams) {
-        val registry = activeTmuxClients ?: return
-        sessionsChangedJob?.cancel()
-        sessionsChangedJob = viewModelScope.launch {
-            registry.clients
-                .map { snapshot -> snapshot[params.hostId]?.takeIf { it.matches(params) }?.client }
-                .distinctUntilChanged()
-                .collectLatest { client ->
-                    if (client == null) return@collectLatest
-                    client.events
-                        .filter { it is ControlEvent.SessionsChanged }
-                        .debounce(SESSIONS_CHANGED_DEBOUNCE_MS)
-                        .collect {
-                            // Only react while this host is still the bound one and
-                            // the tree is initialised. The reconcile is itself
-                            // foreground-gated inside launchReconcile.
-                            if (bound == params && rootSnapshotLoaded) {
-                                launchReconcile(params)
-                            }
-                        }
-                }
-        }
-    }
-
-    /**
-     * Issue #706: does this live-client registry entry describe the SAME host
-     * connection as [params]? Mirrors the gateway's
-     * `ActiveTmuxClients.Entry.matches` (host/port/user/keyPath) so the
-     * `%sessions-changed` subscription only fires for the host actually shown,
-     * never a same-id-but-different-credential entry.
-     */
-    private fun ActiveTmuxClients.Entry.matches(params: BoundParams): Boolean =
-        hostname == params.hostname &&
-            port == params.port &&
-            username == params.username &&
-            keyPath == params.keyPath
-
-    /**
-     * Issue #653: subscribe the held tree to the bound host's live `tmux -CC`
-     * client's `%window-close @<id>` event ([ControlEvent.WindowClose]) and treat
-     * it as a DIRECT, by-id window prune. When a single tmux window is closed
-     * remotely (another terminal, an agent, a `kill-window`) while its session
-     * stays alive, tmux emits `%window-close @<id>` on the already-open control
-     * channel; this drops exactly that window node from the maintained tree
-     * ([HostTreeModel.removeWindow]) — sibling windows and the parent session
-     * keep their slots — and re-projects, INCREMENTALLY, with no full reconcile.
-     *
-     * The whole-session analogue is [startSessionsChangedSubscription]; a window
-     * close that takes the session's last window also surfaces as
-     * `%sessions-changed`, which that path prunes as a whole session. There is NO
-     * debounce here: each `%window-close` carries a distinct id, so coalescing a
-     * burst would risk dropping one of several simultaneous closes — each prune
-     * is a cheap in-place mutation, so they are applied one-for-one.
-     *
-     * D21-clean: NO poll, NO Timer/AlarmManager/WorkManager. It rides the same
-     * hot `-CC` event bus as `%sessions-changed`, follows the live client with
-     * [collectLatest] across reconnects, and only mutates while the app is
-     * foregrounded ([processStarted]) and this host is still bound — so nothing
-     * runs while backgrounded.
-     */
-    private fun startWindowCloseSubscription(params: BoundParams) {
-        val registry = activeTmuxClients ?: return
-        windowCloseJob?.cancel()
-        windowCloseJob = viewModelScope.launch {
-            registry.clients
-                .map { snapshot -> snapshot[params.hostId]?.takeIf { it.matches(params) }?.client }
-                .distinctUntilChanged()
-                .collectLatest { client ->
-                    if (client == null) return@collectLatest
-                    client.events
-                        .filterIsInstance<ControlEvent.WindowClose>()
-                        .collect { event ->
-                            // Only mutate while this host is still bound, the tree
-                            // is initialised, and the app is foregrounded (D21).
-                            if (bound == params && rootSnapshotLoaded && processStarted.value) {
-                                if (tree.removeWindow(event.windowId)) {
-                                    emitReady()
-                                }
-                            }
-                        }
-                }
-        }
-    }
-
-    /**
-     * Issue #783: (re)bind the bound-host EVENT subscriptions
-     * ([startSessionsChangedSubscription] / [startWindowCloseSubscription]) for
-     * [params]'s host.
-     *
-     * Idempotent per host: a same-host re-bind (returning to the tree screen)
-     * keeps the already-running subscriptions, so there is NO restart gap in
-     * which a `%window-close` / `%sessions-changed` could fall on a cancelled
-     * collector. A host CHANGE tears the old subscriptions down and starts fresh
-     * ones for the new host. Tied to the bound-host warm-lease lifetime — NOT
-     * `FolderListScreen` composition — so the prune survives `stopPolling`.
-     *
-     * NOTE: the periodic reconcile heartbeat ([startPeriodicReconcile]) is NOT
-     * part of this — it follows the SCREEN lifecycle ([bind]/[stopPolling]), see
-     * its docs.
-     */
-    private fun ensureBoundHostSubscriptions(params: BoundParams) {
-        if (subscriptionsHost == params.hostId &&
-            sessionsChangedJob?.isActive == true &&
-            windowCloseJob?.isActive == true
-        ) {
-            // Same host, both subscriptions live — keep them so a return to the
-            // tree screen doesn't reopen the dead-collector window.
-            return
-        }
-        startSessionsChangedSubscription(params)
-        startWindowCloseSubscription(params)
-        subscriptionsHost = params.hostId
-    }
-
-    /**
-     * Issue #783: tear down the bound-host EVENT subscriptions. Called on a host
-     * change (before re-subscribing) and from [onCleared]. NOT called from
-     * [stopPolling] — that is the whole point: the subscriptions outlive screen
-     * composition so a `%window-close` while the user is on the session screen
-     * still prunes the tree. (The periodic heartbeat is cancelled separately by
-     * [stopPolling]/[onCleared].)
-     */
-    private fun tearDownBoundHostSubscriptions() {
-        sessionsChangedJob?.cancel()
-        sessionsChangedJob = null
-        windowCloseJob?.cancel()
-        windowCloseJob = null
-        subscriptionsHost = null
-    }
-
-    /**
-     * Issue #783: start the periodic (~5 min) reconcile heartbeat for the SHOWN
-     * tree screen. Started in [bind] and cancelled in [stopPolling] (screen
-     * dispose) / [onCleared] — it follows the screen, not the bound-host event
-     * subscriptions, because it is a freshness net for the tree the user is
-     * looking at and reuses the screen's own warm lease (no second connection).
-     *
-     * D21-clean: each tick's reconcile is gated on the foreground signal inside
-     * [launchReconcile] (`processStarted.first { it }`), so while backgrounded the
-     * loop parks at the gate and performs no SSH work — a foreground heartbeat,
-     * not a `Timer`/`WorkManager`/`AlarmManager`.
-     */
-    private fun startPeriodicReconcile(params: BoundParams) {
-        periodicReconcileJob?.cancel()
-        periodicReconcileJob = null
-        // Issue #783: disabled for the bare internal constructor (most unit
-        // tests) so a directly-constructed VM that never calls `stopPolling`
-        // does not leave an infinite `delay`-loop for `runTest` to chase.
-        if (!periodicReconcileEnabled) return
-        periodicReconcileJob = viewModelScope.launch {
-            while (true) {
-                delay(PERIODIC_RECONCILE_MS)
-                if (bound != params || !rootSnapshotLoaded) continue
-                // launchReconcile is itself foreground-gated, so a tick that
-                // fires while backgrounded suspends at the gate instead of
-                // probing a dead lease.
-                launchReconcile(params)
-            }
-        }
-    }
-
-    /**
-     * Force a reconcile NOW regardless of staleness — the explicit
-     * pull-to-refresh swipe (requirement #4), error-panel retry, and the
-     * post-app-action confirmation. Gated only on the foreground signal (D21).
-     */
-    private fun runReconcileNow() {
-        val params = bound ?: return
-        if (!rootSnapshotLoaded) {
-            if (_state.value !is FolderListUiState.Ready) {
-                _state.value = folderListLoadingState(bound?.hostId, forwardingSnapshots)
-            }
-            return
-        }
-        launchReconcile(params)
-    }
-
-    private fun launchReconcile(params: BoundParams) {
-        probeJob?.cancel()
-        probeJob = viewModelScope.launch {
-            if (_state.value !is FolderListUiState.Ready) {
-                _state.value = folderListLoadingState(bound?.hostId, forwardingSnapshots)
-            }
-            // D21 / #430: gate the reconcile on the whole-process foreground
-            // signal. While backgrounded this suspends (no background SSH work);
-            // it releases on the next ON_START.
-            processStarted.first { it }
-            setSessionRefreshInFlight(true)
-            // Issue #939 (audit #935 S5-1): [runReconcile] sets
-            // `sessionRefreshInFlight = true` then runs an unguarded suspend body
-            // (`tree.reconcile`, `persistTree`/`persistClientCache`, the
-            // `hostDao.getById` Room read, the gateway enumeration). Before this
-            // guard, ANY throw between the flag set and one of `runReconcile`'s
-            // explicit `setSessionRefreshInFlight(false)` clears escaped without
-            // ever releasing the flag — the cold-launch session-picker refresh
-            // bar then spun FOREVER with no error band, and the in-flight guard at
-            // [setSessionRefreshInFlight] made a re-tap a no-op (the user could
-            // not retry without leaving + re-binding the host). The `finally`
-            // guarantees the flag is released on EVERY exit (success, handled
-            // failure, OR an unexpected throw); the `catch` surfaces a retryable
-            // error so the picker is escapable instead of silently wedged.
-            // CancellationException (stopPolling / host change / onCleared) is
-            // rethrown so structured cancellation is preserved.
-            try {
-                runReconcile(params)
-            } catch (cancellation: CancellationException) {
-                throw cancellation
-            } catch (t: Throwable) {
-                surfaceUnexpectedReconcileFailure(params, t)
-            } finally {
-                // Idempotent: the `when` arms in [runReconcile] already clear the
-                // flag on every normal exit, and [setSessionRefreshInFlight]
-                // no-ops when it is already false. This `finally` is the backstop
-                // for the throwing paths only.
-                setSessionRefreshInFlight(false)
-            }
-        }
-    }
-
-    /**
-     * Issue #939 (audit #935 S5-1): an UNEXPECTED throw inside [runReconcile]
-     * (e.g. an `SQLiteException` from the host read, a `persistTree` IO error, or
-     * a `tree.reconcile` projection fault) must NOT leave the picker silently
-     * stuck on the refresh spinner. Surface the same calm, RETRYABLE error the
-     * `ConnectFailed` arm uses: keep the last-known tree visible with a
-     * dismissable refresh-failure banner when one is already painted, otherwise
-     * show the retryable [FolderListUiState.ConnectError] panel. Either way the
-     * user has an escape (Retry / the banner clears on the next success) instead
-     * of a frozen spinner.
-     */
-    private fun surfaceUnexpectedReconcileFailure(params: BoundParams, cause: Throwable) {
-        // A reconcile for a host the user has since navigated away from must not
-        // clobber the now-current binding's state.
-        if (bound != params) return
-        if (preserveReadyOnRefresh(REFRESH_FAILED_MESSAGE)) return
-        _state.value = FolderListUiState.ConnectError(
-            message = folderListConnectErrorMessage(cause, REFRESH_FAILED_MESSAGE),
-            cause = cause,
-        )
-    }
-
-    /**
-     * Stop any in-flight reconcile — wired to the screen's
-     * `DisposableEffect.onDispose` so navigating away (e.g. tapping a session
-     * row → TmuxSessionScreen) frees the SSH probe channel for the next
-     * destination immediately. The MAINTAINED TREE survives (held across opens),
-     * so returning renders it instantly without a fresh probe (#679 req #1).
+     * Stop screen-scoped synchronization while retaining the maintained tree.
+     * The coordinator owns reconcile, heartbeat, subscriptions, and warm release.
      */
     fun stopPolling() {
-        probeJob?.cancel()
-        probeJob = null
-        // Issue #783: the `%sessions-changed` / `%window-close` EVENT
-        // subscriptions are DELIBERATELY NOT torn down here. They are tied to the
-        // bound-host warm-lease lifetime (see [ensureBoundHostSubscriptions]), not
-        // screen composition, so a window/session closed on the host (or in
-        // another terminal) while the user is on the session screen still prunes
-        // the maintained tree the instant the event arrives — no dead-collector
-        // drop, no ~15-min staleness wait. They reuse the registry's live `-CC`
-        // client (D21, no second connection) and are foreground-gated, and are
-        // torn down only on a host change or [onCleared].
-        //
-        // The periodic ~5-min reconcile heartbeat DOES stop here — it is a
-        // freshness net for the SHOWN tree, so it follows screen composition like
-        // the old discovery probe and must not re-acquire the warm lease (just
-        // scheduled for release below) for an undisplayed screen.
-        periodicReconcileJob?.cancel()
-        periodicReconcileJob = null
-        scheduleWarmRelease()
-    }
-
-    private suspend fun runReconcile(params: BoundParams) {
-        val host = withContext(ioDispatcher) { hostDao.getById(params.hostId) } ?: run {
-            setSessionRefreshInFlight(false)
-            _state.value = FolderListUiState.Failed("Host not found.")
-            return
-        }
-        // Issue #847: establish the SSH connection OUTSIDE the enumeration window
-        // below. The cold sshj dial is bounded by the lease manager's connect
-        // timeout (~35s), which is LONGER than the 12s reconcile bound — wrapping
-        // the dial in the 12s window (as before) meant a slow-but-valid connect
-        // (e.g. the FRESH cold dial needed after the bootstrap "Host setup
-        // needed" sheet is dismissed via Skip, which releases the warm
-        // `warm-host-connect` lease) blew the budget and surfaced the spurious
-        // "Session list didn't load within 12000ms" error even though the host
-        // was connectable. Pre-establishing the warm lease here (its OWN connect
-        // bound, decoupled from the enumeration timer) makes the gateway acquire
-        // inside the bounded enumeration a fast REUSE of the live transport, and
-        // the picker shows Loading ("Connecting…") while the connect is in
-        // flight — never a hard 12s error on a connectable host.
-        ensureWarmConnectForReconcile(params)
-        if (bound != params) return
-        engineDiscovery.awaitBindRefresh(params.hostId)
-        if (bound != params) return
-        // Issue #702: bound the ENUMERATION (not the connect). The gateway already
-        // self-bounds its live `-CC` enumeration and SSH-lease reads, but a
-        // `withTimeout` here guarantees that NO gateway path can ever pin the
-        // picker in `Loading` indefinitely — on expiry we surface a retryable
-        // error panel instead of an endless spinner. With the warm lease already
-        // established above, this window now covers only the enumeration round
-        // trip(s), never a cold dial (issue #847).
-        val result = withTimeoutOrNull(reconcileTimeoutMs) {
-            gateway.listSessionsWithFolder(
-                host = host,
-                keyPath = params.keyPath,
-                passphrase = params.passphrase,
-                watchedRoots = lastWatchedFolders,
-            )
-        } ?: FolderListResult.ConnectFailed(
-            FolderReconcileTimeoutException(reconcileTimeoutMs),
-        )
-        if (bound != params) return
-        when (result) {
-            is FolderListResult.Sessions -> {
-                val sessionEntries = result.rows.map { it.toSessionEntry() }
-                val folderPaths = result.rows.associate { row ->
-                    row.sessionName to (row.cwd?.let(::canonicalisePath) ?: UNTRACKED_PATH)
-                }
-                // EPIC #679: reconcile the held tree (diff add/remove/update by
-                // id) instead of overwriting snapshot fields + a from-scratch
-                // rebuild. The reconcile MUTATES the held maps, so — like every
-                // other tree mutation — it runs on Main (the single thread that
-                // owns the model). It is the cheap half (a keyed diff over ≤12
-                // sessions); the EXPENSIVE half is the projection, which
-                // [emitReady] runs OFF Main over an immutable snapshot (issue
-                // #965). Keeping mutations Main-confined is what makes that
-                // snapshot race-free.
-                tree.reconcile(
-                    HostTreeModel.ProbeSnapshot(
-                        sessions = sessionEntries,
-                        folderPaths = folderPaths,
-                        scannedProjectFoldersByRoot = result.projectFoldersByRoot,
-                        historyProjectFoldersByRoot = result.historyProjectFoldersByRoot,
-                        resolvedWatchedRootPaths = result.resolvedWatchedRootPaths,
-                    ),
-                )
-                // Issue #456/#602: filter discovery to interesting ports.
-                lastDiscoveredPorts = InterestingPortFilter.filter(result.discoveredPorts).map { port ->
-                    HostDiscoveredPort(
-                        remotePort = port.port,
-                        process = port.processName,
-                    )
-                }
-                // Issue #711: a successful reconcile clears the quiet-retry
-                // budget so a later, unrelated transient drop gets its own full
-                // retry allowance.
-                transientRefreshRetries = 0
-                sessionIdentityReconcileRequested = false
-                setSessionRefreshInFlight(false)
-                emitReady()
-                // Epic #821 slice C (issue #837): persist the freshened tree so
-                // the next cold start hydrates the just-reconciled order /
-                // expand-collapse / foreign-guess. Fire-and-forget.
-                persistTree(params)
-                // Issue #867: mirror the freshened tree into the CLIENT cache so
-                // the NEXT cold start paints THIS (settled) tree instantly — the
-                // local-first half of stale-while-revalidate. Fire-and-forget.
-                persistClientCache(params)
-                if (refreshSessionsRequested) {
-                    completeManualRefresh()
-                } else {
-                    clearRefreshFailure()
-                }
-            }
-            is FolderListResult.Failed -> {
-                if (handleTransientRefreshDrop(params, RuntimeException(result.message))) return
-                setSessionRefreshInFlight(false)
-                if (preserveReadyOnRefresh(REFRESH_FAILED_MESSAGE)) return
-                _state.value = FolderListUiState.Failed(REFRESH_FAILED_MESSAGE)
-            }
-            is FolderListResult.ConnectFailed -> {
-                if (handleTransientRefreshDrop(params, result.cause)) return
-                setSessionRefreshInFlight(false)
-                if (preserveReadyOnRefresh(REFRESH_FAILED_MESSAGE)) return
-                // Issue #711: the user-facing connect message is the calm copy,
-                // never the raw transport exception text (which embedded the
-                // entire enumeration command). The raw [cause] is still carried
-                // for Retry/diagnostics but never rendered.
-                _state.value = FolderListUiState.ConnectError(
-                    message = folderListConnectErrorMessage(result.cause, REFRESH_FAILED_MESSAGE),
-                    cause = result.cause,
-                )
-            }
-            FolderListResult.ToolUnavailable -> {
-                setSessionRefreshInFlight(false)
-                if (preserveReadyOnRefresh("Couldn't refresh sessions: tmux is not installed.")) return
-                _state.value = FolderListUiState.ToolUnavailable
-            }
-        }
-    }
-
-    /**
-     * Issue #711: a transient transport drop mid-refresh (EOF / broken transport
-     * / channel closed / SSH not connected) is NOT a user-facing error — the
-     * gateway's own evict-and-retry heal (#680) usually recovers it, and the
-     * tree self-refreshes on the next reconcile. When such a transient error
-     * still escapes the gateway (e.g. the fresh lease also blipped), we retry
-     * QUIETLY here — up to [TRANSIENT_REFRESH_RETRY_LIMIT] times — instead of
-     * flashing a scary band carrying the raw enumeration command. We keep the
-     * last-known tree visible (no displacing error, no spinner-only screen) and
-     * only fall through to a COMPACT calm message if the retries are exhausted.
-     *
-     * Returns true when the drop was classified transient and a quiet retry was
-     * scheduled (the caller must `return` without surfacing any error state).
-     */
-    private fun handleTransientRefreshDrop(params: BoundParams, cause: Throwable): Boolean {
-        if (!isTransientFolderRefreshDrop(cause)) return false
-        if (transientRefreshRetries >= TRANSIENT_REFRESH_RETRY_LIMIT) {
-            // Retries exhausted: this is no longer "transient" from the user's
-            // point of view. Fall through to the calm-message path below.
-            transientRefreshRetries = 0
-            return false
-        }
-        transientRefreshRetries += 1
-        // Keep the held tree visible and quietly re-run the reconcile on a fresh
-        // lease. We do NOT clear isRefreshing here so the non-displacing progress
-        // bar (#639) keeps spinning across the silent retry — no error flash.
-        if (bound != params) {
-            transientRefreshRetries = 0
-            return true
-        }
-        launchReconcile(params)
-        return true
+        treeSync.stopPolling()
     }
 
     private fun preserveReadyOnRefresh(message: String): Boolean {
@@ -2540,24 +1565,9 @@ class FolderListViewModel internal constructor(
     }
 
     override fun onCleared() {
-        probeJob?.cancel()
-        // Issue #783: the event subscriptions are torn down here (and on a host
-        // change), not on screen dispose. The periodic heartbeat is cancelled
-        // here too (it normally stops on `stopPolling`, but a VM destroyed while
-        // the tree screen is still composed must not leak the loop).
-        tearDownBoundHostSubscriptions()
-        periodicReconcileJob?.cancel()
-        periodicReconcileJob = null
-        hydrateTreeJob?.cancel()
-        hydrateTreeJob = null
-        clientCacheSeedJob?.cancel()
-        clientCacheSeedJob = null
+        treeSync.close()
         emitJob?.cancel()
         emitJob = null
-        warmJob?.cancel()
-        warmReleaseJob?.cancel()
-        releaseWarmLeaseAsync()
-        watchedFoldersJob?.cancel()
         lifecycleObserver?.let { observer ->
             // `removeObserver` is main-thread-affine; `onCleared` runs on
             // the main thread so this is safe. Only set when lifecycle
@@ -2566,66 +1576,6 @@ class FolderListViewModel internal constructor(
         }
         lifecycleObserver = null
         super.onCleared()
-    }
-
-    private suspend fun releaseWarmLease() {
-        val lease = takeWarmLeaseForRelease() ?: return
-        releaseWarmLeaseBounded(lease)
-    }
-
-    private fun releaseWarmLeaseAsync() {
-        val lease = takeWarmLeaseForRelease() ?: return
-        CoroutineScope(ioDispatcher).launch {
-            releaseWarmLeaseBounded(lease)
-        }
-    }
-
-    private fun takeWarmLeaseForRelease(): SshLease? {
-        val lease = warmLease ?: return null
-        warmLease = null
-        warmSessionReady.value = false
-        return lease
-    }
-
-    private suspend fun releaseWarmLeaseBounded(lease: SshLease) {
-        // Run the bounded release off the Main thread (in production [ioDispatcher]
-        // is `Dispatchers.IO`) so a wedged half-open transport `close()` socket
-        // write can never block the caller; the lease manager's own release does
-        // the wedge-free refcount bookkeeping NonCancellably and only the bounded
-        // transport close runs here. Use the injectable [ioDispatcher] — NOT a
-        // hardcoded `Dispatchers.IO` — so a `runTest` virtual clock drives the
-        // release-into-idle-TTL deterministically, matching every other IO hop in
-        // this view model.
-        withContext(NonCancellable + ioDispatcher) {
-            withTimeoutOrNull(WARM_LEASE_RELEASE_TIMEOUT_MS) {
-                lease.release()
-            }
-        }
-    }
-
-    private suspend fun replaceWarmLease(params: BoundParams) {
-        releaseWarmLease()
-        var acquiredLease: SshLease? = null
-        try {
-            val lease = sshLeaseManager.acquire(params.toSshLeaseTarget()).getOrNull() ?: return
-            acquiredLease = lease
-            warmLeaseAcquiredForTest?.invoke()
-            withContext(NonCancellable) {
-                warmLease = lease
-                acquiredLease = null
-                warmSessionReady.value = true
-            }
-        } finally {
-            acquiredLease?.release()
-        }
-    }
-
-    private fun scheduleWarmRelease() {
-        warmReleaseJob?.cancel()
-        warmReleaseJob = viewModelScope.launch {
-            delay(WARM_RELEASE_DELAY_MS)
-            releaseWarmLease()
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/pocketshell/app/projects/TreeClientCache.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TreeClientCache.kt
@@ -91,7 +91,7 @@ import javax.inject.Singleton
 @Singleton
 public class TreeClientCache @Inject constructor(
     @ApplicationContext private val context: Context,
-) {
+) : TreeSyncCache {
 
     private val cacheDir: File by lazy {
         File(context.filesDir, CACHE_DIR_NAME).apply { mkdirs() }
@@ -129,7 +129,7 @@ public class TreeClientCache @Inject constructor(
      * back to the brief Loading and read OFF Main via [read]. Safe to call on the
      * Main thread: it only touches the in-memory map.
      */
-    public fun peek(host: String): CachedTree? = parsed[sanitise(host)]
+    override fun peek(host: String): CachedTree? = parsed[sanitise(host)]
 
     /**
      * Read the cached snapshot for [host] (the OFF-Main cold-miss / warm read).
@@ -138,7 +138,7 @@ public class TreeClientCache @Inject constructor(
      * any IO/parse failure. This DOES touch disk on a miss, so it must run off the
      * Main thread; the Main-thread seed uses [peek] instead (issue #1109 / #965).
      */
-    public fun read(host: String): CachedTree {
+    override fun read(host: String): CachedTree {
         val key = sanitise(host)
         parsed[key]?.let { return it }
         val file = fileFor(host)
@@ -178,7 +178,7 @@ public class TreeClientCache @Inject constructor(
      * cache file. Any IO failure is swallowed (the tree is still correct in
      * memory; the next write re-persists).
      */
-    public fun write(host: String, tree: CachedTree) {
+    override fun write(host: String, tree: CachedTree) {
         val key = sanitise(host)
         // Issue #1109: keep the in-memory parsed snapshot hot with the just-rendered
         // tree so the NEXT cold connect of this host in the same process [peek]s it

--- a/app/src/main/java/com/pocketshell/app/projects/TreeSyncCache.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TreeSyncCache.kt
@@ -1,0 +1,16 @@
+package com.pocketshell.app.projects
+
+/**
+ * The advisory client-side cache used by [TreeSyncCoordinator].
+ *
+ * Keeping this seam separate from the file-backed implementation lets the
+ * coordinator prove hydrate/persist ordering without making tests touch disk.
+ * The host-side tree registry remains the authoritative source.
+ */
+internal interface TreeSyncCache {
+    fun peek(host: String): TreeClientCache.CachedTree?
+
+    fun read(host: String): TreeClientCache.CachedTree
+
+    fun write(host: String, tree: TreeClientCache.CachedTree)
+}

--- a/app/src/main/java/com/pocketshell/app/projects/TreeSyncCoordinator.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TreeSyncCoordinator.kt
@@ -1,0 +1,619 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+/** A host-tree event emitted by the live remote session registry. */
+internal sealed interface TreeSyncEvent {
+    data object SessionsChanged : TreeSyncEvent
+    data class WindowClosed(val windowId: String) : TreeSyncEvent
+}
+
+/**
+ * Remote operations needed by [TreeSyncCoordinator].
+ *
+ * The coordinator owns *when* synchronization happens; this seam owns the
+ * transport details (host lookup, warm lease reuse, tree RPCs, and live-client
+ * events). Tests can therefore exercise scheduling and failure policy without
+ * opening SSH channels or depending on command strings.
+ */
+internal interface TreeSyncRemote {
+    val hasDurableTree: Boolean
+
+    fun events(params: BoundParams): Flow<TreeSyncEvent>
+
+    suspend fun ensureWarmConnected(params: BoundParams)
+
+    suspend fun fullReconcile(
+        params: BoundParams,
+        watchedFolders: List<ProjectRootEntity>,
+    ): FullResult
+
+    suspend fun getTree(params: BoundParams): TreeRemoteSource.TreeResult
+
+    suspend fun reconcileTree(params: BoundParams): TreeRemoteSource.ReconcileDelta?
+
+    suspend fun upsertTree(
+        params: BoundParams,
+        nodes: List<TreeRemoteSource.TreeNode>,
+    ): Boolean
+
+    suspend fun acquireSessionForUpgrade(params: BoundParams): com.pocketshell.core.ssh.SshSession?
+
+    suspend fun releaseWarm()
+
+    sealed interface FullResult {
+        data class Sessions(val result: FolderListResult.Sessions) : FullResult
+        data object ToolUnavailable : FullResult
+        data class Failed(val message: String) : FullResult
+        data class ConnectFailed(val cause: Throwable) : FullResult
+        data object HostNotFound : FullResult
+    }
+}
+
+/** Injectable timing and retry policy for tree synchronization. */
+internal data class TreeSyncPolicy(
+    var hydrateTimeoutMs: Long = 10_000L,
+    var reconcileTimeoutMs: Long = 12_000L,
+    var staleAfterMs: Long = HostTreeModel.RECONCILE_STALENESS_MS,
+    var resumeFreshenMs: Long = 10_000L,
+    var periodicReconcileMs: Long = 5 * 60 * 1000L,
+    var sessionsChangedDebounceMs: Long = 400L,
+    var warmReleaseDelayMs: Long = 10_000L,
+    var warmReleaseTimeoutMs: Long = 3_000L,
+    var transientRetryLimit: Int = 2,
+    var periodicEnabled: Boolean = false,
+)
+
+/** A user-visible synchronization failure, kept separate from UI projection. */
+internal sealed interface TreeSyncFailure {
+    data object Timeout : TreeSyncFailure
+    data object HostNotFound : TreeSyncFailure
+    data class ToolUnavailable(val result: FolderListResult = FolderListResult.ToolUnavailable) : TreeSyncFailure
+    data class Failed(val message: String) : TreeSyncFailure
+    data class ConnectFailed(val cause: Throwable) : TreeSyncFailure
+    data class Unexpected(val cause: Throwable) : TreeSyncFailure
+}
+
+/**
+ * Owns the maintained tree's synchronization lifecycle.
+ *
+ * [FolderListViewModel] remains the UI projection and action router. This class
+ * owns the synchronization state machine: cache/durable hydration, delta versus
+ * authoritative full reconcile, bounded retries, foreground gating, live-event
+ * subscriptions, periodic scheduling, persistence handoff, and cancellation.
+ */
+internal class TreeSyncCoordinator(
+    private val scope: CoroutineScope,
+    private val remote: TreeSyncRemote,
+    private val cache: TreeSyncCache?,
+    private val processStarted: StateFlow<Boolean>,
+    private val dispatcher: () -> CoroutineDispatcher,
+    private val clock: () -> Long = System::currentTimeMillis,
+    val policy: TreeSyncPolicy = TreeSyncPolicy(),
+    private val awaitBeforeFullReconcile: suspend (BoundParams) -> Unit = {},
+    private val listener: Listener,
+) {
+    interface Listener {
+        fun onLoadingRequested()
+        fun onRefreshingChanged(refreshing: Boolean)
+        fun onTreeChanged(synchronous: Boolean = false)
+        fun onReconcileSuccess(result: FolderListResult.Sessions)
+        fun onReconcileFailure(failure: TreeSyncFailure)
+        fun onUnexpectedFailure(cause: Throwable)
+        fun onPayloadCliVersion(version: String)
+    }
+
+    val tree: HostTreeModel = HostTreeModel()
+
+    val hasSnapshot: Boolean get() = tree.hasSnapshot
+    val isPolling: Boolean get() = reconcileJob != null
+    val isRefreshing: Boolean get() = refreshing
+    val rootSnapshotLoaded: Boolean get() = rootSnapshotLoadedState
+    val watchedFolders: List<ProjectRootEntity> get() = lastWatchedFolders
+
+    private var bound: BoundParams? = null
+    private var watchedFoldersJob: Job? = null
+    private var cacheSeedJob: Job? = null
+    private var hydrateJob: Job? = null
+    private var reconcileJob: Job? = null
+    private var eventJob: Job? = null
+    private var debounceJob: Job? = null
+    private var periodicJob: Job? = null
+    private var warmConnectJob: Job? = null
+    private var warmReleaseJob: Job? = null
+
+    private var lastWatchedFolders: List<ProjectRootEntity> = emptyList()
+    private var rootSnapshotLoadedState: Boolean = false
+    private var refreshing: Boolean = false
+    private var identityReconcileRequested: Boolean = false
+    private var transientRetries: Int = 0
+    private var foregroundGeneration: Long = 0L
+    private var lastResumeGenerationHandled: Long = -1L
+    private var reconcileGeneration: Long = 0L
+    private var closed: Boolean = false
+
+    /**
+     * Foreground transitions are consumed here, so the ViewModel does not own a
+     * second lifecycle subscription for tree synchronization.
+     */
+    private val lifecycleJob: Job = scope.launch {
+        processStarted.collect { started ->
+            if (!started) return@collect
+            foregroundGeneration += 1L
+            maybeReconcileOnResume()
+        }
+    }
+
+    /** Bind the synchronization owner to a host and its watched-root stream. */
+    fun bind(params: BoundParams, watchedFolders: Flow<List<ProjectRootEntity>>) {
+        if (closed) return
+        val sameHost = bound == params && !tree.bindHost(params.hostId)
+        warmReleaseJob?.cancel()
+        warmReleaseJob = null
+
+        if (!sameHost) {
+            reconcileJob?.cancel()
+            reconcileJob = null
+            hydrateJob?.cancel()
+            hydrateJob = null
+            cacheSeedJob?.cancel()
+            cacheSeedJob = null
+            eventJob?.cancel()
+            eventJob = null
+            debounceJob?.cancel()
+            debounceJob = null
+            rootSnapshotLoadedState = false
+            lastWatchedFolders = emptyList()
+            refreshing = false
+            transientRetries = 0
+            identityReconcileRequested = false
+            bound = params
+            tree.bindHost(params.hostId)
+            warmConnectJob?.cancel()
+            warmConnectJob = scope.launch { remote.ensureWarmConnected(params) }
+            if (!hydrateFromClientCache(params)) {
+                listener.onLoadingRequested()
+                warmFromClientCacheOffMain(params)
+            }
+        } else {
+            bound = params
+            if (tree.hasSnapshot) listener.onTreeChanged()
+            maybeReconcileOnOpen(params)
+        }
+
+        bindWatchedFolders(params, watchedFolders)
+        ensureEventSubscription(params)
+        startPeriodic(params)
+    }
+
+    /** Explicit pull-to-refresh, error-panel retry, or action confirmation. */
+    fun requestReconcile() {
+        val params = bound ?: return
+        if (!rootSnapshotLoadedState) {
+            listener.onLoadingRequested()
+            return
+        }
+        scheduleReconcile(params, ReconcileMode.Full)
+    }
+
+    /** Request a generation-safe probe after a name-only lifecycle hint. */
+    fun requestIdentityReconcile() {
+        identityReconcileRequested = true
+        if (isPolling) requestReconcile()
+    }
+
+    /** Mark the held tree stale for deterministic unit coverage. */
+    fun forceTreeStaleForTest() {
+        tree.markReconcileDueForTest()
+    }
+
+    fun setPeriodicEnabledForTest(enabled: Boolean) {
+        policy.periodicEnabled = enabled
+        bound?.let(::startPeriodic)
+    }
+
+    suspend fun acquireSessionForUpgrade(params: BoundParams) =
+        remote.acquireSessionForUpgrade(params)
+
+    suspend fun getTreeForUpgrade(params: BoundParams) = remote.getTree(params)
+
+    /** Toggle + persist is a tree mutation, not a UI-only operation. */
+    fun toggleProjectExpanded(projectPath: String) {
+        tree.toggleProjectExpanded(projectPath)
+        listener.onTreeChanged()
+        bound?.let(::persist)
+    }
+
+    /** Persist after an app action that has already mutated [tree]. */
+    fun persistCurrentTree() {
+        bound?.let(::persist)
+    }
+
+    fun setProcessStartedForTest(started: Boolean) {
+        // The owner of the flow is the ViewModel; this method exists only for
+        // coordinator-focused tests that pass a MutableStateFlow as the seam.
+        (processStarted as? kotlinx.coroutines.flow.MutableStateFlow<Boolean>)?.value = started
+    }
+
+    /** Stop screen-scoped work while retaining host-bound event subscriptions. */
+    fun stopPolling() {
+        reconcileJob?.cancel()
+        reconcileJob = null
+        periodicJob?.cancel()
+        periodicJob = null
+        scheduleWarmRelease()
+    }
+
+    /** Cancel all coordinator work and release the warm transport best-effort. */
+    fun close() {
+        if (closed) return
+        closed = true
+        lifecycleJob.cancel()
+        reconcileJob?.cancel()
+        watchedFoldersJob?.cancel()
+        cacheSeedJob?.cancel()
+        hydrateJob?.cancel()
+        eventJob?.cancel()
+        debounceJob?.cancel()
+        periodicJob?.cancel()
+        warmConnectJob?.cancel()
+        warmReleaseJob?.cancel()
+        CoroutineScope(dispatcher()).launch {
+            withContext(NonCancellable) {
+                withTimeoutOrNull(policy.warmReleaseTimeoutMs) { remote.releaseWarm() }
+            }
+        }
+    }
+
+    private fun bindWatchedFolders(
+        params: BoundParams,
+        watchedFolders: Flow<List<ProjectRootEntity>>,
+    ) {
+        watchedFoldersJob?.cancel()
+        watchedFoldersJob = scope.launch {
+            watchedFolders.collectLatest { rows ->
+                if (closed || bound != params) return@collectLatest
+                lastWatchedFolders = rows
+                tree.setWatchedFolders(rows)
+                val firstSnapshot = !rootSnapshotLoadedState
+                rootSnapshotLoadedState = true
+                if (firstSnapshot) {
+                    hydrateTreeOnColdStart(params)
+                } else {
+                    listener.onTreeChanged()
+                }
+            }
+        }
+    }
+
+    private fun hydrateFromClientCache(params: BoundParams): Boolean {
+        val cached = cache?.peek(params.hostName) ?: return false
+        if (cached.isEmpty) return false
+        if (!applyCachedTree(cached)) return false
+        listener.onTreeChanged(synchronous = true)
+        return true
+    }
+
+    private fun warmFromClientCacheOffMain(params: BoundParams) {
+        val cache = cache ?: return
+        cacheSeedJob?.cancel()
+        cacheSeedJob = scope.launch(dispatcher()) {
+            val cached = runCatching { cache.read(params.hostName) }
+                .getOrDefault(TreeClientCache.CachedTree(nodes = emptyList()))
+            // Resume on the coordinator's owning scope after the injected
+            // dispatcher finishes the blocking cache read.  Hard-coding
+            // Dispatchers.Main here makes the coordinator impossible to run
+            // under a focused JVM harness and gives cache I/O a second,
+            // non-injectable lifecycle context.
+            if (closed || bound != params || cached.isEmpty) return@launch
+            if (!applyCachedTree(cached)) return@launch
+            listener.onTreeChanged()
+        }
+    }
+
+    private fun applyCachedTree(cached: TreeClientCache.CachedTree): Boolean {
+        if (cached.watchedFolders.isNotEmpty()) tree.setWatchedFolders(cached.watchedFolders)
+        tree.hydrate(cached.nodes.map { it.toHydratedNode() })
+        tree.hydrateStructure(
+            resolvedWatchedRootPaths = cached.resolvedWatchedRootPaths,
+            scannedProjectFoldersByRoot = cached.scannedProjectFoldersByRoot,
+            historyProjectFoldersByRoot = cached.historyProjectFoldersByRoot,
+        )
+        return tree.hasSnapshot
+    }
+
+    private fun hydrateTreeOnColdStart(params: BoundParams) {
+        hydrateJob?.cancel()
+        hydrateJob = scope.launch {
+            cacheSeedJob?.join()
+            if (closed || bound != params) return@launch
+            processStarted.first { it }
+            if (!remote.hasDurableTree) {
+                if (isCurrent(params)) maybeReconcileOnOpen(params)
+                return@launch
+            }
+            var cancelled = false
+            try {
+                val result = withTimeoutOrNull(policy.hydrateTimeoutMs) {
+                    async(dispatcher()) { remote.getTree(params) }.await()
+                } ?: TreeRemoteSource.TreeResult.Empty
+                if (!isCurrent(params)) return@launch
+                result.cliVersion?.let(listener::onPayloadCliVersion)
+                if (result.nodes.isNotEmpty()) {
+                    tree.hydrate(result.nodes.map { it.toHydratedNode() })
+                    listener.onTreeChanged()
+                }
+            } catch (cancellation: CancellationException) {
+                cancelled = true
+                throw cancellation
+            } catch (_: Throwable) {
+                // Hydrate is advisory. The authoritative full reconcile still
+                // runs below when the host is current.
+            } finally {
+                if (!cancelled && isCurrent(params)) maybeReconcileOnOpen(params)
+            }
+        }
+    }
+
+    private fun maybeReconcileOnOpen(params: BoundParams) {
+        if (!isCurrent(params)) return
+        if (!rootSnapshotLoadedState) {
+            listener.onLoadingRequested()
+            return
+        }
+        lastResumeGenerationHandled = foregroundGeneration
+        if (identityReconcileRequested ||
+            tree.reconcileDue(now = clock(), staleAfterMs = policy.staleAfterMs)
+        ) {
+            scheduleReconcile(params, ReconcileMode.Full)
+        } else {
+            listener.onTreeChanged()
+        }
+    }
+
+    private fun maybeReconcileOnResume() {
+        val params = bound ?: return
+        if (closed || !rootSnapshotLoadedState) return
+        if (foregroundGeneration == lastResumeGenerationHandled) return
+        lastResumeGenerationHandled = foregroundGeneration
+        if (identityReconcileRequested ||
+            !tree.reconcileDue(now = clock(), staleAfterMs = policy.resumeFreshenMs)
+        ) return
+        scheduleReconcile(
+            params,
+            if (remote.hasDurableTree && tree.hasSnapshot) ReconcileMode.DeltaThenFull
+            else ReconcileMode.Full,
+        )
+    }
+
+    private fun scheduleReconcile(params: BoundParams, mode: ReconcileMode) {
+        reconcileJob?.cancel()
+        val generation = ++reconcileGeneration
+        reconcileJob = scope.launch {
+            if (!isCurrent(params)) return@launch
+            listener.onLoadingRequestedIfNeeded()
+            processStarted.first { it }
+            if (!isCurrent(params)) return@launch
+            setRefreshing(true)
+            try {
+                when (mode) {
+                    ReconcileMode.Full -> runFullReconcile(params, generation)
+                    ReconcileMode.DeltaThenFull -> runDeltaThenFull(params, generation)
+                }
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (unexpected: Throwable) {
+                if (isCurrent(params)) listener.onUnexpectedFailure(unexpected)
+            } finally {
+                if (generation == reconcileGeneration) setRefreshing(false)
+            }
+        }
+    }
+
+    private suspend fun runDeltaThenFull(params: BoundParams, generation: Long) {
+        val delta = withTimeoutOrNull(policy.reconcileTimeoutMs + 1_000L) {
+            remote.reconcileTree(params)
+        }
+        if (!isCurrent(params) || generation != reconcileGeneration) return
+        delta?.cliVersion?.let(listener::onPayloadCliVersion)
+        if (delta == null || delta.added.isNotEmpty() || delta.gone.isNotEmpty()) {
+            runFullReconcile(params, generation)
+        }
+    }
+
+    private suspend fun runFullReconcile(params: BoundParams, generation: Long) {
+        while (isCurrent(params) && generation == reconcileGeneration) {
+            // The warm connect has its own bound. It is intentionally outside
+            // the enumeration timeout so a slow-but-valid cold dial is not
+            // misreported as a 12-second list timeout.
+            remote.ensureWarmConnected(params)
+            if (!isCurrent(params) || generation != reconcileGeneration) return
+            // The pre-extraction ViewModel awaited the bind-time engine
+            // registry read before asking the folder gateway to enumerate
+            // sessions. Keep that ordering at the coordinator boundary so a
+            // cold bind cannot classify rows against an empty registry.
+            awaitBeforeFullReconcile(params)
+            if (!isCurrent(params) || generation != reconcileGeneration) return
+            val result = withTimeoutOrNull(policy.reconcileTimeoutMs) {
+                remote.fullReconcile(params, lastWatchedFolders)
+            } ?: TreeSyncRemote.FullResult.ConnectFailed(
+                FolderReconcileTimeoutException(policy.reconcileTimeoutMs),
+            )
+            if (!isCurrent(params) || generation != reconcileGeneration) return
+            when (result) {
+                is TreeSyncRemote.FullResult.Sessions -> {
+                    applySuccessfulReconcile(params, result.result)
+                    return
+                }
+                TreeSyncRemote.FullResult.HostNotFound -> {
+                    listener.onReconcileFailure(TreeSyncFailure.HostNotFound)
+                    return
+                }
+                TreeSyncRemote.FullResult.ToolUnavailable -> {
+                    listener.onReconcileFailure(TreeSyncFailure.ToolUnavailable())
+                    return
+                }
+                is TreeSyncRemote.FullResult.Failed -> {
+                    if (retryTransient(params, RuntimeException(result.message))) continue
+                    listener.onReconcileFailure(TreeSyncFailure.Failed(result.message))
+                    return
+                }
+                is TreeSyncRemote.FullResult.ConnectFailed -> {
+                    if (result.cause is FolderReconcileTimeoutException) {
+                        listener.onReconcileFailure(TreeSyncFailure.Timeout)
+                        return
+                    }
+                    if (retryTransient(params, result.cause)) continue
+                    listener.onReconcileFailure(TreeSyncFailure.ConnectFailed(result.cause))
+                    return
+                }
+            }
+        }
+    }
+
+    private suspend fun retryTransient(params: BoundParams, cause: Throwable): Boolean {
+        if (!isTransientFolderRefreshDrop(cause)) return false
+        if (transientRetries >= policy.transientRetryLimit) {
+            transientRetries = 0
+            return false
+        }
+        transientRetries += 1
+        return isCurrent(params)
+    }
+
+    private fun applySuccessfulReconcile(
+        params: BoundParams,
+        result: FolderListResult.Sessions,
+    ) {
+        val entries = result.rows.map { it.toSessionEntry() }
+        val folderPaths = result.rows.associate { row ->
+            row.sessionName to (row.cwd?.let(FolderListViewModel::canonicalisePath)
+                ?: FolderListViewModel.UNTRACKED_PATH)
+        }
+        tree.reconcile(
+            HostTreeModel.ProbeSnapshot(
+                sessions = entries,
+                folderPaths = folderPaths,
+                scannedProjectFoldersByRoot = result.projectFoldersByRoot,
+                historyProjectFoldersByRoot = result.historyProjectFoldersByRoot,
+                resolvedWatchedRootPaths = result.resolvedWatchedRootPaths,
+            ),
+            now = clock(),
+        )
+        transientRetries = 0
+        identityReconcileRequested = false
+        listener.onReconcileSuccess(result)
+        listener.onTreeChanged()
+        persist(params)
+    }
+
+    private fun ensureEventSubscription(params: BoundParams) {
+        if (eventJob?.isActive == true && bound == params) return
+        eventJob?.cancel()
+        eventJob = scope.launch {
+            remote.events(params).collect { event ->
+                if (!isCurrent(params) || !rootSnapshotLoadedState) return@collect
+                when (event) {
+                    TreeSyncEvent.SessionsChanged -> {
+                        debounceJob?.cancel()
+                        debounceJob = launch {
+                            delay(policy.sessionsChangedDebounceMs)
+                            if (isCurrent(params) && rootSnapshotLoadedState) {
+                                scheduleReconcile(params, ReconcileMode.Full)
+                            }
+                        }
+                    }
+                    is TreeSyncEvent.WindowClosed -> {
+                        if (processStarted.value && tree.removeWindow(event.windowId)) {
+                            listener.onTreeChanged()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun startPeriodic(params: BoundParams) {
+        periodicJob?.cancel()
+        periodicJob = null
+        if (!policy.periodicEnabled) return
+        periodicJob = scope.launch {
+            while (isCurrent(params)) {
+                delay(policy.periodicReconcileMs)
+                if (isCurrent(params) && rootSnapshotLoadedState) {
+                    scheduleReconcile(params, ReconcileMode.Full)
+                }
+            }
+        }
+    }
+
+    private fun persist(params: BoundParams) {
+        val nodes = tree.exportNodes().map { it.toTreeNode() }
+        if (nodes.isNotEmpty()) {
+            scope.launch {
+                withTimeoutOrNull(policy.hydrateTimeoutMs) {
+                    runCatching { remote.upsertTree(params, nodes) }
+                }
+            }
+        }
+        val cache = cache ?: return
+        val structure = tree.exportStructure()
+        val cached = TreeClientCache.CachedTree(
+            nodes = nodes,
+            watchedFolders = lastWatchedFolders,
+            resolvedWatchedRootPaths = structure.resolvedWatchedRootPaths,
+            scannedProjectFoldersByRoot = structure.scannedProjectFoldersByRoot,
+            historyProjectFoldersByRoot = structure.historyProjectFoldersByRoot,
+        )
+        scope.launch(dispatcher()) {
+            runCatching { cache.write(params.hostName, cached) }
+        }
+    }
+
+    private fun scheduleWarmRelease() {
+        warmReleaseJob?.cancel()
+        warmReleaseJob = scope.launch {
+            delay(policy.warmReleaseDelayMs)
+            withContext(NonCancellable + dispatcher()) {
+                withTimeoutOrNull(policy.warmReleaseTimeoutMs) { remote.releaseWarm() }
+            }
+        }
+    }
+
+    private fun setRefreshing(value: Boolean) {
+        if (refreshing == value) return
+        refreshing = value
+        listener.onRefreshingChanged(value)
+    }
+
+    private fun isCurrent(params: BoundParams): Boolean = !closed && bound == params
+
+    private fun Listener.onLoadingRequestedIfNeeded() {
+        // The ViewModel decides whether a Loading state would displace a Ready
+        // snapshot; this callback is intentionally named separately to keep
+        // that UI policy out of the synchronization owner.
+        onLoadingRequested()
+    }
+
+    private enum class ReconcileMode { Full, DeltaThenFull }
+
+    companion object {
+        const val DEFAULT_WARM_SESSION_AWAIT_MS: Long = 8_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/TreeSyncCoordinator.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TreeSyncCoordinator.kt
@@ -24,6 +24,12 @@ internal sealed interface TreeSyncEvent {
     data class WindowClosed(val windowId: String) : TreeSyncEvent
 }
 
+/** Immutable host binding carried by every asynchronous tree operation. */
+internal data class TreeSyncBinding(
+    val params: BoundParams,
+    val generation: Long,
+)
+
 /**
  * Remote operations needed by [TreeSyncCoordinator].
  *
@@ -35,25 +41,27 @@ internal sealed interface TreeSyncEvent {
 internal interface TreeSyncRemote {
     val hasDurableTree: Boolean
 
-    fun events(params: BoundParams): Flow<TreeSyncEvent>
+    fun bind(binding: TreeSyncBinding) {}
 
-    suspend fun ensureWarmConnected(params: BoundParams)
+    fun events(binding: TreeSyncBinding): Flow<TreeSyncEvent>
+
+    suspend fun ensureWarmConnected(binding: TreeSyncBinding)
 
     suspend fun fullReconcile(
-        params: BoundParams,
+        binding: TreeSyncBinding,
         watchedFolders: List<ProjectRootEntity>,
     ): FullResult
 
-    suspend fun getTree(params: BoundParams): TreeRemoteSource.TreeResult
+    suspend fun getTree(binding: TreeSyncBinding): TreeRemoteSource.TreeResult
 
-    suspend fun reconcileTree(params: BoundParams): TreeRemoteSource.ReconcileDelta?
+    suspend fun reconcileTree(binding: TreeSyncBinding): TreeRemoteSource.ReconcileDelta?
 
     suspend fun upsertTree(
-        params: BoundParams,
+        binding: TreeSyncBinding,
         nodes: List<TreeRemoteSource.TreeNode>,
     ): Boolean
 
-    suspend fun acquireSessionForUpgrade(params: BoundParams): com.pocketshell.core.ssh.SshSession?
+    suspend fun acquireSessionForUpgrade(binding: TreeSyncBinding): com.pocketshell.core.ssh.SshSession?
 
     suspend fun releaseWarm()
 
@@ -128,6 +136,8 @@ internal class TreeSyncCoordinator(
     val watchedFolders: List<ProjectRootEntity> get() = lastWatchedFolders
 
     private var bound: BoundParams? = null
+    private var binding: TreeSyncBinding? = null
+    private var nextBindingGeneration: Long = 0L
     private var watchedFoldersJob: Job? = null
     private var cacheSeedJob: Job? = null
     private var hydrateJob: Job? = null
@@ -164,8 +174,15 @@ internal class TreeSyncCoordinator(
     fun bind(params: BoundParams, watchedFolders: Flow<List<ProjectRootEntity>>) {
         if (closed) return
         val sameHost = bound == params && !tree.bindHost(params.hostId)
+        val nextBinding = if (sameHost) {
+            checkNotNull(binding)
+        } else {
+            TreeSyncBinding(params = params, generation = ++nextBindingGeneration)
+        }
         warmReleaseJob?.cancel()
         warmReleaseJob = null
+        binding = nextBinding
+        remote.bind(nextBinding)
 
         if (!sameHost) {
             reconcileJob?.cancel()
@@ -186,30 +203,30 @@ internal class TreeSyncCoordinator(
             bound = params
             tree.bindHost(params.hostId)
             warmConnectJob?.cancel()
-            warmConnectJob = scope.launch { remote.ensureWarmConnected(params) }
-            if (!hydrateFromClientCache(params)) {
+            warmConnectJob = scope.launch { remote.ensureWarmConnected(nextBinding) }
+            if (!hydrateFromClientCache(nextBinding)) {
                 listener.onLoadingRequested()
-                warmFromClientCacheOffMain(params)
+                warmFromClientCacheOffMain(nextBinding)
             }
         } else {
             bound = params
             if (tree.hasSnapshot) listener.onTreeChanged()
-            maybeReconcileOnOpen(params)
+            maybeReconcileOnOpen(nextBinding)
         }
 
-        bindWatchedFolders(params, watchedFolders)
-        ensureEventSubscription(params)
-        startPeriodic(params)
+        bindWatchedFolders(nextBinding, watchedFolders)
+        ensureEventSubscription(nextBinding)
+        startPeriodic(nextBinding)
     }
 
     /** Explicit pull-to-refresh, error-panel retry, or action confirmation. */
     fun requestReconcile() {
-        val params = bound ?: return
+        val currentBinding = binding ?: return
         if (!rootSnapshotLoadedState) {
             listener.onLoadingRequested()
             return
         }
-        scheduleReconcile(params, ReconcileMode.Full)
+        scheduleReconcile(currentBinding, ReconcileMode.Full)
     }
 
     /** Request a generation-safe probe after a name-only lifecycle hint. */
@@ -225,24 +242,30 @@ internal class TreeSyncCoordinator(
 
     fun setPeriodicEnabledForTest(enabled: Boolean) {
         policy.periodicEnabled = enabled
-        bound?.let(::startPeriodic)
+        binding?.let(::startPeriodic)
     }
 
     suspend fun acquireSessionForUpgrade(params: BoundParams) =
-        remote.acquireSessionForUpgrade(params)
+        binding?.takeIf { it.params == params }?.let { current ->
+            remote.acquireSessionForUpgrade(current)
+        }
 
-    suspend fun getTreeForUpgrade(params: BoundParams) = remote.getTree(params)
+    suspend fun getTreeForUpgrade(params: BoundParams) =
+        binding?.takeIf { it.params == params }?.let { current ->
+            remote.getTree(current)
+        }
+            ?: TreeRemoteSource.TreeResult.Empty
 
     /** Toggle + persist is a tree mutation, not a UI-only operation. */
     fun toggleProjectExpanded(projectPath: String) {
         tree.toggleProjectExpanded(projectPath)
         listener.onTreeChanged()
-        bound?.let(::persist)
+        binding?.let(::persist)
     }
 
     /** Persist after an app action that has already mutated [tree]. */
     fun persistCurrentTree() {
-        bound?.let(::persist)
+        binding?.let(::persist)
     }
 
     fun setProcessStartedForTest(started: Boolean) {
@@ -282,19 +305,19 @@ internal class TreeSyncCoordinator(
     }
 
     private fun bindWatchedFolders(
-        params: BoundParams,
+        binding: TreeSyncBinding,
         watchedFolders: Flow<List<ProjectRootEntity>>,
     ) {
         watchedFoldersJob?.cancel()
         watchedFoldersJob = scope.launch {
             watchedFolders.collectLatest { rows ->
-                if (closed || bound != params) return@collectLatest
+                if (!isCurrent(binding)) return@collectLatest
                 lastWatchedFolders = rows
                 tree.setWatchedFolders(rows)
                 val firstSnapshot = !rootSnapshotLoadedState
                 rootSnapshotLoadedState = true
                 if (firstSnapshot) {
-                    hydrateTreeOnColdStart(params)
+                    hydrateTreeOnColdStart(binding)
                 } else {
                     listener.onTreeChanged()
                 }
@@ -302,7 +325,8 @@ internal class TreeSyncCoordinator(
         }
     }
 
-    private fun hydrateFromClientCache(params: BoundParams): Boolean {
+    private fun hydrateFromClientCache(binding: TreeSyncBinding): Boolean {
+        val params = binding.params
         val cached = cache?.peek(params.hostName) ?: return false
         if (cached.isEmpty) return false
         if (!applyCachedTree(cached)) return false
@@ -310,7 +334,8 @@ internal class TreeSyncCoordinator(
         return true
     }
 
-    private fun warmFromClientCacheOffMain(params: BoundParams) {
+    private fun warmFromClientCacheOffMain(binding: TreeSyncBinding) {
+        val params = binding.params
         val cache = cache ?: return
         cacheSeedJob?.cancel()
         cacheSeedJob = scope.launch(dispatcher()) {
@@ -321,7 +346,7 @@ internal class TreeSyncCoordinator(
             // Dispatchers.Main here makes the coordinator impossible to run
             // under a focused JVM harness and gives cache I/O a second,
             // non-injectable lifecycle context.
-            if (closed || bound != params || cached.isEmpty) return@launch
+            if (!isCurrent(binding) || cached.isEmpty) return@launch
             if (!applyCachedTree(cached)) return@launch
             listener.onTreeChanged()
         }
@@ -338,22 +363,23 @@ internal class TreeSyncCoordinator(
         return tree.hasSnapshot
     }
 
-    private fun hydrateTreeOnColdStart(params: BoundParams) {
+    private fun hydrateTreeOnColdStart(binding: TreeSyncBinding) {
+        val params = binding.params
         hydrateJob?.cancel()
         hydrateJob = scope.launch {
             cacheSeedJob?.join()
-            if (closed || bound != params) return@launch
+            if (!isCurrent(binding)) return@launch
             processStarted.first { it }
             if (!remote.hasDurableTree) {
-                if (isCurrent(params)) maybeReconcileOnOpen(params)
+                if (isCurrent(binding)) maybeReconcileOnOpen(binding)
                 return@launch
             }
             var cancelled = false
             try {
                 val result = withTimeoutOrNull(policy.hydrateTimeoutMs) {
-                    async(dispatcher()) { remote.getTree(params) }.await()
+                    async(dispatcher()) { remote.getTree(binding) }.await()
                 } ?: TreeRemoteSource.TreeResult.Empty
-                if (!isCurrent(params)) return@launch
+                if (!isCurrent(binding)) return@launch
                 result.cliVersion?.let(listener::onPayloadCliVersion)
                 if (result.nodes.isNotEmpty()) {
                     tree.hydrate(result.nodes.map { it.toHydratedNode() })
@@ -366,13 +392,14 @@ internal class TreeSyncCoordinator(
                 // Hydrate is advisory. The authoritative full reconcile still
                 // runs below when the host is current.
             } finally {
-                if (!cancelled && isCurrent(params)) maybeReconcileOnOpen(params)
+                if (!cancelled && isCurrent(binding)) maybeReconcileOnOpen(binding)
             }
         }
     }
 
-    private fun maybeReconcileOnOpen(params: BoundParams) {
-        if (!isCurrent(params)) return
+    private fun maybeReconcileOnOpen(binding: TreeSyncBinding) {
+        if (!isCurrent(binding)) return
+        val params = binding.params
         if (!rootSnapshotLoadedState) {
             listener.onLoadingRequested()
             return
@@ -381,84 +408,86 @@ internal class TreeSyncCoordinator(
         if (identityReconcileRequested ||
             tree.reconcileDue(now = clock(), staleAfterMs = policy.staleAfterMs)
         ) {
-            scheduleReconcile(params, ReconcileMode.Full)
+            scheduleReconcile(binding, ReconcileMode.Full)
         } else {
             listener.onTreeChanged()
         }
     }
 
     private fun maybeReconcileOnResume() {
-        val params = bound ?: return
-        if (closed || !rootSnapshotLoadedState) return
+        val binding = binding ?: return
+        val params = binding.params
+        if (!isCurrent(binding) || !rootSnapshotLoadedState) return
         if (foregroundGeneration == lastResumeGenerationHandled) return
         lastResumeGenerationHandled = foregroundGeneration
         if (identityReconcileRequested ||
             !tree.reconcileDue(now = clock(), staleAfterMs = policy.resumeFreshenMs)
         ) return
         scheduleReconcile(
-            params,
+            binding,
             if (remote.hasDurableTree && tree.hasSnapshot) ReconcileMode.DeltaThenFull
             else ReconcileMode.Full,
         )
     }
 
-    private fun scheduleReconcile(params: BoundParams, mode: ReconcileMode) {
+    private fun scheduleReconcile(binding: TreeSyncBinding, mode: ReconcileMode) {
         reconcileJob?.cancel()
         val generation = ++reconcileGeneration
         reconcileJob = scope.launch {
-            if (!isCurrent(params)) return@launch
+            if (!isCurrent(binding)) return@launch
             listener.onLoadingRequestedIfNeeded()
             processStarted.first { it }
-            if (!isCurrent(params)) return@launch
+            if (!isCurrent(binding)) return@launch
             setRefreshing(true)
             try {
                 when (mode) {
-                    ReconcileMode.Full -> runFullReconcile(params, generation)
-                    ReconcileMode.DeltaThenFull -> runDeltaThenFull(params, generation)
+                    ReconcileMode.Full -> runFullReconcile(binding, generation)
+                    ReconcileMode.DeltaThenFull -> runDeltaThenFull(binding, generation)
                 }
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (unexpected: Throwable) {
-                if (isCurrent(params)) listener.onUnexpectedFailure(unexpected)
+                if (isCurrent(binding)) listener.onUnexpectedFailure(unexpected)
             } finally {
                 if (generation == reconcileGeneration) setRefreshing(false)
             }
         }
     }
 
-    private suspend fun runDeltaThenFull(params: BoundParams, generation: Long) {
+    private suspend fun runDeltaThenFull(binding: TreeSyncBinding, generation: Long) {
         val delta = withTimeoutOrNull(policy.reconcileTimeoutMs + 1_000L) {
-            remote.reconcileTree(params)
+            remote.reconcileTree(binding)
         }
-        if (!isCurrent(params) || generation != reconcileGeneration) return
+        if (!isCurrent(binding) || generation != reconcileGeneration) return
         delta?.cliVersion?.let(listener::onPayloadCliVersion)
         if (delta == null || delta.added.isNotEmpty() || delta.gone.isNotEmpty()) {
-            runFullReconcile(params, generation)
+            runFullReconcile(binding, generation)
         }
     }
 
-    private suspend fun runFullReconcile(params: BoundParams, generation: Long) {
-        while (isCurrent(params) && generation == reconcileGeneration) {
+    private suspend fun runFullReconcile(binding: TreeSyncBinding, generation: Long) {
+        val params = binding.params
+        while (isCurrent(binding) && generation == reconcileGeneration) {
             // The warm connect has its own bound. It is intentionally outside
             // the enumeration timeout so a slow-but-valid cold dial is not
             // misreported as a 12-second list timeout.
-            remote.ensureWarmConnected(params)
-            if (!isCurrent(params) || generation != reconcileGeneration) return
+            remote.ensureWarmConnected(binding)
+            if (!isCurrent(binding) || generation != reconcileGeneration) return
             // The pre-extraction ViewModel awaited the bind-time engine
             // registry read before asking the folder gateway to enumerate
             // sessions. Keep that ordering at the coordinator boundary so a
             // cold bind cannot classify rows against an empty registry.
             awaitBeforeFullReconcile(params)
-            if (!isCurrent(params) || generation != reconcileGeneration) return
+            if (!isCurrent(binding) || generation != reconcileGeneration) return
             val result = withTimeoutOrNull(policy.reconcileTimeoutMs) {
-                remote.fullReconcile(params, lastWatchedFolders)
+                remote.fullReconcile(binding, lastWatchedFolders)
             } ?: TreeSyncRemote.FullResult.ConnectFailed(
                 FolderReconcileTimeoutException(policy.reconcileTimeoutMs),
             )
-            if (!isCurrent(params) || generation != reconcileGeneration) return
+            if (!isCurrent(binding) || generation != reconcileGeneration) return
             when (result) {
                 is TreeSyncRemote.FullResult.Sessions -> {
-                    applySuccessfulReconcile(params, result.result)
+                    applySuccessfulReconcile(binding, result.result)
                     return
                 }
                 TreeSyncRemote.FullResult.HostNotFound -> {
@@ -470,7 +499,7 @@ internal class TreeSyncCoordinator(
                     return
                 }
                 is TreeSyncRemote.FullResult.Failed -> {
-                    if (retryTransient(params, RuntimeException(result.message))) continue
+                    if (retryTransient(binding, RuntimeException(result.message))) continue
                     listener.onReconcileFailure(TreeSyncFailure.Failed(result.message))
                     return
                 }
@@ -479,7 +508,7 @@ internal class TreeSyncCoordinator(
                         listener.onReconcileFailure(TreeSyncFailure.Timeout)
                         return
                     }
-                    if (retryTransient(params, result.cause)) continue
+                    if (retryTransient(binding, result.cause)) continue
                     listener.onReconcileFailure(TreeSyncFailure.ConnectFailed(result.cause))
                     return
                 }
@@ -487,18 +516,18 @@ internal class TreeSyncCoordinator(
         }
     }
 
-    private suspend fun retryTransient(params: BoundParams, cause: Throwable): Boolean {
+    private suspend fun retryTransient(binding: TreeSyncBinding, cause: Throwable): Boolean {
         if (!isTransientFolderRefreshDrop(cause)) return false
         if (transientRetries >= policy.transientRetryLimit) {
             transientRetries = 0
             return false
         }
         transientRetries += 1
-        return isCurrent(params)
+        return isCurrent(binding)
     }
 
     private fun applySuccessfulReconcile(
-        params: BoundParams,
+        binding: TreeSyncBinding,
         result: FolderListResult.Sessions,
     ) {
         val entries = result.rows.map { it.toSessionEntry() }
@@ -520,22 +549,23 @@ internal class TreeSyncCoordinator(
         identityReconcileRequested = false
         listener.onReconcileSuccess(result)
         listener.onTreeChanged()
-        persist(params)
+        persist(binding)
     }
 
-    private fun ensureEventSubscription(params: BoundParams) {
-        if (eventJob?.isActive == true && bound == params) return
+    private fun ensureEventSubscription(binding: TreeSyncBinding) {
+        val params = binding.params
+        if (eventJob?.isActive == true && this.binding == binding) return
         eventJob?.cancel()
         eventJob = scope.launch {
-            remote.events(params).collect { event ->
-                if (!isCurrent(params) || !rootSnapshotLoadedState) return@collect
+            remote.events(binding).collect { event ->
+                if (!isCurrent(binding) || !rootSnapshotLoadedState) return@collect
                 when (event) {
                     TreeSyncEvent.SessionsChanged -> {
                         debounceJob?.cancel()
                         debounceJob = launch {
                             delay(policy.sessionsChangedDebounceMs)
-                            if (isCurrent(params) && rootSnapshotLoadedState) {
-                                scheduleReconcile(params, ReconcileMode.Full)
+                            if (isCurrent(binding) && rootSnapshotLoadedState) {
+                                scheduleReconcile(binding, ReconcileMode.Full)
                             }
                         }
                     }
@@ -549,26 +579,28 @@ internal class TreeSyncCoordinator(
         }
     }
 
-    private fun startPeriodic(params: BoundParams) {
+    private fun startPeriodic(binding: TreeSyncBinding) {
         periodicJob?.cancel()
         periodicJob = null
         if (!policy.periodicEnabled) return
         periodicJob = scope.launch {
-            while (isCurrent(params)) {
+            while (isCurrent(binding)) {
                 delay(policy.periodicReconcileMs)
-                if (isCurrent(params) && rootSnapshotLoadedState) {
-                    scheduleReconcile(params, ReconcileMode.Full)
+                if (isCurrent(binding) && rootSnapshotLoadedState) {
+                    scheduleReconcile(binding, ReconcileMode.Full)
                 }
             }
         }
     }
 
-    private fun persist(params: BoundParams) {
+    private fun persist(binding: TreeSyncBinding) {
+        val params = binding.params
         val nodes = tree.exportNodes().map { it.toTreeNode() }
         if (nodes.isNotEmpty()) {
             scope.launch {
+                if (!isCurrent(binding)) return@launch
                 withTimeoutOrNull(policy.hydrateTimeoutMs) {
-                    runCatching { remote.upsertTree(params, nodes) }
+                    runCatching { remote.upsertTree(binding, nodes) }
                 }
             }
         }
@@ -582,7 +614,9 @@ internal class TreeSyncCoordinator(
             historyProjectFoldersByRoot = structure.historyProjectFoldersByRoot,
         )
         scope.launch(dispatcher()) {
-            runCatching { cache.write(params.hostName, cached) }
+            if (isCurrent(binding)) {
+                runCatching { cache.write(params.hostName, cached) }
+            }
         }
     }
 
@@ -602,7 +636,7 @@ internal class TreeSyncCoordinator(
         listener.onRefreshingChanged(value)
     }
 
-    private fun isCurrent(params: BoundParams): Boolean = !closed && bound == params
+    private fun isCurrent(binding: TreeSyncBinding): Boolean = !closed && this.binding == binding
 
     private fun Listener.onLoadingRequestedIfNeeded() {
         // The ViewModel decides whether a Loading state would displace a Ready

--- a/app/src/test/java/com/pocketshell/app/projects/TreeSyncCoordinatorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/TreeSyncCoordinatorTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -26,6 +27,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.After
@@ -281,10 +283,14 @@ class TreeSyncCoordinatorTest {
             warmSessionAwaitMs = { 1_000L },
         )
 
-        remote.ensureWarmConnected(PARAMS)
-        remote.ensureWarmConnected(OTHER_PARAMS)
-        val tree = remote.getTree(OTHER_PARAMS)
-        val upgradeSession = remote.acquireSessionForUpgrade(OTHER_PARAMS)
+        val firstBinding = TreeSyncBinding(PARAMS, generation = 1L)
+        val secondBinding = TreeSyncBinding(OTHER_PARAMS, generation = 2L)
+        remote.bind(firstBinding)
+        remote.ensureWarmConnected(firstBinding)
+        remote.bind(secondBinding)
+        remote.ensureWarmConnected(secondBinding)
+        val tree = remote.getTree(secondBinding)
+        val upgradeSession = remote.acquireSessionForUpgrade(secondBinding)
 
         // Mutation caught: returning the still-connected first lease before
         // checking BoundParams makes both the tree RPC and upgrade use the
@@ -295,8 +301,129 @@ class TreeSyncCoordinatorTest {
         assertTrue(firstHostSession.closed)
     }
 
+    @Test
+    fun queuedPersistenceAndUpgradeCannotInvokeRemoteAfterHostSwitch() = runTest {
+        val remote = FakeRemote(
+            fullResults = ArrayDeque(listOf(success("held"))),
+        )
+        val coordinator = newCoordinator(remote, RecordingListener())
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        advanceUntilIdle()
+        remote.upsertBindings.clear()
+        remote.upgradeBindings.clear()
+
+        // Both jobs capture A but remain queued on the coordinator dispatcher.
+        // Bind(B) is the only lifecycle action between scheduling and running
+        // them, so the fake must record an invocation if either coordinator
+        // generation fence is removed.  The fake deliberately has no stale
+        // binding guard of its own.
+        coordinator.persistCurrentTree()
+        val upgradeResult = CompletableDeferred<SshSession?>()
+        backgroundScope.launch {
+            upgradeResult.complete(coordinator.acquireSessionForUpgrade(PARAMS))
+        }
+        coordinator.bind(OTHER_PARAMS, flowOf(emptyList()))
+        advanceUntilIdle()
+
+        // Mutation caught: removing TreeSyncCoordinator.persist's
+        // isCurrent(binding) check at its remote-call boundary invokes
+        // upsertTree(A) here.  This assertion therefore cannot be laundered by
+        // a remote double that independently rejects stale bindings.
+        assertTrue(remote.upsertBindings.isEmpty())
+        assertTrue(remote.upgradeBindings.isEmpty())
+        assertNull(upgradeResult.await())
+        assertEquals(OTHER_PARAMS, remote.currentBinding?.params)
+    }
+
+    @Test
+    fun inFlightPersistenceCannotReacquireOldLeaseAfterHostSwitch() = runTest {
+        val aConnectStarted = CompletableDeferred<Unit>()
+        val releaseAConnect = CompletableDeferred<Unit>()
+        val firstHostSession = HostTaggedSshSession("first-host")
+        val secondHostSession = HostTaggedSshSession("second-host")
+        val connector = BlockingHostRoutingConnector(
+            sessions = mapOf(
+                PARAMS.hostname to firstHostSession,
+                OTHER_PARAMS.hostname to secondHostSession,
+            ),
+            blockedHost = PARAMS.hostname,
+            connectStarted = aConnectStarted,
+            releaseConnect = releaseAConnect,
+        )
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val leaseManager = SshLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = 0L,
+            connectTimeoutContext = dispatcher,
+            abortTimeoutContext = dispatcher,
+        )
+        val treeSource = TreeRemoteSource().apply {
+            remoteExecDispatcher = dispatcher
+            remoteExecTimeoutMs = 1_000L
+        }
+        val remote = FolderListTreeSyncRemote(
+            gateway = unusedProxy(),
+            hostDao = unusedProxy(),
+            treeRemoteSource = treeSource,
+            sshLeaseManager = leaseManager,
+            activeTmuxClients = null,
+            scope = this,
+            dispatcher = { dispatcher },
+            warmSessionAwaitMs = { 1_000L },
+        )
+        val firstBinding = TreeSyncBinding(PARAMS, generation = 1L)
+        val secondBinding = TreeSyncBinding(OTHER_PARAMS, generation = 2L)
+
+        remote.bind(firstBinding)
+        val persistence = backgroundScope.launch {
+            remote.upsertTree(
+                firstBinding,
+                listOf(
+                    TreeRemoteSource.TreeNode(
+                        session = "persisted",
+                        order = 0,
+                        folderPath = "/persisted",
+                        collapsed = false,
+                    ),
+                ),
+            )
+        }
+        aConnectStarted.await()
+
+        // The A operation is suspended in the real adapter before its warm
+        // lease is acquired.  B becomes current while that operation is live;
+        // releasing A must not let the stale caller reacquire A or issue the
+        // persistence RPC with A's session.
+        remote.bind(secondBinding)
+        val bWarm = backgroundScope.launch { remote.ensureWarmConnected(secondBinding) }
+        val staleEnsure = backgroundScope.launch {
+            // This is the delayed ensure that a fire-and-forget persistence
+            // caller can reach after the host bind has already advanced.
+            remote.ensureWarmConnected(firstBinding)
+        }
+        releaseAConnect.complete(Unit)
+        advanceUntilIdle()
+        persistence.join()
+        staleEnsure.join()
+        bWarm.join()
+
+        // Mutation caught: removing the adapter's generation checks permits
+        // a second A lease request or an A tree RPC after bind(B).  The only
+        // valid post-switch connection is B, and A must never receive a tree
+        // command.
+        assertEquals(
+            listOf(PARAMS.hostname, OTHER_PARAMS.hostname),
+            connector.requestedHosts,
+        )
+        assertTrue(firstHostSession.execCommands.isEmpty())
+        assertFalse(persistence.isCancelled)
+        remote.releaseWarm()
+    }
+
     private fun TestScope.newCoordinator(
-        remote: FakeRemote,
+        remote: TreeSyncRemote,
         listener: RecordingListener,
         cache: TreeSyncCache? = null,
         policy: TreeSyncPolicy = TreeSyncPolicy(periodicEnabled = false),
@@ -364,14 +491,22 @@ class TreeSyncCoordinatorTest {
             private set
         var firstFullCancelled = false
             private set
+        val upsertBindings = mutableListOf<TreeSyncBinding>()
+        val upgradeBindings = mutableListOf<TreeSyncBinding>()
+        var currentBinding: TreeSyncBinding? = null
+            private set
         private var concurrent = 0
 
-        override fun events(params: BoundParams): Flow<TreeSyncEvent> = eventFlow
+        override fun bind(binding: TreeSyncBinding) {
+            currentBinding = binding
+        }
 
-        override suspend fun ensureWarmConnected(params: BoundParams) = Unit
+        override fun events(binding: TreeSyncBinding): Flow<TreeSyncEvent> = eventFlow
+
+        override suspend fun ensureWarmConnected(binding: TreeSyncBinding) = Unit
 
         override suspend fun fullReconcile(
-            params: BoundParams,
+            binding: TreeSyncBinding,
             watchedFolders: List<ProjectRootEntity>,
         ): TreeSyncRemote.FullResult {
             fullCalls++
@@ -397,19 +532,25 @@ class TreeSyncCoordinatorTest {
             }
         }
 
-        override suspend fun getTree(params: BoundParams): TreeRemoteSource.TreeResult = treeResult
+        override suspend fun getTree(binding: TreeSyncBinding): TreeRemoteSource.TreeResult = treeResult
 
-        override suspend fun reconcileTree(params: BoundParams): TreeRemoteSource.ReconcileDelta? {
+        override suspend fun reconcileTree(binding: TreeSyncBinding): TreeRemoteSource.ReconcileDelta? {
             deltaCalls++
             return deltas.removeFirstOrNull()
         }
 
         override suspend fun upsertTree(
-            params: BoundParams,
+            binding: TreeSyncBinding,
             nodes: List<TreeRemoteSource.TreeNode>,
-        ): Boolean = true
+        ): Boolean {
+            upsertBindings += binding
+            return true
+        }
 
-        override suspend fun acquireSessionForUpgrade(params: BoundParams): SshSession? = null
+        override suspend fun acquireSessionForUpgrade(binding: TreeSyncBinding): SshSession? {
+            upgradeBindings += binding
+            return null
+        }
 
         override suspend fun releaseWarm() = Unit
     }
@@ -425,21 +566,44 @@ class TreeSyncCoordinatorTest {
         }
     }
 
+    private class BlockingHostRoutingConnector(
+        private val sessions: Map<String, HostTaggedSshSession>,
+        private val blockedHost: String,
+        private val connectStarted: CompletableDeferred<Unit>,
+        private val releaseConnect: CompletableDeferred<Unit>,
+    ) : SshLeaseConnector {
+        val requestedHosts = mutableListOf<String>()
+
+        override suspend fun connect(target: com.pocketshell.core.ssh.SshLeaseTarget): Result<SshSession> {
+            val host = target.leaseKey.host
+            requestedHosts += host
+            if (host == blockedHost && requestedHosts.count { it == blockedHost } == 1) {
+                connectStarted.complete(Unit)
+                releaseConnect.await()
+            }
+            return Result.success(sessions.getValue(host))
+        }
+    }
+
     private class HostTaggedSshSession(
         private val hostTag: String,
     ) : SshSession {
         var closed = false
+        val execCommands = mutableListOf<String>()
 
         override val isConnected: Boolean
             get() = !closed
 
-        override suspend fun exec(command: String): ExecResult = ExecResult(
-            stdout = """
-                {"nodes":[{"session":"$hostTag","order":0,"folder_path":"/$hostTag","collapsed":false}]}
-            """.trimIndent(),
-            stderr = "",
-            exitCode = 0,
-        )
+        override suspend fun exec(command: String): ExecResult {
+            execCommands += command
+            return ExecResult(
+                stdout = """
+                    {"nodes":[{"session":"$hostTag","order":0,"folder_path":"/$hostTag","collapsed":false}]}
+                """.trimIndent(),
+                stderr = "",
+                exitCode = 0,
+            )
+        }
 
         override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
 

--- a/app/src/test/java/com/pocketshell/app/projects/TreeSyncCoordinatorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/TreeSyncCoordinatorTest.kt
@@ -1,0 +1,515 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.After
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+import java.lang.reflect.Proxy
+
+/**
+ * Focused contract tests for [TreeSyncCoordinator] (#2307).
+ *
+ * These are deliberately coordinator-level tests rather than command-string
+ * checks.  The load-bearing mutations are documented beside each test:
+ * bypassing [HostTreeModel.reconcile], treating an incomplete delta as final,
+ * removing the outer timeout, converting cancellation to failure, or allowing
+ * concurrent triggers would make the corresponding assertion fail.
+ */
+class TreeSyncCoordinatorTest {
+
+    private val coordinators = mutableListOf<TreeSyncCoordinator>()
+
+    @After
+    fun closeCoordinators() {
+        coordinators.forEach(TreeSyncCoordinator::close)
+        coordinators.clear()
+    }
+
+    @Test
+    fun successfulFullReconcileMutatesHeldTreeAndPublishesSuccess() = runTest {
+        val remote = FakeRemote(
+            fullResults = ArrayDeque(listOf(success("alpha"))),
+        )
+        val listener = RecordingListener()
+        val coordinator = newCoordinator(remote, listener)
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        advanceUntilIdle()
+
+        // Mutation caught: replacing this with a callback-only success leaves
+        // the held tree empty even though the remote returned a real row.
+        assertEquals(
+            "fullCalls=${remote.fullCalls}, successes=${listener.successes}, failures=${listener.failures}",
+            listOf("alpha"),
+            coordinator.tree.sessionEntries().map { it.sessionName },
+        )
+        assertEquals(1, remote.fullCalls)
+        assertEquals(1, listener.successes)
+        assertFalse(coordinator.isRefreshing)
+        coordinator.close()
+    }
+
+    @Test
+    fun durableCacheHydrateIsAdvisoryAndFullProbeStillWins() = runTest {
+        val remote = FakeRemote(
+            fullResults = ArrayDeque(listOf(success("live"))),
+            treeResult = TreeRemoteSource.TreeResult(
+                nodes = listOf(
+                    TreeRemoteSource.TreeNode(
+                        session = "cached",
+                        order = 0,
+                        folderPath = "/cached",
+                        collapsed = true,
+                    ),
+                ),
+            ),
+            hasDurableTree = true,
+        )
+        val listener = RecordingListener()
+        val coordinator = newCoordinator(
+            remote = remote,
+            listener = listener,
+            cache = FakeCache(),
+        )
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        advanceUntilIdle()
+
+        // Mutation caught: making hydrate authoritative would resurrect the
+        // cached placeholder after the live probe and hide the current row.
+        assertEquals(listOf("live"), coordinator.tree.sessionEntries().map { it.sessionName })
+        assertTrue(listener.treeChanges >= 1)
+    }
+
+    @Test
+    fun incompleteResumeDeltaEscalatesToAuthoritativeFullReconcile() = runTest {
+        val remote = FakeRemote(
+            fullResults = ArrayDeque(listOf(success("before"), success("after"))),
+            hasDurableTree = true,
+            deltas = ArrayDeque(
+                listOf(
+                    TreeRemoteSource.ReconcileDelta(
+                        alive = emptyList(),
+                        gone = listOf("before"),
+                        added = emptyList(),
+                    ),
+                ),
+            ),
+        )
+        val listener = RecordingListener()
+        val coordinator = newCoordinator(remote, listener)
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        advanceUntilIdle()
+        val fullCallsBeforeResume = remote.fullCalls
+
+        // A resume is only eligible after the held tree is stale and a genuine
+        // foreground generation occurs.
+        coordinator.forceTreeStaleForTest()
+        coordinator.setProcessStartedForTest(false)
+        advanceUntilIdle()
+        coordinator.setProcessStartedForTest(true)
+        advanceUntilIdle()
+
+        // Mutation caught: accepting a name-only `gone` delta would remove or
+        // retain by display name without the authoritative generation-safe probe.
+        assertEquals(fullCallsBeforeResume + 1, remote.fullCalls)
+        assertEquals(listOf("after"), coordinator.tree.sessionEntries().map { it.sessionName })
+        assertEquals(1, remote.deltaCalls)
+    }
+
+    @Test
+    fun reconcileTimeoutSurfacesFailureAndReleasesRefreshingState() = runTest {
+        val remote = FakeRemote(wedgeFull = true)
+        val listener = RecordingListener()
+        val coordinator = newCoordinator(
+            remote = remote,
+            listener = listener,
+            policy = TreeSyncPolicy(
+                reconcileTimeoutMs = 100L,
+                hydrateTimeoutMs = 100L,
+                periodicEnabled = false,
+            ),
+        )
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        advanceUntilIdle()
+        advanceTimeBy(101L)
+        advanceUntilIdle()
+
+        // Mutation caught: removing withTimeoutOrNull leaves a wedged remote
+        // call active and never gives the UI a retryable failure.
+        assertTrue(listener.failures.single() is TreeSyncFailure.Timeout)
+        assertFalse(coordinator.isRefreshing)
+        assertTrue(remote.fullCancelled)
+    }
+
+    @Test
+    fun partialFailurePreservesTheLastAuthoritativeTree() = runTest {
+        val remote = FakeRemote(
+            fullResults = ArrayDeque(
+                listOf(
+                    success("held"),
+                    TreeSyncRemote.FullResult.Failed("partial probe failure"),
+                ),
+            ),
+        )
+        val listener = RecordingListener()
+        val coordinator = newCoordinator(remote, listener)
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        advanceUntilIdle()
+        coordinator.requestReconcile()
+        advanceUntilIdle()
+
+        // Mutation caught: clearing the held tree before a failed refresh would
+        // turn a recoverable partial failure into a blank screen.
+        assertEquals(listOf("held"), coordinator.tree.sessionEntries().map { it.sessionName })
+        assertTrue(listener.failures.last() is TreeSyncFailure.Failed)
+        assertFalse(coordinator.isRefreshing)
+    }
+
+    @Test
+    fun cancellationDoesNotBecomeFailureOrApplyLateRows() = runTest {
+        val fullStarted = CompletableDeferred<Unit>()
+        val remote = FakeRemote(
+            wedgeFull = true,
+            firstCallStarted = fullStarted,
+        )
+        val listener = RecordingListener()
+        val coordinator = newCoordinator(remote, listener)
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        // Wait for the real bind -> hydrate -> initial full entry point to
+        // enter the remote call, then cancel that in-flight operation.  This
+        // catches cancellation being turned into a failure without advancing
+        // virtual time through the reconcile timeout first.
+        fullStarted.await()
+        coordinator.close()
+        advanceUntilIdle()
+
+        // Mutation caught: catching CancellationException as an ordinary
+        // failure would show an error after stop/host teardown; applying a late
+        // result would repopulate a coordinator that has been closed.
+        assertTrue(remote.fullCancelled)
+        assertTrue(listener.failures.isEmpty())
+        assertTrue(coordinator.tree.sessionEntries().isEmpty())
+    }
+
+    @Test
+    fun concurrentTriggersCancelOlderProbeAndOnlyLatestResultWins() = runTest {
+        val firstStarted = CompletableDeferred<Unit>()
+        val remote = FakeRemote(
+            fullResults = ArrayDeque(listOf(success("latest"))),
+            firstCallStarted = firstStarted,
+            wedgeFirstFull = true,
+        )
+        val listener = RecordingListener()
+        val coordinator = newCoordinator(remote, listener)
+
+        coordinator.bind(PARAMS, flowOf(emptyList()))
+        firstStarted.await()
+        coordinator.requestReconcile()
+        advanceUntilIdle()
+
+        // Mutation caught: launching the second trigger without cancelling or
+        // fencing the first permits overlap and allows the stale first result
+        // to overwrite the newer projection.
+        assertEquals(1, remote.maxConcurrent)
+        assertEquals(listOf("latest"), coordinator.tree.sessionEntries().map { it.sessionName })
+        assertTrue(remote.firstFullCancelled)
+    }
+
+    @Test
+    fun hostSwitchDoesNotReuseThePreviousWarmLeaseForTreeOrUpgrade() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val firstHostSession = HostTaggedSshSession("first-host")
+        val secondHostSession = HostTaggedSshSession("second-host")
+        val connector = HostRoutingConnector(
+            sessions = mapOf(
+                PARAMS.hostname to firstHostSession,
+                OTHER_PARAMS.hostname to secondHostSession,
+            ),
+        )
+        val leaseManager = SshLeaseManager(
+            connector = connector,
+            scope = this,
+            idleTtlMillis = 0L,
+            connectTimeoutContext = dispatcher,
+            abortTimeoutContext = dispatcher,
+        )
+        val treeSource = TreeRemoteSource().apply {
+            remoteExecDispatcher = dispatcher
+            remoteExecTimeoutMs = 1_000L
+        }
+        val remote = FolderListTreeSyncRemote(
+            gateway = unusedProxy(),
+            hostDao = unusedProxy(),
+            treeRemoteSource = treeSource,
+            sshLeaseManager = leaseManager,
+            activeTmuxClients = null,
+            scope = this,
+            dispatcher = { dispatcher },
+            warmSessionAwaitMs = { 1_000L },
+        )
+
+        remote.ensureWarmConnected(PARAMS)
+        remote.ensureWarmConnected(OTHER_PARAMS)
+        val tree = remote.getTree(OTHER_PARAMS)
+        val upgradeSession = remote.acquireSessionForUpgrade(OTHER_PARAMS)
+
+        // Mutation caught: returning the still-connected first lease before
+        // checking BoundParams makes both the tree RPC and upgrade use the
+        // previous host; the connector then records only the first dial.
+        assertEquals(listOf(PARAMS.hostname, OTHER_PARAMS.hostname), connector.requestedHosts)
+        assertEquals("second-host", tree.nodes.single().session)
+        assertSame(secondHostSession, upgradeSession)
+        assertTrue(firstHostSession.closed)
+    }
+
+    private fun TestScope.newCoordinator(
+        remote: FakeRemote,
+        listener: RecordingListener,
+        cache: TreeSyncCache? = null,
+        policy: TreeSyncPolicy = TreeSyncPolicy(periodicEnabled = false),
+    ): TreeSyncCoordinator {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        return TreeSyncCoordinator(
+            scope = CoroutineScope(SupervisorJob() + dispatcher),
+            remote = remote,
+            cache = cache,
+            processStarted = MutableStateFlow(true),
+            dispatcher = { dispatcher },
+            clock = { 10_000L },
+            policy = policy,
+            listener = listener,
+        ).also(coordinators::add)
+    }
+
+    private class RecordingListener : TreeSyncCoordinator.Listener {
+        var successes = 0
+        var synchronousTreeChanges = 0
+        var treeChanges = 0
+        val failures = mutableListOf<TreeSyncFailure>()
+
+        override fun onLoadingRequested() = Unit
+
+        override fun onRefreshingChanged(refreshing: Boolean) = Unit
+
+        override fun onTreeChanged(synchronous: Boolean) {
+            treeChanges++
+            if (synchronous) synchronousTreeChanges++
+        }
+
+        override fun onReconcileSuccess(result: FolderListResult.Sessions) {
+            successes++
+        }
+
+        override fun onReconcileFailure(failure: TreeSyncFailure) {
+            failures += failure
+        }
+
+        override fun onUnexpectedFailure(cause: Throwable) {
+            failures += TreeSyncFailure.Unexpected(cause)
+        }
+
+        override fun onPayloadCliVersion(version: String) = Unit
+    }
+
+    private class FakeRemote(
+        private val fullResults: ArrayDeque<TreeSyncRemote.FullResult> = ArrayDeque(),
+        private val deltas: ArrayDeque<TreeRemoteSource.ReconcileDelta?> = ArrayDeque(),
+        private val treeResult: TreeRemoteSource.TreeResult = TreeRemoteSource.TreeResult.Empty,
+        override val hasDurableTree: Boolean = false,
+        private val wedgeFull: Boolean = false,
+        private val firstCallStarted: CompletableDeferred<Unit>? = null,
+        private val wedgeFirstFull: Boolean = false,
+    ) : TreeSyncRemote {
+        val eventFlow = MutableSharedFlow<TreeSyncEvent>(extraBufferCapacity = 8)
+        var fullCalls = 0
+            private set
+        var deltaCalls = 0
+            private set
+        var maxConcurrent = 0
+            private set
+        var fullCancelled = false
+            private set
+        var firstFullCancelled = false
+            private set
+        private var concurrent = 0
+
+        override fun events(params: BoundParams): Flow<TreeSyncEvent> = eventFlow
+
+        override suspend fun ensureWarmConnected(params: BoundParams) = Unit
+
+        override suspend fun fullReconcile(
+            params: BoundParams,
+            watchedFolders: List<ProjectRootEntity>,
+        ): TreeSyncRemote.FullResult {
+            fullCalls++
+            concurrent++
+            maxConcurrent = maxOf(maxConcurrent, concurrent)
+            try {
+                if (fullCalls == 1) firstCallStarted?.complete(Unit)
+                if (wedgeFull || (wedgeFirstFull && fullCalls == 1)) {
+                    try {
+                        awaitCancellation()
+                    } catch (cancelled: CancellationException) {
+                        if (fullCalls == 1) firstFullCancelled = true
+                        fullCancelled = true
+                        throw cancelled
+                    }
+                }
+                return fullResults.removeFirstOrNull()
+                    ?: TreeSyncRemote.FullResult.Sessions(
+                        FolderListResult.Sessions(rows = emptyList()),
+                    )
+            } finally {
+                concurrent--
+            }
+        }
+
+        override suspend fun getTree(params: BoundParams): TreeRemoteSource.TreeResult = treeResult
+
+        override suspend fun reconcileTree(params: BoundParams): TreeRemoteSource.ReconcileDelta? {
+            deltaCalls++
+            return deltas.removeFirstOrNull()
+        }
+
+        override suspend fun upsertTree(
+            params: BoundParams,
+            nodes: List<TreeRemoteSource.TreeNode>,
+        ): Boolean = true
+
+        override suspend fun acquireSessionForUpgrade(params: BoundParams): SshSession? = null
+
+        override suspend fun releaseWarm() = Unit
+    }
+
+    private class HostRoutingConnector(
+        private val sessions: Map<String, HostTaggedSshSession>,
+    ) : SshLeaseConnector {
+        val requestedHosts = mutableListOf<String>()
+
+        override suspend fun connect(target: com.pocketshell.core.ssh.SshLeaseTarget): Result<SshSession> {
+            requestedHosts += target.leaseKey.host
+            return Result.success(sessions.getValue(target.leaseKey.host))
+        }
+    }
+
+    private class HostTaggedSshSession(
+        private val hostTag: String,
+    ) : SshSession {
+        var closed = false
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult = ExecResult(
+            stdout = """
+                {"nodes":[{"session":"$hostTag","order":0,"folder_path":"/$hostTag","collapsed":false}]}
+            """.trimIndent(),
+            stderr = "",
+            exitCode = 0,
+        )
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private inline fun <reified T> unusedProxy(): T = Proxy.newProxyInstance(
+        T::class.java.classLoader,
+        arrayOf(T::class.java),
+    ) { _, method, _ ->
+        error("${method.name} must not be called by this test")
+    } as T
+
+    private class FakeCache : TreeSyncCache {
+        override fun peek(host: String): TreeClientCache.CachedTree? = null
+
+        override fun read(host: String): TreeClientCache.CachedTree =
+            TreeClientCache.CachedTree(emptyList())
+
+        override fun write(host: String, tree: TreeClientCache.CachedTree) = Unit
+    }
+
+    private fun success(name: String): TreeSyncRemote.FullResult.Sessions =
+        TreeSyncRemote.FullResult.Sessions(
+            FolderListResult.Sessions(
+                rows = listOf(
+                    FolderSessionRow(
+                        sessionName = name,
+                        lastActivity = 1L,
+                        attached = false,
+                        cwd = "/home/alexey/git/$name",
+                    ),
+                ),
+            ),
+        )
+
+    private companion object {
+        val PARAMS = BoundParams(
+            hostId = 1L,
+            hostName = "test-host",
+            hostname = "127.0.0.1",
+            port = 22,
+            username = "test",
+            keyPath = "/tmp/key",
+            passphrase = null,
+        )
+        val OTHER_PARAMS = PARAMS.copy(
+            hostId = 2L,
+            hostName = "other-host",
+            hostname = "192.0.2.2",
+        )
+    }
+}


### PR DESCRIPTION
Closes #2307

## Summary
- Extract FolderList tree synchronization scheduling, remote transport, cache, and lifecycle into TreeSyncCoordinator seams.
- Preserve host tree behavior while keeping the VM as UI projection/action routing.
- Invalidate old warm leases on host switches and add a two-host regression.

## Verification
- Canonical full JVM before host-switch follow-up: Debug 5,015/5,015 and Release 4,997/4,997, zero failures/errors.
- Post-fix focused JVM: 17/17 (FolderList 9 + coordinator 8).
- Post-fix connected emulator + Docker bootstrap: 1/1, exit 0, no failures.
- Static/file-size guards and diff check pass.
- Independent reviewer: APPROVED.