### PR TITLE
Fix session-list undercount at the folder-list and session-picker sites

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -618,7 +618,8 @@ jobs:
 
       # Issue #2060: the #1876/#1458 guards and the #835 balance cap derive the
       # shard count from the matrix via this helper instead of pinning a literal,
-      # so 3 -> 6 cannot silently orphan a hash bucket no shard selects. They are
+      # so a total change (3 -> 6, then 6 -> 9) cannot silently orphan a hash
+      # bucket no shard selects. They are
       # only as good as the helper, so prove it fails closed. The second is the
       # downward-only ratchet: it reddens when a journey-CI guard grows a
       # hardcoded shard total in one of three known shapes. (< 2 s)
@@ -1212,8 +1213,8 @@ jobs:
     # the ~39-min Unit job finished though they share nothing with it but the
     # checkout. That gate was NOT pointless: it stopped a red commit burning one
     # emulator runner per shard for ~40 min each against a 20-concurrent-job
-    # ceiling (process.md). Peak `main`-push concurrency goes ~3 -> ~10 (unit +
-    # both guard jobs + integration overlapping the 6 shards); a PR runs no
+    # ceiling (process.md). Peak `main`-push concurrency goes ~3 -> ~13 (unit +
+    # both guard jobs + integration overlapping the 9 shards); a PR runs no
     # shards, so its peak is the 6-job unit lane.
     #
     # Option (a) was to drop `needs:` and accept the emulator spend on red runs.
@@ -1243,8 +1244,8 @@ jobs:
     #
     # Issue #2110: the core-terminal proofs are sharded by the same #1862 hash
     # now. They used to run on EVERY leg "so a regression in any of them is caught
-    # on every leg", but all six legs run the SAME COMMIT and those proofs are
-    # device-independent in-process tests — five of every six verdicts were
+    # on every leg", but all legs run the SAME COMMIT and those proofs are
+    # device-independent in-process tests — all but one of every N verdicts were
     # copies. Each proof now runs on exactly one leg per push; the union over the
     # matrix is still the whole registry, asserted mechanically by
     # scripts/test-ci-journey-budget.sh rather than by inspection.
@@ -1258,12 +1259,12 @@ jobs:
     # Sharding changes only WHICH runner a class lands on: membership is by
     # class-name hash (#1862), every class still runs on every push.
     #
-    # SIX is chosen on #1850's OWN bar — every leg's drift headroom must exceed
-    # one twice-failing class (~420s) — not on "affordable on a clean run". Five
-    # leaves three legs under that bar and its tightest hosts the 330s
-    # ReconnectStormLivelockE2eTest; six gives every leg >= 488s. Six is the
-    # FIRST total clearing it, NOT the fastest — 8/9 beat it by ~1.4 min for +2/3
-    # runners. Tables/headroom/flakes: scripts/ci-journey-shard-count.sh, which
+    # Issue #2377: 6 -> 9, same bars, recomputed. Registry growth dropped shard
+    # 3's #1850 margin to 350757ms, under the ~420s twice-failing-class bar; the
+    # #1862 name hash forbids rebalancing by rename/reorder, so the total is the
+    # only lever. 9 is the FIRST total clearing BOTH #1850 (tightest 1539357ms)
+    # and #835's 125% count cap — 8 clears the first and fails the second.
+    # Tables/headroom/flakes: scripts/ci-journey-shard-count.sh, which
     # owns this number. The three places that must agree on it — matrix.shard,
     # POCKETSHELL_JOURNEY_CI_SHARD_TOTAL and the aggregation job's
     # EXPECTED_SHARDS — were "keep in sync" comments; they are now cross-checked
@@ -1272,16 +1273,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8]
     env:
       # Set by the matrix; the suite partitions JOURNEY_CLASSES by class-name
       # hash into (index % total). _TOTAL must equal len(matrix.shard).
       POCKETSHELL_JOURNEY_CI_SHARD_INDEX: ${{ matrix.shard }}
-      POCKETSHELL_JOURNEY_CI_SHARD_TOTAL: 6
+      POCKETSHELL_JOURNEY_CI_SHARD_TOTAL: 9
       POCKETSHELL_JOURNEY_SCOPED: ${{needs.sg.outputs.c}}
     # Issue #835 (REOPENED, RIGHT-SIZE): raised 45 -> 95 originally so the FULL
     # serial selection could finish; with sharding each leg runs ~1/N the classes
-    # (#2060: ~38 min modelled worst leg at 6) and finishes well under this cap.
+    # (#2377: ~37 min modelled worst leg at 9) and finishes well under this cap.
     # `timeout-minutes` is a CAP, not a fixed
     # duration: the job ENDS when the suite ends (early on a healthy run), so this
     # only bounds the absolute worst case. The suite owns its OWN 4200s budget and
@@ -2219,7 +2220,7 @@ jobs:
           # #2060 replaced the "keep in sync" honour system with a machine
           # cross-check: test-ci-journey-aggregate-verdict.sh (w9) derives the
           # matrix length via ci-journey-shard-count.sh and fails on disagreement.
-          EXPECTED_SHARDS: 6
+          EXPECTED_SHARDS: 9
           # Issue #1913: a failed matrix with no RED token means the classifier
           # lost a commit-bound failure. Genuine typed INFRA shards finish green,
           # so their matrix result is success and remains neutral RE-RUN.

--- a/app/src/androidTest/java/com/pocketshell/app/projects/Issue2377MultiSocketSessionListDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/Issue2377MultiSocketSessionListDockerTest.kt
@@ -1,0 +1,585 @@
+package com.pocketshell.app.projects
+
+import androidx.lifecycle.ViewModelStore
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.app.repos.ReposJsonParser
+import com.pocketshell.app.repos.ReposRemoteSource
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.sessions.HostTmuxSessionListParser
+import com.pocketshell.app.sessions.HostTmuxSessionListResult
+import com.pocketshell.app.sessions.HostTmuxSessionPickerRequest
+import com.pocketshell.app.sessions.HostTmuxSessionPickerState
+import com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel
+import com.pocketshell.app.sessions.SshHostTmuxSessionsGateway
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.core.tmux.TmuxClient
+import com.pocketshell.core.tmux.TmuxClientFactory
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Issue #2377 — the phone's session list must match `pocketshell sessions list
+ * --json` / `tmuxctl list`, not a single tmux socket.
+ *
+ * Reported on `hetzner`: "1 active · 0 idle · 1 session" against a host with 10
+ * live sessions (7 tmuxctl-managed, one `tmuxctl-*` socket each, plus 3
+ * aplexer-managed). The app had just created a session from the New Session
+ * sheet and been attached into it, which registers a live `tmux -CC` control
+ * client — and that client is attached to exactly ONE tmux server, so the
+ * gateway's live-client shortcut published that one server's `list-sessions` as
+ * the whole host. #2348 forbade exactly this ("do not revert to default-socket
+ * `tmux list-sessions` — that was the 3-session bug") but only ever covered the
+ * no-live-client branch.
+ *
+ * This journey reproduces that host shape on the real Docker `agents` fixture
+ * (host port 2222) through the PRODUCTION [FolderListViewModel] +
+ * [SshFolderListGateway] + a REAL `tmux -CC` client:
+ *
+ *  1. seed three `tmuxctl-*` sockets, one tmux server + session each, plus an
+ *     aplexer snapshot the fixture's `a` binary reports as a second manager;
+ *  2. seed ONE session on the DEFAULT socket — the "just created by the app"
+ *     one — and attach a real `-CC` client to it;
+ *  3. read the host's own answer (`pocketshell sessions list --json`) as the
+ *     oracle, over a separate plain SSH connection;
+ *  4. assert the RENDERED `flatSessions` contains every session the host CLI
+ *     reports, on cold load, after a routine refresh, and after a create made
+ *     through the production view model.
+ *
+ * The load-bearing assertion is the oracle comparison, not "more than one row":
+ * a fixture that lost its multi-socket seeding would fail the precondition
+ * check rather than pass vacuously.
+ *
+ * The app has TWO session lists and both had this defect independently, so both
+ * are driven here against the same fixture: the folder list
+ * ([FolderListViewModel] + [SshFolderListGateway]) and the session picker sheet
+ * ([com.pocketshell.app.sessions.HostTmuxSessionPickerViewModel] +
+ * [com.pocketshell.app.sessions.SshHostTmuxSessionsGateway], see
+ * [sessionPickerListMatchesHostCliWithLiveClientAttached]).
+ */
+@RunWith(AndroidJUnit4::class)
+class Issue2377MultiSocketSessionListDockerTest {
+
+    private lateinit var sshKey: SshKey.Pem
+    private lateinit var keyFile: File
+    private lateinit var db: AppDatabase
+    private val viewModelStore = ViewModelStore()
+    private val tmuxClientScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var ccSession: SshSession? = null
+    private var ccClient: TmuxClient? = null
+    private val socketSessions = mutableListOf<String>()
+    private val defaultSocketSessions = mutableListOf<String>()
+    private var seededAplexer = false
+
+    @Before
+    fun setUp(): Unit { runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val keyText = instrumentation.context.assets.open("test_key")
+            .bufferedReader()
+            .use { it.readText() }
+        sshKey = SshKey.Pem(keyText)
+        keyFile = File(instrumentation.targetContext.cacheDir, "issue2377-key").apply {
+            parentFile?.mkdirs()
+            if (exists()) delete()
+            FileOutputStream(this).use { it.write(keyText.toByteArray()) }
+            setReadable(true, true)
+        }
+        db = Room.inMemoryDatabaseBuilder(
+            instrumentation.targetContext,
+            AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        waitForSshFixtureReady(sshKey)
+    } }
+
+    @After
+    fun tearDown(): Unit { runBlocking {
+        viewModelStore.clear()
+        runCatching { ccClient?.close() }
+        runCatching { ccSession?.close() }
+        runCatching { tmuxClientScope.cancel() }
+        runCatching {
+            withTimeout(25_000L) {
+                connect().use { session ->
+                    socketSessions.forEach { name ->
+                        runCatching {
+                            // kill-server leaves the socket FILE behind; remove
+                            // it too so a shared long-lived fixture container
+                            // does not accumulate dead `tmuxctl-*` entries.
+                            session.exec(
+                                "tmux -L $TMUXCTL_PREFIX$name kill-server 2>/dev/null || true; " +
+                                    "rm -f \"\${TMUX_TMPDIR:-/tmp}/tmux-\$(id -u)/$TMUXCTL_PREFIX$name\"",
+                            )
+                        }
+                    }
+                    defaultSocketSessions.forEach { name ->
+                        runCatching { session.exec("tmux kill-session -t $name 2>/dev/null || true") }
+                    }
+                    if (seededAplexer) {
+                        runCatching { session.exec("rm -f $APLEXER_SNAPSHOT") }
+                    }
+                }
+            }
+        }
+        runCatching { db.close() }
+        runCatching { keyFile.delete() }
+    } }
+
+    @Test
+    fun renderedSessionListMatchesHostCliAcrossSocketsAndManagers(): Unit { runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val seeded = seedHost(suffix)
+        val bound = bindProductionViewModel(seeded.anchorSession)
+        val vm = bound.vm
+
+        // Cold load.
+        val cold = awaitReadyContaining(vm, seeded.hostCliNames)
+        println(
+            "ISSUE2377_COLD rendered=${cold.size} hostCli=${seeded.hostCliNames.size} " +
+                "names=$cold",
+        )
+        assertMatchesHostCli("cold load", seeded, cold)
+
+        // Routine reconcile (pull-to-refresh through the production view model).
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { vm.refresh() }
+        val refreshed = awaitReadyContaining(vm, seeded.hostCliNames)
+        println("ISSUE2377_REFRESH rendered=${refreshed.size} names=$refreshed")
+        assertMatchesHostCli("routine reconcile", seeded, refreshed)
+    } }
+
+    @Test
+    fun listAfterCreatingASessionInTheAppStillMatchesHostCli(): Unit { runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val seeded = seedHost(suffix)
+        val bound = bindProductionViewModel(seeded.anchorSession)
+        val vm = bound.vm
+        assertMatchesHostCli("cold load", seeded, awaitReadyContaining(vm, seeded.hostCliNames))
+
+        // The reported trigger: a session created from the New Session sheet.
+        val createdFolder = "/tmp/issue2377-created-$suffix"
+        val requested = "issue2377-created-$suffix"
+        connect().use { it.exec("mkdir -p $createdFolder") }
+        val resolved = CompletableDeferred<String>()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            vm.createSession(
+                sessionName = requested,
+                cwd = createdFolder,
+                startCommand = null,
+                onResolved = { name -> resolved.complete(name) },
+            )
+        }
+        val createdName = withTimeout(60_000L) { resolved.await() }
+        defaultSocketSessions += createdName
+
+        // The maintained tree keeps the rows it already had, so the tree alone
+        // cannot prove the POST-CREATE probe is still whole — a probe that
+        // returned just the new session would be masked by the durable tree.
+        // Ask the production gateway directly, in the exact state the maintainer
+        // hit (live -CC client attached, a session just created), and require
+        // its OWN rows to match the host CLI. This is the load-bearing
+        // post-create assertion; the tree check below is the user-visible half.
+        val probe = withTimeout(JOURNEY_BOUND_MS) {
+            bound.gateway.listSessionsWithFolder(
+                host = bound.host,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
+        assertTrue("post-create probe must be a session list, got $probe", probe is FolderListResult.Sessions)
+        val probeNames = (probe as FolderListResult.Sessions).rows.map { it.sessionName }.toSet()
+        println("ISSUE2377_AFTER_CREATE_PROBE created=$createdName rows=${probeNames.size} names=$probeNames")
+        assertTrue(
+            "ISSUE2377_UNDERCOUNT post-create gateway probe collapsed to the attached " +
+                "socket. rows=${probeNames.size} $probeNames missing=${seeded.hostCliNames - probeNames}",
+            probeNames.containsAll(seeded.hostCliNames),
+        )
+        assertTrue(
+            "the just-created session must be in the post-create probe; got $probeNames",
+            createdName in probeNames,
+        )
+
+        val afterCreate = awaitReadyContaining(vm, seeded.hostCliNames + createdName)
+        println("ISSUE2377_AFTER_CREATE created=$createdName rendered=${afterCreate.size} names=$afterCreate")
+        assertMatchesHostCli("post-create reconcile", seeded, afterCreate)
+        assertTrue(
+            "the created session must be listed too; got $afterCreate",
+            createdName in afterCreate,
+        )
+    } }
+
+    private fun assertMatchesHostCli(
+        phase: String,
+        seeded: SeededHost,
+        rendered: Set<String>,
+    ) {
+        assertTrue(
+            "$phase: the rendered list must contain every session " +
+                "`pocketshell sessions list --json` reports. missing=" +
+                "${seeded.hostCliNames - rendered} rendered=$rendered",
+            rendered.containsAll(seeded.hostCliNames),
+        )
+        assertTrue(
+            "$phase: every seeded tmuxctl-* SOCKET session must be listed — this is the " +
+                "default-socket-only undercount (#2348's 3-session bug, #2377's 1-session " +
+                "recurrence). missing=${seeded.socketSessionNames - rendered}",
+            rendered.containsAll(seeded.socketSessionNames),
+        )
+        assertTrue(
+            "$phase: the aplexer-managed sessions must be listed. missing=" +
+                "${seeded.aplexerNames - rendered}",
+            rendered.containsAll(seeded.aplexerNames),
+        )
+        assertTrue(
+            "$phase: the attached (live -CC) session must remain listed",
+            seeded.anchorSession in rendered,
+        )
+    }
+
+    private data class SeededHost(
+        val anchorSession: String,
+        val socketSessionNames: Set<String>,
+        val aplexerNames: Set<String>,
+        val hostCliNames: Set<String>,
+    )
+
+    private suspend fun seedHost(suffix: String): SeededHost {
+        val socketNames = (1..SOCKET_COUNT).map { "issue2377-sock$it-$suffix" }
+        val aplexerNames = (1..APLEXER_COUNT).map { "aplexer-follow:issue2377-$suffix-$it" }
+        val anchorSession = "issue2377-anchor-$suffix"
+        withTimeout(60_000L) {
+            connect().use { session ->
+                // One tmux SERVER per session, each on its own `tmuxctl-*`
+                // socket — the real tmuxctl layout, and precisely what a bare
+                // default-socket `tmux list-sessions` (or a `-CC` client) cannot
+                // see.
+                socketNames.forEach { name ->
+                    val result = session.exec(
+                        "tmux -L $TMUXCTL_PREFIX$name new-session -d -s $name -c /tmp",
+                    )
+                    check(result.exitCode == 0) {
+                        "failed to seed tmuxctl socket $name: ${result.stderr}"
+                    }
+                    socketSessions += name
+                }
+                // The aplexer manager, via the fixture `a` binary's snapshot.
+                val snapshot = aplexerNames.mapIndexed { index, name ->
+                    """{"name":"$name","id":"issue2377-aplexer-$index",""" +
+                        """"workspace":"/tmp/aplexer-$suffix-$index"}"""
+                }.joinToString(",")
+                val write = session.exec(
+                    "printf '%s' '{\"sessions\":[$snapshot]}' > $APLEXER_SNAPSHOT",
+                )
+                check(write.exitCode == 0) { "failed to seed aplexer snapshot: ${write.stderr}" }
+                seededAplexer = true
+                // The DEFAULT-socket session the app attaches to.
+                session.exec("tmux new-session -d -s $anchorSession -c /tmp")
+                defaultSocketSessions += anchorSession
+            }
+        }
+
+        // Oracle: the host's own answer, read over a separate plain connection.
+        val hostCliNames = withTimeout(45_000L) {
+            connect().use { session ->
+                val json = session.exec("pocketshell sessions list --json")
+                check(json.exitCode == 0) { "host CLI enumerator failed: ${json.stderr}" }
+                val array = JSONObject(json.stdout.trim()).getJSONArray("sessions")
+                (0 until array.length())
+                    .map { array.getJSONObject(it).getString("name") }
+                    .toSet()
+            }
+        }
+        // Fixture precondition — a fixture that stopped enumerating the sockets
+        // or the aplexer manager must FAIL here, never pass vacuously.
+        check(hostCliNames.containsAll(socketNames)) {
+            "fixture regression: `pocketshell sessions list --json` did not report the " +
+                "seeded tmuxctl-* sockets. reported=$hostCliNames"
+        }
+        check(hostCliNames.containsAll(aplexerNames)) {
+            "fixture regression: `pocketshell sessions list --json` did not report the " +
+                "seeded aplexer sessions. reported=$hostCliNames"
+        }
+        // …and the default socket must be the narrow view the bug published.
+        withTimeout(30_000L) {
+            connect().use { session ->
+                val defaultSocket = session.exec("tmux list-sessions -F '#{session_name}'")
+                val defaultNames = defaultSocket.stdout.lines().map { it.trim() }.filter { it.isNotEmpty() }
+                check(defaultNames.none { it in socketNames }) {
+                    "fixture regression: the tmuxctl-* sessions leaked onto the DEFAULT socket, " +
+                        "so this journey could not reproduce the undercount. default=$defaultNames"
+                }
+                println("ISSUE2377_DEFAULT_SOCKET names=$defaultNames hostCli=${hostCliNames.size}")
+            }
+        }
+        return SeededHost(
+            anchorSession = anchorSession,
+            socketSessionNames = socketNames.toSet(),
+            aplexerNames = aplexerNames.toSet(),
+            hostCliNames = hostCliNames,
+        )
+    }
+
+    /**
+     * The SECOND session list: the session picker sheet. It reads its own
+     * gateway ([SshHostTmuxSessionsGateway]) and had the identical single-socket
+     * `-CC` short-circuit — `listSessionsFromLiveClient(...)?.let { return it }`
+     * — so on the reported host it showed 1 of 10 even after the folder list was
+     * fixed. Same fixture, same real live client, same host-CLI oracle.
+     */
+    @Test
+    fun sessionPickerListMatchesHostCliWithLiveClientAttached(): Unit { runBlocking {
+        val suffix = System.currentTimeMillis().toString().takeLast(6)
+        val seeded = seedHost(suffix)
+        val bound = bindProductionViewModel(seeded.anchorSession)
+
+        val pickerGateway = SshHostTmuxSessionsGateway(
+            parser = HostTmuxSessionListParser(),
+            activeTmuxClients = bound.registry,
+        )
+
+        // Precondition (anti-vacuous): the live `-CC` client MUST be the narrow
+        // single-socket view — otherwise this journey would not be exercising
+        // the bugged path at all and a green would prove nothing.
+        val liveOnly = withTimeout(30_000L) {
+            pickerGateway.listSessionsFromLiveClient(bound.host, keyFile.absolutePath)
+        }
+        check(liveOnly is HostTmuxSessionListResult.Sessions) {
+            "no live -CC client registered for the picker journey; got $liveOnly"
+        }
+        val liveNames = (liveOnly as HostTmuxSessionListResult.Sessions).rows.map { it.name }.toSet()
+        println("ISSUE2377_PICKER_LIVE_ONLY rows=${liveNames.size} names=$liveNames")
+        check(liveNames.none { it in seeded.socketSessionNames }) {
+            "fixture regression: the live -CC client already sees the tmuxctl-* sockets, " +
+                "so the picker undercount cannot reproduce. live=$liveNames"
+        }
+
+        // The user-visible surface: HostTmuxSessionPickerState.Ready.rows.
+        val pickerVm = HostTmuxSessionPickerViewModel(pickerGateway)
+            .also { viewModelStore.put("issue2377-session-picker", it) }
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            pickerVm.load(
+                HostTmuxSessionPickerRequest(
+                    host = bound.host,
+                    keyPath = keyFile.absolutePath,
+                    passphrase = null,
+                ),
+            )
+        }
+        val rendered = awaitPickerRows(pickerVm, seeded.hostCliNames)
+        println("ISSUE2377_PICKER rendered=${rendered.size} hostCli=${seeded.hostCliNames.size} names=$rendered")
+        assertTrue(
+            "ISSUE2377_UNDERCOUNT the session picker must list every session " +
+                "`pocketshell sessions list --json` reports, not the one socket the live " +
+                "-CC client is attached to. missing=${seeded.hostCliNames - rendered} " +
+                "rendered=$rendered",
+            rendered.containsAll(seeded.hostCliNames),
+        )
+        assertTrue(
+            "every seeded tmuxctl-* SOCKET session must be in the picker. missing=" +
+                "${seeded.socketSessionNames - rendered}",
+            rendered.containsAll(seeded.socketSessionNames),
+        )
+        assertTrue(
+            "the aplexer-managed sessions must be in the picker. missing=" +
+                "${seeded.aplexerNames - rendered}",
+            rendered.containsAll(seeded.aplexerNames),
+        )
+        assertTrue(
+            "the attached (live -CC) session must remain listed",
+            seeded.anchorSession in rendered,
+        )
+    } }
+
+    private suspend fun awaitPickerRows(
+        vm: HostTmuxSessionPickerViewModel,
+        required: Set<String>,
+        timeoutMs: Long = JOURNEY_BOUND_MS,
+    ): Set<String> {
+        var last: Set<String> = emptySet()
+        var lastState = "none"
+        try {
+            return withTimeout(timeoutMs) {
+                var settled: Set<String>? = null
+                while (settled == null) {
+                    when (val state = vm.state.value) {
+                        is HostTmuxSessionPickerState.ConnectError ->
+                            error("session picker surfaced ConnectError: ${state.summary}")
+                        is HostTmuxSessionPickerState.Fallback ->
+                            error("session picker fell back: ${state.message}")
+                        is HostTmuxSessionPickerState.Ready -> {
+                            last = state.rows.map { it.name }.toSet()
+                            lastState = "Ready"
+                            if (last.containsAll(required)) settled = last
+                        }
+                        else -> lastState = state::class.java.simpleName
+                    }
+                    if (settled == null) delay(200L)
+                }
+                requireNotNull(settled)
+            }
+        } catch (_: TimeoutCancellationException) {
+            throw AssertionError(
+                "ISSUE2377_UNDERCOUNT the session picker never matched the host CLI within " +
+                    "${timeoutMs}ms. state=$lastState rendered=${last.size} $last " +
+                    "missing=${required - last} required=${required.size} $required",
+            )
+        }
+    }
+
+    private data class BoundApp(
+        val vm: FolderListViewModel,
+        val gateway: SshFolderListGateway,
+        val host: HostEntity,
+        val registry: ActiveTmuxClients,
+    )
+
+    private suspend fun bindProductionViewModel(anchorSession: String): BoundApp {
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "issue2377-key", privateKeyPath = keyFile.absolutePath),
+        )
+        val hostId = db.hostDao().insert(
+            HostEntity(
+                name = "issue2377-host",
+                hostname = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                username = DEFAULT_USER,
+                keyId = keyId,
+            ),
+        )
+        val host = db.hostDao().getById(hostId)!!
+
+        // A REAL `tmux -CC` control client on the DEFAULT socket, registered
+        // exactly the way TmuxSessionViewModel does when the user is inside a
+        // session. This is the state that made the list collapse.
+        val session = withTimeout(30_000L) { connect(timeoutMs = 15_000) }
+        ccSession = session
+        val client = TmuxClientFactory(tmuxClientScope).create(
+            session = session,
+            sessionName = anchorSession,
+        )
+        ccClient = client
+        withTimeout(30_000L) { client.connect() }
+        val registry = ActiveTmuxClients()
+        registry.register(
+            hostId = host.id,
+            hostName = host.name,
+            hostname = host.hostname,
+            port = host.port,
+            username = host.username,
+            keyPath = keyFile.absolutePath,
+            client = client,
+        )
+
+        val gateway = SshFolderListGateway(
+            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+            activeTmuxClients = registry,
+            sessionListParser = HostTmuxSessionListParser(),
+        )
+        val vm = FolderListViewModel(
+            gateway = gateway,
+            hostDao = db.hostDao(),
+            projectRootDao = db.projectRootDao(),
+            forwardingController = ForwardingController(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+            ),
+            activeTmuxClients = registry,
+            attachLifecycle = false,
+        ).also { viewModelStore.put("issue2377-folder-list", it) }
+        vm.setProcessStartedForTest(true)
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            vm.bind(
+                hostId = host.id,
+                hostName = host.name,
+                hostname = host.hostname,
+                port = host.port,
+                username = host.username,
+                keyPath = keyFile.absolutePath,
+                passphrase = null,
+            )
+        }
+        return BoundApp(vm = vm, gateway = gateway, host = host, registry = registry)
+    }
+
+    private suspend fun awaitReadyContaining(
+        vm: FolderListViewModel,
+        required: Set<String>,
+        timeoutMs: Long = JOURNEY_BOUND_MS,
+    ): Set<String> {
+        // `lastRendered` is deliberately hoisted OUT of the timeout scope: when
+        // the undercount bug is present the wait expires, and a bare
+        // TimeoutCancellationException would say nothing about WHY. The RED
+        // evidence for this issue is "rendered=[…1 name…] missing=[…9 names…]",
+        // so report it.
+        var lastRendered: Set<String> = emptySet()
+        try {
+            return withTimeout(timeoutMs) {
+                var settled: Set<String>? = null
+                while (settled == null) {
+                    when (val state = vm.state.value) {
+                        is FolderListUiState.ConnectError ->
+                            error("folder reconcile surfaced ConnectError: ${state.message}")
+                        is FolderListUiState.Failed ->
+                            error("folder reconcile failed: ${state.message}")
+                        is FolderListUiState.Ready -> {
+                            val names = state.flatSessions.map { it.sessionName }.toSet()
+                            lastRendered = names
+                            if (names.containsAll(required)) settled = names
+                        }
+                        else -> Unit
+                    }
+                    if (settled == null) delay(200L)
+                }
+                requireNotNull(settled)
+            }
+        } catch (_: TimeoutCancellationException) {
+            throw AssertionError(
+                "ISSUE2377_UNDERCOUNT the rendered session list never matched the host CLI " +
+                    "within ${timeoutMs}ms. rendered=${lastRendered.size} $lastRendered " +
+                    "missing=${required - lastRendered} required=${required.size} $required",
+            )
+        }
+    }
+
+    private suspend fun connect(timeoutMs: Int = 10_000): SshSession =
+        SshConnection.connect(
+            host = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            user = DEFAULT_USER,
+            key = sshKey,
+            knownHosts = KnownHostsPolicy.AcceptAll,
+            timeoutMs = timeoutMs,
+        ).getOrThrow()
+
+    private companion object {
+        const val SOCKET_COUNT: Int = 3
+        const val APLEXER_COUNT: Int = 2
+        const val TMUXCTL_PREFIX: String = "tmuxctl-"
+        const val APLEXER_SNAPSHOT: String = "\$HOME/.pocketshell-fixture-aplexer.json"
+        const val JOURNEY_BOUND_MS: Long = 60_000L
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -591,17 +590,34 @@ class SshFolderListGateway internal constructor(
         // watched roots are configured. The enumeration is the picker-gating
         // probe (issue #470), and serving it from the already-open control
         // channel in ONE batched round-trip (`list-sessions` + `list-panes`
-        // chained, see [TmuxClient.sendChainedCommands]) avoids dialing a
-        // fresh multi-exec SSH lease and paying 2 serial exec round-trips on
-        // every poll. When no watched roots exist this is the WHOLE result;
-        // when roots exist we only open a lease for the (app-cached, optional)
-        // watched-root expansion and merge it onto the live-client rows,
-        // instead of re-running list-sessions/list-panes/agent-detect over the
-        // lease.
-        val liveRows = listSessionRowsFromLiveClient(host, keyPath)
-        if (liveRows != null && watchedRoots.isEmpty()) {
-            return FolderListResult.Sessions(rows = liveRows)
-        }
+        // chained, see [TmuxClient.sendChainedCommands]) avoids re-running
+        // list-sessions/list-panes/agent-detect over the SSH lease.
+        //
+        // Issue #2377 (hard cut, D22): the live-client rows are NOT the whole
+        // truth and this path used to `return` them as if they were whenever no
+        // watched roots existed. A `-CC` control client is attached to exactly
+        // ONE tmux server, so its `list-sessions` sees only that server's
+        // socket. On the maintainer's host — 7 tmuxctl-managed sessions across 7
+        // separate `tmuxctl-*` sockets plus 3 aplexer-managed ones — the app
+        // attached to the session it had just created on the default socket and
+        // rendered "1 active · 0 idle · 1 session" against a host that
+        // `pocketshell sessions list --json` reported as 10. That is the same
+        // default-socket-only enumeration #2348 explicitly forbade; the #2348
+        // fix only ever covered the no-live-client branch below.
+        //
+        // So the live client keeps owning the RICH per-window/pane metadata for
+        // the server it is attached to, but the tmuxctl+aplexer enumerator is
+        // the authority for the SET of sessions, on every branch. That costs one
+        // bounded exec on the (pooled, already-warm) lease — the same exec the
+        // no-live-client branch already pays — and correctness outranks skipping
+        // it.
+        val liveRows = FolderListLiveClientEnumerator.enumerate(
+            activeTmuxClients = activeTmuxClients,
+            host = host,
+            keyPath = keyPath,
+            liveEnumTimeoutMs = liveEnumTimeoutMs,
+            familyForRawId = { rawId -> enginesGateway?.familyForRawId(host.id, rawId) },
+        )
 
         return try {
             withLeaseSession(
@@ -623,6 +639,12 @@ class SshFolderListGateway internal constructor(
                         // just because a control client is attached (the control
                         // channel can't run the host-wide scan it needs), and it
                         // is INDEPENDENT of the expansion, so the two overlap.
+                        //
+                        // Issue #2377: the tmuxctl+aplexer enumerator starts
+                        // FIRST, alongside the required landing batch, exactly
+                        // like the no-live-client branch — a serial extra hop is
+                        // what blew the 12s mobile bound in #2348.
+                        val enumeratorDeferred = async { fetchPocketshellEnumerator(session) }
                         val required = landingProbeOwner.executeRequired(
                             watchedRoots = watchedRoots,
                             includeEnumeration = false,
@@ -646,7 +668,22 @@ class SshFolderListGateway internal constructor(
                             expansion = expansion,
                             ports = ports,
                         )
-                        probes.sessions(annotated)
+                        // Issue #2377: union the host-wide tmuxctl+aplexer
+                        // enumerator over the single-socket live-client rows,
+                        // with the enumerator as AUTHORITY — identical to the
+                        // no-live-client branch. The live rows stay the overlay
+                        // that contributes cwd/windows/kind for the sessions on
+                        // the attached server.
+                        val enumerator = enumeratorDeferred.await()
+                        if (enumerator is FolderListPocketshellEnumerator.Fetch.Unavailable) {
+                            return@supervisorScope enumeratorUnavailableResult()
+                        }
+                        probes.sessions(
+                            FolderListPocketshellEnumerator.unionFolderSessionRows(
+                                enumerator.rows,
+                                annotated,
+                            ),
+                        )
                     } else {
                         // Issue #2348: start the tmuxctl+aplexer JSON enumerator
                         // alongside the required landing batch. A serial extra hop
@@ -983,6 +1020,13 @@ class SshFolderListGateway internal constructor(
                 // Union the pocketshell enumerator so the phone matches the
                 // terminal, and fold in aplexer rows as a second manager.
                 val enumerator = loadEnumerator()
+                // Issue #2377: an enumerator that could not RUN is not "no extra
+                // sessions". Publishing the default-socket rows here would be a
+                // confidently-wrong undercount; surface a retryable failure so
+                // the view model keeps the last good tree instead.
+                if (enumerator is FolderListPocketshellEnumerator.Fetch.Unavailable) {
+                    return enumeratorUnavailableResult()
+                }
                 probes.sessions(
                     FolderListPocketshellEnumerator.unionFolderSessionRows(
                         enumerator.rows,
@@ -1023,6 +1067,21 @@ class SshFolderListGateway internal constructor(
         )
     }
 
+    /**
+     * Issue #2377: the host session enumerator could not be read this poll.
+     *
+     * The tempting alternative — publish whatever narrower enumeration we do
+     * have (default-socket `tmux list-sessions`, or a live `-CC` client bound to
+     * one tmuxctl socket) — is exactly the reported defect: the phone confidently
+     * showed 1 of the host's 10 sessions. A [FolderListResult.Failed] is the
+     * honest answer: on a screen that already has a tree the view model keeps it
+     * and shows the refresh-failed message (`preserveReadyOnRefresh`), and on a
+     * cold load it renders the retryable panel. Either way the user is never told
+     * a wrong count is the truth.
+     */
+    private fun enumeratorUnavailableResult(): FolderListResult.Failed =
+        FolderListResult.Failed(ENUMERATOR_UNAVAILABLE_MESSAGE)
+
     private suspend fun fetchPocketshellEnumerator(
         session: SshSession,
     ): FolderListPocketshellEnumerator.Fetch =
@@ -1038,12 +1097,17 @@ class SshFolderListGateway internal constructor(
         probes: ReconcileSideProbes,
         familyForRawId: (String?) -> SessionAgentKind? = { null },
         enumerator: FolderListPocketshellEnumerator.Fetch? = null,
-    ): FolderListResult.Sessions? {
+    ): FolderListResult? {
         val fetched = enumerator ?: fetchPocketshellEnumerator(session)
         when (fetched) {
             is FolderListPocketshellEnumerator.Fetch.Json,
             FolderListPocketshellEnumerator.Fetch.Empty,
             -> return probes.sessions(fetched.rows)
+            // Issue #2377: the enumerator is the ONLY source on this branch
+            // (native tmux is missing / errored), so an unreadable enumerator
+            // must not render as "this host has no sessions".
+            FolderListPocketshellEnumerator.Fetch.Unavailable ->
+                return enumeratorUnavailableResult()
             FolderListPocketshellEnumerator.Fetch.Failed -> return null
             is FolderListPocketshellEnumerator.Fetch.Human -> Unit
         }
@@ -1752,114 +1816,6 @@ class SshFolderListGateway internal constructor(
 
     private fun shellQuote(value: String): String = shellQuoteValue(value)
 
-    /**
-     * Issue #692: enumerate session + pane rows from the live `-CC` control
-     * client in ONE batched control-mode round-trip.
-     *
-     * Returns null when no matching live client is connected (the caller then
-     * opens an SSH lease) and when the enumeration errors (so the lease path
-     * can produce an accurate error). An EMPTY list is a valid result — it
-     * means a connected client with `no server running` (all sessions gone),
-     * which is distinct from "no client". The two probes (`list-sessions`,
-     * `list-panes`) are chained via [TmuxClient.sendChainedCommands] so the
-     * already-open channel pays a single wire round-trip instead of two
-     * serial commands.
-     */
-    private suspend fun listSessionRowsFromLiveClient(
-        host: HostEntity,
-        keyPath: String,
-    ): List<FolderSessionRow>? {
-        val entry = activeTmuxClients.clients.value[host.id]
-            ?.takeIf { it.matches(host, keyPath) }
-            ?.takeUnless { it.client.disconnected.value }
-            ?: return null
-        return try {
-            // Issue #702: bound the live-client enumeration so a wedged shared
-            // `-CC` control channel (single-flight mutex held by never-releasing
-            // in-session traffic) can't pin the picker. On timeout we return
-            // null and the caller falls through to the bounded SSH-lease
-            // enumeration (execBounded). `sendChainedCommands` itself also
-            // self-bounds its acquire (#702); this is the gateway-side defence.
-            val responses = withTimeoutOrNull(liveEnumTimeoutMs) {
-                entry.client.sendChainedCommands(
-                    listOf(CONTROL_LIST_SESSIONS_COMMAND, CONTROL_LIST_PANES_COMMAND),
-                )
-            } ?: run {
-                Log.w(
-                    PROBE_LOG_TAG,
-                    "live -CC enumeration wedged >${liveEnumTimeoutMs}ms; " +
-                        "falling through to bounded SSH-lease enumeration.",
-                )
-                return null
-            }
-            val listSessions = responses.getOrNull(0) ?: return null
-            val listPanes = responses.getOrNull(1)
-            when {
-                listSessions.isError &&
-                    listSessions.output.joinToString("\n").contains("no server running", ignoreCase = true) ->
-                    emptyList()
-                listSessions.isError -> null
-                else -> {
-                    val baseRows = parseListSessionsRows(
-                        stdout = listSessions.output.joinToString(separator = "\n"),
-                        familyForRawId = { rawId ->
-                            enginesGateway?.familyForRawId(host.id, rawId)
-                        },
-                    )
-                    val windowRows = if (listPanes != null && !listPanes.isError) {
-                        parseSessionWindowRows(listPanes.output.joinToString("\n"))
-                    } else {
-                        emptyList()
-                    }
-                    val paneRows = activePaneRowsBySession(windowRows)
-                    val windowsBySession = windowRows.groupBy { it.sessionName }
-
-                    baseRows.map { row ->
-                        val pane = paneRows[row.sessionName]
-                        // Epic #821: a recorded `@ps_agent_kind` (read back in
-                        // parseRow from CONTROL_LIST_SESSIONS_COMMAND) is the
-                        // authoritative kind for a session WE launched. This
-                        // live path runs no detector, so the recorded kind is
-                        // the only positive agent signal here for our sessions.
-                        val recorded = row.recordedKind
-                        val windows = windowsBySession[row.sessionName].orEmpty().map { window ->
-                            // Issue #716: the live-client path runs NO detector
-                            // (the control channel can't host the ps/candidate
-                            // scan), so resolve the raw kind affirmative-shell-
-                            // aware — an interactive-shell pane is a confirmed
-                            // Shell, anything else is presumed-agent Probing.
-                            // NEVER emit a raw `Shell` for an undetected window:
-                            // when watched roots are empty this path returns
-                            // WITHOUT annotation and feeds the maintained tree
-                            // directly, where a false `Shell` would downgrade a
-                            // sticky agent (#716). A recorded kind (#821) wins.
-                            window.copy(
-                                agentKind = recorded ?: resolveUndetectedKind(window.command),
-                            )
-                        }
-                        row.copy(
-                            cwd = pane?.cwd ?: row.cwd,
-                            agentKind = recorded ?: resolveUndetectedKind(
-                                (windows.firstOrNull { it.active } ?: windows.firstOrNull())?.command,
-                            ),
-                            windows = windows,
-                        )
-                    }
-                }
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Throwable) {
-            null
-        }
-    }
-
-    private fun ActiveTmuxClients.Entry.matches(host: HostEntity, keyPath: String): Boolean =
-        hostname == host.hostname &&
-            port == host.port &&
-            username == host.username &&
-            this.keyPath == keyPath
-
     private fun shellQuoteRemotePath(value: String): String =
         shellQuoteRemotePathValue(value)
 
@@ -2186,6 +2142,14 @@ class SshFolderListGateway internal constructor(
 
         const val POCKETSHELL_SESSIONS_COMMAND: String = "pocketshell sessions list --by activity"
         const val POCKETSHELL_SESSIONS_JSON_COMMAND: String = "pocketshell sessions list --json"
+
+        /**
+         * Issue #2377: user-visible reason for refusing to publish a session
+         * list we know is incomplete.
+         */
+        const val ENUMERATOR_UNAVAILABLE_MESSAGE: String =
+            "Couldn't read the host session list (pocketshell sessions list did not respond). " +
+                "Not showing a partial list."
         /**
          * Optional raw-id enrichment for the *human-table* old-host fallback
          * only. JSON success must not issue this second hop (#2348). The seven

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListLiveClientEnumerator.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListLiveClientEnumerator.kt
@@ -1,0 +1,132 @@
+package com.pocketshell.app.projects
+
+import android.util.Log
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.uikit.model.SessionAgentKind
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Issue #692: the folder list's session/pane enumeration served off the live
+ * `tmux -CC` control client instead of a fresh SSH lease.
+ *
+ * Split out of [SshFolderListGateway] in issue #2377 (the file sits on a
+ * downward-only size ratchet). The behaviour is unchanged; what DID change is
+ * the caller: a `-CC` client is attached to exactly ONE tmux server, so these
+ * rows are the metadata overlay for that one socket, never the host's session
+ * SET. [SshFolderListGateway.listSessionsWithFolder] unions the tmuxctl+aplexer
+ * enumerator over them.
+ */
+internal object FolderListLiveClientEnumerator {
+    /**
+     * Issue #692: enumerate session + pane rows from the live `-CC` control
+     * client in ONE batched control-mode round-trip.
+     *
+     * Returns null when no matching live client is connected (the caller then
+     * opens an SSH lease) and when the enumeration errors (so the lease path
+     * can produce an accurate error). An EMPTY list is a valid result — it
+     * means a connected client with `no server running` (all sessions gone),
+     * which is distinct from "no client". The two probes (`list-sessions`,
+     * `list-panes`) are chained via [TmuxClient.sendChainedCommands] so the
+     * already-open channel pays a single wire round-trip instead of two
+     * serial commands.
+     */
+    suspend fun enumerate(
+        activeTmuxClients: ActiveTmuxClients,
+        host: HostEntity,
+        keyPath: String,
+        liveEnumTimeoutMs: Long,
+        familyForRawId: (String?) -> SessionAgentKind?,
+    ): List<FolderSessionRow>? {
+        val entry = activeTmuxClients.clients.value[host.id]
+            ?.takeIf { it.matches(host, keyPath) }
+            ?.takeUnless { it.client.disconnected.value }
+            ?: return null
+        return try {
+            // Issue #702: bound the live-client enumeration so a wedged shared
+            // `-CC` control channel (single-flight mutex held by never-releasing
+            // in-session traffic) can't pin the picker. On timeout we return
+            // null and the caller falls through to the bounded SSH-lease
+            // enumeration (execBounded). `sendChainedCommands` itself also
+            // self-bounds its acquire (#702); this is the gateway-side defence.
+            val responses = withTimeoutOrNull(liveEnumTimeoutMs) {
+                entry.client.sendChainedCommands(
+                    listOf(
+                        SshFolderListGateway.CONTROL_LIST_SESSIONS_COMMAND,
+                        SshFolderListGateway.CONTROL_LIST_PANES_COMMAND,
+                    ),
+                )
+            } ?: run {
+                Log.w(
+                    SshFolderListGateway.PROBE_LOG_TAG,
+                    "live -CC enumeration wedged >${liveEnumTimeoutMs}ms; " +
+                        "falling through to bounded SSH-lease enumeration.",
+                )
+                return null
+            }
+            val listSessions = responses.getOrNull(0) ?: return null
+            val listPanes = responses.getOrNull(1)
+            when {
+                listSessions.isError &&
+                    listSessions.output.joinToString("\n").contains("no server running", ignoreCase = true) ->
+                    emptyList()
+                listSessions.isError -> null
+                else -> {
+                    val baseRows = SshFolderListGateway.parseListSessionsRows(
+                        stdout = listSessions.output.joinToString(separator = "\n"),
+                        familyForRawId = familyForRawId,
+                    )
+                    val windowRows = if (listPanes != null && !listPanes.isError) {
+                        SshFolderListGateway.parseSessionWindowRows(listPanes.output.joinToString("\n"))
+                    } else {
+                        emptyList()
+                    }
+                    val paneRows = SshFolderListGateway.activePaneRowsBySession(windowRows)
+                    val windowsBySession = windowRows.groupBy { it.sessionName }
+
+                    baseRows.map { row ->
+                        val pane = paneRows[row.sessionName]
+                        // Epic #821: a recorded `@ps_agent_kind` (read back in
+                        // parseRow from CONTROL_LIST_SESSIONS_COMMAND) is the
+                        // authoritative kind for a session WE launched. This
+                        // live path runs no detector, so the recorded kind is
+                        // the only positive agent signal here for our sessions.
+                        val recorded = row.recordedKind
+                        val windows = windowsBySession[row.sessionName].orEmpty().map { window ->
+                            // Issue #716: the live-client path runs NO detector
+                            // (the control channel can't host the ps/candidate
+                            // scan), so resolve the raw kind affirmative-shell-
+                            // aware — an interactive-shell pane is a confirmed
+                            // Shell, anything else is presumed-agent Probing.
+                            // NEVER emit a raw `Shell` for an undetected window:
+                            // a false `Shell` would downgrade a sticky agent in
+                            // the maintained tree (#716). A recorded kind
+                            // (#821) wins.
+                            window.copy(
+                                agentKind = recorded ?: SshFolderListGateway.resolveUndetectedKind(window.command),
+                            )
+                        }
+                        row.copy(
+                            cwd = pane?.cwd ?: row.cwd,
+                            agentKind = recorded ?: SshFolderListGateway.resolveUndetectedKind(
+                                (windows.firstOrNull { it.active } ?: windows.firstOrNull())?.command,
+                            ),
+                            windows = windows,
+                        )
+                    }
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun ActiveTmuxClients.Entry.matches(host: HostEntity, keyPath: String): Boolean =
+        hostname == host.hostname &&
+            port == host.port &&
+            username == host.username &&
+            this.keyPath == keyPath
+}

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListPocketshellEnumerator.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListPocketshellEnumerator.kt
@@ -1,42 +1,51 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.sessions.HostSessionEnumerator
 import com.pocketshell.app.sessions.HostTmuxSessionListParser
 import com.pocketshell.app.sessions.HostTmuxSessionRow
 import com.pocketshell.core.ssh.ExecResult
-import kotlinx.coroutines.CancellationException
 
 /**
- * Live session names from `pocketshell sessions list --json` (tmuxctl + aplexer),
- * with a human-table fallback for older hosts that reject `--json`.
+ * Folder-list view of the shared [HostSessionEnumerator]: live session names
+ * from `pocketshell sessions list --json` (tmuxctl + aplexer), with a
+ * human-table fallback for older hosts that reject `--json`.
  *
- * Issue #2348: this enumerator is best-effort overlay on the 12s mobile
- * reconcile path. A hung or timed-out JSON exec must fail-safe to [Fetch.Empty]
- * rather than spending a second human exec; JSON empty-success must not fall
- * through to human either. Exit 0 with a non-JSON body (the 0.4.45 fixture
- * prints the human table for `--json`) is parsed in-process from that same
- * stdout — never a second `humanCommand` hop. Stdin is closed on the JSON
- * body so a wrap()-style first-statement `read()` cannot park the hop until
- * the 12s bound. Unknown `--json` (nonzero exit) may still fall back to one
- * human exec.
+ * Issue #2377: the fetch state machine (including the `Empty` vs `Unavailable`
+ * distinction and the #2348 no-second-hop rules) moved to [HostSessionEnumerator]
+ * so the session PICKER shares it instead of keeping its own narrower copy that
+ * short-circuited on a single-socket live `-CC` client. This object is now only
+ * the row-type adapter ([HostTmuxSessionRow] -> [FolderSessionRow]); every
+ * behavioural rule lives in the shared object and is documented there.
  */
 internal object FolderListPocketshellEnumerator {
     /**
      * JSON enumerator with stdin closed. [SshFolderListGateway.pathAware] wraps
      * this in `/bin/sh -lc` so the redirect applies to the pocketshell process.
      */
-    const val JSON_EXEC_BODY: String =
-        "{ ${SshFolderListGateway.POCKETSHELL_SESSIONS_JSON_COMMAND} ; } </dev/null"
+    val JSON_EXEC_BODY: String =
+        HostSessionEnumerator.jsonExecBody(SshFolderListGateway.POCKETSHELL_SESSIONS_JSON_COMMAND)
 
     sealed class Fetch {
         abstract val rows: List<FolderSessionRow>
 
         data class Json(override val rows: List<FolderSessionRow>) : Fetch()
         data class Human(override val rows: List<FolderSessionRow>) : Fetch()
+        /** The host ran the enumerator and authoritatively reported no rows. */
         data object Empty : Fetch() {
             override val rows: List<FolderSessionRow> get() = emptyList()
         }
         /** Human fallback ran and failed (missing binary / tmux error). */
         data object Failed : Fetch() {
+            override val rows: List<FolderSessionRow> get() = emptyList()
+        }
+
+        /**
+         * Issue #2377: the enumerator could not be RUN (bounded-exec timeout or
+         * transport throw). Rows are empty because nothing was read, not because
+         * the host has no sessions — the caller must NOT treat this as "no extra
+         * sessions" and publish a narrower list.
+         */
+        data object Unavailable : Fetch() {
             override val rows: List<FolderSessionRow> get() = emptyList()
         }
     }
@@ -46,59 +55,23 @@ internal object FolderListPocketshellEnumerator {
         exec: suspend (String) -> ExecResult,
         jsonCommand: String,
         humanCommand: String,
-    ): Fetch {
-        val json = try {
-            exec(jsonCommand)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Throwable) {
-            // Timed out / wrap-stdin hang / transport throw: fail-safe. A second
-            // human exec here is the mutation that reddens #2348 (3.5s + 3.5s
-            // serial on the 12s bound).
-            return Fetch.Empty
-        }
-        if (json.exitCode == 0) {
-            val parsed = parser.parsePocketshellSessionsJson(json.stdout)
-            if (parsed != null) {
-                return Fetch.Json(parsed.map { it.toFolderSessionRow() })
-            }
-            // Exit 0 with a blank body is an empty enumerator, not a prompt
-            // to fall through to the human table (that second exec was
-            // stealing the next queued fake response and breaking lease-reuse
-            // command accounting).
-            if (json.stdout.isBlank()) {
-                return Fetch.Empty
-            }
-            // Docker agents fixture 0.4.45 (and any host that accepts `--json`
-            // then prints the human table): exit 0, stdout starts with IDX,
-            // not `{`. parsePocketshellSessionsJson returns null. A second
-            // `pocketshell sessions list --by activity` here is the extra
-            // mobile-RTT hop that misses the 12s bound. Parse this same
-            // stdout in-process; garbage that is not a table is Empty.
-            val humanRows = SshFolderListGateway.parsePocketshellSessionsRows(
-                json.stdout,
-                parser,
+    ): Fetch =
+        when (
+            val fetched = HostSessionEnumerator.fetch(
+                parser = parser,
+                exec = exec,
+                jsonCommand = jsonCommand,
+                humanCommand = humanCommand,
             )
-            return if (humanRows.isEmpty()) {
-                Fetch.Empty
-            } else {
-                Fetch.Human(humanRows)
-            }
+        ) {
+            is HostSessionEnumerator.Fetch.Json ->
+                Fetch.Json(fetched.rows.map { it.toFolderSessionRow() })
+            is HostSessionEnumerator.Fetch.Human ->
+                Fetch.Human(fetched.rows.map { it.toFolderSessionRow() })
+            HostSessionEnumerator.Fetch.Empty -> Fetch.Empty
+            HostSessionEnumerator.Fetch.Failed -> Fetch.Failed
+            HostSessionEnumerator.Fetch.Unavailable -> Fetch.Unavailable
         }
-        val human = try {
-            exec(humanCommand)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Throwable) {
-            return Fetch.Empty
-        }
-        if (human.exitCode == 0) {
-            return Fetch.Human(
-                SshFolderListGateway.parsePocketshellSessionsRows(human.stdout, parser),
-            )
-        }
-        return Fetch.Failed
-    }
 
     fun unionFolderSessionRows(
         authority: List<FolderSessionRow>,

--- a/app/src/main/java/com/pocketshell/app/sessions/HostSessionEnumerator.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostSessionEnumerator.kt
@@ -1,0 +1,128 @@
+package com.pocketshell.app.sessions
+
+import com.pocketshell.core.ssh.ExecResult
+import kotlinx.coroutines.CancellationException
+
+/**
+ * The host's session ENUMERATOR: `pocketshell sessions list --json` (tmuxctl +
+ * aplexer across every socket), with a human-table fallback for older hosts
+ * that reject `--json`.
+ *
+ * Issue #2377: this used to live only inside
+ * [com.pocketshell.app.projects.FolderListPocketshellEnumerator], so the folder
+ * list was the only surface that knew the difference between "the host has no
+ * other sessions" and "we could not read the host's session list". The session
+ * PICKER — the app's other session list — had its own narrower copy and
+ * short-circuited on a live `tmux -CC` client, which is attached to exactly ONE
+ * tmux server. Both surfaces now share this one state machine so a fix to the
+ * undercount class cannot land on one list and miss the other;
+ * `FolderListPocketshellEnumerator` is a thin row-type adapter over it.
+ *
+ * Issue #2348: the enumerator is bounded on the 12s mobile reconcile path. A
+ * hung or timed-out JSON exec must NOT spend a second human exec; JSON
+ * empty-success must not fall through to human either. Exit 0 with a non-JSON
+ * body (the 0.4.45 fixture prints the human table for `--json`) is parsed
+ * in-process from that same stdout — never a second `humanCommand` hop. Stdin
+ * is closed on the JSON body so a wrap()-style first-statement `read()` cannot
+ * park the hop until the 12s bound. Unknown `--json` (nonzero exit) may still
+ * fall back to one human exec.
+ *
+ * Issue #2377: a transport throw/timeout is [Fetch.Unavailable], NOT
+ * [Fetch.Empty]. The two used to be the same value, and that conflation is the
+ * silent-undercount hazard: `Empty` means "the host authoritatively reports
+ * these zero extra sessions", so the caller happily publishes whatever narrower
+ * enumeration it already has (default-socket `tmux list-sessions`, or a live
+ * `-CC` client bound to ONE tmuxctl socket). `Unavailable` means "we do not
+ * know", and the caller must surface a retryable error instead of a
+ * confidently-wrong count. Do not merge these two states again.
+ */
+internal object HostSessionEnumerator {
+    /**
+     * Wrap the JSON enumerator so stdin is closed for the whole pipeline. The
+     * caller still applies its own `pathAware`/`/bin/sh -lc` wrapping, which is
+     * what makes the redirect apply to the pocketshell process.
+     */
+    fun jsonExecBody(jsonCommand: String): String = "{ $jsonCommand ; } </dev/null"
+
+    sealed class Fetch {
+        abstract val rows: List<HostTmuxSessionRow>
+
+        data class Json(override val rows: List<HostTmuxSessionRow>) : Fetch()
+        data class Human(override val rows: List<HostTmuxSessionRow>) : Fetch()
+
+        /** The host ran the enumerator and authoritatively reported no rows. */
+        data object Empty : Fetch() {
+            override val rows: List<HostTmuxSessionRow> get() = emptyList()
+        }
+
+        /** Human fallback ran and failed (missing binary / tmux error). */
+        data object Failed : Fetch() {
+            override val rows: List<HostTmuxSessionRow> get() = emptyList()
+        }
+
+        /**
+         * Issue #2377: the enumerator could not be RUN (bounded-exec timeout or
+         * transport throw). Rows are empty because nothing was read, not because
+         * the host has no sessions — the caller must NOT treat this as "no extra
+         * sessions" and publish a narrower list.
+         */
+        data object Unavailable : Fetch() {
+            override val rows: List<HostTmuxSessionRow> get() = emptyList()
+        }
+    }
+
+    suspend fun fetch(
+        parser: HostTmuxSessionListParser,
+        exec: suspend (String) -> ExecResult,
+        jsonCommand: String,
+        humanCommand: String,
+    ): Fetch {
+        val json = try {
+            exec(jsonCommand)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            // Timed out / wrap-stdin hang / transport throw. A second human exec
+            // here is the mutation that reddens #2348 (3.5s + 3.5s serial on the
+            // 12s bound) — so we still do not retry. But #2377: this is
+            // Unavailable, not Empty. Reporting Empty told the caller the host
+            // has no tmuxctl/aplexer sessions, which silently published the
+            // default-socket subset as if it were the whole truth.
+            return Fetch.Unavailable
+        }
+        if (json.exitCode == 0) {
+            val parsed = parser.parsePocketshellSessionsJson(json.stdout)
+            if (parsed != null) {
+                return Fetch.Json(parsed)
+            }
+            // Exit 0 with a blank body is an empty enumerator, not a prompt
+            // to fall through to the human table (that second exec was
+            // stealing the next queued fake response and breaking lease-reuse
+            // command accounting).
+            if (json.stdout.isBlank()) {
+                return Fetch.Empty
+            }
+            // Docker agents fixture 0.4.45 (and any host that accepts `--json`
+            // then prints the human table): exit 0, stdout starts with IDX,
+            // not `{`. parsePocketshellSessionsJson returns null. A second
+            // `pocketshell sessions list --by activity` here is the extra
+            // mobile-RTT hop that misses the 12s bound. Parse this same
+            // stdout in-process; garbage that is not a table is Empty.
+            val humanRows = parser.parsePocketshellSessionsList(json.stdout)
+            return if (humanRows.isEmpty()) Fetch.Empty else Fetch.Human(humanRows)
+        }
+        val human = try {
+            exec(humanCommand)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            // Issue #2377: same rule as the JSON hop — a transport failure is
+            // "unknown", never "the host has no sessions".
+            return Fetch.Unavailable
+        }
+        if (human.exitCode == 0) {
+            return Fetch.Human(parser.parsePocketshellSessionsList(human.stdout))
+        }
+        return Fetch.Failed
+    }
+}

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionPickerViewModel.kt
@@ -120,6 +120,20 @@ class HostTmuxSessionPickerViewModel @Inject constructor(
      * directory matches [projectPath] (the current pane's cwd). When the
      * host has no live client yet, the previously-known sibling list is
      * retained so the dropdown still opens instantly.
+     *
+     * Issue #2377 — KNOWN, DELIBERATE LIMITATION: a `tmux -CC` client is
+     * attached to exactly ONE tmux server, so these siblings are scoped to the
+     * ATTACHED server. On a tmuxctl host (one `tmuxctl-*` socket per session)
+     * the dropdown can therefore list fewer project siblings than the folder
+     * list shows for the same project. That undercount is fixed in
+     * [HostTmuxSessionsGateway.listSessions] (both session LISTS now union the
+     * host-wide enumerator), but it is left standing HERE on purpose: #463
+     * bought the switcher's "instant" property precisely by never opening an
+     * SSH connection on this path, and the sibling dropdown is a convenience
+     * shortcut, not the app's answer to "what sessions does this host have".
+     * The session picker ([load]) and the folder list are that answer, and both
+     * are complete. Do not "fix" this by calling [HostTmuxSessionsGateway.listSessions]
+     * here without re-deciding the latency contract.
      */
     fun refreshProjectSiblings(
         host: HostEntity,

--- a/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/sessions/HostTmuxSessionsGateway.kt
@@ -31,6 +31,18 @@ interface HostTmuxSessionsGateway {
      * keep the previously-known list rather than blocking on a handshake).
      * This is the data source for the in-session project switcher — using
      * it instead of [listSessions] is what keeps the switch "instant".
+     *
+     * Issue #2377 — READ THIS BEFORE REUSING IT. A `tmux -CC` control client
+     * is attached to exactly ONE tmux server, so these rows are ONE socket's
+     * `list-sessions`, never the host's session SET. On a tmuxctl host (one
+     * `tmuxctl-*` socket per session) plus aplexer, that is a severe
+     * undercount — the maintainer saw "1 session" against a host with 10.
+     * These rows are a metadata OVERLAY only; [listSessions] unions the
+     * host-wide enumerator over them and is the only correct source for a
+     * "these are the host's sessions" list.
+     *
+     * The in-session project switcher (`refreshProjectSiblings`) is the one
+     * deliberate exemption: see the note on that function.
      */
     suspend fun listSessionsFromLiveClient(
         host: HostEntity,
@@ -92,7 +104,27 @@ class SshHostTmuxSessionsGateway internal constructor(
         keyPath: String,
         passphrase: CharArray?,
     ): HostTmuxSessionListResult {
-        listSessionsFromLiveClient(host, keyPath)?.let { return it }
+        // Issue #2377 (hard cut, D22): this used to be
+        // `listSessionsFromLiveClient(host, keyPath)?.let { return it }` — the
+        // live `-CC` client's rows published as the WHOLE session-picker list.
+        // A control client is attached to exactly ONE tmux server, so on the
+        // maintainer's host (7 tmuxctl-managed sessions, one `tmuxctl-*` socket
+        // each, plus 3 aplexer-managed) the picker showed the 1 session on the
+        // socket the app happened to be attached to. Identical defect, identical
+        // trigger and identical class as the folder-list one this issue fixes:
+        // the moment the user is inside a session, a warm client exists.
+        //
+        // The live rows keep their job — they are the richest read of the
+        // ATTACHED server (session_path, recorded `@ps_agent_kind`, ids) and
+        // they cost no SSH — but they are now an OVERLAY, exactly like the
+        // `tmux list-sessions` overlay on the cold branch below. The tmuxctl +
+        // aplexer enumerator is the authority for the session SET on every
+        // branch. Having them means we can skip the cold branch's
+        // `tmux list-sessions` exec, so the warm path still does strictly less
+        // work than the cold one.
+        val liveOverlay =
+            (listSessionsFromLiveClient(host, keyPath) as? HostTmuxSessionListResult.Sessions)
+                ?.rows
 
         SshOpenTelemetry.record(
             source = SSH_SOURCE_SESSION_PICKER_LIST,
@@ -113,21 +145,35 @@ class SshHostTmuxSessionsGateway internal constructor(
                 target = host.toLeaseSessionTarget(keyPath, passphrase),
                 blockTimeoutMs = leaseBlockTimeoutMs,
             ) { session ->
+                if (liveOverlay != null) {
+                    // Warm branch: the live client already read the attached
+                    // server, so the only thing missing is the host-wide set.
+                    return@withSession unionedResult(
+                        enumerator = enumeratorFromPocketshell(session),
+                        overlay = liveOverlay,
+                    )
+                }
                 val tmux = session.execTmuxListSessions(pathAware(LIST_SESSIONS_COMMAND))
                 when {
                     tmux.exitCode == 0 -> {
                         val overlay = parser.parseTmuxListSessions(tmux.stdout) { rawId ->
                             enginesGateway?.familyForRawId(host.id, rawId)
                         }
-                        val enumerator = enumeratorFromPocketshell(session)
-                        HostTmuxSessionListResult.Sessions(
-                            parser.unionLiveSessionRows(enumerator, overlay),
+                        unionedResult(
+                            enumerator = enumeratorFromPocketshell(session),
+                            overlay = overlay,
                         )
                     }
                     tmux.exitCode == 127 || tmux.stderr.contains("not found", ignoreCase = true) ->
                         HostTmuxSessionListResult.ToolUnavailable
                     tmux.stderr.contains("no server running", ignoreCase = true) ->
-                        HostTmuxSessionListResult.Sessions(emptyList())
+                        // The DEFAULT socket has no server. That says nothing
+                        // about the tmuxctl sockets or aplexer, so ask the
+                        // enumerator rather than reporting "no sessions" (#2377).
+                        unionedResult(
+                            enumerator = enumeratorFromPocketshell(session),
+                            overlay = emptyList(),
+                        )
                     else -> HostTmuxSessionListResult.Failed(
                         tmux.stderr.ifBlank { tmux.stdout }.ifBlank { "tmux exited ${tmux.exitCode}" },
                     )
@@ -155,21 +201,51 @@ class SshHostTmuxSessionsGateway internal constructor(
     private fun pathAware(command: String): String =
         ReposRemoteSource.pathAwareCommand(command)
 
-    private suspend fun enumeratorFromPocketshell(session: SshSession): List<HostTmuxSessionRow> {
-        val json = runCatching {
-            session.execTmuxListSessions(pathAware(POCKETSHELL_SESSIONS_JSON_COMMAND))
-        }.getOrNull()
-        if (json != null && json.exitCode == 0) {
-            parser.parsePocketshellSessionsJson(json.stdout)?.let { return it }
+    /**
+     * Issue #2377: the shared host-wide enumerator, the same state machine the
+     * folder list runs (see [HostSessionEnumerator]) instead of this file's old
+     * private copy. The copy swallowed a transport throw into an empty list,
+     * which is indistinguishable from "the host really has no other sessions" —
+     * the conflation that lets a narrow list be published as the truth.
+     */
+    private suspend fun enumeratorFromPocketshell(
+        session: SshSession,
+    ): HostSessionEnumerator.Fetch =
+        HostSessionEnumerator.fetch(
+            parser = parser,
+            exec = { command -> session.execTmuxListSessions(command) },
+            jsonCommand = pathAware(
+                HostSessionEnumerator.jsonExecBody(POCKETSHELL_SESSIONS_JSON_COMMAND),
+            ),
+            humanCommand = pathAware(POCKETSHELL_SESSIONS_COMMAND),
+        )
+
+    /**
+     * Issue #2377: union the host-wide enumerator (AUTHORITY for which sessions
+     * exist) over a single-socket [overlay] (richer metadata for the sessions it
+     * can see) — the same rule, and the same [HostTmuxSessionListParser.unionLiveSessionRows]
+     * call, on every branch of [listSessions].
+     *
+     * [HostSessionEnumerator.Fetch.Unavailable] is the one case that must not
+     * fall back to the overlay: we did not read the host, so publishing the
+     * narrower list would be a confidently-wrong count (the reported defect).
+     * The picker renders [HostTmuxSessionListResult.Failed] as a retryable
+     * fallback sheet with this message, which is honest. A
+     * [HostSessionEnumerator.Fetch.Failed] (the host has no working `pocketshell`
+     * CLI at all, so it has no tmuxctl sockets or aplexer either) legitimately
+     * leaves the default socket as the whole truth.
+     */
+    private fun unionedResult(
+        enumerator: HostSessionEnumerator.Fetch,
+        overlay: List<HostTmuxSessionRow>,
+    ): HostTmuxSessionListResult =
+        if (enumerator is HostSessionEnumerator.Fetch.Unavailable) {
+            HostTmuxSessionListResult.Failed(ENUMERATOR_UNAVAILABLE_MESSAGE)
+        } else {
+            HostTmuxSessionListResult.Sessions(
+                parser.unionLiveSessionRows(enumerator.rows, overlay),
+            )
         }
-        val human = runCatching {
-            session.execTmuxListSessions(pathAware(POCKETSHELL_SESSIONS_COMMAND))
-        }.getOrNull()
-        if (human != null && human.exitCode == 0) {
-            return parser.parsePocketshellSessionsList(human.stdout)
-        }
-        return emptyList()
-    }
 
     override suspend fun listSessionsFromLiveClient(
         host: HostEntity,
@@ -266,6 +342,16 @@ class SshHostTmuxSessionsGateway internal constructor(
             "pocketshell sessions list --by activity"
         const val POCKETSHELL_SESSIONS_JSON_COMMAND: String =
             "pocketshell sessions list --json"
+
+        /**
+         * Issue #2377: user-visible reason for refusing to publish a session
+         * list we know is incomplete. Same wording as the folder list's
+         * `SshFolderListGateway.ENUMERATOR_UNAVAILABLE_MESSAGE` — one symptom,
+         * one message, whichever list the user is looking at.
+         */
+        const val ENUMERATOR_UNAVAILABLE_MESSAGE: String =
+            "Couldn't read the host session list (pocketshell sessions list did not respond). " +
+                "Not showing a partial list."
 
         const val LIST_SESSIONS_COMMAND: String =
             "${TmuxRead.CLIENT} list-sessions -F " +

--- a/app/src/test/java/com/pocketshell/app/docker/DockerAgentFixtureContractTest.kt
+++ b/app/src/test/java/com/pocketshell/app/docker/DockerAgentFixtureContractTest.kt
@@ -6,9 +6,11 @@ import com.pocketshell.core.usage.PocketshellUsageJsonParser
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
+import kotlin.io.path.createTempDirectory
 
 class DockerAgentFixtureContractTest {
     private val projectRoot: Path = findProjectRoot()
@@ -40,6 +42,92 @@ class DockerAgentFixtureContractTest {
 
         assertEquals(listOf("claude-main", "codex", "opencode-lab"), sessions.map { it.name })
         assertTrue(sessions.all { it.createdAt != null })
+    }
+
+    /**
+     * Issue #2377: the fixture's `sessions list --json` is the enumerator the
+     * phone's folder list rides. It must union EVERY `tmuxctl-*` socket (one
+     * tmux server per session — the shape a default-socket `tmux list-sessions`
+     * or a single-socket `-CC` client cannot see) with the aplexer manager.
+     *
+     * Before this, the fixture answered `--json` with the same three canned
+     * rows no matter what the host actually ran, so no test — unit or journey —
+     * could reproduce the reported "phone shows 1 of 10 sessions".
+     *
+     * Hermetic: a stub tmux (no real tmux needed on the CI runner) plus an
+     * explicit socket dir, driven through the REAL shim + helper.
+     */
+    @Test
+    fun pocketshellSessionsJsonFixtureUnionsTmuxctlSocketsAndAplexerManager() {
+        val sandbox = createTempDirectory("issue2377-fixture").toFile()
+        try {
+            val socketDir = File(sandbox, "sockets").apply { mkdirs() }
+            listOf("tmuxctl-alpha", "tmuxctl-beta").forEach { File(socketDir, it).writeText("") }
+            val stubTmux = File(sandbox, "tmux-stub").apply {
+                // `-S <path> list-sessions -F '#{session_name}::#{session_created}'`
+                writeText(
+                    "#!/bin/sh\n" +
+                        "socket=\"\$2\"\n" +
+                        "name=\"\$(basename \"\$socket\" | sed 's/^tmuxctl-//')\"\n" +
+                        "printf '%s::1787900000\\n' \"\$name\"\n",
+                )
+                setExecutable(true)
+            }
+            val aplexerSnapshot = File(sandbox, "aplexer.json").apply {
+                writeText(
+                    """{"sessions":[{"name":"aplexer-follow:yolo","id":"ap-1",""" +
+                        """"workspace":"/tmp/aplexer-follow"}]}""",
+                )
+            }
+            val env = mapOf(
+                "POCKETSHELL_FIXTURE_TMUX_BIN" to stubTmux.absolutePath,
+                "POCKETSHELL_FIXTURE_TMUX_SOCKET_DIR" to socketDir.absolutePath,
+                "APLEXER_BIN" to dockerDir.resolve("agent-bin").resolve("a").toString(),
+                "POCKETSHELL_FIXTURE_APLEXER_FILE" to aplexerSnapshot.absolutePath,
+            )
+
+            val json = runFixtureCommand(env, "pocketshell", "sessions", "list", "--json")
+            val rows = HostTmuxSessionListParser().parsePocketshellSessionsJson(json)
+
+            assertTrue("fixture --json must be real JSON the app parses, got:\n$json", rows != null)
+            val parsed = rows!!
+            assertEquals(
+                "canned rows first, then every tmuxctl-* socket, then the aplexer manager",
+                listOf("claude-main", "codex", "opencode-lab", "alpha", "beta", "aplexer-follow:yolo"),
+                parsed.map { it.name },
+            )
+            assertEquals("aplexer", parsed.single { it.name == "aplexer-follow:yolo" }.manager)
+            assertEquals("ap-1", parsed.single { it.name == "aplexer-follow:yolo" }.aplexerId)
+            assertEquals("tmux", parsed.single { it.name == "alpha" }.manager)
+
+            // `tmuxctl list` (the human table `pocketshell sessions list`
+            // proxies) walks the same sockets.
+            val table = runFixtureCommand(env, "tmuxctl", "list")
+            val tableRows = HostTmuxSessionListParser().parsePocketshellSessionsList(table)
+            assertEquals(
+                listOf("claude-main", "codex", "opencode-lab", "alpha", "beta"),
+                tableRows.map { it.name },
+            )
+        } finally {
+            sandbox.deleteRecursively()
+        }
+    }
+
+    /**
+     * Issue #2377 guard on the other side: with nothing seeded — the state every
+     * OTHER journey runs in — the human table is byte-for-byte the committed
+     * fixture, so routing it through the new enumerator moved no existing test.
+     */
+    @Test
+    fun pocketshellSessionsFixtureIsByteIdenticalWithNoSocketsSeeded() {
+        assertEquals(
+            fixtureDir.resolve("pocketshell-sessions-list.txt").toFile().readText(),
+            runFixtureCommand("pocketshell", "sessions", "list", "--by", "activity"),
+        )
+        assertEquals(
+            fixtureDir.resolve("tmuxctl-list.txt").toFile().readText(),
+            runFixtureCommand("tmuxctl", "list"),
+        )
     }
 
     @Test
@@ -91,7 +179,10 @@ class DockerAgentFixtureContractTest {
         assertEquals("enabled\n", runFixtureCommand("systemctl", "--user", "is-enabled", "pocketshell-jobs.service"))
     }
 
-    private fun runFixtureCommand(vararg args: String): String {
+    private fun runFixtureCommand(vararg args: String): String =
+        runFixtureCommand(emptyMap(), *args)
+
+    private fun runFixtureCommand(extraEnv: Map<String, String>, vararg args: String): String {
         val command = dockerDir.resolve("agent-bin").resolve(args.first())
         val process = ProcessBuilder(listOf(command.toString()) + args.drop(1))
             .directory(projectRoot.toFile())
@@ -99,6 +190,7 @@ class DockerAgentFixtureContractTest {
             .also {
                 it.environment()["POCKETSHELL_AGENT_FIXTURE_DIR"] = fixtureDir.toString()
                 it.environment()["POCKETSHELL_PROJECT_ROOT"] = projectRoot.toString()
+                it.environment().putAll(extraEnv)
             }
             .start()
 

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayLiveClientTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayLiveClientTest.kt
@@ -4,7 +4,6 @@ import com.pocketshell.app.repos.ReposJsonParser
 import com.pocketshell.app.repos.ReposRemoteSource
 import com.pocketshell.app.sessions.ActiveTmuxClients
 import com.pocketshell.app.sessions.HostTmuxSessionListParser
-import com.pocketshell.app.sessions.SSH_SOURCE_FOLDER_LIST_PROBE
 import com.pocketshell.app.sessions.SshOpenTelemetry
 import com.pocketshell.app.tmux.FakeTmuxClient
 import com.pocketshell.core.ssh.ExecResult
@@ -37,7 +36,7 @@ class FolderListGatewayLiveClientTest {
     }
 
     @Test
-    fun sameHostLiveClientListsFolderRowsWithoutOpeningSsh() = runTest {
+    fun sameHostLiveClientListsFolderRowsFromOneControlRoundTrip() = runTest {
         val client = FakeTmuxClient()
         client.responses += CommandResponse(
             number = 1L,
@@ -68,15 +67,34 @@ class FolderListGatewayLiveClientTest {
             keyPath = KEY_PATH,
             client = client,
         )
+        // Issue #2377: the lease still runs the host-wide tmuxctl+aplexer
+        // enumerator (this host reports none), but must NOT re-run
+        // list-sessions / list-panes — the live client already did that in one
+        // control round-trip, which is #692's actual guarantee.
+        val leaseSession = RecordingSshSession()
         val gateway = SshFolderListGateway(
             reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
             activeTmuxClients = activeTmuxClients,
+            sshLeaseManager = SshLeaseManager(
+                connector = object : SshLeaseConnector {
+                    override suspend fun connect(target: SshLeaseTarget) =
+                        Result.success<SshSession>(leaseSession)
+                },
+                scope = this,
+                idleTtlMillis = 0L,
+            ),
         )
 
         val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
 
         val rows = (result as FolderListResult.Sessions).rows
         assertEquals(listOf("git-cable-world", "git-cable-world-map"), rows.map { it.sessionName })
+        assertTrue(
+            "lease must not re-enumerate tmux sessions/panes; got ${leaseSession.execCommands}",
+            leaseSession.execCommands.none {
+                it.contains(LIST_SESSIONS_HEAD) || it.contains(LIST_PANES_HEAD)
+            },
+        )
         assertEquals(listOf("/home/testuser/git/cable-world/app", "/tmp/cable-world-map"), rows.map { it.cwd })
         // Issue #716: the live-client path runs no detector, so each session's
         // kind falls back to the AFFIRMATIVE-shell-aware resolution of its
@@ -96,7 +114,6 @@ class FolderListGatewayLiveClientTest {
         assertEquals(listOf("shell", "claude"), rows[0].windows.map { it.name })
         assertEquals(listOf(false, true), rows[0].windows.map { it.active })
         assertEquals(listOf("/home/testuser/git/cable-world", "/home/testuser/git/cable-world/app"), rows[0].windows.map { it.cwd })
-        assertEquals(0, SshOpenTelemetry.count(SSH_SOURCE_FOLDER_LIST_PROBE))
         assertEquals(
             listOf(
                 SshFolderListGateway.CONTROL_LIST_SESSIONS_COMMAND,
@@ -147,9 +164,13 @@ class FolderListGatewayLiveClientTest {
         val gateway = SshFolderListGateway(
             reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
             activeTmuxClients = activeTmuxClients,
+            // Issue #2377: the live path DOES dial the (pooled) lease now — it
+            // must, to read the host-wide tmuxctl+aplexer enumerator that the
+            // single-socket control client cannot see.
             sshLeaseManager = SshLeaseManager(
-                connector = SshLeaseConnector {
-                    Result.failure(IllegalStateException("live path must not dial"))
+                connector = object : SshLeaseConnector {
+                    override suspend fun connect(target: SshLeaseTarget) =
+                        Result.success<SshSession>(RecordingSshSession())
                 },
                 scope = this,
                 idleTtlMillis = 0L,

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListPocketshellEnumeratorTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListPocketshellEnumeratorTest.kt
@@ -15,7 +15,10 @@ import org.junit.Test
  * Mutation that must redden [jsonHangDoesNotFallThroughToHuman]: catching a
  * JSON timeout/throw and falling through to `pocketshell sessions list --by
  * activity`. That second exec is what turns a 3.5s bounded miss into a 7s
- * serial stall on the 12s mobile reconcile path.
+ * serial stall on the 12s mobile reconcile path. Issue #2377 added the second
+ * half of that assertion: the hang must resolve to [Fetch.Unavailable], not
+ * [Fetch.Empty] — collapsing "we could not read it" into "the host has none"
+ * is what let a narrower enumeration ship as the truth.
  *
  * Mutation that must redden [jsonExitZeroHumanTableDoesNotExecHumanFallback]:
  * JSON exit 0 with `IDX  SESSION…` stdout (the 0.4.45 agents fixture) falling
@@ -94,9 +97,14 @@ class FolderListPocketshellEnumeratorTest {
             humanCommand = HUMAN_CMD,
         )
 
-        assertTrue(fetched is FolderListPocketshellEnumerator.Fetch.Empty)
+        assertTrue(
+            "issue #2377: a hung enumerator is UNAVAILABLE (unknown), never Empty " +
+                "(authoritatively no sessions) — Empty let the caller publish the " +
+                "default-socket subset as the whole host",
+            fetched is FolderListPocketshellEnumerator.Fetch.Unavailable,
+        )
         assertEquals(
-            "a hung JSON enumerator must fail-safe to empty, not spend a second exec",
+            "a hung JSON enumerator must not spend a second exec",
             emptyList<FolderSessionRow>(),
             fetched.rows,
         )

--- a/app/src/test/java/com/pocketshell/app/projects/Issue2377SessionListUndercountTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/Issue2377SessionListUndercountTest.kt
@@ -1,0 +1,419 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.repos.ReposJsonParser
+import com.pocketshell.app.repos.ReposRemoteSource
+import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.sessions.HostTmuxSessionListParser
+import com.pocketshell.app.tmux.FakeTmuxClient
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #2377 — the phone's session list severely UNDERCOUNTED the host.
+ *
+ * Reported 2026-08-28 13:36 on `hetzner`: the folder-list host summary read
+ * "1 active · 0 idle · 1 session" while the host itself reported ten:
+ *
+ * ```
+ * $ pocketshell sessions list --json | jq '.sessions | length'
+ * 10   # 7 tmux-managed (one per tmuxctl-* socket) + 3 aplexer-managed
+ * $ tmuxctl list
+ * 1  git-pocketshell   … 7  git-aplexer
+ * $ tmux list-sessions        # the DEFAULT socket, the app's whole answer
+ * git-pocketshell: 1 windows
+ * ```
+ *
+ * Root cause (a gap #2348's fix never covered, not a revert of it): a live
+ * `-CC` control client is attached to exactly ONE tmux server, so its
+ * `list-sessions` sees one socket. [SshFolderListGateway.listSessionsWithFolder]
+ * used to `return` those single-socket rows verbatim (issue #692's "no watched
+ * roots → no lease at all" shortcut) and, when watched roots existed, still
+ * never consulted the tmuxctl+aplexer enumerator on that branch. #2348 only
+ * ever unioned the enumerator on the NO-live-client branch. The maintainer had
+ * just created `git-pocketshell` from the New Session sheet and been attached
+ * into it — which is precisely what registers the live client — so the poll
+ * that followed rendered the one session on that one socket.
+ *
+ * Class coverage (G2), all three trigger conditions the issue names:
+ *  - cold load with a live client and no watched roots
+ *    ([coldLoadWithLiveClientListsEveryHostSessionNotJustTheAttachedSocket]),
+ *  - routine reconcile with watched roots configured
+ *    ([reconcileWithWatchedRootsAndLiveClientListsEveryHostSession]),
+ *  - the poll immediately after a create+attach
+ *    ([reconcileRightAfterCreateAttachDoesNotCollapseToTheCreatedSession]).
+ *
+ * Plus the silent-degradation half (AC3): an enumerator that could not be READ
+ * must surface a retryable error, never a confidently-wrong narrower count
+ * ([unreadableEnumeratorOnLiveClientPathFailsInsteadOfUndercounting],
+ * [unreadableEnumeratorOnNativePathFailsInsteadOfUndercounting]).
+ */
+class Issue2377SessionListUndercountTest {
+
+    @Test
+    fun coldLoadWithLiveClientListsEveryHostSessionNotJustTheAttachedSocket() = runTest {
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients, attachedSessionRow())
+        val session = HostEnumeratorSession()
+        val gateway = gateway(session, activeTmuxClients)
+
+        val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
+
+        assertTrue("expected a session list, got $result", result is FolderListResult.Sessions)
+        val names = (result as FolderListResult.Sessions).rows.map { it.sessionName }
+        assertEquals(
+            "the app's list must match `pocketshell sessions list --json`, not the " +
+                "one socket the live -CC client happens to be attached to",
+            HOST_CLI_SESSION_NAMES,
+            names,
+        )
+        assertEquals(
+            "the reported symptom was a count of 1 against a host reporting 10",
+            10,
+            names.size,
+        )
+        assertEquals(
+            "the enumerator must be read exactly once per poll",
+            1,
+            session.execCommands.count { it.contains("sessions list --json") },
+        )
+    }
+
+    @Test
+    fun liveClientRowsStillContributeCwdAndWindowsForTheAttachedSocket() = runTest {
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients, attachedSessionRow())
+        val session = HostEnumeratorSession()
+        val gateway = gateway(session, activeTmuxClients)
+
+        val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
+
+        val rows = (result as FolderListResult.Sessions).rows
+        val attached = rows.single { it.sessionName == ATTACHED_SESSION }
+        assertEquals(
+            "the live client stays the metadata overlay for its own socket",
+            "/home/alexey/git/pocketshell",
+            attached.cwd,
+        )
+        assertEquals(listOf("editor"), attached.windows.map { it.name })
+        // …and the aplexer manager/id survives the union so the row is not
+        // silently re-typed as a tmux session.
+        val aplexer = rows.single { it.sessionName == "aplexer-follow:yolo" }
+        assertEquals("aplexer", aplexer.sessionManager)
+        assertEquals("b3feff71-4a78-4055-a2d3-6c99187ecffb", aplexer.aplexerId)
+        assertEquals(
+            "tmux",
+            rows.single { it.sessionName == "git-ai-shipping-labs" }.sessionManager,
+        )
+    }
+
+    @Test
+    fun reconcileWithWatchedRootsAndLiveClientListsEveryHostSession() = runTest {
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients, attachedSessionRow())
+        val session = HostEnumeratorSession()
+        val gateway = gateway(session, activeTmuxClients)
+
+        val result = gateway.listSessionsWithFolder(
+            host = HOST,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            watchedRoots = listOf(
+                ProjectRootEntity(id = 1L, hostId = HOST.id, label = "git", path = "~/git"),
+            ),
+        )
+
+        assertTrue("expected a session list, got $result", result is FolderListResult.Sessions)
+        assertEquals(
+            HOST_CLI_SESSION_NAMES,
+            (result as FolderListResult.Sessions).rows.map { it.sessionName },
+        )
+    }
+
+    @Test
+    fun reconcileRightAfterCreateAttachDoesNotCollapseToTheCreatedSession() = runTest {
+        // The observed trigger: "New session" created `git-pocketshell`, the app
+        // attached into it, and the very next poll ran with a live -CC client
+        // bound to that brand-new server. The host CLI already reports the new
+        // session too, so a correct union is still the full ten.
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients, attachedSessionRow())
+        val session = HostEnumeratorSession()
+        val gateway = gateway(session, activeTmuxClients)
+
+        val names = (1..2).map { poll ->
+            val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
+            assertTrue("poll $poll expected a session list, got $result", result is FolderListResult.Sessions)
+            (result as FolderListResult.Sessions).rows.map { it.sessionName }
+        }
+
+        assertEquals(
+            "the post-create poll must not collapse the list to the just-created session",
+            listOf(HOST_CLI_SESSION_NAMES, HOST_CLI_SESSION_NAMES),
+            names,
+        )
+        assertTrue(
+            "the just-created session must still be present exactly once",
+            names.all { it.count { name -> name == ATTACHED_SESSION } == 1 },
+        )
+    }
+
+    @Test
+    fun nativeTmuxPathWithoutLiveClientKeepsUnioningTheHostEnumerator() = runTest {
+        // #2348's guarantee, re-pinned here so a future live-client change can't
+        // regress the branch it did cover.
+        val session = HostEnumeratorSession()
+        val gateway = gateway(session, ActiveTmuxClients())
+
+        val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
+
+        assertEquals(
+            HOST_CLI_SESSION_NAMES,
+            (result as FolderListResult.Sessions).rows.map { it.sessionName },
+        )
+    }
+
+    @Test
+    fun unreadableEnumeratorOnLiveClientPathFailsInsteadOfUndercounting() = runTest {
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients, attachedSessionRow())
+        val session = HostEnumeratorSession(enumeratorThrows = true)
+        val gateway = gateway(session, activeTmuxClients)
+
+        val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
+
+        assertTrue(
+            "an unreadable enumerator must surface an error, not publish the " +
+                "single attached socket as the whole host; got $result",
+            result is FolderListResult.Failed,
+        )
+        assertEquals(
+            SshFolderListGateway.ENUMERATOR_UNAVAILABLE_MESSAGE,
+            (result as FolderListResult.Failed).message,
+        )
+    }
+
+    @Test
+    fun unreadableEnumeratorOnNativePathFailsInsteadOfUndercounting() = runTest {
+        val session = HostEnumeratorSession(enumeratorThrows = true)
+        val gateway = gateway(session, ActiveTmuxClients())
+
+        val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
+
+        assertTrue(
+            "an unreadable enumerator must surface an error, not publish the " +
+                "default-socket rows as the whole host; got $result",
+            result is FolderListResult.Failed,
+        )
+        assertEquals(
+            SshFolderListGateway.ENUMERATOR_UNAVAILABLE_MESSAGE,
+            (result as FolderListResult.Failed).message,
+        )
+    }
+
+    @Test
+    fun authoritativeEmptyEnumeratorIsNotTreatedAsUnreadable() = runTest {
+        // The counterpart guard: a host that genuinely reports zero rows must
+        // still render (the default-socket overlay), not an error panel.
+        val session = HostEnumeratorSession(enumeratorJson = """{"sessions":[]}""")
+        val gateway = gateway(session, ActiveTmuxClients())
+
+        val result = gateway.listSessionsWithFolder(HOST, KEY_PATH, passphrase = null)
+
+        assertTrue("expected a session list, got $result", result is FolderListResult.Sessions)
+        assertEquals(
+            listOf(DEFAULT_SOCKET_SESSION),
+            (result as FolderListResult.Sessions).rows.map { it.sessionName },
+        )
+    }
+
+    private fun gateway(
+        session: SshSession,
+        activeTmuxClients: ActiveTmuxClients,
+    ): SshFolderListGateway =
+        SshFolderListGateway(
+            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+            activeTmuxClients = activeTmuxClients,
+            sshLeaseManager = SshLeaseManager(
+                connector = SshLeaseConnector { Result.success(session) },
+            ),
+            sessionListParser = HostTmuxSessionListParser(),
+            execReadTimeoutMs = SshFolderListGateway.EXEC_READ_TIMEOUT_MS,
+            enginesGateway = null,
+        )
+
+    /**
+     * A live `-CC` control client attached to ONE tmux server, replaying the
+     * chained `list-sessions` + `list-panes` batch for that server only. Every
+     * `listSessionsWithFolder` call sends the batch again, so the responses are
+     * refilled on demand.
+     */
+    private fun registerLiveClient(
+        activeTmuxClients: ActiveTmuxClients,
+        sessionLine: String,
+    ) {
+        val client = FakeTmuxClient()
+        repeat(REPLAY_POLLS) {
+            client.responses += CommandResponse(number = 1L, output = listOf(sessionLine), isError = false)
+            client.responses += CommandResponse(
+                number = 2L,
+                output = listOf(
+                    "$ATTACHED_SESSION${SEP}0${SEP}editor${SEP}1${SEP}1$SEP" +
+                        "/home/alexey/git/pocketshell${SEP}/dev/pts/4${SEP}nvim${SEP}@0${SEP}4242",
+                ),
+                isError = false,
+            )
+        }
+        activeTmuxClients.register(
+            hostId = HOST.id,
+            hostName = HOST.name,
+            hostname = HOST.hostname,
+            port = HOST.port,
+            username = HOST.username,
+            keyPath = KEY_PATH,
+            client = client,
+        )
+    }
+
+    private fun attachedSessionRow(): String =
+        "$ATTACHED_SESSION$SEP\$1${SEP}1787900039${SEP}1787900039${SEP}1$SEP$SEP$SEP$SEP$SEP" +
+            "/home/alexey/git/pocketshell"
+
+    /**
+     * The maintainer's host as captured in the issue: the DEFAULT socket holds
+     * exactly the session the app just created, while `pocketshell sessions
+     * list --json` reports all ten across the `tmuxctl-*` sockets plus aplexer.
+     */
+    private class HostEnumeratorSession(
+        private val enumeratorThrows: Boolean = false,
+        private val enumeratorJson: String = HOST_CLI_JSON,
+    ) : SshSession {
+        val execCommands: MutableList<String> = java.util.Collections.synchronizedList(mutableListOf())
+
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            synchronized(execCommands) { execCommands += command }
+            return when {
+                command.contains("sessions list --json") -> {
+                    if (enumeratorThrows) {
+                        throw FolderListExecTimeoutException(
+                            command,
+                            SshFolderListGateway.EXEC_READ_TIMEOUT_MS,
+                        )
+                    }
+                    ExecResult(enumeratorJson, "", 0)
+                }
+                command.contains("sessions list --by") ->
+                    error("the JSON enumerator owns this hop (#2348); a second human exec is the regression")
+                command.contains(SshFolderListGateway.ENUMERATION_MARKER) ->
+                    ExecResult(DEFAULT_SOCKET_ENUMERATION, "", 0)
+                else -> ExecResult("", "", 1)
+            }
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+        override fun close() = Unit
+    }
+
+    private companion object {
+        const val KEY_PATH: String = "/tmp/pocketshell-test-key"
+        const val REPLAY_POLLS: Int = 4
+        const val ATTACHED_SESSION: String = "git-pocketshell"
+
+        /**
+         * The default socket holds ONLY the just-created session — this is the
+         * bare `tmux list-sessions` answer that used to reach the user as "1
+         * session" (and, on the live-client path, the one-socket `-CC` answer).
+         */
+        const val DEFAULT_SOCKET_SESSION: String = "git-pocketshell"
+
+        val HOST: HostEntity = HostEntity(
+            id = 42L,
+            name = "hetzner",
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "alexey",
+            keyId = 7L,
+        )
+        val SEP: String = SshFolderListGateway.FIELD_SEP
+        val MARKER: String = SshFolderListGateway.ENUMERATION_MARKER
+
+        /** 7 tmuxctl-managed (one socket each) + 3 aplexer-managed = 10. */
+        val HOST_CLI_SESSION_NAMES: List<String> = listOf(
+            "git-pocketshell",
+            "git-ai-dev-tools-zoomcamp",
+            "git-pocketshell-release",
+            "git-zcode-acp",
+            "git-ai-shipping-labs",
+            "git-game-tester",
+            "git-aplexer",
+            "aplexer-follow:yolo",
+            "aplexer-follow:beta",
+            "aplexer-follow:gamma",
+        )
+
+        val HOST_CLI_JSON: String = buildString {
+            append("""{"managers":["tmux","aplexer"],"sessions":[""")
+            append(
+                HOST_CLI_SESSION_NAMES.take(7).joinToString(",") { name ->
+                    """{"name":"$name","manager":"tmux","created":"2026-08-28 13:33:59"}"""
+                },
+            )
+            append(",")
+            append(
+                """{"name":"aplexer-follow:yolo","manager":"aplexer",""" +
+                    """"id":"b3feff71-4a78-4055-a2d3-6c99187ecffb",""" +
+                    """"workspace":"/tmp/aplexer-follow"},""",
+            )
+            append(
+                """{"name":"aplexer-follow:beta","manager":"aplexer",""" +
+                    """"id":"1d2e3f40-0000-4000-8000-000000000002"},""",
+            )
+            append(
+                """{"name":"aplexer-follow:gamma","manager":"aplexer",""" +
+                    """"id":"1d2e3f40-0000-4000-8000-000000000003"}""",
+            )
+            append("]}")
+        }
+
+        /**
+         * The sectioned landing probe: `tmux list-sessions` then `list-panes`,
+         * both against the DEFAULT socket, which on the reported host holds only
+         * the session the app just created.
+         */
+        val DEFAULT_SOCKET_ENUMERATION: String =
+            "$DEFAULT_SOCKET_SESSION${SEP}\$1${SEP}1787900039${SEP}1787900039${SEP}1" +
+                "$SEP$SEP$SEP$SEP$SEP/home/alexey/git/pocketshell\n" +
+                "$MARKER 0\n" +
+                "$DEFAULT_SOCKET_SESSION${SEP}0${SEP}editor${SEP}1${SEP}1$SEP" +
+                "/home/alexey/git/pocketshell${SEP}/dev/pts/4${SEP}nvim${SEP}@0${SEP}4242\n" +
+                "$MARKER 0\n"
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/HostTmuxSessionsGatewayTest.kt
@@ -35,8 +35,19 @@ class HostTmuxSessionsGatewayTest {
         SshOpenTelemetry.resetForTest()
     }
 
+    /**
+     * Issue #2377: this used to be `sameHostLiveClientListsSessionsWithoutOpeningSsh`
+     * and pinned the defect — the live `-CC` client's rows returned as the WHOLE
+     * picker list, with `SSH_SOURCE_SESSION_PICKER_LIST == 0` proving no lease was
+     * dialled at all. A control client sees ONE tmux server, so that shortcut is
+     * the undercount. What #692 actually bought on this surface, and what is
+     * asserted now, is that the warm path does strictly LESS lease work than the
+     * cold one: the live rows answer `tmux list-sessions`, so the lease only pays
+     * the one host-wide enumerator exec. The union itself is covered by
+     * [Issue2377SessionPickerUndercountTest].
+     */
     @Test
-    fun sameHostLiveClientListsSessionsWithoutOpeningSsh() = runTest {
+    fun sameHostLiveClientListsSessionsFromOneEnumeratorExec() = runTest {
         val client = FakeTmuxClient()
         client.responses += CommandResponse(
             number = 1L,
@@ -55,23 +66,43 @@ class HostTmuxSessionsGatewayTest {
             keyPath = KEY_PATH,
             client = client,
         )
-        val gateway = SshHostTmuxSessionsGateway(parser, activeTmuxClients)
-
-        val result = gateway.listSessions(HOST, KEY_PATH, passphrase = null)
-
-        assertTrue(result is HostTmuxSessionListResult.Sessions)
-        val rows = (result as HostTmuxSessionListResult.Sessions).rows
-        assertEquals(listOf("beta", "alpha"), rows.map { it.name })
-        assertEquals(listOf("\$2", "\$1"), rows.map { it.tmuxSessionId })
-        assertEquals(
-            listOf("/home/alexey/git/pocketshell", "/home/alexey/git/other"),
-            rows.map { it.path },
+        // The host has no working enumerator, so the live rows are the whole
+        // truth here — this test is about the SHAPE of the warm path, not the
+        // union (which Issue2377SessionPickerUndercountTest owns).
+        val session = FakeSshSession()
+        val manager = SshLeaseManager(
+            connector = CountingConnector(Result.success(session)),
+            scope = this,
+            idleTtlMillis = 30_000L,
         )
-        assertEquals(0, SshOpenTelemetry.count(SSH_SOURCE_SESSION_PICKER_LIST))
-        assertEquals(
-            listOf(SshHostTmuxSessionsGateway.LIVE_LIST_SESSIONS_COMMAND),
-            client.sentCommands,
-        )
+        val gateway = SshHostTmuxSessionsGateway(parser, activeTmuxClients, manager)
+
+        try {
+            val result = gateway.listSessions(HOST, KEY_PATH, passphrase = null)
+
+            assertTrue(result is HostTmuxSessionListResult.Sessions)
+            val rows = (result as HostTmuxSessionListResult.Sessions).rows
+            assertEquals(listOf("beta", "alpha"), rows.map { it.name })
+            assertEquals(listOf("\$2", "\$1"), rows.map { it.tmuxSessionId })
+            assertEquals(
+                listOf("/home/alexey/git/pocketshell", "/home/alexey/git/other"),
+                rows.map { it.path },
+            )
+            assertEquals(
+                listOf(SshHostTmuxSessionsGateway.LIVE_LIST_SESSIONS_COMMAND),
+                client.sentCommands,
+            )
+            // The load-bearing #692 property: the lease is NOT asked to redo the
+            // per-socket read the live client just answered.
+            assertEquals(
+                "the warm path must not re-run tmux list-sessions over the lease",
+                0,
+                session.execCommands.count { it.contains("list-sessions") },
+            )
+            assertEquals(1, SshOpenTelemetry.count(SSH_SOURCE_SESSION_PICKER_LIST))
+        } finally {
+            manager.close()
+        }
     }
 
     @Test
@@ -93,10 +124,15 @@ class HostTmuxSessionsGatewayTest {
             keyPath = KEY_PATH,
             client = client,
         )
+        // Issue #2377: the warm path now also reads the host-wide enumerator over
+        // the lease, so a connector that refuses to dial would surface
+        // ConnectFailed. This host simply has no enumerator (`Fetch.Failed`), so
+        // the live rows remain the whole answer and the recorded-kind mapping —
+        // the property under test — is unaffected by the union.
         val manager = SshLeaseManager(
-            connector = CountingConnector(Result.failure(SshException("live path must not dial"))),
+            connector = CountingConnector(Result.success(FakeSshSession())),
             scope = this,
-            idleTtlMillis = 0L,
+            idleTtlMillis = 30_000L,
         )
         val gateway = SshHostTmuxSessionsGateway(
             parser = parser,

--- a/app/src/test/java/com/pocketshell/app/sessions/Issue2377SessionPickerUndercountTest.kt
+++ b/app/src/test/java/com/pocketshell/app/sessions/Issue2377SessionPickerUndercountTest.kt
@@ -1,0 +1,479 @@
+package com.pocketshell.app.sessions
+
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.tmux.FakeTmuxClient
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Issue #2377 — the SESSION PICKER half of the undercount.
+ *
+ * The folder list and the session picker are two independent surfaces reading
+ * two independent gateways, and BOTH had the same defect:
+ * [SshHostTmuxSessionsGateway.listSessions] opened with
+ *
+ * ```kotlin
+ * listSessionsFromLiveClient(host, keyPath)?.let { return it }   // one socket, whole answer
+ * ```
+ *
+ * A `tmux -CC` control client is attached to exactly ONE tmux server, so on the
+ * maintainer's host — 7 tmuxctl-managed sessions, one `tmuxctl-*` socket each,
+ * plus 3 aplexer-managed — the picker published the single session on whichever
+ * socket the app happened to be attached to. The trigger is the same as the
+ * folder list's: being inside a session is what registers the live client, so
+ * the defect is present in exactly the reported state. The lease branch right
+ * below it already unioned the tmuxctl+aplexer enumerator, which is itself the
+ * proof that the union is required for this surface.
+ *
+ * Class coverage (G2) — every branch that can publish a session list:
+ *  - warm live `-CC` client, gateway level
+ *    ([pickerWithLiveClientListsEveryHostSessionNotJustTheAttachedSocket]),
+ *  - warm live `-CC` client, through the production view model to the rendered
+ *    rows ([pickerViewModelRendersEveryHostSessionWithALiveClientAttached]),
+ *  - cold, no live client ([coldPickerWithoutLiveClientKeepsUnioningTheEnumerator]),
+ *  - the default socket reporting `no server running` while tmuxctl/aplexer
+ *    sessions exist ([noServerOnTheDefaultSocketStillListsTmuxctlAndAplexerSessions]).
+ *
+ * Plus the silent-degradation half: an enumerator that could not be READ must
+ * surface a retryable error, never a confidently-wrong narrower count
+ * ([unreadableEnumeratorOnLivePathFailsInsteadOfUndercounting],
+ * [unreadableEnumeratorOnColdPathFailsInsteadOfUndercounting]) — with both
+ * over-correction guards: an authoritatively EMPTY enumerator still renders
+ * ([authoritativeEmptyEnumeratorIsNotTreatedAsUnreadable]) and a host with no
+ * working `pocketshell` CLI at all still lists its default socket
+ * ([oldHostWithoutPocketshellCliStillListsItsDefaultSocketSessions]).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue2377SessionPickerUndercountTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val parser = HostTmuxSessionListParser()
+
+    @Test
+    fun pickerWithLiveClientListsEveryHostSessionNotJustTheAttachedSocket() = runTest {
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients)
+        val session = HostEnumeratorSession()
+        val manager = leaseManager(session)
+
+        try {
+            val result = gateway(activeTmuxClients, manager)
+                .listSessions(HOST, KEY_PATH, passphrase = null)
+
+            assertTrue("expected a session list, got $result", result is HostTmuxSessionListResult.Sessions)
+            val names = (result as HostTmuxSessionListResult.Sessions).rows.map { it.name }
+            assertEquals(
+                "the picker must match `pocketshell sessions list --json`, not the one " +
+                    "socket the live -CC client happens to be attached to",
+                HOST_CLI_SESSION_NAMES,
+                names,
+            )
+            assertEquals(
+                "the reported symptom was a count of 1 against a host reporting 10",
+                10,
+                names.size,
+            )
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun pickerViewModelRendersEveryHostSessionWithALiveClientAttached() = runTest {
+        // The user-visible half: HostTmuxSessionPickerState.Ready.rows is what
+        // the session sheet lists.
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients)
+        val session = HostEnumeratorSession()
+        val manager = leaseManager(session)
+
+        try {
+            val vm = HostTmuxSessionPickerViewModel(gateway(activeTmuxClients, manager))
+            vm.load(
+                HostTmuxSessionPickerRequest(host = HOST, keyPath = KEY_PATH, passphrase = null),
+            )
+
+            val settled = vm.state.first {
+                it is HostTmuxSessionPickerState.Ready ||
+                    it is HostTmuxSessionPickerState.Fallback ||
+                    it is HostTmuxSessionPickerState.ConnectError
+            }
+            assertTrue("picker must reach Ready, got $settled", settled is HostTmuxSessionPickerState.Ready)
+            val names = (settled as HostTmuxSessionPickerState.Ready).rows.map { it.name }
+            assertEquals(
+                "the rendered picker rows must cover every session the host CLI reports; " +
+                    "missing=${HOST_CLI_SESSION_NAMES - names.toSet()}",
+                HOST_CLI_SESSION_NAMES.toSet(),
+                names.toSet(),
+            )
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun liveClientRowsStillContributeIdAndPathForTheAttachedSocket() = runTest {
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients)
+        val session = HostEnumeratorSession()
+        val manager = leaseManager(session)
+
+        try {
+            val rows = sessionsOf(
+                gateway(activeTmuxClients, manager).listSessions(HOST, KEY_PATH, passphrase = null),
+            )
+
+            val attached = rows.single { it.name == ATTACHED_SESSION }
+            assertEquals(
+                "the live client stays the metadata overlay for its own socket",
+                "\$1",
+                attached.tmuxSessionId,
+            )
+            assertEquals("/home/alexey/git/pocketshell", attached.path)
+            assertTrue("the attached session must still read as attached", attached.attached)
+            // …and the aplexer manager/id survives the union so the row is not
+            // silently re-typed as a plain tmux session.
+            val aplexer = rows.single { it.name == "aplexer-follow:yolo" }
+            assertEquals("aplexer", aplexer.manager)
+            assertEquals("b3feff71-4a78-4055-a2d3-6c99187ecffb", aplexer.aplexerId)
+            assertEquals("tmux", rows.single { it.name == "git-ai-shipping-labs" }.manager)
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun warmPickerDoesNotReRunListSessionsOverTheLease() = runTest {
+        // #692's real guarantee on this surface: the warm branch must still do
+        // strictly LESS lease work than the cold one. It pays exactly one
+        // enumerator exec and never re-reads `tmux list-sessions` the live
+        // client already answered.
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients)
+        val session = HostEnumeratorSession()
+        val manager = leaseManager(session)
+
+        try {
+            gateway(activeTmuxClients, manager).listSessions(HOST, KEY_PATH, passphrase = null)
+
+            assertEquals(
+                "the enumerator must be read exactly once per picker load",
+                1,
+                session.execCommands.count { it.contains("sessions list --json") },
+            )
+            assertEquals(
+                "the live client already answered list-sessions for its socket",
+                0,
+                session.execCommands.count { it.contains("list-sessions") },
+            )
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun coldPickerWithoutLiveClientKeepsUnioningTheEnumerator() = runTest {
+        // The branch that was already correct, re-pinned so a future live-client
+        // change cannot regress it either.
+        val session = HostEnumeratorSession()
+        val manager = leaseManager(session)
+
+        try {
+            val rows = sessionsOf(
+                gateway(ActiveTmuxClients(), manager).listSessions(HOST, KEY_PATH, passphrase = null),
+            )
+
+            assertEquals(HOST_CLI_SESSION_NAMES, rows.map { it.name })
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun noServerOnTheDefaultSocketStillListsTmuxctlAndAplexerSessions() = runTest {
+        // A tmuxctl host can legitimately have NOTHING on the default socket
+        // while running ten sessions on `tmuxctl-*` ones. "no server running"
+        // there used to be published as "No tmux sessions found."
+        val session = HostEnumeratorSession(defaultSocketHasNoServer = true)
+        val manager = leaseManager(session)
+
+        try {
+            val rows = sessionsOf(
+                gateway(ActiveTmuxClients(), manager).listSessions(HOST, KEY_PATH, passphrase = null),
+            )
+
+            assertEquals(HOST_CLI_SESSION_NAMES, rows.map { it.name })
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun unreadableEnumeratorOnLivePathFailsInsteadOfUndercounting() = runTest {
+        val activeTmuxClients = ActiveTmuxClients()
+        registerLiveClient(activeTmuxClients)
+        val session = HostEnumeratorSession(enumeratorThrows = true)
+        val manager = leaseManager(session)
+
+        try {
+            val result = gateway(activeTmuxClients, manager)
+                .listSessions(HOST, KEY_PATH, passphrase = null)
+
+            assertTrue(
+                "an unreadable enumerator must surface an error, not publish the single " +
+                    "attached socket as the whole host; got $result",
+                result is HostTmuxSessionListResult.Failed,
+            )
+            assertEquals(
+                SshHostTmuxSessionsGateway.ENUMERATOR_UNAVAILABLE_MESSAGE,
+                (result as HostTmuxSessionListResult.Failed).message,
+            )
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun unreadableEnumeratorOnColdPathFailsInsteadOfUndercounting() = runTest {
+        val session = HostEnumeratorSession(enumeratorThrows = true)
+        val manager = leaseManager(session)
+
+        try {
+            val result = gateway(ActiveTmuxClients(), manager)
+                .listSessions(HOST, KEY_PATH, passphrase = null)
+
+            assertTrue(
+                "an unreadable enumerator must surface an error, not publish the " +
+                    "default-socket rows as the whole host; got $result",
+                result is HostTmuxSessionListResult.Failed,
+            )
+            assertEquals(
+                SshHostTmuxSessionsGateway.ENUMERATOR_UNAVAILABLE_MESSAGE,
+                (result as HostTmuxSessionListResult.Failed).message,
+            )
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun authoritativeEmptyEnumeratorIsNotTreatedAsUnreadable() = runTest {
+        // The counterpart guard: a host that genuinely reports zero enumerator
+        // rows must still render its default-socket sessions, not an error.
+        val session = HostEnumeratorSession(enumeratorJson = """{"sessions":[]}""")
+        val manager = leaseManager(session)
+
+        try {
+            val rows = sessionsOf(
+                gateway(ActiveTmuxClients(), manager).listSessions(HOST, KEY_PATH, passphrase = null),
+            )
+
+            assertEquals(listOf(ATTACHED_SESSION), rows.map { it.name })
+        } finally {
+            manager.close()
+        }
+    }
+
+    @Test
+    fun oldHostWithoutPocketshellCliStillListsItsDefaultSocketSessions() = runTest {
+        // Fetch.Failed (the binary is missing / errors on both shapes) is NOT
+        // Unavailable: such a host has no tmuxctl sockets and no aplexer either,
+        // so the default socket really is the whole truth. Refusing to render
+        // here would be the over-correction.
+        val session = HostEnumeratorSession(enumeratorMissing = true)
+        val manager = leaseManager(session)
+
+        try {
+            val rows = sessionsOf(
+                gateway(ActiveTmuxClients(), manager).listSessions(HOST, KEY_PATH, passphrase = null),
+            )
+
+            assertEquals(listOf(ATTACHED_SESSION), rows.map { it.name })
+        } finally {
+            manager.close()
+        }
+    }
+
+    private fun sessionsOf(result: HostTmuxSessionListResult): List<HostTmuxSessionRow> {
+        assertTrue("expected a session list, got $result", result is HostTmuxSessionListResult.Sessions)
+        return (result as HostTmuxSessionListResult.Sessions).rows
+    }
+
+    private fun leaseManager(session: SshSession): SshLeaseManager =
+        SshLeaseManager(connector = SshLeaseConnector { Result.success(session) })
+
+    private fun gateway(
+        activeTmuxClients: ActiveTmuxClients,
+        manager: SshLeaseManager,
+    ): SshHostTmuxSessionsGateway =
+        SshHostTmuxSessionsGateway(
+            parser = parser,
+            activeTmuxClients = activeTmuxClients,
+            sshLeaseManager = manager,
+        )
+
+    /**
+     * A live `-CC` control client attached to ONE tmux server, answering
+     * `list-sessions` for that server only — the reported state, where the app
+     * had just created a session and been attached into it.
+     */
+    private fun registerLiveClient(activeTmuxClients: ActiveTmuxClients) {
+        val client = FakeTmuxClient()
+        repeat(REPLAY_POLLS) {
+            client.responses += CommandResponse(
+                number = 1L,
+                output = listOf(
+                    "\$1::$ATTACHED_SESSION::1787900039::1787900039::1::" +
+                        "::/home/alexey/git/pocketshell",
+                ),
+                isError = false,
+            )
+        }
+        activeTmuxClients.register(
+            hostId = HOST.id,
+            hostName = HOST.name,
+            hostname = HOST.hostname,
+            port = HOST.port,
+            username = HOST.username,
+            keyPath = KEY_PATH,
+            client = client,
+        )
+    }
+
+    /**
+     * The maintainer's host as captured in the issue: the DEFAULT socket holds
+     * exactly the session the app just created, while `pocketshell sessions
+     * list --json` reports all ten across the `tmuxctl-*` sockets plus aplexer.
+     */
+    private class HostEnumeratorSession(
+        private val enumeratorThrows: Boolean = false,
+        private val enumeratorMissing: Boolean = false,
+        private val defaultSocketHasNoServer: Boolean = false,
+        private val enumeratorJson: String = HOST_CLI_JSON,
+    ) : SshSession {
+        val execCommands: MutableList<String> = java.util.Collections.synchronizedList(mutableListOf())
+
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            synchronized(execCommands) { execCommands += command }
+            return when {
+                command.contains("sessions list --json") -> when {
+                    enumeratorThrows ->
+                        throw TmuxSessionListExecTimeoutException(command, 3_000L)
+                    enumeratorMissing ->
+                        ExecResult("", "pocketshell: not found", 127)
+                    else -> ExecResult(enumeratorJson, "", 0)
+                }
+                command.contains("sessions list --by") -> when {
+                    enumeratorMissing -> ExecResult("", "pocketshell: not found", 127)
+                    else -> error(
+                        "the JSON enumerator owns this hop (#2348); a second human exec is the regression",
+                    )
+                }
+                command.contains("list-sessions") ->
+                    if (defaultSocketHasNoServer) {
+                        ExecResult("", "no server running on /tmp/tmux-1000/default", 1)
+                    } else {
+                        ExecResult(DEFAULT_SOCKET_LIST_SESSIONS, "", 0)
+                    }
+                else -> ExecResult("", "", 1)
+            }
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("not used")
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("not used")
+        override fun startShell(): SshShell = error("not used")
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("not used")
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("not used")
+        override fun close() = Unit
+    }
+
+    private companion object {
+        const val KEY_PATH: String = "/tmp/pocketshell-test-key"
+        const val REPLAY_POLLS: Int = 4
+        const val ATTACHED_SESSION: String = "git-pocketshell"
+
+        val HOST: HostEntity = HostEntity(
+            id = 42L,
+            name = "hetzner",
+            hostname = "10.0.2.2",
+            port = 2222,
+            username = "alexey",
+            keyId = 7L,
+        )
+
+        /** 7 tmuxctl-managed (one socket each) + 3 aplexer-managed = 10. */
+        val HOST_CLI_SESSION_NAMES: List<String> = listOf(
+            "git-pocketshell",
+            "git-ai-dev-tools-zoomcamp",
+            "git-pocketshell-release",
+            "git-zcode-acp",
+            "git-ai-shipping-labs",
+            "git-game-tester",
+            "git-aplexer",
+            "aplexer-follow:yolo",
+            "aplexer-follow:beta",
+            "aplexer-follow:gamma",
+        )
+
+        val HOST_CLI_JSON: String = buildString {
+            append("""{"managers":["tmux","aplexer"],"sessions":[""")
+            append(
+                HOST_CLI_SESSION_NAMES.take(7).joinToString(",") { name ->
+                    """{"name":"$name","manager":"tmux","created":"2026-08-28 13:33:59"}"""
+                },
+            )
+            append(",")
+            append(
+                """{"name":"aplexer-follow:yolo","manager":"aplexer",""" +
+                    """"id":"b3feff71-4a78-4055-a2d3-6c99187ecffb",""" +
+                    """"workspace":"/tmp/aplexer-follow"},""",
+            )
+            append(
+                """{"name":"aplexer-follow:beta","manager":"aplexer",""" +
+                    """"id":"1d2e3f40-0000-4000-8000-000000000002"},""",
+            )
+            append(
+                """{"name":"aplexer-follow:gamma","manager":"aplexer",""" +
+                    """"id":"1d2e3f40-0000-4000-8000-000000000003"}""",
+            )
+            append("]}")
+        }
+
+        /**
+         * The bare `tmux list-sessions` answer for the DEFAULT socket, which on
+         * the reported host holds only the session the app just created — the
+         * one row that used to reach the user as the whole list.
+         */
+        val DEFAULT_SOCKET_LIST_SESSIONS: String =
+            "\$1::$ATTACHED_SESSION::1787900039::1787900039::1::::/home/alexey/git/pocketshell\n"
+    }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2201,7 +2201,7 @@ plus its console timestamps (sum of per-task deltas = 1089s of a 1125s step):
 24 test tasks / 12362 tests. Both halves are close to balanced, and nearly all
 the non-test cost is variant-specific, so splitting by variant halves both.
 
-### The split, and why two shards and not six
+### The split, and why two shards and not more
 
 `unit` is a `strategy.matrix.variant: [Debug, Release]` job: one leg runs
 `./gradlew testDebugUnitTest`, the other `testReleaseUnitTest`. It is a matrix
@@ -2275,8 +2275,10 @@ manual dispatches, not on every pull request.
   The execution guard verifies fresh JUnit results for the complete task set.
 - **Per-push emulator journey subset** — on `main`/manual runs,
   `Emulator journey subset (load-bearing, Docker agents)` fans the journey
-  registry across six independent shards (`0` through `5`). Each shard gets a
-  cold API-35 Pixel 7 emulator and its Docker fixtures. The downstream
+  registry across nine independent shards (`0` through `8`, raised from six in
+  issue #2377 so every leg keeps its #1850 cold-boot retry margin and stays
+  under #835's 125% class-count cap). Each shard gets a cold API-35 Pixel 7
+  emulator and its Docker fixtures. The downstream
   `Emulator journey aggregate verdict` combines shard tokens into `CLEAN`,
   `RE-RUN`, or `RED`, with a real journey failure remaining release-blocking.
 

--- a/scripts/ci-journey-core-terminal-functions.sh
+++ b/scripts/ci-journey-core-terminal-functions.sh
@@ -141,13 +141,15 @@ CORE_TERMINAL_PROOFS=(
 # THE WASTE THIS REMOVES
 # ----------------------
 # Every one of these proofs used to run on EVERY matrix leg. The stated reason
-# was "a regression in any of them is caught on every leg" — but all six legs
+# was "a regression in any of them is caught on every leg" — but all legs
 # run the SAME COMMIT, and these are device-independent in-process Compose /
-# TerminalView tests with no Docker fixture and no cross-shard state. Six
-# identical verdicts on one commit is one verdict plus five copies: ~20-35
-# runner-minutes and 4-7 minutes of wall clock on five legs, buying zero
-# additional signal. (The measured suite is 206 of ~269 runner-min per push and
-# roughly half of that is work repeated six times — see _docs/2026-08-13-test-suite-audit.md §4.)
+# TerminalView tests with no Docker fixture and no cross-shard state. N
+# identical verdicts on one commit is one verdict plus N-1 copies: at the
+# six-shard matrix measured then, ~20-35 runner-minutes and 4-7 minutes of wall
+# clock on five legs, buying zero additional signal, and the waste grows with
+# the total (the matrix is 9 since #2377). (The measured suite is 206 of ~269
+# runner-min per push and roughly half of that is work repeated once per leg —
+# see _docs/2026-08-13-test-suite-audit.md §4.)
 #
 # THE MECHANISM AND WHY THIS SHAPE
 # --------------------------------

--- a/scripts/ci-journey-shard-count.sh
+++ b/scripts/ci-journey-shard-count.sh
@@ -30,8 +30,15 @@
 # a proof that no literal exists — its own header states what it cannot see.
 #
 # ---------------------------------------------------------------------------
-# HOW THE SHIPPED COUNT (6) WAS CHOSEN — the full derivation, kept here rather
-# than in the workflow because this file is what owns the number.
+# HOW THE SHIPPED COUNT (9) WAS CHOSEN — the full derivation, kept here rather
+# than in the workflow because this file is what owns the number. The 6-shard
+# derivation is kept below verbatim (it is still the reasoning FRAMEWORK); the
+# #2377 section at the end is why the answer moved 6 -> 9.
+#
+# --- (1) the #2060 derivation that picked 6, kept as the METHOD ------------
+# Historical in its numbers (registry of 173 entries, run 31292976490) but not in
+# its method: every claim below is how the count is still chosen. Read it first,
+# then section (2) for why the same method now answers 9.
 #
 # The critical path across a matrix is the MAX leg, not the mean, and the max is
 # set by TIME, not class count: membership is by class-name hash (#1862) and
@@ -118,6 +125,70 @@
 # the genuinely measured per-shard `retry_remaining_ms` at total=6 only exists
 # after the first 6-shard `main` run. Read those numbers before treating #1850's
 # AC2 as observed rather than projected.
+#
+# --- (2) issue #2377: the same method now answers 9 -------------------------
+# WHY IT MOVED. #2060's own closing line — "growth headroom at 6 is ~488s on the
+# tightest leg; that is the number to watch as the registry grows" — is exactly
+# what came due. The registry kept growing, and two classes added in the current
+# cycle (FolderSessionRowNavigatorTest 39s from #2380 and
+# Issue2377MultiSocketSessionListDockerTest 61s) pushed shard 3's #1850 margin to
+# 350757ms — UNDER the ~420s twice-failing-class bar. The #1850 hole reopens one
+# leg at a time as the list grows; it does not announce itself.
+#
+# THE ONLY LEVER IS THE TOTAL. Membership is by class-name hash (#1862), which
+# forbids rebalancing by renaming or reordering classes precisely so a hot leg
+# cannot be "fixed" into someone else's leg. Deferring or deleting a class is not
+# a balance fix either. So the question is only which total clears the bar.
+#
+# TWO BARS, NOT ONE, and they disagree. This is the same "heaviest leg by COUNT
+# is not the heaviest by TIME" trap section (1) records, now biting in the other
+# direction — so BOTH shipped-configuration guards have to be satisfied:
+#
+#   #1850 TIME bar   — scripts/test-ci-journey-retry-budget.sh (aa2): every
+#     leg's retry margin > 420000ms. Weighted by measured per-class SECONDS.
+#   #835 COUNT bar   — scripts/test-ci-journey-budget.sh (shard-balance): no leg
+#     over 125% of the ideal CLASS COUNT, plus a 3-sigma uniform band. Unweighted.
+#
+# MEASURED, by re-driving the PRODUCTION selector (and, for the time bar, the
+# PRODUCTION scripts/ci-journey-retry-budget.sh) over the CURRENT 224-class
+# registry and the current per-class fixture
+# (scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv), i.e. exactly
+# what those two cases assert, with the matrix swapped for each candidate total:
+#
+#   total  min #1850 margin (ms)  worst leg (s)  worst count / cap   verdict
+#     3    -2767743               3396            79 / 94            FAIL time
+#     5     -201543               2174            49 / 56            FAIL time
+#     6      350757               1911            43 / 47            FAIL time  (shipped until now)
+#     7      142857               2010            50 / 40            FAIL both
+#     8     1022757               1591            38 / 35            FAIL count
+#     9     1539357               1345            28 / 32            PASS
+#
+# SEVEN IS STILL WORSE THAN SIX, for the same reason #2060 recorded: the hash
+# clusters differently at every total, and at 7 it lands a 2010s / 50-class leg
+# that fails both bars. The ladder is not monotonic in EITHER metric — 10 and 12
+# fail the count cap again while 11 passes — so "just add one shard" is not a
+# valid move; each candidate has to be driven through the selector, which is
+# what the table above is.
+#
+# EIGHT LOOKS RIGHT AND IS NOT. It clears #1850 comfortably (1022757ms) and has
+# a lighter worst leg in SECONDS than 9 does in the tail, but its shard 7 draws
+# 38 of 224 classes against a 35 cap. Shipping 8 would have been green on the
+# retry-budget guard and red on the balance guard — the exact pair of numbers to
+# check together, not one at a time.
+#
+# NINE, on #2060's own rule: the FIRST total that clears EVERY bar. It also has
+# the better-conditioned count margin (28 vs a 32 cap, i.e. 4 classes of growth
+# headroom, against 11's single class) and takes the heaviest leg from 1911s to
+# 1345s. Peak `main`-push concurrency goes to ~13 of the budgeted 20 Actions
+# jobs. Headroom to watch next: 1539357ms of time margin, and 4 classes of count
+# margin on shard 8 — the COUNT bar is now the binding one, so it is what will
+# trip first as the registry grows. When it does, re-run BOTH ladders.
+#
+# The SAME honest caveat as above applies: this table is arithmetic over the
+# production selector and the production budget helper, not an observation of
+# nine shards, and the per-class costs for the two newest rows are local-emulator
+# measurements (see the TSV's own notes) rather than GitHub Actions attempt-1
+# elapsed times. Refresh both once they have run there.
 #
 # It fails CLOSED. An unreadable, missing, empty, or non-contiguous matrix is an
 # error, never a silent default — a helper that guessed would turn every caller

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -598,8 +598,8 @@ source "$CI_JOURNEY_CORE_TERMINAL_HELPER"
 
 # Issue #2110: partition the core-terminal proofs across the CI matrix by the
 # same #1862 name hash the journey classes use, so each proof runs on exactly ONE
-# leg per push instead of all six. Six legs of the same commit re-running the
-# same device-independent in-process proof produced one verdict and five copies.
+# leg per push instead of all of them. N legs of the same commit re-running the
+# same device-independent in-process proof produced one verdict and N-1 copies.
 # A proof this leg does not own is marked OTHER_SHARD before its block below and
 # skipped there; see the helper for why OTHER_SHARD is neither a pass nor a skip.
 # Unsharded runs (no matrix vars) select every proof, unchanged.

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -316,6 +316,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.projects.AgentLaunchVersionMismatchHintE2eTest"  # #853 #848 #759 epic ): the OUTDATED-host agent-launch friendly-hint guard…
   "com.pocketshell.app.projects.FolderListOldCliHydrateDockerTest"  # #849 #848 #847 epic ): the OLD-CLI cold-start tree-HYDRATE connect proof
   "com.pocketshell.app.projects.Issue1876FolderListMobileRttDockerTest"  # #1876 D34/G9/G10: production FolderListViewModel + real sshj over ~400ms RTT, jitter, 5% loss must leave Loading with the full 18-session/3-root tree under the unchanged 12s reconcile bound
+  "com.pocketshell.app.projects.Issue2377MultiSocketSessionListDockerTest"  # #2377 D31/D33/G9/G10 (#2348 recurrence): real tmuxctl-* sockets + an aplexer manager + a LIVE tmux -CC client attached to the default socket — BOTH session lists — the production FolderListViewModel's rendered tree AND the HostTmuxSessionPickerViewModel's rendered picker rows — must equal `pocketshell sessions list --json`, on cold load, on refresh, and right after an in-app create (the reported "1 of 10 sessions")
   "com.pocketshell.app.projects.FolderListBootstrapSkipTreeLoadsDockerTest"  # #849 #848 #847 #788 epic ): the OLD-CLI bootstrap-Skip → tree connect JOURNEY
   "com.pocketshell.app.projects.FolderListClientCacheInstantRenderDockerTest"  # #867 the stale-while-revalidate INSTANT-RENDER journey. A cold co…
   "com.pocketshell.app.projects.FolderListScaleAnrStrictModeDockerTest"  # #965 the SCALE ANR proof — the folder list at

--- a/scripts/ci-red-issue.sh
+++ b/scripts/ci-red-issue.sh
@@ -81,7 +81,7 @@ declare -a failed=()
 [[ "$UNIT_GATE" == "failure" ]] && failed+=("Unit tests")
 [[ "$PYTHON_R" == "failure" ]] && failed+=("Python utility tests (pocketshell)")
 [[ "$INTEGRATION_R" == "failure" ]] && failed+=("Integration tests (Docker)")
-[[ "$JOURNEY_R" == "failure" ]] && failed+=("Emulator journey aggregate verdict (one or more of the 6 shards; see the run for which)")
+[[ "$JOURNEY_R" == "failure" ]] && failed+=("Emulator journey aggregate verdict (one or more of the matrix shards; see the run for which)")
 failure_summary="$(printf '%s; ' "${failed[@]:-}")"
 failure_summary="${failure_summary%; }"
 [[ -n "$failure_summary" ]] || failure_summary="(no job reported failure=true; check the run directly)"

--- a/scripts/ci-skip-check.sh
+++ b/scripts/ci-skip-check.sh
@@ -2,7 +2,7 @@
 # scripts/ci-skip-check.sh — issue #2353
 #
 # Decides whether the ~8h scheduled full-suite run (.github/workflows/tests.yml
-# `schedule:` trigger) should actually pay for the full 6-shard emulator-journey
+# `schedule:` trigger) should actually pay for the full sharded emulator-journey
 # + Docker integration + both unit variants + guards, or SKIP because `main`
 # HEAD has not moved since the last GREEN scheduled run. Avoids spend when
 # nothing landed between cadence ticks; never a correctness gate.

--- a/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
+++ b/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
@@ -292,3 +292,31 @@ com.pocketshell.app.proof.Issue2338SecondLaunchTerminalAttachJourneyE2eTest	64
 # not yet a GitHub Actions run; refresh with a real CI attempt-1 elapsed time
 # once this class has run there, same convention as the Issue2338 row above.
 com.pocketshell.app.proof.FolderSessionRowNavigatorTest	39
+
+# Issue #2377: new selector, never run on GitHub Actions CI. Measured on
+# 2026-08-28 from a warm standalone :app:connectedDebugAndroidTest invocation
+# on the reviewed fix (issue-2377-impl branch, emulator-5554, Docker `agents`
+# fixture on :2222, rc=0, 3/3 passed) via `scripts/connected-test.sh --suffix
+# i2377tsv -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell
+# .app.projects.Issue2377MultiSocketSessionListDockerTest`. The wrapper
+# reported "BUILD SUCCESSFUL in 1m 1s"; this row uses ceil(wrapper wall
+# time)=61s, matching the JOURNEY_PASS wall-time convention used for #1700 and
+# #2338 above. JUnit suite time was 35.942s, and the full wrapper process wall
+# was 132s (AVD pool claim + #776 pre-run sweep + install), but neither is
+# substituted for the isolated Gradle invocation cost — see the #2297 note
+# above on why a contended wrapper wall is not the in-suite cost. Evidence XML
+# digest (sha256):
+# 8c674369431f715c02e2dd22a99645374be4edf26edaf6fbe801f1539a42c8c4. Like
+# #2338, this measurement is from a local dev-box emulator, not a GitHub
+# Actions run — refresh with a real CI attempt-1 elapsed time once this class
+# has run there. Calibration for that local-vs-CI gap, measured the same way on
+# the same emulator on 2026-08-28: the CI-measured sibling
+# FolderListOldCliHydrateDockerTest (24s in this file) reported "BUILD
+# SUCCESSFUL in 34s" locally (JUnit 9.571s), i.e. the local isolated Gradle
+# wall runs ~1.4x the in-suite CI cost. Even discounting by that factor this
+# class costs ~43s, well over the 28s that #1850's shard-3 leg could absorb at
+# the 6-shard matrix, so no defensible cost for it fitted there. That is what
+# moved the matrix to 9 shards (see scripts/ci-journey-shard-count.sh section
+# (2)); the cost below is NOT tuned to fit a total, the total was re-derived to
+# fit the measured costs.
+com.pocketshell.app.projects.Issue2377MultiSocketSessionListDockerTest	61

--- a/tests/docker/Dockerfile.agents
+++ b/tests/docker/Dockerfile.agents
@@ -54,6 +54,8 @@ RUN chmod 600 /home/testuser/.ssh/authorized_keys /root/test_key \
         /usr/local/bin/codex \
         /usr/local/bin/opencode \
         /usr/local/bin/pocketshell \
+        /usr/local/bin/pocketshell-fixture-sessions \
+        /usr/local/bin/a \
         /usr/local/bin/quse \
         /usr/local/bin/agent-log-explorer \
         /usr/local/bin/tmux \

--- a/tests/docker/Dockerfile.agents-old-cli
+++ b/tests/docker/Dockerfile.agents-old-cli
@@ -25,7 +25,14 @@ ARG OLD_CLI_FIXTURE_VERSION=0.4.9
 # responding connect-path host instead — covering the WHOLE connect-break class.
 ARG OLD_CLI_MODE=unknown
 
+# Issue #2377: python3 backs the shared `pocketshell-fixture-sessions` helper
+# that both `tmuxctl list` and the delegated `pocketshell sessions list` use to
+# walk the real `tmuxctl-*` sockets. The `agents` and `agents-daemon` images
+# already carried it; this one did not, and the helper is not optional — a
+# fixture that silently fell back to the canned table would be exactly the
+# "looks green, proves nothing" shape.
 RUN apk add --no-cache openssh-server openssh-client tmux procps bash sqlite git \
+        python3 \
     && mv /usr/bin/tmux /usr/bin/tmux.real \
     && ssh-keygen -A \
     && adduser -D -s /bin/sh testuser \
@@ -54,6 +61,8 @@ RUN chmod 600 /home/testuser/.ssh/authorized_keys /root/test_key \
         /usr/local/bin/codex \
         /usr/local/bin/opencode \
         /usr/local/bin/pocketshell \
+        /usr/local/bin/pocketshell-fixture-sessions \
+        /usr/local/bin/a \
         /usr/local/lib/pocketshell-real-fixture \
         /usr/local/bin/quse \
         /usr/local/bin/agent-log-explorer \

--- a/tests/docker/agent-bin/a
+++ b/tests/docker/agent-bin/a
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+# Issue #2377: minimal `a` (aplexer) fixture for the Docker `agents` image.
+#
+# The real host CLI probes `a --json sessions` and folds the result into
+# `pocketshell sessions list` as a SECOND session manager (see
+# tools/pocketshell/src/pocketshell/{aplexer,session_enum}.py). Without an `a`
+# on the fixture, no connected journey could carry an aplexer-managed row, so
+# the reported "phone shows 1 of 10 sessions" shape (7 tmuxctl + 3 aplexer) was
+# unreproducible on device.
+#
+# State lives in a per-user snapshot file so a journey seeds it over the same
+# SSH session it already has:
+#
+#   printf '%s' '{"sessions":[{"name":"aplexer-follow:yolo","id":"…"}]}' \
+#     > ~/.pocketshell-fixture-aplexer.json
+#
+# Absent file => `{"sessions": []}`, which is what every pre-existing journey
+# sees: the fixture behaves exactly as before this binary existed.
+
+snapshot="${POCKETSHELL_FIXTURE_APLEXER_FILE:-$HOME/.pocketshell-fixture-aplexer.json}"
+
+json=false
+for arg in "$@"; do
+  case "$arg" in
+    --json) json=true ;;
+  esac
+done
+
+verb=""
+for arg in "$@"; do
+  case "$arg" in
+    -*) ;;
+    *)
+      if [ -z "$verb" ]; then verb="$arg"; fi
+      ;;
+  esac
+done
+
+case "$verb" in
+  sessions)
+    if [ "$json" != true ]; then
+      printf 'aplexer fixture only implements `a --json sessions`\n' >&2
+      exit 64
+    fi
+    if [ -r "$snapshot" ]; then
+      cat "$snapshot"
+    else
+      printf '{"sessions": []}\n'
+    fi
+    exit 0
+    ;;
+  --version | version)
+    printf 'aplexer fixture 0.0.0\n'
+    exit 0
+    ;;
+esac
+
+printf 'aplexer fixture supports: --json sessions\n' >&2
+exit 64

--- a/tests/docker/agent-bin/pocketshell
+++ b/tests/docker/agent-bin/pocketshell
@@ -18,6 +18,24 @@ set -eu
 fixture_dir="${POCKETSHELL_AGENT_FIXTURE_DIR:-/opt/pocketshell-agent-fixtures}"
 version_file="${POCKETSHELL_AGENT_FIXTURE_VERSION_FILE:-/opt/pocketshell-agent-fixture-version}"
 
+# Issue #2377: resolve the shared session enumerator NEXT TO THIS SCRIPT first.
+# This shim runs both from `/usr/local/bin` inside the image and straight out of
+# `tests/docker/agent-bin` under DockerAgentFixtureContractTest (and from
+# `/usr/local/lib/pocketshell-real-fixture` in the agents-old-cli image, where
+# the sibling is not next to it — hence the `/usr/local/bin` fallback).
+fixture_sessions_bin() {
+  if [ -n "${POCKETSHELL_FIXTURE_SESSIONS_BIN:-}" ]; then
+    printf '%s\n' "$POCKETSHELL_FIXTURE_SESSIONS_BIN"
+    return 0
+  fi
+  _fsb_dir="$(dirname "$0")"
+  if [ -x "$_fsb_dir/pocketshell-fixture-sessions" ]; then
+    printf '%s\n' "$_fsb_dir/pocketshell-fixture-sessions"
+    return 0
+  fi
+  printf '%s\n' "/usr/local/bin/pocketshell-fixture-sessions"
+}
+
 fixture_version() {
   if [ -n "${POCKETSHELL_AGENT_FIXTURE_VERSION:-}" ]; then
     printf '%s\n' "$POCKETSHELL_AGENT_FIXTURE_VERSION"
@@ -486,13 +504,31 @@ case "${1:-}" in
   sessions)
     shift
     if [ "${1:-}" = "list" ]; then
+      shift
+      # Issue #2377: `--json` is the enumerator the phone's folder list rides
+      # (`pocketshell sessions list --json`), and it must report the union of
+      # EVERY `tmuxctl-*` socket plus the aplexer manager — not just whatever
+      # the default socket (or a live `-CC` client, attached to one server)
+      # happens to hold. The helper below enumerates the seeded sockets and the
+      # `a` fixture for real; with nothing seeded it emits exactly the canned
+      # rows, so every pre-existing journey is byte-for-byte unchanged.
+      sessions_json=0
+      for sessions_arg in "$@"; do
+        case "$sessions_arg" in
+          --json) sessions_json=1 ;;
+        esac
+      done
+      if [ "$sessions_json" = "1" ]; then
+        exec "$(fixture_sessions_bin)" json \
+          "${fixture_dir}/pocketshell-sessions-list.txt"
+      fi
       # The app emits `pocketshell sessions list --by activity`; the
       # fixture ignores the sort flag and returns the canonical listing
       # so the trailing-timestamp parser sees a stable shape.
-      cat "${fixture_dir}/pocketshell-sessions-list.txt"
-      exit 0
+      exec "$(fixture_sessions_bin)" list \
+        "${fixture_dir}/pocketshell-sessions-list.txt"
     fi
-    printf 'pocketshell sessions fixture supports: list [--by created|activity]\n' >&2
+    printf 'pocketshell sessions fixture supports: list [--by created|activity] [--json]\n' >&2
     exit 64
     ;;
   jobs)

--- a/tests/docker/agent-bin/pocketshell-fixture-sessions
+++ b/tests/docker/agent-bin/pocketshell-fixture-sessions
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Live session enumerator for the Docker `agents` fixture (issue #2377).
+
+The real host CLI (`tools/pocketshell/src/pocketshell/session_enum.py`) unions
+two managers:
+
+  * ``tmux``    — every ``tmuxctl-*`` socket, one tmux server per session, which
+                  is why a bare default-socket ``tmux list-sessions`` (and a
+                  live ``-CC`` control client, which is attached to exactly ONE
+                  server) sees only a small subset;
+  * ``aplexer`` — rows reported by the ``a`` binary.
+
+The fixture used to fake all of that with one canned human table, so no journey
+could reproduce the maintainer's reported shape: 7 tmuxctl-managed sessions
+across 7 separate sockets plus 3 aplexer-managed ones, against a default socket
+holding only the session the app had just created. This script gives the fixture
+the real shape while staying byte-for-byte compatible with every existing
+journey:
+
+  * with NO ``tmuxctl-*`` socket and NO aplexer fixture seeded (the state every
+    other journey runs in) ``list`` emits the canned file verbatim and ``json``
+    carries exactly the canned rows;
+  * seeded sockets are enumerated live and appended after the canned rows;
+  * aplexer rows come from the ``a`` fixture binary.
+
+Usage: ``pocketshell-fixture-sessions {list|json} <canned-table-file>``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+
+# The `agents` image renames the distro tmux to `tmux.real` and puts a
+# fault-injecting shim on the PATH; enumerate through the real binary so a
+# journey that arms a shim fault does not also blind the enumerator.
+#
+# `None` means "not inside the fixture image" — the shims are also executed
+# straight out of the repo by DockerAgentFixtureContractTest, and walking the
+# DEVELOPER's `/tmp/tmux-$UID/tmuxctl-*` sockets there would splice their real
+# sessions into a fixture payload. POCKETSHELL_FIXTURE_TMUX_BIN is the explicit
+# opt-in that test (and a local probe) uses.
+TMUX_REAL = os.environ.get("POCKETSHELL_FIXTURE_TMUX_BIN") or (
+    "/usr/bin/tmux.real" if os.path.exists("/usr/bin/tmux.real") else None
+)
+FIELD_SEP = "::"
+TIMESTAMP = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
+LEADING_IDX = re.compile(r"^(\s*\d+\s+)")
+
+
+def read_canned(path: str) -> tuple[list[str], list[tuple[str, str]], list[str], int]:
+    """Split the canned table into (header lines, rows, trailer lines, width)."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+    except OSError:
+        return [], [], [], 0
+    header: list[str] = []
+    rows: list[tuple[str, str]] = []
+    trailer: list[str] = []
+    width = 0
+    for line in lines:
+        stamp = TIMESTAMP.search(line)
+        idx = LEADING_IDX.match(line) if stamp else None
+        if stamp and idx:
+            name = line[idx.end(): stamp.start()].rstrip()
+            width = max(width, stamp.start() - idx.end())
+            if name.strip():
+                rows.append((name.strip(), stamp.group(1)))
+            continue
+        if rows:
+            trailer.append(line)
+        else:
+            header.append(line)
+    return header, rows, trailer, width
+
+
+def socket_dir() -> str:
+    explicit = os.environ.get("POCKETSHELL_FIXTURE_TMUX_SOCKET_DIR")
+    if explicit:
+        return explicit
+    base = os.environ.get("TMUX_TMPDIR") or "/tmp"
+    return os.path.join(base, "tmux-%d" % os.getuid())
+
+
+def tmuxctl_socket_rows() -> list[tuple[str, str]]:
+    """Live sessions on every ``tmuxctl-*`` socket — one server per session."""
+    if not TMUX_REAL:
+        return []
+    directory = socket_dir()
+    try:
+        entries = sorted(
+            entry for entry in os.listdir(directory) if entry.startswith("tmuxctl-")
+        )
+    except OSError:
+        return []
+    rows: list[tuple[str, str]] = []
+    for entry in entries:
+        path = os.path.join(directory, entry)
+        try:
+            proc = subprocess.run(
+                [
+                    TMUX_REAL,
+                    "-S",
+                    path,
+                    "list-sessions",
+                    "-F",
+                    # NOT a literal tab: tmux's -F rewrites a raw tab to `_`
+                    # (verified on the fixture image), which would fold the
+                    # created-epoch into the session name. `::` is the same
+                    # separator the app's own reads use (FIELD_SEP).
+                    "#{session_name}%s#{session_created}" % FIELD_SEP,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode != 0:
+            continue
+        for line in proc.stdout.splitlines():
+            name, _, created = line.rpartition(FIELD_SEP)
+            if not name:
+                continue
+            name = name.strip()
+            if not name:
+                continue
+            try:
+                stamp = datetime.fromtimestamp(int(created.strip())).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+            except (TypeError, ValueError):
+                stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            rows.append((name, stamp))
+    return rows
+
+
+def aplexer_rows() -> list[dict]:
+    """Rows from the `a` fixture binary (aplexer), or none when it is absent."""
+    if os.environ.get("POCKETSHELL_APLEXER") == "0":
+        return []
+    binary = os.environ.get("APLEXER_BIN") or "/usr/local/bin/a"
+    if not os.path.exists(binary):
+        return []
+    try:
+        proc = subprocess.run(
+            [binary, "--json", "sessions"], capture_output=True, text=True, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        payload = json.loads(proc.stdout)
+    except ValueError:
+        return []
+    sessions = payload.get("sessions")
+    if not isinstance(sessions, list):
+        return []
+    rows = []
+    for item in sessions:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name:
+            continue
+        row = {"name": name, "manager": "aplexer"}
+        for key in ("id", "workspace", "engine", "tag", "created", "created_epoch"):
+            if item.get(key) is not None:
+                row[key] = item[key]
+        rows.append(row)
+    return rows
+
+
+def tmux_rows(canned: list[tuple[str, str]]) -> tuple[list[tuple[str, str]], bool]:
+    rows = list(canned)
+    seen = {name for name, _ in rows}
+    extra = False
+    for name, created in tmuxctl_socket_rows():
+        if name in seen:
+            continue
+        seen.add(name)
+        rows.append((name, created))
+        extra = True
+    return rows, extra
+
+
+def render_list(path: str) -> str:
+    header, canned, trailer, width = read_canned(path)
+    rows, extra = tmux_rows(canned)
+    if not extra:
+        # Byte-for-byte the committed fixture, so no pre-existing journey moves.
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+    width = max([width] + [len(name) + 1 for name, _ in rows])
+    lines = list(header)
+    for index, (name, created) in enumerate(rows, start=1):
+        lines.append("%-4d %-*s%s" % (index, width, name, created))
+    lines.extend(trailer)
+    return "\n".join(lines) + "\n"
+
+
+def render_json(path: str) -> str:
+    _, canned, _, _ = read_canned(path)
+    rows, _ = tmux_rows(canned)
+    sessions = [
+        {
+            "name": name,
+            "manager": "tmux",
+            "created": created,
+            "attach": "tmux attach -t %s" % name,
+        }
+        for name, created in rows
+    ]
+    sessions.extend(aplexer_rows())
+    return (
+        json.dumps({"managers": ["tmux", "aplexer"], "sessions": sessions}, indent=2)
+        + "\n"
+    )
+
+
+def main(argv: list[str]) -> int:
+    verb = argv[1] if len(argv) > 1 else ""
+    path = argv[2] if len(argv) > 2 else ""
+    if verb == "list" and path:
+        sys.stdout.write(render_list(path))
+        return 0
+    if verb == "json" and path:
+        sys.stdout.write(render_json(path))
+        return 0
+    sys.stderr.write(
+        "pocketshell-fixture-sessions supports: {list|json} <canned-table-file>\n"
+    )
+    return 64
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/docker/agent-bin/tmuxctl
+++ b/tests/docker/agent-bin/tmuxctl
@@ -3,9 +3,29 @@ set -eu
 
 fixture_dir="${POCKETSHELL_AGENT_FIXTURE_DIR:-/opt/pocketshell-agent-fixtures}"
 
+# Issue #2377: resolve the shared session enumerator NEXT TO THIS SCRIPT first.
+# These shims are executed both from `/usr/local/bin` inside the image AND
+# straight out of `tests/docker/agent-bin` by DockerAgentFixtureContractTest, so
+# a hardcoded `/usr/local/bin` path is a 127 in the JVM gate.
+fixture_sessions_bin() {
+  if [ -n "${POCKETSHELL_FIXTURE_SESSIONS_BIN:-}" ]; then
+    printf '%s\n' "$POCKETSHELL_FIXTURE_SESSIONS_BIN"
+    return 0
+  fi
+  _fsb_dir="$(dirname "$0")"
+  if [ -x "$_fsb_dir/pocketshell-fixture-sessions" ]; then
+    printf '%s\n' "$_fsb_dir/pocketshell-fixture-sessions"
+    return 0
+  fi
+  printf '%s\n' "/usr/local/bin/pocketshell-fixture-sessions"
+}
+
 if [ "${1:-}" = "list" ] || [ "${1:-}" = "ls" ] || [ "${1:-}" = "l" ]; then
-  cat "${fixture_dir}/tmuxctl-list.txt"
-  exit 0
+  # Issue #2377: the real tmuxctl walks EVERY `tmuxctl-*` socket (one tmux
+  # server per session) — that multi-socket set, not the default socket, is the
+  # host truth the phone must match. With no socket seeded this prints the
+  # canned table byte-for-byte, so pre-existing journeys are unchanged.
+  exec "$(fixture_sessions_bin)" list "${fixture_dir}/tmuxctl-list.txt"
 fi
 
 # Issue #726: PocketShell routes session creation through tmuxctl's


### PR DESCRIPTION
Closes #2377.

`SshFolderListGateway.listSessionsWithFolder` short-circuited on the live `tmux -CC` control client: when a live client existed with no watched roots, it returned that client's `list-sessions` directly (one socket only); the watched-roots branch didn't union across sockets either. #2348 only unioned `pocketshell sessions list --json` (tmuxctl + aplexer) on the *no-live-client* branch, so the moment the user was inside any session, the app reverted to single-socket enumeration — the maintainer's exact repro of "1 active · 0 idle · 1 session" with 10 real sessions on the host.

Review (round 1) found the same short-circuit pattern independently in `HostTmuxSessionsGateway` (feeds the session picker) — fixed in the same issue per D31 class coverage, not deferred.

## Changes

- `FolderListGateway.kt` / `FolderListPocketshellEnumerator.kt`: live-client rows are unioned with the tmuxctl+aplexer enumerator on every branch. `FolderListPocketshellEnumerator` now delegates to a new shared `HostSessionEnumerator` state machine (its 14 existing tests pass unchanged — proof the delegation is semantics-preserving). New `FolderListLiveClientEnumerator` extracted for file-size hygiene.
- `HostTmuxSessionsGateway.kt`: the `listSessionsFromLiveClient(...)` short-circuit is gone; live `-CC` rows are a metadata overlay, the shared enumerator is authoritative on every branch. Also fixes a sibling "no server running" → empty-list branch and an `Unavailable` → `Failed(...)` rule.
- `HostTmuxSessionPickerViewModel.kt`: documents `refreshProjectSiblings` as the one deliberate #463 exemption.

## Known follow-ups (filed separately, not this PR's scope)

- #2387: `TmuxClient.connect` attaches without `-S` — related but distinct connection-core mechanism issue.
- #2393: two pre-existing failing tests found on clean `main` during review.
- #2394: `SessionsDashboardViewModel` is a third site with the same bug class — `appAttached` precedence currently masks it in the reported state; needs a deliberate decision reconciled against #1164/#1496, not a drive-by fix.
- #2395: two disabled journey tests will need their stale `emptyMap()` SSH-delta assertion updated once #2393 is fixed.

## Test plan

- [x] Reviewer independently re-verified against current `origin/main` (post-#2378-merge): applied cleanly via 3-way merge test, full JVM gate green there (13,640 tests / 0 failures, including #2378's tests), `check-file-size-hygiene.sh` green with `FolderListGateway.kt` at 128,796 B (2,276 B under the cap).
- [x] Reviewer reproduced the 3-mutant JVM sweep independently (7/3/2 disjoint failures) and their own device RED (`rendered=29`, all 8 required rows missing) → GREEN (3/3, `ISSUE2377_PICKER_LIVE_ONLY rows=27` none of the 8 required, `ISSUE2377_PICKER rendered=35`).
- [x] `sameHostLiveClientListsSessionsFromOneEnumeratorExec` confirmed non-vacuous (fails under the reviewer's mutant).
- [x] Adjacency: `ISSUE1876_CONNECTED_MOBILE_RTT elapsedMs=4118 sessions=53 productBound=12000` green on device.
- [x] This worktree rebased cleanly onto post-#2378 `main` (no conflicts, matching the reviewer's prediction), and `check-file-size-hygiene.sh` re-verified green post-rebase.