### PR TITLE
Fix cross-test coroutine leak: RepoBrowserViewModel resumes on Main after teardown

### DIFF
--- a/app/src/main/java/com/pocketshell/app/projects/RepoBrowserViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/RepoBrowserViewModel.kt
@@ -13,6 +13,7 @@ import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.ssh.SshSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -224,6 +225,23 @@ class RepoBrowserViewModel @Inject constructor(
     private var actionJob: Job? = null
 
     /**
+     * Dispatcher the blocking SSH enumeration / clone work hops onto.
+     *
+     * A test seam, not a product knob (which is why it is a `var` rather than a
+     * Hilt-injected constructor parameter — `@HiltViewModel` cannot honour a
+     * default argument). Issue #2413: `viewModelScope` is
+     * `Dispatchers.Main.immediate`, so `withContext(Dispatchers.IO)` below is a
+     * hop OFF the test scheduler and back ONTO test-controlled Main. A JVM unit
+     * test that finishes while that hop is in flight leaves the resume to land
+     * after its `MainDispatcherRule` teardown, which used to surface as an
+     * uncaught `IllegalStateException` on an IO worker and then as
+     * `UncaughtExceptionsBeforeTest` against an arbitrary innocent sibling test.
+     * Pointing this at the test scheduler keeps the whole load on one virtual
+     * clock, so the load cannot outlive the test that started it.
+     */
+    internal var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    /**
      * Bind to a host and kick the initial list. Re-binding with the same
      * credentials is a no-op so a recomposition does not blow away the
      * visible list or an in-flight clone.
@@ -248,7 +266,7 @@ class RepoBrowserViewModel @Inject constructor(
             _state.value = RepoBrowserUiState.Loading
         }
         loadJob = viewModelScope.launch {
-            val result = withContext(Dispatchers.IO) { runLoad(creds) }
+            val result = withContext(ioDispatcher) { runLoad(creds) }
             val query = (_state.value as? RepoBrowserUiState.Ready)?.query ?: queryAtStart
             _state.value = if (result is RepoBrowserUiState.Ready) {
                 result.copy(query = query)
@@ -299,7 +317,7 @@ class RepoBrowserViewModel @Inject constructor(
             .copy(pendingFullName = row.fullName, actionError = null)
         actionJob?.cancel()
         actionJob = viewModelScope.launch {
-            val result = withContext(Dispatchers.IO) { runAction(creds, row) }
+            val result = withContext(ioDispatcher) { runAction(creds, row) }
             when (result) {
                 is RepoPathResult.Success -> {
                     onResolved(result.path)

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRule.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.app.hosts
 
+import android.os.Looper
 import com.pocketshell.app.tmux.LivenessProbeTestOverride
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,6 +33,18 @@ import org.junit.runner.Description
  * guards against reading `Main` while another thread is swapping it. Hold a
  * shared lock across the whole test statement so every test using this rule
  * sees a stable Main dispatcher until its `@After` cleanup has finished.
+ *
+ * Teardown must never hand Main back in a state where dispatching throws
+ * (issue #2413). Under Robolectric a real main looper exists, so it calls plain
+ * `Dispatchers.resetMain()`. In a looper-less JVM unit test resetting leaves
+ * Main *missing*, so a coroutine that escaped this test and later resumes on
+ * Main throws on its own worker thread; that throw is an uncaught coroutine
+ * exception, which `kotlinx-coroutines-test` replays against an arbitrary
+ * innocent sibling `runTest` as `UncaughtExceptionsBeforeTest`. There it
+ * installs a [PostTestMainDispatcher] instead, which records the late dispatch
+ * against the test that leaked it, so the leak fails loudly with attribution
+ * instead of reddening a random unrelated class. See
+ * [MainDispatcherStragglers].
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(
@@ -48,6 +61,12 @@ class MainDispatcherRule(
         object : Statement() {
             override fun evaluate() {
                 MainDispatcherTestIsolation.withOwnership {
+                    // Issue #2413: a coroutine that escaped an EARLIER test onto
+                    // Main is that test's bug. Report it here, attributed to its
+                    // owner, before this test can be blamed for it.
+                    MainDispatcherStragglers.failIfAnyRecorded(
+                        "entry of ${description.displayName}",
+                    )
                     Dispatchers.setMain(dispatcher)
                     // EPIC #792 Slice D: the LivenessProbe is an infinite periodic
                     // `delay` loop. Under `runTest` + the virtual-clock Main set above,
@@ -75,13 +94,42 @@ class MainDispatcherRule(
                         }
                         beforeResetMain.clear()
                         try {
-                            Dispatchers.resetMain()
+                            // Issue #2413: never hand Main back in a state where
+                            // dispatching THROWS. Under Robolectric there is a
+                            // real main looper, so `resetMain()` returns a
+                            // working platform dispatcher and nothing changes.
+                            // In a looper-less JVM unit test it returns the
+                            // MISSING dispatcher, and a coroutine that escaped
+                            // this test then throws on its own worker thread —
+                            // an uncaught coroutine exception that
+                            // kotlinx-coroutines-test replays against an
+                            // arbitrary innocent sibling `runTest` as
+                            // `UncaughtExceptionsBeforeTest`. See
+                            // [MainDispatcherStragglers].
+                            if (Looper.getMainLooper() != null) {
+                                Dispatchers.resetMain()
+                            } else {
+                                Dispatchers.setMain(
+                                    PostTestMainDispatcher(description.displayName),
+                                )
+                            }
                         } catch (failure: Throwable) {
                             val firstFailure = cleanupFailure
                             if (firstFailure == null) {
                                 cleanupFailure = failure
                             } else if (firstFailure !== failure) {
                                 firstFailure.addSuppressed(failure)
+                            }
+                        }
+                        if (cleanupFailure == null) {
+                            // Only when the test itself is otherwise clean: a
+                            // straggler report must never mask the real failure.
+                            try {
+                                MainDispatcherStragglers.failIfAnyRecorded(
+                                    "exit of ${description.displayName}",
+                                )
+                            } catch (failure: Throwable) {
+                                cleanupFailure = failure
                             }
                         }
                         cleanupFailure?.let { throw it }

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRuleTest.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherRuleTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
@@ -17,6 +18,7 @@ import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.EmptyCoroutineContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRuleTest {
@@ -173,6 +175,61 @@ class MainDispatcherRuleTest {
                     assertion,
                     Description.createTestDescription(javaClass, "foreign-main-construction-$iteration"),
                 ).evaluate()
+            }
+        }
+    }
+
+    @Test
+    fun teardownLeavesMainDispatchableSoAStragglerCannotPoisonASibling() {
+        // Issue #2413: `Dispatchers.resetMain()` leaves Main *missing* in a
+        // looper-less JVM test, so a continuation that captured Main before
+        // teardown throws when it resumes — an uncaught coroutine exception
+        // kotlinx-coroutines-test then replays against an arbitrary innocent
+        // sibling as `UncaughtExceptionsBeforeTest`.
+        MainDispatcherTestIsolation.withOwnership {
+            MainDispatcherStragglers.drain()
+            try {
+                MainDispatcherRule(StandardTestDispatcher(TestCoroutineScheduler())).apply(
+                    object : Statement() {
+                        override fun evaluate() = Unit
+                    },
+                    Description.createTestDescription(javaClass, "post-teardown-owner"),
+                ).evaluate()
+
+                var executed = false
+                val dispatchFailure = runCatching {
+                    Dispatchers.Main.dispatch(EmptyCoroutineContext) { executed = true }
+                }.exceptionOrNull()
+
+                assertNull(
+                    "resuming on Main after teardown must not throw: " +
+                        dispatchFailure?.stackTraceToString(),
+                    dispatchFailure,
+                )
+                assertFalse(
+                    "a straggler is recorded and dropped, never executed inside another test",
+                    executed,
+                )
+                val recorded = MainDispatcherStragglers.drain()
+                assertEquals("the straggler must be recorded: $recorded", 1, recorded.size)
+                assertTrue(
+                    "the straggler must name the test that owned Main: $recorded",
+                    recorded.single().owner.startsWith("post-teardown-owner"),
+                )
+
+                // ...while a NEW `viewModelScope` must still see a missing Main,
+                // exactly as after a plain `Dispatchers.resetMain()`. Without
+                // this, looper-less ViewModel tests that never install a Main
+                // silently rebind onto it instead of falling back to
+                // `EmptyCoroutineContext`.
+                assertTrue(
+                    "Dispatchers.Main.immediate must stay unavailable between tests",
+                    runCatching { Dispatchers.Main.immediate }
+                        .exceptionOrNull() is IllegalStateException,
+                )
+            } finally {
+                Dispatchers.resetMain()
+                MainDispatcherStragglers.drain()
             }
         }
     }

--- a/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherStragglers.kt
+++ b/app/src/test/java/com/pocketshell/app/hosts/MainDispatcherStragglers.kt
@@ -1,0 +1,180 @@
+package com.pocketshell.app.hosts
+
+import kotlinx.coroutines.MainCoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Issue #2413 — post-test `Dispatchers.Main` ownership, with attribution.
+ *
+ * ## The failure this replaces
+ *
+ * A unit test that installs a test Main dispatcher and drives production code
+ * which hops to a REAL dispatcher (`viewModelScope.launch { withContext(
+ * Dispatchers.IO) { … } }`) can finish while that hop is still in flight. The
+ * hop then completes on an IO worker and tries to resume on `Dispatchers.Main`
+ * — which a plain `Dispatchers.resetMain()` has already reverted to the
+ * *missing* platform dispatcher, because a non-Robolectric JVM unit test has no
+ * Android main looper. `TestMainDispatcher.isDispatchNeeded` throws
+ *
+ * ```
+ * java.lang.IllegalStateException: Dispatchers.Main was accessed when the
+ * platform dispatcher was absent and the test dispatcher was unset.
+ * ```
+ *
+ * on the IO worker. Nothing on that path belongs to the leaking test any more,
+ * so the throw becomes an *uncaught coroutine exception*, which
+ * `kotlinx-coroutines-test`'s process-global `ExceptionCollector` stores and
+ * replays against whichever unrelated `runTest` enters next, as
+ * `UncaughtExceptionsBeforeTest`. That is how #2413 reddened
+ * `TreeRemoteSourceTest.upsertTree_buildsRequestAndReturnsTrueOnOk`, a pure
+ * stubbed-stdout parse assertion with no concurrency at all, ~30 seconds after
+ * the actual leak in `RepoBrowserViewModelTest`.
+ *
+ * ## Why taking the window over is the correct fix, not a mask
+ *
+ * `Dispatchers.Main` is *never* absent in production, nor under Robolectric;
+ * the "missing Main" state is manufactured by the harness itself, in
+ * `Dispatchers.resetMain()`. The `IllegalStateException` is therefore not a
+ * product defect being swallowed — it is a harness artifact whose only effect
+ * is to convert a test-hygiene leak into an unattributable failure of an
+ * innocent, arbitrary sibling. [PostTestMainDispatcher] owns that window
+ * instead, closing the cross-test blame channel structurally for every one of
+ * the ~96 classes using [MainDispatcherRule], not just the one leak #2413
+ * happened to surface. Under Robolectric there is a real main looper, so
+ * [MainDispatcherRule] keeps using plain `Dispatchers.resetMain()` there and
+ * this class is never involved.
+ *
+ * ## Recorded and dropped, never executed
+ *
+ * A straggler is recorded and then **dropped**. Dropping matches what already
+ * happened on the unfixed path — the continuation never resumed there either,
+ * it just threw on the way in — whereas *running* it lets a finished test's
+ * coroutine mutate shared state while an unrelated test is executing. That is
+ * measured, not assumed: an earlier revision of this class ran stragglers on a
+ * daemon thread and turned 4 attributed reports into 16 extra failures across
+ * `ForwardingControllerTest`, `WatchedFoldersViewModelTest`,
+ * `ForwardingResumeSchedulerTest` and friends. Dropping keeps the blast radius
+ * at zero.
+ *
+ * ## The leak is not hidden
+ *
+ * Every straggler is recorded with the test that owned Main when it escaped and
+ * printed to stderr, and [failIfAnyRecorded] turns it into a hard failure at the
+ * next [MainDispatcherRule] boundary, quoting the leaking suspension point. So a
+ * leak fails loudly, naming its culprit, instead of reddening a random unrelated
+ * class. A full `:app:testReleaseUnitTest` run produced zero stragglers outside
+ * the two this issue's own regression test raises deliberately, so the guard
+ * ships with no allowlist.
+ */
+internal object MainDispatcherStragglers {
+
+    /** One escaped post-teardown `Dispatchers.Main` dispatch. */
+    data class Straggler(
+        /** JUnit display name of the test that owned Main when this escaped. */
+        val owner: String,
+        val coroutineContext: String,
+        /**
+         * The dropped task's `toString`. For a coroutine continuation this
+         * names the production suspension point that leaked — e.g.
+         * `Continuation at …RepoBrowserViewModel${'$'}refresh${'$'}1.invokeSuspend(
+         * RepoBrowserViewModel.kt:269)` — which is the attribution that matters
+         * when [owner] is only the window the straggler happened to land in.
+         */
+        val task: String,
+    ) {
+        override fun toString(): String =
+            "leaked by '$owner': task=$task context=$coroutineContext"
+    }
+
+    private val lock = Any()
+    private val recorded = mutableListOf<Straggler>()
+
+    internal fun record(owner: String, context: CoroutineContext, task: Runnable) {
+        val straggler = Straggler(
+            owner = owner,
+            coroutineContext = context.toString(),
+            task = task.toString(),
+        )
+        synchronized(lock) { recorded += straggler }
+        System.err.println("POCKETSHELL MAIN-DISPATCHER STRAGGLER (issue #2413): $straggler")
+    }
+
+    /** Removes and returns everything recorded so far. */
+    fun drain(): List<Straggler> = synchronized(lock) {
+        val snapshot = recorded.toList()
+        recorded.clear()
+        snapshot
+    }
+
+    /**
+     * Hard-fails when any coroutine escaped a finished test onto Main.
+     *
+     * @param boundary human-readable description of where the check ran, so the
+     *   report distinguishes "found on the way in" from "found on the way out".
+     */
+    fun failIfAnyRecorded(boundary: String) {
+        val unexpected = drain()
+        if (unexpected.isEmpty()) return
+        throw AssertionError(
+            buildString {
+                append("issue #2413: ")
+                append(unexpected.size)
+                append(" coroutine(s) dispatched to Dispatchers.Main AFTER their test's ")
+                append("MainDispatcherRule teardown, observed at ")
+                append(boundary)
+                append(".\n")
+                append(
+                    "This is a test-hygiene leak in the OWNING test named below, not in the " +
+                        "test that is reporting it: work started under the test Main dispatcher " +
+                        "hopped to a real dispatcher (typically withContext(Dispatchers.IO)) and " +
+                        "was still in flight when the test ended. Await or cancel it before " +
+                        "teardown (MainDispatcherRule.beforeResetMain), or inject a dispatcher " +
+                        "confined to the test scheduler so the hop cannot outlive the test — see " +
+                        "RepoBrowserViewModel.ioDispatcher for the worked example.\n",
+                )
+                unexpected.forEach { append("  - ").append(it).append('\n') }
+            },
+        )
+    }
+}
+
+/**
+ * The `Dispatchers.Main` [MainDispatcherRule] installs, in place of a bare
+ * `Dispatchers.resetMain()`, once a looper-less JVM unit test has finished.
+ *
+ * Records every late dispatch against [owner] — the test that leaked it — and
+ * drops it. See [MainDispatcherStragglers] for the full rationale.
+ *
+ * ## Why [immediate] still throws
+ *
+ * This dispatcher stays installed until the next [MainDispatcherRule] test calls
+ * `Dispatchers.setMain`, so unrelated tests can run while it owns Main. Those
+ * must not observe a *working* Main where the unfixed code gave them a missing
+ * one: `androidx.lifecycle`'s `viewModelScope` reads `Dispatchers.Main.immediate`
+ * and falls back to `EmptyCoroutineContext` (i.e. `Dispatchers.Default`) when it
+ * throws, which is how every looper-less `ViewModel` unit test that does not use
+ * [MainDispatcherRule] works at all. Measured: without this throw,
+ * `CostsViewModelTest`'s `viewModelScope` silently rebound onto Main and its
+ * `init` collector was recorded as a straggler instead of running.
+ *
+ * So [immediate] throws exactly like `MissingMainCoroutineDispatcher.immediate`
+ * does, keeping *new* scopes byte-identical to the unfixed behaviour, while
+ * continuations that captured `Dispatchers.Main` **before** teardown resume
+ * through [dispatch] and get recorded instead of exploding. That is the one and
+ * only behaviour this class changes.
+ */
+internal class PostTestMainDispatcher(private val owner: String) : MainCoroutineDispatcher() {
+
+    override val immediate: MainCoroutineDispatcher
+        get() = throw IllegalStateException(
+            "issue #2413: Dispatchers.Main is unavailable between tests (owner '$owner'). " +
+                "This mirrors Dispatchers.resetMain()'s missing platform dispatcher; a test " +
+                "needing Main must install it via MainDispatcherRule.",
+        )
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        MainDispatcherStragglers.record(owner, context, block)
+    }
+
+    override fun toString(): String = "PostTestMain[$owner]"
+}

--- a/app/src/test/java/com/pocketshell/app/projects/Issue2413MainDispatcherStragglerLeakTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/Issue2413MainDispatcherStragglerLeakTest.kt
@@ -1,0 +1,245 @@
+package com.pocketshell.app.projects
+
+import com.pocketshell.app.hosts.MainDispatcherOwnershipRule
+import com.pocketshell.app.hosts.MainDispatcherRule
+import com.pocketshell.app.hosts.MainDispatcherStragglers
+import com.pocketshell.app.repos.ReposJsonParser
+import com.pocketshell.app.repos.ReposRemoteSource
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshLeaseConnector
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.ssh.SshPortForward
+import com.pocketshell.core.ssh.SshSession
+import com.pocketshell.core.ssh.SshShell
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #2413 regression cover — a coroutine that escapes one test onto
+ * `Dispatchers.Main` must never redden an unrelated sibling `runTest`.
+ *
+ * ## The reported failure
+ *
+ * The scheduled full suite reddened `JVM unit tests (Release)` with
+ *
+ * ```
+ * TreeRemoteSourceTest > upsertTree_buildsRequestAndReturnsTrueOnOk FAILED
+ *     kotlinx.coroutines.test.UncaughtExceptionsBeforeTest at TreeRemoteSourceTest.kt:133
+ * ```
+ *
+ * The named test is a pure stubbed-stdout parse assertion with no concurrency;
+ * it was simply the next `runTest` to enter the worker JVM. The CI artifact's
+ * suppressed cause named the real mechanism:
+ *
+ * ```
+ * IllegalStateException: Dispatchers.Main was accessed when the platform
+ *   dispatcher was absent and the test dispatcher was unset
+ *   … TestMainDispatcher.isDispatchNeeded
+ *   … DispatchedCoroutine.afterResume            <- a withContext(…) returning
+ *   … LimitedDispatcher$Worker.run               <- from Dispatchers.IO
+ * Suppressed: DiagnosticCoroutineContextException:
+ *   [CoroutineId(728), DispatchedCoroutine{Completed}, Dispatchers.IO]
+ * ```
+ *
+ * i.e. a `Dispatchers.Main`-scoped coroutine hopped to the real IO dispatcher,
+ * the owning test finished and `Dispatchers.resetMain()` ran, and the hop then
+ * completed and tried to resume onto a Main that no longer existed.
+ *
+ * ## The real production path this test drives
+ *
+ * `RepoBrowserViewModel.refresh()` is exactly that shape —
+ * `viewModelScope.launch { withContext(Dispatchers.IO) { runLoad(creds) } }` —
+ * and `RepoBrowserViewModelTest` was the last `runTest`-using class to run
+ * before `TreeRemoteSourceTest` in the failing worker. This test drives the
+ * *real* view model through the *real* [MainDispatcherRule] lifecycle, holding
+ * the exec inside the IO hop until after teardown so the straggler is
+ * deterministic rather than a race.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue2413MainDispatcherStragglerLeakTest {
+
+    @get:Rule
+    val ownership = MainDispatcherOwnershipRule()
+
+    @Test
+    fun aStragglerFromAFinishedTestNeverPoisonsAnUnrelatedRunTest() {
+        // A full-suite worker has always run some `runTest` before this point,
+        // which is what arms kotlinx-coroutines-test's process-global
+        // ExceptionCollector. Without it the collector ignores the escape and
+        // the leak only prints to stderr, so this line is load-bearing for
+        // reproducing the reported CI failure rather than a weaker cousin.
+        runTest { }
+
+        val session = leakOneStragglerThroughTheRule().session
+
+        // Non-vacuity, asserted with an oracle that does NOT depend on the fix:
+        // the production IO hop really ran and really returned, so a resume onto
+        // Main really was attempted after teardown.
+        assertTrue(
+            "the repo-browser load never executed its remote enumeration, so nothing " +
+                "could have resumed onto Main and this test would prove nothing",
+            session.execCount > 0,
+        )
+
+        // The reported symptom: the very next unrelated `runTest` inherits the
+        // escaped exception as UncaughtExceptionsBeforeTest. It must not.
+        runTest { }
+    }
+
+    @Test
+    fun aStragglerIsReportedAgainstTheTestThatLeakedIt() {
+        val stragglers = leakOneStragglerThroughTheRule().stragglers
+
+        assertEquals(
+            "exactly one post-teardown Main dispatch was leaked: $stragglers",
+            1,
+            stragglers.size,
+        )
+        assertEquals(
+            "the straggler must be attributed to the test that leaked it, " +
+                "not to whichever sibling runs next: $stragglers",
+            LEAKY_TEST,
+            stragglers.single().owner.substringBefore('('),
+        )
+        val report = runCatching {
+            MainDispatcherStragglers.record(
+                owner = stragglers.single().owner,
+                context = kotlin.coroutines.EmptyCoroutineContext,
+                task = Runnable { },
+            )
+            MainDispatcherStragglers.failIfAnyRecorded("regression check")
+        }.exceptionOrNull()
+        assertTrue(
+            "a leaked straggler must hard-fail with attribution, not warn: $report",
+            report is AssertionError && report.message?.contains(LEAKY_TEST) == true,
+        )
+    }
+
+    /**
+     * Runs one [MainDispatcherRule]-guarded statement that starts the real
+     * `RepoBrowserViewModel` load and leaves it parked inside its
+     * `withContext(Dispatchers.IO)` hop, then releases the hop after teardown.
+     *
+     * @return the stragglers recorded for that statement, drained so they cannot
+     *   leak into a sibling test, plus the fake session that proves the real
+     *   production path ran.
+     */
+    private fun leakOneStragglerThroughTheRule(): LeakOutcome {
+        MainDispatcherStragglers.drain()
+        val enteredIoHop = CountDownLatch(1)
+        val releaseIoHop = CountDownLatch(1)
+        val session = ParkedSession(enteredIoHop, releaseIoHop)
+        val leaseScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            MainDispatcherRule(UnconfinedTestDispatcher(TestCoroutineScheduler())).apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        val viewModel = RepoBrowserViewModel(
+                            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+                            sshLeaseManager = SshLeaseManager(
+                                connector = SshLeaseConnector { Result.success(session) },
+                                scope = leaseScope,
+                                idleTtlMillis = 30_000L,
+                                connectTimeoutContext = Dispatchers.Unconfined,
+                            ),
+                        )
+                        viewModel.bind(CREDENTIALS)
+                        check(enteredIoHop.await(10, TimeUnit.SECONDS)) {
+                            "the repo-browser load never reached its Dispatchers.IO hop"
+                        }
+                    }
+                },
+                Description.createTestDescription(javaClass, LEAKY_TEST),
+            ).evaluate()
+        } finally {
+            releaseIoHop.countDown()
+        }
+
+        // Deliberately NOT a hard `check`: on unfixed code no straggler is ever
+        // recorded (the resume throws instead), and the load-bearing assertion
+        // has to be the one that reddens — not a helper precondition.
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        var stragglers = MainDispatcherStragglers.drain()
+        while (stragglers.isEmpty() && System.nanoTime() < deadline) {
+            Thread.sleep(5L)
+            stragglers = MainDispatcherStragglers.drain()
+        }
+        leaseScope.cancel()
+        return LeakOutcome(stragglers = stragglers, session = session)
+    }
+
+    private class LeakOutcome(
+        val stragglers: List<MainDispatcherStragglers.Straggler>,
+        val session: ParkedSession,
+    )
+
+    /** Blocks inside `exec` — i.e. inside the view model's IO hop — until released. */
+    private class ParkedSession(
+        private val entered: CountDownLatch,
+        private val release: CountDownLatch,
+    ) : SshSession {
+        @Volatile
+        var execCount: Int = 0
+            private set
+
+        override val isConnected: Boolean get() = true
+
+        override suspend fun exec(command: String): ExecResult {
+            entered.countDown()
+            check(release.await(30, TimeUnit.SECONDS)) { "parked exec was never released" }
+            execCount += 1
+            return ExecResult("[]", "", 0)
+        }
+
+        override fun tail(path: String, onLine: (String) -> Unit): Job = error("unused")
+
+        override fun openLocalPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): SshPortForward = error("unused")
+
+        override fun startShell(): SshShell = error("unused")
+
+        override suspend fun uploadFile(file: File, remotePath: String): String = error("unused")
+
+        override suspend fun uploadStream(
+            input: InputStream,
+            length: Long,
+            name: String,
+            remotePath: String,
+        ): String = error("unused")
+
+        override fun close() = Unit
+    }
+
+    private companion object {
+        const val LEAKY_TEST = "issue2413-leaky-owner"
+
+        val CREDENTIALS = RepoBrowserViewModel.SshCredentials(
+            hostId = 42L,
+            hostname = "docker",
+            port = 2222,
+            username = "testuser",
+            keyPath = "/tmp/pocketshell-test-key",
+            passphrase = null,
+        )
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/projects/RepoBrowserViewModelTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/RepoBrowserViewModelTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Assert.assertEquals
@@ -425,10 +424,8 @@ class RepoBrowserViewModelTest {
         val callsBefore = fixture.session.recordedCommands.size
 
         viewModel.refresh()
-        withContext(Dispatchers.Default.limitedParallelism(1)) {
-            withTimeout(2_000L) {
-                while (fixture.session.localListCount < 2) delay(1L)
-            }
+        withTimeout(2_000L) {
+            while (fixture.session.localListCount < 2) delay(1L)
         }
         mainDispatcherRule.runCurrent()
 
@@ -449,11 +446,17 @@ class RepoBrowserViewModelTest {
                 connectTimeoutContext = Dispatchers.Unconfined,
             ),
         )
+        // Issue #2413: confine the view model's `withContext` hop to this test's
+        // scheduler. On the real `Dispatchers.IO` the load runs on a physical
+        // thread pool the test cannot await, so a test could finish with the hop
+        // still in flight; its resume then landed after `MainDispatcherRule`
+        // teardown and poisoned an arbitrary later `runTest` with
+        // `UncaughtExceptionsBeforeTest`. Confined, the load shares one virtual
+        // clock with the test and cannot outlive it.
+        viewModel.ioDispatcher = testDispatcher
         viewModel.bind(testCredentials())
-        val ready = withContext(Dispatchers.Default.limitedParallelism(1)) {
-            withTimeoutOrNull(2_000L) {
-                viewModel.state.filterIsInstance<RepoBrowserUiState.Ready>().first()
-            }
+        val ready = withTimeoutOrNull(2_000L) {
+            viewModel.state.filterIsInstance<RepoBrowserUiState.Ready>().first()
         }
         check(ready != null) {
             "repo browser did not load: state=${viewModel.state.value}, " +


### PR DESCRIPTION
Closes #2413

Root cause, fix, and full review evidence (including an empirical before/after diff of all 5090 test outcomes proving zero blast-radius surprises from the shared MainDispatcherRule change) are on the issue: https://github.com/alexeygrigorev/pocketshell/issues/2413#issuecomment-5466222979

This is the second and last known JVM-level flaky-test class that's been reddening `main`'s scheduled full-suite runs (tracked at #2373); #2359 already merged.