### PR TITLE
ci: propagate release selector checker failures (#2300)

### DIFF
--- a/scripts/capture-terminal-lab.sh
+++ b/scripts/capture-terminal-lab.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -16,6 +17,9 @@ COMPOSE_FILE="${COMPOSE_FILE:-tests/docker/docker-compose.yml}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/terminal-lab}"
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 BUILD_APKS="${BUILD_APKS:-1}"
 SHELL_SCREENCAP="${SHELL_SCREENCAP:-0}"
 DEVICE_OUTPUT_DIR="/sdcard/Android/media/com.pocketshell.app/additional_test_output"
@@ -64,6 +68,9 @@ run_logged() {
 }
 
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" "$TEST_CLASS"
+printf '%s\n' "$TEST_CLASS" > "$SELECTOR_REQUIRED_FILE"
 
 collect_diagnostics() {
   local exit_code=$?
@@ -129,6 +136,26 @@ assert_artifacts_exist() {
   fi
 }
 
+# Keep the release-selector proof as one executable production path. The
+# self-test sources this function with a fixture root and a fake checker, so a
+# checker hidden behind dead code cannot satisfy the release gate's proof.
+verify_terminal_lab_selector_attendance() {
+  pocketshell_instrumentation_assert_log \
+    "$RUN_DIR/11-run-terminal-lab-instrumentation.log" "$TEST_CLASS" >/dev/null ||
+    fail "$TEST_CLASS did not report positive executed selector evidence"
+  pocketshell_record_release_selector_attendance \
+    "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$TEST_CLASS" \
+    "$RUN_DIR/11-run-terminal-lab-instrumentation.log" >/dev/null ||
+    fail "$TEST_CLASS selector attendance could not be recorded"
+  pocketshell_run_release_selector_checker \
+    "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+    --verify-attendance \
+    --selected-file "$SELECTOR_REQUIRED_FILE" \
+    --attendance "$SELECTOR_ATTENDANCE_FILE" \
+    --run-id "$RUN_ID" \
+    --newer-than "$SELECTOR_RUN_START_MARKER"
+}
+
 printf 'PocketShell terminal lab validation\n'
 printf 'Artifacts: %s\n' "$RUN_DIR"
 printf 'ADB: %s\n' "$ADB"
@@ -192,10 +219,7 @@ if [[ -d "$RUN_DIR/artifacts/terminal-lab" ]]; then
   run_logged "13-terminal-lab-artifact-file-info" file "$RUN_DIR"/artifacts/terminal-lab/* || true
 fi
 [[ "$instrumentation_status" -eq 0 ]] || fail "$TEST_CLASS instrumentation command exited with $instrumentation_status"
-grep -q "INSTRUMENTATION_CODE: -1" "$RUN_DIR/11-run-terminal-lab-instrumentation.log" &&
-  grep -q "OK (" "$RUN_DIR/11-run-terminal-lab-instrumentation.log" &&
-  ! grep -q "FAILURES!!!" "$RUN_DIR/11-run-terminal-lab-instrumentation.log" ||
-  fail "$TEST_CLASS did not report instrumentation success"
+verify_terminal_lab_selector_attendance
 assert_artifacts_exist
 
 printf '\nPASS: terminal lab validation completed\n'

--- a/scripts/capture-walkthrough-screenshots.sh
+++ b/scripts/capture-walkthrough-screenshots.sh
@@ -8,6 +8,7 @@ source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
 source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 # Issue #2064: see scripts/phone-walkthrough.sh — same contract, same
 # device-free verification mode, same reason it must not queue on the AVD lock.
@@ -37,6 +38,9 @@ COMPOSE_FILE="${COMPOSE_FILE:-tests/docker/docker-compose.yml}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/walkthrough-visual-pass}"
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 DEVICE_OUTPUT_DIR="/sdcard/Android/media/com.pocketshell.app/additional_test_output"
 DEVICE_SCREENSHOT_DIR="$DEVICE_OUTPUT_DIR/walkthrough-visual-pass"
 MAIN_TEST_CLASS="com.pocketshell.app.proof.WalkthroughVisualScreenshotTest"
@@ -158,6 +162,10 @@ run_logged() {
 }
 
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" \
+  "$MAIN_TEST_CLASS" "$CONVERSATION_TEST_CLASS" "$COMPOSER_TEST_CLASS"
+printf '%s\n' "$MAIN_TEST_CLASS" "$CONVERSATION_TEST_CLASS" "$COMPOSER_TEST_CLASS" > "$SELECTOR_REQUIRED_FILE"
 
 collect_diagnostics() {
   local exit_code=$?
@@ -246,8 +254,7 @@ wait_for_instrumentation() {
 
 visual_audit_instrumentation_log_has_success() {
   local log_file="$1"
-  grep -q "INSTRUMENTATION_CODE: -1" "$log_file" &&
-    grep -q "OK (" "$log_file" &&
+  pocketshell_instrumentation_has_positive_success "$log_file" &&
     ! grep -q "FAILURES!!!" "$log_file"
 }
 
@@ -303,6 +310,13 @@ run_instrumentation_class() {
     attempt_logcat="$RUN_DIR/$attempt_step-logcat.txt"
     "$ADB" logcat -d -v threadtime -t 4000 > "$attempt_logcat" 2>&1 || true
     if visual_audit_instrumentation_log_has_success "$RUN_DIR/$attempt_step.log"; then
+      if [[ -n "${SELECTOR_ATTENDANCE_FILE:-}" ]]; then
+        pocketshell_instrumentation_assert_log "$RUN_DIR/$attempt_step.log" "$test_class" >/dev/null ||
+          fail "$test_class did not produce positive executed selector evidence"
+        pocketshell_record_release_selector_attendance \
+          "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$test_class" "$RUN_DIR/$attempt_step.log" >/dev/null ||
+          fail "$test_class selector attendance could not be recorded"
+      fi
       return 0
     fi
     if [[ "$attempt" -eq "$INSTRUMENTATION_ATTEMPTS" ]]; then
@@ -426,6 +440,14 @@ assert_screenshots_exist "conversation visual pass" "${MAIN_SCREENSHOTS[@]}" "${
 run_instrumentation_class "16-run-composer-visual-instrumentation" "$COMPOSER_TEST_CLASS"
 pull_device_screenshots "17-collect-composer-device-screenshots"
 assert_screenshots_exist "composer visual pass" "${MAIN_SCREENSHOTS[@]}" "${CONVERSATION_SCREENSHOTS[@]}" "${COMPOSER_SCREENSHOTS[@]}"
+
+pocketshell_run_release_selector_checker \
+  "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$SELECTOR_REQUIRED_FILE" \
+  --attendance "$SELECTOR_ATTENDANCE_FILE" \
+  --run-id "$RUN_ID" \
+  --newer-than "$SELECTOR_RUN_START_MARKER"
 
 printf '\nPASS: walkthrough visual screenshots captured\n'
 printf 'Screenshots: %s/screenshots/walkthrough-visual-pass\n' "$RUN_DIR"

--- a/scripts/check-release-selector-execution.sh
+++ b/scripts/check-release-selector-execution.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
+
+MODE=""
+LOG_FILE=""
+SELECTOR=""
+SELECTED_FILE=""
+ATTENDANCE_FILE=""
+RUN_ID=""
+NEWER_THAN=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/check-release-selector-execution.sh --verify-log \
+    --selector CLASS[#METHOD] --log FILE
+  scripts/check-release-selector-execution.sh --verify-attendance \
+    --selected-file FILE --attendance FILE --run-id ID --newer-than MARKER
+
+--verify-log proves one raw Android instrumentation log has a positive
+executed-test count, runner success, and the exact selected status block.
+--verify-attendance proves every selected selector has that same raw proof in
+the current run, with a digest and a raw-log mtime newer than MARKER.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verify-log) MODE="log"; shift ;;
+    --verify-attendance) MODE="attendance"; shift ;;
+    --selector) SELECTOR="$2"; shift 2 ;;
+    --log) LOG_FILE="$2"; shift 2 ;;
+    --selected-file) SELECTED_FILE="$2"; shift 2 ;;
+    --attendance) ATTENDANCE_FILE="$2"; shift 2 ;;
+    --run-id) RUN_ID="$2"; shift 2 ;;
+    --newer-than) NEWER_THAN="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$MODE" == "log" ]]; then
+  [[ -n "$LOG_FILE" && -n "$SELECTOR" ]] || {
+    printf '%s\n' '--verify-log requires --selector and --log' >&2
+    exit 1
+  }
+  count="$(pocketshell_instrumentation_assert_log "$LOG_FILE" "$SELECTOR")"
+  printf 'PASS: selector=%s executed_count=%s raw_log=%s\n' "$SELECTOR" "$count" "$LOG_FILE"
+  exit 0
+fi
+
+[[ "$MODE" == "attendance" ]] || {
+  printf '%s\n' 'one of --verify-log or --verify-attendance is required' >&2
+  usage >&2
+  exit 1
+}
+[[ -n "$SELECTED_FILE" && -n "$ATTENDANCE_FILE" && -n "$RUN_ID" && -n "$NEWER_THAN" ]] || {
+  printf '%s\n' '--verify-attendance requires --selected-file, --attendance, --run-id, and --newer-than' >&2
+  exit 1
+}
+[[ "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]] || {
+  printf 'invalid release selector attendance run id: %s\n' "$RUN_ID" >&2
+  exit 1
+}
+[[ -f "$SELECTED_FILE" ]] || {
+  printf 'selected selector file is missing: %s\n' "$SELECTED_FILE" >&2
+  exit 1
+}
+[[ -s "$SELECTED_FILE" ]] || {
+  printf 'selected selector file is empty: %s\n' "$SELECTED_FILE" >&2
+  exit 1
+}
+[[ -f "$ATTENDANCE_FILE" ]] || {
+  printf 'current-run selector attendance ledger is missing: %s\n' "$ATTENDANCE_FILE" >&2
+  exit 1
+}
+[[ -f "$NEWER_THAN" ]] || {
+  printf 'current-run selector marker is missing: %s\n' "$NEWER_THAN" >&2
+  exit 1
+}
+grep -Fqx '# pocketshell-release-selector-attendance v1' "$ATTENDANCE_FILE" || {
+  printf 'selector attendance ledger has an unknown format: %s\n' "$ATTENDANCE_FILE" >&2
+  exit 1
+}
+grep -Fqx $'run_id\t'"$RUN_ID" "$ATTENDANCE_FILE" || {
+  printf 'selector attendance ledger is stale or belongs to another run: expected run_id=%s\n' "$RUN_ID" >&2
+  exit 1
+}
+
+declare -A selected=()
+selected_count=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  pocketshell_instrumentation_selector_parts "$line" || exit 1
+  if [[ -n "${selected[$line]:-}" ]]; then
+    continue
+  fi
+  selected["$line"]=1
+  selected_count=$((selected_count + 1))
+done < "$SELECTED_FILE"
+[[ "$selected_count" -gt 0 ]] || {
+  printf 'selected selector file contains no selectors: %s\n' "$SELECTED_FILE" >&2
+  exit 1
+}
+
+declare -A attended=()
+row_count=0
+while IFS=$'\t' read -r kind row_selector count raw_log digest extra || [[ -n "$kind" ]]; do
+  [[ -z "$kind" || "$kind" == \#* || "$kind" == run_id* ]] && continue
+  [[ "$kind" == "selector" && -z "${extra:-}" ]] || {
+    printf 'malformed selector attendance row in %s\n' "$ATTENDANCE_FILE" >&2
+    exit 1
+  }
+  pocketshell_instrumentation_selector_parts "$row_selector" || exit 1
+  [[ -n "${selected[$row_selector]:-}" ]] || {
+    printf 'attendance contains an unselected selector: %s\n' "$row_selector" >&2
+    exit 1
+  }
+  [[ "$count" =~ ^[1-9][0-9]*$ ]] || {
+    printf 'attendance has a non-positive executed count for %s\n' "$row_selector" >&2
+    exit 1
+  }
+  [[ -f "$raw_log" ]] || {
+    printf 'raw instrumentation evidence is missing for %s: %s\n' "$row_selector" "$raw_log" >&2
+    exit 1
+  }
+  [[ "$raw_log" -nt "$NEWER_THAN" ]] || {
+    printf 'raw instrumentation evidence is stale for %s: %s\n' "$row_selector" "$raw_log" >&2
+    exit 1
+  }
+  actual_digest="$(sha256sum "$raw_log" | awk '{print $1}')"
+  [[ "$actual_digest" == "$digest" ]] || {
+    printf 'raw instrumentation evidence digest changed for %s: %s\n' "$row_selector" "$raw_log" >&2
+    exit 1
+  }
+  actual_count="$(pocketshell_instrumentation_assert_log "$raw_log" "$row_selector")" || exit 1
+  [[ "$actual_count" == "$count" ]] || {
+    printf 'attendance count disagrees with raw instrumentation evidence for %s\n' "$row_selector" >&2
+    exit 1
+  }
+  attended["$row_selector"]=1
+  row_count=$((row_count + 1))
+done < "$ATTENDANCE_FILE"
+
+missing=()
+for selector in "${!selected[@]}"; do
+  [[ -n "${attended[$selector]:-}" ]] || missing+=("$selector")
+done
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  printf 'current run is missing selector attendance for %s selector(s):\n' "${#missing[@]}" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+printf 'PASS: current-run selector attendance selected=%s attended=%s run_id=%s\n' \
+  "$selected_count" "$row_count" "$RUN_ID"
+printf 'Raw instrumentation evidence is retained and digest-verified in %s\n' "$ATTENDANCE_FILE"

--- a/scripts/ci-test-selection-guards.sh
+++ b/scripts/ci-test-selection-guards.sh
@@ -55,6 +55,8 @@ chmod +x scripts/select-test-areas.sh \
          scripts/check-test-execution-ledger-wiring.py \
          scripts/ci-record-test-execution-ledger.sh \
          scripts/ci-nightly-execution-ledger.sh \
+         scripts/check-release-selector-execution.sh \
+         tests/scripts/release-selector-execution-proof-test.sh \
          scripts/dev-fast-gate-parity-selftest.sh \
          scripts/check-journey-quarantine-expiry.sh \
          scripts/test-journey-quarantine-non-blocking.sh
@@ -92,6 +94,12 @@ run_guard "select-test-areas-selftest" \
 # Execution-ledger guard reds, synthetic AND real-tree.
 run_guard "check-test-execution-ledger-selftest" \
   bash scripts/check-test-execution-ledger-selftest.sh
+
+# Issue #2300: release selectors must have positive executed-test evidence and
+# current-run raw-log attendance; source declarations and rolling ledgers alone
+# are not sufficient.
+run_guard "release-selector-execution-proof" \
+  tests/scripts/release-selector-execution-proof-test.sh
 
 # Issue #2082: workflows actually invoke --record/--verify/attendance against
 # real JUnit artifacts. A ledger nobody calls is decoration; the self-test

--- a/scripts/issue78-phone-walkthrough.sh
+++ b/scripts/issue78-phone-walkthrough.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -18,6 +19,9 @@ SSH_USER="${SSH_USER:-testuser}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/issue78-phone-walkthrough}"
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 TEST_SELECTOR="com.pocketshell.app.proof.EmulatorDockerSshSmokeTest#walkthroughJourneyOpensAppSessionAndRunsShellAndTmuxCommands"
 DEVICE_OUTPUT_DIR="/sdcard/Android/media/com.pocketshell.app/additional_test_output"
 DEVICE_ISSUE78_DIR="$DEVICE_OUTPUT_DIR/issue78-phone-walkthrough"
@@ -54,6 +58,9 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 fi
 
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" "$TEST_SELECTOR"
+printf '%s\n' "$TEST_SELECTOR" > "$SELECTOR_REQUIRED_FILE"
 
 fail() {
   printf '\nFAIL: %s\nArtifacts: %s\n' "$1" "$RUN_DIR" >&2
@@ -200,10 +207,19 @@ run_issue78_test() {
   "$ADB" logcat -d -v threadtime > "$RUN_DIR/10-full-logcat.log" 2>&1 || true
   rg -n 'ISSUE78_|PocketShellWalkthrough|AndroidRuntime|FATAL|Process: com[.]pocketshell[.]app' \
     "$RUN_DIR/10-full-logcat.log" "$instrumentation_log" > "$RUN_DIR/11-issue78-filtered-log.txt" 2>&1 || true
-  grep -q 'INSTRUMENTATION_CODE: -1' "$instrumentation_log" &&
-    grep -q 'OK (' "$instrumentation_log" &&
-    ! grep -q 'FAILURES!!!' "$instrumentation_log" ||
-    fail "issue #78 instrumentation did not report success"
+  pocketshell_instrumentation_assert_log \
+    "$instrumentation_log" "$TEST_SELECTOR" >/dev/null ||
+    fail "issue #78 instrumentation did not report positive executed selector evidence"
+  pocketshell_record_release_selector_attendance \
+    "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$TEST_SELECTOR" "$instrumentation_log" >/dev/null ||
+    fail "issue #78 selector attendance could not be recorded"
+  pocketshell_run_release_selector_checker \
+    "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+    --verify-attendance \
+    --selected-file "$SELECTOR_REQUIRED_FILE" \
+    --attendance "$SELECTOR_ATTENDANCE_FILE" \
+    --run-id "$RUN_ID" \
+    --newer-than "$SELECTOR_RUN_START_MARKER"
 }
 
 pull_artifacts() {

--- a/scripts/keyboard-stress.sh
+++ b/scripts/keyboard-stress.sh
@@ -26,6 +26,7 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -36,6 +37,9 @@ COMPOSE_FILE="${COMPOSE_FILE:-tests/docker/docker-compose.yml}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/keyboard-stress}"
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 ARTIFACT_DIR="$RUN_DIR/artifacts/keyboard-stress"
 BUILD_APKS="${BUILD_APKS:-1}"
 TEST_SELECTOR="${TEST_SELECTOR:-com.pocketshell.app.terminal.TerminalKeyboardStressTest#typingAndKeyboardToggleStayResponsiveUnderLiveOutput}"
@@ -129,6 +133,9 @@ collect_diagnostics() {
 }
 
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" "$TEST_SELECTOR"
+printf '%s\n' "$TEST_SELECTOR" > "$SELECTOR_REQUIRED_FILE"
 trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 printf 'PocketShell keyboard stress harness (issue #104)\n'
@@ -179,9 +186,20 @@ rm -rf "$RUN_DIR/artifacts"
 mkdir -p "$RUN_DIR/artifacts"
 run_logged "08-pull-artifacts" "$ADB" pull "$DEVICE_ARTIFACT_DIR" "$RUN_DIR/artifacts/"
 
-grep -q "OK (" "$RUN_DIR/07-run-keyboard-stress.log" &&
-  grep -q "INSTRUMENTATION_CODE: -1" "$RUN_DIR/07-run-keyboard-stress.log" ||
-  fail "keyboard stress instrumentation did not pass"
+pocketshell_instrumentation_assert_log \
+  "$RUN_DIR/07-run-keyboard-stress.log" "$TEST_SELECTOR" >/dev/null ||
+  fail "keyboard stress instrumentation did not produce positive executed selector evidence"
+pocketshell_record_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$TEST_SELECTOR" \
+  "$RUN_DIR/07-run-keyboard-stress.log" >/dev/null ||
+  fail "keyboard stress selector attendance could not be recorded"
+pocketshell_run_release_selector_checker \
+  "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$SELECTOR_REQUIRED_FILE" \
+  --attendance "$SELECTOR_ATTENDANCE_FILE" \
+  --run-id "$RUN_ID" \
+  --newer-than "$SELECTOR_RUN_START_MARKER"
 
 [[ -s "$ARTIFACT_DIR/keyboard-stress-summary.txt" ]] ||
   fail "keyboard-stress-summary.txt was not produced under $ARTIFACT_DIR"

--- a/scripts/lib/instrumentation-evidence.sh
+++ b/scripts/lib/instrumentation-evidence.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+
+# Shared release-gate instrumentation evidence helpers (issue #2300).
+#
+# The Android runner's exit status and INSTRUMENTATION_CODE describe the
+# runner, not whether the selected test body executed. Keep the three facts
+# separate: a positive OK count proves execution, status blocks prove the
+# requested selector attended this run, and the raw log remains the audit
+# source for both.
+
+pocketshell_instrumentation_selector_parts() {
+  local selector="$1"
+  local selector_class="${selector%%#*}"
+  local selector_method=""
+  if [[ "$selector" == *"#"* ]]; then
+    selector_method="${selector#*#}"
+  fi
+  if [[ -z "$selector_class" || "$selector_class" == *[!A-Za-z0-9_.]* ]]; then
+    printf 'invalid instrumentation selector: %s\n' "$selector" >&2
+    return 1
+  fi
+  if [[ "$selector" == *"#"* ]]; then
+    if [[ -z "$selector_method" || "$selector_method" == *[!A-Za-z0-9_]* ]]; then
+      printf 'invalid instrumentation selector: %s\n' "$selector" >&2
+      return 1
+    fi
+  fi
+  [[ "$selector" != *"#"*"#"* ]] || {
+    printf 'invalid instrumentation selector: %s\n' "$selector" >&2
+    return 1
+  }
+  POCKETSHELL_INSTRUMENTATION_SELECTOR_CLASS="$selector_class"
+  POCKETSHELL_INSTRUMENTATION_SELECTOR_METHOD="$selector_method"
+}
+
+pocketshell_instrumentation_ok_count() {
+  local log_file="$1"
+  [[ -f "$log_file" ]] || return 1
+  local count
+  count="$(sed -nE 's/^OK \(([1-9][0-9]*) tests?[[:space:]]*\)$/\1/p' "$log_file" | tail -n 1)"
+  [[ "$count" =~ ^[1-9][0-9]*$ ]] || return 1
+  printf '%s\n' "$count"
+}
+
+pocketshell_instrumentation_has_runner_success_code() {
+  local log_file="$1"
+  [[ -f "$log_file" ]] || return 1
+  awk '
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line == "INSTRUMENTATION_CODE: -1") { found = 1 }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$log_file"
+}
+
+pocketshell_instrumentation_has_positive_success() {
+  local log_file="$1"
+  pocketshell_instrumentation_has_runner_success_code "$log_file" &&
+    pocketshell_instrumentation_ok_count "$log_file" >/dev/null
+}
+
+pocketshell_instrumentation_selector_attended() {
+  local log_file="$1"
+  local selector="$2"
+  [[ -f "$log_file" ]] || return 1
+  pocketshell_instrumentation_selector_parts "$selector" || return 1
+  local expected_class="$POCKETSHELL_INSTRUMENTATION_SELECTOR_CLASS"
+  local expected_method="$POCKETSHELL_INSTRUMENTATION_SELECTOR_METHOD"
+
+  awk -v expected_class="$expected_class" -v expected_method="$expected_method" '
+    function reset_block() {
+      saw_class = 0
+      saw_method = 0
+    }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line == "INSTRUMENTATION_STATUS: class=" expected_class) {
+        saw_class = 1
+      }
+      if (expected_method != "" &&
+          line == "INSTRUMENTATION_STATUS: test=" expected_method) {
+        saw_method = 1
+      }
+      if (line ~ /^INSTRUMENTATION_STATUS_CODE:/) {
+        if (saw_class && (expected_method == "" || saw_method)) {
+          found = 1
+        }
+        reset_block()
+      }
+    }
+    END {
+      if (saw_class && (expected_method == "" || saw_method)) { found = 1 }
+      exit(found ? 0 : 1)
+    }
+  ' "$log_file"
+}
+
+pocketshell_instrumentation_has_failure_markers() {
+  local log_file="$1"
+  [[ -f "$log_file" ]] || return 1
+  grep -Eq '(^FAILURES!!!$|^FAILURE: |^INSTRUMENTATION_STATUS_CODE: -[0-9]+$|^INSTRUMENTATION_STATUS: stack=|^INSTRUMENTATION_RESULT: shortMsg=Process crashed[.]|^[[:space:]]*at (com[.]pocketshell|androidx[.]test|org[.]junit|kotlin[.]|java[.]|android[.])|^[[:alnum:]_.]*(Exception|Error): |^Process crashed[.])' "$log_file"
+}
+
+pocketshell_instrumentation_assert_log() {
+  local log_file="$1"
+  local selector="$2"
+  local count
+  [[ -f "$log_file" ]] || {
+    printf 'instrumentation evidence is missing: %s\n' "$log_file" >&2
+    return 1
+  }
+  if ! count="$(pocketshell_instrumentation_ok_count "$log_file")"; then
+    printf '%s did not report a positive executed-test count (`OK (N test[s])`, N > 0)\n' "$selector" >&2
+    return 1
+  fi
+  if ! pocketshell_instrumentation_has_runner_success_code "$log_file"; then
+    printf '%s did not report INSTRUMENTATION_CODE: -1\n' "$selector" >&2
+    return 1
+  fi
+  if ! pocketshell_instrumentation_selector_attended "$log_file" "$selector"; then
+    printf '%s did not appear in an instrumentation status block for this run\n' "$selector" >&2
+    return 1
+  fi
+  if pocketshell_instrumentation_has_failure_markers "$log_file"; then
+    printf '%s instrumentation log contains failure markers\n' "$selector" >&2
+    return 1
+  fi
+  printf '%s\n' "$count"
+}
+
+pocketshell_initialize_release_selector_attendance() {
+  local attendance_file="$1"
+  local run_id="$2"
+  local marker_file="$3"
+  shift 3
+  [[ "$run_id" =~ ^[A-Za-z0-9._-]+$ ]] || {
+    printf 'invalid release selector attendance run id: %s\n' "$run_id" >&2
+    return 1
+  }
+  [[ "$#" -gt 0 ]] || {
+    printf 'release selector attendance selected set is empty\n' >&2
+    return 1
+  }
+  mkdir -p "$(dirname "$attendance_file")" "$(dirname "$marker_file")"
+  : > "$marker_file"
+  touch "$marker_file"
+  {
+    printf '# pocketshell-release-selector-attendance v1\n'
+    printf 'run_id\t%s\n' "$run_id"
+  } > "$attendance_file"
+  local selector
+  for selector in "$@"; do
+    pocketshell_instrumentation_selector_parts "$selector" || return 1
+  done
+}
+
+pocketshell_record_release_selector_attendance() {
+  local attendance_file="$1"
+  local run_id="$2"
+  local selector="$3"
+  local log_file="$4"
+  local count digest
+  [[ -f "$attendance_file" ]] || {
+    printf 'release selector attendance ledger is missing: %s\n' "$attendance_file" >&2
+    return 1
+  }
+  grep -Fqx $'run_id\t'"$run_id" "$attendance_file" || {
+    printf 'release selector attendance ledger has the wrong run id: %s\n' "$attendance_file" >&2
+    return 1
+  }
+  pocketshell_instrumentation_selector_parts "$selector" || return 1
+  count="$(pocketshell_instrumentation_assert_log "$log_file" "$selector")" || return 1
+  digest="$(sha256sum "$log_file" | awk '{print $1}')"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || {
+    printf 'could not hash raw instrumentation evidence: %s\n' "$log_file" >&2
+    return 1
+  }
+  printf 'selector\t%s\t%s\t%s\t%s\n' \
+    "$selector" "$count" "$log_file" "$digest" >> "$attendance_file"
+}
+
+# Keep release-gate attendance tied to the command that validates the current
+# run. Callers pass the real checker and its arguments; this wrapper must return
+# the checker result unchanged so a successful-looking selector token cannot
+# bypass current-run validation.
+pocketshell_run_release_selector_checker() {
+  local checker="$1"
+  shift
+  [[ -x "$checker" ]] || {
+    printf 'release selector execution checker is missing or not executable: %s\n' "$checker" >&2
+    return 1
+  }
+  "$checker" "$@"
+}

--- a/scripts/phone-walkthrough.sh
+++ b/scripts/phone-walkthrough.sh
@@ -8,6 +8,7 @@ source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
 source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 # Issue #2064: `--verify-apk-identity` proves the release chain's APK contract
 # end to end — the exported environment, this script's own resolution of it, and
@@ -57,6 +58,9 @@ LOG_DIR="$RUN_DIR/logs"
 SCREENSHOT_ROOT="$RUN_DIR/screenshots"
 TIMING_DIR="$RUN_DIR/timings"
 DEVICE_ARTIFACT_ROOT="$RUN_DIR/device-artifacts"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$LOG_ROOT/gradle-home}"
 BUILD_APKS="${BUILD_APKS:-1}"
 PHONE_WALKTHROUGH_CLEAN_GENERATED="${PHONE_WALKTHROUGH_CLEAN_GENERATED:-${PHONE_DOGFOOD_CLEAN_GENERATED:-1}}"
@@ -309,8 +313,7 @@ run_logged() {
 
 instrumentation_success() {
   local log_file="$1"
-  grep -q "INSTRUMENTATION_CODE: -1" "$log_file" &&
-    grep -q "OK (" "$log_file" &&
+  pocketshell_instrumentation_has_positive_success "$log_file" &&
     ! grep -q "FAILURES!!!" "$log_file"
 }
 
@@ -409,6 +412,10 @@ run_instrumentation_with_retry() {
     crash_file="$(collect_instrumentation_attempt_diagnostics "$attempt_log" "$attempt_name")"
     logcat_file="$LOG_DIR/$attempt_name-logcat.txt"
     if [[ "$status" -eq 0 ]] && instrumentation_success "$attempt_log"; then
+      if [[ -n "${SELECTOR_ATTENDANCE_FILE:-}" ]]; then
+        pocketshell_record_release_selector_attendance \
+          "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$selector" "$attempt_log" >/dev/null || return 1
+      fi
       printf 'attempt=%s status=%s result=success log=%s logcat=%s\n' \
         "$attempt" "$status" "$(relpath "$attempt_log")" "$(relpath "$logcat_file")" >> "$summary_file"
       return 0
@@ -551,6 +558,40 @@ assert_selected_scenario_handlers_defined() {
       fail "selected scenario '$scenario' handler '$handler' is not defined; check phone-walkthrough function definitions before dispatch"
     fi
   done
+}
+
+release_selectors_for_scenarios() {
+  local scenario profile
+  for scenario in "${SCENARIOS[@]}"; do
+    case "$scenario" in
+      terminal-lab)
+        printf '%s\n' "$TERMINAL_LAB_TEST_CLASS"
+        ;;
+      tmux-existing-session)
+        printf '%s\n' "$TMUX_EXISTING_SESSION_TEST_SELECTOR"
+        ;;
+      visual-audit)
+        printf '%s\n' \
+          "$VISUAL_AUDIT_MAIN_TEST_CLASS" \
+          "$VISUAL_AUDIT_CONVERSATION_TEST_CLASS" \
+          "$VISUAL_AUDIT_COMPOSER_TEST_CLASS"
+        ;;
+      setup-detection|setup-detection:*)
+        while IFS= read -r profile; do
+          printf '%s#%s\n' "$SETUP_DETECTION_TEST_CLASS" "${SETUP_DETECTION_METHODS[$profile]}"
+        done < <(setup_detection_profiles_for_scenario "$scenario")
+        ;;
+    esac
+  done
+}
+
+initialize_release_selector_attendance() {
+  local -a selectors=()
+  mapfile -t selectors < <(release_selectors_for_scenarios)
+  pocketshell_initialize_release_selector_attendance \
+    "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" \
+    "${selectors[@]}"
+  printf '%s\n' "${selectors[@]}" > "$SELECTOR_REQUIRED_FILE"
 }
 
 verify_dispatch_only() {
@@ -770,7 +811,7 @@ assert_no_crash_diagnostics() {
 assert_instrumentation_success() {
   local log_file="$1"
   local selector="$2"
-  instrumentation_success "$log_file" ||
+  pocketshell_instrumentation_assert_log "$log_file" "$selector" >/dev/null ||
     fail "$selector did not report instrumentation success"
 }
 
@@ -1184,6 +1225,8 @@ if [[ "$PHONE_WALKTHROUGH_VERIFY_DISPATCH_ONLY" = "1" ]]; then
   exit 0
 fi
 
+initialize_release_selector_attendance
+
 printf 'PocketShell phone walkthrough\n'
 printf 'run-id: %s\n' "$RUN_ID"
 printf 'artifacts: %s\n' "$(relpath "$RUN_DIR")"
@@ -1206,3 +1249,11 @@ for scenario in "${SCENARIOS[@]}"; do
       ;;
   esac
 done
+
+pocketshell_run_release_selector_checker \
+  "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$SELECTOR_REQUIRED_FILE" \
+  --attendance "$SELECTOR_ATTENDANCE_FILE" \
+  --run-id "$RUN_ID" \
+  --newer-than "$SELECTOR_RUN_START_MARKER"

--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -13,6 +13,9 @@ source "$ROOT_DIR/scripts/lib/release-validation-storage.sh"
 # downstream release stage installs and ships THESE bytes. See
 # scripts/lib/apk-identity.sh for why "same source" was not good enough.
 source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+# Issue #2300: every release selector is backed by a positive executed-test
+# count and a current-run raw-evidence attendance record.
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 # Issue #2054: the AVD lock is acquired further down, AFTER the execution-profile
 # assertion. Queuing behind another emulator-touching run can take an hour; an
 # under-resourced profile should be rejected in the first second, not after that
@@ -370,6 +373,9 @@ FOCUSED_STATUSES=()
 FOCUSED_LOGS=()
 FOCUSED_DIAGNOSTICS=()
 FOCUSED_LOGCATS=()
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 
 for _selector in "${FOCUSED_SELECTORS[@]}"; do
   FOCUSED_STATUSES+=("not_run")
@@ -467,6 +473,8 @@ write_summary() {
     printf 'Final data-preserving update install status: %s\n' "$FINAL_INSTALL_STATUS"
     printf 'Legacy v1 database migration status: %s\n' "$LEGACY_V1_DB_MIGRATION_STATUS"
     printf 'Legacy v1 database migration logcat: %s\n' "$LEGACY_V1_DB_MIGRATION_LOGCAT"
+    printf 'Release selector attendance: %s\n' "$SELECTOR_ATTENDANCE_FILE"
+    printf 'Release selector raw evidence: one digest-verified log per selector under %s\n' "$RUN_DIR"
     if [[ "$GATE_RESULT" != "PASS" ]]; then
       printf 'Failing step: %s\n' "${FAILING_STEP:-unknown}"
       printf 'Failure message: %s\n' "${FAILURE_MESSAGE:-unknown}"
@@ -878,15 +886,115 @@ require_command_or_executable() {
   fi
 }
 
-# Issue #749: selector-existence guard. Before doing any expensive work
+# Issue #749/#2300: selector-existence guard. Before doing any expensive work
 # (compile, emulator boot, APK install) verify that EVERY entry in
-# APP_WALKTHROUGH_TESTS resolves to a `fun <method>` in the matching
-# androidTest source file. A future deletion/rename of a referenced test must
-# fail this gate immediately with a clear, actionable message instead of
-# aborting deep into the run with a `ClassNotFoundException` on the device (the
-# #749 failure mode). Resolves against the androidTest source tree under the
-# current ROOT_DIR, which works both in the source workspace and in the
+# APP_WALKTHROUGH_TESTS resolves to an annotated `@Test fun <method>` in the
+# matching androidTest source file. A declaration without @Test compiles but
+# can produce `OK (0 tests)` on the device, so source existence alone is not
+# executable-test evidence. Resolves against the androidTest source tree under
+# the current ROOT_DIR, which works both in the source workspace and in the
 # rsynced isolated worktree copy (app/src is preserved by the rsync).
+androidtest_method_is_annotated_test() {
+  local source_file="$1"
+  local method="$2"
+  awk -v target="$method" '
+    function strip_comments_and_literals(line,    i,c,n1,n2,out) {
+      out = ""
+      i = 1
+      while (i <= length(line)) {
+        c = substr(line, i, 1)
+        n1 = substr(line, i + 1, 1)
+        n2 = substr(line, i + 2, 1)
+
+        if (block_comment_depth > 0) {
+          if (c == "/" && n1 == "*") {
+            block_comment_depth++
+            i += 2
+          } else if (c == "*" && n1 == "/") {
+            block_comment_depth--
+            i += 2
+          } else {
+            i++
+          }
+          continue
+        }
+        if (triple_quoted_string) {
+          if (c == "\"" && n1 == "\"" && n2 == "\"") {
+            triple_quoted_string = 0
+            i += 3
+          } else {
+            i++
+          }
+          continue
+        }
+        if (quoted_string) {
+          if (c == "\\") {
+            i += 2
+          } else if (c == "\"") {
+            quoted_string = 0
+            i++
+          } else {
+            i++
+          }
+          continue
+        }
+        if (char_literal) {
+          if (c == "\\") {
+            i += 2
+          } else if (c == "\047") {
+            char_literal = 0
+            i++
+          } else {
+            i++
+          }
+          continue
+        }
+        if (c == "/" && n1 == "/") {
+          break
+        }
+        if (c == "/" && n1 == "*") {
+          block_comment_depth = 1
+          i += 2
+          continue
+        }
+        if (c == "\"" && n1 == "\"" && n2 == "\"") {
+          triple_quoted_string = 1
+          i += 3
+          continue
+        }
+        if (c == "\"") {
+          quoted_string = 1
+          i++
+          continue
+        }
+        if (c == "\047") {
+          char_literal = 1
+          i++
+          continue
+        }
+        out = out c
+        i++
+      }
+      return out
+    }
+    {
+      line = strip_comments_and_literals($0)
+      if (line ~ /(^|[^[:alnum:]_])@Test([[:space:]]|\(|$)/) {
+        annotated = 1
+      }
+      if (line ~ ("(^|[[:space:]])fun[[:space:]]+" target "[[:space:]]*\\(")) {
+        found = 1
+        valid = annotated
+        exit
+      }
+      if (line ~ /(^|[[:space:]])fun[[:space:]]+/) {
+        annotated = 0
+      }
+    }
+    END { exit(found && valid ? 0 : 1) }
+  ' "$source_file"
+}
+
 assert_app_walkthrough_selectors_exist() {
   local androidtest_root="$ROOT_DIR/app/src/androidTest/java"
   local missing=()
@@ -905,6 +1013,8 @@ assert_app_walkthrough_selectors_exist() {
     fi
     if ! grep -Eq "fun[[:space:]]+${method}[[:space:]]*\(" "$relative_path"; then
       missing+=("$selector (referenced test method not found in $relative_path)")
+    elif ! androidtest_method_is_annotated_test "$relative_path" "$method"; then
+      missing+=("$selector (referenced method is not annotated with @Test in $relative_path)")
     fi
   done
 
@@ -1641,11 +1751,16 @@ run_app_walkthrough_script() {
   local selector="$1"
   local diagnostics_file="$2"
   local full_logcat_file="$3"
+  local selector_log_file="$4"
   cat <<RUN_SCRIPT
 set -euo pipefail
 
 diagnostics_file='$diagnostics_file'
 full_logcat_file='$full_logcat_file'
+selector_log_file='$selector_log_file'
+selector_attendance_file='$SELECTOR_ATTENDANCE_FILE'
+selector_run_id='$RUN_ID'
+source '$ROOT_DIR/scripts/lib/instrumentation-evidence.sh'
 
 dump_instrumentation_diagnostics() {
   local reason="\$1"
@@ -1779,14 +1894,18 @@ while [ "\$attempt" -le "\$max_instrumentation_runs" ]; do
   output=\$('$ADB' shell am instrument -w -r -e class '$selector' com.pocketshell.app.test/androidx.test.runner.AndroidJUnitRunner 2>&1)
   instrument_status=\$?
   set -e
+  printf '%s\n' "\$output" > "\${selector_log_file}.attempt-\$attempt"
+  cp "\${selector_log_file}.attempt-\$attempt" "\$selector_log_file" || true
   if [ "\$instrument_status" -ne 0 ]; then
     sleep 2
   fi
   '$ADB' logcat -d -v time -t 5000 > "\$full_logcat_file" 2>&1 || true
   printf '%s\n' "\$output"
   if [ "\$instrument_status" -eq 0 ] &&
-    printf '%s\n' "\$output" | grep -q 'INSTRUMENTATION_CODE: -1' &&
-    ! instrumentation_output_has_failure_markers; then
+    pocketshell_instrumentation_assert_log "\${selector_log_file}.attempt-\$attempt" '$selector' >/dev/null; then
+    cp "\${selector_log_file}.attempt-\$attempt" "\$selector_log_file"
+    pocketshell_record_release_selector_attendance \
+      "\$selector_attendance_file" "\$selector_run_id" '$selector' "\$selector_log_file" >/dev/null
     exit 0
   fi
   if [ "\$attempt" -eq 1 ] &&
@@ -1921,6 +2040,13 @@ fi
 # deleted/renamed walkthrough test fails fast with a clear message instead of a
 # ClassNotFoundException deep inside the on-device instrumentation loop.
 assert_app_walkthrough_selectors_exist
+
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" \
+  "$RUN_ID" \
+  "$SELECTOR_RUN_START_MARKER" \
+  "${APP_WALKTHROUGH_TESTS[@]}"
+printf '%s\n' "${APP_WALKTHROUGH_TESTS[@]}" > "$SELECTOR_REQUIRED_FILE"
 
 run_step "android-sdk-paths" "$ADB" version
 run_step "available-avds" "$EMULATOR" -list-avds
@@ -2063,8 +2189,9 @@ for app_walkthrough_index in "${!APP_WALKTHROUGH_TESTS[@]}"; do
   app_walkthrough_step_index=$((STEP_INDEX + 1))
   app_walkthrough_diagnostics_file="$(printf '%s/%02d-connected-app-walkthrough-%s-diagnostics.log' "$RUN_DIR" "$app_walkthrough_step_index" "$app_walkthrough_safe_name")"
   app_walkthrough_full_logcat_file="$(printf '%s/%02d-connected-app-walkthrough-%s-full-logcat.log' "$RUN_DIR" "$app_walkthrough_step_index" "$app_walkthrough_safe_name")"
+  app_walkthrough_selector_log_file="$(printf '%s/%02d-connected-app-walkthrough-%s-raw-instrumentation.log' "$RUN_DIR" "$app_walkthrough_step_index" "$app_walkthrough_safe_name")"
   set_focused_status "$app_walkthrough_selector" "running" "" "$app_walkthrough_diagnostics_file" "$app_walkthrough_full_logcat_file"
-  if run_bash_step "connected-app-walkthrough-$app_walkthrough_safe_name" "$(run_app_walkthrough_script "$app_walkthrough_selector" "$app_walkthrough_diagnostics_file" "$app_walkthrough_full_logcat_file")"; then
+  if run_bash_step "connected-app-walkthrough-$app_walkthrough_safe_name" "$(run_app_walkthrough_script "$app_walkthrough_selector" "$app_walkthrough_diagnostics_file" "$app_walkthrough_full_logcat_file" "$app_walkthrough_selector_log_file")"; then
     set_focused_status "$app_walkthrough_selector" "passed" "$RUN_DIR/$(printf '%02d-connected-app-walkthrough-%s.log' "$app_walkthrough_step_index" "$app_walkthrough_safe_name")" "$app_walkthrough_diagnostics_file" "$app_walkthrough_full_logcat_file"
   else
     set_focused_status "$app_walkthrough_selector" "failed" "$RUN_DIR/$(printf '%02d-connected-app-walkthrough-%s.log' "$app_walkthrough_step_index" "$app_walkthrough_safe_name")" "$app_walkthrough_diagnostics_file" "$app_walkthrough_full_logcat_file"
@@ -2073,6 +2200,15 @@ for app_walkthrough_index in "${!APP_WALKTHROUGH_TESTS[@]}"; do
     exit 1
   fi
 done
+
+run_step "verify-release-selector-attendance" \
+  pocketshell_run_release_selector_checker \
+  "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$SELECTOR_REQUIRED_FILE" \
+  --attendance "$SELECTOR_ATTENDANCE_FILE" \
+  --run-id "$RUN_ID" \
+  --newer-than "$SELECTOR_RUN_START_MARKER"
 
 # Issue #2064: this step used to re-run `:app:assembleDebug` after
 # `build-app-test-apks` had already produced the APK — a fourth build of the

--- a/scripts/reconnect-app-switch.sh
+++ b/scripts/reconnect-app-switch.sh
@@ -14,6 +14,7 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -29,6 +30,9 @@ SSH_KEY="${SSH_KEY:-$ROOT_DIR/tests/docker/test_key}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/reconnect-app-switch}"
 RUN_ID="${RUN_ID:-issue-548-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 RUN_SSH_KEY="$RUN_DIR/test_key"
 BUILD_APKS="${BUILD_APKS:-1}"
 APP_APK="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
@@ -118,9 +122,18 @@ collect_diagnostics() {
 
 validate_artifacts() {
   local instrumentation_log="$RUN_DIR/07-run-reconnect-app-switch.log"
-  grep -q "OK (" "$instrumentation_log" &&
-    grep -q "INSTRUMENTATION_CODE: -1" "$instrumentation_log" ||
-    fail "reconnect app-switch instrumentation did not pass"
+  pocketshell_instrumentation_assert_log "$instrumentation_log" "$TEST_SELECTOR" >/dev/null ||
+    fail "reconnect app-switch instrumentation did not produce positive executed selector evidence"
+  pocketshell_record_release_selector_attendance \
+    "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$TEST_SELECTOR" "$instrumentation_log" >/dev/null ||
+    fail "reconnect app-switch selector attendance could not be recorded"
+  pocketshell_run_release_selector_checker \
+    "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+    --verify-attendance \
+    --selected-file "$SELECTOR_REQUIRED_FILE" \
+    --attendance "$SELECTOR_ATTENDANCE_FILE" \
+    --run-id "$RUN_ID" \
+    --newer-than "$SELECTOR_RUN_START_MARKER"
 
   [[ -d "$ARTIFACT_DIR" ]] || fail "artifact directory missing at $ARTIFACT_DIR"
   [[ -s "$ARTIFACT_DIR/timings.txt" ]] || fail "timings.txt is missing or empty"
@@ -157,6 +170,9 @@ validate_artifacts() {
 }
 
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" "$TEST_SELECTOR"
+printf '%s\n' "$TEST_SELECTOR" > "$SELECTOR_REQUIRED_FILE"
 trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 printf 'PocketShell short app-switch reconnect harness\n'

--- a/scripts/release-emulator-validation.sh
+++ b/scripts/release-emulator-validation.sh
@@ -12,6 +12,9 @@ source "$ROOT_DIR/scripts/lib/release-validation-storage.sh"
 # every downstream stage installs it, publish_validated_apk ships it, and each
 # hop re-checks the sha256.
 source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+# Issue #2300: release selectors require positive executed-count evidence and
+# current-run raw-log attendance, including the opt-in gates below.
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 # Issue #2054: apply and assert the release build resource profile ONCE, at the
 # top of the whole validation, before the ~30-60 minute run takes the shared AVD
@@ -378,8 +381,7 @@ publish_validated_apk() {
 
 real_agent_release_gate_instrumentation_log_has_success() {
   local log_file="$1"
-  grep -q 'INSTRUMENTATION_CODE: -1' "$log_file" &&
-    grep -q 'OK (' "$log_file"
+  pocketshell_instrumentation_has_positive_success "$log_file"
 }
 
 real_agent_release_gate_instrumentation_log_has_failure_markers() {
@@ -429,7 +431,14 @@ run_real_agent_release_gate_instrumentation() {
   local attempt_instrumentation_log
   local attempt_logcat
   local attempt_docker_log
+  local selector="$REAL_AGENT_RELEASE_GATE_TEST_CLASS"
+  local selected_file="$run_dir/required-selectors.txt"
+  local attendance_file="$run_dir/selector-attendance.tsv"
+  local start_marker="$run_dir/selector-run-start.marker"
   mkdir -p "$run_dir"
+  printf '%s\n' "$selector" > "$selected_file"
+  pocketshell_initialize_release_selector_attendance \
+    "$attendance_file" "$REAL_AGENT_RELEASE_GATE_RUN_ID" "$start_marker" "$selector"
 
   printf '\n[real-agent release gate instrumentation]\n'
   printf 'Test class: %s\n' "$REAL_AGENT_RELEASE_GATE_TEST_CLASS"
@@ -529,15 +538,40 @@ run_real_agent_release_gate_instrumentation() {
     print_failure_log_tail "$instrumentation_log"
     return "$instrumentation_status"
   fi
-  if ! grep -q 'INSTRUMENTATION_CODE: -1' "$instrumentation_log"; then
-    printf 'FAIL: RealAgentReleaseGateTest did not report INSTRUMENTATION_CODE: -1\n' >&2
+  if ! pocketshell_instrumentation_assert_log "$instrumentation_log" "$selector" >/dev/null; then
+    printf 'FAIL: RealAgentReleaseGateTest did not produce positive executed selector evidence\n' >&2
     print_failure_log_tail "$instrumentation_log"
     return 1
   fi
-  if ! grep -q 'OK (' "$instrumentation_log"; then
-    printf 'FAIL: RealAgentReleaseGateTest did not report an OK summary\n' >&2
-    print_failure_log_tail "$instrumentation_log"
-    return 1
+  local attendance_status=0
+  if pocketshell_record_release_selector_attendance \
+    "$attendance_file" "$REAL_AGENT_RELEASE_GATE_RUN_ID" "$selector" "$instrumentation_log" >/dev/null; then
+    :
+  else
+    attendance_status="$?"
+  fi
+  if [[ "$attendance_status" -ne 0 ]]; then
+    printf 'FAIL: RealAgentReleaseGateTest could not record selector attendance (exit %s)\n' \
+      "$attendance_status" >&2
+    return "$attendance_status"
+  fi
+
+  local checker_status=0
+  if pocketshell_run_release_selector_checker \
+    "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+    --verify-attendance \
+    --selected-file "$selected_file" \
+    --attendance "$attendance_file" \
+    --run-id "$REAL_AGENT_RELEASE_GATE_RUN_ID" \
+    --newer-than "$start_marker"; then
+    :
+  else
+    checker_status="$?"
+  fi
+  if [[ "$checker_status" -ne 0 ]]; then
+    printf 'FAIL: RealAgentReleaseGateTest selector attendance checker failed (exit %s)\n' \
+      "$checker_status" >&2
+    return "$checker_status"
   fi
   return 0
 }
@@ -652,6 +686,13 @@ run_long_running_session_instrumentation() {
   local attempt_logcat
   local attempt_docker_log
   mkdir -p "$run_dir" "$artifacts_dir"
+  local selector="$LONG_RUNNING_TEST_CLASS"
+  local selected_file="$run_dir/required-selectors.txt"
+  local attendance_file="$run_dir/selector-attendance.tsv"
+  local start_marker="$run_dir/selector-run-start.marker"
+  printf '%s\n' "$selector" > "$selected_file"
+  pocketshell_initialize_release_selector_attendance \
+    "$attendance_file" "$LONG_RUNNING_TEST_RUN_ID" "$start_marker" "$selector"
 
   printf '\n[long-running session stability instrumentation]\n'
   printf 'Test class: %s\n' "$LONG_RUNNING_TEST_CLASS"
@@ -744,15 +785,40 @@ run_long_running_session_instrumentation() {
     print_failure_log_tail "$instrumentation_log"
     return "$instrumentation_status"
   fi
-  if ! grep -q 'INSTRUMENTATION_CODE: -1' "$instrumentation_log"; then
-    printf 'FAIL: LongRunningSessionStabilityTest did not report INSTRUMENTATION_CODE: -1\n' >&2
+  if ! pocketshell_instrumentation_assert_log "$instrumentation_log" "$selector" >/dev/null; then
+    printf 'FAIL: LongRunningSessionStabilityTest did not produce positive executed selector evidence\n' >&2
     print_failure_log_tail "$instrumentation_log"
     return 1
   fi
-  if ! grep -q 'OK (' "$instrumentation_log"; then
-    printf 'FAIL: LongRunningSessionStabilityTest did not report an OK summary\n' >&2
-    print_failure_log_tail "$instrumentation_log"
-    return 1
+  local attendance_status=0
+  if pocketshell_record_release_selector_attendance \
+    "$attendance_file" "$LONG_RUNNING_TEST_RUN_ID" "$selector" "$instrumentation_log" >/dev/null; then
+    :
+  else
+    attendance_status="$?"
+  fi
+  if [[ "$attendance_status" -ne 0 ]]; then
+    printf 'FAIL: LongRunningSessionStabilityTest could not record selector attendance (exit %s)\n' \
+      "$attendance_status" >&2
+    return "$attendance_status"
+  fi
+
+  local checker_status=0
+  if pocketshell_run_release_selector_checker \
+    "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+    --verify-attendance \
+    --selected-file "$selected_file" \
+    --attendance "$attendance_file" \
+    --run-id "$LONG_RUNNING_TEST_RUN_ID" \
+    --newer-than "$start_marker"; then
+    :
+  else
+    checker_status="$?"
+  fi
+  if [[ "$checker_status" -ne 0 ]]; then
+    printf 'FAIL: LongRunningSessionStabilityTest selector attendance checker failed (exit %s)\n' \
+      "$checker_status" >&2
+    return "$checker_status"
   fi
   return 0
 }
@@ -834,6 +900,21 @@ run_required \
   "pre-release confidence gate" \
   "build/pre-release-confidence-gate/$PRE_RELEASE_RUN_ID/" \
   env LOG_ROOT="$PRE_RELEASE_GATE_LOG_ROOT" RUN_ID="$PRE_RELEASE_RUN_ID" PRE_RELEASE_MANAGE_EMULATOR=1 scripts/pre-release-confidence-gate.sh
+
+# Re-check the child artifact from the release wrapper as well as inside the
+# child gate. This keeps the release selector attendance contract at the exact
+# boundary that consumes the pre-release result, and prevents a rolling XML or
+# stale ledger from standing in for this run's raw selector evidence.
+run_required \
+  "pre-release selector attendance" \
+  "build/pre-release-confidence-gate/$PRE_RELEASE_RUN_ID/selector-attendance.tsv" \
+  pocketshell_run_release_selector_checker \
+    "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$PRE_RELEASE_GATE_RUN_DIR/required-selectors.txt" \
+  --attendance "$PRE_RELEASE_GATE_RUN_DIR/selector-attendance.tsv" \
+  --run-id "$PRE_RELEASE_RUN_ID" \
+  --newer-than "$PRE_RELEASE_GATE_RUN_DIR/selector-run-start.marker"
 
 # Issue #2064: from here on, every stage installs the pair the gate just built
 # and validated. Before this, terminal-lab / tmux-existing-session /

--- a/scripts/release-terminal-gate.sh
+++ b/scripts/release-terminal-gate.sh
@@ -44,6 +44,7 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -423,6 +424,13 @@ run_ssh_smoke_step() {
   mkdir -p "$step_run_dir"
   local artifact_dir="$step_run_dir/artifacts"
   mkdir -p "$artifact_dir"
+  local selector='com.pocketshell.app.proof.EmulatorDockerSshSmokeTest#debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias'
+  local selected_file="$step_run_dir/required-selectors.txt"
+  local attendance_file="$step_run_dir/selector-attendance.tsv"
+  local start_marker="$step_run_dir/selector-run-start.marker"
+  printf '%s\n' "$selector" > "$selected_file"
+  pocketshell_initialize_release_selector_attendance \
+    "$attendance_file" "$RUN_ID-$step_name" "$start_marker" "$selector"
 
   printf '\n[%s] starting SSH smoke step\n' "$step_name"
 
@@ -434,8 +442,7 @@ run_ssh_smoke_step() {
   set +e
   {
     printf '[%s] %s\n' "$(date -Is)" "$step_name"
-    printf 'selector: %s\n' \
-      'com.pocketshell.app.proof.EmulatorDockerSshSmokeTest#debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias'
+    printf 'selector: %s\n' "$selector"
     printf '\n# bringing up deterministic agents Docker fixture\n'
     docker compose -f "$DETERMINISTIC_COMPOSE_FILE" up -d --build agents
     printf '\n# Docker compose ps\n'
@@ -491,19 +498,46 @@ run_ssh_smoke_step() {
     return "$status"
   fi
 
-  if ! grep -q 'INSTRUMENTATION_CODE: -1' "$instrumentation_log"; then
+  if ! pocketshell_instrumentation_assert_log "$instrumentation_log" "$selector" >/dev/null; then
     record_step "$step_name" "FAIL" "$step_log" "$artifact_dir" "" \
-      "EmulatorDockerSshSmokeTest did not report INSTRUMENTATION_CODE: -1."
+      "EmulatorDockerSshSmokeTest did not produce positive executed selector evidence."
     FAILING_STEP="$step_name"
-    FAILURE_REASON="EmulatorDockerSshSmokeTest did not report INSTRUMENTATION_CODE: -1"
+    FAILURE_REASON="EmulatorDockerSshSmokeTest did not produce positive executed selector evidence"
     return 1
   fi
-  if ! grep -q 'OK (' "$instrumentation_log"; then
+  local attendance_status=0
+  if pocketshell_record_release_selector_attendance \
+    "$attendance_file" "$RUN_ID-$step_name" "$selector" "$instrumentation_log" >/dev/null; then
+    :
+  else
+    attendance_status="$?"
+  fi
+  if [[ "$attendance_status" -ne 0 ]]; then
     record_step "$step_name" "FAIL" "$step_log" "$artifact_dir" "" \
-      "EmulatorDockerSshSmokeTest did not report 'OK (' summary."
+      "Could not record release selector attendance (exit $attendance_status)."
     FAILING_STEP="$step_name"
-    FAILURE_REASON="EmulatorDockerSshSmokeTest did not report OK"
-    return 1
+    FAILURE_REASON="Could not record SSH smoke selector attendance (exit $attendance_status)"
+    return "$attendance_status"
+  fi
+
+  local checker_status=0
+  if pocketshell_run_release_selector_checker \
+    "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+    --verify-attendance \
+    --selected-file "$selected_file" \
+    --attendance "$attendance_file" \
+    --run-id "$RUN_ID-$step_name" \
+    --newer-than "$start_marker"; then
+    :
+  else
+    checker_status="$?"
+  fi
+  if [[ "$checker_status" -ne 0 ]]; then
+    record_step "$step_name" "FAIL" "$step_log" "$artifact_dir" "" \
+      "Current-run release selector attendance check failed (exit $checker_status)."
+    FAILING_STEP="$step_name"
+    FAILURE_REASON="SSH smoke selector attendance checker failed (exit $checker_status)"
+    return "$checker_status"
   fi
 
   record_step "$step_name" "PASS" "$step_log" "$artifact_dir" "" \

--- a/scripts/terminal-workbench.sh
+++ b/scripts/terminal-workbench.sh
@@ -20,6 +20,7 @@ fi
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
 source "$ROOT_DIR/scripts/lib/gradle-profile.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 # Issue #2064: when this workbench is a child of release validation it must
 # install the gate-recorded pair, not stale APKs from the root checkout.
 source "$ROOT_DIR/scripts/lib/apk-identity.sh"
@@ -76,6 +77,9 @@ case "$RUN_ID" in
     ;;
 esac
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 ARTIFACT_DIR="$RUN_DIR/artifacts/terminal-lab"
 BUILD_APKS="${BUILD_APKS:-1}"
 HOLD_MS="${HOLD_MS:-0}"
@@ -374,6 +378,9 @@ case "$RUN_DIR" in
 esac
 rm -rf -- "$RUN_DIR"
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" "$TEST_SELECTOR"
+printf '%s\n' "$TEST_SELECTOR" > "$SELECTOR_REQUIRED_FILE"
 trap collect_diagnostics EXIT
 
 printf 'PocketShell terminal workbench\n'
@@ -441,8 +448,7 @@ fi
 
 instrumentation_log_has_success() {
   local log_file="$1"
-  grep -q "OK (" "$log_file" &&
-    grep -q "INSTRUMENTATION_CODE: -1" "$log_file"
+  pocketshell_instrumentation_has_positive_success "$log_file"
 }
 
 instrumentation_log_has_failure_markers() {
@@ -579,6 +585,21 @@ if instrumentation_log_has_success "$RUN_DIR/07-run-workbench.log"; then
 fi
 
 validate_terminal_artifacts
+
+pocketshell_instrumentation_assert_log \
+  "$RUN_DIR/07-run-workbench.log" "$TEST_SELECTOR" >/dev/null ||
+  fail "terminal workbench did not produce positive executed selector evidence"
+pocketshell_record_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$TEST_SELECTOR" \
+  "$RUN_DIR/07-run-workbench.log" >/dev/null ||
+  fail "terminal workbench selector attendance could not be recorded"
+pocketshell_run_release_selector_checker \
+  "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$SELECTOR_REQUIRED_FILE" \
+  --attendance "$SELECTOR_ATTENDANCE_FILE" \
+  --run-id "$RUN_ID" \
+  --newer-than "$SELECTOR_RUN_START_MARKER"
 
 (( pull_status == 0 )) ||
   fail "terminal workbench artifact pull exited $pull_status"

--- a/scripts/tmux-attach-prefill.sh
+++ b/scripts/tmux-attach-prefill.sh
@@ -28,6 +28,7 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -40,6 +41,9 @@ SSH_PORT="${SSH_PORT:-2222}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/terminal-workbench}"
 RUN_ID="${RUN_ID:-issue-103-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 ARTIFACT_DIR="$RUN_DIR/artifacts/terminal-lab"
 BUILD_APKS="${BUILD_APKS:-1}"
 APP_APK="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
@@ -210,6 +214,9 @@ validate_artifacts() {
 }
 
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" "$TEST_SELECTOR"
+printf '%s\n' "$TEST_SELECTOR" > "$SELECTOR_REQUIRED_FILE"
 trap 'collect_diagnostics; pocketshell_release_all' EXIT
 
 printf 'PocketShell issue #103 tmux attach prefill workbench\n'
@@ -265,9 +272,20 @@ if [[ -d "$ARTIFACT_DIR" ]]; then
   run_logged "09-artifact-file-info" file "$RUN_DIR"/artifacts/terminal-lab/* || true
 fi
 
-grep -q "OK (" "$RUN_DIR/07-run-tmux-attach-prefill.log" &&
-  grep -q "INSTRUMENTATION_CODE: -1" "$RUN_DIR/07-run-tmux-attach-prefill.log" ||
-  fail "tmux-attach-prefill instrumentation did not pass"
+pocketshell_instrumentation_assert_log \
+  "$RUN_DIR/07-run-tmux-attach-prefill.log" "$TEST_SELECTOR" >/dev/null ||
+  fail "tmux-attach-prefill instrumentation did not produce positive executed selector evidence"
+pocketshell_record_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$TEST_SELECTOR" \
+  "$RUN_DIR/07-run-tmux-attach-prefill.log" >/dev/null ||
+  fail "tmux-attach-prefill selector attendance could not be recorded"
+pocketshell_run_release_selector_checker \
+  "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$SELECTOR_REQUIRED_FILE" \
+  --attendance "$SELECTOR_ATTENDANCE_FILE" \
+  --run-id "$RUN_ID" \
+  --newer-than "$SELECTOR_RUN_START_MARKER"
 
 validate_artifacts
 

--- a/scripts/tmux-issue303-toolbar-proof.sh
+++ b/scripts/tmux-issue303-toolbar-proof.sh
@@ -15,6 +15,7 @@ cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
 source "$ROOT_DIR/scripts/lib/scope-run.sh"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
@@ -27,6 +28,9 @@ SSH_PORT="${SSH_PORT:-2222}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/terminal-workbench}"
 RUN_ID="${RUN_ID:-issue-303-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
+SELECTOR_ATTENDANCE_FILE="$RUN_DIR/selector-attendance.tsv"
+SELECTOR_REQUIRED_FILE="$RUN_DIR/required-selectors.txt"
+SELECTOR_RUN_START_MARKER="$RUN_DIR/selector-run-start.marker"
 ARTIFACT_DIR="$RUN_DIR/artifacts/terminal-lab"
 BUILD_APKS="${BUILD_APKS:-1}"
 APP_APK="$ROOT_DIR/app/build/outputs/apk/debug/app-debug.apk"
@@ -202,6 +206,9 @@ validate_artifacts() {
 }
 
 mkdir -p "$RUN_DIR"
+pocketshell_initialize_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$SELECTOR_RUN_START_MARKER" "$TEST_SELECTOR"
+printf '%s\n' "$TEST_SELECTOR" > "$SELECTOR_REQUIRED_FILE"
 cp "$SSH_KEY" "$HOST_SSH_KEY"
 chmod 600 "$HOST_SSH_KEY"
 trap 'collect_diagnostics; pocketshell_release_all' EXIT
@@ -260,9 +267,20 @@ if [[ -d "$ARTIFACT_DIR" ]]; then
   run_logged "09-artifact-file-info" file "$RUN_DIR"/artifacts/terminal-lab/* || true
 fi
 
-grep -q "OK (" "$RUN_DIR/07-run-issue303-proof.log" &&
-  grep -q "INSTRUMENTATION_CODE: -1" "$RUN_DIR/07-run-issue303-proof.log" ||
-  fail "issue303 instrumentation did not pass"
+pocketshell_instrumentation_assert_log \
+  "$RUN_DIR/07-run-issue303-proof.log" "$TEST_SELECTOR" >/dev/null ||
+  fail "issue303 instrumentation did not produce positive executed selector evidence"
+pocketshell_record_release_selector_attendance \
+  "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$TEST_SELECTOR" \
+  "$RUN_DIR/07-run-issue303-proof.log" >/dev/null ||
+  fail "issue303 selector attendance could not be recorded"
+pocketshell_run_release_selector_checker \
+  "$ROOT_DIR/scripts/check-release-selector-execution.sh" \
+  --verify-attendance \
+  --selected-file "$SELECTOR_REQUIRED_FILE" \
+  --attendance "$SELECTOR_ATTENDANCE_FILE" \
+  --run-id "$RUN_ID" \
+  --newer-than "$SELECTOR_RUN_START_MARKER"
 
 validate_artifacts
 

--- a/scripts/two-phase-android-instrumentation.sh
+++ b/scripts/two-phase-android-instrumentation.sh
@@ -13,6 +13,15 @@ cd "$ROOT_DIR"
 # shellcheck source=scripts/lib/avd-lock.sh
 # shellcheck disable=SC1091
 source "$ROOT_DIR/scripts/lib/avd-lock.sh"
+# Issue #2300: successful instrumentation must include a positive executed-test
+# count and the exact phase selector. The phase-specific checks below retain
+# this harness's one-test coverage floor and coherent status-code assertions.
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
+# This is the nightly process-boundary harness invoked by
+# scripts/nightly-extensive-suite.sh, not a release selector consumed by
+# scripts/release-emulator-validation.sh. It keeps its own exact per-phase
+# selector and one-test floor; the release-only attendance ledger is therefore
+# intentionally owned by the release wrappers instead.
 
 ANDROID_SDK="${ANDROID_SDK:-${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/home/alexey/Android/Sdk}}}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
@@ -380,13 +389,9 @@ validate_phase_process_marker() {
 validate_instrumentation_success() {
   local phase="$1" method="$2" log_file="$3" rc="$4"
   [[ "$rc" == "0" ]] || fail "phase $phase am instrument exited $rc"
-  grep -Fqx "INSTRUMENTATION_CODE: -1" "$log_file" \
-    || fail "phase $phase lacks instrumentation success code"
+  pocketshell_instrumentation_assert_log "$log_file" "$TEST_CLASS#$method" >/dev/null \
+    || fail "phase $phase lacks positive executed selector evidence for $TEST_CLASS#$method"
   grep -Fqx "OK (1 test)" "$log_file" || fail "phase $phase did not report exactly one passing test"
-  grep -Fqx "INSTRUMENTATION_STATUS: class=$TEST_CLASS" "$log_file" \
-    || fail "phase $phase did not execute $TEST_CLASS"
-  grep -Fqx "INSTRUMENTATION_STATUS: test=$method" "$log_file" \
-    || fail "phase $phase did not execute $method"
   [[ "$(grep -c '^INSTRUMENTATION_STATUS_CODE: 0$' "$log_file" || true)" == "1" ]] \
     || fail "phase $phase lacks one coherent completed-test status"
   if grep -Eq 'FAILURES!!!|INSTRUMENTATION_FAILED|INSTRUMENTATION_STATUS_CODE: -[12]|shortMsg=' "$log_file"; then

--- a/tests/scripts/long-running-release-gate-retry-test.sh
+++ b/tests/scripts/long-running-release-gate-retry-test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -160,6 +161,7 @@ if [[ "$*" == shell\ rm\ -f\ /data/local/tmp/pocketshell-long-running-*nohup*am\
   fi
 
   {
+    printf 'INSTRUMENTATION_STATUS: class=com.pocketshell.app.proof.LongRunningSessionStabilityTest\n'
     printf 'INSTRUMENTATION_STATUS: stream=LONG_RUNNING_HEARTBEAT elapsed_ms=15000 next_tick_index=1 label=hold\n'
     printf 'INSTRUMENTATION_STATUS_CODE: 0\n'
     printf 'INSTRUMENTATION_CODE: -1\n'
@@ -221,6 +223,7 @@ run_long_running_with_mode() {
   mkdir -p "$run_dir"
 
   ADB="$fake_adb"
+  LONG_RUNNING_TEST_RUN_ID="test-$mode"
   LONG_RUNNING_TEST_RUN_DIR="$run_dir"
   LONG_RUNNING_TEST_CLASS="com.pocketshell.app.proof.LongRunningSessionStabilityTest"
   LONG_RUNNING_TEST_INSTRUMENTATION_ATTEMPTS=2

--- a/tests/scripts/pre-release-gate-retry-test.sh
+++ b/tests/scripts/pre-release-gate-retry-test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -66,6 +67,9 @@ if [[ "$*" == "shell am instrument"* ]]; then
     exit 1
   fi
 
+  printf 'INSTRUMENTATION_STATUS: class=com.pocketshell.app.proof.EmulatorDockerSshSmokeTest\n'
+  printf 'INSTRUMENTATION_STATUS: test=debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias\n'
+  printf 'INSTRUMENTATION_STATUS_CODE: 0\n'
   printf 'INSTRUMENTATION_CODE: -1\n'
   printf 'OK (1 test)\n'
   exit 0
@@ -91,12 +95,18 @@ run_generated_walkthrough() {
   FAKE_ADB_MODE="$mode"
   FAKE_ADB_STATE="$run_dir/adb-state"
   export FAKE_ADB_MODE FAKE_ADB_STATE
+  SELECTOR_ATTENDANCE_FILE="$run_dir/selector-attendance.tsv"
+  RUN_ID="test-$mode"
+  pocketshell_initialize_release_selector_attendance \
+    "$SELECTOR_ATTENDANCE_FILE" "$RUN_ID" "$run_dir/selector-run-start.marker" \
+    "com.pocketshell.app.proof.EmulatorDockerSshSmokeTest#debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias"
 
   local generated_script
   generated_script="$(run_app_walkthrough_script \
     "com.pocketshell.app.proof.EmulatorDockerSshSmokeTest#debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias" \
     "$run_dir/diagnostics.log" \
-    "$run_dir/full-logcat.log")"
+    "$run_dir/full-logcat.log" \
+    "$run_dir/raw-instrumentation.log")"
 
   bash -lc "$generated_script"
 }

--- a/tests/scripts/release-gate-retry-test.sh
+++ b/tests/scripts/release-gate-retry-test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2

--- a/tests/scripts/release-selector-execution-proof-test.sh
+++ b/tests/scripts/release-selector-execution-proof-test.sh
@@ -1,0 +1,621 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PRE_RELEASE_GATE="$ROOT_DIR/scripts/pre-release-confidence-gate.sh"
+CHECKER="$ROOT_DIR/scripts/check-release-selector-execution.sh"
+PRE_RELEASE_GATE="${POCKETSHELL_RELEASE_SELECTOR_PRE_RELEASE_GATE:-$PRE_RELEASE_GATE}"
+CHECKER="${POCKETSHELL_RELEASE_SELECTOR_CHECKER:-$CHECKER}"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
+FIXTURE_ROOT="$(mktemp -d)"
+trap 'find "$FIXTURE_ROOT" -type f -delete; find "$FIXTURE_ROOT" -depth -type d -empty -delete' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+run_capture_terminal_lab_finalizer_oracle() (
+  local capture_script="$1"
+  local expected_checker_result="$2"
+  local probe_name="$3"
+  local probe_root="$FIXTURE_ROOT/live-capture-$probe_name"
+  local run_dir="$probe_root/run"
+  local test_class="com.example.FakeTest"
+  local selector="$test_class"
+  local attendance_file="$run_dir/selector-attendance.tsv"
+  local required_file="$run_dir/required-selectors.txt"
+  local run_start_marker="$run_dir/selector-run-start.marker"
+  local log_file="$run_dir/11-run-terminal-lab-instrumentation.log"
+  local checker="$probe_root/scripts/check-release-selector-execution.sh"
+  local checker_marker="$probe_root/checker-invoked"
+
+  mkdir -p "$probe_root/scripts" "$run_dir"
+  {
+    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+    printf 'printf "%%s\\n" invoked > %q\n' "$checker_marker"
+    printf 'exit %d\n' "$expected_checker_result"
+  } > "$checker"
+  chmod +x "$checker"
+
+  pocketshell_initialize_release_selector_attendance \
+    "$attendance_file" live-run "$run_start_marker" "$test_class"
+  printf '%s\n' "$selector" > "$required_file"
+  sleep 0.02
+  printf '%s\n' \
+    'INSTRUMENTATION_STATUS: class=com.example.FakeTest' \
+    'INSTRUMENTATION_STATUS: test=terminalLabSelector' \
+    'INSTRUMENTATION_STATUS_CODE: 0' \
+    'INSTRUMENTATION_CODE: -1' \
+    'OK (1 test)' > "$log_file"
+
+  eval "$(sed -n '/^verify_terminal_lab_selector_attendance()/,/^}/p' "$capture_script")"
+  ROOT_DIR="$probe_root"
+  RUN_DIR="$run_dir"
+  RUN_ID=live-run
+  TEST_CLASS="$test_class"
+  SELECTOR_ATTENDANCE_FILE="$attendance_file"
+  SELECTOR_REQUIRED_FILE="$required_file"
+  SELECTOR_RUN_START_MARKER="$run_start_marker"
+
+  if [[ "$expected_checker_result" -eq 0 ]]; then
+    verify_terminal_lab_selector_attendance || return 1
+  else
+    local actual_checker_result=0
+    if verify_terminal_lab_selector_attendance; then
+      return 1
+    else
+      actual_checker_result=$?
+    fi
+    [[ "$actual_checker_result" -eq "$expected_checker_result" ]] || return 1
+  fi
+  [[ -s "$checker_marker" ]] || return 1
+  awk -F '\t' -v selector="$selector" \
+    '$1 == "selector" && $2 == selector && $3 == "1" { found = 1 }
+     END { exit(found ? 0 : 1) }' "$attendance_file"
+)
+
+capture_terminal_lab_live_checker_mutation_is_rejected() (
+  local mutant="$FIXTURE_ROOT/capture-terminal-lab-live-checker-mutant.sh"
+  awk '
+    {
+      line = $0
+      sub(/^[[:space:]]*/, "", line)
+      if (!replaced && line ~ /^pocketshell_run_release_selector_checker/) {
+        print "  # The checker token is retained only in unreachable code."
+        print "  if false; then"
+        print "    \"$ROOT_DIR/scripts/check-release-selector-execution.sh\" --help"
+        print "  fi"
+        print "  true"
+        replaced = 1
+        skip = 6
+        next
+      }
+      if (skip > 0) {
+        skip--
+        next
+      }
+      print
+    }
+    END { exit(replaced ? 0 : 1) }
+  ' "$ROOT_DIR/scripts/capture-terminal-lab.sh" > "$mutant"
+  [[ -s "$mutant" ]] || return 1
+  grep -Fq 'The checker token is retained only in unreachable code.' "$mutant" || return 1
+  local mutant_result=0
+  run_capture_terminal_lab_finalizer_oracle "$mutant" 0 live-mutant || mutant_result=$?
+  [[ "$mutant_result" -eq 1 ]] || return 1
+  printf 'PASS: live checker dead/true mutation rc=%s\n' "$mutant_result"
+)
+
+# Exercise the actual release-wrapper functions in the contexts that suppress
+# errexit: run_ssh_smoke_step is called from `if ! ...`, while the two
+# release-emulator-validation functions are passed to run_required after it
+# enters `set +e`. A bare checker/attendance call followed by return 0 must
+# therefore be observable as a failed production step, not only as a source
+# token or a direct helper-function result.
+run_release_selector_context_oracle() (
+  local context="$1"
+  local failure_mode="$2"
+  local expected_status="$3"
+  local probe_root="$FIXTURE_ROOT/release-context-$context-$failure_mode"
+  local bin_dir="$probe_root/bin"
+  local scripts_dir="$probe_root/scripts"
+  local key_file="$probe_root/tests/docker/test_key"
+  local checker="$scripts_dir/check-release-selector-execution.sh"
+  local checker_marker="$probe_root/checker-invoked"
+  local record_marker="$probe_root/attendance-record-invoked"
+  local output_file="$probe_root/output.log"
+  local instrumentation_fixture="$probe_root/instrumentation.log"
+  local step_status_file="$probe_root/step-status"
+  local actual_status=0
+  local selector
+
+  mkdir -p "$bin_dir" "$scripts_dir" "$(dirname "$key_file")"
+  printf 'fixture-key\n' > "$key_file"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+    printf 'printf "%%s\\n" invoked > %q\n' "$checker_marker"
+    if [[ "$failure_mode" == "checker-failure" ]]; then
+      printf 'exit 17\n'
+    else
+      printf 'exit 0\n'
+    fi
+  } > "$checker"
+  chmod +x "$checker"
+
+  cat > "$bin_dir/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  cat > "$bin_dir/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' 'fixture ssh ready'
+exit 0
+EOF
+
+  case "$context" in
+    terminal)
+      selector='com.pocketshell.app.proof.EmulatorDockerSshSmokeTest#debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias'
+      ;;
+    real-agent)
+      selector='com.pocketshell.app.proof.RealAgentReleaseGateTest'
+      ;;
+    long-running)
+      selector='com.pocketshell.app.proof.LongRunningSessionStabilityTest'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  local selector_class="${selector%%#*}"
+  local selector_method=""
+  if [[ "$selector" == *'#'* ]]; then
+    selector_method="${selector#*#}"
+  fi
+  {
+    printf 'INSTRUMENTATION_STATUS: class=%s\n' "$selector_class"
+    [[ -z "$selector_method" ]] || printf 'INSTRUMENTATION_STATUS: test=%s\n' "$selector_method"
+    printf '%s\n' \
+      'INSTRUMENTATION_STATUS_CODE: 0' \
+      'INSTRUMENTATION_CODE: -1' \
+      'OK (1 test)'
+  } > "$instrumentation_fixture"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+    printf 'if [[ "${1:-}" == shell && "${2:-}" == am && "${3:-}" == instrument ]]; then\n'
+    printf '  cat %q\n' "$instrumentation_fixture"
+    printf 'fi\n'
+    printf 'exit 0\n'
+  } > "$bin_dir/adb"
+  chmod +x "$bin_dir/docker" "$bin_dir/ssh" "$bin_dir/adb"
+
+  export PATH="$bin_dir:$PATH"
+  ROOT_DIR="$probe_root"
+  RUN_ID="fixture-run"
+  RUN_DIR="$probe_root/run"
+  WORKBENCH_LOG_ROOT="$probe_root/workbench"
+  DETERMINISTIC_COMPOSE_FILE="$probe_root/compose.yml"
+  ADB="$bin_dir/adb"
+  mkdir -p "$RUN_DIR" "$WORKBENCH_LOG_ROOT"
+
+  wait_for_container_healthy() {
+    printf '%s\n' 'healthy' > "$3"
+    return 0
+  }
+  record_step() {
+    printf '%s\n' "$2" > "$step_status_file"
+  }
+
+  case "$context" in
+    terminal)
+      eval "$(sed -n '/^run_ssh_smoke_step()/,/^}/p' "$RELEASE_TERMINAL_GATE")"
+      ;;
+    real-agent)
+      REAL_AGENT_RELEASE_GATE_RUN_ID="fixture-real-agent"
+      REAL_AGENT_RELEASE_GATE_RUN_DIR="$RUN_DIR"
+      REAL_AGENT_RELEASE_GATE_TEST_CLASS="$selector_class"
+      REAL_AGENT_RELEASE_GATE_INSTRUMENTATION_ATTEMPTS=1
+      REAL_AGENT_COMPOSE_FILE="$probe_root/real-agent-compose.yml"
+      eval "$(sed -n '/^run_real_agent_release_gate_instrumentation()/,/^}/p' "$RELEASE_EMULATOR_VALIDATION")"
+      ;;
+    long-running)
+      LONG_RUNNING_TEST_RUN_ID="fixture-long-running"
+      LONG_RUNNING_TEST_RUN_DIR="$RUN_DIR"
+      LONG_RUNNING_TEST_CLASS="$selector_class"
+      LONG_RUNNING_TEST_INSTRUMENTATION_ATTEMPTS=1
+      LONG_RUNNING_COMPOSE_FILE="$probe_root/long-running-compose.yml"
+      eval "$(sed -n '/^run_long_running_session_instrumentation()/,/^}/p' "$RELEASE_EMULATOR_VALIDATION")"
+      run_long_running_session_detached_instrumentation_attempt() {
+        cp "$instrumentation_fixture" "$2"
+        return 0
+      }
+      ;;
+  esac
+
+  if [[ "$failure_mode" == "attendance-failure" ]]; then
+    pocketshell_record_release_selector_attendance() {
+      printf '%s\n' invoked > "$record_marker"
+      return 23
+    }
+  fi
+
+  case "$context" in
+    terminal)
+      # This conditional call reproduces the `if ! run_ssh_smoke_step` caller.
+      if run_ssh_smoke_step > "$output_file" 2>&1; then
+        actual_status=0
+      else
+        actual_status="$?"
+      fi
+      ;;
+    real-agent)
+      # run_required has set +e around this exact function invocation.
+      set +e
+      run_real_agent_release_gate_instrumentation > "$output_file" 2>&1
+      actual_status="$?"
+      set -e
+      ;;
+    long-running)
+      set +e
+      run_long_running_session_instrumentation > "$output_file" 2>&1
+      actual_status="$?"
+      set -e
+      ;;
+  esac
+
+  [[ "$actual_status" == "$expected_status" ]] || {
+    cat "$output_file" >&2
+    printf 'expected %s/%s to return %s, got %s\n' \
+      "$context" "$failure_mode" "$expected_status" "$actual_status" >&2
+    return 1
+  }
+
+  if [[ "$failure_mode" == "attendance-failure" ]]; then
+    [[ -s "$record_marker" ]] || return 1
+    [[ ! -e "$checker_marker" ]] || {
+      printf '%s/%s invoked the checker after attendance recording failed\n' \
+        "$context" "$failure_mode" >&2
+      return 1
+    }
+  else
+    [[ -s "$checker_marker" ]] || {
+      printf '%s/%s did not execute the checker\n' "$context" "$failure_mode" >&2
+      return 1
+    }
+  fi
+
+  if [[ "$context" == "terminal" ]]; then
+    local expected_step_status=PASS
+    [[ "$failure_mode" == "success" ]] || expected_step_status=FAIL
+    grep -Fqx "$expected_step_status" "$step_status_file" || {
+      printf '%s/%s recorded step status other than %s\n' \
+        "$context" "$failure_mode" "$expected_step_status" >&2
+      return 1
+    }
+  fi
+)
+
+run_release_selector_context_matrix() {
+  local context
+  for context in terminal real-agent long-running; do
+    run_release_selector_context_oracle "$context" success 0 || return 1
+    run_release_selector_context_oracle "$context" checker-failure 17 || return 1
+    run_release_selector_context_oracle "$context" attendance-failure 23 || return 1
+  done
+  printf 'PASS: release-wrapper attendance/checker failures propagate in all three production contexts\n'
+}
+
+# Kill the exact false-green mutation that turns both new failure branches into
+# dead code. The oracle must fail against each mutated production function; a
+# static grep for status-variable names would not prove this.
+release_wrapper_propagation_mutation_is_rejected() (
+  local mutant_root="$FIXTURE_ROOT/release-wrapper-propagation-mutants"
+  local mutant_terminal="$mutant_root/release-terminal-gate.sh"
+  local mutant_emulator="$mutant_root/release-emulator-validation.sh"
+  mkdir -p "$mutant_root"
+  awk '
+    /^  if \[\[ "\$attendance_status" -ne 0 \]\]; then$/ ||
+    /^  if \[\[ "\$checker_status" -ne 0 \]\]; then$/ {
+      print "  if false; then"
+      next
+    }
+    { print }
+  ' "$RELEASE_TERMINAL_GATE" > "$mutant_terminal"
+  awk '
+    /^  if \[\[ "\$attendance_status" -ne 0 \]\]; then$/ ||
+    /^  if \[\[ "\$checker_status" -ne 0 \]\]; then$/ {
+      print "  if false; then"
+      next
+    }
+    { print }
+  ' "$RELEASE_EMULATOR_VALIDATION" > "$mutant_emulator"
+  grep -Fq 'if false; then' "$mutant_terminal" || return 1
+  grep -Fq 'if false; then' "$mutant_emulator" || return 1
+
+  RELEASE_TERMINAL_GATE="$mutant_terminal"
+  RELEASE_EMULATOR_VALIDATION="$mutant_emulator"
+  local context failure_mode expected_status mutation_output
+  for context in terminal real-agent long-running; do
+    for failure_mode in checker-failure attendance-failure; do
+      if [[ "$failure_mode" == checker-failure ]]; then
+        expected_status=17
+      else
+        expected_status=23
+      fi
+      mutation_output="$mutant_root/$context-$failure_mode.log"
+      if run_release_selector_context_oracle \
+        "$context" "$failure_mode" "$expected_status" > "$mutation_output" 2>&1; then
+        printf 'FAIL: %s/%s propagation mutation survived\n' "$context" "$failure_mode" >&2
+        return 1
+      fi
+      grep -Fq "expected $context/$failure_mode to return $expected_status, got 0" \
+        "$mutation_output" || {
+        cat "$mutation_output" >&2
+        printf 'FAIL: %s/%s propagation mutation failed for an unexpected reason\n' \
+          "$context" "$failure_mode" >&2
+        return 1
+      }
+    done
+  done
+  printf 'PASS: dead propagation branches are killed for all three release-wrapper contexts\n'
+)
+
+[[ -x "$CHECKER" ]] || fail "release selector execution checker is missing or not executable"
+
+run_capture_terminal_lab_finalizer_oracle \
+  "$ROOT_DIR/scripts/capture-terminal-lab.sh" 0 live-success ||
+  fail "the live terminal-lab finalizer did not execute a successful fake checker"
+run_capture_terminal_lab_finalizer_oracle \
+  "$ROOT_DIR/scripts/capture-terminal-lab.sh" 17 live-failure ||
+  fail "the live terminal-lab finalizer did not propagate a failing checker result"
+capture_terminal_lab_live_checker_mutation_is_rejected ||
+  fail "the live terminal-lab checker dead/true mutation was accepted"
+printf 'PASS: live terminal-lab checker invocation, result propagation, and mutation rejection\n'
+RELEASE_TERMINAL_GATE="$ROOT_DIR/scripts/release-terminal-gate.sh"
+RELEASE_EMULATOR_VALIDATION="$ROOT_DIR/scripts/release-emulator-validation.sh"
+run_release_selector_context_matrix ||
+  fail "a release-wrapper attendance/checker failure was swallowed in a production-shaped context"
+release_wrapper_propagation_mutation_is_rejected ||
+  fail "the release-wrapper propagation mutation was not killed"
+
+release_selector_gates=(
+  scripts/pre-release-confidence-gate.sh
+  scripts/release-emulator-validation.sh
+  scripts/release-terminal-gate.sh
+  scripts/capture-terminal-lab.sh
+  scripts/capture-walkthrough-screenshots.sh
+  scripts/phone-walkthrough.sh
+  scripts/terminal-workbench.sh
+  scripts/tmux-attach-prefill.sh
+  scripts/reconnect-app-switch.sh
+  scripts/keyboard-stress.sh
+  scripts/issue78-phone-walkthrough.sh
+  scripts/tmux-issue303-toolbar-proof.sh
+)
+for gate in "${release_selector_gates[@]}"; do
+  [[ -f "$ROOT_DIR/$gate" ]] || fail "release selector gate is missing: $gate"
+  grep -Fq 'scripts/lib/instrumentation-evidence.sh' "$ROOT_DIR/$gate" ||
+    fail "$gate does not source the shared instrumentation evidence helper"
+  grep -Fq 'pocketshell_instrumentation_assert_log' "$ROOT_DIR/$gate" ||
+    fail "$gate has no exact positive selector assertion"
+  # This is only a wiring inventory. Semantic checker invocation and result
+  # propagation are exercised through the executable capture finalizer oracle
+  # below, rather than by looking for a checker pathname in source text.
+  grep -Fq 'pocketshell_run_release_selector_checker' "$ROOT_DIR/$gate" ||
+    fail "$gate does not route current-run attendance through the shared checker wrapper"
+  if grep -Fq 'grep -q "OK ("' "$ROOT_DIR/$gate" ||
+    grep -Fq "grep -q 'OK ('" "$ROOT_DIR/$gate"; then
+    fail "$gate still accepts a broad OK summary instead of the shared positive-count parser"
+  fi
+done
+
+# The two-phase process-boundary harness is intentionally nightly-only; its
+# exact one-test assertion is covered by its own self-test and documented in
+# the harness rather than being treated as a release-selector ledger.
+grep -Fq 'nightly process-boundary harness' "$ROOT_DIR/scripts/two-phase-android-instrumentation.sh" ||
+  fail "nightly-only two-phase harness lost its non-release-selector declaration"
+
+selector="com.example.FakeTest#removedAnnotation"
+class_file="$FIXTURE_ROOT/app/src/androidTest/java/com/example/FakeTest.kt"
+zero_log="$FIXTURE_ROOT/zero-tests.log"
+positive_log="$FIXTURE_ROOT/positive-tests.log"
+selected_file="$FIXTURE_ROOT/selected.txt"
+attendance_file="$FIXTURE_ROOT/selector-attendance.tsv"
+marker="$FIXTURE_ROOT/run-start.marker"
+mkdir -p "$(dirname "$class_file")"
+
+printf 'package com.example\nclass FakeTest {\n    fun removedAnnotation() {}\n}\n' > "$class_file"
+printf '%s\n' "$selector" > "$selected_file"
+printf '%s\n' \
+  'INSTRUMENTATION_STATUS: class=com.example.FakeTest' \
+  'INSTRUMENTATION_STATUS: test=removedAnnotation' \
+  'INSTRUMENTATION_STATUS_CODE: 0' \
+  'INSTRUMENTATION_CODE: -1' \
+  'OK (0 tests)' > "$zero_log"
+
+if "$CHECKER" --verify-log --selector "$selector" --log "$zero_log"; then
+  fail "OK (0 tests) was accepted as executed selector proof"
+fi
+
+source_guard_rejects_unannotated_method() (
+  fail() { exit 1; }
+  eval "$(sed -n '/^androidtest_method_is_annotated_test()/,/^}/p' "$PRE_RELEASE_GATE"; sed -n '/^assert_app_walkthrough_selectors_exist()/,/^}/p' "$PRE_RELEASE_GATE")"
+  ROOT_DIR="$FIXTURE_ROOT"
+  APP_WALKTHROUGH_TESTS=("$selector")
+  assert_app_walkthrough_selectors_exist >/dev/null 2>&1
+)
+if source_guard_rejects_unannotated_method; then
+  fail "a method with its @Test annotation removed was accepted by the selector guard"
+fi
+
+source_guard_accepts_real_annotation() (
+  fail() { exit 1; }
+  eval "$(sed -n '/^androidtest_method_is_annotated_test()/,/^}/p' "$PRE_RELEASE_GATE"; sed -n '/^assert_app_walkthrough_selectors_exist()/,/^}/p' "$PRE_RELEASE_GATE")"
+  printf 'package com.example\nclass FakeTest {\n    @Test\n    fun removedAnnotation() {}\n}\n' > "$class_file"
+  ROOT_DIR="$FIXTURE_ROOT"
+  APP_WALKTHROUGH_TESTS=("$selector")
+  assert_app_walkthrough_selectors_exist >/dev/null 2>&1
+)
+source_guard_accepts_real_annotation ||
+  fail "a runnable @Test method was rejected by the selector guard"
+
+source_guard_rejects_false_positive_annotation() (
+  local gate_file="$PRE_RELEASE_GATE"
+  local shape
+  if [[ "$#" -eq 1 ]]; then
+    shape="$1"
+  else
+    gate_file="$1"
+    shape="$2"
+  fi
+  fail() { exit 1; }
+  eval "$(sed -n '/^androidtest_method_is_annotated_test()/,/^}/p' "$gate_file"; sed -n '/^assert_app_walkthrough_selectors_exist()/,/^}/p' "$gate_file")"
+  case "$shape" in
+    block-comment)
+      printf 'package com.example\nclass FakeTest {\n    /*\n       @Test\n    */\n    fun removedAnnotation() {}\n}\n' > "$class_file"
+      ;;
+    line-comment)
+      printf 'package com.example\nclass FakeTest {\n    // @Test\n    fun removedAnnotation() {}\n}\n' > "$class_file"
+      ;;
+    string-literal)
+      printf 'package com.example\nclass FakeTest {\n    val annotationText = "@Test "\n    fun removedAnnotation() {}\n}\n' > "$class_file"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  ROOT_DIR="$FIXTURE_ROOT"
+  APP_WALKTHROUGH_TESTS=("$selector")
+  assert_app_walkthrough_selectors_exist >/dev/null 2>&1
+)
+for false_positive_shape in block-comment line-comment string-literal; do
+  if source_guard_rejects_false_positive_annotation "$false_positive_shape"; then
+    fail "$false_positive_shape containing @Test was accepted by the selector guard"
+  fi
+  printf 'PASS: selector guard rejects @Test in %s\n' "$false_positive_shape"
+done
+
+parser_false_positive_mutation_is_killed() (
+  local shape="$1"
+  local mutant_gate="$FIXTURE_ROOT/pre-release-parser-$shape-mutant.sh"
+  awk '
+    /^androidtest_method_is_annotated_test\(\)/ {
+      print "androidtest_method_is_annotated_test() {"
+      print "  local source_file=\"$1\""
+      print "  local method=\"$2\""
+      print "  grep -q \047@Test\047 \"$source_file\" &&"
+      print "    grep -Eq \"fun[[:space:]]+${method}[[:space:]]*\\\\(\" \"$source_file\""
+      print "}"
+      replacing = 1
+      next
+    }
+    replacing && /^}$/ {
+      replacing = 0
+      next
+    }
+    !replacing { print }
+  ' "$PRE_RELEASE_GATE" > "$mutant_gate"
+  [[ -s "$mutant_gate" ]] || return 1
+  grep -Fq "grep -q '@Test'" "$mutant_gate" || return 1
+  source_guard_rejects_false_positive_annotation "$mutant_gate" "$shape"
+)
+
+for false_positive_shape in block-comment line-comment string-literal; do
+  if ! parser_false_positive_mutation_is_killed "$false_positive_shape"; then
+    fail "the parser mutation for $false_positive_shape survived the false-positive assertion"
+  fi
+  printf 'PASS: parser mutation for %s is killed by the lexical source guard\n' "$false_positive_shape"
+done
+
+touch "$marker"
+sleep 0.02
+printf '%s\n' \
+  'INSTRUMENTATION_STATUS: class=com.example.FakeTest' \
+  'INSTRUMENTATION_STATUS: test=removedAnnotation' \
+  'INSTRUMENTATION_STATUS_CODE: 0' \
+  'INSTRUMENTATION_CODE: -1' \
+  'OK (1 test)' > "$positive_log"
+digest="$(sha256sum "$positive_log" | awk '{print $1}')"
+{
+  printf '%s\n' '# pocketshell-release-selector-attendance v1'
+  printf 'run_id\t%s\n' current-run
+  printf 'selector\t%s\t1\t%s\t%s\n' "$selector" "$positive_log" "$digest"
+} > "$attendance_file"
+
+"$CHECKER" --verify-log --selector "$selector" --log "$positive_log"
+"$CHECKER" --verify-attendance \
+  --selected-file "$selected_file" \
+  --attendance "$attendance_file" \
+  --run-id current-run \
+  --newer-than "$marker"
+
+checker_probe="$FIXTURE_ROOT/checker-result-probe.sh"
+checker_probe_marker="$FIXTURE_ROOT/checker-result-probe.invoked"
+cat > "$checker_probe" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' invoked > "$1"
+exit 17
+EOF
+chmod +x "$checker_probe"
+if pocketshell_run_release_selector_checker "$checker_probe" "$checker_probe_marker" --verify-attendance; then
+  fail "checker wrapper accepted a failing live checker result"
+fi
+grep -Fqx invoked "$checker_probe_marker" ||
+  fail "checker wrapper did not execute the live checker command"
+printf 'PASS: current-run attendance checker execution and result are load-bearing\n'
+
+stale_marker="$FIXTURE_ROOT/stale-run-start.marker"
+touch "$stale_marker"
+sleep 0.02
+stale_log="$FIXTURE_ROOT/stale-run-positive.log"
+printf '%s\n' \
+  'INSTRUMENTATION_STATUS: class=com.example.FakeTest' \
+  'INSTRUMENTATION_STATUS: test=removedAnnotation' \
+  'INSTRUMENTATION_STATUS_CODE: 0' \
+  'INSTRUMENTATION_CODE: -1' \
+  'OK (1 test)' > "$stale_log"
+stale_digest="$(sha256sum "$stale_log" | awk '{print $1}')"
+stale_attendance="$FIXTURE_ROOT/stale-selector-attendance.tsv"
+{
+  printf '%s\n' '# pocketshell-release-selector-attendance v1'
+  printf 'run_id\t%s\n' old-run
+  printf 'selector\t%s\t1\t%s\t%s\n' "$selector" "$stale_log" "$stale_digest"
+} > "$stale_attendance"
+if "$CHECKER" --verify-attendance \
+  --selected-file "$selected_file" \
+  --attendance "$stale_attendance" \
+  --run-id current-run \
+  --newer-than "$stale_marker"; then
+  fail "a stale selector attendance record was accepted for the current run"
+fi
+
+printf '%s\n' \
+  'INSTRUMENTATION_STATUS: class=com.example.FakeTest' \
+  'INSTRUMENTATION_STATUS: test=removedAnnotation' \
+  'INSTRUMENTATION_STATUS_CODE: 0' \
+  'INSTRUMENTATION_CODE: -1' \
+  'OK (1 test)' > "$stale_log"
+stale_current_marker="$FIXTURE_ROOT/stale-current-run-start.marker"
+touch "$stale_current_marker"
+stale_current_digest="$(sha256sum "$stale_log" | awk '{print $1}')"
+stale_current_attendance="$FIXTURE_ROOT/stale-current-run-attendance.tsv"
+{
+  printf '%s\n' '# pocketshell-release-selector-attendance v1'
+  printf 'run_id\t%s\n' current-run
+  printf 'selector\t%s\t1\t%s\t%s\n' "$selector" "$stale_log" "$stale_current_digest"
+} > "$stale_current_attendance"
+if "$CHECKER" --verify-attendance \
+  --selected-file "$selected_file" \
+  --attendance "$stale_current_attendance" \
+  --run-id current-run \
+  --newer-than "$stale_current_marker"; then
+  fail "a pre-marker raw selector log was accepted for the current run"
+fi
+
+printf 'PASS: release selector execution proof and current-run attendance contract\n'

--- a/tests/scripts/terminal-workbench-retry-test.sh
+++ b/tests/scripts/terminal-workbench-retry-test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2

--- a/tests/scripts/walkthrough-visual-retry-test.sh
+++ b/tests/scripts/walkthrough-visual-retry-test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/instrumentation-evidence.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2


### PR DESCRIPTION
Closes #2300

Propagates release-selector attendance-record and checker failures through all three release-wrapper contexts, with regression coverage for the real if ! / set +e call shapes.

Reviewer approval: https://github.com/alexeygrigorev/pocketshell/issues/2300#issuecomment-5447938989