### PR TITLE
ssh: close port-forward copy-thread snapshot race (#2358)

### DIFF
--- a/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
+++ b/shared/core-ssh/src/main/java/com/pocketshell/core/ssh/RealSshPortForward.kt
@@ -60,8 +60,9 @@ internal class RealSshPortForward(
     /**
      * Serialises pair ownership and copy-thread registration with close().
      * Once [running] is false, no new copy thread may be registered. This
-     * makes the snapshots used by close() complete: a thread cannot appear
-     * after close has taken its join set.
+     * lets close() take complete pair and copy-thread snapshots before it
+     * starts teardown: a thread cannot appear after close has taken its join
+     * set.
      */
     private val lifecycleLock = Any()
 
@@ -258,18 +259,20 @@ internal class RealSshPortForward(
      * diagnostic; it never silently detaches a live thread from [copyThreads].
      */
     override fun close() {
-        // Seal the lifecycle transition and pair snapshot together. A copy
+        // Seal the lifecycle transition and both snapshots together. A copy
         // callback that reaches closePairAndUntrack concurrently must either
         // claim the pair before this block or observe that close() owns it;
-        // it cannot mutate activePairs between the snapshot and clear.
-        val pairs = synchronized(lifecycleLock) {
+        // it cannot mutate activePairs or copyThreads between the snapshots
+        // and teardown.
+        val (pairs, threadsToJoin) = synchronized(lifecycleLock) {
             // `running` is written under the same lock that serialises every
             // activePairs mutation and snapshot. This also makes the
             // post-close startCopyThread check a single lifecycle decision.
             if (!running.compareAndSet(true, false)) return
-            val snapshot = ArrayList(activePairs)
+            val pairSnapshot = ArrayList(activePairs)
             activePairs.clear()
-            snapshot
+            val threadSnapshot = ArrayList(copyThreads)
+            pairSnapshot to threadSnapshot
         }
         runCatching { serverSocket.close() }
         // Close every accepted-connection pair we still own. Copy
@@ -291,7 +294,6 @@ internal class RealSshPortForward(
         // calling close() — unusual but cheap to guard).
         val self = Thread.currentThread()
         val deadlineNanos = System.nanoTime() + CLOSE_JOIN_TIMEOUT_MS * NANOS_PER_MILLI
-        val threadsToJoin = synchronized(lifecycleLock) { ArrayList(copyThreads) }
         for (t in threadsToJoin) {
             if (t === self) continue
             val remainingMillis = (deadlineNanos - System.nanoTime()) / NANOS_PER_MILLI

--- a/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
+++ b/shared/core-ssh/src/test/java/com/pocketshell/core/ssh/RealSshPortForwardCountersTest.kt
@@ -249,6 +249,88 @@ class RealSshPortForwardCountersTest {
     }
 
     @Test
+    fun `close joins an r2l copier that exits while its pair is closing`() {
+        val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
+            .use { it.localPort }
+        val copyBodyReleased = CountDownLatch(1)
+        val uncaughtHandlerEntered = CountDownLatch(1)
+        val uncaughtHandlerRelease = CountDownLatch(1)
+        val copiedPair = Socket() to TestDirectConnection()
+        val forward = RealSshPortForward(
+            channels = object : PortForwardChannelTransport {
+                override fun openChannel(remoteHost: String, remotePort: Int): DirectConnection =
+                    error("test does not accept local connections")
+
+                override fun closeChannel(channel: DirectConnection) {
+                    // This is the exact teardown ordering from the reported
+                    // race: pair close lets the copier finish before close()
+                    // takes its old, late copyThreads snapshot.
+                    copyBodyReleased.countDown()
+                    check(uncaughtHandlerEntered.await(2, TimeUnit.SECONDS)) {
+                        "r2l copier did not reach its post-body teardown window"
+                    }
+                }
+            },
+            remoteHost = "remote.example",
+            remotePort = 5432,
+            localPort = localPort,
+            activePairs = setOf(copiedPair).toMutableSet(),
+        )
+        val startCopyThread = RealSshPortForward::class.java.getDeclaredMethod(
+            "startCopyThread",
+            String::class.java,
+            Function0::class.java,
+        ).apply { isAccessible = true }
+        val copyThreadsField = RealSshPortForward::class.java.getDeclaredField("copyThreads")
+            .apply { isAccessible = true }
+        var copyThread: Thread? = null
+
+        try {
+            startCopyThread.invoke(
+                forward,
+                "ssh-portfwd-r2l-$localPort",
+                {
+                    Thread.currentThread().uncaughtExceptionHandler =
+                        Thread.UncaughtExceptionHandler { _, _ ->
+                            uncaughtHandlerEntered.countDown()
+                            try {
+                                uncaughtHandlerRelease.await()
+                            } catch (_: InterruptedException) {
+                                // close() interrupts a handle it captured;
+                                // the test handler then permits termination.
+                            }
+                        }
+                    copyBodyReleased.await()
+                    error("synthetic copier failure after pair close")
+                } as Function0<Unit>,
+            )
+            assertTrue(
+                "the r2l copier must be running before close starts",
+                drainMainLooperUntil(sleepMs = 10L) {
+                    @Suppress("UNCHECKED_CAST")
+                    val registered = copyThreadsField.get(forward) as Set<Thread>
+                    copyThread = registered.singleOrNull { it.name == "ssh-portfwd-r2l-$localPort" }
+                    copyThread?.isAlive == true
+                },
+            )
+
+            forward.close()
+
+            assertTrue(
+                "close must return only after the live r2l copy thread terminates",
+                copyThread != null && !copyThread!!.isAlive,
+            )
+        } finally {
+            copyBodyReleased.countDown()
+            uncaughtHandlerRelease.countDown()
+            copyThread?.interrupt()
+            copyThread?.join(2_000L)
+            copiedPair.first.close()
+            forward.close()
+        }
+    }
+
+    @Test
     fun `close reports a copy callback that stays alive after interrupt`() {
         val localPort = ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))
             .use { it.localPort }


### PR DESCRIPTION
## Summary
- snapshot both active port-forward pairs and registered copy-thread handles under the lifecycle lock before teardown
- preserve idempotent close and bounded aggregate join behavior
- add a regression test for the close-vs-copy-thread race

## Verification
- focused regression: red on baseline, green with fix
- mutation removing the pre-teardown snapshot: red
- core-ssh + core-portfwd release unit tests: 312 passed, 0 failures/errors
- canonical full JVM gate: passed
- Docker integration fixture: 6/6 passed from cached harness; default image build was blocked before test bodies by transient Alpine DNS

Reviewed and approved in issue #2358: https://github.com/alexeygrigorev/pocketshell/issues/2358#issuecomment-5445783057
