### PR TITLE
release: v0.4.45 — aplexer Phase A + tmuxctl session list

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = 91
-        versionName = "0.4.44"
+        versionCode = 92
+        versionName = "0.4.45"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/pocketshell/app/composer/PromptComposerQueueBanners.kt
+++ b/app/src/main/java/com/pocketshell/app/composer/PromptComposerQueueBanners.kt
@@ -14,10 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
@@ -40,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pocketshell.app.voice.PendingTranscriptionItem
 import com.pocketshell.core.storage.entity.PendingTranscriptionEntity
+import com.pocketshell.uikit.components.ConfirmDialog
 import com.pocketshell.uikit.components.DisclosureIcon
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellType
@@ -293,40 +292,20 @@ private fun OutboundQueueBanner(
     }
     val confirmingItem = items.firstOrNull { it.id == resendConfirmationId }
     if (confirmingItem != null) {
-        AlertDialog(
-            onDismissRequest = { resendConfirmationId = null },
+        ConfirmDialog(
+            title = "Send again anyway?",
+            message = "The prompt may already have landed in the pane. Sending it again " +
+                "can create a duplicate.",
+            confirmLabel = "Send again",
+            onConfirm = {
+                resendConfirmationId = null
+                onResend(confirmingItem.id)
+            },
+            onDismiss = { resendConfirmationId = null },
             modifier = Modifier.testTag(composerOutboundQueueResendDialogRootTestTag(confirmingItem.id)),
-            title = {
-                Text(
-                    text = "Send again anyway?",
-                    modifier = Modifier.testTag(
-                        composerOutboundQueueResendDialogTitleTestTag(confirmingItem.id),
-                    ),
-                )
-            },
-            text = {
-                Text(
-                    text = "The prompt may already have landed in the pane. Sending it again " +
-                        "can create a duplicate.",
-                    modifier = Modifier.testTag(
-                        composerOutboundQueueResendDialogBodyTestTag(confirmingItem.id),
-                    ),
-                )
-            },
-            dismissButton = {
-                TextButton(onClick = { resendConfirmationId = null }) { Text("Cancel") }
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        resendConfirmationId = null
-                        onResend(confirmingItem.id)
-                    },
-                    modifier = Modifier.testTag(
-                        composerOutboundQueueResendDialogConfirmTestTag(confirmingItem.id),
-                    ),
-                ) { Text("Send again") }
-            },
+            confirmTestTag = composerOutboundQueueResendDialogConfirmTestTag(confirmingItem.id),
+            titleTestTag = composerOutboundQueueResendDialogTitleTestTag(confirmingItem.id),
+            messageTestTag = composerOutboundQueueResendDialogBodyTestTag(confirmingItem.id),
         )
     }
 }

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -140,6 +140,9 @@ data class FolderSessionRow(
      * [tmuxSessionId].
      */
     val sessionCreated: Long? = null,
+    /** `tmux` or `aplexer`. Default keeps existing tmux-only rows unchanged. */
+    val sessionManager: String = "tmux",
+    val aplexerId: String? = null,
 )
 
 /**
@@ -955,7 +958,12 @@ class SshFolderListGateway internal constructor(
                 // sole kind authority; foreign sessions get the one-shot daemon
                 // guess. No output-parsing detection on this list path.
                 val annotated = annotateAgentKinds(session, merged)
-                probes.sessions(annotated)
+                // Bare `tmux list-sessions` only sees the default socket (the
+                // 3 leftover sessions). tmuxctl/t walks every tmuxctl-* socket.
+                // Union the pocketshell enumerator so the phone matches the
+                // terminal, and fold in aplexer rows as a second manager.
+                val enumerator = fetchPocketshellEnumerator(session, familyForRawId)
+                probes.sessions(SshFolderListGateway.unionFolderSessionRows(enumerator, annotated))
             }
         }
     }
@@ -990,11 +998,90 @@ class SshFolderListGateway internal constructor(
         )
     }
 
+    private suspend fun fetchPocketshellEnumerator(
+        session: SshSession,
+        familyForRawId: (String?) -> SessionAgentKind? = { null },
+    ): List<FolderSessionRow> {
+        val json = try {
+            session.execBounded(pathAware(POCKETSHELL_SESSIONS_JSON_COMMAND))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+        if (json != null && json.exitCode == 0) {
+            val parsed = sessionListParser.parsePocketshellSessionsJson(json.stdout)
+            if (parsed != null) {
+                return parsed.map { it.asFolderSessionRow() }
+            }
+        }
+        val human = try {
+            session.execBounded(pathAware(POCKETSHELL_SESSIONS_COMMAND))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+        if (human != null && human.exitCode == 0) {
+            return parsePocketshellSessionsRows(human.stdout, sessionListParser)
+        }
+        return emptyList()
+    }
+
+    private fun HostTmuxSessionRow.asFolderSessionRow(): FolderSessionRow =
+        FolderSessionRow(
+            sessionName = name,
+            lastActivity = lastActivity,
+            attached = attached,
+            cwd = path,
+            agentKind = agentKind,
+            recordedKind = recordedKind,
+            recordedKindId = recordedKindId,
+            agentStateRaw = agentStateRaw,
+            agentStateUpdatedAt = agentStateUpdatedAt,
+            tmuxSessionId = tmuxSessionId,
+            sessionCreated = createdAt,
+            sessionManager = manager,
+            aplexerId = aplexerId,
+        )
+
     private suspend fun listSessionsWithFolderFromPocketshell(
         session: SshSession,
         probes: ReconcileSideProbes,
         familyForRawId: (String?) -> SessionAgentKind? = { null },
     ): FolderListResult.Sessions? {
+        val json = try {
+            session.execBounded(pathAware(POCKETSHELL_SESSIONS_JSON_COMMAND))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+        val jsonRows = json
+            ?.takeIf { it.exitCode == 0 }
+            ?.let { sessionListParser.parsePocketshellSessionsJson(it.stdout) }
+            ?.map { it.asFolderSessionRow() }
+        if (!jsonRows.isNullOrEmpty()) {
+            val structured = try {
+                session.execBounded(pathAware(POCKETSHELL_SESSIONS_TMUX_COMMAND))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                null
+            }
+            val structuredRows = structured
+                ?.takeIf { it.exitCode == 0 }
+                ?.let {
+                    parsePocketshellSessionsTmuxRows(
+                        stdout = it.stdout,
+                        familyForRawId = familyForRawId,
+                        parser = sessionListParser,
+                    )
+                }
+            return probes.sessions(
+                mergePocketshellSessionRows(jsonRows, structuredRows),
+            )
+        }
         val pocketshell = session.execBounded(pathAware(POCKETSHELL_SESSIONS_COMMAND))
         if (pocketshell.exitCode != 0) {
             if (pocketshell.isTmuxServerAbsent()) {
@@ -2146,6 +2233,7 @@ class SshFolderListGateway internal constructor(
                 "printf '%s\\n' \"\$__ps_n\""
 
         const val POCKETSHELL_SESSIONS_COMMAND: String = "pocketshell sessions list --by activity"
+        const val POCKETSHELL_SESSIONS_JSON_COMMAND: String = "pocketshell sessions list --json"
         /**
          * Optional raw-id enrichment for the legacy pocketshell fallback.
          * This is a bounded, directly supported tmux format probe rather than
@@ -2246,7 +2334,33 @@ class SshFolderListGateway internal constructor(
                 agentStateUpdatedAt = agentStateUpdatedAt,
                 tmuxSessionId = tmuxSessionId,
                 sessionCreated = createdAt,
+                sessionManager = manager,
+                aplexerId = aplexerId,
             )
+
+        /**
+         * [authority] is the tmuxctl + aplexer enumerator; [overlay] is the
+         * default-socket `tmux list-sessions` parse. Empty authority keeps
+         * overlay (older hosts without `pocketshell sessions list --json`).
+         */
+        internal fun unionFolderSessionRows(
+            authority: List<FolderSessionRow>,
+            overlay: List<FolderSessionRow>,
+        ): List<FolderSessionRow> {
+            if (authority.isEmpty()) return overlay
+            val overlayByName = overlay.associateBy { it.sessionName }
+            val merged = authority.map { row ->
+                val extra = overlayByName[row.sessionName] ?: return@map row
+                extra.copy(
+                    sessionName = row.sessionName,
+                    sessionManager = row.sessionManager,
+                    aplexerId = row.aplexerId ?: extra.aplexerId,
+                    cwd = extra.cwd ?: row.cwd,
+                )
+            }
+            val seen = authority.mapTo(HashSet()) { it.sessionName }
+            return merged + overlay.filter { it.sessionName !in seen }
+        }
 
         /**
          * Keep the human list authoritative for ordering and compatibility,

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -962,8 +962,15 @@ class SshFolderListGateway internal constructor(
                 // 3 leftover sessions). tmuxctl/t walks every tmuxctl-* socket.
                 // Union the pocketshell enumerator so the phone matches the
                 // terminal, and fold in aplexer rows as a second manager.
-                val enumerator = fetchPocketshellEnumerator(session, familyForRawId)
-                probes.sessions(SshFolderListGateway.unionFolderSessionRows(enumerator, annotated))
+                val enumerator = FolderListPocketshellEnumerator.fetch(
+                    parser = sessionListParser,
+                    exec = { command -> session.execBounded(command) },
+                    jsonCommand = pathAware(POCKETSHELL_SESSIONS_JSON_COMMAND),
+                    humanCommand = pathAware(POCKETSHELL_SESSIONS_COMMAND),
+                )
+                probes.sessions(
+                    FolderListPocketshellEnumerator.unionFolderSessionRows(enumerator, annotated),
+                )
             }
         }
     }
@@ -998,60 +1005,6 @@ class SshFolderListGateway internal constructor(
         )
     }
 
-    private suspend fun fetchPocketshellEnumerator(
-        session: SshSession,
-        familyForRawId: (String?) -> SessionAgentKind? = { null },
-    ): List<FolderSessionRow> {
-        val json = try {
-            session.execBounded(pathAware(POCKETSHELL_SESSIONS_JSON_COMMAND))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Throwable) {
-            null
-        }
-        if (json != null && json.exitCode == 0) {
-            val parsed = sessionListParser.parsePocketshellSessionsJson(json.stdout)
-            if (parsed != null) {
-                return parsed.map { it.asFolderSessionRow() }
-            }
-            // Exit 0 with a blank body is an empty enumerator, not a prompt
-            // to fall through to the human table (that second exec was
-            // stealing the next queued fake response and breaking lease-reuse
-            // command accounting).
-            if (json.stdout.isBlank()) {
-                return emptyList()
-            }
-        }
-        val human = try {
-            session.execBounded(pathAware(POCKETSHELL_SESSIONS_COMMAND))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Throwable) {
-            null
-        }
-        if (human != null && human.exitCode == 0) {
-            return parsePocketshellSessionsRows(human.stdout, sessionListParser)
-        }
-        return emptyList()
-    }
-
-    private fun HostTmuxSessionRow.asFolderSessionRow(): FolderSessionRow =
-        FolderSessionRow(
-            sessionName = name,
-            lastActivity = lastActivity,
-            attached = attached,
-            cwd = path,
-            agentKind = agentKind,
-            recordedKind = recordedKind,
-            recordedKindId = recordedKindId,
-            agentStateRaw = agentStateRaw,
-            agentStateUpdatedAt = agentStateUpdatedAt,
-            tmuxSessionId = tmuxSessionId,
-            sessionCreated = createdAt,
-            sessionManager = manager,
-            aplexerId = aplexerId,
-        )
-
     private suspend fun listSessionsWithFolderFromPocketshell(
         session: SshSession,
         probes: ReconcileSideProbes,
@@ -1067,7 +1020,7 @@ class SshFolderListGateway internal constructor(
         val jsonRows = json
             ?.takeIf { it.exitCode == 0 }
             ?.let { sessionListParser.parsePocketshellSessionsJson(it.stdout) }
-            ?.map { it.asFolderSessionRow() }
+            ?.map { with(FolderListPocketshellEnumerator) { it.toFolderSessionRow() } }
         if (!jsonRows.isNullOrEmpty()) {
             val structured = try {
                 session.execBounded(pathAware(POCKETSHELL_SESSIONS_TMUX_COMMAND))
@@ -2318,7 +2271,9 @@ class SshFolderListGateway internal constructor(
             stdout: String,
             parser: HostTmuxSessionListParser = HostTmuxSessionListParser(),
         ): List<FolderSessionRow> =
-            parser.parsePocketshellSessionsList(stdout).map { it.toFolderSessionRow() }
+            parser.parsePocketshellSessionsList(stdout).map {
+                with(FolderListPocketshellEnumerator) { it.toFolderSessionRow() }
+            }
 
         internal fun parsePocketshellSessionsTmuxRows(
             stdout: String,
@@ -2326,48 +2281,7 @@ class SshFolderListGateway internal constructor(
             parser: HostTmuxSessionListParser = HostTmuxSessionListParser(),
         ): List<FolderSessionRow> =
             parser.parseTmuxListSessions(stdout, familyForRawId)
-                .map { it.toFolderSessionRow() }
-
-        private fun HostTmuxSessionRow.toFolderSessionRow(): FolderSessionRow =
-            FolderSessionRow(
-                sessionName = name,
-                lastActivity = lastActivity,
-                attached = attached,
-                cwd = path,
-                agentKind = agentKind,
-                recordedKind = recordedKind,
-                recordedKindId = recordedKindId,
-                agentStateRaw = agentStateRaw,
-                agentStateUpdatedAt = agentStateUpdatedAt,
-                tmuxSessionId = tmuxSessionId,
-                sessionCreated = createdAt,
-                sessionManager = manager,
-                aplexerId = aplexerId,
-            )
-
-        /**
-         * [authority] is the tmuxctl + aplexer enumerator; [overlay] is the
-         * default-socket `tmux list-sessions` parse. Empty authority keeps
-         * overlay (older hosts without `pocketshell sessions list --json`).
-         */
-        internal fun unionFolderSessionRows(
-            authority: List<FolderSessionRow>,
-            overlay: List<FolderSessionRow>,
-        ): List<FolderSessionRow> {
-            if (authority.isEmpty()) return overlay
-            val overlayByName = overlay.associateBy { it.sessionName }
-            val merged = authority.map { row ->
-                val extra = overlayByName[row.sessionName] ?: return@map row
-                extra.copy(
-                    sessionName = row.sessionName,
-                    sessionManager = row.sessionManager,
-                    aplexerId = row.aplexerId ?: extra.aplexerId,
-                    cwd = extra.cwd ?: row.cwd,
-                )
-            }
-            val seen = authority.mapTo(HashSet()) { it.sessionName }
-            return merged + overlay.filter { it.sessionName !in seen }
-        }
+                .map { with(FolderListPocketshellEnumerator) { it.toFolderSessionRow() } }
 
         /**
          * Keep the human list authoritative for ordering and compatibility,

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -1014,6 +1014,13 @@ class SshFolderListGateway internal constructor(
             if (parsed != null) {
                 return parsed.map { it.asFolderSessionRow() }
             }
+            // Exit 0 with a blank body is an empty enumerator, not a prompt
+            // to fall through to the human table (that second exec was
+            // stealing the next queued fake response and breaking lease-reuse
+            // command accounting).
+            if (json.stdout.isBlank()) {
+                return emptyList()
+            }
         }
         val human = try {
             session.execBounded(pathAware(POCKETSHELL_SESSIONS_COMMAND))

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListPocketshellEnumerator.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListPocketshellEnumerator.kt
@@ -1,0 +1,87 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.sessions.HostTmuxSessionListParser
+import com.pocketshell.app.sessions.HostTmuxSessionRow
+import com.pocketshell.core.ssh.ExecResult
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Live session names from `pocketshell sessions list --json` (tmuxctl + aplexer),
+ * with a human-table fallback for older hosts.
+ */
+internal object FolderListPocketshellEnumerator {
+    suspend fun fetch(
+        parser: HostTmuxSessionListParser,
+        exec: suspend (String) -> ExecResult,
+        jsonCommand: String,
+        humanCommand: String,
+    ): List<FolderSessionRow> {
+        val json = try {
+            exec(jsonCommand)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+        if (json != null && json.exitCode == 0) {
+            val parsed = parser.parsePocketshellSessionsJson(json.stdout)
+            if (parsed != null) {
+                return parsed.map { it.toFolderSessionRow() }
+            }
+            // Exit 0 with a blank body is an empty enumerator, not a prompt
+            // to fall through to the human table (that second exec was
+            // stealing the next queued fake response and breaking lease-reuse
+            // command accounting).
+            if (json.stdout.isBlank()) {
+                return emptyList()
+            }
+        }
+        val human = try {
+            exec(humanCommand)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+        if (human != null && human.exitCode == 0) {
+            return SshFolderListGateway.parsePocketshellSessionsRows(human.stdout, parser)
+        }
+        return emptyList()
+    }
+
+    fun unionFolderSessionRows(
+        authority: List<FolderSessionRow>,
+        overlay: List<FolderSessionRow>,
+    ): List<FolderSessionRow> {
+        if (authority.isEmpty()) return overlay
+        val overlayByName = overlay.associateBy { it.sessionName }
+        val merged = authority.map { row ->
+            val extra = overlayByName[row.sessionName] ?: return@map row
+            extra.copy(
+                sessionName = row.sessionName,
+                sessionManager = row.sessionManager,
+                aplexerId = row.aplexerId ?: extra.aplexerId,
+                cwd = extra.cwd ?: row.cwd,
+            )
+        }
+        val seen = authority.mapTo(HashSet()) { it.sessionName }
+        return merged + overlay.filter { it.sessionName !in seen }
+    }
+
+    fun HostTmuxSessionRow.toFolderSessionRow(): FolderSessionRow =
+        FolderSessionRow(
+            sessionName = name,
+            lastActivity = lastActivity,
+            attached = attached,
+            cwd = path,
+            agentKind = agentKind,
+            recordedKind = recordedKind,
+            recordedKindId = recordedKindId,
+            agentStateRaw = agentStateRaw,
+            agentStateUpdatedAt = agentStateUpdatedAt,
+            tmuxSessionId = tmuxSessionId,
+            sessionCreated = createdAt,
+            sessionManager = manager,
+            aplexerId = aplexerId,
+        )
+}

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionListParser.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionListParser.kt
@@ -3,6 +3,7 @@ package com.pocketshell.app.sessions
 import com.pocketshell.uikit.model.parseAgentStateUpdatedAtEpochSec
 import com.pocketshell.uikit.model.SessionAgentKind
 import com.pocketshell.uikit.model.sessionAgentKindFromOption
+import org.json.JSONObject
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -13,6 +14,69 @@ class HostTmuxSessionListParser @Inject constructor() {
         stdout.lineSequence()
             .mapNotNull(::parsePocketshellSessionsListRow)
             .toList()
+
+    /**
+     * Structured enumerator from `pocketshell sessions list --json`.
+     * Null when the payload is not that object (older hosts, or the human
+     * table). Empty list is a valid "no sessions" result.
+     */
+    fun parsePocketshellSessionsJson(stdout: String): List<HostTmuxSessionRow>? {
+        val trimmed = stdout.trim()
+        if (!trimmed.startsWith("{")) return null
+        return runCatching {
+            val root = JSONObject(trimmed)
+            val array = root.optJSONArray("sessions") ?: return null
+            buildList {
+                for (index in 0 until array.length()) {
+                    val obj = array.optJSONObject(index) ?: continue
+                    val name = obj.optString("name").trim()
+                    if (name.isEmpty()) continue
+                    val manager = obj.optString("manager").trim().ifEmpty { "tmux" }
+                    val ident = obj.optString("id").trim().ifEmpty { null }
+                    val workspace = obj.optString("workspace").trim().ifEmpty { null }
+                    val engine = obj.optString("engine").trim().ifEmpty { null }
+                    val createdEpoch = obj.optLong("created_epoch", Long.MIN_VALUE)
+                        .takeIf { it != Long.MIN_VALUE && it > 0L }
+                    add(
+                        HostTmuxSessionRow(
+                            name = name,
+                            createdAt = createdEpoch,
+                            lastActivity = createdEpoch,
+                            path = workspace,
+                            recordedKindId = engine,
+                            manager = manager,
+                            aplexerId = ident.takeIf { manager == "aplexer" },
+                        ),
+                    )
+                }
+            }
+        }.getOrNull()
+    }
+
+    /**
+     * [authority] is the tmuxctl + aplexer enumerator (the name set the
+     * terminal shows). [overlay] is a `tmux list-sessions` parse (default
+     * socket, often a subset). Result is authority order, with overlay
+     * metadata copied onto matching names, then any overlay-only names.
+     */
+    fun unionLiveSessionRows(
+        authority: List<HostTmuxSessionRow>,
+        overlay: List<HostTmuxSessionRow>,
+    ): List<HostTmuxSessionRow> {
+        if (authority.isEmpty()) return overlay
+        val overlayByName = overlay.associateBy { it.name }
+        val merged = authority.map { row ->
+            val extra = overlayByName[row.name] ?: return@map row
+            extra.copy(
+                name = row.name,
+                manager = row.manager,
+                aplexerId = row.aplexerId ?: extra.aplexerId,
+                path = extra.path ?: row.path,
+            )
+        }
+        val seen = authority.mapTo(HashSet()) { it.name }
+        return merged + overlay.filter { it.name !in seen }
+    }
 
     fun parseTmuxListSessions(
         stdout: String,

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerModels.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerModels.kt
@@ -40,6 +40,13 @@ data class HostTmuxSessionRow(
      * absent or the source shape did not carry it.
      */
     val agentStateUpdatedAt: Long? = null,
+    /**
+     * Session manager that owns this row: `tmux` (tmuxctl enumerator) or
+     * `aplexer`. Default `tmux` so legacy parsers keep working.
+     */
+    val manager: String = "tmux",
+    /** Aplexer session UUID when [manager] is `aplexer`. */
+    val aplexerId: String? = null,
 )
 
 data class HostTmuxSessionPickerRequest(

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
@@ -115,11 +115,15 @@ class SshHostTmuxSessionsGateway internal constructor(
             ) { session ->
                 val tmux = session.execTmuxListSessions(pathAware(LIST_SESSIONS_COMMAND))
                 when {
-                    tmux.exitCode == 0 -> HostTmuxSessionListResult.Sessions(
-                        parser.parseTmuxListSessions(tmux.stdout) { rawId ->
+                    tmux.exitCode == 0 -> {
+                        val overlay = parser.parseTmuxListSessions(tmux.stdout) { rawId ->
                             enginesGateway?.familyForRawId(host.id, rawId)
-                        },
-                    )
+                        }
+                        val enumerator = enumeratorFromPocketshell(session)
+                        HostTmuxSessionListResult.Sessions(
+                            parser.unionLiveSessionRows(enumerator, overlay),
+                        )
+                    }
                     tmux.exitCode == 127 || tmux.stderr.contains("not found", ignoreCase = true) ->
                         HostTmuxSessionListResult.ToolUnavailable
                     tmux.stderr.contains("no server running", ignoreCase = true) ->
@@ -150,6 +154,22 @@ class SshHostTmuxSessionsGateway internal constructor(
 
     private fun pathAware(command: String): String =
         ReposRemoteSource.pathAwareCommand(command)
+
+    private suspend fun enumeratorFromPocketshell(session: SshSession): List<HostTmuxSessionRow> {
+        val json = runCatching {
+            session.execTmuxListSessions(pathAware(POCKETSHELL_SESSIONS_JSON_COMMAND))
+        }.getOrNull()
+        if (json != null && json.exitCode == 0) {
+            parser.parsePocketshellSessionsJson(json.stdout)?.let { return it }
+        }
+        val human = runCatching {
+            session.execTmuxListSessions(pathAware(POCKETSHELL_SESSIONS_COMMAND))
+        }.getOrNull()
+        if (human != null && human.exitCode == 0) {
+            return parser.parsePocketshellSessionsList(human.stdout)
+        }
+        return emptyList()
+    }
 
     override suspend fun listSessionsFromLiveClient(
         host: HostEntity,
@@ -242,6 +262,11 @@ class SshHostTmuxSessionsGateway internal constructor(
          * [com.pocketshell.app.projects.SshFolderListGateway.LIST_SESSIONS_COMMAND].
          * See [com.pocketshell.core.tmux.TmuxRead].
          */
+        const val POCKETSHELL_SESSIONS_COMMAND: String =
+            "pocketshell sessions list --by activity"
+        const val POCKETSHELL_SESSIONS_JSON_COMMAND: String =
+            "pocketshell sessions list --json"
+
         const val LIST_SESSIONS_COMMAND: String =
             "${TmuxRead.CLIENT} list-sessions -F " +
                 "'#{session_id}::#{session_name}::#{session_created}::" +

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
@@ -1174,6 +1174,8 @@ class FolderListGatewayFallbackTest {
                         exitCode = 1,
                     )
                 }
+                command.contains(SshFolderListGateway.POCKETSHELL_SESSIONS_JSON_COMMAND) ->
+                    ExecResult(stdout = "", stderr = "", exitCode = 1)
                 command.contains(SshFolderListGateway.POCKETSHELL_SESSIONS_COMMAND) -> pocketshellResult
                 else -> ExecResult(stdout = "", stderr = "unexpected command: $command", exitCode = 1)
             }

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
@@ -50,18 +50,25 @@ class FolderListGatewaySshLeaseTest {
         // Issue #692: `list-sessions` + `list-panes` are now fetched in ONE
         // chained shell exec (a single SSH round-trip) instead of two serial
         // probes. The port scan is unchanged (3 commands inside PortScanner).
-        // Two polls => 2 enumeration round-trips + 2x3 port-scan = 8 execs
-        // (was 10 before the batch).
+        // After tmuxctl per-session sockets the folder list also asks
+        // `pocketshell sessions list --json` once per poll so the name set
+        // matches `tmuxctl list` / `t`. Two polls => 2 enumerations + 2 json
+        // enumerators + 2x3 port-scan = 10 execs on ONE reused lease.
+        val jsonEnumerator = ReposRemoteSource.pathAwareCommand(
+            SshFolderListGateway.POCKETSHELL_SESSIONS_JSON_COMMAND,
+        )
         assertEquals(
             listOf(
                 ENUMERATION_COMMAND,
                 "ss -tlnp 2>/dev/null | awk 'NR>1 {print \$4, \$7}'",
                 "netstat -tlnp 2>/dev/null | awk 'NR>1 && /LISTEN/ {print \$4, \$7}'",
                 "ss -tln 2>/dev/null | awk 'NR>1 {print \$4}'",
+                jsonEnumerator,
                 ENUMERATION_COMMAND,
                 "ss -tlnp 2>/dev/null | awk 'NR>1 {print \$4, \$7}'",
                 "netstat -tlnp 2>/dev/null | awk 'NR>1 && /LISTEN/ {print \$4, \$7}'",
                 "ss -tln 2>/dev/null | awk 'NR>1 {print \$4}'",
+                jsonEnumerator,
             ),
             session.execCommands,
         )

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewaySshLeaseTest.kt
@@ -57,21 +57,19 @@ class FolderListGatewaySshLeaseTest {
         val jsonEnumerator = ReposRemoteSource.pathAwareCommand(
             SshFolderListGateway.POCKETSHELL_SESSIONS_JSON_COMMAND,
         )
-        assertEquals(
-            listOf(
-                ENUMERATION_COMMAND,
-                "ss -tlnp 2>/dev/null | awk 'NR>1 {print \$4, \$7}'",
-                "netstat -tlnp 2>/dev/null | awk 'NR>1 && /LISTEN/ {print \$4, \$7}'",
-                "ss -tln 2>/dev/null | awk 'NR>1 {print \$4}'",
-                jsonEnumerator,
-                ENUMERATION_COMMAND,
-                "ss -tlnp 2>/dev/null | awk 'NR>1 {print \$4, \$7}'",
-                "netstat -tlnp 2>/dev/null | awk 'NR>1 && /LISTEN/ {print \$4, \$7}'",
-                "ss -tln 2>/dev/null | awk 'NR>1 {print \$4}'",
-                jsonEnumerator,
-            ),
-            session.execCommands,
+        val portScans = listOf(
+            "ss -tlnp 2>/dev/null | awk 'NR>1 {print \$4, \$7}'",
+            "netstat -tlnp 2>/dev/null | awk 'NR>1 && /LISTEN/ {print \$4, \$7}'",
+            "ss -tln 2>/dev/null | awk 'NR>1 {print \$4}'",
         )
+        // execBounded hops to Dispatchers.IO, so the JSON enumerator and the
+        // concurrent port scan can interleave; the contract is counts on one
+        // reused lease, not a frozen interleaving.
+        assertEquals(2, session.execCommands.count { it == ENUMERATION_COMMAND })
+        assertEquals(2, session.execCommands.count { it == jsonEnumerator })
+        assertEquals(6, session.execCommands.count { it in portScans })
+        assertEquals(10, session.execCommands.size)
+        assertTrue(session.execCommands.none { it.contains("sessions list --by") })
     }
 
     private val ENUMERATION_COMMAND: String = ReposRemoteSource.pathAwareCommand(

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionListParserTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionListParserTest.kt
@@ -399,4 +399,95 @@ class HostTmuxSessionListParserTest {
         assertNull(parser.parseTmuxListSessionsRow("name\tcreated"))
         assertNull(parser.parseTmuxListSessionsRow("\t1\t2\t0"))
     }
+
+    @Test
+    fun parsePocketshellSessionsListNameSetEqualsTmuxctlEnumeratorIncludingLongNames() {
+        val table = """
+            IDX  SESSION               CREATED
+            1    git-pocketshell-release 2026-08-27 09:22:55
+            2    git-aplexer-2         2026-08-26 19:05:34
+            3    git-dataops-2         2026-08-26 16:14:33
+            4    git-pocketshell-2     2026-08-26 15:51:07
+            5    git-dtc-website-4     2026-08-26 15:23:22
+            6    git-dtc-website-3     2026-08-26 15:09:26
+            7    git-zoom-calls        2026-08-26 13:48:17
+            8    git-aplexer           2026-08-26 13:09:26
+            9    git-game-tester       2026-08-26 07:12:25
+            10   git-ai-shipping-labs  2026-08-25 17:28:03
+            11   git-dtc-website       2026-08-24 12:26:03
+            12   git-pocketshell       2026-08-24 12:26:02
+
+            Join a session: tmuxctl <id> or tmuxctl <session>
+        """.trimIndent()
+        val names = parser.parsePocketshellSessionsList(table).map { it.name }.toSet()
+        assertEquals(12, names.size)
+        assertTrue(names.contains("git-pocketshell-release"))
+        val defaultSocketOnly = setOf("git-dtc-website", "git-game-tester", "git-pocketshell")
+        assertTrue(names.containsAll(defaultSocketOnly))
+        assertTrue(names.size > defaultSocketOnly.size)
+    }
+
+    @Test
+    fun parsePocketshellSessionsJsonUnionsTmuxAndAplexerManagers() {
+        val json = """
+            {
+              "managers": ["tmux", "aplexer"],
+              "sessions": [
+                {"name": "git-pocketshell", "manager": "tmux"},
+                {"name": "git-aplexer-2", "manager": "tmux"},
+                {
+                  "name": "toyaikit:codex",
+                  "manager": "aplexer",
+                  "id": "b3feff71-4a78-4055-a2d3-6c99187ecffb",
+                  "workspace": "/home/alexey/git/toyaikit",
+                  "engine": "codex",
+                  "attach": "a attach b3feff71-4a78-4055-a2d3-6c99187ecffb"
+                }
+              ]
+            }
+        """.trimIndent()
+        val rows = parser.parsePocketshellSessionsJson(json)
+        assertEquals(listOf("git-pocketshell", "git-aplexer-2", "toyaikit:codex"), rows?.map { it.name })
+        assertEquals(listOf("tmux", "tmux", "aplexer"), rows?.map { it.manager })
+        assertEquals("b3feff71-4a78-4055-a2d3-6c99187ecffb", rows?.get(2)?.aplexerId)
+        assertEquals("/home/alexey/git/toyaikit", rows?.get(2)?.path)
+    }
+
+    @Test
+    fun unionLiveSessionRowsUsesTmuxctlAuthorityNotDefaultSocketSubset() {
+        val overlay = parser.parseTmuxListSessions(
+            "git-dtc-website::1::1::1::0:::/home/alexey/git/dtc-website\n" +
+                "git-game-tester::1::1::1::0:::/home/alexey/git/game-tester\n" +
+                "git-pocketshell::1::1::1::0:::/home/alexey/git/pocketshell\n",
+        )
+        val authority = parser.parsePocketshellSessionsJson(
+            """
+            {"managers":["tmux"],"sessions":[
+              {"name":"git-pocketshell-release","manager":"tmux"},
+              {"name":"git-aplexer-2","manager":"tmux"},
+              {"name":"git-dtc-website","manager":"tmux"},
+              {"name":"git-game-tester","manager":"tmux"},
+              {"name":"git-pocketshell","manager":"tmux"}
+            ]}
+            """.trimIndent(),
+        )!!
+        val unioned = parser.unionLiveSessionRows(authority, overlay)
+        assertEquals(
+            listOf(
+                "git-pocketshell-release",
+                "git-aplexer-2",
+                "git-dtc-website",
+                "git-game-tester",
+                "git-pocketshell",
+            ),
+            unioned.map { it.name },
+        )
+        assertEquals("/home/alexey/git/pocketshell", unioned.last().path)
+        assertTrue(unioned.size > overlay.size)
+    }
+
+    @Test
+    fun parsePocketshellSessionsJsonRejectsHumanTable() {
+        assertNull(parser.parsePocketshellSessionsJson("IDX  SESSION               CREATED\n"))
+    }
 }

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
@@ -163,7 +163,7 @@ class HostTmuxSessionsGatewayTest {
                     SshHostTmuxSessionsGateway.LIST_SESSIONS_COMMAND,
                     SshHostTmuxSessionsGateway.LIST_SESSIONS_COMMAND,
                 ).map { ReposRemoteSource.pathAwareCommand(it) },
-                session.execCommands,
+                session.execCommands.filter { it.contains("list-sessions") },
             )
         } finally {
             manager.close()
@@ -429,6 +429,9 @@ class HostTmuxSessionsGatewayTest {
                 awaitCancellation()
             }
             execCommands += command
+            if (command.contains("pocketshell sessions list")) {
+                return ExecResult(stdout = "", stderr = "", exitCode = 1)
+            }
             return responses.removeFirstOrNull()
                 ?: ExecResult(stdout = "", stderr = "", exitCode = 0)
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ context; the README and current feature docs track released behavior.
 | [server-setup.md](server-setup.md) | Server-side `pocketshell` helper install, PATH, and troubleshooting |
 | [ux-rules.md](ux-rules.md) | Placement + transition rules across journeys (codified from #163); cite from every UX-touching issue |
 | [roadmap.md](roadmap.md) | Phased build order with rough sizing |
-| [aplexer-integration.md](aplexer-integration.md) | Becoming an aplexer client: phases A–C, current slice A1 (#2341) |
+| [aplexer-integration.md](aplexer-integration.md) | Becoming an aplexer client: phases A–C; Phase A done, both managers listed |
 | [decisions.md](decisions.md) | Log of what's locked, what's still open |
 | [testing.md](testing.md) | Android emulator + Docker remote-server test environment |
 | [docker-emulator-runbook.md](docker-emulator-runbook.md) | Docker profiles, ports, emulator commands, connected-test runbook |

--- a/docs/aplexer-integration.md
+++ b/docs/aplexer-integration.md
@@ -10,17 +10,17 @@ commit — treat this file as authoritative for *what PocketShell will do*,
 and the aplexer CLI/`--json` shapes as authoritative for *what exists
 today*).
 
-**Current slice: Phase A / A1 — shadow-mode profile listing.** (#2341)
+**Current slice: Phase A complete; listing both session managers.** (#2341)
 
 ```text
 Phase 0   aplexer registry surface          DONE (in aplexer)
-Phase A   engines / profiles / launch       IN PROGRESS
-  A1      shadow-mode `a profiles --json`   ← YOU ARE HERE  (#2341)
-  A2      engine listing via `a engines`
-  A3      launch via `a launch-spec`
-  A4      Electron presentation follow-through
-Phase B   aplexer PTY hosts selected sessions   NOT READY
-Phase C   aplexer default; tmux demoted         blocked on B
+Phase A   engines / profiles / launch       DONE
+  A1      prefer `a profiles --json` siblings   DONE
+  A2      engine listing via `a engines`        DONE
+  A3      launch via `a launch-spec`            DONE
+  A4      Electron presentation follow-through  inherited
+Phase B   aplexer PTY attach quality        NOT READY (list both managers anyway)
+Phase C   aplexer default; tmux demoted     blocked on B
 ```
 
 The integration seam is the **host CLI** (`tools/pocketshell/`), not the
@@ -34,15 +34,16 @@ inherits Phase A the same day the helper does.
 
 | Phase | Ready? | Meaning |
 | --- | --- | --- |
-| **A** — aplexer owns engines/profiles/launch; tmux still hosts terminals | **Yes — start now** | Host-CLI swap. Zero Kotlin/Electron attach changes. |
+| **A** — aplexer owns engines/profiles/launch; tmux still hosts terminals | **Done** | Host-CLI swap. Attach stays tmux `-CC`. |
 | **B** — aplexer PTY hosts selected sessions; both backends live | **Not shippable** | Runtime exists, but reattach, agent-state badges, and identity mapping are not. |
 | **C** — aplexer default; tmux demoted | Blocked on B | Plus leftover helper features (`jobs`, cards, usage) aplexer will not own. |
 
 Verified against aplexer HEAD (`87a4b89`): `a profiles --json`,
 `a engines --json`, `a launch-spec` / `a launch-exec`, forced
 `env_unset`, `opencode`, `a watch --jsonl`, and `a transcript` all exist.
-There is still no `aplexer` reference in this repo's production code
-(until A1).
+Host CLI probes `a` for profiles, engines, launch-spec, and session listing.
+Kill switches: `POCKETSHELL_APLEXER=0` plus per-feature `*_PROFILES` /
+`*_ENGINES` / `*_LAUNCH` / `*_SESSIONS`.
 
 ---
 
@@ -74,14 +75,15 @@ Aplexer polish that helps A3 but must not gate A1:
 `pocketshell agent <kind> …` into a tmux pane. Attach, `-CC`, session
 names, `@ps_*` options stay.
 
-### A1 — shadow-mode profile listing  ← current
+### A1 — prefer aplexer profile listing
 
 Issue: #2341.
 
 In `profiles.py`, probe `a profiles --json` when `a` is on PATH (or
 `$APLEXER_BIN`). Map entries onto `Profile` objects. Log divergence
-against native discovery. **Return native.** Kill switch:
-`POCKETSHELL_APLEXER_PROFILES=0`.
+against native discovery. **Prefer mapped siblings**; keep native
+`Claude`/`Codex` defaults. Native discovery is the fallback. Kill
+switches: `POCKETSHELL_APLEXER=0` / `POCKETSHELL_APLEXER_PROFILES=0`.
 
 Adapter (aplexer shape → PocketShell shape):
 
@@ -134,8 +136,11 @@ only then.
 
 ## Phase B — aplexer PTY hosts selected sessions; both backends supported
 
-**Do not start.** Aplexer has `a start` / `attach` / `snapshot` / `watch`,
-but PocketShell attach is not shippable on that runtime yet.
+**Attach quality is not shippable.** Listing both managers is required:
+`pocketshell sessions list --json` unions `tmuxctl list` names with
+`a snapshot` / `a list --json` rows tagged `manager=tmux|aplexer`. Tmux
+rows still attach over `-CC`. Aplexer rows carry `a attach <id>` for when
+reattach is ready. Do not feed `a attach` into a tmux control stream.
 
 | Blocker | Why it matters here |
 | --- | --- |

--- a/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
+++ b/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
@@ -265,3 +265,11 @@ com.pocketshell.app.voice.VoiceGestureCoachmarkLauncherProofTest	43
 # ca1510f2d226f63b24bd2d07e29faaa877572b7c26219afbc2ec79464aa8d332.
 com.pocketshell.app.proof.Issue1700StaleFlushJourneyE2eTest	79
 com.pocketshell.app.composer.PromptComposerOutboundQueueProductionDeleteDockerTest	260
+
+# Issue #2297: SessionCaptureContractTest is a small on-device Compose
+# fixture in the same package as TerminalViewportCaptureTest (21s). An
+# isolated `scripts/connected-test.sh --suffix i2345` invocation on
+# 2026-08-27 spent 216s wrapper wall (APK install + class) on a contended
+# AVD; that is not the in-suite cost. Use the sibling capture fixture's
+# measured 21s plus one extra test method.
+com.pocketshell.app.proof.signals.SessionCaptureContractTest	22

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ConfirmDialog.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ConfirmDialog.kt
@@ -53,6 +53,8 @@ import com.pocketshell.uikit.theme.PocketShellTypography
  *   hooks after migrating onto [ConfirmDialog] (e.g. a "Stop"/"Clear" confirm).
  * @param dismissTestTag optional `testTag` on the dismiss (Cancel) button, same
  *   migration rationale as [confirmTestTag].
+ * @param titleTestTag optional `testTag` on the title [Text].
+ * @param messageTestTag optional `testTag` on the body [Text].
  */
 @Composable
 fun ConfirmDialog(
@@ -66,6 +68,8 @@ fun ConfirmDialog(
     dismissLabel: String = "Cancel",
     confirmTestTag: String? = null,
     dismissTestTag: String? = null,
+    titleTestTag: String? = null,
+    messageTestTag: String? = null,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -75,6 +79,7 @@ fun ConfirmDialog(
                 text = title,
                 color = PocketShellColors.Text,
                 style = PocketShellTypography.titleMedium,
+                modifier = if (titleTestTag != null) Modifier.testTag(titleTestTag) else Modifier,
             )
         },
         text = {
@@ -82,6 +87,7 @@ fun ConfirmDialog(
                 text = message,
                 color = PocketShellColors.TextSecondary,
                 style = PocketShellTypography.bodyMedium,
+                modifier = if (messageTestTag != null) Modifier.testTag(messageTestTag) else Modifier,
             )
         },
         confirmButton = {

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/ConfirmDialogTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/ConfirmDialogTest.kt
@@ -160,4 +160,25 @@ class ConfirmDialogTest {
         composeRule.onNodeWithText("Share").performClick()
         composeRule.runOnIdle { assertEquals(1, confirmed) }
     }
+
+    @Test
+    fun optionalTestTagsLandOnTitleMessageAndConfirm() {
+        composeRule.setContent {
+            PocketShellTheme {
+                ConfirmDialog(
+                    title = "Send again anyway?",
+                    message = "The prompt may already have landed.",
+                    confirmLabel = "Send again",
+                    onConfirm = {},
+                    onDismiss = {},
+                    confirmTestTag = "confirm-tag",
+                    titleTestTag = "title-tag",
+                    messageTestTag = "body-tag",
+                )
+            }
+        }
+        composeRule.onNodeWithTag("title-tag").assertIsDisplayed()
+        composeRule.onNodeWithTag("body-tag").assertIsDisplayed()
+        composeRule.onNodeWithTag("confirm-tag").assertIsDisplayed()
+    }
 }

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -8,7 +8,7 @@ name = "pocketshell"
 # scripts/check-pypi-version.sh enforces this; .github/workflows/build.yml
 # runs that check before publishing to PyPI. See
 # tools/pocketshell/README.md ("Release flow") for the bump procedure.
-version = "0.4.44"
+version = "0.4.45"
 description = "Unified server-side Python utility for the PocketShell Android client."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tools/pocketshell/src/pocketshell/agents.py
+++ b/tools/pocketshell/src/pocketshell/agents.py
@@ -88,6 +88,7 @@ from urllib.parse import quote
 
 import click
 
+from pocketshell import aplexer
 from pocketshell.engines import builtin_engine_ids, engine_for, load_registry
 from pocketshell.env import merged_exports
 
@@ -809,6 +810,84 @@ def record_agent_source(
     return True
 
 
+def _aplexer_profile_id(config_dir: Optional[str]) -> Optional[str]:
+    """Dir-stem aplexer uses as the profile id (``zlaude`` from ``~/.zlaude``)."""
+    if not config_dir:
+        return None
+    stem = Path(config_dir).name.lstrip(".")
+    return stem or None
+
+
+def _aplexer_launch_spec(
+    kind: str,
+    cwd: str,
+    *,
+    skip_permissions: bool,
+    config_dir: Optional[str],
+) -> Optional[dict]:
+    """``a launch-spec --json`` or None on skip/failure.
+
+    PocketShell still owns folder ``.env`` merge, Claude trust seeding, and
+    ``@ps_*`` tmux options; this is only argv + provider-strip + engine env.
+    """
+    args = ["launch-spec", "--engine", kind, "--cwd", cwd]
+    if not skip_permissions:
+        args.append("--no-skip-permissions")
+    profile_id = _aplexer_profile_id(config_dir)
+    if profile_id:
+        args.extend(["--profile", profile_id])
+    payload = aplexer.run_json(
+        args, feature="launch", timeout=aplexer.LAUNCH_TIMEOUT_S
+    )
+    if not isinstance(payload, dict):
+        return None
+    argv = payload.get("argv")
+    if not isinstance(argv, list) or not argv:
+        return None
+    return payload
+
+
+def _ordered_env_unset(*groups: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            name for group in groups for name in group if str(name).strip()
+        )
+    )
+
+
+def _env_from_launch_spec(
+    spec: dict,
+    *,
+    folder_exports: dict[str, str],
+    extra_env: Optional[dict[str, str]],
+    config_dir: Optional[str],
+    profile_env: Optional[str],
+) -> dict[str, str]:
+    """Layer PocketShell env on top of a launch-spec, then strip keys.
+
+    Always unions the host-wide provider strip with ``spec.env_unset`` so a
+    partial/mutant spec cannot leave subscription keys in the child env.
+    """
+    env = dict(os.environ)
+    env.update(folder_exports)
+    if extra_env:
+        env.update(extra_env)
+    env_set = spec.get("env_set")
+    if isinstance(env_set, dict):
+        env.update({str(k): str(v) for k, v in env_set.items()})
+    if config_dir and profile_env:
+        env[profile_env] = config_dir
+    raw_unset = spec.get("env_unset")
+    spec_unset = (
+        tuple(str(name) for name in raw_unset)
+        if isinstance(raw_unset, list)
+        else ()
+    )
+    for name in _ordered_env_unset(PROVIDER_ENV_UNSET_VARS, spec_unset):
+        env.pop(name, None)
+    return env
+
+
 def launch_agent(
     ctx: click.Context,
     kind: str,
@@ -871,14 +950,30 @@ def launch_agent(
     resolved_dir = str(path)
 
     folder_exports = merged_exports(path)
-    env = build_env(
+    spec = _aplexer_launch_spec(
         kind,
-        dict(os.environ),
-        folder_exports,
+        resolved_dir,
+        skip_permissions=skip_permissions,
         config_dir=config_dir,
-        extra_env=extra_env,
     )
-    argv = build_argv(kind, skip_permissions=skip_permissions)
+    if spec is not None:
+        argv = [str(part) for part in spec["argv"]]
+        env = _env_from_launch_spec(
+            spec,
+            folder_exports=folder_exports,
+            extra_env=extra_env,
+            config_dir=config_dir,
+            profile_env=manifest.launch.profile_env,
+        )
+    else:
+        env = build_env(
+            kind,
+            dict(os.environ),
+            folder_exports,
+            config_dir=config_dir,
+            extra_env=extra_env,
+        )
+        argv = build_argv(kind, skip_permissions=skip_permissions)
 
     # Preflight: confirm the agent CLI is on PATH *before* os.chdir + exec.
     # Without this, a missing `claude`/`codex`/`opencode` makes os.execvpe

--- a/tools/pocketshell/src/pocketshell/aplexer.py
+++ b/tools/pocketshell/src/pocketshell/aplexer.py
@@ -1,0 +1,108 @@
+"""Host-local client for the ``a`` binary (aplexer Phase A).
+
+PocketShell and aplexer share a machine: the helper invokes ``a --json …``
+and overlays presentation/tmux concerns. Probe failures are silent and
+return ``None`` so every call site can fall back to the native path.
+
+Kill switches (any one is enough to skip):
+
+- ``POCKETSHELL_APLEXER=0`` — master
+- ``POCKETSHELL_APLEXER_PROFILES=0``
+- ``POCKETSHELL_APLEXER_ENGINES=0``
+- ``POCKETSHELL_APLEXER_LAUNCH=0``
+- ``POCKETSHELL_APLEXER_SESSIONS=0``
+
+``APLEXER_BIN`` overrides ``PATH`` lookup of ``a``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+from typing import Any, Mapping, Optional
+
+JSON_TIMEOUT_S = 2.0
+LAUNCH_TIMEOUT_S = 5.0
+BIN_ENV = "APLEXER_BIN"
+# Snapshot Popen so helper tests that patch ``subprocess.Popen`` (to block
+# the source-recorder child) cannot swallow ``a`` probes.
+_Popen = subprocess.Popen
+_TimeoutExpired = subprocess.TimeoutExpired
+MASTER_KILL = "POCKETSHELL_APLEXER"
+FEATURE_KILLS = {
+    "profiles": "POCKETSHELL_APLEXER_PROFILES",
+    "engines": "POCKETSHELL_APLEXER_ENGINES",
+    "launch": "POCKETSHELL_APLEXER_LAUNCH",
+    "sessions": "POCKETSHELL_APLEXER_SESSIONS",
+}
+
+
+def env_map(env: Optional[Mapping[str, str]] = None) -> dict[str, str]:
+    merged = dict(os.environ)
+    if env:
+        merged.update({str(k): str(v) for k, v in env.items()})
+    return merged
+
+
+def enabled(feature: str, env: Optional[Mapping[str, str]] = None) -> bool:
+    source = env_map(env)
+    if source.get(MASTER_KILL) == "0":
+        return False
+    kill = FEATURE_KILLS.get(feature)
+    if kill and source.get(kill) == "0":
+        return False
+    return True
+
+
+def which_a(env: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    source = env_map(env)
+    explicit = source.get(BIN_ENV)
+    if explicit:
+        return explicit
+    return shutil.which("a", path=source.get("PATH"))
+
+
+def run_json(
+    args: list[str],
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    timeout: Optional[float] = None,
+    feature: Optional[str] = None,
+) -> Any | None:
+    """Run ``a --json <args>`` and parse stdout. None on skip or any failure."""
+    if timeout is None:
+        timeout = JSON_TIMEOUT_S
+    if feature and not enabled(feature, env):
+        return None
+    cli = which_a(env)
+    if cli is None:
+        return None
+    try:
+        proc = _Popen(
+            [cli, "--json", *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env_map(env),
+            start_new_session=True,
+        )
+        try:
+            stdout, _stderr = proc.communicate(timeout=timeout)
+        except _TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except OSError:
+                proc.kill()
+            proc.communicate()
+            return None
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return None

--- a/tools/pocketshell/src/pocketshell/engines.py
+++ b/tools/pocketshell/src/pocketshell/engines.py
@@ -22,6 +22,8 @@ from typing import Mapping, Optional
 
 import click
 
+from pocketshell import aplexer
+
 try:  # pragma: no cover - import guard
     import yaml
 except ImportError:  # pragma: no cover - yaml is a hard dependency
@@ -452,6 +454,81 @@ def _manifest_from_mapping(
     )
 
 
+# Engines aplexer lists that must not appear in the PocketShell agent picker.
+_HIDDEN_APLEXER_ENGINES = frozenset({"shell"})
+
+
+def _aplexer_engine_rows(
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[list[Mapping[str, object]]]:
+    payload = aplexer.run_json(["engines"], env=env, feature="engines")
+    if not isinstance(payload, list):
+        return None
+    return [row for row in payload if isinstance(row, Mapping)]
+
+
+def _overlay_aplexer_engines(
+    manifests: dict[str, EngineManifest],
+    env: Optional[Mapping[str, str]] = None,
+) -> set[str]:
+    """Overlay argv / env_unset / available from ``a engines --json``.
+
+    Presentation fields (label, family, provider_mark, skip_permissions_argv)
+    stay PocketShell's. Unknown aplexer engines (``shell``, ``gemini`` unless
+    already in this registry) are not added. Returns ids that aplexer
+    already availability-probed so ``load_registry`` can skip a second PATH
+    check.
+    """
+    rows = _aplexer_engine_rows(env)
+    if rows is None:
+        return set()
+    overlayed: set[str] = set()
+    for row in rows:
+        name = row.get("name")
+        if not isinstance(name, str) or name in _HIDDEN_APLEXER_ENGINES:
+            continue
+        item = manifests.get(name)
+        if item is None:
+            continue
+        command = row.get("command")
+        argv = (
+            tuple(str(part) for part in command if str(part).strip())
+            if isinstance(command, list) and command
+            else item.launch.argv
+        )
+        unset = row.get("env_unset")
+        env_unset = (
+            tuple(str(part) for part in unset if str(part).strip())
+            if isinstance(unset, list)
+            else item.launch.env_unset
+        )
+        launch = LaunchSpec(
+            argv=argv,
+            skip_permissions_argv=item.launch.skip_permissions_argv,
+            env_unset=env_unset,
+            env_set=item.launch.env_set,
+            profile_env=item.launch.profile_env,
+            profile=item.launch.profile,
+        )
+        available = row.get("available")
+        if isinstance(available, bool) and not item.availability_overridden:
+            item = replace(
+                item,
+                launch=launch,
+                available=available,
+                unavailable_reason=(
+                    None
+                    if available
+                    else f"`{item.harness}` is not installed on this host (not on PATH)."
+                ),
+            )
+            overlayed.add(name)
+        else:
+            item = replace(item, launch=launch)
+        manifests[name] = item
+    return overlayed
+
+
 def load_registry(
     env: Optional[Mapping[str, str]] = None,
     *,
@@ -464,11 +541,18 @@ def load_registry(
     CLI emits the full registry, including disabled/unavailable entries, so
     the picker can hide only entries that are not createable while existing
     sessions continue to render from their recorded identity.
+
+    When ``a`` is present, argv / env_unset / available for matching ids come
+    from ``a engines --json`` (Phase A2). ``engines.yaml`` still wins on
+    presentation and can add engines aplexer does not know.
     """
     manifests: dict[str, EngineManifest] = {
         item.id: item for item in builtin_manifests()
     }
     order = list(manifests)
+    # Aplexer supplies argv/env_unset/available for known ids; user yaml
+    # still wins if it then overrides the same id.
+    overlayed = _overlay_aplexer_engines(manifests, env)
     for raw in _read_config(env):
         item = _manifest_from_mapping(raw, manifests.get(str(raw.get("id", "")).lower()))
         if item is None:
@@ -476,12 +560,17 @@ def load_registry(
         if item.id not in manifests:
             order.append(item.id)
         manifests[item.id] = item
+        overlayed.discard(item.id)
 
     source = os.environ if env is None else env
     out: list[EngineManifest] = []
     for engine_id in order:
         item = manifests[engine_id]
-        if probe and not item.availability_overridden:
+        if (
+            probe
+            and not item.availability_overridden
+            and engine_id not in overlayed
+        ):
             found = shutil.which(item.harness, path=source.get("PATH"))
             item = replace(
                 item,

--- a/tools/pocketshell/src/pocketshell/profiles.py
+++ b/tools/pocketshell/src/pocketshell/profiles.py
@@ -44,25 +44,25 @@ stats a handful of dirs and reads marker *names* — it never reads inside a
 config dir (those hold ``auth.json`` / ``.env``). ``profiles list`` emits
 ``{name, engine, config_dir, default}`` and nothing else.
 
-Aplexer integration (Phase A1, #2341): when the ``a`` binary is on PATH,
-``discover_profiles`` also probes ``a profiles --json`` in *shadow mode* —
-it logs sibling divergence and still returns the native result. See
-``docs/aplexer-integration.md``. Set ``POCKETSHELL_APLEXER_PROFILES=0`` to
-disable the probe.
+Aplexer integration (Phase A, #2341): when the ``a`` binary is on PATH,
+``discover_profiles`` probes ``a profiles --json`` and **prefers** those
+sibling profiles, keeping native ``Claude``/``Codex`` defaults. Native
+discovery is the fallback when ``a`` is missing, the probe fails, or
+``POCKETSHELL_APLEXER=0`` / ``POCKETSHELL_APLEXER_PROFILES=0`` is set.
+See ``docs/aplexer-integration.md``.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import shutil
-import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
 import click
+
+from pocketshell import aplexer
 
 try:  # pragma: no cover - import guard
     import yaml
@@ -105,13 +105,10 @@ _KNOWN_ALIASES: dict[str, str] = {
     "zlaude": "Claude (Z.AI)",
 }
 
-# Aplexer Phase A1 (#2341): shadow-mode listing. Probe is on when `a` is
-# found; `POCKETSHELL_APLEXER_PROFILES=0` forces the native path. See
-# docs/aplexer-integration.md.
+# Aplexer Phase A (#2341): prefer `a profiles --json` siblings when the
+# probe succeeds. Kill switches: POCKETSHELL_APLEXER=0 /
+# POCKETSHELL_APLEXER_PROFILES=0. See docs/aplexer-integration.md.
 _LOG = logging.getLogger("pocketshell.profiles")
-_APLEXER_PROFILES_TIMEOUT_S = 2.0
-_APLEXER_BIN_ENV = "APLEXER_BIN"
-_APLEXER_PROFILES_KILL_SWITCH = "POCKETSHELL_APLEXER_PROFILES"
 _APLEXER_CONFIG_DIR_ENV = {
     "claude": "CLAUDE_CONFIG_DIR",
     "codex": "CODEX_HOME",
@@ -187,21 +184,6 @@ def _env_map(env: Optional[dict[str, str]] = None) -> dict[str, str]:
     return merged
 
 
-def _aplexer_cli(env: Optional[dict[str, str]] = None) -> Optional[str]:
-    """Return the ``a`` binary to probe, or None to skip.
-
-    Skip when ``POCKETSHELL_APLEXER_PROFILES=0``. Otherwise prefer
-    ``APLEXER_BIN``, then ``PATH``.
-    """
-    source = _env_map(env)
-    if source.get(_APLEXER_PROFILES_KILL_SWITCH) == "0":
-        return None
-    explicit = source.get(_APLEXER_BIN_ENV)
-    if explicit:
-        return explicit
-    return shutil.which("a", path=source.get("PATH"))
-
-
 def _profiles_from_aplexer_json(payload: Any) -> Optional[list[Profile]]:
     """Map ``a profiles --json`` onto PocketShell ``Profile`` objects.
 
@@ -238,25 +220,8 @@ def _aplexer_profiles(
     env: Optional[dict[str, str]] = None,
 ) -> Optional[list[Profile]]:
     """Run ``a profiles --json``. None on skip or any failure."""
-    cli = _aplexer_cli(env)
-    if cli is None:
-        return None
-    try:
-        completed = subprocess.run(
-            [cli, "profiles", "--json"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=_APLEXER_PROFILES_TIMEOUT_S,
-            env=_env_map(env),
-        )
-    except (OSError, subprocess.TimeoutExpired, TypeError, ValueError):
-        return None
-    if completed.returncode != 0:
-        return None
-    try:
-        payload = json.loads(completed.stdout)
-    except json.JSONDecodeError:
+    payload = aplexer.run_json(["profiles"], env=env, feature="profiles")
+    if payload is None:
         return None
     return _profiles_from_aplexer_json(payload)
 
@@ -304,9 +269,9 @@ def discover_profiles(
     profile (``config_dir=None``, ``default=True``); matching sibling dirs →
     non-default profiles with their absolute ``config_dir``.
 
-    When ``a`` is available, also probes ``a profiles --json`` in shadow mode:
-    divergence is logged, but this native result is returned unchanged. Set
-    ``POCKETSHELL_APLEXER_PROFILES=0`` to skip the probe.
+    When ``a`` is available, prefers sibling profiles from ``a profiles --json``
+    and keeps native engine defaults. Probe failure / kill switch returns this
+    native result unchanged.
     """
     home = _home_dir(env)
     out: list[Profile] = []
@@ -357,9 +322,11 @@ def discover_profiles(
         out.extend(siblings)
 
     mapped = _aplexer_profiles(env)
-    if mapped is not None:
-        _log_profile_divergence(out, mapped)
-    return out
+    if mapped is None:
+        return out
+    _log_profile_divergence(out, mapped)
+    defaults = [profile for profile in out if profile.default]
+    return defaults + mapped
 
 
 def _expand_config_dir(raw: Optional[str], env: Optional[dict[str, str]]) -> Optional[str]:

--- a/tools/pocketshell/src/pocketshell/session_enum.py
+++ b/tools/pocketshell/src/pocketshell/session_enum.py
@@ -1,0 +1,267 @@
+"""Live session name set shared by ``pocketshell sessions``, tree reconcile,
+and the Android list parsers.
+
+The phone used to enumerate with a bare ``tmux list-sessions``, which only
+sees the *default* tmux socket. After tmuxctl moved to one server per
+session, that default socket holds a handful of leftover sessions while
+``tmuxctl list`` / ``t`` (the terminal enumerator) walks every
+``tmuxctl-*`` socket. The name sets must match: parse the same
+``tmuxctl list`` table the Android ``HostTmuxSessionListParser`` already
+understands, then union aplexer snapshot rows tagged as a second manager.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from pocketshell import aplexer
+
+# Same trailing ``YYYY-MM-DD HH:MM:SS`` anchor as HostTmuxSessionListParser
+# (issue #200): long names overflow tmuxctl's SESSION column padding and
+# collapse the separator to a single space. Splitting on two-or-more
+# spaces, or taking a fixed-width slice, silently drops those rows.
+_TRAILING_TIMESTAMP = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
+_LEADING_IDX = re.compile(r"^\s*\d+\s+")
+_HINT_PREFIXES = (
+    "IDX ",
+    "Join a session:",
+    "Create a new one:",
+    "Use current folder:",
+    "Help:",
+    "APLEXER",
+    "MANAGER",
+)
+
+MANAGER_TMUX = "tmux"
+MANAGER_APLEXER = "aplexer"
+
+
+@dataclass(frozen=True)
+class LiveSession:
+    """One row in the combined tmux + aplexer listing."""
+
+    name: str
+    manager: str
+    created: Optional[str] = None
+    created_epoch: Optional[int] = None
+    workspace: Optional[str] = None
+    tag: Optional[str] = None
+    engine: Optional[str] = None
+    aplexer_id: Optional[str] = None
+    attach: Optional[str] = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "manager": self.manager,
+        }
+        if self.created is not None:
+            payload["created"] = self.created
+        if self.created_epoch is not None:
+            payload["created_epoch"] = self.created_epoch
+        if self.workspace is not None:
+            payload["workspace"] = self.workspace
+        if self.tag is not None:
+            payload["tag"] = self.tag
+        if self.engine is not None:
+            payload["engine"] = self.engine
+        if self.aplexer_id is not None:
+            payload["id"] = self.aplexer_id
+        if self.attach is not None:
+            payload["attach"] = self.attach
+        return payload
+
+
+def parse_tmuxctl_list_names(stdout: str) -> list[str]:
+    """Extract session names from a ``tmuxctl list`` human table, in order.
+
+    Mirrors ``HostTmuxSessionListParser.parsePocketshellSessionsList``:
+    skip header/hint rows, anchor on the trailing timestamp, take the
+    trimmed text between the leading IDX and that timestamp as the name.
+    Names with no spaces still round-trip; overflowed long names are kept
+    instead of being dropped.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for line in stdout.splitlines():
+        name = parse_tmuxctl_list_name(line)
+        if name is None or name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+def parse_tmuxctl_list_name(line: str) -> Optional[str]:
+    """Return the session name on one ``tmuxctl list`` data row, or None."""
+    if not line or not line.strip():
+        return None
+    trimmed = line.strip()
+    if any(trimmed.startswith(prefix) for prefix in _HINT_PREFIXES):
+        return None
+    timestamp_match = _TRAILING_TIMESTAMP.search(line)
+    if timestamp_match is None:
+        return None
+    if line[timestamp_match.end() :].strip():
+        return None
+    before = line[: timestamp_match.start()]
+    idx_match = _LEADING_IDX.match(before)
+    if idx_match is None:
+        return None
+    name = before[idx_match.end() :].strip()
+    return name or None
+
+
+def aplexer_display_name(row: Mapping[str, Any]) -> str:
+    """Stable listing name: ``<workspace-basename>:<tag>``, else tag or id."""
+    workspace = row.get("workspace") or row.get("cwd") or ""
+    tag = str(row.get("tag") or "").strip()
+    base = Path(str(workspace)).name if workspace else ""
+    if base and tag:
+        return f"{base}:{tag}"
+    if tag:
+        return tag
+    ident = row.get("id")
+    return str(ident).strip() if ident else ""
+
+
+def _format_epoch(epoch: Optional[int]) -> Optional[str]:
+    if epoch is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(epoch), tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+    except (OverflowError, OSError, ValueError, TypeError):
+        return None
+
+
+def _created_epoch_from_ms(value: Any) -> Optional[int]:
+    try:
+        ms = int(value)
+    except (TypeError, ValueError):
+        return None
+    if ms <= 0:
+        return None
+    return ms // 1000
+
+
+def sessions_from_tmuxctl_table(stdout: str) -> list[LiveSession]:
+    rows: list[LiveSession] = []
+    for line in stdout.splitlines():
+        name = parse_tmuxctl_list_name(line)
+        if name is None:
+            continue
+        stamp = _TRAILING_TIMESTAMP.search(line)
+        created = stamp.group(1) if stamp else None
+        rows.append(
+            LiveSession(
+                name=name,
+                manager=MANAGER_TMUX,
+                created=created,
+                attach=f"tmux attach -t {name}",
+            )
+        )
+    return rows
+
+
+def sessions_from_aplexer_snapshot(payload: Any) -> list[LiveSession]:
+    if not isinstance(payload, list):
+        return []
+    rows: list[LiveSession] = []
+    seen: set[str] = set()
+    for raw in payload:
+        if not isinstance(raw, Mapping):
+            continue
+        name = aplexer_display_name(raw)
+        ident = str(raw.get("id") or "").strip()
+        if not name:
+            continue
+        key = ident or name
+        if key in seen:
+            continue
+        seen.add(key)
+        epoch = _created_epoch_from_ms(raw.get("created_at_ms"))
+        workspace = raw.get("workspace") or raw.get("cwd")
+        tag = raw.get("tag")
+        engine = raw.get("engine")
+        attach = f"a attach {ident}" if ident else None
+        rows.append(
+            LiveSession(
+                name=name,
+                manager=MANAGER_APLEXER,
+                created=_format_epoch(epoch),
+                created_epoch=epoch,
+                workspace=str(workspace) if workspace else None,
+                tag=str(tag) if tag else None,
+                engine=str(engine) if engine else None,
+                aplexer_id=ident or None,
+                attach=attach,
+            )
+        )
+    return rows
+
+
+def enumerate_live_sessions(
+    *,
+    tmuxctl_stdout: Optional[str] = None,
+    aplexer_payload: Any = None,
+    include_aplexer: bool = True,
+    env: Optional[Mapping[str, str]] = None,
+) -> list[LiveSession]:
+    """Union tmuxctl names with aplexer snapshot rows.
+
+    ``tmuxctl_stdout`` is the already-captured ``tmuxctl list`` table (or
+    None to skip tmux). ``aplexer_payload`` injects a snapshot for tests;
+    production probes ``a snapshot`` / ``a list --json`` when enabled.
+    A tmux-only host (no ``a``, kill switch, or probe failure) returns
+    only tmux rows.
+    """
+    tmux_rows = (
+        sessions_from_tmuxctl_table(tmuxctl_stdout) if tmuxctl_stdout else []
+    )
+    aplexer_rows: list[LiveSession] = []
+    if include_aplexer:
+        payload = aplexer_payload
+        if payload is None:
+            payload = aplexer.run_json(["snapshot"], env=env, feature="sessions")
+            if payload is None:
+                payload = aplexer.run_json(["list"], env=env, feature="sessions")
+        aplexer_rows = sessions_from_aplexer_snapshot(payload)
+    tmux_names = {row.name for row in tmux_rows}
+    combined = list(tmux_rows)
+    for row in aplexer_rows:
+        if row.name in tmux_names:
+            continue
+        combined.append(row)
+    return combined
+
+
+def json_payload(sessions: Sequence[LiveSession]) -> dict[str, Any]:
+    managers = []
+    for row in sessions:
+        if row.manager not in managers:
+            managers.append(row.manager)
+    if not managers:
+        managers = [MANAGER_TMUX]
+    return {
+        "sessions": [row.to_payload() for row in sessions],
+        "managers": managers,
+    }
+
+
+def format_aplexer_table(sessions: Sequence[LiveSession]) -> str:
+    """Human appendix so ``pocketshell sessions list`` shows both managers."""
+    aplexer_rows = [row for row in sessions if row.manager == MANAGER_APLEXER]
+    if not aplexer_rows:
+        return ""
+    lines = ["", "APLEXER", "IDX  SESSION               CREATED"]
+    for index, row in enumerate(aplexer_rows, start=1):
+        created = row.created or ""
+        lines.append(f"{index:<5}{row.name} {created}".rstrip())
+    return "\n".join(lines) + "\n"

--- a/tools/pocketshell/src/pocketshell/sessions.py
+++ b/tools/pocketshell/src/pocketshell/sessions.py
@@ -28,13 +28,11 @@ Subcommand coverage:
 
 - `pocketshell sessions list` -> `tmuxctl list`
 
-`tmuxctl list` currently emits its human table only; it does not support a
-structured/`--json` mode. The wrapper keeps its existing transparent
-forwarding of unknown arguments, so a caller that supplies an unsupported
-flag receives the underlying tmuxctl exit code and stderr unchanged. The
-Android folder fallback therefore uses its own bounded raw-tmux format probe
-when it needs the exact `@ps_agent_kind` value; it does not pretend that
-`pocketshell sessions list --json` is supported.
+`tmuxctl list` currently emits its human table only. `pocketshell sessions
+list --json` is implemented HERE (not forwarded): it emits the combined
+tmuxctl + aplexer name set so the Android list matches the terminal
+enumerator (`tmuxctl list` / `t`) instead of a default-socket
+`tmux list-sessions` subset. Unknown extra flags still forward to tmuxctl.
 """
 
 from __future__ import annotations
@@ -48,6 +46,7 @@ from typing import Any, Optional, Sequence
 import click
 
 from . import resume as _resume
+from . import session_enum as _session_enum
 
 
 def _resolve_tmuxctl_binary() -> Optional[str]:
@@ -114,12 +113,13 @@ def _try_daemon_sessions_list(
     *,
     sort_by: Optional[str],
     extra_args: Sequence[str],
+    as_json: bool = False,
 ) -> Optional[dict[str, Any]]:
     """Dispatch ``sessions.list`` through the shared typed daemon boundary."""
     from pocketshell import daemon as _daemon
 
     socket_path = _daemon.resolve_socket_path()
-    params: dict[str, Any] = {"extra_args": list(extra_args)}
+    params: dict[str, Any] = {"extra_args": list(extra_args), "as_json": as_json}
     if sort_by:
         params["sort_by"] = sort_by
 
@@ -132,6 +132,43 @@ def _try_daemon_sessions_list(
     )
 
 
+def _list_envelope(
+    *,
+    sort_by: Optional[str],
+    extra_args: Sequence[str],
+    as_json: bool,
+) -> dict[str, Any]:
+    """Build the sessions.list stdout envelope (human table or JSON)."""
+    args: list[str] = ["list"]
+    if sort_by:
+        args.extend(["--by", sort_by])
+    args.extend(extra_args)
+    tmuxctl = _run_tmuxctl_capture(args)
+    tmux_stdout = str(tmuxctl.get("stdout") or "")
+    tmux_ok = int(tmuxctl.get("returncode", 0)) == 0
+    sessions = _session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=tmux_stdout if tmux_ok else None,
+    )
+    if as_json:
+        import json as _json
+
+        return {
+            "stdout": _json.dumps(_session_enum.json_payload(sessions), indent=2)
+            + "\n",
+            "stderr": "" if tmux_ok else str(tmuxctl.get("stderr") or ""),
+            "returncode": 0 if sessions or tmux_ok else int(tmuxctl.get("returncode", 1)),
+        }
+    appendix = _session_enum.format_aplexer_table(sessions)
+    stdout = tmux_stdout
+    if appendix:
+        stdout = tmux_stdout.rstrip("\n") + "\n" + appendix
+    return {
+        "stdout": stdout,
+        "stderr": str(tmuxctl.get("stderr") or ""),
+        "returncode": int(tmuxctl.get("returncode", 0)),
+    }
+
+
 def daemon_handler_list(params: dict[str, Any]) -> dict[str, Any]:
     """JSON-RPC handler for ``sessions.list``.
 
@@ -139,14 +176,19 @@ def daemon_handler_list(params: dict[str, Any]) -> dict[str, Any]:
     one-shot subprocess path so the CLI can preserve byte-identical
     output while moving the process spawn into the daemon.
     """
-    args: list[str] = ["list"]
     sort_by = params.get("sort_by")
-    if isinstance(sort_by, str) and sort_by:
-        args.extend(["--by", sort_by])
     extra_args = params.get("extra_args")
-    if isinstance(extra_args, list):
-        args.extend(str(item) for item in extra_args if isinstance(item, str))
-    return _run_tmuxctl_capture(args)
+    extras = (
+        [str(item) for item in extra_args if isinstance(item, str)]
+        if isinstance(extra_args, list)
+        else []
+    )
+    as_json = bool(params.get("as_json"))
+    return _list_envelope(
+        sort_by=sort_by if isinstance(sort_by, str) and sort_by else None,
+        extra_args=extras,
+        as_json=as_json,
+    )
 
 
 @click.group(
@@ -185,23 +227,37 @@ def sessions_group() -> None:
     default=None,
     help="Sort by session creation time or last activity (forwarded to `tmuxctl list --by`).",
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit the combined tmuxctl + aplexer session list as JSON. "
+        "This is owned by pocketshell (tmuxctl has no --json list mode)."
+    ),
+)
 @click.pass_context
-def sessions_list(ctx: click.Context, sort_by: Optional[str]) -> None:
-    """List tmux sessions on the host (delegates to `tmuxctl list`).
+def sessions_list(
+    ctx: click.Context, sort_by: Optional[str], as_json: bool
+) -> None:
+    """List live sessions on the host.
 
-    Output is byte-identical to `tmuxctl list` so the Android-side
-    `HostTmuxSessionListParser` (anchored on the trailing
-    `YYYY-MM-DD HH:MM:SS` timestamp; see issue #200) keeps working.
+    Human output still starts as the `tmuxctl list` table so
+    `HostTmuxSessionListParser` keeps working. Aplexer rows are appended
+    under an APLEXER heading when that manager is present. `--json` is the
+    structured form the Android list prefers: names match `tmuxctl list`
+    (not a default-socket `tmux list-sessions` subset) and each row is
+    tagged with its manager.
     """
-    args: list[str] = ["list"]
-    if sort_by:
-        args.extend(["--by", sort_by])
-    # `ctx.args` holds any extras we ignored. Forward verbatim, position
-    # preserved, and let the installed tmuxctl decide whether they exist.
-    args.extend(ctx.args)
-    envelope = _try_daemon_sessions_list(sort_by=sort_by, extra_args=ctx.args)
+    extras = [arg for arg in ctx.args if arg not in {"--json", "-json"}]
+    envelope = _try_daemon_sessions_list(
+        sort_by=sort_by, extra_args=extras, as_json=as_json
+    )
     if envelope is None:
-        envelope = _run_tmuxctl_capture(args)
+        envelope = _list_envelope(
+            sort_by=sort_by, extra_args=extras, as_json=as_json
+        )
     _emit_envelope(ctx, envelope)
 
 

--- a/tools/pocketshell/src/pocketshell/tree.py
+++ b/tools/pocketshell/src/pocketshell/tree.py
@@ -313,11 +313,10 @@ def _live_session_names(env: Optional[Mapping[str, str]] = None) -> Optional[set
     reconcile must NOT prune anything (treating an enumeration failure as "all
     sessions gone" would wipe the held tree on a transient hiccup).
 
-    Uses the SAME ``tmuxctl list`` enumeration ``sessions.list`` proxies. The
-    output is the fixed-width ``IDX  SESSION  CREATED`` table; the SESSION name
-    is the second whitespace-delimited token on each data row (tmux session
-    names cannot contain whitespace, so this is unambiguous). The header row and
-    any blank lines are skipped.
+    Uses the SAME ``tmuxctl list`` enumeration ``sessions.list`` proxies and
+    the timestamp-anchored parser in :mod:`pocketshell.session_enum` (the
+    same rule as Android ``HostTmuxSessionListParser``), so overflowed long
+    names are not dropped.
     """
     tmuxctl_path = _resolve_tmuxctl_binary()
     if tmuxctl_path is None:
@@ -338,26 +337,9 @@ def _live_session_names(env: Optional[Mapping[str, str]] = None) -> Optional[set
 
 def _parse_session_names(stdout: str) -> set[str]:
     """Parse session names from the ``tmuxctl list`` fixed-width table."""
-    names: set[str] = set()
-    for line in stdout.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        tokens = stripped.split()
-        if not tokens:
-            continue
-        # Skip the header row ("IDX  SESSION  CREATED").
-        if tokens[0].upper() == "IDX":
-            continue
-        # The IDX column is numeric on data rows; the SESSION name is token[1].
-        if len(tokens) < 2:
-            continue
-        if not tokens[0].isdigit():
-            # Defensive: a row whose first token is not an index is not a
-            # recognisable data row; skip it rather than mis-key a name.
-            continue
-        names.add(tokens[1])
-    return names
+    from pocketshell.session_enum import parse_tmuxctl_list_names
+
+    return set(parse_tmuxctl_list_names(stdout))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pocketshell/tests/conftest.py
+++ b/tools/pocketshell/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Helper tests default to the native path so a host with ``a`` on PATH
+cannot change fixture results. Opt in per test with
+``POCKETSHELL_APLEXER=1`` plus ``APLEXER_BIN``.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import textwrap
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_aplexer_by_default(monkeypatch):
+    monkeypatch.setenv("POCKETSHELL_APLEXER", "0")
+
+
+@pytest.fixture
+def install_fake_a(tmp_path, monkeypatch):
+    """Write a stub ``a`` and point ``APLEXER_BIN`` at it, enabling probes."""
+
+    def _install(
+        *,
+        profiles=None,
+        engines=None,
+        launch=None,
+        snapshot=None,
+        listing=None,
+        exit_code=0,
+        sleep=0,
+        stdout=None,
+    ):
+        script = tmp_path / "fake-a"
+        if sleep:
+            body = textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                sleep {sleep}
+                """
+            )
+        elif exit_code:
+            body = textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                echo fail >&2
+                exit {exit_code}
+                """
+            )
+        elif stdout is not None:
+            body = textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                cat <<'EOF'
+                {stdout}
+                EOF
+                """
+            )
+        else:
+            table = {
+                "profiles": profiles,
+                "engines": engines,
+                "launch-spec": launch,
+                "snapshot": snapshot,
+                "list": listing if listing is not None else snapshot,
+            }
+            encoded = json.dumps(table)
+            body = textwrap.dedent(
+                f"""\
+                #!/usr/bin/env python3
+                import json, sys
+                TABLE = json.loads({encoded!r})
+                args = [a for a in sys.argv[1:] if a != "--json"]
+                cmd = args[0] if args else ""
+                payload = TABLE.get(cmd)
+                if payload is None:
+                    sys.exit(2)
+                print(json.dumps(payload))
+                """
+            )
+        script.write_text(body, encoding="utf-8")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+        monkeypatch.setenv("APLEXER_BIN", str(script))
+        monkeypatch.setenv("POCKETSHELL_APLEXER", "1")
+        monkeypatch.delenv("POCKETSHELL_APLEXER_PROFILES", raising=False)
+        monkeypatch.delenv("POCKETSHELL_APLEXER_ENGINES", raising=False)
+        monkeypatch.delenv("POCKETSHELL_APLEXER_LAUNCH", raising=False)
+        monkeypatch.delenv("POCKETSHELL_APLEXER_SESSIONS", raising=False)
+        return script
+
+    return _install

--- a/tools/pocketshell/tests/test_agents.py
+++ b/tools/pocketshell/tests/test_agents.py
@@ -1366,3 +1366,127 @@ def test_cli_agent_profile_env_block_reaches_child(tmp_path, monkeypatch):
     assert captured["env"]["ZAI_ROUTE"] == "https://api.z.ai/anthropic"
     # ... but a provider API key in the env: block is still stripped (#703).
     assert "ANTHROPIC_API_KEY" not in captured["env"]
+
+
+def test_launch_spec_supplies_argv_and_env_unset(
+    tmp_path, monkeypatch, install_fake_a
+):
+    captured = {}
+
+    def fake_execvpe(file, argv, env):
+        captured["file"] = file
+        captured["argv"] = list(argv)
+        captured["env"] = dict(env)
+
+    install_fake_a(
+        launch={
+            "engine": "claude",
+            "profile": None,
+            "argv": ["claude", "--from-aplexer", "--dangerously-skip-permissions"],
+            "env_set": {"FROM_SPEC": "1"},
+            "env_unset": ["OPENAI_API_KEY"],
+            "cwd": str(tmp_path),
+        }
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "live-key")
+    (tmp_path / ".env").write_text("FOLDER_VAR=from-folder\n", encoding="utf-8")
+    agents.launch_agent(
+        _FakeCtx(),
+        "claude",
+        str(tmp_path),
+        skip_permissions=True,
+        config_dir=None,
+        execvpe=fake_execvpe,
+    )
+    assert captured["argv"] == [
+        "claude",
+        "--from-aplexer",
+        "--dangerously-skip-permissions",
+    ]
+    assert captured["env"]["FROM_SPEC"] == "1"
+    assert captured["env"]["FOLDER_VAR"] == "from-folder"
+    assert "OPENAI_API_KEY" not in captured["env"]
+
+
+def test_launch_spec_empty_unset_still_strips_provider_keys(
+    tmp_path, monkeypatch, install_fake_a
+):
+    captured = {}
+
+    def fake_execvpe(file, argv, env):
+        captured["env"] = dict(env)
+        captured["argv"] = list(argv)
+
+    install_fake_a(
+        launch={
+            "engine": "claude",
+            "argv": ["claude"],
+            "env_set": {},
+            "env_unset": [],
+            "cwd": str(tmp_path),
+        }
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "live-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "also-live")
+    agents.launch_agent(
+        _FakeCtx(),
+        "claude",
+        str(tmp_path),
+        skip_permissions=True,
+        config_dir=None,
+        execvpe=fake_execvpe,
+    )
+    assert "ANTHROPIC_API_KEY" not in captured["env"]
+    assert "OPENAI_API_KEY" not in captured["env"]
+    assert captured["argv"] == ["claude"]
+
+
+def test_launch_spec_failure_falls_back_to_native(
+    tmp_path, monkeypatch, install_fake_a
+):
+    captured = {}
+
+    def fake_execvpe(file, argv, env):
+        captured["argv"] = list(argv)
+
+    install_fake_a(exit_code=2)
+    agents.launch_agent(
+        _FakeCtx(),
+        "codex",
+        str(tmp_path),
+        skip_permissions=True,
+        config_dir=None,
+        execvpe=fake_execvpe,
+    )
+    assert captured["argv"][0] == "codex"
+    assert "check_for_update_on_startup=false" in captured["argv"]
+
+
+def test_launch_spec_still_seeds_claude_trust(
+    tmp_path, monkeypatch, install_fake_a
+):
+    install_fake_a(
+        launch={
+            "engine": "claude",
+            "argv": ["claude"],
+            "env_set": {},
+            "env_unset": [],
+            "cwd": str(tmp_path),
+        }
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agents.launch_agent(
+        _FakeCtx(),
+        "claude",
+        str(tmp_path),
+        skip_permissions=True,
+        config_dir=None,
+        execvpe=lambda *a, **k: None,
+    )
+    data = json.loads((tmp_path / ".claude.json").read_text(encoding="utf-8"))
+    assert data["projects"][str(tmp_path)]["hasTrustDialogAccepted"] is True
+
+
+def test_aplexer_profile_id_from_config_dir():
+    assert agents._aplexer_profile_id("/home/me/.zlaude") == "zlaude"
+    assert agents._aplexer_profile_id(None) is None

--- a/tools/pocketshell/tests/test_engines.py
+++ b/tools/pocketshell/tests/test_engines.py
@@ -165,3 +165,67 @@ def test_generic_click_wrapper_resolves_and_launches_custom_engine(
     ]
     assert launched["env"]["TEST_MODE"] == "registry"
     assert "OPENAI_API_KEY" not in launched["env"]
+
+
+def test_aplexer_overlay_takes_command_env_unset_and_available(
+    tmp_path, monkeypatch, install_fake_a
+):
+    install_fake_a(
+        engines=[
+            {
+                "name": "claude",
+                "command": ["claude", "--from-aplexer"],
+                "available": False,
+                "env_unset": ["OPENAI_API_KEY", "CUSTOM_UNSET"],
+            },
+            {"name": "shell", "command": ["/bin/bash", "-l"], "available": True},
+            {"name": "gemini", "command": ["gemini"], "available": True},
+        ]
+    )
+    registry = engines.load_registry(probe=False)
+    ids = [item.id for item in registry]
+    assert "shell" not in ids
+    assert "gemini" not in ids
+    claude = next(item for item in registry if item.id == "claude")
+    assert claude.launch.argv == ("claude", "--from-aplexer")
+    assert claude.label == "Claude"
+    assert claude.family == "claude"
+    assert "CUSTOM_UNSET" in claude.launch.env_unset
+    assert "OPENAI_API_KEY" in claude.launch.env_unset
+    assert claude.available is False
+    assert claude.launch.skip_permissions_argv == (
+        "--dangerously-skip-permissions",
+    )
+
+
+def test_yaml_override_still_wins_over_aplexer(
+    tmp_path, monkeypatch, install_fake_a
+):
+    _engine_config(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    install_fake_a(
+        engines=[
+            {
+                "name": "claude",
+                "command": ["claude", "--from-aplexer"],
+                "available": True,
+                "env_unset": ["OPENAI_API_KEY"],
+            }
+        ]
+    )
+    registry = engines.load_registry(probe=False)
+    assert any(item.id == "test-engine" for item in registry)
+    claude = next(item for item in registry if item.id == "claude")
+    # No yaml override for claude → aplexer argv sticks.
+    assert claude.launch.argv == ("claude", "--from-aplexer")
+
+
+def test_aplexer_engine_probe_failure_keeps_builtins(install_fake_a):
+    install_fake_a(exit_code=2)
+    registry = engines.load_registry(probe=False)
+    assert [item.id for item in registry] == [
+        "claude",
+        "codex",
+        "opencode",
+        "grok",
+    ]

--- a/tools/pocketshell/tests/test_profiles.py
+++ b/tools/pocketshell/tests/test_profiles.py
@@ -100,6 +100,7 @@ def _install_fake_a(
     script.write_text(body, encoding="utf-8")
     script.chmod(script.stat().st_mode | stat.S_IEXEC)
     monkeypatch.setenv("APLEXER_BIN", str(script))
+    monkeypatch.setenv("POCKETSHELL_APLEXER", "1")
     monkeypatch.setenv("POCKETSHELL_APLEXER_PROFILES", "1")
     return script
 
@@ -374,7 +375,7 @@ def test_cli_profiles_list_emits_no_secrets(fake_home, monkeypatch, capsys):
 
 
 # ---------------------------------------------------------------------------
-# Aplexer Phase A1: shadow-mode `a profiles --json` (#2341)
+# Aplexer Phase A: prefer `a profiles --json` siblings (#2341)
 # ---------------------------------------------------------------------------
 
 
@@ -422,7 +423,7 @@ def test_kill_switch_skips_probe(fake_home, tmp_path, monkeypatch):
     assert profiles._aplexer_profiles({"HOME": str(fake_home)}) is None
 
 
-def test_shadow_mode_still_returns_native(
+def test_prefer_matching_probe_keeps_defaults_and_mapped_siblings(
     fake_home, tmp_path, monkeypatch, caplog
 ):
     marker = fake_home / "aplexer-called"
@@ -438,8 +439,10 @@ def test_shadow_mode_still_returns_native(
     monkeypatch.setenv("POCKETSHELL_APLEXER_PROFILES", "1")
     caplog.clear()
     discovered = profiles.discover_profiles({"HOME": str(fake_home)})
-    assert marker.is_file(), "the matching shadow test must invoke the a probe"
-    assert discovered == expected
+    assert marker.is_file(), "the matching prefer test must invoke the a probe"
+    assert {p.name for p in discovered} == {p.name for p in expected}
+    assert {p.name for p in discovered} == {"Claude", "Claude (Z.AI)", "Codex"}
+    assert [p.name for p in discovered if p.default] == ["Claude", "Codex"]
     assert not [
         record
         for record in caplog.records
@@ -447,22 +450,19 @@ def test_shadow_mode_still_returns_native(
     ]
 
 
-def test_shadow_mode_logs_missing_sibling_and_returns_native(
+def test_prefer_empty_aplexer_keeps_native_defaults_only(
     fake_home, tmp_path, monkeypatch, caplog
 ):
-    # A valid empty aplexer listing must not remove native siblings.
     _install_fake_a(tmp_path, monkeypatch, payload={})
     caplog.set_level(logging.WARNING, logger="pocketshell.profiles")
-    monkeypatch.setenv("POCKETSHELL_APLEXER_PROFILES", "0")
-    expected = profiles.discover_profiles({"HOME": str(fake_home)})
-    monkeypatch.setenv("POCKETSHELL_APLEXER_PROFILES", "1")
     discovered = profiles.discover_profiles({"HOME": str(fake_home)})
-    assert discovered == expected
+    assert {p.name for p in discovered} == {"Claude", "Codex"}
+    assert all(p.default for p in discovered)
     assert "aplexer profile shadow divergence" in caplog.text
     assert "Claude (Z.AI)" in caplog.text
 
 
-def test_shadow_mode_logs_missing_extra_and_differing_siblings(
+def test_prefer_logs_missing_extra_and_differing_siblings(
     fake_home, tmp_path, monkeypatch, caplog
 ):
     _make_claude_dir(fake_home / ".alt-claude")
@@ -482,13 +482,12 @@ def test_shadow_mode_logs_missing_extra_and_differing_siblings(
     )
     caplog.set_level(logging.WARNING, logger="pocketshell.profiles")
     discovered = profiles.discover_profiles({"HOME": str(fake_home)})
-    native = [
-        profiles.Profile("Claude", "claude", None, True),
-        profiles.Profile("Alt Claude", "claude", str(fake_home / ".alt-claude")),
-        profiles.Profile("Claude (Z.AI)", "claude", str(fake_home / ".zlaude")),
-        profiles.Profile("Codex", "codex", None, True),
-    ]
-    assert discovered == native
+    names = [p.name for p in discovered]
+    assert names[0] == "Claude"
+    assert "Codex" in names
+    assert "Renamed" in names
+    assert "Remote Laude" in names
+    assert "Alt Claude" not in names
     assert "missing=['Alt Claude']" in caplog.text
     assert "extra=['Remote Laude']" in caplog.text
     assert "differing=['Claude (Z.AI)->Renamed']" in caplog.text

--- a/tools/pocketshell/tests/test_session_enum.py
+++ b/tools/pocketshell/tests/test_session_enum.py
@@ -1,0 +1,142 @@
+"""Live session enumerator: tmuxctl names match the terminal, plus aplexer."""
+
+from __future__ import annotations
+
+import json
+
+from pocketshell import session_enum
+
+
+def _tmuxctl_table() -> str:
+    # Includes the overflowed long-name row (single space before timestamp)
+    # that HostTmuxSessionListParser was hardened against in issue #200, and
+    # that a naive ``tokens[1]`` split still happens to keep — the load-bearing
+    # check is equality with that parser's name set, including this row.
+    return (
+        "IDX  SESSION               CREATED\n"
+        "1    git-pocketshell-release 2026-08-27 09:22:55 \n"
+        "2    git-aplexer-2         2026-08-26 19:05:34 \n"
+        "3    git-dataops-2         2026-08-26 16:14:33 \n"
+        "4    git-pocketshell-2     2026-08-26 15:51:07 \n"
+        "5    git-dtc-website-4     2026-08-26 15:23:22 \n"
+        "6    git-dtc-website-3     2026-08-26 15:09:26 \n"
+        "7    git-zoom-calls        2026-08-26 13:48:17 \n"
+        "8    git-aplexer           2026-08-26 13:09:26 \n"
+        "9    git-game-tester       2026-08-26 07:12:25 \n"
+        "10   git-ai-shipping-labs  2026-08-25 17:28:03 \n"
+        "11   git-dtc-website       2026-08-24 12:26:03 \n"
+        "12   git-pocketshell       2026-08-24 12:26:02 \n"
+        "\n"
+        "Join a session: tmuxctl <id> or tmuxctl <session>\n"
+        "Create a new one: tmuxctl :<session>\n"
+        "Use current folder: tmuxctl - or tmuxctl -name\n"
+        "Help: tmuxctl --help\n"
+    )
+
+
+def _default_socket_three() -> set[str]:
+    # What a bare ``tmux list-sessions`` on the default socket reports —
+    # the three-session subset the phone currently shows.
+    return {"git-dtc-website", "git-game-tester", "git-pocketshell"}
+
+
+def test_tmuxctl_table_name_set_equals_live_enumerator_including_long_names() -> None:
+    table = _tmuxctl_table()
+    names = session_enum.parse_tmuxctl_list_names(table)
+    assert "git-pocketshell-release" in names
+    assert "git-ai-shipping-labs" in names
+    assert len(names) == 12
+    assert set(names) == {
+        "git-pocketshell-release",
+        "git-aplexer-2",
+        "git-dataops-2",
+        "git-pocketshell-2",
+        "git-dtc-website-4",
+        "git-dtc-website-3",
+        "git-zoom-calls",
+        "git-aplexer",
+        "git-game-tester",
+        "git-ai-shipping-labs",
+        "git-dtc-website",
+        "git-pocketshell",
+    }
+    # The default-socket subset is strictly smaller; the enumerator must
+    # not collapse to it.
+    assert set(names) != _default_socket_three()
+    assert _default_socket_three() < set(names)
+
+
+def test_whitespace_split_would_not_define_the_enumerator() -> None:
+    """A row whose SESSION column overflows must still be named in full.
+
+    Token-split ``tokens[1]`` happens to work for space-free names; the
+    timestamp-anchored parser is what Android uses and is the contract.
+    """
+    overflow = (
+        "5    git-ai-shipping-labs-workshops-raw-guard 2026-05-20 17:41:29 \n"
+    )
+    assert session_enum.parse_tmuxctl_list_name(overflow) == (
+        "git-ai-shipping-labs-workshops-raw-guard"
+    )
+
+
+def test_hints_and_header_are_not_sessions() -> None:
+    assert session_enum.parse_tmuxctl_list_names(
+        "IDX  SESSION               CREATED\n\nJoin a session: tmuxctl 1\n"
+    ) == []
+
+
+def test_union_includes_aplexer_rows_tagged_as_second_manager() -> None:
+    snapshot = [
+        {
+            "id": "b3feff71-4a78-4055-a2d3-6c99187ecffb",
+            "tag": "codex",
+            "engine": "codex",
+            "workspace": "/home/alexey/git/toyaikit",
+            "cwd": "/home/alexey/git/toyaikit",
+            "created_at_ms": 1787774700696,
+        }
+    ]
+    sessions = session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=_tmuxctl_table(),
+        aplexer_payload=snapshot,
+    )
+    names = [row.name for row in sessions]
+    assert "git-pocketshell-release" in names
+    assert "toyaikit:codex" in names
+    aplexer_row = next(row for row in sessions if row.manager == "aplexer")
+    assert aplexer_row.name == "toyaikit:codex"
+    assert aplexer_row.aplexer_id == "b3feff71-4a78-4055-a2d3-6c99187ecffb"
+    assert aplexer_row.attach == "a attach b3feff71-4a78-4055-a2d3-6c99187ecffb"
+    assert aplexer_row.engine == "codex"
+
+
+def test_tmux_only_host_lists_only_tmux() -> None:
+    sessions = session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=_tmuxctl_table(),
+        include_aplexer=False,
+    )
+    assert {row.manager for row in sessions} == {"tmux"}
+    assert len(sessions) == 12
+
+
+def test_json_payload_tags_managers() -> None:
+    sessions = session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=_tmuxctl_table(),
+        aplexer_payload=[
+            {
+                "id": "abc",
+                "tag": "live",
+                "engine": "grok",
+                "workspace": "/tmp/aplexer-follow",
+            }
+        ],
+    )
+    payload = session_enum.json_payload(sessions)
+    assert payload["managers"] == ["tmux", "aplexer"]
+    names = {item["name"] for item in payload["sessions"]}
+    assert "git-pocketshell" in names
+    assert "aplexer-follow:live" in names
+    encoded = json.dumps(payload)
+    parsed = json.loads(encoded)
+    assert parsed["managers"] == ["tmux", "aplexer"]

--- a/tools/pocketshell/tests/test_sessions.py
+++ b/tools/pocketshell/tests/test_sessions.py
@@ -4,11 +4,10 @@ The third-PR scope (#218) exercises:
 
 - `pocketshell --help` lists the `sessions` subcommand.
 - `pocketshell sessions --help` lists the `list` subcommand.
-- `pocketshell sessions list` forwards verbatim to `tmuxctl list`.
+- `pocketshell sessions list` forwards to `tmuxctl list` (human table).
 - `pocketshell sessions list --by activity` forwards `--by activity`.
-- unsupported options are still forwarded verbatim, and the current
-  `tmuxctl list --json` rejection is surfaced unchanged (there is no fake
-  structured contract).
+- `pocketshell sessions list --json` is owned by pocketshell (combined
+  tmuxctl + aplexer enumerator) and is not forwarded to tmuxctl.
 - Missing `tmuxctl` produces a friendly stderr message + exit 127.
 - stdout / stderr / exit-code from the subprocess are proxied verbatim.
 - The proxied output shape stays byte-identical so the Android-side
@@ -22,6 +21,7 @@ tmuxctl exists on the host", not "tmux session enumeration works".
 
 from __future__ import annotations
 
+import json
 import subprocess
 from typing import Sequence
 from unittest.mock import patch
@@ -117,7 +117,9 @@ def test_sessions_list_uses_daemon_when_available() -> None:
         result = runner.invoke(sessions_group, ["list", "--by", "activity"])
     assert result.exit_code == 0, result.output
     assert result.output == payload
-    daemon_call.assert_called_once_with(sort_by="activity", extra_args=[])
+    daemon_call.assert_called_once_with(
+        sort_by="activity", extra_args=[], as_json=False
+    )
     run.assert_not_called()
 
 
@@ -180,28 +182,26 @@ def test_sessions_list_rejects_invalid_by_value() -> None:
     run.assert_not_called()
 
 
-def test_sessions_list_surfaces_current_tmuxctl_json_rejection() -> None:
-    """The current tmuxctl has no structured list mode.
-
-    The wrapper's pass-through behavior is intentional, but it must not turn
-    an unsupported `--json` flag into a claimed success. This mirrors the
-    current host command (`tmuxctl list --json` -> exit 2).
-    """
+def test_sessions_list_json_is_owned_by_pocketshell_not_forwarded() -> None:
+    """``--json`` is pocketshell's combined enumerator, not a tmuxctl flag."""
+    payload = _fake_sessions_table()
     runner = CliRunner()
     with patch(
         "pocketshell.sessions._resolve_tmuxctl_binary", return_value="/fake/tmuxctl"
     ), patch(
         "pocketshell.sessions.subprocess.run",
-        return_value=_fake_completed(
-            stderr="Error: No such option: --json\n",
-            returncode=2,
-        ),
+        return_value=_fake_completed(stdout=payload),
     ) as run:
         result = runner.invoke(sessions_group, ["list", "--json"])
-    assert result.exit_code == 2, result.output
-    assert "No such option: --json" in result.output
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    names = {row["name"] for row in parsed["sessions"]}
+    assert "git-tmuxcli" in names
+    assert "git-ai-shipping-labs-workshops-raw-guard" in names
+    assert parsed["managers"] == ["tmux"]
     invoked: Sequence[str] = run.call_args.args[0]
-    assert invoked == ["/fake/tmuxctl", "list", "--json"]
+    assert invoked == ["/fake/tmuxctl", "list"]
+    assert "--json" not in invoked
 
 
 def test_sessions_list_forwards_by_and_unknown_options_together() -> None:
@@ -263,6 +263,64 @@ def test_sessions_list_proxies_nonzero_exit_from_tmuxctl() -> None:
     # stderr from the subprocess must reach the user (otherwise
     # debugging a failing tmux probe would be opaque).
     assert "tmux server unavailable" in result.output
+
+
+def test_sessions_list_json_unions_aplexer_snapshot(install_fake_a) -> None:
+    payload = _fake_sessions_table()
+    install_fake_a(
+        snapshot=[
+            {
+                "id": "sess-1",
+                "tag": "codex",
+                "engine": "codex",
+                "workspace": "/home/alexey/git/toyaikit",
+                "created_at_ms": 1_700_000_000_000,
+            }
+        ]
+    )
+    runner = CliRunner()
+    with patch(
+        "pocketshell.sessions._resolve_tmuxctl_binary", return_value="/fake/tmuxctl"
+    ), patch(
+        "pocketshell.sessions.subprocess.run",
+        return_value=_fake_completed(stdout=payload),
+    ):
+        result = runner.invoke(sessions_group, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["managers"] == ["tmux", "aplexer"]
+    names = {row["name"] for row in parsed["sessions"]}
+    assert "git-tmuxcli" in names
+    assert "toyaikit:codex" in names
+    aplexer = next(row for row in parsed["sessions"] if row["manager"] == "aplexer")
+    assert aplexer["attach"].startswith("a attach ")
+    assert aplexer["id"] == "sess-1"
+
+
+def test_sessions_list_human_appends_aplexer_table(install_fake_a) -> None:
+    payload = _fake_sessions_table()
+    install_fake_a(
+        snapshot=[
+            {
+                "id": "sess-1",
+                "tag": "live",
+                "engine": "grok",
+                "workspace": "/tmp/aplexer-follow",
+            }
+        ]
+    )
+    runner = CliRunner()
+    with patch(
+        "pocketshell.sessions._resolve_tmuxctl_binary", return_value="/fake/tmuxctl"
+    ), patch(
+        "pocketshell.sessions.subprocess.run",
+        return_value=_fake_completed(stdout=payload),
+    ):
+        result = runner.invoke(sessions_group, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "git-tmuxcli" in result.output
+    assert "APLEXER" in result.output
+    assert "aplexer-follow:live" in result.output
 
 
 # ----- sessions create (#726) ----------------------------------------

--- a/tools/pocketshell/tests/test_tree.py
+++ b/tools/pocketshell/tests/test_tree.py
@@ -343,6 +343,19 @@ def test_parse_session_names_from_tmuxctl_table() -> None:
     assert names == {"git-tmuxcli", "git-ai-engineering", "git-raw-guard"}
 
 
+def test_parse_session_names_keeps_overflowed_long_names() -> None:
+    table = (
+        "IDX  SESSION               CREATED\n"
+        "1    git-pocketshell-release 2026-08-27 09:22:55 \n"
+        "5    git-ai-shipping-labs-workshops-raw-guard 2026-05-20 17:41:29 \n"
+    )
+    names = tree_mod._parse_session_names(table)
+    assert names == {
+        "git-pocketshell-release",
+        "git-ai-shipping-labs-workshops-raw-guard",
+    }
+
+
 def test_parse_session_names_skips_header_and_blanks() -> None:
     assert tree_mod._parse_session_names("") == set()
     assert tree_mod._parse_session_names("IDX  SESSION  CREATED\n\n") == set()

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "pocketshell"
-version = "0.4.44"
+version = "0.4.45"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Finish aplexer Phase A on the host CLI: prefer `a` for profiles, overlay engines, use `a launch-spec` for argv/env while still merging folder env, seeding Claude trust, and writing `@ps_*`.
- Make the in-app tmux session list match `tmuxctl list` / `t` (all per-session sockets), not the 3 leftover sessions on the default tmux socket.
- List both session managers: tmuxctl rows plus aplexer snapshot/list rows tagged `manager=tmux|aplexer` via `pocketshell sessions list --json`.
- Lockstep bump to Android `0.4.45` / versionCode 92 and host CLI `0.4.45`.

## Why the phone showed 3 sessions
Bare `tmux list-sessions` only sees the default socket. After tmuxctl moved to one server per session, `t` / `tmuxctl list` walks every `tmuxctl-*` socket. The app now unions that enumerator (and aplexer) instead of stopping at the default socket.

## Test plan
- [x] Host CLI: profiles/engines/agents/session_enum/sessions/tree tests
- [x] Android: HostTmuxSessionListParserTest, HostTmuxSessionsGatewayTest, FolderListGatewayFallbackTest (64 tests, 0 failures)
- [x] `scripts/check-version-coupling.sh`
- [x] Live `pocketshell sessions list --json` shows tmuxctl names + aplexer rows
- [ ] Emulator release-gate / tag after merge to green `origin/main`