### PR TITLE
Remove the NIGHTLY_FAULT_GATE_DISABLED release-gate escape hatch (D37)

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -548,9 +548,10 @@ jobs:
               echo "not complete — most likely genuine nightly-infra breakage such as"
               echo "an emulator boot / Docker-fixture failure). There is NO fault"
               echo "signal to release on. Investigate the shard-0 logs; if it is"
-              echo "genuine infra breakage, re-run the nightly, or use the #1056"
-              echo "escape hatch (NIGHTLY_FAULT_GATE_DISABLED=1) for a deliberately"
-              echo "infra-waived release."
+              echo "genuine infra breakage, re-run the nightly. There is no"
+              echo "release-side waiver for a missing verdict (D37, issue #2379):"
+              echo "fix the failure, or quarantine the offending class through the"
+              echo "D36(4) flake mechanism."
             } | tee -a "$GITHUB_STEP_SUMMARY"
             exit 1
           fi

--- a/.github/workflows/release-emulator-validation.yml
+++ b/.github/workflows/release-emulator-validation.yml
@@ -12,14 +12,13 @@ on:
         required: false
         default: false
         type: boolean
-      disable_nightly_fault_gate:
-        description: >-
-          Waive the nightly-fault release guard (issue #851) for a deliberately
-          fault-suite-waived release, e.g. when Nightly Extensive itself is
-          broken by infra (issue #1056). Off by default.
-        required: false
-        default: false
-        type: boolean
+      # Issue #2379 / decision D37: there is deliberately NO input here that
+      # waives the nightly-fault release guard. A red / stale / cancelled /
+      # missing fault-injection safety verdict on the release commit blocks the
+      # gate, full stop — fix the failing test/journey, or quarantine that class
+      # through the D36(4) flake mechanism. Re-adding one fails
+      # scripts/check-release-gate-bypass-absent.sh in the Unit lane.
+
   # Issue #2356 (Phase 4 of epic #2350): the "validated RC" nightly trigger.
   # Rather than a SEPARATE `schedule:` cron re-deriving "the newest main SHA
   # with a green Phase-1 scheduled full-suite run" from scratch (a second
@@ -216,10 +215,6 @@ jobs:
           EMULATOR: ${{ env.ANDROID_SDK }}/emulator/emulator
           RELEASE_VALIDATION_SKIP_MAIN_GUARD: ${{ env.RELEASE_VALIDATION_SKIP_MAIN_GUARD }}
           TERMINAL_RELEASE_GATE: ${{ inputs.terminal_release_gate && '1' || '0' }}
-          # Issue #1056: allow waiving the nightly-fault guard when Nightly
-          # Extensive is broken by infra. Off by default (normal releases gate
-          # on a clean Nightly).
-          NIGHTLY_FAULT_GATE_DISABLED: ${{ inputs.disable_nightly_fault_gate && '1' || '0' }}
           # Issue #851: `gh` auth for the nightly-fault release guard.
           GH_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -386,6 +386,18 @@ jobs:
           scripts/check-release-gate-execution-profile.sh --self-test
           scripts/check-release-gate-execution-profile.sh
 
+      # Issue #2379 / decision D37: the nightly fault-injection release gate has
+      # no off switch — not the deleted names (C1/C2/C3), and nothing injectable
+      # through the environment on the release path (C4). Waiving it was routine
+      # (v0.4.31-v0.4.38, v0.4.45) and #1671 traced the #1610 reconnect storm
+      # reaching the maintainer to exactly that. Rationale: the script header
+      # and docs/release.md; don't restate it here.
+      - name: "Release-gate bypass guard (issue #2379, D37)"
+        run: |
+          chmod +x scripts/check-release-gate-bypass-absent.sh
+          scripts/check-release-gate-bypass-absent.sh --self-test
+          scripts/check-release-gate-bypass-absent.sh
+
       # Issue #2064: fail-closed proofs for one gate-built APK pair, exact-SHA
       # sharded CI evidence reuse, and measured/provenance-rich summaries.
       - name: Release identity and evidence guards (issue #2064)

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,6 +13,65 @@ checkout on `main` whose `HEAD` already equals `origin/main` — it does not
 accept a release-branch worktree, so tagging always happens after that
 branch's SHA has reached `main`, never before.
 
+## The nightly fault gate blocks the tag, full stop (D37)
+
+`scripts/release-emulator-validation.sh` runs
+`scripts/check-nightly-fault-run.sh` as its first required step. That guard
+reads the `Fault-injection safety verdict` job of the latest
+`Nightly Extensive Tests` run — the toxiproxy network-fault proofs plus the
+bootstrap setup-scenario matrix, with the flaky journey suite and the #822
+expected-fail lane excluded. It BLOCKS when that verdict is red, cancelled,
+stale (the run tested a line that does not contain the release HEAD), or
+missing.
+
+**Nothing you can put in the environment changes that verdict.** No
+environment variable, no `workflow_dispatch` input, no "deliberately waived
+release" branch — they were removed by decision D37 (`docs/decisions.md`),
+because waiving the gate had become routine: v0.4.31–v0.4.38 and v0.4.45 all
+shipped with the fault verdict un-enforced, and #1671 traced the #1610
+reconnect storm reaching the maintainer to exactly that. A gate the
+release-owner can opt out of is not a gate.
+
+Concretely, `scripts/check-nightly-fault-run.sh` reads *no* environment
+variable. Its offline test knobs (`--fixture`, `--workflow`, `--job-needle`)
+are command-line flags precisely so that an exported variable cannot reach
+them, and `gh` is pinned to this checkout's origin repository with `--repo`
+(with `GH_REPO`/`GH_HOST` scrubbed) so the query cannot be redirected at a
+greener repository. A `--fixture` run prints `[FIXTURE DRY RUN]` on every
+line and is never a release verdict; `scripts/release-emulator-validation.sh`
+passes only `--release-head`, and the per-push guard fails if it ever passes
+anything else.
+
+Be precise about what that does and does not claim: it means no *environment*
+can fabricate a verdict, and no flag exists to skip one. It does not mean the
+script is tamper-proof against someone editing the working tree or
+hand-writing a release summary — nothing enforceable would be. If you find
+yourself wanting to, that is the signal to read the two options below instead.
+
+When the guard blocks, there are exactly two ways forward:
+
+1. **Fix the failing test or journey**, re-run
+   `Nightly Extensive Tests` (`workflow_dispatch`, `force_run=true`) on the
+   release commit, and re-run the release gate once the fault-verdict job is
+   green.
+2. **Quarantine the offending test/journey class** through the existing
+   D36(4) flake mechanism — auto-filed issue, moved into the non-blocking
+   lane, 2-week expiry — so the verdict covers a genuinely smaller but still
+   real suite. Quarantine is a recorded, expiring narrowing of *what* the
+   gate checks; it is never a skip of the whole verdict.
+
+"Nightly Extensive is broken by infra" is not a third option: a missing
+verdict means there is no safety signal to release on, so re-run the nightly
+until there is one. If a release is blocked for longer than that is
+tolerable, the fix belongs in #1671 (make the fault gate reliably green),
+not in a new escape hatch.
+
+`scripts/check-release-gate-bypass-absent.sh` (per push, in the
+`guards-static` job) fails if either deleted bypass name reappears under
+`scripts/`, `.github/workflows/` or `.github/actions/` (C1), if the fault
+guard starts honouring them again (C2/C3), or if a fabricated verdict can be
+injected through the environment or a test-only flag in the release path (C4).
+
 ## Fast path: tag the nightly validated-RC (preferred, check this first)
 
 Issue #2356 (Phase 4 of epic #2350) added a nightly marker: a green
@@ -115,9 +174,15 @@ Green means, for this candidate SHA:
 
 - `scripts/release-emulator-validation.sh` (run from the worktree) wrote a
   summary whose `Commit SHA` is exactly this SHA and `Automated status: PASS`.
+  Its first required step is the nightly fault gate — see
+  [The nightly fault gate blocks the tag, full stop](#the-nightly-fault-gate-blocks-the-tag-full-stop-d37).
+  If you run `scripts/check-nightly-fault-run.sh` by hand, run it with no
+  arguments (or `--release-head <sha>`): a run carrying `[FIXTURE DRY RUN]`
+  came from `--fixture` and is a test dry run, not a release verdict.
 - Visual-audit screenshots were inspected.
 
 Don't fake a PASS. Don't treat a cancelled or in-progress Tests run as green.
+Don't look for a way around the nightly fault gate — there isn't one.
 
 ### 4. Merge the candidate back to `main`
 

--- a/scripts/check-nightly-fault-run.sh
+++ b/scripts/check-nightly-fault-run.sh
@@ -13,19 +13,58 @@ set -euo pipefail
 # bootstrap) with the flaky full journey/E2E suite AND the #822 Slice C/D
 # expected-fail lane (TDD specs for unbuilt features, designed RED). Reading the
 # whole extensive-job conclusion meant the job was essentially never `success`,
-# so every recent release had to WAIVE this gate (NIGHTLY_FAULT_GATE_DISABLED=1)
-# — a permanently-waived gate protects nothing. The suite now emits a
-# machine-readable fault verdict from the network-fault + bootstrap phases ONLY,
-# and the workflow exposes it as a dedicated, NON-continue-on-error
-# `Fault-injection safety verdict` job. This guard reads THAT job's conclusion,
-# so it GREENs when the fault phases passed even though an unrelated journey /
-# expected-fail test is red, and REDs only when a fault phase itself failed (or
-# no verdict was produced — genuine nightly-infra breakage, the #1056 escape
-# hatch case).
+# so every recent release had to WAIVE this gate — a permanently-waived gate
+# protects nothing. The suite now emits a machine-readable fault verdict from
+# the network-fault + bootstrap phases ONLY, and the workflow exposes it as a
+# dedicated, NON-continue-on-error `Fault-injection safety verdict` job. This
+# guard reads THAT job's conclusion, so it GREENs when the fault phases passed
+# even though an unrelated journey / expected-fail test is red, and REDs only
+# when a fault phase itself failed (or no verdict was produced — genuine
+# nightly-infra breakage).
 #
 # This guard makes the release gate FAIL when the latest nightly fault-verdict
 # run is red / cancelled / stale / missing. It is wired as an early required
 # step in scripts/release-emulator-validation.sh.
+#
+# ISSUE #2379 / DECISION D37 — THIS GUARD HAS NO OFF SWITCH.
+# There is deliberately NO environment variable, workflow input, or "deliberately
+# waived release" branch that skips this check. Waiving it was routine
+# (v0.4.31–v0.4.38, v0.4.45 all shipped with the fault verdict un-enforced) and
+# #1671 traced the #1610 reconnect storm reaching the maintainer to exactly that.
+# When this guard BLOCKS, the two sanctioned ways forward are:
+#   (a) fix the failing test/journey, or
+#   (b) quarantine the offending test/journey class through the D36(4) flake
+#       mechanism (auto-filed issue, non-blocking lane, 2-week expiry), so the
+#       verdict covers a genuinely smaller but still-real suite.
+# Never a skip of the whole verdict. Reintroducing a skip flag anywhere under
+# scripts/ or .github/workflows/ fails scripts/check-release-gate-bypass-absent.sh
+# on the next push.
+#
+# ISSUE #2379 ROUND 2 — AND NOTHING IN THE ENVIRONMENT CAN CHANGE THE VERDICT.
+# Deleting the named escape hatch was not enough. This guard used to take
+# NIGHTLY_FAULT_RUN_FIXTURE / _WORKFLOW / _JOB_NEEDLE / _RELEASE_HEAD from the
+# ENVIRONMENT, behind a comment claiming they only selected WHICH run is read.
+# That was false: the fixture does not select a run, it SUPPLIES THE ANSWER.
+#     NIGHTLY_FAULT_RUN_FIXTURE=green.json scripts/check-nightly-fault-run.sh
+#     -> "PASS: nightly fault-injection safety verdict is green ...", exit 0
+# and scripts/release-emulator-validation.sh inherited the caller's environment
+# straight into this script, so one exported variable plus a three-line JSON
+# file wrote a fabricated green into the release summary. That is WORSE than the
+# deleted hatch, which at least printed "SKIPPED: ... escape hatch" — a
+# fabricated fixture makes the release artifact lie about having checked.
+#
+# So: every one of those knobs is now a COMMAND-LINE FLAG and no environment
+# variable is read at all. Environment inheritance cannot set a flag, and the
+# release path passes only --release-head. `gh` is additionally pinned to this
+# checkout's origin repository with --repo and invoked with GH_REPO/GH_HOST
+# scrubbed, so the environment cannot point the query at some other green
+# repository either.
+#
+# Honest scope of that claim: this guard still trusts git, the checkout, and
+# `gh`'s credentials — an actor who can rewrite the working tree does not need a
+# bypass. What it no longer trusts is ANY variable in its environment.
+# scripts/check-release-gate-bypass-absent.sh (C4) asserts exactly this, per
+# push, by driving the guard with a hostile environment.
 #
 # Two layers, kept separate so the decision logic is unit-testable WITHOUT any
 # network/`gh` dependency:
@@ -47,20 +86,35 @@ set -euo pipefail
 # GREENs on a fault-verdict-green run and REDs on a fault-verdict-red run — this
 # is the dry-run rejection proof the issue asks for.
 #
-# Override env (for dry-runs / CI without `gh` creds):
-#   NIGHTLY_FAULT_RUN_FIXTURE   path to a JSON file shaped like one element of
-#                               `gh run list --json ...` PLUS a `jobConclusion`
-#                               field (the fault-verdict-job conclusion). When
-#                               set, the script reads this instead of calling `gh`.
-#   NIGHTLY_FAULT_RELEASE_HEAD  override the release HEAD SHA (default: HEAD).
-#   NIGHTLY_FAULT_WORKFLOW      workflow file (default: nightly-extensive.yml).
-#   NIGHTLY_FAULT_JOB_NEEDLE    substring identifying the fault-verdict job
-#                               (default: "Fault-injection safety verdict").
-#   NIGHTLY_FAULT_GATE_DISABLED=1  skip the guard entirely (escape hatch; the
-#                               release gate prints a loud SKIPPED note).
+# Usage:
+#   check-nightly-fault-run.sh [--release-head <sha>]     # the release path
+#   check-nightly-fault-run.sh --self-test                # offline proof matrix
+#
+# TEST-ONLY flags. They exist so the decision path can be proven offline (no
+# network, no `gh` creds). They are flags, not environment variables, precisely
+# so that no exported variable can reach them, and the release path passes none
+# of them — check-release-gate-bypass-absent.sh C4-static asserts that:
+#   --fixture <path>      read this JSON (one element of `gh run list --json ...`
+#                         PLUS a `jobConclusion` field carrying the fault-verdict
+#                         job's conclusion) instead of calling `gh`. Every line of
+#                         output is then marked "[FIXTURE DRY RUN]", so a fixture
+#                         verdict can never be pasted into, or mistaken for, a
+#                         release summary.
+#   --workflow <file>     workflow file (default: nightly-extensive.yml).
+#   --job-needle <needle> substring identifying the fault-verdict job
+#                         (default: "Fault-injection safety verdict").
+#
+# --release-head <sha> overrides the release HEAD (default: `git rev-parse HEAD`).
 
-WORKFLOW="${NIGHTLY_FAULT_WORKFLOW:-nightly-extensive.yml}"
-JOB_NEEDLE="${NIGHTLY_FAULT_JOB_NEEDLE:-Fault-injection safety verdict}"
+WORKFLOW="nightly-extensive.yml"
+JOB_NEEDLE="Fault-injection safety verdict"
+FIXTURE=""
+RELEASE_HEAD_OVERRIDE=""
+FIXTURE_PREFIX=""
+
+usage() {
+  sed -n '/^# Usage:/,/^# --release-head/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
 
 # ---------------------------------------------------------------------------
 # Layer 1: PURE decision function (no git, no gh, no I/O).
@@ -186,21 +240,32 @@ self_test() {
   # so this exercises exactly what the guard reads on a real run. headSha ==
   # release head so the ancestry short-circuit avoids any git dependency.
   # -------------------------------------------------------------------------
+  # Each case also pins the BLOCK/PASS REASON, not just the exit code: the
+  # round-1 "no verdict" case exited 1 through the STALE branch (the tab-split
+  # bug below) and no assertion noticed, so the branch it claimed to cover was
+  # never executed.
   local self_path="${BASH_SOURCE[0]}"
   fixture_dry_run() {
-    local label="$1" expect_rc="$2" job_conclusion="$3"
+    local label="$1" expect_rc="$2" job_conclusion="$3" reason_needle="$4"
     local sha="cccccccccccccccccccccccccccccccccccccccc"
     local tmp; tmp="$(mktemp)"
     printf '{"status":"completed","jobConclusion":"%s","headSha":"%s","databaseId":424242}\n' \
       "$job_conclusion" "$sha" > "$tmp"
+    # Flags, not environment variables — see the D37 round-2 note in the header.
     set +e
-    out="$(NIGHTLY_FAULT_RUN_FIXTURE="$tmp" NIGHTLY_FAULT_RELEASE_HEAD="$sha" \
-      bash "$self_path" 2>&1)"
+    out="$(bash "$self_path" --fixture "$tmp" --release-head "$sha" 2>&1)"
     rc=$?
     set -e
     rm -f "$tmp"
     if [[ "$rc" != "$expect_rc" ]]; then
       printf 'FAIL [%s]: expected guard rc=%s got rc=%s\n%s\n' "$label" "$expect_rc" "$rc" "$out"
+      failures=$((failures + 1))
+    elif ! printf '%s' "$out" | grep -qF -- "$reason_needle"; then
+      printf 'FAIL [%s]: rc=%s was right but the reason was not "%s"\n%s\n' \
+        "$label" "$rc" "$reason_needle" "$out"
+      failures=$((failures + 1))
+    elif ! printf '%s' "$out" | grep -qF -- "[FIXTURE DRY RUN]"; then
+      printf 'FAIL [%s]: fixture output was not marked as a dry run\n%s\n' "$label" "$out"
       failures=$((failures + 1))
     else
       printf 'ok   [%s] guard rc=%s :: %s\n' "$label" "$rc" "$(printf '%s' "$out" | tail -1)"
@@ -210,10 +275,15 @@ self_test() {
   echo "--- fixture-driven end-to-end guard dry run (issue #1201) ---"
   # Fault phases PASSED (verdict job success) while the extensive shard is red
   # from unrelated journey / #822 flakes -> the guard GREENs (exit 0). This is
-  # the exact case that used to force NIGHTLY_FAULT_GATE_DISABLED=1.
-  fixture_dry_run "fault-verdict-green-shard-red" 0 success
+  # the exact case that used to force a release-wide waiver of the gate.
+  fixture_dry_run "fault-verdict-green-shard-red" 0 success   "safety verdict is green"
   # A fault phase itself FAILED (verdict job failure) -> the guard BLOCKS (exit 1).
-  fixture_dry_run "fault-verdict-red"             1 failure
+  fixture_dry_run "fault-verdict-red"             1 failure   "safety verdict is RED"
+  # The fault-verdict job NEVER RAN (empty conclusion). Issue #2379 round 2: this
+  # must reach the "no fault signal" branch. Before the tab-split fix the empty
+  # middle field shifted headSha into job_conclusion and databaseId into
+  # run_head_sha, so this blocked as STALE with headSha=424242.
+  fixture_dry_run "fault-verdict-missing"         1 ""        "did not run the fault-verdict job"
 
   echo
   if [[ "$failures" -eq 0 ]]; then
@@ -228,32 +298,57 @@ self_test() {
 # Layer 2: fetch + resolve, then call the pure function.
 # ---------------------------------------------------------------------------
 
+# Pin `gh` to THIS checkout's repository (issue #2379 round 2). An unpinned
+# `gh run list` honours the inherited GH_REPO environment variable, which is the
+# same class of bypass as the fixture one: point the guard at a green fork and
+# the release gate reads someone else's verdict. Derived from remote.origin.url;
+# unresolvable means BLOCK, never "query unpinned".
+resolve_repo_slug() {
+  local url name rest owner
+  url="$(git config --get remote.origin.url 2>/dev/null || true)"
+  [[ -n "$url" ]] || return 1
+  url="${url%.git}"
+  url="${url%/}"
+  name="${url##*/}"
+  rest="${url%/*}"
+  owner="${rest##*[:/]}"
+  [[ -n "$owner" && -n "$name" && "$owner" != "$url" ]] || return 1
+  printf '%s/%s\n' "$owner" "$name"
+}
+
 # Resolve the latest nightly run that ACTUALLY ran the fault-verdict job, plus
 # that job's conclusion. Emits four tab-separated fields on stdout:
 #   <run_status>\t<job_conclusion>\t<run_head_sha>\t<databaseId>
 # job_conclusion is "" when no run ran a matching job.
 #
-# Reads NIGHTLY_FAULT_RUN_FIXTURE if set (a JSON object with the run fields PLUS
-# a `jobConclusion` field) — no `gh` call. Otherwise queries `gh`.
+# Reads the --fixture file when one was passed (a JSON object with the run fields
+# PLUS a `jobConclusion` field) — no `gh` call. Otherwise queries `gh`, pinned to
+# this repository and with GH_REPO/GH_HOST scrubbed out of the environment.
 resolve_latest_fault_run() {
-  if [[ -n "${NIGHTLY_FAULT_RUN_FIXTURE:-}" ]]; then
-    [[ -f "$NIGHTLY_FAULT_RUN_FIXTURE" ]] ||
-      { echo "fixture not found: $NIGHTLY_FAULT_RUN_FIXTURE" >&2; return 2; }
+  if [[ -n "$FIXTURE" ]]; then
+    [[ -f "$FIXTURE" ]] ||
+      { echo "fixture not found: $FIXTURE" >&2; return 2; }
     jq -r '[(.status // ""), (.jobConclusion // ""), (.headSha // ""), ((.databaseId // "") | tostring)] | @tsv' \
-      "$NIGHTLY_FAULT_RUN_FIXTURE"
+      "$FIXTURE"
     return 0
   fi
 
   command -v gh >/dev/null 2>&1 || { echo "gh CLI is required" >&2; return 2; }
   command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; return 2; }
 
+  local repo
+  repo="$(resolve_repo_slug)" || {
+    echo "could not derive owner/repo from remote.origin.url — refusing to query gh unpinned (an unpinned query trusts \$GH_REPO)" >&2
+    return 2
+  }
+
   # Pull recent runs. Walk newest→oldest and pick the FIRST whose fault-verdict
   # job exists (i.e. it was not guard-skipped). Guard-skipped runs only have the
   # cheap "Guard" job, so the fault suite never ran — those are not a signal.
   local runs
-  runs="$(gh run list --workflow="$WORKFLOW" --limit 15 \
+  runs="$(env -u GH_REPO -u GH_HOST gh run list --repo "$repo" --workflow="$WORKFLOW" --limit 15 \
     --json databaseId,headSha,status,conclusion,createdAt 2>/dev/null)" || {
-    echo "gh run list failed for workflow '$WORKFLOW'" >&2
+    echo "gh run list failed for workflow '$WORKFLOW' in $repo" >&2
     return 2
   }
 
@@ -267,7 +362,7 @@ resolve_latest_fault_run() {
 
     # Inspect this run's jobs; find the fault-verdict job by name needle.
     local jobs job_conclusion
-    jobs="$(gh run view "$id" --json jobs 2>/dev/null)" || continue
+    jobs="$(env -u GH_REPO -u GH_HOST gh run view --repo "$repo" "$id" --json jobs 2>/dev/null)" || continue
     job_conclusion="$(jq -r --arg needle "$JOB_NEEDLE" \
       'first(.jobs[] | select(.name | test($needle)) | .conclusion) // ""' \
       <<<"$jobs")"
@@ -290,13 +385,35 @@ main() {
     exit $?
   fi
 
-  if [[ "${NIGHTLY_FAULT_GATE_DISABLED:-0}" == "1" ]]; then
-    echo "SKIPPED: nightly-fault release guard disabled via NIGHTLY_FAULT_GATE_DISABLED=1 (escape hatch)."
-    exit 0
+  # D37 (#2379): no skip branch belongs here, and no environment variable is
+  # consulted anywhere in this script. A red / stale / cancelled / missing fault
+  # verdict on the release commit unconditionally fails. An unknown flag is a
+  # hard error rather than a silently-ignored argument (fail closed).
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --release-head) RELEASE_HEAD_OVERRIDE="${2:-}"; shift 2 ;;
+      --fixture)      FIXTURE="${2:-}";               shift 2 ;;
+      --workflow)     WORKFLOW="${2:-}";              shift 2 ;;
+      --job-needle)   JOB_NEEDLE="${2:-}";            shift 2 ;;
+      -h|--help)      usage; exit 0 ;;
+      *)
+        echo "unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  # A fixture run is a DRY RUN, never a release verdict. Mark every line so the
+  # output cannot be pasted into (or mistaken for) a release summary — the round-1
+  # bypass produced a bare "PASS: ... verdict is green" from a fabricated file.
+  if [[ -n "$FIXTURE" ]]; then
+    FIXTURE_PREFIX="[FIXTURE DRY RUN] "
+    echo "${FIXTURE_PREFIX}TEST MODE: reading $FIXTURE instead of the real nightly run. This is NOT a release verdict (D37)."
   fi
 
   local release_head
-  release_head="${NIGHTLY_FAULT_RELEASE_HEAD:-$(git rev-parse HEAD)}"
+  release_head="${RELEASE_HEAD_OVERRIDE:-$(git rev-parse HEAD)}"
 
   local resolved
   resolved="$(resolve_latest_fault_run)" || {
@@ -304,8 +421,23 @@ main() {
     exit 1
   }
 
-  local run_status job_conclusion run_head_sha db_id
-  IFS=$'\t' read -r run_status job_conclusion run_head_sha db_id <<<"$resolved"
+  # Split the four tab-separated fields WITHOUT `IFS=$'\t' read`: tab is IFS
+  # whitespace, so bash collapses a run of delimiters and an empty middle field
+  # shifts every later field left. With an empty jobConclusion (the fault-verdict
+  # job never ran) that put the headSha into job_conclusion and the databaseId
+  # into run_head_sha, and the guard blocked as STALE instead of as "no fault
+  # signal" — right exit code, wrong reason, and a "no-verdict" test that passed
+  # without ever reaching the branch it claimed to cover (issue #2379 round 2).
+  local fields=()
+  mapfile -t fields < <(printf '%s\n' "${resolved//$'\t'/$'\n'}")
+  if [[ "${#fields[@]}" -ne 4 ]]; then
+    echo "${FIXTURE_PREFIX}BLOCK: could not parse the resolved nightly fault run (expected 4 tab-separated fields, got ${#fields[@]})." >&2
+    exit 1
+  fi
+  local run_status="${fields[0]}"
+  local job_conclusion="${fields[1]}"
+  local run_head_sha="${fields[2]}"
+  local db_id="${fields[3]}"
 
   # Does the run COVER the release HEAD? The nightly tested commit
   # `run_head_sha`; its result is valid for the release commit `release_head`
@@ -322,15 +454,15 @@ main() {
     fi
   fi
 
-  echo "Nightly fault run: workflow=$WORKFLOW id=${db_id:-none} status=${run_status:-?} fault-verdict-job-conclusion=${job_conclusion:-<none>} headSha=${run_head_sha:-<none>}"
-  echo "Release HEAD=$release_head head_is_ancestor=$head_is_ancestor"
+  echo "${FIXTURE_PREFIX}Nightly fault run: workflow=$WORKFLOW id=${db_id:-none} status=${run_status:-?} fault-verdict-job-conclusion=${job_conclusion:-<none>} headSha=${run_head_sha:-<none>}"
+  echo "${FIXTURE_PREFIX}Release HEAD=$release_head head_is_ancestor=$head_is_ancestor"
 
   local verdict rc
   set +e
   verdict="$(evaluate_nightly_fault_run "$run_status" "$job_conclusion" "$run_head_sha" "$release_head" "$head_is_ancestor")"
   rc=$?
   set -e
-  echo "$verdict"
+  echo "${FIXTURE_PREFIX}${verdict}"
   exit "$rc"
 }
 

--- a/scripts/check-release-gate-bypass-absent.sh
+++ b/scripts/check-release-gate-bypass-absent.sh
@@ -1,0 +1,650 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-release-gate-bypass-absent.sh — locked decision D37 (issue #2379).
+#
+# WHY THIS EXISTS
+# ---------------
+# The nightly fault-injection safety verdict (toxiproxy network-fault proofs +
+# the bootstrap setup-scenario matrix) is what stands between a release tag and
+# shipping a broken reconnect/transport path. It used to carry an opt-out: an
+# environment variable read by scripts/check-nightly-fault-run.sh, plus a
+# matching workflow_dispatch input on
+# .github/workflows/release-emulator-validation.yml. Whoever cut the release
+# could set it and the guard printed SKIPPED and exited 0.
+#
+# It was not a last-resort lever. v0.4.31-v0.4.38 (and v0.4.45) all shipped with
+# the fault verdict waived; #1671 traced the #1610 reconnect storm reaching the
+# maintainer to exactly that. A gate the release-owner can silently opt out of
+# is not a gate.
+#
+# D37 removes the opt-out entirely rather than discouraging it (D22: hard cut, no
+# flag for the old behaviour). A red, stale, cancelled or missing nightly fault
+# verdict on the release commit unconditionally fails the release gate. The two
+# sanctioned ways to unblock a release are (a) fix the failing test/journey, or
+# (b) quarantine the offending class through the D36(4) flake mechanism
+# (auto-filed issue, non-blocking lane, 2-week expiry) so the gate evaluates a
+# genuinely smaller but still-real suite. Never a skip of the whole verdict.
+#
+# Deleting code is easy to undo. This guard is what makes the deletion durable.
+#
+# WHAT IT CHECKS
+#
+#   C1  STATIC — neither bypass name appears in any git-tracked file under
+#       scripts/, .github/workflows/ or .github/actions/. Comments count: a
+#       comment advertising the escape hatch as available is how the next round
+#       reintroduces it, and a name that exists nowhere cannot be "restored" by
+#       accident. Scope: git-TRACKED files only, so an untracked scratch file in
+#       someone's worktree cannot redden the gate (in CI everything is tracked).
+#
+#   C2  BEHAVIOURAL — scripts/check-nightly-fault-run.sh, driven through its
+#       real fetch+decide path with a RED fault-verdict fixture AND both bypass
+#       names exported to every value that used to mean "skip", still exits
+#       non-zero AND blocks for the RED-verdict reason.
+#
+#   C3  BEHAVIOURAL — the same, with a fixture in which the fault-verdict job
+#       never ran (no signal at all): non-zero AND the missing-signal reason.
+#       Missing is not permission to ship. C2/C3 pin the reason string because
+#       "exited non-zero" alone is satisfied by blocking for an unrelated,
+#       accidental reason — which is exactly what C3 did in round 1.
+#
+#   C4  ENVIRONMENT INJECTION — the class that actually survived round 1. C1/C2/
+#       C3 only speak about two literal names; the bypass that remained had a
+#       different name. check-nightly-fault-run.sh used to read
+#       NIGHTLY_FAULT_RUN_FIXTURE from the ENVIRONMENT, and that variable does
+#       not select which run is read, it SUPPLIES THE ANSWER:
+#         NIGHTLY_FAULT_RUN_FIXTURE=green.json scripts/check-nightly-fault-run.sh
+#         -> "PASS: nightly fault-injection safety verdict is green", exit 0
+#       release-emulator-validation.sh inherited its caller's environment
+#       straight into that call, so one exported variable and a three-line file
+#       put a fabricated green in the release summary — worse than the deleted
+#       hatch, which at least printed SKIPPED. C4 has two halves:
+#         C4-static — the release path's own invocation of the guard passes no
+#                     test-only flag and sets no NIGHTLY_FAULT_* variable (and
+#                     still invokes the guard at all).
+#         C4-probe  — the guard, invoked exactly as the release path invokes it
+#                     but with a hostile environment (a fabricated-green fixture
+#                     under every legacy variable name, a decoy --workflow value,
+#                     and GH_REPO pointing at another repository) and a fake `gh`
+#                     that serves a fabricated GREEN run to any UNPINNED query,
+#                     must exit non-zero and must never print "PASS:".
+#
+# What this guard does NOT claim: it cannot catch an arbitrary future bypass
+# spelled with a brand-new name and wired to a brand-new mechanism. C1 catches
+# the two deleted names, C2/C3 catch a guard that honours them, and C4 catches
+# the whole class of "something in the environment decided the verdict".
+#
+# `--self-test` proves each check can go RED: it scans a fixture tree that does
+# contain the names (C1 must reject it), drives a stub guard that honours the
+# environment variable (C2/C3/C4-probe must reject it), and feeds C4-static a
+# release script that passes --fixture (it must reject that too). No network, no
+# real gh, no Gradle.
+#
+# Runs per push in tests.yml's `guards-static` job.
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SELF_REL="scripts/$(basename -- "${BASH_SOURCE[0]}")"
+
+# The two names D37 deletes. Kept as data so C1 and C2/C3 cannot drift apart:
+# whatever C1 forbids in the tree is exactly what C2/C3 export at the guard.
+BYPASS_NAMES=(
+  "NIGHTLY_FAULT_GATE_DISABLED"
+  "disable_nightly_fault_gate"
+)
+
+# Roots scanned by C1 — everything the release path can execute. docs/ is
+# deliberately NOT scanned, because docs/decisions.md's D37 entry and this file's
+# own header must be able to name what was removed in order to explain it.
+SCAN_ROOTS=(
+  "scripts"
+  ".github/workflows"
+  ".github/actions"
+)
+
+# The release entry point whose invocation of the guard C4-static inspects.
+RELEASE_SCRIPT_REL="scripts/release-emulator-validation.sh"
+
+# Test-only flags of check-nightly-fault-run.sh. None of them may appear in the
+# release path's invocation: they replace the environment variables that used to
+# be injectable, and passing one from the release script would hand the bypass
+# straight back.
+TEST_ONLY_FLAGS=(
+  "--fixture"
+  "--workflow"
+  "--job-needle"
+)
+
+FAILURES=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+# The behavioural checks below all assert "the guard did NOT produce a green".
+# Without jq the guard cannot parse a run at all and exits non-zero for that
+# reason, which would satisfy every one of those assertions vacuously. Fail
+# closed instead of collecting a free pass.
+require_jq() {
+  local label="$1"
+  command -v jq >/dev/null 2>&1 && return 0
+  fail "[$label] jq is not installed, so the guard cannot reach its decide path
+      at all. \"It exited non-zero\" would then be evidence of nothing. Install jq."
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# C1: static scan.
+#
+# scan_tree <listing-mode> <root> [exclude-rel-path]
+#   listing-mode "git"  — git-tracked files under <root> (the real check)
+#   listing-mode "find" — every file under <root> (self-test fixture trees)
+#
+# Prints one "<file>:<line>:<text>" per hit; returns 0 when clean, 1 on a hit.
+# ---------------------------------------------------------------------------
+scan_tree() {
+  local mode="$1" root="$2" exclude="${3:-}"
+  local files=() f hits=0 name
+
+  case "$mode" in
+    git)
+      # `git ls-files` keeps the scan on tracked content only, so a scratch file
+      # or an untracked worktree artifact cannot turn the guard red.
+      while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        [[ -n "$exclude" && "$f" == "$exclude" ]] && continue
+        files+=("$f")
+      done < <(git -C "$root" ls-files -- "${SCAN_ROOTS[@]}" 2>/dev/null)
+      ;;
+    find)
+      while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        f="${f#"$root"/}"
+        [[ -n "$exclude" && "$f" == "$exclude" ]] && continue
+        files+=("$f")
+      done < <(find "$root" -type f 2>/dev/null)
+      ;;
+    *)
+      printf 'scan_tree: unknown listing mode %s\n' "$mode" >&2
+      return 2
+      ;;
+  esac
+
+  for f in "${files[@]}"; do
+    [[ -f "$root/$f" ]] || continue
+    for name in "${BYPASS_NAMES[@]}"; do
+      if grep -Fn -- "$name" "$root/$f" >/dev/null 2>&1; then
+        grep -Fn -- "$name" "$root/$f" | while IFS= read -r line; do
+          printf '%s:%s\n' "$f" "$line"
+        done
+        hits=1
+      fi
+    done
+  done
+
+  [[ "$hits" -eq 0 ]]
+}
+
+check_static() {
+  local out
+  if out="$(scan_tree git "$ROOT_DIR" "$SELF_REL")"; then
+    printf 'ok   [C1 static] neither bypass name appears under %s\n' "${SCAN_ROOTS[*]}"
+    return 0
+  fi
+  printf '%s\n' "$out" >&2
+  fail "D37 bypass name reintroduced in the release path (hits above).
+      The nightly fault-injection verdict is not opt-out-able. To unblock a
+      release: fix the failing test/journey, or quarantine that class through
+      the D36(4) flake mechanism (auto-filed issue, non-blocking lane, 2-week
+      expiry). See docs/decisions.md D37 and docs/release.md."
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# C2/C3: behavioural.
+#
+# assert_guard_blocks <label> <guard-script> <job-conclusion> <reason-needle>
+#   Drives the guard through its real fetch+decide path on a fixture run whose
+#   fault-verdict job concluded <job-conclusion> ("" = the job never ran), with
+#   every bypass name exported to "1". The guard must exit non-zero AND block
+#   for <reason-needle>. Pinning the reason is not pedantry: in round 1 the
+#   no-verdict case blocked as STALE because an empty field collapsed in an
+#   `IFS=$'\t' read`, so the branch this check exists to cover never ran and the
+#   exit-code-only assertion reported `ok`.
+# ---------------------------------------------------------------------------
+assert_guard_blocks() {
+  local label="$1" guard="$2" job_conclusion="$3" reason_needle="$4"
+  local sha="dddddddddddddddddddddddddddddddddddddddd"
+  local tmp rc out env_args=() name
+
+  tmp="$(mktemp)"
+  printf '{"status":"completed","jobConclusion":"%s","headSha":"%s","databaseId":379379}\n' \
+    "$job_conclusion" "$sha" > "$tmp"
+
+  for name in "${BYPASS_NAMES[@]}"; do
+    env_args+=("$name=1")
+  done
+
+  # The fixture arrives as a FLAG (the guard reads no environment variable any
+  # more, C4 below asserts that); the deleted bypass names are still exported,
+  # because that is what C2/C3 are here to prove is ignored.
+  # `|| rc=$?` keeps this errexit-safe without ever toggling `set -e`: a helper
+  # that re-enables errexit on behalf of its caller kills the self-test the first
+  # time a check legitimately returns non-zero.
+  rc=0
+  out="$(env "${env_args[@]}" \
+    bash "$guard" --fixture "$tmp" --release-head "$sha" 2>&1)" || rc=$?
+  rm -f "$tmp"
+
+  if [[ "$rc" -eq 0 ]]; then
+    printf '%s\n' "$out" >&2
+    fail "[$label] $guard exited 0 on a non-green fault verdict while the D37
+      bypass names were set. The release gate is opt-out-able again."
+    return 1
+  fi
+
+  if ! printf '%s' "$out" | grep -qF -- "$reason_needle"; then
+    printf '%s\n' "$out" >&2
+    fail "[$label] $guard exited $rc, but not for the expected reason
+      (\"$reason_needle\"). A guard that blocks by accident is not a guard: this
+      check would keep passing after the branch it covers stopped being reached."
+    return 1
+  fi
+
+  printf 'ok   [%s] guard exited %s for the right reason, every bypass name set\n' "$label" "$rc"
+  return 0
+}
+
+check_behavioural() {
+  local guard="$ROOT_DIR/scripts/check-nightly-fault-run.sh"
+  if [[ ! -f "$guard" ]]; then
+    fail "scripts/check-nightly-fault-run.sh is missing — the release gate has no
+      nightly fault guard to enforce."
+    return 1
+  fi
+  local rc=0
+  require_jq "C2/C3" || return 1
+  assert_guard_blocks "C2 red-verdict" "$guard" "failure" \
+    "safety verdict is RED" || rc=1
+  assert_guard_blocks "C3 no-verdict"  "$guard" "" \
+    "did not run the fault-verdict job" || rc=1
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# C4-static: the release path invokes the guard, and invokes it clean.
+#
+# assert_release_invocation_clean <label> <release-script>
+#   Extracts check_nightly_fault_run()'s body, drops comments, and requires that
+#   it (a) still runs scripts/check-nightly-fault-run.sh, (b) passes no test-only
+#   flag, and (c) sets no NIGHTLY_FAULT_* variable for that call.
+# ---------------------------------------------------------------------------
+assert_release_invocation_clean() {
+  local label="$1" release_script="$2"
+  local body flag
+
+  if [[ ! -f "$release_script" ]]; then
+    fail "[$label] $release_script is missing — cannot verify how the release
+      path invokes the nightly fault guard."
+    return 1
+  fi
+
+  body="$(awk '/^check_nightly_fault_run\(\)[[:space:]]*\{/{f=1} f{print} f&&/^\}/{exit}' \
+    "$release_script" | sed 's/#.*$//')"
+
+  if [[ -z "$body" ]]; then
+    fail "[$label] $release_script has no check_nightly_fault_run() function —
+      the release gate's nightly fault check is gone, not just bypassable."
+    return 1
+  fi
+
+  if ! grep -qF -- "check-nightly-fault-run.sh" <<<"$body"; then
+    fail "[$label] check_nightly_fault_run() no longer invokes
+      scripts/check-nightly-fault-run.sh. The release path lost its fault gate."
+    return 1
+  fi
+
+  for flag in "${TEST_ONLY_FLAGS[@]}"; do
+    if grep -qF -- "$flag" <<<"$body"; then
+      printf '%s\n' "$body" >&2
+      fail "[$label] the release path passes the test-only flag '$flag' to
+        check-nightly-fault-run.sh. Those flags fabricate/redirect the verdict;
+        the release invocation may pass only --release-head."
+      return 1
+    fi
+  done
+
+  if grep -qE 'NIGHTLY_FAULT_[A-Z_]+=' <<<"$body"; then
+    printf '%s\n' "$body" >&2
+    fail "[$label] the release path sets a NIGHTLY_FAULT_* variable around the
+      guard call. The guard reads no environment variable by design (D37); an
+      env prefix here is either dead code or a reintroduced injection point."
+    return 1
+  fi
+
+  printf 'ok   [%s] the release path invokes the guard with no test-only flag or NIGHTLY_FAULT_* env\n' "$label"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# C4-probe: a hostile environment cannot fabricate a green verdict.
+#
+# assert_env_cannot_fabricate_green <label> <guard-script>
+#   Invokes <guard-script> the way release-emulator-validation.sh invokes it
+#   (only --release-head), with:
+#     * a fabricated GREEN run file exported under every legacy variable name,
+#     * NIGHTLY_FAULT_WORKFLOW/_JOB_NEEDLE decoys,
+#     * GH_REPO pointing at another repository,
+#     * a fake `gh` first on PATH that answers an UNPINNED query with a
+#       fabricated GREEN run covering the release HEAD, and a --repo-pinned one
+#       with an empty list.
+#   The guard must exit non-zero, must not print "PASS:", and must not have used
+#   the decoy workflow name. Hermetic: no network, no real gh, no credentials.
+# ---------------------------------------------------------------------------
+assert_env_cannot_fabricate_green() {
+  local label="$1" guard="$2"
+  local sha="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  local tmpdir rc out
+  tmpdir="$(mktemp -d)"
+
+  printf '{"status":"completed","jobConclusion":"success","headSha":"%s","databaseId":379379}\n' \
+    "$sha" > "$tmpdir/fabricated-green.json"
+
+  mkdir -p "$tmpdir/bin"
+  cat > "$tmpdir/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+# Fake gh for the D37 C4 probe. An UNPINNED query (one that trusts \$GH_REPO)
+# gets a fabricated GREEN nightly run; a --repo-pinned query gets nothing.
+pinned=0
+for a in "\$@"; do
+  case "\$a" in --repo|-R|--repo=*) pinned=1 ;; esac
+done
+if [[ "\${1:-}" == "run" && "\${2:-}" == "list" ]]; then
+  if [[ "\$pinned" == 1 ]]; then
+    echo '[]'
+  else
+    printf '[{"databaseId":911,"headSha":"%s","status":"completed","conclusion":"success","createdAt":"2026-01-01T00:00:00Z"}]\n' "$sha"
+  fi
+  exit 0
+fi
+if [[ "\${1:-}" == "run" && "\${2:-}" == "view" ]]; then
+  echo '{"jobs":[{"name":"Fault-injection safety verdict","conclusion":"success"}]}'
+  exit 0
+fi
+echo "fake gh: unexpected invocation: \$*" >&2
+exit 1
+GHEOF
+  chmod +x "$tmpdir/bin/gh"
+
+  rc=0
+  # NIGHTLY_FAULT_RELEASE_HEAD is exported too, so a guard of the ROUND-1 shape
+  # (which read the release head from the environment) would happily agree that
+  # the fabricated run covers the release commit and print its green. Without it
+  # such a guard would block as STALE and this probe would pass vacuously.
+  out="$(PATH="$tmpdir/bin:$PATH" env \
+    NIGHTLY_FAULT_RUN_FIXTURE="$tmpdir/fabricated-green.json" \
+    NIGHTLY_FAULT_RELEASE_HEAD="$sha" \
+    NIGHTLY_FAULT_WORKFLOW="attacker-decoy.yml" \
+    NIGHTLY_FAULT_JOB_NEEDLE="Guard" \
+    GH_REPO="attacker/green-fork" \
+    bash "$guard" --release-head "$sha" 2>&1)" || rc=$?
+
+  local verdict=0
+  if [[ "$rc" -eq 0 ]]; then
+    printf '%s\n' "$out" >&2
+    fail "[$label] $guard exited 0 on a fabricated verdict supplied purely
+      through the environment. This is the round-1 bypass: one exported variable
+      plus a three-line JSON file writes a green into the release summary."
+    verdict=1
+  elif printf '%s' "$out" | grep -qF -- "PASS:"; then
+    printf '%s\n' "$out" >&2
+    fail "[$label] $guard printed a PASS line while being fed a fabricated
+      environment. Even with a non-zero exit, a 'PASS: ... verdict is green'
+      line in the release summary is an artifact that lies."
+    verdict=1
+  elif printf '%s' "$out" | grep -qF -- "attacker-decoy.yml"; then
+    printf '%s\n' "$out" >&2
+    fail "[$label] $guard read its target workflow from the environment
+      (NIGHTLY_FAULT_WORKFLOW). Redirecting the guard at a different, green
+      workflow is the same bypass wearing a different name."
+    verdict=1
+  fi
+
+  rm -rf "$tmpdir"
+  if [[ "$verdict" -eq 0 ]]; then
+    printf 'ok   [%s] a hostile environment (fixture + workflow decoy + GH_REPO) produced no green\n' "$label"
+  fi
+  return "$verdict"
+}
+
+check_env_injection() {
+  local guard="$ROOT_DIR/scripts/check-nightly-fault-run.sh"
+  local rc=0
+  assert_release_invocation_clean "C4-static" "$ROOT_DIR/$RELEASE_SCRIPT_REL" || rc=1
+  if [[ ! -f "$guard" ]]; then
+    return 1  # already reported by check_behavioural
+  fi
+  require_jq "C4-probe" || return 1
+  assert_env_cannot_fabricate_green "C4-probe" "$guard" || rc=1
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# --self-test: prove both checks can go RED.
+# ---------------------------------------------------------------------------
+self_test() {
+  local failures=0 tmpdir
+  tmpdir="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmpdir'" RETURN
+
+  # --- C1 can go red: a fixture tree that reintroduces each name. ---
+  local name i=0
+  for name in "${BYPASS_NAMES[@]}"; do
+    i=$((i + 1))
+    local tree="$tmpdir/tree$i"
+    mkdir -p "$tree/scripts" "$tree/.github/workflows"
+    printf '#!/usr/bin/env bash\necho hello\n' > "$tree/scripts/clean.sh"
+    printf 'name: x\n' > "$tree/.github/workflows/clean.yml"
+    printf 'if [[ "${%s:-0}" == "1" ]]; then exit 0; fi\n' "$name" \
+      > "$tree/scripts/reintroduced.sh"
+    if scan_tree find "$tree" >/dev/null 2>&1; then
+      printf 'FAIL [self-test C1/%s]: static scan stayed GREEN over a tree that reintroduces the name\n' "$name"
+      failures=$((failures + 1))
+    else
+      printf 'ok   [self-test C1/%s] static scan reddens on a reintroduced name\n' "$name"
+    fi
+  done
+
+  # --- C1 does not false-alarm on a clean tree. ---
+  local clean="$tmpdir/clean"
+  mkdir -p "$clean/scripts" "$clean/.github/workflows"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$clean/scripts/ok.sh"
+  printf 'name: ok\n' > "$clean/.github/workflows/ok.yml"
+  if scan_tree find "$clean" >/dev/null 2>&1; then
+    printf 'ok   [self-test C1/clean] static scan stays green on a clean tree\n'
+  else
+    printf 'FAIL [self-test C1/clean]: static scan reddened on a tree with neither name\n'
+    failures=$((failures + 1))
+  fi
+
+  # --- C1 excludes only the named path, and does so by exact path. ---
+  local excl="$tmpdir/excl"
+  mkdir -p "$excl/scripts"
+  printf '%s\n' "${BYPASS_NAMES[0]}" > "$excl/scripts/self.sh"
+  if scan_tree find "$excl" "scripts/self.sh" >/dev/null 2>&1; then
+    printf 'ok   [self-test C1/exclude] the guard can exempt its own source\n'
+  else
+    printf 'FAIL [self-test C1/exclude]: exclusion of the guard'"'"'s own source did not apply\n'
+    failures=$((failures + 1))
+  fi
+
+  # --- C2/C3 can go red: a stub guard that DOES honour the bypass variable. ---
+  local stub="$tmpdir/bypassing-guard.sh"
+  cat > "$stub" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${${BYPASS_NAMES[0]}:-0}" == "1" ]]; then
+  echo "SKIPPED: guard disabled (escape hatch)."
+  exit 0
+fi
+echo "BLOCK: fault verdict is not green."
+exit 1
+STUB
+
+  # `expect_red <label> <description> <command...>` runs one assertion helper and
+  # requires it to have reported a failure; `expect_green` the opposite. Both
+  # restore $FAILURES so a deliberate self-test red never leaks into the verdict.
+  expect_red() {
+    local label="$1" what="$2"; shift 2
+    local before="$FAILURES"
+    "$@" >/dev/null 2>&1 || true
+    if [[ "$FAILURES" -gt "$before" ]]; then
+      printf 'ok   [self-test %s] %s\n' "$label" "$what"
+    else
+      printf 'FAIL [self-test %s]: stayed GREEN — %s\n' "$label" "$what"
+      failures=$((failures + 1))
+    fi
+    FAILURES="$before"
+  }
+  expect_green() {
+    local label="$1" what="$2"; shift 2
+    local before="$FAILURES"
+    "$@" >/dev/null 2>&1 || true
+    if [[ "$FAILURES" -eq "$before" ]]; then
+      printf 'ok   [self-test %s] %s\n' "$label" "$what"
+    else
+      printf 'FAIL [self-test %s]: reddened — %s\n' "$label" "$what"
+      failures=$((failures + 1))
+    fi
+    FAILURES="$before"
+  }
+
+  expect_red "C2/stub" "behavioural check reddens on a guard that honours the bypass" \
+    assert_guard_blocks "self-test C2/stub" "$stub" "failure" "BLOCK: fault verdict"
+
+  # --- and stays green on a guard that ignores it entirely. ---
+  local honest="$tmpdir/honest-guard.sh"
+  cat > "$honest" <<'HONEST'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "BLOCK: fault verdict is not green."
+exit 1
+HONEST
+  expect_green "C2/honest" "behavioural check stays green on a non-bypassable guard" \
+    assert_guard_blocks "self-test C2/honest" "$honest" "failure" "BLOCK: fault verdict"
+
+  # --- C2/C3 reject a guard that blocks for the WRONG reason (the round-1 hole:
+  #     the no-verdict case exited 1 through the STALE branch and nobody noticed).
+  local wrongreason="$tmpdir/wrong-reason-guard.sh"
+  cat > "$wrongreason" <<'WRONG'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "BLOCK: something unrelated went wrong."
+exit 1
+WRONG
+  expect_red "C2/wrong-reason" "behavioural check reddens when the block reason is not the expected branch" \
+    assert_guard_blocks "self-test C2/wrong-reason" "$wrongreason" "failure" "BLOCK: fault verdict"
+
+  # --- C4-probe can go red: the ROUND-1 guard shape, which took its answer from
+  #     NIGHTLY_FAULT_RUN_FIXTURE in the environment. ---
+  local envfixture="$tmpdir/env-fixture-guard.sh"
+  cat > "$envfixture" <<'ENVFIX'
+#!/usr/bin/env bash
+set -euo pipefail
+# Round-1 shape: the fixture arrives through the ENVIRONMENT and supplies the answer.
+if [[ -n "${NIGHTLY_FAULT_RUN_FIXTURE:-}" ]]; then
+  echo "PASS: nightly fault-injection safety verdict is green (fault-verdict job conclusion=success)."
+  exit 0
+fi
+echo "BLOCK: no fault signal."
+exit 1
+ENVFIX
+  expect_red "C4-probe/env-fixture" "injection probe reddens on a guard that takes its verdict from the environment" \
+    assert_env_cannot_fabricate_green "self-test C4-probe/env-fixture" "$envfixture"
+
+  # --- and on a guard that trusts GH_REPO (queries `gh` unpinned). ---
+  local unpinned="$tmpdir/unpinned-guard.sh"
+  cat > "$unpinned" <<'UNPINNED'
+#!/usr/bin/env bash
+set -euo pipefail
+runs="$(gh run list --workflow=nightly-extensive.yml --limit 1 --json databaseId,headSha,status)"
+if [[ "$(jq 'length' <<<"$runs")" -gt 0 ]]; then
+  echo "PASS: nightly fault-injection safety verdict is green."
+  exit 0
+fi
+echo "BLOCK: no nightly fault run found."
+exit 1
+UNPINNED
+  expect_red "C4-probe/gh-repo" "injection probe reddens on a guard that queries gh unpinned (trusts \$GH_REPO)" \
+    assert_env_cannot_fabricate_green "self-test C4-probe/gh-repo" "$unpinned"
+
+  expect_green "C4-probe/honest" "injection probe stays green on a guard that reads no environment" \
+    assert_env_cannot_fabricate_green "self-test C4-probe/honest" "$honest"
+
+  # --- C4-static can go red: a release script that passes a test-only flag, one
+  #     that re-adds an env prefix, and one that dropped the guard call. ---
+  local rel_flag="$tmpdir/release-with-flag.sh" rel_env="$tmpdir/release-with-env.sh"
+  local rel_gone="$tmpdir/release-without-guard.sh" rel_ok="$tmpdir/release-clean.sh"
+  cat > "$rel_flag" <<'RELF'
+check_nightly_fault_run() {
+  scripts/check-nightly-fault-run.sh --fixture /tmp/green.json --release-head "$(git rev-parse HEAD)"
+}
+RELF
+  cat > "$rel_env" <<'RELE'
+check_nightly_fault_run() {
+  env NIGHTLY_FAULT_RUN_FIXTURE=/tmp/green.json scripts/check-nightly-fault-run.sh
+}
+RELE
+  cat > "$rel_gone" <<'RELG'
+check_nightly_fault_run() {
+  echo "nothing to see here"
+}
+RELG
+  cat > "$rel_ok" <<'RELOK'
+check_nightly_fault_run() {
+  # --fixture must never appear outside a comment; this line proves comments are stripped.
+  scripts/check-nightly-fault-run.sh --release-head "$(git rev-parse HEAD)"
+}
+RELOK
+  expect_red "C4-static/flag" "release-invocation check reddens on a test-only flag in the release path" \
+    assert_release_invocation_clean "self-test C4-static/flag" "$rel_flag"
+  expect_red "C4-static/env" "release-invocation check reddens on a NIGHTLY_FAULT_* env prefix" \
+    assert_release_invocation_clean "self-test C4-static/env" "$rel_env"
+  expect_red "C4-static/gone" "release-invocation check reddens when the release path stops calling the guard" \
+    assert_release_invocation_clean "self-test C4-static/gone" "$rel_gone"
+  expect_green "C4-static/clean" "release-invocation check stays green on a clean --release-head-only call" \
+    assert_release_invocation_clean "self-test C4-static/clean" "$rel_ok"
+
+  echo
+  if [[ "$failures" -eq 0 ]]; then
+    echo "SELF-TEST PASS: every check in check-release-gate-bypass-absent.sh can go red."
+    return 0
+  fi
+  echo "SELF-TEST FAIL: $failures case(s) wrong."
+  return 1
+}
+
+main() {
+  if [[ "${1:-}" == "--self-test" ]]; then
+    self_test
+    exit $?
+  fi
+
+  echo "D37 release-gate bypass guard (issue #2379)"
+  check_static || true
+  check_behavioural || true
+  check_env_injection || true
+
+  if [[ "$FAILURES" -eq 0 ]]; then
+    # Deliberately specific. The round-1 banner claimed "no bypass path" while a
+    # live environment-injected bypass survived; a guard must claim exactly what
+    # it asserted and nothing more.
+    echo "PASS: the deleted D37 names are absent (C1), the nightly fault guard ignores them (C2/C3), and no environment variable can fabricate its verdict on the release path (C4)."
+    exit 0
+  fi
+  printf 'FAILED: %s check(s) — see above.\n' "$FAILURES" >&2
+  exit 1
+}
+
+main "$@"

--- a/scripts/lib/nightly-fault-verdict.sh
+++ b/scripts/lib/nightly-fault-verdict.sh
@@ -19,8 +19,10 @@
 #
 # Because phase 1's chronic flakes and the #822 expected-fail lane are ALWAYS
 # red, the extensive job conclusion was essentially never `success`, so the
-# release gate had to be waived with NIGHTLY_FAULT_GATE_DISABLED=1 on every
-# recent release — a permanently-waived safety gate protects nothing.
+# release gate had to be waived on every recent release — a permanently-waived
+# safety gate protects nothing. (D37/#2379 has since removed the waiver flag
+# outright: the guard now has no off switch, which is only tenable because the
+# verdict this helper computes is narrow enough to be genuinely achievable.)
 #
 # This helper computes a verdict that reflects ONLY the fault-injection safety
 # phases (network-fault + bootstrap), EXCLUDING the flaky journey suite AND the

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -176,7 +176,8 @@ NETWORK_FAULT_CLASSES=(
 # controller-owned reconnect ladder (Slice C) lands". They are DESIGNED red until
 # those slices land. They are NOT fault-suite regressions, so they must NOT poison
 # the fault-injection safety verdict the release gate reads (that is exactly what
-# forced every recent release to waive the gate with NIGHTLY_FAULT_GATE_DISABLED=1).
+# forced every recent release to waive the gate — a waiver D37/#2379 has since
+# removed, so poisoning the verdict now simply blocks the release).
 #
 # They still RUN nightly (their tracking value — their artifacts/timings are still
 # uploaded and their status is still shown in the summary), but in their OWN phase

--- a/scripts/release-emulator-validation.sh
+++ b/scripts/release-emulator-validation.sh
@@ -106,12 +106,6 @@ Environment overrides:
   RELEASE_VALIDATION_SKIP_MAIN_GUARD=1
       Skip the clean pushed-main guard for CI workflow_dispatch runs where the
       checkout is intentionally detached.
-  NIGHTLY_FAULT_GATE_DISABLED=1
-      Skip the nightly-fault release guard (issue #851). The guard FAILS the
-      release when the latest "Nightly Extensive Tests" fault/bootstrap run is
-      red, cancelled, stale (tested an older sha than the release HEAD), or
-      missing. Use this escape hatch only for a deliberate fault-suite-waived
-      release; the summary records that it was skipped.
   TERMINAL_RELEASE_GATE=1
       Also run the optional high-confidence terminal release gate. This starts
       the real-agent Docker target, SSHes into it from the emulator, drives real
@@ -807,6 +801,11 @@ write_summary_header
 # conclusion. This guard inspects the EXTENSIVE-job conclusion (not the masked
 # workflow conclusion) AND that the run covers the release HEAD, so a stale /
 # cancelled / red fault run blocks the tag instead of silently passing.
+#
+# D37 (#2379): this guard is unconditional. There is no environment variable and
+# no workflow input that skips it — waiving it was routine and is how the #1610
+# reconnect storm shipped. Unblock by fixing the failure, or by quarantining that
+# test/journey class through the D36(4) flake mechanism.
 check_nightly_fault_run() {
   local log_dir="$RUN_DIR/nightly-fault-guard"
   mkdir -p "$log_dir"
@@ -814,9 +813,15 @@ check_nightly_fault_run() {
   printf '\n## Nightly fault/bootstrap run guard (issue #851)\n\n' >> "$SUMMARY_PATH"
   record_artifact "nightly fault guard log" "$log_file"
 
+  # D37 round 2 (#2379): pass ONLY --release-head. The guard's test-only knobs
+  # (--fixture / --workflow / --job-needle) are flags, not environment
+  # variables, exactly so this invocation cannot inherit a fabricated verdict
+  # from whatever the release-owner exported; adding one here — or reviving an
+  # `env NIGHTLY_FAULT_*=` prefix — fails
+  # scripts/check-release-gate-bypass-absent.sh (C4-static) on the next push.
   local rc=0
-  env NIGHTLY_FAULT_RELEASE_HEAD="$(git rev-parse HEAD)" \
-    scripts/check-nightly-fault-run.sh >"$log_file" 2>&1 || rc=$?
+  scripts/check-nightly-fault-run.sh --release-head "$(git rev-parse HEAD)" \
+    >"$log_file" 2>&1 || rc=$?
   cat "$log_file"
 
   {
@@ -827,7 +832,7 @@ check_nightly_fault_run() {
 
   if [[ "$rc" -ne 0 ]]; then
     sed -i 's/^Automated status: RUNNING$/Automated status: FAIL/' "$SUMMARY_PATH"
-    fail "nightly fault/bootstrap run guard BLOCKED the release (see $log_file). Re-run 'Nightly Extensive Tests' (workflow_dispatch, force_run=true) on the release commit and wait for the extensive job to go green, then re-run this gate. Override with NIGHTLY_FAULT_GATE_DISABLED=1 only for a deliberately fault-suite-waived release."
+    fail "nightly fault/bootstrap run guard BLOCKED the release (see $log_file). Re-run 'Nightly Extensive Tests' (workflow_dispatch, force_run=true) on the release commit and wait for the fault-verdict job to go green, then re-run this gate. There is no override (D37): fix the failing test/journey, or quarantine that class through the D36(4) flake mechanism (auto-filed issue, non-blocking lane, 2-week expiry)."
   fi
 }
 


### PR DESCRIPTION
Closes #2379.

Hard cut per locked decision D37 (`docs/decisions.md`) / D22: no code path can bypass the nightly fault-injection safety verdict when tagging a release. v0.4.31-v0.4.38 and v0.4.45 all shipped with this gate waived via `NIGHTLY_FAULT_GATE_DISABLED=1`.

## Changes

- Deleted the `NIGHTLY_FAULT_GATE_DISABLED` skip branch and the `disable_nightly_fault_gate` workflow-dispatch input.
- Round 2 (after round-1 review found a residual bypass): `check-nightly-fault-run.sh`'s env-var overrides (`NIGHTLY_FAULT_RUN_FIXTURE`/`_WORKFLOW`/`_JOB_NEEDLE`) could fabricate a fake green verdict on the real release path — replaced with CLI flags the release path never passes (`release-emulator-validation.sh` now calls it with only `--release-head`). Also pinned `gh` to the real repo to close a `GH_REPO`-redirect variant.
- Added `scripts/check-release-gate-bypass-absent.sh`, wired into the required `Unit tests` job (`guards-static`), so reintroducing any bypass is caught automatically.
- Fixed an unrelated parsing bug in the missing-verdict test path.
- `docs/release.md`: a red nightly fault gate blocks tagging, full stop — the only legitimate outs are fix-forward or D36(4) flake quarantine.

Went through 3 review rounds (round 1: approved the named cut, rejected on the fixture-injection residual; round 2: implementer closed it; round 3: **APPROVED**, adversarially re-verified with 4 independent mutations).

## Follow-ups noted by review (not blocking, filing separately)

- `tests.yml` is within ~153 bytes of the file-size-hygiene guard's ceiling — worth a hygiene issue to split/trim.
- The guard's banner claims "no environment variable can fabricate its verdict," which is true for env vars but not for a `PATH`-substituted fake `gh` binary (tool substitution, judged out of D37's scope) — wording should be tightened.

## Test plan

- [x] Reviewer reproduced round-1's exploit (`NIGHTLY_FAULT_RUN_FIXTURE=fake-green.json` → false `PASS`) and confirmed it's dead post-fix.
- [x] 4 reviewer-run mutations (real base, env-read-only mutant, parsing-bug-restore mutant, `--fixture` on the release path) — each reddens only the load-bearing check, restored cleanly.
- [x] `bash -n` clean on every touched script; `git diff --check` clean.
- [x] Gradle run with `--rerun-tasks`: 199 tasks executed, 14 named guard tests passed (non-vacuous).