### PR TITLE
Fix vacuous RideThrough.brief nightly gate: toxiproxy fixture defect

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -277,6 +277,21 @@ jobs:
           scripts/check-tests-referenced.sh --self-test
           scripts/check-tests-referenced.sh
 
+      # Issue #1678/#1751/#2141: the nightly phase-2 fault verdict is only as
+      # honest as the exact-method guards that compute it — a class-level phase
+      # greens vacuously when a required method is skipped, renamed, or reports a
+      # timeline that claims nothing. Those guards run inside the nightly job, so
+      # nothing per-push proved they still go RED on a vacuous artifact. This runs
+      # their mutation self-test (skipped method, wrong method, forbidden typed
+      # event in the snapshot AND in the timeline, unfired positive-control
+      # observer, blocked/unrecovered same-connection sentinel, malformed
+      # authoritative viewport PNG) every push. Pure shell: no emulator, no
+      # Docker, no Gradle.
+      - name: "Nightly exact-method guard self-test (issue #1678/#1751)"
+        run: |
+          bash scripts/lib/nightly-exact-method-guard.sh --self-test
+          bash scripts/lib/nightly-phase-reports.sh --self-test
+
       # Issue #1355: MainDispatcherRule owns the global Dispatchers.Main reset.
       # Any standalone TmuxSessionViewModel test that leaves an unregistered VM
       # can race that reset from a still-unwinding coroutine and fail an

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -277,20 +277,11 @@ jobs:
           scripts/check-tests-referenced.sh --self-test
           scripts/check-tests-referenced.sh
 
-      # Issue #1678/#1751/#2141: the nightly phase-2 fault verdict is only as
-      # honest as the exact-method guards that compute it — a class-level phase
-      # greens vacuously when a required method is skipped, renamed, or reports a
-      # timeline that claims nothing. Those guards run inside the nightly job, so
-      # nothing per-push proved they still go RED on a vacuous artifact. This runs
-      # their mutation self-test (skipped method, wrong method, forbidden typed
-      # event in the snapshot AND in the timeline, unfired positive-control
-      # observer, blocked/unrecovered same-connection sentinel, malformed
-      # authoritative viewport PNG) every push. Pure shell: no emulator, no
-      # Docker, no Gradle.
+      # Issue #1678/#1751/#2141: per-push mutation self-test for the nightly
+      # exact-method guards. Rationale lives in the script (this workflow is at
+      # its file-size-hygiene cap, so the comments move with the code).
       - name: "Nightly exact-method guard self-test (issue #1678/#1751)"
-        run: |
-          bash scripts/lib/nightly-exact-method-guard.sh --self-test
-          bash scripts/lib/nightly-phase-reports.sh --self-test
+        run: bash scripts/run-nightly-guard-selftests.sh
 
       # Issue #1355: MainDispatcherRule owns the global Dispatchers.Main reset.
       # Any standalone TmuxSessionViewModel test that leaves an unregistered VM

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.proof
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
@@ -58,6 +60,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Assume
 import org.junit.Rule
 import java.io.File
+import java.io.FileOutputStream
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -407,18 +410,20 @@ abstract class NetworkFaultProofBase {
                 "recoveryInProgress=$showsRecoveryInProgress"
     }
 
-    /** The current [TmuxSessionViewModel.ConnectionStatus] simple name (VM real state). */
-    protected fun currentConnectionStatusName(): String {
-        var name = "unknown"
+    /** The current network-fault VM, including its diagnostic test seams. */
+    protected fun currentNetworkFaultViewModel(): TmuxSessionViewModel {
+        var viewModel: TmuxSessionViewModel? = null
         launchedActivity?.onActivity { activity ->
-            name = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
-                .connectionStatus
-                .value::class
-                .simpleName
-                ?: "null"
+            viewModel = ViewModelProvider(activity)[TmuxSessionViewModel::class.java]
         }
-        return name
+        return requireNotNull(viewModel) {
+            "TmuxSessionViewModel is unavailable without a live activity"
+        }
     }
+
+    /** The current [TmuxSessionViewModel.ConnectionStatus] simple name (VM real state). */
+    protected fun currentConnectionStatusName(): String =
+        currentNetworkFaultViewModel().connectionStatus.value::class.simpleName ?: "null"
 
     protected fun sampleRecovery(startedAt: Long): RecoverySnapshot = RecoverySnapshot(
         elapsedMs = SystemClock.elapsedRealtime() - startedAt,
@@ -1053,6 +1058,54 @@ abstract class NetworkFaultProofBase {
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         return requireNotNull(connection) { "TerminalView did not create an InputConnection" }
+    }
+
+    /**
+     * Capture the authoritative rendered TerminalView and its transcript from the
+     * same activity/view in this test run. A Compose tree dump is not sufficient
+     * evidence for the terminal journey: the reviewer needs the pixels the user
+     * could see and the text the terminal surface actually held.
+     */
+    protected fun captureAuthoritativeTerminalViewport(name: String): String {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.waitForIdleSync()
+        SystemClock.sleep(150)
+
+        var bitmap: Bitmap? = null
+        var visibleText = ""
+        launchedActivity?.onActivity { activity ->
+            val terminalView = requireNotNull(activity.window.decorView.findTerminalView()) {
+                "TerminalView was not found while capturing $name"
+            }
+            check(terminalView.width > 0 && terminalView.height > 0) {
+                "TerminalView had no measurable viewport while capturing $name: " +
+                    "${terminalView.width}x${terminalView.height}"
+            }
+            bitmap = Bitmap.createBitmap(
+                terminalView.width,
+                terminalView.height,
+                Bitmap.Config.ARGB_8888,
+            ).also { rendered -> terminalView.draw(Canvas(rendered)) }
+            visibleText = terminalView.currentSession?.emulator?.screen?.transcriptText.orEmpty()
+        }
+
+        val rendered = requireNotNull(bitmap) { "No viewport bitmap was captured for $name" }
+        val png = artifactFile("$name-viewport.png")
+        val text = artifactFile("$name-visible-terminal.txt")
+        try {
+            FileOutputStream(png).use { output ->
+                check(rendered.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                    "TerminalView PNG compression failed for $name"
+                }
+            }
+            text.writeText(visibleText)
+            check(visibleText.isNotBlank()) {
+                "Rendered TerminalView transcript was blank while capturing $name"
+            }
+        } finally {
+            rendered.recycle()
+        }
+        return visibleText
     }
 
     private fun visibleTerminalText(): String {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RideThroughInterruptionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RideThroughInterruptionE2eTest.kt
@@ -3,10 +3,31 @@ package com.pocketshell.app.proof
 import android.os.SystemClock
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.app.App
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.diagnostics.DiagnosticEvents
+import com.pocketshell.app.diagnostics.DiagnosticsEvent
+import com.pocketshell.app.diagnostics.MirroredDiagnostics
+import com.pocketshell.app.tmux.PASSIVE_DISCONNECT_GRACE_MS
 import com.pocketshell.app.tmux.TMUX_CONNECT_ATTEMPTS
+import com.pocketshell.core.connection.ConnectionController
+import com.pocketshell.core.connection.ConnectionJournalSchema
+import com.pocketshell.core.connection.LivenessProbe
+import com.pocketshell.core.ssh.KnownHostsPolicy
+import com.pocketshell.core.ssh.SshConnection
+import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import org.junit.Assume
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -32,9 +53,58 @@ import org.junit.runner.RunWith
  * AUTO-recovers to a usable Connected session once the link restores within the
  * episode budget — no manual tap.
  *
- * The sustained case uses a clean socket drop (`toxiproxy disable`), so the SSH
- * reader hits EOF immediately and the reconnect ladder is entered without needing
- * any detection-timing override — the EOF is the deciding signal.
+ * ## Issue #1678 — the five-second half-open journey is a REAL gate again
+ *
+ * [briefLinkCutRidesThroughWithoutDisconnectOrTeardown] used to open with an
+ * unconditional `Assume.assumeTrue(..., false)`, so the release-gating nightly
+ * phase-2 verdict was green while carrying one skip: the five-second contract was
+ * never executed. The literal-false skip is deleted and the journey now carries its
+ * own proof that it did the thing it claims:
+ *
+ * 1. **The fault engaged.** A wholly independent SSH session, established through
+ *    the SAME `network-fault-proxy:2228` port PocketShell uses, round-trips a nonce
+ *    BEFORE the cut. After the symmetric heal-able stall is installed, a
+ *    command issued on that same starved session must NOT complete and must NOT
+ *    create its remote file for the whole physical five-second window, verified by
+ *    a third, UNPROXIED direct SSH observer on port 2222. A no-op
+ *    `addHalfOpenStall()` reddens this immediately.
+ * 2. **Nothing recovered.** Every ~200 ms tick from before install through ≥4 s
+ *    after restore hard-asserts VM `Connected`, zero Reconnecting pill / Attaching
+ *    hold / Retry-now band / connecting progress row / settled Failed band, zero
+ *    extra dial, an unchanged connect generation, no active connect job, an
+ *    unchanged live control-client identity that is not disconnected, controller
+ *    `Live`, an unchanged exact server-side tmux client list, and zero typed
+ *    recovery/drop/reconnect/timeout diagnostics.
+ * 3. **The restore was real and the session is usable.** A FRESH same-proxy SSH
+ *    connection must complete after the toxics clear, and a command typed through
+ *    PocketShell's real `TerminalView` must create an exact remote file that the
+ *    unproxied observer reads back — a server-observable side effect, never the
+ *    terminal echo of the command text (the #1676 echo-oracle trap).
+ *
+ * [cleanCloseControlSurfacesHonestRecoveryToTheSameObserver] is the positive
+ * control for exactly that observer: a genuine clean socket close, watched by the
+ * SAME sampler, MUST turn it red (an honest user-visible recovery surface appears)
+ * and the app must then auto-heal to a usable session. Without it, "the observer
+ * stayed silent" would be indistinguishable from "the observer cannot speak".
+ *
+ * ### Why the fixture changed, and what the old failure actually was (#1678)
+ *
+ * The brief journey used [ToxiproxyControl.addBlackhole] (`timeout=0`) and then
+ * `clearToxics()`. Measured directly against this fixture, **Toxiproxy closes every
+ * connection carrying a `timeout` toxic when that toxic is removed**: a raw TCP
+ * socket holding a live SSH banner reads EOF on the first read after the DELETE.
+ * So "5 s blackhole then clear" was physically a five-second stall FOLLOWED BY A
+ * GENUINE REMOTE FIN, and the app's `reader_exception`/`eof` -> silent-reattach
+ * response to it was CORRECT. Whether that honest recovery appeared before the
+ * observation window closed was a race with runner speed — which is precisely the
+ * "anti-correlated FAST-night flake" #1676 observed and could not explain. It was
+ * never evidence about production ride-through policy, so nothing in
+ * `core-connection` is changed here.
+ *
+ * The brief journey now uses [ToxiproxyControl.addHalfOpenStall] (`bandwidth`
+ * `rate = 0`, both directions), which starves the same socket identically and
+ * genuinely HEALS on removal. The sustained case deliberately keeps a real close
+ * (`toxiproxy disable`) because a genuine outage is what it is testing.
  */
 @RunWith(AndroidJUnit4::class)
 class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
@@ -46,24 +116,14 @@ class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
      * blip, and the same tmux session resumes so input reaches the agent again
      * without teardown/reconnect.
      *
-     * Issue #1678 owns deleting this Assume and making the five-second journey
-     * non-vacuous. Issue #2141 does NOT restore this method: it makes the skip
-     * fail-closed in `fault-verdict.txt` so a green verdict cannot hide the hole.
-     * Neither issue covers the other. The FAST-night anti-correlation tracking
-     * and the intended deterministic reframe stay on #1678; do not treat this
-     * skip as "covered by #2141" or the verdict hole as "covered by #1678".
-     * See issue #1678 for the tracking + intended deterministic reframe.
+     * Issue #1678: production connection timing is deliberately untouched by this
+     * change. If a fully-engaged run ever leaves `Connected`, the failure artifact
+     * carries the complete typed producer/cause chain so the D28 decision can be
+     * made from evidence instead of a guess.
      */
     @Test
     fun briefLinkCutRidesThroughWithoutDisconnectOrTeardown() { runBlocking {
         assumeNetworkFaultProofsEnabled()
-        // Issue #1678 — gated: anti-correlated FAST-night flake, tracked in #1678.
-        Assume.assumeTrue(
-            "briefLinkCutRidesThroughWithoutDisconnectOrTeardown is gated per issue #1678 " +
-                "(anti-correlated FAST-night flake); re-enable once #1678 lands a deterministic " +
-                "grace-vs-blip seam.",
-            false,
-        )
 
         val key = readFixtureKey()
         val marker = "rt${System.currentTimeMillis().toString(36).takeLast(5)}"
@@ -85,30 +145,1034 @@ class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
         sendCommandThroughTerminalInput("printf 'BEFORE-$marker\\n'", "before-ride")
         waitForVisibleTerminalText("before-ride") { "BEFORE-$marker" in it }
         assertNoExtraConnectAttempts(attemptsBefore, expectedDelta = 1, label = "initial attach")
-
-        starveLinkFor("ride_blip", downMillis = BRIEF_BLIP_MS)
-        waitForNoDisconnectBandDuring("ride_blip_after_restore", durationMillis = POST_RESTORE_SETTLE_MS)
-        assertNoExtraConnectAttempts(
-            attemptsBefore,
-            expectedDelta = 1,
-            label = "ride through brief cut without teardown",
+        waitForConnectedStatus("brief initial attach")
+        val briefPreCutViewport = captureAuthoritativeTerminalViewport("brief-pre-cut")
+        assertTrue(
+            "authoritative pre-cut terminal text did not contain the baseline marker: $briefPreCutViewport",
+            "BEFORE-$marker" in briefPreCutViewport,
         )
 
-        sendCommandThroughTerminalInput("printf 'AFTER-$marker\\n'", "after-ride")
-        waitForVisibleTerminalText("after-ride") { "AFTER-$marker" in it }
-        waitForClientCountAtMost(key, sessionName, max = 1, label = "post-blip same client")
+        val baseline = captureIdentityBaseline("brief")
+
+        val cutSentinelPath = "/tmp/pocketshell-issue1678-cut-$marker"
+        val baselineSentinelPath = "/tmp/pocketshell-issue1678-baseline-$marker"
+        val restoreSentinelPath = "/tmp/pocketshell-issue1678-restored-$marker"
+        val appMarkerPath = "/tmp/pocketshell-issue1678-app-$marker"
+        val cutSentinelMarker = "CUT-SENTINEL-$marker"
+        val baselineSentinelMarker = "BASELINE-SENTINEL-$marker"
+        val restoreSentinelMarker = "RESTORED-SENTINEL-$marker"
+        val appMarker = "APP-RESTORED-$marker"
+        val remotePaths = arrayOf(cutSentinelPath, baselineSentinelPath, restoreSentinelPath, appMarkerPath)
+
+        val snapshots = mutableListOf<BriefRideThroughSnapshot>()
+        val phases = mutableListOf<BriefPhaseBoundary>()
+        val proxy = toxiproxy()
+
+        var observer: SshSession? = null
+        var proxiedSentinel: SshSession? = null
+        var cutExec: Deferred<SentinelOutcome>? = null
+        var cutDurationMs: Long? = null
+        var postRestoreObservedMs = 0L
+        var baselineSentinelCompleted = false
+        var cutSentinelCompletedDuringCut = false
+        var cutSentinelMarkerDuringCut = false
+        var cutSentinelOutcomeAfterRestore = "not-awaited"
+        var cutSentinelRecoveredAfterRestore = false
+        var cutSentinelMarkerAfterRestoreVerified = false
+        var restoredSentinelCompleted = false
+        var appMarkerVerified = false
+        var phaseCompleted = false
+        var proxyStateBeforeCut = "unread"
+        var proxyStateDuringCut = "unread"
+        var proxyStateAfterRestore = "unread"
+        var failure: Throwable? = null
+        var serverClientsBefore: List<String> = emptyList()
+
+        startConnectionDiagnosticCapture()
+        val episodeStartNanos = SystemClock.elapsedRealtimeNanos()
+        val episodeStartMs = SystemClock.elapsedRealtime()
+
+        try {
+            // #2397: prove the archives this proof's negative claims read are live
+            // for THIS episode before any of those claims is made.
+            assertDiagnosticCaptureIsLive(episodeStartNanos, marker)
+
+            val directObserver = openDirectFixtureObserver(key)
+            observer = directObserver
+            removeRemoteFiles(directObserver, *remotePaths)
+
+            serverClientsBefore = serverClientIdentities(directObserver, sessionName)
+            assertEquals(
+                "brief proof baseline must have exactly one server-side tmux client, got $serverClientsBefore",
+                1,
+                serverClientsBefore.size,
+            )
+
+            // The engagement oracle's own control: the SAME proxy port PocketShell
+            // rides must demonstrably work before the fault, or a later "it did not
+            // complete" would prove nothing about the toxic.
+            val proxiedSession = openProxiedSentinelSession(key)
+            proxiedSentinel = proxiedSession
+            val baselineOutcome = withTimeout(PROXY_SENTINEL_BASELINE_TIMEOUT_MS) {
+                runSentinelCommand(proxiedSession, baselineSentinelPath, baselineSentinelMarker)
+            }
+            baselineSentinelCompleted = baselineOutcome.succeededWith(baselineSentinelMarker)
+            assertTrue(
+                "the same-proxy SSH sentinel could not complete BEFORE fault installation; a later " +
+                    "blocked attempt would then prove nothing about engagement: $baselineOutcome",
+                baselineSentinelCompleted,
+            )
+            waitForExactRemoteFile(
+                directObserver,
+                baselineSentinelPath,
+                baselineSentinelMarker,
+                "pre-cut baseline sentinel",
+            )
+            phases += BriefPhaseBoundary("baseline_sentinel_completed", elapsedMs(episodeStartMs))
+
+            proxyStateBeforeCut = proxy.state().toString()
+            phases += BriefPhaseBoundary("pre_install", elapsedMs(episodeStartMs))
+            captureBriefSnapshot(
+                snapshots = snapshots,
+                phase = "pre_install",
+                episodeStartMs = episodeStartMs,
+                episodeStartNanos = episodeStartNanos,
+                observer = directObserver,
+                sessionName = sessionName,
+                baseline = baseline,
+                serverClientsBefore = serverClientsBefore,
+            ).assertSilent("pre_install")
+
+            proxy.addHalfOpenStall()
+            val installedAtMs = SystemClock.elapsedRealtime()
+            proxyStateDuringCut = proxy.state().toString()
+            phases += BriefPhaseBoundary("toxic_installed", elapsedMs(episodeStartMs))
+
+            // G6 / #1678: a command on the ALREADY-ESTABLISHED same-proxy session,
+            // i.e. exactly the condition PocketShell's own live socket is in. If
+            // `addHalfOpenStall()` is mutated to a no-op it completes in
+            // milliseconds and its remote file appears at the first tick, reddening
+            // BOTH halves of the engagement oracle.
+            val runningCutExec = async(Dispatchers.IO) {
+                runSentinelCommand(proxiedSession, cutSentinelPath, cutSentinelMarker)
+            }
+            cutExec = runningCutExec
+
+            val cutDeadline = installedAtMs + BRIEF_BLIP_MS
+            // Sample only while a whole snapshot still fits inside the window, so a
+            // slow tick cannot push the PHYSICAL cut past BRIEF_BLIP_MAX_MS and
+            // disqualify an otherwise-valid iteration. The tail of the window is
+            // slept out, and the window itself is still measured and asserted.
+            while (SystemClock.elapsedRealtime() + SNAPSHOT_BUDGET_MS < cutDeadline) {
+                val snapshot = captureBriefSnapshot(
+                    snapshots = snapshots,
+                    phase = "fault_engaged",
+                    episodeStartMs = episodeStartMs,
+                    episodeStartNanos = episodeStartNanos,
+                    observer = directObserver,
+                    sessionName = sessionName,
+                    baseline = baseline,
+                    serverClientsBefore = serverClientsBefore,
+                    sentinelRemotePath = cutSentinelPath,
+                    sentinelCompleted = runningCutExec.isCompleted,
+                )
+                cutSentinelCompletedDuringCut = cutSentinelCompletedDuringCut || snapshot.sentinelCompleted
+                cutSentinelMarkerDuringCut = cutSentinelMarkerDuringCut || snapshot.sentinelRemoteMarkerPresent
+                snapshot.assertSilent("fault_engaged")
+                assertFalse(
+                    "the same-proxy SSH sentinel COMPLETED during the ${BRIEF_BLIP_MS}ms cut — the " +
+                        "Toxiproxy blackhole did not engage: ${snapshot.asLine()}",
+                    snapshot.sentinelCompleted,
+                )
+                assertFalse(
+                    "the same-proxy SSH sentinel REACHED THE SERVER during the ${BRIEF_BLIP_MS}ms cut — " +
+                        "the Toxiproxy blackhole did not engage: ${snapshot.asLine()}",
+                    snapshot.sentinelRemoteMarkerPresent,
+                )
+                val remaining = cutDeadline - SystemClock.elapsedRealtime()
+                if (remaining > 0L) SystemClock.sleep(minOf(BRIEF_SAMPLE_INTERVAL_MS, remaining))
+            }
+            // The fault MUST stay installed for the whole physical five seconds even
+            // if sampling finished early — the window is the thing under test.
+            (cutDeadline - SystemClock.elapsedRealtime())
+                .takeIf { it > 0L }
+                ?.let { SystemClock.sleep(it) }
+            assertTrue(
+                "the ${BRIEF_BLIP_MS}ms engaged cut must be sampled, not merely slept through; " +
+                    "observed ticks=${snapshots.count { it.phase == "fault_engaged" }}",
+                snapshots.count { it.phase == "fault_engaged" } >= MIN_ENGAGED_TICKS,
+            )
+
+            proxy.clearToxics()
+            val clearedAtMs = SystemClock.elapsedRealtime()
+            cutDurationMs = clearedAtMs - installedAtMs
+            proxyStateAfterRestore = proxy.state().toString()
+            phases += BriefPhaseBoundary("toxic_cleared", elapsedMs(episodeStartMs))
+            recordTiming("ride_blip_actual_ms", clearedAtMs - installedAtMs)
+            assertTrue(
+                "the qualifying brief fault must stay inside the exact five-second window " +
+                    "[$BRIEF_BLIP_MS,$BRIEF_BLIP_MAX_MS]ms; observed=${cutDurationMs}ms",
+                cutDurationMs in BRIEF_BLIP_MS..BRIEF_BLIP_MAX_MS,
+            )
+
+            // The settle window: the user contract stays silent for at least
+            // POST_RESTORE_SETTLE_MS after the link is healthy again.
+            val postRestoreStart = SystemClock.elapsedRealtime()
+            val postRestoreDeadline = postRestoreStart + POST_RESTORE_SETTLE_MS
+            do {
+                captureBriefSnapshot(
+                    snapshots = snapshots,
+                    phase = "post_restore",
+                    episodeStartMs = episodeStartMs,
+                    episodeStartNanos = episodeStartNanos,
+                    observer = directObserver,
+                    sessionName = sessionName,
+                    baseline = baseline,
+                    serverClientsBefore = serverClientsBefore,
+                ).assertSilent("post_restore")
+                val remaining = postRestoreDeadline - SystemClock.elapsedRealtime()
+                if (remaining > 0L) SystemClock.sleep(minOf(BRIEF_SAMPLE_INTERVAL_MS, remaining))
+            } while (SystemClock.elapsedRealtime() < postRestoreDeadline)
+            postRestoreObservedMs = SystemClock.elapsedRealtime() - postRestoreStart
+            phases += BriefPhaseBoundary("post_restore_observation_complete", elapsedMs(episodeStartMs))
+            assertTrue(
+                "post-restore observation must cover at least ${POST_RESTORE_SETTLE_MS}ms, " +
+                    "observed=${postRestoreObservedMs}ms",
+                postRestoreObservedMs >= POST_RESTORE_SETTLE_MS,
+            )
+
+            // The already-established same-proxy session is the primary restore
+            // oracle. It must drain the exact command that was blocked by the
+            // half-open stall, and the independent observer must see its unique
+            // server-side marker. A fresh connection below remains a corroborating
+            // check that the proxy itself accepts new traffic after healing.
+            val cutOutcomeAfterRestore =
+                withTimeoutOrNull(SENTINEL_DRAIN_TIMEOUT_MS) { runningCutExec.await() }
+            val completedCutOutcome = requireNotNull(cutOutcomeAfterRestore) {
+                "the original same-proxy sentinel did not complete within " +
+                    "${SENTINEL_DRAIN_TIMEOUT_MS}ms after the half-open stall was healed"
+            }
+            cutSentinelOutcomeAfterRestore = completedCutOutcome.evidence(cutSentinelMarker)
+            cutSentinelRecoveredAfterRestore =
+                completedCutOutcome.succeededWith(cutSentinelMarker)
+            assertTrue(
+                "the already-established same-proxy SSH sentinel did not complete after the " +
+                    "half-open stall was healed: $cutSentinelOutcomeAfterRestore",
+                cutSentinelRecoveredAfterRestore,
+            )
+            val cutSentinelRemoteMarker = waitForExactRemoteFile(
+                directObserver,
+                cutSentinelPath,
+                cutSentinelMarker,
+                "post-restore same-proxy sentinel",
+            )
+            assertEquals(
+                "the independent observer returned an unexpected original same-proxy sentinel marker",
+                cutSentinelMarker,
+                cutSentinelRemoteMarker,
+            )
+            cutSentinelMarkerAfterRestoreVerified = true
+
+            val restoreOutcome = withTimeout(PROXY_SENTINEL_RESTORE_TIMEOUT_MS) {
+                openProxiedSentinelSession(key).use { fresh ->
+                    runSentinelCommand(fresh, restoreSentinelPath, restoreSentinelMarker)
+                }
+            }
+            restoredSentinelCompleted = restoreOutcome.succeededWith(restoreSentinelMarker)
+            assertTrue(
+                "a FRESH same-proxy SSH sentinel did not complete after the toxics cleared: $restoreOutcome",
+                restoredSentinelCompleted,
+            )
+            waitForExactRemoteFile(
+                directObserver,
+                restoreSentinelPath,
+                restoreSentinelMarker,
+                "post-restore fresh sentinel",
+            )
+            phases += BriefPhaseBoundary("restore_sentinel_completed", elapsedMs(episodeStartMs))
+
+            // The post-restore oracle is SERVER state, not terminal echo (#1676):
+            // PocketShell types through its real TerminalView and the independent
+            // UNPROXIED observer must read the exact remote file back.
+            sendCommandThroughTerminalInput(
+                "printf '%s' ${shellQuote(appMarker)} > ${shellQuote(appMarkerPath)}",
+                "post-restore-server-marker",
+            )
+            waitForExactRemoteFile(
+                directObserver,
+                appMarkerPath,
+                appMarker,
+                "PocketShell post-restore marker",
+            )
+            appMarkerVerified = true
+            val briefPostRestoreViewport = captureAuthoritativeTerminalViewport("brief-post-restore")
+            assertTrue(
+                "authoritative post-restore terminal text did not contain the server marker: " +
+                    briefPostRestoreViewport,
+                appMarker in briefPostRestoreViewport,
+            )
+            phases += BriefPhaseBoundary("app_server_marker_verified", elapsedMs(episodeStartMs))
+
+            val (connectionEvents, journalEvents) = episodeDiagnostics(episodeStartNanos)
+            assertMonotonicDiagnostics("connection", connectionEvents)
+            assertMonotonicDiagnostics("controller journal", journalEvents)
+            assertNoForbiddenRecoveryEvents(connectionEvents, journalEvents, "final brief episode")
+            phaseCompleted = true
+        } catch (error: Throwable) {
+            failure = error
+            throw error
+        } finally {
+            runCatching { cutExec?.cancel() }
+            runCatching { proxy.clearToxics() }
+            writeBriefRideThroughEvidence(
+                episodeStartNanos = episodeStartNanos,
+                snapshots = snapshots,
+                phases = phases,
+                cutDurationMs = cutDurationMs,
+                postRestoreObservedMs = postRestoreObservedMs,
+                baselineSentinelCompleted = baselineSentinelCompleted,
+                cutSentinelCompletedDuringCut = cutSentinelCompletedDuringCut,
+                cutSentinelMarkerDuringCut = cutSentinelMarkerDuringCut,
+                cutSentinelOutcomeAfterRestore = cutSentinelOutcomeAfterRestore,
+                cutSentinelRecoveredAfterRestore = cutSentinelRecoveredAfterRestore,
+                cutSentinelMarkerAfterRestoreVerified = cutSentinelMarkerAfterRestoreVerified,
+                restoredSentinelCompleted = restoredSentinelCompleted,
+                appMarkerVerified = appMarkerVerified,
+                phaseCompleted = phaseCompleted,
+                proxyStateBeforeCut = proxyStateBeforeCut,
+                proxyStateDuringCut = proxyStateDuringCut,
+                proxyStateAfterRestore = proxyStateAfterRestore,
+                failure = failure,
+            )
+            runCatching { observer?.let { removeRemoteFiles(it, *remotePaths) } }
+            runCatching { proxiedSentinel?.close() }
+            runCatching { observer?.close() }
+        }
 
         writeSummary(
             testName = "RideThroughInterruptionE2eTest-brief",
             lines = listOf(
                 "session=$sessionName",
                 "marker=$marker",
-                "cut=toxiproxy timeout toxic timeout=0 for ${BRIEF_BLIP_MS}ms",
-                "expectation=session held, no disconnect band, same client resumes",
-                "connect_attempt_delta=${TMUX_CONNECT_ATTEMPTS.get() - attemptsBefore}",
+                "cut=toxiproxy bandwidth rate=0 (heal-able no-FIN stall) " +
+                    "target=${BRIEF_BLIP_MS}ms actual=${cutDurationMs}ms",
+                "proxy_before_cut=$proxyStateBeforeCut",
+                "proxy_during_cut=$proxyStateDuringCut",
+                "proxy_after_restore=$proxyStateAfterRestore",
+                "same_proxy_sentinel_completed_before_cut=$baselineSentinelCompleted",
+                "same_proxy_sentinel_blocked_during_cut=${!cutSentinelCompletedDuringCut}",
+                "same_proxy_sentinel_marker_absent_during_cut=${!cutSentinelMarkerDuringCut}",
+                "same_proxy_sentinel_completed_after_restore_existing_connection=$cutSentinelRecoveredAfterRestore",
+                "same_proxy_sentinel_marker_verified_after_restore=$cutSentinelMarkerAfterRestoreVerified",
+                "same_proxy_sentinel_completed_after_restore=$restoredSentinelCompleted",
+                "post_restore_observed_ms=$postRestoreObservedMs",
+                "app_server_marker_verified=$appMarkerVerified",
+                "observed_ticks=${snapshots.size}",
+                "expectation=Connected throughout; zero recovery signals/dials/client replacement",
+                "connect_attempt_delta=${TMUX_CONNECT_ATTEMPTS.get() - baseline.connectAttempts}",
             ),
         )
     } }
+
+    /**
+     * Issue #1678 POSITIVE CONTROL — the silent observer must be able to speak.
+     *
+     * [briefLinkCutRidesThroughWithoutDisconnectOrTeardown]'s whole load-bearing
+     * claim is a NEGATIVE one ("no recovery surfaced"), and a negative claim from a
+     * sampler that can never fire is exactly the G6 wrong-cost trap that produced
+     * the vacuous `waitForNoDisconnectBandDuring` this issue replaces. So the SAME
+     * sampler is pointed at a genuine clean socket close: it MUST report an honest,
+     * user-visible recovery surface, and the app MUST then auto-heal to a session
+     * that still executes real input on the server.
+     *
+     * Note the deliberate asymmetry with [sustainedLinkCutReconnectsCleanlyWithoutHang]:
+     * that test proves the PRODUCT recovers; this one proves the OBSERVER used by
+     * the brief journey detects the recovery. Deleting either the recovery-surface
+     * fields or the identity fields from the sampler reddens this test while the
+     * brief journey stays green — the selectivity that makes the negative claim mean
+     * something.
+     */
+    @Test
+    fun cleanCloseControlSurfacesHonestRecoveryToTheSameObserver() { runBlocking {
+        assumeNetworkFaultProofsEnabled()
+
+        val key = readFixtureKey()
+        val marker = "cc${System.currentTimeMillis().toString(36).takeLast(5)}"
+        val sessionName = "issue1678-control-$marker"
+        val hostName = "Issue1678 Control $marker"
+        prepareProxyAndRemoteSession(
+            key = key,
+            sessionName = sessionName,
+            readyText = "ISSUE1678-CONTROL-READY-$marker",
+        )
+        val hostRowTag = seedNetworkFaultHost(key, hostName)
+
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+        attachToSession(hostRowTag, hostName, sessionName)
+        sendCommandThroughTerminalInput("printf 'BEFORE-$marker\\n'", "before-control")
+        waitForVisibleTerminalText("before-control") { "BEFORE-$marker" in it }
+        waitForConnectedStatus("control initial attach")
+        val controlPreCloseViewport = captureAuthoritativeTerminalViewport("control-pre-close")
+        assertTrue(
+            "authoritative control pre-close terminal text did not contain the baseline marker: " +
+                controlPreCloseViewport,
+            "BEFORE-$marker" in controlPreCloseViewport,
+        )
+
+        val baseline = captureIdentityBaseline("control")
+        val appMarkerPath = "/tmp/pocketshell-issue1678-control-app-$marker"
+        val appMarker = "CONTROL-RECOVERED-$marker"
+
+        val snapshots = mutableListOf<BriefRideThroughSnapshot>()
+        val proxy = toxiproxy()
+        var observer: SshSession? = null
+        var readerEofDeferred: Deferred<DiagnosticsEvent>? = null
+        var readerEofDiagnostic: DiagnosticsEvent? = null
+        var firstViolatingTick: BriefRideThroughSnapshot? = null
+        var recoveryDetectedMs = -1L
+        var readerEofDetectedMs = -1L
+        var productionDisconnectTriggered = false
+        var appMarkerVerified = false
+        var failure: Throwable? = null
+
+        startConnectionDiagnosticCapture()
+        val episodeStartNanos = SystemClock.elapsedRealtimeNanos()
+        val episodeStartMs = SystemClock.elapsedRealtime()
+
+        try {
+            // #2397: the positive control's own typed-EOF oracle reads the same
+            // archives, so prove they can speak before trusting either verdict.
+            assertDiagnosticCaptureIsLive(episodeStartNanos, marker)
+
+            val directObserver = openDirectFixtureObserver(key)
+            observer = directObserver
+            removeRemoteFiles(directObserver, appMarkerPath)
+            val serverClientsBefore = serverClientIdentities(directObserver, sessionName)
+            assertEquals(
+                "control baseline must have exactly one server-side tmux client, got $serverClientsBefore",
+                1,
+                serverClientsBefore.size,
+            )
+
+            // Same sampler, healthy link: it must be SILENT here, otherwise "it fired
+            // on the clean close" would be meaningless.
+            captureBriefSnapshot(
+                snapshots = snapshots,
+                phase = "control_pre_close",
+                episodeStartMs = episodeStartMs,
+                episodeStartNanos = episodeStartNanos,
+                observer = directObserver,
+                sessionName = sessionName,
+                baseline = baseline,
+                serverClientsBefore = serverClientsBefore,
+            ).assertSilent("control_pre_close")
+
+            val beforeState = proxy.state()
+            assertTrue(
+                "expected an enabled 2228 -> agents:22 proxy before the control close, got $beforeState",
+                beforeState.enabled,
+            )
+            proxy.disable()
+            val closedState = proxy.state()
+            assertFalse(
+                "expected Toxiproxy's independent oracle to confirm the clean close engaged, got $closedState",
+                closedState.enabled,
+            )
+            // Keep this explicit in the evidence: the positive control must drive the
+            // real socket-close path that the brief journey promises to observe, not
+            // merely sample a pre-existing recovery state.
+            productionDisconnectTriggered = true
+            val closedAtMs = SystemClock.elapsedRealtime()
+            // The positive control must prove the genuine reader-side cause as
+            // well as the user-visible projection. Run the typed EOF wait in
+            // parallel with the shared sampler so either oracle remains within
+            // the same bounded post-close episode.
+            readerEofDeferred = async(Dispatchers.IO) {
+                waitForReaderEofDiagnostic(sessionName, "control")
+            }
+
+            val detectDeadline = closedAtMs + RECONNECTING_BAND_BUDGET_MS
+            while (SystemClock.elapsedRealtime() < detectDeadline && firstViolatingTick == null) {
+                val snapshot = captureBriefSnapshot(
+                    snapshots = snapshots,
+                    phase = "control_closed",
+                    episodeStartMs = episodeStartMs,
+                    episodeStartNanos = episodeStartNanos,
+                    observer = directObserver,
+                    sessionName = sessionName,
+                    baseline = baseline,
+                    serverClientsBefore = serverClientsBefore,
+                )
+                if (snapshot.userVisibleRecoveryViolations().isNotEmpty()) {
+                    firstViolatingTick = snapshot
+                    recoveryDetectedMs = SystemClock.elapsedRealtime() - closedAtMs
+                }
+                SystemClock.sleep(BRIEF_SAMPLE_INTERVAL_MS)
+            }
+            assertNotNull(
+                "POSITIVE CONTROL FAILED: the brief journey's sampler saw NOTHING for " +
+                "${RECONNECTING_BAND_BUDGET_MS}ms after a genuine clean socket close. Either the " +
+                    "sampler is blind (its silence in the brief journey proves nothing) or the app " +
+                    "suppressed an honest drop. Last tick=${snapshots.lastOrNull()?.asLine()}",
+                firstViolatingTick,
+            )
+            readerEofDiagnostic = requireNotNull(readerEofDeferred).await()
+            readerEofDetectedMs =
+                (readerEofDiagnostic!!.monotonicTimestampNanos - episodeStartNanos) / 1_000_000L
+            recordTiming("control_recovery_detected_ms", recoveryDetectedMs)
+            recordTiming("control_reader_eof_ms", readerEofDetectedMs)
+
+            proxy.enable()
+            val restoredState = proxy.state()
+            assertTrue(
+                "expected Toxiproxy's independent oracle to confirm the control restore, got $restoredState",
+                restoredState.enabled,
+            )
+            waitForSshFixtureReady(key = SshKey.Pem(key), port = NETWORK_FAULT_SSH_PORT)
+
+            // Not over-suppressed: a genuine drop still AUTO-heals to a usable session
+            // whose input reaches the real server.
+            waitForConnectedStatus("control auto-recovery")
+            sendCommandThroughTerminalInput(
+                "printf '%s' ${shellQuote(appMarker)} > ${shellQuote(appMarkerPath)}",
+                "control-post-recovery-server-marker",
+            )
+            waitForExactRemoteFile(
+                directObserver,
+                appMarkerPath,
+                appMarker,
+                "control post-recovery marker",
+            )
+            appMarkerVerified = true
+            val controlPostRecoveryViewport = captureAuthoritativeTerminalViewport("control-post-recovery")
+            assertTrue(
+                "authoritative control post-recovery terminal text did not contain the server marker: " +
+                    controlPostRecoveryViewport,
+                appMarker in controlPostRecoveryViewport,
+            )
+            waitForClientCountAtMost(key, sessionName, max = 1, label = "control post-recovery")
+        } catch (error: Throwable) {
+            failure = error
+            throw error
+        } finally {
+            runCatching { proxy.enable() }
+            runCatching { readerEofDeferred?.cancel() }
+            runCatching {
+                artifactFile(CONTROL_EVIDENCE_FILE).writeText(
+                    buildString {
+                        appendLine(
+                            "test=RideThroughInterruptionE2eTest#" +
+                                "cleanCloseControlSurfacesHonestRecoveryToTheSameObserver",
+                        )
+                        appendLine("production_disconnect_triggered=$productionDisconnectTriggered")
+                        appendLine("observer_detected_recovery=${firstViolatingTick != null}")
+                        appendLine("observer_recovery_detected_ms=$recoveryDetectedMs")
+                        appendLine("observer_first_violations=${firstViolatingTick?.userVisibleRecoveryViolations()}")
+                        appendLine("typed_reader_eof_detected=${readerEofDiagnostic != null}")
+                        appendLine("typed_reader_eof_event_name=${readerEofDiagnostic?.name ?: "missing"}")
+                        appendLine(
+                            "typed_reader_eof_disconnect_reason=" +
+                                "${readerEofDiagnostic?.metadata?.get("disconnectReason") ?: "missing"}",
+                        )
+                        appendLine(
+                            "typed_reader_eof_source=${readerEofDiagnostic?.metadata?.get("source") ?: "missing"}",
+                        )
+                        appendLine(
+                            "typed_reader_eof_message=${readerEofDiagnostic?.metadata?.get("message") ?: "missing"}",
+                        )
+                        appendLine("typed_reader_eof_event_elapsed_ms=$readerEofDetectedMs")
+                        appendLine("app_server_marker_verified=$appMarkerVerified")
+                        appendLine("failure=${failure?.let { "${it.javaClass.simpleName}:${it.message}" } ?: "none"}")
+                        appendLine("observer_ticks:")
+                        snapshots.forEach { appendLine("  ${it.asLine()}") }
+                    },
+                )
+            }
+            runCatching { observer?.let { removeRemoteFiles(it, appMarkerPath) } }
+            runCatching { observer?.close() }
+        }
+
+        writeSummary(
+            testName = "RideThroughInterruptionE2eTest-clean-close-control",
+            lines = listOf(
+                "session=$sessionName",
+                "marker=$marker",
+                "cut=toxiproxy disable (genuine clean socket close), then enable",
+                "observer_recovery_detected_ms=$recoveryDetectedMs",
+                "observer_first_violations=${firstViolatingTick?.userVisibleRecoveryViolations()}",
+                "app_server_marker_verified=$appMarkerVerified",
+                "observed_ticks=${snapshots.size}",
+            ),
+        )
+    } }
+
+    // ---------------------------------------------------------------------
+    // Shared #1678 sampler / oracles
+    // ---------------------------------------------------------------------
+
+    private data class IdentityBaseline(
+        val connectAttempts: Int,
+        val connectGeneration: Long,
+        val clientIdentity: Int,
+    )
+
+    private fun captureIdentityBaseline(label: String): IdentityBaseline {
+        val viewModel = currentNetworkFaultViewModel()
+        val clientIdentity = viewModel.currentClientIdentityForTest()
+        assertNotNull("$label proof requires a live control client before the fault", clientIdentity)
+        assertFalse(
+            "$label proof requires a live (non-disconnected) control client before the fault",
+            viewModel.clientDisconnectedForTest(),
+        )
+        return IdentityBaseline(
+            connectAttempts = TMUX_CONNECT_ATTEMPTS.get(),
+            connectGeneration = viewModel.currentConnectGenerationForTest(),
+            clientIdentity = requireNotNull(clientIdentity),
+        )
+    }
+
+    private data class SentinelOutcome(
+        val exitCode: Int,
+        val stdout: String,
+        val stderr: String,
+        val error: String?,
+    ) {
+        fun succeededWith(marker: String): Boolean = error == null && exitCode == 0 && stdout == marker
+
+        fun evidence(marker: String): String =
+            "completed=${succeededWith(marker)} " +
+                "exitCode=$exitCode stdoutMatchesMarker=${stdout == marker} " +
+                "stderrEmpty=${stderr.isEmpty()} error=${error ?: "none"}"
+    }
+
+    private data class BriefPhaseBoundary(val name: String, val elapsedMs: Long)
+
+    private data class BriefRideThroughSnapshot(
+        val phase: String,
+        val recovery: RecoverySnapshot,
+        val connectAttempts: Int,
+        val connectGeneration: Long,
+        val connectJobActive: Boolean,
+        val clientIdentity: Int?,
+        val clientDisconnected: Boolean,
+        val controllerState: String,
+        val serverClients: List<String>,
+        val serverClientsBefore: List<String>,
+        val baseline: IdentityBaseline,
+        val sentinelCompleted: Boolean,
+        val sentinelRemoteMarkerPresent: Boolean,
+        val connectionEventCount: Int,
+        val journalEventCount: Int,
+        val forbiddenEvents: List<String>,
+    ) {
+        /**
+         * Everything a USER would see or feel as "the connection dropped": the VM
+         * status leaving Connected, any rendered recovery surface, a fresh dial, a
+         * replaced/disconnected control client, a controller state that is no longer
+         * Live, or the server-side tmux client set changing. This is the exact set
+         * the brief journey requires to stay EMPTY and the clean-close control
+         * requires to become NON-empty.
+         */
+        fun userVisibleRecoveryViolations(): List<String> = buildList {
+            if (recovery.statusName != "Connected") add("vm_status=${recovery.statusName}")
+            if (recovery.reconnectingPill) add("reconnecting_pill")
+            if (recovery.attachingHold) add("attaching_hold")
+            if (recovery.reconnectBandRetryNow) add("reconnect_band_retry_now")
+            if (recovery.connectingProgressRow) add("connecting_progress_row")
+            if (recovery.settledFailedBand) add("settled_failed_band")
+            if (connectAttempts != baseline.connectAttempts) add("extra_dial=$connectAttempts")
+            if (connectGeneration != baseline.connectGeneration) add("connect_generation=$connectGeneration")
+            if (connectJobActive) add("connect_job_active")
+            if (clientIdentity != baseline.clientIdentity) add("client_replaced=$clientIdentity")
+            if (clientDisconnected) add("client_disconnected")
+            if (controllerState != "Live") add("controller_state=$controllerState")
+            if (serverClients != serverClientsBefore) add("server_clients=$serverClients")
+        }
+
+        fun assertSilent(label: String) {
+            val violations = userVisibleRecoveryViolations()
+            assertTrue(
+                "the ride-through contract was broken during $label: $violations — ${asLine()}",
+                violations.isEmpty(),
+            )
+            assertTrue(
+                "typed recovery/cause diagnostics fired during $label: $forbiddenEvents — ${asLine()}",
+                forbiddenEvents.isEmpty(),
+            )
+        }
+
+        fun asLine(): String = buildString {
+            append("phase=$phase ")
+            append(recovery.asLine())
+            append(" attempts=$connectAttempts generation=$connectGeneration")
+            append(" connectJobActive=$connectJobActive")
+            append(" clientIdentity=$clientIdentity clientDisconnected=$clientDisconnected")
+            append(" controllerState=${controllerState.replace(' ', '_')}")
+            append(" serverClients=${serverClients.joinToString(prefix = "[", postfix = "]")}")
+            append(" sentinelCompleted=$sentinelCompleted")
+            append(" sentinelRemoteMarkerPresent=$sentinelRemoteMarkerPresent")
+            append(" connectionEvents=$connectionEventCount journalEvents=$journalEventCount")
+            append(" forbiddenEvents=${forbiddenEvents.joinToString(prefix = "[", postfix = "]")}")
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private suspend fun captureBriefSnapshot(
+        snapshots: MutableList<BriefRideThroughSnapshot>,
+        phase: String,
+        episodeStartMs: Long,
+        episodeStartNanos: Long,
+        observer: SshSession,
+        sessionName: String,
+        baseline: IdentityBaseline,
+        serverClientsBefore: List<String>,
+        sentinelRemotePath: String? = null,
+        sentinelCompleted: Boolean = false,
+    ): BriefRideThroughSnapshot {
+        val viewModel = currentNetworkFaultViewModel()
+        val recovery = sampleRecovery(episodeStartMs)
+        val serverClients = serverClientIdentities(observer, sessionName)
+        val sentinelMarkerPresent = sentinelRemotePath
+            ?.let { remoteFileContents(observer, it) != null }
+            ?: false
+        val (connectionEvents, journalEvents) = episodeDiagnostics(episodeStartNanos)
+        val snapshot = BriefRideThroughSnapshot(
+            phase = phase,
+            recovery = recovery,
+            connectAttempts = TMUX_CONNECT_ATTEMPTS.get(),
+            connectGeneration = viewModel.currentConnectGenerationForTest(),
+            connectJobActive = viewModel.connectJobActiveForTest(),
+            clientIdentity = viewModel.currentClientIdentityForTest(),
+            clientDisconnected = viewModel.clientDisconnectedForTest(),
+            controllerState = viewModel.connectionControllerStateForTest()::class.simpleName ?: "unknown",
+            serverClients = serverClients,
+            serverClientsBefore = serverClientsBefore,
+            baseline = baseline,
+            sentinelCompleted = sentinelCompleted,
+            sentinelRemoteMarkerPresent = sentinelMarkerPresent,
+            connectionEventCount = connectionEvents.size,
+            journalEventCount = journalEvents.size,
+            forbiddenEvents = forbiddenRecoveryEvents(connectionEvents, journalEvents),
+        )
+        // Append BEFORE any assertion so the FAILING tick is in the artifact.
+        snapshots += snapshot
+        return snapshot
+    }
+
+    /** UNPROXIED direct SSH (port 2222) — the third-party server-state observer. */
+    private suspend fun openDirectFixtureObserver(key: String): SshSession =
+        withTimeout(OBSERVER_CONNECT_TIMEOUT_MS) {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = OBSERVER_CONNECT_TIMEOUT_MS.toInt(),
+            ).getOrThrow()
+        }
+
+    /** A wholly independent SSH session through the SAME proxy port the app rides. */
+    private suspend fun openProxiedSentinelSession(key: String): SshSession =
+        withTimeout(PROXY_SENTINEL_CONNECT_TIMEOUT_MS.toLong()) {
+            SshConnection.connect(
+                host = DEFAULT_HOST,
+                port = NETWORK_FAULT_SSH_PORT,
+                user = DEFAULT_USER,
+                key = SshKey.Pem(key),
+                knownHosts = KnownHostsPolicy.AcceptAll,
+                timeoutMs = PROXY_SENTINEL_CONNECT_TIMEOUT_MS,
+            ).getOrThrow()
+        }
+
+    private suspend fun runSentinelCommand(
+        session: SshSession,
+        remotePath: String,
+        marker: String,
+    ): SentinelOutcome = runCatching {
+        session.exec(
+            "printf '%s' ${shellQuote(marker)} > ${shellQuote(remotePath)}; " +
+                "printf '%s' ${shellQuote(marker)}",
+        )
+    }.fold(
+        onSuccess = { SentinelOutcome(it.exitCode, it.stdout, it.stderr, error = null) },
+        onFailure = { SentinelOutcome(-1, "", "", error = "${it.javaClass.simpleName}:${it.message}") },
+    )
+
+    private suspend fun serverClientIdentities(observer: SshSession, sessionName: String): List<String> {
+        val result = withTimeout(OBSERVER_EXEC_TIMEOUT_MS) {
+            observer.exec(
+                "tmux list-clients -t ${shellQuote(sessionName)} " +
+                    "-F '#{client_pid}:#{client_tty}:#{session_name}' 2>/dev/null || true",
+            )
+        }
+        assertEquals("the direct observer could not list tmux clients: ${result.stderr}", 0, result.exitCode)
+        return result.stdout.lines().filter { it.isNotBlank() }
+    }
+
+    private suspend fun remoteFileContents(observer: SshSession, remotePath: String): String? {
+        val result = withTimeout(OBSERVER_EXEC_TIMEOUT_MS) {
+            observer.exec(
+                "if [ -f ${shellQuote(remotePath)} ]; then " +
+                    "printf '__PRESENT__'; cat -- ${shellQuote(remotePath)}; fi",
+            )
+        }
+        assertEquals("the direct observer could not inspect $remotePath: ${result.stderr}", 0, result.exitCode)
+        return result.stdout.takeIf { it.startsWith("__PRESENT__") }?.removePrefix("__PRESENT__")
+    }
+
+    private suspend fun waitForExactRemoteFile(
+        observer: SshSession,
+        remotePath: String,
+        expected: String,
+        label: String,
+    ): String {
+        val deadline = SystemClock.elapsedRealtime() + REMOTE_MARKER_TIMEOUT_MS
+        var last = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            last = remoteFileContents(observer, remotePath) ?: ""
+            if (last == expected) return last
+            SystemClock.sleep(REMOTE_MARKER_POLL_MS)
+        }
+        throw AssertionError(
+            "expected the exact server-side marker for $label at $remotePath: " +
+                "expected='$expected' actual='$last'",
+        )
+    }
+
+    private suspend fun removeRemoteFiles(observer: SshSession, vararg paths: String) {
+        val result = withTimeout(OBSERVER_EXEC_TIMEOUT_MS) {
+            observer.exec("rm -f -- ${paths.joinToString(" ") { shellQuote(it) }}")
+        }
+        assertEquals("the direct observer could not clean sentinel files: ${result.stderr}", 0, result.exitCode)
+    }
+
+    /**
+     * Issue #1678 / #2397 — prove the diagnostic channel this proof reads can
+     * actually SPEAK for this episode.
+     *
+     * The brief journey's load-bearing diagnostic claim is a NEGATIVE one ("no
+     * typed recovery/drop/reconnect event fired"), and a negative claim read
+     * from a channel that has been silenced is vacuous — exactly the G6 /
+     * `docs/ci-pitfalls.md` mutation-liveness trap. This channel really can be
+     * silenced: `DiagnosticRecorders.close()` installs `DiagnosticEventSink.Noop`
+     * into the global [DiagnosticEvents] and never restores `App`'s recorder
+     * (#2397), so ANY earlier class in the same instrumentation process
+     * permanently blinds every later reader of `app.diagnosticRecorder`.
+     *
+     * So round-trip a probe through the SAME global entry point production
+     * writes through, into BOTH archives [episodeDiagnostics] reads, and require
+     * it to come back. A poisoned sink reddens the brief journey here instead of
+     * letting it pass with an empty forbidden-event list it could never have
+     * populated. The probe names are deliberately outside
+     * [FORBIDDEN_CONNECTION_EVENT_NAMES] / [FORBIDDEN_CONTROLLER_EVENTS], so the
+     * liveness proof cannot itself trip the contract it protects.
+     */
+    private suspend fun assertDiagnosticCaptureIsLive(episodeStartNanos: Long, marker: String) {
+        DiagnosticEvents.record(
+            MirroredDiagnostics.CONNECTION_CATEGORY,
+            DIAGNOSTIC_LIVENESS_PROBE_NAME,
+            "marker" to marker,
+        )
+        DiagnosticEvents.record(
+            ConnectionJournalSchema.CATEGORY,
+            DIAGNOSTIC_LIVENESS_PROBE_NAME,
+            "marker" to marker,
+        )
+
+        val deadline = SystemClock.elapsedRealtime() + DIAGNOSTIC_LIVENESS_TIMEOUT_MS
+        var connectionSeen = false
+        var journalSeen = false
+        while (SystemClock.elapsedRealtime() < deadline && !(connectionSeen && journalSeen)) {
+            val (connectionEvents, journalEvents) = episodeDiagnostics(episodeStartNanos)
+            connectionSeen = connectionEvents.any {
+                it.name == DIAGNOSTIC_LIVENESS_PROBE_NAME && it.metadata["marker"] == marker
+            }
+            journalSeen = journalEvents.any {
+                it.name == DIAGNOSTIC_LIVENESS_PROBE_NAME && it.metadata["marker"] == marker
+            }
+            if (connectionSeen && journalSeen) break
+            SystemClock.sleep(DIAGNOSTIC_LIVENESS_POLL_MS)
+        }
+        assertTrue(
+            "the connection diagnostic archive is BLIND for this episode (probe " +
+                "'$DIAGNOSTIC_LIVENESS_PROBE_NAME' marker=$marker never came back within " +
+                "${DIAGNOSTIC_LIVENESS_TIMEOUT_MS}ms) — every 'no forbidden event fired' " +
+                "assertion in this proof would be vacuous. See #2397: an earlier class in this " +
+                "instrumentation process installed DiagnosticEventSink.Noop and never restored " +
+                "App's recorder.",
+            connectionSeen,
+        )
+        assertTrue(
+            "the controller-journal diagnostic archive is BLIND for this episode (probe " +
+                "'$DIAGNOSTIC_LIVENESS_PROBE_NAME' marker=$marker never came back within " +
+                "${DIAGNOSTIC_LIVENESS_TIMEOUT_MS}ms) — the forbidden controller-event " +
+                "assertions in this proof would be vacuous. See #2397.",
+            journalSeen,
+        )
+    }
+
+    private suspend fun episodeDiagnostics(
+        episodeStartNanos: Long,
+    ): Pair<List<DiagnosticsEvent>, List<DiagnosticsEvent>> {
+        val app = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as App
+        val connectionEvents = app.diagnosticRecorder.connectionLogArchive()
+            .filter { it.monotonicTimestampNanos >= episodeStartNanos }
+        val journalEvents = app.diagnosticRecorder.connectionJournalArchive()
+            .filter { it.monotonicTimestampNanos >= episodeStartNanos }
+        return connectionEvents to journalEvents
+    }
+
+    private fun forbiddenRecoveryEvents(
+        connectionEvents: List<DiagnosticsEvent>,
+        journalEvents: List<DiagnosticsEvent>,
+    ): List<String> = buildList {
+        connectionEvents.filter { event ->
+            event.category == "reconnect" ||
+                event.name.contains("reconnect", ignoreCase = true) ||
+                event.name in FORBIDDEN_CONNECTION_EVENT_NAMES ||
+                (
+                    event.name == "keepalive_death_budget_crossed" &&
+                        event.metadata["outcome"] == "declared_dead"
+                    )
+        }.forEach { add("${it.category}/${it.name}#${it.sequence}:${it.metadata.toSortedMap()}") }
+        journalEvents.filter { event ->
+            event.name == "submit" && event.metadata["event"] in FORBIDDEN_CONTROLLER_EVENTS
+        }.forEach { add("${it.category}/${it.name}#${it.sequence}:${it.metadata.toSortedMap()}") }
+    }
+
+    private fun assertNoForbiddenRecoveryEvents(
+        connectionEvents: List<DiagnosticsEvent>,
+        journalEvents: List<DiagnosticsEvent>,
+        label: String,
+    ) {
+        val forbidden = forbiddenRecoveryEvents(connectionEvents, journalEvents)
+        assertTrue("expected no recovery/cause signal for $label, found=$forbidden", forbidden.isEmpty())
+    }
+
+    /**
+     * The archive's sequence numbers must strictly increase, so a timeline read out
+     * of it is ordered and complete (no duplicate or replayed record can hide an
+     * event this proof would otherwise call forbidden).
+     *
+     * Deliberately NOT asserted: that `monotonicTimestampNanos` never moves
+     * backwards between adjacent records. Producers stamp their own `nanoTime`
+     * before taking the recorder's sequence, so two events emitted from different
+     * threads inside the same microsecond can legitimately be sequenced in the
+     * opposite order to their stamps (observed: 429521435808098 -> 429521435731658,
+     * a 76 µs inversion, on an otherwise perfectly silent ride-through). That is a
+     * property of the diagnostics recorder, not of the connection contract under
+     * test, so asserting it here would only add a false-red channel (G6).
+     */
+    private fun assertMonotonicDiagnostics(label: String, events: List<DiagnosticsEvent>) {
+        events.zipWithNext().forEach { (before, after) ->
+            assertTrue(
+                "$label sequence must increase monotonically: ${before.sequence} -> ${after.sequence}",
+                after.sequence > before.sequence,
+            )
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private suspend fun writeBriefRideThroughEvidence(
+        episodeStartNanos: Long,
+        snapshots: List<BriefRideThroughSnapshot>,
+        phases: List<BriefPhaseBoundary>,
+        cutDurationMs: Long?,
+        postRestoreObservedMs: Long,
+        baselineSentinelCompleted: Boolean,
+        cutSentinelCompletedDuringCut: Boolean,
+        cutSentinelMarkerDuringCut: Boolean,
+        cutSentinelOutcomeAfterRestore: String,
+        cutSentinelRecoveredAfterRestore: Boolean,
+        cutSentinelMarkerAfterRestoreVerified: Boolean,
+        restoredSentinelCompleted: Boolean,
+        appMarkerVerified: Boolean,
+        phaseCompleted: Boolean,
+        proxyStateBeforeCut: String,
+        proxyStateDuringCut: String,
+        proxyStateAfterRestore: String,
+        failure: Throwable?,
+    ) {
+        val diagnosticResult = runCatching { episodeDiagnostics(episodeStartNanos) }
+        val connectionEvents = diagnosticResult.getOrNull()?.first.orEmpty()
+        val journalEvents = diagnosticResult.getOrNull()?.second.orEmpty()
+        val merged = (connectionEvents + journalEvents)
+            .distinctBy { it.sequence }
+            .sortedWith(compareBy<DiagnosticsEvent> { it.monotonicTimestampNanos }.thenBy { it.sequence })
+        val text = buildString {
+            appendLine(
+                "test=RideThroughInterruptionE2eTest#" +
+                    "briefLinkCutRidesThroughWithoutDisconnectOrTeardown",
+            )
+            appendLine("phase_pre_install_executed=${phases.any { it.name == "pre_install" }}")
+            appendLine("phase_toxic_installed_executed=${phases.any { it.name == "toxic_installed" }}")
+            appendLine("phase_toxic_cleared_executed=${phases.any { it.name == "toxic_cleared" }}")
+            appendLine(
+                "phase_post_restore_observation_executed=" +
+                    phases.any { it.name == "post_restore_observation_complete" },
+            )
+            appendLine("brief_cut_target_ms=$BRIEF_BLIP_MS")
+            appendLine("brief_cut_actual_ms=${cutDurationMs ?: -1L}")
+            appendLine("post_restore_target_ms=$POST_RESTORE_SETTLE_MS")
+            appendLine("post_restore_observed_ms=$postRestoreObservedMs")
+            appendLine("detector_reproduction=$DETECTOR_REPRODUCTION")
+            appendLine("production_liveness_probe_interval_ms=${LivenessProbe.DEFAULT_INTERVAL_MS}")
+            appendLine("production_liveness_probe_timeout_ms=${LivenessProbe.DEFAULT_PER_PROBE_TIMEOUT_MS}")
+            appendLine("production_liveness_probe_failure_threshold=${LivenessProbe.DEFAULT_FAILURE_THRESHOLD}")
+            appendLine("production_half_open_detection_budget_ms=$PRODUCTION_HALF_OPEN_DETECTION_BUDGET_MS")
+            appendLine("passive_disconnect_grace_ms=$PASSIVE_DISCONNECT_GRACE_MS")
+            appendLine("controller_grace_ms=${ConnectionController.DEFAULT_GRACE_MS}")
+            appendLine(
+                "brief_is_below_production_detection_budget=" +
+                    (BRIEF_BLIP_MS < PRODUCTION_HALF_OPEN_DETECTION_BUDGET_MS),
+            )
+            appendLine("sentinel_before_cut_completed=$baselineSentinelCompleted")
+            appendLine("sentinel_during_cut_completed=$cutSentinelCompletedDuringCut")
+            appendLine("sentinel_during_cut_marker_present=$cutSentinelMarkerDuringCut")
+            appendLine("sentinel_during_cut_outcome_after_restore=$cutSentinelOutcomeAfterRestore")
+            appendLine(
+                "sentinel_same_connection_after_restore_outcome_completed=" +
+                    cutSentinelRecoveredAfterRestore,
+            )
+            appendLine(
+                "sentinel_same_connection_after_restore_marker_verified=" +
+                    cutSentinelMarkerAfterRestoreVerified,
+            )
+            appendLine(
+                "sentinel_same_connection_after_restore_completed=$cutSentinelRecoveredAfterRestore",
+            )
+            appendLine("sentinel_after_restore_completed=$restoredSentinelCompleted")
+            appendLine("app_server_marker_verified=$appMarkerVerified")
+            appendLine("observed_ticks=${snapshots.size}")
+            appendLine("proxy_state_before_cut=$proxyStateBeforeCut")
+            appendLine("proxy_state_during_cut=$proxyStateDuringCut")
+            appendLine("proxy_state_after_restore=$proxyStateAfterRestore")
+            appendLine("phase_completed=$phaseCompleted")
+            appendLine("failure=${failure?.let { "${it.javaClass.simpleName}:${it.message}" } ?: "none"}")
+            appendLine("diagnostic_capture_error=${diagnosticResult.exceptionOrNull()?.message ?: "none"}")
+            appendLine("phase_boundaries_monotonic:")
+            phases.forEach { appendLine("  t=${it.elapsedMs}ms phase=${it.name}") }
+            appendLine("recovery_and_identity_snapshots:")
+            snapshots.forEach { appendLine("  ${it.asLine()}") }
+            appendLine("typed_connection_and_controller_timeline:")
+            merged.forEach { event ->
+                val elapsedMs = (event.monotonicTimestampNanos - episodeStartNanos) / 1_000_000L
+                appendLine(
+                    "  t=${elapsedMs}ms sequence=${event.sequence} category=${event.category} " +
+                        "name=${event.name} metadata=${event.metadata.toSortedMap()}",
+                )
+            }
+        }
+        runCatching { artifactFile(BRIEF_EVIDENCE_FILE).writeText(text) }
+            .onFailure { println("ISSUE1678_EVIDENCE_WRITE_FAILURE ${it.message}") }
+    }
+
+    private fun elapsedMs(startedAtMs: Long): Long = SystemClock.elapsedRealtime() - startedAtMs
+
+    private fun shellQuote(value: String): String =
+        "'" + value.replace("'", "'\"'\"'") + "'"
 
     /**
      * A sustained clean socket drop is a genuine outage. Under the CURRENT
@@ -212,6 +1276,53 @@ class RideThroughInterruptionE2eTest : NetworkFaultProofBase() {
 
     private companion object {
         const val BRIEF_BLIP_MS: Long = 5_000L
+        const val BRIEF_BLIP_MAX_MS: Long = 6_000L
         const val POST_RESTORE_SETTLE_MS: Long = 4_000L
+        const val BRIEF_SAMPLE_INTERVAL_MS: Long = 200L
+        const val DETECTOR_REPRODUCTION: String = "physical-half-open-production-defaults"
+        val PRODUCTION_HALF_OPEN_DETECTION_BUDGET_MS: Long =
+            LivenessProbe.DEFAULT_FAILURE_THRESHOLD.toLong() *
+                (LivenessProbe.DEFAULT_INTERVAL_MS + LivenessProbe.DEFAULT_PER_PROBE_TIMEOUT_MS)
+
+        /**
+         * Wall-clock headroom reserved for one whole snapshot (Compose tree probes +
+         * two unproxied observer execs + a diagnostics read) so a slow tick cannot
+         * push the measured cut past [BRIEF_BLIP_MAX_MS].
+         */
+        const val SNAPSHOT_BUDGET_MS: Long = 900L
+
+        /** A cut that was slept through rather than OBSERVED proves nothing. */
+        const val MIN_ENGAGED_TICKS: Int = 3
+        const val OBSERVER_CONNECT_TIMEOUT_MS: Long = 15_000L
+        const val OBSERVER_EXEC_TIMEOUT_MS: Long = 10_000L
+        const val PROXY_SENTINEL_CONNECT_TIMEOUT_MS: Int = 15_000
+        const val PROXY_SENTINEL_BASELINE_TIMEOUT_MS: Long = 10_000L
+        const val PROXY_SENTINEL_RESTORE_TIMEOUT_MS: Long = 30_000L
+        const val SENTINEL_DRAIN_TIMEOUT_MS: Long = 15_000L
+        const val REMOTE_MARKER_TIMEOUT_MS: Long = 20_000L
+        const val REMOTE_MARKER_POLL_MS: Long = 100L
+        /** #2397 vacuity guard — see [assertDiagnosticCaptureIsLive]. */
+        const val DIAGNOSTIC_LIVENESS_PROBE_NAME: String = "issue1678_diagnostic_capture_liveness_probe"
+        const val DIAGNOSTIC_LIVENESS_TIMEOUT_MS: Long = 10_000L
+        const val DIAGNOSTIC_LIVENESS_POLL_MS: Long = 100L
+        const val BRIEF_EVIDENCE_FILE: String = "brief-ride-through-timeline.txt"
+        const val CONTROL_EVIDENCE_FILE: String = "clean-close-control-timeline.txt"
+
+        val FORBIDDEN_CONNECTION_EVENT_NAMES: Set<String> = setOf(
+            "liveness_probe_silent_drop",
+            "passive_disconnect",
+            "silent_reattach_start",
+            "tmux_client_reader_exit",
+            "tmux_client_command_timeout",
+            "network_loss_hold",
+        )
+
+        val FORBIDDEN_CONTROLLER_EVENTS: Set<Any?> = setOf(
+            "transport_dropped",
+            "reconnect_ladder_entered",
+            "reconnect_failed",
+            "reconnect_gave_up",
+            "network_lost",
+        )
     }
 }

--- a/scripts/check-test-validity-selftest.sh
+++ b/scripts/check-test-validity-selftest.sh
@@ -690,7 +690,6 @@ assert_report present "A5LBadParenAwareLiteralTrueTest.kt" "A5L — NEW" "A5L ma
 assert_report present "A5LBadBlockCommentCalleeTriviaTest.kt" "A5L — NEW" "A5L matches legal block-comment trivia between the callee and opening parenthesis"
 assert_report present "A5LBadNewlineCommentCalleeTriviaTest.kt" "A5L — NEW" "A5L matches legal newline/comment trivia between the callee and opening parenthesis"
 assert_report absent  "A5LGoodDynamicAndDecoyTest.kt" "A5L — NEW" "A5L spares nested dynamic booleans and string/comment decoys"
-assert_report present "RideThroughInterruptionE2eTest.kt:61" "A5L — KNOWN" "A5L inventories the sole #1678 tracked survivor"
 assert_report absent  "A5GoodSdkGuardTest.kt" "A5 — NEW" "A5 spares a Build.VERSION SDK guard"
 # A5 bad + C1 GOOD-only present here -> A5 is a hard-fail category.
 assert_exit 1 "A5 unjustified IME skip hard-fails the guard"

--- a/scripts/check-test-validity.sh
+++ b/scripts/check-test-validity.sh
@@ -263,7 +263,6 @@ A5_BASELINE=(
 # tracking issue after `|`; stale/malformed entries hard-fail.
 # --------------------------------------------------------------------------
 A5_LITERAL_BASELINE=(
-  "app/src/androidTest/java/com/pocketshell/app/proof/RideThroughInterruptionE2eTest.kt:61|#1678"
 )
 
 # --------------------------------------------------------------------------

--- a/scripts/lib/nightly-exact-method-guard.sh
+++ b/scripts/lib/nightly-exact-method-guard.sh
@@ -256,13 +256,18 @@ clean_close_control_artifact_is_valid() {
     grep -qx 'failure=none' "$file"
 }
 
-authoritative_terminal_viewport_png_is_valid() {
+# Portable PNG contract: signature, chunk framing/CRC, zlib stream, and decoded
+# scanline length, without trusting the filename or byte count. Split out of
+# authoritative_terminal_viewport_png_is_valid so the self-test can assert this
+# path DIRECTLY: on a host that ships ImageMagick, an `identify` rejection would
+# otherwise mask a vacuous Python path, which is exactly how the missing
+# exit-status check below survived (the `identify` call is optional, so its
+# absent-branch status 0 became the function's return value and every existing
+# file read as a valid PNG on ImageMagick-less hosts, i.e. on CI).
+authoritative_terminal_viewport_png_decodes_in_python() {
   local file="$1"
   [[ -f "$file" ]] || return 1
 
-  # Check the PNG signature, chunk framing/CRC, zlib stream, and decoded
-  # scanline length without trusting the filename or byte count. This keeps
-  # the guard useful on hosts that do not ship ImageMagick.
   python3 - "$file" <<'PY'
 import pathlib
 import struct
@@ -334,13 +339,34 @@ except (OSError, IndexError, struct.error, ValueError, zlib.error):
     sys.exit(1)
 sys.exit(0)
 PY
+}
 
-  # Use a full image decoder as an additional check when present. The Python
-  # path above remains the portable contract for CI/minimal review hosts.
-  if command -v identify >/dev/null 2>&1; then
+# ImageMagick is optional and is NOT installed on the CI static-guard runner, so
+# "identify is absent" is the configuration that actually ships. Route the probe
+# through one overridable seam so the self-test can exercise that configuration
+# on a developer host that does ship ImageMagick — otherwise a locally-green
+# self-test says nothing about the only host the guard really runs on.
+nightly_guard_identify_is_available() {
+  if [[ "${NIGHTLY_GUARD_FORCE_NO_IDENTIFY:-0}" == "1" ]]; then
+    return 1
+  fi
+  command -v identify >/dev/null 2>&1
+}
+
+authoritative_terminal_viewport_png_is_valid() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  # The Python decoder is the portable contract for CI/minimal review hosts, so
+  # its exit status is load-bearing and must be checked explicitly.
+  authoritative_terminal_viewport_png_decodes_in_python "$file" || return 1
+
+  # Use a full image decoder as an additional check when present.
+  if nightly_guard_identify_is_available; then
     identify -quiet -format '%m %w %h' "$file" 2>/dev/null \
       | grep -Eq '^PNG [1-9][0-9]* [1-9][0-9]*$' || return 1
   fi
+  return 0
 }
 
 authoritative_terminal_artifact_pair_is_valid() {
@@ -425,6 +451,75 @@ require_exact_clean_close_control_method() {
   fi
   echo "PASS: exact clean-close positive control executed once, unskipped, successful, with an observer that demonstrably fired: $class_name#$method_name"
   return 0
+}
+
+# Self-test helper: derive a deterministic malformed PNG from a valid one.
+# Each mode targets a distinct branch of the portable decoder so a single
+# lenient branch cannot make the whole PNG check vacuous.
+nightly_guard_selftest_mutate_png() {
+  local source_png="$1" target_png="$2" mode="$3"
+  python3 - "$source_png" "$target_png" "$mode" <<'PY'
+import pathlib
+import struct
+import sys
+import zlib
+
+source, target, mode = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), sys.argv[3]
+data = bytearray(source.read_bytes())
+
+
+def first_idat():
+    pos = 8
+    while pos + 12 <= len(data):
+        length = struct.unpack(">I", data[pos:pos + 4])[0]
+        if data[pos + 4:pos + 8] == b"IDAT" and length:
+            return pos, length
+        pos += 12 + length
+    raise SystemExit("missing IDAT in valid PNG self-test fixture")
+
+
+def rewrite_idat(payload):
+    pos, length = first_idat()
+    chunk = struct.pack(">I", len(payload)) + b"IDAT" + payload
+    chunk += struct.pack(">I", zlib.crc32(b"IDAT" + payload) & 0xffffffff)
+    return data[:pos] + bytearray(chunk) + data[pos + 12 + length:]
+
+
+if mode == "idat-crc-only":
+    # Payload and zlib stream stay valid; only the stored CRC is wrong, so the
+    # CRC branch is the ONLY branch that can reject this one.
+    pos, length = first_idat()
+    data[pos + 8 + length] ^= 0xff
+elif mode == "idat-bitflip":
+    # Corrupt the payload and deliberately leave the stored CRC stale.
+    pos, _ = first_idat()
+    data[pos + 8] ^= 0xff
+elif mode == "idat-bitflip-crc-fixed":
+    # Corrupt the zlib stream but repair the CRC, so only the decompress
+    # branch can reject it.
+    pos, length = first_idat()
+    payload = bytearray(data[pos + 8:pos + 8 + length])
+    payload[0] ^= 0xff
+    data = rewrite_idat(bytes(payload))
+elif mode == "idat-truncated-scanline":
+    # Valid CRC and valid zlib stream, but one byte short of the declared
+    # scanline geometry, so only the decoded-length branch can reject it.
+    data = rewrite_idat(zlib.compress(b"\x00" * 1))
+elif mode == "signature":
+    data[1] ^= 0xff
+elif mode == "truncated":
+    data = data[:len(data) - 5]
+elif mode == "trailing-garbage":
+    data.extend(b"pocketshell-trailing-bytes")
+elif mode == "text":
+    data = bytearray(b"not a png, just a text artifact\n")
+elif mode == "empty":
+    data = bytearray()
+else:
+    raise SystemExit("unknown PNG mutation mode: " + mode)
+
+target.write_bytes(bytes(data))
+PY
 }
 
 nightly_exact_method_guard_self_test() {
@@ -584,32 +679,71 @@ EOF
   echo "ok   [typed timeline mutation] forbidden event is rejected"
 
   local malformed_png="$artifacts_root/device/issue342-network-faults/brief-post-restore-viewport.png"
+  local png_mutation png_mutation_mode png_mutation_label png_identify_mode
   cp "$malformed_png" "$malformed_png.orig"
-  python3 - "$malformed_png" <<'PY'
-import pathlib
-import struct
-import sys
-
-path = pathlib.Path(sys.argv[1])
-data = bytearray(path.read_bytes())
-pos = 8
-while pos + 12 <= len(data):
-    length = struct.unpack(">I", data[pos:pos + 4])[0]
-    chunk_type = data[pos + 4:pos + 8]
-    if chunk_type == b"IDAT" and length:
-        data[pos + 8] ^= 0xff
-        path.write_bytes(data)
-        break
-    pos += 12 + length
-else:
-    raise SystemExit("missing IDAT in valid PNG self-test fixture")
-PY
-  if authoritative_terminal_viewport_png_is_valid "$malformed_png"; then
-    echo "SELF-TEST FAIL: malformed PNG mutation passed the decoder" >&2
+  # The valid fixture must be accepted first, otherwise every rejection below
+  # could be a false negative from a broken fixture. Check both host shapes:
+  # with ImageMagick (developer boxes) and without it (the CI runner).
+  authoritative_terminal_viewport_png_decodes_in_python "$malformed_png.orig" || {
+    echo "SELF-TEST FAIL: valid viewport PNG rejected by the portable decoder" >&2
     return 1
-  fi
+  }
+  for png_identify_mode in 0 1; do
+    export NIGHTLY_GUARD_FORCE_NO_IDENTIFY="$png_identify_mode"
+    authoritative_terminal_viewport_png_is_valid "$malformed_png.orig" || {
+      echo "SELF-TEST FAIL: valid viewport PNG rejected by the decoder (force_no_identify=$png_identify_mode)" >&2
+      return 1
+    }
+    authoritative_terminal_artifact_pair_is_valid "$artifacts_root" brief-post-restore || {
+      echo "SELF-TEST FAIL: valid viewport pair rejected (force_no_identify=$png_identify_mode)" >&2
+      return 1
+    }
+  done
+  export NIGHTLY_GUARD_FORCE_NO_IDENTIFY=0
+  for png_mutation in \
+    'idat-crc-only|wrong IDAT chunk CRC over an intact payload' \
+    'idat-bitflip|stale IDAT chunk CRC' \
+    'idat-bitflip-crc-fixed|corrupt IDAT zlib stream with a recomputed CRC' \
+    'idat-truncated-scanline|short decoded scanline with a recomputed CRC' \
+    'signature|corrupt PNG signature' \
+    'truncated|truncated chunk stream' \
+    'trailing-garbage|bytes appended after IEND' \
+    'text|plain text with a .png name' \
+    'empty|empty file'; do
+    png_mutation_mode="${png_mutation%%|*}"
+    png_mutation_label="${png_mutation##*|}"
+    nightly_guard_selftest_mutate_png \
+      "$malformed_png.orig" "$malformed_png" "$png_mutation_mode" || {
+      echo "SELF-TEST FAIL: could not build PNG mutant: $png_mutation_label" >&2
+      return 1
+    }
+    # Assert the portable Python decoder DIRECTLY, not only through the wrapper:
+    # it is the only decoder present on the CI runner.
+    if authoritative_terminal_viewport_png_decodes_in_python "$malformed_png"; then
+      echo "SELF-TEST FAIL: malformed PNG mutation passed the portable decoder: $png_mutation_label" >&2
+      return 1
+    fi
+    # Then assert the wrapper and the pair check under BOTH host shapes. The
+    # force_no_identify=1 pass is the load-bearing one: it is the CI runner's
+    # configuration, and it is where an unchecked Python exit status turns the
+    # whole PNG check vacuous while an ImageMagick-equipped host stays green.
+    for png_identify_mode in 0 1; do
+      export NIGHTLY_GUARD_FORCE_NO_IDENTIFY="$png_identify_mode"
+      if authoritative_terminal_viewport_png_is_valid "$malformed_png"; then
+        echo "SELF-TEST FAIL: malformed PNG mutation passed the decoder (force_no_identify=$png_identify_mode): $png_mutation_label" >&2
+        return 1
+      fi
+      if authoritative_terminal_artifact_pair_is_valid "$artifacts_root" brief-post-restore; then
+        echo "SELF-TEST FAIL: malformed PNG mutation passed the artifact pair check (force_no_identify=$png_identify_mode): $png_mutation_label" >&2
+        return 1
+      fi
+    done
+    export NIGHTLY_GUARD_FORCE_NO_IDENTIFY=0
+    cp "$malformed_png.orig" "$malformed_png"
+  done
   mv "$malformed_png.orig" "$malformed_png"
-  echo "ok   [PNG mutation] malformed authoritative viewport is rejected"
+  unset NIGHTLY_GUARD_FORCE_NO_IDENTIFY
+  echo "ok   [PNG mutation] malformed authoritative viewport is rejected on hosts with and without ImageMagick"
 
   rm "$artifacts_root/device/issue342-network-faults/brief-post-restore-viewport.png"
   if require_exact_brief_ride_through_method \

--- a/scripts/lib/nightly-exact-method-guard.sh
+++ b/scripts/lib/nightly-exact-method-guard.sh
@@ -6,9 +6,40 @@
 # remains. The raw phase exit code also does not prove that the positive-band
 # artifact was pulled. This helper makes all three conditions load-bearing.
 
-require_exact_junit_method() {
-  local results_root="$1" artifacts_root="$2" class_name="$3" method_name="$4"
-  local matches successful_matches recovery_artifacts valid_recovery_artifacts
+EXPECTED_BRIEF_RIDE_THROUGH_CLASS="com.pocketshell.app.proof.RideThroughInterruptionE2eTest"
+EXPECTED_BRIEF_RIDE_THROUGH_METHOD="briefLinkCutRidesThroughWithoutDisconnectOrTeardown"
+
+control_artifact_has_user_visible_recovery_token() {
+  local file="$1" line list token
+  local -a tokens=()
+
+  line="$(grep -E '^observer_first_violations=' "$file" | head -1)"
+  case "$line" in
+    observer_first_violations=\[*\]) ;;
+    *) return 1 ;;
+  esac
+
+  # The Kotlin artifact is List.toString(): [token, token]. Parse complete
+  # comma-separated tokens so an internal field cannot launder a visible-looking
+  # substring (for example `not_reconnecting_pill` or `vm_status=Connected`).
+  list="${line#observer_first_violations=[}"
+  list="${list%]}"
+  IFS=',' read -r -a tokens <<< "$list"
+  for token in "${tokens[@]}"; do
+    token="${token#${token%%[![:space:]]*}}"
+    token="${token%${token##*[![:space:]]}}"
+    case "$token" in
+      vm_status=Idle|vm_status=Connecting|vm_status=Switching|vm_status=Reconnecting|vm_status=Failed|reconnecting_pill|attaching_hold|reconnect_band_retry_now|connecting_progress_row|settled_failed_band)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+require_exact_successful_junit_method() {
+  local results_root="$1" class_name="$2" method_name="$3"
+  local matches successful_matches
 
   matches="$(
     find "$results_root" -type f -name 'TEST-*.xml' -exec grep -hF "name=\"$method_name\"" {} + 2>/dev/null \
@@ -24,6 +55,20 @@ require_exact_junit_method() {
       | grep -Ec '/>[[:space:]]*$' \
       | tr -d '[:space:]'
   )"
+
+  if [[ "$matches" != "1" || "$successful_matches" != "1" ]]; then
+    echo "FAIL: expected exact nightly fault method once and successful (not skipped/failed), found total=${matches:-0} successful=${successful_matches:-0}: $class_name#$method_name" >&2
+    return 1
+  fi
+  return 0
+}
+
+require_exact_junit_method() {
+  local results_root="$1" artifacts_root="$2" class_name="$3" method_name="$4"
+  local recovery_artifacts valid_recovery_artifacts
+
+  require_exact_successful_junit_method "$results_root" "$class_name" "$method_name" || return 1
+
   recovery_artifacts="$(
     find "$artifacts_root" -type f -path '*/issue342-network-faults/recovery-band-longcut.txt' 2>/dev/null \
       | wc -l \
@@ -38,15 +83,347 @@ require_exact_junit_method() {
       | tr -d '[:space:]'
   )"
 
-  if [[ "$matches" != "1" || "$successful_matches" != "1" ]]; then
-    echo "FAIL: expected exact nightly fault method once and successful (not skipped/failed), found total=${matches:-0} successful=${successful_matches:-0}: $class_name#$method_name" >&2
-    return 1
-  fi
   if [[ "$recovery_artifacts" != "1" || "$valid_recovery_artifacts" != "1" ]]; then
     echo "FAIL: expected exactly one valid positive-band artifact, found total=${recovery_artifacts:-0} valid=${valid_recovery_artifacts:-0}: issue342-network-faults/recovery-band-longcut.txt" >&2
     return 1
   fi
   echo "PASS: exact nightly fault method executed once, unskipped, successful, with a valid positive-band artifact: $class_name#$method_name"
+  return 0
+}
+
+brief_ride_through_artifact_has_no_forbidden_events() {
+  local file="$1"
+  awk '
+    function metadata_has_event(metadata, event) {
+      return metadata ~ ("(^|[,{[:space:]])event=" event "([,}]|[[:space:]]|$)")
+    }
+
+    BEGIN {
+      in_snapshots = 0
+      in_timeline = 0
+      snapshot_headers = 0
+      timeline_headers = 0
+      snapshot_lines = 0
+      malformed = 0
+
+      forbidden_connection["liveness_probe_silent_drop"] = 1
+      forbidden_connection["passive_disconnect"] = 1
+      forbidden_connection["silent_reattach_start"] = 1
+      forbidden_connection["tmux_client_reader_exit"] = 1
+      forbidden_connection["tmux_client_command_timeout"] = 1
+      forbidden_connection["network_loss_hold"] = 1
+    }
+
+    $0 == "recovery_and_identity_snapshots:" {
+      if (snapshot_headers != 0 || in_timeline != 0) malformed = 1
+      snapshot_headers++
+      in_snapshots = 1
+      in_timeline = 0
+      next
+    }
+
+    $0 == "typed_connection_and_controller_timeline:" {
+      if (timeline_headers != 0 || snapshot_headers != 1 || !in_snapshots) malformed = 1
+      timeline_headers++
+      in_snapshots = 0
+      in_timeline = 1
+      next
+    }
+
+    in_snapshots {
+      if ($0 ~ /^[[:space:]]*$/) next
+      snapshot_lines++
+      # Kotlin BriefRideThroughSnapshot.asLine() emits forbiddenEvents last.
+      # Require the field and its exact empty List.toString() representation;
+      # missing or non-empty lists are both invalid.
+      if ($0 !~ /^[[:space:]]+phase=[^[:space:]]+[[:space:]].*forbiddenEvents=\[\][[:space:]]*$/) {
+        malformed = 1
+      }
+      next
+    }
+
+    in_timeline {
+      if ($0 ~ /^[[:space:]]*$/) next
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      # Kotlin writes one flattened DiagnosticsEvent per line. Do not let an
+      # unrecognised line or a truncated event silently count as clean.
+      if (line !~ /^t=[0-9]+ms[[:space:]]+sequence=[0-9]+[[:space:]]+category=[^[:space:]]+[[:space:]]+name=[^[:space:]]+[[:space:]]+metadata=\{.*\}[[:space:]]*$/) {
+        malformed = 1
+        next
+      }
+
+      split(line, fields, /[[:space:]]+/)
+      category = fields[3]
+      sub(/^category=/, "", category)
+      name = fields[4]
+      sub(/^name=/, "", name)
+      metadata = line
+      sub(/^t=[^[:space:]]+[[:space:]]+sequence=[^[:space:]]+[[:space:]]+category=[^[:space:]]+[[:space:]]+name=[^[:space:]]+[[:space:]]+metadata=/, "", metadata)
+
+      lower_name = tolower(name)
+      if (category == "reconnect" ||
+          lower_name ~ /reconnect/ ||
+          name in forbidden_connection ||
+          (name == "keepalive_death_budget_crossed" &&
+              metadata ~ /(^|[,{[:space:]])outcome=declared_dead([,}]|[[:space:]]|$)/) ||
+          (name == "submit" &&
+              (metadata_has_event(metadata, "transport_dropped") ||
+               metadata_has_event(metadata, "reconnect_ladder_entered") ||
+               metadata_has_event(metadata, "reconnect_failed") ||
+               metadata_has_event(metadata, "reconnect_gave_up") ||
+               metadata_has_event(metadata, "network_lost")))) {
+        malformed = 1
+      }
+      next
+    }
+
+    END {
+      exit !(snapshot_headers == 1 && timeline_headers == 1 && snapshot_lines > 0 && malformed == 0)
+    }
+  ' "$file"
+}
+
+brief_ride_through_artifact_is_valid() {
+  local file="$1"
+  grep -qx 'phase_pre_install_executed=true' "$file" &&
+    grep -qx 'phase_toxic_installed_executed=true' "$file" &&
+    grep -qx 'phase_toxic_cleared_executed=true' "$file" &&
+    grep -qx 'phase_post_restore_observation_executed=true' "$file" &&
+    grep -qx 'brief_cut_target_ms=5000' "$file" &&
+    awk -F= '$1 == "brief_cut_actual_ms" && $2 >= 5000 && $2 <= 6000 { ok=1 } END { exit !ok }' "$file" &&
+    grep -qx 'post_restore_target_ms=4000' "$file" &&
+    awk -F= '$1 == "post_restore_observed_ms" && $2 >= 4000 { ok=1 } END { exit !ok }' "$file" &&
+    grep -qx 'detector_reproduction=physical-half-open-production-defaults' "$file" &&
+    grep -qx 'production_liveness_probe_interval_ms=7000' "$file" &&
+    grep -qx 'production_liveness_probe_timeout_ms=5000' "$file" &&
+    grep -qx 'production_liveness_probe_failure_threshold=4' "$file" &&
+    grep -qx 'production_half_open_detection_budget_ms=48000' "$file" &&
+    grep -qx 'passive_disconnect_grace_ms=60000' "$file" &&
+    grep -qx 'controller_grace_ms=90000' "$file" &&
+    grep -qx 'brief_is_below_production_detection_budget=true' "$file" &&
+    grep -qx 'sentinel_before_cut_completed=true' "$file" &&
+    grep -qx 'sentinel_during_cut_completed=false' "$file" &&
+    grep -qx 'sentinel_during_cut_marker_present=false' "$file" &&
+    grep -qx 'sentinel_same_connection_after_restore_completed=true' "$file" &&
+    grep -qx 'sentinel_after_restore_completed=true' "$file" &&
+    grep -qx 'app_server_marker_verified=true' "$file" &&
+    grep -qx 'phase_completed=true' "$file" &&
+    grep -qx 'failure=none' "$file" &&
+    awk -F= '$1 == "observed_ticks" && $2 >= 6 { ok=1 } END { exit !ok }' "$file" &&
+    grep -q 'phase=fault_engaged .*status=Connected .*clientIdentity=.*clientDisconnected=false .*controllerState=Live.*serverClients=' "$file" &&
+    grep -q 'phase=post_restore .*status=Connected .*clientIdentity=.*clientDisconnected=false .*controllerState=Live.*serverClients=' "$file" &&
+    grep -qx 'typed_connection_and_controller_timeline:' "$file" || return 1
+
+  # Keep the typed timeline predicate separate from the scalar field checks:
+  # a fixture with otherwise-valid summary fields must still fail when a
+  # forbidden snapshot event or typed connection/controller event is present.
+  if ! brief_ride_through_artifact_has_no_forbidden_events "$file"; then
+    return 1
+  fi
+
+  grep -qx 'sentinel_same_connection_after_restore_outcome_completed=true' "$file" &&
+    grep -qx 'sentinel_same_connection_after_restore_marker_verified=true' "$file"
+}
+
+clean_close_control_typed_reader_eof_is_valid() {
+  local file="$1"
+  local reader_eof_artifact="$(dirname "$file")/reader-eof-control.txt"
+  grep -qx 'typed_reader_eof_detected=true' "$file" &&
+    grep -qx 'typed_reader_eof_event_name=tmux_client_reader_exit' "$file" &&
+    awk -F= '$1 == "typed_reader_eof_event_elapsed_ms" && $2 >= 0 { ok=1 } END { exit !ok }' "$file" &&
+    [[ -f "$reader_eof_artifact" ]] &&
+    grep -Eq '^sequence=[0-9]+ category=connection name=tmux_client_reader_exit metadata=' "$reader_eof_artifact" ||
+    return 1
+
+  if grep -qx 'typed_reader_eof_disconnect_reason=reader_eof' "$file"; then
+    return 0
+  fi
+
+  grep -qx 'typed_reader_eof_disconnect_reason=reader_exception' "$file" &&
+    grep -qx 'typed_reader_eof_source=read_failure' "$file" &&
+    grep -qx 'typed_reader_eof_message=eof' "$file"
+}
+
+clean_close_control_artifact_is_valid() {
+  local file="$1"
+  grep -qx 'production_disconnect_triggered=true' "$file" &&
+    grep -qx 'observer_detected_recovery=true' "$file" &&
+    awk -F= '$1 == "observer_recovery_detected_ms" && $2 >= 0 { ok=1 } END { exit !ok }' "$file" &&
+    control_artifact_has_user_visible_recovery_token "$file" &&
+    clean_close_control_typed_reader_eof_is_valid "$file" &&
+    grep -qx 'app_server_marker_verified=true' "$file" &&
+    grep -qx 'failure=none' "$file"
+}
+
+authoritative_terminal_viewport_png_is_valid() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  # Check the PNG signature, chunk framing/CRC, zlib stream, and decoded
+  # scanline length without trusting the filename or byte count. This keeps
+  # the guard useful on hosts that do not ship ImageMagick.
+  python3 - "$file" <<'PY'
+import pathlib
+import struct
+import sys
+import zlib
+
+try:
+    data = pathlib.Path(sys.argv[1]).read_bytes()
+    signature = b"\x89PNG\r\n\x1a\n"
+    if not data.startswith(signature):
+        raise ValueError("bad PNG signature")
+
+    pos = len(signature)
+    ihdr = None
+    idat = bytearray()
+    saw_iend = False
+    while pos < len(data):
+        if len(data) - pos < 12:
+            raise ValueError("truncated PNG chunk")
+        length = struct.unpack(">I", data[pos:pos + 4])[0]
+        chunk_end = pos + 12 + length
+        if chunk_end > len(data):
+            raise ValueError("PNG chunk exceeds file")
+        chunk_type = data[pos + 4:pos + 8]
+        chunk_data = data[pos + 8:pos + 8 + length]
+        expected_crc = struct.unpack(">I", data[pos + 8 + length:chunk_end])[0]
+        actual_crc = zlib.crc32(chunk_type + chunk_data) & 0xffffffff
+        if actual_crc != expected_crc:
+            raise ValueError("PNG chunk CRC mismatch")
+        if pos == len(signature) and chunk_type != b"IHDR":
+            raise ValueError("PNG does not begin with IHDR")
+        if saw_iend:
+            raise ValueError("data follows IEND")
+
+        if chunk_type == b"IHDR":
+            if ihdr is not None or length != 13:
+                raise ValueError("invalid IHDR")
+            ihdr = struct.unpack(">IIBBBBB", chunk_data)
+        elif chunk_type == b"IDAT":
+            if ihdr is None:
+                raise ValueError("IDAT precedes IHDR")
+            idat.extend(chunk_data)
+        elif chunk_type == b"IEND":
+            if length != 0:
+                raise ValueError("invalid IEND")
+            saw_iend = True
+        pos = chunk_end
+
+    if ihdr is None or not idat or not saw_iend or pos != len(data):
+        raise ValueError("incomplete PNG")
+
+    width, height, bit_depth, color_type, compression, filter_method, interlace = ihdr
+    if width == 0 or height == 0 or compression != 0 or filter_method != 0 or interlace not in (0, 1):
+        raise ValueError("invalid PNG header")
+    channels = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}
+    allowed_depths = {0: (1, 2, 4, 8, 16), 2: (8, 16), 3: (1, 2, 4, 8), 4: (8, 16), 6: (8, 16)}
+    if color_type not in channels or bit_depth not in allowed_depths[color_type]:
+        raise ValueError("invalid PNG color/depth")
+
+    decoded = zlib.decompress(bytes(idat))
+    if interlace == 0:
+        bits_per_pixel = channels[color_type] * bit_depth
+        row_bytes = (width * bits_per_pixel + 7) // 8
+        if len(decoded) != (row_bytes + 1) * height:
+            raise ValueError("invalid decoded scanline length")
+    elif not decoded:
+        raise ValueError("empty interlaced image")
+except (OSError, IndexError, struct.error, ValueError, zlib.error):
+    sys.exit(1)
+sys.exit(0)
+PY
+
+  # Use a full image decoder as an additional check when present. The Python
+  # path above remains the portable contract for CI/minimal review hosts.
+  if command -v identify >/dev/null 2>&1; then
+    identify -quiet -format '%m %w %h' "$file" 2>/dev/null \
+      | grep -Eq '^PNG [1-9][0-9]* [1-9][0-9]*$' || return 1
+  fi
+}
+
+authoritative_terminal_artifact_pair_is_valid() {
+  local artifacts_root="$1" stem="$2"
+  local viewport_count valid_viewport_count text_count
+  viewport_count="$(
+    find "$artifacts_root" -type f \
+      -path "*/issue342-network-faults/${stem}-viewport.png" 2>/dev/null \
+      | wc -l | tr -d '[:space:]'
+  )"
+  valid_viewport_count="$(
+    find "$artifacts_root" -type f \
+      -path "*/issue342-network-faults/${stem}-viewport.png" \
+      -exec bash -c 'source "$1"; authoritative_terminal_viewport_png_is_valid "$2"' \
+        bash "${BASH_SOURCE[0]}" {} \; -print 2>/dev/null \
+      | wc -l | tr -d '[:space:]'
+  )"
+  text_count="$(
+    find "$artifacts_root" -type f \
+      -path "*/issue342-network-faults/${stem}-visible-terminal.txt" -size +0c 2>/dev/null \
+      | wc -l | tr -d '[:space:]'
+  )"
+  [[ "$viewport_count" == "1" && "$valid_viewport_count" == "1" && "$text_count" == "1" ]]
+}
+
+require_exact_brief_ride_through_method() {
+  local results_root="$1" artifacts_root="$2" class_name="$3" method_name="$4"
+  local artifacts valid_artifacts
+
+  if [[ "$class_name" != "$EXPECTED_BRIEF_RIDE_THROUGH_CLASS" ||
+        "$method_name" != "$EXPECTED_BRIEF_RIDE_THROUGH_METHOD" ]]; then
+    echo "FAIL: phase-2 brief guard received the wrong 5-second RideThrough selector: $class_name#$method_name" >&2
+    return 1
+  fi
+  require_exact_successful_junit_method "$results_root" "$class_name" "$method_name" || return 1
+  artifacts="$(
+    find "$artifacts_root" -type f -path '*/issue342-network-faults/brief-ride-through-timeline.txt' 2>/dev/null \
+      | wc -l | tr -d '[:space:]'
+  )"
+  valid_artifacts="$(
+    find "$artifacts_root" -type f -path '*/issue342-network-faults/brief-ride-through-timeline.txt' \
+      -exec bash -c 'source "$1"; brief_ride_through_artifact_is_valid "$2"' \
+        bash "${BASH_SOURCE[0]}" {} \; -print 2>/dev/null \
+      | wc -l | tr -d '[:space:]'
+  )"
+  if [[ "$artifacts" != "1" || "$valid_artifacts" != "1" ]]; then
+    echo "FAIL: expected exactly one complete brief ride-through artifact, found total=${artifacts:-0} valid=${valid_artifacts:-0}: issue342-network-faults/brief-ride-through-timeline.txt" >&2
+    return 1
+  fi
+  if ! authoritative_terminal_artifact_pair_is_valid "$artifacts_root" "brief-pre-cut" ||
+    ! authoritative_terminal_artifact_pair_is_valid "$artifacts_root" "brief-post-restore"; then
+    echo "FAIL: brief ride-through is missing a non-empty authoritative viewport/text artifact pair" >&2
+    return 1
+  fi
+  echo "PASS: exact brief nightly fault method executed once, unskipped, successful, with a complete non-vacuous timeline: $class_name#$method_name"
+  return 0
+}
+
+require_exact_clean_close_control_method() {
+  local results_root="$1" artifacts_root="$2" class_name="$3" method_name="$4"
+  local artifacts valid_artifacts
+
+  require_exact_successful_junit_method "$results_root" "$class_name" "$method_name" || return 1
+  artifacts="$(
+    find "$artifacts_root" -type f -path '*/issue342-network-faults/clean-close-control-timeline.txt' 2>/dev/null \
+      | wc -l | tr -d '[:space:]'
+  )"
+  valid_artifacts="$(
+    find "$artifacts_root" -type f -path '*/issue342-network-faults/clean-close-control-timeline.txt' \
+      -exec bash -c 'source "$1"; clean_close_control_artifact_is_valid "$2"' \
+        bash "${BASH_SOURCE[0]}" {} \; -print 2>/dev/null \
+      | wc -l | tr -d '[:space:]'
+  )"
+  if [[ "$artifacts" != "1" || "$valid_artifacts" != "1" ]]; then
+    echo "FAIL: expected exactly one valid clean-close positive-control artifact (the brief journey's silent observer must be PROVEN able to fire), found total=${artifacts:-0} valid=${valid_artifacts:-0}: issue342-network-faults/clean-close-control-timeline.txt" >&2
+    return 1
+  fi
+  if ! authoritative_terminal_artifact_pair_is_valid "$artifacts_root" "control-pre-close" ||
+    ! authoritative_terminal_artifact_pair_is_valid "$artifacts_root" "control-post-recovery"; then
+    echo "FAIL: clean-close positive control is missing a non-empty authoritative viewport/text artifact pair" >&2
+    return 1
+  fi
+  echo "PASS: exact clean-close positive control executed once, unskipped, successful, with an observer that demonstrably fired: $class_name#$method_name"
   return 0
 }
 
@@ -99,6 +476,242 @@ nightly_exact_method_guard_self_test() {
     echo "SELF-TEST FAIL: a successful exact method with a valid artifact failed" >&2
     return 1
   }
+
+  local brief_method="briefLinkCutRidesThroughWithoutDisconnectOrTeardown"
+  local control_method="cleanCloseControlSurfacesHonestRecoveryToTheSameObserver"
+  local brief_artifact="$artifacts_root/device/issue342-network-faults/brief-ride-through-timeline.txt"
+  local control_artifact="$artifacts_root/device/issue342-network-faults/clean-close-control-timeline.txt"
+  local valid_png_base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+  local mutant
+
+  printf '<testsuite>
+  <testcase name="%s" classname="%s" />
+  <testcase name="%s" classname="%s" />
+</testsuite>
+' "$method_name" "$class_name" "$brief_method" "$class_name" >"$results_root/TEST-guard.xml"
+  cat >"$brief_artifact" <<'EOF'
+phase_pre_install_executed=true
+phase_toxic_installed_executed=true
+phase_toxic_cleared_executed=true
+phase_post_restore_observation_executed=true
+brief_cut_target_ms=5000
+brief_cut_actual_ms=5001
+post_restore_target_ms=4000
+post_restore_observed_ms=4000
+detector_reproduction=physical-half-open-production-defaults
+production_liveness_probe_interval_ms=7000
+production_liveness_probe_timeout_ms=5000
+production_liveness_probe_failure_threshold=4
+production_half_open_detection_budget_ms=48000
+passive_disconnect_grace_ms=60000
+controller_grace_ms=90000
+brief_is_below_production_detection_budget=true
+sentinel_before_cut_completed=true
+sentinel_during_cut_completed=false
+sentinel_during_cut_marker_present=false
+sentinel_same_connection_after_restore_completed=true
+sentinel_same_connection_after_restore_outcome_completed=true
+sentinel_same_connection_after_restore_marker_verified=true
+sentinel_after_restore_completed=true
+app_server_marker_verified=true
+phase_completed=true
+failure=none
+observed_ticks=27
+phase_boundaries_monotonic:
+  t=1ms phase=pre_install
+  t=5001ms phase=toxic_cleared
+recovery_and_identity_snapshots:
+  phase=fault_engaged t=1ms status=Connected pill=false attachingHold=false retryNow=false progressRow=false settledFailed=false recoveryInProgress=false attempts=1 generation=1 connectJobActive=false clientIdentity=1 clientDisconnected=false controllerState=Live serverClients=[1] sentinelCompleted=false sentinelRemoteMarkerPresent=false connectionEvents=0 journalEvents=0 forbiddenEvents=[]
+  phase=post_restore t=9001ms status=Connected pill=false attachingHold=false retryNow=false progressRow=false settledFailed=false recoveryInProgress=false attempts=1 generation=1 connectJobActive=false clientIdentity=1 clientDisconnected=false controllerState=Live serverClients=[1] sentinelCompleted=false sentinelRemoteMarkerPresent=false connectionEvents=0 journalEvents=0 forbiddenEvents=[]
+typed_connection_and_controller_timeline:
+EOF
+  for stem in brief-pre-cut brief-post-restore; do
+    printf '%s' "$valid_png_base64" \
+      | base64 --decode >"$artifacts_root/device/issue342-network-faults/${stem}-viewport.png"
+    printf 'BEFORE-or-APP-RESTORED\n' \
+      >"$artifacts_root/device/issue342-network-faults/${stem}-visible-terminal.txt"
+  done
+  require_exact_brief_ride_through_method \
+    "$results_root" "$artifacts_root" "$class_name" "$brief_method" >/dev/null || {
+    echo "SELF-TEST FAIL: valid brief method/artifact failed" >&2
+    return 1
+  }
+
+  if require_exact_brief_ride_through_method \
+    "$results_root" "$artifacts_root" "$class_name" "$method_name" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: wrong method selector was accepted by the brief guard" >&2
+    return 1
+  else
+    echo "ok   [brief selector] sustained method cannot satisfy the 5-second brief guard"
+  fi
+
+  for mutant in \
+    's/sentinel_during_cut_completed=false/sentinel_during_cut_completed=true/|unengaged toxic' \
+    's/sentinel_during_cut_marker_present=false/sentinel_during_cut_marker_present=true/|sentinel reached server' \
+    's/sentinel_before_cut_completed=true/sentinel_before_cut_completed=false/|missing baseline' \
+    's/sentinel_same_connection_after_restore_outcome_completed=true/sentinel_same_connection_after_restore_outcome_completed=false/|missing original outcome completion' \
+    's/sentinel_same_connection_after_restore_marker_verified=true/sentinel_same_connection_after_restore_marker_verified=false/|missing original server marker' \
+    's/sentinel_same_connection_after_restore_completed=true/sentinel_same_connection_after_restore_completed=false/|unproven same-connection restore' \
+    's/sentinel_after_restore_completed=true/sentinel_after_restore_completed=false/|unproven restore' \
+    's/app_server_marker_verified=true/app_server_marker_verified=false/|missing server marker' \
+    's/brief_cut_actual_ms=5001/brief_cut_actual_ms=1200/|short cut' \
+    's/post_restore_observed_ms=4000/post_restore_observed_ms=900/|short settle' \
+    's/detector_reproduction=physical-half-open-production-defaults/detector_reproduction=synthetic-fast-eager-liveness-seam/|wrong reproduction class' \
+    's/production_half_open_detection_budget_ms=48000/production_half_open_detection_budget_ms=5000/|wrong detector budget' \
+    's/observed_ticks=27/observed_ticks=1/|no sampled window' \
+    's/ clientDisconnected=false / clientDisconnected=true /|disconnected client' \
+    's/controllerState=Live/controllerState=Reconnecting/|non-Live controller' \
+    's/forbiddenEvents=\[\]/forbiddenEvents=[connection\/reconnect#9]/|forbidden typed event in snapshot'; do
+    cp "$brief_artifact" "$brief_artifact.orig"
+    sed -i "${mutant%%|*}" "$brief_artifact"
+    if require_exact_brief_ride_through_method \
+      "$results_root" "$artifacts_root" "$class_name" "$brief_method" >/dev/null 2>&1; then
+      echo "SELF-TEST FAIL: vacuous brief artifact passed: ${mutant##*|}" >&2
+      return 1
+    fi
+    mv "$brief_artifact.orig" "$brief_artifact"
+  done
+
+  cp "$brief_artifact" "$brief_artifact.orig"
+  sed -i '/^typed_connection_and_controller_timeline:$/a\  t=1ms sequence=9 category=connection name=reconnect metadata={cause=forbidden-test}' \
+    "$brief_artifact"
+  if require_exact_brief_ride_through_method \
+    "$results_root" "$artifacts_root" "$class_name" "$brief_method" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: forbidden typed timeline event passed" >&2
+    return 1
+  fi
+  mv "$brief_artifact.orig" "$brief_artifact"
+  echo "ok   [typed timeline mutation] forbidden event is rejected"
+
+  local malformed_png="$artifacts_root/device/issue342-network-faults/brief-post-restore-viewport.png"
+  cp "$malformed_png" "$malformed_png.orig"
+  python3 - "$malformed_png" <<'PY'
+import pathlib
+import struct
+import sys
+
+path = pathlib.Path(sys.argv[1])
+data = bytearray(path.read_bytes())
+pos = 8
+while pos + 12 <= len(data):
+    length = struct.unpack(">I", data[pos:pos + 4])[0]
+    chunk_type = data[pos + 4:pos + 8]
+    if chunk_type == b"IDAT" and length:
+        data[pos + 8] ^= 0xff
+        path.write_bytes(data)
+        break
+    pos += 12 + length
+else:
+    raise SystemExit("missing IDAT in valid PNG self-test fixture")
+PY
+  if authoritative_terminal_viewport_png_is_valid "$malformed_png"; then
+    echo "SELF-TEST FAIL: malformed PNG mutation passed the decoder" >&2
+    return 1
+  fi
+  mv "$malformed_png.orig" "$malformed_png"
+  echo "ok   [PNG mutation] malformed authoritative viewport is rejected"
+
+  rm "$artifacts_root/device/issue342-network-faults/brief-post-restore-viewport.png"
+  if require_exact_brief_ride_through_method \
+    "$results_root" "$artifacts_root" "$class_name" "$brief_method" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: missing authoritative brief viewport passed" >&2
+    return 1
+  fi
+  printf '%s' "$valid_png_base64" \
+    | base64 --decode >"$artifacts_root/device/issue342-network-faults/brief-post-restore-viewport.png"
+
+  printf '<testsuite>
+  <testcase name="%s" classname="%s" />
+  <testcase name="%s" classname="%s" />
+  <testcase name="%s" classname="%s" />
+</testsuite>
+' "$method_name" "$class_name" "$brief_method" "$class_name" \
+    "$control_method" "$class_name" >"$results_root/TEST-guard.xml"
+  if require_exact_clean_close_control_method \
+    "$results_root" "$artifacts_root" "$class_name" "$control_method" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: a missing positive-control artifact passed" >&2
+    return 1
+  fi
+  cat >"$control_artifact" <<'EOF'
+test=RideThroughInterruptionE2eTest#cleanCloseControlSurfacesHonestRecoveryToTheSameObserver
+production_disconnect_triggered=true
+observer_detected_recovery=true
+observer_recovery_detected_ms=1840
+observer_first_violations=[vm_status=Reconnecting, reconnecting_pill]
+typed_reader_eof_detected=true
+typed_reader_eof_event_name=tmux_client_reader_exit
+typed_reader_eof_disconnect_reason=reader_eof
+typed_reader_eof_source=missing
+typed_reader_eof_message=missing
+typed_reader_eof_event_elapsed_ms=1841
+app_server_marker_verified=true
+failure=none
+  observer_ticks:
+EOF
+  cat >"$artifacts_root/device/issue342-network-faults/reader-eof-control.txt" <<'EOF'
+sequence=12 category=connection name=tmux_client_reader_exit metadata={disconnectReason=reader_eof}
+EOF
+  for stem in control-pre-close control-post-recovery; do
+    printf '%s' "$valid_png_base64" \
+      | base64 --decode >"$artifacts_root/device/issue342-network-faults/${stem}-viewport.png"
+    printf 'BEFORE-or-CONTROL-RECOVERED\n' \
+      >"$artifacts_root/device/issue342-network-faults/${stem}-visible-terminal.txt"
+  done
+  require_exact_clean_close_control_method \
+    "$results_root" "$artifacts_root" "$class_name" "$control_method" >/dev/null || {
+    echo "SELF-TEST FAIL: valid positive-control artifact failed" >&2
+    return 1
+  }
+
+  local visible_token
+  for visible_token in \
+    vm_status=Idle \
+    vm_status=Connecting \
+    vm_status=Switching \
+    vm_status=Reconnecting \
+    vm_status=Failed \
+    reconnecting_pill \
+    attaching_hold \
+    reconnect_band_retry_now \
+    connecting_progress_row \
+    settled_failed_band; do
+    cp "$control_artifact" "$control_artifact.orig"
+    sed -E -i "s/^observer_first_violations=.*/observer_first_violations=[$visible_token]/" \
+      "$control_artifact"
+    if ! require_exact_clean_close_control_method \
+      "$results_root" "$artifacts_root" "$class_name" "$control_method" >/dev/null 2>&1; then
+      echo "SELF-TEST FAIL: visible recovery token rejected: $visible_token" >&2
+      return 1
+    fi
+    mv "$control_artifact.orig" "$control_artifact"
+  done
+
+  for mutant in \
+    's/production_disconnect_triggered=true/production_disconnect_triggered=false/|missing production disconnect trigger' \
+    's/observer_detected_recovery=true/observer_detected_recovery=false/|blind observer' \
+    's/typed_reader_eof_detected=true/typed_reader_eof_detected=false/|missing typed reader EOF' \
+    's/typed_reader_eof_disconnect_reason=reader_eof/typed_reader_eof_disconnect_reason=unknown/|missing typed reader cause' \
+    's/observer_first_violations=\[vm_status=Reconnecting, reconnecting_pill\]/observer_first_violations=[connect_generation=2]/|internal-only observer violation' \
+    's/observer_first_violations=\[.*\]/observer_first_violations=[]/|empty violation set' \
+    's/observer_first_violations=\[vm_status=Reconnecting, reconnecting_pill\]/observer_first_violations=[vm_status=Connected]/|non-recovery status token' \
+    's/app_server_marker_verified=true/app_server_marker_verified=false/|missing control marker' \
+    's/failure=none/failure=AssertionError:boom/|failed control run'; do
+    cp "$control_artifact" "$control_artifact.orig"
+    sed -i "${mutant%%|*}" "$control_artifact"
+    if require_exact_clean_close_control_method \
+      "$results_root" "$artifacts_root" "$class_name" "$control_method" >/dev/null 2>&1; then
+      echo "SELF-TEST FAIL: vacuous positive-control artifact passed: ${mutant##*|}" >&2
+      return 1
+    fi
+    mv "$control_artifact.orig" "$control_artifact"
+  done
+
+  rm "$artifacts_root/device/issue342-network-faults/control-post-recovery-visible-terminal.txt"
+  if require_exact_clean_close_control_method \
+    "$results_root" "$artifacts_root" "$class_name" "$control_method" >/dev/null 2>&1; then
+    echo "SELF-TEST FAIL: missing authoritative control text passed" >&2
+    return 1
+  fi
 
   echo "nightly-exact-method-guard self-test: PASS"
 }

--- a/scripts/lib/nightly-phase-reports.sh
+++ b/scripts/lib/nightly-phase-reports.sh
@@ -48,6 +48,19 @@ _PHASE_REPORT_SUBPATHS=(
   "outputs/connected_android_test_additional_output"
 )
 
+# Set by preserve_phase_reports so a caller can distinguish a fresh empty
+# snapshot from a successfully copied snapshot.  The manifest is deliberately
+# inside the phase directory: if clearing/copying fails, a later verdict must
+# not mistake an older XML tree for this run's evidence.
+PHASE_REPORT_SNAPSHOT_STATUS="unknown"
+
+phase_report_snapshot_status() {
+  local phase_dir="${1:-}"
+  local manifest="$phase_dir/phase-report-manifest.txt"
+  [[ -f "$manifest" ]] || return 1
+  sed -n 's/^snapshot_status=//p' "$manifest" | head -1
+}
+
 # ---------------------------------------------------------------------------
 # preserve_phase_reports <phase_slug> [module_build_dir] [dest_root]
 #
@@ -71,13 +84,22 @@ preserve_phase_reports() {
   local phase_slug="${1:-}"
   local module_build_dir="${2:-${REPO_ROOT:+$REPO_ROOT/}app/build}"
   local dest_root="${3:-${REPO_ROOT:+$REPO_ROOT/}artifacts/nightly-extensive/phase-reports}"
+  local phase_dir snapshot_status=complete
+
+  PHASE_REPORT_SNAPSHOT_STATUS="failed"
 
   if [[ -z "$phase_slug" ]]; then
     echo "preserve_phase_reports: missing phase slug (skipping)" >&2
     return 0
   fi
 
-  local phase_dir="$dest_root/$phase_slug"
+  phase_dir="$dest_root/$phase_slug"
+  # A rerun may reuse the same artifact root. Clear this phase's prior snapshot
+  # so a missing current report cannot masquerade as preserved green evidence.
+  if ! rm -rf "$phase_dir" 2>/dev/null; then
+    echo "preserve_phase_reports[$phase_slug]: FAILED to clear stale snapshot" >&2
+    return 0
+  fi
   mkdir -p "$phase_dir" 2>/dev/null || {
     echo "preserve_phase_reports[$phase_slug]: could not create $phase_dir (skipping)" >&2
     return 0
@@ -98,11 +120,25 @@ preserve_phase_reports() {
         copied=$((copied + 1))
       else
         echo "preserve_phase_reports[$phase_slug]: FAILED to copy $src (skipping)" >&2
+        snapshot_status=failed
       fi
     else
       echo "preserve_phase_reports[$phase_slug]: no report at $src (skipped)"
     fi
   done
+
+  if [[ "$copied" -eq 0 && "$snapshot_status" == complete ]]; then
+    snapshot_status=empty
+  fi
+  if ! {
+    printf 'phase=%s\n' "$phase_slug"
+    printf 'source_build_dir=%s\n' "$module_build_dir"
+    printf 'copied_report_trees=%s\n' "$copied"
+    printf 'snapshot_status=%s\n' "$snapshot_status"
+  } > "$phase_dir/phase-report-manifest.txt"; then
+    snapshot_status=failed
+  fi
+  PHASE_REPORT_SNAPSHOT_STATUS="$snapshot_status"
 
   echo "preserve_phase_reports[$phase_slug]: preserved $copied report tree(s) to $phase_dir"
   return 0
@@ -149,6 +185,12 @@ _phase_reports_self_test() {
   echo "--- phase A writes its reports, then we preserve them ---"
   _write_fake_reports "PHASE_A_MARKER"
   preserve_phase_reports "phase-a" "$build_dir" "$dest_root"
+  if [[ "$(phase_report_snapshot_status "$dest_root/phase-a")" == complete ]]; then
+    echo "ok   [manifest] phase-a snapshot is marked complete"
+  else
+    echo "FAIL [manifest] phase-a snapshot is not marked complete"
+    failures=$((failures + 1))
+  fi
 
   echo
   echo "--- phase B OVERWRITES the same build dir (the real clobber), then we preserve ---"
@@ -159,6 +201,12 @@ _phase_reports_self_test() {
   rm -rf "$build_dir/outputs/connected_android_test_additional_output"
   _write_fake_reports "PHASE_B_MARKER"
   preserve_phase_reports "phase-b" "$build_dir" "$dest_root"
+  if [[ "$(phase_report_snapshot_status "$dest_root/phase-b")" == complete ]]; then
+    echo "ok   [manifest] phase-b snapshot is marked complete"
+  else
+    echo "FAIL [manifest] phase-b snapshot is not marked complete"
+    failures=$((failures + 1))
+  fi
 
   echo
   echo "--- assert BOTH phases survived to distinct, non-colliding paths ---"
@@ -185,10 +233,29 @@ _phase_reports_self_test() {
   fi
 
   echo
+  echo "--- absent current source removes stale evidence for the same phase ---"
+  rm -rf "$build_dir"
+  preserve_phase_reports "phase-b" "$build_dir" "$dest_root"
+  if find "$dest_root/phase-b" -type f ! -name phase-report-manifest.txt -print -quit | grep -q .; then
+    echo "FAIL [stale] missing current reports retained a stale phase-b file"
+    failures=$((failures + 1))
+  elif [[ "$(phase_report_snapshot_status "$dest_root/phase-b")" != empty ]]; then
+    echo "FAIL [stale] missing current reports were not marked empty"
+    failures=$((failures + 1))
+  else
+    echo "ok   [stale] missing current reports cannot masquerade as preserved evidence"
+  fi
+
+  echo
   echo "--- missing-report phase is a clean no-op (no crash, returns 0) ---"
   rm -rf "$build_dir"
   if preserve_phase_reports "phase-empty" "$build_dir" "$dest_root"; then
-    echo "ok   [empty] preserve_phase_reports returned 0 with no reports present"
+    if [[ "$PHASE_REPORT_SNAPSHOT_STATUS" == empty ]]; then
+      echo "ok   [empty] preserve_phase_reports returned 0 and marked the snapshot empty"
+    else
+      echo "FAIL [empty] missing-report phase was not marked empty"
+      failures=$((failures + 1))
+    fi
   else
     echo "FAIL [empty] preserve_phase_reports returned non-zero for a missing-report phase"
     failures=$((failures + 1))

--- a/scripts/nightly-extensive-suite.sh
+++ b/scripts/nightly-extensive-suite.sh
@@ -392,12 +392,16 @@ NETWORK_FAULT_CLASS_ARG="$(join_by , "${NETWORK_FAULT_CLASSES[@]}")"
 EXPECTED_FAIL_CLASS_ARG="$(join_by , "${EXPECTED_FAIL_CLASSES[@]}")"
 JOURNEY_NOTCLASS_ARG="$(join_by , "${JOURNEY_EXCLUDED_CLASSES[@]}")"
 
-# Issue #1751: a class-level phase can green vacuously if the sustained method is
-# renamed/removed while the class's intentionally skipped brief method remains.
-# Pin the exact successful release-gating method and its positive-band artifact
-# before computing the fault verdict.
+# Issues #1751/#1678: a class-level phase can green vacuously if a required
+# method is renamed or skipped while another method in its class remains. Pin
+# the sustained method as before, and add the brief/control artifact guards
+# without duplicating #2141's phase coverage accounting.
 REQUIRED_SUSTAINED_FAULT_CLASS="$FQCN_PREFIX.RideThroughInterruptionE2eTest"
 REQUIRED_SUSTAINED_FAULT_METHOD="sustainedLinkCutReconnectsCleanlyWithoutHang"
+REQUIRED_BRIEF_FAULT_CLASS="$FQCN_PREFIX.RideThroughInterruptionE2eTest"
+REQUIRED_BRIEF_FAULT_METHOD="briefLinkCutRidesThroughWithoutDisconnectOrTeardown"
+REQUIRED_CONTROL_FAULT_CLASS="$FQCN_PREFIX.RideThroughInterruptionE2eTest"
+REQUIRED_CONTROL_FAULT_METHOD="cleanCloseControlSurfacesHonestRecoveryToTheSameObserver"
 # shellcheck source=scripts/lib/nightly-exact-method-guard.sh
 source "$REPO_ROOT/scripts/lib/nightly-exact-method-guard.sh"
 
@@ -609,20 +613,45 @@ if [[ "$RUN_AUX_PHASES" == "yes" ]]; then
   NETWORK_FAULT_EXIT=$?
   echo "phase 2 (network-fault proofs) exit code: $NETWORK_FAULT_EXIT"
 
+  # Preserve phase 2 immediately, before exact artifact guards or phase 2b can
+  # touch the shared Gradle output tree. All #1678/#1751 guards consume this
+  # immutable per-phase snapshot, while #2141 consumes the same snapshot for
+  # skipped/unreached class coverage.
+  preserve_phase_reports "phase2-network-fault" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+  if [[ "$(phase_report_snapshot_status "$PHASE_REPORTS_DIR/phase2-network-fault")" != complete ]]; then
+    NETWORK_FAULT_EXIT=1
+    echo "phase 2 (network-fault proofs) forced RED: phase report snapshot is not complete (status=${PHASE_REPORT_SNAPSHOT_STATUS:-unknown})"
+  fi
+  PHASE2_RESULTS_ROOT="$PHASE_REPORTS_DIR/phase2-network-fault/outputs/androidTest-results/connected"
+  PHASE2_ARTIFACTS_ROOT="$PHASE_REPORTS_DIR/phase2-network-fault/outputs/connected_android_test_additional_output"
+
   if ! require_exact_junit_method \
-    "$APP_BUILD_DIR/outputs/androidTest-results/connected" \
-    "$APP_BUILD_DIR/outputs/connected_android_test_additional_output" \
+    "$PHASE2_RESULTS_ROOT" \
+    "$PHASE2_ARTIFACTS_ROOT" \
     "$REQUIRED_SUSTAINED_FAULT_CLASS" \
     "$REQUIRED_SUSTAINED_FAULT_METHOD"; then
     NETWORK_FAULT_EXIT=1
-    echo "phase 2 (network-fault proofs) forced RED by exact-method guard"
+    echo "phase 2 (network-fault proofs) forced RED by sustained exact-method guard"
   fi
 
-  # Snapshot phase 2's report BEFORE the phase-2b gradle invocation overwrites
-  # it (issue #1293). THIS is the release-GATING report whose overwrite made the
-  # DisconnectBlackhole / NatIdle failing assertions unrecoverable. Observability
-  # only — never affects NETWORK_FAULT_EXIT.
-  preserve_phase_reports "phase2-network-fault" "$APP_BUILD_DIR" "$PHASE_REPORTS_DIR"
+  if ! require_exact_brief_ride_through_method \
+    "$PHASE2_RESULTS_ROOT" \
+    "$PHASE2_ARTIFACTS_ROOT" \
+    "$REQUIRED_BRIEF_FAULT_CLASS" \
+    "$REQUIRED_BRIEF_FAULT_METHOD"; then
+    NETWORK_FAULT_EXIT=1
+    echo "phase 2 (network-fault proofs) forced RED by brief exact-method/timeline guard"
+  fi
+
+  if ! require_exact_clean_close_control_method \
+    "$PHASE2_RESULTS_ROOT" \
+    "$PHASE2_ARTIFACTS_ROOT" \
+    "$REQUIRED_CONTROL_FAULT_CLASS" \
+    "$REQUIRED_CONTROL_FAULT_METHOD"; then
+    NETWORK_FAULT_EXIT=1
+    echo "phase 2 (network-fault proofs) forced RED by clean-close positive-control guard"
+  fi
+
   # Issue #2141: compare the preserved phase-2 JUnit XML to NETWORK_FAULT_CLASSES
   # AFTER the snapshot (later phases overwrite app/build). A skipped method or
   # a truncated class set is recorded here and refuses fault_verdict=PASS.

--- a/scripts/run-nightly-guard-selftests.sh
+++ b/scripts/run-nightly-guard-selftests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# The Tests workflow's "Nightly exact-method guard self-test" step (#1678/#1751).
+#
+# Extracted out of `.github/workflows/tests.yml` because that file sits within a
+# kilobyte of the 128 KiB file-size-hygiene threshold, and
+# scripts/check-file-size-hygiene.sh's prescribed remedy for a workflow at its
+# cap is exactly this: move the inline `run: |` shell into scripts/ and call it
+# from the step, taking the explanatory comments with it. The step NAME is
+# unchanged. Same precedent as scripts/run-release-evidence-guards.sh (#2064).
+#
+# Issue #1678/#1751/#2141: the nightly phase-2 fault verdict is only as honest as
+# the exact-method guards that compute it — a class-level phase greens vacuously
+# when a required method is skipped, renamed, or reports a timeline that claims
+# nothing. Those guards run inside the nightly job, so nothing per-push proved
+# they still go RED on a vacuous artifact. This runs their mutation self-test
+# (skipped method, wrong method, forbidden typed event in the snapshot AND in the
+# timeline, unfired positive-control observer, blocked/unrecovered
+# same-connection sentinel, malformed authoritative viewport PNG) every push.
+# Pure shell: no emulator, no Docker, no Gradle.
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+bash scripts/lib/nightly-exact-method-guard.sh --self-test
+bash scripts/lib/nightly-phase-reports.sh --self-test


### PR DESCRIPTION
## Summary
- Root cause: the journey's toxiproxy `timeout` toxic sends a real FIN/EOF when removed, so `RideThroughInterruptionE2eTest.brief` was testing correct reconnect-after-real-close, not a brief ride-through — the product was never over-eager.
- Fix: replaced the fixture with a genuine starve-without-close toxic (`addHalfOpenStall()`, bandwidth rate=0), so the 5s blip no longer closes the connection.
- Added a #2397 vacuity guard so the journey's negative diagnostic claim can't be silently masked by an earlier test class.
- Wired `nightly-exact-method-guard.sh --self-test` into the required `Static guards` CI job.
- Cleaned up ~1600 lines of dead `scripts/issue-1678-*` helpers gated nowhere.

## Review
`APPROVED` — https://github.com/alexeygrigorev/pocketshell/issues/1678#issuecomment-5460985938. Reviewer independently stood up their own toxiproxy container to confirm the protocol-level root cause, drove the real journey red on the old fixture (23ms before `clearToxics` returns) and green on the new one (device run, viewport PNG inspected), and confirmed the D37 gating-coverage guard flips `incomplete` -> `complete` for this journey's share.

Reviewer noted AC6 (full phase-2 green) still needs #2389 (merging separately as #2401) and #2390 — confirmed byte-identical failures on a clean `origin/main` control, not caused by this change.

## Test plan
- [x] `scripts/assemble-debug.sh` - BUILD SUCCESSFUL
- [x] `bash -n` syntax check on all 4 touched scripts
- [x] `scripts/lib/nightly-exact-method-guard.sh --self-test` - PASS (3/3)
- [x] Reviewer's own red->green device reproduction + independent toxiproxy protocol verification (see issue comment)

Closes #1678