### PR TITLE
Fix vacuous network-fault gate: deterministic folder-row navigation

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AttachNavigationMultiFolderE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AttachNavigationMultiFolderE2eTest.kt
@@ -1,0 +1,113 @@
+package com.pocketshell.app.proof
+
+import android.os.SystemClock
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.app.MainActivity
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #2380 — END-TO-END guard for the shared network-fault attach navigation,
+ * over the REAL Docker fixture the phase-2 proofs use.
+ *
+ * The nightly phase-2 network-fault gate went VACUOUS (not merely red) on 2026-08-27:
+ * every proof died in [NetworkFaultProofBase.openSessionFromList] with
+ * `Timed out ... waiting for expanded folder ::untracked:: showing session row ...
+ * after 166-174 tap(s)`, so no Toxiproxy fault was injected at all. The superseded
+ * selector resolved the target folder by taking the FIRST hard-coded candidate
+ * (`::untracked::`, `/home/testuser`, `~`) whose folder row MERELY EXISTED — a
+ * selector that is only correct while every seeded session happens to land in the
+ * first candidate.
+ *
+ * This test creates the non-happy fixture state the bug needs and that no other proof
+ * creates: the seeded target session lives in its OWN project folder, while sibling
+ * sessions occupy `/home/testuser` (the old candidate #2) and a second project folder.
+ * The old selector picks a folder that does not hold the target and dies in setup; the
+ * navigator must open the TARGET session — proved from inside the attached pane by
+ * `tmux display-message -p '#S'`, not merely by "some terminal appeared".
+ */
+// CI_JOURNEY_SUITE_JUSTIFIED: NetworkFaultProofBase toxiproxy proof; gated by
+// assumeNetworkFaultProofsEnabled() (self-skips on CI since tests.yml does not
+// start network-fault-proxy:2228), so wiring it into ci-journey-suite.sh would only
+// produce a vacuous CI skip. Its durable gate is the nightly suite's
+// NETWORK_FAULT_CLASSES (scripts/nightly-extensive-suite.sh), alongside the very
+// proofs whose shared setup this guards. The Docker-free per-push half of the same
+// red->green is com.pocketshell.app.proof.FolderSessionRowNavigatorTest, which IS
+// wired into scripts/ci-journey-suite.sh.
+@RunWith(AndroidJUnit4::class)
+class AttachNavigationMultiFolderE2eTest : NetworkFaultProofBase() {
+
+    @Test
+    fun attachOpensTheSeededSessionWhenSiblingProjectFoldersExist() { runBlocking {
+        assumeNetworkFaultProofsEnabled()
+
+        val key = readFixtureKey()
+        val marker = "nav${System.currentTimeMillis().toString(36).takeLast(5)}"
+        val targetSession = "issue2380-target-$marker"
+        val siblingSession = "issue2380-sibling-$marker"
+        val homeSession = "issue2380-home-$marker"
+        val hostName = "Issue2380 Nav $marker"
+        val targetCwd = "/home/testuser/issue2380-$marker/target"
+        val siblingCwd = "/home/testuser/issue2380-$marker/sibling"
+
+        // The target session lives in its own project folder ...
+        prepareProxyAndRemoteSession(
+            key = key,
+            sessionName = targetSession,
+            readyText = "ISSUE2380-TARGET-READY-$marker",
+            cwd = targetCwd,
+        )
+        // ... alongside a SECOND real project folder ...
+        seedExtraSession(
+            key = key,
+            sessionName = siblingSession,
+            readyText = "ISSUE2380-SIBLING-READY-$marker",
+            cwd = siblingCwd,
+        )
+        // ... and a session in the SSH login directory, which is the folder the
+        // superseded candidate list latched onto whenever `::untracked::` was absent.
+        seedExtraSession(
+            key = key,
+            sessionName = homeSession,
+            readyText = "ISSUE2380-HOME-READY-$marker",
+        )
+
+        val hostRowTag = seedNetworkFaultHost(key, hostName)
+
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        val attachStart = SystemClock.elapsedRealtime()
+        attachToSession(hostRowTag, hostName, targetSession)
+        recordTiming("multi_folder_attach_ms", SystemClock.elapsedRealtime() - attachStart)
+
+        // Identity proof: ask the ATTACHED pane which tmux session it is in. A wrong
+        // folder row (or a wrong session row) would answer with a sibling name.
+        sendCommandThroughTerminalInput(
+            "printf 'ATTACHED-%s\\n' \"\$(tmux display-message -p '#S')\"",
+            "multi-folder-attach-identity",
+        )
+        waitForVisibleTerminalText("multi-folder-attach-identity", timeoutMillis = 25_000L) {
+            "ATTACHED-$targetSession" in it
+        }
+        // ... and that the pane really is the one seeded in the target folder.
+        sendCommandThroughTerminalInput("pwd", "multi-folder-attach-cwd")
+        waitForVisibleTerminalText("multi-folder-attach-cwd", timeoutMillis = 25_000L) {
+            targetCwd in it
+        }
+
+        writeSummary(
+            testName = "AttachNavigationMultiFolderE2eTest",
+            lines = listOf(
+                "target_session=$targetSession",
+                "target_cwd=$targetCwd",
+                "sibling_session=$siblingSession",
+                "sibling_cwd=$siblingCwd",
+                "home_session=$homeSession",
+                "topology=2 project folders + the /home/testuser login folder",
+                "expectation=attach resolves the folder that CONTAINS the target session",
+                "attached_session_verified_by=tmux display-message -p '#S'",
+            ),
+        )
+    } }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/FolderSessionRowNavigator.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/FolderSessionRowNavigator.kt
@@ -1,0 +1,310 @@
+package com.pocketshell.app.proof
+
+import android.os.SystemClock
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.printToString
+import com.pocketshell.app.projects.FOLDER_LIST_BOTTOM_SPACER_TAG
+import com.pocketshell.app.projects.FOLDER_LIST_CONTENT_TAG
+import com.pocketshell.app.projects.FolderListViewModel
+import com.pocketshell.app.projects.folderDetailRowTestTag
+import com.pocketshell.app.projects.folderHeaderClickTestTag
+import com.pocketshell.app.projects.folderRowTestTag
+
+/**
+ * Issue #2380 — deterministic host-detail navigation to ONE named session row.
+ *
+ * The previous implementation (inlined in [NetworkFaultProofBase.openSessionFromList])
+ * resolved the target folder by taking the FIRST entry of a hard-coded candidate list
+ * (`::untracked::`, `/home/testuser`, `~`) whose folder ROW MERELY EXISTED, and then
+ * tapped that folder's header until the session's child row appeared. That is a
+ * "first row that exists" selector, not a "folder that contains the session" selector:
+ * once the fixture grew real project folders (sessions with a resolvable
+ * `pane_current_path` group under their cwd, not under `::untracked::`), every
+ * network-fault proof latched onto the still-rendered `::untracked::` row, tapped it
+ * ~170 times, and died in shared setup BEFORE a single Toxiproxy fault was injected —
+ * so the whole phase-2 gate was vacuous rather than merely red.
+ *
+ * This navigator never commits to a folder it has not VERIFIED contains the session:
+ *
+ *  - an already-visible `folder-list:detail:<path>:<session>` row wins immediately,
+ *    whichever folder it lives in (covers an auto-expanded folder and the degraded
+ *    `::untracked::` placement);
+ *  - otherwise folders are expanded one at a time in a DETERMINISTIC priority order —
+ *    the expected folder (the seeded session's real remote cwd) first, then the other
+ *    real project folders in render order, and the `::untracked::` sentinel LAST —
+ *    and each expansion is verified before it is accepted;
+ *  - a folder that does not reveal the session is restored to its previous state so
+ *    the list does not grow without bound, and the scan scrolls the lazy list so a
+ *    folder below the fold is still reachable;
+ *  - failure raises one AssertionError naming the expected folder, every folder seen,
+ *    every folder tried and the tap count — instead of an opaque
+ *    "expanded folder ::untracked:: … after 170 tap(s)".
+ */
+class FolderSessionRowNavigator(
+    private val compose: ComposeTestRule,
+    private val onTiming: (String, Long) -> Unit = { _, _ -> },
+) {
+
+    /**
+     * Reveal the session child row for [sessionName] and return the folder path it
+     * actually lives under. [expectedFolderPath] is the canonicalised remote cwd the
+     * seeding step observed (null when the caller has no expectation); it only sets
+     * the probe ORDER, it is never trusted without verifying the row appeared.
+     */
+    fun revealSessionRow(
+        sessionName: String,
+        expectedFolderPath: String?,
+        timeoutMillis: Long,
+    ): String {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
+        val tried = LinkedHashSet<String>()
+        val seen = LinkedHashSet<String>()
+        var taps = 0L
+
+        while (SystemClock.elapsedRealtime() < deadline) {
+            compose.waitForIdle()
+
+            // 1. Whichever folder already shows the row wins — including an
+            //    auto-expanded project folder and the degraded `::untracked::`
+            //    placement. This is the only accept path: a folder is never
+            //    selected because it merely exists.
+            folderShowingSession(sessionName)?.let { path ->
+                onTiming(EXPAND_TAPS_TIMING, taps)
+                return path
+            }
+
+            // 2. The expected folder's row (and its child row) may simply be below
+            //    the fold: a virtualised lazy list does not compose off-screen rows,
+            //    so scroll it into composition before concluding it is absent.
+            if (expectedFolderPath != null) {
+                scrollTo(folderDetailRowTestTag(expectedFolderPath, sessionName))
+                if (hasTag(folderDetailRowTestTag(expectedFolderPath, sessionName))) {
+                    onTiming(EXPAND_TAPS_TIMING, taps)
+                    return expectedFolderPath
+                }
+                if (!hasTag(folderRowTestTag(expectedFolderPath))) {
+                    scrollTo(folderRowTestTag(expectedFolderPath))
+                }
+            }
+
+            val candidates = orderedFolderCandidates(expectedFolderPath)
+            seen += candidates
+            val next = candidates.firstOrNull { it !in tried }
+            if (next == null) {
+                // Every folder on screen has been probed. Either the tree is still
+                // hydrating (new folders will appear) or a folder is below the fold;
+                // walk the lazy list forward and re-scan until the deadline.
+                scrollForward()
+                SystemClock.sleep(PROBE_INTERVAL_MS)
+                continue
+            }
+
+            tried += next
+            if (isExpanded(next)) {
+                // Already expanded (folders holding sessions auto-expand): the row
+                // would be rendered here, so scroll it into composition and decide.
+                // Never tap — that would COLLAPSE a folder we did not open.
+                scrollTo(folderDetailRowTestTag(next, sessionName))
+                if (hasTag(folderDetailRowTestTag(next, sessionName))) {
+                    onTiming(EXPAND_TAPS_TIMING, taps)
+                    return next
+                }
+                continue
+            }
+
+            toggleFolder(next)
+            taps += 1
+            val revealed = awaitSessionRow(sessionName, next, deadline)
+            if (revealed != null) {
+                onTiming(EXPAND_TAPS_TIMING, taps)
+                return revealed
+            }
+            // Wrong folder: collapse it again so the list stays short and later
+            // candidates stay reachable without a long scroll.
+            if (isExpanded(next)) {
+                toggleFolder(next)
+                taps += 1
+            }
+        }
+
+        throw AssertionError(
+            buildString {
+                appendLine(
+                    "Timed out after ${timeoutMillis}ms revealing session row $sessionName " +
+                        "in the host-detail folder list after $taps tap(s).",
+                )
+                appendLine("  expected folder (seeded remote cwd) = ${expectedFolderPath ?: "<unknown>"}")
+                appendLine("  folders seen                        = ${seen.toList()}")
+                appendLine("  folders expanded and rejected       = ${tried.toList()}")
+                appendLine(
+                    screenDiagnostics(
+                        textProbes = listOf(sessionName),
+                        tagProbes = buildList {
+                            expectedFolderPath?.let {
+                                add(folderRowTestTag(it))
+                                add(folderHeaderClickTestTag(it))
+                                add(folderDetailRowTestTag(it, sessionName))
+                            }
+                            seen.forEach { add(folderRowTestTag(it)) }
+                            seen.forEach { add(folderDetailRowTestTag(it, sessionName)) }
+                        },
+                    ),
+                )
+            },
+        )
+    }
+
+    /** The folder path whose expanded child row for [sessionName] is on screen, if any. */
+    private fun folderShowingSession(sessionName: String): String? {
+        val suffix = ":$sessionName"
+        return testTags()
+            .asSequence()
+            .filter { it.startsWith(DETAIL_TAG_PREFIX) && it.endsWith(suffix) }
+            .map { it.removePrefix(DETAIL_TAG_PREFIX).removeSuffix(suffix) }
+            // Reject `…:<session>:status` / `:tile` / `:badge` style sub-tags and any
+            // path that is not itself a rendered folder row.
+            .filter { it.isNotEmpty() && !it.contains(':') }
+            .firstOrNull()
+    }
+
+    /**
+     * Every folder row currently composed, in deterministic probe order: the expected
+     * folder first, then real project folders in render order, then the `::untracked::`
+     * sentinel last (it is the degraded bucket — never the intended target when a real
+     * project folder exists).
+     */
+    private fun orderedFolderCandidates(expectedFolderPath: String?): List<String> {
+        val rendered = testTags()
+            .asSequence()
+            .filter { it.startsWith(ROW_TAG_PREFIX) }
+            .map { it.removePrefix(ROW_TAG_PREFIX) }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .toList()
+        val expected = rendered.filter { it == expectedFolderPath }
+        val untracked = rendered.filter { it == FolderListViewModel.UNTRACKED_PATH }
+        val rest = rendered.filter { it != expectedFolderPath && it != FolderListViewModel.UNTRACKED_PATH }
+        return expected + rest + untracked
+    }
+
+    private fun awaitSessionRow(sessionName: String, folderPath: String, deadline: Long): String? {
+        val settleDeadline = minOf(deadline, SystemClock.elapsedRealtime() + EXPAND_SETTLE_MS)
+        while (SystemClock.elapsedRealtime() < settleDeadline) {
+            compose.waitForIdle()
+            if (hasTag(folderDetailRowTestTag(folderPath, sessionName))) return folderPath
+            // A concurrent tree refresh may have auto-expanded the right folder.
+            folderShowingSession(sessionName)?.let { return it }
+            SystemClock.sleep(PROBE_INTERVAL_MS)
+        }
+        return null
+    }
+
+    private fun toggleFolder(folderPath: String) {
+        val headerTag = folderHeaderClickTestTag(folderPath)
+        val tag = if (hasTag(headerTag)) headerTag else folderRowTestTag(folderPath)
+        runCatching { compose.onNodeWithTag(tag, useUnmergedTree = true).performClick() }
+    }
+
+    /**
+     * True when [folderPath] currently renders at least one SESSION CHILD row.
+     *
+     * A collapsed folder header still emits `folder-list:detail:<path>:{disclosure,
+     * status,actions,create}`, so the prefix alone does not mean "expanded" — only a
+     * child tag whose first segment is not one of those header sub-tags does.
+     */
+    private fun isExpanded(folderPath: String): Boolean {
+        val prefix = "$DETAIL_TAG_PREFIX$folderPath:"
+        return testTags().any {
+            it.startsWith(prefix) && it.removePrefix(prefix).substringBefore(':') !in HEADER_SUB_TAGS
+        }
+    }
+
+    private fun scrollTo(tag: String) {
+        runCatching {
+            compose.onNodeWithTag(FOLDER_LIST_CONTENT_TAG, useUnmergedTree = true)
+                .performScrollToNode(hasTestTag(tag))
+        }
+    }
+
+    private fun scrollForward() {
+        // Scrolling to the bottom spacer walks the lazy list forward, composing
+        // folder rows that were below the fold; the next scan picks them up.
+        runCatching {
+            compose.onNodeWithTag(FOLDER_LIST_CONTENT_TAG, useUnmergedTree = true)
+                .performScrollToNode(hasTestTag(FOLDER_LIST_BOTTOM_SPACER_TAG))
+        }
+    }
+
+    private fun testTags(): List<String> =
+        runCatching {
+            compose.onAllNodes(HAS_TEST_TAG, useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .mapNotNull { it.config.getOrNull(SemanticsProperties.TestTag) }
+        }.getOrDefault(emptyList())
+
+    private fun hasTag(tag: String): Boolean =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+
+    private fun screenDiagnostics(textProbes: List<String>, tagProbes: List<String>): String = buildString {
+        appendLine("Tag probe counts:")
+        tagProbes.distinct().forEach { tag ->
+            val count = runCatching {
+                compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().size
+            }.getOrDefault(-1)
+            appendLine("  $tag=$count")
+        }
+        appendLine("Text probe counts:")
+        textProbes.distinct().forEach { text ->
+            val count = runCatching {
+                compose.onAllNodesWithText(text, useUnmergedTree = true).fetchSemanticsNodes().size
+            }.getOrDefault(-1)
+            appendLine("  \"$text\"=$count")
+        }
+        appendLine("Compose semantics tree:")
+        appendLine(
+            runCatching {
+                compose.waitForIdle()
+                compose.onRoot(useUnmergedTree = true).printToString()
+            }.getOrElse { error ->
+                "  <failed to capture semantics tree: ${error.javaClass.simpleName}: " +
+                    "${error.message.orEmpty()}>"
+            },
+        )
+    }
+
+    private companion object {
+        const val PROBE_INTERVAL_MS: Long = 200L
+
+        /**
+         * How long ONE expanded folder gets to render its session child rows before
+         * it is rejected and the next candidate is tried. Generous enough for a
+         * recomposition on the slow swiftshader emulator, small enough that probing
+         * every folder in a handful-of-folders tree stays far inside the caller's
+         * budget.
+         */
+        const val EXPAND_SETTLE_MS: Long = 4_000L
+
+        const val EXPAND_TAPS_TIMING: String = "attach_folder_expand_taps"
+        const val ROW_TAG_PREFIX: String = "folder-list:row:"
+        const val DETAIL_TAG_PREFIX: String = "folder-list:detail:"
+
+        /** `folder-list:detail:<path>:<x>` tags a COLLAPSED folder header still emits. */
+        val HEADER_SUB_TAGS: Set<String> = setOf("disclosure", "status", "actions", "create")
+
+        val HAS_TEST_TAG: SemanticsMatcher = SemanticsMatcher("has a test tag") { node ->
+            node.config.getOrNull(SemanticsProperties.TestTag) != null
+        }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/FolderSessionRowNavigatorTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/FolderSessionRowNavigatorTest.kt
@@ -1,0 +1,347 @@
+package com.pocketshell.app.proof
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.portfwd.ForwardingController
+import com.pocketshell.app.projects.FolderImportPayload
+import com.pocketshell.app.projects.FolderListGateway
+import com.pocketshell.app.projects.FolderListResult
+import com.pocketshell.app.projects.FolderListScreen
+import com.pocketshell.app.projects.FolderListViewModel
+import com.pocketshell.app.projects.FolderSessionRow
+import com.pocketshell.app.projects.SessionCreateOutcome
+import com.pocketshell.app.projects.SessionNamePolicy
+import com.pocketshell.app.projects.folderDetailRowTestTag
+import com.pocketshell.app.projects.folderHeaderClickTestTag
+import com.pocketshell.app.projects.folderRowTestTag
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.uikit.model.SessionAgentKind
+import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #2380 — regression guard for the network-fault proofs' shared host-detail
+ * navigation.
+ *
+ * Reproduces the fixture topology that made the whole nightly phase-2 network-fault
+ * gate VACUOUS: sessions grouped under REAL project folders inside the
+ * `::other-folders::` root, with a `::untracked::` row also rendered. The superseded
+ * selector took the first entry of a hard-coded candidate list (`::untracked::`,
+ * `/home/testuser`, `~`) whose folder row MERELY EXISTED, so it latched onto a folder
+ * that does not hold the target session, tapped it ~170 times and died in shared
+ * setup — before a single Toxiproxy fault was ever injected.
+ *
+ * These cases drive the REAL [FolderListScreen] with the REAL
+ * [FolderSessionRowNavigator] the proofs use, over the exact topology class:
+ * multiple project folders, a `/home/testuser` folder (the old candidate #2), and an
+ * `::untracked::` row that is NOT the target's home. No Docker, no Toxiproxy — this is
+ * the per-push gate for the selector itself; the end-to-end proof over the real
+ * fixture is [AttachNavigationMultiFolderE2eTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class FolderSessionRowNavigatorTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private lateinit var db: AppDatabase
+    private val hostId: Long = 2380L
+
+    @Before
+    fun openDatabase() { runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "issue2380-key", privateKeyPath = "/tmp/issue2380"),
+        )
+        db.hostDao().insert(
+            HostEntity(
+                id = hostId,
+                name = "issue2380-host",
+                hostname = "h.example",
+                port = 22,
+                username = "testuser",
+                keyId = keyId,
+            ),
+        )
+    } }
+
+    @After
+    fun closeDatabase() {
+        db.close()
+    }
+
+    @Test
+    fun resolvesTheProjectFolderHoldingTheSessionWhileAnUntrackedRowExists() {
+        val opened = renderMultiFolderHostDetail()
+
+        val resolved = navigator().revealSessionRow(
+            sessionName = TARGET_SESSION,
+            expectedFolderPath = TARGET_FOLDER,
+            timeoutMillis = RESOLVE_TIMEOUT_MS,
+        )
+
+        assertEquals(TARGET_FOLDER, resolved)
+        // The resolved row is the real, tappable session row the proof opens next.
+        compose.onNodeWithTag(folderDetailRowTestTag(resolved, TARGET_SESSION), useUnmergedTree = true)
+            .performClick()
+        compose.waitUntil(CLICK_TIMEOUT_MS) { opened.session != null }
+        assertEquals(TARGET_SESSION, opened.session)
+        assertEquals(TARGET_FOLDER, opened.startDirectory)
+    }
+
+    @Test
+    fun resolvesTheContainingFolderWithNoExpectedFolderHint() {
+        // The degraded case: the harness could not observe the seeded session's
+        // remote cwd, so ordering has no hint. The navigator must still land on the
+        // folder that CONTAINS the session instead of the first row that exists.
+        renderMultiFolderHostDetail()
+
+        val resolved = navigator().revealSessionRow(
+            sessionName = TARGET_SESSION,
+            expectedFolderPath = null,
+            timeoutMillis = RESOLVE_TIMEOUT_MS,
+        )
+
+        assertEquals(TARGET_FOLDER, resolved)
+    }
+
+    @Test
+    fun resolvesASessionThatGenuinelyLivesUnderTheUntrackedRow() {
+        // The opposite over-correction guard: a session with no resolvable cwd really
+        // does live under `::untracked::`, and must still be found even though real
+        // project folders render first.
+        renderMultiFolderHostDetail()
+
+        val resolved = navigator().revealSessionRow(
+            sessionName = UNTRACKED_SESSION,
+            expectedFolderPath = null,
+            timeoutMillis = RESOLVE_TIMEOUT_MS,
+        )
+
+        assertEquals(FolderListViewModel.UNTRACKED_PATH, resolved)
+    }
+
+    @Test
+    fun reExpandsACollapsedProjectFolderToReachTheSession() {
+        renderMultiFolderHostDetail()
+
+        // Collapse the target's folder, so the session child row is gone and the
+        // navigator has to expand the right folder — not merely read the tree.
+        compose.onNodeWithTag(folderHeaderClickTestTag(TARGET_FOLDER), useUnmergedTree = true)
+            .performClick()
+        compose.waitUntil(CLICK_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(folderDetailRowTestTag(TARGET_FOLDER, TARGET_SESSION), useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+
+        val resolved = navigator().revealSessionRow(
+            sessionName = TARGET_SESSION,
+            expectedFolderPath = TARGET_FOLDER,
+            timeoutMillis = RESOLVE_TIMEOUT_MS,
+        )
+
+        assertEquals(TARGET_FOLDER, resolved)
+        compose.onNodeWithTag(folderDetailRowTestTag(resolved, TARGET_SESSION), useUnmergedTree = true)
+            .assertExists()
+    }
+
+    @Test
+    fun reportsTheFoldersItSearchedWhenTheSessionIsAbsent() {
+        renderMultiFolderHostDetail()
+
+        val error = runCatching {
+            navigator().revealSessionRow(
+                sessionName = "issue2380-not-on-this-host",
+                expectedFolderPath = TARGET_FOLDER,
+                timeoutMillis = ABSENT_TIMEOUT_MS,
+            )
+        }.exceptionOrNull()
+
+        assertTrue("expected an AssertionError, got $error", error is AssertionError)
+        val message = error?.message.orEmpty()
+        assertTrue("diagnostics must name the expected folder: $message", message.contains(TARGET_FOLDER))
+        assertTrue("diagnostics must list the folders seen: $message", message.contains("folders seen"))
+        assertTrue(
+            "diagnostics must list the folders expanded and rejected: $message",
+            message.contains("folders expanded and rejected"),
+        )
+    }
+
+    private fun navigator(): FolderSessionRowNavigator = FolderSessionRowNavigator(compose)
+
+    /**
+     * The reported topology: 2 real project folders, the historical
+     * `/home/testuser` candidate folder, and an `::untracked::` row holding a
+     * session that is NOT the target.
+     */
+    private fun renderMultiFolderHostDetail(): OpenedSession {
+        val opened = OpenedSession()
+        val gateway = StaticFolderGateway(
+            rows = listOf(
+                FolderSessionRow(
+                    sessionName = "issue2380-alpha",
+                    lastActivity = 1_700_000_100L,
+                    attached = false,
+                    cwd = "/home/testuser/projects/alpha",
+                    agentKind = SessionAgentKind.Shell,
+                ),
+                FolderSessionRow(
+                    sessionName = TARGET_SESSION,
+                    lastActivity = 1_700_000_200L,
+                    attached = false,
+                    cwd = TARGET_FOLDER,
+                    agentKind = SessionAgentKind.Shell,
+                ),
+                FolderSessionRow(
+                    sessionName = "issue2380-home",
+                    lastActivity = 1_700_000_300L,
+                    attached = false,
+                    cwd = "/home/testuser",
+                    agentKind = SessionAgentKind.Shell,
+                ),
+                FolderSessionRow(
+                    sessionName = UNTRACKED_SESSION,
+                    lastActivity = 1_700_000_400L,
+                    attached = false,
+                    cwd = null,
+                    agentKind = SessionAgentKind.Shell,
+                ),
+            ),
+        )
+        val viewModel = constructViewModelOnMainThread(gateway)
+        compose.setContent {
+            PocketShellTheme {
+                FolderListScreen(
+                    hostId = hostId,
+                    hostName = "issue2380-host",
+                    hostname = "h.example",
+                    port = 22,
+                    username = "testuser",
+                    keyPath = "/tmp/issue2380",
+                    passphrase = null,
+                    onBack = {},
+                    onOpenSession = { name, start, _, _ ->
+                        opened.session = name
+                        opened.startDirectory = start
+                    },
+                    onSessionCreated = { _, _ -> },
+                    onBrowseRepos = { _ -> },
+                    onEditEnv = { _, _, _ -> },
+                    modifier = Modifier.fillMaxSize(),
+                    viewModel = viewModel,
+                )
+            }
+        }
+        compose.waitUntil(RENDER_TIMEOUT_MS) {
+            compose.onAllNodesWithTag(folderRowTestTag(FolderListViewModel.UNTRACKED_PATH), useUnmergedTree = true)
+                .fetchSemanticsNodes()
+                .isNotEmpty() &&
+                compose.onAllNodesWithTag(folderRowTestTag(TARGET_FOLDER), useUnmergedTree = true)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+        }
+        return opened
+    }
+
+    private fun constructViewModelOnMainThread(gateway: FolderListGateway): FolderListViewModel {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        lateinit var vm: FolderListViewModel
+        instrumentation.runOnMainSync {
+            vm = FolderListViewModel(
+                gateway = gateway,
+                hostDao = db.hostDao(),
+                projectRootDao = db.projectRootDao(),
+                forwardingController = ForwardingController(instrumentation.targetContext),
+            )
+        }
+        return vm
+    }
+
+    private class OpenedSession {
+        @Volatile
+        var session: String? = null
+
+        @Volatile
+        var startDirectory: String? = null
+    }
+
+    private companion object {
+        const val TARGET_SESSION: String = "issue2380-target"
+        const val TARGET_FOLDER: String = "/home/testuser/projects/beta"
+        const val UNTRACKED_SESSION: String = "issue2380-stray"
+        const val RENDER_TIMEOUT_MS: Long = 20_000L
+        const val RESOLVE_TIMEOUT_MS: Long = 30_000L
+        const val CLICK_TIMEOUT_MS: Long = 10_000L
+
+        /**
+         * Deliberately short: the absent-session case must FAIL FAST with a
+         * diagnosable message, not burn a full picker budget silently.
+         */
+        const val ABSENT_TIMEOUT_MS: Long = 8_000L
+    }
+}
+
+private class StaticFolderGateway(
+    private val rows: List<FolderSessionRow>,
+) : FolderListGateway {
+    override suspend fun listSessionsWithFolder(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        watchedRoots: List<ProjectRootEntity>,
+    ): FolderListResult = FolderListResult.Sessions(rows = rows)
+
+    override suspend fun createSession(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        sessionName: String,
+        cwd: String,
+        startCommand: String?,
+        namePolicy: SessionNamePolicy,
+    ): Result<SessionCreateOutcome> = Result.success(SessionCreateOutcome.Created(sessionName))
+
+    override suspend fun createEmptyProject(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        parentPath: String,
+        folderName: String,
+    ): Result<String> = Result.success("$parentPath/$folderName")
+
+    override suspend fun importFile(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        folderPath: String,
+        payload: FolderImportPayload,
+    ): Result<String> = Result.success("$folderPath/${payload.remoteName}")
+
+    override suspend fun killSession(
+        host: HostEntity,
+        keyPath: String,
+        passphrase: CharArray?,
+        sessionName: String,
+    ): Result<Unit> = Result.success(Unit)
+}

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -23,10 +23,9 @@ import com.pocketshell.app.MainActivity
 import com.pocketshell.app.diagnostics.DiagnosticsEvent
 import com.pocketshell.app.hosts.HOST_ROW_TAG_PREFIX
 import com.pocketshell.app.hosts.SshKeyStorage
-import com.pocketshell.app.projects.FolderListViewModel
+import com.pocketshell.app.projects.FOLDER_LIST_CONTENT_TAG
+import com.pocketshell.app.projects.FolderTreeProjection
 import com.pocketshell.app.projects.folderDetailRowTestTag
-import com.pocketshell.app.projects.folderHeaderClickTestTag
-import com.pocketshell.app.projects.folderRowTestTag
 import com.pocketshell.app.tmux.TMUX_CONNECTING_PROGRESS_TAG
 import com.pocketshell.app.tmux.TMUX_CONNECTION_STATUS_PILL_TAG
 import com.pocketshell.app.tmux.TMUX_CONNECT_ATTEMPTS
@@ -87,6 +86,14 @@ abstract class NetworkFaultProofBase {
 
     protected var launchedActivity: ActivityScenario<MainActivity>? = null
     protected val timings: MutableList<String> = mutableListOf()
+
+    /**
+     * Issue #2380 — session name -> the canonicalised folder path the host-detail
+     * tree will group that seeded session under (its real remote `pane_current_path`).
+     * Populated by the seeding helpers; consumed by [openSessionFromList] as the
+     * DETERMINISTIC first probe when it resolves which folder to expand.
+     */
+    private val seededFolderPaths: MutableMap<String, String> = mutableMapOf()
     private var networkFaultProofEnabled: Boolean = false
     private var diagnosticsRecordingWasEnabled: Boolean? = null
 
@@ -161,10 +168,11 @@ abstract class NetworkFaultProofBase {
         key: String,
         sessionName: String,
         readyText: String,
+        cwd: String? = null,
     ) {
         toxiproxy().reset()
         waitForSshFixtureReady(SshKey.Pem(key), port = DEFAULT_PORT)
-        seedTmuxSession(key, sessionName, readyText)
+        seedTmuxSession(key, sessionName, readyText, cwd)
         waitForSshFixtureReady(SshKey.Pem(key), port = NETWORK_FAULT_SSH_PORT)
     }
 
@@ -178,8 +186,9 @@ abstract class NetworkFaultProofBase {
         key: String,
         sessionName: String,
         readyText: String,
+        cwd: String? = null,
     ) {
-        seedTmuxSession(key, sessionName, readyText)
+        seedTmuxSession(key, sessionName, readyText, cwd)
     }
 
     protected suspend fun preparePacketLossProxyAndRemoteSession(
@@ -258,24 +267,25 @@ abstract class NetworkFaultProofBase {
      */
     protected fun openSessionFromList(hostName: String, sessionName: String) {
         val pickerTimeoutMs = TerminalTestTimeouts.terminalVisibilityTimeoutMs()
-        var folderPath = FolderListViewModel.UNTRACKED_PATH
         waitUntilWithDiagnostics(
-            label = "folder row for $sessionName",
+            label = "host-detail folder list for $hostName",
             timeoutMillis = pickerTimeoutMs,
             textProbes = listOf(hostName, sessionName),
-            tagProbes = NETWORK_FAULT_FOLDER_CANDIDATES.map(::folderRowTestTag),
+            tagProbes = listOf(FOLDER_LIST_CONTENT_TAG),
         ) {
-            val match = NETWORK_FAULT_FOLDER_CANDIDATES.firstOrNull { candidate ->
-                hasTag(folderRowTestTag(candidate))
-            }
-            if (match != null) {
-                folderPath = match
-                true
-            } else {
-                false
-            }
+            hasTag(FOLDER_LIST_CONTENT_TAG)
         }
-        expandFolderUntilSessionRowVisible(folderPath, sessionName, pickerTimeoutMs)
+        // Issue #2380: resolve the folder that ACTUALLY CONTAINS the session
+        // (verified by its child row appearing), preferring the seeded session's
+        // real remote cwd. The superseded selector took the first hard-coded
+        // candidate whose row merely existed, so it latched onto the `::untracked::`
+        // row once sessions started grouping under real project folders and every
+        // network-fault proof died in setup before injecting a single fault.
+        val folderPath = FolderSessionRowNavigator(compose, ::recordTiming).revealSessionRow(
+            sessionName = sessionName,
+            expectedFolderPath = seededFolderPaths[sessionName],
+            timeoutMillis = pickerTimeoutMs,
+        )
         val sessionRowTag = folderDetailRowTestTag(folderPath, sessionName)
         compose.onNodeWithTag(sessionRowTag, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
@@ -872,16 +882,42 @@ abstract class NetworkFaultProofBase {
         return File(dir, name)
     }
 
-    private suspend fun seedTmuxSession(key: String, sessionName: String, readyText: String) {
+    /**
+     * Seed one detached tmux session and RECORD the folder path the host-detail
+     * tree will group it under (issue #2380).
+     *
+     * [cwd] is the working directory the session is created in (`tmux new-session -c`);
+     * null keeps the historical behaviour of inheriting the SSH login directory. The
+     * seeded session's real `pane_current_path` is read back from tmux and stored,
+     * canonicalised exactly the way [FolderTreeProjection] canonicalises a grouping
+     * key, so [openSessionFromList] can target the folder the app WILL place this
+     * session in instead of guessing from a hard-coded candidate list. It stays an
+     * ORDERING hint only: the navigator still verifies the session's row actually
+     * appeared under the folder it selects.
+     */
+    private suspend fun seedTmuxSession(
+        key: String,
+        sessionName: String,
+        readyText: String,
+        cwd: String? = null,
+    ) {
         val script = buildString {
             appendLine("set -eu")
+            if (cwd != null) {
+                appendLine("mkdir -p ${shellQuote(cwd)}")
+            }
             appendLine("tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true")
             appendLine(
                 "tmux new-session -d -s ${shellQuote(sessionName)} " +
+                    (if (cwd != null) "-c ${shellQuote(cwd)} " else "") +
                     "${shellQuote("printf '${escapeSingleQuotedForPrintf(readyText)}\\n'; exec sh -i")}",
             )
             appendLine("sleep 1")
             appendLine("tmux list-sessions")
+            appendLine(
+                "printf '$SEEDED_CWD_MARKER%s\\n' " +
+                    "\"\$(tmux display-message -p -t ${shellQuote(sessionName)} '#{pane_current_path}')\"",
+            )
         }
         val result = SshConnection.connect(
             host = DEFAULT_HOST,
@@ -898,6 +934,20 @@ abstract class NetworkFaultProofBase {
             "expected tmux seeding to succeed; exception=${result.exceptionOrNull()} stderr='${exec?.stderr}'",
             exec?.exitCode == 0,
         )
+        val reportedCwd = exec?.stdout
+            .orEmpty()
+            .lineSequence()
+            .firstOrNull { it.startsWith(SEEDED_CWD_MARKER) }
+            ?.removePrefix(SEEDED_CWD_MARKER)
+            ?.trim()
+            .orEmpty()
+        assertTrue(
+            "expected tmux to report a pane_current_path for the seeded session " +
+                "$sessionName so the host-detail folder can be targeted deterministically " +
+                "(#2380); stdout='${exec?.stdout?.take(400)}'",
+            reportedCwd.isNotBlank(),
+        )
+        seededFolderPaths[sessionName] = FolderTreeProjection.canonicalisePath(reportedCwd)
     }
 
     private suspend fun listClientsRaw(key: String, sessionName: String): String {
@@ -930,41 +980,6 @@ abstract class NetworkFaultProofBase {
             attached = view?.currentSession != null && view.mEmulator != null
         }
         return attached
-    }
-
-    private fun expandFolderUntilSessionRowVisible(
-        folderPath: String,
-        sessionName: String,
-        timeoutMillis: Long,
-    ) {
-        val detailTag = folderDetailRowTestTag(folderPath, sessionName)
-        val headerTag = folderHeaderClickTestTag(folderPath)
-        val deadline = SystemClock.elapsedRealtime() + timeoutMillis
-        var taps = 0
-        while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
-            if (hasTag(detailTag)) {
-                recordTiming("attach_folder_expand_taps", taps.toLong())
-                return
-            }
-            if (hasTag(headerTag)) {
-                compose.onNodeWithTag(headerTag, useUnmergedTree = true).performClick()
-                taps += 1
-            }
-            SystemClock.sleep(250)
-        }
-        waitUntilWithDiagnostics(
-            label = "expanded folder $folderPath showing session row $sessionName after $taps tap(s)",
-            timeoutMillis = 5_000,
-            textProbes = listOf(sessionName, folderPath.substringAfterLast('/')),
-            tagProbes = listOf(
-                folderRowTestTag(folderPath),
-                folderHeaderClickTestTag(folderPath),
-                folderDetailRowTestTag(folderPath, sessionName),
-            ),
-        ) {
-            hasTag(detailTag)
-        }
     }
 
     private fun waitUntilWithDiagnostics(
@@ -1142,11 +1157,12 @@ abstract class NetworkFaultProofBase {
         /** Issue #1681 — the un-proxied sentinel exec-ping cadence. */
         const val SENTINEL_INTERVAL_MS: Long = 3_000L
 
-        val NETWORK_FAULT_FOLDER_CANDIDATES: List<String> = listOf(
-            FolderListViewModel.UNTRACKED_PATH,
-            "/home/testuser",
-            "~",
-        )
+        /**
+         * Issue #2380 — stdout marker the seeding script prints the seeded session's
+         * real `pane_current_path` behind, so the harness can target the folder the
+         * host-detail tree will group that session under.
+         */
+        const val SEEDED_CWD_MARKER: String = "POCKETSHELL_SEEDED_CWD="
     }
 }
 

--- a/scripts/check-ci-journey-harness.sh
+++ b/scripts/check-ci-journey-harness.sh
@@ -107,6 +107,18 @@ KNOWN_UNWIRED_ANDROID_E2E_DOCKER_CLASSES=(
   "com.pocketshell.app.projects.FolderListSessionResumeDockerTest"
   "com.pocketshell.app.projects.FolderListTreeStopSessionDockerTest"
   "com.pocketshell.app.projects.WatchedFoldersE2eTest"
+  # Issue #2380: the END-TO-END attach-navigation guard for the nightly phase-2
+  # network-fault lane's own shared setup (the selector that made phase 2 vacuous by
+  # dying on the `::untracked::` row before any fault was injected). A
+  # NetworkFaultProofBase toxiproxy proof: it self-skips on CI
+  # (assumeNetworkFaultProofsEnabled -> tests.yml leaves network-fault-proxy:2228 +
+  # toxiproxy:8474 down), so wiring it into the per-PR ci-journey-suite.sh would only
+  # ALL-SKIP (the G3 vacuous-pass trap). It is enrolled in NETWORK_FAULT_CLASSES and
+  # runs via nightly-extensive.yml / scripts/nightly-extensive-suite.sh (proxy up).
+  # The per-push half of the same red->green is the Docker-free
+  # com.pocketshell.app.proof.FolderSessionRowNavigatorTest, which IS wired into
+  # scripts/ci-journey-suite.sh.
+  "com.pocketshell.app.proof.AttachNavigationMultiFolderE2eTest"
   "com.pocketshell.app.proof.CodexOverflowNoReconnectE2eTest"
   "com.pocketshell.app.proof.CodexRedrawOverflowReconnectE2eTest"
   "com.pocketshell.app.proof.CodexWindowStartupControlSequenceE2eTest"

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -371,6 +371,7 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.usage.Usage1318StrictSchemaRenderE2eTest"  # #1318 on-device render acceptance for the quse-v0.0.9 strict-schem…
   "com.pocketshell.app.usage.UsageResetCreditsLayoutTest"  # #1789 reset-credit inventory remains contained and scrollable on narrow / large-font layouts
   "$FQCN_PREFIX.InheritedFocusOwnerVerdictE2eTest"  # #2021 D31: an INHERITED app-owned focus window must not void a downstream journey's verdict (the state that voided 2 of 7 #1994 reopen arms), while an owner the journey itself leaks still hard-fails. No Docker fixture, ~15s.
+  "$FQCN_PREFIX.FolderSessionRowNavigatorTest"  # #2380 D32 G9: the network-fault proofs' shared attach selector over the fixture topology that made phase 2 VACUOUS (2 project folders + a `::untracked::` row that does not hold the target). Drives the real FolderListScreen + the real FolderSessionRowNavigator; no Docker, no toxiproxy, ~30s. The end-to-end sibling (AttachNavigationMultiFolderE2eTest) needs the opt-in toxiproxy fixture, so it lives in the nightly phase-2 list.
 )
 
 # CI-matrix journey class selection and banner logging live in a sourced helper.

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -415,7 +415,7 @@ if [[ "$CLEANUP_ONLY" != "1" ]]; then
       |*OutboundAttachmentOffsetResumeJourneyE2eTest*\
       |*SilentMidSessionDrop*|*ColdDialUnderBandwidth*|*RealisticWifiStability*\
       |*NatIdleMapping*|*MobileLatencyStorm*|*PushResumeDeadSocket*\
-      |*ConversationOpenLatency*)
+      |*ConversationOpenLatency*|*AttachNavigationMultiFolderE2eTest*)
       NETWORK_FAULT_RUN=1
       ;;
   esac

--- a/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
+++ b/scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv
@@ -287,3 +287,8 @@ com.pocketshell.app.proof.signals.SessionCaptureContractTest	22
 # emulator, not a GitHub Actions run — refresh with a real CI attempt-1
 # elapsed time once this class has run there.
 com.pocketshell.app.proof.Issue2338SecondLaunchTerminalAttachJourneyE2eTest	64
+# #2380: com.pocketshell.app.proof.FolderSessionRowNavigatorTest measured from
+# a local dev-box emulator (BUILD SUCCESSFUL in 39s, 5/5 executed, 0 failed) —
+# not yet a GitHub Actions run; refresh with a real CI attempt-1 elapsed time
+# once this class has run there, same convention as the Issue2338 row above.
+com.pocketshell.app.proof.FolderSessionRowNavigatorTest	39

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -158,6 +158,20 @@ NETWORK_FAULT_CLASSES=(
   # it is enrolled here with its toxiproxy siblings. Reuses network-fault-proxy:2228
   # + toxiproxy API:8474 (no new fixture).
   "$FQCN_PREFIX.MobileLatencyStormSelfInflictedCloseE2eTest"
+  # Issue #2380: the END-TO-END guard for this phase's OWN shared setup navigation.
+  # On 2026-08-27 every proof below died in NetworkFaultProofBase.openSessionFromList
+  # ("expanded folder ::untracked:: … after 166-174 tap(s)") because the selector took
+  # the first hard-coded folder candidate whose row merely EXISTED, so phase 2 injected
+  # no Toxiproxy fault at all — a VACUOUS gate, not a red one. This class seeds the
+  # non-happy topology no other proof creates (target session in its own project
+  # folder, siblings in a second project folder and in /home/testuser) and proves the
+  # attach lands on the TARGET session, verified from inside the pane with
+  # `tmux display-message -p '#S'`. It is a NetworkFaultProofBase subclass, so it
+  # self-skips per-push (needs network-fault-proxy:2228 + toxiproxy API:8474 which
+  # tests.yml leaves down) and belongs here; no new fixture. The per-push half of the
+  # red→green (the selector over the same topology, rendered without Docker) is
+  # com.pocketshell.app.proof.FolderSessionRowNavigatorTest in ci-journey-suite.sh.
+  "$FQCN_PREFIX.AttachNavigationMultiFolderE2eTest"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2380.

`NetworkFaultProofBase`'s shared folder-row selector picked the first row that merely EXISTED, then tapped that folder's header hoping for a child row that could never appear. Once sessions started living under real project folders alongside an empty `::untracked::` row, it latched onto the empty row and timed out after ~170 taps — so no Toxiproxy fault was ever injected. The nightly phase-2 gate was **vacuous, not merely red**, since 2026-08-27, and the release-gate bypass removed in #2379/D37 means this must actually work before a release can ship.

## Changes

- `FolderSessionRowNavigator.kt` (new): only commits to a folder whose actual `folder-list:detail:<path>:<session>` row it has observed — probes the seeded session's real remote `pane_current_path` first, other project folders next, `::untracked::` last.
- `NetworkFaultProofBase.kt`: delegates to the navigator; the old "first row that exists" selector deleted.
- `FolderSessionRowNavigatorTest.kt` (new, wired into `ci-journey-suite.sh`, ~30s, no Docker): per-push red/green proof of the navigator itself.
- `AttachNavigationMultiFolderE2eTest.kt` (new, nightly phase-2 only): end-to-end proof over the real Docker fixture, asserting the attached pane's actual session identity via `tmux display-message -p '#S'`.
- `scripts/fixtures/ci-journey-run-31961310072-class-seconds.tsv`: real-measured cost row for the newly-registered `FolderSessionRowNavigatorTest` (39s, verified against the current 6-shard budget — still passes with margin).

## The honest result, once fault injection genuinely runs

14 PASS / 3 FAIL / 1 SKIP (18 total) — not fixed in this PR, reported honestly and tracked separately:
- `PushResumeDeadSocketMainResponsiveE2eTest` and `NatIdleMappingSurvivalE2eTest` both fail for real, sharing one root cause (post-recovery missing-terminal-viewport capture) — #2389, an implementer is already on it.
- `ColdDialUnderBandwidthLimitE2eTest#bufferbloat` is a genuine flake (wall-clock budget sensitivity) — a D36 quarantine candidate.
- `OutboundAttachmentOffsetResumeJourneyE2eTest` has its own private copy of this same folder-row-picker bug, in a different file, untouched here — #2390.

## Also found, filed separately, not fixed here

`DiagnosticRecorders.kt`'s `close()` installs a `Noop` sink and never restores the previous one, silently blinding every later test in a suite run that depends on captured diagnostic events. This was root-caused as the actual explanation for `RideThroughInterruptionE2eTest`'s apparent flakiness (it isn't a flake) — #2397, a systemic vacuous-pass hazard worth its own priority.

## Test plan

- [x] Reviewer independently reproduced G1 red→green twice (round 2 code review + round 3 final review), including running the discriminator experiment for the DiagnosticRecorders finding themselves.
- [x] Full phase-2 suite run: 18/18 executed, faults genuinely injected (confirmed via in-pane `tmux display-message` identity assertions), honest breakdown above.
- [x] `scripts/full-jvm-gate.py` green (604/604 tasks) — verified independently by two separate reviewer rounds.
- [x] `check-file-size-hygiene.sh`, `check-ci-journey-harness.sh`, `check-nightly-workflow.sh`, `nightly-fault-verdict.sh --self-test` all pass.
- [x] New `FolderSessionRowNavigatorTest` cost measured for real (39s) and verified against the current 6-shard #1850 retry-budget guard.