### PR TITLE
Fix HostBootstrapScenarioSuiteTest: tag-derived versioning broke bootstrap detection

### DIFF
--- a/.github/workflows/nightly-extensive.yml
+++ b/.github/workflows/nightly-extensive.yml
@@ -173,8 +173,18 @@ jobs:
     continue-on-error: true
 
     steps:
+      # Issue #2381: fetch-depth 0. The APK's versionName is DERIVED from the
+      # git tag (#2356) and the app treats its release core as the
+      # `pocketshell` CLI version it expects on the host. A shallow checkout
+      # derives the `0.0.0-dev+<sha>` placeholder, which sits below every real
+      # CLI version — phase 3's uv-upgrade scenarios then cannot express "the
+      # host CLI is outdated" at all and the setup-detection gate is
+      # untestable. Same reason tests.yml's dex job already checks out full
+      # history.
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -239,6 +249,12 @@ jobs:
       # port is unforwarded, so they are started and health-waited like the rest.
       - name: Start Docker fixtures (agents, flaky-agent, tmux + toxiproxy + bootstrap + old-cli + daemon)
         run: |
+          # Issue #2381: publish the derived version into the `agents` fixture
+          # so its `pocketshell --version` matches the APK under test. Without
+          # it the app reports VersionMismatch against the fixture and the
+          # bootstrap sheet takes over every journey using it.
+          source scripts/lib/agents-fixture-version.sh
+          export_agents_fixture_version
           docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps \
             agents flaky-agent tmux network-fault-proxy packet-loss-proxy \
             bootstrap-ready bootstrap-uv-install bootstrap-uv-upgrade \

--- a/.github/workflows/pr-journey-smoke.yml
+++ b/.github/workflows/pr-journey-smoke.yml
@@ -106,7 +106,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # Issue #2381: fetch-depth 0 so the APK's git-tag-derived versionName
+      # (#2356) is a real release version rather than the 0.0.0-dev
+      # placeholder a shallow checkout produces — the `agents` fixture is
+      # stamped with the same derived version, and a mismatch pops the
+      # bootstrap "Host setup needed" sheet over every smoke journey.
       - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1293,8 +1293,11 @@ jobs:
       - name: Record emulator-journey job start
         run: echo "JOURNEY_JOB_START_EPOCH_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
 
+      # fetch-depth 0 (#2381): versionName derives from the git tag.
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       # Issue #2324: create the setup evidence root before any pre-journey
       # operation can fail. The Android SDK repair below writes its captured

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ app/google-services.json
 # any full pytest run rewrote it and dirtied every worktree)
 __pycache__/
 *.pyc
+
+# Issue #2381: scripts/derive-version.sh write-pin's output. It only ever
+# belongs in a DETACHED copy of a checkout (the pre-release gate's `.git`-less
+# rsync worktree, which already lives under build/); committing one would
+# freeze this repo's derived version at whatever it happened to be.
+.pocketshell-version-pin

--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
@@ -142,7 +142,17 @@ class HostBootstrapScenarioSuiteTest {
         assertSetupRows(CLI_UPDATE_ROW_TITLE)
         compose.onNodeWithText("path /usr/local/bin/pocketshell", substring = true).assertExists()
         compose.onNodeWithText("remote 0.1.0", substring = true).assertExists()
-        compose.onNodeWithText("expected ${targetAppVersion()}", substring = true).assertExists()
+        // Issue #2381: the sheet names the version the app actually asks the
+        // host installer for — the RELEASE CORE of this build's versionName,
+        // which is what `pocketshell==<version>` can resolve. The raw
+        // git-derived `versionName` (`0.4.45-4-g9b1d784e`) is neither a
+        // published release nor meaningful to a user. Before #2356 the two
+        // were the same string, which is why this oracle could read the raw
+        // versionName and still pass.
+        compose.onNodeWithText(
+            "expected ${expectedHostCliVersion(targetAppVersion())}",
+            substring = true,
+        ).assertExists()
         compose.onNodeWithText("uv at /usr/local/bin/uv", substring = true).assertExists()
         compose.onNodeWithTag(HOST_BOOTSTRAP_INSTALL_ALL_TAG).assertExists().performClick()
         compose.onNodeWithTag(HOST_BOOTSTRAP_INSTALLING_TAG).assertExists()
@@ -355,8 +365,57 @@ class HostBootstrapScenarioSuiteTest {
         }
     } }
 
+    /**
+     * Issue #2381: every scenario below derives its fixture's reported CLI
+     * version from the APK's own [targetAppVersion] — that is the whole point
+     * of the suite (the app compares the host CLI against the version it was
+     * built for). Since #2356 that version is DERIVED from the git tag, and a
+     * tagless/shallow checkout derives `0.0.0-dev+<sha>`.
+     *
+     * `0.0.0` is below every real CLI version, so the uv-upgrade scenarios
+     * cannot express "the host CLI is outdated" at all and the setup-detection
+     * signal is meaningless. On 2026-08-28 that is exactly what happened and
+     * it surfaced as eight unrelated-looking 20 s Compose timeouts. Fail once,
+     * loudly, with the actual diagnosis instead — and HARD-fail rather than
+     * `Assume`-skip, because a silently skipped release gate is worse than a
+     * red one.
+     *
+     * The message must name the cause that actually applies, because there are
+     * two very different ones and only one of them is fixed by re-checking-out.
+     * The release chain hits the SECOND: `.github/workflows/release-emulator-
+     * validation.yml` already checks out with `fetch-depth: 0`, and
+     * `scripts/pre-release-confidence-gate.sh` then rsyncs that checkout to a
+     * deliberately `.git`-less copy and builds every release-chain APK inside
+     * it — so the tag history is present in CI and absent where the binary is
+     * produced. Telling that operator to "fetch tags" sends them looking for a
+     * problem that is not there.
+     */
+    private fun assertApkCarriesARealReleaseVersion() {
+        val versionName = targetAppVersion()
+        val core = versionName.trim().removePrefix("v").substringBefore('+').substringBefore('-')
+        assertTrue(
+            "the APK under test reports versionName='$versionName', whose release core is " +
+                "'$core'. scripts/derive-version.sh emits that placeholder only when it cannot " +
+                "reach a v* tag, so this build cannot express host-CLI version relationships " +
+                "and every setup-detection scenario is vacuous. Two causes, two different " +
+                "fixes: (1) the CHECKOUT is shallow/tagless — check out with full tag history " +
+                "(actions/checkout fetch-depth: 0) or `git fetch --tags`; (2) the APK was built " +
+                "inside a DETACHED COPY that has no git of its own — scripts/" +
+                "pre-release-confidence-gate.sh rsyncs the checkout to build/" +
+                "pre-release-confidence-gate/<run>/worktree with --exclude='.git' and builds the " +
+                "whole release chain's APK there, so fetching tags in the outer checkout changes " +
+                "nothing. That copy must be stamped by `scripts/derive-version.sh write-pin " +
+                "<copy>`, which the gate does immediately after the rsync; a missing/malformed " +
+                ".pocketshell-version-pin in the copy is the failure. Guards: " +
+                "tests/scripts/gate-isolated-copy-version-test.sh (the pin) and " +
+                "scripts/check-emulator-apk-version-wiring.sh (the fixture stamp) — #2381.",
+            core.isNotEmpty() && core != "0.0.0",
+        )
+    }
+
     private fun scenario(name: String, block: ScenarioContext.() -> Unit) = runBlocking {
         assumeScenariosEnabled()
+        assertApkCarriesARealReleaseVersion()
         val definition = requireNotNull(SCENARIOS[name]) { "unknown bootstrap scenario: $name" }
         val key = testKey()
         val context = ScenarioContext(name = name, definition = definition, key = key)

--- a/app/src/main/java/com/pocketshell/app/bootstrap/AppCliVersion.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/AppCliVersion.kt
@@ -1,0 +1,84 @@
+package com.pocketshell.app.bootstrap
+
+/**
+ * The RELEASE CORE (`MAJOR.MINOR.PATCH`, any number of dotted numeric
+ * components) of a version string, with any semver pre-release qualifier
+ * (`-…`) and any build metadata (`+…`) stripped.
+ *
+ * ## Why this exists (issue #2381)
+ *
+ * Until issue #2356 the app's `versionName` was a hand-maintained
+ * `versionName = "0.4.44"` literal, so "the pocketshell CLI version this app
+ * build expects on the host" was trivially a clean dotted release version:
+ * exactly the `tools/pocketshell` release published in lockstep with the APK.
+ * Every consumer — [compareSemver], the `pocketshell==<version>` install pin in
+ * `HostPocketshellUpgrade` — silently relied on that shape.
+ *
+ * #2356 replaced the literal with `scripts/derive-version.sh`, which produces
+ * four shapes:
+ *
+ * | build                       | derived `versionName`      |
+ * |-----------------------------|----------------------------|
+ * | exact release tag           | `0.4.45`                   |
+ * | commit after a tag (dev/CI) | `0.4.45-4-g9b1d784e`       |
+ * | tagless checkout (CI)       | `0.0.0-dev+525c87a`        |
+ * | no git at all               | `0.0.0-dev`                |
+ *
+ * Three of the four are NOT dotted-numeric, and the app compared them against
+ * the host's reported CLI version with a comparator that only understood the
+ * first shape. The consequences were all user-visible:
+ *
+ *  - A correctly set-up host reported `VersionMismatch`, so the bootstrap
+ *    "Host setup needed" sheet took over and never cleared — the app could not
+ *    navigate past setup at all. This is what collapsed the nightly fault
+ *    gate's bootstrap phase on 2026-08-28 (8 of 10
+ *    `HostBootstrapScenarioSuiteTest` methods), where the CI APK reported
+ *    `0.0.0-dev+525c87a` while `pocketshell --version` on the fixture reported
+ *    the very same string: the app's own `VERSION_PATTERN` truncated the
+ *    host's answer at the `+` (to `0.0.0-dev`) and then declared the two
+ *    unequal.
+ *  - The remote-CLI-is-newer path (#514) degraded into `VersionMismatch` too,
+ *    so a genuinely newer host CLI raised a takeover setup sheet instead of the
+ *    soft, dismissible "consider updating the app" banner.
+ *  - `HostPocketshellUpgrade` pinned `pocketshell==0.4.45-4-g9b1d784e`, a
+ *    version that exists on no index, so the offered fix could never succeed.
+ *
+ * The release core is the right expectation in every case: a build made N
+ * commits after `v0.4.45` still ships against the `0.4.45` CLI, and semver
+ * §10 says build metadata never participates in precedence.
+ *
+ * Returns `null` when [raw] has no parseable dotted-numeric core (callers keep
+ * their existing conservative fallback rather than guessing).
+ */
+internal fun releaseVersionCore(raw: String): String? =
+    releaseVersionCoreComponents(raw)?.joinToString(".")
+
+/** [releaseVersionCore] as numeric components, for ordering comparisons. */
+internal fun releaseVersionCoreComponents(raw: String): List<Int>? {
+    val trimmed = raw.trim().removePrefix("v")
+    if (trimmed.isEmpty()) return null
+    // Semver §10: build metadata (`+…`) is not part of precedence. Strip it
+    // first so `0.0.0-dev+525c87a` and `0.0.0-dev` are the same release.
+    val withoutBuild = trimmed.substringBefore('+')
+    // Then the pre-release / git-describe qualifier: `0.4.45-4-g9b1d784e` is
+    // "4 commits after v0.4.45", i.e. still the 0.4.45 release line.
+    val core = withoutBuild.substringBefore('-')
+    if (core.isEmpty()) return null
+    val parts = core.split('.')
+    val components = ArrayList<Int>(parts.size)
+    for (part in parts) {
+        if (part.isEmpty()) return null
+        val value = part.toIntOrNull() ?: return null
+        if (value < 0) return null
+        components += value
+    }
+    return components
+}
+
+/**
+ * The version this app build expects the host `pocketshell` CLI to be at, from
+ * the installed APK's [versionName]. Empty when it cannot be resolved (callers
+ * then skip the version check entirely, exactly as before #2356).
+ */
+internal fun expectedHostCliVersion(versionName: String?): String =
+    versionName?.let { releaseVersionCore(it) }.orEmpty()

--- a/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
+++ b/app/src/main/java/com/pocketshell/app/bootstrap/HostBootstrapper.kt
@@ -177,19 +177,28 @@ public sealed interface HooksStatus {
 }
 
 /**
- * Compare two dotted-numeric versions (`MAJOR.MINOR.PATCH`, any number of
- * components) numerically. Returns a negative number when [a] < [b], zero
- * when equal, a positive number when [a] > [b], or `null` when either side
- * is not a clean dotted-numeric version (so callers can fall back to the
- * conservative mismatch path instead of guessing).
+ * Compare two versions by their RELEASE CORE (`MAJOR.MINOR.PATCH`, any number
+ * of dotted numeric components). Returns a negative number when [a] < [b],
+ * zero when equal, a positive number when [a] > [b], or `null` when either
+ * side has no parseable core (so callers can fall back to the conservative
+ * mismatch path instead of guessing).
  *
  * Issue #514: a plain string `==` / `compareTo` mis-orders multi-digit
  * components ("0.3.10" < "0.3.9" as strings) and cannot tell "remote is
  * newer" from "remote is older". This pure numeric compare fixes both.
+ *
+ * Issue #2381: it compares CORES, not raw strings, because since #2356 the
+ * app's own `versionName` — which is what the caller passes as the expected
+ * version — can carry a git-describe qualifier and/or semver build metadata
+ * (`0.4.45-4-g9b1d784e`, `0.0.0-dev+525c87a`). Comparing those raw made this
+ * function return `null` for every non-tag build, dropping the caller into a
+ * string-equality fallback that labelled a perfectly current host
+ * `VersionMismatch` and a genuinely newer host `VersionMismatch` instead of
+ * `AppUpdateRequired`. See [releaseVersionCoreComponents].
  */
 internal fun compareSemver(a: String, b: String): Int? {
-    val left = parseSemverComponents(a) ?: return null
-    val right = parseSemverComponents(b) ?: return null
+    val left = releaseVersionCoreComponents(a) ?: return null
+    val right = releaseVersionCoreComponents(b) ?: return null
     val size = maxOf(left.size, right.size)
     for (i in 0 until size) {
         val l = left.getOrElse(i) { 0 }
@@ -197,20 +206,6 @@ internal fun compareSemver(a: String, b: String): Int? {
         if (l != r) return l.compareTo(r)
     }
     return 0
-}
-
-private fun parseSemverComponents(version: String): List<Int>? {
-    val trimmed = version.trim()
-    if (trimmed.isEmpty()) return null
-    val parts = trimmed.split('.')
-    val components = ArrayList<Int>(parts.size)
-    for (part in parts) {
-        if (part.isEmpty()) return null
-        val value = part.toIntOrNull() ?: return null
-        if (value < 0) return null
-        components += value
-    }
-    return components
 }
 
 public sealed interface PocketshellDaemonStatus {
@@ -1070,7 +1065,14 @@ public class HostBootstrapper @javax.inject.Inject constructor() {
             this is ToolStatus.AppUpdateRequired
 
     public companion object {
-        private val VERSION_PATTERN: Regex = Regex("""\b(\d+(?:\.\d+){1,3}(?:[-+][0-9A-Za-z.-]+)?)\b""")
+        // Issue #2381: the qualifier class must include `+` (semver build
+        // metadata). Without it `0.0.0-dev+525c87a` — the versionName a
+        // tagless CI checkout derives (#2356), and therefore what the CI
+        // fixture reports back as its `pocketshell --version` — was truncated
+        // to `0.0.0-dev` here, and the caller then compared that truncated
+        // parse of the app's OWN version against the untruncated original and
+        // called them different.
+        private val VERSION_PATTERN: Regex = Regex("""\b(\d+(?:\.\d+){1,3}(?:[-+][0-9A-Za-z.+-]+)?)\b""")
 
         // Issue #1236: extract every `"installed": true|false` from
         // `pocketshell hooks status --json`. A tolerant regex avoids pulling

--- a/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/hosts/HostListViewModel.kt
@@ -12,6 +12,7 @@ import com.pocketshell.app.bootstrap.BootstrapTool
 import com.pocketshell.app.bootstrap.PocketshellDaemonStatus
 import com.pocketshell.app.bootstrap.TmuxStatus
 import com.pocketshell.app.bootstrap.ToolStatus
+import com.pocketshell.app.bootstrap.expectedHostCliVersion
 import com.pocketshell.app.bootstrap.cliUpdateFailureMessage
 import com.pocketshell.app.bootstrap.cliUpdateNoChangeMessage
 import com.pocketshell.app.bootstrap.compareSemver
@@ -1685,7 +1686,15 @@ class HostListViewModel internal constructor(
         )
     }
 
-    private fun expectedPocketshellVersion(): String = currentVersionName().orEmpty()
+    /**
+     * Issue #2381: the RELEASE CORE of the APK's `versionName`, not the raw
+     * string. Since #2356 `versionName` is derived from git
+     * (`0.4.45-4-g9b1d784e`, `0.0.0-dev+525c87a`, …), and the raw form is
+     * neither a version any host CLI can report back nor one that
+     * `pocketshell==<version>` can resolve on an index. See
+     * [expectedHostCliVersion].
+     */
+    private fun expectedPocketshellVersion(): String = expectedHostCliVersion(currentVersionName())
 
     private fun closeBootstrapSession() {
         val session = bootstrapSession ?: return

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListViewModel.kt
@@ -18,6 +18,7 @@ import com.pocketshell.app.assistant.FolderCandidate
 import com.pocketshell.app.assistant.RealAssistantSshExecutor
 import com.pocketshell.app.assistant.SessionActionBridge
 import com.pocketshell.app.assistant.SessionAssistantController
+import com.pocketshell.app.bootstrap.expectedHostCliVersion
 import com.pocketshell.app.nav.AppDestination
 import com.pocketshell.app.portfwd.ForwardingController
 import com.pocketshell.app.portfwd.ForwardingHostSnapshot
@@ -137,14 +138,20 @@ class FolderListViewModel internal constructor(
     // installed app `versionName` (app + CLI ship in lockstep on every release
     // tag — `tools/pocketshell/pyproject.toml`). Injectable so unit tests can
     // pin it deterministically without a real PackageManager.
+    // Issue #2381: it is the RELEASE CORE of `versionName`, not the raw
+    // string. Since #2356 `versionName` is git-derived and can carry a
+    // describe qualifier and/or build metadata (`0.4.45-4-g9b1d784e`,
+    // `0.0.0-dev+525c87a`) — shapes no host CLI reports and no index can
+    // resolve for the `pocketshell==<version>` upgrade pin. See
+    // [expectedHostCliVersion].
     private val expectedPocketshellVersionProvider: () -> String = expectedPocketshellVersionProvider@{
         val context = applicationContext ?: return@expectedPocketshellVersionProvider ""
         try {
-            context.packageManager
-                .getPackageInfo(context.packageName, 0)
-                .versionName
-                ?.trim()
-                .orEmpty()
+            expectedHostCliVersion(
+                context.packageManager
+                    .getPackageInfo(context.packageName, 0)
+                    .versionName,
+            )
         } catch (_: Throwable) {
             ""
         }

--- a/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/HostPocketshellUpgrade.kt
@@ -212,8 +212,12 @@ public class HostPocketshellUpgrade {
         private fun pinnedSpec(requestedVersion: String): String {
             val version = requestedVersion.trim()
             if (version.isEmpty()) return "pocketshell"
-            // versionName is dotted-numeric from our own APK; still quote so a
-            // surprising character cannot break the /bin/sh -c wrapping.
+            // The caller passes the RELEASE CORE of our own APK's versionName
+            // (issue #2381 — `expectedHostCliVersion`), so this is a real
+            // published `tools/pocketshell` version rather than the raw
+            // git-derived `0.4.45-4-g9b1d784e` that no index can resolve.
+            // Still filtered so a surprising character cannot break the
+            // /bin/sh -c wrapping.
             val safe = version.filter { it.isLetterOrDigit() || it == '.' || it == '-' || it == '_' }
             if (safe.isEmpty()) return "pocketshell"
             return "pocketshell==$safe"

--- a/app/src/test/java/com/pocketshell/app/bootstrap/Issue2381DerivedAppVersionCliCompatibilityTest.kt
+++ b/app/src/test/java/com/pocketshell/app/bootstrap/Issue2381DerivedAppVersionCliCompatibilityTest.kt
@@ -1,0 +1,331 @@
+package com.pocketshell.app.bootstrap
+
+import com.pocketshell.app.projects.HostPocketshellUpgrade
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2381 — the app's own git-derived `versionName` must not make a
+ * correctly set-up host look like it needs a CLI update.
+ *
+ * ## The regression this pins
+ *
+ * `HostBootstrapper` treats the installed APK's `versionName` as "the
+ * `pocketshell` CLI version this build expects on the host". Until issue
+ * #2356 that was a hand-maintained `versionName = "0.4.44"` literal, so the
+ * expectation was always a clean dotted release version. #2356 (commit
+ * `824f2aa2`) replaced it with `scripts/derive-version.sh`, which emits four
+ * shapes — `0.4.45`, `0.4.45-4-g9b1d784e`, `0.0.0-dev+525c87a`, `0.0.0-dev` —
+ * three of which are not dotted-numeric.
+ *
+ * The 2026-08-28 nightly built the APK from a tagless (shallow) checkout, so
+ * `aapt` recorded `versionName='0.0.0-dev+525c87a'`. The bootstrap fixtures
+ * report back the very same string the test wrote into them, yet
+ * `HostBootstrapScenarioSuiteTest` failed 8 of 10 methods, because:
+ *
+ *  1. `VERSION_PATTERN` excluded `+` from its qualifier class, so parsing the
+ *     host's `pocketshell 0.0.0-dev+525c87a` truncated it to `0.0.0-dev`; and
+ *  2. `compareSemver` returned `null` for both sides, dropping into a raw
+ *     string-equality fallback which then said `0.0.0-dev != 0.0.0-dev+525c87a`
+ *     → `VersionMismatch` → "Host setup needed" sheet that never clears.
+ *
+ * Each test below fails on the pre-fix code and passes after it. They also
+ * cover the class, not just the reported instance (G2): every derived
+ * `versionName` shape, crossed with a host CLI that is equal / older / newer,
+ * plus the `pocketshell==<version>` install pin that the same raw string fed.
+ */
+class Issue2381DerivedAppVersionCliCompatibilityTest {
+
+    private val bootstrapper = HostBootstrapper()
+
+    // ---------------------------------------------------------------------
+    // 1. The exact reported instance: the nightly's own versionName.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun hostReportingTheAppsOwnDerivedVersionIsReady_notAVersionMismatch() = runTest {
+        // Reproduces nightly run 33148401037 verbatim: APK versionName
+        // '0.0.0-dev+525c87a', bootstrap fixture seeded with that same string.
+        val report = checkServerSetup(
+            hostReportedVersion = NIGHTLY_APK_VERSION_NAME,
+            appVersionName = NIGHTLY_APK_VERSION_NAME,
+        )
+
+        assertEquals(
+            "a host reporting the app's own version must be Installed, not VersionMismatch " +
+                "(pre-fix this was VersionMismatch, so the bootstrap sheet never cleared)",
+            ToolStatus.Installed(
+                path = POCKETSHELL_PATH,
+                version = NIGHTLY_APK_VERSION_NAME,
+                expectedVersion = NIGHTLY_APK_VERSION_NAME,
+            ),
+            report.tools[BootstrapTool.Pocketshell],
+        )
+        assertTrue("host must be ready so the app navigates past setup", report.isReady)
+        assertTrue(report.versionMismatchedTools.isEmpty())
+    }
+
+    @Test
+    fun buildMetadataIsNotTruncatedOutOfAParsedVersion() {
+        // Root cause (1): the `+` build-metadata suffix fell outside the
+        // qualifier character class, so the app parsed a DIFFERENT string out
+        // of the host's answer than the one the host actually printed.
+        assertEquals(
+            "0.0.0-dev+525c87a",
+            bootstrapper.parsePocketshellVersion("pocketshell $NIGHTLY_APK_VERSION_NAME\n"),
+        )
+        assertEquals(
+            "0.4.45-4-g9b1d784e",
+            bootstrapper.parsePocketshellVersion("pocketshell bootstrap fixture 0.4.45-4-g9b1d784e\n"),
+        )
+        assertEquals("0.4.45", bootstrapper.parsePocketshellVersion("pocketshell, version 0.4.45\n"))
+        assertNull(bootstrapper.parsePocketshellVersion("pocketshell dev build\n"))
+    }
+
+    // ---------------------------------------------------------------------
+    // 2. The class (G2): every derived versionName shape.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun releaseCoreIsResolvedForEveryShapeDeriveVersionCanEmit() {
+        // scripts/derive-version.sh's four documented outputs.
+        assertEquals("0.4.45", releaseVersionCore("0.4.45"))
+        assertEquals("0.4.45", releaseVersionCore("0.4.45-4-g9b1d784e"))
+        assertEquals("0.0.0", releaseVersionCore("0.0.0-dev+525c87a"))
+        assertEquals("0.0.0", releaseVersionCore("0.0.0-dev"))
+        // Plus the tag form and plain semver build metadata.
+        assertEquals("0.4.45", releaseVersionCore("v0.4.45"))
+        assertEquals("1.2.3", releaseVersionCore("1.2.3+build.7"))
+        // Genuinely unparseable stays null so callers keep their conservative
+        // fallback rather than guessing.
+        assertNull(releaseVersionCore("dev"))
+        assertNull(releaseVersionCore(""))
+        assertNull(releaseVersionCore("v-next"))
+    }
+
+    @Test
+    fun everyDerivedVersionShapeAcceptsAHostOnTheSameReleaseLine() = runTest {
+        for (appVersionName in DERIVED_VERSION_NAME_SHAPES) {
+            val core = requireNotNull(releaseVersionCore(appVersionName))
+            // The host reports the plain published release (what a real
+            // `uv tool install pocketshell` leaves behind), the app carries the
+            // derived dev string. Same release line ⇒ ready.
+            val report = checkServerSetup(hostReportedVersion = core, appVersionName = appVersionName)
+            assertTrue(
+                "app versionName '$appVersionName' must accept a host CLI on release core '$core'",
+                report.isReady,
+            )
+            assertTrue(
+                "app versionName '$appVersionName' must not flag a same-core host as mismatched",
+                report.versionMismatchedTools.isEmpty(),
+            )
+        }
+    }
+
+    @Test
+    fun aStrictlyOlderHostCliStaysAVersionMismatchOnEveryDerivedShape() = runTest {
+        // The host-upgrade flow (#514/#779) must survive the fix: an actually
+        // outdated CLI still raises the "pocketshell CLI update needed" row.
+        for (appVersionName in listOf("0.4.45", "0.4.45-4-g9b1d784e")) {
+            val report = checkServerSetup(hostReportedVersion = "0.3.6", appVersionName = appVersionName)
+
+            assertEquals(
+                "app versionName '$appVersionName' must still flag an older host CLI",
+                listOf(BootstrapTool.Pocketshell),
+                report.versionMismatchedTools,
+            )
+            assertEquals(
+                ToolStatus.VersionMismatch(
+                    path = POCKETSHELL_PATH,
+                    currentVersion = "0.3.6",
+                    expectedVersion = appVersionName,
+                ),
+                report.tools[BootstrapTool.Pocketshell],
+            )
+        }
+    }
+
+    @Test
+    fun aStrictlyNewerHostCliIsAppUpdateRequiredOnEveryDerivedShape() = runTest {
+        // Issue #514's remote-newer path. Pre-fix a dev versionName collapsed
+        // this into VersionMismatch, which pops the takeover setup sheet and
+        // runs the host installer in a loop instead of the soft banner —
+        // exactly what broke `appUpdateRequired` in the nightly.
+        for (appVersionName in DERIVED_VERSION_NAME_SHAPES) {
+            val report = checkServerSetup(hostReportedVersion = "9999.0.0", appVersionName = appVersionName)
+
+            val status = report.tools[BootstrapTool.Pocketshell]
+            assertTrue(
+                "app versionName '$appVersionName': remote-newer must be AppUpdateRequired, got $status",
+                status is ToolStatus.AppUpdateRequired,
+            )
+            assertTrue(
+                "app versionName '$appVersionName': remote-newer host stays fully usable (no setup sheet)",
+                report.isReady,
+            )
+        }
+    }
+
+    @Test
+    fun releaseCoresOrderNumericallyAndIgnoreBuildMetadata() {
+        assertEquals(0, compareSemver("0.0.0-dev+525c87a", "0.0.0-dev"))
+        assertEquals(0, compareSemver("0.4.45", "0.4.45-4-g9b1d784e"))
+        assertEquals(0, compareSemver("v0.4.45", "0.4.45+ci.7"))
+        assertTrue(requireNotNull(compareSemver("0.3.10", "0.3.9-rc1")) > 0)
+        assertTrue(requireNotNull(compareSemver("0.0.0-dev", "0.3.6")) < 0)
+        // Unparseable on either side still yields null (conservative path).
+        assertNull(compareSemver("dev", "0.4.45"))
+        assertNull(compareSemver("0.4.45", "nightly"))
+    }
+
+    // ---------------------------------------------------------------------
+    // 3. The same raw string also fed the install pin.
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun expectedHostCliVersionFeedsAResolvableInstallPin() {
+        // Pre-fix, `HostPocketshellUpgrade` pinned
+        // `pocketshell==0.4.45-4-g9b1d784e` — a version published on no index,
+        // so the "Update" action the sheet offered could never succeed.
+        val command = HostPocketshellUpgrade.upgradeCommand(
+            expectedHostCliVersion("0.4.45-4-g9b1d784e"),
+        )
+        assertTrue(
+            "upgrade must pin the published release core, got: $command",
+            command.contains("pocketshell==0.4.45"),
+        )
+        assertTrue(
+            "upgrade must not pin the git-describe suffix, got: $command",
+            !command.contains("g9b1d784e"),
+        )
+    }
+
+    @Test
+    fun expectedHostCliVersionIsEmptyWhenNoReleaseCoreCanBeResolved() {
+        // Empty means "skip the version check", the pre-#2356 behaviour for a
+        // build whose versionName cannot be read at all. It must never be a
+        // half-parsed string that then mismatches everything.
+        assertEquals("", expectedHostCliVersion(null))
+        assertEquals("", expectedHostCliVersion(""))
+        assertEquals("", expectedHostCliVersion("dev"))
+        assertEquals("0.0.0", expectedHostCliVersion("0.0.0-dev+525c87a"))
+    }
+
+    // ---------------------------------------------------------------------
+
+    private suspend fun checkServerSetup(
+        hostReportedVersion: String,
+        appVersionName: String,
+    ): HostBootstrapReport {
+        val session = FakeSshSession(
+            mapOf(
+                pathAware("command -v 'pocketshell'") to ExecResult("$POCKETSHELL_PATH\n", "", 0),
+                pathAware("'$POCKETSHELL_PATH' --version") to
+                    ExecResult("pocketshell $hostReportedVersion\n", "", 0),
+                pathAware("command -v 'uv'") to ExecResult("/home/u/.local/bin/uv\n", "", 0),
+                pathAware("command -v 'systemctl'") to ExecResult("/usr/bin/systemctl\n", "", 0),
+                systemdAware("systemctl --user is-active pocketshell-jobs.service") to
+                    ExecResult("active\n", "", 0),
+                systemdAware("systemctl --user is-enabled pocketshell-jobs.service") to
+                    ExecResult("enabled\n", "", 0),
+            ),
+        )
+        // Deliberately the RAW derived versionName, not the normalized core:
+        // `HostBootstrapper` is the layer that must survive whatever shape
+        // `scripts/derive-version.sh` produced, and this is exactly what the
+        // pre-#2381 ViewModels handed it.
+        val report = bootstrapper.checkServerSetup(
+            session,
+            expectedPocketshellVersion = appVersionName,
+        )
+        assertNotNull("the version probe must actually have run", report.tools[BootstrapTool.Pocketshell])
+        assertTrue(
+            "the version probe must actually have run",
+            session.recorded.contains(pathAware("'$POCKETSHELL_PATH' --version")),
+        )
+        return report
+    }
+
+    private fun pathAware(command: String): String =
+        shell("PATH=${shellQuote(BOOTSTRAP_PATH)}; export PATH; $command")
+
+    private fun systemdAware(command: String): String =
+        shell(
+            "PATH=${shellQuote(BOOTSTRAP_PATH)}; export PATH; " +
+                "XDG_RUNTIME_DIR=\"\${XDG_RUNTIME_DIR:-/run/user/\$(id -u)}\"; export XDG_RUNTIME_DIR; " +
+                "DBUS_SESSION_BUS_ADDRESS=\"\${DBUS_SESSION_BUS_ADDRESS:-unix:path=\$XDG_RUNTIME_DIR/bus}\"; " +
+                "export DBUS_SESSION_BUS_ADDRESS; $command",
+        )
+
+    private fun shell(command: String): String = "/bin/sh -lc ${shellQuote(command)}"
+
+    private fun shellQuote(value: String): String = "'" + value.replace("'", "'\"'\"'") + "'"
+
+    private class FakeSshSession(private val canned: Map<String, ExecResult>) : SshSession {
+        val recorded: MutableList<String> = mutableListOf()
+
+        override val isConnected: Boolean = true
+
+        override suspend fun exec(command: String): ExecResult {
+            recorded += command
+            return canned[command]
+                ?: if (command == HostBootstrapper().detectBootstrapPathCommand()) {
+                    ExecResult(
+                        "__POCKETSHELL_PATH_BEGIN__\n$BOOTSTRAP_PATH\n__POCKETSHELL_PATH_END__\n",
+                        "",
+                        0,
+                    )
+                } else {
+                    ExecResult("", "command not stubbed: $command", 127)
+                }
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("unused")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("unused")
+
+        override fun startShell(): SshShell = error("unused")
+
+        override suspend fun uploadFile(file: java.io.File, remotePath: String): String = error("unused")
+
+        override suspend fun uploadStream(
+            input: java.io.InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("unused")
+
+        override fun close() = Unit
+    }
+
+    private companion object {
+        /** `aapt` output of the 2026-08-28 nightly APK (run 33148401037). */
+        const val NIGHTLY_APK_VERSION_NAME: String = "0.0.0-dev+525c87a"
+
+        const val POCKETSHELL_PATH: String = "/home/u/.local/bin/pocketshell"
+
+        const val BOOTSTRAP_PATH: String =
+            "/home/u/.local/bin:/home/u/bin:/home/u/.cargo/bin:/usr/local/bin:/usr/bin:/bin"
+
+        /** Every shape `scripts/derive-version.sh version-name` can print. */
+        val DERIVED_VERSION_NAME_SHAPES: List<String> = listOf(
+            "0.4.45",
+            "0.4.45-4-g9b1d784e",
+            "0.0.0-dev+525c87a",
+            "0.0.0-dev",
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/scripts/ReleaseGateScriptTest.kt
+++ b/app/src/test/java/com/pocketshell/app/scripts/ReleaseGateScriptTest.kt
@@ -68,6 +68,27 @@ class ReleaseGateScriptTest {
         )
     }
 
+    /**
+     * Issue #2381: the pre-release gate builds every release-chain APK inside a
+     * deliberately `.git`-less rsync copy, where scripts/derive-version.sh used
+     * to answer `0.0.0-dev` / versionCode=1 — so the release gate validated,
+     * journeyed against and published a binary that could not express a release
+     * version, and HostBootstrapScenarioSuiteTest's seven setup-detection
+     * profiles (all of which compare the app version against the host CLI's)
+     * were vacuous. The harness proves the copy is placeholder-versioned
+     * WITHOUT the pin and source-versioned with it, pins the pin's position
+     * between the rsync and the exec, and drives
+     * release-emulator-validation.sh's tagless preflight red then green.
+     */
+    @Test
+    fun preReleaseGateIsolatedCopyCarriesTheCheckoutsRealVersion() {
+        runShellHarness(
+            relativePath = "tests/scripts/gate-isolated-copy-version-test.sh",
+            expectedPassLine = "PASS: gate isolated-copy version pin (14 cases)",
+            timeoutSeconds = 120,
+        )
+    }
+
     /** #548 grace proof: the reconnect script must keep selecting the load-bearing test. */
     @Test
     fun reconnectAppSwitchScriptKeepsItsLoadBearingSelector() {

--- a/scripts/capture-terminal-lab.sh
+++ b/scripts/capture-terminal-lab.sh
@@ -146,6 +146,12 @@ if ! "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then
   fail "AVD '$AVD_NAME' was not listed by $EMULATOR -list-avds"
 fi
 
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it drives sits under the
+# bootstrap "Host setup needed" sheet.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
 run_logged "03-docker-agents-recreate" docker compose -f "$COMPOSE_FILE" up -d --build --force-recreate agents
 wait_for_host_ssh_fixture
 run_logged "05-emulator-readiness" bash -lc \

--- a/scripts/capture-walkthrough-screenshots.sh
+++ b/scripts/capture-walkthrough-screenshots.sh
@@ -359,6 +359,12 @@ if ! "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then
   fail "AVD '$AVD_NAME' was not listed by $EMULATOR -list-avds"
 fi
 
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it captures sits under the
+# bootstrap "Host setup needed" sheet.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$VISUAL_AUDIT_BUILD_APKS" "$APP_APK"
 run_logged "03-docker-agents-recreate" docker compose -f "$COMPOSE_FILE" up -d --build --force-recreate agents
 wait_for_host_ssh_fixture
 run_logged "05-emulator-readiness" bash -lc \

--- a/scripts/check-emulator-apk-version-wiring.sh
+++ b/scripts/check-emulator-apk-version-wiring.sh
@@ -1,0 +1,699 @@
+#!/usr/bin/env bash
+# Issue #2381 — an emulator job must build an APK with a REAL derived version,
+# and the Docker `agents` fixture it runs against must report the same one.
+#
+# WHY
+#
+# Issue #2356 made `versionName` derive from the git tag
+# (scripts/derive-version.sh). The app treats the RELEASE CORE of its own
+# versionName as the `pocketshell` CLI version it expects on the host, so the
+# derived value is load-bearing product input, not decoration:
+#
+#   * A shallow checkout has no `v*` tag reachable, so the derivation falls back
+#     to `0.0.0-dev+<sha>`. `0.0.0` sits BELOW every real CLI version, so the
+#     setup-detection scenarios that need "the host CLI is outdated"
+#     (HostBootstrapScenarioSuiteTest#uvUpgrade / #uvUpgradeFailure) cannot be
+#     expressed at all, and the #515 "New version available" banner is on for
+#     the whole run.
+#   * tests/docker/Dockerfile.agents used to sed the pre-#2356 `versionName =
+#     "X.Y.Z"` literal out of a COPYed app/build.gradle.kts, which kept the
+#     fixture and the APK in lockstep by construction. That literal is gone,
+#     the sed silently matched nothing, and the fixture froze — so the app
+#     reported VersionMismatch and the bootstrap "Host setup needed" sheet took
+#     over journeys that were asserting some other screen entirely. The fixture
+#     is now stamped from POCKETSHELL_AGENT_FIXTURE_VERSION at container start
+#     (tests/docker/agent-entrypoint.sh).
+#
+# The two halves must move together: full tag history WITHOUT the fixture stamp
+# re-breaks every `agents` journey, and the stamp without tag history leaves the
+# setup gate untestable. This guard pins both.
+#
+# CHECKS
+#   1. Every workflow job that uses reactivecircus/android-emulator-runner
+#      checks out with `fetch-depth: 0`.
+#   2. tests/docker/docker-compose.yml's `agents` service forwards
+#      POCKETSHELL_AGENT_FIXTURE_VERSION into the container.
+#   3. tests/docker/agent-entrypoint.sh stamps it into the version file.
+#   4. tests/docker/Dockerfile.agents no longer parses app/build.gradle.kts
+#      (the dead pre-#2356 derivation, removed under D22).
+#   5. THE CALL SITES. Every script that brings the `agents` service up must
+#      first stamp it (scripts/lib/agents-fixture-version.sh). Checks 2-4 pin
+#      the container half and check 1 pins the workflow half, but the coupling
+#      has a third leg: a script can satisfy both and still hand the fixture
+#      nothing, in which case it falls back to the baked `0.0.0-dev` and the
+#      app it installs sees a version mismatch. That is exactly how
+#      scripts/pre-release-confidence-gate.sh and scripts/phone-walkthrough.sh
+#      shipped broken in round 1 of #2381 — enforced by convention, not by a
+#      gate. Enforcing it only by convention is what produced this whole issue.
+#      Covers scripts/ AND .github/workflows/ (a workflow may bring the fixture
+#      up inline), and --self-test additionally pins the stamping helper's own
+#      precedence, since "you must call it" is worthless if the call returns the
+#      wrong version.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+
+EMULATOR_ACTION="reactivecircus/android-emulator-runner"
+FIXTURE_VERSION_VAR="POCKETSHELL_AGENT_FIXTURE_VERSION"
+
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  failures=$((failures + 1))
+}
+
+# Emit "<workflow>\t<job>\t<uses-emulator:0|1>\t<fetch-depth-0:0|1>" per job.
+emulator_job_rows() {
+  local workflow_dir="$1"
+  ruby - "$workflow_dir" "$EMULATOR_ACTION" <<'RUBY'
+require "yaml"
+
+dir, action = ARGV
+Dir.glob(File.join(dir, "*.yml")).sort.each do |path|
+  begin
+    doc = YAML.safe_load_file(path, aliases: true)
+  rescue Psych::Exception => e
+    warn "FAIL: #{path} is not valid YAML: #{e.message.lines.first.to_s.strip}"
+    exit 3
+  end
+  next unless doc.is_a?(Hash)
+  jobs = doc["jobs"]
+  next unless jobs.is_a?(Hash)
+
+  jobs.each do |job_name, job|
+    next unless job.is_a?(Hash)
+    steps = job["steps"]
+    next unless steps.is_a?(Array)
+
+    uses_emulator = steps.any? do |s|
+      s.is_a?(Hash) && s["uses"].to_s.start_with?(action)
+    end
+    # A job may legitimately have several checkouts; require that EVERY
+    # actions/checkout in an emulator job asks for full history, because any
+    # one of them can be the tree the APK is built from.
+    checkouts = steps.select do |s|
+      s.is_a?(Hash) && s["uses"].to_s.start_with?("actions/checkout")
+    end
+    full_history = !checkouts.empty? && checkouts.all? do |s|
+      with = s["with"]
+      with.is_a?(Hash) && with["fetch-depth"].to_s == "0"
+    end
+
+    printf("%s\t%s\t%d\t%d\n", File.basename(path), job_name,
+           uses_emulator ? 1 : 0, full_history ? 1 : 0)
+  end
+end
+RUBY
+}
+
+check_emulator_jobs() {
+  local workflow_dir="$1"
+  local rows seen=0
+  rows="$(emulator_job_rows "$workflow_dir")" || {
+    fail "could not parse the workflows under $workflow_dir"
+    return
+  }
+
+  while IFS=$'\t' read -r workflow job uses_emulator full_history; do
+    [[ -n "${workflow:-}" ]] || continue
+    [[ "$uses_emulator" == "1" ]] || continue
+    seen=$((seen + 1))
+    if [[ "$full_history" != "1" ]]; then
+      fail "$workflow job '$job' boots an emulator but does not check out with fetch-depth: 0 —" \
+        "its APK would report the 0.0.0-dev placeholder versionName (#2381)"
+    else
+      printf '  ok: %s job %s checks out full tag history\n' "$workflow" "$job"
+    fi
+  done <<< "$rows"
+
+  if [[ "$seen" -eq 0 ]]; then
+    fail "found no $EMULATOR_ACTION job under $workflow_dir — this guard would pass vacuously"
+  fi
+}
+
+check_fixture_version_wiring() {
+  local root="$1"
+  local compose="$root/tests/docker/docker-compose.yml"
+  local entrypoint="$root/tests/docker/agent-entrypoint.sh"
+  local dockerfile="$root/tests/docker/Dockerfile.agents"
+
+  if grep -q "$FIXTURE_VERSION_VAR" "$compose" 2>/dev/null; then
+    printf '  ok: docker-compose.yml forwards %s to the agents fixture\n' "$FIXTURE_VERSION_VAR"
+  else
+    fail "tests/docker/docker-compose.yml must forward $FIXTURE_VERSION_VAR into the agents service (#2381)"
+  fi
+
+  if grep -q "$FIXTURE_VERSION_VAR" "$entrypoint" 2>/dev/null; then
+    printf '  ok: agent-entrypoint.sh stamps %s into the fixture version file\n' "$FIXTURE_VERSION_VAR"
+  else
+    fail "tests/docker/agent-entrypoint.sh must stamp $FIXTURE_VERSION_VAR into the version file (#2381)"
+  fi
+
+  # Comments explaining the removal are fine; an INSTRUCTION referencing it is
+  # the dead derivation coming back.
+  if grep -v '^[[:space:]]*#' "$dockerfile" 2>/dev/null | grep -q 'build\.gradle\.kts'; then
+    fail "tests/docker/Dockerfile.agents still references app/build.gradle.kts — the pre-#2356" \
+      "versionName literal it parsed no longer exists, so that derivation is dead (#2381, D22)"
+  else
+    printf '  ok: Dockerfile.agents no longer parses the removed build.gradle.kts literal\n'
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Check 5 — call sites.
+# --------------------------------------------------------------------------
+
+# Files under scripts/ that CONTAIN a matching line but never RUN it: the
+# command text is quoted data (a synthetic fixture script, a grep pattern, this
+# guard's own docs/self-test). Anything else that brings `agents` up is a real
+# caller and must stamp the fixture.
+AGENTS_UP_TEXT_ONLY_ALLOWLIST=(
+  # Asserts the text of the CI journey fixture-retry wrapper; the compose line
+  # lives inside a quoted expectation string, not an invocation.
+  "test-ci-journey-fixture-health.sh"
+  # This guard: the pattern appears in the header docs and in the self-test.
+  "check-emulator-apk-version-wiring.sh"
+)
+
+# Echo the 1-based line number of the first line that actually brings the
+# `agents` service up via `docker compose ... up ...`, or nothing.
+first_agents_up_line() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    {
+      idx = index($0, "docker compose")
+      if (idx == 0) next
+      rest = substr($0, idx)
+      p = index(rest, " up ")
+      if (p == 0) next
+      svc = substr(rest, p + 4)
+      # The service list must actually name `agents` (or the AGENT_SERVICE
+      # variable that defaults to it). `packet-loss-proxy`, `sshd`, the
+      # bootstrap-* profiles and a bare `up` with no service do not count.
+      if (svc ~ /(^|[^A-Za-z0-9_])agents([^A-Za-z0-9_]|$)/ || svc ~ /AGENT_SERVICE/) {
+        print NR
+        exit
+      }
+    }
+  ' "$1"
+}
+
+# Echo the 1-based line number of the first non-comment CALL to the stamping
+# helper, or nothing.
+#
+# "Call", not "mention" (round-3 review finding): scripts/lib/agents-pool.sh
+# opens with `if ! declare -F export_agents_fixture_version >/dev/null; then`,
+# which names the helper without invoking it — the detector credited that line
+# and would therefore have accepted a file that only ever *mentions* the name.
+# `declare -F` / `command -v` / `type` are introspection, not invocation.
+first_fixture_version_call_line() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    /(declare[[:space:]]+-[a-zA-Z]*F|command[[:space:]]+-v|[^A-Za-z0-9_]type[[:space:]])/ { next }
+    /export_agents_fixture_version/ { print NR; exit }
+  ' "$1"
+}
+
+check_agents_up_call_sites() {
+  local scripts_dir="$1"
+  local file base up_line stamp_line
+  local callers=0 allowlisted=0
+
+  while IFS= read -r file; do
+    up_line="$(first_agents_up_line "$file")"
+    [[ -n "$up_line" ]] || continue
+    base="$(basename "$file")"
+
+    local skip=0 entry
+    for entry in "${AGENTS_UP_TEXT_ONLY_ALLOWLIST[@]}"; do
+      if [[ "$base" == "$entry" ]]; then
+        skip=1
+        break
+      fi
+    done
+    if [[ "$skip" == "1" ]]; then
+      allowlisted=$((allowlisted + 1))
+      printf '  ok: %s is on the text-only allowlist (quotes the command, never runs it)\n' "$base"
+      continue
+    fi
+
+    callers=$((callers + 1))
+    stamp_line="$(first_fixture_version_call_line "$file")"
+    if [[ -z "$stamp_line" ]]; then
+      fail "$base brings the agents fixture up (line $up_line) but never calls" \
+        "export_agents_fixture_version — the fixture falls back to its baked 0.0.0-dev while the" \
+        "APK reports a derived versionName, so the app lands on the bootstrap \"Host setup needed\"" \
+        "sheet (#2381). Source scripts/lib/agents-fixture-version.sh and stamp it before the" \
+        "compose up, or add the file to AGENTS_UP_TEXT_ONLY_ALLOWLIST with a reason."
+    elif [[ "$stamp_line" -gt "$up_line" ]]; then
+      fail "$base calls export_agents_fixture_version at line $stamp_line, AFTER it brings the" \
+        "agents fixture up at line $up_line — compose reads the environment at \`up\` time, so the" \
+        "stamp never reaches that container (#2381)"
+    else
+      printf '  ok: %s stamps the agents fixture (line %s) before bringing it up (line %s)\n' \
+        "$base" "$stamp_line" "$up_line"
+    fi
+  done < <(find "$scripts_dir" -type f -name '*.sh' | sort)
+
+  if [[ "$callers" -eq 0 ]]; then
+    fail "found no script under $scripts_dir that brings the agents fixture up —" \
+      "the call-site detector matched nothing, so this check would pass vacuously"
+  fi
+  printf '  ok: %d agents-fixture caller(s) checked, %d text-only allowlisted\n' \
+    "$callers" "$allowlisted"
+}
+
+# Same rule, workflow layer: a CI job can bring `agents` up with an inline
+# `docker compose ... up`, which check 5 (scripts/ only) would never see. Such a
+# line is fine when it is wrapped by scripts/ci-journey-fixture-retry.sh (which
+# stamps), or when the workflow stamps earlier in the same file.
+check_workflow_agents_up_call_sites() {
+  local workflow_dir="$1"
+  local file base up_line stamp_line seen=0
+
+  while IFS= read -r file; do
+    up_line="$(first_agents_up_line "$file")"
+    [[ -n "$up_line" ]] || continue
+    base="$(basename "$file")"
+    seen=$((seen + 1))
+
+    if sed -n "${up_line}p" "$file" | grep -q 'ci-journey-fixture-retry\.sh'; then
+      printf '  ok: %s brings agents up through ci-journey-fixture-retry.sh (line %s)\n' "$base" "$up_line"
+      continue
+    fi
+
+    stamp_line="$(first_fixture_version_call_line "$file")"
+    if [[ -z "$stamp_line" || "$stamp_line" -gt "$up_line" ]]; then
+      fail "$base brings the agents fixture up at line $up_line without stamping it first —" \
+        "wrap it in scripts/ci-journey-fixture-retry.sh or source" \
+        "scripts/lib/agents-fixture-version.sh and call export_agents_fixture_version above it (#2381)"
+    else
+      printf '  ok: %s stamps the agents fixture (line %s) before bringing it up (line %s)\n' \
+        "$base" "$stamp_line" "$up_line"
+    fi
+  done < <(find "$workflow_dir" -maxdepth 1 -type f -name '*.yml' | sort)
+
+  if [[ "$seen" -eq 0 ]]; then
+    fail "found no workflow under $workflow_dir that brings the agents fixture up —" \
+      "the workflow call-site detector matched nothing, so this check would pass vacuously"
+  fi
+}
+
+# The two release/visual-audit entry points #2381 round 1 left unstamped. If a
+# rename or refactor takes them out of the detector's reach, say so loudly
+# rather than reporting a green over an unchecked path.
+check_named_release_call_sites() {
+  local scripts_dir="$1"
+  local required=(
+    "pre-release-confidence-gate.sh"
+    "phone-walkthrough.sh"
+  )
+  local name
+  for name in "${required[@]}"; do
+    if [[ ! -f "$scripts_dir/$name" ]]; then
+      fail "scripts/$name is gone — check 5's coverage of the documented standalone release" \
+        "gate / visual-audit path can no longer be asserted (#2381)"
+      continue
+    fi
+    if [[ -z "$(first_agents_up_line "$scripts_dir/$name")" ]]; then
+      fail "scripts/$name no longer matches the agents-fixture call-site detector; either it" \
+        "stopped bringing the fixture up, or the detector went blind to it (#2381)"
+    else
+      printf '  ok: %s is inside check 5'"'"'s coverage\n' "$name"
+    fi
+  done
+}
+
+run_self_test() {
+  local sandbox
+  sandbox="$(mktemp -d)"
+  trap 'rm -rf "$sandbox"' RETURN
+
+  mkdir -p "$sandbox/wf"
+  cat > "$sandbox/wf/bad.yml" <<'YAML'
+name: Bad
+on: { push: {} }
+jobs:
+  journey:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: reactivecircus/android-emulator-runner@v2
+        with: { api-level: 35 }
+YAML
+
+  local out rc
+  set +e
+  out="$(check_emulator_jobs "$sandbox/wf" 2>&1; printf 'failures=%s' "$failures")"
+  set -e
+  if [[ "$out" != *"does not check out with fetch-depth: 0"* ]]; then
+    printf 'SELF-TEST FAILED: a shallow emulator job was not rejected.\n%s\n' "$out" >&2
+    return 1
+  fi
+  printf '  ok: self-test red — shallow emulator job rejected\n'
+
+  failures=0
+  cat > "$sandbox/wf/bad.yml" <<'YAML'
+name: Good
+on: { push: {} }
+jobs:
+  journey:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: reactivecircus/android-emulator-runner@v2
+        with: { api-level: 35 }
+YAML
+  check_emulator_jobs "$sandbox/wf"
+  rc="$failures"
+  if [[ "$rc" -ne 0 ]]; then
+    printf 'SELF-TEST FAILED: a full-history emulator job was rejected.\n' >&2
+    return 1
+  fi
+  printf '  ok: self-test green — full-history emulator job accepted\n'
+
+  # A workflow set with no emulator job must NOT pass vacuously.
+  failures=0
+  rm -f "$sandbox/wf/bad.yml"
+  cat > "$sandbox/wf/none.yml" <<'YAML'
+name: None
+on: { push: {} }
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+YAML
+  check_emulator_jobs "$sandbox/wf" >/dev/null 2>&1 || true
+  if [[ "$failures" -eq 0 ]]; then
+    printf 'SELF-TEST FAILED: an emulator-job-free workflow set passed vacuously.\n' >&2
+    return 1
+  fi
+  printf '  ok: self-test — a workflow set with no emulator job is rejected, not vacuously green\n'
+
+  # ---- check 5: agents-fixture call sites ----
+  mkdir -p "$sandbox/scripts"
+
+  # RED: a caller that brings the fixture up without stamping it. This is
+  # byte-for-byte the shape scripts/pre-release-confidence-gate.sh and
+  # scripts/phone-walkthrough.sh had at #2381 round 1.
+  failures=0
+  cat > "$sandbox/scripts/broken-gate.sh" <<'SH'
+#!/usr/bin/env bash
+run_step "docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
+SH
+  # NOT a command substitution: that runs in a subshell, so $failures would
+  # never come back and this self-test case could only ever check the message.
+  check_agents_up_call_sites "$sandbox/scripts" > "$sandbox/out.txt" 2>&1 || true
+  out="$(cat "$sandbox/out.txt")"
+  if [[ "$out" != *"never calls"* || "$failures" -eq 0 ]]; then
+    printf 'SELF-TEST FAILED: an unstamped agents call site was not rejected.\n%s\n' "$out" >&2
+    return 1
+  fi
+  printf '  ok: self-test red — an unstamped agents call site is rejected\n'
+
+  # GREEN: the same caller with the stamp before the bring-up.
+  failures=0
+  cat > "$sandbox/scripts/broken-gate.sh" <<'SH'
+#!/usr/bin/env bash
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
+run_step "docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
+SH
+  check_agents_up_call_sites "$sandbox/scripts" >/dev/null 2>&1 || true
+  if [[ "$failures" -ne 0 ]]; then
+    printf 'SELF-TEST FAILED: a correctly stamped agents call site was rejected.\n' >&2
+    return 1
+  fi
+  printf '  ok: self-test green — a stamped agents call site is accepted\n'
+
+  # RED: stamped, but AFTER the bring-up (compose reads the env at `up` time).
+  failures=0
+  cat > "$sandbox/scripts/broken-gate.sh" <<'SH'
+#!/usr/bin/env bash
+run_step "docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version
+SH
+  check_agents_up_call_sites "$sandbox/scripts" > "$sandbox/out.txt" 2>&1 || true
+  out="$(cat "$sandbox/out.txt")"
+  if [[ "$out" != *"AFTER it brings the"* || "$failures" -eq 0 ]]; then
+    printf 'SELF-TEST FAILED: a too-late stamp was not rejected.\n%s\n' "$out" >&2
+    return 1
+  fi
+  printf '  ok: self-test red — stamping after the compose up is rejected\n'
+
+  # RED (round-3 review finding): the helper name appears only inside a
+  # `declare -F` / `command -v` introspection guard. That is a MENTION, not a
+  # call — the fixture is never stamped — and the detector must not credit it.
+  # scripts/lib/agents-pool.sh opens with exactly this line, so before the fix
+  # it was credited at its `declare -F` line instead of its real call.
+  failures=0
+  cat > "$sandbox/scripts/broken-gate.sh" <<'SH'
+#!/usr/bin/env bash
+if ! declare -F export_agents_fixture_version >/dev/null 2>&1; then
+  source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+fi
+command -v export_agents_fixture_version >/dev/null || true
+docker compose -f "$COMPOSE_FILE" up -d --build agents
+SH
+  check_agents_up_call_sites "$sandbox/scripts" > "$sandbox/out.txt" 2>&1 || true
+  out="$(cat "$sandbox/out.txt")"
+  if [[ "$out" != *"never calls"* || "$failures" -eq 0 ]]; then
+    printf 'SELF-TEST FAILED: a declare -F/command -v MENTION of the stamping helper was credited as a call.\n%s\n' "$out" >&2
+    return 1
+  fi
+  printf '  ok: self-test red — a declare -F/command -v mention is not credited as a stamp\n'
+
+  # GREEN: the same introspection guard, now with the real call after it. The
+  # accepted stamp line must be the CALL, not the `declare -F` line.
+  failures=0
+  cat > "$sandbox/scripts/broken-gate.sh" <<'SH'
+#!/usr/bin/env bash
+if ! declare -F export_agents_fixture_version >/dev/null 2>&1; then
+  source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+fi
+export_agents_fixture_version "$APP_APK"
+docker compose -f "$COMPOSE_FILE" up -d --build agents
+SH
+  check_agents_up_call_sites "$sandbox/scripts" > "$sandbox/out.txt" 2>&1 || true
+  out="$(cat "$sandbox/out.txt")"
+  if [[ "$failures" -ne 0 ]]; then
+    printf 'SELF-TEST FAILED: an introspection guard followed by a real call was rejected.\n%s\n' "$out" >&2
+    return 1
+  fi
+  if [[ "$out" != *"(line 5)"* ]]; then
+    printf 'SELF-TEST FAILED: the credited stamp line is not the real call at line 5.\n%s\n' "$out" >&2
+    return 1
+  fi
+  printf '  ok: self-test green — the credited stamp line is the real call, not the introspection guard\n'
+
+  # Not a caller: a service list that does not name `agents`.
+  failures=0
+  cat > "$sandbox/scripts/broken-gate.sh" <<'SH'
+#!/usr/bin/env bash
+docker compose -f "$COMPOSE_FILE" up -d --build --no-deps packet-loss-proxy
+SH
+  check_agents_up_call_sites "$sandbox/scripts" >/dev/null 2>&1 || true
+  if [[ "$failures" -eq 0 ]]; then
+    printf 'SELF-TEST FAILED: a scripts dir with no agents caller passed vacuously.\n' >&2
+    return 1
+  fi
+  printf '  ok: self-test — a scripts dir with no agents caller is rejected, not vacuously green\n'
+
+  # ---- check 5, workflow layer ----
+  failures=0
+  rm -f "$sandbox/wf"/*.yml
+  cat > "$sandbox/wf/journey.yml" <<'YAML'
+name: Journey
+on: { push: {} }
+jobs:
+  journey:
+    steps:
+      - run: docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents
+YAML
+  check_workflow_agents_up_call_sites "$sandbox/wf" > "$sandbox/out.txt" 2>&1 || true
+  out="$(cat "$sandbox/out.txt")"
+  if [[ "$out" != *"without stamping it first"* || "$failures" -eq 0 ]]; then
+    printf 'SELF-TEST FAILED: an unstamped workflow agents call site was not rejected.\n%s\n' "$out" >&2
+    return 1
+  fi
+  printf '  ok: self-test red — an unstamped workflow agents call site is rejected\n'
+
+  failures=0
+  cat > "$sandbox/wf/journey.yml" <<'YAML'
+name: Journey
+on: { push: {} }
+jobs:
+  journey:
+    steps:
+      - run: scripts/ci-journey-fixture-retry.sh agents -- docker compose -f tests/docker/docker-compose.yml up -d --build --no-deps agents
+YAML
+  check_workflow_agents_up_call_sites "$sandbox/wf" >/dev/null 2>&1 || true
+  if [[ "$failures" -ne 0 ]]; then
+    printf 'SELF-TEST FAILED: the ci-journey-fixture-retry.sh wrapper was rejected.\n' >&2
+    return 1
+  fi
+  printf '  ok: self-test green — the ci-journey-fixture-retry.sh wrapper is accepted\n'
+
+  failures=0
+  rm -f "$sandbox/wf"/*.yml
+  cat > "$sandbox/wf/none.yml" <<'YAML'
+name: None
+on: { push: {} }
+jobs:
+  unit:
+    steps:
+      - run: echo hi
+YAML
+  check_workflow_agents_up_call_sites "$sandbox/wf" >/dev/null 2>&1 || true
+  if [[ "$failures" -eq 0 ]]; then
+    printf 'SELF-TEST FAILED: a workflow set with no agents caller passed vacuously.\n' >&2
+    return 1
+  fi
+  printf '  ok: self-test — a workflow set with no agents caller is rejected, not vacuously green\n'
+
+  run_helper_self_test "$sandbox" || return 1
+
+  failures=0
+  printf 'SELF-TEST OK\n'
+  return 0
+}
+
+# The stamping helper's PRECEDENCE, which is the whole reason check 5 can trust
+# a call site that merely calls it. Requiring the call and then getting the
+# wrong version back would be the same silent breakage one level down.
+#
+# No emulator, no Docker, no real APK: `aapt2` is stubbed on PATH, so this
+# exercises the resolve -> badging -> parse -> export chain that reads a
+# release-chain APK, not a mock of it.
+run_helper_self_test() {
+  local sandbox="$1"
+  local lib="$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+
+  [[ -f "$lib" ]] || {
+    printf 'SELF-TEST FAILED: missing %s\n' "$lib" >&2
+    return 1
+  }
+
+  mkdir -p "$sandbox/bin"
+  cat > "$sandbox/bin/aapt2" <<'SH'
+#!/usr/bin/env bash
+# Minimal `aapt2 dump badging` stand-in: prints the badging line shape the
+# helper parses, with the versionName recorded next to the "APK".
+printf "package: name='com.pocketshell.app' versionCode='46' versionName='%s' compileSdkVersion='36'\n" \
+  "$(cat "${3:-/dev/null}" 2>/dev/null)"
+printf "sdkVersion:'26'\n"
+SH
+  chmod +x "$sandbox/bin/aapt2"
+  printf '9.9.9-apk\n' > "$sandbox/app-debug.apk"
+
+  local got
+
+  # 1. An APK wins over an already-set variable: the installed binary is the
+  #    only ground truth, and the release chain sets the variable from a
+  #    DIFFERENT checkout than the one that built the APK (#2064).
+  got="$(
+    PATH="$sandbox/bin:$PATH" \
+    POCKETSHELL_AGENT_FIXTURE_VERSION="0.4.45-4-gDEADBEEF" \
+    bash -c "source '$lib'; export_agents_fixture_version '$sandbox/app-debug.apk'; printf '%s' \"\$POCKETSHELL_AGENT_FIXTURE_VERSION\""
+  )"
+  if [[ "$got" != "9.9.9-apk" ]]; then
+    printf 'SELF-TEST FAILED: an APK argument did not override a preset stamp (got %q, want 9.9.9-apk).\n' "$got" >&2
+    return 1
+  fi
+  printf '  ok: self-test — the installed APK'"'"'s versionName wins over a preset stamp\n'
+
+  # 2. No APK: an explicit caller pin survives (the pre-release gate pins the
+  #    exact string it then asserts).
+  got="$(
+    PATH="$sandbox/bin:$PATH" \
+    POCKETSHELL_AGENT_FIXTURE_VERSION="0.4.45-4-gDEADBEEF" \
+    bash -c "source '$lib'; export_agents_fixture_version; printf '%s' \"\$POCKETSHELL_AGENT_FIXTURE_VERSION\""
+  )"
+  if [[ "$got" != "0.4.45-4-gDEADBEEF" ]]; then
+    printf 'SELF-TEST FAILED: an explicit caller pin was not honoured (got %q).\n' "$got" >&2
+    return 1
+  fi
+  printf '  ok: self-test — an explicit caller pin survives when no APK is given\n'
+
+  # 3. Nothing set, no APK: fall back to THIS checkout's derivation, and it must
+  #    equal scripts/derive-version.sh — not a second, drifting implementation.
+  local derived
+  derived="$(bash "$ROOT_DIR/scripts/derive-version.sh" version-name 2>/dev/null || true)"
+  got="$(
+    env -u POCKETSHELL_AGENT_FIXTURE_VERSION PATH="$sandbox/bin:$PATH" \
+    bash -c "source '$lib'; export_agents_fixture_version; printf '%s' \"\$POCKETSHELL_AGENT_FIXTURE_VERSION\""
+  )"
+  if [[ -z "$derived" || "$got" != "$derived" ]]; then
+    printf 'SELF-TEST FAILED: the no-APK fallback (%q) is not scripts/derive-version.sh'"'"'s answer (%q).\n' \
+      "$got" "$derived" >&2
+    return 1
+  fi
+  printf '  ok: self-test — the fallback is scripts/derive-version.sh, not a second derivation\n'
+
+  # 4. A named-but-absent APK (a standalone run stamps before it builds) must
+  #    fall back silently rather than fail or emit an empty stamp.
+  got="$(
+    env -u POCKETSHELL_AGENT_FIXTURE_VERSION PATH="$sandbox/bin:$PATH" \
+    bash -c "source '$lib'; export_agents_fixture_version '$sandbox/not-built-yet.apk'; printf '%s' \"\$POCKETSHELL_AGENT_FIXTURE_VERSION\"" 2>/dev/null
+  )"
+  if [[ "$got" != "$derived" ]]; then
+    printf 'SELF-TEST FAILED: a not-yet-built APK path did not fall back to the derivation (got %q).\n' "$got" >&2
+    return 1
+  fi
+  printf '  ok: self-test — a not-yet-built APK path falls back to the derivation\n'
+
+  # 5. The BUILD_APKS-shaped wrapper routes both ways: "1" (rebuild from this
+  #    checkout) must NOT read the stale APK, anything else must read it.
+  got="$(
+    env -u POCKETSHELL_AGENT_FIXTURE_VERSION PATH="$sandbox/bin:$PATH" \
+    bash -c "source '$lib'; export_agents_fixture_version_for_run 1 '$sandbox/app-debug.apk' 2>/dev/null; printf '%s' \"\$POCKETSHELL_AGENT_FIXTURE_VERSION\""
+  )"
+  if [[ "$got" != "$derived" ]]; then
+    printf 'SELF-TEST FAILED: BUILD_APKS=1 read the about-to-be-replaced APK (got %q, want %q).\n' \
+      "$got" "$derived" >&2
+    return 1
+  fi
+  got="$(
+    env -u POCKETSHELL_AGENT_FIXTURE_VERSION PATH="$sandbox/bin:$PATH" \
+    bash -c "source '$lib'; export_agents_fixture_version_for_run 0 '$sandbox/app-debug.apk' 2>/dev/null; printf '%s' \"\$POCKETSHELL_AGENT_FIXTURE_VERSION\""
+  )"
+  if [[ "$got" != "9.9.9-apk" ]]; then
+    printf 'SELF-TEST FAILED: BUILD_APKS=0 did not read the installed APK (got %q, want 9.9.9-apk).\n' "$got" >&2
+    return 1
+  fi
+  printf '  ok: self-test — the BUILD_APKS wrapper derives when rebuilding and reads the APK otherwise\n'
+
+  return 0
+}
+
+main() {
+  command -v ruby >/dev/null 2>&1 || {
+    printf 'FAIL: ruby is required to parse GitHub Actions YAML\n' >&2
+    exit 1
+  }
+
+  if [[ "${1:-}" == "--self-test" ]]; then
+    run_self_test
+    exit $?
+  fi
+
+  check_emulator_jobs "$ROOT_DIR/.github/workflows"
+  check_fixture_version_wiring "$ROOT_DIR"
+  check_agents_up_call_sites "$ROOT_DIR/scripts"
+  check_workflow_agents_up_call_sites "$ROOT_DIR/.github/workflows"
+  check_named_release_call_sites "$ROOT_DIR/scripts"
+
+  if [[ "$failures" -ne 0 ]]; then
+    printf 'check-emulator-apk-version-wiring: FAIL — %d problem(s).\n' "$failures" >&2
+    exit 1
+  fi
+  printf 'check-emulator-apk-version-wiring: OK\n'
+}
+
+main "$@"

--- a/scripts/check-version-coupling.sh
+++ b/scripts/check-version-coupling.sh
@@ -215,6 +215,29 @@ run_self_test() {
   return 0
 }
 
+# Issue #2381: emulator-APK version wiring (see the delegated script's header
+# for the full failure story). Self-test first so a broken guard cannot pass
+# silently, then the real tree.
+check_emulator_apk_version_wiring() {
+  local root="$1"
+  local script="$root/scripts/check-emulator-apk-version-wiring.sh"
+
+  if [[ ! -f "$script" ]]; then
+    printf 'FAIL: missing %s (issue #2381)\n' "$script" >&2
+    return 1
+  fi
+
+  if ! bash "$script" --self-test; then
+    printf 'FAIL: check-emulator-apk-version-wiring.sh --self-test did not pass\n' >&2
+    return 1
+  fi
+
+  if ! bash "$script"; then
+    return 1
+  fi
+  return 0
+}
+
 main() {
   local skip_gradle=0
   case "${1:-}" in
@@ -250,6 +273,14 @@ main() {
 
   check_single_source_reference \
     "$ROOT_DIR/$GRADLE_REL" "$ROOT_DIR/$BUILD_WORKFLOW_REL" || ok=0
+
+  # Issue #2381: step 4 — the derived version is load-bearing PRODUCT input
+  # (the app expects the host `pocketshell` CLI to be on its own versionName's
+  # release core), so a CI job that builds an APK for an emulator must have
+  # the tag history to derive a real version, and the Docker `agents` fixture
+  # must be stamped with the same one. Delegated to a dedicated script so the
+  # rule can also be run on its own.
+  check_emulator_apk_version_wiring "$ROOT_DIR" || ok=0
 
   if [[ "$ok" -ne 1 ]]; then
     printf 'FAIL: version-coupling guard failed one or more checks above.\n' >&2

--- a/scripts/ci-journey-fixture-retry.sh
+++ b/scripts/ci-journey-fixture-retry.sh
@@ -149,6 +149,15 @@ shift
 shift
 (( $# > 0 )) || usage
 
+# Issue #2381: every fixture this wrapper starts is started for a run that then
+# installs the app, so the `agents` fixture's reported `pocketshell --version`
+# must track the APK built from this same checkout. Exporting here covers both
+# CI callers (tests.yml's emulator-journey and pr-journey-smoke.yml) at one
+# point; only the `agents` service reads the variable.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/lib/agents-fixture-version.sh"
+export_agents_fixture_version
+
 artifact_root="${CI_JOURNEY_SETUP_ARTIFACT_ROOT:-$DEFAULT_ARTIFACT_ROOT}"
 fixture_dir="$artifact_root/$fixture"
 retry_delay_seconds="${CI_JOURNEY_FIXTURE_RETRY_DELAY_SECONDS:-5}"

--- a/scripts/derive-version.sh
+++ b/scripts/derive-version.sh
@@ -59,16 +59,39 @@
 #     reachable at all, or the bare placeholder `0.0.0-dev` when git itself is
 #     unavailable/not a repo.
 #
+#   * A DETACHED COPY of a checkout (issue #2381) carries the version of the
+#     checkout it was copied from, via a PIN FILE, not a second derivation.
+#     scripts/pre-release-confidence-gate.sh rsyncs the release checkout to
+#     `<checkout>/build/pre-release-confidence-gate/<run>/worktree` with
+#     `--exclude='.git'` and re-execs there; every APK the release chain then
+#     validates, journeys against and publishes is built INSIDE that copy. With
+#     no git of its own the copy derived the `0.0.0-dev`/versionCode=1
+#     placeholder, so the whole release gate — nightly validated-RC included —
+#     validated a binary that could not express a release version at all
+#     (HostBootstrapScenarioSuiteTest's setup-detection scenarios compare the
+#     app's version against the host CLI's, and every one of them is vacuous at
+#     `0.0.0`). `write-pin` closes that: the SOURCE checkout, which does have
+#     tag history, derives once and stamps the answer into the copy, and the
+#     pin is consulted AHEAD of the git derivation (not as a fallback behind
+#     it — D22 hard cut). Invariant: a pinned copy derives EXACTLY what the
+#     checkout it was copied from derives.
+#
 # USAGE
 #   derive-version.sh version-code [--ref REF]
 #   derive-version.sh version-name [--ref REF]
 #   derive-version.sh both [--ref REF]     (default; prints both, KEY=VALUE)
+#   derive-version.sh write-pin TARGET_DIR [--ref REF]
 #   derive-version.sh --self-test
 #
 # --ref defaults to HEAD. Passing an explicit ref lets a caller derive the
 # version for a commit/tag other than the current checkout (e.g. a throwaway
 # worktree, or scripts/push-release-tag.sh deriving against a not-yet-pushed
 # local tag it just created).
+#
+# write-pin derives against THIS script's own checkout and writes
+# `TARGET_DIR/.pocketshell-version-pin` (the same `KEY=VALUE` shape `both`
+# prints). Any later `version-code`/`version-name`/`both` run whose repo root
+# is TARGET_DIR answers from that file instead of asking git.
 #
 # Self-test: run this script with --self-test (builds synthetic git repos
 # under mktemp, never touches this repo's own tags).
@@ -83,7 +106,45 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly VERSION_CODE_OFFSET=1
 
 usage() {
-  sed -n '2,58p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  # Ends at the last line of the header comment block; keep in sync when the
+  # block grows (the pre-#2381 range stopped one section short of USAGE).
+  sed -n '2,97p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Issue #2381: the pin file a detached copy carries instead of git history.
+# Deliberately a repo-root dotfile and NOT under `build/`: the gate's copy runs
+# `clean`/`--rerun-tasks` builds, and a version that can be wiped mid-gate is
+# exactly the silent-placeholder failure this closes.
+readonly VERSION_PIN_FILE_NAME=".pocketshell-version-pin"
+
+# Echoes "<code> <name>" from $1/.pocketshell-version-pin when that file exists
+# AND parses; echoes nothing otherwise. A malformed pin is reported on stderr
+# and ignored rather than fataled: derive-version.sh's top design constraint is
+# that it never fails a build, and Gradle's derivePocketshellVersion() swallows
+# a non-zero exit into the same placeholder anyway, so exiting here would only
+# make the failure quieter. The loud half lives downstream, where it can name
+# the consequence — HostBootstrapScenarioSuiteTest.assertApkCarriesARealRelease
+# Version() and release-emulator-validation.sh's preflight both hard-fail on a
+# `0.0.0` core.
+read_version_pin() {
+  local repo="$1"
+  local pin_file="$repo/$VERSION_PIN_FILE_NAME"
+  [[ -f "$pin_file" ]] || return 1
+
+  local code="" name="" line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      VERSION_CODE=*) code="${line#VERSION_CODE=}" ;;
+      VERSION_NAME=*) name="${line#VERSION_NAME=}" ;;
+    esac
+  done < "$pin_file"
+
+  if [[ ! "$code" =~ ^[1-9][0-9]*$ || -z "$name" ]]; then
+    printf 'derive-version.sh: ignoring malformed version pin at %s (VERSION_CODE=%s VERSION_NAME=%s)\n' \
+      "$pin_file" "${code:-<missing>}" "${name:-<missing>}" >&2
+    return 1
+  fi
+  printf '%s %s\n' "$code" "$name"
 }
 
 # True when $1 is a checkout that carries its OWN git, and git can read it.
@@ -117,6 +178,11 @@ git_tree_usable() {
 # the OFFSET floor (1) when git/tags are unavailable.
 derive_version_code() {
   local repo="$1" ref="$2"
+  local pin
+  if pin="$(read_version_pin "$repo")"; then
+    printf '%s\n' "${pin%% *}"
+    return
+  fi
   if ! command -v git >/dev/null 2>&1; then
     echo "$VERSION_CODE_OFFSET"
     return
@@ -135,6 +201,11 @@ derive_version_code() {
 # HEAD) inside the repo at $1 (default ROOT_DIR). Never fails.
 derive_version_name() {
   local repo="$1" ref="$2"
+  local pin
+  if pin="$(read_version_pin "$repo")"; then
+    printf '%s\n' "${pin#* }"
+    return
+  fi
   if ! command -v git >/dev/null 2>&1; then
     echo "0.0.0-dev"
     return
@@ -165,6 +236,50 @@ derive_version_name() {
   fi
 
   echo "0.0.0-dev"
+}
+
+# Issue #2381: stamp $2 (a detached copy) with the version $1 (the source
+# checkout) derives. Unlike the derivation itself this DOES fail loudly — it is
+# an explicit caller-facing command, not the never-fail build path, and a
+# silently skipped pin is precisely the release-gate placeholder it exists to
+# prevent.
+write_version_pin() {
+  local source_repo="$1" target_dir="$2" ref="$3"
+
+  if [[ ! -d "$target_dir" ]]; then
+    printf 'derive-version.sh write-pin: target directory does not exist: %s\n' "$target_dir" >&2
+    return 1
+  fi
+
+  local source_real target_real
+  source_real="$(cd "$source_repo" && pwd -P)" || return 1
+  target_real="$(cd "$target_dir" && pwd -P)" || return 1
+  if [[ "$source_real" == "$target_real" ]]; then
+    # Pinning a live checkout would freeze its version at whatever it happened
+    # to be, and the next commit/tag would silently keep reporting the old one.
+    printf 'derive-version.sh write-pin: refusing to pin a checkout to itself (%s). The pin is for a DETACHED copy that has no git of its own.\n' \
+      "$target_real" >&2
+    return 1
+  fi
+
+  local code name
+  code="$(derive_version_code "$source_real" "$ref")"
+  name="$(derive_version_name "$source_real" "$ref")"
+  if [[ ! "$code" =~ ^[1-9][0-9]*$ || -z "$name" ]]; then
+    printf 'derive-version.sh write-pin: source %s derived an unusable version (code=%s name=%s)\n' \
+      "$source_real" "${code:-<empty>}" "${name:-<empty>}" >&2
+    return 1
+  fi
+
+  local pin_file="$target_real/$VERSION_PIN_FILE_NAME"
+  {
+    printf '# Generated by scripts/derive-version.sh write-pin (issue #2381).\n'
+    printf '# This tree is a detached copy of %s and has no git history of its\n' "$source_real"
+    printf '# own; without this file it would derive the 0.0.0-dev placeholder.\n'
+    printf 'VERSION_CODE=%s\n' "$code"
+    printf 'VERSION_NAME=%s\n' "$name"
+  } > "$pin_file" || return 1
+  printf '%s\n' "$pin_file"
 }
 
 run_self_test() {
@@ -285,11 +400,104 @@ run_self_test() {
   no_git_name="$(PATH="$empty_path_dir" bash -c "source '${BASH_SOURCE[0]}' 2>/dev/null; derive_version_name '$repo' HEAD" 2>/dev/null || echo "0.0.0-dev")"
   check "no-git PATH versionName fallback" "$no_git_name" "0.0.0-dev"
 
+  # ---- Issue #2381: the detached-copy version pin ------------------------
+  # The gate's `.git`-less rsync copy is where every release-chain APK is
+  # actually built. Red half first, so this block can never pass vacuously.
+  local pinned="$sandbox/gate-copy"
+  mkdir -p "$pinned"
+  check "detached copy WITHOUT a pin is the placeholder (the #2381 bug)" \
+    "$(derive_version_name "$pinned" HEAD)" "0.0.0-dev"
+  check "detached copy WITHOUT a pin floors the versionCode (the #2381 bug)" \
+    "$(derive_version_code "$pinned" HEAD)" "$VERSION_CODE_OFFSET"
+
+  local expected_name expected_code
+  expected_name="$(derive_version_name "$repo" HEAD)"
+  expected_code="$(derive_version_code "$repo" HEAD)"
+  local pin_path
+  pin_path="$(write_version_pin "$repo" "$pinned" HEAD)"
+  check "write-pin reports the file it wrote" \
+    "$pin_path" "$pinned/$VERSION_PIN_FILE_NAME"
+  check "pinned copy derives the SOURCE checkout's versionName" \
+    "$(derive_version_name "$pinned" HEAD)" "$expected_name"
+  check "pinned copy derives the SOURCE checkout's versionCode" \
+    "$(derive_version_code "$pinned" HEAD)" "$expected_code"
+  # Guard against a degenerate green: the source must not itself be the
+  # placeholder, or the two checks above would pass while proving nothing.
+  if [[ "$expected_name" == "0.0.0-dev" || "$expected_code" == "$VERSION_CODE_OFFSET" ]]; then
+    printf '  FAIL: pin cases are vacuous — the self-test source repo derived the placeholder (%s/%s)\n' \
+      "$expected_code" "$expected_name" >&2
+    failures=$((failures + 1))
+  else
+    printf '  ok: pin cases are non-vacuous (source derives %s/%s, not the placeholder)\n' \
+      "$expected_code" "$expected_name"
+  fi
+
+  # The pin is consulted AHEAD of git, not as a fallback behind it (D22 hard
+  # cut). A tree that has BOTH must answer from the pin, otherwise the gate's
+  # copy would silently revert to the parent's history the day git discovery
+  # reaches it again.
+  local pinned_with_git="$sandbox/pinned-with-git"
+  mkdir -p "$pinned_with_git"
+  git -C "$pinned_with_git" init --quiet -b main
+  git -C "$pinned_with_git" config user.email "test@example.com"
+  git -C "$pinned_with_git" config user.name "Self Test"
+  git -C "$pinned_with_git" commit --quiet --allow-empty -m "c1"
+  git -C "$pinned_with_git" tag v9.9.9
+  check "sanity: that tree derives its OWN tag before pinning" \
+    "$(derive_version_name "$pinned_with_git" HEAD)" "9.9.9"
+  printf 'VERSION_CODE=7\nVERSION_NAME=1.2.3\n' > "$pinned_with_git/$VERSION_PIN_FILE_NAME"
+  check "pin wins over a usable git tree (precedence, not fallback)" \
+    "$(derive_version_name "$pinned_with_git" HEAD)" "1.2.3"
+  check "pin wins over a usable git tree (versionCode)" \
+    "$(derive_version_code "$pinned_with_git" HEAD)" "7"
+
+  # A malformed pin must not silently become a wrong version: it is reported
+  # and ignored, and the tree falls back to its documented derivation.
+  local malformed="$sandbox/malformed-pin"
+  mkdir -p "$malformed"
+  printf 'VERSION_NAME=\nVERSION_CODE=not-a-number\n' > "$malformed/$VERSION_PIN_FILE_NAME"
+  local malformed_stderr
+  malformed_stderr="$(derive_version_name "$malformed" HEAD 2>&1 >/dev/null)"
+  check "malformed pin falls back to the placeholder" \
+    "$(derive_version_name "$malformed" HEAD 2>/dev/null)" "0.0.0-dev"
+  if [[ "$malformed_stderr" == *"ignoring malformed version pin"* ]]; then
+    printf '  ok: malformed pin is reported on stderr, not swallowed\n'
+  else
+    printf '  FAIL: malformed pin produced no stderr diagnostic (got: %s)\n' "$malformed_stderr" >&2
+    failures=$((failures + 1))
+  fi
+  # versionCode 0 is not a legal Android versionCode and must be rejected too.
+  printf 'VERSION_CODE=0\nVERSION_NAME=1.2.3\n' > "$malformed/$VERSION_PIN_FILE_NAME"
+  check "pin with versionCode=0 is rejected" \
+    "$(derive_version_code "$malformed" HEAD 2>/dev/null)" "$VERSION_CODE_OFFSET"
+
+  # write-pin refuses to freeze a live checkout at its current version.
+  if write_version_pin "$repo" "$repo" HEAD >/dev/null 2>&1; then
+    printf '  FAIL: write-pin pinned a checkout to itself\n' >&2
+    failures=$((failures + 1))
+    rm -f "$repo/$VERSION_PIN_FILE_NAME"
+  else
+    printf '  ok: write-pin refuses to pin a checkout to itself\n'
+  fi
+  if [[ -e "$repo/$VERSION_PIN_FILE_NAME" ]]; then
+    printf '  FAIL: write-pin left a pin file in the source checkout\n' >&2
+    failures=$((failures + 1))
+    rm -f "$repo/$VERSION_PIN_FILE_NAME"
+  else
+    printf '  ok: the refused self-pin wrote nothing\n'
+  fi
+  if write_version_pin "$repo" "$sandbox/does-not-exist" HEAD >/dev/null 2>&1; then
+    printf '  FAIL: write-pin accepted a non-existent target directory\n' >&2
+    failures=$((failures + 1))
+  else
+    printf '  ok: write-pin rejects a non-existent target directory\n'
+  fi
+
   if [[ "$failures" -ne 0 ]]; then
     printf 'SELF-TEST FAILED: %d case(s) behaved incorrectly.\n' "$failures" >&2
     return 1
   fi
-  printf 'SELF-TEST OK: version-code monotonic across tags, version-name matches convention, both fall back cleanly with no tags / no git.\n'
+  printf 'SELF-TEST OK: version-code monotonic across tags, version-name matches convention, both fall back cleanly with no tags / no git, and a detached copy carries its source checkout'"'"'s version through the pin (#2381).\n'
   return 0
 }
 
@@ -297,8 +505,19 @@ main() {
   local cmd="${1:-both}"
   [[ "$cmd" == "--self-test" ]] && { run_self_test; exit $?; }
   [[ "$cmd" == "-h" || "$cmd" == "--help" ]] && { usage; exit 0; }
+  local pin_target=""
   case "$cmd" in
     version-code|version-name|both) shift || true ;;
+    write-pin)
+      shift || true
+      pin_target="${1:-}"
+      if [[ -z "$pin_target" ]]; then
+        echo "write-pin requires a TARGET_DIR" >&2
+        usage >&2
+        exit 2
+      fi
+      shift
+      ;;
     *) echo "unknown command: $cmd" >&2; usage >&2; exit 2 ;;
   esac
 
@@ -320,6 +539,9 @@ main() {
     both)
       printf 'VERSION_CODE=%s\n' "$(derive_version_code "$ROOT_DIR" "$ref")"
       printf 'VERSION_NAME=%s\n' "$(derive_version_name "$ROOT_DIR" "$ref")"
+      ;;
+    write-pin)
+      write_version_pin "$ROOT_DIR" "$pin_target" "$ref" || exit 1
       ;;
   esac
 }

--- a/scripts/issue78-phone-walkthrough.sh
+++ b/scripts/issue78-phone-walkthrough.sh
@@ -232,6 +232,13 @@ require_command rg
 [[ -f "$ROOT_DIR/$SSH_KEY" ]] || fail "SSH key was not found at $ROOT_DIR/$SSH_KEY"
 
 prepare_verify_root
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it drives sits under the
+# bootstrap "Host setup needed" sheet. This script always rebuilds the pair from
+# THIS checkout at step 04, so the checkout derivation is the right answer.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run 1 ""
 run_logged "01-docker-agents-up" docker compose -f "$ROOT_DIR/$COMPOSE_FILE" up -d --build agents
 wait_for_docker_ssh
 wait_for_emulator

--- a/scripts/keyboard-stress.sh
+++ b/scripts/keyboard-stress.sh
@@ -151,6 +151,12 @@ if ! "$ADB" get-state >/dev/null 2>&1; then
     "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it drives sits under the
+# bootstrap "Host setup needed" sheet.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 

--- a/scripts/lib/agents-fixture-version.sh
+++ b/scripts/lib/agents-fixture-version.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Issue #2381 — keep the Docker `agents` fixture's `pocketshell --version` in
+# lockstep with the APK built from the same checkout.
+#
+# WHY THIS EXISTS
+#
+# The app treats the release core of its own `versionName` as the `pocketshell`
+# CLI version it expects on the host. Before issue #2356 that was a literal in
+# app/build.gradle.kts, and tests/docker/Dockerfile.agents sed'd the SAME
+# literal out of a COPYed copy of that file at image-build time — so the two
+# agreed by construction. #2356 derived versionName from the git tag instead,
+# the literal disappeared, the sed silently started matching nothing, and the
+# fixture froze at a placeholder. From then on every connected journey against
+# the `agents` fixture could land on the bootstrap "Host setup needed" sheet
+# rather than the screen it asserts.
+#
+# The Docker build context cannot carry the git history the derivation needs,
+# so the version is passed IN: this helper exports
+# POCKETSHELL_AGENT_FIXTURE_VERSION, tests/docker/docker-compose.yml forwards it
+# to the container's environment, and tests/docker/agent-entrypoint.sh stamps it
+# into /opt/pocketshell-agent-fixture-version at container start (sshd does not
+# inherit the entrypoint's environment, so the file — not the variable — is what
+# the app's probe can see).
+#
+# Source it before any `docker compose ... up` that brings up `agents` for a run
+# that also installs the app:
+#
+#   source scripts/lib/agents-fixture-version.sh
+#   export_agents_fixture_version "$APP_APK"      # APK is optional
+#
+# PRECEDENCE (highest first), and why:
+#
+#   1. The versionName baked into $1, when an APK path is given and readable.
+#      This is the ONLY ground truth, because it is literally what the running
+#      app reports to HostBootstrapper. The checkout's derivation is merely a
+#      prediction of it, and the two genuinely diverge on the release chain:
+#      scripts/pre-release-confidence-gate.sh builds its APK inside a `.git`-less
+#      isolated rsync copy (so that APK says `0.0.0-dev`), then every downstream
+#      stage — phone-walkthrough, terminal-workbench, capture-* — installs THAT
+#      pair (issue #2064) while running from the tagged outer checkout, whose
+#      derivation says e.g. `0.4.45-4-gSHA`. Deriving there would stamp the
+#      fixture with a version no installed binary ever reports.
+#   2. An already-set POCKETSHELL_AGENT_FIXTURE_VERSION, so a caller that knows
+#      the exact string it is about to ASSERT can pin it (the pre-release gate
+#      pins $APP_VERSION_NAME, making "what we stamp" and "what we assert" the
+#      same value by construction).
+#   3. The checkout's own scripts/derive-version.sh — right whenever the APK is
+#      built from this same tree (agents pool, CI journey lane, a plain local
+#      run).
+#
+# Never fails: an unreadable APK falls through to 2/3, and an underivable
+# version leaves the variable empty, which falls through to the image's baked
+# `0.0.0-dev` — exactly what a tagless checkout's APK reports.
+
+# Echo a usable `aapt2` (or `aapt`) path, or nothing. Checked in PATH first,
+# then the SDK's build-tools, newest first.
+pocketshell_resolve_aapt() {
+  local candidate sdk
+  for candidate in aapt2 aapt; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  for sdk in "${ANDROID_SDK_ROOT:-}" "${ANDROID_HOME:-}" "$HOME/Android/Sdk"; do
+    [ -n "$sdk" ] || continue
+    [ -d "$sdk/build-tools" ] || continue
+    candidate="$(find "$sdk/build-tools" -mindepth 2 -maxdepth 2 \
+      \( -name aapt2 -o -name aapt \) -type f -perm -u+x 2>/dev/null | sort -V | tail -n 1)"
+    if [ -n "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Echo the versionName recorded in the APK at $1, or nothing when it cannot be
+# read (no aapt on this machine, unreadable/corrupt APK).
+pocketshell_apk_version_name() {
+  local apk="$1" aapt badging
+  [ -n "$apk" ] && [ -r "$apk" ] || return 1
+  aapt="$(pocketshell_resolve_aapt)" || return 1
+  badging="$("$aapt" dump badging "$apk" 2>/dev/null | head -n 5 || true)"
+  [ -n "$badging" ] || return 1
+  printf '%s\n' "$badging" |
+    sed -n "s/.*versionName='\([^']*\)'.*/\1/p" | head -n 1
+}
+
+export_agents_fixture_version() {
+  local apk="${1:-}"
+  local from_apk=""
+
+  if [ -n "$apk" ]; then
+    from_apk="$(pocketshell_apk_version_name "$apk" 2>/dev/null || true)"
+    if [ -n "$from_apk" ]; then
+      POCKETSHELL_AGENT_FIXTURE_VERSION="$from_apk"
+      export POCKETSHELL_AGENT_FIXTURE_VERSION
+      return 0
+    fi
+    # An APK that is not there yet is normal (a standalone run stamps the
+    # fixture before it builds), and the checkout derivation is right for that
+    # case. An APK that EXISTS but cannot be parsed is worth saying out loud.
+    if [ -r "$apk" ]; then
+      printf 'WARN: could not read versionName from %s (no usable aapt2/aapt?); falling back to the checkout derivation for the agents fixture stamp (#2381)\n' \
+        "$apk" >&2
+    fi
+  fi
+
+  if [ -n "${POCKETSHELL_AGENT_FIXTURE_VERSION:-}" ]; then
+    export POCKETSHELL_AGENT_FIXTURE_VERSION
+    return 0
+  fi
+
+  local here root derived
+  here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+  root="$(cd -- "$here/../.." && pwd -P)"
+  derived="$(bash "$root/scripts/derive-version.sh" version-name 2>/dev/null || true)"
+
+  POCKETSHELL_AGENT_FIXTURE_VERSION="${derived:-}"
+  export POCKETSHELL_AGENT_FIXTURE_VERSION
+  return 0
+}
+
+# The one idiom every emulator/walkthrough script uses, so the "which version
+# does the binary we are about to install report?" decision lives in ONE place.
+#
+#   $1  the script's BUILD_APKS-style flag: "1" means it rebuilds the pair from
+#       THIS checkout below (so derive), anything else means it installs $2 as
+#       it stands (so read $2).
+#   $2  the app APK that will be installed.
+#
+# Echoes the resulting stamp so every run log carries the evidence.
+export_agents_fixture_version_for_run() {
+  local build_apks="${1:-1}" apk="${2:-}"
+
+  if [ "$build_apks" = "1" ]; then
+    export_agents_fixture_version
+  else
+    export_agents_fixture_version "$apk"
+  fi
+
+  printf 'agents fixture pocketshell version stamp: %s (issue #2381)\n' \
+    "${POCKETSHELL_AGENT_FIXTURE_VERSION:-<empty: image default 0.0.0-dev>}" >&2
+  return 0
+}

--- a/scripts/lib/agents-pool.sh
+++ b/scripts/lib/agents-pool.sh
@@ -31,6 +31,12 @@ if ! declare -F pocketshell_avd_lock_path >/dev/null 2>&1; then
   source "${BASH_SOURCE[0]%/*}/avd-lock.sh"
 fi
 
+# Issue #2381: the derived `agents`-fixture version every lane must publish.
+if ! declare -F export_agents_fixture_version >/dev/null 2>&1; then
+  # shellcheck source=scripts/lib/agents-fixture-version.sh
+  source "${BASH_SOURCE[0]%/*}/agents-fixture-version.sh"
+fi
+
 # --- configuration --------------------------------------------------------
 
 # Candidate host ports, first-free wins. 2243-2245 sit clear of the existing
@@ -134,6 +140,13 @@ pocketshell_agents_compose_env_for_port() {
   if [[ -n "$project" ]]; then
     printf 'COMPOSE_PROJECT_NAME=%s\n' "$project"
   fi
+  # Issue #2381: every lane's fixture must report the same `pocketshell
+  # --version` as the APK built from this checkout, or the app raises the
+  # bootstrap "Host setup needed" sheet over whatever screen the journey is
+  # asserting. This is the single point every `docker compose ... agents`
+  # invocation in this file routes its environment through.
+  export_agents_fixture_version
+  printf 'POCKETSHELL_AGENT_FIXTURE_VERSION=%s\n' "${POCKETSHELL_AGENT_FIXTURE_VERSION:-}"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/phone-walkthrough.sh
+++ b/scripts/phone-walkthrough.sh
@@ -603,6 +603,21 @@ verify_emulator_booted() {
 # follow-up SSH probe so the readiness log still records the same
 # tool-availability sanity-check evidence reviewers look for.
 verify_docker_agents() {
+  # Issue #2381 — the fixture's `pocketshell --version` must match the APK this
+  # walkthrough installs. Since #2356 the APK's versionName is derived from git,
+  # so an unstamped fixture reports its baked `0.0.0-dev`, the app reads that as
+  # a version mismatch, and the bootstrap "Host setup needed" sheet covers every
+  # screen this visual-audit path is meant to capture.
+  #
+  # BUILD_APKS=0 is the release chain (#2064): the installed pair is the one the
+  # pre-release gate built inside its `.git`-less isolated copy, whose
+  # versionName is NOT what $ROOT_DIR derives — read it out of the APK itself.
+  # BUILD_APKS=1 rebuilds from THIS checkout a few steps below, so the checkout
+  # derivation is the right (and only correct) answer there; any APK sitting in
+  # app/build right now is about to be replaced.
+  # shellcheck source=scripts/lib/agents-fixture-version.sh
+  source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+  export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
   run_logged "05-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
   local log_file="$LOG_DIR/06-docker-ssh-readiness.log"
   if ! wait_for_container_healthy "$COMPOSE_FILE" agents "$log_file" 60; then

--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -315,6 +315,28 @@ if [[ "$GATE_ISOLATED_WORKTREE" != "0" && -z "${POCKETSHELL_GATE_ISOLATED_COPY:-
     --exclude='.gradle/' \
     --exclude='build/' \
     "$ROOT_DIR/" "$isolated_root/"
+  # Issue #2381: the copy has no git, so scripts/derive-version.sh inside it
+  # derived the `0.0.0-dev` / versionCode=1 placeholder — and EVERY APK the
+  # release chain validates, journeys against and publishes is built in here.
+  # The whole release gate was therefore validating a binary that cannot
+  # express a release version: HostBootstrapScenarioSuiteTest's setup-detection
+  # profiles compare the app's version against the host CLI's, and at a `0.0.0`
+  # core every one of them is meaningless (they only "passed" because the
+  # fixture was reset to the same placeholder string, so a string-equality
+  # comparison matched two placeholders). Stamp the version the OUTER checkout
+  # — the tagged one this gate was invoked on — derives, so the copy is
+  # version-identical to its source. `--exclude='.git'` still applies: the copy
+  # gets the ANSWER, never the history.
+  # `fail()` is not defined this early (it needs $RUN_DIR-scoped summary state),
+  # so this uses the same explicit printf+exit shape as the admission checks
+  # above; `early_release_exit` is already trapped and does the cleanup.
+  if ! bash "$ROOT_DIR/scripts/derive-version.sh" write-pin "$isolated_root" >/dev/null; then
+    printf 'REFUSING: could not stamp the isolated worktree copy with %s'"'"'s derived version (issue #2381). Without the pin the copy builds a 0.0.0-dev / versionCode=1 APK and the whole release chain validates, journeys against and publishes a binary that cannot express a release version.\n' \
+      "$ROOT_DIR" >&2
+    exit 1
+  fi
+  printf 'Isolated worktree version pin: %s (issue #2381)\n' \
+    "$(bash "$isolated_root/scripts/derive-version.sh" both | tr '\n' ' ')"
   export POCKETSHELL_GATE_ISOLATED_COPY=1
   # Normally the outer release checkout is the exact clean/pushed source of
   # truth. Preserve an explicit source root for pre-merge reviewer validation,
@@ -1978,6 +2000,23 @@ fi
 run_bash_step "gradle-compile-unit" \
   "'$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-ksp-hilt' -- ./gradlew $GRADLE_FLAGS :app:kspDebugKotlin :app:kspReleaseKotlin :app:kspDebugAndroidTestKotlin :app:kspDebugUnitTestKotlin :app:kspReleaseUnitTestKotlin :app:hiltJavaCompileDebug :app:hiltJavaCompileRelease :app:hiltJavaCompileDebugAndroidTest --stacktrace && '$ROOT_DIR/scripts/cgroup-run.sh' --unit 'pocketshell-pre-release-$(pocketshell_unit_token "$RUN_ID")-assemble-check' -- ./gradlew $GRADLE_FLAGS $GATE_COMPILE_UNIT_TASKS --stacktrace"
 
+# Issue #2381 — stamp the `agents` fixture with the SAME versionName this gate
+# asserts a few lines below (docker-agents-pocketshell-version) and that the APK
+# it installs reports. Since #2356 the version is derived from git rather than a
+# literal in app/build.gradle.kts, so the fixture can no longer parse it out of
+# the build context; it is passed in through the environment instead (see
+# scripts/lib/agents-fixture-version.sh). Without this the fixture reports its
+# baked `0.0.0-dev`, this gate's own version assertion hard-fails on every
+# STANDALONE invocation (the one docs/docker-emulator-runbook.md documents), and
+# every app screen it drives sits under the bootstrap "Host setup needed" sheet.
+#
+# Pinning to $APP_VERSION_NAME rather than re-deriving makes "what we stamp" and
+# "what we assert" the same value by construction, in both the plain-checkout
+# and the isolated-copy (git-less, `0.0.0-dev`) gate modes.
+POCKETSHELL_AGENT_FIXTURE_VERSION="$APP_VERSION_NAME"
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version
 run_step "docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build agents
 # Issue #150: wait on the compose `healthcheck:` block via
 # `docker inspect`. The follow-up SSH sanity check still verifies the

--- a/scripts/reconnect-app-switch.sh
+++ b/scripts/reconnect-app-switch.sh
@@ -182,6 +182,12 @@ if ! "$ADB" get-state >/dev/null 2>&1; then
     "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it drives sits under the
+# bootstrap "Host setup needed" sheet.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 

--- a/scripts/release-emulator-validation.sh
+++ b/scripts/release-emulator-validation.sh
@@ -12,6 +12,11 @@ source "$ROOT_DIR/scripts/lib/release-validation-storage.sh"
 # every downstream stage installs it, publish_validated_apk ships it, and each
 # hop re-checks the sha256.
 source "$ROOT_DIR/scripts/lib/apk-identity.sh"
+# Issue #2381: the deterministic `agents` fixture must report the same
+# `pocketshell --version` as the APK this gate validates, or the bootstrap
+# "Host setup needed" sheet takes over the long-running stability journey.
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version
 
 # Issue #2054: apply and assert the release build resource profile ONCE, at the
 # top of the whole validation, before the ~30-60 minute run takes the shared AVD
@@ -142,6 +147,42 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   exit 0
 fi
 
+# Issue #2381: a tagless checkout reaching this script is an ANOMALY, not a
+# supported mode, and it must say so before the ~40-minute gate rather than
+# after it.
+#
+# Everything this chain exists to prove is version-relative: the setup-detection
+# matrix drives HostBootstrapScenarioSuiteTest, whose seven profiles all compare
+# the app's version against the `pocketshell` CLI the Docker host reports
+# ("up to date", "update available", "app too old"). At the `0.0.0` core that
+# scripts/derive-version.sh emits with no reachable `v*` tag, none of those
+# relationships is expressible and every profile is vacuous — and the artifact
+# publish_validated_apk ships would be stamped versionCode=1 / 0.0.0-dev.
+# Before this check the symptom was seven identical, cause-free
+# `java.lang.AssertionError`s inside instrumentation, after the ~40-minute
+# pre-release gate had already run.
+#
+# A function, not an inline block, so tests/scripts/gate-isolated-copy-version-
+# test.sh can drive THIS code (not a copy of it) red and green without starting
+# a release run — the same extract-and-source idiom
+# tests/scripts/pre-release-version-test.sh uses for the gate's fixture check.
+release_chain_version_preflight() {
+  local root_dir="$1"
+  local version_name core
+  version_name="$(bash "$root_dir/scripts/derive-version.sh" version-name 2>/dev/null || true)"
+  core="${version_name#v}"
+  core="${core%%+*}"
+  core="${core%%-*}"
+  if [[ -z "$core" || "$core" == "0.0.0" ]]; then
+    printf 'REFUSING: %s derives versionName=%s, whose release core is %s (issue #2381).\n' \
+      "$root_dir" "${version_name:-<empty>}" "${core:-<empty>}" >&2
+    printf 'The release validation chain is entirely version-relative — every setup-detection profile compares the app version against the host `pocketshell` CLI version — so at a 0.0.0 core it proves nothing, and publish_validated_apk would ship a versionCode=1 / 0.0.0-dev artifact.\n' >&2
+    printf 'Fix the CHECKOUT, not this script: check out with full tag history (actions/checkout fetch-depth: 0, which .github/workflows/release-emulator-validation.yml already does) or `git fetch --tags` so at least one v* tag is reachable from HEAD.\n' >&2
+    return 1
+  fi
+  printf 'Release chain version: %s (core %s) — issue #2381 preflight\n' "$version_name" "$core"
+}
+
 pocketshell_release_validation_require_run_id "$RUN_ID" ||
   exit "$POCKETSHELL_RELEASE_DISK_PREFLIGHT_FAIL_RC"
 
@@ -163,6 +204,11 @@ else
     printf 'Release storage contract satisfied: canonical generated root authenticated; 24 GiB floor available.\n'
     exit 0
   fi
+  # Issue #2381: last of the cheap fail-closed preconditions, in the same zone
+  # as the storage/disk checks above and still before the shared AVD lock, the
+  # isolated rsync copy and every minute of Gradle. `--check-storage` has
+  # already exited; `--verify-apk-identity` never reaches here.
+  release_chain_version_preflight "$ROOT_DIR" || exit 1
 fi
 
 pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
@@ -856,6 +902,16 @@ run_required \
 # rebuild inside terminal-lab is also what OOM-killed release attempt r1, 58
 # minutes in.
 export_validated_apk_identity
+
+# Issue #2381: every stage from here on installs the pair the pre-release gate
+# built INSIDE its `.git`-less isolated rsync copy, so that APK's versionName is
+# the isolated copy's derivation, not this tagged checkout's. The top-of-script
+# derivation was only right for the stages before this point; re-pin the
+# `agents` fixture stamp to the binary that is actually installed, or every
+# downstream journey runs against a host CLI version the app disagrees with.
+export_agents_fixture_version "$APP_APK"
+printf 'Validated-APK agents fixture stamp: %s (issue #2381)\n' \
+  "${POCKETSHELL_AGENT_FIXTURE_VERSION:-<empty: image default 0.0.0-dev>}"
 
 if [[ "$TERMINAL_RELEASE_GATE" == "1" ]]; then
   run_required \

--- a/scripts/release-terminal-gate.sh
+++ b/scripts/release-terminal-gate.sh
@@ -437,6 +437,14 @@ run_ssh_smoke_step() {
     printf 'selector: %s\n' \
       'com.pocketshell.app.proof.EmulatorDockerSshSmokeTest#debugAppConnectsToDockerAgentTargetViaEmulatorHostAlias'
     printf '\n# bringing up deterministic agents Docker fixture\n'
+    # Issue #2381: the fixture's `pocketshell --version` must equal the
+    # versionName of the installed APK, or the SSH smoke test lands on the
+    # bootstrap "Host setup needed" sheet instead of the session it asserts.
+    # The pair this step runs against was built from THIS checkout by the first
+    # workbench step above (FIRST_WORKBENCH_BUILD_APKS=1), so derive.
+    # shellcheck source=scripts/lib/agents-fixture-version.sh
+    source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+    export_agents_fixture_version_for_run 1 ""
     docker compose -f "$DETERMINISTIC_COMPOSE_FILE" up -d --build agents
     printf '\n# Docker compose ps\n'
     docker compose -f "$DETERMINISTIC_COMPOSE_FILE" ps

--- a/scripts/terminal-workbench.sh
+++ b/scripts/terminal-workbench.sh
@@ -405,6 +405,12 @@ if ! "$ADB" get-state >/dev/null 2>&1; then
     "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it drives sits under the
+# bootstrap "Host setup needed" sheet.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 

--- a/scripts/test-agents-pool-isolation.sh
+++ b/scripts/test-agents-pool-isolation.sh
@@ -104,6 +104,11 @@ make_worktree() {
   mkdir -p "$root/scripts/lib" "$root/build" "$root/tests/docker"
   cp "$ROOT_DIR/scripts/lib/agents-pool.sh" "$root/scripts/lib/agents-pool.sh"
   cp "$ROOT_DIR/scripts/lib/avd-lock.sh" "$root/scripts/lib/avd-lock.sh"
+  # Issue #2381: agents-pool.sh also sources this to stamp the fixture's
+  # `pocketshell --version` with the APK's derived version. A synthetic
+  # worktree missing it makes every `source` in the harness print a
+  # "No such file" error, so keep the copied helper set complete.
+  cp "$ROOT_DIR/scripts/lib/agents-fixture-version.sh" "$root/scripts/lib/agents-fixture-version.sh"
   cp "$ROOT_DIR/tests/docker/docker-compose.yml" "$root/tests/docker/docker-compose.yml"
 }
 

--- a/scripts/test-ci-mobile-rtt-readiness.sh
+++ b/scripts/test-ci-mobile-rtt-readiness.sh
@@ -55,20 +55,23 @@ PY
 
 sandbox="$(mktemp -d)"
 trap 'rm -rf "$sandbox"' EXIT
-mkdir -p "$sandbox/repo/tests/docker" "$sandbox/repo/scripts" "$sandbox/bin"
+mkdir -p "$sandbox/repo/tests/docker" "$sandbox/repo/scripts/lib" "$sandbox/bin"
 cp "$REPO_ROOT/tests/docker/test_key" "$sandbox/repo/tests/docker/test_key"
 chmod 0644 "$sandbox/repo/tests/docker/test_key"
 
 # Issue #2095: the extracted production block now calls the bounded fixture
 # retry helper. Copy the real helper, not a no-op stub, so this sandbox exercises
 # its command dispatch and success artifact as production does. The helper is
-# self-contained; its external utilities continue to come from the normal PATH.
+# self-contained; its external utilities continue to come from the normal PATH,
+# except issue #2381's agents-fixture-version.sh, which it sources directly and
+# which must be copied alongside it or the sandbox run fails on "No such file".
 fixture_retry_source="$REPO_ROOT/scripts/ci-journey-fixture-retry.sh"
 fixture_retry_sandbox="$sandbox/repo/scripts/ci-journey-fixture-retry.sh"
 [[ -f "$fixture_retry_source" ]] \
   || fail "repository fixture-retry wrapper not found: $fixture_retry_source"
 cp "$fixture_retry_source" "$fixture_retry_sandbox"
 chmod +x "$fixture_retry_sandbox"
+cp "$REPO_ROOT/scripts/lib/agents-fixture-version.sh" "$sandbox/repo/scripts/lib/agents-fixture-version.sh"
 [[ -x "$fixture_retry_sandbox" ]] \
   || fail "mobile-RTT sandbox is missing the executable fixture-retry wrapper"
 cmp -s "$fixture_retry_source" "$fixture_retry_sandbox" \

--- a/scripts/tmux-attach-prefill.sh
+++ b/scripts/tmux-attach-prefill.sh
@@ -233,6 +233,12 @@ if ! "$ADB" get-state >/dev/null 2>&1; then
     "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it drives sits under the
+# bootstrap "Host setup needed" sheet.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 

--- a/scripts/tmux-issue303-toolbar-proof.sh
+++ b/scripts/tmux-issue303-toolbar-proof.sh
@@ -227,6 +227,12 @@ if ! "$ADB" get-state >/dev/null 2>&1; then
     "${emulator_cmd[@]}"
 fi
 run_logged "01-wait-emulator" wait_for_emulator
+# Issue #2381: the fixture's `pocketshell --version` must equal the versionName
+# of the APK this run installs, or every screen it drives sits under the
+# bootstrap "Host setup needed" sheet.
+# shellcheck source=scripts/lib/agents-fixture-version.sh
+source "$ROOT_DIR/scripts/lib/agents-fixture-version.sh"
+export_agents_fixture_version_for_run "$BUILD_APKS" "$APP_APK"
 run_logged "02-docker-agents-up" docker compose -f "$COMPOSE_FILE" up -d --build "$AGENT_SERVICE"
 run_logged "03-docker-ssh-readiness" wait_for_ssh_fixture
 

--- a/tests/docker/Dockerfile.agents
+++ b/tests/docker/Dockerfile.agents
@@ -39,19 +39,16 @@ COPY tools/pocketshell/pyproject.toml /opt/pocketshell-real/pyproject.toml
 #     grid; recovery must come from the reconciler).
 COPY tests/docker/agent-fixtures/ /opt/pocketshell-agent-fixtures/
 COPY tests/docker/agent-entrypoint.sh /usr/local/bin/pocketshell-agent-entrypoint
-COPY app/build.gradle.kts /opt/pocketshell-app-build.gradle.kts
 
-# Issue #2356 (Phase 4 of epic #2350): app/build.gradle.kts's versionName is
-# no longer a `versionName = "X.Y.Z"` literal to sed out below -- it is
-# derived from the git tag (scripts/derive-version.sh), which needs full tag
-# history the Docker build context does not carry (only the single
-# build.gradle.kts file is COPYed in above, not .git). The sed in the RUN
-# below now always finds nothing; it falls back to a fixed placeholder
-# rather than hard-failing the image build (`test -n "$version"` used to
-# abort here). Making the fixture report the SAME derived dev version a
-# freshly-built connected-test APK would report is a larger follow-up (would
-# need a build-arg threaded through every docker-compose caller in this
-# repo) intentionally deferred, not attempted in this hotfix.
+# Issue #2381: the baked version is only the floor. #2356 removed the
+# `versionName = "X.Y.Z"` literal this image used to sed out of a COPYed
+# app/build.gradle.kts, so that COPY + sed silently degraded to a fixed
+# placeholder and the fixture stopped tracking the APK. Both are deleted here
+# (D22 hard cut, no dead fallback): the caller now passes the derived version
+# as POCKETSHELL_AGENT_FIXTURE_VERSION and the entrypoint stamps it into this
+# same file at container start. `0.0.0-dev` matches what
+# scripts/derive-version.sh yields for a tagless checkout, so an unset caller
+# and a tagless-checkout APK still agree.
 RUN chmod 600 /home/testuser/.ssh/authorized_keys /root/test_key \
     && chmod +x /usr/local/bin/claude \
         /usr/local/bin/codex \
@@ -68,9 +65,7 @@ RUN chmod 600 /home/testuser/.ssh/authorized_keys /root/test_key \
         /usr/local/bin/pocketshell-agent-entrypoint \
         /usr/local/bin/pocketshell-real-send \
     && ln -sf /usr/local/bin/tmux /usr/bin/tmux \
-    && version="$(sed -n 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"\([^"]*\)".*$/\1/p' /opt/pocketshell-app-build.gradle.kts | head -n 1)" \
-    && if [ -z "$version" ]; then version="0.0.0-dev"; fi \
-    && printf '%s\n' "$version" > /opt/pocketshell-agent-fixture-version \
+    && printf '%s\n' "0.0.0-dev" > /opt/pocketshell-agent-fixture-version \
     && chown -R testuser:testuser /home/testuser/.ssh
 
 EXPOSE 22

--- a/tests/docker/agent-entrypoint.sh
+++ b/tests/docker/agent-entrypoint.sh
@@ -4,6 +4,29 @@ set -eu
 fixture_dir="${POCKETSHELL_AGENT_FIXTURE_DIR:-/opt/pocketshell-agent-fixtures}"
 encoded_cwd="-workspace-pocketshell"
 
+# Issue #2381: keep the fixture's `pocketshell --version` in lockstep with the
+# APK under test. The app treats its own versionName's release core as the CLI
+# version it expects on the host, so a fixture pinned to a different release
+# reports VersionMismatch and the bootstrap "Host setup needed" sheet takes
+# over EVERY journey against this fixture.
+#
+# Before #2356 the Dockerfile sed'd the `versionName = "X.Y.Z"` literal out of
+# app/build.gradle.kts at image-build time and the two matched by construction.
+# That literal is gone (the version is derived from the git tag), and the git
+# history the derivation needs is not in the Docker build context — so the
+# caller passes the derived version in instead, and we stamp it here at
+# container start rather than at image build: `docker compose up -d` without
+# `--build` then still picks it up, and a changed value does not bust the
+# image layer cache.
+#
+# The env var itself cannot reach the app's probe: it arrives over sshd, which
+# does not inherit the entrypoint's environment. Writing the file is what makes
+# it visible (same mechanism as Dockerfile.agents-old-cli's #847 fixture).
+version_file="${POCKETSHELL_AGENT_FIXTURE_VERSION_FILE:-/opt/pocketshell-agent-fixture-version}"
+if [ -n "${POCKETSHELL_AGENT_FIXTURE_VERSION:-}" ]; then
+  printf '%s\n' "$POCKETSHELL_AGENT_FIXTURE_VERSION" > "$version_file"
+fi
+
 install -d -o testuser -g testuser "/home/testuser/.claude/projects/${encoded_cwd}"
 install -d -o testuser -g testuser "/home/testuser/.codex/sessions/2026/05/22"
 install -d -o testuser -g testuser "/home/testuser/.local/share/opencode"

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -166,6 +166,15 @@ services:
       dockerfile: tests/docker/Dockerfile.agents
     image: pocketshell-test:agents
     container_name: ${AGENTS_CONTAINER_NAME:-pocketshell-test-agents}
+    # Issue #2381: the `pocketshell --version` this fixture reports must match
+    # the APK under test, or every journey against it lands on the bootstrap
+    # "Host setup needed" sheet instead of the screen it is asserting. The
+    # caller exports the value scripts/derive-version.sh produced for the same
+    # checkout that built the APK (see scripts/lib/agents-fixture-version.sh);
+    # unset falls through to the image's baked `0.0.0-dev`, which is what a
+    # tagless checkout's APK reports too.
+    environment:
+      POCKETSHELL_AGENT_FIXTURE_VERSION: ${POCKETSHELL_AGENT_FIXTURE_VERSION:-}
     ports:
       - "${AGENTS_HOST_PORT:-2222}:22"
     healthcheck: *ssh-healthcheck

--- a/tests/scripts/gate-isolated-copy-version-test.sh
+++ b/tests/scripts/gate-isolated-copy-version-test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tests/scripts/gate-isolated-copy-version-test.sh — issue #2381 (round 4).
+#
+# WHAT WENT WRONG (and what no gate would have told us):
+#   scripts/pre-release-confidence-gate.sh rsyncs the release checkout to
+#   `<checkout>/build/pre-release-confidence-gate/<run>/worktree` with
+#   `--exclude='.git'` and re-execs there. EVERY APK the release chain
+#   validates, journeys against and finally publishes is built inside that
+#   copy. With no git of its own, scripts/derive-version.sh answered with the
+#   `0.0.0-dev` / versionCode=1 placeholder — so the release gate has been
+#   validating a binary that cannot express a release version at all, on a
+#   checkout that (fetch-depth: 0) derives a perfectly good `0.4.45-N-gSHA`.
+#
+#   It stayed invisible because the failure was DEGENERATE, not loud: the
+#   `agents`/bootstrap fixtures were reset to the same placeholder string, and
+#   a string-equality version comparison matched two placeholders. The moment
+#   the comparison became a real version comparison, every setup-detection
+#   profile in HostBootstrapScenarioSuiteTest hard-failed on
+#   release-emulator-validation.sh's REQUIRED `setup-detection` stage.
+#
+# WHAT THIS HARNESS PINS (all red-first — every green below is preceded by the
+# corresponding red on the same tree, so it cannot pass vacuously):
+#   1. A gate-shaped `.git`-less copy of a TAGGED checkout derives the
+#      placeholder without the pin (the bug), and the source checkout's exact
+#      version with it.
+#   2. The pin carries versionCode too, not just versionName.
+#   3. The real scripts/pre-release-confidence-gate.sh writes the pin AFTER its
+#      rsync and BEFORE it `exec`s into the copy — the ordering is the whole
+#      point, and a reordering/deletion is invisible to the compiler.
+#   4. scripts/release-emulator-validation.sh's own release_chain_version_
+#      preflight() (extracted and executed, not re-implemented) REFUSES a
+#      tagless checkout with an actionable message and clears a tagged one —
+#      so the anomaly is surfaced up front with a named cause instead of as
+#      seven cause-free AssertionErrors ~40 minutes in — and its call site sits
+#      before the AVD lock and the pre-release gate.
+#
+# JVM-free, Docker-free, emulator-free: synthetic git repos under mktemp. Never
+# touches this repo's own tags or working tree.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+CASES=0
+pass_case() {
+  CASES=$((CASES + 1))
+  printf '  ok: %s\n' "$1"
+}
+
+expect_eq() {
+  local desc="$1" actual="$2" expected="$3"
+  [[ "$actual" == "$expected" ]] ||
+    fail "$desc: got '$actual', expected '$expected'"
+  pass_case "$desc -> $actual"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+DERIVE="$ROOT_DIR/scripts/derive-version.sh"
+GATE="$ROOT_DIR/scripts/pre-release-confidence-gate.sh"
+VALIDATION="$ROOT_DIR/scripts/release-emulator-validation.sh"
+PIN_FILE_NAME=".pocketshell-version-pin"
+
+for f in "$DERIVE" "$GATE" "$VALIDATION"; do
+  [[ -f "$f" ]] || fail "missing production script under test: $f"
+done
+
+# ---------------------------------------------------------------------------
+# A synthetic checkout shaped like this repo: real git, a real `v*` tag, and
+# commits after it (the release chain's actual shape — a validated-RC build is
+# N commits past the last tag).
+# ---------------------------------------------------------------------------
+source_repo="$tmpdir/checkout"
+mkdir -p "$source_repo/scripts"
+cp "$DERIVE" "$source_repo/scripts/derive-version.sh"
+git -C "$source_repo" init --quiet -b main
+git -C "$source_repo" config user.email "test@example.com"
+git -C "$source_repo" config user.name "Gate Isolated Copy Test"
+git -C "$source_repo" add -A
+git -C "$source_repo" commit --quiet -m "c1"
+git -C "$source_repo" tag v0.4.45
+git -C "$source_repo" commit --quiet --allow-empty -m "c2"
+git -C "$source_repo" commit --quiet --allow-empty -m "c3"
+
+source_name="$(bash "$source_repo/scripts/derive-version.sh" version-name)"
+source_code="$(bash "$source_repo/scripts/derive-version.sh" version-code)"
+[[ "$source_name" == 0.4.45-2-g* ]] ||
+  fail "fixture is not the release chain's shape: source derived '$source_name', expected 0.4.45-2-g<sha>"
+[[ "$source_code" == "2" ]] ||
+  fail "fixture versionCode drifted: got '$source_code', expected 2 (1 v* tag + offset)"
+pass_case "fixture checkout derives a real post-tag release version ($source_code/$source_name)"
+
+# ---------------------------------------------------------------------------
+# Case 1-2 (RED): the gate's own rsync, extracted from the production script so
+# this harness cannot drift from the real exclusion set.
+# ---------------------------------------------------------------------------
+gate_rsync_excludes="$(
+  awk '/^  rsync -a --delete \\$/ { copy = 1 }
+       copy { print; if ($0 ~ /isolated_root/) exit }' "$GATE" |
+    grep -o -- "--exclude='[^']*'" | tr '\n' ' '
+)"
+[[ "$gate_rsync_excludes" == *"--exclude='.git'"* ]] ||
+  fail "could not extract the gate's rsync exclusions (got: '$gate_rsync_excludes'); the harness is no longer testing the real copy shape"
+pass_case "extracted the gate's real rsync exclusions ($gate_rsync_excludes)"
+
+isolated_root="$source_repo/build/pre-release-confidence-gate/harness/worktree"
+mkdir -p "$isolated_root"
+# shellcheck disable=SC2086 # the extracted --exclude flags must word-split
+eval rsync -a --delete $gate_rsync_excludes "\"\$source_repo/\"" "\"\$isolated_root/\""
+
+[[ -e "$isolated_root/.git" ]] &&
+  fail "the gate-shaped copy still carries .git; the extracted exclusions did not apply"
+[[ -f "$isolated_root/scripts/derive-version.sh" ]] ||
+  fail "the gate-shaped copy is missing scripts/derive-version.sh"
+
+expect_eq "RED: unpinned gate copy derives the placeholder versionName" \
+  "$(bash "$isolated_root/scripts/derive-version.sh" version-name)" "0.0.0-dev"
+expect_eq "RED: unpinned gate copy derives the placeholder versionCode" \
+  "$(bash "$isolated_root/scripts/derive-version.sh" version-code)" "1"
+
+# ---------------------------------------------------------------------------
+# Case 3-5 (GREEN): write-pin makes the copy version-identical to its source.
+# ---------------------------------------------------------------------------
+bash "$source_repo/scripts/derive-version.sh" write-pin "$isolated_root" >/dev/null ||
+  fail "write-pin failed against the gate-shaped copy"
+[[ -f "$isolated_root/$PIN_FILE_NAME" ]] ||
+  fail "write-pin reported success but wrote no $PIN_FILE_NAME"
+
+expect_eq "GREEN: pinned gate copy derives the SOURCE checkout's versionName" \
+  "$(bash "$isolated_root/scripts/derive-version.sh" version-name)" "$source_name"
+expect_eq "GREEN: pinned gate copy derives the SOURCE checkout's versionCode" \
+  "$(bash "$isolated_root/scripts/derive-version.sh" version-code)" "$source_code"
+
+# The load-bearing property, stated the way the failure was reported: the
+# release CORE the app compares against the host CLI must not be 0.0.0.
+pinned_core="$(bash "$isolated_root/scripts/derive-version.sh" version-name)"
+pinned_core="${pinned_core#v}"
+pinned_core="${pinned_core%%+*}"
+pinned_core="${pinned_core%%-*}"
+[[ -n "$pinned_core" && "$pinned_core" != "0.0.0" ]] ||
+  fail "the pinned gate copy still resolves the 0.0.0 release core that makes every setup-detection profile vacuous"
+expect_eq "GREEN: pinned gate copy resolves a real release core" "$pinned_core" "0.4.45"
+
+# A re-run of the gate rsyncs again over the same copy. --delete must not strip
+# the pin in a way the re-write cannot repair, and the copy must never silently
+# drop back to the placeholder mid-gate.
+# shellcheck disable=SC2086
+eval rsync -a --delete $gate_rsync_excludes "\"\$source_repo/\"" "\"\$isolated_root/\""
+bash "$source_repo/scripts/derive-version.sh" write-pin "$isolated_root" >/dev/null ||
+  fail "write-pin failed on a re-rsynced copy"
+expect_eq "a re-rsynced copy is re-pinned to the same version" \
+  "$(bash "$isolated_root/scripts/derive-version.sh" version-name)" "$source_name"
+
+# ---------------------------------------------------------------------------
+# Case 7-8: the ORDERING inside the real gate script. The pin only works
+# between the rsync and the exec; anywhere else and the child re-execs into an
+# unpinned copy.
+# ---------------------------------------------------------------------------
+# `|| true` on each: under `set -euo pipefail` a non-matching grep would abort
+# the harness with no message at all, replacing the actionable diagnostic below
+# with a silent non-zero exit — which is exactly the failure shape this file
+# exists to prevent.
+gate_rsync_line="$(grep -n '^  rsync -a --delete \\$' "$GATE" | head -1 | cut -d: -f1 || true)"
+gate_pin_line="$(grep -n 'derive-version\.sh" write-pin "\$isolated_root"' "$GATE" | head -1 | cut -d: -f1 || true)"
+gate_exec_line="$(grep -n '^  exec "\$isolated_root/scripts/pre-release-confidence-gate\.sh"' "$GATE" | head -1 | cut -d: -f1 || true)"
+
+[[ -n "$gate_rsync_line" ]] || fail "scripts/pre-release-confidence-gate.sh no longer rsyncs an isolated copy — this harness is stale"
+[[ -n "$gate_pin_line" ]] ||
+  fail "scripts/pre-release-confidence-gate.sh does not stamp its isolated copy with 'derive-version.sh write-pin \"\$isolated_root\"' (issue #2381). Without it the whole release chain builds, validates and publishes a 0.0.0-dev / versionCode=1 APK."
+[[ -n "$gate_exec_line" ]] || fail "scripts/pre-release-confidence-gate.sh no longer execs into its isolated copy — this harness is stale"
+
+(( gate_pin_line > gate_rsync_line )) ||
+  fail "the isolated-copy version pin (line $gate_pin_line) must come AFTER the rsync (line $gate_rsync_line) — rsync --delete would remove it"
+pass_case "the gate pins the isolated copy after the rsync (lines $gate_rsync_line -> $gate_pin_line)"
+
+(( gate_pin_line < gate_exec_line )) ||
+  fail "the isolated-copy version pin (line $gate_pin_line) must come BEFORE the exec into the copy (line $gate_exec_line) — the child would otherwise build from an unpinned tree"
+pass_case "the gate pins the isolated copy before exec'ing into it (lines $gate_pin_line -> $gate_exec_line)"
+
+# ---------------------------------------------------------------------------
+# Case 9-11: release-emulator-validation.sh's tagless preflight. The PRODUCTION
+# function is extracted and sourced (the same idiom
+# tests/scripts/pre-release-version-test.sh uses on the gate's fixture check),
+# so this exercises the real code without starting a 40-minute release run.
+# ---------------------------------------------------------------------------
+preflight_src="$tmpdir/preflight.sh"
+awk '
+  /^release_chain_version_preflight\(\)/ { copy = 1 }
+  copy {
+    print
+    if ($0 == "}") exit
+  }
+' "$VALIDATION" > "$preflight_src"
+grep -q 'issue #2381' "$preflight_src" ||
+  fail "could not extract release_chain_version_preflight() from $VALIDATION — the harness is no longer testing the real preflight"
+# shellcheck source=/dev/null
+source "$preflight_src"
+pass_case "extracted release_chain_version_preflight() from the production script"
+
+chain_repo="$tmpdir/chain"
+mkdir -p "$chain_repo/scripts"
+cp "$DERIVE" "$chain_repo/scripts/derive-version.sh"
+git -C "$chain_repo" init --quiet -b main
+git -C "$chain_repo" config user.email "test@example.com"
+git -C "$chain_repo" config user.name "Gate Isolated Copy Test"
+git -C "$chain_repo" add -A
+git -C "$chain_repo" commit --quiet -m "c1"
+
+tagless_rc=0
+tagless_output="$(release_chain_version_preflight "$chain_repo" 2>&1)" || tagless_rc=$?
+(( tagless_rc != 0 )) ||
+  fail "release_chain_version_preflight accepted a TAGLESS checkout (rc=0): $tagless_output"
+grep -q 'REFUSING:.*issue #2381' <<< "$tagless_output" ||
+  fail "the tagless refusal does not name issue #2381: $tagless_output"
+grep -q 'fetch-depth: 0' <<< "$tagless_output" ||
+  fail "the tagless refusal does not tell the operator how to fix the checkout: $tagless_output"
+pass_case "RED: the release chain refuses a tagless checkout with an actionable message"
+
+git -C "$chain_repo" tag v0.4.45
+tagged_rc=0
+tagged_output="$(release_chain_version_preflight "$chain_repo" 2>&1)" || tagged_rc=$?
+(( tagged_rc == 0 )) ||
+  fail "release_chain_version_preflight refused a properly TAGGED checkout (rc=$tagged_rc): $tagged_output"
+grep -q 'Release chain version: 0.4.45 (core 0.4.45)' <<< "$tagged_output" ||
+  fail "the tagged checkout did not report its resolved release version: $tagged_output"
+pass_case "GREEN: the release chain clears the preflight on a tagged checkout"
+
+# ---------------------------------------------------------------------------
+# Case 12: the preflight's CALL SITE ordering. It must fire before the shared
+# AVD lock (and therefore before the isolated rsync copy and every minute of
+# Gradle) — a preflight that runs after the 40-minute gate is not a preflight.
+# ---------------------------------------------------------------------------
+preflight_call_line="$(grep -n '^  release_chain_version_preflight "\$ROOT_DIR" || exit 1$' "$VALIDATION" | head -1 | cut -d: -f1 || true)"
+avd_lock_line="$(grep -n '^pocketshell_acquire_avd_lock "\$ROOT_DIR"' "$VALIDATION" | head -1 | cut -d: -f1 || true)"
+gate_stage_line="$(grep -n 'scripts/pre-release-confidence-gate\.sh$' "$VALIDATION" | head -1 | cut -d: -f1 || true)"
+
+[[ -n "$preflight_call_line" ]] ||
+  fail "scripts/release-emulator-validation.sh defines release_chain_version_preflight but never CALLS it (issue #2381) — a tagless run would reach the setup-detection stage and fail there with seven cause-free AssertionErrors instead."
+[[ -n "$avd_lock_line" ]] || fail "could not locate the AVD lock acquisition — this harness is stale"
+[[ -n "$gate_stage_line" ]] || fail "could not locate the pre-release confidence gate stage — this harness is stale"
+
+(( preflight_call_line < avd_lock_line && preflight_call_line < gate_stage_line )) ||
+  fail "the #2381 version preflight (line $preflight_call_line) must run BEFORE the AVD lock (line $avd_lock_line) and the pre-release gate (line $gate_stage_line)"
+pass_case "the version preflight runs before the AVD lock and the 40-minute gate (lines $preflight_call_line -> $avd_lock_line -> $gate_stage_line)"
+
+# Issue #2113: the count line is what makes the JVM assertion about behaviour
+# rather than about bash's exit status.
+(( CASES == 14 )) || fail "expected 14 cases to run, saw $CASES"
+printf 'PASS: gate isolated-copy version pin (%s cases)\n' "$CASES"


### PR DESCRIPTION
Closes #2381.

Bisected to #2356 (`824f2aa2`, tag-derived versionCode/versionName). A tagless nightly checkout produces `versionName` like `0.0.0-dev+525c87a`; `HostBootstrapper.kt`'s `VERSION_PATTERN` excluded `+`, truncating the parsed version to `0.0.0-dev`, and `compareSemver` returned `null` for non-dotted-numeric input, falling back to raw string equality — so the app compared a truncated parse of its own version against itself and got `VersionMismatch`. The "Host setup needed" sheet never cleared. All 8 `HostBootstrapScenarioSuiteTest` methods failed, not the originally-reported 5.

This went five layers deep once traced fully:

1. **Core comparator fix**: correct `VERSION_PATTERN`/`compareSemver` for git-derived version strings.
2. **Docker fixture**: `tests/docker/Dockerfile.agents` pinned its host-CLI version via a literal grep that #2356 also broke — fixed via a shared `agents-fixture-version.sh` helper.
3. **13 real call sites**, not 2: `pre-release-confidence-gate.sh` and `phone-walkthrough.sh` both independently had the identical bug, plus 11 more scripts that install/drive the app.
4. **The automated release chain was silently broken**: `pre-release-confidence-gate.sh` rsyncs to a `.git`-less copy and re-execs there, so `derive-version.sh` returned `0.0.0-dev` for every APK the whole chain built/validated/published — real corruption, not a test artifact. New `derive-version.sh` pin mechanism (`write-pin`) stamps the copy with exactly what its source checkout derives.
5. **That fix then made a previously-degenerate-passing release-gate assertion fail for real.** Root cause, not routed around: a tagless build reaching the release chain is now a genuine, named, EARLY failure (`release_chain_version_preflight`, ~85ms, before the AVD lock) instead of seven cause-less `AssertionError`s deep inside a 40-minute instrumentation run.

## New guards

`scripts/check-emulator-apk-version-wiring.sh` (workflow/container/call-site coupling, so this exact class of silent breakage can't recur), `tests/scripts/gate-isolated-copy-version-test.sh` (14 cases), `AppCliVersion.kt` + `Issue2381DerivedAppVersionCliCompatibilityTest.kt`.

## Test plan

- [x] 5 independent review rounds, each finding one more real layer, until the final round found nothing further.
- [x] Final round APPROVED with everything reproduced independently: the pin invariant verified on the real checkout (including a compounding re-copy/re-pin edge case), RED→GREEN through the real `phone-walkthrough.sh setup-detection` stage (`rc=1` → `rc=0`, 7/7 profiles), the preflight's ~85ms early-failure timing confirmed (AVD lock never acquired on failure), 4/4 mutations of the new guard reproduced, `DiskPreflightScriptTest`/`release-validation-storage-test.sh` confirmed not regressed.
- [x] Full JVM gate green, connected suite 10/10 (one unrelated known flake, #2359, captured and green on clean rerun).

## Non-blocking follow-ups noted by review (filing separately)

A standalone tagless `pre-release-confidence-gate.sh` invocation still pins `0.0.0-dev` and only fails later at the androidTest assertion; `phone-walkthrough.sh` installs the unsuffixed package and isn't protected from sibling-agent collisions.