### PR TITLE
Fix post-recovery viewport capture: wait for Compose, not just the Looper

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NatIdleMappingSurvivalE2eTest.kt
@@ -149,6 +149,20 @@ class NatIdleMappingSurvivalE2eTest : NetworkFaultProofBase() {
         // robust, authoritative auto-recovery signal.)
         waitForConnected("after severed-mapping recovery", timeoutMs = RECOVERY_CONNECTED_TIMEOUT_MS)
         waitForClientCountAtMost(key, sessionName, max = 1, label = "post-recovery clean reconnect")
+        // Issue #2389: the VM reaches Connected BEFORE the surface releases its
+        // recovery hold and re-mounts the Termux AndroidView, and the raw-view
+        // capture below never drove the Compose frame clock, so it photographed a
+        // still-held surface (`Recomposer state=PendingWork` for 16s in the
+        // instrumented run) and reported the `#2135` `viewFound=false`. Wait for the
+        // viewport to come BACK through the Compose-synced path — bounded and
+        // hard-failing, so a surface that never re-mounts still reds as #2135
+        // intends. See [RecoveredTerminalViewport] for the full measurement.
+        val restoredMs = RecoveredTerminalViewport.awaitRestored(
+            compose = compose,
+            scenario = launchedActivity,
+            label = "post_recovery",
+            recordTiming = ::recordTiming,
+        )
         captureViewport("issue1063-recover-02-recovered")
 
         assertTrue(
@@ -166,7 +180,8 @@ class NatIdleMappingSurvivalE2eTest : NetworkFaultProofBase() {
                 "keepalive_override=${RECOVERY_KEEPALIVE_INTERVAL_MS}ms x $KEEPALIVE_COUNT_MAX (SHORT)",
                 "keepalive_death_budget_ms=$KEEPALIVE_DEATH_BUDGET_MS",
                 "detect_ms=$detectMs",
-                "expectation=keepalive detects half-open within budget => Reconnecting band => auto-recover (VM Connected, <=1 client)",
+                "post_recovery_viewport_restored_ms=$restoredMs",
+                "expectation=keepalive detects half-open within budget => Reconnecting band => auto-recover (VM Connected, <=1 client, terminal viewport back)",
             ),
         )
     } }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/PushResumeDeadSocketMainResponsiveE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PushResumeDeadSocketMainResponsiveE2eTest.kt
@@ -250,7 +250,34 @@ class PushResumeDeadSocketMainResponsiveE2eTest : NetworkFaultProofBase() {
             setForceLivenessProbeDead(false)
             proxy.clearToxics()
             val settled = waitForConnectedOrDisconnectBand(SETTLE_WINDOW_MS)
-            captureViewport("issue1139-03-settled")
+            // Issue #2389: this capture used to race the surface. When the session
+            // settles back to Connected the screen still has to release its recovery
+            // hold and re-mount the Termux AndroidView (the VM flips Connected
+            // FIRST), and the raw-view capture never drove the Compose frame clock,
+            // so it found no TerminalView and hard-failed with the `#2135`
+            // `viewFound=false` — the same ONE root cause as
+            // NatIdleMappingSurvivalE2eTest (see [RecoveredTerminalViewport]). Wait
+            // for the viewport to come back (bounded, hard-failing). A settled
+            // DISCONNECTED band legitimately has
+            // no TerminalView, so that branch captures the whole session frame
+            // instead — the evidence stays authoritative either way.
+            val settledConnected =
+                currentConnectionStatus() is TmuxSessionViewModel.ConnectionStatus.Connected
+            val restoredMs = if (settledConnected) {
+                RecoveredTerminalViewport.awaitRestored(
+                    compose = compose,
+                    scenario = launchedActivity,
+                    label = "settled",
+                    recordTiming = ::recordTiming,
+                )
+            } else {
+                -1L
+            }
+            if (settledConnected) {
+                captureViewport("issue1139-03-settled")
+            } else {
+                captureSessionFrame("issue1139-03-settled-disconnect-band")
+            }
             assertTrue(
                 "after the fault cleared the session must reconnect (Connected) or show a " +
                     "Disconnected band — not a permanently frozen UI (status=" +
@@ -271,6 +298,8 @@ class PushResumeDeadSocketMainResponsiveE2eTest : NetworkFaultProofBase() {
                     "main_probe_samples=${result.sampleCount}",
                     "main_responsive=${result.responsive}",
                     "settled_after_clear=$settled",
+                    "settled_connected=$settledConnected",
+                    "settled_viewport_restored_ms=$restoredMs",
                     "expectation=Main stall < budget (no 2-4s ANR); session " +
                         "reconnects-or-Disconnected after clear",
                 ),
@@ -356,6 +385,29 @@ class PushResumeDeadSocketMainResponsiveE2eTest : NetworkFaultProofBase() {
     }
 
     // ---- artifacts -----------------------------------------------------------------
+
+    /**
+     * Issue #2389: the settled-DISCONNECTED-band branch legitimately has no
+     * `TerminalView` (the band replaces the surface), so its evidence is the whole
+     * session frame. Still hard-fails when nothing can be captured.
+     */
+    private fun captureSessionFrame(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+        var bitmap: Bitmap? = null
+        launchedActivity?.onActivity { activity ->
+            bitmap = com.pocketshell.app.proof.signals.captureSessionFrameToBitmap(
+                activity.window.decorView,
+                name,
+            )
+        }
+        val captured = checkNotNull(bitmap) {
+            "activity was not available to capture session frame '$name' (#2389)"
+        }
+        writeBitmap("$name-session-frame", captured)
+        captured.recycle()
+    }
 
     private fun captureViewport(name: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RecoveredTerminalViewport.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RecoveredTerminalViewport.kt
@@ -1,0 +1,137 @@
+package com.pocketshell.app.proof
+
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.MainActivity
+import com.pocketshell.app.proof.signals.describeViewCaptureState
+import com.termux.view.TerminalView
+
+/**
+ * Issue #2389 — the shared POST-RECOVERY terminal-viewport gate for the
+ * network-fault recovery proofs.
+ *
+ * ## What was actually broken (the `#2135` cohort, one root cause)
+ *
+ * `NatIdleMappingSurvivalE2eTest` and `PushResumeDeadSocketMainResponsiveE2eTest`
+ * both died at the SAME place — the post-recovery `captureViewToBitmap(...)` with
+ * `viewFound=false` — after writing their earlier viewports fine. Instrumented
+ * emulator runs (issue #2389) found one shared cause, and it is a HARNESS defect,
+ * not a connection-core defect:
+ *
+ *  - While the surface holds the recovery (`Reconnecting` / `Switching` →
+ *    `SessionSurfaceState.Attaching`, `terminalHeld = true`) the screen
+ *    DELIBERATELY unmounts the Termux `AndroidView`
+ *    ([com.pocketshell.app.tmux.shouldKeepTerminalMounted]) and paints the
+ *    centered "Attaching…" hold. There is no `TerminalView` in the decor tree at
+ *    all during that window — by design.
+ *  - The view model reaches `ConnectionStatus.Connected` FIRST. The re-mount only
+ *    lands when the composition applies the resulting invalidation.
+ *  - Both proofs then captured the authoritative viewport ~120–150 ms later, off
+ *    the RAW view tree behind `Instrumentation.waitForIdleSync()`. That waits for
+ *    the main LOOPER, and never drives the Compose frame clock. Measured on the
+ *    emulator: the `Recomposer` sat at `state=PendingWork pendingWork=true
+ *    changeCount=25` for 16 s with the update already queued; `Snapshot.
+ *    sendApplyNotifications()` did NOT release it; the first Compose-synced wait
+ *    flushed it instantly (`changeCount=29`, `state=Idle`, terminal attached).
+ *    The emulator only produces the vsync the Recomposer is parked on when
+ *    something drives a frame, so a raw-view poll can watch a stale surface for
+ *    tens of seconds while the app is, as far as it is concerned, done.
+ *
+ * That is why every ATTACH-time wait in this suite (`waitForTerminalViewAttached`)
+ * is Compose-synced and green, while these two POST-RECOVERY captures were not and
+ * failed ~90% of the time (1P/9F and 1P/12F in the #2380 round-2 measurement).
+ *
+ * [awaitRestored] closes it the honest way: it waits through the SAME Compose-
+ * synced path as the attach gate and keeps the `#2135` hard failure. Nothing is
+ * weakened — a surface that genuinely never re-mounts the terminal after recovery
+ * still reds, now with a diagnostic that names the observed view state instead of
+ * a bare `viewFound=false`.
+ *
+ * The gate is a shared helper (not a per-test copy) because the failure is a
+ * property of the whole recovery-proof CLASS: any proof that captures a terminal
+ * viewport after a fault clears has the same race, so they all go through here.
+ */
+internal object RecoveredTerminalViewport {
+
+    /**
+     * Generous on purpose: the emulator restores in well under a second when the
+     * box is idle, but this proof family runs on swiftshader alongside sibling
+     * agents, where the same recomposition + `AndroidView` attach has been
+     * observed to stretch into the tens of seconds. It is still a BOUND: a
+     * surface that never re-mounts the terminal fails, which is the #2135 class
+     * the proofs exist to catch. It mirrors the 30 s budget the ATTACH path
+     * already uses (`NetworkFaultProofBase.waitForTerminalViewAttached`).
+     */
+    const val RESTORE_BUDGET_MS: Long = 30_000L
+
+    /**
+     * Block until the recovered session surface has re-attached a LIVE terminal
+     * viewport (a measured `TerminalView` bound to a session + emulator), then
+     * return how long that took. Throws [AssertionError] naming the observed view
+     * state when the viewport never comes back inside [budgetMs].
+     *
+     * "Live" is deliberately stronger than "a view exists": a re-mounted but
+     * unbound `TerminalView` would let a broken recovery capture an empty frame
+     * and call it evidence.
+     */
+    fun awaitRestored(
+        compose: ComposeTestRule,
+        scenario: ActivityScenario<MainActivity>?,
+        label: String,
+        budgetMs: Long = RESTORE_BUDGET_MS,
+        recordTiming: (String, Long) -> Unit = { _, _ -> },
+    ): Long {
+        val started = SystemClock.elapsedRealtime()
+        var lastState = "<activity never available to inspect>"
+        try {
+            // compose.waitUntil (NOT a raw waitForIdleSync poll) is the load-bearing
+            // part: it drives the Compose frame clock, so a recomposition parked in
+            // `PendingWork` is applied instead of being watched forever.
+            compose.waitUntil(timeoutMillis = budgetMs) {
+                var restored = false
+                scenario?.onActivity { activity ->
+                    val view = activity.window.decorView.findTerminalViewInTree()
+                    lastState = describeViewCaptureState(view) +
+                        " session=${view?.currentSession != null}" +
+                        " emulator=${view?.mEmulator != null}"
+                    restored = view != null &&
+                        view.width > 0 &&
+                        view.height > 0 &&
+                        view.currentSession != null &&
+                        view.mEmulator != null
+                }
+                restored
+            }
+        } catch (timeout: Throwable) {
+            recordTiming("${label}_viewport_restored_ms", -1L)
+            throw AssertionError(
+                "the terminal viewport never came back after $label: the connection " +
+                    "recovered but no live TerminalView re-attached within ${budgetMs}ms, " +
+                    "so the session surface is still holding (\"Attaching…\") or paneless. " +
+                    "This is the #2135 class the proofs exist to catch — a missing " +
+                    "post-recovery terminal viewport is a hard failure, never a silent " +
+                    "skip. last observed: $lastState",
+                timeout,
+            )
+        }
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val elapsedMs = SystemClock.elapsedRealtime() - started
+        recordTiming("${label}_viewport_restored_ms", elapsedMs)
+        return elapsedMs
+    }
+
+    /** Depth-first search for the Termux view the proofs capture. */
+    fun View.findTerminalViewInTree(): TerminalView? {
+        if (this is TerminalView) return this
+        if (this !is ViewGroup) return null
+        for (index in 0 until childCount) {
+            val match = getChildAt(index).findTerminalViewInTree()
+            if (match != null) return match
+        }
+        return null
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2389PostRecoveryViewportGateTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2389PostRecoveryViewportGateTest.kt
@@ -1,0 +1,146 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Issue #2389 — the post-recovery terminal-viewport cohort
+ * (`NatIdleMappingSurvivalE2eTest` + `PushResumeDeadSocketMainResponsiveE2eTest`,
+ * both dying at `captureViewToBitmap(...) viewFound=false`).
+ *
+ * Root cause (measured on emulator + toxiproxy, issue #2389): while the surface
+ * holds the recovery ("Attaching…", `terminalHeld = true`) the screen
+ * intentionally unmounts the Termux `AndroidView`; the view model reaches
+ * `Connected` BEFORE the screen recomposes and re-mounts it (~570–610 ms idle,
+ * far longer on a loaded box). Both proofs captured the authoritative viewport
+ * ~120–150 ms after `waitForConnected(...)`, i.e. inside that window.
+ *
+ * These per-push JVM assertions pin the two halves of the fix that a connected
+ * nightly-only proof cannot pin for the PR gate:
+ *
+ *  1. The product mount contract that makes the viewport come back at all — a
+ *     recovered `Connected` pane with panes must re-mount the pager even while
+ *     the reveal fusion is still held ([shouldKeepTerminalMounted]). If that
+ *     regressed, the viewport would never return and the e2e wait would time out.
+ *  2. The harness contract: neither proof may capture its post-recovery viewport
+ *     without first awaiting the restore through the shared, hard-failing
+ *     [com.pocketshell.app.proof.RecoveredTerminalViewport] gate — and that gate
+ *     must stay a bounded HARD failure, never a skip/soft-pass.
+ *
+ * Assertion (2) is a source contract on purpose (the same pattern as
+ * [Issue2357KeepTerminalMountedTest.sessionScreenCallsTheKeepMountedHelper]):
+ * the proofs are toxiproxy-gated nightly classes, so nothing in the per-push lane
+ * can execute them, and a future edit that re-inlines the racy
+ * "capture straight after Connected" shape would otherwise silently resurrect the
+ * whole `#2135` cohort.
+ */
+class Issue2389PostRecoveryViewportGateTest {
+
+    @Test
+    fun recoveredConnectedPaneRemountsTheTerminalEvenWhileTheRevealIsHeld() {
+        // The post-recovery tuple observed on the emulator right after the VM
+        // flips back to Connected: panes are back, the connection is live, the
+        // reveal fusion can still be held for a frame or two.
+        val remounts = shouldKeepTerminalMounted(
+            terminalHeld = true,
+            deferTerminalAttachForSwap = false,
+            hasPanes = true,
+            sessionLive = true,
+        )
+        assertTrue(
+            "REGRESSION (#2389/#2135): after a fault-recovery returns to Connected " +
+                "the terminal pager must re-mount, or the post-recovery viewport " +
+                "never comes back and the recovery proofs red on viewFound=false",
+            remounts,
+        )
+    }
+
+    @Test
+    fun heldSurfaceWithoutALiveConnectionStillUnmounts() {
+        // Vacuity guard: the gate above is not "always true". During the recovery
+        // hold itself (not yet Connected) the terminal IS unmounted — which is
+        // exactly why the proofs must WAIT instead of capturing immediately.
+        assertFalse(
+            "the recovery hold must still unmount the terminal (that is the " +
+                "window the #2135 captures were racing); if this is true the " +
+                "restore-wait assertion above proves nothing",
+            shouldKeepTerminalMounted(
+                terminalHeld = true,
+                deferTerminalAttachForSwap = false,
+                hasPanes = true,
+                sessionLive = false,
+            ),
+        )
+    }
+
+    @Test
+    fun bothRecoveryProofsAwaitTheRestoredViewportBeforeCapturing() {
+        val natIdle = source(
+            "app/src/androidTest/java/com/pocketshell/app/proof/" +
+                "NatIdleMappingSurvivalE2eTest.kt",
+        )
+        val pushResume = source(
+            "app/src/androidTest/java/com/pocketshell/app/proof/" +
+                "PushResumeDeadSocketMainResponsiveE2eTest.kt",
+        )
+        for ((name, body) in listOf("NatIdle" to natIdle, "PushResume" to pushResume)) {
+            assertTrue(
+                "$name must await the restored viewport through the shared #2389 " +
+                    "gate before its post-recovery capture, or it races the surface " +
+                    "hold again (the #2135 viewFound=false cohort)",
+                body.contains("RecoveredTerminalViewport.awaitRestored("),
+            )
+        }
+        assertTrue(
+            "NatIdle must await the restore BEFORE capturing the recovered viewport",
+            natIdle.indexOf("RecoveredTerminalViewport.awaitRestored(") <
+                natIdle.indexOf("captureViewport(\"issue1063-recover-02-recovered\")"),
+        )
+        assertTrue(
+            "PushResume must await the restore BEFORE capturing the settled viewport",
+            pushResume.indexOf("RecoveredTerminalViewport.awaitRestored(") <
+                pushResume.indexOf("captureViewport(\"issue1139-03-settled\")"),
+        )
+    }
+
+    @Test
+    fun theRestoreGateStaysABoundedHardFailure() {
+        val gate = source(
+            "app/src/androidTest/java/com/pocketshell/app/proof/RecoveredTerminalViewport.kt",
+        )
+        assertTrue(
+            "the restore gate must hard-fail when the viewport never comes back " +
+                "(a missing post-recovery terminal viewport is the #2135 defect, " +
+                "not something to wait out silently)",
+            gate.contains("throw AssertionError("),
+        )
+        assertTrue(
+            "the restore gate must stay BOUNDED so a permanently held surface reds " +
+                "instead of hanging the proof",
+            gate.contains("RESTORE_BUDGET_MS"),
+        )
+        assertFalse(
+            "the restore gate must never downgrade a missing viewport to an " +
+                "assume/skip",
+            gate.contains("Assume.assume") || gate.contains("assumeTrue("),
+        )
+        assertTrue(
+            "the restore gate must require a LIVE terminal (session + emulator " +
+                "bound), not merely an attached empty view",
+            gate.contains("currentSession != null") && gate.contains("mEmulator != null"),
+        )
+    }
+
+    private fun source(relativePath: String): String {
+        val userDir = checkNotNull(System.getProperty("user.dir")) { "user.dir is unset" }
+        var cursor = File(userDir).absoluteFile
+        while (true) {
+            val candidate = File(cursor, relativePath)
+            if (candidate.isFile) return candidate.readText()
+            cursor = cursor.parentFile ?: break
+        }
+        error("Cannot locate $relativePath from $userDir")
+    }
+}


### PR DESCRIPTION
Closes #2389.

`NatIdleMappingSurvivalE2eTest` and `PushResumeDeadSocketMainResponsiveE2eTest` both captured the post-recovery terminal viewport using `Instrumentation.waitForIdleSync()`, which pumps the main Looper but never advances Compose's own frame clock. `AndroidComposeTestRule` installs a `TestMonotonicFrameClock` globally for the test's duration, so the app under test only gets a Compose frame when the test explicitly drives one — `waitForIdleSync()` can never do that. During the recovery hold, the terminal `AndroidView` unmounts and remounts via recomposition; that recomposition could sit pending for up to 16s without the old capture noticing, producing a false `viewFound=false` on the `#2135` signature even though the app's actual state was correct in every observed run.

**This was never a connection-core regression** — it was masked behind the vacuous #2380 harness bug and then misdiagnosed as real once that harness was fixed. No product code changes in this PR.

## Changes

- `RecoveredTerminalViewport.kt` (new): a shared, bounded, still hard-failing gate that waits via `compose.waitUntil` for a genuinely live, re-attached terminal (session + emulator bound) before the authoritative capture. Proven non-vacuous: a negative-control mutation making the gate's condition unsatisfiable still produces a bounded hard `AssertionError` capturing the app's real (correct, non-blank) state.
- `Issue2389PostRecoveryViewportGateTest.kt` (new, per-push JVM guard).
- Both proof tests updated to use the shared gate.

## Test plan

- [x] Reviewer independently verified the mechanism by reverse-engineering the actual Compose test framework internals (`AndroidComposeUiTestEnvironment` → `WindowRecomposerPolicy`) — confirmed deterministic, not emulator flakiness, consistent with the observed ~90% failure rate.
- [x] Reviewer's own red→green: removing the `awaitRestored(...)` call reproduces the exact original `viewFound=false` signature; 4/4 passing runs with real restore timings (74-114ms) after the fix.
- [x] Reviewer built their own negative control (not reusing the implementer's, which was on a superseded gate version) confirming the gate still fails loudly and correctly when the condition genuinely can't be satisfied.
- [x] `scripts/full-jvm-gate.py`: BUILD SUCCESSFUL, 604/604 executed, exit 0.
- [x] Rebased cleanly onto `main` post-#2380-merge; vendored review-only files from that process dropped, using the real merged #2380 code instead.

## Non-blocking follow-up noted by review

~50 other androidTest classes share the same latent `waitForIdleSync()`-before-viewport-capture defect class — worth its own audit, not fixed here.