### PR TITLE
Resolve engine harness availability via login-shell PATH

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/projects/EngineAvailabilityPickerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/EngineAvailabilityPickerDockerTest.kt
@@ -1,0 +1,241 @@
+package com.pocketshell.app.projects
+
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.proof.DEFAULT_HOST
+import com.pocketshell.app.proof.DEFAULT_PORT
+import com.pocketshell.app.proof.DEFAULT_USER
+import com.pocketshell.app.proof.waitForSshFixtureReady
+import com.pocketshell.core.ssh.DefaultSshLeaseConnector
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.uikit.theme.PocketShellTheme
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Host-backed issue #2276 journey.
+ *
+ * Unlike [EngineAvailabilityPickerUiTest], this test does not construct the
+ * RemoteEngine rows itself. It connects to the Docker agents fixture,
+ * executes the real [SshEnginesGateway] command through its shared SSH lease,
+ * and passes that exact result to the real picker content. The fixture's
+ * `engines list --json` arm delegates to the repository's REAL
+ * `pocketshell.engines` registry, so the resolution under test is the
+ * production one running over a real non-interactive SSH `exec` channel.
+ *
+ * The whole contract is asserted against that one real manifest:
+ *  - an installed, enabled `codex` row IS offered and can actually be picked
+ *    (the maintainer's reported symptom was an installed Codex that never
+ *    appeared in New session at all);
+ *  - `nvm-only-engine` and `login-only-engine` are installed but NOT on this
+ *    exec channel's PATH — the state the maintainer actually hit, where
+ *    `codex`/`opencode` live in an nvm node bin directory the exec channel
+ *    never sees. Both must be offered, because the pane's login shell (where
+ *    the harness is really launched) resolves them fine;
+ *  - `forced-engine` has no binary anywhere and is offered only because
+ *    `force_available: true` pins it — the manual escape hatch;
+ *  - a missing harness (`fixture-missing-engine`), an absent built-in
+ *    (`grok`) and a present-but-disabled harness (`codex-disabled`) are
+ *    absent from the create choices entirely, not merely greyed out.
+ */
+@RunWith(AndroidJUnit4::class)
+class EngineAvailabilityPickerDockerTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private lateinit var keyFile: File
+    private lateinit var sshKey: SshKey.Pem
+
+    @Test
+    fun realHostManifestHidesUnavailableAndDisabledEnginesFromPicker(): Unit {
+        val keyText = InstrumentationRegistry.getInstrumentation()
+            .context.assets.open("test_key").bufferedReader().use { it.readText() }
+        sshKey = SshKey.Pem(keyText)
+        keyFile = File(
+            InstrumentationRegistry.getInstrumentation().targetContext.cacheDir,
+            "issue2276-engine-availability-key",
+        ).apply {
+            parentFile?.mkdirs()
+            if (exists()) delete()
+            FileOutputStream(this).use { it.write(keyText.toByteArray()) }
+            setReadable(true, true)
+        }
+
+        val engines = runBlocking {
+            waitForSshFixtureReady(sshKey)
+            val leaseManager = SshLeaseManager(connector = DefaultSshLeaseConnector())
+            try {
+                val host = HostEntity(
+                    id = 2276L,
+                    name = "issue-2276-agents",
+                    hostname = DEFAULT_HOST,
+                    port = DEFAULT_PORT,
+                    username = DEFAULT_USER,
+                    keyId = 2276L,
+                )
+                val result = withTimeout(30_000) {
+                    SshEnginesGateway(leaseManager).listEngines(
+                        host = host,
+                        keyPath = keyFile.absolutePath,
+                        passphrase = null,
+                    )
+                }
+                assertTrue(
+                    "expected a real engines manifest, got $result; ToolUnavailable " +
+                        "would mean the fixture command is missing",
+                    result is EnginesResult.Engines,
+                )
+                (result as EnginesResult.Engines).engines
+            } finally {
+                leaseManager.close()
+            }
+        }
+
+        val available = engines.singleOrNull { it.id == "claude" }
+        val installedCodex = engines.singleOrNull { it.id == "codex" }
+        val nvmOnly = engines.singleOrNull { it.id == "nvm-only-engine" }
+        val loginOnly = engines.singleOrNull { it.id == "login-only-engine" }
+        val forced = engines.singleOrNull { it.id == "forced-engine" }
+        val missing = engines.singleOrNull { it.id == "fixture-missing-engine" }
+        val absentBuiltIn = engines.singleOrNull { it.id == "grok" }
+        val disabled = engines.singleOrNull { it.id == "codex-disabled" }
+        assertNotNull("fixture manifest must contain the available row", available)
+        assertNotNull("fixture manifest must contain the installed codex row", installedCodex)
+        assertNotNull("fixture manifest must contain the nvm-only row", nvmOnly)
+        assertNotNull("fixture manifest must contain the login-only row", loginOnly)
+        assertNotNull("fixture manifest must contain the forced row", forced)
+        assertNotNull("fixture manifest must contain the missing row", missing)
+        assertNotNull("fixture manifest must contain the absent built-in row", absentBuiltIn)
+        assertNotNull("fixture manifest must contain the disabled row", disabled)
+        assertTrue("fixture claude harness must be present", available!!.available)
+        assertTrue("fixture claude must be createable", available.availableForCreate)
+        assertTrue("installed codex harness must be present", installedCodex!!.available)
+        assertTrue("installed codex must be createable", installedCodex.availableForCreate)
+
+        // The #2276 round-4 state: installed on disk, launchable from the
+        // pane's login shell, invisible to the PATH this manifest command
+        // itself runs with. A bare `which` probe reports these two as "not
+        // installed on this host" and the picker hides an installed engine —
+        // exactly what happened to the maintainer's nvm-installed codex.
+        assertTrue(
+            "nvm-installed harness must resolve; reason was ${nvmOnly!!.unavailableReason}",
+            nvmOnly.available,
+        )
+        assertTrue("nvm-installed harness must be createable", nvmOnly.availableForCreate)
+        assertTrue(
+            "login-shell-only harness must resolve; reason was " +
+                "${loginOnly!!.unavailableReason}",
+            loginOnly.available,
+        )
+        assertTrue("login-shell-only harness must be createable", loginOnly.availableForCreate)
+        // The manual escape hatch: no binary anywhere, pinned by config.
+        assertTrue("force_available row must be available", forced!!.available)
+        assertTrue("force_available row must be createable", forced.availableForCreate)
+
+        assertFalse("fixture missing harness must be unavailable", missing!!.available)
+        assertFalse("missing harness must not be createable", missing.availableForCreate)
+        assertTrue(
+            "missing harness reason must come from the host manifest",
+            missing.unavailableReason?.contains("not installed") == true,
+        )
+        assertFalse("uninstalled built-in must be unavailable", absentBuiltIn!!.available)
+        assertFalse("uninstalled built-in must not be createable", absentBuiltIn.availableForCreate)
+        assertTrue("disabled harness remains present", disabled!!.available)
+        assertFalse("disabled harness must not be createable", disabled.availableForCreate)
+        assertEquals("disabled in the host registry", disabled.unavailableReason)
+
+        var choice: SessionTypeChoice? = null
+        compose.setContent {
+            PocketShellTheme {
+                SessionTypePickerContent(
+                    folderPath = "/srv/issue-2276",
+                    folderLabel = "issue-2276",
+                    onCancel = {},
+                    onCreate = { choice = it },
+                    engines = engines,
+                )
+            }
+        }
+
+        // The rows below are the SshEnginesGateway result above, not an
+        // injected projection fixture. Visible Claude AND Codex rows prove the
+        // real picker received the host registry and offers every installed,
+        // enabled engine; the two unsafe rows must never be offered as create
+        // choices.
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("claude"))
+            .assertIsDisplayed()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex"))
+            .assertIsDisplayed()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("nvm-only-engine"))
+            .assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("login-only-engine"))
+            .assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("forced-engine"))
+            .assertExists()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("fixture-missing-engine"))
+            .assertDoesNotExist()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("grok"))
+            .assertDoesNotExist()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex-disabled"))
+            .assertDoesNotExist()
+        compose.onNodeWithText("Claude").assertIsDisplayed()
+        compose.onNodeWithText("Codex").assertIsDisplayed()
+        compose.onNodeWithText("Missing fixture engine").assertDoesNotExist()
+        compose.onNodeWithText("Disabled Codex fixture").assertDoesNotExist()
+        compose.onNodeWithText("Grok").assertDoesNotExist()
+
+        captureScreenshot("engine-picker-from-real-host-manifest")
+
+        // The installed Codex engine must be genuinely pickable, not just
+        // rendered: select it and create with it.
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("codex")).performClick()
+        compose.waitForIdle()
+        captureScreenshot("engine-picker-codex-selected")
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
+        compose.waitForIdle()
+        assertEquals("codex", choice?.engineId)
+    }
+
+    /**
+     * Best-effort visual evidence for the review record. The load-bearing
+     * proof is the semantics assertions above, so a capture failure on an
+     * emulator image without a PixelCopy-able decor window must not redden the
+     * journey.
+     */
+    private fun captureScreenshot(name: String) {
+        runCatching {
+            compose.waitForIdle()
+            val instrumentation = InstrumentationRegistry.getInstrumentation()
+            val bitmap = instrumentation.uiAutomation.takeScreenshot()
+                ?: compose.onRoot().captureToImage().asAndroidBitmap()
+            val mediaRoot = com.pocketshell.app.test.testArtifactsRoot(
+                instrumentation.targetContext,
+            )
+            val dir = File(mediaRoot, "additional_test_output/issue2276-engine-picker")
+                .apply { mkdirs() }
+            FileOutputStream(File(dir, "$name.png")).use {
+                bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, it)
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/pocketshell/app/projects/EngineAvailabilityPickerUiTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/EngineAvailabilityPickerUiTest.kt
@@ -1,0 +1,79 @@
+package com.pocketshell.app.projects
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.model.SessionAgentKind
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Device-side picker proof for issue #2276.
+ *
+ * The host manifest remains the source of truth: unavailable and disabled
+ * rows are supplied intact so their reasons can be retained, but only the
+ * createable row gets a segment and can be selected. This drives the real
+ * picker content rather than testing a duplicate list projection.
+ */
+@RunWith(AndroidJUnit4::class)
+class EngineAvailabilityPickerUiTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun unavailableAndDisabledEnginesAreHiddenFromCreatePicker() {
+        val available = pickerTestEngine(
+            id = "available",
+            family = SessionAgentKind.Codex,
+            label = "Available",
+        )
+        val unavailable = available.copy(
+            id = "missing",
+            label = "Missing",
+            available = false,
+            availableForCreate = false,
+            unavailableReason = "`codex` is not installed on this host (not on PATH).",
+        )
+        val disabled = available.copy(
+            id = "disabled",
+            label = "Disabled",
+            enabled = false,
+            availableForCreate = false,
+            unavailableReason = "disabled in the host registry",
+        )
+        var choice: SessionTypeChoice? = null
+
+        compose.setContent {
+            PocketShellTheme {
+                SessionTypePickerContent(
+                    folderPath = "/srv/app",
+                    folderLabel = "app",
+                    onCancel = {},
+                    onCreate = { choice = it },
+                    engines = listOf(available, unavailable, disabled),
+                )
+            }
+        }
+
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("available"))
+            .assertIsDisplayed()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("missing"))
+            .assertDoesNotExist()
+        compose.onNodeWithTag(sessionTypePickerAgentEngineTag("disabled"))
+            .assertDoesNotExist()
+        compose.onNodeWithText("Available").assertIsDisplayed()
+        compose.onNodeWithText("Missing").assertDoesNotExist()
+        compose.onNodeWithText("Disabled").assertDoesNotExist()
+
+        compose.onNodeWithTag(SESSION_TYPE_PICKER_CREATE_TAG).performClick()
+        compose.waitForIdle()
+        assertEquals("available", choice?.engineId)
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/RegistryDrivenSessionTypePickerTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/RegistryDrivenSessionTypePickerTest.kt
@@ -51,6 +51,37 @@ class RegistryDrivenSessionTypePickerTest {
     }
 
     @Test
+    fun hostAvailabilityAndDisabledReasonReachTheCreateProjection() {
+        val rows = SshEnginesGateway.parseEnginesPayload(
+            """
+            {"engines": [
+              {"id":"available","family":"codex","label":"Available",
+               "enabled":true,"available":true,"available_for_create":true},
+              {"id":"missing","family":"codex","label":"Missing",
+               "enabled":true,"available":false,"available_for_create":false,
+               "unavailable_reason":"`codex` is not installed on this host (not on PATH)."},
+              {"id":"disabled","family":"codex","label":"Disabled",
+               "enabled":false,"available":true,"available_for_create":false,
+               "unavailable_reason":"disabled in the host registry"}
+            ]}
+            """.trimIndent(),
+        )
+
+        assertEquals(
+            listOf("available"),
+            availableEnginesForCreate(rows).map { it.id },
+        )
+        assertEquals(
+            "`codex` is not installed on this host (not on PATH).",
+            rows.first { it.id == "missing" }.unavailableReason,
+        )
+        assertEquals(
+            "disabled in the host registry",
+            rows.first { it.id == "disabled" }.unavailableReason,
+        )
+    }
+
+    @Test
     fun customRawIdLaunchesThroughWrapperAndKeepsClosedFamilyForTree() {
         val choice = SessionTypeChoice(
             type = SessionType.Agent,

--- a/scripts/ci-journey-suite.sh
+++ b/scripts/ci-journey-suite.sh
@@ -153,6 +153,8 @@ JOURNEY_CLASSES=(
   "com.pocketshell.app.share.SharePassphraseDialogE2eTest"
   "com.pocketshell.app.projects.ProfileDiscoveryPickerDockerTest"  # #732 Finding B): the host server-PROFILE discovery journey. The p…
   "com.pocketshell.app.projects.SessionTypeProfilePickerUiTest"  # #1875: production host sheet retries profile discovery, renders Z.AI, and launches with --profile; also runs the existing picker class coverage.
+  "com.pocketshell.app.projects.EngineAvailabilityPickerUiTest"  # #2276: host availability/disablement rows are hidden from create choices.
+  "com.pocketshell.app.projects.EngineAvailabilityPickerDockerTest"  # #2276: production SshEnginesGateway manifest reaches the real picker against Docker.
   "com.pocketshell.app.projects.RootProjectAddSheetKeyboardLayoutTest"  # #1742 deterministic modal-root IME layout proof
   "com.pocketshell.app.tmux.TmuxInSessionNewSessionCollisionDockerTest"  # #898 reviewer Blocker B): the in-session + New session rich-sheet
   "com.pocketshell.app.tmux.TmuxCreateAfterAttachFailureDockerTest"  # #1832 failed attach then Create must fail visibly, never silently create nothing

--- a/tests/docker/Dockerfile.agents
+++ b/tests/docker/Dockerfile.agents
@@ -9,8 +9,13 @@ FROM alpine:latest
 # GNU nano, unable to save/exit from PocketShell). The connected nano save/exit
 # journey (`TmuxKeyBarCtrlComboE2eTest`) opens a real nano buffer and drives
 # `^O`/`^X` from the hotkeys panel, so the fixture must ship a real `nano`.
+# Issue #2276: `py3-yaml` is required because the fixture's `engines list
+# --json` arm delegates to the REPOSITORY's real `pocketshell.engines`
+# registry (see agent-bin/pocketshell), which reads
+# ~/.config/pocketshell/engines.yaml. Without PyYAML the registry silently
+# ignores the fixture's engine rows.
 RUN apk add --no-cache openssh-server openssh-client tmux procps bash sqlite git nano \
-    python3 py3-click \
+    python3 py3-click py3-yaml \
     && mv /usr/bin/tmux /usr/bin/tmux.real \
     && ssh-keygen -A \
     && adduser -D -s /bin/sh testuser \
@@ -67,6 +72,66 @@ RUN chmod 600 /home/testuser/.ssh/authorized_keys /root/test_key \
     && ln -sf /usr/local/bin/tmux /usr/bin/tmux \
     && printf '%s\n' "0.0.0-dev" > /opt/pocketshell-agent-fixture-version \
     && chown -R testuser:testuser /home/testuser/.ssh
+
+# Issue #2276: the engine-availability journey needs the state the maintainer
+# actually hit, which lives BETWEEN "on the PATH" and "absent everywhere": a
+# harness that is installed and launchable from the tmux pane's LOGIN shell but
+# invisible to the app's NON-interactive SSH `exec` channel. Two such rows are
+# installed here, one per resolution rung:
+#
+#   * `nvm-only-agent`  -> ~/.nvm/versions/node/v24.13.1/bin, exactly where the
+#     maintainer's `codex`/`opencode` live. No shell config mentions it, so
+#     ONLY the absolute-candidate rung can find it.
+#   * `login-only-agent` -> /opt/site-agents/bin, exported from ~/.profile,
+#     which a login shell reads and a non-interactive `exec` never does (the
+#     same shape as the ~/.bashrc interactive early-return guard behind #484).
+#
+# `fixture-missing-engine` stays genuinely absent everywhere (the negative
+# control), `codex-disabled` is present-but-disabled, and `forced-engine` has
+# no binary at all but pins itself with the `force_available:` escape hatch.
+RUN install -d -o testuser -g testuser \
+        /home/testuser/.nvm/versions/node/v24.13.1/bin \
+        /home/testuser/.config/pocketshell \
+    && install -d /opt/site-agents/bin \
+    && printf '#!/bin/sh\nprintf "nvm-only fixture harness\\n"\nexec sleep 3600\n' \
+        > /home/testuser/.nvm/versions/node/v24.13.1/bin/nvm-only-agent \
+    && printf '#!/bin/sh\nprintf "login-only fixture harness\\n"\nexec sleep 3600\n' \
+        > /opt/site-agents/bin/login-only-agent \
+    && chmod +x /home/testuser/.nvm/versions/node/v24.13.1/bin/nvm-only-agent \
+        /opt/site-agents/bin/login-only-agent \
+    && printf '%s\n' \
+        '# Login shells only (issue #2276 fixture): a non-interactive SSH' \
+        '# `exec` channel never sources this file, so /opt/site-agents/bin is' \
+        '# reachable from a tmux pane but not from the manifest command.' \
+        'export PATH="/opt/site-agents/bin:$PATH"' \
+        > /home/testuser/.profile \
+    && printf '%s\n' \
+        'engines:' \
+        '  - id: fixture-missing-engine' \
+        '    family: codex' \
+        '    harness: fixture-missing-engine' \
+        '    label: Missing fixture engine' \
+        '  - id: codex-disabled' \
+        '    family: codex' \
+        '    harness: codex' \
+        '    label: Disabled Codex fixture' \
+        '    enabled: false' \
+        '  - id: nvm-only-engine' \
+        '    family: codex' \
+        '    harness: nvm-only-agent' \
+        '    label: Nvm-only fixture engine' \
+        '  - id: login-only-engine' \
+        '    family: codex' \
+        '    harness: login-only-agent' \
+        '    label: Login-only fixture engine' \
+        '  - id: forced-engine' \
+        '    family: codex' \
+        '    harness: never-installed-agent' \
+        '    label: Forced fixture engine' \
+        '    force_available: true' \
+        > /home/testuser/.config/pocketshell/engines.yaml \
+    && chown -R testuser:testuser /home/testuser/.nvm /home/testuser/.config \
+        /home/testuser/.profile
 
 EXPOSE 22
 

--- a/tests/docker/agent-bin/pocketshell
+++ b/tests/docker/agent-bin/pocketshell
@@ -474,6 +474,25 @@ case "${1:-}" in
     '
     exit 0
     ;;
+  engines)
+    # Issue #2276: the availability journey must exercise the REAL host
+    # registry, not a shell re-implementation of it. The bug being regressed
+    # lives inside `pocketshell.engines.resolve_harnesses` (a harness that is
+    # installed and launchable from the pane's LOGIN shell but invisible to
+    # this NON-interactive SSH `exec` channel), so a `command -v` mimicry here
+    # would prove nothing about the fix. Delegate to the repository's real
+    # implementation (same idiom as the `send` arm, issue #2240) and let it
+    # observe this container's genuinely off-PATH harnesses.
+    #
+    # Dockerfile.agents seeds ~/.config/pocketshell/engines.yaml with five
+    # fixture rows (missing / disabled / nvm-only / login-only / forced) on top
+    # of the built-in claude/codex/opencode/grok.
+    if [ ! -d /opt/pocketshell-real/src ]; then
+      printf 'pocketshell engines fixture needs /opt/pocketshell-real/src\n' >&2
+      exit 64
+    fi
+    exec /usr/local/bin/pocketshell-real-send "$@"
+    ;;
   usage)
     shift
     if [ "${1:-}" = "--json" ]; then
@@ -1277,5 +1296,5 @@ case "${1:-}" in
     ;;
 esac
 
-printf 'pocketshell fixture supports: usage --json, sessions list, jobs list/add/edit/remove, agent-log, profiles list, agents kind, tree get|upsert|reconcile\n' >&2
+printf 'pocketshell fixture supports: usage --json, sessions list, jobs list/add/edit/remove, agent-log, profiles list, engines list --json, agents kind, tree get|upsert|reconcile\n' >&2
 exit 64

--- a/tools/pocketshell/src/pocketshell/engines.py
+++ b/tools/pocketshell/src/pocketshell/engines.py
@@ -8,6 +8,10 @@ enable, or disable entries without a Kotlin change.
 Registry ids are intentionally open.  ``family`` is the closed detection
 projection used by the client (for example, ``godex`` can use the ``codex``
 family), while ``id`` is the durable value recorded as ``@ps_agent_kind``.
+
+Availability (issue #2276) is an observation this module makes at manifest
+build time, never a config bit: see :func:`resolve_harnesses`.  The single
+deliberate escape hatch is ``force_available:`` in ``engines.yaml``.
 """
 
 from __future__ import annotations
@@ -16,7 +20,10 @@ import json
 import os
 import re
 import shutil
+import signal
+import subprocess
 from dataclasses import dataclass, replace
+from glob import glob
 from pathlib import Path
 from typing import Mapping, Optional
 
@@ -157,7 +164,15 @@ class LaunchSpec:
 
 @dataclass(frozen=True)
 class EngineManifest:
-    """One host registry entry, including current availability/config state."""
+    """One host registry entry, including current availability/config state.
+
+    ``available`` is an OBSERVATION (see :func:`resolve_harnesses`), never an
+    input the config can go stale on.  ``force_available`` is the deliberate
+    escape hatch: an ``engines.yaml`` entry may set it to pin availability on
+    a host whose layout the resolver cannot anticipate.  ``force_available``
+    is deliberately a different key from the ``available`` output field so a
+    copied/stale manifest row can never be mistaken for that intent.
+    """
 
     id: str
     family: str
@@ -169,7 +184,11 @@ class EngineManifest:
     enabled: bool = True
     available: bool = True
     unavailable_reason: Optional[str] = None
-    availability_overridden: bool = False
+    # Explicit `force_available:` from engines.yaml. None = probe decides.
+    force_available: Optional[bool] = None
+    # Explicit `unavailable_reason:` from engines.yaml, kept so the probe
+    # cannot silently discard a host-authored explanation.
+    configured_unavailable_reason: Optional[str] = None
 
     @property
     def available_for_create(self) -> bool:
@@ -206,11 +225,246 @@ class EngineManifest:
             "available": self.available,
             "available_for_create": self.available_for_create,
             "unavailable_reason": self.unavailable_reason,
+            "force_available": self.force_available,
             "launch": launch,
         }
 
 
 _ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+DISABLED_ENGINE_REASON = "disabled in the host registry"
+FORCED_UNAVAILABLE_REASON = "pinned unavailable by `force_available: false`"
+
+
+def _missing_harness_reason(item: EngineManifest) -> str:
+    return f"`{item.harness}` is not installed on this host (not on PATH)."
+
+
+def _availability_reason(item: EngineManifest, available: bool) -> Optional[str]:
+    """Derive the user-facing reason for a non-createable engine.
+
+    A disabled engine whose harness is ALSO missing used to report only the
+    disablement, which silently lost the more actionable half of the state.
+    Both halves are reported when both apply.
+    """
+    if item.enabled and available:
+        return None
+    if not available and item.force_available is False:
+        return FORCED_UNAVAILABLE_REASON
+    if not available and not item.enabled:
+        return (
+            f"`{item.harness}` is not installed on this host (not on PATH) "
+            f"and is {DISABLED_ENGINE_REASON}."
+        )
+    if not available:
+        return _missing_harness_reason(item)
+    return DISABLED_ENGINE_REASON
+
+
+def _effective_reason(item: EngineManifest, available: bool) -> Optional[str]:
+    """Prefer a host-authored reason over the derived one when unavailable."""
+    if item.enabled and available:
+        return None
+    if item.configured_unavailable_reason:
+        return item.configured_unavailable_reason
+    return _availability_reason(item, available)
+
+
+# ---------------------------------------------------------------------------
+# Harness resolution (issue #2276)
+# ---------------------------------------------------------------------------
+#
+# The manifest is built over the app's NON-interactive SSH `exec` channel
+# (`PocketshellCommand.wrap` -> `pocketshell engines list --json`), but the
+# harness itself is launched by `send-keys` into a tmux pane, i.e. from a
+# LOGIN shell.  Those two environments have different PATHs whenever a
+# harness is installed by a version manager: on the maintainer's host
+# `codex`/`opencode` live in `~/.nvm/versions/node/v24.13.1/bin`, which the
+# exec channel never sees, so a plain `shutil.which` reported two installed
+# engines as "not installed" and the picker hid them.
+#
+# This is the same defect class #484/#490 fixed for the `pocketshell` binary
+# itself, one level down.  The ladder below mirrors that fix: resolve the way
+# the harness will actually be launched (login shell), then fall back to the
+# absolute install locations a login shell can still miss (#484 rejected the
+# login shell as a SOLE mechanism because a `~/.bashrc`-only PATH export never
+# runs for a non-interactive login shell).
+#
+# Cost stays "one cheap manifest-time observation" per the issue's non-goals:
+# the plain-PATH lookup answers the happy path with zero subprocesses, and the
+# login shell is consulted at most once per manifest build (cached per env),
+# only when at least one harness is still unresolved.
+
+LOGIN_SHELL_PATH_TIMEOUT_S = 5.0
+# Kill switch for hosts where spawning a login shell is undesirable.
+LOGIN_SHELL_PROBE_KILL = "POCKETSHELL_ENGINE_LOGIN_SHELL_PROBE"
+#: How the login shell is asked for its PATH, most portable form first.
+#: `printenv PATH` is shell-agnostic; fish, for example, expands `"$PATH"` to a
+#: SPACE-separated list, so the POSIX `printf` form is only the fallback for a
+#: host without `printenv`.
+LOGIN_SHELL_PATH_COMMANDS: tuple[str, ...] = (
+    "printenv PATH",
+    'printf %s "$PATH"',
+)
+
+#: Absolute install locations probed when neither the exec `PATH` nor the
+#: login shell resolves a harness.  Globs are expanded (newest match first);
+#: `$HOME`-relative patterns are skipped when the environment has no `HOME`.
+LAUNCH_PATH_PATTERNS: tuple[str, ...] = (
+    # Plain per-user/system bin dirs (mirrors PocketshellCommand.PATH_PREFIX_DIRS).
+    "$HOME/.local/bin",
+    "$HOME/bin",
+    "$HOME/.cargo/bin",
+    "$HOME/.pixi/bin",
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    # Node version managers — every agent harness in the registry today ships
+    # as an npm package, so this is where they usually land.
+    "$HOME/.nvm/versions/node/*/bin",
+    "$HOME/.local/share/fnm/node-versions/*/installation/bin",
+    "$HOME/.volta/bin",
+    "$HOME/.bun/bin",
+    "$HOME/.deno/bin",
+    "$HOME/.npm-global/bin",
+    "$HOME/.npm-packages/bin",
+    "$HOME/.yarn/bin",
+    "$HOME/.config/yarn/global/node_modules/.bin",
+    # Generic language/tool version managers.
+    "$HOME/.asdf/shims",
+    "$HOME/.asdf/installs/*/*/bin",
+    "$HOME/.local/share/mise/shims",
+    "$HOME/.rye/shims",
+    "$HOME/go/bin",
+)
+
+_LOGIN_SHELL_PATH_CACHE: dict[tuple[str, str, str], tuple[str, ...]] = {}
+
+# Snapshot Popen (same rationale as aplexer._Popen): helper tests that patch
+# ``subprocess.Popen`` to block a launched child must not swallow — or crash —
+# this read-only PATH observation.
+_Popen = subprocess.Popen
+_TimeoutExpired = subprocess.TimeoutExpired
+
+
+def _run_capture(argv: list[str], env: dict[str, str]) -> Optional[str]:
+    """Run ``argv`` and return stdout, or None on any failure/timeout."""
+    try:
+        proc = _Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            env=env,
+            start_new_session=True,
+        )
+        try:
+            stdout, _stderr = proc.communicate(timeout=LOGIN_SHELL_PATH_TIMEOUT_S)
+        except _TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except OSError:
+                proc.kill()
+            proc.communicate()
+            return None
+    except (OSError, ValueError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return stdout
+
+
+def clear_resolution_cache() -> None:
+    """Drop the memoised login-shell PATH (used by tests and long-lived procs)."""
+    _LOGIN_SHELL_PATH_CACHE.clear()
+
+
+def _login_shell_dirs(source: Mapping[str, str]) -> tuple[str, ...]:
+    """Return the PATH entries a LOGIN shell exports, memoised per environment.
+
+    This is the environment the harness is actually launched in (tmux runs the
+    user's shell as a login shell, and the create flow `send-keys`-types the
+    wrapper into that pane).  Failures are silent: the caller still has the
+    absolute-candidate ladder below.
+    """
+    if source.get(LOGIN_SHELL_PROBE_KILL) == "0":
+        return ()
+    shells = tuple(
+        dict.fromkeys(shell for shell in (source.get("SHELL"), "/bin/sh") if shell)
+    )
+    key = (shells[0], source.get("HOME", ""), source.get("PATH", ""))
+    cached = _LOGIN_SHELL_PATH_CACHE.get(key)
+    if cached is not None:
+        return cached
+    env = {str(name): str(value) for name, value in source.items()}
+    dirs: tuple[str, ...] = ()
+    for shell in shells:
+        for command in LOGIN_SHELL_PATH_COMMANDS:
+            stdout = _run_capture([shell, "-lc", command], env)
+            if stdout is None:
+                continue
+            dirs = tuple(
+                dict.fromkeys(
+                    entry
+                    for entry in stdout.strip().split(os.pathsep)
+                    if entry.strip()
+                )
+            )
+            if dirs:
+                break
+        if dirs:
+            break
+    _LOGIN_SHELL_PATH_CACHE[key] = dirs
+    return dirs
+
+
+def _launch_candidate_dirs(source: Mapping[str, str]) -> tuple[str, ...]:
+    """Expand :data:`LAUNCH_PATH_PATTERNS` to existing directories."""
+    home = source.get("HOME")
+    found: list[str] = []
+    for pattern in LAUNCH_PATH_PATTERNS:
+        expanded = pattern
+        if expanded.startswith("$HOME"):
+            if not home:
+                continue
+            expanded = f"{home}{expanded[len('$HOME'):]}"
+        if any(ch in expanded for ch in "*?["):
+            # Newest version directory first for `.../node/*/bin`-style layouts.
+            matches = sorted(glob(expanded), reverse=True)
+        else:
+            matches = [expanded]
+        found.extend(match for match in matches if os.path.isdir(match))
+    return tuple(dict.fromkeys(found))
+
+
+def resolve_harnesses(
+    harnesses: tuple[str, ...],
+    source: Mapping[str, str],
+) -> dict[str, Optional[str]]:
+    """Resolve every harness the way it will be LAUNCHED, not merely exec'd.
+
+    Returns ``{harness: absolute path or None}``.  The ladder is
+    ``PATH`` -> login-shell ``PATH`` -> absolute candidate directories, and
+    each rung only runs for the harnesses still unresolved, so a host whose
+    engines are all on ``PATH`` spawns no subprocess at all.
+    """
+    ordered = tuple(dict.fromkeys(harnesses))
+    resolved: dict[str, Optional[str]] = {
+        name: shutil.which(name, path=source.get("PATH")) for name in ordered
+    }
+    missing = [name for name in ordered if resolved[name] is None]
+    if not missing:
+        return resolved
+    for extra_dirs in (_login_shell_dirs(source), _launch_candidate_dirs(source)):
+        if not extra_dirs:
+            continue
+        search = os.pathsep.join(extra_dirs)
+        for name in tuple(missing):
+            found = shutil.which(name, path=search)
+            if found is not None:
+                resolved[name] = found
+        missing = [name for name in missing if resolved[name] is None]
+        if not missing:
+            break
+    return resolved
 
 
 def _profile(
@@ -397,6 +651,31 @@ def _launch_from_mapping(
     )
 
 
+def _force_available(
+    raw: Mapping[str, object],
+    base: Optional[EngineManifest],
+) -> Optional[bool]:
+    """Read the explicit `force_available:` escape hatch (booleans only).
+
+    The `available:` key is NOT accepted as an override: it is an output field
+    of `pocketshell engines list --json`, so honouring it as input made a
+    stale/copied value hide an installed engine forever (#2276 round 3).
+    """
+    value = raw.get("force_available")
+    if isinstance(value, bool):
+        return value
+    return base.force_available if base is not None else None
+
+
+def _configured_reason(
+    raw: Mapping[str, object],
+    base: Optional[EngineManifest],
+) -> Optional[str]:
+    if raw.get("unavailable_reason") is not None:
+        return str(raw["unavailable_reason"])
+    return base.configured_unavailable_reason if base is not None else None
+
+
 def _manifest_from_mapping(
     raw: Mapping[str, object],
     base: Optional[EngineManifest],
@@ -431,7 +710,8 @@ def _manifest_from_mapping(
                 if raw.get("unavailable_reason") is not None
                 else None
             ),
-            availability_overridden="available" in raw,
+            force_available=_force_available(raw, None),
+            configured_unavailable_reason=_configured_reason(raw, None),
         )
 
     return replace(
@@ -453,9 +733,8 @@ def _manifest_from_mapping(
             if raw.get("unavailable_reason") is not None
             else base.unavailable_reason
         ),
-        availability_overridden=(
-            "available" in raw or base.availability_overridden
-        ),
+        force_available=_force_available(raw, base),
+        configured_unavailable_reason=_configured_reason(raw, base),
     )
 
 
@@ -475,19 +754,19 @@ def _aplexer_engine_rows(
 def _overlay_aplexer_engines(
     manifests: dict[str, EngineManifest],
     env: Optional[Mapping[str, str]] = None,
-) -> set[str]:
-    """Overlay argv / env_unset / available from ``a engines --json``.
+) -> None:
+    """Overlay argv / env_unset from ``a engines --json``.
 
     Presentation fields (label, family, provider_mark, skip_permissions_argv)
     stay PocketShell's. Unknown aplexer engines (``shell``, ``gemini`` unless
-    already in this registry) are not added. Returns ids that aplexer
-    already availability-probed so ``load_registry`` can skip a second PATH
-    check.
+    already in this registry) are not added. aplexer's own ``available`` bit is
+    deliberately NOT read: availability is this host's own resolution of the
+    harness (:func:`resolve_harnesses`), and inheriting a second tool's cached
+    answer is exactly what hid an installed engine in #2276.
     """
     rows = _aplexer_engine_rows(env)
     if rows is None:
-        return set()
-    overlayed: set[str] = set()
+        return
     for row in rows:
         name = row.get("name")
         if not isinstance(name, str) or name in _HIDDEN_APLEXER_ENGINES:
@@ -515,23 +794,7 @@ def _overlay_aplexer_engines(
             profile_env=item.launch.profile_env,
             profile=item.launch.profile,
         )
-        available = row.get("available")
-        if isinstance(available, bool) and not item.availability_overridden:
-            item = replace(
-                item,
-                launch=launch,
-                available=available,
-                unavailable_reason=(
-                    None
-                    if available
-                    else f"`{item.harness}` is not installed on this host (not on PATH)."
-                ),
-            )
-            overlayed.add(name)
-        else:
-            item = replace(item, launch=launch)
-        manifests[name] = item
-    return overlayed
+        manifests[name] = replace(item, launch=launch)
 
 
 def load_registry(
@@ -541,14 +804,24 @@ def load_registry(
 ) -> list[EngineManifest]:
     """Load built-ins plus declarative overrides/additions.
 
-    Availability is a host observation: unless an entry explicitly supplies
-    ``available``, the configured harness is checked once with ``PATH``.  The
-    CLI emits the full registry, including disabled/unavailable entries, so
-    the picker can hide only entries that are not createable while existing
+    Availability is a host observation, not config state: when probing is
+    enabled every configured harness is resolved once through
+    :func:`resolve_harnesses`, which searches the exec ``PATH``, then the
+    LOGIN shell's ``PATH`` (the environment the harness is really launched
+    in), then the known absolute install locations. A stale configured or
+    aplexer availability bit cannot override that observation.
+
+    The one deliberate override is ``force_available:`` in ``engines.yaml``:
+    an explicit boolean there pins availability for a host layout the resolver
+    cannot anticipate, in either direction. It is intentionally NOT the
+    ``available`` output key.
+
+    The CLI emits the full registry, including disabled/unavailable entries,
+    so the picker can hide only entries that are not createable while existing
     sessions continue to render from their recorded identity.
 
-    When ``a`` is present, argv / env_unset / available for matching ids come
-    from ``a engines --json`` (Phase A2). ``engines.yaml`` still wins on
+    When ``a`` is present, argv / env_unset for matching ids come from
+    ``a engines --json`` (Phase A2). ``engines.yaml`` still wins on
     presentation and can add engines aplexer does not know.
     """
     manifests: dict[str, EngineManifest] = {
@@ -557,7 +830,7 @@ def load_registry(
     order = list(manifests)
     # Aplexer supplies argv/env_unset/available for known ids; user yaml
     # still wins if it then overrides the same id.
-    overlayed = _overlay_aplexer_engines(manifests, env)
+    _overlay_aplexer_engines(manifests, env)
     for raw in _read_config(env):
         item = _manifest_from_mapping(raw, manifests.get(str(raw.get("id", "")).lower()))
         if item is None:
@@ -565,28 +838,30 @@ def load_registry(
         if item.id not in manifests:
             order.append(item.id)
         manifests[item.id] = item
-        overlayed.discard(item.id)
 
     source = os.environ if env is None else env
+    items = [manifests[engine_id] for engine_id in order]
+    resolved: dict[str, Optional[str]] = {}
+    if probe:
+        resolved = resolve_harnesses(
+            tuple(item.harness for item in items),
+            source,
+        )
     out: list[EngineManifest] = []
-    for engine_id in order:
-        item = manifests[engine_id]
-        if (
-            probe
-            and not item.availability_overridden
-            and engine_id not in overlayed
-        ):
-            found = shutil.which(item.harness, path=source.get("PATH"))
-            item = replace(
+    for item in items:
+        if item.force_available is not None:
+            available = item.force_available
+        elif probe:
+            available = resolved.get(item.harness) is not None
+        else:
+            available = item.available
+        out.append(
+            replace(
                 item,
-                available=found is not None,
-                unavailable_reason=(
-                    None
-                    if found is not None
-                    else f"`{item.harness}` is not installed on this host (not on PATH)."
-                ),
+                available=available,
+                unavailable_reason=_effective_reason(item, available),
             )
-        out.append(item)
+        )
     return out
 
 
@@ -646,4 +921,8 @@ def engines_list(as_json: bool) -> None:
         state = "enabled" if item.enabled else "disabled"
         if not item.available:
             state = f"{state}, unavailable"
+        if item.force_available is not None:
+            state = f"{state}, force_available={str(item.force_available).lower()}"
+        if item.unavailable_reason:
+            state = f"{state} ({item.unavailable_reason})"
         click.echo(f"{item.id}\t{item.label}\t{state}")

--- a/tools/pocketshell/tests/test_agents.py
+++ b/tools/pocketshell/tests/test_agents.py
@@ -1175,6 +1175,54 @@ def test_cli_agent_missing_binary_exits_127(tmp_path, monkeypatch, capsys):
     assert "not installed" in stderr
 
 
+def test_registry_launch_keeps_missing_binary_race_backstop(
+    tmp_path, monkeypatch, capsys
+):
+    """A binary may disappear after the manifest probe and still gets a clear error."""
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: race-engine
+    family: codex
+    harness: race-agent
+    label: Race Engine
+    enabled: true
+    launch:
+      argv: [race-agent]
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+    race_probe_calls = 0
+
+    def disappearing_which(name, *args, **kwargs):
+        nonlocal race_probe_calls
+        if name == "race-agent":
+            race_probe_calls += 1
+            return "/fixture/race-agent" if race_probe_calls == 1 else None
+        return f"/usr/bin/{name}"
+
+    monkeypatch.setattr(agents.shutil, "which", disappearing_which)
+    with pytest.raises(click.exceptions.Exit) as exc:
+        agents.launch_agent(
+            _FakeCtx(),
+            "race-engine",
+            str(tmp_path),
+            skip_permissions=True,
+            config_dir=None,
+            execvpe=lambda *args: pytest.fail(
+                "race backstop must stop before exec"
+            ),
+        )
+
+    assert exc.value.exit_code == 127
+    assert race_probe_calls == 2
+    assert "`race-engine` is not installed on this host" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # CLI wiring end-to-end (exec stubbed out)
 # ---------------------------------------------------------------------------

--- a/tools/pocketshell/tests/test_engines.py
+++ b/tools/pocketshell/tests/test_engines.py
@@ -91,15 +91,503 @@ def test_disabled_engine_is_listed_but_not_createable_or_wrappable(tmp_path, mon
     result = CliRunner().invoke(cli, ["engines", "list", "--json"])
     assert result.exit_code == 0, result.output
     listed = json.loads(result.output)
-    assert next(item for item in listed["engines"] if item["id"] == "disabled-engine")[
-        "available_for_create"
-    ] is False
+    listed_row = next(
+        item for item in listed["engines"] if item["id"] == "disabled-engine"
+    )
+    assert listed_row["available_for_create"] is False
+    # `disabled-agent` is installed nowhere either, so BOTH halves of the
+    # state are reported (issue #2276 round 4: the disablement used to mask
+    # the more actionable "not installed" half).
+    assert listed_row["unavailable_reason"] == (
+        "`disabled-agent` is not installed on this host (not on PATH) "
+        "and is disabled in the host registry."
+    )
 
     # The wrapper command is registry-driven, but a disabled engine must not
     # launch merely because its harness is configured.
     result = CliRunner().invoke(cli, ["agent", "disabled-engine", "--dir", str(tmp_path)])
     assert result.exit_code == 126
     assert "is disabled in the host registry" in result.output
+
+
+def test_manifest_probe_overrides_stale_configured_availability_for_missing_harness(
+    tmp_path,
+):
+    """The manifest must report the current PATH, not a stale config bit."""
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: missing-engine
+    family: codex
+    harness: definitely-missing-engine
+    label: Missing Engine
+    available: true
+    enabled: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "PATH": str(tmp_path / "empty-bin"),
+        }
+    )
+    missing = next(item for item in registry if item.id == "missing-engine")
+
+    assert missing.available is False
+    assert missing.available_for_create is False
+    assert missing.unavailable_reason == (
+        "`definitely-missing-engine` is not installed on this host (not on PATH)."
+    )
+
+
+def test_manifest_probe_checks_each_registered_harness_once(tmp_path, monkeypatch):
+    """Availability is a single manifest-build observation, not polling."""
+    _engine_config(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    probed: list[str] = []
+
+    def record_probe(name, *, path=None):
+        probed.append(name)
+        return f"/fixture/{name}"
+
+    monkeypatch.setattr(engines.shutil, "which", record_probe)
+    registry = engines.load_registry()
+
+    assert probed == [item.harness for item in registry]
+    assert all(item.available for item in registry)
+
+
+def test_manifest_records_distinct_disabled_reason_for_present_engine(tmp_path):
+    """A configured disablement is not reported as a missing executable."""
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    harness = bin_dir / "present-engine"
+    harness.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    harness.chmod(0o755)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: disabled-engine
+    family: codex
+    harness: present-engine
+    label: Disabled Engine
+    enabled: false
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "PATH": str(bin_dir),
+        }
+    )
+    disabled = next(item for item in registry if item.id == "disabled-engine")
+
+    assert disabled.enabled is False
+    assert disabled.available is True
+    assert disabled.available_for_create is False
+    assert disabled.unavailable_reason == "disabled in the host registry"
+
+    payload = engines.registry_payload(registry)
+    payload_row = next(
+        item for item in payload["engines"] if item["id"] == "disabled-engine"
+    )
+    assert payload_row["available"] is True
+    assert payload_row["available_for_create"] is False
+    assert payload_row["unavailable_reason"] == "disabled in the host registry"
+
+
+def test_installed_engine_stays_createable_despite_stale_aplexer_unavailable(
+    tmp_path, monkeypatch, install_fake_a
+):
+    """#2276 reported symptom: an INSTALLED Codex never reached the picker.
+
+    aplexer's ``a engines --json`` carries its own ``available`` bit. When that
+    bit is stale/false for a harness that is genuinely on PATH, the manifest
+    used to inherit it verbatim and the create picker hid the engine forever,
+    so the already-shipped Codex profiles were unreachable. The final PATH
+    observation must win in BOTH directions, not only when it is more
+    restrictive.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for harness in ("claude", "codex"):
+        executable = bin_dir / harness
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o755)
+    install_fake_a(
+        engines=[
+            {"name": "claude", "command": ["claude"], "available": True},
+            # Stale: the binary IS installed below, aplexer says otherwise.
+            {
+                "name": "codex",
+                "command": ["codex", "--from-aplexer"],
+                "available": False,
+            },
+        ]
+    )
+    # `bin_dir` first so the fixture harnesses win; the system dirs stay on
+    # PATH only so the stub `a` interpreter resolves. Neither holds a real
+    # `claude`/`codex`.
+    monkeypatch.setenv("PATH", f"{bin_dir}:/usr/bin:/bin")
+
+    registry = engines.load_registry()
+    codex = next(item for item in registry if item.id == "codex")
+
+    # Guards this test against passing vacuously with the overlay skipped:
+    # the argv proves aplexer's rows really were read and applied.
+    assert codex.launch.argv == ("codex", "--from-aplexer")
+    assert codex.available is True
+    assert codex.available_for_create is True
+    assert codex.unavailable_reason is None
+
+    payload_row = next(
+        item
+        for item in engines.registry_payload(registry)["engines"]
+        if item["id"] == "codex"
+    )
+    assert payload_row["available"] is True
+    assert payload_row["available_for_create"] is True
+    assert payload_row["unavailable_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #2276 round 4: the harness is installed, launchable from the tmux
+# pane's LOGIN shell, but invisible to the app's NON-interactive SSH exec
+# channel (`PocketshellCommand.wrap` -> `pocketshell engines list --json`).
+# On the maintainer's host that is `~/.nvm/versions/node/v24.13.1/bin/codex`.
+# The reported state lives strictly between "on PATH" and "absent everywhere",
+# and the probe must resolve harnesses the way they are actually LAUNCHED.
+# ---------------------------------------------------------------------------
+
+
+def _install_stub(directory, name: str):
+    directory.mkdir(parents=True, exist_ok=True)
+    executable = directory / name
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    return executable
+
+
+def _fake_login_shell(tmp_path, exported_path: str, calls_log, name="fake-login-shell"):
+    """A stand-in `$SHELL` whose login PATH differs from the exec PATH."""
+    shell = tmp_path / name
+    shell.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> {calls_log}\n'
+        f'printf %s "{exported_path}"\n',
+        encoding="utf-8",
+    )
+    shell.chmod(0o755)
+    return shell
+
+
+def _fake_fish_login_shell(tmp_path, path_entries, calls_log):
+    """A `$SHELL` that expands `"$PATH"` the way fish does: space separated.
+
+    Asking such a shell with the POSIX `printf %s "$PATH"` form yields one
+    unusable blob, so the registry must ask in a shell-agnostic way.
+    """
+    shell = tmp_path / "fake-fish-login-shell"
+    shell.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> {calls_log}\n'
+        'case "$*" in\n'
+        f"  *printenv*) printf %s '{':'.join(path_entries)}' ;;\n"
+        f"  *) printf %s '{' '.join(path_entries)}' ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    shell.chmod(0o755)
+    return shell
+
+
+def test_manifest_reports_harness_installed_outside_the_exec_path(tmp_path):
+    """#2276: nvm-installed codex/opencode are hidden by a bare PATH probe.
+
+    The exec channel PATH holds only `claude`; `codex`/`opencode` live in an
+    nvm node bin dir exactly as on the maintainer's host. The login-shell rung
+    is switched OFF here so this test isolates the absolute-candidate rung.
+    """
+    home = tmp_path / "home"
+    nvm_bin = home / ".nvm" / "versions" / "node" / "v24.13.1" / "bin"
+    for name in ("codex", "opencode"):
+        _install_stub(nvm_bin, name)
+    exec_bin = tmp_path / "exec-bin"
+    _install_stub(exec_bin, "claude")
+
+    registry = engines.load_registry(
+        {
+            "HOME": str(home),
+            "PATH": str(exec_bin),
+            "XDG_CONFIG_HOME": str(tmp_path / "no-config"),
+            engines.LOGIN_SHELL_PROBE_KILL: "0",
+        }
+    )
+    by_id = {item.id: item for item in registry}
+
+    assert by_id["codex"].available is True
+    assert by_id["codex"].available_for_create is True
+    assert by_id["codex"].unavailable_reason is None
+    assert by_id["opencode"].available is True
+    assert by_id["opencode"].available_for_create is True
+    # The engine that IS on the exec PATH keeps working ...
+    assert by_id["claude"].available is True
+    # ... and the resolver stays honest: `grok` is installed nowhere here.
+    assert by_id["grok"].available is False
+    assert by_id["grok"].unavailable_reason == (
+        "`grok` is not installed on this host (not on PATH)."
+    )
+
+
+def test_manifest_resolves_a_harness_through_the_login_shell_path(tmp_path):
+    """The login shell is the environment the harness is really launched in.
+
+    tmux runs the user's shell as a login shell and the create flow types the
+    wrapper into that pane, so a harness only reachable there must count as
+    available even when no known absolute install location holds it.
+    """
+    engines.clear_resolution_cache()
+    login_only_bin = tmp_path / "opt" / "site-agents" / "bin"
+    _install_stub(login_only_bin, "login-only-agent")
+    exec_bin = tmp_path / "exec-bin"
+    calls_log = tmp_path / "login-shell-calls.txt"
+    shell = _fake_login_shell(tmp_path, f"{login_only_bin}:{exec_bin}", calls_log)
+
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: login-only-engine
+    family: codex
+    harness: login-only-agent
+    label: Login Only Engine
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PATH": str(exec_bin),
+            "SHELL": str(shell),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        }
+    )
+    engine = next(item for item in registry if item.id == "login-only-engine")
+
+    assert engine.available is True
+    assert engine.available_for_create is True
+    assert engine.unavailable_reason is None
+    # One cheap manifest-time observation, not a subprocess storm: the login
+    # shell is consulted ONCE for the whole registry, however many harnesses
+    # are unresolved.
+    assert calls_log.read_text(encoding="utf-8").splitlines() == [
+        "-lc printenv PATH"
+    ]
+
+
+def test_manifest_login_shell_path_read_is_shell_agnostic(tmp_path):
+    """A fish login shell must not defeat the resolution (class coverage).
+
+    fish expands `"$PATH"` to a space-separated list, so the POSIX
+    `printf %s "$PATH"` form returns one unusable blob there. The registry has
+    to ask in a form every common login shell answers the same way.
+    """
+    engines.clear_resolution_cache()
+    fish_only_bin = tmp_path / "opt" / "fish-agents" / "bin"
+    _install_stub(fish_only_bin, "fish-only-agent")
+    exec_bin = tmp_path / "exec-bin"
+    calls_log = tmp_path / "fish-shell-calls.txt"
+    shell = _fake_fish_login_shell(
+        tmp_path, [str(fish_only_bin), str(exec_bin)], calls_log
+    )
+
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: fish-only-engine
+    family: codex
+    harness: fish-only-agent
+    label: Fish Only Engine
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PATH": str(exec_bin),
+            "SHELL": str(shell),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        }
+    )
+    engine = next(item for item in registry if item.id == "fish-only-engine")
+
+    assert engine.available is True
+    assert engine.available_for_create is True
+
+
+def test_manifest_probe_skips_the_login_shell_when_every_harness_is_on_path(tmp_path):
+    """The happy path stays subprocess-free (the issue's no-polling non-goal)."""
+    engines.clear_resolution_cache()
+    exec_bin = tmp_path / "exec-bin"
+    for name in ("claude", "codex", "opencode", "grok"):
+        _install_stub(exec_bin, name)
+    calls_log = tmp_path / "login-shell-calls.txt"
+    shell = _fake_login_shell(tmp_path, str(exec_bin), calls_log)
+
+    registry = engines.load_registry(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PATH": str(exec_bin),
+            "SHELL": str(shell),
+            "XDG_CONFIG_HOME": str(tmp_path / "no-config"),
+        }
+    )
+
+    assert all(item.available for item in registry)
+    assert not calls_log.exists()
+
+
+def test_force_available_pins_an_engine_the_probe_cannot_resolve(tmp_path):
+    """The manual escape hatch for a host layout the resolver cannot anticipate."""
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: exotic-engine
+    family: codex
+    harness: exotic-agent
+    label: Exotic Engine
+    force_available: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "PATH": str(tmp_path / "empty-bin"),
+            engines.LOGIN_SHELL_PROBE_KILL: "0",
+        }
+    )
+    exotic = next(item for item in registry if item.id == "exotic-engine")
+
+    assert exotic.available is True
+    assert exotic.available_for_create is True
+    assert exotic.unavailable_reason is None
+    payload_row = next(
+        item
+        for item in engines.registry_payload(registry)["engines"]
+        if item["id"] == "exotic-engine"
+    )
+    assert payload_row["available_for_create"] is True
+    assert payload_row["force_available"] is True
+
+
+def test_force_available_false_hides_an_installed_engine(tmp_path):
+    """The escape hatch works in both directions, with a distinct reason."""
+    bin_dir = tmp_path / "bin"
+    _install_stub(bin_dir, "present-agent")
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: pinned-off-engine
+    family: codex
+    harness: present-agent
+    label: Pinned Off Engine
+    force_available: false
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "PATH": str(bin_dir),
+        }
+    )
+    pinned = next(item for item in registry if item.id == "pinned-off-engine")
+
+    assert pinned.available is False
+    assert pinned.available_for_create is False
+    assert pinned.unavailable_reason == engines.FORCED_UNAVAILABLE_REASON
+
+
+def test_missing_and_disabled_engine_reports_both_halves_of_the_state(tmp_path):
+    """Neither half of a doubly-unavailable engine is silently dropped."""
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: gone-and-disabled
+    family: codex
+    harness: gone-agent
+    label: Gone Engine
+    enabled: false
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "PATH": str(tmp_path / "empty-bin"),
+            engines.LOGIN_SHELL_PROBE_KILL: "0",
+        }
+    )
+    gone = next(item for item in registry if item.id == "gone-and-disabled")
+
+    assert gone.available is False
+    assert gone.available_for_create is False
+    assert gone.unavailable_reason == (
+        "`gone-agent` is not installed on this host (not on PATH) "
+        "and is disabled in the host registry."
+    )
+
+
+def test_configured_unavailable_reason_survives_the_probe(tmp_path):
+    """A host-authored explanation is not overwritten by the derived one."""
+    config_dir = tmp_path / "config" / "pocketshell"
+    config_dir.mkdir(parents=True)
+    (config_dir / "engines.yaml").write_text(
+        """
+engines:
+  - id: explained-engine
+    family: codex
+    harness: explained-agent
+    label: Explained Engine
+    unavailable_reason: retired by the ops team, see runbook 42
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    registry = engines.load_registry(
+        {
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "PATH": str(tmp_path / "empty-bin"),
+            engines.LOGIN_SHELL_PROBE_KILL: "0",
+        }
+    )
+    explained = next(item for item in registry if item.id == "explained-engine")
+
+    assert explained.available is False
+    assert explained.unavailable_reason == "retired by the ops team, see runbook 42"
 
 
 def test_registry_engine_is_accepted_by_generic_agent_helpers(tmp_path, monkeypatch):
@@ -167,9 +655,16 @@ def test_generic_click_wrapper_resolves_and_launches_custom_engine(
     assert "OPENAI_API_KEY" not in launched["env"]
 
 
-def test_aplexer_overlay_takes_command_env_unset_and_available(
+def test_aplexer_overlay_takes_command_and_env_unset_but_not_availability(
     tmp_path, monkeypatch, install_fake_a
 ):
+    """Issue #2276: availability is THIS host's own observation.
+
+    aplexer ships its own cached ``available`` bit. Inheriting it made a second
+    tool's stale answer authoritative for the picker, so the overlay now
+    carries launch data only (D22 hard cut — there is no legacy path that
+    still reads it).
+    """
     install_fake_a(
         engines=[
             {
@@ -192,7 +687,8 @@ def test_aplexer_overlay_takes_command_env_unset_and_available(
     assert claude.family == "claude"
     assert "CUSTOM_UNSET" in claude.launch.env_unset
     assert "OPENAI_API_KEY" in claude.launch.env_unset
-    assert claude.available is False
+    # aplexer said `available: False`; the registry does not inherit it.
+    assert claude.available is True
     assert claude.launch.skip_permissions_argv == (
         "--dangerously-skip-permissions",
     )


### PR DESCRIPTION
## Summary
- `resolve_harnesses()` now ladders exec PATH -> memoized login-shell PATH (`$SHELL -lc 'printenv PATH'`) -> glob-expanded nvm/fnm/volta/bun/asdf/mise/pnpm paths, so engines only installed via a version manager (e.g. Codex under nvm) are reported available instead of hidden from the New Session picker.
- Restores the `force_available:` override key in `engines.yaml` as the documented escape hatch.
- Adds `EngineAvailabilityPickerUiTest` / `EngineAvailabilityPickerDockerTest` journey coverage, wired into `scripts/ci-journey-suite.sh`.

## Review
Round 5, `APPROVED` — https://github.com/alexeygrigorev/pocketshell/issues/2276#issuecomment-5460152959. Reviewer reproduced the maintainer's exact bug on this host (login shell resolves `codex`/`opencode`, exec PATH doesn't) and drove G1 red->green twice: host (13 failed/7 passed on base -> 118 passed on candidate) and Docker fixture (BUILD FAILED on base -> 2/2 passed on candidate). AC4 verified via reviewer's own unfiltered gate: 1461 suites / 13602 tests / 0 failures.

Follow-ups filed by the reviewer as non-blocking issues (rung-3 absolute-path launch argv threading, shared `agents` fixture behavior change for other journeys) — tracked separately, not release-blocking.

## Test plan
- [x] `uv run pytest tests/test_engines.py tests/test_agents.py` - 118 passed
- [x] `./gradlew :app:testDebugUnitTest --tests RegistryDrivenSessionTypePickerTest` - 3/3 passed
- [x] `scripts/assemble-debug.sh` - BUILD SUCCESSFUL
- [x] `scripts/check-ci-journey-harness.sh` - rc=0, no new baseline drift
- [x] Reviewer's own red->green host + Docker reproduction (see issue comment)

Closes #2276