### PR TITLE
Fix journey-lane failure classification and validated-rc tagging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -677,6 +677,14 @@ jobs:
             scripts/test-ci-journey-retry-budget.sh
           scripts/test-ci-journey-retry-budget.sh
 
+      # Issue #2374: #2356's validated-RC self-tests ran in NO gate, hiding a
+      # hosted-runner "git has no tagger identity" break in the marker script.
+      - name: Nightly validated-RC marker guards (issues #2356, #2374)
+        run: |
+          scripts/test-ci-nightly-rc-mark.sh
+          scripts/test-ci-nightly-rc-consecutive-check.sh
+          scripts/test-ci-nightly-rc-issue.sh
+
       # Issues #1800/#1919: the failure-SIGNATURE classifier that types the CI
       # swiftshader "real system input-method window never became visible"
       # PRECONDITION as INFRA (-> RE-RUN) while keeping every genuine journey
@@ -1718,20 +1726,19 @@ jobs:
         if: always()
         run: |
           chmod +x scripts/ci-journey-retry-budget.sh
-          # Issue #1800: pass this job's own measurements (first-attempt start
-          # epoch + the suite's measured elapsed) so the requirement reflects
-          # what redoing the observed work costs. Missing/invalid measurements
-          # fall back to the unchanged flat worst case inside the helper.
-          # Issue #1833: also pass the measured cold build (#1814) so the suite
-          # cost is priced as the WARM retry it actually is, instead of charging
-          # a build the retry never repeats a second time. Missing/invalid warm
-          # measurement falls back to #1800's model, unchanged.
+          # This job's own measurements: the first-attempt start epoch (#1800),
+          # the suite's measured elapsed (#1800), the measured cold build
+          # (#1833) and whether the first attempt already failed journeys
+          # (#2374). Each is optional and each degrades to the previous model
+          # inside the helper — scripts/ci-journey-retry-budget.sh's header
+          # carries the full rationale for all four.
           scripts/ci-journey-retry-budget.sh \
             "${JOURNEY_JOB_START_EPOCH_MS:-}" \
             "$(date +%s%3N)" \
             "${JOURNEY_FIRST_ATTEMPT_START_EPOCH_MS:-}" \
             "${{ steps.journey_summary.outputs.first_suite_elapsed_secs }}" \
             "${{ steps.journey_summary.outputs.first_warm_build_secs }}" \
+            "${{ steps.journey_summary.outputs.first_failure }}" \
             | tee -a "$GITHUB_OUTPUT"
 
       # Infra-retry-once: runs if the first bringup failed with a boot/adb abort
@@ -1820,6 +1827,7 @@ jobs:
           retry_cost_model="${{ steps.journey_retry_budget.outputs.retry_cost_model }}"
           retry_shortfall_ms="${{ steps.journey_retry_budget.outputs.retry_shortfall_ms }}"
           retry_warm_build_deducted_ms="${{ steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms }}"
+          retry_denial_class="${{ steps.journey_retry_budget.outputs.retry_denial_class }}"
           summary="artifacts/ci-journey/summary.md"
           # Issue #1458: record this shard's verdict token for the aggregation
           # job. CLEAN = passed; INFRA = environmental (#470 cancel / #771
@@ -1833,54 +1841,59 @@ jobs:
           # branch below passes a short machine reason; the aggregation job
           # prints it per shard. The reason NEVER changes severity.
           write_verdict() { bash scripts/ci-journey-write-shard-verdict.sh "$1" "${2:-unspecified}"; }
-          # Issue #1814: an attempt cut by its per-class wall cap while Gradle
-          # was still BUILDING writes `exit 124 / outer_timeout / raw-junit
-          # count=0` — byte-for-byte what a killed mid-journey runner writes. On
-          # run 30323508796 shard 2 that ambiguity sent an investigation after a
-          # healthy journey class. Read the suite's own per-attempt manifests so
-          # this shard's verdict can NAME the build-cost case instead of leaving
-          # it looking like a product defect. Reporting only: the verdict's
-          # severity is unchanged (a build that outgrows its bound is a real
-          # problem and must stay visible — softening it would be #1458-style
-          # masking in reverse).
+          # Issues #1814/#1840: read the suite's own per-attempt manifests so
+          # this shard can NAME a Gradle-BUILD-phase artefact instead of leaving
+          # it looking like a product defect. Rationale + annotation text:
+          # scripts/ci-journey-build-attribution-notice.sh (reporting only).
           build_phase_out="$(bash scripts/ci-journey-build-phase-timeout.sh artifacts 2>&1 || true)"
           printf '%s\n' "$build_phase_out" | sed 's/^/journey build-phase timeout: /'
           build_phase_attempts="$(sed -n 's/^build_phase_timeout_attempts=//p' <<<"$build_phase_out" | tail -n 1)"
           [[ "$build_phase_attempts" =~ ^[0-9]+$ ]] || build_phase_attempts=0
           build_phase_classes="$(sed -n 's/^build_phase_timeout_classes=//p' <<<"$build_phase_out" | tail -n 1)"
-          if (( build_phase_attempts > 0 )); then
-            echo "::warning title=Emulator journey — an attempt was cut during the Gradle BUILD phase (#1814)::${build_phase_attempts} attempt(s) on this shard hit their per-class wall cap while Gradle was still BUILDING: ${build_phase_classes:-<unnamed>}. Instrumentation never started, so there is no JUnit XML and the zero-test outer timeout is a BUILD-COST artefact — it is NOT evidence that the named journey is broken. The cold build is paid up front by the suite's warm-build step, so a recurrence means the build outgrew its bound; investigate the build, not the journey."
-          fi
-          # Issue #1840: the #1814 sibling one step over. A retry whose GRADLE
-          # BUILD died never started instrumentation and produced NO journey
-          # verdict, yet on run 30339688411 shard 0 it was reported as the class
-          # "failing twice" — the suite's own post-timeout `gradlew --stop`
-          # cleanup left an orphaned build process writing
-          # `kotlin-classes/debugAndroidTest`, the retry's
-          # `compileDebugAndroidTestKotlin` died clearing that directory, and a
-          # self-inflicted infra cascade was typed as a product defect. Read the
-          # suite's own per-attempt manifests so the verdict can NAME it.
-          # Reporting only: severity is unchanged (a build that cannot run is a
-          # real problem and must stay visible).
+          bash scripts/ci-journey-build-attribution-notice.sh phase \
+            "$build_phase_attempts" "$build_phase_classes"
           build_fail_out="$(bash scripts/ci-journey-build-phase-failure.sh artifacts 2>&1 || true)"
           printf '%s\n' "$build_fail_out" | sed 's/^/journey build-phase failure: /'
           build_fail_attempts="$(sed -n 's/^build_phase_failure_attempts=//p' <<<"$build_fail_out" | tail -n 1)"
           [[ "$build_fail_attempts" =~ ^[0-9]+$ ]] || build_fail_attempts=0
           build_fail_classes="$(sed -n 's/^build_phase_failure_classes=//p' <<<"$build_fail_out" | tail -n 1)"
+          bash scripts/ci-journey-build-attribution-notice.sh failure \
+            "$build_fail_attempts" "$build_fail_classes"
+          # Issue #2374: a build attribution may only speak for the classes it
+          # explains. scripts/ci-journey-genuine-journey-failure.sh's header has
+          # the run-33157272170 evidence and the #1840-preserving set subtraction.
+          genuine_out="$(bash scripts/ci-journey-genuine-journey-failure.sh \
+            "$summary" "$build_phase_classes" "$build_fail_classes" 2>&1 || true)"
+          printf '%s\n' "$genuine_out" | sed 's/^/journey genuine failure: /'
+          genuine_failure="$(sed -n 's/^genuine_journey_failure=//p' <<<"$genuine_out" | tail -n 1)"
+          [[ "$genuine_failure" == "true" ]] || genuine_failure=false
+          # Issue #2374: carry the build attribution on the token in its OWN
+          # field, INDEPENDENT of the verdict reason. Once a build attribution no
+          # longer outranks a genuine journey failure it does not name, the mixed
+          # shard writes reason=first_attempt_journey_failure — and #1814's
+          # aggregate rollup (derived from the reason) would lose the build-cost
+          # evidence entirely, leaving it only in this one shard's job log. Same
+          # precedence as verdict_reason_for: build-level subsumes build-phase.
+          SHARD_BUILD_ATTRIBUTION=none
           if (( build_fail_attempts > 0 )); then
-            echo "::warning title=Emulator journey — an attempt died at the Gradle BUILD level (#1840)::${build_fail_attempts} attempt(s) on this shard failed while Gradle was still BUILDING: ${build_fail_classes:-<unnamed>}. Instrumentation never started, so there is no JUnit XML and this attempt produced NO journey verdict — it is NOT evidence that the named journey is broken. Check the inter-attempt cleanup (an orphaned build process still writing the module build outputs makes the next build die clearing them) and the build itself, not the listed journey."
+            SHARD_BUILD_ATTRIBUTION=build_level_failure
+          elif (( build_phase_attempts > 0 )); then
+            SHARD_BUILD_ATTRIBUTION=cold_build_timeout
           fi
+          export SHARD_BUILD_ATTRIBUTION
+          echo "build attribution carried on the token: $SHARD_BUILD_ATTRIBUTION (issue #2374)"
           # verdict_reason_for <fallback> — prefer the most specific attribution
           # this shard carries, else the branch's own reason. A build-level
           # failure is checked FIRST because it explains why the shard has no
           # journey verdict at all, which subsumes a cold-build timeout earlier
-          # in the same class.
+          # in the same class — but neither build branch may outrank a genuine
+          # journey failure it does not name (#2374).
           # Issue #2143: a failure seen while the shared fixture was wedged is a
           # SETUP failure. Verdict stays RED; only the attribution changes.
           verdict_reason_for() {
-            if (( build_fail_attempts > 0 )); then
+            if (( build_fail_attempts > 0 )) && [[ "$genuine_failure" != "true" ]]; then
               printf 'build_level_failure\n'
-            elif (( build_phase_attempts > 0 )); then
+            elif (( build_phase_attempts > 0 )) && [[ "$genuine_failure" != "true" ]]; then
               printf 'cold_build_timeout\n'
             elif [[ -f "$summary" ]] && grep -q 'JOURNEY_FIXTURE_SETUP_FAILURE' "$summary"; then
               printf 'shared_fixture_setup_failure\n'
@@ -1900,27 +1913,25 @@ jobs:
           echo "cold-boot retry remaining/required: ${retry_remaining_ms:-0}/${retry_required_ms:-5400000}ms"
           echo "cold-boot retry cost model: ${retry_cost_model:-worst_case} (issue #1800)"
           echo "cold-boot retry warm-build deducted: ${retry_warm_build_deducted_ms:-0}ms (issue #1833)"
-          # Issue #1833: a shard that reaches its verdict UNABLE to start a
-          # cold-boot retry ran ONE-SHOT — half the gate's resilience is gone and
-          # a single #788-class swiftshader flake reddens `main` outright instead
-          # of recovering. On run 30383504733 all three shards were in that state
-          # and every one still reported a plain CLEAN/RED: a gate that had lost
-          # its retry looked identical to one that had not. Same principle as
-          # #1814's `outer_timeout_phase` and #1827's registry — a condition that
-          # changes what the gate CAN DO must appear in the gate's own evidence.
-          # This is REPORTING only: it never changes a verdict or an exit code,
-          # and it is stamped on the token in EVERY branch below, including the
-          # CLEAN one (where the loss is otherwise completely invisible).
+          # Issues #1833/#2374: stamp the one-shot condition on this shard's
+          # token and annotate it. Both the rationale and the annotation text
+          # live in scripts/ci-journey-retry-denial-notice.sh (reporting only —
+          # it changes no verdict, token or exit code, and always exits 0).
           [[ "$retry_shortfall_ms" =~ ^[0-9]+$ ]] || retry_shortfall_ms=0
+          SHARD_RETRY_AFFORDABLE="false"
           if [[ "${retry_allowed:-false}" == "true" ]]; then
             SHARD_RETRY_AFFORDABLE="true"
-          else
-            SHARD_RETRY_AFFORDABLE="false"
-            echo "::warning title=Emulator journey shard ran ONE-SHOT — no cold-boot retry was affordable (#1833)::This shard reached its verdict unable to start a second cold boot (reason=${retry_reason:-missing_decision}, remaining=${retry_remaining_ms:-0}ms, required=${retry_required_ms:-5400000}ms, short by ${retry_shortfall_ms}ms, cost model=${retry_cost_model:-worst_case}). The verdict below is from ONE attempt: a #788-class environmental flake here reddens the aggregate instead of flake-recovering. Reported so a gate running at half resilience is never invisible (issue #1833)."
           fi
           SHARD_RETRY_DENIED_REASON="${retry_reason:-missing_decision}"
           SHARD_RETRY_SHORTFALL_MS="$retry_shortfall_ms"
-          export SHARD_RETRY_AFFORDABLE SHARD_RETRY_DENIED_REASON SHARD_RETRY_SHORTFALL_MS
+          SHARD_RETRY_DENIAL_CLASS="${retry_denial_class:-unknown}"
+          export SHARD_RETRY_AFFORDABLE SHARD_RETRY_DENIED_REASON \
+            SHARD_RETRY_SHORTFALL_MS SHARD_RETRY_DENIAL_CLASS
+          bash scripts/ci-journey-retry-denial-notice.sh \
+            "$SHARD_RETRY_AFFORDABLE" "$SHARD_RETRY_DENIED_REASON" \
+            "$SHARD_RETRY_DENIAL_CLASS" "$SHARD_RETRY_SHORTFALL_MS" \
+            "${retry_remaining_ms:-0}" "${retry_required_ms:-5400000}" \
+            "${retry_cost_model:-worst_case}"
           # #2095: only captured provider failures with zero journeys are INFRA.
           if [[ "$first" == "skipped" ]]; then
             setup_out="$(scripts/ci-journey-fixture-retry.sh --classify artifacts/ci-journey-setup artifacts/ci-journey 2>&1 || true)"
@@ -2019,7 +2030,12 @@ jobs:
             # The emulator booted and the suite ran to a verdict: a journey class
             # failed twice. This is a GENUINE test failure (app-code regression),
             # NOT the #771 emulator-infra abort.
-            failed_classes="$(awk '/Failed BOTH attempts/{f=1; next} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
+            # Issue #2374: the same section terminator the genuine-failure
+            # helper uses. Without `f=0` at the next header this annotation
+            # reads #2355's quarantined bullets and #2143's wedged bullets as
+            # "genuine test failure" classes, i.e. names a deliberately
+            # non-blocking class as the shard's cause.
+            failed_classes="$(awk '/Failed BOTH attempts/{f=1; next} f && !/^- / && NF{f=0} f && /^- /{gsub(/`/,""); sub(/^- /,"    "); print}' "$summary" || true)"
             echo "::error title=Emulator journey FAILED — genuine test failure::A load-bearing journey class failed on BOTH cold-boot attempts AFTER the emulator booted and the suite ran to a verdict. This is a real test regression (NOT a #771 emulator-infra abort). Failing class(es):"
             [[ -n "$failed_classes" ]] && printf '%s\n' "$failed_classes"
             write_verdict RED "$(verdict_reason_for journey_failure_both_attempts)"

--- a/docs/ci-pitfalls.md
+++ b/docs/ci-pitfalls.md
@@ -189,6 +189,80 @@ that it passes under swiftshader frame timing. Run any newly-registered
 journey class on a real emulator (`scripts/connected-test.sh --suffix
 i<issue>`) before merge.
 
+## A DERIVED failure signature recurs whenever its cause does
+
+Some gate signatures are computed from the run's own measurements, so they
+reappear for any upstream cause that moves those measurements — matching on
+the string re-files the wrong issue. The emulator gate's
+`insufficient_remaining_budget` is the worked example: it is a function of
+observed suite elapsed, so it recurs whenever the suite is long, whether that
+is per-shard overload (#1833/#1850, the matrix is the lever) or genuine
+journey failures each paying two full per-class attempts (#2374, the failing
+classes are the lever). Run 33181062826 was triaged as a recurrence of #1833
+on a byte-identical string while all six shards had in fact already written a
+`Failed BOTH attempts` summary; no budget constant had moved.
+
+Before treating a repeated signature as a repeated cause, check the
+discriminator the gate emits alongside it — for this one,
+`retry_denial_class` (`gate_capacity` vs `journey_failure_inflated_suite`) on
+the shard verdict token and in the aggregate's annotations. A signature with
+no discriminator is a defect in the gate's evidence, not a mystery.
+
+## Untriggered guards: a self-test that runs nowhere proves nothing
+
+`scripts/test-*.sh` are ordinary scripts, not Gradle tests, so nothing runs
+one unless a workflow step names it. Two #2356 self-tests sat in the repo
+un-invoked by any job, and the one covering `ci-nightly-rc-mark.sh` also
+inherited the developer's ambient `~/.gitconfig` — so it never exercised the
+hosted-runner case where git has no tagger identity and `git tag -a` refuses.
+The result was a marker mechanism that had never worked and never could.
+Grep `.github/workflows/` for any self-test you rely on, and give a
+harness that depends on ambient machine state (git identity, `$HOME`, PATH
+tools, locale) an isolated environment plus a live-precondition assertion, or
+it will pass for a reason unrelated to the code.
+
+## An unterminated markdown-section scan silently annexes the next section
+
+Report parsers in the journey harness key on a header line and then read the
+`- ` bullets under it. Setting the "in section" flag on the header without ever
+CLEARING it makes the scan run to EOF, so every later section's bullets are
+read as if they were the first section's. `summary.md` keeps writing after
+`Failed BOTH attempts`: #2355's `Quarantined failures (non-blocking …)` and
+#2143's `Shared SSH/tmux fixture was WEDGED …` both follow it with bullets. An
+unterminated scan therefore reads a QUARANTINED (deliberately non-blocking)
+failure as a blocking one — re-coupling a classifier to exactly the section a
+previous issue decoupled it from, and doing it silently, because the wording
+that section avoids is the HEADER phrase, not the bullet syntax.
+
+Always clear the flag at the first non-bullet, non-blank line (`f && !/^- /
+&& NF { f = 0 }`), reduce each bullet to the identifier the consumer actually
+needs (an FQCN, not the bullet's trailing metadata), and build the fixture with
+the REAL summary writer rather than a hand-typed header — a handwritten header
+drifts out of sync with the producer and the guard then proves nothing.
+
+## A diagnostic stamp read as a verdict puts a failure heading on a GREEN run
+
+The inverse of a vacuous green: a run that passed but whose own artifact reads
+like it failed. Two individually-correct decisions compose into it. The
+emulator gate's classify step computes `SHARD_BUILD_ATTRIBUTION` *before* every
+`write_verdict` branch (so no branch can forget it), and
+`ci-journey-build-phase-timeout.sh` deliberately reads the *preserved
+attempt-1* tree (so a retry cannot hide what happened on the first attempt).
+Together they mean a shard cut mid-Gradle-build on attempt 1 whose retry then
+PASSED writes `CLEAN` + `build_attribution=cold_build_timeout`. An aggregate
+rollup keyed on the stamp alone then prints "investigate the build cost" into
+the step summary of a fully green run — the artifact a release owner reads
+before tagging `validated-rc`.
+
+Attempt-scoped evidence is not the run's outcome. Roll a diagnostic stamp up
+into a run-level notice only where it explains the FINAL verdict; leave it in
+the shard's own log otherwise, where it is still findable and cannot be
+mistaken for a cause. When adding such a branch, enumerate every
+`(verdict token x stamp value)` pair the producer can actually emit — including
+the recovered/CLEAN ones — and diff the notice count against the pre-change
+script for each; "the case I built it for changed and nothing else did" is a
+claim that needs the table, not an assumption.
+
 See also [worktrees.md](worktrees.md) for merge-mechanics pitfalls and
 [review-standards.md](review-standards.md) for reviewer-side acceptance
 bars this catalogue feeds into.

--- a/scripts/ci-journey-aggregate-verdict.sh
+++ b/scripts/ci-journey-aggregate-verdict.sh
@@ -91,6 +91,14 @@ cold_build_shards=()
 # Issue #1833: shards that reached their verdict unable to start a cold-boot
 # retry, i.e. shards whose result came from ONE attempt.
 one_shot_shards=()
+# Issue #2374: one-shot shards split by WHICH denial they were. `gate_capacity`
+# is #1833/#1850's condition and must stay loud; `journey_failure_inflated_suite`
+# is a shard whose own failing classes doubled its suite, where the budget is not
+# the lever. An unstamped/unclassifiable token belongs to neither bucket and must
+# never be counted as evidence that the capacity condition is absent.
+capacity_one_shot_shards=()
+inflated_one_shot_shards=()
+unclassified_one_shot_shards=()
 # #2095 external setup INFRA deliberately fails its shard job so GitHub's
 # failed-job retry re-runs only that shard. Its precise token reason explains
 # the otherwise-fail-closed upstream matrix failure.
@@ -165,15 +173,67 @@ if [[ -d "$verdict_dir" ]]; then
     [[ "$tok_shortfall" =~ ^[0-9]+$ ]] || tok_shortfall="?"
     tok_retry_reason="$(sed -n 's/^retry_denied_reason=//p' "$f" 2>/dev/null | head -n 1)"
     [[ -n "$tok_retry_reason" ]] || tok_retry_reason="unspecified"
+    # Issue #2374: WHICH denial. Absent on a token written before this stamp,
+    # which reads `unknown` and is bucketed as unclassified.
+    tok_denial_class="$(sed -n 's/^retry_denial_class=//p' "$f" 2>/dev/null | head -n 1)"
+    case "$tok_denial_class" in
+      none | gate_capacity | journey_failure_inflated_suite) ;;
+      *) tok_denial_class="unknown" ;;
+    esac
+    # Issue #2374: the build attribution, carried independently of the verdict
+    # reason. Absent on a token written before this stamp existed (and on any
+    # shard with no build evidence), which reads `none`.
+    tok_build_attribution="$(sed -n 's/^build_attribution=//p' "$f" 2>/dev/null | head -n 1)"
+    case "$tok_build_attribution" in
+      none | cold_build_timeout | build_level_failure) ;;
+      *) tok_build_attribution="none" ;;
+    esac
 
     provenance_line="shard ${tok_shard}: ${token} — run ${tok_run}, ${origin}, reason ${tok_reason}"
     if [[ "$tok_affordable" == "false" ]]; then
-      provenance_line+=", ONE-SHOT (no cold-boot retry affordable: ${tok_retry_reason}, short by ${tok_shortfall}ms)"
-      one_shot_shards+=("shard ${tok_shard} (${token}, short by ${tok_shortfall}ms)")
+      provenance_line+=", ONE-SHOT (no cold-boot retry affordable: ${tok_retry_reason}, short by ${tok_shortfall}ms, class ${tok_denial_class})"
+      one_shot_shards+=("shard ${tok_shard} (${token}, short by ${tok_shortfall}ms, ${tok_denial_class})")
+      case "$tok_denial_class" in
+        gate_capacity)
+          capacity_one_shot_shards+=("shard ${tok_shard} (${token}, short by ${tok_shortfall}ms)") ;;
+        journey_failure_inflated_suite)
+          inflated_one_shot_shards+=("shard ${tok_shard} (${token}, short by ${tok_shortfall}ms)") ;;
+        *)
+          unclassified_one_shot_shards+=("shard ${tok_shard} (${token}, short by ${tok_shortfall}ms)") ;;
+      esac
     fi
     provenance+=("$provenance_line")
+    # Issue #1814's rollup, kept whole across #2374's precedence change: a shard
+    # carries cold-build evidence when that IS its verdict reason, OR when the
+    # reason went to an unrelated genuine journey failure and the build evidence
+    # rode the separate `build_attribution` stamp instead. Reading only the
+    # reason is what made the notice disappear from the aggregate (and therefore
+    # from the step summary a release owner reads) in exactly the mixed shape
+    # this issue is about.
+    #
+    # The stamp branch is gated on the shard's FINAL verdict being RED, and that
+    # gate is load-bearing. The classify step computes `SHARD_BUILD_ATTRIBUTION`
+    # before EVERY write_verdict branch, and ci-journey-build-phase-timeout.sh
+    # deliberately reads the PRESERVED first-attempt tree so a retry cannot hide
+    # attempt 1's evidence. Both are right — but together they mean a shard whose
+    # attempt 1 was cut mid-Gradle-build and whose RETRY THEN PASSED writes
+    # `CLEAN` + `build_attribution=cold_build_timeout`. Keying the rollup on the
+    # stamp alone would put an "#1814 … investigate the build cost" heading on a
+    # GREEN aggregate — the artifact a release owner reads before tagging
+    # `validated-rc` — which is a fresh instance of the very misread this issue
+    # exists to remove. A shard that self-healed via its retry SUCCEEDED: its
+    # attempt-1 build hiccup is diagnostic, not a cause of any failure, and it is
+    # not lost — that shard's own unconditional `::warning … (#1814)` from
+    # ci-journey-build-attribution-notice.sh still names it in the job log. The
+    # rollup speaks only where the build cost actually contributed to a RED.
+    # The reason branch needs no such gate: `cold_build_timeout` only ever
+    # reaches a token through `verdict_reason_for`, which is called exclusively
+    # from RED branches. Pinned both ways by (c5)/(c8)/(c9) in
+    # scripts/test-ci-journey-warm-build.sh.
     if [[ "$tok_reason" == "cold_build_timeout" ]]; then
-      cold_build_shards+=("shard ${tok_shard} (${token})")
+      cold_build_shards+=("shard ${tok_shard} (${token}, verdict reason ${tok_reason})")
+    elif [[ "$tok_build_attribution" == "cold_build_timeout" && "$token" == "RED" ]]; then
+      cold_build_shards+=("shard ${tok_shard} (${token}, verdict reason ${tok_reason}, build attribution carried separately — issue #2374)")
     fi
 
     count=$((count + 1))
@@ -254,7 +314,7 @@ fi
 # investigation after a healthy journey class. The verdict's SEVERITY is
 # untouched (naming a failure is not softening it); only its readability is.
 if (( ${#cold_build_shards[@]} > 0 )); then
-  echo "::notice title=Emulator journey verdict — includes a cold-BUILD-phase timeout (#1814)::${#cold_build_shards[@]} shard verdict(s) were reported with reason 'cold_build_timeout': ${cold_build_shards[*]}. At least one attempt there hit its per-class wall cap while Gradle was still BUILDING — instrumentation never started and no JUnit XML exists, so the zero-test outer timeout is a BUILD-COST artefact, not evidence that the named journey is broken. Investigate the build cost (the cold build is paid up front by the suite's warm-build step), not the journey."
+  echo "::notice title=Emulator journey verdict — includes a cold-BUILD-phase timeout (#1814)::${#cold_build_shards[@]} shard verdict(s) carry cold-BUILD-phase evidence, either as the verdict reason or — when the same shard ALSO failed unrelated journeys (issue #2374) — on the token's separate 'build_attribution' stamp: ${cold_build_shards[*]}. At least one attempt there hit its per-class wall cap while Gradle was still BUILDING — instrumentation never started and no JUnit XML exists, so the zero-test outer timeout is a BUILD-COST artefact, not evidence that the named journey is broken. Investigate the build cost (the cold build is paid up front by the suite's warm-build step), not the journey — but where the shard's verdict reason names a genuine journey failure, that failure is a separate, real cause and is not explained by this notice."
 fi
 
 # Issue #1833: a verdict reached WITHOUT the cold-boot retry available must say
@@ -266,6 +326,20 @@ fi
 # resilience produced it.
 if (( ${#one_shot_shards[@]} > 0 )); then
   echo "::notice title=Emulator journey verdict — ${#one_shot_shards[@]} shard(s) ran ONE-SHOT, no cold-boot retry (#1833)::${one_shot_shards[*]} reached their verdict unable to start a second cold boot, so their result comes from a SINGLE attempt. The cold-boot retry is what normally absorbs a #788-class environmental flake; without it such a flake reddens this aggregate instead of recovering. Read a RED from a one-shot shard with that in mind, and read a CLEAN as having had less protection than usual."
+fi
+
+# Issue #2374: WHICH denial, because the two want opposite responses and until
+# now they shared one label. Run 33181062826's six one-shot shards were read as a
+# recurrence of #1833/#1850's capacity loss; every one of them had already failed
+# journeys, so its own suite is what ate the wall and no matrix change would have
+# helped. Both branches below are reporting only — no verdict, count or exit code
+# depends on them.
+if (( ${#capacity_one_shot_shards[@]} > 0 )); then
+  echo "::warning title=Emulator journey — ${#capacity_one_shot_shards[@]} shard(s) lost the cold-boot retry to GATE CAPACITY (#1833/#1850)::${capacity_one_shot_shards[*]} failed NO journey on their first attempt and still could not afford a second cold boot. This is the resilience loss #1833 reports and #1850 sized the matrix against: the levers are the shard count, the class distribution, and the retry-cost estimate — NOT the failing classes, because there were none. Re-check the per-leg headroom derivation in scripts/ci-journey-shard-count.sh against these shards' measured suite elapsed."
+fi
+if (( ${#inflated_one_shot_shards[@]} > 0 && ${#capacity_one_shot_shards[@]} == 0 \
+      && ${#unclassified_one_shot_shards[@]} == 0 )); then
+  echo "::notice title=Emulator journey — every ONE-SHOT shard was inflated by its OWN failing journeys, not a gate-capacity loss (#2374)::${inflated_one_shot_shards[*]} reached their verdict one-shot, but each had already written a 'Failed BOTH attempts' summary. A class that fails pays TWO full per-class attempts, so those failures are what pushed suite elapsed past what a retry could fit. This is NOT a recurrence of #1833/#1850 and no budget, shard count or cost estimate is the lever here — fix the classes each shard's own summary names. Raising a budget would buy a second hour of re-failing them and still end RED."
 fi
 
 if (( ${#carried_over[@]} > 0 )); then
@@ -305,11 +379,23 @@ emit_summary() {
       fi
       if (( ${#cold_build_shards[@]} > 0 )); then
         echo
-        echo "**Cold-build-phase timeout (issue #1814):** ${cold_build_shards[*]} — an attempt there was cut while Gradle was still BUILDING (no instrumentation, no JUnit XML). That is a build-cost artefact, not a defect in the named journey."
+        echo "**Cold-build-phase timeout (issue #1814):** ${cold_build_shards[*]} — an attempt there was cut while Gradle was still BUILDING (no instrumentation, no JUnit XML). That is a build-cost artefact, not a defect in the named journey. Where the shard's verdict reason names a genuine journey failure instead, that failure is a separate real cause this line does not explain (issue #2374)."
       fi
       if (( ${#one_shot_shards[@]} > 0 )); then
         echo
         echo "**Ran ONE-SHOT — no cold-boot retry (issue #1833):** ${one_shot_shards[*]} — these shards reached their verdict unable to start a second cold boot, so their result comes from a SINGLE attempt and a #788-class environmental flake there reddens this aggregate instead of recovering."
+      fi
+      if (( ${#capacity_one_shot_shards[@]} > 0 )); then
+        echo
+        echo "**Denial class \`gate_capacity\` (issues #1833/#1850):** ${capacity_one_shot_shards[*]} — these failed no journey and still could not retry. The lever is the matrix/estimate."
+      fi
+      if (( ${#inflated_one_shot_shards[@]} > 0 )); then
+        echo
+        echo "**Denial class \`journey_failure_inflated_suite\` (issue #2374):** ${inflated_one_shot_shards[*]} — these had already failed journeys, so their own doubled classes consumed the wall. The lever is those classes, not the retry budget."
+      fi
+      if (( ${#unclassified_one_shot_shards[@]} > 0 )); then
+        echo
+        echo "**Denial class \`unknown\`:** ${unclassified_one_shot_shards[*]} — token predates the #2374 stamp or carried no usable reading; do not read these as either condition."
       fi
     } >> "$GITHUB_STEP_SUMMARY"
   fi

--- a/scripts/ci-journey-build-attribution-notice.sh
+++ b/scripts/ci-journey-build-attribution-notice.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Issues #1814 / #1840 / #2374: emit the emulator-journey shard's Gradle-BUILD
+# attribution annotations.
+#
+# Extracted verbatim from `.github/workflows/tests.yml`'s classify step so the
+# workflow stays under scripts/check-file-size-hygiene.sh's workflow headroom —
+# that guard's own prescribed remedy, with the explanatory comments moving here
+# alongside the text they explain.
+#
+# #1814. An attempt cut by its per-class wall cap while Gradle was still
+# BUILDING writes `exit 124 / outer_timeout / raw-junit count=0` — byte-for-byte
+# what a killed mid-journey runner writes. On run 30323508796 shard 2 that
+# ambiguity sent an investigation after a healthy journey class. Naming the
+# build-cost case stops it looking like a product defect.
+#
+# #1840. The sibling one step over: a retry whose Gradle BUILD DIED never
+# started instrumentation and produced NO journey verdict, yet on run
+# 30339688411 shard 0 it was reported as the class "failing twice" — the suite's
+# post-timeout `gradlew --stop` left an orphaned build process writing
+# `kotlin-classes/debugAndroidTest`, the retry's `compileDebugAndroidTestKotlin`
+# died clearing it, and a self-inflicted infra cascade was typed as a product
+# defect.
+#
+# #2374. Both annotations still fire on their own evidence, unconditionally.
+# What changed is only who may speak for the shard's VERDICT REASON: see
+# scripts/ci-journey-genuine-journey-failure.sh. An annotation naming one class
+# must not become the whole shard's explanation when other classes genuinely
+# failed.
+#
+# Reporting only in every case: severity is unchanged (a build that outgrows its
+# bound, or cannot run at all, is a real problem that must stay visible —
+# softening it would be #1458-style masking in reverse). Always exits 0.
+#
+# Usage:
+#   ci-journey-build-attribution-notice.sh phase   ATTEMPTS CLASSES_CSV
+#   ci-journey-build-attribution-notice.sh failure ATTEMPTS CLASSES_CSV
+set -uo pipefail
+
+kind="${1:-}"
+attempts="${2:-0}"
+classes="${3:-}"
+
+[[ "$attempts" =~ ^[0-9]+$ ]] || attempts=0
+(( attempts > 0 )) || exit 0
+[[ -n "$classes" ]] || classes="<unnamed>"
+
+case "$kind" in
+  phase)
+    echo "::warning title=Emulator journey — an attempt was cut during the Gradle BUILD phase (#1814)::${attempts} attempt(s) on this shard hit their per-class wall cap while Gradle was still BUILDING: ${classes}. Instrumentation never started, so there is no JUnit XML and the zero-test outer timeout is a BUILD-COST artefact — it is NOT evidence that the named journey is broken. The cold build is paid up front by the suite's warm-build step, so a recurrence means the build outgrew its bound; investigate the build, not the journey."
+    ;;
+  failure)
+    echo "::warning title=Emulator journey — an attempt died at the Gradle BUILD level (#1840)::${attempts} attempt(s) on this shard failed while Gradle was still BUILDING: ${classes}. Instrumentation never started, so there is no JUnit XML and this attempt produced NO journey verdict — it is NOT evidence that the named journey is broken. Check the inter-attempt cleanup (an orphaned build process still writing the module build outputs makes the next build die clearing them) and the build itself, not the listed journey."
+    ;;
+  *)
+    echo "ci-journey-build-attribution-notice.sh: unknown kind '$kind'" >&2
+    ;;
+esac
+exit 0

--- a/scripts/ci-journey-genuine-journey-failure.sh
+++ b/scripts/ci-journey-genuine-journey-failure.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Issue #2374: does this shard's summary name a class that failed BOTH attempts
+# for a reason the BUILD attributions do not already explain?
+#
+# WHY. `verdict_reason_for` in .github/workflows/tests.yml's classify step
+# prefers the most specific attribution a shard carries, and #1814's
+# `cold_build_timeout` / #1840's `build_level_failure` sit at the top of that
+# order. That order is right when a build artefact is the ONLY thing the shard
+# has to say. It is wrong when the same shard also failed real journeys.
+#
+# The scheduled full-suite run 33157272170, shard 2: EIGHT journey classes ran
+# twice and were listed under `Failed BOTH attempts`, the suite hit its 4200s
+# budget, and the LAST class's two attempts were cut while Gradle was still
+# building (289s of budget left, daemons restarted after eight aborted builds).
+# The shard's verdict reason came out `cold_build_timeout` — "investigate the
+# build, not the journey" — while eight genuine product failures sat in the same
+# summary. Together with the sibling `insufficient_remaining_budget` denial that
+# is why the whole batch was triaged as a recurrence of #1814/#1833 rather than
+# as the product regressions it was.
+#
+# THE DISCRIMINATOR, and why it is not simply "the summary has a failed-both
+# section". #1840 exists precisely because a class whose Gradle BUILD died is
+# ALSO listed under `Failed BOTH attempts` — the whole point of that issue was
+# that a self-inflicted build cascade got typed as a product defect. So the test
+# is set SUBTRACTION: a genuine journey failure is a failed-both class that
+# neither build attribution names. That keeps #1814 and #1840 intact (a shard
+# whose only failed-both classes ARE the build victims still reports the build
+# reason) while stopping a build artefact from speaking for unrelated failures.
+#
+# Reporting only: this changes no verdict's severity — every case here is
+# already RED — and it always exits 0, so missing evidence degrades to `false`
+# (the pre-#2374 behaviour) rather than breaking the classifier.
+#
+# Usage:
+#   ci-journey-genuine-journey-failure.sh SUMMARY_MD \
+#     [BUILD_PHASE_CLASSES_CSV] [BUILD_FAILURE_CLASSES_CSV]
+#
+# Output (key=value on stdout):
+#   genuine_journey_failure=true|false
+#   genuine_journey_failure_classes=<comma-separated FQCNs, or empty>
+set -uo pipefail
+
+summary="${1:-}"
+build_phase_classes="${2:-}"
+build_failure_classes="${3:-}"
+
+genuine=""
+
+if [[ -n "$summary" && -f "$summary" ]]; then
+  # The `- ` bullets under the `Failed BOTH attempts` header, backticks stripped.
+  #
+  # THE SECTION MUST BE TERMINATED, not read to EOF. summary.md keeps writing
+  # after this section (scripts/ci-journey-summary-functions.sh): #2355's
+  # `Quarantined failures (non-blocking — issue #2355 / policy D36):` and #2143's
+  # `Shared SSH/tmux fixture was WEDGED during these classes …:` both follow it
+  # and both use `- ` bullets. An unterminated scan swallows them, and then:
+  #   * a QUARANTINED failure — deliberately excluded from the blocking section,
+  #     and live on main today (scripts/journey-quarantine.txt) — reads as a
+  #     genuine journey failure and flips `build_level_failure`/
+  #     `cold_build_timeout` back to a product-defect reason in exactly the
+  #     #1814/#1840 shape the subtraction below exists to preserve;
+  #   * #2355's invariant that the quarantine wording "deliberately avoids every
+  #     phrase the classifier keys on" is defeated by re-coupling this classifier
+  #     to the section that follows it.
+  # So `f` is cleared at the first non-bullet, non-blank line — i.e. at the next
+  # section's header — and only bullets INSIDE the failed-both section are read.
+  #
+  # Each bullet is also cut at its first space, so what comes out is an FQCN and
+  # never a bullet's trailing metadata. #1827's core-terminal bullets are
+  # `- `<class>` (<label> — status <X>)` and the quarantine bullets carry
+  # `(tracked: …, expires: …) — <reason>`; a class name is the only thing the
+  # set subtraction below (and the classify step's annotation) can use.
+  while IFS= read -r class; do
+    [[ -n "$class" ]] || continue
+    # A class named by either build attribution is explained by it (#1814/#1840).
+    case ",${build_phase_classes}," in *",${class},"*) continue ;; esac
+    case ",${build_failure_classes}," in *",${class},"*) continue ;; esac
+    case ",${genuine}," in *",${class},"*) continue ;; esac
+    genuine="${genuine:+$genuine,}$class"
+  done < <(
+    awk '/Failed BOTH attempts/ { f = 1; next }
+         f && !/^- / && NF       { f = 0 }
+         f && /^- / {
+           gsub(/`/, "")
+           sub(/^- /, "")
+           sub(/[[:space:]].*$/, "")
+           if (length($0)) print
+         }' "$summary" 2>/dev/null
+  )
+fi
+
+if [[ -n "$genuine" ]]; then
+  printf 'genuine_journey_failure=true\n'
+else
+  printf 'genuine_journey_failure=false\n'
+fi
+printf 'genuine_journey_failure_classes=%s\n' "$genuine"

--- a/scripts/ci-journey-retry-budget.sh
+++ b/scripts/ci-journey-retry-budget.sh
@@ -96,10 +96,46 @@
 # the matrix total from scripts/ci-journey-shard-count.sh, and requires every
 # leg's retry headroom to exceed one twice-failing class (~420s).
 #
+# Issue #2374 — a DENIAL now names WHICH condition it is.
+#
+# On 2026-08-28 all six shards on `main` reported `insufficient_remaining_budget`
+# and the run was triaged as a recurrence of #1833/#1850. It was not. Every one
+# of those shards had already written a `Failed BOTH attempts` summary: 4 to 11
+# journey classes per shard genuinely failing, each paying TWO full 420s
+# per-class attempts. That is what drove suite elapsed to 2674-4206s — LONGER
+# than the three-shard suites (1867-3017s) #1850 diagnosed as overload, on HALF
+# the classes per leg — and it is the suite elapsed the model above consumes. No
+# constant here moved; the shard's own failures ate the wall.
+#
+# The two conditions want OPPOSITE responses:
+#
+#   gate_capacity                  the shard failed NO journey and still cannot
+#                                  afford a retry. This is #1833/#1850's loss of
+#                                  resilience; the levers are the shard count,
+#                                  the class distribution, and this estimate.
+#   journey_failure_inflated_suite the shard's first attempt already failed
+#                                  journeys. Its suite is long BECAUSE of them.
+#                                  Nothing here is the lever — fix the classes.
+#                                  Tuning a budget for this case buys a second
+#                                  60-minute cold boot that re-fails the same
+#                                  classes and still ends RED.
+#
+# #1833 shipped `retry_shortfall_ms` so an operator could tell them apart by eye
+# (its own header: "denied by 224s" versus "denied by 22 minutes"). Nothing
+# CLASSIFIED on it, so the next occurrence was read as its own cause. The caller
+# already computes the discriminator — the workflow's `journey_summary` step
+# greps the first attempt's own summary for `JOURNEY_FAILED` / `Failed BOTH
+# attempts` — so this is an exact reading, not a heuristic on the shortfall.
+#
+# It is REPORTING ONLY: `retry_denial_class` is an additional output line and
+# changes no decision, no other field, and no exit code. An absent or malformed
+# reading reports `unknown` rather than guessing, because guessing either way
+# re-creates the misdiagnosis this exists to end.
+#
 # Usage:
 #   ci-journey-retry-budget.sh JOB_START_EPOCH_MS NOW_EPOCH_MS \
 #     [FIRST_ATTEMPT_START_EPOCH_MS] [FIRST_SUITE_ELAPSED_SECS] \
-#     [FIRST_WARM_BUILD_SECS]
+#     [FIRST_WARM_BUILD_SECS] [FIRST_ATTEMPT_JOURNEY_FAILURE]
 #
 # Output is GitHub-step-output-compatible key=value lines. Invalid/missing clock
 # input fails safe by denying the retry while returning success, so the workflow
@@ -124,6 +160,31 @@ RETRY_COST_MODEL="worst_case"
 # 0 whenever the warm-build reading was absent or unusable, i.e. whenever the
 # emitted requirement is #1800's unmodified one.
 RETRY_WARM_BUILD_DEDUCTED_MS=0
+# Issue #2374: which of the two denial conditions this is. `none` while the
+# retry is allowed; `unknown` when the caller supplied no usable reading of
+# whether the first attempt genuinely failed journeys.
+RETRY_DENIAL_CLASS=none
+# The caller's reading of whether the FIRST attempt already failed journeys.
+# Set once per decision; every emit path (including the malformed-clock
+# fail-safes) classifies from it, so no branch can emit an unclassified denial.
+FIRST_ATTEMPT_JOURNEY_FAILURE=""
+
+# journey_failure_denial_class <allowed> <first_attempt_journey_failure>
+#
+# Pure and total: every input maps to exactly one of the four tokens, and
+# anything the caller cannot vouch for maps to `unknown` rather than to a guess.
+journey_failure_denial_class() {
+  local allowed="$1" first_failure="${2-}"
+  if [[ "$allowed" == "true" ]]; then
+    printf 'none'
+    return 0
+  fi
+  case "$first_failure" in
+    true)  printf 'journey_failure_inflated_suite' ;;
+    false) printf 'gate_capacity' ;;
+    *)     printf 'unknown' ;;
+  esac
+}
 
 emit_decision() {
   local allowed="$1" reason="$2" remaining="$3" shortfall=0
@@ -135,6 +196,9 @@ emit_decision() {
   if [[ "$allowed" != "true" ]] && (( RETRY_REQUIRED_MS > remaining )); then
     shortfall=$((RETRY_REQUIRED_MS - remaining))
   fi
+  RETRY_DENIAL_CLASS="$(
+    journey_failure_denial_class "$allowed" "$FIRST_ATTEMPT_JOURNEY_FAILURE"
+  )"
   printf 'retry_allowed=%s\n' "$allowed"
   printf 'retry_reason=%s\n' "$reason"
   printf 'retry_remaining_ms=%s\n' "$remaining"
@@ -142,6 +206,7 @@ emit_decision() {
   printf 'retry_cost_model=%s\n' "$RETRY_COST_MODEL"
   printf 'retry_shortfall_ms=%s\n' "$shortfall"
   printf 'retry_warm_build_deducted_ms=%s\n' "$RETRY_WARM_BUILD_DEDUCTED_MS"
+  printf 'retry_denial_class=%s\n' "$RETRY_DENIAL_CLASS"
 }
 
 canonical_decimal() {
@@ -243,10 +308,19 @@ epoch_out_of_range() {
 journey_retry_budget_decision() {
   local start="${1-}" now="${2-}"
   local attempt_start="${3-}" suite_secs="${4-}" warm_secs="${5-}"
+  local first_failure="${6-}"
 
   RETRY_REQUIRED_MS="$JOURNEY_RETRY_REQUIRED_MS"
   RETRY_COST_MODEL="worst_case"
   RETRY_WARM_BUILD_DEDUCTED_MS=0
+  # Issue #2374: only the two exact tokens the caller's own summary grep can
+  # produce are accepted. Anything else — unset, empty, `TRUE`, `1`, a shell
+  # expansion that silently blanked — is an unusable reading and must classify
+  # `unknown`, never a guess in either direction.
+  case "$first_failure" in
+    true | false) FIRST_ATTEMPT_JOURNEY_FAILURE="$first_failure" ;;
+    *)            FIRST_ATTEMPT_JOURNEY_FAILURE="" ;;
+  esac
 
   if [[ -z "$start" ]]; then
     emit_decision false missing_job_start 0
@@ -325,5 +399,5 @@ journey_retry_budget_decision() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-  journey_retry_budget_decision "${1-}" "${2-}" "${3-}" "${4-}" "${5-}"
+  journey_retry_budget_decision "${1-}" "${2-}" "${3-}" "${4-}" "${5-}" "${6-}"
 fi

--- a/scripts/ci-journey-retry-denial-notice.sh
+++ b/scripts/ci-journey-retry-denial-notice.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Issues #1833 / #2374: emit the emulator-journey shard's ONE-SHOT annotation.
+#
+# Extracted from `.github/workflows/tests.yml`'s classify step so the workflow
+# stays under scripts/check-file-size-hygiene.sh's workflow headroom, which is
+# that guard's own prescribed remedy — the explanatory comments move here with
+# the code they explain rather than being deleted.
+#
+# WHY THE ANNOTATION EXISTS (#1833). A shard that reaches its verdict UNABLE to
+# start a cold-boot retry ran ONE-SHOT: half the gate's resilience is gone and a
+# single #788-class swiftshader flake reddens `main` outright instead of
+# recovering. On run 30383504733 all three shards were in that state and every
+# one still reported a plain CLEAN/RED — a gate that had lost its retry looked
+# identical to one that had not. Same principle as #1814's `outer_timeout_phase`
+# and #1827's registry: a condition that changes what the gate CAN DO must
+# appear in the gate's own evidence.
+#
+# WHY IT NOW NAMES A CLASS (#2374). `retry_affordable=false` alone proved too
+# coarse. On run 33181062826 all six shards carried it, and the batch was triaged
+# as a recurrence of #1833/#1850's capacity loss. It was not: every one of those
+# shards had already written a `Failed BOTH attempts` summary, so 4-11
+# genuinely failing classes — each paying TWO full 420s per-class attempts — are
+# what pushed suite elapsed to 2674-4206s and consumed the wall. Suites at the
+# six-shard matrix ran LONGER than the three-shard suites (1867-3017s) #1850
+# diagnosed as overload, on HALF the classes per leg. No budget constant moved.
+#
+# The two conditions want opposite responses, so the annotation says which:
+#   gate_capacity                   the shard failed NO journey and still could
+#                                   not retry — #1833/#1850's condition; the
+#                                   levers are the matrix and this estimate.
+#   journey_failure_inflated_suite  the shard's own failing classes doubled its
+#                                   suite; nothing here is the lever.
+#   unknown                         no usable reading; assume neither.
+#
+# REPORTING ONLY. This script never changes a verdict, a token or an exit code,
+# and it always exits 0 — an annotation must not be able to fail a shard.
+#
+# Usage:
+#   ci-journey-retry-denial-notice.sh AFFORDABLE REASON CLASS SHORTFALL_MS \
+#     REMAINING_MS REQUIRED_MS COST_MODEL
+set -uo pipefail
+
+affordable="${1:-false}"
+reason="${2:-missing_decision}"
+denial_class="${3:-unknown}"
+shortfall="${4:-0}"
+remaining="${5:-0}"
+required="${6:-5400000}"
+cost_model="${7:-worst_case}"
+
+[[ "$affordable" == "true" ]] && exit 0
+
+case "$denial_class" in
+  gate_capacity)
+    lever="This is #1833/#1850's condition: the shard failed NO journey and still could not retry. The levers are the shard count, the class distribution and the retry-cost estimate." ;;
+  journey_failure_inflated_suite)
+    lever="This is NOT #1833/#1850: the shard's OWN failing journeys each paid two full per-class attempts and doubled its suite. Fix the classes its summary names; no budget or shard count is the lever here (issue #2374)." ;;
+  *)
+    lever="The denial class could not be read, so treat it as neither condition until the shard's own budget evidence says which (issue #2374)." ;;
+esac
+
+echo "::warning title=Emulator journey shard ran ONE-SHOT — no cold-boot retry was affordable (#1833)::This shard reached its verdict unable to start a second cold boot (reason=${reason}, class=${denial_class}, remaining=${remaining}ms, required=${required}ms, short by ${shortfall}ms, cost model=${cost_model}). The verdict below is from ONE attempt: a #788-class environmental flake here reddens the aggregate instead of flake-recovering. ${lever}"
+exit 0

--- a/scripts/ci-journey-write-shard-verdict.sh
+++ b/scripts/ci-journey-write-shard-verdict.sh
@@ -76,6 +76,42 @@
 # start, before any budget decision exists), which is honest — at that point the
 # shard has not yet asked.
 #
+# Issue #2374 (WHICH denial): `retry_affordable=false` alone proved too coarse.
+# On run 33181062826 all six shards carried it and the batch was triaged as a
+# recurrence of #1833's capacity loss — but every one of those shards had
+# already failed journeys, so its own suite is what consumed the wall. The token
+# now also carries `retry_denial_class`:
+#
+#   gate_capacity                   #1833/#1850's condition — the shard failed
+#                                   no journey and still could not retry.
+#   journey_failure_inflated_suite  the shard's own failing classes doubled its
+#                                   suite; the budget is not the lever.
+#   none                            the retry was affordable.
+#   unknown                         no usable reading (also the value on a token
+#                                   written before this stamp existed).
+#
+# Same discipline as the reason and the affordability stamp: it NEVER changes
+# line 1, and a malformed value degrades to `unknown` instead of costing the run
+# its token.
+#
+# Issue #2374 (BUILD ATTRIBUTION, carried separately from the reason): #1814's
+# aggregate rollup ("includes a cold-BUILD-phase timeout") is derived from
+# `verdict_reason`. Once a build attribution may no longer outrank a genuine
+# journey failure it does not name, a shard that has BOTH — the run-33157272170
+# shape this issue is about — writes `verdict_reason=first_attempt_journey_failure`
+# and the build-cost evidence would DISAPPEAR from the aggregate rollup and the
+# step summary, i.e. from the artifact a release owner actually reads, while
+# surviving only in that one shard's job log. So the build attribution now rides
+# its own field:
+#
+#   none                 no build-phase / build-level attempt evidence.
+#   cold_build_timeout   #1814: an attempt was cut by the per-class wall cap
+#                        while Gradle was still BUILDING.
+#   build_level_failure  #1840: an attempt died at the Gradle BUILD level.
+#
+# It is INDEPENDENT of `verdict_reason` (a shard can carry both), it never
+# changes line 1 or any severity, and an unrecognised value degrades to `none`.
+#
 # Usage:
 #   ci-journey-write-shard-verdict.sh <CLEAN|INFRA|RED> [REASON]
 # Env:
@@ -87,6 +123,22 @@
 #                                          `unknown`
 #   SHARD_RETRY_DENIED_REASON              the budget helper's `retry_reason`
 #   SHARD_RETRY_SHORTFALL_MS               required-minus-remaining, in ms
+#   SHARD_RETRY_DENIAL_CLASS               the budget helper's
+#                                          `retry_denial_class` (issue #2374);
+#                                          any unrecognised value records
+#                                          `unknown`
+#   SHARD_BUILD_ATTRIBUTION                `cold_build_timeout` |
+#                                          `build_level_failure` (issue #2374);
+#                                          any unrecognised value, including
+#                                          unset, records `none`. DIAGNOSTIC,
+#                                          not a verdict: the classify step
+#                                          computes it before every branch from
+#                                          the PRESERVED attempt-1 tree, so a
+#                                          CLEAN shard whose retry recovered
+#                                          still carries it. Consumers must gate
+#                                          on the verdict token, not on this
+#                                          stamp alone — see the #1814 rollup in
+#                                          scripts/ci-journey-aggregate-verdict.sh.
 #   POCKETSHELL_JOURNEY_CI_SHARD_INDEX     shard index (set by the matrix)
 #   GITHUB_RUN_ID / GITHUB_RUN_ATTEMPT     provenance (set by Actions)
 #   GITHUB_OUTPUT                          when set, also exports
@@ -130,6 +182,22 @@ retry_denied_reason="${SHARD_RETRY_DENIED_REASON:-unspecified}"
 [[ "$retry_denied_reason" =~ ^[a-z][a-z0-9_]{0,63}$ ]] || retry_denied_reason="unspecified"
 retry_shortfall_ms="${SHARD_RETRY_SHORTFALL_MS:-0}"
 [[ "$retry_shortfall_ms" =~ ^[0-9]{1,18}$ ]] || retry_shortfall_ms=0
+# Issue #2374: a CLOSED set, not a free-form label. A denial class the aggregate
+# does not know how to act on is worse than none, because it would be reported
+# with the confidence of a classification.
+retry_denial_class="${SHARD_RETRY_DENIAL_CLASS:-}"
+case "$retry_denial_class" in
+  none | gate_capacity | journey_failure_inflated_suite) ;;
+  *) retry_denial_class="unknown" ;;
+esac
+# Issue #2374: likewise a CLOSED set. Fails soft to `none` — "no build evidence"
+# is the safe default because it only ever SUPPRESSES an advisory rollup notice;
+# it can never soften a verdict.
+build_attribution="${SHARD_BUILD_ATTRIBUTION:-}"
+case "$build_attribution" in
+  none | cold_build_timeout | build_level_failure) ;;
+  *) build_attribution="none" ;;
+esac
 
 if ! {
   printf '%s\n' "$verdict"
@@ -140,15 +208,17 @@ if ! {
   printf 'retry_affordable=%s\n' "$retry_affordable"
   printf 'retry_denied_reason=%s\n' "$retry_denied_reason"
   printf 'retry_shortfall_ms=%s\n' "$retry_shortfall_ms"
+  printf 'retry_denial_class=%s\n' "$retry_denial_class"
+  printf 'build_attribution=%s\n' "$build_attribution"
   printf 'written_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 } > "$out"; then
   echo "ci-journey-write-shard-verdict.sh: cannot write $out" >&2
   exit 1
 fi
 
-echo "SHARD_VERDICT=$verdict (shard $shard, run $run_id attempt $run_attempt, reason $reason, retry_affordable $retry_affordable)"
+echo "SHARD_VERDICT=$verdict (shard $shard, run $run_id attempt $run_attempt, reason $reason, retry_affordable $retry_affordable, build_attribution $build_attribution)"
 if [[ "$retry_affordable" == "false" ]]; then
-  echo "SHARD_RETRY_UNAFFORDABLE: this shard reached its verdict on ONE attempt — a cold-boot retry did not fit (${retry_denied_reason}, short by ${retry_shortfall_ms}ms) (issue #1833)"
+  echo "SHARD_RETRY_UNAFFORDABLE: this shard reached its verdict on ONE attempt — a cold-boot retry did not fit (${retry_denied_reason}, short by ${retry_shortfall_ms}ms, class ${retry_denial_class}) (issues #1833, #2374)"
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then

--- a/scripts/ci-nightly-rc-mark.sh
+++ b/scripts/ci-nightly-rc-mark.sh
@@ -59,6 +59,32 @@ if ! git cat-file -e "${SHA}^{commit}" 2>/dev/null; then
   exit 1
 fi
 
+# Issue #2374: an ANNOTATED tag is a tag OBJECT, so git needs a tagger identity
+# to write one. A GitHub hosted runner has none: actions/checkout does not set
+# `user.name`/`user.email`, and git's auto-detection produces
+# `runner@fv-az…-….(none)`, which it rejects outright:
+#
+#   fatal: unable to auto-detect email address (got 'runner@host.(none)')
+#
+# So `git tag -f -a validated-rc` below would have failed on EVERY nightly run,
+# and #2356's marker could never have been created even once the scheduled
+# full-suite went green. It has in fact never been created. Nothing caught it
+# because the only exercise of this script is a self-test that ran on a
+# developer machine, where an ambient `~/.gitconfig` identity always existed —
+# and it was never wired into a CI job at all.
+#
+# Fail-safe and narrow: `git var GIT_COMMITTER_IDENT` is git's own answer to
+# "can you form an identity right now?". When it succeeds we change NOTHING, so
+# a local run still tags as the maintainer. Only when git says it cannot do we
+# supply one, and we supply it through the COMMITTER env vars rather than
+# `-c user.email`, because env beats config — `-c` would not override a caller
+# whose identity is unusable because the env vars themselves are empty.
+if ! git var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
+  echo "git has no usable committer identity; tagging as the CI bot (issue #2374)"
+  export GIT_COMMITTER_NAME="pocketshell-ci"
+  export GIT_COMMITTER_EMAIL="pocketshell-ci@users.noreply.github.com"
+fi
+
 TIMESTAMP="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
 TAG_MESSAGE="$(

--- a/scripts/test-ci-journey-enumeration-stall.sh
+++ b/scripts/test-ci-journey-enumeration-stall.sh
@@ -370,7 +370,8 @@ CLASSIFY_EXPRESSIONS='{
   "steps.journey_retry_budget.outputs.retry_required_ms": "${CLASSIFY_steps_journey_retry_budget_outputs_retry_required_ms:-}",
   "steps.journey_retry_budget.outputs.retry_cost_model": "${CLASSIFY_steps_journey_retry_budget_outputs_retry_cost_model:-}",
   "steps.journey_retry_budget.outputs.retry_shortfall_ms": "${CLASSIFY_steps_journey_retry_budget_outputs_retry_shortfall_ms:-}",
-  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "${CLASSIFY_steps_journey_retry_budget_outputs_retry_warm_build_deducted_ms:-}"
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "${CLASSIFY_steps_journey_retry_budget_outputs_retry_warm_build_deducted_ms:-}",
+  "steps.journey_retry_budget.outputs.retry_denial_class": "${CLASSIFY_steps_journey_retry_budget_outputs_retry_denial_class:-unknown}"
 }'
 
 make_workflow_fixture() {
@@ -434,6 +435,9 @@ prepare_workflow_scripts() {
     "$SCRIPT_DIR/ci-journey-infra-signature.sh" \
     "$SCRIPT_DIR/ci-journey-infra-signature.py" \
     "$SCRIPT_DIR/ci-journey-write-shard-verdict.sh" \
+    "$SCRIPT_DIR/ci-journey-retry-denial-notice.sh" \
+    "$SCRIPT_DIR/ci-journey-build-attribution-notice.sh" \
+    "$SCRIPT_DIR/ci-journey-genuine-journey-failure.sh" \
     "$root/scripts/"
   chmod +x "$root/scripts/"*.sh
 }

--- a/scripts/test-ci-journey-infra-signature.sh
+++ b/scripts/test-ci-journey-infra-signature.sh
@@ -1573,7 +1573,8 @@ classify_expressions() {
   "steps.journey_retry_budget.outputs.retry_required_ms": "3028613",
   "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt",
   "steps.journey_retry_budget.outputs.retry_shortfall_ms": "0",
-  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0"
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0",
+  "steps.journey_retry_budget.outputs.retry_denial_class": "none"
 }
 JSONEOF
 }

--- a/scripts/test-ci-journey-pre-journey-classification.sh
+++ b/scripts/test-ci-journey-pre-journey-classification.sh
@@ -96,7 +96,8 @@ classify_expressions() {
   "steps.journey_retry_budget.outputs.retry_required_ms": "5400000",
   "steps.journey_retry_budget.outputs.retry_cost_model": "worst_case",
   "steps.journey_retry_budget.outputs.retry_shortfall_ms": "0",
-  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0"
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0",
+  "steps.journey_retry_budget.outputs.retry_denial_class": "none"
 }
 JSONEOF
 }

--- a/scripts/test-ci-journey-retry-budget.sh
+++ b/scripts/test-ci-journey-retry-budget.sh
@@ -883,7 +883,11 @@ echo
 echo "== #1833 a shard that cannot afford its retry SAYS SO =="
 
 # classify_expressions <journey-outcome> <first_timeout> <first_failure>
-#                      <retry_allowed> <retry_reason> <shortfall>
+#                      <retry_allowed> <retry_reason> <shortfall> [denial_class]
+#
+# Issue #2374: `denial_class` defaults to `unknown` — the value a shard whose
+# budget step could not classify the denial reports — so every pre-existing
+# caller keeps its exact meaning while the new cases pass a real class.
 classify_expressions() {
   cat <<JSONEOF
 {
@@ -900,7 +904,8 @@ classify_expressions() {
   "steps.journey_retry_budget.outputs.retry_required_ms": "3240868",
   "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt",
   "steps.journey_retry_budget.outputs.retry_shortfall_ms": "$6",
-  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0"
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0",
+  "steps.journey_retry_budget.outputs.retry_denial_class": "${7:-unknown}"
 }
 JSONEOF
 }
@@ -911,6 +916,9 @@ run_classify_step() {
   local ws="$1" idx="$2" expressions="$3" body="$ws/classify-step.sh"
   mkdir -p "$ws/scripts"
   cp "$WRITER" "$SCRIPT_DIR/ci-journey-build-phase-timeout.sh" \
+     "$SCRIPT_DIR/ci-journey-retry-denial-notice.sh" \
+     "$SCRIPT_DIR/ci-journey-build-attribution-notice.sh" \
+     "$SCRIPT_DIR/ci-journey-genuine-journey-failure.sh" \
      "$SCRIPT_DIR/ci-journey-enumeration-stall.sh" \
      "$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh" \
      "$SCRIPT_DIR/ci-journey-infra-signature.sh" "$SCRIPT_DIR/ci-journey-infra-signature.py" \
@@ -1382,6 +1390,308 @@ LOAD_MUTANT_MIN="$(load_model_min_margin_ms "$LOAD_MUTANT_TOTAL")"
 (( LOAD_MUTANT_MIN <= TWICE_FAILING_CLASS_MS )) \
   || fail "(aa5) G6 is not live: a tests.yml whose emulator-journey matrix is [0, 1, 2] still clears AC2 (min ${LOAD_MUTANT_MIN}ms) — (aa2) would not redden if the matrix still over-loaded a shard"
 pass "(aa5) G6: collapsing the workflow matrix to [0, 1, 2] makes shard-count return 3 and AC2 fail (min ${LOAD_MUTANT_MIN}ms)"
+
+echo
+echo "== #2374 a DENIED retry must name WHY: gate capacity vs a suite the shard's own failures inflated =="
+
+# THE RECURRENCE. On 2026-08-28 all six emulator-journey shards on `main`
+# reported `insufficient_remaining_budget` and the run was triaged as a
+# recurrence of #1833/#1850 — the gate losing its cold-boot retry to per-shard
+# LOAD. It was not. Every one of those shards had already written a
+# `Failed BOTH attempts` summary: 4-11 journey classes per shard genuinely
+# failing, each paying TWO full 420s per-class attempts, so the shard's own
+# failures are what pushed suite elapsed to 2674-4206s and consumed the wall the
+# budget model then could not find.
+#
+# The two conditions demand OPPOSITE responses — change the matrix / the
+# estimate, versus fix the failing classes and change nothing here — and until
+# this section existed the gate emitted the SAME `retry_reason` token, the same
+# ONE-SHOT warning and the same aggregate notice for both. #1833 shipped
+# `retry_shortfall_ms` so an operator could tell them apart by eye; nothing
+# CLASSIFIED on it, so the recurrence was read as its own cause. That is the
+# narrower-case-than-the-class miss D31 asks about, and this section closes it.
+#
+# The scale, for anyone tempted to tune a constant here again: the six-shard
+# matrix #1850/#2060 sized was projected to run ~1800-2300s suites. It ran
+# 2674-4206s — LONGER than the three-shard suites (1867-3017s) whose load #1850
+# diagnosed, on HALF the classes per leg. No budget constant moved. The extra
+# time is failing classes, and no shard count makes a broken product fit.
+#
+# run 33181062826 (`main` @ 9b1d784e), every shard, from its own job log:
+#   shard | remaining | required | suite s | warm s | boot ms | shortfall
+RECURRENCE_SHARDS=(
+  "0|1660148|4377400|3795|367|62200|2717252"
+  "1|2838368|3056582|2674|420|52394|218214"
+  "2|1292550|4750886|4204|405|50662|3458336"
+  "3|1316931|4789581|4205|398|60627|3472650"
+  "4|1220845|4846102|4205|339|57834|3625257"
+  "5|1272713|4792262|4206|413|66654|3519549"
+)
+
+# (ab) Every shard of the recurrence, driven through the UNCHANGED production
+#      helper, must reproduce its published remaining/required to the
+#      millisecond (so this fixture cannot quietly stop describing the run) and
+#      must classify the denial as caused by the shard's own failing classes.
+recurrence_rows=0
+for rec_row in "${RECURRENCE_SHARDS[@]}"; do
+  IFS='|' read -r rec_idx rec_remaining rec_required rec_suite rec_warm rec_boot rec_short \
+    <<<"$rec_row"
+  rec_now="$(reconstruct_now "$rec_remaining")"
+  rec_start="$(reconstruct_attempt_start "$rec_now" "$rec_suite" "$rec_boot")"
+  run_budget "$fixture_job_start" "$rec_now" "$rec_start" "$rec_suite" "$rec_warm" true
+  [[ "$(budget_field retry_remaining_ms)" == "$rec_remaining" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab/shard $rec_idx) reconstruction gives remaining=$(budget_field retry_remaining_ms), run 33181062826 logged $rec_remaining"; }
+  [[ "$(budget_field retry_required_ms)" == "$rec_required" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab/shard $rec_idx) the production model gives required=$(budget_field retry_required_ms), run 33181062826 logged $rec_required — this fixture no longer describes the recurrence"; }
+  [[ "$(budget_field retry_shortfall_ms)" == "$rec_short" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab/shard $rec_idx) shortfall=$(budget_field retry_shortfall_ms), logged $rec_short"; }
+  [[ "$(budget_field retry_reason)" == "insufficient_remaining_budget" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab/shard $rec_idx) expected the recurrence's insufficient_remaining_budget reason"; }
+  [[ "$(budget_field retry_denial_class)" == "journey_failure_inflated_suite" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab/shard $rec_idx) denial class is '$(budget_field retry_denial_class)'; a shard whose first attempt already failed journeys must not present as the #1833/#1850 capacity condition"; }
+  recurrence_rows=$((recurrence_rows + 1))
+done
+(( recurrence_rows == 6 )) || fail "(ab) drove $recurrence_rows of 6 recurrence shards"
+pass "(ab) all 6 shards of run 33181062826 reproduce their logged budget figures and classify as journey_failure_inflated_suite"
+
+# (ab2) THE CONTROL, and the non-vacuity proof. #1833's own run 30383504733 is
+#       the genuine capacity condition: shards 0 and 2 PASSED their journeys and
+#       were still denied a retry. Those must classify `gate_capacity`. Without
+#       this the classifier could answer "inflated" unconditionally and (ab)
+#       would still be green.
+CAPACITY_SHARDS=(
+  "0|2992443|2512|464|51212"
+  "2|2976238|2531|489|52256"
+)
+for cap_row in "${CAPACITY_SHARDS[@]}"; do
+  IFS='|' read -r cap_idx cap_remaining cap_suite _cap_warm cap_boot <<<"$cap_row"
+  cap_now="$(reconstruct_now "$cap_remaining")"
+  cap_start="$(reconstruct_attempt_start "$cap_now" "$cap_suite" "$cap_boot")"
+  # #1833's correction restores these two, so deny them the deduction to hold
+  # them in the denied state this case is about (that is the #1800 model, which
+  # is what actually ran on run 30383504733's own job).
+  run_budget "$fixture_job_start" "$cap_now" "$cap_start" "$cap_suite" "" false
+  [[ "$(budget_field retry_allowed)" == "false" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab2/shard $cap_idx) run 30383504733's #1800 decision was a denial"; }
+  [[ "$(budget_field retry_denial_class)" == "gate_capacity" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab2/shard $cap_idx) denial class is '$(budget_field retry_denial_class)'; a shard that failed NO journey and still cannot retry is exactly #1833's capacity loss and must stay loud"; }
+done
+pass "(ab2) run 30383504733's passing-but-denied shards still classify as gate_capacity — the two conditions are distinguishable, not one label"
+
+# (ab3) An ALLOWED retry has no denial to classify.
+run_budget "$fixture_job_start" "$((fixture_job_start + JOB_CAP_MS - 5400000))" "" "" "" true
+[[ "$(budget_field retry_allowed)" == "true" && "$(budget_field retry_denial_class)" == "none" ]] \
+  || { printf '%s\n' "$BUDGET_OUT"; fail "(ab3) an allowed retry must report retry_denial_class=none, got '$(budget_field retry_denial_class)'"; }
+pass "(ab3) an allowed retry reports retry_denial_class=none"
+
+# (ab4) FAIL-SAFE. An absent or malformed first-attempt-failure reading must
+#       report `unknown` — never guess a class. Guessing `gate_capacity` would
+#       re-file the recurrence as #1833; guessing `journey_failure_inflated_suite`
+#       would silence a real capacity loss.
+for bad_flag in "" "TRUE" "yes" "1" "maybe"; do
+  run_budget "$fixture_job_start" "$rec_now" "$rec_start" "$rec_suite" "$rec_warm" "$bad_flag"
+  [[ "$(budget_field retry_denial_class)" == "unknown" ]] \
+    || { printf '%s\n' "$BUDGET_OUT"; fail "(ab4) first-attempt-failure reading '$bad_flag' produced class '$(budget_field retry_denial_class)'; an unusable reading must be unknown"; }
+done
+# ...and an unusable reading must change NOTHING else about the decision.
+run_budget "$fixture_job_start" "$rec_now" "$rec_start" "$rec_suite" "$rec_warm"
+unflagged_out="$(grep -v '^retry_denial_class=' <<<"$BUDGET_OUT")"
+run_budget "$fixture_job_start" "$rec_now" "$rec_start" "$rec_suite" "$rec_warm" true
+[[ "$(grep -v '^retry_denial_class=' <<<"$BUDGET_OUT")" == "$unflagged_out" ]] \
+  || { printf '%s\n' "$BUDGET_OUT"; fail "(ab4) classifying the denial changed the decision itself; this is reporting only"; }
+pass "(ab4) an absent/malformed reading is unknown, and classification never alters the decision"
+
+# (ab5) THE WIRING. The workflow must hand the budget step the first-attempt
+#       failure evidence it already computes, or the classification is dead code
+#       that always reads `unknown` in CI while every case above stays green.
+grep -q 'steps.journey_summary.outputs.first_failure' "$WORKFLOW" \
+  || fail "(ab5) the workflow does not reference first_failure at all"
+awk '
+  /^      - name: Check remaining job wall before journey retry$/ { in_step = 1 }
+  in_step && /steps\.journey_summary\.outputs\.first_failure/     { found = 1 }
+  in_step && /^      - name: /                                    { if (++seen > 1) in_step = 0 }
+  END { exit(found ? 0 : 1) }
+' "$WORKFLOW" \
+  || fail "(ab5) the retry-budget step does not forward steps.journey_summary.outputs.first_failure — retry_denial_class would be 'unknown' on every real shard"
+pass "(ab5) the retry-budget step forwards the first attempt's genuine-failure evidence"
+
+# (ab6) END TO END through the real classify step and the real aggregate: the
+#       six-shard recurrence must not be reported as the #1833 capacity signal.
+ws="$warm_ws/classify-inflated"
+mkdir -p "$ws/artifacts/ci-journey"
+write_real_summary "$ws" 3795 ok 367 "com.pocketshell.app.proof.BackgroundGraceReconnectE2eTest"
+run_classify_step "$ws" 0 "$(classify_expressions failure false true false \
+  insufficient_remaining_budget 2717252 journey_failure_inflated_suite)"
+[[ "$CLASSIFY_TOKEN" == "RED" && "$CLASSIFY_RC" -ne 0 ]] \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(ab6) a genuine journey failure must stay RED/exit non-zero, got $CLASSIFY_TOKEN/exit$CLASSIFY_RC — classifying a denial never softens a verdict"; }
+grep -q '^retry_denial_class=journey_failure_inflated_suite$' "$CLASSIFY_TOKEN_FILE" \
+  || { cat "$CLASSIFY_TOKEN_FILE"; fail "(ab6) the shard token does not carry the denial class, so the aggregate cannot tell the two conditions apart"; }
+pass "(ab6) the real classify step stamps the denial class on the shard token and the verdict stays RED"
+
+# The aggregate's EXPECTED_SHARDS is DERIVED from the tokens each case actually
+# seeded, never written as a literal: these are self-contained sandboxes, and a
+# literal here would be one more place the shipped shard total could drift to
+# (scripts/check-journey-shard-literals.sh, issue #2060).
+seeded_shard_count() { find "$agg_dir" -name shard-verdict.txt | wc -l; }
+
+seed_class_token() {
+  local idx="$1" token="$2" affordable="$3" shortfall="$4" denial_class="$5"
+  local sub="$agg_dir/emulator-journey-verdict-shard-$idx"
+  mkdir -p "$sub"
+  SHARD_VERDICT_FILE="$sub/shard-verdict.txt" \
+    POCKETSHELL_JOURNEY_CI_SHARD_INDEX="$idx" \
+    GITHUB_RUN_ID=33181062826 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="" \
+    SHARD_RETRY_AFFORDABLE="$affordable" \
+    SHARD_RETRY_DENIED_REASON=insufficient_remaining_budget \
+    SHARD_RETRY_SHORTFALL_MS="$shortfall" \
+    SHARD_RETRY_DENIAL_CLASS="$denial_class" \
+    bash "$WRITER" "$token" first_attempt_journey_failure >/dev/null \
+    || fail "(ab7) writer refused a $token token for shard $idx"
+}
+
+# (ab7) The whole recurrence: six RED, one-shot, all inflated. The aggregate
+#       must say plainly that NO shard lost its retry to gate capacity, so the
+#       next reader does not re-file #1833/#1850.
+rm -rf "$agg_dir"; mkdir -p "$agg_dir"
+rec_shard_idx=0
+for rec_row in "${RECURRENCE_SHARDS[@]}"; do
+  IFS='|' read -r rec_idx _r _q _s _w _b rec_short <<<"$rec_row"
+  seed_class_token "$rec_idx" RED false "$rec_short" journey_failure_inflated_suite
+  rec_shard_idx=$((rec_shard_idx + 1))
+done
+agg_rc=0
+agg_out="$(EXPECTED_SHARDS="$(seeded_shard_count)" GITHUB_RUN_ATTEMPT=1 \
+  GITHUB_STEP_SUMMARY="$agg_dir/step-summary.md" \
+  bash "$AGG" "$agg_dir" 2>&1)" || agg_rc=$?
+[[ "$agg_rc" -eq 1 ]] && grep -q '^AGGREGATE_VERDICT=RED$' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(ab7) six RED shards must still aggregate RED/exit1"; }
+grep -q 'journey_failure_inflated_suite' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(ab7) the aggregate does not name the denial class; the recurrence still reads as #1833"; }
+grep -qi 'not a .*#1833' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(ab7) with zero gate-capacity denials the aggregate must say so explicitly — that missing sentence is what made run 33181062826 get triaged as a recurrence of #1833/#1850"; }
+grep -q 'journey_failure_inflated_suite' "$agg_dir/step-summary.md" \
+  || { cat "$agg_dir/step-summary.md"; fail "(ab7) the step summary does not carry the denial class"; }
+pass "(ab7) six inflated one-shot shards aggregate RED and are explicitly reported as NOT the #1833 capacity condition"
+
+# (ab8) The control at aggregate level: one genuine capacity denial in the batch
+#       must still raise the #1833 signal. Otherwise (ab7) could be satisfied by
+#       simply deleting the capacity alarm.
+rm -rf "$agg_dir"; mkdir -p "$agg_dir"
+seed_class_token 0 CLEAN false 224393 gate_capacity
+seed_class_token 1 RED   false 2717252 journey_failure_inflated_suite
+seed_class_token 2 CLEAN true  0 none
+agg_rc=0
+agg_out="$(EXPECTED_SHARDS="$(seeded_shard_count)" GITHUB_RUN_ATTEMPT=1 \
+  GITHUB_STEP_SUMMARY="$agg_dir/step-summary.md" \
+  bash "$AGG" "$agg_dir" 2>&1)" || agg_rc=$?
+[[ "$agg_rc" -eq 1 ]] \
+  || { printf '%s\n' "$agg_out"; fail "(ab8) a RED shard must still turn the aggregate red"; }
+grep -q 'gate_capacity' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(ab8) a genuine capacity denial must still be named — this is #1833's own alarm and it must not be lost"; }
+grep -qi 'not a .*#1833' <<<"$agg_out" \
+  && { printf '%s\n' "$agg_out"; fail "(ab8) the aggregate cleared #1833 while a shard HAD lost its retry to capacity"; }
+pass "(ab8) a batch containing one gate_capacity denial still raises the #1833 signal"
+
+# (ab9) A token written before this stamp existed must read `unknown` and be
+#       reported as neither condition — never silently bucketed into one.
+rm -rf "$agg_dir"; mkdir -p "$agg_dir/emulator-journey-verdict-shard-0"
+printf 'RED\nshard=0\nrun_id=33181062826\nrun_attempt=1\nverdict_reason=first_attempt_journey_failure\nretry_affordable=false\nretry_denied_reason=insufficient_remaining_budget\nretry_shortfall_ms=2717252\n' \
+  > "$agg_dir/emulator-journey-verdict-shard-0/shard-verdict.txt"
+agg_rc=0
+agg_out="$(EXPECTED_SHARDS="$(seeded_shard_count)" GITHUB_RUN_ATTEMPT=1 GITHUB_STEP_SUMMARY="" \
+  bash "$AGG" "$agg_dir" 2>&1)" || agg_rc=$?
+[[ "$agg_rc" -eq 1 ]] \
+  || { printf '%s\n' "$agg_out"; fail "(ab9) an unstamped RED token must still aggregate RED/exit1"; }
+grep -q 'ran ONE-SHOT' <<<"$agg_out" \
+  || { printf '%s\n' "$agg_out"; fail "(ab9) an unstamped one-shot token must still be reported as one-shot (#1833 behaviour is unchanged for old tokens)"; }
+grep -qi 'not a .*#1833' <<<"$agg_out" \
+  && { printf '%s\n' "$agg_out"; fail "(ab9) an UNCLASSIFIED denial must not be read as proof that #1833 is cleared"; }
+pass "(ab9) a token without the #2374 stamp stays one-shot, unclassified, and never clears the #1833 signal"
+
+echo
+echo "== #2374 how much of the recurrence #1850's per-shard bar actually covers =="
+
+# (ac) D31 asks whether the earlier fix covered the class or only one instance.
+#      This is the measured answer, and it has two parts.
+#
+#      PART 1 — the units. #1850 records that a shard's retry margin decays at
+#      ~2100ms per SECOND of suite growth (remaining falls 1000ms while required
+#      rises 1100ms). So a margin of N ms does NOT absorb N ms of extra suite; it
+#      absorbs N/2100 SECONDS of it. Case (aa2)'s bar compares a margin in ms
+#      against 420000 (a twice-failing class expressed as ms of CLASS time), so
+#      "every leg clears 420000ms" reads as "every leg survives one twice-failing
+#      class" while actually meaning it survives ~200s of suite growth. That is
+#      not a new defect introduced here and it is NOT fixed here — changing that
+#      bar is a matrix-sizing decision that belongs to #1850, and tightening it
+#      unilaterally would redden this guard on the shipped configuration. It is
+#      MEASURED and PINNED so it cannot stay invisible.
+#
+#      PART 2 — the conclusion #2374 needs. Whatever the bar reads as, the
+#      shipped matrix's tightest leg absorbs FAR less suite growth than the
+#      recurrence's shards carried (4 to 11 twice-failing classes each,
+#      1680-4620s). No shard count in reach closes that gap, so run 33181062826
+#      was never a per-shard-load problem and re-deriving the matrix would not
+#      have prevented it. If a future matrix ever DOES absorb the recurrence's
+#      own load, this case reddens deliberately: that conclusion would have
+#      changed and must be re-derived, not inherited.
+load_model_margin_with_extra_ms() {
+  local total="$1" idx="$2" extra_secs="$3" instr suite_secs now_ms attempt_start
+  instr="$(load_instrumentation_secs "$total" "$idx")"
+  suite_secs=$((instr + LOAD_WARM_SECS + extra_secs))
+  now_ms=$((fixture_job_start + LOAD_PRE_SUITE_MS + suite_secs * 1000))
+  attempt_start=$((now_ms - suite_secs * 1000 - LOAD_BOOT_MS))
+  run_budget "$fixture_job_start" "$now_ms" "$attempt_start" "$suite_secs" "$LOAD_WARM_SECS"
+  printf '%s' "$(( $(budget_field retry_remaining_ms) - $(budget_field retry_required_ms) ))"
+}
+
+# The tightest shipped leg, found by driving the production model — never named.
+ac_tightest_idx=0
+ac_tightest_margin=""
+for (( load_idx = 0; load_idx < LOAD_SHIPPED; load_idx++ )); do
+  load_margin="$(load_model_margin_ms "$LOAD_SHIPPED" "$load_idx")"
+  if [[ -z "$ac_tightest_margin" ]] || (( load_margin < ac_tightest_margin )); then
+    ac_tightest_margin="$load_margin"; ac_tightest_idx="$load_idx"
+  fi
+done
+
+# Binary-search the largest suite growth that leg still survives, by driving the
+# REAL helper at each candidate — nothing here assumes the decay rate.
+ac_lo=0; ac_hi=4200
+while (( ac_lo < ac_hi )); do
+  ac_mid=$(( (ac_lo + ac_hi + 1) / 2 ))
+  if (( $(load_model_margin_with_extra_ms "$LOAD_SHIPPED" "$ac_tightest_idx" "$ac_mid") > 0 )); then
+    ac_lo="$ac_mid"
+  else
+    ac_hi=$((ac_mid - 1))
+  fi
+done
+ac_absorbs_secs="$ac_lo"
+(( ac_absorbs_secs > 0 )) \
+  || fail "(ac) the shipped total=$LOAD_SHIPPED matrix's tightest leg (shard $ac_tightest_idx) absorbs no suite growth at all — it is already at its affordability crossing, which contradicts (aa2)"
+# The boundary must be live in BOTH directions, or the search proved nothing.
+(( $(load_model_margin_with_extra_ms "$LOAD_SHIPPED" "$ac_tightest_idx" "$ac_absorbs_secs") > 0 )) \
+  || fail "(ac) the located boundary ${ac_absorbs_secs}s does not actually survive — the search is not driving the production helper"
+(( $(load_model_margin_with_extra_ms "$LOAD_SHIPPED" "$ac_tightest_idx" "$((ac_absorbs_secs + 1))") <= 0 )) \
+  || fail "(ac) one second past the located boundary still survives — the boundary is not a boundary"
+
+# PART 1: the ms margin buys ~1/2100th of itself in seconds. Pinned as a band so
+# an arithmetic change in the production model surfaces here rather than silently
+# re-scaling what (aa2)'s bar means.
+ac_decay_ms_per_sec=$(( ac_tightest_margin / ac_absorbs_secs ))
+echo "  shipped total=$LOAD_SHIPPED tightest leg=$ac_tightest_idx margin=${ac_tightest_margin}ms"
+echo "    absorbs ${ac_absorbs_secs}s of suite growth (${ac_decay_ms_per_sec}ms of margin per second)"
+(( ac_decay_ms_per_sec >= 1900 && ac_decay_ms_per_sec <= 2300 )) \
+  || fail "(ac) margin decays at ${ac_decay_ms_per_sec}ms per second of suite growth; #1850 derived ~2100. The production cost model changed — re-derive #1850's headroom conclusions and (aa2)'s bar before trusting either."
+pass "(ac) the tightest shipped leg absorbs ${ac_absorbs_secs}s of suite growth; (aa2)'s ${TWICE_FAILING_CLASS_MS}ms bar is ${ac_decay_ms_per_sec}ms-per-second of margin, i.e. ~$((TWICE_FAILING_CLASS_MS / ac_decay_ms_per_sec))s of drift, not ${TWICE_FAILING_CLASS_MS}ms of it (#1850 sizing note, not changed here)"
+
+# PART 2: the recurrence's own load. Its LIGHTEST shard carried four classes
+# failing both in-suite attempts; each pays a second attempt up to the 420s
+# per-class cap.
+RECURRENCE_MIN_TWICE_FAILING_CLASSES=4
+ac_recurrence_secs=$(( RECURRENCE_MIN_TWICE_FAILING_CLASSES * (TWICE_FAILING_CLASS_MS / 1000) ))
+(( ac_absorbs_secs < ac_recurrence_secs )) \
+  || fail "(ac) the tightest shipped leg now absorbs ${ac_absorbs_secs}s, at or past the ${ac_recurrence_secs}s the recurrence's LIGHTEST shard carried. #2374's conclusion — that run 33181062826 was a product failure, not a per-shard-load failure — no longer follows from the shipped matrix and must be re-derived. If it became true by RAISING a budget rather than by re-sharding, that is exactly the constant-chasing #1833/#1850 forbid."
+pass "(ac) the shipped matrix absorbs ${ac_absorbs_secs}s of drift against the ${ac_recurrence_secs}s+ the recurrence's lightest shard carried (heaviest ~$((11 * (TWICE_FAILING_CLASS_MS / 1000)))s) — a $((ac_recurrence_secs / ac_absorbs_secs))x+ gap, so no reachable shard count would have prevented it; the lever is the failing classes"
 
 echo
 echo "ALL TESTS PASSED: scripts/test-ci-journey-retry-budget.sh"

--- a/scripts/test-ci-journey-summary-evidence.sh
+++ b/scripts/test-ci-journey-summary-evidence.sh
@@ -308,7 +308,8 @@ classify_expressions() {
   "steps.journey_retry_budget.outputs.retry_required_ms": "3028613",
   "steps.journey_retry_budget.outputs.retry_cost_model": "measured_first_attempt",
   "steps.journey_retry_budget.outputs.retry_shortfall_ms": "0",
-  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0"
+  "steps.journey_retry_budget.outputs.retry_warm_build_deducted_ms": "0",
+  "steps.journey_retry_budget.outputs.retry_denial_class": "none"
 }
 JSONEOF
 }
@@ -592,7 +593,16 @@ for entry in "${CORE_TERMINAL_PROOFS[@]}"; do
   summary="$ws/artifacts/ci-journey/summary.md"
   grep -qE 'Failed BOTH attempts' "$summary" \
     || { cat "$summary"; fail "(b/$status_var) no failed-both section was written for a proof that reddened the suite (issue #1827)"; }
-  mapfile -t bullets < <(awk '/Failed BOTH attempts/{f=1; next} f && /^- /{print}' "$summary")
+  # Issue #2374: terminate the scan at the section end, exactly as the
+  # production scans now do (scripts/ci-journey-genuine-journey-failure.sh).
+  # `summary.md` keeps writing after `Failed BOTH attempts` — #2355's quarantine
+  # section and #2143's wedged-fixture section both follow it with bullets — so
+  # an unterminated scan runs to EOF and this array silently annexes them,
+  # drifting the "exactly ONE bullet" assertion below for a reason unrelated to
+  # the proof under test.
+  mapfile -t bullets < <(awk '/Failed BOTH attempts/ { f = 1; next }
+                              f && !/^- / && NF       { f = 0 }
+                              f && /^- /              { print }' "$summary")
   # The issue's exact scenario is ONE proof failing twice — if the fixture
   # reddened several, "a section was written" would not be attributable to the
   # proof under test (G6).

--- a/scripts/test-ci-journey-warm-build.sh
+++ b/scripts/test-ci-journey-warm-build.sh
@@ -538,8 +538,13 @@ write_token() {
     bash "$WRITER" "$token" "$reason" > /dev/null \
     || fail "writer refused $token/$reason for shard $idx"
 }
+# AGG_STEP_SUMMARY (optional): where the reducer should write its
+# $GITHUB_STEP_SUMMARY block, for the cases that assert on it. Threaded through
+# this ONE helper rather than a second inline invocation, so the sandbox keeps a
+# single hardcoded shard total (scripts/check-journey-shard-literals.sh).
+AGG_STEP_SUMMARY=""
 run_agg() {
-  AGG_OUT="$(EXPECTED_SHARDS=3 GITHUB_STEP_SUMMARY="" GITHUB_RUN_ATTEMPT=1 \
+  AGG_OUT="$(EXPECTED_SHARDS=3 GITHUB_STEP_SUMMARY="$AGG_STEP_SUMMARY" GITHUB_RUN_ATTEMPT=1 \
     bash "$AGG" "$1" 2>&1)"
   AGG_RC=$?
   AGG_VERDICT="$(sed -n 's/^AGGREGATE_VERDICT=//p' <<<"$AGG_OUT" | tail -n 1)"
@@ -704,6 +709,9 @@ setup_classify_dir() {
   mkdir -p "$CLASSIFY_DIR/scripts" "$CLASSIFY_DIR/artifacts/ci-journey"
   cp "$WRITER" "$BUILD_PHASE" "$BUILD_FAILURE" \
     "$SCRIPT_DIR/ci-journey-enumeration-stall.sh" \
+    "$SCRIPT_DIR/ci-journey-retry-denial-notice.sh" \
+    "$SCRIPT_DIR/ci-journey-build-attribution-notice.sh" \
+    "$SCRIPT_DIR/ci-journey-genuine-journey-failure.sh" \
     "$SCRIPT_DIR/ci-journey-shard-signature-verdict.sh" \
     "$SCRIPT_DIR/ci-journey-infra-signature.sh" "$SCRIPT_DIR/ci-journey-infra-signature.py" \
     "$CLASSIFY_DIR/scripts/"
@@ -715,6 +723,16 @@ seed_build_phase_manifest() {
   local dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/Wedge--0123456789abcdef/attempt-1"
   mkdir -p "$dir"
   printf 'class=com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest\nprimary_classification=outer_timeout\nraw_junit_count=0\nouter_timeout_phase=build\n' \
+    > "$dir/manifest.txt"
+}
+
+# Issue #1840's sibling shape, needed by the #2374 precedence cases below: an
+# attempt whose Gradle BUILD died outright (`attempt_failure_phase=build`) rather
+# than being cut by the wall cap mid-build.
+seed_build_failure_manifest() {
+  local dir="$CLASSIFY_DIR/artifacts/ci-journey/class-attempts/app/Wedge--0123456789abcdef/attempt-2"
+  mkdir -p "$dir"
+  printf 'class=com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest\nprimary_classification=failure\nraw_junit_count=0\nattempt_failure_phase=build\n' \
     > "$dir/manifest.txt"
 }
 
@@ -753,10 +771,16 @@ run_classify() {
       bash "$CLASSIFY_BODY" 2>&1
   )"
   CLASSIFY_RC=$?
-  if grep -Fq 'ci-journey-build-phase-failure.sh: No such file or directory' \
-      <<<"$CLASSIFY_OUT"; then
+  # Issue #2374: this used to name ONE helper. The classify step's inline shell
+  # keeps being extracted into scripts/ (that is check-file-size-hygiene.sh's
+  # prescribed remedy for the workflow headroom), and a helper this sandbox does
+  # not copy then fails with a bare "No such file or directory" that this runner
+  # does NOT propagate — the body has no `-e`. So the guard now catches ANY
+  # missing scripts/ helper, not a hardcoded list that goes stale on the next
+  # extraction.
+  if grep -Eq 'scripts/[A-Za-z0-9._-]+: No such file or directory' <<<"$CLASSIFY_OUT"; then
     printf '%s\n' "$CLASSIFY_OUT"
-    fail "(x) extracted classify body could not run the production build-phase-failure helper"
+    fail "(x) the extracted classify body could not run a production scripts/ helper — add it to setup_classify_dir's copy list"
   fi
   CLASSIFY_TOKEN="$(sed -n 's/^shard_verdict=//p' "$gh")"
   CLASSIFY_REASON="$(sed -n 's/^shard_verdict_reason=//p' "$gh")"
@@ -884,6 +908,398 @@ expect_classify "cold build + budget timeout" RED cold_build_timeout 1 failure f
 setup_classify_dir; seed_summary "${CLEAN_SUMMARY[@]}"; seed_build_phase_manifest
 expect_classify "cold build + clean pass"     CLEAN passed_first_attempt 0 success '' success '' false false true
 pass "(x2) build-phase evidence renames the CAUSE of a red shard without changing its severity, and never touches a CLEAN one"
+
+# (x3) ISSUE #2374 — a build attribution may only speak for the classes it
+# NAMES. Every (x2) case above is the COHERENT shape: the one class listed under
+# `Failed BOTH attempts` IS the build-phase victim, so `cold_build_timeout` is
+# the whole truth and stays. The scheduled full-suite run 33157272170 shard 2 was
+# the incoherent shape: EIGHT unrelated journey classes failed both attempts and
+# the LAST class's attempts were cut mid-Gradle-build with 289s of budget left.
+# The shard reported `cold_build_timeout` — "investigate the build, not the
+# journey" — while eight genuine product failures sat in the same summary, and
+# the batch was triaged as a recurrence of #1814.
+BUILD_VICTIM='com.pocketshell.app.proof.MultiSessionSwitchJourneyE2eTest'
+UNRELATED_FAILURE='com.pocketshell.app.proof.ColdRestoreGoneSessionNoResurrectE2eTest'
+setup_classify_dir
+seed_summary \
+  '# Per-push CI journey suite — summary' \
+  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
+  "- \`$UNRELATED_FAILURE\`" \
+  "- \`$BUILD_VICTIM\`"
+seed_build_phase_manifest
+expect_classify "#2374 build phase + unrelated genuine failure" \
+  RED first_attempt_journey_failure 1 failure failure failure failure false true true
+expect_classify "#2374 build phase + unrelated failed both" \
+  RED journey_failure_both_attempts 1 failure failure failure failure false false true
+# The build annotation must STILL fire — the fix changes who speaks for the
+# shard's reason, never whether the build artefact is reported at all.
+grep -q 'an attempt was cut during the Gradle BUILD phase' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x3) the build-phase annotation stopped firing; #1814's evidence must survive the #2374 precedence change"; }
+grep -q "genuine_journey_failure_classes=$UNRELATED_FAILURE" <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x3) the classify step does not name which failed-both class the build attribution failed to explain"; }
+pass "(x3) #2374: a build-phase artefact no longer speaks for unrelated genuine failures, and its own annotation still fires"
+
+# (x4) THE #1840 CONTROL, and the reason the test is set SUBTRACTION rather than
+# "does the summary have a failed-both section". A class whose Gradle BUILD DIED
+# is itself listed under `Failed BOTH attempts` — that IS #1840. If the shard's
+# only failed-both class is the build victim, `build_level_failure` must survive.
+setup_classify_dir
+seed_summary \
+  '# Per-push CI journey suite — summary' \
+  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
+  "- \`$BUILD_VICTIM\`"
+seed_build_failure_manifest
+expect_classify "#1840 preserved: only the build victim failed both" \
+  RED build_level_failure 1 failure failure failure failure false false true
+pass "(x4) #1840 preserved: a shard whose only failed-both class IS the build victim still reports build_level_failure"
+
+# (x5) ...and the same shard PLUS one unrelated genuine failure must flip, or
+# (x4) would be satisfied by simply never applying the #2374 subtraction.
+setup_classify_dir
+seed_summary \
+  '# Per-push CI journey suite — summary' \
+  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
+  "- \`$BUILD_VICTIM\`" \
+  "- \`$UNRELATED_FAILURE\`"
+seed_build_failure_manifest
+expect_classify "#2374 build level + unrelated genuine failure" \
+  RED journey_failure_both_attempts 1 failure failure failure failure false false true
+grep -q 'an attempt died at the Gradle BUILD level' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x5) #1840's annotation stopped firing"; }
+pass "(x5) the subtraction is live for #1840 too: one unrelated genuine failure flips the reason while the annotation stays"
+
+# ---------------------------------------------------------------------------
+# (x6)/(x7) ISSUE #2374, ROUND 2 — the discriminator must read the failed-both
+# SECTION, not "every `- ` bullet to EOF".
+#
+# THE DEFECT THIS CLOSES. summary.md keeps writing after the failed-both
+# section: #2355's `Quarantined failures (non-blocking …)` and #2143's
+# `Shared SSH/tmux fixture was WEDGED during these classes …`, both with `- `
+# bullets. An unterminated scan reads them as failed-both classes, so a
+# QUARANTINED failure — which #2355 deliberately keeps OUT of the blocking
+# section, and which is live on `main` today — subtracts to a "genuine journey
+# failure" and flips `build_level_failure`/`cold_build_timeout` back to a
+# product-defect reason. That is #1840's own bug returning through the very
+# change that exists to preserve it, and it re-couples this classifier to the
+# section #2355 decoupled it from.
+#
+# THE FIXTURES ARE PRODUCED BY THE REAL SUMMARY WRITER, not hand-typed: a
+# handwritten section header drifts silently from
+# ci-journey-summary-functions.sh and the guard then proves nothing. Same
+# standalone-driver method as scripts/test-journey-quarantine-non-blocking.sh.
+SUMMARY_FN="$SCRIPT_DIR/ci-journey-summary-functions.sh"
+CORE_TERMINAL_FN="$SCRIPT_DIR/ci-journey-core-terminal-functions.sh"
+for required in "$SUMMARY_FN" "$CORE_TERMINAL_FN" "$SCRIPT_DIR/lib/journey-quarantine.sh"; do
+  [[ -f "$required" ]] || fail "(x6) missing required file: $required"
+done
+
+# real_summary <out.md> <quarantine-file-content|""> <wedged-csv|"">
+#              <failed-class>...
+real_summary() {
+  local out="$1" quarantine="$2" wedged_csv="$3"; shift 3
+  local -a failed=("$@") wedged=()
+  [[ -z "$wedged_csv" ]] || IFS=',' read -r -a wedged <<<"$wedged_csv"
+  local d; d="$(mktemp -d "$SANDBOX/realsummary-XXXXXX")"
+  mkdir -p "$d/artifacts/ci-journey"
+  local qfile="$d/journey-quarantine.txt"
+  printf '%s' "$quarantine" > "$qfile"
+  [[ -s "$qfile" ]] || rm -f "$qfile"
+  {
+    echo "source '$CORE_TERMINAL_FN'"
+    echo "source '$SUMMARY_FN'"
+    echo "REPO_ROOT='$REPO_ROOT'"
+    echo "POCKETSHELL_JOURNEY_QUARANTINE_FILE='$qfile'"
+    echo "SUITE_START=0; STEP_TIMEOUT_HIT=0"
+    echo "RECOVERED_CLASSES=(); PASSED_FIRST_TRY=()"
+    echo "BUDGET_TIMEOUT_CLASSES=(); BUILD_PHASE_TIMEOUT_ATTEMPTS=(); BUILD_PHASE_FAILURE_ATTEMPTS=()"
+    printf 'FIXTURE_WEDGED_CLASSES=(%s)\n' "${wedged[*]@Q}"
+    echo "EFFECTIVE_JOURNEY_CLASSES=(${failed[*]@Q})"
+    printf 'FAILED_CLASSES=(%s)\n' "${failed[*]@Q}"
+    echo "JOURNEY_CI_SHARD_INDEX=2; JOURNEY_CI_SHARD_TOTAL=$SHARD_TOTAL"
+    echo "JOURNEY_WARM_BUILD_STATUS=ok; JOURNEY_WARM_BUILD_ELAPSED=1"
+    echo "JOURNEY_STEP_BUDGET_SECS=4200"
+    echo "SUMMARY='$d/artifacts/ci-journey/summary.md'"
+    echo "ARTIFACT_DIR='$d/artifacts/ci-journey'"
+    echo "finish_ci_journey_suite"
+  } > "$d/driver.sh"
+  bash "$d/driver.sh" > "$d/run.log" 2>&1
+  [[ -f "$d/artifacts/ci-journey/summary.md" ]] \
+    || { cat "$d/run.log"; fail "(x6) the real summary writer produced no summary.md"; }
+  cp "$d/artifacts/ci-journey/summary.md" "$out"
+}
+
+QUARANTINED_CLASS='com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest'
+QUARANTINE_ROW="$(printf '%s\t#2391\t2026-08-28\t2099-01-01\ttimes out on the CI AVD\n' "$QUARANTINED_CLASS")"
+
+# (x6) build victim failed both + a QUARANTINED class also failed both.
+REAL_QUARANTINE_SUMMARY="$SANDBOX/real-summary-quarantine.md"
+real_summary "$REAL_QUARANTINE_SUMMARY" "$QUARANTINE_ROW" "" \
+  "$BUILD_VICTIM" "$QUARANTINED_CLASS"
+# Non-vacuity: the fixture MUST actually contain both sections, or (x6) would
+# pass by simply never exercising the bug.
+grep -q '^Failed BOTH attempts' "$REAL_QUARANTINE_SUMMARY" \
+  || { cat "$REAL_QUARANTINE_SUMMARY"; fail "(x6) fixture has no failed-both section"; }
+grep -q '^Quarantined failures' "$REAL_QUARANTINE_SUMMARY" \
+  || { cat "$REAL_QUARANTINE_SUMMARY"; fail "(x6) fixture has no #2355 quarantine section — it cannot reproduce the defect"; }
+grep -q -- "- \`$QUARANTINED_CLASS\` (tracked:" "$REAL_QUARANTINE_SUMMARY" \
+  || { cat "$REAL_QUARANTINE_SUMMARY"; fail "(x6) the quarantine bullet is not in the real writer's shape"; }
+
+# The helper, driven directly: the quarantined bullet must not be read at all.
+GENUINE_OUT="$(bash "$SCRIPT_DIR/ci-journey-genuine-journey-failure.sh" \
+  "$REAL_QUARANTINE_SUMMARY" "" "$BUILD_VICTIM" 2>&1)"
+grep -qx 'genuine_journey_failure=false' <<<"$GENUINE_OUT" \
+  || { printf '%s\n' "$GENUINE_OUT"; fail "(x6) a QUARANTINED failure was read as a genuine journey failure — the scan is not terminated at the section end"; }
+grep -qx 'genuine_journey_failure_classes=' <<<"$GENUINE_OUT" \
+  || { printf '%s\n' "$GENUINE_OUT"; fail "(x6) the quarantine section leaked into genuine_journey_failure_classes"; }
+
+# ...and through the REAL classify body: #1840's and #1814's reasons survive.
+setup_classify_dir
+cp "$REAL_QUARANTINE_SUMMARY" "$CLASSIFY_DIR/artifacts/ci-journey/summary.md"
+seed_build_failure_manifest
+expect_classify "#2374 build level + quarantined failure" \
+  RED build_level_failure 1 failure failure failure failure false false true
+# The failed-both branch's OWN `Failing class(es):` annotation reads the same
+# section with the same awk. It must not name the quarantined class either —
+# that would print a deliberately non-blocking class as this shard's cause.
+grep -q 'genuine test failure' <<<"$CLASSIFY_OUT" \
+  || { printf '%s\n' "$CLASSIFY_OUT"; fail "(x6) the failed-both annotation did not fire, so its class list is untested"; }
+if grep -q "$QUARANTINED_CLASS" <<<"$CLASSIFY_OUT"; then
+  printf '%s\n' "$CLASSIFY_OUT"
+  fail "(x6) the classify step's 'Failing class(es)' annotation names a QUARANTINED class as the genuine cause"
+fi
+setup_classify_dir
+cp "$REAL_QUARANTINE_SUMMARY" "$CLASSIFY_DIR/artifacts/ci-journey/summary.md"
+seed_build_phase_manifest
+expect_classify "#2374 build phase + quarantined failure" \
+  RED cold_build_timeout 1 failure failure failure failure false true true
+pass "(x6) #2374: a QUARANTINED failing class (live on main today) never counts as a genuine journey failure — #1814/#1840 attribution preserved"
+
+# (x7) the same for #2143's fixture-wedged section, which also follows the
+# failed-both section with `- ` bullets. The wedged class here is NOT the build
+# victim, so an unterminated scan would leak it as an unrelated genuine failure.
+WEDGED_ONLY_CLASS='com.pocketshell.app.tmux.TmuxWedgeVictimDockerTest'
+REAL_WEDGED_SUMMARY="$SANDBOX/real-summary-wedged.md"
+real_summary "$REAL_WEDGED_SUMMARY" "" "$WEDGED_ONLY_CLASS" "$BUILD_VICTIM"
+grep -q '^Shared SSH/tmux fixture was WEDGED during these classes' "$REAL_WEDGED_SUMMARY" \
+  || { cat "$REAL_WEDGED_SUMMARY"; fail "(x7) fixture has no #2143 wedged section — it cannot reproduce the defect"; }
+GENUINE_OUT="$(bash "$SCRIPT_DIR/ci-journey-genuine-journey-failure.sh" \
+  "$REAL_WEDGED_SUMMARY" "" "$BUILD_VICTIM" 2>&1)"
+grep -qx 'genuine_journey_failure=false' <<<"$GENUINE_OUT" \
+  || { printf '%s\n' "$GENUINE_OUT"; fail "(x7) #2143's wedged section was read as a genuine journey failure"; }
+setup_classify_dir
+cp "$REAL_WEDGED_SUMMARY" "$CLASSIFY_DIR/artifacts/ci-journey/summary.md"
+seed_build_failure_manifest
+expect_classify "#2374 build level + #2143 wedged section" \
+  RED build_level_failure 1 failure failure failure failure false false true
+pass "(x7) #2374: #2143's wedged section never counts as a genuine journey failure either — the class is closed, not the one instance"
+
+# (x8) THE NON-VACUITY CONTROL for (x6)/(x7): the terminator must not have been
+# implemented by simply never reading anything. A REAL summary whose failed-both
+# section names an unrelated class the build attribution does not explain must
+# still flip the reason — and the class it reports must be a bare FQCN, not a
+# bullet's trailing metadata.
+REAL_MIXED_SUMMARY="$SANDBOX/real-summary-mixed.md"
+real_summary "$REAL_MIXED_SUMMARY" "$QUARANTINE_ROW" "" \
+  "$BUILD_VICTIM" "$UNRELATED_FAILURE" "$QUARANTINED_CLASS"
+GENUINE_OUT="$(bash "$SCRIPT_DIR/ci-journey-genuine-journey-failure.sh" \
+  "$REAL_MIXED_SUMMARY" "" "$BUILD_VICTIM" 2>&1)"
+grep -qx 'genuine_journey_failure=true' <<<"$GENUINE_OUT" \
+  || { printf '%s\n' "$GENUINE_OUT"; fail "(x8) the terminator swallowed a real unrelated failure — the fix would be vacuous"; }
+grep -qx "genuine_journey_failure_classes=$UNRELATED_FAILURE" <<<"$GENUINE_OUT" \
+  || { printf '%s\n' "$GENUINE_OUT"; fail "(x8) genuine_journey_failure_classes is not exactly the one unrelated FQCN"; }
+setup_classify_dir
+cp "$REAL_MIXED_SUMMARY" "$CLASSIFY_DIR/artifacts/ci-journey/summary.md"
+seed_build_failure_manifest
+expect_classify "#2374 build level + quarantined + one unrelated failure" \
+  RED journey_failure_both_attempts 1 failure failure failure failure false false true
+pass "(x8) with a quarantined class AND an unrelated genuine failure in the same real summary, only the unrelated FQCN is reported and the reason still flips"
+
+# (x9) #1827's core-terminal bullets carry `(<label> — status <X>)` after the
+# class. They belong to the failed-both section and must still count, but what
+# is REPORTED must be the FQCN alone — the set subtraction below is a name
+# comparison and a bullet's metadata can never match a build attribution's CSV.
+CORE_BULLET_SUMMARY="$SANDBOX/core-bullet-summary.md"
+{
+  echo '# Per-push CI journey suite — summary'
+  echo
+  echo 'Failed BOTH attempts (`JOURNEY_FAILED` — job red):'
+  echo "- \`$BUILD_VICTIM\` (surface repaint proof — status FAIL)"
+} > "$CORE_BULLET_SUMMARY"
+GENUINE_OUT="$(bash "$SCRIPT_DIR/ci-journey-genuine-journey-failure.sh" \
+  "$CORE_BULLET_SUMMARY" "" "$BUILD_VICTIM" 2>&1)"
+grep -qx 'genuine_journey_failure=false' <<<"$GENUINE_OUT" \
+  || { printf '%s\n' "$GENUINE_OUT"; fail "(x9) a bullet's trailing metadata defeated the #1814/#1840 name subtraction"; }
+pass "(x9) a failed-both bullet is reduced to its FQCN, so the #1814/#1840 subtraction still matches"
+
+# ---------------------------------------------------------------------------
+# (c5) ISSUE #2374 — #1814's AGGREGATE rollup must survive the precedence change.
+#
+# `verdict_reason_for`'s output IS the token's `verdict_reason`, and (c1) shows
+# the aggregate derives its cold-build rollup from that field. So the moment a
+# build attribution stops outranking an unrelated genuine failure, the mixed
+# shard writes `verdict_reason=first_attempt_journey_failure` and #1814's
+# evidence VANISHES from the aggregate and the step summary — the artifact a
+# release owner reads — surviving only in that one shard's job log. The
+# attribution therefore rides its own `build_attribution` token field.
+echo
+echo "== #2374 the build attribution survives in the aggregate (issue #1814 rollup) =="
+
+# End to end: the token used here is the one the REAL classify body just wrote
+# for the mixed shape, not a hand-written one.
+setup_classify_dir
+seed_summary \
+  '# Per-push CI journey suite — summary' \
+  'Failed BOTH attempts (`JOURNEY_FAILED` — job red):' \
+  "- \`$UNRELATED_FAILURE\`" \
+  "- \`$BUILD_VICTIM\`"
+seed_build_phase_manifest
+expect_classify "#2374 mixed shard for the aggregate" \
+  RED first_attempt_journey_failure 1 failure failure failure failure false true true
+grep -qx 'build_attribution=cold_build_timeout' "$CLASSIFY_DIR/shard-verdict.txt" \
+  || { cat "$CLASSIFY_DIR/shard-verdict.txt"; fail "(c5) the mixed shard's token does not carry the build attribution separately"; }
+d="$SANDBOX/verdicts-mixed"; rm -rf "$d"; mkdir -p "$d/emulator-journey-verdict-shard-2"
+cp "$CLASSIFY_DIR/shard-verdict.txt" "$d/emulator-journey-verdict-shard-2/shard-verdict.txt"
+write_token "$d" 0 CLEAN passed_first_attempt
+write_token "$d" 1 CLEAN passed_first_attempt
+STEP_SUMMARY_FILE="$SANDBOX/step-summary-mixed.md"; : > "$STEP_SUMMARY_FILE"
+AGG_STEP_SUMMARY="$STEP_SUMMARY_FILE"
+run_agg "$d"
+AGG_STEP_SUMMARY=""
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c5) the mixed shape must stay RED/exit1, got $AGG_VERDICT/exit$AGG_RC"; }
+COLD_NOTICES="$(grep -c 'includes a cold-BUILD-phase timeout' <<<"$AGG_OUT")"
+[[ "$COLD_NOTICES" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c5) build-phase evidence + an unrelated genuine failure produced $COLD_NOTICES #1814 rollup notice(s), expected 1 — the release owner's artifact lost the build-cost evidence"; }
+grep -q 'Cold-build-phase timeout (issue #1814)' "$STEP_SUMMARY_FILE" \
+  || { cat "$STEP_SUMMARY_FILE"; fail "(c5) the STEP SUMMARY lost the #1814 line for the mixed shape"; }
+# The reason is still the genuine failure — the fix restores the evidence, it
+# does not restore the misattribution.
+grep -q 'shard 2: RED .*reason first_attempt_journey_failure' <<<"$AGG_OUT" \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c5) the aggregate no longer reports the genuine-failure reason"; }
+pass "(c5) #2374: a mixed build-artefact + genuine-failure shard keeps BOTH — #1814's rollup notice and step-summary line survive, and the verdict reason still names the real failure"
+
+# (c6) ...and the notice is still MEANINGFUL: a shard with no build evidence at
+# all must not acquire one. (c2) pins the legacy/unstamped path; this pins the
+# explicitly-stamped `none`.
+d="$SANDBOX/verdicts-no-build"; rm -rf "$d"; mkdir -p "$d/emulator-journey-verdict-shard-2"
+setup_classify_dir; seed_summary "${FAILED_BOTH_SUMMARY[@]}"
+expect_classify "#2374 no build evidence at all" \
+  RED first_attempt_journey_failure 1 failure failure failure failure false true true
+grep -qx 'build_attribution=none' "$CLASSIFY_DIR/shard-verdict.txt" \
+  || { cat "$CLASSIFY_DIR/shard-verdict.txt"; fail "(c6) a shard with no build evidence must stamp build_attribution=none"; }
+cp "$CLASSIFY_DIR/shard-verdict.txt" "$d/emulator-journey-verdict-shard-2/shard-verdict.txt"
+write_token "$d" 0 CLEAN passed_first_attempt
+write_token "$d" 1 CLEAN passed_first_attempt
+run_agg "$d"
+if grep -q 'includes a cold-BUILD-phase timeout' <<<"$AGG_OUT"; then
+  printf '%s\n' "$AGG_OUT"
+  fail "(c6) the #1814 rollup fired for a shard with no build evidence — the label would be meaningless"
+fi
+[[ "$AGG_VERDICT" == "RED" && "$AGG_RC" -eq 1 ]] \
+  || fail "(c6) severity changed: got $AGG_VERDICT/exit$AGG_RC"
+pass "(c6) the rollup stays meaningful: an explicitly stamped build_attribution=none never produces the #1814 notice"
+
+# (c7) the new field fails SOFT, exactly like the reason and the denial class: a
+# malformed stamp degrades to `none` and never costs the shard its token.
+d="$SANDBOX/verdicts-bad-attribution"; rm -rf "$d"; mkdir -p "$d/out"
+SHARD_VERDICT_FILE="$d/out/shard-verdict.txt" POCKETSHELL_JOURNEY_CI_SHARD_INDEX=0 \
+  GITHUB_RUN_ID=1 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="$d/out/gh.txt" \
+  SHARD_BUILD_ATTRIBUTION='Not A Class!' \
+  bash "$WRITER" RED first_attempt_journey_failure > /dev/null \
+  || fail "(c7) a malformed build attribution must not fail the write"
+grep -qx 'build_attribution=none' "$d/out/shard-verdict.txt" \
+  || fail "(c7) a malformed build attribution must degrade to 'none'"
+grep -qx 'shard_verdict=RED' "$d/out/gh.txt" \
+  || fail "(c7) the RED gate output must survive a malformed build attribution"
+[[ "$(head -n1 "$d/out/shard-verdict.txt")" == "RED" ]] \
+  || fail "(c7) line 1 must stay the bare verdict token"
+pass "(c7) a malformed build_attribution degrades to 'none' and never costs the token"
+
+# (c8) ISSUE #2374 — the rollup must not leak onto a GREEN run.
+#
+# `SHARD_BUILD_ATTRIBUTION` is computed and exported BEFORE every write_verdict
+# branch, and scripts/ci-journey-build-phase-timeout.sh deliberately reads the
+# PRESERVED first-attempt tree so a retry cannot hide what happened on attempt 1.
+# Both are correct on their own — but together they mean a shard whose attempt 1
+# was cut mid-Gradle-build and whose RETRY THEN PASSED writes
+# `CLEAN` + `build_attribution=cold_build_timeout`. If the rollup keys on the
+# attribution alone, that green shard puts an "#1814 … Investigate the build
+# cost" heading into the aggregate and into the step summary a release owner
+# reads before tagging `validated-rc` — a fresh instance of exactly the misread
+# this issue exists to remove, on the good case.
+#
+# The attribution is DIAGNOSTIC, not a verdict: a shard that self-healed via its
+# retry succeeded. So the rollup fires only where the build cost actually
+# contributed to a RED outcome. The evidence is not lost — the shard's own
+# `::warning … (#1814)` from ci-journey-build-attribution-notice.sh still fires
+# on its own evidence, unconditionally, in that shard's job log.
+d="$SANDBOX/verdicts-clean-recovered"; rm -rf "$d"
+mkdir -p "$d/emulator-journey-verdict-shard-2"
+setup_classify_dir
+seed_summary "${CLEAN_SUMMARY[@]}"
+seed_build_phase_manifest
+expect_classify "#2374 build-phase evidence on attempt 1, retry PASSED" \
+  CLEAN infra_flake_recovered 0 failure success failure success false false true
+# Non-vacuity: this case is worthless unless the token really does carry the
+# attribution on a CLEAN verdict. Assert the shape before asserting the rollup.
+grep -qx 'build_attribution=cold_build_timeout' "$CLASSIFY_DIR/shard-verdict.txt" \
+  || { cat "$CLASSIFY_DIR/shard-verdict.txt"; fail "(c8) the fixture does not reproduce the scenario — a recovered shard's token carries no build attribution, so this case proves nothing"; }
+cp "$CLASSIFY_DIR/shard-verdict.txt" "$d/emulator-journey-verdict-shard-2/shard-verdict.txt"
+write_token "$d" 0 CLEAN passed_first_attempt
+write_token "$d" 1 CLEAN passed_first_attempt
+STEP_SUMMARY_FILE="$SANDBOX/step-summary-clean-recovered.md"; : > "$STEP_SUMMARY_FILE"
+AGG_STEP_SUMMARY="$STEP_SUMMARY_FILE"
+run_agg "$d"
+AGG_STEP_SUMMARY=""
+[[ "$AGG_VERDICT" == "CLEAN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c8) a recovered shard must keep the aggregate CLEAN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+COLD_NOTICES="$(grep -c 'includes a cold-BUILD-phase timeout' <<<"$AGG_OUT")"
+[[ "$COLD_NOTICES" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c8) a CLEAN shard whose retry recovered fired $COLD_NOTICES #1814 rollup notice(s), expected 0 — a GREEN run's aggregate now carries an 'investigate the build cost' heading"; }
+if grep -q 'Cold-build-phase timeout (issue #1814)' "$STEP_SUMMARY_FILE"; then
+  cat "$STEP_SUMMARY_FILE"
+  fail "(c8) the GREEN run's STEP SUMMARY — the artifact a release owner reads before tagging validated-rc — gained an #1814 build-cost heading"
+fi
+pass "(c8) #2374: a shard whose attempt-1 build hiccup was RECOVERED by its retry never puts an #1814 rollup on the GREEN aggregate"
+
+# (c9) the (c8) gate must be the VERDICT, not the absence of evidence: an INFRA
+# shard carrying the same attribution is also not a build-cost RED and must stay
+# silent, while (c5)'s RED shape — re-asserted here from an independently written
+# token — still fires. Without this pair, (c8) could be satisfied by deleting the
+# rollup outright and (c5) alone would not notice the difference between "fires
+# on RED" and "fires on anything not CLEAN".
+d="$SANDBOX/verdicts-infra-attribution"; rm -rf "$d"; mkdir -p "$d/out"
+SHARD_VERDICT_FILE="$d/out/shard-verdict.txt" POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2 \
+  GITHUB_RUN_ID=30323508796 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="" \
+  SHARD_BUILD_ATTRIBUTION=cold_build_timeout \
+  bash "$WRITER" INFRA attempt_cancelled > /dev/null \
+  || fail "(c9) the writer refused an INFRA token carrying a build attribution"
+mkdir -p "$d/emulator-journey-verdict-shard-2"
+cp "$d/out/shard-verdict.txt" "$d/emulator-journey-verdict-shard-2/shard-verdict.txt"
+write_token "$d" 0 CLEAN passed_first_attempt
+write_token "$d" 1 CLEAN passed_first_attempt
+run_agg "$d"
+[[ "$AGG_VERDICT" == "RE-RUN" && "$AGG_RC" -eq 0 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c9) an INFRA shard must stay RE-RUN/exit0, got $AGG_VERDICT/exit$AGG_RC"; }
+if grep -q 'includes a cold-BUILD-phase timeout' <<<"$AGG_OUT"; then
+  printf '%s\n' "$AGG_OUT"
+  fail "(c9) an environmental INFRA shard fired the #1814 build-cost rollup — that verdict is a re-run signal, not a build-cost failure"
+fi
+d="$SANDBOX/verdicts-red-attribution"; rm -rf "$d"; mkdir -p "$d/out"
+SHARD_VERDICT_FILE="$d/out/shard-verdict.txt" POCKETSHELL_JOURNEY_CI_SHARD_INDEX=2 \
+  GITHUB_RUN_ID=30323508796 GITHUB_RUN_ATTEMPT=1 GITHUB_OUTPUT="" \
+  SHARD_BUILD_ATTRIBUTION=cold_build_timeout \
+  bash "$WRITER" RED first_attempt_journey_failure > /dev/null \
+  || fail "(c9) the writer refused a RED token carrying a build attribution"
+mkdir -p "$d/emulator-journey-verdict-shard-2"
+cp "$d/out/shard-verdict.txt" "$d/emulator-journey-verdict-shard-2/shard-verdict.txt"
+write_token "$d" 0 CLEAN passed_first_attempt
+write_token "$d" 1 CLEAN passed_first_attempt
+run_agg "$d"
+COLD_NOTICES="$(grep -c 'includes a cold-BUILD-phase timeout' <<<"$AGG_OUT")"
+[[ "$COLD_NOTICES" -eq 1 ]] \
+  || { printf '%s\n' "$AGG_OUT"; fail "(c9) a RED shard carrying the attribution produced $COLD_NOTICES #1814 notice(s), expected 1 — (c8)'s gate deleted the rollup instead of scoping it"; }
+pass "(c9) the #1814 rollup keys on a genuinely RED verdict: INFRA stays silent, RED still fires"
 
 echo
 echo "ALL TESTS PASSED: scripts/test-ci-journey-warm-build.sh"

--- a/scripts/test-ci-nightly-rc-mark.sh
+++ b/scripts/test-ci-nightly-rc-mark.sh
@@ -71,4 +71,68 @@ tag_count="$(git -C "$SANDBOX/repo" tag -l 'validated-rc' | wc -l | tr -d ' ')"
 [[ "$tag_count" -eq 1 ]] || fail "expected exactly one validated-rc tag, found $tag_count"
 pass "second mark force-moves validated-rc (one moving pointer, not two tags)"
 
+# --- issue #2374: the marker must be creatable with NO ambient git identity ---
+#
+# THE GAP THIS CLOSES. Every case above inherits the running user's
+# `~/.gitconfig`, so `git tag -a` always had a tagger. A GitHub hosted runner
+# does not: actions/checkout sets no `user.name`/`user.email` and git rejects its
+# own auto-detected `runner@host.(none)`. `record-validated-rc` would therefore
+# have failed on every nightly run — and #2356's marker has in fact never been
+# created once. This case runs the real script in an environment where git can
+# form no identity at all.
+#
+# The precondition is PROVEN LIVE first: a bare `git tag -a` in the same
+# environment must fail. Without that, a host whose git CAN auto-detect an
+# identity would make this case pass vacuously, which is exactly how the gap
+# survived in the first place.
+noident_home="$SANDBOX/noident-home"
+mkdir -p "$noident_home"
+# GIT_CONFIG_NOSYSTEM drops /etc/gitconfig; the empty HOME drops ~/.gitconfig;
+# the empty COMMITTER vars defeat auto-detection on ANY host, so the failure is
+# reproducible everywhere rather than only where the hostname has no domain.
+noident_env=(
+  env -i
+  "PATH=$PATH"
+  "HOME=$noident_home"
+  GIT_CONFIG_NOSYSTEM=1
+  GIT_COMMITTER_NAME=
+  GIT_COMMITTER_EMAIL=
+)
+if (cd "$SANDBOX/repo" && "${noident_env[@]}" git tag -f -a ident-probe "$sha_a" -m probe) >/dev/null 2>&1; then
+  git -C "$SANDBOX/repo" tag -d ident-probe >/dev/null 2>&1 || true
+  fail "the no-identity precondition is not reproducible on this host — a bare 'git tag -a' succeeded, so the #2374 case below would pass vacuously"
+fi
+pass "#2374 precondition is live: a bare annotated 'git tag -a' fails with no git identity"
+
+git -C "$SANDBOX/repo" tag -d validated-rc >/dev/null 2>&1 || true
+git -C "$SANDBOX/repo" push --quiet --delete origin validated-rc >/dev/null 2>&1 || true
+noident_log="$SANDBOX/noident.log"
+if ! (cd "$SANDBOX/repo" && "${noident_env[@]}" bash "$TARGET" \
+        --sha "$sha_a" --run-url "https://example/run/3") > "$noident_log" 2>&1; then
+  cat "$noident_log"
+  fail "#2374: ci-nightly-rc-mark.sh cannot record the marker without an ambient git identity — this is what blocks record-validated-rc on every hosted runner"
+fi
+noident_resolved="$(git -C "$SANDBOX/repo" rev-list -n1 validated-rc)"
+[[ "$noident_resolved" == "$sha_a" ]] \
+  || fail "#2374: validated-rc does not resolve to the requested SHA after an identity-less run (got $noident_resolved)"
+noident_clone="$SANDBOX/clone-noident"
+git clone --quiet "$SANDBOX/remote.git" "$noident_clone"
+git -C "$noident_clone" fetch --quiet --tags origin
+[[ "$(git -C "$noident_clone" rev-list -n1 validated-rc)" == "$sha_a" ]] \
+  || fail "#2374: the identity-less run did not push validated-rc to origin"
+pass "#2374 the marker is created and pushed with no ambient git identity (the hosted-runner case)"
+
+# The fallback must be NARROW: a caller that HAS an identity keeps it, so a
+# local `--dry-run`/manual mark is still attributable to the person who ran it.
+git -C "$SANDBOX/repo" tag -d validated-rc >/dev/null 2>&1 || true
+git -C "$SANDBOX/repo" push --quiet --delete origin validated-rc >/dev/null 2>&1 || true
+( cd "$SANDBOX/repo" && GIT_COMMITTER_NAME="Real Person" \
+    GIT_COMMITTER_EMAIL="real@example.com" \
+    bash "$TARGET" --sha "$sha_b" --run-url "https://example/run/4" >/dev/null ) \
+  || fail "#2374: the script failed for a caller that DOES have an identity"
+tagger="$(git -C "$SANDBOX/repo" for-each-ref --format='%(taggeremail)' refs/tags/validated-rc)"
+[[ "$tagger" == "<real@example.com>" ]] \
+  || fail "#2374: the CI fallback overrode a caller's real identity (tagger $tagger); it must only apply when git has none"
+pass "#2374 a caller with a real git identity keeps it — the fallback is narrow"
+
 echo "ALL $pass_count CHECKS PASSED"


### PR DESCRIPTION
Part of #2374 — does NOT close it (AC3, the journey lane actually going green, is explicitly not met and cannot be from this slice; the lane stays red until #2377/#2380/#2381/#2388-2394's real product regressions are fixed).

Root-caused the recurring "insufficient_remaining_budget / cold_build_timeout" emulator-journey-lane red: nothing regressed in the #1833/#1814 budget constants (byte-identical). The signatures are derived purely from observed suite elapsed, so they recur for ANY cause that inflates duration — this time 4-11 genuinely failing journey classes per shard, each paying two full retry attempts, correlating with #2356's tag-derived versioning (see #2381).

## Changes

- **validated-rc fix**: `scripts/ci-nightly-rc-mark.sh` could never create the `validated-rc` tag on a hosted runner — `git tag -a` has no tagger identity there. This was the actual reason the "release in one hour" fast path had never fired despite shipping.
- **`retry_denial_class`** (`gate_capacity` vs `journey_failure_inflated_suite`) threaded through the shard token and aggregate, so a genuine capacity denial and a denial caused by real failures eating the budget are no longer reported identically.
- **Two real awk section-termination bugs** found and fixed: a quarantined class was being misread as a genuine journey failure in both `ci-journey-genuine-journey-failure.sh` and `tests.yml`'s step-annotation awk — live right now against #2391's quarantine entry. Same defect class fixed in `test-ci-journey-summary-evidence.sh` and documented in `docs/ci-pitfalls.md`.
- **Fixed a subtler regression the first pass introduced**: `build_attribution` is exported even for a CLEAN shard whose retry recovered, so the #1814 rollup notice could fire on a fully GREEN aggregate. Gated on the shard's final verdict being RED, not just the attribution token being present.

## Test plan

- [x] 4 review rounds, each finding one more real layer, until the final round found nothing further.
- [x] Round 3's exhaustive parity check independently regenerated by round 4's reviewer at 10x scale (108 shapes vs. the implementer's 11) — exactly the one intended shape differs from `origin/main`, all others (verdict/exit code/summary) byte-identical.
- [x] 3 mutants driven red by the reviewer against production files, restored md5-identical.
- [x] All 14 guard suites + 13 static checks green, counts independently verified by the reviewer.

## Non-blocking follow-up filed separately

#2406 — a CLEAN shard with `retry_affordable=false` emits an extra warning not present on `origin/main`.