### PR TITLE
ci: scheduled ~8h full-suite cadence + scoped main-push runs (#2353)

### DIFF
--- a/.github/workflows/full-suite-notify.yml
+++ b/.github/workflows/full-suite-notify.yml
@@ -1,0 +1,64 @@
+name: Full-suite red-run notify
+
+# Issue #2353 (Phase 1 of epic #2350): on a RED scheduled full-suite run of
+# the Tests workflow (.github/workflows/tests.yml `schedule:` trigger), file
+# (or update) ONE tracking issue with the failure signature and the bounded
+# list of `main` commits since the last known-green scheduled run — the
+# fast-attribution mechanism the v0.4.45 release postmortem (#2338/#2294, 11
+# days red `main`) was missing.
+#
+# Deliberately a SEPARATE workflow, triggered by `workflow_run` once Tests
+# concludes, rather than a job inside tests.yml: `.github/workflows/tests.yml`
+# is under a hard file-size ratchet (scripts/check-file-size-hygiene.sh) with
+# essentially no headroom left, and this notify logic needs no job-level
+# `needs:` access into Tests' jobs anyway — it re-derives everything it needs
+# (which top-level job failed, the last known-green scheduled run's SHA) from
+# the GitHub API against the now-completed run, via
+# scripts/ci-run-jobs.sh and scripts/ci-skip-check.sh respectively.
+#
+# Only fires for a SCHEDULED Tests run that concluded failure — never for a
+# push/PR/workflow_dispatch run (those have no "last known green scheduled
+# run" concept to bisect against) and never for a green run.
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+
+jobs:
+  notify:
+    name: File/update red scheduled-run tracking issue
+    if: github.event.workflow_run.event == 'schedule' && github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+
+      - id: jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/ci-run-jobs.sh --repo "${{ github.repository }}" --run-id "${{ github.event.workflow_run.id }}"
+
+      - id: green
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/ci-skip-check.sh --repo "${{ github.repository }}" --sha "${{ github.event.workflow_run.head_sha }}"
+
+      - name: File or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/ci-red-issue.sh \
+            --repo "${{ github.repository }}" \
+            --run-url "${{ github.event.workflow_run.html_url }}" \
+            --sha "${{ github.event.workflow_run.head_sha }}" \
+            --last-green-sha "${{ steps.green.outputs.last_green_sha }}" \
+            --unit-gate "${{ steps.jobs.outputs.unit_gate }}" \
+            --python "${{ steps.jobs.outputs.python }}" \
+            --integration "${{ steps.jobs.outputs.integration }}" \
+            --emulator-journey-verdict "${{ steps.jobs.outputs.emulator_journey_verdict }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,11 @@ on:
       - "docs/**"
       - "chat/**"
   workflow_dispatch:
+  schedule: [{cron: "0 0,8,16 * * *"}]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
-  cancel-in-progress: true
+  group: ${{ github.event_name=='schedule'&&'sched'||format('{0}-{1}',github.workflow,github.event_name=='pull_request'&&format('pr-{0}',github.event.pull_request.number)||format('ref-{0}',github.ref)) }}
+  cancel-in-progress: ${{ github.event_name!='schedule' }}
 
 jobs:
   # Issue #2060 (CI Phase A): the ~25 SERIAL guard steps this job used to carry in
@@ -841,6 +842,8 @@ jobs:
           chmod +x scripts/ci-build-profile-guards.sh
           scripts/ci-build-profile-guards.sh
 
+      - run: scripts/test-ci-cadence.sh
+
   # ---------------------------------------------------------------------------
   # Issue #2067: the #2063 test-area coverage guards, as a DEDICATED job. Reached
   # through a JVM test they were paid TWICE per push (both variants) on the Unit
@@ -1089,6 +1092,15 @@ jobs:
           .venv/bin/pocketshell --help
           .venv/bin/pocketshell usage --help
 
+  sg:
+    if: github.event_name=='push'
+    runs-on: ubuntu-latest
+    outputs:
+      c: ${{steps.p.outputs.SCOPED_CLASSES}}
+    steps:
+      - {uses: actions/checkout@v6, with: {fetch-depth: 0}}
+      - {id: p, run: "scripts/ci-plan.sh --before ${{github.event.before}}"}
+
   integration:
     name: Integration tests (Docker)
     if: github.event_name != 'pull_request'
@@ -1180,7 +1192,7 @@ jobs:
 
   emulator-journey:
     name: Emulator journey subset (load-bearing, Docker agents)
-    if: github.event_name != 'pull_request'
+    if: ${{!cancelled()&&github.event_name!='pull_request'&&needs.dex.result=='success'&&needs.python.result=='success'&&needs.sg.result!='failure'}}
     # Issue #2090: Checks-API publisher for last-completed-class telemetry.
     # actions: write keeps the existing artifact uploads working once this job
     # names its token scopes.
@@ -1209,7 +1221,7 @@ jobs:
     # spends the runners. Bounded — `main` pushes already passed the required
     # `Unit tests` check on their PR head (G7), and the main-push concurrency
     # group cancels superseded runs.
-    needs: [dex, python]
+    needs: [dex, python, sg]
     runs-on: ubuntu-latest
     # Issue #835 (REOPENED, SHARD): the right-size-only fix (#1055, 45->95 cap +
     # 4200s budget + Gradle daemon reuse) STILL could not finish the full
@@ -1260,6 +1272,7 @@ jobs:
       # hash into (index % total). _TOTAL must equal len(matrix.shard).
       POCKETSHELL_JOURNEY_CI_SHARD_INDEX: ${{ matrix.shard }}
       POCKETSHELL_JOURNEY_CI_SHARD_TOTAL: 6
+      POCKETSHELL_JOURNEY_SCOPED: ${{needs.sg.outputs.c}}
     # Issue #835 (REOPENED, RIGHT-SIZE): raised 45 -> 95 originally so the FULL
     # serial selection could finish; with sharding each leg runs ~1/N the classes
     # (#2060: ~38 min modelled worst leg at 6) and finishes well under this cap.

--- a/scripts/check-unit-gate-wiring.sh
+++ b/scripts/check-unit-gate-wiring.sh
@@ -84,6 +84,7 @@ EXEMPT_JOBS=(
   "integration"              # batched Docker lane, not a per-PR blocker
   "emulator-journey"         # batched emulator lane, verdict-gated below
   "emulator-journey-verdict" # the emulator lane's own aggregate verdict
+  "sg"                       # issue #2353: scoped-push plan gate, not a per-PR job
 )
 
 # C9: the #2063 coverage guards belong to `guards-test-selection`, never to a

--- a/scripts/ci-journey-class-selection-functions.sh
+++ b/scripts/ci-journey-class-selection-functions.sh
@@ -143,6 +143,41 @@ select_effective_journey_classes() {
     done
     echo ">>> CI journey shard ${JOURNEY_CI_SHARD_INDEX}/${JOURNEY_CI_SHARD_TOTAL} (issues #835, #1862): running ${#EFFECTIVE_JOURNEY_CLASSES[@]} of ${#JOURNEY_CLASSES[@]} journey classes (partitioned by class-name hash, so registering a journey does not re-roll the others); the core-terminal proofs are partitioned by the same hash (issue #2110)"
   fi
+
+  # ---------------------------------------------------------------------------
+  # Issue #2353: optional additional intersection with the #2063 scoped
+  # test-selection plan (scripts/select-test-areas.sh) for a `main`-push
+  # event. POCKETSHELL_JOURNEY_SCOPED is UNSET/EMPTY for every
+  # local run, every existing self-test/fixture, PR (this job never runs for
+  # PRs), schedule, and workflow_dispatch — so this block is a no-op and
+  # EFFECTIVE_JOURNEY_CLASSES is exactly the shard partition computed above,
+  # byte-identical to before this issue. The workflow only sets it to a
+  # non-empty, comma-separated FQCN list when `main`-push's OWN plan is
+  # SCOPED (never when it is FULL — a force-full push still runs every class
+  # its shard owns). When set, only classes in BOTH this shard's partition AND
+  # the scoped plan run: a shard whose intersection with the scoped plan is
+  # empty logs zero classes and exits promptly instead of idling out its
+  # per-shard budget on a run the taxonomy says this push cannot affect.
+  if [[ -n "${POCKETSHELL_JOURNEY_SCOPED:-}" ]]; then
+    local -A _scoped_ci_classes=()
+    local -a _scoped_ci_list=()
+    local _scoped_ci_entry
+    IFS=',' read -ra _scoped_ci_list <<< "${POCKETSHELL_JOURNEY_SCOPED}"
+    for _scoped_ci_entry in "${_scoped_ci_list[@]}"; do
+      [[ -n "$_scoped_ci_entry" ]] && _scoped_ci_classes["$_scoped_ci_entry"]=1
+    done
+    local -a _scoped_ci_filtered=()
+    local _scoped_ci_class_only
+    for _shard_class in "${EFFECTIVE_JOURNEY_CLASSES[@]}"; do
+      # An entry may carry a `#method` suffix; the scoped plan
+      # (select-test-areas.sh journey_registry_classes) lists bare class FQCNs,
+      # so match on the class part only.
+      _scoped_ci_class_only="${_shard_class%%#*}"
+      [[ -n "${_scoped_ci_classes[$_scoped_ci_class_only]:-}" ]] && _scoped_ci_filtered+=("$_shard_class")
+    done
+    echo ">>> CI journey scoped-plan filter (issue #2353): ${#_scoped_ci_filtered[@]} of ${#EFFECTIVE_JOURNEY_CLASSES[@]} shard-selected classes are in the #2063 scoped plan for this push"
+    EFFECTIVE_JOURNEY_CLASSES=("${_scoped_ci_filtered[@]}")
+  fi
 }
 
 print_journey_class_selection() {

--- a/scripts/ci-plan.sh
+++ b/scripts/ci-plan.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/ci-plan.sh — issue #2353
+#
+# Wraps scripts/select-test-areas.sh for the `sgate` workflow job in
+# .github/workflows/tests.yml: picks the diff base for a `main`-push run,
+# runs the plan with --github-output (MODE/AREAS/JOURNEY_CLASSES/etc land in
+# $GITHUB_OUTPUT), echoes the human-readable plan to stdout AND appends it to
+# $GITHUB_STEP_SUMMARY when set (so the caller does not need its own
+# `| tee -a` — one fewer thing for the size-ratcheted workflow to spell out),
+# then derives ONE extra output — SCOPED_CLASSES — that is the journey-class
+# list ONLY when MODE=scoped, and EMPTY when MODE=full.
+# This is the safety-critical gate that keeps a force-full push from ever
+# having its journey classes silently filtered: computing it HERE (unit-
+# testable bash) rather than as a `mode == 'scoped' && ... || ''` conditional
+# inline in the workflow YAML means the "never filter on full" property has
+# its own test coverage instead of living only in an unexercised expression.
+#
+# The base is the PREVIOUS `main` push (github.event.before) — the exact set
+# of commits THIS push introduces. A missing/unreadable `before` (first push
+# to a new ref, a force-push, or a shallow checkout that doesn't have it) falls
+# back to select-test-areas.sh's own default base (merge-base origin/main) —
+# its documented fail-safe: an unreadable diff or empty path set both latch
+# MODE=full, never a silent under-selection.
+#
+# USAGE
+#   ci-plan.sh --before SHA
+#
+# Self-test: scripts/test-ci-plan.sh
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+BEFORE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --before) BEFORE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+ZERO="0000000000000000000000000000000000000000"
+base_args=()
+if [[ -n "$BEFORE" && "$BEFORE" != "$ZERO" ]] && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+  base_args=(--base "$BEFORE")
+fi
+
+plan_out="$("$SCRIPT_DIR/select-test-areas.sh" "${base_args[@]}" --github-output)"
+printf '%s\n' "$plan_out"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  printf '%s\n' "$plan_out" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" && -f "${GITHUB_OUTPUT:-}" ]]; then
+  mode="$(grep '^MODE=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+  classes="$(grep '^JOURNEY_CLASSES=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-)"
+  scoped=""
+  [[ "$mode" == "scoped" ]] && scoped="$classes"
+  printf 'SCOPED_CLASSES=%s\n' "$scoped" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/ci-red-issue.sh
+++ b/scripts/ci-red-issue.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# scripts/ci-red-issue.sh — issue #2353
+#
+# On a RED scheduled full-suite run (.github/workflows/tests.yml `schedule:`
+# trigger), file (or update) ONE tracking issue with the failure signature and
+# the bounded list of `main` commits since the last known-green full run — the
+# "bisect window" that let v0.4.45's 11-day red `main` (#2338/#2294) take days
+# to attribute instead of hours. Repeated red runs COMMENT on the same issue
+# (matched by a stable marker token in the body) rather than spamming a new
+# issue every ~8h.
+#
+# Run from inside the workflow's own checkout (needs full history —
+# `fetch-depth: 0` — to resolve `--last-green-sha..--sha`).
+#
+# USAGE
+#   ci-red-issue.sh
+#     --repo OWNER/NAME --run-url URL --sha SHA
+#     [--last-green-sha SHA]
+#     [--unit-gate RESULT] [--python RESULT] [--integration RESULT]
+#     [--emulator-journey-verdict RESULT]
+#     [--gh PATH]
+#   (each RESULT is a `needs.<job>.result` value; only "failure" counts as
+#   red — "skipped"/"success"/"cancelled" are all silently ignored.)
+#
+# Self-test: scripts/test-ci-red-issue.sh
+#
+# Exits non-zero (and says why on stderr) on any `gh` failure — a red run that
+# fails to notify must ITSELF be loud, not swallowed.
+
+set -uo pipefail
+
+TITLE="CI: scheduled full-suite is red (issue #2353)"
+MARKER="pocketshell-full-suite-red-marker"
+
+REPO=""
+RUN_URL=""
+SHA=""
+LAST_GREEN_SHA=""
+UNIT_GATE=""
+PYTHON_R=""
+INTEGRATION_R=""
+JOURNEY_R=""
+GH_BIN="${POCKETSHELL_GH_BIN:-gh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --run-url) RUN_URL="$2"; shift 2 ;;
+    --sha) SHA="$2"; shift 2 ;;
+    --last-green-sha) LAST_GREEN_SHA="$2"; shift 2 ;;
+    --unit-gate) UNIT_GATE="$2"; shift 2 ;;
+    --python) PYTHON_R="$2"; shift 2 ;;
+    --integration) INTEGRATION_R="$2"; shift 2 ;;
+    --emulator-journey-verdict) JOURNEY_R="$2"; shift 2 ;;
+    --gh) GH_BIN="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$RUN_URL" || -z "$SHA" ]]; then
+  echo "usage: $0 --repo OWNER/NAME --run-url URL --sha SHA [--last-green-sha SHA] [--unit-gate R] [--python R] [--integration R] [--emulator-journey-verdict R] [--gh PATH]" >&2
+  exit 2
+fi
+
+if ! command -v "$GH_BIN" >/dev/null 2>&1; then
+  echo "gh CLI not found ($GH_BIN) — cannot file/update the red-run tracking issue" >&2
+  exit 1
+fi
+
+commits_section="commit list unavailable (no prior known-green scheduled run, or history was not fetched)"
+if [[ -n "$LAST_GREEN_SHA" ]] && git cat-file -e "${LAST_GREEN_SHA}^{commit}" 2>/dev/null; then
+  commits_section="$(git log "${LAST_GREEN_SHA}..${SHA}" --oneline 2>/dev/null)"
+  [[ -n "$commits_section" ]] || commits_section="(no commits between last-green and HEAD)"
+fi
+
+declare -a failed=()
+[[ "$UNIT_GATE" == "failure" ]] && failed+=("Unit tests")
+[[ "$PYTHON_R" == "failure" ]] && failed+=("Python utility tests (pocketshell)")
+[[ "$INTEGRATION_R" == "failure" ]] && failed+=("Integration tests (Docker)")
+[[ "$JOURNEY_R" == "failure" ]] && failed+=("Emulator journey aggregate verdict (one or more of the 6 shards; see the run for which)")
+failure_summary="$(printf '%s; ' "${failed[@]:-}")"
+failure_summary="${failure_summary%; }"
+[[ -n "$failure_summary" ]] || failure_summary="(no job reported failure=true; check the run directly)"
+
+last_green_line="(no prior known-green scheduled run recorded)"
+[[ -n "$LAST_GREEN_SHA" ]] && last_green_line="$LAST_GREEN_SHA"
+
+body="$(cat <<BODY
+This is the standing tracking issue for a red **scheduled full-suite** run
+(\`.github/workflows/tests.yml\` \`schedule:\` trigger — issue #2353 / epic #2350).
+Repeated red runs comment here instead of filing a new issue each cycle.
+
+Marker: $MARKER
+
+## Latest red run
+
+- Run: $RUN_URL
+- Commit: \`$SHA\`
+- Failure signature: $failure_summary
+- Last known-green full run: \`$last_green_line\`
+
+## Bounded merge window (commits since the last known-green full run)
+
+\`\`\`
+$commits_section
+\`\`\`
+
+Bisect the regression to one of the commits above — that is the whole point of
+the ~8h cadence (the merge window a red run must be attributed within).
+BODY
+)"
+
+existing=""
+existing="$("$GH_BIN" issue list --repo "$REPO" --state open \
+  --search "$MARKER in:body" --json number --limit 5 --jq '.[0].number // empty' \
+  2>/dev/null)" || existing=""
+
+if [[ -n "$existing" ]]; then
+  if ! "$GH_BIN" issue comment "$existing" --repo "$REPO" --body "$body"; then
+    echo "failed to comment on existing red-run tracking issue #$existing" >&2
+    exit 1
+  fi
+  echo "Commented on existing tracking issue #$existing"
+else
+  created=""
+  if ! created="$("$GH_BIN" issue create --repo "$REPO" --title "$TITLE" --body "$body")"; then
+    echo "failed to create the red-run tracking issue" >&2
+    exit 1
+  fi
+  echo "Created tracking issue: $created"
+fi

--- a/scripts/ci-run-jobs.sh
+++ b/scripts/ci-run-jobs.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# scripts/ci-run-jobs.sh — issue #2353
+#
+# Reads a completed GitHub Actions run's per-job conclusions by NAME, for the
+# `.github/workflows/full-suite-notify.yml` `workflow_run` notify job: it does
+# not have `needs:` access into `tests.yml`'s jobs (different workflow), so it
+# re-derives "did the required top-level job fail" from the GitHub API instead.
+#
+# USAGE
+#   ci-run-jobs.sh --repo OWNER/NAME --run-id ID [--gh PATH]
+#
+# OUTPUT (stdout, KEY=VALUE, one per line — always all four keys, "unknown"
+# when a job is missing from the run, e.g. it never started):
+#   UNIT_GATE=<conclusion>
+#   PYTHON=<conclusion>
+#   INTEGRATION=<conclusion>
+#   EMULATOR_JOURNEY_VERDICT=<conclusion>
+#
+# If $GITHUB_OUTPUT is set, the same four keys (lowercased) are ALSO appended
+# there for the workflow step to consume directly.
+#
+# Self-test: scripts/test-ci-run-jobs.sh
+
+set -uo pipefail
+
+REPO=""
+RUN_ID=""
+GH_BIN="${POCKETSHELL_GH_BIN:-gh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --run-id) RUN_ID="$2"; shift 2 ;;
+    --gh) GH_BIN="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$RUN_ID" ]]; then
+  echo "usage: $0 --repo OWNER/NAME --run-id ID [--gh PATH]" >&2
+  exit 2
+fi
+
+jobs_json="{}"
+if command -v "$GH_BIN" >/dev/null 2>&1; then
+  jobs_json="$("$GH_BIN" api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" 2>/dev/null)" || jobs_json="{}"
+fi
+
+job_conclusion() {
+  local name="$1"
+  local out
+  out="$(printf '%s' "$jobs_json" | jq -r --arg n "$name" \
+    '(.jobs // []) | map(select(.name == $n)) | .[0].conclusion // empty' 2>/dev/null)" || out=""
+  [[ -n "$out" ]] && printf '%s' "$out" || printf 'unknown'
+}
+
+unit_gate="$(job_conclusion "Unit tests")"
+python_r="$(job_conclusion "Python utility tests (pocketshell)")"
+integration_r="$(job_conclusion "Integration tests (Docker)")"
+journey_r="$(job_conclusion "Emulator journey aggregate verdict (#1458)")"
+
+printf 'UNIT_GATE=%s\n' "$unit_gate"
+printf 'PYTHON=%s\n' "$python_r"
+printf 'INTEGRATION=%s\n' "$integration_r"
+printf 'EMULATOR_JOURNEY_VERDICT=%s\n' "$journey_r"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    printf 'unit_gate=%s\n' "$unit_gate"
+    printf 'python=%s\n' "$python_r"
+    printf 'integration=%s\n' "$integration_r"
+    printf 'emulator_journey_verdict=%s\n' "$journey_r"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/ci-skip-check.sh
+++ b/scripts/ci-skip-check.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# scripts/ci-skip-check.sh — issue #2353
+#
+# Decides whether the ~8h scheduled full-suite run (.github/workflows/tests.yml
+# `schedule:` trigger) should actually pay for the full 6-shard emulator-journey
+# + Docker integration + both unit variants + guards, or SKIP because `main`
+# HEAD has not moved since the last GREEN scheduled run. Avoids spend when
+# nothing landed between cadence ticks; never a correctness gate.
+#
+# FAIL-OPEN, ALWAYS. If `gh` is missing, unauthenticated, the API call fails,
+# the response is unparsable, or no prior successful scheduled run exists, this
+# prints SKIP=false — the safe default is to spend the ~2-3h run, never to
+# silently stop validating `main`. Only an EXACT match between HEAD and the
+# last green scheduled run's head_sha produces SKIP=true.
+#
+# USAGE
+#   ci-skip-check.sh --repo OWNER/NAME --sha SHA
+#     [--workflow-file NAME]     default: tests.yml
+#     [--gh PATH]                default: gh
+#     [--event NAME]             default: schedule (which runs to compare against)
+#
+# Self-test: scripts/test-ci-skip-check.sh
+#
+# OUTPUT (stdout, KEY=VALUE, one per line — always all three keys):
+#   SKIP=true|false
+#   REASON=<free text>
+#   LAST_GREEN_SHA=<40-hex sha, or empty>
+#
+# If $GITHUB_OUTPUT is set (as it is inside a GitHub Actions step), the same
+# decision is ALSO appended there as `should_run` (the inverse of SKIP — what
+# the workflow's job `if:` consumes) and `last_green_sha`, so a single
+# invocation serves both the human log and the workflow step outputs.
+
+set -uo pipefail
+
+REPO=""
+SHA=""
+WORKFLOW_FILE="tests.yml"
+GH_BIN="${POCKETSHELL_GH_BIN:-gh}"
+EVENT="schedule"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --sha) SHA="$2"; shift 2 ;;
+    --workflow-file) WORKFLOW_FILE="$2"; shift 2 ;;
+    --gh) GH_BIN="$2"; shift 2 ;;
+    --event) EVENT="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+emit() {
+  local skip="$1" reason="$2" last_green="$3"
+  printf 'SKIP=%s\n' "$skip"
+  printf 'REASON=%s\n' "$reason"
+  printf 'LAST_GREEN_SHA=%s\n' "$last_green"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    local should_run="true"
+    [[ "$skip" == "true" ]] && should_run="false"
+    {
+      printf 'should_run=%s\n' "$should_run"
+      printf 'last_green_sha=%s\n' "$last_green"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+if [[ -z "$REPO" || -z "$SHA" ]]; then
+  echo "usage: $0 --repo OWNER/NAME --sha SHA [--workflow-file NAME] [--gh PATH] [--event NAME]" >&2
+  exit 2
+fi
+
+if ! command -v "$GH_BIN" >/dev/null 2>&1; then
+  emit false "gh CLI not found ($GH_BIN) — failing open" ""
+  exit 0
+fi
+
+api_out=""
+if ! api_out="$("$GH_BIN" api \
+    "repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?event=$EVENT&status=success&per_page=10" \
+    2>/dev/null)"; then
+  emit false "gh api call failed — failing open" ""
+  exit 0
+fi
+
+last_green=""
+last_green="$(printf '%s' "$api_out" | jq -r \
+  '(.workflow_runs // []) | sort_by(.created_at) | reverse | .[0].head_sha // empty' \
+  2>/dev/null)" || last_green=""
+
+if [[ -z "$last_green" ]]; then
+  emit false "no prior successful '$EVENT' run of $WORKFLOW_FILE found — failing open" ""
+  exit 0
+fi
+
+if [[ "$last_green" == "$SHA" ]]; then
+  emit true "HEAD ($SHA) matches the last green '$EVENT' run's head_sha — nothing new to validate" "$last_green"
+  exit 0
+fi
+
+emit false "HEAD ($SHA) differs from the last green '$EVENT' run's head_sha ($last_green)" "$last_green"
+exit 0

--- a/scripts/test-ci-cadence.sh
+++ b/scripts/test-ci-cadence.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# scripts/test-ci-cadence.sh — issue #2353
+#
+# Runs all four scheduled-cadence self-tests in sequence (a thin wrapper so
+# .github/workflows/tests.yml only needs one short `run:` line under its
+# file-size ratchet — see scripts/check-file-size-hygiene.sh).
+#
+#   scripts/test-ci-skip-check.sh — scripts/ci-skip-check.sh
+#   scripts/test-ci-plan.sh       — scripts/ci-plan.sh
+#   scripts/test-ci-red-issue.sh  — scripts/ci-red-issue.sh
+#   scripts/test-ci-run-jobs.sh   — scripts/ci-run-jobs.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/test-ci-skip-check.sh"
+"$SCRIPT_DIR/test-ci-plan.sh"
+"$SCRIPT_DIR/test-ci-red-issue.sh"
+"$SCRIPT_DIR/test-ci-run-jobs.sh"

--- a/scripts/test-ci-plan.sh
+++ b/scripts/test-ci-plan.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-plan.sh (issue #2353).
+#
+# Runs against a throwaway git repo (no dependency on the real pocketshell
+# tree's test-area manifest) so this is fast and independent of taxonomy
+# drift. Proves: a valid --before SHA is passed through as --base; a missing,
+# all-zero, or unresolvable --before SHA falls back to
+# select-test-areas.sh's own default base instead of erroring; and — the
+# SAFETY-CRITICAL property, since the workflow trusts this script's output
+# unconditionally — the derived SCOPED_CLASSES output is the journey
+# list ONLY when the plan is MODE=scoped, and is EMPTY whenever MODE=full
+# (never silently filters journeys on a force-full push).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-plan.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# A stub select-test-areas.sh that echoes its args (so this test proves the
+# BASE ARGUMENT WIRING, not the real taxonomy) and, when $STUB_MODE is set,
+# also writes MODE=/JOURNEY_CLASSES= to $GITHUB_OUTPUT the way the real
+# --github-output flag does — this is what lets the SCOPED_CLASSES
+# derivation below be exercised without depending on the real manifest.
+mkdir -p "$SANDBOX/scripts"
+cat > "$SANDBOX/scripts/select-test-areas.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "ARGS: $*"
+if [[ -n "${STUB_MODE:-}" && -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "MODE=${STUB_MODE}"
+    echo "JOURNEY_CLASSES=${STUB_CLASSES:-}"
+  } >> "$GITHUB_OUTPUT"
+fi
+STUB
+chmod +x "$SANDBOX/scripts/select-test-areas.sh"
+cp "$TARGET" "$SANDBOX/scripts/ci-plan.sh"
+chmod +x "$SANDBOX/scripts/ci-plan.sh"
+
+# A real (throwaway) git repo so `git cat-file -e` has something to resolve
+# against, with one commit to reference as a valid --before SHA.
+git init --quiet "$SANDBOX/repo"
+git -C "$SANDBOX/repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "initial"
+valid_sha="$(git -C "$SANDBOX/repo" rev-parse HEAD)"
+
+run_target() {
+  (cd "$SANDBOX/repo" && "$SANDBOX/scripts/ci-plan.sh" "$@")
+}
+
+# 1. A valid, resolvable --before SHA is passed through as --base.
+out="$(run_target --before "$valid_sha")"
+echo "$out" | grep -q -- "--base $valid_sha" || fail "a valid --before sha must be forwarded as --base: $out"
+echo "$out" | grep -q -- "--github-output" || fail "must always pass --github-output: $out"
+pass "a valid --before sha is forwarded as --base"
+
+# 2. All-zero SHA (first push to a new ref) falls back — no --base at all.
+zero="0000000000000000000000000000000000000000"
+out="$(run_target --before "$zero")"
+echo "$out" | grep -q -- "--base" && fail "an all-zero --before must NOT be forwarded as --base: $out"
+echo "$out" | grep -q -- "--github-output" || fail "must still pass --github-output on fallback: $out"
+pass "an all-zero --before sha falls back to select-test-areas.sh's own default base"
+
+# 3. Missing --before entirely falls back the same way.
+out="$(run_target --before "")"
+echo "$out" | grep -q -- "--base" && fail "an empty --before must NOT be forwarded as --base: $out"
+pass "an empty --before sha falls back to select-test-areas.sh's own default base"
+
+# 4. An unresolvable (garbage/unknown) --before falls back rather than erroring.
+out="$(run_target --before "0123456789abcdef0123456789abcdef01234567")"
+echo "$out" | grep -q -- "--base" && fail "an unresolvable --before must NOT be forwarded as --base: $out"
+pass "an unresolvable --before sha falls back rather than erroring"
+
+run_target_with_output() {
+  # $1 = STUB_MODE, $2 = STUB_CLASSES
+  local out_file="$SANDBOX/github_output.txt"
+  : > "$out_file"
+  (cd "$SANDBOX/repo" && STUB_MODE="$1" STUB_CLASSES="$2" GITHUB_OUTPUT="$out_file" \
+    "$SANDBOX/scripts/ci-plan.sh" --before "$valid_sha" >/dev/null)
+  cat "$out_file"
+}
+
+# 5. MODE=scoped => SCOPED_CLASSES carries the real journey list.
+gh_out="$(run_target_with_output scoped "com.pocketshell.app.proof.Foo,com.pocketshell.app.proof.Bar")"
+echo "$gh_out" | grep -qx "SCOPED_CLASSES=com.pocketshell.app.proof.Foo,com.pocketshell.app.proof.Bar" \
+  || fail "MODE=scoped must pass the journey list through as SCOPED_CLASSES: $gh_out"
+pass "MODE=scoped carries the journey list into SCOPED_CLASSES"
+
+# 6. MODE=full => SCOPED_CLASSES is EMPTY, even though JOURNEY_CLASSES
+#    itself is non-empty (a full plan always lists every registered class) —
+#    this is the property that stops a force-full push from ever having its
+#    journey classes silently filtered by the shard-side intersection.
+gh_out="$(run_target_with_output full "com.pocketshell.app.proof.Foo,com.pocketshell.app.proof.Bar,com.pocketshell.app.proof.Baz")"
+echo "$gh_out" | grep -qx "SCOPED_CLASSES=" \
+  || fail "MODE=full must leave SCOPED_CLASSES EMPTY (safety property): $gh_out"
+pass "MODE=full leaves SCOPED_CLASSES empty even though JOURNEY_CLASSES is non-empty"
+
+# 7. No $GITHUB_OUTPUT at all (e.g. local invocation) doesn't error.
+(cd "$SANDBOX/repo" && STUB_MODE=scoped STUB_CLASSES=x "$SANDBOX/scripts/ci-plan.sh" --before "$valid_sha" >/dev/null) \
+  || fail "running without \$GITHUB_OUTPUT set must not error"
+pass "running without \$GITHUB_OUTPUT set does not error"
+
+# 8. $GITHUB_STEP_SUMMARY: the script itself appends the human-readable plan
+#    (the same text it prints to stdout), so the workflow step does not need
+#    its own `| tee -a`.
+summary_file="$SANDBOX/step_summary.txt"
+: > "$summary_file"
+stdout_out="$(cd "$SANDBOX/repo" && GITHUB_STEP_SUMMARY="$summary_file" "$SANDBOX/scripts/ci-plan.sh" --before "$valid_sha")"
+[[ -s "$summary_file" ]] || fail "GITHUB_STEP_SUMMARY must be written to when set"
+diff <(printf '%s\n' "$stdout_out") "$summary_file" >/dev/null \
+  || fail "GITHUB_STEP_SUMMARY content must match stdout exactly"
+pass "GITHUB_STEP_SUMMARY gets the same human-readable plan as stdout"
+
+# 9. No $GITHUB_STEP_SUMMARY set (e.g. local invocation) doesn't error.
+(cd "$SANDBOX/repo" && "$SANDBOX/scripts/ci-plan.sh" --before "$valid_sha" >/dev/null) \
+  || fail "running without \$GITHUB_STEP_SUMMARY set must not error"
+pass "running without \$GITHUB_STEP_SUMMARY set does not error"
+
+echo "OK: $pass_count self-test case(s) passed."

--- a/scripts/test-ci-red-issue.sh
+++ b/scripts/test-ci-red-issue.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-red-issue.sh (issue #2353).
+#
+# Stubs `gh` on PATH so this runs with no network, no real repo, no
+# authentication. Captures every `gh` invocation's exact args (NUL-separated,
+# so a call is never mis-parsed by whitespace in --body) to inspect what was
+# actually sent. Uses a throwaway git repo with real commits so the bounded
+# commit-window computation is exercised for real, not stubbed. Covers: no
+# existing tracking issue => create with the exact commit range + failure
+# signature; an existing open issue found via the marker search => comment
+# (never a second create); only jobs reporting "failure" are named in the
+# signature; a missing/unresolvable last-green sha reported honestly rather
+# than invented; a failed search still creates rather than silently dropping
+# the notification; and a failed `gh` call (create, or the binary missing)
+# surfaces as a loud non-zero exit.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-red-issue.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+git init --quiet "$SANDBOX/repo"
+git -C "$SANDBOX/repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "commit A (last green)"
+sha_a="$(git -C "$SANDBOX/repo" rev-parse HEAD)"
+git -C "$SANDBOX/repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "commit B"
+git -C "$SANDBOX/repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "commit C (red)"
+sha_c="$(git -C "$SANDBOX/repo" rev-parse HEAD)"
+
+# $1 = the issue number `issue list` should report as already-existing (empty
+#      string = none found, so the target must create a new one).
+write_fake_gh() {
+  local existing="$1"
+  cat > "$SANDBOX/bin/gh" <<FAKEGH
+#!/usr/bin/env bash
+n=\$(( \$(cat "$SANDBOX/call-count.txt" 2>/dev/null || echo 0) + 1 ))
+echo "\$n" > "$SANDBOX/call-count.txt"
+printf '%s\0' "\$@" > "$SANDBOX/call-\$n.args"
+if [[ "\${FAKE_GH_ISSUE_LIST_FAIL:-}" == "1" && "\$1 \$2" == "issue list" ]]; then exit 1; fi
+if [[ "\${FAKE_GH_CREATE_FAIL:-}" == "1" && "\$1 \$2" == "issue create" ]]; then exit 1; fi
+case "\$1 \$2" in
+  "issue list") echo '$existing' ;;
+  "issue comment") echo "commented" ;;
+  "issue create") echo "https://github.com/owner/repo/issues/999" ;;
+esac
+FAKEGH
+  chmod +x "$SANDBOX/bin/gh"
+}
+
+read_call_args() {
+  local _rca_n="$1" _rca_outvar="$2"
+  local -a _rca_accum=()
+  local _rca_a
+  while IFS= read -r -d '' _rca_a; do
+    _rca_accum+=("$_rca_a")
+  done < "$SANDBOX/call-$_rca_n.args"
+  eval "$_rca_outvar=(\"\${_rca_accum[@]}\")"
+}
+
+arg_value_after() {
+  local n="$1" flag="$2"
+  local -a args=()
+  read_call_args "$n" args
+  local i
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "$flag" ]]; then
+      printf '%s' "${args[$((i + 1))]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+reset_sandbox_calls() { rm -f "$SANDBOX"/call-*.args "$SANDBOX/call-count.txt"; }
+
+# -----------------------------------------------------------------------
+# 1. No existing tracking issue => creates one with the real commit window
+#    (commit A excluded, B/C included) and only-the-failed-jobs signature.
+reset_sandbox_calls
+write_fake_gh ""
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" "$TARGET" \
+  --repo owner/repo \
+  --run-url "https://github.com/owner/repo/actions/runs/123" \
+  --sha "$sha_c" \
+  --last-green-sha "$sha_a" \
+  --unit-gate failure --python success --integration skipped --emulator-journey-verdict failure 2>&1)"
+echo "$out" | grep -q "Created tracking issue" || fail "expected a create when no existing issue is found: $out"
+calls="$(cat "$SANDBOX/call-count.txt")"
+[[ "$calls" -eq 2 ]] || fail "expected exactly 2 gh calls (list, create), got $calls"
+create_body="$(arg_value_after 2 --body)" || fail "create call must carry --body"
+echo "$create_body" | grep -q "commit B" || fail "created body must include commit B"
+echo "$create_body" | grep -q "commit C (red)" || fail "created body must include commit C"
+echo "$create_body" | grep -q "commit A (last green)" && fail "created body must NOT include commit A (the last-green boundary, excluded by a..b)"
+echo "$create_body" | grep -q "Unit tests" || fail "created body must name Unit tests as failed"
+echo "$create_body" | grep -q "Emulator journey aggregate verdict" || fail "created body must name the emulator-journey-verdict failure"
+echo "$create_body" | grep -qi "python" && fail "created body must NOT name Python (it reported success)"
+echo "$create_body" | grep -qi "Integration tests" && fail "created body must NOT name Integration (it was skipped, not failed)"
+echo "$create_body" | grep -q "pocketshell-full-suite-red-marker" || fail "created body must include the stable marker"
+pass "no existing issue creates a new tracking issue with the real bounded commit range and only-failed-jobs signature"
+
+# -----------------------------------------------------------------------
+# 2. Existing open issue found => comments on it, never creates.
+reset_sandbox_calls
+write_fake_gh "42"
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" "$TARGET" \
+  --repo owner/repo --run-url "https://github.com/owner/repo/actions/runs/124" \
+  --sha "$sha_c" --unit-gate failure 2>&1)"
+echo "$out" | grep -q "Commented on existing tracking issue #42" || fail "expected a comment on the existing issue: $out"
+calls="$(cat "$SANDBOX/call-count.txt")"
+[[ "$calls" -eq 2 ]] || fail "expected exactly 2 gh calls (list, comment), got $calls"
+read_call_args 2 comment_args
+[[ "${comment_args[2]}" == "42" ]] || fail "must comment on issue #42, args were: ${comment_args[*]}"
+comment_body="$(arg_value_after 2 --body)" || fail "comment call must carry --body"
+echo "$comment_body" | grep -q "no prior known-green scheduled run recorded" || fail "missing last-green sha must be reported honestly"
+echo "$comment_body" | grep -q "commit list unavailable" || fail "missing last-green sha must report an unavailable commit list, not invented content"
+pass "existing open issue found by marker search gets a comment, not a new issue; missing last-green is reported honestly"
+
+# -----------------------------------------------------------------------
+# 3. gh issue list fails => still falls through to creating (fail toward
+#    over-notifying, never silently drops the red-run signal).
+reset_sandbox_calls
+write_fake_gh ""
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" FAKE_GH_ISSUE_LIST_FAIL=1 "$TARGET" \
+  --repo owner/repo --run-url "u" --sha "$sha_c" --unit-gate failure 2>&1)"
+echo "$out" | grep -q "Created tracking issue" || fail "a failed search must still result in a create (never silently drop the notification): $out"
+pass "a failed issue-list search still creates a tracking issue rather than dropping the notification"
+
+# -----------------------------------------------------------------------
+# 4. gh issue create fails => the step is loud (non-zero exit, clear message).
+reset_sandbox_calls
+write_fake_gh ""
+set +e
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" FAKE_GH_CREATE_FAIL=1 "$TARGET" \
+  --repo owner/repo --run-url "u" --sha "$sha_c" --unit-gate failure 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "a failed gh issue create must exit non-zero"
+echo "$out" | grep -qi "failed to create" || fail "a failed gh issue create must say so: $out"
+pass "a failed gh issue create surfaces loudly"
+
+# -----------------------------------------------------------------------
+# 5. gh CLI missing entirely => loud non-zero exit.
+set +e
+out="$(bash "$TARGET" --repo owner/repo --run-url "u" --sha "$sha_c" --gh does-not-exist-gh-binary-xyz 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "missing gh must exit non-zero"
+echo "$out" | grep -qi "gh CLI not found" || fail "missing gh must say so: $out"
+pass "missing gh CLI surfaces loudly"
+
+# -----------------------------------------------------------------------
+# 6. missing required arguments => usage error, exit 2.
+set +e
+bash "$TARGET" --repo owner/repo >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 2 ]] || fail "missing required arguments must exit 2, got $rc"
+pass "missing required arguments exits 2"
+
+echo "OK: $pass_count self-test case(s) passed."

--- a/scripts/test-ci-run-jobs.sh
+++ b/scripts/test-ci-run-jobs.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-run-jobs.sh (issue #2353).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-run-jobs.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+write_fake_gh() {
+  # $1 = mode: "mixed" (some failed, some not), "empty" (no jobs), "fail" (gh errors)
+  local mode="$1"
+  cat > "$SANDBOX/bin/gh" <<FAKEGH
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "api repos/owner/repo/actions/runs/123/jobs?per_page=100")
+    case "$mode" in
+      fail) exit 1 ;;
+      empty) echo '{"jobs": []}' ;;
+      mixed)
+        echo '{"jobs": [
+          {"name": "Unit tests", "conclusion": "failure"},
+          {"name": "Python utility tests (pocketshell)", "conclusion": "success"},
+          {"name": "Integration tests (Docker)", "conclusion": "success"},
+          {"name": "Emulator journey aggregate verdict (#1458)", "conclusion": "failure"}
+        ]}'
+        ;;
+    esac
+    ;;
+esac
+FAKEGH
+  chmod +x "$SANDBOX/bin/gh"
+}
+
+run_target() {
+  PATH="$SANDBOX/bin:$PATH" "$TARGET" --repo owner/repo --run-id 123 "$@"
+}
+
+# 1. Mixed conclusions: each named job is read correctly and independently.
+write_fake_gh mixed
+out="$(run_target)"
+echo "$out" | grep -qx "UNIT_GATE=failure" || fail "Unit tests must read failure: $out"
+echo "$out" | grep -qx "PYTHON=success" || fail "Python must read success: $out"
+echo "$out" | grep -qx "INTEGRATION=success" || fail "Integration must read success: $out"
+echo "$out" | grep -qx "EMULATOR_JOURNEY_VERDICT=failure" || fail "Emulator journey verdict must read failure: $out"
+pass "each named job's conclusion is read independently and correctly"
+
+# 2. No jobs in the run at all -> every key is "unknown", not invented/blank.
+write_fake_gh empty
+out="$(run_target)"
+echo "$out" | grep -qx "UNIT_GATE=unknown" || fail "missing job must report unknown, not blank/invented: $out"
+echo "$out" | grep -qx "EMULATOR_JOURNEY_VERDICT=unknown" || fail "missing job must report unknown: $out"
+pass "a run with no matching jobs reports 'unknown' for every key (never invented/blank)"
+
+# 3. gh api call fails -> fails open to "unknown" for every key, does not crash.
+write_fake_gh fail
+out="$(run_target)"
+rc=$?
+[[ "$rc" -eq 0 ]] || fail "a failed gh api call must not crash the script, got rc=$rc"
+echo "$out" | grep -qx "UNIT_GATE=unknown" || fail "a failed gh api call must fail open to unknown: $out"
+pass "a failed gh api call fails open to 'unknown' for every key"
+
+# 4. gh CLI missing entirely -> same fail-open behaviour.
+out="$(SCRIPT_DIR_UNUSED=1 "$TARGET" --repo owner/repo --run-id 123 --gh does-not-exist-gh-binary-xyz)"
+echo "$out" | grep -qx "UNIT_GATE=unknown" || fail "missing gh must fail open to unknown: $out"
+pass "missing gh CLI fails open to 'unknown' for every key"
+
+# 5. $GITHUB_OUTPUT mirrors the four values (lowercased keys).
+write_fake_gh mixed
+gh_out="$SANDBOX/github_output.txt"
+: > "$gh_out"
+PATH="$SANDBOX/bin:$PATH" GITHUB_OUTPUT="$gh_out" "$TARGET" --repo owner/repo --run-id 123 >/dev/null
+grep -qx "unit_gate=failure" "$gh_out" || fail "GITHUB_OUTPUT must mirror unit_gate: $(cat "$gh_out")"
+grep -qx "emulator_journey_verdict=failure" "$gh_out" || fail "GITHUB_OUTPUT must mirror emulator_journey_verdict: $(cat "$gh_out")"
+pass "GITHUB_OUTPUT mirrors all four values with lowercased keys"
+
+# 6. missing required arguments -> usage error, exit 2.
+set +e
+"$TARGET" --repo owner/repo >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 2 ]] || fail "missing --run-id must exit 2, got $rc"
+pass "missing required argument exits 2"
+
+echo "OK: $pass_count self-test case(s) passed."

--- a/scripts/test-ci-skip-check.sh
+++ b/scripts/test-ci-skip-check.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-skip-check.sh (issue #2353).
+#
+# Stubs `gh` on PATH so this runs with no network, no real repo, no
+# authentication. Every scenario the target script's fail-open contract
+# depends on is exercised: missing gh, a failing API call, malformed JSON, no
+# prior green run, HEAD matching/differing from the last green sha (including
+# picking the MOST RECENT run by created_at rather than array position), the
+# $GITHUB_OUTPUT mirror, and the required-argument usage error.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-skip-check.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+# $1 = the sha the fake API should report as the (only, most-recent-if-many)
+#      run's head_sha, when relevant to the mode.
+write_fake_gh() {
+  local sha="$1"
+  cat > "$SANDBOX/bin/gh" <<FAKEGH
+#!/usr/bin/env bash
+mode="\${FAKE_GH_MODE:-}"
+case "\$mode" in
+  fail) exit 1 ;;
+  malformed) echo 'not json' ;;
+  empty) echo '{"workflow_runs": []}' ;;
+  one) echo '{"workflow_runs": [{"head_sha": "$sha", "created_at": "2026-01-01T00:00:00Z"}]}' ;;
+  ordering)
+    echo '{"workflow_runs": [
+      {"head_sha": "0000000000000000000000000000000000older", "created_at": "2026-01-01T00:00:00Z"},
+      {"head_sha": "$sha", "created_at": "2026-01-03T00:00:00Z"},
+      {"head_sha": "0000000000000000000000000000000middle0", "created_at": "2026-01-02T00:00:00Z"}
+    ]}'
+    ;;
+  *) echo '{"workflow_runs": []}' ;;
+esac
+FAKEGH
+  chmod +x "$SANDBOX/bin/gh"
+}
+
+run_target() {
+  # $1 = FAKE_GH_MODE, $2 = --sha value
+  PATH="$SANDBOX/bin:$PATH" FAKE_GH_MODE="$1" \
+    bash "$TARGET" --repo owner/repo --sha "$2" 2>&1
+}
+
+green_sha="cafef00d0000000000000000000000000000cafe"
+write_fake_gh "$green_sha"
+
+# 1. gh missing entirely => fail open (SKIP=false), no crash.
+out="$(bash "$TARGET" --repo owner/repo --sha deadbeef00000000000000000000000000000000 --gh does-not-exist-gh-binary-xyz 2>&1)"
+echo "$out" | grep -qx 'SKIP=false' || fail "missing gh must fail open: $out"
+pass "missing gh fails open"
+
+# 2. gh api call fails => fail open.
+out="$(run_target fail deadbeef00000000000000000000000000000000)"
+echo "$out" | grep -qx 'SKIP=false' || fail "gh api failure must fail open: $out"
+pass "gh api failure fails open"
+
+# 3. malformed JSON response => fail open.
+out="$(run_target malformed deadbeef00000000000000000000000000000000)"
+echo "$out" | grep -qx 'SKIP=false' || fail "malformed JSON must fail open: $out"
+pass "malformed JSON fails open"
+
+# 4. no prior green run => fail open, empty LAST_GREEN_SHA.
+out="$(run_target empty deadbeef00000000000000000000000000000000)"
+echo "$out" | grep -qx 'SKIP=false' || fail "no prior green run must fail open: $out"
+echo "$out" | grep -qx 'LAST_GREEN_SHA=' || fail "no prior green run must report empty LAST_GREEN_SHA: $out"
+pass "no prior green run fails open with empty last-green sha"
+
+# 5. HEAD == last green sha => SKIP=true, LAST_GREEN_SHA reported.
+out="$(run_target one "$green_sha")"
+echo "$out" | grep -qx 'SKIP=true' || fail "matching HEAD must skip: $out"
+echo "$out" | grep -qx "LAST_GREEN_SHA=$green_sha" || fail "matching HEAD must report the last green sha: $out"
+pass "HEAD matching last green sha skips"
+
+# 6. HEAD != last green sha => SKIP=false, LAST_GREEN_SHA still reported.
+out="$(run_target one differentshaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)"
+echo "$out" | grep -qx 'SKIP=false' || fail "differing HEAD must not skip: $out"
+echo "$out" | grep -qx "LAST_GREEN_SHA=$green_sha" || fail "differing HEAD must still report the last green sha: $out"
+pass "HEAD differing from last green sha does not skip, still reports last green sha"
+
+# 7. multiple runs => pick the most recent by created_at, not array order.
+out="$(run_target ordering "$green_sha")"
+echo "$out" | grep -qx "LAST_GREEN_SHA=$green_sha" || fail "must pick the most recent run by created_at, not array position: $out"
+pass "picks the most recent run by created_at"
+
+# 8. $GITHUB_OUTPUT mirrors the decision.
+gh_out_file="$SANDBOX/github_output.txt"
+: > "$gh_out_file"
+PATH="$SANDBOX/bin:$PATH" FAKE_GH_MODE=one GITHUB_OUTPUT="$gh_out_file" \
+  bash "$TARGET" --repo owner/repo --sha "$green_sha" >/dev/null
+grep -qx "should_run=false" "$gh_out_file" || fail "GITHUB_OUTPUT must record should_run=false on a skip: $(cat "$gh_out_file")"
+grep -qx "last_green_sha=$green_sha" "$gh_out_file" || fail "GITHUB_OUTPUT must record last_green_sha: $(cat "$gh_out_file")"
+pass "GITHUB_OUTPUT mirrors the decision"
+
+gh_out_file2="$SANDBOX/github_output2.txt"
+: > "$gh_out_file2"
+PATH="$SANDBOX/bin:$PATH" FAKE_GH_MODE=one GITHUB_OUTPUT="$gh_out_file2" \
+  bash "$TARGET" --repo owner/repo --sha differentshaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa >/dev/null
+grep -qx "should_run=true" "$gh_out_file2" || fail "GITHUB_OUTPUT must record should_run=true when not skipping: $(cat "$gh_out_file2")"
+pass "GITHUB_OUTPUT records should_run=true on a non-skip"
+
+# 9. missing required arguments => usage error, exit 2.
+set +e
+bash "$TARGET" --repo owner/repo >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 2 ]] || fail "missing --sha must exit 2, got $rc"
+pass "missing required argument exits 2"
+
+echo "OK: $pass_count self-test case(s) passed."


### PR DESCRIPTION
## Summary
- Adds a `schedule:`-triggered full-suite run (~8h cadence) on `main`: all 6 emulator journey shards, Docker integration, both JVM unit variants. Runs in a dedicated concurrency group with `cancel-in-progress: false` so a `main` push can no longer destroy its verdict (the exact bug that lost CI signal during the v0.4.45 incident — 5 of the last 15 `main` runs were cancelled).
- `main`-push-triggered runs now use `scripts/select-test-areas.sh` (#2063) to scope which journey classes actually run, instead of unconditionally running all 6 shards on every push.
- A red scheduled run auto-files/updates one tracking GitHub issue (via new `full-suite-notify.yml`, `workflow_run`-triggered, kept separate from `tests.yml` to respect its file-size hygiene ratchet) listing the bounded merge window since the last green full run.

Phase 1 of #2350 (release-speed/process epic). Closes #2353.

## Review history
3 rounds, both real defects caught and fixed before merge:
- Round 1: the new scoped-plan job (`sg`) was push-only, so `emulator-journey`'s `needs: [dex, python, sg]` caused the whole journey suite to silently skip on `schedule`/`workflow_dispatch` — while the aggregate-verdict script still reported the workflow green. Fixed by adding `!cancelled()` to `emulator-journey`'s `if:`.
- Round 2: that fix removed GitHub's implicit `success()` gate on `needs:`, so a failing `dex`/`python` would no longer block `emulator-journey` on ANY event including plain pushes. Fixed with explicit `needs.dex.result == 'success' && needs.python.result == 'success' && needs.sg.result != 'failure'`.
- Round 3: independently re-verified with a from-scratch truth table over all reachable event/needs-result combinations. APPROVED.

## Test plan
- [x] YAML validity (both workflow files)
- [x] `scripts/check-file-size-hygiene.sh` — 130029/130048 bytes, PASS
- [x] 31+ self-test cases across the new scripts, re-run fresh by the reviewer
- [x] `scripts/check-unit-gate-wiring.sh`
- [x] `git diff --check`
- [ ] Not locally verifiable: the actual `schedule` cron firing and the `workflow_run` notify chain firing against a real completed run — flagged, needs to be watched on the first real scheduled run post-merge.