### PR TITLE
tmux: recover terminal attach after repeated launch (#2338)

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2338SecondLaunchTerminalAttachJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2338SecondLaunchTerminalAttachJourneyE2eTest.kt
@@ -1,0 +1,374 @@
+package com.pocketshell.app.proof
+
+import android.os.SystemClock
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.ViewModelProvider
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.BackgroundGraceTestOverride
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
+import com.pocketshell.app.hosts.SshKeyStorage
+import com.pocketshell.app.tmux.TMUX_SESSION_SCREEN_TAG
+import com.pocketshell.app.tmux.TmuxSessionLatencyTelemetry
+import com.pocketshell.app.tmux.TmuxSessionViewModel
+import com.pocketshell.app.tmux.revealIdentityAdoption
+import com.pocketshell.core.connection.RevealIdentityAdoption
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.termux.view.TerminalView
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.FixMethodOrder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
+import java.io.File
+
+/**
+ * Issue #2338 — the ORDERING dependency itself: the 2nd+ `MainActivity` launch in one
+ * instrumentation process must still attach its terminal.
+ *
+ * ## Why a whole class exists for one ordering property
+ *
+ * ~15 load-bearing journey classes went red at once on `main` with the same signature: the
+ * FIRST test of the class passes and EVERY later test fails at `waitForTerminalViewAttached`
+ * while SSH/tmux are demonstrably healthy (`tmux-connect-ready`, `paneCount=1`) and the
+ * surface simply never measures (`tmux-client-size-known` absent). Fixing any ONE of those
+ * classes would not pin the property; the class-covering pin is "launch, attach, tear down,
+ * launch AGAIN in the same process, attach again".
+ *
+ * ## The state the second launch is in (and the fixture that creates it)
+ *
+ * A tmux session name is unique per server, so a route's `(tmuxSessionId, sessionCreated)`
+ * pair is only ever as fresh as whatever produced it. The FIRST launch is what writes those
+ * caches, so from the SECOND launch onward the route can carry the PREVIOUS generation of a
+ * same-named session. [tearDown] kills the session and [seedBeforeLaunch] recreates it under
+ * the same name, so the live generation genuinely changes between the two launches — exactly
+ * what every affected journey class does.
+ *
+ * Since #2294 the first authoritative `list-panes` adopts the LIVE generation and re-keys the
+ * reveal reducer + connection controller onto it. Before #2338's fix the screen refused to
+ * follow that adoption whenever its route carried a generation, so the fused surface state
+ * held the terminal forever and no `TerminalView` was ever built.
+ *
+ * ## Non-vacuity (the #780 model)
+ *
+ * The second launch HARD-ASSERTS that the failing state was actually entered: the reveal
+ * reducer must report an exact-generation [RevealIdentityAdoption] whose `from` is an EXACT
+ * durable id (i.e. the route carried a generation) and differs from `to`. If the fixture ever
+ * stops producing a stale route generation this test FAILS loudly instead of turning into a
+ * second copy of the happy path. No `assumeTrue` anywhere.
+ *
+ * Wired into `scripts/ci-journey-suite.sh` so it RUNS on the emulator-journey gate.
+ */
+@RunWith(AndroidJUnit4::class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class Issue2338SecondLaunchTerminalAttachJourneyE2eTest {
+
+    // Issue #788/#848: launch-owned `createAndroidComposeRule<MainActivity>()` with
+    // seed-before-launch via the RuleChain — NOT `createEmptyComposeRule()` + a hand-rolled
+    // `ActivityScenario.launch` (the interop-placement stall).
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val ruleChain: org.junit.rules.RuleChain = org.junit.rules.RuleChain
+        .outerRule(PreGrantPermissionsRule())
+        .around(SeedBeforeLaunchRule { seedBeforeLaunch() })
+        .around(compose)
+
+    private lateinit var fixtureKey: String
+    private lateinit var hostRowTag: String
+
+    private suspend fun seedBeforeLaunch() {
+        BackgroundGraceTestOverride.setForTest(null)
+        TmuxSessionLatencyTelemetry.resetForTest()
+        val key = readFixtureKey()
+        fixtureKey = key
+        waitForSshFixtureReady(SshKey.Pem(key))
+        seedShellSession(key)
+        hostRowTag = seedDockerHost(key)
+    }
+
+    @After
+    fun tearDown() {
+        BackgroundGraceTestOverride.setForTest(null)
+        if (::fixtureKey.isInitialized) {
+            // Kill the session so the NEXT launch's seeding recreates it with a NEW
+            // `session_created` — that generation change is what makes the second launch's
+            // cached route identity stale, which is the state under test.
+            runCatching { runBlocking { cleanupRemoteTmuxSession(fixtureKey) } }
+        }
+    }
+
+    /**
+     * Launch 1 in this process: the baseline. This one always passed even with the bug, so
+     * its job is to establish the caches (and the tmux generation) the second launch inherits.
+     */
+    @Test
+    fun aFirstLaunchInProcessAttachesTerminal() {
+        attachSeededTmuxSession("first launch")
+        writeSummary(
+            launchOrdinal = 1,
+            adoption = revealIdentityAdoption(),
+            note = "baseline launch — establishes the route/tree caches the next launch reuses",
+        )
+    }
+
+    /**
+     * Launch 2 in the SAME process: the reported defect. Before the fix this timed out at
+     * `waitForTerminalViewAttached` after 30s with SSH/tmux fully healthy.
+     */
+    @Test
+    fun bSecondLaunchInSameProcessStillAttachesTerminal() {
+        attachSeededTmuxSession("second launch")
+
+        // Non-vacuity: prove this launch really was in the reported state (a route carrying a
+        // STALE exact generation that the pane listing re-keyed away from). A green that did
+        // not enter the failing state proves nothing, so hard-fail rather than pass quietly.
+        val adoption = revealIdentityAdoption()
+        assertTrue(
+            "the second launch must have re-keyed the reveal identity away from its route " +
+                "(that is the #2338 state); observed adoption=$adoption",
+            adoption != null && adoption.from != adoption.to,
+        )
+        val from = requireNotNull(adoption).from.value
+        assertTrue(
+            "the #2338 wedge is specifically a route that ALREADY carried an exact tmux " +
+                "generation; observed from=$from to=${adoption.to.value}. A name-only `from` " +
+                "means the fixture stopped reproducing the reported state — fix the fixture, " +
+                "do not relax this assertion.",
+            EXACT_TARGET_ID.matches(from),
+        )
+        writeSummary(
+            launchOrdinal = 2,
+            adoption = adoption,
+            note = "reported defect: stale route generation re-keyed by list-panes; the screen " +
+                "must follow the adoption instead of holding the terminal forever",
+        )
+    }
+
+    // ---------------------------------------------------------------- Attach / wait
+
+    private fun attachSeededTmuxSession(label: String) {
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        compose.waitUntil(timeoutMillis = TerminalTestTimeouts.terminalVisibilityTimeoutMs()) {
+            runCatching {
+                compose.onAllNodesWithText(SESSION_NAME, useUnmergedTree = true)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }.getOrDefault(false)
+        }
+        compose.onNodeWithText(SESSION_NAME, useUnmergedTree = true).performClick()
+        compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
+        waitForTerminalViewAttached(label)
+    }
+
+    /**
+     * The exact condition all ~15 affected classes wait on. It is the user-visible symptom:
+     * no `TerminalView` session/emulator means the terminal surface was never built, so the
+     * user is looking at the loading hold with a healthy connection behind it.
+     */
+    private fun waitForTerminalViewAttached(label: String) {
+        val startedAtMs = SystemClock.elapsedRealtime()
+        val attached = runCatching {
+            compose.waitUntil(timeoutMillis = ATTACH_TIMEOUT_MS) {
+                var ready = false
+                compose.activityRule.scenario.onActivity { activity ->
+                    val view = activity.window.decorView.findTerminalView()
+                    ready = view?.currentSession != null && view.mEmulator != null
+                }
+                ready
+            }
+            true
+        }.getOrDefault(false)
+        val elapsedMs = SystemClock.elapsedRealtime() - startedAtMs
+        recordTiming(label, elapsedMs, attached)
+        assertTrue(
+            "REGRESSION (#2338): the terminal never attached on the $label in this process " +
+                "(waited ${elapsedMs}ms). The connection is healthy at this point — this is the " +
+                "reveal-identity handoff wedge, not a transport failure. " +
+                "revealAdoption=${revealIdentityAdoption()}",
+            attached,
+        )
+    }
+
+    private fun revealIdentityAdoption(): RevealIdentityAdoption? {
+        var adoption: RevealIdentityAdoption? = null
+        compose.activityRule.scenario.onActivity { activity ->
+            adoption = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
+                .revealIdentityAdoption.value
+        }
+        return adoption
+    }
+
+    // ---------------------------------------------------------------- Fixture
+
+    private fun readFixtureKey(): String =
+        InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_key").bufferedReader().use { it.readText() }
+
+    private suspend fun seedDockerHost(key: String): String {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
+        return try {
+            db.clearAllTables()
+            val storedKey = SshKeyStorage.persistKey(
+                context = appContext,
+                sshKeyDao = db.sshKeyDao(),
+                name = "issue2338-key-${System.currentTimeMillis()}",
+                content = key,
+            )
+            val hostId = db.hostDao().insert(
+                HostEntity(
+                    name = "Issue2338 Second Launch",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = storedKey.id,
+                    tmuxInstalled = true,
+                    lastBootstrapAt = System.currentTimeMillis(),
+                ),
+            )
+            HOST_ROW_TAG_PREFIX + hostId
+        } finally {
+            db.close()
+        }
+    }
+
+    /**
+     * Recreate the SAME-named session on every launch. Killing it in [tearDown] and creating
+     * it again here is what changes tmux's `session_created`, which is what makes the second
+     * launch's cached route identity stale.
+     */
+    private suspend fun seedShellSession(key: String) {
+        val payload = "printf '$BANNER_MARKER ready\\n'; while true; do sleep 3600; done"
+        val script = buildString {
+            appendLine("set -eu")
+            appendLine("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+            appendLine("tmux new-session -d -s ${shellQuote(SESSION_NAME)} ${shellQuote(payload)}")
+            appendLine("sleep 1")
+            appendLine("tmux list-sessions -F '#{session_name} #{session_id} #{session_created}'")
+        }
+        val result = SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = SshKey.Pem(key),
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = 15_000,
+        ).mapCatching { session -> session.use { it.exec(script) } }
+        val exec = result.getOrNull()
+        assertTrue(
+            "expected tmux session seeding to succeed; exception=${result.exceptionOrNull()} " +
+                "stderr='${exec?.stderr}'",
+            exec?.exitCode == 0,
+        )
+        Log.i(LOG_TAG, "seeded session: ${exec?.stdout?.trim()}")
+    }
+
+    private suspend fun cleanupRemoteTmuxSession(key: String) {
+        runCatching {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = 15_000,
+            ).mapCatching { session ->
+                session.use {
+                    it.exec("tmux kill-session -t ${shellQuote(SESSION_NAME)} 2>/dev/null || true")
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------- Artifacts
+
+    private fun recordTiming(label: String, elapsedMs: Long, attached: Boolean) {
+        val file = artifactFile("issue2338-timings.txt")
+        file.appendText("terminal_attach label=$label attached=$attached elapsed_ms=$elapsedMs\n")
+        println("ISSUE2338_TIMING label=$label attached=$attached elapsed_ms=$elapsedMs")
+    }
+
+    private fun writeSummary(
+        launchOrdinal: Int,
+        adoption: RevealIdentityAdoption?,
+        note: String,
+    ): File {
+        val file = artifactFile("issue2338-launch-$launchOrdinal-summary.txt")
+        file.writeText(
+            buildString {
+                appendLine("test=Issue2338SecondLaunchTerminalAttachJourneyE2eTest")
+                appendLine("issue=2338")
+                appendLine("launch_ordinal_in_process=$launchOrdinal")
+                appendLine("fixture=tests/docker agents ($DEFAULT_HOST:$DEFAULT_PORT)")
+                appendLine("running_on_ci=${TerminalTestTimeouts.isRunningOnCi()}")
+                appendLine("session=$SESSION_NAME")
+                appendLine("reveal_identity_adoption_from=${adoption?.from?.value}")
+                appendLine("reveal_identity_adoption_to=${adoption?.to?.value}")
+                appendLine("terminal_attached=true")
+                appendLine("note=$note")
+            },
+        )
+        println("ISSUE2338_TEXT ${file.absolutePath}")
+        return file
+    }
+
+    private fun artifactFile(name: String): File {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(instrumentation.targetContext)
+        val dir = File(mediaRoot, "additional_test_output/$DEVICE_DIR_NAME")
+        check(dir.exists() || dir.mkdirs()) { "could not create artifact directory ${dir.absolutePath}" }
+        return File(dir, name)
+    }
+
+    private fun View.findTerminalView(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalView()
+            if (match != null) return match
+        }
+        return null
+    }
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private companion object {
+        const val DATABASE_NAME: String = "pocketshell.db"
+        const val LOG_TAG: String = "Issue2338SecondLaunch"
+        const val DEVICE_DIR_NAME: String = "issue2338-second-launch-attach"
+        const val SESSION_NAME: String = "issue2338-second-launch"
+        const val BANNER_MARKER: String = "ISSUE2338-READY"
+
+        /** `tmux:<hostId>:<sessionId>:<createdEpochSeconds>` — an EXACT durable identity. */
+        val EXACT_TARGET_ID: Regex = Regex("""^tmux:\d+:\$\d+:\d+$""")
+
+        val ATTACH_TIMEOUT_MS: Long =
+            if (TerminalTestTimeouts.isRunningOnCi()) 45_000L else 30_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxRevealController.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxRevealController.kt
@@ -4,6 +4,7 @@ import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionTarget
 import com.pocketshell.core.connection.ConnectionState as CoreConnectionState
 import com.pocketshell.core.connection.ConnectionProjection
 import com.pocketshell.core.connection.HostKey
+import com.pocketshell.core.connection.RevealIdentityAdoption
 import com.pocketshell.core.connection.RevealState
 import com.pocketshell.core.connection.RevealStateMachine
 import com.pocketshell.core.connection.Seed
@@ -27,6 +28,12 @@ internal class TmuxRevealController(
     private val revealStateMachine: RevealStateMachine = RevealStateMachine()
 
     val state: StateFlow<RevealState> = revealStateMachine.state
+
+    /**
+     * Issue #2338: the reducer's last identity handoff, so the rendered screen
+     * can follow an adoption of ITS OWN route id (and only that one).
+     */
+    val identityAdoption: StateFlow<RevealIdentityAdoption?> = revealStateMachine.identityAdoption
 
     fun onConnectionState(state: CoreConnectionState) {
         revealStateMachine.onConnectionState(state)

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionScreenRuntime.kt
@@ -17,6 +17,7 @@ import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.tmux.TmuxSessionViewModel.ConnectionStatus
 import com.pocketshell.core.agents.AgentDetection
 import com.pocketshell.core.agents.AgentKind
+import com.pocketshell.core.connection.RevealIdentityAdoption
 import com.pocketshell.core.connection.RevealState
 import com.pocketshell.core.connection.SessionId
 import com.pocketshell.core.connection.SessionSurfaceState
@@ -75,10 +76,19 @@ internal class TmuxSessionConnectionRuntime(
  * A cold deep link can carry only a mutable tmux name. The first authoritative
  * pane listing then rekeys [reveal] to tmux's exact generation, so the screen
  * must follow that same reveal identity or [sessionSurfaceState] will correctly
- * hold an otherwise valid live frame as superseded. An explicit route
- * generation always wins; for a name-only route, adopt only an exact reveal
- * whose host and target name match this route. The fusion below remains the
- * final stale-id fence.
+ * hold an otherwise valid live frame as superseded. For a name-only route,
+ * adopt only an exact reveal whose host and target name match this route. The
+ * fusion below remains the final stale-id fence.
+ *
+ * Issue #2338: a route that DOES carry a generation is not automatically
+ * authoritative — a route id is only ever as fresh as whatever produced it
+ * (persisted last-session record, cached session tree, deep link), and tmux
+ * session names are unique per server, so a route generation that disagrees
+ * with the live pane listing is simply stale. When the reducer publishes an
+ * [adoption] whose `from` is EXACTLY this route's id, the pane listing proved
+ * that and the screen must follow `to`. Without a matching adoption the route
+ * stays authoritative, so a held reveal from another generation still cannot
+ * retarget this screen (the #686 wrong-session fence).
  */
 internal fun tmuxSessionSurfaceTargetId(
     routeTargetId: SessionId,
@@ -87,10 +97,14 @@ internal fun tmuxSessionSurfaceTargetId(
     routeTmuxSessionId: String?,
     routeSessionCreated: Long?,
     reveal: RevealState,
+    adoption: RevealIdentityAdoption? = null,
 ): SessionId {
-    // A route with a generation is already authoritative. Never let a held
-    // reveal from another generation replace an explicit route identity.
-    if (tmuxSessionGenerationOrNull(routeTmuxSessionId, routeSessionCreated) != null) {
+    // A route with a generation stays authoritative unless the reducer re-keyed
+    // THIS route's identity. Never let a merely-held reveal from another
+    // generation replace an explicit route identity.
+    if (tmuxSessionGenerationOrNull(routeTmuxSessionId, routeSessionCreated) != null &&
+        adoption?.from != routeTargetId
+    ) {
         return routeTargetId
     }
 
@@ -128,13 +142,18 @@ internal fun rememberTmuxSessionConnectionRuntime(
     // the rendered screen state is a pure function of that id (`RevealStateMachine`),
     // so a late/stale frame from the previous session can NEVER paint.
     val revealState by viewModel.revealState.collectAsState()
+    // Issue #2338: the reducer's identity handoff must be an observed state read
+    // here, not a snapshot peeked during composition, or the screen would not
+    // recompose onto the adopted identity.
+    val revealIdentityAdoption by viewModel.revealIdentityAdoption.collectAsState()
     val routeTargetSessionId = remember(hostId, sessionName, tmuxSessionId, sessionCreated) {
         tmuxTargetSessionId(hostId, sessionName, tmuxSessionId, sessionCreated)
     }
     // Issue #2294: a name-only cold route is intentionally enriched by the
     // authoritative exact id carried by the reveal reducer after list-panes.
-    // Explicit route generations stay fixed, and the selector's name/host
-    // checks leave the fusion's strict stale-id fence intact.
+    // Issue #2338: a route carrying a STALE exact generation is enriched the
+    // same way, but only when the reducer adopted this exact route id; the
+    // selector's name/host checks leave the fusion's stale-id fence intact.
     val targetSessionId = tmuxSessionSurfaceTargetId(
         routeTargetId = routeTargetSessionId,
         routeHostId = hostId,
@@ -142,6 +161,7 @@ internal fun rememberTmuxSessionConnectionRuntime(
         routeTmuxSessionId = tmuxSessionId,
         routeSessionCreated = sessionCreated,
         reveal = revealState,
+        adoption = revealIdentityAdoption,
     )
     val activeSessionCardsTargetKey = remember(hostId, host, port, user, keyPath, sessionName) {
         sessionCardsTargetKey(

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -1536,7 +1536,7 @@ public class TmuxSessionViewModel @Inject constructor(
     }
 
     /** Id-keyed session reveal projection; the screen renders strictly from [revealState]. */
-    private val revealController: TmuxRevealController =
+    internal val revealController: TmuxRevealController =
         TmuxRevealController(
             hostKeyForTarget = { target -> hostKeyFor(target.toSshLeaseTarget().leaseKey) },
         )

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModelSessionGeneration.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModelSessionGeneration.kt
@@ -1,5 +1,20 @@
 package com.pocketshell.app.tmux
 
+import com.pocketshell.core.connection.RevealIdentityAdoption
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Issue #2338: the reveal reducer's exact-generation identity handoff, published
+ * so the screen keyed to the SUPERSEDED route id can follow it instead of
+ * holding the terminal behind the #686 stale-id fence forever.
+ *
+ * Lives here (with the adoption that produces it) rather than on the VM: the
+ * god object is byte-ratcheted downward and this is identity-promotion state,
+ * not another VM responsibility.
+ */
+public val TmuxSessionViewModel.revealIdentityAdoption: StateFlow<RevealIdentityAdoption?>
+    get() = revealController.identityAdoption
+
 internal data class ParsedPaneApplyResult(
     val newPanes: List<TmuxPaneState>,
     val refreshGuard: RuntimeRefreshGuard?,

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2338StaleRouteGenerationRevealHandoffTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2338StaleRouteGenerationRevealHandoffTest.kt
@@ -1,0 +1,454 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.connection.ConnectionPhase
+import com.pocketshell.core.connection.RevealIdentityAdoption
+import com.pocketshell.core.connection.RevealState
+import com.pocketshell.core.connection.Seed
+import com.pocketshell.core.connection.SessionId
+import com.pocketshell.core.connection.SessionSurfaceState
+import com.pocketshell.core.connection.sessionSurfaceState
+import com.pocketshell.core.connection.targetIdOrNull
+import com.pocketshell.core.connection.terminalHeld
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseTarget
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #2338 — "terminal never attaches on the 2nd+ MainActivity launch in a process".
+ *
+ * ## The class of bug
+ *
+ * A tmux session NAME is unique per server, so a route's `(tmuxSessionId,
+ * sessionCreated)` pair is only ever as fresh as whatever produced it: the
+ * persisted last-session record, the cached session tree the picker renders, or
+ * a deep link. Whenever any of those was written for an EARLIER generation of a
+ * same-named session — which is exactly what "the 2nd+ launch in one process"
+ * means, because the FIRST launch is what wrote them — the cold attach reaches
+ * [TmuxSessionViewModel.reconcilePanes] with a STALE exact generation.
+ *
+ * Since #2294 the first authoritative `list-panes` adopts the LIVE generation
+ * into `activeTarget` / `connectingTarget` / `latestConnectIntent` and re-keys
+ * the reveal reducer + connection controller onto it. The screen, however, is
+ * still composed with the route id. Before this fix the render selector treated
+ * "the route carries a generation" as authoritative and refused to follow the
+ * adoption, so [sessionSurfaceState] saw `reveal.targetId != screen targetId`
+ * and HELD the terminal forever: SSH up, tmux attached, `paneCount=1`, and no
+ * `TerminalView` ever built (no `tmux-client-size-known`).
+ *
+ * The assertions below are on the fused surface state — the thing that decides
+ * whether the terminal is exposed — not on the metadata promotion, so a green
+ * here means the user-visible symptom is gone.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class Issue2338StaleRouteGenerationRevealHandoffTest : TmuxSessionViewModelTestBase() {
+
+    /**
+     * The reported defect, on the production VM path: a route carrying the
+     * PREVIOUS generation of a same-named session must still reveal its
+     * terminal once list-panes supplies the live generation.
+     */
+    @Test
+    fun staleRouteGenerationStillRevealsTerminalAfterExactAdoption() = runTest(scheduler) {
+        val vm = newConnectedVm(
+            routeTmuxSessionId = PREVIOUS_SESSION_ID,
+            routeSessionCreated = PREVIOUS_CREATED,
+            livePaneSessionId = LIVE_SESSION_ID,
+            livePaneCreated = LIVE_CREATED,
+        )
+        advanceUntilIdle()
+
+        val routeTargetId = tmuxTargetSessionId(
+            hostId = HOST_ID,
+            sessionName = SESSION_NAME,
+            tmuxSessionId = PREVIOUS_SESSION_ID,
+            sessionCreated = PREVIOUS_CREATED,
+        )
+        val liveTargetId = tmuxTargetSessionId(
+            hostId = HOST_ID,
+            sessionName = SESSION_NAME,
+            tmuxSessionId = LIVE_SESSION_ID,
+            sessionCreated = LIVE_CREATED,
+        )
+
+        // Non-vacuity: the fixture MUST have entered the failing state — the
+        // reducer re-keyed away from the route id the screen still holds. If the
+        // route and the live generation ever agreed, this test would be proving
+        // nothing, so hard-fail instead of passing quietly.
+        assertNotEquals(
+            "the route generation must differ from the live one for this to be the #2338 state",
+            routeTargetId,
+            liveTargetId,
+        )
+        val adoption = vm.revealIdentityAdoption.value
+        assertEquals(
+            "the production reconcile must publish the identity handoff it performed",
+            RevealIdentityAdoption(from = routeTargetId, to = liveTargetId),
+            adoption,
+        )
+        val reveal = vm.revealState.value
+        assertEquals(
+            "the reveal reducer moved onto the live generation",
+            liveTargetId,
+            reveal.targetIdOrNull(),
+        )
+
+        // The load-bearing assertion: the rendered surface must expose the
+        // terminal. On base the selector returns the stale route id and the
+        // fusion holds it forever.
+        val renderedTargetId = tmuxSessionSurfaceTargetId(
+            routeTargetId = routeTargetId,
+            routeHostId = HOST_ID,
+            routeSessionName = SESSION_NAME,
+            routeTmuxSessionId = PREVIOUS_SESSION_ID,
+            routeSessionCreated = PREVIOUS_CREATED,
+            reveal = reveal,
+            adoption = adoption,
+        )
+        val surface = sessionSurfaceState(
+            reveal = reveal,
+            phase = ConnectionPhase.Live(HOST, PORT, USER),
+            targetId = renderedTargetId,
+        )
+        assertFalse(
+            "REGRESSION (#2338): a stale route generation must not hold the terminal forever " +
+                "(SSH up, tmux attached, panes listed — and no TerminalView ever built); " +
+                "rendered=$renderedTargetId reveal=${reveal.targetIdOrNull()} surface=$surface",
+            surface.terminalHeld,
+        )
+        assertTrue("the surface must be Live", surface is SessionSurfaceState.Live)
+        assertEquals(
+            "the screen must follow the adoption of its OWN route id",
+            liveTargetId,
+            renderedTargetId,
+        )
+    }
+
+    /**
+     * G2 class coverage, other half: the #686 stale-id fence must survive. A
+     * reveal that merely HOLDS another generation — with no adoption of this
+     * route's id — must never retarget this screen.
+     */
+    @Test
+    fun heldForeignGenerationWithoutAdoptionStaysFenced() {
+        val routeTargetId = SessionId("tmux:42:\$9:1700000005")
+        val foreignTargetId = SessionId("tmux:42:\$8:1700000004")
+        val foreignReveal = RevealState.Live(
+            targetId = foreignTargetId,
+            targetName = SESSION_NAME,
+            panes = listOf(Seed(foreignTargetId, "%0", "stale")),
+        )
+
+        val renderedTargetId = tmuxSessionSurfaceTargetId(
+            routeTargetId = routeTargetId,
+            routeHostId = 42L,
+            routeSessionName = SESSION_NAME,
+            routeTmuxSessionId = "\$9",
+            routeSessionCreated = 1_700_000_005L,
+            reveal = foreignReveal,
+            adoption = null,
+        )
+        val surface = sessionSurfaceState(
+            reveal = foreignReveal,
+            phase = ConnectionPhase.Connecting(HOST, PORT, USER),
+            targetId = renderedTargetId,
+        )
+
+        assertEquals(
+            "an un-adopted foreign generation must not retarget this route",
+            routeTargetId,
+            renderedTargetId,
+        )
+        assertTrue("the foreign frame must stay held", surface.terminalHeld)
+    }
+
+    /**
+     * G2 class coverage: an adoption recorded for a DIFFERENT route must not
+     * leak onto this screen either — the handoff is keyed to `from`, not merely
+     * to "an adoption happened".
+     */
+    @Test
+    fun adoptionFromAnotherRouteDoesNotRetargetThisScreen() {
+        val routeTargetId = SessionId("tmux:42:\$9:1700000005")
+        val otherRouteId = SessionId("tmux:42:\$1:1700000001")
+        val adoptedTargetId = SessionId("tmux:42:\$8:1700000004")
+        val reveal = RevealState.Live(
+            targetId = adoptedTargetId,
+            targetName = SESSION_NAME,
+            panes = listOf(Seed(adoptedTargetId, "%0", "other")),
+        )
+
+        val renderedTargetId = tmuxSessionSurfaceTargetId(
+            routeTargetId = routeTargetId,
+            routeHostId = 42L,
+            routeSessionName = SESSION_NAME,
+            routeTmuxSessionId = "\$9",
+            routeSessionCreated = 1_700_000_005L,
+            reveal = reveal,
+            adoption = RevealIdentityAdoption(from = otherRouteId, to = adoptedTargetId),
+        )
+
+        assertEquals(
+            "only the screen whose route id WAS adopted may follow the handoff",
+            routeTargetId,
+            renderedTargetId,
+        )
+    }
+
+    /**
+     * G2 class coverage: a name-only route keeps the #2294 behaviour — it
+     * follows a matching exact reveal even before any adoption record exists.
+     */
+    @Test
+    fun nameOnlyRouteStillFollowsExactRevealWithoutAdoptionRecord() {
+        val routeTargetId = tmuxTargetSessionId(
+            hostId = 42L,
+            sessionName = SESSION_NAME,
+            tmuxSessionId = null,
+            sessionCreated = null,
+        )
+        val exactTargetId = SessionId("tmux:42:\$7:1700000003")
+        val reveal = RevealState.Live(
+            targetId = exactTargetId,
+            targetName = SESSION_NAME,
+            panes = listOf(Seed(exactTargetId, "%0", "prompt")),
+        )
+
+        val renderedTargetId = tmuxSessionSurfaceTargetId(
+            routeTargetId = routeTargetId,
+            routeHostId = 42L,
+            routeSessionName = SESSION_NAME,
+            routeTmuxSessionId = null,
+            routeSessionCreated = null,
+            reveal = reveal,
+            adoption = null,
+        )
+
+        assertEquals("the name-only cold route still adopts the exact reveal", exactTargetId, renderedTargetId)
+    }
+
+    /**
+     * The ORDERING dependency itself: a fresh navigation ends the previous
+     * handoff, so the next screen's route can never be retargeted by the
+     * previous attach's adoption.
+     */
+    @Test
+    fun renavigationClearsThePreviousIdentityHandoff() = runTest(scheduler) {
+        val vm = newConnectedVm(
+            routeTmuxSessionId = PREVIOUS_SESSION_ID,
+            routeSessionCreated = PREVIOUS_CREATED,
+            livePaneSessionId = LIVE_SESSION_ID,
+            livePaneCreated = LIVE_CREATED,
+        )
+        advanceUntilIdle()
+        assertNotNullAdoption(vm)
+
+        vm.connect(
+            hostId = HOST_ID,
+            hostName = HOST_NAME,
+            host = HOST,
+            port = PORT,
+            user = USER,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            sessionName = "another-session",
+        )
+
+        assertNull(
+            "a genuine renavigation must end the previous identity handoff",
+            vm.revealIdentityAdoption.value,
+        )
+    }
+
+    private fun assertNotNullAdoption(vm: TmuxSessionViewModel) {
+        assertTrue(
+            "precondition: the stale-route attach must have adopted the live generation",
+            vm.revealIdentityAdoption.value != null,
+        )
+    }
+
+    /**
+     * Drive the real production path: `connect()` navigates the reveal reducer
+     * with the ROUTE identity, then the attach runs list-panes ->
+     * applyParsedPanes -> exact-generation adoption -> capture seed. Nothing
+     * here calls the reveal/controller adoption directly.
+     */
+    private fun TestScope.newConnectedVm(
+        routeTmuxSessionId: String,
+        routeSessionCreated: Long,
+        livePaneSessionId: String,
+        livePaneCreated: Long,
+    ): TmuxSessionViewModel {
+        val session = FakeSshSession()
+        val connector = QueueLeaseConnector(session)
+        val vm = newVm(
+            sshLeaseManager = testLeaseManager(
+                connector = connector,
+                scope = this,
+                idleTtlMillis = 0L,
+            ),
+        )
+        val newClient = FakeTmuxClient()
+        newClient.responses += CommandResponse(
+            number = 0L,
+            output = listOf(
+                exactGenerationPaneRow(
+                    paneId = "%0",
+                    sessionId = livePaneSessionId,
+                    sessionName = SESSION_NAME,
+                    sessionCreated = livePaneCreated,
+                ),
+            ),
+            isError = false,
+        )
+        newClient.capturePaneResponses += CommandResponse(
+            number = 1L,
+            output = listOf("shell prompt"),
+            isError = false,
+        )
+        vm.setTmuxClientFactoryForTest { _, sessionName, _ ->
+            assertEquals(SESSION_NAME, sessionName)
+            newClient
+        }
+        vm.replaceClientForTest(
+            hostId = HOST_ID,
+            hostName = HOST_NAME,
+            host = HOST,
+            port = PORT,
+            user = USER,
+            keyPath = KEY_PATH,
+            sessionName = "some-other-warm-session",
+            client = FakeTmuxClient(),
+            session = session,
+        )
+        vm.connect(
+            hostId = HOST_ID,
+            hostName = HOST_NAME,
+            host = HOST,
+            port = PORT,
+            user = USER,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            sessionName = SESSION_NAME,
+            tmuxSessionId = routeTmuxSessionId,
+            sessionCreated = routeSessionCreated,
+        )
+        return vm
+    }
+
+    private fun exactGenerationPaneRow(
+        paneId: String,
+        sessionId: String,
+        sessionName: String,
+        sessionCreated: Long?,
+    ): String = listOf(
+        paneId,
+        "@0",
+        "0",
+        sessionId,
+        sessionName,
+        "shell",
+        "0",
+        "/tmp",
+        "bash",
+        "/dev/pts/1",
+        "0",
+        "123",
+        "0",
+        sessionCreated?.toString().orEmpty(),
+        "",
+    ).joinToString(LIST_PANES_FIELD_SEPARATOR)
+
+    private class QueueLeaseConnector(
+        private vararg val sessions: FakeSshSession,
+    ) : SshLeaseConnector {
+        private var connectCount: Int = 0
+
+        override suspend fun connect(target: SshLeaseTarget): Result<SshSession> {
+            val next = sessions.getOrNull(connectCount)
+                ?: error("unexpected lease connect $connectCount for ${target.leaseKey}")
+            connectCount += 1
+            return Result.success(next)
+        }
+    }
+
+    private class FakeSshSession : SshSession {
+        @Volatile
+        private var closed: Boolean = false
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = Job()
+
+        override fun tail(
+            path: String,
+            fromLineExclusive: Long,
+            onLine: (String) -> Unit,
+        ): Job = Job()
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = throw NotImplementedError("not needed")
+
+        override fun startShell(): SshShell = throw NotImplementedError("not needed")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String =
+            error("uploadFile not used in this test")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("uploadStream not used in this test")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        const val HOST_ID = 42L
+        const val HOST_NAME = "docker"
+        const val HOST = "10.0.2.2"
+        const val PORT = 2222
+        const val USER = "alex"
+        const val KEY_PATH = "/keys/a"
+        const val SESSION_NAME = "cold"
+
+        // The generation the FIRST launch in this process recorded.
+        const val PREVIOUS_SESSION_ID = "\$0"
+        const val PREVIOUS_CREATED = 1_787_759_746L
+
+        // The generation tmux actually has now (the session was recreated).
+        const val LIVE_SESSION_ID = "\$0"
+        const val LIVE_CREATED = 1_787_759_789L
+    }
+}

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -211,6 +211,7 @@ JOURNEY_CLASSES=(
   "$FQCN_PREFIX.StaleRenderHealOnLiveTransportJourneyE2eTest"  # #966 #967 / — the DISCRIMINATING render-death-on-a-LIVE-transport jour…
   "$FQCN_PREFIX.AgentAltScreenPartialBlackHealJourneyE2eTest"  # #1138 #966 the SEMI/PARTIAL-black on a live AGENT ALT-SCREEN pane
   "$FQCN_PREFIX.PaneOutputOverflowRecoveryJourneyE2eTest"  # #1205 #780 pane delivery-backlog / seed-gate OVERFLOW must self-heal, n…
+  "$FQCN_PREFIX.Issue2338SecondLaunchTerminalAttachJourneyE2eTest"  # #2338 D33/G2/G10: the 2nd+ MainActivity launch in ONE process must still attach its terminal — a route carrying a STALE exact tmux generation (re-keyed by list-panes since #2294) must not hold the surface forever. Hard-asserts the stale-route state was entered, so it cannot pass vacuously.
   "$FQCN_PREFIX.TmuxTerminalSurfaceFailureE2eTest"  # #423 local terminal/IME/render failure storm shows actionable Recreate terminal on a live transport; no SSH reconnect
   "$FQCN_PREFIX.Issue2178TypedEchoSurvivesReseedE2eTest"  # #2178 #2126 typing inside the reveal->reseed window must not lose bytes: a capture-pane snapshot older than the screen must never be painted over live echo
   "$FQCN_PREFIX.VoiceSendActivePaneStaysVisibleE2eTest"  # #687 #717 #658 epic slice 2, — reveal/reflow-heal absorbed from ): after

--- a/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
+++ b/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
@@ -273,3 +273,17 @@ com.pocketshell.app.composer.PromptComposerOutboundQueueProductionDeleteDockerTe
 # AVD; that is not the in-suite cost. Use the sibling capture fixture's
 # measured 21s plus one extra test method.
 com.pocketshell.app.proof.signals.SessionCaptureContractTest	22
+
+# Issue #2338: new selector, never run on GitHub Actions CI. Measured on
+# 2026-08-27 from a standalone :app:connectedDebugAndroidTest invocation on
+# the reviewed fix (issue-2338 branch, emulator-5558, rc=0, 2/2 passed) via
+# `scripts/connected-test.sh --suffix i2338tsv`. The wrapper reported "BUILD
+# SUCCESSFUL in 1m 4s"; this row uses ceil(wrapper wall time)=64s, matching
+# the JOURNEY_PASS wall-time convention used for #1700 above. JUnit suite
+# time was 22.571s, but is not substituted for the isolated Gradle invocation
+# cost. Evidence XML digest (sha256):
+# db58ff97699c4d16f62ee501d95e75290df0d1c4bc747172895d8142c77d5ea5. Unlike
+# the other rows in this file, this measurement is from a local dev-box
+# emulator, not a GitHub Actions run — refresh with a real CI attempt-1
+# elapsed time once this class has run there.
+com.pocketshell.app.proof.Issue2338SecondLaunchTerminalAttachJourneyE2eTest	64

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/ConnectionModel.kt
@@ -33,6 +33,27 @@ data class HostKey(val value: String)
 data class SessionId(val value: String)
 
 /**
+ * Issue #2338: a record that the reveal reducer re-keyed the CURRENT session
+ * from one [SessionId] to another without renavigating.
+ *
+ * Identity adoption happens when the first authoritative `list-panes` proves the
+ * navigation id incomplete (name-only) or stale (an exact generation that is no
+ * longer the live one). The reducer, the connection controller and every seed
+ * move to [to] at that moment, but the SCREEN still holds the route id it was
+ * composed with — so without this record the fused surface state sees
+ * `reveal.targetId != screen targetId` and holds the terminal forever (the
+ * #2338 "terminal never attaches on the 2nd+ launch" wedge).
+ *
+ * [from] is the identity the screen was navigated with, so a screen may follow
+ * [to] only when its own route id equals [from]. Any other screen keeps its own
+ * identity and stays behind the #686 stale-id fence.
+ */
+data class RevealIdentityAdoption(
+    val from: SessionId,
+    val to: SessionId,
+)
+
+/**
  * An id-tagged pane capture produced by the connection core. The screen (#686)
  * drops any [Seed] whose [targetId] != the current target, so a late seed from a
  * superseded switch never paints. `frame` is the captured pane content as an

--- a/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
+++ b/shared/core-connection/src/main/java/com/pocketshell/core/connection/RevealStateMachine.kt
@@ -44,6 +44,19 @@ class RevealStateMachine {
     /** The single source the view renders name + surface from. */
     val state: StateFlow<RevealState> = _state.asStateFlow()
 
+    private val _identityAdoption = MutableStateFlow<RevealIdentityAdoption?>(null)
+
+    /**
+     * Issue #2338: the LAST [adoptTargetId] handoff, or null when the current
+     * reveal identity is exactly the one [navigate] supplied.
+     *
+     * The render fence needs the `from` half: a screen whose route id equals
+     * [RevealIdentityAdoption.from] is the SAME session the reducer re-keyed,
+     * so it must follow [RevealIdentityAdoption.to]; every other screen keeps
+     * its own route identity and stays fenced.
+     */
+    val identityAdoption: StateFlow<RevealIdentityAdoption?> = _identityAdoption.asStateFlow()
+
     /** The current target id — the drop-by-id reference for all inputs. Null only
      *  before the first [navigate]. */
     private val currentTargetId: SessionId?
@@ -106,6 +119,10 @@ class RevealStateMachine {
         }
         panes.clear()
         agentName = null
+        // Issue #2338: a genuine renavigation ends any previous identity handoff.
+        // Keeping a stale adoption would let the render fence retarget a screen
+        // whose route was never the adopted `from`.
+        _identityAdoption.value = null
         _state.value = RevealState.Navigating(targetId, targetName)
     }
 
@@ -127,6 +144,13 @@ class RevealStateMachine {
         panes.clear()
         panes.addAll(adoptedPanes)
         _state.value = _state.value.withTargetId(to, adoptedPanes)
+        // Issue #2338: publish WHICH navigation id this reveal was adopted FROM.
+        // Without it the render fence cannot distinguish "the pane listing proved
+        // MY route's generation stale" (follow the adopted id) from "the reveal
+        // happens to hold some other generation of a same-named session" (stay
+        // fenced) — and defaulting to the fence wedges every attach whose route
+        // carried a stale exact generation.
+        _identityAdoption.value = RevealIdentityAdoption(from = from, to = to)
     }
 
     /**

--- a/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
+++ b/shared/core-connection/src/test/java/com/pocketshell/core/connection/RevealStateMachineTest.kt
@@ -97,6 +97,68 @@ class RevealStateMachineTest {
         assertEquals(RevealState.Navigating(b, "session-B"), m.state.value)
     }
 
+    // --- issue #2338: the identity handoff must be observable -------------
+
+    @Test
+    fun `adoption publishes the navigation id it re-keyed away from`() {
+        val m = RevealStateMachine()
+        val exact = SessionId("tmux:7:\$0:1700000003")
+        m.navigate(a, "session-A")
+        assertNull("no handoff before any adoption", m.identityAdoption.value)
+
+        m.adoptTargetId(from = a, to = exact)
+
+        assertEquals(
+            "the screen composed with `a` must be able to recognise this handoff as its own",
+            RevealIdentityAdoption(from = a, to = exact),
+            m.identityAdoption.value,
+        )
+    }
+
+    @Test
+    fun `a rejected adoption publishes no handoff`() {
+        val m = RevealStateMachine()
+        val exactA = SessionId("tmux:7:\$0:1700000003")
+        m.navigate(b, "session-B")
+
+        m.adoptTargetId(from = a, to = exactA)
+
+        assertNull(
+            "a late adoption for another runtime must not advertise a handoff",
+            m.identityAdoption.value,
+        )
+    }
+
+    @Test
+    fun `a genuine renavigation ends the previous handoff`() {
+        val m = RevealStateMachine()
+        val exact = SessionId("tmux:7:\$0:1700000003")
+        m.navigate(a, "session-A")
+        m.adoptTargetId(from = a, to = exact)
+        assertEquals(RevealIdentityAdoption(a, exact), m.identityAdoption.value)
+
+        m.navigate(b, "session-B")
+
+        assertNull(
+            "session B's screen must never inherit session A's identity handoff",
+            m.identityAdoption.value,
+        )
+    }
+
+    @Test
+    fun `an idempotent renavigation keeps the handoff`() {
+        val m = RevealStateMachine()
+        val exact = SessionId("tmux:7:\$0:1700000003")
+        m.navigate(a, "session-A")
+        m.adoptTargetId(from = a, to = exact)
+
+        // The VM re-announces the (now adopted) target — same id, so this is a
+        // no-op that must not drop the handoff the screen still needs.
+        m.navigate(exact, "session-A")
+
+        assertEquals(RevealIdentityAdoption(a, exact), m.identityAdoption.value)
+    }
+
     // --- a foreign seed is dropped, never revealed ------------------------
 
     @Test


### PR DESCRIPTION
Closes #2338

This current-main recovery ports the reviewed stale exact-generation identity adoption path and adds:
- a load-bearing JVM regression covering stale, foreign, missing-data, cross-route, and renavigation cases;
- a real second-launch emulator journey wired into the CI journey suite;
- the fixture cost row and current ConnectionModel/RevealStateMachine handoff.

Pre-merge verification:
- reviewer APPROVED with current-base mutation: 15 focused tests, 1 base failure and fixed candidate green;
- reviewer emulator/Docker evidence: second-launch journey 2/2 green, plus preserved switch/reconnect adjacency evidence;
- integration focused run: 15/15 #2338/#2294 tests green;
- static, connection-ratchet, file-size, journey-harness, retry-budget, and test-validity checks green.
- durable artifacts: /home/alexey/.cache/pocketshell/evidence/issue-2338-reviewer-20260827 and issue-2338-review-r2.