### PR TITLE
ssh: instrument critical lease state-edge delivery (#2314)

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshDiagnostics.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshDiagnostics.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.core.ssh
 
+import java.util.concurrent.ArrayBlockingQueue
+
 /**
  * Issue #1683 — the minimal transport-level diagnostics seam for core-ssh.
  *
@@ -15,9 +17,11 @@ package com.pocketshell.core.ssh
  * Like [com.pocketshell.core.connection.ConnectionDiagnostics], this is a
  * fire-and-forget sink the app installs once at startup, forwarding into the
  * real recorder under the `connection` category (so keepalive inputs are
- * mirrored to the host alongside the verdicts). The default is a no-op, so the
- * pure [TransportKeepAlive] virtual-clock tests keep running with zero wiring
- * and the loop cadence is unchanged — recording is never awaited.
+ * mirrored to the host alongside the verdicts). Both [SshDiagnostics.record]
+ * and [SshDiagnostics.recordNonBlocking] use the bounded mailbox, so no
+ * installable sink ever runs on the transport/lease thread. The default is a
+ * no-op, so pure virtual-clock tests keep running with zero wiring and unchanged
+ * loop cadence.
  */
 fun interface SshDiagnosticsSink {
     fun record(event: String, fields: Map<String, Any?>)
@@ -25,20 +29,75 @@ fun interface SshDiagnosticsSink {
 
 object SshDiagnostics {
     private val noop = SshDiagnosticsSink { _, _ -> }
+    private const val NON_BLOCKING_BUFFER_CAPACITY = 64
+
+    private data class InstalledSink(
+        val generation: Long,
+        val sink: SshDiagnosticsSink,
+    )
+
+    private data class PendingEvent(
+        val generation: Long,
+        val event: String,
+        val fields: Map<String, Any?>,
+    )
 
     @Volatile
-    private var sink: SshDiagnosticsSink = noop
+    private var installed = InstalledSink(generation = 0L, sink = noop)
+    private val pending = ArrayBlockingQueue<PendingEvent>(NON_BLOCKING_BUFFER_CAPACITY)
+    private val worker = Thread(::drain, "pocketshell-ssh-diagnostics")
+        .apply {
+            isDaemon = true
+            start()
+        }
 
     fun install(installed: SshDiagnosticsSink) {
-        sink = installed
+        pending.clear()
+        val nextGeneration = this.installed.generation + 1L
+        this.installed = InstalledSink(nextGeneration, installed)
     }
 
     /** Test-only reset back to the no-op sink. */
     fun reset() {
-        sink = noop
+        pending.clear()
+        val nextGeneration = installed.generation + 1L
+        installed = InstalledSink(nextGeneration, noop)
     }
 
+    /** Record a diagnostic through the bounded, nonblocking mailbox. */
     fun record(event: String, vararg fields: Pair<String, Any?>) {
-        sink.record(event, fields.toMap())
+        recordNonBlocking(event, *fields)
+    }
+
+    /**
+     * Queue a diagnostic without invoking the installable sink on the caller's
+     * thread. The queue and its single daemon worker are bounded; a saturated
+     * queue drops this best-effort diagnostic rather than blocking SSH/lease IO.
+     * Sink exceptions are contained on the worker so they cannot cancel the
+     * worker or escape a manager teardown path. A generation fence prevents
+     * events queued for a previous installed test/app sink from crossing an
+     * install/reset boundary.
+     */
+    fun recordNonBlocking(event: String, vararg fields: Pair<String, Any?>) {
+        val current = installed
+        val item = PendingEvent(
+            generation = current.generation,
+            event = event,
+            fields = fields.toMap(),
+        )
+        if (!pending.offer(item)) return
+    }
+
+    private fun drain() {
+        try {
+            while (!Thread.currentThread().isInterrupted) {
+                val item = pending.take()
+                val current = installed
+                if (item.generation != current.generation) continue
+                runCatching { current.sink.record(item.event, item.fields) }
+            }
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
     }
 }

--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/SshLeaseManager.kt
@@ -91,6 +91,9 @@ public class SshLeaseManager(
         linkedMapOf()
     private var closed: Boolean = false
     private var nextEntryId: Long = 1L
+    private var nextStateEventSequence: Long = 1L
+    /** Test seam used to place collector cancellation after tryEmit, before its publication decision. */
+    internal var stateEventAfterTryEmitHookForTest: (() -> Unit)? = null
     private var processStarted: Boolean = true
     private val _stateEvents = MutableSharedFlow<SshLeaseStateEvent>(
         extraBufferCapacity = STATE_EVENT_BUFFER_CAPACITY,
@@ -100,8 +103,15 @@ public class SshLeaseManager(
     // [emitStateLocked] can keep [stateEvents] a true transport-state EDGE stream
     // and not re-announce a transport that was already up. Only mutated under
     // [mutex] (every [emitStateLocked] call site holds it), so no extra
-    // synchronisation is needed. A key drops out of the map only on a `Closed`
-    // edge (transport gone), so a fresh dial after a close re-emits `Connected`.
+    // synchronisation is needed. Issue #2314: a non-suppressed state is written
+    // here ONLY after [_stateEvents.tryEmit] succeeds and the post-publication
+    // subscriber check still sees an active collector (SharedFlow otherwise
+    // returns true while discarding at replay=0). A failed `Closed` attempt is
+    // the sole cleanup exception: its previous published value is captured in
+    // immediate drop telemetry first, then the dead key is forgotten so this
+    // historical bookkeeping cannot grow and a future real dial is not
+    // mistaken for reuse. Forgetting is lifecycle cleanup, not a claim that
+    // `Closed` was published.
     private val lastPublishedState: MutableMap<SshLeaseKey, SshLeaseConnectionState> =
         hashMapOf()
     private val connectScope = CoroutineScope(SupervisorJob() + connectTimeoutContext)
@@ -750,26 +760,71 @@ public class SshLeaseManager(
             if (prior == SshLeaseConnectionState.Connected ||
                 prior == SshLeaseConnectionState.Idle
             ) {
-                // Transport was already up; this acquire merely reused it. No
-                // edge — but keep the published state pinned at `Connected`.
-                lastPublishedState[key] = SshLeaseConnectionState.Connected
+                // Transport was already up; this acquire merely reused it. This
+                // is an intentional semantic suppression, not a publication, so
+                // [lastPublishedState] remains exactly what collectors last saw.
                 return
             }
         }
-        if (state == SshLeaseConnectionState.Closed) {
-            // Transport gone: forget the key so a future reconnect counts as a
-            // genuine transition back into `Connected`.
-            lastPublishedState.remove(key)
-        } else {
-            lastPublishedState[key] = state
-        }
-        _stateEvents.tryEmit(
+        val previousState = lastPublishedState[key]
+        val sequence = nextStateEventSequence++
+        val accepted = _stateEvents.tryEmit(
             SshLeaseStateEvent(
                 key = key,
                 state = state,
                 closeReason = closeReason,
+                sequence = sequence,
+                previousState = previousState,
             ),
         )
+        // The test seam cancels a collector at the actual post-tryEmit boundary.
+        // Keeping this boundary explicit makes the publication linearization
+        // proof executable rather than relying on a timing race.
+        stateEventAfterTryEmitHookForTest?.invoke()
+        // A replay=0 SharedFlow's `tryEmit=true` with no subscriber is a
+        // discard. Checking after the call contains the cancellation race:
+        // cancellation before the tryEmit linearization is diagnosed as a
+        // drop; cancellation after this check is after the publication point.
+        val hasSubscriberAfterEmit = _stateEvents.subscriptionCount.value > 0
+        val published = accepted && hasSubscriberAfterEmit
+        if (published) {
+            if (state == SshLeaseConnectionState.Closed) {
+                lastPublishedState.remove(key)
+            } else {
+                lastPublishedState[key] = state
+            }
+            return
+        }
+
+        // Issue #2314: Connected and Closed are recovery-affecting transport
+        // up/down edges. Connecting and Idle are diagnostic lease-use states;
+        // they remain bounded best-effort and may be inferred from sequence
+        // gaps. Never suspend, launch, or invoke the installed sink while
+        // holding [mutex]: [recordNonBlocking] performs only a bounded queue
+        // offer, so this records the critical miss without blocking SSH IO or
+        // tying delivery to a collector job that may already be cancelled.
+        if (state.isCriticalTransportEdge) {
+            SshDiagnostics.recordNonBlocking(
+                event = "lease_state_edge_dropped",
+                "key" to key.hashCode().toLong(),
+                "host" to key.host,
+                "port" to key.port,
+                "user" to key.user,
+                "credentialId" to key.credentialId,
+                "knownHostsCredentialId" to key.knownHostsId,
+                "previousState" to previousState?.name,
+                "intendedState" to state.name,
+                "closeReason" to closeReason?.name,
+                "sequence" to sequence,
+                "dropReason" to if (hasSubscriberAfterEmit) "buffer_saturated" else "no_subscribers",
+            )
+        }
+        if (state == SshLeaseConnectionState.Closed) {
+            // The transport no longer exists. Keep the failed publication
+            // observable above, then forget historical state so memory remains
+            // bounded and a later dial can publish a genuine Connected edge.
+            lastPublishedState.remove(key)
+        }
     }
 
     private class Entry(
@@ -824,10 +879,21 @@ public class SshLeaseManager(
     }
 }
 
+/**
+ * One attempted lease-state publication that reached [SshLeaseManager.stateEvents].
+ *
+ * [sequence] is manager-local and increases for every non-suppressed publication
+ * attempt, including attempts rejected by the bounded shared-flow buffer. A gap
+ * therefore marks best-effort diagnostic loss; critical Connected/Closed gaps
+ * are also recorded immediately by `lease_state_edge_dropped` telemetry with the
+ * same sequence, [previousState], and intended [state].
+ */
 public data class SshLeaseStateEvent(
     val key: SshLeaseKey,
     val state: SshLeaseConnectionState,
     val closeReason: SshLeaseCloseReason? = null,
+    val sequence: Long = 0L,
+    val previousState: SshLeaseConnectionState? = null,
 )
 
 public enum class SshLeaseConnectionState {
@@ -841,6 +907,9 @@ public enum class SshLeaseConnectionState {
     Idle,
     Closed,
 }
+
+private val SshLeaseConnectionState.isCriticalTransportEdge: Boolean
+    get() = this == SshLeaseConnectionState.Connected || this == SshLeaseConnectionState.Closed
 
 public enum class SshLeaseCloseReason {
     IdleExpired,

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/Issue1683KeepAliveInputTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/Issue1683KeepAliveInputTest.kt
@@ -1,9 +1,13 @@
 package com.pocketshell.core.ssh
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -25,12 +29,14 @@ import org.junit.Test
 class Issue1683KeepAliveInputTest {
 
     private val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+    private val eventSignal = Channel<Unit>(capacity = 16)
 
     @Before
     fun installSink() {
         events.clear()
         SshDiagnostics.install { event, fields ->
             synchronized(events) { events += event to fields }
+            eventSignal.trySend(Unit)
         }
     }
 
@@ -55,6 +61,13 @@ class Issue1683KeepAliveInputTest {
         advanceTimeBy(1_000L); runCurrent() // miss 1
         advanceTimeBy(1_000L); runCurrent() // miss 2
         advanceTimeBy(1_000L); runCurrent() // miss 3 -> death budget crossed
+        keepAlive.stop()
+
+        withContext(Dispatchers.Default) {
+            withTimeout(5_000L) {
+                repeat(4) { eventSignal.receive() }
+            }
+        }
 
         val misses = synchronized(events) { events.filter { it.first == "keepalive_miss" } }
         assertEquals("every miss tick is an INPUT", 3, misses.size)
@@ -76,7 +89,5 @@ class Issue1683KeepAliveInputTest {
             false,
             crossings.last().second["inboundActivityAdvanced"],
         )
-
-        keepAlive.stop()
     }
 }

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseStateEdgeDeliveryTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/SshLeaseStateEdgeDeliveryTest.kt
@@ -1,0 +1,444 @@
+package com.pocketshell.core.ssh
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+/**
+ * Issue #2314 — a saturated [SshLeaseManager.stateEvents] collector must never
+ * make a critical transport edge disappear without an immediate diagnostic.
+ *
+ * These tests exercise only public lease operations. The collector deliberately
+ * stops inside its callback while enough unique live leases are opened to exceed
+ * the production 64-slot shared-flow buffer. The selected first lease has a
+ * known successfully published `Connected` state before saturation, so its
+ * later `Closed` edge has an unambiguous previous state.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SshLeaseStateEdgeDeliveryTest {
+    private val diagnostics = mutableListOf<Pair<String, Map<String, Any?>>>()
+    private val diagnosticSignal = Channel<Pair<String, Map<String, Any?>>>(capacity = 128)
+
+    @Before
+    fun installDiagnostics() {
+        diagnostics.clear()
+        SshDiagnostics.install { event, fields ->
+            val record = event to fields
+            synchronized(diagnostics) { diagnostics += record }
+            diagnosticSignal.trySend(record)
+        }
+    }
+
+    @After
+    fun resetDiagnostics() {
+        SshDiagnostics.reset()
+    }
+
+    @Test
+    fun `saturated slow collector records a dropped critical Closed edge with reconstructable telemetry`() =
+        runTest {
+            val manager = leaseManager()
+            val collectorGate = CompletableDeferred<Unit>()
+            val firstCollected = CompletableDeferred<SshLeaseStateEvent>()
+            val collector = backgroundScope.launch {
+                manager.stateEvents.collect { event ->
+                    firstCollected.complete(event)
+                    collectorGate.await()
+                }
+            }
+            runCurrent()
+
+            val held = mutableListOf<SshLease>()
+            repeat(SATURATING_LEASE_COUNT) { index ->
+                held += manager.acquire(target(index)).getOrThrow()
+            }
+            runCurrent()
+            assertTrue("the collector must be actively blocked, not absent", firstCollected.isCompleted)
+
+            // Exercise the diagnostic-only Idle classification while the same
+            // bounded buffer is saturated. The exact Closed sequence below
+            // proves this transition happened before the critical edge.
+            held[1].release()
+            val droppedKey = held.first().key
+            manager.disconnect(droppedKey)
+
+            val dropped = awaitDiagnostic { (event, fields) ->
+                event == "lease_state_edge_dropped" &&
+                    fields["key"] == droppedKey.hashCode().toLong() &&
+                    fields["intendedState"] == SshLeaseConnectionState.Closed.name
+            }
+            assertNotNull(
+                "the saturated critical Closed edge must be delivered or diagnosed immediately",
+                dropped,
+            )
+            val fields = dropped!!.second
+            assertEquals(droppedKey.host, fields["host"])
+            assertEquals(droppedKey.port, fields["port"])
+            assertEquals(droppedKey.user, fields["user"])
+            assertEquals(droppedKey.credentialId, fields["credentialId"])
+            assertEquals(droppedKey.knownHostsId, fields["knownHostsCredentialId"])
+            assertEquals(SshLeaseConnectionState.Connected.name, fields["previousState"])
+            assertEquals(SshLeaseConnectionState.Closed.name, fields["intendedState"])
+            assertEquals(SshLeaseCloseReason.ExplicitDisconnect.name, fields["closeReason"])
+            assertEquals("buffer_saturated", fields["dropReason"])
+            assertEquals(
+                SATURATING_LEASE_COUNT * 2L + 2L,
+                fields["sequence"],
+            )
+            assertTrue(
+                "drop telemetry must carry a positive manager-local edge sequence",
+                (fields["sequence"] as? Long ?: 0L) > 0L,
+            )
+            assertTrue(
+                "drop sequence must follow the first successfully published event",
+                (fields["sequence"] as Long) > firstCollected.await().sequence,
+            )
+            val connectedDrop = awaitDiagnostic { (event, connectedFields) ->
+                event == "lease_state_edge_dropped" &&
+                    connectedFields["intendedState"] == SshLeaseConnectionState.Connected.name
+            }
+            assertNotNull(
+                "saturation must also make a dropped Connected up-edge immediately observable",
+                connectedDrop,
+            )
+            assertFalse(
+                "best-effort Connecting and Idle diagnostics are classified separately from critical edges",
+                synchronized(diagnostics) {
+                    diagnostics.any { (event, diagnosticFields) ->
+                        event == "lease_state_edge_dropped" &&
+                            diagnosticFields["intendedState"] in setOf(
+                                SshLeaseConnectionState.Connecting.name,
+                                SshLeaseConnectionState.Idle.name,
+                            )
+                    }
+                },
+            )
+
+            collectorGate.complete(Unit)
+            collector.cancelAndJoin()
+
+            // The final key's Connected attempt was beyond the saturated
+            // buffer. Once the old collector is gone, reusing that still-live
+            // transport must try Connected again. If failed tryEmit had falsely
+            // advanced lastPublishedState, this reuse would be deduped away.
+            val retriedPublication = CompletableDeferred<SshLeaseStateEvent>()
+            val retryCollector = backgroundScope.launch {
+                manager.stateEvents.collect { retriedPublication.complete(it) }
+            }
+            runCurrent()
+            val retryLease = manager.acquire(target(SATURATING_LEASE_COUNT - 1)).getOrThrow()
+            val retried = withTimeout(5_000L) { retriedPublication.await() }
+            assertEquals(SshLeaseConnectionState.Connected, retried.state)
+            assertTrue(retried.sequence > (fields["sequence"] as Long))
+            retryCollector.cancelAndJoin()
+
+            retryLease.release()
+            held.drop(1).forEach { it.release() }
+            manager.close()
+        }
+
+    @Test
+    fun `saturation and slow collector cancellation never block lease IO or teardown`() = runTest {
+        withTimeout(5_000L) {
+            val manager = leaseManager()
+            val collectorGate = CompletableDeferred<Unit>()
+            val collector = backgroundScope.launch {
+                manager.stateEvents.collect { collectorGate.await() }
+            }
+            runCurrent()
+
+            val held = mutableListOf<SshLease>()
+            repeat(SATURATING_LEASE_COUNT) { index ->
+                held += manager.acquire(target(index)).getOrThrow()
+            }
+
+            collector.cancelAndJoin()
+            manager.disconnect(held.first().key)
+            held.drop(1).forEach { it.release() }
+            manager.close()
+        }
+    }
+
+    @Test
+    fun `collector cancellation after tryEmit before publication decision is diagnosed as a dropped critical edge`() = runTest {
+        val manager = leaseManager()
+        val collectorGate = CompletableDeferred<Unit>()
+        val collector = backgroundScope.launch {
+            manager.stateEvents.collect { collectorGate.await() }
+        }
+        runCurrent()
+
+        val lease = manager.acquire(target(0)).getOrThrow()
+        runCurrent()
+        manager.stateEventAfterTryEmitHookForTest = {
+            manager.stateEventAfterTryEmitHookForTest = null
+            collector.cancel()
+            runCurrent()
+        }
+
+        manager.disconnect(lease.key)
+        val dropped = awaitDiagnostic { (event, fields) ->
+            event == "lease_state_edge_dropped" &&
+                fields["intendedState"] == SshLeaseConnectionState.Closed.name
+        }
+        assertEquals("no_subscribers", dropped.second["dropReason"])
+        assertEquals(SshLeaseConnectionState.Connected.name, dropped.second["previousState"])
+
+        lease.release()
+        manager.close()
+    }
+
+    @Test
+    fun `direct diagnostic record returns before a blocking installed sink is released`() = runTest {
+        val sinkEntered = CountDownLatch(1)
+        val sinkRelease = CountDownLatch(1)
+        val directReturned = CountDownLatch(1)
+        SshDiagnostics.install { _, _ ->
+            sinkEntered.countDown()
+            sinkRelease.await(5, TimeUnit.SECONDS)
+        }
+
+        val directThread = thread(isDaemon = true, name = "issue-2314-direct-record-test") {
+            try {
+                SshDiagnostics.record("issue-2314-direct-blocking-probe")
+            } finally {
+                directReturned.countDown()
+            }
+        }
+        try {
+            assertTrue(
+                "direct record must reach the installed sink",
+                withContext(Dispatchers.IO) { sinkEntered.await(5, TimeUnit.SECONDS) },
+            )
+            assertTrue(
+                "direct record must return while the sink remains blocked",
+                withContext(Dispatchers.IO) { directReturned.await(1, TimeUnit.SECONDS) },
+            )
+        } finally {
+            sinkRelease.countDown()
+            directThread.join(5_000)
+        }
+    }
+
+    @Test
+    fun `direct diagnostic record contains a throwing sink and the worker remains usable`() = runTest {
+        SshDiagnostics.install { _, _ -> throw IllegalStateException("issue-2314 direct sink") }
+        val directResult = runCatching {
+            SshDiagnostics.record("issue-2314-direct-throwing-probe")
+        }
+        assertTrue("direct record must contain an installed sink exception", directResult.isSuccess)
+
+        val delivered = CompletableDeferred<Unit>()
+        SshDiagnostics.install { event, _ ->
+            if (event == "issue-2314-after-throw-probe") delivered.complete(Unit)
+        }
+        SshDiagnostics.record("issue-2314-after-throw-probe")
+        withContext(Dispatchers.Default) {
+            withTimeout(5_000L) { delivered.await() }
+        }
+    }
+
+    @Test
+    fun `blocking diagnostic sink cannot hold lease mutex during teardown`() = runTest {
+        val sinkEntered = CountDownLatch(1)
+        val sinkRelease = CountDownLatch(1)
+        SshDiagnostics.install { _, _ ->
+            sinkEntered.countDown()
+            sinkRelease.await(5, TimeUnit.SECONDS)
+        }
+        val manager = leaseManager()
+        // Occupy the bounded diagnostics worker independently so the manager
+        // path is measured while an installed sink is genuinely blocked. This
+        // keeps the teardown proof load-bearing even under a mutation that
+        // suppresses the manager's particular edge emission.
+        SshDiagnostics.recordNonBlocking("issue-2314-blocking-sink-probe")
+        val acquireJob = launch(Dispatchers.Default) {
+            manager.acquire(target(0))
+        }
+        var closeThread: Thread? = null
+        try {
+            assertTrue(
+                "the test sink must actually be blocking before teardown is measured",
+                withContext(Dispatchers.IO) { sinkEntered.await(5, TimeUnit.SECONDS) },
+            )
+            val closeFinished = CompletableFuture<Unit>()
+            closeThread = thread(isDaemon = true, name = "issue-2314-close-test") {
+                runCatching { manager.close() }
+                    .onSuccess { closeFinished.complete(Unit) }
+                    .onFailure { closeFinished.completeExceptionally(it) }
+            }
+            assertEquals(
+                "manager teardown must not wait for an installed diagnostic sink",
+                Unit,
+                closeFinished.get(1, TimeUnit.SECONDS),
+            )
+            acquireJob.join()
+        } finally {
+            sinkRelease.countDown()
+            closeThread?.join(5_000)
+            acquireJob.cancelAndJoin()
+            manager.close()
+        }
+    }
+
+    @Test
+    fun `throwing diagnostic sink is contained without failing lease operations`() = runTest {
+        SshDiagnostics.install { _, _ -> throw IllegalStateException("issue-2314 test sink") }
+        val manager = leaseManager()
+
+        val result = withTimeout(1_000L) { manager.acquire(target(0)) }
+        assertTrue("a diagnostic sink exception must not fail the lease", result.isSuccess)
+        result.getOrThrow().release()
+        withTimeout(1_000L) { manager.close() }
+    }
+
+    @Test
+    fun `late collector does not make a no-subscriber Connected edge look published`() = runTest {
+        val manager = leaseManager()
+        val target = target(0)
+
+        // SharedFlow(replay=0) accepts and immediately discards this pair while
+        // no collector exists. Connected is critical, so that loss must be
+        // diagnosed and must not advance lastPublishedState.
+        val firstLease = manager.acquire(target).getOrThrow()
+        val dropped = awaitDiagnostic { (event, fields) ->
+            event == "lease_state_edge_dropped" &&
+                fields["key"] == target.leaseKey.hashCode().toLong() &&
+                fields["intendedState"] == SshLeaseConnectionState.Connected.name
+        }
+        assertEquals("no_subscribers", dropped.second["dropReason"])
+        assertEquals(null, dropped.second["previousState"])
+
+        val delivered = CompletableDeferred<SshLeaseStateEvent>()
+        val collector = backgroundScope.launch {
+            manager.stateEvents.collect { delivered.complete(it) }
+        }
+        runCurrent()
+
+        val reused = manager.acquire(target).getOrThrow()
+        val event = withTimeout(5_000L) { delivered.await() }
+        assertEquals(
+            "the first collector must still receive the live transport up-edge",
+            SshLeaseConnectionState.Connected,
+            event.state,
+        )
+        assertEquals(null, event.previousState)
+        assertTrue(event.sequence > (dropped.second["sequence"] as Long))
+
+        collector.cancelAndJoin()
+        firstLease.release()
+        reused.release()
+        manager.close()
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.leaseManager(): SshLeaseManager {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        return SshLeaseManager(
+            connector = SshLeaseConnector { Result.success(FakeSshSession()) },
+            scope = this,
+            idleTtlMillis = 60_000L,
+            connectTimeoutContext = dispatcher,
+            abortTimeoutContext = dispatcher,
+            nowMillis = { testScheduler.currentTime },
+        )
+    }
+
+    private suspend fun awaitDiagnostic(
+        predicate: (Pair<String, Map<String, Any?>>) -> Boolean,
+    ): Pair<String, Map<String, Any?>> = withContext(Dispatchers.Default) {
+        withTimeout(5_000L) { awaitDiagnosticUntil(predicate) }
+    }
+
+    private suspend fun awaitDiagnosticUntil(
+        predicate: (Pair<String, Map<String, Any?>>) -> Boolean,
+    ): Pair<String, Map<String, Any?>> {
+        while (true) {
+            val found = synchronized(diagnostics) { diagnostics.firstOrNull(predicate) }
+            if (found != null) return found
+            diagnosticSignal.receive()
+        }
+    }
+
+    private fun target(index: Int): SshLeaseTarget {
+        val keyPath = "/tmp/issue-2314-key-$index"
+        return SshLeaseTarget(
+            leaseKey = SshLeaseKey(
+                host = "issue-2314-$index.test",
+                port = 22,
+                user = "tester",
+                credentialId = keyPath,
+                knownHostsId = "issue-2314-known-hosts-$index",
+            ),
+            key = SshKey.Path(File(keyPath)),
+        )
+    }
+
+    private class FakeSshSession : SshSession {
+        private var closed = false
+
+        override val isConnected: Boolean
+            get() = !closed
+
+        override suspend fun exec(command: String): ExecResult =
+            ExecResult(stdout = "", stderr = "", exitCode = 0)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = object : SshShell {
+            override val stdin = ByteArrayOutputStream()
+            override val stdout = ByteArrayInputStream(ByteArray(0))
+            override val stderr = ByteArrayInputStream(ByteArray(0))
+            override fun close() = Unit
+        }
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private companion object {
+        // 40 leases emit Connecting + Connected = 80 attempted events while the
+        // first callback is blocked: deterministically beyond the fixed 64 slots.
+        const val SATURATING_LEASE_COUNT: Int = 40
+    }
+}


### PR DESCRIPTION
## Summary
- make critical SSH lease state-edge delivery loss-observable
- keep best-effort diagnostics bounded and non-blocking, including direct callers
- cover Idle saturation, post-tryEmit cancellation, and blocking/throwing sinks

## Verification
- Reviewer Gibbs: APPROVED on issue #2314
- `:shared:core-ssh:testDebugUnitTest --rerun-tasks`: 265 tests, 0 skipped/failures/errors

Held from merge while main is under D36 red-main freeze; this is unrelated to the current red run.
