### PR TITLE
Fix session-create collision with an existing tmuxctl-managed session

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
@@ -26,6 +26,7 @@ import com.pocketshell.app.projects.SESSION_TYPE_PICKER_SHELL_TAG
 import com.pocketshell.app.projects.SessionCreateOutcome
 import com.pocketshell.app.projects.SessionNamePolicy
 import com.pocketshell.app.projects.SshFolderListGateway
+import com.pocketshell.app.projects.TmuxSocketSweep
 import com.pocketshell.app.proof.DEFAULT_HOST
 import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
@@ -134,6 +135,14 @@ class TmuxInSessionNewSessionCollisionDockerTest {
     private val createdSessions = mutableSetOf<String>()
     private val createdFolders = mutableSetOf<String>()
 
+    /**
+     * Issue #2378: sockets this test started a tmux SERVER on, outside the
+     * default one. They are torn down whole (`kill-server`) — a per-session
+     * server has nothing else on it, and leaving one behind would leak a live
+     * process onto the shared fixture.
+     */
+    private val createdSockets = mutableSetOf<String>()
+
     @After
     fun tearDown() {
         launchedActivity?.close()
@@ -148,14 +157,165 @@ class TmuxInSessionNewSessionCollisionDockerTest {
                     val kill = createdSessions.joinToString("; ") {
                         "tmux kill-session -t '=$it' 2>/dev/null || true"
                     }
+                    val killServers = createdSockets.joinToString("; ") {
+                        "tmux -S '$it' kill-server 2>/dev/null || true; rm -f '$it' || true"
+                    }
                     val rm = createdFolders.joinToString("; ") {
                         "rm -rf '$it' 2>/dev/null || true"
                     }
-                    sshExec("$kill; $rm")
+                    sshExec("$kill; $killServers; $rm")
                 }
             }
         }
     }
+
+    /**
+     * Issue #2378 — a create whose name is already taken by a session on a
+     * DEDICATED tmux socket, against a real tmux over real SSH.
+     *
+     * ## The reported state
+     *
+     * tmuxctl runs one tmux server per session, each on its own
+     * `$TMUX_TMPDIR/tmux-<uid>/tmuxctl-<session>` socket. Everything the create
+     * path asked the host went to the DEFAULT socket, which knows nothing about
+     * those servers, so creating `git-pocketshell` while the maintainer's live
+     * tmuxctl-managed `git-pocketshell` was running produced no disambiguation,
+     * no new session, and a launch that failed with `no server running on
+     * /tmp/tmux-1000/default` while several servers were plainly running.
+     *
+     * ## Why this is here rather than only in a JVM fake
+     *
+     * The fix is a pair of POSIX-sh probes that glob the host's socket
+     * directory and talk to each server with `tmux -S`. Only a real host proves
+     * the glob finds a real per-session socket, that `tmux -S … has-session
+     * -t "=<name>"` answers about THAT server, and that a `tmux -S … send-keys`
+     * reaches a pane the default socket cannot see. The fixture that makes the
+     * bug reachable is created here directly — a second tmux server on its own
+     * socket — instead of depending on the Docker image's tmuxctl stub, which
+     * (like every fixture before this issue) puts everything on the default
+     * socket and therefore cannot reproduce it.
+     *
+     * PRE-FIX: the create resolves the COLLIDING base name, so `<base>` exists
+     * on two sockets at once — the orphan. POST-FIX: `<base>-2`, and the
+     * pre-existing session is untouched.
+     */
+    @Test
+    fun createCollidingWithASessionOnItsOwnSocketDisambiguatesInsteadOfOrphaning() { runBlocking {
+        val key = readFixtureKey()
+        waitForSshFixtureReady(SshKey.Pem(key))
+        val suffix = "issue2378-${System.nanoTime().toString().takeLast(6)}"
+        val folder = "/tmp/$suffix"
+        val baseName = "tmp-$suffix"
+        createdFolders += folder
+        listOf(baseName, "$baseName-2").forEach { createdSessions += it }
+
+        // 1) The fixture: a live session named `<base>` on its OWN socket,
+        //    exactly how tmuxctl runs one — invisible to a bare `tmux`.
+        val socketDir = sshExec("printf '%s' \"\${TMUX_TMPDIR:-/tmp}/tmux-\$(id -u)\"").trim()
+        val dedicatedSocket = "$socketDir/tmuxctl-$baseName"
+        createdSockets += dedicatedSocket
+        sshExec(
+            "mkdir -p '$folder' '$socketDir'; " +
+                "tmux -S '$dedicatedSocket' new-session -d -s '$baseName' -c '$folder' " +
+                "'while true; do sleep 60; done'",
+        )
+        assertEquals(
+            "[host] the seeded session must live on its dedicated socket",
+            listOf(baseName),
+            sessionsOnSocket(dedicatedSocket),
+        )
+        assertFalse(
+            "[host] and must be INVISIBLE to the default socket — otherwise this " +
+                "test is not reproducing the reported state",
+            listSessionsMatching(baseName).contains(baseName),
+        )
+        // Precondition, so a socket-directory mismatch fails by NAME instead of
+        // masquerading as the collision bug: the probe the gateway runs must see
+        // the seeded session on its dedicated socket before the create starts.
+        assertEquals(
+            "[host] the gateway's socket probe must see the seeded session",
+            dedicatedSocket,
+            sshExec(TmuxSocketSweep.sessionSocketCommand("'$baseName'")).trim(),
+        )
+
+        val gateway = SshFolderListGateway()
+        val summary = StringBuilder()
+
+        val resolved = withSshSession { session ->
+            labelled("dedicated-socket-collision-create") {
+                gateway.createSessionOnSession(
+                    session = session,
+                    sessionName = baseName,
+                    cwd = folder,
+                    startCommand = null,
+                    namePolicy = SessionNamePolicy.UniqueOnHost,
+                )
+            }
+        }
+        summary.appendLine("requested=$baseName resolved=$resolved socket=$dedicatedSocket")
+
+        // THE LOAD-BEARING ASSERTION (pre-fix: Created(<base>)).
+        assertEquals(
+            "[host] a name held by a session on another socket must disambiguate",
+            SessionCreateOutcome.Created("$baseName-2"),
+            resolved,
+        )
+        assertEquals(
+            "[host] the pre-existing session must be untouched on its own socket",
+            listOf(baseName),
+            sessionsOnSocket(dedicatedSocket),
+        )
+        val defaultSocketFamily = listSessionsMatching(baseName)
+        summary.appendLine("default_socket_sessions=$defaultSocketFamily")
+        assertFalse(
+            "[host] no same-named orphan may appear on another socket; got $defaultSocketFamily",
+            defaultSocketFamily.contains(baseName),
+        )
+
+        // 2) The launch half's mechanism on the real host: the socket locate
+        //    probe the gateway now runs must find the DEDICATED server, and a
+        //    `tmux -S` send-keys against it must actually reach that pane —
+        //    which the default socket cannot do at all.
+        val located = sshExec(TmuxSocketSweep.sessionSocketCommand("'$baseName'")).trim()
+        summary.appendLine("located=$located")
+        assertEquals(
+            "[host] the locate probe must name the session's own socket",
+            dedicatedSocket,
+            located,
+        )
+        val marker = "issue2378-$suffix-marker"
+        sshExec(
+            "tmux -S '$located' send-keys -t '=$baseName:' \"printf '%s\\n' $marker\" Enter",
+        )
+        SystemClock.sleep(1_000)
+        val pane = sshExec("tmux -S '$located' capture-pane -p -t '=$baseName:' 2>/dev/null || true")
+        summary.appendLine("pane_contains_marker=${pane.contains(marker)}")
+        assertTrue(
+            "[host] the launch must land in the pane on that socket; pane was: $pane",
+            pane.contains(marker),
+        )
+        val defaultSocketProbe = sshExec(
+            "tmux send-keys -t '=$baseName:' 'echo x' Enter 2>&1 || true",
+        )
+        summary.appendLine("default_socket_send_keys=${defaultSocketProbe.trim()}")
+
+        artifactFile("issue2378-socket-collision.txt").writeText(
+            buildString {
+                appendLine("host=$DEFAULT_HOST port=$DEFAULT_PORT user=$DEFAULT_USER")
+                appendLine("folder=$folder")
+                append(summary)
+            },
+        )
+        Log.i(LOG_TAG, "[host] issue2378 socket collision: $summary")
+    } }
+
+    /** Issue #2378: session names on ONE specific tmux socket. */
+    private suspend fun sessionsOnSocket(socket: String): List<String> =
+        sshExec("tmux -S '$socket' list-sessions -F '#{session_name}' 2>/dev/null || true")
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toList()
 
     @Test
     fun inSessionNewSessionInSameFolderGetsSuffixedSessionNotCollisionAllEntryPoints() { runBlocking {

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -1071,15 +1071,10 @@ class SshFolderListGateway internal constructor(
         )
     }
 
-    private fun ExecResult.isTmuxServerAbsent(): Boolean {
-        val output = "$stdout\n$stderr"
-        return output.contains("no server running", ignoreCase = true) ||
-            (
-                output.contains("error connecting to", ignoreCase = true) &&
-                    output.contains("tmux-", ignoreCase = true) &&
-                    output.contains("No such file or directory", ignoreCase = true)
-                )
-    }
+    // Issue #2378: one classifier, shared with the launch path's reason text —
+    // see [TmuxSocketSweep.isServerAbsentOutput].
+    private fun ExecResult.isTmuxServerAbsent(): Boolean =
+        TmuxSocketSweep.isServerAbsentOutput("$stdout\n$stderr")
 
     override suspend fun createSession(
         host: HostEntity,
@@ -1196,13 +1191,30 @@ class SshFolderListGateway internal constructor(
         // (possibly current) pane is exactly the #968-class misroute we refuse, so
         // surface a clear error rather than silently leaking keystrokes. A plain
         // shell/no-launch create keeps its idempotent attach-or-create semantics.
-        if (startCommand != null) {
-            val hasSession = session.execBounded(
+        //
+        // Issue #2378: the guard now asks EVERY tmux socket, not just the
+        // default one — tmuxctl runs one server per session, so a live
+        // same-named session usually sits where a bare `tmux has-session`
+        // cannot see it. See [TmuxSocketSweep].
+        val alreadyLive = when (locateSessionSocket(session, resolvedName)) {
+            is SessionSocket.Located -> true
+            SessionSocket.Absent -> false
+            // Sweep unusable on this host: degrade to the pre-#2378 probe.
+            SessionSocket.Unknown -> session.execBounded(
                 pathAware("tmux has-session -t ${shellQuote(TmuxTarget.session(resolvedName))}"),
-            )
-            if (hasSession.exitCode == 0) {
-                throw RuntimeException(launchTargetCollisionMessage(resolvedName))
-            }
+            ).exitCode == 0
+        }
+        if (startCommand != null && alreadyLive) {
+            throw RuntimeException(launchTargetCollisionMessage(resolvedName))
+        }
+        if (alreadyLive) {
+            // Issue #2378: a no-launch create of an ALREADY live name is the
+            // idempotent attach-or-create case (#642/#429) — answer with the
+            // existing session. Creating anyway targets the DEFAULT socket
+            // (where both the `create-detached` fallback layer and the raw
+            // `new-session -A -d` land) and produces a second, distinct
+            // same-named session on another socket: the reported orphan.
+            return SessionCreateOutcome.Created(resolvedName)
         }
         val createResult = session.execBounded(
             pathAware(cappedCreateSessionCommand(quotedName, quotedCwd)),
@@ -1292,6 +1304,16 @@ class SshFolderListGateway internal constructor(
             if (AgentLaunchVersionCheck.isAgentLaunchCommand(startCommand)) {
                 agentSubcommandUnavailableHint(session)?.let { return it }
             }
+            // Issue #2378: type the launch into the server the session is
+            // ACTUALLY on. A bare `tmux send-keys` talks to the default socket,
+            // while a session created through `tmuxctl create-detached` lives on
+            // its own `tmuxctl-<name>` socket — so the launch failed with
+            // `no server running on /tmp/tmux-1000/default` while the session
+            // sat healthy on another server. The sweep runs AFTER the create
+            // (the socket does not exist before it) and picks the client;
+            // Unknown falls back to the bare pre-#2378 form.
+            val location = locateSessionSocket(session, resolvedName)
+            val tmuxClient = (location as? SessionSocket.Located)?.tmuxClient ?: "tmux"
             // Issue #1820: EXACT pane target. A bare `-t <name>` prefix-matches,
             // so with `<name>-2` alive and `<name>` gone the launch line would be
             // typed into the NEIGHBOUR's pane — the #976 misroute, one line below
@@ -1299,13 +1321,21 @@ class SshFolderListGateway internal constructor(
             // for a pane target (see [TmuxTarget]).
             val sent = session.execBounded(
                 pathAware(
-                    "tmux send-keys -t ${shellQuote(TmuxTarget.pane(resolvedName))} " +
+                    "$tmuxClient send-keys -t ${shellQuote(TmuxTarget.pane(resolvedName))} " +
                         "${shellQuote(startCommand)} Enter",
                 ),
             )
             if (sent.exitCode == 0) return null
-            return sent.stderr.trim().ifBlank { sent.stdout.trim() }
+            val hostReason = sent.stderr.trim().ifBlank { sent.stdout.trim() }
                 .ifBlank { "tmux send-keys exited ${sent.exitCode}" }
+            // Issue #2378: report the REAL cause — when the sweep proved no
+            // socket holds this session, say that, not tmux's misleading
+            // default-socket `no server running`.
+            return if (location is SessionSocket.Absent) {
+                TmuxSocketSweep.launchTargetMissingDetail(resolvedName, hostReason)
+            } else {
+                hostReason
+            }
         } catch (cancellation: CancellationException) {
             throw cancellation
         } catch (error: Throwable) {
@@ -1314,42 +1344,40 @@ class SshFolderListGateway internal constructor(
         }
     }
 
-    /**
-     * Issue #1820: ask the HOST for a free session name, on the very
-     * [session] that is about to create it.
-     *
-     * The whole walk runs remotely in ONE exec, so the client never round-trips
-     * per candidate and the gap between "this name is free" and "create it" is a
-     * single command on one connection, rather than the seconds-wide (and
-     * sometimes simply WRONG) window a UI-cached session list gave us.
-     *
-     * `-t "=<name>"` forces tmux's EXACT session match. Without the `=`, tmux
-     * falls back to prefix and then fnmatch matching, so probing `foo` while
-     * `foo-2` exists answers "taken" — which would make this resolver skip a
-     * genuinely free `foo` (and, in the launch guard above, refuse a launch
-     * outright). The `=` is what makes both checks mean what they read as.
-     *
-     * Fail-safe by design: any non-zero exit or unparseable reply falls back to
-     * the requested base name, i.e. exactly the pre-#1820 behaviour. A create
-     * must never be BLOCKED by the uniqueness probe itself — if the probe cannot
-     * run, the create still runs and reports whatever the host says about it,
-     * and for a LAUNCH the #976 has-session guard still refuses rather than
-     * mistyping into a live pane.
-     */
+    /** Issue #1820/#2378: see [resolveFreeSessionNameOnHost]. */
     private suspend fun resolveFreeSessionName(
         session: SshSession,
         requestedName: String,
-    ): String {
-        val probe = runCatching {
-            session.execBounded(pathAware(freeSessionNameCommand(shellQuote(requestedName))))
-        }.getOrNull() ?: return requestedName
-        if (probe.exitCode != 0) return requestedName
-        return probe.stdout
-            .lineSequence()
-            .map { it.trim() }
-            .lastOrNull { it.isNotEmpty() }
-            ?: requestedName
+    ): String = resolveFreeSessionNameOnHost(
+        requestedName = requestedName,
+        exec = session.boundedExec(),
+        enumeratedNames = { enumeratedSessionNames(session) },
+    )
+
+    /** Issue #2378: the aplexer half of the taken-name union — see above. */
+    private suspend fun enumeratedSessionNames(session: SshSession): Set<String> {
+        val enumerated = try {
+            fetchPocketshellEnumerator(session)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Throwable) {
+            return emptySet()
+        }
+        return enumerated.rows.mapNotNull { it.sessionName.trim().ifBlank { null } }.toSet()
     }
+
+    /** Issue #2378: see [TmuxSocketSweep.locateSession]. */
+    private suspend fun locateSessionSocket(
+        session: SshSession,
+        sessionName: String,
+    ): SessionSocket = TmuxSocketSweep.locateSession(
+        exec = session.boundedExec(),
+        quotedName = shellQuote(sessionName),
+    )
+
+    /** The PATH-aware bounded exec [TmuxSocketSweep] probes run through. */
+    private fun SshSession.boundedExec(): suspend (String) -> ExecResult =
+        { command -> execBounded(pathAware(command)) }
 
     /**
      * Issue #759: pre-flight version guard for an agent launch. Probes the host
@@ -2151,37 +2179,10 @@ class SshFolderListGateway internal constructor(
         internal fun fallbackCreateSessionCommand(quotedName: String, quotedCwd: String): String =
             "tmux new-session -A -d -s $quotedName -c $quotedCwd"
 
-        /**
-         * Issue #1820: the ceiling on the `-2`/`-3`… walk in
-         * [freeSessionNameCommand]. A directory with 200 live sessions is not a
-         * real state; the bound exists only so a pathological host (or a
-         * `has-session` that somehow always answers 0) cannot spin the remote
-         * shell forever. On hitting it the walk returns its last candidate and
-         * the create falls back to its normal idempotent behaviour.
-         */
-        internal const val FREE_SESSION_NAME_MAX_SUFFIX: Int = 200
-
-        /**
-         * Issue #1820: emit the smallest free `<base>`, `<base>-2`, `<base>-3`…
-         * for [quotedBase], evaluated ENTIRELY on the host in one exec.
-         *
-         * `[quotedBase]` must already be shell-quoted by the caller (via
-         * [shellQuote]); it is concatenated with `-$i` in the loop, which is
-         * safe because POSIX sh concatenates adjacent quoted and unquoted words.
-         *
-         * `has-session -t "=$n"` is the EXACT-match form (see
-         * [resolveFreeSessionName] for why the `=` is load-bearing). `2>/dev/null`
-         * keeps "no server running" quiet — with no tmux server nothing is taken,
-         * the loop does not run, and the base name is returned.
-         */
-        internal fun freeSessionNameCommand(quotedBase: String): String =
-            "__ps_n=$quotedBase; __ps_i=2; " +
-                "while tmux has-session -t \"=\$__ps_n\" 2>/dev/null; do " +
-                "if [ \"\$__ps_i\" -gt $FREE_SESSION_NAME_MAX_SUFFIX ]; then break; fi; " +
-                "__ps_n=$quotedBase-\$__ps_i; " +
-                "__ps_i=\$((__ps_i+1)); " +
-                "done; " +
-                "printf '%s\\n' \"\$__ps_n\""
+        // Issue #2378 (hard cut, D22): the host-side `<base>`/`<base>-2`… walk
+        // (`freeSessionNameCommand`, #1820) is GONE — it probed the DEFAULT
+        // socket only, blind to tmuxctl's per-session servers. See
+        // [TmuxSocketSweep] and [resolveFreeSessionName].
 
         const val POCKETSHELL_SESSIONS_COMMAND: String = "pocketshell sessions list --by activity"
         const val POCKETSHELL_SESSIONS_JSON_COMMAND: String = "pocketshell sessions list --json"

--- a/app/src/main/java/com/pocketshell/app/projects/TmuxSocketSweep.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/TmuxSocketSweep.kt
@@ -1,0 +1,313 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.tmux.TmuxRead
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Issue #2378: the host's tmux sessions do NOT all live on one socket, so the
+ * session-create path may not reason about them as if they did.
+ *
+ * ## The state this exists for
+ *
+ * tmuxctl (the host-side session manager PocketShell creates through since
+ * #726) runs **one tmux server per session**, each on its own dedicated socket
+ * `$TMUX_TMPDIR/tmux-<uid>/tmuxctl-<session>`; only legacy/foreign sessions sit
+ * on the literal `default` socket. A bare `tmux has-session` / `tmux
+ * list-sessions` — no `-S` — therefore answers about ONE socket out of many,
+ * and reports a name as free while a live session of exactly that name is
+ * sitting on its own server two socket files away.
+ *
+ * That is what the maintainer hit: creating `git-pocketshell` while a live
+ * tmuxctl-managed `git-pocketshell` already existed on
+ * `/tmp/tmux-1000/tmuxctl-git-pocketshell`. The default-socket probe said
+ * "free", nothing disambiguated the name, `tmuxctl create-detached` no-oped
+ * (it IS cross-socket aware, so it saw the existing session), and the launch's
+ * `tmux send-keys` — default socket again — failed with
+ * `no server running on /tmp/tmux-1000/default` even though a server plainly
+ * existed. One wrong assumption, two user-visible symptoms.
+ *
+ * ## What this object provides
+ *
+ * Two small POSIX-sh probes plus their parsers, so the gateway can ask the host
+ * about **every** socket in one exec each:
+ *
+ *  - [liveSessionNamesCommand] — every live session name on every socket, so
+ *    the `-2`/`-3` disambiguation walk ([nextFreeSessionName]) sees tmuxctl's
+ *    per-session servers, not just the default one.
+ *  - [sessionSocketCommand] — WHICH socket currently holds a given session, so
+ *    a post-create `send-keys` targets the server the session is actually on.
+ *
+ * Both are fail-safe by construction: a host whose shell cannot run them
+ * answers [SessionSocket.Unknown] / an empty name set, and the caller degrades
+ * to exactly the pre-#2378 default-socket behaviour rather than blocking a
+ * create.
+ *
+ * Aplexer-managed sessions are not tmux servers at all, so they are invisible
+ * to both probes; the gateway unions the `pocketshell sessions list`
+ * enumerator (tmuxctl + aplexer) into the taken-name set for that half of the
+ * class.
+ */
+internal object TmuxSocketSweep {
+
+    /**
+     * The ceiling on the `-2`/`-3`… walk in [nextFreeSessionName]. A directory
+     * with 200 live sessions is not a real state; the bound exists only so a
+     * pathological host cannot spin the walk forever. On hitting it the walk
+     * returns the requested base and the create falls back to its normal
+     * idempotent behaviour.
+     */
+    const val MAX_SESSION_NAME_SUFFIX: Int = 200
+
+    /**
+     * Printed by [sessionSocketCommand] when the sweep ran to completion and no
+     * socket holds the session. Distinguishing "swept, genuinely nowhere" from
+     * "could not sweep" is what lets the launch report an accurate reason
+     * instead of the misleading default-socket `no server running`.
+     */
+    const val NO_SOCKET_SENTINEL: String = "-"
+
+    /**
+     * Printed by [sessionSocketCommand] when the session is on the client's
+     * DEFAULT socket, i.e. a bare `tmux` already targets it. Emitted as a token
+     * rather than a path so the caller never has to assume the exec
+     * environment's `TMUX_TMPDIR` resolves the same way tmux's own default does.
+     */
+    const val DEFAULT_SOCKET_TOKEN: String = "default"
+
+    /**
+     * The directory tmux keeps its server sockets in, as a shell expression:
+     * `$TMUX_TMPDIR` when set (tmux's own override), else `/tmp`, then
+     * `tmux-<uid>`. Same rule tmux itself and tmuxctl's `socket_for()` apply,
+     * so the glob below sees exactly the sockets they create.
+     */
+    private const val SOCKET_DIR_EXPR: String = "\"\${TMUX_TMPDIR:-/tmp}/tmux-\$(id -u)\""
+
+    /**
+     * Every live session name on every tmux socket, one per line.
+     *
+     * The glob covers `default` AND every `tmuxctl-<session>` per-session
+     * socket. A stale socket file whose server is gone just prints its error to
+     * `/dev/null` and contributes nothing. The trailing bare `list-sessions` is
+     * belt-and-braces: on a host where the glob resolves to nothing (a
+     * `TMUX_TMPDIR` the exec environment cannot expand, a first-ever server),
+     * the command still returns at least the default socket's names, i.e. never
+     * less than the pre-#2378 answer.
+     *
+     * `exit 0` is deliberate: an empty listing is a valid answer ("no sessions
+     * anywhere"), so the caller distinguishes "ran, nothing taken" from "could
+     * not run" by the exit code rather than by the empty stdout.
+     */
+    fun liveSessionNamesCommand(): String =
+        "for __ps_sock in $SOCKET_DIR_EXPR/*; do " +
+            "[ -S \"\$__ps_sock\" ] || continue; " +
+            "${TmuxRead.CLIENT} -S \"\$__ps_sock\" list-sessions -F '#{session_name}' 2>/dev/null; " +
+            "done; " +
+            "${TmuxRead.CLIENT} list-sessions -F '#{session_name}' 2>/dev/null; " +
+            "exit 0"
+
+    /**
+     * Which socket currently holds [quotedName] (already shell-quoted by the
+     * caller). Prints one line: the socket path, [DEFAULT_SOCKET_TOKEN], or
+     * [NO_SOCKET_SENTINEL].
+     *
+     * Dedicated sockets are probed FIRST and the default one last, mirroring
+     * tmuxctl's own `locate_session()` precedence: when a name exists on both
+     * (the exact orphan state #2378 reports), the session the host's manager
+     * considers authoritative is the one on its dedicated server, and that is
+     * the one a launch must be typed into.
+     *
+     * `-t "=<name>"` is tmux's EXACT session match. Without the `=`, tmux falls
+     * back to prefix then fnmatch matching, so probing `foo` while `foo-2`
+     * exists would answer "taken" and point the launch at the neighbour (#1820).
+     */
+    fun sessionSocketCommand(quotedName: String): String =
+        "__ps_want=$quotedName; " +
+            "for __ps_sock in $SOCKET_DIR_EXPR/*; do " +
+            "case \"\$__ps_sock\" in */$DEFAULT_SOCKET_TOKEN) continue ;; esac; " +
+            "[ -S \"\$__ps_sock\" ] || continue; " +
+            "if tmux -S \"\$__ps_sock\" has-session -t \"=\$__ps_want\" 2>/dev/null; then " +
+            "printf '%s\\n' \"\$__ps_sock\"; exit 0; fi; " +
+            "done; " +
+            "if tmux has-session -t \"=\$__ps_want\" 2>/dev/null; then " +
+            "printf '%s\\n' '$DEFAULT_SOCKET_TOKEN'; exit 0; fi; " +
+            "printf '%s\\n' '$NO_SOCKET_SENTINEL'; exit 0"
+
+    /**
+     * Run [liveSessionNamesCommand] over [exec] and parse it. Best-effort: any
+     * transport/shell failure answers an empty set, which the caller reads as
+     * "nothing known to be taken" and degrades to the requested base name — a
+     * create is never blocked by this probe.
+     *
+     * [exec] must apply the caller's PATH wrapping and bounded-read policy.
+     */
+    suspend fun liveSessionNames(exec: suspend (String) -> ExecResult): Set<String> {
+        val sweep = try {
+            exec(liveSessionNamesCommand())
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Throwable) {
+            return emptySet()
+        }
+        return parseLiveSessionNames(sweep.stdout, sweep.exitCode)
+    }
+
+    /**
+     * Run [sessionSocketCommand] for [quotedName] (already shell-quoted) over
+     * [exec] and parse it. Never throws except on cancellation: an unusable
+     * host answers [SessionSocket.Unknown], never [SessionSocket.Absent], so a
+     * failed sweep can not be mistaken for "the session is gone".
+     */
+    suspend fun locateSession(
+        exec: suspend (String) -> ExecResult,
+        quotedName: String,
+    ): SessionSocket {
+        val probe = try {
+            exec(sessionSocketCommand(quotedName))
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Throwable) {
+            return SessionSocket.Unknown
+        }
+        return parseSessionSocket(probe.stdout, probe.exitCode)
+    }
+
+    /**
+     * True when [output] is a tmux client saying it found no server — either
+     * the plain `no server running on <socket>` or the connect-error form a
+     * stale socket file produces.
+     */
+    fun isServerAbsentOutput(output: String): Boolean =
+        output.contains("no server running", ignoreCase = true) ||
+            (
+                output.contains("error connecting to", ignoreCase = true) &&
+                    output.contains("tmux-", ignoreCase = true) &&
+                    output.contains("No such file or directory", ignoreCase = true)
+                )
+
+    /**
+     * The launch-failure reason for a session the sweep proved is on NO tmux
+     * server on this host.
+     *
+     * tmux's own words for that state — `no server running on
+     * /tmp/tmux-1000/default` — are the misleading half of the #2378 report:
+     * they name one socket out of many and read as "this host has no tmux"
+     * while several servers are running. The host's raw reason is appended only
+     * when it says something else; a server-absent message is dropped rather
+     * than repeated, since it is precisely the sentence that misled.
+     */
+    fun launchTargetMissingDetail(sessionName: String, hostReason: String): String {
+        val detail = "the session “$sessionName” isn't on any tmux server on this host " +
+            "(every tmux socket was checked), so there was nowhere to type the launch"
+        return if (hostReason.isBlank() || isServerAbsentOutput(hostReason)) {
+            detail
+        } else {
+            "$detail; the host said: $hostReason"
+        }
+    }
+
+    /** Parse [liveSessionNamesCommand]'s output into the taken-name set. */
+    fun parseLiveSessionNames(stdout: String, exitCode: Int): Set<String> {
+        if (exitCode != 0) return emptySet()
+        return stdout.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
+
+    /**
+     * Parse [sessionSocketCommand]'s answer. Anything unrecognised — a shell
+     * that could not run the sweep, a login-shell banner, a non-zero exit — is
+     * [SessionSocket.Unknown], which the caller treats as "fall back to the
+     * pre-#2378 default-socket behaviour", never as "the session is missing".
+     */
+    fun parseSessionSocket(stdout: String, exitCode: Int): SessionSocket {
+        if (exitCode != 0) return SessionSocket.Unknown
+        val answer = stdout.lineSequence()
+            .map { it.trim() }
+            .lastOrNull { it.isNotEmpty() }
+            ?: return SessionSocket.Unknown
+        return when {
+            answer == NO_SOCKET_SENTINEL -> SessionSocket.Absent
+            answer == DEFAULT_SOCKET_TOKEN -> SessionSocket.Located(socket = null)
+            answer.startsWith("/") -> SessionSocket.Located(socket = answer)
+            else -> SessionSocket.Unknown
+        }
+    }
+
+    /**
+     * The smallest free name in the `<base>`, `<base>-2`, `<base>-3`… sequence
+     * given the [taken] set — the #1820 disambiguation convention, now decided
+     * against every socket's names rather than one socket's.
+     */
+    fun nextFreeSessionName(base: String, taken: Set<String>): String {
+        if (base !in taken) return base
+        for (suffix in 2..MAX_SESSION_NAME_SUFFIX) {
+            val candidate = "$base-$suffix"
+            if (candidate !in taken) return candidate
+        }
+        return base
+    }
+}
+
+/**
+ * Issue #1820: ask the HOST for a free session name, on the very session that
+ * is about to create it — never from a client-side list, which is seconds stale
+ * and sometimes simply WRONG.
+ *
+ * Issue #2378 (hard cut, D22): the "is this name taken?" question now unions
+ * EVERY session source the host has. The old host-side walk asked a bare
+ * `tmux has-session` — the DEFAULT socket only — and so called
+ * `git-pocketshell` free while the maintainer's live `git-pocketshell` sat on
+ * its own tmuxctl server, skipping the `-2` disambiguation entirely. The two
+ * sources are [TmuxSocketSweep.liveSessionNames] (every socket's tmux
+ * sessions) and [enumeratedNames], the `pocketshell sessions list` enumerator,
+ * which also carries APLEXER rows — not tmux servers at all, so invisible to
+ * the socket sweep.
+ *
+ * The `<base>`/`<base>-2`/`<base>-3`… walk itself is
+ * [TmuxSocketSweep.nextFreeSessionName]; deciding it client-side rather than in
+ * a remote shell loop costs no extra round trip (one exec either way) and makes
+ * the union directly testable.
+ *
+ * Fail-safe by design: when both halves fail the taken set is empty and the
+ * requested base comes back — the pre-#1820 behaviour. A create must never be
+ * BLOCKED by the uniqueness probe itself; for a LAUNCH the #976 collision guard
+ * still refuses rather than mistyping into a live pane.
+ */
+internal suspend fun resolveFreeSessionNameOnHost(
+    requestedName: String,
+    exec: suspend (String) -> ExecResult,
+    enumeratedNames: suspend () -> Set<String>,
+): String {
+    val taken = TmuxSocketSweep.liveSessionNames(exec) + enumeratedNames()
+    if (taken.isEmpty()) return requestedName
+    return TmuxSocketSweep.nextFreeSessionName(requestedName, taken)
+}
+
+/**
+ * Issue #2378: where a tmux session lives, as far as the host can tell.
+ *
+ * The three states are deliberately distinct — collapsing [Absent] and
+ * [Unknown] is the bug this type exists to prevent, because "the sweep found
+ * nothing" and "the sweep could not run" call for opposite behaviour (report an
+ * accurate failure vs. degrade to the legacy default-socket path).
+ */
+internal sealed interface SessionSocket {
+
+    /**
+     * The session is on this server. [socket] is the explicit socket path, or
+     * `null` when it is the client's default socket (a bare `tmux` reaches it).
+     */
+    data class Located(val socket: String?) : SessionSocket {
+        /** `tmux` client prefix that targets exactly this server. */
+        val tmuxClient: String
+            get() = socket?.let { "tmux -S '${it.replace("'", "'\"'\"'")}'" } ?: "tmux"
+    }
+
+    /** The sweep completed and NO socket on the host holds the session. */
+    data object Absent : SessionSocket
+
+    /** The sweep could not run/parse; the caller must not conclude anything. */
+    data object Unknown : SessionSocket
+}

--- a/app/src/test/java/com/pocketshell/app/assistant/AppAssistantActionsTest.kt
+++ b/app/src/test/java/com/pocketshell/app/assistant/AppAssistantActionsTest.kt
@@ -108,8 +108,8 @@ class AppAssistantActionsTest {
      * host that already has [liveSessions]:
      *
      *  - [SessionNamePolicy.UniqueOnHost] → resolve the smallest free
-     *    `<base>`/`<base>-2`/`<base>-3`… (what `freeSessionNameCommand` does on
-     *    the host) and create it.
+     *    `<base>`/`<base>-2`/`<base>-3`… (what the gateway's socket-wide name
+     *    sweep resolves against the host, #1820/#2378) and create it.
      *  - [SessionNamePolicy.ExactName] → use the name verbatim; a LAUNCH
      *    (`startCommand != null`) onto a taken name is refused exactly as the
      *    #976 `has-session` routing guard refuses it, rather than typing into a

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayFallbackTest.kt
@@ -1001,9 +1001,15 @@ class FolderListGatewayFallbackTest {
     @Test
     fun plainRepickWithNoLaunchKeepsIdempotentAttachOrCreate() = runTest {
         // A plain re-pick (no startCommand) must KEEP the idempotent
-        // attach-or-create semantics (#642/#429) — it does NOT probe has-session
-        // and does NOT refuse on an existing name (the collision guard is scoped
-        // to the LAUNCH case only, so the re-pick UX is unchanged).
+        // attach-or-create semantics (#642/#429): it is never REFUSED for an
+        // existing name — the collision guard stays scoped to the LAUNCH case,
+        // so the re-pick UX is unchanged.
+        //
+        // Issue #2378: the re-pick DOES now ask the host which socket holds the
+        // name, because that probe is what stops a same-named orphan being
+        // created on the default socket next to a live tmuxctl session. So the
+        // contract pinned here is "never refuses, still creates", not "never
+        // probes".
         val session = CreateSessionFake(
             results = listOf(
                 CreateSessionFake.Rule(match = "create-detached", result = ok()),
@@ -1011,7 +1017,7 @@ class FolderListGatewayFallbackTest {
         )
         val gateway = SshFolderListGateway()
 
-        gateway.createSessionOnSession(
+        val outcome = gateway.createSessionOnSession(
             session = session,
             sessionName = SESSION_NAME,
             cwd = CWD,
@@ -1019,9 +1025,10 @@ class FolderListGatewayFallbackTest {
             namePolicy = SessionNamePolicy.ExactName,
         )
 
-        assertFalse(
-            "a no-launch re-pick must not probe has-session",
-            session.execCommands.any { it.contains("has-session") },
+        assertEquals(
+            "a no-launch re-pick must succeed, never be refused",
+            SessionCreateOutcome.Created(SESSION_NAME),
+            outcome,
         )
         assertTrue(
             "a no-launch re-pick must still run the idempotent create",
@@ -1049,11 +1056,22 @@ class FolderListGatewayFallbackTest {
         // The host answers the free-name probe with the `-2` variant, i.e. the
         // requested base is already live there. Every downstream step must use
         // THAT name — this is the load-bearing assertion for #1820.
+        // Issue #2378: the host answers the SOCKET SWEEP with the live session
+        // names (here the requested base is already live), and the locate probe
+        // with the Absent sentinel for the resolved `-2` name.
         val session = CreateSessionFake(
             results = listOf(
                 CreateSessionFake.Rule(
-                    match = "__ps_n=",
-                    result = ExecResult(stdout = "$SESSION_NAME-2\n", stderr = "", exitCode = 0),
+                    match = "list-sessions",
+                    result = ExecResult(stdout = "$SESSION_NAME\n", stderr = "", exitCode = 0),
+                ),
+                CreateSessionFake.Rule(
+                    match = "__ps_want=",
+                    result = ExecResult(
+                        stdout = "${TmuxSocketSweep.NO_SOCKET_SENTINEL}\n",
+                        stderr = "",
+                        exitCode = 0,
+                    ),
                 ),
                 CreateSessionFake.Rule(match = "create-detached", result = ok()),
             ),
@@ -1084,13 +1102,27 @@ class FolderListGatewayFallbackTest {
         // host resolving the name, the launch proceeds into the NEW session.
         val session = CreateSessionFake(
             results = listOf(
+                // Issue #2378: `<base>` and `<base>-2` are already live on the
+                // host's sockets, so the walk resolves `-3`.
                 CreateSessionFake.Rule(
-                    match = "__ps_n=",
-                    result = ExecResult(stdout = "$SESSION_NAME-3\n", stderr = "", exitCode = 0),
+                    match = "list-sessions",
+                    result = ExecResult(
+                        stdout = "$SESSION_NAME\n$SESSION_NAME-2\n",
+                        stderr = "",
+                        exitCode = 0,
+                    ),
                 ),
-                // has-session on the RESOLVED name: free, so the #976 guard
-                // passes and the launch is allowed to proceed.
-                CreateSessionFake.Rule(match = "has-session", result = ExecResult("", "", 1)),
+                // The socket locate on the RESOLVED name: on no socket, so the
+                // #976 guard passes and the launch proceeds. The launch then
+                // re-locates it (created on the default socket by the fake).
+                CreateSessionFake.Rule(
+                    match = "__ps_want=",
+                    result = ExecResult(
+                        stdout = "${TmuxSocketSweep.NO_SOCKET_SENTINEL}\n",
+                        stderr = "",
+                        exitCode = 0,
+                    ),
+                ),
                 CreateSessionFake.Rule(match = "agent --help", result = ok()),
                 CreateSessionFake.Rule(match = "create-detached", result = ok()),
                 CreateSessionFake.Rule(match = "send-keys", result = ok()),
@@ -1123,10 +1155,13 @@ class FolderListGatewayFallbackTest {
             "the launch must NOT target the colliding base, got: $sendKeys",
             sendKeys.contains("'=$SESSION_NAME:'"),
         )
-        val guard = session.execCommands.single { it.contains("has-session") && !it.contains("__ps_n=") }
+        // Issue #2378: the #976 guard is now the cross-socket locate probe, and
+        // it must still ask about the RESOLVED name by EXACT match.
+        val guard = session.execCommands.first { it.contains("__ps_want=") }
         assertTrue(
             "the #976 guard must probe the resolved name by EXACT match, got: $guard",
-            guard.contains("'=$SESSION_NAME-3'"),
+            guard.contains("__ps_want=${escapedInWrapper("$SESSION_NAME-3")}") &&
+                guard.contains("has-session -t \"=\$__ps_want\""),
         )
     }
 
@@ -1149,8 +1184,9 @@ class FolderListGatewayFallbackTest {
 
         assertEquals(SessionCreateOutcome.Created(SESSION_NAME), resolved)
         assertFalse(
-            "ExactName must not run the free-name walk",
-            session.execCommands.any { it.contains("__ps_n=") },
+            "ExactName must not run the free-name walk (#2378: the socket-wide " +
+                "name sweep that feeds it)",
+            session.execCommands.any { it.contains("list-sessions") },
         )
     }
 
@@ -1162,7 +1198,7 @@ class FolderListGatewayFallbackTest {
         val session = CreateSessionFake(
             results = listOf(
                 CreateSessionFake.Rule(
-                    match = "__ps_n=",
+                    match = "list-sessions",
                     result = ExecResult(stdout = "", stderr = "tmux: not found", exitCode = 127),
                 ),
                 CreateSessionFake.Rule(match = "create-detached", result = ok()),
@@ -1186,22 +1222,51 @@ class FolderListGatewayFallbackTest {
     }
 
     @Test
-    fun freeSessionNameCommandUsesExactMatchAndABoundedWalk() {
-        // `-t "=$n"` is load-bearing: without the `=`, tmux falls back to prefix
-        // matching, so probing `foo` while only `foo-2` exists answers "taken"
-        // and the walk skips a genuinely free name. The bound stops a
-        // pathological host spinning the remote shell forever.
-        val command = SshFolderListGateway.freeSessionNameCommand("'work session'")
-
-        assertTrue("must exact-match: $command", command.contains("has-session -t \"=\$__ps_n\""))
-        assertTrue("must seed from the quoted base: $command", command.contains("__ps_n='work session'"))
-        assertTrue("must build the suffix from the quoted base: $command", command.contains("__ps_n='work session'-\$__ps_i"))
-        assertTrue("must start at -2: $command", command.contains("__ps_i=2"))
+    fun theSocketSweepCommandsCoverEverySocketAndExactMatchTheName() {
+        // Issue #2378 (replacing #1820's default-socket-only walk): the name
+        // sweep must glob the whole tmux socket directory — tmuxctl's
+        // per-session servers live there, and a bare `tmux` cannot see them —
+        // and the locate probe must exact-match (`=<name>`), or a live
+        // `<base>-2` makes a free `<base>` read as taken (#1820).
+        val names = TmuxSocketSweep.liveSessionNamesCommand()
+        assertTrue("must glob the tmux socket directory: $names", names.contains("tmux-\$(id -u)\"/*"))
+        assertTrue("must skip non-sockets: $names", names.contains("[ -S \"\$__ps_sock\" ]"))
         assertTrue(
-            "must bound the walk: $command",
-            command.contains("-gt ${SshFolderListGateway.FREE_SESSION_NAME_MAX_SUFFIX}"),
+            "must list each socket's sessions: $names",
+            names.contains("-S \"\$__ps_sock\" list-sessions -F '#{session_name}'"),
         )
-        assertTrue("must emit the chosen name: $command", command.contains("printf '%s\\n' \"\$__ps_n\""))
+        assertTrue("an empty host must not fail the probe: $names", names.trimEnd().endsWith("exit 0"))
+
+        val locate = TmuxSocketSweep.sessionSocketCommand("'work session'")
+        assertTrue("must seed from the quoted name: $locate", locate.contains("__ps_want='work session'"))
+        assertTrue("must exact-match: $locate", locate.contains("has-session -t \"=\$__ps_want\""))
+        assertTrue(
+            "dedicated sockets must be probed before the default one: $locate",
+            locate.indexOf("*/default) continue") < locate.indexOf("printf '%s\\n' 'default'"),
+        )
+        assertTrue(
+            "a session on no socket must answer the Absent sentinel: $locate",
+            locate.contains("printf '%s\\n' '${TmuxSocketSweep.NO_SOCKET_SENTINEL}'"),
+        )
+
+        // The `<base>`/`-2`/`-3` walk itself, bounded so a pathological host
+        // cannot spin it forever.
+        assertEquals(
+            "work session-3",
+            TmuxSocketSweep.nextFreeSessionName(
+                "work session",
+                setOf("work session", "work session-2"),
+            ),
+        )
+        assertEquals(
+            "work session",
+            TmuxSocketSweep.nextFreeSessionName(
+                "work session",
+                (1..TmuxSocketSweep.MAX_SESSION_NAME_SUFFIX + 1)
+                    .map { if (it == 1) "work session" else "work session-$it" }
+                    .toSet(),
+            ),
+        )
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/projects/Issue2378CreateSocketCollisionTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/Issue2378CreateSocketCollisionTest.kt
@@ -1,0 +1,487 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #2378 — creating a session whose name is already taken by a
+ * **tmuxctl-managed** session on its own dedicated socket.
+ *
+ * ## The reported state, reproduced
+ *
+ * The maintainer created `git-pocketshell` from the folder tree's New Session
+ * sheet while a live tmuxctl-managed `git-pocketshell` already existed on
+ * `/tmp/tmux-1000/tmuxctl-git-pocketshell`. Everything the create path asked
+ * the host went to the **default** socket, which knew nothing about it:
+ *
+ *  1. the free-name walk called the name free, so nothing disambiguated it;
+ *  2. `tmuxctl create-detached` — which IS cross-socket aware — saw the live
+ *     session and no-oped, so no new session was made;
+ *  3. the launch's `tmux send-keys` (default socket again) failed with
+ *     `no server running on /tmp/tmux-1000/default`, reported to the user as
+ *     "the agent didn't start", while several tmux servers were running.
+ *
+ * ## Why the fixture is the point (G10)
+ *
+ * No existing fixture had a session anywhere but the default socket — the
+ * Docker `agents` stub's `create-detached` is a plain `tmux new-session -A -d`
+ * — so every green create test was run against a host that cannot produce this
+ * bug. [MultiSocketHost] below models the real thing: a socket directory with
+ * several servers, a `create-detached` that is idempotent ACROSS sockets and
+ * creates on its own dedicated one, a raw `new-session -A -d` that only ever
+ * sees the default socket, and a `send-keys` that answers exactly what tmux
+ * answers when it is pointed at a server that is not holding the session.
+ *
+ * Class coverage (G2): tmuxctl-managed AND aplexer-managed collisions, the
+ * capped create AND the raw fallback-layer create, launch AND no-launch
+ * creates, plus the fail-safe host where the socket sweep cannot run at all.
+ */
+class Issue2378CreateSocketCollisionTest {
+
+    @Test
+    fun uniqueOnHostDisambiguatesAgainstATmuxctlSessionOnItsOwnSocket() = runTest {
+        // The maintainer's exact scenario: a live tmuxctl-managed session of the
+        // requested name, on its own dedicated socket, and an agent launch.
+        val host = MultiSocketHost().apply { seedDedicated(BASE) }
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = host,
+            sessionName = BASE,
+            cwd = CWD,
+            startCommand = AGENT_LAUNCH,
+            namePolicy = SessionNamePolicy.UniqueOnHost,
+        )
+
+        // PRE-FIX: LaunchFailed(git-pocketshell, "no server running on
+        // /tmp/tmux-1000/default") — the name was never disambiguated and the
+        // launch was typed at the wrong server.
+        assertEquals(
+            "a name taken by a tmuxctl-managed session must disambiguate to -2",
+            SessionCreateOutcome.Created("$BASE-2"),
+            outcome,
+        )
+        assertEquals(
+            "the pre-existing session must be left alone and NOT duplicated",
+            listOf(host.dedicatedSocket(BASE)),
+            host.socketsHolding(BASE),
+        )
+        assertEquals(
+            "the new session must exist exactly once, on its own dedicated socket",
+            listOf(host.dedicatedSocket("$BASE-2")),
+            host.socketsHolding("$BASE-2"),
+        )
+        assertTrue(
+            "no same-named orphan may appear on the default socket",
+            host.sessionsOn(MultiSocketHost.DEFAULT_SOCKET).isEmpty(),
+        )
+    }
+
+    @Test
+    fun agentLaunchIsTypedIntoTheSocketTheSessionWasActuallyCreatedOn() = runTest {
+        // The second half of the report, isolated: even with NO collision, a
+        // session created through `tmuxctl create-detached` lives on its own
+        // socket, so a default-socket `send-keys` cannot reach it.
+        val host = MultiSocketHost()
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = host,
+            sessionName = BASE,
+            cwd = CWD,
+            startCommand = AGENT_LAUNCH,
+            namePolicy = SessionNamePolicy.UniqueOnHost,
+        )
+
+        // PRE-FIX: LaunchFailed(git-pocketshell, "no server running on
+        // /tmp/tmux-1000/default") on a host where the session was created fine.
+        assertEquals(SessionCreateOutcome.Created(BASE), outcome)
+        assertEquals(
+            "the launch must be delivered into the session's own server",
+            listOf(host.dedicatedSocket(BASE) to AGENT_LAUNCH),
+            host.deliveredKeys,
+        )
+        val sendKeys = host.execCommands.single { it.contains("send-keys") }
+        assertTrue(
+            "send-keys must target the dedicated socket explicitly: $sendKeys",
+            sendKeys.contains("tmux -S ${escapedInWrapper(host.dedicatedSocket(BASE))} send-keys"),
+        )
+    }
+
+    @Test
+    fun rawFallbackCreateNeverOrphansASameNamedSessionOnTheDefaultSocket() = runTest {
+        // Class coverage: the layer-1 fallback host (no tmuxctl / too old). Its
+        // raw `tmux new-session -A -d` only ever sees the DEFAULT socket, so
+        // before the fix it happily made a SECOND `git-pocketshell` there — the
+        // orphan the issue reports, shadowing the real session in every listing.
+        val host = MultiSocketHost(tmuxctlAvailable = false).apply { seedDedicated(BASE) }
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = host,
+            sessionName = BASE,
+            cwd = CWD,
+            startCommand = null,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertEquals(
+            "an ExactName re-pick of a live session is the idempotent attach case",
+            SessionCreateOutcome.Created(BASE),
+            outcome,
+        )
+        assertEquals(
+            "the session must still exist exactly once, on its original socket",
+            listOf(host.dedicatedSocket(BASE)),
+            host.socketsHolding(BASE),
+        )
+        assertFalse(
+            "the raw default-socket create must not run against an already-live name",
+            host.execCommands.any { it.contains("new-session -A -d") },
+        )
+    }
+
+    @Test
+    fun aplexerManagedSessionOfTheSameNameAlsoDisambiguates() = runTest {
+        // Class coverage (G2): aplexer sessions are not tmux servers at all, so
+        // no socket sweep can see them. They still own their name — the union
+        // with the `pocketshell sessions list` enumerator is what covers them.
+        val host = MultiSocketHost().apply { aplexerSessions = listOf(BASE) }
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = host,
+            sessionName = BASE,
+            cwd = CWD,
+            startCommand = null,
+            namePolicy = SessionNamePolicy.UniqueOnHost,
+        )
+
+        assertEquals(
+            "a name owned by an aplexer-managed session must disambiguate too",
+            SessionCreateOutcome.Created("$BASE-2"),
+            outcome,
+        )
+    }
+
+    @Test
+    fun launchCreateOntoALiveTmuxctlSessionIsRefusedNotShadowed() = runTest {
+        // Class coverage: the #976 routing guard, now asked of every socket. An
+        // ExactName LAUNCH at a name a live tmuxctl session owns must be refused
+        // outright — typing the launch line anywhere else is the #968 misroute,
+        // and creating a same-named shadow is the #2378 orphan.
+        val host = MultiSocketHost().apply { seedDedicated(BASE) }
+
+        val failure = runCatching {
+            SshFolderListGateway().createSessionOnSession(
+                session = host,
+                sessionName = BASE,
+                cwd = CWD,
+                startCommand = AGENT_LAUNCH,
+                namePolicy = SessionNamePolicy.ExactName,
+            )
+        }.exceptionOrNull()
+
+        assertTrue("expected a refused launch, got $failure", failure is RuntimeException)
+        assertTrue(
+            "the refusal must name the already-open session: ${failure?.message}",
+            failure?.message.orEmpty().contains(BASE),
+        )
+        assertEquals(
+            "nothing may have been created or typed",
+            emptyList<Pair<String, String>>(),
+            host.deliveredKeys,
+        )
+        assertEquals(listOf(host.dedicatedSocket(BASE)), host.socketsHolding(BASE))
+    }
+
+    @Test
+    fun launchFailureDetailIsAccurateWhenNoServerHoldsTheSession() = runTest {
+        // Issue #2378 acceptance 3: the reason must describe the REAL cause.
+        // Here the create reports success but leaves nothing behind (a create
+        // that raced a server teardown), so the sweep proves the session is on
+        // no socket at all. tmux's own `no server running on <one socket>` is
+        // the misleading sentence and must not be what the user is shown.
+        val host = MultiSocketHost(createSilentlyDoesNothing = true)
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = host,
+            sessionName = BASE,
+            cwd = CWD,
+            startCommand = AGENT_LAUNCH,
+            namePolicy = SessionNamePolicy.ExactName,
+        )
+
+        assertTrue("expected a partial success, got $outcome", outcome is SessionCreateOutcome.LaunchFailed)
+        val detail = (outcome as SessionCreateOutcome.LaunchFailed).detail
+        assertFalse(
+            "the misleading default-socket wording must not be surfaced: $detail",
+            detail.contains("no server running", ignoreCase = true),
+        )
+        assertTrue(
+            "the reason must say the session is on no tmux server: $detail",
+            detail.contains("isn't on any tmux server"),
+        )
+    }
+
+    @Test
+    fun aHostThatCannotRunTheSweepStillCreatesAndLaunches() = runTest {
+        // Fail-safe (the sweep must never BLOCK a create): a host whose shell
+        // rejects the probes degrades to exactly the pre-#2378 default-socket
+        // behaviour rather than refusing, guessing, or reporting a failure.
+        val host = MultiSocketHost(sweepUnavailable = true, tmuxctlAvailable = false)
+
+        val outcome = SshFolderListGateway().createSessionOnSession(
+            session = host,
+            sessionName = BASE,
+            cwd = CWD,
+            startCommand = AGENT_LAUNCH,
+            namePolicy = SessionNamePolicy.UniqueOnHost,
+        )
+
+        assertEquals(SessionCreateOutcome.Created(BASE), outcome)
+        assertEquals(
+            "the launch must still be delivered over the plain default socket",
+            listOf(MultiSocketHost.DEFAULT_SOCKET to AGENT_LAUNCH),
+            host.deliveredKeys,
+        )
+    }
+
+    /**
+     * A fake [SshSession] modelling a host whose tmux sessions are spread over
+     * SEVERAL sockets, the way tmuxctl actually runs them (one server per
+     * session, `…/tmux-<uid>/tmuxctl-<name>`), plus the default socket.
+     *
+     * Behaviour is copied from the real components, including the parts that
+     * make the bug possible:
+     *  - `tmuxctl create-detached` is idempotent ACROSS sockets (it locates the
+     *    session first) and otherwise creates on the session's OWN socket;
+     *  - the raw `tmux new-session -A -d` fallback only ever sees the default
+     *    socket, so it will happily create a same-named twin there;
+     *  - a `tmux` client aimed at a socket with no server answers
+     *    `no server running on <socket>`, and one aimed at a live server that
+     *    lacks the session answers `can't find pane`.
+     */
+    private class MultiSocketHost(
+        private val tmuxctlAvailable: Boolean = true,
+        private val createSilentlyDoesNothing: Boolean = false,
+        private val sweepUnavailable: Boolean = false,
+    ) : SshSession {
+
+        /** socket path -> session names living on that socket's server. */
+        private val servers = linkedMapOf<String, MutableSet<String>>()
+
+        /** Names reported by `pocketshell sessions list --json` as aplexer rows. */
+        var aplexerSessions: List<String> = emptyList()
+
+        val execCommands = mutableListOf<String>()
+
+        /** (socket, keys) actually delivered by a successful `send-keys`. */
+        val deliveredKeys = mutableListOf<Pair<String, String>>()
+
+        fun dedicatedSocket(name: String): String = "$SOCKET_DIR/tmuxctl-$name"
+
+        fun seedDedicated(name: String) {
+            servers.getOrPut(dedicatedSocket(name)) { linkedSetOf() } += name
+        }
+
+        fun sessionsOn(socket: String): Set<String> = servers[socket].orEmpty()
+
+        fun socketsHolding(name: String): List<String> =
+            servers.filterValues { name in it }.keys.toList()
+
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            execCommands += command
+            return when {
+                command.contains("test -d") -> ok()
+                // --- issue #2378 probes -------------------------------------
+                command.contains("__ps_sock") && command.contains("list-sessions") ->
+                    if (sweepUnavailable) shellUnavailable() else namesSweep()
+                command.contains("__ps_want=") ->
+                    if (sweepUnavailable) shellUnavailable() else locateSweep(command)
+                // --- pre-#2378 command shapes, so a base (unfixed) run of this
+                //     test measures BEHAVIOUR rather than an unanswered fake ---
+                command.contains("__ps_n=") -> legacyDefaultSocketNameWalk(command)
+                command.contains("has-session") -> legacyDefaultSocketHasSession(command)
+                // --- create -------------------------------------------------
+                command.contains("create-detached") && command.contains(" -c ") ->
+                    createDetached(command)
+                command.contains("new-session -A -d") -> rawFallbackCreate(command)
+                // --- launch -------------------------------------------------
+                command.contains("pocketshell agent --help") -> ok()
+                command.contains("send-keys") -> sendKeys(command)
+                // --- enumeration --------------------------------------------
+                command.contains(SshFolderListGateway.POCKETSHELL_SESSIONS_JSON_COMMAND) ->
+                    aplexerJson()
+                command.contains(SshFolderListGateway.POCKETSHELL_SESSIONS_COMMAND) ->
+                    ExecResult("", "pocketshell: not found", 127)
+                else -> ExecResult("", "unexpected command: $command", 1)
+            }
+        }
+
+        private fun namesSweep(): ExecResult {
+            // Dedicated servers first, the default socket last — the order the
+            // production glob + trailing bare client produce.
+            val names = servers.entries
+                .sortedBy { it.key == DEFAULT_SOCKET }
+                .flatMap { it.value }
+            return ExecResult(names.joinToString("") { "$it\n" }, "", 0)
+        }
+
+        private fun locateSweep(command: String): ExecResult {
+            val want = quotedArg(command, "__ps_want=") ?: return shellUnavailable()
+            val dedicated = servers.entries
+                .firstOrNull { it.key != DEFAULT_SOCKET && want in it.value }
+            return when {
+                dedicated != null -> ExecResult("${dedicated.key}\n", "", 0)
+                want in sessionsOn(DEFAULT_SOCKET) ->
+                    ExecResult("${TmuxSocketSweep.DEFAULT_SOCKET_TOKEN}\n", "", 0)
+                else -> ExecResult("${TmuxSocketSweep.NO_SOCKET_SENTINEL}\n", "", 0)
+            }
+        }
+
+        private fun legacyDefaultSocketNameWalk(command: String): ExecResult {
+            val base = quotedArg(command, "__ps_n=") ?: return shellUnavailable()
+            var candidate = base
+            var suffix = 2
+            while (candidate in sessionsOn(DEFAULT_SOCKET) && suffix <= 200) {
+                candidate = "$base-$suffix"
+                suffix++
+            }
+            return ExecResult("$candidate\n", "", 0)
+        }
+
+        private fun legacyDefaultSocketHasSession(command: String): ExecResult {
+            val want = quotedArg(command, "has-session -t ")?.removePrefix("=")
+            if (sessionsOn(DEFAULT_SOCKET).isEmpty()) {
+                return ExecResult("", "no server running on $DEFAULT_SOCKET", 1)
+            }
+            return if (want in sessionsOn(DEFAULT_SOCKET)) ok() else ExecResult("", "", 1)
+        }
+
+        private fun createDetached(command: String): ExecResult {
+            if (!tmuxctlAvailable) {
+                return ExecResult("", "", SshFolderListGateway.TMUXCTL_UNSUPPORTED_EXIT_CODE)
+            }
+            // The command carries the capability probe (`create-detached
+            // --help`) BEFORE the real invocation, so match the invocation that
+            // actually carries a quoted name and `-c <cwd>`.
+            val name = Regex("""create-detached '"'"'(.*?)'"'"' -c""")
+                .find(command)?.groupValues?.get(1)
+                ?: return ExecResult("", "no name", 64)
+            if (createSilentlyDoesNothing) return ok()
+            // tmuxctl locates the session across every socket first, so an
+            // existing session anywhere makes this an idempotent no-op.
+            if (socketsHolding(name).isNotEmpty()) return ok()
+            servers.getOrPut(dedicatedSocket(name)) { linkedSetOf() } += name
+            return ok()
+        }
+
+        private fun rawFallbackCreate(command: String): ExecResult {
+            val name = quotedArg(command, "new-session -A -d -s ")
+                ?: return ExecResult("", "no name", 1)
+            if (name in sessionsOn(DEFAULT_SOCKET)) {
+                // `-A` turns this into an attach, and with no tty the attach
+                // dies — the real behaviour recorded in #1820.
+                return ExecResult("", "open terminal failed: not a terminal", 1)
+            }
+            // Blind to every other socket: this is how the orphan is born.
+            servers.getOrPut(DEFAULT_SOCKET) { linkedSetOf() } += name
+            return ok()
+        }
+
+        private fun sendKeys(command: String): ExecResult {
+            val socket = quotedArg(command, "tmux -S ") ?: DEFAULT_SOCKET
+            // `send-keys -t '<target>' '<keys>' Enter`, each value single-quoted
+            // by the gateway and re-escaped by the pathAware wrapper.
+            val quoted = quotedArgs(command.substringAfter("send-keys -t "))
+            val target = quoted.getOrNull(0)?.removePrefix("=")?.removeSuffix(":")
+            val keys = quoted.getOrNull(1)
+            val live = servers[socket]
+            return when {
+                live.isNullOrEmpty() -> ExecResult("", "no server running on $socket", 1)
+                target !in live -> ExecResult("", "can't find pane: $target", 1)
+                else -> {
+                    deliveredKeys += socket to keys.orEmpty()
+                    ok()
+                }
+            }
+        }
+
+        private fun aplexerJson(): ExecResult {
+            if (aplexerSessions.isEmpty()) return ExecResult("", "", 1)
+            val rows = aplexerSessions.joinToString(",") {
+                """{"name":"$it","manager":"aplexer"}"""
+            }
+            return ExecResult("""{"sessions":[$rows],"managers":["aplexer"]}""", "", 0)
+        }
+
+        private fun shellUnavailable(): ExecResult =
+            ExecResult("", "/bin/sh: bad substitution", 2)
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+
+        override fun startShell(): SshShell = error("not used")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+
+        override fun close() = Unit
+
+        companion object {
+            const val SOCKET_DIR = "/tmp/tmux-1000"
+            const val DEFAULT_SOCKET = "$SOCKET_DIR/default"
+        }
+    }
+
+    private companion object {
+        const val BASE = "git-pocketshell"
+        const val CWD = "/home/alexey/git/pocketshell"
+        const val AGENT_LAUNCH = "pocketshell agent claude --dir /home/alexey/git/pocketshell"
+
+        private fun ok(): ExecResult = ExecResult("", "", 0)
+
+        /**
+         * Read the single-quoted value that follows [marker] in a command as it
+         * looks INSIDE the `pathAware` wrapper: the gateway single-quotes the
+         * value and the wrapper then re-escapes every `'` to `'"'"'`.
+         */
+        fun quotedArg(command: String, marker: String): String? {
+            val idx = command.indexOf(marker)
+            if (idx < 0) return null
+            val rest = command.substring(idx + marker.length)
+            return Regex("""^'"'"'(.*?)'"'"'""").find(rest)?.groupValues?.get(1)
+        }
+
+        /** Every wrapper-escaped single-quoted value in [fragment], in order. */
+        fun quotedArgs(fragment: String): List<String> =
+            Regex("""'"'"'(.*?)'"'"'""")
+                .findAll(fragment)
+                .map { it.groupValues[1] }
+                .toList()
+
+        /** A single-quoted value as it appears inside the pathAware wrapper. */
+        fun escapedInWrapper(value: String): String =
+            ("'" + value.replace("'", "'\"'\"'") + "'").replace("'", "'\"'\"'")
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/SessionNameDerivationTest.kt
@@ -191,9 +191,10 @@ class SessionNameDerivationTest {
     // `customNameCollisionWalksUpUntilFreeSlot`.
     //
     // The `-2`/`-3` walk itself is NOT untested — it moved to where it now runs:
-    // the host-side resolver (`FolderListGatewayFallbackTest`'s
-    // `freeSessionNameCommand` + UniqueOnHost cases, incl. the exact-match
-    // assertion) and the connected `TmuxInSessionNewSessionCollisionDockerTest`.
+    // the host-side resolver (`FolderListGatewayFallbackTest`'s socket-sweep +
+    // UniqueOnHost cases, incl. the exact-match assertion; #2378 moved the walk
+    // itself into `TmuxSocketSweep.nextFreeSessionName`) and the connected
+    // `TmuxInSessionNewSessionCollisionDockerTest`.
     //
     // `emptyExistingNamesDerivesTheBareCollidingBase` (#976) survives below as
     // `derivationNeverDisambiguatesEvenForAKnownLiveBase`: its point — the

--- a/app/src/test/java/com/pocketshell/app/projects/TmuxSocketSweepShellTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/TmuxSocketSweepShellTest.kt
@@ -1,0 +1,261 @@
+package com.pocketshell.app.projects
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #2378: run [TmuxSocketSweep]'s POSIX-sh probes for real.
+ *
+ * The gateway tests drive fakes that ANSWER these commands; nothing there
+ * proves the scripts are valid shell, that the socket glob finds tmuxctl's
+ * per-session sockets, or that the dedicated-before-default precedence is what
+ * the code actually emits. So this test runs them through `/bin/sh` against a
+ * throwaway socket directory holding REAL unix sockets and a stub `tmux` on
+ * `PATH` that answers per socket — the same shape the maintainer's host has
+ * (`default` plus `tmuxctl-<session>` servers).
+ *
+ * No tmux and no SSH involved, so it belongs in the JVM gate.
+ */
+class TmuxSocketSweepShellTest {
+
+    @Test
+    fun theNameSweepUnionsEverySocketNotJustTheDefaultOne() {
+        val host = shellHost(
+            "default" to listOf("legacy-leftover"),
+            "tmuxctl-git-pocketshell" to listOf("git-pocketshell"),
+            "tmuxctl-notes" to listOf("notes"),
+        )
+
+        val names = TmuxSocketSweep.parseLiveSessionNames(
+            stdout = host.run(TmuxSocketSweep.liveSessionNamesCommand()).stdout,
+            exitCode = 0,
+        )
+
+        assertEquals(
+            "the sweep must see every socket's sessions",
+            setOf("legacy-leftover", "git-pocketshell", "notes"),
+            names,
+        )
+        assertEquals(
+            "and the disambiguation walk must then skip the taken name",
+            "git-pocketshell-2",
+            TmuxSocketSweep.nextFreeSessionName("git-pocketshell", names),
+        )
+    }
+
+    @Test
+    fun locateFindsTheDedicatedSocketAheadOfTheDefaultOne() {
+        // The exact orphan state #2378 reports: the SAME name on a dedicated
+        // tmuxctl socket and on the default socket. tmuxctl treats the dedicated
+        // server as authoritative, so a launch must be typed there.
+        val host = shellHost(
+            "default" to listOf("git-pocketshell"),
+            "tmuxctl-git-pocketshell" to listOf("git-pocketshell"),
+        )
+
+        val located = TmuxSocketSweep.parseSessionSocket(
+            stdout = host.run(TmuxSocketSweep.sessionSocketCommand("'git-pocketshell'")).stdout,
+            exitCode = 0,
+        )
+
+        assertEquals(
+            SessionSocket.Located("${host.socketDir}/tmuxctl-git-pocketshell"),
+            located,
+        )
+        assertTrue(
+            "the located client must target that socket explicitly",
+            (located as SessionSocket.Located).tmuxClient
+                .contains("tmux -S '${host.socketDir}/tmuxctl-git-pocketshell'"),
+        )
+    }
+
+    @Test
+    fun locateFallsBackToTheDefaultSocketTokenAndTheAbsentSentinel() {
+        val host = shellHost(
+            "default" to listOf("legacy-leftover"),
+            "tmuxctl-notes" to listOf("notes"),
+        )
+
+        assertEquals(
+            "a default-socket session answers the bare-client token",
+            SessionSocket.Located(socket = null),
+            TmuxSocketSweep.parseSessionSocket(
+                host.run(TmuxSocketSweep.sessionSocketCommand("'legacy-leftover'")).stdout,
+                0,
+            ),
+        )
+        assertEquals(
+            "a session on no socket answers Absent, never Unknown",
+            SessionSocket.Absent,
+            TmuxSocketSweep.parseSessionSocket(
+                host.run(TmuxSocketSweep.sessionSocketCommand("'git-pocketshell'")).stdout,
+                0,
+            ),
+        )
+    }
+
+    @Test
+    fun locateUsesTmuxsExactSessionMatchNotAPrefixMatch() {
+        // #1820: without the `=`, `has-session -t foo` matches a live `foo-2`,
+        // which would make the walk skip a free name and point a launch at the
+        // neighbour's pane.
+        val host = shellHost("tmuxctl-git-pocketshell-2" to listOf("git-pocketshell-2"))
+
+        assertEquals(
+            SessionSocket.Absent,
+            TmuxSocketSweep.parseSessionSocket(
+                host.run(TmuxSocketSweep.sessionSocketCommand("'git-pocketshell'")).stdout,
+                0,
+            ),
+        )
+    }
+
+    @Test
+    fun bothProbesSurviveASocketDirectoryThatDoesNotExist() {
+        // A host that has never started tmux: the glob matches nothing, the
+        // trailing bare client finds no server, and both probes must still
+        // answer cleanly (exit 0, empty listing / Absent) rather than erroring
+        // the create out.
+        val host = shellHost(sessionsBySocket = emptyArray(), createSocketDir = false)
+
+        val names = host.run(TmuxSocketSweep.liveSessionNamesCommand())
+        assertEquals("the sweep must exit 0 on a tmux-less host", 0, names.exitCode)
+        assertEquals(emptySet<String>(), TmuxSocketSweep.parseLiveSessionNames(names.stdout, 0))
+
+        val located = host.run(TmuxSocketSweep.sessionSocketCommand("'git-pocketshell'"))
+        assertEquals(0, located.exitCode)
+        assertEquals(
+            SessionSocket.Absent,
+            TmuxSocketSweep.parseSessionSocket(located.stdout, located.exitCode),
+        )
+    }
+
+    // --- harness --------------------------------------------------------
+
+    private class ShellHost(val root: File, val socketDir: String) {
+        fun run(command: String): Answer {
+            val process = ProcessBuilder("/bin/sh", "-c", command)
+                .directory(root)
+                .apply {
+                    environment()["TMUX_TMPDIR"] = root.absolutePath
+                    environment()["PATH"] = "${root.absolutePath}/bin:${System.getenv("PATH")}"
+                }
+                .start()
+            val stdout = process.inputStream.bufferedReader().readText()
+            val stderr = process.errorStream.bufferedReader().readText()
+            check(process.waitFor(30, TimeUnit.SECONDS)) { "probe did not finish: $command" }
+            return Answer(stdout, stderr, process.exitValue())
+        }
+
+        data class Answer(val stdout: String, val stderr: String, val exitCode: Int)
+    }
+
+    /**
+     * A throwaway `$TMUX_TMPDIR/tmux-<uid>` holding one real unix socket per
+     * entry, plus a stub `tmux` that answers `list-sessions` / `has-session`
+     * from the mapping. The sockets have to be REAL: the production probes skip
+     * anything that is not one (`[ -S … ]`), which is what keeps a stray
+     * regular file in that directory from being handed to a tmux client.
+     */
+    private fun shellHost(
+        vararg sessionsBySocket: Pair<String, List<String>>,
+        createSocketDir: Boolean = true,
+    ): ShellHost {
+        val root = createTempDir()
+        val uid = ProcessBuilder("id", "-u").start().let {
+            it.inputStream.bufferedReader().readText().trim()
+        }
+        val socketDir = File(root, "tmux-$uid")
+        if (createSocketDir) {
+            socketDir.mkdirs()
+            sessionsBySocket.forEach { (socket, _) ->
+                createUnixSocket(File(socketDir, socket))
+            }
+        }
+        val bin = File(root, "bin").apply { mkdirs() }
+        File(bin, "tmux").apply {
+            writeText(stubTmux(sessionsBySocket.toMap()))
+            setExecutable(true)
+        }
+        return ShellHost(root, socketDir.absolutePath)
+    }
+
+    /**
+     * A short-pathed scratch directory. AF_UNIX paths are capped at 108 bytes,
+     * so the socket files must not sit under a deep `java.io.tmpdir` (a Gradle
+     * worker's can be arbitrarily deep).
+     */
+    private fun createTempDir(): File {
+        val parent = File("/tmp").takeIf { it.isDirectory && it.canWrite() }
+            ?: File(System.getProperty("java.io.tmpdir"))
+        val dir = File(parent, "i2378-${System.nanoTime()}")
+        check(dir.mkdirs()) { "could not create $dir" }
+        dir.deleteOnExit()
+        return dir
+    }
+
+    /**
+     * Real AF_UNIX socket files — the probes skip anything that is not one.
+     * `nc -lU`/python would drag an external dependency into the JVM gate, and
+     * POSIX sh cannot create a socket at all, so the harness binds them itself
+     * and closes immediately, leaving the socket inode behind exactly like a
+     * tmux server that has since exited.
+     *
+     * Reflection, not a direct call: unit tests compile against `android.jar`,
+     * whose `java.nio` stubs predate `ServerSocketChannel.open(ProtocolFamily)`
+     * even though the JDK 17 these tests RUN on has it.
+     */
+    private fun createUnixSocket(path: File) {
+        val protocolFamily = Class.forName("java.net.ProtocolFamily")
+        @Suppress("UNCHECKED_CAST")
+        val unix = java.lang.Enum.valueOf(
+            Class.forName("java.net.StandardProtocolFamily") as Class<out Enum<*>>,
+            "UNIX",
+        )
+        val channel = java.nio.channels.ServerSocketChannel::class.java
+            .getMethod("open", protocolFamily)
+            .invoke(null, unix) as java.nio.channels.ServerSocketChannel
+        val address = Class.forName("java.net.UnixDomainSocketAddress")
+            .getMethod("of", java.nio.file.Path::class.java)
+            .invoke(null, path.toPath()) as java.net.SocketAddress
+        channel.use { it.bind(address) }
+        path.deleteOnExit()
+    }
+
+    /**
+     * A `tmux` stand-in that understands exactly the two invocation shapes the
+     * production probes emit: an optional `-u`, an optional `-S <socket>`, then
+     * `list-sessions -F …` or `has-session -t =<name>`. Unknown sockets answer
+     * tmux's own `no server running on <socket>` on stderr with a non-zero exit.
+     */
+    private fun stubTmux(sessionsBySocket: Map<String, List<String>>): String {
+        val cases = sessionsBySocket.entries.joinToString("\n") { (socket, names) ->
+            "  $socket) names=\"${names.joinToString(" ")}\" ;;"
+        }
+        return """
+            #!/bin/sh
+            sock=default
+            [ "${'$'}1" = "-u" ] && shift
+            if [ "${'$'}1" = "-S" ]; then sock=${'$'}(basename "${'$'}2"); shift 2; fi
+            [ "${'$'}1" = "-u" ] && shift
+            verb=${'$'}1; shift
+            names=""
+            case "${'$'}sock" in
+            $cases
+              *) echo "no server running on ${'$'}sock" >&2; exit 1 ;;
+            esac
+            case "${'$'}verb" in
+              list-sessions) for n in ${'$'}names; do echo "${'$'}n"; done ;;
+              has-session)
+                want=${'$'}2
+                want=${'$'}{want#=}
+                for n in ${'$'}names; do [ "${'$'}n" = "${'$'}want" ] && exit 0; done
+                exit 1 ;;
+              *) exit 1 ;;
+            esac
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Closes #2378.

tmuxctl runs one tmux server per session on its own dedicated socket (`/tmp/tmux-1000/tmuxctl-<name>`), but the session-create path's "is this name free?" check and the post-create agent launch both only queried the *default* socket. So a create against an already-taken name looked free, `tmuxctl create-detached` no-oped, and the launch's default-socket `send-keys` produced the maintainer's reported `no server running on /tmp/tmux-1000/default` even though a real session existed elsewhere.

## Changes

- New `TmuxSocketSweep.kt`: POSIX-sh probes (all-socket name sweep, socket locate) + parsers, extends the existing `-2`/`-3` disambiguation walk across sockets, and produces an honest launch-failure message.
- `FolderListGateway.kt`: socket-wide name resolution unioned with the aplexer-carrying `pocketshell sessions list` enumerator, a cross-socket collision guard, an idempotent short-circuit that prevents the orphan, and `tmux -S '<socket>' send-keys` for the post-create launch (previously hardcoded to the default socket).

## Known follow-up (separate, connection-core scope)

`TmuxClient.connect` still attaches without `-S`, so it can't reach a dedicated tmuxctl socket at all — tracked as #2387. This PR closes the *create-path* orphan; the *attach-path* mechanism is a separate D28-scope fix.

## Test plan

- [x] Reviewer-run red→green twice: JVM (6/7 red on base → 7/7 green) and connected emulator+Docker (`TmuxInSessionNewSessionCollisionDockerTest` red on base at line 258, green with the fix) — reproduced the maintainer's exact error string and the two-socket orphan.
- [x] On-device logcat evidence from the reviewer's own runs: `located=/tmp/tmux-1000/tmuxctl-...`, `pane_contains_marker=true`, `default_socket_send_keys=can't find session: ...`.
- [x] Shell probes verified injection-safe and validated against tmuxctl's real source; measured cost 0.49-0.51s/probe on a 256-socket directory.
- [x] Full JVM gate: 604/604 tasks, 13600 tests, 0 failures.

## Non-blocking follow-up filed separately

#2391 — an unrelated pre-existing timeout in a sibling test, caused by the shared Docker fixture carrying 31+ leaked sessions from prior runs; reproduced identically on unmodified `origin/main`.